### PR TITLE
feat(edge): serve the web SPA from the Worker (Static Assets)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -168,12 +168,13 @@ cross-origin SPA→API request; `DOCK_WEB_ORIGIN` allow-lists the SPA for CORS.
 ## Cloudflare Workers + D1 (experimental)
 
 Dock has a Cloudflare Workers entry (`apps/api/src/worker.ts`) that runs the whole app
-on the edge: D1 for metadata, R2 for blobs, Better Auth on a Kysely D1 dialect. It reuses
-the same runtime-agnostic `createApp` as the Node entry, so the app logic is identical.
+on the edge: D1 for metadata, R2 for blobs, Better Auth on a Kysely D1 dialect, the
+ArtifactRoom Durable Object for cross-instance realtime fan-out, and the web SPA served
+same-origin via Workers Static Assets. It reuses the same runtime-agnostic `createApp`
+as the Node entry, so the app logic is identical.
 
-Treat it as **experimental**: realtime runs in-process (cross-instance fan-out on the
-edge is a follow-up, a Durable Object behind the `Backplane` port in `bus.ts`), and there
-is no automated edge integration test in CI yet (the entry is typecheck-covered).
+Treat it as **experimental**: there is no automated edge integration test in CI yet (the
+entry is typecheck-covered).
 
 ```bash
 cd apps/api
@@ -182,7 +183,8 @@ wrangler d1 execute dock --remote --file=../../deploy/d1-schema.sql       # app 
 node --experimental-strip-types gen-auth-schema.ts > /tmp/auth-schema.sql # Better Auth tables
 wrangler d1 execute dock --remote --file=/tmp/auth-schema.sql
 wrangler r2 bucket create dock-blobs
-wrangler deploy
+pnpm build:web                              # build the SPA + prep dist/client for Workers
+wrangler deploy                             # or `pnpm deploy` to do build:web + deploy
 wrangler secret put DOCK_AUTH_SECRET        # a strong random secret
 ```
 
@@ -190,3 +192,11 @@ D1 forbids the `sqlite_master` introspection Better Auth's migrator runs (`SQLIT
 so the auth tables are generated offline (`gen-auth-schema.ts`) and applied with
 `wrangler d1 execute`, never at boot. `deploy/d1-schema.sql` is generated from the shared
 schema; regenerate with `pnpm --filter @dock/db gen:d1-schema`.
+
+The worker serves the SPA (login, library, settings) same-origin with the API, so there
+is no CORS or cross-site cookie config. `[assets]` in `wrangler.toml` points at
+`apps/web/dist/client` with `not_found_handling = "single-page-application"`, and
+`run_worker_first` routes `/v1`, `/api`, `/raw`, `/a/*`, and `/healthz` to the worker
+while every other path serves a static file or the SPA shell. `pnpm build:web` builds
+apps/web and preps the output (writes `index.html`, drops the Pages-only `_redirects`
+catch-all that otherwise hijacks `/assets/*`); see `scripts/prep-edge-assets.mjs`.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,8 @@
   "scripts": {
     "dev": "tsx watch src/node.ts",
     "start": "tsx src/node.ts",
+    "build:web": "pnpm --filter @dock/web build && node scripts/prep-edge-assets.mjs",
+    "deploy": "pnpm build:web && wrangler deploy",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.worker.json",
     "test": "vitest run"
   },

--- a/apps/api/scripts/prep-edge-assets.mjs
+++ b/apps/api/scripts/prep-edge-assets.mjs
@@ -1,0 +1,25 @@
+// Prepare the SPA build output (apps/web/dist/client) for Cloudflare Workers Static
+// Assets, so the worker can serve the whole app same-origin with the API:
+//
+//  - copy `_shell.html` -> `index.html`: Workers' `not_found_handling =
+//    "single-page-application"` serves `/index.html` for any non-asset route, which is
+//    how client-side routing (/login, /settings, ...) survives a hard refresh.
+//  - remove the Pages-style `_redirects` (`/*  /_shell.html  200`): on Workers that
+//    catch-all also rewrites `/assets/*`, so JS/CSS get served as HTML and the SPA never
+//    boots. `not_found_handling` replaces it correctly (real files win over the fallback).
+//
+// Run via `pnpm --filter @dock/api build:web` (which builds apps/web first). Idempotent.
+import { copyFileSync, existsSync, rmSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const dist = join(dirname(fileURLToPath(import.meta.url)), "../../web/dist/client")
+const shell = join(dist, "_shell.html")
+if (!existsSync(shell)) {
+  process.stderr.write(`missing ${shell} — run the web build first\n`)
+  process.exit(1)
+}
+copyFileSync(shell, join(dist, "index.html"))
+const redirects = join(dist, "_redirects")
+if (existsSync(redirects)) rmSync(redirects)
+process.stdout.write(`prepped edge assets in ${dist} (index.html written, _redirects removed)\n`)

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -22,6 +22,17 @@ class_name = "ArtifactRoom"
 tag = "v1"
 new_sqlite_classes = ["ArtifactRoom"]
 
+# The web SPA (apps/web) ships from this same Worker via Static Assets, so the whole
+# app — login, library, settings — lives same-origin with the API (no CORS, first-party
+# cookies). Prepare the build first: `pnpm --filter @dock/api build:web` (builds apps/web
+# and preps dist/client for Workers: _shell.html -> index.html, drops the Pages _redirects).
+# API + viewer paths run the Worker first; every other path serves a static asset, and
+# non-asset routes fall back to the SPA shell (index.html) for client-side routing.
+[assets]
+directory = "../web/dist/client"
+run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/a/*", "/healthz"]
+not_found_handling = "single-page-application"
+
 # baseUrl falls back to the request origin when unset. Secured by Better Auth; set
 # DOCK_AUTH_SECRET via `wrangler secret put`. Cross-instance realtime fan-out uses
 # the ArtifactRoom Durable Object (one room per channel).


### PR DESCRIPTION
## Serve the full app from the Worker

The Cloudflare Worker now serves the web SPA (login, library, settings) **same-origin** with the API, so there's no CORS and auth cookies are first-party. This follows Cloudflare's current guidance — Workers + Static Assets is the recommended path for new full-stack apps, with Pages in maintenance ([blog](https://blog.cloudflare.com/full-stack-development-on-cloudflare-workers/), [migration guide](https://developers.cloudflare.com/workers/static-assets/migration-guides/migrate-from-pages/)).

### Changes
- **`wrangler.toml` `[assets]`**: `directory = ../web/dist/client`; `run_worker_first` routes `/v1`, `/api`, `/raw`, `/a/*`, `/healthz` to the Worker (API + viewer); `not_found_handling = "single-page-application"` for client-side routing.
- **`scripts/prep-edge-assets.mjs`**: after the web build, writes `index.html` (the Workers SPA fallback) and drops the Pages-only `_redirects` catch-all — on Workers that catch-all also rewrites `/assets/*` to HTML, so the SPA never boots.
- **`package.json`**: `build:web` (build apps/web + prep) and `deploy` scripts.
- **`DEPLOY.md`**: documents the SPA-on-Worker flow; drops the stale in-process-realtime note (the ArtifactRoom DO landed in #74).

No `worker.ts` change — the existing API/viewer routes are unchanged; routing is config-only.

### Verified live in a real browser (deployed worker, real D1)
7/7: SPA boots from the worker, signup → app, login form gone, **authed API call with the session cookie (200)**, session persists across reload, login with an existing account, wrong password rejected. Plus routing smoke: `/` + `/login` serve the SPA, `/healthz` + `/a/:ref` hit the Worker, `/assets/*` serve as JS.

> Deploy needs the SPA built first: `pnpm --filter @dock/api build:web && wrangler deploy` (or `pnpm --filter @dock/api deploy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)