### PR TITLE
perf(comments): instant post via optimistic insert + off-path fan-out

### DIFF
--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -23,6 +23,7 @@ import { safeEqual, sha256, unlockCookie, unlockToken } from "./lib/crypto"
 import { VIEWER_COOKIE, WS_COOKIE } from "./lib/http"
 import { makeKeyedLimiter } from "./lib/rate-limit"
 import { log } from "./log"
+import { edgeCtx } from "./realtime-do"
 import { enqueueForEvent, type WebhookEvent } from "./webhooks"
 
 export interface SessionUser {
@@ -184,6 +185,22 @@ export function buildContext(deps: AppDeps) {
         error: err instanceof Error ? err.message : String(err),
       }),
     )
+
+  // Run after-the-response work without blocking the reply. On Workers the request
+  // executionCtx keeps the isolate alive past the sent response via waitUntil; on
+  // Node (and tests) there is no such context, so we await inline — local DBs are
+  // fast and tests need the work finished before they assert. Used to keep slow,
+  // best-effort fan-out (webhook enqueue, mention notifications) off the hot path.
+  const background = async (work: Promise<unknown>): Promise<void> => {
+    const guarded = Promise.resolve(work).catch((err) =>
+      log.error("background task failed", {
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    )
+    const ec = edgeCtx.getStore()
+    if (ec) ec.waitUntil(guarded)
+    else await guarded
+  }
 
   const bearer = (c: Context): string => {
     const h = c.req.header("authorization") ?? ""
@@ -486,6 +503,7 @@ export function buildContext(deps: AppDeps) {
     publishLimiter,
     commentLimiter,
     notify,
+    background,
     bearer,
     currentUser,
     agentFor,

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -20,6 +20,7 @@ export const commentRoutes = (ctx: AppContext) => {
     meta,
     bus,
     notify,
+    background,
     actingUser,
     anonLocked,
     authorize,
@@ -162,22 +163,30 @@ export const commentRoutes = (ctx: AppContext) => {
     // Signal-only: never put the comment body on the realtime bus. Clients refetch
     // /comments (which is account-gated), so the content can't leak to an anonymous
     // SSE subscriber. Webhooks carry their own payload via notify() below.
+    // The realtime signal goes out now (cheap, in-process); everyone watching
+    // refetches. The webhook enqueues and mention notifications are best-effort
+    // fan-out, so they run after the response instead of stacking sequential D1
+    // round-trips onto the post (the "couple of seconds to send" people felt).
     bus.publish(artifact.id, { type: "comment.created" })
-    await notify(artifact, "comment.created", {
-      author: created.author,
-      body: created.body_md,
-      quote: quoteOf(created.anchor),
-      thread_id: created.thread_id,
-    })
-    const notified = await notifyMentions(artifact, created, mentions, acting?.id ?? null)
-    if (notified.length)
-      await notify(artifact, "comment.mention", {
-        author: created.author,
-        mentioned: notified,
-        body: created.body_md,
-        quote: quoteOf(created.anchor),
-        thread_id: created.thread_id,
-      })
+    await background(
+      (async () => {
+        await notify(artifact, "comment.created", {
+          author: created.author,
+          body: created.body_md,
+          quote: quoteOf(created.anchor),
+          thread_id: created.thread_id,
+        })
+        const notified = await notifyMentions(artifact, created, mentions, acting?.id ?? null)
+        if (notified.length)
+          await notify(artifact, "comment.mention", {
+            author: created.author,
+            mentioned: notified,
+            body: created.body_md,
+            quote: quoteOf(created.anchor),
+            thread_id: created.thread_id,
+          })
+      })(),
+    )
     return c.json(commentJson(created), 201)
   })
 

--- a/apps/web/src/pages/artifact/artifact-actions.ts
+++ b/apps/web/src/pages/artifact/artifact-actions.ts
@@ -29,7 +29,7 @@ type Selection = {
  */
 export function artifactActions(p: {
   shortId: string
-  art: { title?: string | null; short_id: string }
+  art: { title?: string | null; short_id: string; current_version: number }
   qc: QueryClient
   me: Me
   src: string
@@ -96,15 +96,41 @@ export function artifactActions(p: {
     opts?: { threadId?: string; anchor?: Sel | null; mentions?: Mention[] },
   ) => {
     if (!text.trim()) return
-    await api
-      .comment(shortId, {
+    const key = commentsQuery(shortId).queryKey
+    // Optimistic: the comment appears the instant you hit send, so there is never a
+    // dead gap wondering whether it posted. A `temp-` id marks it as in-flight; the
+    // server's row swaps in on success, a refetch reconciles ordering + anchored
+    // flags, and a failure rolls the temp back out with a toast.
+    const tempId = `temp-${crypto.randomUUID()}`
+    const optimistic: Comment = {
+      id: tempId,
+      thread_id: opts?.threadId ?? tempId,
+      base_version: p.art.current_version,
+      path: null,
+      anchor: opts?.anchor ? JSON.stringify(opts.anchor) : null,
+      body_md: text,
+      author: me?.name ?? me?.email ?? "You",
+      state: "open",
+      created_at: new Date().toISOString(),
+      reactions: {},
+      mentions: opts?.mentions,
+    }
+    qc.setQueryData<Comment[]>(key, (old) => [...(old ?? []), optimistic])
+    try {
+      const real = await api.comment(shortId, {
         body_md: text,
         thread_id: opts?.threadId,
         anchor: opts?.threadId ? undefined : (opts?.anchor ?? undefined),
         mentions: opts?.mentions?.length ? opts.mentions : undefined,
       })
-      .catch((e) => toast.error((e as Error).message))
-    refetchComments()
+      qc.setQueryData<Comment[]>(key, (old) =>
+        (old ?? []).map((cmt) => (cmt.id === tempId ? real : cmt)),
+      )
+      refetchComments()
+    } catch (e) {
+      qc.setQueryData<Comment[]>(key, (old) => (old ?? []).filter((cmt) => cmt.id !== tempId))
+      toast.error((e as Error).message)
+    }
   }
   const reply = (text: string, threadId: string, mentions: Mention[] = []) =>
     addComment(text, { threadId, mentions })

--- a/apps/web/src/pages/artifact/comment-row.tsx
+++ b/apps/web/src/pages/artifact/comment-row.tsx
@@ -80,7 +80,13 @@ export function CommentRow({ c, compact }: { c: Comment; compact?: boolean }) {
   return (
     <div
       data-testid="comment-row"
-      className={cn("group relative px-3 py-2.5", !compact && "border-b border-border-soft")}
+      // An optimistic (not-yet-saved) comment carries a `temp-` id; dim it slightly
+      // until the server row swaps in, so "sending" vs "sent" reads at a glance.
+      className={cn(
+        "group relative px-3 py-2.5",
+        !compact && "border-b border-border-soft",
+        c.id.startsWith("temp-") && "opacity-60",
+      )}
     >
       <div className="mb-1 flex items-center gap-1.5">
         <ColoredAvatar name={c.author} />


### PR DESCRIPTION
**Feedback:** comments took ~2s to post (with no sign they worked) and showed up late for other viewers.

## Causes
- **Server:** the comment `POST` ran ~4–6 *sequential* D1 writes before responding — create the row, then **awaited** webhook-outbox enqueues + mention-notification rows + a second `comment.mention` enqueue. On D1's per-query latency, that serial chain is the lag. All of it is best-effort fan-out that doesn't need to block the reply.
- **Client:** no optimistic UI, so the comment only appeared after the slow POST *and* a refetch. (The recent optimistic composer-close made the gap more visible.)

## Fixes
- **`background()` helper** (`context.ts`): `executionCtx.waitUntil` on Workers, awaited inline on Node (tests/local stay deterministic). The comment `POST` now returns right after the row is written + the realtime signal is published; `notify`/`notifyMentions` run after the response. Faster post **and** the realtime signal flushes to other viewers sooner.
- **Optimistic insert** (`addComment`): the comment lands in the cache instantly with a `temp-` id (dimmed as "sending"), swaps in the server row on success, reconciles via refetch, and rolls back with a toast on failure. Posting feels instant; you can always see it landed.

## Verification
- Unit: api **267**, web **48**
- E2E: full suite **39 passed** (post / reply / react / edit / delete, webhooks settings)
- Coverage gates: api (lines 82.5 / stmts 76.3 / branches 67.9 vs 80/74/66) + web — both pass
- `pnpm run ci` lint bundle: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)