### PR TITLE
Reviews: proposed versions + approve flow

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,6 +4,7 @@ import {
   type Actor,
   ANCHOR_CLIENT_JS,
   type ArtifactRecord,
+  approveProposal,
   artifactUrl,
   type BlobStore,
   BUNDLE_CONTENT_TYPE,
@@ -20,7 +21,9 @@ import {
   type MetaStore,
   mimeFor,
   newId,
+  type ProposalRecord,
   PublishError,
+  propose,
   publish,
   type Role,
   renderMarkdown,
@@ -28,7 +31,6 @@ import {
   roleAllows,
   SELECTION_SCRIPT,
   toJson,
-  type VersionRecord,
   type Visibility,
 } from "@dock/core"
 import { type Context, Hono, type Next } from "hono"
@@ -410,15 +412,17 @@ export function createApp(deps: AppDeps): Hono {
     const me = actor.kind === "user" ? actor.userId : null
     const tags = (await meta.tagsForArtifacts([artifact.id]))[artifact.id] ?? []
     const favorite = me ? (await meta.listUserFavoriteIds(me)).includes(artifact.id) : false
+    const openProposals = await meta.listProposals(artifact.id, { state: "open" })
     // `versions` stays at revision granularity (machines/agents); `sessions` is
     // the time-grouped view the UI shows by default. `my_role` tells the client
-    // which actions to surface.
+    // which actions to surface; `open_proposals` badges the review queue.
     return c.json({
       ...toJson(deps.baseUrl, artifact, versions),
       sessions: groupSessions(versions, versionWindowMs),
       my_role: effectiveRole(actor, artifact.visibility),
       tags,
       favorite,
+      open_proposals: openProposals.length,
     })
   })
 
@@ -553,16 +557,22 @@ export function createApp(deps: AppDeps): Hono {
     )
   })
 
-  /** Source text of a version (entry document for bundles); null if missing. */
-  const sourceText = async (version: VersionRecord): Promise<string | null> => {
+  /**
+   * Source text of stored content (entry document for bundles); null if missing.
+   * Works for a version or a proposal — both carry blob_key + content_type.
+   */
+  const sourceText = async (content: {
+    blob_key: string
+    content_type: string
+  }): Promise<string | null> => {
     let data: Uint8Array | null
-    if (version.content_type === BUNDLE_CONTENT_TYPE) {
-      const manifestBytes = await blobs.get(version.blob_key)
+    if (content.content_type === BUNDLE_CONTENT_TYPE) {
+      const manifestBytes = await blobs.get(content.blob_key)
       if (!manifestBytes) return null
       const manifest = JSON.parse(new TextDecoder().decode(manifestBytes)) as BundleManifest
       data = await blobs.get(manifest.files[manifest.entry].key)
     } else {
-      data = await blobs.get(version.blob_key)
+      data = await blobs.get(content.blob_key)
     }
     return data ? new TextDecoder().decode(data) : null
   }
@@ -613,6 +623,183 @@ export function createApp(deps: AppDeps): Hono {
     if (c.req.query("format") === "json") return c.json({ from, to, ops })
     c.header("Content-Type", "text/plain; charset=utf-8")
     return c.body(formatDiff(ops))
+  })
+
+  // ---- Reviews: proposed versions ---------------------------------------
+
+  const proposalJson = (a: ArtifactRecord, p: ProposalRecord) => ({
+    id: p.id,
+    state: p.state,
+    author: p.author,
+    message: p.message,
+    base_version: p.base_version,
+    kind: p.kind,
+    decided_by: p.decided_by,
+    decided_version: p.decided_version,
+    decided_at: p.decided_at,
+    created_at: p.created_at,
+    // The proposed experience, rendered exactly like a live version.
+    preview_url: `${deps.baseUrl}/raw/${a.short_id}/p/${p.id}/index.html`,
+  })
+
+  // Load an artifact + one of its proposals, read-gated. Returns an error
+  // Response to short-circuit, or the pair to proceed.
+  const loadProposal = async (c: Context) => {
+    const artifact = await meta.getByShortId(c.req.param("shortId") ?? "")
+    if (!artifact || !(await authorize(c, "read", artifact)))
+      return { error: c.json({ error: "not found" }, 404) as Response }
+    const proposal = await meta.getProposal(c.req.param("proposalId") ?? "")
+    if (!proposal || proposal.artifact_id !== artifact.id)
+      return { error: c.json({ error: "not found" }, 404) as Response }
+    return { artifact, proposal }
+  }
+
+  // Propose a candidate version (commenter+). It does NOT go live; an editor
+  // approves it. Same multipart shape as publish.
+  app.post("/v1/artifacts/:shortId/proposals", async (c) => {
+    const artifact = await meta.getByShortId(c.req.param("shortId"))
+    if (!artifact || artifact.current_version === 0) return c.json({ error: "not found" }, 404)
+    if (!(await authorize(c, "propose", artifact))) return c.json({ error: "forbidden" }, 403)
+    const len = Number(c.req.header("content-length") ?? 0)
+    if (len > MAX_UPLOAD_BYTES) return c.json({ error: "upload too large" }, 413)
+
+    const body = await c.req.parseBody()
+    const file = body.file
+    if (!(file instanceof File)) return c.json({ error: "multipart field 'file' required" }, 400)
+    const bytes = new Uint8Array(await file.arrayBuffer())
+    const isBundle =
+      /\.zip$/i.test(file.name) ||
+      body.kind === "bundle" ||
+      (bytes[0] === 0x50 && bytes[1] === 0x4b && (bytes[2] === 3 || bytes[2] === 5))
+
+    const me = await currentUser(c)
+    const author = me ? (me.name ?? me.email) : str(body.author) || "anonymous"
+    try {
+      const { proposal } = await propose(meta, blobs, artifact.short_id, {
+        bytes,
+        filename: file.name,
+        isBundle,
+        spa: body.spa === "true" || body.spa === "1",
+        message: str(body.message),
+        author,
+      })
+      bus.publish(artifact.id, { type: "proposal.created", proposal_id: proposal.id })
+      await notify(artifact, "proposal.created", {
+        proposal_id: proposal.id,
+        author: proposal.author,
+        message: proposal.message,
+        base_version: proposal.base_version,
+      })
+      return c.json(proposalJson(artifact, proposal), 201)
+    } catch (err) {
+      if (err instanceof PublishError) return c.json({ error: err.message }, err.statusCode as 400)
+      throw err
+    }
+  })
+
+  // List proposals (read-gated). ?state=open filters to the review queue.
+  app.get("/v1/artifacts/:shortId/proposals", async (c) => {
+    const artifact = await meta.getByShortId(c.req.param("shortId"))
+    if (!artifact || !(await authorize(c, "read", artifact)))
+      return c.json({ error: "not found" }, 404)
+    const stateQ = c.req.query("state")
+    const state =
+      stateQ === "open" ||
+      stateQ === "approved" ||
+      stateQ === "changes_requested" ||
+      stateQ === "withdrawn"
+        ? stateQ
+        : undefined
+    const proposals = await meta.listProposals(artifact.id, state ? { state } : undefined)
+    return c.json({ proposals: proposals.map((p) => proposalJson(artifact, p)) })
+  })
+
+  // One proposal, with a line diff of its content against its base version.
+  app.get("/v1/artifacts/:shortId/proposals/:proposalId", async (c) => {
+    const r = await loadProposal(c)
+    if ("error" in r) return r.error
+    const { artifact, proposal } = r
+    const base = await meta.getVersion(artifact.id, proposal.base_version)
+    const [a, b] = [base ? await sourceText(base) : "", await sourceText(proposal)]
+    const ops = a !== null && b !== null ? diffLines(a, b) : []
+    return c.json({
+      ...proposalJson(artifact, proposal),
+      diff: { base_version: proposal.base_version, ops },
+    })
+  })
+
+  // Approve: the proposed content becomes the new current version (goes live).
+  app.post("/v1/artifacts/:shortId/proposals/:proposalId/approve", async (c) => {
+    const r = await loadProposal(c)
+    if ("error" in r) return r.error
+    const { artifact, proposal } = r
+    if (!(await authorize(c, "approve", artifact))) return c.json({ error: "forbidden" }, 403)
+    if (proposal.state !== "open") return c.json({ error: `proposal is ${proposal.state}` }, 409)
+    const me = await currentUser(c)
+    const approver = me ? (me.name ?? me.email) : null
+    try {
+      const version = await approveProposal(meta, proposal, approver)
+      bus.publish(artifact.id, {
+        type: "proposal.approved",
+        proposal_id: proposal.id,
+        n: version.n,
+      })
+      bus.publish(artifact.id, {
+        type: "version.published",
+        n: version.n,
+        message: version.message,
+      })
+      await notify(artifact, "proposal.approved", {
+        proposal_id: proposal.id,
+        version: version.n,
+        approver,
+      })
+      const fresh = (await meta.getProposal(proposal.id)) as ProposalRecord
+      return c.json({ ...proposalJson(artifact, fresh), published: version.n })
+    } catch (err) {
+      if (err instanceof PublishError) return c.json({ error: err.message }, err.statusCode as 400)
+      throw err
+    }
+  })
+
+  // Request changes: the candidate stays a proposal; the proposer can revise.
+  app.post("/v1/artifacts/:shortId/proposals/:proposalId/request-changes", async (c) => {
+    const r = await loadProposal(c)
+    if ("error" in r) return r.error
+    const { artifact, proposal } = r
+    if (!(await authorize(c, "approve", artifact))) return c.json({ error: "forbidden" }, 403)
+    if (proposal.state !== "open") return c.json({ error: `proposal is ${proposal.state}` }, 409)
+    const me = await currentUser(c)
+    const reviewer = me ? (me.name ?? me.email) : null
+    await meta.decideProposal(proposal.id, {
+      state: "changes_requested",
+      decided_by: reviewer,
+      decided_version: null,
+    })
+    bus.publish(artifact.id, { type: "proposal.changes_requested", proposal_id: proposal.id })
+    await notify(artifact, "proposal.changes_requested", { proposal_id: proposal.id, reviewer })
+    const fresh = (await meta.getProposal(proposal.id)) as ProposalRecord
+    return c.json(proposalJson(artifact, fresh))
+  })
+
+  // Withdraw: the proposer (or a manager) retracts an open proposal.
+  app.post("/v1/artifacts/:shortId/proposals/:proposalId/withdraw", async (c) => {
+    const r = await loadProposal(c)
+    if ("error" in r) return r.error
+    const { artifact, proposal } = r
+    const me = await currentUser(c)
+    const who = me ? (me.name ?? me.email) : null
+    const isAuthor = who !== null && who === proposal.author
+    if (!isAuthor && !(await authorize(c, "manage", artifact)))
+      return c.json({ error: "forbidden" }, 403)
+    if (proposal.state !== "open") return c.json({ error: `proposal is ${proposal.state}` }, 409)
+    await meta.decideProposal(proposal.id, {
+      state: "withdrawn",
+      decided_by: who,
+      decided_version: null,
+    })
+    const fresh = (await meta.getProposal(proposal.id)) as ProposalRecord
+    return c.json(proposalJson(artifact, fresh))
   })
 
   // ---- Comments ----------------------------------------------------------
@@ -972,20 +1159,19 @@ export function createApp(deps: AppDeps): Hono {
     }),
   )
 
-  app.get("/raw/:shortId/v/:n/*", async (c) => {
-    const shortId = c.req.param("shortId")
-    const n = Number(c.req.param("n"))
-    const artifact = await meta.getByShortId(shortId)
-    if (!artifact || !Number.isInteger(n) || !(await authorize(c, "read", artifact)))
-      return c.text("not found", 404)
-    const version = await meta.getVersion(artifact.id, n)
-    if (!version) return c.text("not found", 404)
-
-    const prefix = `/raw/${shortId}/v/${c.req.param("n")}/`
-    let path = decodeURIComponent(c.req.path.slice(prefix.length))
-
-    if (version.content_type === BUNDLE_CONTENT_TYPE) {
-      const manifestBytes = await blobs.get(version.blob_key)
+  // Serve stored content (a version or a proposal) under `prefix`, resolving a
+  // sub-`path` for bundles. Identical pipeline for both, so a proposal renders
+  // exactly how it will once approved — reviewers approve the experience.
+  const serveContent = async (
+    c: Context,
+    content: { blob_key: string; content_type: string },
+    title: string | null,
+    prefix: string,
+    rawPath: string,
+  ) => {
+    let path = rawPath
+    if (content.content_type === BUNDLE_CONTENT_TYPE) {
+      const manifestBytes = await blobs.get(content.blob_key)
       if (!manifestBytes) return c.text("blob missing", 500)
       const manifest = JSON.parse(new TextDecoder().decode(manifestBytes)) as BundleManifest
 
@@ -1009,16 +1195,16 @@ export function createApp(deps: AppDeps): Hono {
       return c.body(toBody(data), 200, { ...RAW_HEADERS, "Content-Type": entry.type })
     }
 
-    const data = await blobs.get(version.blob_key)
+    const data = await blobs.get(content.blob_key)
     if (!data) return c.text("blob missing", 500)
 
-    if (version.content_type === "text/markdown") {
+    if (content.content_type === "text/markdown") {
       if (path === "raw.md")
         return c.body(toBody(data), 200, {
           ...RAW_HEADERS,
           "Content-Type": "text/markdown; charset=utf-8",
         })
-      const html = await renderMarkdown(new TextDecoder().decode(data), artifact.title)
+      const html = await renderMarkdown(new TextDecoder().decode(data), title)
       return c.body(html, 200, { ...RAW_HEADERS, "Content-Type": "text/html; charset=utf-8" })
     }
 
@@ -1029,6 +1215,34 @@ export function createApp(deps: AppDeps): Hono {
       return c.body(html, 200, { ...RAW_HEADERS, "Content-Type": ct })
     }
     return c.body(toBody(data), 200, { ...RAW_HEADERS, "Content-Type": ct })
+  }
+
+  app.get("/raw/:shortId/v/:n/*", async (c) => {
+    const shortId = c.req.param("shortId")
+    const n = Number(c.req.param("n"))
+    const artifact = await meta.getByShortId(shortId)
+    if (!artifact || !Number.isInteger(n) || !(await authorize(c, "read", artifact)))
+      return c.text("not found", 404)
+    const version = await meta.getVersion(artifact.id, n)
+    if (!version) return c.text("not found", 404)
+
+    const prefix = `/raw/${shortId}/v/${c.req.param("n")}/`
+    const path = decodeURIComponent(c.req.path.slice(prefix.length))
+    return serveContent(c, version, artifact.title, prefix, path)
+  })
+
+  // Render a proposed version exactly like a live one, so review is of the
+  // experience, not a source dump. Read-gated; the proposal must belong here.
+  app.get("/raw/:shortId/p/:proposalId/*", async (c) => {
+    const shortId = c.req.param("shortId")
+    const artifact = await meta.getByShortId(shortId)
+    if (!artifact || !(await authorize(c, "read", artifact))) return c.text("not found", 404)
+    const proposal = await meta.getProposal(c.req.param("proposalId"))
+    if (!proposal || proposal.artifact_id !== artifact.id) return c.text("not found", 404)
+
+    const prefix = `/raw/${shortId}/p/${proposal.id}/`
+    const path = decodeURIComponent(c.req.path.slice(prefix.length))
+    return serveContent(c, proposal, artifact.title, prefix, path)
   })
 
   return app

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -412,17 +412,20 @@ export function createApp(deps: AppDeps): Hono {
     const me = actor.kind === "user" ? actor.userId : null
     const tags = (await meta.tagsForArtifacts([artifact.id]))[artifact.id] ?? []
     const favorite = me ? (await meta.listUserFavoriteIds(me)).includes(artifact.id) : false
-    const openProposals = await meta.listProposals(artifact.id, { state: "open" })
+    const proposals = await meta.listProposals(artifact.id)
     // `versions` stays at revision granularity (machines/agents); `sessions` is
     // the time-grouped view the UI shows by default. `my_role` tells the client
-    // which actions to surface; `open_proposals` badges the review queue.
+    // which actions to surface; `open_proposals` badges the review queue while
+    // `proposals_total` (everything but withdrawn) gates the Proposals entry so a
+    // proposer can return to read feedback after their candidate leaves the queue.
     return c.json({
       ...toJson(deps.baseUrl, artifact, versions),
       sessions: groupSessions(versions, versionWindowMs),
       my_role: effectiveRole(actor, artifact.visibility),
       tags,
       favorite,
-      open_proposals: openProposals.length,
+      open_proposals: proposals.filter((p) => p.state === "open").length,
+      proposals_total: proposals.filter((p) => p.state !== "withdrawn").length,
     })
   })
 
@@ -636,6 +639,7 @@ export function createApp(deps: AppDeps): Hono {
     kind: p.kind,
     decided_by: p.decided_by,
     decided_version: p.decided_version,
+    decision_note: p.decision_note,
     decided_at: p.decided_at,
     created_at: p.created_at,
     // The proposed experience, rendered exactly like a live version.
@@ -737,8 +741,9 @@ export function createApp(deps: AppDeps): Hono {
     if (proposal.state !== "open") return c.json({ error: `proposal is ${proposal.state}` }, 409)
     const me = await currentUser(c)
     const approver = me ? (me.name ?? me.email) : null
+    const body = (await c.req.json().catch(() => ({}))) as { note?: unknown }
     try {
-      const version = await approveProposal(meta, proposal, approver)
+      const version = await approveProposal(meta, proposal, approver, str(body.note) ?? null)
       bus.publish(artifact.id, {
         type: "proposal.approved",
         proposal_id: proposal.id,
@@ -771,10 +776,12 @@ export function createApp(deps: AppDeps): Hono {
     if (proposal.state !== "open") return c.json({ error: `proposal is ${proposal.state}` }, 409)
     const me = await currentUser(c)
     const reviewer = me ? (me.name ?? me.email) : null
+    const body = (await c.req.json().catch(() => ({}))) as { note?: unknown }
     await meta.decideProposal(proposal.id, {
       state: "changes_requested",
       decided_by: reviewer,
       decided_version: null,
+      decision_note: str(body.note) ?? null,
     })
     bus.publish(artifact.id, { type: "proposal.changes_requested", proposal_id: proposal.id })
     await notify(artifact, "proposal.changes_requested", { proposal_id: proposal.id, reviewer })

--- a/apps/api/src/bus.ts
+++ b/apps/api/src/bus.ts
@@ -5,6 +5,9 @@ export interface DockEvent {
     | "comment.reacted"
     | "comment.updated"
     | "version.published"
+    | "proposal.created"
+    | "proposal.approved"
+    | "proposal.changes_requested"
     | "presence"
   [k: string]: unknown
 }

--- a/apps/api/src/webhooks.ts
+++ b/apps/api/src/webhooks.ts
@@ -2,7 +2,14 @@ import { createHmac, randomUUID } from "node:crypto"
 import type { ArtifactRecord, DeliveryRecord, MetaStore } from "@dock/core"
 
 /** Event names webhooks can subscribe to. */
-export const WEBHOOK_EVENTS = ["comment.created", "comment.resolved", "version.published"] as const
+export const WEBHOOK_EVENTS = [
+  "comment.created",
+  "comment.resolved",
+  "version.published",
+  "proposal.created",
+  "proposal.approved",
+  "proposal.changes_requested",
+] as const
 export type WebhookEvent = (typeof WEBHOOK_EVENTS)[number]
 
 const MAX_ATTEMPTS = 6

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -798,20 +798,26 @@ describe("reviews: request changes and withdraw keep content live-unchanged", ()
   const { app } = makeAuthedApp("reviews-rc", [owner, dana], "commenter")
   let shortId: string
 
-  it("request-changes leaves the proposal pending and the artifact at its current version", async () => {
+  it("request-changes carries the reviewer's note back to the proposer, content unchanged", async () => {
     shortId = (await (await publishAs(app, "<h1>base</h1>", {}, as(owner.email))).json()).short_id
     const pid = (await (await proposeAs(app, shortId, "<h1>try</h1>", as(dana.email))).json()).id
     const res = await app.request(`/v1/artifacts/${shortId}/proposals/${pid}/request-changes`, {
       method: "POST",
-      headers: as(owner.email),
+      headers: { "content-type": "application/json", ...as(owner.email) },
+      body: JSON.stringify({ note: "Tighten the intro paragraph first" }),
     })
     expect(res.status).toBe(200)
-    expect((await res.json()).state).toBe("changes_requested")
+    const decided = await res.json()
+    expect(decided.state).toBe("changes_requested")
+    expect(decided.decision_note).toBe("Tighten the intro paragraph first")
     const art = await (
       await app.request(`/v1/artifacts/${shortId}`, { headers: as(owner.email) })
     ).json()
     expect(art.current_version).toBe(1)
     expect(art.open_proposals).toBe(0)
+    // The decided proposal still counts toward the Proposals entry (not withdrawn),
+    // so the proposer can return to read the feedback.
+    expect(art.proposals_total).toBe(1)
   })
 
   it("a proposer can withdraw their own open proposal", async () => {

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -705,6 +705,131 @@ describe("permissions: a per-artifact share overrides the workspace role", () =>
   })
 })
 
+const proposeAs = (
+  app: ReturnType<typeof createApp>,
+  shortId: string,
+  content: string,
+  headers: Record<string, string> = {},
+  fields: Record<string, string> = {},
+) => {
+  const form = new FormData()
+  form.append("file", new Blob([new TextEncoder().encode(content)]), "f.html")
+  for (const [k, v] of Object.entries(fields)) form.append(k, v)
+  return app.request(`/v1/artifacts/${shortId}/proposals`, { method: "POST", body: form, headers })
+}
+
+describe("reviews: propose → approve goes live; commenter can't approve", () => {
+  const owner: TestUser = { id: "u_ro", email: "ro@dock.test", name: "Ro" }
+  const cassie: TestUser = { id: "u_cassie", email: "cassie@dock.test", name: "Cassie" }
+  const { app } = makeAuthedApp("reviews", [owner, cassie], "commenter")
+  let shortId: string
+  let proposalId: string
+
+  it("owner publishes v1; a commenter proposes a candidate that does NOT go live", async () => {
+    shortId = (await (await publishAs(app, "<h1>v1 live</h1>", {}, as(owner.email))).json())
+      .short_id
+    const res = await proposeAs(app, shortId, "<h1>candidate</h1>", as(cassie.email), {
+      message: "tighten the headline",
+    })
+    expect(res.status).toBe(201)
+    const p = await res.json()
+    proposalId = p.id
+    expect(p.state).toBe("open")
+    expect(p.base_version).toBe(1)
+
+    // The artifact is untouched: still v1, but the review queue shows 1.
+    const art = await (
+      await app.request(`/v1/artifacts/${shortId}`, { headers: as(owner.email) })
+    ).json()
+    expect(art.current_version).toBe(1)
+    expect(art.open_proposals).toBe(1)
+  })
+
+  it("renders the proposed experience at its preview URL, distinct from current", async () => {
+    const proposed = await app.request(`/raw/${shortId}/p/${proposalId}/index.html`, {
+      headers: as(owner.email),
+    })
+    expect(proposed.status).toBe(200)
+    expect(await proposed.text()).toContain("<h1>candidate</h1>")
+    // The live content is still v1.
+    const live = await app.request(`/v1/artifacts/${shortId}/content`, { headers: as(owner.email) })
+    expect(await live.text()).toContain("v1 live")
+  })
+
+  it("a commenter cannot approve their own proposal", async () => {
+    const res = await app.request(`/v1/artifacts/${shortId}/proposals/${proposalId}/approve`, {
+      method: "POST",
+      headers: as(cassie.email),
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it("an editor/owner approves: the proposed content becomes the new current version", async () => {
+    const res = await app.request(`/v1/artifacts/${shortId}/proposals/${proposalId}/approve`, {
+      method: "POST",
+      headers: as(owner.email),
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.state).toBe("approved")
+    expect(body.published).toBe(2)
+
+    const art = await (
+      await app.request(`/v1/artifacts/${shortId}`, { headers: as(owner.email) })
+    ).json()
+    expect(art.current_version).toBe(2)
+    expect(art.open_proposals).toBe(0)
+    const live = await app.request(`/v1/artifacts/${shortId}/content`, { headers: as(owner.email) })
+    expect(await live.text()).toContain("candidate")
+  })
+
+  it("approving an already-decided proposal is a conflict", async () => {
+    const res = await app.request(`/v1/artifacts/${shortId}/proposals/${proposalId}/approve`, {
+      method: "POST",
+      headers: as(owner.email),
+    })
+    expect(res.status).toBe(409)
+  })
+})
+
+describe("reviews: request changes and withdraw keep content live-unchanged", () => {
+  const owner: TestUser = { id: "u_rc", email: "rc@dock.test", name: "Rc" }
+  const dana: TestUser = { id: "u_dana", email: "dana@dock.test", name: "Dana" }
+  const { app } = makeAuthedApp("reviews-rc", [owner, dana], "commenter")
+  let shortId: string
+
+  it("request-changes leaves the proposal pending and the artifact at its current version", async () => {
+    shortId = (await (await publishAs(app, "<h1>base</h1>", {}, as(owner.email))).json()).short_id
+    const pid = (await (await proposeAs(app, shortId, "<h1>try</h1>", as(dana.email))).json()).id
+    const res = await app.request(`/v1/artifacts/${shortId}/proposals/${pid}/request-changes`, {
+      method: "POST",
+      headers: as(owner.email),
+    })
+    expect(res.status).toBe(200)
+    expect((await res.json()).state).toBe("changes_requested")
+    const art = await (
+      await app.request(`/v1/artifacts/${shortId}`, { headers: as(owner.email) })
+    ).json()
+    expect(art.current_version).toBe(1)
+    expect(art.open_proposals).toBe(0)
+  })
+
+  it("a proposer can withdraw their own open proposal", async () => {
+    const pid = (await (await proposeAs(app, shortId, "<h1>wip</h1>", as(dana.email))).json()).id
+    const res = await app.request(`/v1/artifacts/${shortId}/proposals/${pid}/withdraw`, {
+      method: "POST",
+      headers: as(dana.email),
+    })
+    expect(res.status).toBe(200)
+    expect((await res.json()).state).toBe("withdrawn")
+  })
+
+  it("an unauthenticated caller on a secured instance cannot propose", async () => {
+    const res = await proposeAs(app, shortId, "<h1>nope</h1>", {})
+    expect(res.status).toBe(403)
+  })
+})
+
 describe("anchored comments", () => {
   it("flags comments anchored vs orphaned against the current version", async () => {
     const sid = (await (await upload("a.md", "alpha beta gamma", { title: "A" })).json()).short_id

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -36,6 +36,25 @@ export interface Artifact {
   tags?: string[]
   /** Whether the current user has starred this artifact. */
   favorite?: boolean
+  /** Count of proposals awaiting review. */
+  open_proposals?: number
+}
+export type ProposalState = "open" | "approved" | "changes_requested" | "withdrawn"
+export interface Proposal {
+  id: string
+  state: ProposalState
+  author: string
+  message: string | null
+  base_version: number
+  kind: "file" | "bundle"
+  decided_by: string | null
+  decided_version: number | null
+  decided_at: string | null
+  created_at: string
+  /** The proposed experience, rendered exactly like a live version. */
+  preview_url: string
+  /** Present on the single-proposal fetch: line diff vs the base version. */
+  diff?: { base_version: number; ops: DiffOp[] }
 }
 export interface ArtifactMember {
   user_id: string
@@ -144,6 +163,28 @@ export const api = {
     f(`/v1/artifacts/${id}/diff?from=${from}&to=${to}&format=json`, opts()).then(j),
   restore: (id: string, version: number): Promise<Artifact> =>
     f(`/v1/artifacts/${id}/restore`, opts({ version })).then(j),
+
+  listProposals: (id: string, state?: ProposalState): Promise<{ proposals: Proposal[] }> =>
+    f(`/v1/artifacts/${id}/proposals${state ? `?state=${state}` : ""}`, opts()).then(j),
+  getProposal: (id: string, proposalId: string): Promise<Proposal> =>
+    f(`/v1/artifacts/${id}/proposals/${proposalId}`, opts()).then(j),
+  propose(id: string, text: string, filename: string, message: string): Promise<Proposal> {
+    const fd = new FormData()
+    fd.append("file", new File([text], filename))
+    if (message) fd.append("message", message)
+    return f(`/v1/artifacts/${id}/proposals`, {
+      method: "POST",
+      body: fd,
+      credentials: "include",
+      headers: { accept: "application/json" },
+    }).then(j)
+  },
+  approveProposal: (id: string, proposalId: string): Promise<Proposal & { published: number }> =>
+    f(`/v1/artifacts/${id}/proposals/${proposalId}/approve`, opts({})).then(j),
+  requestChanges: (id: string, proposalId: string): Promise<Proposal> =>
+    f(`/v1/artifacts/${id}/proposals/${proposalId}/request-changes`, opts({})).then(j),
+  withdrawProposal: (id: string, proposalId: string): Promise<Proposal> =>
+    f(`/v1/artifacts/${id}/proposals/${proposalId}/withdraw`, opts({})).then(j),
 
   listMembers: (id: string): Promise<{ default_role: Role; members: ArtifactMember[] }> =>
     f(`/v1/artifacts/${id}/members`, opts()).then(j),

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -38,6 +38,8 @@ export interface Artifact {
   favorite?: boolean
   /** Count of proposals awaiting review. */
   open_proposals?: number
+  /** Count of non-withdrawn proposals (open + decided) — gates the Proposals entry. */
+  proposals_total?: number
 }
 export type ProposalState = "open" | "approved" | "changes_requested" | "withdrawn"
 export interface Proposal {
@@ -49,6 +51,8 @@ export interface Proposal {
   kind: "file" | "bundle"
   decided_by: string | null
   decided_version: number | null
+  /** The reviewer's feedback when approving or requesting changes. */
+  decision_note: string | null
   decided_at: string | null
   created_at: string
   /** The proposed experience, rendered exactly like a live version. */
@@ -179,10 +183,14 @@ export const api = {
       headers: { accept: "application/json" },
     }).then(j)
   },
-  approveProposal: (id: string, proposalId: string): Promise<Proposal & { published: number }> =>
-    f(`/v1/artifacts/${id}/proposals/${proposalId}/approve`, opts({})).then(j),
-  requestChanges: (id: string, proposalId: string): Promise<Proposal> =>
-    f(`/v1/artifacts/${id}/proposals/${proposalId}/request-changes`, opts({})).then(j),
+  approveProposal: (
+    id: string,
+    proposalId: string,
+    note?: string,
+  ): Promise<Proposal & { published: number }> =>
+    f(`/v1/artifacts/${id}/proposals/${proposalId}/approve`, opts({ note })).then(j),
+  requestChanges: (id: string, proposalId: string, note?: string): Promise<Proposal> =>
+    f(`/v1/artifacts/${id}/proposals/${proposalId}/request-changes`, opts({ note })).then(j),
   withdrawProposal: (id: string, proposalId: string): Promise<Proposal> =>
     f(`/v1/artifacts/${id}/proposals/${proposalId}/withdraw`, opts({})).then(j),
 

--- a/apps/web/src/components/ReviewOverlay.tsx
+++ b/apps/web/src/components/ReviewOverlay.tsx
@@ -1,0 +1,312 @@
+import { useEffect, useState } from "react"
+import { API_BASE, api, type Proposal, type Role } from "../api"
+
+const ago = (iso: string): string => {
+  const s = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000)
+  if (s < 60) return "just now"
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`
+  return `${Math.floor(s / 86400)}d ago`
+}
+
+/**
+ * The review surface. A proposed version is rendered exactly like a live one so
+ * a reviewer approves the EXPERIENCE, not a source dump — toggle Proposed ↔
+ * Current, with the line diff demoted to a secondary tab for the code-y cases.
+ * Self-contained overlay so it composes onto the artifact page with one button.
+ */
+export function ReviewOverlay({
+  shortId,
+  currentVersion,
+  myRole,
+  meName,
+  onClose,
+  onApplied,
+}: {
+  shortId: string
+  currentVersion: number
+  myRole?: Role | null
+  meName?: string | null
+  onClose: () => void
+  onApplied: () => void
+}) {
+  const [proposals, setProposals] = useState<Proposal[]>([])
+  const [activeId, setActiveId] = useState<string | null>(null)
+  const [active, setActive] = useState<Proposal | null>(null)
+  const [view, setView] = useState<"proposed" | "current" | "diff">("proposed")
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  const canApprove = myRole === "editor" || myRole === "owner"
+
+  const load = () =>
+    api
+      .listProposals(shortId, "open")
+      .then((r) => {
+        setProposals(r.proposals)
+        setActiveId((cur) =>
+          cur && r.proposals.some((p) => p.id === cur) ? cur : (r.proposals[0]?.id ?? null),
+        )
+        if (r.proposals.length === 0) onClose()
+      })
+      .catch(() => {})
+
+  useEffect(() => {
+    load()
+  }, [shortId])
+  useEffect(() => {
+    if (activeId)
+      api
+        .getProposal(shortId, activeId)
+        .then(setActive)
+        .catch(() => setActive(null))
+    else setActive(null)
+  }, [shortId, activeId])
+
+  const act = async (fn: () => Promise<unknown>) => {
+    setBusy(true)
+    setErr(null)
+    try {
+      await fn()
+      onApplied()
+      await load()
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Action failed")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const adds = active?.diff?.ops.filter((o) => o.t === "add").length ?? 0
+  const dels = active?.diff?.ops.filter((o) => o.t === "del").length ?? 0
+  const isAuthor = !!meName && active?.author === meName
+  const src =
+    view === "current"
+      ? `${API_BASE}/raw/${shortId}/v/${currentVersion}/index.html`
+      : active
+        ? `${API_BASE}/raw/${shortId}/p/${active.id}/index.html`
+        : "about:blank"
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 80,
+        background: "var(--bg)",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {/* Top bar: what's proposed, by whom, and the close. */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          padding: "11px 16px",
+          borderBottom: "1px solid var(--line)",
+          background: "var(--card)",
+        }}
+      >
+        <span
+          className="mono"
+          style={{
+            fontSize: 10,
+            fontWeight: 700,
+            letterSpacing: ".04em",
+            textTransform: "uppercase",
+            color: "var(--ac)",
+            background: "var(--ac-soft)",
+            borderRadius: 999,
+            padding: "3px 9px",
+          }}
+        >
+          Review
+        </span>
+        {active && (
+          <div style={{ minWidth: 0 }}>
+            <div style={{ fontSize: 13.5, fontWeight: 600 }}>
+              {active.message ?? "Proposed change"}
+            </div>
+            <div className="muted" style={{ fontSize: 11.5 }}>
+              {active.author} · proposed {ago(active.created_at)} · against v{active.base_version}
+            </div>
+          </div>
+        )}
+        {proposals.length > 1 && (
+          <select
+            className="input"
+            value={activeId ?? ""}
+            onChange={(e) => setActiveId(e.target.value)}
+            style={{ width: 150, padding: "5px 8px", fontSize: 12, marginLeft: 8 }}
+          >
+            {proposals.map((p, i) => (
+              <option key={p.id} value={p.id}>
+                {p.message ? p.message.slice(0, 28) : `Proposal ${i + 1}`}
+              </option>
+            ))}
+          </select>
+        )}
+        <span style={{ flex: 1 }} />
+        {/* Proposed ↔ Current ↔ Diff */}
+        <div style={{ display: "flex", gap: 4 }}>
+          {(["proposed", "current", "diff"] as const).map((v) => (
+            <button
+              key={v}
+              type="button"
+              className={`chip${view === v ? " on" : ""}`}
+              onClick={() => setView(v)}
+              style={{ cursor: "pointer", textTransform: "capitalize" }}
+            >
+              {v}
+            </button>
+          ))}
+        </div>
+        <button className="btn sm" onClick={onClose} title="Close review">
+          Close
+        </button>
+      </div>
+
+      {/* Body: the experience (proposed or current), or the source diff. */}
+      <div style={{ flex: 1, minHeight: 0, position: "relative" }}>
+        {view === "diff" ? (
+          <div
+            style={{ position: "absolute", inset: 0, overflow: "auto", background: "var(--card)" }}
+          >
+            <div
+              style={{
+                display: "flex",
+                gap: 12,
+                padding: "8px 16px",
+                borderBottom: "1px solid var(--line-soft)",
+                fontSize: 12,
+                position: "sticky",
+                top: 0,
+                background: "var(--card)",
+              }}
+            >
+              <span className="mono muted" style={{ marginRight: "auto" }}>
+                v{active?.base_version} → proposed
+              </span>
+              <span className="mono" style={{ color: "var(--good)" }}>
+                +{adds}
+              </span>
+              <span className="mono" style={{ color: "var(--bad)" }}>
+                −{dels}
+              </span>
+            </div>
+            <pre
+              className="mono"
+              style={{ margin: 0, padding: "10px 0", fontSize: 12.5, lineHeight: 1.6 }}
+            >
+              {(active?.diff?.ops ?? []).map((o, i) => (
+                <div
+                  key={i}
+                  style={{
+                    padding: "0 16px",
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                    background:
+                      o.t === "add"
+                        ? "var(--good-bg)"
+                        : o.t === "del"
+                          ? "var(--cmt-bg)"
+                          : "transparent",
+                  }}
+                >
+                  <span className="muted" style={{ userSelect: "none" }}>
+                    {o.t === "add" ? "+ " : o.t === "del" ? "− " : "  "}
+                  </span>
+                  {o.line}
+                </div>
+              ))}
+            </pre>
+          </div>
+        ) : (
+          <iframe
+            title="review"
+            src={src}
+            sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
+            style={{
+              position: "absolute",
+              inset: 0,
+              width: "100%",
+              height: "100%",
+              border: 0,
+              background: "#fff",
+            }}
+          />
+        )}
+        {view === "proposed" && (
+          <div
+            style={{
+              position: "absolute",
+              top: 10,
+              left: "50%",
+              transform: "translateX(-50%)",
+              fontSize: 11,
+              fontWeight: 600,
+              color: "var(--ac)",
+              background: "var(--ac-soft)",
+              border: "1px solid var(--ac)",
+              borderRadius: 999,
+              padding: "3px 12px",
+              pointerEvents: "none",
+            }}
+          >
+            Previewing the proposed version
+          </div>
+        )}
+      </div>
+
+      {/* Decision bar. */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          padding: "10px 16px",
+          borderTop: "1px solid var(--line)",
+          background: "var(--card)",
+        }}
+      >
+        {err && <span style={{ color: "var(--bad)", fontSize: 12 }}>{err}</span>}
+        <span style={{ flex: 1 }} />
+        {isAuthor && active && (
+          <button
+            className="btn sm"
+            disabled={busy}
+            onClick={() => act(() => api.withdrawProposal(shortId, active.id))}
+          >
+            Withdraw
+          </button>
+        )}
+        {canApprove && active ? (
+          <>
+            <button
+              className="btn sm"
+              disabled={busy}
+              onClick={() => act(() => api.requestChanges(shortId, active.id))}
+            >
+              Request changes
+            </button>
+            <button
+              className="btn pri sm"
+              disabled={busy}
+              onClick={() => act(() => api.approveProposal(shortId, active.id))}
+            >
+              {busy ? "Approving…" : "Approve & publish"}
+            </button>
+          </>
+        ) : (
+          !isAuthor && (
+            <span className="muted" style={{ fontSize: 12 }}>
+              Only an editor can approve.
+            </span>
+          )
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/ReviewOverlay.tsx
+++ b/apps/web/src/components/ReviewOverlay.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { API_BASE, api, type Proposal, type Role } from "../api"
+import { API_BASE, api, type Proposal, type ProposalState, type Role } from "../api"
 
 const ago = (iso: string): string => {
   const s = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000)
@@ -9,11 +9,62 @@ const ago = (iso: string): string => {
   return `${Math.floor(s / 86400)}d ago`
 }
 
+/** True while the viewport is phone-width; the rail collapses to a dropdown. */
+function useNarrow(): boolean {
+  const [narrow, setNarrow] = useState(
+    typeof window !== "undefined" ? window.matchMedia("(max-width: 820px)").matches : false,
+  )
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 820px)")
+    const on = () => setNarrow(mq.matches)
+    mq.addEventListener("change", on)
+    return () => mq.removeEventListener("change", on)
+  }, [])
+  return narrow
+}
+
+const ellipsis: React.CSSProperties = {
+  whiteSpace: "nowrap",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+}
+
+const STATE_META: Record<ProposalState, { label: string; color: string; soft: string }> = {
+  open: { label: "Open", color: "var(--ac)", soft: "var(--ac-soft)" },
+  approved: { label: "Approved", color: "var(--good)", soft: "var(--good-bg)" },
+  changes_requested: { label: "Changes requested", color: "var(--bad)", soft: "var(--cmt-bg)" },
+  withdrawn: { label: "Withdrawn", color: "var(--fg-mut)", soft: "var(--bg)" },
+}
+
+function StateBadge({ state }: { state: ProposalState }) {
+  const m = STATE_META[state]
+  return (
+    <span
+      className="mono"
+      style={{
+        fontSize: 9.5,
+        fontWeight: 700,
+        letterSpacing: ".03em",
+        color: m.color,
+        background: m.soft,
+        border: `1px solid ${m.color}`,
+        borderRadius: 999,
+        padding: "1px 7px",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {m.label}
+    </span>
+  )
+}
+
 /**
  * The review surface. A proposed version is rendered exactly like a live one so
  * a reviewer approves the EXPERIENCE, not a source dump — toggle Proposed ↔
- * Current, with the line diff demoted to a secondary tab for the code-y cases.
- * Self-contained overlay so it composes onto the artifact page with one button.
+ * Current to compare, with the line diff demoted to a third tab for code-y
+ * cases. A queue rail lists every proposal with its state and the reviewer's
+ * note, so both proposer and reviewer always see status and feedback in one
+ * place. Self-contained overlay; composes onto the artifact page with one button.
  */
 export function ReviewOverlay({
   shortId,
@@ -30,30 +81,42 @@ export function ReviewOverlay({
   onClose: () => void
   onApplied: () => void
 }) {
+  const narrow = useNarrow()
   const [proposals, setProposals] = useState<Proposal[]>([])
   const [activeId, setActiveId] = useState<string | null>(null)
   const [active, setActive] = useState<Proposal | null>(null)
   const [view, setView] = useState<"proposed" | "current" | "diff">("proposed")
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
+  const [noteFor, setNoteFor] = useState<"changes" | "approve" | null>(null)
+  const [note, setNote] = useState("")
 
   const canApprove = myRole === "editor" || myRole === "owner"
 
   const load = () =>
     api
-      .listProposals(shortId, "open")
+      .listProposals(shortId)
       .then((r) => {
-        setProposals(r.proposals)
-        setActiveId((cur) =>
-          cur && r.proposals.some((p) => p.id === cur) ? cur : (r.proposals[0]?.id ?? null),
-        )
-        if (r.proposals.length === 0) onClose()
+        const live = r.proposals.filter((p) => p.state !== "withdrawn")
+        setProposals(live)
+        if (live.length === 0) {
+          onClose()
+          return
+        }
+        setActiveId((cur) => {
+          if (cur && live.some((p) => p.id === cur)) return cur
+          return (live.find((p) => p.state === "open") ?? live[0]).id
+        })
       })
       .catch(() => {})
 
   useEffect(() => {
     load()
   }, [shortId])
+  // Refetch the detail when the selection changes OR when the selected
+  // proposal's state flips in the list (e.g. just approved / changes-requested),
+  // so the decision note and state badge update without reselecting.
+  const activeState = proposals.find((p) => p.id === activeId)?.state
   useEffect(() => {
     if (activeId)
       api
@@ -61,13 +124,15 @@ export function ReviewOverlay({
         .then(setActive)
         .catch(() => setActive(null))
     else setActive(null)
-  }, [shortId, activeId])
+  }, [shortId, activeId, activeState])
 
   const act = async (fn: () => Promise<unknown>) => {
     setBusy(true)
     setErr(null)
     try {
       await fn()
+      setNoteFor(null)
+      setNote("")
       onApplied()
       await load()
     } catch (e) {
@@ -77,15 +142,75 @@ export function ReviewOverlay({
     }
   }
 
+  const open = proposals.filter((p) => p.state === "open")
+  const decided = proposals.filter((p) => p.state !== "open")
   const adds = active?.diff?.ops.filter((o) => o.t === "add").length ?? 0
   const dels = active?.diff?.ops.filter((o) => o.t === "del").length ?? 0
   const isAuthor = !!meName && active?.author === meName
+  const isOpen = active?.state === "open"
+  // Stale base: proposed against an older version than what's now live. Approving
+  // replaces the newer live version wholesale, so we warn and confirm — no merge.
+  const stale = !!active && isOpen && active.base_version !== currentVersion
   const src =
     view === "current"
       ? `${API_BASE}/raw/${shortId}/v/${currentVersion}/index.html`
       : active
         ? `${API_BASE}/raw/${shortId}/p/${active.id}/index.html`
         : "about:blank"
+
+  const strip =
+    view === "proposed"
+      ? { text: "Viewing the proposed version — not live yet", accent: true }
+      : view === "current"
+        ? { text: `Viewing the current live version (v${currentVersion})`, accent: false }
+        : { text: `Source diff · v${active?.base_version ?? "?"} → proposed`, accent: false }
+
+  const Toggle = (
+    <div style={{ display: "flex", gap: 4, flex: "0 0 auto" }}>
+      {(["proposed", "current", "diff"] as const).map((v) => (
+        <button
+          key={v}
+          type="button"
+          className={`chip${view === v ? " on" : ""}`}
+          onClick={() => setView(v)}
+          style={{ cursor: "pointer", textTransform: "capitalize", padding: "4px 11px" }}
+        >
+          {v}
+        </button>
+      ))}
+    </div>
+  )
+
+  const RailItem = ({ p }: { p: Proposal }) => (
+    <button
+      type="button"
+      onClick={() => setActiveId(p.id)}
+      style={{
+        display: "block",
+        width: "100%",
+        textAlign: "left",
+        border: 0,
+        borderLeft: `3px solid ${p.id === activeId ? "var(--ac)" : "transparent"}`,
+        background: p.id === activeId ? "var(--ac-soft)" : "transparent",
+        padding: "9px 12px",
+        cursor: "pointer",
+        font: "inherit",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 3 }}>
+        <StateBadge state={p.state} />
+        <span className="muted" style={{ fontSize: 10.5, marginLeft: "auto" }}>
+          {ago(p.created_at)}
+        </span>
+      </div>
+      <div style={{ fontSize: 12.5, fontWeight: 600, ...ellipsis }}>
+        {p.message ?? "Proposed change"}
+      </div>
+      <div className="muted" style={{ fontSize: 11, ...ellipsis }}>
+        {p.author}
+      </div>
+    </button>
+  )
 
   return (
     <div
@@ -98,214 +223,385 @@ export function ReviewOverlay({
         flexDirection: "column",
       }}
     >
-      {/* Top bar: what's proposed, by whom, and the close. */}
+      {/* Top bar: selected proposal identity + view controls. */}
       <div
         style={{
           display: "flex",
           alignItems: "center",
-          gap: 12,
-          padding: "11px 16px",
+          gap: 14,
+          padding: narrow ? "9px 12px" : "10px 18px",
           borderBottom: "1px solid var(--line)",
           background: "var(--card)",
+          flexWrap: narrow ? "wrap" : "nowrap",
         }}
       >
         <span
           className="mono"
           style={{
+            flex: "0 0 auto",
             fontSize: 10,
             fontWeight: 700,
-            letterSpacing: ".04em",
-            textTransform: "uppercase",
+            letterSpacing: ".05em",
             color: "var(--ac)",
             background: "var(--ac-soft)",
             borderRadius: 999,
-            padding: "3px 9px",
+            padding: "4px 10px",
           }}
         >
-          Review
+          REVIEW
         </span>
-        {active && (
-          <div style={{ minWidth: 0 }}>
-            <div style={{ fontSize: 13.5, fontWeight: 600 }}>
-              {active.message ?? "Proposed change"}
-            </div>
-            <div className="muted" style={{ fontSize: 11.5 }}>
-              {active.author} · proposed {ago(active.created_at)} · against v{active.base_version}
-            </div>
+        <div style={{ flex: 1, minWidth: narrow ? "55%" : 120 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <span style={{ fontSize: 14, fontWeight: 600, ...ellipsis }}>
+              {active?.message ?? "Proposed change"}
+            </span>
+            {active && !narrow && <StateBadge state={active.state} />}
           </div>
-        )}
-        {proposals.length > 1 && (
+          <div className="muted" style={{ fontSize: 11.5, ...ellipsis }}>
+            {active ? `${active.author} · proposed ${ago(active.created_at)}` : "Loading…"}
+          </div>
+        </div>
+        {/* On phones, switch proposals via a dropdown instead of the side rail. */}
+        {narrow && proposals.length > 1 && (
           <select
             className="input"
             value={activeId ?? ""}
             onChange={(e) => setActiveId(e.target.value)}
-            style={{ width: 150, padding: "5px 8px", fontSize: 12, marginLeft: 8 }}
+            style={{ width: 150, padding: "5px 8px", fontSize: 12, flex: "0 0 auto" }}
           >
             {proposals.map((p, i) => (
               <option key={p.id} value={p.id}>
-                {p.message ? p.message.slice(0, 28) : `Proposal ${i + 1}`}
+                {(p.message ? p.message.slice(0, 26) : `Proposal ${i + 1}`) +
+                  (p.state === "open" ? "" : ` · ${STATE_META[p.state].label}`)}
               </option>
             ))}
           </select>
         )}
-        <span style={{ flex: 1 }} />
-        {/* Proposed ↔ Current ↔ Diff */}
-        <div style={{ display: "flex", gap: 4 }}>
-          {(["proposed", "current", "diff"] as const).map((v) => (
-            <button
-              key={v}
-              type="button"
-              className={`chip${view === v ? " on" : ""}`}
-              onClick={() => setView(v)}
-              style={{ cursor: "pointer", textTransform: "capitalize" }}
-            >
-              {v}
-            </button>
-          ))}
-        </div>
-        <button className="btn sm" onClick={onClose} title="Close review">
+        {!narrow && Toggle}
+        <button
+          className="btn sm"
+          onClick={onClose}
+          title="Close review"
+          style={{ flex: "0 0 auto" }}
+        >
           Close
         </button>
-      </div>
-
-      {/* Body: the experience (proposed or current), or the source diff. */}
-      <div style={{ flex: 1, minHeight: 0, position: "relative" }}>
-        {view === "diff" ? (
-          <div
-            style={{ position: "absolute", inset: 0, overflow: "auto", background: "var(--card)" }}
-          >
-            <div
-              style={{
-                display: "flex",
-                gap: 12,
-                padding: "8px 16px",
-                borderBottom: "1px solid var(--line-soft)",
-                fontSize: 12,
-                position: "sticky",
-                top: 0,
-                background: "var(--card)",
-              }}
-            >
-              <span className="mono muted" style={{ marginRight: "auto" }}>
-                v{active?.base_version} → proposed
-              </span>
-              <span className="mono" style={{ color: "var(--good)" }}>
-                +{adds}
-              </span>
-              <span className="mono" style={{ color: "var(--bad)" }}>
-                −{dels}
-              </span>
-            </div>
-            <pre
-              className="mono"
-              style={{ margin: 0, padding: "10px 0", fontSize: 12.5, lineHeight: 1.6 }}
-            >
-              {(active?.diff?.ops ?? []).map((o, i) => (
-                <div
-                  key={i}
-                  style={{
-                    padding: "0 16px",
-                    whiteSpace: "pre-wrap",
-                    wordBreak: "break-word",
-                    background:
-                      o.t === "add"
-                        ? "var(--good-bg)"
-                        : o.t === "del"
-                          ? "var(--cmt-bg)"
-                          : "transparent",
-                  }}
-                >
-                  <span className="muted" style={{ userSelect: "none" }}>
-                    {o.t === "add" ? "+ " : o.t === "del" ? "− " : "  "}
-                  </span>
-                  {o.line}
-                </div>
-              ))}
-            </pre>
-          </div>
-        ) : (
-          <iframe
-            title="review"
-            src={src}
-            sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
-            style={{
-              position: "absolute",
-              inset: 0,
-              width: "100%",
-              height: "100%",
-              border: 0,
-              background: "#fff",
-            }}
-          />
-        )}
-        {view === "proposed" && (
-          <div
-            style={{
-              position: "absolute",
-              top: 10,
-              left: "50%",
-              transform: "translateX(-50%)",
-              fontSize: 11,
-              fontWeight: 600,
-              color: "var(--ac)",
-              background: "var(--ac-soft)",
-              border: "1px solid var(--ac)",
-              borderRadius: 999,
-              padding: "3px 12px",
-              pointerEvents: "none",
-            }}
-          >
-            Previewing the proposed version
-          </div>
+        {narrow && (
+          <div style={{ width: "100%", display: "flex", justifyContent: "center" }}>{Toggle}</div>
         )}
       </div>
 
-      {/* Decision bar. */}
+      {/* Context strip. */}
       <div
         style={{
           display: "flex",
           alignItems: "center",
-          gap: 10,
-          padding: "10px 16px",
+          gap: 8,
+          padding: "6px 18px",
+          fontSize: 12,
+          fontWeight: 500,
+          color: strip.accent ? "var(--ac)" : "var(--fg-mut)",
+          background: strip.accent ? "var(--ac-soft)" : "var(--card)",
+          borderBottom: "1px solid var(--line-soft)",
+          borderLeft: `3px solid ${strip.accent ? "var(--ac)" : "var(--line)"}`,
+        }}
+      >
+        {strip.text}
+        {view === "diff" && (
+          <span style={{ marginLeft: "auto", display: "flex", gap: 12 }}>
+            <span className="mono" style={{ color: "var(--good)" }}>
+              +{adds}
+            </span>
+            <span className="mono" style={{ color: "var(--bad)" }}>
+              −{dels}
+            </span>
+          </span>
+        )}
+      </div>
+
+      <div style={{ flex: 1, minHeight: 0, display: "flex" }}>
+        {/* Queue + history rail (desktop). Open proposals first, then decided. */}
+        {!narrow && (
+          <div
+            style={{
+              width: 232,
+              flex: "0 0 232px",
+              borderRight: "1px solid var(--line)",
+              background: "var(--card)",
+              overflowY: "auto",
+            }}
+          >
+            {open.length > 0 && (
+              <div
+                className="mono muted"
+                style={{
+                  fontSize: 9.5,
+                  letterSpacing: ".06em",
+                  textTransform: "uppercase",
+                  padding: "10px 12px 4px",
+                }}
+              >
+                Awaiting review ({open.length})
+              </div>
+            )}
+            {open.map((p) => (
+              <RailItem key={p.id} p={p} />
+            ))}
+            {decided.length > 0 && (
+              <div
+                className="mono muted"
+                style={{
+                  fontSize: 9.5,
+                  letterSpacing: ".06em",
+                  textTransform: "uppercase",
+                  padding: "14px 12px 4px",
+                }}
+              >
+                Decided ({decided.length})
+              </div>
+            )}
+            {decided.map((p) => (
+              <RailItem key={p.id} p={p} />
+            ))}
+          </div>
+        )}
+
+        {/* Body: the rendered experience, or the source diff. */}
+        <div style={{ flex: 1, minWidth: 0, position: "relative", background: "var(--card)" }}>
+          {/* Reviewer feedback on a decided proposal — what the proposer reads. */}
+          {active && !isOpen && active.decision_note && (
+            <div
+              style={{
+                padding: "10px 18px",
+                fontSize: 12.5,
+                lineHeight: 1.5,
+                borderBottom: "1px solid var(--line-soft)",
+                background: STATE_META[active.state].soft,
+              }}
+            >
+              <b style={{ color: STATE_META[active.state].color }}>
+                {STATE_META[active.state].label}
+                {active.decided_by ? ` by ${active.decided_by}` : ""}:
+              </b>{" "}
+              {active.decision_note}
+            </div>
+          )}
+          {/* Stale-base warning: this was proposed against an older live version. */}
+          {stale && active && (
+            <div
+              style={{
+                padding: "10px 18px",
+                fontSize: 12.5,
+                lineHeight: 1.5,
+                borderBottom: "1px solid var(--line-soft)",
+                background: "var(--cmt-bg)",
+              }}
+            >
+              <b style={{ color: "var(--bad)" }}>Out of date:</b> proposed against v
+              {active.base_version}, but the live version is now v{currentVersion}. Approving
+              replaces v{currentVersion} entirely — compare against{" "}
+              <button
+                type="button"
+                className="lnk"
+                onClick={() => setView("current")}
+                style={{ cursor: "pointer" }}
+              >
+                Current
+              </button>{" "}
+              before approving.
+            </div>
+          )}
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              top: (active && !isOpen && active.decision_note) || stale ? 44 : 0,
+            }}
+          >
+            {view === "diff" ? (
+              <pre
+                className="mono"
+                style={{
+                  position: "absolute",
+                  inset: 0,
+                  overflow: "auto",
+                  margin: 0,
+                  padding: "12px 0",
+                  fontSize: 12.5,
+                  lineHeight: 1.65,
+                }}
+              >
+                {(active?.diff?.ops ?? []).map((o, i) => (
+                  <div
+                    key={i}
+                    style={{
+                      padding: "0 18px",
+                      whiteSpace: "pre-wrap",
+                      wordBreak: "break-word",
+                      background:
+                        o.t === "add"
+                          ? "var(--good-bg)"
+                          : o.t === "del"
+                            ? "var(--cmt-bg)"
+                            : "transparent",
+                    }}
+                  >
+                    <span className="muted" style={{ userSelect: "none" }}>
+                      {o.t === "add" ? "+ " : o.t === "del" ? "− " : "  "}
+                    </span>
+                    {o.line}
+                  </div>
+                ))}
+              </pre>
+            ) : (
+              <iframe
+                title="review"
+                src={src}
+                sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
+                style={{ width: "100%", height: "100%", border: 0, background: "#fff" }}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Decision bar. Request-changes opens an inline note composer first. */}
+      <div
+        style={{
           borderTop: "1px solid var(--line)",
           background: "var(--card)",
         }}
       >
-        {err && <span style={{ color: "var(--bad)", fontSize: 12 }}>{err}</span>}
-        <span style={{ flex: 1 }} />
-        {isAuthor && active && (
-          <button
-            className="btn sm"
-            disabled={busy}
-            onClick={() => act(() => api.withdrawProposal(shortId, active.id))}
-          >
-            Withdraw
-          </button>
+        {noteFor && (
+          <div style={{ padding: "10px 18px 0" }}>
+            {noteFor === "approve" && (
+              <div style={{ fontSize: 12.5, marginBottom: 8, lineHeight: 1.5 }}>
+                {stale ? (
+                  <span style={{ color: "var(--bad)" }}>
+                    <b>Heads up:</b> this was proposed against v{active?.base_version}, but the live
+                    version is now v{currentVersion}. Approving replaces v{currentVersion} entirely.
+                    Approve anyway?
+                  </span>
+                ) : (
+                  <span className="muted">
+                    This publishes the proposed version as the new live v{currentVersion + 1}.
+                    Approve?
+                  </span>
+                )}
+              </div>
+            )}
+            <textarea
+              className="input"
+              autoFocus
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder={
+                noteFor === "changes"
+                  ? "What should change? This goes back to the proposer."
+                  : "Optional note to the proposer (e.g. why you approved)"
+              }
+              style={{ width: "100%", minHeight: 54, resize: "vertical", fontSize: 13 }}
+            />
+          </div>
         )}
-        {canApprove && active ? (
-          <>
-            <button
-              className="btn sm"
-              disabled={busy}
-              onClick={() => act(() => api.requestChanges(shortId, active.id))}
-            >
-              Request changes
-            </button>
-            <button
-              className="btn pri sm"
-              disabled={busy}
-              onClick={() => act(() => api.approveProposal(shortId, active.id))}
-            >
-              {busy ? "Approving…" : "Approve & publish"}
-            </button>
-          </>
-        ) : (
-          !isAuthor && (
-            <span className="muted" style={{ fontSize: 12 }}>
-              Only an editor can approve.
-            </span>
-          )
-        )}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: narrow ? "10px 12px" : "11px 18px",
+          }}
+        >
+          {err ? (
+            <span style={{ color: "var(--bad)", fontSize: 12.5 }}>{err}</span>
+          ) : (
+            isOpen &&
+            canApprove &&
+            !narrow &&
+            !noteFor && (
+              <span className="muted" style={{ fontSize: 12 }}>
+                Approving publishes this as the new live version.
+              </span>
+            )
+          )}
+          <span style={{ flex: 1 }} />
+
+          {noteFor ? (
+            <>
+              <button
+                className="btn sm"
+                disabled={busy}
+                onClick={() => {
+                  setNoteFor(null)
+                  setNote("")
+                }}
+              >
+                Cancel
+              </button>
+              {noteFor === "changes" ? (
+                <button
+                  className="btn pri sm"
+                  disabled={busy || !note.trim()}
+                  onClick={() =>
+                    active && act(() => api.requestChanges(shortId, active.id, note.trim()))
+                  }
+                >
+                  {busy ? "Sending…" : "Send request"}
+                </button>
+              ) : (
+                <button
+                  className="btn pri sm"
+                  disabled={busy}
+                  onClick={() =>
+                    active &&
+                    act(() => api.approveProposal(shortId, active.id, note.trim() || undefined))
+                  }
+                >
+                  {busy ? "Approving…" : stale ? "Approve anyway" : "Approve & publish"}
+                </button>
+              )}
+            </>
+          ) : (
+            isOpen &&
+            active && (
+              <>
+                {isAuthor && (
+                  <button
+                    className="btn sm"
+                    disabled={busy}
+                    onClick={() => act(() => api.withdrawProposal(shortId, active.id))}
+                  >
+                    Withdraw
+                  </button>
+                )}
+                {canApprove ? (
+                  <>
+                    <button
+                      className="btn sm"
+                      disabled={busy}
+                      onClick={() => setNoteFor("changes")}
+                    >
+                      Request changes
+                    </button>
+                    <button
+                      className="btn pri sm"
+                      disabled={busy}
+                      onClick={() => setNoteFor("approve")}
+                    >
+                      Approve & publish
+                    </button>
+                  </>
+                ) : (
+                  !isAuthor && (
+                    <span className="muted" style={{ fontSize: 12 }}>
+                      Only an editor can approve.
+                    </span>
+                  )
+                )}
+              </>
+            )
+          )}
+        </div>
       </div>
     </div>
   )

--- a/apps/web/src/pages/Artifact.tsx
+++ b/apps/web/src/pages/Artifact.tsx
@@ -17,6 +17,7 @@ import {
   type Diff,
 } from "../api"
 import { Header, useIsMobile, useToast } from "../components"
+import { ReviewOverlay } from "../components/ReviewOverlay"
 import { ShareButton } from "../components/ShareDialog"
 import { useAuth } from "../ctx"
 
@@ -58,6 +59,7 @@ export function Artifact() {
   const [failed, setFailed] = useState(false)
   const [comments, setComments] = useState<Comment[]>([])
   const [editing, setEditing] = useState(false)
+  const [reviewing, setReviewing] = useState(false)
   const [view, setView] = useState<"preview" | "diff">("preview")
   const [diff, setDiff] = useState<Diff | null>(null)
   const [restoring, setRestoring] = useState(false)
@@ -341,6 +343,9 @@ export function Artifact() {
   const shown = version ?? art.current_version
   const editable = art.kind === "file" && shown === art.current_version
   const rawSrc = `${API_BASE}/raw/${shortId}/v/${shown}/index.html`
+  // Editors publish directly; commenters propose a candidate for review.
+  const canPublish = art.my_role === "editor" || art.my_role === "owner"
+  const canPropose = canPublish || art.my_role === "commenter"
 
   // Sort threads into pinned (anchored & present in this live doc), general
   // (unanchored or orphaned), and resolved. Pins drive both the margin cards
@@ -377,6 +382,22 @@ export function Artifact() {
         "edited in browser",
       )
       show(`Published v${a.current_version}`)
+      setEditing(false)
+      load()
+    } catch (e) {
+      show((e as Error).message)
+    }
+  }
+  // A commenter can't publish; their edit becomes a proposal for review.
+  const proposeEdit = async () => {
+    try {
+      await api.propose(
+        shortId,
+        src,
+        art.title ? `${art.short_id}.md` : "edit.md",
+        "proposed change",
+      )
+      show("Proposed — sent for review")
       setEditing(false)
       load()
     } catch (e) {
@@ -468,6 +489,16 @@ export function Artifact() {
   return (
     <ActionsCtx.Provider value={actions}>
       <div style={{ height: "100%", display: "flex", flexDirection: "column" }}>
+        {reviewing && (
+          <ReviewOverlay
+            shortId={shortId}
+            currentVersion={art.current_version}
+            myRole={art.my_role}
+            meName={me?.name ?? me?.email ?? null}
+            onClose={() => setReviewing(false)}
+            onApplied={load}
+          />
+        )}
         <Header
           right={
             <>
@@ -495,9 +526,19 @@ export function Artifact() {
                   })
                 }
               />
-              {editable && !editing && (
+              {!!art.open_proposals && art.open_proposals > 0 && (
+                <button
+                  className="btn sm"
+                  onClick={() => setReviewing(true)}
+                  style={{ gap: 6, borderColor: "var(--ac)", color: "var(--ac)" }}
+                  title="Review proposed changes"
+                >
+                  Review <b style={{ fontWeight: 700 }}>{art.open_proposals}</b>
+                </button>
+              )}
+              {editable && canPropose && !editing && (
                 <button className="btn sm" onClick={startEdit}>
-                  Edit
+                  {canPublish ? "Edit" : "Propose"}
                 </button>
               )}
               {/* On phones the bottom-right FAB opens comments, so the header
@@ -555,9 +596,15 @@ export function Artifact() {
                   <button className="btn sm" onClick={() => setEditing(false)}>
                     Cancel
                   </button>
-                  <button className="btn pri sm" onClick={publishEdit}>
-                    Publish new version
-                  </button>
+                  {canPublish ? (
+                    <button className="btn pri sm" onClick={publishEdit}>
+                      Publish new version
+                    </button>
+                  ) : (
+                    <button className="btn pri sm" onClick={proposeEdit}>
+                      Propose change
+                    </button>
+                  )}
                 </div>
                 <textarea
                   className="mono"

--- a/apps/web/src/pages/Artifact.tsx
+++ b/apps/web/src/pages/Artifact.tsx
@@ -60,6 +60,7 @@ export function Artifact() {
   const [comments, setComments] = useState<Comment[]>([])
   const [editing, setEditing] = useState(false)
   const [reviewing, setReviewing] = useState(false)
+  const [proposeMsg, setProposeMsg] = useState("")
   const [view, setView] = useState<"preview" | "diff">("preview")
   const [diff, setDiff] = useState<Diff | null>(null)
   const [restoring, setRestoring] = useState(false)
@@ -388,17 +389,19 @@ export function Artifact() {
       show((e as Error).message)
     }
   }
-  // A commenter can't publish; their edit becomes a proposal for review.
+  // A commenter can't publish; their edit becomes a proposal for review. The
+  // message is the "why" the reviewer reads, so we ask for it before sending.
   const proposeEdit = async () => {
     try {
       await api.propose(
         shortId,
         src,
         art.title ? `${art.short_id}.md` : "edit.md",
-        "proposed change",
+        proposeMsg.trim() || "Proposed change",
       )
       show("Proposed — sent for review")
       setEditing(false)
+      setProposeMsg("")
       load()
     } catch (e) {
       show((e as Error).message)
@@ -526,7 +529,7 @@ export function Artifact() {
                   })
                 }
               />
-              {!!art.open_proposals && art.open_proposals > 0 && (
+              {art.open_proposals && art.open_proposals > 0 ? (
                 <button
                   className="btn sm"
                   onClick={() => setReviewing(true)}
@@ -535,6 +538,17 @@ export function Artifact() {
                 >
                   Review <b style={{ fontWeight: 700 }}>{art.open_proposals}</b>
                 </button>
+              ) : (
+                !!art.proposals_total &&
+                art.proposals_total > 0 && (
+                  <button
+                    className="btn sm"
+                    onClick={() => setReviewing(true)}
+                    title="See proposals and review feedback"
+                  >
+                    Proposals
+                  </button>
+                )
               )}
               {editable && canPropose && !editing && (
                 <button className="btn sm" onClick={startEdit}>
@@ -590,8 +604,19 @@ export function Artifact() {
                   }}
                 >
                   <span className="mono muted" style={{ fontSize: 11 }}>
-                    editing source
+                    {canPublish ? "editing source" : "proposing a change"}
                   </span>
+                  {/* The proposer's "why" — shown to the reviewer. Editors who
+                      publish directly don't need it. */}
+                  {!canPublish && (
+                    <input
+                      className="input"
+                      value={proposeMsg}
+                      onChange={(e) => setProposeMsg(e.target.value)}
+                      placeholder="What are you changing, and why?"
+                      style={{ flex: 1, maxWidth: 420, padding: "5px 9px", fontSize: 12.5 }}
+                    />
+                  )}
                   <span style={{ flex: 1 }} />
                   <button className="btn sm" onClick={() => setEditing(false)}>
                     Cancel

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -4,19 +4,23 @@ import type { Visibility } from "./ports"
  * The role vocabulary, in increasing power. A higher role can do everything a
  * lower one can.
  *  - viewer:    read
- *  - commenter: + comment (creates content to be reviewed; cannot publish/approve)
- *  - editor:    + publish versions directly, and approve others' proposed changes
+ *  - commenter: + comment, and propose a candidate version for review
+ *               (creates content to be reviewed; cannot publish/approve)
+ *  - editor:    + publish versions directly, and approve others' proposals
  *  - owner:     + manage (roles, settings, delete)
  */
 export type Role = "viewer" | "commenter" | "editor" | "owner"
 
 /** What an actor wants to do. Kept coarse on purpose; `can()` is the only gate. */
-export type Action = "read" | "comment" | "publish" | "approve" | "manage"
+export type Action = "read" | "comment" | "propose" | "publish" | "approve" | "manage"
 
 const RANK: Record<Role, number> = { viewer: 0, commenter: 1, editor: 2, owner: 3 }
 const NEEDS: Record<Action, Role> = {
   read: "viewer",
   comment: "commenter",
+  // A commenter can propose a candidate version, but an editor must approve it
+  // before it goes live. This is the review gate: propose ≠ publish.
+  propose: "commenter",
   publish: "editor",
   approve: "editor",
   manage: "owner",

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -143,7 +143,12 @@ export interface MetaStore {
   /** Record a reviewer's decision (approve / request changes / withdraw). */
   decideProposal(
     id: string,
-    fields: { state: ProposalState; decided_by: string | null; decided_version: number | null },
+    fields: {
+      state: ProposalState
+      decided_by: string | null
+      decided_version: number | null
+      decision_note?: string | null
+    },
   ): Promise<ProposalRecord | null>
 
   // ---- User directory (reads Better Auth's `user` table) ----------------
@@ -177,6 +182,8 @@ export interface ProposalRecord {
   decided_by: string | null
   /** The version number it became on approval; null otherwise. */
   decided_version: number | null
+  /** The reviewer's note when approving or requesting changes; the feedback. */
+  decision_note: string | null
   decided_at: string | null
   created_at: string
 }

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -133,9 +133,64 @@ export interface MetaStore {
   /** Replace an artifact's full tag set (deduped, trimmed, lowercased upstream). */
   setArtifactTags(artifactId: string, tags: string[]): Promise<void>
 
+  // ---- Reviews: proposed versions awaiting approval ----------------------
+  createProposal(p: NewProposal): Promise<ProposalRecord>
+  getProposal(id: string): Promise<ProposalRecord | null>
+  /** Proposals for an artifact, newest first; filterable by state. */
+  listProposals(artifactId: string, opts?: { state?: ProposalState }): Promise<ProposalRecord[]>
+  /** How many proposals are still awaiting a decision (for badges, no N+1). */
+  openProposalCounts(artifactIds: string[]): Promise<Record<string, number>>
+  /** Record a reviewer's decision (approve / request changes / withdraw). */
+  decideProposal(
+    id: string,
+    fields: { state: ProposalState; decided_by: string | null; decided_version: number | null },
+  ): Promise<ProposalRecord | null>
+
   // ---- User directory (reads Better Auth's `user` table) ----------------
   findUserByEmail(email: string): Promise<UserDir | null>
   getUsers(ids: string[]): Promise<UserDir[]>
+}
+
+/**
+ * A candidate version awaiting review. It holds content exactly like a version
+ * (blob_key + content_type, file or bundle manifest) but is NOT current until a
+ * reviewer approves it, at which point it is appended as the new live version.
+ *   open → approved | changes_requested | withdrawn
+ */
+export type ProposalState = "open" | "approved" | "changes_requested" | "withdrawn"
+
+export interface ProposalRecord {
+  id: string
+  artifact_id: string
+  blob_key: string
+  content_type: string
+  kind: ArtifactKind
+  /** Optional new title the proposal would set on approval. */
+  title: string | null
+  /** What the proposer is changing, in their words. */
+  message: string | null
+  author: string
+  /** The current_version this candidate was proposed against (for the diff). */
+  base_version: number
+  state: ProposalState
+  /** Set once decided. */
+  decided_by: string | null
+  /** The version number it became on approval; null otherwise. */
+  decided_version: number | null
+  decided_at: string | null
+  created_at: string
+}
+
+export interface NewProposal {
+  id: string
+  artifact_id: string
+  blob_key: string
+  content_type: string
+  kind: ArtifactKind
+  title?: string | null
+  message?: string | null
+  author: string
+  base_version: number
 }
 
 /** A person, as needed for sharing UIs. Sourced from Better Auth's user table. */

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -2,11 +2,13 @@ import { unzipSync } from "fflate"
 import { newId, newShortId, slugify } from "./ids"
 import { mimeFor } from "./mime"
 import {
+  type ArtifactKind,
   type ArtifactRecord,
   type BlobStore,
   BUNDLE_CONTENT_TYPE,
   type BundleManifest,
   type MetaStore,
+  type ProposalRecord,
   type VersionRecord,
   type Visibility,
 } from "./ports"
@@ -54,25 +56,29 @@ const cleanPath = (raw: string): string | null => {
   return `/${p}`
 }
 
-/**
- * Stores content and creates a new artifact (shortId undefined)
- * or the next version of an existing one.
- */
-export async function publish(
-  meta: MetaStore,
-  blobs: BlobStore,
-  input: PublishInput,
-  shortId?: string,
-): Promise<PublishResult> {
-  let blobKey: string
-  let contentType: string
-  let kind: "file" | "bundle"
+/** A piece of stored content, ready to become a version or a proposal. */
+interface StoredContent {
+  blobKey: string
+  contentType: string
+  kind: ArtifactKind
+}
 
-  if (input.isBundle) {
-    kind = "bundle"
+/**
+ * Stores raw bytes (a file) or a zip (a bundle) into the blob store and returns
+ * the content-addressed key, content type, and kind. Shared by publish() and
+ * propose() so a candidate version is processed exactly like a published one.
+ */
+async function storeContent(
+  blobs: BlobStore,
+  bytes: Uint8Array,
+  filename: string,
+  isBundle: boolean,
+  spa: boolean,
+): Promise<StoredContent> {
+  if (isBundle) {
     let unzipped: Record<string, Uint8Array>
     try {
-      unzipped = unzipSync(input.bytes)
+      unzipped = unzipSync(bytes)
     } catch {
       throw new PublishError(400, "not a valid zip")
     }
@@ -96,14 +102,37 @@ export async function publish(
             .sort((a, b) => a.split("/").length - b.split("/").length)[0]
     if (!entry) throw new PublishError(400, "bundle has no html entry point")
 
-    const manifest: BundleManifest = { entry, spa: !!input.spa, files }
-    blobKey = await blobs.put(new TextEncoder().encode(JSON.stringify(manifest)))
-    contentType = BUNDLE_CONTENT_TYPE
-  } else {
-    kind = "file"
-    contentType = /\.(md|markdown)$/i.test(input.filename) ? "text/markdown" : "text/html"
-    blobKey = await blobs.put(input.bytes)
+    const manifest: BundleManifest = { entry, spa, files }
+    return {
+      blobKey: await blobs.put(new TextEncoder().encode(JSON.stringify(manifest))),
+      contentType: BUNDLE_CONTENT_TYPE,
+      kind: "bundle",
+    }
   }
+  return {
+    blobKey: await blobs.put(bytes),
+    contentType: /\.(md|markdown)$/i.test(filename) ? "text/markdown" : "text/html",
+    kind: "file",
+  }
+}
+
+/**
+ * Stores content and creates a new artifact (shortId undefined)
+ * or the next version of an existing one.
+ */
+export async function publish(
+  meta: MetaStore,
+  blobs: BlobStore,
+  input: PublishInput,
+  shortId?: string,
+): Promise<PublishResult> {
+  const { blobKey, contentType, kind } = await storeContent(
+    blobs,
+    input.bytes,
+    input.filename,
+    input.isBundle,
+    !!input.spa,
+  )
 
   const author = input.author ?? "anonymous"
 
@@ -143,6 +172,87 @@ export async function publish(
     name: input.name ?? null,
   })
   return { artifact: (await meta.getByShortId(artifact.short_id)) as ArtifactRecord, version }
+}
+
+export interface ProposeInput {
+  bytes: Uint8Array
+  filename: string
+  isBundle: boolean
+  spa?: boolean
+  /** What the proposer is changing, in their words. */
+  message?: string
+  author?: string
+}
+
+export interface ProposeResult {
+  artifact: ArtifactRecord
+  proposal: ProposalRecord
+}
+
+/**
+ * Stores a candidate version for review WITHOUT making it current. A commenter
+ * (or an agent) proposes; an editor approves. The content is processed exactly
+ * like a publish, so the proposal renders identically to how it will once live.
+ */
+export async function propose(
+  meta: MetaStore,
+  blobs: BlobStore,
+  shortId: string,
+  input: ProposeInput,
+): Promise<ProposeResult> {
+  const artifact = await meta.getByShortId(shortId)
+  if (!artifact) throw new PublishError(404, `no artifact with short_id ${shortId}`)
+
+  const { blobKey, contentType, kind } = await storeContent(
+    blobs,
+    input.bytes,
+    input.filename,
+    input.isBundle,
+    !!input.spa,
+  )
+  if (artifact.kind !== kind)
+    throw new PublishError(409, `artifact is a ${artifact.kind}; propose the same kind`)
+
+  const proposal = await meta.createProposal({
+    id: newId("p"),
+    artifact_id: artifact.id,
+    blob_key: blobKey,
+    content_type: contentType,
+    kind,
+    title: null,
+    message: input.message ?? null,
+    author: input.author ?? "anonymous",
+    base_version: artifact.current_version,
+  })
+  return { artifact, proposal }
+}
+
+/**
+ * Approving a proposal appends its stored content as the new current version
+ * (the experience goes live) and stamps the proposal decided. History is never
+ * rewritten: the proposal row stays as the audit trail of who approved what.
+ */
+export async function approveProposal(
+  meta: MetaStore,
+  proposal: ProposalRecord,
+  approver: string | null,
+): Promise<VersionRecord> {
+  if (proposal.state !== "open")
+    throw new PublishError(409, `proposal is ${proposal.state}, not open`)
+  const version = await meta.addVersion(proposal.artifact_id, {
+    id: newId("v"),
+    blob_key: proposal.blob_key,
+    content_type: proposal.content_type,
+    author: proposal.author,
+    message: proposal.message ?? "Approved proposal",
+    name: null,
+  })
+  await meta.decideProposal(proposal.id, {
+    state: "approved",
+    decided_by: approver,
+    decided_version: version.n,
+  })
+  return version
 }
 
 export const artifactUrl = (baseUrl: string, a: ArtifactRecord): string =>

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -236,6 +236,7 @@ export async function approveProposal(
   meta: MetaStore,
   proposal: ProposalRecord,
   approver: string | null,
+  note?: string | null,
 ): Promise<VersionRecord> {
   if (proposal.state !== "open")
     throw new PublishError(409, `proposal is ${proposal.state}, not open`)
@@ -251,6 +252,7 @@ export async function approveProposal(
     state: "approved",
     decided_by: approver,
     decided_version: version.n,
+    decision_note: note ?? null,
   })
   return version
 }

--- a/packages/core/test/permissions.test.ts
+++ b/packages/core/test/permissions.test.ts
@@ -14,6 +14,13 @@ describe("roleAllows", () => {
     expect(roleAllows("commenter", "publish")).toBe(false)
     expect(roleAllows("commenter", "approve")).toBe(false)
   })
+  it("a commenter proposes a candidate, but only an editor approves it", () => {
+    expect(roleAllows("commenter", "propose")).toBe(true)
+    expect(roleAllows("commenter", "approve")).toBe(false)
+    expect(roleAllows("viewer", "propose")).toBe(false)
+    expect(roleAllows("editor", "propose")).toBe(true)
+    expect(roleAllows("editor", "approve")).toBe(true)
+  })
   it("viewers only read", () => {
     expect(roleAllows("viewer", "read")).toBe(true)
     expect(roleAllows("viewer", "comment")).toBe(false)

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -402,7 +402,12 @@ export class D1MetaStore implements MetaStore {
   }
   async decideProposal(
     id: string,
-    fields: { state: ProposalState; decided_by: string | null; decided_version: number | null },
+    fields: {
+      state: ProposalState
+      decided_by: string | null
+      decided_version: number | null
+      decision_note?: string | null
+    },
   ): Promise<ProposalRecord | null> {
     return (
       (await this.db

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -13,9 +13,12 @@ import type {
   NewComment,
   NewDelivery,
   NewMembership,
+  NewProposal,
   NewVersion,
   NewView,
   NewWebhook,
+  ProposalRecord,
+  ProposalState,
   UserDir,
   VersionRecord,
   ViewStats,
@@ -30,6 +33,7 @@ import {
   artifactTag,
   comment,
   membership,
+  proposal,
   version,
   webhook,
   webhookDelivery,
@@ -45,6 +49,7 @@ const schema = {
   artifactMember,
   artifactFavorite,
   artifactTag,
+  proposal,
 }
 const VIEW_WINDOW_MS = 30 * 86400_000
 
@@ -367,6 +372,46 @@ export class D1MetaStore implements MetaStore {
         .insert(artifactTag)
         .values(tags.map((tag) => ({ id: crypto.randomUUID(), artifact_id: artifactId, tag })))
         .run()
+  }
+
+  // ---- Reviews: proposed versions ----------------------------------------
+  createProposal(p: NewProposal): Promise<ProposalRecord> {
+    return this.db.insert(proposal).values(p).returning().get()
+  }
+  async getProposal(id: string): Promise<ProposalRecord | null> {
+    return (await this.db.select().from(proposal).where(eq(proposal.id, id)).get()) ?? null
+  }
+  listProposals(artifactId: string, opts?: { state?: ProposalState }): Promise<ProposalRecord[]> {
+    const where = opts?.state
+      ? and(eq(proposal.artifact_id, artifactId), eq(proposal.state, opts.state))
+      : eq(proposal.artifact_id, artifactId)
+    return this.db.select().from(proposal).where(where).orderBy(desc(proposal.created_at)).all()
+  }
+  async openProposalCounts(artifactIds: string[]): Promise<Record<string, number>> {
+    if (artifactIds.length === 0) return {}
+    const ids = sql.join(
+      artifactIds.map((id) => sql`${id}`),
+      sql`, `,
+    )
+    const rows = (await this.db.all(
+      sql`SELECT artifact_id, count(*) c FROM proposal WHERE state='open' AND artifact_id IN (${ids}) GROUP BY artifact_id`,
+    )) as { artifact_id: string; c: number }[]
+    const out: Record<string, number> = {}
+    for (const r of rows) out[r.artifact_id] = r.c
+    return out
+  }
+  async decideProposal(
+    id: string,
+    fields: { state: ProposalState; decided_by: string | null; decided_version: number | null },
+  ): Promise<ProposalRecord | null> {
+    return (
+      (await this.db
+        .update(proposal)
+        .set({ ...fields, decided_at: new Date().toISOString() })
+        .where(eq(proposal.id, id))
+        .returning()
+        .get()) ?? null
+    )
   }
 
   // ---- User directory (Better Auth's `user` table; raw, may be absent) ---

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -7,6 +7,8 @@ import type {
   DeliveryRecord,
   DeliveryStatus,
   MembershipRecord,
+  ProposalRecord,
+  ProposalState,
   Role,
   VersionRecord,
   Visibility,
@@ -142,6 +144,24 @@ export const artifactTag = pgTable(
   },
   (t) => [uniqueIndex("artifact_tag_uniq").on(t.artifact_id, t.tag)],
 )
+export const proposal = pgTable("proposal", {
+  id: text("id").primaryKey(),
+  artifact_id: text("artifact_id")
+    .notNull()
+    .references(() => artifact.id),
+  blob_key: text("blob_key").notNull(),
+  content_type: text("content_type").notNull(),
+  kind: text("kind").$type<ArtifactKind>().notNull(),
+  title: text("title"),
+  message: text("message"),
+  author: text("author").notNull(),
+  base_version: integer("base_version").notNull(),
+  state: text("state").$type<ProposalState>().notNull().default("open"),
+  decided_by: text("decided_by"),
+  decided_version: integer("decided_version"),
+  decided_at: text("decided_at"),
+  created_at: text("created_at").notNull().$defaultFn(isoNow),
+})
 
 // Compile-time guard: the pg table defs must match the core record shapes (and
 // therefore the sqlite defs). Drift here means SQLite and Postgres disagree.
@@ -154,7 +174,8 @@ const _pgParity: [
   Exact<typeof webhookDelivery.$inferSelect, DeliveryRecord>,
   Exact<typeof membership.$inferSelect, MembershipRecord>,
   Exact<typeof artifactMember.$inferSelect, ArtifactMemberRecord>,
-] = [true, true, true, true, true, true, true]
+  Exact<typeof proposal.$inferSelect, ProposalRecord>,
+] = [true, true, true, true, true, true, true, true]
 void _pgParity
 
 // Boot DDL (idempotent). created_at uses a SQL default as a server-side backstop.
@@ -280,4 +301,21 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
     UNIQUE (artifact_id, tag)
   )`,
   `CREATE INDEX IF NOT EXISTS tag_name ON artifact_tag (tag)`,
+  `CREATE TABLE IF NOT EXISTS proposal (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    blob_key TEXT NOT NULL,
+    content_type TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    title TEXT,
+    message TEXT,
+    author TEXT NOT NULL,
+    base_version INTEGER NOT NULL,
+    state TEXT NOT NULL DEFAULT 'open',
+    decided_by TEXT,
+    decided_version INTEGER,
+    decided_at TEXT,
+    created_at TEXT NOT NULL DEFAULT ${isoDefault}
+  )`,
+  `CREATE INDEX IF NOT EXISTS proposal_artifact_state ON proposal (artifact_id, state)`,
 ]

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -159,6 +159,7 @@ export const proposal = pgTable("proposal", {
   state: text("state").$type<ProposalState>().notNull().default("open"),
   decided_by: text("decided_by"),
   decided_version: integer("decided_version"),
+  decision_note: text("decision_note"),
   decided_at: text("decided_at"),
   created_at: text("created_at").notNull().$defaultFn(isoNow),
 })
@@ -314,8 +315,10 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
     state TEXT NOT NULL DEFAULT 'open',
     decided_by TEXT,
     decided_version INTEGER,
+    decision_note TEXT,
     decided_at TEXT,
     created_at TEXT NOT NULL DEFAULT ${isoDefault}
   )`,
+  `ALTER TABLE proposal ADD COLUMN IF NOT EXISTS decision_note TEXT`,
   `CREATE INDEX IF NOT EXISTS proposal_artifact_state ON proposal (artifact_id, state)`,
 ]

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -397,7 +397,12 @@ export class PgMetaStore implements MetaStore {
   }
   async decideProposal(
     id: string,
-    fields: { state: ProposalState; decided_by: string | null; decided_version: number | null },
+    fields: {
+      state: ProposalState
+      decided_by: string | null
+      decided_version: number | null
+      decision_note?: string | null
+    },
   ): Promise<ProposalRecord | null> {
     const rows = await this.db
       .update(proposal)

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -12,9 +12,12 @@ import type {
   NewComment,
   NewDelivery,
   NewMembership,
+  NewProposal,
   NewVersion,
   NewView,
   NewWebhook,
+  ProposalRecord,
+  ProposalState,
   UserDir,
   VersionRecord,
   ViewStats,
@@ -31,6 +34,7 @@ import {
   comment,
   membership,
   PG_SCHEMA_STATEMENTS,
+  proposal,
   version,
   webhook,
   webhookDelivery,
@@ -46,6 +50,7 @@ const schema = {
   artifactMember,
   artifactFavorite,
   artifactTag,
+  proposal,
 }
 const VIEW_WINDOW_MS = 30 * 86400_000
 
@@ -362,6 +367,44 @@ export class PgMetaStore implements MetaStore {
           .insert(artifactTag)
           .values(tags.map((tag) => ({ id: crypto.randomUUID(), artifact_id: artifactId, tag })))
     })
+  }
+
+  // ---- Reviews: proposed versions ----------------------------------------
+  async createProposal(p: NewProposal): Promise<ProposalRecord> {
+    const rows = await this.db.insert(proposal).values(p).returning()
+    return rows[0]
+  }
+  async getProposal(id: string): Promise<ProposalRecord | null> {
+    const rows = await this.db.select().from(proposal).where(eq(proposal.id, id))
+    return rows[0] ?? null
+  }
+  listProposals(artifactId: string, opts?: { state?: ProposalState }): Promise<ProposalRecord[]> {
+    const where = opts?.state
+      ? and(eq(proposal.artifact_id, artifactId), eq(proposal.state, opts.state))
+      : eq(proposal.artifact_id, artifactId)
+    return this.db.select().from(proposal).where(where).orderBy(desc(proposal.created_at))
+  }
+  async openProposalCounts(artifactIds: string[]): Promise<Record<string, number>> {
+    if (artifactIds.length === 0) return {}
+    const ph = artifactIds.map((_, i) => `$${i + 1}`).join(",")
+    const { rows } = await this.pool.query(
+      `SELECT artifact_id, count(*)::int c FROM proposal WHERE state='open' AND artifact_id IN (${ph}) GROUP BY artifact_id`,
+      artifactIds,
+    )
+    const out: Record<string, number> = {}
+    for (const r of rows) out[r.artifact_id] = r.c
+    return out
+  }
+  async decideProposal(
+    id: string,
+    fields: { state: ProposalState; decided_by: string | null; decided_version: number | null },
+  ): Promise<ProposalRecord | null> {
+    const rows = await this.db
+      .update(proposal)
+      .set({ ...fields, decided_at: new Date().toISOString() })
+      .where(eq(proposal.id, id))
+      .returning()
+    return rows[0] ?? null
   }
 
   // ---- User directory (Better Auth's "user" table; raw, may be absent) ---

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -7,6 +7,8 @@ import type {
   DeliveryRecord,
   DeliveryStatus,
   MembershipRecord,
+  ProposalRecord,
+  ProposalState,
   Role,
   VersionRecord,
   Visibility,
@@ -148,6 +150,25 @@ export const artifactTag = sqliteTable(
   (t) => [uniqueIndex("artifact_tag_uniq").on(t.artifact_id, t.tag)],
 )
 
+export const proposal = sqliteTable("proposal", {
+  id: text("id").primaryKey(),
+  artifact_id: text("artifact_id")
+    .notNull()
+    .references(() => artifact.id),
+  blob_key: text("blob_key").notNull(),
+  content_type: text("content_type").notNull(),
+  kind: text("kind").$type<ArtifactKind>().notNull(),
+  title: text("title"),
+  message: text("message"),
+  author: text("author").notNull(),
+  base_version: integer("base_version").notNull(),
+  state: text("state").$type<ProposalState>().notNull().default("open"),
+  decided_by: text("decided_by"),
+  decided_version: integer("decided_version"),
+  decided_at: text("decided_at"),
+  created_at: text("created_at").notNull().default(now),
+})
+
 // user/session/account/verification tables are owned and migrated by Better Auth
 // (see apps/api/src/auth-config.ts) — not declared here.
 
@@ -274,6 +295,23 @@ export const SCHEMA_STATEMENTS: string[] = [
     UNIQUE (artifact_id, tag)
   )`,
   `CREATE INDEX IF NOT EXISTS tag_name ON artifact_tag (tag)`,
+  `CREATE TABLE IF NOT EXISTS proposal (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    blob_key TEXT NOT NULL,
+    content_type TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    title TEXT,
+    message TEXT,
+    author TEXT NOT NULL,
+    base_version INTEGER NOT NULL,
+    state TEXT NOT NULL DEFAULT 'open',
+    decided_by TEXT,
+    decided_version INTEGER,
+    decided_at TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  )`,
+  `CREATE INDEX IF NOT EXISTS proposal_artifact_state ON proposal (artifact_id, state)`,
   // user/session/account/verification are owned and migrated by Better Auth.
 ]
 
@@ -298,5 +336,6 @@ const _schemaParity: [
   Exact<typeof webhookDelivery.$inferSelect, DeliveryRecord>,
   Exact<typeof membership.$inferSelect, MembershipRecord>,
   Exact<typeof artifactMember.$inferSelect, ArtifactMemberRecord>,
-] = [true, true, true, true, true, true, true]
+  Exact<typeof proposal.$inferSelect, ProposalRecord>,
+] = [true, true, true, true, true, true, true, true]
 void _schemaParity

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -165,6 +165,7 @@ export const proposal = sqliteTable("proposal", {
   state: text("state").$type<ProposalState>().notNull().default("open"),
   decided_by: text("decided_by"),
   decided_version: integer("decided_version"),
+  decision_note: text("decision_note"),
   decided_at: text("decided_at"),
   created_at: text("created_at").notNull().default(now),
 })
@@ -308,6 +309,7 @@ export const SCHEMA_STATEMENTS: string[] = [
     state TEXT NOT NULL DEFAULT 'open',
     decided_by TEXT,
     decided_version INTEGER,
+    decision_note TEXT,
     decided_at TEXT,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
   )`,
@@ -323,6 +325,7 @@ export const SCHEMA_STATEMENTS: string[] = [
 export const MIGRATION_STATEMENTS: string[] = [
   `ALTER TABLE comment ADD COLUMN meta TEXT`,
   `ALTER TABLE version ADD COLUMN name TEXT`,
+  `ALTER TABLE proposal ADD COLUMN decision_note TEXT`,
 ]
 
 // Compile-time guard: the drizzle table defs must exactly match the core record

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -427,7 +427,12 @@ export class SqliteMetaStore implements MetaStore {
   }
   async decideProposal(
     id: string,
-    fields: { state: ProposalState; decided_by: string | null; decided_version: number | null },
+    fields: {
+      state: ProposalState
+      decided_by: string | null
+      decided_version: number | null
+      decision_note?: string | null
+    },
   ): Promise<ProposalRecord | null> {
     return (
       this.db

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -12,9 +12,12 @@ import type {
   NewComment,
   NewDelivery,
   NewMembership,
+  NewProposal,
   NewVersion,
   NewView,
   NewWebhook,
+  ProposalRecord,
+  ProposalState,
   UserDir,
   VersionRecord,
   ViewStats,
@@ -31,6 +34,7 @@ import {
   comment,
   MIGRATION_STATEMENTS,
   membership,
+  proposal,
   SCHEMA_STATEMENTS,
   version,
   webhook,
@@ -49,6 +53,7 @@ const schema = {
   artifactMember,
   artifactFavorite,
   artifactTag,
+  proposal,
 }
 
 /** Embedded SQLite (WAL). The zero-dependency default; no external services. */
@@ -391,6 +396,47 @@ export class SqliteMetaStore implements MetaStore {
           .run()
       }
     })()
+  }
+
+  // ---- Reviews: proposed versions ----------------------------------------
+  createProposal(p: NewProposal): Promise<ProposalRecord> {
+    return Promise.resolve(this.db.insert(proposal).values(p).returning().get())
+  }
+  async getProposal(id: string): Promise<ProposalRecord | null> {
+    return this.db.select().from(proposal).where(eq(proposal.id, id)).get() ?? null
+  }
+  listProposals(artifactId: string, opts?: { state?: ProposalState }): Promise<ProposalRecord[]> {
+    const where = opts?.state
+      ? and(eq(proposal.artifact_id, artifactId), eq(proposal.state, opts.state))
+      : eq(proposal.artifact_id, artifactId)
+    return Promise.resolve(
+      this.db.select().from(proposal).where(where).orderBy(desc(proposal.created_at)).all(),
+    )
+  }
+  async openProposalCounts(artifactIds: string[]): Promise<Record<string, number>> {
+    if (artifactIds.length === 0) return {}
+    const ph = artifactIds.map(() => "?").join(",")
+    const rows = this.raw
+      .prepare(
+        `SELECT artifact_id, count(*) c FROM proposal WHERE state='open' AND artifact_id IN (${ph}) GROUP BY artifact_id`,
+      )
+      .all(...artifactIds) as { artifact_id: string; c: number }[]
+    const out: Record<string, number> = {}
+    for (const r of rows) out[r.artifact_id] = r.c
+    return out
+  }
+  async decideProposal(
+    id: string,
+    fields: { state: ProposalState; decided_by: string | null; decided_version: number | null },
+  ): Promise<ProposalRecord | null> {
+    return (
+      this.db
+        .update(proposal)
+        .set({ ...fields, decided_at: new Date().toISOString() })
+        .where(eq(proposal.id, id))
+        .returning()
+        .get() ?? null
+    )
   }
 
   // ---- User directory (Better Auth's `user` table; raw, may be absent) ---


### PR DESCRIPTION
## What

Some people publish directly; others should only propose. This adds the review half of the loop: a **proposed** version state on top of the permissions from #25. A commenter (or an agent) publishes a candidate that does NOT go live; an editor reviews it and approves (it becomes current) or requests changes. The pull-request model, applied to artifacts.

## Approve the experience, not the diff

A Dock version is a whole rendered document, so the review surface centers on the **rendered experience**: a proposed version is served through the exact same pipeline as a live one, and the reviewer toggles **Proposed ↔ Current** to compare what users will actually see. The line diff is demoted to a third tab (it's noise on rendered HTML). The proposed render reuses the version-serving path — proposals are versions-not-yet-current.

## A real collaboration, both sides

- **Proposer says why:** the propose composer asks "what are you changing, and why?"; that message is shown prominently to the reviewer. A **Proposals** entry + a queue/history rail let the proposer track status and **read the reviewer's feedback** even after their candidate leaves the open queue.
- **Reviewer gives feedback:** request-changes (and approve) carry a **note** back to the proposer (`decision_note`). A queue rail lists every proposal with its state badge, author, and note — open first, then decided.
- **Roles:** new `propose` action at commenter rank (propose ≠ publish); approve/request-changes gated on the existing `approve` action; withdraw by the author or a manager.

## Staleness guard, not merge

Whole-document artifacts have no 3-way merge. Instead: when a proposal's base is behind the live version, an **"Out of date"** banner appears and Approve becomes an explicit **"Approve anyway?"** confirm spelling out the consequence — an informed decision, never a silent clobber.

## Surface

- Data model: `proposal` table across sqlite/pg/d1 (drizzle + parity guards) + MetaStore methods; `decision_note` column.
- Core: `storeContent()` extracted from `publish()` so a proposal is processed identically; `propose()` / `approveProposal()`.
- API: `POST/GET /v1/artifacts/:id/proposals`, `GET …/:proposalId` (+ base diff), `…/approve`, `…/request-changes`, `…/withdraw`; proposal raw serving at `/raw/:id/p/:proposalId`; `open_proposals` + `proposals_total` on the artifact; webhook + SSE events for the proposal lifecycle.
- Web: a self-contained `ReviewOverlay` (queue rail · rendered toggle · diff · feedback notes · staleness/approve confirm), and a commenter Propose path; minimal wiring into the artifact page.

## Verification

- Core unit tests for the `propose` rank; API integration tests (propose→approve goes live, commenter-can't-approve, request-changes carries the note, withdraw, conflict 409).
- An 8-check end-to-end run against **real Postgres** (isolated temp DB): propose → request-changes-with-note → approve goes live, incl. `decision_note` + `proposals_total`.
- Full browser loop verified on **desktop and mobile** (rail collapses to a dropdown on phones).
- `pnpm typecheck` + full suite + `biome ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)