### PR TITLE
Origin isolation: serve artifact bytes off the cookie origin (A4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,13 @@ DATA_DIR=./data
 # localhost dev ports (3000, 5173) are trusted automatically.
 # DOCK_WEB_ORIGIN=https://app.example.com
 
+# Origin isolation (recommended for any instance hosting other people's HTML):
+# serve artifact bytes from a SEPARATE registrable domain pointed at this same
+# container, so user HTML can never execute on the app's cookie origin. Use a
+# different domain (not a subdomain of BASE_URL) so session cookies can't reach
+# it. Unset = single-origin self-host (the iframe sandbox attribute is the wall).
+# DOCK_SANDBOX_URL=https://usercontent.example.com
+
 # Optional Google sign-in.
 # GOOGLE_CLIENT_ID=
 # GOOGLE_CLIENT_SECRET=

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -130,6 +130,15 @@ export interface AppDeps {
    * owns the app shell; the Node entry wires the static + fallback middleware.
    */
   serveWeb?: boolean
+  /**
+   * A separate origin that serves artifact bytes (`/raw/*`), keeping user HTML
+   * off the app's cookie origin — the real isolation wall (CSP sandbox is
+   * defense-in-depth). When set, the app origin redirects `/raw/*` here, and
+   * this origin serves ONLY raw bytes (never auth, the API, or the app). Use a
+   * different registrable domain so session cookies can never reach it. Unset =
+   * single-origin self-host, where the iframe `sandbox` attribute is the wall.
+   */
+  sandboxOrigin?: string
 }
 
 /** The single workspace (multi-workspace is a later layer). */
@@ -234,6 +243,32 @@ export function createApp(deps: AppDeps): Hono {
   const app = new Hono()
   const bus = createBus()
   const presence = new Presence()
+
+  // ---- Origin isolation (A4) --------------------------------------------
+  // When a sandbox origin is configured, artifact bytes live on a different
+  // registrable domain than the app + auth cookies. This guard, registered
+  // before everything, splits the two:
+  //   · on the sandbox host  → ONLY /raw/* (and /healthz); never auth/API/app,
+  //     so the sandbox can't double as a session front-door.
+  //   · on the app host      → /raw/* 302-redirects to the sandbox, so user
+  //     HTML can never execute on the cookie origin. The redirect IS the wall,
+  //     independent of any client pointing its iframe at the right place.
+  const sandboxHost = deps.sandboxOrigin ? new URL(deps.sandboxOrigin).host : null
+  if (sandboxHost) {
+    const reqHost = (c: Context) => (c.req.header("host") ?? new URL(c.req.url).host).toLowerCase()
+    app.use("*", async (c, next) => {
+      const path = c.req.path
+      if (reqHost(c) === sandboxHost.toLowerCase()) {
+        if (path === "/healthz" || path.startsWith("/raw/")) return next()
+        return c.text("not found", 404)
+      }
+      // App host: bounce raw bytes to the sandbox origin (preserve the path+query).
+      if (path.startsWith("/raw/")) {
+        return c.redirect(`${deps.sandboxOrigin}${path}${new URL(c.req.url).search}`, 302)
+      }
+      return next()
+    })
+  }
 
   // Credentialed CORS for the cross-origin SPA. A wildcard ACAO can't carry
   // cookies, so the request's Origin is echoed back only when it's allow-listed;
@@ -1598,7 +1633,9 @@ export function createApp(deps: AppDeps): Hono {
     const version = await meta.getVersion(artifact.id, n)
     if (!version) return c.text(`no version ${n}`, 404)
     const versions = await meta.listVersions(artifact.id)
-    const rawSrc = `/raw/${artifact.short_id}/v/${n}/index.html`
+    // Point the iframe straight at the sandbox origin when split (skips the
+    // redirect hop); same-origin otherwise.
+    const rawSrc = `${deps.sandboxOrigin ?? ""}/raw/${artifact.short_id}/v/${n}/index.html`
     return c.html(renderShell(artifact, versions, n, rawSrc))
   })
 

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -104,6 +104,9 @@ const app = createApp({
   analytics: process.env.DOCK_ANALYTICS !== "false",
   rateLimit: process.env.DOCK_RATE_LIMIT !== "false",
   serveWeb: SERVE_WEB,
+  // Origin isolation: serve artifact bytes from a separate registrable domain
+  // pointed at this same container. Keeps user HTML off the app's cookie origin.
+  sandboxOrigin: process.env.DOCK_SANDBOX_URL,
   versionWindowMs: process.env.DOCK_VERSION_WINDOW
     ? Number(process.env.DOCK_VERSION_WINDOW) * 60_000
     : undefined,

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -960,6 +960,62 @@ describe("anchored comments", () => {
   })
 })
 
+describe("security: sandbox serving origin (A4)", () => {
+  const app = createApp({
+    meta: new SqliteMetaStore(join(dir, "sandbox.db")),
+    blobs: new FsBlobStore(join(dir, "blobs")),
+    baseUrl: "http://app.test",
+    sandboxOrigin: "http://sandbox.test",
+  })
+  let shortId: string
+
+  it("serves artifact bytes only from the sandbox host; the app host redirects there", async () => {
+    const fd = new FormData()
+    fd.append("file", new Blob([new TextEncoder().encode("<h1>user html</h1>")]), "x.html")
+    shortId = (
+      await (await app.request("http://app.test/v1/artifacts", { method: "POST", body: fd })).json()
+    ).short_id
+
+    // App (cookie) origin must never render user HTML — it 302s to the sandbox.
+    const onApp = await app.request(`http://app.test/raw/${shortId}/v/1/index.html`)
+    expect(onApp.status).toBe(302)
+    expect(onApp.headers.get("location")).toBe(`http://sandbox.test/raw/${shortId}/v/1/index.html`)
+
+    // The sandbox origin serves the bytes.
+    const onSandbox = await app.request(`http://sandbox.test/raw/${shortId}/v/1/index.html`)
+    expect(onSandbox.status).toBe(200)
+    expect(await onSandbox.text()).toContain("<h1>user html</h1>")
+  })
+
+  it("the sandbox host exposes ONLY raw bytes — never the API, auth, or the app", async () => {
+    expect((await app.request("http://sandbox.test/v1/artifacts")).status).toBe(404)
+    expect((await app.request("http://sandbox.test/api/auth/get-session")).status).toBe(404)
+    expect((await app.request(`http://sandbox.test/a/${shortId}`)).status).toBe(404)
+    // Health stays reachable on the sandbox host (for its own monitoring).
+    expect((await app.request("http://sandbox.test/healthz")).status).toBe(200)
+  })
+
+  it("the viewer shell points its iframe at the sandbox origin", async () => {
+    const shell = await (await app.request(`http://app.test/a/${shortId}`)).text()
+    expect(shell).toContain(`http://sandbox.test/raw/${shortId}/v/1/index.html`)
+  })
+
+  it("without a sandbox origin, raw is served in place (single-origin self-host)", async () => {
+    const solo = createApp({
+      meta: new SqliteMetaStore(join(dir, "solo.db")),
+      blobs: new FsBlobStore(join(dir, "blobs")),
+      baseUrl: "http://app.test",
+    })
+    const fd = new FormData()
+    fd.append("file", new Blob([new TextEncoder().encode("<h1>solo</h1>")]), "s.html")
+    const sid = (await (await solo.request("/v1/artifacts", { method: "POST", body: fd })).json())
+      .short_id
+    const raw = await solo.request(`/raw/${sid}/v/1/index.html`)
+    expect(raw.status).toBe(200)
+    expect(await raw.text()).toContain("<h1>solo</h1>")
+  })
+})
+
 describe("security: webhook SSRF guard", () => {
   const owner: TestUser = { id: "u_wh", email: "wh@dock.test", name: "Wh" }
   const { app } = makeAuthedApp("ssrf", [owner])


### PR DESCRIPTION
## Why

A host of arbitrary user HTML must never run that HTML on the same origin as its own session cookie — otherwise an artifact can read the host's auth. Today the embedded viewer serves `/raw/*` from the app origin; the CSP `sandbox` attribute is the only isolation. This adds the real wall: a **separate serving origin**.

## What

`DOCK_SANDBOX_URL` points artifact bytes at a separate registrable domain aimed at this same container. When set, a guard registered before everything:

- **On the sandbox host** — serves *only* `/raw/*` (and `/healthz`). The API, auth, and the SPA all 404 there, so the sandbox domain can't become a second session front-door.
- **On the app host** — `/raw/*` **302-redirects to the sandbox origin**. User HTML can therefore only ever render off the cookie origin, and the redirect enforces it regardless of where a client points its iframe. The CSP sandbox stays as defense-in-depth.
- The viewer shell points its iframe straight at the sandbox origin (skips the hop).

**No web changes needed:** the iframe↔host `postMessage` already targets `"*"`, so comment anchoring and the deck protocol work cross-origin unchanged, and every web iframe pointed at the app origin is transparently redirected to the sandbox.

**Self-host stays simple:** unset = single origin, where the iframe `sandbox` attribute remains the isolation (documented).

## Verification

4 tests: app-host `/raw` 302s to the sandbox; the sandbox host serves the bytes; the sandbox host 404s `/v1`, `/api/auth`, and `/a` (only raw + health); the viewer shell embeds the sandbox URL; and with no sandbox origin, raw is served in place. Full suite + typecheck + `biome ci` green. `.env.example` documents the variable and the "use a different registrable domain" requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)