### PR TITLE
refactor(mcp): tighten tools per Anthropic's tool-design guidance (9 → 7)

### DIFF
--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -1,13 +1,19 @@
 // Remote MCP endpoint — Dock as a Model Context Protocol server an AI client
-// (claude.ai / Claude Desktop) connects to over Streamable HTTP, authenticated by
-// the same OAuth 2.1 bearer the rest of the app uses. It's the transport for the
-// agentic loop: the agent connects once, then observes the plan (and, in later
-// phases, diffs it and proposes revisions) without a static token.
+// (claude.ai / Claude Code) connects to over Streamable HTTP, authenticated by the
+// same OAuth 2.1 bearer the rest of the app uses. It's the transport for the agentic
+// loop: connect once, see what changed (catch_me_up), read, and propose revisions a
+// human approves — no static token.
 //
 // Stateless + fetch-native (no Durable Object, no nodejs_compat): a fresh McpServer
 // is built per request closing over the resolved agent identity, so tool calls act
 // in exactly that bearer's workspace at that bearer's role. Runs identically on the
 // Node tier and the Cloudflare Workers tier — same `createApp`.
+//
+// Tool design follows Anthropic's "Writing effective tools for agents": few tools
+// shaped to the agent's workflow (not the API surface), high-signal responses with
+// truncate-and-steer, semantic ids (short_id / vN / page path — never UUIDs),
+// actionable errors, and identity carried in the server `instructions` rather than a
+// tool slot.
 
 import {
   type AgentRecord,
@@ -28,13 +34,19 @@ import type { AppContext } from "./context"
 
 const text = (s: string) => ({ content: [{ type: "text" as const, text: s }] })
 const json = (v: unknown) => text(JSON.stringify(v, null, 2))
+// An actionable error the model can recover from (per the MCP spec, isError text is
+// fed back to the agent so it self-corrects), rather than an opaque failure.
+const err = (s: string) => ({
+  content: [{ type: "text" as const, text: s }],
+  isError: true as const,
+})
 
 // Tool reads are bounded so a big artifact can never blow the client's context
 // window (Claude caps tool responses at ~25k tokens; ~80k chars is a safe ceiling).
 const MAX_CHARS = 80_000
 const clip = (s: string) =>
   s.length > MAX_CHARS
-    ? `${s.slice(0, MAX_CHARS)}\n\n…[truncated ${s.length - MAX_CHARS} chars]`
+    ? `${s.slice(0, MAX_CHARS)}\n\n…[truncated ${s.length - MAX_CHARS} chars — read a specific section]`
     : s
 
 const summarizeArtifact = (a: ArtifactRecord) => ({
@@ -89,15 +101,30 @@ const bundleFileChanges = (from: BundleManifest, to: BundleManifest) => ({
     .map(cleanPath),
 })
 
+const changeCount = (c: ReturnType<typeof bundleFileChanges>) =>
+  c.added.length + c.changed.length + c.removed.length
+
 /**
  * A new MCP server for one request, scoped to `agent` (the OAuth-resolved identity).
  * Tools act in the bearer's workspace at the bearer's role: reads for anyone, and
  * `propose` (the human-in-the-loop write) for commenter+ — a proposal never goes
  * live without a human approving it, so an agent is a safe contributor, not a
- * publisher.
+ * publisher. Identity rides in the server `instructions` (below), not a `whoami`
+ * tool — it's a one-shot fact, not a per-call action.
  */
 function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
-  const server = new McpServer({ name: "dock", version: "1.0.0" })
+  const server = new McpServer(
+    { name: "dock", version: "1.0.0" },
+    {
+      instructions:
+        `You are connected to Dock as "${agent.name}", acting in workspace ${agent.org_id} ` +
+        `with ${agent.role} permissions. Dock hosts living documents and plans with versioned ` +
+        `history, text-anchored review comments, and a propose → review → revise loop. ` +
+        `Start a session with catch_me_up to re-sync on what changed; use read to view content ` +
+        `(outline first for multi-page bundles); use propose to suggest a revision a human ` +
+        `approves — you cannot publish directly.`,
+    },
+  )
   const org = agent.org_id
 
   // Resolve a short id within the caller's workspace (never another org's artifact).
@@ -105,22 +132,14 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
     const a = await ctx.meta.getByShortId(shortId)
     return a && a.org_id === org ? a : null
   }
-
-  server.registerTool(
-    "whoami",
-    {
-      description:
-        "Who you are to Dock: your agent name, the workspace you're acting in, and your role (what you're allowed to do). Call this first to confirm the connection.",
-      inputSchema: {},
-    },
-    async () => json({ name: agent.name, workspace: org, role: agent.role }),
-  )
+  const notFound = (shortId: string) =>
+    err(`No artifact "${shortId}" in your workspace. Call list_artifacts to see what's here.`)
 
   server.registerTool(
     "list_artifacts",
     {
       description:
-        "List the artifacts (docs, plans, sites) in your workspace: short id, title, kind, current version, visibility. Start here to find what to read.",
+        "List the artifacts (docs, plans, sites) in your workspace — short id, title, kind, current version, visibility. Start here to find what to work on, then catch_me_up or read it.",
       inputSchema: { query: z.string().optional().describe("Optional title search filter.") },
     },
     async ({ query }) => {
@@ -130,26 +149,167 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
   )
 
   server.registerTool(
-    "read_artifact",
+    "catch_me_up",
     {
       description:
-        "Read one artifact by its short id: its metadata plus the current version's text content. (Multi-page bundles report their shape here; per-page reads come with read_section.)",
-      inputSchema: { short_id: z.string().describe("The artifact's short id, e.g. nk0dsral.") },
+        "START HERE on an artifact. The coalesced delta since you last saw it (`since_version`): a one-line summary, the versions that landed, which pages changed, and the open comment threads — everything to re-sync in one call. For an exact line-by-line comparison of two specific versions, use `diff` instead. Pass response_format='detailed' to also include the entry-document diff inline.",
+      inputSchema: {
+        short_id: z.string(),
+        since_version: z
+          .number()
+          .optional()
+          .describe("The version you last saw. Defaults to current − 1."),
+        response_format: z
+          .enum(["summary", "detailed"])
+          .optional()
+          .describe(
+            "'summary' (default, token-light) omits the line diff; 'detailed' includes it.",
+          ),
+      },
     },
-    async ({ short_id }) => {
+    async ({ short_id, since_version, response_format }) => {
       const a = await own(short_id)
-      if (!a) return text(`No artifact "${short_id}" in this workspace.`)
-      const meta = summarizeArtifact(a)
-      if (a.kind === "bundle")
+      if (!a) return notFound(short_id)
+      const head = a.current_version
+      const since = Math.min(head, Math.max(1, since_version ?? head - 1))
+      const newVersions = (await ctx.meta.listVersions(a.id)).filter((v) => v.n > since)
+      const vs = await ctx.meta.getVersion(a.id, since)
+      const vh = await ctx.meta.getVersion(a.id, head)
+      let entryDiff: string | null = null
+      let pagesChanged: ReturnType<typeof bundleFileChanges> | null = null
+      if (vs && vh && since < head) {
+        const [ms, mh] = [await manifestOf(ctx, vs), await manifestOf(ctx, vh)]
+        if (ms && mh) pagesChanged = bundleFileChanges(ms, mh)
+        if (response_format === "detailed") {
+          const [as_, ah] = [await ctx.sourceText(vs), await ctx.sourceText(vh)]
+          if (as_ !== null && ah !== null) entryDiff = clip(formatDiff(diffLines(as_, ah)))
+        }
+      }
+      const open = await ctx.meta.listComments(a.id, { state: "open" })
+      const pageBits =
+        pagesChanged && changeCount(pagesChanged)
+          ? ` Pages: ${[
+              pagesChanged.added.length && `+${pagesChanged.added.length}`,
+              pagesChanged.changed.length && `~${pagesChanged.changed.length}`,
+              pagesChanged.removed.length && `-${pagesChanged.removed.length}`,
+            ]
+              .filter(Boolean)
+              .join(" ")}.`
+          : ""
+      const summary =
+        since >= head
+          ? `You're up to date on "${a.title}" (v${head}); ${open.length} open comment${open.length === 1 ? "" : "s"}.`
+          : `"${a.title}": ${newVersions.length} new version${newVersions.length === 1 ? "" : "s"} since v${since} (now v${head}).${pageBits} ${open.length} open comment${open.length === 1 ? "" : "s"}.`
+      return json({
+        summary,
+        short_id,
+        since,
+        head,
+        caught_up: since >= head,
+        new_versions: newVersions.map(summarizeVersion),
+        pages_changed: pagesChanged,
+        ...(entryDiff
+          ? { entry_diff: entryDiff }
+          : {
+              entry_diff:
+                "(omitted) — call again with response_format='detailed', or diff(from, to), for the line-level changes.",
+            }),
+        open_comments: open.map((c) => ({
+          thread: c.thread_id,
+          author: c.author,
+          body: c.body_md,
+        })),
+      })
+    },
+  )
+
+  server.registerTool(
+    "read",
+    {
+      description:
+        "Read an artifact's content by short id. Multi-page bundle: omit `section` to get its outline (the list of pages), then call again with a `section` (a page path) for that page's full text. Single-file artifact: returns the full content. Pass a past `version` to read history.",
+      inputSchema: {
+        short_id: z.string().describe("The artifact's short id, e.g. nk0dsral."),
+        section: z
+          .string()
+          .optional()
+          .describe("A bundle page path, e.g. agentic-loop.html. Omit to get the outline first."),
+        version: z.number().optional().describe("Defaults to the current version."),
+      },
+    },
+    async ({ short_id, section, version }) => {
+      const a = await own(short_id)
+      if (!a) return notFound(short_id)
+      const n = version ?? a.current_version
+      if (n < 1 || n > a.current_version)
+        return err(`No version ${n} for "${short_id}" — it has versions 1..${a.current_version}.`)
+      const v = await ctx.meta.getVersion(a.id, n)
+      if (!v) return err(`Version ${n} of "${short_id}" is unavailable.`)
+      const manifest = await manifestOf(ctx, v)
+      if (!manifest) {
+        // Single-file artifact — return its content.
+        const body = await ctx.sourceText(v)
         return json({
-          ...meta,
-          note: "Multi-page bundle; per-page content via read_section (soon).",
+          short_id,
+          title: a.title,
+          kind: a.kind,
+          version: n,
+          content: clip(body ?? ""),
         })
-      const v = await ctx.meta.getVersion(a.id, a.current_version)
-      if (!v) return json({ ...meta, content: null })
-      const bytes = await ctx.blobs.get(v.blob_key)
-      const body = bytes ? new TextDecoder().decode(bytes) : ""
-      return json({ ...meta, content_type: v.content_type, content: clip(body) })
+      }
+      const pages = Object.keys(manifest.files).map(cleanPath)
+      if (!section)
+        return json({
+          short_id,
+          title: a.title,
+          kind: "bundle",
+          version: n,
+          entry: cleanPath(manifest.entry),
+          pages,
+          next: "Call read again with a `section` (one of the pages above) for that page's content.",
+        })
+      const file = manifest.files[section] ?? manifest.files[`/${cleanPath(section)}`]
+      if (!file) return err(`No page "${section}" in "${short_id}". Pages: ${pages.join(", ")}.`)
+      const bytes = await ctx.blobs.get(file.key)
+      return json({
+        short_id,
+        version: n,
+        section: cleanPath(section),
+        type: file.type,
+        content: clip(bytes ? new TextDecoder().decode(bytes) : ""),
+      })
+    },
+  )
+
+  server.registerTool(
+    "diff",
+    {
+      description:
+        "Exact line-by-line comparison of two versions of an artifact: a unified diff of the entry document, plus (for bundles) which pages were added / removed / changed. For a summary of everything new since you last looked, prefer catch_me_up. `to` defaults to the current version.",
+      inputSchema: {
+        short_id: z.string(),
+        from: z.number().describe("The base version number."),
+        to: z.number().optional().describe("Defaults to the current version."),
+      },
+    },
+    async ({ short_id, from, to }) => {
+      const a = await own(short_id)
+      if (!a) return notFound(short_id)
+      const toN = to ?? a.current_version
+      const vf = await ctx.meta.getVersion(a.id, from)
+      const vt = await ctx.meta.getVersion(a.id, toN)
+      if (!vf || !vt)
+        return err(`Missing version — "${short_id}" has versions 1..${a.current_version}.`)
+      const [af, at] = [await ctx.sourceText(vf), await ctx.sourceText(vt)]
+      if (af === null || at === null) return err("Version content is unavailable.")
+      const [mf, mt] = [await manifestOf(ctx, vf), await manifestOf(ctx, vt)]
+      return json({
+        short_id,
+        from,
+        to: toN,
+        pages_changed: mf && mt ? bundleFileChanges(mf, mt) : null,
+        entry_diff: clip(formatDiff(diffLines(af, at))),
+      })
     },
   )
 
@@ -157,7 +317,7 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
     "list_comments",
     {
       description:
-        "The review feedback on an artifact: open and resolved comment threads with author, body, and the text each is anchored to. This is the agent's to-do list.",
+        "The review feedback on an artifact: comment threads with author, body, state, and the version they were left on. This is your to-do list before proposing. Filter by `state`.",
       inputSchema: {
         short_id: z.string(),
         state: z.enum(["open", "resolved"]).optional().describe("Filter by thread state."),
@@ -165,7 +325,7 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
     },
     async ({ short_id, state }) => {
       const a = await own(short_id)
-      if (!a) return text(`No artifact "${short_id}" in this workspace.`)
+      if (!a) return notFound(short_id)
       const comments = await ctx.meta.listComments(a.id, state ? { state } : undefined)
       return json({
         count: comments.length,
@@ -184,152 +344,16 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
     "list_versions",
     {
       description:
-        "The version history of an artifact, newest first: version number, checkpoint name, message, author, and timestamp. Use it to see how the plan has evolved.",
+        "The version history of an artifact, newest first: number, checkpoint name, message, author, timestamp. For what actually changed between versions, use diff or catch_me_up.",
       inputSchema: { short_id: z.string() },
     },
     async ({ short_id }) => {
       const a = await own(short_id)
-      if (!a) return text(`No artifact "${short_id}" in this workspace.`)
+      if (!a) return notFound(short_id)
       const versions = await ctx.meta.listVersions(a.id)
       return json({
         current: a.current_version,
-        versions: versions
-          .slice()
-          .reverse()
-          .map((v) => ({
-            n: v.n,
-            name: v.name,
-            message: v.message,
-            author: v.author,
-            created_at: v.created_at,
-          })),
-      })
-    },
-  )
-
-  server.registerTool(
-    "read_section",
-    {
-      description:
-        "Read a specific page of a multi-page artifact (bundle), or the content of a single-file one. Omit `path` to list a bundle's pages first.",
-      inputSchema: {
-        short_id: z.string(),
-        path: z
-          .string()
-          .optional()
-          .describe("A page path within a bundle, e.g. agentic-loop.html. Omit to list pages."),
-        version: z.number().optional().describe("Defaults to the current version."),
-      },
-    },
-    async ({ short_id, path, version }) => {
-      const a = await own(short_id)
-      if (!a) return text(`No artifact "${short_id}" in this workspace.`)
-      const n = version ?? a.current_version
-      const v = await ctx.meta.getVersion(a.id, n)
-      if (!v) return text(`No version ${n} (have 1..${a.current_version}).`)
-      const manifest = await manifestOf(ctx, v)
-      if (!manifest) {
-        const body = await ctx.sourceText(v)
-        return json({ short_id, version: n, path: null, content: clip(body ?? "") })
-      }
-      if (!path)
-        return json({
-          short_id,
-          version: n,
-          entry: cleanPath(manifest.entry),
-          pages: Object.keys(manifest.files).map(cleanPath),
-        })
-      // Accept the page path with or without a leading slash.
-      const file = manifest.files[path] ?? manifest.files[`/${cleanPath(path)}`]
-      if (!file)
-        return text(
-          `No page "${path}". Pages: ${Object.keys(manifest.files).map(cleanPath).join(", ")}`,
-        )
-      const bytes = await ctx.blobs.get(file.key)
-      return json({
-        short_id,
-        version: n,
-        path: cleanPath(path),
-        type: file.type,
-        content: clip(bytes ? new TextDecoder().decode(bytes) : ""),
-      })
-    },
-  )
-
-  server.registerTool(
-    "diff",
-    {
-      description:
-        "What changed between two versions of an artifact: a unified diff of the entry document, plus (for bundles) which pages were added / removed / changed. `to` defaults to the current version.",
-      inputSchema: {
-        short_id: z.string(),
-        from: z.number().describe("The base version number."),
-        to: z.number().optional().describe("Defaults to the current version."),
-      },
-    },
-    async ({ short_id, from, to }) => {
-      const a = await own(short_id)
-      if (!a) return text(`No artifact "${short_id}" in this workspace.`)
-      const toN = to ?? a.current_version
-      const vf = await ctx.meta.getVersion(a.id, from)
-      const vt = await ctx.meta.getVersion(a.id, toN)
-      if (!vf || !vt) return text(`Missing version (have 1..${a.current_version}).`)
-      const [af, at] = [await ctx.sourceText(vf), await ctx.sourceText(vt)]
-      if (af === null || at === null) return text("Version content is missing.")
-      const [mf, mt] = [await manifestOf(ctx, vf), await manifestOf(ctx, vt)]
-      return json({
-        short_id,
-        from,
-        to: toN,
-        pages_changed: mf && mt ? bundleFileChanges(mf, mt) : null,
-        entry_diff: clip(formatDiff(diffLines(af, at))),
-      })
-    },
-  )
-
-  server.registerTool(
-    "catch_me_up",
-    {
-      description:
-        "The coalesced delta since you last looked: every version that landed since `since_version`, which pages changed, a diff of the entry document, and the open comment threads — everything you need to re-sync on the plan in one call. `since_version` defaults to the version before current.",
-      inputSchema: {
-        short_id: z.string(),
-        since_version: z
-          .number()
-          .optional()
-          .describe("The version you last saw. Defaults to current − 1."),
-      },
-    },
-    async ({ short_id, since_version }) => {
-      const a = await own(short_id)
-      if (!a) return text(`No artifact "${short_id}" in this workspace.`)
-      const head = a.current_version
-      const since = Math.min(head, Math.max(1, since_version ?? head - 1))
-      const newVersions = (await ctx.meta.listVersions(a.id)).filter((v) => v.n > since)
-      const vs = await ctx.meta.getVersion(a.id, since)
-      const vh = await ctx.meta.getVersion(a.id, head)
-      let entryDiff: string | null = null
-      let pagesChanged: ReturnType<typeof bundleFileChanges> | null = null
-      if (vs && vh && since < head) {
-        const [as_, ah] = [await ctx.sourceText(vs), await ctx.sourceText(vh)]
-        if (as_ !== null && ah !== null) entryDiff = clip(formatDiff(diffLines(as_, ah)))
-        const [ms, mh] = [await manifestOf(ctx, vs), await manifestOf(ctx, vh)]
-        if (ms && mh) pagesChanged = bundleFileChanges(ms, mh)
-      }
-      const open = await ctx.meta.listComments(a.id, { state: "open" })
-      return json({
-        short_id,
-        since,
-        head,
-        caught_up: since >= head,
-        new_versions: newVersions.map(summarizeVersion),
-        pages_changed: pagesChanged,
-        entry_diff: entryDiff,
-        open_comments: open.map((c) => ({
-          thread: c.thread_id,
-          author: c.author,
-          body: c.body_md,
-        })),
+        versions: versions.slice().reverse().map(summarizeVersion),
       })
     },
   )
@@ -338,13 +362,16 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
     "propose",
     {
       description:
-        "Propose a revised version of a single-file artifact for human review. It does NOT go live — a reviewer approves it or requests changes. Provide the FULL new content (not a patch) and a rationale. (Multi-page bundles aren't proposable over MCP yet.)",
+        "Propose a revised version of a single-file artifact for human review. It does NOT go live — a reviewer approves it or requests changes, so you're a safe contributor, not a publisher. Provide the FULL new content (not a patch) and a rationale that tells the reviewer what changed and why. Multi-page bundles aren't proposable over MCP yet.",
       inputSchema: {
         short_id: z.string(),
         content: z
           .string()
           .describe("The complete new content of the document (HTML or Markdown)."),
-        message: z.string().describe("What you changed and why — shown to the reviewer."),
+        message: z
+          .string()
+          .min(1)
+          .describe("What you changed and why — shown to the reviewer. Required."),
         filename: z
           .string()
           .optional()
@@ -353,13 +380,13 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
     },
     async ({ short_id, content, message, filename }) => {
       const a = await own(short_id)
-      if (!a) return text(`No artifact "${short_id}" in this workspace.`)
+      if (!a) return notFound(short_id)
       if (agent.role === "viewer")
-        return text(
-          "Your grant is read-only (dock:read). Re-authorize with dock:propose to propose changes.",
+        return err(
+          "Your grant is read-only (dock:read). Re-authorize the connector with dock:propose to propose changes.",
         )
       if (a.kind === "bundle")
-        return text(
+        return err(
           `"${short_id}" is a multi-page bundle; proposing bundle revisions over MCP isn't supported yet (single-file artifacts only).`,
         )
       try {
@@ -378,8 +405,9 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           note: "Submitted for review — a human approves it or requests changes. It is NOT live yet.",
         })
       } catch (e) {
-        const msg = e instanceof PublishError ? e.message : "could not store the proposal"
-        return text(`Propose failed: ${msg}`)
+        return err(
+          `Couldn't store the proposal: ${e instanceof PublishError ? e.message : "unknown error"}.`,
+        )
       }
     },
   )

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -113,25 +113,32 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(r.wwwAuth).toContain("oauth-protected-resource")
   })
 
-  it("initializes and lists the read tools for a valid bearer", async () => {
-    const { app, token } = appWithGrant("init", "openid dock:read")
+  it("initializes (identity in instructions) and lists the consolidated tools", async () => {
+    const { app, token } = appWithGrant("init", "openid dock:read dock:publish")
     const init = await rpc(app, token, initBody)
-    expect(init.parsed?.result).toMatchObject({ serverInfo: { name: "dock" } })
+    const result = init.parsed?.result as { serverInfo?: { name: string }; instructions?: string }
+    expect(result.serverInfo).toMatchObject({ name: "dock" })
+    // Identity rides in the server instructions, not a whoami tool.
+    expect(result.instructions).toContain("Claude")
+    expect(result.instructions).toContain("editor")
 
     const list = await rpc(app, token, { jsonrpc: "2.0", id: 2, method: "tools/list" })
-    expect(toolNames(list)).toEqual(
+    const names = toolNames(list)
+    expect(names).toEqual(
       expect.arrayContaining([
-        "whoami",
         "list_artifacts",
-        "read_artifact",
+        "catch_me_up",
+        "read",
+        "diff",
         "list_comments",
         "list_versions",
-        "read_section",
-        "diff",
-        "catch_me_up",
         "propose",
       ]),
     )
+    // Consolidated away: no whoami / read_artifact / read_section.
+    expect(names).not.toContain("whoami")
+    expect(names).not.toContain("read_artifact")
+    expect(names).not.toContain("read_section")
   })
 
   const call = (app: App, token: string, name: string, args: Record<string, unknown> = {}) =>
@@ -142,16 +149,7 @@ describe("remote MCP endpoint (/mcp)", () => {
       params: { name, arguments: args },
     })
 
-  it("whoami reports the bearer's identity, workspace, and role", async () => {
-    const { app, token } = appWithGrant("who", "openid dock:read dock:publish")
-    const r = await call(app, token, "whoami")
-    const id = JSON.parse(toolText(r))
-    expect(id.name).toBe("Claude")
-    expect(id.role).toBe("editor") // dock:publish ⇒ editor
-    expect(id.workspace).toBeTruthy()
-  })
-
-  it("list_artifacts + read_artifact see the agent's own published artifact", async () => {
+  it("list_artifacts + read see the agent's own published artifact", async () => {
     const { app, token } = appWithGrant("read", "openid dock:read dock:publish")
     const pub = await publish(app, token, "My Plan")
     expect(pub.status).toBe(201)
@@ -161,7 +159,7 @@ describe("remote MCP endpoint (/mcp)", () => {
     const listOut = JSON.parse(toolText(list))
     expect(listOut.artifacts.some((a: { short_id: string }) => a.short_id === shortId)).toBe(true)
 
-    const read = await call(app, token, "read_artifact", { short_id: shortId })
+    const read = await call(app, token, "read", { short_id: shortId })
     const readOut = JSON.parse(toolText(read))
     expect(readOut.title).toBe("My Plan")
     expect(readOut.content).toContain("My Plan")
@@ -192,11 +190,24 @@ describe("remote MCP endpoint (/mcp)", () => {
     )
     expect(c.head).toBe(2)
     expect(c.new_versions.map((v: { n: number }) => v.n)).toContain(2)
-    expect(c.entry_diff).toContain("V2 Title")
+    expect(c.summary).toContain("v2") // prose summary up top
     expect(c.caught_up).toBe(false)
+    expect(c.entry_diff).not.toContain("V2 Title") // omitted by default (token-light)
+
+    // 'detailed' includes the line diff inline.
+    const cd = JSON.parse(
+      toolText(
+        await call(app, token, "catch_me_up", {
+          short_id: shortId,
+          since_version: 1,
+          response_format: "detailed",
+        }),
+      ),
+    )
+    expect(cd.entry_diff).toContain("V2 Title")
   })
 
-  it("read_section + catch_me_up handle multi-page bundles", async () => {
+  it("read + catch_me_up handle multi-page bundles", async () => {
     const { app, token } = appWithGrant("bundle", "openid dock:read dock:publish")
     const enc = (s: string) => new TextEncoder().encode(s)
     const postZip = (
@@ -222,14 +233,12 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(pj.kind).toBe("bundle")
     const shortId = pj.short_id
 
-    // No path → lists the bundle's pages.
-    const pages = JSON.parse(
-      toolText(await call(app, token, "read_section", { short_id: shortId })),
-    )
+    // No section → outline (the bundle's pages).
+    const pages = JSON.parse(toolText(await call(app, token, "read", { short_id: shortId })))
     expect(pages.pages).toEqual(expect.arrayContaining(["index.html", "page.html"]))
-    // A path → that page's content.
+    // A section → that page's content.
     const page = JSON.parse(
-      toolText(await call(app, token, "read_section", { short_id: shortId, path: "page.html" })),
+      toolText(await call(app, token, "read", { short_id: shortId, section: "page.html" })),
     )
     expect(page.content).toContain("Page")
 
@@ -269,9 +278,7 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(p.base_version).toBe(1)
 
     // The live version is untouched — a proposal is not a publish.
-    const read = JSON.parse(
-      toolText(await call(app, token, "read_artifact", { short_id: shortId })),
-    )
+    const read = JSON.parse(toolText(await call(app, token, "read", { short_id: shortId })))
     expect(read.version).toBe(1)
     expect(read.content).toContain("Draft")
     expect(read.content).not.toContain("Revised")


### PR DESCRIPTION
Applies Anthropic's **"Writing effective tools for AI agents"** (Sept 2025) + *Building Effective Agents*. We're already under every tool-count threshold, so the leverage is consolidation + response quality, not trimming for its own sake. **9 → 7 tools**, validated live (`catch_me_up` over the real MCP connection returns the new shape).

- **Merge `read_artifact` + `read_section` → one outline-first `read`** — omit `section` to get a bundle's outline (or a single-file's content); pass `section` for a page. The two-tools-differ-by-one-arg split was API surface, not agent intention.
- **Retire `whoami`** → carry identity (name + workspace + role) in the MCP server **`instructions`**, set per-connection. A one-shot fact, not a tool slot.
- **`catch_me_up`** leads with a **prose summary**; the entry diff is now opt-in via `response_format='detailed'` (token-light by default). It stays the documented "start here" entry point; `diff`/`list_*` are the drill-downs (descriptions carry the when-to-use / when-NOT boundaries).
- **Actionable `isError` responses** the agent can recover from (e.g. "No version 9 — it has versions 1..7"), per the MCP spec.

Tools now: `list_artifacts`, `catch_me_up`, `read`, `diff`, `list_comments`, `list_versions`, `propose`. Tests updated (identity asserted via `instructions`; consolidated reads); full api suite green (283).

🤖 Generated with [Claude Code](https://claude.com/claude-code)