### PR TITLE
fix(deploy): close idle keep-alive sockets on shutdown so drain doesn't stall

### DIFF
--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -200,7 +200,16 @@ const shutdown = async (signal: string) => {
   }, 10_000).unref()
   stopWorker()
   if (pruneTimer) clearInterval(pruneTimer)
-  await new Promise<void>((resolve) => server.close(() => resolve()))
+  // server.close() stops accepting connections and resolves once existing ones end,
+  // but Node never closes IDLE keep-alive sockets on its own — a browser, a load
+  // balancer, or any client holding one keeps close() pending until the hard
+  // deadline force-exits (a 10s stall on every redeploy). closeIdleConnections drops
+  // those now; in-flight requests keep their socket and still drain.
+  const drained = new Promise<void>((resolve) => server.close(() => resolve()))
+  // `in` narrows the http2/https union @hono/node-server returns; our serve() is a
+  // plain http.Server, which has had closeIdleConnections since Node 18.2.
+  if ("closeIdleConnections" in server) server.closeIdleConnections()
+  await drained
   try {
     await closeStores()
   } catch (e) {


### PR DESCRIPTION
Follow-on to #120. #120 made SIGTERM actually reach the graceful-shutdown handler (node as PID 1). This fixes the handler itself.

## The stall
`shutdown()` does `await new Promise(r => server.close(() => r()))`. `server.close()` stops accepting new connections and resolves once existing connections end — but Node **never closes idle keep-alive sockets** on its own. A browser tab, a load balancer, or any client parking a keep-alive connection keeps `close()` pending until the 10s hard deadline force-exits with code 1.

So in production every redeploy / Fly auto-stop that landed while a keep-alive connection was parked stalled ~10 seconds and exited non-zero, even with zero in-flight work. I caught it re-testing the container: a plain `docker stop` after some signup/publish traffic hit `shutdown timed out; forcing exit`.

## The fix
Call `server.closeIdleConnections()` (Node 18.2+) right after `server.close()`: idle sockets drop immediately, in-flight requests keep their socket and still drain to completion. The `in` guard narrows the http2/https union `@hono/node-server`'s `serve()` returns to the plain `http.Server` we create (no cast, no suppression).

## Verification
Container repro — signup + publish + parked keep-alive traffic, then `docker stop -t 15`:
- **Before:** 10s wall time, `shutdown timed out; forcing exit` (exit 1).
- **After:** 0.15s wall time, clean `shutting down` -> `shutdown complete` (7ms drain).

Typecheck (node + worker) + biome + 198 api tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)