### PR TITLE
feat(api): production lifecycle — graceful shutdown, crash safety, readiness, fail-fast config

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -105,6 +105,23 @@ export function createApp(deps: AppDeps): Hono {
 
   app.get("/healthz", (c) => c.json({ ok: true }))
 
+  // Readiness (vs /healthz liveness): proves the datastore + blob store are
+  // actually reachable, so an orchestrator stops routing to an instance whose DB
+  // or blob backend is down instead of letting it 500 every request. 503 on any
+  // failure. Point the platform healthcheck here for rollout/traffic gating.
+  app.get("/readyz", async (c) => {
+    try {
+      await deps.meta.getWorkspace(deps.defaultOrgId ?? "default")
+      await deps.blobs.get("__readyz_probe__")
+      return c.json({ ok: true })
+    } catch (err) {
+      log.error("readiness check failed", {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return c.json({ ok: false }, 503)
+    }
+  })
+
   // A minimal API-origin landing. Skipped when the SPA is bundled in-process
   // (serveWeb) so the app's own home page owns `/`.
   if (!deps.serveWeb)

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -3,10 +3,36 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs"
 import { join, resolve } from "node:path"
 import { log } from "./log"
 
-/** Parse a positive integer env var; undefined (unset/blank/≤0/NaN) = "no limit". */
-const posInt = (v: string | undefined): number | undefined => {
-  const n = v ? Number(v) : NaN
-  return Number.isFinite(n) && n > 0 ? Math.floor(n) : undefined
+/** Parse a positive-integer env var; unset/blank = "no limit". A set-but-invalid
+ *  value is a likely typo, so warn loudly rather than silently ignore it. */
+const posInt = (name: string, v: string | undefined): number | undefined => {
+  if (v === undefined || v === "") return undefined
+  const n = Number(v)
+  if (!Number.isFinite(n) || n <= 0) {
+    log.warn(`ignoring invalid ${name}=${v} (expected a positive integer)`)
+    return undefined
+  }
+  return Math.floor(n)
+}
+
+/** A required-with-default numeric env var; a malformed value fails fast at boot. */
+const numOr = (name: string, v: string | undefined, def: number): number => {
+  if (v === undefined || v === "") return def
+  const n = Number(v)
+  if (!Number.isFinite(n)) throw new Error(`invalid ${name}: ${v} (expected a number)`)
+  return n
+}
+
+/** Validate that an optional env var parses as a URL; a typo fails fast at boot
+ *  rather than lazily on the first request that touches the DB / blob store. */
+const urlOr = (name: string, v: string | undefined): string | undefined => {
+  if (!v) return undefined
+  try {
+    new URL(v)
+  } catch {
+    throw new Error(`invalid ${name}: ${v} (expected a URL)`)
+  }
+  return v
 }
 
 /** The fully-resolved, validated runtime configuration. Read once at boot from
@@ -83,7 +109,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     port,
     dataDir,
     baseUrl,
-    databaseUrl: env.DATABASE_URL,
+    databaseUrl: urlOr("DATABASE_URL", env.DATABASE_URL),
     token: env.DOCK_TOKEN,
     // Comma-separated operator emails (case-insensitive). More than one person
     // can run + host a deployment, so this is a list, not a single owner.
@@ -95,14 +121,16 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     rateLimit: env.DOCK_RATE_LIMIT !== "false",
     sandboxOrigin: env.DOCK_SANDBOX_URL,
     crossSite: env.DOCK_CROSS_SITE === "true",
-    versionWindowMs: env.DOCK_VERSION_WINDOW ? Number(env.DOCK_VERSION_WINDOW) * 60_000 : undefined,
-    maxArtifacts: posInt(env.DOCK_MAX_ARTIFACTS),
-    maxBytes: posInt(env.DOCK_MAX_BYTES),
-    publishRate: posInt(env.DOCK_PUBLISH_RATE),
-    commentRate: posInt(env.DOCK_COMMENT_RATE),
+    versionWindowMs: env.DOCK_VERSION_WINDOW
+      ? numOr("DOCK_VERSION_WINDOW", env.DOCK_VERSION_WINDOW, 0) * 60_000
+      : undefined,
+    maxArtifacts: posInt("DOCK_MAX_ARTIFACTS", env.DOCK_MAX_ARTIFACTS),
+    maxBytes: posInt("DOCK_MAX_BYTES", env.DOCK_MAX_BYTES),
+    publishRate: posInt("DOCK_PUBLISH_RATE", env.DOCK_PUBLISH_RATE),
+    commentRate: posInt("DOCK_COMMENT_RATE", env.DOCK_COMMENT_RATE),
     webOrigins,
-    retentionDays: Number(env.DOCK_ANALYTICS_RETENTION_DAYS ?? 365),
-    objectStoreUrl: env.OBJECT_STORE_URL,
+    retentionDays: numOr("DOCK_ANALYTICS_RETENTION_DAYS", env.DOCK_ANALYTICS_RETENTION_DAYS, 365),
+    objectStoreUrl: urlOr("OBJECT_STORE_URL", env.OBJECT_STORE_URL),
     webDir,
     webShell,
     serveWeb: existsSync(webShell),

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -22,17 +22,37 @@ mkdirSync(join(cfg.dataDir, "blobs"), { recursive: true })
 // stateless multi-instance topology), else embedded SQLite (zero-config).
 let meta: MetaStore
 let authDb: AuthDb
+// Closes the metadata store + the Better Auth datastore (separate handles onto
+// the same backend) for graceful shutdown.
+let closeStores: () => Promise<void>
 if (cfg.databaseUrl) {
-  meta = await PgMetaStore.create(cfg.databaseUrl)
-  authDb = new Pool({ connectionString: cfg.databaseUrl })
+  // A pool 'error' (DB restart / network blip / Neon scale-to-zero) without a
+  // listener becomes an unhandled exception that crashes the process — log it.
+  const pgMeta = await PgMetaStore.create(cfg.databaseUrl, (e) =>
+    log.error("pg meta pool error", { error: e.message }),
+  )
+  const pool = new Pool({ connectionString: cfg.databaseUrl })
+  pool.on("error", (e) => log.error("pg auth pool error", { error: e.message }))
+  meta = pgMeta
+  authDb = pool
+  closeStores = async () => {
+    await pgMeta.close()
+    await pool.end()
+  }
 } else {
-  meta = new SqliteMetaStore(join(cfg.dataDir, "dock.db"))
-  authDb = new Database(join(cfg.dataDir, "dock.db"))
+  const db = new Database(join(cfg.dataDir, "dock.db"))
   // Better Auth opens its own connection to the same dock.db. Match the store's
   // WAL + busy_timeout so concurrent auth writes (e.g. bursts of signups) wait
   // for the lock instead of failing with SQLITE_BUSY.
-  authDb.pragma("journal_mode = WAL")
-  authDb.pragma("busy_timeout = 5000")
+  db.pragma("journal_mode = WAL")
+  db.pragma("busy_timeout = 5000")
+  const sqliteMeta = new SqliteMetaStore(join(cfg.dataDir, "dock.db"))
+  meta = sqliteMeta
+  authDb = db
+  closeStores = async () => {
+    sqliteMeta.close()
+    db.close()
+  }
 }
 
 const auth = makeAuth(authDb, cfg.baseUrl, resolveAuthSecret(cfg.dataDir))
@@ -107,17 +127,19 @@ if (cfg.serveWeb && shellHtml !== undefined)
   })
 
 // The webhook outbox worker delivers queued events with retries + backoff.
-startWebhookWorker(meta)
+const stopWorker = startWebhookWorker(meta)
 
 // Analytics retention: views are a rolling window (default 365 days). A daily
 // prune keeps the append-only view table bounded. 0 disables pruning entirely.
+let pruneTimer: ReturnType<typeof setInterval> | undefined
 if (cfg.retentionDays > 0) {
   const prune = () =>
     meta
       .pruneViews(new Date(Date.now() - cfg.retentionDays * 86400_000).toISOString())
       .catch(() => 0)
   void prune()
-  setInterval(prune, 24 * 3600_000).unref?.()
+  pruneTimer = setInterval(prune, 24 * 3600_000)
+  pruneTimer.unref?.()
 }
 
 // One-time cleanup of pre-existing owner self-views (the route no longer records
@@ -150,7 +172,7 @@ if (!cfg.sandboxOrigin && (cfg.crossSite || cfg.webOrigins.length)) {
   )
 }
 
-serve({ fetch: app.fetch, port: cfg.port }, () => {
+const server = serve({ fetch: app.fetch, port: cfg.port }, () => {
   log.info("dock api listening", {
     port: cfg.port,
     base_url: cfg.baseUrl,
@@ -159,4 +181,44 @@ serve({ fetch: app.fetch, port: cfg.port }, () => {
     web: cfg.serveWeb ? "bundled SPA" : "API only",
     spaces: `multi-workspace (bootstrap org ${defaultOrg})`,
   })
+})
+
+// Graceful shutdown: Fly's auto-stop and every redeploy send SIGTERM. Stop the
+// worker + timers, stop accepting connections and drain in-flight requests, close
+// the datastores, then exit — instead of Node's default of dropping everything.
+let shuttingDown = false
+const shutdown = async (signal: string) => {
+  if (shuttingDown) return
+  shuttingDown = true
+  log.info("shutting down", { signal })
+  // Hard deadline so a hung drain can't wedge the orchestrator forever.
+  setTimeout(() => {
+    log.error("shutdown timed out; forcing exit")
+    process.exit(1)
+  }, 10_000).unref()
+  stopWorker()
+  if (pruneTimer) clearInterval(pruneTimer)
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+  try {
+    await closeStores()
+  } catch (e) {
+    log.error("error closing datastores", { error: e instanceof Error ? e.message : String(e) })
+  }
+  log.info("shutdown complete")
+  process.exit(0)
+}
+process.on("SIGTERM", () => void shutdown("SIGTERM"))
+process.on("SIGINT", () => void shutdown("SIGINT"))
+
+// Last-resort crash safety: a stray rejection shouldn't vanish silently, and a
+// truly uncaught exception should exit cleanly so the orchestrator restarts a
+// fresh process rather than leaving a half-dead one serving 500s.
+process.on("unhandledRejection", (reason) => {
+  log.error("unhandledRejection", {
+    error: reason instanceof Error ? reason.message : String(reason),
+  })
+})
+process.on("uncaughtException", (err) => {
+  log.error("uncaughtException", { error: err.message, stack: err.stack })
+  process.exit(1)
 })

--- a/apps/api/test/config.test.ts
+++ b/apps/api/test/config.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { loadConfig } from "../src/config"
+
+// loadConfig should fail fast at boot on a malformed value rather than coercing it
+// to a silent default (or failing lazily on the first request that touches it).
+describe("config: fail-fast env validation", () => {
+  const base = { PORT: "8080", BASE_URL: "http://dock.test" }
+
+  it("accepts a clean environment", () => {
+    expect(loadConfig({ ...base }).port).toBe(8080)
+  })
+
+  it("rejects a non-numeric PORT", () => {
+    expect(() => loadConfig({ ...base, PORT: "nope" })).toThrow(/PORT/)
+  })
+
+  it("rejects a malformed BASE_URL", () => {
+    expect(() => loadConfig({ ...base, BASE_URL: "not a url" })).toThrow(/BASE_URL/)
+  })
+
+  it("rejects a malformed DATABASE_URL instead of failing at first query", () => {
+    expect(() => loadConfig({ ...base, DATABASE_URL: "not a url" })).toThrow(/DATABASE_URL/)
+  })
+
+  it("rejects a malformed OBJECT_STORE_URL", () => {
+    expect(() => loadConfig({ ...base, OBJECT_STORE_URL: "::::" })).toThrow(/OBJECT_STORE_URL/)
+  })
+
+  it("rejects a non-numeric retention window", () => {
+    expect(() => loadConfig({ ...base, DOCK_ANALYTICS_RETENTION_DAYS: "abc" })).toThrow(/RETENTION/)
+  })
+
+  it("ignores an invalid quota knob (no-limit) without throwing", () => {
+    // A typo'd cap is "no limit", warned not fatal — it shouldn't take the app down.
+    expect(loadConfig({ ...base, DOCK_MAX_ARTIFACTS: "lots" }).maxArtifacts).toBeUndefined()
+  })
+})

--- a/apps/api/test/readyz.test.ts
+++ b/apps/api/test/readyz.test.ts
@@ -1,0 +1,32 @@
+import { join } from "node:path"
+import { FsBlobStore } from "@dock/storage/fs"
+import { describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { dir, meta } from "./helpers"
+
+// /healthz is liveness (process up); /readyz is readiness (the DB + blob backend
+// are actually reachable), so an orchestrator can gate traffic on dependencies.
+describe("health + readiness endpoints", () => {
+  const blobs = new FsBlobStore(join(dir, "blobs"))
+
+  it("/healthz is a pure liveness check (200, no dependency probe)", async () => {
+    const app = createApp({ meta, blobs, baseUrl: "http://dock.test" })
+    expect((await app.request("/healthz")).status).toBe(200)
+  })
+
+  it("/readyz returns 200 when the datastore + blob store are reachable", async () => {
+    const app = createApp({ meta, blobs, baseUrl: "http://dock.test" })
+    const r = await app.request("/readyz")
+    expect(r.status).toBe(200)
+    expect(await r.json()).toEqual({ ok: true })
+  })
+
+  it("/readyz returns 503 when the datastore is unreachable", async () => {
+    const broken = new Proxy(meta, {
+      get: (t, p) =>
+        p === "getWorkspace" ? () => Promise.reject(new Error("db down")) : Reflect.get(t, p),
+    })
+    const app = createApp({ meta: broken, blobs, baseUrl: "http://dock.test" })
+    expect((await app.request("/readyz")).status).toBe(503)
+  })
+})

--- a/deploy/fly.toml
+++ b/deploy/fly.toml
@@ -21,7 +21,9 @@ primary_region = "iad"
 
   [[http_service.checks]]
     method = "GET"
-    path = "/healthz"
+    # Readiness, not liveness: also verifies the DB + blob backend are reachable,
+    # so traffic isn't routed to an instance whose backend is down.
+    path = "/readyz"
     interval = "15s"
     timeout = "2s"
 

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -137,9 +137,22 @@ export class PgMetaStore implements MetaStore {
     private db: NodePgDatabase<typeof schema>,
   ) {}
 
-  /** Connect and apply the schema (idempotent) before first use. */
-  static async create(connectionString: string): Promise<PgMetaStore> {
-    const pool = new Pool({ connectionString })
+  /** Connect and apply the schema (idempotent) before first use. `onError` is
+   *  invoked for idle-pool errors: a DB restart / network blip emits an `'error'`
+   *  on the pool, and without a listener node-postgres turns it into an unhandled
+   *  exception that crashes the whole process. */
+  static async create(
+    connectionString: string,
+    onError?: (err: Error) => void,
+  ): Promise<PgMetaStore> {
+    const pool = new Pool({
+      connectionString,
+      // Bound how long a query / connection acquisition can hang, so a stuck query
+      // can't pin a connection indefinitely and exhaust the pool.
+      statement_timeout: 30_000,
+      connectionTimeoutMillis: 10_000,
+    })
+    pool.on("error", (err) => onError?.(err))
     for (const stmt of PG_SCHEMA_STATEMENTS) await pool.query(stmt)
     return new PgMetaStore(pool, drizzle(pool, { schema }))
   }

--- a/railway.json
+++ b/railway.json
@@ -6,7 +6,7 @@
   },
   "deploy": {
     "startCommand": "pnpm --filter @dock/api start",
-    "healthcheckPath": "/healthz",
+    "healthcheckPath": "/readyz",
     "healthcheckTimeout": 30,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 3


### PR DESCRIPTION
**Tier 0 (operability), PR 1 of 3.** The API could be deployed but not operated with confidence — this wires the runtime basics. (Tier 0 = the biggest gap from the engineering-foundation audit.)

## Graceful shutdown
SIGTERM/SIGINT now: stop the webhook worker + retention timer → `server.close()` (stop accepting, drain in-flight) → close the datastores → exit, with a 10s hard deadline. Fly's `auto_stop_machines` and every redeploy send SIGTERM; previously Node exited instantly, dropping in-flight requests and never closing the pg pool (and killing a webhook mid-POST).

## Crash safety
- `pool.on('error')` on **both** pg pools (meta + Better Auth). A node-postgres idle-client error (DB restart, Neon scale-to-zero, network blip) with no listener becomes an unhandled exception that **crashes the whole process** — now logged, pool reconnects.
- Process-level `unhandledRejection` (log) and `uncaughtException` (log + exit, so the orchestrator restarts a clean process).

## Readiness
New `GET /readyz` actually probes the datastore + blob backend (503 if unreachable), vs `/healthz` which only proves the process is up. **Fly + Railway healthchecks repointed to `/readyz`** so traffic isn't routed to an instance whose DB is down. (Single-instance SQLite self-host: always 200, no behavior change.)

## Fail-fast config
Malformed `PORT`/`BASE_URL`/`DATABASE_URL`/`OBJECT_STORE_URL` and the numeric retention/version-window knobs now throw at boot instead of silently coercing to a default or failing lazily on the first request; invalid quota knobs warn loudly. Plus `statement_timeout` + `connectionTimeoutMillis` on the pg pool.

## Tests
`/readyz` 200 + 503, `/healthz` liveness, config fail-fast validation. Full gate green: typecheck, all unit tests, biome + lints + knip.

Next in Tier 0: request observability (request-id + structured access log), then the webhook outbox atomic claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)