### PR TITLE
fix(edge): don't 500 SSE — guard security-header middleware against immutable response headers

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -52,19 +52,28 @@ export function createApp(deps: AppDeps): Hono {
   // (/v1/embed), a subdomain-served artifact (already carries a CSP), or SSE streams.
   app.use("*", async (c, next) => {
     await next()
-    const h = c.res.headers
-    if (!h.has("x-content-type-options")) h.set("X-Content-Type-Options", "nosniff")
-    const proto = (c.req.header("x-forwarded-proto") ?? new URL(c.req.url).protocol).replace(
-      ":",
-      "",
-    )
-    if (proto === "https" && !h.has("strict-transport-security"))
-      h.set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
-    const path = c.req.path
-    const framable = path.startsWith("/raw/") || path.startsWith("/v1/embed/")
-    if (!framable && !path.endsWith("/events") && !h.has("content-security-policy")) {
-      h.set("Content-Security-Policy", "frame-ancestors 'none'")
-      h.set("X-Frame-Options", "DENY")
+    // A proxied/streamed response (e.g. a Durable Object's SSE stream on the edge,
+    // returned via stub.fetch) carries IMMUTABLE headers — mutating them throws and
+    // would 500 the request. These headers are belt-and-suspenders on the app
+    // surface, never load-bearing on a streamed DO/raw response, so skip silently
+    // when the headers can't be written.
+    try {
+      const h = c.res.headers
+      if (!h.has("x-content-type-options")) h.set("X-Content-Type-Options", "nosniff")
+      const proto = (c.req.header("x-forwarded-proto") ?? new URL(c.req.url).protocol).replace(
+        ":",
+        "",
+      )
+      if (proto === "https" && !h.has("strict-transport-security"))
+        h.set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
+      const path = c.req.path
+      const framable = path.startsWith("/raw/") || path.startsWith("/v1/embed/")
+      if (!framable && !path.endsWith("/events") && !h.has("content-security-policy")) {
+        h.set("Content-Security-Policy", "frame-ancestors 'none'")
+        h.set("X-Frame-Options", "DENY")
+      }
+    } catch {
+      // immutable (proxied/streamed) response headers — leave as-is
     }
   })
 

--- a/apps/web/src/lib/emoji.test.ts
+++ b/apps/web/src/lib/emoji.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { emojifyShortcodes, EMOJI, PICKER_EMOJI } from "./emoji"
+import { EMOJI, emojifyShortcodes, PICKER_EMOJI } from "./emoji"
 
 describe("emojifyShortcodes", () => {
   it("replaces known shortcodes with their emoji", () => {


### PR DESCRIPTION
## The bug (live edge outage)
After deploying current `main` to the Cloudflare edge, **all realtime broke** — live cursors, presence ("N viewing"), and live comment updates. `GET /v1/artifacts/:id/events` returned **500**.

Root cause: the app-origin security-header middleware from #132 runs `c.res.headers.set(...)` on every response. On the edge the SSE stream is returned from the `ArtifactRoom` Durable Object via `stub.fetch()`, and a **fetch `Response` has immutable headers** — so `set()` threw and 500'd the request, killing the stream. The Node/self-host path uses in-process `streamSSE` (mutable headers), which is why it never showed up in tests or self-host.

## The fix
Wrap the header writes in `try/catch`. These headers are belt-and-suspenders on the app surface and never load-bearing on a streamed DO/raw response, so when they can't be written (proxied/streamed responses) we leave them as-is instead of throwing. Normal responses still get HSTS / nosniff / frame-ancestors (verified on the live worker: `/healthz` keeps all three; `/events` now returns `200 text/event-stream`).

Note: not unit-testable in the node/vitest harness (the in-process backplane returns mutable-header responses; header immutability is a workerd/fetch-guard behavior). Verified directly against the deployed edge worker. The #132 header tests still pass (8/8).

(Also: a one-line `biome organize-imports` sort on `emoji.test.ts`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)