### PR TITLE
web: redesigned login + e2e smoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ dist/
 .DS_Store
 .wrangler/
 .tanstack/
+
+# e2e (Playwright)
+.e2e-data/
+test-results/
+playwright-report/

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -1,0 +1,42 @@
+import { Buffer } from "node:buffer"
+import { expect, test } from "@playwright/test"
+
+// The core loop, end to end through the real UI: sign up, publish an artifact,
+// comment on it, and resolve the thread.
+test("publish, comment, and resolve", async ({ page }) => {
+  // A fresh database each run means this first user is the workspace owner.
+  const email = `smoke+${Date.now()}@dock.test`
+
+  await page.goto("/login")
+  await page.getByRole("button", { name: "Create an account" }).click()
+  await page.getByPlaceholder("Your name").fill("Smoke Tester")
+  await page.getByPlaceholder("you@company.com").fill(email)
+  await page.getByPlaceholder("At least 8 characters").fill("smoke-pass-123")
+  await page.getByRole("button", { name: "Create account" }).click()
+
+  // Signed in: redirected off the login page.
+  await expect(page).not.toHaveURL(/\/login/, { timeout: 15_000 })
+
+  // Publish a markdown doc through the now-authenticated session.
+  const md = "# Smoke Doc\n\nThe body of the smoke-test document for the comment loop."
+  const res = await page.request.post("/v1/artifacts", {
+    multipart: {
+      file: { name: "smoke.md", mimeType: "text/markdown", buffer: Buffer.from(md) },
+    },
+  })
+  expect(res.ok()).toBeTruthy()
+  const { short_id: shortId } = (await res.json()) as { short_id: string }
+
+  // Open it and add a comment from the panel.
+  await page.goto(`/a/${shortId}`)
+  await expect(page.getByText("Comments", { exact: true })).toBeVisible()
+  await page.getByTitle("New comment").click()
+  await page.getByPlaceholder("Add a comment…").fill("Looks good, shipping.")
+  await page.getByRole("button", { name: "Comment", exact: true }).click()
+  await expect(page.getByText("Looks good, shipping.")).toBeVisible()
+
+  // Resolve the thread: activate the card, then resolve it.
+  await page.getByText("Looks good, shipping.").click()
+  await page.getByRole("button", { name: "Resolve" }).click()
+  await expect(page.getByText(/Resolved \(\d+\)/)).toBeVisible()
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@tanstack/react-router": "^1.170.15",
@@ -16,6 +17,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/node": "^22.19.21",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from "@playwright/test"
+
+// Dedicated ports so the e2e never clashes with a dev server on the usual ones.
+const API_PORT = 8392
+const WEB_PORT = 3392
+const WEB = `http://localhost:${WEB_PORT}`
+
+// Boots a throwaway API (fresh SQLite each run) + the web app, then drives the
+// real browser through the publish -> comment -> resolve loop.
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  workers: 1,
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  reporter: process.env.CI ? "github" : "list",
+  use: { baseURL: WEB, trace: "retain-on-failure" },
+  webServer: [
+    {
+      command: `rm -rf .e2e-data && PORT=${API_PORT} DATA_DIR=.e2e-data DOCK_WEB_ORIGIN=${WEB} DOCK_RATE_LIMIT=false pnpm --filter @dock/api dev`,
+      url: `http://localhost:${API_PORT}/healthz`,
+      cwd: "../..",
+      timeout: 60_000,
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      command: `DOCK_API=http://localhost:${API_PORT} pnpm --filter @dock/web dev --port ${WEB_PORT} --strictPort`,
+      url: WEB,
+      cwd: "../..",
+      timeout: 120_000,
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
+})

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -1,8 +1,16 @@
 import { useNavigate } from "@tanstack/react-router"
+import type { FormEvent } from "react"
 import { useEffect, useState } from "react"
 import { api } from "../api"
 import { Logo } from "../components"
 import { useAuth } from "../ctx"
+
+const FEATURES: [string, string][] = [
+  ["Permanent URLs", "Every artifact gets a stable link with full version history."],
+  ["Review in context", "Comments anchor to the text and survive every republish."],
+  ["Publish from anywhere", "Ship from the CLI, the HTTP API, or an agent over MCP."],
+  ["Yours to host", "Self-host the whole thing, or use the hosted tier."],
+]
 
 export function Login() {
   const { me, loading, setMe } = useAuth()
@@ -18,7 +26,7 @@ export function Login() {
     if (!loading && me) nav({ to: "/" })
   }, [loading, me, nav])
 
-  const submit = async (e: React.FormEvent) => {
+  const submit = async (e: FormEvent) => {
     e.preventDefault()
     setErr("")
     setBusy(true)
@@ -35,113 +43,116 @@ export function Login() {
   }
 
   return (
-    <div className="center">
-      <div style={{ width: 360, maxWidth: "90vw" }}>
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-            gap: 10,
-            marginBottom: 6,
-          }}
-        >
-          <Logo size={30} />
-          <span className="display" style={{ fontWeight: 600, fontSize: 22 }}>
-            Dock
-          </span>
+    <div className="auth">
+      <aside className="auth-aside">
+        <div className="auth-aside-inner">
+          <div className="auth-brand">
+            <Logo size={30} />
+            <span className="display">Dock</span>
+          </div>
+          <h1 className="display auth-headline">The permanent home for your AI artifacts.</h1>
+          <p className="auth-sub">
+            Give any HTML page, doc, or built site a lasting URL, version history, and a review loop
+            your team and your agents can actually use.
+          </p>
+          <ul className="auth-features">
+            {FEATURES.map(([title, desc]) => (
+              <li key={title}>
+                <span className="auth-check" aria-hidden>
+                  ✓
+                </span>
+                <div>
+                  <b>{title}</b>
+                  <span>{desc}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
         </div>
-        <p className="muted" style={{ textAlign: "center", margin: "0 0 24px" }}>
-          {mode === "signup" ? "Create your account." : "Sign in to your workspace."}
-        </p>
-        <form
-          className="card"
-          style={{ padding: 22, boxShadow: "var(--shadow)" }}
-          onSubmit={submit}
-        >
-          {err && (
-            <div
-              style={{
-                background: "var(--cmt-bg)",
-                color: "var(--bad)",
-                borderRadius: 8,
-                padding: "8px 12px",
-                fontSize: 13,
-                marginBottom: 12,
-              }}
-            >
-              {err}
-            </div>
-          )}
-          {mode === "signup" && (
-            <label style={lbl}>
-              Name
+      </aside>
+
+      <main className="auth-main">
+        <div className="auth-card-wrap">
+          <div className="auth-brand auth-brand-mobile">
+            <Logo size={26} />
+            <span className="display">Dock</span>
+          </div>
+          <p className="auth-tagline-mobile muted">
+            Permanent URLs, versions, and review for your AI artifacts.
+          </p>
+          <h2 className="display auth-title">
+            {mode === "signup" ? "Create your account" : "Welcome back"}
+          </h2>
+          <p className="muted auth-card-sub">
+            {mode === "signup"
+              ? "Start publishing artifacts in seconds."
+              : "Sign in to your workspace."}
+          </p>
+
+          <form className="auth-form" onSubmit={submit}>
+            {err && <div className="auth-err">{err}</div>}
+            {mode === "signup" && (
+              <label className="auth-field">
+                Name
+                <input
+                  className="input"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Your name"
+                />
+              </label>
+            )}
+            <label className="auth-field">
+              Email
               <input
                 className="input"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="Your name"
+                type="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@company.com"
               />
             </label>
-          )}
-          <label style={lbl}>
-            Email
-            <input
-              className="input"
-              type="email"
-              required
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="you@company.com"
-            />
-          </label>
-          <label style={{ ...lbl, marginBottom: 16 }}>
-            Password
-            <input
-              className="input"
-              type="password"
-              required
-              minLength={8}
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="At least 8 characters"
-            />
-          </label>
-          <button
-            className="btn pri"
-            type="submit"
-            disabled={busy}
-            style={{ width: "100%", justifyContent: "center" }}
-          >
-            {busy ? "…" : mode === "signup" ? "Create account" : "Sign in"}
-          </button>
-        </form>
-        <p className="muted" style={{ textAlign: "center", fontSize: 13, marginTop: 14 }}>
-          {mode === "login" ? (
-            <>
-              New here?{" "}
-              <a style={{ cursor: "pointer" }} onClick={() => setMode("signup")}>
-                Create an account
-              </a>
-            </>
-          ) : (
-            <>
-              Have an account?{" "}
-              <a style={{ cursor: "pointer" }} onClick={() => setMode("login")}>
-                Sign in
-              </a>
-            </>
-          )}
-        </p>
-      </div>
+            <label className="auth-field">
+              Password
+              <input
+                className="input"
+                type="password"
+                required
+                minLength={8}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="At least 8 characters"
+              />
+            </label>
+            <button
+              className="btn pri auth-submit"
+              type="submit"
+              disabled={busy || !email || !password}
+            >
+              {busy ? "…" : mode === "signup" ? "Create account" : "Sign in"}
+            </button>
+          </form>
+
+          <p className="auth-toggle muted">
+            {mode === "login" ? (
+              <>
+                New here?{" "}
+                <button type="button" className="lnk" onClick={() => setMode("signup")}>
+                  Create an account
+                </button>
+              </>
+            ) : (
+              <>
+                Have an account?{" "}
+                <button type="button" className="lnk" onClick={() => setMode("login")}>
+                  Sign in
+                </button>
+              </>
+            )}
+          </p>
+        </div>
+      </main>
     </div>
   )
-}
-
-const lbl: React.CSSProperties = {
-  display: "block",
-  fontSize: 12.5,
-  fontWeight: 600,
-  color: "var(--fg-mut)",
-  marginBottom: 12,
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -136,3 +136,51 @@ a{color:var(--ac);text-decoration:none}
   font:500 12px Inter,sans-serif;padding:7px 10px;border-radius:7px;cursor:pointer;text-align:left;white-space:nowrap}
 .cmt-menu button:hover{background:var(--hover)}
 .cmt-menu button.danger:hover{color:var(--bad)}
+
+/* -- Login: branded story on the left, the form on the right. -- */
+.auth{min-height:100%;display:grid;grid-template-columns:1.05fr 1fr}
+.auth-aside{position:relative;overflow:hidden;display:flex;align-items:center;padding:7vh 6vw;color:#fff;
+  background:linear-gradient(155deg,#6f60b2 0%,#4a3f7a 46%,#2a2540 100%)}
+/* paper-grain texture over the gradient, same noise as the body */
+.auth-aside::after{content:"";position:absolute;inset:0;pointer-events:none;opacity:.06;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+/* a soft glow in the corner for depth */
+.auth-aside::before{content:"";position:absolute;top:-20%;right:-10%;width:55%;height:55%;border-radius:50%;
+  background:radial-gradient(circle,rgba(185,174,240,.45),transparent 70%);filter:blur(10px);pointer-events:none}
+.auth-aside-inner{position:relative;max-width:460px;animation:authin .5s cubic-bezier(.2,.8,.2,1)}
+.auth-brand{display:flex;align-items:center;gap:10px}
+.auth-aside .auth-brand .display{font-size:22px;font-weight:600;color:#fff}
+.auth-headline{font-size:clamp(28px,3.3vw,42px);line-height:1.08;letter-spacing:-.02em;color:#fff;
+  margin:30px 0 14px}
+.auth-sub{font-size:15px;line-height:1.6;color:rgba(255,255,255,.82);margin:0 0 32px;max-width:42ch}
+.auth-features{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:17px}
+.auth-features li{display:flex;gap:12px;align-items:flex-start}
+.auth-check{flex:0 0 auto;width:22px;height:22px;border-radius:50%;display:grid;place-items:center;font-size:12px;
+  color:#fff;background:rgba(255,255,255,.18);margin-top:1px}
+.auth-features li>div{display:flex;flex-direction:column;gap:2px}
+.auth-features b{font-size:14px;color:#fff}
+.auth-features span{font-size:13px;line-height:1.5;color:rgba(255,255,255,.7)}
+
+.auth-main{display:flex;align-items:center;justify-content:center;padding:6vh 24px;background:var(--bg)}
+.auth-card-wrap{width:360px;max-width:100%;animation:authin .5s cubic-bezier(.2,.8,.2,1) .06s both}
+.auth-brand-mobile{display:none;justify-content:center;margin-bottom:14px}
+.auth-tagline-mobile{display:none;text-align:center;font-size:13.5px;line-height:1.5;margin:0 0 24px}
+.auth-brand-mobile .display{font-size:20px;font-weight:600;color:var(--fg)}
+.auth-title{font-size:26px;letter-spacing:-.02em;margin:0 0 4px;color:var(--fg)}
+.auth-card-sub{font-size:13.5px;margin:0 0 22px}
+.auth-form{display:flex;flex-direction:column;gap:14px}
+.auth-field{display:flex;flex-direction:column;gap:6px;font-size:12.5px;font-weight:600;color:var(--fg-mut)}
+.auth-err{background:var(--cmt-bg);color:var(--bad);border-radius:8px;padding:8px 12px;font-size:13px}
+.auth-submit{width:100%;justify-content:center;margin-top:4px}
+.auth-submit:disabled{opacity:.5;cursor:not-allowed}
+.auth-toggle{text-align:center;font-size:13px;margin-top:18px}
+.auth-toggle .lnk{font-weight:600;font-size:13px}
+@keyframes authin{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
+
+@media (max-width:900px){
+  .auth{grid-template-columns:1fr}
+  .auth-aside{display:none}
+  .auth-brand-mobile{display:flex}
+  .auth-tagline-mobile{display:block}
+  .auth-main{padding:8vh 22px}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@types/node':
         specifier: ^22.19.21
         version: 22.19.21
@@ -673,6 +676,11 @@ packages:
 
   '@petamoriken/float16@3.9.3':
     resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -1564,6 +1572,11 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1924,6 +1937,16 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -2789,6 +2812,10 @@ snapshots:
   '@petamoriken/float16@3.9.3':
     optional: true
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
@@ -3562,6 +3589,9 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3836,6 +3866,14 @@ snapshots:
   picomatch@4.0.4: {}
 
   pkce-challenge@5.0.1: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.15:
     dependencies:


### PR DESCRIPTION
Two commits:

## feat(web): redesign the login
A split layout — branded story panel on the left (gradient + grain, headline, what Dock is, feature highlights) and a clean sign-in / sign-up form on the right. Collapses to a form-focused mobile view with a compact brand + tagline. Uses the existing design tokens, so it tracks all four themes.

## test(web): Playwright e2e smoke
The web app had zero automated coverage. This boots a throwaway API (fresh SQLite) + the web app and drives the real browser through **sign up → publish → comment → resolve**, guarding the whole loop, the new login, and the comment panel. Run with `pnpm --filter @dock/web test:e2e` (passes in ~10s incl. server boot). Kept out of the default CI run for now so the lint/typecheck/test job stays fast; easy to add as its own job later.

Typecheck clean, Biome 0 errors, vitest green (api 57, mcp 10, core, storage, cli).

🤖 Generated with [Claude Code](https://claude.com/claude-code)