### PR TITLE
v1: login, app home, browser comment loop + inline editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,17 @@ Optional env vars (nothing is required):
 `DATABASE_URL` → Postgres · `OBJECT_STORE_URL` → S3/R2 · `DOCK_TOKEN` → require a
 bearer token for publishing and for reading gated artifacts · `BASE_URL`, `PORT`, `DATA_DIR`.
 
-### Access
+### The app & accounts
 
-Publish with `--visibility public|link|org|password` (default `link`). When
-`DOCK_TOKEN` is set, writes require `Authorization: Bearer <token>`, and reading
-anything other than `public`/`link` requires it too — gated artifacts 404 without
-it. (Per-user accounts and SSO come later; this is the zero-dependency gate.)
+Open **`/app`** in a browser (or `/login`). The first account you create is the
+admin. Once signed in you get a library, in-browser publishing, and the comment
+loop — comments are authored as you, and Markdown/HTML artifacts can be edited
+inline to publish a new version.
+
+Writes are authorized by a login session **or** a static `DOCK_TOKEN` (for
+CI/agents). Publish with `--visibility public|link|org|password` (default `link`);
+when `DOCK_TOKEN` is set, gated artifacts 404 for anyone without a session or the
+token. (OAuth/SSO/orgs via Better Auth come next; this is the zero-dependency base.)
 
 ## Architecture
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,6 +1,9 @@
 import { Hono, type Context } from "hono"
 import { streamSSE } from "hono/streaming"
+import { deleteCookie, getCookie, setCookie } from "hono/cookie"
 import { Presence, createBus } from "./bus"
+import { SESSION_DAYS, hashPassword, newSessionToken, sessionExpiry, verifyPassword } from "./auth"
+import { renderHome, renderLogin, renderSignup } from "./pages"
 import {
   BUNDLE_CONTENT_TYPE,
   PublishError,
@@ -17,6 +20,7 @@ import {
   type BlobStore,
   type BundleManifest,
   type MetaStore,
+  type UserRecord,
   type VersionRecord,
   type Visibility,
 } from "@dock/core"
@@ -68,14 +72,47 @@ export function createApp(deps: AppDeps): Hono {
   const bus = createBus()
   const presence = new Presence()
 
+  const SESSION_COOKIE = "dock_session"
+
   const bearer = (c: Context): string => {
     const h = c.req.header("authorization") ?? ""
     return h.startsWith("Bearer ") ? h.slice(7) : ""
   }
-  // Open when no token is configured; otherwise the bearer must match.
-  const writeOk = (c: Context): boolean => !deps.token || bearer(c) === deps.token
-  const readOk = (c: Context, a: ArtifactRecord): boolean =>
-    a.visibility === "public" || a.visibility === "link" || !deps.token || bearer(c) === deps.token
+
+  const currentUser = async (c: Context): Promise<UserRecord | null> => {
+    const tok = getCookie(c, SESSION_COOKIE)
+    if (!tok) return null
+    const s = await meta.getSession(tok)
+    if (!s) return null
+    if (new Date(s.expires_at).getTime() < Date.now()) {
+      await meta.deleteSession(tok)
+      return null
+    }
+    return meta.getUserById(s.user_id)
+  }
+
+  const startSession = async (c: Context, userId: string): Promise<void> => {
+    const token = newSessionToken()
+    await meta.createSession({ token, user_id: userId, expires_at: sessionExpiry(Date.now()) })
+    setCookie(c, SESSION_COOKIE, token, {
+      httpOnly: true,
+      sameSite: "Lax",
+      secure: deps.baseUrl.startsWith("https"),
+      path: "/",
+      maxAge: SESSION_DAYS * 86_400,
+    })
+  }
+
+  // A static token (if configured) or a valid login session authorizes writes;
+  // gated reads need one too. No token + no session = open dev instance.
+  const writeOk = async (c: Context): Promise<boolean> =>
+    !deps.token || bearer(c) === deps.token || (await currentUser(c)) !== null
+  const readOk = async (c: Context, a: ArtifactRecord): Promise<boolean> =>
+    a.visibility === "public" ||
+    a.visibility === "link" ||
+    !deps.token ||
+    bearer(c) === deps.token ||
+    (await currentUser(c)) !== null
 
   app.get("/healthz", (c) => c.json({ ok: true }))
 
@@ -85,14 +122,70 @@ export function createApp(deps: AppDeps): Hono {
 <body style="font:16px/1.6 system-ui;background:#f6f0e3;color:#2a2540;display:grid;place-items:center;height:100vh;margin:0">
 <div style="text-align:center"><h1 style="letter-spacing:-.02em">Dock</h1>
 <p>An open home for AI-generated artifacts.<br>
-<code style="background:#eee7d6;padding:2px 8px;border-radius:6px">dock publish ./your-thing</code></p></div>`,
+<code style="background:#eee7d6;padding:2px 8px;border-radius:6px">dock publish ./your-thing</code></p>
+<p style="margin-top:18px"><a href="/app" style="color:#4f447e">Open the app →</a></p></div>`,
     ),
   )
+
+  // ---- Auth + app shell -------------------------------------------------
+
+  app.get("/login", async (c) => {
+    if (await currentUser(c)) return c.redirect("/app")
+    return c.html(renderLogin({ firstUser: (await meta.countUsers()) === 0 }))
+  })
+
+  app.get("/signup", (c) => c.html(renderSignup()))
+
+  app.post("/auth/signup", async (c) => {
+    const body = await c.req.parseBody()
+    const email = String(body.email ?? "").trim().toLowerCase()
+    const password = String(body.password ?? "")
+    if (!email || password.length < 8)
+      return c.html(renderSignup("Enter an email and a password of at least 8 characters."), 400)
+    if (await meta.getUserByEmail(email))
+      return c.html(renderSignup("That email is already registered."), 400)
+    const first = (await meta.countUsers()) === 0
+    const u = await meta.createUser({
+      id: newId("u"),
+      email,
+      name: str(body.name) ?? null,
+      password_hash: hashPassword(password),
+      role: first ? "admin" : "member",
+    })
+    await startSession(c, u.id)
+    return c.redirect("/app")
+  })
+
+  app.post("/auth/login", async (c) => {
+    const body = await c.req.parseBody()
+    const email = String(body.email ?? "").trim().toLowerCase()
+    const u = await meta.getUserByEmail(email)
+    if (!u || !verifyPassword(String(body.password ?? ""), u.password_hash))
+      return c.html(
+        renderLogin({ error: "Wrong email or password.", firstUser: (await meta.countUsers()) === 0 }),
+        401,
+      )
+    await startSession(c, u.id)
+    return c.redirect("/app")
+  })
+
+  app.post("/auth/logout", async (c) => {
+    const tok = getCookie(c, SESSION_COOKIE)
+    if (tok) await meta.deleteSession(tok)
+    deleteCookie(c, SESSION_COOKIE, { path: "/" })
+    return c.redirect("/login")
+  })
+
+  app.get("/app", async (c) => {
+    const user = await currentUser(c)
+    if (!user) return c.redirect("/login")
+    return c.html(renderHome(user, await meta.listArtifacts({ limit: 100 }), deps.baseUrl))
+  })
 
   // ---- Publish ----------------------------------------------------------
 
   const handlePublish = async (c: Context, shortId?: string) => {
-    if (!writeOk(c)) return c.json({ error: "unauthorized" }, 401)
+    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
     const len = Number(c.req.header("content-length") ?? 0)
     if (len > MAX_UPLOAD_BYTES) return c.json({ error: "upload too large" }, 413)
 
@@ -152,7 +245,7 @@ export function createApp(deps: AppDeps): Hono {
 
   app.get("/v1/artifacts/:shortId", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || !readOk(c, artifact)) return c.json({ error: "not found" }, 404)
+    if (!artifact || !(await readOk(c, artifact))) return c.json({ error: "not found" }, 404)
     return c.json(toJson(deps.baseUrl, artifact, await meta.listVersions(artifact.id)))
   })
 
@@ -174,7 +267,7 @@ export function createApp(deps: AppDeps): Hono {
   // version, as plain text (?v=N selects a version; defaults to current).
   app.get("/v1/artifacts/:shortId/content", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || artifact.current_version === 0 || !readOk(c, artifact))
+    if (!artifact || artifact.current_version === 0 || !(await readOk(c, artifact)))
       return c.json({ error: "not found" }, 404)
     const v = c.req.query("v") ? Number(c.req.query("v")) : artifact.current_version
     if (!Number.isInteger(v)) return c.json({ error: "bad version" }, 400)
@@ -194,7 +287,7 @@ export function createApp(deps: AppDeps): Hono {
   // ?format=json returns the structured ops; otherwise unified-style text.
   app.get("/v1/artifacts/:shortId/diff", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || artifact.current_version === 0 || !readOk(c, artifact))
+    if (!artifact || artifact.current_version === 0 || !(await readOk(c, artifact)))
       return c.json({ error: "not found" }, 404)
     const cur = artifact.current_version
     const from = c.req.query("from") ? Number(c.req.query("from")) : Math.max(1, cur - 1)
@@ -218,7 +311,7 @@ export function createApp(deps: AppDeps): Hono {
 
   // Create a comment (new thread) or a reply (pass thread_id).
   app.post("/v1/artifacts/:shortId/comments", async (c) => {
-    if (!writeOk(c)) return c.json({ error: "unauthorized" }, 401)
+    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact || artifact.current_version === 0) return c.json({ error: "not found" }, 404)
     const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>
@@ -237,6 +330,12 @@ export function createApp(deps: AppDeps): Hono {
           ? body.anchor
           : null
 
+    const me = await currentUser(c)
+    const author = me
+      ? (me.name ?? me.email)
+      : typeof body.author === "string" && body.author
+        ? body.author
+        : "anonymous"
     const created = await meta.createComment({
       id,
       artifact_id: artifact.id,
@@ -245,7 +344,7 @@ export function createApp(deps: AppDeps): Hono {
       path: typeof body.path === "string" ? body.path : null,
       anchor,
       body_md: body.body_md,
-      author: typeof body.author === "string" && body.author ? body.author : "anonymous",
+      author,
     })
     bus.publish(artifact.id, { type: "comment.created", comment: created })
     return c.json(created, 201)
@@ -253,7 +352,7 @@ export function createApp(deps: AppDeps): Hono {
 
   app.get("/v1/artifacts/:shortId/comments", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || !readOk(c, artifact)) return c.json({ error: "not found" }, 404)
+    if (!artifact || !(await readOk(c, artifact))) return c.json({ error: "not found" }, 404)
     const q = c.req.query("state")
     const state = q === "open" || q === "resolved" ? q : undefined
     return c.json({ comments: await meta.listComments(artifact.id, state ? { state } : undefined) })
@@ -261,7 +360,7 @@ export function createApp(deps: AppDeps): Hono {
 
   // Resolve (or reopen, with {state:"open"}) the thread a comment belongs to.
   app.post("/v1/artifacts/:shortId/comments/:commentId/resolve", async (c) => {
-    if (!writeOk(c)) return c.json({ error: "unauthorized" }, 401)
+    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact) return c.json({ error: "not found" }, 404)
     const cm = await meta.getComment(c.req.param("commentId"))
@@ -277,7 +376,7 @@ export function createApp(deps: AppDeps): Hono {
 
   app.get("/v1/artifacts/:shortId/events", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || !readOk(c, artifact)) return c.text("not found", 404)
+    if (!artifact || !(await readOk(c, artifact))) return c.text("not found", 404)
     c.header("Access-Control-Allow-Origin", "*")
     return streamSSE(c, async (stream) => {
       const unsub = bus.subscribe(artifact.id, (e) => {
@@ -294,7 +393,7 @@ export function createApp(deps: AppDeps): Hono {
 
   app.post("/v1/artifacts/:shortId/presence", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || !readOk(c, artifact)) return c.json({ error: "not found" }, 404)
+    if (!artifact || !(await readOk(c, artifact))) return c.json({ error: "not found" }, 404)
     const body = (await c.req.json().catch(() => ({}))) as { name?: string }
     const name = typeof body.name === "string" && body.name ? body.name : "anonymous"
     const viewers = presence.heartbeat(artifact.id, name, Date.now())
@@ -308,7 +407,7 @@ export function createApp(deps: AppDeps): Hono {
     const m = REF_RE.exec(c.req.param("ref"))
     if (!m) return c.text("not found", 404)
     const artifact = await meta.getByShortId(m[1])
-    if (!artifact || artifact.current_version === 0 || !readOk(c, artifact))
+    if (!artifact || artifact.current_version === 0 || !(await readOk(c, artifact)))
       return c.text("not found", 404)
     const n = m[2] ? Number(m[2]) : artifact.current_version
     const version = await meta.getVersion(artifact.id, n)
@@ -324,7 +423,7 @@ export function createApp(deps: AppDeps): Hono {
     const shortId = c.req.param("shortId")
     const n = Number(c.req.param("n"))
     const artifact = await meta.getByShortId(shortId)
-    if (!artifact || !Number.isInteger(n) || !readOk(c, artifact)) return c.text("not found", 404)
+    if (!artifact || !Number.isInteger(n) || !(await readOk(c, artifact))) return c.text("not found", 404)
     const version = await meta.getVersion(artifact.id, n)
     if (!version) return c.text("not found", 404)
 

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -1,0 +1,22 @@
+import { randomBytes, scryptSync, timingSafeEqual } from "node:crypto"
+
+/** scrypt password hashing — `salt:hash` hex. Node-only (the container). */
+export function hashPassword(pw: string): string {
+  const salt = randomBytes(16)
+  const hash = scryptSync(pw, salt, 32)
+  return `${salt.toString("hex")}:${hash.toString("hex")}`
+}
+
+export function verifyPassword(pw: string, stored: string): boolean {
+  const [saltHex, hashHex] = stored.split(":")
+  if (!saltHex || !hashHex) return false
+  const expected = Buffer.from(hashHex, "hex")
+  const actual = scryptSync(pw, Buffer.from(saltHex, "hex"), 32)
+  return expected.length === actual.length && timingSafeEqual(expected, actual)
+}
+
+export const newSessionToken = (): string => randomBytes(32).toString("hex")
+
+export const SESSION_DAYS = 30
+export const sessionExpiry = (now: number): string =>
+  new Date(now + SESSION_DAYS * 86_400_000).toISOString()

--- a/apps/api/src/pages.ts
+++ b/apps/api/src/pages.ts
@@ -1,0 +1,96 @@
+import { escapeHtml, type ArtifactRecord, type UserRecord } from "@dock/core"
+
+const HEAD = (title: string) => `<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex"><title>${title} · Dock</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
+<style>
+  :root{--paper:#f6f0e3;--panel:#fdf8ec;--panel-2:#f1ead9;--ink:#2a2540;--soft:#46415c;--muted:#6b6680;
+    --line:#e4dcc9;--line-2:#eee7d6;--accent:#655999;--accent-ink:#4f447e;--accent-soft:#e8e4f1;
+    --sans:Inter,system-ui,sans-serif;--display:"Space Grotesk",var(--sans);--mono:ui-monospace,Menlo,monospace}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--paper);color:var(--ink);font:15px/1.55 var(--sans);
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.04'/%3E%3C/svg%3E")}
+  a{color:var(--accent-ink)}
+  .mk{width:30px;height:30px}
+  .brand{display:flex;align-items:center;gap:11px;font-family:var(--display);font-weight:600;font-size:20px;letter-spacing:-.02em}
+  .btn{display:inline-flex;align-items:center;gap:7px;font-weight:600;font-size:14px;padding:9px 15px;border-radius:10px;border:1px solid var(--line);background:var(--panel);color:var(--ink);cursor:pointer;text-decoration:none}
+  .btn.pri{background:var(--accent);color:#fff;border-color:var(--accent)}
+  .btn:hover{filter:brightness(1.03)}
+  input{width:100%;border:1px solid var(--line);border-radius:9px;padding:9px 11px;font:14px var(--sans);color:var(--ink);background:var(--panel);margin-top:4px}
+  label{font-size:12.5px;font-weight:600;color:var(--soft)}
+  .err{background:#f1e1d6;color:#a04425;border-radius:8px;padding:8px 12px;font-size:13px;margin-bottom:12px}
+</style></head><body>`
+
+const LOGO = `<svg class="mk" viewBox="0 0 32 32" fill="none"><rect x="1" y="1" width="30" height="30" rx="8" fill="#2a2540"/>
+<path d="M16 7l7 7v11h-4.6v-6.2h-4.8V25H9V14l7-7z" fill="none" stroke="#8a7dc0" stroke-width="1.7" stroke-linejoin="round"/>
+<rect x="13.6" y="6.4" width="4.8" height="4.8" rx="1.2" fill="#655999"/></svg>`
+
+export function renderLogin(opts: { error?: string; firstUser: boolean } = { firstUser: false }): string {
+  const { error, firstUser } = opts
+  return `${HEAD("Sign in")}
+<div style="max-width:380px;margin:9vh auto;padding:0 22px">
+  <div class="brand" style="justify-content:center;margin-bottom:6px">${LOGO} Dock</div>
+  <p style="text-align:center;color:var(--muted);margin:0 0 26px">${firstUser ? "Create the first account to get started." : "Sign in to your workspace."}</p>
+  <div style="background:var(--panel);border:1px solid var(--line);border-radius:16px;padding:22px;box-shadow:0 12px 28px -16px rgba(42,37,64,.25)">
+    ${error ? `<div class="err">${escapeHtml(error)}</div>` : ""}
+    <form method="post" action="${firstUser ? "/auth/signup" : "/auth/login"}">
+      ${firstUser ? `<div style="margin-bottom:12px"><label>Name</label><input name="name" placeholder="Your name"></div>` : ""}
+      <div style="margin-bottom:12px"><label>Email</label><input name="email" type="email" required placeholder="you@company.com"></div>
+      <div style="margin-bottom:16px"><label>Password</label><input name="password" type="password" required minlength="8" placeholder="At least 8 characters"></div>
+      <button class="btn pri" type="submit" style="width:100%;justify-content:center">${firstUser ? "Create account" : "Sign in"}</button>
+    </form>
+    ${
+      firstUser
+        ? ""
+        : `<p style="text-align:center;font-size:13px;color:var(--muted);margin:14px 0 0">New here? <a href="/signup">Create an account</a></p>`
+    }
+  </div>
+</div></body></html>`
+}
+
+export function renderSignup(error?: string): string {
+  return renderLogin({ error, firstUser: true })
+    .replace("/auth/signup", "/auth/signup")
+    .replace("Create the first account to get started.", "Create your account.")
+}
+
+export function renderHome(user: UserRecord, artifacts: ArtifactRecord[], baseUrl: string): string {
+  const cards =
+    artifacts.length === 0
+      ? `<div style="grid-column:1/-1;text-align:center;color:var(--muted);padding:40px;border:1px dashed var(--line);border-radius:14px">Nothing published yet. Use the box above, or <code>dock publish</code> from your terminal.</div>`
+      : artifacts
+          .map((a) => {
+            const url = `${baseUrl}/a/${a.short_id}${a.slug ? `-${a.slug}` : ""}`
+            return `<a href="${url}" style="display:flex;flex-direction:column;gap:7px;background:var(--panel);border:1px solid var(--line);border-radius:13px;padding:15px;text-decoration:none;color:var(--ink);box-shadow:0 1px 2px rgba(42,37,64,.04)">
+      <div style="font-family:var(--display);font-weight:600;font-size:15px;letter-spacing:-.01em">${escapeHtml(a.title ?? a.short_id)}</div>
+      <div style="font-family:var(--mono);font-size:11px;color:var(--muted);display:flex;gap:8px">
+        <span style="background:var(--panel-2);border:1px solid var(--line-2);border-radius:5px;padding:1px 6px">${a.kind}</span>
+        <span>v${a.current_version}</span><span>${a.visibility}</span></div></a>`
+          })
+          .join("")
+  return `${HEAD("Library")}
+<header style="display:flex;align-items:center;gap:12px;padding:13px 26px;background:var(--panel);border-bottom:1px solid var(--line)">
+  <span class="brand" style="font-size:18px">${LOGO} Dock</span>
+  <span style="margin-left:auto;font-size:13px;color:var(--muted)">${escapeHtml(user.name ?? user.email)}</span>
+  <form method="post" action="/auth/logout"><button class="btn" style="padding:6px 12px;font-size:13px">Sign out</button></form>
+</header>
+<main style="max-width:1000px;margin:0 auto;padding:26px 22px 60px">
+  <div style="background:var(--panel);border:1px solid var(--line);border-radius:15px;padding:18px;margin-bottom:24px;display:flex;align-items:center;gap:14px;flex-wrap:wrap">
+    <div style="flex:1;min-width:220px"><div style="font-family:var(--display);font-weight:600;font-size:16px">Publish an artifact</div>
+      <div style="font-size:13px;color:var(--muted)">Drop an HTML or Markdown file, or run <code>dock publish ./file</code>.</div></div>
+    <input type="file" id="file" accept=".html,.htm,.md,.markdown,.zip" style="max-width:260px;margin:0">
+    <button class="btn pri" id="pub">Publish</button>
+  </div>
+  <h2 style="font-family:var(--display);font-size:18px;letter-spacing:-.01em;margin:0 0 14px">Library <span style="color:var(--muted);font-weight:400;font-size:14px">· ${artifacts.length}</span></h2>
+  <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:13px">${cards}</div>
+</main>
+<script>
+const f=document.getElementById("file"), b=document.getElementById("pub");
+b.onclick=async()=>{ if(!f.files[0]){f.click();return;} const fd=new FormData(); fd.append("file",f.files[0]); fd.append("title",f.files[0].name.replace(/\\.[^.]+$/,""));
+  b.textContent="Publishing…"; const r=await fetch("/v1/artifacts",{method:"POST",body:fd});
+  if(r.ok){ const j=await r.json(); location.href="/a/"+j.short_id; } else { b.textContent="Publish"; alert("Publish failed"); } };
+</script>
+</body></html>`
+}

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -68,6 +68,43 @@ export interface MetaStore {
   getComment(id: string): Promise<CommentRecord | null>
   /** Flips every comment in a thread to a state; returns the count updated. */
   setThreadState(artifactId: string, threadId: string, state: CommentState): Promise<number>
+
+  createUser(u: NewUser): Promise<UserRecord>
+  getUserByEmail(email: string): Promise<UserRecord | null>
+  getUserById(id: string): Promise<UserRecord | null>
+  countUsers(): Promise<number>
+  listArtifacts(opts?: { limit?: number }): Promise<ArtifactRecord[]>
+  createSession(s: NewSession): Promise<SessionRecord>
+  getSession(token: string): Promise<SessionRecord | null>
+  deleteSession(token: string): Promise<void>
+}
+
+export interface UserRecord {
+  id: string
+  email: string
+  name: string | null
+  password_hash: string
+  role: string
+  created_at: string
+}
+export interface NewUser {
+  id: string
+  email: string
+  name?: string | null
+  password_hash: string
+  role?: string
+}
+
+export interface SessionRecord {
+  token: string
+  user_id: string
+  expires_at: string
+  created_at: string
+}
+export interface NewSession {
+  token: string
+  user_id: string
+  expires_at: string
 }
 
 export type CommentState = "open" | "resolved"

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -6,7 +6,7 @@ const LOGO = `<svg width="22" height="22" viewBox="0 0 32 32" fill="none" aria-h
 <path d="M16 7l7 7v11h-4.6v-6.2h-4.8V25H9V14l7-7z" fill="none" stroke="#8a7dc0" stroke-width="1.7" stroke-linejoin="round"/>
 <rect x="13.6" y="6.4" width="4.8" height="4.8" rx="1.2" fill="#655999"/></svg>`
 
-/** Viewer chrome around the sandboxed artifact iframe. */
+/** Viewer chrome around the sandboxed artifact iframe, with a live comment panel and inline editing. */
 export function renderShell(
   artifact: ArtifactRecord,
   versions: VersionRecord[],
@@ -16,13 +16,24 @@ export function renderShell(
   const title = escapeHtml(artifact.title ?? artifact.short_id)
   const current = artifact.current_version
   const version = versions.find((v) => v.n === shownVersion)
+  const isMd = version?.content_type === "text/markdown"
+  const editable = artifact.kind === "file" && shownVersion === current
   const chips = versions
     .map(
       (v) =>
         `<a class="chip${v.n === shownVersion ? " on" : ""}" href="/a/${artifact.short_id}@v${v.n}" title="${escapeHtml(v.message ?? "")}">v${v.n}</a>`,
     )
     .join("")
-  const isMd = version?.content_type === "text/markdown"
+
+  const cfg = JSON.stringify({
+    shortId: artifact.short_id,
+    version: shownVersion,
+    current,
+    kind: artifact.kind,
+    ext: isMd ? "md" : "html",
+    filename: `${(artifact.slug || artifact.short_id).replace(/[^a-z0-9-]/gi, "-")}.${isMd ? "md" : "html"}`,
+  })
+
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -31,25 +42,69 @@ export function renderShell(
 <meta name="robots" content="noindex">
 <title>${title} · Dock</title>
 <style>
-  :root{--paper:#f6f0e3;--panel:#fdf8ec;--ink:#2a2540;--muted:#6b6680;--line:#e4dcc9;
-    --accent:#655999;--accent-ink:#4f447e}
+  :root{--paper:#f6f0e3;--paper-2:#f1ead9;--panel:#fdf8ec;--ink:#2a2540;--ink-soft:#46415c;--muted:#6b6680;
+    --line:#e4dcc9;--line-2:#eee7d6;--accent:#655999;--accent-ink:#4f447e;--accent-soft:#e8e4f1;
+    --cmt-bg:#ebe7f5;--cmt-tx:#564f82;--cmt-bd:#cbc5e5;--good:#3c6e2f;--good-bg:#e3eedb;
+    --sans:Inter,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;--mono:ui-monospace,Menlo,Consolas,monospace}
   *{box-sizing:border-box}
   body{margin:0;height:100vh;display:flex;flex-direction:column;background:var(--paper);
-    font:13px/1.5 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;color:var(--ink)}
+    font:13px/1.5 var(--sans);color:var(--ink)}
   header{display:flex;align-items:center;gap:10px;padding:9px 16px;background:var(--panel);
     border-bottom:1px solid var(--line);flex:0 0 auto}
-  .t{font-weight:600;font-size:14px;letter-spacing:-.01em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  .meta{font-family:ui-monospace,Menlo,monospace;font-size:10.5px;color:var(--muted);white-space:nowrap}
-  .chips{display:flex;gap:5px;margin-left:auto}
-  .chip{font-family:ui-monospace,Menlo,monospace;font-size:10.5px;color:var(--muted);text-decoration:none;
-    border:1px solid var(--line);border-radius:6px;padding:3px 8px;background:var(--paper)}
+  .t{font-weight:600;font-size:14px;letter-spacing:-.01em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:42vw}
+  .meta{font-family:var(--mono);font-size:10.5px;color:var(--muted);white-space:nowrap}
+  .grow{flex:1}
+  .chips{display:flex;gap:5px}
+  .chip{font-family:var(--mono);font-size:10.5px;color:var(--muted);text-decoration:none;border:1px solid var(--line);
+    border-radius:6px;padding:3px 8px;background:var(--paper)}
   .chip.on{background:var(--accent);border-color:var(--accent);color:#fff;font-weight:700}
   .btn{font-size:11.5px;font-weight:600;border:1px solid var(--line);background:var(--paper);color:var(--ink);
-    border-radius:7px;padding:5px 11px;cursor:pointer;text-decoration:none}
+    border-radius:7px;padding:5px 11px;cursor:pointer;text-decoration:none;white-space:nowrap}
   .btn:hover{border-color:var(--accent);color:var(--accent-ink)}
+  .btn.pri{background:var(--accent);color:#fff;border-color:var(--accent)}
+  .btn.pri:hover{color:#fff;filter:brightness(1.05)}
   .old{background:#f4ead4;color:#7a531a;font-size:11.5px;padding:4px 16px;border-bottom:1px solid var(--line);flex:0 0 auto}
   .old a{color:#7a531a;font-weight:700}
+  main{flex:1;display:flex;min-height:0}
+  .stage{flex:1;display:flex;min-width:0}
   iframe{flex:1;border:0;width:100%;background:#fff}
+  /* inline editor */
+  .editor{flex:1;display:none;flex-direction:column;background:#fff}
+  .editor.on{display:flex}
+  .editor .bar{display:flex;align-items:center;gap:9px;padding:8px 12px;background:var(--paper-2);border-bottom:1px solid var(--line-2)}
+  .editor .bar .lbl{font-family:var(--mono);font-size:11px;color:var(--muted)}
+  .editor textarea{flex:1;border:0;resize:none;padding:16px 20px;font-family:var(--mono);font-size:13px;line-height:1.6;color:var(--ink);outline:none}
+  /* comment panel */
+  aside{width:320px;flex:0 0 320px;border-left:1px solid var(--line);background:var(--panel);display:flex;flex-direction:column;min-height:0}
+  aside.hidden{display:none}
+  .ph{display:flex;align-items:center;gap:8px;padding:11px 14px;border-bottom:1px solid var(--line-2)}
+  .ph b{font-family:Inter;font-size:13px}
+  .ph .cnt{font-family:var(--mono);font-size:10px;color:var(--accent-ink);background:var(--accent-soft);border-radius:999px;padding:1px 8px;font-weight:700}
+  .ph .pres{margin-left:auto;font-size:10.5px;color:var(--muted);display:flex;align-items:center;gap:5px}
+  .ph .pres i{width:6px;height:6px;border-radius:50%;background:var(--good)}
+  .threads{flex:1;overflow:auto;padding:12px}
+  .empty{color:var(--muted);font-size:12px;text-align:center;padding:30px 12px}
+  .thread{border:1px solid var(--line);border-radius:11px;background:var(--paper);margin-bottom:11px;overflow:hidden}
+  .thread.resolved{opacity:.62}
+  .cmt{padding:10px 12px;border-bottom:1px solid var(--line-2)}
+  .cmt:last-child{border-bottom:0}
+  .cmt .who{display:flex;align-items:center;gap:7px;font-size:11px;font-weight:700;color:var(--cmt-tx);margin-bottom:4px}
+  .cmt .who .av{width:17px;height:17px;border-radius:50%;background:var(--cmt-bg);color:var(--cmt-tx);display:grid;place-items:center;font-size:9px}
+  .cmt .who .vb{margin-left:auto;font-family:var(--mono);font-size:9px;color:var(--muted);font-weight:400}
+  .cmt p{margin:0;font-size:12.5px;color:var(--ink);line-height:1.45;white-space:pre-wrap;word-break:break-word}
+  .cmt .anc{font-family:var(--mono);font-size:9.5px;color:var(--muted);background:var(--paper-2);border-radius:5px;padding:2px 6px;display:inline-block;margin-bottom:5px}
+  .tfoot{display:flex;gap:7px;align-items:center;padding:7px 12px;background:var(--paper-2)}
+  .tfoot .st{font-family:var(--mono);font-size:9.5px;font-weight:700;padding:2px 8px;border-radius:999px}
+  .tfoot .st.open{background:var(--accent-soft);color:var(--accent-ink)} .tfoot .st.resolved{background:var(--good-bg);color:var(--good)}
+  .tfoot button{margin-left:auto;font-size:10.5px;font-weight:600;border:1px solid var(--line);background:var(--paper);color:var(--ink-soft);border-radius:6px;padding:3px 9px;cursor:pointer}
+  .reply{display:flex;gap:6px;padding:8px 12px;border-top:1px solid var(--line-2)}
+  .reply input{flex:1;border:1px solid var(--line);border-radius:7px;padding:6px 9px;font-family:var(--sans);font-size:12px;color:var(--ink);background:var(--paper)}
+  .composer{flex:0 0 auto;border-top:1px solid var(--line-2);padding:11px 12px;background:var(--panel)}
+  .composer textarea{width:100%;border:1px solid var(--cmt-bd);border-radius:9px;padding:8px 10px;font-family:var(--sans);font-size:12.5px;color:var(--ink);resize:vertical;min-height:52px;background:var(--paper)}
+  .composer .row{display:flex;gap:8px;align-items:center;margin-top:7px}
+  .composer .name{flex:1;border:1px solid var(--line);border-radius:7px;padding:5px 9px;font-size:11px;color:var(--muted);background:var(--paper)}
+  .toast{position:fixed;bottom:16px;left:50%;transform:translateX(-50%);background:var(--ink);color:var(--paper);font-size:12px;padding:8px 14px;border-radius:9px;opacity:0;transition:.25s;pointer-events:none;z-index:50}
+  .toast.show{opacity:1}
 </style>
 </head>
 <body>
@@ -57,12 +112,138 @@ export function renderShell(
   ${LOGO}
   <span class="t">${title}</span>
   <span class="meta">v${shownVersion} · ${escapeHtml(version?.author ?? "")}${artifact.kind === "bundle" ? " · bundle" : ""}</span>
+  <span class="grow"></span>
   <div class="chips">${chips}</div>
+  ${editable ? `<button class="btn" id="editBtn">Edit</button>` : ""}
   ${isMd ? `<a class="btn" href="${rawSrc.replace(/index\.html$/, "raw.md")}">.md</a>` : ""}
-  <button class="btn" onclick="navigator.clipboard.writeText(location.href).then(()=>{this.textContent='Copied';setTimeout(()=>this.textContent='Copy link',1200)})">Copy link</button>
+  <button class="btn" id="copyBtn">Copy link</button>
+  <button class="btn" id="toggleBtn">Comments</button>
 </header>
 ${shownVersion !== current ? `<div class="old">Viewing v${shownVersion} — <a href="/a/${artifact.short_id}">jump to current (v${current})</a></div>` : ""}
-<iframe src="${rawSrc}" sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads" title="${title}"></iframe>
+<main>
+  <div class="stage">
+    <iframe id="frame" src="${rawSrc}" sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads" title="${title}"></iframe>
+    <div class="editor" id="editor">
+      <div class="bar"><span class="lbl" id="editLbl">editing source</span><span class="grow"></span>
+        <button class="btn" id="cancelEdit">Cancel</button>
+        <button class="btn pri" id="publishEdit">Publish new version</button>
+      </div>
+      <textarea id="src" spellcheck="false" placeholder="loading…"></textarea>
+    </div>
+  </div>
+  <aside id="panel">
+    <div class="ph"><b>Comments</b><span class="cnt" id="openCount">0</span>
+      <span class="pres" id="pres" hidden><i></i><span id="presN">1</span> viewing</span></div>
+    <div class="threads" id="threads"><div class="empty">Loading…</div></div>
+    <div class="composer">
+      <textarea id="newBody" placeholder="Add a comment…"></textarea>
+      <div class="row"><input class="name" id="who" placeholder="Your name"><button class="btn pri" id="addBtn">Comment</button></div>
+    </div>
+  </aside>
+</main>
+<div class="toast" id="toast"></div>
+<script>
+const CFG = ${cfg};
+const base = "/v1/artifacts/" + CFG.shortId;
+const $ = (s) => document.querySelector(s);
+const esc = (s) => (s||"").replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
+let who = localStorage.getItem("dock_name") || "";
+$("#who").value = who;
+$("#who").addEventListener("change", e => { who = e.target.value; localStorage.setItem("dock_name", who); });
+
+function toast(m){ const t=$("#toast"); t.textContent=m; t.classList.add("show"); setTimeout(()=>t.classList.remove("show"),1800); }
+
+$("#copyBtn").onclick = () => navigator.clipboard.writeText(location.href).then(()=>toast("Link copied"));
+$("#toggleBtn").onclick = () => $("#panel").classList.toggle("hidden");
+
+/* ---- comments ---- */
+function anchorLabel(a){ try{ const o=JSON.parse(a); return o.path||o.exact||o.value||a; }catch{ return a; } }
+function group(comments){
+  const map = new Map();
+  for(const c of comments){ if(!map.has(c.thread_id)) map.set(c.thread_id, []); map.get(c.thread_id).push(c); }
+  return [...map.values()];
+}
+async function loadComments(){
+  const r = await fetch(base + "/comments");
+  if(!r.ok){ $("#threads").innerHTML = '<div class="empty">Comments unavailable.</div>'; return; }
+  const { comments } = await r.json();
+  const threads = group(comments);
+  const open = threads.filter(t => t[0].state === "open").length;
+  $("#openCount").textContent = open;
+  if(threads.length === 0){ $("#threads").innerHTML = '<div class="empty">No comments yet.<br>Leave the first one below.</div>'; return; }
+  $("#threads").innerHTML = threads.map(t => {
+    const root = t[0]; const resolved = root.state === "resolved";
+    const cmts = t.map(c => \`<div class="cmt">
+      <div class="who"><span class="av">\${esc((c.author||"?").slice(0,2)).toUpperCase()}</span>\${esc(c.author||"anon")}<span class="vb">base v\${c.base_version}</span></div>
+      \${c.anchor?\`<span class="anc">@ \${esc(anchorLabel(c.anchor))}</span>\`:""}
+      <p>\${esc(c.body_md)}</p></div>\`).join("");
+    return \`<div class="thread \${resolved?"resolved":""}" data-tid="\${root.thread_id}" data-cid="\${root.id}">
+      \${cmts}
+      <div class="tfoot"><span class="st \${resolved?"resolved":"open"}">\${resolved?"resolved":"open"}</span>
+        <button class="resolveBtn">\${resolved?"Reopen":"Resolve"}</button></div>
+      <div class="reply"><input placeholder="Reply…"><button class="btn replyBtn">Reply</button></div>
+    </div>\`;
+  }).join("");
+  $("#threads").querySelectorAll(".thread").forEach(el => {
+    const tid = el.dataset.tid, cid = el.dataset.cid;
+    const resolved = el.classList.contains("resolved");
+    el.querySelector(".resolveBtn").onclick = async () => {
+      await fetch(base + "/comments/" + cid + "/resolve", {method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({state: resolved?"open":"resolved"})});
+      loadComments();
+    };
+    const ri = el.querySelector(".reply input"), rb = el.querySelector(".replyBtn");
+    const send = async () => { const v=ri.value.trim(); if(!v) return; await post({body_md:v, thread_id:tid}); ri.value=""; };
+    rb.onclick = send; ri.addEventListener("keydown", e => { if(e.key==="Enter") send(); });
+  });
+}
+async function post(payload){
+  payload.author = who || "anonymous";
+  payload.base_version = CFG.current;
+  const r = await fetch(base + "/comments", {method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify(payload)});
+  if(r.status === 401){ toast("Sign-in required to comment"); return; }
+  if(!r.ok){ toast("Could not post"); return; }
+  loadComments();
+}
+$("#addBtn").onclick = async () => { const v=$("#newBody").value.trim(); if(!v) return; await post({body_md:v}); $("#newBody").value=""; };
+
+/* ---- inline edit ---- */
+const editor = $("#editor"), frame = $("#frame");
+if($("#editBtn")){
+  $("#editBtn").onclick = async () => {
+    editor.classList.add("on"); frame.style.display="none";
+    $("#editLbl").textContent = "editing " + CFG.filename;
+    const r = await fetch(base + "/content");
+    $("#src").value = r.ok ? await r.text() : "";
+    $("#src").focus();
+  };
+  $("#cancelEdit").onclick = () => { editor.classList.remove("on"); frame.style.display=""; };
+  $("#publishEdit").onclick = async () => {
+    const body = $("#src").value;
+    const fd = new FormData();
+    fd.append("file", new Blob([body]), CFG.filename);
+    fd.append("message", "edited in browser");
+    const r = await fetch(base + "/versions", {method:"POST",body:fd});
+    if(r.status === 401){ toast("Sign-in required to publish"); return; }
+    if(!r.ok){ toast("Publish failed"); return; }
+    const j = await r.json();
+    toast("Published v" + j.current_version);
+    location.href = "/a/" + CFG.shortId;
+  };
+}
+
+/* ---- live updates ---- */
+loadComments();
+try {
+  const ev = new EventSource(base + "/events");
+  ev.addEventListener("comment.created", loadComments);
+  ev.addEventListener("comment.resolved", loadComments);
+  ev.addEventListener("version.published", () => toast("A new version was published"));
+  ev.addEventListener("presence", e => { try{ const d=JSON.parse(e.data); const n=(d.viewers||[]).length; $("#presN").textContent=n; $("#pres").hidden = n<2; }catch{} });
+} catch {}
+const myName = () => who || "anonymous";
+function beat(){ fetch(base + "/presence", {method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({name: myName()})}).catch(()=>{}); }
+beat(); setInterval(beat, 25000);
+</script>
 </body>
 </html>`
 }

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -1,5 +1,5 @@
 import type { D1Database } from "@cloudflare/workers-types"
-import { and, asc, eq } from "drizzle-orm"
+import { and, asc, desc, eq } from "drizzle-orm"
 import { drizzle, type DrizzleD1Database } from "drizzle-orm/d1"
 import type {
   ArtifactRecord,
@@ -8,12 +8,16 @@ import type {
   MetaStore,
   NewArtifact,
   NewComment,
+  NewSession,
+  NewUser,
   NewVersion,
+  SessionRecord,
+  UserRecord,
   VersionRecord,
 } from "@dock/core"
-import { artifact, comment, version } from "./schema"
+import { artifact, comment, session, user, version } from "./schema"
 
-const schema = { artifact, version, comment }
+const schema = { artifact, version, comment, user, session }
 
 /**
  * Cloudflare D1 driver. Same schema as the SQLite driver; apply
@@ -99,5 +103,39 @@ export class D1MetaStore implements MetaStore {
       .where(and(eq(comment.artifact_id, artifactId), eq(comment.thread_id, threadId)))
       .run()
     return res.meta.changes ?? 0
+  }
+
+  async createUser(u: NewUser): Promise<UserRecord> {
+    await this.db.insert(user).values(u).run()
+    return (await this.db.select().from(user).where(eq(user.id, u.id)).get()) as UserRecord
+  }
+  async getUserByEmail(email: string): Promise<UserRecord | null> {
+    return (await this.db.select().from(user).where(eq(user.email, email)).get()) ?? null
+  }
+  async getUserById(id: string): Promise<UserRecord | null> {
+    return (await this.db.select().from(user).where(eq(user.id, id)).get()) ?? null
+  }
+  async countUsers(): Promise<number> {
+    return (await this.db.select().from(user).all()).length
+  }
+
+  async listArtifacts(opts?: { limit?: number }): Promise<ArtifactRecord[]> {
+    const q = this.db.select().from(artifact).orderBy(desc(artifact.created_at))
+    return (opts?.limit ? q.limit(opts.limit) : q).all()
+  }
+
+  async createSession(s: NewSession): Promise<SessionRecord> {
+    await this.db.insert(session).values(s).run()
+    return (await this.db
+      .select()
+      .from(session)
+      .where(eq(session.token, s.token))
+      .get()) as SessionRecord
+  }
+  async getSession(token: string): Promise<SessionRecord | null> {
+    return (await this.db.select().from(session).where(eq(session.token, token)).get()) ?? null
+  }
+  async deleteSession(token: string): Promise<void> {
+    await this.db.delete(session).where(eq(session.token, token)).run()
   }
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -51,6 +51,24 @@ export const comment = sqliteTable("comment", {
   created_at: text("created_at").notNull().default(now),
 })
 
+export const user = sqliteTable("user", {
+  id: text("id").primaryKey(),
+  email: text("email").notNull().unique(),
+  name: text("name"),
+  password_hash: text("password_hash").notNull(),
+  role: text("role").notNull().default("member"),
+  created_at: text("created_at").notNull().default(now),
+})
+
+export const session = sqliteTable("session", {
+  token: text("token").primaryKey(),
+  user_id: text("user_id")
+    .notNull()
+    .references(() => user.id),
+  expires_at: text("expires_at").notNull(),
+  created_at: text("created_at").notNull().default(now),
+})
+
 /**
  * Raw DDL run at boot for the self-host SQLite default (zero-config), and used
  * to seed D1 (deploy/d1-schema.sql). Tables not yet queried (comment, principal,
@@ -104,5 +122,19 @@ export const SCHEMA_STATEMENTS: string[] = [
     visibility TEXT NOT NULL,
     password_hash TEXT,
     org_gate TEXT
+  )`,
+  `CREATE TABLE IF NOT EXISTS user (
+    id TEXT PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    name TEXT,
+    password_hash TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'member',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  )`,
+  `CREATE TABLE IF NOT EXISTS session (
+    token TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES user(id),
+    expires_at TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
   )`,
 ]

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -1,5 +1,5 @@
 import Database from "better-sqlite3"
-import { and, asc, eq } from "drizzle-orm"
+import { and, asc, desc, eq } from "drizzle-orm"
 import { drizzle, type BetterSQLite3Database } from "drizzle-orm/better-sqlite3"
 import type {
   ArtifactRecord,
@@ -8,12 +8,16 @@ import type {
   MetaStore,
   NewArtifact,
   NewComment,
+  NewSession,
+  NewUser,
   NewVersion,
+  SessionRecord,
+  UserRecord,
   VersionRecord,
 } from "@dock/core"
-import { SCHEMA_STATEMENTS, artifact, comment, version } from "./schema"
+import { SCHEMA_STATEMENTS, artifact, comment, session, user, version } from "./schema"
 
-const schema = { artifact, version, comment }
+const schema = { artifact, version, comment, user, session }
 
 /** Embedded SQLite (WAL). The zero-dependency default; no external services. */
 export class SqliteMetaStore implements MetaStore {
@@ -101,6 +105,36 @@ export class SqliteMetaStore implements MetaStore {
       .where(and(eq(comment.artifact_id, artifactId), eq(comment.thread_id, threadId)))
       .run()
     return res.changes
+  }
+
+  async createUser(u: NewUser): Promise<UserRecord> {
+    this.db.insert(user).values(u).run()
+    return this.db.select().from(user).where(eq(user.id, u.id)).get() as UserRecord
+  }
+  async getUserByEmail(email: string): Promise<UserRecord | null> {
+    return this.db.select().from(user).where(eq(user.email, email)).get() ?? null
+  }
+  async getUserById(id: string): Promise<UserRecord | null> {
+    return this.db.select().from(user).where(eq(user.id, id)).get() ?? null
+  }
+  async countUsers(): Promise<number> {
+    return this.db.select().from(user).all().length
+  }
+
+  async listArtifacts(opts?: { limit?: number }): Promise<ArtifactRecord[]> {
+    const q = this.db.select().from(artifact).orderBy(desc(artifact.created_at))
+    return opts?.limit ? q.limit(opts.limit).all() : q.all()
+  }
+
+  async createSession(s: NewSession): Promise<SessionRecord> {
+    this.db.insert(session).values(s).run()
+    return this.db.select().from(session).where(eq(session.token, s.token)).get() as SessionRecord
+  }
+  async getSession(token: string): Promise<SessionRecord | null> {
+    return this.db.select().from(session).where(eq(session.token, token)).get() ?? null
+  }
+  async deleteSession(token: string): Promise<void> {
+    this.db.delete(session).where(eq(session.token, token)).run()
   }
 
   close(): void {


### PR DESCRIPTION
## Summary

Turns Dock into a usable app: a real browser experience for the whole loop — log in, see your library, publish, and run the publish → comment → revise cycle in the browser, including **inline editing** of Markdown/HTML artifacts. This is the v1 you can actually sit down and use.

## What's included

**Viewer (the loop, in the browser)**
- Live **comment panel**: threads, add/reply, resolve/reopen, presence — all live over SSE.
- **Inline editing** for file artifacts: load the source, edit, publish a new version.

**Accounts & app**
- `user` + `session` tables (Drizzle + both drivers); **email + password** auth (scrypt) with httpOnly `SameSite` session cookies.
- `/login`, `/signup`, `/auth/*`, and a **`/app` library home** with in-browser publishing.
- Writes and gated reads are authorized by a **login session or `DOCK_TOKEN`**; comments are authored as the signed-in user.

## Validated in a real browser

Sign up (first user = admin) → land in `/app` → publish → open the viewer → comment (authored as the logged-in user) → inline-edit the source → publish v2 → resolve/reply/presence update live. Screenshots in the PR thread.

## Tests

35 passing (`pnpm test`), typecheck clean.

## Next

- **Better Auth** for OAuth/SSO/orgs (this is the zero-dependency base it slots onto).
- Comment re-anchoring across republishes; Postgres driver for the hosted tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
