### PR TITLE
feat(presence): viewer popover with name, email, and role

### DIFF
--- a/apps/api/src/bus.ts
+++ b/apps/api/src/bus.ts
@@ -39,28 +39,39 @@ export function createBus(): EventBus {
   }
 }
 
-/** Ephemeral presence per artifact: name → last-seen ms. Lost on restart. */
+/** A live viewer of an artifact: server-derived identity + their effective role.
+ *  `email` is present for signed-in users, null for an anonymous (rando-handle)
+ *  viewer. Identity is never client-supplied (see the presence route). */
+export interface Viewer {
+  id: string
+  name: string
+  email: string | null
+  role: string | null
+}
+
+/** Ephemeral presence per artifact: viewer id → {viewer, last-seen ms}. Lost on
+ *  restart. Keyed by id so multiple tabs of one person collapse to a single row. */
 export class Presence {
-  private viewers = new Map<string, Map<string, number>>()
+  private viewers = new Map<string, Map<string, { v: Viewer; t: number }>>()
   constructor(private ttlMs = 45_000) {}
 
-  /** Records a heartbeat and returns the live viewer names. */
-  heartbeat(artifactId: string, name: string, now: number): string[] {
+  /** Records a heartbeat and returns the live viewers. */
+  heartbeat(artifactId: string, viewer: Viewer, now: number): Viewer[] {
     let m = this.viewers.get(artifactId)
     if (!m) {
       m = new Map()
       this.viewers.set(artifactId, m)
     }
-    m.set(name, now)
-    for (const [n, t] of m) if (now - t > this.ttlMs) m.delete(n)
-    return [...m.keys()]
+    m.set(viewer.id, { v: viewer, t: now })
+    for (const [id, e] of m) if (now - e.t > this.ttlMs) m.delete(id)
+    return [...m.values()].map((e) => e.v)
   }
 }
 
 /** Presence as a port: in-process is synchronous; a Durable Object / Redis store
  *  resolves asynchronously, so callers await the result either way. */
 export interface PresenceStore {
-  heartbeat(channel: string, name: string, now: number): string[] | Promise<string[]>
+  heartbeat(channel: string, viewer: Viewer, now: number): Viewer[] | Promise<Viewer[]>
 }
 
 /**

--- a/apps/api/src/realtime-do.ts
+++ b/apps/api/src/realtime-do.ts
@@ -5,7 +5,7 @@ import type {
   ExecutionContext,
 } from "@cloudflare/workers-types"
 import type { Context } from "hono"
-import type { Backplane, DockEvent, PresenceStore } from "./bus"
+import type { Backplane, DockEvent, PresenceStore, Viewer } from "./bus"
 
 /**
  * Per-request execution context, so the DO backplane's fire-and-forget publish can
@@ -32,7 +32,7 @@ const frame = (event: string, data: string) => enc.encode(`event: ${event}\ndata
  */
 export class ArtifactRoom {
   private streams = new Set<ReadableStreamDefaultController<Uint8Array>>()
-  private viewers = new Map<string, number>()
+  private viewers = new Map<string, { v: Viewer; t: number }>()
   constructor(private state: DurableObjectState) {}
 
   async fetch(req: Request): Promise<Response> {
@@ -78,12 +78,12 @@ export class ArtifactRoom {
       return new Response("ok")
     }
 
-    // Presence heartbeat: record + return the live viewer names.
+    // Presence heartbeat: record + return the live viewers.
     if (req.method === "POST" && url.pathname.endsWith("/heartbeat")) {
-      const { name, now } = (await req.json()) as { name: string; now: number }
-      this.viewers.set(name, now)
-      for (const [n, t] of this.viewers) if (now - t > PRESENCE_TTL_MS) this.viewers.delete(n)
-      return Response.json([...this.viewers.keys()])
+      const { viewer, now } = (await req.json()) as { viewer: Viewer; now: number }
+      this.viewers.set(viewer.id, { v: viewer, t: now })
+      for (const [id, e] of this.viewers) if (now - e.t > PRESENCE_TTL_MS) this.viewers.delete(id)
+      return Response.json([...this.viewers.values()].map((e) => e.v))
     }
 
     return new Response("not found", { status: 404 })
@@ -116,12 +116,12 @@ export class ArtifactRoom {
 export function createDoBackplane(rooms: DurableObjectNamespace): Backplane {
   const stub = (channel: string) => rooms.get(rooms.idFromName(channel))
   const presence: PresenceStore = {
-    async heartbeat(channel, name, now) {
+    async heartbeat(channel, viewer, now) {
       const res = await stub(channel).fetch("https://do/heartbeat", {
         method: "POST",
-        body: JSON.stringify({ name, now }),
+        body: JSON.stringify({ viewer, now }),
       })
-      return (await res.json()) as string[]
+      return (await res.json()) as Viewer[]
     },
   }
   return {

--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -1,12 +1,24 @@
+import { effectiveRole } from "@dock/core"
 import { Hono } from "hono"
 import { streamSSE } from "hono/streaming"
 import { z } from "zod"
+import type { Viewer } from "../bus"
 import type { AppContext } from "../context"
 import { anonName, fail, readJson } from "../lib/http"
 
 /** Live updates per artifact (SSE) + ephemeral presence (who's viewing now). */
 export const realtimeRoutes = (ctx: AppContext) => {
-  const { meta, bus, presence, backplane, authorize, actingUser, anonViewerId } = ctx
+  const {
+    meta,
+    bus,
+    presence,
+    backplane,
+    authorize,
+    actingUser,
+    currentUser,
+    actorFor,
+    anonViewerId,
+  } = ctx
   const app = new Hono()
 
   app.get("/v1/artifacts/:shortId/events", async (c) => {
@@ -36,13 +48,18 @@ export const realtimeRoutes = (ctx: AppContext) => {
   app.post("/v1/artifacts/:shortId/presence", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact || !(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
-    // Presence identity is server-derived, never client-supplied: a signed-in
-    // user or agent shows by their account name; an anonymous viewer gets a
-    // stable, friendly handle (`helpful-kitty-95`) keyed to their viewer cookie,
-    // so they can't impersonate anyone or spam arbitrary names. This is the only
-    // thing an anonymous caller may do beyond reading (see the lockdown in app.ts).
-    const name = (await actingUser(c))?.name ?? anonName(anonViewerId(c))
-    const viewers = await presence.heartbeat(artifact.id, name, Date.now())
+    // Presence identity is built entirely server-side, never client-supplied: a
+    // signed-in user by their account (name + email), an anonymous viewer by a
+    // stable, friendly handle (`helpful-kitty-95`) keyed to their viewer cookie and
+    // no email, so nobody can impersonate or spam names. `role` is their effective
+    // role on this artifact (so email/role can't be forged either). Presence is the
+    // only thing an anonymous caller may do beyond reading (lockdown in app.ts).
+    const me = await currentUser(c)
+    const role = effectiveRole(await actorFor(c, artifact), artifact.visibility)
+    const viewer: Viewer = me
+      ? { id: me.id, name: me.name ?? me.email, email: me.email, role }
+      : { id: anonViewerId(c), name: anonName(anonViewerId(c)), email: null, role }
+    const viewers = await presence.heartbeat(artifact.id, viewer, Date.now())
     bus.publish(artifact.id, { type: "presence", viewers })
     return c.json({ viewers })
   })

--- a/apps/api/test/analytics.test.ts
+++ b/apps/api/test/analytics.test.ts
@@ -2,6 +2,7 @@ import { join } from "node:path"
 import { FsBlobStore } from "@dock/storage/fs"
 import { describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
+import type { Viewer } from "../src/bus"
 import {
   anonApp,
   app,
@@ -136,26 +137,31 @@ describe("live stream (SSE)", () => {
     }
   })
 
-  it("reports presence by server identity (signed-in name; anon gets a rando handle)", async () => {
+  it("reports presence by server identity: name + email + role; anon gets a rando handle, no email", async () => {
     const jess: TestUser = { id: "u_pres_jess", email: "jess@dock.test", name: "Jess" }
     const { app: a } = makeAuthedApp("presence", [jess])
     const { short_id } = await (
       await publishAs(a, "<h1>p</h1>", { visibility: "public" }, as(jess.email))
     ).json()
-    // Signed-in: the heartbeat is attributed to the account name, never a
-    // client-supplied one.
+    // Signed-in: identity is server-derived — account name + email + their role on
+    // the artifact (owner here), never a client-supplied label.
     const signed = await a.request(
       `/v1/artifacts/${short_id}/presence`,
       jsonAs(as(jess.email), { name: "SPOOF" }),
     )
-    const signedViewers = (await signed.json()).viewers as string[]
-    expect(signedViewers).toContain("Jess")
-    expect(signedViewers).not.toContain("SPOOF")
-    // Anonymous: a stable, friendly handle (helpful-kitty-95 style), never "anonymous".
+    const signedViewers = (await signed.json()).viewers as Viewer[]
+    const me = signedViewers.find((v) => v.email === "jess@dock.test")
+    expect(me).toMatchObject({ name: "Jess", email: "jess@dock.test", role: "owner" })
+    expect(signedViewers.some((v) => v.name === "SPOOF")).toBe(false)
+    // Anonymous: a stable, friendly handle (helpful-kitty-95 style), never
+    // "anonymous", and no email. Public artifact → role "viewer".
     const anon = await a.request(`/v1/artifacts/${short_id}/presence`, json({}))
-    const viewers = (await anon.json()).viewers as string[]
-    expect(viewers).not.toContain("anonymous")
-    expect(viewers.some((v) => /^[a-z]+-[a-z]+-\d{1,2}$/.test(v))).toBe(true)
+    const viewers = (await anon.json()).viewers as Viewer[]
+    expect(viewers.some((v) => v.name === "anonymous")).toBe(false)
+    const handle = viewers.find((v) => /^[a-z]+-[a-z]+-\d{1,2}$/.test(v.name))
+    expect(handle).toBeDefined()
+    expect(handle?.email).toBeNull()
+    expect(handle?.role).toBe("viewer")
   })
 })
 

--- a/apps/api/test/bus.test.ts
+++ b/apps/api/test/bus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { createBus, Presence } from "../src/bus"
+import { createBus, Presence, type Viewer } from "../src/bus"
 
 describe("event bus", () => {
   it("delivers published events to subscribers of that artifact only", () => {
@@ -25,11 +25,24 @@ describe("event bus", () => {
 })
 
 describe("presence", () => {
-  it("tracks live viewers and prunes stale ones past the TTL", () => {
+  const v = (id: string): Viewer => ({ id, name: id, email: null, role: "viewer" })
+  it("tracks live viewers (keyed by id) and prunes stale ones past the TTL", () => {
     const p = new Presence(1000)
-    expect(p.heartbeat("a", "jess", 0)).toEqual(["jess"])
-    expect(p.heartbeat("a", "sam", 500).sort()).toEqual(["jess", "sam"])
+    expect(p.heartbeat("a", v("jess"), 0)).toEqual([v("jess")])
+    expect(
+      p
+        .heartbeat("a", v("sam"), 500)
+        .map((x) => x.id)
+        .sort(),
+    ).toEqual(["jess", "sam"])
     // jess last seen at 0; at t=1600 she's stale (>1000ms), sam stays
-    expect(p.heartbeat("a", "sam", 1600)).toEqual(["sam"])
+    expect(p.heartbeat("a", v("sam"), 1600)).toEqual([v("sam")])
+  })
+
+  it("upserts by id, so a viewer's later heartbeat replaces (not duplicates) the row", () => {
+    const p = new Presence(1000)
+    p.heartbeat("a", { id: "u1", name: "Old", email: null, role: "viewer" }, 0)
+    const out = p.heartbeat("a", { id: "u1", name: "New", email: "u1@x.test", role: "owner" }, 100)
+    expect(out).toEqual([{ id: "u1", name: "New", email: "u1@x.test", role: "owner" }])
   })
 })

--- a/apps/web/e2e/deep/presence-popover.deep.spec.ts
+++ b/apps/web/e2e/deep/presence-popover.deep.spec.ts
@@ -1,0 +1,49 @@
+import { Buffer } from "node:buffer"
+import type { Page } from "@playwright/test"
+import { expect, openArtifact, test } from "../fixtures"
+
+// "Who's viewing" is an avatar stack that opens a popover listing each live viewer
+// with their server-derived identity: name, email (signed-in only), and role.
+
+async function publishPublic(page: Page): Promise<string> {
+  let id = ""
+  await expect(async () => {
+    const res = await page.request.post("/v1/artifacts", {
+      multipart: {
+        file: { name: "p.md", mimeType: "text/markdown", buffer: Buffer.from("# Shared\n\nbody") },
+        visibility: "public",
+      },
+    })
+    expect(res.ok(), `publish failed: ${res.status()}`).toBeTruthy()
+    id = ((await res.json()) as { short_id: string }).short_id
+  }).toPass({ timeout: 10_000 })
+  return id
+}
+
+test("the presence stack opens a popover listing each viewer with name, email, and role", async ({
+  owner,
+  secondUser,
+}) => {
+  const id = await publishPublic(owner)
+  await openArtifact(owner, id)
+
+  // A second account opens the same artifact → they join presence (heartbeat).
+  await secondUser.page.goto(`/a/${id}`)
+  await expect(secondUser.page.getByText("Comments", { exact: true })).toBeVisible()
+
+  // The owner now sees the stack (someone else is viewing) and opens it.
+  await expect(owner.getByTestId("presence-trigger")).toBeVisible({ timeout: 15_000 })
+  await owner.getByTestId("presence-trigger").click()
+  const pop = owner.getByTestId("presence-popover")
+  await expect(pop).toBeVisible()
+
+  // The second user shows by their server-derived account name + email.
+  await expect(pop).toContainText("Second User")
+  await expect(pop).toContainText(secondUser.email)
+  // The owner is flagged as themselves, with the owner role on their own artifact.
+  await expect(pop.getByText("(you)")).toBeVisible()
+  await expect(pop).toContainText("owner")
+  // The anonymous-or-not distinction: the second user (a non-member on a public
+  // artifact) is a viewer.
+  await expect(pop).toContainText("viewer")
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -197,6 +197,14 @@ export interface Agent {
   role: Role
   created_at: string
 }
+/** A live viewer of an artifact (presence). `email` is present for signed-in
+ *  users, null for an anonymous viewer; `role` is their effective role here. */
+export interface Viewer {
+  id: string
+  name: string
+  email: string | null
+  role: string | null
+}
 export interface Delivery {
   id: string
   event_type: string
@@ -408,8 +416,9 @@ export const api = {
     f(`/v1/workspace/domains/${host}`, { method: "DELETE", credentials: "include" }).then(
       () => undefined,
     ),
-  heartbeat: (id: string, name: string): Promise<{ viewers: string[] }> =>
-    f(`/v1/artifacts/${id}/presence`, opts({ name })).then(j),
+  // Identity is derived server-side from the session/cookie, so we send nothing.
+  heartbeat: (id: string): Promise<{ viewers: Viewer[] }> =>
+    f(`/v1/artifacts/${id}/presence`, opts({})).then(j),
 
   favorite: (id: string, on: boolean): Promise<{ favorite: boolean }> =>
     f(`/v1/artifacts/${id}/favorite`, { ...opts(), method: on ? "PUT" : "DELETE" }).then(j),

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -93,7 +93,7 @@ export function Artifact() {
   // Presence, live multiplayer cursors, the SSE stream, and view recording — see
   // use-artifact-live. The page feeds pointer moves in (from the iframe bridge
   // below) and reads `viewers` + the `cursorLayer` overlay ref back out.
-  const live = useArtifactLive({ shortId, me, onComment: refetchComments, onVersion: load })
+  const live = useArtifactLive({ shortId, onComment: refetchComments, onVersion: load })
 
   // The whole postMessage channel with the sandboxed iframe: text selection,
   // anchor geometry, scroll, deck position, and peer cursors in; highlight
@@ -294,7 +294,7 @@ export function Artifact() {
       {topBarSlot &&
         createPortal(
           <>
-            {!isMobile && <Presence viewers={live.viewers} self={me?.name ?? me?.email ?? ""} />}
+            {!isMobile && <Presence viewers={live.viewers} selfId={me?.id} />}
             {!isMobile && <CursorButton />}
             {!isAnon && (
               <ArtifactTopBar

--- a/apps/web/src/pages/artifact/rail-deck.tsx
+++ b/apps/web/src/pages/artifact/rail-deck.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useState } from "react"
+import type { Viewer } from "@/api"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { cn } from "@/lib/utils"
 import { clamp } from "./lib/layout"
 import type { PinItem } from "./types"
@@ -159,36 +161,82 @@ export function DeckBar({
   )
 }
 
-export function Presence({ viewers, self }: { viewers: string[]; self: string }) {
-  const others = viewers.filter((v) => v !== self)
+const initials = (v: Viewer) => (v.name || "?").slice(0, 2).toUpperCase()
+
+// "Who's viewing" — an avatar stack that opens a popover listing each live viewer
+// with their name, email (signed-in only), and role. Identity is server-derived
+// (see the presence route), so nothing here is spoofable. Hidden when you're the
+// only viewer. Built on the shared Popover, so it dismisses on outside/iframe click.
+export function Presence({ viewers, selfId }: { viewers: Viewer[]; selfId?: string }) {
+  const self = viewers.find((v) => v.id === selfId) ?? null
+  const others = viewers.filter((v) => v.id !== selfId)
   if (others.length === 0) return null
-  const ordered = [self, ...others].filter(Boolean)
+  const ordered = self ? [self, ...others] : others
   const shown = ordered.slice(0, 4)
   const extra = ordered.length - shown.length
   return (
-    <div
-      className="flex items-center gap-1.5"
-      title={`${ordered.length} viewing: ${ordered.join(", ")}`}
-    >
-      <div className="flex">
-        {shown.map((name, i) => (
-          <span
-            key={name}
-            className={cn(
-              "grid size-[22px] place-items-center rounded-full border-2 border-card font-mono text-2xs font-bold",
-              name === self ? "bg-primary text-primary-foreground" : "bg-accent text-primary",
-              i > 0 && "-ml-[7px]",
-            )}
-          >
-            {(name || "?").slice(0, 2).toUpperCase()}
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          data-testid="presence-trigger"
+          aria-label={`${ordered.length} viewing — see who`}
+          className="flex items-center gap-1.5 rounded-full py-0.5 pl-1 pr-2 transition-colors hover:bg-hover"
+        >
+          <div className="flex">
+            {shown.map((v, i) => (
+              <span
+                key={v.id}
+                className={cn(
+                  "grid size-[22px] place-items-center rounded-full border-2 border-card font-mono text-2xs font-bold",
+                  v.id === selfId ? "bg-primary text-primary-foreground" : "bg-accent text-primary",
+                  i > 0 && "-ml-[7px]",
+                )}
+              >
+                {initials(v)}
+              </span>
+            ))}
+          </div>
+          <span className="flex items-center gap-1 font-mono text-xs text-muted-foreground">
+            <span className="size-1.5 rounded-full bg-success" />
+            {ordered.length} viewing{extra > 0 ? ` (+${extra})` : ""}
           </span>
-        ))}
-      </div>
-      <span className="flex items-center gap-1 font-mono text-xs text-muted-foreground">
-        <span className="size-1.5 rounded-full bg-success" />
-        {ordered.length} viewing{extra > 0 ? ` (+${extra})` : ""}
-      </span>
-    </div>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" data-testid="presence-popover" className="w-64 p-1.5">
+        <div className="px-2 py-1 font-mono text-2xs uppercase tracking-wide text-muted-foreground">
+          {ordered.length} viewing now
+        </div>
+        <div className="max-h-[280px] overflow-auto">
+          {ordered.map((v) => (
+            <div key={v.id} className="flex items-center gap-2.5 rounded-md px-2 py-1.5">
+              <span
+                className={cn(
+                  "grid size-7 shrink-0 place-items-center rounded-full font-mono text-2xs font-bold",
+                  v.id === selfId ? "bg-primary text-primary-foreground" : "bg-accent text-primary",
+                )}
+              >
+                {initials(v)}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+                  <span className="truncate">{v.name}</span>
+                  {v.id === selfId && <span className="text-2xs text-muted-foreground">(you)</span>}
+                </span>
+                <span className="block truncate text-xs text-muted-foreground">
+                  {v.email ?? "Anonymous viewer"}
+                </span>
+              </span>
+              {v.role && (
+                <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 font-mono text-2xs capitalize text-muted-foreground">
+                  {v.role}
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
   )
 }
 

--- a/apps/web/src/pages/artifact/use-artifact-live.ts
+++ b/apps/web/src/pages/artifact/use-artifact-live.ts
@@ -1,8 +1,6 @@
 import { useEffect, useRef, useState } from "react"
-import { API_BASE, api } from "@/api"
+import { API_BASE, api, type Viewer } from "@/api"
 import { useLiveCursors } from "./cursors/use-live-cursors"
-
-type Me = { name?: string | null; email?: string | null } | null
 
 /**
  * Everything realtime on the artifact page, kept out of the page component:
@@ -18,12 +16,11 @@ type Me = { name?: string | null; email?: string | null } | null
  */
 export function useArtifactLive(opts: {
   shortId: string
-  me: Me
   onComment: () => void
   onVersion: () => void
 }) {
-  const { shortId, me, onComment, onVersion } = opts
-  const [viewers, setViewers] = useState<string[]>([])
+  const { shortId, onComment, onVersion } = opts
+  const [viewers, setViewers] = useState<Viewer[]>([])
   const cursors = useLiveCursors(shortId)
   const { paintFrame } = cursors
 
@@ -40,7 +37,7 @@ export function useArtifactLive(opts: {
     ev.addEventListener("version.published", onVersion)
     ev.addEventListener("presence", (e) => {
       try {
-        setViewers((JSON.parse((e as MessageEvent).data).viewers as string[]) ?? [])
+        setViewers((JSON.parse((e as MessageEvent).data).viewers as Viewer[]) ?? [])
       } catch {
         /* ignore malformed frames */
       }
@@ -58,16 +55,15 @@ export function useArtifactLive(opts: {
   // Announce we're viewing (anon shows up by their server handle — Google-Docs
   // style) and keep the heartbeat alive (TTL 45s).
   useEffect(() => {
-    const name = me ? (me.name ?? me.email ?? "Guest") : "Guest"
     const beat = () =>
       api
-        .heartbeat(shortId, name ?? "Guest")
+        .heartbeat(shortId)
         .then((r) => setViewers(r.viewers))
         .catch(() => {})
     beat()
     const t = setInterval(beat, 20_000)
     return () => clearInterval(t)
-  }, [shortId, me])
+  }, [shortId])
 
   // Record one view per artifact open.
   const recorded = useRef("")


### PR DESCRIPTION
Hover (click) the "who's viewing" avatar stack to open a popover listing every live viewer, with their **server-derived** identity: name, email (signed-in only), and role.

## Server
- Presence now carries a `Viewer {id, name, email, role}` instead of a bare name string. Both stores — the in-memory `Presence` and the `ArtifactRoom` Durable Object — key by `id` (so multiple tabs of one person collapse to one row) and return the full records.
- The `/presence` route builds the viewer **entirely server-side**: a signed-in user by account name + email + their `effectiveRole` on the artifact; an anonymous viewer by their stable rando handle with `email: null`. Email/role are never client-supplied, so a viewer can't impersonate anyone or grant themselves a role.

## Web
- `api.heartbeat` returns `Viewer[]` (the server ignores any client name, so the client sends none).
- The `Presence` component renders the avatar stack as a `Popover` trigger; the content lists each viewer — avatar, name, `(you)` for self, email (or "Anonymous viewer"), and a role pill. It's built on the shared `Popover`, so it inherits the outside-click / artifact-iframe dismissal.

## Tests
- `bus.test.ts` + `analytics.test.ts`: the `Viewer` shape, upsert-by-id, and the name/email/role/anon derivation (signed-in gets email + role; anon gets a handle + null email).
- New `e2e/deep/presence-popover.deep.spec.ts`: two real accounts on one artifact → the popover shows the second user's name + email + role and flags the owner as `(you)`.
- Full **31-test deep suite** + all unit suites green; typecheck, biome, and token/frontend/testid/api lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)