### PR TITLE
Security + a11y review fixes: ids-not-names authz, app-origin headers, visibility-aware cache, reduced-motion

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,7 +2,7 @@ import { type ArtifactRecord, parseRef } from "@dock/core"
 import { type Context, Hono } from "hono"
 import { compress } from "hono/compress"
 import { type AppDeps, buildContext } from "./context"
-import { corsFor, fail, TOMBSTONE } from "./lib/http"
+import { cacheControlFor, corsFor, fail, TOMBSTONE } from "./lib/http"
 import { observability } from "./lib/observability"
 import { makeRateLimiter } from "./lib/rate-limit"
 import { serveContent } from "./lib/serve-content"
@@ -43,6 +43,30 @@ export function createApp(deps: AppDeps): Hono {
   // Outermost: a per-request id + one structured access-log line (method, path,
   // status, duration, actor, org), so a 500 is correlatable to who/what.
   app.use("*", observability())
+
+  // App-origin security headers. Set after the handler so responses that declare
+  // their own policy keep it: artifact bytes carry the sandbox CSP (serveContent),
+  // and the embed iframe opts into `frame-ancestors *`. HSTS + nosniff are safe on
+  // every response; the clickjacking lock (frame-ancestors 'none' + X-Frame-Options)
+  // covers the app UI + API, but never artifact bytes (/raw), the embed surface
+  // (/v1/embed), a subdomain-served artifact (already carries a CSP), or SSE streams.
+  app.use("*", async (c, next) => {
+    await next()
+    const h = c.res.headers
+    if (!h.has("x-content-type-options")) h.set("X-Content-Type-Options", "nosniff")
+    const proto = (c.req.header("x-forwarded-proto") ?? new URL(c.req.url).protocol).replace(
+      ":",
+      "",
+    )
+    if (proto === "https" && !h.has("strict-transport-security"))
+      h.set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
+    const path = c.req.path
+    const framable = path.startsWith("/raw/") || path.startsWith("/v1/embed/")
+    if (!framable && !path.endsWith("/events") && !h.has("content-security-policy")) {
+      h.set("Content-Security-Policy", "frame-ancestors 'none'")
+      h.set("X-Frame-Options", "DENY")
+    }
+  })
 
   // gzip everything (Node/Fly entry only — the Worker edge compresses already).
   // Registered first so it wraps every downstream response; honors Accept-Encoding
@@ -125,7 +149,15 @@ export function createApp(deps: AppDeps): Hono {
       if (a.removed_at) return c.text(TOMBSTONE, 410)
       const version = await ctx.meta.getVersion(a.id, n)
       if (!version) return c.text("not found", 404)
-      return serveContent(c, ctx.blobs, version, a.title, prefix, rawPath)
+      return serveContent(
+        c,
+        ctx.blobs,
+        version,
+        a.title,
+        prefix,
+        rawPath,
+        cacheControlFor(a.visibility),
+      )
     }
     app.use("*", async (c, next) => {
       const host = (c.req.header("host") ?? new URL(c.req.url).host).toLowerCase().split(":")[0]

--- a/apps/api/src/lib/http.ts
+++ b/apps/api/src/lib/http.ts
@@ -115,6 +115,9 @@ export const MAX_UPLOAD_BYTES = 100 * 1024 * 1024
  *  to one recorded view — a refresh or quick re-open doesn't inflate the count. */
 export const VIEW_DEDUP_MS = 30 * 60_000
 
+/** Versioned, fully-public artifact paths are immutable by construction. */
+export const IMMUTABLE_CACHE = "public, max-age=31536000, immutable"
+
 /** Headers for everything inside the artifact sandbox. */
 export const RAW_HEADERS: Record<string, string> = {
   // Opaque origin: scripts run, but can touch no cookies, storage, or APIs.
@@ -125,9 +128,18 @@ export const RAW_HEADERS: Record<string, string> = {
   // Raw artifact bytes are never the indexable surface; keeping them out of
   // search engines also blunts using the host for SEO-spam/phishing.
   "X-Robots-Tag": "noindex",
-  // Versioned paths are immutable by construction.
-  "Cache-Control": "public, max-age=31536000, immutable",
+  "Cache-Control": IMMUTABLE_CACHE,
 }
+
+/**
+ * Cache-Control for an artifact's bytes by access model. Only fully `public`
+ * artifacts are safe to sit in a shared/CDN cache: `link`, `org`, and `password`
+ * are gated (per-identity authorization, or a secret the cache key doesn't carry),
+ * so a shared cache must never store one response and replay it to a viewer who
+ * never passed the gate. Non-public ⇒ `private, no-store`.
+ */
+export const cacheControlFor = (visibility: Visibility): string =>
+  visibility === "public" ? IMMUTABLE_CACHE : "private, no-store"
 
 /** A taken-down artifact: content is gone (410), the record is preserved. */
 export const TOMBSTONE = "This artifact was removed."

--- a/apps/api/src/lib/serve-content.ts
+++ b/apps/api/src/lib/serve-content.ts
@@ -7,7 +7,7 @@ import {
   SELECTION_SCRIPT,
 } from "@dock/core"
 import type { Context } from "hono"
-import { RAW_HEADERS, rewriteAbsoluteUrls, toBody } from "./http"
+import { IMMUTABLE_CACHE, RAW_HEADERS, rewriteAbsoluteUrls, toBody } from "./http"
 
 /**
  * Serve stored artifact content (a version or a proposal) under `prefix`, resolving
@@ -15,6 +15,10 @@ import { RAW_HEADERS, rewriteAbsoluteUrls, toBody } from "./http"
  * for `/raw/:id/v/:n/` the prefix carries the path; for a vanity host the prefix is
  * `/`, so the absolute-URL rewriting becomes a no-op and the artifact serves at its
  * own origin root. Always carries the opaque-origin CSP (RAW_HEADERS).
+ *
+ * `cacheControl` sets Cache-Control per the artifact's access model (see
+ * `cacheControlFor`): a shared cache must never store a gated artifact's bytes and
+ * replay them to an unauthorized viewer, so only fully-public content is immutable.
  */
 export const serveContent = async (
   c: Context,
@@ -23,7 +27,9 @@ export const serveContent = async (
   title: string | null,
   prefix: string,
   rawPath: string,
+  cacheControl: string = IMMUTABLE_CACHE,
 ) => {
+  const headers = { ...RAW_HEADERS, "Cache-Control": cacheControl }
   let path = rawPath
   if (content.content_type === BUNDLE_CONTENT_TYPE) {
     const manifestBytes = await blobs.get(content.blob_key)
@@ -37,7 +43,7 @@ export const serveContent = async (
     // Pretty URLs (Astro-style dir output), then SPA fallback.
     if (!entry && !/\.[a-z0-9]+$/i.test(lookup)) entry = manifest.files[`${lookup}/index.html`]
     if (!entry && manifest.spa) entry = manifest.files[manifest.entry]
-    if (!entry) return c.text("not found", 404, RAW_HEADERS)
+    if (!entry) return c.text("not found", 404, headers)
 
     const data = await blobs.get(entry.key)
     if (!data) return c.text("blob missing", 500)
@@ -45,9 +51,9 @@ export const serveContent = async (
       const rewritten = rewriteAbsoluteUrls(new TextDecoder().decode(data), prefix.slice(0, -1))
       // Bundle pages get the anchor client too — comments stick everywhere.
       const out = entry.type.startsWith("text/html") ? rewritten + SELECTION_SCRIPT : rewritten
-      return c.body(out, 200, { ...RAW_HEADERS, "Content-Type": entry.type })
+      return c.body(out, 200, { ...headers, "Content-Type": entry.type })
     }
-    return c.body(toBody(data), 200, { ...RAW_HEADERS, "Content-Type": entry.type })
+    return c.body(toBody(data), 200, { ...headers, "Content-Type": entry.type })
   }
 
   const data = await blobs.get(content.blob_key)
@@ -56,18 +62,18 @@ export const serveContent = async (
   if (content.content_type === "text/markdown") {
     if (path === "raw.md")
       return c.body(toBody(data), 200, {
-        ...RAW_HEADERS,
+        ...headers,
         "Content-Type": "text/markdown; charset=utf-8",
       })
     const html = await renderMarkdown(new TextDecoder().decode(data), title)
-    return c.body(html, 200, { ...RAW_HEADERS, "Content-Type": "text/html; charset=utf-8" })
+    return c.body(html, 200, { ...headers, "Content-Type": "text/html; charset=utf-8" })
   }
 
   // html file artifact — any path serves the document (+ selection capture)
   const ct = mimeFor(path || "index.html")
   if (ct.startsWith("text/html")) {
     const html = new TextDecoder().decode(data) + SELECTION_SCRIPT
-    return c.body(html, 200, { ...RAW_HEADERS, "Content-Type": ct })
+    return c.body(html, 200, { ...headers, "Content-Type": ct })
   }
-  return c.body(toBody(data), 200, { ...RAW_HEADERS, "Content-Type": ct })
+  return c.body(toBody(data), 200, { ...headers, "Content-Type": ct })
 }

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -99,6 +99,13 @@ export const commentRoutes = (ctx: AppContext) => {
   const actorName = async (c: Context): Promise<string | null> =>
     (await actingUser(c))?.name ?? null
 
+  // Authorship is keyed on the stable actor id, never the mutable display name:
+  // renaming your profile to a victim's name must not grant edit/delete rights.
+  // Legacy rows (author_id null, written before this column) fall back to the
+  // name match so their authors don't lose access.
+  const ownsComment = (cm: CommentRecord, acting: { id: string; name: string }): boolean =>
+    cm.author_id ? cm.author_id === acting.id : cm.author === acting.name
+
   // Create a comment (new thread) or a reply (pass thread_id).
   app.post("/v1/artifacts/:shortId/comments", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
@@ -142,6 +149,7 @@ export const commentRoutes = (ctx: AppContext) => {
       anchor,
       body_md: body.body_md,
       author,
+      author_id: acting?.id ?? null,
     })
     // Mentions live in the comment's meta JSON (the picker supplies user ids, so
     // there's no fragile server-side @name parsing); persist them with the row.
@@ -241,8 +249,8 @@ export const commentRoutes = (ctx: AppContext) => {
     if ("error" in r) return r.error
     const { artifact, cm } = r
     if (!(await authorize(c, "comment", artifact))) return fail(c, 403, "forbidden")
-    const actor = await actorName(c)
-    if (actor && cm.author !== actor) return fail(c, 403, "forbidden")
+    const acting = await actingUser(c)
+    if (acting && !ownsComment(cm, acting)) return fail(c, 403, "forbidden")
     const body = await readJson(
       c,
       z.object({ body_md: z.string().refine((s) => s.trim() !== "", "body_md required") }),
@@ -265,8 +273,8 @@ export const commentRoutes = (ctx: AppContext) => {
     if ("error" in r) return r.error
     const { artifact, cm } = r
     if (!(await authorize(c, "comment", artifact))) return fail(c, 403, "forbidden")
-    const actor = await actorName(c)
-    if (actor && cm.author !== actor) return fail(c, 403, "forbidden")
+    const acting = await actingUser(c)
+    if (acting && !ownsComment(cm, acting)) return fail(c, 403, "forbidden")
     const md = parseMeta(cm.meta)
     md.deleted = true
     const updated = await meta.updateComment(cm.id, { meta: JSON.stringify(md) })

--- a/apps/api/src/routes/proposals.ts
+++ b/apps/api/src/routes/proposals.ts
@@ -100,6 +100,7 @@ export const proposalRoutes = (ctx: AppContext) => {
         spa: body.spa === "true" || body.spa === "1",
         message: str(body.message),
         author,
+        author_id: acting?.id ?? null,
       })
       bus.publish(artifact.id, { type: "proposal.created", proposal_id: proposal.id })
       await notify(artifact, "proposal.created", {
@@ -210,14 +211,17 @@ export const proposalRoutes = (ctx: AppContext) => {
     const r = await loadProposal(c)
     if ("error" in r) return r.error
     const { artifact, proposal } = r
-    const me = await currentUser(c)
-    const who = me ? (me.name ?? me.email) : null
-    const isAuthor = who !== null && who === proposal.author
+    // Authorship keys on the stable proposer id, never the mutable display name.
+    // Legacy rows (author_id null) fall back to the name match.
+    const acting = await actingUser(c)
+    const isAuthor =
+      acting !== null &&
+      (proposal.author_id ? proposal.author_id === acting.id : proposal.author === acting.name)
     if (!isAuthor && !(await authorize(c, "manage", artifact))) return fail(c, 403, "forbidden")
     if (proposal.state !== "open") return fail(c, 409, `proposal is ${proposal.state}`)
     await meta.decideProposal(proposal.id, {
       state: "withdrawn",
-      decided_by: who,
+      decided_by: acting?.name ?? null,
       decided_version: null,
     })
     const fresh = (await meta.getProposal(proposal.id)) as ProposalRecord

--- a/apps/api/src/routes/raw.ts
+++ b/apps/api/src/routes/raw.ts
@@ -1,7 +1,7 @@
 import { ANCHOR_CLIENT_JS } from "@dock/core"
 import { Hono } from "hono"
 import type { AppContext } from "../context"
-import { TOMBSTONE } from "../lib/http"
+import { cacheControlFor, TOMBSTONE } from "../lib/http"
 import { serveContent } from "../lib/serve-content"
 
 /** The sandbox: raw artifact + proposal bytes under /raw/*. Served with an
@@ -32,7 +32,15 @@ export const rawRoutes = (ctx: AppContext) => {
 
     const prefix = `/raw/${shortId}/v/${c.req.param("n")}/`
     const path = decodeURIComponent(c.req.path.slice(prefix.length))
-    return serveContent(c, blobs, version, artifact.title, prefix, path)
+    return serveContent(
+      c,
+      blobs,
+      version,
+      artifact.title,
+      prefix,
+      path,
+      cacheControlFor(artifact.visibility),
+    )
   })
 
   // Render a proposed version exactly like a live one, so review is of the
@@ -47,7 +55,9 @@ export const rawRoutes = (ctx: AppContext) => {
 
     const prefix = `/raw/${shortId}/p/${proposal.id}/`
     const path = decodeURIComponent(c.req.path.slice(prefix.length))
-    return serveContent(c, blobs, proposal, artifact.title, prefix, path)
+    // A proposal is in-review, transient content (it can be withdrawn or change);
+    // never let a shared cache hold it, regardless of the artifact's visibility.
+    return serveContent(c, blobs, proposal, artifact.title, prefix, path, "private, no-store")
   })
 
   return app

--- a/apps/api/test/review-hardening.test.ts
+++ b/apps/api/test/review-hardening.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest"
+import {
+  app,
+  as,
+  jsonAs,
+  makeAuthedApp,
+  proposeAs,
+  publishAs,
+  type TestUser,
+  upload,
+} from "./helpers"
+
+// Authorship must key on the stable actor id, never the mutable display name:
+// renaming your profile to a victim's name must not grant edit/delete/withdraw.
+describe("authorship is keyed on id, not display name", () => {
+  const owner: TestUser = { id: "u_own", email: "own@dock.test", name: "Owner" }
+  const sam1: TestUser = { id: "u_sam1", email: "sam1@dock.test", name: "Sam" }
+  // Same display name as sam1, different id — the impersonation attempt.
+  const sam2: TestUser = { id: "u_sam2", email: "sam2@dock.test", name: "Sam" }
+  const { app: authed } = makeAuthedApp("id-authz", [owner, sam1, sam2], "editor")
+  let shortId: string
+  let commentId: string
+
+  it("seeds an artifact + a comment authored by sam1", async () => {
+    shortId = (await (await publishAs(authed, "<h1>doc</h1>", {}, as(sam1.email))).json()).short_id
+    const res = await authed.request(
+      `/v1/artifacts/${shortId}/comments`,
+      jsonAs(as(sam1.email), { body_md: "sam1's note" }),
+    )
+    expect(res.status).toBe(201)
+    commentId = (await res.json()).id
+  })
+
+  it("refuses edit + delete from a different user who shares the display name", async () => {
+    const edit = await authed.request(`/v1/artifacts/${shortId}/comments/${commentId}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json", ...as(sam2.email) },
+      body: JSON.stringify({ body_md: "hijacked" }),
+    })
+    expect(edit.status).toBe(403)
+    const del = await authed.request(`/v1/artifacts/${shortId}/comments/${commentId}`, {
+      method: "DELETE",
+      headers: as(sam2.email),
+    })
+    expect(del.status).toBe(403)
+  })
+
+  it("allows the real author (matched by id) to edit", async () => {
+    const edit = await authed.request(`/v1/artifacts/${shortId}/comments/${commentId}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json", ...as(sam1.email) },
+      body: JSON.stringify({ body_md: "sam1 edited" }),
+    })
+    expect(edit.status).toBe(200)
+    expect((await edit.json()).body_md).toBe("sam1 edited")
+  })
+
+  it("refuses proposal withdraw from a same-named non-author, allows the author", async () => {
+    const p = await (await proposeAs(authed, shortId, "<h1>v2</h1>", as(sam1.email))).json()
+    const bad = await authed.request(`/v1/artifacts/${shortId}/proposals/${p.id}/withdraw`, {
+      method: "POST",
+      headers: as(sam2.email),
+    })
+    expect(bad.status).toBe(403)
+    const ok = await authed.request(`/v1/artifacts/${shortId}/proposals/${p.id}/withdraw`, {
+      method: "POST",
+      headers: as(sam1.email),
+    })
+    expect(ok.status).toBe(200)
+    expect((await ok.json()).state).toBe("withdrawn")
+  })
+})
+
+// Clickjacking + transport hardening on the app (cookie) origin, without touching
+// the artifact sandbox or the embed surface.
+describe("app-origin security headers", () => {
+  it("locks framing + sets nosniff on app/API responses", async () => {
+    const res = await app.request("/healthz")
+    expect(res.headers.get("content-security-policy")).toBe("frame-ancestors 'none'")
+    expect(res.headers.get("x-frame-options")).toBe("DENY")
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff")
+  })
+
+  it("sets HSTS only over https", async () => {
+    expect((await app.request("/healthz")).headers.get("strict-transport-security")).toBeNull()
+    const https = await app.request("/healthz", { headers: { "x-forwarded-proto": "https" } })
+    expect(https.headers.get("strict-transport-security")).toContain("max-age=63072000")
+  })
+
+  it("never frame-locks artifact bytes — they keep the sandbox CSP", async () => {
+    const sid = (
+      await (await upload("h.html", "<h1>hi</h1>", { title: "H", visibility: "public" })).json()
+    ).short_id
+    const raw = await app.request(`/raw/${sid}/v/1/index.html`)
+    expect(raw.headers.get("content-security-policy")).toContain("sandbox")
+    expect(raw.headers.get("x-frame-options")).toBeNull()
+  })
+})
+
+// A shared/CDN cache must never hold a gated artifact's bytes and replay them to
+// a viewer who never passed the gate: only fully-public content is immutable.
+describe("visibility-aware raw caching", () => {
+  it("serves public bytes immutable, gated bytes no-store", async () => {
+    const pub = (
+      await (await upload("p.html", "<h1>p</h1>", { title: "P", visibility: "public" })).json()
+    ).short_id
+    expect(
+      (await app.request(`/raw/${pub}/v/1/index.html`)).headers.get("cache-control"),
+    ).toContain("immutable")
+
+    // Default visibility is `link` (gated by URL possession, not fully public).
+    const gated = (await (await upload("q.html", "<h1>q</h1>", { title: "Q" })).json()).short_id
+    expect((await app.request(`/raw/${gated}/v/1/index.html`)).headers.get("cache-control")).toBe(
+      "private, no-store",
+    )
+  })
+})

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -193,6 +193,14 @@ export function AppShell({ children }: { children: ReactNode }) {
     <ShellCtx.Provider value={value}>
       <TopBarSlotCtx.Provider value={topBarSlot}>
         <div className="flex h-full flex-col">
+          {/* Keyboard users land here first and can jump past the rail + top bar
+              straight to the page. Visually hidden until focused. */}
+          <a
+            href="#main-content"
+            className="sr-only rounded-md bg-primary px-4 py-2 text-primary-foreground focus:not-sr-only focus:absolute focus:left-3 focus:top-3 focus:z-[100]"
+          >
+            Skip to content
+          </a>
           <header className="flex items-center gap-2.5 border-b border-border bg-card px-5.5 py-3 max-sm:flex-wrap max-sm:px-3.5 max-sm:py-2.5">
             <Button
               variant="outline"
@@ -229,7 +237,13 @@ export function AppShell({ children }: { children: ReactNode }) {
               />
             )}
             <NavRail />
-            <main className="flex min-w-0 flex-1 flex-col overflow-hidden">{children}</main>
+            <main
+              id="main-content"
+              tabIndex={-1}
+              className="flex min-w-0 flex-1 flex-col overflow-hidden outline-none"
+            >
+              {children}
+            </main>
           </div>
         </div>
         {paletteOpen && (

--- a/apps/web/src/pages/artifact/artifact-top-bar.tsx
+++ b/apps/web/src/pages/artifact/artifact-top-bar.tsx
@@ -64,6 +64,7 @@ export function ArtifactTopBar(props: {
             variant="outline"
             size="icon"
             title="More"
+            aria-label="More actions"
             data-testid="artifact-more"
             className={cn(openProposals > 0 && "border-primary text-primary")}
           >
@@ -101,6 +102,7 @@ export function ArtifactTopBar(props: {
           data-testid="artifact-show-comments"
           onClick={props.onShowComments}
           title="Show comments (c)"
+          aria-label="Show comments"
         >
           <Icon name="comments" size={16} />
           {props.openCount > 0 && <b className="font-bold">{props.openCount}</b>}

--- a/apps/web/src/pages/artifact/cursors/cursor-layer.tsx
+++ b/apps/web/src/pages/artifact/cursors/cursor-layer.tsx
@@ -10,6 +10,7 @@ export function CursorLayer({ layer }: { layer: CursorLayerHandle }) {
   return (
     <div
       ref={layer.ref}
+      aria-hidden="true"
       className="pointer-events-none absolute inset-0 z-20 overflow-hidden"
       data-testid="cursor-layer"
     >

--- a/apps/web/src/pages/artifact/cursors/use-live-cursors.ts
+++ b/apps/web/src/pages/artifact/cursors/use-live-cursors.ts
@@ -78,6 +78,22 @@ export function useLiveCursors(shortId: string): {
   const prefRef = useRef(pref)
   prefRef.current = pref
 
+  // When the viewer prefers reduced motion, peers snap to position (no glide) and
+  // click ripples are suppressed. A ref (synced below) so the rAF loop + paintFrame
+  // can read it every frame without re-subscribing. SSR-safe: false until mounted.
+  const reducedMotion = useRef(
+    typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  )
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)")
+    const sync = () => {
+      reducedMotion.current = mq.matches
+    }
+    sync()
+    mq.addEventListener("change", sync)
+    return () => mq.removeEventListener("change", sync)
+  }, [])
+
   const layerRef = useRef<HTMLDivElement>(null)
   const selfId = useRef("")
   if (!selfId.current) selfId.current = Math.random().toString(36).slice(2, 9)
@@ -179,7 +195,7 @@ export function useLiveCursors(shortId: string): {
     (f: CursorFrame) => {
       if (!f?.id || f.id === selfId.current) return
 
-      if (f.tap) {
+      if (f.tap && !reducedMotion.current) {
         const key = ++rippleKey.current
         setRipples((rs) => [...rs, { key, x: f.x, y: f.y, color: f.color ?? CURSOR_FALLBACK }])
         setTimeout(
@@ -251,8 +267,10 @@ export function useLiveCursors(shortId: string): {
           const tx = t.x * r.width
           const ty = t.y * r.height
           const moved = Math.abs(tx - t.cx) + Math.abs(ty - t.cy) > 0.5
-          t.cx += (tx - t.cx) * CURSOR_TUNING.lerp
-          t.cy += (ty - t.cy) * CURSOR_TUNING.lerp
+          // Reduced motion: snap straight to the target (lerp factor 1, no glide).
+          const ease = reducedMotion.current ? 1 : CURSOR_TUNING.lerp
+          t.cx += (tx - t.cx) * ease
+          t.cy += (ty - t.cy) * ease
           if (moved) t.lastMoveAt = now
           if (t.gone) t.fade = Math.max(0, t.fade - 16 / CURSOR_TUNING.leaveFadeMs)
           if (t.el) {

--- a/apps/web/src/pages/artifact/rail-deck.tsx
+++ b/apps/web/src/pages/artifact/rail-deck.tsx
@@ -30,6 +30,7 @@ export function Rail({
         data-testid="comments-rail-expand"
         onClick={onExpand}
         title="Expand comments (c)"
+        aria-label="Expand comments"
         className="flex h-[38px] w-full shrink-0 items-center justify-center gap-1.5 border-b border-border-soft text-foreground transition-colors hover:bg-hover"
       >
         <span className="text-xs">⟨</span>
@@ -50,6 +51,7 @@ export function Rail({
               data-testid={`comments-rail-dot-${id}`}
               onClick={() => onDot(id)}
               title={p.thread[0].body_md}
+              aria-label={`Jump to comment: ${p.thread[0].body_md}`}
               className={cn(
                 "absolute left-1/2 -translate-x-1/2 rounded-full border-2 border-card bg-primary p-0 transition-all",
                 isActive ? "size-3.5 shadow-[0_0_0_3px_var(--ac-soft)]" : "size-2.5",
@@ -65,6 +67,7 @@ export function Rail({
         data-testid="comments-rail-hide"
         onClick={onHide}
         title="Hide comments"
+        aria-label="Hide comments"
         className="flex h-[38px] w-full shrink-0 items-center justify-center border-t border-border-soft text-muted-foreground transition-colors hover:bg-hover"
       >
         ✕
@@ -89,6 +92,7 @@ export function IconBtn({
       type="button"
       data-testid={testId}
       title={title}
+      aria-label={title}
       onClick={onClick}
       className="grid size-[26px] place-items-center rounded-md text-muted-foreground transition-colors hover:bg-hover hover:text-foreground"
     >

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -175,3 +175,25 @@
     transform: translate(-50%, -50%) scale(1.9);
   }
 }
+
+/* Honor prefers-reduced-motion: near-zero out CSS animations, transitions, and
+   view transitions for vestibular-sensitive users. These rules are unlayered, so
+   the cascade-layer order above puts them ahead of every Tailwind utility (no
+   !important needed). The live-cursor rAF loop is JS-driven (transforms, not CSS),
+   so it snaps instead of gliding and skips click ripples in code too: see
+   use-live-cursors. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms;
+    animation-iteration-count: 1;
+    transition-duration: 0.01ms;
+    scroll-behavior: auto;
+  }
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none;
+  }
+}

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -43,6 +43,7 @@ CREATE TABLE IF NOT EXISTS comment (
     anchor TEXT,
     body_md TEXT NOT NULL,
     author TEXT NOT NULL,
+    author_id TEXT,
     state TEXT NOT NULL DEFAULT 'open',
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
     meta TEXT
@@ -259,6 +260,7 @@ CREATE TABLE IF NOT EXISTS proposal (
     title TEXT,
     message TEXT,
     author TEXT NOT NULL,
+    author_id TEXT,
     base_version INTEGER NOT NULL,
     state TEXT NOT NULL DEFAULT 'open',
     decided_by TEXT,

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -464,6 +464,9 @@ export interface ProposalRecord {
   /** What the proposer is changing, in their words. */
   message: string | null
   author: string
+  /** Stable id of the proposer (user/agent); withdraw authorization keys on this,
+   *  not `author`. Null for legacy rows and anonymous proposals. */
+  author_id: string | null
   /** The current_version this candidate was proposed against (for the diff). */
   base_version: number
   state: ProposalState
@@ -486,6 +489,7 @@ export interface NewProposal {
   title?: string | null
   message?: string | null
   author: string
+  author_id?: string | null
   base_version: number
 }
 
@@ -730,6 +734,9 @@ export interface CommentRecord {
   anchor: string | null
   body_md: string
   author: string
+  /** Stable id of the author (user/agent); authorization keys on this, not `author`.
+   *  Null for legacy rows and anonymous comments. */
+  author_id: string | null
   state: CommentState
   created_at: string
   /** JSON blob: { reactions?: {emoji: author[]}, edited_at?: string, deleted?: boolean }. */
@@ -745,6 +752,7 @@ export interface NewComment {
   anchor?: string | null
   body_md: string
   author: string
+  author_id?: string | null
 }
 
 /** A bundle version's blob is this manifest; file versions point at content directly. */

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -191,6 +191,8 @@ export interface ProposeInput {
   /** What the proposer is changing, in their words. */
   message?: string
   author?: string
+  /** Stable id of the proposer (user/agent); persisted for withdraw authorization. */
+  author_id?: string | null
 }
 
 export interface ProposeResult {
@@ -231,6 +233,7 @@ export async function propose(
     title: null,
     message: input.message ?? null,
     author: input.author ?? "anonymous",
+    author_id: input.author_id ?? null,
     base_version: artifact.current_version,
   })
   return { artifact, proposal }

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -62,6 +62,9 @@ export const comment = pgTable("comment", {
   anchor: text("anchor"),
   body_md: text("body_md").notNull(),
   author: text("author").notNull(),
+  // Stable identity of the author (user or agent id). Authorization keys on this,
+  // never the mutable display `author` name. Nullable for legacy/anonymous rows.
+  author_id: text("author_id"),
   state: text("state").$type<CommentState>().notNull().default("open"),
   created_at: text("created_at").notNull().$defaultFn(isoNow),
   meta: text("meta"),
@@ -268,6 +271,9 @@ export const proposal = pgTable("proposal", {
   title: text("title"),
   message: text("message"),
   author: text("author").notNull(),
+  // Stable identity of the proposer (user or agent id). Withdraw authorization
+  // keys on this, never the mutable display `author` name. Nullable for legacy.
+  author_id: text("author_id"),
   base_version: integer("base_version").notNull(),
   state: text("state").$type<ProposalState>().notNull().default("open"),
   decided_by: text("decided_by"),
@@ -351,11 +357,13 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
     anchor TEXT,
     body_md TEXT NOT NULL,
     author TEXT NOT NULL,
+    author_id TEXT,
     state TEXT NOT NULL DEFAULT 'open',
     created_at TEXT NOT NULL DEFAULT ${isoDefault},
     meta TEXT
   )`,
   `ALTER TABLE comment ADD COLUMN IF NOT EXISTS meta TEXT`,
+  `ALTER TABLE comment ADD COLUMN IF NOT EXISTS author_id TEXT`,
   `CREATE TABLE IF NOT EXISTS principal (
     id TEXT PRIMARY KEY,
     org_id TEXT NOT NULL,
@@ -539,6 +547,7 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
     title TEXT,
     message TEXT,
     author TEXT NOT NULL,
+    author_id TEXT,
     base_version INTEGER NOT NULL,
     state TEXT NOT NULL DEFAULT 'open',
     decided_by TEXT,
@@ -548,6 +557,7 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
     created_at TEXT NOT NULL DEFAULT ${isoDefault}
   )`,
   `ALTER TABLE proposal ADD COLUMN IF NOT EXISTS decision_note TEXT`,
+  `ALTER TABLE proposal ADD COLUMN IF NOT EXISTS author_id TEXT`,
   `CREATE INDEX IF NOT EXISTS proposal_artifact_state ON proposal (artifact_id, state)`,
   `CREATE TABLE IF NOT EXISTS report (
     id TEXT PRIMARY KEY,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -65,6 +65,10 @@ export const comment = sqliteTable("comment", {
   anchor: text("anchor"),
   body_md: text("body_md").notNull(),
   author: text("author").notNull(),
+  // Stable identity of the author (user or agent id). Authorization (edit/delete)
+  // keys on this, never the mutable display `author` name. Nullable for legacy
+  // rows + anonymous comments, which fall back to the name check.
+  author_id: text("author_id"),
   state: text("state").$type<CommentState>().notNull().default("open"),
   created_at: text("created_at").notNull().default(now),
   meta: text("meta"),
@@ -294,6 +298,9 @@ export const proposal = sqliteTable("proposal", {
   title: text("title"),
   message: text("message"),
   author: text("author").notNull(),
+  // Stable identity of the proposer (user or agent id). Withdraw authorization
+  // keys on this, never the mutable display `author` name. Nullable for legacy.
+  author_id: text("author_id"),
   base_version: integer("base_version").notNull(),
   state: text("state").$type<ProposalState>().notNull().default("open"),
   decided_by: text("decided_by"),
@@ -377,6 +384,7 @@ export const SCHEMA_STATEMENTS: string[] = [
     anchor TEXT,
     body_md TEXT NOT NULL,
     author TEXT NOT NULL,
+    author_id TEXT,
     state TEXT NOT NULL DEFAULT 'open',
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
     meta TEXT
@@ -564,6 +572,7 @@ export const SCHEMA_STATEMENTS: string[] = [
     title TEXT,
     message TEXT,
     author TEXT NOT NULL,
+    author_id TEXT,
     base_version INTEGER NOT NULL,
     state TEXT NOT NULL DEFAULT 'open',
     decided_by TEXT,
@@ -605,6 +614,8 @@ export const SCHEMA_STATEMENTS: string[] = [
  */
 export const MIGRATION_STATEMENTS: string[] = [
   `ALTER TABLE comment ADD COLUMN meta TEXT`,
+  `ALTER TABLE comment ADD COLUMN author_id TEXT`,
+  `ALTER TABLE proposal ADD COLUMN author_id TEXT`,
   `ALTER TABLE version ADD COLUMN name TEXT`,
   `ALTER TABLE proposal ADD COLUMN decision_note TEXT`,
   `ALTER TABLE artifact ADD COLUMN removed_at TEXT`,


### PR DESCRIPTION
Closes the deep-review findings for **Security** (8.2 → 9+ target) and the new **Accessibility** axis (6.8 → 8+).

## Security
- **Authorship keyed on ids, never display names.** Comment edit/delete and proposal withdraw compared a mutable display `name`, so renaming your profile to a victim's name let you tamper with their content. Now they compare a stable `author_id` (user/agent id). New nullable `author_id` column on `comment` + `proposal` across sqlite + pg (DDL + forward `ALTER`s + d1 regen + core `Record`/`New` types + `propose()`); legacy/anonymous rows fall back to the name match.
- **App-origin security headers.** A global middleware adds `Strict-Transport-Security` (https only), `X-Content-Type-Options: nosniff`, and a clickjacking lock (`Content-Security-Policy: frame-ancestors 'none'` + `X-Frame-Options: DENY`) to app/API responses. It never touches `/raw` artifact bytes (sandbox CSP), `/v1/embed` (opts into `frame-ancestors *`), subdomain-served artifacts (already carry a CSP), or SSE streams.
- **Visibility-aware raw caching.** Only fully `public` artifacts are served `public, immutable`; `link`/`org`/`password` (gated) bytes are `private, no-store`, so a shared/CDN cache can't store and replay a private artifact to an unauthorized viewer. Proposal previews are always `no-store`.

## Accessibility
- **`prefers-reduced-motion`**: a global CSS reset (unlayered, so it beats Tailwind utilities without `!important`) + a JS guard so the live-cursor rAF loop snaps instead of gliding and skips click ripples.
- **Accessible names** on icon-only controls (the shared `IconBtn`, comment-rail expand/hide/dots, the More menu, show-comments); the decorative cursor overlay is `aria-hidden`.
- **Skip-link** ("Skip to content") as the first shell child, targeting the `<main>` region past the nav rail.

## Tests
`apps/api/test/review-hardening.test.ts` (8 cases): the rename attack on comment edit/delete + proposal withdraw, the app-origin headers (and that `/raw` keeps the sandbox CSP), and the public-vs-gated cache split. Full suite + `pnpm run ci` green (api 261, typecheck clean across all packages).

> Note: split out of an intermixed safety-snapshot (`5513fe7` on `chore/review-quick-fixes`) onto a clean branch off `main`. The other half of that snapshot (dead-code removal + emoji→Icon chrome) is a separate concern, left for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)