### PR TITLE
fix(bug-hunt): takedown tombstone, OIDC discovery, comment cap, /a trailing slash

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -260,6 +260,18 @@ export function createApp(deps: AppDeps): Hono {
     }
   }
   app.get("/.well-known/oauth-authorization-server", (c) => c.json(asMeta(c)))
+  // OIDC discovery for standards-compliant OIDC clients. We issue id tokens (jwt
+  // plugin) + advertise the openid scope + a userinfo endpoint, so RPs that probe
+  // /.well-known/openid-configuration must get JSON here — previously this path fell
+  // through to the SPA shell (HTML 200), breaking discovery. Superset of the OAuth AS
+  // metadata with the two OIDC-required fields.
+  app.get("/.well-known/openid-configuration", (c) =>
+    c.json({
+      ...asMeta(c),
+      subject_types_supported: ["public"],
+      id_token_signing_alg_values_supported: ["EdDSA"],
+    }),
+  )
   app.get("/.well-known/oauth-protected-resource", (c) => {
     const base = new URL(c.req.url).origin
     return c.json({

--- a/apps/api/src/lib/serve-web.ts
+++ b/apps/api/src/lib/serve-web.ts
@@ -26,6 +26,7 @@ const API_EXACT = [
   "/mcp",
   "/.well-known/oauth-authorization-server",
   "/.well-known/oauth-protected-resource",
+  "/.well-known/openid-configuration",
 ] as const
 
 // Page prefixes the SERVER renders before handing off to the SPA, but that are NOT

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -278,6 +278,32 @@ export const artifactRoutes = (ctx: AppContext) => {
       return artifact.visibility === "password"
         ? fail(c, 401, "password required")
         : fail(c, 404, "not found")
+    // Taken down: serve a minimal tombstone, not the full record. A takedown is a
+    // moderation action and the title is often the very thing being removed
+    // (harassment/doxxing), so drop title, author, the slug in the URL, and the
+    // version history — keep only enough for the SPA to render its "removed" state.
+    // (Content already 410s at /raw; the /a unfurl injects no meta for removed.)
+    if (artifact.removed_at)
+      return c.json({
+        short_id: artifact.short_id,
+        url: `${deps.baseUrl.replace(/\/$/, "")}/a/${artifact.short_id}`,
+        title: null,
+        kind: artifact.kind,
+        visibility: artifact.visibility,
+        spa: !!artifact.spa,
+        current_version: artifact.current_version,
+        created_at: artifact.created_at,
+        versions: [],
+        sessions: [],
+        my_role: effectiveRole(actor, artifact.visibility),
+        tags: [],
+        favorite: false,
+        collections: [],
+        open_proposals: 0,
+        proposals_total: 0,
+        removed: true,
+        managed: false,
+      })
     const versions = await meta.listVersions(artifact.id)
     const me = actor.kind === "user" ? actor.userId : null
     const tags = (await meta.tagsForArtifacts([artifact.id]))[artifact.id] ?? []

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -117,7 +117,12 @@ export const commentRoutes = (ctx: AppContext) => {
     const body = await readJson(
       c,
       z
-        .object({ body_md: z.string().refine((s) => s.trim() !== "", "body_md required") })
+        .object({
+          body_md: z
+            .string()
+            .max(10_000, "comment is too long (max 10000 characters)")
+            .refine((s) => s.trim() !== "", "body_md required"),
+        })
         .catchall(z.unknown()),
     )
     if (body instanceof Response) return body
@@ -263,7 +268,12 @@ export const commentRoutes = (ctx: AppContext) => {
     if (acting && !ownsComment(cm, acting)) return fail(c, 403, "forbidden")
     const body = await readJson(
       c,
-      z.object({ body_md: z.string().refine((s) => s.trim() !== "", "body_md required") }),
+      z.object({
+        body_md: z
+          .string()
+          .max(10_000, "comment is too long (max 10000 characters)")
+          .refine((s) => s.trim() !== "", "body_md required"),
+      }),
     )
     if (body instanceof Response) return body
     const md = parseMeta(cm.meta)

--- a/apps/api/src/routes/embeds.ts
+++ b/apps/api/src/routes/embeds.ts
@@ -139,9 +139,14 @@ export const embedRoutes = (ctx: AppContext) => {
       const shell = await getShell()
       if (!shell) return c.notFound()
       const artifact = await readable(c, c.req.param("ref"))
-      if (!artifact) return c.html(shell)
+      // A taken-down artifact serves the bare shell (the SPA shows a tombstone) and
+      // injects NO unfurl meta, so the removed title doesn't live on for crawlers.
+      if (!artifact || artifact.removed_at) return c.html(shell)
       return c.html(injectHead(shell, unfurlMetaTags(await infoFor(artifact))))
     })
+    // A copy-pasted share link with a trailing slash ("/a/slug-id/") would otherwise
+    // 404; canonicalize it to the no-slash form.
+    app.get("/a/:ref/", (c) => c.redirect(`/a/${c.req.param("ref")}`, 301))
 
   return app
 }

--- a/apps/api/test/cleanup.test.ts
+++ b/apps/api/test/cleanup.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import { anonApp, as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+describe("bug-hunt cleanup fixes", () => {
+  const owner: TestUser = { id: "u_cl_owner", email: "owner-cl@dock.test", name: "Owner CL" }
+
+  // B-017: comment body is length-capped.
+  it("B-017: rejects an over-long comment body (max 10000)", async () => {
+    const { app } = makeAuthedApp("cl-comment", [owner])
+    const { short_id } = await (
+      await publishAs(app, "<h1>p</h1>", { visibility: "public" }, as(owner.email))
+    ).json()
+    const tooLong = await app.request(
+      `/v1/artifacts/${short_id}/comments`,
+      jsonAs(as(owner.email), { body_md: "x".repeat(10_001), anchor: null }),
+    )
+    expect(tooLong.status).toBe(400)
+    const ok = await app.request(
+      `/v1/artifacts/${short_id}/comments`,
+      jsonAs(as(owner.email), { body_md: "x".repeat(9_000), anchor: null }),
+    )
+    expect(ok.status).toBe(201)
+  })
+
+  // B-016: a taken-down artifact's detail is a minimal tombstone — no title / author /
+  // version metadata, even to a member.
+  it("B-016: takedown returns a minimal tombstone (no title/versions), content 410s", async () => {
+    const { app } = makeAuthedApp("cl-takedown", [owner])
+    const { short_id } = await (
+      await publishAs(
+        app,
+        "<h1>secret</h1>",
+        { title: "Sensitive Title", visibility: "public" },
+        as(owner.email),
+      )
+    ).json()
+    const td = await app.request(`/v1/artifacts/${short_id}/takedown`, jsonAs(as(owner.email), {}))
+    expect(td.status).toBe(200)
+    const detail = await (
+      await app.request(`/v1/artifacts/${short_id}`, { headers: as(owner.email) })
+    ).json()
+    expect(detail.removed).toBe(true)
+    expect(detail.title).toBeNull() // the (often-abusive) title is not retained
+    expect(detail.versions).toEqual([]) // no author / sha256 / message metadata
+    expect(detail.url).not.toContain("sensitive-title") // no title in the slug
+    const content = await app.request(`/v1/artifacts/${short_id}/content`)
+    expect(content.status).toBe(410) // tombstone
+  })
+
+  // B-006: OIDC discovery returns JSON metadata (previously fell through to the SPA shell).
+  it("B-006: /.well-known/openid-configuration serves OIDC metadata", async () => {
+    const res = await anonApp.request("/.well-known/openid-configuration")
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toContain("application/json")
+    const meta = await res.json()
+    expect(meta.issuer).toBeTruthy()
+    expect(meta.jwks_uri).toBeTruthy()
+    expect(meta.subject_types_supported).toContain("public")
+    expect(meta.id_token_signing_alg_values_supported).toContain("EdDSA")
+  })
+})

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -55,7 +55,7 @@ crons = ["* * * * *"]
 [assets]
 directory = "../web/dist/client"
 binding = "ASSETS"
-run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/oauth/*", "/a/*", "/healthz", "/mcp", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource"]
+run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/oauth/*", "/a/*", "/healthz", "/mcp", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource", "/.well-known/openid-configuration"]
 not_found_handling = "single-page-application"
 
 # baseUrl falls back to the request origin when unset. Secured by Better Auth; set

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
         "/mcp",
         "/.well-known/oauth-authorization-server",
         "/.well-known/oauth-protected-resource",
+        "/.well-known/openid-configuration",
       ].map((p) => [p, { target: API, changeOrigin: true }]),
     ),
   },


### PR DESCRIPTION
## What

Follow-up to #171 with the remaining bug-hunt read-path / consistency findings.

| ID | Sev | Fix |
|----|-----|-----|
| **B-016** | S3 | A taken-down artifact's detail is now a **minimal tombstone** — drops `title`, `author`, the slug in the `url`, and the version history. A takedown is a moderation action and the title is often the abuse (harassment/doxxing), so it shouldn't keep being served. The `/a/:ref` unfurl injects **no meta** for a removed artifact either, so the title doesn't live on for crawlers/link-previews. Content already 410s at `/raw`; the SPA still renders its generic "removed" tombstone. |
| **B-006** | S3 | Serve `/.well-known/openid-configuration` as JSON (issuer, jwks_uri, `subject_types_supported`, `id_token_signing_alg_values_supported: ["EdDSA"]` — verified against the live JWKS). It previously fell through to the SPA shell (HTML 200), breaking OIDC RP discovery. Added to the worker-first path set in **all three** declarations (serve-web contract + `wrangler.toml` + the Vite dev proxy — the contract test enforces they agree). |
| **B-017** | S4 | Cap comment `body_md` at 10000 chars on **create + update** (it was the lone uncapped free-text field). |
| **B-009** | S4 | `/a/<slug>/` (trailing slash) now **301-redirects** to the canonical no-slash form instead of 404ing. |

## Deferred (intentionally)

- **B-007** (anon 401-vs-403) — cosmetic S4; the clean fix needs a principal-detection helper across ~8 workspace-gated handlers. Low value for the churn.
- **B-008** (rate-limiter → durable store) — architectural S2; you have a `feat/rate-limit-shared-store` branch for it.

## Verification

- api: typecheck + **330 tests** + coverage (83.8% lines, above the gate) — incl. new `test/cleanup.test.ts` for the tombstone, OIDC metadata, and comment cap.
- web: typecheck · biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
