### PR TITLE
Slides: real presentation layer — on-screen controls, fullscreen, deck protocol

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -64,8 +64,33 @@ HTML, old artifacts would be frozen on old client behavior forever. Serving it a
 a URL (short cache) lets the comment layer evolve independently of published
 content — and lets other tools build their own viewers against this contract.
 
-## 3. The agent loop
+## 3. The deck protocol (slides)
+
+An artifact that is a slide deck can announce itself so the Dock viewer shows a
+presentation bar (prev / next / position / fullscreen) and can drive it. Like the
+anchor client, it's pure `postMessage`. Opt-in: any HTML that posts these works;
+anything that doesn't is served normally.
+
+### Deck → host (`source: "dock-deck"`)
+
+| `type` | payload | meaning |
+|---|---|---|
+| `state` | `{ i, total }` | current slide index (0-based) and slide count; post on load and on every change |
+
+### Host → deck (`source: "dock-host"`)
+
+| `type` | payload | meaning |
+|---|---|---|
+| `deck` | `{ action: "next" \| "prev" \| "goto", n? }` | advance, go back, or jump to slide `n` |
+
+The deck owns its own rendering, keyboard, and on-screen controls; the host bar
+is an additional driver. Fullscreen is host-side (it fullscreens the iframe
+wrapper), so a deck needs no special support for it. `dock init --template slides`
+scaffolds a deck that speaks this protocol.
+
+## 4. The agent loop
 
 `dock init` scaffolds an `AGENTS.md` describing publish → read comments → revise
-→ reply/resolve over the HTTP API. That's the convention for agents (and humans)
-to close the loop without prior knowledge of Dock.
+→ reply/resolve over the HTTP API (and the matching `dock comments` / `reply` /
+`resolve` / `open` verbs). That's the convention for agents (and humans) to close
+the loop without prior knowledge of Dock.

--- a/apps/web/src/pages/Artifact.tsx
+++ b/apps/web/src/pages/Artifact.tsx
@@ -38,15 +38,24 @@ export function Artifact() {
 
   // The anchor channel with the sandboxed iframe (see SELECTION_SCRIPT).
   const frame = useRef<HTMLIFrameElement>(null)
+  const presentWrap = useRef<HTMLDivElement>(null)
   const [frameReady, setFrameReady] = useState(0)
   const [inDoc, setInDoc] = useState<Record<string, boolean>>({})
   const [activeThread, setActiveThread] = useState<string | null>(null)
+  // Set when the artifact announces itself as a deck (dock-deck protocol).
+  const [deck, setDeck] = useState<{ i: number; total: number } | null>(null)
   const threadEls = useRef(new Map<string, HTMLDivElement>())
 
   useEffect(() => {
     const onMsg = (e: MessageEvent) => {
       const d = e.data
-      if (!d || d.source !== "dock") return
+      if (!d) return
+      // A slide deck reporting its position (any HTML that speaks the protocol).
+      if (d.source === "dock-deck" && d.type === "state") {
+        setDeck({ i: d.i ?? 0, total: d.total ?? 1 })
+        return
+      }
+      if (d.source !== "dock") return
       if (d.type === "select") setAnchor(d.selector ?? null)
       // which threads' text exists in the shown version (truth for highlights + badges)
       else if (d.type === "anchors-resolved") setInDoc(d.resolved ?? {})
@@ -59,6 +68,31 @@ export function Artifact() {
     window.addEventListener("message", onMsg)
     return () => window.removeEventListener("message", onMsg)
   }, [])
+
+  // Drive the deck from the host bar; fullscreen wraps the iframe + bar so the
+  // controls stay reachable while presenting.
+  const deckCmd = (action: "next" | "prev" | "goto", n?: number) =>
+    frame.current?.contentWindow?.postMessage({ source: "dock-host", type: "deck", action, n }, "*")
+  const toggleFullscreen = () => {
+    const el = presentWrap.current
+    if (!el) return
+    if (document.fullscreenElement) document.exitFullscreen()
+    else el.requestFullscreen?.()
+  }
+  // Reset deck state when the artifact/version changes (re-announced on load).
+  useEffect(() => setDeck(null), [shortId, version])
+  // Arrow keys drive the deck from the host (when not typing in a field).
+  useEffect(() => {
+    if (!deck) return
+    const onKey = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement
+      if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA")) return
+      if (e.key === "ArrowRight") deckCmd("next")
+      else if (e.key === "ArrowLeft") deckCmd("prev")
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [deck])
 
   // Paint highlights for open, anchored threads whenever the doc or comments change.
   const sendAnchors = useCallback(() => {
@@ -268,14 +302,25 @@ export function Artifact() {
               {view === "diff" && shown !== art.current_version ? (
                 <DiffView diff={diff} fromLabel={`v${shown}`} toLabel="current" />
               ) : (
-                <iframe
-                  ref={frame}
-                  onLoad={() => setFrameReady((n) => n + 1)}
-                  title={art.title ?? shortId}
-                  src={rawSrc}
-                  sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
-                  style={{ flex: 1, border: 0, background: "#fff" }}
-                />
+                <div ref={presentWrap} style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0, position: "relative", background: "#fff" }}>
+                  <iframe
+                    ref={frame}
+                    onLoad={() => setFrameReady((n) => n + 1)}
+                    title={art.title ?? shortId}
+                    src={rawSrc}
+                    allow="fullscreen"
+                    sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
+                    style={{ flex: 1, border: 0, background: "#fff" }}
+                  />
+                  {deck && (
+                    <DeckBar
+                      deck={deck}
+                      onPrev={() => deckCmd("prev")}
+                      onNext={() => deckCmd("next")}
+                      onFullscreen={toggleFullscreen}
+                    />
+                  )}
+                </div>
               )}
             </>
           )}
@@ -417,6 +462,59 @@ function Thread({
 
 // Who is viewing right now. Live over the presence SSE channel; self listed
 // first as "you". Hidden when you're the only one here.
+// Host presentation bar — shown when the artifact is a slide deck. Drives the
+// deck over postMessage and fullscreens the wrapper (controls stay reachable).
+function DeckBar({
+  deck,
+  onPrev,
+  onNext,
+  onFullscreen,
+}: {
+  deck: { i: number; total: number }
+  onPrev: () => void
+  onNext: () => void
+  onFullscreen: () => void
+}) {
+  const btn: React.CSSProperties = {
+    width: 30,
+    height: 30,
+    borderRadius: 8,
+    border: "1px solid var(--line)",
+    background: "var(--card)",
+    color: "var(--fg)",
+    cursor: "pointer",
+    display: "grid",
+    placeItems: "center",
+    fontSize: 15,
+  }
+  return (
+    <div
+      style={{
+        position: "absolute",
+        bottom: 14,
+        left: "50%",
+        transform: "translateX(-50%)",
+        display: "flex",
+        alignItems: "center",
+        gap: 6,
+        padding: 6,
+        borderRadius: 999,
+        background: "var(--card)",
+        border: "1px solid var(--line)",
+        boxShadow: "var(--shadow)",
+        zIndex: 5,
+      }}
+    >
+      <button style={btn} onClick={onPrev} disabled={deck.i <= 0} aria-label="Previous slide">‹</button>
+      <span className="mono" style={{ fontSize: 12, color: "var(--fg-mut)", minWidth: 52, textAlign: "center" }}>
+        {deck.i + 1} / {deck.total}
+      </span>
+      <button style={btn} onClick={onNext} disabled={deck.i >= deck.total - 1} aria-label="Next slide">›</button>
+      <button style={{ ...btn, marginLeft: 4 }} onClick={onFullscreen} title="Present (fullscreen)" aria-label="Present fullscreen">⛶</button>
+    </div>
+  )
+}
+
 function Presence({ viewers, self }: { viewers: string[]; self: string }) {
   const others = viewers.filter((v) => v !== self)
   if (others.length === 0) return null

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -215,8 +215,9 @@ const starterHtml = (title) => `<!doctype html>
 </html>
 `
 
-// Pure-HTML slides with a small viewing + presentation layer (arrow / space to
-// navigate, F for fullscreen). Self-contained so it renders in the sandbox.
+// Pure-HTML slides with a real presentation layer: on-screen prev/next +
+// fullscreen, keyboard, and the dock-deck protocol so the Dock viewer can drive
+// it too (postMessage). Self-contained, renders in the sandbox.
 const starterSlides = (title) => `<!doctype html>
 <html lang="en">
 <head>
@@ -240,7 +241,17 @@ const starterSlides = (title) => `<!doctype html>
   ul{padding-left:1.1em} li{margin:.3em 0}
   .bar{position:fixed;bottom:0;left:0;right:0;height:3px;background:rgba(255,255,255,.08)}
   .bar i{display:block;height:100%;background:var(--ac);transition:width .3s}
-  .num{position:fixed;bottom:14px;right:18px;font-size:13px;color:var(--mut);font-variant-numeric:tabular-nums}
+  /* on-screen controls — fade in on hover/move, always reachable */
+  .ctrl{position:fixed;bottom:16px;left:50%;transform:translateX(-50%);display:flex;align-items:center;gap:6px;
+    background:rgba(20,16,31,.72);border:1px solid rgba(255,255,255,.12);border-radius:999px;padding:6px 8px;
+    backdrop-filter:blur(8px);opacity:0;transition:opacity .25s;z-index:5}
+  body:hover .ctrl,.ctrl:focus-within{opacity:1}
+  .ctrl button{width:34px;height:34px;border:0;border-radius:50%;background:transparent;color:var(--fg);
+    font-size:16px;cursor:pointer;display:grid;place-items:center}
+  .ctrl button:hover{background:rgba(255,255,255,.12)}
+  .ctrl .pos{font-size:13px;color:var(--mut);padding:0 8px;font-variant-numeric:tabular-nums;min-width:54px;text-align:center}
+  .edge{position:fixed;top:0;bottom:0;width:18vw;border:0;background:transparent;cursor:pointer;z-index:4}
+  .edge.l{left:0} .edge.r{right:0}
   kbd{background:rgba(255,255,255,.1);border-radius:4px;padding:1px 6px;font-size:.8em}
 </style>
 </head>
@@ -248,7 +259,7 @@ const starterSlides = (title) => `<!doctype html>
 <div class="deck">
   <section class="slide on">
     <h1>${title}</h1>
-    <p class="lede">Pure-HTML slides. <kbd>→</kbd> / <kbd>Space</kbd> to advance, <kbd>←</kbd> back, <kbd>F</kbd> fullscreen.</p>
+    <p class="lede">Pure-HTML slides. <kbd>→</kbd> / <kbd>Space</kbd> advance, <kbd>←</kbd> back, <kbd>F</kbd> fullscreen.</p>
   </section>
   <section class="slide">
     <h2>One idea per slide</h2>
@@ -263,21 +274,41 @@ const starterSlides = (title) => `<!doctype html>
     <p class="lede">Edit the markup and styles. It's just HTML.</p>
   </section>
 </div>
+<button class="edge l" aria-label="Previous"></button>
+<button class="edge r" aria-label="Next"></button>
 <div class="bar"><i></i></div>
-<div class="num"></div>
+<div class="ctrl">
+  <button data-act="prev" aria-label="Previous slide">‹</button>
+  <span class="pos"></span>
+  <button data-act="next" aria-label="Next slide">›</button>
+  <button data-act="full" aria-label="Fullscreen" title="Fullscreen (F)">⛶</button>
+</div>
 <script>
   var slides=[].slice.call(document.querySelectorAll('.slide')),i=0;
-  var bar=document.querySelector('.bar i'),num=document.querySelector('.num');
+  var bar=document.querySelector('.bar i'),pos=document.querySelector('.pos');
+  function announce(){ // dock-deck protocol: report position to the Dock viewer
+    try{parent.postMessage({source:'dock-deck',type:'state',i:i,total:slides.length},'*')}catch(e){}
+  }
   function show(n){i=Math.max(0,Math.min(slides.length-1,n));
     slides.forEach(function(s,k){s.classList.toggle('on',k===i)});
-    bar.style.width=((i+1)/slides.length*100)+'%';num.textContent=(i+1)+' / '+slides.length}
+    bar.style.width=((i+1)/slides.length*100)+'%';pos.textContent=(i+1)+' / '+slides.length;announce()}
+  function full(){if(!document.fullscreenElement){(document.documentElement.requestFullscreen||function(){})()}else{document.exitFullscreen()}}
   addEventListener('keydown',function(e){
     if(e.key==='ArrowRight'||e.key===' '||e.key==='PageDown'){e.preventDefault();show(i+1)}
     else if(e.key==='ArrowLeft'||e.key==='PageUp'){show(i-1)}
-    else if(e.key==='f'||e.key==='F'){if(!document.fullscreenElement)document.documentElement.requestFullscreen&&document.documentElement.requestFullscreen();else document.exitFullscreen()}
+    else if(e.key==='f'||e.key==='F'){full()}
+    else if(e.key==='Home'){show(0)} else if(e.key==='End'){show(slides.length-1)}
   });
-  addEventListener('click',function(e){if(e.target.closest('a'))return;show(i+1)});
-  show(0);
+  document.querySelector('.ctrl').addEventListener('click',function(e){
+    var b=e.target.closest('button'); if(!b)return;
+    var a=b.getAttribute('data-act'); if(a==='prev')show(i-1); else if(a==='next')show(i+1); else if(a==='full')full()});
+  document.querySelector('.edge.l').addEventListener('click',function(){show(i-1)});
+  document.querySelector('.edge.r').addEventListener('click',function(){show(i+1)});
+  // accept drive commands from the Dock viewer's presentation bar
+  addEventListener('message',function(e){var d=e.data;
+    if(!d||d.source!=='dock-host'||d.type!=='deck')return;
+    if(d.action==='next')show(i+1);else if(d.action==='prev')show(i-1);else if(d.action==='goto')show(d.n)});
+  show(0); announce();
 </script>
 </body>
 </html>

--- a/packages/cli/test/config.test.js
+++ b/packages/cli/test/config.test.js
@@ -40,14 +40,18 @@ describe("scaffold", () => {
     expect(readFileSync(join(d, "index.html"), "utf8")).toContain("<title>Page</title>")
   })
 
-  it("slides template scaffolds a self-contained deck with a nav layer", () => {
+  it("slides template scaffolds a deck with controls + the dock-deck protocol", () => {
     const d = tmp()
     const { created } = scaffold(d, "Talk", "slides")
     expect(created).toContain("slides.html")
     const html = readFileSync(join(d, "slides.html"), "utf8")
     expect(JSON.parse(readFileSync(join(d, CONFIG_FILE), "utf8")).entry).toBe("slides.html")
     expect(html).toContain('class="slide')
-    expect(html).toMatch(/ArrowRight|ArrowLeft/) // keyboard navigation present
+    expect(html).toMatch(/ArrowRight|ArrowLeft/) // keyboard navigation
+    expect(html).toMatch(/data-act="prev"|data-act="next"/) // on-screen prev/next
+    expect(html).toContain('data-act="full"') // fullscreen control
+    expect(html).toContain("source:'dock-deck'") // announces state to the host
+    expect(html).toMatch(/dock-host[\s\S]*deck/) // accepts host drive commands
   })
 
   it("never clobbers existing files", () => {


### PR DESCRIPTION
Makes slide decks proper to present: visible prev/next, fullscreen, and a Dock-viewer presentation bar that can drive any deck.

## Deck template (`dock init --template slides`)
- **On-screen controls** — a bottom `‹ n/total › ⛶` cluster (fades in on hover) plus invisible left/right edge click-zones. Keyboard still works (←/→/Space/Home/End, **F** fullscreen).
- **Speaks the `dock-deck` protocol** — posts `{source:"dock-deck", type:"state", i, total}` on load + each change; accepts `{source:"dock-host", type:"deck", action}` so the viewer can drive it.

## Dock viewer (host)
- **Detects a deck** from its state message and shows a **presentation bar** over the artifact: `◀ n / total ▶` + **Present**. Prev/Next drive the deck over `postMessage` (disable at the ends); ←/→ at the host drive it too.
- **Present** fullscreens a wrapper around the iframe + bar, so controls stay reachable while presenting. The iframe gets `allow="fullscreen"`, so the deck's own **F** key works as well.

## Standard
[STANDARD.md](STANDARD.md) documents the `dock-deck` protocol as a public, opt-in contract — any HTML that posts it gets the presentation chrome; anything that doesn't is served normally.

## Verification
Browser-driven against the running viewer: published a slides deck → the host presentation bar appeared (`‹ 1/3 › ⛶`) → **Next** drove the deck across all slides (counter synced, buttons disabled at the ends). **89 tests** (deck-template test added: on-screen controls + protocol present), typecheck clean, build + prerender pass.

Builds on #20 (time-based version history) and #22 (the slides template). No stack — off current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)