### PR TITLE
feat: remove single-workspace mode (always multi-workspace)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,10 +43,11 @@ the bundled SPA when present.
   `DOCK_TOKEN` authorizes CI/agents. `packages/core/src/permissions.ts` is the one
   authorization gate (`can(actor, action, visibility)`); every route resolves an
   `Actor` and asks it.
-- **Workspaces** are keyed by a real `org_id` (never a magic constant). Single-
-  workspace is the self-host default; `DOCK_MULTI_WORKSPACE=true` unlocks
-  create/switch. The active workspace is resolved per request and scopes all
-  workspace data.
+- **Workspaces** are keyed by a real `org_id` (never a magic constant). Every
+  signed-in user owns a personal workspace (provisioned on first login) and can
+  create/switch; the active workspace is resolved per request (cookie → membership
+  → provision) and scopes all workspace data. Collaboration is by per-artifact
+  share or explicit workspace membership.
 - **Realtime** is an in-process pub/sub (`bus.ts`) over SSE, plus ephemeral
   presence. **Webhooks** are an outbox with retries (`webhooks.ts`).
 - **Origin isolation (A4):** artifact bytes (`/raw/*`) can be served from a separate

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -23,7 +23,6 @@ export interface Config {
   superAdmins: string[]
   analytics: boolean
   rateLimit: boolean
-  multiWorkspace: boolean
   sandboxOrigin?: string
   crossSite: boolean
   versionWindowMs?: number
@@ -90,7 +89,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
       .filter(Boolean),
     analytics: env.DOCK_ANALYTICS !== "false",
     rateLimit: env.DOCK_RATE_LIMIT !== "false",
-    multiWorkspace: env.DOCK_MULTI_WORKSPACE === "true",
     sandboxOrigin: env.DOCK_SANDBOX_URL,
     crossSite: env.DOCK_CROSS_SITE === "true",
     versionWindowMs: env.DOCK_VERSION_WINDOW ? Number(env.DOCK_VERSION_WINDOW) * 60_000 : undefined,

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -56,15 +56,9 @@ export interface AppDeps {
   /** Workspace role granted to a member who isn't the first user. Default "editor". */
   defaultRole?: Role
   /**
-   * Enable multiple workspaces: users can create/switch workspaces and each is
-   * scoped by org_id. Off by default (self-host is single-workspace); the hosted
-   * product turns it on. Single mode behaves exactly as before, just keyed by a
-   * real `defaultOrgId` instead of a magic constant.
-   */
-  multiWorkspace?: boolean
-  /**
-   * The org_id of the single/bootstrap workspace. A real, persisted id (never a
-   * magic literal) so flipping on multiWorkspace later is a no-op for the data.
+   * The org_id of the bootstrap workspace: the fallback for anonymous requests.
+   * Every signed-in user gets their own personal workspace on first login. A
+   * real, persisted id, never a magic literal.
    * Defaults to "default" when unset (tests); the Node entry generates + persists
    * one and rekeys any legacy rows onto it.
    */
@@ -132,8 +126,7 @@ export function buildContext(deps: AppDeps) {
   const allowOrigins = new Set(deps.webOrigins ?? [])
   const open = !deps.token
   const defaultRole: Role = deps.defaultRole ?? "editor"
-  const multi = !!deps.multiWorkspace
-  // The single/bootstrap workspace id — always a real value, never a magic
+  // The bootstrap workspace id — always a real value, never a magic
   // literal. The Node entry generates + persists one; tests fall back to this.
   const defaultOrg = deps.defaultOrgId ?? "default"
 
@@ -257,7 +250,6 @@ export function buildContext(deps: AppDeps) {
   // membership), else the user's first workspace, provisioning one if they have none.
   const wsCache = new WeakMap<Context, string>()
   const activeWorkspace = async (c: Context): Promise<string> => {
-    if (!multi) return defaultOrg
     const cached = wsCache.get(c)
     if (cached) return cached
     // An agent acts within its own workspace, never a cookie's.
@@ -299,12 +291,10 @@ export function buildContext(deps: AppDeps) {
     }
     const me = await currentUser(c)
     if (!me) return { kind: "anon", open }
-    // Baseline role = membership in the ARTIFACT's workspace. Single mode keeps
-    // its first-user-owner auto-join; multi mode never auto-joins you into
-    // someone else's workspace just because you opened a shared link.
-    const orgRole = multi
-      ? ((await meta.getMembership(a.org_id, me.id))?.role ?? null)
-      : await ensureMembership(a.org_id, me.id)
+    // Baseline role = membership in the ARTIFACT's workspace. Opening a shared
+    // link never auto-joins you into someone else's workspace; you only carry an
+    // org role where you're explicitly a member.
+    const orgRole = (await meta.getMembership(a.org_id, me.id))?.role ?? null
     const am = await meta.getArtifactMember(a.id, me.id)
     // A collection share grants its role on every artifact in the collection,
     // folded in alongside any per-artifact share (the higher wins).
@@ -364,7 +354,6 @@ export function buildContext(deps: AppDeps) {
     versionWindowMs,
     allowOrigins,
     open,
-    multi,
     defaultOrg,
     defaultRole,
     publishLimiter,

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -74,7 +74,6 @@ const app = createApp({
   analytics: cfg.analytics,
   rateLimit: cfg.rateLimit,
   serveWeb: cfg.serveWeb,
-  multiWorkspace: cfg.multiWorkspace,
   defaultOrgId: defaultOrg,
   // Origin isolation: serve artifact bytes from a separate registrable domain
   // pointed at this same container. Keeps user HTML off the app's cookie origin.
@@ -158,6 +157,6 @@ serve({ fetch: app.fetch, port: cfg.port }, () => {
     meta: cfg.databaseUrl ? "postgres" : `sqlite (${cfg.dataDir})`,
     blobs: cfg.objectStoreUrl ? "S3/R2" : `local disk (${cfg.dataDir})`,
     web: cfg.serveWeb ? "bundled SPA" : "API only",
-    spaces: cfg.multiWorkspace ? "multi-workspace" : `single (org ${defaultOrg})`,
+    spaces: `multi-workspace (bootstrap org ${defaultOrg})`,
   })
 })

--- a/apps/api/src/routes/session.ts
+++ b/apps/api/src/routes/session.ts
@@ -5,14 +5,14 @@ import { fail } from "../lib/http"
 
 /** Session identity + the workspace member/agent directory for the @mention picker. */
 export const sessionRoutes = (ctx: AppContext) => {
-  const { meta, deps, open, multi, bearer, currentUser, ensureMembership, activeWorkspace } = ctx
+  const { meta, deps, open, bearer, currentUser, ensureMembership, activeWorkspace } = ctx
   const app = new Hono()
 
   app.get("/v1/me", async (c) => {
     const u = await currentUser(c)
     if (!u) return fail(c, 401, "unauthenticated")
     const role = await ensureMembership(await activeWorkspace(c), u.id) // provisions on first load
-    return c.json({ user: { ...u, role }, multi })
+    return c.json({ user: { ...u, role }, multi: true })
   })
 
   // Workspace member directory for the @mention picker — people AND agents, so

--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -7,8 +7,7 @@ import { DEFAULT_WORKSPACE_NAME, fail, isWorkspaceRole, readJson } from "../lib/
 /** The workspace itself: name + members (Admin-managed), plus multi-workspace
  *  list / create / switch. A workspace always keeps at least one Admin. */
 export const workspaceRoutes = (ctx: AppContext) => {
-  const { meta, multi, currentUser, activeWorkspace, setWsCookie, workspaceRole, workspaceCan } =
-    ctx
+  const { meta, currentUser, activeWorkspace, setWsCookie, workspaceRole, workspaceCan } = ctx
   const app = new Hono()
 
   // A workspace must always keep at least one Admin, so it stays manageable:
@@ -40,7 +39,7 @@ export const workspaceRoutes = (ctx: AppContext) => {
       id: org,
       name: ws?.name ?? DEFAULT_WORKSPACE_NAME,
       role,
-      multi,
+      multi: true,
       members: members.map((m) => memberJson(m, dir)),
     })
   })
@@ -125,25 +124,24 @@ export const workspaceRoutes = (ctx: AppContext) => {
     if (role === null) return fail(c, 401, "unauthenticated")
     const active = await activeWorkspace(c)
     const me = await currentUser(c)
-    if (!multi || !me) {
+    if (!me) {
       const ws = await meta.getWorkspace(active)
       return c.json({
-        multi,
+        multi: true,
         active,
         workspaces: [{ id: active, name: ws?.name ?? DEFAULT_WORKSPACE_NAME, role }],
       })
     }
     const mine = await meta.listWorkspaces(me.id)
     return c.json({
-      multi,
+      multi: true,
       active,
       workspaces: mine.map((w) => ({ id: w.id, name: w.name, role: w.role })),
     })
   })
 
-  // Create a workspace (multi only). The creator becomes its Admin and is switched in.
+  // Create a workspace. The creator becomes its Admin and is switched in.
   app.post("/v1/workspaces", async (c) => {
-    if (!multi) return fail(c, 403, "multi-workspace is disabled")
     const me = await currentUser(c)
     if (!me) return fail(c, 401, "unauthenticated")
     const b = await readJson(
@@ -159,9 +157,8 @@ export const workspaceRoutes = (ctx: AppContext) => {
     return c.json({ id, name, role: "owner" }, 201)
   })
 
-  // Switch the active workspace (multi only). Must be a member.
+  // Switch the active workspace. Must be a member.
   app.post("/v1/workspace/switch", async (c) => {
-    if (!multi) return fail(c, 403, "multi-workspace is disabled")
     const me = await currentUser(c)
     if (!me) return fail(c, 401, "unauthenticated")
     const b = await readJson(c, z.object({}).catchall(z.unknown()))

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -35,7 +35,6 @@ export interface Env {
   ROOMS: DurableObjectNamespace
   BASE_URL?: string
   DOCK_AUTH_SECRET?: string
-  DOCK_MULTI_WORKSPACE?: string
   DOCK_SUPERADMIN_EMAILS?: string
 }
 
@@ -67,7 +66,6 @@ export default {
           .split(",")
           .map((s) => s.trim().toLowerCase())
           .filter(Boolean),
-        multiWorkspace: env.DOCK_MULTI_WORKSPACE === "true",
         defaultOrgId: "default",
       })
     }

--- a/apps/api/test/helpers.ts
+++ b/apps/api/test/helpers.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import type { MetaStore } from "@dock/core"
+import type { MetaStore, Role } from "@dock/core"
 import { PgMetaStore } from "@dock/db/pg"
 import { SqliteMetaStore } from "@dock/db/sqlite"
 import { FsBlobStore } from "@dock/storage/fs"
@@ -9,6 +9,7 @@ import Database from "better-sqlite3"
 import { Pool } from "pg"
 import { afterAll } from "vitest"
 import { type AppDeps, createApp } from "../src/app"
+import { DEFAULT_WORKSPACE_NAME } from "../src/lib/http"
 
 export const dir = mkdtempSync(join(tmpdir(), "dock-test-"))
 
@@ -22,6 +23,8 @@ if (process.env.DOCK_TEST_DB === "pg" && !PG_URL)
   throw new Error("DOCK_TEST_DB=pg requires TEST_DATABASE_URL to be set")
 
 type TestStore = MetaStore & { close(): unknown }
+// A seat in the shared test workspace: who, at what role.
+type Seat = { user_id: string; role: Role }
 
 // Postgres has no file-per-store isolation like SQLite, so each named store gets
 // its own schema (search_path), dropped + recreated on first use in this process.
@@ -32,7 +35,7 @@ const pgSchemas = new Set<string>()
 const schemaFor = (name: string) =>
   `t_${process.pid}_${name.replace(/[^a-z0-9]+/gi, "_").toLowerCase()}`
 
-const makePgStore = (name: string, users: TestUser[]): TestStore => {
+const makePgStore = (name: string, users: TestUser[], team: Seat[]): TestStore => {
   const base = PG_URL as string
   const schema = schemaFor(name)
   const ready = (async (): Promise<TestStore> => {
@@ -59,7 +62,20 @@ const makePgStore = (name: string, users: TestUser[]): TestStore => {
     // Encode the search_path manually: URLSearchParams emits `+` for spaces, which
     // node-postgres decodeURIComponent's back to `+` (not a space) → invalid options.
     const opt = encodeURIComponent(`-c search_path=${schema}`)
-    return PgMetaStore.create(`${base}${base.includes("?") ? "&" : "?"}options=${opt}`)
+    const store = await PgMetaStore.create(`${base}${base.includes("?") ? "&" : "?"}options=${opt}`)
+    // Seed the shared "default" team inside `ready`, so the Proxy's deferred calls
+    // (test requests) only run once the membership rows exist (no race).
+    if (team.length) {
+      await store.setWorkspace("default", DEFAULT_WORKSPACE_NAME)
+      for (const t of team)
+        await store.setMembership({
+          id: `m_${t.user_id}`,
+          org_id: "default",
+          user_id: t.user_id,
+          role: t.role,
+        })
+    }
+    return store
   })()
   // Every MetaStore method is async, so a Proxy that defers each call until
   // connect+migrate finishes lets the synchronous call sites stay unchanged.
@@ -83,17 +99,32 @@ const seedSqliteUsers = (path: string, users: TestUser[]): void => {
   raw.close()
 }
 
+// Seed a shared "default" workspace + memberships (the single-mode default before
+// always-multi). The tables exist after SqliteMetaStore migrates on construction.
+const seedSqliteTeam = (path: string, team: Seat[]): void => {
+  const raw = new Database(path)
+  raw
+    .prepare(`INSERT OR IGNORE INTO workspace (id, name) VALUES ('default', ?)`)
+    .run(DEFAULT_WORKSPACE_NAME)
+  const ins = raw.prepare(
+    `INSERT OR IGNORE INTO membership (id, org_id, user_id, role) VALUES (?, 'default', ?, ?)`,
+  )
+  for (const t of team) ins.run(`m_${t.user_id}`, t.user_id, t.role)
+  raw.close()
+}
+
 // One metadata store per named test app: Postgres schema or SQLite file. Seeds
 // the Better Auth `user` table so the share/mention routes can resolve email→id.
-const makeStore = (name: string, users: TestUser[]): TestStore => {
+const makeStore = (name: string, users: TestUser[], team: Seat[] = []): TestStore => {
   if (PG_URL) {
-    const s = makePgStore(name, users)
+    const s = makePgStore(name, users, team)
     pgStores.push(s)
     return s
   }
   const path = join(dir, `${name}.db`)
   const m = new SqliteMetaStore(path)
   if (users.length) seedSqliteUsers(path, users)
+  if (team.length) seedSqliteTeam(path, team)
   return m
 }
 
@@ -158,9 +189,20 @@ export const makeAuthedApp = (
   name: string,
   users: TestUser[],
   defaultRole?: AppDeps["defaultRole"],
-  multiWorkspace?: boolean,
+  opts?: { isolated?: boolean },
 ) => {
-  const m = makeStore(name, users)
+  // Seed a shared "default" workspace so the user list collaborates (the single-
+  // mode default before always-multi): users[0] is the Admin/owner, the rest take
+  // defaultRole. `isolated` skips it, so each user provisions their own workspace
+  // (the cross-tenant / multi-workspace tests).
+  const team: Seat[] =
+    opts?.isolated || !users.length
+      ? []
+      : users.map((u, i) => ({
+          user_id: u.id,
+          role: i === 0 ? "owner" : (defaultRole ?? "editor"),
+        }))
+  const m = makeStore(name, users, team)
   const app = createApp({
     meta: m,
     blobs: new FsBlobStore(join(dir, "blobs")),
@@ -168,7 +210,6 @@ export const makeAuthedApp = (
     token: "tok",
     auth: fakeAuth(users),
     defaultRole,
-    multiWorkspace,
     defaultOrgId: "default",
   })
   return { app, meta: m }

--- a/apps/api/test/quotas.test.ts
+++ b/apps/api/test/quotas.test.ts
@@ -78,7 +78,7 @@ describe("multi-tenant hardening: per-org quotas + cross-org isolation", () => {
   const ben: TestUser = { id: "u_mt_ben", email: "mtben@dock.test", name: "Ben" }
 
   it("storage quota is per-workspace — one org filling up does NOT block another", async () => {
-    const { app } = quotaApp("mt-quota", { multiWorkspace: true, maxBytes: 12 }, [amy, ben])
+    const { app } = quotaApp("mt-quota", { maxBytes: 12 }, [amy, ben])
     await app.request("/v1/me", { headers: as(amy.email) }) // provision Amy's workspace
     await app.request("/v1/me", { headers: as(ben.email) }) // provision Ben's workspace
     // Amy fills her own 12-byte cap.
@@ -90,7 +90,7 @@ describe("multi-tenant hardening: per-org quotas + cross-org isolation", () => {
   })
 
   it("an artifact in one org with 'org' visibility is 404 to a member of another org", async () => {
-    const { app } = quotaApp("mt-isolation", { multiWorkspace: true }, [amy, ben])
+    const { app } = quotaApp("mt-isolation", {}, [amy, ben])
     await app.request("/v1/me", { headers: as(amy.email) })
     await app.request("/v1/me", { headers: as(ben.email) })
     const a = await (

--- a/apps/api/test/tenant-isolation.test.ts
+++ b/apps/api/test/tenant-isolation.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "vitest"
 import { as, bearer, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 
-// Cross-tenant isolation regression tests. Each app runs multiWorkspace=true, so
-// Alice and Bob land in separate personal workspaces; "tok" is the instance
+// Cross-tenant isolation regression tests. Each app uses isolated:true, so Alice
+// and Bob each provision their own personal workspace; "tok" is the instance
 // super-admin (operator) credential. These pin the fixes for the cross-tenant
 // findings the authz-coverage guard structurally can't catch (a route gating on
 // the caller's workspace while acting on a globally-keyed resource).
@@ -10,7 +10,7 @@ import { as, bearer, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./h
 const alice: TestUser = { id: "u_alice", email: "alice@a.test", name: "Alice" }
 const bob: TestUser = { id: "u_bob", email: "bob@b.test", name: "Bob" }
 
-const setup = (name: string) => makeAuthedApp(name, [alice, bob], undefined, true)
+const setup = (name: string) => makeAuthedApp(name, [alice, bob], undefined, { isolated: true })
 type App = ReturnType<typeof setup>["app"]
 
 const publish = async (app: App, who: TestUser): Promise<string> => {

--- a/apps/api/test/workspace.test.ts
+++ b/apps/api/test/workspace.test.ts
@@ -193,7 +193,7 @@ describe("workspace: open + token modes", () => {
 describe("multi-workspace: isolation, switch, create, provision", () => {
   const ada: TestUser = { id: "u_mw_ada", email: "mwada@dock.test", name: "Ada" }
   const bo: TestUser = { id: "u_mw_bo", email: "mwbo@dock.test", name: "Bo" }
-  const { app } = makeAuthedApp("multiws", [ada, bo], "commenter", true)
+  const { app } = makeAuthedApp("multiws", [ada, bo], "commenter", { isolated: true })
 
   // Pull the dock_ws cookie out of a Set-Cookie header to thread it on later calls.
   const wsCookie = (res: Response): string => {
@@ -257,19 +257,5 @@ describe("multi-workspace: isolation, switch, create, provision", () => {
   })
 })
 
-describe("multi-workspace: create/switch are disabled in single mode", () => {
-  const ada: TestUser = { id: "u_sw_ada", email: "swada@dock.test", name: "Ada" }
-  const { app } = makeAuthedApp("singlews", [ada], "commenter") // multi off
-
-  it("403s create and switch, and reports multi:false", async () => {
-    expect((await app.request("/v1/workspaces", jsonAs(as(ada.email), { name: "X" }))).status).toBe(
-      403,
-    )
-    expect(
-      (await app.request("/v1/workspace/switch", jsonAs(as(ada.email), { id: "whatever" }))).status,
-    ).toBe(403)
-    const list = await (await app.request("/v1/workspaces", { headers: as(ada.email) })).json()
-    expect(list.multi).toBe(false)
-    expect(list.workspaces).toHaveLength(1)
-  })
-})
+// (single-mode create/switch-disabled tests removed — multi-workspace is now the
+// only mode; create + switch are always available, /me reports multi:true.)

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -37,4 +37,5 @@ not_found_handling = "single-page-application"
 # DOCK_AUTH_SECRET via `wrangler secret put`. Cross-instance realtime fan-out uses
 # the ArtifactRoom Durable Object (one room per channel).
 [vars]
-DOCK_MULTI_WORKSPACE = "false"
+# DOCK_SUPERADMIN_EMAILS (operator allow-list) is optional; BASE_URL optional;
+# DOCK_AUTH_SECRET is a secret (`wrangler secret put`). Workspaces are always multi.


### PR DESCRIPTION
Follow-up to #81. Removes the single-workspace concept entirely: every deployment runs multi-workspace. Each signed-in user owns a personal workspace (provisioned on first login); collaboration is by per-artifact share or explicit workspace membership. This cuts the test matrix in half and makes the tested path the only path (the hosted product + e2e already ran multi).

Now that #81's tenant-isolation fixes are in, flipping always-multi is safe — the cross-tenant scoping that single-mode masked is enforced.

## Source
- **`context.ts`**: drop the `multi` flag. `activeWorkspace` always resolves via cookie → membership → provision (no single-org shortcut); **`actorFor` never auto-joins** (`orgRole` = explicit membership or `null`), so opening a shared link can't grant a workspace role.
- **`config` / `node` / `worker` / `AppDeps`**: drop `multiWorkspace` + `DOCK_MULTI_WORKSPACE` (and the misleading `="false"` in wrangler.toml).
- **`workspace.ts` / `session.ts`**: create + switch are always available; responses report `multi:true` so the frontend workspace switcher is untouched (zero web churn).
- ARCHITECTURE.md updated.

## Tests
The 26 collaboration tests that assumed single-mode's shared workspace now get it explicitly: `makeAuthedApp` seeds a shared `default` workspace (`users[0]` = owner, the rest take `defaultRole`), with an **`isolated`** opt-out for the cross-tenant + multi-workspace tests. Seeding is race-free on both backends (sqlite: raw sync; pg: inside the store's `ready` promise). Removed the now-obsolete single-mode create/switch test.

## Gate
`pnpm run ci` + `pnpm typecheck` + **140 api tests on sqlite + 140 on Postgres** (`test:pg`) + db/mcp/storage/cli — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)