### PR TITLE
fix: review punch-list round 2 — share authz clamp + cache + small UX

### DIFF
--- a/apps/api/src/routes/sharing.ts
+++ b/apps/api/src/routes/sharing.ts
@@ -1,5 +1,5 @@
-import { isRole, newId, type Role } from "@dock/core"
-import { Hono } from "hono"
+import { type ArtifactRecord, effectiveRole, isRole, newId, ROLES, type Role } from "@dock/core"
+import { type Context, Hono } from "hono"
 import { z } from "zod"
 import type { AppContext } from "../context"
 import { fail, readJson } from "../lib/http"
@@ -7,8 +7,16 @@ import { fail, readJson } from "../lib/http"
 /** Per-artifact role overrides (a share). Managing shares requires `share`
  *  (editor+, GDocs model); the share's role beats the caller's workspace baseline. */
 export const sharingRoutes = (ctx: AppContext) => {
-  const { meta, defaultRole, anonLocked, authorize } = ctx
+  const { meta, defaultRole, anonLocked, authorize, actorFor } = ctx
   const app = new Hono()
+
+  // A sharer can never grant — or remove — a role above their own. An editor (who
+  // has `share` but not `manage`) invites viewers/commenters/editors; only an owner
+  // can grant owner. Without this, an editor could PUT themselves `owner` (which
+  // confers `manage`) and DELETE the real owner, seizing the artifact.
+  const rank = (r: Role | null): number => (r ? ROLES.indexOf(r) : -1)
+  const callerRank = async (c: Context, a: ArtifactRecord): Promise<number> =>
+    rank(effectiveRole(await actorFor(c, a), a.visibility))
 
   app.get("/v1/artifacts/:shortId/members", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
@@ -42,6 +50,8 @@ export const sharingRoutes = (ctx: AppContext) => {
       }),
     )
     if (b instanceof Response) return b
+    if (rank(b.role) > (await callerRank(c, artifact)))
+      return fail(c, 403, "you can't grant a role above your own")
     const user = await meta.findUserByEmail(b.email.trim())
     if (!user) return fail(c, 404, "no Dock user with that email")
     await meta.setArtifactMember({
@@ -57,6 +67,11 @@ export const sharingRoutes = (ctx: AppContext) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact) return fail(c, 404, "not found")
     if (!(await authorize(c, "share", artifact))) return fail(c, 403, "forbidden")
+    const target = (await meta.listArtifactMembers(artifact.id)).find(
+      (m) => m.user_id === c.req.param("userId"),
+    )
+    if (target && rank(target.role) > (await callerRank(c, artifact)))
+      return fail(c, 403, "you can't remove a collaborator who outranks you")
     await meta.removeArtifactMember(artifact.id, c.req.param("userId"))
     return c.body(null, 204)
   })

--- a/apps/api/test/permissions.test.ts
+++ b/apps/api/test/permissions.test.ts
@@ -164,3 +164,44 @@ describe("permissions: a per-artifact share overrides the workspace role", () =>
     )
   })
 })
+
+describe("permissions: a sharer can't grant or remove a role above their own", () => {
+  const owner: TestUser = { id: "u_o2", email: "o2@dock.test", name: "O2" }
+  const ed: TestUser = { id: "u_ed2", email: "ed2@dock.test", name: "Ed2" }
+  const out: TestUser = { id: "u_out2", email: "out2@dock.test", name: "Out2" }
+  const { app } = makeAuthedApp("perm-clamp", [owner, ed, out], "viewer")
+  let shortId: string
+
+  const putMember = (by: TestUser, email: string, role: string) =>
+    app.request(`/v1/artifacts/${shortId}/members`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", ...as(by.email) },
+      body: JSON.stringify({ email, role }),
+    })
+  const delMember = (by: TestUser, userId: string) =>
+    app.request(`/v1/artifacts/${shortId}/members/${userId}`, {
+      method: "DELETE",
+      headers: as(by.email),
+    })
+
+  it("sets up an org artifact shared to an editor", async () => {
+    shortId = (
+      await (await publishAs(app, "<h1>x</h1>", { visibility: "org" }, as(owner.email))).json()
+    ).short_id
+    expect((await putMember(owner, ed.email, "editor")).status).toBe(201)
+  })
+
+  it("blocks an editor from granting owner (privilege escalation), but an owner can", async () => {
+    expect((await putMember(ed, out.email, "owner")).status).toBe(403)
+    expect((await putMember(owner, out.email, "owner")).status).toBe(201)
+  })
+
+  it("blocks an editor from removing a collaborator who outranks them, but an owner can", async () => {
+    expect((await delMember(ed, out.id)).status).toBe(403)
+    expect((await delMember(owner, out.id)).status).toBe(204)
+  })
+
+  it("still lets an editor grant up to their own role", async () => {
+    expect((await putMember(ed, out.email, "editor")).status).toBe(201)
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -256,9 +256,10 @@ export const api = {
   }> => f("/v1/tags", opts()).then(j),
   getArtifact: (id: string): Promise<Artifact> => f(`/v1/artifacts/${id}`, opts()).then(j),
   getContent: (id: string, v?: number): Promise<string> =>
-    f(`/v1/artifacts/${id}/content${v ? `?v=${v}` : ""}`, { credentials: "include" }).then((r) =>
-      r.text(),
-    ),
+    f(`/v1/artifacts/${id}/content${v ? `?v=${v}` : ""}`, { credentials: "include" }).then((r) => {
+      if (!r.ok) throw new Error(`HTTP ${r.status}`)
+      return r.text()
+    }),
   diff: (id: string, from: number, to: number): Promise<Diff> =>
     f(`/v1/artifacts/${id}/diff?from=${from}&to=${to}&format=json`, opts()).then(j),
   restore: (id: string, version: number): Promise<Artifact> =>

--- a/apps/web/src/components/ShareDialog.tsx
+++ b/apps/web/src/components/ShareDialog.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query"
 import { Lock, Share2, X } from "lucide-react"
 import { useState } from "react"
 import { type ArtifactMember, api, type Role } from "@/api"
@@ -46,6 +47,7 @@ export function ShareButton({ shortId, myRole }: { shortId: string; myRole?: Rol
   // GDocs model: owners and editors manage access; everyone else gets view-only.
   const canManage = myRole === "owner" || myRole === "editor"
 
+  const qc = useQueryClient()
   const load = () =>
     api
       .listMembers(shortId)
@@ -54,6 +56,13 @@ export function ShareButton({ shortId, myRole }: { shortId: string; myRole?: Rol
         setDefaultRole(r.default_role)
       })
       .catch(() => {})
+  // After a share change, refresh the local list AND the shared cache: the artifact
+  // query holds `my_role` (drives the toolbar), and the library reflects access.
+  const synced = async () => {
+    await load()
+    qc.invalidateQueries({ queryKey: ["artifact", shortId] })
+    qc.invalidateQueries({ queryKey: ["artifacts"] })
+  }
 
   const add = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -64,7 +73,7 @@ export function ShareButton({ shortId, myRole }: { shortId: string; myRole?: Rol
     try {
       await api.setMember(shortId, addr, role)
       setEmail("")
-      await load()
+      await synced()
     } catch (x) {
       setErr(x instanceof Error ? x.message : "Could not share")
     } finally {
@@ -74,11 +83,11 @@ export function ShareButton({ shortId, myRole }: { shortId: string; myRole?: Rol
   const change = async (m: ArtifactMember, next: Role) => {
     if (next === m.role || !m.email) return
     await api.setMember(shortId, m.email, next).catch(() => {})
-    await load()
+    await synced()
   }
   const remove = async (m: ArtifactMember) => {
     await api.removeMember(shortId, m.user_id).catch(() => {})
-    await load()
+    await synced()
   }
 
   return (

--- a/apps/web/src/pages/artifact/artifact-actions.ts
+++ b/apps/web/src/pages/artifact/artifact-actions.ts
@@ -125,13 +125,20 @@ export function artifactActions(p: {
   const actions: CommentActions = {
     meName: me?.name ?? me?.email ?? "",
     react: (commentId, emoji) => {
-      // Optimistic: reflect the toggle in the cache immediately, reconcile on the response.
-      qc.setQueryData(commentsQuery(shortId).queryKey, (cs) =>
+      // Optimistic: reflect the toggle immediately, snapshot to roll back on failure.
+      // A plain refetch can't undo the toggle when the server is unreachable, so the
+      // catch restores the pre-toggle cache instead.
+      const key = commentsQuery(shortId).queryKey
+      const prev = qc.getQueryData(key)
+      qc.setQueryData(key, (cs) =>
         (cs ?? []).map((c) =>
           c.id === commentId ? toggleReaction(c, emoji, me?.name ?? me?.email ?? "anonymous") : c,
         ),
       )
-      api.react(shortId, commentId, emoji).then(refetchComments).catch(refetchComments)
+      api
+        .react(shortId, commentId, emoji)
+        .then(refetchComments)
+        .catch(() => qc.setQueryData(key, prev))
     },
     edit: async (commentId, body) => {
       await api.editComment(shortId, commentId, body).catch((e) => show((e as Error).message))


### PR DESCRIPTION
Second pass on the deep-review punch-list (round 1 was #105). All small, focused fixes.

## Sharing authz: clamp grants/removals to the caller's role (the one real security hole)
`PUT /v1/artifacts/:id/members` gated only on `share` (editor+) but accepted **any** role including `owner`. An editor (who has `share`, not `manage`) could grant themselves `owner` — which confers `manage` — and then `DELETE` the real owner, seizing the artifact. Now a sharer can grant/remove at most their own effective role on that artifact; only an owner can grant/remove owner. Test added (`permissions.test.ts`).

## Share dialog: refresh the shared cache after a member change
`ShareButton` kept members in local state and never touched React Query, so after a self-demote the artifact toolbar (`my_role`) stayed stale until a hard refresh. Now invalidates `["artifact", id]` + `["artifacts"]` after add/change/remove.

## api.getContent: guard non-ok responses
Was `.then(r => r.text())` with no `r.ok` check, so a 403/410 error page could be pasted into the source editor (and re-published). Now throws on non-ok.

## Comment reaction: snapshot + rollback
Optimistic toggle relied on a refetch to "undo" on failure, which also fails offline. Now snapshots the cache and restores it in `catch`.

## Verification
typecheck (all pkgs) · biome ci + lints + knip · full api test suite (incl. 4 new privesc tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)