### PR TITLE
Vanity subdomains: serve an artifact at its own host root (C1, subdomain tier)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,11 @@ DATA_DIR=./data
 # it. Unset = single-origin self-host (the iframe sandbox attribute is the wall).
 # DOCK_SANDBOX_URL=https://usercontent.example.com
 
+# Vanity subdomains (domain mode): a base domain whose wildcard (*.<base>) points
+# at this server. An artifact assigned `q3-review.<base>` is then served at that
+# host's root — its own origin, a clean URL. Unset = subdomain serving off.
+# DOCK_SUBDOMAIN_BASE=dockd.app
+
 # --- Abuse limits & quotas ------------------------------------------------
 # Per-IP rate limiting on auth + mutating routes is ON by default; set false to
 # disable (e.g. behind your own gateway). Turning it off also disables the

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,14 +1,16 @@
 import { type Context, Hono } from "hono"
 import { compress } from "hono/compress"
 import { type AppDeps, buildContext } from "./context"
-import { corsFor, fail } from "./lib/http"
+import { corsFor, fail, TOMBSTONE } from "./lib/http"
 import { makeRateLimiter } from "./lib/rate-limit"
+import { serveContent } from "./lib/serve-content"
 import { log } from "./log"
 import { agentRoutes } from "./routes/agents"
 import { analyticsRoutes } from "./routes/analytics"
 import { artifactRoutes } from "./routes/artifacts"
 import { collectionRoutes } from "./routes/collections"
 import { commentRoutes } from "./routes/comments"
+import { domainRoutes } from "./routes/domains"
 import { embedRoutes } from "./routes/embeds"
 import { favoriteRoutes } from "./routes/favorites"
 import { moderationRoutes } from "./routes/moderation"
@@ -78,6 +80,47 @@ export function createApp(deps: AppDeps): Hono {
         return c.redirect(`${deps.sandboxOrigin}${path}${new URL(c.req.url).search}`, 302)
       }
       return next()
+    })
+  }
+
+  // ---- Domain mode (C1): vanity subdomains -------------------------------
+  // With a base domain configured, a request to `<label>.<base>` whose host is in
+  // the `domain` table serves that artifact at the host root: its own origin, no
+  // path prefix, the absolute-URL rewriting a no-op. Like the sandbox host, these
+  // vanity hosts serve ONLY artifact bytes + the anchor client, never the
+  // app/auth/API, and the app's own host is never matched. A vanity host is
+  // cross-origin, so the actor is anonymous: only public/link artifacts resolve,
+  // gated ones 404, a removed one 410.
+  const subBase = deps.subdomainBase?.toLowerCase()
+  const appHostForSub = (() => {
+    try {
+      return new URL(deps.baseUrl).host.toLowerCase()
+    } catch {
+      return null
+    }
+  })()
+  if (subBase) {
+    app.use("*", async (c, next) => {
+      const host = (c.req.header("host") ?? new URL(c.req.url).host).toLowerCase().split(":")[0]
+      if (
+        !host ||
+        host === appHostForSub ||
+        (sandboxHost && host === sandboxHost.toLowerCase()) ||
+        host === subBase ||
+        !host.endsWith(`.${subBase}`)
+      )
+        return next()
+      // The served HTML references /raw/dock-client.js; let raw + health through.
+      if (c.req.path === "/healthz" || c.req.path.startsWith("/raw/")) return next()
+      const record = await ctx.meta.getDomain(host)
+      if (!record) return c.text("not found", 404)
+      const artifact = await ctx.meta.getArtifactById(record.artifact_id)
+      if (!artifact || !(await ctx.authorize(c, "read", artifact))) return c.text("not found", 404)
+      if (artifact.removed_at) return c.text(TOMBSTONE, 410)
+      const version = await ctx.meta.getVersion(artifact.id, artifact.current_version)
+      if (!version) return c.text("not found", 404)
+      const reqPath = decodeURIComponent(c.req.path.replace(/^\/+/, ""))
+      return serveContent(c, ctx.blobs, version, artifact.title, "/", reqPath)
     })
   }
 
@@ -161,6 +204,7 @@ export function createApp(deps: AppDeps): Hono {
     webhookRoutes,
     rawRoutes,
     embedRoutes,
+    domainRoutes,
   ])
     app.route("/", routes(ctx))
 

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -25,6 +25,9 @@ export interface Config {
   rateLimit: boolean
   sandboxOrigin?: string
   crossSite: boolean
+  /** Base domain for vanity subdomains (e.g. "dockd.app"): an artifact assigned
+   *  `q3.dockd.app` is served at that host's root. Unset = subdomain mode off. */
+  subdomainBase?: string
   versionWindowMs?: number
   maxArtifacts?: number
   maxBytes?: number
@@ -95,6 +98,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     rateLimit: env.DOCK_RATE_LIMIT !== "false",
     sandboxOrigin: env.DOCK_SANDBOX_URL,
     crossSite: env.DOCK_CROSS_SITE === "true",
+    subdomainBase: env.DOCK_SUBDOMAIN_BASE?.toLowerCase().replace(/^\.+|\.+$/g, "") || undefined,
     versionWindowMs: env.DOCK_VERSION_WINDOW ? Number(env.DOCK_VERSION_WINDOW) * 60_000 : undefined,
     maxArtifacts: posInt(env.DOCK_MAX_ARTIFACTS),
     maxBytes: posInt(env.DOCK_MAX_BYTES),

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -117,6 +117,12 @@ export interface AppDeps {
    */
   sandboxOrigin?: string
   /**
+   * Base domain for vanity subdomains (e.g. "dockd.app"). When set, a request to
+   * `<label>.<base>` whose host is in the `domain` table serves that artifact at
+   * the host root (domain mode). Unset = subdomain serving off.
+   */
+  subdomainBase?: string
+  /**
    * The SPA and API are on different sites (hosted split). Makes first-party
    * cookies we set here — currently the anonymous-viewer id — `SameSite=None;
    * Secure` so they survive the cross-site request, matching the session cookie.

--- a/apps/api/src/lib/serve-content.ts
+++ b/apps/api/src/lib/serve-content.ts
@@ -1,0 +1,73 @@
+import {
+  type BlobStore,
+  BUNDLE_CONTENT_TYPE,
+  type BundleManifest,
+  mimeFor,
+  renderMarkdown,
+  SELECTION_SCRIPT,
+} from "@dock/core"
+import type { Context } from "hono"
+import { RAW_HEADERS, rewriteAbsoluteUrls, toBody } from "./http"
+
+/**
+ * Serve stored artifact content (a version or a proposal) under `prefix`, resolving
+ * a sub-`path` for bundles. Shared by the `/raw/*` sandbox routes and domain mode:
+ * for `/raw/:id/v/:n/` the prefix carries the path; for a vanity host the prefix is
+ * `/`, so the absolute-URL rewriting becomes a no-op and the artifact serves at its
+ * own origin root. Always carries the opaque-origin CSP (RAW_HEADERS).
+ */
+export const serveContent = async (
+  c: Context,
+  blobs: BlobStore,
+  content: { blob_key: string; content_type: string },
+  title: string | null,
+  prefix: string,
+  rawPath: string,
+) => {
+  let path = rawPath
+  if (content.content_type === BUNDLE_CONTENT_TYPE) {
+    const manifestBytes = await blobs.get(content.blob_key)
+    if (!manifestBytes) return c.text("blob missing", 500)
+    const manifest = JSON.parse(new TextDecoder().decode(manifestBytes)) as BundleManifest
+
+    if (path === "" || path === "index.html") path = manifest.entry.slice(1)
+    let lookup = `/${path}`
+    if (lookup.endsWith("/")) lookup += "index.html"
+    let entry = manifest.files[lookup]
+    // Pretty URLs (Astro-style dir output), then SPA fallback.
+    if (!entry && !/\.[a-z0-9]+$/i.test(lookup)) entry = manifest.files[`${lookup}/index.html`]
+    if (!entry && manifest.spa) entry = manifest.files[manifest.entry]
+    if (!entry) return c.text("not found", 404, RAW_HEADERS)
+
+    const data = await blobs.get(entry.key)
+    if (!data) return c.text("blob missing", 500)
+    if (entry.type.startsWith("text/html") || entry.type.startsWith("text/css")) {
+      const rewritten = rewriteAbsoluteUrls(new TextDecoder().decode(data), prefix.slice(0, -1))
+      // Bundle pages get the anchor client too — comments stick everywhere.
+      const out = entry.type.startsWith("text/html") ? rewritten + SELECTION_SCRIPT : rewritten
+      return c.body(out, 200, { ...RAW_HEADERS, "Content-Type": entry.type })
+    }
+    return c.body(toBody(data), 200, { ...RAW_HEADERS, "Content-Type": entry.type })
+  }
+
+  const data = await blobs.get(content.blob_key)
+  if (!data) return c.text("blob missing", 500)
+
+  if (content.content_type === "text/markdown") {
+    if (path === "raw.md")
+      return c.body(toBody(data), 200, {
+        ...RAW_HEADERS,
+        "Content-Type": "text/markdown; charset=utf-8",
+      })
+    const html = await renderMarkdown(new TextDecoder().decode(data), title)
+    return c.body(html, 200, { ...RAW_HEADERS, "Content-Type": "text/html; charset=utf-8" })
+  }
+
+  // html file artifact — any path serves the document (+ selection capture)
+  const ct = mimeFor(path || "index.html")
+  if (ct.startsWith("text/html")) {
+    const html = new TextDecoder().decode(data) + SELECTION_SCRIPT
+    return c.body(html, 200, { ...RAW_HEADERS, "Content-Type": ct })
+  }
+  return c.body(toBody(data), 200, { ...RAW_HEADERS, "Content-Type": ct })
+}

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -87,6 +87,8 @@ const app = createApp({
   // pointed at this same container. Keeps user HTML off the app's cookie origin.
   sandboxOrigin: cfg.sandboxOrigin,
   crossSite: cfg.crossSite,
+  // Vanity subdomains (domain mode): when set, name.<base> serves its artifact.
+  subdomainBase: cfg.subdomainBase,
   versionWindowMs: cfg.versionWindowMs,
   // Storage backstops: unset = unlimited (self-host stays open).
   maxArtifacts: cfg.maxArtifacts,

--- a/apps/api/src/routes/domains.ts
+++ b/apps/api/src/routes/domains.ts
@@ -1,0 +1,102 @@
+import type { DomainRecord } from "@dock/core"
+import { Hono } from "hono"
+import { z } from "zod"
+import type { AppContext } from "../context"
+import { fail, readJson } from "../lib/http"
+
+// Labels an artifact may never claim — they belong to the app or common infra.
+const RESERVED = new Set([
+  "www",
+  "app",
+  "api",
+  "admin",
+  "mail",
+  "smtp",
+  "ns",
+  "ns1",
+  "ns2",
+  "cdn",
+  "static",
+  "assets",
+  "dashboard",
+  "status",
+  "docs",
+  "help",
+])
+// A single DNS label: 1-63 chars, a-z0-9 and hyphens, not hyphen-edged.
+const LABEL = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
+
+/**
+ * Vanity subdomains (domain mode C1, subdomain tier): assign `<label>.<base>` to an
+ * artifact, list, and release. Gated on `share` (the same authority as visibility),
+ * and only available when the server sets a base domain (DOCK_SUBDOMAIN_BASE).
+ * Serving at the host root is handled by the host-dispatch middleware in app.ts.
+ */
+export const domainRoutes = (ctx: AppContext) => {
+  const { meta, authorize } = ctx
+  const base = ctx.deps.subdomainBase?.toLowerCase()
+  const scheme = (() => {
+    try {
+      return new URL(ctx.deps.baseUrl).protocol
+    } catch {
+      return "https:"
+    }
+  })()
+  const app = new Hono()
+
+  const toJson = (d: DomainRecord) => ({
+    host: d.host,
+    url: `${scheme}//${d.host}`,
+    kind: d.kind,
+    created_at: d.created_at,
+  })
+
+  // The artifact's vanity hosts (and whether the server has a base configured).
+  app.get("/v1/artifacts/:shortId/domains", async (c) => {
+    const artifact = await meta.getByShortId(c.req.param("shortId"))
+    if (!artifact || !(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
+    const domains = await meta.getArtifactDomains(artifact.id)
+    return c.json({ base: base ?? null, domains: domains.map(toJson) })
+  })
+
+  // Claim `<label>.<base>` for the artifact. Idempotent if it is already yours.
+  app.put("/v1/artifacts/:shortId/domains", async (c) => {
+    if (!base) return fail(c, 501, "subdomains are not enabled on this server")
+    const artifact = await meta.getByShortId(c.req.param("shortId"))
+    if (!artifact || !(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
+    if (!(await authorize(c, "share", artifact))) return fail(c, 403, "forbidden")
+    const body = await readJson(c, z.object({ label: z.string() }))
+    if (body instanceof Response) return body
+    const label = body.label.trim().toLowerCase()
+    if (!LABEL.test(label) || RESERVED.has(label))
+      return fail(c, 400, "invalid or reserved subdomain label")
+    const host = `${label}.${base}`
+    const existing = await meta.getDomain(host)
+    if (existing)
+      return existing.artifact_id === artifact.id
+        ? c.json(toJson(existing))
+        : fail(c, 409, "that subdomain is taken")
+    const created = await meta.setDomain({
+      host,
+      artifact_id: artifact.id,
+      org_id: artifact.org_id,
+      kind: "subdomain",
+    })
+    if (!created) return fail(c, 409, "that subdomain is taken")
+    return c.json(toJson(created), 201)
+  })
+
+  // Release a vanity host (scoped to the artifact's workspace).
+  app.delete("/v1/artifacts/:shortId/domains/:host", async (c) => {
+    const artifact = await meta.getByShortId(c.req.param("shortId"))
+    if (!artifact || !(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
+    if (!(await authorize(c, "share", artifact))) return fail(c, 403, "forbidden")
+    const host = c.req.param("host").toLowerCase()
+    const existing = await meta.getDomain(host)
+    if (!existing || existing.artifact_id !== artifact.id) return fail(c, 404, "not found")
+    await meta.deleteDomain(host, artifact.org_id)
+    return c.json({ ok: true })
+  })
+
+  return app
+}

--- a/apps/api/src/routes/raw.ts
+++ b/apps/api/src/routes/raw.ts
@@ -1,14 +1,8 @@
-import {
-  ANCHOR_CLIENT_JS,
-  BUNDLE_CONTENT_TYPE,
-  type BundleManifest,
-  mimeFor,
-  renderMarkdown,
-  SELECTION_SCRIPT,
-} from "@dock/core"
-import { type Context, Hono } from "hono"
+import { ANCHOR_CLIENT_JS } from "@dock/core"
+import { Hono } from "hono"
 import type { AppContext } from "../context"
-import { RAW_HEADERS, rewriteAbsoluteUrls, TOMBSTONE, toBody } from "../lib/http"
+import { TOMBSTONE } from "../lib/http"
+import { serveContent } from "../lib/serve-content"
 
 /** The sandbox: raw artifact + proposal bytes under /raw/*. Served with an
  *  opaque-origin CSP; a proposal renders exactly like the live version will. */
@@ -26,64 +20,6 @@ export const rawRoutes = (ctx: AppContext) => {
     }),
   )
 
-  // Serve stored content (a version or a proposal) under `prefix`, resolving a
-  // sub-`path` for bundles. Identical pipeline for both, so a proposal renders
-  // exactly how it will once approved — reviewers approve the experience.
-  const serveContent = async (
-    c: Context,
-    content: { blob_key: string; content_type: string },
-    title: string | null,
-    prefix: string,
-    rawPath: string,
-  ) => {
-    let path = rawPath
-    if (content.content_type === BUNDLE_CONTENT_TYPE) {
-      const manifestBytes = await blobs.get(content.blob_key)
-      if (!manifestBytes) return c.text("blob missing", 500)
-      const manifest = JSON.parse(new TextDecoder().decode(manifestBytes)) as BundleManifest
-
-      if (path === "" || path === "index.html") path = manifest.entry.slice(1)
-      let lookup = `/${path}`
-      if (lookup.endsWith("/")) lookup += "index.html"
-      let entry = manifest.files[lookup]
-      // Pretty URLs (Astro-style dir output), then SPA fallback.
-      if (!entry && !/\.[a-z0-9]+$/i.test(lookup)) entry = manifest.files[`${lookup}/index.html`]
-      if (!entry && manifest.spa) entry = manifest.files[manifest.entry]
-      if (!entry) return c.text("not found", 404, RAW_HEADERS)
-
-      const data = await blobs.get(entry.key)
-      if (!data) return c.text("blob missing", 500)
-      if (entry.type.startsWith("text/html") || entry.type.startsWith("text/css")) {
-        const rewritten = rewriteAbsoluteUrls(new TextDecoder().decode(data), prefix.slice(0, -1))
-        // Bundle pages get the anchor client too — comments stick everywhere.
-        const out = entry.type.startsWith("text/html") ? rewritten + SELECTION_SCRIPT : rewritten
-        return c.body(out, 200, { ...RAW_HEADERS, "Content-Type": entry.type })
-      }
-      return c.body(toBody(data), 200, { ...RAW_HEADERS, "Content-Type": entry.type })
-    }
-
-    const data = await blobs.get(content.blob_key)
-    if (!data) return c.text("blob missing", 500)
-
-    if (content.content_type === "text/markdown") {
-      if (path === "raw.md")
-        return c.body(toBody(data), 200, {
-          ...RAW_HEADERS,
-          "Content-Type": "text/markdown; charset=utf-8",
-        })
-      const html = await renderMarkdown(new TextDecoder().decode(data), title)
-      return c.body(html, 200, { ...RAW_HEADERS, "Content-Type": "text/html; charset=utf-8" })
-    }
-
-    // html file artifact — any path serves the document (+ selection capture)
-    const ct = mimeFor(path || "index.html")
-    if (ct.startsWith("text/html")) {
-      const html = new TextDecoder().decode(data) + SELECTION_SCRIPT
-      return c.body(html, 200, { ...RAW_HEADERS, "Content-Type": ct })
-    }
-    return c.body(toBody(data), 200, { ...RAW_HEADERS, "Content-Type": ct })
-  }
-
   app.get("/raw/:shortId/v/:n/*", async (c) => {
     const shortId = c.req.param("shortId")
     const n = Number(c.req.param("n"))
@@ -96,7 +32,7 @@ export const rawRoutes = (ctx: AppContext) => {
 
     const prefix = `/raw/${shortId}/v/${c.req.param("n")}/`
     const path = decodeURIComponent(c.req.path.slice(prefix.length))
-    return serveContent(c, version, artifact.title, prefix, path)
+    return serveContent(c, blobs, version, artifact.title, prefix, path)
   })
 
   // Render a proposed version exactly like a live one, so review is of the
@@ -111,7 +47,7 @@ export const rawRoutes = (ctx: AppContext) => {
 
     const prefix = `/raw/${shortId}/p/${proposal.id}/`
     const path = decodeURIComponent(c.req.path.slice(prefix.length))
-    return serveContent(c, proposal, artifact.title, prefix, path)
+    return serveContent(c, blobs, proposal, artifact.title, prefix, path)
   })
 
   return app

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -40,6 +40,8 @@ export interface Env {
   BASE_URL?: string
   DOCK_AUTH_SECRET?: string
   DOCK_SUPERADMIN_EMAILS?: string
+  // Base domain for vanity subdomains (domain mode); unset = off.
+  DOCK_SUBDOMAIN_BASE?: string
 }
 
 let app: ReturnType<typeof createApp> | null = null
@@ -74,6 +76,8 @@ export default {
           .map((s) => s.trim().toLowerCase())
           .filter(Boolean),
         defaultOrgId: "default",
+        subdomainBase:
+          env.DOCK_SUBDOMAIN_BASE?.toLowerCase().replace(/^\.+|\.+$/g, "") || undefined,
         // Read the SPA shell from static assets so /a/:ref can carry unfurl meta.
         // Cached per isolate; null on any miss leaves the shell untouched.
         shellFetch: async () => {

--- a/apps/api/test/domains.test.ts
+++ b/apps/api/test/domains.test.ts
@@ -1,0 +1,95 @@
+import { join } from "node:path"
+import { FsBlobStore } from "@dock/storage/fs"
+import { describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { dir, meta, ownerApp } from "./helpers"
+
+const BASE = "dockd.app"
+const blobs = new FsBlobStore(join(dir, "blobs-domains"))
+// Owner (token-authed) sets domains + publishes; anon serves them like the public.
+const owner = ownerApp({ meta, blobs, baseUrl: "http://dock.test", subdomainBase: BASE })
+const anon = createApp({
+  meta,
+  blobs,
+  baseUrl: "http://dock.test",
+  subdomainBase: BASE,
+  token: "tok",
+})
+
+const publish = async (content: string, fields: Record<string, string> = {}): Promise<string> => {
+  const form = new FormData()
+  form.append("file", new Blob([new TextEncoder().encode(content)]), "page.html")
+  for (const [k, v] of Object.entries(fields)) form.append(k, v)
+  const res = await owner.request("/v1/artifacts", { method: "POST", body: form })
+  return (await res.json()).short_id
+}
+const setLabel = (short: string, label: string) =>
+  owner.request(`/v1/artifacts/${short}/domains`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ label }),
+  })
+
+describe("vanity subdomains", () => {
+  it("assigns a subdomain and serves the artifact at its host root", async () => {
+    const short = await publish("<h1>Launch</h1>", { visibility: "public", title: "Launch" })
+    const put = await setLabel(short, "launch")
+    expect(put.status).toBe(201)
+    expect((await put.json()).host).toBe(`launch.${BASE}`)
+
+    const list = await owner.request(`/v1/artifacts/${short}/domains`)
+    expect((await list.json()).domains[0].host).toBe(`launch.${BASE}`)
+
+    // The public, at the vanity host root, gets the artifact bytes (no /raw prefix).
+    const served = await anon.request(`http://launch.${BASE}/`)
+    expect(served.status).toBe(200)
+    expect(served.headers.get("content-type")).toContain("text/html")
+    expect(await served.text()).toContain("Launch")
+  })
+
+  it("409s a label already taken by another artifact", async () => {
+    const a = await publish("<p>a</p>", { visibility: "public" })
+    const b = await publish("<p>b</p>", { visibility: "public" })
+    expect((await setLabel(a, "dup")).status).toBe(201)
+    expect((await setLabel(b, "dup")).status).toBe(409)
+  })
+
+  it("is idempotent for the same artifact, and rejects invalid + reserved labels", async () => {
+    const short = await publish("<p>x</p>", { visibility: "public" })
+    expect((await setLabel(short, "mine")).status).toBe(201)
+    expect((await setLabel(short, "mine")).status).toBe(200) // already yours
+    expect((await setLabel(short, "Bad Label!")).status).toBe(400)
+    expect((await setLabel(short, "www")).status).toBe(400) // reserved
+  })
+
+  it("never serves a gated artifact to the anonymous public", async () => {
+    const short = await publish("<p>secret</p>", { visibility: "org", title: "Secret" })
+    expect((await setLabel(short, "private")).status).toBe(201)
+    expect((await anon.request(`http://private.${BASE}/`)).status).toBe(404)
+  })
+
+  it("404s an unknown subdomain", async () => {
+    expect((await anon.request(`http://nope.${BASE}/`)).status).toBe(404)
+  })
+
+  it("releases a subdomain", async () => {
+    const short = await publish("<p>x</p>", { visibility: "public" })
+    await setLabel(short, "temp")
+    const del = await owner.request(`/v1/artifacts/${short}/domains/temp.${BASE}`, {
+      method: "DELETE",
+    })
+    expect(del.status).toBe(200)
+    expect((await anon.request(`http://temp.${BASE}/`)).status).toBe(404)
+  })
+
+  it("501s when the server has no base domain configured", async () => {
+    const noBase = ownerApp({ meta, blobs, baseUrl: "http://dock.test" })
+    const short = await publish("<p>x</p>", { visibility: "public" })
+    const res = await noBase.request(`/v1/artifacts/${short}/domains`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ label: "x" }),
+    })
+    expect(res.status).toBe(501)
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -88,6 +88,13 @@ export interface ArtifactMember {
   name: string | null
   role: Role
 }
+/** A vanity host serving an artifact (domain mode). */
+export interface ArtifactDomain {
+  host: string
+  url: string
+  kind: string
+  created_at: string
+}
 /** The workspace: its name, the caller's role, and the member directory. */
 export interface Workspace {
   id: string
@@ -330,6 +337,17 @@ export const api = {
     f(`/v1/artifacts/${id}/members`, { ...opts({ email, role }), method: "PUT" }).then(j),
   removeMember: (id: string, userId: string): Promise<void> =>
     f(`/v1/artifacts/${id}/members/${userId}`, { method: "DELETE", credentials: "include" }).then(
+      () => undefined,
+    ),
+
+  // Vanity subdomains (domain mode). `base` is null when the server has none set,
+  // in which case the Share dialog hides the section.
+  listDomains: (id: string): Promise<{ base: string | null; domains: ArtifactDomain[] }> =>
+    f(`/v1/artifacts/${id}/domains`, opts()).then(j),
+  setDomain: (id: string, label: string): Promise<ArtifactDomain> =>
+    f(`/v1/artifacts/${id}/domains`, { ...opts({ label }), method: "PUT" }).then(j),
+  removeDomain: (id: string, host: string): Promise<void> =>
+    f(`/v1/artifacts/${id}/domains/${host}`, { method: "DELETE", credentials: "include" }).then(
       () => undefined,
     ),
   heartbeat: (id: string, name: string): Promise<{ viewers: string[] }> =>

--- a/apps/web/src/components/ShareDialog.tsx
+++ b/apps/web/src/components/ShareDialog.tsx
@@ -2,7 +2,7 @@ import { useQueryClient } from "@tanstack/react-query"
 import { Lock, Share2, X } from "lucide-react"
 import { useState } from "react"
 import { toast } from "sonner"
-import { API_BASE, type ArtifactMember, api, type Role } from "@/api"
+import { API_BASE, type ArtifactDomain, type ArtifactMember, api, type Role } from "@/api"
 import { EmptyState } from "@/components/shared/empty-state"
 import { RoleSelect } from "@/components/shared/role-select"
 import { Button } from "@/components/ui/button"
@@ -71,6 +71,13 @@ export function ShareButton({
   const [savingVis, setSavingVis] = useState(false)
 
   const [copied, setCopied] = useState(false)
+
+  // Domain mode (vanity subdomains). `domainBase` is null when the server has no
+  // base configured, which hides the whole section.
+  const [domains, setDomains] = useState<ArtifactDomain[]>([])
+  const [domainBase, setDomainBase] = useState<string | null>(null)
+  const [label, setLabel] = useState("")
+  const [claiming, setClaiming] = useState(false)
 
   // GDocs model: owners and editors manage access; everyone else gets view-only.
   const canManage = myRole === "owner" || myRole === "editor"
@@ -153,6 +160,43 @@ export function ShareButton({
     await synced()
   }
 
+  const loadDomains = () =>
+    api
+      .listDomains(shortId)
+      .then((r) => {
+        setDomains(r.domains)
+        setDomainBase(r.base)
+      })
+      .catch(() => {})
+  const claimDomain = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const l = label.trim().toLowerCase()
+    if (!l) return
+    setClaiming(true)
+    try {
+      await api.setDomain(shortId, l)
+      setLabel("")
+      await loadDomains()
+      toast.success("Custom URL claimed")
+    } catch (x) {
+      toast.error(x instanceof Error ? x.message : "Couldn't claim that URL")
+    } finally {
+      setClaiming(false)
+    }
+  }
+  const dropDomain = async (host: string) => {
+    await api.removeDomain(shortId, host).catch(() => {})
+    await loadDomains()
+  }
+  const copyUrl = async (url: string) => {
+    try {
+      await navigator.clipboard.writeText(url)
+      toast.success("URL copied")
+    } catch {
+      toast.error("Couldn't copy to clipboard")
+    }
+  }
+
   return (
     <Dialog
       onOpenChange={(o) => {
@@ -161,6 +205,7 @@ export function ShareButton({
           setVis(visibility)
           setPw("")
           load()
+          loadDomains()
         }
       }}
     >
@@ -368,6 +413,79 @@ export function ShareButton({
               : "Set access to “Anyone with the link” or “Public” for the embed to load for others."}
           </p>
         </div>
+
+        {/* Custom URL — a vanity subdomain that serves the artifact at its own
+            origin. Only shown when the server has a base domain configured. */}
+        {domainBase && (
+          <div className="mt-4 border-t border-border pt-3.5">
+            <div className="mb-1.5 font-mono text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Custom URL
+            </div>
+            {domains.length > 0 ? (
+              <div className="flex flex-col gap-1.5">
+                {domains.map((d) => (
+                  <div key={d.host} className="flex items-center gap-1.5">
+                    <Input
+                      readOnly
+                      data-testid="share-domain-url"
+                      aria-label="Custom URL"
+                      value={d.url}
+                      onFocus={(e) => e.currentTarget.select()}
+                      className="flex-1 font-mono text-2xs"
+                    />
+                    <Button
+                      variant="outline"
+                      data-testid="share-domain-copy"
+                      onClick={() => copyUrl(d.url)}
+                    >
+                      Copy
+                    </Button>
+                    {canManage && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        data-testid="share-domain-remove"
+                        className="size-7 text-muted-foreground hover:text-foreground"
+                        onClick={() => dropDomain(d.host)}
+                        aria-label="Remove custom URL"
+                      >
+                        <X />
+                      </Button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ) : canManage ? (
+              <form onSubmit={claimDomain} className="flex items-center gap-1.5">
+                <Input
+                  data-testid="share-domain-label"
+                  aria-label="Subdomain label"
+                  placeholder="my-page"
+                  value={label}
+                  onChange={(e) => setLabel(e.target.value)}
+                  className="flex-1"
+                />
+                <span className="whitespace-nowrap font-mono text-2xs text-muted-foreground">
+                  .{domainBase}
+                </span>
+                <Button
+                  data-testid="share-domain-claim"
+                  variant="primary"
+                  type="submit"
+                  disabled={claiming || !label.trim()}
+                >
+                  {claiming ? "…" : "Claim"}
+                </Button>
+              </form>
+            ) : (
+              <p className="text-xs text-muted-foreground">No custom URL.</p>
+            )}
+            <p className="mt-1.5 font-mono text-2xs text-muted-foreground">
+              A clean URL on {domainBase}, served at its own origin. Works for link- or
+              world-readable artifacts.
+            </p>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -220,6 +220,16 @@ CREATE TABLE IF NOT EXISTS collection_member (
 
 CREATE INDEX IF NOT EXISTS collection_member_user ON collection_member (user_id);
 
+CREATE TABLE IF NOT EXISTS domain (
+    host TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    org_id TEXT NOT NULL,
+    kind TEXT NOT NULL DEFAULT 'subdomain',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  );
+
+CREATE INDEX IF NOT EXISTS domain_artifact ON domain (artifact_id);
+
 CREATE TABLE IF NOT EXISTS proposal (
     id TEXT PRIMARY KEY,
     artifact_id TEXT NOT NULL REFERENCES artifact(id),

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -15,6 +15,9 @@ export type ArtifactKind = "file" | "bundle"
 // the visitor enters the password (then a viewer; members/owners see it by role).
 export type Visibility = "public" | "link" | "org" | "password"
 
+/** A platform subdomain (`name.dockd.app`) or a customer's own domain. */
+export type DomainKind = "subdomain" | "custom"
+
 export interface ArtifactRecord {
   id: string
   short_id: string
@@ -96,6 +99,8 @@ export interface MetaStore {
     passwordHash: string | null,
   ): Promise<void>
   getByShortId(shortId: string): Promise<ArtifactRecord | null>
+  /** Load an artifact by its internal id (used by domain mode's host lookup). */
+  getArtifactById(id: string): Promise<ArtifactRecord | null>
   /** Appends the next version and bumps current_version. */
   addVersion(artifactId: string, v: NewVersion): Promise<VersionRecord>
   listVersions(artifactId: string): Promise<VersionRecord[]>
@@ -229,6 +234,16 @@ export interface MetaStore {
   /** This user's collection-member roles over collections containing the
    *  artifact — folded into their effective artifact role (collection sharing). */
   collectionRolesForArtifact(artifactId: string, userId: string): Promise<Role[]>
+
+  // ---- Domain mode: a hostname serving an artifact at its own origin ------
+  /** The artifact a hostname serves, or null. The hot path for host dispatch. */
+  getDomain(host: string): Promise<DomainRecord | null>
+  /** Claim a hostname for an artifact. Returns null if the host is already taken. */
+  setDomain(d: NewDomain): Promise<DomainRecord | null>
+  /** Hostnames pointing at an artifact (for the share UI). */
+  getArtifactDomains(artifactId: string): Promise<DomainRecord[]>
+  /** Release a hostname, scoped to its owning workspace. */
+  deleteDomain(host: string, orgId: string): Promise<void>
 
   // ---- Reviews: proposed versions awaiting approval ----------------------
   createProposal(p: NewProposal): Promise<ProposalRecord>
@@ -502,6 +517,19 @@ export interface NewCollection {
   org_id: string
   title: string
   created_by: string
+}
+export interface DomainRecord {
+  host: string
+  artifact_id: string
+  org_id: string
+  kind: DomainKind
+  created_at: string
+}
+export interface NewDomain {
+  host: string
+  artifact_id: string
+  org_id: string
+  kind: DomainKind
 }
 export interface CollectionMemberRecord {
   id: string

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -22,6 +22,7 @@ import type {
   CollectionRecord,
   CommentRecord,
   DeliveryRecord,
+  DomainRecord,
   MembershipRecord,
   NotificationRecord,
   ProposalRecord,
@@ -50,6 +51,7 @@ export interface TypedTables {
   agentMention: AgentMentionRecord
   collection: CollectionRecord
   collectionMember: CollectionMemberRecord
+  domain: DomainRecord
   report: ReportRecord
   auditLog: AuditLogRecord
 }

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -4,6 +4,7 @@ import type {
   AuditAction,
   CommentState,
   DeliveryStatus,
+  DomainKind,
   NotificationKind,
   ProposalState,
   ReportState,
@@ -229,6 +230,15 @@ export const collectionMember = pgTable(
   },
   (t) => [uniqueIndex("collection_member_uniq").on(t.collection_id, t.user_id)],
 )
+export const domain = pgTable("domain", {
+  host: text("host").primaryKey(),
+  artifact_id: text("artifact_id")
+    .notNull()
+    .references(() => artifact.id),
+  org_id: text("org_id").notNull(),
+  kind: text("kind").$type<DomainKind>().notNull().default("subdomain"),
+  created_at: text("created_at").notNull().$defaultFn(isoNow),
+})
 export const proposal = pgTable("proposal", {
   id: text("id").primaryKey(),
   artifact_id: text("artifact_id")
@@ -476,6 +486,14 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
     UNIQUE (collection_id, user_id)
   )`,
   `CREATE INDEX IF NOT EXISTS collection_member_user ON collection_member (user_id)`,
+  `CREATE TABLE IF NOT EXISTS domain (
+    host TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    org_id TEXT NOT NULL,
+    kind TEXT NOT NULL DEFAULT 'subdomain',
+    created_at TEXT NOT NULL DEFAULT ${isoDefault}
+  )`,
+  `CREATE INDEX IF NOT EXISTS domain_artifact ON domain (artifact_id)`,
   `CREATE TABLE IF NOT EXISTS proposal (
     id TEXT PRIMARY KEY,
     artifact_id TEXT NOT NULL REFERENCES artifact(id),

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -10,6 +10,7 @@ import type {
   CommentState,
   DeliveryRecord,
   DeliveryStatus,
+  DomainRecord,
   ListArtifactsOpts,
   MembershipRecord,
   MetaStore,
@@ -22,6 +23,7 @@ import type {
   NewCollectionMember,
   NewComment,
   NewDelivery,
+  NewDomain,
   NewMembership,
   NewNotification,
   NewProposal,
@@ -58,6 +60,7 @@ import {
   collectionItem,
   collectionMember,
   comment,
+  domain,
   membership,
   notification,
   PG_SCHEMA_STATEMENTS,
@@ -93,6 +96,7 @@ const schema = {
   collection,
   collectionItem,
   collectionMember,
+  domain,
   report,
   auditLog,
 }
@@ -116,6 +120,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   agentMention: true,
   collection: true,
   collectionMember: true,
+  domain: true,
   report: true,
   auditLog: true,
 }
@@ -162,6 +167,10 @@ export class PgMetaStore implements MetaStore {
 
   async getByShortId(shortId: string): Promise<ArtifactRecord | null> {
     const rows = await this.db.select().from(artifact).where(eq(artifact.short_id, shortId))
+    return rows[0] ?? null
+  }
+  async getArtifactById(id: string): Promise<ArtifactRecord | null> {
+    const rows = await this.db.select().from(artifact).where(eq(artifact.id, id))
     return rows[0] ?? null
   }
 
@@ -688,6 +697,24 @@ export class PgMetaStore implements MetaStore {
       .innerJoin(collectionItem, eq(collectionItem.collection_id, collectionMember.collection_id))
       .where(and(eq(collectionItem.artifact_id, artifactId), eq(collectionMember.user_id, userId)))
     return rows.map((r) => r.role)
+  }
+
+  // ---- Domains (hostname → artifact) -------------------------------------
+  async getDomain(host: string): Promise<DomainRecord | null> {
+    const rows = await this.db.select().from(domain).where(eq(domain.host, host))
+    return rows[0] ?? null
+  }
+  // Insert-only: a taken host yields no row (→ 409 in the route), so a workspace
+  // can never claim a host already owned by another.
+  async setDomain(d: NewDomain): Promise<DomainRecord | null> {
+    const rows = await this.db.insert(domain).values(d).onConflictDoNothing().returning()
+    return rows[0] ?? null
+  }
+  async getArtifactDomains(artifactId: string): Promise<DomainRecord[]> {
+    return this.db.select().from(domain).where(eq(domain.artifact_id, artifactId))
+  }
+  async deleteDomain(host: string, orgId: string): Promise<void> {
+    await this.db.delete(domain).where(and(eq(domain.host, host), eq(domain.org_id, orgId)))
   }
 
   // ---- Reviews: proposed versions ----------------------------------------

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -10,6 +10,7 @@ import type {
   CommentState,
   DeliveryRecord,
   DeliveryStatus,
+  DomainRecord,
   ListArtifactsOpts,
   MembershipRecord,
   NewAgent,
@@ -21,6 +22,7 @@ import type {
   NewCollectionMember,
   NewComment,
   NewDelivery,
+  NewDomain,
   NewMembership,
   NewNotification,
   NewProposal,
@@ -53,6 +55,7 @@ import {
   collectionItem,
   collectionMember,
   comment,
+  domain,
   membership,
   notification,
   proposal,
@@ -82,6 +85,7 @@ export const schema = {
   collection,
   collectionItem,
   collectionMember,
+  domain,
   report,
   auditLog,
 }
@@ -105,6 +109,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   agentMention: true,
   collection: true,
   collectionMember: true,
+  domain: true,
   report: true,
   auditLog: true,
 }
@@ -135,6 +140,8 @@ export function makeRepos(db: SqliteDb) {
   // ---- Artifacts + versions ----------------------------------------------
   const getByShortId = async (shortId: string): Promise<ArtifactRecord | null> =>
     (await db.select().from(artifact).where(eq(artifact.short_id, shortId)).get()) ?? null
+  const getArtifactById = async (id: string): Promise<ArtifactRecord | null> =>
+    (await db.select().from(artifact).where(eq(artifact.id, id)).get()) ?? null
 
   const createArtifact = async (a: NewArtifact): Promise<ArtifactRecord> => {
     await db.insert(artifact).values(a).run()
@@ -609,6 +616,24 @@ export function makeRepos(db: SqliteDb) {
         .all()
     ).map((r) => r.role)
 
+  // ---- Domains (hostname → artifact) -------------------------------------
+  const getDomain = async (host: string): Promise<DomainRecord | null> =>
+    (await db.select().from(domain).where(eq(domain.host, host)).get()) ?? null
+  // Insert-only: a taken host yields no row (the route turns that into a 409),
+  // so one workspace can never claim a host already owned by another.
+  const setDomain = async (d: NewDomain): Promise<DomainRecord | null> =>
+    ((await db.insert(domain).values(d).onConflictDoNothing().returning().get()) as
+      | DomainRecord
+      | undefined) ?? null
+  const getArtifactDomains = async (artifactId: string): Promise<DomainRecord[]> =>
+    db.select().from(domain).where(eq(domain.artifact_id, artifactId)).all()
+  const deleteDomain = async (host: string, orgId: string): Promise<void> => {
+    await db
+      .delete(domain)
+      .where(and(eq(domain.host, host), eq(domain.org_id, orgId)))
+      .run()
+  }
+
   // ---- Reviews: proposals ------------------------------------------------
   const createProposal = async (p: NewProposal): Promise<ProposalRecord> =>
     (await db.insert(proposal).values(p).returning().get()) as ProposalRecord
@@ -770,6 +795,7 @@ export function makeRepos(db: SqliteDb) {
     createArtifact,
     setVisibility,
     getByShortId,
+    getArtifactById,
     addVersion,
     listVersions,
     getVersion,
@@ -825,6 +851,10 @@ export function makeRepos(db: SqliteDb) {
     setCollectionMember,
     removeCollectionMember,
     collectionRolesForArtifact,
+    getDomain,
+    setDomain,
+    getArtifactDomains,
+    deleteDomain,
     createProposal,
     getProposal,
     listProposals,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -4,6 +4,7 @@ import type {
   AuditAction,
   CommentState,
   DeliveryStatus,
+  DomainKind,
   NotificationKind,
   ProposalState,
   ReportState,
@@ -241,6 +242,19 @@ export const collectionMember = sqliteTable(
   },
   (t) => [uniqueIndex("collection_member_uniq").on(t.collection_id, t.user_id)],
 )
+
+// Domain mode: a hostname that serves an artifact at the root of its own origin.
+// `host` is globally unique (one host → one artifact); `kind` separates a platform
+// subdomain (name.dockd.app) from a customer's own domain.
+export const domain = sqliteTable("domain", {
+  host: text("host").primaryKey(),
+  artifact_id: text("artifact_id")
+    .notNull()
+    .references(() => artifact.id),
+  org_id: text("org_id").notNull(),
+  kind: text("kind").$type<DomainKind>().notNull().default("subdomain"),
+  created_at: text("created_at").notNull().default(now),
+})
 
 export const proposal = sqliteTable("proposal", {
   id: text("id").primaryKey(),
@@ -488,6 +502,14 @@ export const SCHEMA_STATEMENTS: string[] = [
     UNIQUE (collection_id, user_id)
   )`,
   `CREATE INDEX IF NOT EXISTS collection_member_user ON collection_member (user_id)`,
+  `CREATE TABLE IF NOT EXISTS domain (
+    host TEXT PRIMARY KEY,
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    org_id TEXT NOT NULL,
+    kind TEXT NOT NULL DEFAULT 'subdomain',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  )`,
+  `CREATE INDEX IF NOT EXISTS domain_artifact ON domain (artifact_id)`,
   `CREATE TABLE IF NOT EXISTS proposal (
     id TEXT PRIMARY KEY,
     artifact_id TEXT NOT NULL REFERENCES artifact(id),


### PR DESCRIPTION
The subdomain tier of domain mode (C1). An artifact assigned `name.<base>` is served at that host's **root** — its own origin, a clean URL, the absolute-URL rewriting a no-op. Builds directly on the A4 host-dispatch already in `app.ts`. Plan: https://dock-ddu.pages.dev/domains

## What's here
- **Data:** a `domain` table (`host` PK → `artifact_id`) across sqlite/pg/d1 — drizzle defs + DDL + parity classification + regenerated `d1-schema.sql`; new `getDomain`/`setDomain`/`getArtifactDomains`/`deleteDomain` + `getArtifactById`.
- **Dispatch:** host-header middleware beside the A4 sandbox guard that serves a known vanity host's artifact via a shared `serveContent` (extracted to `lib/serve-content.ts`, reused by `/raw/*`). Visibility is honored against the request actor, so a vanity host (cross-origin = anonymous) serves only public/link artifacts; gated → 404, removed → 410. `/raw/*` + `/healthz` pass through so the anchor client still loads.
- **API:** `PUT/GET/DELETE /v1/artifacts/:shortId/domains`, gated on `share`, with label validation + a reserved-label denylist, 409 on a taken host, 501 when no base is set.
- **Web:** a "Custom URL" section in the Share dialog (shown only when a base is configured) to claim/copy/remove a subdomain.
- **Config:** `DOCK_SUBDOMAIN_BASE` wired through node + worker + `.env.example`.

## Verification
- 7 new api tests (assign/list/serve/release, 409, idempotent, reserved, gated, unknown, 501). Full suite **271 green**; `pnpm run ci` clean; typecheck across node + worker + web.
- **Live + browser e2e:** claimed a subdomain in the Share dialog, then loaded `launch.lvh.me` in a real browser — the artifact renders at its own origin root. Org + unknown hosts 404; `dock-client.js` resolves on the vanity host.

## To enable on the hosted edge
Add a wildcard Worker Custom Domain (`*.dockd.app`) and set `DOCK_SUBDOMAIN_BASE`. Bring-your-own custom domains (Cloudflare for SaaS) are the next tier.

## Follow-ups (noted, out of scope)
Host→artifact lookup cache; BYO custom domains via Custom Hostnames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)