### PR TITLE
Backend hardening: Postgres integration tests + review follow-ups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,23 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  # Runs the SAME apps/api suite against a real Postgres (ephemeral Docker
+  # container, via scripts/test-pg.sh) so the hosted-tier driver is covered by
+  # the full behavioral suite, not just typecheck + parity guards.
+  pg:
+    runs-on: ubicloud-standard-2
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Test against Postgres
+        run: pnpm test:pg

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -65,8 +65,12 @@ All three drivers implement the single `MetaStore` interface from `core/ports.ts
 - **pg** (`node-postgres`, async) is a different dialect (its own `pgTable` schema,
   `::int` casts, `for("update")` locks) and keeps a parallel repository set.
 
-`Exact<>` compile-time guards in `schema.ts`/`pg-schema.ts` assert every drizzle row
-type matches its `core` record type, so the two schemas can't drift from the port.
+Per-table parity guards (`packages/db/src/parity.ts`) force every drizzle table to be
+classified and assert each typed table's row shape matches its `core` Record, so the
+schemas can't drift from the port. Type guards only catch type drift, so the pg adapter
+is also run against the full `apps/api` suite (`pnpm test:pg`, a real Postgres in
+Docker): behavioral drift in the parallel pg implementation fails CI, not just
+signature drift.
 Adapters are selected by env in `node.ts` (`DATABASE_URL` ⇒ Postgres, else SQLite);
 the Workers entry can only reach `./d1` + `./schema`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,9 @@ shipping. If something below surprises you, that's the guardrail doing its job:
   raw `SCHEMA_STATEMENTS`/`MIGRATION_STATEMENTS` and asserts every drizzle column exists
   in the table that's actually created — so a column in the type but missing from the
   DDL goes red.
+- **Postgres behavioral drift.** The full `apps/api` suite also runs against a real
+  Postgres in CI (`pnpm test:pg`), so a pg driver bug (a wrong query, a missing org
+  scope) fails a test, not just a typecheck.
 - **Event names.** Bus and webhook event names come from one list
   (`apps/api/src/events.ts`); a typo or a webhook event the bus doesn't know about is a
   compile error.
@@ -94,4 +97,14 @@ shipping. If something below surprises you, that's the guardrail doing its job:
 
 API behavior is covered by `apps/api/test/*` (vitest against `app.request()`, no
 network). New routes get tests; bug fixes get a regression test. Hit a real
-in-memory SQLite store rather than mocking the DB layer.
+SQLite store rather than mocking the DB layer.
+
+```bash
+pnpm test       # the suite on embedded SQLite (zero-config), the first CI job
+pnpm test:pg    # the SAME suite on a real Postgres (ephemeral Docker container)
+```
+
+`pnpm test:pg` ([scripts/test-pg.sh](scripts/test-pg.sh)) points the harness at
+Postgres with `DOCK_TEST_DB=pg` + `TEST_DATABASE_URL` (each test app gets an isolated
+schema), so the hosted-tier driver is verified by the full behavioral suite, not just
+typecheck. CI runs both jobs. Requires Docker.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -164,3 +164,23 @@ fly secrets set DOCK_WEB_ORIGIN='https://app.example.com' DOCK_CROSS_SITE='true'
 `DOCK_CROSS_SITE=true` makes the session cookie `SameSite=None; Secure` so it rides the
 cross-origin SPA→API request; `DOCK_WEB_ORIGIN` allow-lists the SPA for CORS.
 `apps/web/public/_redirects` already ships the SPA fallback.
+
+## Cloudflare Workers + D1 (experimental)
+
+`packages/db` ships a Cloudflare D1 driver (`@dock/db/d1`) for an edge deployment, but
+this path is **experimental and unverified**. It reuses the same SQLite repositories and
+schema as the default driver, so the query logic and DDL are covered by the test suite,
+but the D1-specific runtime has no integration test yet and Dock ships no Worker
+entrypoint. Don't expect production parity with the SQLite or Postgres tiers.
+
+To experiment, the bootstrap schema is generated for you from the shared source of truth:
+
+```bash
+wrangler d1 create dock
+wrangler d1 execute dock --file=deploy/d1-schema.sql
+# d1-schema.sql is generated; after a schema change run: pnpm --filter @dock/db gen:d1-schema
+```
+
+Then wire `createD1Store(env.DB)` from `@dock/db/d1` into your Worker's fetch handler.
+Closing the gap to "supported" means a Miniflare-backed smoke test of the driver; the
+shared half is already covered by the SQLite suite.

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -152,10 +152,16 @@ export function buildContext(deps: AppDeps) {
     return h.startsWith("Bearer ") ? h.slice(7) : ""
   }
 
+  // The signed-in user for this request, memoized like agentFor below: several
+  // handlers (actingUser, activeWorkspace, the route itself) resolve the caller
+  // more than once, and the session lookup shouldn't run again each time.
+  const userCache = new WeakMap<Context, SessionUser | null>()
   const currentUser = async (c: Context): Promise<SessionUser | null> => {
-    if (!deps.auth) return null
-    const s = await deps.auth.api.getSession({ headers: c.req.raw.headers })
-    return s?.user ? { id: s.user.id, email: s.user.email, name: s.user.name ?? null } : null
+    if (userCache.has(c)) return userCache.get(c) ?? null
+    const s = deps.auth ? await deps.auth.api.getSession({ headers: c.req.raw.headers }) : null
+    const u = s?.user ? { id: s.user.id, email: s.user.email, name: s.user.name ?? null } : null
+    userCache.set(c, u)
+    return u
   }
 
   // A registered agent acting via its bearer token (memoized per request). An

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -116,11 +116,13 @@ if (cfg.retentionDays > 0) {
 }
 
 // One-time cleanup of pre-existing owner self-views (the route no longer records
-// them). Owners are workspace members with the `owner` role; match their id, name
-// and email so rows from before the id-based identity change are caught too.
+// them). Pre-multi-workspace rows were rekeyed from "local" onto defaultOrg above,
+// so the legacy owners live under defaultOrg now (not the "local" sentinel). Match
+// their id, name and email so rows from before the id-based identity change are
+// caught too.
 void (async () => {
   try {
-    const owners = (await meta.listMemberships("local")).filter((m) => m.role === "owner")
+    const owners = (await meta.listMemberships(defaultOrg)).filter((m) => m.role === "owner")
     if (owners.length === 0) return
     const users = await meta.getUsers(owners.map((m) => m.user_id))
     const viewers = [

--- a/apps/api/test/helpers.ts
+++ b/apps/api/test/helpers.ts
@@ -1,22 +1,112 @@
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import type { MetaStore } from "@dock/core"
+import { PgMetaStore } from "@dock/db/pg"
 import { SqliteMetaStore } from "@dock/db/sqlite"
 import { FsBlobStore } from "@dock/storage/fs"
 import Database from "better-sqlite3"
+import { Pool } from "pg"
 import { afterAll } from "vitest"
 import { type AppDeps, createApp } from "../src/app"
 
 export const dir = mkdtempSync(join(tmpdir(), "dock-test-"))
-export const meta = new SqliteMetaStore(join(dir, "dock.db"))
+
+// ---- Backend selection -----------------------------------------------------
+// `pnpm test` runs the embedded SQLite path (zero-config). Set DOCK_TEST_DB=pg
+// + TEST_DATABASE_URL to point the SAME test files at Postgres, so the hosted-
+// tier driver is exercised by the full behavioral suite, not just typecheck.
+// `scripts/test-pg.sh` spins up an ephemeral container and wires both vars.
+const PG_URL = process.env.DOCK_TEST_DB === "pg" ? process.env.TEST_DATABASE_URL : undefined
+if (process.env.DOCK_TEST_DB === "pg" && !PG_URL)
+  throw new Error("DOCK_TEST_DB=pg requires TEST_DATABASE_URL to be set")
+
+type TestStore = MetaStore & { close(): unknown }
+
+// Postgres has no file-per-store isolation like SQLite, so each named store gets
+// its own schema (search_path), dropped + recreated on first use in this process.
+// Same name → same schema (mirrors SQLite's `${name}.db`); the pid keeps parallel
+// test files from colliding. Pools are tracked so afterAll can release handles.
+const pgStores: TestStore[] = []
+const pgSchemas = new Set<string>()
+const schemaFor = (name: string) =>
+  `t_${process.pid}_${name.replace(/[^a-z0-9]+/gi, "_").toLowerCase()}`
+
+const makePgStore = (name: string, users: TestUser[]): TestStore => {
+  const base = PG_URL as string
+  const schema = schemaFor(name)
+  const ready = (async (): Promise<TestStore> => {
+    // Bootstrap on the default search_path: (re)create the schema and the Better
+    // Auth `user` table + seed it, all schema-qualified so search_path is moot.
+    const boot = new Pool({ connectionString: base, max: 1 })
+    try {
+      if (!pgSchemas.has(schema)) {
+        await boot.query(`DROP SCHEMA IF EXISTS ${schema} CASCADE`)
+        await boot.query(`CREATE SCHEMA ${schema}`)
+        pgSchemas.add(schema)
+      }
+      await boot.query(
+        `CREATE TABLE IF NOT EXISTS ${schema}."user" (id text primary key, email text, name text, image text)`,
+      )
+      for (const u of users)
+        await boot.query(
+          `INSERT INTO ${schema}."user" (id, email, name, image) VALUES ($1, $2, $3, $4) ON CONFLICT (id) DO NOTHING`,
+          [u.id, u.email, u.name, u.image ?? null],
+        )
+    } finally {
+      await boot.end()
+    }
+    // Encode the search_path manually: URLSearchParams emits `+` for spaces, which
+    // node-postgres decodeURIComponent's back to `+` (not a space) → invalid options.
+    const opt = encodeURIComponent(`-c search_path=${schema}`)
+    return PgMetaStore.create(`${base}${base.includes("?") ? "&" : "?"}options=${opt}`)
+  })()
+  // Every MetaStore method is async, so a Proxy that defers each call until
+  // connect+migrate finishes lets the synchronous call sites stay unchanged.
+  return new Proxy({} as TestStore, {
+    get:
+      (_t, prop: string) =>
+      (...args: unknown[]) =>
+        ready.then((s) =>
+          (s as unknown as Record<string, (...a: unknown[]) => unknown>)[prop](...args),
+        ),
+  })
+}
+
+const seedSqliteUsers = (path: string, users: TestUser[]): void => {
+  const raw = new Database(path)
+  raw.exec(
+    `CREATE TABLE IF NOT EXISTS user (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT)`,
+  )
+  const ins = raw.prepare(`INSERT OR IGNORE INTO user (id, email, name, image) VALUES (?,?,?,?)`)
+  for (const u of users) ins.run(u.id, u.email, u.name, u.image ?? null)
+  raw.close()
+}
+
+// One metadata store per named test app: Postgres schema or SQLite file. Seeds
+// the Better Auth `user` table so the share/mention routes can resolve email→id.
+const makeStore = (name: string, users: TestUser[]): TestStore => {
+  if (PG_URL) {
+    const s = makePgStore(name, users)
+    pgStores.push(s)
+    return s
+  }
+  const path = join(dir, `${name}.db`)
+  const m = new SqliteMetaStore(path)
+  if (users.length) seedSqliteUsers(path, users)
+  return m
+}
+
+export const meta = makeStore("default", [])
 export const app = createApp({
   meta,
   blobs: new FsBlobStore(join(dir, "blobs")),
   baseUrl: "http://dock.test",
 })
 
-afterAll(() => {
-  meta.close()
+afterAll(async () => {
+  if (PG_URL) await Promise.all(pgStores.map((s) => Promise.resolve(s.close()).catch(() => {})))
+  else meta.close()
   rmSync(dir, { recursive: true, force: true })
 })
 
@@ -53,22 +143,8 @@ export const json = (obj: unknown) => ({
 // token keeps the instance secured, so an unauthenticated caller is NOT owner.
 export type TestUser = { id: string; email: string; name: string | null; image?: string | null }
 
-export const makeAuthedApp = (
-  name: string,
-  users: TestUser[],
-  defaultRole?: AppDeps["defaultRole"],
-  multiWorkspace?: boolean,
-) => {
-  const path = join(dir, `${name}.db`)
-  const m = new SqliteMetaStore(path)
-  const raw = new Database(path)
-  raw.exec(
-    `CREATE TABLE IF NOT EXISTS user (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT)`,
-  )
-  const ins = raw.prepare(`INSERT OR IGNORE INTO user (id, email, name, image) VALUES (?,?,?,?)`)
-  for (const u of users) ins.run(u.id, u.email, u.name, u.image ?? null)
-  raw.close()
-  const auth = {
+const fakeAuth = (users: TestUser[]): AppDeps["auth"] =>
+  ({
     handler: async () => new Response(null, { status: 404 }),
     api: {
       getSession: async ({ headers }: { headers: Headers }) => {
@@ -76,13 +152,21 @@ export const makeAuthedApp = (
         return u ? { user: u } : null
       },
     },
-  } as unknown as AppDeps["auth"]
+  }) as unknown as AppDeps["auth"]
+
+export const makeAuthedApp = (
+  name: string,
+  users: TestUser[],
+  defaultRole?: AppDeps["defaultRole"],
+  multiWorkspace?: boolean,
+) => {
+  const m = makeStore(name, users)
   const app = createApp({
     meta: m,
     blobs: new FsBlobStore(join(dir, "blobs")),
     baseUrl: "http://dock.test",
     token: "tok",
-    auth,
+    auth: fakeAuth(users),
     defaultRole,
     multiWorkspace,
     defaultOrgId: "default",
@@ -130,30 +214,12 @@ export const bearer = (token: string) => ({ authorization: `Bearer ${token}` })
 // = owner) — handy for quota/anonymous-flood tests; with `users` it's secured
 // and the session is picked by an `x-test-user` header, for per-actor tests.
 export const quotaApp = (name: string, extra: Partial<AppDeps>, users?: TestUser[]) => {
-  const path = join(dir, `${name}.db`)
-  const m = new SqliteMetaStore(path)
-  let auth: AppDeps["auth"]
-  if (users) {
-    const raw = new Database(path)
-    raw.exec(`CREATE TABLE IF NOT EXISTS user (id TEXT PRIMARY KEY, email TEXT, name TEXT)`)
-    const ins = raw.prepare(`INSERT OR IGNORE INTO user (id, email, name) VALUES (?,?,?)`)
-    for (const u of users) ins.run(u.id, u.email, u.name)
-    raw.close()
-    auth = {
-      handler: async () => new Response(null, { status: 404 }),
-      api: {
-        getSession: async ({ headers }: { headers: Headers }) => {
-          const u = users.find((x) => x.email === headers.get("x-test-user"))
-          return u ? { user: u } : null
-        },
-      },
-    } as unknown as AppDeps["auth"]
-  }
+  const m = makeStore(name, users ?? [])
   const app = createApp({
     meta: m,
     blobs: new FsBlobStore(join(dir, `blobs-${name}`)),
     baseUrl: "http://dock.test",
-    ...(users ? { token: "tok", auth } : {}),
+    ...(users ? { token: "tok", auth: fakeAuth(users) } : {}),
     ...extra,
   })
   return { app, meta: m }

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -1,0 +1,261 @@
+-- Cloudflare D1 bootstrap schema for Dock.
+-- GENERATED from packages/db/src/schema.ts (SCHEMA_STATEMENTS); do not edit by hand.
+-- Regenerate after a schema change: `pnpm --filter @dock/db gen:d1-schema`.
+-- Apply once: `wrangler d1 execute <db> --file=deploy/d1-schema.sql`.
+
+CREATE TABLE IF NOT EXISTS artifact (
+    id TEXT PRIMARY KEY,
+    short_id TEXT NOT NULL UNIQUE,
+    org_id TEXT NOT NULL DEFAULT 'local',
+    slug TEXT,
+    title TEXT,
+    visibility TEXT NOT NULL DEFAULT 'link',
+    kind TEXT NOT NULL,
+    spa INTEGER NOT NULL DEFAULT 0,
+    current_version INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    removed_at TEXT
+  );
+
+CREATE TABLE IF NOT EXISTS version (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    n INTEGER NOT NULL,
+    blob_key TEXT NOT NULL,
+    content_type TEXT NOT NULL,
+    size_bytes INTEGER NOT NULL DEFAULT 0,
+    author TEXT NOT NULL,
+    message TEXT,
+    name TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (artifact_id, n)
+  );
+
+CREATE TABLE IF NOT EXISTS comment (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    thread_id TEXT NOT NULL,
+    base_version INTEGER NOT NULL,
+    path TEXT,
+    anchor TEXT,
+    body_md TEXT NOT NULL,
+    author TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'open',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    meta TEXT
+  );
+
+CREATE TABLE IF NOT EXISTS principal (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    email TEXT,
+    kind TEXT NOT NULL DEFAULT 'human',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  );
+
+CREATE TABLE IF NOT EXISTS acl (
+    artifact_id TEXT PRIMARY KEY REFERENCES artifact(id),
+    visibility TEXT NOT NULL,
+    password_hash TEXT,
+    org_gate TEXT
+  );
+
+CREATE TABLE IF NOT EXISTS view (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    version INTEGER NOT NULL,
+    viewer TEXT NOT NULL,
+    viewer_kind TEXT NOT NULL DEFAULT 'anon',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  );
+
+CREATE INDEX IF NOT EXISTS view_artifact_time ON view (artifact_id, created_at);
+
+CREATE TABLE IF NOT EXISTS webhook (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT REFERENCES artifact(id),
+    url TEXT NOT NULL,
+    secret TEXT NOT NULL,
+    kind TEXT NOT NULL DEFAULT 'generic',
+    events TEXT NOT NULL DEFAULT '*',
+    label TEXT,
+    active INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  );
+
+CREATE TABLE IF NOT EXISTS webhook_delivery (
+    id TEXT PRIMARY KEY,
+    webhook_id TEXT NOT NULL,
+    url TEXT NOT NULL,
+    secret TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    next_attempt_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  );
+
+CREATE INDEX IF NOT EXISTS delivery_due ON webhook_delivery (status, next_attempt_at);
+
+CREATE TABLE IF NOT EXISTS membership (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (org_id, user_id)
+  );
+
+CREATE TABLE IF NOT EXISTS workspace (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  );
+
+CREATE TABLE IF NOT EXISTS artifact_member (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    user_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (artifact_id, user_id)
+  );
+
+CREATE TABLE IF NOT EXISTS notification (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    actor TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    artifact_id TEXT NOT NULL,
+    artifact_short_id TEXT NOT NULL,
+    artifact_title TEXT,
+    thread_id TEXT NOT NULL,
+    comment_id TEXT NOT NULL,
+    preview TEXT NOT NULL,
+    read INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  );
+
+CREATE INDEX IF NOT EXISTS notification_user_time ON notification (user_id, created_at);
+
+CREATE TABLE IF NOT EXISTS agent (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    token TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'commenter',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (token),
+    UNIQUE (org_id, name)
+  );
+
+CREATE TABLE IF NOT EXISTS agent_mention (
+    id TEXT PRIMARY KEY,
+    agent_id TEXT NOT NULL,
+    artifact_id TEXT NOT NULL,
+    artifact_short_id TEXT NOT NULL,
+    comment_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    author TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'pending',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  );
+
+CREATE INDEX IF NOT EXISTS agent_mention_inbox ON agent_mention (agent_id, state, created_at);
+
+CREATE TABLE IF NOT EXISTS artifact_favorite (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    user_id TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (artifact_id, user_id)
+  );
+
+CREATE INDEX IF NOT EXISTS favorite_user ON artifact_favorite (user_id);
+
+CREATE TABLE IF NOT EXISTS artifact_tag (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    tag TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (artifact_id, tag)
+  );
+
+CREATE INDEX IF NOT EXISTS tag_name ON artifact_tag (tag);
+
+CREATE TABLE IF NOT EXISTS collection (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL DEFAULT 'local',
+    title TEXT NOT NULL,
+    created_by TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  );
+
+CREATE TABLE IF NOT EXISTS collection_item (
+    id TEXT PRIMARY KEY,
+    collection_id TEXT NOT NULL REFERENCES collection(id),
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (collection_id, artifact_id)
+  );
+
+CREATE INDEX IF NOT EXISTS collection_item_artifact ON collection_item (artifact_id);
+
+CREATE TABLE IF NOT EXISTS collection_member (
+    id TEXT PRIMARY KEY,
+    collection_id TEXT NOT NULL REFERENCES collection(id),
+    user_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (collection_id, user_id)
+  );
+
+CREATE INDEX IF NOT EXISTS collection_member_user ON collection_member (user_id);
+
+CREATE TABLE IF NOT EXISTS proposal (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    blob_key TEXT NOT NULL,
+    content_type TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    title TEXT,
+    message TEXT,
+    author TEXT NOT NULL,
+    base_version INTEGER NOT NULL,
+    state TEXT NOT NULL DEFAULT 'open',
+    decided_by TEXT,
+    decided_version INTEGER,
+    decision_note TEXT,
+    decided_at TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  );
+
+CREATE INDEX IF NOT EXISTS proposal_artifact_state ON proposal (artifact_id, state);
+
+CREATE TABLE IF NOT EXISTS report (
+    id TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL,
+    artifact_short_id TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    detail TEXT,
+    reporter TEXT,
+    state TEXT NOT NULL DEFAULT 'open',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  );
+
+CREATE INDEX IF NOT EXISTS report_state ON report (state, created_at);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id TEXT PRIMARY KEY,
+    action TEXT NOT NULL,
+    artifact_id TEXT,
+    actor TEXT NOT NULL,
+    detail TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  );
+
+CREATE INDEX IF NOT EXISTS audit_artifact ON audit_log (artifact_id, created_at);

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "start": "pnpm --filter @dock/api start",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
+    "test:pg": "bash scripts/test-pg.sh",
     "lint": "biome lint",
     "format": "biome format --write",
     "check": "biome check",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run --passWithNoTests",
+    "gen:d1-schema": "vitest run test/d1-schema.test.ts -u"
   },
   "dependencies": {
     "@dock/core": "workspace:*",

--- a/packages/db/src/d1-schema.ts
+++ b/packages/db/src/d1-schema.ts
@@ -1,0 +1,20 @@
+import { SCHEMA_STATEMENTS } from "./schema"
+
+/**
+ * The Cloudflare D1 bootstrap schema as a single SQL file body. D1 is SQLite-
+ * compatible and the d1 driver shares the SQLite `schema`, so the DDL is exactly
+ * `SCHEMA_STATEMENTS` — the same statements the SQLite driver boots and the
+ * schema-conformance test validates against the drizzle defs. Joining them here
+ * (rather than hand-maintaining a parallel `.sql`) keeps the D1 deploy schema from
+ * drifting; `deploy/d1-schema.sql` is generated from this and guarded by a test.
+ */
+export const buildD1SchemaSql = (): string => {
+  const header = `-- Cloudflare D1 bootstrap schema for Dock.
+-- GENERATED from packages/db/src/schema.ts (SCHEMA_STATEMENTS); do not edit by hand.
+-- Regenerate after a schema change: \`pnpm --filter @dock/db gen:d1-schema\`.
+-- Apply once: \`wrangler d1 execute <db> --file=deploy/d1-schema.sql\`.
+
+`
+  const body = SCHEMA_STATEMENTS.map((s) => `${s.trim().replace(/;\s*$/, "")};`).join("\n\n")
+  return `${header}${body}\n`
+}

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -13,7 +13,12 @@ const VIEW_WINDOW_MS = 30 * 86400_000
  * transactions, so the repos' sequential writes are used as-is — addVersion
  * relies on UNIQUE(artifact_id, n) to turn a race into a clean error.
  *
- * Apply deploy/d1-schema.sql once before first use.
+ * Apply deploy/d1-schema.sql once before first use (generated from the shared
+ * SCHEMA_STATEMENTS; see src/d1-schema.ts).
+ *
+ * Experimental: the shared query logic rides on the SQLite suite and the schema on
+ * schema-conformance, but the D1-specific runtime path has no integration test yet
+ * and Dock ships no Worker entrypoint. Treat as unverified. See DEPLOY.md.
  */
 export function createD1Store(d1: D1Database): MetaStore {
   const db = drizzle(d1, { schema })

--- a/packages/db/test/d1-schema.test.ts
+++ b/packages/db/test/d1-schema.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest"
+import { buildD1SchemaSql } from "../src/d1-schema"
+
+// deploy/d1-schema.sql is the Cloudflare D1 bootstrap schema, generated from
+// SCHEMA_STATEMENTS (see src/d1-schema.ts) so it can't drift from the SQLite DDL
+// that the schema-conformance test already validates against the drizzle defs.
+// This locks the committed file to the generated output; after a schema change,
+// regenerate with `pnpm --filter @dock/db gen:d1-schema` (vitest -u under the hood).
+describe("d1 deploy schema", () => {
+  it("deploy/d1-schema.sql stays in sync with SCHEMA_STATEMENTS", async () => {
+    await expect(buildD1SchemaSql()).toMatchFileSnapshot("../../../deploy/d1-schema.sql")
+  })
+})

--- a/scripts/test-pg.sh
+++ b/scripts/test-pg.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Run the apps/api test suite against a real Postgres in an ephemeral container.
+# The same specs that `pnpm test` runs on embedded SQLite exercise the hosted-
+# tier Postgres driver here, so a wrong WHERE / missing org scope / broken
+# transaction in pg.ts fails a test instead of shipping. Requires Docker.
+#
+#   pnpm test:pg                       # whole suite
+#   pnpm test:pg artifacts.test.ts     # one file (extra args pass through)
+set -euo pipefail
+
+PASSWORD=postgres
+DB=dock_test
+NAME="dock-pg-test-$$"
+IMAGE="${DOCK_PG_IMAGE:-postgres:16-alpine}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+cleanup() { docker rm -f "$NAME" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "→ starting ephemeral Postgres ($IMAGE)…"
+# Random host port (avoids clashing with any local :5432); bound to loopback.
+# A generous max_connections covers one Pool per isolated test schema.
+docker run -d --rm --name "$NAME" \
+  -e POSTGRES_PASSWORD="$PASSWORD" -e POSTGRES_DB="$DB" \
+  -p 127.0.0.1::5432 \
+  "$IMAGE" -c max_connections=200 >/dev/null
+
+PORT="$(docker port "$NAME" 5432/tcp | head -1 | sed 's/.*://')"
+URL="postgres://postgres:${PASSWORD}@127.0.0.1:${PORT}/${DB}"
+echo "→ Postgres on 127.0.0.1:${PORT}"
+
+printf "→ waiting for readiness"
+for i in $(seq 1 60); do
+  if docker exec "$NAME" pg_isready -U postgres -d "$DB" >/dev/null 2>&1; then
+    echo " ok"
+    break
+  fi
+  printf "."
+  sleep 0.5
+  if [ "$i" -eq 60 ]; then echo " timed out" && exit 1; fi
+done
+
+export DOCK_TEST_DB=pg
+export TEST_DATABASE_URL="$URL"
+
+echo "→ running apps/api suite against Postgres"
+cd "$ROOT/apps/api"
+pnpm exec vitest run --no-file-parallelism "$@"


### PR DESCRIPTION
Follow-ups from the post-refactor review, all backend-only (no `apps/web`).

## What's here

**1. The api suite now runs against real Postgres, not just SQLite.**
pg is the hosted-tier driver but rode on typecheck + parity guards alone (those catch schema drift, never a wrong WHERE or a missing org scope). The 12 test files are byte-identical; only `apps/api/test/helpers.ts` learned a pg mode: each test app gets its own schema (mirrors SQLite's file-per-name), and a Proxy defers the async connect/migrate so the synchronous call sites are unchanged. `pnpm test:pg` spins up an ephemeral Docker Postgres and runs the suite; a CI `pg` job runs the same script. **135/135 pass on Postgres.**

**2. Two correctness/perf fixes from the review.**
- `currentUser` is now memoized per request with a WeakMap, like `agentFor`/`activeWorkspace` right beside it. It re-ran `auth.getSession()` on every call, and several handlers resolve the caller 2-3x per request.
- `node.ts`'s one-time owner self-view cleanup queried `listMemberships("local")`, but boot rekeys every org-scoped row from `"local"` onto `defaultOrg`, so the query matched nothing and the cleanup silently no-op'd. It queries `defaultOrg` now.

**3. D1 made honest.**
- Generated `deploy/d1-schema.sql` (the file `d1.ts` told users to apply, but it didn't exist), locked to the conformance-tested `SCHEMA_STATEMENTS` by a snapshot test so it can't drift. Regenerate with `pnpm --filter @dock/db gen:d1-schema`.
- Labeled experimental/unverified in `DEPLOY.md` + the driver header: the shared query logic rides the SQLite suite, but the D1-specific runtime has no integration test and Dock ships no Worker entrypoint. No `workerd` dependency added.

## Gate
typecheck, biome (0 errors), **214 tests on SQLite**, **135 on Postgres**.

Complements the `guardrails` commit: that made the invariants static/structural, this adds the behavioral Postgres coverage plus the two fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)