### PR TITLE
Phase A: permissions + per-artifact sharing

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -11,22 +11,29 @@ import {
   PublishError,
   artifactUrl,
   SELECTION_SCRIPT,
+  can,
+  effectiveRole,
   diffLines,
   formatDiff,
   groupSessions,
   DEFAULT_VERSION_WINDOW_MS,
   isAnchored,
+  isRole,
   mimeFor,
   newId,
   publish,
   renderMarkdown,
   renderShell,
+  roleAllows,
   toJson,
+  type Action,
+  type Actor,
   type ArtifactRecord,
   type BlobStore,
   type BundleManifest,
   type CommentRecord,
   type MetaStore,
+  type Role,
   type VersionRecord,
   type Visibility,
 } from "@dock/core"
@@ -84,7 +91,12 @@ export interface AppDeps {
   analytics?: boolean
   /** Revisions within this window (ms) collapse into one displayed version. */
   versionWindowMs?: number
+  /** Workspace role granted to a member who isn't the first user. Default "editor". */
+  defaultRole?: Role
 }
+
+/** The single workspace (multi-workspace is a later layer). */
+const WORKSPACE = "local"
 
 const VISIBILITIES = ["public", "link", "org", "password"] as const
 
@@ -148,16 +160,46 @@ export function createApp(deps: AppDeps): Hono {
     return s?.user ? { id: s.user.id, email: s.user.email, name: s.user.name ?? null } : null
   }
 
-  // A static token (CI/agents) or a valid login session authorizes writes;
-  // gated reads need one too. No token + no session = open dev instance.
-  const writeOk = async (c: Context): Promise<boolean> =>
-    !deps.token || bearer(c) === deps.token || (await currentUser(c)) !== null
-  const readOk = async (c: Context, a: ArtifactRecord): Promise<boolean> =>
-    a.visibility === "public" ||
-    a.visibility === "link" ||
-    !deps.token ||
-    bearer(c) === deps.token ||
-    (await currentUser(c)) !== null
+  // ---- Authorization ----------------------------------------------------
+  // One choke point: every gate resolves an Actor and asks can(). An unsecured
+  // instance (no static token) trusts anonymous callers — zero-config self-host.
+  const open = !deps.token
+  const defaultRole: Role = deps.defaultRole ?? "editor"
+
+  // Lazy provisioning: the first member of the workspace is its owner; everyone
+  // else joins at the default role. Returns the caller's workspace role.
+  const ensureMembership = async (userId: string): Promise<Role> => {
+    const existing = await meta.getMembership(WORKSPACE, userId)
+    if (existing) return existing.role
+    const role: Role = (await meta.countMemberships(WORKSPACE)) === 0 ? "owner" : defaultRole
+    await meta.setMembership({ id: newId("m"), org_id: WORKSPACE, user_id: userId, role })
+    return role
+  }
+
+  const actorFor = async (c: Context, a: ArtifactRecord): Promise<Actor> => {
+    if (deps.token && bearer(c) === deps.token) return { kind: "token" }
+    const me = await currentUser(c)
+    if (!me) return { kind: "anon", open }
+    const orgRole = await ensureMembership(me.id)
+    const am = await meta.getArtifactMember(a.id, me.id)
+    return { kind: "user", userId: me.id, artifactRole: am?.role ?? null, orgRole, open }
+  }
+
+  /** Authorize an action against a specific artifact. */
+  const authorize = (c: Context, action: Action, a: ArtifactRecord): Promise<boolean> =>
+    actorFor(c, a).then((actor) => can(actor, action, a.visibility))
+
+  /** The caller's role at the workspace level (creating artifacts, settings). */
+  const workspaceRole = async (c: Context): Promise<Role | null> => {
+    if (deps.token && bearer(c) === deps.token) return "owner"
+    const me = await currentUser(c)
+    if (!me) return open ? "owner" : null
+    return ensureMembership(me.id)
+  }
+  const workspaceCan = async (c: Context, action: Action): Promise<boolean> => {
+    const r = await workspaceRole(c)
+    return r !== null && roleAllows(r, action)
+  }
 
   // Better Auth owns /api/auth/* (sign-up/in/out, OAuth, OIDC/SSO, session).
   if (deps.auth) {
@@ -179,7 +221,9 @@ export function createApp(deps: AppDeps): Hono {
 
   app.get("/v1/me", async (c) => {
     const u = await currentUser(c)
-    return u ? c.json({ user: u }) : c.json({ error: "unauthenticated" }, 401)
+    if (!u) return c.json({ error: "unauthenticated" }, 401)
+    const role = await ensureMembership(u.id) // provisions on first load
+    return c.json({ user: { ...u, role } })
   })
 
   app.get("/v1/artifacts", async (c) => {
@@ -195,7 +239,15 @@ export function createApp(deps: AppDeps): Hono {
   // ---- Publish ----------------------------------------------------------
 
   const handlePublish = async (c: Context, shortId?: string) => {
-    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
+    // Republishing a version needs publish rights on that artifact; creating a
+    // new one needs publish rights at the workspace level.
+    if (shortId) {
+      const existing = await meta.getByShortId(shortId)
+      if (!existing) return c.json({ error: "not found" }, 404)
+      if (!(await authorize(c, "publish", existing))) return c.json({ error: "forbidden" }, 403)
+    } else if (!(await workspaceCan(c, "publish"))) {
+      return c.json({ error: "forbidden" }, 403)
+    }
     const len = Number(c.req.header("content-length") ?? 0)
     if (len > MAX_UPLOAD_BYTES) return c.json({ error: "upload too large" }, 413)
 
@@ -261,22 +313,63 @@ export function createApp(deps: AppDeps): Hono {
 
   app.get("/v1/artifacts/:shortId", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || !(await readOk(c, artifact))) return c.json({ error: "not found" }, 404)
+    const actor = await actorFor(c, artifact ?? ({ id: "", visibility: "password" } as ArtifactRecord))
+    if (!artifact || !can(actor, "read", artifact.visibility)) return c.json({ error: "not found" }, 404)
     const versions = await meta.listVersions(artifact.id)
     // `versions` stays at revision granularity (machines/agents); `sessions` is
-    // the time-grouped view the UI shows by default.
+    // the time-grouped view the UI shows by default. `my_role` tells the client
+    // which actions to surface.
     return c.json({
       ...toJson(deps.baseUrl, artifact, versions),
       sessions: groupSessions(versions, versionWindowMs),
+      my_role: effectiveRole(actor, artifact.visibility),
     })
+  })
+
+  // ---- Sharing: per-artifact role overrides -----------------------------
+  app.get("/v1/artifacts/:shortId/members", async (c) => {
+    const artifact = await meta.getByShortId(c.req.param("shortId"))
+    if (!artifact || !(await authorize(c, "read", artifact))) return c.json({ error: "not found" }, 404)
+    const rows = await meta.listArtifactMembers(artifact.id)
+    const users = await meta.getUsers(rows.map((r) => r.user_id))
+    const byId = new Map(users.map((u) => [u.id, u]))
+    return c.json({
+      default_role: defaultRole,
+      members: rows.map((r) => ({
+        user_id: r.user_id,
+        email: byId.get(r.user_id)?.email ?? null,
+        name: byId.get(r.user_id)?.name ?? null,
+        role: r.role,
+      })),
+    })
+  })
+
+  app.put("/v1/artifacts/:shortId/members", async (c) => {
+    const artifact = await meta.getByShortId(c.req.param("shortId"))
+    if (!artifact) return c.json({ error: "not found" }, 404)
+    if (!(await authorize(c, "manage", artifact))) return c.json({ error: "forbidden" }, 403)
+    const b = (await c.req.json().catch(() => ({}))) as { email?: string; role?: string }
+    if (!b.email || !isRole(b.role)) return c.json({ error: "email and a valid role are required" }, 400)
+    const user = await meta.findUserByEmail(b.email.trim())
+    if (!user) return c.json({ error: "no Dock user with that email" }, 404)
+    await meta.setArtifactMember({ id: newId("am"), artifact_id: artifact.id, user_id: user.id, role: b.role })
+    return c.json({ user_id: user.id, email: user.email, name: user.name, role: b.role }, 201)
+  })
+
+  app.delete("/v1/artifacts/:shortId/members/:userId", async (c) => {
+    const artifact = await meta.getByShortId(c.req.param("shortId"))
+    if (!artifact) return c.json({ error: "not found" }, 404)
+    if (!(await authorize(c, "manage", artifact))) return c.json({ error: "forbidden" }, 403)
+    await meta.removeArtifactMember(artifact.id, c.req.param("userId"))
+    return c.body(null, 204)
   })
 
   // Restore a past version: re-point a new revision at its stored blob (no
   // re-upload, works for files and bundles). History is never rewritten.
   app.post("/v1/artifacts/:shortId/restore", async (c) => {
-    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact) return c.json({ error: "not found" }, 404)
+    if (!(await authorize(c, "publish", artifact))) return c.json({ error: "forbidden" }, 403)
     const body = (await c.req.json().catch(() => ({}))) as { version?: number }
     if (!Number.isInteger(body.version)) return c.json({ error: "version required" }, 400)
     const src = await meta.getVersion(artifact.id, body.version as number)
@@ -315,7 +408,7 @@ export function createApp(deps: AppDeps): Hono {
   // version, as plain text (?v=N selects a version; defaults to current).
   app.get("/v1/artifacts/:shortId/content", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || artifact.current_version === 0 || !(await readOk(c, artifact)))
+    if (!artifact || artifact.current_version === 0 || !(await authorize(c, "read", artifact)))
       return c.json({ error: "not found" }, 404)
     const v = c.req.query("v") ? Number(c.req.query("v")) : artifact.current_version
     if (!Number.isInteger(v)) return c.json({ error: "bad version" }, 400)
@@ -335,7 +428,7 @@ export function createApp(deps: AppDeps): Hono {
   // ?format=json returns the structured ops; otherwise unified-style text.
   app.get("/v1/artifacts/:shortId/diff", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || artifact.current_version === 0 || !(await readOk(c, artifact)))
+    if (!artifact || artifact.current_version === 0 || !(await authorize(c, "read", artifact)))
       return c.json({ error: "not found" }, 404)
     const cur = artifact.current_version
     const from = c.req.query("from") ? Number(c.req.query("from")) : Math.max(1, cur - 1)
@@ -359,9 +452,9 @@ export function createApp(deps: AppDeps): Hono {
 
   // Create a comment (new thread) or a reply (pass thread_id).
   app.post("/v1/artifacts/:shortId/comments", async (c) => {
-    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact || artifact.current_version === 0) return c.json({ error: "not found" }, 404)
+    if (!(await authorize(c, "comment", artifact))) return c.json({ error: "forbidden" }, 403)
     const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>
     if (typeof body.body_md !== "string" || body.body_md.trim() === "")
       return c.json({ error: "body_md required" }, 400)
@@ -406,7 +499,7 @@ export function createApp(deps: AppDeps): Hono {
 
   app.get("/v1/artifacts/:shortId/comments", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || !(await readOk(c, artifact))) return c.json({ error: "not found" }, 404)
+    if (!artifact || !(await authorize(c, "read", artifact))) return c.json({ error: "not found" }, 404)
     const q = c.req.query("state")
     const state = q === "open" || q === "resolved" ? q : undefined
     const comments = await meta.listComments(artifact.id, state ? { state } : undefined)
@@ -420,9 +513,9 @@ export function createApp(deps: AppDeps): Hono {
 
   // Resolve (or reopen, with {state:"open"}) the thread a comment belongs to.
   app.post("/v1/artifacts/:shortId/comments/:commentId/resolve", async (c) => {
-    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact) return c.json({ error: "not found" }, 404)
+    if (!(await authorize(c, "comment", artifact))) return c.json({ error: "forbidden" }, 403)
     const cm = await meta.getComment(c.req.param("commentId"))
     if (!cm || cm.artifact_id !== artifact.id) return c.json({ error: "not found" }, 404)
     const body = (await c.req.json().catch(() => ({}))) as { state?: string }
@@ -451,10 +544,10 @@ export function createApp(deps: AppDeps): Hono {
 
   // Toggle the current user's reaction (one of REACTIONS) on a comment.
   app.post("/v1/artifacts/:shortId/comments/:commentId/react", async (c) => {
-    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
     const r = await loadComment(c)
     if ("error" in r) return r.error
     const { artifact, cm } = r
+    if (!(await authorize(c, "comment", artifact))) return c.json({ error: "forbidden" }, 403)
     const body = (await c.req.json().catch(() => ({}))) as { emoji?: string }
     if (!body.emoji || !REACTIONS.includes(body.emoji)) return c.json({ error: "unknown reaction" }, 400)
     const actor = (await actorName(c)) ?? "anonymous"
@@ -474,10 +567,10 @@ export function createApp(deps: AppDeps): Hono {
 
   // Edit a comment's body (author only when signed in).
   app.patch("/v1/artifacts/:shortId/comments/:commentId", async (c) => {
-    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
     const r = await loadComment(c)
     if ("error" in r) return r.error
     const { artifact, cm } = r
+    if (!(await authorize(c, "comment", artifact))) return c.json({ error: "forbidden" }, 403)
     const actor = await actorName(c)
     if (actor && cm.author !== actor) return c.json({ error: "forbidden" }, 403)
     const body = (await c.req.json().catch(() => ({}))) as { body_md?: string }
@@ -493,10 +586,10 @@ export function createApp(deps: AppDeps): Hono {
   // Soft-delete a comment (author only when signed in); the row stays so replies
   // keep their thread, and the body is tombstoned.
   app.delete("/v1/artifacts/:shortId/comments/:commentId", async (c) => {
-    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
     const r = await loadComment(c)
     if ("error" in r) return r.error
     const { artifact, cm } = r
+    if (!(await authorize(c, "comment", artifact))) return c.json({ error: "forbidden" }, 403)
     const actor = await actorName(c)
     if (actor && cm.author !== actor) return c.json({ error: "forbidden" }, 403)
     const md = parseMeta(cm.meta)
@@ -510,7 +603,7 @@ export function createApp(deps: AppDeps): Hono {
 
   app.get("/v1/artifacts/:shortId/events", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || !(await readOk(c, artifact))) return c.text("not found", 404)
+    if (!artifact || !(await authorize(c, "read", artifact))) return c.text("not found", 404)
     c.header("Access-Control-Allow-Origin", "*")
     return streamSSE(c, async (stream) => {
       const unsub = bus.subscribe(artifact.id, (e) => {
@@ -527,7 +620,7 @@ export function createApp(deps: AppDeps): Hono {
 
   app.post("/v1/artifacts/:shortId/presence", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || !(await readOk(c, artifact))) return c.json({ error: "not found" }, 404)
+    if (!artifact || !(await authorize(c, "read", artifact))) return c.json({ error: "not found" }, 404)
     const body = (await c.req.json().catch(() => ({}))) as { name?: string }
     const name = typeof body.name === "string" && body.name ? body.name : "anonymous"
     const viewers = presence.heartbeat(artifact.id, name, Date.now())
@@ -542,7 +635,7 @@ export function createApp(deps: AppDeps): Hono {
   app.post("/v1/artifacts/:shortId/view", async (c) => {
     if (!analyticsOn) return c.body(null, 204)
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || artifact.current_version === 0 || !(await readOk(c, artifact)))
+    if (!artifact || artifact.current_version === 0 || !(await authorize(c, "read", artifact)))
       return c.json({ error: "not found" }, 404)
     const me = await currentUser(c)
     let viewer: string
@@ -568,7 +661,7 @@ export function createApp(deps: AppDeps): Hono {
   app.get("/v1/artifacts/:shortId/analytics", async (c) => {
     if (!analyticsOn) return c.json({ error: "analytics disabled" }, 404)
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || !(await readOk(c, artifact))) return c.json({ error: "not found" }, 404)
+    if (!artifact || !(await authorize(c, "read", artifact))) return c.json({ error: "not found" }, 404)
     return c.json(await meta.viewStats(artifact.id))
   })
 
@@ -577,13 +670,13 @@ export function createApp(deps: AppDeps): Hono {
   const publicWebhook = (w: { secret: string }) => ({ ...w, secret: undefined })
 
   app.get("/v1/webhooks", async (c) => {
-    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
+    if (!(await workspaceCan(c, "manage"))) return c.json({ error: "forbidden" }, 403)
     const hooks = await meta.listWebhooks()
     return c.json({ webhooks: hooks.map(publicWebhook) })
   })
 
   app.post("/v1/webhooks", async (c) => {
-    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
+    if (!(await workspaceCan(c, "manage"))) return c.json({ error: "forbidden" }, 403)
     const b = (await c.req.json().catch(() => ({}))) as Record<string, unknown>
     if (typeof b.url !== "string" || !/^https?:\/\//.test(b.url))
       return c.json({ error: "a valid http(s) url is required" }, 400)
@@ -612,13 +705,13 @@ export function createApp(deps: AppDeps): Hono {
   })
 
   app.delete("/v1/webhooks/:id", async (c) => {
-    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
+    if (!(await workspaceCan(c, "manage"))) return c.json({ error: "forbidden" }, 403)
     await meta.deleteWebhook(c.req.param("id"))
     return c.body(null, 204)
   })
 
   app.get("/v1/webhooks/:id/deliveries", async (c) => {
-    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
+    if (!(await workspaceCan(c, "manage"))) return c.json({ error: "forbidden" }, 403)
     const rows = await meta.recentDeliveries(c.req.param("id"), 20)
     return c.json({
       deliveries: rows.map((d) => ({
@@ -634,7 +727,7 @@ export function createApp(deps: AppDeps): Hono {
 
   // Send a sample event to a webhook so you can confirm it lands.
   app.post("/v1/webhooks/:id/test", async (c) => {
-    if (!(await writeOk(c))) return c.json({ error: "unauthorized" }, 401)
+    if (!(await workspaceCan(c, "manage"))) return c.json({ error: "forbidden" }, 403)
     const w = await meta.getWebhook(c.req.param("id"))
     if (!w) return c.json({ error: "not found" }, 404)
     const sample = JSON.stringify({
@@ -661,7 +754,7 @@ export function createApp(deps: AppDeps): Hono {
     const m = REF_RE.exec(c.req.param("ref"))
     if (!m) return c.text("not found", 404)
     const artifact = await meta.getByShortId(m[1])
-    if (!artifact || artifact.current_version === 0 || !(await readOk(c, artifact)))
+    if (!artifact || artifact.current_version === 0 || !(await authorize(c, "read", artifact)))
       return c.text("not found", 404)
     const n = m[2] ? Number(m[2]) : artifact.current_version
     const version = await meta.getVersion(artifact.id, n)
@@ -687,7 +780,7 @@ export function createApp(deps: AppDeps): Hono {
     const shortId = c.req.param("shortId")
     const n = Number(c.req.param("n"))
     const artifact = await meta.getByShortId(shortId)
-    if (!artifact || !Number.isInteger(n) || !(await readOk(c, artifact))) return c.text("not found", 404)
+    if (!artifact || !Number.isInteger(n) || !(await authorize(c, "read", artifact))) return c.text("not found", 404)
     const version = await meta.getVersion(artifact.id, n)
     if (!version) return c.text("not found", 404)
 

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -1,11 +1,12 @@
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import Database from "better-sqlite3"
 import { zipSync } from "fflate"
 import { afterAll, describe, expect, it } from "vitest"
 import { SqliteMetaStore } from "@dock/db/sqlite"
 import { FsBlobStore } from "@dock/storage/fs"
-import { createApp } from "../src/app"
+import { createApp, type AppDeps } from "../src/app"
 
 const dir = mkdtempSync(join(tmpdir(), "dock-test-"))
 const meta = new SqliteMetaStore(join(dir, "dock.db"))
@@ -429,7 +430,7 @@ describe("auth: token write-gating + per-artifact read-gating", () => {
   }
 
   it("rejects writes without the token, accepts with it", async () => {
-    expect((await pub("link")).status).toBe(401)
+    expect((await pub("link")).status).toBe(403) // permission-gated: forbidden
     const ok = await pub("link", { authorization: "Bearer s3cret" })
     expect(ok.status).toBe(201)
   })
@@ -504,6 +505,130 @@ describe("live stream (SSE)", () => {
     const { short_id } = await (await upload("p.md", "# p", {})).json()
     const res = await app.request(`/v1/artifacts/${short_id}/presence`, json({ name: "Jess" }))
     expect((await res.json()).viewers).toEqual(["Jess"])
+  })
+})
+
+// A faithful role test needs real sessions. We seed Better Auth's `user` table
+// (so the share route can resolve email→id) and stand in a fake `auth` whose
+// session is chosen by an `x-test-user` header (the user's email). A static
+// token keeps the instance secured, so an unauthenticated caller is NOT owner.
+type TestUser = { id: string; email: string; name: string | null }
+
+const makeAuthedApp = (name: string, users: TestUser[], defaultRole?: AppDeps["defaultRole"]) => {
+  const path = join(dir, `${name}.db`)
+  const m = new SqliteMetaStore(path)
+  const raw = new Database(path)
+  raw.exec(`CREATE TABLE IF NOT EXISTS user (id TEXT PRIMARY KEY, email TEXT, name TEXT)`)
+  const ins = raw.prepare(`INSERT OR IGNORE INTO user (id, email, name) VALUES (?,?,?)`)
+  for (const u of users) ins.run(u.id, u.email, u.name)
+  raw.close()
+  const auth = {
+    handler: async () => new Response(null, { status: 404 }),
+    api: {
+      getSession: async ({ headers }: { headers: Headers }) => {
+        const u = users.find((x) => x.email === headers.get("x-test-user"))
+        return u ? { user: u } : null
+      },
+    },
+  } as unknown as AppDeps["auth"]
+  const app = createApp({
+    meta: m,
+    blobs: new FsBlobStore(join(dir, "blobs")),
+    baseUrl: "http://dock.test",
+    token: "tok",
+    auth,
+    defaultRole,
+  })
+  return { app, meta: m }
+}
+
+const as = (email: string) => ({ "x-test-user": email })
+const publishAs = (
+  app: ReturnType<typeof createApp>,
+  content: string,
+  fields: Record<string, string> = {},
+  headers: Record<string, string> = {},
+  shortId?: string,
+) => {
+  const form = new FormData()
+  form.append("file", new Blob([new TextEncoder().encode(content)]), "f.html")
+  for (const [k, v] of Object.entries(fields)) form.append(k, v)
+  const url = shortId ? `/v1/artifacts/${shortId}/versions` : "/v1/artifacts"
+  return app.request(url, { method: "POST", body: form, headers })
+}
+const jsonAs = (headers: Record<string, string>, body: unknown) => ({
+  method: "POST" as const,
+  headers: { "content-type": "application/json", ...headers },
+  body: JSON.stringify(body),
+})
+
+describe("permissions: workspace roles gate writes", () => {
+  const alice: TestUser = { id: "u_alice", email: "alice@dock.test", name: "Alice" }
+  const bob: TestUser = { id: "u_bob", email: "bob@dock.test", name: "Bob" }
+  const { app } = makeAuthedApp("perm-roles", [alice, bob], "commenter")
+  let shortId: string
+
+  it("makes the first member the owner, who can create artifacts", async () => {
+    const res = await publishAs(app, "<h1>a</h1>", {}, as(alice.email))
+    expect(res.status).toBe(201)
+    shortId = (await res.json()).short_id
+  })
+
+  it("provisions later members at the default role (commenter)", async () => {
+    const me = await (await app.request("/v1/me", { headers: as(bob.email) })).json()
+    expect(me.user.role).toBe("commenter")
+  })
+
+  it("blocks a commenter from creating or republishing", async () => {
+    expect((await publishAs(app, "<h1>b</h1>", {}, as(bob.email))).status).toBe(403)
+    expect((await publishAs(app, "<h1>a2</h1>", {}, as(bob.email), shortId)).status).toBe(403)
+  })
+
+  it("lets a commenter comment, but not an unauthenticated caller", async () => {
+    const ok = await app.request(`/v1/artifacts/${shortId}/comments`, jsonAs(as(bob.email), { body_md: "nice" }))
+    expect(ok.status).toBe(201)
+    const anon = await app.request(`/v1/artifacts/${shortId}/comments`, jsonAs({}, { body_md: "x" }))
+    expect(anon.status).toBe(403)
+  })
+})
+
+describe("permissions: a per-artifact share overrides the workspace role", () => {
+  const owner: TestUser = { id: "u_own", email: "own@dock.test", name: "Own" }
+  const carol: TestUser = { id: "u_carol", email: "carol@dock.test", name: "Carol" }
+  const { app } = makeAuthedApp("perm-share", [owner, carol], "viewer")
+  let shortId: string
+
+  it("a workspace viewer can read an org artifact but not republish it", async () => {
+    shortId = (await (await publishAs(app, "<h1>secret</h1>", { visibility: "org" }, as(owner.email))).json()).short_id
+    expect((await app.request(`/v1/artifacts/${shortId}`, { headers: as(carol.email) })).status).toBe(200)
+    expect((await publishAs(app, "<h1>edit</h1>", {}, as(carol.email), shortId)).status).toBe(403)
+  })
+
+  it("sharing the artifact as editor lets the viewer republish, and my_role reflects it", async () => {
+    const share = await app.request(`/v1/artifacts/${shortId}/members`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", ...as(owner.email) },
+      body: JSON.stringify({ email: carol.email, role: "editor" }),
+    })
+    expect(share.status).toBe(201)
+    expect((await publishAs(app, "<h1>edit</h1>", {}, as(carol.email), shortId)).status).toBe(201)
+    const meta = await (await app.request(`/v1/artifacts/${shortId}`, { headers: as(carol.email) })).json()
+    expect(meta.my_role).toBe("editor")
+  })
+
+  it("only an owner can manage shares (an editor cannot)", async () => {
+    const byEditor = await app.request(`/v1/artifacts/${shortId}/members`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", ...as(carol.email) },
+      body: JSON.stringify({ email: owner.email, role: "viewer" }),
+    })
+    expect(byEditor.status).toBe(403)
+  })
+
+  it("the owner sees the share in the member list", async () => {
+    const list = await (await app.request(`/v1/artifacts/${shortId}/members`, { headers: as(owner.email) })).json()
+    expect(list.default_role).toBe("viewer")
+    expect(list.members).toContainEqual(expect.objectContaining({ email: carol.email, role: "editor" }))
   })
 })
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -12,6 +12,7 @@ export interface VersionSession {
   name: string | null
   created_at: string
 }
+export type Role = "viewer" | "commenter" | "editor" | "owner"
 export interface Artifact {
   short_id: string
   url: string
@@ -23,6 +24,14 @@ export interface Artifact {
   /** Time-grouped view of versions for display; newest-first. */
   sessions?: VersionSession[]
   views?: number
+  /** The current caller's effective role on this artifact (null = no access). */
+  my_role?: Role | null
+}
+export interface ArtifactMember {
+  user_id: string
+  email: string | null
+  name: string | null
+  role: Role
 }
 export interface Analytics {
   total: number
@@ -121,6 +130,13 @@ export const api = {
     f(`/v1/artifacts/${id}/diff?from=${from}&to=${to}&format=json`, opts()).then(j),
   restore: (id: string, version: number): Promise<Artifact> =>
     f(`/v1/artifacts/${id}/restore`, opts({ version })).then(j),
+
+  listMembers: (id: string): Promise<{ default_role: Role; members: ArtifactMember[] }> =>
+    f(`/v1/artifacts/${id}/members`, opts()).then(j),
+  setMember: (id: string, email: string, role: Role): Promise<ArtifactMember> =>
+    f(`/v1/artifacts/${id}/members`, { ...opts({ email, role }), method: "PUT" }).then(j),
+  removeMember: (id: string, userId: string): Promise<void> =>
+    f(`/v1/artifacts/${id}/members/${userId}`, { method: "DELETE", credentials: "include" }).then(() => undefined),
   heartbeat: (id: string, name: string): Promise<{ viewers: string[] }> =>
     f(`/v1/artifacts/${id}/presence`, opts({ name })).then(j),
 

--- a/apps/web/src/components/ShareDialog.tsx
+++ b/apps/web/src/components/ShareDialog.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useRef, useState } from "react"
+import { api, type ArtifactMember, type Role } from "../api"
+
+const ROLES: Role[] = ["viewer", "commenter", "editor", "owner"]
+const BLURB: Record<Role, string> = {
+  viewer: "Can view",
+  commenter: "Can view and comment",
+  editor: "Can publish new versions",
+  owner: "Full control, incl. sharing",
+}
+
+/**
+ * Per-artifact sharing, as a header popover that mirrors Insights/History. Only
+ * an owner of this artifact can change shares; everyone else sees nothing. Kept
+ * fully self-contained (no shared Dialog primitive, no edits to the comment
+ * sidebar) so it composes into the artifact header with a single line.
+ */
+export function ShareButton({ shortId, myRole }: { shortId: string; myRole?: Role | null }) {
+  const [open, setOpen] = useState(false)
+  const [members, setMembers] = useState<ArtifactMember[]>([])
+  const [defaultRole, setDefaultRole] = useState<Role>("editor")
+  const [email, setEmail] = useState("")
+  const [role, setRole] = useState<Role>("editor")
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const h = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener("click", h)
+    return () => document.removeEventListener("click", h)
+  }, [])
+
+  const load = () =>
+    api
+      .listMembers(shortId)
+      .then((r) => {
+        setMembers(r.members)
+        setDefaultRole(r.default_role)
+      })
+      .catch(() => {})
+  useEffect(() => {
+    if (open) load()
+  }, [open, shortId])
+
+  // Only an owner can manage shares; hide the affordance otherwise.
+  if (myRole !== "owner") return null
+
+  const add = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const addr = email.trim()
+    if (!addr) return
+    setBusy(true)
+    setErr(null)
+    try {
+      await api.setMember(shortId, addr, role)
+      setEmail("")
+      await load()
+    } catch (x) {
+      setErr(x instanceof Error ? x.message : "Could not share")
+    } finally {
+      setBusy(false)
+    }
+  }
+  const change = async (m: ArtifactMember, next: Role) => {
+    if (next === m.role || !m.email) return
+    await api.setMember(shortId, m.email, next).catch(() => {})
+    await load()
+  }
+  const remove = async (m: ArtifactMember) => {
+    await api.removeMember(shortId, m.user_id).catch(() => {})
+    await load()
+  }
+
+  return (
+    <div ref={ref} style={{ position: "relative" }}>
+      <button
+        className="btn sm"
+        onClick={(e) => {
+          e.stopPropagation()
+          setOpen((o) => !o)
+        }}
+        style={{ gap: 6 }}
+        title="Share this artifact"
+      >
+        <span style={{ fontSize: 12 }}>🔗</span>
+        Share
+      </button>
+      {open && (
+        <div
+          className="card"
+          style={{ position: "absolute", right: 0, top: "calc(100% + 7px)", width: 330, padding: 14, boxShadow: "var(--shadow)", zIndex: 30 }}
+        >
+          <div className="mono muted" style={{ fontSize: 9.5, letterSpacing: ".06em", textTransform: "uppercase", marginBottom: 8 }}>
+            People with access
+          </div>
+
+          <form onSubmit={add} style={{ display: "flex", gap: 6, marginBottom: 4 }}>
+            <input
+              className="input"
+              type="email"
+              placeholder="teammate@email.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              style={{ flex: 1, padding: "7px 9px", fontSize: 13 }}
+            />
+            <select
+              value={role}
+              onChange={(e) => setRole(e.target.value as Role)}
+              className="input"
+              style={{ width: 104, padding: "7px 6px", fontSize: 12 }}
+            >
+              {ROLES.map((r) => (
+                <option key={r} value={r}>
+                  {r}
+                </option>
+              ))}
+            </select>
+            <button className="btn pri sm" type="submit" disabled={busy}>
+              {busy ? "…" : "Add"}
+            </button>
+          </form>
+          <div className="mono muted" style={{ fontSize: 10, marginBottom: 10 }}>{BLURB[role]}.</div>
+          {err && <div style={{ color: "var(--bad)", fontSize: 11.5, marginBottom: 8 }}>{err}</div>}
+
+          {members.length === 0 ? (
+            <div className="muted" style={{ fontSize: 11.5 }}>
+              No one shared yet. Everyone else is a <b>{defaultRole}</b> by default.
+            </div>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+              {members.map((m) => (
+                <div key={m.user_id} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 12.5, fontWeight: 600, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                      {m.name ?? m.email ?? m.user_id}
+                    </div>
+                    {m.name && m.email && <div className="muted" style={{ fontSize: 10.5 }}>{m.email}</div>}
+                  </div>
+                  <select
+                    value={m.role}
+                    onChange={(e) => change(m, e.target.value as Role)}
+                    className="input"
+                    style={{ width: 96, padding: "5px 6px", fontSize: 11.5 }}
+                  >
+                    {ROLES.map((r) => (
+                      <option key={r} value={r}>
+                        {r}
+                      </option>
+                    ))}
+                  </select>
+                  <button className="lnk" onClick={() => remove(m)} title="Remove" style={{ textDecoration: "none", fontSize: 14 }}>
+                    ✕
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/Artifact.tsx
+++ b/apps/web/src/pages/Artifact.tsx
@@ -2,6 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useLayoutEffect, use
 import { useNavigate, useParams } from "@tanstack/react-router"
 import { api, API_BASE, type Analytics, type Artifact as Art, type Comment, type Diff } from "../api"
 import { Header, useToast } from "../components"
+import { ShareButton } from "../components/ShareDialog"
 import { useAuth } from "../ctx"
 
 type Sel = { type?: string; exact: string; prefix?: string; suffix?: string }
@@ -389,6 +390,7 @@ export function Artifact() {
         right={
           <>
             <Presence viewers={viewers} self={me?.name ?? me?.email ?? ""} />
+            <ShareButton shortId={shortId} myRole={art.my_role} />
             <Insights shortId={shortId} />
             <HistoryMenu
               art={art}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./ports"
+export * from "./permissions"
 export * from "./ids"
 export * from "./mime"
 export * from "./hash"

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -1,0 +1,70 @@
+import type { Visibility } from "./ports"
+
+/**
+ * The role vocabulary, in increasing power. A higher role can do everything a
+ * lower one can.
+ *  - viewer:    read
+ *  - commenter: + comment (creates content to be reviewed; cannot publish/approve)
+ *  - editor:    + publish versions directly, and approve others' proposed changes
+ *  - owner:     + manage (roles, settings, delete)
+ */
+export type Role = "viewer" | "commenter" | "editor" | "owner"
+
+/** What an actor wants to do. Kept coarse on purpose; `can()` is the only gate. */
+export type Action = "read" | "comment" | "publish" | "approve" | "manage"
+
+const RANK: Record<Role, number> = { viewer: 0, commenter: 1, editor: 2, owner: 3 }
+const NEEDS: Record<Action, Role> = {
+  read: "viewer",
+  comment: "commenter",
+  publish: "editor",
+  approve: "editor",
+  manage: "owner",
+}
+
+export const ROLES: readonly Role[] = ["viewer", "commenter", "editor", "owner"]
+export const isRole = (v: unknown): v is Role => typeof v === "string" && v in RANK
+
+/** Does this role permit this action? */
+export const roleAllows = (role: Role, action: Action): boolean => RANK[role] >= RANK[NEEDS[action]]
+
+/**
+ * Who is making a request, with their standing already resolved from the store.
+ * Every surface (web session, static token, MCP agent) becomes one of these.
+ */
+export interface Actor {
+  kind: "user" | "token" | "anon"
+  userId?: string
+  /** Per-artifact role override (a share), if any. Beats the workspace role. */
+  artifactRole?: Role | null
+  /** Baseline role from membership in the artifact's workspace, if any. */
+  orgRole?: Role | null
+  /**
+   * Unsecured instance (no static token configured): anonymous callers are
+   * trusted as owners, preserving the zero-config self-host / CI experience.
+   */
+  open?: boolean
+}
+
+/**
+ * The actor's effective role on an artifact of this visibility:
+ *   per-artifact share  →  workspace membership  →  visibility floor.
+ * null means no access at all.
+ */
+export function effectiveRole(actor: Actor, visibility: Visibility): Role | null {
+  if (actor.kind === "token") return "owner"
+  if (actor.kind === "user") {
+    const explicit = actor.artifactRole ?? actor.orgRole
+    if (explicit) return explicit
+  }
+  // No membership / anonymous: an unsecured instance trusts everyone; otherwise
+  // only public + link artifacts are world-readable.
+  if (actor.open) return "owner"
+  return visibility === "public" || visibility === "link" ? "viewer" : null
+}
+
+/** The one authorization gate. */
+export function can(actor: Actor, action: Action, visibility: Visibility): boolean {
+  const role = effectiveRole(actor, visibility)
+  return role !== null && roleAllows(role, action)
+}

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -2,6 +2,7 @@
  * Core owns the ports; packages/db and packages/storage provide the adapters.
  * Everything here must run on Node AND Cloudflare Workers — no Node APIs.
  */
+import type { Role } from "./permissions"
 
 export interface BlobStore {
   /** Content-addressed put; returns the sha256 hex key. Idempotent. */
@@ -100,6 +101,58 @@ export interface MetaStore {
   ): Promise<void>
   /** Recent deliveries for a webhook (for the settings log). */
   recentDeliveries(webhookId: string, limit: number): Promise<DeliveryRecord[]>
+
+  // ---- Permissions: workspace membership + per-artifact shares -----------
+  getMembership(orgId: string, userId: string): Promise<MembershipRecord | null>
+  listMemberships(orgId: string): Promise<MembershipRecord[]>
+  countMemberships(orgId: string): Promise<number>
+  /** Insert or update a member's workspace role. */
+  setMembership(m: NewMembership): Promise<MembershipRecord>
+
+  getArtifactMember(artifactId: string, userId: string): Promise<ArtifactMemberRecord | null>
+  listArtifactMembers(artifactId: string): Promise<ArtifactMemberRecord[]>
+  /** Insert or update a per-artifact role override (a share). */
+  setArtifactMember(m: NewArtifactMember): Promise<ArtifactMemberRecord>
+  removeArtifactMember(artifactId: string, userId: string): Promise<void>
+
+  // ---- User directory (reads Better Auth's `user` table) ----------------
+  findUserByEmail(email: string): Promise<UserDir | null>
+  getUsers(ids: string[]): Promise<UserDir[]>
+}
+
+/** A person, as needed for sharing UIs. Sourced from Better Auth's user table. */
+export interface UserDir {
+  id: string
+  email: string
+  name: string | null
+}
+
+export interface MembershipRecord {
+  id: string
+  org_id: string
+  user_id: string
+  role: Role
+  created_at: string
+}
+export interface NewMembership {
+  id: string
+  org_id: string
+  user_id: string
+  role: Role
+}
+
+export interface ArtifactMemberRecord {
+  id: string
+  artifact_id: string
+  user_id: string
+  role: Role
+  created_at: string
+}
+export interface NewArtifactMember {
+  id: string
+  artifact_id: string
+  user_id: string
+  role: Role
 }
 
 export type WebhookKind = "generic" | "slack"

--- a/packages/core/test/permissions.test.ts
+++ b/packages/core/test/permissions.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+import { type Actor, can, effectiveRole, roleAllows } from "../src/permissions"
+
+describe("roleAllows", () => {
+  it("editors publish + approve but only owners manage", () => {
+    expect(roleAllows("editor", "publish")).toBe(true)
+    expect(roleAllows("editor", "approve")).toBe(true)
+    expect(roleAllows("editor", "manage")).toBe(false)
+    expect(roleAllows("owner", "manage")).toBe(true)
+  })
+  it("commenters comment + read but cannot publish or approve", () => {
+    expect(roleAllows("commenter", "comment")).toBe(true)
+    expect(roleAllows("commenter", "read")).toBe(true)
+    expect(roleAllows("commenter", "publish")).toBe(false)
+    expect(roleAllows("commenter", "approve")).toBe(false)
+  })
+  it("viewers only read", () => {
+    expect(roleAllows("viewer", "read")).toBe(true)
+    expect(roleAllows("viewer", "comment")).toBe(false)
+  })
+})
+
+describe("effectiveRole resolution", () => {
+  const user = (over: Partial<Actor>): Actor => ({ kind: "user", userId: "u1", ...over })
+
+  it("per-artifact share overrides the workspace role", () => {
+    expect(effectiveRole(user({ orgRole: "viewer", artifactRole: "editor" }), "org")).toBe("editor")
+    expect(effectiveRole(user({ orgRole: "editor", artifactRole: "viewer" }), "org")).toBe("viewer")
+  })
+  it("falls back to the workspace role when there's no share", () => {
+    expect(effectiveRole(user({ orgRole: "commenter" }), "org")).toBe("commenter")
+  })
+  it("a non-member gets viewer on public/link, nothing on private", () => {
+    expect(effectiveRole(user({}), "link")).toBe("viewer")
+    expect(effectiveRole(user({}), "public")).toBe("viewer")
+    expect(effectiveRole(user({}), "org")).toBe(null)
+    expect(effectiveRole(user({}), "password")).toBe(null)
+  })
+  it("a static token is owner; anon on a secured instance is read-only", () => {
+    expect(effectiveRole({ kind: "token" }, "org")).toBe("owner")
+    expect(effectiveRole({ kind: "anon" }, "org")).toBe(null)
+    expect(effectiveRole({ kind: "anon" }, "link")).toBe("viewer")
+  })
+  it("an unsecured (open) instance trusts anonymous callers as owners", () => {
+    expect(effectiveRole({ kind: "anon", open: true }, "org")).toBe("owner")
+  })
+})
+
+describe("can", () => {
+  it("an editor publishes, a commenter cannot", () => {
+    expect(can({ kind: "user", artifactRole: "editor" }, "publish", "org")).toBe(true)
+    expect(can({ kind: "user", artifactRole: "commenter" }, "publish", "org")).toBe(false)
+    expect(can({ kind: "user", artifactRole: "commenter" }, "comment", "org")).toBe(true)
+  })
+  it("a link viewer reads but cannot comment", () => {
+    expect(can({ kind: "anon" }, "read", "link")).toBe(true)
+    expect(can({ kind: "anon" }, "comment", "link")).toBe(false)
+  })
+})

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -1,26 +1,31 @@
 import type { D1Database } from "@cloudflare/workers-types"
-import { and, asc, desc, eq, isNull, lte, or, sql } from "drizzle-orm"
+import { and, asc, count, desc, eq, isNull, lte, or, sql } from "drizzle-orm"
 import { drizzle, type DrizzleD1Database } from "drizzle-orm/d1"
 import type {
+  ArtifactMemberRecord,
   ArtifactRecord,
   CommentRecord,
   CommentState,
   DeliveryRecord,
   DeliveryStatus,
+  MembershipRecord,
   MetaStore,
   NewArtifact,
+  NewArtifactMember,
   NewComment,
   NewDelivery,
+  NewMembership,
   NewVersion,
   NewView,
   NewWebhook,
+  UserDir,
   VersionRecord,
   ViewStats,
   WebhookRecord,
 } from "@dock/core"
-import { artifact, comment, version, webhook, webhookDelivery } from "./schema"
+import { artifact, artifactMember, comment, membership, version, webhook, webhookDelivery } from "./schema"
 
-const schema = { artifact, version, comment, webhook, webhookDelivery }
+const schema = { artifact, version, comment, webhook, webhookDelivery, membership, artifactMember }
 const VIEW_WINDOW_MS = 30 * 86400_000
 
 /**
@@ -208,5 +213,79 @@ export class D1MetaStore implements MetaStore {
       .orderBy(desc(webhookDelivery.created_at))
       .limit(limit)
       .all()
+  }
+
+  // ---- Permissions: membership + per-artifact shares ---------------------
+  async getMembership(orgId: string, userId: string): Promise<MembershipRecord | null> {
+    return (
+      (await this.db
+        .select()
+        .from(membership)
+        .where(and(eq(membership.org_id, orgId), eq(membership.user_id, userId)))
+        .get()) ?? null
+    )
+  }
+  listMemberships(orgId: string): Promise<MembershipRecord[]> {
+    return this.db.select().from(membership).where(eq(membership.org_id, orgId)).all()
+  }
+  async countMemberships(orgId: string): Promise<number> {
+    const r = await this.db.select({ n: count() }).from(membership).where(eq(membership.org_id, orgId)).get()
+    return r?.n ?? 0
+  }
+  setMembership(m: NewMembership): Promise<MembershipRecord> {
+    return this.db
+      .insert(membership)
+      .values(m)
+      .onConflictDoUpdate({ target: [membership.org_id, membership.user_id], set: { role: m.role } })
+      .returning()
+      .get()
+  }
+
+  async getArtifactMember(artifactId: string, userId: string): Promise<ArtifactMemberRecord | null> {
+    return (
+      (await this.db
+        .select()
+        .from(artifactMember)
+        .where(and(eq(artifactMember.artifact_id, artifactId), eq(artifactMember.user_id, userId)))
+        .get()) ?? null
+    )
+  }
+  listArtifactMembers(artifactId: string): Promise<ArtifactMemberRecord[]> {
+    return this.db.select().from(artifactMember).where(eq(artifactMember.artifact_id, artifactId)).all()
+  }
+  setArtifactMember(m: NewArtifactMember): Promise<ArtifactMemberRecord> {
+    return this.db
+      .insert(artifactMember)
+      .values(m)
+      .onConflictDoUpdate({ target: [artifactMember.artifact_id, artifactMember.user_id], set: { role: m.role } })
+      .returning()
+      .get()
+  }
+  async removeArtifactMember(artifactId: string, userId: string): Promise<void> {
+    await this.db
+      .delete(artifactMember)
+      .where(and(eq(artifactMember.artifact_id, artifactId), eq(artifactMember.user_id, userId)))
+      .run()
+  }
+
+  // ---- User directory (Better Auth's `user` table; raw, may be absent) ---
+  async findUserByEmail(email: string): Promise<UserDir | null> {
+    try {
+      return ((await this.db.get(sql`SELECT id, email, name FROM user WHERE email = ${email}`)) as UserDir) ?? null
+    } catch {
+      return null
+    }
+  }
+  async getUsers(ids: string[]): Promise<UserDir[]> {
+    if (ids.length === 0) return []
+    try {
+      const list = sql.join(
+        ids.map((id) => sql`${id}`),
+        sql`, `,
+      )
+      return (await this.db.all(sql`SELECT id, email, name FROM user WHERE id IN (${list})`)) as UserDir[]
+    } catch {
+      return []
+    }
   }
 }

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -1,11 +1,14 @@
-import { integer, pgTable, text } from "drizzle-orm/pg-core"
+import { integer, pgTable, text, uniqueIndex } from "drizzle-orm/pg-core"
 import type {
   ArtifactKind,
+  ArtifactMemberRecord,
   ArtifactRecord,
   CommentRecord,
   CommentState,
   DeliveryRecord,
   DeliveryStatus,
+  MembershipRecord,
+  Role,
   VersionRecord,
   Visibility,
   WebhookKind,
@@ -88,6 +91,32 @@ export const webhookDelivery = pgTable("webhook_delivery", {
   created_at: text("created_at").notNull().$defaultFn(isoNow),
 })
 
+export const membership = pgTable(
+  "membership",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    user_id: text("user_id").notNull(),
+    role: text("role").$type<Role>().notNull(),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [uniqueIndex("membership_org_user").on(t.org_id, t.user_id)],
+)
+
+export const artifactMember = pgTable(
+  "artifact_member",
+  {
+    id: text("id").primaryKey(),
+    artifact_id: text("artifact_id")
+      .notNull()
+      .references(() => artifact.id),
+    user_id: text("user_id").notNull(),
+    role: text("role").$type<Role>().notNull(),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [uniqueIndex("artifact_member_user").on(t.artifact_id, t.user_id)],
+)
+
 // Compile-time guard: the pg table defs must match the core record shapes (and
 // therefore the sqlite defs). Drift here means SQLite and Postgres disagree.
 type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false
@@ -97,7 +126,9 @@ const _pgParity: [
   Exact<typeof comment.$inferSelect, CommentRecord>,
   Exact<typeof webhook.$inferSelect, WebhookRecord>,
   Exact<typeof webhookDelivery.$inferSelect, DeliveryRecord>,
-] = [true, true, true, true, true]
+  Exact<typeof membership.$inferSelect, MembershipRecord>,
+  Exact<typeof artifactMember.$inferSelect, ArtifactMemberRecord>,
+] = [true, true, true, true, true, true, true]
 void _pgParity
 
 // Boot DDL (idempotent). created_at uses a SQL default as a server-side backstop.
@@ -191,4 +222,20 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
     created_at TEXT NOT NULL DEFAULT ${isoDefault}
   )`,
   `CREATE INDEX IF NOT EXISTS delivery_due ON webhook_delivery (status, next_attempt_at)`,
+  `CREATE TABLE IF NOT EXISTS membership (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT ${isoDefault},
+    UNIQUE (org_id, user_id)
+  )`,
+  `CREATE TABLE IF NOT EXISTS artifact_member (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    user_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT ${isoDefault},
+    UNIQUE (artifact_id, user_id)
+  )`,
 ]

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1,26 +1,40 @@
-import { and, asc, desc, eq, isNull, lte, or } from "drizzle-orm"
+import { and, asc, count, desc, eq, isNull, lte, or } from "drizzle-orm"
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres"
 import { Pool } from "pg"
 import type {
+  ArtifactMemberRecord,
   ArtifactRecord,
   CommentRecord,
   CommentState,
   DeliveryRecord,
   DeliveryStatus,
+  MembershipRecord,
   MetaStore,
   NewArtifact,
+  NewArtifactMember,
   NewComment,
   NewDelivery,
+  NewMembership,
   NewVersion,
   NewView,
   NewWebhook,
+  UserDir,
   VersionRecord,
   ViewStats,
   WebhookRecord,
 } from "@dock/core"
-import { PG_SCHEMA_STATEMENTS, artifact, comment, version, webhook, webhookDelivery } from "./pg-schema"
+import {
+  PG_SCHEMA_STATEMENTS,
+  artifact,
+  artifactMember,
+  comment,
+  membership,
+  version,
+  webhook,
+  webhookDelivery,
+} from "./pg-schema"
 
-const schema = { artifact, version, comment, webhook, webhookDelivery }
+const schema = { artifact, version, comment, webhook, webhookDelivery, membership, artifactMember }
 const VIEW_WINDOW_MS = 30 * 86400_000
 
 /**
@@ -215,6 +229,74 @@ export class PgMetaStore implements MetaStore {
       .where(eq(webhookDelivery.webhook_id, webhookId))
       .orderBy(desc(webhookDelivery.created_at))
       .limit(limit)
+  }
+
+  // ---- Permissions: membership + per-artifact shares ---------------------
+  async getMembership(orgId: string, userId: string): Promise<MembershipRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(membership)
+      .where(and(eq(membership.org_id, orgId), eq(membership.user_id, userId)))
+    return rows[0] ?? null
+  }
+  listMemberships(orgId: string): Promise<MembershipRecord[]> {
+    return this.db.select().from(membership).where(eq(membership.org_id, orgId))
+  }
+  async countMemberships(orgId: string): Promise<number> {
+    const rows = await this.db.select({ n: count() }).from(membership).where(eq(membership.org_id, orgId))
+    return rows[0]?.n ?? 0
+  }
+  async setMembership(m: NewMembership): Promise<MembershipRecord> {
+    const rows = await this.db
+      .insert(membership)
+      .values(m)
+      .onConflictDoUpdate({ target: [membership.org_id, membership.user_id], set: { role: m.role } })
+      .returning()
+    return rows[0]
+  }
+
+  async getArtifactMember(artifactId: string, userId: string): Promise<ArtifactMemberRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(artifactMember)
+      .where(and(eq(artifactMember.artifact_id, artifactId), eq(artifactMember.user_id, userId)))
+    return rows[0] ?? null
+  }
+  listArtifactMembers(artifactId: string): Promise<ArtifactMemberRecord[]> {
+    return this.db.select().from(artifactMember).where(eq(artifactMember.artifact_id, artifactId))
+  }
+  async setArtifactMember(m: NewArtifactMember): Promise<ArtifactMemberRecord> {
+    const rows = await this.db
+      .insert(artifactMember)
+      .values(m)
+      .onConflictDoUpdate({ target: [artifactMember.artifact_id, artifactMember.user_id], set: { role: m.role } })
+      .returning()
+    return rows[0]
+  }
+  async removeArtifactMember(artifactId: string, userId: string): Promise<void> {
+    await this.db
+      .delete(artifactMember)
+      .where(and(eq(artifactMember.artifact_id, artifactId), eq(artifactMember.user_id, userId)))
+  }
+
+  // ---- User directory (Better Auth's "user" table; raw, may be absent) ---
+  async findUserByEmail(email: string): Promise<UserDir | null> {
+    try {
+      const { rows } = await this.pool.query(`SELECT id, email, name FROM "user" WHERE email = $1`, [email])
+      return (rows[0] as UserDir) ?? null
+    } catch {
+      return null
+    }
+  }
+  async getUsers(ids: string[]): Promise<UserDir[]> {
+    if (ids.length === 0) return []
+    try {
+      const ph = ids.map((_, i) => `$${i + 1}`).join(",")
+      const { rows } = await this.pool.query(`SELECT id, email, name FROM "user" WHERE id IN (${ph})`, ids)
+      return rows as UserDir[]
+    } catch {
+      return []
+    }
   }
 
   async close(): Promise<void> {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2,11 +2,14 @@ import { sql } from "drizzle-orm"
 import { integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core"
 import type {
   ArtifactKind,
+  ArtifactMemberRecord,
   ArtifactRecord,
   CommentRecord,
   CommentState,
   DeliveryRecord,
   DeliveryStatus,
+  MembershipRecord,
+  Role,
   VersionRecord,
   Visibility,
   WebhookKind,
@@ -90,6 +93,32 @@ export const webhookDelivery = sqliteTable("webhook_delivery", {
   next_attempt_at: text("next_attempt_at").notNull().default(now),
   created_at: text("created_at").notNull().default(now),
 })
+
+export const membership = sqliteTable(
+  "membership",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    user_id: text("user_id").notNull(),
+    role: text("role").$type<Role>().notNull(),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [uniqueIndex("membership_org_user").on(t.org_id, t.user_id)],
+)
+
+export const artifactMember = sqliteTable(
+  "artifact_member",
+  {
+    id: text("id").primaryKey(),
+    artifact_id: text("artifact_id")
+      .notNull()
+      .references(() => artifact.id),
+    user_id: text("user_id").notNull(),
+    role: text("role").$type<Role>().notNull(),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [uniqueIndex("artifact_member_user").on(t.artifact_id, t.user_id)],
+)
 
 // user/session/account/verification tables are owned and migrated by Better Auth
 // (see apps/api/src/auth-config.ts) — not declared here.
@@ -185,6 +214,22 @@ export const SCHEMA_STATEMENTS: string[] = [
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
   )`,
   `CREATE INDEX IF NOT EXISTS delivery_due ON webhook_delivery (status, next_attempt_at)`,
+  `CREATE TABLE IF NOT EXISTS membership (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (org_id, user_id)
+  )`,
+  `CREATE TABLE IF NOT EXISTS artifact_member (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    user_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (artifact_id, user_id)
+  )`,
   // user/session/account/verification are owned and migrated by Better Auth.
 ]
 
@@ -207,5 +252,7 @@ const _schemaParity: [
   Exact<typeof comment.$inferSelect, CommentRecord>,
   Exact<typeof webhook.$inferSelect, WebhookRecord>,
   Exact<typeof webhookDelivery.$inferSelect, DeliveryRecord>,
-] = [true, true, true, true, true]
+  Exact<typeof membership.$inferSelect, MembershipRecord>,
+  Exact<typeof artifactMember.$inferSelect, ArtifactMemberRecord>,
+] = [true, true, true, true, true, true, true]
 void _schemaParity

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -1,28 +1,43 @@
 import Database from "better-sqlite3"
-import { and, asc, desc, eq, isNull, lte, or } from "drizzle-orm"
+import { and, asc, count, desc, eq, isNull, lte, or } from "drizzle-orm"
 import { drizzle, type BetterSQLite3Database } from "drizzle-orm/better-sqlite3"
 import type {
+  ArtifactMemberRecord,
   ArtifactRecord,
   CommentRecord,
   CommentState,
   DeliveryRecord,
   DeliveryStatus,
+  MembershipRecord,
   MetaStore,
   NewArtifact,
+  NewArtifactMember,
   NewComment,
   NewDelivery,
+  NewMembership,
   NewVersion,
   NewView,
   NewWebhook,
+  UserDir,
   VersionRecord,
   ViewStats,
   WebhookRecord,
 } from "@dock/core"
-import { MIGRATION_STATEMENTS, SCHEMA_STATEMENTS, artifact, comment, version, webhook, webhookDelivery } from "./schema"
+import {
+  MIGRATION_STATEMENTS,
+  SCHEMA_STATEMENTS,
+  artifact,
+  artifactMember,
+  comment,
+  membership,
+  version,
+  webhook,
+  webhookDelivery,
+} from "./schema"
 
 const VIEW_WINDOW_MS = 30 * 86400_000
 
-const schema = { artifact, version, comment, webhook, webhookDelivery }
+const schema = { artifact, version, comment, webhook, webhookDelivery, membership, artifactMember }
 
 /** Embedded SQLite (WAL). The zero-dependency default; no external services. */
 export class SqliteMetaStore implements MetaStore {
@@ -222,6 +237,79 @@ export class SqliteMetaStore implements MetaStore {
         .limit(limit)
         .all(),
     )
+  }
+
+  // ---- Permissions: membership + per-artifact shares ---------------------
+  async getMembership(orgId: string, userId: string): Promise<MembershipRecord | null> {
+    return (
+      this.db.select().from(membership).where(and(eq(membership.org_id, orgId), eq(membership.user_id, userId))).get() ??
+      null
+    )
+  }
+  listMemberships(orgId: string): Promise<MembershipRecord[]> {
+    return Promise.resolve(this.db.select().from(membership).where(eq(membership.org_id, orgId)).all())
+  }
+  async countMemberships(orgId: string): Promise<number> {
+    return this.db.select({ n: count() }).from(membership).where(eq(membership.org_id, orgId)).get()?.n ?? 0
+  }
+  setMembership(m: NewMembership): Promise<MembershipRecord> {
+    return Promise.resolve(
+      this.db
+        .insert(membership)
+        .values(m)
+        .onConflictDoUpdate({ target: [membership.org_id, membership.user_id], set: { role: m.role } })
+        .returning()
+        .get(),
+    )
+  }
+
+  async getArtifactMember(artifactId: string, userId: string): Promise<ArtifactMemberRecord | null> {
+    return (
+      this.db
+        .select()
+        .from(artifactMember)
+        .where(and(eq(artifactMember.artifact_id, artifactId), eq(artifactMember.user_id, userId)))
+        .get() ?? null
+    )
+  }
+  listArtifactMembers(artifactId: string): Promise<ArtifactMemberRecord[]> {
+    return Promise.resolve(
+      this.db.select().from(artifactMember).where(eq(artifactMember.artifact_id, artifactId)).all(),
+    )
+  }
+  setArtifactMember(m: NewArtifactMember): Promise<ArtifactMemberRecord> {
+    return Promise.resolve(
+      this.db
+        .insert(artifactMember)
+        .values(m)
+        .onConflictDoUpdate({ target: [artifactMember.artifact_id, artifactMember.user_id], set: { role: m.role } })
+        .returning()
+        .get(),
+    )
+  }
+  async removeArtifactMember(artifactId: string, userId: string): Promise<void> {
+    this.db
+      .delete(artifactMember)
+      .where(and(eq(artifactMember.artifact_id, artifactId), eq(artifactMember.user_id, userId)))
+      .run()
+  }
+
+  // ---- User directory (Better Auth's `user` table; raw, may be absent) ---
+  async findUserByEmail(email: string): Promise<UserDir | null> {
+    try {
+      return (this.raw.prepare(`SELECT id, email, name FROM user WHERE email = ?`).get(email) as UserDir) ?? null
+    } catch {
+      return null
+    }
+  }
+  async getUsers(ids: string[]): Promise<UserDir[]> {
+    if (ids.length === 0) return []
+    try {
+      const ph = ids.map(() => "?").join(",")
+      return this.raw.prepare(`SELECT id, email, name FROM user WHERE id IN (${ph})`).all(...ids) as UserDir[]
+    } catch {
+      return []
+    }
   }
 
   close(): void {


### PR DESCRIPTION
## What

Artifacts get a real authorization model. A single choke point — `can(actor, action, visibility)` — gates every write, and a per-artifact share can lift or lower one person on one artifact without touching their workspace role. This is the foundation for reviews next: some people publish directly, others only propose.

## The model

- **Roles** `viewer < commenter < editor < owner`; **actions** `read / comment / publish / approve / manage`.
- A **commenter** creates content to be reviewed but cannot approve or publish; **editors** and **owners** do.
- **Effective role** resolves per-artifact override → workspace membership → visibility floor. So a share is the override; workspace membership is the baseline ("Both").
- **Lazy provisioning**: the first member of the workspace is its owner, everyone else joins at the configured default role — a fresh secured instance has exactly one owner, no setup.
- An **open instance** (no static token) still trusts anonymous callers as owner, so zero-config self-host keeps working.

## Surface

- Data model: `membership` + `artifact_member` across all three MetaStore drivers (sqlite / pg / d1), with drizzle defs + compile-time parity guards, plus a thin read of Better Auth's `user` table for sharing-by-email.
- API: every gate (read, comment, publish, restore, webhook-manage) routed through `can()`; denials return 403. New `GET/PUT/DELETE /v1/artifacts/:id/members` (owner-gated); the artifact response carries `my_role` and `/v1/me` carries the caller's workspace role.
- Web: a Share popover on the artifact header, visible only to an owner — add a teammate by email at a role, change or remove inline; unlisted people fall back to the workspace default, stated plainly. Self-contained component, one line into the header.

## Verification

- 10 core unit tests (the `can()` matrix), 8 new API integration tests (commenter-blocked-from-publish, viewer-read-only, a share lifting a viewer to editor, owner-only manage).
- 11-check end-to-end run against **real Postgres** (isolated temp DB) exercising the same scenarios through the pg driver.
- Full UI roundtrip confirmed in the browser: owner shares an artifact with a teammate by email, the member appears as editor.
- `pnpm typecheck` + `pnpm test` green across all 7 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)