### PR TITLE
fix(authz): scope an agent's role to its own workspace (no cross-workspace mutation)

### DIFF
--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -414,7 +414,15 @@ export function buildContext(deps: AppDeps) {
     const ag = await agentFor(c)
     if (ag) {
       const am = await meta.getArtifactMember(a.id, ag.id)
-      return { kind: "user", userId: ag.id, artifactRole: am?.role ?? null, orgRole: ag.role }
+      // An agent (registered token or OAuth-consent grant) carries its role ONLY
+      // within its OWN workspace, never onto an artifact owned by another one — it
+      // can resolve any artifact by its global short_id, so binding here is the
+      // gate. Mirrors the human branch below: orgRole is scoped to the ARTIFACT's
+      // workspace; on a foreign artifact it drops to the visibility floor while its
+      // own per-artifact shares (artifactRole) still apply. Without this an agent's
+      // home-workspace editor role would let it publish/share/mutate anything.
+      const orgRole = ag.org_id === a.org_id ? ag.role : null
+      return { kind: "user", userId: ag.id, artifactRole: am?.role ?? null, orgRole }
     }
     const me = await currentUser(c)
     if (!me) return { kind: "anon", unlocked }

--- a/apps/api/test/authz-ownership.test.ts
+++ b/apps/api/test/authz-ownership.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+import { as, bearer, jsonAs, makeAuthedApp, pub, publishAs, type TestUser } from "./helpers"
+
+// Regression for the cross-ownership authority leak: an agent (registered token or
+// OAuth-consent grant) carries its role ONLY within its own workspace. Because
+// short_ids are global, an agent could resolve a foreign workspace's artifact and,
+// before the fix, its home-workspace editor role was applied to it — letting it
+// publish/comment/share on artifacts it doesn't own. actorFor now binds the agent's
+// orgRole to the artifact's workspace (ag.org_id === a.org_id), exactly like a human.
+describe("authz: an agent cannot act on artifacts outside its own workspace", () => {
+  const alice: TestUser = { id: "u_authz_alice", email: "alice@authz.test", name: "Alice" }
+  const bob: TestUser = { id: "u_authz_bob", email: "bob@authz.test", name: "Bob" }
+  // isolated → each user owns a SEPARATE personal workspace (no shared team seed).
+  const { app } = makeAuthedApp("authz-ownership", [alice, bob], undefined, { isolated: true })
+
+  it("scopes an editor agent to its home workspace; cross-workspace writes are refused", async () => {
+    // Provision both personal workspaces (first /v1/me makes each user their owner).
+    await app.request("/v1/me", { headers: as(alice.email) })
+    await app.request("/v1/me", { headers: as(bob.email) })
+
+    // Alice registers an EDITOR agent in HER workspace; it returns a bearer once.
+    const reg = await app.request(
+      "/v1/agents",
+      jsonAs(as(alice.email), { name: "Helper", role: "editor" }),
+    )
+    expect(reg.status).toBe(201)
+    const agentToken = (await reg.json()).token as string
+
+    // Bob publishes an artifact in HIS workspace.
+    const bobId = (await (await publishAs(app, "<h1>Bob's</h1>", {}, as(bob.email))).json())
+      .short_id
+
+    // The agent (workspace A, editor) must NOT mutate Bob's artifact (workspace B):
+    // republishing a version and commenting are both refused — its home-workspace
+    // role does not reach a foreign workspace's artifact.
+    expect((await pub(app, "<h1>hijacked</h1>", {}, bobId, bearer(agentToken))).status).toBe(403)
+    expect(
+      (
+        await app.request(
+          `/v1/artifacts/${bobId}/comments`,
+          jsonAs(bearer(agentToken), { body_md: "mine now" }),
+        )
+      ).status,
+    ).toBe(403)
+    // Bob's artifact is untouched — still at version 1.
+    const after = await (
+      await app.request(`/v1/artifacts/${bobId}`, { headers: as(bob.email) })
+    ).json()
+    expect(after.current_version).toBe(1)
+
+    // No over-reach: the SAME agent CAN still act in its OWN workspace.
+    const aliceId = (await (await publishAs(app, "<h1>Alice's</h1>", {}, as(alice.email))).json())
+      .short_id
+    expect(
+      (await pub(app, "<h1>v2</h1>", { message: "bump" }, aliceId, bearer(agentToken))).ok,
+    ).toBe(true)
+    const own = await (
+      await app.request(`/v1/artifacts/${aliceId}`, { headers: as(alice.email) })
+    ).json()
+    expect(own.current_version).toBe(2)
+  })
+})


### PR DESCRIPTION
## The leak (critical)

A registered agent token (`dk_agt_…`) or an OAuth-consent access token could act on artifacts owned by **any** workspace, not just its own.

`short_id`s are global, so an agent could resolve a foreign workspace's artifact by id and `actorFor`'s agent branch stamped the agent's **home-workspace** role onto it:

```ts
// apps/api/src/context.ts (before)
if (ag) {
  const am = await meta.getArtifactMember(a.id, ag.id)
  return { kind: "user", userId: ag.id, artifactRole: am?.role ?? null, orgRole: ag.role }
  //                                                                     ^^^^^^^^^^^^^^^ never checked ag.org_id === a.org_id
}
```

An `editor` agent (e.g. a `dock:publish` OAuth grant) therefore passed `authorize(c, "publish"/"share"/…, foreignArtifact)` and could publish a version, restore, propose+approve, comment, change visibility, or re-share an artifact in a workspace it has no membership in. This is exactly the "publish to something you don't own" case.

The signed-in-user branch one line below already did the right thing (`orgRole` re-derived per target via `getMembership(a.org_id, me.id)`); the agent branch simply omitted that gate.

## The fix (one line, mirrors the human branch)

```ts
const orgRole = ag.org_id === a.org_id ? ag.role : null
return { kind: "user", userId: ag.id, artifactRole: am?.role ?? null, orgRole }
```

On a foreign artifact the agent drops to the visibility floor; its own per-artifact shares (`artifactRole`) still apply, and an agent acting **in its own workspace** is unchanged. The static `DOCK_TOKEN` operator key and all human / share / collection paths are untouched.

## How it was found

An adversarial multi-agent audit of the whole authorization model: five lenses mapping the permission primitives, `actorFor`, the OAuth-agent path, every mutating route, and the token/test constraints; a synthesis into a threat model + ranked leaks; then a per-finding refutation pass. Both the registered-agent and OAuth-agent leaks reduce to this one root cause. **10** other candidate paths (static token global owner, `getByShortId` global lookup, takedown/moderation, collection re-share, workspace-object routes, the anon allowlist, share rank-clamp, etc.) were each checked and confirmed already gated.

## Test

New `apps/api/test/authz-ownership.test.ts`: an org-A `editor` agent is refused (**403**) when publishing a version or commenting on an org-B artifact, the target stays at version 1, and the same agent still publishes successfully in its **own** workspace. Confirmed the test **fails on the pre-fix code** (cross-workspace publish returned 201), so it's a genuine regression guard.

Full gate green: typecheck, all API tests (282), biome + every custom lint + knip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)