### PR TITLE
perf(api): Tier 5 — gzip responses (Node/Fly), keep SSE uncompressed

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,5 @@
 import { type Context, Hono } from "hono"
+import { compress } from "hono/compress"
 import { type AppDeps, buildContext } from "./context"
 import { corsFor } from "./lib/http"
 import { makeRateLimiter } from "./lib/rate-limit"
@@ -32,6 +33,16 @@ export type { AppDeps }
 export function createApp(deps: AppDeps): Hono {
   const ctx = buildContext(deps)
   const app = new Hono()
+
+  // gzip everything (Node/Fly entry only — the Worker edge compresses already).
+  // Registered first so it wraps every downstream response; honors Accept-Encoding
+  // and skips already-small bodies. Exception: the SSE streams (paths ending in
+  // /events) — gzip buffers the stream and would stall real-time delivery, so they
+  // pass through uncompressed.
+  if (deps.compress) {
+    const gzip = compress()
+    app.use("*", (c, next) => (c.req.path.endsWith("/events") ? next() : gzip(c, next)))
+  }
 
   // Uncaught errors become a consistent JSON 500 (never a stack trace to the
   // client) and a structured server log line.

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -88,6 +88,12 @@ export interface AppDeps {
    */
   serveWeb?: boolean
   /**
+   * gzip the responses. On for the Node/Fly entry (Fly's proxy gives HTTP/2 but
+   * doesn't compress); left off for the Cloudflare Worker entry, where the edge
+   * already compresses (gzip/brotli) and doubling it up wastes CPU.
+   */
+  compress?: boolean
+  /**
    * A separate origin that serves artifact bytes (`/raw/*`), keeping user HTML
    * off the app's cookie origin — the real isolation wall (CSP sandbox is
    * defense-in-depth). When set, the app origin redirects `/raw/*` here, and

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -74,6 +74,9 @@ const app = createApp({
   analytics: cfg.analytics,
   rateLimit: cfg.rateLimit,
   serveWeb: cfg.serveWeb,
+  // Fly gives HTTP/2 but doesn't compress; gzip here. (The Worker edge does its
+  // own compression, so worker.ts leaves this off.)
+  compress: true,
   defaultOrgId: defaultOrg,
   // Origin isolation: serve artifact bytes from a separate registrable domain
   // pointed at this same container. Keeps user HTML off the app's cookie origin.


### PR DESCRIPTION
## Tier 5 of the performance roadmap — final tier

Load bytes once, and send fewer of them on the first load.

### Immutable caching (already in place — confirmed)
`/raw/:id/v/:n/*` (and proposal bytes) already carry `Cache-Control: public, max-age=31536000, immutable` via `RAW_HEADERS` — and every version/proposal is immutable by id, so it's correct. Vite's hashed assets cache hard too. Net: thumbnails + artifact iframes are a **one-time fetch**, instant on every repeat view.

### gzip (the new bit)
- Added `hono/compress`, gated by a `compress` flag set **only on the Node/Fly entry**. Fly gives HTTP/2 but doesn't compress; the **Cloudflare Worker entry leaves it off** (the edge already compresses gzip/brotli — doubling it up just burns CPU).
- **Excluded the SSE streams** (paths ending in `/events`) — gzip buffers a stream and would stall real-time comment/notification delivery.

### Verified
- `content-encoding: gzip` on `/raw/dock-client.js`; **none** on `/v1/.../events` (SSE intact).
- `tsc` (node + worker) + `biome ci` + all guards + knip green · **141 API tests** pass · **29/29 e2e cold** (`retries=0`, SSE comment flow works).

Completes the performance roadmap: #82 (T1) · #85 (T2) · #89 (T3) · #91 (T4) · this (T5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)