### PR TITLE
fix(mcp): /mcp must be an exact worker-first path, not a prefix

### DIFF
--- a/apps/api/src/lib/serve-web.ts
+++ b/apps/api/src/lib/serve-web.ts
@@ -15,12 +15,15 @@ import type { Hono } from "hono"
  *  · prefixes match the path and any subpath (`/v1`, `/v1/artifacts`, …)
  *  · exact paths match only themselves (`/healthz`)
  */
-const API_PREFIXES = ["/v1", "/api", "/raw", "/oauth", "/mcp"] as const
-// OAuth 2.0 discovery docs (RFC 8414 / RFC 9728) the Worker must answer with JSON.
-// Without these the SPA not_found_handling shadows them with index.html, so MCP
-// clients probing the well-known root get HTML instead of the metadata.
+const API_PREFIXES = ["/v1", "/api", "/raw", "/oauth"] as const
+// Exact server-owned paths. The OAuth 2.0 discovery docs (RFC 8414 / RFC 9728) the
+// Worker must answer with JSON, else SPA not_found_handling shadows them. `/mcp` is
+// EXACT, not a prefix: the MCP Streamable-HTTP endpoint is hit at exactly /mcp with
+// no subpath, so a `/mcp/*` worker-first glob misses it and the asset handler 405s
+// the POST. (Trailing-slash/subpath variants aren't used by the transport.)
 const API_EXACT = [
   "/healthz",
+  "/mcp",
   "/.well-known/oauth-authorization-server",
   "/.well-known/oauth-protected-resource",
 ] as const

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -38,7 +38,7 @@ new_sqlite_classes = ["ArtifactRoom"]
 [assets]
 directory = "../web/dist/client"
 binding = "ASSETS"
-run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/oauth/*", "/mcp/*", "/a/*", "/healthz", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource"]
+run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/oauth/*", "/a/*", "/healthz", "/mcp", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource"]
 not_found_handling = "single-page-application"
 
 # baseUrl falls back to the request origin when unset. Secured by Better Auth; set


### PR DESCRIPTION
Follow-up to #152. The MCP Streamable-HTTP endpoint is hit at exactly `/mcp` with no subpath, so the `/mcp/*` `run_worker_first` glob missed it — Cloudflare fell through to the static-asset handler, which **405s the POST** before the Worker ran (observed live right after deploy). Moving `/mcp` from `API_PREFIXES` to `API_EXACT` emits an exact `/mcp` worker-first rule; POST `/mcp` now reaches the handler and returns the spec **401 + `WWW-Authenticate`** that bootstraps the OAuth handshake. Already deployed to production (version 8d44c17e); this lands the same change on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)