### PR TITLE
test(api): cover the deploy/entry surface; extract shutdown to lifecycle.ts

### DIFF
--- a/apps/api/src/lifecycle.ts
+++ b/apps/api/src/lifecycle.ts
@@ -1,0 +1,68 @@
+/**
+ * Graceful shutdown, extracted from the Node entry so the sequence is unit-testable
+ * (the entry itself boots a real server + process handlers on import). Fly's
+ * auto-stop and every redeploy send SIGTERM: stop the background worker + timers,
+ * stop accepting connections and drain in-flight requests, close the datastores,
+ * then exit — instead of Node's default of dropping everything mid-flight.
+ */
+interface ShutdownLogger {
+  info(msg: string, fields?: Record<string, unknown>): void
+  error(msg: string, fields?: Record<string, unknown>): void
+}
+
+/** The subset of a Node http.Server the shutdown touches. closeIdleConnections is
+ *  optional because @hono/node-server's return type is an http2/https union. */
+interface ClosableServer {
+  close(cb: () => void): void
+  closeIdleConnections?: () => void
+}
+
+export interface ShutdownDeps {
+  server: ClosableServer
+  stopWorker: () => void
+  clearTimers: () => void
+  closeStores: () => Promise<void>
+  log: ShutdownLogger
+  exit: (code: number) => void
+  /** Hard deadline before a hung drain is force-exited. Defaults to 10s. */
+  deadlineMs?: number
+}
+
+/**
+ * Build the signal handler. The returned function is idempotent: a second signal
+ * (SIGTERM then SIGINT, or a repeated SIGTERM) is a no-op while the first drain is
+ * in flight. A hard deadline guarantees the process exits even if `close()` or
+ * `closeStores()` hangs, so the orchestrator is never wedged.
+ */
+export const makeShutdown = (deps: ShutdownDeps): ((signal: string) => Promise<void>) => {
+  let shuttingDown = false
+  return async (signal: string): Promise<void> => {
+    if (shuttingDown) return
+    shuttingDown = true
+    deps.log.info("shutting down", { signal })
+    const deadline = setTimeout(() => {
+      deps.log.error("shutdown timed out; forcing exit")
+      deps.exit(1)
+    }, deps.deadlineMs ?? 10_000)
+    deadline.unref?.()
+    deps.stopWorker()
+    deps.clearTimers()
+    // close() resolves once existing connections end, but Node never closes IDLE
+    // keep-alive sockets on its own — a parked browser/LB connection would keep it
+    // pending until the deadline. closeIdleConnections drops those now; in-flight
+    // requests keep their socket and still drain.
+    const drained = new Promise<void>((resolve) => deps.server.close(() => resolve()))
+    deps.server.closeIdleConnections?.()
+    await drained
+    try {
+      await deps.closeStores()
+    } catch (e) {
+      deps.log.error("error closing datastores", {
+        error: e instanceof Error ? e.message : String(e),
+      })
+    }
+    clearTimeout(deadline)
+    deps.log.info("shutdown complete")
+    deps.exit(0)
+  }
+}

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -12,6 +12,7 @@ import { createApp } from "./app"
 import { type AuthDb, makeAuth, migrateAuth } from "./auth-config"
 import { loadConfig, resolveAuthSecret, resolveDefaultOrg } from "./config"
 import { mountWeb } from "./lib/serve-web"
+import { makeShutdown } from "./lifecycle"
 import { log } from "./log"
 import { startWebhookWorker } from "./webhooks"
 
@@ -185,39 +186,24 @@ const server = serve({ fetch: app.fetch, port: cfg.port }, () => {
   })
 })
 
-// Graceful shutdown: Fly's auto-stop and every redeploy send SIGTERM. Stop the
-// worker + timers, stop accepting connections and drain in-flight requests, close
-// the datastores, then exit — instead of Node's default of dropping everything.
-let shuttingDown = false
-const shutdown = async (signal: string) => {
-  if (shuttingDown) return
-  shuttingDown = true
-  log.info("shutting down", { signal })
-  // Hard deadline so a hung drain can't wedge the orchestrator forever.
-  setTimeout(() => {
-    log.error("shutdown timed out; forcing exit")
-    process.exit(1)
-  }, 10_000).unref()
-  stopWorker()
-  if (pruneTimer) clearInterval(pruneTimer)
-  // server.close() stops accepting connections and resolves once existing ones end,
-  // but Node never closes IDLE keep-alive sockets on its own — a browser, a load
-  // balancer, or any client holding one keeps close() pending until the hard
-  // deadline force-exits (a 10s stall on every redeploy). closeIdleConnections drops
-  // those now; in-flight requests keep their socket and still drain.
-  const drained = new Promise<void>((resolve) => server.close(() => resolve()))
-  // `in` narrows the http2/https union @hono/node-server returns; our serve() is a
-  // plain http.Server, which has had closeIdleConnections since Node 18.2.
-  if ("closeIdleConnections" in server) server.closeIdleConnections()
-  await drained
-  try {
-    await closeStores()
-  } catch (e) {
-    log.error("error closing datastores", { error: e instanceof Error ? e.message : String(e) })
-  }
-  log.info("shutdown complete")
-  process.exit(0)
-}
+// Graceful shutdown: Fly's auto-stop and every redeploy send SIGTERM. The sequence
+// lives in lifecycle.ts (so it's unit-testable); here we just wire the real server,
+// timers, and datastores to it. `in` narrows the http2/https union @hono/node-server
+// returns to the plain http.Server we create (closeIdleConnections since Node 18.2).
+const shutdown = makeShutdown({
+  server: {
+    close: (cb) => server.close(() => cb()),
+    closeIdleConnections:
+      "closeIdleConnections" in server ? () => server.closeIdleConnections() : undefined,
+  },
+  stopWorker,
+  clearTimers: () => {
+    if (pruneTimer) clearInterval(pruneTimer)
+  },
+  closeStores,
+  log,
+  exit: (code) => process.exit(code),
+})
 process.on("SIGTERM", () => void shutdown("SIGTERM"))
 process.on("SIGINT", () => void shutdown("SIGINT"))
 

--- a/apps/api/test/auth-config.test.ts
+++ b/apps/api/test/auth-config.test.ts
@@ -1,0 +1,72 @@
+import Database from "better-sqlite3"
+import { afterEach, describe, expect, it } from "vitest"
+import { makeAuth } from "../src/auth-config"
+
+// makeAuth wires optional identity providers off env: Google when its client
+// id/secret are set, and an enterprise OIDC provider (Okta/Entra/…) via the
+// generic-OAuth plugin when OIDC_* is set. These cover the provider branches that
+// the same-origin test (which runs with neither set) leaves cold.
+const PROVIDER_ENV = [
+  "GOOGLE_CLIENT_ID",
+  "GOOGLE_CLIENT_SECRET",
+  "OIDC_ISSUER",
+  "OIDC_CLIENT_ID",
+  "OIDC_CLIENT_SECRET",
+  "OIDC_PROVIDER_ID",
+  "DOCK_CROSS_SITE",
+] as const
+
+const saved = Object.fromEntries(PROVIDER_ENV.map((k) => [k, process.env[k]]))
+const db = () => new Database(":memory:")
+
+afterEach(() => {
+  for (const k of PROVIDER_ENV) {
+    if (saved[k] === undefined) delete process.env[k]
+    else process.env[k] = saved[k]
+  }
+})
+
+describe("auth-config: optional providers", () => {
+  it("enables Google when GOOGLE_CLIENT_ID/SECRET are set", () => {
+    process.env.GOOGLE_CLIENT_ID = "gid"
+    process.env.GOOGLE_CLIENT_SECRET = "gsecret"
+    const auth = makeAuth(db(), "http://dock.test", "test-secret-0123456789abcd")
+    expect(auth.options.socialProviders?.google).toMatchObject({
+      clientId: "gid",
+      clientSecret: "gsecret",
+    })
+  })
+
+  it("does not enable Google when only one of the pair is set", () => {
+    process.env.GOOGLE_CLIENT_ID = "gid" // no secret
+    const auth = makeAuth(db(), "http://dock.test", "test-secret-0123456789abcd")
+    expect(auth.options.socialProviders?.google).toBeUndefined()
+  })
+
+  it("registers the generic-OAuth (OIDC) plugin when OIDC_* is set", () => {
+    process.env.OIDC_ISSUER = "https://issuer.example.com/"
+    process.env.OIDC_CLIENT_ID = "oid"
+    process.env.OIDC_CLIENT_SECRET = "osecret"
+    process.env.OIDC_PROVIDER_ID = "okta"
+    const auth = makeAuth(db(), "http://dock.test", "test-secret-0123456789abcd")
+    // The plugin self-registers an endpoint surface; its presence is the signal.
+    expect(Array.isArray(auth.options.plugins)).toBe(true)
+    expect(auth.options.plugins?.length).toBeGreaterThan(0)
+  })
+
+  it("omits the OIDC plugin when the OIDC_* trio is incomplete", () => {
+    process.env.OIDC_ISSUER = "https://issuer.example.com/"
+    // no client id/secret
+    const auth = makeAuth(db(), "http://dock.test", "test-secret-0123456789abcd")
+    expect(auth.options.plugins ?? []).toHaveLength(0)
+  })
+
+  it("applies SameSite=None;Secure cookies when DOCK_CROSS_SITE=true", () => {
+    process.env.DOCK_CROSS_SITE = "true"
+    const auth = makeAuth(db(), "http://dock.test", "test-secret-0123456789abcd")
+    expect(auth.options.advanced?.defaultCookieAttributes).toMatchObject({
+      sameSite: "none",
+      secure: true,
+    })
+  })
+})

--- a/apps/api/test/config.test.ts
+++ b/apps/api/test/config.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest"
-import { loadConfig } from "../src/config"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { loadConfig, resolveAuthSecret, resolveDefaultOrg } from "../src/config"
 
 // loadConfig should fail fast at boot on a malformed value rather than coercing it
 // to a silent default (or failing lazily on the first request that touches it).
@@ -12,6 +15,11 @@ describe("config: fail-fast env validation", () => {
 
   it("rejects a non-numeric PORT", () => {
     expect(() => loadConfig({ ...base, PORT: "nope" })).toThrow(/PORT/)
+  })
+
+  it("rejects a zero / negative PORT", () => {
+    expect(() => loadConfig({ ...base, PORT: "0" })).toThrow(/PORT/)
+    expect(() => loadConfig({ ...base, PORT: "-1" })).toThrow(/PORT/)
   })
 
   it("rejects a malformed BASE_URL", () => {
@@ -33,5 +41,176 @@ describe("config: fail-fast env validation", () => {
   it("ignores an invalid quota knob (no-limit) without throwing", () => {
     // A typo'd cap is "no limit", warned not fatal — it shouldn't take the app down.
     expect(loadConfig({ ...base, DOCK_MAX_ARTIFACTS: "lots" }).maxArtifacts).toBeUndefined()
+  })
+})
+
+// The public origin drives auth cookies + share links. An explicit BASE_URL always
+// wins; otherwise infer the URL a managed host assigned us, so a one-click deploy
+// gets working auth without anyone hand-typing the domain.
+describe("config: baseUrl inference", () => {
+  it("prefers an explicit BASE_URL over everything", () => {
+    const c = loadConfig({
+      BASE_URL: "https://dock.example.com",
+      RAILWAY_PUBLIC_DOMAIN: "ignored.up.railway.app",
+      FLY_APP_NAME: "ignored",
+    })
+    expect(c.baseUrl).toBe("https://dock.example.com")
+  })
+
+  it("infers https from RAILWAY_PUBLIC_DOMAIN", () => {
+    expect(loadConfig({ RAILWAY_PUBLIC_DOMAIN: "dock.up.railway.app" }).baseUrl).toBe(
+      "https://dock.up.railway.app",
+    )
+  })
+
+  it("uses RENDER_EXTERNAL_URL verbatim (it already carries the scheme)", () => {
+    expect(loadConfig({ RENDER_EXTERNAL_URL: "https://dock.onrender.com" }).baseUrl).toBe(
+      "https://dock.onrender.com",
+    )
+  })
+
+  it("infers https://<app>.fly.dev from FLY_APP_NAME", () => {
+    expect(loadConfig({ FLY_APP_NAME: "my-dock" }).baseUrl).toBe("https://my-dock.fly.dev")
+  })
+
+  it("falls back to http://localhost:<port> with nothing set", () => {
+    expect(loadConfig({ PORT: "9090" }).baseUrl).toBe("http://localhost:9090")
+  })
+
+  it("orders the managed hosts Railway > Render > Fly", () => {
+    const c = loadConfig({
+      RAILWAY_PUBLIC_DOMAIN: "r.up.railway.app",
+      RENDER_EXTERNAL_URL: "https://render.example",
+      FLY_APP_NAME: "fly-app",
+    })
+    expect(c.baseUrl).toBe("https://r.up.railway.app")
+  })
+})
+
+// The env -> Config field mapping: defaults, on/off knobs, list parsing, and the
+// derived bundled-SPA flags. These feed every downstream subsystem.
+describe("config: field mapping", () => {
+  const base = { PORT: "8080", BASE_URL: "http://dock.test" }
+
+  it("defaults analytics + rate limiting on, and turns them off only on 'false'", () => {
+    const on = loadConfig({ ...base })
+    expect(on.analytics).toBe(true)
+    expect(on.rateLimit).toBe(true)
+    const off = loadConfig({ ...base, DOCK_ANALYTICS: "false", DOCK_RATE_LIMIT: "false" })
+    expect(off.analytics).toBe(false)
+    expect(off.rateLimit).toBe(false)
+  })
+
+  it("parses superAdmins as a trimmed, lowercased, comma-separated list", () => {
+    const c = loadConfig({ ...base, DOCK_SUPERADMIN_EMAILS: " Amy@X.com , bob@y.com ,," })
+    expect(c.superAdmins).toEqual(["amy@x.com", "bob@y.com"])
+  })
+
+  it("normalizes subdomainBase (lowercase, strips leading/trailing dots)", () => {
+    expect(loadConfig({ ...base, DOCK_SUBDOMAIN_BASE: ".Dockd.App." }).subdomainBase).toBe(
+      "dockd.app",
+    )
+    expect(loadConfig({ ...base, DOCK_SUBDOMAIN_BASE: "" }).subdomainBase).toBeUndefined()
+  })
+
+  it("turns the version window from minutes into ms", () => {
+    expect(loadConfig({ ...base, DOCK_VERSION_WINDOW: "5" }).versionWindowMs).toBe(300_000)
+    expect(loadConfig({ ...base }).versionWindowMs).toBeUndefined()
+  })
+
+  it("parses the web-origin allowlist and crossSite flag", () => {
+    const c = loadConfig({
+      ...base,
+      DOCK_WEB_ORIGIN: "https://a.com, https://b.com",
+      DOCK_CROSS_SITE: "true",
+    })
+    expect(c.webOrigins).toEqual(["https://a.com", "https://b.com"])
+    expect(c.crossSite).toBe(true)
+  })
+
+  it("serveWeb is false when no built shell is present (empty DOCK_WEB_DIR)", () => {
+    const empty = mkdtempSync(join(tmpdir(), "dock-webdir-"))
+    try {
+      const c = loadConfig({ ...base, DOCK_WEB_DIR: empty })
+      expect(c.serveWeb).toBe(false)
+      expect(c.webDir).toBe(empty)
+    } finally {
+      rmSync(empty, { recursive: true, force: true })
+    }
+  })
+
+  it("serveWeb is true and webShell points at index.html when the SPA is built", () => {
+    const dir = mkdtempSync(join(tmpdir(), "dock-webdir-"))
+    try {
+      writeFileSync(join(dir, "index.html"), "<!doctype html>")
+      const c = loadConfig({ ...base, DOCK_WEB_DIR: dir })
+      expect(c.serveWeb).toBe(true)
+      expect(c.webShell).toBe(join(dir, "index.html"))
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+// A stable session-signing secret survives restarts (or zero-config self-host would
+// invalidate every session on each boot). Explicit env wins; else persist beside data.
+describe("config: resolveAuthSecret", () => {
+  let dir: string
+  const saved = process.env.DOCK_AUTH_SECRET
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "dock-secret-"))
+    delete process.env.DOCK_AUTH_SECRET
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+    if (saved === undefined) delete process.env.DOCK_AUTH_SECRET
+    else process.env.DOCK_AUTH_SECRET = saved
+  })
+
+  it("uses an explicit DOCK_AUTH_SECRET (>= 16 chars)", () => {
+    process.env.DOCK_AUTH_SECRET = "a-very-long-explicit-secret"
+    expect(resolveAuthSecret(dir)).toBe("a-very-long-explicit-secret")
+  })
+
+  it("ignores a too-short env secret and generates+persists one instead", () => {
+    process.env.DOCK_AUTH_SECRET = "short"
+    const s = resolveAuthSecret(dir)
+    expect(s).not.toBe("short")
+    expect(s.length).toBeGreaterThanOrEqual(32)
+    // Persisted so the next boot reuses it.
+    expect(readFileSync(join(dir, ".auth-secret"), "utf8").trim()).toBe(s)
+  })
+
+  it("reuses the persisted secret on a later call (stable across restarts)", () => {
+    const first = resolveAuthSecret(dir)
+    expect(resolveAuthSecret(dir)).toBe(first)
+  })
+})
+
+// The bootstrap workspace id is a real persisted value, so enabling multi-workspace
+// later needs no data migration.
+describe("config: resolveDefaultOrg", () => {
+  let dir: string
+  const saved = process.env.DOCK_DEFAULT_ORG_ID
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "dock-org-"))
+    delete process.env.DOCK_DEFAULT_ORG_ID
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+    if (saved === undefined) delete process.env.DOCK_DEFAULT_ORG_ID
+    else process.env.DOCK_DEFAULT_ORG_ID = saved
+  })
+
+  it("uses an explicit DOCK_DEFAULT_ORG_ID", () => {
+    process.env.DOCK_DEFAULT_ORG_ID = "ws_explicit"
+    expect(resolveDefaultOrg(dir)).toBe("ws_explicit")
+  })
+
+  it("generates a ws_-prefixed id, persists it, and reuses it", () => {
+    const id = resolveDefaultOrg(dir)
+    expect(id).toMatch(/^ws_[0-9a-f]+$/)
+    expect(readFileSync(join(dir, ".org-id"), "utf8").trim()).toBe(id)
+    expect(resolveDefaultOrg(dir)).toBe(id)
   })
 })

--- a/apps/api/test/lifecycle.test.ts
+++ b/apps/api/test/lifecycle.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest"
+import { makeShutdown, type ShutdownDeps } from "../src/lifecycle"
+
+// A controllable server: by default close() resolves on the next tick; pass
+// neverCloses to simulate a hung drain (a parked keep-alive connection).
+const makeDeps = (over: Partial<ShutdownDeps> & { neverCloses?: boolean } = {}) => {
+  const { neverCloses, ...rest } = over
+  const log = { info: vi.fn(), error: vi.fn() }
+  const exit = vi.fn()
+  const closeIdleConnections = vi.fn()
+  const close = vi.fn((cb: () => void) => {
+    if (!neverCloses) queueMicrotask(cb)
+  })
+  const deps: ShutdownDeps = {
+    server: { close, closeIdleConnections },
+    stopWorker: vi.fn(),
+    clearTimers: vi.fn(),
+    closeStores: vi.fn(async () => {}),
+    log,
+    exit,
+    ...rest,
+  }
+  return { deps, log, exit, close, closeIdleConnections }
+}
+
+describe("lifecycle: graceful shutdown", () => {
+  it("runs the full sequence and exits 0", async () => {
+    const { deps, log, exit, close, closeIdleConnections } = makeDeps()
+    await makeShutdown(deps)("SIGTERM")
+    expect(log.info).toHaveBeenCalledWith("shutting down", { signal: "SIGTERM" })
+    expect(deps.stopWorker).toHaveBeenCalledOnce()
+    expect(deps.clearTimers).toHaveBeenCalledOnce()
+    expect(close).toHaveBeenCalledOnce()
+    // Idle keep-alive sockets are dropped so the drain doesn't stall on them.
+    expect(closeIdleConnections).toHaveBeenCalledOnce()
+    expect(deps.closeStores).toHaveBeenCalledOnce()
+    expect(log.info).toHaveBeenCalledWith("shutdown complete")
+    expect(exit).toHaveBeenCalledWith(0)
+  })
+
+  it("is idempotent — a second signal while draining is a no-op", async () => {
+    const { deps, exit } = makeDeps()
+    const shutdown = makeShutdown(deps)
+    const first = shutdown("SIGTERM")
+    const second = shutdown("SIGINT") // shuttingDown already set synchronously
+    await Promise.all([first, second])
+    expect(deps.stopWorker).toHaveBeenCalledOnce()
+    expect(exit).toHaveBeenCalledOnce()
+    expect(exit).toHaveBeenCalledWith(0)
+  })
+
+  it("still exits 0 if closing the datastores throws (logs the error)", async () => {
+    const { deps, log, exit } = makeDeps({
+      closeStores: vi.fn(async () => {
+        throw new Error("pool already ended")
+      }),
+    })
+    await makeShutdown(deps)("SIGTERM")
+    expect(log.error).toHaveBeenCalledWith(
+      "error closing datastores",
+      expect.objectContaining({ error: "pool already ended" }),
+    )
+    expect(exit).toHaveBeenCalledWith(0)
+  })
+
+  it("works when the server has no closeIdleConnections (http2/https union member)", async () => {
+    const close = vi.fn((cb: () => void) => queueMicrotask(cb))
+    const exit = vi.fn()
+    const deps: ShutdownDeps = {
+      server: { close }, // no closeIdleConnections
+      stopWorker: vi.fn(),
+      clearTimers: vi.fn(),
+      closeStores: vi.fn(async () => {}),
+      log: { info: vi.fn(), error: vi.fn() },
+      exit,
+    }
+    await makeShutdown(deps)("SIGTERM")
+    expect(exit).toHaveBeenCalledWith(0)
+  })
+
+  it("force-exits 1 when the drain hangs past the deadline", async () => {
+    const { deps, log, exit } = makeDeps({ neverCloses: true, deadlineMs: 20 })
+    // close() never calls back, so the shutdown promise never resolves — don't await
+    // it; just let the hard deadline fire.
+    void makeShutdown(deps)("SIGTERM")
+    await new Promise((r) => setTimeout(r, 50))
+    expect(log.error).toHaveBeenCalledWith("shutdown timed out; forcing exit")
+    expect(exit).toHaveBeenCalledWith(1)
+  })
+})

--- a/apps/api/test/worker.test.ts
+++ b/apps/api/test/worker.test.ts
@@ -1,0 +1,42 @@
+import type { ExecutionContext } from "@cloudflare/workers-types"
+import { describe, expect, it } from "vitest"
+import type { Env } from "../src/worker"
+import worker from "../src/worker"
+
+// The Workers entry must fail CLOSED when the session-signing secret is absent or
+// weak: a stateless Worker can't generate+persist one like the Node path, and
+// booting with a forgeable secret would let anyone mint a valid session. The check
+// runs before any binding is touched, so it's unit-testable without D1/R2/DO mocks.
+//
+// (The successful-boot path needs the workerd runtime + real bindings and is covered
+// by the wrangler-dev integration run, not here. These tests never build the app, so
+// the module-level `app` singleton stays null and each assertion re-runs the check.)
+const ctx = { waitUntil() {}, passThroughOnException() {} } as unknown as ExecutionContext
+const req = new Request("https://dock.test/")
+
+describe("worker (edge): fail-closed auth secret", () => {
+  it("throws when DOCK_AUTH_SECRET is unset", () => {
+    expect(() => worker.fetch(req, {} as Env, ctx)).toThrow(/DOCK_AUTH_SECRET/)
+  })
+
+  it("throws when DOCK_AUTH_SECRET is too short (< 16 chars)", () => {
+    expect(() => worker.fetch(req, { DOCK_AUTH_SECRET: "short" } as Env, ctx)).toThrow(
+      /DOCK_AUTH_SECRET/,
+    )
+  })
+
+  it("throws on a 15-char secret but not a 16-char one (boundary)", () => {
+    expect(() => worker.fetch(req, { DOCK_AUTH_SECRET: "x".repeat(15) } as Env, ctx)).toThrow(
+      /DOCK_AUTH_SECRET/,
+    )
+    // A 16-char secret clears the secret gate, so failure (if any) is downstream in
+    // binding setup — NOT the ">= 16 chars" guard. Either way it must not throw that.
+    let msg = ""
+    try {
+      worker.fetch(req, { DOCK_AUTH_SECRET: "x".repeat(16) } as Env, ctx)
+    } catch (e) {
+      msg = e instanceof Error ? e.message : String(e)
+    }
+    expect(msg).not.toMatch(/DOCK_AUTH_SECRET/)
+  })
+})

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -9,13 +9,18 @@ import { defineConfig } from "vitest/config"
 // 74% lines, vs ~73% across the board before). That's a measurement-basis change,
 // not a coverage regression — so the floor is reset to the new basis, not lowered
 // to hide lost coverage.
+//
+// Raised after backfilling the deploy/entry surface (config.ts, worker.ts edge
+// secret gate, the extracted shutdown in lifecycle.ts, auth-config providers): the
+// suite now reports ~82% lines / 75% stmts / 68% branches. Floor sits just under
+// that so a regression fails but normal noise doesn't.
 export default defineConfig({
   test: {
     coverage: {
       provider: "v8",
       include: ["src/**"],
       reporter: ["text-summary"],
-      thresholds: { lines: 72, statements: 66, branches: 57 },
+      thresholds: { lines: 80, statements: 74, branches: 66 },
     },
   },
 })


### PR DESCRIPTION
First of a few coverage PRs. The deploy code shipped this week (#120/#121/#122/#124) was the least-tested part of the suite, so it gets covered first and the api gate ratchets up to lock it in.

## What's covered
- **config.ts 55% → 94%** — the baseUrl inference matrix (explicit `BASE_URL` wins, then Railway → Render → Fly → localhost, in order; this is the inference behind the auth-origin footgun), env→Config field mapping (superAdmins parsing, `subdomainBase` normalization, version window minutes→ms, web-origin allowlist, `serveWeb`/`webShell` from a built SPA dir), and `resolveAuthSecret` / `resolveDefaultOrg` (explicit env wins, persist-and-reuse, too-short-secret regenerates).
- **lifecycle.ts (new) at 100%** — the graceful-shutdown sequence, **extracted from `node.ts`** so it's unit-testable. `node.ts` now just wires the real server / timers / stores to it; behavior is identical. Tests: happy path, idempotency (a second SIGTERM/SIGINT while draining is a no-op), `closeStores` throwing (still exits 0), the http2/https union member with no `closeIdleConnections`, and the hard-deadline force-exit(1) when the drain hangs.
- **worker.ts 0% → 66%** — the fail-closed edge auth-secret gate (unset / too short / 16-char boundary). The successful-boot path needs the workerd runtime and stays covered by the wrangler-dev integration run.
- **auth-config.ts → 100%** — Google + OIDC provider branches, cross-site cookie attributes.

## Numbers
apps/api: **198 → 230 tests**, **~79% → ~82% lines**, **65.5% → 68% branches**. Coverage gate raised `72/66/57` → `80/74/66` (floor sits just under actuals).

Typecheck (node + worker) + biome + 230 tests all green; the CI coverage gate passes at the new floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)