### PR TITLE
Comments: stick to their text — in-document highlights, two-way jump, honest re-anchoring

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,6 +4,7 @@ import { streamSSE } from "hono/streaming"
 import { Presence, createBus } from "./bus"
 import type { Auth } from "./auth-config"
 import {
+  ANCHOR_CLIENT_JS,
   BUNDLE_CONTENT_TYPE,
   PublishError,
   artifactUrl,
@@ -432,6 +433,16 @@ export function createApp(deps: AppDeps): Hono {
 
   // ---- Raw content (the sandbox) ----------------------------------------
 
+  // The comment-anchor client, referenced by URL from artifact HTML. Artifact
+  // pages are cached immutable; this is cached short so the client can evolve
+  // without stranding old behavior in already-viewed artifacts.
+  app.get("/raw/dock-client.js", (c) =>
+    c.body(ANCHOR_CLIENT_JS, 200, {
+      "Content-Type": "text/javascript; charset=utf-8",
+      "Cache-Control": "public, max-age=300",
+    }),
+  )
+
   app.get("/raw/:shortId/v/:n/*", async (c) => {
     const shortId = c.req.param("shortId")
     const n = Number(c.req.param("n"))
@@ -464,7 +475,9 @@ export function createApp(deps: AppDeps): Hono {
           new TextDecoder().decode(data),
           prefix.slice(0, -1),
         )
-        return c.body(rewritten, 200, { ...RAW_HEADERS, "Content-Type": entry.type })
+        // Bundle pages get the anchor client too — comments stick everywhere.
+        const out = entry.type.startsWith("text/html") ? rewritten + SELECTION_SCRIPT : rewritten
+        return c.body(out, 200, { ...RAW_HEADERS, "Content-Type": entry.type })
       }
       return c.body(toBody(data), 200, { ...RAW_HEADERS, "Content-Type": entry.type })
     }

--- a/apps/web/src/pages/Artifact.tsx
+++ b/apps/web/src/pages/Artifact.tsx
@@ -35,15 +35,52 @@ export function Artifact() {
   const [body, setBody] = useState("")
   const [anchor, setAnchor] = useState<{ type?: string; exact: string; prefix?: string; suffix?: string } | null>(null)
 
-  // Selections inside the sandboxed artifact post a quote selector to us.
+  // The anchor channel with the sandboxed iframe (see SELECTION_SCRIPT).
+  const frame = useRef<HTMLIFrameElement>(null)
+  const [frameReady, setFrameReady] = useState(0)
+  const [inDoc, setInDoc] = useState<Record<string, boolean>>({})
+  const [activeThread, setActiveThread] = useState<string | null>(null)
+  const threadEls = useRef(new Map<string, HTMLDivElement>())
+
   useEffect(() => {
     const onMsg = (e: MessageEvent) => {
       const d = e.data
-      if (d && d.source === "dock" && d.type === "select") setAnchor(d.selector ?? null)
+      if (!d || d.source !== "dock") return
+      if (d.type === "select") setAnchor(d.selector ?? null)
+      // which threads' text exists in the shown version (truth for highlights + badges)
+      else if (d.type === "anchors-resolved") setInDoc(d.resolved ?? {})
+      // clicking a highlight in the document focuses its thread
+      else if (d.type === "anchor-click") {
+        setActiveThread(d.id)
+        threadEls.current.get(d.id)?.scrollIntoView({ behavior: "smooth", block: "center" })
+      }
     }
     window.addEventListener("message", onMsg)
     return () => window.removeEventListener("message", onMsg)
   }, [])
+
+  // Paint highlights for open, anchored threads whenever the doc or comments change.
+  const sendAnchors = useCallback(() => {
+    const w = frame.current?.contentWindow
+    if (!w) return
+    const anchors = groupThreads(comments)
+      .filter((t) => t[0].state === "open")
+      .map((t) => ({ id: t[0].thread_id, sel: parseAnchor(t[0].anchor) }))
+      .filter((x): x is { id: string; sel: NonNullable<ReturnType<typeof parseAnchor>> } => !!x.sel)
+      .map((x) => ({ id: x.id, exact: x.sel.exact, prefix: x.sel.prefix, suffix: x.sel.suffix }))
+    w.postMessage({ source: "dock-host", type: "anchors", anchors }, "*")
+  }, [comments])
+  useEffect(() => {
+    sendAnchors()
+  }, [sendAnchors, frameReady])
+
+  useEffect(() => setActiveThread(null), [shortId, version])
+
+  // Clicking a thread's quote scrolls the document to its highlight.
+  const jumpTo = (threadId: string) => {
+    setActiveThread(threadId)
+    frame.current?.contentWindow?.postMessage({ source: "dock-host", type: "focus-anchor", id: threadId }, "*")
+  }
 
   useEffect(() => {
     if (!loading && !me) nav({ to: "/login" })
@@ -214,6 +251,8 @@ export function Artifact() {
                 <DiffView diff={diff} />
               ) : (
                 <iframe
+                  ref={frame}
+                  onLoad={() => setFrameReady((n) => n + 1)}
                   title={art.title ?? shortId}
                   src={rawSrc}
                   sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
@@ -233,7 +272,21 @@ export function Artifact() {
             {threads.length === 0 ? (
               <div className="muted" style={{ textAlign: "center", fontSize: 12, padding: "26px 12px" }}>No comments yet.</div>
             ) : (
-              threads.map((t) => <Thread key={t[0].thread_id} thread={t} onReply={addComment} onResolve={toggleResolve} />)
+              threads.map((t) => (
+                <Thread
+                  key={t[0].thread_id}
+                  thread={t}
+                  onReply={addComment}
+                  onResolve={toggleResolve}
+                  active={activeThread === t[0].thread_id}
+                  inDoc={inDoc[t[0].thread_id]}
+                  onJump={() => jumpTo(t[0].thread_id)}
+                  refEl={(el) => {
+                    if (el) threadEls.current.set(t[0].thread_id, el)
+                    else threadEls.current.delete(t[0].thread_id)
+                  }}
+                />
+              ))
             )}
           </div>
           <div style={{ borderTop: "1px solid var(--line-soft)", padding: 11 }}>
@@ -253,12 +306,62 @@ export function Artifact() {
   )
 }
 
-function Thread({ thread, onReply, onResolve }: { thread: Comment[]; onReply: (t: string, tid: string) => void; onResolve: (c: Comment) => void }) {
+function Thread({
+  thread,
+  onReply,
+  onResolve,
+  active,
+  inDoc,
+  onJump,
+  refEl,
+}: {
+  thread: Comment[]
+  onReply: (t: string, tid: string) => void
+  onResolve: (c: Comment) => void
+  active?: boolean
+  /** Whether the anchored text exists in the version being shown (from the iframe). */
+  inDoc?: boolean
+  onJump?: () => void
+  refEl?: (el: HTMLDivElement | null) => void
+}) {
   const [reply, setReply] = useState("")
   const root = thread[0]
   const resolved = root.state === "resolved"
+  const quote = anchorExact(root.anchor)
+  // The iframe's answer is the truth for the shown version; the server flag
+  // (computed against the latest version) is the fallback before it arrives.
+  const textPresent = inDoc !== undefined ? inDoc : root.anchored !== false
   return (
-    <div className="card" style={{ marginBottom: 11, overflow: "hidden", opacity: resolved ? 0.62 : 1 }}>
+    <div
+      ref={refEl}
+      className="card"
+      style={{
+        marginBottom: 11,
+        overflow: "hidden",
+        opacity: resolved ? 0.62 : 1,
+        scrollMarginTop: 12,
+        outline: active ? "2px solid var(--ac)" : undefined,
+        outlineOffset: 1,
+        transition: "outline-color .2s",
+      }}
+    >
+      {quote &&
+        (textPresent && !resolved ? (
+          <button
+            onClick={onJump}
+            title="Jump to the highlighted text"
+            style={{ display: "block", width: "100%", textAlign: "left", border: 0, borderLeft: "3px solid var(--ac)", background: "var(--ac-soft)", color: "var(--fg)", padding: "6px 10px", fontSize: 11.5, lineHeight: 1.4, cursor: "pointer", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", fontStyle: "italic" }}
+          >
+            “{quote}”
+          </button>
+        ) : (
+          <div
+            title="The text this comment was attached to was edited or removed in this version"
+            style={{ borderLeft: "3px solid var(--line)", background: "var(--card-2)", color: "var(--fg-mut)", padding: "6px 10px", fontSize: 11.5, lineHeight: 1.4, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", fontStyle: "italic" }}
+          >
+            “{quote}”
+          </div>
+        ))}
       {thread.map((c) => (
         <div key={c.id} style={{ padding: "10px 12px", borderBottom: "1px solid var(--line-soft)" }}>
           <div style={{ display: "flex", alignItems: "center", gap: 7, fontSize: 11, fontWeight: 700, color: "var(--cmt-tx)", marginBottom: 4 }}>
@@ -266,13 +369,8 @@ function Thread({ thread, onReply, onResolve }: { thread: Comment[]; onReply: (t
               {(c.author || "?").slice(0, 2).toUpperCase()}
             </span>
             {c.author}
-            <span className="mono muted" style={{ marginLeft: "auto", fontWeight: 400, fontSize: 9 }}>base v{c.base_version}</span>
+            <span className="mono muted" style={{ marginLeft: "auto", fontWeight: 400, fontSize: 9 }}>on v{c.base_version}</span>
           </div>
-          {anchorExact(c.anchor) && (
-            <div className="mono" style={{ fontSize: 9.5, color: "var(--cmt-tx)", background: "var(--card-2)", borderRadius: 5, padding: "2px 6px", display: "inline-block", marginBottom: 5, maxWidth: "100%", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-              “{anchorExact(c.anchor)}”
-            </div>
-          )}
           <p style={{ margin: 0, fontSize: 12.5, lineHeight: 1.45, whiteSpace: "pre-wrap" }}>{c.body_md}</p>
         </div>
       ))}
@@ -280,9 +378,9 @@ function Thread({ thread, onReply, onResolve }: { thread: Comment[]; onReply: (t
         <span className="mono" style={{ fontSize: 9.5, fontWeight: 700, padding: "2px 8px", borderRadius: 999, background: resolved ? "var(--good-bg)" : "var(--ac-soft)", color: resolved ? "var(--good)" : "var(--ac)" }}>
           {resolved ? "resolved" : "open"}
         </span>
-        {root.anchored === false && (
-          <span className="mono" title="The anchored text changed in a newer version" style={{ fontSize: 9.5, fontWeight: 700, padding: "2px 8px", borderRadius: 999, background: "var(--cmt-bg)", color: "var(--cmt-tx)" }}>
-            orphaned
+        {quote && !textPresent && !resolved && (
+          <span className="mono" title="The text this comment was attached to was edited or removed in this version" style={{ fontSize: 9.5, fontWeight: 700, padding: "2px 8px", borderRadius: 999, background: "var(--cmt-bg)", color: "var(--cmt-tx)" }}>
+            text changed
           </span>
         )}
         <button className="btn sm" style={{ marginLeft: "auto" }} onClick={() => onResolve(root)}>
@@ -519,14 +617,17 @@ function DiffView({ diff }: { diff: Diff | null }) {
   )
 }
 
-function anchorExact(a: string | null): string | null {
+function parseAnchor(a: string | null): { exact: string; prefix?: string; suffix?: string } | null {
   if (!a) return null
   try {
-    return (JSON.parse(a) as { exact?: string }).exact ?? null
+    const s = JSON.parse(a) as { exact?: string; prefix?: string; suffix?: string }
+    return s.exact ? { exact: s.exact, prefix: s.prefix, suffix: s.suffix } : null
   } catch {
     return null
   }
 }
+
+const anchorExact = (a: string | null): string | null => parseAnchor(a)?.exact ?? null
 
 function groupThreads(comments: Comment[]): Comment[][] {
   const map = new Map<string, Comment[]>()

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -40,15 +40,104 @@ export function reanchor(sel: QuoteSelector, text: string): Reanchor {
 }
 
 /**
- * Injected into served artifacts. On text selection it posts a quote selector
- * to the parent window — the only way to anchor across a sandboxed iframe.
+ * The comment-anchor client that runs inside the sandboxed artifact iframe.
+ * The frame has an opaque origin, so everything rides postMessage:
+ *
+ *  frame → host:  select            (user selected text — a quote selector)
+ *                 anchors-resolved  (which anchor ids matched this document)
+ *                 anchor-click      (user clicked a highlight)
+ *  host → frame:  anchors           (paint highlights for these anchors)
+ *                 focus-anchor      (scroll to + flash one anchor)
+ *
+ * Served at /raw/dock-client.js with a SHORT cache and referenced by URL from
+ * artifact HTML — the HTML itself is cached immutable, so baking the client
+ * inline would freeze old behavior into every previously-viewed artifact.
  */
-export const SELECTION_SCRIPT = `<script>(function(){document.addEventListener("mouseup",function(){
-var s=window.getSelection(),t=s?s.toString().trim():"";
-if(!t||t.length<2){parent.postMessage({source:"dock",type:"select",selector:null},"*");return}
-var ctx=(s.anchorNode&&s.anchorNode.textContent)||t,i=ctx.indexOf(t);
-parent.postMessage({source:"dock",type:"select",selector:{type:"TextQuoteSelector",exact:t,
-prefix:i>=0?ctx.slice(Math.max(0,i-24),i):"",suffix:i>=0?ctx.slice(i+t.length,i+t.length+24):""}},"*")})})();</script>`
+export const ANCHOR_CLIENT_JS = `(function(){
+function post(m){m.source="dock";parent.postMessage(m,"*")}
+
+/* -- selection capture: a text selection becomes a TextQuoteSelector -- */
+document.addEventListener("mouseup",function(){
+  var s=window.getSelection(),t=s?s.toString().trim():"";
+  if(!t||t.length<2){post({type:"select",selector:null});return}
+  var ctx=(s.anchorNode&&s.anchorNode.textContent)||t,i=ctx.indexOf(t);
+  post({type:"select",selector:{type:"TextQuoteSelector",exact:t,
+    prefix:i>=0?ctx.slice(Math.max(0,i-24),i):"",
+    suffix:i>=0?ctx.slice(i+t.length,i+t.length+24):""}})
+});
+
+/* -- highlight styles (mark's default yellow is overridden) -- */
+var st=document.createElement("style");
+st.textContent="mark.dock-hl{background:rgba(124,108,189,.26);color:inherit;border-bottom:2px solid rgba(124,108,189,.7);border-radius:2px;cursor:pointer;transition:background .15s}"+
+"mark.dock-hl:hover{background:rgba(124,108,189,.45)}"+
+"mark.dock-hl-flash{animation:dockflash 1s ease 2}"+
+"@keyframes dockflash{50%{background:rgba(124,108,189,.75)}}";
+(document.head||document.documentElement).appendChild(st);
+
+function textNodes(){
+  var w=document.createTreeWalker(document.body,NodeFilter.SHOW_TEXT,{acceptNode:function(n){
+    var p=n.parentNode?n.parentNode.nodeName:"";
+    return p==="SCRIPT"||p==="STYLE"||p==="NOSCRIPT"?NodeFilter.FILTER_REJECT:NodeFilter.FILTER_ACCEPT}});
+  var out=[],n;while((n=w.nextNode()))out.push(n);return out}
+function clearMarks(){
+  var ms=document.querySelectorAll("mark[data-dock-id]");
+  for(var i=0;i<ms.length;i++){var m=ms[i],p=m.parentNode;
+    while(m.firstChild)p.insertBefore(m.firstChild,m);
+    p.removeChild(m);p.normalize()}}
+/* same resolution order as the server: context match first, then exact */
+function find(full,a){
+  var pre=a.prefix||"",suf=a.suffix||"",ctx=pre+a.exact+suf;
+  if(ctx!==a.exact){var i=full.indexOf(ctx);if(i>=0)return i+pre.length}
+  return full.indexOf(a.exact)}
+/* wrap [s,e) of the concatenated text in marks; reverse order keeps offsets valid */
+function wrap(id,s,e){
+  var nodes=textNodes(),offs=[],full="";
+  for(var i=0;i<nodes.length;i++){offs.push(full.length);full+=nodes[i].nodeValue}
+  var segs=[];
+  for(var i=0;i<nodes.length;i++){
+    var ns=offs[i],ne=ns+nodes[i].nodeValue.length;
+    if(ne<=s||ns>=e)continue;
+    segs.push({n:nodes[i],a:Math.max(0,s-ns),b:Math.min(nodes[i].nodeValue.length,e-ns)})}
+  for(var q=segs.length-1;q>=0;q--){
+    var g=segs[q],t=g.n;
+    if(g.b<t.nodeValue.length)t.splitText(g.b);
+    var mid=g.a>0?t.splitText(g.a):t;
+    var mk=document.createElement("mark");
+    mk.setAttribute("data-dock-id",id);mk.className="dock-hl";mk.title="View comment";
+    t.parentNode.insertBefore(mk,mid);mk.appendChild(mid)}}
+function applyAnchors(anchors){
+  clearMarks();
+  var res={};
+  for(var k=0;k<anchors.length;k++){
+    var a=anchors[k];
+    /* recompute the text walk per anchor — earlier wraps split text nodes */
+    var nodes=textNodes(),full="";
+    for(var i=0;i<nodes.length;i++)full+=nodes[i].nodeValue;
+    var s=find(full,a);
+    res[a.id]=s>=0;
+    if(s>=0)wrap(a.id,s,s+a.exact.length)}
+  post({type:"anchors-resolved",resolved:res})}
+
+/* clicking a highlight focuses its thread in the host */
+document.addEventListener("click",function(e){
+  var el=e.target,m=el&&el.closest?el.closest("mark[data-dock-id]"):null;
+  if(m)post({type:"anchor-click",id:m.getAttribute("data-dock-id")})
+},true);
+
+window.addEventListener("message",function(e){
+  var d=e.data;
+  if(!d||d.source!=="dock-host")return;
+  if(d.type==="anchors")applyAnchors(d.anchors||[]);
+  else if(d.type==="focus-anchor"){
+    var ms=document.querySelectorAll('mark[data-dock-id="'+d.id+'"]');
+    if(!ms.length)return;
+    ms[0].scrollIntoView({behavior:"smooth",block:"center"});
+    for(var i=0;i<ms.length;i++){ms[i].classList.remove("dock-hl-flash");void ms[i].offsetWidth;ms[i].classList.add("dock-hl-flash")}}
+});
+})();`
+
+/** The tag appended to served artifact HTML; resolves on any host. */
+export const SELECTION_SCRIPT = `<script src="/raw/dock-client.js"></script>`
 
 /** True if the comment's stored anchor still resolves in `text`. */
 export function isAnchored(anchorJson: string | null, text: string): boolean {


### PR DESCRIPTION
Off current `main` (everything merged). No stack.

## The problem

Anchored comments stored a quote selector, but nothing showed **where** a comment lived in the document. And "orphaned" was both hostile language and frequently **wrong**: the server compared rendered-text quotes against raw source, so a selection spanning bold text in HTML/markdown false-flagged as orphaned (the exact case in the bug report screenshot).

## What changed

**Comments are sticky now.**
- The injected client resolves each open thread's quote selector **inside the sandboxed iframe** (context match → exact match, same order as the server) and paints highlight marks on the text. The iframe's answer is the truth for the version being shown — a v1 comment highlights on v2 when its text survives, and the false-orphan bug class is gone.
- **Two-way jump** over postMessage: click a highlight → its thread focuses in the sidebar (accent ring + scroll). Click a thread's quote bar → the document scrolls there and the text flashes. Resolve clears the highlight; reopen repaints it.
- **Every artifact kind**: bundle pages get the anchor client too (previously only file artifacts).

**The client is a served standard, not baked HTML.** Artifact HTML is cached immutable, so an inline script freezes old behavior into every previously-viewed artifact forever. The client now ships at `/raw/dock-client.js` (5-min cache) and is referenced by URL — it can evolve independently of published content. This is the first piece of the "content standards" story (`dock init`, md/html conventions) — logged in the plan.

**Language.** "orphaned" is gone. Threads lead with a clickable quote bar (accent border). When the text no longer exists in the shown version, the bar mutes and a small **"text changed"** pill explains why. "base vN" now reads "on vN".

## Verification

Browser-driven on the exact artifact from the bug report: highlight painted, v1→v2 re-anchor across a republish, the false-"orphaned" badge cleared, click-highlight → thread ring, quote-click → scroll+flash, resolve clears, reopen repaints. `pnpm typecheck` clean, **50 tests** green, build + prerender pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)