### PR TITLE
refine(comments): compose bar + full list on mobile (drop half state)

### DIFF
--- a/apps/web/e2e/deep/comments-mobile.deep.spec.ts
+++ b/apps/web/e2e/deep/comments-mobile.deep.spec.ts
@@ -24,9 +24,8 @@ test("tap a paragraph to comment: bar + composer, anchored to the block", async 
   await expect(bar).toBeVisible()
   await expect(bar).toContainText("Second paragraph here")
 
-  // Comment opens the sheet composer, quoting the tapped block. Composing keeps the
-  // sheet at half (pinned above the keyboard on a real device), so the box is in
-  // view with the document still visible above it — not a full sheet iOS pushes off.
+  // Comment opens a COMPACT composer bar (pinned above the keyboard on a real
+  // device) with the quote — the document stays visible above it, not a full sheet.
   await page.getByTestId("mobile-comment-start").tap()
   await expect(page.getByTestId("composer-input")).toBeVisible()
   await expect(page.getByText("Second paragraph here", { exact: false }).first()).toBeVisible()
@@ -35,9 +34,9 @@ test("tap a paragraph to comment: bar + composer, anchored to the block", async 
     .poll(
       async () => (await page.getByRole("dialog", { name: "Comments" }).boundingBox())?.height ?? 0,
     )
-    .toBeLessThan(vvh * 0.65) // half, not a full-screen sheet
+    .toBeLessThan(vvh * 0.6) // a compact bar, not a full/half-screen sheet
 
-  // Posting lands the anchored comment.
+  // Posting lands the anchored comment and opens the full list to show it.
   await page.getByTestId("composer-input").fill("Looks good on mobile.")
   await page.getByTestId("composer-submit").tap()
   await expect(page.getByText("Looks good on mobile.")).toBeVisible()
@@ -59,29 +58,27 @@ test("the bottom bar dismisses without commenting", async ({ page }) => {
   await expect(page.getByTestId("mobile-comment-bar")).toHaveCount(0)
 })
 
-test("tapping out collapses the sheet to a peek bar, and it reopens", async ({ page }) => {
+test("collapse the full list to a peek bar, and reopen", async ({ page }) => {
   await signUp(page)
   const shortId = await publishArtifact(page, "m.md", "# Doc\n\nA paragraph to comment on here.")
   await page.goto(`/a/${shortId}`)
   await page.waitForTimeout(2000)
 
-  // Comment on a paragraph and post, so the (full-height) sheet holds a card.
+  // Post a comment; the sheet opens to the full list so the new comment shows.
   await page.frameLocator("iframe").getByText("A paragraph to comment").tap()
   await page.getByTestId("mobile-comment-start").tap()
   await page.getByTestId("composer-input").fill("First note.")
   await page.getByTestId("composer-submit").tap()
   await expect(page.getByText("First note.")).toBeVisible()
 
-  // Expand to full (the sheet drops to half once the composer closes), which shows
-  // the dimmed backdrop. Tapping it -> collapse to the peek bar: body gone, header
-  // bar stays, the resize control flips to Expand.
-  await page.getByTestId("comments-sheet-grip").tap()
+  // Tap the dimmed strip above the full sheet -> collapse to the peek bar: the list
+  // is gone, the header bar stays, and the resize control flips to Expand.
   await page.getByTestId("comments-sheet-backdrop").tap({ position: { x: 180, y: 36 } })
   await expect(page.getByText("First note.")).toHaveCount(0)
   await expect(page.getByText("Comments", { exact: true })).toBeVisible()
   await expect(page.getByTestId("comments-sheet-resize")).toHaveAttribute("title", "Expand")
 
-  // Tap the peek bar's expand control -> the list comes back.
+  // Tap the peek bar's expand control -> the full list returns.
   await page.getByTestId("comments-sheet-resize").tap()
   await expect(page.getByText("First note.")).toBeVisible()
 })

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -46,20 +46,14 @@ export function MobileComments({
   onSubmitNew: (text: string, mentions?: Mention[]) => void
   onCancelNew: () => void
 }) {
-  // Three heights: peek (a slim bar you tap to reopen), half (document visible
-  // above), full. Reset to half on each open; a composer wants room so it expands
-  // to full; and tapping out (the full-height backdrop) collapses to the peek bar
-  // rather than closing outright, so comments stay one tap away.
-  const [size, setSize] = useState<"peek" | "half" | "full">("half")
+  // Two states only: peek (a slim "Comments (N)" bar — the default) and full (the
+  // list). Composing overrides both with a compact composer bar pinned above the
+  // keyboard (see the height + `kb` style below), so the box sits flush above the
+  // keyboard with the document visible above — no awkward half-height middle state.
+  const [size, setSize] = useState<"peek" | "full">("peek")
   useEffect(() => {
-    if (open) setSize("half")
+    if (open) setSize("peek")
   }, [open])
-  // While composing, keep the sheet HALF, not full: a full sheet plus the iOS
-  // keyboard leaves the composer with nowhere to go (iOS shoves the fixed sheet
-  // off the top of the window). Half-height, pinned just above the keyboard (the
-  // `kb` style below), puts the box squarely in the visible band with a sliver of
-  // document above it. The user's resize drives `size` once composing ends.
-  const sheet = composer ? "half" : size
   // iOS keeps `position: fixed` put when the keyboard opens, so a bottom sheet hides
   // behind it. Track the keyboard via visualViewport and pin the sheet into the
   // visible area above it. Measure against the layout viewport (clientHeight is
@@ -101,11 +95,11 @@ export function MobileComments({
     if (!composer) (document.activeElement as HTMLElement | null)?.blur?.()
   }, [composer])
   const empty = openThreads.length === 0 && resolved.length === 0 && !composer
-  // The grip taps bigger; full wraps back to half. The chevron handles peek.
-  const grip = () => setSize((s) => (s === "peek" ? "half" : s === "half" ? "full" : "half"))
-  // Jumping to text: drop to half so the highlight lands in the visible doc.
+  // The grip toggles peek <-> full.
+  const grip = () => setSize((s) => (s === "peek" ? "full" : "peek"))
+  // Jumping to text: drop to the peek bar so the highlight is visible in the doc.
   const jumpToText = (id: string) => {
-    setSize("half")
+    setSize("peek")
     onJump(id)
   }
   return (
@@ -116,11 +110,11 @@ export function MobileComments({
         type="button"
         data-testid="comments-sheet-backdrop"
         aria-label="Collapse comments"
-        tabIndex={open && sheet === "full" ? 0 : -1}
+        tabIndex={open && !composer && size === "full" ? 0 : -1}
         onClick={() => setSize("peek")}
         className={cn(
           "fixed inset-0 z-[60] bg-black/35 transition-opacity",
-          open && sheet === "full" ? "opacity-100" : "pointer-events-none opacity-0",
+          open && !composer && size === "full" ? "opacity-100" : "pointer-events-none opacity-0",
         )}
       />
       <div
@@ -128,7 +122,9 @@ export function MobileComments({
           "fixed inset-x-0 bottom-0 z-[61] flex flex-col rounded-t-[18px] border-t border-border bg-card shadow-[0_-14px_44px_-18px_rgba(0,0,0,0.5)] duration-[260ms]",
           // Don't animate height while the keyboard repositions the sheet.
           kb ? "transition-transform" : "transition-[transform,height]",
-          sheet === "full" ? "h-[88vh]" : sheet === "peek" ? "h-[74px]" : "h-[50vh]",
+          // Composing: a compact bar sized to its content (capped), so the box sits
+          // flush above the keyboard rather than high up in a tall sheet.
+          composer ? "max-h-[80vh]" : size === "full" ? "h-[88vh]" : "h-[74px]",
           open ? "translate-y-0" : "translate-y-full",
         )}
         // While the keyboard is up, lift the sheet's bottom to just above it and cap
@@ -168,7 +164,7 @@ export function MobileComments({
             big
             title={size === "peek" ? "Expand" : "Collapse"}
             testId="comments-sheet-resize"
-            onClick={() => setSize(size === "peek" ? "half" : "peek")}
+            onClick={() => setSize(size === "peek" ? "full" : "peek")}
           >
             <Icon name="caret" size={20} className={size === "peek" ? "rotate-180" : undefined} />
           </IconBtn>
@@ -176,17 +172,24 @@ export function MobileComments({
             <Icon name="close" size={20} />
           </IconBtn>
         </div>
-        {sheet !== "peek" && (
+        {composer ? (
+          // Composing ("half open"): just the composer, so the sheet is a compact bar
+          // pinned above the keyboard with the document visible above. The list
+          // reappears once you send or cancel.
+          <div className="overflow-auto p-3 pb-[max(14px,env(safe-area-inset-bottom))]">
+            <Composer
+              quote={composer.anchor?.exact ?? null}
+              // After posting, open the full list so the new comment is visible (the
+              // sheet would otherwise drop back to the peek bar and hide it).
+              onSubmit={(text, mentions) => {
+                setSize("full")
+                onSubmitNew(text, mentions)
+              }}
+              onCancel={onCancelNew}
+            />
+          </div>
+        ) : size === "full" ? (
           <div className="min-h-0 flex-1 overflow-auto p-3 pb-[max(14px,env(safe-area-inset-bottom))]">
-            {composer && (
-              <div className="mb-3">
-                <Composer
-                  quote={composer.anchor?.exact ?? null}
-                  onSubmit={onSubmitNew}
-                  onCancel={onCancelNew}
-                />
-              </div>
-            )}
             {empty && (
               <div className="grid place-items-center gap-2 p-[34px] text-center">
                 <div className="text-3xl opacity-50">💬</div>
@@ -229,7 +232,7 @@ export function MobileComments({
               />
             )}
           </div>
-        )}
+        ) : null}
       </div>
     </>
   )


### PR DESCRIPTION
Per the feedback, simplify the mobile sheet:

- **Composing ("half open")** — a **compact composer bar** at the bottom, pinned just above the keyboard, document visible above. The box sits flush above the keyboard instead of floating high in a tall sheet. Posting opens the full list so the new comment shows.
- **Full** — the comment list, for viewing + replying.
- **Peek** — the slim bar (default + on collapse).

Removed the awkward half-height middle state and the `sheet` derivation; grip/chevron toggle peek↔full.

Verified: full e2e 45, Pixel + WebKit/iPhone, lints, typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)