### PR TITLE
feat(cli): `dock login` — OAuth sign-in with a hosted callback

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -8,6 +8,7 @@ import { observability } from "./lib/observability"
 import { makeRateLimiter } from "./lib/rate-limit"
 import { serveContent } from "./lib/serve-content"
 import { log } from "./log"
+import { cliCallbackHTML } from "./oauth-cli-callback"
 import { consentHTML } from "./oauth-consent"
 import { agentRoutes } from "./routes/agents"
 import { analyticsRoutes } from "./routes/analytics"
@@ -275,6 +276,16 @@ export function createApp(deps: AppDeps): Hono {
     const scopes = (c.req.query("scope") ?? "").split(/\s+/).filter(Boolean)
     const clientName = (await ctx.meta.getOAuthClientName(clientId)) || clientId || "An application"
     return c.html(consentHTML({ clientName, scopes, query: new URL(c.req.url).search }))
+  })
+
+  // Hosted callback for the CLI/native OAuth flow (`dock login`). A command-line
+  // client registers this as its redirect_uri instead of localhost; after consent
+  // the browser lands here with the one-time code, which we display for the user to
+  // paste back into the terminal (the PKCE verifier stays on their machine).
+  app.get("/oauth/cli-callback", (c) => {
+    const code = c.req.query("code")
+    const error = c.req.query("error_description") ?? c.req.query("error")
+    return c.html(cliCallbackHTML({ code, error }))
   })
 
   // Better Auth owns /api/auth/* (sign-up/in/out, OAuth, OIDC/SSO, session).

--- a/apps/api/src/oauth-cli-callback.ts
+++ b/apps/api/src/oauth-cli-callback.ts
@@ -1,0 +1,76 @@
+// The hosted landing page for the CLI/native OAuth flow. A command-line client
+// (`dock login`) can't host a public callback, but it shouldn't bounce you to
+// localhost either — so it registers THIS page as its redirect_uri. After you
+// approve consent, the authorization server sends the browser here with the
+// one-time `code`; we display it for you to paste back into the terminal. The
+// PKCE code_verifier never leaves the CLI, so the displayed code is useless to
+// anyone else — it only completes the exchange paired with that local verifier.
+
+const esc = (s: string): string =>
+  s.replace(/[&<>"']/g, (c) =>
+    c === "&" ? "&amp;" : c === "<" ? "&lt;" : c === ">" ? "&gt;" : c === '"' ? "&quot;" : "&#39;",
+  )
+
+const SHELL = (title: string, inner: string): string => `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>${title} · Dock</title>
+<style>
+  :root{--bg:#f6f0e3;--card:#fffdf8;--ink:#1a1714;--mut:#6b6258;--line:#e7ddc9;--ac:#7c6cbd;--ac-ink:#fff;--good:#3c8f4e}
+  *{box-sizing:border-box}
+  body{margin:0;min-height:100vh;display:grid;place-items:center;background:var(--bg);color:var(--ink);
+    font:15px/1.55 Inter,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased;padding:24px}
+  .card{width:100%;max-width:460px;background:var(--card);border:1px solid var(--line);border-radius:18px;
+    padding:30px 30px 26px;box-shadow:0 10px 40px rgba(60,45,20,.10)}
+  .logo{font-weight:700;letter-spacing:-.01em;font-size:15px;color:var(--mut);margin-bottom:20px;display:flex;align-items:center;gap:7px}
+  h1{font-size:20px;line-height:1.3;letter-spacing:-.02em;margin:0 0 6px;font-weight:650}
+  .sub{color:var(--mut);font-size:13.5px;margin:0 0 18px}
+  .code{display:flex;gap:10px;align-items:center;border:1px solid var(--line);border-radius:12px;background:#fbf7ee;padding:12px 14px}
+  .code code{flex:1;font:13px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;word-break:break-all;color:var(--ink)}
+  .btn{padding:9px 14px;border-radius:9px;font:600 13px Inter,system-ui,sans-serif;cursor:pointer;border:1px solid var(--ac);background:var(--ac);color:var(--ac-ink);transition:transform .04s,filter .15s;flex:none}
+  .btn:active{transform:translateY(1px)} .btn:hover{filter:brightness(1.06)}
+  .foot{color:var(--mut);font-size:12px;margin:18px 0 0}
+  .err{color:#c0492b;font-size:13.5px;margin:0}
+  kbd{background:#f1ead9;border-radius:5px;padding:1px 6px;font-size:.85em}
+</style>
+</head>
+<body><main class="card">${inner}</main></body>
+</html>`
+
+/**
+ * Render the CLI callback page. With a `code`, shows it for copy-paste back to the
+ * terminal; with an `error`, shows the failure so the user isn't left on a blank
+ * page. Either way it's a hosted Dock page — never a localhost redirect.
+ */
+export function cliCallbackHTML(props: { code?: string; error?: string }): string {
+  if (props.error || !props.code) {
+    const msg = esc(
+      props.error || "No authorization code was returned. Please run `dock login` again.",
+    )
+    return SHELL(
+      "Authorization failed",
+      `<div class="logo">⚓ Dock</div>
+      <h1>Authorization didn't complete</h1>
+      <p class="err">${msg}</p>
+      <p class="foot">Close this tab and re-run <kbd>dock login</kbd> in your terminal.</p>`,
+    )
+  }
+  const code = esc(props.code)
+  return SHELL(
+    "Authorized",
+    `<div class="logo">⚓ Dock</div>
+    <h1>You're authorized</h1>
+    <p class="sub">Copy this code and paste it back into your terminal to finish signing in.</p>
+    <div class="code">
+      <code id="code">${code}</code>
+      <button class="btn" id="copy" type="button">Copy</button>
+    </div>
+    <p class="foot">This code only works paired with the verifier on your machine, and expires shortly. You can close this tab after copying.</p>
+    <script>
+      var b=document.getElementById("copy"),c=${JSON.stringify(props.code)};
+      b.onclick=function(){navigator.clipboard&&navigator.clipboard.writeText(c);b.textContent="Copied";setTimeout(function(){b.textContent="Copy"},1500)};
+    </script>`,
+  )
+}

--- a/apps/api/test/oauth-cli-callback.test.ts
+++ b/apps/api/test/oauth-cli-callback.test.ts
@@ -1,0 +1,38 @@
+import { join } from "node:path"
+import { FsBlobStore } from "@dock/storage/fs"
+import { describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { dir, meta } from "./helpers"
+
+// The hosted landing page for `dock login` (the native/CLI OAuth flow). It must
+// answer from the Worker with the one-time code on success and a readable failure
+// otherwise — never a blank page or a localhost bounce.
+describe("GET /oauth/cli-callback", () => {
+  const blobs = new FsBlobStore(join(dir, "blobs"))
+  const app = createApp({ meta, blobs, baseUrl: "http://dock.test" })
+
+  it("shows the authorization code for copy-paste back to the terminal", async () => {
+    const r = await app.request("/oauth/cli-callback?code=ABC123XYZ&state=s")
+    expect(r.status).toBe(200)
+    expect(r.headers.get("content-type")).toContain("text/html")
+    const html = await r.text()
+    expect(html).toContain("ABC123XYZ")
+    expect(html).toContain("paste it back into your terminal")
+  })
+
+  it("renders the error (and no code) when authorization fails", async () => {
+    const r = await app.request(
+      "/oauth/cli-callback?error=access_denied&error_description=You%20declined",
+    )
+    expect(r.status).toBe(200)
+    const html = await r.text()
+    expect(html).toContain("You declined")
+    expect(html).toContain("didn't complete")
+  })
+
+  it("handles a missing code without crashing", async () => {
+    const r = await app.request("/oauth/cli-callback")
+    expect(r.status).toBe(200)
+    expect(await r.text()).toContain("didn't complete")
+  })
+})

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -1,5 +1,4 @@
 # Cloudflare Workers entry for Dock (experimental edge tier: Workers + D1 + R2).
-# Replace database_id with your own `wrangler d1 create dock` id. See DEPLOY.md.
 name = "dock"
 main = "src/worker.ts"
 compatibility_date = "2024-11-01"
@@ -8,7 +7,11 @@ compatibility_flags = ["nodejs_compat"]
 [[d1_databases]]
 binding = "DB"
 database_name = "dock"
-database_id = "REPLACE_WITH_YOUR_D1_ID"
+# This is Sift's prod D1 id. A D1 id is not a secret (it's inert without a
+# Cloudflare API token scoped to the account), so it lives here so `pnpm run
+# deploy` is one step. Self-hosting Dock? Run `wrangler d1 create dock` and put
+# your own id here. See DEPLOY.md.
+database_id = "63229e09-fdf4-4232-807d-1c60fabd9a39"
 
 [[r2_buckets]]
 binding = "BUCKET"

--- a/packages/cli/bin/dock.js
+++ b/packages/cli/bin/dock.js
@@ -1,20 +1,24 @@
 #!/usr/bin/env node
 // dock — scaffold, publish, and run the review loop against a Dock server.
 //   dock init [dir] [--template md|html|slides|site] [--title t]
+//   dock login [--server url] [--scope "…"]   OAuth sign-in; saves a token
 //   dock publish [file|dir] [--id --title --slug --spa --message --name --visibility --server --token]
 //   dock comments [--id]                 list the artifact's comment threads
 //   dock open [--id]                     open the artifact in a browser
 //   dock reply <thread_id> <message…>    reply in a thread
 //   dock resolve|reopen <comment_id>     set a thread's state
 import { spawn } from "node:child_process"
+import { createHash, randomBytes } from "node:crypto"
 import { readdirSync, readFileSync, statSync } from "node:fs"
 import { basename, join, relative } from "node:path"
+import { createInterface } from "node:readline"
 import { zipSync } from "fflate"
 import {
   CONFIG_FILE,
   formatComments,
   loadConfig,
   resolvePublish,
+  saveToken,
   scaffold,
   TEMPLATES,
   writeId,
@@ -49,6 +53,94 @@ if (cmd === "init") {
       ? `\nReady (${template}). Edit ${entry}, then run \`dock publish\`.`
       : `\nNothing to do — ${CONFIG_FILE} already here.`,
   )
+  process.exit(0)
+}
+
+// ---- dock login (OAuth 2.1, PKCE, hosted callback) ------------------------
+// The native-app flow without the localhost bounce: register a public client,
+// send the user to approve consent in their browser, land on Dock's hosted
+// /oauth/cli-callback page, and have them paste the one-time code back here. The
+// PKCE verifier never leaves this process, so the exchange (and the resulting
+// token) stay bound to this machine.
+if (cmd === "login") {
+  const b64url = (b) =>
+    b.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+  const server = (flags.server ?? process.env.DOCK_SERVER ?? "http://localhost:8080").replace(
+    /\/+$/,
+    "",
+  )
+  const redirect = `${server}/oauth/cli-callback`
+  const scope = flags.scope ?? "openid dock:read dock:publish"
+  const verifier = b64url(randomBytes(64))
+  const challenge = b64url(createHash("sha256").update(verifier).digest())
+  const state = b64url(randomBytes(16))
+
+  const reg = await fetch(`${server}/api/auth/oauth2/register`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      client_name: flags.name ?? "Dock CLI",
+      redirect_uris: [redirect],
+      token_endpoint_auth_method: "none",
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+    }),
+  }).catch((e) => ({ ok: false, status: 0, json: async () => ({ error: e.message }) }))
+  const client = await reg.json().catch(() => ({}))
+  if (!reg.ok || !client.client_id) {
+    console.error(`error: client registration failed (${reg.status}): ${client.error ?? "unknown"}`)
+    process.exit(1)
+  }
+
+  const authUrl =
+    `${server}/api/auth/oauth2/authorize?response_type=code` +
+    `&client_id=${encodeURIComponent(client.client_id)}` +
+    `&redirect_uri=${encodeURIComponent(redirect)}` +
+    `&scope=${encodeURIComponent(scope)}` +
+    `&code_challenge=${challenge}&code_challenge_method=S256&state=${state}`
+
+  console.log(`\nOpening Dock to authorize (scopes: ${scope}).`)
+  console.log(`If your browser doesn't open, visit:\n\n  ${authUrl}\n`)
+  const opener =
+    process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open"
+  spawn(opener, [authUrl], { stdio: "ignore", detached: true })
+    .on("error", () => {})
+    .unref()
+
+  const code = await new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout })
+    rl.question("Paste the code from the Dock page: ", (a) => {
+      rl.close()
+      resolve((a ?? "").trim())
+    })
+  })
+  if (!code) {
+    console.error("error: no code entered")
+    process.exit(1)
+  }
+
+  const tok = await fetch(`${server}/api/auth/oauth2/token`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirect,
+      client_id: client.client_id,
+      code_verifier: verifier,
+    }),
+  }).catch((e) => ({ ok: false, status: 0, json: async () => ({ error: e.message }) }))
+  const tj = await tok.json().catch(() => ({}))
+  if (!tok.ok || !tj.access_token) {
+    console.error(
+      `error: token exchange failed (${tok.status}): ${tj.error_description ?? tj.error ?? "unknown"}`,
+    )
+    process.exit(1)
+  }
+
+  const path = saveToken(server, tj.access_token)
+  console.log(`\n✓ Signed in to ${server}`)
+  console.log(`  Token saved to ${path} — \`dock publish\` will use it automatically.`)
   process.exit(0)
 }
 
@@ -129,6 +221,7 @@ if (LOOP.includes(cmd)) {
 if (cmd !== "publish") {
   console.error(`usage:
   dock init [dir] [--template md|html|slides|site] [--title t]
+  dock login [--server url] [--scope "openid dock:read dock:publish"]   OAuth sign-in; saves a token
   dock publish [file|dir] [--id X] [--title t] [--slug s] [--spa] [--message m] [--name "x"] [--visibility v] [--password p] [--server url] [--token t] [--json]
   dock comments [--id X]                 list comment threads
   dock open [--id X]                     open the artifact in a browser

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -1,8 +1,49 @@
 // dock.json + scaffold logic, kept pure so it's unit-testable without a server.
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 
 export const CONFIG_FILE = "dock.json"
+
+// ---- User-level credentials (`dock login`) --------------------------------
+// Tokens are secrets, so they live in a user-level store (one entry per Dock
+// origin), never in the project's dock.json. DOCK_CONFIG_DIR overrides the dir.
+
+const configDir = () => process.env.DOCK_CONFIG_DIR ?? join(homedir(), ".config", "dock")
+const credsPath = () => join(configDir(), "credentials.json")
+
+/** Normalize a server URL to its origin so one entry covers every path under it. */
+const originOf = (server) => {
+  try {
+    return new URL(server).origin
+  } catch {
+    return server
+  }
+}
+
+/** All saved credentials, keyed by server origin. {} if none / unreadable. */
+export function loadCredentials() {
+  try {
+    return JSON.parse(readFileSync(credsPath(), "utf8"))
+  } catch {
+    return {}
+  }
+}
+
+/** Persist a token for `server` (0600, owner-only). Returns the store path. */
+export function saveToken(server, token) {
+  const dir = configDir()
+  mkdirSync(dir, { recursive: true })
+  const all = loadCredentials()
+  all[originOf(server)] = { token, saved_at: new Date().toISOString() }
+  writeFileSync(credsPath(), `${JSON.stringify(all, null, 2)}\n`, { mode: 0o600 })
+  return credsPath()
+}
+
+/** The saved token for `server`, or null. */
+export function tokenFor(server) {
+  return loadCredentials()[originOf(server)]?.token ?? null
+}
 
 /** The dock.json a fresh project starts with (no id until first publish). */
 export const defaultConfig = (title = "My artifact", entry = "index.md") => ({
@@ -34,6 +75,7 @@ export function loadConfig(dir = ".") {
 export function resolvePublish(opts = {}, config = null) {
   const c = config ?? {}
   const spa = opts.spa != null ? opts.spa === "true" || opts.spa === true : !!c.spa
+  const server = opts.server ?? c.server ?? process.env.DOCK_SERVER ?? "http://localhost:8080"
   return {
     id: opts.id ?? c.id ?? null,
     target: opts.target ?? c.entry ?? null,
@@ -43,8 +85,9 @@ export function resolvePublish(opts = {}, config = null) {
     spa,
     message: opts.message,
     name: opts.name,
-    server: opts.server ?? c.server ?? process.env.DOCK_SERVER ?? "http://localhost:8080",
-    token: opts.token ?? process.env.DOCK_TOKEN,
+    server,
+    // Explicit flag / env win; otherwise fall back to the `dock login` token.
+    token: opts.token ?? process.env.DOCK_TOKEN ?? tokenFor(server),
   }
 }
 

--- a/packages/cli/test/config.test.js
+++ b/packages/cli/test/config.test.js
@@ -1,16 +1,19 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import {
   CONFIG_FILE,
   defaultConfig,
   formatComments,
   loadConfig,
+  loadCredentials,
   resolvePublish,
+  saveToken,
   scaffold,
   scaffoldFiles,
   TEMPLATES,
+  tokenFor,
   writeId,
 } from "../src/config.js"
 
@@ -192,5 +195,56 @@ describe("writeId", () => {
     const d = tmp()
     writeId(d, "zz99")
     expect(loadConfig(d).id).toBe("zz99")
+  })
+})
+
+describe("credentials (dock login)", () => {
+  // Isolate the user-level store in a tmp dir, and keep DOCK_TOKEN out of the way.
+  let prevDir
+  let prevToken
+  beforeEach(() => {
+    prevDir = process.env.DOCK_CONFIG_DIR
+    prevToken = process.env.DOCK_TOKEN
+    process.env.DOCK_CONFIG_DIR = tmp()
+    delete process.env.DOCK_TOKEN
+  })
+  const restore = (key, prev) => {
+    if (prev === undefined) delete process.env[key]
+    else process.env[key] = prev
+  }
+  afterEach(() => {
+    restore("DOCK_CONFIG_DIR", prevDir)
+    restore("DOCK_TOKEN", prevToken)
+  })
+
+  it("saves and reads a token per server origin", () => {
+    expect(tokenFor("https://dock.example.com")).toBeNull()
+    saveToken("https://dock.example.com/some/path", "tok_abc")
+    // Stored + read by origin, so a path on the same host resolves the same token.
+    expect(tokenFor("https://dock.example.com")).toBe("tok_abc")
+    expect(tokenFor("https://dock.example.com/other")).toBe("tok_abc")
+    expect(loadCredentials()["https://dock.example.com"].token).toBe("tok_abc")
+  })
+
+  it("keeps separate tokens for different servers", () => {
+    saveToken("https://a.dock.com", "tok_a")
+    saveToken("https://b.dock.com", "tok_b")
+    expect(tokenFor("https://a.dock.com")).toBe("tok_a")
+    expect(tokenFor("https://b.dock.com")).toBe("tok_b")
+  })
+
+  it("resolvePublish uses the saved token for the resolved server", () => {
+    saveToken("https://dock.example.com", "tok_login")
+    const r = resolvePublish({ server: "https://dock.example.com" }, null)
+    expect(r.token).toBe("tok_login")
+  })
+
+  it("explicit --token and DOCK_TOKEN win over the saved token", () => {
+    saveToken("https://dock.example.com", "tok_login")
+    expect(
+      resolvePublish({ server: "https://dock.example.com", token: "tok_flag" }, null).token,
+    ).toBe("tok_flag")
+    process.env.DOCK_TOKEN = "tok_env"
+    expect(resolvePublish({ server: "https://dock.example.com" }, null).token).toBe("tok_env")
   })
 })


### PR DESCRIPTION
Wraps the OAuth 2.1 server (#137) into a real CLI login, replacing the static `DOCK_TOKEN` setup with a consented, scoped token — and **no localhost redirect**.

## What's new
- **Hosted `GET /oauth/cli-callback`** ([oauth-cli-callback.ts](apps/api/src/oauth-cli-callback.ts)): after consent the browser lands on a branded Dock page showing the one-time code with a Copy button. The PKCE `code_verifier` never leaves the CLI, so the displayed code is inert on its own. Rides the existing `/oauth` worker-first prefix — no path-contract change.
- **`dock login [--server] [--scope]`** ([dock.js](packages/cli/bin/dock.js)): PKCE + anonymous DCR + authorize, prompts for the pasted code, exchanges it, and saves the token to a per-origin user store (`~/.config/dock/credentials.json`, `0600`). `dock publish` falls back to it; `--token` / `DOCK_TOKEN` still win.
- **One-step deploy**: commit the prod D1 id (not a credential; private repo) so `pnpm run deploy` needs no placeholder swap.

## Why hosted callback (not localhost)
A CLI has no public URL, so the OAuth-standard pattern is a localhost loopback (gh/aws/gcloud). For a cloud app that feels wrong, so the CLI registers Dock's own `/oauth/cli-callback` as the redirect: the code is shown on a hosted page to paste back, while the verifier stays local. Clean and still PKCE-secure.

## Tests
- Callback page: code / error / missing-code render paths.
- Credential store: save/read by origin, multi-server isolation, `resolvePublish` precedence (`--token` > `DOCK_TOKEN` > saved).
- Full suite green (CLI 22, API 270) + typecheck + lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)