### PR TITLE
ops hardening: atomic takedown, vitals collector, real readyz probe, unlock limiter + bundle budget split

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,13 +1,15 @@
-name: e2e smoke (post-merge)
+name: e2e smoke
 
 # The fast critical-path suite: one happy path per surface (sign up, publish →
 # comment → resolve, library, share, settings, theme, review) — runs in well
-# under two minutes. Intended as the POST-MERGE gate on main.
+# under two minutes.
 #
-# Runs on every push to main (the post-merge gate) and on demand. Fast enough
-# (~2 min) that a regression is caught within minutes of landing.
+# Runs on every PR (the pre-merge gate, so a broken critical path can't land),
+# on every push to main (the post-merge backstop), and on demand. Fast enough
+# (~2 min) that it gates a PR without slowing review.
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches: [main]
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -25,6 +25,7 @@ import { realtimeRoutes } from "./routes/realtime"
 import { sessionRoutes } from "./routes/session"
 import { sharingRoutes } from "./routes/sharing"
 import { syncRoutes } from "./routes/sync"
+import { vitalsRoutes } from "./routes/vitals"
 import { webhookRoutes } from "./routes/webhooks"
 import { workspaceRoutes } from "./routes/workspace"
 import { workspaceDomainRoutes } from "./routes/workspace-domains"
@@ -292,7 +293,11 @@ export function createApp(deps: AppDeps): Hono {
   app.get("/readyz", async (c) => {
     try {
       await deps.meta.getWorkspace(deps.defaultOrgId ?? "default")
-      await deps.blobs.get("__readyz_probe__")
+      // A valid 64-hex key so the store does real I/O (fs read / S3 GET): the
+      // sentinel doesn't exist, so a healthy backend returns null, but an
+      // unreachable one throws — which is the signal we want. A non-hex key
+      // would short-circuit to null without touching the backend (no-op probe).
+      await deps.blobs.get("0".repeat(64))
       return c.json({ ok: true })
     } catch (err) {
       log.error("readiness check failed", {
@@ -330,6 +335,7 @@ export function createApp(deps: AppDeps): Hono {
     /^\/v1\/artifacts\/[^/]+\/cursor$/, // ephemeral live cursor (viral viewing)
     /^\/v1\/artifacts\/[^/]+\/view$/, // de-duped, anonymous-safe view counter
     /^\/v1\/artifacts\/[^/]+\/unlock$/, // password unlock — the password is the gate
+    /^\/v1\/vitals$/, // anonymous Core Web Vitals beacon (telemetry, no state)
   ]
   app.use("/v1/*", async (c, next) => {
     const m = c.req.method
@@ -350,6 +356,7 @@ export function createApp(deps: AppDeps): Hono {
     favoriteRoutes,
     collectionRoutes,
     syncRoutes,
+    vitalsRoutes,
     moderationRoutes,
     proposalRoutes,
     commentRoutes,

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -171,6 +171,10 @@ export function buildContext(deps: AppDeps) {
   // rate limiting is on; the IP middleware is the per-origin backstop.
   const publishLimiter = deps.rateLimit ? makeKeyedLimiter(60_000, deps.publishRate ?? 30) : null
   const commentLimiter = deps.rateLimit ? makeKeyedLimiter(60_000, deps.commentRate ?? 60) : null
+  // Password unlock is a credential-guessing surface, so it gets a much tighter
+  // cap than the lenient global /v1 write limiter (120/min) it would otherwise
+  // share: 10 attempts/min per caller (IP, when anonymous) bounds brute force.
+  const unlockLimiter = deps.rateLimit ? makeKeyedLimiter(60_000, 10) : null
 
   // Fan an event to subscribed webhooks (enqueues to the outbox; the worker
   // delivers). Awaited so the row is durable before we respond, but never fatal.
@@ -485,6 +489,7 @@ export function buildContext(deps: AppDeps) {
     defaultRole,
     publishLimiter,
     commentLimiter,
+    unlockLimiter,
     notify,
     bearer,
     currentUser,

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -47,6 +47,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     limited,
     overStorage,
     publishLimiter,
+    unlockLimiter,
     sourceText,
   } = ctx
   const app = new Hono()
@@ -308,9 +309,12 @@ export const artifactRoutes = (ctx: AppContext) => {
 
   // Unlock a `password` artifact: verify the password and drop a cookie whose
   // value is derived from the server-only hash (so it can't be forged and dies if
-  // the password changes). Brute force is bounded by the global /v1 rate limiter.
+  // the password changes). Brute force is bounded by a dedicated tight limiter
+  // (10 attempts/min per caller), well below the lenient global /v1 write cap.
   // authz-exempt: the password itself is the gate; any visitor may attempt unlock.
   app.post("/v1/artifacts/:shortId/unlock", async (c) => {
+    const over = await limited(c, unlockLimiter)
+    if (over) return over
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact || artifact.visibility !== "password" || !artifact.password_hash)
       return fail(c, 404, "not found")

--- a/apps/api/src/routes/moderation.ts
+++ b/apps/api/src/routes/moderation.ts
@@ -79,17 +79,21 @@ export const moderationRoutes = (ctx: AppContext) => {
     const who = (await actingUser(c))?.name ?? "owner"
     const b = await readJson(c, z.object({ note: z.unknown().optional() }))
     if (b instanceof Response) return b
-    await meta.setArtifactRemoved(artifact.id, new Date().toISOString())
-    for (const r of await meta.listReports(artifact.org_id, { state: "open" }))
-      if (r.artifact_id === artifact.id)
-        await meta.setReportState(r.id, "actioned", artifact.org_id)
-    await meta.createAuditLog({
-      id: newId("aud"),
-      org_id: artifact.org_id,
-      action: "takedown",
-      artifact_id: artifact.id,
-      actor: who,
-      detail: str(b.note) ?? null,
+    // One atomic step: tombstone the artifact, resolve every open report against
+    // it, and write the audit entry. (Was a non-transactional read-loop-write that
+    // also scanned the whole open-report queue to filter by artifact — N+1.)
+    await meta.takedownArtifact({
+      artifactId: artifact.id,
+      orgId: artifact.org_id,
+      removedAt: new Date().toISOString(),
+      audit: {
+        id: newId("aud"),
+        org_id: artifact.org_id,
+        action: "takedown",
+        artifact_id: artifact.id,
+        actor: who,
+        detail: str(b.note) ?? null,
+      },
     })
     return c.json({ ok: true, removed: true })
   })

--- a/apps/api/src/routes/vitals.ts
+++ b/apps/api/src/routes/vitals.ts
@@ -1,0 +1,39 @@
+import { Hono } from "hono"
+import { z } from "zod"
+import type { AppContext } from "../context"
+import { readJson } from "../lib/http"
+import { log } from "../log"
+
+/** Core Web Vitals collector: the SPA beacons real field metrics here (LCP / INP
+ *  / CLS / TTFB), so production performance is measured from actual users instead
+ *  of guessed at. We only structure-log them (one line per metric) — a log
+ *  pipeline can aggregate p75s — so there's no datastore write and nothing to
+ *  brute force; the global per-IP /v1 write limiter is the only backstop needed. */
+export const vitalsRoutes = (_ctx: AppContext) => {
+  const app = new Hono()
+
+  // A real user's browser, signed in or not, reports its vitals — so this is
+  // anonymous by design (it's allow-listed in the anon-write lockdown). The body
+  // is the web-vitals Metric shape the SPA sends; sendBeacon can't read the
+  // response, so we just accept and 204.
+  // authz-exempt: anonymous client performance telemetry — no identity, no state mutated.
+  app.post("/v1/vitals", async (c) => {
+    const b = await readJson(
+      c,
+      z.object({
+        name: z.enum(["LCP", "INP", "CLS", "TTFB", "FCP"]),
+        value: z.number().finite(),
+        rating: z.enum(["good", "needs-improvement", "poor"]),
+        id: z.string().max(120),
+        path: z.string().max(512),
+      }),
+    )
+    if (b instanceof Response) return b
+    // Raw value (not rounded): CLS is a 0–1 float that rounding would flatten to
+    // 0, while LCP/INP/TTFB are already ms. The log pipeline aggregates p75s.
+    log.info("web-vital", { metric: b.name, value: b.value, rating: b.rating, path: b.path })
+    return c.body(null, 204)
+  })
+
+  return app
+}

--- a/apps/api/test/quotas.test.ts
+++ b/apps/api/test/quotas.test.ts
@@ -60,6 +60,30 @@ describe("rate limits: per-actor write throttles (C4b)", () => {
     expect((await comment()).status).toBe(429)
   })
 
+  it("throttles password-unlock attempts with a tight dedicated cap (10/min)", async () => {
+    const { app } = quotaApp("rl-unlock", { rateLimit: true })
+    const form = new FormData()
+    form.append("file", new Blob([new TextEncoder().encode("<h1>x</h1>")]), "x.html")
+    form.append("visibility", "password")
+    form.append("password", "hunter2")
+    const a = await (
+      await app.request("/v1/artifacts", { method: "POST", body: form, headers: bearer("tok") })
+    ).json()
+    // Anonymous wrong-password attempts: the limiter runs before the password
+    // check, so each counts. Ten are allowed (401 wrong-password), the 11th 429s —
+    // far below the lenient 120/min global write cap this used to share.
+    const attempt = () =>
+      app.request(`/v1/artifacts/${a.short_id}/unlock`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ password: "wrong" }),
+      })
+    for (let i = 0; i < 10; i++) expect((await attempt()).status).toBe(401)
+    const blocked = await attempt()
+    expect(blocked.status).toBe(429)
+    expect(blocked.headers.get("Retry-After")).toBeTruthy()
+  })
+
   it("keys the limit by identity — one user hitting the cap doesn't block another", async () => {
     const amy: TestUser = { id: "u_amy", email: "amy@dock.test", name: "Amy" }
     const ben: TestUser = { id: "u_ben", email: "ben@dock.test", name: "Ben" }

--- a/apps/api/test/readyz.test.ts
+++ b/apps/api/test/readyz.test.ts
@@ -29,4 +29,17 @@ describe("health + readiness endpoints", () => {
     const app = createApp({ meta: broken, blobs, baseUrl: "http://dock.test" })
     expect((await app.request("/readyz")).status).toBe(503)
   })
+
+  it("/readyz returns 503 when the blob store is unreachable", async () => {
+    // The probe must do real blob I/O: it reads with a valid 64-hex sentinel key
+    // (a non-hex key short-circuits to null without touching the backend), so a
+    // store whose backend is down throws and the check fails. This guards against
+    // the probe silently regressing back into a no-op.
+    const brokenBlobs = new Proxy(blobs, {
+      get: (t, p) =>
+        p === "get" ? () => Promise.reject(new Error("blob backend down")) : Reflect.get(t, p),
+    })
+    const app = createApp({ meta, blobs: brokenBlobs, baseUrl: "http://dock.test" })
+    expect((await app.request("/readyz")).status).toBe(503)
+  })
 })

--- a/apps/api/test/vitals.test.ts
+++ b/apps/api/test/vitals.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import { anonApp, json } from "./helpers"
+
+// The Core Web Vitals collector: the SPA beacons real field metrics here. It's
+// anonymous by design (any visitor's browser reports), so these run against the
+// no-auth app to prove the anon-write lockdown lets the beacon through.
+describe("POST /v1/vitals", () => {
+  it("accepts a beacon from an anonymous visitor (204, no body)", async () => {
+    const r = await anonApp.request(
+      "/v1/vitals",
+      json({ name: "LCP", value: 1234.5, rating: "good", id: "v1-abc", path: "/a/xyz" }),
+    )
+    expect(r.status).toBe(204)
+    expect(await r.text()).toBe("")
+  })
+
+  it("accepts a CLS metric (a 0–1 float)", async () => {
+    const r = await anonApp.request(
+      "/v1/vitals",
+      json({ name: "CLS", value: 0.04, rating: "good", id: "v1-cls", path: "/" }),
+    )
+    expect(r.status).toBe(204)
+  })
+
+  it("rejects an unknown metric name (400)", async () => {
+    const r = await anonApp.request(
+      "/v1/vitals",
+      json({ name: "BOGUS", value: 1, rating: "good", id: "x", path: "/" }),
+    )
+    expect(r.status).toBe(400)
+  })
+
+  it("rejects a non-finite value (400)", async () => {
+    const r = await anonApp.request(
+      "/v1/vitals",
+      json({ name: "INP", value: "fast", rating: "good", id: "x", path: "/" }),
+    )
+    expect(r.status).toBe(400)
+  })
+})

--- a/apps/web/src/lib/vitals.ts
+++ b/apps/web/src/lib/vitals.ts
@@ -1,20 +1,23 @@
 import { type Metric, onCLS, onINP, onLCP, onTTFB } from "web-vitals"
+import { API_BASE } from "@/api"
 
-// Where to beacon field metrics. Optional: unset → no beacon (e.g. local dev),
-// set in prod to collect real LCP / INP / CLS / TTFB from users.
-const BEACON_URL = import.meta.env.VITE_VITALS_URL as string | undefined
+// Where to beacon field metrics. Defaults to the API's own collector
+// (`/v1/vitals`, same-origin in the single-container deploy, the API origin in
+// the hosted split), so vitals are measured out of the box; point VITE_VITALS_URL
+// at a different sink to override. Skipped in dev (we only console-log there).
+const BEACON_URL =
+  (import.meta.env.VITE_VITALS_URL as string | undefined) ?? `${API_BASE}/v1/vitals`
 
 // Report Core Web Vitals. In dev we log each metric to the console (with its
-// rating) for before/after tuning; when VITE_VITALS_URL is set we also beacon it
-// — sendBeacon survives the page unload that finalizes CLS/INP/LCP, so the
-// numbers are real field data, not synthetic. Both sinks are no-ops off-window.
+// rating) for before/after tuning; in prod we also beacon it to the collector —
+// sendBeacon survives the page unload that finalizes CLS/INP/LCP, so the numbers
+// are real field data, not synthetic. Both sinks are no-ops off-window.
 export function reportWebVitals() {
   if (typeof window === "undefined") return
   const sink = (m: Metric) => {
     if (import.meta.env.DEV) {
       console.info(`[web-vitals] ${m.name} ${Math.round(m.value)} (${m.rating})`)
-    }
-    if (BEACON_URL) {
+    } else {
       const body = JSON.stringify({
         name: m.name,
         value: m.value,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -23,6 +23,10 @@ export default defineConfig({
     alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },
   },
   build: {
+    // Emit .vite/manifest.json so the bundle budget can tell the eager critical
+    // path (entry + its static-import closure) apart from lazy route chunks, and
+    // gate the two separately (scripts/check-bundle.mjs).
+    manifest: true,
     rollupOptions: {
       output: {
         // Keep React/runtime in its own vendor chunk so app changes don't bust

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -347,6 +347,12 @@ export interface MetaStore {
   setReportState(id: string, state: ReportState, orgId?: string): Promise<void>
   /** Set or clear an artifact's takedown tombstone (the record is never deleted). */
   setArtifactRemoved(id: string, removedAt: string | null): Promise<void>
+  /** Take an artifact down atomically: tombstone the artifact, resolve every open
+   *  report against it (→ actioned), and write the audit entry — all in one
+   *  transaction so a crash mid-way can't leave a half-applied takedown (removed
+   *  but reports still open, or no audit trail). Replaces the route's
+   *  read-loop-write, which was both non-atomic and N+1 in the open-report count. */
+  takedownArtifact(input: TakedownInput): Promise<void>
   /** Update an artifact's display title (used when a GitHub-synced file is renamed —
    *  the title tracks the repo path; the artifact + its comments are preserved). */
   setArtifactTitle(id: string, title: string): Promise<void>
@@ -414,6 +420,16 @@ export interface NewAuditLog {
   artifact_id?: string | null
   actor: string
   detail?: string | null
+}
+
+/** A whole takedown as one unit: the artifact + workspace it targets, the
+ *  tombstone timestamp, and the audit entry to record — applied atomically by
+ *  {@link MetaStore.takedownArtifact}. */
+export interface TakedownInput {
+  artifactId: string
+  orgId: string
+  removedAt: string
+  audit: NewAuditLog
 }
 
 /**

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -41,6 +41,7 @@ import type {
   ReportState,
   RepoSourceRecord,
   Role,
+  TakedownInput,
   UserDir,
   VersionRecord,
   ViewStats,
@@ -1035,6 +1036,28 @@ export class PgMetaStore implements MetaStore {
   }
   async createAuditLog(a: NewAuditLog): Promise<void> {
     await this.db.insert(auditLog).values(a)
+  }
+  // Atomic takedown: tombstone + bulk open-report resolution + audit entry in one
+  // transaction, so a failure mid-way rolls back instead of leaving a half-applied
+  // takedown. The single bulk UPDATE replaces the route's per-report loop (N+1).
+  async takedownArtifact(input: TakedownInput): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      await tx
+        .update(artifact)
+        .set({ removed_at: input.removedAt })
+        .where(eq(artifact.id, input.artifactId))
+      await tx
+        .update(report)
+        .set({ state: "actioned" })
+        .where(
+          and(
+            eq(report.artifact_id, input.artifactId),
+            eq(report.org_id, input.orgId),
+            eq(report.state, "open"),
+          ),
+        )
+      await tx.insert(auditLog).values(input.audit)
+    })
   }
   listAuditLog(
     orgId: string | undefined,

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -39,6 +39,7 @@ import type {
   ReportState,
   RepoSourceRecord,
   Role,
+  TakedownInput,
   VersionRecord,
   Visibility,
   WebhookRecord,
@@ -979,6 +980,28 @@ export function makeRepos(db: SqliteDb) {
   const createAuditLog = async (a: NewAuditLog): Promise<void> => {
     await db.insert(auditLog).values(a).run()
   }
+  // Sequential takedown (used by D1, which has no multi-statement transaction in
+  // this driver). better-sqlite3 + pg override this with a real transaction; the
+  // single bulk report UPDATE (vs the old per-report loop) is the same here.
+  const takedownArtifact = async (input: TakedownInput): Promise<void> => {
+    await db
+      .update(artifact)
+      .set({ removed_at: input.removedAt })
+      .where(eq(artifact.id, input.artifactId))
+      .run()
+    await db
+      .update(report)
+      .set({ state: "actioned" })
+      .where(
+        and(
+          eq(report.artifact_id, input.artifactId),
+          eq(report.org_id, input.orgId),
+          eq(report.state, "open"),
+        ),
+      )
+      .run()
+    await db.insert(auditLog).values(input.audit).run()
+  }
   const listAuditLog = async (
     orgId: string | undefined,
     opts?: { artifactId?: string; limit?: number },
@@ -1093,6 +1116,7 @@ export function makeRepos(db: SqliteDb) {
     countOpenReports,
     setReportState,
     createAuditLog,
+    takedownArtifact,
     listAuditLog,
   }
 }

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -1,15 +1,17 @@
 import type { MetaStore, NewVersion, UserDir, VersionRecord, ViewStats } from "@dock/core"
 import Database from "better-sqlite3"
-import { eq } from "drizzle-orm"
+import { and, eq } from "drizzle-orm"
 import { drizzle } from "drizzle-orm/better-sqlite3"
 import { makeRepos, schema } from "./repos"
 import {
   artifact,
   artifactTag,
+  auditLog,
   collection,
   collectionItem,
   collectionMember,
   MIGRATION_STATEMENTS,
+  report,
   SCHEMA_STATEMENTS,
   version,
 } from "./schema"
@@ -82,6 +84,29 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
         db.delete(collectionItem).where(eq(collectionItem.collection_id, id)).run()
         db.delete(collectionMember).where(eq(collectionMember.collection_id, id)).run()
         db.delete(collection).where(eq(collection.id, id)).run()
+      })()
+    },
+
+    // Atomic takedown: the tombstone, the bulk open-report resolution, and the
+    // audit entry commit together (or not at all), so a crash mid-takedown can't
+    // leave an artifact removed with its reports still open or no audit trail.
+    takedownArtifact: async (input): Promise<void> => {
+      raw.transaction(() => {
+        db.update(artifact)
+          .set({ removed_at: input.removedAt })
+          .where(eq(artifact.id, input.artifactId))
+          .run()
+        db.update(report)
+          .set({ state: "actioned" })
+          .where(
+            and(
+              eq(report.artifact_id, input.artifactId),
+              eq(report.org_id, input.orgId),
+              eq(report.state, "open"),
+            ),
+          )
+          .run()
+        db.insert(auditLog).values(input.audit).run()
       })()
     },
 

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -483,5 +483,56 @@ export function runStoreContract(
       const log = await store.listAuditLog(ORG, { artifactId: a.id })
       expect(log.map((x) => x.action)).toContain("takedown")
     })
+
+    it("takedownArtifact applies the tombstone, resolves open reports, and audits atomically", async () => {
+      const a = await store.createArtifact(newArtifact())
+      // Two open reports against this artifact, plus one against another that must
+      // be left untouched (the bulk resolve is scoped to the target artifact).
+      const r1 = await store.createReport({
+        id: uuid(),
+        org_id: ORG,
+        artifact_id: a.id,
+        artifact_short_id: a.short_id,
+        reason: "spam",
+      })
+      const r2 = await store.createReport({
+        id: uuid(),
+        org_id: ORG,
+        artifact_id: a.id,
+        artifact_short_id: a.short_id,
+        reason: "abuse",
+      })
+      const other = await store.createArtifact(newArtifact())
+      const rOther = await store.createReport({
+        id: uuid(),
+        org_id: ORG,
+        artifact_id: other.id,
+        artifact_short_id: other.short_id,
+        reason: "unrelated",
+      })
+
+      await store.takedownArtifact({
+        artifactId: a.id,
+        orgId: ORG,
+        removedAt: "2026-06-14T00:00:00.000Z",
+        audit: {
+          id: uuid(),
+          org_id: ORG,
+          action: "takedown",
+          artifact_id: a.id,
+          actor: "amy",
+          detail: "policy",
+        },
+      })
+
+      // Tombstone set, both of this artifact's reports actioned, the other left open.
+      expect((await store.getArtifactById(a.id))?.removed_at).toBe("2026-06-14T00:00:00.000Z")
+      expect((await store.getReport(r1.id, ORG))?.state).toBe("actioned")
+      expect((await store.getReport(r2.id, ORG))?.state).toBe("actioned")
+      expect((await store.getReport(rOther.id, ORG))?.state).toBe("open")
+      // The audit entry landed in the same step.
+      const log = await store.listAuditLog(ORG, { artifactId: a.id })
+      expect(log.map((x) => x.action)).toContain("takedown")
+    })
   })
 }

--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,6 @@
     "dockerfilePath": "deploy/Dockerfile"
   },
   "deploy": {
-    "startCommand": "pnpm --filter @dock/api start",
     "healthcheckPath": "/readyz",
     "healthcheckTimeout": 30,
     "restartPolicyType": "ON_FAILURE",

--- a/scripts/check-bundle.mjs
+++ b/scripts/check-bundle.mjs
@@ -1,24 +1,56 @@
 #!/usr/bin/env node
-// Bundle budget. The web client's JS is gzipped and summed; a big jump (a stray
-// eager import of phosphor / radix / cmdk, a fat new dep) trips the budget so it
-// can't land silently. Run `pnpm --filter @dock/web build` first — this reads the
-// emitted client chunks. Budgets carry ~25% headroom over the real numbers at
-// the time of writing; raise them deliberately (in a PR) when a feature earns it.
+// Bundle budget. The real cost that matters is the CRITICAL PATH: the JS the
+// browser must download before the app is interactive — the entry chunk plus the
+// closure of its STATIC imports (react-vendor, the API client, the runtime).
+// Route chunks behind a dynamic `import()` (the CodeMirror editor, per-route
+// pages) are lazy: a visitor who never opens that surface never pays for them, so
+// they don't belong in the same budget as the first paint.
+//
+// So this gates two things hard — the eager total and any single chunk — and
+// reports the lazy/aggregate weight for visibility without failing on it (a CDN
+// serves the client with multi-MB of room; the point is catching an ACCIDENT, a
+// fat dep landing EAGERLY, not policing on-demand features). Run
+// `pnpm --filter @dock/web build` first; it emits the manifest this reads.
 import { readdirSync, readFileSync } from "node:fs"
 import { join } from "node:path"
 import { gzipSync } from "node:zlib"
 
-const ASSETS = join(process.cwd(), "apps/web/dist/client/assets")
+const CLIENT = join(process.cwd(), "apps/web/dist/client")
+const ASSETS = join(CLIENT, "assets")
+const MANIFEST = join(CLIENT, ".vite/manifest.json")
 
-// This is a tripwire for ACCIDENTS (a stray `import * from "phosphor"`, a fat dep
-// landing eagerly), not a perf diet. Cloudflare gives the client assets multi-MB
-// of room, so the absolute numbers are loose on purpose — generous headroom over
-// the real figures (~259 kB total / ~113 kB largest at the time of writing) so a
-// normal dep doesn't trip it, but a sudden balloon does. Bump deliberately when a
-// feature earns it. The single-chunk budget is the sharper signal: a fat eager
-// import shows up as one chunk blowing past, not as broad creep.
-const TOTAL_BUDGET = 450 * 1024
+// The eager budget sits generously over the measured critical path (~186 kB at
+// the time of writing) — room for the first-paint surface to grow before this
+// trips. The single-chunk budget is the sharper tripwire for one fat dep (eager
+// or lazy); the aggregate is a loose backstop only. Raise any of these
+// deliberately (in a PR) when a feature earns it.
+const EAGER_BUDGET = 300 * 1024
 const CHUNK_BUDGET = 180 * 1024
+const TOTAL_BACKSTOP = 800 * 1024
+
+let manifest
+try {
+  manifest = JSON.parse(readFileSync(MANIFEST, "utf8"))
+} catch {
+  console.error(
+    `bundle: no client manifest at ${MANIFEST}\n` +
+      "  Run `pnpm --filter @dock/web build` first (needs build.manifest in vite.config).",
+  )
+  process.exit(1)
+}
+
+// The eager set: every chunk reachable from an entry through STATIC imports only.
+// `dynamicImports` (lazy route chunks) are deliberately not followed.
+const eagerKeys = new Set()
+const walk = (key) => {
+  if (eagerKeys.has(key) || !manifest[key]) return
+  eagerKeys.add(key)
+  for (const imp of manifest[key].imports ?? []) walk(imp)
+}
+for (const [key, chunk] of Object.entries(manifest)) if (chunk.isEntry) walk(key)
+const eagerFiles = new Set(
+  [...eagerKeys].map((k) => manifest[k].file).filter((f) => f?.endsWith(".js")),
+)
 
 let files
 try {
@@ -30,35 +62,43 @@ try {
   process.exit(1)
 }
 
+let eager = 0
 let total = 0
 let biggest = { file: "", gz: 0 }
 const rows = files
   .map((f) => {
     const gz = gzipSync(readFileSync(join(ASSETS, f)), { level: 9 }).length
     total += gz
+    if (eagerFiles.has(`assets/${f}`)) eager += gz
     if (gz > biggest.gz) biggest = { file: f, gz }
-    return { f, gz }
+    return { f, gz, eager: eagerFiles.has(`assets/${f}`) }
   })
   .sort((a, b) => b.gz - a.gz)
 
 const kb = (n) => `${(n / 1024).toFixed(1)} kB`
-const overTotal = total > TOTAL_BUDGET
+const overEager = eager > EAGER_BUDGET
 const overChunk = biggest.gz > CHUNK_BUDGET
+const overTotal = total > TOTAL_BACKSTOP
 
-console.log("bundle: gzipped client JS")
-for (const r of rows.slice(0, 6)) console.log(`  ${kb(r.gz).padStart(9)}  ${r.f}`)
-console.log(`  ${"…".padStart(9)}  (${files.length} chunks total)`)
-console.log(`  total:   ${kb(total)} / ${kb(TOTAL_BUDGET)} budget`)
+console.log("bundle: gzipped client JS (▸ = eager / critical path)")
+for (const r of rows.slice(0, 8))
+  console.log(`  ${r.eager ? "▸" : " "} ${kb(r.gz).padStart(9)}  ${r.f}`)
+console.log(`  ${"…".padStart(11)}  (${files.length} chunks total)`)
+console.log(`  eager:   ${kb(eager)} / ${kb(EAGER_BUDGET)} budget   (critical path)`)
+console.log(`  lazy:    ${kb(total - eager)}   (on-demand route chunks)`)
+console.log(`  total:   ${kb(total)} / ${kb(TOTAL_BACKSTOP)} backstop`)
 console.log(`  largest: ${kb(biggest.gz)} (${biggest.file}) / ${kb(CHUNK_BUDGET)} budget`)
 
-if (overTotal || overChunk) {
+if (overEager || overChunk || overTotal) {
   console.error("\nbundle: OVER BUDGET")
-  if (overTotal) console.error(`  total ${kb(total)} exceeds ${kb(TOTAL_BUDGET)}`)
+  if (overEager) console.error(`  eager critical path ${kb(eager)} exceeds ${kb(EAGER_BUDGET)}`)
   if (overChunk)
     console.error(`  chunk ${biggest.file} ${kb(biggest.gz)} exceeds ${kb(CHUNK_BUDGET)}`)
+  if (overTotal) console.error(`  total ${kb(total)} exceeds the ${kb(TOTAL_BACKSTOP)} backstop`)
   console.error(
-    "\n  Trim the import (lazy-load it, or import the specific symbol),\n" +
-      "  or raise the budget in scripts/check-bundle.mjs if the weight is justified.",
+    "\n  If it's eager: lazy-load it (`lazy(() => import(...))`) or import the\n" +
+      "  specific symbol. If the weight is justified, raise the budget in\n" +
+      "  scripts/check-bundle.mjs.",
   )
   process.exit(1)
 }


### PR DESCRIPTION
The deploy/ops robustness items from the latest review (the tech leg scoped out of #143), plus a bundle-budget fix.

## Ops
- **Transactional takedown.** New `MetaStore.takedownArtifact` tombstones the artifact, bulk-resolves every open report (one `UPDATE`, not a per-report loop), and writes the audit entry in a single transaction (sqlite + pg overrides; sequential for D1). The route was non-atomic + N+1. Contract test covers atomicity + scoping on both dialects.
- **`/v1/vitals` collector.** The SPA beacons real Core Web Vitals (LCP/INP/CLS/TTFB) to a structure-logging endpoint; the web beacon now defaults same-origin instead of needing `VITE_VITALS_URL`. Anonymous (allow-listed in the write lockdown).
- **Real `/readyz` probe.** Uses a valid 64-hex sentinel key so it does real blob I/O — a non-hex key short-circuits to `null` and never touches the backend (the old probe was a no-op). Regression test for a down blob store.
- **Password-unlock limiter.** Dedicated 10/min cap instead of sharing the lenient 120/min global write budget (credential-guessing surface).
- **`railway.json` SIGTERM fix.** Drop the `startCommand` override so the Dockerfile CMD runs node as PID 1 (pnpm doesn't forward SIGTERM → no graceful drain).
- **e2e-smoke as a pre-merge gate.** Also runs on `pull_request`, not just post-merge.

## Bundle budget
The budget summed every chunk, so the lazily-loaded CodeMirror editor (171 kB, only fetched when editing source) squeezed a gate meant to catch eager bloat. Now enables `build.manifest` and splits by the static-import graph:
- **eager** (entry + static-import closure, ~186 kB): hard critical-path gate at 300 kB.
- **per-chunk** (180 kB): still hard, catches one fat dep whether eager or lazy.
- **total**: demoted to a loose 800 kB backstop, reported for visibility.

## Verification
typecheck · `pnpm run ci` · 276 api + 48 db tests on **SQLite and Postgres** · coverage gates (api/db/core) · web build + bundle · e2e smoke (9 passed). `origin/main` merged in (cursors/comments/oauth-cli) and re-verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)