### PR TITLE
Review punch-list: artifact feed index, delivery-time SSRF guard, UX robustness

### DIFF
--- a/apps/api/src/lib/net.ts
+++ b/apps/api/src/lib/net.ts
@@ -50,31 +50,25 @@ function ipv4Octets(host: string): number[] | null {
 }
 
 /**
- * Reject webhook URLs aimed at private, loopback, or link-local addresses
- * (incl. the cloud metadata endpoint) to blunt SSRF. Literal IPs (in every
- * encoding) + localhost are blocked here; hostnames that resolve into private
- * space (DNS rebinding) are out of scope for this static check.
+ * Is a host literal a private / loopback / link-local address (incl. the cloud
+ * metadata endpoint)? Handles `localhost`, IPv4 in every inet_aton encoding, and
+ * IPv6 (loopback, unique-local, link-local, IPv4-mapped). A plain DNS hostname
+ * returns false — it isn't a literal private address; resolve it first to judge
+ * where it points (see the delivery-time check in webhooks.ts).
  */
-export function isPublicHttpUrl(raw: string): boolean {
-  let u: URL
-  try {
-    u = new URL(raw)
-  } catch {
-    return false
-  }
-  if (u.protocol !== "http:" && u.protocol !== "https:") return false
-  const host = u.hostname.toLowerCase().replace(/^\[|\]$/g, "")
-  if (host === "" || host === "localhost" || host.endsWith(".localhost")) return false
-  const v4 = ipv4Octets(host)
-  if (v4) return !isPrivateV4(v4)
-  if (host.includes(":")) {
-    if (host === "::1" || host === "::") return false
-    if (/^f[cd]/.test(host)) return false // unique-local fc00::/7
-    if (/^fe80/.test(host)) return false // link-local
+export function isPrivateAddress(host: string): boolean {
+  const h = host.toLowerCase().replace(/^\[|\]$/g, "")
+  if (h === "" || h === "localhost" || h.endsWith(".localhost")) return true
+  const v4 = ipv4Octets(h)
+  if (v4) return isPrivateV4(v4)
+  if (h.includes(":")) {
+    if (h === "::1" || h === "::") return true
+    if (/^f[cd]/.test(h)) return true // unique-local fc00::/7
+    if (/^fe80/.test(h)) return true // link-local
     // IPv4-mapped (::ffff:a.b.c.d). The URL parser rewrites the dotted tail to
     // hex hextets (::ffff:7f00:1), so handle both: decode the embedded v4 and
     // run the private-range check on it.
-    const m = host.match(/^::ffff:(.+)$/i)
+    const m = h.match(/^::ffff:(.+)$/i)
     if (m) {
       const suf = m[1] ?? ""
       let oct: number[] | null = null
@@ -88,9 +82,26 @@ export function isPublicHttpUrl(raw: string): boolean {
           oct = [(hi >> 8) & 255, hi & 255, (lo >> 8) & 255, lo & 255]
         }
       }
-      if (oct && isPrivateV4(oct)) return false
+      if (oct && isPrivateV4(oct)) return true
     }
-    return true
+    return false
   }
-  return true
+  return false
+}
+
+/**
+ * Reject webhook URLs aimed at private, loopback, or link-local addresses to
+ * blunt SSRF at registration. Literal IPs (in every encoding) + localhost are
+ * blocked here; a hostname that *resolves* into private space (DNS rebinding) is
+ * re-checked at delivery time (see deliverOnce), which is where DNS is available.
+ */
+export function isPublicHttpUrl(raw: string): boolean {
+  let u: URL
+  try {
+    u = new URL(raw)
+  } catch {
+    return false
+  }
+  if (u.protocol !== "http:" && u.protocol !== "https:") return false
+  return !isPrivateAddress(u.hostname)
 }

--- a/apps/api/src/webhooks.ts
+++ b/apps/api/src/webhooks.ts
@@ -1,6 +1,8 @@
 import { createHmac, randomUUID } from "node:crypto"
+import { lookup } from "node:dns/promises"
 import type { ArtifactRecord, DeliveryRecord, MetaStore } from "@dock/core"
 import type { WebhookEvent } from "./events"
+import { isPrivateAddress } from "./lib/net"
 import { log } from "./log"
 
 // Event names live in one place (./events) so the webhook list and the bus list
@@ -90,6 +92,20 @@ export async function deliverOnce(d: DeliveryRecord): Promise<{ ok: boolean; sta
       "x-dock-event": d.event_type,
     }
     if (!isSlack) headers["x-dock-signature"] = sign(d.secret, body)
+    // Re-validate the target at delivery, not just at registration: a hostname
+    // that was public when the webhook was created can be rebinded to an internal
+    // IP (169.254.169.254 / RFC1918 / loopback) by delivery time (DNS rebinding).
+    // Resolve every address and refuse if any is private. (Undici re-resolves on
+    // the fetch below, leaving a sub-second TOCTOU window; pinning to the
+    // validated IP — which needs an SNI-preserving dispatcher — is the follow-up.)
+    let addrs: { address: string }[]
+    try {
+      addrs = await lookup(new URL(d.url).hostname, { all: true })
+    } catch {
+      return { ok: false, status: "dns lookup failed" }
+    }
+    if (addrs.some((a) => isPrivateAddress(a.address)))
+      return { ok: false, status: "blocked: resolves to a private address" }
     // Do NOT follow redirects: the URL was SSRF-checked at registration, but a
     // 302 to 169.254.169.254 / localhost would bypass that. A redirect is a
     // delivery failure here.

--- a/apps/web/src/components/shared/route-error.tsx
+++ b/apps/web/src/components/shared/route-error.tsx
@@ -1,0 +1,57 @@
+import { type ErrorComponentProps, Link, useRouter } from "@tanstack/react-router"
+import { Icon } from "@/components/icons"
+import { Button } from "@/components/ui/button"
+
+// Shown by the router when a route's loader or render throws. Without it a
+// thrown error blanks the content area (or dumps a stack in dev). The chrome
+// (rail + top bar) stays mounted above this, so the user can always navigate
+// away. "Try again" resets the boundary and re-runs the loader. The raw message
+// is dev-only — a thrown error can carry internals we don't want in prod UI.
+export function RouteError({ error, reset }: ErrorComponentProps) {
+  const router = useRouter()
+  const detail = import.meta.env.DEV ? error.message : "Something went wrong loading this page."
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 p-10 text-center">
+      <Icon name="removed" size={32} className="text-destructive" />
+      <div className="space-y-1">
+        <p className="font-semibold text-base text-foreground">Couldn't load this page</p>
+        <p className="max-w-md text-muted-foreground text-sm">{detail}</p>
+      </div>
+      <div className="flex gap-2">
+        <Button
+          data-testid="route-error-retry"
+          variant="primary"
+          onClick={() => {
+            reset()
+            router.invalidate()
+          }}
+        >
+          Try again
+        </Button>
+        <Button asChild variant="outline" data-testid="route-error-home">
+          <Link to="/">Go home</Link>
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// Shown when navigation lands on a path with no matching route (or a loader
+// calls notFound()). Same recoverable shape as RouteError; just an invitation
+// back to the library rather than a retry.
+export function RouteNotFound() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 p-10 text-center">
+      <Icon name="search" size={32} className="text-muted-foreground" />
+      <div className="space-y-1">
+        <p className="font-semibold text-base text-foreground">Page not found</p>
+        <p className="max-w-md text-muted-foreground text-sm">
+          That link doesn't point anywhere in this workspace.
+        </p>
+      </div>
+      <Button asChild variant="primary" data-testid="route-notfound-home">
+        <Link to="/">Go home</Link>
+      </Button>
+    </div>
+  )
+}

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -1,25 +1,52 @@
-import { useState } from "react"
+import { useCallback, useRef, useState } from "react"
 import { cn } from "@/lib/utils"
 
-// Minimal transient toast. Inverted (foreground bg / background text) so it
-// reads on any theme. Returns the element to render + a `show(msg)` trigger.
+type ToastKind = "info" | "error"
+interface ToastItem {
+  id: number
+  msg: string
+  kind: ToastKind
+}
+
+// How long each kind lingers before auto-dismiss. Errors stay long enough to
+// read and act on; info is a quick confirmation.
+const TIMEOUT_MS: Record<ToastKind, number> = { info: 2200, error: 6000 }
+
+// Transient toast stack. Multiple rapid calls queue and stack instead of
+// clobbering a single slot — the old single-`msg` version dropped every toast
+// but the last (publish-then-copy would lose the first message). Each toast
+// owns its own dismiss timer. Info is inverted (foreground bg) so it reads on
+// any theme; error uses the destructive token and announces assertively.
+// Returns the element to render + a `show(msg, kind?)` trigger; existing
+// `show(msg)` callers are unchanged (kind defaults to "info").
 export function useToast() {
-  const [msg, setMsg] = useState("")
+  const [items, setItems] = useState<ToastItem[]>([])
+  const seq = useRef(0)
+  const show = useCallback((msg: string, kind: ToastKind = "info") => {
+    const id = ++seq.current
+    setItems((prev) => [...prev, { id, msg, kind }])
+    setTimeout(() => setItems((prev) => prev.filter((t) => t.id !== id)), TIMEOUT_MS[kind])
+  }, [])
+  // The container is always mounted so the live regions exist before any text
+  // lands in them; toasts are inserted as children as they fire.
   const toast = (
-    <div
-      role="status"
-      aria-live="polite"
-      className={cn(
-        "pointer-events-none fixed bottom-[18px] left-1/2 z-[90] -translate-x-1/2 rounded-[10px] bg-foreground px-[15px] py-2.5 text-sm text-background transition-opacity duration-200",
-        msg ? "opacity-100" : "opacity-0",
-      )}
-    >
-      {msg}
+    <div className="pointer-events-none fixed bottom-[18px] left-1/2 z-[90] flex -translate-x-1/2 flex-col items-center gap-2">
+      {items.map((t) => (
+        <div
+          key={t.id}
+          role={t.kind === "error" ? "alert" : "status"}
+          aria-live={t.kind === "error" ? "assertive" : "polite"}
+          className={cn(
+            "rounded-[10px] px-[15px] py-2.5 text-sm shadow-lg",
+            t.kind === "error"
+              ? "bg-destructive text-destructive-foreground"
+              : "bg-foreground text-background",
+          )}
+        >
+          {t.msg}
+        </div>
+      ))}
     </div>
   )
-  const show = (m: string) => {
-    setMsg(m)
-    setTimeout(() => setMsg(""), 1900)
-  }
   return { toast, show }
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,4 +1,5 @@
 import { createRouter } from "@tanstack/react-router"
+import { RouteError, RouteNotFound } from "./components/shared/route-error"
 import { RouteSkeleton } from "./components/shared/route-skeleton"
 import { queryClient } from "./lib/query-client"
 import { routeTree } from "./routeTree.gen"
@@ -27,6 +28,11 @@ export function getRouter() {
     defaultPendingMs: 150,
     defaultPendingMinMs: 300,
     defaultPendingComponent: RouteSkeleton,
+    // A thrown loader/render error or a missing route renders inside the content
+    // area (chrome stays mounted, so the user can always navigate away) instead
+    // of a blank screen or a raw stack trace.
+    defaultErrorComponent: RouteError,
+    defaultNotFoundComponent: RouteNotFound,
     context: { queryClient },
   })
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -11,8 +11,19 @@ import { type ReactNode, useEffect } from "react"
 import { AppShell } from "../components/app-shell"
 import { AuthProvider, ThemeProvider } from "../ctx"
 import { queryClient } from "../lib/query-client"
+import { STORAGE_KEYS } from "../lib/storage-keys"
 import { reportWebVitals } from "../lib/vitals"
 import "@/styles/globals.css"
+
+// Apply the saved theme before first paint. The prerendered shell ships
+// data-theme="paper"; without this, a user on Dark/Dusk/Light sees a paper
+// flash until ThemeProvider's effect runs post-hydration. This runs
+// synchronously in <head>, ahead of body render. Keyed off STORAGE_KEYS.theme
+// (not a literal) so it tracks the one key definition and stays out of the
+// storage-key linter's way.
+const THEME_BOOT = `(function(){try{var t=localStorage.getItem(${JSON.stringify(
+  STORAGE_KEYS.theme,
+)});if(t)document.documentElement.dataset.theme=t}catch(e){}})()`
 
 export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()({
   head: () => ({
@@ -77,6 +88,10 @@ function RootDocument({ children }: { children: ReactNode }) {
   return (
     <html lang="en" data-theme="paper">
       <head>
+        <script
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: static boot string built from a constant storage key, no user input.
+          dangerouslySetInnerHTML={{ __html: THEME_BOOT }}
+        />
         <HeadContent />
       </head>
       <body>

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -17,6 +17,8 @@ CREATE TABLE IF NOT EXISTS artifact (
     removed_at TEXT
   );
 
+CREATE INDEX IF NOT EXISTS artifact_org_created ON artifact (org_id, created_at, id);
+
 CREATE TABLE IF NOT EXISTS version (
     id TEXT PRIMARY KEY,
     artifact_id TEXT NOT NULL REFERENCES artifact(id),

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -293,6 +293,9 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
     removed_at TEXT
   )`,
   `ALTER TABLE artifact ADD COLUMN IF NOT EXISTS removed_at TEXT`,
+  // Library feed: scope by org_id + keyset order on (created_at, id) desc. One
+  // composite serves both; Postgres backward-scans it for the DESC order.
+  `CREATE INDEX IF NOT EXISTS artifact_org_created ON artifact (org_id, created_at, id)`,
   `CREATE TABLE IF NOT EXISTS version (
     id TEXT PRIMARY KEY,
     artifact_id TEXT NOT NULL REFERENCES artifact(id),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -307,6 +307,11 @@ export const SCHEMA_STATEMENTS: string[] = [
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
     removed_at TEXT
   )`,
+  // The library feed: filter by org_id, order by (created_at, id) desc (keyset
+  // pagination). Composite index serves both the scope and the sort; SQLite/D1
+  // reverse-scan it for the DESC order. Without it every workspace list is a
+  // full table scan + filesort.
+  `CREATE INDEX IF NOT EXISTS artifact_org_created ON artifact (org_id, created_at, id)`,
   `CREATE TABLE IF NOT EXISTS version (
     id TEXT PRIMARY KEY,
     artifact_id TEXT NOT NULL REFERENCES artifact(id),


### PR DESCRIPTION
Top items from the deep review, in one reviewable pass.

## DB: composite artifact feed index
Add `artifact (org_id, created_at, id)` across all three stores (`SCHEMA_STATEMENTS`, `PG_SCHEMA_STATEMENTS`, generated `deploy/d1-schema.sql`). One index serves both the workspace scope and the `(created_at, id)` DESC keyset sort, so the library feed stops doing a full scan + filesort. Confirmed on all chosen stores: SQLite/D1 reverse-scan a composite for DESC, Postgres backward-scans it.

## API: delivery-time SSRF guard
Re-validate webhook targets at delivery, not just at registration. Extract `isPrivateAddress()` from `isPublicHttpUrl()`; in `deliverOnce`, resolve the host and refuse if any address is private. Closes the DNS-rebinding window between registration and delivery. Existing `redirect: "manual"` stays. A sub-second TOCTOU window remains (undici re-resolves on fetch); IP-pinning via an SNI-preserving dispatcher is a noted follow-up.

## Web: UX robustness trio
- **toast** is now a queued stack with per-item timers and an `error` variant (destructive bg, `aria-live=assertive`, longer dwell), replacing the single slot that dropped every toast but the last. `show(msg)` callers unchanged; `kind` defaults to `"info"`.
- **theme FOUC**: a blocking inline boot script in `<head>` applies the saved theme before first paint (keyed off `STORAGE_KEYS.theme`), so Dark/Dusk/Light no longer flash the prerendered paper shell.
- **router boundaries**: `defaultErrorComponent` + `defaultNotFoundComponent` (new `shared/route-error.tsx`) render a recoverable surface under the persistent chrome instead of a blank screen or raw stack.

## Verification
root typecheck (7 pkgs) · biome ci · token/frontend/testid/api checkers · knip · bundle budget (246.6/260 kB) · unit tests (db 20, api 153, storage 6, mcp 10, core) · e2e 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)