### PR TITLE
fix(auth): trust same-origin requests so port/proxy self-hosts don't 403

### DIFF
--- a/apps/api/src/auth-config.ts
+++ b/apps/api/src/auth-config.ts
@@ -25,7 +25,25 @@ export function makeAuth(db: AuthDb, baseUrl: string, secret: string) {
   const devOrigins = /^https?:\/\/(localhost|127\.0\.0\.1)(:|$)/.test(baseUrl)
     ? ["http://localhost:3000", "http://localhost:5173"]
     : []
-  const trusted = [...new Set([baseUrl, ...webOrigins, ...devOrigins])]
+  const staticTrusted = [...new Set([baseUrl, ...webOrigins, ...devOrigins])]
+
+  // Also trust a request whose Origin equals the origin it was actually served on
+  // (its own Host). A same-origin request is never CSRF, so this is safe: a
+  // cross-site attacker's Origin can never equal the victim browser's Host. It
+  // rescues the common self-host footgun: a port-mapped container or reverse proxy
+  // reached at an origin that doesn't exactly match BASE_URL (e.g. BASE_URL inferred
+  // as :8080 but the host published :8081) would otherwise 403 INVALID_ORIGIN on
+  // signup/login. Cross-origin (the real CSRF case) still requires an explicit
+  // baseUrl / DOCK_WEB_ORIGIN entry. A TLS-terminating proxy (browser https, app
+  // http) won't match here, so set BASE_URL to the public https origin for those.
+  const trusted = async (request?: Request): Promise<string[]> => {
+    try {
+      const origin = request?.headers.get("origin")
+      if (origin && request && origin === new URL(request.url).origin)
+        return [...staticTrusted, origin]
+    } catch {}
+    return staticTrusted
+  }
 
   const socialProviders: Record<string, { clientId: string; clientSecret: string }> = {}
   const googleId = env("GOOGLE_CLIENT_ID")
@@ -64,9 +82,15 @@ export function makeAuth(db: AuthDb, baseUrl: string, secret: string) {
     socialProviders,
     trustedOrigins: trusted,
     plugins: oidc.length ? [genericOAuth({ config: oidc })] : [],
-    ...(crossSite
-      ? { advanced: { defaultCookieAttributes: { sameSite: "none" as const, secure: true } } }
-      : {}),
+    advanced: {
+      // Keep the CSRF origin check on in every environment. Better Auth silently
+      // disables it when NODE_ENV=test; pinning it false means a server mistakenly
+      // booted with NODE_ENV=test still validates Origin (and lets the suite test it).
+      disableOriginCheck: false,
+      ...(crossSite
+        ? { defaultCookieAttributes: { sameSite: "none" as const, secure: true } }
+        : {}),
+    },
   })
 }
 

--- a/apps/api/test/auth-origin.test.ts
+++ b/apps/api/test/auth-origin.test.ts
@@ -1,0 +1,78 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { SqliteMetaStore } from "@dock/db/sqlite"
+import { FsBlobStore } from "@dock/storage/fs"
+import Database from "better-sqlite3"
+import { afterAll, describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { makeAuth, migrateAuth } from "../src/auth-config"
+
+// The same-origin trust in makeAuth. Better Auth rejects a sign-up/in whose Origin
+// is not in trustedOrigins (CSRF defense). That check fires for real browsers
+// (they send Sec-Fetch-* / cookies); a self-host reached at an origin that doesn't
+// exactly match BASE_URL (port-mapped container, reverse proxy) would otherwise
+// 403 INVALID_ORIGIN. We trust a request whose Origin equals the origin it was
+// actually served on — a same-origin request is never CSRF — while a genuinely
+// cross-site Origin stays rejected.
+//
+// The requests below carry the Fetch-Metadata headers a browser sends, so they hit
+// the real CSRF path (validateOrigin) rather than the no-cookie/no-metadata
+// short-circuit a bare programmatic POST would take.
+const dir = mkdtempSync(join(tmpdir(), "dock-auth-origin-"))
+
+// baseUrl is :8080, but the same-origin/cross-site requests are served at :8081 (a
+// port-mapped host) — the exact mismatch that used to 403 on a real browser signup.
+const dbPath = join(dir, "auth.db")
+const db = new Database(dbPath)
+const auth = makeAuth(db, "http://localhost:8080", "test-secret-0123456789abcd")
+const app = createApp({
+  meta: new SqliteMetaStore(dbPath),
+  blobs: new FsBlobStore(join(dir, "blobs")),
+  baseUrl: "http://localhost:8080",
+  auth,
+})
+
+// A browser-shaped sign-up: served at `servedAt`, carrying `origin` and a cookie.
+// Better Auth only runs the origin check on /sign-up/email when the request carries
+// a cookie (the real SPA always does — the Better Auth client sets one), so the
+// cookie is what arms the CSRF/origin check this fix lives behind.
+const signUp = (servedAt: string, origin: string, email: string) =>
+  app.request(`${servedAt}/api/auth/sign-up/email`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin,
+      cookie: "dock_probe=1",
+    },
+    body: JSON.stringify({ email, password: "password12345", name: "Tester" }),
+  })
+
+afterAll(() => {
+  db.close()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe("auth: same-origin trust (self-host port/proxy mismatch)", () => {
+  it("migrates the Better Auth tables", async () => {
+    await migrateAuth(auth)
+  })
+
+  it("accepts a same-origin sign-up whose Origin matches the served origin, not BASE_URL", async () => {
+    // Served at :8081, Origin :8081 (same-origin) — != BASE_URL :8080. Without the
+    // same-origin trust this 403s; with it, the request is trusted.
+    const res = await signUp("http://localhost:8081", "http://localhost:8081", "ok@dock.test")
+    expect(res.status).toBe(200)
+  })
+
+  it("still rejects a genuinely cross-site Origin (CSRF stays blocked)", async () => {
+    // Served at :8081, Origin evil.example (cross-site) — must 403.
+    const res = await signUp("http://localhost:8081", "http://evil.example", "evil@dock.test")
+    expect(res.status).toBe(403)
+  })
+
+  it("accepts a sign-up whose Origin matches BASE_URL exactly", async () => {
+    const res = await signUp("http://localhost:8080", "http://localhost:8080", "base@dock.test")
+    expect(res.status).toBe(200)
+  })
+})


### PR DESCRIPTION
## The footgun
Better Auth rejects a sign-up/login whose `Origin` isn't in `trustedOrigins` (CSRF defense). Our `trustedOrigins` was `baseUrl` + `DOCK_WEB_ORIGIN` + localhost dev ports. A self-host reached at an origin that doesn't **exactly** match `BASE_URL` — a port-mapped container (`BASE_URL` inferred as `:8080` but the host published `:8081`), or a reverse proxy — 403s `INVALID_ORIGIN` on the very first signup, with a cryptic error. I hit this verifying the Docker deploy.

## The fix
Trust a request whose `Origin` equals the origin it was **actually served on** (its own `Host`). A same-origin request is by definition not CSRF: a cross-site attacker's `Origin` can never equal the victim browser's `Host`. So this is purely additive — a genuinely cross-site `Origin` still requires an explicit `baseUrl` / `DOCK_WEB_ORIGIN` entry and stays rejected. (A TLS-terminating proxy where the browser speaks https but the app sees http won't match here; that case is covered by setting `BASE_URL` to the public https origin.)

Also pins `advanced.disableOriginCheck: false`. Better Auth silently disables the origin/CSRF check when `NODE_ENV=test`; pinning it keeps the check active in every environment — a server mistakenly booted with `NODE_ENV=test` still validates `Origin` — and lets the suite actually exercise it.

## Verification
- `test/auth-origin.test.ts` drives **real** sign-up through `createApp` + `betterAuth` (real cookie-armed CSRF path): same-origin-but-not-BASE_URL accepted, cross-site still 403, BASE_URL-exact accepted.
- Mutation check: confirmed the same-origin case **403s without the fix**, so the test guards the regression.
- Full api suite: 198 tests pass (194 + 4 new); typecheck (node + worker) + biome clean.
- **End-to-end in a real container**: ran the image with `-p 8086:8080` and no `BASE_URL` (inferred `:8080`, the mismatch). Browser signup at `:8086` — which previously 403'd — now succeeds and lands in the app; cross-site `Origin` curls still 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)