### PR TITLE
guardrails: make backend invariants machine-enforced, not convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,8 +55,32 @@ Read [ARCHITECTURE.md](ARCHITECTURE.md) first. Two rules matter most:
   `Actor` and ask it; don't hand-roll role checks in routes.
 
 Adding a `MetaStore` method? Implement it once in the shared sqlite repos
-(`packages/db/src/repos/*`, covers SQLite + D1) and once in the Postgres repos. The
-`Exact<>` guards will fail typecheck if a schema drifts from the port.
+(`packages/db/src/repos.ts`, covers SQLite + D1) and once in the Postgres driver
+(`pg.ts`). The `implements MetaStore` annotation fails typecheck if a driver misses one.
+
+## Guardrails (you don't have to remember these — the tooling does)
+
+The invariants above are machine-enforced, so a mistake fails the gate instead of
+shipping. If something below surprises you, that's the guardrail doing its job:
+
+- **Forgotten `await`.** A floating promise in `apps/api` or the backend packages is a
+  lint error (`noFloatingPromises`). `void` it deliberately or handle it.
+- **`console.*` in the server.** Lint error outside the logger and the process entry —
+  use `log` (`apps/api/src/log.ts`).
+- **DB drivers in routes/lib.** Importing `drizzle-orm`, a driver, or `@dock/db/*` from
+  `routes/*` or `lib/*` is a lint error. Reach the database through `ctx.meta` (the
+  `MetaStore` port); add a store method instead.
+- **Schema parity + exhaustiveness.** Every drizzle table must be classified in
+  `packages/db/src/parity.ts` (typed-and-shape-checked against its core Record, or named
+  a junction). Add a table without classifying it and typecheck fails. A column that
+  drifts from its Record fails too.
+- **DDL drift.** `packages/db/test/schema-conformance.test.ts` boots a real DB from the
+  raw `SCHEMA_STATEMENTS`/`MIGRATION_STATEMENTS` and asserts every drizzle column exists
+  in the table that's actually created — so a column in the type but missing from the
+  DDL goes red.
+- **Event names.** Bus and webhook event names come from one list
+  (`apps/api/src/events.ts`); a typo or a webhook event the bus doesn't know about is a
+  compile error.
 
 ## Commits & PRs
 

--- a/apps/api/src/bus.ts
+++ b/apps/api/src/bus.ts
@@ -1,15 +1,10 @@
+import type { DomainEvent } from "./events"
+
 export interface DockEvent {
-  type:
-    | "comment.created"
-    | "comment.resolved"
-    | "comment.reacted"
-    | "comment.updated"
-    | "version.published"
-    | "proposal.created"
-    | "proposal.approved"
-    | "proposal.changes_requested"
-    | "presence"
-    | "notification"
+  // The event name is constrained to the shared DOMAIN_EVENTS union, so a typo
+  // (`bus.publish(id, { type: "comment.reslved" })`) is a compile error. The
+  // per-event payload stays open via the index signature.
+  type: DomainEvent
   [k: string]: unknown
 }
 

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -21,6 +21,7 @@ import { createBus, Presence } from "./bus"
 import { safeEqual, sha256 } from "./lib/crypto"
 import { WS_COOKIE } from "./lib/http"
 import { makeKeyedLimiter } from "./lib/rate-limit"
+import { log } from "./log"
 import { enqueueForEvent, type WebhookEvent } from "./webhooks"
 
 export interface SessionUser {
@@ -136,7 +137,15 @@ export function buildContext(deps: AppDeps) {
   // Fan an event to subscribed webhooks (enqueues to the outbox; the worker
   // delivers). Awaited so the row is durable before we respond, but never fatal.
   const notify = (a: ArtifactRecord, event: WebhookEvent, data: Record<string, unknown>) =>
-    enqueueForEvent(meta, deps.baseUrl, a, event, data).catch(() => {})
+    enqueueForEvent(meta, deps.baseUrl, a, event, data).catch((err) =>
+      // Non-fatal (the request still succeeds), but a dropped enqueue means the
+      // webhook silently never fires — log it rather than swallow.
+      log.error("webhook enqueue failed", {
+        event,
+        artifact: a.short_id,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    )
 
   const bearer = (c: Context): string => {
     const h = c.req.header("authorization") ?? ""

--- a/apps/api/src/events.ts
+++ b/apps/api/src/events.ts
@@ -1,0 +1,41 @@
+// Single source of truth for event names.
+//
+// `DOMAIN_EVENTS` is everything the system emits on the in-process bus (the SSE
+// fan-out). `WEBHOOK_EVENTS` is the outbound-relevant subset. Both derive from
+// the lists here, and the compile-time check at the bottom proves the webhook
+// list is a subset of the domain list — so the two can never silently diverge
+// the way two independent enums did before. Add an event in ONE place.
+
+export const DOMAIN_EVENTS = [
+  "comment.created",
+  "comment.mention",
+  "comment.resolved",
+  "comment.reacted",
+  "comment.updated",
+  "version.published",
+  "proposal.created",
+  "proposal.approved",
+  "proposal.changes_requested",
+  "presence",
+  "notification",
+] as const
+export type DomainEvent = (typeof DOMAIN_EVENTS)[number]
+
+/** The subset of domain events a webhook can subscribe to (no presence/notification). */
+export const WEBHOOK_EVENTS = [
+  "comment.created",
+  "comment.mention",
+  "comment.resolved",
+  "version.published",
+  "proposal.created",
+  "proposal.approved",
+  "proposal.changes_requested",
+] as const
+export type WebhookEvent = (typeof WEBHOOK_EVENTS)[number]
+
+// Guardrail: every webhook event must be a real domain event. If someone adds a
+// name to WEBHOOK_EVENTS that isn't in DOMAIN_EVENTS (a typo, or a webhook-only
+// event the bus doesn't know about), this assignment stops compiling.
+type WebhookIsSubsetOfDomain = WebhookEvent extends DomainEvent ? true : never
+const _webhookSubset: WebhookIsSubsetOfDomain = true
+void _webhookSubset

--- a/apps/api/src/webhooks.ts
+++ b/apps/api/src/webhooks.ts
@@ -1,17 +1,11 @@
 import { createHmac, randomUUID } from "node:crypto"
 import type { ArtifactRecord, DeliveryRecord, MetaStore } from "@dock/core"
+import type { WebhookEvent } from "./events"
+import { log } from "./log"
 
-/** Event names webhooks can subscribe to. */
-export const WEBHOOK_EVENTS = [
-  "comment.created",
-  "comment.mention",
-  "comment.resolved",
-  "version.published",
-  "proposal.created",
-  "proposal.approved",
-  "proposal.changes_requested",
-] as const
-export type WebhookEvent = (typeof WEBHOOK_EVENTS)[number]
+// Event names live in one place (./events) so the webhook list and the bus list
+// can't drift apart. Re-exported here for existing importers.
+export { WEBHOOK_EVENTS, type WebhookEvent } from "./events"
 
 const MAX_ATTEMPTS = 6
 const BASE_BACKOFF_MS = 3_000
@@ -173,8 +167,12 @@ export function startWebhookWorker(meta: MetaStore, intervalMs = 1500): () => vo
           })
         }
       }
-    } catch {
-      /* a bad tick shouldn't kill the loop */
+    } catch (err) {
+      // A bad tick must not kill the loop, but it must not vanish either —
+      // otherwise a persistently failing outbox is invisible.
+      log.error("webhook delivery tick failed", {
+        error: err instanceof Error ? err.message : String(err),
+      })
     }
   }
   const timer = setInterval(tick, intervalMs)

--- a/biome.json
+++ b/biome.json
@@ -65,6 +65,47 @@
       }
     }
   },
+  "overrides": [
+    {
+      "includes": ["apps/api/**", "packages/core/**", "packages/db/**", "packages/storage/**"],
+      "linter": {
+        "rules": {
+          "suspicious": { "noConsole": "error" },
+          "nursery": { "noFloatingPromises": "error" }
+        }
+      }
+    },
+    {
+      "includes": ["apps/api/src/log.ts", "apps/api/src/node.ts", "**/*.test.ts"],
+      "linter": { "rules": { "suspicious": { "noConsole": "off" } } }
+    },
+    {
+      "includes": ["apps/api/src/routes/**", "apps/api/src/lib/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": [
+                      "drizzle-orm",
+                      "drizzle-orm/**",
+                      "@dock/db/*",
+                      "better-sqlite3",
+                      "pg"
+                    ],
+                    "message": "Routes and lib reach the database through the MetaStore port on the request context (ctx.meta), never a DB driver or query builder. Add a method to the store, don't import a driver here."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
   "assist": {
     "enabled": true,
     "actions": {

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -1,0 +1,80 @@
+// Schema parity spec — shared by every dialect (sqlite/d1 via repos.ts, pg via
+// pg.ts). It does two things at compile time:
+//
+//   1. EXHAUSTIVENESS — every drizzle table must be CLASSIFIED, either as a
+//      typed table (mapped to its @dock/core Record in `TypedTables`) or as a
+//      junction table (named in `JunctionTable`). Add a `sqliteTable`/`pgTable`
+//      without classifying it and `Exhaustive<typeof schema>` stops being
+//      `true`, so the guard in the driver fails to compile. No more "added a
+//      table, forgot the parity check."
+//
+//   2. SHAPE — each typed table's inferred row (`$inferSelect`) must EXACTLY
+//      match its core Record type. Drift a column and `Shapes<typeof schema>`
+//      flags exactly which table broke.
+
+import type {
+  AgentMentionRecord,
+  AgentRecord,
+  ArtifactMemberRecord,
+  ArtifactRecord,
+  AuditLogRecord,
+  CollectionMemberRecord,
+  CollectionRecord,
+  CommentRecord,
+  DeliveryRecord,
+  MembershipRecord,
+  NotificationRecord,
+  ProposalRecord,
+  ReportRecord,
+  VersionRecord,
+  WebhookRecord,
+  WorkspaceRecord,
+} from "@dock/core"
+
+/** A is structurally identical to B (assignable both ways). */
+export type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false
+
+/** Drizzle tables that mirror a core Record type — their shape is parity-checked. */
+export interface TypedTables {
+  artifact: ArtifactRecord
+  version: VersionRecord
+  comment: CommentRecord
+  webhook: WebhookRecord
+  webhookDelivery: DeliveryRecord
+  membership: MembershipRecord
+  workspace: WorkspaceRecord
+  artifactMember: ArtifactMemberRecord
+  notification: NotificationRecord
+  proposal: ProposalRecord
+  agent: AgentRecord
+  agentMention: AgentMentionRecord
+  collection: CollectionRecord
+  collectionMember: CollectionMemberRecord
+  report: ReportRecord
+  auditLog: AuditLogRecord
+}
+
+/**
+ * Junction tables with no dedicated core Record (simple link rows whose shape
+ * isn't mirrored in @dock/core). Naming a table here is a deliberate opt-out of
+ * shape parity — but it still has to be named, so it can't be forgotten.
+ */
+export type JunctionTable = "artifactFavorite" | "artifactTag" | "collectionItem"
+
+type ClassifiedKey = keyof TypedTables | JunctionTable
+
+/** `true` iff the schema's table keys are exactly the classified keys. */
+export type Exhaustive<Schema> = [Exclude<keyof Schema, ClassifiedKey>] extends [never]
+  ? [Exclude<ClassifiedKey, keyof Schema>] extends [never]
+    ? true
+    : false
+  : false
+
+/** Per-typed-table shape parity for a given dialect's `schema` object. */
+export type Shapes<Schema> = {
+  [K in keyof TypedTables]: K extends keyof Schema
+    ? Schema[K] extends { $inferSelect: infer Row }
+      ? Exact<Row, TypedTables[K]>
+      : false
+    : false
+}

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -1,28 +1,15 @@
 import type {
-  AgentMentionRecord,
   AgentMentionState,
-  AgentRecord,
   ArtifactKind,
-  ArtifactMemberRecord,
-  ArtifactRecord,
   AuditAction,
-  AuditLogRecord,
-  CommentRecord,
   CommentState,
-  DeliveryRecord,
   DeliveryStatus,
-  MembershipRecord,
   NotificationKind,
-  NotificationRecord,
-  ProposalRecord,
   ProposalState,
-  ReportRecord,
   ReportState,
   Role,
-  VersionRecord,
   Visibility,
   WebhookKind,
-  WebhookRecord,
 } from "@dock/core"
 import { integer, pgTable, text, uniqueIndex } from "drizzle-orm/pg-core"
 
@@ -280,25 +267,10 @@ export const auditLog = pgTable("audit_log", {
   created_at: text("created_at").notNull().$defaultFn(isoNow),
 })
 
-// Compile-time guard: the pg table defs must match the core record shapes (and
-// therefore the sqlite defs). Drift here means SQLite and Postgres disagree.
-type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false
-const _pgParity: [
-  Exact<typeof artifact.$inferSelect, ArtifactRecord>,
-  Exact<typeof version.$inferSelect, VersionRecord>,
-  Exact<typeof comment.$inferSelect, CommentRecord>,
-  Exact<typeof webhook.$inferSelect, WebhookRecord>,
-  Exact<typeof webhookDelivery.$inferSelect, DeliveryRecord>,
-  Exact<typeof membership.$inferSelect, MembershipRecord>,
-  Exact<typeof artifactMember.$inferSelect, ArtifactMemberRecord>,
-  Exact<typeof notification.$inferSelect, NotificationRecord>,
-  Exact<typeof proposal.$inferSelect, ProposalRecord>,
-  Exact<typeof agent.$inferSelect, AgentRecord>,
-  Exact<typeof agentMention.$inferSelect, AgentMentionRecord>,
-  Exact<typeof report.$inferSelect, ReportRecord>,
-  Exact<typeof auditLog.$inferSelect, AuditLogRecord>,
-] = [true, true, true, true, true, true, true, true, true, true, true, true, true]
-void _pgParity
+// Schema parity is enforced in pg.ts, where the pg `schema` object lives — it
+// checks these table defs (via `Exhaustive`/`Shapes` in ./parity) against the
+// same core Record types the sqlite dialect uses, so the two dialects can't
+// disagree. See ./parity.
 
 // Boot DDL (idempotent). created_at uses a SQL default as a server-side backstop.
 const isoDefault = `to_char((now() at time zone 'utc'), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -44,6 +44,7 @@ import type {
 import { and, asc, count, desc, eq, inArray, isNull, like, lt, lte, or, sql } from "drizzle-orm"
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres"
 import { Pool } from "pg"
+import type { Exhaustive, Shapes } from "./parity"
 import {
   agent,
   agentMention,
@@ -88,6 +89,32 @@ const schema = {
   report,
   auditLog,
 }
+
+// Compile-time schema parity (see ./parity), same classification as the sqlite
+// dialect but checking the pg `$inferSelect` shapes. New table not classified, or
+// a pg column that drifts from its core Record → compile error here.
+const _schemaExhaustive: Exhaustive<typeof schema> = true
+const _schemaShapes: Shapes<typeof schema> = {
+  artifact: true,
+  version: true,
+  comment: true,
+  webhook: true,
+  webhookDelivery: true,
+  membership: true,
+  workspace: true,
+  artifactMember: true,
+  notification: true,
+  proposal: true,
+  agent: true,
+  agentMention: true,
+  collection: true,
+  collectionMember: true,
+  report: true,
+  auditLog: true,
+}
+void _schemaExhaustive
+void _schemaShapes
+
 const VIEW_WINDOW_MS = 30 * 86400_000
 
 /**

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -39,6 +39,7 @@ import type {
 } from "@dock/core"
 import { and, asc, count, desc, eq, inArray, isNull, like, lt, lte, or, sql } from "drizzle-orm"
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core"
+import type { Exhaustive, Shapes } from "./parity"
 import {
   agent,
   agentMention,
@@ -83,6 +84,31 @@ export const schema = {
   report,
   auditLog,
 }
+
+// Compile-time schema parity (see ./parity): every table must be classified, and
+// every typed table's row shape must match its @dock/core Record exactly. A new
+// table that isn't classified, or a column that drifts, fails to compile here.
+const _schemaExhaustive: Exhaustive<typeof schema> = true
+const _schemaShapes: Shapes<typeof schema> = {
+  artifact: true,
+  version: true,
+  comment: true,
+  webhook: true,
+  webhookDelivery: true,
+  membership: true,
+  workspace: true,
+  artifactMember: true,
+  notification: true,
+  proposal: true,
+  agent: true,
+  agentMention: true,
+  collection: true,
+  collectionMember: true,
+  report: true,
+  auditLog: true,
+}
+void _schemaExhaustive
+void _schemaShapes
 
 /**
  * A drizzle SQLite database of either result kind. better-sqlite3 is synchronous

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,28 +1,15 @@
 import type {
-  AgentMentionRecord,
   AgentMentionState,
-  AgentRecord,
   ArtifactKind,
-  ArtifactMemberRecord,
-  ArtifactRecord,
   AuditAction,
-  AuditLogRecord,
-  CommentRecord,
   CommentState,
-  DeliveryRecord,
   DeliveryStatus,
-  MembershipRecord,
   NotificationKind,
-  NotificationRecord,
-  ProposalRecord,
   ProposalState,
-  ReportRecord,
   ReportState,
   Role,
-  VersionRecord,
   Visibility,
   WebhookKind,
-  WebhookRecord,
 } from "@dock/core"
 import { sql } from "drizzle-orm"
 import { integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core"
@@ -544,22 +531,6 @@ export const MIGRATION_STATEMENTS: string[] = [
   `ALTER TABLE version ADD COLUMN size_bytes INTEGER NOT NULL DEFAULT 0`,
 ]
 
-// Compile-time guard: the drizzle table defs must exactly match the core record
-// shapes. A non-`true` element here is schema drift — fix the table or the type.
-type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false
-const _schemaParity: [
-  Exact<typeof artifact.$inferSelect, ArtifactRecord>,
-  Exact<typeof version.$inferSelect, VersionRecord>,
-  Exact<typeof comment.$inferSelect, CommentRecord>,
-  Exact<typeof webhook.$inferSelect, WebhookRecord>,
-  Exact<typeof webhookDelivery.$inferSelect, DeliveryRecord>,
-  Exact<typeof membership.$inferSelect, MembershipRecord>,
-  Exact<typeof artifactMember.$inferSelect, ArtifactMemberRecord>,
-  Exact<typeof notification.$inferSelect, NotificationRecord>,
-  Exact<typeof proposal.$inferSelect, ProposalRecord>,
-  Exact<typeof agent.$inferSelect, AgentRecord>,
-  Exact<typeof agentMention.$inferSelect, AgentMentionRecord>,
-  Exact<typeof report.$inferSelect, ReportRecord>,
-  Exact<typeof auditLog.$inferSelect, AuditLogRecord>,
-] = [true, true, true, true, true, true, true, true, true, true, true, true, true]
-void _schemaParity
+// Schema parity is enforced in repos.ts, where the shared `schema` object lives:
+// `Exhaustive`/`Shapes` (./parity) force every table to be classified and every
+// typed table's row shape to match its @dock/core Record. See ./parity.

--- a/packages/db/test/schema-conformance.test.ts
+++ b/packages/db/test/schema-conformance.test.ts
@@ -1,0 +1,56 @@
+import Database from "better-sqlite3"
+import { getTableColumns, getTableName } from "drizzle-orm"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { schema } from "../src/repos"
+import { MIGRATION_STATEMENTS, SCHEMA_STATEMENTS } from "../src/schema"
+
+// The drizzle table defs are the *type* source of truth (parity-guarded against
+// the core Records), but the table that actually gets created comes from the
+// hand-written SCHEMA_STATEMENTS / MIGRATION_STATEMENTS strings — and nothing
+// at compile time ties those two together. So a column can live in the drizzle
+// def (typechecks green) yet be missing from the CREATE TABLE that runs at boot.
+//
+// This boots a real SQLite DB exactly the way the driver does, then asserts that
+// every drizzle table's columns match the columns that actually exist. Forget to
+// add a column to the DDL and the matching test goes red.
+
+describe("schema conformance: drizzle defs match the DDL that actually runs", () => {
+  let db: Database.Database
+
+  beforeAll(() => {
+    db = new Database(":memory:")
+    for (const stmt of SCHEMA_STATEMENTS) db.exec(stmt)
+    // Forward migrations are idempotent ALTERs; on a fresh DB the column already
+    // exists, so a "duplicate column" throw is the expected no-op (same as boot).
+    for (const stmt of MIGRATION_STATEMENTS) {
+      try {
+        db.exec(stmt)
+      } catch {
+        /* already applied by the CREATE above */
+      }
+    }
+  })
+  afterAll(() => db.close())
+
+  const liveColumns = (table: string): string[] =>
+    (db.prepare(`PRAGMA table_info("${table}")`).all() as { name: string }[])
+      .map((r) => r.name)
+      .sort()
+
+  for (const [key, table] of Object.entries(schema)) {
+    it(`${key}: drizzle columns === the created table's columns`, () => {
+      const sqlName = getTableName(table)
+      const defined = Object.values(getTableColumns(table))
+        .map((c) => c.name)
+        .sort()
+      const live = liveColumns(sqlName)
+      expect(
+        live.length,
+        `table "${sqlName}" was not created by SCHEMA_STATEMENTS`,
+      ).toBeGreaterThan(0)
+      // Exact set: catches a drizzle column missing from the DDL AND a DDL column
+      // the drizzle def doesn't know about.
+      expect(defined).toEqual(live)
+    })
+  }
+})


### PR DESCRIPTION
The post-#51 backend is clean, but its invariants (the dependency rule, "use the port not a driver", schema parity, single event list, logger-not-console) live in docs and discipline. A newcomer can break any of them with a green build. This makes the load-bearing ones **fail the gate** instead of shipping.

## Compile-time
- **One source of truth for event names** (`apps/api/src/events.ts`). The bus list and the webhook list both derive from it, with a subset check, so they can't silently diverge (they had: `comment.mention` vs `comment.reacted`/`updated`). Bus event names are constrained to the union, so a typo won't compile.
- **Exhaustive schema parity** (`packages/db/src/parity.ts`). Every drizzle table must be classified — typed and shape-checked against its `@dock/core` Record, or explicitly named a junction. Add a table without a parity entry and typecheck fails. This closes the 6 tables that were silently unguarded (`workspace`, `collection`, favorites, tags, …) and any future one. Replaces the two hand-maintained `Exact<>` tuples.

## Test
- **DDL conformance** (`packages/db/test/schema-conformance.test.ts`). Boots a real SQLite DB from the raw `SCHEMA_STATEMENTS`/`MIGRATION_STATEMENTS` and asserts every drizzle column exists in the table that actually gets created — catching a column that's in the type but missing from the DDL (the silent half of a schema change). 19 tables; the `packages/db` test step was previously a no-op.

## Lint (scoped to the backend, so the web app is untouched)
- **`noFloatingPromises`** (error): a forgotten `await` across the ~80 async store calls in the route modules is the highest-probability latent bug class — now caught.
- **`noConsole`** (error): server code uses the structured logger; only `log.ts`, `node.ts`, and tests print.
- **`noRestrictedImports`** (error): `routes/*` and `lib/*` cannot import `drizzle-orm`, a DB driver, or `@dock/db/*` — they reach the database through `ctx.meta` (the `MetaStore` port).

## Runtime
- The webhook delivery worker and the `notify()` enqueue no longer swallow errors silently — a persistently broken outbox now logs instead of vanishing.

## Docs
- `CONTRIBUTING.md` gains a "Guardrails" section listing what's enforced and why a contributor might hit it.

Verified the guards actually bite (a probe route with a `console.log`, a `drizzle-orm` import, and a floating promise trips all three rules). Gate green: typecheck clean, 213 tests (incl. 19 new), biome 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)