### PR TITLE
B1: dock init + CLI loop + dock.json + content standard (md/html/slides/site)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,20 @@ API; view it rendered and sandboxed. Self-host it, or use the hosted tier.
 pnpm install
 pnpm dev                                  # api on http://localhost:8080
 
-# publish a file
-node packages/cli/bin/dock.js publish ./README.md
+# scaffold a project (templates: md · html · slides)
+node packages/cli/bin/dock.js init my-doc --template slides
+cd my-doc
 
-# publish any static build output (a dist/ folder)
-node packages/cli/bin/dock.js publish ./dist --title "My site" --spa
-
-# new version, same URL
-node packages/cli/bin/dock.js publish ./README.md --id <short_id> --message "v2"
+# publish — reads dock.json, so no flags; the id is saved for next time
+node packages/cli/bin/dock.js publish
+# edit, then publish again → new version, same URL, same artifact
+node packages/cli/bin/dock.js publish --name "First draft"
 ```
+
+`dock init` writes a `dock.json` (artifact id, title, visibility, spa, entry) and
+an `AGENTS.md` describing the publish → review → revise loop. Without a project
+you can still `dock publish <file|dir> [--title --spa --id …]` directly.
+Authoring + the anchor-client protocol are documented in [STANDARD.md](STANDARD.md).
 
 ## Self-host
 
@@ -60,7 +65,7 @@ apps/web          web UI (TanStack Start, SPA mode — static bundle)
 packages/core     domain: ports, publish, markdown render, viewer shell
 packages/db       MetaStore: sqlite (default) · postgres · d1
 packages/storage  BlobStore: fs (default) · s3/r2
-packages/cli      dock publish <file|dir>
+packages/cli      dock init (md/html/slides) · dock publish <file|dir>
 packages/mcp      MCP server: publish / read-back tools for agents
 ```
 

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -1,0 +1,71 @@
+# The Dock content standard
+
+Dock artifacts are ordinary HTML, Markdown, or static bundles. Two conventions
+make them work well in the review loop: authoring so comments stay anchored, and
+the anchor-client protocol that any viewer can speak.
+
+## 1. Author for durable comments
+
+Comments anchor to a **text quote** plus a little surrounding context (a W3C
+`TextQuoteSelector`). When you republish, each open comment re-anchors against
+the new version: exact match with context first, then exact match anywhere, and
+if the text is gone it's marked "text changed" rather than silently moved. So
+anchors survive edits as long as the text stays recognizable.
+
+To keep comments attached across revisions:
+
+- **Make local edits, not wholesale rewrites.** Fixing a clause keeps its
+  neighbors as context; replacing a whole paragraph drops every anchor in it.
+- **Keep headings and distinctive phrases stable.** They're the strongest
+  context. Rename a heading only when you mean to.
+- **Prefer real text over images of text.** Anchors need selectable text;
+  baked-in screenshots can't be commented on.
+- **Markdown:** one idea per paragraph, stable headings. **HTML/slides:** keep
+  the readable text in the DOM (not generated late by script), so it's there
+  when the page loads and when an anchor resolves.
+
+These are guidelines, not validation — Dock never rejects content. They just
+make the loop smoother.
+
+## 2. The anchor-client protocol
+
+Dock serves a small client at **`/raw/dock-client.js`** and references it from
+served artifact HTML. It runs inside the sandboxed artifact iframe (opaque
+origin), so the host page (the viewer) and the artifact communicate only by
+`postMessage`. Any viewer can implement the host side; any host can serve a
+compatible client. Messages are tagged with a `source` field.
+
+### Artifact frame → host (`source: "dock"`)
+
+| `type` | payload | meaning |
+|---|---|---|
+| `select` | `{ selector }` | user selected text; `selector` is a `TextQuoteSelector` (`{type, exact, prefix, suffix}`) or `null` when the selection cleared |
+| `anchors-resolved` | `{ resolved: { [id]: boolean } }` | which anchor ids were found in the current document |
+| `anchor-click` | `{ id }` | user clicked a painted highlight |
+
+### Host → artifact frame (`source: "dock-host"`)
+
+| `type` | payload | meaning |
+|---|---|---|
+| `anchors` | `{ anchors: [{ id, exact, prefix, suffix }] }` | paint these anchors as highlights; reply with `anchors-resolved` |
+| `focus-anchor` | `{ id }` | scroll to + flash that anchor |
+
+### Resolution
+
+An anchor is located the same way on the client and the server: try
+`prefix + exact + suffix` first, then `exact` alone; not found ⇒ unresolved.
+Highlights wrap matched text in `<mark data-dock-id="…">`; clicking one posts
+`anchor-click`.
+
+### Why it's served, not inlined
+
+Artifact HTML is cached immutably per version. If the client were baked into the
+HTML, old artifacts would be frozen on old client behavior forever. Serving it at
+a URL (short cache) lets the comment layer evolve independently of published
+content — and lets other tools build their own viewers against this contract.
+
+## 3. The agent loop
+
+`dock init` scaffolds an `AGENTS.md` describing publish → read comments → revise
+→ reply/resolve over the HTTP API. That's the convention for agents (and humans)
+to close the loop without prior knowledge of Dock.

--- a/packages/cli/bin/dock.js
+++ b/packages/cli/bin/dock.js
@@ -1,70 +1,116 @@
 #!/usr/bin/env node
-// dock — publish HTML, Markdown, or any static build output to a Dock server.
-//   dock publish <file|dir> [--id <short_id>] [--title t] [--slug s] [--spa]
-//                [--message m] [--name "checkpoint"] [--visibility public|link|org|password]
-//                [--server http://localhost:8080] [--token t]
+// dock — scaffold and publish artifacts to a Dock server.
+//   dock init [dir] [--template md|html|slides] [--title t]   scaffold a project
+//   dock publish [file|dir] [flags]        publish (reads dock.json if present)
+//     flags: --id X --title t --slug s --spa --message m --name "checkpoint"
+//            --visibility public|link|org|password --server url --token t
 import { readFileSync, readdirSync, statSync } from "node:fs"
-import { join, basename, relative } from "node:path"
+import { basename, join, relative } from "node:path"
 import { zipSync } from "fflate"
+import { CONFIG_FILE, TEMPLATES, loadConfig, resolvePublish, scaffold, writeId } from "../src/config.js"
 
 const args = process.argv.slice(2)
 const cmd = args.shift()
 
-if (cmd !== "publish" || args.length === 0 || args[0].startsWith("--")) {
-  console.error(`usage: dock publish <file|dir> [--id X] [--title t] [--slug s] [--spa] [--message m] [--visibility v] [--server url] [--token t]`)
-  process.exit(cmd === "publish" ? 1 : cmd ? 1 : 0)
-}
-
-const target = args.shift()
-const opts = {}
+const flags = {}
+const positional = []
 for (let i = 0; i < args.length; i++) {
   const a = args[i]
-  if (a === "--spa") opts.spa = "true"
-  else if (a.startsWith("--")) opts[a.slice(2)] = args[++i]
+  if (a === "--spa") flags.spa = "true"
+  else if (a.startsWith("--")) flags[a.slice(2)] = args[++i]
+  else positional.push(a)
 }
-const server = opts.server ?? process.env.DOCK_SERVER ?? "http://localhost:8080"
-const token = opts.token ?? process.env.DOCK_TOKEN
+
+if (cmd === "init") {
+  const dir = positional[0] ?? "."
+  const template = flags.template ?? "md"
+  if (!TEMPLATES.includes(template)) {
+    console.error(`error: unknown template "${template}". Choose: ${TEMPLATES.join(", ")}`)
+    process.exit(1)
+  }
+  const { created, skipped } = scaffold(dir, flags.title ?? "My artifact", template)
+  for (const f of created) console.log(`  + ${f}`)
+  for (const f of skipped) console.log(`  · ${f} (exists, kept)`)
+  const entry = created.find((f) => f !== CONFIG_FILE && f !== "AGENTS.md") ?? "the entry"
+  console.log(created.length ? `\nReady (${template}). Edit ${entry}, then run \`dock publish\`.` : `\nNothing to do — ${CONFIG_FILE} already here.`)
+  process.exit(0)
+}
+
+if (cmd !== "publish") {
+  console.error(`usage:
+  dock init [dir] [--title t]
+  dock publish [file|dir] [--id X] [--title t] [--slug s] [--spa] [--message m] [--name "x"] [--visibility v] [--server url] [--token t]`)
+  process.exit(cmd ? 1 : 0)
+}
+
+// Merge dock.json (if present in cwd) with flags; flags win.
+let config = null
+try {
+  config = loadConfig(".")
+} catch (e) {
+  console.error(`error: ${e.message}`)
+  process.exit(1)
+}
+const p = resolvePublish({ ...flags, target: positional[0] }, config)
+
+if (!p.target) {
+  console.error(`error: nothing to publish. Pass a file/dir, or set "entry" in ${CONFIG_FILE} (run \`dock init\`).`)
+  process.exit(1)
+}
 
 const collect = (dir, base, out = {}) => {
   for (const name of readdirSync(dir)) {
-    if (name === ".DS_Store" || name === "node_modules" || name.startsWith(".git")) continue
-    const p = join(dir, name)
-    const st = statSync(p)
-    if (st.isDirectory()) collect(p, base, out)
-    else out[relative(base, p).split("\\").join("/")] = readFileSync(p)
+    if (name === ".DS_Store" || name === "node_modules" || name.startsWith(".git") || name === CONFIG_FILE) continue
+    const path = join(dir, name)
+    const st = statSync(path)
+    if (st.isDirectory()) collect(path, base, out)
+    else out[relative(base, path).split("\\").join("/")] = readFileSync(path)
   }
   return out
 }
 
-let bytes, filename
-const st = statSync(target)
+let bytes
+let filename
+const st = statSync(p.target)
 if (st.isDirectory()) {
-  const files = collect(target, target)
+  const files = collect(p.target, p.target)
   if (Object.keys(files).length === 0) {
-    console.error(`error: ${target} is empty`)
+    console.error(`error: ${p.target} is empty`)
     process.exit(1)
   }
   bytes = zipSync(files)
-  filename = `${basename(target)}.zip`
+  filename = `${basename(p.target)}.zip`
 } else {
-  bytes = readFileSync(target)
-  filename = basename(target)
+  bytes = readFileSync(p.target)
+  filename = basename(p.target)
 }
 
 const form = new FormData()
 form.append("file", new Blob([bytes]), filename)
-for (const k of ["title", "slug", "spa", "message", "visibility", "name"]) if (opts[k]) form.append(k, opts[k])
+if (p.title) form.append("title", p.title)
+if (p.slug) form.append("slug", p.slug)
+if (p.spa) form.append("spa", "true")
+if (p.message) form.append("message", p.message)
+if (p.name) form.append("name", p.name)
+if (p.visibility) form.append("visibility", p.visibility)
 
-const url = opts.id
-  ? `${server}/v1/artifacts/${opts.id}/versions`
-  : `${server}/v1/artifacts`
-
-const headers = token ? { authorization: `Bearer ${token}` } : {}
+const url = p.id ? `${p.server}/v1/artifacts/${p.id}/versions` : `${p.server}/v1/artifacts`
+const headers = p.token ? { authorization: `Bearer ${p.token}` } : {}
 const res = await fetch(url, { method: "POST", body: form, headers })
 const json = await res.json().catch(() => ({}))
 if (!res.ok) {
   console.error(`error (${res.status}): ${json.error ?? res.statusText}`)
   process.exit(1)
 }
+
+// First publish of a configured project: remember the id so the next publish
+// targets the same artifact with zero flags.
+let savedId = false
+if (!p.id && config && json.short_id) {
+  writeId(".", json.short_id)
+  savedId = true
+}
+
 console.log(`✓ ${json.url}`)
 console.log(`  short_id ${json.short_id} · v${json.current_version} · ${json.kind}`)
+if (savedId) console.log(`  saved id to ${CONFIG_FILE} — future publishes target this artifact`)

--- a/packages/cli/bin/dock.js
+++ b/packages/cli/bin/dock.js
@@ -1,13 +1,16 @@
 #!/usr/bin/env node
-// dock — scaffold and publish artifacts to a Dock server.
-//   dock init [dir] [--template md|html|slides] [--title t]   scaffold a project
-//   dock publish [file|dir] [flags]        publish (reads dock.json if present)
-//     flags: --id X --title t --slug s --spa --message m --name "checkpoint"
-//            --visibility public|link|org|password --server url --token t
+// dock — scaffold, publish, and run the review loop against a Dock server.
+//   dock init [dir] [--template md|html|slides|site] [--title t]
+//   dock publish [file|dir] [--id --title --slug --spa --message --name --visibility --server --token]
+//   dock comments [--id]                 list the artifact's comment threads
+//   dock open [--id]                     open the artifact in a browser
+//   dock reply <thread_id> <message…>    reply in a thread
+//   dock resolve|reopen <comment_id>     set a thread's state
+import { spawn } from "node:child_process"
 import { readFileSync, readdirSync, statSync } from "node:fs"
 import { basename, join, relative } from "node:path"
 import { zipSync } from "fflate"
-import { CONFIG_FILE, TEMPLATES, loadConfig, resolvePublish, scaffold, writeId } from "../src/config.js"
+import { CONFIG_FILE, TEMPLATES, formatComments, loadConfig, resolvePublish, scaffold, writeId } from "../src/config.js"
 
 const args = process.argv.slice(2)
 const cmd = args.shift()
@@ -36,10 +39,85 @@ if (cmd === "init") {
   process.exit(0)
 }
 
+// ---- Loop verbs (comments / open / reply / resolve / reopen) --------------
+const LOOP = ["comments", "open", "reply", "resolve", "reopen"]
+if (LOOP.includes(cmd)) {
+  let cfg = null
+  try {
+    cfg = loadConfig(".")
+  } catch (e) {
+    console.error(`error: ${e.message}`)
+    process.exit(1)
+  }
+  const r = resolvePublish(flags, cfg)
+  if (!r.id) {
+    console.error(`error: no artifact id. Set "id" in ${CONFIG_FILE} (publish once), or pass --id.`)
+    process.exit(1)
+  }
+  const auth = r.token ? { authorization: `Bearer ${r.token}` } : {}
+  const base = `${r.server}/v1/artifacts/${r.id}`
+  const die = async (res) => {
+    const j = await res.json().catch(() => ({}))
+    console.error(`error (${res.status}): ${j.error ?? res.statusText}`)
+    process.exit(1)
+  }
+
+  if (cmd === "open") {
+    const url = `${r.server}/a/${r.id}`
+    console.log(url)
+    const opener = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open"
+    spawn(opener, [url], { stdio: "ignore", detached: true }).on("error", () => {}).unref()
+    process.exit(0)
+  }
+
+  if (cmd === "comments") {
+    const res = await fetch(`${base}/comments`, { headers: auth })
+    if (!res.ok) await die(res)
+    console.log(formatComments((await res.json()).comments))
+    process.exit(0)
+  }
+
+  if (cmd === "reply") {
+    const threadId = positional[0]
+    const body = positional.slice(1).join(" ")
+    if (!threadId || !body) {
+      console.error(`usage: dock reply <thread_id> <message…>`)
+      process.exit(1)
+    }
+    const res = await fetch(`${base}/comments`, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...auth },
+      body: JSON.stringify({ thread_id: threadId, body_md: body }),
+    })
+    if (!res.ok) await die(res)
+    console.log(`✓ replied in ${threadId}`)
+    process.exit(0)
+  }
+
+  // resolve | reopen
+  const commentId = positional[0]
+  if (!commentId) {
+    console.error(`usage: dock ${cmd} <comment_id>`)
+    process.exit(1)
+  }
+  const res = await fetch(`${base}/comments/${commentId}/resolve`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...auth },
+    body: JSON.stringify({ state: cmd === "resolve" ? "resolved" : "open" }),
+  })
+  if (!res.ok) await die(res)
+  console.log(`✓ thread ${cmd === "resolve" ? "resolved" : "reopened"}`)
+  process.exit(0)
+}
+
 if (cmd !== "publish") {
   console.error(`usage:
-  dock init [dir] [--title t]
-  dock publish [file|dir] [--id X] [--title t] [--slug s] [--spa] [--message m] [--name "x"] [--visibility v] [--server url] [--token t]`)
+  dock init [dir] [--template md|html|slides|site] [--title t]
+  dock publish [file|dir] [--id X] [--title t] [--slug s] [--spa] [--message m] [--name "x"] [--visibility v] [--server url] [--token t]
+  dock comments [--id X]                 list comment threads
+  dock open [--id X]                     open the artifact in a browser
+  dock reply <thread_id> <message…>      reply in a thread
+  dock resolve|reopen <comment_id>       set a thread's state`)
   process.exit(cmd ? 1 : 0)
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,9 +6,12 @@
   "bin": { "dock": "./bin/dock.js" },
   "scripts": {
     "typecheck": "echo 'plain js cli'",
-    "test": "echo 'covered by api integration tests'"
+    "test": "vitest run"
   },
   "dependencies": {
     "fflate": "^0.8.2"
+  },
+  "devDependencies": {
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -6,6 +6,7 @@ export const CONFIG_FILE = "dock.json"
 
 /** The dock.json a fresh project starts with (no id until first publish). */
 export const defaultConfig = (title = "My artifact", entry = "index.md") => ({
+  $schema: "./dock.schema.json",
   title,
   entry,
   visibility: "link",
@@ -13,7 +14,7 @@ export const defaultConfig = (title = "My artifact", entry = "index.md") => ({
   id: null,
 })
 
-export const TEMPLATES = ["md", "html", "slides"]
+export const TEMPLATES = ["md", "html", "slides", "site"]
 
 /** Read dock.json from `dir`, or null if absent. Throws on malformed JSON. */
 export function loadConfig(dir = ".") {
@@ -56,25 +57,76 @@ export function writeId(dir, id) {
   return config
 }
 
-// Each template's entry file + its starter content. AGENTS.md + dock.json are
-// added to every template.
+// Each template's entry (what `dock publish` targets) + the starter file(s) it
+// writes. `site` is a multi-file bundle (entry is a directory). dock.json,
+// dock.schema.json, and AGENTS.md are added to every template.
 const STARTERS = {
-  md: { entry: "index.md", content: () => STARTER_MD },
-  html: { entry: "index.html", content: (t) => starterHtml(t) },
-  slides: { entry: "slides.html", content: (t) => starterSlides(t) },
+  md: { entry: "index.md", files: (t) => ({ "index.md": starterMd(t) }) },
+  html: { entry: "index.html", files: (t) => ({ "index.html": starterHtml(t) }) },
+  slides: { entry: "slides.html", files: (t) => ({ "slides.html": starterSlides(t) }) },
+  site: {
+    entry: "site",
+    files: (t) => ({
+      "site/index.html": starterSiteIndex(t),
+      "site/about.html": starterSiteAbout(t),
+      "site/style.css": SITE_CSS,
+    }),
+  },
 }
 
 /**
  * Files a new project gets for a template. dock.json drives publishing; AGENTS.md
- * is the loop convention for agents; the entry file is a publishable starter so
- * `dock publish` works immediately.
+ * is the loop convention for agents; the starter is publishable immediately.
  */
 export function scaffoldFiles(title = "My artifact", template = "md") {
   const t = STARTERS[template] ?? STARTERS.md
   return {
     [CONFIG_FILE]: `${JSON.stringify(defaultConfig(title, t.entry), null, 2)}\n`,
-    [t.entry]: t.content(title),
+    "dock.schema.json": `${JSON.stringify(DOCK_SCHEMA, null, 2)}\n`,
+    ...t.files(title),
     "AGENTS.md": AGENTS_MD,
+  }
+}
+
+/** JSON Schema for dock.json — gives editors autocomplete + validation. */
+export const DOCK_SCHEMA = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  title: "dock.json",
+  type: "object",
+  properties: {
+    title: { type: "string", description: "Artifact title." },
+    entry: { type: "string", description: "File or directory `dock publish` targets." },
+    visibility: { enum: ["public", "link", "org", "password"], default: "link" },
+    spa: { type: "boolean", description: "Serve a single-page-app fallback for unknown paths.", default: false },
+    id: { type: ["string", "null"], description: "Artifact short id; set automatically on first publish." },
+    server: { type: "string", description: "Dock server URL (overrides DOCK_SERVER)." },
+  },
+}
+
+/** Render comments as a readable thread list for `dock comments`. Pure. */
+export function formatComments(comments) {
+  if (!comments || comments.length === 0) return "No comments yet."
+  const threads = new Map()
+  for (const c of comments) {
+    if (!threads.has(c.thread_id)) threads.set(c.thread_id, [])
+    threads.get(c.thread_id).push(c)
+  }
+  const out = []
+  for (const [tid, thread] of threads) {
+    const root = thread[0]
+    const quote = anchorQuote(root.anchor)
+    out.push(`${root.state === "resolved" ? "✓" : "○"} thread ${tid}${quote ? `  “${quote}”` : ""}`)
+    for (const c of thread) out.push(`    ${c.author}: ${c.body_md.replace(/\n/g, " ")}`)
+  }
+  return out.join("\n")
+}
+
+const anchorQuote = (anchor) => {
+  if (!anchor) return null
+  try {
+    return JSON.parse(anchor).exact ?? null
+  } catch {
+    return null
   }
 }
 
@@ -100,7 +152,7 @@ export function scaffold(dir = ".", title = "My artifact", template = "md") {
   return { created, skipped }
 }
 
-const STARTER_MD = `# My artifact
+const starterMd = (title) => `# ${title}
 
 Edit this, then run \`dock publish\`. Every publish becomes a new version at the
 same URL, and reviewers can comment on the rendered page.
@@ -110,6 +162,34 @@ same URL, and reviewers can comment on the rendered page.
 Comments anchor to the words they're attached to. They survive edits best when
 surrounding text stays recognizable — keep headings stable and avoid rewording
 a sentence end to end when you only meant to tweak it. See STANDARD.md.
+`
+
+const starterSiteIndex = (title) => `<!doctype html>
+<meta charset="utf-8">
+<title>${title}</title>
+<link rel="stylesheet" href="/style.css">
+<nav><a href="/">Home</a> · <a href="/about.html">About</a></nav>
+<h1>${title}</h1>
+<p>A multi-page static site, published as one artifact. Build any generator into
+a folder; <code>dock publish</code> zips it and serves it. Absolute asset paths
+are rewritten so the bundle stays sandboxed.</p>
+`
+
+const starterSiteAbout = (title) => `<!doctype html>
+<meta charset="utf-8">
+<title>About · ${title}</title>
+<link rel="stylesheet" href="/style.css">
+<nav><a href="/">Home</a> · <a href="/about.html">About</a></nav>
+<h1>About</h1>
+<p>Page two. Internal links work; reviewers can comment on any page.</p>
+`
+
+const SITE_CSS = `body{font:16px/1.7 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;color:#23203a;
+  max-width:640px;margin:0 auto;padding:48px 24px}
+nav{font-size:14px;color:#655999;margin-bottom:22px}
+a{color:#655999}
+h1{letter-spacing:-.02em}
+code{background:#f1ead9;padding:1px 6px;border-radius:5px}
 `
 
 const starterHtml = (title) => `<!doctype html>
@@ -223,26 +303,21 @@ Each publish is a new immutable version at the same URL. Name a checkpoint with
 
 ## The loop: publish -> review -> revise
 
-1. **Publish** a draft. Share the URL.
-2. **Read comments** — each has a quote (the anchored text), a thread, and a state:
-   \`\`\`bash
-   curl -s "$DOCK_SERVER/v1/artifacts/$ID/comments"
-   \`\`\`
-3. **Revise** the source to address the feedback, then **publish again** — same id,
-   new version. The comment's highlight re-anchors to the moved text automatically.
-4. **Reply in-thread** to discuss, or **resolve** a thread once handled:
-   \`\`\`bash
-   # reply (omit thread_id to start a new thread)
-   curl -s -X POST "$DOCK_SERVER/v1/artifacts/$ID/comments" \\
-     -H 'content-type: application/json' \\
-     -d '{"thread_id":"<id>","body_md":"Addressed in the new version."}'
+The CLI has a verb for each step (all read the artifact id from dock.json):
 
-   # resolve the thread a comment belongs to
-   curl -s -X POST "$DOCK_SERVER/v1/artifacts/$ID/comments/<commentId>/resolve" \\
-     -H 'content-type: application/json' -d '{"state":"resolved"}'
-   \`\`\`
-   Republishing can also resolve threads in one call: add \`resolves=<commentId,...>\`
-   to the publish request.
+\`\`\`bash
+dock publish                      # 1. publish a draft, share the URL
+dock comments                     # 2. read the comment threads (quote · author · state)
+# 3. revise the source for the feedback, then:
+dock publish --name "Rev 2"       #    publish again — same URL, highlights re-anchor
+dock reply <thread_id> "Fixed in this version."   # 4a. discuss
+dock resolve <comment_id>         # 4b. close a handled thread  (dock reopen to undo)
+dock open                         # open the artifact in a browser
+\`\`\`
+
+Each is also a plain HTTP call if you'd rather not shell out — see the API under
+\`/v1/artifacts/:id/comments\`. Republishing can resolve threads in one shot:
+include \`resolves=<commentId,...>\` in the publish request.
 
 ## Keep comments anchorable
 

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -1,0 +1,252 @@
+// dock.json + scaffold logic, kept pure so it's unit-testable without a server.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+
+export const CONFIG_FILE = "dock.json"
+
+/** The dock.json a fresh project starts with (no id until first publish). */
+export const defaultConfig = (title = "My artifact", entry = "index.md") => ({
+  title,
+  entry,
+  visibility: "link",
+  spa: false,
+  id: null,
+})
+
+export const TEMPLATES = ["md", "html", "slides"]
+
+/** Read dock.json from `dir`, or null if absent. Throws on malformed JSON. */
+export function loadConfig(dir = ".") {
+  const path = join(dir, CONFIG_FILE)
+  if (!existsSync(path)) return null
+  try {
+    return JSON.parse(readFileSync(path, "utf8"))
+  } catch (e) {
+    throw new Error(`${CONFIG_FILE} is not valid JSON: ${e.message}`)
+  }
+}
+
+/**
+ * Effective publish settings: CLI flags win over dock.json, which wins over
+ * built-in defaults. Returns the values the publish command actually uses.
+ */
+export function resolvePublish(opts = {}, config = null) {
+  const c = config ?? {}
+  const spa = opts.spa != null ? opts.spa === "true" || opts.spa === true : !!c.spa
+  return {
+    id: opts.id ?? c.id ?? null,
+    target: opts.target ?? c.entry ?? null,
+    title: opts.title ?? c.title,
+    slug: opts.slug ?? c.slug,
+    visibility: opts.visibility ?? c.visibility,
+    spa,
+    message: opts.message,
+    name: opts.name,
+    server: opts.server ?? c.server ?? process.env.DOCK_SERVER ?? "http://localhost:8080",
+    token: opts.token ?? process.env.DOCK_TOKEN,
+  }
+}
+
+/** Persist the server-assigned id back into dock.json (preserving other keys). */
+export function writeId(dir, id) {
+  const path = join(dir, CONFIG_FILE)
+  const config = loadConfig(dir) ?? defaultConfig()
+  config.id = id
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`)
+  return config
+}
+
+// Each template's entry file + its starter content. AGENTS.md + dock.json are
+// added to every template.
+const STARTERS = {
+  md: { entry: "index.md", content: () => STARTER_MD },
+  html: { entry: "index.html", content: (t) => starterHtml(t) },
+  slides: { entry: "slides.html", content: (t) => starterSlides(t) },
+}
+
+/**
+ * Files a new project gets for a template. dock.json drives publishing; AGENTS.md
+ * is the loop convention for agents; the entry file is a publishable starter so
+ * `dock publish` works immediately.
+ */
+export function scaffoldFiles(title = "My artifact", template = "md") {
+  const t = STARTERS[template] ?? STARTERS.md
+  return {
+    [CONFIG_FILE]: `${JSON.stringify(defaultConfig(title, t.entry), null, 2)}\n`,
+    [t.entry]: t.content(title),
+    "AGENTS.md": AGENTS_MD,
+  }
+}
+
+/**
+ * Write the scaffold into `dir`. Never clobbers existing files. Returns
+ * { created: [...], skipped: [...] }.
+ */
+export function scaffold(dir = ".", title = "My artifact", template = "md") {
+  mkdirSync(dir, { recursive: true })
+  const files = scaffoldFiles(title, template)
+  const created = []
+  const skipped = []
+  for (const [name, contents] of Object.entries(files)) {
+    const path = join(dir, name)
+    if (existsSync(path)) {
+      skipped.push(name)
+      continue
+    }
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, contents)
+    created.push(name)
+  }
+  return { created, skipped }
+}
+
+const STARTER_MD = `# My artifact
+
+Edit this, then run \`dock publish\`. Every publish becomes a new version at the
+same URL, and reviewers can comment on the rendered page.
+
+## Tips for durable comments
+
+Comments anchor to the words they're attached to. They survive edits best when
+surrounding text stays recognizable — keep headings stable and avoid rewording
+a sentence end to end when you only meant to tweak it. See STANDARD.md.
+`
+
+const starterHtml = (title) => `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title}</title>
+<style>
+  body{font:17px/1.7 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;color:#23203a;
+    max-width:680px;margin:0 auto;padding:56px 24px}
+  h1{font-size:38px;letter-spacing:-.02em;margin:0 0 6px}
+  .sub{color:#6b6680;margin:0 0 28px}
+  code{background:#f1ead9;padding:1px 6px;border-radius:5px;font-size:.9em}
+</style>
+</head>
+<body>
+  <h1>${title}</h1>
+  <p class="sub">A standalone HTML artifact.</p>
+  <p>Edit this file and run <code>dock publish</code>. Each publish is a new version
+  at the same URL, and reviewers can select any text to comment on it.</p>
+</body>
+</html>
+`
+
+// Pure-HTML slides with a small viewing + presentation layer (arrow / space to
+// navigate, F for fullscreen). Self-contained so it renders in the sandbox.
+const starterSlides = (title) => `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title}</title>
+<style>
+  :root{--bg:#15101f;--fg:#f6e9d6;--ac:#b9aef0;--mut:#a99cc4}
+  *{box-sizing:border-box}
+  html,body{height:100%;margin:0}
+  body{background:var(--bg);color:var(--fg);font:20px/1.5 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;overflow:hidden}
+  .deck{height:100%}
+  .slide{position:absolute;inset:0;display:none;flex-direction:column;justify-content:center;
+    padding:8vh 10vw;animation:in .35s ease}
+  .slide.on{display:flex}
+  @keyframes in{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
+  h1{font-size:clamp(34px,6vw,68px);letter-spacing:-.025em;line-height:1.05;margin:0 0 .3em}
+  h2{font-size:clamp(26px,4vw,44px);letter-spacing:-.02em;margin:0 0 .4em}
+  p,li{font-size:clamp(18px,2.4vw,26px);color:var(--fg)}
+  .lede{color:var(--mut)}
+  ul{padding-left:1.1em} li{margin:.3em 0}
+  .bar{position:fixed;bottom:0;left:0;right:0;height:3px;background:rgba(255,255,255,.08)}
+  .bar i{display:block;height:100%;background:var(--ac);transition:width .3s}
+  .num{position:fixed;bottom:14px;right:18px;font-size:13px;color:var(--mut);font-variant-numeric:tabular-nums}
+  kbd{background:rgba(255,255,255,.1);border-radius:4px;padding:1px 6px;font-size:.8em}
+</style>
+</head>
+<body>
+<div class="deck">
+  <section class="slide on">
+    <h1>${title}</h1>
+    <p class="lede">Pure-HTML slides. <kbd>→</kbd> / <kbd>Space</kbd> to advance, <kbd>←</kbd> back, <kbd>F</kbd> fullscreen.</p>
+  </section>
+  <section class="slide">
+    <h2>One idea per slide</h2>
+    <ul>
+      <li>Write each slide as a <code>&lt;section class="slide"&gt;</code>.</li>
+      <li>Publish with <code>dock publish</code>; reviewers comment on any slide.</li>
+      <li>Every publish is a new version at the same URL.</li>
+    </ul>
+  </section>
+  <section class="slide">
+    <h2>Make it yours</h2>
+    <p class="lede">Edit the markup and styles. It's just HTML.</p>
+  </section>
+</div>
+<div class="bar"><i></i></div>
+<div class="num"></div>
+<script>
+  var slides=[].slice.call(document.querySelectorAll('.slide')),i=0;
+  var bar=document.querySelector('.bar i'),num=document.querySelector('.num');
+  function show(n){i=Math.max(0,Math.min(slides.length-1,n));
+    slides.forEach(function(s,k){s.classList.toggle('on',k===i)});
+    bar.style.width=((i+1)/slides.length*100)+'%';num.textContent=(i+1)+' / '+slides.length}
+  addEventListener('keydown',function(e){
+    if(e.key==='ArrowRight'||e.key===' '||e.key==='PageDown'){e.preventDefault();show(i+1)}
+    else if(e.key==='ArrowLeft'||e.key==='PageUp'){show(i-1)}
+    else if(e.key==='f'||e.key==='F'){if(!document.fullscreenElement)document.documentElement.requestFullscreen&&document.documentElement.requestFullscreen();else document.exitFullscreen()}
+  });
+  addEventListener('click',function(e){if(e.target.closest('a'))return;show(i+1)});
+  show(0);
+</script>
+</body>
+</html>
+`
+
+// Scaffolded into every project: the publish -> review -> revise loop, written
+// for an agent (or a human) to follow without prior knowledge of Dock.
+const AGENTS_MD = `# Working with Dock
+
+This project publishes to **Dock**: artifacts get a permanent URL, versions, and
+inline comments. Config lives in \`dock.json\`; the artifact id is filled in there
+after the first publish, so later publishes target the same artifact.
+
+## Publish
+
+\`\`\`bash
+dock publish              # publishes dock.json "entry", or:
+dock publish ./report.md  # a file, or a folder (a built site)
+\`\`\`
+
+Each publish is a new immutable version at the same URL. Name a checkpoint with
+\`dock publish --name "Final draft"\`.
+
+## The loop: publish -> review -> revise
+
+1. **Publish** a draft. Share the URL.
+2. **Read comments** — each has a quote (the anchored text), a thread, and a state:
+   \`\`\`bash
+   curl -s "$DOCK_SERVER/v1/artifacts/$ID/comments"
+   \`\`\`
+3. **Revise** the source to address the feedback, then **publish again** — same id,
+   new version. The comment's highlight re-anchors to the moved text automatically.
+4. **Reply in-thread** to discuss, or **resolve** a thread once handled:
+   \`\`\`bash
+   # reply (omit thread_id to start a new thread)
+   curl -s -X POST "$DOCK_SERVER/v1/artifacts/$ID/comments" \\
+     -H 'content-type: application/json' \\
+     -d '{"thread_id":"<id>","body_md":"Addressed in the new version."}'
+
+   # resolve the thread a comment belongs to
+   curl -s -X POST "$DOCK_SERVER/v1/artifacts/$ID/comments/<commentId>/resolve" \\
+     -H 'content-type: application/json' -d '{"state":"resolved"}'
+   \`\`\`
+   Republishing can also resolve threads in one call: add \`resolves=<commentId,...>\`
+   to the publish request.
+
+## Keep comments anchorable
+
+Anchors are text quotes with surrounding context. They survive edits when prose
+stays recognizable. Prefer small, local edits over wholesale rewrites; keep
+headings and distinctive phrases stable. Full guidance: STANDARD.md.
+`

--- a/packages/cli/test/config.test.js
+++ b/packages/cli/test/config.test.js
@@ -1,0 +1,121 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import {
+  CONFIG_FILE,
+  TEMPLATES,
+  defaultConfig,
+  loadConfig,
+  resolvePublish,
+  scaffold,
+  scaffoldFiles,
+  writeId,
+} from "../src/config.js"
+
+const dirs = []
+const tmp = () => {
+  const d = mkdtempSync(join(tmpdir(), "dock-cli-"))
+  dirs.push(d)
+  return d
+}
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+
+describe("scaffold", () => {
+  it("md template writes dock.json + index.md + AGENTS.md", () => {
+    const d = tmp()
+    const { created } = scaffold(d, "Report", "md")
+    expect(created.sort()).toEqual(["AGENTS.md", "dock.json", "index.md"])
+    const cfg = JSON.parse(readFileSync(join(d, CONFIG_FILE), "utf8"))
+    expect(cfg).toMatchObject({ title: "Report", entry: "index.md", id: null, visibility: "link" })
+  })
+
+  it("html template uses index.html as the entry", () => {
+    const d = tmp()
+    scaffold(d, "Page", "html")
+    expect(JSON.parse(readFileSync(join(d, CONFIG_FILE), "utf8")).entry).toBe("index.html")
+    expect(readFileSync(join(d, "index.html"), "utf8")).toContain("<title>Page</title>")
+  })
+
+  it("slides template scaffolds a self-contained deck with a nav layer", () => {
+    const d = tmp()
+    const { created } = scaffold(d, "Talk", "slides")
+    expect(created).toContain("slides.html")
+    const html = readFileSync(join(d, "slides.html"), "utf8")
+    expect(JSON.parse(readFileSync(join(d, CONFIG_FILE), "utf8")).entry).toBe("slides.html")
+    expect(html).toContain('class="slide')
+    expect(html).toMatch(/ArrowRight|ArrowLeft/) // keyboard navigation present
+  })
+
+  it("never clobbers existing files", () => {
+    const d = tmp()
+    writeFileSync(join(d, CONFIG_FILE), '{"title":"mine","id":"keep"}')
+    const { created, skipped } = scaffold(d, "X", "md")
+    expect(skipped).toContain(CONFIG_FILE)
+    expect(created).not.toContain(CONFIG_FILE)
+    expect(JSON.parse(readFileSync(join(d, CONFIG_FILE), "utf8")).id).toBe("keep")
+  })
+
+  it("exposes the three templates", () => {
+    expect(TEMPLATES).toEqual(["md", "html", "slides"])
+    expect(Object.keys(scaffoldFiles("T", "slides"))).toContain("slides.html")
+  })
+})
+
+describe("loadConfig", () => {
+  it("returns null when no dock.json", () => {
+    expect(loadConfig(tmp())).toBeNull()
+  })
+  it("parses dock.json", () => {
+    const d = tmp()
+    writeFileSync(join(d, CONFIG_FILE), JSON.stringify(defaultConfig("Y")))
+    expect(loadConfig(d)).toMatchObject({ title: "Y", entry: "index.md" })
+  })
+  it("throws a clear error on malformed JSON", () => {
+    const d = tmp()
+    writeFileSync(join(d, CONFIG_FILE), "{ not json")
+    expect(() => loadConfig(d)).toThrow(/not valid JSON/)
+  })
+})
+
+describe("resolvePublish", () => {
+  it("flags win over config win over defaults", () => {
+    const cfg = { id: "cfg", title: "cfgTitle", entry: "doc.md", visibility: "org", spa: true, server: "http://cfg" }
+    const r = resolvePublish({ title: "flagTitle", server: "http://flag" }, cfg)
+    expect(r.title).toBe("flagTitle") // flag wins
+    expect(r.id).toBe("cfg") // from config
+    expect(r.target).toBe("doc.md") // config entry
+    expect(r.visibility).toBe("org")
+    expect(r.spa).toBe(true)
+    expect(r.server).toBe("http://flag")
+  })
+  it("falls back to defaults with no config", () => {
+    const r = resolvePublish({ target: "x.md" }, null)
+    expect(r.id).toBeNull()
+    expect(r.target).toBe("x.md")
+    expect(r.server).toBe("http://localhost:8080")
+  })
+  it("--spa flag string coerces to boolean", () => {
+    expect(resolvePublish({ spa: "true" }, null).spa).toBe(true)
+    expect(resolvePublish({}, { spa: false }).spa).toBe(false)
+  })
+})
+
+describe("writeId", () => {
+  it("writes the assigned id, preserving other keys", () => {
+    const d = tmp()
+    scaffold(d, "Doc", "md")
+    writeId(d, "ab12cd34")
+    const cfg = JSON.parse(readFileSync(join(d, CONFIG_FILE), "utf8"))
+    expect(cfg.id).toBe("ab12cd34")
+    expect(cfg.title).toBe("Doc") // untouched
+    expect(cfg.entry).toBe("index.md")
+  })
+  it("creates a config if missing", () => {
+    const d = tmp()
+    writeId(d, "zz99")
+    expect(loadConfig(d).id).toBe("zz99")
+  })
+})

--- a/packages/cli/test/config.test.js
+++ b/packages/cli/test/config.test.js
@@ -6,6 +6,7 @@ import {
   CONFIG_FILE,
   TEMPLATES,
   defaultConfig,
+  formatComments,
   loadConfig,
   resolvePublish,
   scaffold,
@@ -27,7 +28,7 @@ describe("scaffold", () => {
   it("md template writes dock.json + index.md + AGENTS.md", () => {
     const d = tmp()
     const { created } = scaffold(d, "Report", "md")
-    expect(created.sort()).toEqual(["AGENTS.md", "dock.json", "index.md"])
+    expect(created.sort()).toEqual(["AGENTS.md", "dock.json", "dock.schema.json", "index.md"])
     const cfg = JSON.parse(readFileSync(join(d, CONFIG_FILE), "utf8"))
     expect(cfg).toMatchObject({ title: "Report", entry: "index.md", id: null, visibility: "link" })
   })
@@ -58,9 +59,49 @@ describe("scaffold", () => {
     expect(JSON.parse(readFileSync(join(d, CONFIG_FILE), "utf8")).id).toBe("keep")
   })
 
-  it("exposes the three templates", () => {
-    expect(TEMPLATES).toEqual(["md", "html", "slides"])
+  it("site template scaffolds a multi-file bundle with a directory entry", () => {
+    const d = tmp()
+    const { created } = scaffold(d, "Docs", "site")
+    expect(created).toEqual(expect.arrayContaining(["site/index.html", "site/about.html", "site/style.css"]))
+    expect(JSON.parse(readFileSync(join(d, CONFIG_FILE), "utf8")).entry).toBe("site")
+  })
+
+  it("writes a dock.schema.json and references it from dock.json", () => {
+    const d = tmp()
+    scaffold(d, "X", "md")
+    const cfg = JSON.parse(readFileSync(join(d, CONFIG_FILE), "utf8"))
+    expect(cfg.$schema).toBe("./dock.schema.json")
+    const schema = JSON.parse(readFileSync(join(d, "dock.schema.json"), "utf8"))
+    expect(schema.properties.visibility.enum).toContain("link")
+  })
+
+  it("exposes the four templates", () => {
+    expect(TEMPLATES).toEqual(["md", "html", "slides", "site"])
     expect(Object.keys(scaffoldFiles("T", "slides"))).toContain("slides.html")
+  })
+})
+
+describe("formatComments", () => {
+  const c = (id, tid, author, body, state = "open", anchor = null) => ({
+    id, thread_id: tid, author, body_md: body, state, anchor,
+  })
+  it("returns a friendly message when empty", () => {
+    expect(formatComments([])).toBe("No comments yet.")
+  })
+  it("groups by thread and shows author, body, and state glyph", () => {
+    const out = formatComments([
+      c("c1", "t1", "ava", "looks off", "open"),
+      c("c2", "t1", "bo", "fixed"),
+      c("c3", "t2", "ci", "done", "resolved"),
+    ])
+    expect(out).toContain("○ thread t1")
+    expect(out).toContain("    ava: looks off")
+    expect(out).toContain("    bo: fixed")
+    expect(out).toContain("✓ thread t2")
+  })
+  it("shows the anchored quote when present", () => {
+    const out = formatComments([c("c1", "t1", "ava", "tighten", "open", JSON.stringify({ exact: "p99 budget" }))])
+    expect(out).toContain("“p99 budget”")
   })
 })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,10 @@ importers:
       fflate:
         specifier: ^0.8.2
         version: 0.8.3
+    devDependencies:
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.6(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)
 
   packages/core:
     dependencies:


### PR DESCRIPTION
**Phase B · B1** — the full init + CLI surface that makes publish → review → revise a real workflow, plus the documented standard.

## `dock init` — scaffold a project
```bash
dock init my-doc --template slides --title "Q3 Strategy"
```
Writes `dock.json` (title, entry, visibility, spa, id, `$schema`), a `dock.schema.json` (editor autocomplete), `AGENTS.md` (the loop), and a publishable starter. Never clobbers existing files.

**Templates:** `md` · `html` · `slides` · `site`.
- **slides** — a self-contained pure-HTML deck with a viewing/presentation layer (←/→/Space nav, progress bar, slide counter, F fullscreen). The seed of first-class slides; no imports.
- **site** — a multi-page static-site starter that publishes as a bundle.

## Zero-flag publish
`dock publish` reads `dock.json` (entry, title, visibility, spa, id); flags override. The first publish **writes the id back**, so later publishes target the same artifact with no flags. Direct `dock publish <file|dir>` still works.

## The loop is real CLI, not curl
```bash
dock comments              # threads: quote · author · state
dock reply <thread> <msg…> # reply in a thread
dock resolve|reopen <id>   # set a thread's state
dock open                  # open the artifact in a browser
```
All read the id from `dock.json`. `AGENTS.md` is written in these verbs so agents follow the loop natively.

## The content standard
**[STANDARD.md](STANDARD.md):** anchor-friendly authoring (why comments survive edits) + the **anchor-client protocol** (`/raw/dock-client.js` postMessage contract) as a public spec any viewer can implement.

## Verification
End-to-end, browser + live server: `init slides` → `publish` (id saved) → edit → `publish --name` (v2, same id) → deck renders + navigates; then `dock comments` → `reply` (2-message thread) → `resolve` (✓) → `open`. **89 tests** (18 CLI unit: scaffold per template, no-clobber, schema, config precedence, id write-back, formatComments), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)