### PR TITLE
feat(mcp): Phase 1 — the pull loop (diff, read_section, catch_me_up, propose)

### DIFF
--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -16,6 +16,8 @@ import {
   type BundleManifest,
   diffLines,
   formatDiff,
+  PublishError,
+  propose as proposeChange,
   type VersionRecord,
 } from "@dock/core"
 import { StreamableHTTPTransport } from "@hono/mcp"
@@ -89,8 +91,10 @@ const bundleFileChanges = (from: BundleManifest, to: BundleManifest) => ({
 
 /**
  * A new MCP server for one request, scoped to `agent` (the OAuth-resolved identity).
- * Phase 0 is read-only — the agent can see what it's working on; the write/loop
- * tools (diff, propose, catch_me_up) land in Phase 1.
+ * Tools act in the bearer's workspace at the bearer's role: reads for anyone, and
+ * `propose` (the human-in-the-loop write) for commenter+ — a proposal never goes
+ * live without a human approving it, so an agent is a safe contributor, not a
+ * publisher.
  */
 function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
   const server = new McpServer({ name: "dock", version: "1.0.0" })
@@ -327,6 +331,56 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           body: c.body_md,
         })),
       })
+    },
+  )
+
+  server.registerTool(
+    "propose",
+    {
+      description:
+        "Propose a revised version of a single-file artifact for human review. It does NOT go live — a reviewer approves it or requests changes. Provide the FULL new content (not a patch) and a rationale. (Multi-page bundles aren't proposable over MCP yet.)",
+      inputSchema: {
+        short_id: z.string(),
+        content: z
+          .string()
+          .describe("The complete new content of the document (HTML or Markdown)."),
+        message: z.string().describe("What you changed and why — shown to the reviewer."),
+        filename: z
+          .string()
+          .optional()
+          .describe("Filename hint for the content type, e.g. index.html or notes.md."),
+      },
+    },
+    async ({ short_id, content, message, filename }) => {
+      const a = await own(short_id)
+      if (!a) return text(`No artifact "${short_id}" in this workspace.`)
+      if (agent.role === "viewer")
+        return text(
+          "Your grant is read-only (dock:read). Re-authorize with dock:propose to propose changes.",
+        )
+      if (a.kind === "bundle")
+        return text(
+          `"${short_id}" is a multi-page bundle; proposing bundle revisions over MCP isn't supported yet (single-file artifacts only).`,
+        )
+      try {
+        const { proposal } = await proposeChange(ctx.meta, ctx.blobs, short_id, {
+          bytes: new TextEncoder().encode(content),
+          filename: filename ?? "index.html",
+          isBundle: false,
+          message,
+          author: agent.name,
+          author_id: agent.id,
+        })
+        return json({
+          proposed: true,
+          proposal_id: proposal.id,
+          base_version: proposal.base_version,
+          note: "Submitted for review — a human approves it or requests changes. It is NOT live yet.",
+        })
+      } catch (e) {
+        const msg = e instanceof PublishError ? e.message : "could not store the proposal"
+        return text(`Propose failed: ${msg}`)
+      }
     },
   )
 

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -9,7 +9,15 @@
 // in exactly that bearer's workspace at that bearer's role. Runs identically on the
 // Node tier and the Cloudflare Workers tier — same `createApp`.
 
-import type { AgentRecord, ArtifactRecord } from "@dock/core"
+import {
+  type AgentRecord,
+  type ArtifactRecord,
+  BUNDLE_CONTENT_TYPE,
+  type BundleManifest,
+  diffLines,
+  formatDiff,
+  type VersionRecord,
+} from "@dock/core"
 import { StreamableHTTPTransport } from "@hono/mcp"
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import type { Hono } from "hono"
@@ -34,6 +42,49 @@ const summarizeArtifact = (a: ArtifactRecord) => ({
   version: a.current_version,
   visibility: a.visibility,
   removed: !!a.removed_at,
+})
+
+const summarizeVersion = (v: VersionRecord) => ({
+  n: v.n,
+  name: v.name,
+  message: v.message,
+  author: v.author,
+  created_at: v.created_at,
+})
+
+// A version's bundle manifest (null when it isn't a bundle / is unreadable). Lets
+// the loop tools see a multi-page artifact's actual files, not just its entry doc.
+const manifestOf = async (ctx: AppContext, v: VersionRecord): Promise<BundleManifest | null> => {
+  if (v.content_type !== BUNDLE_CONTENT_TYPE) return null
+  const bytes = await ctx.blobs.get(v.blob_key)
+  if (!bytes) return null
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes)) as BundleManifest
+  } catch {
+    return null
+  }
+}
+
+// Bundle manifests store paths with a leading slash (/index.html); present them
+// cleanly to the agent, and accept either form on the way back in.
+const cleanPath = (p: string) => p.replace(/^\//, "")
+
+// Which pages changed between two bundle versions — by comparing each file's
+// content-addressed blob key. This is the "what's new" a coalesced catch-up needs.
+const bundleFileChanges = (from: BundleManifest, to: BundleManifest) => ({
+  added: Object.keys(to.files)
+    .filter((p) => !from.files[p])
+    .map(cleanPath),
+  removed: Object.keys(from.files)
+    .filter((p) => !to.files[p])
+    .map(cleanPath),
+  changed: Object.keys(to.files)
+    .filter((p) => {
+      const f = from.files[p]
+      const t = to.files[p]
+      return f && t && f.key !== t.key
+    })
+    .map(cleanPath),
 })
 
 /**
@@ -148,6 +199,133 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
             author: v.author,
             created_at: v.created_at,
           })),
+      })
+    },
+  )
+
+  server.registerTool(
+    "read_section",
+    {
+      description:
+        "Read a specific page of a multi-page artifact (bundle), or the content of a single-file one. Omit `path` to list a bundle's pages first.",
+      inputSchema: {
+        short_id: z.string(),
+        path: z
+          .string()
+          .optional()
+          .describe("A page path within a bundle, e.g. agentic-loop.html. Omit to list pages."),
+        version: z.number().optional().describe("Defaults to the current version."),
+      },
+    },
+    async ({ short_id, path, version }) => {
+      const a = await own(short_id)
+      if (!a) return text(`No artifact "${short_id}" in this workspace.`)
+      const n = version ?? a.current_version
+      const v = await ctx.meta.getVersion(a.id, n)
+      if (!v) return text(`No version ${n} (have 1..${a.current_version}).`)
+      const manifest = await manifestOf(ctx, v)
+      if (!manifest) {
+        const body = await ctx.sourceText(v)
+        return json({ short_id, version: n, path: null, content: clip(body ?? "") })
+      }
+      if (!path)
+        return json({
+          short_id,
+          version: n,
+          entry: cleanPath(manifest.entry),
+          pages: Object.keys(manifest.files).map(cleanPath),
+        })
+      // Accept the page path with or without a leading slash.
+      const file = manifest.files[path] ?? manifest.files[`/${cleanPath(path)}`]
+      if (!file)
+        return text(
+          `No page "${path}". Pages: ${Object.keys(manifest.files).map(cleanPath).join(", ")}`,
+        )
+      const bytes = await ctx.blobs.get(file.key)
+      return json({
+        short_id,
+        version: n,
+        path: cleanPath(path),
+        type: file.type,
+        content: clip(bytes ? new TextDecoder().decode(bytes) : ""),
+      })
+    },
+  )
+
+  server.registerTool(
+    "diff",
+    {
+      description:
+        "What changed between two versions of an artifact: a unified diff of the entry document, plus (for bundles) which pages were added / removed / changed. `to` defaults to the current version.",
+      inputSchema: {
+        short_id: z.string(),
+        from: z.number().describe("The base version number."),
+        to: z.number().optional().describe("Defaults to the current version."),
+      },
+    },
+    async ({ short_id, from, to }) => {
+      const a = await own(short_id)
+      if (!a) return text(`No artifact "${short_id}" in this workspace.`)
+      const toN = to ?? a.current_version
+      const vf = await ctx.meta.getVersion(a.id, from)
+      const vt = await ctx.meta.getVersion(a.id, toN)
+      if (!vf || !vt) return text(`Missing version (have 1..${a.current_version}).`)
+      const [af, at] = [await ctx.sourceText(vf), await ctx.sourceText(vt)]
+      if (af === null || at === null) return text("Version content is missing.")
+      const [mf, mt] = [await manifestOf(ctx, vf), await manifestOf(ctx, vt)]
+      return json({
+        short_id,
+        from,
+        to: toN,
+        pages_changed: mf && mt ? bundleFileChanges(mf, mt) : null,
+        entry_diff: clip(formatDiff(diffLines(af, at))),
+      })
+    },
+  )
+
+  server.registerTool(
+    "catch_me_up",
+    {
+      description:
+        "The coalesced delta since you last looked: every version that landed since `since_version`, which pages changed, a diff of the entry document, and the open comment threads — everything you need to re-sync on the plan in one call. `since_version` defaults to the version before current.",
+      inputSchema: {
+        short_id: z.string(),
+        since_version: z
+          .number()
+          .optional()
+          .describe("The version you last saw. Defaults to current − 1."),
+      },
+    },
+    async ({ short_id, since_version }) => {
+      const a = await own(short_id)
+      if (!a) return text(`No artifact "${short_id}" in this workspace.`)
+      const head = a.current_version
+      const since = Math.min(head, Math.max(1, since_version ?? head - 1))
+      const newVersions = (await ctx.meta.listVersions(a.id)).filter((v) => v.n > since)
+      const vs = await ctx.meta.getVersion(a.id, since)
+      const vh = await ctx.meta.getVersion(a.id, head)
+      let entryDiff: string | null = null
+      let pagesChanged: ReturnType<typeof bundleFileChanges> | null = null
+      if (vs && vh && since < head) {
+        const [as_, ah] = [await ctx.sourceText(vs), await ctx.sourceText(vh)]
+        if (as_ !== null && ah !== null) entryDiff = clip(formatDiff(diffLines(as_, ah)))
+        const [ms, mh] = [await manifestOf(ctx, vs), await manifestOf(ctx, vh)]
+        if (ms && mh) pagesChanged = bundleFileChanges(ms, mh)
+      }
+      const open = await ctx.meta.listComments(a.id, { state: "open" })
+      return json({
+        short_id,
+        since,
+        head,
+        caught_up: since >= head,
+        new_versions: newVersions.map(summarizeVersion),
+        pages_changed: pagesChanged,
+        entry_diff: entryDiff,
+        open_comments: open.map((c) => ({
+          thread: c.thread_id,
+          author: c.author,
+          body: c.body_md,
+        })),
       })
     },
   )

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -129,6 +129,7 @@ describe("remote MCP endpoint (/mcp)", () => {
         "read_section",
         "diff",
         "catch_me_up",
+        "propose",
       ]),
     )
   })
@@ -246,5 +247,33 @@ describe("remote MCP endpoint (/mcp)", () => {
       toolText(await call(app, token, "catch_me_up", { short_id: shortId, since_version: 1 })),
     )
     expect(cu.pages_changed.added).toContain("new.html")
+  })
+
+  it("propose stages a revision for review without going live", async () => {
+    // Editor grant so the setup publish works; over MCP even an editor only gets
+    // `propose` (no direct-publish tool), so the candidate still never auto-goes-live.
+    const { app, token } = appWithGrant("propose", "openid dock:read dock:publish")
+    const shortId = (await (await publish(app, token, "Draft")).json()).short_id
+
+    const p = JSON.parse(
+      toolText(
+        await call(app, token, "propose", {
+          short_id: shortId,
+          content: "<h1>Revised draft</h1>",
+          message: "tightened the intro",
+        }),
+      ),
+    )
+    expect(p.proposed).toBe(true)
+    expect(p.proposal_id).toBeTruthy()
+    expect(p.base_version).toBe(1)
+
+    // The live version is untouched — a proposal is not a publish.
+    const read = JSON.parse(
+      toolText(await call(app, token, "read_artifact", { short_id: shortId })),
+    )
+    expect(read.version).toBe(1)
+    expect(read.content).toContain("Draft")
+    expect(read.content).not.toContain("Revised")
   })
 })

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 import { SqliteMetaStore } from "@dock/db/sqlite"
 import { FsBlobStore } from "@dock/storage/fs"
 import Database from "better-sqlite3"
+import { zipSync } from "fflate"
 import { afterAll, describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
 import { sha256 } from "../src/lib/crypto"
@@ -125,6 +126,9 @@ describe("remote MCP endpoint (/mcp)", () => {
         "read_artifact",
         "list_comments",
         "list_versions",
+        "read_section",
+        "diff",
+        "catch_me_up",
       ]),
     )
   })
@@ -160,5 +164,87 @@ describe("remote MCP endpoint (/mcp)", () => {
     const readOut = JSON.parse(toolText(read))
     expect(readOut.title).toBe("My Plan")
     expect(readOut.content).toContain("My Plan")
+  })
+
+  it("diff + catch_me_up report what changed between versions", async () => {
+    const { app, token } = appWithGrant("diff", "openid dock:read dock:publish")
+    const shortId = (await (await publish(app, token, "V1 Title")).json()).short_id
+
+    // Republish a second version with different content.
+    const form = new FormData()
+    form.append("file", new Blob([new TextEncoder().encode("<h1>V2 Title</h1>")]), "index.html")
+    form.append("name", "rev 2")
+    const rep = await app.request(`/v1/artifacts/${shortId}/versions`, {
+      method: "POST",
+      body: form,
+      headers: { authorization: `Bearer ${token}` },
+    })
+    expect(rep.status).toBe(201)
+
+    const d = JSON.parse(
+      toolText(await call(app, token, "diff", { short_id: shortId, from: 1, to: 2 })),
+    )
+    expect(d.entry_diff).toContain("V2 Title")
+
+    const c = JSON.parse(
+      toolText(await call(app, token, "catch_me_up", { short_id: shortId, since_version: 1 })),
+    )
+    expect(c.head).toBe(2)
+    expect(c.new_versions.map((v: { n: number }) => v.n)).toContain(2)
+    expect(c.entry_diff).toContain("V2 Title")
+    expect(c.caught_up).toBe(false)
+  })
+
+  it("read_section + catch_me_up handle multi-page bundles", async () => {
+    const { app, token } = appWithGrant("bundle", "openid dock:read dock:publish")
+    const enc = (s: string) => new TextEncoder().encode(s)
+    const postZip = (
+      files: Record<string, Uint8Array>,
+      fields: Record<string, string>,
+      id?: string,
+    ) => {
+      const form = new FormData()
+      form.append("file", new Blob([zipSync(files)]), "site.zip")
+      for (const [k, v] of Object.entries(fields)) form.append(k, v)
+      return app.request(id ? `/v1/artifacts/${id}/versions` : "/v1/artifacts", {
+        method: "POST",
+        body: form,
+        headers: { authorization: `Bearer ${token}` },
+      })
+    }
+    const pj = await (
+      await postZip(
+        { "index.html": enc("<h1>Home</h1>"), "page.html": enc("<h1>Page</h1>") },
+        { title: "Site", visibility: "link" },
+      )
+    ).json()
+    expect(pj.kind).toBe("bundle")
+    const shortId = pj.short_id
+
+    // No path → lists the bundle's pages.
+    const pages = JSON.parse(
+      toolText(await call(app, token, "read_section", { short_id: shortId })),
+    )
+    expect(pages.pages).toEqual(expect.arrayContaining(["index.html", "page.html"]))
+    // A path → that page's content.
+    const page = JSON.parse(
+      toolText(await call(app, token, "read_section", { short_id: shortId, path: "page.html" })),
+    )
+    expect(page.content).toContain("Page")
+
+    // Republish with a new page; catch_me_up reports it under pages_changed.added.
+    await postZip(
+      {
+        "index.html": enc("<h1>Home</h1>"),
+        "page.html": enc("<h1>Page</h1>"),
+        "new.html": enc("<h1>New</h1>"),
+      },
+      { name: "rev 2" },
+      shortId,
+    )
+    const cu = JSON.parse(
+      toolText(await call(app, token, "catch_me_up", { short_id: shortId, since_version: 1 })),
+    )
+    expect(cu.pages_changed.added).toContain("new.html")
   })
 })


### PR DESCRIPTION
Builds the agentic loop on top of Phase 0's transport (#152): the observe → orient → act tools, so an AI client connected over `/mcp` can stay fresh on a plan and propose revisions — all bounded and workspace-scoped.

## Tools added (9 total now)
- **`diff(short_id, from, to)`** — unified diff of the entry document between two versions, plus (for bundles) which pages were added / removed / changed by content-addressed key.
- **`read_section(short_id, path?, version?)`** — read one page of a multi-page bundle (omit `path` to list pages) or a single-file artifact. Slash-tolerant paths.
- **`catch_me_up(short_id, since_version?)`** — the signature tool: the coalesced delta since the agent last looked (new versions + pages changed + entry diff + open comments) in one bounded call. The "always fresh, knows the diff" experience the design calls for.
- **`propose(short_id, content, message)`** — the human-in-the-loop write. Stores a candidate version for review (via `@dock/core`'s `propose()`); it does **not** go live. Gated to commenter+, authored as the agent. Because MCP exposes only `propose` (no direct-publish tool), an agent is a safe contributor regardless of scope.

## Design notes
- All reads bounded to ~80k chars (truncate-and-steer) so a big plan can't blow the client's context window.
- Bundle-aware throughout (`pages_changed`, per-page reads) — the live plan is a bundle.
- Single-file `propose` for now; bundle-page proposals are a later phase.

## Tested
7 MCP integration tests over the real JSON-RPC transport: handshake + tool list, `whoami` role mapping, single-file `diff`/`catch_me_up`, multi-page bundle `read_section` + `catch_me_up` `pages_changed`, and `propose` (proposal created, live version provably untouched). Full api suite green (284), typecheck (Node + Worker) + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)