### PR TITLE
harden: token hashing, constant-time compares, drop dead password visibility

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto"
+import { createHash, randomUUID, timingSafeEqual } from "node:crypto"
 import {
   type Action,
   type Actor,
@@ -195,9 +195,17 @@ const isWorkspaceRole = (v: unknown): v is Role =>
  *  to one recorded view — a refresh or quick re-open doesn't inflate the count. */
 const VIEW_DEDUP_MS = 30 * 60_000
 
-const VISIBILITIES = ["public", "link", "org", "password"] as const
+const VISIBILITIES = ["public", "link", "org"] as const
 
 const MAX_UPLOAD_BYTES = 100 * 1024 * 1024
+
+const sha256 = (s: string): string => createHash("sha256").update(s).digest("hex")
+// Constant-time string compare: hash both sides to a fixed length first so
+// neither the contents nor the length leak through comparison timing. An unset
+// secret (undefined) never matches.
+const safeEqual = (a: string, b: string | undefined): boolean =>
+  !!b &&
+  timingSafeEqual(createHash("sha256").update(a).digest(), createHash("sha256").update(b).digest())
 
 /** Headers for everything inside the artifact sandbox. */
 const RAW_HEADERS: Record<string, string> = {
@@ -446,7 +454,9 @@ export function createApp(deps: AppDeps): Hono {
   const agentFor = async (c: Context): Promise<AgentRecord | null> => {
     if (agentCache.has(c)) return agentCache.get(c) ?? null
     const b = bearer(c)
-    const a = !b || (deps.token && b === deps.token) ? null : await meta.getAgentByToken(b)
+    // Tokens are stored hashed; look up by the hash of the presented bearer.
+    const a =
+      !b || (deps.token && safeEqual(b, deps.token)) ? null : await meta.getAgentByToken(sha256(b))
     agentCache.set(c, a)
     return a
   }
@@ -553,7 +563,7 @@ export function createApp(deps: AppDeps): Hono {
     })
 
   const actorFor = async (c: Context, a: ArtifactRecord): Promise<Actor> => {
-    if (deps.token && bearer(c) === deps.token) return { kind: "token" }
+    if (deps.token && safeEqual(bearer(c), deps.token)) return { kind: "token" }
     const ag = await agentFor(c)
     if (ag) {
       const am = await meta.getArtifactMember(a.id, ag.id)
@@ -581,7 +591,7 @@ export function createApp(deps: AppDeps): Hono {
 
   /** The caller's role in their active workspace (creating artifacts, settings). */
   const workspaceRole = async (c: Context): Promise<Role | null> => {
-    if (deps.token && bearer(c) === deps.token) return "owner"
+    if (deps.token && safeEqual(bearer(c), deps.token)) return "owner"
     const ag = await agentFor(c)
     if (ag) return ag.role
     const me = await currentUser(c)
@@ -625,7 +635,7 @@ export function createApp(deps: AppDeps): Hono {
   // an agent can be @mentioned like anyone. Signed-in (or open) only; optional
   // ?q= filters by name/email prefix. Never exposes non-members.
   app.get("/v1/users", async (c) => {
-    if (!open && !(await currentUser(c)) && bearer(c) !== deps.token)
+    if (!open && !(await currentUser(c)) && !safeEqual(bearer(c), deps.token))
       return c.json({ error: "unauthenticated" }, 401)
     const org = await activeWorkspace(c)
     const members = await meta.listMemberships(org)
@@ -808,8 +818,10 @@ export function createApp(deps: AppDeps): Hono {
   })
 
   // Create an agent + mint its token. The token is returned ONCE here; only its
-  // hash-free secret lives in the row, so store it now. Default role commenter
-  // (propose-only); editor is opt-in. Owner is never allowed for an agent.
+  // SHA-256 hash is stored, so a database leak can't expose usable credentials
+  // (the token is high-entropy random, so a plain hash is sufficient — no salt
+  // or slow KDF needed). Default role commenter (propose-only); editor is
+  // opt-in. Owner is never allowed for an agent.
   app.post("/v1/agents", async (c) => {
     if (!(await workspaceCan(c, "manage"))) return c.json({ error: "forbidden" }, 403)
     const b = (await c.req.json().catch(() => ({}))) as { name?: unknown; role?: unknown }
@@ -823,10 +835,10 @@ export function createApp(deps: AppDeps): Hono {
         id: newId("ag"),
         org_id: await activeWorkspace(c),
         name,
-        token,
+        token: sha256(token),
         role,
       })
-      // The only place the token is ever exposed.
+      // The only place the raw token is ever exposed.
       return c.json({ ...agentJson(agent), token }, 201)
     } catch {
       return c.json({ error: "an agent with that name already exists" }, 409)
@@ -873,7 +885,7 @@ export function createApp(deps: AppDeps): Hono {
   // { artifacts, next_cursor }. tag/favorite resolve to an id set first.
   app.get("/v1/artifacts", async (c) => {
     const me = await currentUser(c)
-    if (!me && deps.token && bearer(c) !== deps.token)
+    if (!me && deps.token && !safeEqual(bearer(c), deps.token))
       return c.json({ error: "unauthenticated" }, 401)
     const limit = Math.min(100, Math.max(1, Number(c.req.query("limit")) || 30))
     // Opaque compound cursor "<created_at>|<id>" — the id tiebreak keeps paging
@@ -926,7 +938,7 @@ export function createApp(deps: AppDeps): Hono {
   // and tag → count (so counts stay accurate independent of the current page).
   app.get("/v1/tags", async (c) => {
     const me = await currentUser(c)
-    if (!me && deps.token && bearer(c) !== deps.token)
+    if (!me && deps.token && !safeEqual(bearer(c), deps.token))
       return c.json({ error: "unauthenticated" }, 401)
     const org = await activeWorkspace(c)
     const [total, tags, favIds, ws] = await Promise.all([
@@ -947,7 +959,7 @@ export function createApp(deps: AppDeps): Hono {
   // ---- Collections (shareable groups; a member's role propagates to items) -
   // A user's role on a collection: creator/member role, token/open → owner.
   const collectionRole = async (c: Context, col: CollectionRecord): Promise<Role | null> => {
-    if (deps.token && bearer(c) === deps.token) return "owner"
+    if (deps.token && safeEqual(bearer(c), deps.token)) return "owner"
     const me = await currentUser(c)
     if (!me) return open ? "owner" : null
     if (col.created_by === me.id) return "owner"
@@ -958,7 +970,7 @@ export function createApp(deps: AppDeps): Hono {
     roleAllows((await collectionRole(c, col)) ?? "viewer", action)
 
   app.get("/v1/collections", async (c) => {
-    if (!(await currentUser(c)) && deps.token && bearer(c) !== deps.token)
+    if (!(await currentUser(c)) && deps.token && !safeEqual(bearer(c), deps.token))
       return c.json({ error: "unauthenticated" }, 401)
     return c.json({ collections: await meta.listCollections(await activeWorkspace(c)) })
   })
@@ -1145,10 +1157,9 @@ export function createApp(deps: AppDeps): Hono {
 
   app.get("/v1/artifacts/:shortId", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
-    const actor = await actorFor(
-      c,
-      artifact ?? ({ id: "", visibility: "password" } as ArtifactRecord),
-    )
+    // For a missing artifact, fall back to the most restrictive visibility so
+    // an anonymous probe can't learn anything (a non-member gets no access).
+    const actor = await actorFor(c, artifact ?? ({ id: "", visibility: "org" } as ArtifactRecord))
     if (!artifact || !can(actor, "read", artifact.visibility))
       return c.json({ error: "not found" }, 404)
     const versions = await meta.listVersions(artifact.id)

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -222,6 +222,19 @@ void (async () => {
 const blobDesc = process.env.OBJECT_STORE_URL ? "S3/R2" : `local disk (${DATA_DIR})`
 const metaDesc = DATABASE_URL ? "postgres" : `sqlite (${DATA_DIR})`
 
+// Loud warning for the footgun: a cross-site / public-looking deployment that
+// serves untrusted artifact HTML on its own origin (no separate sandbox host).
+// Single-origin self-host is a supported mode (the iframe sandbox is the wall);
+// a cross-site setup without isolation is not.
+if (
+  !process.env.DOCK_SANDBOX_URL &&
+  (process.env.DOCK_CROSS_SITE === "true" || webOrigins.length)
+) {
+  console.warn(
+    "⚠ DOCK_SANDBOX_URL is unset on a cross-site deployment. Artifact HTML will be served from the app origin; set DOCK_SANDBOX_URL to a separate domain to isolate untrusted content from session cookies.",
+  )
+}
+
 serve({ fetch: app.fetch, port: PORT }, () => {
   console.log(`dock api listening on :${PORT}`)
   console.log(`  meta:    ${metaDesc}`)

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -762,6 +762,25 @@ describe("agents: @mention → pull inbox → propose → ack", () => {
     expect(typeof agentToken).toBe("string")
   })
 
+  it("stores only the token hash at rest, yet the raw token still authenticates", async () => {
+    const ag: TestUser = { id: "u_ag_hash", email: "aghash@dock.test", name: "Hasher" }
+    const { app: a2, meta: m2 } = makeAuthedApp("agent-hash", [ag], "commenter")
+    await a2.request("/v1/me", { headers: as(ag.email) }) // claims ownership
+    const reg = await (await a2.request("/v1/agents", jsonAs(as(ag.email), { name: "Bot" }))).json()
+    const raw = reg.token as string
+    // Single-workspace mode provisions under the default org id.
+    const [stored] = await m2.listAgents("default")
+    expect(stored.token).not.toBe(raw) // the raw secret is never at rest
+    expect(stored.token).toMatch(/^[0-9a-f]{64}$/) // it's a sha-256 hash
+    // The raw token still works: the agent can read its own inbox.
+    const inbox = await a2.request("/v1/agent/inbox", { headers: bearer(raw) })
+    expect(inbox.status).toBe(200)
+    // A near-miss token (its hash) does not authenticate.
+    const wrong = await a2.request("/v1/agent/inbox", { headers: bearer(stored.token) })
+    expect(wrong.status).toBe(401)
+    m2.close()
+  })
+
   it("the agent shows up in the @mention directory", async () => {
     const dir = await (await app.request("/v1/users?q=clau", { headers: as(owner.email) })).json()
     expect(dir.users).toContainEqual(

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -11,7 +11,7 @@ export interface BlobStore {
 }
 
 export type ArtifactKind = "file" | "bundle"
-export type Visibility = "public" | "link" | "org" | "password"
+export type Visibility = "public" | "link" | "org"
 
 export interface ArtifactRecord {
   id: string


### PR DESCRIPTION
Post-launch-gate hardening: the easy, high-value gaps a security pass surfaced. No behavior change for normal use; this is defense-in-depth.

## Changes
- **Agent tokens are stored hashed (SHA-256), never raw.** A DB leak can no longer yield usable agent credentials. The token is high-entropy random, so a plain hash (no salt/KDF) is the right tool. Raw token is shown once at creation and hashed on every lookup.
- **Constant-time compare for the static instance token** (`DOCK_TOKEN`) at all call sites, via `timingSafeEqual` over fixed-length digests. Closes the theoretical timing side-channel of `===` on a secret.
- **Removed the `password` visibility.** It was defined but never enforced (no password column, dead `acl` table, no UI). It failed *closed*, so nothing leaked, but it was a misleading non-feature. The missing-artifact deny sentinel now uses `org` (equally restrictive).
- **Boot warning** when a cross-site / public-looking deployment (`DOCK_CROSS_SITE` or `DOCK_WEB_ORIGIN` set) has no `DOCK_SANDBOX_URL` — the one config footgun that would leave untrusted HTML on the app's cookie origin.

## Deferred (noted, not "easy")
Webhook SSRF DNS-rebinding, CSRF tokens on the cross-site cookie path, and distributed (Redis) rate limits. Tracked for a later pass.

## Tests
New: a registered agent's token is a SHA-256 hash at rest, the raw token still authenticates, and presenting the stored hash does not. Full suite 131 api tests green; typecheck + biome clean. Rebased onto the multi-workspace work (#48).

🤖 Generated with [Claude Code](https://claude.com/claude-code)