### PR TITLE
live: SSE event stream + presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ DOCK_SERVER=http://localhost:8080 pnpm --filter @dock/mcp start
 
 Tools: `publish_artifact`, `publish_version` (with `resolves`), `get_artifact` (source read-back), `list_versions`, `list_comments`, `reply_comment`.
 
+## Live updates
+
+`GET /v1/artifacts/:id/events` is a Server-Sent Events stream emitting
+`comment.created`, `comment.resolved`, `version.published`, and `presence`.
+`POST /v1/artifacts/:id/presence {name}` records a heartbeat. Plain HTTP — no
+WebSockets, no sticky sessions.
+
 Every artifact is served with `Content-Security-Policy: sandbox` on an opaque
 origin and rendered inside a sandboxed iframe — scripts run, but cannot reach
 cookies, storage, or other artifacts.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,6 @@
 import { Hono, type Context } from "hono"
+import { streamSSE } from "hono/streaming"
+import { Presence, createBus } from "./bus"
 import {
   BUNDLE_CONTENT_TYPE,
   PublishError,
@@ -63,6 +65,8 @@ const rewriteAbsoluteUrls = (text: string, prefix: string): string =>
 export function createApp(deps: AppDeps): Hono {
   const { meta, blobs } = deps
   const app = new Hono()
+  const bus = createBus()
+  const presence = new Presence()
 
   const bearer = (c: Context): string => {
     const h = c.req.header("authorization") ?? ""
@@ -119,6 +123,11 @@ export function createApp(deps: AppDeps): Hono {
         },
         shortId,
       )
+      bus.publish(artifact.id, {
+        type: "version.published",
+        n: version.n,
+        message: version.message,
+      })
       // Republish can resolve comment threads in the same call.
       const resolves = body["resolves"]
       if (shortId && typeof resolves === "string" && resolves) {
@@ -126,6 +135,7 @@ export function createApp(deps: AppDeps): Hono {
           const cm = await meta.getComment(cid)
           if (cm && cm.artifact_id === artifact.id) {
             await meta.setThreadState(artifact.id, cm.thread_id, "resolved")
+            bus.publish(artifact.id, { type: "comment.resolved", thread_id: cm.thread_id })
           }
         }
       }
@@ -237,6 +247,7 @@ export function createApp(deps: AppDeps): Hono {
       body_md: body.body_md,
       author: typeof body.author === "string" && body.author ? body.author : "anonymous",
     })
+    bus.publish(artifact.id, { type: "comment.created", comment: created })
     return c.json(created, 201)
   })
 
@@ -258,7 +269,37 @@ export function createApp(deps: AppDeps): Hono {
     const body = (await c.req.json().catch(() => ({}))) as { state?: string }
     const state = body.state === "open" ? "open" : "resolved"
     const updated = await meta.setThreadState(artifact.id, cm.thread_id, state)
+    bus.publish(artifact.id, { type: "comment.resolved", thread_id: cm.thread_id, state })
     return c.json({ thread_id: cm.thread_id, state, updated })
+  })
+
+  // ---- Live stream (SSE) + presence -------------------------------------
+
+  app.get("/v1/artifacts/:shortId/events", async (c) => {
+    const artifact = await meta.getByShortId(c.req.param("shortId"))
+    if (!artifact || !readOk(c, artifact)) return c.text("not found", 404)
+    c.header("Access-Control-Allow-Origin", "*")
+    return streamSSE(c, async (stream) => {
+      const unsub = bus.subscribe(artifact.id, (e) => {
+        void stream.writeSSE({ event: e.type, data: JSON.stringify(e) })
+      })
+      stream.onAbort(unsub)
+      await stream.writeSSE({ event: "ready", data: JSON.stringify({ short_id: artifact.short_id }) })
+      while (!stream.aborted) {
+        await stream.sleep(15000)
+        await stream.writeSSE({ event: "ping", data: "{}" })
+      }
+    })
+  })
+
+  app.post("/v1/artifacts/:shortId/presence", async (c) => {
+    const artifact = await meta.getByShortId(c.req.param("shortId"))
+    if (!artifact || !readOk(c, artifact)) return c.json({ error: "not found" }, 404)
+    const body = (await c.req.json().catch(() => ({}))) as { name?: string }
+    const name = typeof body.name === "string" && body.name ? body.name : "anonymous"
+    const viewers = presence.heartbeat(artifact.id, name, Date.now())
+    bus.publish(artifact.id, { type: "presence", viewers })
+    return c.json({ viewers })
   })
 
   // ---- Viewer ------------------------------------------------------------

--- a/apps/api/src/bus.ts
+++ b/apps/api/src/bus.ts
@@ -1,0 +1,50 @@
+export interface DockEvent {
+  type: "comment.created" | "comment.resolved" | "version.published" | "presence"
+  [k: string]: unknown
+}
+
+/** In-process pub/sub, keyed by artifact id. One process fans out in memory. */
+export interface EventBus {
+  subscribe(artifactId: string, cb: (e: DockEvent) => void): () => void
+  publish(artifactId: string, e: DockEvent): void
+}
+
+export function createBus(): EventBus {
+  const subs = new Map<string, Set<(e: DockEvent) => void>>()
+  return {
+    subscribe(artifactId, cb) {
+      let set = subs.get(artifactId)
+      if (!set) {
+        set = new Set()
+        subs.set(artifactId, set)
+      }
+      const s = set
+      s.add(cb)
+      return () => {
+        s.delete(cb)
+        if (s.size === 0) subs.delete(artifactId)
+      }
+    },
+    publish(artifactId, e) {
+      subs.get(artifactId)?.forEach((cb) => cb(e))
+    },
+  }
+}
+
+/** Ephemeral presence per artifact: name → last-seen ms. Lost on restart. */
+export class Presence {
+  private viewers = new Map<string, Map<string, number>>()
+  constructor(private ttlMs = 45_000) {}
+
+  /** Records a heartbeat and returns the live viewer names. */
+  heartbeat(artifactId: string, name: string, now: number): string[] {
+    let m = this.viewers.get(artifactId)
+    if (!m) {
+      m = new Map()
+      this.viewers.set(artifactId, m)
+    }
+    m.set(name, now)
+    for (const [n, t] of m) if (now - t > this.ttlMs) m.delete(n)
+    return [...m.keys()]
+  }
+}

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -295,3 +295,54 @@ describe("auth: token write-gating + per-artifact read-gating", () => {
     expect((await app.request("/v1/artifacts", { method: "POST", body: form })).status).toBe(201)
   })
 })
+
+describe("live stream (SSE)", () => {
+  async function readUntil(
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+    needle: string,
+    timeoutMs = 2500,
+  ): Promise<string> {
+    const dec = new TextDecoder()
+    let buf = ""
+    const start = Date.now()
+    while (Date.now() - start < timeoutMs) {
+      const res = await Promise.race([
+        reader.read(),
+        new Promise<{ value?: Uint8Array; done: boolean }>((r) =>
+          setTimeout(() => r({ value: undefined, done: false }), 150),
+        ),
+      ])
+      if (res.value) buf += dec.decode(res.value, { stream: true })
+      if (buf.includes(needle)) return buf
+      if (res.done) break
+    }
+    throw new Error(`SSE timeout waiting for "${needle}"; got:\n${buf}`)
+  }
+
+  it("emits ready, then comment.created and version.published", async () => {
+    const { short_id } = await (await upload("live.md", "# live", {})).json()
+    const res = await app.request(`/v1/artifacts/${short_id}/events`)
+    expect(res.headers.get("content-type")).toContain("text/event-stream")
+    const reader = res.body!.getReader()
+    try {
+      await readUntil(reader, "event: ready")
+
+      await app.request(`/v1/artifacts/${short_id}/comments`, json({ body_md: "live note" }))
+      expect(await readUntil(reader, "event: comment.created")).toContain("live note")
+
+      const form = new FormData()
+      form.append("file", new Blob([new TextEncoder().encode("# live v2")]), "live.md")
+      form.append("message", "v2")
+      await app.request(`/v1/artifacts/${short_id}/versions`, { method: "POST", body: form })
+      expect(await readUntil(reader, "event: version.published")).toContain('"n":2')
+    } finally {
+      await reader.cancel()
+    }
+  })
+
+  it("reports presence on heartbeat", async () => {
+    const { short_id } = await (await upload("p.md", "# p", {})).json()
+    const res = await app.request(`/v1/artifacts/${short_id}/presence`, json({ name: "Jess" }))
+    expect((await res.json()).viewers).toEqual(["Jess"])
+  })
+})

--- a/apps/api/test/bus.test.ts
+++ b/apps/api/test/bus.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+import { Presence, createBus } from "../src/bus"
+
+describe("event bus", () => {
+  it("delivers published events to subscribers of that artifact only", () => {
+    const bus = createBus()
+    const a: unknown[] = []
+    const b: unknown[] = []
+    bus.subscribe("art_a", (e) => a.push(e))
+    bus.subscribe("art_b", (e) => b.push(e))
+    bus.publish("art_a", { type: "version.published", n: 2 })
+    expect(a).toHaveLength(1)
+    expect(b).toHaveLength(0)
+  })
+
+  it("stops delivering after unsubscribe", () => {
+    const bus = createBus()
+    const seen: unknown[] = []
+    const off = bus.subscribe("x", (e) => seen.push(e))
+    bus.publish("x", { type: "presence", viewers: [] })
+    off()
+    bus.publish("x", { type: "presence", viewers: [] })
+    expect(seen).toHaveLength(1)
+  })
+})
+
+describe("presence", () => {
+  it("tracks live viewers and prunes stale ones past the TTL", () => {
+    const p = new Presence(1000)
+    expect(p.heartbeat("a", "jess", 0)).toEqual(["jess"])
+    expect(p.heartbeat("a", "sam", 500).sort()).toEqual(["jess", "sam"])
+    // jess last seen at 0; at t=1600 she's stale (>1000ms), sam stays
+    expect(p.heartbeat("a", "sam", 1600)).toEqual(["sam"])
+  })
+})


### PR DESCRIPTION
## Summary

Makes the loop real-time. An in-process event bus fans out per-artifact events to a Server-Sent Events stream, so the (future) UI and any subscriber see comments and new versions live. Plain HTTP — no WebSockets, no sticky sessions, fits the one-container story.

## What's included

- **`GET /v1/artifacts/:id/events`** (SSE) — emits `comment.created`, `comment.resolved`, `version.published`, `presence`, plus a `ready` hello and a 15s `ping` keepalive. Read-gated like the rest.
- **`POST /v1/artifacts/:id/presence {name}`** — ephemeral presence heartbeat with a TTL; returns + broadcasts the live viewer list.
- **In-process bus** (`createBus`) keyed by artifact id; emit points wired into publish, comment-create, and resolve.

## Tests

35 total (`pnpm test`), typecheck clean — incl. a deterministic bus/presence unit test and an SSE integration test that reads `ready` → `comment.created` → `version.published` off a live stream.

## Notes

- Single-process fan-out today; multi-replica fan-out (Postgres LISTEN/NOTIFY) is a later swap behind the same bus interface.
- Presence is in-memory by design (lost on restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
