### PR TITLE
fix(web): resilient artifact load — self-heal transient failures, come back cleanly

### DIFF
--- a/apps/web/src/lib/emoji.test.ts
+++ b/apps/web/src/lib/emoji.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { emojifyShortcodes, EMOJI, PICKER_EMOJI } from "./emoji"
+import { EMOJI, emojifyShortcodes, PICKER_EMOJI } from "./emoji"
 
 describe("emojifyShortcodes", () => {
   it("replaces known shortcodes with their emoji", () => {

--- a/apps/web/src/lib/query-client.test.ts
+++ b/apps/web/src/lib/query-client.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+import { isTransient, retryQuery } from "./query-client"
+
+// The resilience seam: transient failures self-heal, client errors fail fast.
+const apiErr = (status: number) => Object.assign(new Error(`HTTP ${status}`), { status })
+
+describe("isTransient", () => {
+  it("treats 4xx (auth, not-found, conflict) as non-transient", () => {
+    for (const s of [400, 401, 403, 404, 409, 429]) expect(isTransient(apiErr(s))).toBe(false)
+  })
+  it("treats 5xx as transient", () => {
+    for (const s of [500, 502, 503]) expect(isTransient(apiErr(s))).toBe(true)
+  })
+  it("treats a network/unknown error (no status) as transient", () => {
+    expect(isTransient(new TypeError("Failed to fetch"))).toBe(true)
+    expect(isTransient(undefined)).toBe(true)
+  })
+})
+
+describe("retryQuery", () => {
+  it("retries transient failures up to 3 times then stops", () => {
+    expect(retryQuery(0, apiErr(503))).toBe(true)
+    expect(retryQuery(2, apiErr(503))).toBe(true)
+    expect(retryQuery(3, apiErr(503))).toBe(false)
+  })
+  it("never retries a 404/403", () => {
+    expect(retryQuery(0, apiErr(404))).toBe(false)
+    expect(retryQuery(0, apiErr(403))).toBe(false)
+  })
+})

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -2,14 +2,33 @@ import { QueryClient } from "@tanstack/react-query"
 
 // One client for the app: route loaders warm it via ensureQueryData / prefetch,
 // components read it via useQuery, so an intent-preloaded route serves its data
-// from cache on the click that follows. retry is off (the API is auth-gated — a
-// 401/404 should fail fast, not retry three times), focus refetches are off
-// (matches the prior hand-rolled fetches), and a 30s staleTime lets a preload
-// stay warm long enough to be consumed.
+// from cache on the click that follows. Focus refetches are off (matches the prior
+// hand-rolled fetches); a 30s staleTime lets a preload stay warm long enough to be
+// consumed.
+//
+// Retry is the resilience seam. A 4xx (auth, not-found, conflict) won't fix itself,
+// so fail fast. But a transient failure — a network blip, a 5xx, the server briefly
+// unhealthy mid-deploy — SHOULD self-heal, so retry those a few times with backoff
+// instead of dead-ending the UI. Status is read by duck-typing (ApiError carries a
+// numeric `status`; a network failure throws without one), so this file needn't
+// import from the api module.
+/** A 4xx (auth, not-found, conflict) won't fix itself; anything else — a 5xx or a
+ *  network/unknown failure (which throws without a numeric status) — is transient
+ *  and worth retrying. */
+export const isTransient = (err: unknown): boolean => {
+  const status = (err as { status?: unknown })?.status
+  return !(typeof status === "number" && status >= 400 && status < 500)
+}
+
+/** Retry transient failures up to 3 times; fail fast on client errors. */
+export const retryQuery = (failureCount: number, err: unknown): boolean =>
+  failureCount < 3 && isTransient(err)
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      retry: false,
+      retry: retryQuery,
+      retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 5000),
       refetchOnWindowFocus: false,
       staleTime: 30_000,
     },

--- a/apps/web/src/pages/artifact/artifact-states.tsx
+++ b/apps/web/src/pages/artifact/artifact-states.tsx
@@ -23,6 +23,36 @@ export function ArtifactNotFound({ onBack }: { onBack: () => void }) {
   )
 }
 
+// A TRANSIENT failure (network blip, a 5xx, the server briefly unhealthy) — distinct
+// from a real 404/403. The query already auto-retries with backoff; this is the
+// recoverable fallback once those are exhausted, so the page comes back with one
+// click instead of dead-ending on "not found".
+export function ArtifactLoadError({
+  onRetry,
+  onBack,
+}: {
+  onRetry: () => void
+  onBack: () => void
+}) {
+  return (
+    <div className="grid h-full place-items-center gap-3 text-center">
+      <Icon name="removed" size={36} className="opacity-50" />
+      <div className="text-lg font-semibold">Couldn't load this artifact</div>
+      <div className="max-w-[360px] text-sm leading-relaxed text-muted-foreground">
+        Something went wrong reaching the server. This is usually temporary.
+      </div>
+      <div className="flex gap-2">
+        <Button variant="primary" data-testid="artifact-load-retry" onClick={onRetry}>
+          Try again
+        </Button>
+        <Button variant="outline" data-testid="artifact-load-back" onClick={onBack}>
+          Back to library
+        </Button>
+      </div>
+    </div>
+  )
+}
+
 // A taken-down artifact: content is gone (the server 410s the raw routes), but an
 // owner can still reinstate it.
 export function ArtifactRemoved({

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -14,7 +14,12 @@ import { cn } from "@/lib/utils"
 import { artifactActions } from "./artifact-actions"
 import { ArtifactComments } from "./artifact-comments"
 import { ArtifactDocument } from "./artifact-document"
-import { ArtifactLoading, ArtifactNotFound, ArtifactRemoved } from "./artifact-states"
+import {
+  ArtifactLoadError,
+  ArtifactLoading,
+  ArtifactNotFound,
+  ArtifactRemoved,
+} from "./artifact-states"
 import { ArtifactTopBar } from "./artifact-top-bar"
 import { ActionsCtx } from "./comment-actions"
 import { groupThreads, parseAnchor } from "./lib/layout"
@@ -136,11 +141,15 @@ export function Artifact() {
   }
 
   useEffect(() => {
-    // Anonymous can view a public artifact (read-only, with a sign-up CTA). Only
-    // bounce to login when it isn't readable for them (private / 404) — then an
-    // account is required. A signed-in user with no access bounces the same way.
-    if (!loading && !me && failed && !locked) nav({ to: "/login" })
-  }, [loading, me, failed, locked, nav])
+    // Anonymous can view a public artifact (read-only, with a sign-up CTA). Bounce
+    // to login ONLY when the artifact is genuinely gated (404/403) for a logged-out
+    // visitor — then an account is required. A TRANSIENT failure (5xx/network) also
+    // nulls `me` (the session check failed too), but must NOT eject the user to
+    // login mid-outage — the recoverable error state below handles that, so the
+    // page comes back cleanly once the server does.
+    const gated = error instanceof ApiError && (error.status === 404 || error.status === 403)
+    if (!loading && !me && failed && !locked && gated) nav({ to: "/login" })
+  }, [loading, me, failed, locked, error, nav])
 
   // Deep link: ?c=<thread> opens the panel, activates that thread, and jumps to
   // its text. Runs once, after comments are in.
@@ -157,7 +166,18 @@ export function Artifact() {
   }, [comments, post, setPanel])
 
   if (locked) return <PasswordGate shortId={shortId} onUnlocked={() => refetch()} />
-  if (failed) return <ArtifactNotFound onBack={() => nav({ to: "/" })} />
+  if (failed) {
+    // A genuine 404/403 is "not found / no access". Anything else (a 5xx, a
+    // network blip, the server briefly unhealthy) is transient — the query already
+    // auto-retried with backoff, so offer a clean "Try again" rather than a
+    // dead-end. This is what made the outage look like a permanent failure.
+    const status = error instanceof ApiError ? error.status : undefined
+    return status === 404 || status === 403 ? (
+      <ArtifactNotFound onBack={() => nav({ to: "/" })} />
+    ) : (
+      <ArtifactLoadError onRetry={() => refetch()} onBack={() => nav({ to: "/" })} />
+    )
+  }
   if (!art) return <ArtifactLoading />
   // Removed artifacts show a tombstone instead of the document — content is gone
   // (the server 410s the raw routes), but an owner can still reinstate.


### PR DESCRIPTION
Hardens the artifact experience so a transient backend issue **degrades gracefully and recovers on its own**, instead of looking like a permanent break (the failure mode from today's edge incident).

### Before
A 5xx / network blip / server-briefly-unhealthy →
- the artifact page showed the dead-end **"Artifact not found, or you don't have access"**, and
- because the session check also failed (`me` null), it **bounced the user to /login** — a transient outage looked like a forced logout.

### After
- **Smart retry.** `query-client` retry is now a policy: a 4xx (auth/not-found/conflict) fails fast; a transient failure (5xx, or a network error that throws without a status) retries up to 3× with exponential backoff. Most blips self-heal before anything is shown. Exported `isTransient`/`retryQuery` with unit tests.
- **Recoverable error state.** A genuine 404/403 still shows "not found / no access"; anything else shows **`ArtifactLoadError`** — "Couldn't load this artifact… usually temporary" with a **Try again** button that refetches.
- **No logout on outage.** The `/login` bounce now fires only for a genuinely gated (404/403) artifact when logged out — never on a transient failure.
- **Realtime** already auto-reconnects via `EventSource`, so cursors/presence/live-comments recover on their own once the stream is healthy.

### Vetted locally, end-to-end (Node API + web + browser)
1. Normal load ✅
2. Kill the API → recoverable **"Try again"** (no login bounce, no dead-end) ✅
3. Restart API + Try again → clean recovery, artifact renders ✅
4. Genuine 404 → routes correctly (login when anon / not-found when authed) ✅

typecheck, `pnpm run ci`, and web tests (33) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)