### PR TITLE
feat(workspace): multi-workspace mode (hosted), single-workspace default (self-host)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -122,6 +122,20 @@ export interface AppDeps {
   versionWindowMs?: number
   /** Workspace role granted to a member who isn't the first user. Default "editor". */
   defaultRole?: Role
+  /**
+   * Enable multiple workspaces: users can create/switch workspaces and each is
+   * scoped by org_id. Off by default (self-host is single-workspace); the hosted
+   * product turns it on. Single mode behaves exactly as before, just keyed by a
+   * real `defaultOrgId` instead of a magic constant.
+   */
+  multiWorkspace?: boolean
+  /**
+   * The org_id of the single/bootstrap workspace. A real, persisted id (never a
+   * magic literal) so flipping on multiWorkspace later is a no-op for the data.
+   * Defaults to "default" when unset (tests); the Node entry generates + persists
+   * one and rekeys any legacy rows onto it.
+   */
+  defaultOrgId?: string
   /** In-memory per-IP rate limiting on auth + mutating routes. Off by default. */
   rateLimit?: boolean
   /**
@@ -147,9 +161,9 @@ export interface AppDeps {
   crossSite?: boolean
 }
 
-/** The single workspace (multi-workspace is a later layer). */
-const WORKSPACE = "local"
 const DEFAULT_WORKSPACE_NAME = "My Workspace"
+/** Cookie holding the active workspace id (multi-workspace mode). */
+const WS_COOKIE = "dock_ws"
 
 // Workspace membership is three simple roles, presented to people as
 // Admin / Creator / Viewer:
@@ -323,7 +337,7 @@ export function createApp(deps: AppDeps): Hono {
     const real = new Set((await meta.getUsers(targetIds)).map((u) => u.id))
     // Registered agents are mentionable too; a mention of an agent lands in its
     // pull inbox instead of a notification bell.
-    const agentIds = new Set((await meta.listAgents(WORKSPACE)).map((ag) => ag.id))
+    const agentIds = new Set((await meta.listAgents(a.org_id)).map((ag) => ag.id))
     const preview = previewOf(cm.body_md)
     const notified: string[] = []
     for (const m of mentions) {
@@ -413,16 +427,67 @@ export function createApp(deps: AppDeps): Hono {
   // instance (no static token) trusts anonymous callers — zero-config self-host.
   const open = !deps.token
   const defaultRole: Role = deps.defaultRole ?? "editor"
+  const multi = !!deps.multiWorkspace
+  // The single/bootstrap workspace id — always a real value, never a magic
+  // literal. The Node entry generates + persists one; tests fall back to this.
+  const DEFAULT_ORG = deps.defaultOrgId ?? "default"
 
-  // Lazy provisioning: the first member of the workspace is its owner; everyone
-  // else joins at the default role. Returns the caller's workspace role.
-  const ensureMembership = async (userId: string): Promise<Role> => {
-    const existing = await meta.getMembership(WORKSPACE, userId)
+  // Lazy provisioning: the first member of a workspace is its owner; everyone
+  // else joins at the default role. Returns the caller's role in that workspace.
+  const ensureMembership = async (orgId: string, userId: string): Promise<Role> => {
+    const existing = await meta.getMembership(orgId, userId)
     if (existing) return existing.role
-    const role: Role = (await meta.countMemberships(WORKSPACE)) === 0 ? "owner" : defaultRole
-    await meta.setMembership({ id: newId("m"), org_id: WORKSPACE, user_id: userId, role })
+    const role: Role = (await meta.countMemberships(orgId)) === 0 ? "owner" : defaultRole
+    await meta.setMembership({ id: newId("m"), org_id: orgId, user_id: userId, role })
     return role
   }
+
+  // A signed-in user's own workspace, created on demand (multi mode, first login).
+  const provisionPersonal = async (me: SessionUser): Promise<string> => {
+    const id = newId("ws")
+    const base = (me.name ?? me.email).split("@")[0] || "My"
+    await meta.setWorkspace(id, `${base}'s Workspace`)
+    await meta.setMembership({ id: newId("m"), org_id: id, user_id: me.id, role: "owner" })
+    return id
+  }
+
+  // The caller's active workspace for this request (memoized). Single mode: always
+  // the bootstrap org. Multi mode: the dock_ws cookie (validated against
+  // membership), else the user's first workspace, provisioning one if they have none.
+  const wsCache = new WeakMap<Context, string>()
+  const activeWorkspace = async (c: Context): Promise<string> => {
+    if (!multi) return DEFAULT_ORG
+    const cached = wsCache.get(c)
+    if (cached) return cached
+    // An agent acts within its own workspace, never a cookie's.
+    const ag = await agentFor(c)
+    const me = ag ? null : await currentUser(c)
+    let ws: string
+    if (ag) {
+      ws = ag.org_id
+    } else if (!me) {
+      ws = getCookie(c, WS_COOKIE) || DEFAULT_ORG
+    } else {
+      const ck = getCookie(c, WS_COOKIE)
+      if (ck && (await meta.getMembership(ck, me.id))) ws = ck
+      else {
+        const mine = await meta.listWorkspaces(me.id)
+        ws = mine.length ? mine[0].id : await provisionPersonal(me)
+      }
+    }
+    wsCache.set(c, ws)
+    return ws
+  }
+  // Persist the active-workspace choice. Same cross-site handling as the viewer
+  // cookie so it survives the hosted SPA↔API split.
+  const setWsCookie = (c: Context, id: string): void =>
+    setCookie(c, WS_COOKIE, id, {
+      path: "/",
+      maxAge: 60 * 60 * 24 * 365,
+      httpOnly: true,
+      sameSite: deps.crossSite ? "None" : "Lax",
+      secure: deps.crossSite || new URL(deps.baseUrl).protocol === "https:",
+    })
 
   const actorFor = async (c: Context, a: ArtifactRecord): Promise<Actor> => {
     if (deps.token && bearer(c) === deps.token) return { kind: "token" }
@@ -433,7 +498,12 @@ export function createApp(deps: AppDeps): Hono {
     }
     const me = await currentUser(c)
     if (!me) return { kind: "anon", open }
-    const orgRole = await ensureMembership(me.id)
+    // Baseline role = membership in the ARTIFACT's workspace. Single mode keeps
+    // its first-user-owner auto-join; multi mode never auto-joins you into
+    // someone else's workspace just because you opened a shared link.
+    const orgRole = multi
+      ? ((await meta.getMembership(a.org_id, me.id))?.role ?? null)
+      : await ensureMembership(a.org_id, me.id)
     const am = await meta.getArtifactMember(a.id, me.id)
     // A collection share grants its role on every artifact in the collection,
     // folded in alongside any per-artifact share (the higher wins).
@@ -446,14 +516,14 @@ export function createApp(deps: AppDeps): Hono {
   const authorize = (c: Context, action: Action, a: ArtifactRecord): Promise<boolean> =>
     actorFor(c, a).then((actor) => can(actor, action, a.visibility))
 
-  /** The caller's role at the workspace level (creating artifacts, settings). */
+  /** The caller's role in their active workspace (creating artifacts, settings). */
   const workspaceRole = async (c: Context): Promise<Role | null> => {
     if (deps.token && bearer(c) === deps.token) return "owner"
     const ag = await agentFor(c)
     if (ag) return ag.role
     const me = await currentUser(c)
     if (!me) return open ? "owner" : null
-    return ensureMembership(me.id)
+    return ensureMembership(await activeWorkspace(c), me.id)
   }
   const workspaceCan = async (c: Context, action: Action): Promise<boolean> => {
     const r = await workspaceRole(c)
@@ -484,8 +554,8 @@ export function createApp(deps: AppDeps): Hono {
   app.get("/v1/me", async (c) => {
     const u = await currentUser(c)
     if (!u) return c.json({ error: "unauthenticated" }, 401)
-    const role = await ensureMembership(u.id) // provisions on first load
-    return c.json({ user: { ...u, role } })
+    const role = await ensureMembership(await activeWorkspace(c), u.id) // provisions on first load
+    return c.json({ user: { ...u, role }, multi })
   })
 
   // Workspace member directory for the @mention picker — people AND agents, so
@@ -494,7 +564,8 @@ export function createApp(deps: AppDeps): Hono {
   app.get("/v1/users", async (c) => {
     if (!open && !(await currentUser(c)) && bearer(c) !== deps.token)
       return c.json({ error: "unauthenticated" }, 401)
-    const members = await meta.listMemberships(WORKSPACE)
+    const org = await activeWorkspace(c)
+    const members = await meta.listMemberships(org)
     const users = await meta.getUsers(members.map((m) => m.user_id))
     const q = (c.req.query("q") ?? "").trim().toLowerCase()
     const people = (
@@ -504,7 +575,7 @@ export function createApp(deps: AppDeps): Hono {
           )
         : users
     ).map((u) => ({ id: u.id, name: u.name ?? u.email, email: u.email, kind: "user" as const }))
-    const agents = (await meta.listAgents(WORKSPACE))
+    const agents = (await meta.listAgents(org))
       .filter((ag) => !q || ag.name.toLowerCase().includes(q))
       .map((ag) => ({ id: ag.id, name: ag.name, email: "", kind: "agent" as const }))
     const all = [...people, ...agents].sort((a, b) => a.name.localeCompare(b.name))
@@ -512,10 +583,10 @@ export function createApp(deps: AppDeps): Hono {
   })
 
   // ---- Workspace: name + members (Admin-managed) -------------------------
-  // The workspace must always keep at least one Admin, so it stays manageable:
+  // A workspace must always keep at least one Admin, so it stays manageable:
   // demoting or removing the last owner is refused.
-  const isLastOwner = async (userId: string): Promise<boolean> => {
-    const owners = (await meta.listMemberships(WORKSPACE)).filter((m) => m.role === "owner")
+  const isLastOwner = async (orgId: string, userId: string): Promise<boolean> => {
+    const owners = (await meta.listMemberships(orgId)).filter((m) => m.role === "owner")
     return owners.length <= 1 && owners.some((m) => m.user_id === userId)
   }
 
@@ -533,15 +604,15 @@ export function createApp(deps: AppDeps): Hono {
   app.get("/v1/workspace", async (c) => {
     const role = await workspaceRole(c)
     if (role === null) return c.json({ error: "unauthenticated" }, 401)
-    const [ws, members] = await Promise.all([
-      meta.getWorkspace(WORKSPACE),
-      meta.listMemberships(WORKSPACE),
-    ])
+    const org = await activeWorkspace(c)
+    const [ws, members] = await Promise.all([meta.getWorkspace(org), meta.listMemberships(org)])
     const users = await meta.getUsers(members.map((m) => m.user_id))
     const dir = new Map(users.map((u) => [u.id, u]))
     return c.json({
+      id: org,
       name: ws?.name ?? DEFAULT_WORKSPACE_NAME,
       role,
+      multi,
       members: members.map((m) => memberJson(m, dir)),
     })
   })
@@ -552,7 +623,7 @@ export function createApp(deps: AppDeps): Hono {
     const b = (await c.req.json().catch(() => ({}))) as { name?: unknown }
     const name = typeof b.name === "string" ? b.name.trim().slice(0, 80) : ""
     if (!name) return c.json({ error: "name required" }, 400)
-    const ws = await meta.setWorkspace(WORKSPACE, name)
+    const ws = await meta.setWorkspace(await activeWorkspace(c), name)
     return c.json({ name: ws.name })
   })
 
@@ -564,14 +635,15 @@ export function createApp(deps: AppDeps): Hono {
       return c.json({ error: "email and a valid role are required" }, 400)
     const user = await meta.findUserByEmail(b.email.trim())
     if (!user) return c.json({ error: "no Dock user with that email" }, 404)
+    const org = await activeWorkspace(c)
     // This route both adds and re-roles, so it must honor the same last-Admin
     // guard as PATCH — otherwise an Admin could demote the sole Admin via PUT.
-    const existing = await meta.getMembership(WORKSPACE, user.id)
-    if (existing?.role === "owner" && b.role !== "owner" && (await isLastOwner(user.id)))
+    const existing = await meta.getMembership(org, user.id)
+    if (existing?.role === "owner" && b.role !== "owner" && (await isLastOwner(org, user.id)))
       return c.json({ error: "the workspace needs at least one admin" }, 409)
     await meta.setMembership({
       id: existing?.id ?? newId("m"),
-      org_id: WORKSPACE,
+      org_id: org,
       user_id: user.id,
       role: b.role,
     })
@@ -584,11 +656,12 @@ export function createApp(deps: AppDeps): Hono {
     const userId = c.req.param("userId")
     const b = (await c.req.json().catch(() => ({}))) as { role?: unknown }
     if (!isWorkspaceRole(b.role)) return c.json({ error: "a valid role is required" }, 400)
-    const existing = await meta.getMembership(WORKSPACE, userId)
+    const org = await activeWorkspace(c)
+    const existing = await meta.getMembership(org, userId)
     if (!existing) return c.json({ error: "not a member" }, 404)
-    if (existing.role === "owner" && b.role !== "owner" && (await isLastOwner(userId)))
+    if (existing.role === "owner" && b.role !== "owner" && (await isLastOwner(org, userId)))
       return c.json({ error: "the workspace needs at least one admin" }, 409)
-    await meta.setMembership({ id: existing.id, org_id: WORKSPACE, user_id: userId, role: b.role })
+    await meta.setMembership({ id: existing.id, org_id: org, user_id: userId, role: b.role })
     return c.json({ user_id: userId, role: b.role })
   })
 
@@ -596,12 +669,65 @@ export function createApp(deps: AppDeps): Hono {
   app.delete("/v1/workspace/members/:userId", async (c) => {
     if (!(await workspaceCan(c, "manage"))) return c.json({ error: "forbidden" }, 403)
     const userId = c.req.param("userId")
-    const existing = await meta.getMembership(WORKSPACE, userId)
+    const org = await activeWorkspace(c)
+    const existing = await meta.getMembership(org, userId)
     if (!existing) return c.body(null, 204)
-    if (existing.role === "owner" && (await isLastOwner(userId)))
+    if (existing.role === "owner" && (await isLastOwner(org, userId)))
       return c.json({ error: "the workspace needs at least one admin" }, 409)
-    await meta.removeMembership(WORKSPACE, userId)
+    await meta.removeMembership(org, userId)
     return c.body(null, 204)
+  })
+
+  // ---- Workspaces: list / create / switch (multi-workspace) --------------
+  // The caller's workspaces (just the one in single mode). `active` is the id of
+  // the workspace this request resolved to.
+  app.get("/v1/workspaces", async (c) => {
+    const role = await workspaceRole(c)
+    if (role === null) return c.json({ error: "unauthenticated" }, 401)
+    const active = await activeWorkspace(c)
+    const me = await currentUser(c)
+    if (!multi || !me) {
+      const ws = await meta.getWorkspace(active)
+      return c.json({
+        multi,
+        active,
+        workspaces: [{ id: active, name: ws?.name ?? DEFAULT_WORKSPACE_NAME, role }],
+      })
+    }
+    const mine = await meta.listWorkspaces(me.id)
+    return c.json({
+      multi,
+      active,
+      workspaces: mine.map((w) => ({ id: w.id, name: w.name, role: w.role })),
+    })
+  })
+
+  // Create a workspace (multi only). The creator becomes its Admin and is switched in.
+  app.post("/v1/workspaces", async (c) => {
+    if (!multi) return c.json({ error: "multi-workspace is disabled" }, 403)
+    const me = await currentUser(c)
+    if (!me) return c.json({ error: "unauthenticated" }, 401)
+    const b = (await c.req.json().catch(() => ({}))) as { name?: unknown }
+    const name = typeof b.name === "string" ? b.name.trim().slice(0, 80) : ""
+    if (!name) return c.json({ error: "name required" }, 400)
+    const id = newId("ws")
+    await meta.setWorkspace(id, name)
+    await meta.setMembership({ id: newId("m"), org_id: id, user_id: me.id, role: "owner" })
+    setWsCookie(c, id)
+    return c.json({ id, name, role: "owner" }, 201)
+  })
+
+  // Switch the active workspace (multi only). Must be a member.
+  app.post("/v1/workspace/switch", async (c) => {
+    if (!multi) return c.json({ error: "multi-workspace is disabled" }, 403)
+    const me = await currentUser(c)
+    if (!me) return c.json({ error: "unauthenticated" }, 401)
+    const b = (await c.req.json().catch(() => ({}))) as { id?: unknown }
+    const id = typeof b.id === "string" ? b.id : ""
+    if (!id || !(await meta.getMembership(id, me.id)))
+      return c.json({ error: "not a member of that workspace" }, 403)
+    setWsCookie(c, id)
+    return c.json({ active: id })
   })
 
   // ---- Agents: registry (owner-managed) + the pull inbox -----------------
@@ -614,7 +740,7 @@ export function createApp(deps: AppDeps): Hono {
 
   app.get("/v1/agents", async (c) => {
     if (!(await workspaceCan(c, "manage"))) return c.json({ error: "forbidden" }, 403)
-    const agents = await meta.listAgents(WORKSPACE)
+    const agents = await meta.listAgents(await activeWorkspace(c))
     return c.json({ agents: agents.map(agentJson) })
   })
 
@@ -632,7 +758,7 @@ export function createApp(deps: AppDeps): Hono {
     try {
       const agent = await meta.createAgent({
         id: newId("ag"),
-        org_id: WORKSPACE,
+        org_id: await activeWorkspace(c),
         name,
         token,
         role,
@@ -712,7 +838,8 @@ export function createApp(deps: AppDeps): Hono {
     if (favOnly) narrow(favIds)
     if (ids && ids.length === 0) return c.json({ artifacts: [], next_cursor: null })
 
-    const rows = await meta.listArtifacts({ limit: limit + 1, cursor, q, ids })
+    const orgId = await activeWorkspace(c)
+    const rows = await meta.listArtifacts({ limit: limit + 1, cursor, q, ids, orgId })
     const hasMore = rows.length > limit
     const page = hasMore ? rows.slice(0, limit) : rows
     const last = page[page.length - 1]
@@ -738,11 +865,12 @@ export function createApp(deps: AppDeps): Hono {
     const me = await currentUser(c)
     if (!me && deps.token && bearer(c) !== deps.token)
       return c.json({ error: "unauthenticated" }, 401)
+    const org = await activeWorkspace(c)
     const [total, tags, favIds, ws] = await Promise.all([
-      meta.countArtifacts(),
-      meta.tagCounts(),
+      meta.countArtifacts(org),
+      meta.tagCounts(org),
       me ? meta.listUserFavoriteIds(me.id) : Promise.resolve([]),
-      meta.getWorkspace(WORKSPACE),
+      meta.getWorkspace(org),
     ])
     tags.sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
     return c.json({
@@ -769,7 +897,7 @@ export function createApp(deps: AppDeps): Hono {
   app.get("/v1/collections", async (c) => {
     if (!(await currentUser(c)) && deps.token && bearer(c) !== deps.token)
       return c.json({ error: "unauthenticated" }, 401)
-    return c.json({ collections: await meta.listCollections() })
+    return c.json({ collections: await meta.listCollections(await activeWorkspace(c)) })
   })
   app.post("/v1/collections", async (c) => {
     if (!(await workspaceCan(c, "comment"))) return c.json({ error: "forbidden" }, 403)
@@ -777,10 +905,10 @@ export function createApp(deps: AppDeps): Hono {
     const body = (await c.req.json().catch(() => ({}))) as { title?: string }
     const title = (body.title ?? "").trim().slice(0, 120)
     if (!title) return c.json({ error: "title required" }, 400)
-    const createdBy = me?.id ?? "local"
+    const createdBy = me?.id ?? "anon"
     const col = await meta.createCollection({
       id: newId("col"),
-      org_id: WORKSPACE,
+      org_id: await activeWorkspace(c),
       title,
       created_by: createdBy,
     })
@@ -906,6 +1034,7 @@ export function createApp(deps: AppDeps): Hono {
           message: str(body["message"]),
           author: str(body["author"]),
           name: str(body["name"]),
+          orgId: await activeWorkspace(c),
           visibility: visibilityOf(body["visibility"]),
         },
         shortId,

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -84,6 +84,49 @@ const AUTH_SECRET = ((): string => {
 const auth = makeAuth(authDb, BASE_URL, AUTH_SECRET)
 await migrateAuth(auth)
 
+// The bootstrap workspace id — a real, persisted value (never a magic literal),
+// so turning on multi-workspace later needs no data change. DOCK_DEFAULT_ORG_ID
+// wins; otherwise generate one and persist it beside the data, like the auth secret.
+const DEFAULT_ORG = ((): string => {
+  const fromEnv = process.env.DOCK_DEFAULT_ORG_ID
+  if (fromEnv) return fromEnv
+  const file = join(DATA_DIR, ".org-id")
+  try {
+    if (existsSync(file)) return readFileSync(file, "utf8").trim()
+  } catch {
+    /* fall through and generate */
+  }
+  const generated = `ws_${randomBytes(12).toString("hex")}`
+  try {
+    writeFileSync(file, generated, { mode: 0o600 })
+  } catch {
+    /* best-effort; a fresh id next boot is harmless on an empty store */
+  }
+  return generated
+})()
+
+// One-time rekey of the pre-multi-workspace "local" sentinel onto the real
+// default org id. Idempotent (no rows remain on 'local' afterward) and a no-op
+// for fresh installs and hosted Postgres that never used 'local'.
+if (DEFAULT_ORG !== "local") {
+  const orgTables = ["membership", "artifact", "collection", "agent"]
+  if (DATABASE_URL) {
+    const pool = authDb as Pool
+    for (const t of orgTables)
+      await pool.query(`UPDATE "${t}" SET org_id = $1 WHERE org_id = 'local'`, [DEFAULT_ORG])
+    await pool.query(`UPDATE workspace SET id = $1 WHERE id = 'local'`, [DEFAULT_ORG])
+  } else {
+    const db = authDb as Database.Database
+    for (const t of orgTables)
+      db.prepare(`UPDATE ${t} SET org_id = ? WHERE org_id = 'local'`).run(DEFAULT_ORG)
+    db.prepare(`UPDATE workspace SET id = ? WHERE id = 'local'`).run(DEFAULT_ORG)
+  }
+}
+
+// Multi-workspace: off by default (self-host is single-workspace); the hosted
+// product sets DOCK_MULTI_WORKSPACE=true to unlock create/switch.
+const MULTI_WORKSPACE = process.env.DOCK_MULTI_WORKSPACE === "true"
+
 const webOrigins = (process.env.DOCK_WEB_ORIGIN ?? "")
   .split(",")
   .map((s) => s.trim())
@@ -104,6 +147,8 @@ const app = createApp({
   analytics: process.env.DOCK_ANALYTICS !== "false",
   rateLimit: process.env.DOCK_RATE_LIMIT !== "false",
   serveWeb: SERVE_WEB,
+  multiWorkspace: MULTI_WORKSPACE,
+  defaultOrgId: DEFAULT_ORG,
   // Origin isolation: serve artifact bytes from a separate registrable domain
   // pointed at this same container. Keeps user HTML off the app's cookie origin.
   sandboxOrigin: process.env.DOCK_SANDBOX_URL,
@@ -153,5 +198,6 @@ serve({ fetch: app.fetch, port: PORT }, () => {
   console.log(`  blobs:   ${blobDesc}`)
   console.log(`  auth:    /api/auth/* (Better Auth)`)
   console.log(`  web:     ${SERVE_WEB ? `bundled SPA at ${BASE_URL}` : "not bundled (API only)"}`)
+  console.log(`  spaces:  ${MULTI_WORKSPACE ? "multi-workspace" : `single (org ${DEFAULT_ORG})`}`)
   console.log(`  publish: dock publish <file|dir> --server ${BASE_URL}`)
 })

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -579,7 +579,12 @@ describe("live stream (SSE)", () => {
 // token keeps the instance secured, so an unauthenticated caller is NOT owner.
 type TestUser = { id: string; email: string; name: string | null }
 
-const makeAuthedApp = (name: string, users: TestUser[], defaultRole?: AppDeps["defaultRole"]) => {
+const makeAuthedApp = (
+  name: string,
+  users: TestUser[],
+  defaultRole?: AppDeps["defaultRole"],
+  multiWorkspace?: boolean,
+) => {
   const path = join(dir, `${name}.db`)
   const m = new SqliteMetaStore(path)
   const raw = new Database(path)
@@ -603,6 +608,8 @@ const makeAuthedApp = (name: string, users: TestUser[], defaultRole?: AppDeps["d
     token: "tok",
     auth,
     defaultRole,
+    multiWorkspace,
+    defaultOrgId: "default",
   })
   return { app, meta: m }
 }
@@ -1712,5 +1719,89 @@ describe("workspace: open + token modes", () => {
     })
     expect(r.status).toBe(200)
     expect((await r.json()).name).toBe("Tokenspace")
+  })
+})
+
+describe("multi-workspace: isolation, switch, create, provision", () => {
+  const ada: TestUser = { id: "u_mw_ada", email: "mwada@dock.test", name: "Ada" }
+  const bo: TestUser = { id: "u_mw_bo", email: "mwbo@dock.test", name: "Bo" }
+  const { app } = makeAuthedApp("multiws", [ada, bo], "commenter", true)
+
+  // Pull the dock_ws cookie out of a Set-Cookie header to thread it on later calls.
+  const wsCookie = (res: Response): string => {
+    const m = (res.headers.get("set-cookie") ?? "").match(/dock_ws=([^;]+)/)
+    return m ? `dock_ws=${m[1]}` : ""
+  }
+  const withCookie = (email: string, cookie: string) => ({ ...as(email), cookie })
+
+  it("provisions a personal workspace for each new user on first load", async () => {
+    const a = await (await app.request("/v1/workspaces", { headers: as(ada.email) })).json()
+    expect(a.multi).toBe(true)
+    expect(a.workspaces).toHaveLength(1)
+    expect(a.workspaces[0].role).toBe("owner")
+    const b = await (await app.request("/v1/workspaces", { headers: as(bo.email) })).json()
+    // Bo gets his OWN workspace, distinct from Ada's.
+    expect(b.workspaces[0].id).not.toBe(a.workspaces[0].id)
+  })
+
+  it("isolates artifacts to the active workspace", async () => {
+    expect((await publishAs(app, "<h1>ada</h1>", { title: "Ada doc" }, as(ada.email))).status).toBe(
+      201,
+    )
+    const adaList = await (await app.request("/v1/artifacts", { headers: as(ada.email) })).json()
+    expect(adaList.artifacts.map((x: { title: string }) => x.title)).toContain("Ada doc")
+    const boList = await (await app.request("/v1/artifacts", { headers: as(bo.email) })).json()
+    expect(boList.artifacts).toHaveLength(0)
+  })
+
+  it("creates a workspace, switches into it, and it starts empty", async () => {
+    const create = await app.request("/v1/workspaces", jsonAs(as(ada.email), { name: "Acme" }))
+    expect(create.status).toBe(201)
+    const { id: acmeId, role } = await create.json()
+    expect(role).toBe("owner")
+    const cookie = wsCookie(create)
+    expect(cookie).toContain(acmeId)
+    // In Acme (via the cookie), Ada sees none of her personal-workspace artifacts.
+    const inAcme = await (
+      await app.request("/v1/artifacts", { headers: withCookie(ada.email, cookie) })
+    ).json()
+    expect(inAcme.artifacts).toHaveLength(0)
+    const spaces = await (
+      await app.request("/v1/workspaces", { headers: withCookie(ada.email, cookie) })
+    ).json()
+    expect(spaces.active).toBe(acmeId)
+    expect(spaces.workspaces).toHaveLength(2)
+  })
+
+  it("switches back to a workspace you belong to; rejects one you don't", async () => {
+    const a = await (await app.request("/v1/workspaces", { headers: as(ada.email) })).json()
+    const personal = a.workspaces.find((w: { name: string }) => w.name !== "Acme")
+    const sw = await app.request("/v1/workspace/switch", jsonAs(as(ada.email), { id: personal.id }))
+    expect(sw.status).toBe(200)
+    const back = await (
+      await app.request("/v1/artifacts", { headers: withCookie(ada.email, wsCookie(sw)) })
+    ).json()
+    expect(back.artifacts.map((x: { title: string }) => x.title)).toContain("Ada doc")
+    // Bo is not a member of Ada's personal workspace.
+    expect(
+      (await app.request("/v1/workspace/switch", jsonAs(as(bo.email), { id: personal.id }))).status,
+    ).toBe(403)
+  })
+})
+
+describe("multi-workspace: create/switch are disabled in single mode", () => {
+  const ada: TestUser = { id: "u_sw_ada", email: "swada@dock.test", name: "Ada" }
+  const { app } = makeAuthedApp("singlews", [ada], "commenter") // multi off
+
+  it("403s create and switch, and reports multi:false", async () => {
+    expect((await app.request("/v1/workspaces", jsonAs(as(ada.email), { name: "X" }))).status).toBe(
+      403,
+    )
+    expect(
+      (await app.request("/v1/workspace/switch", jsonAs(as(ada.email), { id: "whatever" }))).status,
+    ).toBe(403)
+    const list = await (await app.request("/v1/workspaces", { headers: as(ada.email) })).json()
+    expect(list.multi).toBe(false)
+    expect(list.workspaces).toHaveLength(1)
   })
 })

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -93,6 +93,18 @@ export interface Workspace {
   role: Role
   members: ArtifactMember[]
 }
+/** One entry in the workspace switcher. */
+export interface WorkspaceSummary {
+  id: string
+  name: string
+  role: Role
+}
+/** The switcher payload: whether multi-workspace is on, the active id, the list. */
+export interface Workspaces {
+  multi: boolean
+  active: string
+  workspaces: WorkspaceSummary[]
+}
 export interface Analytics {
   total: number
   unique: number
@@ -320,6 +332,13 @@ export const api = {
     f(`/v1/workspace/members/${userId}`, { method: "DELETE", credentials: "include" }).then(
       () => undefined,
     ),
+
+  // Multi-workspace: list / create / switch (the switcher; dormant in single mode)
+  listWorkspaces: (): Promise<Workspaces> => f("/v1/workspaces", opts()).then(j),
+  createWorkspace: (name: string): Promise<WorkspaceSummary> =>
+    f("/v1/workspaces", opts({ name })).then(j),
+  switchWorkspace: (id: string): Promise<{ active: string }> =>
+    f("/v1/workspace/switch", opts({ id })).then(j),
 
   // Collections (shareable groups; sharing grants the role on every item)
   listCollections: (): Promise<{ collections: Collection[] }> =>

--- a/apps/web/src/pages/Library.tsx
+++ b/apps/web/src/pages/Library.tsx
@@ -7,6 +7,7 @@ import {
   api,
   type Collection,
   type Role,
+  type Workspaces,
 } from "../api"
 import { Header, useIsMobile, useToast } from "../components"
 import { useAuth } from "../ctx"
@@ -76,6 +77,7 @@ export function Library() {
   const [summary, setSummary] = useState<Summary | null>(null)
   const [collections, setCollections] = useState<Collection[]>([])
   const [shareCol, setShareCol] = useState<Collection | null>(null)
+  const [workspaces, setWorkspaces] = useState<Workspaces | null>(null)
 
   const [query, setQuery] = useState("")
   const [debouncedQ, setDebouncedQ] = useState("")
@@ -148,12 +150,39 @@ export function Library() {
       .then((r) => setCollections(r.collections))
       .catch(() => {})
   }, [])
+  const refreshWorkspaces = useCallback(() => {
+    api
+      .listWorkspaces()
+      .then(setWorkspaces)
+      .catch(() => {})
+  }, [])
   useEffect(() => {
     if (me) {
       refreshSummary()
       refreshCollections()
+      refreshWorkspaces()
     }
-  }, [me, refreshSummary, refreshCollections])
+  }, [me, refreshSummary, refreshCollections, refreshWorkspaces])
+
+  // Switching or creating a workspace swaps the whole content context, so reload
+  // the page rather than re-thread every list — a deliberate, infrequent action.
+  const switchWorkspace = async (id: string) => {
+    if (id === workspaces?.active) return
+    try {
+      await api.switchWorkspace(id)
+      window.location.reload()
+    } catch (e) {
+      show((e as Error).message)
+    }
+  }
+  const createWorkspace = async (name: string) => {
+    try {
+      await api.createWorkspace(name)
+      window.location.reload()
+    } catch (e) {
+      show((e as Error).message)
+    }
+  }
 
   const publish = async () => {
     const f = file.current?.files?.[0]
@@ -271,6 +300,7 @@ export function Library() {
           drawer={isMobile}
           open={drawer}
           workspace={summary?.workspace ?? ""}
+          workspaces={workspaces}
           total={summary?.total ?? 0}
           favCount={summary?.favorites ?? 0}
           tags={summary?.tags ?? []}
@@ -278,6 +308,8 @@ export function Library() {
           filter={filter}
           onPick={pick}
           onCreateCollection={createCollection}
+          onSwitchWorkspace={switchWorkspace}
+          onCreateWorkspace={createWorkspace}
           onToggleRail={() => setRail((r) => !r)}
           onClose={() => setDrawer(false)}
           onSettings={() => {
@@ -681,11 +713,147 @@ function CollectionShareDialog({
   )
 }
 
+// The workspace name in the sidebar. Single mode: a shortcut to settings. Multi
+// mode: a dropdown to switch between workspaces or create a new one.
+function WorkspaceSwitcher({
+  label,
+  workspaces,
+  onSwitch,
+  onCreate,
+  onSettings,
+}: {
+  label: string
+  workspaces: Workspaces | null
+  onSwitch: (id: string) => void
+  onCreate: (name: string) => void
+  onSettings: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [adding, setAdding] = useState(false)
+  const [name, setName] = useState("")
+
+  if (!workspaces?.multi)
+    return (
+      <button
+        className="side-item"
+        onClick={onSettings}
+        title="Workspace settings"
+        style={{ fontWeight: 600 }}
+      >
+        <span className="ic">◆</span>
+        <span className="lbl" style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+          {label}
+        </span>
+      </button>
+    )
+
+  const submit = () => {
+    const t = name.trim()
+    if (t) onCreate(t)
+    setName("")
+    setAdding(false)
+    setOpen(false)
+  }
+  return (
+    <div style={{ position: "relative" }}>
+      <button
+        className="side-item"
+        onClick={() => setOpen((v) => !v)}
+        title="Switch workspace"
+        style={{ fontWeight: 600 }}
+      >
+        <span className="ic">◆</span>
+        <span className="lbl" style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+          {label}
+        </span>
+        <span className="n">⌄</span>
+      </button>
+      {open && (
+        <>
+          <button
+            type="button"
+            aria-label="Close workspace menu"
+            onClick={() => setOpen(false)}
+            style={{
+              position: "fixed",
+              inset: 0,
+              zIndex: 20,
+              border: 0,
+              background: "transparent",
+              cursor: "default",
+            }}
+          />
+          <div
+            className="card"
+            style={{
+              position: "absolute",
+              top: "100%",
+              left: 0,
+              right: 0,
+              zIndex: 21,
+              marginTop: 4,
+              padding: 4,
+              maxHeight: 320,
+              overflowY: "auto",
+            }}
+          >
+            {workspaces.workspaces.map((w) => (
+              <button
+                key={w.id}
+                className={`side-item${w.id === workspaces.active ? " on" : ""}`}
+                onClick={() => {
+                  onSwitch(w.id)
+                  setOpen(false)
+                }}
+              >
+                <span className="ic">{w.id === workspaces.active ? "✓" : "◇"}</span>
+                <span className="lbl" style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+                  {w.name}
+                </span>
+              </button>
+            ))}
+            <div style={{ borderTop: "1px solid var(--line)", margin: "4px 0" }} />
+            {adding ? (
+              <input
+                className="input"
+                placeholder="Workspace name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") submit()
+                  if (e.key === "Escape") setAdding(false)
+                }}
+                style={{ width: "100%", margin: "2px 0" }}
+              />
+            ) : (
+              <button className="side-item" onClick={() => setAdding(true)}>
+                <span className="ic">＋</span>
+                <span className="lbl">New workspace</span>
+              </button>
+            )}
+            <button
+              className="side-item"
+              onClick={() => {
+                setOpen(false)
+                onSettings()
+              }}
+            >
+              <span className="ic">⚙</span>
+              <span className="lbl">Workspace settings</span>
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
 function Sidebar({
   rail,
   drawer,
   open,
   workspace,
+  workspaces,
   total,
   favCount,
   tags,
@@ -693,6 +861,8 @@ function Sidebar({
   filter,
   onPick,
   onCreateCollection,
+  onSwitchWorkspace,
+  onCreateWorkspace,
   onToggleRail,
   onClose,
   onSettings,
@@ -701,6 +871,7 @@ function Sidebar({
   drawer: boolean
   open: boolean
   workspace: string
+  workspaces: Workspaces | null
   total: number
   favCount: number
   tags: TagCount[]
@@ -708,6 +879,8 @@ function Sidebar({
   filter: Filter
   onPick: (f: Filter) => void
   onCreateCollection: (title: string) => void
+  onSwitchWorkspace: (id: string) => void
+  onCreateWorkspace: (name: string) => void
   onToggleRail: () => void
   onClose: () => void
   onSettings: () => void
@@ -724,17 +897,13 @@ function Sidebar({
   return (
     <aside className={cls} aria-label="Browse">
       {!rail && workspace && (
-        <button
-          className="side-item"
-          onClick={onSettings}
-          title="Workspace settings"
-          style={{ fontWeight: 600 }}
-        >
-          <span className="ic">◆</span>
-          <span className="lbl" style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
-            {workspace}
-          </span>
-        </button>
+        <WorkspaceSwitcher
+          label={workspace}
+          workspaces={workspaces}
+          onSwitch={onSwitchWorkspace}
+          onCreate={onCreateWorkspace}
+          onSettings={onSettings}
+        />
       )}
       <div className="side-lbl">Library</div>
       <button

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -40,6 +40,8 @@ export interface ListArtifactsOpts {
   q?: string
   /** Restrict to these artifact ids (tag / favorite filters resolve to ids). Empty ⇒ none. */
   ids?: string[]
+  /** Scope to one workspace (multi-workspace). Omitted ⇒ every workspace. */
+  orgId?: string
 }
 
 export interface VersionRecord {
@@ -103,10 +105,10 @@ export interface MetaStore {
   listArtifacts(opts?: ListArtifactsOpts): Promise<ArtifactRecord[]>
   /** Artifact ids carrying a tag (server-side tag filtering). */
   artifactIdsByTag(tag: string): Promise<string[]>
-  /** Total artifact count (browse summary). */
-  countArtifacts(): Promise<number>
-  /** Tag → usage count across the workspace (browse sidebar). */
-  tagCounts(): Promise<{ tag: string; count: number }[]>
+  /** Total artifact count, scoped to a workspace when orgId is given. */
+  countArtifacts(orgId?: string): Promise<number>
+  /** Tag → usage count, scoped to a workspace when orgId is given (browse sidebar). */
+  tagCounts(orgId?: string): Promise<{ tag: string; count: number }[]>
 
   /** Append a view event. */
   recordView(v: NewView): Promise<void>
@@ -152,6 +154,8 @@ export interface MetaStore {
   getWorkspace(orgId: string): Promise<WorkspaceRecord | null>
   /** Insert or rename the workspace. */
   setWorkspace(orgId: string, name: string): Promise<WorkspaceRecord>
+  /** Every workspace a user belongs to, with their role, oldest first (the switcher). */
+  listWorkspaces(userId: string): Promise<(WorkspaceRecord & { role: Role })[]>
   getMembership(orgId: string, userId: string): Promise<MembershipRecord | null>
   listMemberships(orgId: string): Promise<MembershipRecord[]>
   countMemberships(orgId: string): Promise<number>
@@ -182,8 +186,8 @@ export interface MetaStore {
   updateCollection(id: string, fields: { title?: string }): Promise<CollectionRecord | null>
   /** Remove a collection and its items + member rows. */
   deleteCollection(id: string): Promise<void>
-  /** All collections (workspace-wide) with their item counts, newest first. */
-  listCollections(): Promise<(CollectionRecord & { count: number })[]>
+  /** Collections with their item counts, newest first; scoped to a workspace when orgId is given. */
+  listCollections(orgId?: string): Promise<(CollectionRecord & { count: number })[]>
   /** Artifact ids in a collection (drives ?collection= browse). */
   collectionArtifactIds(collectionId: string): Promise<string[]>
   /** Collection ids containing an artifact (for the artifact's "add to" UI). */

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -22,6 +22,8 @@ export interface PublishInput {
   spa?: boolean
   message?: string
   author?: string
+  /** The workspace the new artifact belongs to (multi-workspace). */
+  orgId?: string
   visibility?: Visibility
   /** Names this publish a pinned checkpoint (Docs-style). */
   name?: string
@@ -156,7 +158,7 @@ export async function publish(
   const artifact = await meta.createArtifact({
     id: newId("a"),
     short_id: newShortId(),
-    org_id: "local",
+    org_id: input.orgId ?? "local",
     slug: input.slug ? slugify(input.slug) : slugify(title) || null,
     title,
     visibility: input.visibility ?? "link",

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -200,6 +200,7 @@ export class D1MetaStore implements MetaStore {
         ),
       )
     if (opts?.ids) conds.push(inArray(artifact.id, opts.ids))
+    if (opts?.orgId) conds.push(eq(artifact.org_id, opts.orgId))
     const q = this.db
       .select()
       .from(artifact)
@@ -215,14 +216,17 @@ export class D1MetaStore implements MetaStore {
       .all()
     return rows.map((r) => r.id)
   }
-  async countArtifacts(): Promise<number> {
-    const r = await this.db.select({ c: count() }).from(artifact).get()
+  async countArtifacts(orgId?: string): Promise<number> {
+    const q = this.db.select({ c: count() }).from(artifact)
+    const r = await (orgId ? q.where(eq(artifact.org_id, orgId)) : q).get()
     return r?.c ?? 0
   }
-  async tagCounts(): Promise<{ tag: string; count: number }[]> {
-    return this.db
+  async tagCounts(orgId?: string): Promise<{ tag: string; count: number }[]> {
+    const base = this.db
       .select({ tag: artifactTag.tag, count: count() })
       .from(artifactTag)
+      .innerJoin(artifact, eq(artifact.id, artifactTag.artifact_id))
+    return (orgId ? base.where(eq(artifact.org_id, orgId)) : base)
       .groupBy(artifactTag.tag)
       .orderBy(asc(artifactTag.tag))
       .all()
@@ -392,6 +396,20 @@ export class D1MetaStore implements MetaStore {
       .returning()
       .get()
   }
+  listWorkspaces(userId: string): Promise<(WorkspaceRecord & { role: Role })[]> {
+    return this.db
+      .select({
+        id: workspace.id,
+        name: workspace.name,
+        created_at: workspace.created_at,
+        role: membership.role,
+      })
+      .from(membership)
+      .innerJoin(workspace, eq(workspace.id, membership.org_id))
+      .where(eq(membership.user_id, userId))
+      .orderBy(asc(workspace.created_at))
+      .all()
+  }
 
   async getArtifactMember(
     artifactId: string,
@@ -502,8 +520,11 @@ export class D1MetaStore implements MetaStore {
     await this.db.delete(collectionMember).where(eq(collectionMember.collection_id, id)).run()
     await this.db.delete(collection).where(eq(collection.id, id)).run()
   }
-  async listCollections(): Promise<(CollectionRecord & { count: number })[]> {
-    const rows = await this.db.select().from(collection).orderBy(desc(collection.created_at)).all()
+  async listCollections(orgId?: string): Promise<(CollectionRecord & { count: number })[]> {
+    const base = this.db.select().from(collection)
+    const rows = await (orgId ? base.where(eq(collection.org_id, orgId)) : base)
+      .orderBy(desc(collection.created_at))
+      .all()
     const counts = await this.db
       .select({ id: collectionItem.collection_id, c: count() })
       .from(collectionItem)

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -201,6 +201,7 @@ export class PgMetaStore implements MetaStore {
         ),
       )
     if (opts?.ids) conds.push(inArray(artifact.id, opts.ids))
+    if (opts?.orgId) conds.push(eq(artifact.org_id, opts.orgId))
     const q = this.db
       .select()
       .from(artifact)
@@ -215,14 +216,17 @@ export class PgMetaStore implements MetaStore {
       .where(eq(artifactTag.tag, tag))
     return rows.map((r) => r.id)
   }
-  async countArtifacts(): Promise<number> {
-    const rows = await this.db.select({ c: count() }).from(artifact)
+  async countArtifacts(orgId?: string): Promise<number> {
+    const q = this.db.select({ c: count() }).from(artifact)
+    const rows = await (orgId ? q.where(eq(artifact.org_id, orgId)) : q)
     return Number(rows[0]?.c ?? 0)
   }
-  async tagCounts(): Promise<{ tag: string; count: number }[]> {
-    const rows = await this.db
+  async tagCounts(orgId?: string): Promise<{ tag: string; count: number }[]> {
+    const base = this.db
       .select({ tag: artifactTag.tag, count: count() })
       .from(artifactTag)
+      .innerJoin(artifact, eq(artifact.id, artifactTag.artifact_id))
+    const rows = await (orgId ? base.where(eq(artifact.org_id, orgId)) : base)
       .groupBy(artifactTag.tag)
       .orderBy(asc(artifactTag.tag))
     return rows.map((r) => ({ tag: r.tag, count: Number(r.count) }))
@@ -398,6 +402,19 @@ export class PgMetaStore implements MetaStore {
       .returning()
     return rows[0]
   }
+  listWorkspaces(userId: string): Promise<(WorkspaceRecord & { role: Role })[]> {
+    return this.db
+      .select({
+        id: workspace.id,
+        name: workspace.name,
+        created_at: workspace.created_at,
+        role: membership.role,
+      })
+      .from(membership)
+      .innerJoin(workspace, eq(workspace.id, membership.org_id))
+      .where(eq(membership.user_id, userId))
+      .orderBy(asc(workspace.created_at))
+  }
 
   async getArtifactMember(
     artifactId: string,
@@ -499,8 +516,11 @@ export class PgMetaStore implements MetaStore {
       await tx.delete(collection).where(eq(collection.id, id))
     })
   }
-  async listCollections(): Promise<(CollectionRecord & { count: number })[]> {
-    const rows = await this.db.select().from(collection).orderBy(desc(collection.created_at))
+  async listCollections(orgId?: string): Promise<(CollectionRecord & { count: number })[]> {
+    const base = this.db.select().from(collection)
+    const rows = await (orgId ? base.where(eq(collection.org_id, orgId)) : base).orderBy(
+      desc(collection.created_at),
+    )
     const counts = await this.db
       .select({ id: collectionItem.collection_id, c: count() })
       .from(collectionItem)

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -207,6 +207,7 @@ export class SqliteMetaStore implements MetaStore {
         ),
       )
     if (opts?.ids) conds.push(inArray(artifact.id, opts.ids))
+    if (opts?.orgId) conds.push(eq(artifact.org_id, opts.orgId))
     const rows = this.db
       .select()
       .from(artifact)
@@ -222,13 +223,16 @@ export class SqliteMetaStore implements MetaStore {
       .all()
       .map((r) => r.id)
   }
-  async countArtifacts(): Promise<number> {
-    return this.db.select({ c: count() }).from(artifact).get()?.c ?? 0
+  async countArtifacts(orgId?: string): Promise<number> {
+    const q = this.db.select({ c: count() }).from(artifact)
+    return (orgId ? q.where(eq(artifact.org_id, orgId)).get() : q.get())?.c ?? 0
   }
-  async tagCounts(): Promise<{ tag: string; count: number }[]> {
-    return this.db
+  async tagCounts(orgId?: string): Promise<{ tag: string; count: number }[]> {
+    const base = this.db
       .select({ tag: artifactTag.tag, count: count() })
       .from(artifactTag)
+      .innerJoin(artifact, eq(artifact.id, artifactTag.artifact_id))
+    return (orgId ? base.where(eq(artifact.org_id, orgId)) : base)
       .groupBy(artifactTag.tag)
       .orderBy(asc(artifactTag.tag))
       .all()
@@ -416,6 +420,22 @@ export class SqliteMetaStore implements MetaStore {
         .get(),
     )
   }
+  listWorkspaces(userId: string): Promise<(WorkspaceRecord & { role: Role })[]> {
+    return Promise.resolve(
+      this.db
+        .select({
+          id: workspace.id,
+          name: workspace.name,
+          created_at: workspace.created_at,
+          role: membership.role,
+        })
+        .from(membership)
+        .innerJoin(workspace, eq(workspace.id, membership.org_id))
+        .where(eq(membership.user_id, userId))
+        .orderBy(asc(workspace.created_at))
+        .all(),
+    )
+  }
 
   async getArtifactMember(
     artifactId: string,
@@ -530,8 +550,11 @@ export class SqliteMetaStore implements MetaStore {
       this.db.delete(collection).where(eq(collection.id, id)).run()
     })()
   }
-  async listCollections(): Promise<(CollectionRecord & { count: number })[]> {
-    const rows = this.db.select().from(collection).orderBy(desc(collection.created_at)).all()
+  async listCollections(orgId?: string): Promise<(CollectionRecord & { count: number })[]> {
+    const base = this.db.select().from(collection)
+    const rows = (orgId ? base.where(eq(collection.org_id, orgId)) : base)
+      .orderBy(desc(collection.created_at))
+      .all()
     const counts = this.db
       .select({ id: collectionItem.collection_id, c: count() })
       .from(collectionItem)


### PR DESCRIPTION
Makes workspaces first-class and switchable for the hosted product, while keeping self-host single-workspace by default. The whole thing is invisible unless turned on.

## The model
- **Single mode (default, self-host):** one workspace, no switcher, behaves exactly as before.
- **Multi mode (hosted):** set `DOCK_MULTI_WORKSPACE=true`. Users create/switch workspaces; everything scopes by `org_id`.

The key change: **kill the hardcoded `"local"` sentinel.** There is always a real, resolved `orgId`. A per-request `activeWorkspace(c)` replaces the constant:
- single → the bootstrap org id
- multi → the `dock_ws` cookie (validated against membership) → your first workspace → else a personal workspace provisioned on first login
- an agent always acts in **its own** workspace (`agent.org_id`)

So flipping to multi later is a flag, never a data retrofit — the escape hatch is built in.

## Data
- `ListArtifactsOpts.orgId`; `countArtifacts(orgId?)` / `tagCounts(orgId?)` / `listCollections(orgId?)` scope by workspace.
- New `listWorkspaces(userId)` → `(workspace + role)[]` for the switcher.
- `publish()` takes `orgId`, so new artifacts are stamped with the active workspace (was hardcoded `"local"`).

## API
- `GET /v1/workspaces` — your workspaces, the active id, and the `multi` flag.
- `POST /v1/workspaces` — create (you become owner, switched in). Multi only.
- `POST /v1/workspace/switch` — set the active workspace (member-gated). Multi only.
- Artifacts, collections, tags, the member directory, and agents are all scoped to the active workspace. `/v1/me` and `/v1/workspace` expose `multi`.

## Node entry
- `DOCK_MULTI_WORKSPACE` (off by default).
- `DOCK_DEFAULT_ORG_ID`, or a generated id persisted to `DATA_DIR/.org-id` (same pattern as the auth secret) — a real bootstrap orgId, no magic literal.
- An **idempotent** one-time rekey migrates any legacy `org_id='local'` rows onto the default org. No-op on fresh installs and hosted Postgres.

## Web
- The sidebar workspace name becomes a **switcher** in multi mode (switch between workspaces / create one / open settings); in single mode it stays a plain link to settings.
- New api-client methods + `Workspaces` type.

## Tests + verification
- 123 tests in `apps/api`. Single-mode behavior is unchanged (all prior tests pass with artifacts now stamped by the resolved org).
- 5 multi-mode tests: personal-workspace provisioning (distinct per user), per-workspace artifact **isolation**, create+switch (new workspace starts empty), switch-rejection for non-members, and create/switch returning 403 in single mode.
- Browser-verified in multi mode: auto-provisioned personal workspace, the sidebar switcher dropdown (switch / create / settings), and the create→reload flow.

## Notes / follow-ups
- Per-artifact and collection shares intentionally cross workspace boundaries (opening a shared link doesn't require it to be in your active workspace, and never auto-joins you).
- Webhooks and notifications are not yet workspace-scoped (no `org_id` column on webhooks; notifications are per-user and naturally span your workspaces). Reasonable as a follow-up before heavy multi-tenant webhook use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)