### PR TITLE
feat(realtime): live multiplayer cursors

### DIFF
--- a/apps/api/src/events.ts
+++ b/apps/api/src/events.ts
@@ -17,6 +17,7 @@ export const DOMAIN_EVENTS = [
   "proposal.approved",
   "proposal.changes_requested",
   "presence",
+  "cursor",
   "notification",
 ] as const
 export type DomainEvent = (typeof DOMAIN_EVENTS)[number]

--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -44,5 +44,34 @@ export const realtimeRoutes = (ctx: AppContext) => {
     return c.json({ viewers })
   })
 
+  // Live cursor: a viewer's pointer position (viewport-normalized 0..1) fanned out
+  // to everyone else on the artifact. Ephemeral — never stored, never webhooked;
+  // it rides the same backplane as presence, so the DO relays it across isolates.
+  app.post("/v1/artifacts/:shortId/cursor", async (c) => {
+    const artifact = await meta.getByShortId(c.req.param("shortId"))
+    if (!artifact || !(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
+    const body = await readJson(
+      c,
+      z.object({
+        id: z.string().min(1).max(64),
+        name: z.string().max(80).optional(),
+        color: z.string().max(32).optional(),
+        x: z.number(),
+        y: z.number(),
+      }),
+    )
+    if (body instanceof Response) return body
+    const clamp = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n)
+    bus.publish(artifact.id, {
+      type: "cursor",
+      id: body.id,
+      name: body.name ?? "anonymous",
+      color: body.color ?? "#655999",
+      x: clamp(body.x),
+      y: clamp(body.y),
+    })
+    return c.body(null, 204)
+  })
+
   return app
 }

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -76,6 +76,14 @@ document.addEventListener("mouseup",function(){setTimeout(emitSelection,0)});
 document.addEventListener("selectionchange",function(){
   var s=window.getSelection();if(!s||s.isCollapsed)post({type:"select",selector:null,rect:null})});
 
+/* -- live cursor: throttled pointer position, viewport-normalized 0..1, so the
+      host can fan it out to other viewers as a multiplayer cursor -- */
+var cT=0;
+document.addEventListener("mousemove",function(e){
+  var n=Date.now();if(n-cT<40)return;cT=n;
+  var w=window.innerWidth||1,h=window.innerHeight||1;
+  post({type:"cursor",x:e.clientX/w,y:e.clientY/h})});
+
 /* -- highlight styles (mark's default yellow is overridden) -- */
 var st=document.createElement("style");
 st.textContent="mark.dock-hl{background:rgba(124,108,189,.20);color:inherit;border-bottom:2px solid rgba(124,108,189,.5);border-radius:2px;cursor:pointer;transition:background .15s,border-color .15s}"+

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -105,6 +105,12 @@ export function renderShell(
   .composer .name{flex:1;border:1px solid var(--line);border-radius:7px;padding:5px 9px;font-size:11px;color:var(--muted);background:var(--paper)}
   .toast{position:fixed;bottom:16px;left:50%;transform:translateX(-50%);background:var(--ink);color:var(--paper);font-size:12px;padding:8px 14px;border-radius:9px;opacity:0;transition:.25s;pointer-events:none;z-index:50}
   .toast.show{opacity:1}
+  /* live multiplayer cursors (overlaid on the artifact stage) */
+  #cursors{position:absolute;inset:0;overflow:hidden;pointer-events:none;z-index:30}
+  .pcur{position:absolute;top:0;left:0;transition:transform .09s linear,opacity .3s;will-change:transform}
+  .pcur svg{display:block;fill:var(--c);filter:drop-shadow(0 1px 1.5px rgba(0,0,0,.35))}
+  .pcur b{position:absolute;left:12px;top:14px;background:var(--c);color:#fff;font:600 10.5px var(--sans);
+    padding:1px 7px;border-radius:5px;white-space:nowrap;box-shadow:0 1px 4px rgba(0,0,0,.25)}
 </style>
 </head>
 <body>
@@ -239,10 +245,39 @@ try {
   ev.addEventListener("comment.resolved", loadComments);
   ev.addEventListener("version.published", () => toast("A new version was published"));
   ev.addEventListener("presence", e => { try{ const d=JSON.parse(e.data); const n=(d.viewers||[]).length; $("#presN").textContent=n; $("#pres").hidden = n<2; }catch{} });
+  ev.addEventListener("cursor", e => { try{ const d=JSON.parse(e.data); if(d.id!==myId) showPeer(d); }catch{} });
 } catch {}
 const myName = () => who || "anonymous";
 function beat(){ fetch(base + "/presence", {method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({name: myName()})}).catch(()=>{}); }
 beat(); setInterval(beat, 25000);
+
+/* ---- live cursors (multiplayer) ---- */
+const stage = $(".stage"); stage.style.position = "relative";
+const clayer = document.createElement("div"); clayer.id = "cursors"; stage.appendChild(clayer);
+const myId = Math.random().toString(36).slice(2, 9);
+let h = 0; for (let i = 0; i < myId.length; i++) h = (h * 31 + myId.charCodeAt(i)) % 360;
+const myColor = "hsl(" + h + " 72% 52%)";
+const peers = {};
+let lastXY = null, lastSent = 0;
+function sendCursor(){ if(!lastXY) return; lastSent = Date.now();
+  fetch(base + "/cursor", {method:"POST",headers:{"content-type":"application/json"},
+    body: JSON.stringify({id: myId, name: myName(), color: myColor, x: lastXY[0], y: lastXY[1]})}).catch(()=>{}); }
+window.addEventListener("message", e => {
+  const m = e.data; if(!m || m.source !== "dock" || m.type !== "cursor") return;
+  lastXY = [m.x, m.y]; if(Date.now() - lastSent >= 45) sendCursor(); });
+setInterval(() => { if(lastXY) sendCursor(); }, 3000);
+const CUR_SVG = '<svg width="20" height="20" viewBox="0 0 16 20"><path d="M1 1 L1 16 L5 12.5 L8 19 L10.5 18 L7.5 11.5 L13 11.5 Z" stroke="#fff" stroke-width="1.3" stroke-linejoin="round"/></svg>';
+function showPeer(d){
+  let el = peers[d.id];
+  if(!el){ el = document.createElement("div"); el.className = "pcur"; el.innerHTML = CUR_SVG + "<b></b>"; clayer.appendChild(el); peers[d.id] = el; }
+  el.style.setProperty("--c", d.color || "#655999");
+  el.querySelector("b").textContent = d.name || "anon";
+  const r = stage.getBoundingClientRect();
+  el.style.transform = "translate(" + (d.x * r.width).toFixed(1) + "px," + (d.y * r.height).toFixed(1) + "px)";
+  el.style.opacity = "1";
+  clearTimeout(el._t);
+  el._t = setTimeout(() => { el.style.opacity = "0"; setTimeout(() => { el.remove(); delete peers[d.id]; }, 400); }, 8000);
+}
 </script>
 </body>
 </html>`


### PR DESCRIPTION
## Live multiplayer cursors

Builds on the DO realtime backplane (#74). Every viewer's pointer is visible to everyone else on an artifact, live.

### How it works
- `cursor` is a new **ephemeral** domain event (like `presence`: fanned out, never persisted, never webhooked).
- The sandboxed artifact iframe is opaque-origin, so a throttled `mousemove` (~25/s) is bridged out via the existing `postMessage` channel in the injected client (`anchor.ts`).
- The viewer shell publishes the local pointer (viewport-normalized 0..1) to `POST /v1/artifacts/:id/cursor` and renders peers as a labeled, colored overlay on the artifact stage, with an 8s TTL + 3s keepalive so a still cursor doesn't vanish.
- Rides the same `bus.publish` path as comments/presence: **in-process** for self-host (zero-dep), the **ArtifactRoom Durable Object** across isolates on the edge.

### Verified
- typecheck (Node + worker tsconfigs), biome, **136 api tests**
- cursor fan-out over SSE confirmed
- 4 isolated browser sessions each render the other 3 cursors live

### Note
Transport is throttled POST-per-move over the existing SSE+POST channel: fine at this scale; WebSockets on the DO is the natural follow-up for heavy rooms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)