### PR TITLE
chore(web): move tslib to devDependencies

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,7 +44,6 @@
     "react-dom": "^19.2.7",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
-    "tslib": "^2.8.1",
     "web-vitals": "^5.3.0"
   },
   "devDependencies": {
@@ -62,6 +61,7 @@
     "react-scan": "^0.5.7",
     "rollup-plugin-visualizer": "^7.0.1",
     "tailwindcss": "^4.3.1",
+    "tslib": "^2.8.1",
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,9 +169,6 @@ importers:
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
       web-vitals:
         specifier: ^5.3.0
         version: 5.3.0
@@ -218,6 +215,9 @@ importers:
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0


### PR DESCRIPTION
`tslib` was added to `apps/web` **dependencies** on main (commit "Minor fix to run locally (outside of container)") as a phantom runtime shim a transitive dep needs when running outside the container.

`apps/web` is a bundled Vite SPA with no production Node runtime — `tslib`'s helpers are baked into the build output, so it is only ever needed at build time. `devDependencies` is the correct home.

**Safe because:** CI installs with `pnpm install --frozen-lockfile` (all deps) on every job, and the edge deploy builds with a full install. No prod-only install runs before any build, so the bundle still gets `tslib`.

**Verified locally:** `vite build` ✓ · web typecheck ✓ · web tests 34/34 ✓ · knip ✓ (still ignored as a phantom dep, since nothing imports it from source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)