### PR TITLE
refine(comments): iOS mobile commenting pass (keyboard, zoom, sheet, jump)

### DIFF
--- a/apps/web/src/pages/artifact/artifact-comments.tsx
+++ b/apps/web/src/pages/artifact/artifact-comments.tsx
@@ -1,4 +1,4 @@
-import type { Dispatch, SetStateAction } from "react"
+import { type Dispatch, type SetStateAction, useRef } from "react"
 import type { Comment, Mention } from "@/api"
 import { Icon } from "@/components/icons"
 import { cn } from "@/lib/utils"
@@ -56,6 +56,12 @@ export function ArtifactComments(p: {
   startSelComment: () => void
 }) {
   const { isMobile, isAnon, panel, sel } = p
+  // Focus primer: tapping "Comment" focuses this synchronously, inside the tap
+  // gesture, so iOS raises the keyboard; the composer's autofocus then takes over
+  // and the keyboard stays up. (iOS won't open the keyboard for a focus that lands
+  // after the React commit, outside the gesture — that's why the box came up with
+  // no keyboard.)
+  const primer = useRef<HTMLTextAreaElement>(null)
   const newGeneral = () => {
     p.setComposer({ anchor: null, top: null })
     p.setActiveThread(null)
@@ -67,6 +73,17 @@ export function ArtifactComments(p: {
 
   return (
     <CommentScopeProvider value={{ shortId: p.shortId }}>
+      {isMobile && !isAnon && (
+        // Always mounted so the Comment tap can focus it synchronously (see `primer`).
+        // text-base (16px) avoids iOS's zoom-on-focus.
+        <textarea
+          ref={primer}
+          aria-hidden
+          tabIndex={-1}
+          data-testid="compose-primer"
+          className="pointer-events-none fixed bottom-0 left-0 -z-10 size-px resize-none border-0 bg-transparent p-0 text-lg opacity-0"
+        />
+      )}
       {!isMobile && !isAnon && (
         <aside
           className={cn(
@@ -183,6 +200,7 @@ export function ArtifactComments(p: {
             type="button"
             data-testid="mobile-comment-start"
             onClick={() => {
+              primer.current?.focus()
               p.setPanel("open")
               p.startSelComment()
             }}

--- a/apps/web/src/pages/artifact/comment-composer.tsx
+++ b/apps/web/src/pages/artifact/comment-composer.tsx
@@ -194,7 +194,9 @@ export function MentionField({
   // The field's text is transparent; the highlight backdrop paints the same text
   // (with lit-up mentions) directly underneath, so a tag glows live as you type or
   // pick someone. Both share `textBox` exactly, or the highlight drifts off the caret.
-  const textBox = cn("px-2.5 py-1.5 pr-9 text-sm leading-relaxed", className)
+  // 16px on phones so iOS doesn't zoom the page when the field focuses; the usual
+  // 12.5px from md up. Backdrop + field share this, so the highlight stays aligned.
+  const textBox = cn("px-2.5 py-1.5 pr-9 text-lg leading-relaxed md:text-sm", className)
   const handlers = {
     ref,
     "data-testid": testId,

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -60,23 +60,44 @@ export function MobileComments({
   const sheet = composer ? "full" : size
   // iOS keeps `position: fixed` put when the keyboard opens, so a bottom sheet hides
   // behind it. Track the keyboard via visualViewport and pin the sheet into the
-  // visible area above it while one is up (ignore the small URL-bar shrink).
+  // visible area above it. Measure against the layout viewport (clientHeight is
+  // keyboard-stable on iOS); a >150px shrink is a real keyboard, which rules out the
+  // ~60-115px Safari toolbar collapse that would otherwise false-trigger. rAF-
+  // coalesced and change-guarded so the scroll/resize bursts don't thrash.
   const [kb, setKb] = useState<{ inset: number; height: number } | null>(null)
   useEffect(() => {
     const vv = window.visualViewport
     if (!vv) return
-    const update = () => {
-      const inset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop)
-      setKb(inset > 80 ? { inset, height: vv.height } : null)
+    let raf = 0
+    const measure = () => {
+      const layoutH = document.documentElement.clientHeight
+      const inset = Math.max(0, layoutH - vv.height - vv.offsetTop)
+      const next = inset > 150 ? { inset: Math.round(inset), height: Math.round(vv.height) } : null
+      setKb((prev) => {
+        if (!prev && !next) return prev
+        if (prev && next && prev.inset === next.inset && prev.height === next.height) return prev
+        return next
+      })
     }
-    update()
+    const update = () => {
+      cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(measure)
+    }
+    measure()
     vv.addEventListener("resize", update)
     vv.addEventListener("scroll", update)
     return () => {
+      cancelAnimationFrame(raf)
       vv.removeEventListener("resize", update)
       vv.removeEventListener("scroll", update)
     }
   }, [])
+  // When the composer closes (submit/cancel), drop focus so iOS dismisses the
+  // keyboard instead of leaving it up over an empty sheet (which would keep the
+  // sheet pinned/shrunk via `kb`).
+  useEffect(() => {
+    if (!composer) (document.activeElement as HTMLElement | null)?.blur?.()
+  }, [composer])
   const empty = openThreads.length === 0 && resolved.length === 0 && !composer
   // The grip taps bigger; full wraps back to half. The chevron handles peek.
   const grip = () => setSize((s) => (s === "peek" ? "half" : s === "half" ? "full" : "half"))
@@ -102,7 +123,10 @@ export function MobileComments({
       />
       <div
         className={cn(
-          "fixed inset-x-0 bottom-0 z-[61] flex flex-col rounded-t-[18px] border-t border-border bg-card shadow-[0_-14px_44px_-18px_rgba(0,0,0,0.5)] transition-[transform,height] duration-[260ms]",
+          "fixed inset-x-0 bottom-0 z-[61] flex flex-col rounded-t-[18px] border-t border-border bg-card shadow-[0_-14px_44px_-18px_rgba(0,0,0,0.5)] duration-[260ms]",
+          // While the keyboard pins height to the live vv.height, animating height
+          // fights the keyboard slide — transform-only then.
+          kb ? "transition-transform" : "transition-[transform,height]",
           sheet === "full" ? "h-[88vh]" : sheet === "peek" ? "h-[74px]" : "h-[50vh]",
           open ? "translate-y-0" : "translate-y-full",
         )}

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -144,10 +144,12 @@ export function Artifact() {
     setComposer(null)
   }, [shortId, version])
 
-  // Clicking a thread's quote scrolls the document to its highlight.
+  // Clicking a thread's quote scrolls the document to its highlight. On phones the
+  // bottom ~half is covered by the comments sheet, so bias the scroll to drop the
+  // highlight into the upper band rather than dead-center (behind the sheet).
   const jumpTo = (threadId: string) => {
     setActiveThread(threadId)
-    post({ type: "focus-anchor", id: threadId })
+    post({ type: "focus-anchor", id: threadId, bias: isMobile ? 0.28 : undefined })
   }
 
   useEffect(() => {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -30,7 +30,13 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
   head: () => ({
     meta: [
       { charSet: "utf-8" },
-      { name: "viewport", content: "width=device-width, initial-scale=1" },
+      {
+        // viewport-fit=cover exposes the notch/home-indicator safe-area insets;
+        // interactive-widget is harmless on iOS (no-op) and helps Android resize.
+        name: "viewport",
+        content:
+          "width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content",
+      },
       { title: "Dock" },
     ],
     links: [

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -238,7 +238,11 @@ window.addEventListener("message",function(e){
   else if(d.type==="focus-anchor"){
     var ms=document.querySelectorAll('mark[data-dock-id="'+d.id+'"]');
     if(!ms.length)return;
-    ms[0].scrollIntoView({behavior:"smooth",block:"center"});
+    /* bias (0..1) places the highlight at that fraction of the viewport instead of
+       dead-center — phones pass ~0.28 so it lands above the comments sheet. */
+    if(typeof d.bias==="number"){var br=ms[0].getBoundingClientRect();
+      window.scrollTo({top:scrollTop()+br.top-window.innerHeight*d.bias,behavior:"smooth"})}
+    else ms[0].scrollIntoView({behavior:"smooth",block:"center"});
     for(var i=0;i<ms.length;i++){ms[i].classList.remove("dock-hl-flash");void ms[i].offsetWidth;ms[i].classList.add("dock-hl-flash")}
     setTimeout(reportScroll,360)}
 });


### PR DESCRIPTION
A real refinement pass on mobile commenting, driven by an **adversarial code audit** + a **research survey** of iOS-Safari commenting patterns, and tested on the **WebKit engine** (not just chromium emulation).

## What was broken on a real iPhone
- **Keyboard didn't open on first tap.** `autoFocus` runs after the React commit, outside the tap gesture, so iOS focuses the box but suppresses the keyboard (and the `visualViewport` pin never fires).
- **Page zoomed on focus** (inputs were <16px).
- **Keyboard pin was fragile** (80px threshold false-fired on the Safari toolbar collapse; height fought the slide).
- **Tap-a-quote scrolled the text behind the half-sheet.**

## Fixes
- **Focus primer**: a hidden textarea focused *synchronously* in the Comment tap → iOS raises the keyboard, composer autofocus takes over.
- **16px fields on phones** (`text-lg`, `md:text-sm` from desktop) → no zoom; backdrop+field share the size so the mention highlight stays aligned.
- **Sturdier `visualViewport` pin**: measure vs the layout viewport, >150px = real keyboard, rAF-coalesced + change-guarded, transform-only transition while pinned.
- **`blur()` on close** so iOS dismisses the keyboard and the pin clears.
- **Jump bias** (~0.28) so a tapped quote lands above the sheet.
- **viewport-fit=cover** for safe-area insets.

## Verification
- Full e2e **45** (mobile on Pixel), the flow on **WebKit / iPhone 13**, `pnpm run ci` exit 0, typecheck.
- Honest caveat: the keyboard-specific bits can't be fully automated (no soft keyboard in headless WebKit) — reasoned from the research + verified the flow on the iOS engine. Real-device test next.

Audit follow-ups deliberately deferred (tap-anchor prefix/suffix, derived-full vs user resize, tapGuard intent, select-message coalescing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)