### PR TITLE
Secure-by-default container: lock anonymous unless DOCK_OPEN=true

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -91,7 +91,7 @@ the default role. Sign up at `/login`.
 | `DOCK_WEB_ORIGIN` | (none) | Comma-separated web origins for CORS (split deploy only) |
 | `DOCK_CROSS_SITE` | `false` | `true` for `SameSite=None; Secure` cookies (split deploy only) |
 | `DOCK_TOKEN` | (none) | Static bearer token for CI/agents |
-| `DOCK_OPEN` | `!DOCK_TOKEN` (Node) · `false` (Worker) | `true` trusts anonymous callers as owners (zero-config single-user). Leave off for a real multi-user instance so permissions apply (anon → viewer on public links, else no access). |
+| `DOCK_OPEN` | `false` | `true` trusts anonymous callers as owners (zero-config single-user localhost demo). Secure by default on both the Node container and the Worker: leave it off so permissions apply (anon → viewer on public links, else no access). Sign up to get an owner account. |
 | `DOCK_WEB_DIR` | (auto) | Override the bundled SPA path |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | (none) | Google sign-in |
 | `OIDC_ISSUER` / `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` / `OIDC_PROVIDER_ID` | (none) | Enterprise SSO |

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -17,6 +17,10 @@ export interface Config {
   baseUrl: string
   databaseUrl?: string
   token?: string
+  /** Secure by default: anonymous callers get real (locked) permissions. Set
+   *  DOCK_OPEN=true to opt into zero-config "open" mode where the anonymous
+   *  caller is the trusted owner (a single-user localhost demo, never public). */
+  open: boolean
   /** Operator (instance super-admin) emails: these accounts get global powers
    *  (cross-workspace takedown, the global reports/audit queue) on top of the
    *  DOCK_TOKEN bearer. The people who run + host the deployment. */
@@ -81,6 +85,11 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     baseUrl,
     databaseUrl: env.DATABASE_URL,
     token: env.DOCK_TOKEN,
+    // Secure by default (anonymous is locked). DOCK_OPEN=true is an explicit
+    // opt-in to zero-config open mode (single-user localhost), matching the
+    // edge worker's DOCK_OPEN handling — never open implicitly just because no
+    // DOCK_TOKEN is set.
+    open: env.DOCK_OPEN === "true",
     // Comma-separated operator emails (case-insensitive). More than one person
     // can run + host a deployment, so this is a list, not a single owner.
     superAdmins: (env.DOCK_SUPERADMIN_EMAILS ?? "")

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -138,9 +138,10 @@ export function buildContext(deps: AppDeps) {
   const analyticsOn = deps.analytics !== false
   const versionWindowMs = deps.versionWindowMs ?? DEFAULT_VERSION_WINDOW_MS
   const allowOrigins = new Set(deps.webOrigins ?? [])
-  // Explicit `open` wins; otherwise fall back to the historical default (an instance
-  // with no static token is treated as open / zero-config). A real multi-user
-  // deployment passes `open: false` so anonymous callers get real permissions.
+  // Explicit `open` wins. Both real entrypoints pass it (node.ts from DOCK_OPEN,
+  // worker.ts from env.DOCK_OPEN) so deployments are secure by default — anonymous
+  // callers get real (locked) permissions unless open is explicitly true. The
+  // `!deps.token` fallback only applies to embedders/tests that omit `open`.
   const open = deps.open ?? !deps.token
   const defaultRole: Role = deps.defaultRole ?? "editor"
   // The bootstrap workspace id — always a real value, never a magic

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -68,6 +68,11 @@ const app = createApp({
   blobs,
   baseUrl: cfg.baseUrl,
   token: cfg.token,
+  // Secure by default: anonymous callers are locked unless DOCK_OPEN=true is set
+  // explicitly. Without this the context falls back to `!token` (open when no
+  // token), which let anonymous publish on a no-token container — the edge worker
+  // already passes an explicit `open`, so this makes both entrypoints consistent.
+  open: cfg.open,
   superAdmins: cfg.superAdmins,
   auth,
   webOrigins: cfg.webOrigins,

--- a/apps/api/test/permissions.test.ts
+++ b/apps/api/test/permissions.test.ts
@@ -48,6 +48,25 @@ describe("auth: token write-gating + per-artifact read-gating", () => {
   })
 })
 
+describe("security: container is secure by default (anonymous locked without DOCK_OPEN)", () => {
+  // What node.ts passes when DOCK_OPEN is unset: no token, open:false. The bug it
+  // closes: `open` defaulting to `!token` (true) on a no-token container let an
+  // anonymous caller publish (it was the trusted owner). open:false locks anon
+  // everywhere; the edge worker already passed an explicit open. No bypass.
+  const locked = createApp({
+    meta,
+    blobs: new FsBlobStore(join(dir, "blobs")),
+    baseUrl: "http://dock.test",
+    open: false,
+  })
+
+  it("refuses an anonymous publish (no token, not open)", async () => {
+    const form = new FormData()
+    form.append("file", new Blob([new TextEncoder().encode("<h1>x</h1>")]), "x.html")
+    expect((await locked.request("/v1/artifacts", { method: "POST", body: form })).status).toBe(403)
+  })
+})
+
 describe("permissions: workspace roles gate writes", () => {
   const alice: TestUser = { id: "u_alice", email: "alice@dock.test", name: "Alice" }
   const bob: TestUser = { id: "u_bob", email: "bob@dock.test", name: "Bob" }


### PR DESCRIPTION
## The bug

The single-container entry (`node.ts` — the **Fly / Docker** path) passed no `open` to `createApp`, so it fell through to the historical default `open = !token`. A no-token container therefore treated the **anonymous caller as OWNER** — anyone could publish/manage without signing in. The edge Worker already passed an explicit `open` (from `DOCK_OPEN`), so the two entrypoints disagreed and only the edge was locked.

Found while verifying #100 across all three environments: Cloudflare was locked (18/18), but the local/Fly single-container let an anonymous publish return **201**.

## The fix

- `config.ts` parses `DOCK_OPEN` (default **false**) into `Config.open`
- `node.ts` passes `open: cfg.open` to `createApp`, matching `worker.ts`
- both entrypoints are now secure by default; `DOCK_OPEN=true` is an explicit opt-in to zero-config "open" mode (single-user localhost demo)

Anonymous is locked everywhere by default (anon → viewer on public links, else no access). Self-host is unaffected: the operator signs up and owns their workspace. The `!deps.token` fallback stays only for embedders/tests that omit `open`.

## Verification

- typecheck (Node + Worker), 145 api tests (incl. a new "secure-by-default refuses anonymous publish" test)
- single-container browser test, end to end: **anonymous publish now 403** (was 201), authed signup → publish still works, anon view stays read-only (11/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)