### PR TITLE
Single-container self-host: one image serves the whole app

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,103 +1,63 @@
 # Deploying Dock
 
-Two supported shapes. Pick one.
+One image, two shapes:
 
-1. **Hosted split** (scales): web SPA on a CDN, API container, managed Postgres, S3/R2 blobs.
-2. **Single container** (simplest): one box, SQLite + local disk on a persistent volume.
-
-The same image and code serve both. Everything is driven by env vars; nothing is required for the single-container path.
-
----
-
-## Shape 1: Hosted split
-
-```
-  browser
-    |
-    |  app.example.com  (static SPA, Cloudflare Pages)
-    |  api.example.com  (Dock container: Fly / Hetzner / any host)
-    v
-  Postgres (Neon)        <- metadata: artifacts, versions, comments, users
-  S3 / R2                <- blobs: artifact bytes (zero egress on R2)
-```
-
-### 1. Provision data
-
-- **Postgres**: create a database (Neon, RDS, Supabase, self-hosted). Copy its `DATABASE_URL`.
-- **Object storage**: create an S3 or R2 bucket plus an access key pair. Build the connection URL:
-  - R2: `s3://<key>:<secret>@<account>.r2.cloudflarestorage.com/<bucket>?region=auto`
-  - S3: `s3://<key>:<secret>@s3.<region>.amazonaws.com/<bucket>?region=<region>`
-
-### 2. Deploy the API container
-
-Fly is the reference; any container host works (the image is plain `node:22-slim`).
-
-```bash
-# from the repo root
-fly launch --config deploy/fly.toml --dockerfile deploy/Dockerfile --no-deploy
-
-fly secrets set \
-  DATABASE_URL='postgres://...' \
-  OBJECT_STORE_URL='s3://...' \
-  DOCK_AUTH_SECRET="$(openssl rand -hex 32)" \
-  BASE_URL='https://api.example.com' \
-  DOCK_WEB_ORIGIN='https://app.example.com' \
-  DOCK_CROSS_SITE='true'
-
-fly deploy --config deploy/fly.toml --dockerfile deploy/Dockerfile
-```
-
-With `DATABASE_URL` + `OBJECT_STORE_URL` set the container holds no state: scale it
-horizontally and remove the `[mounts]` volume from `fly.toml`.
-
-`DOCK_CROSS_SITE=true` makes the session cookie `SameSite=None; Secure` so it rides
-the cross origin SPA to API request. `DOCK_WEB_ORIGIN` allow lists the SPA for CORS.
-
-### 3. Deploy the web SPA (Cloudflare Pages)
-
-Connect the repo in the Cloudflare dashboard, or use Wrangler:
-
-```bash
-pnpm --filter @dock/web build      # VITE_DOCK_API is baked in at build time
-npx wrangler pages deploy apps/web/dist/client --project-name dock
-```
-
-Build settings (dashboard):
-
-| Setting | Value |
-|---|---|
-| Build command | `pnpm --filter @dock/web build` |
-| Output directory | `apps/web/dist/client` |
-| Environment variable | `VITE_DOCK_API = https://api.example.com` |
-
-`apps/web/public/_redirects` already ships the SPA fallback (`/* /index.html 200`).
-
-### 4. OAuth / SSO redirect URIs (optional)
-
-If you set `GOOGLE_*` or `OIDC_*` secrets, register the callback with the provider:
-
-```
-https://api.example.com/api/auth/callback/google
-https://api.example.com/api/auth/oauth2/callback/<OIDC_PROVIDER_ID>
-```
+1. **Single container** (start here): one box runs the API *and* the web app on one
+   origin, with SQLite + local blobs on a mounted volume. No CORS, no external services.
+2. **Scale-out split**: web SPA on a CDN, stateless API containers, managed Postgres,
+   S3/R2 blobs. Same image — just add env vars.
 
 ---
 
-## Shape 2: Single container
+## Single container
 
-No external services. SQLite and local blobs live in one mounted volume.
+One command gives you a complete, working Dock — sign-in, publish, comments, reviews,
+notifications, the sandboxed viewer — all served from `http://localhost:8080`.
 
 ```bash
-docker build -f deploy/Dockerfile -t dock-api .
+docker build -f deploy/Dockerfile -t dock .
+
 docker run -d -p 8080:8080 -v dock_data:/data \
   -e DOCK_AUTH_SECRET="$(openssl rand -hex 32)" \
-  -e BASE_URL='https://dock.example.com' \
-  dock-api
+  -e BASE_URL="https://dock.example.com" \
+  dock
 ```
 
-Or `docker compose -f deploy/compose.yml up`. Put a TLS terminating proxy in front and
-point a domain at it. The SPA can be served same origin via the dev proxy, or hosted
-separately as in Shape 1 with `VITE_DOCK_API` pointed back at this container.
+Or with Compose:
+
+```bash
+docker compose -f deploy/compose.yml up -d
+```
+
+That's the whole thing. The image bundles the built SPA and the API serves it
+same-origin, so there's nothing else to host. State (SQLite + artifact blobs) lives
+in the `/data` volume — back that up and you've backed up the instance.
+
+- **`BASE_URL`** is the public origin you'll reach it at. It signs auth cookies and
+  builds artifact share links, so set it to your real URL (behind a proxy, the
+  `https://…` domain — not `localhost`).
+- **`DOCK_AUTH_SECRET`** signs sessions. Set it (any 32-byte hex). If you don't, the
+  container generates one and persists it in the volume, so logins survive restarts —
+  but an explicit secret is what you want in production.
+
+### Put it on the internet
+
+Point a TLS-terminating proxy at the container and a domain at the proxy. Caddy is the
+shortest path:
+
+```caddyfile
+dock.example.com {
+  reverse_proxy localhost:8080
+}
+```
+
+Cloudflare Tunnel, nginx, or any host's built-in HTTPS works the same way. Then set
+`BASE_URL=https://dock.example.com` and you're live.
+
+### First user
+
+The first person to sign up becomes the workspace **owner**; everyone after joins at
+the default role. Sign up at `/login`.
 
 ---
 
@@ -105,14 +65,85 @@ separately as in Shape 1 with `VITE_DOCK_API` pointed back at this container.
 
 | Var | Default | Purpose |
 |---|---|---|
-| `DATABASE_URL` | (SQLite) | Postgres for metadata + auth |
-| `OBJECT_STORE_URL` | (local disk) | S3/R2 blob storage |
-| `DOCK_AUTH_SECRET` | dev secret | Session signing key (set in prod) |
-| `BASE_URL` | `http://localhost:PORT` | Public origin of the API |
-| `DOCK_WEB_ORIGIN` | (none) | Comma separated web origins for CORS |
-| `DOCK_CROSS_SITE` | `false` | `true` for `SameSite=None; Secure` cookies |
-| `DOCK_TOKEN` | (none) | Static bearer token for CI/agents |
-| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | (none) | Google sign in |
-| `OIDC_ISSUER` / `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` / `OIDC_PROVIDER_ID` | (none) | Enterprise SSO |
+| `BASE_URL` | `http://localhost:PORT` | Public origin of the instance (cookies + share links) |
+| `DOCK_AUTH_SECRET` | generated, persisted | Session signing key (set in prod) |
 | `PORT` | `8080` | Listen port |
-| `DATA_DIR` | `./data` | SQLite + blob dir (single container) |
+| `DATA_DIR` | `/data` | SQLite + blob dir (single container) |
+| `DATABASE_URL` | (SQLite) | Postgres for metadata + auth (scale-out) |
+| `OBJECT_STORE_URL` | (local disk) | S3/R2 blob storage (scale-out) |
+| `DOCK_WEB_ORIGIN` | (none) | Comma-separated web origins for CORS (split deploy only) |
+| `DOCK_CROSS_SITE` | `false` | `true` for `SameSite=None; Secure` cookies (split deploy only) |
+| `DOCK_TOKEN` | (none) | Static bearer token for CI/agents |
+| `DOCK_WEB_DIR` | (auto) | Override the bundled SPA path |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | (none) | Google sign-in |
+| `OIDC_ISSUER` / `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` / `OIDC_PROVIDER_ID` | (none) | Enterprise SSO |
+
+### OAuth / SSO (optional)
+
+If you set `GOOGLE_*` or `OIDC_*`, register the callback with the provider:
+
+```
+https://dock.example.com/api/auth/callback/google
+https://dock.example.com/api/auth/oauth2/callback/<OIDC_PROVIDER_ID>
+```
+
+---
+
+## Scale-out split
+
+When one box isn't enough: put Postgres + object storage behind the API and the
+container holds no state — run as many as you like. Optionally serve the SPA from a CDN
+on its own origin (then it's a cross-origin call, hence the CORS + cookie vars).
+
+```
+  browser
+    |  app.example.com   static SPA on a CDN (optional — the container also serves it)
+    |  api.example.com   Dock container(s): Fly / Hetzner / any host
+    v
+  Postgres (Neon, RDS, Supabase, self-hosted)   <- artifacts, versions, comments, users
+  S3 / R2                                        <- artifact blobs (zero egress on R2)
+```
+
+### 1. Provision data
+
+- **Postgres**: create a database, copy its `DATABASE_URL`.
+- **Object storage**: create an S3/R2 bucket + access key pair, build the URL:
+  - R2: `s3://<key>:<secret>@<account>.r2.cloudflarestorage.com/<bucket>?region=auto`
+  - S3: `s3://<key>:<secret>@s3.<region>.amazonaws.com/<bucket>?region=<region>`
+
+### 2. Deploy the API (Fly is the reference; any container host works)
+
+```bash
+fly launch --config deploy/fly.toml --dockerfile deploy/Dockerfile --no-deploy
+
+fly secrets set \
+  DATABASE_URL='postgres://...' \
+  OBJECT_STORE_URL='s3://...' \
+  DOCK_AUTH_SECRET="$(openssl rand -hex 32)" \
+  BASE_URL='https://api.example.com'
+
+fly deploy --config deploy/fly.toml --dockerfile deploy/Dockerfile
+```
+
+With `DATABASE_URL` + `OBJECT_STORE_URL` set the container is stateless: scale it
+horizontally and drop the `[mounts]` volume from `fly.toml`. Each instance must share
+the same `DOCK_AUTH_SECRET`.
+
+### 3. (Optional) Serve the SPA from a CDN
+
+The container already serves the web app, so this is only for putting it on a separate
+cache/origin. Build with the API origin baked in and add the CORS vars to the API:
+
+```bash
+VITE_DOCK_API='https://api.example.com' pnpm --filter @dock/web build
+npx wrangler pages deploy apps/web/dist/client --project-name dock
+```
+
+```bash
+# on the API:
+fly secrets set DOCK_WEB_ORIGIN='https://app.example.com' DOCK_CROSS_SITE='true'
+```
+
+`DOCK_CROSS_SITE=true` makes the session cookie `SameSite=None; Secure` so it rides the
+cross-origin SPA→API request; `DOCK_WEB_ORIGIN` allow-lists the SPA for CORS.
+`apps/web/public/_redirects` already ships the SPA fallback.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -121,6 +121,12 @@ export interface AppDeps {
   defaultRole?: Role
   /** In-memory per-IP rate limiting on auth + mutating routes. Off by default. */
   rateLimit?: boolean
+  /**
+   * The web SPA is served from this same process (single-container self-host).
+   * When true, the bare `/` placeholder is dropped so the bundled SPA's index
+   * owns the app shell; the Node entry wires the static + fallback middleware.
+   */
+  serveWeb?: boolean
 }
 
 /** The single workspace (multi-workspace is a later layer). */
@@ -348,15 +354,18 @@ export function createApp(deps: AppDeps): Hono {
 
   app.get("/healthz", (c) => c.json({ ok: true }))
 
-  app.get("/", (c) =>
-    c.html(
-      `<!doctype html><meta charset="utf-8"><title>Dock</title>
+  // A minimal API-origin landing. Skipped when the SPA is bundled in-process
+  // (serveWeb) so the app's own home page owns `/`.
+  if (!deps.serveWeb)
+    app.get("/", (c) =>
+      c.html(
+        `<!doctype html><meta charset="utf-8"><title>Dock</title>
 <body style="font:16px/1.6 system-ui;background:#f6f0e3;color:#2a2540;display:grid;place-items:center;height:100vh;margin:0">
 <div style="text-align:center"><h1 style="letter-spacing:-.02em">Dock</h1>
 <p>An open home for AI-generated artifacts.<br>
 <code style="background:#eee7d6;padding:2px 8px;border-radius:6px">dock publish ./your-thing</code></p></div>`,
-    ),
-  )
+      ),
+    )
 
   app.get("/v1/me", async (c) => {
     const u = await currentUser(c)

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -1,12 +1,13 @@
 import { randomBytes } from "node:crypto"
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
-import { join } from "node:path"
+import { join, relative, resolve } from "node:path"
 import type { BlobStore, MetaStore } from "@dock/core"
 import { PgMetaStore } from "@dock/db/pg"
 import { SqliteMetaStore } from "@dock/db/sqlite"
 import { FsBlobStore } from "@dock/storage/fs"
 import { s3FromUrl } from "@dock/storage/s3"
 import { serve } from "@hono/node-server"
+import { serveStatic } from "@hono/node-server/serve-static"
 import Database from "better-sqlite3"
 import { Pool } from "pg"
 import { createApp } from "./app"
@@ -17,6 +18,18 @@ const PORT = Number(process.env.PORT ?? 8080)
 const DATA_DIR = process.env.DATA_DIR ?? "./data"
 const BASE_URL = process.env.BASE_URL ?? `http://localhost:${PORT}`
 const DATABASE_URL = process.env.DATABASE_URL
+
+// Single-container self-host: when the web SPA has been built (Docker image, or
+// `pnpm --filter @dock/web build` locally), this same process serves it so the
+// whole app lives at one origin — no CDN, no CORS, no cross-site cookies.
+// DOCK_WEB_DIR overrides; default is the build output relative to this file.
+const WEB_DIR = resolve(
+  process.env.DOCK_WEB_DIR ?? join(import.meta.dirname, "../../web/dist/client"),
+)
+// TanStack Start's SPA build emits `_shell.html` (the prerendered shell every
+// route hydrates from), not index.html.
+const WEB_SHELL = join(WEB_DIR, "_shell.html")
+const SERVE_WEB = existsSync(WEB_SHELL)
 
 mkdirSync(join(DATA_DIR, "blobs"), { recursive: true })
 
@@ -79,10 +92,29 @@ const app = createApp({
   webOrigins,
   analytics: process.env.DOCK_ANALYTICS !== "false",
   rateLimit: process.env.DOCK_RATE_LIMIT !== "false",
+  serveWeb: SERVE_WEB,
   versionWindowMs: process.env.DOCK_VERSION_WINDOW
     ? Number(process.env.DOCK_VERSION_WINDOW) * 60_000
     : undefined,
 })
+
+// Serve the bundled SPA from this process (single-container self-host). The API
+// routes above always win; static assets are served by hash (immutable), and any
+// other GET that isn't an API/asset path falls back to index.html so the client
+// router can take over (deep links, refresh). serveStatic roots are cwd-relative.
+if (SERVE_WEB) {
+  const webRoot = relative(process.cwd(), WEB_DIR) || "."
+  const shellHtml = readFileSync(WEB_SHELL, "utf8")
+  app.use("/assets/*", serveStatic({ root: webRoot }))
+  // Root-level static files Vite emits (favicon, manifest, etc.).
+  app.get("/:file{[^/]+\\.[^/]+}", serveStatic({ root: webRoot }))
+  app.notFound((c) => {
+    const p = c.req.path
+    if (p.startsWith("/v1") || p.startsWith("/api") || p.startsWith("/raw") || p === "/healthz")
+      return c.json({ error: "not found" }, 404)
+    return c.html(shellHtml)
+  })
+}
 
 // The webhook outbox worker delivers queued events with retries + backoff.
 startWebhookWorker(meta)
@@ -95,5 +127,6 @@ serve({ fetch: app.fetch, port: PORT }, () => {
   console.log(`  meta:    ${metaDesc}`)
   console.log(`  blobs:   ${blobDesc}`)
   console.log(`  auth:    /api/auth/* (Better Auth)`)
+  console.log(`  web:     ${SERVE_WEB ? `bundled SPA at ${BASE_URL}` : "not bundled (API only)"}`)
   console.log(`  publish: dock publish <file|dir> --server ${BASE_URL}`)
 })

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -1164,3 +1164,23 @@ describe("server-side search + cursor pagination", () => {
     expect(r.tags.find((t: { tag: string }) => t.tag === "summaryfilter")?.count).toBe(1)
   })
 })
+
+describe("single-container web serving", () => {
+  it("serves the API landing at / by default", async () => {
+    const r = await app.request("/")
+    expect(r.status).toBe(200)
+    expect(await r.text()).toContain("open home for AI-generated artifacts")
+  })
+
+  it("drops the / placeholder when serveWeb is set, so the bundled SPA owns the shell", async () => {
+    const webApp = createApp({
+      meta,
+      blobs: new FsBlobStore(join(dir, "blobs")),
+      baseUrl: "http://dock.test",
+      serveWeb: true,
+    })
+    // No placeholder here; the Node entry's static + index.html fallback (added
+    // around createApp when a build is present) is what answers `/` in prod.
+    expect((await webApp.request("/")).status).toBe(404)
+  })
+})

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,5 +1,6 @@
-# Dock API container — serves the publish API, comment loop, and sandboxed
-# artifact viewer. The web SPA deploys separately to a CDN (see DEPLOY.md).
+# Dock — one self-contained container: the publish API, comment + review loops,
+# the sandboxed artifact viewer, AND the web app, all on one origin. Point a
+# domain at it and you have a working Dock. (Scale-out split: see DEPLOY.md.)
 FROM node:22-slim AS base
 ENV CI=true
 RUN corepack enable
@@ -7,6 +8,13 @@ WORKDIR /app
 COPY . .
 # better-sqlite3 v11 ships prebuilt binaries; pg is pure JS — no compiler needed.
 RUN pnpm install --frozen-lockfile --prod=false
+
+# Build the SPA into apps/web/dist/client. VITE_DOCK_API is intentionally unset
+# so the bundle calls the API same-origin (no CORS, no cross-site cookies). The
+# Node entry auto-detects this build and serves it. ipv4first keeps TanStack
+# Start's prerender loopback (server bind vs fetch) on the same address in the
+# slim image, which otherwise splits ::1 / 127.0.0.1 and ECONNREFUSEs.
+RUN NODE_OPTIONS=--dns-result-order=ipv4first pnpm --filter @dock/web build
 
 ENV NODE_ENV=production \
     PORT=8080 \

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -1,4 +1,5 @@
-# Default: zero external dependencies — sqlite + local blobs in one volume.
+# The whole app (API + web + sandboxed viewer) in one container: zero external
+# dependencies — SQLite + local blobs in one volume. Open http://localhost:8080.
 # Uncomment DATABASE_URL / OBJECT_STORE_URL to use Postgres + S3/R2 instead.
 services:
   dock:
@@ -11,6 +12,8 @@ services:
       - dock-data:/data
     environment:
       BASE_URL: http://localhost:8080
+      # Set a stable session secret in production (any 32-byte hex):
+      # DOCK_AUTH_SECRET: change-me
       # DATABASE_URL: postgres://...
       # OBJECT_STORE_URL: s3://...
 


### PR DESCRIPTION
## What

`docker run` now gives you a complete, working Dock at one URL — sign-in, publish, comments, reviews, notifications, the sandboxed viewer — all from a single container with SQLite + local blobs in a volume. No CDN, no CORS, no cross-site cookies, no external services.

```bash
docker build -f deploy/Dockerfile -t dock .
docker run -d -p 8080:8080 -v dock_data:/data \
  -e DOCK_AUTH_SECRET="$(openssl rand -hex 32)" \
  -e BASE_URL="https://dock.example.com" dock
```

## How

- **Node entry** (`apps/api/src/node.ts`): when a web build is present (auto-detected at `apps/web/dist/client`, or `DOCK_WEB_DIR`), the same process serves `/assets` + root static files and falls back to the SPA shell for client routes. API paths (`/v1`, `/api`, `/raw`, `/healthz`) still return JSON 404s. The SPA entry is TanStack Start's `_shell.html`.
- **App** (`apps/api/src/app.ts`): a `serveWeb` flag drops the bare `/` placeholder so the bundled SPA owns the app shell.
- **Dockerfile**: builds the SPA with `VITE_DOCK_API` unset (same-origin calls). `--dns-result-order=ipv4first` keeps TanStack Start's prerender loopback on one address in the slim image (it otherwise splits `::1` / `127.0.0.1` and `ECONNREFUSE`s).
- **DEPLOY.md**: now leads with the one-command single-container path as *the* self-host quickstart (Caddy one-liner for TLS); the scale-out split (Postgres + S3/R2 + optional CDN) is the advanced section. Same image for both.

## Verification

Built the image and ran it: boot log shows `web: bundled SPA at …`; `/`, `/login`, `/settings` serve the SPA, `/assets/*` serve static, `/v1/*` serve JSON (with JSON 404s), `/healthz` ok. End-to-end smoke in the container: publish → server viewer → raw render all 200. The SPA hydrates same-origin (login page renders). 82 API tests pass (2 new for the `serveWeb` gate); typecheck + biome clean.

## Not in this PR

Actually pushing it to a public host (Fly / Hetzner / a VPS) — that needs an account + domain. The image + guide make it a one-command step from here.