### PR TITLE
fix(comments): iOS compose — derive full + keep the sheet above the keyboard

### DIFF
--- a/apps/web/e2e/deep/comments-mobile.deep.spec.ts
+++ b/apps/web/e2e/deep/comments-mobile.deep.spec.ts
@@ -24,10 +24,20 @@ test("tap a paragraph to comment: bar + composer, anchored to the block", async 
   await expect(bar).toBeVisible()
   await expect(bar).toContainText("Second paragraph here")
 
-  // Comment opens the sheet composer, quoting the tapped block.
+  // Comment opens the sheet composer, quoting the tapped block. The sheet must
+  // auto-expand to full (a half sheet would sit behind the iOS keyboard with the
+  // box out of view), so the dialog fills most of the viewport.
   await page.getByTestId("mobile-comment-start").tap()
   await expect(page.getByTestId("composer-input")).toBeVisible()
   await expect(page.getByText("Second paragraph here", { exact: false }).first()).toBeVisible()
+  // The sheet fills the area above the (emulated) keyboard, so the composer is in
+  // view rather than stuck at half behind it.
+  const vvh = await page.evaluate(() => window.visualViewport?.height ?? window.innerHeight)
+  await expect
+    .poll(
+      async () => (await page.getByRole("dialog", { name: "Comments" }).boundingBox())?.height ?? 0,
+    )
+    .toBeGreaterThan(vvh * 0.7)
 
   // Posting lands the anchored comment.
   await page.getByTestId("composer-input").fill("Looks good on mobile.")
@@ -64,8 +74,10 @@ test("tapping out collapses the sheet to a peek bar, and it reopens", async ({ p
   await page.getByTestId("composer-submit").tap()
   await expect(page.getByText("First note.")).toBeVisible()
 
-  // Tap out (the dimmed strip above the full-height sheet) -> collapse to the peek
-  // bar: body gone, header bar stays, the resize control flips to Expand.
+  // Expand to full (the sheet drops to half once the composer closes), which shows
+  // the dimmed backdrop. Tapping it -> collapse to the peek bar: body gone, header
+  // bar stays, the resize control flips to Expand.
+  await page.getByTestId("comments-sheet-grip").tap()
   await page.getByTestId("comments-sheet-backdrop").tap({ position: { x: 180, y: 36 } })
   await expect(page.getByText("First note.")).toHaveCount(0)
   await expect(page.getByText("Comments", { exact: true })).toBeVisible()

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -54,9 +54,29 @@ export function MobileComments({
   useEffect(() => {
     if (open) setSize("half")
   }, [open])
+  // A composer must sit fully above the iOS keyboard, so derive "full" whenever one
+  // is open instead of racing an effect (which could leave the sheet at half, behind
+  // the keyboard, with the box out of view). The user's resize drives `size` after.
+  const sheet = composer ? "full" : size
+  // iOS keeps `position: fixed` put when the keyboard opens, so a bottom sheet hides
+  // behind it. Track the keyboard via visualViewport and pin the sheet into the
+  // visible area above it while one is up (ignore the small URL-bar shrink).
+  const [kb, setKb] = useState<{ inset: number; height: number } | null>(null)
   useEffect(() => {
-    if (open && composer) setSize("full")
-  }, [open, composer])
+    const vv = window.visualViewport
+    if (!vv) return
+    const update = () => {
+      const inset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop)
+      setKb(inset > 80 ? { inset, height: vv.height } : null)
+    }
+    update()
+    vv.addEventListener("resize", update)
+    vv.addEventListener("scroll", update)
+    return () => {
+      vv.removeEventListener("resize", update)
+      vv.removeEventListener("scroll", update)
+    }
+  }, [])
   const empty = openThreads.length === 0 && resolved.length === 0 && !composer
   // The grip taps bigger; full wraps back to half. The chevron handles peek.
   const grip = () => setSize((s) => (s === "peek" ? "half" : s === "half" ? "full" : "half"))
@@ -73,19 +93,22 @@ export function MobileComments({
         type="button"
         data-testid="comments-sheet-backdrop"
         aria-label="Collapse comments"
-        tabIndex={open && size === "full" ? 0 : -1}
+        tabIndex={open && sheet === "full" ? 0 : -1}
         onClick={() => setSize("peek")}
         className={cn(
           "fixed inset-0 z-[60] bg-black/35 transition-opacity",
-          open && size === "full" ? "opacity-100" : "pointer-events-none opacity-0",
+          open && sheet === "full" ? "opacity-100" : "pointer-events-none opacity-0",
         )}
       />
       <div
         className={cn(
           "fixed inset-x-0 bottom-0 z-[61] flex flex-col rounded-t-[18px] border-t border-border bg-card shadow-[0_-14px_44px_-18px_rgba(0,0,0,0.5)] transition-[transform,height] duration-[260ms]",
-          size === "full" ? "h-[88vh]" : size === "peek" ? "h-[74px]" : "h-[50vh]",
+          sheet === "full" ? "h-[88vh]" : sheet === "peek" ? "h-[74px]" : "h-[50vh]",
           open ? "translate-y-0" : "translate-y-full",
         )}
+        // While the keyboard is up, pin the sheet into the visible area above it
+        // (overrides bottom-0 + the height class) so the composer is never hidden.
+        style={kb ? { bottom: kb.inset, height: kb.height } : undefined}
         role="dialog"
         aria-label="Comments"
       >
@@ -127,7 +150,7 @@ export function MobileComments({
             <Icon name="close" size={20} />
           </IconBtn>
         </div>
-        {size !== "peek" && (
+        {sheet !== "peek" && (
           <div className="min-h-0 flex-1 overflow-auto p-3 pb-[max(14px,env(safe-area-inset-bottom))]">
             {composer && (
               <div className="mb-3">


### PR DESCRIPTION
**Real-iOS feedback:** tapping Comment didn't auto-expand the sheet, and the comment box wasn't in view.

**Cause:** expanding to full ran through a `useEffect` that could lose the race on iOS, leaving the sheet at **half** — and a half bottom sheet sits **behind the iOS keyboard**, hiding the composer.

**Fix:**
- **Derive** the sheet height from "is there a composer" (`full` while composing) instead of an effect — it can't get stuck at half.
- **`visualViewport`**: track the keyboard and pin the sheet into the visible area above it (overrides `bottom-0` + the height class), so the composer is always in view when the keyboard is up.

**Tests (Pixel 7):** tapping Comment now polls the sheet up to >70% of the viewport (auto-expand); peek-collapse expands via the grip since the sheet drops to half after submit. Full e2e **45**, `pnpm run ci` exit 0, typecheck clean.

Honest caveat: validated in chromium mobile emulation, not real iOS Safari — deploying to test on a real device next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)