### PR TITLE
Agents: @mention an agent, it proposes for review

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto"
 import {
   type Action,
   type Actor,
+  type AgentRecord,
   ANCHOR_CLIENT_JS,
   type ArtifactRecord,
   approveProposal,
@@ -256,28 +257,45 @@ export function createApp(deps: AppDeps): Hono {
     const targetIds = mentions.map((m) => m.id).filter((mid) => mid !== actorId)
     if (targetIds.length === 0) return []
     const real = new Set((await meta.getUsers(targetIds)).map((u) => u.id))
+    // Registered agents are mentionable too; a mention of an agent lands in its
+    // pull inbox instead of a notification bell.
+    const agentIds = new Set((await meta.listAgents(WORKSPACE)).map((ag) => ag.id))
     const preview = previewOf(cm.body_md)
     const notified: string[] = []
     for (const m of mentions) {
-      if (m.id === actorId || !real.has(m.id)) continue
-      const row = {
-        id: newId("n"),
-        user_id: m.id,
-        actor: cm.author,
-        kind: "mention" as const,
-        artifact_id: a.id,
-        artifact_short_id: a.short_id,
-        artifact_title: a.title,
-        thread_id: cm.thread_id,
-        comment_id: cm.id,
-        preview,
+      if (m.id === actorId) continue
+      if (real.has(m.id)) {
+        const row = {
+          id: newId("n"),
+          user_id: m.id,
+          actor: cm.author,
+          kind: "mention" as const,
+          artifact_id: a.id,
+          artifact_short_id: a.short_id,
+          artifact_title: a.title,
+          thread_id: cm.thread_id,
+          comment_id: cm.id,
+          preview,
+        }
+        await meta.createNotification(row)
+        notified.push(m.name)
+        bus.publish(`u:${m.id}`, {
+          type: "notification",
+          notification: { ...row, read: 0, created_at: new Date().toISOString() },
+        })
+      } else if (agentIds.has(m.id)) {
+        await meta.createAgentMention({
+          id: newId("amn"),
+          agent_id: m.id,
+          artifact_id: a.id,
+          artifact_short_id: a.short_id,
+          comment_id: cm.id,
+          thread_id: cm.thread_id,
+          body: cm.body_md,
+          author: cm.author,
+        })
+        notified.push(m.name)
       }
-      await meta.createNotification(row)
-      notified.push(m.name)
-      bus.publish(`u:${m.id}`, {
-        type: "notification",
-        notification: { ...row, read: 0, created_at: new Date().toISOString() },
-      })
     }
     return notified
   }
@@ -305,6 +323,27 @@ export function createApp(deps: AppDeps): Hono {
     return s?.user ? { id: s.user.id, email: s.user.email, name: s.user.name ?? null } : null
   }
 
+  // A registered agent acting via its bearer token (memoized per request). An
+  // agent is a workspace principal: same authorization path as a member, with
+  // its own identity and (default commenter) role.
+  const agentCache = new WeakMap<Context, AgentRecord | null>()
+  const agentFor = async (c: Context): Promise<AgentRecord | null> => {
+    if (agentCache.has(c)) return agentCache.get(c) ?? null
+    const b = bearer(c)
+    const a = !b || (deps.token && b === deps.token) ? null : await meta.getAgentByToken(b)
+    agentCache.set(c, a)
+    return a
+  }
+
+  // The acting identity (agent or signed-in user) for authorship; null when
+  // anonymous. Agents author as their name, never spoofing a person.
+  const actingUser = async (c: Context): Promise<{ id: string; name: string } | null> => {
+    const ag = await agentFor(c)
+    if (ag) return { id: ag.id, name: ag.name }
+    const me = await currentUser(c)
+    return me ? { id: me.id, name: me.name ?? me.email } : null
+  }
+
   // ---- Authorization ----------------------------------------------------
   // One choke point: every gate resolves an Actor and asks can(). An unsecured
   // instance (no static token) trusts anonymous callers — zero-config self-host.
@@ -323,6 +362,11 @@ export function createApp(deps: AppDeps): Hono {
 
   const actorFor = async (c: Context, a: ArtifactRecord): Promise<Actor> => {
     if (deps.token && bearer(c) === deps.token) return { kind: "token" }
+    const ag = await agentFor(c)
+    if (ag) {
+      const am = await meta.getArtifactMember(a.id, ag.id)
+      return { kind: "user", userId: ag.id, artifactRole: am?.role ?? null, orgRole: ag.role, open }
+    }
     const me = await currentUser(c)
     if (!me) return { kind: "anon", open }
     const orgRole = await ensureMembership(me.id)
@@ -337,6 +381,8 @@ export function createApp(deps: AppDeps): Hono {
   /** The caller's role at the workspace level (creating artifacts, settings). */
   const workspaceRole = async (c: Context): Promise<Role | null> => {
     if (deps.token && bearer(c) === deps.token) return "owner"
+    const ag = await agentFor(c)
+    if (ag) return ag.role
     const me = await currentUser(c)
     if (!me) return open ? "owner" : null
     return ensureMembership(me.id)
@@ -374,23 +420,102 @@ export function createApp(deps: AppDeps): Hono {
     return c.json({ user: { ...u, role } })
   })
 
-  // Workspace member directory for the @mention picker. Signed-in (or open) only;
-  // optional ?q= filters by name/email prefix. Never exposes non-members.
+  // Workspace member directory for the @mention picker — people AND agents, so
+  // an agent can be @mentioned like anyone. Signed-in (or open) only; optional
+  // ?q= filters by name/email prefix. Never exposes non-members.
   app.get("/v1/users", async (c) => {
     if (!open && !(await currentUser(c)) && bearer(c) !== deps.token)
       return c.json({ error: "unauthenticated" }, 401)
     const members = await meta.listMemberships(WORKSPACE)
     const users = await meta.getUsers(members.map((m) => m.user_id))
     const q = (c.req.query("q") ?? "").trim().toLowerCase()
-    const filtered = q
-      ? users.filter(
-          (u) => (u.name ?? "").toLowerCase().includes(q) || u.email.toLowerCase().includes(q),
-        )
-      : users
-    filtered.sort((a, b) => (a.name ?? a.email).localeCompare(b.name ?? b.email))
+    const people = (
+      q
+        ? users.filter(
+            (u) => (u.name ?? "").toLowerCase().includes(q) || u.email.toLowerCase().includes(q),
+          )
+        : users
+    ).map((u) => ({ id: u.id, name: u.name ?? u.email, email: u.email, kind: "user" as const }))
+    const agents = (await meta.listAgents(WORKSPACE))
+      .filter((ag) => !q || ag.name.toLowerCase().includes(q))
+      .map((ag) => ({ id: ag.id, name: ag.name, email: "", kind: "agent" as const }))
+    const all = [...people, ...agents].sort((a, b) => a.name.localeCompare(b.name))
+    return c.json({ users: all })
+  })
+
+  // ---- Agents: registry (owner-managed) + the pull inbox -----------------
+  const agentJson = (a: AgentRecord) => ({
+    id: a.id,
+    name: a.name,
+    role: a.role,
+    created_at: a.created_at,
+  })
+
+  app.get("/v1/agents", async (c) => {
+    if (!(await workspaceCan(c, "manage"))) return c.json({ error: "forbidden" }, 403)
+    const agents = await meta.listAgents(WORKSPACE)
+    return c.json({ agents: agents.map(agentJson) })
+  })
+
+  // Create an agent + mint its token. The token is returned ONCE here; only its
+  // hash-free secret lives in the row, so store it now. Default role commenter
+  // (propose-only); editor is opt-in. Owner is never allowed for an agent.
+  app.post("/v1/agents", async (c) => {
+    if (!(await workspaceCan(c, "manage"))) return c.json({ error: "forbidden" }, 403)
+    const b = (await c.req.json().catch(() => ({}))) as { name?: unknown; role?: unknown }
+    const name = typeof b.name === "string" ? b.name.trim() : ""
+    if (!name) return c.json({ error: "name required" }, 400)
+    const role: Role =
+      b.role === "viewer" || b.role === "commenter" || b.role === "editor" ? b.role : "commenter"
+    const token = `dk_agt_${randomUUID().replace(/-/g, "")}${randomUUID().replace(/-/g, "")}`
+    try {
+      const agent = await meta.createAgent({
+        id: newId("ag"),
+        org_id: WORKSPACE,
+        name,
+        token,
+        role,
+      })
+      // The only place the token is ever exposed.
+      return c.json({ ...agentJson(agent), token }, 201)
+    } catch {
+      return c.json({ error: "an agent with that name already exists" }, 409)
+    }
+  })
+
+  app.delete("/v1/agents/:id", async (c) => {
+    if (!(await workspaceCan(c, "manage"))) return c.json({ error: "forbidden" }, 403)
+    await meta.deleteAgent(c.req.param("id"))
+    return c.body(null, 204)
+  })
+
+  // The agent's pull inbox: mentions awaiting a response. Auth = the agent's
+  // own bearer token. The agent reads context via the normal read endpoints,
+  // proposes/replies with this same token, then acks.
+  app.get("/v1/agent/inbox", async (c) => {
+    const agent = await agentFor(c)
+    if (!agent) return c.json({ error: "agent token required" }, 401)
+    const limit = Math.min(50, Math.max(1, Number(c.req.query("limit")) || 20))
+    const mentions = await meta.listPendingAgentMentions(agent.id, limit)
     return c.json({
-      users: filtered.map((u) => ({ id: u.id, name: u.name ?? u.email, email: u.email })),
+      agent: agentJson(agent),
+      mentions: mentions.map((m) => ({
+        id: m.id,
+        artifact: m.artifact_short_id,
+        comment_id: m.comment_id,
+        thread_id: m.thread_id,
+        body: m.body,
+        author: m.author,
+        created_at: m.created_at,
+      })),
     })
+  })
+
+  app.post("/v1/agent/mentions/:id/ack", async (c) => {
+    const agent = await agentFor(c)
+    if (!agent) return c.json({ error: "agent token required" }, 401)
+    const ok = await meta.ackAgentMention(agent.id, c.req.param("id"))
+    return ok ? c.json({ ok: true }) : c.json({ error: "not found" }, 404)
   })
 
   // Newest-first, keyset-paginated (?cursor=<created_at>&limit=N), with optional
@@ -801,8 +926,8 @@ export function createApp(deps: AppDeps): Hono {
       body.kind === "bundle" ||
       (bytes[0] === 0x50 && bytes[1] === 0x4b && (bytes[2] === 3 || bytes[2] === 5))
 
-    const me = await currentUser(c)
-    const author = me ? (me.name ?? me.email) : str(body.author) || "anonymous"
+    const acting = await actingUser(c)
+    const author = acting ? acting.name : str(body.author) || "anonymous"
     try {
       const { proposal } = await propose(meta, blobs, artifact.short_id, {
         bytes,
@@ -957,9 +1082,9 @@ export function createApp(deps: AppDeps): Hono {
           ? body.anchor
           : null
 
-    const me = await currentUser(c)
-    const author = me
-      ? (me.name ?? me.email)
+    const acting = await actingUser(c)
+    const author = acting
+      ? acting.name
       : typeof body.author === "string" && body.author
         ? body.author
         : "anonymous"
@@ -989,7 +1114,7 @@ export function createApp(deps: AppDeps): Hono {
       quote: quoteOf(created.anchor),
       thread_id: created.thread_id,
     })
-    const notified = await notifyMentions(artifact, created, mentions, me?.id ?? null)
+    const notified = await notifyMentions(artifact, created, mentions, acting?.id ?? null)
     if (notified.length)
       await notify(artifact, "comment.mention", {
         author: created.author,
@@ -1043,11 +1168,9 @@ export function createApp(deps: AppDeps): Hono {
     if (!cm || cm.artifact_id !== artifact.id) return { error: c.json({ error: "not found" }, 404) }
     return { artifact, cm }
   }
-  // The signed-in actor's display name, or null on an open (no-auth) instance.
-  const actorName = async (c: Context): Promise<string | null> => {
-    const me = await currentUser(c)
-    return me ? (me.name ?? me.email) : null
-  }
+  // The acting display name (agent or signed-in user); null on an open instance.
+  const actorName = async (c: Context): Promise<string | null> =>
+    (await actingUser(c))?.name ?? null
 
   // Toggle the current user's reaction (one of REACTIONS) on a comment.
   app.post("/v1/artifacts/:shortId/comments/:commentId/react", async (c) => {

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -718,6 +718,109 @@ const proposeAs = (
   return app.request(`/v1/artifacts/${shortId}/proposals`, { method: "POST", body: form, headers })
 }
 
+const bearer = (token: string) => ({ authorization: `Bearer ${token}` })
+
+describe("agents: @mention → pull inbox → propose → ack", () => {
+  const owner: TestUser = { id: "u_ag_own", email: "agown@dock.test", name: "Owner" }
+  const dev: TestUser = { id: "u_ag_dev", email: "agdev@dock.test", name: "Dev" }
+  const { app } = makeAuthedApp("agents", [owner, dev], "commenter")
+  let shortId: string
+  let agentId: string
+  let agentToken: string
+  let mentionId: string
+
+  it("an owner registers an agent and gets its token once; a commenter cannot", async () => {
+    // Provision roles in order: owner first (claims ownership), then dev (commenter).
+    await app.request("/v1/me", { headers: as(owner.email) })
+    await app.request("/v1/me", { headers: as(dev.email) })
+    expect((await app.request("/v1/agents", jsonAs(as(dev.email), { name: "Nope" }))).status).toBe(
+      403,
+    )
+    const res = await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Claude" }))
+    expect(res.status).toBe(201)
+    const a = await res.json()
+    agentId = a.id
+    agentToken = a.token
+    expect(a.role).toBe("commenter")
+    expect(typeof agentToken).toBe("string")
+  })
+
+  it("the agent shows up in the @mention directory", async () => {
+    const dir = await (await app.request("/v1/users?q=clau", { headers: as(owner.email) })).json()
+    expect(dir.users).toContainEqual(
+      expect.objectContaining({ id: agentId, name: "Claude", kind: "agent" }),
+    )
+  })
+
+  it("a comment @mentioning the agent lands in the agent's inbox, not a notification", async () => {
+    shortId = (await (await publishAs(app, "<h1>draft</h1>", {}, as(owner.email))).json()).short_id
+    const cm = await app.request(
+      `/v1/artifacts/${shortId}/comments`,
+      jsonAs(as(owner.email), {
+        body_md: "@Claude tighten the headline",
+        mentions: [{ id: agentId, name: "Claude" }],
+      }),
+    )
+    expect(cm.status).toBe(201)
+
+    // The agent pulls its inbox with its own token.
+    const inbox = await (
+      await app.request("/v1/agent/inbox", { headers: bearer(agentToken) })
+    ).json()
+    expect(inbox.agent.id).toBe(agentId)
+    expect(inbox.mentions).toHaveLength(1)
+    expect(inbox.mentions[0].artifact).toBe(shortId)
+    expect(inbox.mentions[0].body).toContain("tighten the headline")
+    mentionId = inbox.mentions[0].id
+  })
+
+  it("the agent proposes a candidate (commenter rank) authored as itself", async () => {
+    const res = await proposeAs(app, shortId, "<h1>A tighter headline</h1>", bearer(agentToken), {
+      message: "tightened per the mention",
+    })
+    expect(res.status).toBe(201)
+    const p = await res.json()
+    expect(p.author).toBe("Claude")
+    expect(p.state).toBe("open")
+    // It did NOT go live — a human still approves.
+    const art = await (
+      await app.request(`/v1/artifacts/${shortId}`, { headers: as(owner.email) })
+    ).json()
+    expect(art.current_version).toBe(1)
+    expect(art.open_proposals).toBe(1)
+  })
+
+  it("the agent cannot approve its own proposal (commenter, not editor)", async () => {
+    const open = await (
+      await app.request(`/v1/artifacts/${shortId}/proposals?state=open`, {
+        headers: as(owner.email),
+      })
+    ).json()
+    const pid = open.proposals[0].id
+    const res = await app.request(`/v1/artifacts/${shortId}/proposals/${pid}/approve`, {
+      method: "POST",
+      headers: bearer(agentToken),
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it("acking the mention clears it from the inbox", async () => {
+    const ack = await app.request(`/v1/agent/mentions/${mentionId}/ack`, {
+      method: "POST",
+      headers: bearer(agentToken),
+    })
+    expect(ack.status).toBe(200)
+    const inbox = await (
+      await app.request("/v1/agent/inbox", { headers: bearer(agentToken) })
+    ).json()
+    expect(inbox.mentions).toHaveLength(0)
+  })
+
+  it("the inbox rejects a non-agent caller", async () => {
+    expect((await app.request("/v1/agent/inbox", { headers: as(owner.email) })).status).toBe(401)
+  })
+})
+
 describe("reviews: propose → approve goes live; commenter can't approve", () => {
   const owner: TestUser = { id: "u_ro", email: "ro@dock.test", name: "Ro" }
   const cassie: TestUser = { id: "u_cassie", email: "cassie@dock.test", name: "Cassie" }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -125,6 +125,12 @@ export interface Webhook {
   active: 0 | 1
   created_at: string
 }
+export interface Agent {
+  id: string
+  name: string
+  role: Role
+  created_at: string
+}
 export interface Delivery {
   id: string
   event_type: string
@@ -255,6 +261,12 @@ export const api = {
     f(`/v1/artifacts/${id}/favorite`, { ...opts(), method: on ? "PUT" : "DELETE" }).then(j),
   setTags: (id: string, tags: string[]): Promise<{ tags: string[] }> =>
     f(`/v1/artifacts/${id}/tags`, { ...opts({ tags }), method: "PUT" }).then(j),
+
+  listAgents: (): Promise<{ agents: Agent[] }> => f("/v1/agents", opts()).then(j),
+  createAgent: (name: string, role?: Role): Promise<Agent & { token: string }> =>
+    f("/v1/agents", opts({ name, role })).then(j),
+  deleteAgent: (id: string): Promise<void> =>
+    f(`/v1/agents/${id}`, { method: "DELETE", credentials: "include" }).then(() => undefined),
 
   listWebhooks: (): Promise<{ webhooks: Webhook[] }> => f("/v1/webhooks", opts()).then(j),
   createWebhook: (body: {

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
-import { api, type Delivery, type Webhook } from "../api"
+import { type Agent, api, type Delivery, type Role, type Webhook } from "../api"
 import { Header, useToast } from "../components"
 import { useAuth } from "../ctx"
 
@@ -11,6 +11,7 @@ export function Settings() {
   const nav = useNavigate()
   const { toast, show } = useToast()
   const [hooks, setHooks] = useState<Webhook[] | null>(null)
+  const [agents, setAgents] = useState<Agent[] | null>(null)
 
   useEffect(() => {
     if (!loading && !me) nav({ to: "/login" })
@@ -20,8 +21,16 @@ export function Settings() {
       .listWebhooks()
       .then((r) => setHooks(r.webhooks))
       .catch(() => setHooks([]))
+  const loadAgents = () =>
+    api
+      .listAgents()
+      .then((r) => setAgents(r.agents))
+      .catch(() => setAgents([]))
   useEffect(() => {
-    if (me) load()
+    if (me) {
+      load()
+      loadAgents()
+    }
   }, [me])
 
   if (!me)
@@ -97,8 +106,213 @@ export function Settings() {
             )}
           </div>
         </section>
+
+        <section style={{ marginTop: 38 }}>
+          <div style={{ display: "flex", alignItems: "baseline", gap: 10, marginBottom: 4 }}>
+            <h3 className="display" style={{ fontSize: 16, margin: 0 }}>
+              Agents
+            </h3>
+            <span className="muted" style={{ fontSize: 13 }}>
+              · {agents?.length ?? 0}
+            </span>
+          </div>
+          <p className="muted" style={{ fontSize: 13, margin: "0 0 16px" }}>
+            Register an agent so people can <code className="mono">@mention</code> it in a thread.
+            It gets a scoped token and acts as a commenter — it can propose changes for review, but
+            a human still approves. The agent reads its mentions from{" "}
+            <code className="mono">GET /v1/agent/inbox</code> with its token.
+          </p>
+
+          <NewAgent
+            onCreated={(msg) => {
+              show(msg)
+              loadAgents()
+            }}
+          />
+
+          <div style={{ marginTop: 18, display: "flex", flexDirection: "column", gap: 11 }}>
+            {agents === null ? (
+              <div className="center" style={{ height: 80 }}>
+                <div className="spin" />
+              </div>
+            ) : agents.length === 0 ? (
+              <div
+                className="muted"
+                style={{
+                  textAlign: "center",
+                  padding: 28,
+                  border: "1px dashed var(--line)",
+                  borderRadius: 12,
+                  fontSize: 13,
+                }}
+              >
+                No agents yet. Add one above.
+              </div>
+            ) : (
+              agents.map((a) => (
+                <AgentRow
+                  key={a.id}
+                  agent={a}
+                  onChanged={(m) => {
+                    show(m)
+                    loadAgents()
+                  }}
+                  onError={show}
+                />
+              ))
+            )}
+          </div>
+        </section>
       </main>
       {toast}
+    </div>
+  )
+}
+
+function NewAgent({ onCreated }: { onCreated: (msg: string) => void }) {
+  const [name, setName] = useState("")
+  const [role, setRole] = useState<Role>("commenter")
+  const [busy, setBusy] = useState(false)
+  const [created, setCreated] = useState<{ name: string; token: string } | null>(null)
+
+  const add = async () => {
+    if (!name.trim()) return
+    setBusy(true)
+    try {
+      const a = await api.createAgent(name.trim(), role)
+      setCreated({ name: a.name, token: a.token })
+      setName("")
+      onCreated(`Agent ${a.name} created`)
+    } catch (e) {
+      onCreated((e as Error).message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="card" style={{ padding: 16 }}>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <input
+          className="input"
+          placeholder="Agent name (e.g. Claude)"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          style={{ flex: 1, minWidth: 180 }}
+        />
+        <select
+          className="input"
+          value={role}
+          onChange={(e) => setRole(e.target.value as Role)}
+          style={{ width: 150 }}
+        >
+          <option value="commenter">Commenter (propose)</option>
+          <option value="editor">Editor (publish)</option>
+        </select>
+        <button className="btn pri" onClick={add} disabled={busy || !name.trim()}>
+          {busy ? "Adding…" : "Add agent"}
+        </button>
+      </div>
+      {/* The token is shown exactly once, right after creation. */}
+      {created && (
+        <div
+          style={{
+            marginTop: 12,
+            padding: "11px 13px",
+            background: "var(--ac-soft)",
+            border: "1px solid var(--ac)",
+            borderRadius: 10,
+          }}
+        >
+          <div style={{ fontSize: 12.5, fontWeight: 600, marginBottom: 6 }}>
+            Token for {created.name} — copy it now, it won't be shown again.
+          </div>
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <code
+              className="mono"
+              style={{
+                flex: 1,
+                fontSize: 11.5,
+                wordBreak: "break-all",
+                background: "var(--card)",
+                padding: "7px 9px",
+                borderRadius: 7,
+                border: "1px solid var(--line)",
+              }}
+            >
+              {created.token}
+            </code>
+            <button
+              className="btn sm"
+              onClick={() => {
+                navigator.clipboard?.writeText(created.token)
+                onCreated("Token copied")
+              }}
+            >
+              Copy
+            </button>
+            <button className="btn sm" onClick={() => setCreated(null)}>
+              Done
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function AgentRow({
+  agent,
+  onChanged,
+  onError,
+}: {
+  agent: Agent
+  onChanged: (msg: string) => void
+  onError: (msg: string) => void
+}) {
+  const [busy, setBusy] = useState(false)
+  const remove = async () => {
+    if (!confirm(`Remove agent ${agent.name}? Its token stops working.`)) return
+    setBusy(true)
+    try {
+      await api.deleteAgent(agent.id)
+      onChanged(`Agent ${agent.name} removed`)
+    } catch (e) {
+      onError((e as Error).message)
+    } finally {
+      setBusy(false)
+    }
+  }
+  return (
+    <div
+      className="card"
+      style={{ padding: "12px 15px", display: "flex", alignItems: "center", gap: 12 }}
+    >
+      <span style={{ fontSize: 16 }}>🤖</span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 14, fontWeight: 600 }}>
+          @{agent.name}{" "}
+          <span
+            className="mono"
+            style={{
+              fontSize: 10,
+              fontWeight: 700,
+              color: "var(--ac)",
+              background: "var(--ac-soft)",
+              borderRadius: 999,
+              padding: "1px 7px",
+            }}
+          >
+            {agent.role}
+          </span>
+        </div>
+        <div className="muted" style={{ fontSize: 11.5 }}>
+          Mention it in any thread to send it work.
+        </div>
+      </div>
+      <button className="btn sm" onClick={remove} disabled={busy} title="Remove agent">
+        Remove
+      </button>
     </div>
   )
 }

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -183,6 +183,67 @@ export interface MetaStore {
   unreadNotificationCount(userId: string): Promise<number>
   /** Mark the given ids read, or all of the user's notifications when "all". */
   markNotificationsRead(userId: string, ids: string[] | "all"): Promise<void>
+
+  // ---- Agents (mentionable principals that act via a scoped token) -------
+  createAgent(a: NewAgent): Promise<AgentRecord>
+  listAgents(orgId: string): Promise<AgentRecord[]>
+  /** Resolve an agent from its bearer token (the agent's identity). */
+  getAgentByToken(token: string): Promise<AgentRecord | null>
+  deleteAgent(id: string): Promise<void>
+  /** Queue a mention into an agent's pull inbox. */
+  createAgentMention(m: NewAgentMention): Promise<void>
+  /** Pending (unhandled) mentions for an agent, oldest first. */
+  listPendingAgentMentions(agentId: string, limit: number): Promise<AgentMentionRecord[]>
+  /** Mark a mention handled; false if it isn't this agent's or doesn't exist. */
+  ackAgentMention(agentId: string, id: string): Promise<boolean>
+}
+
+/**
+ * A registered agent: a mentionable principal that acts through a scoped token.
+ * Default role is commenter, so an agent can propose but never publish directly
+ * — a human still approves. Treated like a member of the workspace.
+ */
+export interface AgentRecord {
+  id: string
+  org_id: string
+  name: string
+  token: string
+  role: Role
+  created_at: string
+}
+export interface NewAgent {
+  id: string
+  org_id: string
+  name: string
+  token: string
+  role: Role
+}
+
+export type AgentMentionState = "pending" | "done"
+/** A queued mention for an agent's pull inbox (denormalized for a cheap read). */
+export interface AgentMentionRecord {
+  id: string
+  agent_id: string
+  artifact_id: string
+  artifact_short_id: string
+  comment_id: string
+  thread_id: string
+  /** The body of the comment that mentioned the agent. */
+  body: string
+  /** Who mentioned it. */
+  author: string
+  state: AgentMentionState
+  created_at: string
+}
+export interface NewAgentMention {
+  id: string
+  agent_id: string
+  artifact_id: string
+  artifact_short_id: string
+  comment_id: string
+  thread_id: string
+  body: string
+  author: string
 }
 
 /**

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -1,5 +1,7 @@
 import type { D1Database } from "@cloudflare/workers-types"
 import type {
+  AgentMentionRecord,
+  AgentRecord,
   ArtifactMemberRecord,
   ArtifactRecord,
   CommentRecord,
@@ -9,6 +11,8 @@ import type {
   ListArtifactsOpts,
   MembershipRecord,
   MetaStore,
+  NewAgent,
+  NewAgentMention,
   NewArtifact,
   NewArtifactMember,
   NewComment,
@@ -30,6 +34,8 @@ import type {
 import { and, asc, count, desc, eq, inArray, isNull, like, lt, lte, or, sql } from "drizzle-orm"
 import { type DrizzleD1Database, drizzle } from "drizzle-orm/d1"
 import {
+  agent,
+  agentMention,
   artifact,
   artifactFavorite,
   artifactMember,
@@ -55,6 +61,8 @@ const schema = {
   artifactFavorite,
   artifactTag,
   proposal,
+  agent,
+  agentMention,
 }
 const VIEW_WINDOW_MS = 30 * 86400_000
 
@@ -510,5 +518,39 @@ export class D1MetaStore implements MetaStore {
           : null
     if (!where) return
     await this.db.update(notification).set({ read: 1 }).where(where).run()
+  }
+
+  // ---- Agents + their pull inbox -----------------------------------------
+  createAgent(a: NewAgent): Promise<AgentRecord> {
+    return this.db.insert(agent).values(a).returning().get()
+  }
+  listAgents(orgId: string): Promise<AgentRecord[]> {
+    return this.db.select().from(agent).where(eq(agent.org_id, orgId)).all()
+  }
+  async getAgentByToken(token: string): Promise<AgentRecord | null> {
+    return (await this.db.select().from(agent).where(eq(agent.token, token)).get()) ?? null
+  }
+  async deleteAgent(id: string): Promise<void> {
+    await this.db.delete(agent).where(eq(agent.id, id)).run()
+  }
+  async createAgentMention(m: NewAgentMention): Promise<void> {
+    await this.db.insert(agentMention).values(m).run()
+  }
+  listPendingAgentMentions(agentId: string, limit: number): Promise<AgentMentionRecord[]> {
+    return this.db
+      .select()
+      .from(agentMention)
+      .where(and(eq(agentMention.agent_id, agentId), eq(agentMention.state, "pending")))
+      .orderBy(asc(agentMention.created_at))
+      .limit(limit)
+      .all()
+  }
+  async ackAgentMention(agentId: string, id: string): Promise<boolean> {
+    const res = await this.db
+      .update(agentMention)
+      .set({ state: "done" })
+      .where(and(eq(agentMention.id, id), eq(agentMention.agent_id, agentId)))
+      .run()
+    return (res.meta.changes ?? 0) > 0
   }
 }

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -1,4 +1,7 @@
 import type {
+  AgentMentionRecord,
+  AgentMentionState,
+  AgentRecord,
   ArtifactKind,
   ArtifactMemberRecord,
   ArtifactRecord,
@@ -136,6 +139,35 @@ export const notification = pgTable("notification", {
   created_at: text("created_at").notNull().$defaultFn(isoNow),
 })
 
+export const agent = pgTable(
+  "agent",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    name: text("name").notNull(),
+    token: text("token").notNull(),
+    role: text("role").$type<Role>().notNull().default("commenter"),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [
+    uniqueIndex("agent_token").on(t.token),
+    uniqueIndex("agent_org_name").on(t.org_id, t.name),
+  ],
+)
+
+export const agentMention = pgTable("agent_mention", {
+  id: text("id").primaryKey(),
+  agent_id: text("agent_id").notNull(),
+  artifact_id: text("artifact_id").notNull(),
+  artifact_short_id: text("artifact_short_id").notNull(),
+  comment_id: text("comment_id").notNull(),
+  thread_id: text("thread_id").notNull(),
+  body: text("body").notNull(),
+  author: text("author").notNull(),
+  state: text("state").$type<AgentMentionState>().notNull().default("pending"),
+  created_at: text("created_at").notNull().$defaultFn(isoNow),
+})
+
 export const artifactFavorite = pgTable(
   "artifact_favorite",
   {
@@ -194,7 +226,9 @@ const _pgParity: [
   Exact<typeof artifactMember.$inferSelect, ArtifactMemberRecord>,
   Exact<typeof notification.$inferSelect, NotificationRecord>,
   Exact<typeof proposal.$inferSelect, ProposalRecord>,
-] = [true, true, true, true, true, true, true, true, true]
+  Exact<typeof agent.$inferSelect, AgentRecord>,
+  Exact<typeof agentMention.$inferSelect, AgentMentionRecord>,
+] = [true, true, true, true, true, true, true, true, true, true, true]
 void _pgParity
 
 // Boot DDL (idempotent). created_at uses a SQL default as a server-side backstop.
@@ -319,6 +353,29 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
     created_at TEXT NOT NULL DEFAULT ${isoDefault}
   )`,
   `CREATE INDEX IF NOT EXISTS notification_user_time ON notification (user_id, created_at)`,
+  `CREATE TABLE IF NOT EXISTS agent (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    token TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'commenter',
+    created_at TEXT NOT NULL DEFAULT ${isoDefault},
+    UNIQUE (token),
+    UNIQUE (org_id, name)
+  )`,
+  `CREATE TABLE IF NOT EXISTS agent_mention (
+    id TEXT PRIMARY KEY,
+    agent_id TEXT NOT NULL,
+    artifact_id TEXT NOT NULL,
+    artifact_short_id TEXT NOT NULL,
+    comment_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    author TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'pending',
+    created_at TEXT NOT NULL DEFAULT ${isoDefault}
+  )`,
+  `CREATE INDEX IF NOT EXISTS agent_mention_inbox ON agent_mention (agent_id, state, created_at)`,
   `CREATE TABLE IF NOT EXISTS artifact_favorite (
     id TEXT PRIMARY KEY,
     artifact_id TEXT NOT NULL REFERENCES artifact(id),

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1,4 +1,6 @@
 import type {
+  AgentMentionRecord,
+  AgentRecord,
   ArtifactMemberRecord,
   ArtifactRecord,
   CommentRecord,
@@ -8,6 +10,8 @@ import type {
   ListArtifactsOpts,
   MembershipRecord,
   MetaStore,
+  NewAgent,
+  NewAgentMention,
   NewArtifact,
   NewArtifactMember,
   NewComment,
@@ -30,6 +34,8 @@ import { and, asc, count, desc, eq, inArray, isNull, like, lt, lte, or, sql } fr
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres"
 import { Pool } from "pg"
 import {
+  agent,
+  agentMention,
   artifact,
   artifactFavorite,
   artifactMember,
@@ -56,6 +62,8 @@ const schema = {
   artifactFavorite,
   artifactTag,
   proposal,
+  agent,
+  agentMention,
 }
 const VIEW_WINDOW_MS = 30 * 86400_000
 
@@ -499,6 +507,41 @@ export class PgMetaStore implements MetaStore {
           : null
     if (!where) return
     await this.db.update(notification).set({ read: 1 }).where(where)
+  }
+
+  // ---- Agents + their pull inbox -----------------------------------------
+  async createAgent(a: NewAgent): Promise<AgentRecord> {
+    const rows = await this.db.insert(agent).values(a).returning()
+    return rows[0]
+  }
+  listAgents(orgId: string): Promise<AgentRecord[]> {
+    return this.db.select().from(agent).where(eq(agent.org_id, orgId))
+  }
+  async getAgentByToken(token: string): Promise<AgentRecord | null> {
+    const rows = await this.db.select().from(agent).where(eq(agent.token, token))
+    return rows[0] ?? null
+  }
+  async deleteAgent(id: string): Promise<void> {
+    await this.db.delete(agent).where(eq(agent.id, id))
+  }
+  async createAgentMention(m: NewAgentMention): Promise<void> {
+    await this.db.insert(agentMention).values(m)
+  }
+  listPendingAgentMentions(agentId: string, limit: number): Promise<AgentMentionRecord[]> {
+    return this.db
+      .select()
+      .from(agentMention)
+      .where(and(eq(agentMention.agent_id, agentId), eq(agentMention.state, "pending")))
+      .orderBy(asc(agentMention.created_at))
+      .limit(limit)
+  }
+  async ackAgentMention(agentId: string, id: string): Promise<boolean> {
+    const rows = await this.db
+      .update(agentMention)
+      .set({ state: "done" })
+      .where(and(eq(agentMention.id, id), eq(agentMention.agent_id, agentId)))
+      .returning({ id: agentMention.id })
+    return rows.length > 0
   }
 
   async close(): Promise<void> {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,4 +1,7 @@
 import type {
+  AgentMentionRecord,
+  AgentMentionState,
+  AgentRecord,
   ArtifactKind,
   ArtifactMemberRecord,
   ArtifactRecord,
@@ -136,6 +139,37 @@ export const notification = sqliteTable("notification", {
   comment_id: text("comment_id").notNull(),
   preview: text("preview").notNull(),
   read: integer("read").$type<0 | 1>().notNull().default(0),
+  created_at: text("created_at").notNull().default(now),
+})
+
+// A registered agent: a mentionable principal that acts via a scoped token.
+export const agent = sqliteTable(
+  "agent",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    name: text("name").notNull(),
+    token: text("token").notNull(),
+    role: text("role").$type<Role>().notNull().default("commenter"),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [
+    uniqueIndex("agent_token").on(t.token),
+    uniqueIndex("agent_org_name").on(t.org_id, t.name),
+  ],
+)
+
+// An agent's pull inbox: one row per mention directed at the agent.
+export const agentMention = sqliteTable("agent_mention", {
+  id: text("id").primaryKey(),
+  agent_id: text("agent_id").notNull(),
+  artifact_id: text("artifact_id").notNull(),
+  artifact_short_id: text("artifact_short_id").notNull(),
+  comment_id: text("comment_id").notNull(),
+  thread_id: text("thread_id").notNull(),
+  body: text("body").notNull(),
+  author: text("author").notNull(),
+  state: text("state").$type<AgentMentionState>().notNull().default("pending"),
   created_at: text("created_at").notNull().default(now),
 })
 
@@ -312,6 +346,29 @@ export const SCHEMA_STATEMENTS: string[] = [
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
   )`,
   `CREATE INDEX IF NOT EXISTS notification_user_time ON notification (user_id, created_at)`,
+  `CREATE TABLE IF NOT EXISTS agent (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    token TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'commenter',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (token),
+    UNIQUE (org_id, name)
+  )`,
+  `CREATE TABLE IF NOT EXISTS agent_mention (
+    id TEXT PRIMARY KEY,
+    agent_id TEXT NOT NULL,
+    artifact_id TEXT NOT NULL,
+    artifact_short_id TEXT NOT NULL,
+    comment_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    author TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'pending',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  )`,
+  `CREATE INDEX IF NOT EXISTS agent_mention_inbox ON agent_mention (agent_id, state, created_at)`,
   `CREATE TABLE IF NOT EXISTS artifact_favorite (
     id TEXT PRIMARY KEY,
     artifact_id TEXT NOT NULL REFERENCES artifact(id),
@@ -373,5 +430,7 @@ const _schemaParity: [
   Exact<typeof artifactMember.$inferSelect, ArtifactMemberRecord>,
   Exact<typeof notification.$inferSelect, NotificationRecord>,
   Exact<typeof proposal.$inferSelect, ProposalRecord>,
-] = [true, true, true, true, true, true, true, true, true]
+  Exact<typeof agent.$inferSelect, AgentRecord>,
+  Exact<typeof agentMention.$inferSelect, AgentMentionRecord>,
+] = [true, true, true, true, true, true, true, true, true, true, true]
 void _schemaParity

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -1,4 +1,6 @@
 import type {
+  AgentMentionRecord,
+  AgentRecord,
   ArtifactMemberRecord,
   ArtifactRecord,
   CommentRecord,
@@ -8,6 +10,8 @@ import type {
   ListArtifactsOpts,
   MembershipRecord,
   MetaStore,
+  NewAgent,
+  NewAgentMention,
   NewArtifact,
   NewArtifactMember,
   NewComment,
@@ -30,6 +34,8 @@ import Database from "better-sqlite3"
 import { and, asc, count, desc, eq, inArray, isNull, like, lt, lte, or, sql } from "drizzle-orm"
 import { type BetterSQLite3Database, drizzle } from "drizzle-orm/better-sqlite3"
 import {
+  agent,
+  agentMention,
   artifact,
   artifactFavorite,
   artifactMember,
@@ -59,6 +65,8 @@ const schema = {
   artifactFavorite,
   artifactTag,
   proposal,
+  agent,
+  agentMention,
 }
 
 /** Embedded SQLite (WAL). The zero-dependency default; no external services. */
@@ -534,6 +542,42 @@ export class SqliteMetaStore implements MetaStore {
           : null
     if (!where) return
     this.db.update(notification).set({ read: 1 }).where(where).run()
+  }
+
+  // ---- Agents + their pull inbox -----------------------------------------
+  createAgent(a: NewAgent): Promise<AgentRecord> {
+    return Promise.resolve(this.db.insert(agent).values(a).returning().get())
+  }
+  listAgents(orgId: string): Promise<AgentRecord[]> {
+    return Promise.resolve(this.db.select().from(agent).where(eq(agent.org_id, orgId)).all())
+  }
+  async getAgentByToken(token: string): Promise<AgentRecord | null> {
+    return this.db.select().from(agent).where(eq(agent.token, token)).get() ?? null
+  }
+  async deleteAgent(id: string): Promise<void> {
+    this.db.delete(agent).where(eq(agent.id, id)).run()
+  }
+  async createAgentMention(m: NewAgentMention): Promise<void> {
+    this.db.insert(agentMention).values(m).run()
+  }
+  listPendingAgentMentions(agentId: string, limit: number): Promise<AgentMentionRecord[]> {
+    return Promise.resolve(
+      this.db
+        .select()
+        .from(agentMention)
+        .where(and(eq(agentMention.agent_id, agentId), eq(agentMention.state, "pending")))
+        .orderBy(asc(agentMention.created_at))
+        .limit(limit)
+        .all(),
+    )
+  }
+  async ackAgentMention(agentId: string, id: string): Promise<boolean> {
+    const res = this.db
+      .update(agentMention)
+      .set({ state: "done" })
+      .where(and(eq(agentMention.id, id), eq(agentMention.agent_id, agentId)))
+      .run()
+    return res.changes > 0
   }
 
   close(): void {


### PR DESCRIPTION
## What

Closes the loop's last gap: **@mention an agent in a thread and it proposes a change for review**. An agent is a registered principal that acts through a scoped token, at **commenter rank** by default — so it can propose all day, but a human still approves. This is the @agent design from the plan (dock-ddu.pages.dev/agents), built on the permissions + reviews + structured-mentions work that already shipped.

## Pull-based spine (with webhooks for free)

The primary model is **pull**: the agent reads its mentions from `GET /v1/agent/inbox` with its token, acts, and acks — zero new infra, dead simple to wire to Claude Code (headless) or any harness. And because a mention still fires the existing `comment.mention` webhook, **push works too** as a "wake up and check your inbox" signal.

## How it rides what exists

- **Agent = actor + role.** A bearer token resolves to the agent as an authorization actor (commenter ⇒ propose-only, never publish) and as an author identity (it authors as its name, never spoofing a person).
- **Mentionable like anyone.** Agents appear in the `/v1/users` @mention directory (`kind: "agent"`), so the existing picker offers them. A mention of an agent lands in its **pull inbox** instead of a notification bell.
- **Acts via existing endpoints.** It reads context (artifact / content / comments) and proposes through the reviews API with the same token; the human approves on the rendered-experience review surface.

## Surface

- Data: `agent` + `agent_mention` tables across sqlite/pg/d1 (drizzle + parity guards + boot DDL) + MetaStore methods (registry, `getAgentByToken`, inbox list/ack).
- API: owner-gated registry `GET/POST/DELETE /v1/agents` (token returned once on create); the pull loop `GET /v1/agent/inbox` + `POST /v1/agent/mentions/:id/ack`; agent auth + identity threaded through `actorFor` / authorship; mention routing in `notifyMentions`.
- Web: a Settings → Agents section (add with name + role, copy the token once, remove). Agents surface in the @mention picker via the shared directory.

## Verification

- 7 API integration tests: owner-registers / commenter-can't, agent in the directory, @mention → inbox, agent proposes (authored as itself, doesn't go live), agent can't approve its own proposal, ack clears the inbox, non-agent rejected.
- A 9-check end-to-end run against **real Postgres** (isolated temp DB): register → @mention → inbox → propose-as-agent → ack → still-awaiting-review.
- Browser-verified the Settings flow (create → token reveal → list). `pnpm typecheck` + full suite + `biome ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)