### PR TITLE
feat(feedback): addressed comment state — link proposals to the threads they fix (loop Phase 3)

### DIFF
--- a/apps/api/src/events.ts
+++ b/apps/api/src/events.ts
@@ -11,6 +11,7 @@ export const DOMAIN_EVENTS = [
   "comment.mention",
   "comment.resolved",
   "comment.outdated",
+  "comment.addressed",
   "comment.reacted",
   "comment.updated",
   "version.published",

--- a/apps/api/src/lib/addressed.ts
+++ b/apps/api/src/lib/addressed.ts
@@ -1,0 +1,58 @@
+import type { CommentState, MetaStore } from "@dock/core"
+import { type CommentMeta, parseMeta } from "./comments"
+
+// Linking a proposal to the comment threads it claims to fix, without a schema
+// change: the link lives in each root comment's existing `meta` JSON
+// (`addressed_by` = the proposal id) alongside the `addressed` thread state.
+// propose marks; approve/withdraw/changes release.
+
+/**
+ * Flip the cited threads to `addressed`, tagging each root comment's meta with
+ * the proposal id so a later approve/withdraw can release exactly these.
+ * A thread is addressable only if its root exists on this artifact and isn't
+ * already resolved (don't pull settled feedback back into a pending state).
+ * Returns the thread ids actually marked.
+ */
+export async function markAddressed(
+  meta: Pick<MetaStore, "getComment" | "setThreadState" | "updateComment">,
+  artifactId: string,
+  proposalId: string,
+  threadIds: string[],
+): Promise<string[]> {
+  const marked: string[] = []
+  for (const threadId of threadIds) {
+    const root = await meta.getComment(threadId)
+    if (!root || root.artifact_id !== artifactId || root.id !== threadId) continue
+    if (root.state === "resolved") continue
+    const md: CommentMeta = { ...parseMeta(root.meta), addressed_by: proposalId }
+    await meta.updateComment(root.id, { meta: JSON.stringify(md) })
+    await meta.setThreadState(artifactId, threadId, "addressed")
+    marked.push(threadId)
+  }
+  return marked
+}
+
+/**
+ * Release every thread addressed by `proposalId` to `toState` — `resolved` when
+ * the proposal is approved (the fix landed), `open` when it's withdrawn or sent
+ * back for changes — clearing the meta tag. Returns the thread ids released.
+ */
+export async function releaseAddressed(
+  meta: Pick<MetaStore, "listComments" | "setThreadState" | "updateComment">,
+  artifactId: string,
+  proposalId: string,
+  toState: Extract<CommentState, "open" | "resolved">,
+): Promise<string[]> {
+  const comments = await meta.listComments(artifactId)
+  const released: string[] = []
+  for (const cm of comments) {
+    if (cm.id !== cm.thread_id) continue // the root carries the tag + the state
+    const md = parseMeta(cm.meta)
+    if (md.addressed_by !== proposalId) continue
+    delete md.addressed_by
+    await meta.updateComment(cm.id, { meta: JSON.stringify(md) })
+    await meta.setThreadState(artifactId, cm.thread_id, toState)
+    released.push(cm.thread_id)
+  }
+  return released
+}

--- a/apps/api/src/lib/comments.ts
+++ b/apps/api/src/lib/comments.ts
@@ -11,6 +11,10 @@ export type CommentMeta = {
   edited_at?: string
   deleted?: boolean
   mentions?: Mention[]
+  // The id of the open proposal whose revision claims to address this thread.
+  // Set when the thread flips to `addressed`; cleared when that proposal is
+  // approved (→ resolved) or withdrawn / sent back for changes (→ open).
+  addressed_by?: string
 }
 
 export const parseMeta = (m: string | null): CommentMeta => {

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -30,6 +30,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import type { Hono } from "hono"
 import { z } from "zod"
 import type { AppContext } from "./context"
+import { markAddressed } from "./lib/addressed"
 import { cleanPath, manifestOf as sharedManifestOf } from "./lib/bundle"
 import { quoteOf } from "./lib/comments"
 
@@ -109,8 +110,10 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
         `with ${agent.role} permissions. Dock hosts living documents and plans with versioned ` +
         `history, text-anchored review comments, and a propose → review → revise loop. ` +
         `Start a session with catch_me_up to re-sync on what changed; use read to view content ` +
-        `(outline first for multi-page bundles); use propose to suggest a revision a human ` +
-        `approves — you cannot publish directly.`,
+        `(outline first for multi-page bundles); work the open threads from list_comments and use ` +
+        `propose to suggest a revision a human approves — you cannot publish directly. When a ` +
+        `proposal fixes specific feedback, pass those thread ids as propose's "addresses" so the ` +
+        `threads show as pending and auto-resolve on approval.`,
     },
   )
   const org = agent.org_id
@@ -181,6 +184,11 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
       const outdatedBit = outdated.length
         ? ` ${outdated.length} now outdated (the quoted text changed).`
         : ""
+      // Threads with a proposal already pending — the agent shouldn't re-propose them.
+      const addressed = await ctx.meta.listComments(a.id, { state: "addressed" })
+      const addressedBit = addressed.length
+        ? ` ${addressed.length} addressed (a proposal is pending review).`
+        : ""
       const pageBits =
         pagesChanged && changeCount(pagesChanged)
           ? ` Pages: ${[
@@ -193,8 +201,8 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           : ""
       const summary =
         since >= head
-          ? `You're up to date on "${a.title}" (v${head}); ${open.length} open comment${open.length === 1 ? "" : "s"}.${outdatedBit}`
-          : `"${a.title}": ${newVersions.length} new version${newVersions.length === 1 ? "" : "s"} since v${since} (now v${head}).${pageBits} ${open.length} open comment${open.length === 1 ? "" : "s"}.${outdatedBit}`
+          ? `You're up to date on "${a.title}" (v${head}); ${open.length} open comment${open.length === 1 ? "" : "s"}.${addressedBit}${outdatedBit}`
+          : `"${a.title}": ${newVersions.length} new version${newVersions.length === 1 ? "" : "s"} since v${since} (now v${head}).${pageBits} ${open.length} open comment${open.length === 1 ? "" : "s"}.${addressedBit}${outdatedBit}`
       return json({
         summary,
         short_id,
@@ -324,11 +332,11 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
     "list_comments",
     {
       description:
-        "The review feedback on an artifact: comment threads with author, body, the quoted text they're anchored to, the version they were left on, and state. This is your to-do list before proposing — work the `open` threads. State is open (live feedback), resolved (a human marked it done), or outdated (the quoted text changed in a later version, so the feedback may no longer apply — verify before acting). Filter by `state`; default lists all.",
+        "The review feedback on an artifact: comment threads with author, body, the quoted text they're anchored to, the version they were left on, and state. This is your to-do list before proposing — work the `open` threads. State is open (live feedback), addressed (a proposal you/someone made is pending review for it — don't re-propose), resolved (settled), or outdated (the quoted text changed in a later version, so the feedback may no longer apply — verify before acting). Filter by `state`; default lists all.",
       inputSchema: {
         short_id: z.string(),
         state: z
-          .enum(["open", "resolved", "outdated"])
+          .enum(["open", "addressed", "resolved", "outdated"])
           .optional()
           .describe("Filter by thread state. Omit to list every thread."),
       },
@@ -376,7 +384,7 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
     "propose",
     {
       description:
-        "Propose a revised version of a single-file artifact for human review. It does NOT go live — a reviewer approves it or requests changes, so you're a safe contributor, not a publisher. Provide the FULL new content (not a patch) and a rationale that tells the reviewer what changed and why. Multi-page bundles aren't proposable over MCP yet.",
+        "Propose a revised version of a single-file artifact for human review. It does NOT go live — a reviewer approves it or requests changes, so you're a safe contributor, not a publisher. Provide the FULL new content (not a patch) and a rationale that tells the reviewer what changed and why. Pass `addresses` with the thread ids (from list_comments) this revision resolves — those threads show as `addressed` (pending review) and auto-resolve when the proposal is approved. Multi-page bundles aren't proposable over MCP yet.",
       inputSchema: {
         short_id: z.string(),
         content: z
@@ -390,9 +398,15 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           .string()
           .optional()
           .describe("Filename hint for the content type, e.g. index.html or notes.md."),
+        addresses: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Thread ids (from list_comments) this revision resolves. They flip to `addressed` and resolve on approval.",
+          ),
       },
     },
-    async ({ short_id, content, message, filename }) => {
+    async ({ short_id, content, message, filename, addresses }) => {
       const a = await own(short_id)
       if (!a) return notFound(short_id)
       if (agent.role === "viewer")
@@ -412,10 +426,20 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           author: agent.name,
           author_id: agent.id,
         })
+        const addressed = addresses?.length
+          ? await markAddressed(ctx.meta, a.id, proposal.id, addresses)
+          : []
+        for (const threadId of addressed)
+          ctx.bus.publish(a.id, {
+            type: "comment.addressed",
+            thread_id: threadId,
+            state: "addressed",
+          })
         return json({
           proposed: true,
           proposal_id: proposal.id,
           base_version: proposal.base_version,
+          addressed,
           note: "Submitted for review — a human approves it or requests changes. It is NOT live yet.",
         })
       } catch (e) {

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -198,7 +198,8 @@ export const commentRoutes = (ctx: AppContext) => {
     // viewer — do, the Google-Docs way. So the gate is "has an account", not the role.
     if (await anonLocked(c, artifact)) return fail(c, 404, "not found")
     const q = c.req.query("state")
-    const state = q === "open" || q === "resolved" || q === "outdated" ? q : undefined
+    const state =
+      q === "open" || q === "resolved" || q === "outdated" || q === "addressed" ? q : undefined
     const comments = await meta.listComments(artifact.id, state ? { state } : undefined)
     // Flag whether each anchor still resolves against the current version.
     const cur = await meta.getVersion(artifact.id, artifact.current_version)

--- a/apps/api/src/routes/proposals.ts
+++ b/apps/api/src/routes/proposals.ts
@@ -9,8 +9,16 @@ import {
 import { type Context, Hono } from "hono"
 import { z } from "zod"
 import type { AppContext } from "../context"
+import { markAddressed, releaseAddressed } from "../lib/addressed"
 import { sweepAnchors } from "../lib/anchor-sweep"
 import { fail, MAX_UPLOAD_BYTES, readJson, str } from "../lib/http"
+
+/** Parse a comma-separated id list (the `addresses` multipart field). */
+const idList = (raw: string | undefined): string[] =>
+  (raw ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
 
 /** Reviews: a proposal is a candidate version awaiting approval. A commenter
  *  proposes; an editor approves (it goes live) or requests changes. */
@@ -104,13 +112,27 @@ export const proposalRoutes = (ctx: AppContext) => {
         author_id: acting?.id ?? null,
       })
       bus.publish(artifact.id, { type: "proposal.created", proposal_id: proposal.id })
+      // Threads this revision claims to fix flip to `addressed` (pending review),
+      // tagged with the proposal id so approve/withdraw can release exactly these.
+      const addressed = await markAddressed(
+        meta,
+        artifact.id,
+        proposal.id,
+        idList(str(body.addresses)),
+      )
+      for (const threadId of addressed)
+        bus.publish(artifact.id, {
+          type: "comment.addressed",
+          thread_id: threadId,
+          state: "addressed",
+        })
       await notify(artifact, "proposal.created", {
         proposal_id: proposal.id,
         author: proposal.author,
         message: proposal.message,
         base_version: proposal.base_version,
       })
-      return c.json(proposalJson(artifact, proposal), 201)
+      return c.json({ ...proposalJson(artifact, proposal), addressed }, 201)
     } catch (err) {
       if (err instanceof PublishError) return fail(c, err.statusCode as 400, err.message)
       throw err
@@ -179,6 +201,13 @@ export const proposalRoutes = (ctx: AppContext) => {
           thread_id: t.thread_id,
           state: t.state,
         })
+      // Threads this proposal addressed are now settled — the fix landed.
+      for (const threadId of await releaseAddressed(meta, artifact.id, proposal.id, "resolved"))
+        bus.publish(artifact.id, {
+          type: "comment.addressed",
+          thread_id: threadId,
+          state: "resolved",
+        })
       await notify(artifact, "proposal.approved", {
         proposal_id: proposal.id,
         version: version.n,
@@ -210,6 +239,9 @@ export const proposalRoutes = (ctx: AppContext) => {
       decision_note: str(body.note) ?? null,
     })
     bus.publish(artifact.id, { type: "proposal.changes_requested", proposal_id: proposal.id })
+    // The fix didn't land — reopen the threads it had staged as addressed.
+    for (const threadId of await releaseAddressed(meta, artifact.id, proposal.id, "open"))
+      bus.publish(artifact.id, { type: "comment.addressed", thread_id: threadId, state: "open" })
     await notify(artifact, "proposal.changes_requested", { proposal_id: proposal.id, reviewer })
     const fresh = (await meta.getProposal(proposal.id)) as ProposalRecord
     return c.json(proposalJson(artifact, fresh))
@@ -233,6 +265,9 @@ export const proposalRoutes = (ctx: AppContext) => {
       decided_by: acting?.name ?? null,
       decided_version: null,
     })
+    // Retracting the proposal reopens the threads it had staged as addressed.
+    for (const threadId of await releaseAddressed(meta, artifact.id, proposal.id, "open"))
+      bus.publish(artifact.id, { type: "comment.addressed", thread_id: threadId, state: "open" })
     const fresh = (await meta.getProposal(proposal.id)) as ProposalRecord
     return c.json(proposalJson(artifact, fresh))
   })

--- a/apps/api/test/addressed.test.ts
+++ b/apps/api/test/addressed.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest"
+import { as, jsonAs, makeAuthedApp, proposeAs, publishAs, type TestUser } from "./helpers"
+
+// The `addressed` state machine: a proposal that cites comment threads flips them
+// to `addressed` (pending review); approving resolves them, withdrawing or
+// requesting changes reopens them.
+
+const owner: TestUser = { id: "u_ao", email: "ao@dock.test", name: "Ao" }
+const ed: TestUser = { id: "u_ae", email: "ae@dock.test", name: "Ae" }
+
+const stateOf = async (
+  app: ReturnType<typeof makeAuthedApp>["app"],
+  shortId: string,
+  threadId: string,
+) => {
+  const list = await (
+    await app.request(`/v1/artifacts/${shortId}/comments`, { headers: as(owner.email) })
+  ).json()
+  return list.comments.find((c: { thread_id: string }) => c.thread_id === threadId)?.state
+}
+
+const comment = async (
+  app: ReturnType<typeof makeAuthedApp>["app"],
+  shortId: string,
+  body: string,
+) => {
+  const res = await app.request(
+    `/v1/artifacts/${shortId}/comments`,
+    jsonAs(as(owner.email), { body_md: body }),
+  )
+  return res.json()
+}
+
+describe("addressed: propose cites threads → pending → resolve on approve", () => {
+  const { app } = makeAuthedApp("addressed-approve", [owner, ed], "editor")
+
+  it("flips cited threads to addressed, then resolves them when the proposal is approved", async () => {
+    const shortId = (await (await publishAs(app, "<h1>v1</h1>", {}, as(owner.email))).json())
+      .short_id
+    const cm = await comment(app, shortId, "please fix the headline")
+    expect(await stateOf(app, shortId, cm.thread_id)).toBe("open")
+
+    // Propose citing the thread → it becomes addressed (pending review).
+    const pr = await (
+      await proposeAs(app, shortId, "<h1>v2</h1>", as(ed.email), {
+        message: "fixed headline",
+        addresses: cm.thread_id,
+      })
+    ).json()
+    expect(pr.addressed).toEqual([cm.thread_id])
+    expect(await stateOf(app, shortId, cm.thread_id)).toBe("addressed")
+    // It's off the open to-do list while a fix is pending.
+    const open = await (
+      await app.request(`/v1/artifacts/${shortId}/comments?state=open`, {
+        headers: as(owner.email),
+      })
+    ).json()
+    expect(open.comments).toHaveLength(0)
+
+    // Approve → the fix landed → the thread resolves.
+    const ap = await app.request(`/v1/artifacts/${shortId}/proposals/${pr.id}/approve`, {
+      method: "POST",
+      headers: as(owner.email),
+    })
+    expect(ap.status).toBe(200)
+    expect(await stateOf(app, shortId, cm.thread_id)).toBe("resolved")
+  })
+})
+
+describe("addressed: reopens when the proposal doesn't land", () => {
+  const { app } = makeAuthedApp("addressed-revert", [owner, ed], "editor")
+
+  it("reopens on withdraw and on request-changes", async () => {
+    const shortId = (await (await publishAs(app, "<h1>v1</h1>", {}, as(owner.email))).json())
+      .short_id
+
+    // Withdraw path.
+    const cm1 = await comment(app, shortId, "tweak intro")
+    const p1 = await (
+      await proposeAs(app, shortId, "<h1>v2</h1>", as(ed.email), {
+        message: "intro",
+        addresses: cm1.thread_id,
+      })
+    ).json()
+    expect(await stateOf(app, shortId, cm1.thread_id)).toBe("addressed")
+    await app.request(`/v1/artifacts/${shortId}/proposals/${p1.id}/withdraw`, {
+      method: "POST",
+      headers: as(ed.email),
+    })
+    expect(await stateOf(app, shortId, cm1.thread_id)).toBe("open")
+
+    // Request-changes path.
+    const cm2 = await comment(app, shortId, "trim footer")
+    const p2 = await (
+      await proposeAs(app, shortId, "<h1>v2b</h1>", as(ed.email), {
+        message: "footer",
+        addresses: cm2.thread_id,
+      })
+    ).json()
+    expect(await stateOf(app, shortId, cm2.thread_id)).toBe("addressed")
+    await app.request(`/v1/artifacts/${shortId}/proposals/${p2.id}/request-changes`, {
+      method: "POST",
+      headers: as(owner.email),
+    })
+    expect(await stateOf(app, shortId, cm2.thread_id)).toBe("open")
+  })
+})

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -329,4 +329,44 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(cu.outdated_comments).toHaveLength(1)
     expect(cu.outdated_comments[0].quote).toBe("beta")
   })
+
+  it("propose with `addresses` marks the cited threads addressed (pending review)", async () => {
+    const { app, token } = appWithGrant("addr", "openid dock:read dock:comment dock:publish")
+    const shortId = (await (await publish(app, token, "headline to fix")).json()).short_id
+    const cm = await (
+      await app.request(`/v1/artifacts/${shortId}/comments`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+        body: JSON.stringify({ body_md: "fix the headline" }),
+      })
+    ).json()
+
+    const p = JSON.parse(
+      toolText(
+        await call(app, token, "propose", {
+          short_id: shortId,
+          content: "<h1>fixed headline</h1>",
+          message: "fixed it",
+          addresses: [cm.thread_id],
+        }),
+      ),
+    )
+    expect(p.proposed).toBe(true)
+    expect(p.addressed).toEqual([cm.thread_id])
+
+    // The thread is now addressed — off the open list, listed under `addressed`.
+    const open = JSON.parse(
+      toolText(await call(app, token, "list_comments", { short_id: shortId, state: "open" })),
+    )
+    expect(open.count).toBe(0)
+    const addr = JSON.parse(
+      toolText(await call(app, token, "list_comments", { short_id: shortId, state: "addressed" })),
+    )
+    expect(addr.count).toBe(1)
+    expect(addr.comments[0].state).toBe("addressed")
+
+    // catch_me_up flags it so the agent won't re-propose the same fix.
+    const cu = JSON.parse(toolText(await call(app, token, "catch_me_up", { short_id: shortId })))
+    expect(cu.summary).toContain("addressed")
+  })
 })

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -164,9 +164,10 @@ export interface Comment {
   anchor: string | null
   body_md: string
   author: string
+  // `addressed` = a proposed revision citing this thread is pending review.
   // `outdated` = the quoted text this thread anchored to changed in a later
   // version (set by the server's re-anchor sweep); the feedback may no longer apply.
-  state: "open" | "resolved" | "outdated"
+  state: "open" | "addressed" | "resolved" | "outdated"
   created_at: string
   anchored?: boolean
   reactions?: Record<string, string[]>

--- a/apps/web/src/pages/artifact/comment-thread.tsx
+++ b/apps/web/src/pages/artifact/comment-thread.tsx
@@ -205,6 +205,7 @@ export function CommentCard({
   }
   const resolved = root.state === "resolved"
   const outdated = root.state === "outdated"
+  const addressed = root.state === "addressed"
   const quote = anchorExact(root.anchor)
   const textPresent = present !== undefined ? present : root.anchored !== false
   const replies = thread.length - 1
@@ -302,17 +303,21 @@ export function CommentCard({
                   ? "bg-success/15 text-success"
                   : outdated
                     ? "bg-gold/15 text-gold"
-                    : "bg-accent text-primary",
+                    : addressed
+                      ? "bg-review/15 text-review"
+                      : "bg-accent text-primary",
               )}
               title={
                 outdated
                   ? "The text this thread was attached to changed in a later version — this feedback may no longer apply"
-                  : undefined
+                  : addressed
+                    ? "A proposed revision addressing this thread is pending review"
+                    : undefined
               }
             >
-              {resolved ? "resolved" : outdated ? "outdated" : "open"}
+              {resolved ? "resolved" : outdated ? "outdated" : addressed ? "addressed" : "open"}
             </span>
-            {quote && !textPresent && !resolved && !outdated && (
+            {quote && !textPresent && !resolved && !outdated && !addressed && (
               <span
                 title="The text this comment was attached to was edited or removed in this version"
                 className="rounded-full bg-accent px-2 py-0.5 font-mono text-2xs font-bold text-primary"

--- a/apps/web/src/pages/artifact/use-artifact-frame.ts
+++ b/apps/web/src/pages/artifact/use-artifact-frame.ts
@@ -157,13 +157,14 @@ export function useArtifactFrame(p: {
     return () => window.removeEventListener("keydown", onKey)
   }, [deck, deckCmd])
 
-  // Paint highlights for open, anchored threads whenever the doc or comments change.
+  // Paint highlights for active (open or addressed), anchored threads whenever
+  // the doc or comments change. Resolved/outdated threads don't paint.
   const sendAnchors = useCallback(() => {
     const w = frame.current?.contentWindow
     if (!w) return
     const anchors = groupThreads(comments)
       .map((t) => t[0])
-      .filter((head): head is Comment => head?.state === "open")
+      .filter((head): head is Comment => head?.state === "open" || head?.state === "addressed")
       .map((head) => ({ id: head.thread_id, sel: parseAnchor(head.anchor) }))
       .filter((x): x is { id: string; sel: NonNullable<ReturnType<typeof parseAnchor>> } => !!x.sel)
       .map((x) => ({ id: x.id, exact: x.sel.exact, prefix: x.sel.prefix, suffix: x.sel.suffix }))

--- a/apps/web/src/pages/artifact/use-artifact-live.ts
+++ b/apps/web/src/pages/artifact/use-artifact-live.ts
@@ -33,6 +33,7 @@ export function useArtifactLive(opts: {
     ev.addEventListener("comment.created", onComment)
     ev.addEventListener("comment.resolved", onComment)
     ev.addEventListener("comment.outdated", onComment)
+    ev.addEventListener("comment.addressed", onComment)
     ev.addEventListener("comment.reacted", onComment)
     ev.addEventListener("comment.updated", onComment)
     ev.addEventListener("version.published", onVersion)

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -1,3 +1,5 @@
+import type { CommentState } from "./ports"
+
 /** A W3C Web Annotation TextQuoteSelector — survives republishing. */
 export interface QuoteSelector {
   type: "TextQuoteSelector"
@@ -268,7 +270,7 @@ export function isAnchored(anchorJson: string | null, text: string): boolean {
 export interface AnchorThread {
   thread_id: string
   anchor: string | null
-  state: "open" | "resolved" | "outdated"
+  state: CommentState
 }
 
 /** A state flip the sweep wants applied (always thread-level). */

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -780,12 +780,16 @@ export interface ViewStats {
 }
 
 // open      — live feedback awaiting a reply/resolution
-// resolved  — a human marked the thread done
+// addressed — a proposed revision that cites this thread is pending review. Set
+//             when an agent/author `propose`s with `addresses`; clears to
+//             `resolved` if that proposal is approved (the fix landed) or back to
+//             `open` if it's withdrawn / sent back for changes.
+// resolved  — a human marked the thread done (or an addressing proposal landed)
 // outdated  — the text this thread anchored to changed or vanished in a later
 //             version, so the feedback may no longer apply. Set automatically by
 //             the re-anchor sweep on every version bump; flips back to `open` if
-//             the quoted text reappears. Never overwrites `resolved`.
-export type CommentState = "open" | "resolved" | "outdated"
+//             the quoted text reappears. Never overwrites `resolved`/`addressed`.
+export type CommentState = "open" | "addressed" | "resolved" | "outdated"
 
 export interface CommentRecord {
   id: string


### PR DESCRIPTION
**Phase 3 of the agentic loop** — closes the `propose → review → resolve` cycle. Builds on #167's `outdated`.

`CommentState` gains **`addressed`**: a thread with a proposed fix pending review. The agent reads the open threads, proposes a revision **citing the thread ids it resolves**, and those threads show as `addressed` so nobody re-works them; on approval they auto-resolve.

**No schema change.** The live D1 schema is applied out-of-band via `wrangler d1 execute` ([worker.ts](apps/api/src/worker.ts#L35)), so rather than a new `proposal.addresses` column, the proposal↔thread link lives in the existing `comment.meta` JSON (`addressed_by`). Ships with a plain code deploy, no migration.

### Lifecycle ([lib/addressed.ts](apps/api/src/lib/addressed.ts))
- **propose** with `addresses: [threadId, …]` → those threads flip to `addressed`, tagged with the proposal id. Wired into both the MCP `propose` tool and the REST route.
- **approved** → addressed threads **resolve** (the fix landed).
- **withdrawn / changes-requested** → revert to **open** (the fix didn't land).
- the re-anchor sweep **skips** `addressed` — a staged fix shouldn't be flagged outdated by an unrelated republish.

### Surfaces
- **MCP**: `propose` accepts `addresses` and returns what it marked; `list_comments` filters by + reports `addressed`; `catch_me_up` counts pending-fix threads so the agent doesn't re-propose; the server `instructions` teach the cite-your-fixes flow.
- **Web**: a `review`-colored `addressed` badge; threads stay in the active list and keep their in-doc highlight; live `comment.addressed` event; resolve handles it. `GET /comments?state=addressed` added.

### Tests
- the addressed lifecycle: propose→`addressed`→resolve on approve; reopen on withdraw **and** request-changes.
- the MCP `propose`-with-`addresses` path (→ `list_comments`/`catch_me_up` report it).
- 322 api + 64 core green; web/api/core typecheck + biome clean.

Now the full machine: feedback goes `open → addressed` (a fix is staged) → `resolved` (it landed) or back to `open`, with `outdated` as the automatic escape hatch when text moves underneath it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)