### PR TITLE
refactor(api): one source for the SPA-vs-API serving contract + parity test

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -66,9 +66,13 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   const dataDir = env.DATA_DIR ?? "./data"
   // Single-container self-host: when the web SPA has been built, this process
   // serves it. DOCK_WEB_DIR overrides; default is the build output beside us.
-  // TanStack Start's SPA build emits `_shell.html` (not index.html).
+  // TanStack Start's SPA build emits `_shell.html`; the edge prep copies it to
+  // `index.html`. Accept either (preferring `index.html`) so the bundled-SPA
+  // server and the Worker agree on one shell, whatever the build left behind.
   const webDir = resolve(env.DOCK_WEB_DIR ?? join(import.meta.dirname, "../../web/dist/client"))
-  const webShell = join(webDir, "_shell.html")
+  const webShell =
+    [join(webDir, "index.html"), join(webDir, "_shell.html")].find(existsSync) ??
+    join(webDir, "_shell.html")
 
   const webOrigins = (env.DOCK_WEB_ORIGIN ?? "")
     .split(",")

--- a/apps/api/src/lib/serve-web.ts
+++ b/apps/api/src/lib/serve-web.ts
@@ -1,0 +1,60 @@
+import { serveStatic } from "@hono/node-server/serve-static"
+import type { Hono } from "hono"
+
+/**
+ * The single source of truth for which request paths the API/server owns. Every
+ * other GET falls back to the SPA shell so the client router handles it (deep
+ * links, refresh, /a/:ref, /settings, …).
+ *
+ * The same contract is declared in two other places that can't import a value —
+ * the Cloudflare Worker (`wrangler.toml` `run_worker_first`) and the Vite dev
+ * proxy (`apps/web/vite.config.ts`). `serve-web.test.ts` parses both and asserts
+ * they stay in lockstep with this list, so the Node server, the edge Worker, and
+ * local dev can never disagree about who owns a path.
+ *
+ *  · prefixes match the path and any subpath (`/v1`, `/v1/artifacts`, …)
+ *  · exact paths match only themselves (`/healthz`)
+ */
+const API_PREFIXES = ["/v1", "/api", "/raw"] as const
+const API_EXACT = ["/healthz"] as const
+
+/** Server-owned path tokens in declaration order (as the dev proxy lists them). */
+export const API_PATHS: readonly string[] = [...API_PREFIXES, ...API_EXACT]
+
+/** True when the API/server owns this path (everything else is the SPA's). */
+export const isApiPath = (path: string): boolean =>
+  API_PREFIXES.some((p) => path.startsWith(p)) || (API_EXACT as readonly string[]).includes(path)
+
+/** The `run_worker_first` globs this contract implies (prefixes → `/*`, exact as-is). */
+export const workerFirstGlobs = (): string[] => [...API_PREFIXES.map((p) => `${p}/*`), ...API_EXACT]
+
+// Content-hashed assets never change behind a URL — cache them for a year. A new
+// build emits new hashes, so this is safe and maximizes cache hits.
+const IMMUTABLE_CACHE = "public, max-age=31536000, immutable"
+
+export interface ServeWebOpts {
+  /** serveStatic root, relative to `process.cwd()`. */
+  webRoot: string
+  /** The SPA shell HTML (index.html / _shell.html), already read from disk. */
+  shellHtml: string
+}
+
+/**
+ * Serve the bundled SPA from the API process (single-container self-host). This is
+ * the Node-mode mirror of the Worker's Cloudflare Static Assets: hashed `/assets/*`
+ * cached immutably, other root files served as-is, and any non-API GET falling back
+ * to the shell so the client router takes over. API routes mounted before this
+ * always win; `isApiPath` keeps unmatched API URLs as JSON 404s instead of leaking
+ * the shell.
+ */
+export const mountWeb = (app: Hono, { webRoot, shellHtml }: ServeWebOpts): void => {
+  app.use(
+    "/assets/*",
+    serveStatic({ root: webRoot, onFound: (_p, c) => c.header("Cache-Control", IMMUTABLE_CACHE) }),
+  )
+  // Root-level static files Vite emits (favicon, manifest, …).
+  app.get("/:file{[^/]+\\.[^/]+}", serveStatic({ root: webRoot }))
+  app.notFound((c) =>
+    isApiPath(c.req.path) ? c.json({ error: "not found" }, 404) : c.html(shellHtml),
+  )
+}

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -6,12 +6,12 @@ import { SqliteMetaStore } from "@dock/db/sqlite"
 import { FsBlobStore } from "@dock/storage/fs"
 import { s3FromUrl } from "@dock/storage/s3"
 import { serve } from "@hono/node-server"
-import { serveStatic } from "@hono/node-server/serve-static"
 import Database from "better-sqlite3"
 import { Pool } from "pg"
 import { createApp } from "./app"
 import { type AuthDb, makeAuth, migrateAuth } from "./auth-config"
 import { loadConfig, resolveAuthSecret, resolveDefaultOrg } from "./config"
+import { mountWeb } from "./lib/serve-web"
 import { log } from "./log"
 import { startWebhookWorker } from "./webhooks"
 
@@ -92,30 +92,14 @@ const app = createApp({
 })
 
 // Serve the bundled SPA from this process (single-container self-host). The API
-// routes above always win; static assets are served by hash (immutable), and any
-// other GET that isn't an API/asset path falls back to index.html so the client
-// router can take over (deep links, refresh). serveStatic roots are cwd-relative.
-if (cfg.serveWeb) {
-  const webRoot = relative(process.cwd(), cfg.webDir) || "."
-  const shellHtml = readFileSync(cfg.webShell, "utf8")
-  // Vite's /assets/* are content-hashed, so the bytes behind a URL never change
-  // — cache them hard (a year, immutable). A new build emits new hashes.
-  app.use(
-    "/assets/*",
-    serveStatic({
-      root: webRoot,
-      onFound: (_path, c) => c.header("Cache-Control", "public, max-age=31536000, immutable"),
-    }),
-  )
-  // Root-level static files Vite emits (favicon, manifest, etc.).
-  app.get("/:file{[^/]+\\.[^/]+}", serveStatic({ root: webRoot }))
-  app.notFound((c) => {
-    const p = c.req.path
-    if (p.startsWith("/v1") || p.startsWith("/api") || p.startsWith("/raw") || p === "/healthz")
-      return c.json({ error: "not found" }, 404)
-    return c.html(shellHtml)
+// routes above always win; the server-owned path set, the immutable-asset caching,
+// and the index.html fallback live in mountWeb, shared as one contract with the
+// edge Worker (wrangler.toml) and the dev proxy (serve-web.test asserts parity).
+if (cfg.serveWeb)
+  mountWeb(app, {
+    webRoot: relative(process.cwd(), cfg.webDir) || ".",
+    shellHtml: readFileSync(cfg.webShell, "utf8"),
   })
-}
 
 // The webhook outbox worker delivers queued events with retries + backoff.
 startWebhookWorker(meta)

--- a/apps/api/test/serve-web.test.ts
+++ b/apps/api/test/serve-web.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+import { API_PATHS, isApiPath, mountWeb, workerFirstGlobs } from "../src/lib/serve-web"
+
+const apiDir = join(import.meta.dirname, "..")
+
+// Mirror node.ts: a real API route, then the bundled-SPA serving on top. (Asset
+// streaming + the immutable cache header are @hono/node-server's serveStatic over
+// the real node server; node.ts wires them unchanged, so they aren't re-asserted
+// here — this exercises the path contract that keeps the two modes consistent.)
+const makeApp = (shell = "<!doctype html><div id=app></div>") => {
+  const app = new Hono()
+  app.get("/v1/ping", (c) => c.json({ ok: true }))
+  mountWeb(app, { webRoot: ".", shellHtml: shell })
+  return app
+}
+
+const quoted = (s: string) => [...s.matchAll(/"([^"]+)"/g)].map((m) => m[1] ?? "")
+
+describe("serve-web: SPA vs API path contract", () => {
+  it("classifies server-owned vs SPA paths", () => {
+    for (const p of ["/v1/x", "/api/auth/session", "/raw/ab/v/1/index.html", "/healthz"])
+      expect(isApiPath(p)).toBe(true)
+    for (const p of ["/", "/a/abc123", "/login", "/settings/agents", "/library"])
+      expect(isApiPath(p)).toBe(false)
+  })
+
+  it("falls back to the SPA shell for non-API GETs, JSON 404 for unknown API paths", async () => {
+    const app = makeApp("SHELL_MARKER")
+    expect((await app.request("/v1/ping")).status).toBe(200) // a real API route still wins
+    for (const p of ["/", "/a/xyz", "/settings/agents"]) {
+      const r = await app.request(p)
+      expect(r.status).toBe(200)
+      expect(await r.text()).toContain("SHELL_MARKER") // deep client links → shell
+    }
+    const miss = await app.request("/v1/nope")
+    expect(miss.status).toBe(404) // unknown API path → JSON 404, never the shell
+    expect(await miss.json()).toEqual({ error: "not found" })
+  })
+})
+
+// The server-owned path set is declared in three places that can't share a value:
+// the Node server (the contract above), the Cloudflare Worker, and the dev proxy.
+// These assert the other two never drift from the contract.
+describe("serve-web: every declaration of the path set agrees", () => {
+  it("wrangler.toml run_worker_first == the contract", () => {
+    const toml = readFileSync(join(apiDir, "wrangler.toml"), "utf8")
+    const m = toml.match(/run_worker_first\s*=\s*\[([^\]]*)\]/)
+    if (!m) throw new Error("run_worker_first not found in wrangler.toml")
+    expect(quoted(m[1] ?? "").sort()).toEqual([...workerFirstGlobs()].sort())
+  })
+
+  it("the Vite dev proxy list == the contract", () => {
+    const vite = readFileSync(join(apiDir, "../web/vite.config.ts"), "utf8")
+    const m = vite.match(/(\[\s*"\/[^\]]*\])\.map\(\(p\)\s*=>/)
+    if (!m) throw new Error("dev proxy path list not found in vite.config.ts")
+    expect(quoted(m[1] ?? "").sort()).toEqual([...API_PATHS].sort())
+  })
+})


### PR DESCRIPTION
## Why
Which request paths the server owns (everything else falls back to the SPA shell) was hand-duplicated in **three** places that can't import a shared value:

- the Node server (`node.ts` `notFound`),
- the Cloudflare Worker (`wrangler.toml` `run_worker_first`),
- the Vite dev proxy (`apps/web/vite.config.ts`).

They agreed today only by hand. Nothing stopped the next added route prefix (an OAuth callback, `/.well-known`, a new API namespace) from being added to one and silently breaking the other mode. #100 (retire server viewer) already shifted this surface; this makes it drift-proof.

## What
- **`apps/api/src/lib/serve-web.ts`** is the single source of truth: `isApiPath`, `workerFirstGlobs`, and `mountWeb()` (the bundled-SPA serving lifted verbatim from `node.ts` so it's importable + testable).
- **`node.ts`** calls `mountWeb` instead of inlining `serveStatic` + the path list.
- **`config.ts`** accepts `index.html` or `_shell.html` for the SPA shell, so the Node server and the Worker (whose edge prep renames `_shell.html` → `index.html`) agree on one shell name.
- **`serve-web.test.ts`** asserts the path classification + SPA-fallback-vs-API-404 behavior, and parses `wrangler.toml` and `vite.config.ts` to assert both stay in lockstep with the contract. The next prefix that drifts now fails CI.

The frontend stays fully decoupled (`apps/web` has no `@dock/*` deps); the two declarations it can't import are kept honest by the test rather than a code dependency.

## No behavior change
Served paths, immutable-asset caching, and the `index.html` fallback are identical to before. This is a restructure + a guardrail.

## Test plan
- `pnpm -r typecheck` — clean
- `pnpm run ci` (biome + 6 lints + knip) — clean
- `pnpm --filter @dock/api test` — all pass, incl. the 4 new serve-web tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)