### PR TITLE
test: cover blob stores + core domain logic; gate storage/core/mcp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,8 @@ jobs:
         run: pnpm test:pg
 
   # Coverage gates (ratchet floors; see each package's vitest.config.ts): the API
-  # suite and the data layer (@dock/db repos + sqlite driver).
+  # suite, the data layer (@dock/db), the shared domain logic (@dock/core), the blob
+  # stores (@dock/storage), and the MCP client.
   coverage:
     runs-on: ubicloud-standard-2
     steps:
@@ -70,6 +71,12 @@ jobs:
         run: pnpm --filter @dock/api test:coverage
       - name: DB coverage
         run: pnpm --filter @dock/db test:coverage
+      - name: Core coverage
+        run: pnpm --filter @dock/core test:coverage
+      - name: Storage coverage
+        run: pnpm --filter @dock/storage test:coverage
+      - name: MCP coverage
+        run: pnpm --filter @dock/mcp test:coverage
 
   # Bundle budget: build the web client and fail if the gzipped JS blows past the
   # budget (see scripts/check-bundle.mjs), so phosphor / radix / cmdk weight can't

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,8 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "fflate": "^0.8.2",

--- a/packages/core/test/hash.test.ts
+++ b/packages/core/test/hash.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+import { sha256Hex } from "../src/hash"
+
+describe("sha256Hex", () => {
+  it("returns the known digest for a fixed input", async () => {
+    // The canonical sha256("abc").
+    expect(await sha256Hex(new TextEncoder().encode("abc"))).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    )
+  })
+
+  it("digests empty input and is deterministic + content-addressed", async () => {
+    expect(await sha256Hex(new Uint8Array())).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    )
+    const a = await sha256Hex(new TextEncoder().encode("same"))
+    const b = await sha256Hex(new TextEncoder().encode("same"))
+    const c = await sha256Hex(new TextEncoder().encode("different"))
+    expect(a).toBe(b)
+    expect(a).not.toBe(c)
+    expect(a).toMatch(/^[0-9a-f]{64}$/)
+  })
+})

--- a/packages/core/test/mime.test.ts
+++ b/packages/core/test/mime.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { mimeFor } from "../src/mime"
+
+describe("mimeFor", () => {
+  it("maps known extensions (case-insensitive, by last segment)", () => {
+    expect(mimeFor("index.html")).toBe("text/html; charset=utf-8")
+    expect(mimeFor("README.MD")).toBe("text/markdown; charset=utf-8")
+    expect(mimeFor("app.js")).toBe("text/javascript; charset=utf-8")
+    expect(mimeFor("data.json")).toBe("application/json; charset=utf-8")
+    expect(mimeFor("logo.svg")).toBe("image/svg+xml")
+    expect(mimeFor("photo.JPEG")).toBe("image/jpeg")
+    expect(mimeFor("font.woff2")).toBe("font/woff2")
+  })
+
+  it("falls back to octet-stream for unknown or missing extensions", () => {
+    expect(mimeFor("mystery.xyz")).toBe("application/octet-stream")
+    expect(mimeFor("noext")).toBe("application/octet-stream")
+  })
+
+  it("uses the final extension of a multi-dot path", () => {
+    expect(mimeFor("bundle.min.css")).toBe("text/css; charset=utf-8")
+    expect(mimeFor("archive.tar.gz")).toBe("application/octet-stream")
+  })
+})

--- a/packages/core/test/publish.test.ts
+++ b/packages/core/test/publish.test.ts
@@ -1,0 +1,302 @@
+import { zipSync } from "fflate"
+import { describe, expect, it } from "vitest"
+import { sha256Hex } from "../src/hash"
+import type {
+  ArtifactRecord,
+  BlobStore,
+  MetaStore,
+  NewArtifact,
+  NewProposal,
+  NewVersion,
+} from "../src/ports"
+import {
+  approveProposal,
+  artifactUrl,
+  type ProposeInput,
+  PublishError,
+  type PublishInput,
+  propose,
+  publish,
+  toJson,
+} from "../src/publish"
+
+// publish()/propose() store content then write the artifact/version. The
+// interesting, security-relevant logic is storeContent's bundle handling (zip
+// entry detection + path cleaning), reachable only through publish(). Drive it with
+// a Map-backed blob store and a tiny fake MetaStore implementing just the handful of
+// methods these two functions touch.
+const makeBlobs = (): BlobStore => {
+  const map = new Map<string, Uint8Array>()
+  return {
+    put: async (d) => {
+      const k = await sha256Hex(d)
+      map.set(k, d)
+      return k
+    },
+    get: async (k) => map.get(k) ?? null,
+  }
+}
+
+// A focused in-memory fake: only the handful of methods publish/propose/approve
+// actually call, over plain records (no `any`). Cast through MetaStore at the end —
+// the uncalled ~75 methods are never reached.
+type FakeArtifact = NewArtifact & { current_version: number; created_at: string; removed_at: null }
+type FakeVersion = NewVersion & { n: number; artifact_id: string; created_at: string }
+type FakeProposal = NewProposal & { state: string; created_at: string }
+
+const makeMeta = (): MetaStore => {
+  const byShort = new Map<string, FakeArtifact>()
+  const byId = new Map<string, FakeArtifact>()
+  const versions = new Map<string, FakeVersion[]>()
+  const proposals = new Map<string, FakeProposal>()
+  const meta = {
+    createArtifact: async (a: NewArtifact): Promise<FakeArtifact> => {
+      const rec: FakeArtifact = { ...a, current_version: 0, created_at: "t", removed_at: null }
+      byShort.set(a.short_id, rec)
+      byId.set(a.id, rec)
+      return rec
+    },
+    getByShortId: async (s: string) => byShort.get(s) ?? null,
+    getArtifactById: async (id: string) => byId.get(id) ?? null,
+    addVersion: async (artifactId: string, v: NewVersion): Promise<FakeVersion> => {
+      const list = versions.get(artifactId) ?? []
+      const rec: FakeVersion = {
+        ...v,
+        n: list.length + 1,
+        artifact_id: artifactId,
+        created_at: "t",
+      }
+      list.push(rec)
+      versions.set(artifactId, list)
+      const art = byId.get(artifactId)
+      if (art) art.current_version = rec.n
+      return rec
+    },
+    createProposal: async (p: NewProposal): Promise<FakeProposal> => {
+      const rec: FakeProposal = { ...p, state: "open", created_at: "t" }
+      proposals.set(p.id, rec)
+      return rec
+    },
+    getProposal: async (id: string) => proposals.get(id) ?? null,
+    decideProposal: async (id: string, f: Record<string, unknown>) => {
+      const p = proposals.get(id)
+      if (p) Object.assign(p, f)
+      return p ?? null
+    },
+  }
+  return meta as unknown as MetaStore
+}
+
+const file = (body: string, over: Partial<PublishInput> = {}): PublishInput => ({
+  bytes: new TextEncoder().encode(body),
+  filename: "page.html",
+  isBundle: false,
+  ...over,
+})
+
+const zip = (files: Record<string, string>): Uint8Array =>
+  zipSync(
+    Object.fromEntries(Object.entries(files).map(([k, v]) => [k, new TextEncoder().encode(v)])),
+  )
+
+const bundle = (files: Record<string, string>, over: Partial<PublishInput> = {}): PublishInput => ({
+  bytes: zip(files),
+  filename: "site.zip",
+  isBundle: true,
+  ...over,
+})
+
+describe("publish: single file", () => {
+  it("creates an artifact + first version, titled from the filename", async () => {
+    const meta = makeMeta()
+    const blobs = makeBlobs()
+    const { artifact, version } = await publish(meta, blobs, file("<h1>hi</h1>"))
+    expect(artifact.kind).toBe("file")
+    expect(artifact.title).toBe("page") // ".html" stripped
+    expect(artifact.visibility).toBe("link")
+    expect(version.n).toBe(1)
+    expect(version.content_type).toBe("text/html")
+    expect(new TextDecoder().decode((await blobs.get(version.blob_key)) ?? undefined)).toBe(
+      "<h1>hi</h1>",
+    )
+  })
+
+  it("detects markdown by extension", async () => {
+    const { version } = await publish(makeMeta(), makeBlobs(), file("# md", { filename: "doc.md" }))
+    expect(version.content_type).toBe("text/markdown")
+  })
+
+  it("honors explicit title, visibility, and author", async () => {
+    const { artifact, version } = await publish(
+      makeMeta(),
+      makeBlobs(),
+      file("x", { title: "Custom", visibility: "public", author: "amy" }),
+    )
+    expect(artifact.title).toBe("Custom")
+    expect(artifact.visibility).toBe("public")
+    expect(version.author).toBe("amy")
+  })
+})
+
+describe("publish: bundles (zip)", () => {
+  it("prefers a root index.html as the entry point", async () => {
+    const blobs = makeBlobs()
+    const { artifact, version } = await publish(
+      makeMeta(),
+      blobs,
+      bundle({ "index.html": "<h1>home</h1>", "style.css": "body{}" }),
+    )
+    expect(artifact.kind).toBe("bundle")
+    const manifest = JSON.parse(
+      new TextDecoder().decode((await blobs.get(version.blob_key)) ?? undefined),
+    )
+    expect(manifest.entry).toBe("/index.html")
+    expect(Object.keys(manifest.files).sort()).toEqual(["/index.html", "/style.css"])
+  })
+
+  it("falls back to the shallowest html when there's no root index", async () => {
+    const blobs = makeBlobs()
+    const { version } = await publish(
+      makeMeta(),
+      blobs,
+      bundle({ "deep/a/b.html": "x", "top.html": "y" }),
+    )
+    const manifest = JSON.parse(
+      new TextDecoder().decode((await blobs.get(version.blob_key)) ?? undefined),
+    )
+    expect(manifest.entry).toBe("/top.html")
+  })
+
+  it("strips path-traversal, __MACOSX, and .DS_Store entries", async () => {
+    const blobs = makeBlobs()
+    const { version } = await publish(
+      makeMeta(),
+      blobs,
+      bundle({
+        "../escape.html": "no",
+        "__MACOSX/x": "no",
+        ".DS_Store": "no",
+        "ok.html": "yes",
+      }),
+    )
+    const manifest = JSON.parse(
+      new TextDecoder().decode((await blobs.get(version.blob_key)) ?? undefined),
+    )
+    expect(Object.keys(manifest.files)).toEqual(["/ok.html"])
+    expect(manifest.entry).toBe("/ok.html")
+  })
+
+  it("rejects a non-zip, an empty bundle, and one with no html entry", async () => {
+    const meta = makeMeta()
+    const blobs = makeBlobs()
+    await expect(
+      publish(meta, blobs, {
+        bytes: new TextEncoder().encode("not a zip"),
+        filename: "x.zip",
+        isBundle: true,
+      }),
+    ).rejects.toMatchObject({ statusCode: 400 })
+    await expect(publish(meta, blobs, bundle({}))).rejects.toMatchObject({ statusCode: 400 })
+    await expect(publish(meta, blobs, bundle({ "readme.txt": "hi" }))).rejects.toMatchObject({
+      statusCode: 400,
+    })
+  })
+})
+
+describe("publish: republish an existing artifact", () => {
+  it("appends a version under the same short id", async () => {
+    const meta = makeMeta()
+    const blobs = makeBlobs()
+    const { artifact } = await publish(meta, blobs, file("v1"))
+    const { version } = await publish(meta, blobs, file("v2"), artifact.short_id)
+    expect(version.n).toBe(2)
+  })
+
+  it("404s for an unknown short id and 409s on a kind change", async () => {
+    const meta = makeMeta()
+    const blobs = makeBlobs()
+    await expect(publish(meta, blobs, file("x"), "missing")).rejects.toMatchObject({
+      statusCode: 404,
+    })
+    const { artifact } = await publish(meta, blobs, file("a file"))
+    await expect(
+      publish(meta, blobs, bundle({ "index.html": "x" }), artifact.short_id),
+    ).rejects.toMatchObject({ statusCode: 409 })
+  })
+})
+
+describe("propose: a candidate version awaiting review", () => {
+  const proposeInput = (body: string): ProposeInput => ({
+    bytes: new TextEncoder().encode(body),
+    filename: "page.html",
+    isBundle: false,
+    author: "bob",
+    message: "tweak",
+  })
+
+  it("stores an open proposal against an existing artifact", async () => {
+    const meta = makeMeta()
+    const blobs = makeBlobs()
+    const { artifact } = await publish(meta, blobs, file("v1"))
+    const { proposal } = await propose(meta, blobs, artifact.short_id, proposeInput("candidate"))
+    expect(proposal.state).toBe("open")
+    expect(proposal.author).toBe("bob")
+  })
+
+  it("404s when proposing against an unknown artifact", async () => {
+    await expect(
+      propose(makeMeta(), makeBlobs(), "nope", proposeInput("x")),
+    ).rejects.toBeInstanceOf(PublishError)
+  })
+
+  it("approveProposal promotes the candidate to the next live version", async () => {
+    const meta = makeMeta()
+    const blobs = makeBlobs()
+    const { artifact } = await publish(meta, blobs, file("v1"))
+    const { proposal } = await propose(meta, blobs, artifact.short_id, proposeInput("candidate"))
+    const version = await approveProposal(meta, blobs, proposal, "amy", "lgtm")
+    expect(version.n).toBe(2)
+    expect(version.blob_key).toBe(proposal.blob_key) // reuses the proposal's stored bytes
+  })
+
+  it("approveProposal 409s if the proposal isn't open", async () => {
+    const meta = makeMeta()
+    const blobs = makeBlobs()
+    const { artifact } = await publish(meta, blobs, file("v1"))
+    const { proposal } = await propose(meta, blobs, artifact.short_id, proposeInput("candidate"))
+    await expect(
+      approveProposal(meta, blobs, { ...proposal, state: "approved" }, "amy"),
+    ).rejects.toMatchObject({ statusCode: 409 })
+  })
+})
+
+describe("publish: URL + JSON helpers", () => {
+  const artifact = {
+    short_id: "abc123",
+    slug: "my-doc",
+    title: "My Doc",
+    kind: "file",
+    visibility: "link",
+    spa: 0,
+    current_version: 2,
+    created_at: "t",
+  } as unknown as ArtifactRecord
+
+  it("artifactUrl appends the slug when present, omits it otherwise", () => {
+    expect(artifactUrl("https://dock.test", artifact)).toBe("https://dock.test/a/abc123-my-doc")
+    expect(artifactUrl("https://dock.test", { ...artifact, slug: null })).toBe(
+      "https://dock.test/a/abc123",
+    )
+  })
+
+  it("toJson shapes the public artifact payload", () => {
+    const json = toJson("https://dock.test", artifact, [])
+    expect(json).toMatchObject({
+      short_id: "abc123",
+      url: "https://dock.test/a/abc123-my-doc",
+      kind: "file",
+      spa: false,
+      current_version: 2,
+    })
+  })
+})

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config"
+
+// Coverage gate on the shared domain logic: publish/storeContent (bundle entry +
+// path cleaning), anchors, diff, unfurl, permissions, mime, hash, ids, md. ports.ts
+// is type-only. Thresholds sit just under the current numbers as a ratchet floor.
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      include: ["src/**"],
+      reporter: ["text-summary"],
+      thresholds: { lines: 92, statements: 90, branches: 72 },
+    },
+  },
+})

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -26,7 +26,8 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config"
+
+// Coverage gate scoped to the API client (client.ts). index.ts is the stdio MCP
+// server entry — it registers tools and connects a transport on import (like the
+// Node app entry), so it's covered end-to-end by running the server, not by unit
+// tests. The client is where the request/response logic lives. Ratchet floor.
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      include: ["src/client.ts"],
+      reporter: ["text-summary"],
+      thresholds: { lines: 86, statements: 78, branches: 58 },
+    },
+  },
+})

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -17,7 +17,8 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@dock/core": "workspace:*"

--- a/packages/storage/test/blob-stores.test.ts
+++ b/packages/storage/test/blob-stores.test.ts
@@ -1,0 +1,63 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll, describe, expect, it } from "vitest"
+import { FsBlobStore } from "../src/fs"
+import { R2BlobStore, type R2Like } from "../src/r2"
+
+const bytes = (s: string) => new TextEncoder().encode(s)
+const str = (u: Uint8Array | null) => (u ? new TextDecoder().decode(u) : null)
+const SHA_RE = /^[0-9a-f]{64}$/
+
+// Both content-addressed stores share the BlobStore contract: put returns a sha256
+// hex key, get round-trips, a malformed key is rejected without a backend call, and
+// a well-formed-but-absent key is null (not an error).
+describe("FsBlobStore (local disk, the default store)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "dock-blobs-"))
+  const store = new FsBlobStore(dir)
+  afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+  it("puts content-addressed and round-trips it", async () => {
+    const key = await store.put(bytes("hello world"))
+    expect(key).toMatch(SHA_RE)
+    expect(str(await store.get(key))).toBe("hello world")
+  })
+
+  it("dedupes identical bytes to the same key (idempotent put)", async () => {
+    const a = await store.put(bytes("same"))
+    const b = await store.put(bytes("same")) // hits the existsSync short-circuit
+    expect(a).toBe(b)
+  })
+
+  it("rejects a malformed key and returns null for a missing one", async () => {
+    expect(await store.get("not-a-key")).toBeNull()
+    expect(await store.get("a".repeat(64))).toBeNull() // valid shape, absent
+  })
+})
+
+describe("R2BlobStore (Cloudflare R2)", () => {
+  // A Map-backed stand-in for the R2 binding (structural R2Like, no workers-types).
+  const map = new Map<string, Uint8Array>()
+  const bucket: R2Like = {
+    put: async (key, value) => {
+      map.set(key, value instanceof Uint8Array ? value : new Uint8Array(value))
+    },
+    get: async (key) => {
+      const v = map.get(key)
+      return v ? { arrayBuffer: async () => v.slice().buffer } : null
+    },
+  }
+  const store = new R2BlobStore(bucket)
+
+  it("puts content-addressed and round-trips it", async () => {
+    const key = await store.put(bytes("edge bytes"))
+    expect(key).toMatch(SHA_RE)
+    expect(map.has(key)).toBe(true)
+    expect(str(await store.get(key))).toBe("edge bytes")
+  })
+
+  it("rejects a malformed key (no bucket call) and returns null for a missing one", async () => {
+    expect(await store.get("nope")).toBeNull()
+    expect(await store.get("b".repeat(64))).toBeNull()
+  })
+})

--- a/packages/storage/test/s3.test.ts
+++ b/packages/storage/test/s3.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { type S3BlobStore, s3FromUrl } from "../src/s3"
 
 const cfgOf = (store: S3BlobStore) => (store as unknown as { cfg: Record<string, unknown> }).cfg
@@ -52,5 +52,72 @@ describe("s3FromUrl", () => {
 
   it("rejects a URL with no bucket", () => {
     expect(() => s3FromUrl("s3://AK:SECRET@host.example.com/")).toThrow(/bucket/)
+  })
+})
+
+// put/get sign a SigV4 request and hit the endpoint over fetch. A fetch stub backed
+// by a Map stands in for the S3 server, so we exercise the signer + the success and
+// error branches without a network.
+describe("S3BlobStore put/get (SigV4 over fetch)", () => {
+  const store = s3FromUrl("s3://minioadmin:minioadmin@localhost:9000/dock?region=us-east-1")
+  afterEach(() => vi.unstubAllGlobals())
+
+  // Records every request and serves PUT bodies back on GET (keyed by URL).
+  const stubFetch = () => {
+    const objects = new Map<string, Uint8Array>()
+    const calls: { method: string; url: string; headers: Record<string, string> }[] = []
+    const fetchStub = vi.fn(async (url: string, init: RequestInit) => {
+      const method = init.method ?? "GET"
+      calls.push({ method, url, headers: init.headers as Record<string, string> })
+      if (method === "PUT") {
+        objects.set(url, new Uint8Array(init.body as ArrayBuffer))
+        return new Response(null, { status: 200 })
+      }
+      const obj = objects.get(url)
+      return obj ? new Response(obj, { status: 200 }) : new Response("nope", { status: 404 })
+    })
+    vi.stubGlobal("fetch", fetchStub)
+    return { calls }
+  }
+
+  it("signs a PUT and returns the content-addressed key", async () => {
+    const { calls } = stubFetch()
+    const key = await store.put(new TextEncoder().encode("payload"))
+    expect(key).toMatch(/^[0-9a-f]{64}$/)
+    const put = calls.find((c) => c.method === "PUT")
+    expect(put?.url).toBe(`http://localhost:9000/dock/${key}`)
+    // The SigV4 headers the signer must attach.
+    expect(put?.headers.authorization).toMatch(/^AWS4-HMAC-SHA256 Credential=minioadmin\//)
+    expect(put?.headers["x-amz-content-sha256"]).toMatch(/^[0-9a-f]{64}$/)
+    expect(put?.headers["x-amz-date"]).toMatch(/^\d{8}T\d{6}Z$/)
+  })
+
+  it("round-trips bytes through put then get", async () => {
+    stubFetch()
+    const key = await store.put(new TextEncoder().encode("hello s3"))
+    expect(new TextDecoder().decode(await store.get(key))).toBe("hello s3")
+  })
+
+  it("returns null for a missing object (404) and a malformed key (no fetch)", async () => {
+    const { calls } = stubFetch()
+    expect(await store.get("f".repeat(64))).toBeNull() // 404
+    expect(await store.get("bad")).toBeNull() // rejected before any fetch
+    expect(calls.filter((c) => c.method === "GET")).toHaveLength(1)
+  })
+
+  it("throws when put fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("denied", { status: 403 })),
+    )
+    await expect(store.put(new TextEncoder().encode("x"))).rejects.toThrow(/s3 put .* failed: 403/)
+  })
+
+  it("throws when get fails with a non-404 error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("boom", { status: 500 })),
+    )
+    await expect(store.get("c".repeat(64))).rejects.toThrow(/s3 get .* failed: 500/)
   })
 })

--- a/packages/storage/vitest.config.ts
+++ b/packages/storage/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config"
+
+// Coverage gate on the blob stores. All three drivers are exercised: fs (temp dir),
+// R2 (a Map-backed R2Like), and S3 (the SigV4 signer + put/get over a stubbed
+// fetch). Thresholds sit just under the current numbers as a ratchet floor.
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      include: ["src/**"],
+      reporter: ["text-summary"],
+      thresholds: { lines: 95, statements: 92, branches: 85 },
+    },
+  },
+})


### PR DESCRIPTION
Third coverage PR — the package layer.

## storage 30% → 100% lines
- **FsBlobStore** (default disk store): content-addressed put, idempotent dedup, malformed-key reject, missing-key null
- **R2BlobStore**: round-trip against a Map-backed `R2Like`
- **S3BlobStore put/get**: the SigV4 signer + success / 404 / non-404-error branches over a stubbed `fetch` (the existing test only covered `s3FromUrl`/`target`)

## core 66% → 97% lines, 49% → 79% branches
- **publish.ts 0 → 97%** — `storeContent`'s bundle handling: root-`index.html` vs shallowest-`.html` entry detection, and the **path-cleaning that drops `../` traversal, `__MACOSX`, `.DS_Store`** (security-relevant); single-file publish; republish (version bump, 404 unknown, 409 kind change); `propose` + `approveProposal` (promote to next version, 409 if not open); `artifactUrl`/`toJson`
- **mime.ts → 100%** (full table + octet-stream fallback), **hash.ts → 100%** (known sha256 vectors)

## Gates
Adds coverage gates + CI steps for **@dock/core** (92/90/72), **@dock/storage** (95/92/85), and **@dock/mcp** (scoped to `client.ts` at 86/78/58 — `index.ts` is the stdio MCP server entry, covered by running it, not by units, like the Node app entry).

All gates pass with headroom; typecheck + biome clean across the three packages. No `any` in the new tests (the publish fake is properly typed and cast once through `MetaStore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)