### PR TITLE
fix(deploy): run node as PID 1 so graceful shutdown runs on SIGTERM

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -22,4 +22,10 @@ ENV NODE_ENV=production \
 # Only used in the SQLite fallback; ignored when DATABASE_URL + OBJECT_STORE_URL are set.
 VOLUME /data
 EXPOSE 8080
-CMD ["pnpm", "--filter", "@dock/api", "start"]
+# Run node directly as PID 1, NOT via `pnpm ... start`: pnpm doesn't forward
+# SIGTERM to the node child, so on `docker stop` / Fly's auto-stop / a redeploy the
+# process would die instantly without running node.ts's graceful-shutdown handler
+# (drain in-flight requests, close the DB pool). tsx supplies the TS loader and the
+# app runs in this same process, so SIGTERM reaches our handler.
+WORKDIR /app/apps/api
+CMD ["node", "--import", "tsx", "src/node.ts"]


### PR DESCRIPTION
Found while testing the actual Fly/Docker deploy: **the Tier 0 graceful-shutdown handler never ran in the container.**

The CMD was `pnpm --filter @dock/api start`, so PID 1 is `pnpm`, which doesn't forward `SIGTERM` to the node child. On `docker stop` / Fly's `auto_stop_machines` / a redeploy, the process died instantly (0.16s, **no** shutdown logs) — the in-flight drain + DB-pool close from #115 never executed on the real deploy.

**Fix:** run node directly as PID 1 (`node --import tsx src/node.ts`, tsx as the loader), so SIGTERM reaches `node.ts`'s handler.

**Verified in the built image** (latest main + this change): `docker stop` now logs `shutting down {SIGTERM}` → `shutdown complete` and exits cleanly in <0.3s; `/healthz`, `/readyz`, and the token publish→raw loop all still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)