### PR TITLE
feat(edge): Durable Object realtime backplane — cross-instance fan-out

### DIFF
--- a/apps/api/src/realtime-do.ts
+++ b/apps/api/src/realtime-do.ts
@@ -1,0 +1,128 @@
+import type { DurableObjectNamespace, DurableObjectState } from "@cloudflare/workers-types"
+import type { Context } from "hono"
+import type { Backplane, DockEvent, PresenceStore } from "./bus"
+
+const PING_MS = 20_000
+const PRESENCE_TTL_MS = 45_000
+const enc = new TextEncoder()
+const frame = (event: string, data: string) => enc.encode(`event: ${event}\ndata: ${data}\n\n`)
+
+/**
+ * Realtime room: one Durable Object per channel (an artifact id, or `u:<userId>`
+ * for the notification bell). It owns the SSE connections for that channel and
+ * broadcasts events to them, so fan-out works across Worker isolates — every
+ * client for a channel reaches the same DO. Presence is tracked here too.
+ *
+ * Plain SSE (not WebSocket) keeps the existing EventSource client unchanged; an
+ * alarm pings open streams so intermediaries don't drop idle connections. This is
+ * the connection-owning half of the Backplane port (see bus.ts).
+ */
+export class ArtifactRoom {
+  private streams = new Set<ReadableStreamDefaultController<Uint8Array>>()
+  private viewers = new Map<string, number>()
+  constructor(private state: DurableObjectState) {}
+
+  async fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url)
+
+    // SSE connect: hold an open stream for this client.
+    if (req.method === "GET") {
+      const streams = this.streams
+      const storage = this.state.storage
+      let ctrl: ReadableStreamDefaultController<Uint8Array>
+      const body = new ReadableStream<Uint8Array>({
+        start(c) {
+          ctrl = c
+          streams.add(c)
+          c.enqueue(frame("ready", "{}"))
+          if (streams.size === 1) void storage.setAlarm(Date.now() + PING_MS)
+        },
+        cancel() {
+          streams.delete(ctrl)
+        },
+      })
+      return new Response(body, {
+        headers: {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          "access-control-allow-origin": "*",
+        },
+      })
+    }
+
+    // Broadcast an event to every open stream on this channel.
+    if (req.method === "POST" && url.pathname.endsWith("/publish")) {
+      const raw = await req.text()
+      const ev = JSON.parse(raw) as DockEvent
+      const f = frame(ev.type, raw)
+      for (const c of this.streams) {
+        try {
+          c.enqueue(f)
+        } catch {
+          this.streams.delete(c)
+        }
+      }
+      return new Response("ok")
+    }
+
+    // Presence heartbeat: record + return the live viewer names.
+    if (req.method === "POST" && url.pathname.endsWith("/heartbeat")) {
+      const { name, now } = (await req.json()) as { name: string; now: number }
+      this.viewers.set(name, now)
+      for (const [n, t] of this.viewers) if (now - t > PRESENCE_TTL_MS) this.viewers.delete(n)
+      return Response.json([...this.viewers.keys()])
+    }
+
+    return new Response("not found", { status: 404 })
+  }
+
+  // Keep-alive: ping open streams (SSE comment), reschedule while any remain.
+  async alarm(): Promise<void> {
+    const ping = enc.encode(": ping\n\n")
+    for (const c of this.streams) {
+      try {
+        c.enqueue(ping)
+      } catch {
+        this.streams.delete(c)
+      }
+    }
+    if (this.streams.size > 0) await this.state.storage.setAlarm(Date.now() + PING_MS)
+  }
+}
+
+/**
+ * Durable Object backplane (the Workers adapter). Routes the SSE stream to the
+ * per-channel DO, fans events out through it, and tracks presence in it. `subscribe`
+ * is unused — the DO owns the streams, so `handleStream` returns the DO's Response
+ * and the route never falls back to local SSE.
+ *
+ * The `as unknown as Response` casts reconcile the two Response types in scope here
+ * (the Workers `DurableObjectStub.fetch` Response vs the ambient global one); the
+ * runtime value is a real workerd Response.
+ */
+export function createDoBackplane(rooms: DurableObjectNamespace): Backplane {
+  const stub = (channel: string) => rooms.get(rooms.idFromName(channel))
+  const presence: PresenceStore = {
+    async heartbeat(channel, name, now) {
+      const res = await stub(channel).fetch("https://do/heartbeat", {
+        method: "POST",
+        body: JSON.stringify({ name, now }),
+      })
+      return (await res.json()) as string[]
+    },
+  }
+  return {
+    publish(channel, e) {
+      void stub(channel)
+        .fetch("https://do/publish", { method: "POST", body: JSON.stringify(e) })
+        .catch(() => {})
+    },
+    subscribe() {
+      return () => {}
+    },
+    presence,
+    handleStream(_c: Context, channel: string) {
+      return stub(channel).fetch("https://do/sse", { method: "GET" }) as unknown as Response
+    },
+  }
+}

--- a/apps/api/src/realtime-do.ts
+++ b/apps/api/src/realtime-do.ts
@@ -1,6 +1,19 @@
-import type { DurableObjectNamespace, DurableObjectState } from "@cloudflare/workers-types"
+import { AsyncLocalStorage } from "node:async_hooks"
+import type {
+  DurableObjectNamespace,
+  DurableObjectState,
+  ExecutionContext,
+} from "@cloudflare/workers-types"
 import type { Context } from "hono"
 import type { Backplane, DockEvent, PresenceStore } from "./bus"
+
+/**
+ * Per-request execution context, so the DO backplane's fire-and-forget publish can
+ * ride `waitUntil` — Workers cancels un-awaited async once the response is sent, so
+ * a bare `void fetch(...)` to the room DO would be killed before it lands. The Worker
+ * entry wraps `app.fetch` in `edgeCtx.run(ctx, …)`.
+ */
+export const edgeCtx = new AsyncLocalStorage<ExecutionContext>()
 
 const PING_MS = 20_000
 const PRESENCE_TTL_MS = 45_000
@@ -113,9 +126,12 @@ export function createDoBackplane(rooms: DurableObjectNamespace): Backplane {
   }
   return {
     publish(channel, e) {
-      void stub(channel)
+      const p = stub(channel)
         .fetch("https://do/publish", { method: "POST", body: JSON.stringify(e) })
         .catch(() => {})
+      const ctx = edgeCtx.getStore()
+      if (ctx) ctx.waitUntil(p)
+      else void p
     },
     subscribe() {
       return () => {}

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -1,10 +1,15 @@
-import type { D1Database, DurableObjectNamespace, R2Bucket } from "@cloudflare/workers-types"
+import type {
+  D1Database,
+  DurableObjectNamespace,
+  ExecutionContext,
+  R2Bucket,
+} from "@cloudflare/workers-types"
 import { createD1Store } from "@dock/db/d1"
 import { R2BlobStore } from "@dock/storage"
 import { D1Dialect } from "kysely-d1"
 import { createApp } from "./app"
 import { makeAuth } from "./auth-config"
-import { createDoBackplane } from "./realtime-do"
+import { createDoBackplane, edgeCtx } from "./realtime-do"
 
 // The realtime room Durable Object (one per channel). Exported so the Workers
 // runtime can instantiate the bound class.
@@ -36,7 +41,7 @@ export interface Env {
 let app: ReturnType<typeof createApp> | null = null
 
 export default {
-  fetch(req: Request, env: Env): Response | Promise<Response> {
+  fetch(req: Request, env: Env, ctx: ExecutionContext): Response | Promise<Response> {
     if (!app) {
       const baseUrl = env.BASE_URL ?? new URL(req.url).origin
       const auth = makeAuth(
@@ -54,6 +59,8 @@ export default {
         defaultOrgId: "default",
       })
     }
-    return app.fetch(req)
+    // Run within the per-request context so the DO backplane's publish can waitUntil.
+    const ready = app
+    return edgeCtx.run(ctx, () => ready.fetch(req))
   },
 }

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -1,18 +1,22 @@
-import type { D1Database, R2Bucket } from "@cloudflare/workers-types"
+import type { D1Database, DurableObjectNamespace, R2Bucket } from "@cloudflare/workers-types"
 import { createD1Store } from "@dock/db/d1"
 import { R2BlobStore } from "@dock/storage"
 import { D1Dialect } from "kysely-d1"
 import { createApp } from "./app"
 import { makeAuth } from "./auth-config"
+import { createDoBackplane } from "./realtime-do"
+
+// The realtime room Durable Object (one per channel). Exported so the Workers
+// runtime can instantiate the bound class.
+export { ArtifactRoom } from "./realtime-do"
 
 /**
  * Cloudflare Workers entry (experimental edge tier). The same runtime-agnostic
  * `createApp` the Node entry uses, wired to edge adapters: D1 for the MetaStore,
- * R2 for blobs, Better Auth on a Kysely D1 dialect.
- *
- * Realtime runs in-process here (fine for a single instance); cross-instance
- * fan-out on the edge is a follow-up — a Durable Object adapter behind the
- * `Backplane` port (see bus.ts), which this entry would inject.
+ * R2 for blobs, Better Auth on a Kysely D1 dialect, and a Durable Object backplane
+ * for cross-instance realtime fan-out (every client for a channel reaches the same
+ * room DO). The Node/self-host path uses the in-process backplane instead, so
+ * realtime stays zero-dependency there — the DO is opt-in to this entry.
  *
  * Schema (app + Better Auth) is applied to D1 out of band via `wrangler d1 execute`,
  * not at runtime: D1 forbids the sqlite_master introspection Better Auth's migrator
@@ -23,6 +27,7 @@ import { makeAuth } from "./auth-config"
 export interface Env {
   DB: D1Database
   BUCKET: R2Bucket
+  ROOMS: DurableObjectNamespace
   BASE_URL?: string
   DOCK_AUTH_SECRET?: string
   DOCK_MULTI_WORKSPACE?: string
@@ -42,6 +47,7 @@ export default {
       app = createApp({
         meta: createD1Store(env.DB),
         blobs: new R2BlobStore(env.BUCKET),
+        backplane: createDoBackplane(env.ROOMS),
         baseUrl,
         auth,
         multiWorkspace: env.DOCK_MULTI_WORKSPACE === "true",

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": { "types": ["node"] },
   "include": ["src", "test"],
   "//": "The Cloudflare Workers entry is checked separately (tsconfig.worker.json) under @cloudflare/workers-types; its Workers globals conflict with the Node/DOM lib used here.",
-  "exclude": ["src/worker.ts"]
+  "exclude": ["src/worker.ts", "src/realtime-do.ts"]
 }

--- a/apps/api/tsconfig.worker.json
+++ b/apps/api/tsconfig.worker.json
@@ -5,5 +5,5 @@
     "types": ["@cloudflare/workers-types", "node"],
     "skipLibCheck": true
   },
-  "include": ["src/worker.ts"]
+  "include": ["src/worker.ts", "src/realtime-do.ts"]
 }

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -14,8 +14,16 @@ database_id = "REPLACE_WITH_YOUR_D1_ID"
 binding = "BUCKET"
 bucket_name = "dock-blobs"
 
+[[durable_objects.bindings]]
+name = "ROOMS"
+class_name = "ArtifactRoom"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["ArtifactRoom"]
+
 # baseUrl falls back to the request origin when unset. Secured by Better Auth; set
-# DOCK_AUTH_SECRET via `wrangler secret put`. Realtime runs in-process here;
-# cross-instance fan-out on the edge is a follow-up (a Durable Object backplane).
+# DOCK_AUTH_SECRET via `wrangler secret put`. Cross-instance realtime fan-out uses
+# the ArtifactRoom Durable Object (one room per channel).
 [vars]
 DOCK_MULTI_WORKSPACE = "false"


### PR DESCRIPTION
Adds the Durable Object realtime adapter behind the `Backplane` port from #71, giving the Cloudflare edge tier **cross-instance realtime fan-out**.

`ArtifactRoom` is a Durable Object — one per channel (an artifact id, or `u:<userId>` for the notification bell) — that owns the SSE connections for that channel and broadcasts events to them. Every client for a channel reaches the same room regardless of which Worker isolate served the request, so live comments/presence fan out across instances.

- **Opt-in.** `createDoBackplane` implements the `Backplane` port; the Worker entry injects it. The Node/self-host path stays on the in-process backplane, so **realtime is still zero-dependency for self-host** — no Redis, no DO required.
- **Plain SSE** (not WebSocket) keeps the existing `EventSource` client unchanged; an alarm pings open streams so idle connections aren't dropped.
- Presence is tracked in the DO; publish is fire-and-forget to the room.
- `wrangler.toml` gains the `ROOMS` binding + a `new_sqlite_classes` migration.

## Gate
typecheck (both Node + worker configs), `pnpm run ci` (biome + lint:tokens + knip), 136 api tests, worker bundles clean. The edge entry is typecheck-covered and re-vetted live (SSE fan-out across two clients on the deployed worker); a Miniflare CI smoke test is a future add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)