### PR TITLE
Move "New workspace" out of the rail switcher into Settings

### DIFF
--- a/apps/web/src/components/nav-rail.tsx
+++ b/apps/web/src/components/nav-rail.tsx
@@ -91,7 +91,6 @@ export function NavRail() {
     collections,
     workspaces,
     switchWorkspace,
-    createWorkspace,
     refreshCollections,
     setPaletteOpen,
   } = useShell()
@@ -329,7 +328,6 @@ export function NavRail() {
           workspaceLabel={summary?.workspace ?? ""}
           workspaces={workspaces}
           onSwitchWorkspace={switchWorkspace}
-          onCreateWorkspace={createWorkspace}
         />
       </div>
     </aside>

--- a/apps/web/src/components/user-pod.tsx
+++ b/apps/web/src/components/user-pod.tsx
@@ -2,9 +2,6 @@ import { useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
 import { api, type Workspaces } from "@/api"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
-import { Button } from "@/components/ui/button"
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { Input } from "@/components/ui/input"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { useAuth } from "@/ctx"
 import { cn } from "@/lib/utils"
@@ -18,28 +15,25 @@ const SECTION =
   "px-2 pb-1 pt-1 font-mono text-2xs uppercase tracking-[0.06em] text-muted-foreground"
 
 // The account + workspace pod at the foot of the nav rail (bottom-left). Opens
-// UPWARD. Holds the workspace switcher (multi mode), the segmented theme control,
-// and the account actions. Creating a workspace opens a centered modal (a
-// deliberate action) rather than an inline input. Keeps the e2e test-ids:
-// user-menu-trigger, theme-option-*, menu-signout, workspace-*.
+// UPWARD. Holds the workspace switcher (switch between the ones you're in), the
+// segmented theme control, and the account actions. Creating a NEW workspace
+// lives in Settings → Workspace (a deliberate, infrequent action), not here.
+// Keeps the e2e test-ids: user-menu-trigger, theme-option-*, menu-signout,
+// workspace-*.
 export function UserPod({
   workspaceLabel,
   workspaces,
   onSwitchWorkspace,
-  onCreateWorkspace,
   rail,
 }: {
   workspaceLabel: string
   workspaces: Workspaces | null
   onSwitchWorkspace: (id: string) => void
-  onCreateWorkspace: (name: string) => void
   rail?: boolean
 }) {
   const { me, setMe } = useAuth()
   const nav = useNavigate()
   const [open, setOpen] = useState(false)
-  const [createOpen, setCreateOpen] = useState(false)
-  const [name, setName] = useState("")
   if (!me) return null
 
   const initials = (me.name ?? me.email).slice(0, 2).toUpperCase()
@@ -55,171 +49,110 @@ export function UserPod({
     setMe(null)
     nav({ to: "/login" })
   }
-  const openCreate = () => {
-    setOpen(false)
-    setName("")
-    setCreateOpen(true)
-  }
-  const createSubmit = () => {
-    const t = name.trim()
-    if (!t) return
-    onCreateWorkspace(t) // reloads the page into the new workspace
-    setName("")
-    setCreateOpen(false)
-  }
 
   return (
-    <>
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <button
-            type="button"
-            data-testid="user-menu-trigger"
-            title={me.name ?? me.email}
-            className={cn(
-              "flex w-full items-center gap-2.5 rounded-md px-2 py-2 text-left transition-colors hover:bg-hover",
-              rail && "justify-center px-0",
-            )}
-          >
-            <Avatar className="size-7 shrink-0">
-              <AvatarFallback className="bg-primary text-xs text-primary-foreground">
-                {initials}
-              </AvatarFallback>
-            </Avatar>
-            {!rail && (
-              <span className="min-w-0 flex-1">
-                <span className="block truncate text-sm font-semibold text-foreground">
-                  {me.name ?? me.email}
-                </span>
-                <span className="block truncate text-2xs text-muted-foreground">
-                  {workspaceLabel || me.email}
-                </span>
-              </span>
-            )}
-            {!rail && <Icon name="more" size={16} />}
-          </button>
-        </PopoverTrigger>
-
-        <PopoverContent side="top" align="start" className="w-64 p-1.5">
-          <div className="flex items-center gap-2.5 px-2 py-1.5">
-            <Avatar className="size-7 shrink-0">
-              <AvatarFallback className="bg-primary text-xs text-primary-foreground">
-                {initials}
-              </AvatarFallback>
-            </Avatar>
-            <span className="min-w-0">
-              <span className="block truncate text-sm font-semibold">{me.name ?? me.email}</span>
-              <span className="block truncate text-2xs text-muted-foreground">{me.email}</span>
-            </span>
-          </div>
-          <div className="my-1 h-px bg-border-soft" />
-
-          {multi ? (
-            <>
-              <div className={SECTION}>Workspace</div>
-              {workspaces?.workspaces.map((w) => (
-                <button
-                  key={w.id}
-                  type="button"
-                  data-testid={`workspace-${w.id}`}
-                  onClick={() => {
-                    onSwitchWorkspace(w.id)
-                    setOpen(false)
-                  }}
-                  className={cn(ROW, w.id === workspaces.active && "text-primary")}
-                >
-                  {w.id === workspaces.active ? (
-                    <Icon name="check" size={16} />
-                  ) : (
-                    <span className="size-4 shrink-0" />
-                  )}
-                  <span className="truncate">{w.name}</span>
-                </button>
-              ))}
-              <button
-                type="button"
-                data-testid="workspace-new"
-                onClick={openCreate}
-                className={ROW}
-              >
-                <Icon name="plus" size={16} /> New workspace
-              </button>
-              <div className="my-1 h-px bg-border-soft" />
-            </>
-          ) : (
-            <button
-              type="button"
-              data-testid="workspace-switcher"
-              onClick={goSettings}
-              title="Workspace settings"
-              className={ROW}
-            >
-              <Icon name="workspace" size={16} />
-              <span className="truncate">{workspaceLabel || "Workspace"}</span>
-            </button>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          data-testid="user-menu-trigger"
+          title={me.name ?? me.email}
+          className={cn(
+            "flex w-full items-center gap-2.5 rounded-md px-2 py-2 text-left transition-colors hover:bg-hover",
+            rail && "justify-center px-0",
           )}
+        >
+          <Avatar className="size-7 shrink-0">
+            <AvatarFallback className="bg-primary text-xs text-primary-foreground">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+          {!rail && (
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-sm font-semibold text-foreground">
+                {me.name ?? me.email}
+              </span>
+              <span className="block truncate text-2xs text-muted-foreground">
+                {workspaceLabel || me.email}
+              </span>
+            </span>
+          )}
+          {!rail && <Icon name="more" size={16} />}
+        </button>
+      </PopoverTrigger>
 
-          <div className={SECTION}>Theme</div>
-          <div className="px-1 pb-1">
-            <ThemeSwitch />
-          </div>
-          <div className="my-1 h-px bg-border-soft" />
+      <PopoverContent side="top" align="start" className="w-64 p-1.5">
+        <div className="flex items-center gap-2.5 px-2 py-1.5">
+          <Avatar className="size-7 shrink-0">
+            <AvatarFallback className="bg-primary text-xs text-primary-foreground">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+          <span className="min-w-0">
+            <span className="block truncate text-sm font-semibold">{me.name ?? me.email}</span>
+            <span className="block truncate text-2xs text-muted-foreground">{me.email}</span>
+          </span>
+        </div>
+        <div className="my-1 h-px bg-border-soft" />
 
-          <div className={SECTION}>Cursor</div>
-          <div className="px-1 pb-1">
-            <CursorSwitch />
-          </div>
-          <div className="my-1 h-px bg-border-soft" />
-
+        {multi ? (
+          <>
+            <div className={SECTION}>Workspace</div>
+            {workspaces?.workspaces.map((w) => (
+              <button
+                key={w.id}
+                type="button"
+                data-testid={`workspace-${w.id}`}
+                onClick={() => {
+                  onSwitchWorkspace(w.id)
+                  setOpen(false)
+                }}
+                className={cn(ROW, w.id === workspaces.active && "text-primary")}
+              >
+                {w.id === workspaces.active ? (
+                  <Icon name="check" size={16} />
+                ) : (
+                  <span className="size-4 shrink-0" />
+                )}
+                <span className="truncate">{w.name}</span>
+              </button>
+            ))}
+            <div className="my-1 h-px bg-border-soft" />
+          </>
+        ) : (
           <button
             type="button"
-            data-testid="menu-signout"
-            onClick={signOut}
-            className={cn(ROW, "text-muted-foreground")}
+            data-testid="workspace-switcher"
+            onClick={goSettings}
+            title="Workspace settings"
+            className={ROW}
           >
-            <Icon name="signout" size={16} /> Sign out
+            <Icon name="workspace" size={16} />
+            <span className="truncate">{workspaceLabel || "Workspace"}</span>
           </button>
-        </PopoverContent>
-      </Popover>
+        )}
 
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>Create a workspace</DialogTitle>
-          </DialogHeader>
-          <label htmlFor="ws-name" className="text-sm font-medium text-foreground">
-            Name
-          </label>
-          <Input
-            id="ws-name"
-            autoFocus
-            value={name}
-            placeholder="Acme Marketing"
-            aria-label="Workspace name"
-            data-testid="workspace-new-input"
-            onChange={(e) => setName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") createSubmit()
-            }}
-            className="mt-1.5"
-          />
-          <p className="mt-2 text-xs text-muted-foreground">Starts empty. You'll be the owner.</p>
-          <div className="mt-4 flex justify-end gap-2">
-            <Button variant="outline" size="sm" onClick={() => setCreateOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={createSubmit}
-              disabled={!name.trim()}
-              data-testid="workspace-create-submit"
-            >
-              Create
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-    </>
+        <div className={SECTION}>Theme</div>
+        <div className="px-1 pb-1">
+          <ThemeSwitch />
+        </div>
+        <div className="my-1 h-px bg-border-soft" />
+
+        <div className={SECTION}>Cursor</div>
+        <div className="px-1 pb-1">
+          <CursorSwitch />
+        </div>
+        <div className="my-1 h-px bg-border-soft" />
+
+        <button
+          type="button"
+          data-testid="menu-signout"
+          onClick={signOut}
+          className={cn(ROW, "text-muted-foreground")}
+        >
+          <Icon name="signout" size={16} /> Sign out
+        </button>
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/apps/web/src/pages/settings/workspace-section.tsx
+++ b/apps/web/src/pages/settings/workspace-section.tsx
@@ -19,10 +19,12 @@ import { Input } from "@/components/ui/input"
 import { roleLabel, roleValue, selectClass, WS_ROLES } from "./roles"
 
 export function WorkspaceSection({ meId }: { meId: string }) {
-  const { refreshWorkspaces } = useShell()
+  const { refreshWorkspaces, createWorkspace } = useShell()
   const [ws, setWs] = useState<Workspace | null>(null)
   const [name, setName] = useState("")
   const [savingName, setSavingName] = useState(false)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [newName, setNewName] = useState("")
   const [email, setEmail] = useState("")
   const [addRole, setAddRole] = useState<Role>("commenter")
   const [adding, setAdding] = useState(false)
@@ -45,6 +47,17 @@ export function WorkspaceSection({ meId }: { meId: string }) {
   }, [load])
 
   const isAdmin = ws?.role === "owner"
+
+  // Create a brand-new workspace. Lives here (a deliberate, infrequent action)
+  // rather than in the rail's workspace switcher. createWorkspace reloads the
+  // page into the new workspace.
+  const createSubmit = () => {
+    const t = newName.trim()
+    if (!t) return
+    createWorkspace(t)
+    setNewName("")
+    setCreateOpen(false)
+  }
 
   const saveName = async () => {
     const n = name.trim()
@@ -122,10 +135,54 @@ export function WorkspaceSection({ meId }: { meId: string }) {
 
   return (
     <section>
-      <p className="mb-4 text-sm text-muted-foreground">
-        Name your workspace and choose who's in it. <strong>Admins</strong> add people,{" "}
-        <strong>Creators</strong> publish artifacts, <strong>Viewers</strong> read and comment.
-      </p>
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <p className="text-sm text-muted-foreground">
+          Name your workspace and choose who's in it. <strong>Admins</strong> add people,{" "}
+          <strong>Creators</strong> publish artifacts, <strong>Viewers</strong> read and comment.
+        </p>
+        <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+          <DialogTrigger asChild>
+            <Button data-testid="workspace-new" variant="outline" size="sm" className="shrink-0">
+              New workspace
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="max-w-sm">
+            <DialogHeader>
+              <DialogTitle>Create a workspace</DialogTitle>
+              <DialogDescription>Starts empty. You'll be the owner.</DialogDescription>
+            </DialogHeader>
+            <Input
+              autoFocus
+              value={newName}
+              placeholder="Acme Marketing"
+              aria-label="New workspace name"
+              data-testid="workspace-new-input"
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && createSubmit()}
+              maxLength={80}
+            />
+            <div className="mt-3 flex justify-end gap-2">
+              <Button
+                data-testid="workspace-new-cancel"
+                variant="outline"
+                size="sm"
+                onClick={() => setCreateOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={createSubmit}
+                disabled={!newName.trim()}
+                data-testid="workspace-create-submit"
+              >
+                Create
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </div>
 
       <Card className="p-4">
         <div className="text-xs font-semibold text-muted-foreground">Workspace name</div>


### PR DESCRIPTION
Super-minor UX: the workspace switcher (foot of the nav rail) is opened frequently just to **switch** workspaces, so a "New workspace" entry there invited accidental/excess creation. Creating a workspace is a deliberate, infrequent action, so it moves to **Settings → Workspace**.

- **UserPod**: removed the "New workspace" button + its create dialog/state and the `onCreateWorkspace` prop. The pod now only switches between the workspaces you're already in.
- **nav-rail**: stopped threading `createWorkspace` into the pod.
- **WorkspaceSection**: added a modest "New workspace" button + create dialog (top-right of the Workspace tab), wired to the shell's `createWorkspace` (reloads into the new workspace). The `workspace-new` / `workspace-new-input` / `workspace-create-submit` test-ids move with it; no e2e references the old location.

Verified: typecheck clean, `pnpm run ci` green, web unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)