### PR TITLE
@mentions + in-app notifications

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -41,7 +41,14 @@ import { enqueueForEvent, WEBHOOK_EVENTS, type WebhookEvent } from "./webhooks"
 /** The fixed reaction set; arbitrary emoji are rejected to keep data clean. */
 const REACTIONS = ["👍", "❤️", "🎉", "😄", "👀", "🙏", "🚀", "👎"]
 
-type CommentMeta = { reactions?: Record<string, string[]>; edited_at?: string; deleted?: boolean }
+/** A resolved @mention captured by the composer: the picked user's id + display name. */
+type Mention = { id: string; name: string }
+type CommentMeta = {
+  reactions?: Record<string, string[]>
+  edited_at?: string
+  deleted?: boolean
+  mentions?: Mention[]
+}
 const parseMeta = (m: string | null): CommentMeta => {
   if (!m) return {}
   try {
@@ -49,6 +56,22 @@ const parseMeta = (m: string | null): CommentMeta => {
   } catch {
     return {}
   }
+}
+
+/** Coerce arbitrary input into a clean Mention[] (defensive against bad clients). */
+function parseMentions(input: unknown): Mention[] {
+  if (!Array.isArray(input)) return []
+  const out: Mention[] = []
+  const seen = new Set<string>()
+  for (const m of input) {
+    if (!m || typeof m !== "object") continue
+    const id = (m as { id?: unknown }).id
+    const name = (m as { name?: unknown }).name
+    if (typeof id !== "string" || typeof name !== "string" || !id || seen.has(id)) continue
+    seen.add(id)
+    out.push({ id, name })
+  }
+  return out
 }
 
 /** Wire shape for a comment: meta unpacked into clean fields; deleted bodies blanked. */
@@ -63,6 +86,7 @@ function commentJson(cm: CommentRecord, anchored?: boolean) {
     edited: !!md.edited_at,
     edited_at: md.edited_at ?? null,
     deleted,
+    mentions: deleted ? [] : (md.mentions ?? []),
     ...(anchored !== undefined ? { anchored } : {}),
   }
 }
@@ -211,6 +235,44 @@ export function createApp(deps: AppDeps): Hono {
   // delivers). Awaited so the row is durable before we respond, but never fatal.
   const notify = (a: ArtifactRecord, event: WebhookEvent, data: Record<string, unknown>) =>
     enqueueForEvent(meta, deps.baseUrl, a, event, data).catch(() => {})
+
+  // Create in-app notification rows for the people a comment @mentions (real
+  // users only, never the author) and push each a live event over their stream.
+  // Returns the display names actually notified (for the Slack webhook).
+  const notifyMentions = async (
+    a: ArtifactRecord,
+    cm: CommentRecord,
+    mentions: Mention[],
+    actorId: string | null,
+  ): Promise<string[]> => {
+    const targetIds = mentions.map((m) => m.id).filter((mid) => mid !== actorId)
+    if (targetIds.length === 0) return []
+    const real = new Set((await meta.getUsers(targetIds)).map((u) => u.id))
+    const preview = previewOf(cm.body_md)
+    const notified: string[] = []
+    for (const m of mentions) {
+      if (m.id === actorId || !real.has(m.id)) continue
+      const row = {
+        id: newId("n"),
+        user_id: m.id,
+        actor: cm.author,
+        kind: "mention" as const,
+        artifact_id: a.id,
+        artifact_short_id: a.short_id,
+        artifact_title: a.title,
+        thread_id: cm.thread_id,
+        comment_id: cm.id,
+        preview,
+      }
+      await meta.createNotification(row)
+      notified.push(m.name)
+      bus.publish(`u:${m.id}`, {
+        type: "notification",
+        notification: { ...row, read: 0, created_at: new Date().toISOString() },
+      })
+    }
+    return notified
+  }
   if (allowOrigins.size) {
     app.use("/api/*", corsFor(allowOrigins))
     app.use("/v1/*", corsFor(allowOrigins))
@@ -299,6 +361,25 @@ export function createApp(deps: AppDeps): Hono {
     if (!u) return c.json({ error: "unauthenticated" }, 401)
     const role = await ensureMembership(u.id) // provisions on first load
     return c.json({ user: { ...u, role } })
+  })
+
+  // Workspace member directory for the @mention picker. Signed-in (or open) only;
+  // optional ?q= filters by name/email prefix. Never exposes non-members.
+  app.get("/v1/users", async (c) => {
+    if (!open && !(await currentUser(c)) && bearer(c) !== deps.token)
+      return c.json({ error: "unauthenticated" }, 401)
+    const members = await meta.listMemberships(WORKSPACE)
+    const users = await meta.getUsers(members.map((m) => m.user_id))
+    const q = (c.req.query("q") ?? "").trim().toLowerCase()
+    const filtered = q
+      ? users.filter(
+          (u) => (u.name ?? "").toLowerCase().includes(q) || u.email.toLowerCase().includes(q),
+        )
+      : users
+    filtered.sort((a, b) => (a.name ?? a.email).localeCompare(b.name ?? b.email))
+    return c.json({
+      users: filtered.map((u) => ({ id: u.id, name: u.name ?? u.email, email: u.email })),
+    })
   })
 
   app.get("/v1/artifacts", async (c) => {
@@ -584,7 +665,8 @@ export function createApp(deps: AppDeps): Hono {
       : typeof body.author === "string" && body.author
         ? body.author
         : "anonymous"
-    const created = await meta.createComment({
+    const mentions = parseMentions(body.mentions)
+    let created = await meta.createComment({
       id,
       artifact_id: artifact.id,
       thread_id: threadId,
@@ -594,13 +676,30 @@ export function createApp(deps: AppDeps): Hono {
       body_md: body.body_md,
       author,
     })
-    bus.publish(artifact.id, { type: "comment.created", comment: created })
+    // Mentions live in the comment's meta JSON (the picker supplies user ids, so
+    // there's no fragile server-side @name parsing); persist them with the row.
+    if (mentions.length) {
+      const patched = await meta.updateComment(created.id, {
+        meta: JSON.stringify({ ...parseMeta(created.meta), mentions }),
+      })
+      if (patched) created = patched
+    }
+    bus.publish(artifact.id, { type: "comment.created", comment: commentJson(created) })
     await notify(artifact, "comment.created", {
       author: created.author,
       body: created.body_md,
       quote: quoteOf(created.anchor),
       thread_id: created.thread_id,
     })
+    const notified = await notifyMentions(artifact, created, mentions, me?.id ?? null)
+    if (notified.length)
+      await notify(artifact, "comment.mention", {
+        author: created.author,
+        mentioned: notified,
+        body: created.body_md,
+        quote: quoteOf(created.anchor),
+        thread_id: created.thread_id,
+      })
     return c.json(commentJson(created), 201)
   })
 
@@ -795,6 +894,52 @@ export function createApp(deps: AppDeps): Hono {
     if (!artifact || !(await authorize(c, "read", artifact)))
       return c.json({ error: "not found" }, 404)
     return c.json(await meta.viewStats(artifact.id))
+  })
+
+  // ---- In-app notifications (per signed-in user) ------------------------
+
+  app.get("/v1/notifications", async (c) => {
+    const me = await currentUser(c)
+    if (!me) return c.json({ error: "unauthenticated" }, 401)
+    const [notifications, unread] = await Promise.all([
+      meta.listNotifications(me.id, 50),
+      meta.unreadNotificationCount(me.id),
+    ])
+    return c.json({ notifications, unread })
+  })
+
+  app.post("/v1/notifications/read", async (c) => {
+    const me = await currentUser(c)
+    if (!me) return c.json({ error: "unauthenticated" }, 401)
+    const body = (await c.req.json().catch(() => ({}))) as { ids?: unknown; all?: unknown }
+    const ids =
+      body.all === true
+        ? "all"
+        : Array.isArray(body.ids)
+          ? body.ids.filter((x): x is string => typeof x === "string")
+          : []
+    await meta.markNotificationsRead(me.id, ids)
+    const unread = await meta.unreadNotificationCount(me.id)
+    return c.json({ unread })
+  })
+
+  // Live notification stream for the signed-in user (the header bell subscribes).
+  app.get("/v1/notifications/events", async (c) => {
+    const me = await currentUser(c)
+    if (!me) return c.text("unauthenticated", 401)
+    c.header("Access-Control-Allow-Origin", "*")
+    const userId = me.id
+    return streamSSE(c, async (stream) => {
+      const unsub = bus.subscribe(`u:${userId}`, (e) => {
+        void stream.writeSSE({ event: e.type, data: JSON.stringify(e) })
+      })
+      stream.onAbort(unsub)
+      await stream.writeSSE({ event: "ready", data: "{}" })
+      while (!stream.aborted) {
+        await stream.sleep(15000)
+        await stream.writeSSE({ event: "ping", data: "{}" })
+      }
+    })
   })
 
   // ---- Webhooks (notifications: Slack + arbitrary endpoints) -------------
@@ -1007,6 +1152,12 @@ const quoteOf = (anchor: string | null): string | null => {
   } catch {
     return null
   }
+}
+
+/** A short single-line preview of a comment body for notification rows. */
+const previewOf = (body: string): string => {
+  const flat = body.replace(/\s+/g, " ").trim()
+  return flat.length > 160 ? `${flat.slice(0, 159)}…` : flat
 }
 
 const str = (v: unknown): string | undefined => (typeof v === "string" && v !== "" ? v : undefined)

--- a/apps/api/src/bus.ts
+++ b/apps/api/src/bus.ts
@@ -6,6 +6,7 @@ export interface DockEvent {
     | "comment.updated"
     | "version.published"
     | "presence"
+    | "notification"
   [k: string]: unknown
 }
 

--- a/apps/api/src/webhooks.ts
+++ b/apps/api/src/webhooks.ts
@@ -2,7 +2,12 @@ import { createHmac, randomUUID } from "node:crypto"
 import type { ArtifactRecord, DeliveryRecord, MetaStore } from "@dock/core"
 
 /** Event names webhooks can subscribe to. */
-export const WEBHOOK_EVENTS = ["comment.created", "comment.resolved", "version.published"] as const
+export const WEBHOOK_EVENTS = [
+  "comment.created",
+  "comment.mention",
+  "comment.resolved",
+  "version.published",
+] as const
 export type WebhookEvent = (typeof WEBHOOK_EVENTS)[number]
 
 const MAX_ATTEMPTS = 6
@@ -46,6 +51,12 @@ export function slackMessage(p: EventPayload): unknown {
   if (p.event === "comment.created") {
     const author = String(p.data.author ?? "someone")
     head = `:speech_balloon: *${author}* commented on ${link}`
+    if (p.data.quote) lines.push(`> _${truncate(String(p.data.quote), 140)}_`)
+    if (p.data.body) lines.push(truncate(String(p.data.body), 280))
+  } else if (p.event === "comment.mention") {
+    const author = String(p.data.author ?? "someone")
+    const who = Array.isArray(p.data.mentioned) ? (p.data.mentioned as string[]).join(", ") : ""
+    head = `:wave: *${author}* mentioned ${who ? `*${who}*` : "you"} on ${link}`
     if (p.data.quote) lines.push(`> _${truncate(String(p.data.quote), 140)}_`)
     if (p.data.body) lines.push(truncate(String(p.data.body), 280))
   } else if (p.event === "comment.resolved") {

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -777,3 +777,147 @@ describe("security: rate limiting", () => {
     expect(status).toBe(429)
   })
 })
+
+describe("@mentions + in-app notifications", () => {
+  const alice: TestUser = { id: "u_m_alice", email: "ma@dock.test", name: "Alice" }
+  const bob: TestUser = { id: "u_m_bob", email: "mb@dock.test", name: "Bob" }
+  const { app, meta: m } = makeAuthedApp("mentions", [alice, bob], "editor")
+  let shortId: string
+
+  it("lists provisioned workspace members in the mention directory, filtered by ?q=", async () => {
+    shortId = (await (await publishAs(app, "<h1>doc</h1>", {}, as(alice.email))).json()).short_id
+    await app.request("/v1/me", { headers: as(bob.email) }) // provisions bob as a member
+    const all = await (await app.request("/v1/users", { headers: as(alice.email) })).json()
+    const ids = all.users.map((u: { id: string }) => u.id)
+    expect(ids).toContain(alice.id)
+    expect(ids).toContain(bob.id)
+
+    const filtered = await (
+      await app.request("/v1/users?q=bob", { headers: as(alice.email) })
+    ).json()
+    expect(filtered.users).toHaveLength(1)
+    expect(filtered.users[0]).toMatchObject({ id: bob.id, name: "Bob", email: bob.email })
+  })
+
+  it("stores mentions on the comment and notifies the mentioned user, never the author", async () => {
+    const res = await app.request(
+      `/v1/artifacts/${shortId}/comments`,
+      jsonAs(as(alice.email), {
+        body_md: "hey please take a look",
+        mentions: [
+          { id: bob.id, name: "Bob" },
+          { id: alice.id, name: "Alice" }, // self-mention must NOT notify Alice
+        ],
+      }),
+    )
+    expect(res.status).toBe(201)
+    const cm = await res.json()
+    expect(cm.mentions).toEqual([
+      { id: bob.id, name: "Bob" },
+      { id: alice.id, name: "Alice" },
+    ])
+
+    const bobN = await (await app.request("/v1/notifications", { headers: as(bob.email) })).json()
+    expect(bobN.unread).toBe(1)
+    expect(bobN.notifications[0]).toMatchObject({
+      kind: "mention",
+      actor: "Alice",
+      artifact_short_id: shortId,
+      thread_id: cm.thread_id,
+      comment_id: cm.id,
+      read: 0,
+    })
+    expect(bobN.notifications[0].preview).toContain("take a look")
+
+    const aliceN = await (
+      await app.request("/v1/notifications", { headers: as(alice.email) })
+    ).json()
+    expect(aliceN.unread).toBe(0)
+  })
+
+  it("drops mentions of unknown user ids (no junk notifications)", async () => {
+    await app.request(
+      `/v1/artifacts/${shortId}/comments`,
+      jsonAs(as(alice.email), {
+        body_md: "ghost ping",
+        mentions: [{ id: "u_does_not_exist", name: "Ghost" }],
+      }),
+    )
+    // Bob still has only his single earlier notification; no row for the ghost id.
+    const ghost = await m.listNotifications("u_does_not_exist", 10)
+    expect(ghost).toHaveLength(0)
+  })
+
+  it("marks notifications read", async () => {
+    const before = await (await app.request("/v1/notifications", { headers: as(bob.email) })).json()
+    expect(before.unread).toBe(1)
+    const read = await app.request("/v1/notifications/read", jsonAs(as(bob.email), { all: true }))
+    expect((await read.json()).unread).toBe(0)
+    const after = await (await app.request("/v1/notifications", { headers: as(bob.email) })).json()
+    expect(after.unread).toBe(0)
+    expect(after.notifications[0].read).toBe(1)
+  })
+
+  it("requires auth for the directory and the notification feed", async () => {
+    expect((await app.request("/v1/users")).status).toBe(401)
+    expect((await app.request("/v1/notifications")).status).toBe(401)
+    expect((await app.request("/v1/notifications/events")).status).toBe(401)
+  })
+
+  it("enqueues a comment.mention webhook carrying the notified names", async () => {
+    await app.request("/v1/webhooks", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...as(alice.email) },
+      body: JSON.stringify({
+        url: "https://hooks.example.com/mention",
+        events: ["comment.mention"],
+      }),
+    })
+    await app.request(
+      `/v1/artifacts/${shortId}/comments`,
+      jsonAs(as(alice.email), { body_md: "ping again", mentions: [{ id: bob.id, name: "Bob" }] }),
+    )
+    const due = await m.claimDueDeliveries(new Date(Date.now() + 1000).toISOString(), 50)
+    const mention = due.find((d) => d.event_type === "comment.mention")
+    expect(mention).toBeTruthy()
+    const payload = JSON.parse(mention?.payload ?? "{}")
+    expect(payload.data.mentioned).toContain("Bob")
+    expect(payload.data.author).toBe("Alice")
+  })
+
+  it("pushes a live notification event to the mentioned user's stream", async () => {
+    const res = await app.request("/v1/notifications/events", { headers: as(bob.email) })
+    expect(res.headers.get("content-type")).toContain("text/event-stream")
+    const reader = res.body?.getReader()
+    if (!reader) throw new Error("no stream body")
+    const dec = new TextDecoder()
+    const readUntil = async (needle: string, timeoutMs = 2500) => {
+      let buf = ""
+      const start = Date.now()
+      while (Date.now() - start < timeoutMs) {
+        const r = await Promise.race([
+          reader.read(),
+          new Promise<{ value?: Uint8Array; done: boolean }>((res) =>
+            setTimeout(() => res({ value: undefined, done: false }), 100),
+          ),
+        ])
+        if (r.value) buf += dec.decode(r.value, { stream: true })
+        if (buf.includes(needle)) return buf
+        if (r.done) break
+      }
+      throw new Error(`SSE timeout waiting for "${needle}"; got:\n${buf}`)
+    }
+    try {
+      await readUntil("event: ready")
+      await app.request(
+        `/v1/artifacts/${shortId}/comments`,
+        jsonAs(as(alice.email), { body_md: "live ping", mentions: [{ id: bob.id, name: "Bob" }] }),
+      )
+      const got = await readUntil("event: notification")
+      expect(got).toContain('"kind":"mention"')
+      expect(got).toContain("live ping")
+    } finally {
+      await reader.cancel()
+    }
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -46,6 +46,11 @@ export interface Analytics {
   daily: { day: string; count: number }[]
   recent: { viewer: string; kind: "user" | "anon"; at: string }[]
 }
+/** A resolved @mention: the picked user's id + the display name shown inline. */
+export interface Mention {
+  id: string
+  name: string
+}
 export interface Comment {
   id: string
   thread_id: string
@@ -61,6 +66,27 @@ export interface Comment {
   edited?: boolean
   edited_at?: string | null
   deleted?: boolean
+  mentions?: Mention[]
+}
+/** A workspace member as offered by the @mention picker. */
+export interface DirUser {
+  id: string
+  name: string
+  email: string
+}
+export interface Notification {
+  id: string
+  user_id: string
+  actor: string
+  kind: "mention" | "comment"
+  artifact_id: string
+  artifact_short_id: string
+  artifact_title: string | null
+  thread_id: string
+  comment_id: string
+  preview: string
+  read: 0 | 1
+  created_at: string
 }
 export interface Webhook {
   id: string
@@ -172,7 +198,7 @@ export const api = {
     f(`/v1/artifacts/${id}/comments`, opts()).then(j),
   comment: (
     id: string,
-    body: { body_md: string; thread_id?: string; anchor?: unknown },
+    body: { body_md: string; thread_id?: string; anchor?: unknown; mentions?: Mention[] },
   ): Promise<Comment> => f(`/v1/artifacts/${id}/comments`, opts(body)).then(j),
   resolve: (id: string, commentId: string, state: "open" | "resolved") =>
     f(`/v1/artifacts/${id}/comments/${commentId}/resolve`, opts({ state })).then(j),
@@ -188,6 +214,15 @@ export const api = {
       credentials: "include",
       headers: { accept: "application/json" },
     }).then(j),
+
+  // ---- Mention directory + in-app notifications -------------------------
+  users: (q?: string): Promise<{ users: DirUser[] }> =>
+    f(`/v1/users${q ? `?q=${encodeURIComponent(q)}` : ""}`, opts()).then(j),
+  notifications: (): Promise<{ notifications: Notification[]; unread: number }> =>
+    f("/v1/notifications", opts()).then(j),
+  markNotificationsRead: (sel: { ids: string[] } | { all: true }): Promise<{ unread: number }> =>
+    f("/v1/notifications/read", opts(sel)).then(j),
+  notificationsStreamUrl: (): string => u("/v1/notifications/events"),
 
   async publish(file: File, fields: Record<string, string> = {}, id?: string): Promise<Artifact> {
     const fd = new FormData()

--- a/apps/web/src/components.tsx
+++ b/apps/web/src/components.tsx
@@ -1,7 +1,15 @@
 import { Link, useNavigate } from "@tanstack/react-router"
-import { useEffect, useRef, useState } from "react"
-import { api } from "./api"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { api, type Notification } from "./api"
 import { THEMES, useAuth, useTheme } from "./ctx"
+
+const ago = (iso: string): string => {
+  const s = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000)
+  if (s < 60) return "just now"
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`
+  return `${Math.floor(s / 86400)}d ago`
+}
 
 export const Logo = ({ size = 24 }: { size?: number }) => (
   <svg width={size} height={size} viewBox="0 0 32 32" fill="none" aria-hidden>
@@ -43,8 +51,169 @@ export function Header({ right }: { right?: React.ReactNode }) {
         </span>
       </Link>
       {right && <div className="hdr-actions">{right}</div>}
+      <NotificationBell />
       <UserMenu />
     </header>
+  )
+}
+
+// Header bell: unread badge + a panel of recent @mentions, kept live over SSE.
+// Clicking an item deep-links to its comment thread (?c=) and marks it read.
+export function NotificationBell() {
+  const { me } = useAuth()
+  const nav = useNavigate()
+  const [items, setItems] = useState<Notification[]>([])
+  const [unread, setUnread] = useState(0)
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  const load = useCallback(() => {
+    api
+      .notifications()
+      .then((r) => {
+        setItems(r.notifications)
+        setUnread(r.unread)
+      })
+      .catch(() => {})
+  }, [])
+
+  // Initial load + live updates. EventSource reconnects on its own.
+  useEffect(() => {
+    if (!me) return
+    load()
+    const ev = new EventSource(api.notificationsStreamUrl(), { withCredentials: true })
+    ev.addEventListener("notification", load)
+    return () => ev.close()
+  }, [me, load])
+
+  useEffect(() => {
+    const h = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener("click", h)
+    return () => document.removeEventListener("click", h)
+  }, [])
+
+  if (!me) return null
+
+  const openItem = (n: Notification) => {
+    setOpen(false)
+    if (!n.read) {
+      setUnread((u) => Math.max(0, u - 1))
+      setItems((cur) => cur.map((x) => (x.id === n.id ? { ...x, read: 1 } : x)))
+      api
+        .markNotificationsRead({ ids: [n.id] })
+        .then((r) => setUnread(r.unread))
+        .catch(() => {})
+    }
+    nav({ to: "/a/$ref", params: { ref: n.artifact_short_id }, search: { c: n.thread_id } })
+  }
+
+  const markAll = () => {
+    setUnread(0)
+    setItems((cur) => cur.map((x) => ({ ...x, read: 1 })))
+    api
+      .markNotificationsRead({ all: true })
+      .then((r) => setUnread(r.unread))
+      .catch(() => {})
+  }
+
+  return (
+    <div ref={ref} style={{ position: "relative" }}>
+      <button
+        className="btn sm icon-btn"
+        title="Notifications"
+        onClick={(e) => {
+          e.stopPropagation()
+          setOpen((o) => !o)
+        }}
+        style={{ position: "relative" }}
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+          <path
+            d="M6 9a6 6 0 1 1 12 0c0 4 1.5 5.5 2 6.2.3.5 0 1.3-.7 1.3H4.7c-.7 0-1-.8-.7-1.3.5-.7 2-2.2 2-6.2Z"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinejoin="round"
+          />
+          <path d="M9.5 19a2.5 2.5 0 0 0 5 0" stroke="currentColor" strokeWidth="1.6" />
+        </svg>
+        {unread > 0 && <span className="notif-badge">{unread > 9 ? "9+" : unread}</span>}
+      </button>
+      {open && (
+        <div
+          className="card"
+          style={{
+            position: "absolute",
+            right: 0,
+            top: "calc(100% + 7px)",
+            width: 330,
+            padding: 0,
+            boxShadow: "var(--shadow)",
+            zIndex: 30,
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              padding: "9px 12px",
+              borderBottom: "1px solid var(--line-soft)",
+            }}
+          >
+            <span style={{ fontWeight: 600, fontSize: 13 }}>Notifications</span>
+            {unread > 0 && (
+              <button className="lnk" onClick={markAll} style={{ fontSize: 11.5 }}>
+                Mark all read
+              </button>
+            )}
+          </div>
+          <div style={{ maxHeight: 380, overflow: "auto" }}>
+            {items.length === 0 ? (
+              <div
+                className="muted"
+                style={{ padding: "22px 12px", fontSize: 12, textAlign: "center" }}
+              >
+                Nothing yet
+              </div>
+            ) : (
+              items.map((n) => (
+                <button
+                  key={n.id}
+                  type="button"
+                  onClick={() => openItem(n)}
+                  className="notif-item"
+                  style={{ background: n.read ? "transparent" : "var(--ac-soft)" }}
+                >
+                  <span className={`notif-dot${n.read ? " read" : ""}`} />
+                  <span style={{ minWidth: 0, flex: 1 }}>
+                    <span style={{ fontSize: 12.5, color: "var(--fg)", display: "block" }}>
+                      <strong>{n.actor}</strong>{" "}
+                      {n.kind === "mention" ? "mentioned you" : "commented"}
+                      {n.artifact_title ? (
+                        <>
+                          {" in "}
+                          <strong>{n.artifact_title}</strong>
+                        </>
+                      ) : null}
+                    </span>
+                    <span className="notif-preview">{n.preview}</span>
+                    <span
+                      className="mono"
+                      style={{ fontSize: 10, color: "var(--fg-mut)", display: "block" }}
+                    >
+                      {ago(n.created_at)}
+                    </span>
+                  </span>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/apps/web/src/pages/Artifact.tsx
+++ b/apps/web/src/pages/Artifact.tsx
@@ -1,6 +1,8 @@
 import { useNavigate, useParams } from "@tanstack/react-router"
 import {
+  type CSSProperties,
   createContext,
+  type KeyboardEvent as ReactKeyboardEvent,
   useCallback,
   useContext,
   useEffect,
@@ -15,6 +17,8 @@ import {
   api,
   type Comment,
   type Diff,
+  type DirUser,
+  type Mention,
 } from "../api"
 import { Header, useIsMobile, useToast } from "../components"
 import { ShareButton } from "../components/ShareDialog"
@@ -383,20 +387,25 @@ export function Artifact() {
       show((e as Error).message)
     }
   }
-  const addComment = async (text: string, opts?: { threadId?: string; anchor?: Sel | null }) => {
+  const addComment = async (
+    text: string,
+    opts?: { threadId?: string; anchor?: Sel | null; mentions?: Mention[] },
+  ) => {
     if (!text.trim()) return
     await api
       .comment(shortId, {
         body_md: text,
         thread_id: opts?.threadId,
         anchor: opts?.threadId ? undefined : (opts?.anchor ?? undefined),
+        mentions: opts?.mentions?.length ? opts.mentions : undefined,
       })
       .catch((e) => show((e as Error).message))
     api.listComments(shortId).then((r) => setComments(r.comments))
   }
-  const reply = (text: string, threadId: string) => addComment(text, { threadId })
-  const submitNew = async (text: string) => {
-    await addComment(text, { anchor: composer?.anchor ?? null })
+  const reply = (text: string, threadId: string, mentions: Mention[] = []) =>
+    addComment(text, { threadId, mentions })
+  const submitNew = async (text: string, mentions: Mention[] = []) => {
+    await addComment(text, { anchor: composer?.anchor ?? null, mentions })
     setComposer(null)
     setSel(null)
   }
@@ -822,9 +831,9 @@ function MobileComments({
   onNewGeneral: () => void
   onActivate: (id: string) => void
   onResolve: (c: Comment) => void
-  onReply: (text: string, threadId: string) => void
+  onReply: (text: string, threadId: string, mentions?: Mention[]) => void
   onJump: (id: string) => void
-  onSubmitNew: (text: string) => void
+  onSubmitNew: (text: string, mentions?: Mention[]) => void
   onCancelNew: () => void
 }) {
   // Half by default (document visible above). Reset to half each time it opens;
@@ -973,10 +982,10 @@ function OpenPanel(props: {
   onActivate: (id: string) => void
   onHover: (id: string | null) => void
   onResolve: (c: Comment) => void
-  onReply: (text: string, threadId: string) => void
+  onReply: (text: string, threadId: string, mentions?: Mention[]) => void
   onJump: (id: string) => void
   onNewGeneral: () => void
-  onSubmitNew: (text: string) => void
+  onSubmitNew: (text: string, mentions?: Mention[]) => void
   onCancelNew: () => void
 }) {
   const {
@@ -1163,9 +1172,9 @@ function PinnedZone({
   onActivate: (id: string) => void
   onHover: (id: string | null) => void
   onResolve: (c: Comment) => void
-  onReply: (text: string, threadId: string) => void
+  onReply: (text: string, threadId: string, mentions?: Mention[]) => void
   onJump: (id: string) => void
-  onSubmitNew: (text: string) => void
+  onSubmitNew: (text: string, mentions?: Mention[]) => void
   onCancelNew: () => void
 }) {
   const [heights, setHeights] = useState<Record<string, number>>({})
@@ -1342,8 +1351,18 @@ const esc = (s: string) =>
     /[&<>"]/g,
     (ch) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[ch] as string,
   )
-function mdToHtml(src: string): string {
+const escRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+function mdToHtml(src: string, mentions?: Mention[]): string {
   let h = esc(src)
+  // Highlight @mentions from the comment's known set (longest name first so a
+  // fuller name wins over a prefix). Names are escaped to match the escaped body.
+  if (mentions?.length) {
+    const names = [...new Set(mentions.map((m) => m.name))]
+      .sort((a, b) => b.length - a.length)
+      .map((n) => escRe(esc(n)))
+    if (names.length)
+      h = h.replace(new RegExp(`@(${names.join("|")})`, "g"), '<span class="mention">@$1</span>')
+  }
   h = h.replace(/`([^`]+)`/g, "<code>$1</code>")
   h = h.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
   h = h.replace(/(^|[^*])\*([^*\n]+)\*/g, "$1<em>$2</em>")
@@ -1512,7 +1531,7 @@ function CommentRow({ c, compact }: { c: Comment; compact?: boolean }) {
         <div
           className={`cmt-body${compact ? " cmt-clamp" : ""}`}
           // biome-ignore lint/security/noDangerouslySetInnerHtml: input is escaped first in mdToHtml.
-          dangerouslySetInnerHTML={{ __html: mdToHtml(c.body_md) }}
+          dangerouslySetInnerHTML={{ __html: mdToHtml(c.body_md, c.mentions) }}
         />
       )}
 
@@ -1629,11 +1648,18 @@ function CommentCard({
   onActivate: (id: string) => void
   onHover: (id: string | null) => void
   onResolve: (c: Comment) => void
-  onReply: (text: string, threadId: string) => void
+  onReply: (text: string, threadId: string, mentions?: Mention[]) => void
   onJump: (id: string) => void
 }) {
   const [reply, setReply] = useState("")
+  const [replyMentions, setReplyMentions] = useState<Mention[]>([])
   const root = thread[0]
+  const sendReply = (resolved: Mention[]) => {
+    if (!reply.trim()) return
+    onReply(reply, root.thread_id, resolved)
+    setReply("")
+    setReplyMentions([])
+  }
   const resolved = root.state === "resolved"
   const quote = anchorExact(root.anchor)
   const textPresent = present !== undefined ? present : root.anchored !== false
@@ -1713,30 +1739,25 @@ function CommentCard({
               borderTop: "1px solid var(--line-soft)",
             }}
           >
-            <input
-              className="input"
-              style={{ padding: "6px 9px", fontSize: 12 }}
-              value={reply}
-              placeholder="Reply…"
-              autoFocus
-              onClick={(e) => e.stopPropagation()}
-              onChange={(e) => setReply(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && reply.trim()) {
-                  onReply(reply, root.thread_id)
-                  setReply("")
-                }
-              }}
-            />
+            <div style={{ flex: 1 }} onClick={(e) => e.stopPropagation()}>
+              <MentionField
+                className="input"
+                style={{ padding: "6px 9px", fontSize: 12, width: "100%" }}
+                value={reply}
+                onChange={setReply}
+                mentions={replyMentions}
+                onMentions={setReplyMentions}
+                onSubmit={sendReply}
+                placeholder="Reply… (@ to mention)"
+                autoFocus
+              />
+            </div>
             <button
               className="btn sm"
               disabled={!reply.trim()}
               onClick={(e) => {
                 e.stopPropagation()
-                if (reply.trim()) {
-                  onReply(reply, root.thread_id)
-                  setReply("")
-                }
+                sendReply(replyMentions.filter((m) => reply.includes(`@${m.name}`)))
               }}
             >
               Reply
@@ -1813,7 +1834,7 @@ function ResolvedSection({
   onActivate: (id: string) => void
   onHover: (id: string | null) => void
   onResolve: (c: Comment) => void
-  onReply: (text: string, threadId: string) => void
+  onReply: (text: string, threadId: string, mentions?: Mention[]) => void
   onJump: (id: string) => void
 }) {
   const [open, setOpen] = useState(false)
@@ -1861,22 +1882,219 @@ function ResolvedSection({
 }
 
 // New-comment composer (anchored or general).
+/**
+ * A text control with @mention autocomplete. Typing "@" opens a live directory
+ * popover (/v1/users); picking inserts "@Name " and records the user's id. The
+ * picker — not a server-side @name parse — is the source of mention ids, so the
+ * data is unambiguous. Mentions whose inserted "@Name" is later deleted from the
+ * text are dropped at submit time. Single-line submits on Enter; multiline on
+ * Cmd/Ctrl+Enter (matching the surrounding composer/reply conventions).
+ */
+function MentionField({
+  value,
+  onChange,
+  mentions,
+  onMentions,
+  onSubmit,
+  onCancel,
+  placeholder,
+  autoFocus,
+  multiline,
+  className,
+  style,
+}: {
+  value: string
+  onChange: (v: string) => void
+  mentions: Mention[]
+  onMentions: (m: Mention[]) => void
+  /** Receives the mentions still present in the text (deleted ones pruned). */
+  onSubmit: (resolved: Mention[]) => void
+  onCancel?: () => void
+  placeholder?: string
+  autoFocus?: boolean
+  multiline?: boolean
+  className?: string
+  style?: CSSProperties
+}) {
+  const ref = useRef<HTMLTextAreaElement & HTMLInputElement>(null)
+  const [menu, setMenu] = useState<{ at: number; end: number; q: string } | null>(null)
+  const [results, setResults] = useState<DirUser[]>([])
+  const [active, setActive] = useState(0)
+
+  useLayoutEffect(() => {
+    if (autoFocus) ref.current?.focus()
+  }, [autoFocus])
+
+  // Fetch directory matches as the @query under the caret changes.
+  useEffect(() => {
+    if (!menu) {
+      setResults([])
+      return
+    }
+    let cancelled = false
+    api
+      .users(menu.q)
+      .then((r) => {
+        if (!cancelled) {
+          setResults(r.users.slice(0, 6))
+          setActive(0)
+        }
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [menu])
+
+  // Is the caret sitting at the end of an "@token"? If so, open the popover.
+  const detect = (el: HTMLTextAreaElement | HTMLInputElement) => {
+    const caret = el.selectionStart ?? el.value.length
+    const m = /(?:^|\s)@([\w.-]{0,30})$/.exec(el.value.slice(0, caret))
+    if (m) setMenu({ at: caret - m[1].length - 1, end: caret, q: m[1] })
+    else setMenu(null)
+  }
+
+  const choose = (u: DirUser) => {
+    if (!menu) return
+    const before = value.slice(0, menu.at)
+    const insert = `@${u.name} `
+    onChange(before + insert + value.slice(menu.end))
+    if (!mentions.some((m) => m.id === u.id)) onMentions([...mentions, { id: u.id, name: u.name }])
+    setMenu(null)
+    const pos = before.length + insert.length
+    requestAnimationFrame(() => {
+      const el = ref.current
+      if (el) {
+        el.focus()
+        el.setSelectionRange(pos, pos)
+      }
+    })
+  }
+
+  // Mentions whose "@Name" survived edits are the real ones.
+  const resolve = () => mentions.filter((m) => value.includes(`@${m.name}`))
+  const submit = () => {
+    if (value.trim()) onSubmit(resolve())
+  }
+
+  const onKeyDown = (e: ReactKeyboardEvent) => {
+    if (menu && results.length) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault()
+        setActive((a) => (a + 1) % results.length)
+        return
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault()
+        setActive((a) => (a - 1 + results.length) % results.length)
+        return
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault()
+        choose(results[active])
+        return
+      }
+      if (e.key === "Escape") {
+        e.preventDefault()
+        setMenu(null)
+        return
+      }
+    }
+    if (e.key === "Escape") {
+      onCancel?.()
+      return
+    }
+    if (e.key === "Enter" && (!multiline || e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      submit()
+    }
+  }
+
+  const shared = {
+    ref,
+    className,
+    value,
+    placeholder,
+    onChange: (e: { target: HTMLTextAreaElement | HTMLInputElement }) => {
+      onChange(e.target.value)
+      detect(e.target)
+    },
+    onKeyUp: (e: ReactKeyboardEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+      // Caret moves (arrows/click) can leave or re-enter a token.
+      if (e.key.startsWith("Arrow") || e.key === "Home" || e.key === "End") detect(e.currentTarget)
+    },
+    onKeyDown,
+    style,
+  }
+
+  return (
+    <div style={{ position: "relative" }}>
+      {multiline ? (
+        <textarea {...shared} />
+      ) : (
+        <input {...shared} onClick={(e) => e.stopPropagation()} />
+      )}
+      {menu && results.length > 0 && (
+        <div
+          className="card"
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            top: "calc(100% + 4px)",
+            zIndex: 40,
+            padding: 4,
+            boxShadow: "var(--shadow)",
+            maxHeight: 200,
+            overflow: "auto",
+          }}
+        >
+          {results.map((u, i) => (
+            <button
+              key={u.id}
+              type="button"
+              onMouseDown={(e) => {
+                e.preventDefault()
+                choose(u)
+              }}
+              onMouseEnter={() => setActive(i)}
+              style={{
+                display: "flex",
+                width: "100%",
+                gap: 8,
+                alignItems: "baseline",
+                padding: "6px 8px",
+                borderRadius: 6,
+                textAlign: "left",
+                background: i === active ? "var(--ac-soft)" : "transparent",
+                color: "var(--fg)",
+              }}
+            >
+              <span style={{ fontWeight: 600, fontSize: 12.5 }}>{u.name}</span>
+              <span className="mono" style={{ fontSize: 10.5, color: "var(--fg-mut)" }}>
+                {u.email}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 function Composer({
   quote,
   onSubmit,
   onCancel,
 }: {
   quote: string | null
-  onSubmit: (t: string) => void
+  onSubmit: (t: string, mentions: Mention[]) => void
   onCancel: () => void
 }) {
   const [text, setText] = useState("")
-  const ref = useRef<HTMLTextAreaElement>(null)
-  useLayoutEffect(() => {
-    ref.current?.focus()
-  }, [])
-  const submit = () => {
-    if (text.trim()) onSubmit(text)
+  const [mentions, setMentions] = useState<Mention[]>([])
+  const submit = (resolved: Mention[]) => {
+    if (text.trim()) onSubmit(text, resolved)
   }
   return (
     <div
@@ -1897,23 +2115,26 @@ function Composer({
         </div>
       )}
       <div style={{ padding: 9 }}>
-        <textarea
-          ref={ref}
+        <MentionField
+          multiline
+          autoFocus
           className="input"
           value={text}
-          onChange={(e) => setText(e.target.value)}
-          placeholder={quote ? "Comment on the selection…" : "Add a comment…"}
-          style={{ minHeight: 56, resize: "vertical", fontSize: 12.5 }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) submit()
-            if (e.key === "Escape") onCancel()
-          }}
+          onChange={setText}
+          mentions={mentions}
+          onMentions={setMentions}
+          onSubmit={submit}
+          onCancel={onCancel}
+          placeholder={
+            quote ? "Comment on the selection… (@ to mention)" : "Add a comment… (@ to mention)"
+          }
+          style={{ minHeight: 56, resize: "vertical", fontSize: 12.5, width: "100%" }}
         />
         <div style={{ display: "flex", gap: 6, marginTop: 7 }}>
           <button
             className="btn pri sm"
             disabled={!text.trim()}
-            onClick={submit}
+            onClick={() => submit(mentions.filter((m) => text.includes(`@${m.name}`)))}
             style={{ flex: 1, justifyContent: "center" }}
           >
             Comment

--- a/apps/web/src/routes/a.$ref.tsx
+++ b/apps/web/src/routes/a.$ref.tsx
@@ -2,5 +2,8 @@ import { createFileRoute } from "@tanstack/react-router"
 import { Artifact } from "../pages/Artifact"
 
 export const Route = createFileRoute("/a/$ref")({
+  // `c` deep-links to a comment thread (opens the panel + focuses its anchor).
+  validateSearch: (s: Record<string, unknown>): { c?: string } =>
+    typeof s.c === "string" ? { c: s.c } : {},
   component: Artifact,
 })

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -66,6 +66,19 @@ a{color:var(--ac);text-decoration:none}
 .hdr-brand{display:flex;align-items:center;gap:10px;color:var(--fg);margin-right:auto}
 .hdr-actions{display:flex;align-items:center;gap:8px}
 
+/* -- Notification bell + panel. -- */
+.icon-btn{padding:6px 8px}
+.notif-badge{position:absolute;top:-5px;right:-5px;min-width:16px;height:16px;padding:0 4px;border-radius:999px;
+  background:var(--ac);color:var(--ac-fg);font:700 9.5px/16px ui-monospace,Menlo,monospace;text-align:center;box-shadow:0 0 0 2px var(--card)}
+.notif-item{display:flex;gap:9px;width:100%;text-align:left;border:0;border-bottom:1px solid var(--line-soft);
+  padding:10px 12px;cursor:pointer;color:var(--fg);transition:background .12s}
+.notif-item:last-child{border-bottom:0}
+.notif-item:hover{filter:brightness(.97)}
+.notif-dot{flex:0 0 auto;width:7px;height:7px;margin-top:5px;border-radius:50%;background:var(--ac)}
+.notif-dot.read{background:var(--line)}
+.notif-preview{display:block;font-size:11.5px;color:var(--fg-mut);margin:1px 0 2px;
+  overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+
 /* -- Mobile comments sheet: slides up over the full-width document. -- */
 .sheet-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.34);opacity:0;pointer-events:none;transition:opacity .22s;z-index:60}
 .sheet-backdrop.show{opacity:1;pointer-events:auto}
@@ -121,6 +134,7 @@ a{color:var(--ac);text-decoration:none}
   border:1px solid var(--line-soft);border-radius:5px;padding:1px 4px}
 .cmt-body a{color:var(--ac);text-decoration:underline;text-underline-offset:2px}
 .cmt-body strong{font-weight:700}
+.mention{color:var(--ac);background:var(--ac-soft);font-weight:600;border-radius:4px;padding:0 3px;white-space:nowrap}
 /* Reaction pills. */
 .cmt-pills{display:flex;flex-wrap:wrap;gap:4px;margin-top:6px}
 .cmt-pill{display:inline-flex;align-items:center;gap:4px;font-size:11px;line-height:1;padding:3px 7px;border-radius:999px;

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -126,6 +126,13 @@ export interface MetaStore {
   // ---- User directory (reads Better Auth's `user` table) ----------------
   findUserByEmail(email: string): Promise<UserDir | null>
   getUsers(ids: string[]): Promise<UserDir[]>
+
+  // ---- Notifications (in-app, one row per recipient) --------------------
+  createNotification(n: NewNotification): Promise<void>
+  listNotifications(userId: string, limit: number): Promise<NotificationRecord[]>
+  unreadNotificationCount(userId: string): Promise<number>
+  /** Mark the given ids read, or all of the user's notifications when "all". */
+  markNotificationsRead(userId: string, ids: string[] | "all"): Promise<void>
 }
 
 /** A person, as needed for sharing UIs. Sourced from Better Auth's user table. */
@@ -133,6 +140,34 @@ export interface UserDir {
   id: string
   email: string
   name: string | null
+}
+
+export type NotificationKind = "mention" | "comment"
+export interface NotificationRecord {
+  id: string
+  user_id: string
+  actor: string
+  kind: NotificationKind
+  artifact_id: string
+  artifact_short_id: string
+  artifact_title: string | null
+  thread_id: string
+  comment_id: string
+  preview: string
+  read: 0 | 1
+  created_at: string
+}
+export interface NewNotification {
+  id: string
+  user_id: string
+  actor: string
+  kind: NotificationKind
+  artifact_id: string
+  artifact_short_id: string
+  artifact_title: string | null
+  thread_id: string
+  comment_id: string
+  preview: string
 }
 
 export interface MembershipRecord {

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -13,27 +13,39 @@ import type {
   NewComment,
   NewDelivery,
   NewMembership,
+  NewNotification,
   NewVersion,
   NewView,
   NewWebhook,
+  NotificationRecord,
   UserDir,
   VersionRecord,
   ViewStats,
   WebhookRecord,
 } from "@dock/core"
-import { and, asc, count, desc, eq, isNull, lte, or, sql } from "drizzle-orm"
+import { and, asc, count, desc, eq, inArray, isNull, lte, or, sql } from "drizzle-orm"
 import { type DrizzleD1Database, drizzle } from "drizzle-orm/d1"
 import {
   artifact,
   artifactMember,
   comment,
   membership,
+  notification,
   version,
   webhook,
   webhookDelivery,
 } from "./schema"
 
-const schema = { artifact, version, comment, webhook, webhookDelivery, membership, artifactMember }
+const schema = {
+  artifact,
+  version,
+  comment,
+  webhook,
+  webhookDelivery,
+  membership,
+  artifactMember,
+  notification,
+}
 const VIEW_WINDOW_MS = 30 * 86400_000
 
 /**
@@ -333,5 +345,37 @@ export class D1MetaStore implements MetaStore {
     } catch {
       return []
     }
+  }
+
+  // ---- Notifications (in-app, one row per recipient) ---------------------
+  async createNotification(n: NewNotification): Promise<void> {
+    await this.db.insert(notification).values(n).run()
+  }
+  listNotifications(userId: string, limit: number): Promise<NotificationRecord[]> {
+    return this.db
+      .select()
+      .from(notification)
+      .where(eq(notification.user_id, userId))
+      .orderBy(desc(notification.created_at))
+      .limit(limit)
+      .all()
+  }
+  async unreadNotificationCount(userId: string): Promise<number> {
+    const r = await this.db
+      .select({ n: count() })
+      .from(notification)
+      .where(and(eq(notification.user_id, userId), eq(notification.read, 0)))
+      .get()
+    return r?.n ?? 0
+  }
+  async markNotificationsRead(userId: string, ids: string[] | "all"): Promise<void> {
+    const where =
+      ids === "all"
+        ? eq(notification.user_id, userId)
+        : ids.length > 0
+          ? and(eq(notification.user_id, userId), inArray(notification.id, ids))
+          : null
+    if (!where) return
+    await this.db.update(notification).set({ read: 1 }).where(where).run()
   }
 }

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -7,6 +7,8 @@ import type {
   DeliveryRecord,
   DeliveryStatus,
   MembershipRecord,
+  NotificationKind,
+  NotificationRecord,
   Role,
   VersionRecord,
   Visibility,
@@ -117,6 +119,21 @@ export const artifactMember = pgTable(
   (t) => [uniqueIndex("artifact_member_user").on(t.artifact_id, t.user_id)],
 )
 
+export const notification = pgTable("notification", {
+  id: text("id").primaryKey(),
+  user_id: text("user_id").notNull(),
+  actor: text("actor").notNull(),
+  kind: text("kind").$type<NotificationKind>().notNull(),
+  artifact_id: text("artifact_id").notNull(),
+  artifact_short_id: text("artifact_short_id").notNull(),
+  artifact_title: text("artifact_title"),
+  thread_id: text("thread_id").notNull(),
+  comment_id: text("comment_id").notNull(),
+  preview: text("preview").notNull(),
+  read: integer("read").$type<0 | 1>().notNull().default(0),
+  created_at: text("created_at").notNull().$defaultFn(isoNow),
+})
+
 // Compile-time guard: the pg table defs must match the core record shapes (and
 // therefore the sqlite defs). Drift here means SQLite and Postgres disagree.
 type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false
@@ -128,7 +145,8 @@ const _pgParity: [
   Exact<typeof webhookDelivery.$inferSelect, DeliveryRecord>,
   Exact<typeof membership.$inferSelect, MembershipRecord>,
   Exact<typeof artifactMember.$inferSelect, ArtifactMemberRecord>,
-] = [true, true, true, true, true, true, true]
+  Exact<typeof notification.$inferSelect, NotificationRecord>,
+] = [true, true, true, true, true, true, true, true]
 void _pgParity
 
 // Boot DDL (idempotent). created_at uses a SQL default as a server-side backstop.
@@ -238,4 +256,19 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
     created_at TEXT NOT NULL DEFAULT ${isoDefault},
     UNIQUE (artifact_id, user_id)
   )`,
+  `CREATE TABLE IF NOT EXISTS notification (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    actor TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    artifact_id TEXT NOT NULL,
+    artifact_short_id TEXT NOT NULL,
+    artifact_title TEXT,
+    thread_id TEXT NOT NULL,
+    comment_id TEXT NOT NULL,
+    preview TEXT NOT NULL,
+    read INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT ${isoDefault}
+  )`,
+  `CREATE INDEX IF NOT EXISTS notification_user_time ON notification (user_id, created_at)`,
 ]

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -12,15 +12,17 @@ import type {
   NewComment,
   NewDelivery,
   NewMembership,
+  NewNotification,
   NewVersion,
   NewView,
   NewWebhook,
+  NotificationRecord,
   UserDir,
   VersionRecord,
   ViewStats,
   WebhookRecord,
 } from "@dock/core"
-import { and, asc, count, desc, eq, isNull, lte, or } from "drizzle-orm"
+import { and, asc, count, desc, eq, inArray, isNull, lte, or } from "drizzle-orm"
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres"
 import { Pool } from "pg"
 import {
@@ -28,13 +30,23 @@ import {
   artifactMember,
   comment,
   membership,
+  notification,
   PG_SCHEMA_STATEMENTS,
   version,
   webhook,
   webhookDelivery,
 } from "./pg-schema"
 
-const schema = { artifact, version, comment, webhook, webhookDelivery, membership, artifactMember }
+const schema = {
+  artifact,
+  version,
+  comment,
+  webhook,
+  webhookDelivery,
+  membership,
+  artifactMember,
+  notification,
+}
 const VIEW_WINDOW_MS = 30 * 86400_000
 
 /**
@@ -331,6 +343,36 @@ export class PgMetaStore implements MetaStore {
     } catch {
       return []
     }
+  }
+
+  // ---- Notifications (in-app, one row per recipient) ---------------------
+  async createNotification(n: NewNotification): Promise<void> {
+    await this.db.insert(notification).values(n)
+  }
+  listNotifications(userId: string, limit: number): Promise<NotificationRecord[]> {
+    return this.db
+      .select()
+      .from(notification)
+      .where(eq(notification.user_id, userId))
+      .orderBy(desc(notification.created_at))
+      .limit(limit)
+  }
+  async unreadNotificationCount(userId: string): Promise<number> {
+    const rows = await this.db
+      .select({ n: count() })
+      .from(notification)
+      .where(and(eq(notification.user_id, userId), eq(notification.read, 0)))
+    return rows[0]?.n ?? 0
+  }
+  async markNotificationsRead(userId: string, ids: string[] | "all"): Promise<void> {
+    const where =
+      ids === "all"
+        ? eq(notification.user_id, userId)
+        : ids.length > 0
+          ? and(eq(notification.user_id, userId), inArray(notification.id, ids))
+          : null
+    if (!where) return
+    await this.db.update(notification).set({ read: 1 }).where(where)
   }
 
   async close(): Promise<void> {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -7,6 +7,8 @@ import type {
   DeliveryRecord,
   DeliveryStatus,
   MembershipRecord,
+  NotificationKind,
+  NotificationRecord,
   Role,
   VersionRecord,
   Visibility,
@@ -120,6 +122,21 @@ export const artifactMember = sqliteTable(
   (t) => [uniqueIndex("artifact_member_user").on(t.artifact_id, t.user_id)],
 )
 
+export const notification = sqliteTable("notification", {
+  id: text("id").primaryKey(),
+  user_id: text("user_id").notNull(),
+  actor: text("actor").notNull(),
+  kind: text("kind").$type<NotificationKind>().notNull(),
+  artifact_id: text("artifact_id").notNull(),
+  artifact_short_id: text("artifact_short_id").notNull(),
+  artifact_title: text("artifact_title"),
+  thread_id: text("thread_id").notNull(),
+  comment_id: text("comment_id").notNull(),
+  preview: text("preview").notNull(),
+  read: integer("read").$type<0 | 1>().notNull().default(0),
+  created_at: text("created_at").notNull().default(now),
+})
+
 // user/session/account/verification tables are owned and migrated by Better Auth
 // (see apps/api/src/auth-config.ts) — not declared here.
 
@@ -230,6 +247,21 @@ export const SCHEMA_STATEMENTS: string[] = [
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
     UNIQUE (artifact_id, user_id)
   )`,
+  `CREATE TABLE IF NOT EXISTS notification (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    actor TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    artifact_id TEXT NOT NULL,
+    artifact_short_id TEXT NOT NULL,
+    artifact_title TEXT,
+    thread_id TEXT NOT NULL,
+    comment_id TEXT NOT NULL,
+    preview TEXT NOT NULL,
+    read INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  )`,
+  `CREATE INDEX IF NOT EXISTS notification_user_time ON notification (user_id, created_at)`,
   // user/session/account/verification are owned and migrated by Better Auth.
 ]
 
@@ -254,5 +286,6 @@ const _schemaParity: [
   Exact<typeof webhookDelivery.$inferSelect, DeliveryRecord>,
   Exact<typeof membership.$inferSelect, MembershipRecord>,
   Exact<typeof artifactMember.$inferSelect, ArtifactMemberRecord>,
-] = [true, true, true, true, true, true, true]
+  Exact<typeof notification.$inferSelect, NotificationRecord>,
+] = [true, true, true, true, true, true, true, true]
 void _schemaParity

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -12,16 +12,18 @@ import type {
   NewComment,
   NewDelivery,
   NewMembership,
+  NewNotification,
   NewVersion,
   NewView,
   NewWebhook,
+  NotificationRecord,
   UserDir,
   VersionRecord,
   ViewStats,
   WebhookRecord,
 } from "@dock/core"
 import Database from "better-sqlite3"
-import { and, asc, count, desc, eq, isNull, lte, or } from "drizzle-orm"
+import { and, asc, count, desc, eq, inArray, isNull, lte, or } from "drizzle-orm"
 import { type BetterSQLite3Database, drizzle } from "drizzle-orm/better-sqlite3"
 import {
   artifact,
@@ -29,6 +31,7 @@ import {
   comment,
   MIGRATION_STATEMENTS,
   membership,
+  notification,
   SCHEMA_STATEMENTS,
   version,
   webhook,
@@ -37,7 +40,16 @@ import {
 
 const VIEW_WINDOW_MS = 30 * 86400_000
 
-const schema = { artifact, version, comment, webhook, webhookDelivery, membership, artifactMember }
+const schema = {
+  artifact,
+  version,
+  comment,
+  webhook,
+  webhookDelivery,
+  membership,
+  artifactMember,
+  notification,
+}
 
 /** Embedded SQLite (WAL). The zero-dependency default; no external services. */
 export class SqliteMetaStore implements MetaStore {
@@ -352,6 +364,41 @@ export class SqliteMetaStore implements MetaStore {
     } catch {
       return []
     }
+  }
+
+  // ---- Notifications (in-app, one row per recipient) ---------------------
+  async createNotification(n: NewNotification): Promise<void> {
+    this.db.insert(notification).values(n).run()
+  }
+  listNotifications(userId: string, limit: number): Promise<NotificationRecord[]> {
+    return Promise.resolve(
+      this.db
+        .select()
+        .from(notification)
+        .where(eq(notification.user_id, userId))
+        .orderBy(desc(notification.created_at))
+        .limit(limit)
+        .all(),
+    )
+  }
+  async unreadNotificationCount(userId: string): Promise<number> {
+    return (
+      this.db
+        .select({ n: count() })
+        .from(notification)
+        .where(and(eq(notification.user_id, userId), eq(notification.read, 0)))
+        .get()?.n ?? 0
+    )
+  }
+  async markNotificationsRead(userId: string, ids: string[] | "all"): Promise<void> {
+    const where =
+      ids === "all"
+        ? eq(notification.user_id, userId)
+        : ids.length > 0
+          ? and(eq(notification.user_id, userId), inArray(notification.id, ids))
+          : null
+    if (!where) return
+    this.db.update(notification).set({ read: 1 }).where(where).run()
   }
 
   close(): void {


### PR DESCRIPTION
## What

Comment threads can now @mention teammates, and mentions surface as live in-app notifications in the header. Mentions (and comments on an artifact) also fan out to subscribed webhooks, so a Slack incoming-webhook gets a message — that delivery side is wired but not yet exercised end to end.

## How it works

**@mention picker (no @name parsing).** Typing `@` in the composer or a reply opens a live directory popover backed by `GET /v1/users`; picking inserts `@Name ` and records the user's id. The picked ids — not a fragile server-side parse of the body — are the source of truth, stored in the comment's existing `meta` JSON column. Mentions whose `@Name` text is later deleted are pruned at submit.

**In-app notifications.** Creating a comment writes one notification row per mentioned user (real users only, never the author — a self-mention is dropped), pushes a live event to that user's SSE stream, and the header bell shows an unread badge + a panel of recent mentions. Clicking an item deep-links to the thread (`?c=`) and marks it read.

**Webhooks.** The same event fires `comment.mention` to subscribed webhooks with the notified names; the Slack formatter renders it. (`comment.created` already covered "a comment landed".) Delivering to a real Slack endpoint is the part still to be tested.

## Surface area

- **Data:** a `notification` table across sqlite/pg/d1 (drizzle defs + compile-time parity guards + idempotent boot DDL) and four `MetaStore` methods.
- **API:** `GET /v1/users` (mention directory, `?q=` filter), `GET /v1/notifications`, `POST /v1/notifications/read`, `GET /v1/notifications/events` (per-user SSE); the comment route now persists mentions, notifies, and fires `comment.mention`.
- **Web:** a reusable `MentionField` autocomplete control (composer + replies), highlighted `@names` in rendered bodies, and a `NotificationBell` in the header kept live over SSE.

## Tests

8 new API tests (directory + `?q=`, mention → notification, self-mention excluded, unknown-id dropped, mark-read, `comment.mention` webhook payload, live SSE delivery). Full suite green; typecheck + biome clean. Verified in a browser: bell badge on a live mention, the panel contents, the `@` autocomplete dropdown, picking via Enter, and the highlighted mention in a rendered comment.

## Follow-ups (not this PR)

- "Comment on your stuff" in-app notifications (thread-participant / artifact-owner targeting needs a comment author id).
- Testing real Slack delivery of `comment.mention`.