### PR TITLE
fix(security): remove "open" mode entirely + hard anonymous lockdown + rando handles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,8 +18,9 @@ DATA_DIR=./data
 # Optional: Postgres for metadata instead of the default embedded SQLite.
 # DATABASE_URL=postgres://user:pass@host:5432/dock
 
-# Set to require a bearer token for publishing and for reading gated artifacts.
-# Unset = open instance (zero-config dev).
+# A static bearer token for headless CI/agent writes (and reading gated artifacts).
+# Optional: signed-in users can always write. Anonymous callers are read-only either
+# way — there is no "open" mode that makes them owners.
 # DOCK_TOKEN=
 
 # View analytics (counts, unique viewers, timeline, recent viewers) are on by

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -90,8 +90,7 @@ the default role. Sign up at `/login`.
 | `OBJECT_STORE_URL` | (local disk) | S3/R2 blob storage (scale-out) |
 | `DOCK_WEB_ORIGIN` | (none) | Comma-separated web origins for CORS (split deploy only) |
 | `DOCK_CROSS_SITE` | `false` | `true` for `SameSite=None; Secure` cookies (split deploy only) |
-| `DOCK_TOKEN` | (none) | Static bearer token for CI/agents |
-| `DOCK_OPEN` | `!DOCK_TOKEN` (Node) · `false` (Worker) | `true` trusts anonymous callers as owners (zero-config single-user). Leave off for a real multi-user instance so permissions apply (anon → viewer on public links, else no access). |
+| `DOCK_TOKEN` | (none) | Static bearer token for CI/agents. One of the two ways to write (the other is a sign-in session); anonymous callers are always read-only (public/link artifacts), never owners. |
 | `DOCK_WEB_DIR` | (auto) | Override the bundled SPA path |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | (none) | Google sign-in |
 | `OIDC_ISSUER` / `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` / `OIDC_PROVIDER_ID` | (none) | Enterprise SSO |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,9 +21,11 @@ release; please run a recent build.
 
 Dock ships safe defaults, but a few choices matter for an internet-facing deploy:
 
-- **Set `DOCK_TOKEN`.** Without a static token the instance runs *open* — anonymous
-  callers are trusted as owners (the zero-config local/CI experience). Always set a
-  token for any shared or public deployment.
+- **Anonymous callers are always read-only.** They may view public/link artifacts
+  and join live presence (a server-assigned handle + cursor) — nothing else. There is
+  no "open" mode that elevates anonymous callers to owners. To write, a caller must
+  sign in (Better Auth is always available, even zero-config) or present a static
+  `DOCK_TOKEN`; set `DOCK_TOKEN` for headless CI/agent automation.
 - **Set `DOCK_AUTH_SECRET`.** Generated and persisted automatically for single-node
   self-host; you must set it explicitly for multi-instance deployments so every node
   shares the same session-signing secret.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,7 +1,7 @@
 import { type Context, Hono } from "hono"
 import { compress } from "hono/compress"
 import { type AppDeps, buildContext } from "./context"
-import { corsFor } from "./lib/http"
+import { corsFor, fail } from "./lib/http"
 import { makeRateLimiter } from "./lib/rate-limit"
 import { log } from "./log"
 import { agentRoutes } from "./routes/agents"
@@ -116,6 +116,29 @@ export function createApp(deps: AppDeps): Hono {
 <code style="background:#eee7d6;padding:2px 8px;border-radius:6px">dock publish ./your-thing</code></p></div>`,
       ),
     )
+
+  // ---- Hard anonymous lockdown ------------------------------------------
+  // An anonymous caller (no signed-in session, no agent, no static token) may
+  // only READ and signal that they're viewing — the Google-Docs/Figma "someone
+  // is here" experience (presence, view count, and a live cursor). Every other
+  // mutation is refused here, at the door, before any route runs: one structural
+  // gate, so a newly added mutating route can never accidentally be exposed to
+  // anonymous callers. The per-route role checks still apply on top (defense in
+  // depth). Auth lives under /api/auth and reads (GET/HEAD) are untouched;
+  // OPTIONS preflights pass through to CORS. All three allowed actions are
+  // ephemeral and identity-safe (the server, not the client, names the viewer).
+  const ANON_WRITE_ALLOW = [
+    /^\/v1\/artifacts\/[^/]+\/presence$/, // ephemeral "I'm viewing" heartbeat
+    /^\/v1\/artifacts\/[^/]+\/cursor$/, // ephemeral live cursor (viral viewing)
+    /^\/v1\/artifacts\/[^/]+\/view$/, // de-duped, anonymous-safe view counter
+  ]
+  app.use("/v1/*", async (c, next) => {
+    const m = c.req.method
+    if (m === "GET" || m === "HEAD" || m === "OPTIONS") return next()
+    if (await ctx.isPrincipal(c)) return next()
+    if (ANON_WRITE_ALLOW.some((re) => re.test(c.req.path))) return next()
+    return fail(c, 403, "forbidden")
+  })
 
   // One router per feature, all sharing the context. Paths are distinct, so the
   // mount order doesn't affect matching.

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -19,7 +19,7 @@ import { getCookie, setCookie } from "hono/cookie"
 import type { Auth } from "./auth-config"
 import { type Backplane, createInProcessBackplane } from "./bus"
 import { safeEqual, sha256 } from "./lib/crypto"
-import { WS_COOKIE } from "./lib/http"
+import { VIEWER_COOKIE, WS_COOKIE } from "./lib/http"
 import { makeKeyedLimiter } from "./lib/rate-limit"
 import { log } from "./log"
 import { enqueueForEvent, type WebhookEvent } from "./webhooks"
@@ -39,14 +39,6 @@ export interface AppDeps {
   baseUrl: string
   /** A static token (CI/agents) authorizes writes + gated reads, alongside a login session. */
   token?: string
-  /**
-   * "Open" instance: anonymous (and non-member) callers are trusted as owners —
-   * the zero-config self-host / CI experience. Leave UNSET on a real multi-user
-   * deployment so normal permissions apply (anon → viewer on public links, no
-   * access otherwise). Defaults to `!token` when unset, preserving the historical
-   * behavior; the edge worker sets it explicitly from DOCK_OPEN (secure default).
-   */
-  open?: boolean
   /** Operator (instance super-admin) emails: global moderation powers, on top of `token`. */
   superAdmins?: string[]
   /** Better Auth instance — mounts /api/auth/* and provides the session. */
@@ -138,10 +130,6 @@ export function buildContext(deps: AppDeps) {
   const analyticsOn = deps.analytics !== false
   const versionWindowMs = deps.versionWindowMs ?? DEFAULT_VERSION_WINDOW_MS
   const allowOrigins = new Set(deps.webOrigins ?? [])
-  // Explicit `open` wins; otherwise fall back to the historical default (an instance
-  // with no static token is treated as open / zero-config). A real multi-user
-  // deployment passes `open: false` so anonymous callers get real permissions.
-  const open = deps.open ?? !deps.token
   const defaultRole: Role = deps.defaultRole ?? "editor"
   // The bootstrap workspace id — always a real value, never a magic
   // literal. The Node entry generates + persists one; tests fall back to this.
@@ -299,15 +287,34 @@ export function buildContext(deps: AppDeps) {
       secure: deps.crossSite || new URL(deps.baseUrl).protocol === "https:",
     })
 
+  // A stable id for an anonymous viewer, kept in a long-lived first-party cookie
+  // so the same browser counts as one viewer across opens (unique-view counts +
+  // a stable presence handle). Minted on first sight. Same SameSite/secure rules
+  // as the workspace cookie so it survives the hosted cross-site split.
+  const anonViewerId = (c: Context): string => {
+    let vid = getCookie(c, VIEWER_COOKIE)
+    if (!vid) {
+      vid = newId("anon")
+      setCookie(c, VIEWER_COOKIE, vid, {
+        path: "/",
+        maxAge: 60 * 60 * 24 * 365,
+        httpOnly: true,
+        sameSite: deps.crossSite ? "None" : "Lax",
+        secure: deps.crossSite || new URL(deps.baseUrl).protocol === "https:",
+      })
+    }
+    return vid
+  }
+
   const actorFor = async (c: Context, a: ArtifactRecord): Promise<Actor> => {
     if (deps.token && safeEqual(bearer(c), deps.token)) return { kind: "token" }
     const ag = await agentFor(c)
     if (ag) {
       const am = await meta.getArtifactMember(a.id, ag.id)
-      return { kind: "user", userId: ag.id, artifactRole: am?.role ?? null, orgRole: ag.role, open }
+      return { kind: "user", userId: ag.id, artifactRole: am?.role ?? null, orgRole: ag.role }
     }
     const me = await currentUser(c)
-    if (!me) return { kind: "anon", open }
+    if (!me) return { kind: "anon" }
     // Baseline role = membership in the ARTIFACT's workspace. Opening a shared
     // link never auto-joins you into someone else's workspace; you only carry an
     // org role where you're explicitly a member.
@@ -317,7 +324,7 @@ export function buildContext(deps: AppDeps) {
     // folded in alongside any per-artifact share (the higher wins).
     const cRoles = await meta.collectionRolesForArtifact(a.id, me.id)
     const artifactRole = maxRole(am?.role ?? null, ...cRoles)
-    return { kind: "user", userId: me.id, artifactRole, orgRole, open }
+    return { kind: "user", userId: me.id, artifactRole, orgRole }
   }
 
   /** Authorize an action against a specific artifact. */
@@ -325,15 +332,26 @@ export function buildContext(deps: AppDeps) {
     actorFor(c, a).then((actor) => can(actor, action, a.visibility))
 
   /**
-   * True when the caller is an anonymous visitor on a SECURE instance — they may
-   * view public content but nothing collaborative (comments, member list, proposals,
-   * analytics). On an open / zero-config instance, anonymous is the trusted owner,
-   * so this is false. Use as a post-`read` gate to hide collaboration from public
-   * link-visitors without touching the role model.
+   * True when the caller is an anonymous visitor — they may view public content
+   * but nothing collaborative (comments, member list, proposals, analytics).
+   * Anonymous is never a trusted principal, so this is a simple kind check. Use
+   * as a post-`read` gate to hide collaboration from public link-visitors without
+   * touching the role model.
    */
   const anonLocked = async (c: Context, a: ArtifactRecord): Promise<boolean> => {
     const actor = await actorFor(c, a)
-    return actor.kind === "anon" && !actor.open
+    return actor.kind === "anon"
+  }
+
+  /**
+   * Is the caller an authenticated principal — a static token, a registered
+   * agent, or a signed-in user — as opposed to an anonymous visitor? The single
+   * source of truth for "not anonymous", used by the global anonymous-write
+   * lockdown so a new mutating route can never accidentally be exposed to anon.
+   */
+  const isPrincipal = async (c: Context): Promise<boolean> => {
+    if (deps.token && safeEqual(bearer(c), deps.token)) return true
+    return !!(await actingUser(c))
   }
 
   /** The caller's role in their active workspace (creating artifacts, settings). */
@@ -342,7 +360,7 @@ export function buildContext(deps: AppDeps) {
     const ag = await agentFor(c)
     if (ag) return ag.role
     const me = await currentUser(c)
-    if (!me) return open ? "owner" : null
+    if (!me) return null
     return ensureMembership(await activeWorkspace(c), me.id)
   }
   const workspaceCan = async (c: Context, action: Action): Promise<boolean> => {
@@ -382,7 +400,6 @@ export function buildContext(deps: AppDeps) {
     analyticsOn,
     versionWindowMs,
     allowOrigins,
-    open,
     defaultOrg,
     defaultRole,
     publishLimiter,
@@ -398,9 +415,11 @@ export function buildContext(deps: AppDeps) {
     provisionPersonal,
     activeWorkspace,
     setWsCookie,
+    anonViewerId,
     actorFor,
     authorize,
     anonLocked,
+    isPrincipal,
     isSuperAdmin,
     workspaceRole,
     workspaceCan,

--- a/apps/api/src/lib/http.ts
+++ b/apps/api/src/lib/http.ts
@@ -33,6 +33,79 @@ export const readJson = async <T>(c: Context, schema: z.ZodType<T>): Promise<T |
 export const DEFAULT_WORKSPACE_NAME = "My Workspace"
 /** Cookie holding the active workspace id (multi-workspace mode). */
 export const WS_COOKIE = "dock_ws"
+/** Long-lived cookie that gives an anonymous browser one stable identity — used
+ *  for unique-view counts and a stable presence name across opens. */
+export const VIEWER_COOKIE = "dock_vid"
+
+// Friendly, anonymous presence handles — `helpful-kitty-95` style. An anonymous
+// viewer never picks their own name (no impersonation/spam); the server derives a
+// stable one from their viewer cookie, so the same browser keeps the same handle.
+const ANON_ADJECTIVES = [
+  "helpful",
+  "brave",
+  "calm",
+  "clever",
+  "eager",
+  "gentle",
+  "jolly",
+  "keen",
+  "lively",
+  "mellow",
+  "nimble",
+  "plucky",
+  "quiet",
+  "swift",
+  "witty",
+  "zesty",
+  "sunny",
+  "breezy",
+  "cosy",
+  "merry",
+  "spry",
+  "chipper",
+  "dapper",
+  "snappy",
+] as const
+const ANON_ANIMALS = [
+  "kitty",
+  "otter",
+  "panda",
+  "koala",
+  "finch",
+  "lynx",
+  "heron",
+  "tapir",
+  "gecko",
+  "moth",
+  "wren",
+  "yak",
+  "ibis",
+  "puma",
+  "seal",
+  "crane",
+  "fox",
+  "robin",
+  "badger",
+  "newt",
+  "vole",
+  "swan",
+  "hare",
+  "owl",
+] as const
+
+/** A deterministic `adjective-animal-NN` handle for an anonymous viewer, keyed to
+ *  a stable seed (their viewer cookie) so it doesn't change between heartbeats. */
+export const anonName = (seed: string): string => {
+  let h = 2166136261
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i)
+    h = Math.imul(h, 16777619)
+  }
+  h >>>= 0
+  const adj = ANON_ADJECTIVES[h % ANON_ADJECTIVES.length]
+  const animal = ANON_ANIMALS[(h >>> 8) % ANON_ANIMALS.length]
+  return `${adj}-${animal}-${(h >>> 16) % 100}`
+}
 
 export const VISIBILITIES = ["public", "link", "org"] as const
 

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -177,7 +177,9 @@ export const artifactRoutes = (ctx: AppContext) => {
           message: str(body["message"]),
           // Author is the authenticated identity (signed-in user or agent), never a
           // client-supplied field — a logged-in publish must be attributed to that
-          // person, not "anonymous". Anonymous can't publish at all (open mode off).
+          // person. Anonymous callers can't reach this route at all, so a publish is
+          // always attributed to a real principal (the token's optional `author`
+          // label is the one headless exception).
           author: (await actingUser(c))?.name ?? str(body["author"]),
           name: str(body["name"]),
           orgId: org,

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -15,17 +15,18 @@ import { fail, readJson } from "../lib/http"
 /** Collections: shareable groups of artifacts. A member's role on a collection
  *  propagates to every artifact inside it (see collectionRolesForArtifact). */
 export const collectionRoutes = (ctx: AppContext) => {
-  const { meta, deps, open, bearer, currentUser, activeWorkspace, workspaceCan, authorize } = ctx
+  const { meta, deps, bearer, currentUser, activeWorkspace, workspaceCan, authorize } = ctx
   const app = new Hono()
 
-  // A user's role on a collection: creator/member role, token/open → owner.
+  // A user's role on a collection: the static token is owner; otherwise the
+  // creator/member role. Anonymous (no session) has no role — never elevated.
   const collectionRole = async (c: Context, col: CollectionRecord): Promise<Role | null> => {
     if (deps.token && safeEqual(bearer(c), deps.token)) return "owner"
     const me = await currentUser(c)
-    if (!me) return open ? "owner" : null
+    if (!me) return null
     if (col.created_by === me.id) return "owner"
     const m = await meta.getCollectionMember(col.id, me.id)
-    return m?.role ?? (open ? "owner" : null)
+    return m?.role ?? null
   }
   const canManageCollection = async (c: Context, col: CollectionRecord, action: Action) =>
     roleAllows((await collectionRole(c, col)) ?? "viewer", action)

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -94,7 +94,8 @@ export const commentRoutes = (ctx: AppContext) => {
     if (!cm || cm.artifact_id !== artifact.id) return { error: fail(c, 404, "not found") }
     return { artifact, cm }
   }
-  // The acting display name (agent or signed-in user); null on an open instance.
+  // The acting display name (agent or signed-in user); null for an anonymous
+  // caller — who can't reach any commenting route anyway.
   const actorName = async (c: Context): Promise<string | null> =>
     (await actingUser(c))?.name ?? null
 

--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -2,11 +2,11 @@ import { Hono } from "hono"
 import { streamSSE } from "hono/streaming"
 import { z } from "zod"
 import type { AppContext } from "../context"
-import { fail, readJson } from "../lib/http"
+import { anonName, fail, readJson } from "../lib/http"
 
 /** Live updates per artifact (SSE) + ephemeral presence (who's viewing now). */
 export const realtimeRoutes = (ctx: AppContext) => {
-  const { meta, bus, presence, backplane, authorize } = ctx
+  const { meta, bus, presence, backplane, authorize, actingUser, anonViewerId } = ctx
   const app = new Hono()
 
   app.get("/v1/artifacts/:shortId/events", async (c) => {
@@ -36,9 +36,12 @@ export const realtimeRoutes = (ctx: AppContext) => {
   app.post("/v1/artifacts/:shortId/presence", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact || !(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
-    const body = await readJson(c, z.object({ name: z.string().optional() }).catchall(z.unknown()))
-    if (body instanceof Response) return body
-    const name = typeof body.name === "string" && body.name ? body.name : "anonymous"
+    // Presence identity is server-derived, never client-supplied: a signed-in
+    // user or agent shows by their account name; an anonymous viewer gets a
+    // stable, friendly handle (`helpful-kitty-95`) keyed to their viewer cookie,
+    // so they can't impersonate anyone or spam arbitrary names. This is the only
+    // thing an anonymous caller may do beyond reading (see the lockdown in app.ts).
+    const name = (await actingUser(c))?.name ?? anonName(anonViewerId(c))
     const viewers = await presence.heartbeat(artifact.id, name, Date.now())
     bus.publish(artifact.id, { type: "presence", viewers })
     return c.json({ viewers })
@@ -62,10 +65,14 @@ export const realtimeRoutes = (ctx: AppContext) => {
     )
     if (body instanceof Response) return body
     const clamp = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n)
+    // Same server-derived identity as presence: a signed-in user/agent by their
+    // account name, an anonymous viewer by their stable rando handle — never a
+    // client-supplied label. So a cursor and its presence row share one identity.
+    const name = (await actingUser(c))?.name ?? anonName(anonViewerId(c))
     bus.publish(artifact.id, {
       type: "cursor",
       id: body.id,
-      name: body.name ?? "anonymous",
+      name,
       color: body.color ?? "#655999",
       x: clamp(body.x),
       y: clamp(body.y),

--- a/apps/api/src/routes/session.ts
+++ b/apps/api/src/routes/session.ts
@@ -5,7 +5,7 @@ import { fail } from "../lib/http"
 
 /** Session identity + the workspace member/agent directory for the @mention picker. */
 export const sessionRoutes = (ctx: AppContext) => {
-  const { meta, deps, open, bearer, currentUser, ensureMembership, activeWorkspace } = ctx
+  const { meta, deps, bearer, currentUser, ensureMembership, activeWorkspace } = ctx
   const app = new Hono()
 
   app.get("/v1/me", async (c) => {
@@ -16,10 +16,11 @@ export const sessionRoutes = (ctx: AppContext) => {
   })
 
   // Workspace member directory for the @mention picker — people AND agents, so
-  // an agent can be @mentioned like anyone. Signed-in (or open) only; optional
-  // ?q= filters by name/email prefix. Never exposes non-members.
+  // an agent can be @mentioned like anyone. Authenticated callers only (a signed-in
+  // user or the static token); an anonymous visitor can never enumerate members.
+  // Optional ?q= filters by name/email prefix. Never exposes non-members.
   app.get("/v1/users", async (c) => {
-    if (!open && !(await currentUser(c)) && !safeEqual(bearer(c), deps.token))
+    if (!(await currentUser(c)) && !safeEqual(bearer(c), deps.token))
       return fail(c, 401, "unauthenticated")
     const org = await activeWorkspace(c)
     const members = await meta.listMemberships(org)

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -36,9 +36,6 @@ export interface Env {
   BASE_URL?: string
   DOCK_AUTH_SECRET?: string
   DOCK_SUPERADMIN_EMAILS?: string
-  /** "true" to run the edge instance open (anon = owner, zero-config). Unset/anything
-   *  else = secure: real permissions apply (anon → viewer on public, else no access). */
-  DOCK_OPEN?: string
 }
 
 let app: ReturnType<typeof createApp> | null = null
@@ -65,9 +62,6 @@ export default {
         backplane: createDoBackplane(env.ROOMS),
         baseUrl,
         auth,
-        // Secure by default on the edge: anonymous callers are NOT owners. Set
-        // DOCK_OPEN=true only for a single-user / zero-config edge instance.
-        open: env.DOCK_OPEN === "true",
         superAdmins: (env.DOCK_SUPERADMIN_EMAILS ?? "")
           .split(",")
           .map((s) => s.trim().toLowerCase())

--- a/apps/api/test/analytics.test.ts
+++ b/apps/api/test/analytics.test.ts
@@ -3,14 +3,17 @@ import { FsBlobStore } from "@dock/storage/fs"
 import { describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
 import {
+  anonApp,
   app,
   as,
+  bearer,
   dir,
   json,
   jsonAs,
   makeAuthedApp,
   meta,
   publishAs,
+  TEST_TOKEN,
   type TestUser,
   upload,
 } from "./helpers"
@@ -24,7 +27,7 @@ describe("view analytics", () => {
     // recorded view — a refresh no longer inflates the count.
     let cookie = ""
     for (let i = 0; i < 3; i++) {
-      const r = await app.request(`/v1/artifacts/${short_id}/view`, {
+      const r = await anonApp.request(`/v1/artifacts/${short_id}/view`, {
         method: "POST",
         headers: { "content-type": "application/json", ...(cookie ? { cookie } : {}) },
         body: JSON.stringify({ version: 1 }),
@@ -32,13 +35,13 @@ describe("view analytics", () => {
       cookie ||= (r.headers.get("set-cookie") ?? "").split(";")[0] ?? ""
     }
     // The same viewer on a different version is a distinct view.
-    await app.request(`/v1/artifacts/${short_id}/view`, {
+    await anonApp.request(`/v1/artifacts/${short_id}/view`, {
       method: "POST",
       headers: { "content-type": "application/json", cookie },
       body: JSON.stringify({ version: 2 }),
     })
     // A fresh anonymous viewer (no cookie) is a distinct unique.
-    await app.request(`/v1/artifacts/${short_id}/view`, {
+    await anonApp.request(`/v1/artifacts/${short_id}/view`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ version: 2 }),
@@ -133,10 +136,26 @@ describe("live stream (SSE)", () => {
     }
   })
 
-  it("reports presence on heartbeat", async () => {
-    const { short_id } = await (await upload("p.md", "# p", {})).json()
-    const res = await app.request(`/v1/artifacts/${short_id}/presence`, json({ name: "Jess" }))
-    expect((await res.json()).viewers).toEqual(["Jess"])
+  it("reports presence by server identity (signed-in name; anon gets a rando handle)", async () => {
+    const jess: TestUser = { id: "u_pres_jess", email: "jess@dock.test", name: "Jess" }
+    const { app: a } = makeAuthedApp("presence", [jess])
+    const { short_id } = await (
+      await publishAs(a, "<h1>p</h1>", { visibility: "public" }, as(jess.email))
+    ).json()
+    // Signed-in: the heartbeat is attributed to the account name, never a
+    // client-supplied one.
+    const signed = await a.request(
+      `/v1/artifacts/${short_id}/presence`,
+      jsonAs(as(jess.email), { name: "SPOOF" }),
+    )
+    const signedViewers = (await signed.json()).viewers as string[]
+    expect(signedViewers).toContain("Jess")
+    expect(signedViewers).not.toContain("SPOOF")
+    // Anonymous: a stable, friendly handle (helpful-kitty-95 style), never "anonymous".
+    const anon = await a.request(`/v1/artifacts/${short_id}/presence`, json({}))
+    const viewers = (await anon.json()).viewers as string[]
+    expect(viewers).not.toContain("anonymous")
+    expect(viewers.some((v) => /^[a-z]+-[a-z]+-\d{1,2}$/.test(v))).toBe(true)
   })
 })
 
@@ -213,11 +232,13 @@ describe("analytics: identity + retention", () => {
       blobs: new FsBlobStore(join(dir, "blobs")),
       baseUrl: "https://api.dock.test",
       crossSite: true,
+      token: TEST_TOKEN,
     })
     const fd = new FormData()
     fd.append("file", new Blob([new TextEncoder().encode("# x")]), "x.md")
+    // Publish as the token (owner); the view below is anonymous so it sets the cookie.
     const { short_id } = await (
-      await xs.request("/v1/artifacts", { method: "POST", body: fd })
+      await xs.request("/v1/artifacts", { method: "POST", body: fd, headers: bearer(TEST_TOKEN) })
     ).json()
     const r = await xs.request(`/v1/artifacts/${short_id}/view`, {
       method: "POST",

--- a/apps/api/test/anonymous.test.ts
+++ b/apps/api/test/anonymous.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest"
 import { as, json, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 
-// On a SECURE instance (token set => open=false), an anonymous visitor can view a
-// public artifact and nothing else: no comments, members, proposals, analytics,
-// sharing, or writes. Presence + cursor stay open (Google-Docs anonymous presence).
+// An anonymous visitor (no session, no token) can view a public artifact and send
+// the ephemeral "I'm here" signals — a presence heartbeat and a live cursor. Nothing
+// else: no comments, members, proposals, analytics, sharing, or any write. There is
+// no "open" mode that would elevate them.
 // Authenticated users keep normal role-based access — a viewer still sees comments.
 describe("anonymous lockdown (secure instance)", () => {
   const owner: TestUser = { id: "u_own", email: "own@dock.test", name: "Owner One" }
@@ -31,7 +32,9 @@ describe("anonymous lockdown (secure instance)", () => {
     ).json()
     const a = (p: string, init?: RequestInit) => app.request(`/v1/artifacts/${short_id}${p}`, init)
 
-    // allowed: view content + presence/cursor (Google-Docs anonymous presence)
+    // allowed: read content + the "someone is viewing" signals — a presence
+    // heartbeat and a live cursor (Figma-style viral viewing). Both are ephemeral
+    // and server-named; they are the ONLY things an anonymous caller may do.
     expect((await a("")).status).toBe(200)
     expect((await a("/content")).status).toBe(200)
     expect((await a("/presence", json({ name: "Guest" }))).status).toBe(200)
@@ -71,5 +74,73 @@ describe("anonymous lockdown (secure instance)", () => {
     })
     expect(list.status).toBe(200)
     expect((await list.json()).comments.length).toBe(1)
+  })
+})
+
+// The structural guarantee: NO anonymous caller can ever mutate anything. This
+// sweeps every mutating surface at once, so a regression (or a newly added route
+// that forgets its gate) trips here. The only things anon may do are read a
+// public artifact, count a view, and send a presence heartbeat.
+describe("anonymous can never write — global lockdown sweep", () => {
+  const owner: TestUser = { id: "u_sweep_own", email: "sweepown@dock.test", name: "Owner" }
+  const { app } = makeAuthedApp("anon-sweep", [owner])
+  let shortId: string
+  const at = (p: string, init?: RequestInit) => app.request(`/v1/artifacts/${shortId}${p}`, init)
+  const put = (body: unknown) => ({
+    method: "PUT" as const,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  })
+
+  it("seeds a public artifact (as the owner) to probe against", async () => {
+    shortId = (
+      await (await publishAs(app, "<h1>pub</h1>", { visibility: "public" }, as(owner.email))).json()
+    ).short_id
+    expect(shortId).toBeTruthy()
+  })
+
+  it("allows ONLY read + the ephemeral viewing signals for an anonymous caller", async () => {
+    expect((await at("")).status).toBe(200) // read metadata
+    expect((await at("/content")).status).toBe(200) // read content
+    expect((await at("/view", json({}))).status).toBe(204) // passive view counter
+    expect((await at("/presence", json({}))).status).toBe(200) // "someone is viewing"
+    expect((await at("/cursor", json({ id: "g", x: 0, y: 0 }))).status).toBe(204) // live cursor
+  })
+
+  it("refuses every anonymous mutation across the API", async () => {
+    // artifact-scoped writes
+    expect((await publishAs(app, "<h1>v2</h1>", {}, {}, shortId)).status).toBe(403)
+    expect((await at("/comments", json({ body_md: "x" }))).status).toBe(403)
+    expect((await at("/proposals", json({}))).status).toBe(403)
+    expect((await at("/report", json({ reason: "spam" }))).status).toBe(403)
+    expect((await at("/takedown", json({}))).status).toBe(403)
+    expect((await at("/restore", json({ version: 1 }))).status).toBe(403)
+    expect((await at("/members", put({ email: "x@y.com", role: "editor" }))).status).toBe(403)
+    expect((await at("/favorite", { method: "PUT" })).status).toBe(403)
+    expect((await at("/tags", put({ tags: ["x"] }))).status).toBe(403)
+    // workspace / collection / agent / webhook creation
+    expect((await app.request("/v1/collections", json({ title: "c" }))).status).toBe(403)
+    expect((await app.request("/v1/workspaces", json({ name: "w" }))).status).toBe(403)
+    expect((await app.request("/v1/agents", json({ name: "a" }))).status).toBe(403)
+    expect(
+      (
+        await app.request(
+          "/v1/webhooks",
+          json({ url: "https://example.com/h", events: ["version.published"] }),
+        )
+      ).status,
+    ).toBe(403)
+    expect(
+      (await app.request("/v1/workspace", { ...json({ name: "x" }), method: "PATCH" })).status,
+    ).toBe(403)
+  })
+
+  it("hides the member directory and private artifacts from anonymous callers", async () => {
+    expect((await app.request("/v1/users")).status).toBe(401)
+    const priv = (
+      await (await publishAs(app, "<h1>secret</h1>", { visibility: "org" }, as(owner.email))).json()
+    ).short_id
+    expect((await app.request(`/v1/artifacts/${priv}`)).status).toBe(404)
+    expect((await app.request(`/v1/artifacts/${priv}/content`)).status).toBe(404)
   })
 })

--- a/apps/api/test/artifacts.test.ts
+++ b/apps/api/test/artifacts.test.ts
@@ -4,7 +4,7 @@ import { FsBlobStore } from "@dock/storage/fs"
 import { zipSync } from "fflate"
 import { describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
-import { app, dir, meta, postJson, upload } from "./helpers"
+import { app, dir, meta, ownerApp, postJson, upload } from "./helpers"
 
 describe("version sessions", () => {
   it("a named publish stores the checkpoint name on the version", async () => {
@@ -54,7 +54,7 @@ describe("version sessions", () => {
 
   it("honors the configured window (each revision its own session)", async () => {
     const m2 = new SqliteMetaStore(join(dir, "win.db"))
-    const app2 = createApp({
+    const app2 = ownerApp({
       meta: m2,
       blobs: new FsBlobStore(join(dir, "blobs")),
       baseUrl: "http://dock.test",

--- a/apps/api/test/helpers.ts
+++ b/apps/api/test/helpers.ts
@@ -128,12 +128,50 @@ const makeStore = (name: string, users: TestUser[], team: Seat[] = []): TestStor
   return m
 }
 
+// The shared default app is SECURED with a static token — anonymous callers can
+// no longer write (open mode is gone). The convenience helpers below
+// (`upload`/`postJson`/`pub`) authenticate as that token by default, so most test
+// bodies stay unchanged while still exercising the real authz path. Tests that
+// probe anonymous behavior stand up their own no-token app.
+export const TEST_TOKEN = "tok"
+const TOKEN_HEADER = { authorization: `Bearer ${TEST_TOKEN}` }
+
+// Wrap an app so every request auto-authenticates as the static token (owner)
+// unless the caller set their own Authorization header. The overwhelming majority
+// of tests drive an app to set up + exercise happy paths and never thought about
+// auth (anonymous used to be the owner); routing them through the token keeps
+// those bodies unchanged against a now-SECURED instance. Anonymous-probe tests
+// send no Authorization (or use `anonApp`), so requests there stay anonymous.
+export const authProxy = <T extends ReturnType<typeof createApp>>(a: T): T =>
+  new Proxy(a, {
+    get(target, prop, receiver) {
+      if (prop !== "request") return Reflect.get(target, prop, receiver)
+      return (input: string | URL | Request, init?: RequestInit) => {
+        const headers = new Headers(init?.headers as HeadersInit | undefined)
+        if (!headers.has("authorization")) headers.set("authorization", `Bearer ${TEST_TOKEN}`)
+        return target.request(input as string, { ...init, headers })
+      }
+    },
+  }) as T
+
+// A standalone app with custom deps, secured by the test token and wrapped so its
+// requests auto-authenticate as that token — the shared `app` with knobs (sandbox
+// origin, version window, …).
+export const ownerApp = (deps: Omit<AppDeps, "token">) =>
+  authProxy(createApp({ ...deps, token: TEST_TOKEN }))
+
 export const meta = makeStore("default", [])
-export const app = createApp({
+const sharedApp = createApp({
   meta,
   blobs: new FsBlobStore(join(dir, "blobs")),
   baseUrl: "http://dock.test",
+  token: TEST_TOKEN,
 })
+// The default app: every request authenticates as the token (owner).
+export const app = authProxy(sharedApp)
+// The SAME instance + store, but with NO auto-auth — send your own headers; with
+// none you are anonymous. For probing anonymous behavior against shared data.
+export const anonApp = sharedApp
 
 afterAll(async () => {
   if (PG_URL) await Promise.all(pgStores.map((s) => Promise.resolve(s.close()).catch(() => {})))
@@ -152,13 +190,13 @@ export const upload = (
   form.append("file", new Blob([bytes as BlobPart]), name)
   for (const [k, v] of Object.entries(fields)) form.append(k, v)
   const url = shortId ? `/v1/artifacts/${shortId}/versions` : "/v1/artifacts"
-  return app.request(url, { method: "POST", body: form })
+  return app.request(url, { method: "POST", body: form, headers: TOKEN_HEADER })
 }
 
 export const postJson = (path: string, body: unknown) =>
   app.request(path, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...TOKEN_HEADER },
     body: JSON.stringify(body),
   })
 
@@ -251,16 +289,18 @@ export const proposeAs = (
 export const bearer = (token: string) => ({ authorization: `Bearer ${token}` })
 
 // C4b — launch-gate prevention: storage quotas + per-actor rate limits.
-// A fresh app with custom deps. Without `users` it's an open instance (anonymous
-// = owner) — handy for quota/anonymous-flood tests; with `users` it's secured
-// and the session is picked by an `x-test-user` header, for per-actor tests.
+// A fresh app with custom deps, always SECURED by a static token (anonymous
+// callers can't write). `pub(app, …)` with no headers authenticates as that
+// token; with `users`, an `x-test-user` header picks a session, for per-actor
+// tests.
 export const quotaApp = (name: string, extra: Partial<AppDeps>, users?: TestUser[]) => {
   const m = makeStore(name, users ?? [])
   const app = createApp({
     meta: m,
     blobs: new FsBlobStore(join(dir, `blobs-${name}`)),
     baseUrl: "http://dock.test",
-    ...(users ? { token: "tok", auth: fakeAuth(users) } : {}),
+    token: TEST_TOKEN,
+    ...(users ? { auth: fakeAuth(users) } : {}),
     ...extra,
   })
   return { app, meta: m }
@@ -279,5 +319,8 @@ export const pub = (
   form.append("file", new Blob([new TextEncoder().encode(content)]), "f.html")
   for (const [k, v] of Object.entries(fields)) form.append(k, v)
   const url = shortId ? `/v1/artifacts/${shortId}/versions` : "/v1/artifacts"
-  return app.request(url, { method: "POST", body: form, headers })
+  // Default to the static token (owner) so a bare `pub(app, …)` writes; an
+  // explicit session header (e.g. `as(amy)`) still wins for per-actor tests.
+  const h = Object.keys(headers).length ? headers : TOKEN_HEADER
+  return app.request(url, { method: "POST", body: form, headers: h })
 }

--- a/apps/api/test/moderation.test.ts
+++ b/apps/api/test/moderation.test.ts
@@ -11,11 +11,17 @@ describe("moderation: report → takedown (410) → reinstate + audit (C4a)", ()
     await app.request("/v1/me", { headers: as(owner.email) })
     await app.request("/v1/me", { headers: as(dev.email) })
     shortId = (await (await publishAs(app, "<h1>spammy</h1>", {}, as(owner.email))).json()).short_id
-    // No reason → 400. Anonymous (no session) → still allowed.
-    expect((await app.request(`/v1/artifacts/${shortId}/report`, jsonAs({}, {}))).status).toBe(400)
+    // Anonymous (no session) can't report at all — refused at the door.
+    expect(
+      (await app.request(`/v1/artifacts/${shortId}/report`, jsonAs({}, { reason: "x" }))).status,
+    ).toBe(403)
+    // Signed in but no reason → 400.
+    expect(
+      (await app.request(`/v1/artifacts/${shortId}/report`, jsonAs(as(dev.email), {}))).status,
+    ).toBe(400)
     const r = await app.request(
       `/v1/artifacts/${shortId}/report`,
-      jsonAs({}, { reason: "phishing", detail: "fake login page" }),
+      jsonAs(as(dev.email), { reason: "phishing", detail: "fake login page" }),
     )
     expect(r.status).toBe(201)
   })

--- a/apps/api/test/permissions.test.ts
+++ b/apps/api/test/permissions.test.ts
@@ -2,7 +2,7 @@ import { join } from "node:path"
 import { FsBlobStore } from "@dock/storage/fs"
 import { describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
-import { app, as, dir, jsonAs, makeAuthedApp, meta, publishAs, type TestUser } from "./helpers"
+import { anonApp, as, dir, jsonAs, makeAuthedApp, meta, publishAs, type TestUser } from "./helpers"
 
 describe("auth: token write-gating + per-artifact read-gating", () => {
   const authApp = createApp({
@@ -41,10 +41,14 @@ describe("auth: token write-gating + per-artifact read-gating", () => {
     expect((await authApp.request(`/v1/artifacts/${short_id}`, authed())).status).toBe(200)
   })
 
-  it("leaves a no-token instance fully open (the default app)", async () => {
+  it("rejects anonymous writes even on a no-token instance (no open mode)", async () => {
+    // `anonApp` is the shared instance with no auto-auth: a request with no
+    // Authorization is anonymous, and anonymous can never publish.
     const form = new FormData()
     form.append("file", new Blob([new TextEncoder().encode("# x")]), "x.md")
-    expect((await app.request("/v1/artifacts", { method: "POST", body: form })).status).toBe(201)
+    expect((await anonApp.request("/v1/artifacts", { method: "POST", body: form })).status).toBe(
+      403,
+    )
   })
 })
 

--- a/apps/api/test/quotas.test.ts
+++ b/apps/api/test/quotas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { as, pub, quotaApp, type TestUser } from "./helpers"
+import { as, bearer, pub, quotaApp, type TestUser } from "./helpers"
 
 describe("quotas: per-workspace storage caps (C4b)", () => {
   it("persists each version's byte size and meters the workspace total", async () => {
@@ -52,7 +52,7 @@ describe("rate limits: per-actor write throttles (C4b)", () => {
     const comment = () =>
       app.request(`/v1/artifacts/${a.short_id}/comments`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", ...bearer("tok") },
         body: JSON.stringify({ body_md: "hi", author: "x" }),
       })
     expect((await comment()).status).toBe(201)

--- a/apps/api/test/security.test.ts
+++ b/apps/api/test/security.test.ts
@@ -3,10 +3,10 @@ import { SqliteMetaStore } from "@dock/db/sqlite"
 import { FsBlobStore } from "@dock/storage/fs"
 import { describe, expect, it } from "vitest"
 import { createApp, isPublicHttpUrl } from "../src/app"
-import { as, dir, makeAuthedApp, meta, type TestUser } from "./helpers"
+import { as, dir, makeAuthedApp, meta, ownerApp, type TestUser } from "./helpers"
 
 describe("security: sandbox serving origin (A4)", () => {
-  const app = createApp({
+  const app = ownerApp({
     meta: new SqliteMetaStore(join(dir, "sandbox.db")),
     blobs: new FsBlobStore(join(dir, "blobs")),
     baseUrl: "http://app.test",
@@ -45,7 +45,7 @@ describe("security: sandbox serving origin (A4)", () => {
   })
 
   it("without a sandbox origin, raw is served in place (single-origin self-host)", async () => {
-    const solo = createApp({
+    const solo = ownerApp({
       meta: new SqliteMetaStore(join(dir, "solo.db")),
       blobs: new FsBlobStore(join(dir, "blobs")),
       baseUrl: "http://app.test",

--- a/apps/api/test/tenant-isolation.test.ts
+++ b/apps/api/test/tenant-isolation.test.ts
@@ -101,7 +101,7 @@ describe.skipIf(process.env.DOCK_TEST_DB === "pg" && !process.env.TEST_DATABASE_
       const aliceArt = await publish(app, alice)
       const rep = await app.request(`/v1/artifacts/${aliceArt}/report`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", ...as(alice.email) },
         body: JSON.stringify({ reason: "spam" }),
       })
       expect(rep.status).toBe(201)

--- a/apps/api/test/webhooks.test.ts
+++ b/apps/api/test/webhooks.test.ts
@@ -5,8 +5,8 @@ import type { ArtifactRecord } from "@dock/core"
 import { SqliteMetaStore } from "@dock/db/sqlite"
 import { FsBlobStore } from "@dock/storage/fs"
 import { afterAll, describe, expect, it } from "vitest"
-import { createApp } from "../src/app"
 import { buildPayload, sign, slackMessage } from "../src/webhooks"
+import { ownerApp } from "./helpers"
 
 const sampleArtifact = {
   id: "a1",
@@ -45,7 +45,7 @@ describe("webhook formatting + signing", () => {
 
 const dir = mkdtempSync(join(tmpdir(), "dock-wh-"))
 const meta = new SqliteMetaStore(join(dir, "dock.db"))
-const app = createApp({
+const app = ownerApp({
   meta,
   blobs: new FsBlobStore(join(dir, "blobs")),
   baseUrl: "http://dock.test",

--- a/apps/api/test/workspace.test.ts
+++ b/apps/api/test/workspace.test.ts
@@ -157,24 +157,20 @@ describe("workspace: edge conditions", () => {
   })
 })
 
-describe("workspace: open + token modes", () => {
-  it("an unsecured instance trusts anon as Admin and defaults the name", async () => {
-    const openApp = createApp({
+describe("workspace: anonymous lockout + token mode", () => {
+  it("a no-token instance still does NOT trust anonymous callers (can't manage)", async () => {
+    const noTokenApp = createApp({
       meta: new SqliteMetaStore(join(dir, "ws-open.db")),
       blobs: new FsBlobStore(join(dir, "blobs")),
       baseUrl: "http://dock.test",
     })
-    const w = await (await openApp.request("/v1/workspace")).json()
-    expect(w.name).toBe("My Workspace")
-    expect(w.role).toBe("owner")
-    expect(w.members).toEqual([])
-    const renamed = await openApp.request("/v1/workspace", {
+    // No open-mode owner elevation: an anonymous caller can't rename the workspace.
+    const renamed = await noTokenApp.request("/v1/workspace", {
       method: "PATCH",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ name: "Solo" }),
     })
-    expect(renamed.status).toBe(200)
-    expect((await renamed.json()).name).toBe("Solo")
+    expect(renamed.status).toBe(403)
   })
 
   it("a static token acts as Admin", async () => {

--- a/apps/web/e2e/deep/review.deep.spec.ts
+++ b/apps/web/e2e/deep/review.deep.spec.ts
@@ -1,13 +1,15 @@
-import { expect, proposeEdit, publishArtifact, test } from "../fixtures"
+import { expect, proposeEdit, publishArtifact, shareArtifact, test } from "../fixtures"
 
 // The review overlay (full-screen, tabbed Proposed/Current/Diff + decision bar)
-// in depth. The `owner` fixture approves; the `secondUser` (an editor on the
-// link-visible artifact) authors the proposals, so owner ≠ author and can decide.
+// in depth. The `owner` fixture approves; the `secondUser` (shared as an editor on
+// the artifact) authors the proposals, so owner ≠ author and can decide.
 test("owner reviews proposals: toggles views, approves one, requests changes on another", async ({
   owner,
   secondUser,
 }) => {
   const id = await publishArtifact(owner)
+  // Only collaborators can propose — share the artifact with the teammate first.
+  await shareArtifact(owner.request, id, secondUser.email, "editor")
   await proposeEdit(secondUser.page.request, id, "Tighten the intro", "# Doc\n\ntighter intro")
   await proposeEdit(secondUser.page.request, id, "Fix the footer", "# Doc\n\nbody\n\nfixed footer")
 

--- a/apps/web/e2e/fixtures.ts
+++ b/apps/web/e2e/fixtures.ts
@@ -5,6 +5,7 @@ import {
   openArtifact,
   proposeEdit,
   publishArtifact,
+  shareArtifact,
   signUp,
 } from "./helpers"
 
@@ -38,4 +39,13 @@ export const test = base.extend<Fixtures>({
   },
 })
 
-export { activateThread, addComment, expect, openArtifact, proposeEdit, publishArtifact, signUp }
+export {
+  activateThread,
+  addComment,
+  expect,
+  openArtifact,
+  proposeEdit,
+  publishArtifact,
+  shareArtifact,
+  signUp,
+}

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -98,3 +98,18 @@ export async function proposeEdit(
     expect(res.ok(), `propose failed: ${res.status()}`).toBeTruthy()
   }).toPass({ timeout: 10_000 })
 }
+
+// Grant another account a role on an artifact (the GDocs-style per-artifact share).
+// Needed so a collaborator can comment/propose — only members can; an anonymous or
+// non-member link visitor is read-only.
+export async function shareArtifact(
+  req: APIRequestContext,
+  shortId: string,
+  email: string,
+  role: "viewer" | "commenter" | "editor" | "owner",
+): Promise<void> {
+  await expect(async () => {
+    const res = await req.put(`/v1/artifacts/${shortId}/members`, { data: { email, role } })
+    expect(res.ok(), `share failed: ${res.status()}`).toBeTruthy()
+  }).toPass({ timeout: 10_000 })
+}

--- a/apps/web/e2e/smoke/review.smoke.spec.ts
+++ b/apps/web/e2e/smoke/review.smoke.spec.ts
@@ -1,8 +1,11 @@
-import { expect, proposeEdit, publishArtifact, test } from "../fixtures"
+import { expect, proposeEdit, publishArtifact, shareArtifact, test } from "../fixtures"
 
 // A teammate proposes an edit; the owner opens the review overlay and approves it.
 test("owner approves a proposed change", async ({ owner, secondUser }) => {
   const shortId = await publishArtifact(owner)
+  // The teammate must be a collaborator to propose — share it with them first
+  // (only members can comment/propose; a non-member link visitor is read-only).
+  await shareArtifact(owner.request, shortId, secondUser.email, "commenter")
   await proposeEdit(secondUser.page.request, shortId, "Tighten the intro", "# Doc\n\ntighter intro")
 
   await owner.goto(`/a/${shortId}`)

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -55,12 +55,6 @@ export interface Actor {
   artifactRole?: Role | null
   /** Baseline role from membership in the artifact's workspace, if any. */
   orgRole?: Role | null
-  /**
-   * "Open" instance: anonymous (and non-member) callers are trusted as owners,
-   * for zero-config self-host / CI. Set per deployment (the `open` dep / DOCK_OPEN);
-   * a real multi-user instance leaves it off so normal permissions apply.
-   */
-  open?: boolean
 }
 
 /**
@@ -74,9 +68,9 @@ export function effectiveRole(actor: Actor, visibility: Visibility): Role | null
     const explicit = actor.artifactRole ?? actor.orgRole
     if (explicit) return explicit
   }
-  // No membership / anonymous: an unsecured instance trusts everyone; otherwise
-  // only public + link artifacts are world-readable.
-  if (actor.open) return "owner"
+  // No membership / anonymous: only public + link artifacts are world-readable,
+  // and only as a viewer. There is deliberately no "trusted anonymous" path — an
+  // unauthenticated caller can never be elevated to a writing role.
   return visibility === "public" || visibility === "link" ? "viewer" : null
 }
 

--- a/packages/core/test/permissions.test.ts
+++ b/packages/core/test/permissions.test.ts
@@ -43,13 +43,12 @@ describe("effectiveRole resolution", () => {
     expect(effectiveRole(user({}), "org")).toBe(null)
     expect(effectiveRole(user({}), "password")).toBe(null)
   })
-  it("a static token is owner; anon on a secured instance is read-only", () => {
+  it("a static token is owner; an anonymous caller is always read-only", () => {
     expect(effectiveRole({ kind: "token" }, "org")).toBe("owner")
+    // No "open"/trusted-anonymous path exists: anon never gets a writing role.
     expect(effectiveRole({ kind: "anon" }, "org")).toBe(null)
     expect(effectiveRole({ kind: "anon" }, "link")).toBe("viewer")
-  })
-  it("an unsecured (open) instance trusts anonymous callers as owners", () => {
-    expect(effectiveRole({ kind: "anon", open: true }, "org")).toBe("owner")
+    expect(effectiveRole({ kind: "anon" }, "public")).toBe("viewer")
   })
 })
 

--- a/packages/mcp/test/client.test.ts
+++ b/packages/mcp/test/client.test.ts
@@ -16,16 +16,19 @@ const dir = mkdtempSync(join(tmpdir(), "dock-mcp-"))
 
 beforeAll(async () => {
   meta = new SqliteMetaStore(join(dir, "dock.db"))
+  // The MCP server authenticates to Dock with a static token (DOCK_TOKEN in prod);
+  // anonymous callers can't write, so the test wires the same token end-to-end.
   const app = createApp({
     meta,
     blobs: new FsBlobStore(join(dir, "blobs")),
     baseUrl: "http://dock.test",
+    token: "tok",
   })
   await new Promise<void>((resolve) => {
     server = serve({ fetch: app.fetch, port: 0 }, () => resolve())
   })
   const port = (server.address() as AddressInfo).port
-  client = createClient({ baseUrl: `http://localhost:${port}` })
+  client = createClient({ baseUrl: `http://localhost:${port}`, token: "tok" })
 })
 
 afterAll(() => {


### PR DESCRIPTION
## Why

Builds on #92 / #96 / #100. Those secured the **edge** and locked anonymous to view-only **on a secure instance** — but the `open` mechanism stayed in place. A Node self-host with no `DOCK_TOKEN` still defaulted to `open` (`open = !token`), which means **anonymous = owner on the most common deployment**. The original "published as anonymous" footgun was still reachable there.

This removes the `open` concept outright. Its only effect anywhere was elevating anonymous to owner, so deleting it makes the footgun structurally impossible to reintroduce.

## What

**Remove `open` entirely**
- `core/permissions`: drop the `Actor.open` field and the `if (actor.open) return "owner"` line. Anonymous / non-members fall to the visibility floor — `viewer` on public/link, `null` otherwise.
- `api/context`: drop the `open` dep/var/exports; `workspaceRole` returns `null` for no-session; `anonLocked` becomes a plain `kind === "anon"`; add `isPrincipal` (token | agent | user) and `anonViewerId` (a stable per-browser cookie). `worker` / `collections` / `session` de-opened.

**Hard structural lockdown.** A single global `/v1/*` middleware refuses every non-GET request from an anonymous caller, except a tiny allowlist — `presence`, `view`-count, and live `cursor`. A newly added mutating route can never accidentally be exposed to anonymous callers. Abuse reports now require a session.

**Identity-safe viral viewing.** Presence and cursor names are now **server-derived**, never client-supplied: a signed-in user shows by their account name, an anonymous viewer by a stable, friendly handle (`breezy-otter-35`). No impersonation, no spoofing. The live cursors and anon viral viewing from #100 are **kept** (allow-listed) — the Figma/Notion-style experience is preserved, just locked down and identity-safe.

## Behaviour (anonymous, no token, no session)

| Action | Result |
|---|---|
| read a public/link artifact + content | `200` |
| presence heartbeat | `200` → server handle (`breezy-otter-35`), never the client's label |
| live cursor | `204` (kept) |
| publish / comment / report / share / manage | `403` |
| list the member directory | `401` |

## Tests

Secure the shared test app with a token and auto-authenticate the helpers (author attribution preserved via the token path); add `anonApp` / `ownerApp`; an exhaustive "anonymous can only read + presence + cursor" sweep over every mutating surface; presence asserts the server handle, never a client label.

- `pnpm typecheck` · `pnpm run ci` · `pnpm test` (148 api + 24 core + 10 mcp, sqlite) · `pnpm test:pg` (148 api, Postgres) — all green.
- Verified live: anon read `200`, presence `breezy-otter-35`, cursor `204`, publish/comment/report `403`, `/v1/users` `401`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)