### PR TITLE
fix(auth): verify OAuth JWTs against a local JWKS (DB read), not a Worker self-fetch

### DIFF
--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -16,7 +16,7 @@ import {
 } from "@dock/core"
 import type { Context } from "hono"
 import { getCookie, setCookie } from "hono/cookie"
-import { createRemoteJWKSet, type JWTPayload, jwtVerify } from "jose"
+import { createLocalJWKSet, type JWTPayload, jwtVerify } from "jose"
 import type { Auth } from "./auth-config"
 import { type Backplane, createInProcessBackplane } from "./bus"
 import type { CustomDomainProvider } from "./lib/cloudflare-saas"
@@ -313,10 +313,18 @@ export function buildContext(deps: AppDeps) {
     return mine[0]?.id ?? (await provisionPersonal({ id: userId, email: email ?? "", name }))
   }
 
-  // Our own JWKS (served by the jwt plugin at /api/auth/jwks), fetched + cached by
-  // jose on first verify. Used to verify the JWT access tokens below.
-  const jwks = createRemoteJWKSet(new URL("/api/auth/jwks", deps.baseUrl))
+  // Our own JWKS (served by the jwt plugin at /api/auth/jwks), read straight from
+  // Better Auth's store on this instance — NOT an HTTP self-fetch, which a
+  // Cloudflare Worker can't do against its own hostname. The local key set is
+  // cached per isolate, rebuilt on a verify miss (a rotated signing key).
   const oauthIssuer = new URL("/api/auth", deps.baseUrl).toString()
+  let jwksCache: ReturnType<typeof createLocalJWKSet> | null = null
+  const loadJwks = async () => {
+    const res = (await deps.auth?.api.getJwks()) as
+      | Parameters<typeof createLocalJWKSet>[0]
+      | undefined
+    return res?.keys?.length ? createLocalJWKSet(res) : null
+  }
 
   // An OAuth access token (granted via the consent screen) acts as a scoped agent:
   // it runs in the granting user's workspace, authors as the client's name, and
@@ -347,12 +355,25 @@ export function buildContext(deps: AppDeps) {
   }
 
   const oauthAgentFromJwt = async (token: string): Promise<AgentRecord | null> => {
-    let claims: JWTPayload
-    try {
-      ;({ payload: claims } = await jwtVerify(token, jwks, { issuer: oauthIssuer }))
-    } catch {
-      return null // bad signature, wrong issuer, or expired (jose checks exp)
+    const verify = async (): Promise<JWTPayload | null> => {
+      jwksCache ??= await loadJwks()
+      if (!jwksCache) return null
+      return (await jwtVerify(token, jwksCache, { issuer: oauthIssuer })).payload
     }
+    let claims: JWTPayload | null
+    try {
+      claims = await verify()
+    } catch {
+      // Bad signature/issuer/expiry — or a rotated key the cache misses. Rebuild
+      // the key set once and retry before giving up.
+      jwksCache = null
+      try {
+        claims = await verify()
+      } catch {
+        return null
+      }
+    }
+    if (!claims) return null
     const userId = typeof claims.sub === "string" ? claims.sub : ""
     if (!userId) return null
     const scopes = String(claims.scope ?? "")

--- a/apps/api/src/routes/embeds.ts
+++ b/apps/api/src/routes/embeds.ts
@@ -144,9 +144,9 @@ export const embedRoutes = (ctx: AppContext) => {
       if (!artifact || artifact.removed_at) return c.html(shell)
       return c.html(injectHead(shell, unfurlMetaTags(await infoFor(artifact))))
     })
-    // A copy-pasted share link with a trailing slash ("/a/slug-id/") would otherwise
-    // 404; canonicalize it to the no-slash form.
-    app.get("/a/:ref/", (c) => c.redirect(`/a/${c.req.param("ref")}`, 301))
+  // A copy-pasted share link with a trailing slash ("/a/slug-id/") would otherwise
+  // 404; canonicalize it to the no-slash form.
+  app.get("/a/:ref/", (c) => c.redirect(`/a/${c.req.param("ref")}`, 301))
 
   return app
 }

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -5,6 +5,7 @@ import { SqliteMetaStore } from "@dock/db/sqlite"
 import { FsBlobStore } from "@dock/storage/fs"
 import Database from "better-sqlite3"
 import { zipSync } from "fflate"
+import { exportJWK, generateKeyPair, SignJWT } from "jose"
 import { afterAll, describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
 import { sha256 } from "../src/lib/crypto"
@@ -368,5 +369,73 @@ describe("remote MCP endpoint (/mcp)", () => {
     // catch_me_up flags it so the agent won't re-propose the same fix.
     const cu = JSON.parse(toolText(await call(app, token, "catch_me_up", { short_id: shortId })))
     expect(cu.summary).toContain("addressed")
+  })
+
+  // Regression guard for the "Needs Auth" outage: a remote MCP client (Claude
+  // Code / claude.ai), because it sends an RFC 8707 `resource` indicator, gets a
+  // SIGNED JWT access token rather than the opaque token. The server must verify
+  // it against the JWKS read from Better Auth's store on this instance — NOT by
+  // HTTP-fetching its own /api/auth/jwks, which a Cloudflare Worker can't do.
+  // This mints a real JWT, exposes the public key via a getJwks() stub, and
+  // asserts /mcp accepts it. It FAILS against a createRemoteJWKSet (self-fetch)
+  // implementation, so it pins the verification path in place.
+  it("authenticates an OAuth JWT access token via the local JWKS", async () => {
+    const { publicKey, privateKey } = await generateKeyPair("EdDSA", { extractable: true })
+    const kid = "test-jwt-kid"
+    const jwk = { ...(await exportJWK(publicKey)), kid, alg: "EdDSA", use: "sig" }
+
+    // Seed the granting user + client the JWT claims will resolve to, then build
+    // an app whose auth exposes the matching public JWKS (no network).
+    const path = join(dir, "jwtauth.db")
+    const meta = new SqliteMetaStore(path)
+    const seed = new Database(path)
+    seed.exec(`
+      CREATE TABLE IF NOT EXISTS "user" (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT);
+      CREATE TABLE IF NOT EXISTS "oauthClient" (clientId TEXT PRIMARY KEY, name TEXT);
+    `)
+    seed
+      .prepare(`INSERT OR IGNORE INTO "user"(id,email,name) VALUES('u_jwt','j@x.test','Jay')`)
+      .run()
+    seed.prepare(`INSERT OR IGNORE INTO "oauthClient"(clientId,name) VALUES('cli','Claude')`).run()
+    seed.close()
+
+    const app = createApp({
+      meta,
+      blobs: new FsBlobStore(join(dir, "jwtauth-blobs")),
+      baseUrl: "http://dock.test",
+      token: "tok",
+      auth: {
+        handler: async () => new Response(null, { status: 404 }),
+        api: { getJwks: async () => ({ keys: [jwk] }) },
+      } as unknown as Parameters<typeof createApp>[0]["auth"],
+    })
+
+    const mint = (over: Record<string, unknown> = {}) =>
+      new SignJWT({ scope: "openid dock:read dock:publish", azp: "cli", ...over })
+        .setProtectedHeader({ alg: "EdDSA", kid })
+        .setSubject("u_jwt")
+        .setIssuer("http://dock.test/api/auth")
+        .setExpirationTime("1h")
+        .sign(privateKey)
+
+    // A valid JWT authenticates and resolves the agent's role from its scopes.
+    const ok = await rpc(app, await mint(), initBody)
+    expect(ok.status).toBe(200)
+    expect((ok.parsed?.result as { instructions?: string }).instructions).toContain("editor")
+
+    // A tampered signature is rejected (401), not silently trusted.
+    const good = await mint()
+    const tampered = `${good.slice(0, -6)}AAAAAA`
+    const bad = await rpc(app, tampered, initBody)
+    expect(bad.status).toBe(401)
+
+    // Wrong issuer is rejected too (the verify pins `issuer`).
+    const wrongIss = await new SignJWT({ scope: "openid dock:read", azp: "cli" })
+      .setProtectedHeader({ alg: "EdDSA", kid })
+      .setSubject("u_jwt")
+      .setIssuer("http://evil.test/api/auth")
+      .setExpirationTime("1h")
+      .sign(privateKey)
+    expect((await rpc(app, wrongIss, initBody)).status).toBe(401)
   })
 })


### PR DESCRIPTION
**Fixes the live "Needs Auth" regression on remote MCP.**

Remote MCP clients (Claude Code, claude.ai) send an RFC 8707 `resource` indicator, so the oauth-provider issues a **signed JWT** access token (not the opaque token in our table). `main` verified it with `createRemoteJWKSet`, which HTTP-fetches `/api/auth/jwks` — but **a Cloudflare Worker can't fetch its own hostname**, so the fetch fails, every JWT 401s, and the client shows "Needs Auth" even though the consent dance succeeded.

The fix reads the JWKS straight from Better Auth's store on this instance (`auth.api.getJwks()` + jose `createLocalJWKSet`), cached per isolate and rebuilt on a verify miss (handles key rotation). The opaque-token path (`dock login`) is untouched.

### Why it regressed
This verification originally shipped by deploying from `feat/mcp-remote`. The `createLocalJWKSet` fix never landed on `main` — `main` kept the `createRemoteJWKSet` first attempt — so deploying #167/#169 from main overwrote the working worker with the broken version. This PR ports the known-good code onto main so it can't regress again.

### Verification
- 322 api tests pass; typecheck clean.
- Live OAuth metadata + `/mcp` 401-challenge confirmed healthy (the dance is fine; only token verification was broken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)