### PR TITLE
feat(api): request observability — request id + structured access log

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,6 +2,7 @@ import { type Context, Hono } from "hono"
 import { compress } from "hono/compress"
 import { type AppDeps, buildContext } from "./context"
 import { corsFor, fail, TOMBSTONE } from "./lib/http"
+import { observability } from "./lib/observability"
 import { makeRateLimiter } from "./lib/rate-limit"
 import { serveContent } from "./lib/serve-content"
 import { log } from "./log"
@@ -36,6 +37,10 @@ export function createApp(deps: AppDeps): Hono {
   const ctx = buildContext(deps)
   const app = new Hono()
 
+  // Outermost: a per-request id + one structured access-log line (method, path,
+  // status, duration, actor, org), so a 500 is correlatable to who/what.
+  app.use("*", observability())
+
   // gzip everything (Node/Fly entry only — the Worker edge compresses already).
   // Registered first so it wraps every downstream response; honors Accept-Encoding
   // and skips already-small bodies. Exception: the SSE streams (paths ending in
@@ -52,6 +57,7 @@ export function createApp(deps: AppDeps): Hono {
     log.error("unhandled error", {
       method: c.req.method,
       path: c.req.path,
+      request_id: c.get("requestId"),
       error: err instanceof Error ? err.message : String(err),
     })
     return c.json({ error: "internal error" }, 500)

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -188,6 +188,7 @@ export function buildContext(deps: AppDeps) {
     const s = deps.auth ? await deps.auth.api.getSession({ headers: c.req.raw.headers }) : null
     const u = s?.user ? { id: s.user.id, email: s.user.email, name: s.user.name ?? null } : null
     userCache.set(c, u)
+    if (u) c.set("actorId", u.id) // tag the access log with the resolved actor
     return u
   }
 
@@ -214,6 +215,7 @@ export function buildContext(deps: AppDeps) {
     const a =
       !b || (deps.token && safeEqual(b, deps.token)) ? null : await meta.getAgentByToken(sha256(b))
     agentCache.set(c, a)
+    if (a) c.set("actorId", a.id)
     return a
   }
 
@@ -294,6 +296,7 @@ export function buildContext(deps: AppDeps) {
       }
     }
     wsCache.set(c, ws)
+    c.set("orgId", ws)
     return ws
   }
   // Persist the active-workspace choice. Same cross-site handling as the viewer

--- a/apps/api/src/lib/observability.ts
+++ b/apps/api/src/lib/observability.ts
@@ -1,0 +1,42 @@
+import { randomUUID } from "node:crypto"
+import type { MiddlewareHandler } from "hono"
+import { log } from "../log"
+
+// Per-request context set by the middleware below + the identity resolvers in
+// context.ts, so the access log can name who/what made each request.
+declare module "hono" {
+  interface ContextVariableMap {
+    requestId: string
+    actorId?: string
+    orgId?: string
+  }
+}
+
+// Liveness/readiness probes hit every ~15s; access-logging them would drown the
+// real signal. (They still get a request id + the X-Request-Id header.)
+const SKIP_LOG = new Set(["/healthz", "/readyz"])
+
+/**
+ * Tags every request with a stable id (honoring an inbound `X-Request-Id` from a
+ * proxy/load balancer, else minting one), echoes it back as a response header, and
+ * emits one structured access-log line per request — method, path, status,
+ * duration, and the resolved actor/org — so a 500 can be correlated back to who
+ * and what triggered it. Registered outermost so it times the whole request.
+ */
+export const observability = (): MiddlewareHandler => async (c, next) => {
+  const requestId = c.req.header("x-request-id") || randomUUID()
+  c.set("requestId", requestId)
+  c.header("x-request-id", requestId)
+  const start = Date.now()
+  await next()
+  if (SKIP_LOG.has(c.req.path)) return
+  log.info("request", {
+    method: c.req.method,
+    path: c.req.path,
+    status: c.res.status,
+    duration_ms: Date.now() - start,
+    request_id: requestId,
+    actor: c.get("actorId"),
+    org: c.get("orgId"),
+  })
+}

--- a/apps/api/test/observability.test.ts
+++ b/apps/api/test/observability.test.ts
@@ -1,0 +1,25 @@
+import { join } from "node:path"
+import { FsBlobStore } from "@dock/storage/fs"
+import { describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { dir, meta } from "./helpers"
+
+// Every response carries a request id (minted, or honoring a proxy's inbound one)
+// so logs + clients can correlate a request end to end.
+describe("observability: request id", () => {
+  const app = createApp({
+    meta,
+    blobs: new FsBlobStore(join(dir, "blobs")),
+    baseUrl: "http://dock.test",
+  })
+
+  it("stamps every response with an X-Request-Id", async () => {
+    const id = (await app.request("/healthz")).headers.get("x-request-id")
+    expect(id).toMatch(/^[0-9a-f-]{36}$/)
+  })
+
+  it("honors an inbound X-Request-Id (proxy / load-balancer correlation)", async () => {
+    const r = await app.request("/healthz", { headers: { "x-request-id": "trace-abc-123" } })
+    expect(r.headers.get("x-request-id")).toBe("trace-abc-123")
+  })
+})


### PR DESCRIPTION
**Tier 0 (operability), PR 2 of 3.** The server had a structured logger but almost no request visibility — a 500 logged method+path with no way to correlate it to a request or an actor.

## What changed
- **`lib/observability.ts`** — an outermost middleware that mints a request id (honoring an inbound `X-Request-Id` from a proxy/LB), echoes it as a response header, and emits **one structured access-log line per request**: `method, path, status, duration_ms, request_id, actor, org`. Health/readiness probes are skipped so they don't drown the signal.
- The identity resolvers (`currentUser` / `agentFor` / `activeWorkspace`) tag the request with `actorId` + `orgId` **when they resolve them** (memoized — no extra queries), so the access log names who/what made each request.
- The request id is threaded into the `onError` 500 log, so an error correlates to its access line and the client's `X-Request-Id`.

Self-implemented (no new dep). Next: the webhook outbox atomic claim (PR 3).

## Tests
request id minted + inbound id honored. Full gate green: typecheck, all unit tests, biome + lints + knip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)