### PR TITLE
Analytics: exclude owner self-views + Notion/Docs people-first panel

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1674,6 +1674,11 @@ export function createApp(deps: AppDeps): Hono {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact || artifact.current_version === 0 || !(await authorize(c, "read", artifact)))
       return c.json({ error: "not found" }, 404)
+    // The owner's own opens aren't audience — don't count them (Notion/Docs do
+    // the same). `manage` requires the owner role, so this is exactly "is owner";
+    // editors/commenters/viewers and anonymous openers still count.
+    const actor = await actorFor(c, artifact)
+    if (actor.kind !== "anon" && can(actor, "manage", artifact.visibility)) return c.body(null, 204)
     const me = await currentUser(c)
     let viewer: string
     let kind: "user" | "anon"
@@ -1723,13 +1728,15 @@ export function createApp(deps: AppDeps): Hono {
     if (!artifact || !(await authorize(c, "read", artifact)))
       return c.json({ error: "not found" }, 404)
     const stats = await meta.viewStats(artifact.id)
-    // Recent user-viewers are stored by id (stable); resolve to display names.
+    // Recent user-viewers are stored by id (stable); resolve to name + avatar.
     const userIds = stats.recent.filter((r) => r.kind === "user").map((r) => r.viewer)
     if (userIds.length) {
-      const byId = new Map((await meta.getUsers(userIds)).map((u) => [u.id, u.name ?? u.email]))
-      stats.recent = stats.recent.map((r) =>
-        r.kind === "user" ? { ...r, viewer: byId.get(r.viewer) ?? "Someone" } : r,
-      )
+      const byId = new Map((await meta.getUsers(userIds)).map((u) => [u.id, u]))
+      stats.recent = stats.recent.map((r) => {
+        if (r.kind !== "user") return r
+        const u = byId.get(r.viewer)
+        return { ...r, viewer: u ? (u.name ?? u.email) : "Someone", avatar: u?.image ?? null }
+      })
     }
     return c.json(stats)
   })

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -144,6 +144,24 @@ if (RETENTION_DAYS > 0) {
   setInterval(prune, 24 * 3600_000).unref?.()
 }
 
+// One-time cleanup of pre-existing owner self-views (the route no longer records
+// them). Owners are workspace members with the `owner` role; match their id, name
+// and email so rows from before the id-based identity change are caught too.
+void (async () => {
+  try {
+    const owners = (await meta.listMemberships("local")).filter((m) => m.role === "owner")
+    if (owners.length === 0) return
+    const users = await meta.getUsers(owners.map((m) => m.user_id))
+    const viewers = [
+      ...new Set(users.flatMap((u) => [u.id, u.name, u.email].filter((v): v is string => !!v))),
+    ]
+    const removed = await meta.pruneViewsByViewers(viewers)
+    if (removed > 0) console.log(`analytics: removed ${removed} owner self-view(s)`)
+  } catch {
+    /* best-effort; never blocks boot */
+  }
+})()
+
 const blobDesc = process.env.OBJECT_STORE_URL ? "S3/R2" : `local disk (${DATA_DIR})`
 const metaDesc = DATABASE_URL ? "postgres" : `sqlite (${DATA_DIR})`
 

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -577,15 +577,17 @@ describe("live stream (SSE)", () => {
 // (so the share route can resolve email→id) and stand in a fake `auth` whose
 // session is chosen by an `x-test-user` header (the user's email). A static
 // token keeps the instance secured, so an unauthenticated caller is NOT owner.
-type TestUser = { id: string; email: string; name: string | null }
+type TestUser = { id: string; email: string; name: string | null; image?: string | null }
 
 const makeAuthedApp = (name: string, users: TestUser[], defaultRole?: AppDeps["defaultRole"]) => {
   const path = join(dir, `${name}.db`)
   const m = new SqliteMetaStore(path)
   const raw = new Database(path)
-  raw.exec(`CREATE TABLE IF NOT EXISTS user (id TEXT PRIMARY KEY, email TEXT, name TEXT)`)
-  const ins = raw.prepare(`INSERT OR IGNORE INTO user (id, email, name) VALUES (?,?,?)`)
-  for (const u of users) ins.run(u.id, u.email, u.name)
+  raw.exec(
+    `CREATE TABLE IF NOT EXISTS user (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT)`,
+  )
+  const ins = raw.prepare(`INSERT OR IGNORE INTO user (id, email, name, image) VALUES (?,?,?,?)`)
+  for (const u of users) ins.run(u.id, u.email, u.name, u.image ?? null)
   raw.close()
   const auth = {
     handler: async () => new Response(null, { status: 404 }),
@@ -1479,31 +1481,69 @@ describe("collections", () => {
 
 describe("analytics: identity + retention", () => {
   const ann: TestUser = { id: "u_view_ann", email: "ann@dock.test", name: "Ann" }
-  const { app, meta: m } = makeAuthedApp("analytics-id", [ann])
+  const bob: TestUser = {
+    id: "u_view_bob",
+    email: "bob@dock.test",
+    name: "Bob",
+    image: "https://cdn.dock.test/bob.png",
+  }
+  const { app, meta: m } = makeAuthedApp("analytics-id", [ann, bob], "commenter")
 
-  it("attributes a signed-in viewer to their account, shown by name (not anonymous)", async () => {
+  it("excludes the owner's own opens; counts a viewer (by name + avatar) and anon", async () => {
     const sid = (await (await publishAs(app, "<h1>v</h1>", {}, as(ann.email))).json()).short_id
-    // Two opens by Ann collapse to one view, recorded as a user (never anon).
+    // Ann is the workspace owner (first member). Her own opens don't count.
     for (let i = 0; i < 2; i++)
       await app.request(`/v1/artifacts/${sid}/view`, jsonAs(as(ann.email), { version: 1 }))
+    // Bob is a commenter (audience); his two opens collapse to one counted view.
+    for (let i = 0; i < 2; i++)
+      await app.request(`/v1/artifacts/${sid}/view`, jsonAs(as(bob.email), { version: 1 }))
+    // An anonymous open also counts.
+    await app.request(`/v1/artifacts/${sid}/view`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ version: 1 }),
+    })
     const a = await (
       await app.request(`/v1/artifacts/${sid}/analytics`, { headers: as(ann.email) })
     ).json()
-    expect(a.total).toBe(1) // de-duped
-    expect(a.recent).toHaveLength(1)
-    expect(a.recent[0]).toMatchObject({ kind: "user", viewer: "Ann" }) // name, not id, not "Anonymous"
+    expect(a.total).toBe(2) // Bob (de-duped) + anon; Ann excluded
+    expect(a.unique).toBe(2)
+    expect(a.anonViewers).toBe(1)
+    const named = a.recent.filter((r: { kind: string }) => r.kind === "user")
+    expect(named).toHaveLength(1)
+    expect(named[0]).toMatchObject({ viewer: "Bob", avatar: bob.image }) // name + profile pic
+    expect(a.recent.some((r: { viewer: string }) => r.viewer === "Ann")).toBe(false)
   })
 
   it("prunes view rows older than the cutoff, keeps newer ones", async () => {
     const sid = (await (await publishAs(app, "<h1>p</h1>", {}, as(ann.email))).json()).short_id
-    await app.request(`/v1/artifacts/${sid}/view`, jsonAs(as(ann.email), { version: 1 }))
     const art = await m.getByShortId(sid)
     if (!art) throw new Error("no artifact")
+    await m.recordView({
+      id: "v_old",
+      artifact_id: art.id,
+      version: 1,
+      viewer: "anon_p",
+      viewer_kind: "anon",
+    })
     expect((await m.viewStats(art.id)).total).toBe(1)
     expect(await m.pruneViews(new Date(Date.now() - 86400_000).toISOString())).toBe(0) // none that old
     expect((await m.viewStats(art.id)).total).toBe(1) // kept
     expect(await m.pruneViews(new Date(Date.now() + 86400_000).toISOString())).toBeGreaterThan(0)
     expect((await m.viewStats(art.id)).total).toBe(0) // pruned
+  })
+
+  it("pruneViewsByViewers removes only the listed user-kind rows", async () => {
+    const sid = (await (await publishAs(app, "<h1>pv</h1>", {}, as(ann.email))).json()).short_id
+    const art = await m.getByShortId(sid)
+    if (!art) throw new Error("no artifact")
+    const v = (id: string, viewer: string, kind: "user" | "anon") =>
+      m.recordView({ id, artifact_id: art.id, version: 1, viewer, viewer_kind: kind })
+    await v("v_keep", "u_keep", "user")
+    await v("v_drop", "u_drop", "user")
+    await v("v_anon", "u_drop", "anon") // same string but anon-kind → must be kept
+    expect(await m.pruneViewsByViewers(["u_drop"])).toBe(1) // only the user-kind row
+    expect((await m.viewStats(art.id)).total).toBe(2) // u_keep + the anon row remain
   })
 
   it("the anonymous-viewer cookie is cross-site-safe when the SPA is split", async () => {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -96,9 +96,10 @@ export interface Workspace {
 export interface Analytics {
   total: number
   unique: number
+  anonViewers: number
   perVersion: { version: number; count: number }[]
   daily: { day: string; count: number }[]
-  recent: { viewer: string; kind: "user" | "anon"; at: string }[]
+  recent: { viewer: string; kind: "user" | "anon"; at: string; avatar?: string | null }[]
 }
 /** A resolved @mention: the picked user's id + the display name shown inline. */
 export interface Mention {

--- a/apps/web/src/pages/Artifact.tsx
+++ b/apps/web/src/pages/Artifact.tsx
@@ -2989,7 +2989,9 @@ function Insights({ shortId }: { shortId: string }) {
   }, [open, data, off, shortId])
   if (off) return null
   const max = data ? Math.max(1, ...data.daily.map((d) => d.count)) : 1
-  const maxV = data ? Math.max(1, ...data.perVersion.map((v) => v.count)) : 1
+  const namedRecent = data ? data.recent.filter((r) => r.kind === "user") : []
+  const newestAnonAt = data?.recent.find((r) => r.kind === "anon")?.at
+  const moreNamed = data ? Math.max(0, data.unique - data.anonViewers - namedRecent.length) : 0
   return (
     <div ref={ref} style={{ position: "relative" }}>
       <button
@@ -3002,7 +3004,7 @@ function Insights({ shortId }: { shortId: string }) {
         title="View analytics"
       >
         <span style={{ fontSize: 12 }}>👁</span>
-        {data ? data.total.toLocaleString() : "Insights"}
+        {data ? data.unique.toLocaleString() : "Insights"}
       </button>
       {open && (
         <div
@@ -3023,171 +3025,149 @@ function Insights({ shortId }: { shortId: string }) {
             </div>
           ) : (
             <>
-              <div style={{ display: "flex", gap: 18, marginBottom: 12 }}>
-                <div>
-                  <div className="display" style={{ fontSize: 22, fontWeight: 700, lineHeight: 1 }}>
-                    {data.total.toLocaleString()}
-                  </div>
-                  <div className="mono muted" style={{ fontSize: 10 }}>
-                    views
-                  </div>
-                </div>
+              {/* General bar: people-first (viewers), views second, trend right. */}
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 16,
+                  paddingBottom: 12,
+                  marginBottom: 12,
+                  borderBottom: "1px solid var(--line-soft)",
+                }}
+              >
                 <div>
                   <div className="display" style={{ fontSize: 22, fontWeight: 700, lineHeight: 1 }}>
                     {data.unique.toLocaleString()}
                   </div>
                   <div className="mono muted" style={{ fontSize: 10 }}>
-                    unique
+                    {data.unique === 1 ? "viewer" : "viewers"}
                   </div>
                 </div>
+                <div>
+                  <div className="display" style={{ fontSize: 22, fontWeight: 700, lineHeight: 1 }}>
+                    {data.total.toLocaleString()}
+                  </div>
+                  <div className="mono muted" style={{ fontSize: 10 }}>
+                    {data.total === 1 ? "view" : "views"}
+                  </div>
+                </div>
+                {data.daily.length > 0 && (
+                  <div
+                    title="Last 30 days"
+                    style={{
+                      marginLeft: "auto",
+                      display: "flex",
+                      alignItems: "flex-end",
+                      gap: 1.5,
+                      height: 26,
+                      width: 96,
+                    }}
+                  >
+                    {data.daily.map((d) => (
+                      <div
+                        key={d.day}
+                        title={`${d.day}: ${d.count}`}
+                        style={{
+                          flex: 1,
+                          minWidth: 1,
+                          height: `${Math.max(6, (d.count / max) * 100)}%`,
+                          background: "var(--ac)",
+                          borderRadius: 1.5,
+                          opacity: 0.85,
+                        }}
+                      />
+                    ))}
+                  </div>
+                )}
               </div>
+
               <div
                 className="mono muted"
                 style={{
                   fontSize: 9.5,
                   letterSpacing: ".06em",
                   textTransform: "uppercase",
-                  marginBottom: 5,
+                  marginBottom: 7,
                 }}
               >
-                Last 30 days
+                Viewed by
               </div>
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "flex-end",
-                  gap: 2,
-                  height: 40,
-                  marginBottom: 12,
-                }}
-              >
-                {data.daily.length === 0 ? (
-                  <span className="muted" style={{ fontSize: 11 }}>
-                    No views yet.
-                  </span>
-                ) : (
-                  data.daily.map((d) => (
+              {namedRecent.length === 0 && data.anonViewers === 0 ? (
+                <div className="muted" style={{ fontSize: 11.5 }}>
+                  No views yet.
+                </div>
+              ) : (
+                <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+                  {namedRecent.map((r) => (
                     <div
-                      key={d.day}
-                      title={`${d.day}: ${d.count}`}
-                      style={{
-                        flex: 1,
-                        minWidth: 2,
-                        height: `${(d.count / max) * 100}%`,
-                        background: "var(--ac)",
-                        borderRadius: 2,
-                        opacity: 0.85,
-                      }}
-                    />
-                  ))
-                )}
-              </div>
-              {data.perVersion.length > 0 && (
-                <>
-                  <div
-                    className="mono muted"
-                    style={{
-                      fontSize: 9.5,
-                      letterSpacing: ".06em",
-                      textTransform: "uppercase",
-                      marginBottom: 5,
-                    }}
-                  >
-                    By version
-                  </div>
-                  <div style={{ marginBottom: 12 }}>
-                    {data.perVersion.map((v) => (
-                      <div
-                        key={v.version}
-                        style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 3 }}
-                      >
-                        <span
-                          className="mono"
-                          style={{ fontSize: 10.5, width: 22, color: "var(--fg-mut)" }}
-                        >
-                          v{v.version}
-                        </span>
-                        <div
+                      key={r.viewer + r.at}
+                      style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12 }}
+                    >
+                      {r.avatar ? (
+                        <img
+                          src={r.avatar}
+                          alt=""
                           style={{
-                            flex: 1,
-                            height: 6,
-                            background: "var(--card-2)",
-                            borderRadius: 999,
-                            overflow: "hidden",
-                          }}
-                        >
-                          <div
-                            style={{
-                              width: `${(v.count / maxV) * 100}%`,
-                              height: "100%",
-                              background: "var(--ac)",
-                              borderRadius: 999,
-                            }}
-                          />
-                        </div>
-                        <span
-                          className="mono muted"
-                          style={{ fontSize: 10, width: 30, textAlign: "right" }}
-                        >
-                          {v.count}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                </>
-              )}
-              {data.recent.length > 0 && (
-                <>
-                  <div
-                    className="mono muted"
-                    style={{
-                      fontSize: 9.5,
-                      letterSpacing: ".06em",
-                      textTransform: "uppercase",
-                      marginBottom: 5,
-                    }}
-                  >
-                    Recent viewers
-                  </div>
-                  <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                    {data.recent.map((r) => (
-                      <div
-                        key={r.viewer}
-                        style={{ display: "flex", alignItems: "center", gap: 7, fontSize: 11.5 }}
-                      >
-                        <span
-                          style={{
-                            width: 17,
-                            height: 17,
+                            width: 18,
+                            height: 18,
                             borderRadius: "50%",
-                            background: r.kind === "user" ? "var(--ac-soft)" : "var(--card-2)",
-                            color: "var(--fg-mut)",
-                            display: "grid",
-                            placeItems: "center",
-                            fontSize: 8,
-                            fontWeight: 700,
-                            fontFamily: "ui-monospace,Menlo,monospace",
+                            objectFit: "cover",
+                            flex: "0 0 auto",
                           }}
-                        >
-                          {r.kind === "user" ? (r.viewer || "?").slice(0, 2).toUpperCase() : "·"}
-                        </span>
-                        <span
-                          style={{
-                            flex: 1,
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                          }}
-                        >
-                          {r.kind === "user" ? r.viewer : "Anonymous"}
-                        </span>
+                        />
+                      ) : (
+                        <ColoredAvatar name={r.viewer} size={18} />
+                      )}
+                      <span
+                        style={{
+                          flex: 1,
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                          fontWeight: 500,
+                        }}
+                      >
+                        {r.viewer}
+                      </span>
+                      <span className="mono muted" style={{ fontSize: 9.5 }}>
+                        {ago(r.at)}
+                      </span>
+                    </div>
+                  ))}
+                  {data.anonViewers > 0 && (
+                    <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12 }}>
+                      <span
+                        style={{
+                          width: 18,
+                          height: 18,
+                          borderRadius: "50%",
+                          background: "var(--card-2)",
+                          color: "var(--fg-mut)",
+                          display: "grid",
+                          placeItems: "center",
+                          fontSize: 11,
+                          flex: "0 0 auto",
+                        }}
+                      >
+                        ·
+                      </span>
+                      <span style={{ flex: 1, color: "var(--fg-mut)" }}>
+                        {data.anonViewers.toLocaleString()} anonymous
+                      </span>
+                      {newestAnonAt && (
                         <span className="mono muted" style={{ fontSize: 9.5 }}>
-                          {ago(r.at)}
+                          {ago(newestAnonAt)}
                         </span>
-                      </div>
-                    ))}
-                  </div>
-                </>
+                      )}
+                    </div>
+                  )}
+                  {moreNamed > 0 && (
+                    <div className="muted" style={{ fontSize: 11, paddingLeft: 26 }}>
+                      +{moreNamed} more
+                    </div>
+                  )}
+                </div>
               )}
             </>
           )}

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -119,6 +119,8 @@ export interface MetaStore {
   ): Promise<boolean>
   /** Delete view rows older than `cutoffIso`; returns the count removed (retention). */
   pruneViews(cutoffIso: string): Promise<number>
+  /** Delete user-kind view rows whose viewer is in the set (owner self-view cleanup). */
+  pruneViewsByViewers(viewers: string[]): Promise<number>
   /** Aggregated view analytics for one artifact. */
   viewStats(artifactId: string): Promise<ViewStats>
   /** Total view counts for many artifacts at once (no N+1). */
@@ -390,6 +392,8 @@ export interface UserDir {
   id: string
   email: string
   name: string | null
+  /** Profile picture URL (set by OAuth providers; null for password signups). */
+  image: string | null
 }
 
 export type NotificationKind = "mention" | "comment"
@@ -542,11 +546,13 @@ export interface NewView {
 export interface ViewStats {
   total: number
   unique: number
+  /** Distinct anonymous viewers (the rest of `unique` are named users). */
+  anonViewers: number
   perVersion: { version: number; count: number }[]
   /** Daily counts over the trailing window, oldest first. */
   daily: { day: string; count: number }[]
-  /** Most-recent distinct viewers, newest first. */
-  recent: { viewer: string; kind: "user" | "anon"; at: string }[]
+  /** Most-recent distinct viewers, newest first. `avatar` is set for users. */
+  recent: { viewer: string; kind: "user" | "anon"; at: string; avatar?: string | null }[]
 }
 
 export type CommentState = "open" | "resolved"

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -251,6 +251,18 @@ export class D1MetaStore implements MetaStore {
     return res.meta.changes ?? 0
   }
 
+  async pruneViewsByViewers(viewers: string[]): Promise<number> {
+    if (viewers.length === 0) return 0
+    const list = sql.join(
+      viewers.map((v) => sql`${v}`),
+      sql`, `,
+    )
+    const res = await this.db.run(
+      sql`DELETE FROM view WHERE viewer_kind='user' AND viewer IN (${list})`,
+    )
+    return res.meta.changes ?? 0
+  }
+
   async viewStats(artifactId: string): Promise<ViewStats> {
     const cutoff = new Date(Date.now() - VIEW_WINDOW_MS).toISOString()
     const tot = (await this.db.get(
@@ -258,6 +270,9 @@ export class D1MetaStore implements MetaStore {
     )) as { n: number }
     const uni = (await this.db.get(
       sql`SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=${artifactId}`,
+    )) as { n: number }
+    const anon = (await this.db.get(
+      sql`SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=${artifactId} AND viewer_kind='anon'`,
     )) as { n: number }
     const perVersion = (await this.db.all(
       sql`SELECT version, count(*) count FROM view WHERE artifact_id=${artifactId} GROUP BY version ORDER BY version`,
@@ -268,7 +283,7 @@ export class D1MetaStore implements MetaStore {
     const recent = (await this.db.all(
       sql`SELECT viewer, viewer_kind kind, max(created_at) at FROM view WHERE artifact_id=${artifactId} GROUP BY viewer, viewer_kind ORDER BY at DESC LIMIT 8`,
     )) as { viewer: string; kind: "user" | "anon"; at: string }[]
-    return { total: tot.n, unique: uni.n, perVersion, daily, recent }
+    return { total: tot.n, unique: uni.n, anonViewers: anon.n, perVersion, daily, recent }
   }
 
   async viewCounts(artifactIds: string[]): Promise<Record<string, number>> {
@@ -649,7 +664,7 @@ export class D1MetaStore implements MetaStore {
     try {
       return (
         ((await this.db.get(
-          sql`SELECT id, email, name FROM user WHERE email = ${email}`,
+          sql`SELECT id, email, name, image FROM user WHERE email = ${email}`,
         )) as UserDir) ?? null
       )
     } catch {
@@ -664,7 +679,7 @@ export class D1MetaStore implements MetaStore {
         sql`, `,
       )
       return (await this.db.all(
-        sql`SELECT id, email, name FROM user WHERE id IN (${list})`,
+        sql`SELECT id, email, name, image FROM user WHERE id IN (${list})`,
       )) as UserDir[]
     } catch {
       return []

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -254,13 +254,27 @@ export class PgMetaStore implements MetaStore {
     return res.rowCount ?? 0
   }
 
+  async pruneViewsByViewers(viewers: string[]): Promise<number> {
+    if (viewers.length === 0) return 0
+    const ph = viewers.map((_, i) => `$${i + 1}`).join(",")
+    const res = await this.pool.query(
+      `DELETE FROM view WHERE viewer_kind='user' AND viewer IN (${ph})`,
+      viewers,
+    )
+    return res.rowCount ?? 0
+  }
+
   async viewStats(artifactId: string): Promise<ViewStats> {
     const cutoff = new Date(Date.now() - VIEW_WINDOW_MS).toISOString()
-    const [tot, uni, perV, daily, recent] = await Promise.all([
+    const [tot, uni, anon, perV, daily, recent] = await Promise.all([
       this.pool.query(`SELECT count(*)::int n FROM view WHERE artifact_id=$1`, [artifactId]),
       this.pool.query(`SELECT count(DISTINCT viewer)::int n FROM view WHERE artifact_id=$1`, [
         artifactId,
       ]),
+      this.pool.query(
+        `SELECT count(DISTINCT viewer)::int n FROM view WHERE artifact_id=$1 AND viewer_kind='anon'`,
+        [artifactId],
+      ),
       this.pool.query(
         `SELECT version, count(*)::int c FROM view WHERE artifact_id=$1 GROUP BY version ORDER BY version`,
         [artifactId],
@@ -277,6 +291,7 @@ export class PgMetaStore implements MetaStore {
     return {
       total: tot.rows[0].n,
       unique: uni.rows[0].n,
+      anonViewers: anon.rows[0].n,
       perVersion: perV.rows.map((r) => ({ version: r.version, count: r.c })),
       daily: daily.rows.map((r) => ({ day: r.day, count: r.c })),
       recent: recent.rows.map((r) => ({ viewer: r.viewer, kind: r.viewer_kind, at: r.at })),
@@ -630,7 +645,7 @@ export class PgMetaStore implements MetaStore {
   async findUserByEmail(email: string): Promise<UserDir | null> {
     try {
       const { rows } = await this.pool.query(
-        `SELECT id, email, name FROM "user" WHERE email = $1`,
+        `SELECT id, email, name, image FROM "user" WHERE email = $1`,
         [email],
       )
       return (rows[0] as UserDir) ?? null
@@ -643,7 +658,7 @@ export class PgMetaStore implements MetaStore {
     try {
       const ph = ids.map((_, i) => `$${i + 1}`).join(",")
       const { rows } = await this.pool.query(
-        `SELECT id, email, name FROM "user" WHERE id IN (${ph})`,
+        `SELECT id, email, name, image FROM "user" WHERE id IN (${ph})`,
         ids,
       )
       return rows as UserDir[]

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -260,12 +260,24 @@ export class SqliteMetaStore implements MetaStore {
     return this.raw.prepare(`DELETE FROM view WHERE created_at < ?`).run(cutoffIso).changes
   }
 
+  async pruneViewsByViewers(viewers: string[]): Promise<number> {
+    if (viewers.length === 0) return 0
+    const ph = viewers.map(() => "?").join(",")
+    return this.raw
+      .prepare(`DELETE FROM view WHERE viewer_kind='user' AND viewer IN (${ph})`)
+      .run(...viewers).changes
+  }
+
   async viewStats(artifactId: string): Promise<ViewStats> {
     const cutoff = new Date(Date.now() - VIEW_WINDOW_MS).toISOString()
     const n = (q: string, ...p: unknown[]) => (this.raw.prepare(q).get(...p) as { n: number }).n
     return {
       total: n(`SELECT count(*) n FROM view WHERE artifact_id=?`, artifactId),
       unique: n(`SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=?`, artifactId),
+      anonViewers: n(
+        `SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=? AND viewer_kind='anon'`,
+        artifactId,
+      ),
       perVersion: this.raw
         .prepare(
           `SELECT version, count(*) count FROM view WHERE artifact_id=? GROUP BY version ORDER BY version`,
@@ -682,7 +694,7 @@ export class SqliteMetaStore implements MetaStore {
     try {
       return (
         (this.raw
-          .prepare(`SELECT id, email, name FROM user WHERE email = ?`)
+          .prepare(`SELECT id, email, name, image FROM user WHERE email = ?`)
           .get(email) as UserDir) ?? null
       )
     } catch {
@@ -694,7 +706,7 @@ export class SqliteMetaStore implements MetaStore {
     try {
       const ph = ids.map(() => "?").join(",")
       return this.raw
-        .prepare(`SELECT id, email, name FROM user WHERE id IN (${ph})`)
+        .prepare(`SELECT id, email, name, image FROM user WHERE id IN (${ph})`)
         .all(...ids) as UserDir[]
     } catch {
       return []


### PR DESCRIPTION
Follows the Notion / Google Docs model: analytics is **people-first** (who viewed, by name + avatar + when), and the owner's **own opens don't count** (GDocs even hides your own view history). Two decisions confirmed with the user: exclude **just the owner** (co-editors still count); panel is a **summary bar + viewer list**.

## Owner self-views out
- View route skips recording when a signed-in viewer can `manage` the artifact (effective role = owner). Editors / commenters / viewers and anonymous openers still count; anonymous (incl. open-instance) is never excluded.
- One-time cleanup: `pruneViewsByViewers` (ports + sqlite/pg/d1) + a startup pass in `node.ts` that removes existing owner self-views, matching id/name/email so rows from before the id-based identity change are caught. Idempotent, logs the count.

## People-first payload
- `UserDir.image` (Better Auth's avatar column) selected in `getUsers` / `findUserByEmail`; the analytics route attaches `avatar` to recent user viewers.
- `ViewStats.anonViewers` (distinct anonymous) added to each driver's `viewStats`.

## Panel redesign (`Insights`)
- A **general bar** — `N viewers` · `N views` · a compact trend sparkline — over a **Viewed by** list: avatar (profile pic if present, else colored initials) + name + last-viewed (`ago`), a grouped `N anonymous` row, and a `+N more`. Per-version detail dropped from the panel; the button now shows the viewer (unique) count.

## Verification
Real Better Auth end-to-end: owner opened 3× → **0 counted**; a non-owner viewer → **1 by name**; anonymous → **1** (`anonViewers`). Owner absent from `recent`. 119 API tests (4 new/updated: owner-excluded + viewer-by-name+avatar, `pruneViewsByViewers`, payload fields); typecheck + biome clean. Local browser pass of the redesigned panel to follow.