### PR TITLE
feat(workspace): rename refreshes the switcher + delete with type-to-confirm

### DIFF
--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -170,5 +170,25 @@ export const workspaceRoutes = (ctx: AppContext) => {
     return c.json({ active: id })
   })
 
+  // Delete a workspace you own. Guarded: Admin only, never your last workspace, and
+  // it must be empty (no artifacts) — we don't cascade-delete content. If it was the
+  // active workspace, switch to another one you own.
+  app.delete("/v1/workspaces/:id", async (c) => {
+    const me = await currentUser(c)
+    if (!me) return fail(c, 401, "unauthenticated")
+    const id = c.req.param("id")
+    const mem = await meta.getMembership(id, me.id)
+    if (!mem || mem.role !== "owner") return fail(c, 403, "only an admin can delete this workspace")
+    const mine = await meta.listWorkspaces(me.id)
+    if (mine.length <= 1) return fail(c, 409, "you need at least one workspace")
+    if ((await meta.countArtifacts(id)) > 0)
+      return fail(c, 409, "this workspace still has artifacts — delete or move them first")
+    const wasActive = (await activeWorkspace(c)) === id
+    await meta.deleteWorkspace(id)
+    const next = mine.find((w) => w.id !== id)?.id ?? null
+    if (wasActive && next) setWsCookie(c, next)
+    return c.json({ deleted: id, active: wasActive ? next : null })
+  })
+
   return app
 }

--- a/apps/api/test/workspace.test.ts
+++ b/apps/api/test/workspace.test.ts
@@ -259,3 +259,34 @@ describe("multi-workspace: isolation, switch, create, provision", () => {
 
 // (single-mode create/switch-disabled tests removed — multi-workspace is now the
 // only mode; create + switch are always available, /me reports multi:true.)
+
+describe("workspace: delete (guarded)", () => {
+  const me: TestUser = { id: "u_wsdel", email: "wsdel@dock.test", name: "Del" }
+  const { app } = makeAuthedApp("ws-del", [me], undefined, { isolated: true })
+  const H = as(me.email)
+  const del = (id: string) => app.request(`/v1/workspaces/${id}`, { method: "DELETE", headers: H })
+  const create = (name: string) =>
+    app.request("/v1/workspaces", jsonAs(H, { name })).then((r) => r.json())
+  const listWs = async () =>
+    (await (await app.request("/v1/workspaces", { headers: H })).json()).workspaces as {
+      id: string
+    }[]
+
+  it("blocks your last workspace, non-owners, and non-empty; deletes an empty one", async () => {
+    await app.request("/v1/me", { headers: H }) // provision the personal workspace (active)
+    const mine = await listWs()
+    const personal = mine[0].id
+    // can't delete your only workspace
+    expect((await del(personal)).status).toBe(409)
+    // not a member / unknown id → forbidden
+    expect((await del("ws_not_mine")).status).toBe(403)
+    // publish into the active (personal) workspace, then add a second so it isn't "last"
+    expect((await publishAs(app, "<h1>x</h1>", {}, H)).status).toBe(201)
+    const empty = await create("Empty One")
+    // the personal workspace now has an artifact → must be emptied first
+    expect((await del(personal)).status).toBe(409)
+    // the empty second workspace deletes cleanly
+    expect((await del(empty.id)).status).toBe(200)
+    expect((await listWs()).some((w) => w.id === empty.id)).toBe(false)
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -89,6 +89,7 @@ export interface ArtifactMember {
 }
 /** The workspace: its name, the caller's role, and the member directory. */
 export interface Workspace {
+  id: string
   name: string
   role: Role
   members: ArtifactMember[]
@@ -340,6 +341,8 @@ export const api = {
     f("/v1/workspaces", opts({ name })).then(j),
   switchWorkspace: (id: string): Promise<{ active: string }> =>
     f("/v1/workspace/switch", opts({ id })).then(j),
+  deleteWorkspace: (id: string): Promise<{ deleted: string; active: string | null }> =>
+    f(`/v1/workspaces/${id}`, { method: "DELETE", credentials: "include" }).then(j),
 
   // Collections (shareable groups; sharing grants the role on every item)
   listCollections: (): Promise<{ collections: Collection[] }> =>

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -131,6 +131,12 @@ export function AppShell({ children }: { children: ReactNode }) {
       /* surfaced elsewhere */
     }
   }, [])
+  // Deleting may swap the active workspace (the server switches the cookie when you
+  // delete the one you're in), so reload to pick up the new active context.
+  const deleteWorkspace = useCallback(async (id: string) => {
+    await api.deleteWorkspace(id)
+    window.location.reload()
+  }, [])
 
   const toggleCollapsed = useCallback(() => setCollapsed((c) => !c), [])
 
@@ -151,8 +157,10 @@ export function AppShell({ children }: { children: ReactNode }) {
       workspaces,
       refreshSummary,
       refreshCollections,
+      refreshWorkspaces,
       switchWorkspace,
       createWorkspace,
+      deleteWorkspace,
     }),
     // setDrawerOpen / setPaletteOpen are stable useState setters — intentionally
     // not listed (React guarantees their identity).
@@ -166,8 +174,10 @@ export function AppShell({ children }: { children: ReactNode }) {
       workspaces,
       refreshSummary,
       refreshCollections,
+      refreshWorkspaces,
       switchWorkspace,
       createWorkspace,
+      deleteWorkspace,
     ],
   )
 

--- a/apps/web/src/components/shell-context.ts
+++ b/apps/web/src/components/shell-context.ts
@@ -24,8 +24,10 @@ export interface ShellValue {
   workspaces: Workspaces | null
   refreshSummary: () => void
   refreshCollections: () => void
+  refreshWorkspaces: () => void
   switchWorkspace: (id: string) => void
   createWorkspace: (name: string) => void
+  deleteWorkspace: (id: string) => void
 }
 
 export const ShellCtx = createContext<ShellValue | null>(null)

--- a/apps/web/src/pages/settings/workspace-section.tsx
+++ b/apps/web/src/pages/settings/workspace-section.tsx
@@ -2,19 +2,31 @@ import { User } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
 import { type ArtifactMember, api, type Role, type Workspace } from "@/api"
 import { Spinner } from "@/components/shared/spinner"
+import { useShell } from "@/components/shell-context"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { roleLabel, roleValue, selectClass, WS_ROLES } from "./roles"
 
 export function WorkspaceSection({ meId, show }: { meId: string; show: (m: string) => void }) {
+  const { refreshWorkspaces } = useShell()
   const [ws, setWs] = useState<Workspace | null>(null)
   const [name, setName] = useState("")
   const [savingName, setSavingName] = useState(false)
   const [email, setEmail] = useState("")
   const [addRole, setAddRole] = useState<Role>("commenter")
   const [adding, setAdding] = useState(false)
+  const [delName, setDelName] = useState("")
+  const [deleting, setDeleting] = useState(false)
 
   const load = useCallback(
     () =>
@@ -40,11 +52,28 @@ export function WorkspaceSection({ meId, show }: { meId: string; show: (m: strin
     try {
       const r = await api.renameWorkspace(n)
       setWs((w) => (w ? { ...w, name: r.name } : w))
+      // Refresh the shell so the switcher + sidebar pick up the new name immediately.
+      refreshWorkspaces()
       show("Workspace renamed")
     } catch (e) {
       show((e as Error).message)
     } finally {
       setSavingName(false)
+    }
+  }
+
+  // Delete the active workspace. The server enforces the guards (Admin, not your
+  // last, must be empty); we surface those errors and reload on success (the active
+  // workspace may have changed).
+  const onDelete = async () => {
+    if (!ws) return
+    setDeleting(true)
+    try {
+      await api.deleteWorkspace(ws.id)
+      window.location.reload()
+    } catch (e) {
+      show((e as Error).message)
+      setDeleting(false)
     }
   }
 
@@ -225,6 +254,56 @@ export function WorkspaceSection({ meId, show }: { meId: string; show: (m: strin
           ))
         )}
       </div>
+
+      {isAdmin && ws && (
+        <Card className="mt-6 border-destructive/40 p-4">
+          <div className="text-xs font-semibold uppercase tracking-wide text-destructive">
+            Danger zone
+          </div>
+          <div className="mt-2 flex flex-wrap items-center justify-between gap-3">
+            <p className="max-w-md text-sm text-muted-foreground">
+              Delete this workspace permanently. It must be empty (no artifacts), and this can't be
+              undone.
+            </p>
+            <Dialog onOpenChange={(o) => !o && setDelName("")}>
+              <DialogTrigger asChild>
+                <Button
+                  data-testid="workspace-delete"
+                  variant="outline"
+                  className="shrink-0 border-destructive/50 text-destructive hover:bg-destructive/10"
+                >
+                  Delete workspace
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Delete "{ws.name}"?</DialogTitle>
+                  <DialogDescription>
+                    This permanently deletes the workspace and removes everyone from it. To confirm,
+                    type <b className="text-foreground">{ws.name}</b> below.
+                  </DialogDescription>
+                </DialogHeader>
+                <Input
+                  data-testid="workspace-delete-confirm"
+                  aria-label="Type the workspace name to confirm"
+                  value={delName}
+                  onChange={(e) => setDelName(e.target.value)}
+                  placeholder={ws.name}
+                  autoComplete="off"
+                />
+                <Button
+                  data-testid="workspace-delete-go"
+                  onClick={onDelete}
+                  disabled={deleting || delName.trim() !== ws.name}
+                  className="mt-2 w-full bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                >
+                  {deleting ? "Deleting…" : "Delete this workspace"}
+                </Button>
+              </DialogContent>
+            </Dialog>
+          </div>
+        </Card>
+      )}
     </section>
   )
 }

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -166,6 +166,9 @@ export interface MetaStore {
   getWorkspace(orgId: string): Promise<WorkspaceRecord | null>
   /** Insert or rename the workspace. */
   setWorkspace(orgId: string, name: string): Promise<WorkspaceRecord>
+  /** Delete the workspace row + all its memberships. The caller guarantees it is
+   *  empty (no artifacts) — this does not cascade artifacts/blobs. */
+  deleteWorkspace(orgId: string): Promise<void>
   /** Every workspace a user belongs to, with their role, oldest first (the switcher). */
   listWorkspaces(userId: string): Promise<(WorkspaceRecord & { role: Role })[]>
   getMembership(orgId: string, userId: string): Promise<MembershipRecord | null>

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -473,6 +473,10 @@ export class PgMetaStore implements MetaStore {
       .returning()
     return one(rows)
   }
+  async deleteWorkspace(orgId: string): Promise<void> {
+    await this.db.delete(membership).where(eq(membership.org_id, orgId))
+    await this.db.delete(workspace).where(eq(workspace.id, orgId))
+  }
   listWorkspaces(userId: string): Promise<(WorkspaceRecord & { role: Role })[]> {
     return this.db
       .select({

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -383,6 +383,10 @@ export function makeRepos(db: SqliteDb) {
       .onConflictDoUpdate({ target: workspace.id, set: { name } })
       .returning()
       .get()) as WorkspaceRecord
+  const deleteWorkspace = async (orgId: string): Promise<void> => {
+    await db.delete(membership).where(eq(membership.org_id, orgId)).run()
+    await db.delete(workspace).where(eq(workspace.id, orgId)).run()
+  }
   const listWorkspaces = async (userId: string): Promise<(WorkspaceRecord & { role: Role })[]> =>
     db
       .select({
@@ -782,6 +786,7 @@ export function makeRepos(db: SqliteDb) {
     removeMembership,
     getWorkspace,
     setWorkspace,
+    deleteWorkspace,
     listWorkspaces,
     getArtifactMember,
     listArtifactMembers,


### PR DESCRIPTION
## Workspace management: rename-refresh + delete

**Rename refresh (bug):** renaming a workspace updated the server but the shell's workspace list went stale — the switcher + sidebar kept the old name until a manual reload. Now `saveName` calls `refreshWorkspaces()` so it updates immediately.

**Delete a workspace (new):**
- `deleteWorkspace(orgId)` store method — deletes the workspace row + its memberships (sqlite/d1 via `repos.ts`, plus `pg`). No artifact cascade by design.
- `DELETE /v1/workspaces/:id` — **guarded**: Admin (owner) only, never your **last** workspace, and it must be **empty** (no artifacts → 409 with a clear message). Deleting the active workspace switches you to another server-side.
- **Type-the-name confirmation** (GitHub-style): a danger-zone dialog whose Delete button stays disabled until you type the workspace name exactly.

### Tests + live
- `workspace.test.ts` delete-guard test (last/owner/empty); **145 api tests pass**.
- Verified live (dock.siftai.workers.dev), 8/8: rename reflects **without reload**; delete is disabled before typing, disabled on a wrong name, enabled once it matches; delete removes the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)