### PR TITLE
feat(web): mobile comment sheet — keep the document visible while commenting

### DIFF
--- a/apps/web/src/pages/Artifact.tsx
+++ b/apps/web/src/pages/Artifact.tsx
@@ -512,6 +512,11 @@ export function Artifact() {
               flexDirection: "column",
               minWidth: 0,
               position: "relative",
+              // On phones, the comments sheet sits in the bottom half — reserve
+              // that space so the document stays visible above it (and a
+              // jumped-to highlight lands in view, not behind the sheet).
+              paddingBottom: isMobile && panel === "open" ? "50vh" : undefined,
+              transition: "padding-bottom .26s cubic-bezier(.4,0,.2,1)",
             }}
           >
             {editing ? (
@@ -723,9 +728,10 @@ export function Artifact() {
             </aside>
           )}
         </div>
-        {/* Phones: comments live in a slide-up sheet over the full-width document
-          — a flat thread list (no document margin), tapping a quote jumps to the
-          text and closes the sheet. */}
+        {/* Phones: comments live in a slide-up sheet that takes the bottom half,
+          so the document stays visible above it. A flat thread list (no document
+          margin); tapping a quote scrolls the visible document to the highlight
+          without closing the sheet. The grip expands it to full for reading. */}
         {isMobile && (
           <MobileComments
             open={panel === "open"}
@@ -747,10 +753,7 @@ export function Artifact() {
             onActivate={activate}
             onResolve={toggleResolve}
             onReply={reply}
-            onJump={(id) => {
-              jumpTo(id)
-              setPanel("hidden")
-            }}
+            onJump={jumpTo}
             onSubmitNew={submitNew}
             onCancelNew={() => {
               setComposer(null)
@@ -824,19 +827,42 @@ function MobileComments({
   onSubmitNew: (text: string) => void
   onCancelNew: () => void
 }) {
+  // Half by default (document visible above). Reset to half each time it opens;
+  // a composer wants room, so expand to full automatically.
+  const [full, setFull] = useState(false)
+  useEffect(() => {
+    if (open) setFull(false)
+  }, [open])
+  useEffect(() => {
+    if (open && composer) setFull(true)
+  }, [open, composer])
   const empty = openThreads.length === 0 && resolved.length === 0 && !composer
+  // Jumping to text: collapse to half so the highlight lands in the visible doc.
+  const jumpToText = (id: string) => {
+    setFull(false)
+    onJump(id)
+  }
   return (
     <>
+      {/* Backdrop only at full height (reading mode). At half the document above
+          stays tappable/scrollable, so no dimming layer intercepts it. */}
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: backdrop dismissal mirrors the ✕ button. */}
-      <div className={`sheet-backdrop${open ? " show" : ""}`} onClick={onClose} aria-hidden />
       <div
-        className={`sheet${open ? " show" : ""}`}
+        className={`sheet-backdrop${open && full ? " show" : ""}`}
+        onClick={onClose}
+        aria-hidden
+      />
+      <div
+        className={`sheet ${full ? "full" : "half"}${open ? " show" : ""}`}
         role="dialog"
-        aria-modal="true"
         aria-label="Comments"
       >
-        {/* biome-ignore lint/a11y/useKeyWithClickEvents: grip is a redundant close affordance. */}
-        <div className="sheet-grip" onClick={onClose} />
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: grip toggles height; ✕ closes. */}
+        <div
+          className="sheet-grip"
+          onClick={() => setFull((f) => !f)}
+          title={full ? "Collapse" : "Expand"}
+        />
         <div className="sheet-head">
           <b style={{ fontSize: 14 }}>Comments</b>
           {openCount > 0 && (
@@ -855,9 +881,18 @@ function MobileComments({
             </span>
           )}
           <span style={{ flex: 1 }} />
-          <button className="btn sm" onClick={onNewGeneral}>
+          <button
+            className="btn sm"
+            onClick={() => {
+              setFull(true)
+              onNewGeneral()
+            }}
+          >
             ＋ New
           </button>
+          <IconBtn title={full ? "Collapse" : "Expand"} onClick={() => setFull((f) => !f)}>
+            {full ? "▾" : "▴"}
+          </IconBtn>
           <IconBtn title="Close comments" onClick={onClose}>
             ✕
           </IconBtn>
@@ -896,7 +931,7 @@ function MobileComments({
                 onHover={() => {}}
                 onResolve={onResolve}
                 onReply={onReply}
-                onJump={onJump}
+                onJump={jumpToText}
               />
             </div>
           ))}
@@ -909,7 +944,7 @@ function MobileComments({
               onHover={() => {}}
               onResolve={onResolve}
               onReply={onReply}
-              onJump={onJump}
+              onJump={jumpToText}
             />
           )}
         </div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -69,10 +69,12 @@ a{color:var(--ac);text-decoration:none}
 /* -- Mobile comments sheet: slides up over the full-width document. -- */
 .sheet-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.34);opacity:0;pointer-events:none;transition:opacity .22s;z-index:60}
 .sheet-backdrop.show{opacity:1;pointer-events:auto}
-.sheet{position:fixed;left:0;right:0;bottom:0;height:80vh;max-height:80vh;background:var(--card);
+.sheet{position:fixed;left:0;right:0;bottom:0;background:var(--card);
   border-top-left-radius:18px;border-top-right-radius:18px;border-top:1px solid var(--line);
   box-shadow:0 -14px 44px -18px rgba(0,0,0,.5);display:flex;flex-direction:column;
-  transform:translateY(102%);transition:transform .26s cubic-bezier(.4,0,.2,1);z-index:61}
+  transform:translateY(102%);transition:transform .26s cubic-bezier(.4,0,.2,1),height .24s cubic-bezier(.4,0,.2,1);z-index:61}
+.sheet.half{height:50vh}
+.sheet.full{height:88vh}
 .sheet.show{transform:none}
 .sheet-grip{width:40px;height:4px;border-radius:999px;background:var(--line);margin:9px auto 4px;flex:0 0 auto;cursor:grab}
 .sheet-head{display:flex;align-items:center;gap:8px;padding:4px 10px 10px 14px;border-bottom:1px solid var(--line-soft)}


### PR DESCRIPTION
**Problem (caught while vetting on a phone):** the comment sheet covered the full document, so you couldn't see the text you were commenting on. The mechanics worked; the spatial UX didn't.

**Fix:** the mobile comment sheet is now a two-detent bottom sheet.
- **Opens at half height.** The document reserves that space and stays visible — and scrollable/selectable — above it. No dimming backdrop at half, so the doc is fully usable.
- **Jump-to-text keeps the sheet open.** Tapping a quote scrolls the visible document to the highlight (collapsing full→half first if needed), so you always see the context the thread is about — instead of the sheet closing.
- **Grip / chevron expands to full** for reading long threads (backdrop dims then). **＋ New auto-expands** so the composer has room.

Desktop is untouched (everything is behind `useIsMobile`).

## Vetted on mobile (390px)
Post a comment, reply, react, resolve (→ moves to Resolved), jump-to-text, version history menu, view-an-old-version banner (wraps), and the diff view — all verified, 390/390 no horizontal overflow. Screenshots walk through each state.

`biome ci` ✓ · `pnpm typecheck` ✓ · `pnpm test` ✓ (api 57 · mcp 10 · storage 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)