### PR TITLE
fix: per-workspace quota scoping + SSRF encoding/redirect holes + byte meter

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -288,6 +288,51 @@ function makeKeyedLimiter(windowMs: number, max: number) {
  * blocked here; hostnames that resolve into private space (DNS rebinding) are
  * out of scope for this static check.
  */
+/** Is a dotted-decimal octet quad in a private / loopback / link-local range? */
+function isPrivateV4([a, b]: number[]): boolean {
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 169 && b === 254) || // link-local + cloud metadata
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 100 && b >= 64 && b <= 127) // CGNAT
+  )
+}
+
+/**
+ * Parse any inet_aton IPv4 form to its four octets, or null if not an IPv4.
+ * Covers dotted-decimal AND the bypass forms `curl`/browsers accept: a bare
+ * integer (`2130706433`), hex (`0x7f000001`), octal (`0177.0.0.1`), and short
+ * dotted forms (`127.1`). Without this, those all read as "not an IP" and slip
+ * past the private-range check while still resolving to loopback.
+ */
+function ipv4Octets(host: string): number[] | null {
+  const parts = host.split(".")
+  if (parts.length === 0 || parts.length > 4) return null
+  const vals: number[] = []
+  for (const p of parts) {
+    let n: number
+    if (/^0x[0-9a-f]+$/i.test(p)) n = Number.parseInt(p.slice(2), 16)
+    else if (/^0[0-7]+$/.test(p)) n = Number.parseInt(p, 8)
+    else if (p === "0" || /^[1-9][0-9]*$/.test(p)) n = Number.parseInt(p, 10)
+    else return null
+    if (!Number.isInteger(n) || n < 0) return null
+    vals.push(n)
+  }
+  const k = vals.length
+  // The last value fills the remaining low bytes; each leading value is one byte.
+  if (vals[k - 1] > 2 ** ((5 - k) * 8) - 1) return null
+  let value = vals[k - 1]
+  for (let i = 0; i < k - 1; i++) {
+    if (vals[i] > 255) return null
+    value += vals[i] * 2 ** (24 - i * 8)
+  }
+  if (value > 0xffffffff) return null
+  return [(value >>> 24) & 255, (value >>> 16) & 255, (value >>> 8) & 255, value & 255]
+}
+
 export function isPublicHttpUrl(raw: string): boolean {
   let u: URL
   try {
@@ -297,24 +342,32 @@ export function isPublicHttpUrl(raw: string): boolean {
   }
   if (u.protocol !== "http:" && u.protocol !== "https:") return false
   const host = u.hostname.toLowerCase().replace(/^\[|\]$/g, "")
-  if (host === "" || host === "0.0.0.0" || host === "localhost" || host.endsWith(".localhost"))
-    return false
-  const v4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
-  if (v4) {
-    const o = v4.slice(1).map(Number)
-    if (o.some((n) => n > 255)) return false
-    const [a, b] = o
-    if (a === 0 || a === 10 || a === 127) return false
-    if (a === 169 && b === 254) return false // link-local + cloud metadata
-    if (a === 172 && b >= 16 && b <= 31) return false
-    if (a === 192 && b === 168) return false
-    if (a === 100 && b >= 64 && b <= 127) return false // CGNAT
-    return true
-  }
+  if (host === "" || host === "localhost" || host.endsWith(".localhost")) return false
+  const v4 = ipv4Octets(host)
+  if (v4) return !isPrivateV4(v4)
   if (host.includes(":")) {
     if (host === "::1" || host === "::") return false
     if (/^f[cd]/.test(host)) return false // unique-local fc00::/7
     if (/^fe80/.test(host)) return false // link-local
+    // IPv4-mapped (::ffff:a.b.c.d). The URL parser rewrites the dotted tail to
+    // hex hextets (::ffff:7f00:1), so handle both: decode the embedded v4 and
+    // run the private-range check on it.
+    const m = host.match(/^::ffff:(.+)$/i)
+    if (m) {
+      const suf = m[1]
+      let oct: number[] | null = null
+      if (suf.includes(".")) {
+        oct = ipv4Octets(suf)
+      } else {
+        const g = suf.split(":").map((x) => Number.parseInt(x, 16))
+        if (g.every((x) => Number.isInteger(x) && x >= 0 && x <= 0xffff)) {
+          const lo = g[g.length - 1]
+          const hi = g.length >= 2 ? g[g.length - 2] : 0
+          oct = [(hi >> 8) & 255, hi & 255, (lo >> 8) & 255, lo & 255]
+        }
+      }
+      if (oct && isPrivateV4(oct)) return false
+    }
     return true
   }
   return true
@@ -491,9 +544,9 @@ export function createApp(deps: AppDeps): Hono {
     c.header("Retry-After", String(r.retryAfter))
     return c.json({ error: "rate limit exceeded" }, 429)
   }
-  // Would storing `incoming` more bytes push the workspace over its storage cap?
-  const overStorage = async (incoming: number): Promise<boolean> =>
-    !!deps.maxBytes && (await meta.storageBytes()) + incoming > deps.maxBytes
+  // Would storing `incoming` more bytes push THIS workspace over its storage cap?
+  const overStorage = async (orgId: string, incoming: number): Promise<boolean> =>
+    !!deps.maxBytes && (await meta.storageBytes(orgId)) + incoming > deps.maxBytes
 
   // ---- Authorization ----------------------------------------------------
   // One choke point: every gate resolves an Actor and asks can(). An unsecured
@@ -1075,17 +1128,21 @@ export function createApp(deps: AppDeps): Hono {
   const handlePublish = async (c: Context, shortId?: string) => {
     // Republishing a version needs publish rights on that artifact; creating a
     // new one needs publish rights at the workspace level.
+    let existing: ArtifactRecord | null = null
     if (shortId) {
-      const existing = await meta.getByShortId(shortId)
+      existing = await meta.getByShortId(shortId)
       if (!existing) return c.json({ error: "not found" }, 404)
       if (!(await authorize(c, "publish", existing))) return c.json({ error: "forbidden" }, 403)
     } else if (!(await workspaceCan(c, "publish"))) {
       return c.json({ error: "forbidden" }, 403)
     }
+    // Quotas are per-workspace: a republish counts against the artifact's own
+    // org, a new artifact against the caller's active workspace.
+    const org = existing ? existing.org_id : await activeWorkspace(c)
     const rl = await limited(c, publishLimiter)
     if (rl) return rl
     // A new artifact counts against the artifact cap; republishes don't.
-    if (!shortId && deps.maxArtifacts && (await meta.countArtifacts()) >= deps.maxArtifacts)
+    if (!shortId && deps.maxArtifacts && (await meta.countArtifacts(org)) >= deps.maxArtifacts)
       return c.json({ error: "artifact quota reached" }, 409)
     const len = Number(c.req.header("content-length") ?? 0)
     if (len > MAX_UPLOAD_BYTES) return c.json({ error: "upload too large" }, 413)
@@ -1095,7 +1152,8 @@ export function createApp(deps: AppDeps): Hono {
     if (!(file instanceof File)) return c.json({ error: "multipart field 'file' required" }, 400)
 
     const bytes = new Uint8Array(await file.arrayBuffer())
-    if (await overStorage(bytes.length)) return c.json({ error: "storage quota exceeded" }, 413)
+    if (await overStorage(org, bytes.length))
+      return c.json({ error: "storage quota exceeded" }, 413)
     const isBundle =
       /\.zip$/i.test(file.name) ||
       body["kind"] === "bundle" ||
@@ -1115,7 +1173,7 @@ export function createApp(deps: AppDeps): Hono {
           message: str(body["message"]),
           author: str(body["author"]),
           name: str(body["name"]),
-          orgId: await activeWorkspace(c),
+          orgId: org,
           visibility: visibilityOf(body["visibility"]),
         },
         shortId,
@@ -1395,6 +1453,9 @@ export function createApp(deps: AppDeps): Hono {
       id: newId("v"),
       blob_key: src.blob_key,
       content_type: src.content_type,
+      // Same blob as the restored version — carry its size so the storage meter
+      // stays consistent (and dedup'd, since it reuses the same blob_key).
+      size_bytes: src.size_bytes,
       author: me ? (me.name ?? me.email) : "anonymous",
       message: `Restored v${src.n}`,
       name: null,
@@ -1531,8 +1592,10 @@ export function createApp(deps: AppDeps): Hono {
     const file = body.file
     if (!(file instanceof File)) return c.json({ error: "multipart field 'file' required" }, 400)
     const bytes = new Uint8Array(await file.arrayBuffer())
-    // Proposals store a blob immediately, so they count toward the storage cap.
-    if (await overStorage(bytes.length)) return c.json({ error: "storage quota exceeded" }, 413)
+    // Proposals store a blob immediately, so they count toward the artifact's
+    // own workspace storage cap.
+    if (await overStorage(artifact.org_id, bytes.length))
+      return c.json({ error: "storage quota exceeded" }, 413)
     const isBundle =
       /\.zip$/i.test(file.name) ||
       body.kind === "bundle" ||

--- a/apps/api/src/webhooks.ts
+++ b/apps/api/src/webhooks.ts
@@ -96,8 +96,13 @@ export async function deliverOnce(d: DeliveryRecord): Promise<{ ok: boolean; sta
       "x-dock-event": d.event_type,
     }
     if (!isSlack) headers["x-dock-signature"] = sign(d.secret, body)
-    const res = await fetch(d.url, { method: "POST", headers, body })
+    // Do NOT follow redirects: the URL was SSRF-checked at registration, but a
+    // 302 to 169.254.169.254 / localhost would bypass that. A redirect is a
+    // delivery failure here.
+    const res = await fetch(d.url, { method: "POST", headers, body, redirect: "manual" })
     if (res.ok) return { ok: true, status: String(res.status) }
+    if (res.status >= 300 && res.status < 400)
+      return { ok: false, status: `HTTP ${res.status} (redirect not followed)` }
     return { ok: false, status: `HTTP ${res.status}` }
   } catch (err) {
     return { ok: false, status: (err as Error).message.slice(0, 200) }

--- a/apps/api/test/api.test.ts
+++ b/apps/api/test/api.test.ts
@@ -6,7 +6,7 @@ import { FsBlobStore } from "@dock/storage/fs"
 import Database from "better-sqlite3"
 import { zipSync } from "fflate"
 import { afterAll, describe, expect, it } from "vitest"
-import { type AppDeps, createApp } from "../src/app"
+import { type AppDeps, createApp, isPublicHttpUrl } from "../src/app"
 
 const dir = mkdtempSync(join(tmpdir(), "dock-test-"))
 const meta = new SqliteMetaStore(join(dir, "dock.db"))
@@ -1923,7 +1923,11 @@ describe("quotas: per-workspace storage caps (C4b)", () => {
     const { app, meta: m } = quotaApp("quota-meter", {})
     const a = await (await pub(app, "hello")).json() // 5 bytes
     await pub(app, "worldwide", {}, a.short_id) // +9 bytes on v2
-    expect(await m.storageBytes()).toBe(14)
+    expect(await m.storageBytes("default")).toBe(14)
+    // Republishing identical bytes is content-addressed to the same blob, so the
+    // meter dedups it — still 14, not 19.
+    await pub(app, "hello", {}, a.short_id)
+    expect(await m.storageBytes("default")).toBe(14)
     m.close()
   })
 
@@ -1933,7 +1937,7 @@ describe("quotas: per-workspace storage caps (C4b)", () => {
     const over = await pub(app, "0123456789AB") // total 22 > 20
     expect(over.status).toBe(413)
     expect((await over.json()).error).toMatch(/storage quota/)
-    expect(await m.storageBytes()).toBe(10) // the rejected upload stored nothing
+    expect(await m.storageBytes("default")).toBe(10) // the rejected upload stored nothing
     m.close()
   })
 
@@ -1983,5 +1987,73 @@ describe("rate limits: per-actor write throttles (C4b)", () => {
     expect((await pub(app, "a1", {}, undefined, as(amy.email))).status).toBe(201)
     expect((await pub(app, "a2", {}, undefined, as(amy.email))).status).toBe(429) // Amy capped
     expect((await pub(app, "b1", {}, undefined, as(ben.email))).status).toBe(201) // Ben unaffected
+  })
+})
+
+describe("multi-tenant hardening: per-org quotas + cross-org isolation", () => {
+  const amy: TestUser = { id: "u_mt_amy", email: "mtamy@dock.test", name: "Amy" }
+  const ben: TestUser = { id: "u_mt_ben", email: "mtben@dock.test", name: "Ben" }
+
+  it("storage quota is per-workspace — one org filling up does NOT block another", async () => {
+    const { app } = quotaApp("mt-quota", { multiWorkspace: true, maxBytes: 12 }, [amy, ben])
+    await app.request("/v1/me", { headers: as(amy.email) }) // provision Amy's workspace
+    await app.request("/v1/me", { headers: as(ben.email) }) // provision Ben's workspace
+    // Amy fills her own 12-byte cap.
+    expect((await pub(app, "0123456789", {}, undefined, as(amy.email))).status).toBe(201) // 10
+    expect((await pub(app, "ABCDE", {}, undefined, as(amy.email))).status).toBe(413) // +5 > 12
+    // Ben's workspace meter is independent — before the per-org fix this 413'd
+    // because the meter summed every workspace's bytes against one global cap.
+    expect((await pub(app, "0123456789", {}, undefined, as(ben.email))).status).toBe(201)
+  })
+
+  it("an artifact in one org with 'org' visibility is 404 to a member of another org", async () => {
+    const { app } = quotaApp("mt-isolation", { multiWorkspace: true }, [amy, ben])
+    await app.request("/v1/me", { headers: as(amy.email) })
+    await app.request("/v1/me", { headers: as(ben.email) })
+    const a = await (
+      await pub(app, "amy's private doc", { visibility: "org" }, undefined, as(amy.email))
+    ).json()
+    // Amy sees her own artifact; Ben (different workspace) cannot, by id.
+    expect(
+      (await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(amy.email) })).status,
+    ).toBe(200)
+    expect(
+      (await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(ben.email) })).status,
+    ).toBe(404)
+    expect(
+      (await app.request(`/v1/artifacts/${a.short_id}/content`, { headers: as(ben.email) })).status,
+    ).toBe(404)
+  })
+})
+
+describe("SSRF guard: integer/hex/octal IP encodings can't bypass the private-range check", () => {
+  it("blocks loopback / metadata / private in every encoding", () => {
+    for (const u of [
+      "http://127.0.0.1/", // dotted
+      "http://2130706433/", // decimal int = 127.0.0.1
+      "http://0x7f000001/", // hex = 127.0.0.1
+      "http://0177.0.0.1/", // octal octet = 127.0.0.1
+      "http://127.1/", // short form = 127.0.0.1
+      "http://[::ffff:127.0.0.1]/", // IPv4-mapped IPv6 loopback
+      "http://169.254.169.254/latest/meta-data/", // cloud metadata
+      "http://localhost/", // name
+      "http://10.0.0.5/",
+      "http://192.168.1.1/",
+      "http://[::1]/", // IPv6 loopback
+      "ftp://example.com/", // wrong scheme
+    ]) {
+      expect(isPublicHttpUrl(u)).toBe(false)
+    }
+  })
+
+  it("allows genuinely public hosts", () => {
+    for (const u of [
+      "https://hooks.example.com/abc",
+      "http://8.8.8.8/",
+      "http://1.1.1.1/",
+      "https://203.0.113.10/webhook",
+    ]) {
+      expect(isPublicHttpUrl(u)).toBe(true)
+    }
   })
 })

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -110,8 +110,12 @@ export interface MetaStore {
   artifactIdsByTag(tag: string): Promise<string[]>
   /** Total artifact count, scoped to a workspace when orgId is given. */
   countArtifacts(orgId?: string): Promise<number>
-  /** Sum of version byte sizes across the workspace — the storage-quota meter. */
-  storageBytes(): Promise<number>
+  /**
+   * The storage-quota meter for one workspace: bytes counted once per distinct
+   * blob (content is content-addressed, so republishes/restores of identical
+   * bytes don't double-count), scoped to the given org.
+   */
+  storageBytes(orgId: string): Promise<number>
   /** Tag → usage count, scoped to a workspace when orgId is given (browse sidebar). */
   tagCounts(orgId?: string): Promise<{ tag: string; count: number }[]>
 

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -221,10 +221,19 @@ export class D1MetaStore implements MetaStore {
     const r = await (orgId ? q.where(eq(artifact.org_id, orgId)) : q).get()
     return r?.c ?? 0
   }
-  async storageBytes(): Promise<number> {
-    const r = await this.db
-      .select({ s: sql<number>`coalesce(sum(${version.size_bytes}), 0)` })
+  async storageBytes(orgId: string): Promise<number> {
+    // One row per distinct blob in the org (max size_bytes guards a stale 0 on a
+    // restored row), then summed — so dedup'd content is counted once.
+    const perBlob = this.db
+      .select({ mx: sql<number>`max(${version.size_bytes})`.as("mx") })
       .from(version)
+      .innerJoin(artifact, eq(artifact.id, version.artifact_id))
+      .where(eq(artifact.org_id, orgId))
+      .groupBy(version.blob_key)
+      .as("per_blob")
+    const r = await this.db
+      .select({ s: sql<number>`coalesce(sum(${perBlob.mx}), 0)` })
+      .from(perBlob)
       .get()
     return Number(r?.s ?? 0)
   }

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -221,10 +221,19 @@ export class PgMetaStore implements MetaStore {
     const rows = await (orgId ? q.where(eq(artifact.org_id, orgId)) : q)
     return Number(rows[0]?.c ?? 0)
   }
-  async storageBytes(): Promise<number> {
-    const rows = await this.db
-      .select({ s: sql<number>`coalesce(sum(${version.size_bytes}), 0)` })
+  async storageBytes(orgId: string): Promise<number> {
+    // One row per distinct blob in the org (max size_bytes guards a stale 0 on a
+    // restored row), then summed — so dedup'd content is counted once.
+    const perBlob = this.db
+      .select({ mx: sql<number>`max(${version.size_bytes})`.as("mx") })
       .from(version)
+      .innerJoin(artifact, eq(artifact.id, version.artifact_id))
+      .where(eq(artifact.org_id, orgId))
+      .groupBy(version.blob_key)
+      .as("per_blob")
+    const rows = await this.db
+      .select({ s: sql<number>`coalesce(sum(${perBlob.mx}), 0)` })
+      .from(perBlob)
     return Number(rows[0]?.s ?? 0)
   }
   async tagCounts(orgId?: string): Promise<{ tag: string; count: number }[]> {

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -227,10 +227,19 @@ export class SqliteMetaStore implements MetaStore {
     const q = this.db.select({ c: count() }).from(artifact)
     return (orgId ? q.where(eq(artifact.org_id, orgId)).get() : q.get())?.c ?? 0
   }
-  async storageBytes(): Promise<number> {
-    const row = this.db
-      .select({ s: sql<number>`coalesce(sum(${version.size_bytes}), 0)` })
+  async storageBytes(orgId: string): Promise<number> {
+    // One row per distinct blob in the org (max size_bytes guards a stale 0 on a
+    // restored row), then summed — so dedup'd content is counted once.
+    const perBlob = this.db
+      .select({ mx: sql<number>`max(${version.size_bytes})`.as("mx") })
       .from(version)
+      .innerJoin(artifact, eq(artifact.id, version.artifact_id))
+      .where(eq(artifact.org_id, orgId))
+      .groupBy(version.blob_key)
+      .as("per_blob")
+    const row = this.db
+      .select({ s: sql<number>`coalesce(sum(${perBlob.mx}), 0)` })
+      .from(perBlob)
       .get()
     return Number(row?.s ?? 0)
   }


### PR DESCRIPTION
Fixes the four findings the post-launch-gate audit surfaced (the review on the plan site flagged these with severities).

## 🔴 HIGH — quotas enforced globally, not per-workspace
`storageBytes()` and the no-arg `countArtifacts()` summed across **every** workspace. Latent on self-host (single-workspace) but on the hosted multi-tenant tier one org's usage would cap every other tenant. Both are now scoped: a republish/propose counts against the artifact's own org, a new artifact against the caller's active workspace.

## 🟠 MED — webhook SSRF: redirect-follow + IP encodings
- `fetch` followed redirects by default, so a registered public URL could 302 to `169.254.169.254`/`localhost` past the registration-time guard. Now `redirect: "manual"`; a 3xx is a delivery failure.
- `isPublicHttpUrl` only matched dotted-quad, missing decimal (`2130706433`), hex (`0x7f000001`), octal (`0177.0.0.1`), short (`127.1`), and IPv4-mapped IPv6 (`::ffff:127.0.0.1`). Rewrote with an inet_aton parser + a shared private-range check. The WHATWG URL parser normalizes most forms; this closes the mapped-IPv6 gap it leaves.

## 🟠 MED — byte meter inconsistent with content-addressed storage
The meter summed every version's `size_bytes`, double-counting republishes of identical content while `restore` omitted the size and under-counted. Now `storageBytes` sums one row per **distinct blob** (max size, scoped to org), and `restore` carries the source version's `size_bytes`.

## Tests (135 api, all green)
- per-org quota isolation: one workspace filling its cap does **not** block another
- cross-org direct-object access by short id returns 404 (regression guard for tenant isolation)
- SSRF guard blocks loopback/metadata/private in every encoding incl. mapped IPv6, allows genuine public hosts
- the meter dedups identical republishes (14 bytes stays 14, not 19)

Typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)