### PR TITLE
Accessibility labeling pass + destructive-DDL guard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,12 @@ shipping. If something below surprises you, that's the guardrail doing its job:
 - **Postgres behavioral drift.** The full `apps/api` suite also runs against a real
   Postgres in CI (`pnpm test:pg`), so a pg driver bug (a wrong query, a missing org
   scope) fails a test, not just a typecheck.
+- **Destructive DDL.** The schema sources are re-applied at boot, so a `DROP TABLE` /
+  `DROP COLUMN` / `TRUNCATE` / `DELETE FROM` in `packages/db/src/schema.ts`
+  (`SCHEMA_STATEMENTS`/`MIGRATION_STATEMENTS`) or `pg-schema.ts` (`PG_SCHEMA_STATEMENTS`)
+  would wipe data on every restart — it fails `pnpm lint:schema`. Evolve by adding
+  (expand/contract), deprecating a column in place; a deliberate, reviewed removal opts out
+  with a `schema-ignore` comment. See [Database migrations](#database-migrations).
 - **Event names.** Bus and webhook event names come from one list
   (`apps/api/src/events.ts`); a typo or a webhook event the bus doesn't know about is a
   compile error.
@@ -117,9 +123,45 @@ shipping. If something below surprises you, that's the guardrail doing its job:
   files + dependencies only (not every unused export, to leave the design-system surface
   alone).
 
-The custom checks (`lint:tokens`, `lint:frontend`, `lint:testids`, `lint:api`) and Biome all
-run inside `pnpm run ci`, so the one gate command covers them; `pnpm typecheck` and
-`pnpm test` (which includes the authz-coverage test) complete it.
+The custom checks (`lint:tokens`, `lint:frontend`, `lint:testids`, `lint:api`, `lint:schema`)
+and Biome all run inside `pnpm run ci`, so the one gate command covers them; `pnpm typecheck`
+and `pnpm test` (which includes the authz-coverage test) complete it.
+
+## Database migrations
+
+Dock evolves the schema with **forward-only, idempotent DDL applied at boot** — no migration
+framework, so a fresh self-host is one command. The trade-off is that the same statements
+re-run on every start, so they must be additive (see the destructive-DDL guard above) and
+idempotent. The model is small but spread across a few files; the guards below catch anything
+you miss.
+
+- **SQLite/D1** ([packages/db/src/schema.ts](packages/db/src/schema.ts)): tables in
+  `SCHEMA_STATEMENTS` use `CREATE TABLE IF NOT EXISTS`; a new column on an existing table goes
+  in `MIGRATION_STATEMENTS` as a plain `ALTER TABLE … ADD COLUMN` (SQLite has no per-column
+  `IF NOT EXISTS`, so the boot runner swallows the "duplicate column" throw).
+- **Postgres** ([packages/db/src/pg-schema.ts](packages/db/src/pg-schema.ts)):
+  `PG_SCHEMA_STATEMENTS` mirrors it with `CREATE TABLE IF NOT EXISTS` + `ALTER TABLE …
+  ADD COLUMN IF NOT EXISTS`.
+- **D1**: `deploy/d1-schema.sql` is generated from `SCHEMA_STATEMENTS` — never hand-edit it;
+  run `pnpm --filter @dock/db gen:d1-schema`.
+
+**Adding a column:**
+
+1. Add the field to the `@dock/core` Record (+ its `New*` input) in
+   [packages/core/src/ports.ts](packages/core/src/ports.ts).
+2. Add it to the drizzle table in **both** `schema.ts` and `pg-schema.ts` (the parity guard
+   fails the typecheck if a dialect, or the Record, drifts).
+3. Add the column to the DDL: `SCHEMA_STATEMENTS` + `MIGRATION_STATEMENTS` (sqlite) and
+   `PG_SCHEMA_STATEMENTS` (pg). The conformance tests
+   ([schema-conformance.test.ts](packages/db/test/schema-conformance.test.ts), and
+   [pg-schema-conformance.test.ts](packages/db/test/pg-schema-conformance.test.ts) under
+   `pnpm test:pg`) go red if the live table's columns don't match the drizzle defs.
+4. Run `pnpm --filter @dock/db gen:d1-schema` to regenerate `deploy/d1-schema.sql`.
+
+**Removing or renaming** is the unsafe path: prefer expand/contract — add the new shape,
+move reads/writes over, and leave the old column unused — over a `DROP`. An actual drop is a
+separate, deliberately-reviewed change that opts past `lint:schema` with a `schema-ignore`
+comment.
 
 ## Commits & PRs
 

--- a/apps/web/e2e/deep/chrome.deep.spec.ts
+++ b/apps/web/e2e/deep/chrome.deep.spec.ts
@@ -31,3 +31,10 @@ test("sign out returns to the login screen", async ({ owner }) => {
   await owner.getByTestId("menu-signout").click()
   await expect(owner).toHaveURL(/\/login/)
 })
+
+// Accessibility: icon-only chrome controls must expose an accessible name (added
+// in the a11y pass). Located by ROLE + NAME, so a dropped aria-label fails here.
+test("icon-only chrome controls expose accessible names", async ({ owner }) => {
+  await expect(owner.getByRole("button", { name: "Search (⌘K)" })).toBeVisible()
+  await expect(owner.getByRole("textbox", { name: "Search artifacts by title" })).toBeVisible()
+})

--- a/apps/web/src/components/nav-rail.tsx
+++ b/apps/web/src/components/nav-rail.tsx
@@ -46,6 +46,7 @@ function SideItem({
       to="/"
       search={search}
       title={label}
+      aria-label={label}
       data-testid={testId}
       aria-current={active ? "page" : undefined}
       onClick={onClick}
@@ -205,6 +206,7 @@ export function NavRail() {
             setPaletteOpen(true)
           }}
           title="Search (⌘K)"
+          aria-label="Search (⌘K)"
           data-testid="open-command-palette"
           className={cn(ROW_BASE, railMode && ROW_RAIL)}
         >

--- a/apps/web/src/components/review/decision-bar.tsx
+++ b/apps/web/src/components/review/decision-bar.tsx
@@ -65,6 +65,7 @@ export function ReviewDecisionBar({
           )}
           <Textarea
             data-testid="review-note"
+            aria-label="Decision note to the proposer"
             autoFocus
             value={note}
             onChange={(e) => onNoteChange(e.target.value)}

--- a/apps/web/src/pages/artifact/comment-composer.tsx
+++ b/apps/web/src/pages/artifact/comment-composer.tsx
@@ -286,11 +286,12 @@ export function MentionField({
               <button
                 key={emo}
                 type="button"
+                aria-label={`Insert ${emo} emoji`}
                 data-testid="emoji-option"
-                onMouseDown={(e) => {
-                  e.preventDefault()
-                  insertEmoji(emo)
-                }}
+                // mousedown only prevents the textarea from losing focus; the
+                // actual insert is onClick so keyboard (Enter/Space) works too.
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => insertEmoji(emo)}
                 className="grid size-7 place-items-center rounded text-lg leading-none hover:bg-hover"
               >
                 {emo}

--- a/apps/web/src/pages/artifact/comment-row.tsx
+++ b/apps/web/src/pages/artifact/comment-row.tsx
@@ -185,6 +185,7 @@ export function CommentRow({ c, compact }: { c: Comment; compact?: boolean }) {
               <button
                 type="button"
                 title="React"
+                aria-label="Add reaction"
                 data-testid="comment-react"
                 className="grid size-6 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-hover hover:text-foreground"
               >
@@ -197,6 +198,7 @@ export function CommentRow({ c, compact }: { c: Comment; compact?: boolean }) {
                   <button
                     key={em}
                     type="button"
+                    aria-label={`React with ${em}`}
                     data-testid={`react-emoji-${em}`}
                     onClick={() => {
                       A.react(c.id, em)
@@ -215,6 +217,7 @@ export function CommentRow({ c, compact }: { c: Comment; compact?: boolean }) {
               <button
                 type="button"
                 title="More"
+                aria-label="Comment actions"
                 data-testid="comment-more"
                 className="grid size-6 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-hover hover:text-foreground"
               >

--- a/apps/web/src/pages/artifact/header-actions.tsx
+++ b/apps/web/src/pages/artifact/header-actions.tsx
@@ -178,6 +178,7 @@ export function CollectionsMenu({
           size="sm"
           className="gap-1.5"
           title="Collections"
+          aria-label="Add to collection"
           data-testid="artifact-collections"
         >
           <Icon name="collections" size={16} />
@@ -275,6 +276,7 @@ export function TagsMenu({
           size="sm"
           className="gap-1.5"
           title="Tags"
+          aria-label="Manage tags"
           data-testid="artifact-tags"
         >
           <Icon name="tag" size={16} />

--- a/apps/web/src/pages/artifact/source-editor.tsx
+++ b/apps/web/src/pages/artifact/source-editor.tsx
@@ -107,6 +107,7 @@ export function SourceEditor({
             value={message}
             onChange={(e) => onMessage(e.target.value)}
             placeholder="Describe this version (optional)"
+            aria-label="Version description"
             data-testid="artifact-commit-message"
             className="order-last h-8 w-full text-sm md:order-none md:w-auto md:max-w-[360px] md:flex-1"
           />
@@ -115,6 +116,7 @@ export function SourceEditor({
             value={proposeMsg}
             onChange={(e) => onProposeMsg(e.target.value)}
             placeholder="What are you changing, and why?"
+            aria-label="Proposal description"
             data-testid="artifact-propose-message"
             className="order-last h-8 w-full text-sm md:order-none md:w-auto md:max-w-[420px] md:flex-1"
           />
@@ -175,6 +177,7 @@ export function SourceEditor({
                 value={src}
                 onChange={(e) => onSrc(e.target.value)}
                 spellCheck={false}
+                aria-label="Artifact source"
                 data-testid="artifact-source-editor"
                 className="h-full flex-1 resize-none border-0 bg-card px-5 py-4 font-mono text-sm leading-relaxed text-foreground outline-none"
               />

--- a/apps/web/src/pages/library/artifact-card.tsx
+++ b/apps/web/src/pages/library/artifact-card.tsx
@@ -23,7 +23,7 @@ export function ArtifactCard({
   onPrefetch?: () => void
 }) {
   return (
-    <div className="group relative flex cursor-pointer flex-col gap-2 rounded-lg border border-border bg-card p-3.5 transition-all hover:-translate-y-0.5 hover:border-primary hover:shadow-[var(--shadow)] active:translate-y-0">
+    <div className="group relative flex cursor-pointer flex-col gap-2 rounded-lg border border-border bg-card p-3.5 transition-all motion-safe:hover:-translate-y-0.5 hover:border-primary hover:shadow-[var(--shadow)] active:translate-y-0">
       <div className="relative">
         <Thumb id={a.short_id} v={a.current_version} />
         <button
@@ -65,6 +65,7 @@ export function ArtifactCard({
             <span className="ml-auto inline-flex items-center gap-1" title={`${a.views} viewers`}>
               <Icon name="views" size={13} />{" "}
               {a.views > 999 ? `${(a.views / 1000).toFixed(1)}k` : a.views}
+              <span className="sr-only"> views</span>
             </span>
           )}
         </span>

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -183,6 +183,7 @@ function LibraryBody() {
         <div className="mb-[18px] flex flex-wrap items-center gap-2.5">
           <Input
             placeholder="Search by title…"
+            aria-label="Search artifacts by title"
             data-testid="library-search"
             value={query}
             onChange={(e) => setQuery(e.target.value)}

--- a/package.json
+++ b/package.json
@@ -36,13 +36,14 @@
     "lint:frontend": "node scripts/check-frontend.mjs",
     "lint:testids": "node scripts/check-testids.mjs",
     "lint:api": "node scripts/check-api.mjs",
+    "lint:schema": "node scripts/check-schema.mjs",
     "lint:filesize": "node scripts/check-file-size.mjs",
     "lint:bundle": "node scripts/check-bundle.mjs",
     "lint:deadcode": "knip",
     "format": "biome format --write",
     "check": "biome check",
     "check:fix": "biome check --write",
-    "ci": "biome ci && pnpm lint:tokens && pnpm lint:frontend && pnpm lint:testids && pnpm lint:api && pnpm lint:filesize && pnpm lint:deadcode"
+    "ci": "biome ci && pnpm lint:tokens && pnpm lint:frontend && pnpm lint:testids && pnpm lint:api && pnpm lint:schema && pnpm lint:filesize && pnpm lint:deadcode"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",

--- a/scripts/check-schema.mjs
+++ b/scripts/check-schema.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// Schema-safety guardrail. The boot-applied DDL + forward-only migrations
+// (packages/db/src/schema.ts SCHEMA_STATEMENTS/MIGRATION_STATEMENTS, and
+// pg-schema.ts PG_SCHEMA_STATEMENTS) must stay NON-DESTRUCTIVE: Dock evolves the
+// schema by adding (expand/contract), never by dropping. A DROP TABLE / DROP
+// COLUMN / TRUNCATE / bare DELETE FROM in the schema source is a data-loss
+// footgun — boot re-applies these, so a stray destructive statement would wipe
+// real data on every restart. It fails here so it can't ship silently. Deprecate
+// a column by leaving it in place; an actual removal (if ever) is a deliberate,
+// separately-reviewed migration. Runs in the CI gate.
+// Escape hatch: a `schema-ignore` comment on the line.
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+const FILES = ["packages/db/src/schema.ts", "packages/db/src/pg-schema.ts"]
+
+const RULES = [
+  { re: /\bDROP\s+TABLE\b/i, msg: "DROP TABLE is destructive — evolve by adding, never dropping" },
+  {
+    re: /\bDROP\s+COLUMN\b/i,
+    msg: "DROP COLUMN is data-lossy — deprecate the column in place instead",
+  },
+  { re: /\bTRUNCATE\b/i, msg: "TRUNCATE wipes a table — not allowed in schema/migration DDL" },
+  {
+    re: /\bDELETE\s+FROM\b/i,
+    msg: "DELETE FROM in schema DDL is destructive — migrations are additive",
+  },
+]
+
+// Strip JS comments so a pattern named in a comment isn't a false positive; the
+// real DDL lives in template-literal strings, which are untouched.
+const stripIgnorable = (line) => line.replace(/\/\/.*$/, "").replace(/\/\*.*?\*\//g, "")
+
+const violations = []
+for (const rel of FILES) {
+  let src
+  try {
+    src = readFileSync(join(process.cwd(), rel), "utf8")
+  } catch {
+    continue
+  }
+  src.split("\n").forEach((raw, i) => {
+    if (raw.includes("schema-ignore")) return
+    const line = stripIgnorable(raw)
+    for (const rule of RULES) {
+      const m = rule.re.exec(line)
+      if (m)
+        violations.push({ rel, line: i + 1, col: m.index + 1, snippet: m[0].trim(), msg: rule.msg })
+    }
+  })
+}
+
+if (violations.length === 0) {
+  console.log("schema: ok — no destructive DDL in the schema/migration sources")
+  process.exit(0)
+}
+
+console.error(`schema: ${violations.length} destructive DDL statement(s)\n`)
+for (const v of violations) {
+  console.error(`  ${v.rel}:${v.line}:${v.col}  ${v.snippet}`)
+  console.error(`    → ${v.msg}`)
+}
+process.exit(1)


### PR DESCRIPTION
First pass on the review's lowest axis (**Accessibility 6.8**) plus the user-requested **safe-migration** hardening. The *structural* a11y wins already shipped (#132/#140: reduced-motion, skip-link, landmarks, focus-visible, cursor opt-out); this closes the remaining labeling + keyboard residue, which was the main thing holding the axis below ~8.5.

## Accessibility (apps/web)
- **Accessible names** on every icon-only control: comment toolbar (React / each reaction emoji / More), composer emoji-picker buttons, artifact toolbar (Collections, Tags), nav-rail Search + the collapsed-rail nav links (`aria-label` on `SideItem`).
- **Form labels**: library search, review decision note, source-editor version/proposal messages + the source textarea. (ShareDialog + rail-deck were already labeled.)
- **Keyboard**: composer emoji buttons activate on click (mousedown only prevents blur) so Enter/Space insert; card hover-translate gated behind `motion-safe:`; view count gets an sr-only "views".
- **Regression lock**: a chrome e2e asserts icon-only controls expose names by role+name, so a dropped `aria-label` fails CI.

## Safe DB migrations (harden the zero-config model)
- **`scripts/check-schema.mjs`** (`lint:schema`, in `pnpm run ci`): the boot-applied DDL re-runs every start, so a `DROP TABLE` / `DROP COLUMN` / `TRUNCATE` / `DELETE FROM` in `schema.ts` / `pg-schema.ts` is a data-loss footgun — it now fails the gate (escape hatch: `schema-ignore`). Evolve by adding (expand/contract).
- **`CONTRIBUTING.md`** "Database migrations" section: the forward-only idempotent model, the add-a-column checklist, the conformance/parity guards. (Postgres column-conformance was already added in the coverage sweep — not duplicated.)

## Scope
This is the accessibility-axis closer + DB-safety add. The review's remaining **ops** items are a separate pass: takedown atomicity, shared-state rate limits, `/readyz` no-op, `/v1/vitals` collector, smoke-e2e PR gate, password-unlock limiter, `railway.json` SIGTERM, and the pg/repos dedup.

## Verification
typecheck (7 pkgs) · `pnpm run ci` (biome + all checkers incl. new `lint:schema` + knip) · unit + coverage gates · bundle 447.7/450 kB · e2e 34/34 (incl. the new a11y assertion). `lint:schema` negative-tested (injected DROP → fails with file:line, reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)