### PR TITLE
auth: token write-gating + per-artifact read-gating

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ DATA_DIR=./data
 # Optional: point at Postgres / S3-compatible object storage instead.
 # DATABASE_URL=
 # OBJECT_STORE_URL=
+
+# Set to require a bearer token for publishing and for reading gated artifacts.
+# Unset = open instance (zero-config dev).
+# DOCK_TOKEN=

--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@ docker compose -f deploy/compose.yml up -d
 ```
 
 Optional env vars (nothing is required):
-`DATABASE_URL` → Postgres · `OBJECT_STORE_URL` → S3/R2 · `BASE_URL`, `PORT`, `DATA_DIR`.
+`DATABASE_URL` → Postgres · `OBJECT_STORE_URL` → S3/R2 · `DOCK_TOKEN` → require a
+bearer token for publishing and for reading gated artifacts · `BASE_URL`, `PORT`, `DATA_DIR`.
+
+### Access
+
+Publish with `--visibility public|link|org|password` (default `link`). When
+`DOCK_TOKEN` is set, writes require `Authorization: Bearer <token>`, and reading
+anything other than `public`/`link` requires it too — gated artifacts 404 without
+it. (Per-user accounts and SSO come later; this is the zero-dependency gate.)
 
 ## Architecture
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -11,17 +11,27 @@ import {
   renderMarkdown,
   renderShell,
   toJson,
+  type ArtifactRecord,
   type BlobStore,
   type BundleManifest,
   type MetaStore,
   type VersionRecord,
+  type Visibility,
 } from "@dock/core"
 
 export interface AppDeps {
   meta: MetaStore
   blobs: BlobStore
   baseUrl: string
+  /**
+   * When set, writes require `Authorization: Bearer <token>`, and reads of
+   * non-public/link artifacts require it too. When unset (zero-config dev),
+   * the instance is open. Full user/SSO auth replaces this later.
+   */
+  token?: string
 }
+
+const VISIBILITIES = ["public", "link", "org", "password"] as const
 
 const MAX_UPLOAD_BYTES = 100 * 1024 * 1024
 
@@ -54,6 +64,15 @@ export function createApp(deps: AppDeps): Hono {
   const { meta, blobs } = deps
   const app = new Hono()
 
+  const bearer = (c: Context): string => {
+    const h = c.req.header("authorization") ?? ""
+    return h.startsWith("Bearer ") ? h.slice(7) : ""
+  }
+  // Open when no token is configured; otherwise the bearer must match.
+  const writeOk = (c: Context): boolean => !deps.token || bearer(c) === deps.token
+  const readOk = (c: Context, a: ArtifactRecord): boolean =>
+    a.visibility === "public" || a.visibility === "link" || !deps.token || bearer(c) === deps.token
+
   app.get("/healthz", (c) => c.json({ ok: true }))
 
   app.get("/", (c) =>
@@ -69,6 +88,7 @@ export function createApp(deps: AppDeps): Hono {
   // ---- Publish ----------------------------------------------------------
 
   const handlePublish = async (c: Context, shortId?: string) => {
+    if (!writeOk(c)) return c.json({ error: "unauthorized" }, 401)
     const len = Number(c.req.header("content-length") ?? 0)
     if (len > MAX_UPLOAD_BYTES) return c.json({ error: "upload too large" }, 413)
 
@@ -95,6 +115,7 @@ export function createApp(deps: AppDeps): Hono {
           spa: body["spa"] === "true" || body["spa"] === "1",
           message: str(body["message"]),
           author: str(body["author"]),
+          visibility: visibilityOf(body["visibility"]),
         },
         shortId,
       )
@@ -121,7 +142,7 @@ export function createApp(deps: AppDeps): Hono {
 
   app.get("/v1/artifacts/:shortId", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact) return c.json({ error: "not found" }, 404)
+    if (!artifact || !readOk(c, artifact)) return c.json({ error: "not found" }, 404)
     return c.json(toJson(deps.baseUrl, artifact, await meta.listVersions(artifact.id)))
   })
 
@@ -143,7 +164,8 @@ export function createApp(deps: AppDeps): Hono {
   // version, as plain text (?v=N selects a version; defaults to current).
   app.get("/v1/artifacts/:shortId/content", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || artifact.current_version === 0) return c.json({ error: "not found" }, 404)
+    if (!artifact || artifact.current_version === 0 || !readOk(c, artifact))
+      return c.json({ error: "not found" }, 404)
     const v = c.req.query("v") ? Number(c.req.query("v")) : artifact.current_version
     if (!Number.isInteger(v)) return c.json({ error: "bad version" }, 400)
     const version = await meta.getVersion(artifact.id, v)
@@ -162,7 +184,8 @@ export function createApp(deps: AppDeps): Hono {
   // ?format=json returns the structured ops; otherwise unified-style text.
   app.get("/v1/artifacts/:shortId/diff", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || artifact.current_version === 0) return c.json({ error: "not found" }, 404)
+    if (!artifact || artifact.current_version === 0 || !readOk(c, artifact))
+      return c.json({ error: "not found" }, 404)
     const cur = artifact.current_version
     const from = c.req.query("from") ? Number(c.req.query("from")) : Math.max(1, cur - 1)
     const to = c.req.query("to") ? Number(c.req.query("to")) : cur
@@ -185,6 +208,7 @@ export function createApp(deps: AppDeps): Hono {
 
   // Create a comment (new thread) or a reply (pass thread_id).
   app.post("/v1/artifacts/:shortId/comments", async (c) => {
+    if (!writeOk(c)) return c.json({ error: "unauthorized" }, 401)
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact || artifact.current_version === 0) return c.json({ error: "not found" }, 404)
     const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>
@@ -218,7 +242,7 @@ export function createApp(deps: AppDeps): Hono {
 
   app.get("/v1/artifacts/:shortId/comments", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact) return c.json({ error: "not found" }, 404)
+    if (!artifact || !readOk(c, artifact)) return c.json({ error: "not found" }, 404)
     const q = c.req.query("state")
     const state = q === "open" || q === "resolved" ? q : undefined
     return c.json({ comments: await meta.listComments(artifact.id, state ? { state } : undefined) })
@@ -226,6 +250,7 @@ export function createApp(deps: AppDeps): Hono {
 
   // Resolve (or reopen, with {state:"open"}) the thread a comment belongs to.
   app.post("/v1/artifacts/:shortId/comments/:commentId/resolve", async (c) => {
+    if (!writeOk(c)) return c.json({ error: "unauthorized" }, 401)
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact) return c.json({ error: "not found" }, 404)
     const cm = await meta.getComment(c.req.param("commentId"))
@@ -242,7 +267,8 @@ export function createApp(deps: AppDeps): Hono {
     const m = REF_RE.exec(c.req.param("ref"))
     if (!m) return c.text("not found", 404)
     const artifact = await meta.getByShortId(m[1])
-    if (!artifact || artifact.current_version === 0) return c.text("not found", 404)
+    if (!artifact || artifact.current_version === 0 || !readOk(c, artifact))
+      return c.text("not found", 404)
     const n = m[2] ? Number(m[2]) : artifact.current_version
     const version = await meta.getVersion(artifact.id, n)
     if (!version) return c.text(`no version ${n}`, 404)
@@ -257,7 +283,7 @@ export function createApp(deps: AppDeps): Hono {
     const shortId = c.req.param("shortId")
     const n = Number(c.req.param("n"))
     const artifact = await meta.getByShortId(shortId)
-    if (!artifact || !Number.isInteger(n)) return c.text("not found", 404)
+    if (!artifact || !Number.isInteger(n) || !readOk(c, artifact)) return c.text("not found", 404)
     const version = await meta.getVersion(artifact.id, n)
     if (!version) return c.text("not found", 404)
 
@@ -308,5 +334,10 @@ export function createApp(deps: AppDeps): Hono {
 }
 
 const str = (v: unknown): string | undefined => (typeof v === "string" && v !== "" ? v : undefined)
+
+const visibilityOf = (v: unknown): Visibility | undefined =>
+  typeof v === "string" && (VISIBILITIES as readonly string[]).includes(v)
+    ? (v as Visibility)
+    : undefined
 
 export { artifactUrl }

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -15,6 +15,7 @@ const app = createApp({
   meta: new SqliteMetaStore(join(DATA_DIR, "dock.db")),
   blobs: new FsBlobStore(join(DATA_DIR, "blobs")),
   baseUrl: BASE_URL,
+  token: process.env.DOCK_TOKEN,
 })
 
 serve({ fetch: app.fetch, port: PORT }, () => {

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -249,3 +249,49 @@ describe("comments + the loop", () => {
     expect((await app.request("/v1/artifacts/zzzzzzzz/comments")).status).toBe(404)
   })
 })
+
+describe("auth: token write-gating + per-artifact read-gating", () => {
+  const authApp = createApp({
+    meta,
+    blobs: new FsBlobStore(join(dir, "blobs")),
+    baseUrl: "http://dock.test",
+    token: "s3cret",
+  })
+  const authed = (extra: RequestInit = {}) => ({
+    ...extra,
+    headers: { authorization: "Bearer s3cret", ...(extra.headers ?? {}) },
+  })
+  const pub = (visibility?: string, headers?: HeadersInit) => {
+    const form = new FormData()
+    form.append("file", new Blob([new TextEncoder().encode("<h1>secret</h1>")]), "s.html")
+    if (visibility) form.append("visibility", visibility)
+    return authApp.request("/v1/artifacts", { method: "POST", body: form, headers })
+  }
+
+  it("rejects writes without the token, accepts with it", async () => {
+    expect((await pub("link")).status).toBe(401)
+    const ok = await pub("link", { authorization: "Bearer s3cret" })
+    expect(ok.status).toBe(201)
+  })
+
+  it("serves public/link artifacts to anyone", async () => {
+    const { short_id } = await (await pub("link", { authorization: "Bearer s3cret" })).json()
+    expect((await authApp.request(`/a/${short_id}`)).status).toBe(200)
+    expect((await authApp.request(`/v1/artifacts/${short_id}/content`)).status).toBe(200)
+  })
+
+  it("hides gated artifacts without the token (404), reveals with it", async () => {
+    const { short_id } = await (await pub("org", { authorization: "Bearer s3cret" })).json()
+    expect((await authApp.request(`/a/${short_id}`)).status).toBe(404)
+    expect((await authApp.request(`/v1/artifacts/${short_id}`)).status).toBe(404)
+    expect((await authApp.request(`/v1/artifacts/${short_id}/content`)).status).toBe(404)
+    expect((await authApp.request(`/a/${short_id}`, authed())).status).toBe(200)
+    expect((await authApp.request(`/v1/artifacts/${short_id}`, authed())).status).toBe(200)
+  })
+
+  it("leaves a no-token instance fully open (the default app)", async () => {
+    const form = new FormData()
+    form.append("file", new Blob([new TextEncoder().encode("# x")]), "x.md")
+    expect((await app.request("/v1/artifacts", { method: "POST", body: form })).status).toBe(201)
+  })
+})

--- a/packages/cli/bin/dock.js
+++ b/packages/cli/bin/dock.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 // dock — publish HTML, Markdown, or any static build output to a Dock server.
 //   dock publish <file|dir> [--id <short_id>] [--title t] [--slug s] [--spa]
-//                [--message m] [--server http://localhost:8080]
+//                [--message m] [--visibility public|link|org|password]
+//                [--server http://localhost:8080] [--token t]
 import { readFileSync, readdirSync, statSync } from "node:fs"
 import { join, basename, relative } from "node:path"
 import { zipSync } from "fflate"
@@ -10,7 +11,7 @@ const args = process.argv.slice(2)
 const cmd = args.shift()
 
 if (cmd !== "publish" || args.length === 0 || args[0].startsWith("--")) {
-  console.error(`usage: dock publish <file|dir> [--id X] [--title t] [--slug s] [--spa] [--message m] [--server url]`)
+  console.error(`usage: dock publish <file|dir> [--id X] [--title t] [--slug s] [--spa] [--message m] [--visibility v] [--server url] [--token t]`)
   process.exit(cmd === "publish" ? 1 : cmd ? 1 : 0)
 }
 
@@ -22,6 +23,7 @@ for (let i = 0; i < args.length; i++) {
   else if (a.startsWith("--")) opts[a.slice(2)] = args[++i]
 }
 const server = opts.server ?? process.env.DOCK_SERVER ?? "http://localhost:8080"
+const token = opts.token ?? process.env.DOCK_TOKEN
 
 const collect = (dir, base, out = {}) => {
   for (const name of readdirSync(dir)) {
@@ -51,13 +53,14 @@ if (st.isDirectory()) {
 
 const form = new FormData()
 form.append("file", new Blob([bytes]), filename)
-for (const k of ["title", "slug", "spa", "message"]) if (opts[k]) form.append(k, opts[k])
+for (const k of ["title", "slug", "spa", "message", "visibility"]) if (opts[k]) form.append(k, opts[k])
 
 const url = opts.id
   ? `${server}/v1/artifacts/${opts.id}/versions`
   : `${server}/v1/artifacts`
 
-const res = await fetch(url, { method: "POST", body: form })
+const headers = token ? { authorization: `Bearer ${token}` } : {}
+const res = await fetch(url, { method: "POST", body: form, headers })
 const json = await res.json().catch(() => ({}))
 if (!res.ok) {
   console.error(`error (${res.status}): ${json.error ?? res.statusText}`)

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -8,6 +8,7 @@ import {
   type BundleManifest,
   type MetaStore,
   type VersionRecord,
+  type Visibility,
 } from "./ports"
 
 export interface PublishInput {
@@ -19,6 +20,7 @@ export interface PublishInput {
   spa?: boolean
   message?: string
   author?: string
+  visibility?: Visibility
 }
 
 export interface PublishResult {
@@ -122,7 +124,7 @@ export async function publish(
     org_id: "local",
     slug: input.slug ? slugify(input.slug) : slugify(title) || null,
     title,
-    visibility: "link",
+    visibility: input.visibility ?? "link",
     kind,
     spa: input.spa ? 1 : 0,
   })

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -7,6 +7,7 @@ export interface PublishArgs {
   slug?: string
   spa?: boolean
   message?: string
+  visibility?: "public" | "link" | "org" | "password"
   /** When set, publishes a new version of this artifact instead of a new one. */
   id?: string
   /** Comment ids whose threads to resolve as part of this (re)publish. */
@@ -81,6 +82,7 @@ export function createClient(opts: ClientOptions): DockClient {
       if (args.title) form.append("title", args.title)
       if (args.slug) form.append("slug", args.slug)
       if (args.message) form.append("message", args.message)
+      if (args.visibility) form.append("visibility", args.visibility)
       if (args.spa) form.append("spa", "true")
       if (args.resolves?.length) form.append("resolves", args.resolves.join(","))
       const url = args.id ? `${base}/v1/artifacts/${args.id}/versions` : `${base}/v1/artifacts`

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -21,6 +21,7 @@ server.registerTool(
       filename: z.string().describe("Filename, e.g. report.html or notes.md."),
       title: z.string().optional(),
       slug: z.string().optional(),
+      visibility: z.enum(["public", "link", "org", "password"]).optional(),
     },
   },
   async (args) => {


### PR DESCRIPTION
## Summary

The zero-dependency first step of auth: a bearer token gates writes, and per-artifact visibility gates reads. No user model yet — that's deliberate. Full login/SSO (Better Auth) lands with the web UI; this makes private/gated artifacts actually private today, with nothing to configure in dev.

## What changed

- **`DOCK_TOKEN`** — when set, every write (publish, version, comment, resolve) requires `Authorization: Bearer <token>`. Unset = open instance (zero-config dev) — fully backward compatible.
- **Per-artifact visibility** plumbed through publish (`public | link | org | password`, default `link`). Reads of anything other than `public`/`link` require the token; gated artifacts **404 without it** (don't leak existence) across the viewer, raw serving, content read-back, diff, and comments.
- **CLI**: `--visibility`, `--token` / `DOCK_TOKEN`. **MCP**: `publish_artifact` gains `visibility`; client sends the token.

## Tests

30 passing (`pnpm test`), typecheck clean — core 3 · api 22 · mcp 5. Covers: write 401 without token / 201 with, public/link open, gated 404→200 with token, and the default no-token instance staying open.

## Next

- Better Auth at the `apps/web` milestone: real accounts, magic-link, OAuth, orgs → replaces "the token" with "an authenticated org member", and `password` visibility gets a real unlock flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
