### PR TITLE
One-click cloud deploy: Railway/Fly + auto-detected public URL

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -54,6 +54,23 @@ dock.example.com {
 Cloudflare Tunnel, nginx, or any host's built-in HTTPS works the same way. Then set
 `BASE_URL=https://dock.example.com` and you're live.
 
+### On a managed host (Railway / Render / Fly)
+
+Any host that builds a Dockerfile and gives you a persistent disk runs this as-is.
+
+- **Railway**: New Project → *Deploy from GitHub repo*. `railway.json` points it at
+  `deploy/Dockerfile`. Add a **Volume mounted at `/data`** for SQLite + blobs (or
+  attach Railway Postgres and set `DATABASE_URL`).
+- **Fly.io**: `fly launch --config deploy/fly.toml --dockerfile deploy/Dockerfile`
+  then `fly deploy` — `fly.toml` already mounts `/data`.
+- **Render**: a Docker web service + a persistent disk at `/data`.
+
+`PORT` is read from the environment, and the public URL is auto-detected from the
+host (`RAILWAY_PUBLIC_DOMAIN` / `RENDER_EXTERNAL_URL` / `FLY_APP_NAME`) so auth
+cookies and share links work out of the box. Set `BASE_URL` only when you point a
+custom domain at it. Set `DOCK_AUTH_SECRET` once so sessions survive redeploys on
+hosts with an ephemeral filesystem.
+
 ### First user
 
 The first person to sign up becomes the workspace **owner**; everyone after joins at

--- a/README.md
+++ b/README.md
@@ -31,12 +31,31 @@ Authoring + the anchor-client protocol are documented in [STANDARD.md](STANDARD.
 
 ```bash
 docker compose -f deploy/compose.yml up -d
-# → http://localhost:8080 · SQLite + local blobs in one volume, zero config
+# → http://localhost:8080 · the whole app (API + web), SQLite + blobs in one volume
 ```
 
-Optional env vars (nothing is required):
+The image bundles the web app and serves it same-origin, so one container is the
+complete product — sign-in, publish, comments, reviews, the sandboxed viewer — at
+one URL. Optional env vars (nothing is required):
 `DATABASE_URL` → Postgres · `OBJECT_STORE_URL` → S3/R2 · `DOCK_TOKEN` → require a
 bearer token for publishing and for reading gated artifacts · `BASE_URL`, `PORT`, `DATA_DIR`.
+
+### Deploy to the cloud
+
+The single-container image runs on any host with a persistent volume.
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new)
+&nbsp;&nbsp;
+[![Deploy to Fly.io](https://img.shields.io/badge/Deploy%20to-Fly.io-8B5CF6)](DEPLOY.md)
+
+- **Railway** — New Project → *Deploy from GitHub repo* → this repo. `railway.json`
+  builds `deploy/Dockerfile`; add a **Volume mounted at `/data`** so SQLite + blobs
+  persist (or attach Railway Postgres and set `DATABASE_URL`).
+- **Fly.io** — `fly launch --config deploy/fly.toml --dockerfile deploy/Dockerfile`,
+  then `fly deploy`. The bundled volume keeps `/data`.
+
+Both auto-detect their assigned URL for auth cookies + share links; set `BASE_URL`
+only when you put a custom domain in front. Full guide: [DEPLOY.md](DEPLOY.md).
 
 ### The app & accounts
 

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -16,7 +16,18 @@ import { startWebhookWorker } from "./webhooks"
 
 const PORT = Number(process.env.PORT ?? 8080)
 const DATA_DIR = process.env.DATA_DIR ?? "./data"
-const BASE_URL = process.env.BASE_URL ?? `http://localhost:${PORT}`
+// The public origin: explicit BASE_URL wins; otherwise infer the URL a managed
+// host assigned us (Railway/Render/Fly) so a one-click deploy gets working auth
+// cookies + share links without anyone hand-typing the domain. Localhost is the
+// last resort. Override BASE_URL once you point a custom domain at it.
+const inferredBaseUrl = process.env.RAILWAY_PUBLIC_DOMAIN
+  ? `https://${process.env.RAILWAY_PUBLIC_DOMAIN}`
+  : process.env.RENDER_EXTERNAL_URL
+    ? process.env.RENDER_EXTERNAL_URL
+    : process.env.FLY_APP_NAME
+      ? `https://${process.env.FLY_APP_NAME}.fly.dev`
+      : `http://localhost:${PORT}`
+const BASE_URL = process.env.BASE_URL ?? inferredBaseUrl
 const DATABASE_URL = process.env.DATABASE_URL
 
 // Single-container self-host: when the web SPA has been built (Docker image, or

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "deploy/Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "pnpm --filter @dock/api start",
+    "healthcheckPath": "/healthz",
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}


### PR DESCRIPTION
Builds on the single-container image (#37) to make the managed-host path turnkey.

- **Auto-detected public URL** (`apps/api/src/node.ts`): when `BASE_URL` is unset, infer it from the host's assigned domain — `RAILWAY_PUBLIC_DOMAIN`, `RENDER_EXTERNAL_URL`, or `FLY_APP_NAME` → `*.fly.dev`. A one-click deploy then gets working auth cookies + share links with nothing to hand-type. Explicit `BASE_URL` still wins (custom domains).
- **`railway.json`**: builds `deploy/Dockerfile`, `/healthz` check, restart policy — so Railway's deploy-from-repo flow just works.
- **README → "Deploy to the cloud"**: Railway + Fly badges, the deploy-from-repo / `fly launch` steps, and the `/data` volume note (SQLite persistence) or Postgres alternative.
- **DEPLOY.md**: a managed-host (Railway / Render / Fly) subsection — volume, auto-URL detection, and setting `DOCK_AUTH_SECRET` on ephemeral filesystems.

The repo is private today, so the buttons one-click once it's public; the deploy-from-repo (connected GitHub) and `fly launch` flows work now. 92 API tests pass; typecheck + biome clean.