### PR TITLE
feat(web): browse experience — sidebar, favorites, tags, search

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -302,14 +302,20 @@ export function createApp(deps: AppDeps): Hono {
   })
 
   app.get("/v1/artifacts", async (c) => {
-    if (!(await currentUser(c)) && deps.token && bearer(c) !== deps.token)
+    const me = await currentUser(c)
+    if (!me && deps.token && bearer(c) !== deps.token)
       return c.json({ error: "unauthenticated" }, 401)
     const artifacts = await meta.listArtifacts({ limit: 200 })
-    const counts = analyticsOn ? await meta.viewCounts(artifacts.map((a) => a.id)) : {}
+    const ids = artifacts.map((a) => a.id)
+    const counts = analyticsOn ? await meta.viewCounts(ids) : {}
+    const tags = await meta.tagsForArtifacts(ids)
+    const favorites = me ? new Set(await meta.listUserFavoriteIds(me.id)) : new Set<string>()
     return c.json({
       artifacts: artifacts.map((a) => ({
         ...toJson(deps.baseUrl, a, []),
         views: counts[a.id] ?? 0,
+        tags: tags[a.id] ?? [],
+        favorite: favorites.has(a.id),
       })),
     })
   })
@@ -401,6 +407,9 @@ export function createApp(deps: AppDeps): Hono {
     if (!artifact || !can(actor, "read", artifact.visibility))
       return c.json({ error: "not found" }, 404)
     const versions = await meta.listVersions(artifact.id)
+    const me = actor.kind === "user" ? actor.userId : null
+    const tags = (await meta.tagsForArtifacts([artifact.id]))[artifact.id] ?? []
+    const favorite = me ? (await meta.listUserFavoriteIds(me)).includes(artifact.id) : false
     // `versions` stays at revision granularity (machines/agents); `sessions` is
     // the time-grouped view the UI shows by default. `my_role` tells the client
     // which actions to surface.
@@ -408,6 +417,8 @@ export function createApp(deps: AppDeps): Hono {
       ...toJson(deps.baseUrl, artifact, versions),
       sessions: groupSessions(versions, versionWindowMs),
       my_role: effectiveRole(actor, artifact.visibility),
+      tags,
+      favorite,
     })
   })
 
@@ -454,6 +465,55 @@ export function createApp(deps: AppDeps): Hono {
     if (!(await authorize(c, "manage", artifact))) return c.json({ error: "forbidden" }, 403)
     await meta.removeArtifactMember(artifact.id, c.req.param("userId"))
     return c.body(null, 204)
+  })
+
+  // ---- Favorites (per-user stars) + tags (browse metadata) --------------
+  // Favorites are personal: any user who can read the artifact can star it.
+  app.put("/v1/artifacts/:shortId/favorite", async (c) => {
+    const me = await currentUser(c)
+    if (!me) return c.json({ error: "unauthenticated" }, 401)
+    const artifact = await meta.getByShortId(c.req.param("shortId"))
+    if (!artifact || !(await authorize(c, "read", artifact)))
+      return c.json({ error: "not found" }, 404)
+    await meta.setFavorite(artifact.id, me.id)
+    return c.json({ favorite: true })
+  })
+  app.delete("/v1/artifacts/:shortId/favorite", async (c) => {
+    const me = await currentUser(c)
+    if (!me) return c.json({ error: "unauthenticated" }, 401)
+    const artifact = await meta.getByShortId(c.req.param("shortId"))
+    if (!artifact) return c.json({ error: "not found" }, 404)
+    await meta.removeFavorite(artifact.id, me.id)
+    return c.json({ favorite: false })
+  })
+
+  // Tags are workspace metadata: editors set them. Normalized (trimmed,
+  // lowercased, deduped, capped) so browse stays tidy.
+  const normalizeTags = (raw: unknown): string[] => {
+    if (!Array.isArray(raw)) return []
+    const seen = new Set<string>()
+    const out: string[] = []
+    for (const t of raw) {
+      if (typeof t !== "string") continue
+      const v = t.trim().toLowerCase().replace(/\s+/g, " ").slice(0, 40)
+      if (!v || seen.has(v)) continue
+      seen.add(v)
+      out.push(v)
+      if (out.length >= 20) break
+    }
+    // Sorted so the PUT response matches the list/detail order (tagsForArtifacts
+    // also sorts), and browse chips read alphabetically everywhere.
+    return out.sort()
+  }
+  app.put("/v1/artifacts/:shortId/tags", async (c) => {
+    const artifact = await meta.getByShortId(c.req.param("shortId"))
+    if (!artifact || !(await authorize(c, "read", artifact)))
+      return c.json({ error: "not found" }, 404)
+    if (!(await authorize(c, "publish", artifact))) return c.json({ error: "forbidden" }, 403)
+    const body = (await c.req.json().catch(() => ({}))) as { tags?: unknown }
+    const tags = normalizeTags(body.tags)
+    await meta.setArtifactTags(artifact.id, tags)
+    return c.json({ tags })
   })
 
   // Restore a past version: re-point a new revision at its stored blob (no

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -777,3 +777,64 @@ describe("security: rate limiting", () => {
     expect(status).toBe(429)
   })
 })
+
+describe("favorites + tags (browse)", () => {
+  const idOf = async (shortId: string) => {
+    const a = await meta.getByShortId(shortId)
+    if (!a) throw new Error(`no artifact ${shortId}`)
+    return a.id
+  }
+  const putTags = (shortId: string, tags: string[]) =>
+    app.request(`/v1/artifacts/${shortId}/tags`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tags }),
+    })
+
+  it("favorites are per-user at the store layer (set, idempotent, remove)", async () => {
+    const { short_id } = await (await upload("fav.md", "# Fav")).json()
+    const id = await idOf(short_id)
+    expect(await meta.listUserFavoriteIds("u1")).not.toContain(id)
+    await meta.setFavorite(id, "u1")
+    await meta.setFavorite(id, "u1") // idempotent — no duplicate row
+    expect(await meta.listUserFavoriteIds("u1")).toContain(id)
+    expect(await meta.listUserFavoriteIds("u2")).not.toContain(id) // personal
+    await meta.removeFavorite(id, "u1")
+    expect(await meta.listUserFavoriteIds("u1")).not.toContain(id)
+  })
+
+  it("normalizes tags and surfaces them on list + detail", async () => {
+    const { short_id } = await (await upload("t.md", "# Tagged")).json()
+    const res = await putTags(short_id, ["React", "react", "  Demo  ", ""])
+    expect(res.status).toBe(200)
+    expect((await res.json()).tags).toEqual(["demo", "react"]) // trimmed, lowercased, deduped, sorted
+
+    const detail = await (await app.request(`/v1/artifacts/${short_id}`)).json()
+    expect(detail.tags).toEqual(["demo", "react"])
+    expect(detail.favorite).toBe(false)
+
+    const list = await (await app.request("/v1/artifacts")).json()
+    const row = list.artifacts.find((x: { short_id: string }) => x.short_id === short_id)
+    expect(row.tags).toEqual(["demo", "react"])
+    expect(row).toHaveProperty("favorite")
+  })
+
+  it("replaces the full tag set (old tags drop)", async () => {
+    const { short_id } = await (await upload("r.md", "# R")).json()
+    await putTags(short_id, ["one", "two"])
+    expect((await (await putTags(short_id, ["three"])).json()).tags).toEqual(["three"])
+    const detail = await (await app.request(`/v1/artifacts/${short_id}`)).json()
+    expect(detail.tags).toEqual(["three"])
+  })
+
+  it("batches tags across artifacts without N+1", async () => {
+    const a1 = await (await upload("b1.md", "# 1")).json()
+    const a2 = await (await upload("b2.md", "# 2")).json()
+    await putTags(a1.short_id, ["solo"])
+    const id1 = await idOf(a1.short_id)
+    const id2 = await idOf(a2.short_id)
+    const map = await meta.tagsForArtifacts([id1, id2])
+    expect(map[id1]).toEqual(["solo"])
+    expect(map[id2]).toBeUndefined() // untagged ids simply have no entry
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -32,6 +32,10 @@ export interface Artifact {
   views?: number
   /** The current caller's effective role on this artifact (null = no access). */
   my_role?: Role | null
+  /** Browse tags (workspace-wide). */
+  tags?: string[]
+  /** Whether the current user has starred this artifact. */
+  favorite?: boolean
 }
 export interface ArtifactMember {
   user_id: string
@@ -151,6 +155,11 @@ export const api = {
     ),
   heartbeat: (id: string, name: string): Promise<{ viewers: string[] }> =>
     f(`/v1/artifacts/${id}/presence`, opts({ name })).then(j),
+
+  favorite: (id: string, on: boolean): Promise<{ favorite: boolean }> =>
+    f(`/v1/artifacts/${id}/favorite`, { ...opts(), method: on ? "PUT" : "DELETE" }).then(j),
+  setTags: (id: string, tags: string[]): Promise<{ tags: string[] }> =>
+    f(`/v1/artifacts/${id}/tags`, { ...opts({ tags }), method: "PUT" }).then(j),
 
   listWebhooks: (): Promise<{ webhooks: Webhook[] }> => f("/v1/webhooks", opts()).then(j),
   createWebhook: (body: {

--- a/apps/web/src/components.tsx
+++ b/apps/web/src/components.tsx
@@ -33,9 +33,10 @@ export function useIsMobile(bp = 640): boolean {
   return m
 }
 
-export function Header({ right }: { right?: React.ReactNode }) {
+export function Header({ left, right }: { left?: React.ReactNode; right?: React.ReactNode }) {
   return (
     <header className="app-header">
+      {left}
       <Link to="/" className="hdr-brand">
         <Logo />
         <span className="display" style={{ fontWeight: 600, fontSize: 18 }}>

--- a/apps/web/src/pages/Artifact.tsx
+++ b/apps/web/src/pages/Artifact.tsx
@@ -472,6 +472,17 @@ export function Artifact() {
           right={
             <>
               {!isMobile && <Presence viewers={viewers} self={me?.name ?? me?.email ?? ""} />}
+              <StarButton
+                shortId={shortId}
+                favorite={!!art.favorite}
+                onChange={(fav) => setArt((a) => (a ? { ...a, favorite: fav } : a))}
+              />
+              <TagsMenu
+                shortId={shortId}
+                tags={art.tags ?? []}
+                canEdit={art.my_role === "editor" || art.my_role === "owner"}
+                onChange={(tags) => setArt((a) => (a ? { ...a, tags } : a))}
+              />
               <ShareButton shortId={shortId} myRole={art.my_role} />
               <Insights shortId={shortId} />
               <HistoryMenu
@@ -786,6 +797,177 @@ export function Artifact() {
         {toast}
       </div>
     </ActionsCtx.Provider>
+  )
+}
+
+// Header star: toggle this artifact as a personal favorite. Optimistic.
+function StarButton({
+  shortId,
+  favorite,
+  onChange,
+}: {
+  shortId: string
+  favorite: boolean
+  onChange: (f: boolean) => void
+}) {
+  const [busy, setBusy] = useState(false)
+  const toggle = async () => {
+    const next = !favorite
+    onChange(next)
+    setBusy(true)
+    try {
+      await api.favorite(shortId, next)
+    } catch {
+      onChange(!next)
+    } finally {
+      setBusy(false)
+    }
+  }
+  return (
+    <button
+      className="btn sm"
+      onClick={toggle}
+      disabled={busy}
+      title={favorite ? "Remove from favorites" : "Add to favorites"}
+      aria-label="Toggle favorite"
+      style={{
+        color: favorite ? "#e0a93a" : undefined,
+        borderColor: favorite ? "#e0a93a" : undefined,
+      }}
+    >
+      {favorite ? "★" : "☆"}
+    </button>
+  )
+}
+
+// Header tags popover: view tags; editors add/remove. Writes replace the full
+// set (the server normalizes: trim, lowercase, dedupe, cap).
+function TagsMenu({
+  shortId,
+  tags,
+  canEdit,
+  onChange,
+}: {
+  shortId: string
+  tags: string[]
+  canEdit: boolean
+  onChange: (t: string[]) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [draft, setDraft] = useState("")
+  const ref = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const h = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener("click", h)
+    return () => document.removeEventListener("click", h)
+  }, [])
+  const save = async (next: string[]) => {
+    onChange(next)
+    try {
+      const r = await api.setTags(shortId, next)
+      onChange(r.tags)
+    } catch {
+      /* keep the optimistic value */
+    }
+  }
+  const add = () => {
+    const v = draft.trim().toLowerCase()
+    setDraft("")
+    if (v && !tags.includes(v)) save([...tags, v])
+  }
+  return (
+    <div ref={ref} style={{ position: "relative" }}>
+      <button
+        className="btn sm"
+        onClick={(e) => {
+          e.stopPropagation()
+          setOpen((o) => !o)
+        }}
+        style={{ gap: 6 }}
+        title="Tags"
+      >
+        🏷 {tags.length > 0 && <b style={{ fontWeight: 700 }}>{tags.length}</b>}
+      </button>
+      {open && (
+        <div
+          className="card"
+          style={{
+            position: "absolute",
+            right: 0,
+            top: "calc(100% + 7px)",
+            width: 244,
+            padding: 12,
+            boxShadow: "var(--shadow)",
+            zIndex: 30,
+          }}
+        >
+          <div
+            className="mono muted"
+            style={{
+              fontSize: 9.5,
+              letterSpacing: ".06em",
+              textTransform: "uppercase",
+              marginBottom: 8,
+            }}
+          >
+            Tags
+          </div>
+          {tags.length === 0 && (
+            <div className="muted" style={{ fontSize: 12, marginBottom: canEdit ? 9 : 0 }}>
+              {canEdit ? "No tags yet — add one below." : "No tags."}
+            </div>
+          )}
+          {tags.length > 0 && (
+            <div
+              style={{ display: "flex", flexWrap: "wrap", gap: 5, marginBottom: canEdit ? 10 : 0 }}
+            >
+              {tags.map((t) => (
+                <span key={t} className="tagchip" style={{ cursor: "default" }}>
+                  #{t}
+                  {canEdit && (
+                    <button
+                      onClick={() => save(tags.filter((x) => x !== t))}
+                      aria-label={`Remove ${t}`}
+                      style={{
+                        border: 0,
+                        background: "transparent",
+                        color: "inherit",
+                        cursor: "pointer",
+                        padding: 0,
+                        marginLeft: 2,
+                        fontSize: 13,
+                        lineHeight: 1,
+                      }}
+                    >
+                      ×
+                    </button>
+                  )}
+                </span>
+              ))}
+            </div>
+          )}
+          {canEdit && (
+            <div style={{ display: "flex", gap: 6 }}>
+              <input
+                className="input"
+                value={draft}
+                placeholder="Add a tag…"
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") add()
+                }}
+                style={{ padding: "6px 9px", fontSize: 12.5 }}
+              />
+              <button className="btn sm" onClick={add} disabled={!draft.trim()}>
+                Add
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/apps/web/src/pages/Library.tsx
+++ b/apps/web/src/pages/Library.tsx
@@ -1,8 +1,12 @@
 import { useNavigate } from "@tanstack/react-router"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { API_BASE, type Artifact, api } from "../api"
-import { Header, useToast } from "../components"
+import { Header, useIsMobile, useToast } from "../components"
 import { useAuth } from "../ctx"
+
+type Filter = { kind: "all" } | { kind: "favorites" } | { kind: "tag"; tag: string }
+
+const RAIL_KEY = "dock.browse.rail"
 
 // A live, scaled-down render of the artifact's current version. Sandboxed and
 // non-interactive (clicks fall through to the card); lazy so off-screen cards
@@ -46,10 +50,30 @@ function Thumb({ id, v }: { id: string; v: number }) {
 export function Library() {
   const { me, loading } = useAuth()
   const nav = useNavigate()
+  const isMobile = useIsMobile()
   const [items, setItems] = useState<Artifact[] | null>(null)
   const [busy, setBusy] = useState(false)
   const file = useRef<HTMLInputElement>(null)
   const { toast, show } = useToast()
+
+  const [query, setQuery] = useState("")
+  const [filter, setFilter] = useState<Filter>({ kind: "all" })
+  const [rail, setRail] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(RAIL_KEY) === "1"
+    } catch {
+      return false
+    }
+  })
+  const [drawer, setDrawer] = useState(false)
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(RAIL_KEY, rail ? "1" : "0")
+    } catch {
+      /* private mode */
+    }
+  }, [rail])
 
   useEffect(() => {
     if (!loading && !me) nav({ to: "/login" })
@@ -78,6 +102,53 @@ export function Library() {
     }
   }
 
+  // Star toggle is optimistic: reflect immediately, reconcile/revert on error.
+  const toggleFav = async (a: Artifact) => {
+    const on = !a.favorite
+    const flip = (val: boolean) =>
+      setItems((p) => p?.map((x) => (x.short_id === a.short_id ? { ...x, favorite: val } : x)) ?? p)
+    flip(on)
+    try {
+      await api.favorite(a.short_id, on)
+    } catch (e) {
+      show((e as Error).message)
+      flip(!on)
+    }
+  }
+
+  const all = items ?? []
+  const favCount = all.filter((a) => a.favorite).length
+  const tagCounts = useMemo(() => {
+    const m = new Map<string, number>()
+    for (const a of all) for (const t of a.tags ?? []) m.set(t, (m.get(t) ?? 0) + 1)
+    return [...m.entries()].sort((x, y) => y[1] - x[1] || x[0].localeCompare(y[0]))
+  }, [all])
+
+  const filtered = useMemo(() => {
+    let list = all
+    if (filter.kind === "favorites") list = list.filter((a) => a.favorite)
+    else if (filter.kind === "tag") list = list.filter((a) => (a.tags ?? []).includes(filter.tag))
+    const q = query.trim().toLowerCase()
+    if (q)
+      list = list.filter(
+        (a) =>
+          (a.title ?? a.short_id).toLowerCase().includes(q) ||
+          (a.tags ?? []).some((t) => t.includes(q)),
+      )
+    return list
+  }, [all, filter, query])
+
+  const pick = (f: Filter) => {
+    setFilter(f)
+    setDrawer(false)
+  }
+  const heading =
+    filter.kind === "all"
+      ? "All artifacts"
+      : filter.kind === "favorites"
+        ? "Favorites"
+        : `#${filter.tag}`
+
   if (!me)
     return (
       <div className="center">
@@ -86,116 +157,303 @@ export function Library() {
     )
 
   return (
-    <div style={{ minHeight: "100%" }}>
-      <Header />
-      <main style={{ maxWidth: 1000, margin: "0 auto", padding: "26px 22px 60px" }}>
-        <div
-          className="card"
-          style={{
-            padding: 18,
-            marginBottom: 24,
-            display: "flex",
-            alignItems: "center",
-            gap: 14,
-            flexWrap: "wrap",
-          }}
-        >
-          <div style={{ flex: 1, minWidth: 220 }}>
-            <div className="display" style={{ fontWeight: 600, fontSize: 16 }}>
-              Publish an artifact
-            </div>
-            <div className="muted" style={{ fontSize: 13 }}>
-              Drop an HTML or Markdown file, or run <code className="mono">dock publish</code>.
-            </div>
-          </div>
-          <input
-            ref={file}
-            type="file"
-            accept=".html,.htm,.md,.markdown,.zip"
-            style={{ maxWidth: 240, fontSize: 12 }}
-            onChange={publish}
+    <div style={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      <Header
+        left={
+          isMobile ? (
+            <button
+              className="btn sm"
+              onClick={() => setDrawer(true)}
+              title="Menu"
+              aria-label="Open menu"
+              style={{ padding: "5px 10px", fontSize: 15 }}
+            >
+              ☰
+            </button>
+          ) : undefined
+        }
+      />
+      <div className="browse">
+        {isMobile && (
+          // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop mirrors the close button.
+          <div
+            className={`drawer-backdrop${drawer ? " show" : ""}`}
+            onClick={() => setDrawer(false)}
+            aria-hidden
           />
-          <button className="btn pri" onClick={publish} disabled={busy}>
-            {busy ? "Publishing…" : "Publish"}
-          </button>
-        </div>
+        )}
+        <Sidebar
+          rail={!isMobile && rail}
+          drawer={isMobile}
+          open={drawer}
+          total={all.length}
+          favCount={favCount}
+          tags={tagCounts}
+          filter={filter}
+          onPick={pick}
+          onToggleRail={() => setRail((r) => !r)}
+          onClose={() => setDrawer(false)}
+          onSettings={() => {
+            setDrawer(false)
+            nav({ to: "/settings" })
+          }}
+        />
+        <main className="browse-main">
+          <div style={{ maxWidth: 1000, margin: "0 auto", padding: "22px 22px 64px" }}>
+            <div className="searchbar">
+              <input
+                className="input"
+                placeholder="Search by title or tag…"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                style={{ flex: 1, minWidth: 200 }}
+              />
+              {filter.kind !== "all" && (
+                <button className="btn sm" onClick={() => setFilter({ kind: "all" })}>
+                  {filter.kind === "favorites" ? "★ Favorites" : `#${filter.tag}`} ✕
+                </button>
+              )}
+            </div>
 
-        <h2 className="display" style={{ fontSize: 18, margin: "0 0 14px" }}>
-          Library{" "}
-          <span className="muted" style={{ fontWeight: 400, fontSize: 14 }}>
-            · {items?.length ?? 0}
-          </span>
-        </h2>
-        {items === null ? (
-          <div className="center" style={{ height: 160 }}>
-            <div className="spin" />
-          </div>
-        ) : items.length === 0 ? (
-          <div
-            className="muted"
-            style={{
-              textAlign: "center",
-              padding: 40,
-              border: "1px dashed var(--line)",
-              borderRadius: 14,
-            }}
-          >
-            Nothing yet. Publish above, or run <code className="mono">dock publish ./file</code>.
-          </div>
-        ) : (
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fill,minmax(220px,1fr))",
-              gap: 13,
-            }}
-          >
-            {items.map((a) => (
-              <button
-                key={a.short_id}
-                onClick={() => nav({ to: "/a/$ref", params: { ref: a.short_id } })}
-                className="card"
+            <div
+              className="card"
+              style={{
+                padding: 16,
+                marginBottom: 22,
+                display: "flex",
+                alignItems: "center",
+                gap: 14,
+                flexWrap: "wrap",
+              }}
+            >
+              <div style={{ flex: 1, minWidth: 220 }}>
+                <div className="display" style={{ fontWeight: 600, fontSize: 15 }}>
+                  Publish an artifact
+                </div>
+                <div className="muted" style={{ fontSize: 13 }}>
+                  Drop an HTML or Markdown file, or run <code className="mono">dock publish</code>.
+                </div>
+              </div>
+              <input
+                ref={file}
+                type="file"
+                accept=".html,.htm,.md,.markdown,.zip"
+                style={{ maxWidth: 230, fontSize: 12 }}
+                onChange={publish}
+              />
+              <button className="btn pri" onClick={publish} disabled={busy}>
+                {busy ? "Publishing…" : "Publish"}
+              </button>
+            </div>
+
+            <h2 className="display" style={{ fontSize: 17, margin: "0 0 14px" }}>
+              {heading}{" "}
+              <span className="muted" style={{ fontWeight: 400, fontSize: 14 }}>
+                · {filtered.length}
+              </span>
+            </h2>
+
+            {items === null ? (
+              <div className="center" style={{ height: 160 }}>
+                <div className="spin" />
+              </div>
+            ) : filtered.length === 0 ? (
+              <EmptyState filter={filter} query={query} />
+            ) : (
+              <div
                 style={{
-                  textAlign: "left",
-                  padding: 15,
-                  cursor: "pointer",
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: 8,
+                  display: "grid",
+                  gridTemplateColumns: "repeat(auto-fill,minmax(220px,1fr))",
+                  gap: 13,
                 }}
               >
-                <Thumb id={a.short_id} v={a.current_version} />
-                <div className="display" style={{ fontWeight: 600, fontSize: 15 }}>
-                  {a.title ?? a.short_id}
-                </div>
-                <div
-                  className="mono muted"
-                  style={{ fontSize: 11, display: "flex", gap: 8, alignItems: "center" }}
-                >
-                  <span
-                    style={{
-                      background: "var(--card-2)",
-                      border: "1px solid var(--line-soft)",
-                      borderRadius: 5,
-                      padding: "1px 6px",
-                    }}
-                  >
-                    {a.kind}
-                  </span>
-                  <span>v{a.current_version}</span>
-                  <span>{a.visibility}</span>
-                  {a.views !== undefined && a.views > 0 && (
-                    <span style={{ marginLeft: "auto" }} title={`${a.views} views`}>
-                      👁 {a.views > 999 ? `${(a.views / 1000).toFixed(1)}k` : a.views}
-                    </span>
-                  )}
-                </div>
-              </button>
-            ))}
+                {filtered.map((a) => (
+                  <div key={a.short_id} className="card browse-card">
+                    <div style={{ position: "relative" }}>
+                      <Thumb id={a.short_id} v={a.current_version} />
+                      <button
+                        className={`star${a.favorite ? " on" : ""}`}
+                        title={a.favorite ? "Remove from favorites" : "Add to favorites"}
+                        aria-label="Toggle favorite"
+                        onClick={() => toggleFav(a)}
+                      >
+                        {a.favorite ? "★" : "☆"}
+                      </button>
+                    </div>
+                    <button
+                      className="card-open"
+                      onClick={() => nav({ to: "/a/$ref", params: { ref: a.short_id } })}
+                    >
+                      <span className="display" style={{ fontWeight: 600, fontSize: 15 }}>
+                        {a.title ?? a.short_id}
+                      </span>
+                      <span
+                        className="mono muted"
+                        style={{ fontSize: 11, display: "flex", gap: 8, alignItems: "center" }}
+                      >
+                        <span
+                          style={{
+                            background: "var(--card-2)",
+                            border: "1px solid var(--line-soft)",
+                            borderRadius: 5,
+                            padding: "1px 6px",
+                          }}
+                        >
+                          {a.kind}
+                        </span>
+                        <span>v{a.current_version}</span>
+                        {a.views !== undefined && a.views > 0 && (
+                          <span style={{ marginLeft: "auto" }} title={`${a.views} views`}>
+                            👁 {a.views > 999 ? `${(a.views / 1000).toFixed(1)}k` : a.views}
+                          </span>
+                        )}
+                      </span>
+                    </button>
+                    {(a.tags ?? []).length > 0 && (
+                      <div style={{ display: "flex", flexWrap: "wrap", gap: 5 }}>
+                        {(a.tags ?? []).slice(0, 6).map((t) => (
+                          <button
+                            key={t}
+                            className="tagchip"
+                            onClick={() => pick({ kind: "tag", tag: t })}
+                          >
+                            #{t}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
-        )}
-      </main>
+        </main>
+      </div>
       {toast}
+    </div>
+  )
+}
+
+function Sidebar({
+  rail,
+  drawer,
+  open,
+  total,
+  favCount,
+  tags,
+  filter,
+  onPick,
+  onToggleRail,
+  onClose,
+  onSettings,
+}: {
+  rail: boolean
+  drawer: boolean
+  open: boolean
+  total: number
+  favCount: number
+  tags: [string, number][]
+  filter: Filter
+  onPick: (f: Filter) => void
+  onToggleRail: () => void
+  onClose: () => void
+  onSettings: () => void
+}) {
+  const cls = drawer ? `side side-drawer${open ? " open" : ""}` : `side${rail ? " rail" : ""}`
+  return (
+    <aside className={cls} aria-label="Browse">
+      <div className="side-lbl">Library</div>
+      <button
+        className={`side-item${filter.kind === "all" ? " on" : ""}`}
+        onClick={() => onPick({ kind: "all" })}
+        title="All artifacts"
+      >
+        <span className="ic">⊞</span>
+        <span className="lbl">All artifacts</span>
+        <span className="n">{total}</span>
+      </button>
+      <button
+        className={`side-item${filter.kind === "favorites" ? " on" : ""}`}
+        onClick={() => onPick({ kind: "favorites" })}
+        title="Favorites"
+      >
+        <span className="ic">★</span>
+        <span className="lbl">Favorites</span>
+        <span className="n">{favCount}</span>
+      </button>
+
+      {tags.length > 0 && (
+        <>
+          <div className="side-lbl">Tags</div>
+          {tags.map(([t, n]) => (
+            <button
+              key={t}
+              className={`side-item${filter.kind === "tag" && filter.tag === t ? " on" : ""}`}
+              onClick={() => onPick({ kind: "tag", tag: t })}
+              title={`#${t}`}
+            >
+              <span className="ic">#</span>
+              <span className="lbl" style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+                {t}
+              </span>
+              <span className="n">{n}</span>
+            </button>
+          ))}
+        </>
+      )}
+
+      <div
+        style={{
+          marginTop: "auto",
+          display: "flex",
+          flexDirection: "column",
+          gap: 1,
+          paddingTop: 8,
+        }}
+      >
+        <button className="side-item" onClick={onSettings} title="Settings">
+          <span className="ic">⚙</span>
+          <span className="lbl">Settings</span>
+        </button>
+        {drawer ? (
+          <button className="side-toggle" onClick={onClose}>
+            <span className="ic">✕</span>
+            <span className="lbl">Close</span>
+          </button>
+        ) : (
+          <button
+            className="side-toggle"
+            onClick={onToggleRail}
+            title={rail ? "Expand sidebar" : "Collapse sidebar"}
+          >
+            <span className="ic">{rail ? "»" : "«"}</span>
+            <span className="lbl">Collapse</span>
+          </button>
+        )}
+      </div>
+    </aside>
+  )
+}
+
+function EmptyState({ filter, query }: { filter: Filter; query: string }) {
+  const msg = query
+    ? `No artifacts match “${query}”.`
+    : filter.kind === "favorites"
+      ? "No favorites yet. Tap the ☆ on any artifact to star it."
+      : filter.kind === "tag"
+        ? `Nothing tagged #${filter.tag} yet.`
+        : "Nothing yet. Publish above, or run dock publish ./file."
+  return (
+    <div
+      className="muted"
+      style={{
+        textAlign: "center",
+        padding: 40,
+        border: "1px dashed var(--line)",
+        borderRadius: 14,
+      }}
+    >
+      {msg}
     </div>
   )
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -80,6 +80,42 @@ a{color:var(--ac);text-decoration:none}
 .sheet-head{display:flex;align-items:center;gap:8px;padding:4px 10px 10px 14px;border-bottom:1px solid var(--line-soft)}
 .sheet-body{flex:1;min-height:0;overflow:auto;padding:12px;padding-bottom:max(14px,env(safe-area-inset-bottom));-webkit-overflow-scrolling:touch}
 
+/* -- Browse: collapsible sidebar (rail on desktop, drawer on mobile) + grid -- */
+.browse{display:flex;flex:1;min-height:0}
+.browse-main{flex:1;min-width:0;overflow-y:auto}
+.side{flex:0 0 224px;width:224px;border-right:1px solid var(--line);background:var(--card);
+  display:flex;flex-direction:column;gap:1px;padding:14px 10px;overflow-y:auto;transition:flex-basis .2s,width .2s}
+.side.rail{flex-basis:62px;width:62px;padding:14px 9px}
+.side-lbl{font-family:ui-monospace,Menlo,monospace;font-size:9.5px;letter-spacing:.07em;text-transform:uppercase;color:var(--fg-mut);padding:13px 8px 5px}
+.side-item{display:flex;align-items:center;gap:11px;width:100%;border:0;background:transparent;color:var(--fg);
+  font:600 13px Inter,sans-serif;padding:8px 10px;border-radius:9px;cursor:pointer;text-align:left;white-space:nowrap}
+.side-item:hover{background:var(--hover)}
+.side-item.on{background:var(--ac-soft);color:var(--ac)}
+.side-item .ic{width:18px;text-align:center;flex:0 0 auto;font-size:14px}
+.side-item .n{margin-left:auto;font-family:ui-monospace,Menlo,monospace;font-size:10.5px;color:var(--fg-mut)}
+.side-item.on .n{color:var(--ac)}
+.side.rail .side-lbl{visibility:hidden;height:6px;padding:6px 0}
+.side.rail .side-item .lbl,.side.rail .side-item .n,.side.rail .side-toggle .lbl{display:none}
+.side.rail .side-item,.side.rail .side-toggle{justify-content:center;padding:9px 0}
+.side-toggle{margin-top:auto;display:flex;align-items:center;gap:11px;border:0;background:transparent;color:var(--fg-mut);
+  font:600 12px Inter,sans-serif;padding:9px 10px;border-radius:9px;cursor:pointer}
+.side-toggle:hover{background:var(--hover);color:var(--fg)}
+.side-drawer{position:fixed;top:0;bottom:0;left:0;z-index:61;width:266px;flex-basis:266px;
+  transform:translateX(-105%);transition:transform .24s cubic-bezier(.4,0,.2,1);box-shadow:0 0 44px -10px rgba(0,0,0,.45)}
+.side-drawer.open{transform:none}
+.drawer-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.34);opacity:0;pointer-events:none;transition:.2s;z-index:60}
+.drawer-backdrop.show{opacity:1;pointer-events:auto}
+.tagchip{display:inline-flex;align-items:center;gap:4px;font-family:ui-monospace,Menlo,monospace;font-size:10.5px;color:var(--ac);
+  background:var(--ac-soft);border:1px solid transparent;border-radius:999px;padding:2px 9px;cursor:pointer;white-space:nowrap}
+.tagchip:hover{border-color:var(--ac)}
+.browse-card{position:relative;display:flex;flex-direction:column;gap:8px;padding:13px}
+.browse-card .star{position:absolute;top:9px;right:9px;z-index:2;width:30px;height:30px;border-radius:8px;border:1px solid var(--line);
+  background:var(--card);color:var(--fg-mut);cursor:pointer;font-size:14px;display:grid;place-items:center;opacity:.9;transition:.12s}
+.browse-card .star:hover{opacity:1;border-color:var(--ac)}
+.browse-card .star.on{color:#e0a93a;border-color:#e0a93a}
+.card-open{border:0;background:transparent;text-align:left;cursor:pointer;padding:0;display:flex;flex-direction:column;gap:7px;width:100%}
+.searchbar{display:flex;align-items:center;gap:9px;flex-wrap:wrap;margin-bottom:18px}
+
 @media(max-width:640px){
   .app-header{padding:10px 14px;flex-wrap:wrap;gap:8px}
   .hdr-actions{order:3;flex:1 1 100%;flex-wrap:wrap;justify-content:flex-end;gap:6px}

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -123,6 +123,16 @@ export interface MetaStore {
   setArtifactMember(m: NewArtifactMember): Promise<ArtifactMemberRecord>
   removeArtifactMember(artifactId: string, userId: string): Promise<void>
 
+  // ---- Favorites (per-user stars) + tags (browse metadata) ---------------
+  /** Artifact ids this user has starred. */
+  listUserFavoriteIds(userId: string): Promise<string[]>
+  setFavorite(artifactId: string, userId: string): Promise<void>
+  removeFavorite(artifactId: string, userId: string): Promise<void>
+  /** Tags per artifact, batched (no N+1). Missing ids map to no entry. */
+  tagsForArtifacts(artifactIds: string[]): Promise<Record<string, string[]>>
+  /** Replace an artifact's full tag set (deduped, trimmed, lowercased upstream). */
+  setArtifactTags(artifactId: string, tags: string[]): Promise<void>
+
   // ---- User directory (reads Better Auth's `user` table) ----------------
   findUserByEmail(email: string): Promise<UserDir | null>
   getUsers(ids: string[]): Promise<UserDir[]>

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -21,11 +21,13 @@ import type {
   ViewStats,
   WebhookRecord,
 } from "@dock/core"
-import { and, asc, count, desc, eq, isNull, lte, or, sql } from "drizzle-orm"
+import { and, asc, count, desc, eq, inArray, isNull, lte, or, sql } from "drizzle-orm"
 import { type DrizzleD1Database, drizzle } from "drizzle-orm/d1"
 import {
   artifact,
+  artifactFavorite,
   artifactMember,
+  artifactTag,
   comment,
   membership,
   version,
@@ -33,7 +35,17 @@ import {
   webhookDelivery,
 } from "./schema"
 
-const schema = { artifact, version, comment, webhook, webhookDelivery, membership, artifactMember }
+const schema = {
+  artifact,
+  version,
+  comment,
+  webhook,
+  webhookDelivery,
+  membership,
+  artifactMember,
+  artifactFavorite,
+  artifactTag,
+}
 const VIEW_WINDOW_MS = 30 * 86400_000
 
 /**
@@ -306,6 +318,55 @@ export class D1MetaStore implements MetaStore {
       .delete(artifactMember)
       .where(and(eq(artifactMember.artifact_id, artifactId), eq(artifactMember.user_id, userId)))
       .run()
+  }
+
+  // ---- Favorites + tags --------------------------------------------------
+  async listUserFavoriteIds(userId: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ id: artifactFavorite.artifact_id })
+      .from(artifactFavorite)
+      .where(eq(artifactFavorite.user_id, userId))
+      .all()
+    return rows.map((r) => r.id)
+  }
+  async setFavorite(artifactId: string, userId: string): Promise<void> {
+    await this.db
+      .insert(artifactFavorite)
+      .values({ id: crypto.randomUUID(), artifact_id: artifactId, user_id: userId })
+      .onConflictDoNothing({ target: [artifactFavorite.artifact_id, artifactFavorite.user_id] })
+      .run()
+  }
+  async removeFavorite(artifactId: string, userId: string): Promise<void> {
+    await this.db
+      .delete(artifactFavorite)
+      .where(
+        and(eq(artifactFavorite.artifact_id, artifactId), eq(artifactFavorite.user_id, userId)),
+      )
+      .run()
+  }
+  async tagsForArtifacts(artifactIds: string[]): Promise<Record<string, string[]>> {
+    if (artifactIds.length === 0) return {}
+    const rows = await this.db
+      .select({ artifact_id: artifactTag.artifact_id, tag: artifactTag.tag })
+      .from(artifactTag)
+      .where(inArray(artifactTag.artifact_id, artifactIds))
+      .all()
+    const out: Record<string, string[]> = {}
+    for (const r of rows) {
+      if (!out[r.artifact_id]) out[r.artifact_id] = []
+      out[r.artifact_id].push(r.tag)
+    }
+    for (const k in out) out[k].sort()
+    return out
+  }
+  // D1 has no interactive transactions; replace is delete-then-insert.
+  async setArtifactTags(artifactId: string, tags: string[]): Promise<void> {
+    await this.db.delete(artifactTag).where(eq(artifactTag.artifact_id, artifactId)).run()
+    if (tags.length)
+      await this.db
+        .insert(artifactTag)
+        .values(tags.map((tag) => ({ id: crypto.randomUUID(), artifact_id: artifactId, tag })))
+        .run()
   }
 
   // ---- User directory (Better Auth's `user` table; raw, may be absent) ---

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -117,6 +117,32 @@ export const artifactMember = pgTable(
   (t) => [uniqueIndex("artifact_member_user").on(t.artifact_id, t.user_id)],
 )
 
+export const artifactFavorite = pgTable(
+  "artifact_favorite",
+  {
+    id: text("id").primaryKey(),
+    artifact_id: text("artifact_id")
+      .notNull()
+      .references(() => artifact.id),
+    user_id: text("user_id").notNull(),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [uniqueIndex("artifact_favorite_user").on(t.artifact_id, t.user_id)],
+)
+
+export const artifactTag = pgTable(
+  "artifact_tag",
+  {
+    id: text("id").primaryKey(),
+    artifact_id: text("artifact_id")
+      .notNull()
+      .references(() => artifact.id),
+    tag: text("tag").notNull(),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [uniqueIndex("artifact_tag_uniq").on(t.artifact_id, t.tag)],
+)
+
 // Compile-time guard: the pg table defs must match the core record shapes (and
 // therefore the sqlite defs). Drift here means SQLite and Postgres disagree.
 type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false
@@ -238,4 +264,20 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
     created_at TEXT NOT NULL DEFAULT ${isoDefault},
     UNIQUE (artifact_id, user_id)
   )`,
+  `CREATE TABLE IF NOT EXISTS artifact_favorite (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    user_id TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT ${isoDefault},
+    UNIQUE (artifact_id, user_id)
+  )`,
+  `CREATE INDEX IF NOT EXISTS favorite_user ON artifact_favorite (user_id)`,
+  `CREATE TABLE IF NOT EXISTS artifact_tag (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    tag TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT ${isoDefault},
+    UNIQUE (artifact_id, tag)
+  )`,
+  `CREATE INDEX IF NOT EXISTS tag_name ON artifact_tag (tag)`,
 ]

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -20,12 +20,14 @@ import type {
   ViewStats,
   WebhookRecord,
 } from "@dock/core"
-import { and, asc, count, desc, eq, isNull, lte, or } from "drizzle-orm"
+import { and, asc, count, desc, eq, inArray, isNull, lte, or } from "drizzle-orm"
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres"
 import { Pool } from "pg"
 import {
   artifact,
+  artifactFavorite,
   artifactMember,
+  artifactTag,
   comment,
   membership,
   PG_SCHEMA_STATEMENTS,
@@ -34,7 +36,17 @@ import {
   webhookDelivery,
 } from "./pg-schema"
 
-const schema = { artifact, version, comment, webhook, webhookDelivery, membership, artifactMember }
+const schema = {
+  artifact,
+  version,
+  comment,
+  webhook,
+  webhookDelivery,
+  membership,
+  artifactMember,
+  artifactFavorite,
+  artifactTag,
+}
 const VIEW_WINDOW_MS = 30 * 86400_000
 
 /**
@@ -305,6 +317,51 @@ export class PgMetaStore implements MetaStore {
     await this.db
       .delete(artifactMember)
       .where(and(eq(artifactMember.artifact_id, artifactId), eq(artifactMember.user_id, userId)))
+  }
+
+  // ---- Favorites + tags --------------------------------------------------
+  async listUserFavoriteIds(userId: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ id: artifactFavorite.artifact_id })
+      .from(artifactFavorite)
+      .where(eq(artifactFavorite.user_id, userId))
+    return rows.map((r) => r.id)
+  }
+  async setFavorite(artifactId: string, userId: string): Promise<void> {
+    await this.db
+      .insert(artifactFavorite)
+      .values({ id: crypto.randomUUID(), artifact_id: artifactId, user_id: userId })
+      .onConflictDoNothing({ target: [artifactFavorite.artifact_id, artifactFavorite.user_id] })
+  }
+  async removeFavorite(artifactId: string, userId: string): Promise<void> {
+    await this.db
+      .delete(artifactFavorite)
+      .where(
+        and(eq(artifactFavorite.artifact_id, artifactId), eq(artifactFavorite.user_id, userId)),
+      )
+  }
+  async tagsForArtifacts(artifactIds: string[]): Promise<Record<string, string[]>> {
+    if (artifactIds.length === 0) return {}
+    const rows = await this.db
+      .select({ artifact_id: artifactTag.artifact_id, tag: artifactTag.tag })
+      .from(artifactTag)
+      .where(inArray(artifactTag.artifact_id, artifactIds))
+    const out: Record<string, string[]> = {}
+    for (const r of rows) {
+      if (!out[r.artifact_id]) out[r.artifact_id] = []
+      out[r.artifact_id].push(r.tag)
+    }
+    for (const k in out) out[k].sort()
+    return out
+  }
+  async setArtifactTags(artifactId: string, tags: string[]): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      await tx.delete(artifactTag).where(eq(artifactTag.artifact_id, artifactId))
+      if (tags.length)
+        await tx
+          .insert(artifactTag)
+          .values(tags.map((tag) => ({ id: crypto.randomUUID(), artifact_id: artifactId, tag })))
+    })
   }
 
   // ---- User directory (Better Auth's "user" table; raw, may be absent) ---

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -120,6 +120,34 @@ export const artifactMember = sqliteTable(
   (t) => [uniqueIndex("artifact_member_user").on(t.artifact_id, t.user_id)],
 )
 
+// Per-user stars. One row per (artifact, user); favorites are personal, never shared.
+export const artifactFavorite = sqliteTable(
+  "artifact_favorite",
+  {
+    id: text("id").primaryKey(),
+    artifact_id: text("artifact_id")
+      .notNull()
+      .references(() => artifact.id),
+    user_id: text("user_id").notNull(),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [uniqueIndex("artifact_favorite_user").on(t.artifact_id, t.user_id)],
+)
+
+// Browse tags. One row per (artifact, tag); workspace-wide, not per-user.
+export const artifactTag = sqliteTable(
+  "artifact_tag",
+  {
+    id: text("id").primaryKey(),
+    artifact_id: text("artifact_id")
+      .notNull()
+      .references(() => artifact.id),
+    tag: text("tag").notNull(),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [uniqueIndex("artifact_tag_uniq").on(t.artifact_id, t.tag)],
+)
+
 // user/session/account/verification tables are owned and migrated by Better Auth
 // (see apps/api/src/auth-config.ts) — not declared here.
 
@@ -230,6 +258,22 @@ export const SCHEMA_STATEMENTS: string[] = [
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
     UNIQUE (artifact_id, user_id)
   )`,
+  `CREATE TABLE IF NOT EXISTS artifact_favorite (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    user_id TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (artifact_id, user_id)
+  )`,
+  `CREATE INDEX IF NOT EXISTS favorite_user ON artifact_favorite (user_id)`,
+  `CREATE TABLE IF NOT EXISTS artifact_tag (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    tag TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (artifact_id, tag)
+  )`,
+  `CREATE INDEX IF NOT EXISTS tag_name ON artifact_tag (tag)`,
   // user/session/account/verification are owned and migrated by Better Auth.
 ]
 

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -21,11 +21,13 @@ import type {
   WebhookRecord,
 } from "@dock/core"
 import Database from "better-sqlite3"
-import { and, asc, count, desc, eq, isNull, lte, or } from "drizzle-orm"
+import { and, asc, count, desc, eq, inArray, isNull, lte, or } from "drizzle-orm"
 import { type BetterSQLite3Database, drizzle } from "drizzle-orm/better-sqlite3"
 import {
   artifact,
+  artifactFavorite,
   artifactMember,
+  artifactTag,
   comment,
   MIGRATION_STATEMENTS,
   membership,
@@ -37,7 +39,17 @@ import {
 
 const VIEW_WINDOW_MS = 30 * 86400_000
 
-const schema = { artifact, version, comment, webhook, webhookDelivery, membership, artifactMember }
+const schema = {
+  artifact,
+  version,
+  comment,
+  webhook,
+  webhookDelivery,
+  membership,
+  artifactMember,
+  artifactFavorite,
+  artifactTag,
+}
 
 /** Embedded SQLite (WAL). The zero-dependency default; no external services. */
 export class SqliteMetaStore implements MetaStore {
@@ -328,6 +340,57 @@ export class SqliteMetaStore implements MetaStore {
       .delete(artifactMember)
       .where(and(eq(artifactMember.artifact_id, artifactId), eq(artifactMember.user_id, userId)))
       .run()
+  }
+
+  // ---- Favorites + tags --------------------------------------------------
+  async listUserFavoriteIds(userId: string): Promise<string[]> {
+    return this.db
+      .select({ id: artifactFavorite.artifact_id })
+      .from(artifactFavorite)
+      .where(eq(artifactFavorite.user_id, userId))
+      .all()
+      .map((r) => r.id)
+  }
+  async setFavorite(artifactId: string, userId: string): Promise<void> {
+    this.db
+      .insert(artifactFavorite)
+      .values({ id: crypto.randomUUID(), artifact_id: artifactId, user_id: userId })
+      .onConflictDoNothing({ target: [artifactFavorite.artifact_id, artifactFavorite.user_id] })
+      .run()
+  }
+  async removeFavorite(artifactId: string, userId: string): Promise<void> {
+    this.db
+      .delete(artifactFavorite)
+      .where(
+        and(eq(artifactFavorite.artifact_id, artifactId), eq(artifactFavorite.user_id, userId)),
+      )
+      .run()
+  }
+  async tagsForArtifacts(artifactIds: string[]): Promise<Record<string, string[]>> {
+    if (artifactIds.length === 0) return {}
+    const rows = this.db
+      .select({ artifact_id: artifactTag.artifact_id, tag: artifactTag.tag })
+      .from(artifactTag)
+      .where(inArray(artifactTag.artifact_id, artifactIds))
+      .all()
+    const out: Record<string, string[]> = {}
+    for (const r of rows) {
+      if (!out[r.artifact_id]) out[r.artifact_id] = []
+      out[r.artifact_id].push(r.tag)
+    }
+    for (const k in out) out[k].sort()
+    return out
+  }
+  async setArtifactTags(artifactId: string, tags: string[]): Promise<void> {
+    this.raw.transaction(() => {
+      this.db.delete(artifactTag).where(eq(artifactTag.artifact_id, artifactId)).run()
+      for (const tag of tags) {
+        this.db
+          .insert(artifactTag)
+          .values({ id: crypto.randomUUID(), artifact_id: artifactId, tag })
+          .run()
+      }
+    })()
   }
 
   // ---- User directory (Better Auth's `user` table; raw, may be absent) ---


### PR DESCRIPTION
A real home for "your stuff": a collapsible main-menu **sidebar** plus **favorites**, **tags**, and **search** to browse the library — mobile-friendly throughout.

## Sidebar (the main menu)
- **All artifacts** / **★ Favorites** with live counts, then a **Tags** section (each tag with a count).
- **Collapsible to an icon rail** on desktop (persisted in localStorage); an **off-canvas drawer** on phones behind a header hamburger (dimmed backdrop, tap-to-close).

## Browse
- **Search** by title or tag (instant, client-side over the loaded list).
- Cards gain a **★ star toggle** and **clickable tag chips** (tap a chip → filter).
- The **artifact header** gains a star + a **tags popover** (editors add/remove; the server normalizes — trim, lowercase, dedupe, cap, sort).

## Data layer (sqlite · postgres · d1)
Two junction tables — `artifact_favorite` (per-user stars) and `artifact_tag` (workspace tags) — mirroring the existing `artifact_member`, so **no `ArtifactRecord`/`Exact<>` changes**. List + detail JSON now carry `tags` + `favorite` (favorites fetched once per user, tags **batched across the page** — no N+1).

## Scope note
Tags are the browse primitive here (folders/collections can layer on later). Server-side full-text search stays the roadmap's **C3**; this PR is the sidebar + filter layer.

## Verified
Desktop (sidebar, rail collapse, stars, tag chips) and **mobile** (hamburger → drawer, full-width grid, artifact star + tags popover) — screenshots attached. `biome ci` ✓ · `pnpm typecheck` ✓ · `pnpm test` ✓ (api **61** incl. favorites per-user, tag normalize/replace, batch no-N+1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)