### PR TITLE
Live cursors: hide on blur, glide, and pick your own look

### DIFF
--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -50,6 +50,12 @@ export const realtimeRoutes = (ctx: AppContext) => {
   // Live cursor: a viewer's pointer position (viewport-normalized 0..1) fanned out
   // to everyone else on the artifact. Ephemeral — never stored, never webhooked;
   // it rides the same backplane as presence, so the DO relays it across isolates.
+  //
+  // The same frame also carries the viewer's chosen style (`kind` + `emoji`, a
+  // cosmetic preference) and two one-shot signals: `gone` (the viewer blurred /
+  // went idle — peers drop the cursor at once instead of waiting for it to go
+  // stale) and `tap` (the viewer clicked — peers pulse a ripple there). Style and
+  // signals are length/enum-bounded; identity (`name`) stays server-derived.
   app.post("/v1/artifacts/:shortId/cursor", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact || !(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
@@ -59,6 +65,10 @@ export const realtimeRoutes = (ctx: AppContext) => {
         id: z.string().min(1).max(64),
         name: z.string().max(80).optional(),
         color: z.string().max(32).optional(),
+        kind: z.enum(["arrow", "emoji"]).optional(),
+        emoji: z.string().max(16).optional(),
+        gone: z.boolean().optional(),
+        tap: z.boolean().optional(),
         x: z.number(),
         y: z.number(),
       }),
@@ -69,11 +79,19 @@ export const realtimeRoutes = (ctx: AppContext) => {
     // account name, an anonymous viewer by their stable rando handle — never a
     // client-supplied label. So a cursor and its presence row share one identity.
     const name = (await actingUser(c))?.name ?? anonName(anonViewerId(c))
+    const kind = body.kind ?? "arrow"
     bus.publish(artifact.id, {
       type: "cursor",
       id: body.id,
       name,
       color: body.color ?? "#655999",
+      kind,
+      // Only forward the glyph when the emoji style is actually selected.
+      emoji: kind === "emoji" ? body.emoji : undefined,
+      // Coerce to a strict, present-only boolean so a frame is either a leave/tap
+      // or it isn't — peers branch on truthiness without inspecting the value.
+      gone: body.gone === true ? true : undefined,
+      tap: body.tap === true ? true : undefined,
       x: clamp(body.x),
       y: clamp(body.y),
     })

--- a/apps/api/test/anonymous.test.ts
+++ b/apps/api/test/anonymous.test.ts
@@ -105,6 +105,9 @@ describe("anonymous can never write — global lockdown sweep", () => {
     expect((await at("/view", json({}))).status).toBe(204) // passive view counter
     expect((await at("/presence", json({}))).status).toBe(200) // "someone is viewing"
     expect((await at("/cursor", json({ id: "g", x: 0, y: 0 }))).status).toBe(204) // live cursor
+    // leave/tap ride the same /cursor route (a flag, not a new path), so they need
+    // no new anonymous gate — an anon viewer can retire their own cursor.
+    expect((await at("/cursor", json({ id: "g", gone: true, x: 0, y: 0 }))).status).toBe(204)
   })
 
   it("refuses every anonymous mutation across the API", async () => {

--- a/apps/api/test/realtime.test.ts
+++ b/apps/api/test/realtime.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+import { type Backplane, createInProcessBackplane, type DockEvent } from "../src/bus"
+import { bearer, json, publishAs, quotaApp, TEST_TOKEN } from "./helpers"
+
+// The live-cursor frame is the wire contract between viewers: it carries a chosen
+// look (kind + emoji) plus two one-shot signals (gone = "I blurred/left", tap =
+// "I clicked"). The server passes the cosmetic fields through but keeps them
+// bounded, and — as everywhere — derives the identity name itself. These tests
+// pin that contract by watching what gets published on the bus.
+
+/** A backplane that records every published frame, delegating the rest in-process. */
+const recordingBackplane = (): { backplane: Backplane; frames: DockEvent[] } => {
+  const inner = createInProcessBackplane()
+  const frames: DockEvent[] = []
+  return {
+    frames,
+    backplane: {
+      ...inner,
+      publish(channel, e) {
+        frames.push(e)
+        inner.publish(channel, e)
+      },
+    },
+  }
+}
+
+describe("live cursor frame", () => {
+  const seed = async () => {
+    const { backplane, frames } = recordingBackplane()
+    const { app } = quotaApp("realtime-cursor", { backplane })
+    const { short_id } = await (
+      await publishAs(app, "<h1>doc</h1>", { visibility: "public" }, bearer(TEST_TOKEN))
+    ).json()
+    const cursor = (body: unknown) => app.request(`/v1/artifacts/${short_id}/cursor`, json(body))
+    const lastCursor = () =>
+      [...frames].reverse().find((f) => f.type === "cursor") as
+        | (DockEvent & Record<string, unknown>)
+        | undefined
+    return { cursor, lastCursor }
+  }
+
+  it("passes an emoji look through and defaults the rest", async () => {
+    const { cursor, lastCursor } = await seed()
+    expect((await cursor({ id: "a", kind: "emoji", emoji: "🦊", x: 0.5, y: 0.5 })).status).toBe(204)
+    const f = lastCursor()
+    expect(f).toMatchObject({ type: "cursor", id: "a", kind: "emoji", emoji: "🦊" })
+    // color falls back to the server default; x/y survive.
+    expect(f?.color).toBe("#655999")
+    expect(f).toMatchObject({ x: 0.5, y: 0.5 })
+  })
+
+  it("defaults kind to arrow and never forwards an emoji for an arrow cursor", async () => {
+    const { cursor, lastCursor } = await seed()
+    // Even if a client sends an emoji with an arrow kind, it isn't forwarded.
+    await cursor({ id: "b", kind: "arrow", emoji: "🦊", x: 0.1, y: 0.2 })
+    expect(lastCursor()).toMatchObject({ kind: "arrow" })
+    expect(lastCursor()?.emoji).toBeUndefined()
+    // Omitted kind → arrow.
+    await cursor({ id: "b", x: 0.3, y: 0.4 })
+    expect(lastCursor()).toMatchObject({ kind: "arrow" })
+  })
+
+  it("forwards the gone (leave) and tap signals as present-only flags", async () => {
+    const { cursor, lastCursor } = await seed()
+    expect((await cursor({ id: "c", gone: true, x: 0.5, y: 0.5 })).status).toBe(204)
+    expect(lastCursor()?.gone).toBe(true)
+
+    await cursor({ id: "c", tap: true, x: 0.5, y: 0.5 })
+    expect(lastCursor()?.tap).toBe(true)
+
+    // A plain move carries neither flag (so peers branch on truthiness).
+    await cursor({ id: "c", x: 0.6, y: 0.6 })
+    expect(lastCursor()?.gone).toBeUndefined()
+    expect(lastCursor()?.tap).toBeUndefined()
+  })
+
+  it("rejects an out-of-bounds look (oversized emoji, unknown kind)", async () => {
+    const { cursor } = await seed()
+    expect((await cursor({ id: "d", emoji: "x".repeat(64), x: 0, y: 0 })).status).toBe(400)
+    expect((await cursor({ id: "d", kind: "rainbow", x: 0, y: 0 })).status).toBe(400)
+  })
+})

--- a/apps/web/e2e/deep/cursors.deep.spec.ts
+++ b/apps/web/e2e/deep/cursors.deep.spec.ts
@@ -1,0 +1,65 @@
+import { Buffer } from "node:buffer"
+import type { Page } from "@playwright/test"
+import { expect, openArtifact, test } from "../fixtures"
+
+// Live multiplayer cursors, end to end across two real browser contexts: a peer's
+// cursor reaches the other viewer over SSE, carries a chosen look, and is removed
+// the instant the peer signals it left — no 8s lingering. Plus the self picker.
+
+async function publishPublic(page: Page): Promise<string> {
+  let shortId = ""
+  await expect(async () => {
+    const res = await page.request.post("/v1/artifacts", {
+      multipart: {
+        file: { name: "live.md", mimeType: "text/markdown", buffer: Buffer.from("# Live\n\nbody") },
+        visibility: "public",
+      },
+    })
+    expect(res.ok(), `publish failed: ${res.status()}`).toBeTruthy()
+    shortId = ((await res.json()) as { short_id: string }).short_id
+  }).toPass({ timeout: 10_000 })
+  return shortId
+}
+
+test.describe("live multiplayer cursors", () => {
+  test("a peer cursor appears, restyles to an emoji, and leaves on signal", async ({
+    owner,
+    secondUser,
+  }) => {
+    const shortId = await publishPublic(owner)
+    await openArtifact(owner, shortId)
+
+    // The second viewer drives a cursor through the real API (a different session,
+    // so the name is server-derived). The owner's page should paint it.
+    const peer = (body: Record<string, unknown>) =>
+      secondUser.page.request.post(`/v1/artifacts/${shortId}/cursor`, {
+        data: { id: "peer-1", x: 0.5, y: 0.4, ...body },
+      })
+
+    // Appears — retry the publish until the owner's SSE has connected and painted.
+    await expect(async () => {
+      expect((await peer({ color: "#7c6cbd", kind: "arrow" })).ok()).toBeTruthy()
+      await expect(owner.getByTestId("remote-cursor")).toBeVisible({ timeout: 1000 })
+    }).toPass({ timeout: 15_000 })
+    // Identity is server-derived, never a client field.
+    await expect(owner.getByTestId("remote-cursor")).toContainText("Second User")
+
+    // Restyle to an emoji cursor — the glyph swaps.
+    await peer({ kind: "emoji", emoji: "🦊" })
+    await expect(owner.getByTestId("remote-cursor")).toContainText("🦊")
+
+    // Leave → removed promptly.
+    await peer({ gone: true })
+    await expect(owner.getByTestId("remote-cursor")).toHaveCount(0)
+  })
+
+  test("you can customize your own cursor", async ({ owner }) => {
+    const shortId = await publishPublic(owner)
+    await openArtifact(owner, shortId)
+
+    await owner.getByTestId("cursor-self-trigger").click()
+    await owner.getByTestId("cursor-kind-emoji").click()
+    await owner.getByTestId("cursor-emoji-2").click() // 🦊
+    await expect(owner.getByTestId("cursor-self-trigger")).toContainText("🦊")
+  })
+})

--- a/apps/web/src/components/cursor/cursor-button.tsx
+++ b/apps/web/src/components/cursor/cursor-button.tsx
@@ -1,0 +1,32 @@
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { useCursorPref } from "@/ctx"
+import { CursorSwitch } from "./cursor-switch"
+import { CursorGlyph } from "./glyph"
+
+// A compact "your cursor" control for the artifact bar: shows your current
+// glyph and opens the picker. This is the entry point that works for anonymous
+// public-link viewers (who never see the account pod), so anyone can customize.
+export function CursorButton() {
+  const { pref } = useCursorPref()
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          data-testid="cursor-self-trigger"
+          title="Customize your cursor"
+          aria-label="Customize your cursor"
+          className="grid size-[26px] place-items-center rounded-md text-muted-foreground transition-colors hover:bg-hover"
+        >
+          <CursorGlyph color={pref.color} kind={pref.kind} emoji={pref.emoji} size={16} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-60 p-2">
+        <div className="px-0.5 pb-1.5 font-mono text-2xs uppercase tracking-[0.06em] text-muted-foreground">
+          Your cursor
+        </div>
+        <CursorSwitch />
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/cursor/cursor-switch.tsx
+++ b/apps/web/src/components/cursor/cursor-switch.tsx
@@ -1,0 +1,73 @@
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { useCursorPref } from "@/ctx"
+import { CURSOR_COLORS, CURSOR_EMOJI, type CursorKind } from "@/lib/cursors"
+import { cn } from "@/lib/utils"
+import { CursorGlyph, NameTag } from "./glyph"
+
+// Pick your live cursor: a color, arrow-or-emoji, and (for emoji) the glyph.
+// Used both in the account pod and on the artifact page, so anonymous viewers
+// can customize too. Swatch colors are identity data, not theme tokens.
+export function CursorSwitch({ className }: { className?: string }) {
+  const { pref, setPref } = useCursorPref()
+  return (
+    <div className={cn("space-y-2", className)}>
+      {/* Live preview of your own cursor. */}
+      <div className="flex items-center gap-2 rounded-md bg-accent/40 px-2.5 py-2">
+        <CursorGlyph color={pref.color} kind={pref.kind} emoji={pref.emoji} size={20} />
+        <NameTag color={pref.color}>You</NameTag>
+      </div>
+
+      {/* Color. */}
+      <div className="flex flex-wrap gap-1.5">
+        {CURSOR_COLORS.map((c, i) => (
+          <button
+            key={c}
+            type="button"
+            data-testid={`cursor-color-${i}`}
+            aria-label={`Cursor color ${i + 1}`}
+            aria-pressed={pref.color === c}
+            onClick={() => setPref({ ...pref, color: c })}
+            className={cn(
+              "size-5 rounded-full ring-offset-1 ring-offset-card transition-transform hover:scale-110",
+              pref.color === c && "ring-2 ring-foreground",
+            )}
+            style={{ background: c }}
+          />
+        ))}
+      </div>
+
+      {/* Style. */}
+      <Tabs value={pref.kind} onValueChange={(k) => setPref({ ...pref, kind: k as CursorKind })}>
+        <TabsList className="h-8 w-full gap-0.5 p-0.5">
+          <TabsTrigger value="arrow" data-testid="cursor-kind-arrow" className="flex-1 text-xs">
+            Arrow
+          </TabsTrigger>
+          <TabsTrigger value="emoji" data-testid="cursor-kind-emoji" className="flex-1 text-xs">
+            Emoji
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      {pref.kind === "emoji" && (
+        <div className="grid grid-cols-5 gap-1">
+          {CURSOR_EMOJI.map((e, i) => (
+            <button
+              key={e}
+              type="button"
+              data-testid={`cursor-emoji-${i}`}
+              aria-label={`Emoji ${e}`}
+              aria-pressed={pref.emoji === e}
+              onClick={() => setPref({ ...pref, kind: "emoji", emoji: e })}
+              className={cn(
+                "grid h-7 place-items-center rounded-md text-base transition-colors hover:bg-hover",
+                pref.emoji === e && "bg-accent ring-1 ring-foreground",
+              )}
+            >
+              {e}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/cursor/glyph.tsx
+++ b/apps/web/src/components/cursor/glyph.tsx
@@ -1,0 +1,86 @@
+import type { CSSProperties, ReactNode } from "react"
+import type { CursorKind } from "@/lib/cursors"
+import { cn } from "@/lib/utils"
+
+// The visual half of a live cursor, shared by the on-canvas overlay and the
+// picker's preview so there's one definition of "what a cursor looks like".
+// Raw colors here are identity data (the viewer's chosen tint) and fixed
+// contrast values (#fff keyline, the lift shadow) — not theme tokens.
+
+/**
+ * The pointer itself. A crisper, slightly slimmer arrow than the old flat one:
+ * filled in the viewer's color, a white keyline so it reads on any artifact
+ * background, and a soft drop shadow so it lifts off the page. Swaps to the
+ * chosen emoji when that style is selected.
+ */
+export function CursorGlyph({
+  color,
+  kind,
+  emoji,
+  size = 22,
+}: {
+  color: string
+  kind: CursorKind
+  emoji?: string
+  size?: number
+}) {
+  if (kind === "emoji" && emoji) {
+    return (
+      <span
+        aria-hidden="true"
+        className="block leading-none drop-shadow-[0_2px_3px_rgba(0,0,0,0.28)]"
+        style={{ fontSize: size }}
+      >
+        {emoji}
+      </span>
+    )
+  }
+  return (
+    <svg
+      aria-hidden="true"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      className="drop-shadow-[0_2px_3px_rgba(0,0,0,0.3)]"
+    >
+      <path
+        d="M5 2.2 L5 19.7 L9.35 15.6 L12.1 21.5 L14.8 20.2 L12.05 14.4 L18 14.4 Z"
+        fill={color}
+        stroke="#fff"
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
+/**
+ * The little name flag beside a cursor. Background is the viewer's identity
+ * color; text is fixed white for legibility on any of the palette tints. Carries
+ * `data-cursor-label` so the overlay's animation loop can fade it on stillness.
+ */
+export function NameTag({
+  color,
+  children,
+  className,
+  style,
+}: {
+  color: string
+  children: ReactNode
+  className?: string
+  style?: CSSProperties
+}) {
+  return (
+    <span
+      data-cursor-label
+      className={cn(
+        "inline-block max-w-[160px] truncate rounded-[5px] px-1.5 py-px text-2xs font-semibold leading-tight text-white",
+        className,
+      )}
+      style={{ background: color, ...style }}
+    >
+      {children}
+    </span>
+  )
+}

--- a/apps/web/src/components/user-pod.tsx
+++ b/apps/web/src/components/user-pod.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { useAuth } from "@/ctx"
 import { cn } from "@/lib/utils"
+import { CursorSwitch } from "./cursor/cursor-switch"
 import { Icon } from "./icons"
 import { ThemeSwitch } from "./theme-switch"
 
@@ -161,6 +162,12 @@ export function UserPod({
           <div className={SECTION}>Theme</div>
           <div className="px-1 pb-1">
             <ThemeSwitch />
+          </div>
+          <div className="my-1 h-px bg-border-soft" />
+
+          <div className={SECTION}>Cursor</div>
+          <div className="px-1 pb-1">
+            <CursorSwitch />
           </div>
           <div className="my-1 h-px bg-border-soft" />
 

--- a/apps/web/src/ctx.tsx
+++ b/apps/web/src/ctx.tsx
@@ -1,5 +1,6 @@
 import { createContext, type ReactNode, useContext, useEffect, useState } from "react"
 import { api, type Me } from "./api"
+import { type CursorPref, defaultPrefFor, normalizePref } from "./lib/cursors"
 import { STORAGE_KEYS } from "./lib/storage-keys"
 
 /* ---- auth ---- */
@@ -50,4 +51,39 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     localStorage.setItem(STORAGE_KEYS.theme, theme)
   }, [theme])
   return <ThemeCtx.Provider value={{ theme, setTheme }}>{children}</ThemeCtx.Provider>
+}
+
+/* ---- cursor preference (your live multiplayer cursor look) ---- */
+// Persisted per-browser, exactly like the theme — so it works for anonymous
+// public-link viewers too (no account, no server round-trip), and a signed-in
+// user's pick is instant. The look only ever rides ephemeral cursor frames, so
+// there's nothing to store server-side.
+const CursorPrefCtx = createContext<{ pref: CursorPref; setPref: (p: CursorPref) => void }>({
+  pref: defaultPrefFor("default"),
+  setPref: () => {},
+})
+export const useCursorPref = () => useContext(CursorPrefCtx)
+
+export function CursorPrefProvider({ children }: { children: ReactNode }) {
+  const [pref, setPref] = useState<CursorPref>(() => {
+    // Guard for the prerendered shell (no window/localStorage at build time).
+    if (typeof localStorage === "undefined") return defaultPrefFor("default")
+    try {
+      const saved = localStorage.getItem(STORAGE_KEYS.cursorPref)
+      if (saved) return normalizePref(JSON.parse(saved), defaultPrefFor("default"))
+    } catch {
+      /* fall through to a fresh default */
+    }
+    // First visit: seed a stable-ish random look (persisted by the effect below),
+    // so a viewer keeps the same cursor across reloads — Figma-style.
+    return defaultPrefFor(Math.random().toString(36).slice(2))
+  })
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEYS.cursorPref, JSON.stringify(pref))
+    } catch {
+      /* private mode / storage full — the in-memory pref still works this session */
+    }
+  }, [pref])
+  return <CursorPrefCtx.Provider value={{ pref, setPref }}>{children}</CursorPrefCtx.Provider>
 }

--- a/apps/web/src/lib/cursors.ts
+++ b/apps/web/src/lib/cursors.ts
@@ -1,0 +1,93 @@
+// The live-cursor domain — one source of truth shared by the preference store
+// (ctx), the picker, and the on-canvas overlay, so the look and the feel are
+// tuned in exactly one place.
+//
+// Nothing here touches React or the DOM: just the vocabulary (a viewer's
+// `CursorPref`, the `CursorFrame` peers exchange over the wire), the curated
+// palettes a viewer chooses from, and the animation/lifecycle tuning.
+
+export type CursorKind = "arrow" | "emoji"
+
+/** A viewer's chosen cursor look. Persisted per-browser (see `useCursorPref`). */
+export interface CursorPref {
+  color: string
+  kind: CursorKind
+  emoji: string
+}
+
+/** A cursor frame as it arrives over the SSE bus (server-shaped, sans `type`). */
+export interface CursorFrame {
+  id: string
+  name?: string
+  color?: string
+  kind?: CursorKind
+  emoji?: string
+  /** The viewer blurred / went idle — drop their cursor now, don't wait it out. */
+  gone?: boolean
+  /** The viewer clicked — pulse a ripple at (x, y). */
+  tap?: boolean
+  x: number
+  y: number
+}
+
+// Curated identity palette, tuned to read on both light and dark artifact
+// backgrounds (the avatar identity tints' sibling). Raw hex is the point here.
+export const CURSOR_COLORS = [
+  "#7c6cbd",
+  "#3c8f4e",
+  "#d2724b",
+  "#3aa6a6",
+  "#b15fb0",
+  "#c79a2a",
+  "#5170d8",
+  "#cc5d80",
+] as const
+
+// A small, friendly set — personal without the weight of a full emoji picker.
+export const CURSOR_EMOJI = ["👆", "🐱", "🦊", "🚀", "✨", "🌸", "🔥", "👀", "💜", "🐙"] as const
+
+/** Server's fallback tint when a (stale) client sends a cursor with no color. */
+export const CURSOR_FALLBACK = "#655999"
+
+export const DEFAULT_EMOJI = CURSOR_EMOJI[0]
+
+// Animation + lifecycle tuning, all in one place so "feel" is a one-file tweak.
+export const CURSOR_TUNING = {
+  /** Pointer easing per frame, 0..1 — higher is snappier, lower floatier. */
+  lerp: 0.22,
+  /** Hide the name tag after this much stillness (the cursor stays). */
+  labelIdleMs: 1600,
+  /** Local pointer idle this long → tell peers we've gone. */
+  idleMs: 5000,
+  /** Swallow a blur that's really a quick focus hop (devtools, iframe). */
+  blurDebounceMs: 180,
+  /** Backstop: drop a peer we've heard nothing from at all. */
+  staleMs: 4000,
+  /** Fade-out duration when a peer leaves / goes idle. */
+  leaveFadeMs: 150,
+  /** One-shot click-ripple lifetime. */
+  rippleMs: 620,
+  /** Outgoing cursor-publish throttle. */
+  sendThrottleMs: 45,
+  /** Re-publish a still (but present) pointer so peers don't time it out. */
+  resendMs: 3000,
+} as const
+
+/** Deterministic default look for a viewer with no saved preference, seeded by
+ *  their per-tab id so two strangers usually land on different colors. */
+export function defaultPrefFor(seed: string): CursorPref {
+  let h = 0
+  for (const ch of seed) h = (h * 31 + ch.charCodeAt(0)) >>> 0
+  return { color: CURSOR_COLORS[h % CURSOR_COLORS.length], kind: "arrow", emoji: DEFAULT_EMOJI }
+}
+
+/** Coerce a persisted/garbage value into a valid `CursorPref`. */
+export function normalizePref(raw: unknown, fallback: CursorPref): CursorPref {
+  if (!raw || typeof raw !== "object") return fallback
+  const r = raw as Record<string, unknown>
+  return {
+    color: typeof r.color === "string" ? r.color : fallback.color,
+    kind: r.kind === "emoji" ? "emoji" : "arrow",
+    emoji: typeof r.emoji === "string" && r.emoji ? r.emoji : fallback.emoji,
+  }
+}

--- a/apps/web/src/lib/storage-keys.ts
+++ b/apps/web/src/lib/storage-keys.ts
@@ -4,6 +4,7 @@
 // object, never a bare string literal.
 export const STORAGE_KEYS = {
   theme: "dock_theme",
+  cursorPref: "dock.cursor.pref",
   libraryRail: "dock.browse.rail",
   commentsPanel: "dock.comments.panel",
   navCollapsed: "dock.nav.collapsed",

--- a/apps/web/src/pages/artifact/artifact-document.tsx
+++ b/apps/web/src/pages/artifact/artifact-document.tsx
@@ -1,6 +1,8 @@
 import type { RefObject } from "react"
 import type { Diff } from "@/api"
 import { Button } from "@/components/ui/button"
+import { CursorLayer } from "./cursors/cursor-layer"
+import type { CursorLayerHandle } from "./cursors/use-live-cursors"
 import { DiffView } from "./diff-view"
 import { DeckBar } from "./rail-deck"
 
@@ -21,7 +23,7 @@ export function ArtifactDocument({
   deck,
   frameRef,
   presentWrapRef,
-  cursorLayerRef,
+  cursor,
   onFrameLoad,
   onToggleDiff,
   onRestore,
@@ -40,7 +42,7 @@ export function ArtifactDocument({
   deck: { i: number; total: number } | null
   frameRef: RefObject<HTMLIFrameElement | null>
   presentWrapRef: RefObject<HTMLDivElement | null>
-  cursorLayerRef: RefObject<HTMLDivElement | null>
+  cursor: CursorLayerHandle
   onFrameLoad: () => void
   onToggleDiff: () => void
   onRestore: () => void
@@ -107,13 +109,11 @@ export function ArtifactDocument({
               onFullscreen={onFullscreen}
             />
           )}
-          {/* Live peer cursors (Google-Docs style). The iframe is a separate opaque
-              origin, so its anchor script forwards mousemove out via postMessage; we
-              paint the dots here in the parent, over the frame. Anon viewers too. */}
-          <div
-            ref={cursorLayerRef}
-            className="pointer-events-none absolute inset-0 z-20 overflow-hidden"
-          />
+          {/* Live peer cursors (Figma/Notion style). The iframe is a separate opaque
+              origin, so its anchor script forwards pointer moves/leave/tap out via
+              postMessage; the overlay eases them in here in the parent, over the
+              frame. Anon viewers too. */}
+          <CursorLayer layer={cursor} />
         </div>
       )}
     </>

--- a/apps/web/src/pages/artifact/cursors/cursor-layer.tsx
+++ b/apps/web/src/pages/artifact/cursors/cursor-layer.tsx
@@ -1,0 +1,68 @@
+import { memo } from "react"
+import { CursorGlyph, NameTag } from "@/components/cursor/glyph"
+import type { CursorLayerHandle, PeerView, Ripple } from "./use-live-cursors"
+
+// The peer-cursor overlay, painted over the artifact frame. Mount/unmount and
+// styling are React's job; every-frame motion is driven straight on the DOM by
+// the rAF loop in use-live-cursors (it writes `transform`/`opacity` on these
+// nodes via the `register` ref). Ripple/peer colors are identity data.
+export function CursorLayer({ layer }: { layer: CursorLayerHandle }) {
+  return (
+    <div
+      ref={layer.ref}
+      className="pointer-events-none absolute inset-0 z-20 overflow-hidden"
+      data-testid="cursor-layer"
+    >
+      {layer.roster.map((p) => (
+        <RemoteCursor key={p.id} peer={p} register={layer.register} />
+      ))}
+      {layer.ripples.map((r) => (
+        <RippleDot key={r.key} ripple={r} />
+      ))}
+    </div>
+  )
+}
+
+const RemoteCursor = memo(function RemoteCursor({
+  peer,
+  register,
+}: {
+  peer: PeerView
+  register: (id: string, el: HTMLElement | null) => void
+}) {
+  return (
+    <div
+      ref={(el) => register(peer.id, el)}
+      data-testid="remote-cursor"
+      data-cursor-id={peer.id}
+      // Positioned at the origin; the animation loop translates it each frame.
+      // Opacity transitions handle the leave fade smoothly.
+      className="absolute left-0 top-0 will-change-transform transition-opacity duration-150"
+    >
+      <CursorGlyph color={peer.color} kind={peer.kind} emoji={peer.emoji} />
+      <NameTag
+        color={peer.color}
+        className="absolute left-[15px] top-[16px] whitespace-nowrap transition-opacity duration-200"
+      >
+        {peer.name}
+      </NameTag>
+    </div>
+  )
+})
+
+// A click ripple — a ring that expands and fades once. Positioned by percentage
+// so it's resolution-independent (no layout read needed); the keyframe lives in
+// globals.css (dock-cursor-ripple).
+function RippleDot({ ripple }: { ripple: Ripple }) {
+  return (
+    <span
+      className="absolute block size-5 rounded-full border-2"
+      style={{
+        left: `${ripple.x * 100}%`,
+        top: `${ripple.y * 100}%`,
+        borderColor: ripple.color,
+        animation: "dock-cursor-ripple 620ms ease-out forwards",
+      }}
+    />
+  )
+}

--- a/apps/web/src/pages/artifact/cursors/use-live-cursors.ts
+++ b/apps/web/src/pages/artifact/cursors/use-live-cursors.ts
@@ -1,0 +1,313 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { API_BASE } from "@/api"
+import { useCursorPref } from "@/ctx"
+import { CURSOR_FALLBACK, CURSOR_TUNING, type CursorFrame } from "@/lib/cursors"
+
+// All of the live-cursor realtime behaviour, kept out of the page and out of the
+// presence/comments hook:
+//  - sending our own pointer (throttled), our chosen look, and explicit
+//    leave / tap signals;
+//  - a focus/idle state machine so a blurred or idle tab stops showing a cursor
+//    at once (no more cursors lingering on an abandoned tab);
+//  - painting peers as a single rAF-driven overlay that eases (lerps) toward each
+//    peer's latest position, so cursors glide instead of teleporting between
+//    throttled samples; the name tag fades after a beat of stillness.
+//
+// React only re-renders when the *roster* changes (a peer joins, leaves, or
+// restyles) or a ripple fires; every-frame motion is written straight to the
+// DOM via refs, never through React.
+
+/** A peer entry the overlay mounts/unmounts and styles (no per-frame churn). */
+export interface PeerView {
+  id: string
+  color: string
+  kind: "arrow" | "emoji"
+  emoji?: string
+  name: string
+}
+
+/** A one-shot click ripple. */
+export interface Ripple {
+  key: number
+  x: number
+  y: number
+  color: string
+}
+
+/** What the overlay needs to render + animate the layer. */
+export interface CursorLayerHandle {
+  ref: React.RefObject<HTMLDivElement | null>
+  roster: PeerView[]
+  ripples: Ripple[]
+  register: (id: string, el: HTMLElement | null) => void
+}
+
+/** Per-peer animation state — lives in a ref, mutated outside React. */
+interface PeerTarget {
+  x: number // latest normalized target (0..1)
+  y: number
+  cx: number // current eased position, in layer pixels
+  cy: number
+  color: string
+  kind: "arrow" | "emoji"
+  emoji?: string
+  name: string
+  gone: boolean
+  fade: number // opacity while leaving (1 → 0)
+  lastSeen: number
+  lastMoveAt: number
+  el: HTMLElement | null
+  labelEl: HTMLElement | null
+}
+
+const styleChanged = (t: PeerTarget, f: CursorFrame) =>
+  t.color !== (f.color ?? t.color) ||
+  t.kind !== (f.kind ?? t.kind) ||
+  t.emoji !== f.emoji ||
+  t.name !== (f.name ?? t.name)
+
+export function useLiveCursors(shortId: string): {
+  onPointerMove: (x: number, y: number) => void
+  onPointerLeave: () => void
+  onTap: (x: number, y: number) => void
+  paintFrame: (f: CursorFrame) => void
+  layer: CursorLayerHandle
+} {
+  const { pref } = useCursorPref()
+  // Always send the latest pick without re-binding the send callbacks.
+  const prefRef = useRef(pref)
+  prefRef.current = pref
+
+  const layerRef = useRef<HTMLDivElement>(null)
+  const selfId = useRef("")
+  if (!selfId.current) selfId.current = Math.random().toString(36).slice(2, 9)
+
+  // Peer animation state (ref) + the React-visible roster/ripples (state).
+  const targets = useRef(new Map<string, PeerTarget>())
+  const [roster, setRoster] = useState<PeerView[]>([])
+  const [ripples, setRipples] = useState<Ripple[]>([])
+  const rosterDirty = useRef(false)
+
+  // Local send + lifecycle state.
+  const xy = useRef<[number, number] | null>(null)
+  const sentAt = useRef(0)
+  const live = useRef(false)
+  const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const rippleKey = useRef(0)
+
+  // Rebuild the roster from the targets map, coalesced to ≤1 render per burst.
+  const markRosterDirty = useCallback(() => {
+    if (rosterDirty.current) return
+    rosterDirty.current = true
+    queueMicrotask(() => {
+      rosterDirty.current = false
+      setRoster(
+        [...targets.current.entries()].map(([id, t]) => ({
+          id,
+          color: t.color,
+          kind: t.kind,
+          emoji: t.emoji,
+          name: t.name,
+        })),
+      )
+    })
+  }, [])
+
+  const send = useCallback(
+    (extra: Record<string, unknown>) => {
+      const pt = xy.current ?? [0, 0]
+      fetch(`${API_BASE}/v1/artifacts/${shortId}/cursor`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        credentials: "include",
+        keepalive: true, // so a leave fired at unload still flushes
+        body: JSON.stringify({ id: selfId.current, x: pt[0], y: pt[1], ...extra }),
+      }).catch(() => {})
+    },
+    [shortId],
+  )
+
+  // Our current look as wire fields (reads a ref, so it's stable).
+  const look = useCallback(() => {
+    const p = prefRef.current
+    return { color: p.color, kind: p.kind, emoji: p.kind === "emoji" ? p.emoji : undefined }
+  }, [])
+
+  const sendCursor = useCallback(() => {
+    sentAt.current = Date.now()
+    send(look())
+  }, [send, look])
+
+  const sendLeave = useCallback(() => {
+    if (!live.current) return
+    live.current = false
+    send({ gone: true })
+  }, [send])
+
+  const onPointerMove = useCallback(
+    (x: number, y: number) => {
+      xy.current = [x, y]
+      live.current = true
+      if (idleTimer.current) clearTimeout(idleTimer.current)
+      idleTimer.current = setTimeout(sendLeave, CURSOR_TUNING.idleMs)
+      if (Date.now() - sentAt.current >= CURSOR_TUNING.sendThrottleMs) sendCursor()
+    },
+    [sendCursor, sendLeave],
+  )
+
+  const onPointerLeave = useCallback(() => sendLeave(), [sendLeave])
+
+  const onTap = useCallback(
+    (x: number, y: number) => {
+      xy.current = [x, y]
+      live.current = true
+      send({ ...look(), tap: true })
+    },
+    [send, look],
+  )
+
+  const register = useCallback((id: string, el: HTMLElement | null) => {
+    const t = targets.current.get(id)
+    if (!t) return
+    t.el = el
+    t.labelEl = el?.querySelector<HTMLElement>("[data-cursor-label]") ?? null
+  }, [])
+
+  // Incoming peer frame (fed from the shared SSE stream in use-artifact-live).
+  const paintFrame = useCallback(
+    (f: CursorFrame) => {
+      if (!f?.id || f.id === selfId.current) return
+
+      if (f.tap) {
+        const key = ++rippleKey.current
+        setRipples((rs) => [...rs, { key, x: f.x, y: f.y, color: f.color ?? CURSOR_FALLBACK }])
+        setTimeout(
+          () => setRipples((rs) => rs.filter((r) => r.key !== key)),
+          CURSOR_TUNING.rippleMs,
+        )
+      }
+
+      const existing = targets.current.get(f.id)
+      if (f.gone) {
+        if (existing) existing.gone = true // the rAF loop fades it out, then prunes
+        return
+      }
+
+      const now = Date.now()
+      if (!existing) {
+        // New peer: seed the eased position at the target so it appears in place.
+        const r = layerRef.current?.getBoundingClientRect()
+        targets.current.set(f.id, {
+          x: f.x,
+          y: f.y,
+          cx: f.x * (r?.width ?? 0),
+          cy: f.y * (r?.height ?? 0),
+          color: f.color ?? CURSOR_FALLBACK,
+          kind: f.kind ?? "arrow",
+          emoji: f.emoji,
+          name: f.name ?? "Guest",
+          gone: false,
+          fade: 1,
+          lastSeen: now,
+          lastMoveAt: now,
+          el: null,
+          labelEl: null,
+        })
+        markRosterDirty()
+        return
+      }
+
+      if (styleChanged(existing, f)) markRosterDirty()
+      existing.x = f.x
+      existing.y = f.y
+      existing.color = f.color ?? existing.color
+      existing.kind = f.kind ?? existing.kind
+      existing.emoji = f.emoji
+      existing.name = f.name ?? existing.name
+      existing.gone = false
+      existing.fade = 1
+      existing.lastSeen = now
+    },
+    [markRosterDirty],
+  )
+
+  // The single animation loop: ease every peer toward its target, fade the name
+  // tag on stillness, fade-out and prune anyone who left or went stale.
+  useEffect(() => {
+    let raf = 0
+    const tick = () => {
+      const layer = layerRef.current
+      if (layer) {
+        const r = layer.getBoundingClientRect()
+        const now = Date.now()
+        let pruned = false
+        for (const [id, t] of targets.current) {
+          if ((t.gone && t.fade <= 0.02) || now - t.lastSeen > CURSOR_TUNING.staleMs) {
+            targets.current.delete(id)
+            pruned = true
+            continue
+          }
+          const tx = t.x * r.width
+          const ty = t.y * r.height
+          const moved = Math.abs(tx - t.cx) + Math.abs(ty - t.cy) > 0.5
+          t.cx += (tx - t.cx) * CURSOR_TUNING.lerp
+          t.cy += (ty - t.cy) * CURSOR_TUNING.lerp
+          if (moved) t.lastMoveAt = now
+          if (t.gone) t.fade = Math.max(0, t.fade - 16 / CURSOR_TUNING.leaveFadeMs)
+          if (t.el) {
+            t.el.style.transform = `translate3d(${t.cx.toFixed(1)}px, ${t.cy.toFixed(1)}px, 0)`
+            t.el.style.opacity = t.gone ? t.fade.toFixed(2) : "1"
+          }
+          if (t.labelEl) {
+            const hideLabel = !t.gone && now - t.lastMoveAt > CURSOR_TUNING.labelIdleMs
+            t.labelEl.style.opacity = hideLabel ? "0" : "1"
+          }
+        }
+        if (pruned) markRosterDirty()
+      }
+      raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [markRosterDirty])
+
+  // Local focus/idle/leave: blur, tab-hide, idle, or unload all retire our cursor
+  // for peers immediately; a slow re-send keeps a still-but-present pointer alive.
+  useEffect(() => {
+    const onHide = () => {
+      if (document.hidden) sendLeave()
+    }
+    const onBlur = () => {
+      if (blurTimer.current) clearTimeout(blurTimer.current)
+      blurTimer.current = setTimeout(sendLeave, CURSOR_TUNING.blurDebounceMs)
+    }
+    const onFocus = () => {
+      if (blurTimer.current) clearTimeout(blurTimer.current)
+    }
+    document.addEventListener("visibilitychange", onHide)
+    window.addEventListener("blur", onBlur)
+    window.addEventListener("focus", onFocus)
+    window.addEventListener("pagehide", sendLeave)
+    const resend = setInterval(() => {
+      if (live.current && xy.current) sendCursor()
+    }, CURSOR_TUNING.resendMs)
+    return () => {
+      document.removeEventListener("visibilitychange", onHide)
+      window.removeEventListener("blur", onBlur)
+      window.removeEventListener("focus", onFocus)
+      window.removeEventListener("pagehide", sendLeave)
+      clearInterval(resend)
+      if (idleTimer.current) clearTimeout(idleTimer.current)
+      if (blurTimer.current) clearTimeout(blurTimer.current)
+    }
+  }, [sendLeave, sendCursor])
+
+  return {
+    onPointerMove,
+    onPointerLeave,
+    onTap,
+    paintFrame,
+    layer: { ref: layerRef, roster, ripples, register },
+  }
+}

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom"
 import { toast } from "sonner"
 import { API_BASE, ApiError, api, type Comment } from "@/api"
 import { useIsMobile } from "@/components"
+import { CursorButton } from "@/components/cursor/cursor-button"
 import { Icon } from "@/components/icons"
 import { useTopBarSlot } from "@/components/shell-context"
 import { useAuth } from "@/ctx"
@@ -111,6 +112,8 @@ export function Artifact() {
     version,
     hoverThread,
     onPointerMove: live.onPointerMove,
+    onPointerLeave: live.onPointerLeave,
+    onTap: live.onTap,
     setHoverThread,
     setActiveThread,
     setPanel,
@@ -260,6 +263,7 @@ export function Artifact() {
         createPortal(
           <>
             {!isMobile && <Presence viewers={live.viewers} self={me?.name ?? me?.email ?? ""} />}
+            {!isMobile && <CursorButton />}
             {!isAnon && (
               <ArtifactTopBar
                 shortId={shortId}
@@ -375,7 +379,7 @@ export function Artifact() {
                 deck={deck}
                 frameRef={frame}
                 presentWrapRef={presentWrap}
-                cursorLayerRef={live.cursorLayer}
+                cursor={live.cursor}
                 onFrameLoad={onFrameLoad}
                 onToggleDiff={() => setView(view === "diff" ? "preview" : "diff")}
                 onRestore={() => restore(shown)}

--- a/apps/web/src/pages/artifact/use-artifact-frame.ts
+++ b/apps/web/src/pages/artifact/use-artifact-frame.ts
@@ -31,11 +31,13 @@ export function useArtifactFrame(p: {
   version: number | undefined
   hoverThread: string | null
   onPointerMove: (x: number, y: number) => void
+  onPointerLeave: () => void
+  onTap: (x: number, y: number) => void
   setHoverThread: Dispatch<SetStateAction<string | null>>
   setActiveThread: Dispatch<SetStateAction<string | null>>
   setPanel: Dispatch<SetStateAction<Panel>>
 }) {
-  const { comments, shortId, version, hoverThread, onPointerMove } = p
+  const { comments, shortId, version, hoverThread, onPointerMove, onPointerLeave, onTap } = p
   const { setHoverThread, setActiveThread, setPanel } = p
   const frame = useRef<HTMLIFrameElement>(null)
   const presentWrap = useRef<HTMLDivElement>(null)
@@ -89,11 +91,15 @@ export function useArtifactFrame(p: {
         setPanel((cur) => (cur === "open" ? cur : "open"))
       } else if (d.type === "cursor" && typeof d.x === "number" && typeof d.y === "number") {
         onPointerMove(d.x, d.y)
+      } else if (d.type === "cursor-tap" && typeof d.x === "number" && typeof d.y === "number") {
+        onTap(d.x, d.y)
+      } else if (d.type === "cursor-leave") {
+        onPointerLeave()
       }
     }
     window.addEventListener("message", onMsg)
     return () => window.removeEventListener("message", onMsg)
-  }, [onPointerMove, setHoverThread, setActiveThread, setPanel])
+  }, [onPointerMove, onPointerLeave, onTap, setHoverThread, setActiveThread, setPanel])
 
   // Two-way hover: emphasize the matching highlight in the doc when a comment
   // card is hovered (the inbound anchor-hover sets the same state the other way).

--- a/apps/web/src/pages/artifact/use-artifact-live.ts
+++ b/apps/web/src/pages/artifact/use-artifact-live.ts
@@ -1,21 +1,20 @@
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { API_BASE, api } from "@/api"
+import { useLiveCursors } from "./cursors/use-live-cursors"
 
 type Me = { name?: string | null; email?: string | null } | null
-
-type CursorMsg = { id: string; name?: string; color?: string; x: number; y: number }
 
 /**
  * Everything realtime on the artifact page, kept out of the page component:
  *  - presence ("who's viewing" — anon shows as a server handle), heartbeated;
- *  - live multiplayer cursors (Google-Docs/Figma style) — the sandboxed iframe
- *    relays pointer moves out via postMessage, we publish ours (throttled) and
- *    paint peers as an overlay over the frame;
+ *  - live multiplayer cursors — delegated to {@link useLiveCursors}, which owns
+ *    the overlay, the smooth motion, and the focus/idle/leave behaviour; here we
+ *    just feed it the cursor frames off the shared SSE stream;
  *  - the SSE stream that refetches comments + reloads on a new version;
  *  - one view record per open.
  *
- * The page feeds pointer moves in (`onPointerMove`, from the iframe message
- * bridge) and reads `viewers` + the `cursorLayer` ref back out.
+ * The page feeds pointer moves/leave/tap in (from the iframe message bridge) and
+ * reads `viewers` + the `cursor` overlay handle back out.
  */
 export function useArtifactLive(opts: {
   shortId: string
@@ -25,86 +24,8 @@ export function useArtifactLive(opts: {
 }) {
   const { shortId, me, onComment, onVersion } = opts
   const [viewers, setViewers] = useState<string[]>([])
-
-  // Stable per-tab cursor identity: a random id + a hashed hue, so peers can tell
-  // cursors apart without any account.
-  const cursorLayer = useRef<HTMLDivElement>(null)
-  const self = useRef<{ id: string; color: string }>({ id: "", color: "" })
-  if (!self.current.id) {
-    const id = Math.random().toString(36).slice(2, 9)
-    let h = 0
-    for (const ch of id) h = (h * 31 + ch.charCodeAt(0)) % 360
-    self.current = { id, color: `hsl(${h} 72% 52%)` } // tokens-ignore: per-peer identity hue (hashed), not a theme color
-  }
-  const xy = useRef<[number, number] | null>(null)
-  const sentAt = useRef(0)
-  const peers = useRef(new Map<string, HTMLDivElement>())
-  const timers = useRef(new Map<string, ReturnType<typeof setTimeout>>())
-
-  const sendCursor = useCallback(() => {
-    const pt = xy.current
-    if (!pt) return
-    sentAt.current = Date.now()
-    fetch(`${API_BASE}/v1/artifacts/${shortId}/cursor`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      credentials: "include",
-      body: JSON.stringify({
-        id: self.current.id,
-        name: me?.name ?? me?.email ?? "Guest",
-        color: self.current.color,
-        x: pt[0],
-        y: pt[1],
-      }),
-    }).catch(() => {})
-  }, [shortId, me])
-
-  // The iframe forwards the local pointer; we throttle outgoing publishes.
-  const onPointerMove = useCallback(
-    (x: number, y: number) => {
-      xy.current = [x, y]
-      if (Date.now() - sentAt.current >= 45) sendCursor()
-    },
-    [sendCursor],
-  )
-
-  const showPeer = useCallback((d: CursorMsg) => {
-    if (d.id === self.current.id) return
-    const layer = cursorLayer.current
-    if (!layer) return
-    let el = peers.current.get(d.id)
-    if (!el) {
-      el = document.createElement("div")
-      el.className =
-        "pointer-events-none absolute left-0 top-0 z-30 transition-[transform,opacity] duration-100"
-      // tokens-ignore: #fff is the fixed white cursor outline + label text (contrast on any artifact bg), not a theme color
-      el.innerHTML =
-        '<svg width="20" height="20" viewBox="0 0 16 20"><path d="M1 1 L1 16 L5 12.5 L8 19 L10.5 18 L7.5 11.5 L13 11.5 Z" stroke="#fff" stroke-width="1.3" stroke-linejoin="round"/></svg><b style="position:absolute;left:13px;top:13px;padding:1px 6px;border-radius:5px;color:#fff;font:600 10.5px ui-sans-serif,system-ui;white-space:nowrap"></b>' // tokens-ignore
-      layer.appendChild(el)
-      peers.current.set(d.id, el)
-    }
-    const color = d.color || "#655999" // tokens-ignore: lavender fallback only if a peer sends no color
-    const svg = el.querySelector("svg")
-    if (svg) (svg as SVGElement).style.fill = color
-    const tag = el.querySelector("b")
-    if (tag) {
-      tag.textContent = d.name || "Guest"
-      ;(tag as HTMLElement).style.background = color
-    }
-    const r = layer.getBoundingClientRect()
-    el.style.transform = `translate(${(d.x * r.width).toFixed(1)}px, ${(d.y * r.height).toFixed(1)}px)`
-    el.style.opacity = "1"
-    const prev = timers.current.get(d.id)
-    if (prev) clearTimeout(prev)
-    timers.current.set(
-      d.id,
-      setTimeout(() => {
-        peers.current.get(d.id)?.remove()
-        peers.current.delete(d.id)
-        timers.current.delete(d.id)
-      }, 8000),
-    )
-  }, [])
+  const cursors = useLiveCursors(shortId)
+  const { paintFrame } = cursors
 
   // The live stream: comment churn + new versions refetch/reload; presence and
   // peer cursors paint directly.
@@ -126,17 +47,16 @@ export function useArtifactLive(opts: {
     })
     ev.addEventListener("cursor", (e) => {
       try {
-        showPeer(JSON.parse((e as MessageEvent).data))
+        paintFrame(JSON.parse((e as MessageEvent).data))
       } catch {
         /* ignore malformed frames */
       }
     })
     return () => ev.close()
-  }, [shortId, onComment, onVersion, showPeer])
+  }, [shortId, onComment, onVersion, paintFrame])
 
   // Announce we're viewing (anon shows up by their server handle — Google-Docs
-  // style), keep the heartbeat alive (TTL 45s), and re-send our cursor so a still
-  // pointer doesn't fade out for peers.
+  // style) and keep the heartbeat alive (TTL 45s).
   useEffect(() => {
     const name = me ? (me.name ?? me.email ?? "Guest") : "Guest"
     const beat = () =>
@@ -146,14 +66,8 @@ export function useArtifactLive(opts: {
         .catch(() => {})
     beat()
     const t = setInterval(beat, 20_000)
-    const ct = setInterval(() => {
-      if (xy.current) sendCursor()
-    }, 3000)
-    return () => {
-      clearInterval(t)
-      clearInterval(ct)
-    }
-  }, [shortId, me, sendCursor])
+    return () => clearInterval(t)
+  }, [shortId, me])
 
   // Record one view per artifact open.
   const recorded = useRef("")
@@ -163,5 +77,11 @@ export function useArtifactLive(opts: {
     api.recordView(shortId).catch(() => {})
   }, [shortId])
 
-  return { viewers, cursorLayer, onPointerMove }
+  return {
+    viewers,
+    onPointerMove: cursors.onPointerMove,
+    onPointerLeave: cursors.onPointerLeave,
+    onTap: cursors.onTap,
+    cursor: cursors.layer,
+  }
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -10,7 +10,7 @@ import {
 import { type ReactNode, useEffect } from "react"
 import { AppShell } from "../components/app-shell"
 import { Toaster } from "../components/ui/sonner"
-import { AuthProvider, ThemeProvider } from "../ctx"
+import { AuthProvider, CursorPrefProvider, ThemeProvider } from "../ctx"
 import { queryClient } from "../lib/query-client"
 import { STORAGE_KEYS } from "../lib/storage-keys"
 import { reportWebVitals } from "../lib/vitals"
@@ -62,7 +62,9 @@ function RootComponent() {
       <QueryClientProvider client={queryClient}>
         <ThemeProvider>
           <AuthProvider>
-            <AppFrame />
+            <CursorPrefProvider>
+              <AppFrame />
+            </CursorPrefProvider>
           </AuthProvider>
         </ThemeProvider>
       </QueryClientProvider>

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -161,3 +161,17 @@
     white-space: nowrap;
   }
 }
+
+/* A peer's click ripple on the live-cursor overlay: a ring that expands from the
+   click point and fades once. Centered via the transform so percentage left/top
+   place the click point itself (see cursor-layer.tsx RippleDot). */
+@keyframes dock-cursor-ripple {
+  from {
+    opacity: 0.55;
+    transform: translate(-50%, -50%) scale(0.4);
+  }
+  to {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(1.9);
+  }
+}

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -49,6 +49,9 @@ export function reanchor(sel: QuoteSelector, text: string): Reanchor {
  *                 scroll            (live scroll offset — cards track their text)
  *                 anchor-click      (user clicked a highlight)
  *                 anchor-hover      (pointer entered/left a highlight)
+ *                 cursor            (live pointer position for multiplayer cursors)
+ *                 cursor-tap        (a click — peers ripple at this point)
+ *                 cursor-leave      (pointer left / frame blurred — drop our cursor)
  *  host → frame:  anchors           (paint highlights for these anchors)
  *                 focus-anchor      (scroll to + flash one anchor)
  *                 emphasize         (lift one anchor's highlight — host card hover)
@@ -77,12 +80,22 @@ document.addEventListener("selectionchange",function(){
   var s=window.getSelection();if(!s||s.isCollapsed)post({type:"select",selector:null,rect:null})});
 
 /* -- live cursor: throttled pointer position, viewport-normalized 0..1, so the
-      host can fan it out to other viewers as a multiplayer cursor -- */
+      host can fan it out to other viewers as a multiplayer cursor. Plus an
+      explicit leave (pointer left the doc / frame blurred / tab hidden) so peers
+      drop us at once instead of waiting the cursor out, and a tap on click so
+      peers can ripple where we acted. -- */
 var cT=0;
 document.addEventListener("mousemove",function(e){
   var n=Date.now();if(n-cT<40)return;cT=n;
   var w=window.innerWidth||1,h=window.innerHeight||1;
   post({type:"cursor",x:e.clientX/w,y:e.clientY/h})});
+document.addEventListener("mousedown",function(e){
+  var w=window.innerWidth||1,h=window.innerHeight||1;
+  post({type:"cursor-tap",x:e.clientX/w,y:e.clientY/h})});
+document.addEventListener("mouseleave",function(){post({type:"cursor-leave"})});
+window.addEventListener("blur",function(){post({type:"cursor-leave"})});
+document.addEventListener("visibilitychange",function(){
+  if(document.hidden)post({type:"cursor-leave"})});
 
 /* -- highlight styles (mark's default yellow is overridden) -- */
 var st=document.createElement("style");

--- a/scripts/check-design-tokens.mjs
+++ b/scripts/check-design-tokens.mjs
@@ -17,10 +17,16 @@ const TOKEN_SOURCE = new Set(["styles/globals.css", "styles.css"])
 // Files that carry raw color DATA, not theming — a logo doesn't theme, avatar
 // identity tints are a fixed categorical palette, and the theme picker must show
 // each theme's literal swatch color. These are the "right places" for a raw color.
+// The live-cursor files are the same shape: a viewer's chosen identity tint (and
+// the fixed white keyline / lift shadow) painted onto the multiplayer overlay.
 const ALLOW_FILES = new Set([
   "components/shared/logo.tsx",
   "components/shared/colored-avatar.tsx",
   "ctx.tsx",
+  "lib/cursors.ts",
+  "components/cursor/glyph.tsx",
+  "components/cursor/cursor-switch.tsx",
+  "pages/artifact/cursors/cursor-layer.tsx",
 ])
 
 const PALETTE =


### PR DESCRIPTION
Multiplayer cursors got the love they were missing. Three things people asked for, plus a bit of delight.

## What's better

**1. Idle cursors stop being silly.** A cursor now disappears the instant its owner loses focus — tab blur, tab hidden, pointer left the doc, 5s idle, or page unload all fire an explicit *leave* signal, so peers drop it at once instead of watching it linger ~8s on an abandoned tab.

**2. Better than a bare arrow.**
- Peers are painted by a single `requestAnimationFrame` loop that **eases (lerps)** toward each latest position, so cursors *glide* instead of teleporting between throttled samples.
- The **name tag fades** after a beat of stillness and comes back on movement (Notion-style), so a still screen stays clean.
- The **arrow itself is redrawn** with a white keyline and a soft lift shadow, so it reads on any artifact background.

**3. Pick your own cursor.** A per-browser **color + style** preference (refined arrow, or an **emoji** cursor). The picker lives in the account pod *and* on the artifact bar, so even anonymous public-link viewers can customize. Persisted in `localStorage` like the theme — no schema change, works without an account.

**Plus — click ripples.** A peer's click pulses a ring where they acted, so you feel others working in the doc.

## How it's built

Organized as a small **cursor domain** rather than piled into the live hook:

| File | Role |
|---|---|
| `apps/web/src/lib/cursors.ts` | Pure domain: `CursorPref`/`CursorFrame` types, curated palettes, and all animation tuning in one place |
| `apps/web/src/ctx.tsx` | `CursorPrefProvider` / `useCursorPref` (mirrors the theme provider) |
| `apps/web/src/components/cursor/*` | Shared visuals: `glyph.tsx` (arrow/emoji + name tag), `cursor-switch.tsx` picker, `cursor-button.tsx` trigger |
| `apps/web/src/pages/artifact/cursors/use-live-cursors.ts` | Realtime hook: focus/idle/leave state machine, targets + roster + ripples, the rAF loop, send helpers |
| `apps/web/src/pages/artifact/cursors/cursor-layer.tsx` | The overlay (`RemoteCursor` + ripple) |

Rendering stays cheap: **React only re-renders when the roster changes** (a peer joins, leaves, or restyles) or a ripple fires; every-frame motion is written straight to the DOM via refs.

**Wire protocol:** `kind` / `emoji` (a chosen look) and `gone` / `tap` (one-shot leave/click) ride the existing `/cursor` frame — length/enum-bounded, identity `name` still server-derived, and *no new anonymous gate* (the leave is a flag on an already-allowed route). New fields/flags flow through both the in-process and the Durable Object backplanes for free.

## Testing
- `apps/api/test/realtime.test.ts` — pins the frame contract (emoji passthrough + arrow default, gone/tap flags, server-derived name, out-of-bounds rejection).
- `apps/api/test/anonymous.test.ts` — asserts an anon viewer can retire their own cursor (leave needs no new gate).
- `apps/web/e2e/deep/cursors.deep.spec.ts` — two real browser contexts: a peer cursor appears over SSE, restyles to an emoji, and is removed on the leave signal; plus the self picker.

All green: typecheck, biome, the 4 custom guardrails, knip, and the full unit + e2e suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)