### PR TITLE
Review follow-ups: native edge rate limiting + D1 driver test lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,25 @@ jobs:
       - name: Test against Postgres
         run: pnpm test:pg
 
+  # Runs the SAME @dock/db store contract against a real Cloudflare D1, inside
+  # workerd via Miniflare (the `pnpm test:d1` lane). The default (Node) lane can't
+  # host the D1 driver, so this is the only place src/d1.ts is exercised at runtime —
+  # the edge tier runs on it.
+  d1:
+    runs-on: ubicloud-standard-2
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Test against Cloudflare D1 (workerd)
+        run: pnpm --filter @dock/db test:d1
+
   # Coverage gates (ratchet floors; see each package's vitest.config.ts): the API
   # suite, the data layer (@dock/db), the shared domain logic (@dock/core), the blob
   # stores (@dock/storage), the MCP client, and the web app's pure logic (@dock/web;

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,7 +5,7 @@ import { OAUTH_SCOPES } from "./auth-config"
 import { type AppDeps, buildContext } from "./context"
 import { cacheControlFor, corsFor, fail, TOMBSTONE } from "./lib/http"
 import { observability } from "./lib/observability"
-import { makeRateLimiter } from "./lib/rate-limit"
+import { inMemoryRateLimiters, ipRateLimit } from "./lib/rate-limit"
 import { serveContent } from "./lib/serve-content"
 import { log } from "./log"
 import { mountMcp } from "./mcp"
@@ -42,7 +42,12 @@ export type { AppDeps }
  * `node.ts` adds static SPA serving around what this returns.
  */
 export function createApp(deps: AppDeps): Hono {
-  const ctx = buildContext(deps)
+  // One limiter set, shared by the IP middleware below and the keyed limiters in
+  // buildContext (resolved here and passed in, so both see the same instance). The edge
+  // entry supplies native per-colo limiters; Node / self-host / tests fall back to the
+  // in-process set (authoritative on one container).
+  const rateLimiters = deps.rateLimiters ?? inMemoryRateLimiters(deps)
+  const ctx = buildContext({ ...deps, rateLimiters })
   const app = new Hono()
 
   // Outermost: a per-request id + one structured access-log line (method, path,
@@ -218,11 +223,11 @@ export function createApp(deps: AppDeps): Hono {
   }
   if (deps.rateLimit) {
     // Strict on auth (credential brute-force); lenient on mutating API calls.
-    app.use("/api/auth/*", makeRateLimiter(60_000, 20))
+    app.use("/api/auth/*", ipRateLimit(rateLimiters.auth))
     // Anonymous OAuth client registration (open DCR) gets a tighter per-IP cap on
     // top, so no single source can flood the client table.
-    app.use("/api/auth/oauth2/register", makeRateLimiter(3_600_000, 10))
-    const writeLimiter = makeRateLimiter(60_000, 120)
+    app.use("/api/auth/oauth2/register", ipRateLimit(rateLimiters.oauthRegister))
+    const writeLimiter = ipRateLimit(rateLimiters.write)
     app.use("/v1/*", (c, next) =>
       c.req.method === "GET" || c.req.method === "HEAD" ? next() : writeLimiter(c, next),
     )

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -22,7 +22,7 @@ import { type Backplane, createInProcessBackplane } from "./bus"
 import type { CustomDomainProvider } from "./lib/cloudflare-saas"
 import { safeEqual, sha256, unlockCookie, unlockToken } from "./lib/crypto"
 import { VIEWER_COOKIE, WS_COOKIE } from "./lib/http"
-import { makeKeyedLimiter } from "./lib/rate-limit"
+import { inMemoryRateLimiters, type Limiter, type RateLimiters } from "./lib/rate-limit"
 import { log } from "./log"
 import { edgeCtx } from "./realtime-do"
 import { enqueueForEvent, type WebhookEvent } from "./webhooks"
@@ -74,8 +74,14 @@ export interface AppDeps {
    * one and rekeys any legacy rows onto it.
    */
   defaultOrgId?: string
-  /** In-memory per-IP rate limiting on auth + mutating routes. Off by default. */
+  /** Per-IP / per-actor rate limiting on auth + mutating routes. Off by default. */
   rateLimit?: boolean
+  /**
+   * The rate limiters to enforce. Omit for the in-process default (authoritative on a
+   * single container — Node / self-host — and used by tests). The edge entry supplies a
+   * set backed by Cloudflare's native per-colo limiter (see worker.ts).
+   */
+  rateLimiters?: RateLimiters
   /**
    * Per-workspace storage backstops (abuse gate). Both default to unlimited so
    * self-host stays open; the hosted tier sets them. maxArtifacts caps how many
@@ -179,16 +185,16 @@ export function buildContext(deps: AppDeps) {
   // literal. The Node entry generates + persists one; tests fall back to this.
   const defaultOrg = deps.defaultOrgId ?? "default"
 
-  // Per-actor limiters on the two flood-prone actions, identity-keyed so one
-  // account can't drown the workspace even from many IPs. Active only when
-  // rate limiting is on; the IP middleware is the per-origin backstop.
-  const publishLimiter = deps.rateLimit ? makeKeyedLimiter(60_000, deps.publishRate ?? 30) : null
-  const commentLimiter = deps.rateLimit ? makeKeyedLimiter(60_000, deps.commentRate ?? 60) : null
-  // Password unlock is a credential-guessing surface, so it gets a much tighter
-  // cap than the lenient global /v1 write limiter (120/min) it would otherwise
-  // share: 5 attempts per 5 minutes per caller (IP, when anonymous) — enough for
-  // a legit fat-finger, slow enough that brute force is hopeless.
-  const unlockLimiter = deps.rateLimit ? makeKeyedLimiter(5 * 60_000, 5) : null
+  // Per-actor limiters on the flood-prone actions, identity-keyed so one account can't
+  // drown the workspace even from many IPs. Active only when rate limiting is on; the IP
+  // middleware (app.ts) is the per-origin backstop. The same limiter set backs both call
+  // sites — app.ts resolves it once and passes it in, so it's a single source of truth.
+  // Password unlock is a credential-guessing surface and gets a much tighter cap (5 / 5
+  // min in-process; the edge's native binding caps it to a 60s window — see worker.ts).
+  const limiters = deps.rateLimiters ?? inMemoryRateLimiters(deps)
+  const publishLimiter = deps.rateLimit ? limiters.publish : null
+  const commentLimiter = deps.rateLimit ? limiters.comment : null
+  const unlockLimiter = deps.rateLimit ? limiters.unlock : null
 
   // Fan an event to subscribed webhooks (enqueues to the outbox; the drainer
   // delivers). Awaited so the row is durable before we respond, but never fatal.
@@ -390,12 +396,9 @@ export function buildContext(deps: AppDeps) {
 
   // Apply a keyed limiter to the caller; returns a 429 Response when over, else
   // null to continue. Helper because publish + propose + comment share it.
-  const limited = async (
-    c: Context,
-    limiter: ReturnType<typeof makeKeyedLimiter> | null,
-  ): Promise<Response | null> => {
+  const limited = async (c: Context, limiter: Limiter | null): Promise<Response | null> => {
     if (!limiter) return null
-    const r = limiter(await actorKey(c))
+    const r = await limiter(await actorKey(c))
     if (r.ok) return null
     c.header("Retry-After", String(r.retryAfter))
     return c.json({ error: "rate limit exceeded" }, 429)

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -1,44 +1,90 @@
+import type { RateLimit } from "@cloudflare/workers-types"
 import type { Context, Next } from "hono"
 
-/** Fixed-window per-IP limiter. In-memory (per instance); good enough as a
- *  brute-force / abuse backstop on a single container. */
-export function makeRateLimiter(windowMs: number, max: number) {
+/** A rate-limit verdict for one request: within the cap, and seconds to retry if not. */
+export type RateLimitVerdict = { ok: boolean; retryAfter: number }
+
+/**
+ * Check one request against a cap, keyed by IP or actor id. Async because the backing
+ * limiter may be remote: in-process on a single container (Node / self-host), or the
+ * Cloudflare native per-colo limiter on the edge.
+ */
+export type Limiter = (key: string) => Promise<RateLimitVerdict>
+
+/**
+ * An in-process fixed-window limiter — one counter Map. Authoritative on a single
+ * container (Node / self-host) and the universal default + test path. A lazy sweep of
+ * expired entries caps the Map so a flood of distinct keys can't grow it without bound.
+ */
+export function inMemoryLimiter(windowMs: number, max: number): Limiter {
   const hits = new Map<string, { count: number; reset: number }>()
-  return async (c: Context, next: Next) => {
+  return async (key) => {
     const now = Date.now()
     if (hits.size > 10_000) for (const [k, v] of hits) if (v.reset < now) hits.delete(k)
-    const ip = (
-      c.req.header("x-forwarded-for")?.split(",")[0] ??
-      c.req.header("x-real-ip") ??
-      "global"
-    ).trim()
-    let b = hits.get(ip)
-    if (!b || b.reset < now) {
-      b = { count: 0, reset: now + windowMs }
-      hits.set(ip, b)
-    }
+    const cur = hits.get(key)
+    const b = !cur || cur.reset < now ? { count: 0, reset: now + windowMs } : cur
     b.count++
-    if (b.count > max) {
-      c.header("Retry-After", String(Math.ceil((b.reset - now) / 1000)))
-      return c.json({ error: "rate limit exceeded" }, 429)
-    }
-    return next()
+    hits.set(key, b)
+    return { ok: b.count <= max, retryAfter: Math.ceil((b.reset - now) / 1000) }
   }
 }
 
-/** Fixed-window limiter keyed by an arbitrary string (e.g. an actor id), for
- *  identity-based limits on specific actions — distinct from the IP middleware. */
-export function makeKeyedLimiter(windowMs: number, max: number) {
-  const hits = new Map<string, { count: number; reset: number }>()
-  return (key: string): { ok: boolean; retryAfter: number } => {
-    const now = Date.now()
-    if (hits.size > 10_000) for (const [k, v] of hits) if (v.reset < now) hits.delete(k)
-    let b = hits.get(key)
-    if (!b || b.reset < now) {
-      b = { count: 0, reset: now + windowMs }
-      hits.set(key, b)
-    }
-    b.count++
-    return { ok: b.count <= max, retryAfter: Math.ceil((b.reset - now) / 1000) }
+/**
+ * A limiter over a Cloudflare native rate-limit binding (per-colo, fixed window declared
+ * in wrangler). The binding returns only success/fail, so `period` (its configured window,
+ * 10 or 60s) is reported as Retry-After. `prefix` namespaces the key when one binding
+ * backs more than one surface, so their counts stay separate.
+ */
+export function nativeLimiter(binding: RateLimit, period: number, prefix = ""): Limiter {
+  return async (key) => {
+    const { success } = await binding.limit({ key: prefix ? `${prefix}:${key}` : key })
+    return { ok: success, retryAfter: period }
+  }
+}
+
+/** The rate-limited surfaces, as ready-to-call limiters. Built from in-process counters
+ *  (Node / self-host / tests) or native bindings (the edge). */
+export interface RateLimiters {
+  auth: Limiter
+  oauthRegister: Limiter
+  write: Limiter
+  publish: Limiter
+  comment: Limiter
+  unlock: Limiter
+}
+
+/**
+ * The default in-process limiter set, each surface at its real window — including the
+ * long ones (unlock 5 min, oauth registration 1 hr) that the edge's native binding can't
+ * express (its period is capped at 60s). publish/comment honor the configured per-minute
+ * rates.
+ */
+export function inMemoryRateLimiters(
+  opts: { publishRate?: number; commentRate?: number } = {},
+): RateLimiters {
+  return {
+    auth: inMemoryLimiter(60_000, 20),
+    oauthRegister: inMemoryLimiter(3_600_000, 10),
+    write: inMemoryLimiter(60_000, 120),
+    publish: inMemoryLimiter(60_000, opts.publishRate ?? 30),
+    comment: inMemoryLimiter(60_000, opts.commentRate ?? 60),
+    unlock: inMemoryLimiter(5 * 60_000, 5),
+  }
+}
+
+/** The caller's IP from the proxy headers, falling back to a shared bucket. */
+const ipOf = (c: Context): string =>
+  (c.req.header("x-forwarded-for")?.split(",")[0] ?? c.req.header("x-real-ip") ?? "global").trim()
+
+/**
+ * IP-keyed limiter middleware (brute-force / abuse backstop): 429 + Retry-After once the
+ * caller's IP is over the cap, else passes through.
+ */
+export function ipRateLimit(limiter: Limiter) {
+  return async (c: Context, next: Next) => {
+    const r = await limiter(ipOf(c))
+    if (r.ok) return next()
+    c.header("Retry-After", String(r.retryAfter))
+    return c.json({ error: "rate limit exceeded" }, 429)
   }
 }

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -4,6 +4,7 @@ import type {
   ExecutionContext,
   Fetcher,
   R2Bucket,
+  RateLimit,
   ScheduledController,
 } from "@cloudflare/workers-types"
 import { createD1Store } from "@dock/db/d1"
@@ -12,11 +13,12 @@ import { D1Dialect } from "kysely-d1"
 import { createApp } from "./app"
 import { makeAuth } from "./auth-config"
 import { customDomainsFromEnv } from "./lib/cloudflare-saas"
+import { nativeLimiter } from "./lib/rate-limit"
 import { createDoBackplane, edgeCtx } from "./realtime-do"
 
-// The realtime room Durable Object (one per channel) and the webhook outbox drainer
-// (a single named instance). Exported so the Workers runtime can instantiate the
-// bound classes (see wrangler.toml `durable_objects.bindings`).
+// The bound Durable Object classes — the realtime room (one per channel) and the webhook
+// outbox drainer (a single named instance) — re-exported so the Workers runtime can
+// instantiate them (see wrangler.toml `durable_objects.bindings`).
 export { ArtifactRoom } from "./realtime-do"
 export { WebhookOutbox } from "./webhook-do"
 
@@ -53,6 +55,15 @@ export interface Env {
   ROOMS: DurableObjectNamespace
   // The webhook outbox drainer DO (a single named instance). Declared in wrangler.toml.
   WEBHOOK_OUTBOX: DurableObjectNamespace
+  // Native per-colo rate-limit bindings (limit + 60s window declared in wrangler.toml
+  // [[ratelimits]]). The edge counts against these instead of an in-process Map so a cap
+  // holds across isolates within a location. RL_STRICT is shared by the two tight 3/60
+  // surfaces (unlock + oauth-register), namespaced by key so their counts stay separate.
+  RL_AUTH: RateLimit
+  RL_WRITE: RateLimit
+  RL_PUBLISH: RateLimit
+  RL_COMMENT: RateLimit
+  RL_STRICT: RateLimit
   // The static-assets binding: lets the Worker read the SPA shell to inject unfurl
   // meta into /a/:ref (the share URL). Declared in wrangler.toml `[assets] binding`.
   ASSETS: Fetcher
@@ -110,6 +121,20 @@ export default {
         subdomainBase:
           env.DOCK_SUBDOMAIN_BASE?.toLowerCase().replace(/^\.+|\.+$/g, "") || undefined,
         customDomains: customDomainsFromEnv(env),
+        // Enable rate limiting on the edge, counted by Cloudflare's native per-colo
+        // limiter (a plain in-memory Map would cap per isolate only). The native binding's
+        // window is fixed at 60s, so unlock / oauth-register run a tighter per-minute cap
+        // here than the long-window in-process defaults (see wrangler.toml [[ratelimits]]).
+        rateLimit: true,
+        rateLimiters: {
+          auth: nativeLimiter(env.RL_AUTH, 60),
+          write: nativeLimiter(env.RL_WRITE, 60),
+          publish: nativeLimiter(env.RL_PUBLISH, 60),
+          comment: nativeLimiter(env.RL_COMMENT, 60),
+          // Both ride RL_STRICT (3/60); the prefix keeps their counts separate.
+          unlock: nativeLimiter(env.RL_STRICT, 60, "unlock"),
+          oauthRegister: nativeLimiter(env.RL_STRICT, 60, "oauth-register"),
+        },
         // Deliver freshly enqueued events now: poke the outbox DO so its alarm fires,
         // riding waitUntil so the subrequest isn't cancelled when the response is sent.
         pokeWebhooks: () => {

--- a/apps/api/test/rate-limit.test.ts
+++ b/apps/api/test/rate-limit.test.ts
@@ -1,0 +1,98 @@
+import type { RateLimit } from "@cloudflare/workers-types"
+import { Hono } from "hono"
+import { describe, expect, it, vi } from "vitest"
+import {
+  inMemoryLimiter,
+  inMemoryRateLimiters,
+  ipRateLimit,
+  nativeLimiter,
+} from "../src/lib/rate-limit"
+
+describe("inMemoryLimiter (fixed-window, in-process)", () => {
+  it("counts up, trips at the cap, and isolates distinct keys", async () => {
+    const limit = inMemoryLimiter(60_000, 2)
+    expect((await limit("k")).ok).toBe(true)
+    const second = await limit("k")
+    expect(second.ok).toBe(true) // 2 == max
+    expect(second.retryAfter).toBe(60) // ceil(60000 / 1000)
+    expect((await limit("k")).ok).toBe(false) // 3 > max
+    expect((await limit("other")).ok).toBe(true) // distinct key, fresh window
+  })
+
+  it("rolls over to a fresh window once it elapses", async () => {
+    vi.useFakeTimers()
+    try {
+      const limit = inMemoryLimiter(1_000, 1)
+      expect((await limit("k")).ok).toBe(true)
+      expect((await limit("k")).ok).toBe(false) // still in window
+      vi.advanceTimersByTime(1_001)
+      expect((await limit("k")).ok).toBe(true) // new window, count starts over
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe("ipRateLimit (IP middleware)", () => {
+  const build = (max: number) => {
+    const app = new Hono()
+    app.use("*", ipRateLimit(inMemoryLimiter(60_000, max)))
+    app.get("/", (c) => c.text("ok"))
+    return app
+  }
+
+  it("429s with a Retry-After header once an IP exceeds the cap", async () => {
+    const app = build(2)
+    const ip = { "x-forwarded-for": "203.0.113.9" }
+    expect((await app.request("/", { headers: ip })).status).toBe(200)
+    expect((await app.request("/", { headers: ip })).status).toBe(200)
+    const blocked = await app.request("/", { headers: ip })
+    expect(blocked.status).toBe(429)
+    expect(Number(blocked.headers.get("Retry-After"))).toBeGreaterThan(0)
+  })
+
+  it("scopes the window per IP", async () => {
+    const app = build(1)
+    expect((await app.request("/", { headers: { "x-forwarded-for": "1.1.1.1" } })).status).toBe(200)
+    // a different IP still has its own fresh window
+    expect((await app.request("/", { headers: { "x-forwarded-for": "2.2.2.2" } })).status).toBe(200)
+  })
+})
+
+describe("nativeLimiter (Cloudflare native binding adapter)", () => {
+  it("maps success→ok and reports the period as retryAfter", async () => {
+    let n = 0
+    const binding: RateLimit = {
+      limit: async () => {
+        n++
+        return { success: n <= 2 }
+      },
+    }
+    const limit = nativeLimiter(binding, 60)
+    expect(await limit("a")).toEqual({ ok: true, retryAfter: 60 })
+    expect((await limit("a")).ok).toBe(true)
+    expect((await limit("a")).ok).toBe(false) // 3rd hit over the fake's cap
+  })
+
+  it("namespaces the key by prefix so one binding can back two surfaces", async () => {
+    const seen: string[] = []
+    const binding: RateLimit = {
+      limit: async ({ key }) => {
+        seen.push(key)
+        return { success: true }
+      },
+    }
+    await nativeLimiter(binding, 60, "unlock")("ip:x")
+    await nativeLimiter(binding, 60, "oauth-register")("ip:x")
+    expect(seen).toEqual(["unlock:ip:x", "oauth-register:ip:x"]) // distinct counts on a shared binding
+  })
+})
+
+describe("inMemoryRateLimiters (default set)", () => {
+  it("honors the configured publish rate and gives each surface its own window", async () => {
+    const rl = inMemoryRateLimiters({ publishRate: 1 })
+    expect((await rl.publish("id:1")).ok).toBe(true)
+    expect((await rl.publish("id:1")).ok).toBe(false) // publishRate = 1
+    expect((await rl.comment("id:1")).ok).toBe(true) // different surface, own counter
+  })
+})

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -35,6 +35,48 @@ new_sqlite_classes = ["ArtifactRoom"]
 tag = "v2"
 new_sqlite_classes = ["WebhookOutbox"]
 
+# Native rate limiting (per-colo). One binding per surface; the worker counts each
+# rate-limited request against the matching binding (apps/api/src/worker.ts). The window
+# (period) can only be 10 or 60s, so the long in-process windows (unlock 5 min, oauth
+# registration 1 hr) become tighter per-minute caps here — the abuse-backstop intent
+# holds, just per-colo. namespace_id is an arbitrary unique id per limiter.
+[[ratelimits]]
+name = "RL_AUTH"
+namespace_id = "1001"
+  [ratelimits.simple]
+  limit = 20
+  period = 60
+
+[[ratelimits]]
+name = "RL_WRITE"
+namespace_id = "1002"
+  [ratelimits.simple]
+  limit = 120
+  period = 60
+
+[[ratelimits]]
+name = "RL_PUBLISH"
+namespace_id = "1003"
+  [ratelimits.simple]
+  limit = 30
+  period = 60
+
+[[ratelimits]]
+name = "RL_COMMENT"
+namespace_id = "1004"
+  [ratelimits.simple]
+  limit = 60
+  period = 60
+
+# Shared by the two tight 3/60 surfaces (unlock + oauth registration); the worker
+# namespaces the key per surface so their counts stay separate.
+[[ratelimits]]
+name = "RL_STRICT"
+namespace_id = "1005"
+  [ratelimits.simple]
+  limit = 3
+  period = 60
+
 # Retry/crash backstop for webhook delivery: the outbox DO self-reschedules while busy
 # and is poked on each new event, then goes idle. This wakes it every minute so a retry
 # scheduled during an idle gap (or a missed poke) still drains. The leased claim makes

--- a/knip.json
+++ b/knip.json
@@ -7,6 +7,10 @@
     "apps/web": {
       "entry": ["src/components/ui/**"],
       "ignoreDependencies": ["tslib"]
+    },
+    "packages/db": {
+      "ignore": ["test/env.d.ts"],
+      "ignoreDependencies": ["cloudflare"]
     }
   },
   "rules": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -21,6 +21,7 @@
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage",
     "test:pg": "vitest run --config vitest.pg.config.ts --coverage test/pg-store.test.ts test/pg-schema-conformance.test.ts",
+    "test:d1": "vitest run --config vitest.d1.config.ts test/d1-store.test.ts",
     "gen:d1-schema": "vitest run test/d1-schema.test.ts -u"
   },
   "dependencies": {
@@ -30,6 +31,7 @@
     "pg": "^8.13.1"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.16.15",
     "@cloudflare/workers-types": "^4.20260613.1",
     "@types/better-sqlite3": "^7.6.11",
     "@types/node": "^25.9.3",

--- a/packages/db/test/d1-store.test.ts
+++ b/packages/db/test/d1-store.test.ts
@@ -1,0 +1,22 @@
+import { env } from "cloudflare:test"
+import { createD1Store } from "../src/d1"
+import { SCHEMA_STATEMENTS } from "../src/schema"
+import { runStoreContract } from "./store-contract"
+
+// The cross-dialect MetaStore contract on a REAL Cloudflare D1, run inside workerd
+// via Miniflare (the `pnpm test:d1` lane / the CI `d1` job — see vitest.d1.config.ts).
+// This is the first runtime coverage of src/d1.ts: until now the shared query logic
+// rode the SQLite suite and the DDL rode schema-conformance, but the D1-specific path
+// (drizzle-orm/d1 + the raw analytics SQL) had none, and Dock's edge tier runs on it.
+// A wrong WHERE, a missing org scope, or a D1-only SQL quirk fails the same assertion
+// that passes on SQLite/Postgres.
+//
+// The `cloudflare:test` `env` is typed by env.d.ts (DB: D1Database).
+runStoreContract("d1 store", async () => {
+  // The binding starts empty; apply the same DDL the deploy uses (SCHEMA_STATEMENTS,
+  // the source of deploy/d1-schema.sql). One statement at a time — D1's batch/exec
+  // splits on newlines, which would mangle the multi-line CREATE TABLEs. isolatedStorage
+  // is off (see the config), so this persists for the whole contract.
+  for (const stmt of SCHEMA_STATEMENTS) await env.DB.prepare(stmt).run()
+  return { store: createD1Store(env.DB), cleanup: () => {} }
+})

--- a/packages/db/test/env.d.ts
+++ b/packages/db/test/env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+import type { D1Database } from "@cloudflare/workers-types"
+
+// Types the `cloudflare:test` `env` for the D1 lane (vitest.d1.config.ts binds D1 as
+// DB). `cloudflare:test` exports `env: Cloudflare.Env`, so the binding goes here.
+declare namespace Cloudflare {
+  interface Env {
+    DB: D1Database
+  }
+}

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,16 +1,18 @@
-import { defineConfig } from "vitest/config"
+import { configDefaults, defineConfig } from "vitest/config"
 
 // Coverage gate on the data layer. It scopes to the code this package's own tests
 // exercise: the cross-dialect query layer (repos.ts), the SQLite driver (sqlite.ts),
 // and the DDL (schema.ts / d1-schema.ts, pinned by the schema-conformance test).
 //
-// pg.ts is gated separately in the `pg` lane (vitest.pg.config.ts): the store
-// contract runs against a real Postgres there, which this default (no-Postgres) lane
-// can't. d1.ts stays out — the Cloudflare-D1 driver needs the workerd runtime. Both
-// dialects' DDL is conformance-checked against the drizzle defs. The thresholds sit
-// just under the current numbers as a ratchet.
+// pg.ts and d1.ts are each gated in their own lane against a real engine the default
+// (Node, no-Postgres) lane can't host: pg.ts on a real Postgres (vitest.pg.config.ts /
+// `test:pg`), d1.ts on Miniflare D1 inside workerd (vitest.d1.config.ts / `test:d1`).
+// The d1 lane's test imports `cloudflare:test`, which only resolves under the workers
+// pool, so it's excluded here. Both dialects' DDL is conformance-checked against the
+// drizzle defs. The thresholds sit just under the current numbers as a ratchet.
 export default defineConfig({
   test: {
+    exclude: [...configDefaults.exclude, "test/d1-store.test.ts"],
     coverage: {
       provider: "v8",
       include: ["src/repos.ts", "src/sqlite.ts", "src/schema.ts", "src/d1-schema.ts"],

--- a/packages/db/vitest.d1.config.ts
+++ b/packages/db/vitest.d1.config.ts
@@ -1,0 +1,24 @@
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers"
+import { defineConfig } from "vitest/config"
+
+// The MetaStore contract on a real Cloudflare D1, run inside workerd via Miniflare —
+// the only place src/d1.ts (the D1 driver) is exercised at runtime. The cross-dialect
+// query layer otherwise rides the SQLite suite and the DDL on schema-conformance, but
+// the D1 runtime path (drizzle-orm/d1 + the raw analytics SQL) had no test until this
+// lane. Run with `pnpm test:d1` (and the CI `d1` job).
+//
+//   - nodejs_compat gives the contract its `node:crypto` randomUUID.
+//   - The pool isolates storage per test; the contract applies the DDL in its root
+//     beforeAll, which seeds the base storage and so persists into every test (the
+//     documented Cloudflare D1 pattern). Each `it` is otherwise self-contained.
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      miniflare: {
+        compatibilityDate: "2025-05-01",
+        compatibilityFlags: ["nodejs_compat"],
+        d1Databases: { DB: "dock-test" },
+      },
+    }),
+  ],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,9 @@ importers:
         specifier: ^8.13.1
         version: 8.21.0
     devDependencies:
+      '@cloudflare/vitest-pool-workers':
+        specifier: ^0.16.15
+        version: 0.16.15(@cloudflare/workers-types@4.20260613.1)(@vitest/runner@4.1.8)(@vitest/snapshot@4.1.8)(vitest@4.1.8)
       '@cloudflare/workers-types':
         specifier: ^4.20260613.1
         version: 4.20260613.1
@@ -595,6 +598,13 @@ packages:
     peerDependenciesMeta:
       workerd:
         optional: true
+
+  '@cloudflare/vitest-pool-workers@0.16.15':
+    resolution: {integrity: sha512-R0kZhIm4uSxOeTWPHY9xYIFPGRBEHPzl/n9BbHZSY/gk0n16uDU7T1JZe372oTF+diXG1uVBWqiiRc7Hxstdow==}
+    peerDependencies:
+      '@vitest/runner': ^4.1.0
+      '@vitest/snapshot': ^4.1.0
+      vitest: ^4.1.0
 
   '@cloudflare/workerd-darwin-64@1.20260611.1':
     resolution: {integrity: sha512-iJICldmi4sBGgi7IrQles8cStOGXM/Tmv95C4OODVs6VIbMsJPqThUM5h3uYVQNULuJ8I/aVvnJ3Eh/wZCKwuA==}
@@ -2906,6 +2916,9 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  cjs-module-lexer@1.2.3:
+    resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
+
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
@@ -4780,6 +4793,9 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -5001,6 +5017,21 @@ snapshots:
       unenv: 2.0.0-rc.24
     optionalDependencies:
       workerd: 1.20260611.1
+
+  '@cloudflare/vitest-pool-workers@0.16.15(@cloudflare/workers-types@4.20260613.1)(@vitest/runner@4.1.8)(@vitest/snapshot@4.1.8)(vitest@4.1.8)':
+    dependencies:
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      cjs-module-lexer: 1.2.3
+      esbuild: 0.28.1
+      miniflare: 4.20260611.0
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      wrangler: 4.100.0(@cloudflare/workers-types@4.20260613.1)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - bufferutil
+      - utf-8-validate
 
   '@cloudflare/workerd-darwin-64@1.20260611.1':
     optional: true
@@ -6984,6 +7015,8 @@ snapshots:
 
   chownr@1.1.4: {}
 
+  cjs-module-lexer@1.2.3: {}
+
   cjs-module-lexer@2.2.0: {}
 
   class-variance-authority@0.7.1:
@@ -8800,5 +8833,7 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}


### PR DESCRIPTION
The two remaining MED findings from the app review, as two independent commits.

## 1. Rate limiting behind a pluggable limiter (native per-colo on the edge)
The limiters kept counters in a per-instance in-memory Map. On a single container (Node / self-host) that's authoritative, but on the edge (many isolates) the same Map means the effective cap is `max × isolates`, and the edge never set `rateLimit` so it had no limiting at all.

- A `Limiter` is now just `(key) => Promise<{ ok, retryAfter }>`. `inMemoryLimiter` is the in-process fixed-window counter (the default + test path, each surface at its real window including unlock 5 min / oauth registration 1 hr); `nativeLimiter` adapts a Cloudflare native rate-limit binding (per-colo, fixed window), with an optional key prefix so one binding can back two surfaces.
- The edge enables `rateLimit` and wires native bindings. Native is per-colo (the right tradeoff for an abuse backstop: in-colo, zero maintenance, no Durable Object or migration). Its window is capped at 60s, so unlock + oauth-register run a tighter 3/60s cap on the edge than their long in-process windows.
- `createApp` resolves one limiter set, shared by the IP middleware (`ipRateLimit`) and the keyed limiters. `publishRate`/`commentRate` still tune the in-process set.
- wrangler: 5 `[[ratelimits]]` bindings, no DO, no migration (the two 3/60 surfaces share `RL_STRICT`, namespaced by key).

## 2. Exercise the D1 driver in workerd via the store contract
`src/d1.ts` (the Cloudflare D1 MetaStore) had no runtime coverage: the shared query layer rode the SQLite suite and the DDL rode schema-conformance, but the D1-specific path had none, and the edge tier runs on it.

- New `pnpm test:d1` lane (`@cloudflare/vitest-pool-workers`) runs the same cross-dialect store contract against a real Miniflare-backed D1 in workerd. 21 contract tests.
- Excluded from the default Node lane (its `cloudflare:test` import only resolves under the pool); CI `d1` job mirrors the `pg` job.

## Verification
`pnpm typecheck`, full `pnpm test` (every package), `pnpm --filter @dock/db test:d1` (21), and `pnpm run ci` (biome + knip + guards) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)