### PR TITLE
Workspace custom domains (Cloudflare for SaaS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,14 @@ DATA_DIR=./data
 # host's root — its own origin, a clean URL. Unset = subdomain serving off.
 # DOCK_SUBDOMAIN_BASE=dockd.app
 
+# Bring-your-own custom domains (hosted tier): let an owner attach their own domain
+# (launch.acme.com) to an artifact. Cloudflare for SaaS issues + renews the TLS cert;
+# the customer CNAMEs their domain at CF_SAAS_FALLBACK_ORIGIN. All three are required
+# to enable; unset = custom domains disabled (subdomains are unaffected).
+# CF_API_TOKEN=...                # scoped token: SSL for SaaS / custom-hostname edit
+# CF_ZONE_ID=...                  # the zone hosting your SaaS fallback origin
+# CF_SAAS_FALLBACK_ORIGIN=dock-saas.example.com
+
 # --- Abuse limits & quotas ------------------------------------------------
 # Per-IP rate limiting on auth + mutating routes is ON by default; set false to
 # disable (e.g. behind your own gateway). Turning it off also disables the

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -89,15 +89,18 @@ export function createApp(deps: AppDeps): Hono {
     })
   }
 
-  // ---- Domain mode (C1): vanity subdomains -------------------------------
-  // With a base domain configured, a request to `<label>.<base>` whose host is in
-  // the `domain` table serves that artifact at the host root: its own origin, no
-  // path prefix, the absolute-URL rewriting a no-op. Like the sandbox host, these
-  // vanity hosts serve ONLY artifact bytes + the anchor client, never the
-  // app/auth/API, and the app's own host is never matched. A vanity host is
-  // cross-origin, so the actor is anonymous: only public/link artifacts resolve,
-  // gated ones 404, a removed one 410.
+  // ---- Domain mode (C1): vanity subdomains + custom domains --------------
+  // A request whose Host is in the `domain` table (a `<label>.<base>` subdomain, or a
+  // bring-your-own custom domain registered via Cloudflare for SaaS) serves that
+  // artifact at the host root: its own origin, no path prefix, the absolute-URL
+  // rewriting a no-op. Like the sandbox host, these hosts serve ONLY artifact bytes +
+  // the anchor client, never the app/auth/API, and the app's own host is never
+  // matched. The host is cross-origin so the actor is anonymous: only public/link
+  // artifacts resolve, gated ones 404, a removed one 410, a not-yet-active custom
+  // domain falls through. No host cache needed: on the edge, Cloudflare only routes
+  // registered hostnames to the Worker, so the lookup surface is bounded.
   const subBase = deps.subdomainBase?.toLowerCase()
+  const customEnabled = !!deps.customDomains
   const appHostForSub = (() => {
     try {
       return new URL(deps.baseUrl).host.toLowerCase()
@@ -105,21 +108,20 @@ export function createApp(deps: AppDeps): Hono {
       return null
     }
   })()
-  if (subBase) {
+  if (subBase || customEnabled) {
     app.use("*", async (c, next) => {
       const host = (c.req.header("host") ?? new URL(c.req.url).host).toLowerCase().split(":")[0]
-      if (
-        !host ||
-        host === appHostForSub ||
-        (sandboxHost && host === sandboxHost.toLowerCase()) ||
-        host === subBase ||
-        !host.endsWith(`.${subBase}`)
-      )
+      if (!host || host === appHostForSub || (sandboxHost && host === sandboxHost.toLowerCase()))
         return next()
+      const isSub = !!subBase && host !== subBase && host.endsWith(`.${subBase}`)
+      // A custom-domain candidate is any other host, but only when custom domains are on.
+      if (!isSub && !customEnabled) return next()
       // The served HTML references /raw/dock-client.js; let raw + health through.
       if (c.req.path === "/healthz" || c.req.path.startsWith("/raw/")) return next()
       const record = await ctx.meta.getDomain(host)
-      if (!record) return c.text("not found", 404)
+      // Unknown subdomain → 404 (clearly ours); unknown/pending custom host → fall
+      // through so an unregistered host pointed at us never serves stale content.
+      if (!record || record.status !== "active") return isSub ? c.text("not found", 404) : next()
       const artifact = await ctx.meta.getArtifactById(record.artifact_id)
       if (!artifact || !(await ctx.authorize(c, "read", artifact))) return c.text("not found", 404)
       if (artifact.removed_at) return c.text(TOMBSTONE, 410)

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,3 +1,4 @@
+import { type ArtifactRecord, parseRef } from "@dock/core"
 import { type Context, Hono } from "hono"
 import { compress } from "hono/compress"
 import { type AppDeps, buildContext } from "./context"
@@ -23,6 +24,7 @@ import { sessionRoutes } from "./routes/session"
 import { sharingRoutes } from "./routes/sharing"
 import { webhookRoutes } from "./routes/webhooks"
 import { workspaceRoutes } from "./routes/workspace"
+import { workspaceDomainRoutes } from "./routes/workspace-domains"
 
 // Re-exported from its lib home so existing importers (and tests) keep working.
 export { isPublicHttpUrl } from "./lib/net"
@@ -89,16 +91,18 @@ export function createApp(deps: AppDeps): Hono {
     })
   }
 
-  // ---- Domain mode (C1): vanity subdomains + custom domains --------------
-  // A request whose Host is in the `domain` table (a `<label>.<base>` subdomain, or a
-  // bring-your-own custom domain registered via Cloudflare for SaaS) serves that
-  // artifact at the host root: its own origin, no path prefix, the absolute-URL
-  // rewriting a no-op. Like the sandbox host, these hosts serve ONLY artifact bytes +
-  // the anchor client, never the app/auth/API, and the app's own host is never
-  // matched. The host is cross-origin so the actor is anonymous: only public/link
-  // artifacts resolve, gated ones 404, a removed one 410, a not-yet-active custom
-  // domain falls through. No host cache needed: on the edge, Cloudflare only routes
-  // registered hostnames to the Worker, so the lookup surface is bounded.
+  // ---- Domain mode (C1): vanity subdomains + workspace custom domains -----
+  // A request whose Host is in the `domain` table serves artifact bytes off the app
+  // origin (only bytes + the anchor client, never the app/auth/API; the app's own
+  // host is never matched). The host is cross-origin so the actor is anonymous: only
+  // public/link artifacts resolve, gated ones 404, removed ones 410. Two shapes,
+  // chosen by whether the row is bound to one artifact — this keeps per-artifact
+  // custom domains + wildcard subdomains addable later with no dispatch change:
+  //   · artifact-bound (subdomain today)  → serve that artifact at the host root.
+  //   · workspace domain (artifact_id null) → serve `<host>/<ref>`, scoped to the
+  //     domain's workspace so one tenant's domain can't serve another's artifact.
+  // No host cache needed: on the edge, Cloudflare only routes registered hostnames
+  // to the Worker, so the lookup surface is bounded.
   const subBase = deps.subdomainBase?.toLowerCase()
   const customEnabled = !!deps.customDomains
   const appHostForSub = (() => {
@@ -109,12 +113,24 @@ export function createApp(deps: AppDeps): Hono {
     }
   })()
   if (subBase || customEnabled) {
+    const serveArtifact = async (
+      c: Context,
+      a: ArtifactRecord,
+      n: number,
+      prefix: string,
+      rawPath: string,
+    ) => {
+      if (!(await ctx.authorize(c, "read", a))) return c.text("not found", 404)
+      if (a.removed_at) return c.text(TOMBSTONE, 410)
+      const version = await ctx.meta.getVersion(a.id, n)
+      if (!version) return c.text("not found", 404)
+      return serveContent(c, ctx.blobs, version, a.title, prefix, rawPath)
+    }
     app.use("*", async (c, next) => {
       const host = (c.req.header("host") ?? new URL(c.req.url).host).toLowerCase().split(":")[0]
       if (!host || host === appHostForSub || (sandboxHost && host === sandboxHost.toLowerCase()))
         return next()
       const isSub = !!subBase && host !== subBase && host.endsWith(`.${subBase}`)
-      // A custom-domain candidate is any other host, but only when custom domains are on.
       if (!isSub && !customEnabled) return next()
       // The served HTML references /raw/dock-client.js; let raw + health through.
       if (c.req.path === "/healthz" || c.req.path.startsWith("/raw/")) return next()
@@ -122,13 +138,27 @@ export function createApp(deps: AppDeps): Hono {
       // Unknown subdomain → 404 (clearly ours); unknown/pending custom host → fall
       // through so an unregistered host pointed at us never serves stale content.
       if (!record || record.status !== "active") return isSub ? c.text("not found", 404) : next()
-      const artifact = await ctx.meta.getArtifactById(record.artifact_id)
-      if (!artifact || !(await ctx.authorize(c, "read", artifact))) return c.text("not found", 404)
-      if (artifact.removed_at) return c.text(TOMBSTONE, 410)
-      const version = await ctx.meta.getVersion(artifact.id, artifact.current_version)
-      if (!version) return c.text("not found", 404)
-      const reqPath = decodeURIComponent(c.req.path.replace(/^\/+/, ""))
-      return serveContent(c, ctx.blobs, version, artifact.title, "/", reqPath)
+      if (record.artifact_id) {
+        // Artifact-bound host (subdomain today): serve that one artifact at the root.
+        const a = await ctx.meta.getArtifactById(record.artifact_id)
+        if (!a) return c.text("not found", 404)
+        return serveArtifact(
+          c,
+          a,
+          a.current_version,
+          "/",
+          decodeURIComponent(c.req.path.replace(/^\/+/, "")),
+        )
+      }
+      // Workspace domain: `<host>/<ref>/<sub>` → the workspace's artifact at <ref>,
+      // scoped to the domain's org so a tenant can't serve another tenant's artifact.
+      const segs = c.req.path.replace(/^\/+/, "").split("/")
+      const ref = segs[0] ?? ""
+      if (!ref) return c.text("not found", 404)
+      const a = await ctx.meta.getByShortId(parseRef(ref).shortId)
+      if (!a || a.org_id !== record.org_id) return c.text("not found", 404)
+      const n = parseRef(ref).version ?? a.current_version
+      return serveArtifact(c, a, n, `/${ref}/`, decodeURIComponent(segs.slice(1).join("/")))
     })
   }
 
@@ -230,6 +260,7 @@ export function createApp(deps: AppDeps): Hono {
     rawRoutes,
     embedRoutes,
     domainRoutes,
+    workspaceDomainRoutes,
   ])
     app.route("/", routes(ctx))
 

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -18,6 +18,7 @@ import type { Context } from "hono"
 import { getCookie, setCookie } from "hono/cookie"
 import type { Auth } from "./auth-config"
 import { type Backplane, createInProcessBackplane } from "./bus"
+import type { CustomDomainProvider } from "./lib/cloudflare-saas"
 import { safeEqual, sha256, unlockCookie, unlockToken } from "./lib/crypto"
 import { VIEWER_COOKIE, WS_COOKIE } from "./lib/http"
 import { makeKeyedLimiter } from "./lib/rate-limit"
@@ -122,6 +123,12 @@ export interface AppDeps {
    * the host root (domain mode). Unset = subdomain serving off.
    */
   subdomainBase?: string
+  /**
+   * Bring-your-own custom domains (hosted tier). When set, an owner can attach their
+   * own hostname to an artifact and Cloudflare for SaaS issues + renews the TLS cert.
+   * Unset = custom domains disabled (those endpoints 501). Subdomains work without it.
+   */
+  customDomains?: CustomDomainProvider
   /**
    * The SPA and API are on different sites (hosted split). Makes first-party
    * cookies we set here — currently the anonymous-viewer id — `SameSite=None;

--- a/apps/api/src/lib/cloudflare-saas.ts
+++ b/apps/api/src/lib/cloudflare-saas.ts
@@ -1,0 +1,109 @@
+import type { DomainStatus } from "@dock/core"
+
+/**
+ * Cloudflare for SaaS (Custom Hostnames) — the BYO-custom-domain provider. Cloudflare
+ * owns the hard part (issuing, validating, and renewing the per-domain TLS cert); we
+ * just register the hostname, surface the DNS the customer must add, and poll status.
+ * Uses only `fetch`, so it runs in both the Node and the Workers entry.
+ * Docs: https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/
+ */
+export interface CustomDomainDnsRecord {
+  type: "CNAME" | "TXT"
+  name: string
+  value: string
+}
+export interface CustomDomainState {
+  /** Cloudflare custom-hostname id (stored for refresh + teardown). */
+  cfHostnameId: string
+  status: DomainStatus
+  /** DNS records the customer adds at their registrar to point + validate the domain. */
+  records: CustomDomainDnsRecord[]
+}
+export interface CustomDomainProvider {
+  /** The CNAME target customers point their domain at (the SaaS fallback origin). */
+  readonly cnameTarget: string
+  create(host: string): Promise<CustomDomainState>
+  refresh(cfHostnameId: string): Promise<CustomDomainState>
+  remove(cfHostnameId: string): Promise<void>
+}
+
+interface CfResult {
+  id: string
+  hostname?: string
+  status?: string
+  ssl?: { status?: string }
+  ownership_verification?: { type?: string; name?: string; value?: string }
+}
+
+const toState = (cnameTarget: string, host: string, r: CfResult): CustomDomainState => {
+  const records: CustomDomainDnsRecord[] = [{ type: "CNAME", name: host, value: cnameTarget }]
+  const ov = r.ownership_verification
+  if (ov?.type === "txt" && ov.name && ov.value)
+    records.push({ type: "TXT", name: ov.name, value: ov.value })
+  const ssl = r.ssl?.status
+  const status: DomainStatus =
+    r.status === "active" && ssl === "active"
+      ? "active"
+      : ssl === "validation_timed_out" || r.status === "blocked" || r.status === "moved"
+        ? "error"
+        : "pending"
+  return { cfHostnameId: r.id, status, records }
+}
+
+export const cloudflareCustomDomains = (cfg: {
+  apiToken: string
+  zoneId: string
+  cnameTarget: string
+  fetchImpl?: typeof fetch
+}): CustomDomainProvider => {
+  const f = cfg.fetchImpl ?? fetch
+  const base = `https://api.cloudflare.com/client/v4/zones/${cfg.zoneId}/custom_hostnames`
+  const headers = { authorization: `Bearer ${cfg.apiToken}`, "content-type": "application/json" }
+
+  // CF wraps every response in {success, result, errors}. Throw the first error so the
+  // route can turn it into a clean 4xx/5xx rather than leaking a half-parsed body.
+  const call = async (url: string, init?: RequestInit): Promise<CfResult> => {
+    const res = await f(url, { ...init, headers })
+    const body = (await res.json().catch(() => ({}))) as {
+      success?: boolean
+      result?: CfResult
+      errors?: { message?: string }[]
+    }
+    if (!res.ok || !body.success || !body.result)
+      throw new Error(body.errors?.[0]?.message ?? `cloudflare error (${res.status})`)
+    return body.result
+  }
+
+  return {
+    cnameTarget: cfg.cnameTarget,
+    async create(host) {
+      const result = await call(base, {
+        method: "POST",
+        body: JSON.stringify({ hostname: host, ssl: { method: "http", type: "dv" } }),
+      })
+      return toState(cfg.cnameTarget, host, result)
+    },
+    async refresh(cfHostnameId) {
+      const result = await call(`${base}/${cfHostnameId}`)
+      return toState(cfg.cnameTarget, result.hostname ?? "", result)
+    },
+    async remove(cfHostnameId) {
+      await call(`${base}/${cfHostnameId}`, { method: "DELETE" })
+    },
+  }
+}
+
+/** Build the provider from env, or undefined when Cloudflare for SaaS isn't configured
+ *  (custom domains then 501). Shared by the Node and Workers entries. */
+export const customDomainsFromEnv = (
+  env: { CF_API_TOKEN?: string; CF_ZONE_ID?: string; CF_SAAS_FALLBACK_ORIGIN?: string },
+  fetchImpl?: typeof fetch,
+): CustomDomainProvider | undefined =>
+  env.CF_API_TOKEN && env.CF_ZONE_ID && env.CF_SAAS_FALLBACK_ORIGIN
+    ? cloudflareCustomDomains({
+        apiToken: env.CF_API_TOKEN,
+        zoneId: env.CF_ZONE_ID,
+        cnameTarget: env.CF_SAAS_FALLBACK_ORIGIN,
+        fetchImpl,
+      })
+    : undefined

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -11,6 +11,7 @@ import { Pool } from "pg"
 import { createApp } from "./app"
 import { type AuthDb, makeAuth, migrateAuth } from "./auth-config"
 import { loadConfig, resolveAuthSecret, resolveDefaultOrg } from "./config"
+import { customDomainsFromEnv } from "./lib/cloudflare-saas"
 import { mountWeb } from "./lib/serve-web"
 import { log } from "./log"
 import { startWebhookWorker } from "./webhooks"
@@ -109,6 +110,8 @@ const app = createApp({
   crossSite: cfg.crossSite,
   // Vanity subdomains (domain mode): when set, name.<base> serves its artifact.
   subdomainBase: cfg.subdomainBase,
+  // BYO custom domains via Cloudflare for SaaS, when CF_* env is configured.
+  customDomains: customDomainsFromEnv(process.env),
   versionWindowMs: cfg.versionWindowMs,
   // Storage backstops: unset = unlimited (self-host stays open).
   maxArtifacts: cfg.maxArtifacts,

--- a/apps/api/src/routes/domains.ts
+++ b/apps/api/src/routes/domains.ts
@@ -25,21 +25,42 @@ const RESERVED = new Set([
 ])
 // A single DNS label: 1-63 chars, a-z0-9 and hyphens, not hyphen-edged.
 const LABEL = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
+// A fully-qualified domain (at least one dot), for bring-your-own custom domains.
+const FQDN = /^(?=.{1,253}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/
+
+const parseRecords = (v: string | null): unknown => {
+  if (!v) return undefined
+  try {
+    return JSON.parse(v)
+  } catch {
+    return undefined
+  }
+}
 
 /**
- * Vanity subdomains (domain mode C1, subdomain tier): assign `<label>.<base>` to an
- * artifact, list, and release. Gated on `share` (the same authority as visibility),
- * and only available when the server sets a base domain (DOCK_SUBDOMAIN_BASE).
- * Serving at the host root is handled by the host-dispatch middleware in app.ts.
+ * Domain mode (C1). Two tiers, same `domain` table + host-dispatch:
+ *  - vanity subdomains `<label>.<base>` (needs DOCK_SUBDOMAIN_BASE), always active.
+ *  - bring-your-own custom domains via Cloudflare for SaaS (needs `customDomains`):
+ *    registered as a CF custom hostname, `pending` until the cert + ownership validate.
+ * All mutations are gated on `share` (the same authority as visibility); serving at the
+ * host root is handled by the host-dispatch middleware in app.ts.
  */
 export const domainRoutes = (ctx: AppContext) => {
   const { meta, authorize } = ctx
   const base = ctx.deps.subdomainBase?.toLowerCase()
+  const cd = ctx.deps.customDomains
   const scheme = (() => {
     try {
       return new URL(ctx.deps.baseUrl).protocol
     } catch {
       return "https:"
+    }
+  })()
+  const appHost = (() => {
+    try {
+      return new URL(ctx.deps.baseUrl).host.toLowerCase()
+    } catch {
+      return null
     }
   })()
   const app = new Hono()
@@ -48,15 +69,22 @@ export const domainRoutes = (ctx: AppContext) => {
     host: d.host,
     url: `${scheme}//${d.host}`,
     kind: d.kind,
+    status: d.status,
+    records: parseRecords(d.verification),
     created_at: d.created_at,
   })
 
-  // The artifact's vanity hosts (and whether the server has a base configured).
+  // The artifact's hosts + what the server supports (drives the share UI).
   app.get("/v1/artifacts/:shortId/domains", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact || !(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
     const domains = await meta.getArtifactDomains(artifact.id)
-    return c.json({ base: base ?? null, domains: domains.map(toJson) })
+    return c.json({
+      base: base ?? null,
+      custom_enabled: !!cd,
+      cname_target: cd?.cnameTarget ?? null,
+      domains: domains.map(toJson),
+    })
   })
 
   // Claim `<label>.<base>` for the artifact. Idempotent if it is already yours.
@@ -86,7 +114,67 @@ export const domainRoutes = (ctx: AppContext) => {
     return c.json(toJson(created), 201)
   })
 
-  // Release a vanity host (scoped to the artifact's workspace).
+  // Attach a bring-your-own domain. Registers a Cloudflare custom hostname and stores
+  // it `pending` with the DNS records to display; it serves once CF validates the cert.
+  app.post("/v1/artifacts/:shortId/custom-domains", async (c) => {
+    if (!cd) return fail(c, 501, "custom domains are not enabled on this server")
+    const artifact = await meta.getByShortId(c.req.param("shortId"))
+    if (!artifact || !(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
+    if (!(await authorize(c, "share", artifact))) return fail(c, 403, "forbidden")
+    const body = await readJson(c, z.object({ host: z.string() }))
+    if (body instanceof Response) return body
+    const host = body.host.trim().toLowerCase().replace(/\.+$/, "")
+    if (!FQDN.test(host) || (base && host.endsWith(`.${base}`)) || host === appHost)
+      return fail(c, 400, "enter a valid domain you control")
+    const existing = await meta.getDomain(host)
+    if (existing)
+      return existing.artifact_id === artifact.id
+        ? c.json(toJson(existing))
+        : fail(c, 409, "that domain is already attached")
+    let state: Awaited<ReturnType<typeof cd.create>>
+    try {
+      state = await cd.create(host)
+    } catch (e) {
+      return fail(c, 502, e instanceof Error ? e.message : "couldn't register the domain")
+    }
+    const created = await meta.setDomain({
+      host,
+      artifact_id: artifact.id,
+      org_id: artifact.org_id,
+      kind: "custom",
+      status: state.status,
+      cf_hostname_id: state.cfHostnameId,
+      verification: JSON.stringify(state.records),
+    })
+    if (!created) {
+      await cd.remove(state.cfHostnameId).catch(() => {})
+      return fail(c, 409, "that domain is already attached")
+    }
+    return c.json({ ...toJson(created), cname_target: cd.cnameTarget }, 201)
+  })
+
+  // Re-check a custom domain's validation status against Cloudflare.
+  app.post("/v1/artifacts/:shortId/domains/:host/refresh", async (c) => {
+    const artifact = await meta.getByShortId(c.req.param("shortId"))
+    if (!artifact || !(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
+    if (!(await authorize(c, "share", artifact))) return fail(c, 403, "forbidden")
+    const existing = await meta.getDomain(c.req.param("host").toLowerCase())
+    if (!existing || existing.artifact_id !== artifact.id) return fail(c, 404, "not found")
+    if (existing.kind !== "custom" || !existing.cf_hostname_id || !cd)
+      return c.json(toJson(existing))
+    try {
+      const state = await cd.refresh(existing.cf_hostname_id)
+      const updated = await meta.updateDomain(existing.host, {
+        status: state.status,
+        verification: JSON.stringify(state.records),
+      })
+      return c.json(toJson(updated ?? existing))
+    } catch {
+      return c.json(toJson(existing))
+    }
+  })
+
+  // Release a host (scoped to the artifact's workspace); tears down the CF hostname too.
   app.delete("/v1/artifacts/:shortId/domains/:host", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact || !(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
@@ -94,6 +182,8 @@ export const domainRoutes = (ctx: AppContext) => {
     const host = c.req.param("host").toLowerCase()
     const existing = await meta.getDomain(host)
     if (!existing || existing.artifact_id !== artifact.id) return fail(c, 404, "not found")
+    if (existing.kind === "custom" && existing.cf_hostname_id && cd)
+      await cd.remove(existing.cf_hostname_id).catch(() => {})
     await meta.deleteDomain(host, artifact.org_id)
     return c.json({ ok: true })
   })

--- a/apps/api/src/routes/domains.ts
+++ b/apps/api/src/routes/domains.ts
@@ -1,4 +1,4 @@
-import type { DomainRecord } from "@dock/core"
+import type { ArtifactRecord, DomainRecord } from "@dock/core"
 import { Hono } from "hono"
 import { z } from "zod"
 import type { AppContext } from "../context"
@@ -25,42 +25,24 @@ const RESERVED = new Set([
 ])
 // A single DNS label: 1-63 chars, a-z0-9 and hyphens, not hyphen-edged.
 const LABEL = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
-// A fully-qualified domain (at least one dot), for bring-your-own custom domains.
-const FQDN = /^(?=.{1,253}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/
 
-const parseRecords = (v: string | null): unknown => {
-  if (!v) return undefined
-  try {
-    return JSON.parse(v)
-  } catch {
-    return undefined
-  }
-}
+/** The artifact's ref (`<short_id>-<slug>`), the path segment in its URLs. */
+const refOf = (a: ArtifactRecord): string => (a.slug ? `${a.short_id}-${a.slug}` : a.short_id)
 
 /**
- * Domain mode (C1). Two tiers, same `domain` table + host-dispatch:
- *  - vanity subdomains `<label>.<base>` (needs DOCK_SUBDOMAIN_BASE), always active.
- *  - bring-your-own custom domains via Cloudflare for SaaS (needs `customDomains`):
- *    registered as a CF custom hostname, `pending` until the cert + ownership validate.
- * All mutations are gated on `share` (the same authority as visibility); serving at the
- * host root is handled by the host-dispatch middleware in app.ts.
+ * Per-artifact vanity subdomains (`<label>.<base>`, needs DOCK_SUBDOMAIN_BASE): claim,
+ * list, release; gated on `share`. Workspace custom domains are managed separately
+ * (workspace-domains.ts) but surfaced here read-only as "also at <domain>/<ref>", so
+ * the share dialog shows every URL an artifact is reachable at. Serving is in app.ts.
  */
 export const domainRoutes = (ctx: AppContext) => {
   const { meta, authorize } = ctx
   const base = ctx.deps.subdomainBase?.toLowerCase()
-  const cd = ctx.deps.customDomains
   const scheme = (() => {
     try {
       return new URL(ctx.deps.baseUrl).protocol
     } catch {
       return "https:"
-    }
-  })()
-  const appHost = (() => {
-    try {
-      return new URL(ctx.deps.baseUrl).host.toLowerCase()
-    } catch {
-      return null
     }
   })()
   const app = new Hono()
@@ -70,20 +52,25 @@ export const domainRoutes = (ctx: AppContext) => {
     url: `${scheme}//${d.host}`,
     kind: d.kind,
     status: d.status,
-    records: parseRecords(d.verification),
     created_at: d.created_at,
   })
 
-  // The artifact's hosts + what the server supports (drives the share UI).
+  // The artifact's subdomains (manageable) + the workspace's active custom domains
+  // (read-only here; managed in workspace settings), each with this artifact's URL.
   app.get("/v1/artifacts/:shortId/domains", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact || !(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
-    const domains = await meta.getArtifactDomains(artifact.id)
+    const [subs, wsDomains] = await Promise.all([
+      meta.getArtifactDomains(artifact.id),
+      meta.getWorkspaceDomains(artifact.org_id),
+    ])
+    const ref = refOf(artifact)
     return c.json({
       base: base ?? null,
-      custom_enabled: !!cd,
-      cname_target: cd?.cnameTarget ?? null,
-      domains: domains.map(toJson),
+      domains: subs.map(toJson),
+      workspace_domains: wsDomains
+        .filter((d) => d.status === "active")
+        .map((d) => ({ host: d.host, url: `${scheme}//${d.host}/${ref}` })),
     })
   })
 
@@ -114,67 +101,7 @@ export const domainRoutes = (ctx: AppContext) => {
     return c.json(toJson(created), 201)
   })
 
-  // Attach a bring-your-own domain. Registers a Cloudflare custom hostname and stores
-  // it `pending` with the DNS records to display; it serves once CF validates the cert.
-  app.post("/v1/artifacts/:shortId/custom-domains", async (c) => {
-    if (!cd) return fail(c, 501, "custom domains are not enabled on this server")
-    const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || !(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
-    if (!(await authorize(c, "share", artifact))) return fail(c, 403, "forbidden")
-    const body = await readJson(c, z.object({ host: z.string() }))
-    if (body instanceof Response) return body
-    const host = body.host.trim().toLowerCase().replace(/\.+$/, "")
-    if (!FQDN.test(host) || (base && host.endsWith(`.${base}`)) || host === appHost)
-      return fail(c, 400, "enter a valid domain you control")
-    const existing = await meta.getDomain(host)
-    if (existing)
-      return existing.artifact_id === artifact.id
-        ? c.json(toJson(existing))
-        : fail(c, 409, "that domain is already attached")
-    let state: Awaited<ReturnType<typeof cd.create>>
-    try {
-      state = await cd.create(host)
-    } catch (e) {
-      return fail(c, 502, e instanceof Error ? e.message : "couldn't register the domain")
-    }
-    const created = await meta.setDomain({
-      host,
-      artifact_id: artifact.id,
-      org_id: artifact.org_id,
-      kind: "custom",
-      status: state.status,
-      cf_hostname_id: state.cfHostnameId,
-      verification: JSON.stringify(state.records),
-    })
-    if (!created) {
-      await cd.remove(state.cfHostnameId).catch(() => {})
-      return fail(c, 409, "that domain is already attached")
-    }
-    return c.json({ ...toJson(created), cname_target: cd.cnameTarget }, 201)
-  })
-
-  // Re-check a custom domain's validation status against Cloudflare.
-  app.post("/v1/artifacts/:shortId/domains/:host/refresh", async (c) => {
-    const artifact = await meta.getByShortId(c.req.param("shortId"))
-    if (!artifact || !(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
-    if (!(await authorize(c, "share", artifact))) return fail(c, 403, "forbidden")
-    const existing = await meta.getDomain(c.req.param("host").toLowerCase())
-    if (!existing || existing.artifact_id !== artifact.id) return fail(c, 404, "not found")
-    if (existing.kind !== "custom" || !existing.cf_hostname_id || !cd)
-      return c.json(toJson(existing))
-    try {
-      const state = await cd.refresh(existing.cf_hostname_id)
-      const updated = await meta.updateDomain(existing.host, {
-        status: state.status,
-        verification: JSON.stringify(state.records),
-      })
-      return c.json(toJson(updated ?? existing))
-    } catch {
-      return c.json(toJson(existing))
-    }
-  })
-
-  // Release a host (scoped to the artifact's workspace); tears down the CF hostname too.
+  // Release one of the artifact's subdomains (scoped to this artifact).
   app.delete("/v1/artifacts/:shortId/domains/:host", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact || !(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
@@ -182,8 +109,6 @@ export const domainRoutes = (ctx: AppContext) => {
     const host = c.req.param("host").toLowerCase()
     const existing = await meta.getDomain(host)
     if (!existing || existing.artifact_id !== artifact.id) return fail(c, 404, "not found")
-    if (existing.kind === "custom" && existing.cf_hostname_id && cd)
-      await cd.remove(existing.cf_hostname_id).catch(() => {})
     await meta.deleteDomain(host, artifact.org_id)
     return c.json({ ok: true })
   })

--- a/apps/api/src/routes/workspace-domains.ts
+++ b/apps/api/src/routes/workspace-domains.ts
@@ -1,0 +1,124 @@
+import type { DomainRecord } from "@dock/core"
+import { Hono } from "hono"
+import { z } from "zod"
+import type { AppContext } from "../context"
+import { fail, readJson } from "../lib/http"
+
+// A fully-qualified domain (at least one dot).
+const FQDN = /^(?=.{1,253}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/
+
+const parseRecords = (v: string | null): unknown => {
+  if (!v) return undefined
+  try {
+    return JSON.parse(v)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Workspace custom domains (the easy "slap your own URL on it" path). An admin
+ * attaches their domain to the workspace once; Cloudflare for SaaS issues + renews
+ * the cert, and every artifact is then served at `<domain>/<ref>` (the host-dispatch
+ * in app.ts does the routing). Bound to the workspace (org), not a single artifact,
+ * so the `domain` row has a null artifact_id. Gated on workspace `manage`.
+ */
+export const workspaceDomainRoutes = (ctx: AppContext) => {
+  const { meta, activeWorkspace, workspaceCan } = ctx
+  const cd = ctx.deps.customDomains
+  const app = new Hono()
+
+  const toJson = (d: DomainRecord) => ({
+    host: d.host,
+    status: d.status,
+    records: parseRecords(d.verification),
+    created_at: d.created_at,
+  })
+
+  // The workspace's custom domains + whether the server supports them.
+  app.get("/v1/workspace/domains", async (c) => {
+    const org = await activeWorkspace(c)
+    const domains = await meta.getWorkspaceDomains(org)
+    return c.json({
+      enabled: !!cd,
+      cname_target: cd?.cnameTarget ?? null,
+      domains: domains.map(toJson),
+    })
+  })
+
+  // Attach a domain to the workspace. Registers a Cloudflare custom hostname and
+  // stores it `pending` with the DNS to display; it serves once CF validates the cert.
+  app.post("/v1/workspace/domains", async (c) => {
+    if (!cd) return fail(c, 501, "custom domains are not enabled on this server")
+    if (!(await workspaceCan(c, "manage"))) return fail(c, 403, "forbidden")
+    const org = await activeWorkspace(c)
+    const body = await readJson(c, z.object({ host: z.string() }))
+    if (body instanceof Response) return body
+    const host = body.host
+      .trim()
+      .toLowerCase()
+      .replace(/^https?:\/\//, "")
+      .replace(/\/.*$/, "")
+      .replace(/\.+$/, "")
+    if (!FQDN.test(host)) return fail(c, 400, "enter a valid domain you control")
+    const existing = await meta.getDomain(host)
+    if (existing)
+      return existing.org_id === org && !existing.artifact_id
+        ? c.json(toJson(existing))
+        : fail(c, 409, "that domain is already in use")
+    let state: Awaited<ReturnType<typeof cd.create>>
+    try {
+      state = await cd.create(host)
+    } catch (e) {
+      return fail(c, 502, e instanceof Error ? e.message : "couldn't register the domain")
+    }
+    const created = await meta.setDomain({
+      host,
+      org_id: org,
+      kind: "custom",
+      status: state.status,
+      cf_hostname_id: state.cfHostnameId,
+      verification: JSON.stringify(state.records),
+    })
+    if (!created) {
+      await cd.remove(state.cfHostnameId).catch(() => {})
+      return fail(c, 409, "that domain is already in use")
+    }
+    return c.json({ ...toJson(created), cname_target: cd.cnameTarget }, 201)
+  })
+
+  // Re-check a domain's validation status against Cloudflare.
+  app.post("/v1/workspace/domains/:host/refresh", async (c) => {
+    if (!(await workspaceCan(c, "manage"))) return fail(c, 403, "forbidden")
+    const org = await activeWorkspace(c)
+    const existing = await meta.getDomain(c.req.param("host").toLowerCase())
+    if (!existing || existing.org_id !== org || existing.artifact_id)
+      return fail(c, 404, "not found")
+    if (!existing.cf_hostname_id || !cd) return c.json(toJson(existing))
+    try {
+      const state = await cd.refresh(existing.cf_hostname_id)
+      const updated = await meta.updateDomain(existing.host, {
+        status: state.status,
+        verification: JSON.stringify(state.records),
+      })
+      return c.json(toJson(updated ?? existing))
+    } catch {
+      return c.json(toJson(existing))
+    }
+  })
+
+  // Detach a domain (tears down the Cloudflare hostname too).
+  app.delete("/v1/workspace/domains/:host", async (c) => {
+    if (!(await workspaceCan(c, "manage"))) return fail(c, 403, "forbidden")
+    const org = await activeWorkspace(c)
+    const host = c.req.param("host").toLowerCase()
+    const existing = await meta.getDomain(host)
+    if (!existing || existing.org_id !== org || existing.artifact_id)
+      return fail(c, 404, "not found")
+    if (existing.cf_hostname_id && cd) await cd.remove(existing.cf_hostname_id).catch(() => {})
+    await meta.deleteDomain(host, org)
+    return c.json({ ok: true })
+  })
+
+  return app
+}

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -10,6 +10,7 @@ import { R2BlobStore } from "@dock/storage"
 import { D1Dialect } from "kysely-d1"
 import { createApp } from "./app"
 import { makeAuth } from "./auth-config"
+import { customDomainsFromEnv } from "./lib/cloudflare-saas"
 import { createDoBackplane, edgeCtx } from "./realtime-do"
 
 // The realtime room Durable Object (one per channel). Exported so the Workers
@@ -48,6 +49,10 @@ export interface Env {
   DOCK_SUPERADMIN_EMAILS?: string
   // Base domain for vanity subdomains (domain mode); unset = off.
   DOCK_SUBDOMAIN_BASE?: string
+  // Cloudflare for SaaS (BYO custom domains); all three unset = custom domains off.
+  CF_API_TOKEN?: string
+  CF_ZONE_ID?: string
+  CF_SAAS_FALLBACK_ORIGIN?: string
 }
 
 let app: ReturnType<typeof createApp> | null = null
@@ -84,6 +89,7 @@ export default {
         defaultOrgId: "default",
         subdomainBase:
           env.DOCK_SUBDOMAIN_BASE?.toLowerCase().replace(/^\.+|\.+$/g, "") || undefined,
+        customDomains: customDomainsFromEnv(env),
         // Read the SPA shell from static assets so /a/:ref can carry unfurl meta.
         // Cached per isolate; null on any miss leaves the shell untouched.
         shellFetch: async () => {

--- a/apps/api/test/custom-domains.test.ts
+++ b/apps/api/test/custom-domains.test.ts
@@ -5,21 +5,20 @@ import { createApp } from "../src/app"
 import type { CustomDomainProvider } from "../src/lib/cloudflare-saas"
 import { dir, meta, ownerApp } from "./helpers"
 
-// A controllable fake Cloudflare for SaaS provider: create returns pending, refresh
-// flips to active once `activate()` is called, remove records the torn-down id.
+// A controllable fake Cloudflare for SaaS provider: create → pending, refresh flips
+// to active after activate(), remove records the torn-down id.
 const makeFakeCf = () => {
   const removed: string[] = []
   let active = false
-  const records = (host: string) => [
-    { type: "CNAME" as const, name: host, value: "dock-saas.test" },
-    { type: "TXT" as const, name: `_cf.${host}`, value: "v=token" },
-  ]
   const cf: CustomDomainProvider = {
     cnameTarget: "dock-saas.test",
     create: async (host) => ({
       cfHostnameId: `cf_${host}`,
       status: "pending",
-      records: records(host),
+      records: [
+        { type: "CNAME", name: host, value: "dock-saas.test" },
+        { type: "TXT", name: `_cf.${host}`, value: "v=token" },
+      ],
     }),
     refresh: async (id) => ({
       cfHostnameId: id,
@@ -49,8 +48,8 @@ const publish = async (
   const form = new FormData()
   form.append("file", new Blob([new TextEncoder().encode(content)]), "page.html")
   for (const [k, v] of Object.entries(fields)) form.append(k, v)
-  const res = await app.request("/v1/artifacts", { method: "POST", body: form })
-  return (await res.json()).short_id
+  return (await (await app.request("/v1/artifacts", { method: "POST", body: form })).json())
+    .short_id
 }
 const postJson = (app: ReturnType<typeof ownerApp>, path: string, body: unknown) =>
   app.request(path, {
@@ -59,8 +58,8 @@ const postJson = (app: ReturnType<typeof ownerApp>, path: string, body: unknown)
     body: JSON.stringify(body),
   })
 
-describe("custom domains (Cloudflare for SaaS)", () => {
-  it("attaches a domain (pending) with the DNS records, then serves it once active", async () => {
+describe("workspace custom domains (Cloudflare for SaaS)", () => {
+  it("attaches a workspace domain, validates, and serves artifacts at <domain>/<ref>", async () => {
     const { cf, activate } = makeFakeCf()
     const owner = ownerApp({ meta, blobs, baseUrl: "https://dock.test", customDomains: cf })
     const anon = createApp({
@@ -75,62 +74,71 @@ describe("custom domains (Cloudflare for SaaS)", () => {
       title: "Launch",
     })
 
-    const res = await postJson(owner, `/v1/artifacts/${short}/custom-domains`, {
-      host: "launch.acme.com",
-    })
+    const res = await postJson(owner, "/v1/workspace/domains", { host: "docs.acme.com" })
     expect(res.status).toBe(201)
     const body = await res.json()
-    expect(body).toMatchObject({ host: "launch.acme.com", kind: "custom", status: "pending" })
+    expect(body).toMatchObject({ host: "docs.acme.com", status: "pending" })
     expect(body.cname_target).toBe("dock-saas.test")
     expect(body.records).toEqual(
-      expect.arrayContaining([{ type: "CNAME", name: "launch.acme.com", value: "dock-saas.test" }]),
+      expect.arrayContaining([{ type: "CNAME", name: "docs.acme.com", value: "dock-saas.test" }]),
     )
 
-    // Pending → the host does NOT serve the artifact yet (falls through).
-    expect(await (await anon.request("https://launch.acme.com/")).text()).not.toContain(
+    // Pending → not served yet.
+    expect(await (await anon.request(`https://docs.acme.com/${short}`)).text()).not.toContain(
       "Acme Launch",
     )
 
-    // Validate via CF, refresh → active → now it serves at the host root.
+    // Validate via CF → active → the workspace's artifact serves under the domain.
     activate()
-    const refreshed = await postJson(
-      owner,
-      `/v1/artifacts/${short}/domains/launch.acme.com/refresh`,
-      {},
-    )
-    expect((await refreshed.json()).status).toBe("active")
-    const served = await anon.request("https://launch.acme.com/")
+    expect(
+      (await (await postJson(owner, "/v1/workspace/domains/docs.acme.com/refresh", {})).json())
+        .status,
+    ).toBe("active")
+    const served = await anon.request(`https://docs.acme.com/${short}`)
     expect(served.status).toBe(200)
     expect(await served.text()).toContain("Acme Launch")
   })
 
-  it("lists custom-domain support + the attached domain", async () => {
-    const { cf } = makeFakeCf()
+  it("lists workspace domains + surfaces them read-only on the artifact's share data", async () => {
+    const { cf, activate } = makeFakeCf()
+    activate()
     const owner = ownerApp({ meta, blobs, baseUrl: "https://dock.test", customDomains: cf })
     const short = await publish(owner, "<p>x</p>", { visibility: "public" })
-    await postJson(owner, `/v1/artifacts/${short}/custom-domains`, { host: "docs.acme.com" })
-    const list = await (await owner.request(`/v1/artifacts/${short}/domains`)).json()
-    expect(list.custom_enabled).toBe(true)
-    expect(list.cname_target).toBe("dock-saas.test")
-    expect(list.domains.find((d: { host: string }) => d.host === "docs.acme.com").status).toBe(
-      "pending",
+    await postJson(owner, "/v1/workspace/domains", { host: "pages.acme.com" })
+    await postJson(owner, "/v1/workspace/domains/pages.acme.com/refresh", {})
+
+    const ws = await (await owner.request("/v1/workspace/domains")).json()
+    expect(ws.enabled).toBe(true)
+    expect(ws.domains.find((d: { host: string }) => d.host === "pages.acme.com").status).toBe(
+      "active",
     )
+
+    // The per-artifact share data shows the artifact's URL on the workspace domain.
+    const art = await (await owner.request(`/v1/artifacts/${short}/domains`)).json()
+    const wd = art.workspace_domains.find((d: { host: string }) => d.host === "pages.acme.com")
+    expect(wd?.url).toMatch(new RegExp(`^https://pages\\.acme\\.com/${short}`))
   })
 
-  it("rejects invalid hosts and a host already attached elsewhere", async () => {
+  it("never serves one workspace's artifact under another workspace's domain", async () => {
     const { cf } = makeFakeCf()
     const owner = ownerApp({ meta, blobs, baseUrl: "https://dock.test", customDomains: cf })
-    const a = await publish(owner, "<p>a</p>", { visibility: "public" })
-    const b = await publish(owner, "<p>b</p>", { visibility: "public" })
-    expect(
-      (await postJson(owner, `/v1/artifacts/${a}/custom-domains`, { host: "nodot" })).status,
-    ).toBe(400)
-    expect(
-      (await postJson(owner, `/v1/artifacts/${a}/custom-domains`, { host: "dup.acme.com" })).status,
-    ).toBe(201)
-    expect(
-      (await postJson(owner, `/v1/artifacts/${b}/custom-domains`, { host: "dup.acme.com" })).status,
-    ).toBe(409)
+    const anon = createApp({
+      meta,
+      blobs,
+      baseUrl: "https://dock.test",
+      token: "tok",
+      customDomains: cf,
+    })
+    const short = await publish(owner, "<h1>Mine</h1>", { visibility: "public" })
+    // A domain owned by a different workspace, active.
+    await meta.setDomain({
+      host: "evil.test",
+      org_id: "other-org",
+      kind: "custom",
+      status: "active",
+      cf_hostname_id: "cf_evil",
+    })
+    expect(await (await anon.request(`https://evil.test/${short}`)).text()).not.toContain("Mine")
   })
 
   it("tears down the Cloudflare hostname on delete and stops serving", async () => {
@@ -145,23 +153,26 @@ describe("custom domains (Cloudflare for SaaS)", () => {
       customDomains: cf,
     })
     const short = await publish(owner, "<h1>Bye</h1>", { visibility: "public" })
-    await postJson(owner, `/v1/artifacts/${short}/custom-domains`, { host: "gone.acme.com" })
-    await postJson(owner, `/v1/artifacts/${short}/domains/gone.acme.com/refresh`, {})
-    expect((await anon.request("https://gone.acme.com/")).status).toBe(200)
-    const del = await owner.request(`/v1/artifacts/${short}/domains/gone.acme.com`, {
-      method: "DELETE",
-    })
+    await postJson(owner, "/v1/workspace/domains", { host: "gone.acme.com" })
+    await postJson(owner, "/v1/workspace/domains/gone.acme.com/refresh", {})
+    expect((await anon.request(`https://gone.acme.com/${short}`)).status).toBe(200)
+    const del = await owner.request("/v1/workspace/domains/gone.acme.com", { method: "DELETE" })
     expect(del.status).toBe(200)
     expect(removed).toContain("cf_gone.acme.com")
-    expect(await (await anon.request("https://gone.acme.com/")).text()).not.toContain("Bye")
+    expect(await (await anon.request(`https://gone.acme.com/${short}`)).text()).not.toContain("Bye")
   })
 
-  it("501s when Cloudflare for SaaS is not configured", async () => {
-    const owner = ownerApp({ meta, blobs, baseUrl: "https://dock.test" })
-    const short = await publish(owner, "<p>x</p>", { visibility: "public" })
-    const res = await postJson(owner, `/v1/artifacts/${short}/custom-domains`, {
-      host: "x.acme.com",
-    })
-    expect(res.status).toBe(501)
+  it("rejects invalid hosts, a host in use, and 501s when CF is unconfigured", async () => {
+    const { cf } = makeFakeCf()
+    const owner = ownerApp({ meta, blobs, baseUrl: "https://dock.test", customDomains: cf })
+    expect((await postJson(owner, "/v1/workspace/domains", { host: "nodot" })).status).toBe(400)
+    expect((await postJson(owner, "/v1/workspace/domains", { host: "dup.acme.com" })).status).toBe(
+      201,
+    )
+    expect((await postJson(owner, "/v1/workspace/domains", { host: "dup.acme.com" })).status).toBe(
+      200,
+    )
+    const noCf = ownerApp({ meta, blobs, baseUrl: "https://dock.test" })
+    expect((await postJson(noCf, "/v1/workspace/domains", { host: "x.acme.com" })).status).toBe(501)
   })
 })

--- a/apps/api/test/custom-domains.test.ts
+++ b/apps/api/test/custom-domains.test.ts
@@ -1,0 +1,167 @@
+import { join } from "node:path"
+import { FsBlobStore } from "@dock/storage/fs"
+import { describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import type { CustomDomainProvider } from "../src/lib/cloudflare-saas"
+import { dir, meta, ownerApp } from "./helpers"
+
+// A controllable fake Cloudflare for SaaS provider: create returns pending, refresh
+// flips to active once `activate()` is called, remove records the torn-down id.
+const makeFakeCf = () => {
+  const removed: string[] = []
+  let active = false
+  const records = (host: string) => [
+    { type: "CNAME" as const, name: host, value: "dock-saas.test" },
+    { type: "TXT" as const, name: `_cf.${host}`, value: "v=token" },
+  ]
+  const cf: CustomDomainProvider = {
+    cnameTarget: "dock-saas.test",
+    create: async (host) => ({
+      cfHostnameId: `cf_${host}`,
+      status: "pending",
+      records: records(host),
+    }),
+    refresh: async (id) => ({
+      cfHostnameId: id,
+      status: active ? "active" : "pending",
+      records: [],
+    }),
+    remove: async (id) => {
+      removed.push(id)
+    },
+  }
+  return {
+    cf,
+    removed,
+    activate: () => {
+      active = true
+    },
+  }
+}
+
+const blobs = new FsBlobStore(join(dir, "blobs-custom-domains"))
+
+const publish = async (
+  app: ReturnType<typeof ownerApp>,
+  content: string,
+  fields: Record<string, string> = {},
+): Promise<string> => {
+  const form = new FormData()
+  form.append("file", new Blob([new TextEncoder().encode(content)]), "page.html")
+  for (const [k, v] of Object.entries(fields)) form.append(k, v)
+  const res = await app.request("/v1/artifacts", { method: "POST", body: form })
+  return (await res.json()).short_id
+}
+const postJson = (app: ReturnType<typeof ownerApp>, path: string, body: unknown) =>
+  app.request(path, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  })
+
+describe("custom domains (Cloudflare for SaaS)", () => {
+  it("attaches a domain (pending) with the DNS records, then serves it once active", async () => {
+    const { cf, activate } = makeFakeCf()
+    const owner = ownerApp({ meta, blobs, baseUrl: "https://dock.test", customDomains: cf })
+    const anon = createApp({
+      meta,
+      blobs,
+      baseUrl: "https://dock.test",
+      token: "tok",
+      customDomains: cf,
+    })
+    const short = await publish(owner, "<h1>Acme Launch</h1>", {
+      visibility: "public",
+      title: "Launch",
+    })
+
+    const res = await postJson(owner, `/v1/artifacts/${short}/custom-domains`, {
+      host: "launch.acme.com",
+    })
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body).toMatchObject({ host: "launch.acme.com", kind: "custom", status: "pending" })
+    expect(body.cname_target).toBe("dock-saas.test")
+    expect(body.records).toEqual(
+      expect.arrayContaining([{ type: "CNAME", name: "launch.acme.com", value: "dock-saas.test" }]),
+    )
+
+    // Pending → the host does NOT serve the artifact yet (falls through).
+    expect(await (await anon.request("https://launch.acme.com/")).text()).not.toContain(
+      "Acme Launch",
+    )
+
+    // Validate via CF, refresh → active → now it serves at the host root.
+    activate()
+    const refreshed = await postJson(
+      owner,
+      `/v1/artifacts/${short}/domains/launch.acme.com/refresh`,
+      {},
+    )
+    expect((await refreshed.json()).status).toBe("active")
+    const served = await anon.request("https://launch.acme.com/")
+    expect(served.status).toBe(200)
+    expect(await served.text()).toContain("Acme Launch")
+  })
+
+  it("lists custom-domain support + the attached domain", async () => {
+    const { cf } = makeFakeCf()
+    const owner = ownerApp({ meta, blobs, baseUrl: "https://dock.test", customDomains: cf })
+    const short = await publish(owner, "<p>x</p>", { visibility: "public" })
+    await postJson(owner, `/v1/artifacts/${short}/custom-domains`, { host: "docs.acme.com" })
+    const list = await (await owner.request(`/v1/artifacts/${short}/domains`)).json()
+    expect(list.custom_enabled).toBe(true)
+    expect(list.cname_target).toBe("dock-saas.test")
+    expect(list.domains.find((d: { host: string }) => d.host === "docs.acme.com").status).toBe(
+      "pending",
+    )
+  })
+
+  it("rejects invalid hosts and a host already attached elsewhere", async () => {
+    const { cf } = makeFakeCf()
+    const owner = ownerApp({ meta, blobs, baseUrl: "https://dock.test", customDomains: cf })
+    const a = await publish(owner, "<p>a</p>", { visibility: "public" })
+    const b = await publish(owner, "<p>b</p>", { visibility: "public" })
+    expect(
+      (await postJson(owner, `/v1/artifacts/${a}/custom-domains`, { host: "nodot" })).status,
+    ).toBe(400)
+    expect(
+      (await postJson(owner, `/v1/artifacts/${a}/custom-domains`, { host: "dup.acme.com" })).status,
+    ).toBe(201)
+    expect(
+      (await postJson(owner, `/v1/artifacts/${b}/custom-domains`, { host: "dup.acme.com" })).status,
+    ).toBe(409)
+  })
+
+  it("tears down the Cloudflare hostname on delete and stops serving", async () => {
+    const { cf, removed, activate } = makeFakeCf()
+    activate()
+    const owner = ownerApp({ meta, blobs, baseUrl: "https://dock.test", customDomains: cf })
+    const anon = createApp({
+      meta,
+      blobs,
+      baseUrl: "https://dock.test",
+      token: "tok",
+      customDomains: cf,
+    })
+    const short = await publish(owner, "<h1>Bye</h1>", { visibility: "public" })
+    await postJson(owner, `/v1/artifacts/${short}/custom-domains`, { host: "gone.acme.com" })
+    await postJson(owner, `/v1/artifacts/${short}/domains/gone.acme.com/refresh`, {})
+    expect((await anon.request("https://gone.acme.com/")).status).toBe(200)
+    const del = await owner.request(`/v1/artifacts/${short}/domains/gone.acme.com`, {
+      method: "DELETE",
+    })
+    expect(del.status).toBe(200)
+    expect(removed).toContain("cf_gone.acme.com")
+    expect(await (await anon.request("https://gone.acme.com/")).text()).not.toContain("Bye")
+  })
+
+  it("501s when Cloudflare for SaaS is not configured", async () => {
+    const owner = ownerApp({ meta, blobs, baseUrl: "https://dock.test" })
+    const short = await publish(owner, "<p>x</p>", { visibility: "public" })
+    const res = await postJson(owner, `/v1/artifacts/${short}/custom-domains`, {
+      host: "x.acme.com",
+    })
+    expect(res.status).toBe(501)
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -88,11 +88,20 @@ export interface ArtifactMember {
   name: string | null
   role: Role
 }
+/** A DNS record the customer adds to validate a custom domain. */
+export interface DomainDnsRecord {
+  type: string
+  name: string
+  value: string
+}
 /** A vanity host serving an artifact (domain mode). */
 export interface ArtifactDomain {
   host: string
   url: string
   kind: string
+  status: string
+  /** DNS records to add while a custom domain is pending (undefined for subdomains). */
+  records?: DomainDnsRecord[]
   created_at: string
 }
 /** The workspace: its name, the caller's role, and the member directory. */
@@ -342,10 +351,20 @@ export const api = {
 
   // Vanity subdomains (domain mode). `base` is null when the server has none set,
   // in which case the Share dialog hides the section.
-  listDomains: (id: string): Promise<{ base: string | null; domains: ArtifactDomain[] }> =>
-    f(`/v1/artifacts/${id}/domains`, opts()).then(j),
+  listDomains: (
+    id: string,
+  ): Promise<{
+    base: string | null
+    custom_enabled: boolean
+    cname_target: string | null
+    domains: ArtifactDomain[]
+  }> => f(`/v1/artifacts/${id}/domains`, opts()).then(j),
   setDomain: (id: string, label: string): Promise<ArtifactDomain> =>
     f(`/v1/artifacts/${id}/domains`, { ...opts({ label }), method: "PUT" }).then(j),
+  addCustomDomain: (id: string, host: string): Promise<ArtifactDomain & { cname_target: string }> =>
+    f(`/v1/artifacts/${id}/custom-domains`, opts({ host })).then(j),
+  refreshDomain: (id: string, host: string): Promise<ArtifactDomain> =>
+    f(`/v1/artifacts/${id}/domains/${host}/refresh`, opts({})).then(j),
   removeDomain: (id: string, host: string): Promise<void> =>
     f(`/v1/artifacts/${id}/domains/${host}`, { method: "DELETE", credentials: "include" }).then(
       () => undefined,

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -94,13 +94,19 @@ export interface DomainDnsRecord {
   name: string
   value: string
 }
-/** A vanity host serving an artifact (domain mode). */
+/** A vanity subdomain bound to one artifact (the per-artifact share section). */
 export interface ArtifactDomain {
   host: string
   url: string
   kind: string
   status: string
-  /** DNS records to add while a custom domain is pending (undefined for subdomains). */
+  created_at: string
+}
+/** A workspace custom domain (managed in settings; Cloudflare for SaaS). */
+export interface WorkspaceDomain {
+  host: string
+  status: string
+  /** DNS records to add while pending (undefined once active). */
   records?: DomainDnsRecord[]
   created_at: string
 }
@@ -349,24 +355,34 @@ export const api = {
       () => undefined,
     ),
 
-  // Vanity subdomains (domain mode). `base` is null when the server has none set,
-  // in which case the Share dialog hides the section.
+  // Per-artifact vanity subdomains (`base` null when off) + the workspace's custom
+  // domains shown read-only as the artifact's URL on each.
   listDomains: (
     id: string,
   ): Promise<{
     base: string | null
-    custom_enabled: boolean
-    cname_target: string | null
     domains: ArtifactDomain[]
+    workspace_domains: { host: string; url: string }[]
   }> => f(`/v1/artifacts/${id}/domains`, opts()).then(j),
   setDomain: (id: string, label: string): Promise<ArtifactDomain> =>
     f(`/v1/artifacts/${id}/domains`, { ...opts({ label }), method: "PUT" }).then(j),
-  addCustomDomain: (id: string, host: string): Promise<ArtifactDomain & { cname_target: string }> =>
-    f(`/v1/artifacts/${id}/custom-domains`, opts({ host })).then(j),
-  refreshDomain: (id: string, host: string): Promise<ArtifactDomain> =>
-    f(`/v1/artifacts/${id}/domains/${host}/refresh`, opts({})).then(j),
   removeDomain: (id: string, host: string): Promise<void> =>
     f(`/v1/artifacts/${id}/domains/${host}`, { method: "DELETE", credentials: "include" }).then(
+      () => undefined,
+    ),
+
+  // Workspace custom domains (Cloudflare for SaaS), managed in settings.
+  listWorkspaceDomains: (): Promise<{
+    enabled: boolean
+    cname_target: string | null
+    domains: WorkspaceDomain[]
+  }> => f("/v1/workspace/domains", opts()).then(j),
+  addWorkspaceDomain: (host: string): Promise<WorkspaceDomain & { cname_target: string }> =>
+    f("/v1/workspace/domains", opts({ host })).then(j),
+  refreshWorkspaceDomain: (host: string): Promise<WorkspaceDomain> =>
+    f(`/v1/workspace/domains/${host}/refresh`, opts({})).then(j),
+  removeWorkspaceDomain: (host: string): Promise<void> =>
+    f(`/v1/workspace/domains/${host}`, { method: "DELETE", credentials: "include" }).then(
       () => undefined,
     ),
   heartbeat: (id: string, name: string): Promise<{ viewers: string[] }> =>

--- a/apps/web/src/components/ShareDialog.tsx
+++ b/apps/web/src/components/ShareDialog.tsx
@@ -73,12 +73,17 @@ export function ShareButton({
 
   const [copied, setCopied] = useState(false)
 
-  // Domain mode (vanity subdomains). `domainBase` is null when the server has no
-  // base configured, which hides the whole section.
+  // Domain mode. `domainBase` is null when subdomains are off; `cnameTarget` is null
+  // when bring-your-own custom domains are off — each hides its own section.
   const [domains, setDomains] = useState<ArtifactDomain[]>([])
   const [domainBase, setDomainBase] = useState<string | null>(null)
+  const [cnameTarget, setCnameTarget] = useState<string | null>(null)
   const [label, setLabel] = useState("")
   const [claiming, setClaiming] = useState(false)
+  const [customHost, setCustomHost] = useState("")
+  const [addingCustom, setAddingCustom] = useState(false)
+  const subdomains = domains.filter((d) => d.kind === "subdomain")
+  const customDomains = domains.filter((d) => d.kind === "custom")
 
   // GDocs model: owners and editors manage access; everyone else gets view-only.
   const canManage = myRole === "owner" || myRole === "editor"
@@ -167,8 +172,29 @@ export function ShareButton({
       .then((r) => {
         setDomains(r.domains)
         setDomainBase(r.base)
+        setCnameTarget(r.cname_target)
       })
       .catch(() => {})
+  const addCustomDomain = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const host = customHost.trim().toLowerCase()
+    if (!host) return
+    setAddingCustom(true)
+    try {
+      await api.addCustomDomain(shortId, host)
+      setCustomHost("")
+      await loadDomains()
+      toast.success("Domain added — add the DNS records to finish")
+    } catch (x) {
+      toast.error(x instanceof Error ? x.message : "Couldn't add that domain")
+    } finally {
+      setAddingCustom(false)
+    }
+  }
+  const refreshDomain = async (host: string) => {
+    await api.refreshDomain(shortId, host).catch(() => {})
+    await loadDomains()
+  }
   const claimDomain = async (e: React.FormEvent) => {
     e.preventDefault()
     const l = label.trim().toLowerCase()
@@ -434,9 +460,9 @@ export function ShareButton({
                 <div className="mb-1.5 font-mono text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
                   Custom URL
                 </div>
-                {domains.length > 0 ? (
+                {subdomains.length > 0 ? (
                   <div className="flex flex-col gap-1.5">
-                    {domains.map((d) => (
+                    {subdomains.map((d) => (
                       <div key={d.host} className="flex items-center gap-1.5">
                         <Input
                           readOnly
@@ -496,6 +522,107 @@ export function ShareButton({
                 <p className="mt-1.5 font-mono text-2xs text-muted-foreground">
                   A clean URL on {domainBase}, served at its own origin. Works for link- or
                   world-readable artifacts.
+                </p>
+              </div>
+            )}
+
+            {/* Custom domain — bring your own hostname (Cloudflare for SaaS). Shown
+                only when the server has custom domains enabled. */}
+            {cnameTarget && (
+              <div className="mt-4 border-t border-border pt-3.5">
+                <div className="mb-1.5 font-mono text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Custom domain
+                </div>
+                {customDomains.length > 0 ? (
+                  <div className="flex flex-col gap-2.5">
+                    {customDomains.map((d) => (
+                      <div key={d.host} className="flex flex-col gap-1.5">
+                        <div className="flex items-center gap-1.5">
+                          <span className="flex-1 truncate font-mono text-xs text-foreground">
+                            {d.host}
+                          </span>
+                          <span
+                            data-testid="share-customdomain-status"
+                            className={`rounded px-1.5 py-0.5 font-mono text-2xs ${d.status === "active" ? "bg-primary/10 text-primary" : d.status === "error" ? "bg-destructive/10 text-destructive" : "bg-muted text-muted-foreground"}`}
+                          >
+                            {d.status === "active"
+                              ? "Active"
+                              : d.status === "error"
+                                ? "Error"
+                                : "Pending"}
+                          </span>
+                          {d.status === "active" ? (
+                            <Button variant="outline" onClick={() => copyUrl(d.url)}>
+                              Copy
+                            </Button>
+                          ) : (
+                            canManage && (
+                              <Button
+                                variant="outline"
+                                data-testid="share-customdomain-refresh"
+                                onClick={() => refreshDomain(d.host)}
+                              >
+                                Refresh
+                              </Button>
+                            )
+                          )}
+                          {canManage && (
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              data-testid="share-customdomain-remove"
+                              className="size-7 text-muted-foreground hover:text-foreground"
+                              onClick={() => dropDomain(d.host)}
+                              aria-label="Remove custom domain"
+                            >
+                              <X />
+                            </Button>
+                          )}
+                        </div>
+                        {d.status !== "active" && d.records && d.records.length > 0 && (
+                          <div className="rounded-md border border-border bg-muted/40 p-2">
+                            <p className="mb-1 font-mono text-2xs text-muted-foreground">
+                              Add these DNS records at your registrar:
+                            </p>
+                            {d.records.map((r) => (
+                              <div
+                                key={`${r.type}-${r.name}`}
+                                className="truncate font-mono text-2xs text-foreground"
+                              >
+                                <span className="text-muted-foreground">{r.type}</span> {r.name} →{" "}
+                                {r.value}
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                ) : canManage ? (
+                  <form onSubmit={addCustomDomain} className="flex items-center gap-1.5">
+                    <Input
+                      data-testid="share-customdomain-host"
+                      aria-label="Custom domain"
+                      placeholder="launch.acme.com"
+                      value={customHost}
+                      onChange={(e) => setCustomHost(e.target.value)}
+                      className="flex-1 font-mono text-2xs"
+                    />
+                    <Button
+                      data-testid="share-customdomain-add"
+                      variant="primary"
+                      type="submit"
+                      disabled={addingCustom || !customHost.trim()}
+                    >
+                      {addingCustom ? "…" : "Add"}
+                    </Button>
+                  </form>
+                ) : (
+                  <p className="text-xs text-muted-foreground">No custom domain.</p>
+                )}
+                <p className="mt-1.5 font-mono text-2xs text-muted-foreground">
+                  Point your own domain here. Cloudflare issues the TLS cert; CNAME it to{" "}
+                  <span className="text-foreground">{cnameTarget}</span>.
                 </p>
               </div>
             )}

--- a/apps/web/src/components/ShareDialog.tsx
+++ b/apps/web/src/components/ShareDialog.tsx
@@ -73,17 +73,13 @@ export function ShareButton({
 
   const [copied, setCopied] = useState(false)
 
-  // Domain mode. `domainBase` is null when subdomains are off; `cnameTarget` is null
-  // when bring-your-own custom domains are off — each hides its own section.
+  // Per-artifact vanity subdomains (`domainBase` null = off) + the workspace's
+  // custom domains shown read-only (managed in Settings).
   const [domains, setDomains] = useState<ArtifactDomain[]>([])
   const [domainBase, setDomainBase] = useState<string | null>(null)
-  const [cnameTarget, setCnameTarget] = useState<string | null>(null)
+  const [workspaceDomains, setWorkspaceDomains] = useState<{ host: string; url: string }[]>([])
   const [label, setLabel] = useState("")
   const [claiming, setClaiming] = useState(false)
-  const [customHost, setCustomHost] = useState("")
-  const [addingCustom, setAddingCustom] = useState(false)
-  const subdomains = domains.filter((d) => d.kind === "subdomain")
-  const customDomains = domains.filter((d) => d.kind === "custom")
 
   // GDocs model: owners and editors manage access; everyone else gets view-only.
   const canManage = myRole === "owner" || myRole === "editor"
@@ -172,29 +168,9 @@ export function ShareButton({
       .then((r) => {
         setDomains(r.domains)
         setDomainBase(r.base)
-        setCnameTarget(r.cname_target)
+        setWorkspaceDomains(r.workspace_domains)
       })
       .catch(() => {})
-  const addCustomDomain = async (e: React.FormEvent) => {
-    e.preventDefault()
-    const host = customHost.trim().toLowerCase()
-    if (!host) return
-    setAddingCustom(true)
-    try {
-      await api.addCustomDomain(shortId, host)
-      setCustomHost("")
-      await loadDomains()
-      toast.success("Domain added — add the DNS records to finish")
-    } catch (x) {
-      toast.error(x instanceof Error ? x.message : "Couldn't add that domain")
-    } finally {
-      setAddingCustom(false)
-    }
-  }
-  const refreshDomain = async (host: string) => {
-    await api.refreshDomain(shortId, host).catch(() => {})
-    await loadDomains()
-  }
   const claimDomain = async (e: React.FormEvent) => {
     e.preventDefault()
     const l = label.trim().toLowerCase()
@@ -460,9 +436,9 @@ export function ShareButton({
                 <div className="mb-1.5 font-mono text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
                   Custom URL
                 </div>
-                {subdomains.length > 0 ? (
+                {domains.length > 0 ? (
                   <div className="flex flex-col gap-1.5">
-                    {subdomains.map((d) => (
+                    {domains.map((d) => (
                       <div key={d.host} className="flex items-center gap-1.5">
                         <Input
                           readOnly
@@ -526,103 +502,32 @@ export function ShareButton({
               </div>
             )}
 
-            {/* Custom domain — bring your own hostname (Cloudflare for SaaS). Shown
-                only when the server has custom domains enabled. */}
-            {cnameTarget && (
+            {/* Also at — this artifact's URL on each of the workspace's custom
+                domains (managed in workspace settings, shown read-only here). */}
+            {workspaceDomains.length > 0 && (
               <div className="mt-4 border-t border-border pt-3.5">
                 <div className="mb-1.5 font-mono text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  Custom domain
+                  Also at
                 </div>
-                {customDomains.length > 0 ? (
-                  <div className="flex flex-col gap-2.5">
-                    {customDomains.map((d) => (
-                      <div key={d.host} className="flex flex-col gap-1.5">
-                        <div className="flex items-center gap-1.5">
-                          <span className="flex-1 truncate font-mono text-xs text-foreground">
-                            {d.host}
-                          </span>
-                          <span
-                            data-testid="share-customdomain-status"
-                            className={`rounded px-1.5 py-0.5 font-mono text-2xs ${d.status === "active" ? "bg-primary/10 text-primary" : d.status === "error" ? "bg-destructive/10 text-destructive" : "bg-muted text-muted-foreground"}`}
-                          >
-                            {d.status === "active"
-                              ? "Active"
-                              : d.status === "error"
-                                ? "Error"
-                                : "Pending"}
-                          </span>
-                          {d.status === "active" ? (
-                            <Button variant="outline" onClick={() => copyUrl(d.url)}>
-                              Copy
-                            </Button>
-                          ) : (
-                            canManage && (
-                              <Button
-                                variant="outline"
-                                data-testid="share-customdomain-refresh"
-                                onClick={() => refreshDomain(d.host)}
-                              >
-                                Refresh
-                              </Button>
-                            )
-                          )}
-                          {canManage && (
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              data-testid="share-customdomain-remove"
-                              className="size-7 text-muted-foreground hover:text-foreground"
-                              onClick={() => dropDomain(d.host)}
-                              aria-label="Remove custom domain"
-                            >
-                              <X />
-                            </Button>
-                          )}
-                        </div>
-                        {d.status !== "active" && d.records && d.records.length > 0 && (
-                          <div className="rounded-md border border-border bg-muted/40 p-2">
-                            <p className="mb-1 font-mono text-2xs text-muted-foreground">
-                              Add these DNS records at your registrar:
-                            </p>
-                            {d.records.map((r) => (
-                              <div
-                                key={`${r.type}-${r.name}`}
-                                className="truncate font-mono text-2xs text-foreground"
-                              >
-                                <span className="text-muted-foreground">{r.type}</span> {r.name} →{" "}
-                                {r.value}
-                              </div>
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                ) : canManage ? (
-                  <form onSubmit={addCustomDomain} className="flex items-center gap-1.5">
-                    <Input
-                      data-testid="share-customdomain-host"
-                      aria-label="Custom domain"
-                      placeholder="launch.acme.com"
-                      value={customHost}
-                      onChange={(e) => setCustomHost(e.target.value)}
-                      className="flex-1 font-mono text-2xs"
-                    />
-                    <Button
-                      data-testid="share-customdomain-add"
-                      variant="primary"
-                      type="submit"
-                      disabled={addingCustom || !customHost.trim()}
-                    >
-                      {addingCustom ? "…" : "Add"}
-                    </Button>
-                  </form>
-                ) : (
-                  <p className="text-xs text-muted-foreground">No custom domain.</p>
-                )}
+                <div className="flex flex-col gap-1.5">
+                  {workspaceDomains.map((d) => (
+                    <div key={d.host} className="flex items-center gap-1.5">
+                      <Input
+                        readOnly
+                        data-testid="share-workspace-domain"
+                        aria-label={`URL on ${d.host}`}
+                        value={d.url}
+                        onFocus={(e) => e.currentTarget.select()}
+                        className="flex-1 font-mono text-2xs"
+                      />
+                      <Button variant="outline" onClick={() => copyUrl(d.url)}>
+                        Copy
+                      </Button>
+                    </div>
+                  ))}
+                </div>
                 <p className="mt-1.5 font-mono text-2xs text-muted-foreground">
-                  Point your own domain here. Cloudflare issues the TLS cert; CNAME it to{" "}
-                  <span className="text-foreground">{cnameTarget}</span>.
+                  On your workspace's custom domain. Manage domains in workspace settings.
                 </p>
               </div>
             )}

--- a/apps/web/src/pages/settings/custom-domains-section.tsx
+++ b/apps/web/src/pages/settings/custom-domains-section.tsx
@@ -1,0 +1,188 @@
+import { useCallback, useEffect, useState } from "react"
+import { toast } from "sonner"
+import { api, type WorkspaceDomain } from "@/api"
+import { EmptyState } from "@/components/shared/empty-state"
+import { Spinner } from "@/components/shared/spinner"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+
+type State = { enabled: boolean; cname_target: string | null; domains: WorkspaceDomain[] }
+
+export function CustomDomainsSection() {
+  const [state, setState] = useState<State | null>(null)
+  const load = useCallback(
+    () =>
+      api
+        .listWorkspaceDomains()
+        .then(setState)
+        .catch(() => setState({ enabled: false, cname_target: null, domains: [] })),
+    [],
+  )
+  useEffect(() => {
+    load()
+  }, [load])
+
+  if (state === null)
+    return (
+      <div className="flex h-20 items-center justify-center">
+        <Spinner />
+      </div>
+    )
+
+  if (!state.enabled)
+    return (
+      <section>
+        <EmptyState>Custom domains aren't enabled on this server.</EmptyState>
+      </section>
+    )
+
+  return (
+    <section>
+      <p className="mb-4 text-sm text-muted-foreground">
+        Put your own domain on this workspace. Every artifact is then served at{" "}
+        <code className="font-mono">your-domain/&lt;id&gt;</code>. Cloudflare for SaaS issues and
+        renews the TLS cert.
+      </p>
+
+      <NewDomain cnameTarget={state.cname_target} onCreated={load} />
+
+      <div className="mt-4 flex flex-col gap-2.5">
+        {state.domains.length === 0 ? (
+          <EmptyState>No custom domains yet. Add one above.</EmptyState>
+        ) : (
+          state.domains.map((d) => <DomainRow key={d.host} domain={d} onChanged={load} />)
+        )}
+      </div>
+    </section>
+  )
+}
+
+function NewDomain({
+  cnameTarget,
+  onCreated,
+}: {
+  cnameTarget: string | null
+  onCreated: () => void
+}) {
+  const [host, setHost] = useState("")
+  const [busy, setBusy] = useState(false)
+  const add = async () => {
+    const h = host.trim()
+    if (!h) return
+    setBusy(true)
+    try {
+      await api.addWorkspaceDomain(h)
+      setHost("")
+      toast.success("Domain added — add the DNS records to finish")
+      onCreated()
+    } catch (e) {
+      toast.error((e as Error).message)
+    } finally {
+      setBusy(false)
+    }
+  }
+  return (
+    <Card className="p-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
+          data-testid="domain-host"
+          aria-label="Custom domain"
+          value={host}
+          onChange={(e) => setHost(e.target.value)}
+          placeholder="docs.acme.com"
+          className="min-w-[240px] flex-1 font-mono text-sm"
+        />
+        <Button
+          data-testid="domain-add"
+          variant="primary"
+          onClick={add}
+          disabled={busy || !host.trim()}
+        >
+          {busy ? "Adding…" : "Add"}
+        </Button>
+      </div>
+      {cnameTarget && (
+        <p className="mt-2 font-mono text-2xs text-muted-foreground">
+          CNAME your domain to <span className="text-foreground">{cnameTarget}</span>.
+        </p>
+      )}
+    </Card>
+  )
+}
+
+const statusBadge = (
+  s: string,
+): { variant: "success" | "outline" | "default"; label: string; cls?: string } =>
+  s === "active"
+    ? { variant: "success", label: "Active" }
+    : s === "error"
+      ? { variant: "outline", label: "Error", cls: "text-destructive" }
+      : { variant: "default", label: "Pending" }
+
+function DomainRow({ domain, onChanged }: { domain: WorkspaceDomain; onChanged: () => void }) {
+  const b = statusBadge(domain.status)
+  const refresh = async () => {
+    try {
+      await api.refreshWorkspaceDomain(domain.host)
+      onChanged()
+    } catch (e) {
+      toast.error((e as Error).message)
+    }
+  }
+  const remove = async () => {
+    try {
+      await api.removeWorkspaceDomain(domain.host)
+      toast.success("Domain removed")
+      onChanged()
+    } catch (e) {
+      toast.error((e as Error).message)
+    }
+  }
+  return (
+    <Card data-testid={`domain-row-${domain.host}`} className="overflow-hidden p-0">
+      <div className="flex items-center gap-2.5 px-3.5 py-3">
+        <div className="min-w-0 flex-1 truncate font-mono text-sm text-foreground">
+          {domain.host}
+        </div>
+        <Badge
+          data-testid="domain-status"
+          variant={b.variant}
+          className={`font-mono ${b.cls ?? ""}`}
+        >
+          {b.label}
+        </Badge>
+        {domain.status !== "active" && (
+          <Button data-testid="domain-refresh" variant="ghost" size="sm" onClick={refresh}>
+            Refresh
+          </Button>
+        )}
+        <Button
+          data-testid="domain-remove"
+          variant="ghost"
+          size="sm"
+          className="text-destructive hover:text-destructive"
+          onClick={remove}
+        >
+          Remove
+        </Button>
+      </div>
+      {domain.status !== "active" && domain.records && domain.records.length > 0 && (
+        <div className="border-t border-border-soft bg-secondary px-3.5 py-2">
+          <p className="mb-1 font-mono text-2xs text-muted-foreground">
+            Add these DNS records at your registrar:
+          </p>
+          {domain.records.map((r) => (
+            <div
+              key={`${r.type}-${r.name}`}
+              className="truncate font-mono text-2xs text-foreground"
+            >
+              <span className="text-muted-foreground">{r.type}</span> {r.name} → {r.value}
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  )
+}

--- a/apps/web/src/pages/settings/index.tsx
+++ b/apps/web/src/pages/settings/index.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useAuth } from "@/ctx"
 import { AgentsSection } from "./agents-section"
+import { CustomDomainsSection } from "./custom-domains-section"
 import { ReportsSection } from "./reports-section"
 import { WebhooksSection } from "./webhooks-section"
 import { WorkspaceSection } from "./workspace-section"
@@ -58,6 +59,9 @@ export function Settings() {
             <TabsTrigger data-testid="settings-tab-agents" value="agents">
               Agents
             </TabsTrigger>
+            <TabsTrigger data-testid="settings-tab-domains" value="domains">
+              Domains
+            </TabsTrigger>
             {hasReports && (
               <TabsTrigger data-testid="settings-tab-reports" value="reports">
                 Reports
@@ -76,6 +80,9 @@ export function Settings() {
           </TabsContent>
           <TabsContent value="agents">
             <AgentsSection />
+          </TabsContent>
+          <TabsContent value="domains">
+            <CustomDomainsSection />
           </TabsContent>
           {hasReports && (
             <TabsContent value="reports">

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -222,7 +222,7 @@ CREATE INDEX IF NOT EXISTS collection_member_user ON collection_member (user_id)
 
 CREATE TABLE IF NOT EXISTS domain (
     host TEXT PRIMARY KEY,
-    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    artifact_id TEXT REFERENCES artifact(id),
     org_id TEXT NOT NULL,
     kind TEXT NOT NULL DEFAULT 'subdomain',
     status TEXT NOT NULL DEFAULT 'active',

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -225,6 +225,9 @@ CREATE TABLE IF NOT EXISTS domain (
     artifact_id TEXT NOT NULL REFERENCES artifact(id),
     org_id TEXT NOT NULL,
     kind TEXT NOT NULL DEFAULT 'subdomain',
+    status TEXT NOT NULL DEFAULT 'active',
+    cf_hostname_id TEXT,
+    verification TEXT,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
   );
 

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -248,13 +248,19 @@ export interface MetaStore {
    *  artifact — folded into their effective artifact role (collection sharing). */
   collectionRolesForArtifact(artifactId: string, userId: string): Promise<Role[]>
 
-  // ---- Domain mode: a hostname serving an artifact at its own origin ------
-  /** The artifact a hostname serves, or null. The hot path for host dispatch. */
+  // ---- Domain mode: a hostname serving artifact(s) at its own origin ------
+  // A domain row is either bound to one artifact (`artifact_id` set: a vanity
+  // subdomain today, a per-artifact custom domain later — served at the host root)
+  // or a workspace domain (`artifact_id` null, `org_id` set — the workspace's
+  // artifacts served at `<host>/<ref>`).
+  /** The domain record for a host, or null. The hot path for host dispatch. */
   getDomain(host: string): Promise<DomainRecord | null>
-  /** Claim a hostname for an artifact. Returns null if the host is already taken. */
+  /** Claim a host. Returns null if it's already taken (globally unique). */
   setDomain(d: NewDomain): Promise<DomainRecord | null>
-  /** Hostnames pointing at an artifact (for the share UI). */
+  /** Hosts bound to a specific artifact (subdomains; per-artifact customs later). */
   getArtifactDomains(artifactId: string): Promise<DomainRecord[]>
+  /** A workspace's own custom domains (artifact_id null), for the settings UI. */
+  getWorkspaceDomains(orgId: string): Promise<DomainRecord[]>
   /** Update a custom domain's validation status + the records to display. */
   updateDomain(
     host: string,
@@ -538,7 +544,8 @@ export interface NewCollection {
 }
 export interface DomainRecord {
   host: string
-  artifact_id: string
+  /** The artifact this host serves at its root; null for a workspace domain. */
+  artifact_id: string | null
   org_id: string
   kind: DomainKind
   status: DomainStatus
@@ -550,7 +557,8 @@ export interface DomainRecord {
 }
 export interface NewDomain {
   host: string
-  artifact_id: string
+  /** Bind to an artifact (subdomain / per-artifact custom); omit for a workspace domain. */
+  artifact_id?: string | null
   org_id: string
   kind: DomainKind
   status?: DomainStatus

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -18,6 +18,10 @@ export type Visibility = "public" | "link" | "org" | "password"
 /** A platform subdomain (`name.dockd.app`) or a customer's own domain. */
 export type DomainKind = "subdomain" | "custom"
 
+/** Serving status of a host. Subdomains are `active` immediately; a custom domain
+ *  is `pending` until its TLS cert + ownership validate (then `active`), or `error`. */
+export type DomainStatus = "active" | "pending" | "error"
+
 export interface ArtifactRecord {
   id: string
   short_id: string
@@ -251,6 +255,11 @@ export interface MetaStore {
   setDomain(d: NewDomain): Promise<DomainRecord | null>
   /** Hostnames pointing at an artifact (for the share UI). */
   getArtifactDomains(artifactId: string): Promise<DomainRecord[]>
+  /** Update a custom domain's validation status + the records to display. */
+  updateDomain(
+    host: string,
+    fields: { status?: DomainStatus; verification?: string | null },
+  ): Promise<DomainRecord | null>
   /** Release a hostname, scoped to its owning workspace. */
   deleteDomain(host: string, orgId: string): Promise<void>
 
@@ -532,6 +541,11 @@ export interface DomainRecord {
   artifact_id: string
   org_id: string
   kind: DomainKind
+  status: DomainStatus
+  /** The Cloudflare custom-hostname id, for status refresh + teardown (custom only). */
+  cf_hostname_id: string | null
+  /** JSON-encoded DNS records the customer must add to validate (custom, while pending). */
+  verification: string | null
   created_at: string
 }
 export interface NewDomain {
@@ -539,6 +553,9 @@ export interface NewDomain {
   artifact_id: string
   org_id: string
   kind: DomainKind
+  status?: DomainStatus
+  cf_hostname_id?: string | null
+  verification?: string | null
 }
 export interface CollectionMemberRecord {
   id: string

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -5,6 +5,7 @@ import type {
   CommentState,
   DeliveryStatus,
   DomainKind,
+  DomainStatus,
   NotificationKind,
   ProposalState,
   ReportState,
@@ -237,6 +238,9 @@ export const domain = pgTable("domain", {
     .references(() => artifact.id),
   org_id: text("org_id").notNull(),
   kind: text("kind").$type<DomainKind>().notNull().default("subdomain"),
+  status: text("status").$type<DomainStatus>().notNull().default("active"),
+  cf_hostname_id: text("cf_hostname_id"),
+  verification: text("verification"),
   created_at: text("created_at").notNull().$defaultFn(isoNow),
 })
 export const proposal = pgTable("proposal", {
@@ -491,6 +495,9 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
     artifact_id TEXT NOT NULL REFERENCES artifact(id),
     org_id TEXT NOT NULL,
     kind TEXT NOT NULL DEFAULT 'subdomain',
+    status TEXT NOT NULL DEFAULT 'active',
+    cf_hostname_id TEXT,
+    verification TEXT,
     created_at TEXT NOT NULL DEFAULT ${isoDefault}
   )`,
   `CREATE INDEX IF NOT EXISTS domain_artifact ON domain (artifact_id)`,

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -233,9 +233,7 @@ export const collectionMember = pgTable(
 )
 export const domain = pgTable("domain", {
   host: text("host").primaryKey(),
-  artifact_id: text("artifact_id")
-    .notNull()
-    .references(() => artifact.id),
+  artifact_id: text("artifact_id").references(() => artifact.id),
   org_id: text("org_id").notNull(),
   kind: text("kind").$type<DomainKind>().notNull().default("subdomain"),
   status: text("status").$type<DomainStatus>().notNull().default("active"),
@@ -492,7 +490,7 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
   `CREATE INDEX IF NOT EXISTS collection_member_user ON collection_member (user_id)`,
   `CREATE TABLE IF NOT EXISTS domain (
     host TEXT PRIMARY KEY,
-    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    artifact_id TEXT REFERENCES artifact(id),
     org_id TEXT NOT NULL,
     kind TEXT NOT NULL DEFAULT 'subdomain',
     status TEXT NOT NULL DEFAULT 'active',

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -11,6 +11,7 @@ import type {
   DeliveryRecord,
   DeliveryStatus,
   DomainRecord,
+  DomainStatus,
   ListArtifactsOpts,
   MembershipRecord,
   MetaStore,
@@ -734,6 +735,13 @@ export class PgMetaStore implements MetaStore {
   }
   async getArtifactDomains(artifactId: string): Promise<DomainRecord[]> {
     return this.db.select().from(domain).where(eq(domain.artifact_id, artifactId))
+  }
+  async updateDomain(
+    host: string,
+    fields: { status?: DomainStatus; verification?: string | null },
+  ): Promise<DomainRecord | null> {
+    const rows = await this.db.update(domain).set(fields).where(eq(domain.host, host)).returning()
+    return rows[0] ?? null
   }
   async deleteDomain(host: string, orgId: string): Promise<void> {
     await this.db.delete(domain).where(and(eq(domain.host, host), eq(domain.org_id, orgId)))

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -736,6 +736,12 @@ export class PgMetaStore implements MetaStore {
   async getArtifactDomains(artifactId: string): Promise<DomainRecord[]> {
     return this.db.select().from(domain).where(eq(domain.artifact_id, artifactId))
   }
+  async getWorkspaceDomains(orgId: string): Promise<DomainRecord[]> {
+    return this.db
+      .select()
+      .from(domain)
+      .where(and(eq(domain.org_id, orgId), isNull(domain.artifact_id)))
+  }
   async updateDomain(
     host: string,
     fields: { status?: DomainStatus; verification?: string | null },

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -640,6 +640,13 @@ export function makeRepos(db: SqliteDb) {
       | undefined) ?? null
   const getArtifactDomains = async (artifactId: string): Promise<DomainRecord[]> =>
     db.select().from(domain).where(eq(domain.artifact_id, artifactId)).all()
+  // A workspace's own custom domains: org-scoped and not bound to one artifact.
+  const getWorkspaceDomains = async (orgId: string): Promise<DomainRecord[]> =>
+    db
+      .select()
+      .from(domain)
+      .where(and(eq(domain.org_id, orgId), isNull(domain.artifact_id)))
+      .all()
   const updateDomain = async (
     host: string,
     fields: { status?: DomainStatus; verification?: string | null },
@@ -874,6 +881,7 @@ export function makeRepos(db: SqliteDb) {
     getDomain,
     setDomain,
     getArtifactDomains,
+    getWorkspaceDomains,
     updateDomain,
     deleteDomain,
     createProposal,

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -11,6 +11,7 @@ import type {
   DeliveryRecord,
   DeliveryStatus,
   DomainRecord,
+  DomainStatus,
   ListArtifactsOpts,
   MembershipRecord,
   NewAgent,
@@ -639,6 +640,13 @@ export function makeRepos(db: SqliteDb) {
       | undefined) ?? null
   const getArtifactDomains = async (artifactId: string): Promise<DomainRecord[]> =>
     db.select().from(domain).where(eq(domain.artifact_id, artifactId)).all()
+  const updateDomain = async (
+    host: string,
+    fields: { status?: DomainStatus; verification?: string | null },
+  ): Promise<DomainRecord | null> =>
+    ((await db.update(domain).set(fields).where(eq(domain.host, host)).returning().get()) as
+      | DomainRecord
+      | undefined) ?? null
   const deleteDomain = async (host: string, orgId: string): Promise<void> => {
     await db
       .delete(domain)
@@ -866,6 +874,7 @@ export function makeRepos(db: SqliteDb) {
     getDomain,
     setDomain,
     getArtifactDomains,
+    updateDomain,
     deleteDomain,
     createProposal,
     getProposal,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -249,9 +249,9 @@ export const collectionMember = sqliteTable(
 // subdomain (name.dockd.app) from a customer's own domain.
 export const domain = sqliteTable("domain", {
   host: text("host").primaryKey(),
-  artifact_id: text("artifact_id")
-    .notNull()
-    .references(() => artifact.id),
+  // Set when the host serves one artifact at its root (subdomain / per-artifact
+  // custom); null for a workspace domain (artifacts served at `<host>/<ref>`).
+  artifact_id: text("artifact_id").references(() => artifact.id),
   org_id: text("org_id").notNull(),
   kind: text("kind").$type<DomainKind>().notNull().default("subdomain"),
   // `active` immediately for subdomains; a custom domain is `pending` until its
@@ -512,7 +512,7 @@ export const SCHEMA_STATEMENTS: string[] = [
   `CREATE INDEX IF NOT EXISTS collection_member_user ON collection_member (user_id)`,
   `CREATE TABLE IF NOT EXISTS domain (
     host TEXT PRIMARY KEY,
-    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    artifact_id TEXT REFERENCES artifact(id),
     org_id TEXT NOT NULL,
     kind TEXT NOT NULL DEFAULT 'subdomain',
     status TEXT NOT NULL DEFAULT 'active',

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -5,6 +5,7 @@ import type {
   CommentState,
   DeliveryStatus,
   DomainKind,
+  DomainStatus,
   NotificationKind,
   ProposalState,
   ReportState,
@@ -253,6 +254,13 @@ export const domain = sqliteTable("domain", {
     .references(() => artifact.id),
   org_id: text("org_id").notNull(),
   kind: text("kind").$type<DomainKind>().notNull().default("subdomain"),
+  // `active` immediately for subdomains; a custom domain is `pending` until its
+  // Cloudflare custom-hostname cert + ownership validate.
+  status: text("status").$type<DomainStatus>().notNull().default("active"),
+  // Cloudflare custom-hostname id (for refresh + teardown) and the JSON-encoded DNS
+  // records to show while pending. Null for subdomains.
+  cf_hostname_id: text("cf_hostname_id"),
+  verification: text("verification"),
   created_at: text("created_at").notNull().default(now),
 })
 
@@ -507,6 +515,9 @@ export const SCHEMA_STATEMENTS: string[] = [
     artifact_id TEXT NOT NULL REFERENCES artifact(id),
     org_id TEXT NOT NULL,
     kind TEXT NOT NULL DEFAULT 'subdomain',
+    status TEXT NOT NULL DEFAULT 'active',
+    cf_hostname_id TEXT,
+    verification TEXT,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
   )`,
   `CREATE INDEX IF NOT EXISTS domain_artifact ON domain (artifact_id)`,


### PR DESCRIPTION
The "slap your own URL on your workspace" path: an admin attaches a domain once in Settings, and every artifact is then served at `<domain>/<ref>`. Cloudflare for SaaS issues + renews the TLS cert. Plan: https://dock-ddu.pages.dev/domains

## Backend
- **Data:** `domain.artifact_id` is now nullable. A row is either *artifact-bound* (a subdomain, served at the host root) or a *workspace domain* (`artifact_id` null, served by path). Adds `getWorkspaceDomains`; migration + d1 regen + parity.
- **CF client** (`lib/cloudflare-saas.ts`): create / refresh / remove custom hostnames; built from `CF_API_TOKEN`/`CF_ZONE_ID`/`CF_SAAS_FALLBACK_ORIGIN`, wired into node + worker. Unset → endpoints 501.
- **API:** `/v1/workspace/domains` add/list/refresh/remove (gated on workspace `manage`); the per-artifact `GET /domains` surfaces active workspace domains read-only.
- **Dispatch:** one branch keyed on *artifact-bound (root)* vs *workspace (path, org-scoped)* — a tenant can't serve another tenant's artifact, and per-artifact custom domains + wildcard subdomains can slot in later with no dispatch change.
- Self-host Caddy path deliberately cut (a self-hoster domains the whole instance instead).

## UI
- A **Custom Domains** section in workspace Settings (add, status, DNS records, refresh, remove).
- The Share dialog's Links tab shows **"Also at `<domain>/<ref>`"** read-only.

## Verification
- 203 api tests green (workspace CRUD, path serving, **tenant isolation**, 409/501); full CI clean; typecheck across node + worker + web. Verified in the browser (Settings + Share).
- Caveat: the CF Custom Hostnames calls are covered by tests with a faithful fake but unproven against a live Cloudflare zone — smoke-test against a real zone before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)