### PR TITLE
feat(edge): secure access by default — make "open" mode explicit (DOCK_OPEN)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -91,6 +91,7 @@ the default role. Sign up at `/login`.
 | `DOCK_WEB_ORIGIN` | (none) | Comma-separated web origins for CORS (split deploy only) |
 | `DOCK_CROSS_SITE` | `false` | `true` for `SameSite=None; Secure` cookies (split deploy only) |
 | `DOCK_TOKEN` | (none) | Static bearer token for CI/agents |
+| `DOCK_OPEN` | `!DOCK_TOKEN` (Node) · `false` (Worker) | `true` trusts anonymous callers as owners (zero-config single-user). Leave off for a real multi-user instance so permissions apply (anon → viewer on public links, else no access). |
 | `DOCK_WEB_DIR` | (auto) | Override the bundled SPA path |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | (none) | Google sign-in |
 | `OIDC_ISSUER` / `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` / `OIDC_PROVIDER_ID` | (none) | Enterprise SSO |

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -39,6 +39,14 @@ export interface AppDeps {
   baseUrl: string
   /** A static token (CI/agents) authorizes writes + gated reads, alongside a login session. */
   token?: string
+  /**
+   * "Open" instance: anonymous (and non-member) callers are trusted as owners —
+   * the zero-config self-host / CI experience. Leave UNSET on a real multi-user
+   * deployment so normal permissions apply (anon → viewer on public links, no
+   * access otherwise). Defaults to `!token` when unset, preserving the historical
+   * behavior; the edge worker sets it explicitly from DOCK_OPEN (secure default).
+   */
+  open?: boolean
   /** Operator (instance super-admin) emails: global moderation powers, on top of `token`. */
   superAdmins?: string[]
   /** Better Auth instance — mounts /api/auth/* and provides the session. */
@@ -124,7 +132,10 @@ export function buildContext(deps: AppDeps) {
   const analyticsOn = deps.analytics !== false
   const versionWindowMs = deps.versionWindowMs ?? DEFAULT_VERSION_WINDOW_MS
   const allowOrigins = new Set(deps.webOrigins ?? [])
-  const open = !deps.token
+  // Explicit `open` wins; otherwise fall back to the historical default (an instance
+  // with no static token is treated as open / zero-config). A real multi-user
+  // deployment passes `open: false` so anonymous callers get real permissions.
+  const open = deps.open ?? !deps.token
   const defaultRole: Role = deps.defaultRole ?? "editor"
   // The bootstrap workspace id — always a real value, never a magic
   // literal. The Node entry generates + persists one; tests fall back to this.

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -36,6 +36,9 @@ export interface Env {
   BASE_URL?: string
   DOCK_AUTH_SECRET?: string
   DOCK_SUPERADMIN_EMAILS?: string
+  /** "true" to run the edge instance open (anon = owner, zero-config). Unset/anything
+   *  else = secure: real permissions apply (anon → viewer on public, else no access). */
+  DOCK_OPEN?: string
 }
 
 let app: ReturnType<typeof createApp> | null = null
@@ -62,6 +65,9 @@ export default {
         backplane: createDoBackplane(env.ROOMS),
         baseUrl,
         auth,
+        // Secure by default on the edge: anonymous callers are NOT owners. Set
+        // DOCK_OPEN=true only for a single-user / zero-config edge instance.
+        open: env.DOCK_OPEN === "true",
         superAdmins: (env.DOCK_SUPERADMIN_EMAILS ?? "")
           .split(",")
           .map((s) => s.trim().toLowerCase())

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -56,8 +56,9 @@ export interface Actor {
   /** Baseline role from membership in the artifact's workspace, if any. */
   orgRole?: Role | null
   /**
-   * Unsecured instance (no static token configured): anonymous callers are
-   * trusted as owners, preserving the zero-config self-host / CI experience.
+   * "Open" instance: anonymous (and non-member) callers are trusted as owners,
+   * for zero-config self-host / CI. Set per deployment (the `open` dep / DOCK_OPEN);
+   * a real multi-user instance leaves it off so normal permissions apply.
    */
   open?: boolean
 }


### PR DESCRIPTION
## Secure access by default on the edge

Open mode (anonymous callers trusted as **owners**) was derived from `!token` — conflating a CI bearer token with access control. The edge worker sets no token, so it silently treated **every anonymous request as owner**: real permissions and the view-only share state never applied.

### Change
- **`context.ts`**: `open = deps.open ?? !deps.token` — explicit wins; the default preserves the historical zero-config behavior for the Node self-host and tests.
- **`worker.ts`**: `open: env.DOCK_OPEN === "true"` — **secure by default** on the edge. Anonymous → `viewer` on public/link artifacts, no access otherwise; signed-in users get their real workspace/share role.
- **`permissions.ts`** (`Actor.open` doc) + **`DEPLOY.md`** env reference updated. Set `DOCK_OPEN=true` to opt a single-user/zero-config edge instance back into open mode.

### Verified live (dock.siftai.workers.dev)
- anon publish **201 → 403**; anon `my_role` on a public artifact **owner → viewer**.
- Share panel now shows **View only** for anon (no invite box, copy link still works); owners/editors still get the manage panel.
- Typecheck (Node + worker), biome, **141 api tests** (unchanged — they don't set `open`, so default stays `!token`).

Blast radius is surgical: only the Worker flips to secure-by-default; Node self-host and the test suite are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)