### PR TITLE
perf(web): Tier 4 — render hygiene (context split) + web-vitals beacon

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate, useRouterState } from "@tanstack/react-router"
-import { lazy, type ReactNode, Suspense, useCallback, useEffect, useState } from "react"
+import { lazy, type ReactNode, Suspense, useCallback, useEffect, useMemo, useState } from "react"
 import { api, type Collection, type Workspaces } from "@/api"
 import { Button } from "@/components/ui/button"
 import { useAuth } from "@/ctx"
@@ -10,7 +10,7 @@ import { Icon } from "./icons"
 import { NavRail } from "./nav-rail"
 import { Logo } from "./shared/logo"
 import { CenteredSpinner } from "./shared/spinner"
-import { ShellCtx, type ShellValue, type Summary } from "./shell-context"
+import { ShellCtx, type ShellValue, type Summary, TopBarSlotCtx } from "./shell-context"
 
 // The ⌘K palette pulls in cmdk; it's only needed once the user opens it, so keep
 // it (and cmdk) out of the shared bundle every route pays for. Loads on first open.
@@ -42,7 +42,7 @@ export function AppShell({ children }: { children: ReactNode }) {
   const [summary, setSummary] = useState<Summary | null>(null)
   const [collections, setCollections] = useState<Collection[]>([])
   const [workspaces, setWorkspaces] = useState<Workspaces | null>(null)
-  // The top bar's right region; a page portals its actions here (see useShell).
+  // The top bar's right region; a page portals its actions here (see useTopBarSlot).
   const [topBarSlot, setTopBarSlot] = useState<HTMLElement | null>(null)
 
   // Auth gate for the whole authed app (this shell wraps every non-login route):
@@ -134,22 +134,42 @@ export function AppShell({ children }: { children: ReactNode }) {
 
   const toggleCollapsed = useCallback(() => setCollapsed((c) => !c), [])
 
-  const value: ShellValue = {
-    collapsed,
-    toggleCollapsed,
-    drawerOpen,
-    setDrawerOpen,
-    paletteOpen,
-    setPaletteOpen,
-    summary,
-    collections,
-    workspaces,
-    refreshSummary,
-    refreshCollections,
-    switchWorkspace,
-    createWorkspace,
-    topBarSlot,
-  }
+  // Memoized so the provider gets a stable value object — consumers re-render
+  // only when shell state actually changes, not on every AppShell render. The
+  // action fns are already stable (useCallback / setState), so the volatile
+  // deps are just the state. topBarSlot lives in its own context (below).
+  const value = useMemo<ShellValue>(
+    () => ({
+      collapsed,
+      toggleCollapsed,
+      drawerOpen,
+      setDrawerOpen,
+      paletteOpen,
+      setPaletteOpen,
+      summary,
+      collections,
+      workspaces,
+      refreshSummary,
+      refreshCollections,
+      switchWorkspace,
+      createWorkspace,
+    }),
+    // setDrawerOpen / setPaletteOpen are stable useState setters — intentionally
+    // not listed (React guarantees their identity).
+    [
+      collapsed,
+      toggleCollapsed,
+      drawerOpen,
+      paletteOpen,
+      summary,
+      collections,
+      workspaces,
+      refreshSummary,
+      refreshCollections,
+      switchWorkspace,
+      createWorkspace,
+    ],
+  )
 
   // Until the session resolves, hold the frame rather than flashing the rail
   // (and the redirect above handles the signed-out case).
@@ -157,48 +177,50 @@ export function AppShell({ children }: { children: ReactNode }) {
 
   return (
     <ShellCtx.Provider value={value}>
-      <div className="flex h-full flex-col">
-        <header className="flex items-center gap-2.5 border-b border-border bg-card px-5.5 py-3 max-sm:px-3.5 max-sm:py-2.5">
-          <Button
-            variant="outline"
-            size="icon"
-            data-testid="library-menu"
-            aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-            title="Toggle sidebar"
-            onClick={() => (isMobile ? setDrawerOpen(true) : toggleCollapsed())}
-          >
-            <Icon name="sidebar" size={18} />
-          </Button>
-          <Link to="/" className="mr-auto flex items-center gap-2.5 text-foreground">
-            <Logo />
-            <span className="font-display text-lg font-semibold">Dock</span>
-          </Link>
-          <div ref={setTopBarSlot} className="ml-auto flex items-center gap-2" />
-        </header>
+      <TopBarSlotCtx.Provider value={topBarSlot}>
+        <div className="flex h-full flex-col">
+          <header className="flex items-center gap-2.5 border-b border-border bg-card px-5.5 py-3 max-sm:px-3.5 max-sm:py-2.5">
+            <Button
+              variant="outline"
+              size="icon"
+              data-testid="library-menu"
+              aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+              title="Toggle sidebar"
+              onClick={() => (isMobile ? setDrawerOpen(true) : toggleCollapsed())}
+            >
+              <Icon name="sidebar" size={18} />
+            </Button>
+            <Link to="/" className="mr-auto flex items-center gap-2.5 text-foreground">
+              <Logo />
+              <span className="font-display text-lg font-semibold">Dock</span>
+            </Link>
+            <div ref={setTopBarSlot} className="ml-auto flex items-center gap-2" />
+          </header>
 
-        <div className="flex min-h-0 flex-1">
-          {isMobile && (
-            <button
-              type="button"
-              data-testid="library-menu-backdrop"
-              aria-label="Close menu"
-              tabIndex={drawerOpen ? 0 : -1}
-              onClick={() => setDrawerOpen(false)}
-              className={cn(
-                "fixed inset-0 z-[60] bg-black/35 transition-opacity",
-                drawerOpen ? "opacity-100" : "pointer-events-none opacity-0",
-              )}
-            />
-          )}
-          <NavRail />
-          <main className="flex min-w-0 flex-1 flex-col overflow-hidden">{children}</main>
+          <div className="flex min-h-0 flex-1">
+            {isMobile && (
+              <button
+                type="button"
+                data-testid="library-menu-backdrop"
+                aria-label="Close menu"
+                tabIndex={drawerOpen ? 0 : -1}
+                onClick={() => setDrawerOpen(false)}
+                className={cn(
+                  "fixed inset-0 z-[60] bg-black/35 transition-opacity",
+                  drawerOpen ? "opacity-100" : "pointer-events-none opacity-0",
+                )}
+              />
+            )}
+            <NavRail />
+            <main className="flex min-w-0 flex-1 flex-col overflow-hidden">{children}</main>
+          </div>
         </div>
-      </div>
-      {paletteOpen && (
-        <Suspense fallback={null}>
-          <CommandPalette />
-        </Suspense>
-      )}
+        {paletteOpen && (
+          <Suspense fallback={null}>
+            <CommandPalette />
+          </Suspense>
+        )}
+      </TopBarSlotCtx.Provider>
     </ShellCtx.Provider>
   )
 }

--- a/apps/web/src/components/shell-context.ts
+++ b/apps/web/src/components/shell-context.ts
@@ -26,10 +26,6 @@ export interface ShellValue {
   refreshCollections: () => void
   switchWorkspace: (id: string) => void
   createWorkspace: (name: string) => void
-  // The top bar's right-side region. AppShell is mounted once around the router
-  // Outlet, so a page can't pass top-bar actions as a prop — it portals them
-  // into this slot instead (null until the bar has mounted).
-  topBarSlot: HTMLElement | null
 }
 
 export const ShellCtx = createContext<ShellValue | null>(null)
@@ -39,3 +35,13 @@ export function useShell(): ShellValue {
   if (!v) throw new Error("useShell must be used within <AppShell>")
   return v
 }
+
+// The top bar's right-side region lives in its own context, separate from the
+// volatile shell state above. AppShell is mounted once around the router Outlet,
+// so a page (the artifact view) portals its header actions into this slot rather
+// than passing a prop. Splitting it out means the artifact page subscribes only
+// to the slot — it no longer re-renders when unrelated shell state churns
+// (rail collapse, summary refresh, ⌘K). Null until the bar has mounted.
+export const TopBarSlotCtx = createContext<HTMLElement | null>(null)
+
+export const useTopBarSlot = (): HTMLElement | null => useContext(TopBarSlotCtx)

--- a/apps/web/src/lib/vitals.ts
+++ b/apps/web/src/lib/vitals.ts
@@ -1,15 +1,32 @@
-import { onCLS, onINP, onLCP, onTTFB } from "web-vitals"
+import { type Metric, onCLS, onINP, onLCP, onTTFB } from "web-vitals"
 
-// Report Core Web Vitals to the console (one line per metric, with its rating)
-// so before/after numbers are visible in the devtools while we tune the perf
-// tiers. Cheap enough to always run; point the sink at an endpoint when we want
-// field data instead of local readings.
+// Where to beacon field metrics. Optional: unset → no beacon (e.g. local dev),
+// set in prod to collect real LCP / INP / CLS / TTFB from users.
+const BEACON_URL = import.meta.env.VITE_VITALS_URL as string | undefined
+
+// Report Core Web Vitals. In dev we log each metric to the console (with its
+// rating) for before/after tuning; when VITE_VITALS_URL is set we also beacon it
+// — sendBeacon survives the page unload that finalizes CLS/INP/LCP, so the
+// numbers are real field data, not synthetic. Both sinks are no-ops off-window.
 export function reportWebVitals() {
   if (typeof window === "undefined") return
-  const log = (m: { name: string; value: number; rating: string }) =>
-    console.info(`[web-vitals] ${m.name} ${Math.round(m.value)} (${m.rating})`)
-  onLCP(log)
-  onINP(log)
-  onCLS(log)
-  onTTFB(log)
+  const sink = (m: Metric) => {
+    if (import.meta.env.DEV) {
+      console.info(`[web-vitals] ${m.name} ${Math.round(m.value)} (${m.rating})`)
+    }
+    if (BEACON_URL) {
+      const body = JSON.stringify({
+        name: m.name,
+        value: m.value,
+        rating: m.rating,
+        id: m.id,
+        path: location.pathname,
+      })
+      navigator.sendBeacon?.(BEACON_URL, body)
+    }
+  }
+  onLCP(sink)
+  onINP(sink)
+  onCLS(sink)
+  onTTFB(sink)
 }

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -7,7 +7,7 @@ import { useIsMobile, useToast } from "@/components"
 import { Icon } from "@/components/icons"
 import { ShareButton } from "@/components/ShareDialog"
 import { Spinner } from "@/components/shared/spinner"
-import { useShell } from "@/components/shell-context"
+import { useTopBarSlot } from "@/components/shell-context"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -59,7 +59,8 @@ export function Artifact() {
   const isMobile = useIsMobile()
   // The persistent shell exposes its top-bar region; this page's header actions
   // are portaled into it (the shell is mounted once, above the route Outlet).
-  const { topBarSlot } = useShell()
+  // Its own context, so the artifact page doesn't re-render on shell-state churn.
+  const topBarSlot = useTopBarSlot()
 
   // Artifact metadata + comments come from React Query, so the route loader's
   // intent preload (ensureQueryData) warms exactly what we render here — the

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -34,15 +34,14 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
 })
 
 function RootComponent() {
-  // Dev-only perf instrumentation. web-vitals logs to the console for before/
-  // after numbers (dev only — no prod console noise; Tier 5 adds a real beacon).
-  // react-scan (flags wasted re-renders) is further gated behind VITE_REACT_SCAN
-  // because its overlay intercepts pointer events. Both dynamic/dev-gated, so
-  // they're dead-code-eliminated from the prod build.
+  // Perf instrumentation. web-vitals self-gates its sinks: console in dev (no
+  // prod noise), and a field beacon when VITE_VITALS_URL is set — so it runs in
+  // prod to collect real LCP/INP/CLS. react-scan (flags wasted re-renders) is
+  // dev-only + behind VITE_REACT_SCAN (its overlay intercepts pointer events);
+  // that dynamic import is dead-code-eliminated from the prod build.
   useEffect(() => {
-    if (!import.meta.env.DEV) return
     reportWebVitals()
-    if (import.meta.env.VITE_REACT_SCAN) {
+    if (import.meta.env.DEV && import.meta.env.VITE_REACT_SCAN) {
       import("react-scan").then(({ scan }) => scan({ enabled: true })).catch(() => {})
     }
   }, [])


### PR DESCRIPTION
## Tier 4 of the performance roadmap

See the real numbers; kill wasted renders.

### Render hygiene
- **Memoized the AppShell context value.** It was a fresh object every render → every `useShell` consumer re-rendered on *any* shell change. Now consumers re-render only when shell state actually changes (the action fns were already stable).
- **Split the top-bar slot into its own context** (`TopBarSlotCtx` / `useTopBarSlot`). The artifact page — the heaviest route, and the only consumer that needs *just* the slot — no longer subscribes to shell state, so rail-collapse / summary-refresh / ⌘K stop re-rendering it.

### web-vitals beacon
- `vitals` self-gates: console in dev (no prod noise) + `navigator.sendBeacon` to `VITE_VITALS_URL` when set, so **prod collects real LCP / INP / CLS / TTFB** (sendBeacon survives the unload that finalizes those metrics). `reportWebVitals` now runs in prod too (beacon only); react-scan stays dev-only behind `VITE_REACT_SCAN`.

### Deferred (with reason)
- **React Compiler** — needs a React 19 upgrade (this app is on 18.3); that's a separate decision, not a perf-sweep drive-by.
- **million.js** — unnecessary now that the grid is virtualized (Tier 3).

### Verification
- `tsc` + `biome ci` + token/frontend/testid/api/knip guards green · bundle budget green (209.6/260 kB).
- **29/29 Playwright e2e across 2 cold runs (`retries=0`)** — the artifact's portaled top-bar actions still work through the new context.

Builds on #82 / #85 / #89 (Tiers 1–3, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)