### PR TITLE
Webhooks + Slack notifications, on a proper-drizzle data layer

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+dedupe-peer-dependents=true

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,7 +1,9 @@
+import { randomUUID } from "node:crypto"
 import { Hono, type Context } from "hono"
 import { getCookie, setCookie } from "hono/cookie"
 import { streamSSE } from "hono/streaming"
 import { Presence, createBus } from "./bus"
+import { WEBHOOK_EVENTS, type WebhookEvent, enqueueForEvent } from "./webhooks"
 import type { Auth } from "./auth-config"
 import {
   ANCHOR_CLIENT_JS,
@@ -90,6 +92,11 @@ export function createApp(deps: AppDeps): Hono {
   // OPTIONS preflights are answered here. Same-origin/self-host = no-op.
   const analyticsOn = deps.analytics !== false
   const allowOrigins = new Set(deps.webOrigins ?? [])
+
+  // Fan an event to subscribed webhooks (enqueues to the outbox; the worker
+  // delivers). Awaited so the row is durable before we respond, but never fatal.
+  const notify = (a: ArtifactRecord, event: WebhookEvent, data: Record<string, unknown>) =>
+    enqueueForEvent(meta, deps.baseUrl, a, event, data).catch(() => {})
   if (allowOrigins.size) {
     app.use("/api/*", corsFor(allowOrigins))
     app.use("/v1/*", corsFor(allowOrigins))
@@ -188,6 +195,11 @@ export function createApp(deps: AppDeps): Hono {
         type: "version.published",
         n: version.n,
         message: version.message,
+      })
+      await notify(artifact, "version.published", {
+        version: version.n,
+        message: version.message,
+        author: version.author,
       })
       // Republish can resolve comment threads in the same call.
       const resolves = body["resolves"]
@@ -315,6 +327,12 @@ export function createApp(deps: AppDeps): Hono {
       author,
     })
     bus.publish(artifact.id, { type: "comment.created", comment: created })
+    await notify(artifact, "comment.created", {
+      author: created.author,
+      body: created.body_md,
+      quote: quoteOf(created.anchor),
+      thread_id: created.thread_id,
+    })
     return c.json(created, 201)
   })
 
@@ -346,6 +364,7 @@ export function createApp(deps: AppDeps): Hono {
     const state = body.state === "open" ? "open" : "resolved"
     const updated = await meta.setThreadState(artifact.id, cm.thread_id, state)
     bus.publish(artifact.id, { type: "comment.resolved", thread_id: cm.thread_id, state })
+    await notify(artifact, "comment.resolved", { state, thread_id: cm.thread_id })
     return c.json({ thread_id: cm.thread_id, state, updated })
   })
 
@@ -413,6 +432,89 @@ export function createApp(deps: AppDeps): Hono {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact || !(await readOk(c, artifact))) return c.json({ error: "not found" }, 404)
     return c.json(await meta.viewStats(artifact.id))
+  })
+
+  // ---- Webhooks (notifications: Slack + arbitrary endpoints) -------------
+
+  const publicWebhook = (w: { secret: string }) => ({ ...w, secret: undefined })
+
+  app.get("/v1/webhooks", async (c) => {
+    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
+    const hooks = await meta.listWebhooks()
+    return c.json({ webhooks: hooks.map(publicWebhook) })
+  })
+
+  app.post("/v1/webhooks", async (c) => {
+    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
+    const b = (await c.req.json().catch(() => ({}))) as Record<string, unknown>
+    if (typeof b.url !== "string" || !/^https?:\/\//.test(b.url))
+      return c.json({ error: "a valid http(s) url is required" }, 400)
+    const kind = b.kind === "slack" ? "slack" : "generic"
+    // events: array or "*"; validate against the known set
+    const events =
+      Array.isArray(b.events) && b.events.length
+        ? b.events.filter((e): e is WebhookEvent => (WEBHOOK_EVENTS as readonly string[]).includes(e as string)).join(",")
+        : "*"
+    let artifactRef: string | null = null
+    if (typeof b.artifact === "string" && b.artifact) {
+      const a = await meta.getByShortId(b.artifact)
+      if (!a) return c.json({ error: "artifact not found" }, 404)
+      artifactRef = a.id
+    }
+    const created = await meta.createWebhook({
+      id: `wh_${randomUUID().slice(0, 12)}`,
+      artifact_id: artifactRef,
+      url: b.url,
+      secret: typeof b.secret === "string" && b.secret ? b.secret : randomUUID().replace(/-/g, ""),
+      kind,
+      events,
+      label: typeof b.label === "string" ? b.label : null,
+    })
+    return c.json(publicWebhook(created), 201)
+  })
+
+  app.delete("/v1/webhooks/:id", async (c) => {
+    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
+    await meta.deleteWebhook(c.req.param("id"))
+    return c.body(null, 204)
+  })
+
+  app.get("/v1/webhooks/:id/deliveries", async (c) => {
+    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
+    const rows = await meta.recentDeliveries(c.req.param("id"), 20)
+    return c.json({
+      deliveries: rows.map((d) => ({
+        id: d.id,
+        event_type: d.event_type,
+        status: d.status,
+        attempts: d.attempts,
+        last_error: d.last_error,
+        created_at: d.created_at,
+      })),
+    })
+  })
+
+  // Send a sample event to a webhook so you can confirm it lands.
+  app.post("/v1/webhooks/:id/test", async (c) => {
+    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
+    const w = await meta.getWebhook(c.req.param("id"))
+    if (!w) return c.json({ error: "not found" }, 404)
+    const sample = JSON.stringify({
+      event: "version.published",
+      at: new Date().toISOString(),
+      artifact: { short_id: "sample00", title: "Test artifact", url: `${deps.baseUrl}/a/sample00` },
+      data: { version: 1, message: "test delivery from Dock", author: "dock" },
+    })
+    await meta.enqueueDelivery({
+      id: `wd_${randomUUID().slice(0, 12)}`,
+      webhook_id: w.id,
+      url: w.url,
+      secret: w.secret,
+      kind: w.kind,
+      event_type: "version.published",
+      payload: sample,
+    })
+    return c.json({ queued: true })
   })
 
   // ---- Viewer ------------------------------------------------------------
@@ -526,6 +628,16 @@ const corsFor = (allowed: Set<string>) => async (c: Context, next: () => Promise
     c.res.headers.set("Access-Control-Allow-Origin", origin)
     c.res.headers.set("Access-Control-Allow-Credentials", "true")
     c.res.headers.append("Vary", "Origin")
+  }
+}
+
+/** The quoted text from a comment anchor, for webhook payloads. */
+const quoteOf = (anchor: string | null): string | null => {
+  if (!anchor) return null
+  try {
+    return (JSON.parse(anchor) as { exact?: string }).exact ?? null
+  } catch {
+    return null
   }
 }
 

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -10,6 +10,7 @@ import { FsBlobStore } from "@dock/storage/fs"
 import { s3FromUrl } from "@dock/storage/s3"
 import { createApp } from "./app"
 import { makeAuth, migrateAuth, type AuthDb } from "./auth-config"
+import { startWebhookWorker } from "./webhooks"
 
 const PORT = Number(process.env.PORT ?? 8080)
 const DATA_DIR = process.env.DATA_DIR ?? "./data"
@@ -51,6 +52,9 @@ const app = createApp({
   webOrigins,
   analytics: process.env.DOCK_ANALYTICS !== "false",
 })
+
+// The webhook outbox worker delivers queued events with retries + backoff.
+startWebhookWorker(meta)
 
 const blobDesc = process.env.OBJECT_STORE_URL ? "S3/R2" : `local disk (${DATA_DIR})`
 const metaDesc = DATABASE_URL ? "postgres" : `sqlite (${DATA_DIR})`

--- a/apps/api/src/webhooks.ts
+++ b/apps/api/src/webhooks.ts
@@ -1,0 +1,152 @@
+import { createHmac, randomUUID } from "node:crypto"
+import type { ArtifactRecord, DeliveryRecord, MetaStore } from "@dock/core"
+
+/** Event names webhooks can subscribe to. */
+export const WEBHOOK_EVENTS = ["comment.created", "comment.resolved", "version.published"] as const
+export type WebhookEvent = (typeof WEBHOOK_EVENTS)[number]
+
+const MAX_ATTEMPTS = 6
+const BASE_BACKOFF_MS = 3_000
+const MAX_BACKOFF_MS = 60 * 60_000
+
+/** Normalized payload stored in the outbox (canonical, re-deliverable). */
+export interface EventPayload {
+  event: WebhookEvent
+  at: string
+  artifact: { short_id: string; title: string | null; url: string }
+  data: Record<string, unknown>
+}
+
+export function buildPayload(
+  baseUrl: string,
+  artifact: ArtifactRecord,
+  event: WebhookEvent,
+  data: Record<string, unknown>,
+): EventPayload {
+  return {
+    event,
+    at: new Date().toISOString(),
+    artifact: {
+      short_id: artifact.short_id,
+      title: artifact.title,
+      url: `${baseUrl}/a/${artifact.short_id}`,
+    },
+    data,
+  }
+}
+
+const truncate = (s: string, n: number) => (s.length > n ? `${s.slice(0, n - 1)}…` : s)
+
+/** Format a normalized payload as a Slack incoming-webhook message. */
+export function slackMessage(p: EventPayload): unknown {
+  const title = p.artifact.title ?? p.artifact.short_id
+  const link = `<${p.artifact.url}|${title}>`
+  let head = ""
+  const lines: string[] = []
+  if (p.event === "comment.created") {
+    const author = String(p.data.author ?? "someone")
+    head = `:speech_balloon: *${author}* commented on ${link}`
+    if (p.data.quote) lines.push(`> _${truncate(String(p.data.quote), 140)}_`)
+    if (p.data.body) lines.push(truncate(String(p.data.body), 280))
+  } else if (p.event === "comment.resolved") {
+    head = `:white_check_mark: A thread was ${p.data.state === "open" ? "reopened" : "resolved"} on ${link}`
+  } else {
+    head = `:package: ${link} — *v${p.data.version}* published`
+    if (p.data.message) lines.push(truncate(String(p.data.message), 200))
+    if (p.data.author) lines.push(`by ${p.data.author}`)
+  }
+  return {
+    text: head,
+    blocks: [
+      { type: "section", text: { type: "mrkdwn", text: [head, ...lines].join("\n") } },
+      { type: "context", elements: [{ type: "mrkdwn", text: `Dock · ${p.event}` }] },
+    ],
+  }
+}
+
+/** HMAC-SHA256 of the request body, hex. Header: X-Dock-Signature: sha256=… */
+export function sign(secret: string, body: string): string {
+  return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`
+}
+
+/** Deliver one outbox row. Slack kind sends a Slack message; generic sends the
+ *  signed normalized payload. Returns ok + a short status for the delivery log. */
+export async function deliverOnce(d: DeliveryRecord): Promise<{ ok: boolean; status: string }> {
+  try {
+    const payload = JSON.parse(d.payload) as EventPayload
+    const isSlack = d.kind === "slack"
+    const body = JSON.stringify(isSlack ? slackMessage(payload) : payload)
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      "user-agent": "dock-webhooks/1",
+      "x-dock-event": d.event_type,
+    }
+    if (!isSlack) headers["x-dock-signature"] = sign(d.secret, body)
+    const res = await fetch(d.url, { method: "POST", headers, body })
+    if (res.ok) return { ok: true, status: String(res.status) }
+    return { ok: false, status: `HTTP ${res.status}` }
+  } catch (err) {
+    return { ok: false, status: (err as Error).message.slice(0, 200) }
+  }
+}
+
+/** Find webhooks subscribed to this event for the artifact and enqueue a row each. */
+export async function enqueueForEvent(
+  meta: MetaStore,
+  baseUrl: string,
+  artifact: ArtifactRecord,
+  event: WebhookEvent,
+  data: Record<string, unknown>,
+): Promise<void> {
+  const hooks = await meta.activeWebhooks(artifact.id)
+  if (hooks.length === 0) return
+  const subscribed = hooks.filter((h) => h.events === "*" || h.events.split(",").includes(event))
+  if (subscribed.length === 0) return
+  const payload = JSON.stringify(buildPayload(baseUrl, artifact, event, data))
+  await Promise.all(
+    subscribed.map((h) =>
+      meta.enqueueDelivery({
+        id: `wd_${randomUUID().slice(0, 12)}`,
+        webhook_id: h.id,
+        url: h.url,
+        secret: h.secret,
+        kind: h.kind,
+        event_type: event,
+        payload,
+      }),
+    ),
+  )
+}
+
+const backoff = (attempts: number) =>
+  Math.min(MAX_BACKOFF_MS, BASE_BACKOFF_MS * 2 ** attempts)
+
+/** The outbox worker: claim due deliveries, deliver, retry with backoff, dead-letter. */
+export function startWebhookWorker(meta: MetaStore, intervalMs = 1500): () => void {
+  let stopped = false
+  const tick = async () => {
+    if (stopped) return
+    try {
+      const due = await meta.claimDueDeliveries(new Date().toISOString(), 20)
+      for (const d of due) {
+        const r = await deliverOnce(d)
+        const attempts = d.attempts + 1
+        if (r.ok) {
+          await meta.updateDelivery(d.id, { status: "delivered", attempts, last_error: null, next_attempt_at: d.next_attempt_at })
+        } else if (attempts >= MAX_ATTEMPTS) {
+          await meta.updateDelivery(d.id, { status: "dead", attempts, last_error: r.status, next_attempt_at: d.next_attempt_at })
+        } else {
+          const next = new Date(Date.now() + backoff(attempts)).toISOString()
+          await meta.updateDelivery(d.id, { status: "pending", attempts, last_error: r.status, next_attempt_at: next })
+        }
+      }
+    } catch {
+      /* a bad tick shouldn't kill the loop */
+    }
+  }
+  const timer = setInterval(tick, intervalMs)
+  return () => {
+    stopped = true
+    clearInterval(timer)
+  }
+}

--- a/apps/api/test/webhooks.test.ts
+++ b/apps/api/test/webhooks.test.ts
@@ -1,0 +1,80 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll, describe, expect, it } from "vitest"
+import { SqliteMetaStore } from "@dock/db/sqlite"
+import { FsBlobStore } from "@dock/storage/fs"
+import { createApp } from "../src/app"
+import { buildPayload, sign, slackMessage } from "../src/webhooks"
+import type { ArtifactRecord } from "@dock/core"
+
+const sampleArtifact = {
+  id: "a1",
+  short_id: "sample00",
+  title: "Spec",
+} as ArtifactRecord
+
+describe("webhook formatting + signing", () => {
+  it("signs the body with HMAC-SHA256 and a stable header shape", () => {
+    const s = sign("secret", '{"a":1}')
+    expect(s).toMatch(/^sha256=[0-9a-f]{64}$/)
+    expect(sign("secret", '{"a":1}')).toBe(s) // deterministic
+    expect(sign("other", '{"a":1}')).not.toBe(s) // key matters
+  })
+
+  it("builds a normalized payload", () => {
+    const p = buildPayload("http://h", sampleArtifact, "comment.created", { author: "ann" })
+    expect(p.event).toBe("comment.created")
+    expect(p.artifact).toEqual({ short_id: "sample00", title: "Spec", url: "http://h/a/sample00" })
+    expect(p.data.author).toBe("ann")
+  })
+
+  it("formats Slack messages per event type", () => {
+    const comment = slackMessage(buildPayload("http://h", sampleArtifact, "comment.created", { author: "ann", body: "nice" })) as { text: string }
+    expect(comment.text).toContain(":speech_balloon:")
+    expect(comment.text).toContain("ann")
+    const published = slackMessage(buildPayload("http://h", sampleArtifact, "version.published", { version: 3 })) as { text: string }
+    expect(published.text).toContain(":package:")
+    expect(published.text).toContain("v3")
+  })
+})
+
+const dir = mkdtempSync(join(tmpdir(), "dock-wh-"))
+const meta = new SqliteMetaStore(join(dir, "dock.db"))
+const app = createApp({ meta, blobs: new FsBlobStore(join(dir, "blobs")), baseUrl: "http://dock.test" })
+afterAll(() => {
+  meta.close()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe("webhook outbox", () => {
+  it("enqueues a delivery when a subscribed event fires", async () => {
+    await app.request("/v1/webhooks", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ url: "http://example.com/hook", kind: "generic", secret: "s", events: ["version.published"] }),
+    })
+
+    // each publish (the new artifact + the republish) fires version.published
+    const form = new FormData()
+    form.append("file", new Blob([new TextEncoder().encode("# a")]), "a.md")
+    const { short_id } = await (await app.request("/v1/artifacts", { method: "POST", body: form })).json()
+    const f2 = new FormData()
+    f2.append("file", new Blob([new TextEncoder().encode("# a2")]), "a.md")
+    f2.append("message", "v2")
+    await app.request(`/v1/artifacts/${short_id}/versions`, { method: "POST", body: f2 })
+
+    const due = await meta.claimDueDeliveries(new Date(Date.now() + 1000).toISOString(), 10)
+    const forThis = due.filter((d) => JSON.parse(d.payload).artifact.short_id === short_id)
+    expect(forThis.length).toBe(2)
+    expect(forThis.every((d) => d.event_type === "version.published")).toBe(true)
+    expect(forThis[0].url).toBe("http://example.com/hook")
+    expect(JSON.parse(forThis[1].payload).data.version).toBe(2)
+  })
+
+  it("hides the secret in the API response", async () => {
+    const list = await (await app.request("/v1/webhooks")).json()
+    expect(list.webhooks.length).toBeGreaterThan(0)
+    expect(list.webhooks[0].secret).toBeUndefined()
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -33,6 +33,24 @@ export interface Comment {
   created_at: string
   anchored?: boolean
 }
+export interface Webhook {
+  id: string
+  artifact_id: string | null
+  url: string
+  kind: "generic" | "slack"
+  events: string
+  label: string | null
+  active: 0 | 1
+  created_at: string
+}
+export interface Delivery {
+  id: string
+  event_type: string
+  status: "pending" | "delivered" | "dead"
+  attempts: number
+  last_error: string | null
+  created_at: string
+}
 export interface DiffOp {
   t: "ctx" | "add" | "del"
   line: string
@@ -89,6 +107,20 @@ export const api = {
     f(`/v1/artifacts/${id}/diff?from=${from}&to=${to}&format=json`, opts()).then(j),
   heartbeat: (id: string, name: string): Promise<{ viewers: string[] }> =>
     f(`/v1/artifacts/${id}/presence`, opts({ name })).then(j),
+
+  listWebhooks: (): Promise<{ webhooks: Webhook[] }> => f("/v1/webhooks", opts()).then(j),
+  createWebhook: (body: {
+    url: string
+    kind: "generic" | "slack"
+    events?: string[]
+    label?: string
+    artifact?: string
+  }): Promise<Webhook> => f("/v1/webhooks", opts(body)).then(j),
+  deleteWebhook: (id: string): Promise<void> =>
+    f(`/v1/webhooks/${id}`, { method: "DELETE", credentials: "include" }).then(() => undefined),
+  testWebhook: (id: string): Promise<unknown> => f(`/v1/webhooks/${id}/test`, opts({})).then(j),
+  webhookDeliveries: (id: string): Promise<{ deliveries: Delivery[] }> =>
+    f(`/v1/webhooks/${id}/deliveries`, opts()).then(j),
   recordView: (id: string, version?: number): Promise<void> =>
     f(`/v1/artifacts/${id}/view`, opts({ version })).then(() => undefined),
   analytics: (id: string): Promise<Analytics> => f(`/v1/artifacts/${id}/analytics`, opts()).then(j),

--- a/apps/web/src/components.tsx
+++ b/apps/web/src/components.tsx
@@ -98,6 +98,9 @@ export function UserMenu() {
             </button>
           ))}
           <div style={{ height: 1, background: "var(--line-soft)", margin: "5px 2px" }} />
+          <button onClick={() => { setOpen(false); nav({ to: "/settings" }) }} style={menuRow}>
+            Settings
+          </button>
           <button
             onClick={async () => {
               await api.logout().catch(() => {})

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from "react"
+import { useNavigate } from "@tanstack/react-router"
+import { api, type Delivery, type Webhook } from "../api"
+import { Header, useToast } from "../components"
+import { useAuth } from "../ctx"
+
+const ALL_EVENTS = ["comment.created", "comment.resolved", "version.published"] as const
+
+export function Settings() {
+  const { me, loading } = useAuth()
+  const nav = useNavigate()
+  const { toast, show } = useToast()
+  const [hooks, setHooks] = useState<Webhook[] | null>(null)
+
+  useEffect(() => {
+    if (!loading && !me) nav({ to: "/login" })
+  }, [loading, me, nav])
+  const load = () => api.listWebhooks().then((r) => setHooks(r.webhooks)).catch(() => setHooks([]))
+  useEffect(() => {
+    if (me) load()
+  }, [me])
+
+  if (!me) return <div className="center"><div className="spin" /></div>
+
+  return (
+    <div style={{ minHeight: "100%" }}>
+      <Header />
+      <main style={{ maxWidth: 760, margin: "0 auto", padding: "26px 22px 60px" }}>
+        <h2 className="display" style={{ fontSize: 22, margin: "0 0 4px" }}>Settings</h2>
+        <p className="muted" style={{ margin: "0 0 26px", fontSize: 14 }}>
+          Notifications and integrations for this workspace.
+        </p>
+
+        <section>
+          <div style={{ display: "flex", alignItems: "baseline", gap: 10, marginBottom: 4 }}>
+            <h3 className="display" style={{ fontSize: 16, margin: 0 }}>Webhooks &amp; Slack</h3>
+            <span className="muted" style={{ fontSize: 13 }}>· {hooks?.length ?? 0}</span>
+          </div>
+          <p className="muted" style={{ fontSize: 13, margin: "0 0 16px" }}>
+            Get a POST (or a Slack message) when a comment is added or resolved, or a new version is
+            published. Generic payloads are signed with <code className="mono">X-Dock-Signature</code>.
+          </p>
+
+          <NewWebhook onCreated={(msg) => { show(msg); load() }} />
+
+          <div style={{ marginTop: 18, display: "flex", flexDirection: "column", gap: 11 }}>
+            {hooks === null ? (
+              <div className="center" style={{ height: 80 }}><div className="spin" /></div>
+            ) : hooks.length === 0 ? (
+              <div className="muted" style={{ textAlign: "center", padding: 28, border: "1px dashed var(--line)", borderRadius: 12, fontSize: 13 }}>
+                No webhooks yet. Add one above.
+              </div>
+            ) : (
+              hooks.map((w) => (
+                <WebhookRow key={w.id} hook={w} onChanged={(m) => { show(m); load() }} onError={show} />
+              ))
+            )}
+          </div>
+        </section>
+      </main>
+      {toast}
+    </div>
+  )
+}
+
+function NewWebhook({ onCreated }: { onCreated: (msg: string) => void }) {
+  const [url, setUrl] = useState("")
+  const [kind, setKind] = useState<"generic" | "slack">("generic")
+  const [events, setEvents] = useState<string[]>([...ALL_EVENTS])
+  const [busy, setBusy] = useState(false)
+  const toggle = (e: string) =>
+    setEvents((cur) => (cur.includes(e) ? cur.filter((x) => x !== e) : [...cur, e]))
+  const add = async () => {
+    if (!/^https?:\/\//.test(url)) return
+    setBusy(true)
+    try {
+      await api.createWebhook({
+        url,
+        kind,
+        events: events.length === ALL_EVENTS.length ? undefined : events,
+      })
+      setUrl("")
+      onCreated("Webhook added")
+    } catch (e) {
+      onCreated((e as Error).message)
+    } finally {
+      setBusy(false)
+    }
+  }
+  return (
+    <div className="card" style={{ padding: 16 }}>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+        <select className="input" value={kind} onChange={(e) => setKind(e.target.value as "generic" | "slack")} style={{ width: 110, padding: "8px 9px" }}>
+          <option value="generic">Webhook</option>
+          <option value="slack">Slack</option>
+        </select>
+        <input
+          className="input"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder={kind === "slack" ? "Slack incoming-webhook URL" : "https://your-endpoint.example.com/hook"}
+          style={{ flex: 1, minWidth: 240 }}
+        />
+        <button className="btn pri" onClick={add} disabled={busy || !/^https?:\/\//.test(url)}>
+          {busy ? "Adding…" : "Add"}
+        </button>
+      </div>
+      <div style={{ display: "flex", gap: 14, marginTop: 11, flexWrap: "wrap" }}>
+        {ALL_EVENTS.map((e) => (
+          <label key={e} className="mono" style={{ fontSize: 11.5, display: "flex", alignItems: "center", gap: 5, color: "var(--fg-mut)", cursor: "pointer" }}>
+            <input type="checkbox" checked={events.includes(e)} onChange={() => toggle(e)} />
+            {e}
+          </label>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function WebhookRow({ hook, onChanged, onError }: { hook: Webhook; onChanged: (m: string) => void; onError: (m: string) => void }) {
+  const [open, setOpen] = useState(false)
+  const [deliveries, setDeliveries] = useState<Delivery[] | null>(null)
+  const showLog = async () => {
+    const next = !open
+    setOpen(next)
+    if (next) api.webhookDeliveries(hook.id).then((r) => setDeliveries(r.deliveries)).catch(() => setDeliveries([]))
+  }
+  const test = async () => {
+    try {
+      await api.testWebhook(hook.id)
+      onChanged("Test event queued")
+      if (open) setTimeout(() => api.webhookDeliveries(hook.id).then((r) => setDeliveries(r.deliveries)), 1500)
+    } catch (e) {
+      onError((e as Error).message)
+    }
+  }
+  const remove = async () => {
+    try {
+      await api.deleteWebhook(hook.id)
+      onChanged("Webhook removed")
+    } catch (e) {
+      onError((e as Error).message)
+    }
+  }
+  return (
+    <div className="card" style={{ overflow: "hidden" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 11, padding: "12px 14px" }}>
+        <span className="mono" style={{ fontSize: 9.5, fontWeight: 700, padding: "2px 8px", borderRadius: 999, background: hook.kind === "slack" ? "var(--ac-soft)" : "var(--card-2)", color: hook.kind === "slack" ? "var(--ac)" : "var(--fg-mut)" }}>
+          {hook.kind === "slack" ? "Slack" : "Webhook"}
+        </span>
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div className="mono" style={{ fontSize: 12, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{hook.url}</div>
+          <div className="mono muted" style={{ fontSize: 10, marginTop: 1 }}>{hook.events === "*" ? "all events" : hook.events.split(",").join(" · ")}</div>
+        </div>
+        <button className="btn sm" onClick={showLog}>{open ? "Hide" : "Log"}</button>
+        <button className="btn sm" onClick={test}>Test</button>
+        <button className="btn sm" onClick={remove} style={{ color: "var(--bad)" }}>Remove</button>
+      </div>
+      {open && (
+        <div style={{ borderTop: "1px solid var(--line-soft)", padding: "8px 14px", background: "var(--card-2)" }}>
+          {deliveries === null ? (
+            <div className="muted" style={{ fontSize: 12 }}>Loading…</div>
+          ) : deliveries.length === 0 ? (
+            <div className="muted" style={{ fontSize: 12 }}>No deliveries yet. Hit Test.</div>
+          ) : (
+            deliveries.map((d) => (
+              <div key={d.id} style={{ display: "flex", alignItems: "center", gap: 9, fontSize: 11.5, padding: "3px 0" }}>
+                <span className="mono" style={{ fontSize: 9.5, fontWeight: 700, padding: "1px 7px", borderRadius: 999, background: d.status === "delivered" ? "var(--good-bg)" : d.status === "dead" ? "var(--cmt-bg)" : "var(--warn-bg, var(--card))", color: d.status === "delivered" ? "var(--good)" : d.status === "dead" ? "var(--bad)" : "var(--fg-mut)" }}>
+                  {d.status}
+                </span>
+                <span className="mono muted">{d.event_type}</span>
+                {d.attempts > 1 && <span className="mono muted">· {d.attempts} tries</span>}
+                {d.last_error && <span className="mono" style={{ color: "var(--bad)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>· {d.last_error}</span>}
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -9,10 +9,16 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ARefRouteImport } from './routes/a.$ref'
 
+const SettingsRoute = SettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
@@ -32,35 +38,46 @@ const ARefRoute = ARefRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/settings': typeof SettingsRoute
   '/a/$ref': typeof ARefRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/settings': typeof SettingsRoute
   '/a/$ref': typeof ARefRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/settings': typeof SettingsRoute
   '/a/$ref': typeof ARefRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/login' | '/a/$ref'
+  fullPaths: '/' | '/login' | '/settings' | '/a/$ref'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/a/$ref'
-  id: '__root__' | '/' | '/login' | '/a/$ref'
+  to: '/' | '/login' | '/settings' | '/a/$ref'
+  id: '__root__' | '/' | '/login' | '/settings' | '/a/$ref'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LoginRoute: typeof LoginRoute
+  SettingsRoute: typeof SettingsRoute
   ARefRoute: typeof ARefRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/login': {
       id: '/login'
       path: '/login'
@@ -88,6 +105,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LoginRoute: LoginRoute,
+  SettingsRoute: SettingsRoute,
   ARefRoute: ARefRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Settings } from "../pages/Settings"
+
+export const Route = createFileRoute("/settings")({
+  component: Settings,
+})

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "pnpm": {
     "onlyBuiltDependencies": ["better-sqlite3"],
     "overrides": {
-      "esbuild": ">=0.25.0"
+      "esbuild": ">=0.25.0",
+      "drizzle-orm": "0.45.2"
     }
   },
   "scripts": {

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -77,6 +77,73 @@ export interface MetaStore {
   viewStats(artifactId: string): Promise<ViewStats>
   /** Total view counts for many artifacts at once (no N+1). */
   viewCounts(artifactIds: string[]): Promise<Record<string, number>>
+
+  // ---- Webhooks + outbox -------------------------------------------------
+  createWebhook(w: NewWebhook): Promise<WebhookRecord>
+  listWebhooks(): Promise<WebhookRecord[]>
+  getWebhook(id: string): Promise<WebhookRecord | null>
+  deleteWebhook(id: string): Promise<void>
+  /** Active webhooks that fire for this artifact (incl. global, artifact_id null). */
+  activeWebhooks(artifactId: string): Promise<WebhookRecord[]>
+  /** Enqueue a delivery into the outbox (target is denormalized for durability). */
+  enqueueDelivery(d: NewDelivery): Promise<void>
+  /** Pending deliveries whose next_attempt_at has passed, oldest first. */
+  claimDueDeliveries(now: string, limit: number): Promise<DeliveryRecord[]>
+  updateDelivery(
+    id: string,
+    fields: { status: DeliveryStatus; attempts: number; last_error: string | null; next_attempt_at: string },
+  ): Promise<void>
+  /** Recent deliveries for a webhook (for the settings log). */
+  recentDeliveries(webhookId: string, limit: number): Promise<DeliveryRecord[]>
+}
+
+export type WebhookKind = "generic" | "slack"
+export type DeliveryStatus = "pending" | "delivered" | "dead"
+
+export interface WebhookRecord {
+  id: string
+  artifact_id: string | null
+  url: string
+  secret: string
+  kind: WebhookKind
+  /** Comma-separated event types this hook fires on, or "*" for all. */
+  events: string
+  label: string | null
+  active: 0 | 1
+  created_at: string
+}
+export interface NewWebhook {
+  id: string
+  artifact_id?: string | null
+  url: string
+  secret: string
+  kind: WebhookKind
+  events: string
+  label?: string | null
+}
+
+export interface DeliveryRecord {
+  id: string
+  webhook_id: string
+  url: string
+  secret: string
+  kind: WebhookKind
+  event_type: string
+  payload: string
+  status: DeliveryStatus
+  attempts: number
+  last_error: string | null
+  next_attempt_at: string
+  created_at: string
+}
+export interface NewDelivery {
+  id: string
+  webhook_id: string
+  url: string
+  secret: string
+  kind: WebhookKind
+  event_type: string
+  payload: string
 }
 
 export interface NewView {

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -1,21 +1,26 @@
 import type { D1Database } from "@cloudflare/workers-types"
-import { and, asc, desc, eq, sql } from "drizzle-orm"
+import { and, asc, desc, eq, isNull, lte, or, sql } from "drizzle-orm"
 import { drizzle, type DrizzleD1Database } from "drizzle-orm/d1"
 import type {
   ArtifactRecord,
   CommentRecord,
   CommentState,
+  DeliveryRecord,
+  DeliveryStatus,
   MetaStore,
   NewArtifact,
   NewComment,
+  NewDelivery,
   NewVersion,
   NewView,
+  NewWebhook,
   VersionRecord,
   ViewStats,
+  WebhookRecord,
 } from "@dock/core"
-import { artifact, comment, version } from "./schema"
+import { artifact, comment, version, webhook, webhookDelivery } from "./schema"
 
-const schema = { artifact, version, comment }
+const schema = { artifact, version, comment, webhook, webhookDelivery }
 const VIEW_WINDOW_MS = 30 * 86400_000
 
 /**
@@ -147,5 +152,53 @@ export class D1MetaStore implements MetaStore {
     const out: Record<string, number> = {}
     for (const r of rows) out[r.artifact_id] = r.c
     return out
+  }
+
+  // ---- Webhooks + outbox -------------------------------------------------
+  async createWebhook(w: NewWebhook): Promise<WebhookRecord> {
+    return this.db.insert(webhook).values(w).returning().get()
+  }
+  listWebhooks(): Promise<WebhookRecord[]> {
+    return this.db.select().from(webhook).orderBy(desc(webhook.created_at)).all()
+  }
+  async getWebhook(id: string): Promise<WebhookRecord | null> {
+    return (await this.db.select().from(webhook).where(eq(webhook.id, id)).get()) ?? null
+  }
+  async deleteWebhook(id: string): Promise<void> {
+    await this.db.delete(webhook).where(eq(webhook.id, id)).run()
+  }
+  activeWebhooks(artifactId: string): Promise<WebhookRecord[]> {
+    return this.db
+      .select()
+      .from(webhook)
+      .where(and(eq(webhook.active, 1), or(isNull(webhook.artifact_id), eq(webhook.artifact_id, artifactId))))
+      .all()
+  }
+  async enqueueDelivery(d: NewDelivery): Promise<void> {
+    await this.db.insert(webhookDelivery).values(d).run()
+  }
+  claimDueDeliveries(now: string, limit: number): Promise<DeliveryRecord[]> {
+    return this.db
+      .select()
+      .from(webhookDelivery)
+      .where(and(eq(webhookDelivery.status, "pending"), lte(webhookDelivery.next_attempt_at, now)))
+      .orderBy(asc(webhookDelivery.next_attempt_at))
+      .limit(limit)
+      .all()
+  }
+  async updateDelivery(
+    id: string,
+    f: { status: DeliveryStatus; attempts: number; last_error: string | null; next_attempt_at: string },
+  ): Promise<void> {
+    await this.db.update(webhookDelivery).set(f).where(eq(webhookDelivery.id, id)).run()
+  }
+  recentDeliveries(webhookId: string, limit: number): Promise<DeliveryRecord[]> {
+    return this.db
+      .select()
+      .from(webhookDelivery)
+      .where(eq(webhookDelivery.webhook_id, webhookId))
+      .orderBy(desc(webhookDelivery.created_at))
+      .limit(limit)
+      .all()
   }
 }

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -1,6 +1,104 @@
-// Postgres schema DDL, applied at boot (idempotent). created_at is an ISO-8601
-// text column so every record shape — and its lexical sort — is identical to the
-// SQLite driver. user/session/account/verification are owned by Better Auth.
+import { integer, pgTable, text } from "drizzle-orm/pg-core"
+import type {
+  ArtifactKind,
+  ArtifactRecord,
+  CommentRecord,
+  CommentState,
+  DeliveryRecord,
+  DeliveryStatus,
+  VersionRecord,
+  Visibility,
+  WebhookKind,
+  WebhookRecord,
+} from "@dock/core"
+
+// Postgres drizzle schema — the query source of truth, dialect-paired with the
+// SQLite defs in schema.ts. created_at is ISO-8601 text so record shapes and
+// lexical sort match the SQLite driver exactly. Client-side timestamp defaults
+// (kept out of the column type) keep inserts optional without sql() fragments.
+const isoNow = () => new Date().toISOString()
+
+export const artifact = pgTable("artifact", {
+  id: text("id").primaryKey(),
+  short_id: text("short_id").notNull().unique(),
+  org_id: text("org_id").notNull().default("local"),
+  slug: text("slug"),
+  title: text("title"),
+  visibility: text("visibility").$type<Visibility>().notNull().default("link"),
+  kind: text("kind").$type<ArtifactKind>().notNull(),
+  spa: integer("spa").$type<0 | 1>().notNull().default(0),
+  current_version: integer("current_version").notNull().default(0),
+  created_at: text("created_at").notNull().$defaultFn(isoNow),
+})
+
+export const version = pgTable("version", {
+  id: text("id").primaryKey(),
+  artifact_id: text("artifact_id")
+    .notNull()
+    .references(() => artifact.id),
+  n: integer("n").notNull(),
+  blob_key: text("blob_key").notNull(),
+  content_type: text("content_type").notNull(),
+  author: text("author").notNull(),
+  message: text("message"),
+  created_at: text("created_at").notNull().$defaultFn(isoNow),
+})
+
+export const comment = pgTable("comment", {
+  id: text("id").primaryKey(),
+  artifact_id: text("artifact_id")
+    .notNull()
+    .references(() => artifact.id),
+  thread_id: text("thread_id").notNull(),
+  base_version: integer("base_version").notNull(),
+  path: text("path"),
+  anchor: text("anchor"),
+  body_md: text("body_md").notNull(),
+  author: text("author").notNull(),
+  state: text("state").$type<CommentState>().notNull().default("open"),
+  created_at: text("created_at").notNull().$defaultFn(isoNow),
+})
+
+export const webhook = pgTable("webhook", {
+  id: text("id").primaryKey(),
+  artifact_id: text("artifact_id").references(() => artifact.id),
+  url: text("url").notNull(),
+  secret: text("secret").notNull(),
+  kind: text("kind").$type<WebhookKind>().notNull().default("generic"),
+  events: text("events").notNull().default("*"),
+  label: text("label"),
+  active: integer("active").$type<0 | 1>().notNull().default(1),
+  created_at: text("created_at").notNull().$defaultFn(isoNow),
+})
+
+export const webhookDelivery = pgTable("webhook_delivery", {
+  id: text("id").primaryKey(),
+  webhook_id: text("webhook_id").notNull(),
+  url: text("url").notNull(),
+  secret: text("secret").notNull(),
+  kind: text("kind").$type<WebhookKind>().notNull(),
+  event_type: text("event_type").notNull(),
+  payload: text("payload").notNull(),
+  status: text("status").$type<DeliveryStatus>().notNull().default("pending"),
+  attempts: integer("attempts").notNull().default(0),
+  last_error: text("last_error"),
+  next_attempt_at: text("next_attempt_at").notNull().$defaultFn(isoNow),
+  created_at: text("created_at").notNull().$defaultFn(isoNow),
+})
+
+// Compile-time guard: the pg table defs must match the core record shapes (and
+// therefore the sqlite defs). Drift here means SQLite and Postgres disagree.
+type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false
+const _pgParity: [
+  Exact<typeof artifact.$inferSelect, ArtifactRecord>,
+  Exact<typeof version.$inferSelect, VersionRecord>,
+  Exact<typeof comment.$inferSelect, CommentRecord>,
+  Exact<typeof webhook.$inferSelect, WebhookRecord>,
+  Exact<typeof webhookDelivery.$inferSelect, DeliveryRecord>,
+] = [true, true, true, true, true]
+void _pgParity
+
+// Boot DDL (idempotent). created_at uses a SQL default as a server-side backstop.
 const isoDefault = `to_char((now() at time zone 'utc'), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`
 
 export const PG_SCHEMA_STATEMENTS: string[] = [
@@ -61,4 +159,30 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
     created_at TEXT NOT NULL DEFAULT ${isoDefault}
   )`,
   `CREATE INDEX IF NOT EXISTS view_artifact_time ON view (artifact_id, created_at)`,
+  `CREATE TABLE IF NOT EXISTS webhook (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT REFERENCES artifact(id),
+    url TEXT NOT NULL,
+    secret TEXT NOT NULL,
+    kind TEXT NOT NULL DEFAULT 'generic',
+    events TEXT NOT NULL DEFAULT '*',
+    label TEXT,
+    active INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL DEFAULT ${isoDefault}
+  )`,
+  `CREATE TABLE IF NOT EXISTS webhook_delivery (
+    id TEXT PRIMARY KEY,
+    webhook_id TEXT NOT NULL,
+    url TEXT NOT NULL,
+    secret TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    next_attempt_at TEXT NOT NULL DEFAULT ${isoDefault},
+    created_at TEXT NOT NULL DEFAULT ${isoDefault}
+  )`,
+  `CREATE INDEX IF NOT EXISTS delivery_due ON webhook_delivery (status, next_attempt_at)`,
 ]

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1,145 +1,121 @@
+import { and, asc, desc, eq, isNull, lte, or } from "drizzle-orm"
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres"
 import { Pool } from "pg"
 import type {
   ArtifactRecord,
   CommentRecord,
   CommentState,
+  DeliveryRecord,
+  DeliveryStatus,
   MetaStore,
   NewArtifact,
   NewComment,
+  NewDelivery,
   NewVersion,
   NewView,
+  NewWebhook,
   VersionRecord,
   ViewStats,
+  WebhookRecord,
 } from "@dock/core"
-import { PG_SCHEMA_STATEMENTS } from "./pg-schema"
+import { PG_SCHEMA_STATEMENTS, artifact, comment, version, webhook, webhookDelivery } from "./pg-schema"
 
+const schema = { artifact, version, comment, webhook, webhookDelivery }
 const VIEW_WINDOW_MS = 30 * 86400_000
 
 /**
  * Postgres metadata store (Neon, RDS, self-hosted) for horizontal scale — the
- * container is stateless and many instances share one database. Same interface
- * and record shapes as the SQLite driver. Raw parameterized SQL via node-postgres
- * keeps it dialect-explicit and free of the query-builder version skew.
+ * container is stateless and many instances share one database. CRUD goes
+ * through the drizzle query builder against the pg-dialect schema (one table
+ * definition, dialect-correct SQL generated for us); the analytics aggregations
+ * stay raw `pool.query` where GROUP BY / DISTINCT read clearer.
  */
 export class PgMetaStore implements MetaStore {
-  private constructor(private pool: Pool) {}
+  private constructor(
+    private pool: Pool,
+    private db: NodePgDatabase<typeof schema>,
+  ) {}
 
   /** Connect and apply the schema (idempotent) before first use. */
   static async create(connectionString: string): Promise<PgMetaStore> {
     const pool = new Pool({ connectionString })
     for (const stmt of PG_SCHEMA_STATEMENTS) await pool.query(stmt)
-    return new PgMetaStore(pool)
-  }
-
-  private async one<T>(text: string, params: unknown[]): Promise<T | null> {
-    const { rows } = await this.pool.query(text, params)
-    return (rows[0] as T) ?? null
+    return new PgMetaStore(pool, drizzle(pool, { schema }))
   }
 
   async createArtifact(a: NewArtifact): Promise<ArtifactRecord> {
-    await this.pool.query(
-      `INSERT INTO artifact (id, short_id, org_id, slug, title, visibility, kind, spa)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
-      [a.id, a.short_id, a.org_id, a.slug, a.title, a.visibility, a.kind, a.spa],
-    )
+    await this.db.insert(artifact).values(a)
     return (await this.getByShortId(a.short_id)) as ArtifactRecord
   }
 
-  getByShortId(shortId: string): Promise<ArtifactRecord | null> {
-    return this.one<ArtifactRecord>(`SELECT * FROM artifact WHERE short_id = $1`, [shortId])
+  async getByShortId(shortId: string): Promise<ArtifactRecord | null> {
+    const rows = await this.db.select().from(artifact).where(eq(artifact.short_id, shortId))
+    return rows[0] ?? null
   }
 
   async addVersion(artifactId: string, v: NewVersion): Promise<VersionRecord> {
-    const client = await this.pool.connect()
-    try {
-      await client.query("BEGIN")
-      const cur = await client.query(
-        `SELECT current_version FROM artifact WHERE id = $1 FOR UPDATE`,
-        [artifactId],
-      )
-      if (!cur.rows[0]) throw new Error(`artifact not found: ${artifactId}`)
-      const next = (cur.rows[0].current_version as number) + 1
-      await client.query(
-        `INSERT INTO version (id, artifact_id, n, blob_key, content_type, author, message)
-         VALUES ($1,$2,$3,$4,$5,$6,$7)`,
-        [v.id, artifactId, next, v.blob_key, v.content_type, v.author, v.message],
-      )
-      await client.query(`UPDATE artifact SET current_version = $1 WHERE id = $2`, [
-        next,
-        artifactId,
-      ])
-      await client.query("COMMIT")
-      return (await this.getVersion(artifactId, next)) as VersionRecord
-    } catch (err) {
-      await client.query("ROLLBACK")
-      throw err
-    } finally {
-      client.release()
-    }
+    return this.db.transaction(async (tx) => {
+      const cur = await tx
+        .select({ cv: artifact.current_version })
+        .from(artifact)
+        .where(eq(artifact.id, artifactId))
+        .for("update")
+      if (!cur[0]) throw new Error(`artifact not found: ${artifactId}`)
+      const n = cur[0].cv + 1
+      await tx.insert(version).values({ ...v, artifact_id: artifactId, n })
+      await tx.update(artifact).set({ current_version: n }).where(eq(artifact.id, artifactId))
+      const rows = await tx
+        .select()
+        .from(version)
+        .where(and(eq(version.artifact_id, artifactId), eq(version.n, n)))
+      return rows[0]
+    })
   }
 
-  async listVersions(artifactId: string): Promise<VersionRecord[]> {
-    const { rows } = await this.pool.query(
-      `SELECT * FROM version WHERE artifact_id = $1 ORDER BY n ASC`,
-      [artifactId],
-    )
-    return rows as VersionRecord[]
+  listVersions(artifactId: string): Promise<VersionRecord[]> {
+    return this.db.select().from(version).where(eq(version.artifact_id, artifactId)).orderBy(asc(version.n))
   }
 
-  getVersion(artifactId: string, n: number): Promise<VersionRecord | null> {
-    return this.one<VersionRecord>(`SELECT * FROM version WHERE artifact_id = $1 AND n = $2`, [
-      artifactId,
-      n,
-    ])
+  async getVersion(artifactId: string, n: number): Promise<VersionRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(version)
+      .where(and(eq(version.artifact_id, artifactId), eq(version.n, n)))
+    return rows[0] ?? null
   }
 
   async createComment(c: NewComment): Promise<CommentRecord> {
-    const { rows } = await this.pool.query(
-      `INSERT INTO comment (id, artifact_id, thread_id, base_version, path, anchor, body_md, author)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING *`,
-      [c.id, c.artifact_id, c.thread_id, c.base_version, c.path, c.anchor, c.body_md, c.author],
-    )
-    return rows[0] as CommentRecord
+    const rows = await this.db.insert(comment).values(c).returning()
+    return rows[0]
   }
 
-  getComment(id: string): Promise<CommentRecord | null> {
-    return this.one<CommentRecord>(`SELECT * FROM comment WHERE id = $1`, [id])
+  async getComment(id: string): Promise<CommentRecord | null> {
+    const rows = await this.db.select().from(comment).where(eq(comment.id, id))
+    return rows[0] ?? null
   }
 
-  async listComments(artifactId: string, opts?: { state?: CommentState }): Promise<CommentRecord[]> {
-    const { rows } = opts?.state
-      ? await this.pool.query(
-          `SELECT * FROM comment WHERE artifact_id = $1 AND state = $2 ORDER BY created_at ASC`,
-          [artifactId, opts.state],
-        )
-      : await this.pool.query(
-          `SELECT * FROM comment WHERE artifact_id = $1 ORDER BY created_at ASC`,
-          [artifactId],
-        )
-    return rows as CommentRecord[]
+  listComments(artifactId: string, opts?: { state?: CommentState }): Promise<CommentRecord[]> {
+    const where = opts?.state
+      ? and(eq(comment.artifact_id, artifactId), eq(comment.state, opts.state))
+      : eq(comment.artifact_id, artifactId)
+    return this.db.select().from(comment).where(where).orderBy(asc(comment.created_at))
   }
 
-  async setThreadState(
-    artifactId: string,
-    threadId: string,
-    state: CommentState,
-  ): Promise<number> {
-    const res = await this.pool.query(
-      `UPDATE comment SET state = $1 WHERE artifact_id = $2 AND thread_id = $3`,
-      [state, artifactId, threadId],
-    )
-    return res.rowCount ?? 0
+  async setThreadState(artifactId: string, threadId: string, state: CommentState): Promise<number> {
+    const rows = await this.db
+      .update(comment)
+      .set({ state })
+      .where(and(eq(comment.artifact_id, artifactId), eq(comment.thread_id, threadId)))
+      .returning({ id: comment.id })
+    return rows.length
   }
 
-  async listArtifacts(opts?: { limit?: number }): Promise<ArtifactRecord[]> {
-    const { rows } = opts?.limit
-      ? await this.pool.query(`SELECT * FROM artifact ORDER BY created_at DESC LIMIT $1`, [
-          opts.limit,
-        ])
-      : await this.pool.query(`SELECT * FROM artifact ORDER BY created_at DESC`)
-    return rows as ArtifactRecord[]
+  listArtifacts(opts?: { limit?: number }): Promise<ArtifactRecord[]> {
+    const q = this.db.select().from(artifact).orderBy(desc(artifact.created_at))
+    return opts?.limit ? q.limit(opts.limit) : q
   }
 
+  // ---- View analytics (raw: aggregation-heavy) ---------------------------
   async recordView(v: NewView): Promise<void> {
     await this.pool.query(
       `INSERT INTO view (id, artifact_id, version, viewer, viewer_kind) VALUES ($1,$2,$3,$4,$5)`,
@@ -184,6 +160,53 @@ export class PgMetaStore implements MetaStore {
     const out: Record<string, number> = {}
     for (const r of rows) out[r.artifact_id] = r.c
     return out
+  }
+
+  // ---- Webhooks + outbox -------------------------------------------------
+  async createWebhook(w: NewWebhook): Promise<WebhookRecord> {
+    const rows = await this.db.insert(webhook).values(w).returning()
+    return rows[0]
+  }
+  listWebhooks(): Promise<WebhookRecord[]> {
+    return this.db.select().from(webhook).orderBy(desc(webhook.created_at))
+  }
+  async getWebhook(id: string): Promise<WebhookRecord | null> {
+    const rows = await this.db.select().from(webhook).where(eq(webhook.id, id))
+    return rows[0] ?? null
+  }
+  async deleteWebhook(id: string): Promise<void> {
+    await this.db.delete(webhook).where(eq(webhook.id, id))
+  }
+  activeWebhooks(artifactId: string): Promise<WebhookRecord[]> {
+    return this.db
+      .select()
+      .from(webhook)
+      .where(and(eq(webhook.active, 1), or(isNull(webhook.artifact_id), eq(webhook.artifact_id, artifactId))))
+  }
+  async enqueueDelivery(d: NewDelivery): Promise<void> {
+    await this.db.insert(webhookDelivery).values(d)
+  }
+  claimDueDeliveries(now: string, limit: number): Promise<DeliveryRecord[]> {
+    return this.db
+      .select()
+      .from(webhookDelivery)
+      .where(and(eq(webhookDelivery.status, "pending"), lte(webhookDelivery.next_attempt_at, now)))
+      .orderBy(asc(webhookDelivery.next_attempt_at))
+      .limit(limit)
+  }
+  async updateDelivery(
+    id: string,
+    f: { status: DeliveryStatus; attempts: number; last_error: string | null; next_attempt_at: string },
+  ): Promise<void> {
+    await this.db.update(webhookDelivery).set(f).where(eq(webhookDelivery.id, id))
+  }
+  recentDeliveries(webhookId: string, limit: number): Promise<DeliveryRecord[]> {
+    return this.db
+      .select()
+      .from(webhookDelivery)
+      .where(eq(webhookDelivery.webhook_id, webhookId))
+      .orderBy(desc(webhookDelivery.created_at))
+      .limit(limit)
   }
 
   async close(): Promise<void> {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,6 +1,17 @@
 import { sql } from "drizzle-orm"
 import { integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core"
-import type { ArtifactKind, CommentState, Visibility } from "@dock/core"
+import type {
+  ArtifactKind,
+  ArtifactRecord,
+  CommentRecord,
+  CommentState,
+  DeliveryRecord,
+  DeliveryStatus,
+  VersionRecord,
+  Visibility,
+  WebhookKind,
+  WebhookRecord,
+} from "@dock/core"
 
 const now = sql`(strftime('%Y-%m-%dT%H:%M:%fZ','now'))`
 
@@ -48,6 +59,33 @@ export const comment = sqliteTable("comment", {
   body_md: text("body_md").notNull(),
   author: text("author").notNull(),
   state: text("state").$type<CommentState>().notNull().default("open"),
+  created_at: text("created_at").notNull().default(now),
+})
+
+export const webhook = sqliteTable("webhook", {
+  id: text("id").primaryKey(),
+  artifact_id: text("artifact_id").references(() => artifact.id),
+  url: text("url").notNull(),
+  secret: text("secret").notNull(),
+  kind: text("kind").$type<WebhookKind>().notNull().default("generic"),
+  events: text("events").notNull().default("*"),
+  label: text("label"),
+  active: integer("active").$type<0 | 1>().notNull().default(1),
+  created_at: text("created_at").notNull().default(now),
+})
+
+export const webhookDelivery = sqliteTable("webhook_delivery", {
+  id: text("id").primaryKey(),
+  webhook_id: text("webhook_id").notNull(),
+  url: text("url").notNull(),
+  secret: text("secret").notNull(),
+  kind: text("kind").$type<WebhookKind>().notNull(),
+  event_type: text("event_type").notNull(),
+  payload: text("payload").notNull(),
+  status: text("status").$type<DeliveryStatus>().notNull().default("pending"),
+  attempts: integer("attempts").notNull().default(0),
+  last_error: text("last_error"),
+  next_attempt_at: text("next_attempt_at").notNull().default(now),
   created_at: text("created_at").notNull().default(now),
 })
 
@@ -117,5 +155,43 @@ export const SCHEMA_STATEMENTS: string[] = [
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
   )`,
   `CREATE INDEX IF NOT EXISTS view_artifact_time ON view (artifact_id, created_at)`,
+  `CREATE TABLE IF NOT EXISTS webhook (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT REFERENCES artifact(id),
+    url TEXT NOT NULL,
+    secret TEXT NOT NULL,
+    kind TEXT NOT NULL DEFAULT 'generic',
+    events TEXT NOT NULL DEFAULT '*',
+    label TEXT,
+    active INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  )`,
+  `CREATE TABLE IF NOT EXISTS webhook_delivery (
+    id TEXT PRIMARY KEY,
+    webhook_id TEXT NOT NULL,
+    url TEXT NOT NULL,
+    secret TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    next_attempt_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  )`,
+  `CREATE INDEX IF NOT EXISTS delivery_due ON webhook_delivery (status, next_attempt_at)`,
   // user/session/account/verification are owned and migrated by Better Auth.
 ]
+
+// Compile-time guard: the drizzle table defs must exactly match the core record
+// shapes. A non-`true` element here is schema drift — fix the table or the type.
+type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false
+const _schemaParity: [
+  Exact<typeof artifact.$inferSelect, ArtifactRecord>,
+  Exact<typeof version.$inferSelect, VersionRecord>,
+  Exact<typeof comment.$inferSelect, CommentRecord>,
+  Exact<typeof webhook.$inferSelect, WebhookRecord>,
+  Exact<typeof webhookDelivery.$inferSelect, DeliveryRecord>,
+] = [true, true, true, true, true]
+void _schemaParity

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -1,23 +1,28 @@
 import Database from "better-sqlite3"
-import { and, asc, desc, eq } from "drizzle-orm"
+import { and, asc, desc, eq, isNull, lte, or } from "drizzle-orm"
 import { drizzle, type BetterSQLite3Database } from "drizzle-orm/better-sqlite3"
 import type {
   ArtifactRecord,
   CommentRecord,
   CommentState,
+  DeliveryRecord,
+  DeliveryStatus,
   MetaStore,
   NewArtifact,
   NewComment,
+  NewDelivery,
   NewVersion,
   NewView,
+  NewWebhook,
   VersionRecord,
   ViewStats,
+  WebhookRecord,
 } from "@dock/core"
-import { SCHEMA_STATEMENTS, artifact, comment, version } from "./schema"
+import { SCHEMA_STATEMENTS, artifact, comment, version, webhook, webhookDelivery } from "./schema"
 
 const VIEW_WINDOW_MS = 30 * 86400_000
 
-const schema = { artifact, version, comment }
+const schema = { artifact, version, comment, webhook, webhookDelivery }
 
 /** Embedded SQLite (WAL). The zero-dependency default; no external services. */
 export class SqliteMetaStore implements MetaStore {
@@ -146,6 +151,60 @@ export class SqliteMetaStore implements MetaStore {
     const out: Record<string, number> = {}
     for (const r of rows) out[r.artifact_id] = r.c
     return out
+  }
+
+  // ---- Webhooks + outbox -------------------------------------------------
+  createWebhook(w: NewWebhook): Promise<WebhookRecord> {
+    return Promise.resolve(this.db.insert(webhook).values(w).returning().get())
+  }
+  listWebhooks(): Promise<WebhookRecord[]> {
+    return Promise.resolve(this.db.select().from(webhook).orderBy(desc(webhook.created_at)).all())
+  }
+  getWebhook(id: string): Promise<WebhookRecord | null> {
+    return Promise.resolve(this.db.select().from(webhook).where(eq(webhook.id, id)).get() ?? null)
+  }
+  async deleteWebhook(id: string): Promise<void> {
+    this.db.delete(webhook).where(eq(webhook.id, id)).run()
+  }
+  activeWebhooks(artifactId: string): Promise<WebhookRecord[]> {
+    return Promise.resolve(
+      this.db
+        .select()
+        .from(webhook)
+        .where(and(eq(webhook.active, 1), or(isNull(webhook.artifact_id), eq(webhook.artifact_id, artifactId))))
+        .all(),
+    )
+  }
+  async enqueueDelivery(d: NewDelivery): Promise<void> {
+    this.db.insert(webhookDelivery).values(d).run()
+  }
+  claimDueDeliveries(now: string, limit: number): Promise<DeliveryRecord[]> {
+    return Promise.resolve(
+      this.db
+        .select()
+        .from(webhookDelivery)
+        .where(and(eq(webhookDelivery.status, "pending"), lte(webhookDelivery.next_attempt_at, now)))
+        .orderBy(asc(webhookDelivery.next_attempt_at))
+        .limit(limit)
+        .all(),
+    )
+  }
+  async updateDelivery(
+    id: string,
+    f: { status: DeliveryStatus; attempts: number; last_error: string | null; next_attempt_at: string },
+  ): Promise<void> {
+    this.db.update(webhookDelivery).set(f).where(eq(webhookDelivery.id, id)).run()
+  }
+  recentDeliveries(webhookId: string, limit: number): Promise<DeliveryRecord[]> {
+    return Promise.resolve(
+      this.db
+        .select()
+        .from(webhookDelivery)
+        .where(eq(webhookDelivery.webhook_id, webhookId))
+        .orderBy(desc(webhookDelivery.created_at))
+        .limit(limit)
+        .all(),
+    )
   }
 
   close(): void {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   esbuild: '>=0.25.0'
+  drizzle-orm: 0.45.2
 
 importers:
 
@@ -27,7 +28,7 @@ importers:
         version: 1.19.14(hono@4.12.25)
       better-auth:
         specifier: ^1.6.18
-        version: 1.6.18(@cloudflare/workers-types@4.20260611.1)(@tanstack/react-start@1.168.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.6(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
+        version: 1.6.18(@cloudflare/workers-types@4.20260611.1)(@tanstack/react-start@1.168.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)))(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.6(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
@@ -131,7 +132,7 @@ importers:
         specifier: ^11.10.0
         version: 11.10.0
       drizzle-orm:
-        specifier: ^0.45.2
+        specifier: 0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0)
       pg:
         specifier: ^8.13.1
@@ -304,7 +305,7 @@ packages:
     peerDependencies:
       '@better-auth/core': ^1.6.18
       '@better-auth/utils': 0.4.1
-      drizzle-orm: ^0.45.2
+      drizzle-orm: 0.45.2
     peerDependenciesMeta:
       drizzle-orm:
         optional: true
@@ -384,34 +385,16 @@ packages:
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
     deprecated: 'Merged into tsx: https://tsx.is'
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.28.1':
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.1':
@@ -420,34 +403,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.28.1':
     resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.1':
@@ -456,22 +421,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -480,22 +433,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.1':
@@ -504,22 +445,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.1':
@@ -528,22 +457,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -552,22 +469,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.1':
@@ -576,34 +481,16 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.28.1':
     resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.28.1':
     resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.1':
@@ -612,22 +499,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.28.1':
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -636,23 +511,11 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@esbuild/openharmony-arm64@0.28.1':
     resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
-
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
 
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
@@ -660,34 +523,16 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-arm64@0.28.1':
     resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.1':
@@ -1242,7 +1087,7 @@ packages:
       '@tanstack/solid-start': ^1.0.0
       better-sqlite3: ^12.0.0
       drizzle-kit: '>=0.31.4'
-      drizzle-orm: ^0.45.2
+      drizzle-orm: 0.45.2
       mongodb: ^6.0.0 || ^7.0.0
       mysql2: ^3.0.0
       next: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -1570,11 +1415,6 @@ packages:
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
-
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -2695,157 +2535,79 @@ snapshots:
       '@esbuild-kit/core-utils': 3.3.2
       get-tsconfig: 4.14.0
 
-  '@esbuild/aix-ppc64@0.27.7':
-    optional: true
-
   '@esbuild/aix-ppc64@0.28.1':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
-    optional: true
-
   '@esbuild/android-arm@0.28.1':
-    optional: true
-
-  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
-    optional: true
-
   '@esbuild/darwin-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
-    optional: true
-
   '@esbuild/linux-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
-    optional: true
-
   '@esbuild/linux-ia32@0.28.1':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
-    optional: true
-
   '@esbuild/linux-mips64el@0.28.1':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
-    optional: true
-
   '@esbuild/linux-riscv64@0.28.1':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
-    optional: true
-
   '@esbuild/linux-x64@0.28.1':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/netbsd-x64@0.28.1':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/openbsd-x64@0.28.1':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
-    optional: true
-
   '@esbuild/sunos-x64@0.28.1':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
-    optional: true
-
   '@esbuild/win32-ia32@0.28.1':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -3078,6 +2840,28 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@tanstack/react-start-rsc@0.1.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))':
+    dependencies:
+      '@tanstack/react-router': 1.170.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/start-client-core': 1.170.12
+      '@tanstack/start-fn-stubs': 1.162.0
+      '@tanstack/start-plugin-core': 1.171.17(@tanstack/react-router@1.170.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
+      '@tanstack/start-server-core': 1.169.14
+      '@tanstack/start-storage-context': 1.167.15
+      pathe: 2.0.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@rsbuild/core'
+      - crossws
+      - supports-color
+      - vite
+      - vite-plugin-solid
+      - webpack
+    optional: true
+
   '@tanstack/react-start-rsc@0.1.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))':
     dependencies:
       '@tanstack/react-router': 1.170.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3108,6 +2892,30 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - crossws
+
+  '@tanstack/react-start@1.168.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))':
+    dependencies:
+      '@tanstack/react-router': 1.170.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-start-client': 1.168.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-start-rsc': 0.1.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
+      '@tanstack/react-start-server': 1.167.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/start-client-core': 1.170.12
+      '@tanstack/start-plugin-core': 1.171.17(@tanstack/react-router@1.170.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
+      '@tanstack/start-server-core': 1.169.14
+      pathe: 2.0.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      vite: 6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - crossws
+      - react-server-dom-rspack
+      - supports-color
+      - vite-plugin-solid
+      - webpack
+    optional: true
 
   '@tanstack/react-start@1.168.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))':
     dependencies:
@@ -3159,6 +2967,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@tanstack/router-plugin@1.168.18(@tanstack/react-router@1.170.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-generator': 1.167.17
+      '@tanstack/router-utils': 1.162.2
+      chokidar: 5.0.0
+      unplugin: 3.0.0
+      zod: 4.4.3
+    optionalDependencies:
+      '@tanstack/react-router': 1.170.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      vite: 6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@tanstack/router-plugin@1.168.18(@tanstack/react-router@1.170.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))':
     dependencies:
       '@babel/core': 7.29.7
@@ -3197,6 +3023,38 @@ snapshots:
       seroval: 1.5.4
 
   '@tanstack/start-fn-stubs@1.162.0': {}
+
+  '@tanstack/start-plugin-core@1.171.17(@tanstack/react-router@1.170.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/core': 7.29.7
+      '@babel/types': 7.29.7
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-generator': 1.167.17
+      '@tanstack/router-plugin': 1.168.18(@tanstack/react-router@1.170.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/start-server-core': 1.169.14
+      exsolve: 1.0.8
+      lightningcss: 1.32.0
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      seroval: 1.5.4
+      source-map: 0.7.6
+      srvx: 0.11.16
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      vitefu: 1.1.3(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
+      xmlbuilder2: 4.0.3
+      zod: 4.4.3
+    optionalDependencies:
+      vite: 6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)
+    transitivePeerDependencies:
+      - '@tanstack/react-router'
+      - crossws
+      - supports-color
+      - vite-plugin-solid
+      - webpack
+    optional: true
 
   '@tanstack/start-plugin-core@1.171.17(@tanstack/react-router@1.170.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))':
     dependencies:
@@ -3370,7 +3228,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.37: {}
 
-  better-auth@1.6.18(@cloudflare/workers-types@4.20260611.1)(@tanstack/react-start@1.168.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.6(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)):
+  better-auth@1.6.18(@cloudflare/workers-types@4.20260611.1)(@tanstack/react-start@1.168.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)))(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.6(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)):
     dependencies:
       '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@cloudflare/workers-types@4.20260611.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@cloudflare/workers-types@4.20260611.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))
@@ -3390,7 +3248,7 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
     optionalDependencies:
-      '@tanstack/react-start': 1.168.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+      '@tanstack/react-start': 1.168.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
       better-sqlite3: 11.10.0
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260611.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0)
@@ -3583,35 +3441,6 @@ snapshots:
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
-
-  esbuild@0.27.7:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -4386,7 +4215,7 @@ snapshots:
 
   vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4):
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.15
@@ -4412,6 +4241,11 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.22.4
+
+  vitefu@1.1.3(vite@6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)):
+    optionalDependencies:
+      vite: 6.4.3(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)
+    optional: true
 
   vitefu@1.1.3(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)):
     optionalDependencies:


### PR DESCRIPTION
Two commits: the data-layer refactor, then the feature it rides on. Off current `main`, no stack.

## 1. Proper drizzle across all drivers (refactor)

The data layer had drifted — Postgres was raw SQL from day one (a drizzle-orm version skew broke `pg-core`), SQLite mixed query-builder + raw, and the schema was hand-written DDL duplicated across two files. That drift already caused real cross-writer bugs (the pg `at`/`day` reserved-word breakages SQLite never saw).

- **Root cause fixed**: pinned `drizzle-orm` to one version + `dedupe-peer-dependents` — drizzle's many optional peers (better-sqlite3 *and* pg in one package) were spawning mismatched instances. Now one resolves.
- **Uniform query builder**: every table has drizzle defs in both dialects; all CRUD goes through the builder in pg/sqlite/d1 (dialect-correct SQL generated, not hand-written). Analytics aggregations stay raw `sql`.
- **Compile-time parity guards** (`Exact<table.$inferSelect, Record>`) in both schema files — if a table drifts from its core record type, or SQLite and Postgres disagree, **typecheck fails**. That's the "works across writers" guarantee, enforced.

Verified live: full CRUD on fresh Postgres + SQLite via the suite.

## 2. Webhooks + Slack (feature)

Notifications that reach you. Subscribe an endpoint or a Slack incoming-webhook to `comment.created` / `comment.resolved` / `version.published`.

- **Reliable**: outbox table + in-process worker, exponential backoff, dead-letter after 6 attempts, visible delivery log.
- **Signed**: generic payloads get `X-Dock-Signature` (HMAC-SHA256). Slack gets Block Kit messages. Canonical payload stored once, formatted per-kind at delivery.
- **Safe**: secrets never returned by the API. Per-artifact or global; per-event subscriptions.
- **UI**: a Settings page (user menu) to add/remove webhooks, a Test button, and an inline delivery log.

Arbitrary webhooks are the base primitive; Slack is the first connector (same adapter shape covers Teams/Discord later) — exactly the roadmap framing.

## Verification

End to end on **both SQLite and Postgres** against a local catcher: generic + Slack deliveries, HMAC validated, event filtering, retry→delivered on a flaky endpoint, secret hidden, and the settings UI (add / test / log), all browser-driven. `pnpm typecheck` clean, **55 tests** green (signing/formatting + outbox integration test added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)