### PR TITLE
ci: run the e2e smoke nightly, not per-PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,23 +33,3 @@ jobs:
 
       - name: Test
         run: pnpm test
-
-  e2e:
-    runs-on: ubicloud-standard-2
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright browser
-        run: pnpm --filter @dock/web exec playwright install --with-deps chromium
-
-      - name: e2e smoke (publish, comment, resolve)
-        run: pnpm --filter @dock/web test:e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,33 @@
+name: e2e (nightly)
+
+# The browser smoke is slow + heavier than the per-PR checks, so it runs on a
+# schedule rather than every push. Trigger it by hand any time from the Actions
+# tab via "Run workflow".
+on:
+  schedule:
+    - cron: "0 7 * * *" # 07:00 UTC nightly
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubicloud-standard-2
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: pnpm --filter @dock/web exec playwright install --with-deps chromium
+
+      - name: e2e smoke (publish, comment, resolve)
+        run: pnpm --filter @dock/web test:e2e


### PR DESCRIPTION
Moves the Chromium/Playwright smoke out of the per-PR CI into a nightly scheduled workflow (`07:00 UTC`) with a manual `workflow_dispatch` trigger. Per-PR CI is back to just the fast `check` job (biome + typecheck + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)