### PR TITLE
feat(profiles): share by username or email + opt-in discoverability + people search

### DIFF
--- a/apps/api/src/auth-config.ts
+++ b/apps/api/src/auth-config.ts
@@ -104,6 +104,10 @@ export function makeAuth(db: AuthDb, baseUrl: string, secret: string) {
         // can't share one; nullable until claimed. Better Auth's migration adds
         // the column + unique index, and getSession returns it on the user.
         username: { type: "string", required: false, unique: true, input: false },
+        // Opt-in discoverability: when true, the account shows up in people search
+        // (GET /v1/users/search). Off by default (input:false, server-set via
+        // POST /v1/me/discoverable), so you're only findable if you choose to be.
+        discoverable: { type: "boolean", required: false, defaultValue: false, input: false },
       },
     },
     socialProviders,

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -32,6 +32,8 @@ export interface SessionUser {
   name: string | null
   /** Public handle (Profiles & Accounts v1); null until claimed at onboarding. */
   username: string | null
+  /** Opt-in: findable in people search when true. Off by default. */
+  discoverable: boolean
 }
 
 export interface AppDeps {
@@ -221,13 +223,25 @@ export function buildContext(deps: AppDeps) {
   const currentUser = async (c: Context): Promise<SessionUser | null> => {
     if (userCache.has(c)) return userCache.get(c) ?? null
     const s = deps.auth ? await deps.auth.api.getSession({ headers: c.req.raw.headers }) : null
-    // `username` rides the session via Better Auth additionalFields (see
-    // auth-config.ts); read it through a narrow cast since it's an optional extra.
+    // `username`/`discoverable` ride the session via Better Auth additionalFields
+    // (see auth-config.ts); read them through a narrow cast (optional extras).
     const su = s?.user as
-      | { id: string; email: string; name?: string | null; username?: string | null }
+      | {
+          id: string
+          email: string
+          name?: string | null
+          username?: string | null
+          discoverable?: boolean | number | null
+        }
       | undefined
     const u: SessionUser | null = su
-      ? { id: su.id, email: su.email, name: su.name ?? null, username: su.username ?? null }
+      ? {
+          id: su.id,
+          email: su.email,
+          name: su.name ?? null,
+          username: su.username ?? null,
+          discoverable: !!su.discoverable,
+        }
       : null
     userCache.set(c, u)
     if (u) c.set("actorId", u.id) // tag the access log with the resolved actor

--- a/apps/api/src/lib/resolve-user.ts
+++ b/apps/api/src/lib/resolve-user.ts
@@ -1,0 +1,19 @@
+import { type MetaStore, normalizeUsername } from "@dock/core"
+
+/**
+ * Resolve a sharing/invite target that may be typed as either an email or a
+ * @handle, returning the matched user's id (or null if unknown). An email has an
+ * `@` in the middle (`a@b.c`); a handle is bare or `@`-prefixed (`@nia` / `nia`).
+ * So Share accepts both: the username is the public identifier, the email still
+ * works for people who only know that.
+ */
+export const resolveUserRef = async (meta: MetaStore, ref: string): Promise<string | null> => {
+  const s = ref.trim()
+  if (!s) return null
+  if (/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s)) {
+    const u = await meta.findUserByEmail(s)
+    return u?.id ?? null
+  }
+  const p = await meta.getUserByUsername(normalizeUsername(s.replace(/^@/, "")))
+  return p?.id ?? null
+}

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -11,6 +11,7 @@ import { z } from "zod"
 import type { AppContext } from "../context"
 import { safeEqual } from "../lib/crypto"
 import { fail, readJson } from "../lib/http"
+import { resolveUserRef } from "../lib/resolve-user"
 
 /** Collections: shareable groups of artifacts. A member's role on a collection
  *  propagates to every artifact inside it (see collectionRolesForArtifact). */
@@ -124,14 +125,18 @@ export const collectionRoutes = (ctx: AppContext) => {
     if (!(await canManageCollection(c, col, "manage"))) return fail(c, 403, "forbidden")
     const b = await readJson(
       c,
-      z.object({
-        email: z.string().min(1, "an email is required"),
-        role: z.custom<Role>(isRole, "a valid role is required"),
-      }),
+      z
+        .object({
+          user: z.string().min(1).optional(),
+          email: z.string().min(1).optional(),
+          role: z.custom<Role>(isRole, "a valid role is required"),
+        })
+        .refine((v) => v.user || v.email, "a username or email is required"),
     )
     if (b instanceof Response) return b
-    const user = await meta.findUserByEmail(b.email.trim())
-    if (!user) return fail(c, 404, "no Dock user with that email")
+    const id = await resolveUserRef(meta, (b.user ?? b.email) as string)
+    const [user] = id ? await meta.getUsers([id]) : []
+    if (!user) return fail(c, 404, "no Dock user with that username or email")
     await meta.setCollectionMember({
       id: newId("cm"),
       collection_id: col.id,

--- a/apps/api/src/routes/session.ts
+++ b/apps/api/src/routes/session.ts
@@ -37,6 +37,32 @@ export const sessionRoutes = (ctx: AppContext) => {
     return c.json({ username })
   })
 
+  // Opt in/out of people search. Off by default, so you're only findable by
+  // username if you choose to be (signed-in user sets their own).
+  app.post("/v1/me/discoverable", async (c) => {
+    const u = await currentUser(c)
+    if (!u) return fail(c, 401, "unauthenticated")
+    const body = await readJson(c, z.object({ discoverable: z.boolean() }))
+    if (body instanceof Response) return body
+    await meta.setUserDiscoverable(u.id, body.discoverable)
+    return c.json({ discoverable: body.discoverable })
+  })
+
+  // People search: find OPTED-IN accounts by handle or name (GitHub-style "add by
+  // username"). Only users who turned on discoverability appear, and only the
+  // public fields (handle, name, avatar) come back — never email. Signed-in only,
+  // and an empty query returns nothing, so it can't be used to enumerate everyone.
+  // Registered before /v1/users/:handle so "search" isn't read as a handle.
+  app.get("/v1/users/search", async (c) => {
+    if (!(await currentUser(c))) return fail(c, 401, "unauthenticated")
+    const q = (c.req.query("q") ?? "").trim()
+    if (!q) return c.json({ users: [] })
+    const found = await meta.searchDiscoverableUsers(q, 20)
+    return c.json({
+      users: found.map((u) => ({ username: u.username, name: u.name, image: u.image })),
+    })
+  })
+
   // A public profile by handle — the GitHub-style discovery surface. Email is
   // intentionally omitted (private); the handle, name, and avatar are public, so
   // this is readable by anyone (the GET passes the anon lockdown).

--- a/apps/api/src/routes/sharing.ts
+++ b/apps/api/src/routes/sharing.ts
@@ -3,6 +3,7 @@ import { type Context, Hono } from "hono"
 import { z } from "zod"
 import type { AppContext } from "../context"
 import { fail, readJson } from "../lib/http"
+import { resolveUserRef } from "../lib/resolve-user"
 
 /** Per-artifact role overrides (a share). Managing shares requires `share`
  *  (editor+, GDocs model); the share's role beats the caller's workspace baseline. */
@@ -44,16 +45,21 @@ export const sharingRoutes = (ctx: AppContext) => {
     if (!(await authorize(c, "share", artifact))) return fail(c, 403, "forbidden")
     const b = await readJson(
       c,
-      z.object({
-        email: z.string().min(1, "an email is required"),
-        role: z.custom<Role>(isRole, "a valid role is required"),
-      }),
+      z
+        .object({
+          // Share by @username or by email — either resolves to the account.
+          user: z.string().min(1).optional(),
+          email: z.string().min(1).optional(),
+          role: z.custom<Role>(isRole, "a valid role is required"),
+        })
+        .refine((v) => v.user || v.email, "a username or email is required"),
     )
     if (b instanceof Response) return b
     if (rank(b.role) > (await callerRank(c, artifact)))
       return fail(c, 403, "you can't grant a role above your own")
-    const user = await meta.findUserByEmail(b.email.trim())
-    if (!user) return fail(c, 404, "no Dock user with that email")
+    const id = await resolveUserRef(meta, (b.user ?? b.email) as string)
+    const [user] = id ? await meta.getUsers([id]) : []
+    if (!user) return fail(c, 404, "no Dock user with that username or email")
     await meta.setArtifactMember({
       id: newId("am"),
       artifact_id: artifact.id,

--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono"
 import { z } from "zod"
 import type { AppContext } from "../context"
 import { DEFAULT_WORKSPACE_NAME, fail, isWorkspaceRole, readJson } from "../lib/http"
+import { resolveUserRef } from "../lib/resolve-user"
 
 /** The workspace itself: name + members (Admin-managed), plus multi-workspace
  *  list / create / switch. A workspace always keeps at least one Admin. */
@@ -62,14 +63,18 @@ export const workspaceRoutes = (ctx: AppContext) => {
     if (!(await workspaceCan(c, "manage"))) return fail(c, 403, "forbidden")
     const b = await readJson(
       c,
-      z.object({
-        email: z.string().min(1, "an email is required"),
-        role: z.custom<Role>(isWorkspaceRole, "a valid role is required"),
-      }),
+      z
+        .object({
+          user: z.string().min(1).optional(),
+          email: z.string().min(1).optional(),
+          role: z.custom<Role>(isWorkspaceRole, "a valid role is required"),
+        })
+        .refine((v) => v.user || v.email, "a username or email is required"),
     )
     if (b instanceof Response) return b
-    const user = await meta.findUserByEmail(b.email.trim())
-    if (!user) return fail(c, 404, "no Dock user with that email")
+    const id = await resolveUserRef(meta, (b.user ?? b.email) as string)
+    const [user] = id ? await meta.getUsers([id]) : []
+    if (!user) return fail(c, 404, "no Dock user with that username or email")
     const org = await activeWorkspace(c)
     // This route both adds and re-roles, so it must honor the same last-Admin
     // guard as PATCH — otherwise an Admin could demote the sole Admin via PUT.

--- a/apps/api/test/helpers.ts
+++ b/apps/api/test/helpers.ts
@@ -49,7 +49,7 @@ const makePgStore = (name: string, users: TestUser[], team: Seat[]): TestStore =
         pgSchemas.add(schema)
       }
       await boot.query(
-        `CREATE TABLE IF NOT EXISTS ${schema}."user" (id text primary key, email text, name text, image text, username text)`,
+        `CREATE TABLE IF NOT EXISTS ${schema}."user" (id text primary key, email text, name text, image text, username text, discoverable boolean default false)`,
       )
       // Unique handle, mirroring Better Auth's additionalFields(username, unique).
       await boot.query(
@@ -57,8 +57,8 @@ const makePgStore = (name: string, users: TestUser[], team: Seat[]): TestStore =
       )
       for (const u of users)
         await boot.query(
-          `INSERT INTO ${schema}."user" (id, email, name, image, username) VALUES ($1, $2, $3, $4, $5) ON CONFLICT (id) DO NOTHING`,
-          [u.id, u.email, u.name, u.image ?? null, u.username ?? null],
+          `INSERT INTO ${schema}."user" (id, email, name, image, username, discoverable) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT (id) DO NOTHING`,
+          [u.id, u.email, u.name, u.image ?? null, u.username ?? null, u.discoverable ?? false],
         )
     } finally {
       await boot.end()
@@ -96,14 +96,15 @@ const makePgStore = (name: string, users: TestUser[], team: Seat[]): TestStore =
 const seedSqliteUsers = (path: string, users: TestUser[]): void => {
   const raw = new Database(path)
   raw.exec(
-    `CREATE TABLE IF NOT EXISTS user (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT, username TEXT)`,
+    `CREATE TABLE IF NOT EXISTS user (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT, username TEXT, discoverable INTEGER DEFAULT 0)`,
   )
   // Unique handle, mirroring Better Auth's additionalFields(username, unique).
   raw.exec(`CREATE UNIQUE INDEX IF NOT EXISTS user_username ON user (username)`)
   const ins = raw.prepare(
-    `INSERT OR IGNORE INTO user (id, email, name, image, username) VALUES (?,?,?,?,?)`,
+    `INSERT OR IGNORE INTO user (id, email, name, image, username, discoverable) VALUES (?,?,?,?,?,?)`,
   )
-  for (const u of users) ins.run(u.id, u.email, u.name, u.image ?? null, u.username ?? null)
+  for (const u of users)
+    ins.run(u.id, u.email, u.name, u.image ?? null, u.username ?? null, u.discoverable ? 1 : 0)
   raw.close()
 }
 
@@ -224,6 +225,7 @@ export type TestUser = {
   name: string | null
   image?: string | null
   username?: string | null
+  discoverable?: boolean
 }
 
 const fakeAuth = (users: TestUser[]): AppDeps["auth"] =>

--- a/apps/api/test/profiles.test.ts
+++ b/apps/api/test/profiles.test.ts
@@ -151,3 +151,43 @@ describe("profile avatars", () => {
     expect((await app.request("/v1/me/avatar", { method: "POST", body: fd })).status).toBe(403)
   })
 })
+
+describe("opt-in discoverability + people search", () => {
+  const nova: TestUser = {
+    id: "u_disc_nova",
+    email: "nova@d.test",
+    name: "Nova Star",
+    username: "nova",
+    discoverable: true,
+  }
+  // Dane has a handle but has NOT opted in.
+  const dane: TestUser = { id: "u_disc_dane", email: "dane@d.test", name: "Dane", username: "dane" }
+  const { app } = makeAuthedApp("discover", [nova, dane])
+  const handles = (r: { users: { username: string }[] }) => r.users.map((u) => u.username)
+  const search = async (q: string, by?: string) =>
+    (await app.request(`/v1/users/search?q=${q}`, by ? { headers: as(by) } : {})).json()
+
+  it("returns only opted-in users, never email; needs a query + auth", async () => {
+    // Nova opted in → found by handle and by name; Dane (opted out) never appears.
+    expect(handles(await search("nov", dane.email))).toContain("nova")
+    expect(handles(await search("star", dane.email))).toContain("nova")
+    expect((await search("nov", dane.email)).users[0]).not.toHaveProperty("email")
+    expect(handles(await search("dane", nova.email))).toHaveLength(0)
+    // Empty query returns nothing (no full enumeration); anonymous is refused.
+    expect(handles(await search("", nova.email))).toHaveLength(0)
+    expect((await app.request("/v1/users/search?q=nov")).status).toBe(401)
+  })
+
+  it("toggling discoverability on makes you findable, off hides you again", async () => {
+    expect(
+      (await app.request("/v1/me/discoverable", jsonAs(as(dane.email), { discoverable: true })))
+        .status,
+    ).toBe(200)
+    expect(handles(await search("dane", nova.email))).toContain("dane")
+    await app.request("/v1/me/discoverable", jsonAs(as(dane.email), { discoverable: false }))
+    expect(handles(await search("dane", nova.email))).toHaveLength(0)
+    // /v1/me carries the (seeded) flag.
+    const me = await (await app.request("/v1/me", { headers: as(nova.email) })).json()
+    expect(me.user.discoverable).toBe(true)
+  })
+})

--- a/apps/api/test/sharing.test.ts
+++ b/apps/api/test/sharing.test.ts
@@ -41,3 +41,33 @@ describe("artifact share → notification", () => {
     expect(aliceN.unread).toBe(0)
   })
 })
+
+describe("share by username or email", () => {
+  const ann: TestUser = { id: "u_shu_ann", email: "ann@shu.test", name: "Ann" }
+  // Bob has a handle; we'll add him by @handle, not his email.
+  const bob: TestUser = { id: "u_shu_bob", email: "bob@shu.test", name: "Bob", username: "bobby" }
+  const { app } = makeAuthedApp("share-by-username", [ann, bob], "editor")
+
+  const put = (body: Record<string, unknown>, by: string) =>
+    app.request(`/v1/artifacts/${SID}/members`, { ...jsonAs(as(by), body), method: "PUT" })
+  let SID = ""
+
+  it("resolves a @handle, a bare handle, and an email to the same account", async () => {
+    SID = (await (await publishAs(app, "<h1>d</h1>", {}, as(ann.email))).json()).short_id
+
+    // By @handle.
+    const r1 = await put({ user: "@bobby", role: "viewer" }, ann.email)
+    expect(r1.status).toBe(201)
+    expect((await r1.json()).user_id).toBe(bob.id)
+
+    // By bare handle (case-insensitive).
+    expect((await put({ user: "BOBBY", role: "commenter" }, ann.email)).status).toBe(201)
+    // Still by email (back-compat).
+    expect((await put({ email: "bob@shu.test", role: "editor" }, ann.email)).status).toBe(201)
+
+    // An unknown handle is a 404, not a silent no-op.
+    expect((await put({ user: "@nobody", role: "viewer" }, ann.email)).status).toBe(404)
+    // Neither field → 400.
+    expect((await put({ role: "viewer" }, ann.email)).status).toBe(400)
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -6,6 +6,8 @@ export interface Me {
   username: string | null
   /** Avatar URL; null until a photo is set. */
   image: string | null
+  /** Opt-in: findable in people search when true. */
+  discoverable: boolean
   role: string
 }
 /** A public profile, by handle. Email is private and never returned here. */
@@ -301,6 +303,7 @@ export const api = {
         name: s.user.name ?? null,
         username: s.user.username ?? null,
         image: s.user.image ?? null,
+        discoverable: !!s.user.discoverable,
         role: "member",
       },
     }
@@ -312,6 +315,12 @@ export const api = {
   // A public profile by handle (no email). Readable without a session.
   profile: (handle: string): Promise<{ user: PublicProfile }> =>
     f(`/v1/users/${encodeURIComponent(handle)}`, { credentials: "include" }).then(j),
+  // Opt in/out of people search.
+  setDiscoverable: (discoverable: boolean): Promise<{ discoverable: boolean }> =>
+    f("/v1/me/discoverable", opts({ discoverable })).then(j),
+  // Find opted-in people by @handle or name (signed-in; empty q → []).
+  searchPeople: (q: string): Promise<{ users: PublicProfile[] }> =>
+    f(`/v1/users/search?q=${encodeURIComponent(q)}`, opts()).then(j),
   // Upload a profile picture (raster image; server validates + stores it and sets
   // user.image to the served URL). Returns the new image URL.
   uploadAvatar: (file: File): Promise<{ image: string }> => {
@@ -415,8 +424,9 @@ export const api = {
 
   listMembers: (id: string): Promise<{ default_role: Role; members: ArtifactMember[] }> =>
     f(`/v1/artifacts/${id}/members`, opts()).then(j),
-  setMember: (id: string, email: string, role: Role): Promise<ArtifactMember> =>
-    f(`/v1/artifacts/${id}/members`, { ...opts({ email, role }), method: "PUT" }).then(j),
+  // `user` is a @username or an email; the server resolves either to the account.
+  setMember: (id: string, user: string, role: Role): Promise<ArtifactMember> =>
+    f(`/v1/artifacts/${id}/members`, { ...opts({ user, role }), method: "PUT" }).then(j),
   removeMember: (id: string, userId: string): Promise<void> =>
     f(`/v1/artifacts/${id}/members/${userId}`, { method: "DELETE", credentials: "include" }).then(
       () => undefined,
@@ -494,8 +504,8 @@ export const api = {
   getWorkspace: (): Promise<Workspace> => f("/v1/workspace", opts()).then(j),
   renameWorkspace: (name: string): Promise<{ name: string }> =>
     f("/v1/workspace", { ...opts({ name }), method: "PATCH" }).then(j),
-  addWorkspaceMember: (email: string, role: Role): Promise<ArtifactMember> =>
-    f("/v1/workspace/members", { ...opts({ email, role }), method: "PUT" }).then(j),
+  addWorkspaceMember: (user: string, role: Role): Promise<ArtifactMember> =>
+    f("/v1/workspace/members", { ...opts({ user, role }), method: "PUT" }).then(j),
   setWorkspaceMemberRole: (userId: string, role: Role): Promise<{ user_id: string; role: Role }> =>
     f(`/v1/workspace/members/${userId}`, { ...opts({ role }), method: "PATCH" }).then(j),
   removeWorkspaceMember: (userId: string): Promise<void> =>
@@ -532,8 +542,8 @@ export const api = {
     }).then(() => undefined),
   listCollectionMembers: (id: string): Promise<{ created_by: string; members: ArtifactMember[] }> =>
     f(`/v1/collections/${id}/members`, opts()).then(j),
-  setCollectionMember: (id: string, email: string, role: Role): Promise<ArtifactMember> =>
-    f(`/v1/collections/${id}/members`, { ...opts({ email, role }), method: "PUT" }).then(j),
+  setCollectionMember: (id: string, user: string, role: Role): Promise<ArtifactMember> =>
+    f(`/v1/collections/${id}/members`, { ...opts({ user, role }), method: "PUT" }).then(j),
   removeCollectionMember: (id: string, userId: string): Promise<void> =>
     f(`/v1/collections/${id}/members/${userId}`, {
       method: "DELETE",

--- a/apps/web/src/components/ShareDialog.tsx
+++ b/apps/web/src/components/ShareDialog.tsx
@@ -245,9 +245,11 @@ export function ShareButton({
                 <form onSubmit={add} className="flex gap-1.5">
                   <Input
                     data-testid="share-email"
-                    type="email"
-                    placeholder="teammate@email.com"
-                    aria-label="Email"
+                    type="text"
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                    placeholder="@username or email"
+                    aria-label="Username or email"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
                     className="flex-1"

--- a/apps/web/src/components/nav-rail.tsx
+++ b/apps/web/src/components/nav-rail.tsx
@@ -240,6 +240,20 @@ export function NavRail() {
           testId="sidebar-favorites"
           onClick={closeDrawer}
         />
+        <Link
+          to="/people"
+          title="Find people"
+          aria-label="Find people"
+          data-testid="sidebar-people"
+          aria-current={loc.pathname === "/people" ? "page" : undefined}
+          onClick={closeDrawer}
+          className={cn(ROW_BASE, loc.pathname === "/people" && ROW_ACTIVE, railMode && ROW_RAIL)}
+        >
+          <span className="flex w-[18px] shrink-0 items-center justify-center">
+            <Icon name="user" size={18} />
+          </span>
+          {!railMode && <span className="overflow-hidden text-ellipsis">Find people</span>}
+        </Link>
 
         {!railMode && (
           <SideLabel

--- a/apps/web/src/pages/library/share-collection-dialog.tsx
+++ b/apps/web/src/pages/library/share-collection-dialog.tsx
@@ -75,10 +75,12 @@ export function ShareCollectionDialog({
 
         <form onSubmit={add} className="mb-3 flex gap-1.5">
           <Input
-            type="email"
+            type="text"
+            autoCapitalize="none"
+            autoCorrect="off"
             data-testid="collection-share-email"
-            placeholder="teammate@email.com"
-            aria-label="Email"
+            placeholder="@username or email"
+            aria-label="Username or email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             className="flex-1"

--- a/apps/web/src/pages/people.tsx
+++ b/apps/web/src/pages/people.tsx
@@ -1,0 +1,76 @@
+import { useQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
+import { useEffect, useRef, useState } from "react"
+import { api } from "@/api"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Input } from "@/components/ui/input"
+
+// Find people: search opted-in accounts by @handle or name and open their public
+// profile. Only users who turned on discoverability appear (server-enforced).
+export function People() {
+  const [q, setQ] = useState("")
+  const [debounced, setDebounced] = useState("")
+  const input = useRef<HTMLInputElement>(null)
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only focus.
+  useEffect(() => input.current?.focus(), [])
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(q.trim()), 250)
+    return () => clearTimeout(t)
+  }, [q])
+
+  const { data, isFetching } = useQuery({
+    queryKey: ["people", debounced],
+    queryFn: () => api.searchPeople(debounced).then((r) => r.users),
+    enabled: debounced.length > 0,
+  })
+  const users = debounced ? (data ?? []) : []
+
+  return (
+    <div className="mx-auto w-full max-w-xl p-6 sm:p-10">
+      <h1 className="mb-1 font-display text-2xl font-semibold text-foreground">Find people</h1>
+      <p className="mb-4 text-sm text-muted-foreground">
+        Search people by username or name. Only those who've made themselves discoverable appear.
+      </p>
+      <Input
+        ref={input}
+        data-testid="people-search"
+        value={q}
+        autoCapitalize="none"
+        autoCorrect="off"
+        onChange={(e) => setQ(e.target.value)}
+        placeholder="@username or name"
+        aria-label="Search people"
+      />
+      <div className="mt-4 flex flex-col gap-1">
+        {debounced && users.length === 0 && !isFetching && (
+          <p className="px-2 text-sm text-muted-foreground" data-testid="people-empty">
+            No one found for "{debounced}".
+          </p>
+        )}
+        {users.map((u) => (
+          <Link
+            key={u.username}
+            to="/u/$handle"
+            params={{ handle: u.username }}
+            data-testid="people-result"
+            className="flex items-center gap-3 rounded-lg p-2 transition-colors hover:bg-hover"
+          >
+            <Avatar className="size-9">
+              {u.image && <AvatarImage src={u.image} alt={u.name ?? u.username} />}
+              <AvatarFallback>{(u.name ?? u.username).slice(0, 2).toUpperCase()}</AvatarFallback>
+            </Avatar>
+            <span className="min-w-0">
+              {u.name && (
+                <span className="block truncate text-sm font-semibold text-foreground">
+                  {u.name}
+                </span>
+              )}
+              <span className="block truncate text-xs text-muted-foreground">@{u.username}</span>
+            </span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/profile.tsx
+++ b/apps/web/src/pages/profile.tsx
@@ -21,6 +21,19 @@ export function Profile() {
   const { me, setMe } = useAuth()
   const nav = useNavigate()
   const [editing, setEditing] = useState(false)
+  const [discoverable, setDiscoverable] = useState(!!me?.discoverable)
+
+  // Opt in/out of people search (optimistic; revert on failure).
+  const toggleDiscoverable = async () => {
+    const next = !discoverable
+    setDiscoverable(next)
+    try {
+      await api.setDiscoverable(next)
+      if (me) setMe({ ...me, discoverable: next })
+    } catch {
+      setDiscoverable(!next)
+    }
+  }
 
   const { data, isPending, isError } = useQuery({
     queryKey: ["profile", handle],
@@ -81,14 +94,26 @@ export function Profile() {
               />
             </div>
           ) : (
-            <Button
-              variant="outline"
-              size="sm"
-              data-testid="profile-edit"
-              onClick={() => setEditing(true)}
-            >
-              Change username
-            </Button>
+            <div className="flex flex-col items-center gap-3 pt-1">
+              <Button
+                variant="outline"
+                size="sm"
+                data-testid="profile-edit"
+                onClick={() => setEditing(true)}
+              >
+                Change username
+              </Button>
+              <label className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
+                <input
+                  type="checkbox"
+                  data-testid="profile-discoverable"
+                  checked={discoverable}
+                  onChange={toggleDiscoverable}
+                  className="size-4"
+                />
+                Let people find me by username in search
+              </label>
+            </div>
           ))}
       </Card>
     </div>

--- a/apps/web/src/pages/settings/workspace-section.tsx
+++ b/apps/web/src/pages/settings/workspace-section.tsx
@@ -220,8 +220,10 @@ export function WorkspaceSection({ meId }: { meId: string }) {
           <div className="flex flex-wrap gap-2">
             <Input
               data-testid="member-email"
-              aria-label="Email of a Dock user"
-              placeholder="Email of a Dock user"
+              autoCapitalize="none"
+              autoCorrect="off"
+              aria-label="Username or email of a Dock user"
+              placeholder="@username or email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && addMember()}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as PeopleRouteImport } from './routes/people'
 import { Route as NewRouteImport } from './routes/new'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as IndexRouteImport } from './routes/index'
@@ -19,6 +20,11 @@ import { Route as ARefRouteImport } from './routes/a.$ref'
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PeopleRoute = PeopleRouteImport.update({
+  id: '/people',
+  path: '/people',
   getParentRoute: () => rootRouteImport,
 } as any)
 const NewRoute = NewRouteImport.update({
@@ -51,6 +57,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/new': typeof NewRoute
+  '/people': typeof PeopleRoute
   '/settings': typeof SettingsRoute
   '/a/$ref': typeof ARefRoute
   '/u/$handle': typeof UHandleRoute
@@ -59,6 +66,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/new': typeof NewRoute
+  '/people': typeof PeopleRoute
   '/settings': typeof SettingsRoute
   '/a/$ref': typeof ARefRoute
   '/u/$handle': typeof UHandleRoute
@@ -68,20 +76,36 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/new': typeof NewRoute
+  '/people': typeof PeopleRoute
   '/settings': typeof SettingsRoute
   '/a/$ref': typeof ARefRoute
   '/u/$handle': typeof UHandleRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/login' | '/new' | '/settings' | '/a/$ref' | '/u/$handle'
+  fullPaths:
+    | '/'
+    | '/login'
+    | '/new'
+    | '/people'
+    | '/settings'
+    | '/a/$ref'
+    | '/u/$handle'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/new' | '/settings' | '/a/$ref' | '/u/$handle'
+  to:
+    | '/'
+    | '/login'
+    | '/new'
+    | '/people'
+    | '/settings'
+    | '/a/$ref'
+    | '/u/$handle'
   id:
     | '__root__'
     | '/'
     | '/login'
     | '/new'
+    | '/people'
     | '/settings'
     | '/a/$ref'
     | '/u/$handle'
@@ -91,6 +115,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LoginRoute: typeof LoginRoute
   NewRoute: typeof NewRoute
+  PeopleRoute: typeof PeopleRoute
   SettingsRoute: typeof SettingsRoute
   ARefRoute: typeof ARefRoute
   UHandleRoute: typeof UHandleRoute
@@ -103,6 +128,13 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/settings'
       preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/people': {
+      id: '/people'
+      path: '/people'
+      fullPath: '/people'
+      preLoaderRoute: typeof PeopleRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/new': {
@@ -147,6 +179,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LoginRoute: LoginRoute,
   NewRoute: NewRoute,
+  PeopleRoute: PeopleRoute,
   SettingsRoute: SettingsRoute,
   ARefRoute: ARefRoute,
   UHandleRoute: UHandleRoute,

--- a/apps/web/src/routes/people.tsx
+++ b/apps/web/src/routes/people.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { People } from "../pages/people"
+
+// Find people by username/name (opt-in discoverability).
+export const Route = createFileRoute("/people")({
+  component: People,
+})

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -315,6 +315,11 @@ export interface MetaStore {
   setUsername(userId: string, username: string): Promise<"ok" | "taken">
   /** Set a user's avatar URL (image column on Better Auth's user table). */
   setUserImage(userId: string, image: string): Promise<void>
+  /** Opt a user in/out of people search (discoverable column). */
+  setUserDiscoverable(userId: string, discoverable: boolean): Promise<void>
+  /** People search: opted-in (discoverable) profiles matching `q` on username or
+   *  name, capped to `limit`. Empty `q` returns nothing (no full enumeration). */
+  searchDiscoverableUsers(q: string, limit: number): Promise<UserProfile[]>
 
   // ---- Notifications (in-app, one row per recipient) --------------------
   createNotification(n: NewNotification): Promise<void>

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -162,6 +162,24 @@ export function createD1Store(d1: D1Database): MetaStore {
     setUserImage: async (userId: string, image: string): Promise<void> => {
       await db.run(sql`UPDATE user SET image = ${image} WHERE id = ${userId}`)
     },
+    setUserDiscoverable: async (userId: string, discoverable: boolean): Promise<void> => {
+      await db.run(sql`UPDATE user SET discoverable = ${discoverable ? 1 : 0} WHERE id = ${userId}`)
+    },
+    searchDiscoverableUsers: async (q: string, limit: number): Promise<UserProfile[]> => {
+      const s = q.trim().toLowerCase()
+      if (!s) return []
+      try {
+        const like = `%${s}%`
+        return (await db.all(
+          sql`SELECT id, name, image, username FROM user
+              WHERE discoverable = 1 AND username IS NOT NULL
+                AND (lower(username) LIKE ${like} OR lower(name) LIKE ${like})
+              ORDER BY username LIMIT ${limit}`,
+        )) as UserProfile[]
+      } catch {
+        return []
+      }
+    },
   }
 }
 

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -885,6 +885,29 @@ export class PgMetaStore implements MetaStore {
   async setUserImage(userId: string, image: string): Promise<void> {
     await this.pool.query(`UPDATE "user" SET image = $1 WHERE id = $2`, [image, userId])
   }
+  async setUserDiscoverable(userId: string, discoverable: boolean): Promise<void> {
+    await this.pool.query(`UPDATE "user" SET discoverable = $1 WHERE id = $2`, [
+      discoverable,
+      userId,
+    ])
+  }
+  async searchDiscoverableUsers(q: string, limit: number): Promise<UserProfile[]> {
+    const s = q.trim()
+    if (!s) return []
+    try {
+      const like = `%${s}%`
+      const { rows } = await this.pool.query(
+        `SELECT id, name, image, username FROM "user"
+         WHERE discoverable = true AND username IS NOT NULL
+           AND (username ILIKE $1 OR name ILIKE $1)
+         ORDER BY username LIMIT $2`,
+        [like, limit],
+      )
+      return rows as UserProfile[]
+    } catch {
+      return []
+    }
+  }
 
   // ---- Notifications (in-app, one row per recipient) ---------------------
   async createNotification(n: NewNotification): Promise<void> {

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -245,6 +245,26 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
     setUserImage: async (userId, image): Promise<void> => {
       raw.prepare(`UPDATE user SET image = ? WHERE id = ?`).run(image, userId)
     },
+    setUserDiscoverable: async (userId, discoverable): Promise<void> => {
+      raw.prepare(`UPDATE user SET discoverable = ? WHERE id = ?`).run(discoverable ? 1 : 0, userId)
+    },
+    searchDiscoverableUsers: async (q, limit): Promise<UserProfile[]> => {
+      const s = q.trim().toLowerCase()
+      if (!s) return []
+      try {
+        const like = `%${s}%`
+        return raw
+          .prepare(
+            `SELECT id, name, image, username FROM user
+             WHERE discoverable = 1 AND username IS NOT NULL
+               AND (lower(username) LIKE ? OR lower(name) LIKE ?)
+             ORDER BY username LIMIT ?`,
+          )
+          .all(like, like, limit) as UserProfile[]
+      } catch {
+        return []
+      }
+    },
 
     close: () => raw.close(),
   }

--- a/packages/db/test/pg-store.test.ts
+++ b/packages/db/test/pg-store.test.ts
@@ -117,6 +117,77 @@ if (PG_URL) {
       )
     })
   })
+
+  // The user-directory methods read Better Auth's `user` table (created out of
+  // band), so — like the OAuth block — they're seeded + asserted per-dialect here.
+  describe("pg store: user directory (Better Auth `user` table)", () => {
+    const u = url
+    const inSchema = async (
+      seed: (boot: Pool, schema: string) => Promise<void>,
+      run: (store: PgMetaStore) => Promise<void>,
+    ) => {
+      const schema = `t_pguser_${process.pid}_${uuid().replace(/-/g, "")}`
+      const boot = new Pool({ connectionString: u, max: 1 })
+      await boot.query(`CREATE SCHEMA ${schema}`)
+      await seed(boot, schema)
+      await boot.end()
+      const opt = encodeURIComponent(`-c search_path=${schema}`)
+      const store = await PgMetaStore.create(`${u}${u.includes("?") ? "&" : "?"}options=${opt}`)
+      try {
+        await run(store)
+      } finally {
+        await store.close()
+        const drop = new Pool({ connectionString: u, max: 1 })
+        await drop.query(`DROP SCHEMA IF EXISTS ${schema} CASCADE`)
+        await drop.end()
+      }
+    }
+
+    it("tolerates the user table being absent", async () => {
+      await inSchema(
+        async () => {},
+        async (store) => {
+          expect(await store.findUserByEmail("x@y.com")).toBeNull()
+          expect(await store.getUsers(["x"])).toEqual([])
+          expect(await store.getUserByUsername("ghost")).toBeNull()
+          expect(await store.searchDiscoverableUsers("a", 10)).toEqual([])
+        },
+      )
+    })
+
+    it("resolves users by email/id/handle, sets avatar, powers opt-in search", async () => {
+      await inSchema(
+        async (boot, schema) => {
+          await boot.query(
+            `CREATE TABLE ${schema}."user" (id text primary key, email text, name text, image text, username text, discoverable boolean default false)`,
+          )
+          await boot.query(`CREATE UNIQUE INDEX ON ${schema}."user" (username)`)
+          await boot.query(
+            `INSERT INTO ${schema}."user"(id,email,name) VALUES('u1','amy@x.com','Amy'),('u2','bo@x.com','Bo')`,
+          )
+        },
+        async (store) => {
+          expect(await store.findUserByEmail("amy@x.com")).toMatchObject({ id: "u1", name: "Amy" })
+          expect((await store.getUsers(["u1"])).map((x) => x.email)).toEqual(["amy@x.com"])
+          expect(await store.setUsername("u1", "amy")).toBe("ok")
+          expect(await store.getUserByUsername("amy")).toMatchObject({ id: "u1", username: "amy" })
+          expect(await store.getUserByUsername("nope")).toBeNull()
+          expect(await store.setUsername("u2", "amy")).toBe("taken")
+          await store.setUserImage("u1", "https://cdn/x.png")
+          expect((await store.getUserByUsername("amy"))?.image).toBe("https://cdn/x.png")
+          expect(await store.searchDiscoverableUsers("am", 10)).toEqual([]) // not opted in
+          await store.setUserDiscoverable("u1", true)
+          expect((await store.searchDiscoverableUsers("am", 10)).map((x) => x.username)).toEqual([
+            "amy",
+          ])
+          expect((await store.searchDiscoverableUsers("AMY", 10)).map((x) => x.id)).toEqual(["u1"])
+          expect(await store.searchDiscoverableUsers("", 10)).toEqual([])
+          await store.setUserDiscoverable("u1", false)
+          expect(await store.searchDiscoverableUsers("am", 10)).toEqual([])
+        },
+      )
+    })
+  })
 } else {
   // Keep the file non-empty for the default (SQLite-only) run.
   describe("pg store", () => {

--- a/packages/db/test/sqlite-store.test.ts
+++ b/packages/db/test/sqlite-store.test.ts
@@ -21,10 +21,12 @@ describe("sqlite store: user directory (Better Auth `user` table)", () => {
     const fresh = new SqliteMetaStore(":memory:")
     expect(await fresh.findUserByEmail("nobody@x.com")).toBeNull()
     expect(await fresh.getUsers(["x"])).toEqual([])
+    expect(await fresh.getUserByUsername("ghost")).toBeNull()
+    expect(await fresh.searchDiscoverableUsers("a", 10)).toEqual([])
     fresh.close()
   })
 
-  it("resolves seeded users by email and id", async () => {
+  it("resolves users by email/id/handle, sets avatar, and powers opt-in search", async () => {
     const { mkdtempSync, rmSync } = await import("node:fs")
     const { tmpdir } = await import("node:os")
     const { join } = await import("node:path")
@@ -33,15 +35,40 @@ describe("sqlite store: user directory (Better Auth `user` table)", () => {
     const s = new SqliteMetaStore(path)
     const raw = new Database(path)
     raw.exec(
-      `CREATE TABLE IF NOT EXISTS user (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT)`,
+      `CREATE TABLE IF NOT EXISTS user (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT, username TEXT, discoverable INTEGER DEFAULT 0)`,
     )
-    raw
-      .prepare(`INSERT INTO user (id, email, name, image) VALUES (?,?,?,?)`)
-      .run("u1", "amy@x.com", "Amy", null)
+    raw.exec(`CREATE UNIQUE INDEX user_username ON user (username)`)
+    const ins = raw.prepare(`INSERT INTO user (id, email, name) VALUES (?,?,?)`)
+    ins.run("u1", "amy@x.com", "Amy")
+    ins.run("u2", "bo@x.com", "Bo")
     raw.close()
+
+    // Email + id directory.
     expect(await s.findUserByEmail("amy@x.com")).toMatchObject({ id: "u1", name: "Amy" })
     expect((await s.getUsers(["u1"])).map((u) => u.email)).toEqual(["amy@x.com"])
     expect(await s.getUsers([])).toEqual([])
+
+    // Claim a handle; resolve it; reject a clash; own handle re-set is a no-op.
+    expect(await s.setUsername("u1", "amy")).toBe("ok")
+    expect(await s.getUserByUsername("amy")).toMatchObject({ id: "u1", username: "amy" })
+    expect(await s.getUserByUsername("nope")).toBeNull()
+    expect(await s.setUsername("u2", "amy")).toBe("taken")
+    expect(await s.setUsername("u1", "amy")).toBe("ok")
+
+    // Avatar.
+    await s.setUserImage("u1", "https://cdn/x.png")
+    expect((await s.getUserByUsername("amy"))?.image).toBe("https://cdn/x.png")
+
+    // People search: only opted-in users; by handle or name; case-insensitive;
+    // empty query returns nothing; opting back out hides you again.
+    expect(await s.searchDiscoverableUsers("am", 10)).toEqual([]) // not discoverable yet
+    await s.setUserDiscoverable("u1", true)
+    expect((await s.searchDiscoverableUsers("am", 10)).map((u) => u.username)).toEqual(["amy"])
+    expect((await s.searchDiscoverableUsers("AMY", 10)).map((u) => u.id)).toEqual(["u1"])
+    expect(await s.searchDiscoverableUsers("", 10)).toEqual([])
+    await s.setUserDiscoverable("u1", false)
+    expect(await s.searchDiscoverableUsers("am", 10)).toEqual([])
+
     s.close()
     rmSync(dir, { recursive: true, force: true })
   })


### PR DESCRIPTION
Username-powered collaboration on top of Profiles v1 (#154).

## Share by @handle **or** email
- `resolveUserRef` (`apps/api/src/lib/resolve-user.ts`) maps either form to the account: an email has an `@` in the middle, a handle is bare or `@`-prefixed.
- The artifact `/members`, collection `/members`, and workspace `/members` routes now accept `user` (handle or email) and still accept `email` for back-compat.
- The Share dialogs + settings member-add read **"@username or email"** (text input, not `type=email`) and send `user`.

## Opt-in discoverability + people search
- A **`discoverable`** flag on the account (Better Auth `additionalFields`, **default off**, server-set via `POST /v1/me/discoverable`). `setUserDiscoverable` + `searchDiscoverableUsers` on the MetaStore (sqlite/d1/pg).
- `GET /v1/users/search` (signed-in; registered **before** `/v1/users/:handle` so "search" isn't read as a handle) returns **only opted-in** profiles matching a non-empty query, **public fields only** (no email, and an empty query returns nothing so it can't enumerate everyone).
- A **"Let people find me by username"** toggle on your own profile, a **Find people** nav entry + `/people` search page, and `discoverable` surfaced on `Me`/the session.

## Tests
- Share resolves `@handle` / bare handle / email (+ 404 unknown, 400 neither).
- Search returns only opted-in users (never email), needs a query + auth, and toggling the flag flips findability.
- Full gate green: typecheck, **API 299**, web 48, biome + custom lints + knip.

Verified in the browser: toggled discoverability on → found in People search; Share added a collaborator by `@handle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)