### PR TITLE
Deploy: hosted split (CDN web + container API + Postgres + R2)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+**/node_modules
+**/dist
+.git
+*.log
+data
+.env
+.env.local
+apps/web/dist

--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,15 @@ BASE_URL=http://localhost:8080
 # Default storage: SQLite + local blobs inside one directory.
 DATA_DIR=./data
 
-# Optional: point at Postgres / S3-compatible object storage instead.
-# DATABASE_URL=
+# Optional: S3-compatible object storage for blobs (AWS S3, Cloudflare R2, MinIO,
+# GCS). Path-style URL: s3://ACCESS_KEY:SECRET_KEY@host[:port]/bucket?region=...
+# TLS is on unless tls=false or the host is localhost.
+#   R2:    s3://<key>:<secret>@<account>.r2.cloudflarestorage.com/dock?region=auto
+#   MinIO: s3://minioadmin:minioadmin@localhost:9000/dock?region=us-east-1&tls=false
 # OBJECT_STORE_URL=
+
+# Optional: Postgres for metadata instead of the default embedded SQLite.
+# DATABASE_URL=postgres://user:pass@host:5432/dock
 
 # Set to require a bearer token for publishing and for reading gated artifacts.
 # Unset = open instance (zero-config dev).

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,118 @@
+# Deploying Dock
+
+Two supported shapes. Pick one.
+
+1. **Hosted split** (scales): web SPA on a CDN, API container, managed Postgres, S3/R2 blobs.
+2. **Single container** (simplest): one box, SQLite + local disk on a persistent volume.
+
+The same image and code serve both. Everything is driven by env vars; nothing is required for the single-container path.
+
+---
+
+## Shape 1: Hosted split
+
+```
+  browser
+    |
+    |  app.example.com  (static SPA, Cloudflare Pages)
+    |  api.example.com  (Dock container: Fly / Hetzner / any host)
+    v
+  Postgres (Neon)        <- metadata: artifacts, versions, comments, users
+  S3 / R2                <- blobs: artifact bytes (zero egress on R2)
+```
+
+### 1. Provision data
+
+- **Postgres**: create a database (Neon, RDS, Supabase, self-hosted). Copy its `DATABASE_URL`.
+- **Object storage**: create an S3 or R2 bucket plus an access key pair. Build the connection URL:
+  - R2: `s3://<key>:<secret>@<account>.r2.cloudflarestorage.com/<bucket>?region=auto`
+  - S3: `s3://<key>:<secret>@s3.<region>.amazonaws.com/<bucket>?region=<region>`
+
+### 2. Deploy the API container
+
+Fly is the reference; any container host works (the image is plain `node:22-slim`).
+
+```bash
+# from the repo root
+fly launch --config deploy/fly.toml --dockerfile deploy/Dockerfile --no-deploy
+
+fly secrets set \
+  DATABASE_URL='postgres://...' \
+  OBJECT_STORE_URL='s3://...' \
+  DOCK_AUTH_SECRET="$(openssl rand -hex 32)" \
+  BASE_URL='https://api.example.com' \
+  DOCK_WEB_ORIGIN='https://app.example.com' \
+  DOCK_CROSS_SITE='true'
+
+fly deploy --config deploy/fly.toml --dockerfile deploy/Dockerfile
+```
+
+With `DATABASE_URL` + `OBJECT_STORE_URL` set the container holds no state: scale it
+horizontally and remove the `[mounts]` volume from `fly.toml`.
+
+`DOCK_CROSS_SITE=true` makes the session cookie `SameSite=None; Secure` so it rides
+the cross origin SPA to API request. `DOCK_WEB_ORIGIN` allow lists the SPA for CORS.
+
+### 3. Deploy the web SPA (Cloudflare Pages)
+
+Connect the repo in the Cloudflare dashboard, or use Wrangler:
+
+```bash
+pnpm --filter @dock/web build      # VITE_DOCK_API is baked in at build time
+npx wrangler pages deploy apps/web/dist --project-name dock
+```
+
+Build settings (dashboard):
+
+| Setting | Value |
+|---|---|
+| Build command | `pnpm --filter @dock/web build` |
+| Output directory | `apps/web/dist` |
+| Environment variable | `VITE_DOCK_API = https://api.example.com` |
+
+`apps/web/public/_redirects` already ships the SPA fallback (`/* /index.html 200`).
+
+### 4. OAuth / SSO redirect URIs (optional)
+
+If you set `GOOGLE_*` or `OIDC_*` secrets, register the callback with the provider:
+
+```
+https://api.example.com/api/auth/callback/google
+https://api.example.com/api/auth/oauth2/callback/<OIDC_PROVIDER_ID>
+```
+
+---
+
+## Shape 2: Single container
+
+No external services. SQLite and local blobs live in one mounted volume.
+
+```bash
+docker build -f deploy/Dockerfile -t dock-api .
+docker run -d -p 8080:8080 -v dock_data:/data \
+  -e DOCK_AUTH_SECRET="$(openssl rand -hex 32)" \
+  -e BASE_URL='https://dock.example.com' \
+  dock-api
+```
+
+Or `docker compose -f deploy/compose.yml up`. Put a TLS terminating proxy in front and
+point a domain at it. The SPA can be served same origin via the dev proxy, or hosted
+separately as in Shape 1 with `VITE_DOCK_API` pointed back at this container.
+
+---
+
+## Env reference
+
+| Var | Default | Purpose |
+|---|---|---|
+| `DATABASE_URL` | (SQLite) | Postgres for metadata + auth |
+| `OBJECT_STORE_URL` | (local disk) | S3/R2 blob storage |
+| `DOCK_AUTH_SECRET` | dev secret | Session signing key (set in prod) |
+| `BASE_URL` | `http://localhost:PORT` | Public origin of the API |
+| `DOCK_WEB_ORIGIN` | (none) | Comma separated web origins for CORS |
+| `DOCK_CROSS_SITE` | `false` | `true` for `SameSite=None; Secure` cookies |
+| `DOCK_TOKEN` | (none) | Static bearer token for CI/agents |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | (none) | Google sign in |
+| `OIDC_ISSUER` / `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` / `OIDC_PROVIDER_ID` | (none) | Enterprise SSO |
+| `PORT` | `8080` | Listen port |
+| `DATA_DIR` | `./data` | SQLite + blob dir (single container) |

--- a/README.md
+++ b/README.md
@@ -56,13 +56,19 @@ One Node container is the whole product; storage is pluggable behind interfaces.
 
 ```
 apps/api          HTTP API, sandboxed artifact serving, viewer
-apps/web          web UI (TanStack Start) — coming later
+apps/web          web UI (React + TanStack Router SPA)
 packages/core     domain: ports, publish, markdown render, viewer shell
 packages/db       MetaStore: sqlite (default) · postgres · d1
 packages/storage  BlobStore: fs (default) · s3/r2
 packages/cli      dock publish <file|dir>
-packages/mcp      MCP server — publish / read-back tools for agents
+packages/mcp      MCP server: publish / read-back tools for agents
 ```
+
+## Deploy
+
+Single container (SQLite + local disk) or a hosted split (CDN web + API container +
+Postgres + S3/R2). Both run the same image; everything is env driven. See
+[DEPLOY.md](DEPLOY.md).
 
 ## MCP
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,11 +17,13 @@
     "@hono/node-server": "^1.13.0",
     "better-auth": "^1.6.18",
     "better-sqlite3": "^11.10.0",
-    "hono": "^4.6.0"
+    "hono": "^4.6.0",
+    "pg": "^8.13.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.11",
     "@types/node": "^22.0.0",
+    "@types/pg": "^8.11.10",
     "fflate": "^0.8.2",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -38,6 +38,12 @@ export interface AppDeps {
   token?: string
   /** Better Auth instance — mounts /api/auth/* and provides the session. */
   auth?: Auth
+  /**
+   * Web origins allowed to make credentialed (cookie) calls to /api + /v1.
+   * Needed only for the hosted split where the SPA (CDN) and API (container)
+   * are on different origins; empty for same-origin self-host or dev proxy.
+   */
+  webOrigins?: string[]
 }
 
 const VISIBILITIES = ["public", "link", "org", "password"] as const
@@ -74,6 +80,15 @@ export function createApp(deps: AppDeps): Hono {
   const app = new Hono()
   const bus = createBus()
   const presence = new Presence()
+
+  // Credentialed CORS for the cross-origin SPA. A wildcard ACAO can't carry
+  // cookies, so the request's Origin is echoed back only when it's allow-listed;
+  // OPTIONS preflights are answered here. Same-origin/self-host = no-op.
+  const allowOrigins = new Set(deps.webOrigins ?? [])
+  if (allowOrigins.size) {
+    app.use("/api/*", corsFor(allowOrigins))
+    app.use("/v1/*", corsFor(allowOrigins))
+  }
 
   const bearer = (c: Context): string => {
     const h = c.req.header("authorization") ?? ""
@@ -430,6 +445,31 @@ export function createApp(deps: AppDeps): Hono {
   })
 
   return app
+}
+
+/**
+ * Echo-origin CORS middleware so the cross-origin SPA can send cookies. Headers
+ * are written onto the final response after next() — the Better Auth handler
+ * returns its own Response, so setting them beforehand would be discarded.
+ */
+const corsFor = (allowed: Set<string>) => async (c: Context, next: () => Promise<void>) => {
+  const origin = c.req.header("origin")
+  const ok = !!origin && allowed.has(origin)
+  if (ok && c.req.method === "OPTIONS")
+    return c.body(null, 204, {
+      "Access-Control-Allow-Origin": origin,
+      "Access-Control-Allow-Credentials": "true",
+      "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+      "Access-Control-Allow-Headers": "content-type,authorization",
+      "Access-Control-Max-Age": "86400",
+      Vary: "Origin",
+    })
+  await next()
+  if (ok) {
+    c.res.headers.set("Access-Control-Allow-Origin", origin)
+    c.res.headers.set("Access-Control-Allow-Credentials", "true")
+    c.res.headers.append("Vary", "Origin")
+  }
 }
 
 const str = (v: unknown): string | undefined => (typeof v === "string" && v !== "" ? v : undefined)

--- a/apps/api/src/auth-config.ts
+++ b/apps/api/src/auth-config.ts
@@ -44,6 +44,10 @@ export function makeAuth(db: Database.Database, baseUrl: string) {
       scopes: ["openid", "email", "profile"],
     })
 
+  // When the SPA and API are on different sites (CDN web + container API), the
+  // session cookie must be SameSite=None; Secure to ride cross-site fetches.
+  const crossSite = env("DOCK_CROSS_SITE") === "true" || env("DOCK_CROSS_SITE") === "1"
+
   return betterAuth({
     database: db,
     baseURL: baseUrl,
@@ -52,6 +56,9 @@ export function makeAuth(db: Database.Database, baseUrl: string) {
     socialProviders,
     trustedOrigins: trusted,
     plugins: oidc.length ? [genericOAuth({ config: oidc })] : [],
+    ...(crossSite
+      ? { advanced: { defaultCookieAttributes: { sameSite: "none" as const, secure: true } } }
+      : {}),
   })
 }
 

--- a/apps/api/src/auth-config.ts
+++ b/apps/api/src/auth-config.ts
@@ -1,16 +1,20 @@
-import Database from "better-sqlite3"
+import type Database from "better-sqlite3"
+import type { Pool } from "pg"
 import { betterAuth } from "better-auth"
 import { getMigrations } from "better-auth/db/migration"
 import { genericOAuth } from "better-auth/plugins"
 
 const env = (k: string) => process.env[k]
 
+/** Better Auth runs on the same datastore as the app: a better-sqlite3 handle or a pg Pool. */
+export type AuthDb = Database.Database | Pool
+
 /**
  * Better Auth: email+password out of the box; Google when its env is set; and
  * an enterprise OIDC provider (Okta/Entra/etc.) via the generic-OAuth plugin
  * when OIDC_* is set. Owns its own user/session/account tables.
  */
-export function makeAuth(db: Database.Database, baseUrl: string) {
+export function makeAuth(db: AuthDb, baseUrl: string) {
   // The browser sends its own Origin (the web app), which differs from the API's
   // baseURL whenever the SPA and API are on separate origins (dev proxy, or the
   // hosted split of static-web + API container). DOCK_WEB_ORIGIN lists those in

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -17,12 +17,18 @@ const meta = new SqliteMetaStore(join(DATA_DIR, "dock.db"))
 const auth = makeAuth(new Database(join(DATA_DIR, "dock.db")), BASE_URL)
 await migrateAuth(auth)
 
+const webOrigins = (process.env.DOCK_WEB_ORIGIN ?? "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean)
+
 const app = createApp({
   meta,
   blobs: new FsBlobStore(join(DATA_DIR, "blobs")),
   baseUrl: BASE_URL,
   token: process.env.DOCK_TOKEN,
   auth,
+  webOrigins,
 })
 
 serve({ fetch: app.fetch, port: PORT }, () => {

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -2,21 +2,34 @@ import { serve } from "@hono/node-server"
 import { mkdirSync } from "node:fs"
 import { join } from "node:path"
 import Database from "better-sqlite3"
+import { Pool } from "pg"
 import { SqliteMetaStore } from "@dock/db/sqlite"
-import type { BlobStore } from "@dock/core"
+import { PgMetaStore } from "@dock/db/pg"
+import type { BlobStore, MetaStore } from "@dock/core"
 import { FsBlobStore } from "@dock/storage/fs"
 import { s3FromUrl } from "@dock/storage/s3"
 import { createApp } from "./app"
-import { makeAuth, migrateAuth } from "./auth-config"
+import { makeAuth, migrateAuth, type AuthDb } from "./auth-config"
 
 const PORT = Number(process.env.PORT ?? 8080)
 const DATA_DIR = process.env.DATA_DIR ?? "./data"
 const BASE_URL = process.env.BASE_URL ?? `http://localhost:${PORT}`
+const DATABASE_URL = process.env.DATABASE_URL
 
 mkdirSync(join(DATA_DIR, "blobs"), { recursive: true })
 
-const meta = new SqliteMetaStore(join(DATA_DIR, "dock.db"))
-const auth = makeAuth(new Database(join(DATA_DIR, "dock.db")), BASE_URL)
+// Metadata + auth share one datastore: Postgres when DATABASE_URL is set (the
+// stateless multi-instance topology), else embedded SQLite (zero-config).
+let meta: MetaStore
+let authDb: AuthDb
+if (DATABASE_URL) {
+  meta = await PgMetaStore.create(DATABASE_URL)
+  authDb = new Pool({ connectionString: DATABASE_URL })
+} else {
+  meta = new SqliteMetaStore(join(DATA_DIR, "dock.db"))
+  authDb = new Database(join(DATA_DIR, "dock.db"))
+}
+const auth = makeAuth(authDb, BASE_URL)
 await migrateAuth(auth)
 
 const webOrigins = (process.env.DOCK_WEB_ORIGIN ?? "")
@@ -39,10 +52,11 @@ const app = createApp({
 })
 
 const blobDesc = process.env.OBJECT_STORE_URL ? "S3/R2" : `local disk (${DATA_DIR})`
+const metaDesc = DATABASE_URL ? "postgres" : `sqlite (${DATA_DIR})`
 
 serve({ fetch: app.fetch, port: PORT }, () => {
   console.log(`dock api listening on :${PORT}`)
-  console.log(`  meta:    sqlite (${DATA_DIR})`)
+  console.log(`  meta:    ${metaDesc}`)
   console.log(`  blobs:   ${blobDesc}`)
   console.log(`  auth:    /api/auth/* (Better Auth)`)
   console.log(`  publish: dock publish <file|dir> --server ${BASE_URL}`)

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -3,7 +3,9 @@ import { mkdirSync } from "node:fs"
 import { join } from "node:path"
 import Database from "better-sqlite3"
 import { SqliteMetaStore } from "@dock/db/sqlite"
+import type { BlobStore } from "@dock/core"
 import { FsBlobStore } from "@dock/storage/fs"
+import { s3FromUrl } from "@dock/storage/s3"
 import { createApp } from "./app"
 import { makeAuth, migrateAuth } from "./auth-config"
 
@@ -22,18 +24,26 @@ const webOrigins = (process.env.DOCK_WEB_ORIGIN ?? "")
   .map((s) => s.trim())
   .filter(Boolean)
 
+// Blobs: S3/R2 when OBJECT_STORE_URL is set, else local disk (zero-config).
+const blobs: BlobStore = process.env.OBJECT_STORE_URL
+  ? s3FromUrl(process.env.OBJECT_STORE_URL)
+  : new FsBlobStore(join(DATA_DIR, "blobs"))
+
 const app = createApp({
   meta,
-  blobs: new FsBlobStore(join(DATA_DIR, "blobs")),
+  blobs,
   baseUrl: BASE_URL,
   token: process.env.DOCK_TOKEN,
   auth,
   webOrigins,
 })
 
+const blobDesc = process.env.OBJECT_STORE_URL ? "S3/R2" : `local disk (${DATA_DIR})`
+
 serve({ fetch: app.fetch, port: PORT }, () => {
   console.log(`dock api listening on :${PORT}`)
-  console.log(`  storage: sqlite + local blobs (${DATA_DIR})`)
+  console.log(`  meta:    sqlite (${DATA_DIR})`)
+  console.log(`  blobs:   ${blobDesc}`)
   console.log(`  auth:    /api/auth/* (Better Auth)`)
   console.log(`  publish: dock publish <file|dir> --server ${BASE_URL}`)
 })

--- a/apps/web/public/_redirects
+++ b/apps/web/public/_redirects
@@ -1,0 +1,2 @@
+# Cloudflare Pages SPA fallback — every route renders the client app.
+/*  /index.html  200

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -26,6 +26,12 @@ export interface Comment {
   anchored?: boolean
 }
 
+// Same-origin by default (dev proxy / embedded self-host). Set VITE_DOCK_API to
+// the API origin when the SPA is served from a CDN separate from the container.
+export const API_BASE = (import.meta.env.VITE_DOCK_API ?? "").replace(/\/$/, "")
+const u = (path: string) => API_BASE + path
+const f = (path: string, init?: RequestInit) => fetch(u(path), init)
+
 const j = async (r: Response) => {
   if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error ?? `HTTP ${r.status}`)
   return r.json()
@@ -45,36 +51,36 @@ const authJson = async (r: Response) => {
 
 export const api = {
   async me(): Promise<{ user: Me }> {
-    const s = await fetch("/api/auth/get-session", { credentials: "include" }).then((r) =>
+    const s = await f("/api/auth/get-session", { credentials: "include" }).then((r) =>
       r.ok ? r.json() : null,
     )
     if (!s?.user) throw new Error("unauthenticated")
     return { user: { id: s.user.id, email: s.user.email, name: s.user.name ?? null, role: "member" } }
   },
   login: (email: string, password: string): Promise<unknown> =>
-    fetch("/api/auth/sign-in/email", opts({ email, password })).then(authJson),
+    f("/api/auth/sign-in/email", opts({ email, password })).then(authJson),
   signup: (email: string, password: string, name: string): Promise<unknown> =>
-    fetch("/api/auth/sign-up/email", opts({ email, password, name: name || email })).then(authJson),
-  logout: () => fetch("/api/auth/sign-out", opts({})).then((r) => r.json().catch(() => ({}))),
-  googleUrl: "/api/auth/sign-in/social?provider=google",
+    f("/api/auth/sign-up/email", opts({ email, password, name: name || email })).then(authJson),
+  logout: () => f("/api/auth/sign-out", opts({})).then((r) => r.json().catch(() => ({}))),
+  googleUrl: u("/api/auth/sign-in/social?provider=google"),
 
-  listArtifacts: (): Promise<{ artifacts: Artifact[] }> => fetch("/v1/artifacts", opts()).then(j),
-  getArtifact: (id: string): Promise<Artifact> => fetch(`/v1/artifacts/${id}`, opts()).then(j),
+  listArtifacts: (): Promise<{ artifacts: Artifact[] }> => f("/v1/artifacts", opts()).then(j),
+  getArtifact: (id: string): Promise<Artifact> => f(`/v1/artifacts/${id}`, opts()).then(j),
   getContent: (id: string, v?: number): Promise<string> =>
-    fetch(`/v1/artifacts/${id}/content${v ? `?v=${v}` : ""}`, { credentials: "include" }).then((r) => r.text()),
+    f(`/v1/artifacts/${id}/content${v ? `?v=${v}` : ""}`, { credentials: "include" }).then((r) => r.text()),
   listComments: (id: string): Promise<{ comments: Comment[] }> =>
-    fetch(`/v1/artifacts/${id}/comments`, opts()).then(j),
+    f(`/v1/artifacts/${id}/comments`, opts()).then(j),
   comment: (id: string, body: { body_md: string; thread_id?: string; anchor?: unknown }): Promise<Comment> =>
-    fetch(`/v1/artifacts/${id}/comments`, opts(body)).then(j),
+    f(`/v1/artifacts/${id}/comments`, opts(body)).then(j),
   resolve: (id: string, commentId: string, state: "open" | "resolved") =>
-    fetch(`/v1/artifacts/${id}/comments/${commentId}/resolve`, opts({ state })).then(j),
+    f(`/v1/artifacts/${id}/comments/${commentId}/resolve`, opts({ state })).then(j),
 
   async publish(file: File, fields: Record<string, string> = {}, id?: string): Promise<Artifact> {
     const fd = new FormData()
     fd.append("file", file)
     for (const [k, v] of Object.entries(fields)) fd.append(k, v)
-    const url = id ? `/v1/artifacts/${id}/versions` : "/v1/artifacts"
-    return fetch(url, { method: "POST", body: fd, credentials: "include", headers: { accept: "application/json" } }).then(j)
+    const path = id ? `/v1/artifacts/${id}/versions` : "/v1/artifacts"
+    return f(path, { method: "POST", body: fd, credentials: "include", headers: { accept: "application/json" } }).then(j)
   },
   publishText(id: string, text: string, filename: string, message: string): Promise<Artifact> {
     return this.publish(new File([text], filename), { message }, id)

--- a/apps/web/src/pages/Artifact.tsx
+++ b/apps/web/src/pages/Artifact.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react"
 import { useNavigate, useParams } from "@tanstack/react-router"
-import { api, type Artifact as Art, type Comment } from "../api"
+import { api, API_BASE, type Artifact as Art, type Comment } from "../api"
 import { Header, useToast } from "../components"
 import { useAuth } from "../ctx"
 
@@ -46,7 +46,9 @@ export function Artifact() {
 
   // live updates
   useEffect(() => {
-    const ev = new EventSource(`/v1/artifacts/${shortId}/events`)
+    const ev = new EventSource(`${API_BASE}/v1/artifacts/${shortId}/events`, {
+      withCredentials: true,
+    })
     const refresh = () => api.listComments(shortId).then((r) => setComments(r.comments)).catch(() => {})
     ev.addEventListener("comment.created", refresh)
     ev.addEventListener("comment.resolved", refresh)
@@ -68,7 +70,7 @@ export function Artifact() {
 
   const shown = version ?? art.current_version
   const editable = art.kind === "file" && shown === art.current_version
-  const rawSrc = `/raw/${shortId}/v/${shown}/index.html`
+  const rawSrc = `${API_BASE}/raw/${shortId}/v/${shown}/index.html`
   const threads = groupThreads(comments)
   const openCount = threads.filter((t) => t[0].state === "open").length
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,13 +1,17 @@
-# Dock — one container: API + viewer (+ embedded web UI once apps/web ships).
+# Dock API container — serves the publish API, comment loop, and sandboxed
+# artifact viewer. The web SPA deploys separately to a CDN (see DEPLOY.md).
 FROM node:22-slim AS base
+ENV CI=true
 RUN corepack enable
 WORKDIR /app
 COPY . .
+# better-sqlite3 v11 ships prebuilt binaries; pg is pure JS — no compiler needed.
 RUN pnpm install --frozen-lockfile --prod=false
 
 ENV NODE_ENV=production \
     PORT=8080 \
     DATA_DIR=/data
+# Only used in the SQLite fallback; ignored when DATABASE_URL + OBJECT_STORE_URL are set.
 VOLUME /data
 EXPOSE 8080
 CMD ["pnpm", "--filter", "@dock/api", "start"]

--- a/deploy/fly.toml
+++ b/deploy/fly.toml
@@ -1,0 +1,31 @@
+# Fly.io config for the Dock API container. `fly launch --no-deploy` to create
+# the app, set secrets (see DEPLOY.md), then `fly deploy`.
+app = "dock-api"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8080"
+  # BASE_URL, DOCK_WEB_ORIGIN, DOCK_CROSS_SITE are set per-deploy (see DEPLOY.md).
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[http_service.checks]]
+    method = "GET"
+    path = "/healthz"
+    interval = "15s"
+    timeout = "2s"
+
+# With DATABASE_URL + OBJECT_STORE_URL set, the container is stateless — scale it
+# horizontally and drop this volume. Without them, it falls back to SQLite + local
+# blobs and needs one persistent volume mounted at /data.
+[mounts]
+  source = "dock_data"
+  destination = "/data"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "dock.build",
   "private": true,
+  "packageManager": "pnpm@10.26.1",
   "pnpm": {
     "onlyBuiltDependencies": ["better-sqlite3"],
     "overrides": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./sqlite": "./src/sqlite.ts",
+    "./pg": "./src/pg.ts",
     "./d1": "./src/d1.ts",
     "./schema": "./src/schema.ts"
   },
@@ -16,12 +17,14 @@
   "dependencies": {
     "@dock/core": "workspace:*",
     "better-sqlite3": "^11.10.0",
-    "drizzle-orm": "^0.45.2"
+    "drizzle-orm": "^0.45.2",
+    "pg": "^8.13.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241127.0",
     "@types/better-sqlite3": "^7.6.11",
     "@types/node": "^22.0.0",
+    "@types/pg": "^8.11.10",
     "drizzle-kit": "^0.31.0",
     "typescript": "^5.6.0",
     "vitest": "^3.0.0"

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -1,0 +1,55 @@
+// Postgres schema DDL, applied at boot (idempotent). created_at is an ISO-8601
+// text column so every record shape — and its lexical sort — is identical to the
+// SQLite driver. user/session/account/verification are owned by Better Auth.
+const isoDefault = `to_char((now() at time zone 'utc'), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`
+
+export const PG_SCHEMA_STATEMENTS: string[] = [
+  `CREATE TABLE IF NOT EXISTS artifact (
+    id TEXT PRIMARY KEY,
+    short_id TEXT NOT NULL UNIQUE,
+    org_id TEXT NOT NULL DEFAULT 'local',
+    slug TEXT,
+    title TEXT,
+    visibility TEXT NOT NULL DEFAULT 'link',
+    kind TEXT NOT NULL,
+    spa INTEGER NOT NULL DEFAULT 0,
+    current_version INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT ${isoDefault}
+  )`,
+  `CREATE TABLE IF NOT EXISTS version (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    n INTEGER NOT NULL,
+    blob_key TEXT NOT NULL,
+    content_type TEXT NOT NULL,
+    author TEXT NOT NULL,
+    message TEXT,
+    created_at TEXT NOT NULL DEFAULT ${isoDefault},
+    UNIQUE (artifact_id, n)
+  )`,
+  `CREATE TABLE IF NOT EXISTS comment (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    thread_id TEXT NOT NULL,
+    base_version INTEGER NOT NULL,
+    path TEXT,
+    anchor TEXT,
+    body_md TEXT NOT NULL,
+    author TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'open',
+    created_at TEXT NOT NULL DEFAULT ${isoDefault}
+  )`,
+  `CREATE TABLE IF NOT EXISTS principal (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    email TEXT,
+    kind TEXT NOT NULL DEFAULT 'human',
+    created_at TEXT NOT NULL DEFAULT ${isoDefault}
+  )`,
+  `CREATE TABLE IF NOT EXISTS acl (
+    artifact_id TEXT PRIMARY KEY REFERENCES artifact(id),
+    visibility TEXT NOT NULL,
+    password_hash TEXT,
+    org_gate TEXT
+  )`,
+]

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1,0 +1,142 @@
+import { Pool } from "pg"
+import type {
+  ArtifactRecord,
+  CommentRecord,
+  CommentState,
+  MetaStore,
+  NewArtifact,
+  NewComment,
+  NewVersion,
+  VersionRecord,
+} from "@dock/core"
+import { PG_SCHEMA_STATEMENTS } from "./pg-schema"
+
+/**
+ * Postgres metadata store (Neon, RDS, self-hosted) for horizontal scale — the
+ * container is stateless and many instances share one database. Same interface
+ * and record shapes as the SQLite driver. Raw parameterized SQL via node-postgres
+ * keeps it dialect-explicit and free of the query-builder version skew.
+ */
+export class PgMetaStore implements MetaStore {
+  private constructor(private pool: Pool) {}
+
+  /** Connect and apply the schema (idempotent) before first use. */
+  static async create(connectionString: string): Promise<PgMetaStore> {
+    const pool = new Pool({ connectionString })
+    for (const stmt of PG_SCHEMA_STATEMENTS) await pool.query(stmt)
+    return new PgMetaStore(pool)
+  }
+
+  private async one<T>(text: string, params: unknown[]): Promise<T | null> {
+    const { rows } = await this.pool.query(text, params)
+    return (rows[0] as T) ?? null
+  }
+
+  async createArtifact(a: NewArtifact): Promise<ArtifactRecord> {
+    await this.pool.query(
+      `INSERT INTO artifact (id, short_id, org_id, slug, title, visibility, kind, spa)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
+      [a.id, a.short_id, a.org_id, a.slug, a.title, a.visibility, a.kind, a.spa],
+    )
+    return (await this.getByShortId(a.short_id)) as ArtifactRecord
+  }
+
+  getByShortId(shortId: string): Promise<ArtifactRecord | null> {
+    return this.one<ArtifactRecord>(`SELECT * FROM artifact WHERE short_id = $1`, [shortId])
+  }
+
+  async addVersion(artifactId: string, v: NewVersion): Promise<VersionRecord> {
+    const client = await this.pool.connect()
+    try {
+      await client.query("BEGIN")
+      const cur = await client.query(
+        `SELECT current_version FROM artifact WHERE id = $1 FOR UPDATE`,
+        [artifactId],
+      )
+      if (!cur.rows[0]) throw new Error(`artifact not found: ${artifactId}`)
+      const next = (cur.rows[0].current_version as number) + 1
+      await client.query(
+        `INSERT INTO version (id, artifact_id, n, blob_key, content_type, author, message)
+         VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+        [v.id, artifactId, next, v.blob_key, v.content_type, v.author, v.message],
+      )
+      await client.query(`UPDATE artifact SET current_version = $1 WHERE id = $2`, [
+        next,
+        artifactId,
+      ])
+      await client.query("COMMIT")
+      return (await this.getVersion(artifactId, next)) as VersionRecord
+    } catch (err) {
+      await client.query("ROLLBACK")
+      throw err
+    } finally {
+      client.release()
+    }
+  }
+
+  async listVersions(artifactId: string): Promise<VersionRecord[]> {
+    const { rows } = await this.pool.query(
+      `SELECT * FROM version WHERE artifact_id = $1 ORDER BY n ASC`,
+      [artifactId],
+    )
+    return rows as VersionRecord[]
+  }
+
+  getVersion(artifactId: string, n: number): Promise<VersionRecord | null> {
+    return this.one<VersionRecord>(`SELECT * FROM version WHERE artifact_id = $1 AND n = $2`, [
+      artifactId,
+      n,
+    ])
+  }
+
+  async createComment(c: NewComment): Promise<CommentRecord> {
+    const { rows } = await this.pool.query(
+      `INSERT INTO comment (id, artifact_id, thread_id, base_version, path, anchor, body_md, author)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING *`,
+      [c.id, c.artifact_id, c.thread_id, c.base_version, c.path, c.anchor, c.body_md, c.author],
+    )
+    return rows[0] as CommentRecord
+  }
+
+  getComment(id: string): Promise<CommentRecord | null> {
+    return this.one<CommentRecord>(`SELECT * FROM comment WHERE id = $1`, [id])
+  }
+
+  async listComments(artifactId: string, opts?: { state?: CommentState }): Promise<CommentRecord[]> {
+    const { rows } = opts?.state
+      ? await this.pool.query(
+          `SELECT * FROM comment WHERE artifact_id = $1 AND state = $2 ORDER BY created_at ASC`,
+          [artifactId, opts.state],
+        )
+      : await this.pool.query(
+          `SELECT * FROM comment WHERE artifact_id = $1 ORDER BY created_at ASC`,
+          [artifactId],
+        )
+    return rows as CommentRecord[]
+  }
+
+  async setThreadState(
+    artifactId: string,
+    threadId: string,
+    state: CommentState,
+  ): Promise<number> {
+    const res = await this.pool.query(
+      `UPDATE comment SET state = $1 WHERE artifact_id = $2 AND thread_id = $3`,
+      [state, artifactId, threadId],
+    )
+    return res.rowCount ?? 0
+  }
+
+  async listArtifacts(opts?: { limit?: number }): Promise<ArtifactRecord[]> {
+    const { rows } = opts?.limit
+      ? await this.pool.query(`SELECT * FROM artifact ORDER BY created_at DESC LIMIT $1`, [
+          opts.limit,
+        ])
+      : await this.pool.query(`SELECT * FROM artifact ORDER BY created_at DESC`)
+    return rows as ArtifactRecord[]
+  }
+
+  async close(): Promise<void> {
+    await this.pool.end()
+  }
+}

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./fs": "./src/fs.ts",
+    "./s3": "./src/s3.ts",
     "./r2": "./src/r2.ts"
   },
   "scripts": {

--- a/packages/storage/src/s3.ts
+++ b/packages/storage/src/s3.ts
@@ -1,0 +1,121 @@
+import { createHash, createHmac } from "node:crypto"
+import { sha256Hex, type BlobStore } from "@dock/core"
+
+/**
+ * S3-compatible blob store for the Node container — covers AWS S3, Cloudflare
+ * R2, MinIO, GCS, anything that speaks the S3 REST API. Path-style addressing
+ * (https://endpoint/bucket/key) so one code path serves every provider, and a
+ * self-contained SigV4 signer over fetch so there's no AWS SDK dependency.
+ *
+ * Keys are content-addressed (sha256 of the bytes), matching the fs and R2
+ * drivers, so the same artifact dedupes across stores.
+ */
+export interface S3Config {
+  endpoint: string // host[:port], no scheme
+  bucket: string
+  accessKey: string
+  secretKey: string
+  region: string
+  tls: boolean
+}
+
+const enc = (s: string) =>
+  encodeURIComponent(s).replace(/[!'()*]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`)
+
+const hash = (data: string | Uint8Array) => createHash("sha256").update(data).digest("hex")
+const hmac = (key: string | Buffer, data: string) => createHmac("sha256", key).update(data).digest()
+
+export class S3BlobStore implements BlobStore {
+  constructor(private cfg: S3Config) {}
+
+  private origin(): string {
+    return `${this.cfg.tls ? "https" : "http"}://${this.cfg.endpoint}`
+  }
+
+  /** SigV4-sign a request for an object key and return headers + URL. */
+  private sign(method: "PUT" | "GET", key: string, payloadHash: string) {
+    const { bucket, region, accessKey, secretKey } = this.cfg
+    const path = `/${bucket}/${enc(key)}`
+    const now = new Date()
+    const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, "")
+    const date = amzDate.slice(0, 8)
+    const host = this.cfg.endpoint
+
+    const canonicalHeaders =
+      `host:${host}\n` + `x-amz-content-sha256:${payloadHash}\n` + `x-amz-date:${amzDate}\n`
+    const signedHeaders = "host;x-amz-content-sha256;x-amz-date"
+    const canonicalRequest = [
+      method,
+      path,
+      "",
+      canonicalHeaders,
+      signedHeaders,
+      payloadHash,
+    ].join("\n")
+
+    const scope = `${date}/${region}/s3/aws4_request`
+    const stringToSign = ["AWS4-HMAC-SHA256", amzDate, scope, hash(canonicalRequest)].join("\n")
+
+    const kDate = hmac(`AWS4${secretKey}`, date)
+    const kRegion = hmac(kDate, region)
+    const kService = hmac(kRegion, "s3")
+    const kSigning = hmac(kService, "aws4_request")
+    const signature = createHmac("sha256", kSigning).update(stringToSign).digest("hex")
+
+    const authorization =
+      `AWS4-HMAC-SHA256 Credential=${accessKey}/${scope}, ` +
+      `SignedHeaders=${signedHeaders}, Signature=${signature}`
+
+    return {
+      url: `${this.origin()}${path}`,
+      headers: {
+        host,
+        "x-amz-content-sha256": payloadHash,
+        "x-amz-date": amzDate,
+        authorization,
+      },
+    }
+  }
+
+  async put(data: Uint8Array): Promise<string> {
+    const key = await sha256Hex(data)
+    const payloadHash = hash(data)
+    const { url, headers } = this.sign("PUT", key, payloadHash)
+    // Copy into a plain ArrayBuffer — an unambiguous BodyInit across TS lib versions.
+    const body = new ArrayBuffer(data.byteLength)
+    new Uint8Array(body).set(data)
+    const res = await fetch(url, { method: "PUT", headers, body })
+    if (!res.ok) throw new Error(`s3 put ${key} failed: ${res.status} ${await res.text()}`)
+    return key
+  }
+
+  async get(key: string): Promise<Uint8Array | null> {
+    if (!/^[0-9a-f]{64}$/.test(key)) return null
+    const { url, headers } = this.sign("GET", key, hash(""))
+    const res = await fetch(url, { method: "GET", headers })
+    if (res.status === 404) return null
+    if (!res.ok) throw new Error(`s3 get ${key} failed: ${res.status}`)
+    return new Uint8Array(await res.arrayBuffer())
+  }
+}
+
+/**
+ * Parse OBJECT_STORE_URL into a config:
+ *   s3://ACCESS_KEY:SECRET_KEY@endpoint[:port]/bucket?region=auto&tls=false
+ * TLS defaults on (off only when tls=false or the host is localhost).
+ */
+export function s3FromUrl(raw: string): S3BlobStore {
+  const url = new URL(raw)
+  const bucket = url.pathname.replace(/^\//, "").split("/")[0]
+  if (!bucket) throw new Error("OBJECT_STORE_URL must include a /bucket path")
+  const local = url.hostname === "localhost" || url.hostname === "127.0.0.1"
+  const tls = url.searchParams.get("tls") === "false" ? false : !local
+  return new S3BlobStore({
+    endpoint: url.host,
+    bucket,
+    accessKey: decodeURIComponent(url.username),
+    secretKey: decodeURIComponent(url.password),
+    region: url.searchParams.get("region") ?? "auto",
+    tls,
+  })
+}

--- a/packages/storage/test/s3.test.ts
+++ b/packages/storage/test/s3.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { S3BlobStore, s3FromUrl } from "../src/s3"
+
+describe("s3FromUrl", () => {
+  it("parses an R2-style URL with TLS on by default", () => {
+    const store = s3FromUrl(
+      "s3://AK:SECRET@acct.r2.cloudflarestorage.com/dock?region=auto",
+    )
+    expect(store).toBeInstanceOf(S3BlobStore)
+    const cfg = (store as unknown as { cfg: Record<string, unknown> }).cfg
+    expect(cfg).toMatchObject({
+      endpoint: "acct.r2.cloudflarestorage.com",
+      bucket: "dock",
+      accessKey: "AK",
+      secretKey: "SECRET",
+      region: "auto",
+      tls: true,
+    })
+  })
+
+  it("turns TLS off for localhost and honours tls=false", () => {
+    const cfg = (
+      s3FromUrl("s3://minioadmin:minioadmin@localhost:9000/dock?region=us-east-1") as unknown as {
+        cfg: Record<string, unknown>
+      }
+    ).cfg
+    expect(cfg).toMatchObject({ endpoint: "localhost:9000", tls: false, region: "us-east-1" })
+  })
+
+  it("rejects a URL with no bucket", () => {
+    expect(() => s3FromUrl("s3://AK:SECRET@host.example.com/")).toThrow(/bucket/)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,13 +27,16 @@ importers:
         version: 1.19.14(hono@4.12.25)
       better-auth:
         specifier: ^1.6.18
-        version: 1.6.18(@cloudflare/workers-types@4.20260611.1)(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.6(@types/node@22.19.21)(tsx@4.22.4))
+        version: 1.6.18(@cloudflare/workers-types@4.20260611.1)(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.6(@types/node@22.19.21)(tsx@4.22.4))
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
       hono:
         specifier: ^4.6.0
         version: 4.12.25
+      pg:
+        specifier: ^8.13.1
+        version: 8.21.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.11
@@ -41,6 +44,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.21
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
       fflate:
         specifier: ^0.8.2
         version: 0.8.3
@@ -120,7 +126,10 @@ importers:
         version: 11.10.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)
+        version: 0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0)
+      pg:
+        specifier: ^8.13.1
+        version: 8.21.0
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20241127.0
@@ -131,6 +140,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.21
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
       drizzle-kit:
         specifier: ^0.31.0
         version: 0.31.10
@@ -910,6 +922,9 @@ packages:
   '@types/node@22.19.21':
     resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
 
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
@@ -1628,6 +1643,40 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.13.0:
+    resolution: {integrity: sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.14.0:
+    resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.21.0:
+    resolution: {integrity: sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1642,6 +1691,22 @@ packages:
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -1797,6 +1862,10 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2029,6 +2098,10 @@ packages:
     engines: {node: '>= 0.10.0'}
     hasBin: true
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2171,12 +2244,12 @@ snapshots:
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260611.1
 
-  '@better-auth/drizzle-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@cloudflare/workers-types@4.20260611.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2))':
+  '@better-auth/drizzle-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@cloudflare/workers-types@4.20260611.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))':
     dependencies:
       '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@cloudflare/workers-types@4.20260611.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.1
     optionalDependencies:
-      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0)
 
   '@better-auth/kysely-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@cloudflare/workers-types@4.20260611.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(kysely@0.29.2)':
     dependencies:
@@ -2580,6 +2653,12 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.19.21
+      pg-protocol: 1.14.0
+      pg-types: 2.2.0
+
   '@types/prop-types@15.7.15': {}
 
   '@types/react-dom@18.3.7(@types/react@18.3.31)':
@@ -2667,10 +2746,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.37: {}
 
-  better-auth@1.6.18(@cloudflare/workers-types@4.20260611.1)(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.6(@types/node@22.19.21)(tsx@4.22.4)):
+  better-auth@1.6.18(@cloudflare/workers-types@4.20260611.1)(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.6(@types/node@22.19.21)(tsx@4.22.4)):
     dependencies:
       '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@cloudflare/workers-types@4.20260611.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@cloudflare/workers-types@4.20260611.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2))
+      '@better-auth/drizzle-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@cloudflare/workers-types@4.20260611.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))
       '@better-auth/kysely-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@cloudflare/workers-types@4.20260611.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(kysely@0.29.2)
       '@better-auth/memory-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@cloudflare/workers-types@4.20260611.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
       '@better-auth/mongo-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@cloudflare/workers-types@4.20260611.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
@@ -2689,7 +2768,8 @@ snapshots:
     optionalDependencies:
       better-sqlite3: 11.10.0
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0)
+      pg: 8.21.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       vitest: 3.2.6(@types/node@22.19.21)(tsx@4.22.4)
@@ -2834,13 +2914,15 @@ snapshots:
       esbuild: 0.28.1
       tsx: 4.22.4
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260611.1
       '@types/better-sqlite3': 7.6.13
+      '@types/pg': 8.20.0
       better-sqlite3: 11.10.0
       gel: 2.2.0
       kysely: 0.29.2
+      pg: 8.21.0
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3190,6 +3272,41 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.13.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.21.0):
+    dependencies:
+      pg: 8.21.0
+
+  pg-protocol@1.14.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.21.0:
+    dependencies:
+      pg-connection-string: 2.13.0
+      pg-pool: 3.14.0(pg@8.21.0)
+      pg-protocol: 1.14.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
@@ -3201,6 +3318,16 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prebuild-install@7.1.3:
     dependencies:
@@ -3415,6 +3542,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  split2@4.2.0: {}
+
   stackback@0.0.2: {}
 
   statuses@2.0.2: {}
@@ -3607,6 +3736,8 @@ snapshots:
     dependencies:
       commander: 2.20.3
       cssfilter: 0.0.10
+
+  xtend@4.0.2: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
Stacked on #9 (Better Auth). Base is `feat/better-auth`; rebase onto main after #9 merges.

## What

Makes Dock deployable in the topology we chose: static SPA on a CDN, API in a container, Postgres for metadata, S3/R2 for blobs. The same image also runs the zero-config single-container path (SQLite + local disk). Everything is env driven.

Every datastore option was verified end to end against local Docker (Postgres + MinIO), and the container image was built, booted, and smoke-published.

## Commits

1. **Cross-origin support** for the CDN-web + container-API split: credentialed CORS on `/api` + `/v1` (origin echoed only when allow-listed via `DOCK_WEB_ORIGIN`, applied after `next()` so it lands on Better Auth's own Response), `SameSite=None; Secure` cookies under `DOCK_CROSS_SITE`, and a configurable web API base via `VITE_DOCK_API` (fetch, SSE, and the artifact iframe). All gated on env, so the same-origin self-host path is unchanged.
2. **S3/R2 blob driver** for the container: a path-style S3 store with a self-contained SigV4 signer over `fetch` (no AWS SDK). Content-addressed keys, so it dedupes the same as fs/r2. Selected by `OBJECT_STORE_URL`.
3. **Postgres metadata store**: `PgMetaStore` over node-postgres with raw parameterized SQL; `addVersion` uses `SELECT ... FOR UPDATE` so concurrent republishes can't collide. Better Auth runs on the same pool. Selected by `DATABASE_URL`. `created_at` is ISO text, so record shapes match the SQLite driver exactly.
4. **Deploy config + runbook**: `deploy/fly.toml` (healthcheck, stateless when the external stores are set), a reproducible `Dockerfile` (pinned pnpm) + `.dockerignore`, Cloudflare Pages SPA `_redirects`, and `DEPLOY.md` covering both shapes plus an env reference and OAuth/SSO callback URLs.

## Verification

- Full hosted stack against Docker Postgres + MinIO: signup (auth on pg), publish (meta on pg, blob on R2/MinIO), v2 republish transaction, session-authored comment, read-back. Better Auth created its own tables; row counts and `created_at` format confirmed.
- Cross-origin: OPTIONS preflight + credentialed ACAO on `/v1` and `/api/auth`, `SameSite=None` cookie, disallowed origins rejected; same-origin SPA login still works.
- Container image builds, boots, serves `/healthz` (200), and publishes.
- `pnpm typecheck` clean, 45 tests green.

## Not in this PR

A fully reachable URL needs infra you provision: a container host (Fly/Hetzner), a Postgres (Neon), an R2 bucket + token, and a domain. The runbook is the exact path once those exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)