### PR TITLE
web: the real app (TanStack Router SPA + Dock design system)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -129,21 +129,35 @@ export function createApp(deps: AppDeps): Hono {
 
   // ---- Auth + app shell -------------------------------------------------
 
+  const wantsJson = (c: Context): boolean =>
+    (c.req.header("accept") ?? "").includes("application/json") ||
+    (c.req.header("content-type") ?? "").includes("application/json")
+  const readFields = async (c: Context): Promise<Record<string, unknown>> =>
+    (c.req.header("content-type") ?? "").includes("application/json")
+      ? ((await c.req.json().catch(() => ({}))) as Record<string, unknown>)
+      : ((await c.req.parseBody()) as Record<string, unknown>)
+  const publicUser = (u: UserRecord) => ({ id: u.id, email: u.email, name: u.name, role: u.role })
+
   app.get("/login", async (c) => {
     if (await currentUser(c)) return c.redirect("/app")
     return c.html(renderLogin({ firstUser: (await meta.countUsers()) === 0 }))
   })
-
   app.get("/signup", (c) => c.html(renderSignup()))
 
+  app.get("/v1/me", async (c) => {
+    const u = await currentUser(c)
+    return u ? c.json({ user: publicUser(u) }) : c.json({ error: "unauthenticated" }, 401)
+  })
+
   app.post("/auth/signup", async (c) => {
-    const body = await c.req.parseBody()
+    const body = await readFields(c)
     const email = String(body.email ?? "").trim().toLowerCase()
     const password = String(body.password ?? "")
+    const fail = (msg: string) =>
+      wantsJson(c) ? c.json({ error: msg }, 400) : c.html(renderSignup(msg), 400)
     if (!email || password.length < 8)
-      return c.html(renderSignup("Enter an email and a password of at least 8 characters."), 400)
-    if (await meta.getUserByEmail(email))
-      return c.html(renderSignup("That email is already registered."), 400)
+      return fail("Enter an email and a password of at least 8 characters.")
+    if (await meta.getUserByEmail(email)) return fail("That email is already registered.")
     const first = (await meta.countUsers()) === 0
     const u = await meta.createUser({
       id: newId("u"),
@@ -153,27 +167,35 @@ export function createApp(deps: AppDeps): Hono {
       role: first ? "admin" : "member",
     })
     await startSession(c, u.id)
-    return c.redirect("/app")
+    return wantsJson(c) ? c.json({ user: publicUser(u) }) : c.redirect("/app")
   })
 
   app.post("/auth/login", async (c) => {
-    const body = await c.req.parseBody()
+    const body = await readFields(c)
     const email = String(body.email ?? "").trim().toLowerCase()
     const u = await meta.getUserByEmail(email)
-    if (!u || !verifyPassword(String(body.password ?? ""), u.password_hash))
-      return c.html(
-        renderLogin({ error: "Wrong email or password.", firstUser: (await meta.countUsers()) === 0 }),
-        401,
-      )
+    if (!u || !verifyPassword(String(body.password ?? ""), u.password_hash)) {
+      const msg = "Wrong email or password."
+      return wantsJson(c)
+        ? c.json({ error: msg }, 401)
+        : c.html(renderLogin({ error: msg, firstUser: (await meta.countUsers()) === 0 }), 401)
+    }
     await startSession(c, u.id)
-    return c.redirect("/app")
+    return wantsJson(c) ? c.json({ user: publicUser(u) }) : c.redirect("/app")
   })
 
   app.post("/auth/logout", async (c) => {
     const tok = getCookie(c, SESSION_COOKIE)
     if (tok) await meta.deleteSession(tok)
     deleteCookie(c, SESSION_COOKIE, { path: "/" })
-    return c.redirect("/login")
+    return wantsJson(c) ? c.json({ ok: true }) : c.redirect("/login")
+  })
+
+  app.get("/v1/artifacts", async (c) => {
+    if (!(await currentUser(c)) && deps.token && bearer(c) !== deps.token)
+      return c.json({ error: "unauthenticated" }, 401)
+    const artifacts = await meta.listArtifacts({ limit: 200 })
+    return c.json({ artifacts: artifacts.map((a) => toJson(deps.baseUrl, a, [])) })
   })
 
   app.get("/app", async (c) => {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en" data-theme="paper">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
+<title>Dock</title>
+</head>
+<body>
+<div id="root"></div>
+<script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@dock/web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@tanstack/react-router": "^1.95.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "typescript": "^5.6.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,0 +1,67 @@
+export interface Me {
+  id: string
+  email: string
+  name: string | null
+  role: string
+}
+export interface Artifact {
+  short_id: string
+  url: string
+  title: string | null
+  kind: "file" | "bundle"
+  visibility: string
+  current_version: number
+  versions: { n: number; author: string; message: string | null; created_at: string }[]
+}
+export interface Comment {
+  id: string
+  thread_id: string
+  base_version: number
+  path: string | null
+  anchor: string | null
+  body_md: string
+  author: string
+  state: "open" | "resolved"
+  created_at: string
+}
+
+const j = async (r: Response) => {
+  if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error ?? `HTTP ${r.status}`)
+  return r.json()
+}
+const opts = (body?: unknown): RequestInit => ({
+  credentials: "include",
+  headers: { accept: "application/json", ...(body ? { "content-type": "application/json" } : {}) },
+  ...(body ? { method: "POST", body: JSON.stringify(body) } : {}),
+})
+
+export const api = {
+  me: (): Promise<{ user: Me }> => fetch("/v1/me", opts()).then(j),
+  login: (email: string, password: string): Promise<{ user: Me }> =>
+    fetch("/auth/login", opts({ email, password })).then(j),
+  signup: (email: string, password: string, name: string): Promise<{ user: Me }> =>
+    fetch("/auth/signup", opts({ email, password, name })).then(j),
+  logout: () => fetch("/auth/logout", opts({})).then(j),
+
+  listArtifacts: (): Promise<{ artifacts: Artifact[] }> => fetch("/v1/artifacts", opts()).then(j),
+  getArtifact: (id: string): Promise<Artifact> => fetch(`/v1/artifacts/${id}`, opts()).then(j),
+  getContent: (id: string, v?: number): Promise<string> =>
+    fetch(`/v1/artifacts/${id}/content${v ? `?v=${v}` : ""}`, { credentials: "include" }).then((r) => r.text()),
+  listComments: (id: string): Promise<{ comments: Comment[] }> =>
+    fetch(`/v1/artifacts/${id}/comments`, opts()).then(j),
+  comment: (id: string, body: { body_md: string; thread_id?: string; anchor?: unknown }): Promise<Comment> =>
+    fetch(`/v1/artifacts/${id}/comments`, opts(body)).then(j),
+  resolve: (id: string, commentId: string, state: "open" | "resolved") =>
+    fetch(`/v1/artifacts/${id}/comments/${commentId}/resolve`, opts({ state })).then(j),
+
+  async publish(file: File, fields: Record<string, string> = {}, id?: string): Promise<Artifact> {
+    const fd = new FormData()
+    fd.append("file", file)
+    for (const [k, v] of Object.entries(fields)) fd.append(k, v)
+    const url = id ? `/v1/artifacts/${id}/versions` : "/v1/artifacts"
+    return fetch(url, { method: "POST", body: fd, credentials: "include", headers: { accept: "application/json" } }).then(j)
+  },
+  publishText(id: string, text: string, filename: string, message: string): Promise<Artifact> {
+    return this.publish(new File([text], filename), { message }, id)
+  },
+}

--- a/apps/web/src/components.tsx
+++ b/apps/web/src/components.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useRef, useState } from "react"
+import { Link, useNavigate } from "@tanstack/react-router"
+import { api } from "./api"
+import { THEMES, useAuth, useTheme } from "./ctx"
+
+export const Logo = ({ size = 24 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 32 32" fill="none" aria-hidden>
+    <rect x="1" y="1" width="30" height="30" rx="8" fill="#2a2540" />
+    <path d="M16 7l7 7v11h-4.6v-6.2h-4.8V25H9V14l7-7z" fill="none" stroke="#8a7dc0" strokeWidth="1.7" strokeLinejoin="round" />
+    <rect x="13.6" y="6.4" width="4.8" height="4.8" rx="1.2" fill="#655999" />
+  </svg>
+)
+
+export function Header({ right }: { right?: React.ReactNode }) {
+  return (
+    <header
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 11,
+        padding: "12px 22px",
+        background: "var(--card)",
+        borderBottom: "1px solid var(--line)",
+      }}
+    >
+      <Link to="/" style={{ display: "flex", alignItems: "center", gap: 10, color: "var(--fg)" }}>
+        <Logo />
+        <span className="display" style={{ fontWeight: 600, fontSize: 18 }}>
+          Dock
+        </span>
+      </Link>
+      <span style={{ flex: 1 }} />
+      {right}
+      <UserMenu />
+    </header>
+  )
+}
+
+export function UserMenu() {
+  const { me, setMe } = useAuth()
+  const { theme, setTheme } = useTheme()
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const nav = useNavigate()
+  useEffect(() => {
+    const h = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener("click", h)
+    return () => document.removeEventListener("click", h)
+  }, [])
+  if (!me) return null
+  const initials = (me.name ?? me.email).slice(0, 2).toUpperCase()
+  return (
+    <div ref={ref} style={{ position: "relative" }}>
+      <button
+        className="btn sm"
+        onClick={(e) => {
+          e.stopPropagation()
+          setOpen((o) => !o)
+        }}
+        style={{ gap: 8 }}
+      >
+        <span
+          style={{
+            width: 20,
+            height: 20,
+            borderRadius: "50%",
+            background: "var(--ac)",
+            color: "var(--ac-fg)",
+            display: "grid",
+            placeItems: "center",
+            fontSize: 10,
+            fontWeight: 700,
+          }}
+        >
+          {initials}
+        </span>
+        {me.name ?? me.email} ⌄
+      </button>
+      {open && (
+        <div
+          className="card"
+          style={{ position: "absolute", right: 0, top: "calc(100% + 7px)", width: 200, padding: 6, boxShadow: "var(--shadow)", zIndex: 30 }}
+        >
+          <div className="mono" style={{ fontSize: 9.5, letterSpacing: ".06em", textTransform: "uppercase", color: "var(--fg-mut)", padding: "6px 8px 4px" }}>
+            Theme
+          </div>
+          {THEMES.map((t) => (
+            <button
+              key={t.id}
+              onClick={() => setTheme(t.id)}
+              style={menuRow}
+            >
+              <span style={{ width: 13, height: 13, borderRadius: "50%", background: t.sw, border: "1px solid rgba(0,0,0,.12)" }} />
+              {t.label}
+              <span style={{ marginLeft: "auto", color: "var(--ac)", fontWeight: 700 }}>{theme === t.id ? "✓" : ""}</span>
+            </button>
+          ))}
+          <div style={{ height: 1, background: "var(--line-soft)", margin: "5px 2px" }} />
+          <button
+            onClick={async () => {
+              await api.logout().catch(() => {})
+              setMe(null)
+              nav({ to: "/login" })
+            }}
+            style={{ ...menuRow, color: "var(--fg-mut)" }}
+          >
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const menuRow: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 9,
+  width: "100%",
+  border: 0,
+  background: "transparent",
+  color: "var(--fg)",
+  font: "500 12.5px Inter,sans-serif",
+  padding: "7px 8px",
+  borderRadius: 7,
+  cursor: "pointer",
+  textAlign: "left",
+}
+
+export function useToast() {
+  const [msg, setMsg] = useState("")
+  const el = (
+    <div className={`toast${msg ? " show" : ""}`}>{msg}</div>
+  )
+  const show = (m: string) => {
+    setMsg(m)
+    setTimeout(() => setMsg(""), 1900)
+  }
+  return { toast: el, show }
+}

--- a/apps/web/src/ctx.tsx
+++ b/apps/web/src/ctx.tsx
@@ -1,0 +1,47 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react"
+import { api, type Me } from "./api"
+
+/* ---- auth ---- */
+interface AuthState {
+  me: Me | null
+  loading: boolean
+  setMe: (m: Me | null) => void
+}
+const AuthCtx = createContext<AuthState>({ me: null, loading: true, setMe: () => {} })
+export const useAuth = () => useContext(AuthCtx)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [me, setMe] = useState<Me | null>(null)
+  const [loading, setLoading] = useState(true)
+  useEffect(() => {
+    api
+      .me()
+      .then((r) => setMe(r.user))
+      .catch(() => setMe(null))
+      .finally(() => setLoading(false))
+  }, [])
+  return <AuthCtx.Provider value={{ me, loading, setMe }}>{children}</AuthCtx.Provider>
+}
+
+/* ---- theme ---- */
+export const THEMES = [
+  { id: "paper", label: "Paper", sw: "#f6f0e3" },
+  { id: "light", label: "Light", sw: "#ffffff" },
+  { id: "dark", label: "Dark", sw: "#0f0f10" },
+  { id: "dusk", label: "Dusk", sw: "#241e3a" },
+] as const
+
+const ThemeCtx = createContext<{ theme: string; setTheme: (t: string) => void }>({
+  theme: "paper",
+  setTheme: () => {},
+})
+export const useTheme = () => useContext(ThemeCtx)
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState(() => localStorage.getItem("dock_theme") ?? "paper")
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme
+    localStorage.setItem("dock_theme", theme)
+  }, [theme])
+  return <ThemeCtx.Provider value={{ theme, setTheme }}>{children}</ThemeCtx.Provider>
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,39 @@
+import { StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+import {
+  Outlet,
+  RouterProvider,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router"
+import { AuthProvider, ThemeProvider } from "./ctx"
+import { Login } from "./pages/Login"
+import { Library } from "./pages/Library"
+import { Artifact } from "./pages/Artifact"
+import "./styles.css"
+
+const rootRoute = createRootRoute({ component: () => <Outlet /> })
+const indexRoute = createRoute({ getParentRoute: () => rootRoute, path: "/", component: Library })
+const loginRoute = createRoute({ getParentRoute: () => rootRoute, path: "/login", component: Login })
+const artifactRoute = createRoute({ getParentRoute: () => rootRoute, path: "/a/$ref", component: Artifact })
+
+const router = createRouter({
+  routeTree: rootRoute.addChildren([indexRoute, loginRoute, artifactRoute]),
+})
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router
+  }
+}
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <ThemeProvider>
+      <AuthProvider>
+        <RouterProvider router={router} />
+      </AuthProvider>
+    </ThemeProvider>
+  </StrictMode>,
+)

--- a/apps/web/src/pages/Artifact.tsx
+++ b/apps/web/src/pages/Artifact.tsx
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useState } from "react"
+import { useNavigate, useParams } from "@tanstack/react-router"
+import { api, type Artifact as Art, type Comment } from "../api"
+import { Header, useToast } from "../components"
+import { useAuth } from "../ctx"
+
+const parseRef = (ref: string) => {
+  const m = ref.match(/^([0-9a-z]{6,12})(?:-[a-z0-9-]*?)?(?:@v(\d+))?$/)
+  return { shortId: m?.[1] ?? ref, version: m?.[2] ? Number(m[2]) : undefined }
+}
+
+export function Artifact() {
+  const { ref } = useParams({ from: "/a/$ref" })
+  const { shortId, version } = parseRef(ref)
+  const { me, loading } = useAuth()
+  const nav = useNavigate()
+  const { toast, show } = useToast()
+
+  const [art, setArt] = useState<Art | null>(null)
+  const [failed, setFailed] = useState(false)
+  const [comments, setComments] = useState<Comment[]>([])
+  const [editing, setEditing] = useState(false)
+  const [src, setSrc] = useState("")
+  const [body, setBody] = useState("")
+
+  useEffect(() => {
+    if (!loading && !me) nav({ to: "/login" })
+  }, [loading, me, nav])
+
+  const load = useCallback(() => {
+    api.getArtifact(shortId).then((a) => { setArt(a); setFailed(false) }).catch(() => setFailed(true))
+    api.listComments(shortId).then((r) => setComments(r.comments)).catch(() => {})
+  }, [shortId])
+  useEffect(load, [load])
+
+  // live updates
+  useEffect(() => {
+    const ev = new EventSource(`/v1/artifacts/${shortId}/events`)
+    const refresh = () => api.listComments(shortId).then((r) => setComments(r.comments)).catch(() => {})
+    ev.addEventListener("comment.created", refresh)
+    ev.addEventListener("comment.resolved", refresh)
+    ev.addEventListener("version.published", load)
+    return () => ev.close()
+  }, [shortId, load])
+
+  if (failed)
+    return (
+      <div style={{ minHeight: "100%" }}>
+        <Header />
+        <div className="center" style={{ height: "60vh", flexDirection: "column", gap: 10 }}>
+          <div className="muted">Artifact not found, or you don't have access.</div>
+          <button className="btn" onClick={() => nav({ to: "/" })}>Back to library</button>
+        </div>
+      </div>
+    )
+  if (!art) return <div style={{ minHeight: "100%" }}><Header /><div className="center" style={{ height: "60vh" }}><div className="spin" /></div></div>
+
+  const shown = version ?? art.current_version
+  const editable = art.kind === "file" && shown === art.current_version
+  const rawSrc = `/raw/${shortId}/v/${shown}/index.html`
+  const threads = groupThreads(comments)
+  const openCount = threads.filter((t) => t[0].state === "open").length
+
+  const startEdit = async () => {
+    setEditing(true)
+    setSrc(await api.getContent(shortId))
+  }
+  const publishEdit = async () => {
+    try {
+      const a = await api.publishText(shortId, src, art.title ? `${art.short_id}.md` : "edit.md", "edited in browser")
+      show(`Published v${a.current_version}`)
+      setEditing(false)
+      load()
+    } catch (e) {
+      show((e as Error).message)
+    }
+  }
+  const addComment = async (text: string, threadId?: string) => {
+    if (!text.trim()) return
+    await api.comment(shortId, { body_md: text, thread_id: threadId }).catch((e) => show((e as Error).message))
+    if (!threadId) setBody("")
+    api.listComments(shortId).then((r) => setComments(r.comments))
+  }
+  const toggleResolve = async (root: Comment) => {
+    await api.resolve(shortId, root.id, root.state === "open" ? "resolved" : "open")
+    api.listComments(shortId).then((r) => setComments(r.comments))
+  }
+
+  return (
+    <div style={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      <Header
+        right={
+          <>
+            <div style={{ display: "flex", gap: 5 }}>
+              {art.versions.map((v) => (
+                <button
+                  key={v.n}
+                  className={`chip${v.n === shown ? " on" : ""}`}
+                  onClick={() => nav({ to: "/a/$ref", params: { ref: `${shortId}@v${v.n}` } })}
+                  title={v.message ?? ""}
+                >
+                  v{v.n}
+                </button>
+              ))}
+            </div>
+            {editable && !editing && <button className="btn sm" onClick={startEdit}>Edit</button>}
+          </>
+        }
+      />
+      <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+        <div style={{ flex: 1, display: "flex", minWidth: 0 }}>
+          {editing ? (
+            <div style={{ flex: 1, display: "flex", flexDirection: "column", background: "var(--card)" }}>
+              <div style={{ display: "flex", gap: 8, padding: "8px 12px", borderBottom: "1px solid var(--line-soft)", alignItems: "center" }}>
+                <span className="mono muted" style={{ fontSize: 11 }}>editing source</span>
+                <span style={{ flex: 1 }} />
+                <button className="btn sm" onClick={() => setEditing(false)}>Cancel</button>
+                <button className="btn pri sm" onClick={publishEdit}>Publish new version</button>
+              </div>
+              <textarea
+                className="mono"
+                value={src}
+                onChange={(e) => setSrc(e.target.value)}
+                spellCheck={false}
+                style={{ flex: 1, border: 0, resize: "none", padding: "16px 20px", fontSize: 13, lineHeight: 1.6, color: "var(--fg)", background: "var(--card)", outline: "none" }}
+              />
+            </div>
+          ) : (
+            <iframe
+              title={art.title ?? shortId}
+              src={rawSrc}
+              sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
+              style={{ flex: 1, border: 0, background: "#fff" }}
+            />
+          )}
+        </div>
+
+        <aside style={{ width: 320, flex: "0 0 320px", borderLeft: "1px solid var(--line)", background: "var(--card)", display: "flex", flexDirection: "column", minHeight: 0 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "11px 14px", borderBottom: "1px solid var(--line-soft)" }}>
+            <b style={{ fontSize: 13 }}>Comments</b>
+            <span className="mono" style={{ fontSize: 10, color: "var(--cmt-tx)", background: "var(--cmt-bg)", borderRadius: 999, padding: "1px 8px", fontWeight: 700 }}>{openCount}</span>
+          </div>
+          <div style={{ flex: 1, overflow: "auto", padding: 12 }}>
+            {threads.length === 0 ? (
+              <div className="muted" style={{ textAlign: "center", fontSize: 12, padding: "26px 12px" }}>No comments yet.</div>
+            ) : (
+              threads.map((t) => <Thread key={t[0].thread_id} thread={t} onReply={addComment} onResolve={toggleResolve} />)
+            )}
+          </div>
+          <div style={{ borderTop: "1px solid var(--line-soft)", padding: 11 }}>
+            <textarea className="input" value={body} onChange={(e) => setBody(e.target.value)} placeholder="Add a comment…" style={{ minHeight: 50, resize: "vertical" }} />
+            <button className="btn pri sm" onClick={() => addComment(body)} style={{ marginTop: 7, width: "100%", justifyContent: "center" }}>Comment</button>
+          </div>
+        </aside>
+      </div>
+      {toast}
+    </div>
+  )
+}
+
+function Thread({ thread, onReply, onResolve }: { thread: Comment[]; onReply: (t: string, tid: string) => void; onResolve: (c: Comment) => void }) {
+  const [reply, setReply] = useState("")
+  const root = thread[0]
+  const resolved = root.state === "resolved"
+  return (
+    <div className="card" style={{ marginBottom: 11, overflow: "hidden", opacity: resolved ? 0.62 : 1 }}>
+      {thread.map((c) => (
+        <div key={c.id} style={{ padding: "10px 12px", borderBottom: "1px solid var(--line-soft)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 7, fontSize: 11, fontWeight: 700, color: "var(--cmt-tx)", marginBottom: 4 }}>
+            <span style={{ width: 17, height: 17, borderRadius: "50%", background: "var(--cmt-bg)", display: "grid", placeItems: "center", fontSize: 9 }}>
+              {(c.author || "?").slice(0, 2).toUpperCase()}
+            </span>
+            {c.author}
+            <span className="mono muted" style={{ marginLeft: "auto", fontWeight: 400, fontSize: 9 }}>base v{c.base_version}</span>
+          </div>
+          <p style={{ margin: 0, fontSize: 12.5, lineHeight: 1.45, whiteSpace: "pre-wrap" }}>{c.body_md}</p>
+        </div>
+      ))}
+      <div style={{ display: "flex", alignItems: "center", gap: 7, padding: "7px 12px", background: "var(--card-2)" }}>
+        <span className="mono" style={{ fontSize: 9.5, fontWeight: 700, padding: "2px 8px", borderRadius: 999, background: resolved ? "var(--good-bg)" : "var(--ac-soft)", color: resolved ? "var(--good)" : "var(--ac)" }}>
+          {resolved ? "resolved" : "open"}
+        </span>
+        <button className="btn sm" style={{ marginLeft: "auto" }} onClick={() => onResolve(root)}>
+          {resolved ? "Reopen" : "Resolve"}
+        </button>
+      </div>
+      <div style={{ display: "flex", gap: 6, padding: "8px 12px", borderTop: "1px solid var(--line-soft)" }}>
+        <input className="input" style={{ padding: "6px 9px", fontSize: 12 }} value={reply} placeholder="Reply…"
+          onChange={(e) => setReply(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") { onReply(reply, root.thread_id); setReply("") } }} />
+        <button className="btn sm" onClick={() => { onReply(reply, root.thread_id); setReply("") }}>Reply</button>
+      </div>
+    </div>
+  )
+}
+
+function groupThreads(comments: Comment[]): Comment[][] {
+  const map = new Map<string, Comment[]>()
+  for (const c of comments) {
+    if (!map.has(c.thread_id)) map.set(c.thread_id, [])
+    map.get(c.thread_id)!.push(c)
+  }
+  return [...map.values()]
+}

--- a/apps/web/src/pages/Library.tsx
+++ b/apps/web/src/pages/Library.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from "react"
+import { useNavigate } from "@tanstack/react-router"
+import { api, type Artifact } from "../api"
+import { Header, useToast } from "../components"
+import { useAuth } from "../ctx"
+
+export function Library() {
+  const { me, loading } = useAuth()
+  const nav = useNavigate()
+  const [items, setItems] = useState<Artifact[] | null>(null)
+  const [busy, setBusy] = useState(false)
+  const file = useRef<HTMLInputElement>(null)
+  const { toast, show } = useToast()
+
+  useEffect(() => {
+    if (!loading && !me) nav({ to: "/login" })
+  }, [loading, me, nav])
+  useEffect(() => {
+    if (me) api.listArtifacts().then((r) => setItems(r.artifacts)).catch(() => setItems([]))
+  }, [me])
+
+  const publish = async () => {
+    const f = file.current?.files?.[0]
+    if (!f) {
+      file.current?.click()
+      return
+    }
+    setBusy(true)
+    try {
+      const a = await api.publish(f, { title: f.name.replace(/\.[^.]+$/, "") })
+      nav({ to: "/a/$ref", params: { ref: a.short_id } })
+    } catch (e) {
+      show((e as Error).message)
+      setBusy(false)
+    }
+  }
+
+  if (!me) return <div className="center"><div className="spin" /></div>
+
+  return (
+    <div style={{ minHeight: "100%" }}>
+      <Header />
+      <main style={{ maxWidth: 1000, margin: "0 auto", padding: "26px 22px 60px" }}>
+        <div className="card" style={{ padding: 18, marginBottom: 24, display: "flex", alignItems: "center", gap: 14, flexWrap: "wrap" }}>
+          <div style={{ flex: 1, minWidth: 220 }}>
+            <div className="display" style={{ fontWeight: 600, fontSize: 16 }}>
+              Publish an artifact
+            </div>
+            <div className="muted" style={{ fontSize: 13 }}>
+              Drop an HTML or Markdown file, or run <code className="mono">dock publish</code>.
+            </div>
+          </div>
+          <input ref={file} type="file" accept=".html,.htm,.md,.markdown,.zip" style={{ maxWidth: 240, fontSize: 12 }} onChange={publish} />
+          <button className="btn pri" onClick={publish} disabled={busy}>
+            {busy ? "Publishing…" : "Publish"}
+          </button>
+        </div>
+
+        <h2 className="display" style={{ fontSize: 18, margin: "0 0 14px" }}>
+          Library <span className="muted" style={{ fontWeight: 400, fontSize: 14 }}>· {items?.length ?? 0}</span>
+        </h2>
+        {items === null ? (
+          <div className="center" style={{ height: 160 }}><div className="spin" /></div>
+        ) : items.length === 0 ? (
+          <div className="muted" style={{ textAlign: "center", padding: 40, border: "1px dashed var(--line)", borderRadius: 14 }}>
+            Nothing yet. Publish above, or run <code className="mono">dock publish ./file</code>.
+          </div>
+        ) : (
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill,minmax(220px,1fr))", gap: 13 }}>
+            {items.map((a) => (
+              <button
+                key={a.short_id}
+                onClick={() => nav({ to: "/a/$ref", params: { ref: a.short_id } })}
+                className="card"
+                style={{ textAlign: "left", padding: 15, cursor: "pointer", display: "flex", flexDirection: "column", gap: 8 }}
+              >
+                <div style={{ height: 64, borderRadius: 8, background: "linear-gradient(135deg,var(--ac-soft),var(--card-2))", border: "1px solid var(--line-soft)" }} />
+                <div className="display" style={{ fontWeight: 600, fontSize: 15 }}>
+                  {a.title ?? a.short_id}
+                </div>
+                <div className="mono muted" style={{ fontSize: 11, display: "flex", gap: 8 }}>
+                  <span style={{ background: "var(--card-2)", border: "1px solid var(--line-soft)", borderRadius: 5, padding: "1px 6px" }}>{a.kind}</span>
+                  <span>v{a.current_version}</span>
+                  <span>{a.visibility}</span>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </main>
+      {toast}
+    </div>
+  )
+}

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from "react"
+import { useNavigate } from "@tanstack/react-router"
+import { api } from "../api"
+import { Logo } from "../components"
+import { useAuth } from "../ctx"
+
+export function Login() {
+  const { me, loading, setMe } = useAuth()
+  const nav = useNavigate()
+  const [mode, setMode] = useState<"login" | "signup">("login")
+  const [name, setName] = useState("")
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [err, setErr] = useState("")
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    if (!loading && me) nav({ to: "/" })
+  }, [loading, me, nav])
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setErr("")
+    setBusy(true)
+    try {
+      const r = mode === "signup" ? await api.signup(email, password, name) : await api.login(email, password)
+      setMe(r.user)
+      nav({ to: "/" })
+    } catch (e) {
+      setErr((e as Error).message)
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="center">
+      <div style={{ width: 360, maxWidth: "90vw" }}>
+        <div style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: 10, marginBottom: 6 }}>
+          <Logo size={30} />
+          <span className="display" style={{ fontWeight: 600, fontSize: 22 }}>
+            Dock
+          </span>
+        </div>
+        <p className="muted" style={{ textAlign: "center", margin: "0 0 24px" }}>
+          {mode === "signup" ? "Create your account." : "Sign in to your workspace."}
+        </p>
+        <form className="card" style={{ padding: 22, boxShadow: "var(--shadow)" }} onSubmit={submit}>
+          {err && (
+            <div style={{ background: "var(--cmt-bg)", color: "var(--bad)", borderRadius: 8, padding: "8px 12px", fontSize: 13, marginBottom: 12 }}>
+              {err}
+            </div>
+          )}
+          {mode === "signup" && (
+            <label style={lbl}>
+              Name
+              <input className="input" value={name} onChange={(e) => setName(e.target.value)} placeholder="Your name" />
+            </label>
+          )}
+          <label style={lbl}>
+            Email
+            <input className="input" type="email" required value={email} onChange={(e) => setEmail(e.target.value)} placeholder="you@company.com" />
+          </label>
+          <label style={{ ...lbl, marginBottom: 16 }}>
+            Password
+            <input className="input" type="password" required minLength={8} value={password} onChange={(e) => setPassword(e.target.value)} placeholder="At least 8 characters" />
+          </label>
+          <button className="btn pri" type="submit" disabled={busy} style={{ width: "100%", justifyContent: "center" }}>
+            {busy ? "…" : mode === "signup" ? "Create account" : "Sign in"}
+          </button>
+        </form>
+        <p className="muted" style={{ textAlign: "center", fontSize: 13, marginTop: 14 }}>
+          {mode === "login" ? (
+            <>
+              New here?{" "}
+              <a style={{ cursor: "pointer" }} onClick={() => setMode("signup")}>
+                Create an account
+              </a>
+            </>
+          ) : (
+            <>
+              Have an account?{" "}
+              <a style={{ cursor: "pointer" }} onClick={() => setMode("login")}>
+                Sign in
+              </a>
+            </>
+          )}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+const lbl: React.CSSProperties = { display: "block", fontSize: 12.5, fontWeight: 600, color: "var(--fg-mut)", marginBottom: 12 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,0 +1,54 @@
+/* Dock design system — token-driven, 4 themes, set via [data-theme] on <html>. */
+[data-theme="paper"]{
+  --bg:#f6f0e3;--card:#fdf8ec;--card-2:#efe8d8;--hover:#f1ead9;
+  --fg:#2a2540;--fg-mut:#5e5878;--line:#ddd6c6;--line-soft:#e7e0d2;
+  --ac:#655999;--ac-fg:#fff;--ac-soft:#e9e6f2;
+  --cmt-bg:#ebe7f5;--cmt-tx:#564f82;--cmt-bd:#cbc5e5;--good:#3c6e2f;--good-bg:#e3eedb;--bad:#a04425;
+  --shadow:0 1px 2px rgba(42,37,64,.05),0 14px 30px -18px rgba(42,37,64,.3);--grain:.045}
+[data-theme="light"]{
+  --bg:#ffffff;--card:#fcfcfd;--card-2:#f3f3f5;--hover:#f5f5f7;
+  --fg:#18181b;--fg-mut:#5d5d65;--line:#e6e6ea;--line-soft:#efeff2;
+  --ac:#655999;--ac-fg:#fff;--ac-soft:#ecebf6;
+  --cmt-bg:#efeefa;--cmt-tx:#564f82;--cmt-bd:#dad6ef;--good:#3c6e2f;--good-bg:#eef1e0;--bad:#a04425;
+  --shadow:0 1px 2px rgba(20,20,30,.05),0 14px 30px -18px rgba(20,20,30,.18);--grain:.03}
+[data-theme="dark"]{
+  --bg:#0f0f10;--card:#1a1a1d;--card-2:#232327;--hover:#212125;
+  --fg:#ededee;--fg-mut:#9a9aa1;--line:#2e2e33;--line-soft:#262629;
+  --ac:#a99fe0;--ac-fg:#15131f;--ac-soft:#28243c;
+  --cmt-bg:#221f33;--cmt-tx:#b6ace8;--cmt-bd:#3a3556;--good:#9fb05a;--good-bg:#1f2417;--bad:#e08a6e;
+  --shadow:0 1px 2px rgba(0,0,0,.4),0 18px 36px -18px rgba(0,0,0,.7);--grain:.05}
+[data-theme="dusk"]{
+  --bg:#15101f;--card:#241e3a;--card-2:#2b2542;--hover:#2a2342;
+  --fg:#f6e9d6;--fg-mut:#b1a48d;--line:#3a3357;--line-soft:#322b4c;
+  --ac:#b9aef0;--ac-fg:#1a1430;--ac-soft:#2d2649;
+  --cmt-bg:#271f3f;--cmt-tx:#c5bbf2;--cmt-bd:#463d6a;--good:#aebb6a;--good-bg:#23271a;--bad:#e7806a;
+  --shadow:0 1px 2px rgba(0,0,0,.4),0 18px 36px -18px rgba(0,0,0,.6);--grain:.05}
+
+*{box-sizing:border-box}
+html,body,#root{height:100%}
+body{margin:0;background:var(--bg);color:var(--fg);
+  font:14px/1.55 Inter,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.04'/%3E%3C/svg%3E")}
+a{color:var(--ac);text-decoration:none}
+.display{font-family:"Space Grotesk",Inter,sans-serif;letter-spacing:-.02em}
+.mono{font-family:ui-monospace,Menlo,Consolas,monospace}
+.muted{color:var(--fg-mut)}
+.btn{display:inline-flex;align-items:center;gap:7px;font-weight:600;font-size:13px;padding:8px 14px;border-radius:10px;
+  border:1px solid var(--line);background:var(--card);color:var(--fg);cursor:pointer;text-decoration:none;white-space:nowrap;transition:.15s}
+.btn:hover{border-color:var(--ac);color:var(--ac)}
+.btn.pri{background:var(--ac);color:var(--ac-fg);border-color:var(--ac)}
+.btn.pri:hover{filter:brightness(1.06);color:var(--ac-fg)}
+.btn.sm{padding:5px 10px;font-size:12px;border-radius:8px}
+.input{width:100%;border:1px solid var(--line);border-radius:9px;padding:9px 11px;font:14px Inter,sans-serif;
+  color:var(--fg);background:var(--card);outline:none}
+.input:focus{border-color:var(--ac);box-shadow:0 0 0 3px var(--ac-soft)}
+.card{background:var(--card);border:1px solid var(--line);border-radius:14px}
+.chip{font-family:ui-monospace,Menlo,monospace;font-size:10.5px;color:var(--fg-mut);border:1px solid var(--line);
+  border-radius:6px;padding:2px 8px;background:var(--card);text-decoration:none}
+.chip.on{background:var(--ac);border-color:var(--ac);color:var(--ac-fg);font-weight:700}
+.spin{width:22px;height:22px;border:2px solid var(--line);border-top-color:var(--ac);border-radius:50%;animation:sp .7s linear infinite}
+@keyframes sp{to{transform:rotate(360deg)}}
+.toast{position:fixed;bottom:18px;left:50%;transform:translateX(-50%);background:var(--fg);color:var(--bg);
+  font-size:12.5px;padding:9px 15px;border-radius:10px;opacity:0;transition:.25s;pointer-events:none;z-index:90}
+.toast.show{opacity:1}
+.center{height:100%;display:grid;place-items:center}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,19 @@
+import react from "@vitejs/plugin-react"
+import { defineConfig } from "vite"
+
+const API = process.env.DOCK_API ?? "http://localhost:8090"
+
+// Dev: proxy the API so the SPA is same-origin (session cookies work).
+export default defineConfig({
+  plugins: [react()],
+  esbuild: { target: "esnext" },
+  optimizeDeps: { esbuildOptions: { target: "esnext" } },
+  build: { target: "esnext" },
+  server: {
+    port: 3000,
+    // NOTE: /a is the SPA's own route — only proxy API + raw artifact bytes.
+    proxy: Object.fromEntries(
+      ["/v1", "/auth", "/raw", "/healthz"].map((p) => [p, { target: API, changeOrigin: true }]),
+    ),
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,34 @@ importers:
         specifier: ^3.0.0
         version: 3.2.6(@types/node@22.19.21)(tsx@4.22.4)
 
+  apps/web:
+    dependencies:
+      '@tanstack/react-router':
+        specifier: ^1.95.0
+        version: 1.170.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.31
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.7(@types/react@18.3.31)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.3(@types/node@22.19.21)(tsx@4.22.4))
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.3(@types/node@22.19.21)(tsx@4.22.4)
+
   packages/cli:
     dependencies:
       fflate:
@@ -155,6 +183,89 @@ importers:
         version: 3.2.6(@types/node@22.19.21)(tsx@4.22.4)
 
 packages:
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
 
   '@cloudflare/workers-types@4.20260611.1':
     resolution: {integrity: sha512-DLiz8Ol1OIWLigJ+dGvuQ5Nm66D/CHNPasl8YnPiz6fGo10ggYSIVuEDMlFk6oho+piAHstNmZMl088w8xqW6g==}
@@ -488,8 +599,21 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -503,6 +627,9 @@ packages:
 
   '@petamoriken/float16@3.9.3':
     resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rollup/rollup-android-arm-eabi@4.61.1':
     resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
@@ -629,6 +756,42 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tanstack/history@1.162.0':
+    resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/react-router@1.170.15':
+    resolution: {integrity: sha512-GawYz7HEjj8rTUUDoT/SemDEVm63pZUO+2mOcXHY9Jl3EwMS5gFBnPu/2UvcrwRm1jN1k79fokc0d4aFmrLatg==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.171.13':
+    resolution: {integrity: sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
@@ -643,6 +806,23 @@ packages:
 
   '@types/node@22.19.21':
     resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
+
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.31':
+    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/expect@3.2.6':
     resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
@@ -695,6 +875,11 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  baseline-browser-mapping@2.10.37:
+    resolution: {integrity: sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   better-sqlite3@11.10.0:
     resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
 
@@ -707,6 +892,11 @@ packages:
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -729,6 +919,9 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -756,6 +949,12 @@ packages:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
@@ -774,6 +973,9 @@ packages:
 
   cssfilter@0.0.10:
     resolution: {integrity: sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -907,6 +1109,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  electron-to-chromium@1.5.372:
+    resolution: {integrity: sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==}
+
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
@@ -942,6 +1147,10 @@ packages:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -1028,6 +1237,10 @@ packages:
     engines: {node: '>= 18.0.0'}
     hasBin: true
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -1086,6 +1299,10 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  isbot@5.1.42:
+    resolution: {integrity: sha512-/SXsVh7KpPRISrD4ffrGSxnTLlUBzEQUfWIusaJPrpJ93FW1P0YEZri5vAUkFsA0m2HRUhQRQadk2wJ+EeKowQ==}
+    engines: {node: '>=18'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -1096,8 +1313,16 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -1105,8 +1330,20 @@ packages:
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1169,6 +1406,10 @@ packages:
   node-abi@3.92.0:
     resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
     engines: {node: '>=10'}
+
+  node-releases@2.0.47:
+    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
+    engines: {node: '>=18'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1247,6 +1488,19 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -1273,6 +1527,13 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
   semver@7.8.4:
     resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
@@ -1281,6 +1542,16 @@ packages:
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
+
+  seroval-plugins@1.5.4:
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
+    engines: {node: '>=10'}
 
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
@@ -1414,6 +1685,17 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -1425,6 +1707,46 @@ packages:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
+
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vite@7.3.5:
     resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
@@ -1517,6 +1839,9 @@ packages:
     engines: {node: '>= 0.10.0'}
     hasBin: true
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
@@ -1526,6 +1851,118 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@cloudflare/workers-types@4.20260611.1': {}
 
@@ -1701,7 +2138,24 @@ snapshots:
     dependencies:
       hono: 4.12.25
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
@@ -1727,6 +2181,8 @@ snapshots:
 
   '@petamoriken/float16@3.9.3':
     optional: true
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.61.1':
     optional: true
@@ -1803,6 +2259,54 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.61.1':
     optional: true
 
+  '@tanstack/history@1.162.0': {}
+
+  '@tanstack/react-router@1.170.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/react-store': 0.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/router-core': 1.171.13
+      isbot: 5.1.42
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/react-store@0.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
+  '@tanstack/router-core@1.171.13':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      cookie-es: 3.1.1
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+
+  '@tanstack/store@0.9.3': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 22.19.21
@@ -1819,6 +2323,29 @@ snapshots:
   '@types/node@22.19.21':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.31)':
+    dependencies:
+      '@types/react': 18.3.31
+
+  '@types/react@18.3.31':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.19.21)(tsx@4.22.4))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.3(@types/node@22.19.21)(tsx@4.22.4)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@3.2.6':
     dependencies:
@@ -1882,6 +2409,8 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  baseline-browser-mapping@2.10.37: {}
+
   better-sqlite3@11.10.0:
     dependencies:
       bindings: 1.5.0
@@ -1911,6 +2440,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.37
+      caniuse-lite: 1.0.30001799
+      electron-to-chromium: 1.5.372
+      node-releases: 2.0.47
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
   buffer-from@1.1.2: {}
 
   buffer@5.7.1:
@@ -1932,6 +2469,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  caniuse-lite@1.0.30001799: {}
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -1952,6 +2491,10 @@ snapshots:
 
   content-type@2.0.0: {}
 
+  convert-source-map@2.0.0: {}
+
+  cookie-es@3.1.1: {}
+
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
@@ -1968,6 +2511,8 @@ snapshots:
       which: 2.0.2
 
   cssfilter@0.0.10: {}
+
+  csstype@3.2.3: {}
 
   debug@4.4.3:
     dependencies:
@@ -2006,6 +2551,8 @@ snapshots:
       gopd: 1.2.0
 
   ee-first@1.1.1: {}
+
+  electron-to-chromium@1.5.372: {}
 
   encodeurl@2.0.0: {}
 
@@ -2083,6 +2630,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.1
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
+
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -2186,6 +2735,8 @@ snapshots:
       - supports-color
     optional: true
 
+  gensync@1.0.0-beta.2: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -2244,6 +2795,8 @@ snapshots:
 
   is-promise@4.0.0: {}
 
+  isbot@5.1.42: {}
+
   isexe@2.0.0: {}
 
   isexe@3.1.5:
@@ -2251,13 +2804,27 @@ snapshots:
 
   jose@6.2.3: {}
 
+  js-tokens@4.0.0: {}
+
   js-tokens@9.0.1: {}
+
+  jsesc@3.1.0: {}
 
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
 
+  json5@2.2.3: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   loupe@3.2.1: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   magic-string@0.30.21:
     dependencies:
@@ -2296,6 +2863,8 @@ snapshots:
   node-abi@3.92.0:
     dependencies:
       semver: 7.8.4
+
+  node-releases@2.0.47: {}
 
   object-assign@4.1.1: {}
 
@@ -2376,6 +2945,18 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-refresh@0.17.0: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
@@ -2431,6 +3012,12 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  semver@6.3.1: {}
+
   semver@7.8.4: {}
 
   send@1.2.1:
@@ -2448,6 +3035,12 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  seroval-plugins@1.5.4(seroval@1.5.4):
+    dependencies:
+      seroval: 1.5.4
+
+  seroval@1.5.4: {}
 
   serve-static@2.2.1:
     dependencies:
@@ -2586,6 +3179,16 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   util-deprecate@1.0.2: {}
 
   vary@1.1.2: {}
@@ -2596,7 +3199,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.5(@types/node@22.19.21)(tsx@4.22.4)
+      vite: 6.4.3(@types/node@22.19.21)(tsx@4.22.4)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2610,6 +3213,19 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vite@6.4.3(@types/node@22.19.21)(tsx@4.22.4):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.61.1
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.19.21
+      fsevents: 2.3.3
+      tsx: 4.22.4
 
   vite@7.3.5(@types/node@22.19.21)(tsx@4.22.4):
     dependencies:
@@ -2685,6 +3301,8 @@ snapshots:
     dependencies:
       commander: 2.20.3
       cssfilter: 0.0.10
+
+  yallist@3.1.1: {}
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
## Summary

The real Dock app — replaces the bare server-rendered pages with a polished SPA on Dock's own design system. This is the product you can sit down and use.

## What's included

- **`apps/web`** — Vite + React + TanStack Router SPA:
  - **Login / signup** (Dock-branded)
  - **Library** — artifact grid + in-browser publishing
  - **Artifact page** — sandboxed iframe + **live comment panel** (threads, reply, resolve, SSE), version chips, and **inline editing → publish a new version**
  - **4 themes** (paper / light / dark / dusk) on a token-driven design system, switched from the **user menu**
- **API** — `/v1/me`, `GET /v1/artifacts` list, and JSON auth (login/signup/logout) so the SPA can drive it; dev proxy keeps cookies same-origin.

## Validated in a real browser

Sign up → land in the library → publish → open the artifact → comment (authored as the signed-in user) → switch theme (Dusk) → inline edit. Screenshots in the thread. Static build is ~78KB gzipped (deployable to a CDN).

## Tests

35 passing, typecheck clean across the workspace; `apps/web` builds to static.

## Part of the v1 push (remaining PRs)

- **Better Auth** (email magic-link + Google OAuth + **SSO/Okta**) replacing the hand-rolled session layer
- **Anchored comments** (select-to-comment + re-anchor across versions)
- **Deploy**: web → Cloudflare, API container + Neon Postgres + R2 → a reachable URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
