### PR TITLE
feat(oauth): branded "Connected" confirmation on the consent screen

### DIFF
--- a/apps/api/src/oauth-consent.ts
+++ b/apps/api/src/oauth-consent.ts
@@ -51,6 +51,15 @@ export function consentHTML(props: {
       }</span><span>${esc(SCOPE_LABELS[s] ?? s)}</span></li>`
     })
     .join("")
+  // The card swapped in after Approve — a branded confirmation on the page we own,
+  // shown for a beat before the browser carries the auth code back to the client.
+  const connectedInner = `<div class="brand">${MARK}<span class="name">Dock</span><span class="badge ok">Connected</span></div>
+    <div class="done">
+      <div class="check" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg></div>
+      <h1>You're connected</h1>
+      <p class="sub"><b>${name}</b> can now act in your workspace. Taking you back…</p>
+      <a class="back" id="back" href="#">Return to ${name} now</a>
+    </div>`
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -64,7 +73,7 @@ export function consentHTML(props: {
   :root{
     --paper:#f6f0e3;--panel:#fdf8ec;--panel-2:#f6efe0;--ink:#2a2540;--ink-soft:#46415c;
     --muted:#6b6680;--line:#e4dcc9;--line-2:#eee7d6;--accent:#655999;--accent-ink:#4f447e;
-    --accent-2:#8a7dc0;--accent-soft:#e8e4f1;--good:#6f7a35;--bad:#a04425;
+    --accent-2:#8a7dc0;--accent-soft:#e8e4f1;--good:#6f7a35;--good-soft:#ebedda;--bad:#a04425;
     --display:"Space Grotesk",ui-sans-serif,system-ui,sans-serif;
     --sans:"Inter",system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
     --mono:ui-monospace,"SF Mono",Menlo,Consolas,monospace;
@@ -99,6 +108,22 @@ export function consentHTML(props: {
   .btn[disabled]{opacity:.55;cursor:default}
   .foot{color:var(--muted);font-size:12px;text-align:center;margin:16px 0 0}
   .err{color:var(--bad);font-size:12.5px;text-align:center;margin:12px 0 0;min-height:0}
+  .badge.ok{background:var(--good-soft);color:var(--good)}
+  /* The post-approve confirmation: a branded "you're connected" beat on the page
+     we control, before the browser hands the code back to the client. */
+  .done{text-align:center;padding:10px 4px 2px}
+  .check{width:58px;height:58px;margin:6px auto 20px;border-radius:50%;background:var(--good);
+    display:grid;place-items:center;box-shadow:0 10px 26px -10px rgba(111,122,53,.7);
+    animation:pop .36s cubic-bezier(.2,.9,.3,1.4) both}
+  .check svg{width:30px;height:30px;fill:none;stroke:#fff;stroke-width:3;stroke-linecap:round;
+    stroke-linejoin:round;stroke-dasharray:26;stroke-dashoffset:26;animation:draw .4s .14s ease forwards}
+  @keyframes pop{from{transform:scale(.4);opacity:0}to{transform:scale(1);opacity:1}}
+  @keyframes draw{to{stroke-dashoffset:0}}
+  .done h1{margin:0 0 7px}
+  .done .sub{margin:0}
+  .back{display:inline-block;margin-top:20px;color:var(--accent-ink);font-size:13px;
+    text-decoration:none;border-bottom:1px solid var(--line);padding-bottom:1px}
+  .back:hover{color:var(--accent);border-color:var(--accent-2)}
   ::selection{background:var(--accent-soft);color:var(--accent-ink)}
 </style>
 </head>
@@ -117,7 +142,17 @@ export function consentHTML(props: {
   </main>
   <script>
     var query = ${JSON.stringify(props.query)};
+    var CONNECTED = ${JSON.stringify(connectedInner)};
     var allow = document.getElementById("allow"), deny = document.getElementById("deny"), err = document.getElementById("err");
+    // Show our branded "Connected" card, then hand the code back to the client.
+    // The auth code is short-lived but a ~1.1s beat is well within its window.
+    function goConnected(to){
+      var card = document.querySelector("main.card");
+      if (card) card.innerHTML = CONNECTED;
+      var back = document.getElementById("back");
+      if (back) back.setAttribute("href", to);
+      setTimeout(function(){ window.location.href = to; }, 1100);
+    }
     async function decide(accept){
       allow.disabled = deny.disabled = true; err.textContent = "";
       try{
@@ -129,10 +164,13 @@ export function consentHTML(props: {
         // The plugin replies JSON { redirect: true, url: "<redirect_uri>?code=..." }
         // (note: "redirect" is a boolean flag, the destination is "url").
         var loc = r.headers.get("location");
-        if (loc){ window.location.href = loc; return; }
-        var data = await r.json().catch(function(){ return {}; });
-        var to = data && (data.url || data.redirectURI || data.location);
-        if (to){ window.location.href = to; return; }
+        var to = loc;
+        if (!to){
+          var data = await r.json().catch(function(){ return {}; });
+          to = data && (data.url || data.redirectURI || data.location);
+        }
+        // On approve, linger on our confirmation; on deny, bounce straight back.
+        if (to){ if (accept) goConnected(to); else window.location.href = to; return; }
         err.textContent = (data && (data.error_description || data.error)) || "Something went wrong.";
       }catch(e){ err.textContent = "Network error. Try again."; }
       allow.disabled = deny.disabled = false;

--- a/apps/api/test/oauth-consent.test.ts
+++ b/apps/api/test/oauth-consent.test.ts
@@ -1,0 +1,56 @@
+import { writeFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+import { consentHTML } from "../src/oauth-consent"
+
+describe("oauth consent screen", () => {
+  const html = consentHTML({
+    clientName: "Claude Code",
+    scopes: ["openid", "dock:read", "dock:propose", "dock:publish"],
+    query: "client_id=cli&scope=openid+dock:read&code=abc",
+  })
+
+  it("renders the authorize card with the client name and scope labels", () => {
+    expect(html).toContain("wants to act in your workspace")
+    expect(html).toContain("Claude Code")
+    expect(html).toContain("Read your artifacts and comments")
+    expect(html).toContain("Propose new versions")
+  })
+
+  it("ships the branded post-approve confirmation card + the goConnected handoff", () => {
+    expect(html).toContain("var CONNECTED =")
+    expect(html).toContain("function goConnected(")
+    // On approve we linger on our card; deny bounces straight back.
+    expect(html).toContain("if (accept) goConnected(to)")
+    // The success card is embedded JSON-encoded; decode it and assert its markup.
+    const connected = JSON.parse(
+      (html.match(/var CONNECTED = (".*?");/s)?.[1] as string) ?? '""',
+    ) as string
+    expect(connected).toContain("You're connected")
+    expect(connected).toContain('class="badge ok">Connected')
+    expect(connected).toContain('class="done"')
+    expect(connected).toContain("Claude Code") // the client name, escaped, in the card
+  })
+
+  it("escapes a hostile client name in both the authorize and connected cards", () => {
+    const evil = consentHTML({ clientName: "<script>x</script>", scopes: ["openid"], query: "" })
+    expect(evil).not.toContain("<script>x</script>")
+    expect(evil).toContain("&lt;script&gt;")
+  })
+
+  // Emit preview HTML for visual review (both states), when a target dir is given.
+  it("writes preview files", () => {
+    const dir = process.env.CONSENT_PREVIEW_DIR
+    if (!dir) return
+    writeFileSync(`${dir}/consent.html`, html)
+    // Swap the card to the connected state the way the script does at runtime.
+    const connected = JSON.parse(
+      (html.match(/var CONNECTED = (".*?");/s)?.[1] as string) ?? '""',
+    ) as string
+    const shown = html.replace(
+      /<main class="card">[\s\S]*?<\/main>/,
+      `<main class="card">${connected}</main>`,
+    )
+    writeFileSync(`${dir}/consent-connected.html`, shown)
+    expect(connected).toContain("You're connected")
+  })
+})


### PR DESCRIPTION
The final "Authentication Successful" tab a remote MCP client shows lives on the **client's** redirect origin (Claude Code's loopback / Anthropic) — not ours, so it's unstyleable; that's the same page for every MCP server. But the **consent screen is the last page we render**, and it used to jump straight to that page the instant you click Approve.

Now Approve swaps in a branded **"You're connected"** card — the anchor mark, a drawn check, the client name, a "Connected" badge — for ~1.1s before the browser carries the auth code back to the client. A real Dock moment on the page we own. Deny still bounces straight back; the auth code's lifetime easily covers the beat.

Unit test covers the card markup + the `goConnected` handoff + escaping.

| Authorize | Connected |
|---|---|
| _(branded consent, unchanged)_ | _(new: green check, "You're connected", "Taking you back…")_ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)