### PR TITLE
polish(oauth): on-brand cli-callback page

### DIFF
--- a/apps/api/src/oauth-cli-callback.ts
+++ b/apps/api/src/oauth-cli-callback.ts
@@ -5,38 +5,71 @@
 // one-time `code`; we display it for you to paste back into the terminal. The
 // PKCE code_verifier never leaves the CLI, so the displayed code is useless to
 // anyone else — it only completes the exchange paired with that local verifier.
+//
+// On the Dock plan-site palette (Space Grotesk + Inter, the anchor mark) so the
+// auth experience feels like Dock.
 
 const esc = (s: string): string =>
   s.replace(/[&<>"']/g, (c) =>
     c === "&" ? "&amp;" : c === "<" ? "&lt;" : c === ">" ? "&gt;" : c === '"' ? "&quot;" : "&#39;",
   )
 
-const SHELL = (title: string, inner: string): string => `<!doctype html>
+// The Dock anchor mark, inline so the page is a single self-contained document.
+const MARK = `<svg class="mk" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="8" fill="#2a2540"/>
+  <path d="M16 7l7 7v11h-4.6v-6.2h-4.8V25H9V14l7-7z" fill="none" stroke="#8a7dc0" stroke-width="1.7" stroke-linejoin="round"/>
+  <rect x="13.6" y="6.4" width="4.8" height="4.8" rx="1.2" fill="#655999"/>
+</svg>`
+
+const SHELL = (title: string, inner: { badge: string; body: string }): string => `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>${title} · Dock</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
 <style>
-  :root{--bg:#f6f0e3;--card:#fffdf8;--ink:#1a1714;--mut:#6b6258;--line:#e7ddc9;--ac:#7c6cbd;--ac-ink:#fff;--good:#3c8f4e}
+  :root{
+    --paper:#f6f0e3;--panel:#fdf8ec;--panel-2:#f6efe0;--ink:#2a2540;--ink-soft:#46415c;
+    --muted:#6b6680;--line:#e4dcc9;--line-2:#eee7d6;--accent:#655999;--accent-ink:#4f447e;
+    --accent-2:#8a7dc0;--accent-soft:#e8e4f1;--good:#6f7a35;--good-soft:#ebedda;--bad:#a04425;
+    --display:"Space Grotesk",ui-sans-serif,system-ui,sans-serif;
+    --sans:"Inter",system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+    --mono:ui-monospace,"SF Mono",Menlo,Consolas,monospace;
+  }
   *{box-sizing:border-box}
-  body{margin:0;min-height:100vh;display:grid;place-items:center;background:var(--bg);color:var(--ink);
-    font:15px/1.55 Inter,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased;padding:24px}
-  .card{width:100%;max-width:460px;background:var(--card);border:1px solid var(--line);border-radius:18px;
-    padding:30px 30px 26px;box-shadow:0 10px 40px rgba(60,45,20,.10)}
-  .logo{font-weight:700;letter-spacing:-.01em;font-size:15px;color:var(--mut);margin-bottom:20px;display:flex;align-items:center;gap:7px}
-  h1{font-size:20px;line-height:1.3;letter-spacing:-.02em;margin:0 0 6px;font-weight:650}
-  .sub{color:var(--mut);font-size:13.5px;margin:0 0 18px}
-  .code{display:flex;gap:10px;align-items:center;border:1px solid var(--line);border-radius:12px;background:#fbf7ee;padding:12px 14px}
-  .code code{flex:1;font:13px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;word-break:break-all;color:var(--ink)}
-  .btn{padding:9px 14px;border-radius:9px;font:600 13px Inter,system-ui,sans-serif;cursor:pointer;border:1px solid var(--ac);background:var(--ac);color:var(--ac-ink);transition:transform .04s,filter .15s;flex:none}
-  .btn:active{transform:translateY(1px)} .btn:hover{filter:brightness(1.06)}
-  .foot{color:var(--mut);font-size:12px;margin:18px 0 0}
-  .err{color:#c0492b;font-size:13.5px;margin:0}
-  kbd{background:#f1ead9;border-radius:5px;padding:1px 6px;font-size:.85em}
+  body{margin:0;min-height:100vh;display:grid;place-items:center;padding:24px;color:var(--ink);
+    background:var(--paper);font:15px/1.55 var(--sans);-webkit-font-smoothing:antialiased;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='220' height='220'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.045'/%3E%3C/svg%3E");}
+  .card{width:100%;max-width:460px;background:var(--panel);border:1px solid var(--line);border-radius:20px;
+    padding:32px 32px 26px;box-shadow:0 1px 2px rgba(42,37,64,.04),0 24px 60px -22px rgba(42,37,64,.32)}
+  .brand{display:flex;align-items:center;gap:10px;margin-bottom:22px}
+  .mk{width:30px;height:30px;display:block;flex:none}
+  .brand .name{font-family:var(--display);font-weight:600;font-size:17px;letter-spacing:-.02em}
+  .badge{margin-left:auto;font-family:var(--mono);font-size:10px;font-weight:600;letter-spacing:.05em;
+    text-transform:uppercase;padding:4px 9px;border-radius:999px}
+  .badge.ok{background:var(--good-soft);color:var(--good)}
+  .badge.err{background:#f1e1d6;color:var(--bad)}
+  h1{font-family:var(--display);font-weight:600;font-size:23px;line-height:1.2;letter-spacing:-.02em;margin:0 0 7px}
+  .sub{color:var(--ink-soft);font-size:14px;margin:0 0 20px}
+  .code{display:flex;gap:10px;align-items:center;border:1px solid var(--line);border-radius:13px;
+    background:var(--panel-2);padding:13px 15px}
+  .code code{flex:1;font:13px/1.45 var(--mono);word-break:break-all;color:var(--ink);letter-spacing:.01em}
+  .btn{padding:9px 15px;border-radius:10px;font:600 13px var(--sans);cursor:pointer;border:1px solid var(--accent);
+    background:var(--accent);color:#fff;flex:none;transition:transform .05s,filter .15s}
+  .btn:active{transform:translateY(1px)} .btn:hover{filter:brightness(1.07)}
+  .foot{color:var(--muted);font-size:12.5px;line-height:1.5;margin:20px 0 0}
+  .err{color:var(--bad);font-size:14px;margin:0 0 4px;font-weight:500}
+  kbd{font-family:var(--mono);background:var(--panel-2);border:1px solid var(--line-2);border-radius:6px;padding:1px 6px;font-size:.85em}
+  ::selection{background:var(--accent-soft);color:var(--accent-ink)}
 </style>
 </head>
-<body><main class="card">${inner}</main></body>
+<body><main class="card">
+  <div class="brand">${MARK}<span class="name">Dock</span>${inner.badge}</div>
+  ${inner.body}
+</main></body>
 </html>`
 
 /**
@@ -49,28 +82,26 @@ export function cliCallbackHTML(props: { code?: string; error?: string }): strin
     const msg = esc(
       props.error || "No authorization code was returned. Please run `dock login` again.",
     )
-    return SHELL(
-      "Authorization failed",
-      `<div class="logo">⚓ Dock</div>
-      <h1>Authorization didn't complete</h1>
+    return SHELL("Authorization failed", {
+      badge: `<span class="badge err">Failed</span>`,
+      body: `<h1>Authorization didn't complete</h1>
       <p class="err">${msg}</p>
-      <p class="foot">Close this tab and re-run <kbd>dock login</kbd> in your terminal.</p>`,
-    )
+      <p class="foot">Close this tab and re-run <kbd>dock login</kbd> in your terminal to try again.</p>`,
+    })
   }
   const code = esc(props.code)
-  return SHELL(
-    "Authorized",
-    `<div class="logo">⚓ Dock</div>
-    <h1>You're authorized</h1>
+  return SHELL("Authorized", {
+    badge: `<span class="badge ok">Authorized</span>`,
+    body: `<h1>You're authorized</h1>
     <p class="sub">Copy this code and paste it back into your terminal to finish signing in.</p>
     <div class="code">
       <code id="code">${code}</code>
       <button class="btn" id="copy" type="button">Copy</button>
     </div>
-    <p class="foot">This code only works paired with the verifier on your machine, and expires shortly. You can close this tab after copying.</p>
+    <p class="foot">This code only works paired with the verifier on your machine and expires shortly. You can close this tab once you've copied it.</p>
     <script>
       var b=document.getElementById("copy"),c=${JSON.stringify(props.code)};
-      b.onclick=function(){navigator.clipboard&&navigator.clipboard.writeText(c);b.textContent="Copied";setTimeout(function(){b.textContent="Copy"},1500)};
+      b.onclick=function(){navigator.clipboard&&navigator.clipboard.writeText(c);b.textContent="Copied ✓";setTimeout(function(){b.textContent="Copy"},1600)};
     </script>`,
-  )
+  })
 }

--- a/apps/api/src/oauth-consent.ts
+++ b/apps/api/src/oauth-consent.ts
@@ -4,6 +4,9 @@
 // /api/auth/oauth2/consent with the original query, and the plugin returns the
 // browser to the client's redirect_uri with the authorization code. This is the
 // human-in-the-loop grant: an agent can't self-authorize.
+//
+// On the Dock plan-site palette (Space Grotesk + Inter, the anchor mark) so the
+// grant moment feels like Dock.
 
 const SCOPE_LABELS: Record<string, string> = {
   openid: "Confirm who you are",
@@ -17,10 +20,20 @@ const SCOPE_LABELS: Record<string, string> = {
   "dock:review": "Approve or request changes on proposals",
 }
 
+// Scopes that let the agent change something get a distinct accent tick; read-only
+// scopes get a quieter one — so the grant's blast radius reads at a glance.
+const WRITE_SCOPES = new Set(["dock:comment", "dock:propose", "dock:publish", "dock:review"])
+
 const esc = (s: string): string =>
   s.replace(/[&<>"']/g, (c) =>
     c === "&" ? "&amp;" : c === "<" ? "&lt;" : c === ">" ? "&gt;" : c === '"' ? "&quot;" : "&#39;",
   )
+
+const MARK = `<svg class="mk" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+  <rect x="1" y="1" width="30" height="30" rx="8" fill="#2a2540"/>
+  <path d="M16 7l7 7v11h-4.6v-6.2h-4.8V25H9V14l7-7z" fill="none" stroke="#8a7dc0" stroke-width="1.7" stroke-linejoin="round"/>
+  <rect x="13.6" y="6.4" width="4.8" height="4.8" rx="1.2" fill="#655999"/>
+</svg>`
 
 /** The consent page HTML. `query` is the original authorize query string, echoed
  *  back to /oauth2/consent so the plugin can complete the authorization. */
@@ -31,7 +44,12 @@ export function consentHTML(props: {
 }): string {
   const name = esc(props.clientName || "An application")
   const items = props.scopes
-    .map((s) => `<li><span class="tick">✓</span><span>${esc(SCOPE_LABELS[s] ?? s)}</span></li>`)
+    .map((s) => {
+      const write = WRITE_SCOPES.has(s)
+      return `<li><span class="tick${write ? " w" : ""}" aria-hidden="true">${
+        write ? "✦" : "✓"
+      }</span><span>${esc(SCOPE_LABELS[s] ?? s)}</span></li>`
+    })
     .join("")
   return `<!doctype html>
 <html lang="en">
@@ -39,36 +57,54 @@ export function consentHTML(props: {
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Authorize ${name} · Dock</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
 <style>
-  :root{--bg:#f6f0e3;--card:#fffdf8;--ink:#1a1714;--mut:#6b6258;--line:#e7ddc9;--ac:#7c6cbd;--ac-ink:#fff;--good:#3c8f4e}
+  :root{
+    --paper:#f6f0e3;--panel:#fdf8ec;--panel-2:#f6efe0;--ink:#2a2540;--ink-soft:#46415c;
+    --muted:#6b6680;--line:#e4dcc9;--line-2:#eee7d6;--accent:#655999;--accent-ink:#4f447e;
+    --accent-2:#8a7dc0;--accent-soft:#e8e4f1;--good:#6f7a35;--bad:#a04425;
+    --display:"Space Grotesk",ui-sans-serif,system-ui,sans-serif;
+    --sans:"Inter",system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+    --mono:ui-monospace,"SF Mono",Menlo,Consolas,monospace;
+  }
   *{box-sizing:border-box}
-  body{margin:0;min-height:100vh;display:grid;place-items:center;background:var(--bg);color:var(--ink);
-    font:15px/1.55 Inter,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased;padding:24px}
-  .card{width:100%;max-width:440px;background:var(--card);border:1px solid var(--line);border-radius:18px;
-    padding:30px 30px 24px;box-shadow:0 10px 40px rgba(60,45,20,.10)}
-  .logo{font-weight:700;letter-spacing:-.01em;font-size:15px;color:var(--mut);margin-bottom:20px;display:flex;align-items:center;gap:7px}
-  h1{font-size:20px;line-height:1.3;letter-spacing:-.02em;margin:0 0 6px;font-weight:650}
-  h1 b{color:var(--ac);font-weight:700}
-  .sub{color:var(--mut);font-size:13.5px;margin:0 0 18px}
-  ul.scopes{list-style:none;margin:0 0 22px;padding:14px 16px;border:1px solid var(--line);border-radius:12px;background:#fbf7ee}
-  ul.scopes li{display:flex;gap:10px;align-items:flex-start;padding:6px 0;font-size:13.5px}
-  ul.scopes li+li{border-top:1px solid var(--line)}
-  .tick{color:var(--good);font-weight:700;flex:none}
+  body{margin:0;min-height:100vh;display:grid;place-items:center;padding:24px;color:var(--ink);
+    background:var(--paper);font:15px/1.55 var(--sans);-webkit-font-smoothing:antialiased;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='220' height='220'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.045'/%3E%3C/svg%3E");}
+  .card{width:100%;max-width:448px;background:var(--panel);border:1px solid var(--line);border-radius:20px;
+    padding:32px 32px 26px;box-shadow:0 1px 2px rgba(42,37,64,.04),0 24px 60px -22px rgba(42,37,64,.32)}
+  .brand{display:flex;align-items:center;gap:10px;margin-bottom:22px}
+  .mk{width:30px;height:30px;display:block;flex:none}
+  .brand .name{font-family:var(--display);font-weight:600;font-size:17px;letter-spacing:-.02em}
+  .badge{margin-left:auto;font-family:var(--mono);font-size:10px;font-weight:600;letter-spacing:.05em;
+    text-transform:uppercase;padding:4px 9px;border-radius:999px;background:var(--accent-soft);color:var(--accent-ink)}
+  h1{font-family:var(--display);font-weight:600;font-size:22px;line-height:1.25;letter-spacing:-.02em;margin:0 0 7px}
+  h1 b{color:var(--accent-ink);font-weight:700}
+  .sub{color:var(--ink-soft);font-size:13.5px;margin:0 0 18px}
+  ul.scopes{list-style:none;margin:0 0 22px;padding:8px 16px;border:1px solid var(--line);border-radius:14px;background:var(--panel-2)}
+  ul.scopes li{display:flex;gap:11px;align-items:flex-start;padding:9px 0;font-size:13.5px;color:var(--ink-soft)}
+  ul.scopes li+li{border-top:1px solid var(--line-2)}
+  .tick{color:var(--good);font-weight:700;flex:none;font-size:13px;line-height:1.5}
+  .tick.w{color:var(--accent)}
   .row{display:flex;gap:10px}
-  .btn{flex:1;padding:11px 16px;border-radius:10px;font:600 14px Inter,system-ui,sans-serif;cursor:pointer;border:1px solid var(--line);transition:transform .04s,background .15s}
+  .btn{flex:1;padding:12px 16px;border-radius:11px;font:600 14px var(--sans);cursor:pointer;border:1px solid var(--line);
+    transition:transform .05s,background .15s,filter .15s}
   .btn:active{transform:translateY(1px)}
-  .btn.ghost{background:transparent;color:var(--mut)}
-  .btn.ghost:hover{background:#f2ead9}
-  .btn.primary{background:var(--ac);color:var(--ac-ink);border-color:var(--ac)}
-  .btn.primary:hover{filter:brightness(1.06)}
+  .btn.ghost{background:transparent;color:var(--muted)}
+  .btn.ghost:hover{background:var(--panel-2);color:var(--ink-soft)}
+  .btn.primary{background:var(--accent);color:#fff;border-color:var(--accent)}
+  .btn.primary:hover{filter:brightness(1.07)}
   .btn[disabled]{opacity:.55;cursor:default}
-  .foot{color:var(--mut);font-size:12px;text-align:center;margin:16px 0 0}
-  .err{color:#c0492b;font-size:12.5px;text-align:center;margin:12px 0 0;min-height:0}
+  .foot{color:var(--muted);font-size:12px;text-align:center;margin:16px 0 0}
+  .err{color:var(--bad);font-size:12.5px;text-align:center;margin:12px 0 0;min-height:0}
+  ::selection{background:var(--accent-soft);color:var(--accent-ink)}
 </style>
 </head>
 <body>
   <main class="card">
-    <div class="logo">⚓ Dock</div>
+    <div class="brand">${MARK}<span class="name">Dock</span><span class="badge">Authorize</span></div>
     <h1><b>${name}</b> wants to act in your workspace</h1>
     <p class="sub">Approving lets this agent do the following as you, with a token that expires. You stay in control.</p>
     <ul class="scopes">${items}</ul>


### PR DESCRIPTION
Brings the hosted `/oauth/cli-callback` page (the "you're authorized" landing for `dock login` / native OAuth) onto the Dock plan-site design language — the anchor mark, Space Grotesk, the warm paper/accent palette — with a status badge and matching success + error states, replacing the plain default styling. (The post-auth page a remote MCP client like Claude Code shows is served by the client on localhost, not by us, so it's out of scope.)

Test: `oauth-cli-callback.test.ts` still green (code / error / missing-code paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)