### PR TITLE
feat: server-side search + keyset pagination for the artifact list

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -303,23 +303,58 @@ export function createApp(deps: AppDeps): Hono {
     return c.json({ user: { ...u, role } })
   })
 
+  // Newest-first, keyset-paginated (?cursor=<created_at>&limit=N), with optional
+  // server-side ?q= (title search), ?tag=, and ?favorite=true. Returns
+  // { artifacts, next_cursor }. tag/favorite resolve to an id set first.
   app.get("/v1/artifacts", async (c) => {
     const me = await currentUser(c)
     if (!me && deps.token && bearer(c) !== deps.token)
       return c.json({ error: "unauthenticated" }, 401)
-    const artifacts = await meta.listArtifacts({ limit: 200 })
-    const ids = artifacts.map((a) => a.id)
-    const counts = analyticsOn ? await meta.viewCounts(ids) : {}
-    const tags = await meta.tagsForArtifacts(ids)
-    const favorites = me ? new Set(await meta.listUserFavoriteIds(me.id)) : new Set<string>()
+    const limit = Math.min(100, Math.max(1, Number(c.req.query("limit")) || 30))
+    const cursor = c.req.query("cursor") || undefined
+    const q = c.req.query("q")?.trim() || undefined
+    const tag = c.req.query("tag")?.trim() || undefined
+    const favOnly = c.req.query("favorite") === "true"
+
+    const favIds = me ? await meta.listUserFavoriteIds(me.id) : []
+    const favorites = new Set(favIds)
+    let ids: string[] | undefined
+    if (tag) ids = await meta.artifactIdsByTag(tag)
+    if (favOnly) ids = ids ? ids.filter((id) => favorites.has(id)) : favIds
+    if (ids && ids.length === 0) return c.json({ artifacts: [], next_cursor: null })
+
+    const rows = await meta.listArtifacts({ limit: limit + 1, cursor, q, ids })
+    const hasMore = rows.length > limit
+    const page = hasMore ? rows.slice(0, limit) : rows
+    const next_cursor = hasMore ? page[page.length - 1].created_at : null
+
+    const pageIds = page.map((a) => a.id)
+    const counts = analyticsOn ? await meta.viewCounts(pageIds) : {}
+    const tags = await meta.tagsForArtifacts(pageIds)
     return c.json({
-      artifacts: artifacts.map((a) => ({
+      artifacts: page.map((a) => ({
         ...toJson(deps.baseUrl, a, []),
         views: counts[a.id] ?? 0,
         tags: tags[a.id] ?? [],
         favorite: favorites.has(a.id),
       })),
+      next_cursor,
     })
+  })
+
+  // Browse summary for the sidebar: total artifacts, this user's favorite count,
+  // and tag → count (so counts stay accurate independent of the current page).
+  app.get("/v1/tags", async (c) => {
+    const me = await currentUser(c)
+    if (!me && deps.token && bearer(c) !== deps.token)
+      return c.json({ error: "unauthenticated" }, 401)
+    const [total, tags, favIds] = await Promise.all([
+      meta.countArtifacts(),
+      meta.tagCounts(),
+      me ? meta.listUserFavoriteIds(me.id) : Promise.resolve([]),
+    ])
+    tags.sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
+    return c.json({ total, favorites: favIds.length, tags })
   })
 
   // ---- Publish ----------------------------------------------------------

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -969,3 +969,54 @@ describe("favorites + tags (browse)", () => {
     expect(map[id2]).toBeUndefined() // untagged ids simply have no entry
   })
 })
+
+describe("server-side search + cursor pagination", () => {
+  const putTags = (shortId: string, tags: string[]) =>
+    app.request(`/v1/artifacts/${shortId}/tags`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tags }),
+    })
+
+  it("searches by title server-side, case-insensitive", async () => {
+    await upload("s1.md", "x", { title: "Quarterly ZZUNIQUE Report" })
+    await upload("s2.md", "x", { title: "Totally unrelated" })
+    const r = await (await app.request("/v1/artifacts?q=zzunique")).json()
+    const titles = r.artifacts.map((a: { title: string | null }) => a.title)
+    expect(titles).toContain("Quarterly ZZUNIQUE Report")
+    expect(titles.every((t: string | null) => /zzunique/i.test(t ?? ""))).toBe(true)
+  })
+
+  it("paginates newest-first with a keyset cursor (no overlap)", async () => {
+    for (const n of ["A", "B", "C"]) await upload(`pg${n}.md`, "x", { title: `PGSEED ${n}` })
+    const p1 = await (await app.request("/v1/artifacts?q=PGSEED&limit=2")).json()
+    expect(p1.artifacts).toHaveLength(2)
+    expect(typeof p1.next_cursor).toBe("string")
+    const p2 = await (
+      await app.request(
+        `/v1/artifacts?q=PGSEED&limit=2&cursor=${encodeURIComponent(p1.next_cursor)}`,
+      )
+    ).json()
+    expect(p2.artifacts).toHaveLength(1)
+    expect(p2.next_cursor).toBeNull()
+    const seen = new Set(p1.artifacts.map((a: { short_id: string }) => a.short_id))
+    expect(p2.artifacts.some((a: { short_id: string }) => seen.has(a.short_id))).toBe(false)
+  })
+
+  it("filters by ?tag= server-side", async () => {
+    const { short_id } = await (await upload("tg.md", "x", { title: "Tagged one" })).json()
+    await putTags(short_id, ["serverfilter"])
+    const r = await (await app.request("/v1/artifacts?tag=serverfilter")).json()
+    expect(r.artifacts.map((a: { short_id: string }) => a.short_id)).toEqual([short_id])
+  })
+
+  it("GET /v1/tags returns a browse summary (total, favorites, tag counts)", async () => {
+    const { short_id } = await (await upload("sum.md", "x", { title: "Summary doc" })).json()
+    await putTags(short_id, ["summaryfilter"])
+    const r = await (await app.request("/v1/tags")).json()
+    expect(typeof r.total).toBe("number")
+    expect(r.total).toBeGreaterThan(0)
+    expect(r.favorites).toBe(0) // anonymous in tests
+    expect(r.tags.find((t: { tag: string }) => t.tag === "summaryfilter")?.count).toBe(1)
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -157,7 +157,27 @@ export const api = {
   logout: () => f("/api/auth/sign-out", opts({})).then((r) => r.json().catch(() => ({}))),
   googleUrl: u("/api/auth/sign-in/social?provider=google"),
 
-  listArtifacts: (): Promise<{ artifacts: Artifact[] }> => f("/v1/artifacts", opts()).then(j),
+  listArtifacts: (params?: {
+    q?: string
+    tag?: string
+    favorite?: boolean
+    cursor?: string
+    limit?: number
+  }): Promise<{ artifacts: Artifact[]; next_cursor: string | null }> => {
+    const qs = new URLSearchParams()
+    if (params?.q) qs.set("q", params.q)
+    if (params?.tag) qs.set("tag", params.tag)
+    if (params?.favorite) qs.set("favorite", "true")
+    if (params?.cursor) qs.set("cursor", params.cursor)
+    if (params?.limit) qs.set("limit", String(params.limit))
+    const s = qs.toString()
+    return f(`/v1/artifacts${s ? `?${s}` : ""}`, opts()).then(j)
+  },
+  browseSummary: (): Promise<{
+    total: number
+    favorites: number
+    tags: { tag: string; count: number }[]
+  }> => f("/v1/tags", opts()).then(j),
   getArtifact: (id: string): Promise<Artifact> => f(`/v1/artifacts/${id}`, opts()).then(j),
   getContent: (id: string, v?: number): Promise<string> =>
     f(`/v1/artifacts/${id}/content${v ? `?v=${v}` : ""}`, { credentials: "include" }).then((r) =>

--- a/apps/web/src/pages/Library.tsx
+++ b/apps/web/src/pages/Library.tsx
@@ -1,12 +1,15 @@
 import { useNavigate } from "@tanstack/react-router"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { API_BASE, type Artifact, api } from "../api"
 import { Header, useIsMobile, useToast } from "../components"
 import { useAuth } from "../ctx"
 
 type Filter = { kind: "all" } | { kind: "favorites" } | { kind: "tag"; tag: string }
+type TagCount = { tag: string; count: number }
+type Summary = { total: number; favorites: number; tags: TagCount[] }
 
 const RAIL_KEY = "dock.browse.rail"
+const PAGE = 30
 
 // A live, scaled-down render of the artifact's current version. Sandboxed and
 // non-interactive (clicks fall through to the card); lazy so off-screen cards
@@ -51,12 +54,18 @@ export function Library() {
   const { me, loading } = useAuth()
   const nav = useNavigate()
   const isMobile = useIsMobile()
-  const [items, setItems] = useState<Artifact[] | null>(null)
-  const [busy, setBusy] = useState(false)
   const file = useRef<HTMLInputElement>(null)
   const { toast, show } = useToast()
 
+  const [items, setItems] = useState<Artifact[]>([])
+  const [nextCursor, setNextCursor] = useState<string | null>(null)
+  const [fetching, setFetching] = useState(true)
+  const [more, setMore] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [summary, setSummary] = useState<Summary | null>(null)
+
   const [query, setQuery] = useState("")
+  const [debouncedQ, setDebouncedQ] = useState("")
   const [filter, setFilter] = useState<Filter>({ kind: "all" })
   const [rail, setRail] = useState<boolean>(() => {
     try {
@@ -78,13 +87,50 @@ export function Library() {
   useEffect(() => {
     if (!loading && !me) nav({ to: "/login" })
   }, [loading, me, nav])
+
+  // Debounce typing into a server query.
   useEffect(() => {
-    if (me)
-      api
-        .listArtifacts()
-        .then((r) => setItems(r.artifacts))
-        .catch(() => setItems([]))
-  }, [me])
+    const t = setTimeout(() => setDebouncedQ(query.trim()), 280)
+    return () => clearTimeout(t)
+  }, [query])
+
+  // Server-side search + filter + keyset pagination. Page 1 on every
+  // query/filter change; `cursor` appends the next page.
+  const load = useCallback(
+    async (cursor?: string) => {
+      cursor ? setMore(true) : setFetching(true)
+      try {
+        const r = await api.listArtifacts({
+          q: debouncedQ || undefined,
+          tag: filter.kind === "tag" ? filter.tag : undefined,
+          favorite: filter.kind === "favorites" || undefined,
+          cursor,
+          limit: PAGE,
+        })
+        setItems((prev) => (cursor ? [...prev, ...r.artifacts] : r.artifacts))
+        setNextCursor(r.next_cursor)
+      } catch {
+        if (!cursor) setItems([])
+      } finally {
+        setFetching(false)
+        setMore(false)
+      }
+    },
+    [debouncedQ, filter],
+  )
+  useEffect(() => {
+    if (me) load()
+  }, [me, load])
+
+  const refreshSummary = useCallback(() => {
+    api
+      .browseSummary()
+      .then(setSummary)
+      .catch(() => {})
+  }, [])
+  useEffect(() => {
+    if (me) refreshSummary()
+  }, [me, refreshSummary])
 
   const publish = async () => {
     const f = file.current?.files?.[0]
@@ -102,41 +148,23 @@ export function Library() {
     }
   }
 
-  // Star toggle is optimistic: reflect immediately, reconcile/revert on error.
+  // Star toggle is optimistic; in the Favorites view an un-star drops the card.
   const toggleFav = async (a: Artifact) => {
     const on = !a.favorite
-    const flip = (val: boolean) =>
-      setItems((p) => p?.map((x) => (x.short_id === a.short_id ? { ...x, favorite: val } : x)) ?? p)
-    flip(on)
+    setItems((prev) => {
+      const next = prev.map((x) => (x.short_id === a.short_id ? { ...x, favorite: on } : x))
+      return filter.kind === "favorites" && !on
+        ? next.filter((x) => x.short_id !== a.short_id)
+        : next
+    })
     try {
       await api.favorite(a.short_id, on)
+      refreshSummary()
     } catch (e) {
       show((e as Error).message)
-      flip(!on)
+      load()
     }
   }
-
-  const all = items ?? []
-  const favCount = all.filter((a) => a.favorite).length
-  const tagCounts = useMemo(() => {
-    const m = new Map<string, number>()
-    for (const a of all) for (const t of a.tags ?? []) m.set(t, (m.get(t) ?? 0) + 1)
-    return [...m.entries()].sort((x, y) => y[1] - x[1] || x[0].localeCompare(y[0]))
-  }, [all])
-
-  const filtered = useMemo(() => {
-    let list = all
-    if (filter.kind === "favorites") list = list.filter((a) => a.favorite)
-    else if (filter.kind === "tag") list = list.filter((a) => (a.tags ?? []).includes(filter.tag))
-    const q = query.trim().toLowerCase()
-    if (q)
-      list = list.filter(
-        (a) =>
-          (a.title ?? a.short_id).toLowerCase().includes(q) ||
-          (a.tags ?? []).some((t) => t.includes(q)),
-      )
-    return list
-  }, [all, filter, query])
 
   const pick = (f: Filter) => {
     setFilter(f)
@@ -148,6 +176,13 @@ export function Library() {
       : filter.kind === "favorites"
         ? "Favorites"
         : `#${filter.tag}`
+  const headingCount = debouncedQ
+    ? items.length
+    : filter.kind === "all"
+      ? (summary?.total ?? items.length)
+      : filter.kind === "favorites"
+        ? (summary?.favorites ?? items.length)
+        : (summary?.tags.find((t) => t.tag === filter.tag)?.count ?? items.length)
 
   if (!me)
     return (
@@ -186,9 +221,9 @@ export function Library() {
           rail={!isMobile && rail}
           drawer={isMobile}
           open={drawer}
-          total={all.length}
-          favCount={favCount}
-          tags={tagCounts}
+          total={summary?.total ?? 0}
+          favCount={summary?.favorites ?? 0}
+          tags={summary?.tags ?? []}
           filter={filter}
           onPick={pick}
           onToggleRail={() => setRail((r) => !r)}
@@ -203,7 +238,7 @@ export function Library() {
             <div className="searchbar">
               <input
                 className="input"
-                placeholder="Search by title or tag…"
+                placeholder="Search by title…"
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
                 style={{ flex: 1, minWidth: 200 }}
@@ -249,82 +284,91 @@ export function Library() {
             <h2 className="display" style={{ fontSize: 17, margin: "0 0 14px" }}>
               {heading}{" "}
               <span className="muted" style={{ fontWeight: 400, fontSize: 14 }}>
-                · {filtered.length}
+                · {headingCount}
               </span>
             </h2>
 
-            {items === null ? (
+            {fetching && items.length === 0 ? (
               <div className="center" style={{ height: 160 }}>
                 <div className="spin" />
               </div>
-            ) : filtered.length === 0 ? (
-              <EmptyState filter={filter} query={query} />
+            ) : items.length === 0 ? (
+              <EmptyState filter={filter} query={debouncedQ} />
             ) : (
-              <div
-                style={{
-                  display: "grid",
-                  gridTemplateColumns: "repeat(auto-fill,minmax(220px,1fr))",
-                  gap: 13,
-                }}
-              >
-                {filtered.map((a) => (
-                  <div key={a.short_id} className="card browse-card">
-                    <div style={{ position: "relative" }}>
-                      <Thumb id={a.short_id} v={a.current_version} />
-                      <button
-                        className={`star${a.favorite ? " on" : ""}`}
-                        title={a.favorite ? "Remove from favorites" : "Add to favorites"}
-                        aria-label="Toggle favorite"
-                        onClick={() => toggleFav(a)}
-                      >
-                        {a.favorite ? "★" : "☆"}
-                      </button>
-                    </div>
-                    <button
-                      className="card-open"
-                      onClick={() => nav({ to: "/a/$ref", params: { ref: a.short_id } })}
-                    >
-                      <span className="display" style={{ fontWeight: 600, fontSize: 15 }}>
-                        {a.title ?? a.short_id}
-                      </span>
-                      <span
-                        className="mono muted"
-                        style={{ fontSize: 11, display: "flex", gap: 8, alignItems: "center" }}
-                      >
-                        <span
-                          style={{
-                            background: "var(--card-2)",
-                            border: "1px solid var(--line-soft)",
-                            borderRadius: 5,
-                            padding: "1px 6px",
-                          }}
+              <>
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(auto-fill,minmax(220px,1fr))",
+                    gap: 13,
+                  }}
+                >
+                  {items.map((a) => (
+                    <div key={a.short_id} className="card browse-card">
+                      <div style={{ position: "relative" }}>
+                        <Thumb id={a.short_id} v={a.current_version} />
+                        <button
+                          className={`star${a.favorite ? " on" : ""}`}
+                          title={a.favorite ? "Remove from favorites" : "Add to favorites"}
+                          aria-label="Toggle favorite"
+                          onClick={() => toggleFav(a)}
                         >
-                          {a.kind}
-                        </span>
-                        <span>v{a.current_version}</span>
-                        {a.views !== undefined && a.views > 0 && (
-                          <span style={{ marginLeft: "auto" }} title={`${a.views} views`}>
-                            👁 {a.views > 999 ? `${(a.views / 1000).toFixed(1)}k` : a.views}
-                          </span>
-                        )}
-                      </span>
-                    </button>
-                    {(a.tags ?? []).length > 0 && (
-                      <div style={{ display: "flex", flexWrap: "wrap", gap: 5 }}>
-                        {(a.tags ?? []).slice(0, 6).map((t) => (
-                          <button
-                            key={t}
-                            className="tagchip"
-                            onClick={() => pick({ kind: "tag", tag: t })}
-                          >
-                            #{t}
-                          </button>
-                        ))}
+                          {a.favorite ? "★" : "☆"}
+                        </button>
                       </div>
-                    )}
+                      <button
+                        className="card-open"
+                        onClick={() => nav({ to: "/a/$ref", params: { ref: a.short_id } })}
+                      >
+                        <span className="display" style={{ fontWeight: 600, fontSize: 15 }}>
+                          {a.title ?? a.short_id}
+                        </span>
+                        <span
+                          className="mono muted"
+                          style={{ fontSize: 11, display: "flex", gap: 8, alignItems: "center" }}
+                        >
+                          <span
+                            style={{
+                              background: "var(--card-2)",
+                              border: "1px solid var(--line-soft)",
+                              borderRadius: 5,
+                              padding: "1px 6px",
+                            }}
+                          >
+                            {a.kind}
+                          </span>
+                          <span>v{a.current_version}</span>
+                          {a.views !== undefined && a.views > 0 && (
+                            <span style={{ marginLeft: "auto" }} title={`${a.views} views`}>
+                              👁 {a.views > 999 ? `${(a.views / 1000).toFixed(1)}k` : a.views}
+                            </span>
+                          )}
+                        </span>
+                      </button>
+                      {(a.tags ?? []).length > 0 && (
+                        <div style={{ display: "flex", flexWrap: "wrap", gap: 5 }}>
+                          {(a.tags ?? []).slice(0, 6).map((t) => (
+                            <button
+                              key={t}
+                              className="tagchip"
+                              onClick={() => pick({ kind: "tag", tag: t })}
+                            >
+                              #{t}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+                {nextCursor && (
+                  <div style={{ textAlign: "center", marginTop: 20 }}>
+                    <button className="btn" onClick={() => load(nextCursor)} disabled={more}>
+                      {more ? "Loading…" : "Load more"}
+                    </button>
                   </div>
-                ))}
-              </div>
+                )}
+              </>
             )}
           </div>
         </main>
@@ -352,7 +396,7 @@ function Sidebar({
   open: boolean
   total: number
   favCount: number
-  tags: [string, number][]
+  tags: TagCount[]
   filter: Filter
   onPick: (f: Filter) => void
   onToggleRail: () => void
@@ -385,18 +429,18 @@ function Sidebar({
       {tags.length > 0 && (
         <>
           <div className="side-lbl">Tags</div>
-          {tags.map(([t, n]) => (
+          {tags.map(({ tag, count }) => (
             <button
-              key={t}
-              className={`side-item${filter.kind === "tag" && filter.tag === t ? " on" : ""}`}
-              onClick={() => onPick({ kind: "tag", tag: t })}
-              title={`#${t}`}
+              key={tag}
+              className={`side-item${filter.kind === "tag" && filter.tag === tag ? " on" : ""}`}
+              onClick={() => onPick({ kind: "tag", tag })}
+              title={`#${tag}`}
             >
               <span className="ic">#</span>
               <span className="lbl" style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
-                {t}
+                {tag}
               </span>
-              <span className="n">{n}</span>
+              <span className="n">{count}</span>
             </button>
           ))}
         </>

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -26,6 +26,16 @@ export interface ArtifactRecord {
   created_at: string
 }
 
+export interface ListArtifactsOpts {
+  limit?: number
+  /** Keyset cursor: return artifacts created strictly before this ISO timestamp. */
+  cursor?: string
+  /** Case-insensitive title search. */
+  q?: string
+  /** Restrict to these artifact ids (tag / favorite filters resolve to ids). Empty ⇒ none. */
+  ids?: string[]
+}
+
 export interface VersionRecord {
   id: string
   artifact_id: string
@@ -78,7 +88,19 @@ export interface MetaStore {
   /** Flips every comment in a thread to a state; returns the count updated. */
   setThreadState(artifactId: string, threadId: string, state: CommentState): Promise<number>
 
-  listArtifacts(opts?: { limit?: number }): Promise<ArtifactRecord[]>
+  /**
+   * Newest-first artifact page. `cursor` is keyset pagination on created_at
+   * (rows strictly older than it); `q` is a case-insensitive title search;
+   * `ids` restricts to a set (tag / favorite filters resolve to ids) — an empty
+   * `ids` array matches nothing.
+   */
+  listArtifacts(opts?: ListArtifactsOpts): Promise<ArtifactRecord[]>
+  /** Artifact ids carrying a tag (server-side tag filtering). */
+  artifactIdsByTag(tag: string): Promise<string[]>
+  /** Total artifact count (browse summary). */
+  countArtifacts(): Promise<number>
+  /** Tag → usage count across the workspace (browse sidebar). */
+  tagCounts(): Promise<{ tag: string; count: number }[]>
 
   /** Append a view event. */
   recordView(v: NewView): Promise<void>

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -6,6 +6,7 @@ import type {
   CommentState,
   DeliveryRecord,
   DeliveryStatus,
+  ListArtifactsOpts,
   MembershipRecord,
   MetaStore,
   NewArtifact,
@@ -24,7 +25,7 @@ import type {
   ViewStats,
   WebhookRecord,
 } from "@dock/core"
-import { and, asc, count, desc, eq, inArray, isNull, lte, or, sql } from "drizzle-orm"
+import { and, asc, count, desc, eq, inArray, isNull, like, lt, lte, or, sql } from "drizzle-orm"
 import { type DrizzleD1Database, drizzle } from "drizzle-orm/d1"
 import {
   artifact,
@@ -152,9 +153,38 @@ export class D1MetaStore implements MetaStore {
     return res.meta.changes ?? 0
   }
 
-  async listArtifacts(opts?: { limit?: number }): Promise<ArtifactRecord[]> {
-    const q = this.db.select().from(artifact).orderBy(desc(artifact.created_at))
+  async listArtifacts(opts?: ListArtifactsOpts): Promise<ArtifactRecord[]> {
+    if (opts?.ids && opts.ids.length === 0) return []
+    const conds = []
+    if (opts?.q) conds.push(like(sql`lower(${artifact.title})`, `%${opts.q.toLowerCase()}%`))
+    if (opts?.cursor) conds.push(lt(artifact.created_at, opts.cursor))
+    if (opts?.ids) conds.push(inArray(artifact.id, opts.ids))
+    const q = this.db
+      .select()
+      .from(artifact)
+      .where(conds.length ? and(...conds) : undefined)
+      .orderBy(desc(artifact.created_at))
     return (opts?.limit ? q.limit(opts.limit) : q).all()
+  }
+  async artifactIdsByTag(tag: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ id: artifactTag.artifact_id })
+      .from(artifactTag)
+      .where(eq(artifactTag.tag, tag))
+      .all()
+    return rows.map((r) => r.id)
+  }
+  async countArtifacts(): Promise<number> {
+    const r = await this.db.select({ c: count() }).from(artifact).get()
+    return r?.c ?? 0
+  }
+  async tagCounts(): Promise<{ tag: string; count: number }[]> {
+    return this.db
+      .select({ tag: artifactTag.tag, count: count() })
+      .from(artifactTag)
+      .groupBy(artifactTag.tag)
+      .orderBy(asc(artifactTag.tag))
+      .all()
   }
 
   async recordView(v: NewView): Promise<void> {

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -5,6 +5,7 @@ import type {
   CommentState,
   DeliveryRecord,
   DeliveryStatus,
+  ListArtifactsOpts,
   MembershipRecord,
   MetaStore,
   NewArtifact,
@@ -23,7 +24,7 @@ import type {
   ViewStats,
   WebhookRecord,
 } from "@dock/core"
-import { and, asc, count, desc, eq, inArray, isNull, lte, or } from "drizzle-orm"
+import { and, asc, count, desc, eq, inArray, isNull, like, lt, lte, or, sql } from "drizzle-orm"
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres"
 import { Pool } from "pg"
 import {
@@ -153,9 +154,37 @@ export class PgMetaStore implements MetaStore {
     return rows.length
   }
 
-  listArtifacts(opts?: { limit?: number }): Promise<ArtifactRecord[]> {
-    const q = this.db.select().from(artifact).orderBy(desc(artifact.created_at))
+  listArtifacts(opts?: ListArtifactsOpts): Promise<ArtifactRecord[]> {
+    if (opts?.ids && opts.ids.length === 0) return Promise.resolve([])
+    const conds = []
+    if (opts?.q) conds.push(like(sql`lower(${artifact.title})`, `%${opts.q.toLowerCase()}%`))
+    if (opts?.cursor) conds.push(lt(artifact.created_at, opts.cursor))
+    if (opts?.ids) conds.push(inArray(artifact.id, opts.ids))
+    const q = this.db
+      .select()
+      .from(artifact)
+      .where(conds.length ? and(...conds) : undefined)
+      .orderBy(desc(artifact.created_at))
     return opts?.limit ? q.limit(opts.limit) : q
+  }
+  async artifactIdsByTag(tag: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ id: artifactTag.artifact_id })
+      .from(artifactTag)
+      .where(eq(artifactTag.tag, tag))
+    return rows.map((r) => r.id)
+  }
+  async countArtifacts(): Promise<number> {
+    const rows = await this.db.select({ c: count() }).from(artifact)
+    return Number(rows[0]?.c ?? 0)
+  }
+  async tagCounts(): Promise<{ tag: string; count: number }[]> {
+    const rows = await this.db
+      .select({ tag: artifactTag.tag, count: count() })
+      .from(artifactTag)
+      .groupBy(artifactTag.tag)
+      .orderBy(asc(artifactTag.tag))
+    return rows.map((r) => ({ tag: r.tag, count: Number(r.count) }))
   }
 
   // ---- View analytics (raw: aggregation-heavy) ---------------------------

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -5,6 +5,7 @@ import type {
   CommentState,
   DeliveryRecord,
   DeliveryStatus,
+  ListArtifactsOpts,
   MembershipRecord,
   MetaStore,
   NewArtifact,
@@ -24,7 +25,7 @@ import type {
   WebhookRecord,
 } from "@dock/core"
 import Database from "better-sqlite3"
-import { and, asc, count, desc, eq, inArray, isNull, lte, or } from "drizzle-orm"
+import { and, asc, count, desc, eq, inArray, isNull, like, lt, lte, or, sql } from "drizzle-orm"
 import { type BetterSQLite3Database, drizzle } from "drizzle-orm/better-sqlite3"
 import {
   artifact,
@@ -159,9 +160,37 @@ export class SqliteMetaStore implements MetaStore {
     return res.changes
   }
 
-  async listArtifacts(opts?: { limit?: number }): Promise<ArtifactRecord[]> {
-    const q = this.db.select().from(artifact).orderBy(desc(artifact.created_at))
-    return opts?.limit ? q.limit(opts.limit).all() : q.all()
+  async listArtifacts(opts?: ListArtifactsOpts): Promise<ArtifactRecord[]> {
+    if (opts?.ids && opts.ids.length === 0) return []
+    const conds = []
+    if (opts?.q) conds.push(like(sql`lower(${artifact.title})`, `%${opts.q.toLowerCase()}%`))
+    if (opts?.cursor) conds.push(lt(artifact.created_at, opts.cursor))
+    if (opts?.ids) conds.push(inArray(artifact.id, opts.ids))
+    const rows = this.db
+      .select()
+      .from(artifact)
+      .where(conds.length ? and(...conds) : undefined)
+      .orderBy(desc(artifact.created_at))
+    return opts?.limit ? rows.limit(opts.limit).all() : rows.all()
+  }
+  async artifactIdsByTag(tag: string): Promise<string[]> {
+    return this.db
+      .select({ id: artifactTag.artifact_id })
+      .from(artifactTag)
+      .where(eq(artifactTag.tag, tag))
+      .all()
+      .map((r) => r.id)
+  }
+  async countArtifacts(): Promise<number> {
+    return this.db.select({ c: count() }).from(artifact).get()?.c ?? 0
+  }
+  async tagCounts(): Promise<{ tag: string; count: number }[]> {
+    return this.db
+      .select({ tag: artifactTag.tag, count: count() })
+      .from(artifactTag)
+      .groupBy(artifactTag.tag)
+      .orderBy(asc(artifactTag.tag))
+      .all()
   }
 
   async recordView(v: NewView): Promise<void> {


### PR DESCRIPTION
Moves browse filtering to the **server** and lays down the **pagination primitive** that folders / notifications / etc. will reuse.

## API
- **`GET /v1/artifacts`** gains `?q=` (case-insensitive title search), `?tag=`, `?favorite=true`, and **keyset pagination** (`?cursor=<created_at>&limit=N`, default 30, cap 100) → `{ artifacts, next_cursor }`. `tag`/`favorite` resolve to an id set; newest-first; cursor is `created_at` (efficient, feed-friendly — what notifications will want).
- **`GET /v1/tags`** — browse summary: `{ total, favorites, tags: [{tag,count}] }`, so the sidebar stays accurate independent of the current page.

## Store (sqlite · postgres · d1)
`listArtifacts({ q, cursor, ids })` + `artifactIdsByTag` / `countArtifacts` / `tagCounts`.

## Web
The library drives search/filter off the server (debounced 280ms), appends pages via a **Load more** cursor, and builds the sidebar from the summary. Layout unchanged → still mobile-friendly.

## Notes
- "Basic" as asked: title search server-side; tag/favorite are exact filters; full-text/relevance can come later (roadmap C3).
- Rebased onto the **proposed-versions / review-flow** merge — both coexist (review counts live on the detail endpoint; the list stays a lean paginated feed).

## Verified
`biome ci` ✓ · `pnpm typecheck` ✓ · `pnpm test` ✓ (**api 73** — search, keyset pagination no-overlap, tag filter, summary). Server-side search confirmed live on a 390px mobile viewport (sidebar counts from summary, debounced `q` → server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)