### PR TITLE
migrate(login, share): Tailwind v4 + shadcn ui/ + Playwright

### DIFF
--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -13,11 +13,11 @@ const uniqueEmail = () => `e2e+${Date.now()}-${seq++}@dock.test`
 export async function signUp(page: Page, name = "E2E Tester"): Promise<string> {
   const email = uniqueEmail()
   await page.goto("/login")
-  await page.getByRole("button", { name: "Create an account" }).click()
-  await page.getByPlaceholder("Your name").fill(name)
-  await page.getByPlaceholder("you@company.com").fill(email)
-  await page.getByPlaceholder("At least 8 characters").fill("e2e-pass-1234")
-  await page.getByRole("button", { name: "Create account" }).click()
+  await page.getByTestId("login-toggle").click() // switch from sign-in to create-account
+  await page.getByTestId("login-name").fill(name)
+  await page.getByTestId("login-email").fill(email)
+  await page.getByTestId("login-password").fill("e2e-pass-1234")
+  await page.getByTestId("login-submit").click()
   await expect(page).not.toHaveURL(/\/login/, { timeout: 15_000 })
   return email
 }

--- a/apps/web/e2e/login.spec.ts
+++ b/apps/web/e2e/login.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test"
+import { signUp } from "./helpers"
+
+// The Login surface, driven through stable test-ids on the migrated Card/Input/Button.
+
+test("the toggle switches between sign in and create account", async ({ page }) => {
+  await page.goto("/login")
+  // Sign-in mode: no name field, the submit reads "Sign in".
+  await expect(page.getByTestId("login-name")).toBeHidden()
+  await expect(page.getByTestId("login-submit")).toHaveText("Sign in")
+  // Switch to create-account.
+  await page.getByTestId("login-toggle").click()
+  await expect(page.getByTestId("login-name")).toBeVisible()
+  await expect(page.getByTestId("login-submit")).toHaveText("Create account")
+})
+
+test("a sign-in with unknown credentials shows an error and stays on /login", async ({ page }) => {
+  await page.goto("/login")
+  await page.getByTestId("login-email").fill("nobody@dock.test")
+  await page.getByTestId("login-password").fill("wrong-password-123")
+  await page.getByTestId("login-submit").click()
+  await expect(page.getByTestId("login-error")).toBeVisible()
+  await expect(page).toHaveURL(/\/login/)
+})
+
+test("creating an account signs in and leaves the login page", async ({ page }) => {
+  await signUp(page) // drives login-toggle / login-name / login-email / login-password / login-submit
+  await expect(page).not.toHaveURL(/\/login/)
+})

--- a/apps/web/e2e/share-dialog.spec.ts
+++ b/apps/web/e2e/share-dialog.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/test"
+import { publishArtifact, signUp } from "./helpers"
+
+// The artifact share dialog (built on the Dialog primitive + RoleSelect), driven
+// through stable test-ids. One self-contained test so the FIRST signup is the
+// workspace owner (the share affordance is owner-only) on the throwaway DB.
+
+test("owner shares an artifact, changes the role, and removes the member", async ({
+  page,
+  browser,
+}) => {
+  await signUp(page) // first account on the fresh DB = workspace owner
+
+  // A second registered user to share with, created in an isolated session so it
+  // doesn't disturb the owner's page (and so it's an editor, not the owner).
+  const ctx = await browser.newContext()
+  const viewerPage = await ctx.newPage()
+  const teammate = await signUp(viewerPage)
+
+  const id = await publishArtifact(page) // owner publishes (link visibility)
+
+  // A non-owner (the editor) opens the artifact: no share affordance.
+  await viewerPage.goto(`/a/${id}`)
+  await expect(viewerPage.getByTestId("share-trigger")).toBeHidden()
+
+  // The owner opens the dialog: starts empty.
+  await page.goto(`/a/${id}`)
+  await page.getByTestId("share-trigger").click()
+  await expect(page.getByTestId("share-email")).toBeVisible()
+  await expect(page.getByTestId("share-empty")).toBeVisible()
+
+  // Share with the teammate as a commenter.
+  await page.getByTestId("share-email").fill(teammate)
+  await page.getByTestId("share-role").locator("select").selectOption("commenter")
+  await page.getByTestId("share-add").click()
+
+  const row = page.locator('[data-testid^="share-member-row-"]')
+  await expect(row).toHaveCount(1)
+  await expect(row).toContainText(teammate)
+  await expect(row.locator("select")).toHaveValue("commenter")
+
+  // Promote them to editor.
+  await page.locator('[data-testid^="share-member-role-"] select').selectOption("editor")
+  await expect(row.locator("select")).toHaveValue("editor")
+
+  // Remove them: back to the empty state.
+  await page.locator('[data-testid^="share-member-remove-"]').click()
+  await expect(page.getByTestId("share-empty")).toBeVisible()
+
+  await ctx.close()
+})

--- a/apps/web/src/components/ShareDialog.tsx
+++ b/apps/web/src/components/ShareDialog.tsx
@@ -1,7 +1,19 @@
-import { useEffect, useRef, useState } from "react"
-import { type ArtifactMember, api, type Role } from "../api"
+import { Share2, X } from "lucide-react"
+import { useState } from "react"
+import { type ArtifactMember, api, type Role } from "@/api"
+import { EmptyState } from "@/components/shared/empty-state"
+import { RoleSelect } from "@/components/shared/role-select"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
 
-const ROLES: Role[] = ["viewer", "commenter", "editor", "owner"]
 const BLURB: Record<Role, string> = {
   viewer: "Can view",
   commenter: "Can view and comment",
@@ -10,28 +22,21 @@ const BLURB: Record<Role, string> = {
 }
 
 /**
- * Per-artifact sharing, as a header popover that mirrors Insights/History. Only
- * an owner of this artifact can change shares; everyone else sees nothing. Kept
- * fully self-contained (no shared Dialog primitive, no edits to the comment
- * sidebar) so it composes into the artifact header with a single line.
+ * Per-artifact sharing, opened from the artifact header. Add people by email at a
+ * role, change a member's role, or remove them. Only an owner of this artifact
+ * can manage shares; for anyone else the trigger isn't rendered. Built on the
+ * shared Dialog primitive (focus trap, Esc, roles for free) and RoleSelect.
  */
 export function ShareButton({ shortId, myRole }: { shortId: string; myRole?: Role | null }) {
-  const [open, setOpen] = useState(false)
   const [members, setMembers] = useState<ArtifactMember[]>([])
   const [defaultRole, setDefaultRole] = useState<Role>("editor")
   const [email, setEmail] = useState("")
   const [role, setRole] = useState<Role>("editor")
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
-  const ref = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
-    const h = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
-    }
-    document.addEventListener("click", h)
-    return () => document.removeEventListener("click", h)
-  }, [])
+  // Only an owner can manage shares; hide the affordance otherwise.
+  if (myRole !== "owner") return null
 
   const load = () =>
     api
@@ -41,12 +46,6 @@ export function ShareButton({ shortId, myRole }: { shortId: string; myRole?: Rol
         setDefaultRole(r.default_role)
       })
       .catch(() => {})
-  useEffect(() => {
-    if (open) load()
-  }, [open, shortId])
-
-  // Only an owner can manage shares; hide the affordance otherwise.
-  if (myRole !== "owner") return null
 
   const add = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -75,126 +74,103 @@ export function ShareButton({ shortId, myRole }: { shortId: string; myRole?: Rol
   }
 
   return (
-    <div ref={ref} style={{ position: "relative" }}>
-      <button
-        className="btn sm"
-        onClick={(e) => {
-          e.stopPropagation()
-          setOpen((o) => !o)
-        }}
-        style={{ gap: 6 }}
-        title="Share this artifact"
-      >
-        <span style={{ fontSize: 12 }}>🔗</span>
-        Share
-      </button>
-      {open && (
-        <div
-          className="card"
-          style={{
-            position: "absolute",
-            right: 0,
-            top: "calc(100% + 7px)",
-            width: 330,
-            padding: 14,
-            boxShadow: "var(--shadow)",
-            zIndex: 30,
-          }}
-        >
-          <div
-            className="mono muted"
-            style={{
-              fontSize: 9.5,
-              letterSpacing: ".06em",
-              textTransform: "uppercase",
-              marginBottom: 8,
-            }}
-          >
-            People with access
-          </div>
+    <Dialog
+      onOpenChange={(o) => {
+        if (o) {
+          setErr(null)
+          load()
+        }
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button data-testid="share-trigger" variant="default" size="sm" title="Share this artifact">
+          <Share2 />
+          Share
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Share this artifact</DialogTitle>
+          <DialogDescription>
+            Add people by email. Everyone you don't list is a{" "}
+            <b className="text-foreground">{defaultRole}</b> by default.
+          </DialogDescription>
+        </DialogHeader>
 
-          <form onSubmit={add} style={{ display: "flex", gap: 6, marginBottom: 4 }}>
-            <input
-              className="input"
-              type="email"
-              placeholder="teammate@email.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              style={{ flex: 1, padding: "7px 9px", fontSize: 13 }}
-            />
-            <select
+        <form onSubmit={add} className="flex gap-1.5">
+          <Input
+            data-testid="share-email"
+            type="email"
+            placeholder="teammate@email.com"
+            aria-label="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="flex-1"
+          />
+          <div data-testid="share-role" className="w-[104px]">
+            <RoleSelect
               value={role}
-              onChange={(e) => setRole(e.target.value as Role)}
-              className="input"
-              style={{ width: 104, padding: "7px 6px", fontSize: 12 }}
-            >
-              {ROLES.map((r) => (
-                <option key={r} value={r}>
-                  {r}
-                </option>
-              ))}
-            </select>
-            <button className="btn pri sm" type="submit" disabled={busy}>
-              {busy ? "…" : "Add"}
-            </button>
-          </form>
-          <div className="mono muted" style={{ fontSize: 10, marginBottom: 10 }}>
-            {BLURB[role]}.
+              onChange={setRole}
+              aria-label="Role for new member"
+              className="w-full"
+            />
           </div>
-          {err && <div style={{ color: "var(--bad)", fontSize: 11.5, marginBottom: 8 }}>{err}</div>}
+          <Button data-testid="share-add" variant="primary" type="submit" disabled={busy}>
+            {busy ? "…" : "Add"}
+          </Button>
+        </form>
+        <p className="mt-1.5 font-mono text-2xs text-muted-foreground">{BLURB[role]}.</p>
+        {err && (
+          <p data-testid="share-error" role="alert" className="mt-2 text-xs text-destructive">
+            {err}
+          </p>
+        )}
 
+        <div className="mt-3.5">
           {members.length === 0 ? (
-            <div className="muted" style={{ fontSize: 11.5 }}>
-              No one shared yet. Everyone else is a <b>{defaultRole}</b> by default.
+            <div data-testid="share-empty">
+              <EmptyState className="p-6 text-xs">No one shared yet.</EmptyState>
             </div>
           ) : (
-            <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+            <div className="flex flex-col gap-1.5">
               {members.map((m) => (
-                <div key={m.user_id} style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <div
-                      style={{
-                        fontSize: 12.5,
-                        fontWeight: 600,
-                        whiteSpace: "nowrap",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                      }}
-                    >
+                <div
+                  key={m.user_id}
+                  data-testid={`share-member-row-${m.user_id}`}
+                  className="flex items-center gap-2"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm font-semibold text-foreground">
                       {m.name ?? m.email ?? m.user_id}
                     </div>
                     {m.name && m.email && (
-                      <div className="muted" style={{ fontSize: 10.5 }}>
-                        {m.email}
-                      </div>
+                      <div className="truncate text-2xs text-muted-foreground">{m.email}</div>
                     )}
                   </div>
-                  <select
-                    value={m.role}
-                    onChange={(e) => change(m, e.target.value as Role)}
-                    className="input"
-                    style={{ width: 96, padding: "5px 6px", fontSize: 11.5 }}
-                  >
-                    {ROLES.map((r) => (
-                      <option key={r} value={r}>
-                        {r}
-                      </option>
-                    ))}
-                  </select>
-                  <button
-                    className="lnk"
+                  <div data-testid={`share-member-role-${m.user_id}`} className="w-[92px]">
+                    <RoleSelect
+                      value={m.role}
+                      onChange={(next) => change(m, next)}
+                      aria-label={`Role for ${m.name ?? m.email ?? "member"}`}
+                      className="w-full"
+                    />
+                  </div>
+                  <Button
+                    data-testid={`share-member-remove-${m.user_id}`}
+                    variant="ghost"
+                    size="icon"
+                    className="size-7 text-muted-foreground hover:text-foreground"
                     onClick={() => remove(m)}
-                    title="Remove"
-                    style={{ textDecoration: "none", fontSize: 14 }}
+                    aria-label={`Remove ${m.name ?? m.email ?? "member"}`}
                   >
-                    ✕
-                  </button>
+                    <X />
+                  </Button>
                 </div>
               ))}
             </div>
           )}
         </div>
-      )}
-    </div>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -1,9 +1,13 @@
 import { useNavigate } from "@tanstack/react-router"
+import { Check } from "lucide-react"
 import type { FormEvent } from "react"
 import { useEffect, useState } from "react"
-import { api } from "../api"
-import { Logo } from "../components"
-import { useAuth } from "../ctx"
+import { api } from "@/api"
+import { Logo } from "@/components/shared/logo"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { useAuth } from "@/ctx"
 
 const FEATURES: [string, string][] = [
   ["Permanent URLs", "Every artifact gets a stable link with full version history."],
@@ -42,115 +46,144 @@ export function Login() {
     }
   }
 
+  const signup = mode === "signup"
+
   return (
-    <div className="auth">
-      <aside className="auth-aside">
-        <div className="auth-aside-inner">
-          <div className="auth-brand">
-            <Logo size={30} />
-            <span className="display">Dock</span>
-          </div>
-          <h1 className="display auth-headline">The permanent home for your AI artifacts.</h1>
-          <p className="auth-sub">
+    <div className="grid min-h-screen lg:grid-cols-2">
+      {/* Brand + value panel — desktop only; the form carries a compact brand on mobile. */}
+      <aside className="hidden flex-col justify-between bg-secondary p-10 text-secondary-foreground lg:flex">
+        <div className="flex items-center gap-2.5">
+          <Logo size={30} />
+          <span className="font-display text-xl font-semibold">Dock</span>
+        </div>
+        <div className="max-w-md">
+          <h1 className="font-display text-3xl font-semibold leading-tight text-foreground">
+            The permanent home for your AI artifacts.
+          </h1>
+          <p className="mt-3 text-sm text-muted-foreground">
             Give any HTML page, doc, or built site a lasting URL, version history, and a review loop
             your team and your agents can actually use.
           </p>
-          <ul className="auth-features">
+          <ul className="mt-6 flex flex-col gap-3">
             {FEATURES.map(([title, desc]) => (
-              <li key={title}>
-                <span className="auth-check" aria-hidden>
-                  ✓
-                </span>
-                <div>
-                  <b>{title}</b>
-                  <span>{desc}</span>
+              <li key={title} className="flex gap-2.5">
+                <Check className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden />
+                <div className="flex flex-col">
+                  <span className="text-sm font-semibold text-foreground">{title}</span>
+                  <span className="text-xs text-muted-foreground">{desc}</span>
                 </div>
               </li>
             ))}
           </ul>
         </div>
+        <p className="text-2xs text-muted-foreground">
+          Open source. Self-host the whole thing, or use the hosted tier.
+        </p>
       </aside>
 
-      <main className="auth-main">
-        <div className="auth-card-wrap">
-          <div className="auth-brand auth-brand-mobile">
-            <Logo size={26} />
-            <span className="display">Dock</span>
+      {/* Auth form */}
+      <main className="flex items-center justify-center p-6">
+        <div className="w-full max-w-sm">
+          <div className="mb-6 flex flex-col items-center gap-1 text-center lg:hidden">
+            <div className="flex items-center gap-2">
+              <Logo size={26} />
+              <span className="font-display text-lg font-semibold">Dock</span>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Permanent URLs, versions, and review for your AI artifacts.
+            </p>
           </div>
-          <p className="auth-tagline-mobile muted">
-            Permanent URLs, versions, and review for your AI artifacts.
-          </p>
-          <h2 className="display auth-title">
-            {mode === "signup" ? "Create your account" : "Welcome back"}
-          </h2>
-          <p className="muted auth-card-sub">
-            {mode === "signup"
-              ? "Start publishing artifacts in seconds."
-              : "Sign in to your workspace."}
-          </p>
 
-          <form className="auth-form" onSubmit={submit}>
-            {err && <div className="auth-err">{err}</div>}
-            {mode === "signup" && (
-              <label className="auth-field">
-                Name
-                <input
-                  className="input"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  placeholder="Your name"
-                />
-              </label>
-            )}
-            <label className="auth-field">
-              Email
-              <input
-                className="input"
-                type="email"
-                required
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="you@company.com"
-              />
-            </label>
-            <label className="auth-field">
-              Password
-              <input
-                className="input"
-                type="password"
-                required
-                minLength={8}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                placeholder="At least 8 characters"
-              />
-            </label>
-            <button
-              className="btn pri auth-submit"
-              type="submit"
-              disabled={busy || !email || !password}
-            >
-              {busy ? "…" : mode === "signup" ? "Create account" : "Sign in"}
-            </button>
-          </form>
+          <Card>
+            <CardHeader>
+              <CardTitle>{signup ? "Create your account" : "Welcome back"}</CardTitle>
+              <CardDescription>
+                {signup ? "Start publishing artifacts in seconds." : "Sign in to your workspace."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-3">
+              <form onSubmit={submit} className="flex flex-col gap-3">
+                {err && (
+                  <div
+                    data-testid="login-error"
+                    role="alert"
+                    className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                  >
+                    {err}
+                  </div>
+                )}
+                {signup && (
+                  <label
+                    htmlFor="login-name"
+                    className="flex flex-col gap-1.5 text-sm font-medium text-foreground"
+                  >
+                    Name
+                    <Input
+                      id="login-name"
+                      data-testid="login-name"
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                      placeholder="Your name"
+                    />
+                  </label>
+                )}
+                <label
+                  htmlFor="login-email"
+                  className="flex flex-col gap-1.5 text-sm font-medium text-foreground"
+                >
+                  Email
+                  <Input
+                    id="login-email"
+                    data-testid="login-email"
+                    type="email"
+                    required
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="you@company.com"
+                  />
+                </label>
+                <label
+                  htmlFor="login-password"
+                  className="flex flex-col gap-1.5 text-sm font-medium text-foreground"
+                >
+                  Password
+                  <Input
+                    id="login-password"
+                    data-testid="login-password"
+                    type="password"
+                    required
+                    minLength={8}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="At least 8 characters"
+                  />
+                </label>
+                <Button
+                  data-testid="login-submit"
+                  variant="primary"
+                  size="lg"
+                  type="submit"
+                  disabled={busy || !email || !password}
+                  className="mt-1 w-full"
+                >
+                  {busy ? "…" : signup ? "Create account" : "Sign in"}
+                </Button>
+              </form>
 
-          <p className="auth-toggle muted">
-            {mode === "login" ? (
-              <>
-                New here?{" "}
-                <button type="button" className="lnk" onClick={() => setMode("signup")}>
-                  Create an account
-                </button>
-              </>
-            ) : (
-              <>
-                Have an account?{" "}
-                <button type="button" className="lnk" onClick={() => setMode("login")}>
-                  Sign in
-                </button>
-              </>
-            )}
-          </p>
+              <p className="text-sm text-muted-foreground">
+                {signup ? "Have an account? " : "New here? "}
+                <Button
+                  data-testid="login-toggle"
+                  variant="link"
+                  type="button"
+                  className="h-auto p-0 align-baseline text-sm font-semibold"
+                  onClick={() => setMode(signup ? "login" : "signup")}
+                >
+                  {signup ? "Sign in" : "Create an account"}
+                </Button>
+              </p>
+            </CardContent>
+          </Card>
         </div>
       </main>
     </div>


### PR DESCRIPTION
Two surfaces off hand-rolled CSS onto the `ui/` + `shared/` primitives, per the migration playbook: tokenized (all 4 themes), accessible (Radix), responsive (390px), `data-testid`'d, and proven by Playwright.

## Login (`pages/Login.tsx`)
Rebuilt on `Card` + `Input` + `Button`. Tokens only (no hex / `var()` / arbitrary sizes; type scale only). Responsive: the brand/value panel hides below `lg`, with a compact brand on mobile. Accessible labels (`htmlFor`/`id`). Test-ids: `login-toggle`, `login-name`, `login-email`, `login-password`, `login-submit`, `login-error`.

## Share dialog (`components/ShareDialog.tsx`)
Rebuilt the artifact share affordance on the Radix **Dialog** primitive (was a click-outside popover) + reused `RoleSelect` — focus trap, Esc, and dialog roles for free. Public API unchanged (`ShareButton({ shortId, myRole })`, owner-only), so the artifact header call site is untouched. Test-ids: `share-trigger`, `share-email`, `share-role`, `share-add`, `share-empty`, `share-error`, and per-member `share-member-row-<id>`, `share-member-role-<id>`, `share-member-remove-<id>`.

## Automation
- `e2e/helpers.ts` `signUp()` now drives Login through test-ids (no text/placeholder lookups).
- `e2e/login.spec.ts` — mode toggle, bad-credentials error, create-account flow.
- `e2e/share-dialog.spec.ts` — owner shares by email, changes the role, removes the member; a non-owner sees no trigger.

## Verify
`pnpm typecheck` clean, `biome check` clean, both new specs green (and the existing `chrome`/`smoke` specs still pass). Captured in all 4 themes (light/dark/paper/dusk) at desktop and mobile (390px).

Composes existing primitives only; `ui/`, `shared/`, and `globals.css` untouched, and no classes removed from `styles.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)