### PR TITLE
feat(comments): graceful mobile commenting (tap-a-paragraph + bottom bar)

### DIFF
--- a/apps/web/e2e/deep/comments-mobile.deep.spec.ts
+++ b/apps/web/e2e/deep/comments-mobile.deep.spec.ts
@@ -1,0 +1,52 @@
+import { devices, expect, test } from "@playwright/test"
+import { publishArtifact, signUp } from "../helpers"
+
+// Mobile commenting: a tap on a paragraph (no fiddly drag-select fighting the iOS
+// menu) anchors a comment there and surfaces the bottom action bar, which opens
+// the sheet composer pinned to that block. Pixel 7 = a chromium touch profile, the
+// same touch + mobile-viewport path real phones hit.
+test.use({ ...devices["Pixel 7"] })
+
+test("tap a paragraph to comment: bar + composer, anchored to the block", async ({ page }) => {
+  await signUp(page)
+  const shortId = await publishArtifact(
+    page,
+    "m.md",
+    "# Mobile\n\nFirst paragraph, short.\n\nSecond paragraph here with enough text to anchor a comment onto cleanly on a phone.",
+  )
+  await page.goto(`/a/${shortId}`)
+  // Let the sandbox iframe load + the anchor client wire up.
+  await page.waitForTimeout(2000)
+
+  // Tap a paragraph in the document; the bottom bar appears with that block quoted.
+  await page.frameLocator("iframe").getByText("Second paragraph here").tap()
+  const bar = page.getByTestId("mobile-comment-bar")
+  await expect(bar).toBeVisible()
+  await expect(bar).toContainText("Second paragraph here")
+
+  // Comment opens the sheet composer, quoting the tapped block.
+  await page.getByTestId("mobile-comment-start").tap()
+  await expect(page.getByTestId("composer-input")).toBeVisible()
+  await expect(page.getByText("Second paragraph here", { exact: false }).first()).toBeVisible()
+
+  // Posting lands the anchored comment.
+  await page.getByTestId("composer-input").fill("Looks good on mobile.")
+  await page.getByTestId("composer-submit").tap()
+  await expect(page.getByText("Looks good on mobile.")).toBeVisible()
+})
+
+test("the bottom bar dismisses without commenting", async ({ page }) => {
+  await signUp(page)
+  const shortId = await publishArtifact(
+    page,
+    "m.md",
+    "# Doc\n\nA paragraph to tap and then dismiss.",
+  )
+  await page.goto(`/a/${shortId}`)
+  await page.waitForTimeout(2000)
+
+  await page.frameLocator("iframe").getByText("A paragraph to tap").tap()
+  await expect(page.getByTestId("mobile-comment-bar")).toBeVisible()
+  await page.getByTestId("mobile-comment-dismiss").tap()
+  await expect(page.getByTestId("mobile-comment-bar")).toHaveCount(0)
+})

--- a/apps/web/e2e/deep/comments-mobile.deep.spec.ts
+++ b/apps/web/e2e/deep/comments-mobile.deep.spec.ts
@@ -50,3 +50,28 @@ test("the bottom bar dismisses without commenting", async ({ page }) => {
   await page.getByTestId("mobile-comment-dismiss").tap()
   await expect(page.getByTestId("mobile-comment-bar")).toHaveCount(0)
 })
+
+test("tapping out collapses the sheet to a peek bar, and it reopens", async ({ page }) => {
+  await signUp(page)
+  const shortId = await publishArtifact(page, "m.md", "# Doc\n\nA paragraph to comment on here.")
+  await page.goto(`/a/${shortId}`)
+  await page.waitForTimeout(2000)
+
+  // Comment on a paragraph and post, so the (full-height) sheet holds a card.
+  await page.frameLocator("iframe").getByText("A paragraph to comment").tap()
+  await page.getByTestId("mobile-comment-start").tap()
+  await page.getByTestId("composer-input").fill("First note.")
+  await page.getByTestId("composer-submit").tap()
+  await expect(page.getByText("First note.")).toBeVisible()
+
+  // Tap out (the dimmed strip above the full-height sheet) -> collapse to the peek
+  // bar: body gone, header bar stays, the resize control flips to Expand.
+  await page.getByTestId("comments-sheet-backdrop").tap({ position: { x: 180, y: 36 } })
+  await expect(page.getByText("First note.")).toHaveCount(0)
+  await expect(page.getByText("Comments", { exact: true })).toBeVisible()
+  await expect(page.getByTestId("comments-sheet-resize")).toHaveAttribute("title", "Expand")
+
+  // Tap the peek bar's expand control -> the list comes back.
+  await page.getByTestId("comments-sheet-resize").tap()
+  await expect(page.getByText("First note.")).toBeVisible()
+})

--- a/apps/web/src/pages/artifact/artifact-comments.tsx
+++ b/apps/web/src/pages/artifact/artifact-comments.tsx
@@ -138,10 +138,11 @@ export function ArtifactComments(p: {
           onCancelNew={cancelNew}
         />
       )}
-      {/* The "comment on selection" affordance floats beside the selection in every
-          panel state. Clicking it opens the panel if needed and starts a composer
-          pinned to the selection. Logged-in only. */}
-      {!isAnon && p.docLive && sel && !p.composer && (
+      {/* Desktop: the "comment on selection" pill floats beside the selection (the
+          mouse can reach it and there is no native callout in the way). On phones
+          this would land under iOS's own selection menu, so mobile uses the bottom
+          bar below instead. Clicking opens the panel and starts a pinned composer. */}
+      {!isMobile && !isAnon && p.docLive && sel && !p.composer && (
         <button
           type="button"
           className="fixed z-50 inline-flex items-center gap-2 whitespace-nowrap rounded-full border border-primary bg-card px-3.5 py-2 text-sm font-semibold text-primary shadow-[var(--shadow)] transition-colors hover:bg-primary hover:text-primary-foreground"
@@ -165,6 +166,40 @@ export function ArtifactComments(p: {
         >
           <Icon name="comments" size={16} /> Comment
         </button>
+      )}
+      {/* Phones: a selection (drag) OR a tapped paragraph surfaces this bottom bar,
+          pinned below iOS's own selection menu and big enough to thumb. It shows
+          the quote so you know what you're attaching to; Comment opens the sheet
+          composer, ✕ clears the selection. */}
+      {isMobile && !isAnon && p.docLive && sel && !p.composer && (
+        <div
+          data-testid="mobile-comment-bar"
+          className="fixed inset-x-0 bottom-0 z-[62] flex items-center gap-2.5 border-t border-border bg-card px-3 pb-[max(12px,env(safe-area-inset-bottom))] pt-3 shadow-[0_-12px_36px_-16px_rgba(0,0,0,0.55)]"
+        >
+          <span className="min-w-0 flex-1 truncate border-l-[3px] border-primary bg-accent px-2.5 py-1.5 text-xs italic text-foreground">
+            “{sel.selector.exact}”
+          </span>
+          <button
+            type="button"
+            data-testid="mobile-comment-start"
+            onClick={() => {
+              p.setPanel("open")
+              p.startSelComment()
+            }}
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground"
+          >
+            <Icon name="comments" size={15} /> Comment
+          </button>
+          <button
+            type="button"
+            aria-label="Dismiss selection"
+            data-testid="mobile-comment-dismiss"
+            onClick={() => p.setSel(null)}
+            className="grid size-9 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-hover"
+          >
+            ✕
+          </button>
+        </div>
       )}
     </CommentScopeProvider>
   )

--- a/apps/web/src/pages/artifact/artifact-comments.tsx
+++ b/apps/web/src/pages/artifact/artifact-comments.tsx
@@ -174,7 +174,7 @@ export function ArtifactComments(p: {
       {isMobile && !isAnon && p.docLive && sel && !p.composer && (
         <div
           data-testid="mobile-comment-bar"
-          className="fixed inset-x-0 bottom-0 z-[62] flex items-center gap-2.5 border-t border-border bg-card px-3 pb-[max(12px,env(safe-area-inset-bottom))] pt-3 shadow-[0_-12px_36px_-16px_rgba(0,0,0,0.55)]"
+          className="fixed inset-x-0 bottom-0 z-[62] flex items-center gap-2.5 border-t border-border bg-card px-3 pb-[max(16px,env(safe-area-inset-bottom))] pt-4 shadow-[0_-12px_36px_-16px_rgba(0,0,0,0.55)]"
         >
           <span className="min-w-0 flex-1 truncate border-l-[3px] border-primary bg-accent px-2.5 py-1.5 text-xs italic text-foreground">
             “{sel.selector.exact}”

--- a/apps/web/src/pages/artifact/artifact-comments.tsx
+++ b/apps/web/src/pages/artifact/artifact-comments.tsx
@@ -195,9 +195,9 @@ export function ArtifactComments(p: {
             aria-label="Dismiss selection"
             data-testid="mobile-comment-dismiss"
             onClick={() => p.setSel(null)}
-            className="grid size-9 shrink-0 place-items-center rounded-md text-lg text-muted-foreground transition-colors hover:bg-hover"
+            className="grid size-9 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-hover"
           >
-            ✕
+            <Icon name="close" size={20} />
           </button>
         </div>
       )}

--- a/apps/web/src/pages/artifact/artifact-comments.tsx
+++ b/apps/web/src/pages/artifact/artifact-comments.tsx
@@ -188,14 +188,14 @@ export function ArtifactComments(p: {
             }}
             className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground"
           >
-            <Icon name="comments" size={15} /> Comment
+            <Icon name="comments" size={17} /> Comment
           </button>
           <button
             type="button"
             aria-label="Dismiss selection"
             data-testid="mobile-comment-dismiss"
             onClick={() => p.setSel(null)}
-            className="grid size-9 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-hover"
+            className="grid size-9 shrink-0 place-items-center rounded-md text-lg text-muted-foreground transition-colors hover:bg-hover"
           >
             ✕
           </button>

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -45,19 +45,23 @@ export function MobileComments({
   onSubmitNew: (text: string, mentions?: Mention[]) => void
   onCancelNew: () => void
 }) {
-  // Half by default (document visible above). Reset to half each time it opens;
-  // a composer wants room, so expand to full automatically.
-  const [full, setFull] = useState(false)
+  // Three heights: peek (a slim bar you tap to reopen), half (document visible
+  // above), full. Reset to half on each open; a composer wants room so it expands
+  // to full; and tapping out (the full-height backdrop) collapses to the peek bar
+  // rather than closing outright, so comments stay one tap away.
+  const [size, setSize] = useState<"peek" | "half" | "full">("half")
   useEffect(() => {
-    if (open) setFull(false)
+    if (open) setSize("half")
   }, [open])
   useEffect(() => {
-    if (open && composer) setFull(true)
+    if (open && composer) setSize("full")
   }, [open, composer])
   const empty = openThreads.length === 0 && resolved.length === 0 && !composer
-  // Jumping to text: collapse to half so the highlight lands in the visible doc.
+  // The grip taps bigger; full wraps back to half. The chevron handles peek.
+  const grip = () => setSize((s) => (s === "peek" ? "half" : s === "half" ? "full" : "half"))
+  // Jumping to text: drop to half so the highlight lands in the visible doc.
   const jumpToText = (id: string) => {
-    setFull(false)
+    setSize("half")
     onJump(id)
   }
   return (
@@ -67,28 +71,29 @@ export function MobileComments({
       <button
         type="button"
         data-testid="comments-sheet-backdrop"
-        aria-label="Close comments"
-        tabIndex={open && full ? 0 : -1}
-        onClick={onClose}
+        aria-label="Collapse comments"
+        tabIndex={open && size === "full" ? 0 : -1}
+        onClick={() => setSize("peek")}
         className={cn(
           "fixed inset-0 z-[60] bg-black/35 transition-opacity",
-          open && full ? "opacity-100" : "pointer-events-none opacity-0",
+          open && size === "full" ? "opacity-100" : "pointer-events-none opacity-0",
         )}
       />
       <div
         className={cn(
           "fixed inset-x-0 bottom-0 z-[61] flex flex-col rounded-t-[18px] border-t border-border bg-card shadow-[0_-14px_44px_-18px_rgba(0,0,0,0.5)] transition-[transform,height] duration-[260ms]",
-          full ? "h-[88vh]" : "h-[50vh]",
+          size === "full" ? "h-[88vh]" : size === "peek" ? "h-[56px]" : "h-[50vh]",
           open ? "translate-y-0" : "translate-y-full",
         )}
         role="dialog"
         aria-label="Comments"
       >
-        {/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: grip toggles height; ✕ closes. */}
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: grip resizes the sheet; ✕ closes. */}
         <div
+          data-testid="comments-sheet-grip"
           className="mx-auto mb-1 mt-[9px] h-1 w-10 shrink-0 cursor-grab rounded-full bg-border"
-          onClick={() => setFull((f) => !f)}
-          title={full ? "Collapse" : "Expand"}
+          onClick={grip}
+          title="Resize"
         />
         <div className="flex items-center gap-2 border-b border-border-soft pb-2.5 pl-3.5 pr-2.5 pt-1">
           <b className="text-base">Comments</b>
@@ -103,71 +108,77 @@ export function MobileComments({
             size="sm"
             data-testid="comments-sheet-new"
             onClick={() => {
-              setFull(true)
+              setSize("full")
               onNewGeneral()
             }}
           >
             ＋ New
           </Button>
-          <IconBtn title={full ? "Collapse" : "Expand"} onClick={() => setFull((f) => !f)}>
-            {full ? "▾" : "▴"}
+          <IconBtn
+            title={size === "peek" ? "Expand" : "Collapse"}
+            testId="comments-sheet-resize"
+            onClick={() => setSize(size === "peek" ? "half" : "peek")}
+          >
+            {size === "peek" ? "▴" : "▾"}
           </IconBtn>
           <IconBtn title="Close comments" onClick={onClose}>
             ✕
           </IconBtn>
         </div>
-        <div className="min-h-0 flex-1 overflow-auto p-3 pb-[max(14px,env(safe-area-inset-bottom))]">
-          {composer && (
-            <div className="mb-3">
-              <Composer
-                quote={composer.anchor?.exact ?? null}
-                onSubmit={onSubmitNew}
-                onCancel={onCancelNew}
-              />
-            </div>
-          )}
-          {empty && (
-            <div className="grid place-items-center gap-2 p-[34px] text-center">
-              <div className="text-3xl opacity-50">💬</div>
-              <div className="text-sm leading-relaxed text-muted-foreground">
-                No comments yet.
-                <br />
-                Select text in the document to start one.
-              </div>
-            </div>
-          )}
-          {openThreads.map((t) => {
-            const head = t[0]
-            if (!head) return null
-            return (
-              <div key={head.thread_id} className="mb-2.5">
-                <CommentCard
-                  thread={t}
-                  active={activeThread === head.thread_id}
-                  hovered={false}
-                  present={inDoc[head.thread_id]}
-                  onActivate={onActivate}
-                  onHover={() => {}}
-                  onResolve={onResolve}
-                  onReply={onReply}
-                  onJump={jumpToText}
+        {size !== "peek" && (
+          <div className="min-h-0 flex-1 overflow-auto p-3 pb-[max(14px,env(safe-area-inset-bottom))]">
+            {composer && (
+              <div className="mb-3">
+                <Composer
+                  quote={composer.anchor?.exact ?? null}
+                  onSubmit={onSubmitNew}
+                  onCancel={onCancelNew}
                 />
               </div>
-            )
-          })}
-          {resolved.length > 0 && (
-            <ResolvedSection
-              threads={resolved}
-              activeThread={activeThread}
-              hoverThread={null}
-              onActivate={onActivate}
-              onHover={() => {}}
-              onResolve={onResolve}
-              onReply={onReply}
-              onJump={jumpToText}
-            />
-          )}
-        </div>
+            )}
+            {empty && (
+              <div className="grid place-items-center gap-2 p-[34px] text-center">
+                <div className="text-3xl opacity-50">💬</div>
+                <div className="text-sm leading-relaxed text-muted-foreground">
+                  No comments yet.
+                  <br />
+                  Select text in the document to start one.
+                </div>
+              </div>
+            )}
+            {openThreads.map((t) => {
+              const head = t[0]
+              if (!head) return null
+              return (
+                <div key={head.thread_id} className="mb-2.5">
+                  <CommentCard
+                    thread={t}
+                    active={activeThread === head.thread_id}
+                    hovered={false}
+                    present={inDoc[head.thread_id]}
+                    onActivate={onActivate}
+                    onHover={() => {}}
+                    onResolve={onResolve}
+                    onReply={onReply}
+                    onJump={jumpToText}
+                  />
+                </div>
+              )
+            })}
+            {resolved.length > 0 && (
+              <ResolvedSection
+                threads={resolved}
+                activeThread={activeThread}
+                hoverThread={null}
+                onActivate={onActivate}
+                onHover={() => {}}
+                onResolve={onResolve}
+                onReply={onReply}
+                onJump={jumpToText}
+              />
+            )}
+          </div>
+        )}
       </div>
     </>
   )

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -83,7 +83,7 @@ export function MobileComments({
       <div
         className={cn(
           "fixed inset-x-0 bottom-0 z-[61] flex flex-col rounded-t-[18px] border-t border-border bg-card shadow-[0_-14px_44px_-18px_rgba(0,0,0,0.5)] transition-[transform,height] duration-[260ms]",
-          size === "full" ? "h-[88vh]" : size === "peek" ? "h-[56px]" : "h-[50vh]",
+          size === "full" ? "h-[88vh]" : size === "peek" ? "h-[74px]" : "h-[50vh]",
           open ? "translate-y-0" : "translate-y-full",
         )}
         role="dialog"
@@ -96,7 +96,7 @@ export function MobileComments({
           onClick={grip}
           title="Resize"
         />
-        <div className="flex items-center gap-2 border-b border-border-soft pb-2.5 pl-3.5 pr-2.5 pt-1">
+        <div className="flex items-center gap-2 border-b border-border-soft pb-3 pl-3.5 pr-2.5 pt-2">
           <b className="text-base">Comments</b>
           {openCount > 0 && (
             <span className="rounded-full bg-accent px-2 py-px font-mono text-2xs font-bold text-primary">

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -115,13 +115,14 @@ export function MobileComments({
             ＋ New
           </Button>
           <IconBtn
+            big
             title={size === "peek" ? "Expand" : "Collapse"}
             testId="comments-sheet-resize"
             onClick={() => setSize(size === "peek" ? "half" : "peek")}
           >
             {size === "peek" ? "▴" : "▾"}
           </IconBtn>
-          <IconBtn title="Close comments" onClick={onClose}>
+          <IconBtn big title="Close comments" onClick={onClose}>
             ✕
           </IconBtn>
         </div>

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react"
 import type { Comment, Mention } from "@/api"
+import { Icon } from "@/components/icons"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import {
@@ -120,10 +121,10 @@ export function MobileComments({
             testId="comments-sheet-resize"
             onClick={() => setSize(size === "peek" ? "half" : "peek")}
           >
-            {size === "peek" ? "▴" : "▾"}
+            <Icon name="caret" size={20} className={size === "peek" ? "rotate-180" : undefined} />
           </IconBtn>
           <IconBtn big title="Close comments" onClick={onClose}>
-            ✕
+            <Icon name="close" size={20} />
           </IconBtn>
         </div>
         {size !== "peek" && (

--- a/apps/web/src/pages/artifact/rail-deck.tsx
+++ b/apps/web/src/pages/artifact/rail-deck.tsx
@@ -85,11 +85,14 @@ export function IconBtn({
   onClick,
   children,
   testId,
+  big,
 }: {
   title: string
   onClick: () => void
   children: React.ReactNode
   testId?: string
+  /** A bigger target + glyph for thumbs (the mobile sheet controls). */
+  big?: boolean
 }) {
   return (
     <button
@@ -98,7 +101,10 @@ export function IconBtn({
       title={title}
       aria-label={title}
       onClick={onClick}
-      className="grid size-[26px] place-items-center rounded-md text-muted-foreground transition-colors hover:bg-hover hover:text-foreground"
+      className={cn(
+        "grid place-items-center rounded-md text-muted-foreground transition-colors hover:bg-hover hover:text-foreground",
+        big ? "size-9 text-lg" : "size-[26px]",
+      )}
     >
       {children}
     </button>

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -68,7 +68,9 @@ function scrollTop(){return window.scrollY||document.documentElement.scrollTop||
       on-screen rect of the selection, so the host can float a button beside it -- */
 function emitSelection(){
   var s=window.getSelection(),t=s?s.toString().trim():"";
-  if(!t||t.length<2){post({type:"select",selector:null,rect:null});return}
+  // A tap fires a synthesized mouseup with no selection; don't let it clear the
+  // block anchor we just placed (tapGuard, set in the touch handler below).
+  if(!t||t.length<2){if(Date.now()-tapGuard<600)return;post({type:"select",selector:null,rect:null});return}
   var ctx=(s.anchorNode&&s.anchorNode.textContent)||t,i=ctx.indexOf(t);
   var rect=null;try{var r=s.getRangeAt(0).getBoundingClientRect();
     if(r&&(r.height||r.width))rect={top:r.top,bottom:r.bottom,left:r.left,right:r.right}}catch(_){}
@@ -76,8 +78,42 @@ function emitSelection(){
     prefix:i>=0?ctx.slice(Math.max(0,i-24),i):"",
     suffix:i>=0?ctx.slice(i+t.length,i+t.length+24):""}})}
 document.addEventListener("mouseup",function(){setTimeout(emitSelection,0)});
+
+/* Touch makes "select a phrase, then find a tiny floating button" miserable, and
+   iOS pops its own Copy/Look-Up menu over wherever we'd place one. So on touch we
+   (a) emit drag-selections on a debounced selectionchange (they glide as you drag
+   the handles, no mouseup needed) and (b) treat a clean tap on a text block as a
+   coarse "comment on this" anchor. The host shows a bottom bar for both; here we
+   just report. tapGuard keeps the collapse that follows a tap from clearing it. */
+var emitT=0,tapGuard=0,tx=0,ty=0,tMoved=false;
+function scheduleEmit(){if(emitT)clearTimeout(emitT);emitT=setTimeout(emitSelection,120)}
 document.addEventListener("selectionchange",function(){
-  var s=window.getSelection();if(!s||s.isCollapsed)post({type:"select",selector:null,rect:null})});
+  var s=window.getSelection();
+  if(s&&!s.isCollapsed){scheduleEmit();return}
+  if(Date.now()-tapGuard<600)return;
+  post({type:"select",selector:null,rect:null})});
+document.addEventListener("touchstart",function(e){
+  var t=e.touches&&e.touches[0];if(t){tx=t.clientX;ty=t.clientY;tMoved=false}},{passive:true});
+document.addEventListener("touchmove",function(e){
+  var t=e.touches&&e.touches[0];
+  if(t&&(Math.abs(t.clientX-tx)>10||Math.abs(t.clientY-ty)>10))tMoved=true},{passive:true});
+document.addEventListener("touchend",function(e){
+  var s=window.getSelection();
+  if(s&&!s.isCollapsed){setTimeout(emitSelection,0);return}
+  if(tMoved)return;
+  var el=e.target;
+  if(!el||!el.closest||el.closest("a,button,input,textarea,select,label,[data-dock-id]"))return;
+  var b=el.closest("p,li,h1,h2,h3,h4,h5,h6,blockquote,td,th,figcaption,dd,dt,pre");
+  if(!b)return;
+  var txt=(b.textContent||"").trim();
+  if(txt.length<2)return;
+  var r=b.getBoundingClientRect();
+  tapGuard=Date.now();flashBlock(b);
+  post({type:"select",block:true,rect:{top:r.top,bottom:r.bottom,left:r.left,right:r.right},
+    selector:{type:"TextQuoteSelector",exact:txt.slice(0,180),prefix:"",suffix:""}})},{passive:true});
+function flashBlock(b){var bg=b.style.backgroundColor,tr=b.style.transition;
+  b.style.transition="background-color .15s ease";b.style.backgroundColor="rgba(101,89,153,.18)";
+  setTimeout(function(){b.style.backgroundColor=bg;setTimeout(function(){b.style.transition=tr},220)},1000)}
 
 /* -- live cursor: throttled pointer position, DOCUMENT-normalized 0..1 (x by
       width, y by the full document height, including scroll). The host maps it


### PR DESCRIPTION
**Feedback:** commenting on mobile was broken — highlighting popped the iOS Copy/Look-Up menu and there was no clean way to leave a comment.

iOS won't let us suppress its selection menu while keeping text selectable, so instead of fighting it we give commenting its own surface.

## Changes
**Selection client (`anchor.ts`):**
- Drag-selections emit on a **debounced `selectionchange`** so they track as you drag the handles (no `mouseup` needed — the thing that made touch selection flaky).
- A **clean tap on a text block** reports that block as a coarse anchor, with a brief highlight. A `tapGuard` stops the synthesized post-tap `mouseup`/`selectionchange` from clearing it.

**Parent (`artifact-comments`):**
- The floating "Comment" pill is now **desktop-only** (it used to collide with the iOS menu on phones).
- On mobile, a selection **or** a tapped paragraph raises a **fixed bottom bar** — above the iOS menu, thumb-sized — showing the quote, with **Comment** (opens the sheet composer pinned to it) and a dismiss. Drag-select still works for an exact phrase.

So: **tap a paragraph** for the fast path, **drag-select** for a precise phrase, both into one bottom bar.

## Tests
- Two deep e2e on a Pixel 7 touch profile: tap → bar (quoting the block) → anchored composer → posted comment; and bar-dismiss.
- Full e2e **44**, unit core **55** / api **277**, `pnpm run ci` exit 0, repo typecheck.

_Screenshots (Pixel 7): tapped paragraph highlights + bottom bar; Comment opens the anchored sheet composer._

🤖 Generated with [Claude Code](https://claude.com/claude-code)