### PR TITLE
feat(feedback): outdated comment state + re-anchor sweep (agentic loop Phase 2)

### DIFF
--- a/apps/api/src/events.ts
+++ b/apps/api/src/events.ts
@@ -10,6 +10,7 @@ export const DOMAIN_EVENTS = [
   "comment.created",
   "comment.mention",
   "comment.resolved",
+  "comment.outdated",
   "comment.reacted",
   "comment.updated",
   "version.published",

--- a/apps/api/src/lib/anchor-sweep.ts
+++ b/apps/api/src/lib/anchor-sweep.ts
@@ -1,0 +1,78 @@
+import {
+  type AnchorThread,
+  type AnchorTransition,
+  type BlobStore,
+  type MetaStore,
+  planAnchorSweep,
+  type VersionRecord,
+} from "@dock/core"
+import { pageTextResolver } from "./bundle"
+
+/** A thread reduced for the sweep, plus the bundle page it lives on (null = a
+ *  single-file artifact or whole-document thread). */
+type Thread = AnchorThread & { path: string | null }
+
+/**
+ * Re-anchor a published artifact's comment threads against the new version and
+ * apply the resulting state flips (open↔outdated). Called after every version
+ * bump (publish, restore, proposal approve) so feedback whose quoted text
+ * changed is marked `outdated` — and un-marked if the text reappears.
+ *
+ * Each thread is checked against ITS page's text (single-file artifacts use the
+ * whole document; bundle threads use their own page via the manifest), so a
+ * comment on one page of a bundle never goes stale because a different page
+ * changed. A thread is open/resolved/outdated as a unit, so we collapse its
+ * comments to the root's anchor + state + path before planning. One
+ * `listComments`, one blob read per referenced page, one `setThreadState` per
+ * thread that actually changes — never per comment.
+ */
+export async function sweepAnchors(
+  meta: Pick<MetaStore, "listComments" | "setThreadState">,
+  blobs: BlobStore,
+  artifactId: string,
+  version: VersionRecord,
+): Promise<AnchorTransition[]> {
+  const comments = await meta.listComments(artifactId)
+  if (comments.length === 0) return []
+
+  const byThread = new Map<string, Thread>()
+  for (const cm of comments) {
+    const cur = byThread.get(cm.thread_id)
+    if (!cur) {
+      byThread.set(cm.thread_id, {
+        thread_id: cm.thread_id,
+        anchor: cm.anchor,
+        state: cm.state,
+        path: cm.path,
+      })
+      continue
+    }
+    // The root comment (id == thread_id) is authoritative for the anchor, state,
+    // and page; a reply only contributes an anchor if the root somehow lacked one.
+    if (cm.id === cm.thread_id) {
+      cur.state = cm.state
+      cur.path = cm.path
+      if (cm.anchor) cur.anchor = cm.anchor
+    } else if (!cur.anchor && cm.anchor) {
+      cur.anchor = cm.anchor
+    }
+  }
+
+  const resolveText = await pageTextResolver(blobs, version)
+  // Group by page so each page's text is read once, then plan per page.
+  const byPage = new Map<string | null, Thread[]>()
+  for (const t of byThread.values()) {
+    const list = byPage.get(t.path)
+    if (list) list.push(t)
+    else byPage.set(t.path, [t])
+  }
+
+  const transitions: AnchorTransition[] = []
+  for (const [path, threads] of byPage) {
+    const text = await resolveText(path)
+    if (text == null) continue // page no longer resolvable — leave its threads alone
+    transitions.push(...planAnchorSweep(threads, text))
+  }
+  for (const t of transitions) await meta.setThreadState(artifactId, t.thread_id, t.state)
+  return transitions
+}

--- a/apps/api/src/lib/bundle.ts
+++ b/apps/api/src/lib/bundle.ts
@@ -1,0 +1,53 @@
+import {
+  type BlobStore,
+  BUNDLE_CONTENT_TYPE,
+  type BundleManifest,
+  type VersionRecord,
+} from "@dock/core"
+
+// Bundle manifests store paths with a leading slash (/index.html); present them
+// cleanly to callers, and accept either form on the way back in.
+export const cleanPath = (p: string): string => p.replace(/^\//, "")
+
+// A version's bundle manifest (null when it isn't a bundle / is unreadable).
+export async function manifestOf(
+  blobs: BlobStore,
+  v: VersionRecord,
+): Promise<BundleManifest | null> {
+  if (v.content_type !== BUNDLE_CONTENT_TYPE) return null
+  const bytes = await blobs.get(v.blob_key)
+  if (!bytes) return null
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes)) as BundleManifest
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resolve the source text of one page of a version. Single-file artifact: every
+ * path returns the whole document. Bundle: looks the page up in the manifest
+ * (accepts a slashed or clean path); a null path resolves to the entry page.
+ * Returns null when the page/blob can't be read.
+ */
+export async function pageTextResolver(
+  blobs: BlobStore,
+  v: VersionRecord,
+): Promise<(path: string | null) => Promise<string | null>> {
+  const manifest = await manifestOf(blobs, v)
+  if (!manifest) {
+    const bytes = await blobs.get(v.blob_key)
+    const text = bytes ? new TextDecoder().decode(bytes) : null
+    return async () => text
+  }
+  const keyFor = (path: string | null): string | undefined => {
+    if (!path) return manifest.files[manifest.entry]?.key
+    return (manifest.files[path] ?? manifest.files[`/${cleanPath(path)}`])?.key
+  }
+  return async (path) => {
+    const key = keyFor(path)
+    if (!key) return null
+    const bytes = await blobs.get(key)
+    return bytes ? new TextDecoder().decode(bytes) : null
+  }
+}

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -18,7 +18,6 @@
 import {
   type AgentRecord,
   type ArtifactRecord,
-  BUNDLE_CONTENT_TYPE,
   type BundleManifest,
   diffLines,
   formatDiff,
@@ -31,6 +30,8 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import type { Hono } from "hono"
 import { z } from "zod"
 import type { AppContext } from "./context"
+import { cleanPath, manifestOf as sharedManifestOf } from "./lib/bundle"
+import { quoteOf } from "./lib/comments"
 
 const text = (s: string) => ({ content: [{ type: "text" as const, text: s }] })
 const json = (v: unknown) => text(JSON.stringify(v, null, 2))
@@ -66,22 +67,9 @@ const summarizeVersion = (v: VersionRecord) => ({
   created_at: v.created_at,
 })
 
-// A version's bundle manifest (null when it isn't a bundle / is unreadable). Lets
-// the loop tools see a multi-page artifact's actual files, not just its entry doc.
-const manifestOf = async (ctx: AppContext, v: VersionRecord): Promise<BundleManifest | null> => {
-  if (v.content_type !== BUNDLE_CONTENT_TYPE) return null
-  const bytes = await ctx.blobs.get(v.blob_key)
-  if (!bytes) return null
-  try {
-    return JSON.parse(new TextDecoder().decode(bytes)) as BundleManifest
-  } catch {
-    return null
-  }
-}
-
-// Bundle manifests store paths with a leading slash (/index.html); present them
-// cleanly to the agent, and accept either form on the way back in.
-const cleanPath = (p: string) => p.replace(/^\//, "")
+// A version's bundle manifest, presented cleanly. Lets the loop tools see a
+// multi-page artifact's actual files, not just its entry doc.
+const manifestOf = (ctx: AppContext, v: VersionRecord) => sharedManifestOf(ctx.blobs, v)
 
 // Which pages changed between two bundle versions — by comparing each file's
 // content-addressed blob key. This is the "what's new" a coalesced catch-up needs.
@@ -186,6 +174,13 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
         }
       }
       const open = await ctx.meta.listComments(a.id, { state: "open" })
+      // Threads whose quoted text changed in a landed version — feedback that may
+      // no longer apply. Surfacing the count tells the agent its (or someone's)
+      // edits touched commented passages.
+      const outdated = await ctx.meta.listComments(a.id, { state: "outdated" })
+      const outdatedBit = outdated.length
+        ? ` ${outdated.length} now outdated (the quoted text changed).`
+        : ""
       const pageBits =
         pagesChanged && changeCount(pagesChanged)
           ? ` Pages: ${[
@@ -198,8 +193,8 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           : ""
       const summary =
         since >= head
-          ? `You're up to date on "${a.title}" (v${head}); ${open.length} open comment${open.length === 1 ? "" : "s"}.`
-          : `"${a.title}": ${newVersions.length} new version${newVersions.length === 1 ? "" : "s"} since v${since} (now v${head}).${pageBits} ${open.length} open comment${open.length === 1 ? "" : "s"}.`
+          ? `You're up to date on "${a.title}" (v${head}); ${open.length} open comment${open.length === 1 ? "" : "s"}.${outdatedBit}`
+          : `"${a.title}": ${newVersions.length} new version${newVersions.length === 1 ? "" : "s"} since v${since} (now v${head}).${pageBits} ${open.length} open comment${open.length === 1 ? "" : "s"}.${outdatedBit}`
       return json({
         summary,
         short_id,
@@ -217,8 +212,20 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
         open_comments: open.map((c) => ({
           thread: c.thread_id,
           author: c.author,
+          quote: quoteOf(c.anchor),
           body: c.body_md,
         })),
+        // Only included when non-empty, to keep the common response lean.
+        ...(outdated.length
+          ? {
+              outdated_comments: outdated.map((c) => ({
+                thread: c.thread_id,
+                author: c.author,
+                quote: quoteOf(c.anchor),
+                body: c.body_md,
+              })),
+            }
+          : {}),
       })
     },
   )
@@ -317,10 +324,13 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
     "list_comments",
     {
       description:
-        "The review feedback on an artifact: comment threads with author, body, state, and the version they were left on. This is your to-do list before proposing. Filter by `state`.",
+        "The review feedback on an artifact: comment threads with author, body, the quoted text they're anchored to, the version they were left on, and state. This is your to-do list before proposing — work the `open` threads. State is open (live feedback), resolved (a human marked it done), or outdated (the quoted text changed in a later version, so the feedback may no longer apply — verify before acting). Filter by `state`; default lists all.",
       inputSchema: {
         short_id: z.string(),
-        state: z.enum(["open", "resolved"]).optional().describe("Filter by thread state."),
+        state: z
+          .enum(["open", "resolved", "outdated"])
+          .optional()
+          .describe("Filter by thread state. Omit to list every thread."),
       },
     },
     async ({ short_id, state }) => {
@@ -334,6 +344,10 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           author: c.author,
           state: c.state,
           base_version: c.base_version,
+          // The quoted text the thread is anchored to (null for whole-document
+          // feedback) — tells the agent WHERE in the artifact the note applies.
+          quote: quoteOf(c.anchor),
+          path: c.path,
           body: c.body_md,
         })),
       })

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -15,6 +15,7 @@ import { type Context, Hono } from "hono"
 import { setCookie } from "hono/cookie"
 import { z } from "zod"
 import type { AppContext } from "../context"
+import { sweepAnchors } from "../lib/anchor-sweep"
 import { hashPassword, safeEqual, unlockCookie, unlockToken, verifyPassword } from "../lib/crypto"
 import {
   DEFAULT_WORKSPACE_NAME,
@@ -229,6 +230,14 @@ export const artifactRoutes = (ctx: AppContext) => {
           }
         }
       }
+      // Re-anchor existing threads against the new version: feedback whose quoted
+      // text changed flips to `outdated` (and back to `open` if it reappears).
+      for (const t of await sweepAnchors(meta, blobs, artifact.id, version))
+        bus.publish(artifact.id, {
+          type: t.state === "outdated" ? "comment.outdated" : "comment.resolved",
+          thread_id: t.thread_id,
+          state: t.state,
+        })
       const versions = await meta.listVersions(artifact.id)
       return c.json({ ...toJson(deps.baseUrl, artifact, versions), published: version.n }, 201)
     } catch (err) {
@@ -364,6 +373,13 @@ export const artifactRoutes = (ctx: AppContext) => {
       author: version.author,
     })
     bus.publish(artifact.id, { type: "version.published", n: version.n, message: version.message })
+    // Restoring an old blob is a content change too — re-anchor threads against it.
+    for (const t of await sweepAnchors(meta, blobs, artifact.id, version))
+      bus.publish(artifact.id, {
+        type: t.state === "outdated" ? "comment.outdated" : "comment.resolved",
+        thread_id: t.thread_id,
+        state: t.state,
+      })
     const fresh = (await meta.getByShortId(artifact.short_id)) as ArtifactRecord
     const versions = await meta.listVersions(artifact.id)
     return c.json(

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -198,7 +198,7 @@ export const commentRoutes = (ctx: AppContext) => {
     // viewer — do, the Google-Docs way. So the gate is "has an account", not the role.
     if (await anonLocked(c, artifact)) return fail(c, 404, "not found")
     const q = c.req.query("state")
-    const state = q === "open" || q === "resolved" ? q : undefined
+    const state = q === "open" || q === "resolved" || q === "outdated" ? q : undefined
     const comments = await meta.listComments(artifact.id, state ? { state } : undefined)
     // Flag whether each anchor still resolves against the current version.
     const cur = await meta.getVersion(artifact.id, artifact.current_version)

--- a/apps/api/src/routes/proposals.ts
+++ b/apps/api/src/routes/proposals.ts
@@ -9,6 +9,7 @@ import {
 import { type Context, Hono } from "hono"
 import { z } from "zod"
 import type { AppContext } from "../context"
+import { sweepAnchors } from "../lib/anchor-sweep"
 import { fail, MAX_UPLOAD_BYTES, readJson, str } from "../lib/http"
 
 /** Reviews: a proposal is a candidate version awaiting approval. A commenter
@@ -170,6 +171,14 @@ export const proposalRoutes = (ctx: AppContext) => {
         n: version.n,
         message: version.message,
       })
+      // The approved candidate is now live content — re-anchor existing threads
+      // against it so feedback on changed text flips to `outdated`.
+      for (const t of await sweepAnchors(meta, blobs, artifact.id, version))
+        bus.publish(artifact.id, {
+          type: t.state === "outdated" ? "comment.outdated" : "comment.resolved",
+          thread_id: t.thread_id,
+          state: t.state,
+        })
       await notify(artifact, "proposal.approved", {
         proposal_id: proposal.id,
         version: version.n,

--- a/apps/api/test/comments.test.ts
+++ b/apps/api/test/comments.test.ts
@@ -102,6 +102,48 @@ describe("anchored comments", () => {
   })
 })
 
+describe("the outdated state machine (re-anchor sweep on republish)", () => {
+  const anchor = { type: "TextQuoteSelector", exact: "beta", prefix: "alpha ", suffix: " gamma" }
+  const republish = (sid: string, body: string, message: string) => {
+    const fd = new FormData()
+    fd.append("file", new Blob([new TextEncoder().encode(body)]), "a.md")
+    fd.append("message", message)
+    return app.request(`/v1/artifacts/${sid}/versions`, { method: "POST", body: fd })
+  }
+  const byState = async (sid: string, state: string) =>
+    (await (await app.request(`/v1/artifacts/${sid}/comments?state=${state}`)).json()).comments
+
+  it("flips open→outdated when the quote vanishes, and back to open when it returns", async () => {
+    const sid = (await (await upload("a.md", "alpha beta gamma", { title: "A" })).json()).short_id
+    await app.request(`/v1/artifacts/${sid}/comments`, json({ body_md: "on beta", anchor }))
+    expect(await byState(sid, "open")).toHaveLength(1)
+
+    // v2 drops "beta" → the thread is now outdated (persisted, not just a flag).
+    await republish(sid, "alpha gamma delta", "v2 drops beta")
+    expect(await byState(sid, "open")).toHaveLength(0)
+    const outdated = await byState(sid, "outdated")
+    expect(outdated).toHaveLength(1)
+    expect(outdated[0].state).toBe("outdated")
+
+    // v3 brings "beta" back → the thread reopens automatically.
+    await republish(sid, "alpha beta gamma again", "v3 restores beta")
+    expect(await byState(sid, "outdated")).toHaveLength(0)
+    expect(await byState(sid, "open")).toHaveLength(1)
+  })
+
+  it("never resurrects a resolved thread, even if its quote later vanishes", async () => {
+    const sid = (await (await upload("a.md", "alpha beta gamma", { title: "A" })).json()).short_id
+    const cm = await (
+      await app.request(`/v1/artifacts/${sid}/comments`, json({ body_md: "on beta", anchor }))
+    ).json()
+    await app.request(`/v1/artifacts/${sid}/comments/${cm.id}/resolve`, { method: "POST" })
+
+    await republish(sid, "alpha gamma delta", "v2 drops beta")
+    expect(await byState(sid, "resolved")).toHaveLength(1)
+    expect(await byState(sid, "outdated")).toHaveLength(0)
+  })
+})
+
 describe("@mentions + in-app notifications", () => {
   const alice: TestUser = { id: "u_m_alice", email: "ma@dock.test", name: "Alice" }
   const bob: TestUser = { id: "u_m_bob", email: "mb@dock.test", name: "Bob" }

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -283,4 +283,50 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(read.content).toContain("Draft")
     expect(read.content).not.toContain("Revised")
   })
+
+  it("surfaces outdated feedback after a republish drops the quoted text", async () => {
+    const { app, token } = appWithGrant("stale", "openid dock:read dock:comment dock:publish")
+    const shortId = (await (await publish(app, token, "alpha beta gamma")).json()).short_id
+
+    // A comment anchored to "beta".
+    await app.request(`/v1/artifacts/${shortId}/comments`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        body_md: "tighten this",
+        anchor: { type: "TextQuoteSelector", exact: "beta", prefix: "alpha ", suffix: " gamma" },
+      }),
+    })
+
+    // Republish without "beta" — the sweep should mark the thread outdated.
+    const form = new FormData()
+    form.append(
+      "file",
+      new Blob([new TextEncoder().encode("<h1>alpha gamma delta</h1>")]),
+      "index.html",
+    )
+    form.append("name", "rev 2")
+    await app.request(`/v1/artifacts/${shortId}/versions`, {
+      method: "POST",
+      body: form,
+      headers: { authorization: `Bearer ${token}` },
+    })
+
+    // list_comments reports the new state + the quoted text the thread targets.
+    const all = JSON.parse(toolText(await call(app, token, "list_comments", { short_id: shortId })))
+    expect(all.comments[0].state).toBe("outdated")
+    expect(all.comments[0].quote).toBe("beta")
+    const onlyStale = JSON.parse(
+      toolText(await call(app, token, "list_comments", { short_id: shortId, state: "outdated" })),
+    )
+    expect(onlyStale.count).toBe(1)
+
+    // catch_me_up leads with it so the agent knows its edits touched commented text.
+    const cu = JSON.parse(
+      toolText(await call(app, token, "catch_me_up", { short_id: shortId, since_version: 1 })),
+    )
+    expect(cu.summary).toContain("outdated")
+    expect(cu.outdated_comments).toHaveLength(1)
+    expect(cu.outdated_comments[0].quote).toBe("beta")
+  })
 })

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -164,7 +164,9 @@ export interface Comment {
   anchor: string | null
   body_md: string
   author: string
-  state: "open" | "resolved"
+  // `outdated` = the quoted text this thread anchored to changed in a later
+  // version (set by the server's re-anchor sweep); the feedback may no longer apply.
+  state: "open" | "resolved" | "outdated"
   created_at: string
   anchored?: boolean
   reactions?: Record<string, string[]>

--- a/apps/web/src/pages/artifact/artifact-actions.ts
+++ b/apps/web/src/pages/artifact/artifact-actions.ts
@@ -149,7 +149,8 @@ export function artifactActions(p: {
     await addComment(text, { anchor, mentions })
   }
   const toggleResolve = async (root: Comment) => {
-    await api.resolve(shortId, root.id, root.state === "open" ? "resolved" : "open")
+    // Resolve anything not already resolved (open or outdated); reopen a resolved thread.
+    await api.resolve(shortId, root.id, root.state === "resolved" ? "open" : "resolved")
     refetchComments()
   }
   const activate = (id: string) => {

--- a/apps/web/src/pages/artifact/comment-thread.tsx
+++ b/apps/web/src/pages/artifact/comment-thread.tsx
@@ -204,6 +204,7 @@ export function CommentCard({
     setReplyMentions([])
   }
   const resolved = root.state === "resolved"
+  const outdated = root.state === "outdated"
   const quote = anchorExact(root.anchor)
   const textPresent = present !== undefined ? present : root.anchored !== false
   const replies = thread.length - 1
@@ -297,12 +298,21 @@ export function CommentCard({
             <span
               className={cn(
                 "rounded-full px-2 py-0.5 font-mono text-2xs font-bold",
-                resolved ? "bg-success/15 text-success" : "bg-accent text-primary",
+                resolved
+                  ? "bg-success/15 text-success"
+                  : outdated
+                    ? "bg-gold/15 text-gold"
+                    : "bg-accent text-primary",
               )}
+              title={
+                outdated
+                  ? "The text this thread was attached to changed in a later version — this feedback may no longer apply"
+                  : undefined
+              }
             >
-              {resolved ? "resolved" : "open"}
+              {resolved ? "resolved" : outdated ? "outdated" : "open"}
             </span>
-            {quote && !textPresent && !resolved && (
+            {quote && !textPresent && !resolved && !outdated && (
               <span
                 title="The text this comment was attached to was edited or removed in this version"
                 className="rounded-full bg-accent px-2 py-0.5 font-mono text-2xs font-bold text-primary"

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -236,7 +236,10 @@ export function Artifact() {
   // and the collapsed rail dots.
   const docLive = !editing && view === "preview"
   const all = groupThreads(comments)
-  const openThreads = all.filter((t) => t[0]?.state === "open")
+  // `outdated` threads (their quoted text changed in a later version) stay in the
+  // active list, not the resolved drawer — their anchor no longer resolves, so
+  // they fall into the general/orphaned bucket below and stay visible to triage.
+  const openThreads = all.filter((t) => t[0] && t[0].state !== "resolved")
   const resolvedThreads = all.filter((t) => t[0]?.state === "resolved")
   const pinned: PinItem[] = []
   const general: Comment[][] = []

--- a/apps/web/src/pages/artifact/use-artifact-live.ts
+++ b/apps/web/src/pages/artifact/use-artifact-live.ts
@@ -32,6 +32,7 @@ export function useArtifactLive(opts: {
     })
     ev.addEventListener("comment.created", onComment)
     ev.addEventListener("comment.resolved", onComment)
+    ev.addEventListener("comment.outdated", onComment)
     ev.addEventListener("comment.reacted", onComment)
     ev.addEventListener("comment.updated", onComment)
     ev.addEventListener("version.published", onVersion)

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -262,3 +262,36 @@ export function isAnchored(anchorJson: string | null, text: string): boolean {
     return true
   }
 }
+
+/** One thread's anchoring inputs for the re-anchor sweep. `anchor` is the stored
+ *  selector JSON of the thread's root comment (null = a whole-document thread). */
+export interface AnchorThread {
+  thread_id: string
+  anchor: string | null
+  state: "open" | "resolved" | "outdated"
+}
+
+/** A state flip the sweep wants applied (always thread-level). */
+export interface AnchorTransition {
+  thread_id: string
+  state: "open" | "outdated"
+}
+
+/**
+ * Decide which threads change state when an artifact is republished. Pure — the
+ * caller applies the returned flips.
+ *
+ * - `open` + anchored + no longer resolves → `outdated` (the quoted text changed)
+ * - `outdated` + resolves again            → `open`     (the text came back)
+ * - `resolved` threads and whole-document (un-anchored) threads are never touched.
+ */
+export function planAnchorSweep(threads: AnchorThread[], newText: string): AnchorTransition[] {
+  const out: AnchorTransition[] = []
+  for (const t of threads) {
+    if (!t.anchor) continue // whole-document feedback never goes stale
+    const resolves = isAnchored(t.anchor, newText)
+    if (t.state === "open" && !resolves) out.push({ thread_id: t.thread_id, state: "outdated" })
+    else if (t.state === "outdated" && resolves) out.push({ thread_id: t.thread_id, state: "open" })
+  }
+  return out
+}

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -779,7 +779,13 @@ export interface ViewStats {
   recent: { viewer: string; kind: "user" | "anon"; at: string; avatar?: string | null }[]
 }
 
-export type CommentState = "open" | "resolved"
+// open      — live feedback awaiting a reply/resolution
+// resolved  — a human marked the thread done
+// outdated  — the text this thread anchored to changed or vanished in a later
+//             version, so the feedback may no longer apply. Set automatically by
+//             the re-anchor sweep on every version bump; flips back to `open` if
+//             the quoted text reappears. Never overwrites `resolved`.
+export type CommentState = "open" | "resolved" | "outdated"
 
 export interface CommentRecord {
   id: string

--- a/packages/core/test/anchor.test.ts
+++ b/packages/core/test/anchor.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest"
-import { isAnchored, quoteSelector, reanchor } from "../src/anchor"
+import {
+  type AnchorThread,
+  isAnchored,
+  planAnchorSweep,
+  quoteSelector,
+  reanchor,
+} from "../src/anchor"
 
 const text = "Q1 trended down to mean sentiment 3.1 across all channels this quarter."
 
@@ -40,5 +46,37 @@ describe("isAnchored", () => {
     const sel = JSON.stringify(quoteSelector(text, text.indexOf("3.1"), 3))
     expect(isAnchored(sel, text)).toBe(true)
     expect(isAnchored(sel, "no numbers here")).toBe(false)
+  })
+})
+
+describe("planAnchorSweep", () => {
+  const anchor = (quote: string) =>
+    JSON.stringify(quoteSelector(text, text.indexOf(quote), quote.length))
+  const thread = (over: Partial<AnchorThread> = {}): AnchorThread => ({
+    thread_id: "t1",
+    anchor: anchor("mean sentiment 3.1"),
+    state: "open",
+    ...over,
+  })
+
+  it("outdates an open thread whose quote vanished", () => {
+    const gone = "We switched to median sentiment 3.6 this quarter."
+    expect(planAnchorSweep([thread()], gone)).toEqual([{ thread_id: "t1", state: "outdated" }])
+  })
+
+  it("leaves an open thread alone when its quote survives", () => {
+    expect(planAnchorSweep([thread()], text)).toEqual([])
+  })
+
+  it("reopens an outdated thread when its quote reappears", () => {
+    expect(planAnchorSweep([thread({ state: "outdated" })], text)).toEqual([
+      { thread_id: "t1", state: "open" },
+    ])
+  })
+
+  it("never touches resolved threads or whole-document (un-anchored) threads", () => {
+    const gone = "nothing here"
+    expect(planAnchorSweep([thread({ state: "resolved" })], gone)).toEqual([])
+    expect(planAnchorSweep([thread({ anchor: null })], gone)).toEqual([])
   })
 })


### PR DESCRIPTION
**Phase 2 of the agentic loop.** The agent can already *see* what changed (`catch_me_up`) and *propose* revisions. This adds the missing feedback signal: **a comment state machine that tells the agent which review threads its revisions touched.**

`CommentState` gains **`outdated`** — set automatically when a thread's quoted text changes or vanishes in a later version, flipped back to `open` if the text reappears, and never overwriting a human's `resolved`. Until now the anchoring engine (`reanchor`, the W3C selectors, the iframe client) existed but `reanchor` was wired *nowhere* — `isAnchored` was only a read-time flag. This persists the lifecycle and acts on it.

### How it works
- **core** — `planAnchorSweep`, a pure open↔outdated planner beside the existing `reanchor`/`isAnchored`.
- **api** — `sweepAnchors` re-anchors every thread against **its own page** (bundle-aware via a shared `lib/bundle` page-text resolver, so a comment on one page of a multi-page bundle never goes stale because a *different* page changed). Wired into all three version bumps: **publish, restore, proposal approve**. One `listComments`, one blob read per referenced page, one `setThreadState` per thread that actually flips — never per comment.
- **mcp** — `list_comments` now reports `state` + the anchored `quote` + `path`, and filters by `outdated`; `catch_me_up` leads its summary with the outdated count and surfaces the stale threads, so the agent sees its edits landed on commented passages and verifies before re-addressing.
- **web** — outdated threads stay in the **active** list (not the resolved drawer) with a gold `outdated` badge; the resolve button now resolves anything not-resolved; the SPA refetches on a new `comment.outdated` realtime event.
- Fixed a latent gap: the `GET /comments?state=` filter silently ignored anything but `open`/`resolved`.

### Tests
- core: planner cases (vanish→outdated, survive→noop, reappear→reopen, resolved/un-anchored untouched).
- api: the state machine end-to-end (`open→outdated→open`; a resolved thread is never resurrected).
- mcp: republish drops the quoted text → `list_comments` + `catch_me_up` report it outdated with the quote.
- 319 api + 64 core green; web/api/core typecheck + biome clean.

### Follow-up (not this PR)
`addressed` state — link a proposal to the comment ids it claims to address, mark them on approve. That's the human/agent-asserted counterpart to this automatic `outdated`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)