### PR TITLE
chore(deploy): immutable cache on hashed assets + one-command Fly deploy

### DIFF
--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -98,7 +98,15 @@ const app = createApp({
 if (cfg.serveWeb) {
   const webRoot = relative(process.cwd(), cfg.webDir) || "."
   const shellHtml = readFileSync(cfg.webShell, "utf8")
-  app.use("/assets/*", serveStatic({ root: webRoot }))
+  // Vite's /assets/* are content-hashed, so the bytes behind a URL never change
+  // — cache them hard (a year, immutable). A new build emits new hashes.
+  app.use(
+    "/assets/*",
+    serveStatic({
+      root: webRoot,
+      onFound: (_path, c) => c.header("Cache-Control", "public, max-age=31536000, immutable"),
+    }),
+  )
   // Root-level static files Vite emits (favicon, manifest, etc.).
   app.get("/:file{[^/]+\\.[^/]+}", serveStatic({ root: webRoot }))
   app.notFound((c) => {

--- a/deploy/fly.toml
+++ b/deploy/fly.toml
@@ -1,6 +1,8 @@
-# Fly.io config for the Dock API container. `fly launch --no-deploy` to create
-# the app, set secrets (see DEPLOY.md), then `fly deploy`.
-app = "dock-api"
+# Fly.io config for the Dock API container. Deploy with:
+#   fly deploy --config deploy/fly.toml
+# Self-hosting your own instance? Change `app` to yours (or run `fly launch`,
+# which rewrites it) and make the volume name below match yours.
+app = "dock-api-lively-hill-7367"
 primary_region = "iad"
 
 [build]
@@ -27,5 +29,5 @@ primary_region = "iad"
 # horizontally and drop this volume. Without them, it falls back to SQLite + local
 # blobs and needs one persistent volume mounted at /data.
 [mounts]
-  source = "dock_data"
+  source = "data"
   destination = "/data"


### PR DESCRIPTION
Two small follow-ups from exercising the live app.

- **Immutable cache on `/assets/*`** — Vite's content-hashed JS/CSS now serve `Cache-Control: public, max-age=31536000, immutable` (via serveStatic's `onFound`). The bytes behind a hashed URL never change, so repeat visits don't re-fetch them; a new build just emits new hashes. (Previously served with no cache header.)
- **One-command Fly deploy** — `deploy/fly.toml` points at the live app + its `data` volume, so `fly deploy --config deploy/fly.toml` works without the per-deploy `--app` / mount overrides we'd been applying. A comment notes self-hosters swap the app name.

typecheck + biome ci + guards green; 144 API tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)