### PR TITLE
fix(web): float comment button on selection + single-control publish card

### DIFF
--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -79,6 +79,8 @@ export function Artifact() {
     top: number
     vTop: number
     vBottom: number
+    vLeft: number
+    vRight: number
   } | null>(null)
   const [composer, setComposer] = useState<{ anchor: Sel | null; top: number | null } | null>(null)
   const [activeThread, setActiveThread] = useState<string | null>(null)
@@ -110,12 +112,18 @@ export function Artifact() {
       if (d.source !== "dock") return
       if (d.type === "select") {
         if (d.selector && d.rect) {
-          const ft = frame.current?.getBoundingClientRect().top ?? 0
+          const fr = frame.current?.getBoundingClientRect()
+          const ft = fr?.top ?? 0
+          const fl = fr?.left ?? 0
           setSel({
             selector: d.selector,
             top: d.rect.top,
             vTop: ft + d.rect.top,
             vBottom: ft + d.rect.bottom,
+            // left/right are sent by the current anchor client; guard against a
+            // stale-cached client posting only top/bottom so we never get NaN.
+            vLeft: fl + (d.rect.left ?? 0),
+            vRight: fl + (d.rect.right ?? d.rect.left ?? 0),
           })
         } else setSel(null)
       } else if (d.type === "anchors-resolved") setInDoc(d.resolved ?? {})
@@ -890,7 +898,7 @@ export function Artifact() {
         {docLive && sel && !composer && (
           <button
             type="button"
-            className="fixed z-50 inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-primary bg-card px-2.5 py-1.5 text-xs font-semibold text-primary shadow-[var(--shadow)] transition-colors hover:bg-primary hover:text-primary-foreground"
+            className="fixed z-50 inline-flex items-center gap-2 whitespace-nowrap rounded-full border border-primary bg-card px-3.5 py-2 text-sm font-semibold text-primary shadow-[var(--shadow)] transition-colors hover:bg-primary hover:text-primary-foreground"
             title="Comment on the selection"
             data-testid="comment-on-selection"
             onMouseDown={(e) => e.preventDefault()}
@@ -899,11 +907,18 @@ export function Artifact() {
               startSelComment()
             }}
             style={{
-              top: clamp((sel.vTop + sel.vBottom) / 2 - 15, 64, window.innerHeight - 46),
-              right: asideWidth + 12,
+              // Float just above the selection, horizontally centered on it, so it
+              // lands where the user is actually reading. Clamp into the document
+              // column (left of the aside) and below the top header.
+              top: clamp(sel.vTop - 44, 64, window.innerHeight - 52),
+              left: clamp(
+                (sel.vLeft + sel.vRight) / 2 - 60,
+                12,
+                window.innerWidth - asideWidth - 132,
+              ),
             }}
           >
-            <Icon name="comments" size={14} /> Comment
+            <Icon name="comments" size={16} /> Comment
           </button>
         )}
         {toast}

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -13,6 +13,7 @@ import { Card } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { useAuth } from "@/ctx"
 import { usePrefetchArtifact } from "@/lib/use-prefetch-artifact"
+import { cn } from "@/lib/utils"
 import { ArtifactCard } from "./artifact-card"
 import { CollectionBar } from "./collection-bar"
 import { ShareCollectionDialog } from "./share-collection-dialog"
@@ -50,6 +51,7 @@ function LibraryBody() {
   const [fetching, setFetching] = useState(true)
   const [more, setMore] = useState(false)
   const [busy, setBusy] = useState(false)
+  const [dragging, setDragging] = useState(false)
   const [shareCol, setShareCol] = useState<(typeof collections)[number] | null>(null)
   const [query, setQuery] = useState(search.q ?? "")
   const [debouncedQ, setDebouncedQ] = useState((search.q ?? "").trim())
@@ -102,12 +104,8 @@ function LibraryBody() {
     load()
   }, [load])
 
-  const publish = async () => {
-    const f = file.current?.files?.[0]
-    if (!f) {
-      file.current?.click()
-      return
-    }
+  // One publish path, fed by either a drag-drop or the native picker.
+  const publishFile = async (f: File) => {
     setBusy(true)
     try {
       const a = await api.publish(f, { title: f.name.replace(/\.[^.]+$/, "") })
@@ -117,6 +115,8 @@ function LibraryBody() {
       setBusy(false)
     }
   }
+  // The "Publish" button opens the OS picker; choosing a file uploads immediately.
+  const pickFile = () => file.current?.click()
 
   // Star toggle is optimistic; in the Favorites view an un-star drops the card.
   const toggleFav = async (a: Artifact) => {
@@ -211,11 +211,29 @@ function LibraryBody() {
         </div>
 
         {filter.kind !== "collection" && (
-          <Card className="mb-5.5 flex flex-wrap items-center gap-3.5 p-4">
+          // The whole card is the drop target; the button opens the picker. One
+          // affordance each — no stray native "Browse… no file selected" input.
+          <Card
+            className={cn(
+              "mb-5.5 flex flex-wrap items-center gap-3.5 border-dashed p-4 transition-colors",
+              dragging && "border-primary bg-primary/5",
+            )}
+            onDragOver={(e) => {
+              e.preventDefault()
+              if (!dragging) setDragging(true)
+            }}
+            onDragLeave={() => setDragging(false)}
+            onDrop={(e) => {
+              e.preventDefault()
+              setDragging(false)
+              const f = e.dataTransfer.files?.[0]
+              if (f) publishFile(f)
+            }}
+          >
             <div className="min-w-[220px] flex-1">
               <div className="font-display text-lg font-semibold">Publish an artifact</div>
               <div className="text-sm text-muted-foreground">
-                Drop an HTML or Markdown file, or run{" "}
+                Drop an HTML or Markdown file here, or run{" "}
                 <code className="rounded bg-muted px-1.5 py-px font-mono text-[0.86em]">
                   dock publish
                 </code>
@@ -227,13 +245,16 @@ function LibraryBody() {
               type="file"
               data-testid="library-file-input"
               accept=".html,.htm,.md,.markdown,.zip"
-              className="max-w-[230px] text-sm text-muted-foreground"
-              onChange={publish}
+              className="hidden"
+              onChange={(e) => {
+                const f = e.target.files?.[0]
+                if (f) publishFile(f)
+              }}
             />
             <Button
               variant="primary"
               data-testid="library-publish"
-              onClick={publish}
+              onClick={pickFile}
               disabled={busy}
             >
               {busy ? (

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -68,7 +68,7 @@ function emitSelection(){
   if(!t||t.length<2){post({type:"select",selector:null,rect:null});return}
   var ctx=(s.anchorNode&&s.anchorNode.textContent)||t,i=ctx.indexOf(t);
   var rect=null;try{var r=s.getRangeAt(0).getBoundingClientRect();
-    if(r&&(r.height||r.width))rect={top:r.top,bottom:r.bottom}}catch(_){}
+    if(r&&(r.height||r.width))rect={top:r.top,bottom:r.bottom,left:r.left,right:r.right}}catch(_){}
   post({type:"select",rect:rect,selector:{type:"TextQuoteSelector",exact:t,
     prefix:i>=0?ctx.slice(Math.max(0,i-24),i):"",
     suffix:i>=0?ctx.slice(i+t.length,i+t.length+24):""}})}


### PR DESCRIPTION
Two UX-polish fixes on the artifact + library surfaces.

## Comment-on-selection button
Was pinned to the right comment-panel edge (`right: asideWidth + 12`), nowhere near where you were reading. Now it floats just above the highlighted text, centered horizontally on the selection (clamped into the document column, below the top header), and is bigger by default (`text-sm`, larger padding, 16px icon).

While wiring this up I found a latent bug: the in-iframe anchor client only posted the selection rect's `top`/`bottom`, never `left`/`right`, so horizontal centering would have been `NaN`. The client now reports `left`/`right`; the host guards against a stale-cached client so it can never produce a NaN position.

## Library publish card
Dropped the redundant raw native file input (the "Browse… no file selected" control) that sat next to the "+ Publish" button. Clicking Publish with nothing selected already opened that same picker, so it was two affordances for one action. Now:
- the native input is hidden; "+ Publish" is the single control and opens the picker (choosing a file uploads immediately)
- the whole card is a real drag-drop zone that highlights on drag, honoring the existing "Drop a file here" copy

## Test plan
- `pnpm -r typecheck` — clean (all packages)
- `biome check` — clean on all three changed files
- Playwright (smoke harness, auto-started stack): published an artifact, selected text in the sandboxed iframe, confirmed the comment button renders on the selection; confirmed the library card shows no native file input. Screenshots captured locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)