### PR TITLE
perf(web): Tier 2 — persistent shell + view transitions + pending skeletons

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@tanstack/react-router"
+import { Link, useNavigate } from "@tanstack/react-router"
 import { type ReactNode, useCallback, useEffect, useState } from "react"
 import { api, type Collection, type Workspaces } from "@/api"
 import { Button } from "@/components/ui/button"
@@ -10,6 +10,7 @@ import { CommandPalette } from "./command-palette"
 import { Icon } from "./icons"
 import { NavRail } from "./nav-rail"
 import { Logo } from "./shared/logo"
+import { CenteredSpinner } from "./shared/spinner"
 import { ShellCtx, type ShellValue, type Summary } from "./shell-context"
 
 const COLLAPSE_KEY = STORAGE_KEYS.navCollapsed
@@ -18,14 +19,9 @@ const COLLAPSE_KEY = STORAGE_KEYS.navCollapsed
 // bell right) over [nav rail | page]. Owns the rail collapse state (collapsed by
 // default) and fetches the nav data (summary, collections, workspaces) once, so
 // the rail + pod behave identically on every page.
-export function AppShell({
-  children,
-  topBarActions,
-}: {
-  children: ReactNode
-  topBarActions?: ReactNode
-}) {
-  const { me } = useAuth()
+export function AppShell({ children }: { children: ReactNode }) {
+  const { me, loading } = useAuth()
+  const nav = useNavigate()
   const isMobile = useIsMobile()
 
   const [collapsed, setCollapsed] = useState<boolean>(() => {
@@ -41,6 +37,14 @@ export function AppShell({
   const [summary, setSummary] = useState<Summary | null>(null)
   const [collections, setCollections] = useState<Collection[]>([])
   const [workspaces, setWorkspaces] = useState<Workspaces | null>(null)
+  // The top bar's right region; a page portals its actions here (see useShell).
+  const [topBarSlot, setTopBarSlot] = useState<HTMLElement | null>(null)
+
+  // Auth gate for the whole authed app (this shell wraps every non-login route):
+  // bounce to /login once we know there's no session.
+  useEffect(() => {
+    if (!loading && !me) nav({ to: "/login" })
+  }, [loading, me, nav])
 
   useEffect(() => {
     try {
@@ -127,7 +131,12 @@ export function AppShell({
     refreshCollections,
     switchWorkspace,
     createWorkspace,
+    topBarSlot,
   }
+
+  // Until the session resolves, hold the frame rather than flashing the rail
+  // (and the redirect above handles the signed-out case).
+  if (loading || !me) return <CenteredSpinner />
 
   return (
     <ShellCtx.Provider value={value}>
@@ -147,7 +156,7 @@ export function AppShell({
             <Logo />
             <span className="font-display text-lg font-semibold">Dock</span>
           </Link>
-          {topBarActions && <div className="ml-auto flex items-center gap-2">{topBarActions}</div>}
+          <div ref={setTopBarSlot} className="ml-auto flex items-center gap-2" />
         </header>
 
         <div className="flex min-h-0 flex-1">

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from "@tanstack/react-router"
+import { Link, useNavigate, useRouterState } from "@tanstack/react-router"
 import { type ReactNode, useCallback, useEffect, useState } from "react"
 import { api, type Collection, type Workspaces } from "@/api"
 import { Button } from "@/components/ui/button"
@@ -84,13 +84,25 @@ export function AppShell({ children }: { children: ReactNode }) {
       .then(setWorkspaces)
       .catch(() => {})
   }, [])
+  // Workspaces only change via create/switch, which both hard-reload the page —
+  // so they can't go stale mid-session. Fetch once.
+  useEffect(() => {
+    if (me) refreshWorkspaces()
+  }, [me, refreshWorkspaces])
+
+  // Summary (rail counts) + collections refresh on every route change. The shell
+  // is mounted once now (it no longer remounts per nav), so without this the
+  // counts would freeze at their mount-time values after a publish / favorite /
+  // collection edit. Keyed to the pathname, so in-page filter changes (search,
+  // tag) on the library don't trigger a refetch.
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathname is an intentional re-run trigger — the effect refetches on every route change, even though its body doesn't read pathname.
   useEffect(() => {
     if (me) {
       refreshSummary()
       refreshCollections()
-      refreshWorkspaces()
     }
-  }, [me, refreshSummary, refreshCollections, refreshWorkspaces])
+  }, [me, pathname, refreshSummary, refreshCollections])
 
   // Switching/creating a workspace swaps the whole content context, so reload the
   // page rather than re-thread every list (a deliberate, infrequent action).

--- a/apps/web/src/components/shared/route-skeleton.tsx
+++ b/apps/web/src/components/shared/route-skeleton.tsx
@@ -1,0 +1,13 @@
+// Router-level pending placeholder. Shown in the content area (the persistent
+// rail + top bar stay put) when a route's loader runs longer than
+// defaultPendingMs, so a slow nav shows a shaped shimmer instead of a blank
+// flash or a frozen previous page. Deliberately content-agnostic — a heading
+// line over a filling panel reads fine for both a document and a list.
+export function RouteSkeleton() {
+  return (
+    <div className="flex flex-1 flex-col gap-3 p-5.5" aria-hidden>
+      <div className="h-7 w-44 animate-pulse rounded-md bg-muted" />
+      <div className="flex-1 animate-pulse rounded-lg border border-border bg-card" />
+    </div>
+  )
+}

--- a/apps/web/src/components/shell-context.ts
+++ b/apps/web/src/components/shell-context.ts
@@ -26,6 +26,10 @@ export interface ShellValue {
   refreshCollections: () => void
   switchWorkspace: (id: string) => void
   createWorkspace: (name: string) => void
+  // The top bar's right-side region. AppShell is mounted once around the router
+  // Outlet, so a page can't pass top-bar actions as a prop — it portals them
+  // into this slot instead (null until the bar has mounted).
+  topBarSlot: HTMLElement | null
 }
 
 export const ShellCtx = createContext<ShellValue | null>(null)

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -1,13 +1,14 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate, useParams } from "@tanstack/react-router"
 import { useCallback, useEffect, useRef, useState } from "react"
+import { createPortal } from "react-dom"
 import { API_BASE, api, type Comment, type Diff, type Mention } from "@/api"
 import { useIsMobile, useToast } from "@/components"
-import { AppShell } from "@/components/app-shell"
 import { Icon } from "@/components/icons"
 import { ReviewOverlay } from "@/components/review"
 import { ShareButton } from "@/components/ShareDialog"
 import { Spinner } from "@/components/shared/spinner"
+import { useShell } from "@/components/shell-context"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -48,6 +49,9 @@ export function Artifact() {
   const nav = useNavigate()
   const { toast, show } = useToast()
   const isMobile = useIsMobile()
+  // The persistent shell exposes its top-bar region; this page's header actions
+  // are portaled into it (the shell is mounted once, above the route Outlet).
+  const { topBarSlot } = useShell()
 
   // Artifact metadata + comments come from React Query, so the route loader's
   // intent preload (ensureQueryData) warms exactly what we render here — the
@@ -323,67 +327,61 @@ export function Artifact() {
 
   if (failed)
     return (
-      <AppShell>
-        <div className="grid h-full place-items-center gap-2.5">
-          <div className="text-muted-foreground">Artifact not found, or you don't have access.</div>
-          <Button
-            variant="outline"
-            data-testid="artifact-notfound-back"
-            onClick={() => nav({ to: "/" })}
-          >
-            Back to library
-          </Button>
-        </div>
-      </AppShell>
+      <div className="grid h-full place-items-center gap-2.5">
+        <div className="text-muted-foreground">Artifact not found, or you don't have access.</div>
+        <Button
+          variant="outline"
+          data-testid="artifact-notfound-back"
+          onClick={() => nav({ to: "/" })}
+        >
+          Back to library
+        </Button>
+      </div>
     )
   if (!art)
     return (
-      <AppShell>
-        <div className="grid h-full place-items-center">
-          <Spinner />
-        </div>
-      </AppShell>
+      <div className="grid h-full place-items-center">
+        <Spinner />
+      </div>
     )
 
   // Removed artifacts show a tombstone instead of the document — content is
   // gone (the server 410s the raw routes), but an owner can still reinstate.
   if (art.removed)
     return (
-      <AppShell>
-        <div className="grid h-full place-items-center gap-3 text-center">
-          <Icon name="removed" size={40} className="opacity-55" />
-          <div className="text-lg font-semibold">This artifact was removed</div>
-          <div className="max-w-[360px] text-sm leading-relaxed text-muted-foreground">
-            It was taken down by a moderator and is no longer available.
-          </div>
-          <div className="flex gap-2">
-            {art.my_role === "owner" && (
-              <Button
-                variant="outline"
-                data-testid="artifact-reinstate"
-                onClick={async () => {
-                  try {
-                    await api.reinstate(shortId)
-                    show("Reinstated")
-                    load()
-                  } catch (e) {
-                    show((e as Error).message)
-                  }
-                }}
-              >
-                Reinstate
-              </Button>
-            )}
+      <div className="grid h-full place-items-center gap-3 text-center">
+        <Icon name="removed" size={40} className="opacity-55" />
+        <div className="text-lg font-semibold">This artifact was removed</div>
+        <div className="max-w-[360px] text-sm leading-relaxed text-muted-foreground">
+          It was taken down by a moderator and is no longer available.
+        </div>
+        <div className="flex gap-2">
+          {art.my_role === "owner" && (
             <Button
               variant="outline"
-              data-testid="artifact-removed-back"
-              onClick={() => nav({ to: "/" })}
+              data-testid="artifact-reinstate"
+              onClick={async () => {
+                try {
+                  await api.reinstate(shortId)
+                  show("Reinstated")
+                  load()
+                } catch (e) {
+                  show((e as Error).message)
+                }
+              }}
             >
-              Back to library
+              Reinstate
             </Button>
-          </div>
+          )}
+          <Button
+            variant="outline"
+            data-testid="artifact-removed-back"
+            onClick={() => nav({ to: "/" })}
+          >
+            Back to library
+          </Button>
         </div>
-      </AppShell>
+      </div>
     )
 
   const shown = version ?? art.current_version
@@ -536,99 +534,103 @@ export function Artifact() {
   const asideWidth = isMobile ? 0 : panel === "open" ? 340 : panel === "rail" ? 50 : 0
 
   return (
-    <AppShell
-      topBarActions={
-        <>
-          {!isMobile && <Presence viewers={viewers} self={me?.name ?? me?.email ?? ""} />}
-          <StarButton
-            shortId={shortId}
-            favorite={!!art.favorite}
-            onChange={(fav) =>
-              qc.setQueryData(artifactQuery(shortId).queryKey, (a) =>
-                a ? { ...a, favorite: fav } : a,
-              )
-            }
-          />
-          <TagsMenu
-            shortId={shortId}
-            tags={art.tags ?? []}
-            canEdit={art.my_role === "editor" || art.my_role === "owner"}
-            onChange={(tags) =>
-              qc.setQueryData(artifactQuery(shortId).queryKey, (a) => (a ? { ...a, tags } : a))
-            }
-          />
-          <CollectionsMenu
-            shortId={shortId}
-            inCollections={art.collections ?? []}
-            onChange={(collections) =>
-              qc.setQueryData(artifactQuery(shortId).queryKey, (a) =>
-                a ? { ...a, collections } : a,
-              )
-            }
-          />
-          <ShareButton shortId={shortId} myRole={art.my_role} />
-          <ReportButton shortId={shortId} onDone={show} />
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
+    <>
+      {topBarSlot &&
+        createPortal(
+          <>
+            {!isMobile && <Presence viewers={viewers} self={me?.name ?? me?.email ?? ""} />}
+            <StarButton
+              shortId={shortId}
+              favorite={!!art.favorite}
+              onChange={(fav) =>
+                qc.setQueryData(artifactQuery(shortId).queryKey, (a) =>
+                  a ? { ...a, favorite: fav } : a,
+                )
+              }
+            />
+            <TagsMenu
+              shortId={shortId}
+              tags={art.tags ?? []}
+              canEdit={art.my_role === "editor" || art.my_role === "owner"}
+              onChange={(tags) =>
+                qc.setQueryData(artifactQuery(shortId).queryKey, (a) => (a ? { ...a, tags } : a))
+              }
+            />
+            <CollectionsMenu
+              shortId={shortId}
+              inCollections={art.collections ?? []}
+              onChange={(collections) =>
+                qc.setQueryData(artifactQuery(shortId).queryKey, (a) =>
+                  a ? { ...a, collections } : a,
+                )
+              }
+            />
+            <ShareButton shortId={shortId} myRole={art.my_role} />
+            <ReportButton shortId={shortId} onDone={show} />
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  title="More"
+                  data-testid="artifact-more"
+                  className={cn(
+                    art.open_proposals && art.open_proposals > 0 && "border-primary text-primary",
+                  )}
+                >
+                  <Icon name="more" size={18} />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem
+                  data-testid="artifact-insights"
+                  onSelect={() => setSurface("insights")}
+                >
+                  <Icon name="insights" size={16} /> Insights
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  data-testid="artifact-history"
+                  onSelect={() => setSurface("history")}
+                >
+                  <Icon name="history" size={16} /> Version history
+                </DropdownMenuItem>
+                {!!art.proposals_total && art.proposals_total > 0 && (
+                  <DropdownMenuItem
+                    data-testid="artifact-review"
+                    onSelect={() => setReviewing(true)}
+                  >
+                    <Icon name="review" size={16} />
+                    {art.open_proposals && art.open_proposals > 0
+                      ? `Review proposals (${art.open_proposals})`
+                      : "Proposals"}
+                  </DropdownMenuItem>
+                )}
+                {editable && canPropose && !editing && (
+                  <DropdownMenuItem data-testid="artifact-edit" onSelect={startEdit}>
+                    <Icon name="edit" size={16} />
+                    {canPublish ? "Edit source (dev)" : "Propose change (dev)"}
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+            {/* On phones the bottom-right FAB opens comments, so the header
+                button would just be a redundant extra wrap-row. */}
+            {!isMobile && panel !== "open" && (
               <Button
                 variant="outline"
-                size="icon"
-                title="More"
-                data-testid="artifact-more"
-                className={cn(
-                  art.open_proposals && art.open_proposals > 0 && "border-primary text-primary",
-                )}
+                size="sm"
+                className="gap-1.5"
+                data-testid="artifact-show-comments"
+                onClick={() => setPanel("open")}
+                title="Show comments (c)"
               >
-                <Icon name="more" size={18} />
+                <Icon name="comments" size={16} />
+                {openCount > 0 && <b className="font-bold">{openCount}</b>}
               </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <DropdownMenuItem
-                data-testid="artifact-insights"
-                onSelect={() => setSurface("insights")}
-              >
-                <Icon name="insights" size={16} /> Insights
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                data-testid="artifact-history"
-                onSelect={() => setSurface("history")}
-              >
-                <Icon name="history" size={16} /> Version history
-              </DropdownMenuItem>
-              {!!art.proposals_total && art.proposals_total > 0 && (
-                <DropdownMenuItem data-testid="artifact-review" onSelect={() => setReviewing(true)}>
-                  <Icon name="review" size={16} />
-                  {art.open_proposals && art.open_proposals > 0
-                    ? `Review proposals (${art.open_proposals})`
-                    : "Proposals"}
-                </DropdownMenuItem>
-              )}
-              {editable && canPropose && !editing && (
-                <DropdownMenuItem data-testid="artifact-edit" onSelect={startEdit}>
-                  <Icon name="edit" size={16} />
-                  {canPublish ? "Edit source (dev)" : "Propose change (dev)"}
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-          {/* On phones the bottom-right FAB opens comments, so the header
-                button would just be a redundant extra wrap-row. */}
-          {!isMobile && panel !== "open" && (
-            <Button
-              variant="outline"
-              size="sm"
-              className="gap-1.5"
-              data-testid="artifact-show-comments"
-              onClick={() => setPanel("open")}
-              title="Show comments (c)"
-            >
-              <Icon name="comments" size={16} />
-              {openCount > 0 && <b className="font-bold">{openCount}</b>}
-            </Button>
-          )}
-        </>
-      }
-    >
+            )}
+          </>,
+          topBarSlot,
+        )}
       <ActionsCtx.Provider value={actions}>
         {reviewing && (
           <ReviewOverlay
@@ -908,6 +910,6 @@ export function Artifact() {
         )}
         {toast}
       </ActionsCtx.Provider>
-    </AppShell>
+    </>
   )
 }

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -2,16 +2,14 @@ import { useNavigate, useSearch } from "@tanstack/react-router"
 import { Plus, X } from "lucide-react"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { type Artifact, api } from "@/api"
-import { AppShell } from "@/components/app-shell"
 import { Icon } from "@/components/icons"
 import { EmptyState } from "@/components/shared/empty-state"
-import { CenteredSpinner, Spinner } from "@/components/shared/spinner"
+import { Spinner } from "@/components/shared/spinner"
 import { useShell } from "@/components/shell-context"
 import { useToast } from "@/components/toast"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
-import { useAuth } from "@/ctx"
 import { usePrefetchArtifact } from "@/lib/use-prefetch-artifact"
 import { ArtifactCard } from "./artifact-card"
 import { CollectionBar } from "./collection-bar"
@@ -20,21 +18,12 @@ import type { Filter } from "./types"
 
 const PAGE = 30
 
-// Route component for "/". Auth-gates, then renders the library inside the app
-// shell (which owns the nav rail + pod). The filter lives in the URL, so the body
-// reads it from search rather than local state.
+// Route component for "/". The persistent AppShell (mounted once around the
+// router Outlet) owns the rail/pod and the auth gate, so this just renders the
+// library body. The filter lives in the URL, so the body reads it from search
+// rather than local state.
 export function Library() {
-  const { me, loading } = useAuth()
-  const nav = useNavigate()
-  useEffect(() => {
-    if (!loading && !me) nav({ to: "/login" })
-  }, [loading, me, nav])
-  if (!me) return <CenteredSpinner />
-  return (
-    <AppShell>
-      <LibraryBody />
-    </AppShell>
-  )
+  return <LibraryBody />
 }
 
 function LibraryBody() {

--- a/apps/web/src/pages/settings/index.tsx
+++ b/apps/web/src/pages/settings/index.tsx
@@ -1,9 +1,6 @@
-import { useNavigate } from "@tanstack/react-router"
 import { useCallback, useEffect, useState } from "react"
 import { api, type Report } from "@/api"
 import { useToast } from "@/components"
-import { AppShell } from "@/components/app-shell"
-import { CenteredSpinner } from "@/components/shared/spinner"
 import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useAuth } from "@/ctx"
@@ -13,15 +10,12 @@ import { WebhooksSection } from "./webhooks-section"
 import { WorkspaceSection } from "./workspace-section"
 
 export function Settings() {
-  const { me, loading } = useAuth()
-  const nav = useNavigate()
+  // AppShell (mounted once around the Outlet) gates auth, so `me` is present
+  // whenever Settings renders.
+  const { me } = useAuth()
   const { toast, show } = useToast()
   const [reports, setReports] = useState<Report[] | null>(null)
   const [tab, setTab] = useState("workspace")
-
-  useEffect(() => {
-    if (!loading && !me) nav({ to: "/login" })
-  }, [loading, me, nav])
 
   const loadReports = useCallback(
     () =>
@@ -41,14 +35,14 @@ export function Settings() {
     if ((reports?.length ?? 0) === 0 && tab === "reports") setTab("workspace")
   }, [reports, tab])
 
-  if (!me) return <CenteredSpinner />
+  if (!me) return null
 
   // Reports are urgent + owner-only — surface a tab only when there are open ones.
   const openReports = reports ?? []
   const hasReports = openReports.length > 0
 
   return (
-    <AppShell>
+    <>
       <div className="flex-1 overflow-y-auto">
         <main className="mx-auto max-w-3xl px-5 pb-16 pt-7">
           <h1 className="font-display text-2xl font-semibold">Settings</h1>
@@ -95,6 +89,6 @@ export function Settings() {
         </main>
       </div>
       {toast}
-    </AppShell>
+    </>
   )
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,4 +1,5 @@
 import { createRouter } from "@tanstack/react-router"
+import { RouteSkeleton } from "./components/shared/route-skeleton"
 import { queryClient } from "./lib/query-client"
 import { routeTree } from "./routeTree.gen"
 
@@ -13,6 +14,19 @@ export function getRouter() {
     // means an intent hover always reaches the loader, which dedupes through the
     // query client (so it's a cache read, not a refetch, within staleTime).
     defaultPreloadStaleTime: 0,
+    // Debounce intent so a pointer brushing past a link doesn't fire the loader;
+    // ~65ms is below the time it takes to settle on a target you actually want.
+    defaultPreloadDelay: 65,
+    // Cross-fade route changes. The rail/top bar are mounted once above the
+    // Outlet, so only the content visibly morphs. No-ops where the View
+    // Transitions API is unavailable.
+    defaultViewTransition: true,
+    // Perceived-perf: hold the current page for 150ms before showing a skeleton
+    // (most cache-warm navs resolve first, so nothing flashes), and once shown
+    // keep it at least 300ms so a just-too-slow load doesn't strobe.
+    defaultPendingMs: 150,
+    defaultPendingMinMs: 300,
+    defaultPendingComponent: RouteSkeleton,
     context: { queryClient },
   })
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,7 +1,14 @@
 import type { QueryClient } from "@tanstack/react-query"
 import { QueryClientProvider } from "@tanstack/react-query"
-import { createRootRouteWithContext, HeadContent, Outlet, Scripts } from "@tanstack/react-router"
+import {
+  createRootRouteWithContext,
+  HeadContent,
+  Outlet,
+  Scripts,
+  useRouterState,
+} from "@tanstack/react-router"
 import { type ReactNode, useEffect } from "react"
+import { AppShell } from "../components/app-shell"
 import { AuthProvider, ThemeProvider } from "../ctx"
 import { queryClient } from "../lib/query-client"
 import { reportWebVitals } from "../lib/vitals"
@@ -27,13 +34,15 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
 })
 
 function RootComponent() {
-  // Report web vitals to the console for before/after perf numbers. react-scan
-  // (flags wasted re-renders) is opt-in via VITE_REACT_SCAN — its overlay
-  // intercepts pointer events, so it must stay off by default in dev and under
-  // e2e. Dev-only + dynamic import: dead-code-eliminated from the prod build.
+  // Dev-only perf instrumentation. web-vitals logs to the console for before/
+  // after numbers (dev only — no prod console noise; Tier 5 adds a real beacon).
+  // react-scan (flags wasted re-renders) is further gated behind VITE_REACT_SCAN
+  // because its overlay intercepts pointer events. Both dynamic/dev-gated, so
+  // they're dead-code-eliminated from the prod build.
   useEffect(() => {
+    if (!import.meta.env.DEV) return
     reportWebVitals()
-    if (import.meta.env.DEV && import.meta.env.VITE_REACT_SCAN) {
+    if (import.meta.env.VITE_REACT_SCAN) {
       import("react-scan").then(({ scan }) => scan({ enabled: true })).catch(() => {})
     }
   }, [])
@@ -42,11 +51,25 @@ function RootComponent() {
       <QueryClientProvider client={queryClient}>
         <ThemeProvider>
           <AuthProvider>
-            <Outlet />
+            <AppFrame />
           </AuthProvider>
         </ThemeProvider>
       </QueryClientProvider>
     </RootDocument>
+  )
+}
+
+// AppShell (persistent rail + top bar) wraps every authed route's Outlet and is
+// mounted once here, so navigating between pages morphs only the content — the
+// rail never remounts. /login is the one chrome-less route.
+function AppFrame() {
+  const isLogin = useRouterState({ select: (s) => s.location.pathname === "/login" })
+  return isLogin ? (
+    <Outlet />
+  ) : (
+    <AppShell>
+      <Outlet />
+    </AppShell>
   )
 }
 


### PR DESCRIPTION
## Tier 2 of the performance roadmap

Make every transition feel intentional, never blank — and stop the rail from remounting on each navigation.

### Persistent shell (the foundation)
- AppShell is mounted **once** around the router Outlet (`__root`), instead of each page wrapping itself. The rail + top bar now persist across navigations, so only the content morphs. Verified live: the rail DOM node survives multiple route changes (it would be discarded on a remount).
- Auth-gating consolidates into AppShell (one place, not three). `/login` is the one chrome-less route.
- Pages (library, settings, artifact) drop their own `<AppShell>`. The artifact's header actions **portal** into a top-bar slot the shell exposes via `ShellCtx` (a page can't pass props to a shell it no longer renders).

### Perceived-perf
- `defaultViewTransition` — cross-fade on route change. The rail/top bar live above the Outlet, so they don't flicker; only content cross-fades. No-op where the View Transitions API is absent.
- `defaultPendingMs: 150` + `defaultPendingMinMs: 300` with a content-area `RouteSkeleton` — a slow nav shows a shaped shimmer (rail intact), not a blank flash or a frozen previous page.
- `defaultPreloadDelay: 65` — a pointer brushing past a link no longer fires the loader.

### Cleanup
- web-vitals reporting is now **dev-only** (no prod console noise; Tier 5 adds a real beacon). react-scan stays opt-in via `VITE_REACT_SCAN`.

### Verification
- `tsc` clean · `biome ci` + token/frontend/testid/api/knip guards green · **29/29 Playwright e2e**.
- Live: signed up, published, navigated artifact↔library repeatedly — rail persisted (same node), top-bar actions portaled correctly, **no console errors, no stuck view-transition overlay**.

Builds on #82 (Tier 1, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)