### PR TITLE
ci: use Ubicloud runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,9 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    # Ubicloud runners (cheaper than GitHub-hosted). Bump the suffix (-4, -8) for
+    # more cores; falls back to a label your org's Ubicloud integration provides.
+    runs-on: ubicloud-standard-2
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Switches CI from `ubuntu-latest` (GitHub-hosted, billable on private repos) to `ubicloud-standard-2`. This PR's own CI run is the validation: if an Ubicloud runner picks it up and goes green, the label is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)