### PR TITLE
feat: collections — shareable groups of artifacts (share at the collection level)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -10,6 +10,7 @@ import {
   type BlobStore,
   BUNDLE_CONTENT_TYPE,
   type BundleManifest,
+  type CollectionRecord,
   type CommentRecord,
   can,
   DEFAULT_VERSION_WINDOW_MS,
@@ -20,6 +21,7 @@ import {
   isAnchored,
   isRole,
   type MetaStore,
+  maxRole,
   mimeFor,
   newId,
   type ProposalRecord,
@@ -371,7 +373,11 @@ export function createApp(deps: AppDeps): Hono {
     if (!me) return { kind: "anon", open }
     const orgRole = await ensureMembership(me.id)
     const am = await meta.getArtifactMember(a.id, me.id)
-    return { kind: "user", userId: me.id, artifactRole: am?.role ?? null, orgRole, open }
+    // A collection share grants its role on every artifact in the collection,
+    // folded in alongside any per-artifact share (the higher wins).
+    const cRoles = await meta.collectionRolesForArtifact(a.id, me.id)
+    const artifactRole = maxRole(am?.role ?? null, ...cRoles)
+    return { kind: "user", userId: me.id, artifactRole, orgRole, open }
   }
 
   /** Authorize an action against a specific artifact. */
@@ -526,22 +532,36 @@ export function createApp(deps: AppDeps): Hono {
     if (!me && deps.token && bearer(c) !== deps.token)
       return c.json({ error: "unauthenticated" }, 401)
     const limit = Math.min(100, Math.max(1, Number(c.req.query("limit")) || 30))
-    const cursor = c.req.query("cursor") || undefined
+    // Opaque compound cursor "<created_at>|<id>" — the id tiebreak keeps paging
+    // correct when many artifacts share a created_at.
+    const rawCursor = c.req.query("cursor")
+    const sep = rawCursor?.indexOf("|") ?? -1
+    const cursor =
+      rawCursor && sep > 0
+        ? { created_at: rawCursor.slice(0, sep), id: rawCursor.slice(sep + 1) }
+        : undefined
     const q = c.req.query("q")?.trim() || undefined
     const tag = c.req.query("tag")?.trim() || undefined
+    const collectionId = c.req.query("collection")?.trim() || undefined
     const favOnly = c.req.query("favorite") === "true"
 
     const favIds = me ? await meta.listUserFavoriteIds(me.id) : []
     const favorites = new Set(favIds)
+    // tag / collection / favorite each narrow to an id set; intersect when combined.
     let ids: string[] | undefined
-    if (tag) ids = await meta.artifactIdsByTag(tag)
-    if (favOnly) ids = ids ? ids.filter((id) => favorites.has(id)) : favIds
+    const narrow = (next: string[]) => {
+      ids = ids ? ids.filter((id) => next.includes(id)) : next
+    }
+    if (tag) narrow(await meta.artifactIdsByTag(tag))
+    if (collectionId) narrow(await meta.collectionArtifactIds(collectionId))
+    if (favOnly) narrow(favIds)
     if (ids && ids.length === 0) return c.json({ artifacts: [], next_cursor: null })
 
     const rows = await meta.listArtifacts({ limit: limit + 1, cursor, q, ids })
     const hasMore = rows.length > limit
     const page = hasMore ? rows.slice(0, limit) : rows
-    const next_cursor = hasMore ? page[page.length - 1].created_at : null
+    const last = page[page.length - 1]
+    const next_cursor = hasMore && last ? `${last.created_at}|${last.id}` : null
 
     const pageIds = page.map((a) => a.id)
     const counts = analyticsOn ? await meta.viewCounts(pageIds) : {}
@@ -570,6 +590,120 @@ export function createApp(deps: AppDeps): Hono {
     ])
     tags.sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
     return c.json({ total, favorites: favIds.length, tags })
+  })
+
+  // ---- Collections (shareable groups; a member's role propagates to items) -
+  // A user's role on a collection: creator/member role, token/open → owner.
+  const collectionRole = async (c: Context, col: CollectionRecord): Promise<Role | null> => {
+    if (deps.token && bearer(c) === deps.token) return "owner"
+    const me = await currentUser(c)
+    if (!me) return open ? "owner" : null
+    if (col.created_by === me.id) return "owner"
+    const m = await meta.getCollectionMember(col.id, me.id)
+    return m?.role ?? (open ? "owner" : null)
+  }
+  const canManageCollection = async (c: Context, col: CollectionRecord, action: Action) =>
+    roleAllows((await collectionRole(c, col)) ?? "viewer", action)
+
+  app.get("/v1/collections", async (c) => {
+    if (!(await currentUser(c)) && deps.token && bearer(c) !== deps.token)
+      return c.json({ error: "unauthenticated" }, 401)
+    return c.json({ collections: await meta.listCollections() })
+  })
+  app.post("/v1/collections", async (c) => {
+    if (!(await workspaceCan(c, "comment"))) return c.json({ error: "forbidden" }, 403)
+    const me = await currentUser(c)
+    const body = (await c.req.json().catch(() => ({}))) as { title?: string }
+    const title = (body.title ?? "").trim().slice(0, 120)
+    if (!title) return c.json({ error: "title required" }, 400)
+    const createdBy = me?.id ?? "local"
+    const col = await meta.createCollection({
+      id: newId("col"),
+      org_id: WORKSPACE,
+      title,
+      created_by: createdBy,
+    })
+    // The creator joins as owner: they manage it, and (like any member) their
+    // role propagates to the collection's artifacts.
+    await meta.setCollectionMember({
+      id: newId("cm"),
+      collection_id: col.id,
+      user_id: createdBy,
+      role: "owner",
+    })
+    return c.json(col, 201)
+  })
+  app.patch("/v1/collections/:id", async (c) => {
+    const col = await meta.getCollection(c.req.param("id"))
+    if (!col) return c.json({ error: "not found" }, 404)
+    if (!(await canManageCollection(c, col, "publish"))) return c.json({ error: "forbidden" }, 403)
+    const body = (await c.req.json().catch(() => ({}))) as { title?: string }
+    return c.json(await meta.updateCollection(col.id, { title: body.title?.trim().slice(0, 120) }))
+  })
+  app.delete("/v1/collections/:id", async (c) => {
+    const col = await meta.getCollection(c.req.param("id"))
+    if (!col) return c.json({ error: "not found" }, 404)
+    if (!(await canManageCollection(c, col, "manage"))) return c.json({ error: "forbidden" }, 403)
+    await meta.deleteCollection(col.id)
+    return c.body(null, 204)
+  })
+  app.put("/v1/collections/:id/items/:shortId", async (c) => {
+    const col = await meta.getCollection(c.req.param("id"))
+    if (!col) return c.json({ error: "not found" }, 404)
+    if (!(await canManageCollection(c, col, "publish"))) return c.json({ error: "forbidden" }, 403)
+    const art = await meta.getByShortId(c.req.param("shortId"))
+    if (!art) return c.json({ error: "artifact not found" }, 404)
+    await meta.addCollectionItem(col.id, art.id)
+    return c.json({ ok: true })
+  })
+  app.delete("/v1/collections/:id/items/:shortId", async (c) => {
+    const col = await meta.getCollection(c.req.param("id"))
+    if (!col) return c.json({ error: "not found" }, 404)
+    if (!(await canManageCollection(c, col, "publish"))) return c.json({ error: "forbidden" }, 403)
+    const art = await meta.getByShortId(c.req.param("shortId"))
+    if (!art) return c.json({ error: "artifact not found" }, 404)
+    await meta.removeCollectionItem(col.id, art.id)
+    return c.body(null, 204)
+  })
+  app.get("/v1/collections/:id/members", async (c) => {
+    const col = await meta.getCollection(c.req.param("id"))
+    if (!col || (await collectionRole(c, col)) === null) return c.json({ error: "not found" }, 404)
+    const rows = await meta.listCollectionMembers(col.id)
+    const users = await meta.getUsers(rows.map((r) => r.user_id))
+    const byId = new Map(users.map((u) => [u.id, u]))
+    return c.json({
+      created_by: col.created_by,
+      members: rows.map((r) => ({
+        user_id: r.user_id,
+        email: byId.get(r.user_id)?.email ?? null,
+        name: byId.get(r.user_id)?.name ?? null,
+        role: r.role,
+      })),
+    })
+  })
+  app.put("/v1/collections/:id/members", async (c) => {
+    const col = await meta.getCollection(c.req.param("id"))
+    if (!col) return c.json({ error: "not found" }, 404)
+    if (!(await canManageCollection(c, col, "manage"))) return c.json({ error: "forbidden" }, 403)
+    const b = (await c.req.json().catch(() => ({}))) as { email?: string; role?: string }
+    if (!b.email || !isRole(b.role))
+      return c.json({ error: "email and a valid role are required" }, 400)
+    const user = await meta.findUserByEmail(b.email.trim())
+    if (!user) return c.json({ error: "no Dock user with that email" }, 404)
+    await meta.setCollectionMember({
+      id: newId("cm"),
+      collection_id: col.id,
+      user_id: user.id,
+      role: b.role,
+    })
+    return c.json({ user_id: user.id, email: user.email, name: user.name, role: b.role }, 201)
+  })
+  app.delete("/v1/collections/:id/members/:userId", async (c) => {
+    const col = await meta.getCollection(c.req.param("id"))
+    if (!col) return c.json({ error: "not found" }, 404)
+    if (!(await canManageCollection(c, col, "manage"))) return c.json({ error: "forbidden" }, 403)
+    await meta.removeCollectionMember(col.id, c.req.param("userId"))
+    return c.body(null, 204)
   })
 
   // ---- Publish ----------------------------------------------------------
@@ -662,6 +796,7 @@ export function createApp(deps: AppDeps): Hono {
     const me = actor.kind === "user" ? actor.userId : null
     const tags = (await meta.tagsForArtifacts([artifact.id]))[artifact.id] ?? []
     const favorite = me ? (await meta.listUserFavoriteIds(me)).includes(artifact.id) : false
+    const collections = await meta.collectionIdsForArtifact(artifact.id)
     const proposals = await meta.listProposals(artifact.id)
     // `versions` stays at revision granularity (machines/agents); `sessions` is
     // the time-grouped view the UI shows by default. `my_role` tells the client
@@ -674,6 +809,7 @@ export function createApp(deps: AppDeps): Hono {
       my_role: effectiveRole(actor, artifact.visibility),
       tags,
       favorite,
+      collections,
       open_proposals: proposals.filter((p) => p.state === "open").length,
       proposals_total: proposals.filter((p) => p.state !== "withdrawn").length,
     })

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -1287,3 +1287,66 @@ describe("single-container web serving", () => {
     expect((await webApp.request("/")).status).toBe(404)
   })
 })
+
+describe("collections", () => {
+  const put = (path: string) =>
+    app.request(path, { method: "PUT", headers: { "content-type": "application/json" } })
+
+  it("CRUD + items + ?collection filter + detail membership", async () => {
+    const col = await (await postJson("/v1/collections", { title: "Launch" })).json()
+    expect(col.title).toBe("Launch")
+    const { short_id } = await (await upload("c1.md", "x", { title: "In collection" })).json()
+    expect((await put(`/v1/collections/${col.id}/items/${short_id}`)).status).toBe(200)
+
+    const list = await (await app.request("/v1/collections")).json()
+    expect(list.collections.find((c: { id: string }) => c.id === col.id)?.count).toBe(1)
+
+    const filtered = await (await app.request(`/v1/artifacts?collection=${col.id}`)).json()
+    expect(filtered.artifacts.map((a: { short_id: string }) => a.short_id)).toEqual([short_id])
+
+    const detail = await (await app.request(`/v1/artifacts/${short_id}`)).json()
+    expect(detail.collections).toEqual([col.id])
+
+    await app.request(`/v1/collections/${col.id}/items/${short_id}`, { method: "DELETE" })
+    expect(
+      (await (await app.request(`/v1/artifacts?collection=${col.id}`)).json()).artifacts,
+    ).toHaveLength(0)
+  })
+
+  it("sharing a collection grants its role on every artifact in it", async () => {
+    const col = await (await postJson("/v1/collections", { title: "Shared" })).json()
+    const { short_id } = await (await upload("cs.md", "x", { title: "Shared art" })).json()
+    await put(`/v1/collections/${col.id}/items/${short_id}`)
+    const art = await meta.getByShortId(short_id)
+    if (!art) throw new Error("missing artifact")
+    // A stranger has no role over the artifact…
+    expect(await meta.collectionRolesForArtifact(art.id, "stranger")).toEqual([])
+    // …until the collection is shared with them — then it propagates to items.
+    await meta.setCollectionMember({
+      id: "cm_test",
+      collection_id: col.id,
+      user_id: "stranger",
+      role: "editor",
+    })
+    expect(await meta.collectionRolesForArtifact(art.id, "stranger")).toEqual(["editor"])
+    // Removing the item drops the propagation.
+    await meta.removeCollectionItem(col.id, art.id)
+    expect(await meta.collectionRolesForArtifact(art.id, "stranger")).toEqual([])
+  })
+
+  it("renames and deletes a collection (artifacts survive)", async () => {
+    const col = await (await postJson("/v1/collections", { title: "Temp" })).json()
+    const { short_id } = await (await upload("cd.md", "x", { title: "Survivor" })).json()
+    await put(`/v1/collections/${col.id}/items/${short_id}`)
+    await app.request(`/v1/collections/${col.id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "Renamed" }),
+    })
+    expect((await meta.getCollection(col.id))?.title).toBe("Renamed")
+    expect((await app.request(`/v1/collections/${col.id}`, { method: "DELETE" })).status).toBe(204)
+    expect(await meta.getCollection(col.id)).toBeNull()
+    // the artifact itself is untouched
+    expect(await meta.getByShortId(short_id)).not.toBeNull()
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -40,6 +40,15 @@ export interface Artifact {
   open_proposals?: number
   /** Count of non-withdrawn proposals (open + decided) — gates the Proposals entry. */
   proposals_total?: number
+  /** Collection ids this artifact belongs to (detail endpoint). */
+  collections?: string[]
+}
+export interface Collection {
+  id: string
+  title: string
+  created_by: string
+  created_at: string
+  count: number
 }
 export type ProposalState = "open" | "approved" | "changes_requested" | "withdrawn"
 export interface Proposal {
@@ -192,6 +201,7 @@ export const api = {
   listArtifacts: (params?: {
     q?: string
     tag?: string
+    collection?: string
     favorite?: boolean
     cursor?: string
     limit?: number
@@ -199,6 +209,7 @@ export const api = {
     const qs = new URLSearchParams()
     if (params?.q) qs.set("q", params.q)
     if (params?.tag) qs.set("tag", params.tag)
+    if (params?.collection) qs.set("collection", params.collection)
     if (params?.favorite) qs.set("favorite", "true")
     if (params?.cursor) qs.set("cursor", params.cursor)
     if (params?.limit) qs.set("limit", String(params.limit))
@@ -267,6 +278,34 @@ export const api = {
     f("/v1/agents", opts({ name, role })).then(j),
   deleteAgent: (id: string): Promise<void> =>
     f(`/v1/agents/${id}`, { method: "DELETE", credentials: "include" }).then(() => undefined),
+
+  // Collections (shareable groups; sharing grants the role on every item)
+  listCollections: (): Promise<{ collections: Collection[] }> =>
+    f("/v1/collections", opts()).then(j),
+  createCollection: (title: string): Promise<Collection> =>
+    f("/v1/collections", opts({ title })).then(j),
+  renameCollection: (id: string, title: string): Promise<Collection> =>
+    f(`/v1/collections/${id}`, { ...opts({ title }), method: "PATCH" }).then(j),
+  deleteCollection: (id: string): Promise<void> =>
+    f(`/v1/collections/${id}`, { method: "DELETE", credentials: "include" }).then(() => undefined),
+  addToCollection: (collectionId: string, shortId: string): Promise<void> =>
+    f(`/v1/collections/${collectionId}/items/${shortId}`, { ...opts(), method: "PUT" }).then(
+      () => undefined,
+    ),
+  removeFromCollection: (collectionId: string, shortId: string): Promise<void> =>
+    f(`/v1/collections/${collectionId}/items/${shortId}`, {
+      method: "DELETE",
+      credentials: "include",
+    }).then(() => undefined),
+  listCollectionMembers: (id: string): Promise<{ created_by: string; members: ArtifactMember[] }> =>
+    f(`/v1/collections/${id}/members`, opts()).then(j),
+  setCollectionMember: (id: string, email: string, role: Role): Promise<ArtifactMember> =>
+    f(`/v1/collections/${id}/members`, { ...opts({ email, role }), method: "PUT" }).then(j),
+  removeCollectionMember: (id: string, userId: string): Promise<void> =>
+    f(`/v1/collections/${id}/members/${userId}`, {
+      method: "DELETE",
+      credentials: "include",
+    }).then(() => undefined),
 
   listWebhooks: (): Promise<{ webhooks: Webhook[] }> => f("/v1/webhooks", opts()).then(j),
   createWebhook: (body: {

--- a/apps/web/src/pages/Artifact.tsx
+++ b/apps/web/src/pages/Artifact.tsx
@@ -15,6 +15,7 @@ import {
   API_BASE,
   type Artifact as Art,
   api,
+  type Collection,
   type Comment,
   type Diff,
   type DirUser,
@@ -526,6 +527,11 @@ export function Artifact() {
                 canEdit={art.my_role === "editor" || art.my_role === "owner"}
                 onChange={(tags) => setArt((a) => (a ? { ...a, tags } : a))}
               />
+              <CollectionsMenu
+                shortId={shortId}
+                inCollections={art.collections ?? []}
+                onChange={(collections) => setArt((a) => (a ? { ...a, collections } : a))}
+              />
               <ShareButton shortId={shortId} myRole={art.my_role} />
               <Insights shortId={shortId} />
               <HistoryMenu
@@ -918,6 +924,163 @@ function StarButton({
     >
       {favorite ? "★" : "☆"}
     </button>
+  )
+}
+
+// Header collections popover: toggle this artifact in/out of collections, or
+// create one on the fly. Adding to a shared collection grants its members their
+// role on this artifact too.
+function CollectionsMenu({
+  shortId,
+  inCollections,
+  onChange,
+}: {
+  shortId: string
+  inCollections: string[]
+  onChange: (ids: string[]) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [all, setAll] = useState<Collection[]>([])
+  const [draft, setDraft] = useState("")
+  const ref = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const h = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener("click", h)
+    return () => document.removeEventListener("click", h)
+  }, [])
+  useEffect(() => {
+    if (open)
+      api
+        .listCollections()
+        .then((r) => setAll(r.collections))
+        .catch(() => {})
+  }, [open])
+  const inSet = new Set(inCollections)
+  const toggle = async (col: Collection) => {
+    const isIn = inSet.has(col.id)
+    onChange(isIn ? inCollections.filter((id) => id !== col.id) : [...inCollections, col.id])
+    try {
+      if (isIn) await api.removeFromCollection(col.id, shortId)
+      else await api.addToCollection(col.id, shortId)
+    } catch {
+      onChange(inCollections)
+    }
+  }
+  const create = async () => {
+    const t = draft.trim()
+    setDraft("")
+    if (!t) return
+    try {
+      const col = await api.createCollection(t)
+      await api.addToCollection(col.id, shortId)
+      setAll((a) => [col, ...a])
+      onChange([...inCollections, col.id])
+    } catch {
+      /* ignore */
+    }
+  }
+  return (
+    <div ref={ref} style={{ position: "relative" }}>
+      <button
+        className="btn sm"
+        onClick={(e) => {
+          e.stopPropagation()
+          setOpen((o) => !o)
+        }}
+        style={{ gap: 6 }}
+        title="Collections"
+      >
+        📁 {inCollections.length > 0 && <b style={{ fontWeight: 700 }}>{inCollections.length}</b>}
+      </button>
+      {open && (
+        <div
+          className="card"
+          style={{
+            position: "absolute",
+            right: 0,
+            top: "calc(100% + 7px)",
+            width: 248,
+            padding: 12,
+            boxShadow: "var(--shadow)",
+            zIndex: 30,
+            maxHeight: 340,
+            overflow: "auto",
+          }}
+        >
+          <div
+            className="mono muted"
+            style={{
+              fontSize: 9.5,
+              letterSpacing: ".06em",
+              textTransform: "uppercase",
+              marginBottom: 8,
+            }}
+          >
+            Add to collection
+          </div>
+          {all.length === 0 && (
+            <div className="muted" style={{ fontSize: 12, marginBottom: 9 }}>
+              No collections yet — create one below.
+            </div>
+          )}
+          {all.length > 0 && (
+            <div style={{ display: "flex", flexDirection: "column", gap: 1, marginBottom: 10 }}>
+              {all.map((col) => (
+                <button
+                  key={col.id}
+                  onClick={() => toggle(col)}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    width: "100%",
+                    border: 0,
+                    background: inSet.has(col.id) ? "var(--ac-soft)" : "transparent",
+                    color: "var(--fg)",
+                    padding: "6px 8px",
+                    borderRadius: 7,
+                    cursor: "pointer",
+                    textAlign: "left",
+                    font: "500 12.5px Inter,sans-serif",
+                  }}
+                >
+                  <span style={{ width: 14, color: "var(--ac)" }}>
+                    {inSet.has(col.id) ? "✓" : ""}
+                  </span>
+                  <span
+                    style={{
+                      flex: 1,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {col.title}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+          <div style={{ display: "flex", gap: 6 }}>
+            <input
+              className="input"
+              value={draft}
+              placeholder="New collection…"
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") create()
+              }}
+              style={{ padding: "6px 9px", fontSize: 12.5 }}
+            />
+            <button className="btn sm" onClick={create} disabled={!draft.trim()}>
+              Add
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/apps/web/src/pages/Library.tsx
+++ b/apps/web/src/pages/Library.tsx
@@ -1,10 +1,21 @@
 import { useNavigate } from "@tanstack/react-router"
 import { useCallback, useEffect, useRef, useState } from "react"
-import { API_BASE, type Artifact, api } from "../api"
+import {
+  API_BASE,
+  type Artifact,
+  type ArtifactMember,
+  api,
+  type Collection,
+  type Role,
+} from "../api"
 import { Header, useIsMobile, useToast } from "../components"
 import { useAuth } from "../ctx"
 
-type Filter = { kind: "all" } | { kind: "favorites" } | { kind: "tag"; tag: string }
+type Filter =
+  | { kind: "all" }
+  | { kind: "favorites" }
+  | { kind: "tag"; tag: string }
+  | { kind: "collection"; id: string; title: string }
 type TagCount = { tag: string; count: number }
 type Summary = { total: number; favorites: number; tags: TagCount[] }
 
@@ -63,6 +74,8 @@ export function Library() {
   const [more, setMore] = useState(false)
   const [busy, setBusy] = useState(false)
   const [summary, setSummary] = useState<Summary | null>(null)
+  const [collections, setCollections] = useState<Collection[]>([])
+  const [shareCol, setShareCol] = useState<Collection | null>(null)
 
   const [query, setQuery] = useState("")
   const [debouncedQ, setDebouncedQ] = useState("")
@@ -103,6 +116,7 @@ export function Library() {
         const r = await api.listArtifacts({
           q: debouncedQ || undefined,
           tag: filter.kind === "tag" ? filter.tag : undefined,
+          collection: filter.kind === "collection" ? filter.id : undefined,
           favorite: filter.kind === "favorites" || undefined,
           cursor,
           limit: PAGE,
@@ -128,9 +142,18 @@ export function Library() {
       .then(setSummary)
       .catch(() => {})
   }, [])
+  const refreshCollections = useCallback(() => {
+    api
+      .listCollections()
+      .then((r) => setCollections(r.collections))
+      .catch(() => {})
+  }, [])
   useEffect(() => {
-    if (me) refreshSummary()
-  }, [me, refreshSummary])
+    if (me) {
+      refreshSummary()
+      refreshCollections()
+    }
+  }, [me, refreshSummary, refreshCollections])
 
   const publish = async () => {
     const f = file.current?.files?.[0]
@@ -170,19 +193,45 @@ export function Library() {
     setFilter(f)
     setDrawer(false)
   }
+  const createCollection = async (title: string) => {
+    try {
+      const col = await api.createCollection(title)
+      refreshCollections()
+      pick({ kind: "collection", id: col.id, title: col.title })
+    } catch (e) {
+      show((e as Error).message)
+    }
+  }
+  const renameCollection = async (id: string, title: string) => {
+    await api.renameCollection(id, title).catch((e) => show((e as Error).message))
+    refreshCollections()
+    setFilter((f) => (f.kind === "collection" && f.id === id ? { ...f, title } : f))
+  }
+  const deleteCollection = async (id: string) => {
+    await api.deleteCollection(id).catch((e) => show((e as Error).message))
+    refreshCollections()
+    setFilter({ kind: "all" })
+  }
+
+  const activeCollection =
+    filter.kind === "collection" ? collections.find((c) => c.id === filter.id) : undefined
   const heading =
     filter.kind === "all"
       ? "All artifacts"
       : filter.kind === "favorites"
         ? "Favorites"
-        : `#${filter.tag}`
+        : filter.kind === "tag"
+          ? `#${filter.tag}`
+          : filter.title
   const headingCount = debouncedQ
     ? items.length
     : filter.kind === "all"
       ? (summary?.total ?? items.length)
       : filter.kind === "favorites"
         ? (summary?.favorites ?? items.length)
-        : (summary?.tags.find((t) => t.tag === filter.tag)?.count ?? items.length)
+        : filter.kind === "tag"
+          ? (summary?.tags.find((t) => t.tag === filter.tag)?.count ?? items.length)
+          : (activeCollection?.count ?? items.length)
 
   if (!me)
     return (
@@ -224,8 +273,10 @@ export function Library() {
           total={summary?.total ?? 0}
           favCount={summary?.favorites ?? 0}
           tags={summary?.tags ?? []}
+          collections={collections}
           filter={filter}
           onPick={pick}
+          onCreateCollection={createCollection}
           onToggleRail={() => setRail((r) => !r)}
           onClose={() => setDrawer(false)}
           onSettings={() => {
@@ -245,48 +296,66 @@ export function Library() {
               />
               {filter.kind !== "all" && (
                 <button className="btn sm" onClick={() => setFilter({ kind: "all" })}>
-                  {filter.kind === "favorites" ? "★ Favorites" : `#${filter.tag}`} ✕
+                  {filter.kind === "favorites"
+                    ? "★ Favorites"
+                    : filter.kind === "tag"
+                      ? `#${filter.tag}`
+                      : `📁 ${filter.title}`}{" "}
+                  ✕
                 </button>
               )}
             </div>
 
-            <div
-              className="card"
-              style={{
-                padding: 16,
-                marginBottom: 22,
-                display: "flex",
-                alignItems: "center",
-                gap: 14,
-                flexWrap: "wrap",
-              }}
-            >
-              <div style={{ flex: 1, minWidth: 220 }}>
-                <div className="display" style={{ fontWeight: 600, fontSize: 15 }}>
-                  Publish an artifact
+            {filter.kind !== "collection" && (
+              <div
+                className="card"
+                style={{
+                  padding: 16,
+                  marginBottom: 22,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 14,
+                  flexWrap: "wrap",
+                }}
+              >
+                <div style={{ flex: 1, minWidth: 220 }}>
+                  <div className="display" style={{ fontWeight: 600, fontSize: 15 }}>
+                    Publish an artifact
+                  </div>
+                  <div className="muted" style={{ fontSize: 13 }}>
+                    Drop an HTML or Markdown file, or run <code className="mono">dock publish</code>
+                    .
+                  </div>
                 </div>
-                <div className="muted" style={{ fontSize: 13 }}>
-                  Drop an HTML or Markdown file, or run <code className="mono">dock publish</code>.
-                </div>
+                <input
+                  ref={file}
+                  type="file"
+                  accept=".html,.htm,.md,.markdown,.zip"
+                  style={{ maxWidth: 230, fontSize: 12 }}
+                  onChange={publish}
+                />
+                <button className="btn pri" onClick={publish} disabled={busy}>
+                  {busy ? "Publishing…" : "Publish"}
+                </button>
               </div>
-              <input
-                ref={file}
-                type="file"
-                accept=".html,.htm,.md,.markdown,.zip"
-                style={{ maxWidth: 230, fontSize: 12 }}
-                onChange={publish}
-              />
-              <button className="btn pri" onClick={publish} disabled={busy}>
-                {busy ? "Publishing…" : "Publish"}
-              </button>
-            </div>
+            )}
 
-            <h2 className="display" style={{ fontSize: 17, margin: "0 0 14px" }}>
-              {heading}{" "}
-              <span className="muted" style={{ fontWeight: 400, fontSize: 14 }}>
-                · {headingCount}
-              </span>
-            </h2>
+            {filter.kind === "collection" ? (
+              <CollectionBar
+                title={heading}
+                count={headingCount}
+                onShare={() => activeCollection && setShareCol(activeCollection)}
+                onRename={(t) => renameCollection(filter.id, t)}
+                onDelete={() => deleteCollection(filter.id)}
+              />
+            ) : (
+              <h2 className="display" style={{ fontSize: 17, margin: "0 0 14px" }}>
+                {heading}{" "}
+                <span className="muted" style={{ fontWeight: 400, fontSize: 14 }}>
+                  · {headingCount}
+                </span>
+              </h2>
+            )}
 
             {fetching && items.length === 0 ? (
               <div className="center" style={{ height: 160 }}>
@@ -373,7 +442,240 @@ export function Library() {
           </div>
         </main>
       </div>
+      {shareCol && (
+        <CollectionShareDialog
+          collection={shareCol}
+          show={show}
+          onClose={() => setShareCol(null)}
+        />
+      )}
       {toast}
+    </div>
+  )
+}
+
+// The bar shown when viewing a collection: title, count, and the owner actions
+// (share / rename / delete). Share is the headline — it grants the role on
+// every artifact in the collection.
+function CollectionBar({
+  title,
+  count,
+  onShare,
+  onRename,
+  onDelete,
+}: {
+  title: string
+  count: number
+  onShare: () => void
+  onRename: (title: string) => void
+  onDelete: () => void
+}) {
+  const [renaming, setRenaming] = useState(false)
+  const [draft, setDraft] = useState(title)
+  useEffect(() => setDraft(title), [title])
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        flexWrap: "wrap",
+        margin: "0 0 16px",
+        paddingBottom: 14,
+        borderBottom: "1px solid var(--line-soft)",
+      }}
+    >
+      <span style={{ fontSize: 19 }}>📁</span>
+      {renaming ? (
+        <input
+          className="input"
+          value={draft}
+          autoFocus
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && draft.trim()) {
+              onRename(draft.trim())
+              setRenaming(false)
+            }
+            if (e.key === "Escape") setRenaming(false)
+          }}
+          style={{ maxWidth: 280, fontSize: 16, fontWeight: 600 }}
+        />
+      ) : (
+        <h2 className="display" style={{ fontSize: 19, margin: 0 }}>
+          {title}{" "}
+          <span className="muted" style={{ fontWeight: 400, fontSize: 14 }}>
+            · {count}
+          </span>
+        </h2>
+      )}
+      <span style={{ flex: 1 }} />
+      <button className="btn sm pri" onClick={onShare} title="Share this collection">
+        🔗 Share
+      </button>
+      <button
+        className="btn sm"
+        onClick={() =>
+          renaming ? (onRename(draft.trim()), setRenaming(false)) : setRenaming(true)
+        }
+      >
+        {renaming ? "Save" : "Rename"}
+      </button>
+      <button
+        className="btn sm"
+        style={{ color: "var(--bad)" }}
+        onClick={() => {
+          if (confirm(`Delete the collection “${title}”? The artifacts are not deleted.`))
+            onDelete()
+        }}
+      >
+        Delete
+      </button>
+    </div>
+  )
+}
+
+// Share a collection: add people by email at a role. A member's role applies to
+// every artifact in the collection (the headline of collection-level sharing).
+function CollectionShareDialog({
+  collection,
+  show,
+  onClose,
+}: {
+  collection: Collection
+  show: (m: string) => void
+  onClose: () => void
+}) {
+  const [members, setMembers] = useState<ArtifactMember[]>([])
+  const [email, setEmail] = useState("")
+  const [role, setRole] = useState<Role>("editor")
+  const [busy, setBusy] = useState(false)
+  const load = useCallback(() => {
+    api
+      .listCollectionMembers(collection.id)
+      .then((r) => setMembers(r.members))
+      .catch(() => {})
+  }, [collection.id])
+  useEffect(() => {
+    load()
+  }, [load])
+  const add = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const addr = email.trim()
+    if (!addr) return
+    setBusy(true)
+    try {
+      await api.setCollectionMember(collection.id, addr, role)
+      setEmail("")
+      load()
+    } catch (x) {
+      show((x as Error).message)
+    } finally {
+      setBusy(false)
+    }
+  }
+  const remove = async (m: ArtifactMember) => {
+    await api.removeCollectionMember(collection.id, m.user_id).catch(() => {})
+    load()
+  }
+  const ROLES: Role[] = ["viewer", "commenter", "editor", "owner"]
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop dismissal mirrors the ✕ button.
+    <div
+      className="sheet-backdrop show"
+      style={{ display: "grid", placeItems: "center", padding: 18 }}
+      onClick={onClose}
+    >
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: stop click-through to the backdrop. */}
+      <div
+        className="card"
+        style={{ width: 380, maxWidth: "100%", padding: 18, boxShadow: "var(--shadow)" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
+          <b className="display" style={{ fontSize: 15 }}>
+            Share “{collection.title}”
+          </b>
+          <span style={{ flex: 1 }} />
+          <button
+            className="btn sm"
+            onClick={onClose}
+            aria-label="Close"
+            style={{ padding: "4px 9px" }}
+          >
+            ✕
+          </button>
+        </div>
+        <p className="muted" style={{ fontSize: 12.5, margin: "0 0 12px" }}>
+          People here get this role on <b>every artifact</b> in the collection.
+        </p>
+        <form onSubmit={add} style={{ display: "flex", gap: 6, marginBottom: 12 }}>
+          <input
+            className="input"
+            type="email"
+            placeholder="teammate@email.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            style={{ flex: 1, padding: "7px 9px", fontSize: 13 }}
+          />
+          <select
+            value={role}
+            onChange={(e) => setRole(e.target.value as Role)}
+            className="input"
+            style={{ width: 104, padding: "7px 6px", fontSize: 12 }}
+          >
+            {ROLES.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+          <button className="btn pri sm" type="submit" disabled={busy}>
+            {busy ? "…" : "Add"}
+          </button>
+        </form>
+        {members.length === 0 ? (
+          <div className="muted" style={{ fontSize: 12 }}>
+            No one shared yet.
+          </div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+            {members.map((m) => (
+              <div key={m.user_id} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div
+                    style={{
+                      fontSize: 12.5,
+                      fontWeight: 600,
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }}
+                  >
+                    {m.name ?? m.email ?? m.user_id}
+                  </div>
+                  {m.name && m.email && (
+                    <div className="muted" style={{ fontSize: 10.5 }}>
+                      {m.email}
+                    </div>
+                  )}
+                </div>
+                <span className="mono muted" style={{ fontSize: 11 }}>
+                  {m.role}
+                </span>
+                <button
+                  className="lnk"
+                  onClick={() => remove(m)}
+                  title="Remove"
+                  style={{ textDecoration: "none", fontSize: 14 }}
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   )
 }
@@ -385,8 +687,10 @@ function Sidebar({
   total,
   favCount,
   tags,
+  collections,
   filter,
   onPick,
+  onCreateCollection,
   onToggleRail,
   onClose,
   onSettings,
@@ -397,13 +701,23 @@ function Sidebar({
   total: number
   favCount: number
   tags: TagCount[]
+  collections: Collection[]
   filter: Filter
   onPick: (f: Filter) => void
+  onCreateCollection: (title: string) => void
   onToggleRail: () => void
   onClose: () => void
   onSettings: () => void
 }) {
   const cls = drawer ? `side side-drawer${open ? " open" : ""}` : `side${rail ? " rail" : ""}`
+  const [creating, setCreating] = useState(false)
+  const [name, setName] = useState("")
+  const submit = () => {
+    const t = name.trim()
+    if (t) onCreateCollection(t)
+    setName("")
+    setCreating(false)
+  }
   return (
     <aside className={cls} aria-label="Browse">
       <div className="side-lbl">Library</div>
@@ -425,6 +739,59 @@ function Sidebar({
         <span className="lbl">Favorites</span>
         <span className="n">{favCount}</span>
       </button>
+
+      <div className="side-lbl" style={{ display: "flex", alignItems: "center" }}>
+        <span className="lbl" style={{ flex: 1 }}>
+          Collections
+        </span>
+        <button
+          className="lbl"
+          onClick={() => setCreating((v) => !v)}
+          title="New collection"
+          style={{
+            border: 0,
+            background: "transparent",
+            color: "var(--accent-ink, var(--ac))",
+            cursor: "pointer",
+            fontSize: 13,
+            padding: 0,
+          }}
+        >
+          ＋
+        </button>
+      </div>
+      {creating && (
+        <input
+          className="input lbl"
+          value={name}
+          autoFocus
+          placeholder="Collection name…"
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") submit()
+            if (e.key === "Escape") {
+              setCreating(false)
+              setName("")
+            }
+          }}
+          onBlur={submit}
+          style={{ margin: "2px 4px 6px", padding: "6px 9px", fontSize: 13 }}
+        />
+      )}
+      {collections.map((col) => (
+        <button
+          key={col.id}
+          className={`side-item${filter.kind === "collection" && filter.id === col.id ? " on" : ""}`}
+          onClick={() => onPick({ kind: "collection", id: col.id, title: col.title })}
+          title={col.title}
+        >
+          <span className="ic">📁</span>
+          <span className="lbl" style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+            {col.title}
+          </span>
+          <span className="n">{col.count}</span>
+        </button>
+      ))}
 
       {tags.length > 0 && (
         <>
@@ -486,7 +853,9 @@ function EmptyState({ filter, query }: { filter: Filter; query: string }) {
       ? "No favorites yet. Tap the ☆ on any artifact to star it."
       : filter.kind === "tag"
         ? `Nothing tagged #${filter.tag} yet.`
-        : "Nothing yet. Publish above, or run dock publish ./file."
+        : filter.kind === "collection"
+          ? "This collection is empty. Open an artifact and add it from the 📁 menu."
+          : "Nothing yet. Publish above, or run dock publish ./file."
   return (
     <div
       className="muted"

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -32,6 +32,14 @@ export const isRole = (v: unknown): v is Role => typeof v === "string" && v in R
 /** Does this role permit this action? */
 export const roleAllows = (role: Role, action: Action): boolean => RANK[role] >= RANK[NEEDS[action]]
 
+/** The highest of a set of roles (nulls ignored); null if none. Folds a
+ *  collection-membership role in alongside a per-artifact share. */
+export function maxRole(...roles: (Role | null | undefined)[]): Role | null {
+  let best: Role | null = null
+  for (const r of roles) if (r && (best === null || RANK[r] > RANK[best])) best = r
+  return best
+}
+
 /**
  * Who is making a request, with their standing already resolved from the store.
  * Every surface (web session, static token, MCP agent) becomes one of these.

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -28,8 +28,12 @@ export interface ArtifactRecord {
 
 export interface ListArtifactsOpts {
   limit?: number
-  /** Keyset cursor: return artifacts created strictly before this ISO timestamp. */
-  cursor?: string
+  /**
+   * Keyset cursor — return artifacts strictly older than this (created_at, id)
+   * pair. The `id` tiebreak makes pagination correct even when many artifacts
+   * share a created_at timestamp (sub-millisecond bulk inserts).
+   */
+  cursor?: { created_at: string; id: string }
   /** Case-insensitive title search. */
   q?: string
   /** Restrict to these artifact ids (tag / favorite filters resolve to ids). Empty ⇒ none. */
@@ -154,6 +158,28 @@ export interface MetaStore {
   tagsForArtifacts(artifactIds: string[]): Promise<Record<string, string[]>>
   /** Replace an artifact's full tag set (deduped, trimmed, lowercased upstream). */
   setArtifactTags(artifactId: string, tags: string[]): Promise<void>
+
+  // ---- Collections (shareable groups; a member's role propagates to items) -
+  createCollection(c: NewCollection): Promise<CollectionRecord>
+  getCollection(id: string): Promise<CollectionRecord | null>
+  updateCollection(id: string, fields: { title?: string }): Promise<CollectionRecord | null>
+  /** Remove a collection and its items + member rows. */
+  deleteCollection(id: string): Promise<void>
+  /** All collections (workspace-wide) with their item counts, newest first. */
+  listCollections(): Promise<(CollectionRecord & { count: number })[]>
+  /** Artifact ids in a collection (drives ?collection= browse). */
+  collectionArtifactIds(collectionId: string): Promise<string[]>
+  /** Collection ids containing an artifact (for the artifact's "add to" UI). */
+  collectionIdsForArtifact(artifactId: string): Promise<string[]>
+  addCollectionItem(collectionId: string, artifactId: string): Promise<void>
+  removeCollectionItem(collectionId: string, artifactId: string): Promise<void>
+  getCollectionMember(collectionId: string, userId: string): Promise<CollectionMemberRecord | null>
+  listCollectionMembers(collectionId: string): Promise<CollectionMemberRecord[]>
+  setCollectionMember(m: NewCollectionMember): Promise<CollectionMemberRecord>
+  removeCollectionMember(collectionId: string, userId: string): Promise<void>
+  /** This user's collection-member roles over collections containing the
+   *  artifact — folded into their effective artifact role (collection sharing). */
+  collectionRolesForArtifact(artifactId: string, userId: string): Promise<Role[]>
 
   // ---- Reviews: proposed versions awaiting approval ----------------------
   createProposal(p: NewProposal): Promise<ProposalRecord>
@@ -335,6 +361,33 @@ export interface MembershipRecord {
 export interface NewMembership {
   id: string
   org_id: string
+  user_id: string
+  role: Role
+}
+
+export interface CollectionRecord {
+  id: string
+  org_id: string
+  title: string
+  created_by: string
+  created_at: string
+}
+export interface NewCollection {
+  id: string
+  org_id: string
+  title: string
+  created_by: string
+}
+export interface CollectionMemberRecord {
+  id: string
+  collection_id: string
+  user_id: string
+  role: Role
+  created_at: string
+}
+export interface NewCollectionMember {
+  id: string
+  collection_id: string
   user_id: string
   role: Role
 }

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -4,6 +4,8 @@ import type {
   AgentRecord,
   ArtifactMemberRecord,
   ArtifactRecord,
+  CollectionMemberRecord,
+  CollectionRecord,
   CommentRecord,
   CommentState,
   DeliveryRecord,
@@ -15,6 +17,8 @@ import type {
   NewAgentMention,
   NewArtifact,
   NewArtifactMember,
+  NewCollection,
+  NewCollectionMember,
   NewComment,
   NewDelivery,
   NewMembership,
@@ -26,6 +30,7 @@ import type {
   NotificationRecord,
   ProposalRecord,
   ProposalState,
+  Role,
   UserDir,
   VersionRecord,
   ViewStats,
@@ -40,6 +45,9 @@ import {
   artifactFavorite,
   artifactMember,
   artifactTag,
+  collection,
+  collectionItem,
+  collectionMember,
   comment,
   membership,
   notification,
@@ -63,6 +71,9 @@ const schema = {
   proposal,
   agent,
   agentMention,
+  collection,
+  collectionItem,
+  collectionMember,
 }
 const VIEW_WINDOW_MS = 30 * 86400_000
 
@@ -169,13 +180,19 @@ export class D1MetaStore implements MetaStore {
     if (opts?.ids && opts.ids.length === 0) return []
     const conds = []
     if (opts?.q) conds.push(like(sql`lower(${artifact.title})`, `%${opts.q.toLowerCase()}%`))
-    if (opts?.cursor) conds.push(lt(artifact.created_at, opts.cursor))
+    if (opts?.cursor)
+      conds.push(
+        or(
+          lt(artifact.created_at, opts.cursor.created_at),
+          and(eq(artifact.created_at, opts.cursor.created_at), lt(artifact.id, opts.cursor.id)),
+        ),
+      )
     if (opts?.ids) conds.push(inArray(artifact.id, opts.ids))
     const q = this.db
       .select()
       .from(artifact)
       .where(conds.length ? and(...conds) : undefined)
-      .orderBy(desc(artifact.created_at))
+      .orderBy(desc(artifact.created_at), desc(artifact.id))
     return (opts?.limit ? q.limit(opts.limit) : q).all()
   }
   async artifactIdsByTag(tag: string): Promise<string[]> {
@@ -414,6 +431,126 @@ export class D1MetaStore implements MetaStore {
         .insert(artifactTag)
         .values(tags.map((tag) => ({ id: crypto.randomUUID(), artifact_id: artifactId, tag })))
         .run()
+  }
+
+  // ---- Collections (no interactive transactions on D1; sequential writes) -
+  async createCollection(c: NewCollection): Promise<CollectionRecord> {
+    return this.db.insert(collection).values(c).returning().get()
+  }
+  async getCollection(id: string): Promise<CollectionRecord | null> {
+    return (await this.db.select().from(collection).where(eq(collection.id, id)).get()) ?? null
+  }
+  async updateCollection(id: string, fields: { title?: string }): Promise<CollectionRecord | null> {
+    if (fields.title === undefined) return this.getCollection(id)
+    return (
+      (await this.db
+        .update(collection)
+        .set({ title: fields.title })
+        .where(eq(collection.id, id))
+        .returning()
+        .get()) ?? null
+    )
+  }
+  async deleteCollection(id: string): Promise<void> {
+    await this.db.delete(collectionItem).where(eq(collectionItem.collection_id, id)).run()
+    await this.db.delete(collectionMember).where(eq(collectionMember.collection_id, id)).run()
+    await this.db.delete(collection).where(eq(collection.id, id)).run()
+  }
+  async listCollections(): Promise<(CollectionRecord & { count: number })[]> {
+    const rows = await this.db.select().from(collection).orderBy(desc(collection.created_at)).all()
+    const counts = await this.db
+      .select({ id: collectionItem.collection_id, c: count() })
+      .from(collectionItem)
+      .groupBy(collectionItem.collection_id)
+      .all()
+    const cmap = new Map(counts.map((r) => [r.id, r.c]))
+    return rows.map((r) => ({ ...r, count: cmap.get(r.id) ?? 0 }))
+  }
+  async collectionArtifactIds(collectionId: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ id: collectionItem.artifact_id })
+      .from(collectionItem)
+      .where(eq(collectionItem.collection_id, collectionId))
+      .all()
+    return rows.map((r) => r.id)
+  }
+  async collectionIdsForArtifact(artifactId: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ id: collectionItem.collection_id })
+      .from(collectionItem)
+      .where(eq(collectionItem.artifact_id, artifactId))
+      .all()
+    return rows.map((r) => r.id)
+  }
+  async addCollectionItem(collectionId: string, artifactId: string): Promise<void> {
+    await this.db
+      .insert(collectionItem)
+      .values({ id: crypto.randomUUID(), collection_id: collectionId, artifact_id: artifactId })
+      .onConflictDoNothing({ target: [collectionItem.collection_id, collectionItem.artifact_id] })
+      .run()
+  }
+  async removeCollectionItem(collectionId: string, artifactId: string): Promise<void> {
+    await this.db
+      .delete(collectionItem)
+      .where(
+        and(
+          eq(collectionItem.collection_id, collectionId),
+          eq(collectionItem.artifact_id, artifactId),
+        ),
+      )
+      .run()
+  }
+  async getCollectionMember(
+    collectionId: string,
+    userId: string,
+  ): Promise<CollectionMemberRecord | null> {
+    return (
+      (await this.db
+        .select()
+        .from(collectionMember)
+        .where(
+          and(
+            eq(collectionMember.collection_id, collectionId),
+            eq(collectionMember.user_id, userId),
+          ),
+        )
+        .get()) ?? null
+    )
+  }
+  listCollectionMembers(collectionId: string): Promise<CollectionMemberRecord[]> {
+    return this.db
+      .select()
+      .from(collectionMember)
+      .where(eq(collectionMember.collection_id, collectionId))
+      .all()
+  }
+  setCollectionMember(m: NewCollectionMember): Promise<CollectionMemberRecord> {
+    return this.db
+      .insert(collectionMember)
+      .values(m)
+      .onConflictDoUpdate({
+        target: [collectionMember.collection_id, collectionMember.user_id],
+        set: { role: m.role },
+      })
+      .returning()
+      .get()
+  }
+  async removeCollectionMember(collectionId: string, userId: string): Promise<void> {
+    await this.db
+      .delete(collectionMember)
+      .where(
+        and(eq(collectionMember.collection_id, collectionId), eq(collectionMember.user_id, userId)),
+      )
+      .run()
+  }
+  async collectionRolesForArtifact(artifactId: string, userId: string): Promise<Role[]> {
+    const rows = await this.db
+      .select({ role: collectionMember.role })
+      .from(collectionMember)
+      .innerJoin(collectionItem, eq(collectionItem.collection_id, collectionMember.collection_id))
+      .where(and(eq(collectionItem.artifact_id, artifactId), eq(collectionMember.user_id, userId)))
+      .all()
+    return rows.map((r) => r.role)
   }
 
   // ---- Reviews: proposed versions ----------------------------------------

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -193,6 +193,40 @@ export const artifactTag = pgTable(
   },
   (t) => [uniqueIndex("artifact_tag_uniq").on(t.artifact_id, t.tag)],
 )
+export const collection = pgTable("collection", {
+  id: text("id").primaryKey(),
+  org_id: text("org_id").notNull().default("local"),
+  title: text("title").notNull(),
+  created_by: text("created_by").notNull(),
+  created_at: text("created_at").notNull().$defaultFn(isoNow),
+})
+export const collectionItem = pgTable(
+  "collection_item",
+  {
+    id: text("id").primaryKey(),
+    collection_id: text("collection_id")
+      .notNull()
+      .references(() => collection.id),
+    artifact_id: text("artifact_id")
+      .notNull()
+      .references(() => artifact.id),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [uniqueIndex("collection_item_uniq").on(t.collection_id, t.artifact_id)],
+)
+export const collectionMember = pgTable(
+  "collection_member",
+  {
+    id: text("id").primaryKey(),
+    collection_id: text("collection_id")
+      .notNull()
+      .references(() => collection.id),
+    user_id: text("user_id").notNull(),
+    role: text("role").$type<Role>().notNull(),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [uniqueIndex("collection_member_uniq").on(t.collection_id, t.user_id)],
+)
 export const proposal = pgTable("proposal", {
   id: text("id").primaryKey(),
   artifact_id: text("artifact_id")
@@ -392,6 +426,30 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
     UNIQUE (artifact_id, tag)
   )`,
   `CREATE INDEX IF NOT EXISTS tag_name ON artifact_tag (tag)`,
+  `CREATE TABLE IF NOT EXISTS collection (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL DEFAULT 'local',
+    title TEXT NOT NULL,
+    created_by TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT ${isoDefault}
+  )`,
+  `CREATE TABLE IF NOT EXISTS collection_item (
+    id TEXT PRIMARY KEY,
+    collection_id TEXT NOT NULL REFERENCES collection(id),
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    created_at TEXT NOT NULL DEFAULT ${isoDefault},
+    UNIQUE (collection_id, artifact_id)
+  )`,
+  `CREATE INDEX IF NOT EXISTS collection_item_artifact ON collection_item (artifact_id)`,
+  `CREATE TABLE IF NOT EXISTS collection_member (
+    id TEXT PRIMARY KEY,
+    collection_id TEXT NOT NULL REFERENCES collection(id),
+    user_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT ${isoDefault},
+    UNIQUE (collection_id, user_id)
+  )`,
+  `CREATE INDEX IF NOT EXISTS collection_member_user ON collection_member (user_id)`,
   `CREATE TABLE IF NOT EXISTS proposal (
     id TEXT PRIMARY KEY,
     artifact_id TEXT NOT NULL REFERENCES artifact(id),

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -3,6 +3,8 @@ import type {
   AgentRecord,
   ArtifactMemberRecord,
   ArtifactRecord,
+  CollectionMemberRecord,
+  CollectionRecord,
   CommentRecord,
   CommentState,
   DeliveryRecord,
@@ -14,6 +16,8 @@ import type {
   NewAgentMention,
   NewArtifact,
   NewArtifactMember,
+  NewCollection,
+  NewCollectionMember,
   NewComment,
   NewDelivery,
   NewMembership,
@@ -25,6 +29,7 @@ import type {
   NotificationRecord,
   ProposalRecord,
   ProposalState,
+  Role,
   UserDir,
   VersionRecord,
   ViewStats,
@@ -40,6 +45,9 @@ import {
   artifactFavorite,
   artifactMember,
   artifactTag,
+  collection,
+  collectionItem,
+  collectionMember,
   comment,
   membership,
   notification,
@@ -64,6 +72,9 @@ const schema = {
   proposal,
   agent,
   agentMention,
+  collection,
+  collectionItem,
+  collectionMember,
 }
 const VIEW_WINDOW_MS = 30 * 86400_000
 
@@ -170,13 +181,19 @@ export class PgMetaStore implements MetaStore {
     if (opts?.ids && opts.ids.length === 0) return Promise.resolve([])
     const conds = []
     if (opts?.q) conds.push(like(sql`lower(${artifact.title})`, `%${opts.q.toLowerCase()}%`))
-    if (opts?.cursor) conds.push(lt(artifact.created_at, opts.cursor))
+    if (opts?.cursor)
+      conds.push(
+        or(
+          lt(artifact.created_at, opts.cursor.created_at),
+          and(eq(artifact.created_at, opts.cursor.created_at), lt(artifact.id, opts.cursor.id)),
+        ),
+      )
     if (opts?.ids) conds.push(inArray(artifact.id, opts.ids))
     const q = this.db
       .select()
       .from(artifact)
       .where(conds.length ? and(...conds) : undefined)
-      .orderBy(desc(artifact.created_at))
+      .orderBy(desc(artifact.created_at), desc(artifact.id))
     return opts?.limit ? q.limit(opts.limit) : q
   }
   async artifactIdsByTag(tag: string): Promise<string[]> {
@@ -408,6 +425,115 @@ export class PgMetaStore implements MetaStore {
           .insert(artifactTag)
           .values(tags.map((tag) => ({ id: crypto.randomUUID(), artifact_id: artifactId, tag })))
     })
+  }
+
+  // ---- Collections -------------------------------------------------------
+  async createCollection(c: NewCollection): Promise<CollectionRecord> {
+    const rows = await this.db.insert(collection).values(c).returning()
+    return rows[0]
+  }
+  async getCollection(id: string): Promise<CollectionRecord | null> {
+    const rows = await this.db.select().from(collection).where(eq(collection.id, id))
+    return rows[0] ?? null
+  }
+  async updateCollection(id: string, fields: { title?: string }): Promise<CollectionRecord | null> {
+    if (fields.title === undefined) return this.getCollection(id)
+    const rows = await this.db
+      .update(collection)
+      .set({ title: fields.title })
+      .where(eq(collection.id, id))
+      .returning()
+    return rows[0] ?? null
+  }
+  async deleteCollection(id: string): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      await tx.delete(collectionItem).where(eq(collectionItem.collection_id, id))
+      await tx.delete(collectionMember).where(eq(collectionMember.collection_id, id))
+      await tx.delete(collection).where(eq(collection.id, id))
+    })
+  }
+  async listCollections(): Promise<(CollectionRecord & { count: number })[]> {
+    const rows = await this.db.select().from(collection).orderBy(desc(collection.created_at))
+    const counts = await this.db
+      .select({ id: collectionItem.collection_id, c: count() })
+      .from(collectionItem)
+      .groupBy(collectionItem.collection_id)
+    const cmap = new Map(counts.map((r) => [r.id, Number(r.c)]))
+    return rows.map((r) => ({ ...r, count: cmap.get(r.id) ?? 0 }))
+  }
+  async collectionArtifactIds(collectionId: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ id: collectionItem.artifact_id })
+      .from(collectionItem)
+      .where(eq(collectionItem.collection_id, collectionId))
+    return rows.map((r) => r.id)
+  }
+  async collectionIdsForArtifact(artifactId: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ id: collectionItem.collection_id })
+      .from(collectionItem)
+      .where(eq(collectionItem.artifact_id, artifactId))
+    return rows.map((r) => r.id)
+  }
+  async addCollectionItem(collectionId: string, artifactId: string): Promise<void> {
+    await this.db
+      .insert(collectionItem)
+      .values({ id: crypto.randomUUID(), collection_id: collectionId, artifact_id: artifactId })
+      .onConflictDoNothing({ target: [collectionItem.collection_id, collectionItem.artifact_id] })
+  }
+  async removeCollectionItem(collectionId: string, artifactId: string): Promise<void> {
+    await this.db
+      .delete(collectionItem)
+      .where(
+        and(
+          eq(collectionItem.collection_id, collectionId),
+          eq(collectionItem.artifact_id, artifactId),
+        ),
+      )
+  }
+  async getCollectionMember(
+    collectionId: string,
+    userId: string,
+  ): Promise<CollectionMemberRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(collectionMember)
+      .where(
+        and(eq(collectionMember.collection_id, collectionId), eq(collectionMember.user_id, userId)),
+      )
+    return rows[0] ?? null
+  }
+  listCollectionMembers(collectionId: string): Promise<CollectionMemberRecord[]> {
+    return this.db
+      .select()
+      .from(collectionMember)
+      .where(eq(collectionMember.collection_id, collectionId))
+  }
+  async setCollectionMember(m: NewCollectionMember): Promise<CollectionMemberRecord> {
+    const rows = await this.db
+      .insert(collectionMember)
+      .values(m)
+      .onConflictDoUpdate({
+        target: [collectionMember.collection_id, collectionMember.user_id],
+        set: { role: m.role },
+      })
+      .returning()
+    return rows[0]
+  }
+  async removeCollectionMember(collectionId: string, userId: string): Promise<void> {
+    await this.db
+      .delete(collectionMember)
+      .where(
+        and(eq(collectionMember.collection_id, collectionId), eq(collectionMember.user_id, userId)),
+      )
+  }
+  async collectionRolesForArtifact(artifactId: string, userId: string): Promise<Role[]> {
+    const rows = await this.db
+      .select({ role: collectionMember.role })
+      .from(collectionMember)
+      .innerJoin(collectionItem, eq(collectionItem.collection_id, collectionMember.collection_id))
+      .where(and(eq(collectionItem.artifact_id, artifactId), eq(collectionMember.user_id, userId)))
+    return rows.map((r) => r.role)
   }
 
   // ---- Reviews: proposed versions ----------------------------------------

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -201,6 +201,45 @@ export const artifactTag = sqliteTable(
   (t) => [uniqueIndex("artifact_tag_uniq").on(t.artifact_id, t.tag)],
 )
 
+// A named, shareable group of artifacts. Sharing a collection grants its role
+// on every artifact inside it (see bestCollectionRole in the drivers).
+export const collection = sqliteTable("collection", {
+  id: text("id").primaryKey(),
+  org_id: text("org_id").notNull().default("local"),
+  title: text("title").notNull(),
+  created_by: text("created_by").notNull(),
+  created_at: text("created_at").notNull().default(now),
+})
+
+export const collectionItem = sqliteTable(
+  "collection_item",
+  {
+    id: text("id").primaryKey(),
+    collection_id: text("collection_id")
+      .notNull()
+      .references(() => collection.id),
+    artifact_id: text("artifact_id")
+      .notNull()
+      .references(() => artifact.id),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [uniqueIndex("collection_item_uniq").on(t.collection_id, t.artifact_id)],
+)
+
+export const collectionMember = sqliteTable(
+  "collection_member",
+  {
+    id: text("id").primaryKey(),
+    collection_id: text("collection_id")
+      .notNull()
+      .references(() => collection.id),
+    user_id: text("user_id").notNull(),
+    role: text("role").$type<Role>().notNull(),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [uniqueIndex("collection_member_uniq").on(t.collection_id, t.user_id)],
+)
+
 export const proposal = sqliteTable("proposal", {
   id: text("id").primaryKey(),
   artifact_id: text("artifact_id")
@@ -385,6 +424,30 @@ export const SCHEMA_STATEMENTS: string[] = [
     UNIQUE (artifact_id, tag)
   )`,
   `CREATE INDEX IF NOT EXISTS tag_name ON artifact_tag (tag)`,
+  `CREATE TABLE IF NOT EXISTS collection (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL DEFAULT 'local',
+    title TEXT NOT NULL,
+    created_by TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  )`,
+  `CREATE TABLE IF NOT EXISTS collection_item (
+    id TEXT PRIMARY KEY,
+    collection_id TEXT NOT NULL REFERENCES collection(id),
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (collection_id, artifact_id)
+  )`,
+  `CREATE INDEX IF NOT EXISTS collection_item_artifact ON collection_item (artifact_id)`,
+  `CREATE TABLE IF NOT EXISTS collection_member (
+    id TEXT PRIMARY KEY,
+    collection_id TEXT NOT NULL REFERENCES collection(id),
+    user_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (collection_id, user_id)
+  )`,
+  `CREATE INDEX IF NOT EXISTS collection_member_user ON collection_member (user_id)`,
   `CREATE TABLE IF NOT EXISTS proposal (
     id TEXT PRIMARY KEY,
     artifact_id TEXT NOT NULL REFERENCES artifact(id),

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -3,6 +3,8 @@ import type {
   AgentRecord,
   ArtifactMemberRecord,
   ArtifactRecord,
+  CollectionMemberRecord,
+  CollectionRecord,
   CommentRecord,
   CommentState,
   DeliveryRecord,
@@ -14,6 +16,8 @@ import type {
   NewAgentMention,
   NewArtifact,
   NewArtifactMember,
+  NewCollection,
+  NewCollectionMember,
   NewComment,
   NewDelivery,
   NewMembership,
@@ -25,6 +29,7 @@ import type {
   NotificationRecord,
   ProposalRecord,
   ProposalState,
+  Role,
   UserDir,
   VersionRecord,
   ViewStats,
@@ -40,6 +45,9 @@ import {
   artifactFavorite,
   artifactMember,
   artifactTag,
+  collection,
+  collectionItem,
+  collectionMember,
   comment,
   MIGRATION_STATEMENTS,
   membership,
@@ -67,6 +75,9 @@ const schema = {
   proposal,
   agent,
   agentMention,
+  collection,
+  collectionItem,
+  collectionMember,
 }
 
 /** Embedded SQLite (WAL). The zero-dependency default; no external services. */
@@ -176,13 +187,19 @@ export class SqliteMetaStore implements MetaStore {
     if (opts?.ids && opts.ids.length === 0) return []
     const conds = []
     if (opts?.q) conds.push(like(sql`lower(${artifact.title})`, `%${opts.q.toLowerCase()}%`))
-    if (opts?.cursor) conds.push(lt(artifact.created_at, opts.cursor))
+    if (opts?.cursor)
+      conds.push(
+        or(
+          lt(artifact.created_at, opts.cursor.created_at),
+          and(eq(artifact.created_at, opts.cursor.created_at), lt(artifact.id, opts.cursor.id)),
+        ),
+      )
     if (opts?.ids) conds.push(inArray(artifact.id, opts.ids))
     const rows = this.db
       .select()
       .from(artifact)
       .where(conds.length ? and(...conds) : undefined)
-      .orderBy(desc(artifact.created_at))
+      .orderBy(desc(artifact.created_at), desc(artifact.id))
     return opts?.limit ? rows.limit(opts.limit).all() : rows.all()
   }
   async artifactIdsByTag(tag: string): Promise<string[]> {
@@ -437,6 +454,132 @@ export class SqliteMetaStore implements MetaStore {
           .run()
       }
     })()
+  }
+
+  // ---- Collections -------------------------------------------------------
+  createCollection(c: NewCollection): Promise<CollectionRecord> {
+    return Promise.resolve(this.db.insert(collection).values(c).returning().get())
+  }
+  async getCollection(id: string): Promise<CollectionRecord | null> {
+    return this.db.select().from(collection).where(eq(collection.id, id)).get() ?? null
+  }
+  async updateCollection(id: string, fields: { title?: string }): Promise<CollectionRecord | null> {
+    if (fields.title === undefined) return this.getCollection(id)
+    return (
+      this.db
+        .update(collection)
+        .set({ title: fields.title })
+        .where(eq(collection.id, id))
+        .returning()
+        .get() ?? null
+    )
+  }
+  async deleteCollection(id: string): Promise<void> {
+    this.raw.transaction(() => {
+      this.db.delete(collectionItem).where(eq(collectionItem.collection_id, id)).run()
+      this.db.delete(collectionMember).where(eq(collectionMember.collection_id, id)).run()
+      this.db.delete(collection).where(eq(collection.id, id)).run()
+    })()
+  }
+  async listCollections(): Promise<(CollectionRecord & { count: number })[]> {
+    const rows = this.db.select().from(collection).orderBy(desc(collection.created_at)).all()
+    const counts = this.db
+      .select({ id: collectionItem.collection_id, c: count() })
+      .from(collectionItem)
+      .groupBy(collectionItem.collection_id)
+      .all()
+    const cmap = new Map(counts.map((r) => [r.id, r.c]))
+    return rows.map((r) => ({ ...r, count: cmap.get(r.id) ?? 0 }))
+  }
+  async collectionArtifactIds(collectionId: string): Promise<string[]> {
+    return this.db
+      .select({ id: collectionItem.artifact_id })
+      .from(collectionItem)
+      .where(eq(collectionItem.collection_id, collectionId))
+      .all()
+      .map((r) => r.id)
+  }
+  async collectionIdsForArtifact(artifactId: string): Promise<string[]> {
+    return this.db
+      .select({ id: collectionItem.collection_id })
+      .from(collectionItem)
+      .where(eq(collectionItem.artifact_id, artifactId))
+      .all()
+      .map((r) => r.id)
+  }
+  async addCollectionItem(collectionId: string, artifactId: string): Promise<void> {
+    this.db
+      .insert(collectionItem)
+      .values({ id: crypto.randomUUID(), collection_id: collectionId, artifact_id: artifactId })
+      .onConflictDoNothing({ target: [collectionItem.collection_id, collectionItem.artifact_id] })
+      .run()
+  }
+  async removeCollectionItem(collectionId: string, artifactId: string): Promise<void> {
+    this.db
+      .delete(collectionItem)
+      .where(
+        and(
+          eq(collectionItem.collection_id, collectionId),
+          eq(collectionItem.artifact_id, artifactId),
+        ),
+      )
+      .run()
+  }
+  async getCollectionMember(
+    collectionId: string,
+    userId: string,
+  ): Promise<CollectionMemberRecord | null> {
+    return (
+      this.db
+        .select()
+        .from(collectionMember)
+        .where(
+          and(
+            eq(collectionMember.collection_id, collectionId),
+            eq(collectionMember.user_id, userId),
+          ),
+        )
+        .get() ?? null
+    )
+  }
+  listCollectionMembers(collectionId: string): Promise<CollectionMemberRecord[]> {
+    return Promise.resolve(
+      this.db
+        .select()
+        .from(collectionMember)
+        .where(eq(collectionMember.collection_id, collectionId))
+        .all(),
+    )
+  }
+  setCollectionMember(m: NewCollectionMember): Promise<CollectionMemberRecord> {
+    return Promise.resolve(
+      this.db
+        .insert(collectionMember)
+        .values(m)
+        .onConflictDoUpdate({
+          target: [collectionMember.collection_id, collectionMember.user_id],
+          set: { role: m.role },
+        })
+        .returning()
+        .get(),
+    )
+  }
+  async removeCollectionMember(collectionId: string, userId: string): Promise<void> {
+    this.db
+      .delete(collectionMember)
+      .where(
+        and(eq(collectionMember.collection_id, collectionId), eq(collectionMember.user_id, userId)),
+      )
+      .run()
+  }
+  async collectionRolesForArtifact(artifactId: string, userId: string): Promise<Role[]> {
+    return this.db
+      .select({ role: collectionMember.role })
+      .from(collectionMember)
+      .innerJoin(collectionItem, eq(collectionItem.collection_id, collectionMember.collection_id))
+      .where(and(eq(collectionItem.artifact_id, artifactId), eq(collectionMember.user_id, userId)))
+      .all()
+      .map((r) => r.role)
   }
 
   // ---- Reviews: proposed versions ----------------------------------------


### PR DESCRIPTION
Collections sit alongside tags: a named, **shareable** group of artifacts. The headline — **sharing a collection grants its role on every artifact inside it**. (Re-opened from #39, which auto-closed when its branch was deleted; rebased cleanly onto the agents + single-container work that landed on main.)

## Permissions (the headline)
`actorFor` folds the user's collection-member role in via a new `maxRole` helper, so a collection share applies that role to **each contained artifact** — the higher of the per-artifact share and the collection role wins.

## Data layer (sqlite · postgres · d1)
`collection`, `collection_item`, `collection_member` + CRUD / items / members / `collectionRolesForArtifact`.

## API
`/v1/collections` CRUD, `items/:shortId` add/remove, `members` (share by email at a role); `?collection=` on the artifact list (reuses keyset pagination); artifact detail carries its `collections` ids.

## Web
Collections section in the browse sidebar (create inline; rail + mobile drawer), a collection header (Share / Rename / Delete), a share dialog ("this role on **every artifact**"), and an "Add to collection" popover on the artifact header.

## Also
Compound **(created_at, id)** keyset cursor so pagination stays correct under same-timestamp inserts.

## Verified
`biome ci` ✓ · `pnpm typecheck` ✓ · tests **api 92** (collections incl. "sharing a collection grants its role on its artifacts"), core 25, cli 18, storage 6, mcp 10. Clicked through desktop + mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)