### PR TITLE
feat(mcp): complete the agent publish→review→revise loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ Point an agent at a Dock server over MCP (stdio):
 DOCK_SERVER=http://localhost:8080 pnpm --filter @dock/mcp start
 ```
 
-Tools: `publish_artifact`, `publish_version` (with `resolves`), `get_artifact` (source read-back), `list_versions`, `list_comments`, `reply_comment`.
+Tools: `publish_artifact`, `publish_version` (with `resolves`), `get_artifact`
+(source read-back), `list_versions`, `diff_versions`, `restore_version`,
+`list_comments`, `add_comment` (with a `quote` anchor), `reply_comment`,
+`resolve_thread`, `view_stats`. The `dock://guide` resource serves the full
+publish → review → revise loop (also in [packages/mcp/SKILL.md](packages/mcp/SKILL.md)).
 
 ## Live updates
 

--- a/packages/mcp/SKILL.md
+++ b/packages/mcp/SKILL.md
@@ -1,0 +1,49 @@
+# Dock — agent skill
+
+Dock hosts an artifact (HTML, Markdown, or a static bundle) at a permanent,
+versioned URL with inline comments. You drive the **publish → review → revise**
+loop through these MCP tools. Also readable as the `dock://guide` resource.
+
+## Tools
+
+| Tool | Use |
+|---|---|
+| `publish_artifact` | Publish new content; returns a `short_id` + URL. |
+| `publish_version` | New version of an existing artifact (same URL). `resolves: [ids]` closes threads in the same step. |
+| `get_artifact` | Read metadata + source for a version (defaults to current). |
+| `list_versions` | Version history. |
+| `diff_versions` | What changed between two versions (defaults previous → current). |
+| `restore_version` | Make a past version current again (history is preserved). |
+| `list_comments` | The feedback queue; filter by `open` / `resolved`. |
+| `add_comment` | Leave new feedback; optionally `quote` exact text to anchor it. |
+| `reply_comment` | Reply in an existing thread (`thread_id`). |
+| `resolve_thread` | Resolve (or reopen) the thread a comment belongs to. |
+| `view_stats` | View analytics (total, unique, per-version). |
+
+## The loop
+
+1. **Publish** a draft with `publish_artifact`. Keep the `short_id`.
+2. **Read** feedback with `list_comments` (state `open`). Each comment has a
+   quoted anchor, a thread, and a base version.
+3. **Understand** a comment in context: `get_artifact` for the source, or
+   `diff_versions` to see what changed since it was written.
+4. **Revise** the source and `publish_version` — the same URL, a new version.
+   Comment highlights re-anchor to the moved text automatically. Pass
+   `resolves: [commentId]` to close the threads you addressed in one call.
+5. **Reply** with `reply_comment` to discuss, or `resolve_thread` to close a
+   thread once handled. Leave your own review with `add_comment` (+ `quote`).
+
+## Keep comments anchorable
+
+Anchors are text quotes with surrounding context, matched in the rendered
+document. They survive edits when the text stays recognizable: make local edits,
+keep headings and distinctive phrases stable, and prefer real text over images
+of text. A comment whose text is gone is shown as "text changed", never moved to
+the wrong place.
+
+## Notes
+
+- Versions are immutable; `@vN` URLs never change. The viewer groups rapid
+  same-author revisions into time-based sessions, but every revision is addressable.
+- Set `DOCK_SERVER` (and `DOCK_TOKEN` if the instance is gated) for the tools to
+  reach your Dock server.

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -35,6 +35,21 @@ export interface NewCommentArgs {
   anchor?: unknown
 }
 
+export interface VersionJson {
+  n: number
+  author: string
+  message: string | null
+  name: string | null
+  created_at: string
+}
+export interface SessionJson {
+  n: number
+  from_n: number
+  count: number
+  author: string
+  name: string | null
+  created_at: string
+}
 export interface ArtifactJson {
   short_id: string
   url: string
@@ -42,7 +57,27 @@ export interface ArtifactJson {
   kind: "file" | "bundle"
   visibility: string
   current_version: number
-  versions: { n: number; author: string; message: string | null; created_at: string }[]
+  versions: VersionJson[]
+  /** Time-grouped version view (newest-first); present on the detail endpoint. */
+  sessions?: SessionJson[]
+}
+
+export interface DiffOpJson {
+  t: "ctx" | "add" | "del"
+  line: string
+}
+export interface DiffJson {
+  from: number
+  to: number
+  ops: DiffOpJson[]
+}
+
+export interface ViewStatsJson {
+  total: number
+  unique: number
+  perVersion: { version: number; count: number }[]
+  daily: { day: string; count: number }[]
+  recent: { viewer: string; kind: "user" | "anon"; at: string }[]
 }
 
 export interface DockClient {
@@ -51,6 +86,14 @@ export interface DockClient {
   getContent(shortId: string, version?: number): Promise<string>
   listComments(shortId: string, state?: "open" | "resolved"): Promise<CommentJson[]>
   createComment(shortId: string, args: NewCommentArgs): Promise<CommentJson>
+  /** Resolve or reopen the thread a comment belongs to. */
+  setThreadState(shortId: string, commentId: string, state: "resolved" | "open"): Promise<void>
+  /** Line diff between two versions (defaults: current-1 → current). */
+  diff(shortId: string, from?: number, to?: number): Promise<DiffJson>
+  /** Restore a past version as a new current revision. */
+  restore(shortId: string, version: number): Promise<ArtifactJson>
+  /** Aggregated view analytics. */
+  viewStats(shortId: string): Promise<ViewStatsJson>
 }
 
 export interface ClientOptions {
@@ -119,6 +162,41 @@ export function createClient(opts: ClientOptions): DockClient {
           body: JSON.stringify(args),
         }),
       ) as Promise<CommentJson>
+    },
+
+    async setThreadState(shortId, commentId, state) {
+      await ok(
+        await f(`${base}/v1/artifacts/${shortId}/comments/${commentId}/resolve`, {
+          method: "POST",
+          headers: { ...authHeaders, "content-type": "application/json" },
+          body: JSON.stringify({ state }),
+        }),
+      )
+    },
+
+    async diff(shortId, from, to) {
+      const q = new URLSearchParams({ format: "json" })
+      if (from != null) q.set("from", String(from))
+      if (to != null) q.set("to", String(to))
+      return ok(
+        await f(`${base}/v1/artifacts/${shortId}/diff?${q}`, { headers: authHeaders }),
+      ) as Promise<DiffJson>
+    },
+
+    async restore(shortId, version) {
+      return ok(
+        await f(`${base}/v1/artifacts/${shortId}/restore`, {
+          method: "POST",
+          headers: { ...authHeaders, "content-type": "application/json" },
+          body: JSON.stringify({ version }),
+        }),
+      ) as Promise<ArtifactJson>
+    },
+
+    async viewStats(shortId) {
+      return ok(
+        await f(`${base}/v1/artifacts/${shortId}/analytics`, { headers: authHeaders }),
+      ) as Promise<ViewStatsJson>
     },
   }
 }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod"
@@ -7,6 +9,15 @@ const client = createClient({
   baseUrl: process.env.DOCK_SERVER ?? "http://localhost:8080",
   token: process.env.DOCK_TOKEN,
 })
+
+// The agent guide, served as an MCP resource (single source: SKILL.md).
+const GUIDE = (() => {
+  try {
+    return readFileSync(fileURLToPath(new URL("../SKILL.md", import.meta.url)), "utf8")
+  } catch {
+    return "# Dock\nPublish, read comments, revise, reply, resolve via the dock tools."
+  }
+})()
 
 const server = new McpServer({ name: "dock", version: "0.1.0" })
 
@@ -108,6 +119,94 @@ server.registerTool(
     const c = await client.createComment(short_id, { thread_id, body_md, author: "agent" })
     return text(`Replied in thread ${c.thread_id} (comment ${c.id}).`)
   },
+)
+
+server.registerTool(
+  "add_comment",
+  {
+    description:
+      "Leave new feedback as a new thread. Optionally anchor it to a quoted span of the rendered text.",
+    inputSchema: {
+      short_id: z.string(),
+      body_md: z.string(),
+      quote: z.string().optional().describe("Exact text to anchor the comment to."),
+    },
+  },
+  async ({ short_id, body_md, quote }) => {
+    const anchor = quote ? { type: "TextQuoteSelector", exact: quote } : undefined
+    const c = await client.createComment(short_id, { body_md, anchor, author: "agent" })
+    return text(`Commented (thread ${c.thread_id}, comment ${c.id})${quote ? ` on “${quote}”` : ""}.`)
+  },
+)
+
+server.registerTool(
+  "resolve_thread",
+  {
+    description: "Resolve (or reopen) the thread a comment belongs to, once feedback is handled.",
+    inputSchema: {
+      short_id: z.string(),
+      comment_id: z.string(),
+      state: z.enum(["resolved", "open"]).default("resolved"),
+    },
+  },
+  async ({ short_id, comment_id, state }) => {
+    await client.setThreadState(short_id, comment_id, state)
+    return text(`Thread ${state === "resolved" ? "resolved" : "reopened"}.`)
+  },
+)
+
+server.registerTool(
+  "diff_versions",
+  {
+    description: "Show what changed between two versions (defaults to previous → current).",
+    inputSchema: {
+      short_id: z.string(),
+      from: z.number().int().optional(),
+      to: z.number().int().optional(),
+    },
+  },
+  async ({ short_id, from, to }) => {
+    const d = await client.diff(short_id, from, to)
+    const body = d.ops
+      .map((o) => `${o.t === "add" ? "+" : o.t === "del" ? "-" : " "} ${o.line}`)
+      .join("\n")
+    const adds = d.ops.filter((o) => o.t === "add").length
+    const dels = d.ops.filter((o) => o.t === "del").length
+    return text(`diff v${d.from} → v${d.to}  (+${adds} -${dels})\n\n${body}`)
+  },
+)
+
+server.registerTool(
+  "restore_version",
+  {
+    description: "Restore a past version as a new current revision (history is not rewritten).",
+    inputSchema: { short_id: z.string(), version: z.number().int() },
+  },
+  async ({ short_id, version }) => {
+    const a = await client.restore(short_id, version)
+    return text(`Restored v${version} → ${a.url} is now v${a.current_version}.`)
+  },
+)
+
+server.registerTool(
+  "view_stats",
+  {
+    description: "Read view analytics for an artifact (total, unique viewers, per-version).",
+    inputSchema: { short_id: z.string() },
+  },
+  async ({ short_id }) => {
+    const s = await client.viewStats(short_id)
+    const perV = s.perVersion.map((v) => `v${v.version}: ${v.count}`).join(", ")
+    return text(`${s.total} views · ${s.unique} unique${perV ? `\nby version — ${perV}` : ""}`)
+  },
+)
+
+// Expose the agent loop as an MCP resource so any client can read the conventions.
+server.registerResource(
+  "dock-guide",
+  "dock://guide",
+  { title: "Dock agent guide", description: "How to run the publish → review → revise loop.", mimeType: "text/markdown" },
+  async (uri) => ({ contents: [{ uri: uri.href, mimeType: "text/markdown", text: GUIDE }] }),
 )
 
 await server.connect(new StdioServerTransport())

--- a/packages/mcp/test/client.test.ts
+++ b/packages/mcp/test/client.test.ts
@@ -89,6 +89,52 @@ describe("dock client (the MCP server's backend) over real HTTP", () => {
     expect(await client.listComments(a.short_id, "open")).toHaveLength(0)
   })
 
+  it("resolves and reopens a thread directly (not just via republish)", async () => {
+    const a = await client.publish({ content: "x", filename: "t.md" })
+    const c = await client.createComment(a.short_id, { body_md: "fix", author: "jess" })
+    await client.setThreadState(a.short_id, c.id, "resolved")
+    expect(await client.listComments(a.short_id, "open")).toHaveLength(0)
+    await client.setThreadState(a.short_id, c.id, "open")
+    expect(await client.listComments(a.short_id, "open")).toHaveLength(1)
+  })
+
+  it("leaves an anchored comment as a new thread", async () => {
+    const a = await client.publish({ content: "alpha beta", filename: "ac.md" })
+    const c = await client.createComment(a.short_id, {
+      body_md: "on beta",
+      author: "agent",
+      anchor: { type: "TextQuoteSelector", exact: "beta" },
+    })
+    expect(c.thread_id).toBe(c.id) // a brand-new thread
+    expect(JSON.parse(c.anchor as string).exact).toBe("beta")
+  })
+
+  it("diffs two versions", async () => {
+    const a = await client.publish({ content: "# title\nalpha", filename: "d.md" })
+    await client.publish({ id: a.short_id, content: "# title\nbeta", filename: "d.md", message: "v2" })
+    const d = await client.diff(a.short_id, 1, 2)
+    expect(d).toMatchObject({ from: 1, to: 2 })
+    expect(d.ops).toContainEqual({ t: "add", line: "beta" })
+    expect(d.ops).toContainEqual({ t: "del", line: "alpha" })
+  })
+
+  it("restores a past version as a new current revision", async () => {
+    const a = await client.publish({ content: "original", filename: "r.md" })
+    await client.publish({ id: a.short_id, content: "changed", filename: "r.md", message: "v2" })
+    const restored = await client.restore(a.short_id, 1)
+    expect(restored.current_version).toBe(3)
+    expect(await client.getContent(a.short_id)).toBe("original")
+    expect(await client.getContent(a.short_id, 1)).toBe("original") // history intact
+  })
+
+  it("includes time-grouped sessions and version names on the detail endpoint", async () => {
+    const a = await client.publish({ content: "v1", filename: "s.md" })
+    await client.publish({ id: a.short_id, content: "v2", filename: "s.md", message: "edit" })
+    const got = await client.get(a.short_id)
+    expect(Array.isArray(got.sessions)).toBe(true)
+    expect(got.versions[0]).toHaveProperty("name")
+  })
+
   it("surfaces server errors as thrown messages", async () => {
     await expect(client.get("nope0000")).rejects.toThrow(/dock 404/)
   })


### PR DESCRIPTION
Brings the MCP server to parity with the HTTP API so an agent can run the entire artifact loop headlessly — no web UI needed.

## New tools
| Tool | Use |
|---|---|
| `add_comment` | Leave new feedback as a new thread; optional `quote` anchors it to a span of rendered text. |
| `resolve_thread` | Resolve (or reopen) the thread a comment belongs to. |
| `diff_versions` | Unified line diff between two versions (defaults previous → current). |
| `restore_version` | Re-point a new current revision at an old blob; history is preserved, not rewritten. |
| `view_stats` | Total / unique / per-version view analytics. |

Plus the existing `publish_artifact`, `publish_version` (with `resolves`), `get_artifact`, `list_versions`, `list_comments`, `reply_comment` — **11 tools total**.

## Guide resource
`dock://guide` exposes the publish → review → revise loop to any MCP client. Single source: `packages/mcp/SKILL.md` (also the agent skill doc).

## Plumbing
Extends the shared `DockClient` with `setThreadState` / `diff` / `restore` / `viewStats` and the version-session / diff / view-stats JSON types — reused by the CLI and any tooling, not just MCP.

## Verification
- 10 client tests over real in-process HTTP (resolve/reopen, anchored comment, diff, restore round-trip with history intact, sessions + version names).
- stdio smoke test confirms all 11 tools + the `dock://guide` resource register on the actual server.
- `pnpm typecheck` + `pnpm test` green across the repo (mcp 10, api 46, storage 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)