### PR TITLE
fix: dismiss popovers on artifact-iframe click + notify on artifact share

### DIFF
--- a/apps/api/src/routes/sharing.ts
+++ b/apps/api/src/routes/sharing.ts
@@ -7,7 +7,7 @@ import { fail, readJson } from "../lib/http"
 /** Per-artifact role overrides (a share). Managing shares requires `share`
  *  (editor+, GDocs model); the share's role beats the caller's workspace baseline. */
 export const sharingRoutes = (ctx: AppContext) => {
-  const { meta, defaultRole, anonLocked, authorize, actorFor } = ctx
+  const { meta, defaultRole, anonLocked, authorize, actorFor, actingUser, bus } = ctx
   const app = new Hono()
 
   // A sharer can never grant — or remove — a role above their own. An editor (who
@@ -60,6 +60,29 @@ export const sharingRoutes = (ctx: AppContext) => {
       user_id: user.id,
       role: b.role,
     })
+    // Notify the person you just shared with (bell + live stream), unless that's
+    // you. A share has no comment thread, so the thread/comment ids are empty and
+    // the bell deep-links straight to the artifact.
+    const sharer = await actingUser(c)
+    if (sharer && sharer.id !== user.id) {
+      const row = {
+        id: newId("n"),
+        user_id: user.id,
+        actor: sharer.name,
+        kind: "share" as const,
+        artifact_id: artifact.id,
+        artifact_short_id: artifact.short_id,
+        artifact_title: artifact.title,
+        thread_id: "",
+        comment_id: "",
+        preview: `Shared with you as ${b.role}`,
+      }
+      await meta.createNotification(row)
+      bus.publish(`u:${user.id}`, {
+        type: "notification",
+        notification: { ...row, read: 0, created_at: new Date().toISOString() },
+      })
+    }
     return c.json({ user_id: user.id, email: user.email, name: user.name, role: b.role }, 201)
   })
 

--- a/apps/api/test/sharing.test.ts
+++ b/apps/api/test/sharing.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import { as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// Sharing an artifact with someone should land in their notification bell, the
+// same way an @mention does. A share has no comment thread, so the thread/comment
+// ids are empty and the bell deep-links to the artifact itself.
+describe("artifact share → notification", () => {
+  const alice: TestUser = { id: "u_sh_alice", email: "sha@dock.test", name: "Alice" }
+  const bob: TestUser = { id: "u_sh_bob", email: "shb@dock.test", name: "Bob" }
+  const { app } = makeAuthedApp("share-notif", [alice, bob], "editor")
+  let shortId: string
+
+  const share = (email: string, role: string, by: string) =>
+    app.request(`/v1/artifacts/${shortId}/members`, {
+      ...jsonAs(as(by), { email, role }),
+      method: "PUT",
+    })
+
+  it("notifies the person an artifact is shared with", async () => {
+    shortId = (await (await publishAs(app, "<h1>doc</h1>", {}, as(alice.email))).json()).short_id
+    expect((await share(bob.email, "viewer", alice.email)).status).toBe(201)
+
+    const bobN = await (await app.request("/v1/notifications", { headers: as(bob.email) })).json()
+    expect(bobN.unread).toBe(1)
+    expect(bobN.notifications[0]).toMatchObject({
+      kind: "share",
+      actor: "Alice",
+      artifact_short_id: shortId,
+      thread_id: "",
+      comment_id: "",
+      read: 0,
+    })
+    expect(bobN.notifications[0].preview).toContain("viewer")
+  })
+
+  it("does not notify when you share with yourself", async () => {
+    expect((await share(alice.email, "editor", alice.email)).status).toBe(201)
+    const aliceN = await (
+      await app.request("/v1/notifications", { headers: as(alice.email) })
+    ).json()
+    expect(aliceN.unread).toBe(0)
+  })
+})

--- a/apps/web/e2e/deep/popover-dismiss.deep.spec.ts
+++ b/apps/web/e2e/deep/popover-dismiss.deep.spec.ts
@@ -1,0 +1,18 @@
+import { expect, openArtifact, publishArtifact, test } from "../fixtures"
+
+// Clicking the artifact itself should dismiss an open popover. The artifact renders
+// in a sandboxed <iframe>, which swallows the click — the parent document never
+// sees a pointerdown — so Radix's normal outside-dismiss never fires. The fix wires
+// it through the window `blur` that an iframe focus-steal produces; this guards it.
+test("clicking the artifact iframe dismisses an open popover", async ({ owner }) => {
+  const id = await publishArtifact(owner, "doc.md", "# Doc\n\nbody text")
+  await openArtifact(owner, id)
+
+  // Open the cursor popover; its contents (the kind picker) are visible.
+  await owner.getByTestId("cursor-self-trigger").click()
+  await expect(owner.getByTestId("cursor-kind-emoji")).toBeVisible()
+
+  // Click into the artifact (focuses the iframe → window blur → dismiss).
+  await owner.locator("iframe").first().click()
+  await expect(owner.getByTestId("cursor-kind-emoji")).toBeHidden()
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -171,7 +171,7 @@ export interface Notification {
   id: string
   user_id: string
   actor: string
-  kind: "mention" | "comment"
+  kind: "mention" | "comment" | "share"
   artifact_id: string
   artifact_short_id: string
   artifact_title: string | null

--- a/apps/web/src/components/notification-bell.tsx
+++ b/apps/web/src/components/notification-bell.tsx
@@ -54,7 +54,12 @@ export function NotificationBell({ collapsed }: { collapsed?: boolean }) {
         .then((r) => setUnread(r.unread))
         .catch(() => {})
     }
-    nav({ to: "/a/$ref", params: { ref: n.artifact_short_id }, search: { c: n.thread_id } })
+    nav({
+      to: "/a/$ref",
+      params: { ref: n.artifact_short_id },
+      // A share notification has no thread; open the artifact itself.
+      search: n.thread_id ? { c: n.thread_id } : {},
+    })
   }
 
   const markAll = () => {
@@ -130,13 +135,23 @@ export function NotificationBell({ collapsed }: { collapsed?: boolean }) {
                 <span className="min-w-0 flex-1">
                   <span className="block text-sm text-foreground">
                     <strong>{n.actor}</strong>{" "}
-                    {n.kind === "mention" ? "mentioned you" : "commented"}
-                    {n.artifact_title ? (
+                    {n.kind === "share" ? (
                       <>
-                        {" in "}
-                        <strong>{n.artifact_title}</strong>
+                        shared{" "}
+                        {n.artifact_title ? <strong>{n.artifact_title}</strong> : "an artifact"}
+                        {" with you"}
                       </>
-                    ) : null}
+                    ) : (
+                      <>
+                        {n.kind === "mention" ? "mentioned you" : "commented"}
+                        {n.artifact_title ? (
+                          <>
+                            {" in "}
+                            <strong>{n.artifact_title}</strong>
+                          </>
+                        ) : null}
+                      </>
+                    )}
                   </span>
                   <span className="my-px block truncate text-xs text-muted-foreground">
                     {n.preview}

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -1,10 +1,30 @@
 import * as PopoverPrimitive from "@radix-ui/react-popover"
 import type * as React from "react"
+import { useEffect } from "react"
 import { cn } from "@/lib/utils"
 
 export const Popover = PopoverPrimitive.Root
 export const PopoverTrigger = PopoverPrimitive.Trigger
 export const PopoverAnchor = PopoverPrimitive.Anchor
+
+// Radix dismisses a popover on a pointerdown outside it, but a click that lands
+// inside the artifact <iframe> never reaches this document (the iframe swallows
+// it), so the popover would stay open. When focus jumps into an iframe the window
+// fires `blur`; translate that into a synthetic outside pointerdown so Radix's own
+// dismissal runs. Fixes "click the artifact to dismiss the cursor/notification popover."
+function useDismissOnIframeBlur() {
+  useEffect(() => {
+    const onBlur = () => {
+      // activeElement settles to the iframe just after the blur event fires.
+      setTimeout(() => {
+        if (document.activeElement instanceof HTMLIFrameElement)
+          document.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }))
+      }, 0)
+    }
+    window.addEventListener("blur", onBlur)
+    return () => window.removeEventListener("blur", onBlur)
+  }, [])
+}
 
 export function PopoverContent({
   className,
@@ -12,6 +32,7 @@ export function PopoverContent({
   sideOffset = 7,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  useDismissOnIframeBlur()
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Content

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -502,7 +502,7 @@ export interface UserDir {
   image: string | null
 }
 
-export type NotificationKind = "mention" | "comment"
+export type NotificationKind = "mention" | "comment" | "share"
 export interface NotificationRecord {
   id: string
   user_id: string


### PR DESCRIPTION
Two reported bugs.

## 1. Popovers don't dismiss when you click the artifact
The cursor switcher, notification bell, tags menu, etc. are all Radix popovers, which dismiss on a `pointerdown` outside them. But the artifact renders in a sandboxed `<iframe>`, and a click that lands in the iframe never reaches the parent document, so the outside-dismiss never fires and the popover stays open.

An iframe focus-steal *does* fire a window `blur` (the live-cursor code already relies on this). So the shared `PopoverContent` now listens for `blur`, and when focus has moved into an `<iframe>`, dispatches a synthetic outside `pointerdown` so Radix's own dismissal runs. One fix covers every popover; it's a no-op on pages without an iframe.

Guarded by `e2e/deep/popover-dismiss.deep.spec.ts` (open the cursor popover → click the artifact → it closes).

## 2. Sharing an artifact doesn't notify the recipient
The notification pipeline already worked for @mentions but nothing fired on a share. Added a `"share"` `NotificationKind`; `PUT /v1/artifacts/:shortId/members` now creates a bell + live-SSE notification for the person shared with (skipped when you share with yourself). A share has no comment thread, so thread/comment ids are empty and the bell deep-links straight to the artifact. The bell renders the new kind ("shared **X** with you"). Covered by `test/sharing.test.ts`.

## Scope
Deliberately **stayed out of `comments.ts` and the @mention path** — an in-flight PR owns comments + mentions, and tags/mentions already notify. The "notify on a plain comment" case belongs to that PR.

## Verification
- `pnpm typecheck` ✓ · `pnpm test` ✓ (api 261, web 33, core 55, db 44, storage 16, mcp 10)
- new `test/sharing.test.ts` ✓ · new popover-dismiss e2e ✓ · chrome + cursors deep specs ✓ (no regression)
- biome + all `lint:*` scripts ✓. The pre-existing `knip` findings (`tslib`, `worker.ts`) are unrelated (identical on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)