### PR TITLE
test(web): unit-test the pure frontend logic; add a scoped coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,8 @@ jobs:
 
   # Coverage gates (ratchet floors; see each package's vitest.config.ts): the API
   # suite, the data layer (@dock/db), the shared domain logic (@dock/core), the blob
-  # stores (@dock/storage), and the MCP client.
+  # stores (@dock/storage), the MCP client, and the web app's pure logic (@dock/web;
+  # its user flows are covered separately by the Playwright e2e suite).
   coverage:
     runs-on: ubicloud-standard-2
     steps:
@@ -77,6 +78,8 @@ jobs:
         run: pnpm --filter @dock/storage test:coverage
       - name: MCP coverage
         run: pnpm --filter @dock/mcp test:coverage
+      - name: Web coverage
+        run: pnpm --filter @dock/web test:coverage
 
   # Bundle budget: build the web client and fail if the gzipped JS blows past the
   # budget (see scripts/check-bundle.mjs), so phosphor / radix / cmdk weight can't

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:smoke": "playwright test --project=smoke",
     "test:e2e:deep": "playwright test --project=deep",
@@ -54,12 +56,14 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
+    "@vitest/coverage-v8": "^4.1.8",
     "babel-plugin-react-compiler": "^1.0.0",
     "react-scan": "^0.5.7",
     "rollup-plugin-visualizer": "^7.0.1",
     "tailwindcss": "^4.3.1",
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.8"
   }
 }

--- a/apps/web/src/lib/time.test.ts
+++ b/apps/web/src/lib/time.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { ago } from "./time"
+
+// `ago` reads Date.now(), so pin the clock and feed ISO timestamps at known offsets.
+const NOW = new Date("2026-06-14T12:00:00.000Z")
+const offset = (ms: number) => new Date(NOW.getTime() - ms).toISOString()
+
+describe("ago", () => {
+  afterEach(() => vi.useRealTimers())
+
+  const at = (ms: number) => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    return ago(offset(ms))
+  }
+
+  it("renders each bucket", () => {
+    expect(at(0)).toBe("just now")
+    expect(at(30_000)).toBe("just now") // < 1m
+    expect(at(5 * 60_000)).toBe("5m ago")
+    expect(at(3 * 3600_000)).toBe("3h ago")
+    expect(at(2 * 86400_000)).toBe("2d ago")
+  })
+
+  it("clamps a future timestamp to 'just now' (no negative)", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    expect(ago(new Date(NOW.getTime() + 60_000).toISOString())).toBe("just now")
+  })
+})

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+import { cn } from "./utils"
+
+describe("cn", () => {
+  it("joins class names", () => {
+    expect(cn("a", "b")).toBe("a b")
+  })
+
+  it("drops falsy conditional classes", () => {
+    expect(cn("a", false && "b", null, undefined, "c")).toBe("a c")
+  })
+
+  it("de-dupes conflicting Tailwind utilities (last wins)", () => {
+    expect(cn("p-2", "p-4")).toBe("p-4")
+    expect(cn("text-sm text-foreground", "text-lg")).toBe("text-foreground text-lg")
+  })
+})

--- a/apps/web/src/pages/artifact/lib/layout.test.ts
+++ b/apps/web/src/pages/artifact/lib/layout.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import type { Comment } from "@/api"
+import { anchorExact, clamp, groupThreads, layoutPins, parseAnchor } from "./layout"
+
+describe("clamp", () => {
+  it("bounds a value to [lo, hi]", () => {
+    expect(clamp(5, 0, 10)).toBe(5)
+    expect(clamp(-3, 0, 10)).toBe(0)
+    expect(clamp(99, 0, 10)).toBe(10)
+  })
+})
+
+describe("layoutPins", () => {
+  const heights = { a: 100, b: 100 }
+
+  it("stacks overlapping cards apart by the gap, top-down", () => {
+    const pos = layoutPins(
+      [
+        { id: "a", desiredY: 0 },
+        { id: "b", desiredY: 10 },
+      ],
+      heights,
+      null,
+      8,
+    )
+    expect(pos.a).toBe(0)
+    // b wanted 10 but a occupies 0..100, so b is pushed to 100 + gap.
+    expect(pos.b).toBe(108)
+  })
+
+  it("pins the active card to its exact Y and pushes a neighbour above out of the way", () => {
+    const pos = layoutPins(
+      [
+        { id: "a", desiredY: 0 },
+        { id: "b", desiredY: 10 },
+      ],
+      heights,
+      "b",
+      8,
+    )
+    expect(pos.b).toBe(10) // pinned to its desired Y
+    expect(pos.a).toBe(-98) // pushed up: 10 - 8(gap) - 100(height)
+  })
+})
+
+describe("parseAnchor / anchorExact", () => {
+  it("returns null for null, invalid JSON, or a missing exact", () => {
+    expect(parseAnchor(null)).toBeNull()
+    expect(parseAnchor("{not json")).toBeNull()
+    expect(parseAnchor(JSON.stringify({ prefix: "x" }))).toBeNull()
+    expect(anchorExact(null)).toBeNull()
+  })
+
+  it("extracts the exact quote (with optional prefix/suffix)", () => {
+    const a = JSON.stringify({ exact: "hello", prefix: "say ", suffix: "!" })
+    expect(parseAnchor(a)).toEqual({ exact: "hello", prefix: "say ", suffix: "!" })
+    expect(anchorExact(a)).toBe("hello")
+  })
+})
+
+describe("groupThreads", () => {
+  it("buckets comments by thread_id, preserving order", () => {
+    const c = (id: string, thread_id: string) => ({ id, thread_id }) as unknown as Comment
+    const groups = groupThreads([c("1", "t1"), c("2", "t2"), c("3", "t1")])
+    expect(groups).toHaveLength(2)
+    expect(groups[0].map((x) => x.id)).toEqual(["1", "3"])
+    expect(groups[1].map((x) => x.id)).toEqual(["2"])
+  })
+})

--- a/apps/web/src/pages/artifact/lib/reactions.test.ts
+++ b/apps/web/src/pages/artifact/lib/reactions.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import type { Comment } from "@/api"
+import { REACTION_EMOJI, toggleReaction } from "./reactions"
+
+const comment = (reactions: Record<string, string[]> = {}): Comment =>
+  ({ id: "c1", thread_id: "t1", reactions }) as unknown as Comment
+
+describe("toggleReaction", () => {
+  it("adds a reaction when the user hasn't reacted", () => {
+    const out = toggleReaction(comment(), "👍", "amy")
+    expect(out.reactions).toEqual({ "👍": ["amy"] })
+  })
+
+  it("removes the reaction (and drops the empty emoji key) when toggled off", () => {
+    const out = toggleReaction(comment({ "👍": ["amy"] }), "👍", "amy")
+    expect(out.reactions).toEqual({})
+  })
+
+  it("appends a second reactor without disturbing the first", () => {
+    const out = toggleReaction(comment({ "👍": ["amy"] }), "👍", "bob")
+    expect(out.reactions?.["👍"]).toEqual(["amy", "bob"])
+  })
+
+  it("does not mutate the input comment", () => {
+    const input = comment({ "❤️": ["amy"] })
+    toggleReaction(input, "❤️", "bob")
+    expect(input.reactions).toEqual({ "❤️": ["amy"] })
+  })
+
+  it("exposes a stable emoji palette", () => {
+    expect(REACTION_EMOJI).toContain("👍")
+    expect(REACTION_EMOJI.length).toBeGreaterThan(0)
+  })
+})

--- a/apps/web/src/pages/artifact/parse-ref.test.ts
+++ b/apps/web/src/pages/artifact/parse-ref.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { parseRef } from "./parse-ref"
+
+describe("parseRef", () => {
+  it("reads a bare short id", () => {
+    expect(parseRef("abc123")).toEqual({ shortId: "abc123", version: undefined })
+  })
+
+  it("ignores a trailing slug", () => {
+    expect(parseRef("abc123-my-title")).toEqual({ shortId: "abc123", version: undefined })
+    expect(parseRef("abc123-a-longer-slug-here")).toMatchObject({ shortId: "abc123" })
+  })
+
+  it("parses an @vN version suffix", () => {
+    expect(parseRef("abc123@v4")).toEqual({ shortId: "abc123", version: 4 })
+    expect(parseRef("abc123-my-title@v2")).toEqual({ shortId: "abc123", version: 2 })
+  })
+
+  it("falls back to the raw ref when it doesn't match the shape", () => {
+    // Too short / wrong charset → no capture, so the whole ref is the id.
+    expect(parseRef("X")).toEqual({ shortId: "X", version: undefined })
+    expect(parseRef("ABC123")).toEqual({ shortId: "ABC123", version: undefined })
+  })
+})

--- a/apps/web/src/pages/settings/roles.test.ts
+++ b/apps/web/src/pages/settings/roles.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+import type { Role } from "@/api"
+import { ALL_EVENTS, roleLabel, roleValue, WS_ROLES } from "./roles"
+
+describe("workspace roles", () => {
+  it("maps each canonical role to its display label", () => {
+    expect(roleLabel("owner")).toBe("Admin")
+    expect(roleLabel("editor")).toBe("Creator")
+    expect(roleLabel("commenter")).toBe("Viewer")
+  })
+
+  it("falls back to Viewer for an unknown role", () => {
+    expect(roleLabel("mystery" as Role)).toBe("Viewer")
+  })
+
+  it("normalizes a legacy bare viewer onto commenter", () => {
+    expect(roleValue("viewer")).toBe("commenter")
+    expect(roleValue("editor")).toBe("editor")
+    expect(roleValue("owner")).toBe("owner")
+  })
+
+  it("exposes the three-role vocabulary and the webhook event set", () => {
+    expect(WS_ROLES.map((r) => r.value)).toEqual(["owner", "editor", "commenter"])
+    expect(ALL_EVENTS).toContain("version.published")
+    expect(ALL_EVENTS).toHaveLength(3)
+  })
+})

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,29 @@
+import { fileURLToPath } from "node:url"
+import { defineConfig } from "vitest/config"
+
+// Unit tests for the web app's PURE logic — ref parsing, relative time, the
+// optimistic reaction toggle, role mapping, class merge, and the comment-pin
+// layout. A standalone config (NOT the TanStack Start vite config) so tests don't
+// boot the SSR/router plugins. The user-facing flows are covered by the Playwright
+// e2e suite (e2e/); this gate is scoped to the unit-testable helpers, so a regression
+// in that logic fails CI without pretending to measure the React components.
+export default defineConfig({
+  resolve: { alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) } },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: [
+        "src/pages/artifact/parse-ref.ts",
+        "src/lib/time.ts",
+        "src/pages/artifact/lib/reactions.ts",
+        "src/pages/settings/roles.ts",
+        "src/lib/utils.ts",
+        "src/pages/artifact/lib/layout.ts",
+      ],
+      reporter: ["text-summary"],
+      thresholds: { lines: 90, statements: 90, branches: 80 },
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.2
         version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -221,6 +224,9 @@ importers:
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/cli:
     dependencies:


### PR DESCRIPTION
Fourth and final coverage PR. apps/web had only the Playwright e2e suite (user flows) and **no unit tests** — its pure helpers had no fast, isolated coverage.

Adds a **standalone vitest harness** (node env, deliberately *not* the TanStack Start vite config, so tests don't boot the SSR/router plugins) and covers the pure logic:

- **parse-ref** — short id / slug / `@vN` parsing + raw-ref fallback
- **time** — the relative-time buckets (clock pinned with fake timers) + future clamp
- **reactions** — the optimistic toggle (add, remove-and-drop-empty-key, second reactor, no input mutation)
- **roles** — label/value mapping, legacy `viewer → commenter`, the role + webhook-event sets
- **utils** — `cn` (join, drop falsy, Tailwind conflict de-dupe)
- **layout** — `clamp`, `layoutPins` (top-down no-overlap stacking + active-card pin that pushes neighbours out of the way), `parseAnchor`/`anchorExact`, `groupThreads`

**24 tests.** The gate is scoped to these files (**95% lines / 87% branches / 100% funcs**) so a regression in the logic fails CI without pretending to measure the React components. Wired into the CI `coverage` job. The e2e specs (`.spec.ts` in `e2e/`) stay Playwright-only and are excluded from the vitest run (confirmed: 0 e2e files picked up).

`pnpm run ci` (biome + token/frontend/testid/api/filesize/deadcode lints) passes; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)