### PR TITLE
fix(api): tighten password-unlock limiter to 5 per 5 minutes

### DIFF
--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -174,8 +174,9 @@ export function buildContext(deps: AppDeps) {
   const commentLimiter = deps.rateLimit ? makeKeyedLimiter(60_000, deps.commentRate ?? 60) : null
   // Password unlock is a credential-guessing surface, so it gets a much tighter
   // cap than the lenient global /v1 write limiter (120/min) it would otherwise
-  // share: 10 attempts/min per caller (IP, when anonymous) bounds brute force.
-  const unlockLimiter = deps.rateLimit ? makeKeyedLimiter(60_000, 10) : null
+  // share: 5 attempts per 5 minutes per caller (IP, when anonymous) — enough for
+  // a legit fat-finger, slow enough that brute force is hopeless.
+  const unlockLimiter = deps.rateLimit ? makeKeyedLimiter(5 * 60_000, 5) : null
 
   // Fan an event to subscribed webhooks (enqueues to the outbox; the worker
   // delivers). Awaited so the row is durable before we respond, but never fatal.

--- a/apps/api/test/quotas.test.ts
+++ b/apps/api/test/quotas.test.ts
@@ -60,7 +60,7 @@ describe("rate limits: per-actor write throttles (C4b)", () => {
     expect((await comment()).status).toBe(429)
   })
 
-  it("throttles password-unlock attempts with a tight dedicated cap (10/min)", async () => {
+  it("throttles password-unlock attempts with a tight dedicated cap (5 per 5 min)", async () => {
     const { app } = quotaApp("rl-unlock", { rateLimit: true })
     const form = new FormData()
     form.append("file", new Blob([new TextEncoder().encode("<h1>x</h1>")]), "x.html")
@@ -70,7 +70,7 @@ describe("rate limits: per-actor write throttles (C4b)", () => {
       await app.request("/v1/artifacts", { method: "POST", body: form, headers: bearer("tok") })
     ).json()
     // Anonymous wrong-password attempts: the limiter runs before the password
-    // check, so each counts. Ten are allowed (401 wrong-password), the 11th 429s —
+    // check, so each counts. Five are allowed (401 wrong-password), the 6th 429s —
     // far below the lenient 120/min global write cap this used to share.
     const attempt = () =>
       app.request(`/v1/artifacts/${a.short_id}/unlock`, {
@@ -78,7 +78,7 @@ describe("rate limits: per-actor write throttles (C4b)", () => {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ password: "wrong" }),
       })
-    for (let i = 0; i < 10; i++) expect((await attempt()).status).toBe(401)
+    for (let i = 0; i < 5; i++) expect((await attempt()).status).toBe(401)
     const blocked = await attempt()
     expect(blocked.status).toBe(429)
     expect(blocked.headers.get("Retry-After")).toBeTruthy()


### PR DESCRIPTION
Follow-up to #148. The dedicated password-unlock limiter was 10/min — still loose for a credential-guessing surface. Tighten to **5 attempts per 5-minute window** per caller (IP when anonymous): enough for a legitimate fat-finger, slow enough that brute force is hopeless.

`makeKeyedLimiter(5 * 60_000, 5)`, active only when rate-limiting is on (hosted tier). Test updated (5 allowed → 6th 429s).

Verified: typecheck, `pnpm run ci`, 276 api tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)