### PR TITLE
ci: run the e2e smoke in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,23 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  e2e:
+    runs-on: ubicloud-standard-2
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: pnpm --filter @dock/web exec playwright install --with-deps chromium
+
+      - name: e2e smoke (publish, comment, resolve)
+        run: pnpm --filter @dock/web test:e2e


### PR DESCRIPTION
Adds a parallel `e2e` job to CI (Ubicloud) that installs Chromium and runs the publish → comment → resolve smoke. This PR's own run validates the job works in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)