### PR TITLE
refactor(web): decompose the artifact page into focused hooks + components

### DIFF
--- a/apps/web/src/pages/artifact/artifact-actions.ts
+++ b/apps/web/src/pages/artifact/artifact-actions.ts
@@ -1,0 +1,181 @@
+import type { QueryClient } from "@tanstack/react-query"
+import type { Dispatch, SetStateAction } from "react"
+import { api, type Comment, type Mention } from "@/api"
+import { commentsQuery } from "@/lib/queries"
+import type { CommentActions } from "./comment-actions"
+import { toggleReaction } from "./lib/reactions"
+import type { Sel } from "./types"
+
+type Me = { name?: string | null; email?: string | null } | null
+type Composer = { anchor: Sel | null; top: number | null } | null
+// The page's full selection shape — the hook only reads selector + top, but the
+// setSel setter is typed against the whole thing (so the types line up).
+type Selection = {
+  selector: Sel
+  top: number
+  vTop: number
+  vBottom: number
+  vLeft: number
+  vRight: number
+} | null
+
+/**
+ * Every mutating action the artifact page drives: editing (publish a version /
+ * submit a proposal), the comment loop (add / reply / resolve / react / edit /
+ * delete / copy-link), thread activation + the comment-on-selection composer, and
+ * version restore. Lifted out of the page so it holds the wiring; `nav` is
+ * decoupled as `onRestoredJump` so the hook stays router-type-free.
+ */
+export function artifactActions(p: {
+  shortId: string
+  art: { title?: string | null; short_id: string }
+  qc: QueryClient
+  me: Me
+  src: string
+  proposeMsg: string
+  composer: Composer
+  sel: Selection
+  post: (msg: Record<string, unknown>) => void
+  load: () => void
+  refetchComments: () => void
+  show: (msg: string) => void
+  onRestoredJump: () => void
+  setEditing: Dispatch<SetStateAction<boolean>>
+  setSrc: Dispatch<SetStateAction<string>>
+  setProposeMsg: Dispatch<SetStateAction<string>>
+  setComposer: Dispatch<SetStateAction<Composer>>
+  setSel: Dispatch<SetStateAction<Selection>>
+  setActiveThread: Dispatch<SetStateAction<string | null>>
+  setRestoring: Dispatch<SetStateAction<boolean>>
+}) {
+  const { shortId, art, qc, me, post, load, refetchComments, show } = p
+
+  const startEdit = async () => {
+    p.setEditing(true)
+    p.setSrc(await api.getContent(shortId))
+  }
+  const publishEdit = async () => {
+    try {
+      const a = await api.publishText(
+        shortId,
+        p.src,
+        art.title ? `${art.short_id}.md` : "edit.md",
+        "edited in browser",
+      )
+      show(`Published v${a.current_version}`)
+      p.setEditing(false)
+      load()
+    } catch (e) {
+      show((e as Error).message)
+    }
+  }
+  // A commenter can't publish; their edit becomes a proposal for review. The
+  // message is the "why" the reviewer reads, so we ask for it before sending.
+  const proposeEdit = async () => {
+    try {
+      await api.propose(
+        shortId,
+        p.src,
+        art.title ? `${art.short_id}.md` : "edit.md",
+        p.proposeMsg.trim() || "Proposed change",
+      )
+      show("Proposed — sent for review")
+      p.setEditing(false)
+      p.setProposeMsg("")
+      load()
+    } catch (e) {
+      show((e as Error).message)
+    }
+  }
+  const addComment = async (
+    text: string,
+    opts?: { threadId?: string; anchor?: Sel | null; mentions?: Mention[] },
+  ) => {
+    if (!text.trim()) return
+    await api
+      .comment(shortId, {
+        body_md: text,
+        thread_id: opts?.threadId,
+        anchor: opts?.threadId ? undefined : (opts?.anchor ?? undefined),
+        mentions: opts?.mentions?.length ? opts.mentions : undefined,
+      })
+      .catch((e) => show((e as Error).message))
+    refetchComments()
+  }
+  const reply = (text: string, threadId: string, mentions: Mention[] = []) =>
+    addComment(text, { threadId, mentions })
+  const submitNew = async (text: string, mentions: Mention[] = []) => {
+    await addComment(text, { anchor: p.composer?.anchor ?? null, mentions })
+    p.setComposer(null)
+    p.setSel(null)
+  }
+  const toggleResolve = async (root: Comment) => {
+    await api.resolve(shortId, root.id, root.state === "open" ? "resolved" : "open")
+    refetchComments()
+  }
+  const activate = (id: string) => {
+    p.setActiveThread((cur) => (cur === id ? cur : id))
+    post({ type: "emphasize", id })
+  }
+  const startSelComment = () => {
+    if (!p.sel) return
+    p.setComposer({ anchor: p.sel.selector, top: p.sel.top })
+    p.setActiveThread(null)
+  }
+  const actions: CommentActions = {
+    meName: me?.name ?? me?.email ?? "",
+    react: (commentId, emoji) => {
+      // Optimistic: reflect the toggle in the cache immediately, reconcile on the response.
+      qc.setQueryData(commentsQuery(shortId).queryKey, (cs) =>
+        (cs ?? []).map((c) =>
+          c.id === commentId ? toggleReaction(c, emoji, me?.name ?? me?.email ?? "anonymous") : c,
+        ),
+      )
+      api.react(shortId, commentId, emoji).then(refetchComments).catch(refetchComments)
+    },
+    edit: async (commentId, body) => {
+      await api.editComment(shortId, commentId, body).catch((e) => show((e as Error).message))
+      refetchComments()
+    },
+    remove: (commentId) => {
+      api
+        .deleteComment(shortId, commentId)
+        .then(refetchComments)
+        .catch((e) => show((e as Error).message))
+    },
+    copyLink: (threadId) => {
+      const url = `${window.location.origin}${window.location.pathname}?c=${threadId}`
+      navigator.clipboard
+        ?.writeText(url)
+        .then(() => show("Link copied"))
+        .catch(() => show(url))
+    },
+  }
+  const restore = async (n: number) => {
+    p.setRestoring(true)
+    try {
+      const a = await api.restore(shortId, n)
+      show(`Restored as v${a.current_version}`)
+      p.onRestoredJump() // jump to the new current
+      load()
+    } catch (e) {
+      show((e as Error).message)
+    } finally {
+      p.setRestoring(false)
+    }
+  }
+
+  return {
+    startEdit,
+    publishEdit,
+    proposeEdit,
+    addComment,
+    reply,
+    submitNew,
+    toggleResolve,
+    activate,
+    startSelComment,
+    actions,
+    restore,
+  }
+}

--- a/apps/web/src/pages/artifact/artifact-comments.tsx
+++ b/apps/web/src/pages/artifact/artifact-comments.tsx
@@ -1,0 +1,165 @@
+import type { Dispatch, SetStateAction } from "react"
+import type { Comment, Mention } from "@/api"
+import { Icon } from "@/components/icons"
+import { cn } from "@/lib/utils"
+import { MobileComments, OpenPanel } from "./comment-panels"
+import { clamp } from "./lib/layout"
+import { Rail } from "./rail-deck"
+import type { Panel, PinItem, Sel } from "./types"
+
+type Composer = { anchor: Sel | null; top: number | null } | null
+type Selection = {
+  selector: Sel
+  top: number
+  vTop: number
+  vBottom: number
+  vLeft: number
+  vRight: number
+} | null
+
+/**
+ * All the comment surfaces for an artifact, in one place: the desktop margin aside
+ * (rail or open panel), the phone slide-up sheet, and the floating "comment on the
+ * selection" affordance. Hidden entirely for an anonymous visitor (read-only). The
+ * page owns the state + mutations and threads them in.
+ */
+export function ArtifactComments(p: {
+  isMobile: boolean
+  isAnon: boolean
+  docLive: boolean
+  panel: Panel
+  asideWidth: number
+  openCount: number
+  pinned: PinItem[]
+  general: Comment[][]
+  resolved: Comment[][]
+  openThreads: Comment[][]
+  activeThread: string | null
+  hoverThread: string | null
+  inDoc: Record<string, boolean>
+  composer: Composer
+  sel: Selection
+  setPanel: Dispatch<SetStateAction<Panel>>
+  setComposer: Dispatch<SetStateAction<Composer>>
+  setSel: Dispatch<SetStateAction<Selection>>
+  setActiveThread: Dispatch<SetStateAction<string | null>>
+  setHoverThread: Dispatch<SetStateAction<string | null>>
+  activate: (id: string) => void
+  toggleResolve: (root: Comment) => void
+  reply: (text: string, threadId: string, mentions?: Mention[]) => void
+  submitNew: (text: string, mentions?: Mention[]) => void
+  jumpTo: (threadId: string) => void
+  startSelComment: () => void
+}) {
+  const { isMobile, isAnon, panel, sel } = p
+  const newGeneral = () => {
+    p.setComposer({ anchor: null, top: null })
+    p.setActiveThread(null)
+  }
+  const cancelNew = () => {
+    p.setComposer(null)
+    p.setSel(null)
+  }
+
+  return (
+    <>
+      {!isMobile && !isAnon && (
+        <aside
+          className={cn(
+            "flex min-h-0 shrink-0 grow-0 flex-col overflow-hidden bg-card transition-[width,flex-basis] duration-200",
+            panel !== "hidden" && "border-l border-border",
+          )}
+          style={{ width: p.asideWidth, flexBasis: p.asideWidth }}
+        >
+          {panel === "rail" ? (
+            <Rail
+              pins={p.pinned}
+              generalCount={p.general.length}
+              active={p.activeThread}
+              onExpand={() => p.setPanel("open")}
+              onHide={() => p.setPanel("hidden")}
+              onDot={(id) => {
+                p.setPanel("open")
+                p.jumpTo(id)
+              }}
+            />
+          ) : (
+            <OpenPanel
+              openCount={p.openCount}
+              pinned={p.pinned}
+              general={p.general}
+              resolved={p.resolved}
+              activeThread={p.activeThread}
+              hoverThread={p.hoverThread}
+              inDoc={p.inDoc}
+              composer={p.composer}
+              onMinimize={() => p.setPanel("rail")}
+              onHide={() => p.setPanel("hidden")}
+              onActivate={p.activate}
+              onHover={p.setHoverThread}
+              onResolve={p.toggleResolve}
+              onReply={p.reply}
+              onJump={p.jumpTo}
+              onNewGeneral={newGeneral}
+              onSubmitNew={p.submitNew}
+              onCancelNew={cancelNew}
+            />
+          )}
+        </aside>
+      )}
+      {/* Phones: comments live in a slide-up sheet that takes the bottom half, so
+          the document stays visible above it. Tapping a quote scrolls the visible
+          document to the highlight without closing the sheet. */}
+      {isMobile && !isAnon && (
+        <MobileComments
+          open={panel === "open"}
+          openThreads={p.openThreads}
+          resolved={p.resolved}
+          openCount={p.openCount}
+          composer={p.composer}
+          activeThread={p.activeThread}
+          inDoc={p.inDoc}
+          onClose={() => {
+            p.setPanel("hidden")
+            cancelNew()
+          }}
+          onNewGeneral={newGeneral}
+          onActivate={p.activate}
+          onResolve={p.toggleResolve}
+          onReply={p.reply}
+          onJump={p.jumpTo}
+          onSubmitNew={p.submitNew}
+          onCancelNew={cancelNew}
+        />
+      )}
+      {/* The "comment on selection" affordance floats beside the selection in every
+          panel state. Clicking it opens the panel if needed and starts a composer
+          pinned to the selection. Logged-in only. */}
+      {!isAnon && p.docLive && sel && !p.composer && (
+        <button
+          type="button"
+          className="fixed z-50 inline-flex items-center gap-2 whitespace-nowrap rounded-full border border-primary bg-card px-3.5 py-2 text-sm font-semibold text-primary shadow-[var(--shadow)] transition-colors hover:bg-primary hover:text-primary-foreground"
+          title="Comment on the selection"
+          data-testid="comment-on-selection"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => {
+            if (panel !== "open") p.setPanel("open")
+            p.startSelComment()
+          }}
+          style={{
+            // Float just above the selection, centered on it, clamped into the
+            // document column (left of the aside) and below the top header.
+            top: clamp(sel.vTop - 44, 64, window.innerHeight - 52),
+            left: clamp(
+              (sel.vLeft + sel.vRight) / 2 - 60,
+              12,
+              window.innerWidth - p.asideWidth - 132,
+            ),
+          }}
+        >
+          <Icon name="comments" size={16} /> Comment
+        </button>
+      )}
+    </>
+  )
+}

--- a/apps/web/src/pages/artifact/artifact-document.tsx
+++ b/apps/web/src/pages/artifact/artifact-document.tsx
@@ -1,0 +1,116 @@
+import type { RefObject } from "react"
+import type { Diff } from "@/api"
+import { Button } from "@/components/ui/button"
+import { DiffView } from "./diff-view"
+import { DeckBar } from "./rail-deck"
+
+/**
+ * The document surface: a history banner when viewing a past version, then either
+ * the line diff or the sandboxed iframe (with the live-cursor overlay + the deck
+ * bar for slide artifacts). The refs are owned by the page (its anchor/presence/
+ * fullscreen effects drive them) and passed in.
+ */
+export function ArtifactDocument({
+  shown,
+  currentVersion,
+  title,
+  rawSrc,
+  view,
+  diff,
+  restoring,
+  deck,
+  frameRef,
+  presentWrapRef,
+  cursorLayerRef,
+  onFrameLoad,
+  onToggleDiff,
+  onRestore,
+  onBackToCurrent,
+  onDeckPrev,
+  onDeckNext,
+  onFullscreen,
+}: {
+  shown: number
+  currentVersion: number
+  title: string
+  rawSrc: string
+  view: "preview" | "diff"
+  diff: Diff | null
+  restoring: boolean
+  deck: { i: number; total: number } | null
+  frameRef: RefObject<HTMLIFrameElement | null>
+  presentWrapRef: RefObject<HTMLDivElement | null>
+  cursorLayerRef: RefObject<HTMLDivElement | null>
+  onFrameLoad: () => void
+  onToggleDiff: () => void
+  onRestore: () => void
+  onBackToCurrent: () => void
+  onDeckPrev: () => void
+  onDeckNext: () => void
+  onFullscreen: () => void
+}) {
+  const past = shown !== currentVersion
+  return (
+    <>
+      {/* History-viewing banner: only when looking at a past version. The current
+          version just shows the artifact, no version chrome. */}
+      {past && (
+        <div className="flex flex-wrap items-center gap-2.5 gap-y-1.5 border-b border-border-soft bg-accent px-3.5 py-2 text-sm">
+          <span className="font-semibold text-primary">Viewing an earlier version</span>
+          <span className="text-muted-foreground">·</span>
+          <button
+            type="button"
+            data-testid="artifact-toggle-diff"
+            className="text-primary underline underline-offset-2 hover:opacity-80"
+            onClick={onToggleDiff}
+          >
+            {view === "diff" ? "Hide changes" : "Show changes since this"}
+          </button>
+          <span className="flex-1" />
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="artifact-restore"
+            onClick={onRestore}
+            disabled={restoring}
+          >
+            {restoring ? "Restoring…" : "Restore this version"}
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            data-testid="artifact-back-to-current"
+            onClick={onBackToCurrent}
+          >
+            Back to current
+          </Button>
+        </div>
+      )}
+      {view === "diff" && past ? (
+        <DiffView diff={diff} fromLabel={`v${shown}`} toLabel="current" />
+      ) : (
+        <div ref={presentWrapRef} className="relative flex min-h-0 flex-1 flex-col bg-white">
+          <iframe
+            ref={frameRef}
+            onLoad={onFrameLoad}
+            title={title}
+            src={rawSrc}
+            allow="fullscreen"
+            sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
+            className="flex-1 border-0 bg-white"
+          />
+          {deck && (
+            <DeckBar deck={deck} onPrev={onDeckPrev} onNext={onDeckNext} onFullscreen={onFullscreen} />
+          )}
+          {/* Live peer cursors (Google-Docs style). The iframe is a separate opaque
+              origin, so its anchor script forwards mousemove out via postMessage; we
+              paint the dots here in the parent, over the frame. Anon viewers too. */}
+          <div
+            ref={cursorLayerRef}
+            className="pointer-events-none absolute inset-0 z-20 overflow-hidden"
+          />
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/web/src/pages/artifact/artifact-document.tsx
+++ b/apps/web/src/pages/artifact/artifact-document.tsx
@@ -100,7 +100,12 @@ export function ArtifactDocument({
             className="flex-1 border-0 bg-white"
           />
           {deck && (
-            <DeckBar deck={deck} onPrev={onDeckPrev} onNext={onDeckNext} onFullscreen={onFullscreen} />
+            <DeckBar
+              deck={deck}
+              onPrev={onDeckPrev}
+              onNext={onDeckNext}
+              onFullscreen={onFullscreen}
+            />
           )}
           {/* Live peer cursors (Google-Docs style). The iframe is a separate opaque
               origin, so its anchor script forwards mousemove out via postMessage; we

--- a/apps/web/src/pages/artifact/artifact-states.tsx
+++ b/apps/web/src/pages/artifact/artifact-states.tsx
@@ -1,0 +1,56 @@
+import { Icon } from "@/components/icons"
+import { Spinner } from "@/components/shared/spinner"
+import { Button } from "@/components/ui/button"
+
+/** Full-page states the artifact route renders before (or instead of) the doc. */
+
+export function ArtifactLoading() {
+  return (
+    <div className="grid h-full place-items-center">
+      <Spinner />
+    </div>
+  )
+}
+
+export function ArtifactNotFound({ onBack }: { onBack: () => void }) {
+  return (
+    <div className="grid h-full place-items-center gap-2.5">
+      <div className="text-muted-foreground">Artifact not found, or you don't have access.</div>
+      <Button variant="outline" data-testid="artifact-notfound-back" onClick={onBack}>
+        Back to library
+      </Button>
+    </div>
+  )
+}
+
+// A taken-down artifact: content is gone (the server 410s the raw routes), but an
+// owner can still reinstate it.
+export function ArtifactRemoved({
+  canReinstate,
+  onReinstate,
+  onBack,
+}: {
+  canReinstate: boolean
+  onReinstate: () => void
+  onBack: () => void
+}) {
+  return (
+    <div className="grid h-full place-items-center gap-3 text-center">
+      <Icon name="removed" size={40} className="opacity-55" />
+      <div className="text-lg font-semibold">This artifact was removed</div>
+      <div className="max-w-[360px] text-sm leading-relaxed text-muted-foreground">
+        It was taken down by a moderator and is no longer available.
+      </div>
+      <div className="flex gap-2">
+        {canReinstate && (
+          <Button variant="outline" data-testid="artifact-reinstate" onClick={onReinstate}>
+            Reinstate
+          </Button>
+        )}
+        <Button variant="outline" data-testid="artifact-removed-back" onClick={onBack}>
+          Back to library
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/artifact/artifact-top-bar.tsx
+++ b/apps/web/src/pages/artifact/artifact-top-bar.tsx
@@ -1,0 +1,111 @@
+import type { Role } from "@/api"
+import { Icon } from "@/components/icons"
+import { ShareButton } from "@/components/ShareDialog"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { cn } from "@/lib/utils"
+import { CollectionsMenu, ReportButton, StarButton, TagsMenu } from "./header-actions"
+
+/**
+ * The artifact header actions (portaled into the shell top bar): favorite, tags,
+ * collections, share, report, the "⋯ More" menu (insights / history / review /
+ * edit), and the show-comments button. Shown only to signed-in viewers — an anon
+ * visitor gets none of it. Pure + props-driven; the page keeps the cache writes.
+ */
+export function ArtifactTopBar(props: {
+  shortId: string
+  myRole?: Role | null
+  favorite: boolean
+  tags: string[]
+  collections: string[]
+  canEditTags: boolean
+  openProposals: number
+  proposalsTotal: number
+  isMobile: boolean
+  panelOpen: boolean
+  openCount: number
+  showEdit: boolean
+  editLabel: string
+  onFavorite: (fav: boolean) => void
+  onTags: (tags: string[]) => void
+  onCollections: (ids: string[]) => void
+  onReport: (msg: string) => void
+  onInsights: () => void
+  onHistory: () => void
+  onReview: () => void
+  onStartEdit: () => void
+  onShowComments: () => void
+}) {
+  const { shortId, openProposals, proposalsTotal } = props
+  return (
+    <>
+      <StarButton shortId={shortId} favorite={props.favorite} onChange={props.onFavorite} />
+      <TagsMenu
+        shortId={shortId}
+        tags={props.tags}
+        canEdit={props.canEditTags}
+        onChange={props.onTags}
+      />
+      <CollectionsMenu
+        shortId={shortId}
+        inCollections={props.collections}
+        onChange={props.onCollections}
+      />
+      <ShareButton shortId={shortId} myRole={props.myRole} />
+      <ReportButton shortId={shortId} onDone={props.onReport} />
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="icon"
+            title="More"
+            data-testid="artifact-more"
+            className={cn(openProposals > 0 && "border-primary text-primary")}
+          >
+            <Icon name="more" size={18} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem data-testid="artifact-insights" onSelect={props.onInsights}>
+            <Icon name="insights" size={16} /> Insights
+          </DropdownMenuItem>
+          <DropdownMenuItem data-testid="artifact-history" onSelect={props.onHistory}>
+            <Icon name="history" size={16} /> Version history
+          </DropdownMenuItem>
+          {proposalsTotal > 0 && (
+            <DropdownMenuItem data-testid="artifact-review" onSelect={props.onReview}>
+              <Icon name="review" size={16} />
+              {openProposals > 0 ? `Review proposals (${openProposals})` : "Proposals"}
+            </DropdownMenuItem>
+          )}
+          {props.showEdit && (
+            <DropdownMenuItem data-testid="artifact-edit" onSelect={props.onStartEdit}>
+              <Icon name="edit" size={16} />
+              {props.editLabel}
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {/* On phones the bottom-right FAB opens comments, so the header button would
+          just be a redundant extra wrap-row. */}
+      {!props.isMobile && !props.panelOpen && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-1.5"
+          data-testid="artifact-show-comments"
+          onClick={props.onShowComments}
+          title="Show comments (c)"
+        >
+          <Icon name="comments" size={16} />
+          {props.openCount > 0 && <b className="font-bold">{props.openCount}</b>}
+        </Button>
+      )}
+    </>
+  )
+}

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate, useParams } from "@tanstack/react-router"
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react"
 import { createPortal } from "react-dom"
-import { API_BASE, api, type Comment, type Diff, type Mention } from "@/api"
+import { API_BASE, api, type Comment, type Diff } from "@/api"
 import { useIsMobile, useToast } from "@/components"
 import { Icon } from "@/components/icons"
 import { useTopBarSlot } from "@/components/shell-context"
@@ -11,15 +11,15 @@ import { useAuth } from "@/ctx"
 import { artifactQuery, commentsQuery } from "@/lib/queries"
 import { STORAGE_KEYS } from "@/lib/storage-keys"
 import { cn } from "@/lib/utils"
+import { artifactActions } from "./artifact-actions"
+import { ArtifactDocument } from "./artifact-document"
 import { ArtifactLoading, ArtifactNotFound, ArtifactRemoved } from "./artifact-states"
 import { ArtifactTopBar } from "./artifact-top-bar"
-import { ActionsCtx, type CommentActions } from "./comment-actions"
+import { ActionsCtx } from "./comment-actions"
 import { MobileComments, OpenPanel } from "./comment-panels"
-import { DiffView } from "./diff-view"
 import { clamp, groupThreads, parseAnchor } from "./lib/layout"
-import { toggleReaction } from "./lib/reactions"
 import { parseRef } from "./parse-ref"
-import { DeckBar, Presence, Rail } from "./rail-deck"
+import { Presence, Rail } from "./rail-deck"
 import { SourceEditor } from "./source-editor"
 import type { Panel, PinItem, Sel } from "./types"
 import { useArtifactLive } from "./use-artifact-live"
@@ -357,121 +357,40 @@ export function Artifact() {
   }
   const openCount = openThreads.length
 
-  const startEdit = async () => {
-    setEditing(true)
-    setSrc(await api.getContent(shortId))
-  }
-  const publishEdit = async () => {
-    try {
-      const a = await api.publishText(
-        shortId,
-        src,
-        art.title ? `${art.short_id}.md` : "edit.md",
-        "edited in browser",
-      )
-      show(`Published v${a.current_version}`)
-      setEditing(false)
-      load()
-    } catch (e) {
-      show((e as Error).message)
-    }
-  }
-  // A commenter can't publish; their edit becomes a proposal for review. The
-  // message is the "why" the reviewer reads, so we ask for it before sending.
-  const proposeEdit = async () => {
-    try {
-      await api.propose(
-        shortId,
-        src,
-        art.title ? `${art.short_id}.md` : "edit.md",
-        proposeMsg.trim() || "Proposed change",
-      )
-      show("Proposed — sent for review")
-      setEditing(false)
-      setProposeMsg("")
-      load()
-    } catch (e) {
-      show((e as Error).message)
-    }
-  }
-  const addComment = async (
-    text: string,
-    opts?: { threadId?: string; anchor?: Sel | null; mentions?: Mention[] },
-  ) => {
-    if (!text.trim()) return
-    await api
-      .comment(shortId, {
-        body_md: text,
-        thread_id: opts?.threadId,
-        anchor: opts?.threadId ? undefined : (opts?.anchor ?? undefined),
-        mentions: opts?.mentions?.length ? opts.mentions : undefined,
-      })
-      .catch((e) => show((e as Error).message))
-    refetchComments()
-  }
-  const reply = (text: string, threadId: string, mentions: Mention[] = []) =>
-    addComment(text, { threadId, mentions })
-  const submitNew = async (text: string, mentions: Mention[] = []) => {
-    await addComment(text, { anchor: composer?.anchor ?? null, mentions })
-    setComposer(null)
-    setSel(null)
-  }
-  const toggleResolve = async (root: Comment) => {
-    await api.resolve(shortId, root.id, root.state === "open" ? "resolved" : "open")
-    refetchComments()
-  }
-  const activate = (id: string) => {
-    setActiveThread((cur) => (cur === id ? cur : id))
-    post({ type: "emphasize", id })
-  }
-  const startSelComment = () => {
-    if (!sel) return
-    setComposer({ anchor: sel.selector, top: sel.top })
-    setActiveThread(null)
-  }
-  const actions: CommentActions = {
-    meName: me?.name ?? me?.email ?? "",
-    react: (commentId, emoji) => {
-      // Optimistic: reflect the toggle in the cache immediately, reconcile on
-      // the response.
-      qc.setQueryData(commentsQuery(shortId).queryKey, (cs) =>
-        (cs ?? []).map((c) =>
-          c.id === commentId ? toggleReaction(c, emoji, me?.name ?? me?.email ?? "anonymous") : c,
-        ),
-      )
-      api.react(shortId, commentId, emoji).then(refetchComments).catch(refetchComments)
-    },
-    edit: async (commentId, body) => {
-      await api.editComment(shortId, commentId, body).catch((e) => show((e as Error).message))
-      refetchComments()
-    },
-    remove: (commentId) => {
-      api
-        .deleteComment(shortId, commentId)
-        .then(refetchComments)
-        .catch((e) => show((e as Error).message))
-    },
-    copyLink: (threadId) => {
-      const url = `${window.location.origin}${window.location.pathname}?c=${threadId}`
-      navigator.clipboard
-        ?.writeText(url)
-        .then(() => show("Link copied"))
-        .catch(() => show(url))
-    },
-  }
-  const restore = async (n: number) => {
-    setRestoring(true)
-    try {
-      const a = await api.restore(shortId, n)
-      show(`Restored as v${a.current_version}`)
-      nav({ to: "/a/$ref", params: { ref: shortId } }) // jump to the new current
-      load()
-    } catch (e) {
-      show((e as Error).message)
-    } finally {
-      setRestoring(false)
-    }
-  }
+  const {
+    startEdit,
+    publishEdit,
+    proposeEdit,
+    addComment,
+    reply,
+    submitNew,
+    toggleResolve,
+    activate,
+    startSelComment,
+    actions,
+    restore,
+  } = artifactActions({
+    shortId,
+    art,
+    qc,
+    me,
+    src,
+    proposeMsg,
+    composer,
+    sel,
+    post,
+    load,
+    refetchComments,
+    show,
+    onRestoredJump: () => nav({ to: "/a/$ref", params: { ref: shortId } }),
+    setEditing,
+    setSrc,
+    setProposeMsg,
+    setComposer,
+    setSel,
+    setActiveThread,
+    setRestoring,
+  })
 
   // On phones the comments live in a slide-up sheet, so the in-flow aside has
   // no width and the document gets the full screen.
@@ -584,73 +503,26 @@ export function Artifact() {
                 onPropose={proposeEdit}
               />
             ) : (
-              <>
-                {/* History-viewing banner: only when looking at a past version.
-                  The current version just shows the artifact, no version chrome. */}
-                {shown !== art.current_version && (
-                  <div className="flex flex-wrap items-center gap-2.5 gap-y-1.5 border-b border-border-soft bg-accent px-3.5 py-2 text-sm">
-                    <span className="font-semibold text-primary">Viewing an earlier version</span>
-                    <span className="text-muted-foreground">·</span>
-                    <button
-                      type="button"
-                      data-testid="artifact-toggle-diff"
-                      className="text-primary underline underline-offset-2 hover:opacity-80"
-                      onClick={() => setView(view === "diff" ? "preview" : "diff")}
-                    >
-                      {view === "diff" ? "Hide changes" : "Show changes since this"}
-                    </button>
-                    <span className="flex-1" />
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      data-testid="artifact-restore"
-                      onClick={() => restore(shown)}
-                      disabled={restoring}
-                    >
-                      {restoring ? "Restoring…" : "Restore this version"}
-                    </Button>
-                    <Button
-                      variant="primary"
-                      size="sm"
-                      data-testid="artifact-back-to-current"
-                      onClick={() => nav({ to: "/a/$ref", params: { ref: shortId } })}
-                    >
-                      Back to current
-                    </Button>
-                  </div>
-                )}
-                {view === "diff" && shown !== art.current_version ? (
-                  <DiffView diff={diff} fromLabel={`v${shown}`} toLabel="current" />
-                ) : (
-                  <div ref={presentWrap} className="relative flex min-h-0 flex-1 flex-col bg-white">
-                    <iframe
-                      ref={frame}
-                      onLoad={() => setFrameReady((n) => n + 1)}
-                      title={art.title ?? shortId}
-                      src={rawSrc}
-                      allow="fullscreen"
-                      sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
-                      className="flex-1 border-0 bg-white"
-                    />
-                    {deck && (
-                      <DeckBar
-                        deck={deck}
-                        onPrev={() => deckCmd("prev")}
-                        onNext={() => deckCmd("next")}
-                        onFullscreen={toggleFullscreen}
-                      />
-                    )}
-                    {/* Live peer cursors (Google-Docs style). The iframe is a
-                        separate opaque origin, so its anchor script forwards
-                        mousemove out via postMessage; we paint the dots here in
-                        the parent, over the frame. Anon viewers see + are seen. */}
-                    <div
-                      ref={live.cursorLayer}
-                      className="pointer-events-none absolute inset-0 z-20 overflow-hidden"
-                    />
-                  </div>
-                )}
-              </>
+              <ArtifactDocument
+                shown={shown}
+                currentVersion={art.current_version}
+                title={art.title ?? shortId}
+                rawSrc={rawSrc}
+                view={view}
+                diff={diff}
+                restoring={restoring}
+                deck={deck}
+                frameRef={frame}
+                presentWrapRef={presentWrap}
+                cursorLayerRef={live.cursorLayer}
+                onFrameLoad={() => setFrameReady((n) => n + 1)}
+                onToggleDiff={() => setView(view === "diff" ? "preview" : "diff")}
+                onRestore={() => restore(shown)}
+                onBackToCurrent={() => nav({ to: "/a/$ref", params: { ref: shortId } })}
+                onDeckPrev={() => deckCmd("prev")}
+                onDeckNext={() => deckCmd("next")}
+                onFullscreen={toggleFullscreen}
+              />
             )}
             {!isAnon && panel === "hidden" && (
               <button

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -2,27 +2,28 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate, useParams } from "@tanstack/react-router"
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react"
 import { createPortal } from "react-dom"
-import { API_BASE, api, type Comment, type Diff } from "@/api"
+import { API_BASE, api, type Comment } from "@/api"
 import { useIsMobile, useToast } from "@/components"
 import { Icon } from "@/components/icons"
 import { useTopBarSlot } from "@/components/shell-context"
-import { Button } from "@/components/ui/button"
 import { useAuth } from "@/ctx"
 import { artifactQuery, commentsQuery } from "@/lib/queries"
-import { STORAGE_KEYS } from "@/lib/storage-keys"
 import { cn } from "@/lib/utils"
 import { artifactActions } from "./artifact-actions"
+import { ArtifactComments } from "./artifact-comments"
 import { ArtifactDocument } from "./artifact-document"
 import { ArtifactLoading, ArtifactNotFound, ArtifactRemoved } from "./artifact-states"
 import { ArtifactTopBar } from "./artifact-top-bar"
 import { ActionsCtx } from "./comment-actions"
-import { MobileComments, OpenPanel } from "./comment-panels"
-import { clamp, groupThreads, parseAnchor } from "./lib/layout"
+import { groupThreads, parseAnchor } from "./lib/layout"
 import { parseRef } from "./parse-ref"
-import { Presence, Rail } from "./rail-deck"
+import { Presence } from "./rail-deck"
 import { SourceEditor } from "./source-editor"
-import type { Panel, PinItem, Sel } from "./types"
+import type { PinItem, Sel } from "./types"
+import { useArtifactFrame } from "./use-artifact-frame"
 import { useArtifactLive } from "./use-artifact-live"
+import { useCommentsPanel } from "./use-comments-panel"
+import { useVersionDiff } from "./use-version-diff"
 
 // Heavy on-demand surfaces — split out of the artifact route's initial chunk and
 // loaded only when the user opens them (review proposals / insights / history).
@@ -33,16 +34,6 @@ const Insights = lazy(() => import("./insights-history").then((m) => ({ default:
 const HistoryDrawer = lazy(() =>
   import("./insights-history").then((m) => ({ default: m.HistoryDrawer })),
 )
-
-const PANEL_KEY = STORAGE_KEYS.commentsPanel
-const loadPanel = (): Panel => {
-  try {
-    const v = localStorage.getItem(PANEL_KEY)
-    return v === "rail" || v === "hidden" ? v : "open"
-  } catch {
-    return "open"
-  }
-}
 
 export function Artifact() {
   const { ref } = useParams({ from: "/a/$ref" })
@@ -68,43 +59,15 @@ export function Artifact() {
   // Which "⋯ More" surface is open (large dialog / drawer).
   const [surface, setSurface] = useState<null | "insights" | "history">(null)
   const [proposeMsg, setProposeMsg] = useState("")
-  const [view, setView] = useState<"preview" | "diff">("preview")
-  const [diff, setDiff] = useState<Diff | null>(null)
   const [restoring, setRestoring] = useState(false)
   const [src, setSrc] = useState("")
 
-  // Comments UI state. On phones the panel is a slide-up sheet that starts
-  // closed (document-first); on desktop it restores the saved rail/open state.
-  const [panel, setPanel] = useState<Panel>(() =>
-    typeof window !== "undefined" && window.matchMedia("(max-width:640px)").matches
-      ? "hidden"
-      : loadPanel(),
-  )
-  const [sel, setSel] = useState<{
-    selector: Sel
-    top: number
-    vTop: number
-    vBottom: number
-    vLeft: number
-    vRight: number
-  } | null>(null)
+  // Comments UI state shared across the page, the panel, and the iframe bridge.
   const [composer, setComposer] = useState<{ anchor: Sel | null; top: number | null } | null>(null)
   const [activeThread, setActiveThread] = useState<string | null>(null)
   const [hoverThread, setHoverThread] = useState<string | null>(null)
-
-  // The anchor channel with the sandboxed iframe (see ANCHOR_CLIENT_JS).
-  const frame = useRef<HTMLIFrameElement>(null)
-  const presentWrap = useRef<HTMLDivElement>(null)
-  const [frameReady, setFrameReady] = useState(0)
-  const [inDoc, setInDoc] = useState<Record<string, boolean>>({})
-  const [anchorTops, setAnchorTops] = useState<Record<string, number>>({})
-  const [scrollY, setScrollY] = useState(0)
-  // Set when the artifact announces itself as a deck (dock-deck protocol).
-  const [deck, setDeck] = useState<{ i: number; total: number } | null>(null)
-
-  const post = useCallback((msg: Record<string, unknown>) => {
-    frame.current?.contentWindow?.postMessage({ source: "dock-host", ...msg }, "*")
-  }, [])
+  // The open/rail/hidden comments panel, with its persistence + `c`/Esc hotkeys.
+  const { panel, setPanel } = useCommentsPanel(() => setComposer(null))
 
   // Server-truth refetch after a write or an SSE ping (defined up here so the
   // realtime hook + the iframe message bridge below can both lean on them).
@@ -121,133 +84,41 @@ export function Artifact() {
   // below) and reads `viewers` + the `cursorLayer` overlay ref back out.
   const live = useArtifactLive({ shortId, me, onComment: refetchComments, onVersion: load })
 
-  useEffect(() => {
-    const onMsg = (e: MessageEvent) => {
-      const d = e.data
-      if (!d) return
-      // A slide deck reporting its position (any HTML that speaks the protocol).
-      if (d.source === "dock-deck" && d.type === "state") {
-        setDeck({ i: d.i ?? 0, total: d.total ?? 1 })
-        return
-      }
-      if (d.source !== "dock") return
-      if (d.type === "select") {
-        if (d.selector && d.rect) {
-          const fr = frame.current?.getBoundingClientRect()
-          const ft = fr?.top ?? 0
-          const fl = fr?.left ?? 0
-          setSel({
-            selector: d.selector,
-            top: d.rect.top,
-            vTop: ft + d.rect.top,
-            vBottom: ft + d.rect.bottom,
-            // left/right are sent by the current anchor client; guard against a
-            // stale-cached client posting only top/bottom so we never get NaN.
-            vLeft: fl + (d.rect.left ?? 0),
-            vRight: fl + (d.rect.right ?? d.rect.left ?? 0),
-          })
-        } else setSel(null)
-      } else if (d.type === "anchors-resolved") setInDoc(d.resolved ?? {})
-      else if (d.type === "anchor-rects") {
-        setAnchorTops(d.tops ?? {})
-        if (typeof d.scrollY === "number") setScrollY(d.scrollY)
-      } else if (d.type === "scroll") {
-        if (typeof d.scrollY === "number") setScrollY(d.scrollY)
-      } else if (d.type === "anchor-hover") setHoverThread(d.id ?? null)
-      else if (d.type === "anchor-click") {
-        setActiveThread(d.id)
-        setPanel((p) => (p === "open" ? p : "open"))
-      } else if (d.type === "cursor" && typeof d.x === "number" && typeof d.y === "number") {
-        live.onPointerMove(d.x, d.y)
-      }
-    }
-    window.addEventListener("message", onMsg)
-    return () => window.removeEventListener("message", onMsg)
-  }, [live])
+  // The whole postMessage channel with the sandboxed iframe: text selection,
+  // anchor geometry, scroll, deck position, and peer cursors in; highlight
+  // anchors + deck/emphasis commands out. See use-artifact-frame.
+  const {
+    frame,
+    presentWrap,
+    onFrameLoad,
+    post,
+    deck,
+    deckCmd,
+    toggleFullscreen,
+    sel,
+    setSel,
+    inDoc,
+    anchorTops,
+    scrollY,
+  } = useArtifactFrame({
+    comments,
+    shortId,
+    version,
+    hoverThread,
+    onPointerMove: live.onPointerMove,
+    setHoverThread,
+    setActiveThread,
+    setPanel,
+  })
 
-  // Persist the collapse state.
-  useEffect(() => {
-    try {
-      localStorage.setItem(PANEL_KEY, panel)
-    } catch {
-      /* private mode — ignore */
-    }
-  }, [panel])
+  // Preview vs. line-diff for the shown version, plus the fetched diff. See
+  // use-version-diff.
+  const { view, setView, diff } = useVersionDiff(art, shortId, version)
 
-  // Keyboard: 'c' toggles the panel open/closed; Escape cancels a composer.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      const el = e.target as HTMLElement
-      if (e.key === "Escape") {
-        setComposer(null)
-        return
-      }
-      if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.altKey) return
-      if (el && /^(input|textarea|select)$/i.test(el.tagName)) return
-      if (e.key === "c" || e.key === "C") setPanel((p) => (p === "open" ? "rail" : "open"))
-    }
-    window.addEventListener("keydown", onKey)
-    return () => window.removeEventListener("keydown", onKey)
-  }, [])
-
-  // Two-way hover: emphasize the highlight in the doc when a card is hovered.
-  useEffect(() => {
-    post({ type: "emphasize", id: hoverThread })
-  }, [hoverThread, post])
-
-  // Drive the deck from the host bar; fullscreen wraps the iframe + bar so the
-  // controls stay reachable while presenting.
-  const deckCmd = useCallback(
-    (action: "next" | "prev" | "goto", n?: number) =>
-      frame.current?.contentWindow?.postMessage(
-        { source: "dock-host", type: "deck", action, n },
-        "*",
-      ),
-    [],
-  )
-  const toggleFullscreen = () => {
-    const el = presentWrap.current
-    if (!el) return
-    if (document.fullscreenElement) document.exitFullscreen()
-    else el.requestFullscreen?.()
-  }
-  // Reset deck state when the artifact/version changes (re-announced on load).
-  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed to the artifact/version change, not to anything the callback reads.
-  useEffect(() => setDeck(null), [shortId, version])
-  // Arrow keys drive the deck from the host (when not typing in a field).
-  useEffect(() => {
-    if (!deck) return
-    const onKey = (e: KeyboardEvent) => {
-      const t = e.target as HTMLElement
-      if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA")) return
-      if (e.key === "ArrowRight") deckCmd("next")
-      else if (e.key === "ArrowLeft") deckCmd("prev")
-    }
-    window.addEventListener("keydown", onKey)
-    return () => window.removeEventListener("keydown", onKey)
-  }, [deck, deckCmd])
-
-  // Paint highlights for open, anchored threads whenever the doc or comments change.
-  const sendAnchors = useCallback(() => {
-    const w = frame.current?.contentWindow
-    if (!w) return
-    const anchors = groupThreads(comments)
-      .filter((t) => t[0].state === "open")
-      .map((t) => ({ id: t[0].thread_id, sel: parseAnchor(t[0].anchor) }))
-      .filter((x): x is { id: string; sel: NonNullable<ReturnType<typeof parseAnchor>> } => !!x.sel)
-      .map((x) => ({ id: x.id, exact: x.sel.exact, prefix: x.sel.prefix, suffix: x.sel.suffix }))
-    w.postMessage({ source: "dock-host", type: "anchors", anchors }, "*")
-  }, [comments])
-  // biome-ignore lint/correctness/useExhaustiveDependencies: frameReady is an intentional repaint trigger (re-send anchors when the iframe reloads).
-  useEffect(() => {
-    sendAnchors()
-  }, [sendAnchors, frameReady])
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: clears transient selection when the artifact/version changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: clears the active thread + composer when the artifact/version changes (the iframe bridge clears its own selection).
   useEffect(() => {
     setActiveThread(null)
     setComposer(null)
-    setSel(null)
   }, [shortId, version])
 
   // Clicking a thread's quote scrolls the document to its highlight.
@@ -275,31 +146,7 @@ export function Artifact() {
       setActiveThread(cid)
       setTimeout(() => post({ type: "focus-anchor", id: cid }), 320)
     }
-  }, [comments, post])
-
-  // Switching versions returns to the rendered preview.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: resets the view on a version/artifact change.
-  useEffect(() => setView("preview"), [version, shortId])
-
-  // In history mode, "show changes" diffs the version being viewed against the
-  // current one — what's changed since this older version.
-  useEffect(() => {
-    if (view !== "diff" || !art) return
-    const shownN = version ?? art.current_version
-    if (shownN >= art.current_version) {
-      setDiff(null)
-      return
-    }
-    setDiff(null)
-    let alive = true
-    api
-      .diff(shortId, shownN, art.current_version)
-      .then((d) => alive && setDiff(d))
-      .catch(() => {})
-    return () => {
-      alive = false
-    }
-  }, [view, version, art, shortId])
+  }, [comments, post, setPanel])
 
   if (failed) return <ArtifactNotFound onBack={() => nav({ to: "/" })} />
   if (!art) return <ArtifactLoading />
@@ -361,7 +208,6 @@ export function Artifact() {
     startEdit,
     publishEdit,
     proposeEdit,
-    addComment,
     reply,
     submitNew,
     toggleResolve,
@@ -515,7 +361,7 @@ export function Artifact() {
                 frameRef={frame}
                 presentWrapRef={presentWrap}
                 cursorLayerRef={live.cursorLayer}
-                onFrameLoad={() => setFrameReady((n) => n + 1)}
+                onFrameLoad={onFrameLoad}
                 onToggleDiff={() => setView(view === "diff" ? "preview" : "diff")}
                 onRestore={() => restore(shown)}
                 onBackToCurrent={() => nav({ to: "/a/$ref", params: { ref: shortId } })}
@@ -540,120 +386,35 @@ export function Artifact() {
             )}
           </div>
 
-          {!isMobile && !isAnon && (
-            <aside
-              className={cn(
-                "flex min-h-0 shrink-0 grow-0 flex-col overflow-hidden bg-card transition-[width,flex-basis] duration-200",
-                panel !== "hidden" && "border-l border-border",
-              )}
-              style={{ width: asideWidth, flexBasis: asideWidth }}
-            >
-              {panel === "rail" ? (
-                <Rail
-                  pins={pinned}
-                  generalCount={general.length}
-                  active={activeThread}
-                  onExpand={() => setPanel("open")}
-                  onHide={() => setPanel("hidden")}
-                  onDot={(id) => {
-                    setPanel("open")
-                    jumpTo(id)
-                  }}
-                />
-              ) : (
-                <OpenPanel
-                  openCount={openCount}
-                  pinned={pinned}
-                  general={general}
-                  resolved={resolvedThreads}
-                  activeThread={activeThread}
-                  hoverThread={hoverThread}
-                  inDoc={inDoc}
-                  composer={composer}
-                  onMinimize={() => setPanel("rail")}
-                  onHide={() => setPanel("hidden")}
-                  onActivate={activate}
-                  onHover={setHoverThread}
-                  onResolve={toggleResolve}
-                  onReply={reply}
-                  onJump={jumpTo}
-                  onNewGeneral={() => {
-                    setComposer({ anchor: null, top: null })
-                    setActiveThread(null)
-                  }}
-                  onSubmitNew={submitNew}
-                  onCancelNew={() => {
-                    setComposer(null)
-                    setSel(null)
-                  }}
-                />
-              )}
-            </aside>
-          )}
-        </div>
-        {/* Phones: comments live in a slide-up sheet that takes the bottom half,
-          so the document stays visible above it. A flat thread list (no document
-          margin); tapping a quote scrolls the visible document to the highlight
-          without closing the sheet. The grip expands it to full for reading. */}
-        {isMobile && !isAnon && (
-          <MobileComments
-            open={panel === "open"}
-            openThreads={openThreads}
-            resolved={resolvedThreads}
+          <ArtifactComments
+            isMobile={isMobile}
+            isAnon={isAnon}
+            docLive={docLive}
+            panel={panel}
+            asideWidth={asideWidth}
             openCount={openCount}
-            composer={composer}
+            pinned={pinned}
+            general={general}
+            resolved={resolvedThreads}
+            openThreads={openThreads}
             activeThread={activeThread}
+            hoverThread={hoverThread}
             inDoc={inDoc}
-            onClose={() => {
-              setPanel("hidden")
-              setComposer(null)
-              setSel(null)
-            }}
-            onNewGeneral={() => {
-              setComposer({ anchor: null, top: null })
-              setActiveThread(null)
-            }}
-            onActivate={activate}
-            onResolve={toggleResolve}
-            onReply={reply}
-            onJump={jumpTo}
-            onSubmitNew={submitNew}
-            onCancelNew={() => {
-              setComposer(null)
-              setSel(null)
-            }}
+            composer={composer}
+            sel={sel}
+            setPanel={setPanel}
+            setComposer={setComposer}
+            setSel={setSel}
+            setActiveThread={setActiveThread}
+            setHoverThread={setHoverThread}
+            activate={activate}
+            toggleResolve={toggleResolve}
+            reply={reply}
+            submitNew={submitNew}
+            jumpTo={jumpTo}
+            startSelComment={startSelComment}
           />
-        )}
-        {/* The "comment on selection" affordance floats beside the selection in
-          every panel state — minimized or hidden included. Clicking it opens
-          the panel if needed and starts a composer pinned to the selection.
-          Hidden for anon (commenting is logged-in only). */}
-        {!isAnon && docLive && sel && !composer && (
-          <button
-            type="button"
-            className="fixed z-50 inline-flex items-center gap-2 whitespace-nowrap rounded-full border border-primary bg-card px-3.5 py-2 text-sm font-semibold text-primary shadow-[var(--shadow)] transition-colors hover:bg-primary hover:text-primary-foreground"
-            title="Comment on the selection"
-            data-testid="comment-on-selection"
-            onMouseDown={(e) => e.preventDefault()}
-            onClick={() => {
-              if (panel !== "open") setPanel("open")
-              startSelComment()
-            }}
-            style={{
-              // Float just above the selection, horizontally centered on it, so it
-              // lands where the user is actually reading. Clamp into the document
-              // column (left of the aside) and below the top header.
-              top: clamp(sel.vTop - 44, 64, window.innerHeight - 52),
-              left: clamp(
-                (sel.vLeft + sel.vRight) / 2 - 60,
-                12,
-                window.innerWidth - asideWidth - 132,
-              ),
-            }}
-          >
-            <Icon name="comments" size={16} /> Comment
-          </button>
-        )}
+        </div>
         {toast}
       </ActionsCtx.Provider>
     </>

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -5,24 +5,17 @@ import { createPortal } from "react-dom"
 import { API_BASE, api, type Comment, type Diff, type Mention } from "@/api"
 import { useIsMobile, useToast } from "@/components"
 import { Icon } from "@/components/icons"
-import { ShareButton } from "@/components/ShareDialog"
 import { useTopBarSlot } from "@/components/shell-context"
 import { Button } from "@/components/ui/button"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 import { useAuth } from "@/ctx"
 import { artifactQuery, commentsQuery } from "@/lib/queries"
 import { STORAGE_KEYS } from "@/lib/storage-keys"
 import { cn } from "@/lib/utils"
 import { ArtifactLoading, ArtifactNotFound, ArtifactRemoved } from "./artifact-states"
+import { ArtifactTopBar } from "./artifact-top-bar"
 import { ActionsCtx, type CommentActions } from "./comment-actions"
 import { MobileComments, OpenPanel } from "./comment-panels"
 import { DiffView } from "./diff-view"
-import { CollectionsMenu, ReportButton, StarButton, TagsMenu } from "./header-actions"
 import { clamp, groupThreads, parseAnchor } from "./lib/layout"
 import { toggleReaction } from "./lib/reactions"
 import { parseRef } from "./parse-ref"
@@ -491,101 +484,40 @@ export function Artifact() {
           <>
             {!isMobile && <Presence viewers={live.viewers} self={me?.name ?? me?.email ?? ""} />}
             {!isAnon && (
-              <>
-                <StarButton
-                  shortId={shortId}
-                  favorite={!!art.favorite}
-                  onChange={(fav) =>
-                    qc.setQueryData(artifactQuery(shortId).queryKey, (a) =>
-                      a ? { ...a, favorite: fav } : a,
-                    )
-                  }
-                />
-                <TagsMenu
-                  shortId={shortId}
-                  tags={art.tags ?? []}
-                  canEdit={art.my_role === "editor" || art.my_role === "owner"}
-                  onChange={(tags) =>
-                    qc.setQueryData(artifactQuery(shortId).queryKey, (a) =>
-                      a ? { ...a, tags } : a,
-                    )
-                  }
-                />
-                <CollectionsMenu
-                  shortId={shortId}
-                  inCollections={art.collections ?? []}
-                  onChange={(collections) =>
-                    qc.setQueryData(artifactQuery(shortId).queryKey, (a) =>
-                      a ? { ...a, collections } : a,
-                    )
-                  }
-                />
-                <ShareButton shortId={shortId} myRole={art.my_role} />
-                <ReportButton shortId={shortId} onDone={show} />
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      title="More"
-                      data-testid="artifact-more"
-                      className={cn(
-                        art.open_proposals &&
-                          art.open_proposals > 0 &&
-                          "border-primary text-primary",
-                      )}
-                    >
-                      <Icon name="more" size={18} />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent>
-                    <DropdownMenuItem
-                      data-testid="artifact-insights"
-                      onSelect={() => setSurface("insights")}
-                    >
-                      <Icon name="insights" size={16} /> Insights
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      data-testid="artifact-history"
-                      onSelect={() => setSurface("history")}
-                    >
-                      <Icon name="history" size={16} /> Version history
-                    </DropdownMenuItem>
-                    {!!art.proposals_total && art.proposals_total > 0 && (
-                      <DropdownMenuItem
-                        data-testid="artifact-review"
-                        onSelect={() => setReviewing(true)}
-                      >
-                        <Icon name="review" size={16} />
-                        {art.open_proposals && art.open_proposals > 0
-                          ? `Review proposals (${art.open_proposals})`
-                          : "Proposals"}
-                      </DropdownMenuItem>
-                    )}
-                    {editable && canPropose && !editing && (
-                      <DropdownMenuItem data-testid="artifact-edit" onSelect={startEdit}>
-                        <Icon name="edit" size={16} />
-                        {canPublish ? "Edit source (dev)" : "Propose change (dev)"}
-                      </DropdownMenuItem>
-                    )}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-                {/* On phones the bottom-right FAB opens comments, so the header
-                button would just be a redundant extra wrap-row. */}
-                {!isMobile && panel !== "open" && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="gap-1.5"
-                    data-testid="artifact-show-comments"
-                    onClick={() => setPanel("open")}
-                    title="Show comments (c)"
-                  >
-                    <Icon name="comments" size={16} />
-                    {openCount > 0 && <b className="font-bold">{openCount}</b>}
-                  </Button>
-                )}
-              </>
+              <ArtifactTopBar
+                shortId={shortId}
+                myRole={art.my_role}
+                favorite={!!art.favorite}
+                tags={art.tags ?? []}
+                collections={art.collections ?? []}
+                canEditTags={art.my_role === "editor" || art.my_role === "owner"}
+                openProposals={art.open_proposals ?? 0}
+                proposalsTotal={art.proposals_total ?? 0}
+                isMobile={isMobile}
+                panelOpen={panel === "open"}
+                openCount={openCount}
+                showEdit={editable && canPropose && !editing}
+                editLabel={canPublish ? "Edit source (dev)" : "Propose change (dev)"}
+                onFavorite={(fav) =>
+                  qc.setQueryData(artifactQuery(shortId).queryKey, (a) =>
+                    a ? { ...a, favorite: fav } : a,
+                  )
+                }
+                onTags={(tags) =>
+                  qc.setQueryData(artifactQuery(shortId).queryKey, (a) => (a ? { ...a, tags } : a))
+                }
+                onCollections={(collections) =>
+                  qc.setQueryData(artifactQuery(shortId).queryKey, (a) =>
+                    a ? { ...a, collections } : a,
+                  )
+                }
+                onReport={show}
+                onInsights={() => setSurface("insights")}
+                onHistory={() => setSurface("history")}
+                onReview={() => setReviewing(true)}
+                onStartEdit={startEdit}
+                onShowComments={() => setPanel("open")}
+              />
             )}
           </>,
           topBarSlot,

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -6,7 +6,6 @@ import { API_BASE, api, type Comment, type Diff, type Mention } from "@/api"
 import { useIsMobile, useToast } from "@/components"
 import { Icon } from "@/components/icons"
 import { ShareButton } from "@/components/ShareDialog"
-import { Spinner } from "@/components/shared/spinner"
 import { useTopBarSlot } from "@/components/shell-context"
 import { Button } from "@/components/ui/button"
 import {
@@ -15,11 +14,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { Input } from "@/components/ui/input"
 import { useAuth } from "@/ctx"
 import { artifactQuery, commentsQuery } from "@/lib/queries"
 import { STORAGE_KEYS } from "@/lib/storage-keys"
 import { cn } from "@/lib/utils"
+import { ArtifactLoading, ArtifactNotFound, ArtifactRemoved } from "./artifact-states"
 import { ActionsCtx, type CommentActions } from "./comment-actions"
 import { MobileComments, OpenPanel } from "./comment-panels"
 import { DiffView } from "./diff-view"
@@ -28,7 +27,9 @@ import { clamp, groupThreads, parseAnchor } from "./lib/layout"
 import { toggleReaction } from "./lib/reactions"
 import { parseRef } from "./parse-ref"
 import { DeckBar, Presence, Rail } from "./rail-deck"
+import { SourceEditor } from "./source-editor"
 import type { Panel, PinItem, Sel } from "./types"
+import { useArtifactLive } from "./use-artifact-live"
 
 // Heavy on-demand surfaces — split out of the artifact route's initial chunk and
 // loaded only when the user opens them (review proposals / insights / history).
@@ -77,7 +78,6 @@ export function Artifact() {
   const [view, setView] = useState<"preview" | "diff">("preview")
   const [diff, setDiff] = useState<Diff | null>(null)
   const [restoring, setRestoring] = useState(false)
-  const [viewers, setViewers] = useState<string[]>([])
   const [src, setSrc] = useState("")
 
   // Comments UI state. On phones the panel is a slide-up sheet that starts
@@ -113,80 +113,20 @@ export function Artifact() {
     frame.current?.contentWindow?.postMessage({ source: "dock-host", ...msg }, "*")
   }, [])
 
-  // ---- Live multiplayer cursors (one viewer for everyone — ported from the old
-  // server shell). The anchor client inside the iframe relays pointer moves out via
-  // postMessage; we publish them (throttled) and render peers as an overlay layer. ----
-  const cursorLayer = useRef<HTMLDivElement>(null)
-  const cursorSelf = useRef<{ id: string; color: string }>({ id: "", color: "" })
-  if (!cursorSelf.current.id) {
-    const id = Math.random().toString(36).slice(2, 9)
-    let h = 0
-    for (const ch of id) h = (h * 31 + ch.charCodeAt(0)) % 360
-    cursorSelf.current = { id, color: `hsl(${h} 72% 52%)` } // tokens-ignore: per-peer identity hue (hashed), not a theme color
-  }
-  const cursorXY = useRef<[number, number] | null>(null)
-  const cursorSentAt = useRef(0)
-  const peerCursors = useRef(new Map<string, HTMLDivElement>())
-  const cursorTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>())
+  // Server-truth refetch after a write or an SSE ping (defined up here so the
+  // realtime hook + the iframe message bridge below can both lean on them).
+  const load = useCallback(() => {
+    qc.invalidateQueries({ queryKey: artifactQuery(shortId).queryKey })
+    qc.invalidateQueries({ queryKey: commentsQuery(shortId).queryKey })
+  }, [qc, shortId])
+  const refetchComments = useCallback(() => {
+    qc.invalidateQueries({ queryKey: commentsQuery(shortId).queryKey })
+  }, [qc, shortId])
 
-  const sendCursor = useCallback(() => {
-    const xy = cursorXY.current
-    if (!xy) return
-    cursorSentAt.current = Date.now()
-    fetch(`${API_BASE}/v1/artifacts/${shortId}/cursor`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      credentials: "include",
-      body: JSON.stringify({
-        id: cursorSelf.current.id,
-        name: me?.name ?? me?.email ?? "Guest",
-        color: cursorSelf.current.color,
-        x: xy[0],
-        y: xy[1],
-      }),
-    }).catch(() => {})
-  }, [shortId, me])
-
-  const showPeerCursor = useCallback(
-    (d: { id: string; name?: string; color?: string; x: number; y: number }) => {
-      if (d.id === cursorSelf.current.id) return
-      const layer = cursorLayer.current
-      if (!layer) return
-      let el = peerCursors.current.get(d.id)
-      if (!el) {
-        el = document.createElement("div")
-        el.className =
-          "pointer-events-none absolute left-0 top-0 z-30 transition-[transform,opacity] duration-100"
-        // tokens-ignore: #fff is the fixed white cursor outline + label text (contrast on any artifact bg), not a theme color
-        el.innerHTML =
-          '<svg width="20" height="20" viewBox="0 0 16 20"><path d="M1 1 L1 16 L5 12.5 L8 19 L10.5 18 L7.5 11.5 L13 11.5 Z" stroke="#fff" stroke-width="1.3" stroke-linejoin="round"/></svg><b style="position:absolute;left:13px;top:13px;padding:1px 6px;border-radius:5px;color:#fff;font:600 10.5px ui-sans-serif,system-ui;white-space:nowrap"></b>' // tokens-ignore
-        layer.appendChild(el)
-        peerCursors.current.set(d.id, el)
-      }
-      const color = d.color || "#655999" // tokens-ignore: lavender fallback only if a peer sends no color
-      const svg = el.querySelector("svg")
-      if (svg) (svg as SVGElement).style.fill = color
-      const tag = el.querySelector("b")
-      if (tag) {
-        tag.textContent = d.name || "Guest"
-        ;(tag as HTMLElement).style.background = color
-      }
-      const r = layer.getBoundingClientRect()
-      el.style.transform = `translate(${(d.x * r.width).toFixed(1)}px, ${(d.y * r.height).toFixed(1)}px)`
-      el.style.opacity = "1"
-      const prev = cursorTimers.current.get(d.id)
-      if (prev) clearTimeout(prev)
-      cursorTimers.current.set(
-        d.id,
-        setTimeout(() => {
-          peerCursors.current.get(d.id)?.remove()
-          peerCursors.current.delete(d.id)
-          cursorTimers.current.delete(d.id)
-        }, 8000),
-      )
-    },
-    [],
-  )
+  // Presence, live multiplayer cursors, the SSE stream, and view recording — see
+  // use-artifact-live. The page feeds pointer moves in (from the iframe bridge
+  // below) and reads `viewers` + the `cursorLayer` overlay ref back out.
+  const live = useArtifactLive({ shortId, me, onComment: refetchComments, onVersion: load })
 
   useEffect(() => {
     const onMsg = (e: MessageEvent) => {
@@ -225,13 +165,12 @@ export function Artifact() {
         setActiveThread(d.id)
         setPanel((p) => (p === "open" ? p : "open"))
       } else if (d.type === "cursor" && typeof d.x === "number" && typeof d.y === "number") {
-        cursorXY.current = [d.x, d.y]
-        if (Date.now() - cursorSentAt.current >= 45) sendCursor()
+        live.onPointerMove(d.x, d.y)
       }
     }
     window.addEventListener("message", onMsg)
     return () => window.removeEventListener("message", onMsg)
-  }, [sendCursor])
+  }, [live])
 
   // Persist the collapse state.
   useEffect(() => {
@@ -331,18 +270,6 @@ export function Artifact() {
     if (!loading && !me && failed) nav({ to: "/login" })
   }, [loading, me, failed, nav])
 
-  // Re-pull the artifact + comments from the server (after a publish/restore, or
-  // an SSE version.published). The initial fetch is handled by the useQuery hooks
-  // above; this just invalidates so they refetch.
-  const load = useCallback(() => {
-    qc.invalidateQueries({ queryKey: artifactQuery(shortId).queryKey })
-    qc.invalidateQueries({ queryKey: commentsQuery(shortId).queryKey })
-  }, [qc, shortId])
-  // Pull comments fresh (server is the source of truth after a write or SSE ping).
-  const refetchComments = useCallback(() => {
-    qc.invalidateQueries({ queryKey: commentsQuery(shortId).queryKey })
-  }, [qc, shortId])
-
   // Deep link: ?c=<thread> opens the panel, activates that thread, and jumps to
   // its text. Runs once, after comments are in.
   const deepLinked = useRef(false)
@@ -356,62 +283,6 @@ export function Artifact() {
       setTimeout(() => post({ type: "focus-anchor", id: cid }), 320)
     }
   }, [comments, post])
-
-  // live updates
-  useEffect(() => {
-    const ev = new EventSource(`${API_BASE}/v1/artifacts/${shortId}/events`, {
-      withCredentials: true,
-    })
-    ev.addEventListener("comment.created", refetchComments)
-    ev.addEventListener("comment.resolved", refetchComments)
-    ev.addEventListener("comment.reacted", refetchComments)
-    ev.addEventListener("comment.updated", refetchComments)
-    ev.addEventListener("version.published", load)
-    ev.addEventListener("presence", (e) => {
-      try {
-        setViewers((JSON.parse((e as MessageEvent).data).viewers as string[]) ?? [])
-      } catch {
-        /* ignore malformed frames */
-      }
-    })
-    ev.addEventListener("cursor", (e) => {
-      try {
-        showPeerCursor(JSON.parse((e as MessageEvent).data))
-      } catch {
-        /* ignore malformed frames */
-      }
-    })
-    return () => ev.close()
-  }, [shortId, load, refetchComments, showPeerCursor])
-
-  // Announce we're viewing (anon shows up as "Guest" — Google-Docs-style presence),
-  // keep the heartbeat alive (TTL 45s), and re-send our cursor so a still pointer
-  // doesn't fade out for peers.
-  useEffect(() => {
-    const name = me ? (me.name ?? me.email) : "Guest"
-    const beat = () =>
-      api
-        .heartbeat(shortId, name)
-        .then((r) => setViewers(r.viewers))
-        .catch(() => {})
-    beat()
-    const t = setInterval(beat, 20_000)
-    const ct = setInterval(() => {
-      if (cursorXY.current) sendCursor()
-    }, 3000)
-    return () => {
-      clearInterval(t)
-      clearInterval(ct)
-    }
-  }, [shortId, me, sendCursor])
-
-  // Record one view per artifact open.
-  const recorded = useRef("")
-  useEffect(() => {
-    if (recorded.current === shortId) return
-    recorded.current = shortId
-    api.recordView(shortId).catch(() => {})
-  }, [shortId])
 
   // Switching versions returns to the rendered preview.
   // biome-ignore lint/correctness/useExhaustiveDependencies: resets the view on a version/artifact change.
@@ -437,63 +308,25 @@ export function Artifact() {
     }
   }, [view, version, art, shortId])
 
-  if (failed)
-    return (
-      <div className="grid h-full place-items-center gap-2.5">
-        <div className="text-muted-foreground">Artifact not found, or you don't have access.</div>
-        <Button
-          variant="outline"
-          data-testid="artifact-notfound-back"
-          onClick={() => nav({ to: "/" })}
-        >
-          Back to library
-        </Button>
-      </div>
-    )
-  if (!art)
-    return (
-      <div className="grid h-full place-items-center">
-        <Spinner />
-      </div>
-    )
-
-  // Removed artifacts show a tombstone instead of the document — content is
-  // gone (the server 410s the raw routes), but an owner can still reinstate.
+  if (failed) return <ArtifactNotFound onBack={() => nav({ to: "/" })} />
+  if (!art) return <ArtifactLoading />
+  // Removed artifacts show a tombstone instead of the document — content is gone
+  // (the server 410s the raw routes), but an owner can still reinstate.
   if (art.removed)
     return (
-      <div className="grid h-full place-items-center gap-3 text-center">
-        <Icon name="removed" size={40} className="opacity-55" />
-        <div className="text-lg font-semibold">This artifact was removed</div>
-        <div className="max-w-[360px] text-sm leading-relaxed text-muted-foreground">
-          It was taken down by a moderator and is no longer available.
-        </div>
-        <div className="flex gap-2">
-          {art.my_role === "owner" && (
-            <Button
-              variant="outline"
-              data-testid="artifact-reinstate"
-              onClick={async () => {
-                try {
-                  await api.reinstate(shortId)
-                  show("Reinstated")
-                  load()
-                } catch (e) {
-                  show((e as Error).message)
-                }
-              }}
-            >
-              Reinstate
-            </Button>
-          )}
-          <Button
-            variant="outline"
-            data-testid="artifact-removed-back"
-            onClick={() => nav({ to: "/" })}
-          >
-            Back to library
-          </Button>
-        </div>
-      </div>
+      <ArtifactRemoved
+        canReinstate={art.my_role === "owner"}
+        onReinstate={async () => {
+          try {
+            await api.reinstate(shortId)
+            show("Reinstated")
+            load()
+          } catch (e) {
+            show((e as Error).message)
+          }
+        }}
+        onBack={() => nav({ to: "/" })}
+      />
     )
 
   const shown = version ?? art.current_version
@@ -656,7 +489,7 @@ export function Artifact() {
       {topBarSlot &&
         createPortal(
           <>
-            {!isMobile && <Presence viewers={viewers} self={me?.name ?? me?.email ?? ""} />}
+            {!isMobile && <Presence viewers={live.viewers} self={me?.name ?? me?.email ?? ""} />}
             {!isAnon && (
               <>
                 <StarButton
@@ -807,60 +640,17 @@ export function Artifact() {
             )}
           >
             {editing ? (
-              <div className="fixed inset-0 z-[70] flex flex-col bg-card">
-                <div className="flex items-center gap-2 border-b border-border-soft px-4 py-2.5">
-                  <Icon name="edit" size={16} />
-                  <span className="font-mono text-xs text-muted-foreground">
-                    {canPublish ? `Editing source · ${art.title ?? shortId}` : "Proposing a change"}
-                  </span>
-                  {/* The proposer's "why" — shown to the reviewer. Editors who
-                      publish directly don't need it. */}
-                  {!canPublish && (
-                    <Input
-                      value={proposeMsg}
-                      onChange={(e) => setProposeMsg(e.target.value)}
-                      placeholder="What are you changing, and why?"
-                      data-testid="artifact-propose-message"
-                      className="h-8 max-w-[420px] flex-1 text-sm"
-                    />
-                  )}
-                  <span className="flex-1" />
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    data-testid="artifact-edit-cancel"
-                    onClick={() => setEditing(false)}
-                  >
-                    Cancel
-                  </Button>
-                  {canPublish ? (
-                    <Button
-                      variant="primary"
-                      size="sm"
-                      data-testid="artifact-publish-version"
-                      onClick={publishEdit}
-                    >
-                      Publish new version
-                    </Button>
-                  ) : (
-                    <Button
-                      variant="primary"
-                      size="sm"
-                      data-testid="artifact-propose-submit"
-                      onClick={proposeEdit}
-                    >
-                      Propose change
-                    </Button>
-                  )}
-                </div>
-                <textarea
-                  value={src}
-                  onChange={(e) => setSrc(e.target.value)}
-                  spellCheck={false}
-                  data-testid="artifact-source-editor"
-                  className="flex-1 resize-none border-0 bg-card px-5 py-4 font-mono text-sm leading-relaxed text-foreground outline-none"
-                />
-              </div>
+              <SourceEditor
+                canPublish={canPublish}
+                title={art.title ?? shortId}
+                proposeMsg={proposeMsg}
+                src={src}
+                onProposeMsg={setProposeMsg}
+                onSrc={setSrc}
+                onCancel={() => setEditing(false)}
+                onPublish={publishEdit}
+                onPropose={proposeEdit}
+              />
             ) : (
               <>
                 {/* History-viewing banner: only when looking at a past version.
@@ -923,7 +713,7 @@ export function Artifact() {
                         mousemove out via postMessage; we paint the dots here in
                         the parent, over the frame. Anon viewers see + are seen. */}
                     <div
-                      ref={cursorLayer}
+                      ref={live.cursorLayer}
                       className="pointer-events-none absolute inset-0 z-20 overflow-hidden"
                     />
                   </div>

--- a/apps/web/src/pages/artifact/source-editor.tsx
+++ b/apps/web/src/pages/artifact/source-editor.tsx
@@ -1,0 +1,82 @@
+import { Icon } from "@/components/icons"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+/**
+ * The full-screen source editor: editors publish a new version directly;
+ * commenters submit the same edit as a proposal for review (with a "why" the
+ * reviewer reads). A self-contained overlay driven entirely by props.
+ */
+export function SourceEditor({
+  canPublish,
+  title,
+  proposeMsg,
+  src,
+  onProposeMsg,
+  onSrc,
+  onCancel,
+  onPublish,
+  onPropose,
+}: {
+  canPublish: boolean
+  title: string
+  proposeMsg: string
+  src: string
+  onProposeMsg: (v: string) => void
+  onSrc: (v: string) => void
+  onCancel: () => void
+  onPublish: () => void
+  onPropose: () => void
+}) {
+  return (
+    <div className="fixed inset-0 z-[70] flex flex-col bg-card">
+      <div className="flex items-center gap-2 border-b border-border-soft px-4 py-2.5">
+        <Icon name="edit" size={16} />
+        <span className="font-mono text-xs text-muted-foreground">
+          {canPublish ? `Editing source · ${title}` : "Proposing a change"}
+        </span>
+        {/* The proposer's "why" — shown to the reviewer. Editors who publish
+            directly don't need it. */}
+        {!canPublish && (
+          <Input
+            value={proposeMsg}
+            onChange={(e) => onProposeMsg(e.target.value)}
+            placeholder="What are you changing, and why?"
+            data-testid="artifact-propose-message"
+            className="h-8 max-w-[420px] flex-1 text-sm"
+          />
+        )}
+        <span className="flex-1" />
+        <Button variant="outline" size="sm" data-testid="artifact-edit-cancel" onClick={onCancel}>
+          Cancel
+        </Button>
+        {canPublish ? (
+          <Button
+            variant="primary"
+            size="sm"
+            data-testid="artifact-publish-version"
+            onClick={onPublish}
+          >
+            Publish new version
+          </Button>
+        ) : (
+          <Button
+            variant="primary"
+            size="sm"
+            data-testid="artifact-propose-submit"
+            onClick={onPropose}
+          >
+            Propose change
+          </Button>
+        )}
+      </div>
+      <textarea
+        value={src}
+        onChange={(e) => onSrc(e.target.value)}
+        spellCheck={false}
+        data-testid="artifact-source-editor"
+        className="flex-1 resize-none border-0 bg-card px-5 py-4 font-mono text-sm leading-relaxed text-foreground outline-none"
+      />
+    </div>
+  )
+}

--- a/apps/web/src/pages/artifact/use-artifact-frame.ts
+++ b/apps/web/src/pages/artifact/use-artifact-frame.ts
@@ -1,0 +1,170 @@
+import type { Dispatch, SetStateAction } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import type { Comment } from "@/api"
+import { groupThreads, parseAnchor } from "./lib/layout"
+import type { Panel, Sel } from "./types"
+
+type Selection = {
+  selector: Sel
+  top: number
+  vTop: number
+  vBottom: number
+  vLeft: number
+  vRight: number
+} | null
+
+/**
+ * The entire conversation with the sandboxed artifact iframe, kept out of the
+ * page. The frame is a separate opaque origin, so everything crosses via
+ * postMessage: it reports text selections, anchor geometry, scroll, hover/click
+ * on highlights, deck position, and pointer moves; we send it highlight anchors
+ * and deck/emphasis commands. This hook owns the frame ref, the inbound message
+ * router, the doc geometry those messages carry (selection + anchor tops +
+ * scroll), and the deck controls. The page reads `sel`/`inDoc`/`anchorTops`/
+ * `scrollY` back out to lay out the comment pins and uses `post` to drive
+ * emphasis/focus. The three setters it pokes are the page's stable useState
+ * dispatchers, so the message listener subscribes once.
+ */
+export function useArtifactFrame(p: {
+  comments: Comment[]
+  shortId: string
+  version: number | undefined
+  hoverThread: string | null
+  onPointerMove: (x: number, y: number) => void
+  setHoverThread: Dispatch<SetStateAction<string | null>>
+  setActiveThread: Dispatch<SetStateAction<string | null>>
+  setPanel: Dispatch<SetStateAction<Panel>>
+}) {
+  const { comments, shortId, version, hoverThread, onPointerMove } = p
+  const { setHoverThread, setActiveThread, setPanel } = p
+  const frame = useRef<HTMLIFrameElement>(null)
+  const presentWrap = useRef<HTMLDivElement>(null)
+  const [frameReady, setFrameReady] = useState(0)
+  const [sel, setSel] = useState<Selection>(null)
+  const [inDoc, setInDoc] = useState<Record<string, boolean>>({})
+  const [anchorTops, setAnchorTops] = useState<Record<string, number>>({})
+  const [scrollY, setScrollY] = useState(0)
+  // Set when the artifact announces itself as a deck (dock-deck protocol).
+  const [deck, setDeck] = useState<{ i: number; total: number } | null>(null)
+
+  const post = useCallback((msg: Record<string, unknown>) => {
+    frame.current?.contentWindow?.postMessage({ source: "dock-host", ...msg }, "*")
+  }, [])
+
+  useEffect(() => {
+    const onMsg = (e: MessageEvent) => {
+      const d = e.data
+      if (!d) return
+      // A slide deck reporting its position (any HTML that speaks the protocol).
+      if (d.source === "dock-deck" && d.type === "state") {
+        setDeck({ i: d.i ?? 0, total: d.total ?? 1 })
+        return
+      }
+      if (d.source !== "dock") return
+      if (d.type === "select") {
+        if (d.selector && d.rect) {
+          const fr = frame.current?.getBoundingClientRect()
+          const ft = fr?.top ?? 0
+          const fl = fr?.left ?? 0
+          setSel({
+            selector: d.selector,
+            top: d.rect.top,
+            vTop: ft + d.rect.top,
+            vBottom: ft + d.rect.bottom,
+            // left/right are sent by the current anchor client; guard against a
+            // stale-cached client posting only top/bottom so we never get NaN.
+            vLeft: fl + (d.rect.left ?? 0),
+            vRight: fl + (d.rect.right ?? d.rect.left ?? 0),
+          })
+        } else setSel(null)
+      } else if (d.type === "anchors-resolved") setInDoc(d.resolved ?? {})
+      else if (d.type === "anchor-rects") {
+        setAnchorTops(d.tops ?? {})
+        if (typeof d.scrollY === "number") setScrollY(d.scrollY)
+      } else if (d.type === "scroll") {
+        if (typeof d.scrollY === "number") setScrollY(d.scrollY)
+      } else if (d.type === "anchor-hover") setHoverThread(d.id ?? null)
+      else if (d.type === "anchor-click") {
+        setActiveThread(d.id)
+        setPanel((cur) => (cur === "open" ? cur : "open"))
+      } else if (d.type === "cursor" && typeof d.x === "number" && typeof d.y === "number") {
+        onPointerMove(d.x, d.y)
+      }
+    }
+    window.addEventListener("message", onMsg)
+    return () => window.removeEventListener("message", onMsg)
+  }, [onPointerMove, setHoverThread, setActiveThread, setPanel])
+
+  // Two-way hover: emphasize the matching highlight in the doc when a comment
+  // card is hovered (the inbound anchor-hover sets the same state the other way).
+  useEffect(() => {
+    post({ type: "emphasize", id: hoverThread })
+  }, [hoverThread, post])
+
+  // Drive the deck from the host bar; fullscreen wraps the iframe + bar so the
+  // controls stay reachable while presenting.
+  const deckCmd = useCallback(
+    (action: "next" | "prev" | "goto", n?: number) =>
+      frame.current?.contentWindow?.postMessage(
+        { source: "dock-host", type: "deck", action, n },
+        "*",
+      ),
+    [],
+  )
+  const toggleFullscreen = () => {
+    const el = presentWrap.current
+    if (!el) return
+    if (document.fullscreenElement) document.exitFullscreen()
+    else el.requestFullscreen?.()
+  }
+  // Reset the per-document iframe state when the artifact/version changes — the
+  // deck re-announces on load and a stale selection shouldn't carry over.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed to the artifact/version change, not to anything the callbacks read.
+  useEffect(() => {
+    setDeck(null)
+    setSel(null)
+  }, [shortId, version])
+  // Arrow keys drive the deck from the host (when not typing in a field).
+  useEffect(() => {
+    if (!deck) return
+    const onKey = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement
+      if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA")) return
+      if (e.key === "ArrowRight") deckCmd("next")
+      else if (e.key === "ArrowLeft") deckCmd("prev")
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [deck, deckCmd])
+
+  // Paint highlights for open, anchored threads whenever the doc or comments change.
+  const sendAnchors = useCallback(() => {
+    const w = frame.current?.contentWindow
+    if (!w) return
+    const anchors = groupThreads(comments)
+      .filter((t) => t[0].state === "open")
+      .map((t) => ({ id: t[0].thread_id, sel: parseAnchor(t[0].anchor) }))
+      .filter((x): x is { id: string; sel: NonNullable<ReturnType<typeof parseAnchor>> } => !!x.sel)
+      .map((x) => ({ id: x.id, exact: x.sel.exact, prefix: x.sel.prefix, suffix: x.sel.suffix }))
+    w.postMessage({ source: "dock-host", type: "anchors", anchors }, "*")
+  }, [comments])
+  // biome-ignore lint/correctness/useExhaustiveDependencies: frameReady is an intentional repaint trigger (re-send anchors when the iframe reloads).
+  useEffect(() => {
+    sendAnchors()
+  }, [sendAnchors, frameReady])
+
+  return {
+    frame,
+    presentWrap,
+    onFrameLoad: () => setFrameReady((n) => n + 1),
+    post,
+    deck,
+    deckCmd,
+    toggleFullscreen,
+    sel,
+    setSel,
+    inDoc,
+    anchorTops,
+    scrollY,
+  }
+}

--- a/apps/web/src/pages/artifact/use-artifact-live.ts
+++ b/apps/web/src/pages/artifact/use-artifact-live.ts
@@ -1,0 +1,167 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { API_BASE, api } from "@/api"
+
+type Me = { name?: string | null; email?: string | null } | null
+
+type CursorMsg = { id: string; name?: string; color?: string; x: number; y: number }
+
+/**
+ * Everything realtime on the artifact page, kept out of the page component:
+ *  - presence ("who's viewing" — anon shows as a server handle), heartbeated;
+ *  - live multiplayer cursors (Google-Docs/Figma style) — the sandboxed iframe
+ *    relays pointer moves out via postMessage, we publish ours (throttled) and
+ *    paint peers as an overlay over the frame;
+ *  - the SSE stream that refetches comments + reloads on a new version;
+ *  - one view record per open.
+ *
+ * The page feeds pointer moves in (`onPointerMove`, from the iframe message
+ * bridge) and reads `viewers` + the `cursorLayer` ref back out.
+ */
+export function useArtifactLive(opts: {
+  shortId: string
+  me: Me
+  onComment: () => void
+  onVersion: () => void
+}) {
+  const { shortId, me, onComment, onVersion } = opts
+  const [viewers, setViewers] = useState<string[]>([])
+
+  // Stable per-tab cursor identity: a random id + a hashed hue, so peers can tell
+  // cursors apart without any account.
+  const cursorLayer = useRef<HTMLDivElement>(null)
+  const self = useRef<{ id: string; color: string }>({ id: "", color: "" })
+  if (!self.current.id) {
+    const id = Math.random().toString(36).slice(2, 9)
+    let h = 0
+    for (const ch of id) h = (h * 31 + ch.charCodeAt(0)) % 360
+    self.current = { id, color: `hsl(${h} 72% 52%)` } // tokens-ignore: per-peer identity hue (hashed), not a theme color
+  }
+  const xy = useRef<[number, number] | null>(null)
+  const sentAt = useRef(0)
+  const peers = useRef(new Map<string, HTMLDivElement>())
+  const timers = useRef(new Map<string, ReturnType<typeof setTimeout>>())
+
+  const sendCursor = useCallback(() => {
+    const pt = xy.current
+    if (!pt) return
+    sentAt.current = Date.now()
+    fetch(`${API_BASE}/v1/artifacts/${shortId}/cursor`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({
+        id: self.current.id,
+        name: me?.name ?? me?.email ?? "Guest",
+        color: self.current.color,
+        x: pt[0],
+        y: pt[1],
+      }),
+    }).catch(() => {})
+  }, [shortId, me])
+
+  // The iframe forwards the local pointer; we throttle outgoing publishes.
+  const onPointerMove = useCallback(
+    (x: number, y: number) => {
+      xy.current = [x, y]
+      if (Date.now() - sentAt.current >= 45) sendCursor()
+    },
+    [sendCursor],
+  )
+
+  const showPeer = useCallback((d: CursorMsg) => {
+    if (d.id === self.current.id) return
+    const layer = cursorLayer.current
+    if (!layer) return
+    let el = peers.current.get(d.id)
+    if (!el) {
+      el = document.createElement("div")
+      el.className =
+        "pointer-events-none absolute left-0 top-0 z-30 transition-[transform,opacity] duration-100"
+      // tokens-ignore: #fff is the fixed white cursor outline + label text (contrast on any artifact bg), not a theme color
+      el.innerHTML =
+        '<svg width="20" height="20" viewBox="0 0 16 20"><path d="M1 1 L1 16 L5 12.5 L8 19 L10.5 18 L7.5 11.5 L13 11.5 Z" stroke="#fff" stroke-width="1.3" stroke-linejoin="round"/></svg><b style="position:absolute;left:13px;top:13px;padding:1px 6px;border-radius:5px;color:#fff;font:600 10.5px ui-sans-serif,system-ui;white-space:nowrap"></b>' // tokens-ignore
+      layer.appendChild(el)
+      peers.current.set(d.id, el)
+    }
+    const color = d.color || "#655999" // tokens-ignore: lavender fallback only if a peer sends no color
+    const svg = el.querySelector("svg")
+    if (svg) (svg as SVGElement).style.fill = color
+    const tag = el.querySelector("b")
+    if (tag) {
+      tag.textContent = d.name || "Guest"
+      ;(tag as HTMLElement).style.background = color
+    }
+    const r = layer.getBoundingClientRect()
+    el.style.transform = `translate(${(d.x * r.width).toFixed(1)}px, ${(d.y * r.height).toFixed(1)}px)`
+    el.style.opacity = "1"
+    const prev = timers.current.get(d.id)
+    if (prev) clearTimeout(prev)
+    timers.current.set(
+      d.id,
+      setTimeout(() => {
+        peers.current.get(d.id)?.remove()
+        peers.current.delete(d.id)
+        timers.current.delete(d.id)
+      }, 8000),
+    )
+  }, [])
+
+  // The live stream: comment churn + new versions refetch/reload; presence and
+  // peer cursors paint directly.
+  useEffect(() => {
+    const ev = new EventSource(`${API_BASE}/v1/artifacts/${shortId}/events`, {
+      withCredentials: true,
+    })
+    ev.addEventListener("comment.created", onComment)
+    ev.addEventListener("comment.resolved", onComment)
+    ev.addEventListener("comment.reacted", onComment)
+    ev.addEventListener("comment.updated", onComment)
+    ev.addEventListener("version.published", onVersion)
+    ev.addEventListener("presence", (e) => {
+      try {
+        setViewers((JSON.parse((e as MessageEvent).data).viewers as string[]) ?? [])
+      } catch {
+        /* ignore malformed frames */
+      }
+    })
+    ev.addEventListener("cursor", (e) => {
+      try {
+        showPeer(JSON.parse((e as MessageEvent).data))
+      } catch {
+        /* ignore malformed frames */
+      }
+    })
+    return () => ev.close()
+  }, [shortId, onComment, onVersion, showPeer])
+
+  // Announce we're viewing (anon shows up by their server handle — Google-Docs
+  // style), keep the heartbeat alive (TTL 45s), and re-send our cursor so a still
+  // pointer doesn't fade out for peers.
+  useEffect(() => {
+    const name = me ? (me.name ?? me.email ?? "Guest") : "Guest"
+    const beat = () =>
+      api
+        .heartbeat(shortId, name ?? "Guest")
+        .then((r) => setViewers(r.viewers))
+        .catch(() => {})
+    beat()
+    const t = setInterval(beat, 20_000)
+    const ct = setInterval(() => {
+      if (xy.current) sendCursor()
+    }, 3000)
+    return () => {
+      clearInterval(t)
+      clearInterval(ct)
+    }
+  }, [shortId, me, sendCursor])
+
+  // Record one view per artifact open.
+  const recorded = useRef("")
+  useEffect(() => {
+    if (recorded.current === shortId) return
+    recorded.current = shortId
+    api.recordView(shortId).catch(() => {})
+  }, [shortId])
+
+  return { viewers, cursorLayer, onPointerMove }
+}

--- a/apps/web/src/pages/artifact/use-comments-panel.ts
+++ b/apps/web/src/pages/artifact/use-comments-panel.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from "react"
+import { STORAGE_KEYS } from "@/lib/storage-keys"
+import type { Panel } from "./types"
+
+const PANEL_KEY = STORAGE_KEYS.commentsPanel
+const loadPanel = (): Panel => {
+  try {
+    const v = localStorage.getItem(PANEL_KEY)
+    return v === "rail" || v === "hidden" ? v : "open"
+  } catch {
+    return "open"
+  }
+}
+
+/**
+ * The comments panel's open/rail/hidden state and its two side effects: it's
+ * persisted per device across visits, and the `c` hotkey toggles it. Escape is
+ * wired through the same keydown listener (it routes to the page's composer
+ * cancel via `onEscape`) so the page keeps one listener, not two. Phones start
+ * hidden (document-first); desktop restores the saved state.
+ */
+export function useCommentsPanel(onEscape: () => void) {
+  const [panel, setPanel] = useState<Panel>(() =>
+    typeof window !== "undefined" && window.matchMedia("(max-width:640px)").matches
+      ? "hidden"
+      : loadPanel(),
+  )
+
+  // Persist the collapse state.
+  useEffect(() => {
+    try {
+      localStorage.setItem(PANEL_KEY, panel)
+    } catch {
+      /* private mode — ignore */
+    }
+  }, [panel])
+
+  // Keep the latest onEscape without resubscribing the listener every render.
+  const escRef = useRef(onEscape)
+  escRef.current = onEscape
+  // Keyboard: 'c' toggles the panel open/closed; Escape cancels a composer.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const el = e.target as HTMLElement
+      if (e.key === "Escape") {
+        escRef.current()
+        return
+      }
+      if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.altKey) return
+      if (el && /^(input|textarea|select)$/i.test(el.tagName)) return
+      if (e.key === "c" || e.key === "C") setPanel((p) => (p === "open" ? "rail" : "open"))
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [])
+
+  return { panel, setPanel }
+}

--- a/apps/web/src/pages/artifact/use-version-diff.ts
+++ b/apps/web/src/pages/artifact/use-version-diff.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react"
+import { api, type Diff } from "@/api"
+
+/**
+ * The version view: whether we're showing the rendered preview or a line diff,
+ * plus the fetched diff. Switching artifact/version snaps back to preview;
+ * entering diff mode on a past version fetches "what changed since this version"
+ * against current. The page reads `view`/`diff` and flips `setView`.
+ */
+export function useVersionDiff(
+  art: { current_version: number } | undefined,
+  shortId: string,
+  version: number | undefined,
+) {
+  const [view, setView] = useState<"preview" | "diff">("preview")
+  const [diff, setDiff] = useState<Diff | null>(null)
+
+  // Switching versions returns to the rendered preview.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resets the view on a version/artifact change.
+  useEffect(() => setView("preview"), [version, shortId])
+
+  // In history mode, "show changes" diffs the version being viewed against the
+  // current one — what's changed since this older version.
+  useEffect(() => {
+    if (view !== "diff" || !art) return
+    const shownN = version ?? art.current_version
+    if (shownN >= art.current_version) {
+      setDiff(null)
+      return
+    }
+    setDiff(null)
+    let alive = true
+    api
+      .diff(shortId, shownN, art.current_version)
+      .then((d) => alive && setDiff(d))
+      .catch(() => {})
+    return () => {
+      alive = false
+    }
+  }, [view, version, art, shortId])
+
+  return { view, setView, diff }
+}

--- a/package.json
+++ b/package.json
@@ -36,12 +36,13 @@
     "lint:frontend": "node scripts/check-frontend.mjs",
     "lint:testids": "node scripts/check-testids.mjs",
     "lint:api": "node scripts/check-api.mjs",
+    "lint:filesize": "node scripts/check-file-size.mjs",
     "lint:bundle": "node scripts/check-bundle.mjs",
     "lint:deadcode": "knip",
     "format": "biome format --write",
     "check": "biome check",
     "check:fix": "biome check --write",
-    "ci": "biome ci && pnpm lint:tokens && pnpm lint:frontend && pnpm lint:testids && pnpm lint:api && pnpm lint:deadcode"
+    "ci": "biome ci && pnpm lint:tokens && pnpm lint:frontend && pnpm lint:testids && pnpm lint:api && pnpm lint:filesize && pnpm lint:deadcode"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",

--- a/scripts/check-file-size.mjs
+++ b/scripts/check-file-size.mjs
@@ -27,7 +27,7 @@ const SCAN = [
 // MAX_LINES. Prefer splitting over allowlisting — only pin genuinely flat files.
 const ALLOWLIST = {
   // React pages worth decomposing (tracked down, not pinned forever):
-  "apps/web/src/pages/artifact/index.tsx": 790, // page orchestration — next: extract the document body + comment/edit handlers
+  "apps/web/src/pages/artifact/index.tsx": 662, // page orchestration — next: the iframe/anchor bridge + the comments aside, to clear 500
   "apps/web/src/pages/artifact/comment-thread.tsx": 803, // comment thread UI — split candidate
   // Irreducibly flat by nature (DDL / a port interface / driver query catalogs):
   "packages/db/src/pg.ts": 883, // Postgres MetaStore: one flat method per query

--- a/scripts/check-file-size.mjs
+++ b/scripts/check-file-size.mjs
@@ -27,7 +27,6 @@ const SCAN = [
 // MAX_LINES. Prefer splitting over allowlisting — only pin genuinely flat files.
 const ALLOWLIST = {
   // React pages worth decomposing (tracked down, not pinned forever):
-  "apps/web/src/pages/artifact/index.tsx": 662, // page orchestration — next: the iframe/anchor bridge + the comments aside, to clear 500
   "apps/web/src/pages/artifact/comment-thread.tsx": 803, // comment thread UI — split candidate
   // Irreducibly flat by nature (DDL / a port interface / driver query catalogs):
   "packages/db/src/pg.ts": 883, // Postgres MetaStore: one flat method per query

--- a/scripts/check-file-size.mjs
+++ b/scripts/check-file-size.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// File-size guard. Big files accrete complexity, hide bugs, and breed merge
+// conflicts — and agents (human or AI) keep appending to the file that's already
+// open instead of extracting. Source files must stay under MAX_LINES. A small
+// allowlist pins the existing large files at their current ceiling: they may only
+// SHRINK, never grow, and the moment one drops under the limit its entry must be
+// removed. Any NEW oversized file fails outright — split it into focused
+// modules/components/hooks. Escape hatch: add the path to ALLOWLIST with the reason
+// it's irreducibly long (a generated schema, a flat type/DDL catalog).
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import { join, relative } from "node:path"
+
+const MAX_LINES = 500
+const ROOT = process.cwd()
+const SCAN = [
+  "apps/api/src",
+  "apps/web/src",
+  "packages/core/src",
+  "packages/db/src",
+  "packages/cli/src",
+  "packages/mcp/src",
+  "packages/storage/src",
+]
+
+// path -> ceiling (its current line count). An allowlisted file may be <= its
+// ceiling; lower the number as you split it, and delete the entry once it's under
+// MAX_LINES. Prefer splitting over allowlisting — only pin genuinely flat files.
+const ALLOWLIST = {
+  // React pages worth decomposing (tracked down, not pinned forever):
+  "apps/web/src/pages/artifact/index.tsx": 858, // page orchestration — next: extract the top-bar + comment/edit handlers
+  "apps/web/src/pages/artifact/comment-thread.tsx": 803, // comment thread UI — split candidate
+  // Irreducibly flat by nature (DDL / a port interface / driver query catalogs):
+  "packages/db/src/pg.ts": 883, // Postgres MetaStore: one flat method per query
+  "packages/db/src/repos.ts": 840, // shared SQL repo methods
+  "packages/core/src/ports.ts": 628, // the MetaStore port — a flat interface catalog
+  "packages/db/src/schema.ts": 546, // SQLite schema (DDL)
+  "packages/db/src/pg-schema.ts": 518, // Postgres schema (DDL)
+}
+
+const EXCLUDE = /\.(test|spec|gen|d)\.tsx?$|[/\\]generated[/\\]/
+
+const walk = (dir, out = []) => {
+  let entries
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return out
+  }
+  for (const name of entries) {
+    const full = join(dir, name)
+    if (statSync(full).isDirectory()) walk(full, out)
+    else if (/\.tsx?$/.test(name) && !EXCLUDE.test(full)) out.push(full)
+  }
+  return out
+}
+
+const files = SCAN.flatMap((d) => walk(join(ROOT, d)))
+const errors = []
+const seen = new Set()
+
+for (const file of files) {
+  const rel = relative(ROOT, file).split("\\").join("/")
+  const lines = readFileSync(file, "utf8").split("\n").length
+  const ceiling = ALLOWLIST[rel]
+  if (ceiling != null) {
+    seen.add(rel)
+    if (lines > ceiling)
+      errors.push(`${rel}: ${lines} lines > pinned ${ceiling} — it grew. Split it, don't append.`)
+    else if (lines <= MAX_LINES)
+      errors.push(`${rel}: ${lines} lines is under ${MAX_LINES} now — delete its allowlist entry.`)
+  } else if (lines > MAX_LINES) {
+    errors.push(
+      `${rel}: ${lines} lines > ${MAX_LINES} — split into focused modules` +
+        ` (allowlist only if irreducibly flat, with a reason).`,
+    )
+  }
+}
+for (const rel of Object.keys(ALLOWLIST))
+  if (!seen.has(rel)) errors.push(`${rel}: allowlisted but not found — remove the stale entry.`)
+
+if (errors.length === 0) {
+  console.log(
+    `filesize: ok — no source file over ${MAX_LINES} lines` +
+      ` (${Object.keys(ALLOWLIST).length} pinned + shrinking)`,
+  )
+  process.exit(0)
+}
+console.error(`filesize: ${errors.length} oversized-file issue(s)\n`)
+for (const e of errors) console.error(`  ${e}`)
+console.error(
+  `\n  Keep files small: extract components, hooks, and helpers. Files balloon one` +
+    `\n  append at a time — this guard ratchets them down. See scripts/check-file-size.mjs.`,
+)
+process.exit(1)

--- a/scripts/check-file-size.mjs
+++ b/scripts/check-file-size.mjs
@@ -27,7 +27,7 @@ const SCAN = [
 // MAX_LINES. Prefer splitting over allowlisting — only pin genuinely flat files.
 const ALLOWLIST = {
   // React pages worth decomposing (tracked down, not pinned forever):
-  "apps/web/src/pages/artifact/index.tsx": 858, // page orchestration — next: extract the top-bar + comment/edit handlers
+  "apps/web/src/pages/artifact/index.tsx": 790, // page orchestration — next: extract the document body + comment/edit handlers
   "apps/web/src/pages/artifact/comment-thread.tsx": 803, // comment thread UI — split candidate
   // Irreducibly flat by nature (DDL / a port interface / driver query catalogs):
   "packages/db/src/pg.ts": 883, // Postgres MetaStore: one flat method per query

--- a/scripts/check-file-size.mjs
+++ b/scripts/check-file-size.mjs
@@ -1,16 +1,14 @@
 #!/usr/bin/env node
-// File-size guard. Big files accrete complexity, hide bugs, and breed merge
-// conflicts — and agents (human or AI) keep appending to the file that's already
-// open instead of extracting. Source files must stay under MAX_LINES. A small
-// allowlist pins the existing large files at their current ceiling: they may only
-// SHRINK, never grow, and the moment one drops under the limit its entry must be
-// removed. Any NEW oversized file fails outright — split it into focused
-// modules/components/hooks. Escape hatch: add the path to ALLOWLIST with the reason
-// it's irreducibly long (a generated schema, a flat type/DDL catalog).
+// File-size nudge — NOT a hard gate. Big files tend to lose their shape: too many
+// concerns in one place, harder to review, a magnet for merge conflicts. This
+// never fails the build; it just flags any source file over WARN_LINES so someone
+// can decide whether it's time to pull out a hook, component, or module. Length
+// itself is fine — a flat DDL or query catalog is legitimately long. The point is
+// organization, not a line count. Treat a warning as "take a look," not "blocked."
 import { readdirSync, readFileSync, statSync } from "node:fs"
 import { join, relative } from "node:path"
 
-const MAX_LINES = 500
+const WARN_LINES = 750
 const ROOT = process.cwd()
 const SCAN = [
   "apps/api/src",
@@ -21,21 +19,6 @@ const SCAN = [
   "packages/mcp/src",
   "packages/storage/src",
 ]
-
-// path -> ceiling (its current line count). An allowlisted file may be <= its
-// ceiling; lower the number as you split it, and delete the entry once it's under
-// MAX_LINES. Prefer splitting over allowlisting — only pin genuinely flat files.
-const ALLOWLIST = {
-  // React pages worth decomposing (tracked down, not pinned forever):
-  "apps/web/src/pages/artifact/comment-thread.tsx": 803, // comment thread UI — split candidate
-  // Irreducibly flat by nature (DDL / a port interface / driver query catalogs):
-  "packages/db/src/pg.ts": 883, // Postgres MetaStore: one flat method per query
-  "packages/db/src/repos.ts": 840, // shared SQL repo methods
-  "packages/core/src/ports.ts": 628, // the MetaStore port — a flat interface catalog
-  "packages/db/src/schema.ts": 546, // SQLite schema (DDL)
-  "packages/db/src/pg-schema.ts": 518, // Postgres schema (DDL)
-}
-
 const EXCLUDE = /\.(test|spec|gen|d)\.tsx?$|[/\\]generated[/\\]/
 
 const walk = (dir, out = []) => {
@@ -53,41 +36,23 @@ const walk = (dir, out = []) => {
   return out
 }
 
-const files = SCAN.flatMap((d) => walk(join(ROOT, d)))
-const errors = []
-const seen = new Set()
-
-for (const file of files) {
-  const rel = relative(ROOT, file).split("\\").join("/")
+const big = []
+for (const file of SCAN.flatMap((d) => walk(join(ROOT, d)))) {
   const lines = readFileSync(file, "utf8").split("\n").length
-  const ceiling = ALLOWLIST[rel]
-  if (ceiling != null) {
-    seen.add(rel)
-    if (lines > ceiling)
-      errors.push(`${rel}: ${lines} lines > pinned ${ceiling} — it grew. Split it, don't append.`)
-    else if (lines <= MAX_LINES)
-      errors.push(`${rel}: ${lines} lines is under ${MAX_LINES} now — delete its allowlist entry.`)
-  } else if (lines > MAX_LINES) {
-    errors.push(
-      `${rel}: ${lines} lines > ${MAX_LINES} — split into focused modules` +
-        ` (allowlist only if irreducibly flat, with a reason).`,
-    )
-  }
+  if (lines > WARN_LINES) big.push({ rel: relative(ROOT, file).split("\\").join("/"), lines })
 }
-for (const rel of Object.keys(ALLOWLIST))
-  if (!seen.has(rel)) errors.push(`${rel}: allowlisted but not found — remove the stale entry.`)
+big.sort((a, b) => b.lines - a.lines)
 
-if (errors.length === 0) {
-  console.log(
-    `filesize: ok — no source file over ${MAX_LINES} lines` +
-      ` (${Object.keys(ALLOWLIST).length} pinned + shrinking)`,
+if (big.length === 0) {
+  console.log(`filesize: ok — no source file over ${WARN_LINES} lines`)
+} else {
+  console.warn(`filesize: ${big.length} file(s) over ${WARN_LINES} lines — worth a look:`)
+  for (const { rel, lines } of big) console.warn(`  ${rel}: ${lines} lines`)
+  console.warn(
+    `\n  Not a hard limit. Long is fine when a file is one cohesive thing (a flat` +
+      `\n  DDL/query catalog). If it's several concerns piled up, extract a hook,` +
+      `\n  component, or module. Organization over length.`,
   )
-  process.exit(0)
 }
-console.error(`filesize: ${errors.length} oversized-file issue(s)\n`)
-for (const e of errors) console.error(`  ${e}`)
-console.error(
-  `\n  Keep files small: extract components, hooks, and helpers. Files balloon one` +
-    `\n  append at a time — this guard ratchets them down. See scripts/check-file-size.mjs.`,
-)
-process.exit(1)
+// Always succeeds — this is a warning, never a gate.
+process.exit(0)


### PR DESCRIPTION
## What

`apps/web/src/pages/artifact/index.tsx` had grown to 1068 lines: one component doing data loading, the iframe bridge, presence/cursors, the comments UI, version/diff, and every mutation. This branch decomposes it into focused, named units so the page just composes them.

`index.tsx`: **1068 → 422 lines**, `useEffect`s **8 → 3**.

### Extracted
- `use-artifact-live` — presence, live cursors, SSE stream, view recording
- `use-artifact-frame` — the whole sandboxed-iframe postMessage channel (selection, anchor geometry, scroll, deck, peer cursors, hover emphasis)
- `use-comments-panel` — open/rail/hidden state + persistence + `c`/Esc hotkeys
- `use-version-diff` — preview vs line-diff + the diff fetch
- `artifact-actions` — every mutation (edit/publish/propose, comment loop, restore)
- `ArtifactComments` — desktop aside + mobile sheet + selection affordance
- `ArtifactDocument` / `ArtifactTopBar` / `ArtifactStates` / `SourceEditor` — presentational pieces

The 3 effects left in the page are genuine page concerns: the artifact/version reset, the login redirect, and the one-shot `?c=` deep-link.

### File-size check
`scripts/check-file-size.mjs`, wired into `pnpm run ci`. A **soft warning over 750 lines, never a hard gate** (always exits 0): the point is keeping code organized, not minimizing line count. Long is fine when a file is one cohesive thing (a flat DDL/query catalog).

## Verification
- 29 e2e (9 smoke + 20 deep) green
- 227 unit tests green
- root typecheck + full lint gate green

The deep suite covers the exact behaviors moved: comment/reply/resolve, emoji react, edit/delete, the mobile comment loop, and the review view-toggle.