### PR TITLE
feat(cursors): anchor live cursors to the document, with off-screen edge indicators

### DIFF
--- a/apps/web/e2e/deep/cursor-doc-anchored.deep.spec.ts
+++ b/apps/web/e2e/deep/cursor-doc-anchored.deep.spec.ts
@@ -106,3 +106,89 @@ test("hiding cursors removes the edge indicators too", async ({ owner, secondUse
   await expect(owner.getByTestId("cursor-offscreen-bottom")).toHaveCount(0)
   await expect(owner.getByTestId("remote-cursor")).toHaveCount(0)
 })
+
+test("capture side: the iframe reports a document position, so the same screen point yields a different y after scrolling", async ({
+  owner,
+}) => {
+  const shortId = await publishTall(owner)
+  await openArtifact(owner, shortId)
+
+  // Record the y of every cursor frame the app posts for our own pointer.
+  const ys: number[] = []
+  owner.on("request", (req) => {
+    if (req.method() === "POST" && req.url().includes("/cursor")) {
+      try {
+        const b = req.postDataJSON() as { y?: number }
+        if (typeof b?.y === "number") ys.push(b.y)
+      } catch {
+        /* non-JSON body */
+      }
+    }
+  })
+
+  const box = await owner.locator("iframe").first().boundingBox()
+  if (!box) throw new Error("no iframe box")
+  const cx = box.x + box.width / 2
+  const cy = box.y + box.height / 2
+
+  // Move at a fixed point over the artifact → a frame at scroll 0.
+  await owner.mouse.move(cx - 4, cy - 4)
+  await owner.mouse.move(cx, cy)
+  await expect.poll(() => ys.length, { timeout: 10_000 }).toBeGreaterThan(0)
+  const atTop = ys.at(-1) as number
+
+  // Scroll the document, then move to the SAME screen point again.
+  await owner.mouse.move(cx, cy)
+  await owner.mouse.wheel(0, 2000)
+  await owner.waitForTimeout(400)
+  ys.length = 0
+  await owner.mouse.move(cx + 4, cy + 4)
+  await owner.mouse.move(cx, cy)
+  await expect.poll(() => ys.length, { timeout: 10_000 }).toBeGreaterThan(0)
+  const afterScroll = ys.at(-1) as number
+
+  // Same screen position, but scrolled down → a larger fraction of the document.
+  // (A viewport-relative cursor would report the same y both times.)
+  expect(afterScroll).toBeGreaterThan(atTop + 0.02)
+})
+
+test("stress: many peers and rapid scrolling stay consistent (above + below at once)", async ({
+  owner,
+  secondUser,
+}) => {
+  const shortId = await publishTall(owner)
+  await openArtifact(owner, shortId)
+  const N = 12
+  // A crowd spread evenly down the document, re-sent in parallel to keep alive.
+  const sendAll = () =>
+    Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        secondUser.page.request.post(`/v1/artifacts/${shortId}/cursor`, {
+          data: { id: `s${i}`, x: ((i % 5) + 1) / 6, y: (i + 1) / (N + 1), color: "#7c6cbd" },
+        }),
+      ),
+    )
+
+  await expect(async () => {
+    await sendAll()
+    await expect(owner.getByTestId("cursor-offscreen-bottom")).toBeVisible({ timeout: 1000 })
+  }).toPass({ timeout: 20_000 })
+
+  // Rapidly scroll into the middle; peers stay alive and re-map every frame.
+  for (let i = 0; i < 6; i++) {
+    await owner
+      .getByTestId("cursor-offscreen-bottom")
+      .click()
+      .catch(() => {})
+    await sendAll()
+    await owner.waitForTimeout(120)
+  }
+
+  // In the middle of a tall doc the crowd splits: some above, some below — and the
+  // page is still alive and rendering cursors (no crash under load).
+  await expect(async () => {
+    await sendAll()
+    await expect(owner.getByTestId("cursor-offscreen-top")).toBeVisible({ timeout: 1500 })
+    await expect(owner.getByTestId("cursor-offscreen-bottom")).toBeVisible({ timeout: 1500 })
+  }).toPass({ timeout: 20_000 })
+})

--- a/apps/web/e2e/deep/cursor-doc-anchored.deep.spec.ts
+++ b/apps/web/e2e/deep/cursor-doc-anchored.deep.spec.ts
@@ -3,9 +3,9 @@ import type { Page } from "@playwright/test"
 import { expect, openArtifact, test } from "../fixtures"
 
 // Cursors are anchored to a position in the DOCUMENT, not the viewport. A peer
-// whose document position is below the fold (the viewer is at the top of a tall
-// doc) shows as a bottom edge indicator, not a cursor pinned to the screen; when
-// their position is on-screen, a real cursor is painted and the indicator clears.
+// whose document position is outside the viewer's scroll window shows as a top /
+// bottom edge indicator (Miro/Figma style), not a cursor pinned to the screen;
+// scrolling moves peers with the content, and an on-screen peer is a real cursor.
 
 const tall = `# Tall document\n\n${Array.from(
   { length: 120 },
@@ -27,23 +27,29 @@ async function publishTall(page: Page): Promise<string> {
   return shortId
 }
 
-test("a peer below the fold is a bottom edge indicator, then a cursor when on-screen", async ({
+// Drive a peer cursor at a document-normalized y from a second viewer.
+const peerOf =
+  (page: Page, shortId: string, id: string) =>
+  (y: number, x = 0.5) =>
+    page.request.post(`/v1/artifacts/${shortId}/cursor`, {
+      data: { id, x, y, color: "#7c6cbd", kind: "arrow" },
+    })
+
+test("a peer below the fold is a bottom indicator (with a count), then a cursor on-screen", async ({
   owner,
   secondUser,
 }) => {
   const shortId = await publishTall(owner)
   await openArtifact(owner, shortId)
-  const peer = (y: number) =>
-    secondUser.page.request.post(`/v1/artifacts/${shortId}/cursor`, {
-      data: { id: "peer-doc", x: 0.5, y, color: "#7c6cbd", kind: "arrow" },
-    })
+  const peer = peerOf(secondUser.page, shortId, "peer-doc")
 
   // Near the bottom of the doc while the owner sits at the top → below the fold,
-  // so a bottom edge indicator appears (retry until SSE + geometry have settled).
+  // so a bottom edge indicator appears, counting one peer.
   await expect(async () => {
     expect((await peer(0.96)).ok()).toBeTruthy()
     await expect(owner.getByTestId("cursor-offscreen-bottom")).toBeVisible({ timeout: 1000 })
   }).toPass({ timeout: 20_000 })
+  await expect(owner.getByTestId("cursor-offscreen-bottom")).toContainText("1")
 
   // Move to the very top → on-screen: the indicator clears and a cursor is painted.
   await expect(async () => {
@@ -51,4 +57,52 @@ test("a peer below the fold is a bottom edge indicator, then a cursor when on-sc
     await expect(owner.getByTestId("cursor-offscreen-bottom")).toHaveCount(0)
     await expect(owner.getByTestId("remote-cursor")).toBeVisible({ timeout: 1000 })
   }).toPass({ timeout: 20_000 })
+})
+
+test("scrolling moves peers with the document: a top peer passes above the fold", async ({
+  owner,
+  secondUser,
+}) => {
+  const shortId = await publishTall(owner)
+  await openArtifact(owner, shortId)
+  const top = peerOf(secondUser.page, shortId, "peer-top")
+  const bottom = peerOf(secondUser.page, shortId, "peer-bottom")
+
+  // A peer near the very top (on-screen) and one well below the fold: a bottom
+  // indicator only, nobody above yet.
+  await expect(async () => {
+    expect((await top(0.02)).ok()).toBeTruthy()
+    expect((await bottom(0.6)).ok()).toBeTruthy()
+    await expect(owner.getByTestId("cursor-offscreen-bottom")).toBeVisible({ timeout: 1000 })
+    await expect(owner.getByTestId("cursor-offscreen-top")).toHaveCount(0)
+  }).toPass({ timeout: 20_000 })
+
+  // Click the bottom indicator to scroll down; the top peer is glued to the
+  // document, so it passes above the fold and becomes a TOP indicator.
+  await expect(async () => {
+    await owner
+      .getByTestId("cursor-offscreen-bottom")
+      .click()
+      .catch(() => {})
+    expect((await top(0.02)).ok()).toBeTruthy()
+    expect((await bottom(0.6)).ok()).toBeTruthy()
+    await expect(owner.getByTestId("cursor-offscreen-top")).toBeVisible({ timeout: 1500 })
+  }).toPass({ timeout: 25_000 })
+})
+
+test("hiding cursors removes the edge indicators too", async ({ owner, secondUser }) => {
+  const shortId = await publishTall(owner)
+  await openArtifact(owner, shortId)
+  const peer = peerOf(secondUser.page, shortId, "peer-doc")
+
+  await expect(async () => {
+    expect((await peer(0.92)).ok()).toBeTruthy()
+    await expect(owner.getByTestId("cursor-offscreen-bottom")).toBeVisible({ timeout: 1000 })
+  }).toPass({ timeout: 20_000 })
+
+  // Opt out of the layer entirely → no cursors and no edge indicators.
+  await owner.getByTestId("cursor-self-trigger").click()
+  await owner.getByTestId("cursor-hide").click()
+  await expect(owner.getByTestId("cursor-offscreen-bottom")).toHaveCount(0)
+  await expect(owner.getByTestId("remote-cursor")).toHaveCount(0)
 })

--- a/apps/web/e2e/deep/cursor-doc-anchored.deep.spec.ts
+++ b/apps/web/e2e/deep/cursor-doc-anchored.deep.spec.ts
@@ -1,0 +1,54 @@
+import { Buffer } from "node:buffer"
+import type { Page } from "@playwright/test"
+import { expect, openArtifact, test } from "../fixtures"
+
+// Cursors are anchored to a position in the DOCUMENT, not the viewport. A peer
+// whose document position is below the fold (the viewer is at the top of a tall
+// doc) shows as a bottom edge indicator, not a cursor pinned to the screen; when
+// their position is on-screen, a real cursor is painted and the indicator clears.
+
+const tall = `# Tall document\n\n${Array.from(
+  { length: 120 },
+  (_, i) => `Paragraph ${i + 1}. Lorem ipsum dolor sit amet, consectetur adipiscing elit.`,
+).join("\n\n")}`
+
+async function publishTall(page: Page): Promise<string> {
+  let shortId = ""
+  await expect(async () => {
+    const res = await page.request.post("/v1/artifacts", {
+      multipart: {
+        file: { name: "tall.md", mimeType: "text/markdown", buffer: Buffer.from(tall) },
+        visibility: "public",
+      },
+    })
+    expect(res.ok(), `publish failed: ${res.status()}`).toBeTruthy()
+    shortId = ((await res.json()) as { short_id: string }).short_id
+  }).toPass({ timeout: 10_000 })
+  return shortId
+}
+
+test("a peer below the fold is a bottom edge indicator, then a cursor when on-screen", async ({
+  owner,
+  secondUser,
+}) => {
+  const shortId = await publishTall(owner)
+  await openArtifact(owner, shortId)
+  const peer = (y: number) =>
+    secondUser.page.request.post(`/v1/artifacts/${shortId}/cursor`, {
+      data: { id: "peer-doc", x: 0.5, y, color: "#7c6cbd", kind: "arrow" },
+    })
+
+  // Near the bottom of the doc while the owner sits at the top → below the fold,
+  // so a bottom edge indicator appears (retry until SSE + geometry have settled).
+  await expect(async () => {
+    expect((await peer(0.96)).ok()).toBeTruthy()
+    await expect(owner.getByTestId("cursor-offscreen-bottom")).toBeVisible({ timeout: 1000 })
+  }).toPass({ timeout: 20_000 })
+
+  // Move to the very top → on-screen: the indicator clears and a cursor is painted.
+  await expect(async () => {
+    expect((await peer(0.01)).ok()).toBeTruthy()
+    await expect(owner.getByTestId("cursor-offscreen-bottom")).toHaveCount(0)
+    await expect(owner.getByTestId("remote-cursor")).toBeVisible({ timeout: 1000 })
+  }).toPass({ timeout: 20_000 })
+})

--- a/apps/web/src/lib/cursors.test.ts
+++ b/apps/web/src/lib/cursors.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest"
+import {
+  CURSOR_COLORS,
+  type CursorPref,
+  defaultPrefFor,
+  effectiveDocH,
+  normalizePref,
+  placePeer,
+  type ViewerGeom,
+} from "./cursors"
+
+// The document-anchored placement math: a peer's eased document position mapped
+// against THIS viewer's scroll into a screen position, or classified as an
+// off-screen (above/below) peer for the edge indicator. Pure, so we hammer the
+// boundaries here instead of through the flaky rAF loop.
+
+describe("effectiveDocH", () => {
+  it("uses the reported document height when present", () => {
+    expect(effectiveDocH(2000, 800)).toBe(2000)
+    expect(effectiveDocH(1500, 0)).toBe(1500)
+  })
+  it("falls back to the visible height until geometry is reported", () => {
+    expect(effectiveDocH(0, 800)).toBe(800)
+  })
+  it("is never 0 (so we never divide/scale by zero)", () => {
+    expect(effectiveDocH(0, 0)).toBe(1)
+  })
+})
+
+describe("placePeer", () => {
+  const geom = (over: Partial<ViewerGeom> = {}): ViewerGeom => ({
+    scrollY: 0,
+    docH: 2000,
+    viewH: 800,
+    ...over,
+  })
+
+  it("places an in-view peer at its document position, unshifted at scroll 0", () => {
+    expect(placePeer(120, 500, geom())).toEqual({ onScreen: true, x: 120, y: 500 })
+  })
+
+  it("passes x through unchanged (x does not scroll)", () => {
+    const p = placePeer(333, 100, geom())
+    expect(p.x).toBe(333)
+  })
+
+  it("treats the exact top and bottom edges as on-screen", () => {
+    // cyDoc === scrollY -> y === 0 (top edge)
+    expect(placePeer(0, 300, geom({ scrollY: 300 }))).toMatchObject({ onScreen: true, y: 0 })
+    // y === viewH (bottom edge)
+    expect(placePeer(0, 800, geom())).toMatchObject({ onScreen: true, y: 800 })
+  })
+
+  it("classifies a peer one pixel past the top as above", () => {
+    expect(placePeer(0, 299, geom({ scrollY: 300 }))).toEqual({
+      onScreen: false,
+      side: "above",
+      x: 0,
+      y: -1,
+    })
+  })
+
+  it("classifies a peer one pixel past the bottom as below", () => {
+    expect(placePeer(0, 801, geom())).toEqual({
+      onScreen: false,
+      side: "below",
+      x: 0,
+      y: 801,
+    })
+  })
+
+  it("glues a peer to the document as the viewer scrolls (the whole point)", () => {
+    const peerDocY = 1000 // a peer 1000px down the document
+    // At the top, they're below the 800px viewport.
+    expect(placePeer(0, peerDocY, geom({ scrollY: 0 }))).toMatchObject({
+      onScreen: false,
+      side: "below",
+    })
+    // Scroll down 400px and they enter view, shifted up by exactly the scroll.
+    expect(placePeer(0, peerDocY, geom({ scrollY: 400 }))).toEqual({
+      onScreen: true,
+      x: 0,
+      y: 600,
+    })
+    // Scroll past them and they're now above the viewport.
+    expect(placePeer(0, peerDocY, geom({ scrollY: 1100 }))).toMatchObject({
+      onScreen: false,
+      side: "above",
+    })
+  })
+})
+
+describe("normalizePref / defaultPrefFor (hidden field)", () => {
+  const fb: CursorPref = { color: CURSOR_COLORS[0], kind: "arrow", emoji: "👆", hidden: false }
+  it("defaults hidden to false", () => {
+    expect(defaultPrefFor("seed").hidden).toBe(false)
+    expect(normalizePref({}, fb).hidden).toBe(false)
+  })
+  it("only treats a strict true as hidden", () => {
+    expect(normalizePref({ hidden: true }, fb).hidden).toBe(true)
+    expect(normalizePref({ hidden: "yes" }, fb).hidden).toBe(false)
+    expect(normalizePref({ hidden: 1 }, fb).hidden).toBe(false)
+  })
+})

--- a/apps/web/src/lib/cursors.test.ts
+++ b/apps/web/src/lib/cursors.test.ts
@@ -90,6 +90,31 @@ describe("placePeer", () => {
   })
 })
 
+describe("document mapping (effectiveDocH + placePeer, as the rAF loop composes them)", () => {
+  // Mirror the loop: a peer's normalized y -> document pixels -> screen placement.
+  const map = (yNorm: number, reportedDocH: number, layerH: number, scrollY: number) =>
+    placePeer(0, yNorm * effectiveDocH(reportedDocH, layerH), {
+      scrollY,
+      docH: reportedDocH,
+      viewH: layerH,
+    })
+
+  it("never pushes a peer off-screen in a document shorter than the viewport", () => {
+    // docH 400 < viewH 800: even a peer at the very bottom of the doc is in view.
+    expect(map(0.99, 400, 800, 0)).toMatchObject({ onScreen: true })
+  })
+
+  it("classifies a peer deep in a tall document as below, then on-screen once scrolled", () => {
+    expect(map(0.6, 5000, 800, 0)).toMatchObject({ onScreen: false, side: "below" })
+    expect(map(0.6, 5000, 800, 2400)).toEqual({ onScreen: true, x: 0, y: 600 })
+  })
+
+  it("still shows a peer (viewport-mapped) before the frame has reported geometry", () => {
+    // reportedDocH 0 -> fall back to the layer height, so y=0.5 lands mid-viewport.
+    expect(map(0.5, 0, 800, 0)).toEqual({ onScreen: true, x: 0, y: 400 })
+  })
+})
+
 describe("normalizePref / defaultPrefFor (hidden field)", () => {
   const fb: CursorPref = { color: CURSOR_COLORS[0], kind: "arrow", emoji: "👆", hidden: false }
   it("defaults hidden to false", () => {

--- a/apps/web/src/lib/cursors.ts
+++ b/apps/web/src/lib/cursors.ts
@@ -99,3 +99,38 @@ export function normalizePref(raw: unknown, fallback: CursorPref): CursorPref {
     hidden: r.hidden === true,
   }
 }
+
+// ---- document-anchored placement ------------------------------------------
+// A peer broadcasts a document-normalized position (x by width, y by the full
+// document height). Each viewer maps it against their OWN live scroll, so a peer
+// sits where they are in the document and glides as you scroll; peers scrolled
+// past an edge become a top/bottom indicator instead of a cursor pinned at the
+// edge. The math lives here, pure and unit-tested; the rAF loop just calls it.
+
+/** This viewer's live geometry inside the artifact iframe. */
+export interface ViewerGeom {
+  scrollY: number
+  docH: number
+  viewH: number
+}
+
+/** Document height to map a peer's normalized y against, falling back to the
+ *  visible height until the frame has reported real geometry (so a peer still
+ *  shows, viewport-mapped, in the first frames after load). Never 0. */
+export const effectiveDocH = (docH: number, layerH: number): number => docH || layerH || 1
+
+export type PeerPlacement =
+  | { onScreen: true; x: number; y: number }
+  | { onScreen: false; side: "above" | "below"; x: number; y: number }
+
+/** Map an eased peer position (`cx` already in layer pixels, `cyDoc` in document
+ *  pixels) to a screen position in this viewer's viewport. Subtracting our scroll
+ *  gives the on-screen y; past the top it's "above", past the visible height it's
+ *  "below" — an off-screen peer for the edge indicator. The top/bottom edges
+ *  (y === 0 and y === viewH) count as on-screen. */
+export function placePeer(cx: number, cyDoc: number, geom: ViewerGeom): PeerPlacement {
+  const y = cyDoc - geom.scrollY
+  if (y < 0) return { onScreen: false, side: "above", x: cx, y }
+  if (y > geom.viewH) return { onScreen: false, side: "below", x: cx, y }
+  return { onScreen: true, x: cx, y }
+}

--- a/apps/web/src/pages/artifact/artifact-document.tsx
+++ b/apps/web/src/pages/artifact/artifact-document.tsx
@@ -24,6 +24,7 @@ export function ArtifactDocument({
   frameRef,
   presentWrapRef,
   cursor,
+  onScrollDoc,
   onFrameLoad,
   onToggleDiff,
   onRestore,
@@ -43,6 +44,7 @@ export function ArtifactDocument({
   frameRef: RefObject<HTMLIFrameElement | null>
   presentWrapRef: RefObject<HTMLDivElement | null>
   cursor: CursorLayerHandle
+  onScrollDoc: (dy: number) => void
   onFrameLoad: () => void
   onToggleDiff: () => void
   onRestore: () => void
@@ -113,7 +115,7 @@ export function ArtifactDocument({
               origin, so its anchor script forwards pointer moves/leave/tap out via
               postMessage; the overlay eases them in here in the parent, over the
               frame. Anon viewers too. */}
-          <CursorLayer layer={cursor} />
+          <CursorLayer layer={cursor} onScrollDoc={onScrollDoc} />
         </div>
       )}
     </>

--- a/apps/web/src/pages/artifact/cursors/cursor-layer.tsx
+++ b/apps/web/src/pages/artifact/cursors/cursor-layer.tsx
@@ -1,12 +1,24 @@
 import { memo } from "react"
 import { CursorGlyph, NameTag } from "@/components/cursor/glyph"
+import { cn } from "@/lib/utils"
 import type { CursorLayerHandle, PeerView, Ripple } from "./use-live-cursors"
 
 // The peer-cursor overlay, painted over the artifact frame. Mount/unmount and
 // styling are React's job; every-frame motion is driven straight on the DOM by
 // the rAF loop in use-live-cursors (it writes `transform`/`opacity` on these
 // nodes via the `register` ref). Ripple/peer colors are identity data.
-export function CursorLayer({ layer }: { layer: CursorLayerHandle }) {
+export function CursorLayer({
+  layer,
+  onScrollDoc,
+}: {
+  layer: CursorLayerHandle
+  onScrollDoc?: (dy: number) => void
+}) {
+  // Click an edge indicator to scroll ~70% of a screen toward those peers.
+  const jump = (dir: "up" | "down") => {
+    const h = layer.ref.current?.clientHeight ?? 600
+    onScrollDoc?.(dir === "up" ? -h * 0.7 : h * 0.7)
+  }
   return (
     <div
       ref={layer.ref}
@@ -20,7 +32,51 @@ export function CursorLayer({ layer }: { layer: CursorLayerHandle }) {
       {layer.ripples.map((r) => (
         <RippleDot key={r.key} ripple={r} />
       ))}
+      {layer.above.length > 0 && (
+        <EdgeIndicator side="top" peers={layer.above} onClick={() => jump("up")} />
+      )}
+      {layer.below.length > 0 && (
+        <EdgeIndicator side="bottom" peers={layer.below} onClick={() => jump("down")} />
+      )}
     </div>
+  )
+}
+
+// Peers scrolled out of view, collapsed into a cluster at the top/bottom edge
+// (Miro/Figma style): how many, in their cursor colors, click to scroll toward
+// them. Identity colors are data, not theme tokens, so they ride inline styles.
+function EdgeIndicator({
+  side,
+  peers,
+  onClick,
+}: {
+  side: "top" | "bottom"
+  peers: PeerView[]
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid={`cursor-offscreen-${side}`}
+      title={`${peers.map((p) => p.name).join(", ")} ${side === "top" ? "above" : "below"}. Click to scroll.`}
+      className={cn(
+        "pointer-events-auto absolute left-1/2 z-30 flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-border bg-card/95 px-2.5 py-1 text-xs font-semibold text-foreground shadow-[var(--shadow)] backdrop-blur transition-colors hover:bg-hover",
+        side === "top" ? "top-2" : "bottom-2",
+      )}
+    >
+      <span aria-hidden>{side === "top" ? "▲" : "▼"}</span>
+      <span className="flex -space-x-1">
+        {peers.slice(0, 3).map((p) => (
+          <span
+            key={p.id}
+            className="size-3 rounded-full ring-1 ring-card"
+            style={{ background: p.color }}
+          />
+        ))}
+      </span>
+      <span className="tabular-nums">{peers.length}</span>
+    </button>
   )
 }
 

--- a/apps/web/src/pages/artifact/cursors/use-live-cursors.ts
+++ b/apps/web/src/pages/artifact/cursors/use-live-cursors.ts
@@ -40,13 +40,17 @@ export interface CursorLayerHandle {
   roster: PeerView[]
   ripples: Ripple[]
   register: (id: string, el: HTMLElement | null) => void
+  /** Peers whose document position is above / below the visible viewport, shown
+   *  as edge indicators instead of a cursor pinned at the edge. */
+  above: PeerView[]
+  below: PeerView[]
 }
 
 /** Per-peer animation state — lives in a ref, mutated outside React. */
 interface PeerTarget {
-  x: number // latest normalized target (0..1)
+  x: number // latest document-normalized target (0..1): x by width, y by doc height
   y: number
-  cx: number // current eased position, in layer pixels
+  cx: number // current eased position: cx in layer px (x), cy in document px (y)
   cy: number
   color: string
   kind: "arrow" | "emoji"
@@ -71,12 +75,23 @@ export function useLiveCursors(shortId: string): {
   onPointerLeave: () => void
   onTap: (x: number, y: number) => void
   paintFrame: (f: CursorFrame) => void
+  setGeom: (g: { scrollY: number; docH: number; viewH: number }) => void
   layer: CursorLayerHandle
 } {
   const { pref } = useCursorPref()
   // Always send the latest pick without re-binding the send callbacks.
   const prefRef = useRef(pref)
   prefRef.current = pref
+
+  // This viewer's own live iframe geometry (scroll offset + document/visible
+  // height), fed in from the frame bridge. Peers are stored as document-normalized
+  // positions and mapped against THIS every frame, so a peer sits where they are
+  // in the document and glides as we scroll. A ref so the rAF loop reads it without
+  // re-subscribing.
+  const geomRef = useRef({ scrollY: 0, docH: 0, viewH: 0 })
+  const setGeom = useCallback((g: { scrollY: number; docH: number; viewH: number }) => {
+    geomRef.current = g
+  }, [])
 
   // When the viewer prefers reduced motion, peers snap to position (no glide) and
   // click ripples are suppressed. A ref (synced below) so the rAF loop + paintFrame
@@ -103,6 +118,14 @@ export function useLiveCursors(shortId: string): {
   const [roster, setRoster] = useState<PeerView[]>([])
   const [ripples, setRipples] = useState<Ripple[]>([])
   const rosterDirty = useRef(false)
+  // Peers scrolled above / below this viewport, surfaced as edge indicators
+  // (Miro/Figma style). Computed in the rAF loop, pushed to React only when the
+  // membership actually changes (never every frame).
+  const [offscreen, setOffscreen] = useState<{ above: PeerView[]; below: PeerView[] }>({
+    above: [],
+    below: [],
+  })
+  const offscreenKey = useRef("")
 
   // Local send + lifecycle state.
   const xy = useRef<[number, number] | null>(null)
@@ -218,12 +241,14 @@ export function useLiveCursors(shortId: string): {
       const now = Date.now()
       if (!existing) {
         // New peer: seed the eased position at the target so it appears in place.
+        // y is document-normalized, so seed cy in document pixels (eased there).
         const r = layerRef.current?.getBoundingClientRect()
+        const docH = geomRef.current.docH || r?.height || 0
         targets.current.set(f.id, {
           x: f.x,
           y: f.y,
           cx: f.x * (r?.width ?? 0),
-          cy: f.y * (r?.height ?? 0),
+          cy: f.y * docH,
           color: f.color ?? CURSOR_FALLBACK,
           kind: f.kind ?? "arrow",
           emoji: f.emoji,
@@ -264,8 +289,10 @@ export function useLiveCursors(shortId: string): {
     setRipples([])
   }, [pref.hidden, sendLeave])
 
-  // The single animation loop: ease every peer toward its target, fade the name
-  // tag on stillness, fade-out and prune anyone who left or went stale.
+  // The single animation loop: ease every peer toward its document position, map
+  // it to a screen position against THIS viewer's scroll (so a peer glides with the
+  // content), fade the name tag on stillness, prune anyone who left, and collect
+  // who's scrolled off-screen for the edge indicators.
   useEffect(() => {
     let raf = 0
     const tick = () => {
@@ -273,15 +300,25 @@ export function useLiveCursors(shortId: string): {
       if (layer) {
         const r = layer.getBoundingClientRect()
         const now = Date.now()
+        // Receiver geometry: a peer's y is a fraction of the document, so map it to
+        // document pixels and subtract our scroll for a screen y. Fall back to
+        // viewport mapping until the frame reports real geometry.
+        const docH = geomRef.current.docH || r.height || 1
+        const scrollY = geomRef.current.scrollY || 0
         let pruned = false
+        const above: PeerView[] = []
+        const below: PeerView[] = []
         for (const [id, t] of targets.current) {
           if ((t.gone && t.fade <= 0.02) || now - t.lastSeen > CURSOR_TUNING.staleMs) {
             targets.current.delete(id)
             pruned = true
             continue
           }
+          // Ease in document space (x by width, y by doc height), then subtract
+          // scroll AFTER easing — so scrolling moves a peer with the content
+          // instantly (no lerp lag); the lerp only smooths the peer's own motion.
           const tx = t.x * r.width
-          const ty = t.y * r.height
+          const ty = t.y * docH
           const moved = Math.abs(tx - t.cx) + Math.abs(ty - t.cy) > 0.5
           // Reduced motion: snap straight to the target (lerp factor 1, no glide).
           const ease = reducedMotion.current ? 1 : CURSOR_TUNING.lerp
@@ -289,14 +326,31 @@ export function useLiveCursors(shortId: string): {
           t.cy += (ty - t.cy) * ease
           if (moved) t.lastMoveAt = now
           if (t.gone) t.fade = Math.max(0, t.fade - 16 / CURSOR_TUNING.leaveFadeMs)
+          const screenY = t.cy - scrollY
+          const onScreen = screenY >= 0 && screenY <= r.height
           if (t.el) {
-            t.el.style.transform = `translate3d(${t.cx.toFixed(1)}px, ${t.cy.toFixed(1)}px, 0)`
-            t.el.style.opacity = t.gone ? t.fade.toFixed(2) : "1"
+            if (onScreen) {
+              t.el.style.transform = `translate3d(${t.cx.toFixed(1)}px, ${screenY.toFixed(1)}px, 0)`
+              t.el.style.opacity = t.gone ? t.fade.toFixed(2) : "1"
+            } else {
+              // Off-screen: the edge indicator stands in for this cursor.
+              t.el.style.opacity = "0"
+            }
+          }
+          if (!onScreen && !t.gone) {
+            const v: PeerView = { id, color: t.color, kind: t.kind, emoji: t.emoji, name: t.name }
+            ;(screenY < 0 ? above : below).push(v)
           }
           if (t.labelEl) {
             const hideLabel = !t.gone && now - t.lastMoveAt > CURSOR_TUNING.labelIdleMs
             t.labelEl.style.opacity = hideLabel ? "0" : "1"
           }
+        }
+        // Re-render React only when the off-screen membership actually changes.
+        const key = `${above.map((p) => p.id).join(",")}|${below.map((p) => p.id).join(",")}`
+        if (key !== offscreenKey.current) {
+          offscreenKey.current = key
+          setOffscreen({ above, below })
         }
         if (pruned) markRosterDirty()
       }
@@ -342,6 +396,14 @@ export function useLiveCursors(shortId: string): {
     onPointerLeave,
     onTap,
     paintFrame,
-    layer: { ref: layerRef, roster, ripples, register },
+    setGeom,
+    layer: {
+      ref: layerRef,
+      roster,
+      ripples,
+      register,
+      above: offscreen.above,
+      below: offscreen.below,
+    },
   }
 }

--- a/apps/web/src/pages/artifact/cursors/use-live-cursors.ts
+++ b/apps/web/src/pages/artifact/cursors/use-live-cursors.ts
@@ -1,7 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { API_BASE } from "@/api"
 import { useCursorPref } from "@/ctx"
-import { CURSOR_FALLBACK, CURSOR_TUNING, type CursorFrame } from "@/lib/cursors"
+import {
+  CURSOR_FALLBACK,
+  CURSOR_TUNING,
+  type CursorFrame,
+  effectiveDocH,
+  placePeer,
+} from "@/lib/cursors"
 
 // All of the live-cursor realtime behaviour, kept out of the page and out of the
 // presence/comments hook:
@@ -243,7 +249,7 @@ export function useLiveCursors(shortId: string): {
         // New peer: seed the eased position at the target so it appears in place.
         // y is document-normalized, so seed cy in document pixels (eased there).
         const r = layerRef.current?.getBoundingClientRect()
-        const docH = geomRef.current.docH || r?.height || 0
+        const docH = effectiveDocH(geomRef.current.docH, r?.height ?? 0)
         targets.current.set(f.id, {
           x: f.x,
           y: f.y,
@@ -303,7 +309,7 @@ export function useLiveCursors(shortId: string): {
         // Receiver geometry: a peer's y is a fraction of the document, so map it to
         // document pixels and subtract our scroll for a screen y. Fall back to
         // viewport mapping until the frame reports real geometry.
-        const docH = geomRef.current.docH || r.height || 1
+        const docH = effectiveDocH(geomRef.current.docH, r.height)
         const scrollY = geomRef.current.scrollY || 0
         let pruned = false
         const above: PeerView[] = []
@@ -326,20 +332,19 @@ export function useLiveCursors(shortId: string): {
           t.cy += (ty - t.cy) * ease
           if (moved) t.lastMoveAt = now
           if (t.gone) t.fade = Math.max(0, t.fade - 16 / CURSOR_TUNING.leaveFadeMs)
-          const screenY = t.cy - scrollY
-          const onScreen = screenY >= 0 && screenY <= r.height
+          const place = placePeer(t.cx, t.cy, { scrollY, docH, viewH: r.height })
           if (t.el) {
-            if (onScreen) {
-              t.el.style.transform = `translate3d(${t.cx.toFixed(1)}px, ${screenY.toFixed(1)}px, 0)`
+            if (place.onScreen) {
+              t.el.style.transform = `translate3d(${place.x.toFixed(1)}px, ${place.y.toFixed(1)}px, 0)`
               t.el.style.opacity = t.gone ? t.fade.toFixed(2) : "1"
             } else {
               // Off-screen: the edge indicator stands in for this cursor.
               t.el.style.opacity = "0"
             }
           }
-          if (!onScreen && !t.gone) {
+          if (!place.onScreen && !t.gone) {
             const v: PeerView = { id, color: t.color, kind: t.kind, emoji: t.emoji, name: t.name }
-            ;(screenY < 0 ? above : below).push(v)
+            ;(place.side === "above" ? above : below).push(v)
           }
           if (t.labelEl) {
             const hideLabel = !t.gone && now - t.lastMoveAt > CURSOR_TUNING.labelIdleMs

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -112,6 +112,8 @@ export function Artifact() {
     inDoc,
     anchorTops,
     scrollY,
+    docH,
+    viewH,
   } = useArtifactFrame({
     comments,
     shortId,
@@ -128,6 +130,13 @@ export function Artifact() {
   // Preview vs. line-diff for the shown version, plus the fetched diff. See
   // use-version-diff.
   const { view, setView, diff } = useVersionDiff(art, shortId, version)
+
+  // Feed our live iframe geometry to the cursor layer, so peers render at their
+  // document position (mapped against our scroll) and scrolled-off peers collapse
+  // into the top/bottom edge indicators.
+  useEffect(() => {
+    live.setGeom({ scrollY, docH, viewH })
+  }, [live.setGeom, scrollY, docH, viewH])
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: clears the active thread + composer when the artifact/version changes (the iframe bridge clears its own selection).
   useEffect(() => {
@@ -403,6 +412,7 @@ export function Artifact() {
                 frameRef={frame}
                 presentWrapRef={presentWrap}
                 cursor={live.cursor}
+                onScrollDoc={scrollBy}
                 onFrameLoad={onFrameLoad}
                 onToggleDiff={() => setView(view === "diff" ? "preview" : "diff")}
                 onRestore={() => restore(shown)}

--- a/apps/web/src/pages/artifact/use-artifact-frame.ts
+++ b/apps/web/src/pages/artifact/use-artifact-frame.ts
@@ -46,6 +46,11 @@ export function useArtifactFrame(p: {
   const [inDoc, setInDoc] = useState<Record<string, boolean>>({})
   const [anchorTops, setAnchorTops] = useState<Record<string, number>>({})
   const [scrollY, setScrollY] = useState(0)
+  // The frame's own document height + visible height, reported alongside scroll.
+  // The live-cursor layer needs both to map a peer's document position to a screen
+  // position in this viewport (and decide who's scrolled off-screen).
+  const [docH, setDocH] = useState(0)
+  const [viewH, setViewH] = useState(0)
   // Set when the artifact announces itself as a deck (dock-deck protocol).
   const [deck, setDeck] = useState<{ i: number; total: number } | null>(null)
 
@@ -88,8 +93,12 @@ export function useArtifactFrame(p: {
       else if (d.type === "anchor-rects") {
         setAnchorTops(d.tops ?? {})
         if (typeof d.scrollY === "number") setScrollY(d.scrollY)
+        if (typeof d.docH === "number") setDocH(d.docH)
+        if (typeof d.viewH === "number") setViewH(d.viewH)
       } else if (d.type === "scroll") {
         if (typeof d.scrollY === "number") setScrollY(d.scrollY)
+        if (typeof d.docH === "number") setDocH(d.docH)
+        if (typeof d.viewH === "number") setViewH(d.viewH)
       } else if (d.type === "anchor-hover") setHoverThread(d.id ?? null)
       else if (d.type === "anchor-click") {
         setActiveThread(d.id)
@@ -179,5 +188,7 @@ export function useArtifactFrame(p: {
     inDoc,
     anchorTops,
     scrollY,
+    docH,
+    viewH,
   }
 }

--- a/apps/web/src/pages/artifact/use-artifact-live.ts
+++ b/apps/web/src/pages/artifact/use-artifact-live.ts
@@ -82,6 +82,7 @@ export function useArtifactLive(opts: {
     onPointerMove: cursors.onPointerMove,
     onPointerLeave: cursors.onPointerLeave,
     onTap: cursors.onTap,
+    setGeom: cursors.setGeom,
     cursor: cursors.layer,
   }
 }

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -79,19 +79,21 @@ document.addEventListener("mouseup",function(){setTimeout(emitSelection,0)});
 document.addEventListener("selectionchange",function(){
   var s=window.getSelection();if(!s||s.isCollapsed)post({type:"select",selector:null,rect:null})});
 
-/* -- live cursor: throttled pointer position, viewport-normalized 0..1, so the
-      host can fan it out to other viewers as a multiplayer cursor. Plus an
-      explicit leave (pointer left the doc / frame blurred / tab hidden) so peers
-      drop us at once instead of waiting the cursor out, and a tap on click so
-      peers can ripple where we acted. -- */
+/* -- live cursor: throttled pointer position, DOCUMENT-normalized 0..1 (x by
+      width, y by the full document height, including scroll). The host maps it
+      back against each viewer's own scroll, so a peer's cursor sits where they
+      are IN THE DOCUMENT — not at a fixed screen spot — and glides as you scroll;
+      peers scrolled out of view collapse into an edge indicator. Plus an explicit
+      leave (pointer left the doc / frame blurred / tab hidden) so peers drop us at
+      once, and a tap on click so peers can ripple where we acted. -- */
 var cT=0;
 document.addEventListener("mousemove",function(e){
   var n=Date.now();if(n-cT<40)return;cT=n;
-  var w=window.innerWidth||1,h=window.innerHeight||1;
-  post({type:"cursor",x:e.clientX/w,y:e.clientY/h})});
+  var w=window.innerWidth||1,dh=document.documentElement.scrollHeight||1;
+  post({type:"cursor",x:e.clientX/w,y:(e.clientY+scrollTop())/dh})});
 document.addEventListener("mousedown",function(e){
-  var w=window.innerWidth||1,h=window.innerHeight||1;
-  post({type:"cursor-tap",x:e.clientX/w,y:e.clientY/h})});
+  var w=window.innerWidth||1,dh=document.documentElement.scrollHeight||1;
+  post({type:"cursor-tap",x:e.clientX/w,y:(e.clientY+scrollTop())/dh})});
 document.addEventListener("mouseleave",function(){post({type:"cursor-leave"})});
 window.addEventListener("blur",function(){post({type:"cursor-leave"})});
 document.addEventListener("visibilitychange",function(){
@@ -145,7 +147,7 @@ function reportRects(){
     if(seen[id])continue;seen[id]=1;tops[id]=ms[i].getBoundingClientRect().top+sy}
   post({type:"anchor-rects",tops:tops,scrollY:sy,viewH:window.innerHeight,
     docH:document.documentElement.scrollHeight})}
-function reportScroll(){post({type:"scroll",scrollY:scrollTop()})}
+function reportScroll(){post({type:"scroll",scrollY:scrollTop(),viewH:window.innerHeight,docH:document.documentElement.scrollHeight})}
 
 function applyAnchors(anchors){
   clearMarks();


### PR DESCRIPTION
Live cursors were **viewport-relative**: a peer painted at the same screen fraction no matter where they actually were in the document, so they didn't move with the content as you scrolled, and a peer scrolled out of view still showed at a (wrong) screen spot.

Now they're **document-anchored** (the Miro/Figma model):

- **Capture** (`anchor.ts`): the injected iframe client sends document-normalized coordinates (`x` by width, `y = (clientY + scrollTop) / scrollHeight`) and reports `viewH`/`docH` alongside scroll — the same way comment anchors already report doc-absolute geometry.
- **Map** (`use-live-cursors`): peers ease in *document* space; each frame we subtract **this** viewer's live scroll to get a screen `y`, so a peer is glued to the content and glides instantly as you scroll (the lerp only smooths the peer's own motion). Geometry reaches the hook via a `setGeom` ref, fed from the frame bridge (`use-artifact-frame` → page → `live`), which sidesteps the hook-ordering cycle.
- **Off-screen** (`cursor-layer`): peers above/below the viewport collapse into top/bottom **edge indicators** (a count + their cursor colors), click to scroll toward them — instead of a cursor pinned at the edge.


## Verification
- `pnpm typecheck` ✓ · `biome` ✓ · web (34) + core (55) unit tests ✓ · token/frontend/testid lints ✓
- new `e2e/deep/cursor-doc-anchored.deep.spec.ts` ✓ (peer below the fold → bottom indicator → on-screen → real cursor)
- `cursors.deep.spec.ts` + `cursor-hide.deep.spec.ts` ✓ (no regression)

Note: this is a v1 spatial anchor (normalized document position). Exact text-offset anchoring (survives reflow perfectly) is a possible follow-up. Touches `anchor.ts` + `use-artifact-frame.ts`, which the comments/mentions work also lives near — additive, but worth a heads-up for sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
