### PR TITLE
feat(workspace): name your workspace + simple Admin/Creator/Viewer roles

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -513,7 +513,17 @@ export function createApp(deps: AppDeps): Hono {
       return c.json({ error: "email and a valid role are required" }, 400)
     const user = await meta.findUserByEmail(b.email.trim())
     if (!user) return c.json({ error: "no Dock user with that email" }, 404)
-    await meta.setMembership({ id: newId("m"), org_id: WORKSPACE, user_id: user.id, role: b.role })
+    // This route both adds and re-roles, so it must honor the same last-Admin
+    // guard as PATCH — otherwise an Admin could demote the sole Admin via PUT.
+    const existing = await meta.getMembership(WORKSPACE, user.id)
+    if (existing?.role === "owner" && b.role !== "owner" && (await isLastOwner(user.id)))
+      return c.json({ error: "the workspace needs at least one admin" }, 409)
+    await meta.setMembership({
+      id: existing?.id ?? newId("m"),
+      org_id: WORKSPACE,
+      user_id: user.id,
+      role: b.role,
+    })
     return c.json({ user_id: user.id, email: user.email, name: user.name, role: b.role }, 201)
   })
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -134,6 +134,17 @@ export interface AppDeps {
 
 /** The single workspace (multi-workspace is a later layer). */
 const WORKSPACE = "local"
+const DEFAULT_WORKSPACE_NAME = "My Workspace"
+
+// Workspace membership is three simple roles, presented to people as
+// Admin / Creator / Viewer:
+//   - owner     → Admin:   manage members + settings (and everything below)
+//   - editor    → Creator: create + publish artifacts
+//   - commenter → Viewer:  read + comment
+// The canonical Role vocabulary is unchanged; a bare read-only "viewer" isn't
+// offered as a workspace role (a Viewer can always comment).
+const isWorkspaceRole = (v: unknown): v is Role =>
+  v === "owner" || v === "editor" || v === "commenter"
 
 const VISIBILITIES = ["public", "link", "org", "password"] as const
 
@@ -449,6 +460,89 @@ export function createApp(deps: AppDeps): Hono {
     return c.json({ users: all })
   })
 
+  // ---- Workspace: name + members (Admin-managed) -------------------------
+  // The workspace must always keep at least one Admin, so it stays manageable:
+  // demoting or removing the last owner is refused.
+  const isLastOwner = async (userId: string): Promise<boolean> => {
+    const owners = (await meta.listMemberships(WORKSPACE)).filter((m) => m.role === "owner")
+    return owners.length <= 1 && owners.some((m) => m.user_id === userId)
+  }
+
+  const memberJson = (
+    m: { user_id: string; role: Role },
+    dir: Map<string, { email: string; name: string | null }>,
+  ) => ({
+    user_id: m.user_id,
+    email: dir.get(m.user_id)?.email ?? null,
+    name: dir.get(m.user_id)?.name ?? null,
+    role: m.role,
+  })
+
+  // The workspace name, the caller's role, and the full member directory.
+  app.get("/v1/workspace", async (c) => {
+    const role = await workspaceRole(c)
+    if (role === null) return c.json({ error: "unauthenticated" }, 401)
+    const [ws, members] = await Promise.all([
+      meta.getWorkspace(WORKSPACE),
+      meta.listMemberships(WORKSPACE),
+    ])
+    const users = await meta.getUsers(members.map((m) => m.user_id))
+    const dir = new Map(users.map((u) => [u.id, u]))
+    return c.json({
+      name: ws?.name ?? DEFAULT_WORKSPACE_NAME,
+      role,
+      members: members.map((m) => memberJson(m, dir)),
+    })
+  })
+
+  // Rename the workspace (Admin only).
+  app.patch("/v1/workspace", async (c) => {
+    if (!(await workspaceCan(c, "manage"))) return c.json({ error: "forbidden" }, 403)
+    const b = (await c.req.json().catch(() => ({}))) as { name?: unknown }
+    const name = typeof b.name === "string" ? b.name.trim().slice(0, 80) : ""
+    if (!name) return c.json({ error: "name required" }, 400)
+    const ws = await meta.setWorkspace(WORKSPACE, name)
+    return c.json({ name: ws.name })
+  })
+
+  // Add a member by email, or update their role (Admin only).
+  app.put("/v1/workspace/members", async (c) => {
+    if (!(await workspaceCan(c, "manage"))) return c.json({ error: "forbidden" }, 403)
+    const b = (await c.req.json().catch(() => ({}))) as { email?: string; role?: unknown }
+    if (!b.email || !isWorkspaceRole(b.role))
+      return c.json({ error: "email and a valid role are required" }, 400)
+    const user = await meta.findUserByEmail(b.email.trim())
+    if (!user) return c.json({ error: "no Dock user with that email" }, 404)
+    await meta.setMembership({ id: newId("m"), org_id: WORKSPACE, user_id: user.id, role: b.role })
+    return c.json({ user_id: user.id, email: user.email, name: user.name, role: b.role }, 201)
+  })
+
+  // Change a member's role (Admin only; can't strip the last Admin).
+  app.patch("/v1/workspace/members/:userId", async (c) => {
+    if (!(await workspaceCan(c, "manage"))) return c.json({ error: "forbidden" }, 403)
+    const userId = c.req.param("userId")
+    const b = (await c.req.json().catch(() => ({}))) as { role?: unknown }
+    if (!isWorkspaceRole(b.role)) return c.json({ error: "a valid role is required" }, 400)
+    const existing = await meta.getMembership(WORKSPACE, userId)
+    if (!existing) return c.json({ error: "not a member" }, 404)
+    if (existing.role === "owner" && b.role !== "owner" && (await isLastOwner(userId)))
+      return c.json({ error: "the workspace needs at least one admin" }, 409)
+    await meta.setMembership({ id: existing.id, org_id: WORKSPACE, user_id: userId, role: b.role })
+    return c.json({ user_id: userId, role: b.role })
+  })
+
+  // Remove a member (Admin only; can't remove the last Admin).
+  app.delete("/v1/workspace/members/:userId", async (c) => {
+    if (!(await workspaceCan(c, "manage"))) return c.json({ error: "forbidden" }, 403)
+    const userId = c.req.param("userId")
+    const existing = await meta.getMembership(WORKSPACE, userId)
+    if (!existing) return c.body(null, 204)
+    if (existing.role === "owner" && (await isLastOwner(userId)))
+      return c.json({ error: "the workspace needs at least one admin" }, 409)
+    await meta.removeMembership(WORKSPACE, userId)
+    return c.body(null, 204)
+  })
+
   // ---- Agents: registry (owner-managed) + the pull inbox -----------------
   const agentJson = (a: AgentRecord) => ({
     id: a.id,
@@ -583,13 +677,19 @@ export function createApp(deps: AppDeps): Hono {
     const me = await currentUser(c)
     if (!me && deps.token && bearer(c) !== deps.token)
       return c.json({ error: "unauthenticated" }, 401)
-    const [total, tags, favIds] = await Promise.all([
+    const [total, tags, favIds, ws] = await Promise.all([
       meta.countArtifacts(),
       meta.tagCounts(),
       me ? meta.listUserFavoriteIds(me.id) : Promise.resolve([]),
+      meta.getWorkspace(WORKSPACE),
     ])
     tags.sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
-    return c.json({ total, favorites: favIds.length, tags })
+    return c.json({
+      total,
+      favorites: favIds.length,
+      tags,
+      workspace: ws?.name ?? DEFAULT_WORKSPACE_NAME,
+    })
   })
 
   // ---- Collections (shareable groups; a member's role propagates to items) -

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -1350,3 +1350,83 @@ describe("collections", () => {
     expect(await meta.getByShortId(short_id)).not.toBeNull()
   })
 })
+
+describe("workspace: name + members (Admin / Creator / Viewer)", () => {
+  const admin: TestUser = { id: "u_ws_admin", email: "wsadmin@dock.test", name: "Ada" }
+  const creator: TestUser = { id: "u_ws_creator", email: "wscreator@dock.test", name: "Cara" }
+  const viewer: TestUser = { id: "u_ws_viewer", email: "wsviewer@dock.test", name: "Vic" }
+  const { app } = makeAuthedApp("workspace", [admin, creator, viewer], "commenter")
+
+  const ws = async (headers: Record<string, string>) =>
+    (await app.request("/v1/workspace", { headers })).json()
+  const patchWs = (headers: Record<string, string>, body: unknown) =>
+    app.request("/v1/workspace", { ...jsonAs(headers, body), method: "PATCH" })
+  const putMember = (headers: Record<string, string>, body: unknown) =>
+    app.request("/v1/workspace/members", { ...jsonAs(headers, body), method: "PUT" })
+  const patchMember = (headers: Record<string, string>, userId: string, body: unknown) =>
+    app.request(`/v1/workspace/members/${userId}`, { ...jsonAs(headers, body), method: "PATCH" })
+
+  it("defaults the name and makes the first user the Admin (owner)", async () => {
+    // The first /v1/me claims ownership; the others provision as Viewers.
+    const me = await (await app.request("/v1/me", { headers: as(admin.email) })).json()
+    expect(me.user.role).toBe("owner")
+    await app.request("/v1/me", { headers: as(creator.email) })
+    await app.request("/v1/me", { headers: as(viewer.email) })
+    const w = await ws(as(admin.email))
+    expect(w.name).toBe("My Workspace")
+    expect(w.role).toBe("owner")
+    expect(w.members).toHaveLength(3)
+  })
+
+  it("an Admin renames the workspace; a Viewer cannot; the name shows in browse", async () => {
+    const ok = await patchWs(as(admin.email), { name: "Acme HQ" })
+    expect(ok.status).toBe(200)
+    expect((await ok.json()).name).toBe("Acme HQ")
+    expect((await ws(as(viewer.email))).name).toBe("Acme HQ")
+    expect((await patchWs(as(viewer.email), { name: "Hijacked" })).status).toBe(403)
+    const summary = await (await app.request("/v1/tags", { headers: as(admin.email) })).json()
+    expect(summary.workspace).toBe("Acme HQ")
+  })
+
+  it("an Admin promotes a member to Creator (editor); a Viewer cannot add anyone", async () => {
+    expect(
+      (await putMember(as(admin.email), { email: creator.email, role: "editor" })).status,
+    ).toBe(201)
+    const me = await (await app.request("/v1/me", { headers: as(creator.email) })).json()
+    expect(me.user.role).toBe("editor")
+    expect((await putMember(as(viewer.email), { email: viewer.email, role: "owner" })).status).toBe(
+      403,
+    )
+  })
+
+  it("rejects an unknown email and an invalid role", async () => {
+    expect(
+      (await putMember(as(admin.email), { email: "ghost@dock.test", role: "editor" })).status,
+    ).toBe(404)
+    expect(
+      (await putMember(as(admin.email), { email: creator.email, role: "wizard" })).status,
+    ).toBe(400)
+  })
+
+  it("changes a member's role and removes a member", async () => {
+    expect((await patchMember(as(admin.email), creator.id, { role: "owner" })).status).toBe(200)
+    const del = await app.request(`/v1/workspace/members/${viewer.id}`, {
+      method: "DELETE",
+      headers: as(admin.email),
+    })
+    expect(del.status).toBe(204)
+    const w = await ws(as(admin.email))
+    expect(w.members.find((m: { user_id: string }) => m.user_id === viewer.id)).toBeUndefined()
+  })
+
+  it("won't strip or remove the last Admin", async () => {
+    // creator is currently an Admin too; demote it so `admin` is the only one.
+    expect((await patchMember(as(admin.email), creator.id, { role: "editor" })).status).toBe(200)
+    expect((await patchMember(as(admin.email), admin.id, { role: "editor" })).status).toBe(409)
+    const remove = await app.request(`/v1/workspace/members/${admin.id}`, {
+      method: "DELETE",
+      headers: as(admin.email),
+    })
+    expect(remove.status).toBe(409)
+  })
+})

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -1430,3 +1430,108 @@ describe("workspace: name + members (Admin / Creator / Viewer)", () => {
     expect(remove.status).toBe(409)
   })
 })
+
+describe("workspace: edge conditions", () => {
+  const admin: TestUser = { id: "u_we_admin", email: "weadmin@dock.test", name: "Ed" }
+  const other: TestUser = { id: "u_we_other", email: "weother@dock.test", name: "Otto" }
+  const { app } = makeAuthedApp("ws-edge", [admin, other], "commenter")
+
+  const putMember = (headers: Record<string, string>, body: unknown) =>
+    app.request("/v1/workspace/members", { ...jsonAs(headers, body), method: "PUT" })
+  const patchWs = (headers: Record<string, string>, body: unknown) =>
+    app.request("/v1/workspace", { ...jsonAs(headers, body), method: "PATCH" })
+
+  it("provisions the first user as Admin, then clamps long names and rejects blank ones", async () => {
+    await app.request("/v1/me", { headers: as(admin.email) }) // first member → owner
+    expect((await patchWs(as(admin.email), { name: "   " })).status).toBe(400)
+    expect((await patchWs(as(admin.email), {})).status).toBe(400)
+    const ok = await patchWs(as(admin.email), { name: "x".repeat(200) })
+    expect(ok.status).toBe(200)
+    expect((await ok.json()).name).toHaveLength(80)
+  })
+
+  it("rejects any role outside Admin / Creator / Viewer", async () => {
+    for (const role of ["viewer", "admin", "boss", 3, null]) {
+      expect((await putMember(as(admin.email), { email: other.email, role })).status).toBe(400)
+    }
+  })
+
+  it("PUT is idempotent: re-adding a member re-roles them without duplicating", async () => {
+    expect(
+      (await putMember(as(admin.email), { email: other.email, role: "commenter" })).status,
+    ).toBe(201)
+    expect((await putMember(as(admin.email), { email: other.email, role: "editor" })).status).toBe(
+      201,
+    )
+    const w = await (await app.request("/v1/workspace", { headers: as(admin.email) })).json()
+    const rows = w.members.filter((m: { user_id: string }) => m.user_id === other.id)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].role).toBe("editor")
+  })
+
+  it("the add/update (PUT) path also refuses to strip the last Admin", async () => {
+    // admin is the sole owner — demoting itself via PUT must be blocked too.
+    expect(
+      (await putMember(as(admin.email), { email: admin.email, role: "commenter" })).status,
+    ).toBe(409)
+  })
+
+  it("404s a PATCH on a non-member; a Creator can't manage", async () => {
+    // `other` is a Creator (editor) — no manage rights.
+    expect((await patchWs(as(other.email), { name: "Nope" })).status).toBe(403)
+    expect((await putMember(as(other.email), { email: other.email, role: "owner" })).status).toBe(
+      403,
+    )
+    const ghost = await app.request("/v1/workspace/members/u_ghost", {
+      ...jsonAs(as(admin.email), { role: "editor" }),
+      method: "PATCH",
+    })
+    expect(ghost.status).toBe(404)
+  })
+
+  it("allows self-demotion once a second Admin exists", async () => {
+    expect((await putMember(as(admin.email), { email: other.email, role: "owner" })).status).toBe(
+      201,
+    )
+    const demote = await app.request(`/v1/workspace/members/${admin.id}`, {
+      ...jsonAs(as(admin.email), { role: "editor" }),
+      method: "PATCH",
+    })
+    expect(demote.status).toBe(200)
+    // having dropped Admin, the former Admin can no longer manage.
+    expect((await patchWs(as(admin.email), { name: "X" })).status).toBe(403)
+  })
+})
+
+describe("workspace: open + token modes", () => {
+  it("an unsecured instance trusts anon as Admin and defaults the name", async () => {
+    const openApp = createApp({
+      meta: new SqliteMetaStore(join(dir, "ws-open.db")),
+      blobs: new FsBlobStore(join(dir, "blobs")),
+      baseUrl: "http://dock.test",
+    })
+    const w = await (await openApp.request("/v1/workspace")).json()
+    expect(w.name).toBe("My Workspace")
+    expect(w.role).toBe("owner")
+    expect(w.members).toEqual([])
+    const renamed = await openApp.request("/v1/workspace", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Solo" }),
+    })
+    expect(renamed.status).toBe(200)
+    expect((await renamed.json()).name).toBe("Solo")
+  })
+
+  it("a static token acts as Admin", async () => {
+    const admin: TestUser = { id: "u_tok_admin", email: "tokadmin@dock.test", name: "Toki" }
+    const { app: tokApp } = makeAuthedApp("ws-token", [admin], "commenter")
+    const r = await tokApp.request("/v1/workspace", {
+      method: "PATCH",
+      headers: { "content-type": "application/json", ...bearer("tok") },
+      body: JSON.stringify({ name: "Tokenspace" }),
+    })
+    expect(r.status).toBe(200)
+    expect((await r.json()).name).toBe("Tokenspace")
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -75,6 +75,12 @@ export interface ArtifactMember {
   name: string | null
   role: Role
 }
+/** The workspace: its name, the caller's role, and the member directory. */
+export interface Workspace {
+  name: string
+  role: Role
+  members: ArtifactMember[]
+}
 export interface Analytics {
   total: number
   unique: number
@@ -220,6 +226,7 @@ export const api = {
     total: number
     favorites: number
     tags: { tag: string; count: number }[]
+    workspace: string
   }> => f("/v1/tags", opts()).then(j),
   getArtifact: (id: string): Promise<Artifact> => f(`/v1/artifacts/${id}`, opts()).then(j),
   getContent: (id: string, v?: number): Promise<string> =>
@@ -278,6 +285,19 @@ export const api = {
     f("/v1/agents", opts({ name, role })).then(j),
   deleteAgent: (id: string): Promise<void> =>
     f(`/v1/agents/${id}`, { method: "DELETE", credentials: "include" }).then(() => undefined),
+
+  // Workspace name + members (Admin / Creator / Viewer = owner / editor / commenter)
+  getWorkspace: (): Promise<Workspace> => f("/v1/workspace", opts()).then(j),
+  renameWorkspace: (name: string): Promise<{ name: string }> =>
+    f("/v1/workspace", { ...opts({ name }), method: "PATCH" }).then(j),
+  addWorkspaceMember: (email: string, role: Role): Promise<ArtifactMember> =>
+    f("/v1/workspace/members", { ...opts({ email, role }), method: "PUT" }).then(j),
+  setWorkspaceMemberRole: (userId: string, role: Role): Promise<{ user_id: string; role: Role }> =>
+    f(`/v1/workspace/members/${userId}`, { ...opts({ role }), method: "PATCH" }).then(j),
+  removeWorkspaceMember: (userId: string): Promise<void> =>
+    f(`/v1/workspace/members/${userId}`, { method: "DELETE", credentials: "include" }).then(
+      () => undefined,
+    ),
 
   // Collections (shareable groups; sharing grants the role on every item)
   listCollections: (): Promise<{ collections: Collection[] }> =>

--- a/apps/web/src/pages/Library.tsx
+++ b/apps/web/src/pages/Library.tsx
@@ -17,7 +17,7 @@ type Filter =
   | { kind: "tag"; tag: string }
   | { kind: "collection"; id: string; title: string }
 type TagCount = { tag: string; count: number }
-type Summary = { total: number; favorites: number; tags: TagCount[] }
+type Summary = { total: number; favorites: number; tags: TagCount[]; workspace: string }
 
 const RAIL_KEY = "dock.browse.rail"
 const PAGE = 30
@@ -270,6 +270,7 @@ export function Library() {
           rail={!isMobile && rail}
           drawer={isMobile}
           open={drawer}
+          workspace={summary?.workspace ?? ""}
           total={summary?.total ?? 0}
           favCount={summary?.favorites ?? 0}
           tags={summary?.tags ?? []}
@@ -684,6 +685,7 @@ function Sidebar({
   rail,
   drawer,
   open,
+  workspace,
   total,
   favCount,
   tags,
@@ -698,6 +700,7 @@ function Sidebar({
   rail: boolean
   drawer: boolean
   open: boolean
+  workspace: string
   total: number
   favCount: number
   tags: TagCount[]
@@ -720,6 +723,19 @@ function Sidebar({
   }
   return (
     <aside className={cls} aria-label="Browse">
+      {!rail && workspace && (
+        <button
+          className="side-item"
+          onClick={onSettings}
+          title="Workspace settings"
+          style={{ fontWeight: 600 }}
+        >
+          <span className="ic">◆</span>
+          <span className="lbl" style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+            {workspace}
+          </span>
+        </button>
+      )}
       <div className="side-lbl">Library</div>
       <button
         className={`side-item${filter.kind === "all" ? " on" : ""}`}

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -1,10 +1,29 @@
 import { useNavigate } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
-import { type Agent, api, type Delivery, type Role, type Webhook } from "../api"
+import {
+  type Agent,
+  type ArtifactMember,
+  api,
+  type Delivery,
+  type Role,
+  type Webhook,
+  type Workspace,
+} from "../api"
 import { Header, useToast } from "../components"
 import { useAuth } from "../ctx"
 
 const ALL_EVENTS = ["comment.created", "comment.resolved", "version.published"] as const
+
+// Workspace membership, presented as three simple roles. The values are the
+// canonical Role vocabulary; the labels are what people see.
+const WS_ROLES: { value: Role; label: string; hint: string }[] = [
+  { value: "owner", label: "Admin", hint: "Add people, manage settings" },
+  { value: "editor", label: "Creator", hint: "Create & publish" },
+  { value: "commenter", label: "Viewer", hint: "Read & comment" },
+]
+const roleLabel = (r: Role): string => WS_ROLES.find((x) => x.value === r)?.label ?? "Viewer"
+// A historical bare "viewer" maps onto the Viewer (commenter) option.
+const roleValue = (r: Role): Role => (r === "viewer" ? "commenter" : r)
 
 export function Settings() {
   const { me, loading } = useAuth()
@@ -48,10 +67,12 @@ export function Settings() {
           Settings
         </h2>
         <p className="muted" style={{ margin: "0 0 26px", fontSize: 14 }}>
-          Notifications and integrations for this workspace.
+          Your workspace, members, and integrations.
         </p>
 
-        <section>
+        <WorkspaceSection meId={me.id} show={show} />
+
+        <section style={{ marginTop: 38 }}>
           <div style={{ display: "flex", alignItems: "baseline", gap: 10, marginBottom: 4 }}>
             <h3 className="display" style={{ fontSize: 16, margin: 0 }}>
               Webhooks &amp; Slack
@@ -166,6 +187,235 @@ export function Settings() {
       </main>
       {toast}
     </div>
+  )
+}
+
+function WorkspaceSection({ meId, show }: { meId: string; show: (m: string) => void }) {
+  const [ws, setWs] = useState<Workspace | null>(null)
+  const [name, setName] = useState("")
+  const [savingName, setSavingName] = useState(false)
+  const [email, setEmail] = useState("")
+  const [addRole, setAddRole] = useState<Role>("commenter")
+  const [adding, setAdding] = useState(false)
+
+  const load = () =>
+    api
+      .getWorkspace()
+      .then((w) => {
+        setWs(w)
+        setName(w.name)
+      })
+      .catch(() => setWs(null))
+  useEffect(() => {
+    load()
+  }, [])
+
+  const isAdmin = ws?.role === "owner"
+
+  const saveName = async () => {
+    const n = name.trim()
+    if (!n || n === ws?.name) return
+    setSavingName(true)
+    try {
+      const r = await api.renameWorkspace(n)
+      setWs((w) => (w ? { ...w, name: r.name } : w))
+      show("Workspace renamed")
+    } catch (e) {
+      show((e as Error).message)
+    } finally {
+      setSavingName(false)
+    }
+  }
+
+  const addMember = async () => {
+    const em = email.trim()
+    if (!em) return
+    setAdding(true)
+    try {
+      await api.addWorkspaceMember(em, addRole)
+      setEmail("")
+      show("Member added")
+      load()
+    } catch (e) {
+      show((e as Error).message)
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  const changeRole = async (userId: string, role: Role) => {
+    try {
+      await api.setWorkspaceMemberRole(userId, role)
+      setWs((w) =>
+        w
+          ? { ...w, members: w.members.map((m) => (m.user_id === userId ? { ...m, role } : m)) }
+          : w,
+      )
+      show("Role updated")
+    } catch (e) {
+      show((e as Error).message)
+      load()
+    }
+  }
+
+  const removeMember = async (m: ArtifactMember) => {
+    if (!confirm(`Remove ${m.name ?? m.email ?? "this member"} from the workspace?`)) return
+    try {
+      await api.removeWorkspaceMember(m.user_id)
+      setWs((w) => (w ? { ...w, members: w.members.filter((x) => x.user_id !== m.user_id) } : w))
+      show("Member removed")
+    } catch (e) {
+      show((e as Error).message)
+    }
+  }
+
+  return (
+    <section>
+      <h3 className="display" style={{ fontSize: 16, margin: "0 0 4px" }}>
+        Workspace
+      </h3>
+      <p className="muted" style={{ fontSize: 13, margin: "0 0 16px" }}>
+        Name your workspace and choose who's in it. <strong>Admins</strong> add people,{" "}
+        <strong>Creators</strong> publish artifacts, <strong>Viewers</strong> read and comment.
+      </p>
+
+      <div className="card" style={{ padding: 16 }}>
+        <div className="muted" style={{ fontSize: 12, fontWeight: 600 }}>
+          Workspace name
+        </div>
+        <div style={{ display: "flex", gap: 8, marginTop: 6 }}>
+          <input
+            className="input"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={!isAdmin || ws === null}
+            maxLength={80}
+            placeholder="My Workspace"
+            style={{ flex: 1 }}
+          />
+          {isAdmin && (
+            <button
+              className="btn pri"
+              onClick={saveName}
+              disabled={savingName || !name.trim() || name.trim() === ws?.name}
+            >
+              {savingName ? "Saving…" : "Save"}
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div style={{ display: "flex", alignItems: "baseline", gap: 10, margin: "22px 0 4px" }}>
+        <h4 className="display" style={{ fontSize: 14, margin: 0 }}>
+          Members
+        </h4>
+        <span className="muted" style={{ fontSize: 13 }}>
+          · {ws?.members.length ?? 0}
+        </span>
+      </div>
+
+      {isAdmin && (
+        <div className="card" style={{ padding: 16, marginBottom: 14 }}>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <input
+              className="input"
+              placeholder="Email of a Dock user"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && addMember()}
+              style={{ flex: 1, minWidth: 200 }}
+            />
+            <select
+              className="input"
+              value={addRole}
+              onChange={(e) => setAddRole(e.target.value as Role)}
+              style={{ width: 130 }}
+            >
+              {WS_ROLES.map((r) => (
+                <option key={r.value} value={r.value}>
+                  {r.label}
+                </option>
+              ))}
+            </select>
+            <button className="btn pri" onClick={addMember} disabled={adding || !email.trim()}>
+              {adding ? "Adding…" : "Add"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 11 }}>
+        {ws === null ? (
+          <div className="center" style={{ height: 80 }}>
+            <div className="spin" />
+          </div>
+        ) : (
+          ws.members.map((m) => (
+            <div
+              key={m.user_id}
+              className="card"
+              style={{ padding: "12px 15px", display: "flex", alignItems: "center", gap: 12 }}
+            >
+              <span style={{ fontSize: 16 }}>👤</span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 14, fontWeight: 600 }}>
+                  {m.name ?? m.email ?? m.user_id}
+                  {m.user_id === meId && (
+                    <span className="muted" style={{ fontWeight: 400 }}>
+                      {" "}
+                      (you)
+                    </span>
+                  )}
+                </div>
+                {m.email && m.name && (
+                  <div className="muted" style={{ fontSize: 11.5 }}>
+                    {m.email}
+                  </div>
+                )}
+              </div>
+              {isAdmin ? (
+                <select
+                  className="input"
+                  value={roleValue(m.role)}
+                  onChange={(e) => changeRole(m.user_id, e.target.value as Role)}
+                  style={{ width: 120 }}
+                >
+                  {WS_ROLES.map((r) => (
+                    <option key={r.value} value={r.value}>
+                      {r.label}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <span
+                  className="mono"
+                  style={{
+                    fontSize: 10,
+                    fontWeight: 700,
+                    color: "var(--ac)",
+                    background: "var(--ac-soft)",
+                    borderRadius: 999,
+                    padding: "1px 7px",
+                  }}
+                >
+                  {roleLabel(m.role)}
+                </span>
+              )}
+              {isAdmin && (
+                <button
+                  className="btn sm"
+                  onClick={() => removeMember(m)}
+                  style={{ color: "var(--bad)" }}
+                  title="Remove member"
+                >
+                  Remove
+                </button>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </section>
   )
 }
 

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -137,11 +137,17 @@ export interface MetaStore {
   recentDeliveries(webhookId: string, limit: number): Promise<DeliveryRecord[]>
 
   // ---- Permissions: workspace membership + per-artifact shares -----------
+  /** The workspace's display name + metadata (one row per org_id). */
+  getWorkspace(orgId: string): Promise<WorkspaceRecord | null>
+  /** Insert or rename the workspace. */
+  setWorkspace(orgId: string, name: string): Promise<WorkspaceRecord>
   getMembership(orgId: string, userId: string): Promise<MembershipRecord | null>
   listMemberships(orgId: string): Promise<MembershipRecord[]>
   countMemberships(orgId: string): Promise<number>
   /** Insert or update a member's workspace role. */
   setMembership(m: NewMembership): Promise<MembershipRecord>
+  /** Remove a member from the workspace. */
+  removeMembership(orgId: string, userId: string): Promise<void>
 
   getArtifactMember(artifactId: string, userId: string): Promise<ArtifactMemberRecord | null>
   listArtifactMembers(artifactId: string): Promise<ArtifactMemberRecord[]>
@@ -349,6 +355,13 @@ export interface NewNotification {
   thread_id: string
   comment_id: string
   preview: string
+}
+
+/** The workspace itself — a display name keyed by org_id (one row). */
+export interface WorkspaceRecord {
+  id: string
+  name: string
+  created_at: string
 }
 
 export interface MembershipRecord {

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -35,6 +35,7 @@ import type {
   VersionRecord,
   ViewStats,
   WebhookRecord,
+  WorkspaceRecord,
 } from "@dock/core"
 import { and, asc, count, desc, eq, inArray, isNull, like, lt, lte, or, sql } from "drizzle-orm"
 import { type DrizzleD1Database, drizzle } from "drizzle-orm/d1"
@@ -55,6 +56,7 @@ import {
   version,
   webhook,
   webhookDelivery,
+  workspace,
 } from "./schema"
 
 const schema = {
@@ -64,6 +66,7 @@ const schema = {
   webhook,
   webhookDelivery,
   membership,
+  workspace,
   artifactMember,
   notification,
   artifactFavorite,
@@ -343,6 +346,23 @@ export class D1MetaStore implements MetaStore {
         target: [membership.org_id, membership.user_id],
         set: { role: m.role },
       })
+      .returning()
+      .get()
+  }
+  async removeMembership(orgId: string, userId: string): Promise<void> {
+    await this.db
+      .delete(membership)
+      .where(and(eq(membership.org_id, orgId), eq(membership.user_id, userId)))
+      .run()
+  }
+  async getWorkspace(orgId: string): Promise<WorkspaceRecord | null> {
+    return (await this.db.select().from(workspace).where(eq(workspace.id, orgId)).get()) ?? null
+  }
+  setWorkspace(orgId: string, name: string): Promise<WorkspaceRecord> {
+    return this.db
+      .insert(workspace)
+      .values({ id: orgId, name })
+      .onConflictDoUpdate({ target: workspace.id, set: { name } })
       .returning()
       .get()
   }

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -110,6 +110,13 @@ export const membership = pgTable(
   (t) => [uniqueIndex("membership_org_user").on(t.org_id, t.user_id)],
 )
 
+// The workspace itself — just a display name for now (one row per org_id).
+export const workspace = pgTable("workspace", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  created_at: text("created_at").notNull().$defaultFn(isoNow),
+})
+
 export const artifactMember = pgTable(
   "artifact_member",
   {
@@ -363,6 +370,11 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
     role TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT ${isoDefault},
     UNIQUE (org_id, user_id)
+  )`,
+  `CREATE TABLE IF NOT EXISTS workspace (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT ${isoDefault}
   )`,
   `CREATE TABLE IF NOT EXISTS artifact_member (
     id TEXT PRIMARY KEY,

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -34,6 +34,7 @@ import type {
   VersionRecord,
   ViewStats,
   WebhookRecord,
+  WorkspaceRecord,
 } from "@dock/core"
 import { and, asc, count, desc, eq, inArray, isNull, like, lt, lte, or, sql } from "drizzle-orm"
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres"
@@ -56,6 +57,7 @@ import {
   version,
   webhook,
   webhookDelivery,
+  workspace,
 } from "./pg-schema"
 
 const schema = {
@@ -65,6 +67,7 @@ const schema = {
   webhook,
   webhookDelivery,
   membership,
+  workspace,
   artifactMember,
   notification,
   artifactFavorite,
@@ -348,6 +351,23 @@ export class PgMetaStore implements MetaStore {
         target: [membership.org_id, membership.user_id],
         set: { role: m.role },
       })
+      .returning()
+    return rows[0]
+  }
+  async removeMembership(orgId: string, userId: string): Promise<void> {
+    await this.db
+      .delete(membership)
+      .where(and(eq(membership.org_id, orgId), eq(membership.user_id, userId)))
+  }
+  async getWorkspace(orgId: string): Promise<WorkspaceRecord | null> {
+    const rows = await this.db.select().from(workspace).where(eq(workspace.id, orgId))
+    return rows[0] ?? null
+  }
+  async setWorkspace(orgId: string, name: string): Promise<WorkspaceRecord> {
+    const rows = await this.db
+      .insert(workspace)
+      .values({ id: orgId, name })
+      .onConflictDoUpdate({ target: workspace.id, set: { name } })
       .returning()
     return rows[0]
   }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -113,6 +113,13 @@ export const membership = sqliteTable(
   (t) => [uniqueIndex("membership_org_user").on(t.org_id, t.user_id)],
 )
 
+// The workspace itself — just a display name for now (one row per org_id).
+export const workspace = sqliteTable("workspace", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  created_at: text("created_at").notNull().default(now),
+})
+
 export const artifactMember = sqliteTable(
   "artifact_member",
   {
@@ -361,6 +368,11 @@ export const SCHEMA_STATEMENTS: string[] = [
     role TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
     UNIQUE (org_id, user_id)
+  )`,
+  `CREATE TABLE IF NOT EXISTS workspace (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
   )`,
   `CREATE TABLE IF NOT EXISTS artifact_member (
     id TEXT PRIMARY KEY,

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -34,6 +34,7 @@ import type {
   VersionRecord,
   ViewStats,
   WebhookRecord,
+  WorkspaceRecord,
 } from "@dock/core"
 import Database from "better-sqlite3"
 import { and, asc, count, desc, eq, inArray, isNull, like, lt, lte, or, sql } from "drizzle-orm"
@@ -57,6 +58,7 @@ import {
   version,
   webhook,
   webhookDelivery,
+  workspace,
 } from "./schema"
 
 const VIEW_WINDOW_MS = 30 * 86400_000
@@ -68,6 +70,7 @@ const schema = {
   webhook,
   webhookDelivery,
   membership,
+  workspace,
   artifactMember,
   notification,
   artifactFavorite,
@@ -363,6 +366,25 @@ export class SqliteMetaStore implements MetaStore {
           target: [membership.org_id, membership.user_id],
           set: { role: m.role },
         })
+        .returning()
+        .get(),
+    )
+  }
+  async removeMembership(orgId: string, userId: string): Promise<void> {
+    this.db
+      .delete(membership)
+      .where(and(eq(membership.org_id, orgId), eq(membership.user_id, userId)))
+      .run()
+  }
+  async getWorkspace(orgId: string): Promise<WorkspaceRecord | null> {
+    return this.db.select().from(workspace).where(eq(workspace.id, orgId)).get() ?? null
+  }
+  setWorkspace(orgId: string, name: string): Promise<WorkspaceRecord> {
+    return Promise.resolve(
+      this.db
+        .insert(workspace)
+        .values({ id: orgId, name })
+        .onConflictDoUpdate({ target: workspace.id, set: { name } })
         .returning()
         .get(),
     )


### PR DESCRIPTION
Makes the workspace a first-class, manageable thing: a name and members with three simple roles.

## Roles (what you see → what it maps to)
- **Admin** = `owner`: add people, manage settings (and everything below)
- **Creator** = `editor`: create + publish artifacts
- **Viewer** = `commenter`: read + comment

The canonical `Role` vocabulary (viewer<commenter<editor<owner) is unchanged. The workspace UI presents and validates a three-role subset; a bare read-only `viewer` isn't offered (a Viewer can always comment). Per-artifact and collection shares are untouched.

## Data
- New `workspace` table (id, name) across sqlite / pg / d1 + boot DDL.
- `MetaStore` gains `getWorkspace`, `setWorkspace` (upsert), `removeMembership`, implemented in all three drivers.

## API
- `GET /v1/workspace` → name + caller's role + member directory
- `PATCH /v1/workspace` → rename (Admin, clamps to 80 chars)
- `PUT /v1/workspace/members` → add by email / re-role
- `PATCH /v1/workspace/members/:userId` → change role
- `DELETE /v1/workspace/members/:userId` → remove
- All member mutations are Admin-gated with a **last-Admin guard** (the workspace can never become unmanageable). Workspace name is folded into the `/v1/tags` browse summary.

## Web
- Settings gains a **Workspace** section: rename + member list (role selects, add-by-email, remove). Non-admins see a read-only view (locked name, role badges).
- The workspace name heads the Library sidebar.

## Tests
14 workspace integration tests (106 total in apps/api), covering rename gating, add/promote/remove, name clamp/blank reject, role validation, PUT idempotency, the last-Admin guard on **both** PATCH and PUT, non-member 404, Creator-can't-manage, self-demotion, and open-mode / static-token behavior.

An edge pass found and fixed a real gap: the PUT add/update path originally bypassed the last-Admin guard. Fixed.

## Note
On a secured instance, removing a member is soft: anyone who can still authenticate re-joins at the default role (the lazy-provisioning model). Sensitive-artifact access stays with visibility + shares. A hard block-list is intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)