### PR TITLE
fix: harden over-broad reads, identity off-the-wire + input validation (B-018/019/020/021)

### DIFF
--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -404,7 +404,10 @@ export function buildContext(deps: AppDeps) {
     const ag = await agentFor(c)
     if (ag) return { id: ag.id, name: ag.name }
     const me = await currentUser(c)
-    return me ? { id: me.id, name: me.name ?? me.email } : null
+    // Display identity feeds the comment/version author byline shown to others, so
+    // fall back to the public handle, never the email (the email→handle migration).
+    // Every account has a username post-migration; email is only a last-ditch guard.
+    return me ? { id: me.id, name: me.name ?? me.username ?? me.email } : null
   }
 
   const ipOf = (c: Context): string =>

--- a/apps/api/src/lib/comments.ts
+++ b/apps/api/src/lib/comments.ts
@@ -6,6 +6,12 @@ export const REACTIONS = ["👍", "❤️", "🎉", "😄", "👀", "🙏", "�
 /** A resolved @mention captured by the composer: the picked user's id + display name. */
 export type Mention = { id: string; name: string }
 
+/** Upper bound on distinct @mentions per comment. A real comment mentions a
+ *  handful of collaborators; the cap stops one comment from fanning out to a huge
+ *  list (notifications are gated to members/shares, but this bounds the work +
+ *  the blast radius regardless). */
+export const MAX_MENTIONS = 50
+
 export type CommentMeta = {
   reactions?: Record<string, string[]>
   edited_at?: string
@@ -38,6 +44,7 @@ export function parseMentions(input: unknown): Mention[] {
     if (typeof id !== "string" || typeof name !== "string" || !id || seen.has(id)) continue
     seen.add(id)
     out.push({ id, name })
+    if (out.length >= MAX_MENTIONS) break
   }
   return out
 }

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -7,7 +7,7 @@ import { fail, readJson, VIEW_DEDUP_MS } from "../lib/http"
 
 /** View recording (de-duped, owner self-views excluded) + per-artifact stats. */
 export const analyticsRoutes = (ctx: AppContext) => {
-  const { meta, deps, analyticsOn, currentUser, actorFor, anonLocked, authorize } = ctx
+  const { meta, deps, analyticsOn, currentUser, actorFor, authorize } = ctx
   const app = new Hono()
 
   // Record a view. The viewer is the logged-in user, or a stable anonymous id
@@ -70,17 +70,26 @@ export const analyticsRoutes = (ctx: AppContext) => {
     if (!analyticsOn) return fail(c, 404, "analytics disabled")
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact || !(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
-    // View analytics are for collaborators, not anonymous link-visitors.
-    if (await anonLocked(c, artifact)) return fail(c, 404, "not found")
+    // Who-viewed-this is for COLLABORATORS, not every signed-in reader. `read`
+    // access is satisfied by any signed-in user on a public/link artifact, so the
+    // not-anon check alone would expose the view counts + viewer identities to a
+    // cross-workspace stranger. Require a workspace member / sharee (or token),
+    // exactly like the member-roster gate. See bug-hunt B-020 (and B-013).
+    const actor = await actorFor(c, artifact)
+    const collaborator =
+      actor.kind === "token" ||
+      (actor.kind === "user" && (actor.orgRole != null || actor.artifactRole != null))
+    if (!collaborator) return fail(c, 404, "not found")
     const stats = await meta.viewStats(artifact.id)
-    // Recent user-viewers are stored by id (stable); resolve to name + avatar.
+    // Recent user-viewers are stored by id (stable); resolve to a public handle
+    // (or display name) + avatar — never the email (off the wire, like the rosters).
     const userIds = stats.recent.filter((r) => r.kind === "user").map((r) => r.viewer)
     if (userIds.length) {
       const byId = new Map((await meta.getUsers(userIds)).map((u) => [u.id, u]))
       stats.recent = stats.recent.map((r) => {
         if (r.kind !== "user") return r
         const u = byId.get(r.viewer)
-        return { ...r, viewer: u ? (u.name ?? u.email) : "Someone", avatar: u?.image ?? null }
+        return { ...r, viewer: u?.name ?? u?.username ?? "Someone", avatar: u?.image ?? null }
       })
     }
     return c.json(stats)

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -412,7 +412,7 @@ export const artifactRoutes = (ctx: AppContext) => {
       // Same blob as the restored version — carry its size so the storage meter
       // stays consistent (and dedup'd, since it reuses the same blob_key).
       size_bytes: src.size_bytes,
-      author: me ? (me.name ?? me.email) : "anonymous",
+      author: me ? (me.name ?? me.username ?? me.email) : "anonymous",
       message: `Restored v${src.n}`,
       name: null,
     })

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -193,6 +193,12 @@ export const artifactRoutes = (ctx: AppContext) => {
     // republish keeps whatever the artifact already has (publish() never re-creates
     // the artifact, only adds a version, so visibility/password are set-on-create).
     const visibility = visibilityOf(body["visibility"])
+    // An explicitly-provided visibility that isn't a known value is rejected, not
+    // silently coerced. publish() defaults an *absent* visibility to `link`, so a
+    // natural-but-wrong value like "private" would otherwise become URL-readable —
+    // more open than intended, with no error. The enum is closed; surface the typo.
+    if (str(body["visibility"]) && !visibility)
+      return fail(c, 400, "visibility must be one of: public, link, org, password")
     const password = str(body["password"])
     if (!shortId && visibility === "password" && !password)
       return fail(c, 400, "a password is required for password visibility")

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -45,11 +45,22 @@ export const commentRoutes = (ctx: AppContext) => {
     // Registered agents are mentionable too; a mention of an agent lands in its
     // pull inbox instead of a notification bell.
     const agentIds = new Set((await meta.listAgents(a.org_id)).map((ag) => ag.id))
+    // A mention only notifies someone who can actually SEE the artifact: a member
+    // of its workspace or an explicit share recipient (the collaborator set, like
+    // the B-012/B-013 roster gate). The `mentions[]` array is client-supplied, so
+    // without this any user could push a notification carrying attacker-controlled
+    // title/preview to ANY other user — cross-workspace spam/phishing into the bell
+    // + SSE. "Could view a public artifact" is intentionally NOT enough; a real
+    // collaboration mention means a member/share, not a stranger.
+    const collaborators = new Set<string>([
+      ...(await meta.listMemberships(a.org_id)).map((m) => m.user_id),
+      ...(await meta.listArtifactMembers(a.id)).map((r) => r.user_id),
+    ])
     const preview = previewOf(cm.body_md)
     const notified: string[] = []
     for (const m of mentions) {
       if (m.id === actorId) continue
-      if (real.has(m.id)) {
+      if (real.has(m.id) && collaborators.has(m.id)) {
         const row = {
           id: newId("n"),
           user_id: m.id,

--- a/apps/api/src/routes/proposals.ts
+++ b/apps/api/src/routes/proposals.ts
@@ -178,7 +178,7 @@ export const proposalRoutes = (ctx: AppContext) => {
     if (!(await authorize(c, "approve", artifact))) return fail(c, 403, "forbidden")
     if (proposal.state !== "open") return fail(c, 409, `proposal is ${proposal.state}`)
     const me = await currentUser(c)
-    const approver = me ? (me.name ?? me.email) : null
+    const approver = me ? (me.name ?? me.username ?? me.email) : null
     const body = await readJson(c, z.object({ note: z.unknown().optional() }))
     if (body instanceof Response) return body
     try {
@@ -229,7 +229,7 @@ export const proposalRoutes = (ctx: AppContext) => {
     if (!(await authorize(c, "approve", artifact))) return fail(c, 403, "forbidden")
     if (proposal.state !== "open") return fail(c, 409, `proposal is ${proposal.state}`)
     const me = await currentUser(c)
-    const reviewer = me ? (me.name ?? me.email) : null
+    const reviewer = me ? (me.name ?? me.username ?? me.email) : null
     const body = await readJson(c, z.object({ note: z.unknown().optional() }))
     if (body instanceof Response) return body
     await meta.decideProposal(proposal.id, {

--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -58,9 +58,9 @@ export const realtimeRoutes = (ctx: AppContext) => {
     const role = effectiveRole(await actorFor(c, artifact), artifact.visibility)
     const viewer: Viewer = me
       ? // Handle-based identity, never PII: presence reaches anonymous co-viewers and
-        // rides the wildcard-CORS /events SSE. Prefer the public @handle; fall back to
-        // the email's local-part (not the full address) for an unclaimed handle.
-        { id: me.id, name: me.username ?? me.email.split("@")[0] ?? "someone", role }
+        // rides the wildcard-CORS /events SSE. Always the public @handle (every account
+        // has one post-migration); never any part of the email, even the local-part.
+        { id: me.id, name: me.username ?? "someone", role }
       : { id: anonViewerId(c), name: anonName(anonViewerId(c)), role }
     const viewers = await presence.heartbeat(artifact.id, viewer, Date.now())
     bus.publish(artifact.id, { type: "presence", viewers })

--- a/apps/api/test/harden.test.ts
+++ b/apps/api/test/harden.test.ts
@@ -168,3 +168,54 @@ describe("B-018: publish rejects an unknown visibility", () => {
     expect(def.visibility).toBe("link")
   })
 })
+
+// B-020: view-analytics (who-viewed + counts) is for collaborators, not every
+// signed-in reader. A public artifact's `read` access is satisfied by any
+// signed-in user, so the endpoint must additionally require a member/sharee — and
+// resolve viewers to a handle, never email. See bug-hunt B-020 (and B-013).
+describe("B-020: view-analytics is collaborator-gated + never leaks email", () => {
+  const owner: TestUser = { id: "u_b20_owner", email: "o20@dock.test", name: "Owner20" }
+  // name:null forces the viewer-display fallback — it must land on the handle, not email.
+  const viewer: TestUser = {
+    id: "u_b20_viewer",
+    email: "v20@dock.test",
+    name: null,
+    username: "viewer20",
+  }
+  const outsider: TestUser = { id: "u_b20_out", email: "x20@dock.test", name: "Out20" }
+
+  it("refuses a non-member; serves a member; viewers resolve to handle, never email", async () => {
+    const { app, meta: m } = makeAuthedApp("harden-b20", [owner, viewer, outsider], undefined, {
+      isolated: true,
+    })
+    const { short_id } = await (
+      await publishAs(app, "<h1>p</h1>", { visibility: "public" }, as(owner.email))
+    ).json()
+    const art = await m.getByShortId(short_id)
+    if (!art) throw new Error("artifact not found")
+    // viewer joins the workspace and records a view (non-owner → counts).
+    await m.setMembership({
+      id: "m_b20",
+      org_id: art.org_id,
+      user_id: viewer.id,
+      role: "commenter",
+    })
+    await app.request(`/v1/artifacts/${short_id}/view`, jsonAs(as(viewer.email), {}))
+
+    // A signed-in NON-member stranger is refused, even though the artifact is public.
+    const stranger = await app.request(`/v1/artifacts/${short_id}/analytics`, {
+      headers: as(outsider.email),
+    })
+    expect(stranger.status).toBe(404)
+
+    // The owner (a collaborator) sees the stats; the recent viewer shows by HANDLE
+    // (name is null) and the email never appears anywhere in the payload.
+    const ownerRes = await app.request(`/v1/artifacts/${short_id}/analytics`, {
+      headers: as(owner.email),
+    })
+    expect(ownerRes.status).toBe(200)
+    const stats = await ownerRes.json()
+    expect(stats.recent.map((r: { viewer: string }) => r.viewer)).toContain("viewer20")
+    expect(JSON.stringify(stats)).not.toContain("v20@dock.test")
+  })
+})

--- a/apps/api/test/harden.test.ts
+++ b/apps/api/test/harden.test.ts
@@ -219,3 +219,36 @@ describe("B-020: view-analytics is collaborator-gated + never leaks email", () =
     expect(JSON.stringify(stats)).not.toContain("v20@dock.test")
   })
 })
+
+// B-021: author/actor attribution shown to others (publish + version author byline,
+// comment author, proposal approver/reviewer) must fall back to the public handle
+// when a user has no display name — never the email. The email→handle migration
+// fixed the rosters but missed these byline paths. See bug-hunt B-021.
+describe("B-021: author/actor attribution falls back to handle, never email", () => {
+  // name:null forces the fallback — it must land on the username, not the email.
+  const ghost: TestUser = {
+    id: "u_b21",
+    email: "ghost21@dock.test",
+    name: null,
+    username: "ghost21",
+  }
+
+  it("a name-less user's publish + comment author show the handle, not the email", async () => {
+    const { app } = makeAuthedApp("harden-b21", [ghost])
+    const pub = await (
+      await publishAs(app, "<h1>p</h1>", { title: "B21", visibility: "public" }, as(ghost.email))
+    ).json()
+    // The version author byline (shown publicly) is the handle, and the email is absent.
+    expect(pub.versions[0].author).toBe("ghost21")
+    expect(JSON.stringify(pub)).not.toContain("ghost21@dock.test")
+
+    const cm = await (
+      await app.request(
+        `/v1/artifacts/${pub.short_id}/comments`,
+        jsonAs(as(ghost.email), { body_md: "hi" }),
+      )
+    ).json()
+    expect(cm.author).toBe("ghost21")
+    expect(JSON.stringify(cm)).not.toContain("ghost21@dock.test")
+  })
+})

--- a/apps/api/test/harden.test.ts
+++ b/apps/api/test/harden.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
-import { as, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+import { MAX_MENTIONS, parseMentions } from "../src/lib/comments"
+import { as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 
 // Coverage for the read-path hardening: a non-member / anonymous caller gets only
 // content they're entitled to (public artifacts) — never an org/link title, a member
@@ -81,5 +82,89 @@ describe("read-path exposure hardening", () => {
     const body = await res.json()
     expect(body).not.toHaveProperty("email")
     expect(body.role).toBe("viewer")
+  })
+})
+
+// B-019: @mentions are client-supplied; a mention must only notify someone who can
+// actually SEE the artifact (a workspace member or an explicit sharee). Otherwise any
+// user could push an attacker-controlled title/preview into ANY user's bell + SSE —
+// cross-workspace spam/phishing. See bug-hunt B-019.
+describe("B-019: @mention notifies only collaborators", () => {
+  const owner: TestUser = { id: "u_b19_owner", email: "o19@dock.test", name: "Owner19" }
+  const member: TestUser = { id: "u_b19_member", email: "m19@dock.test", name: "Member19" }
+  const sharee: TestUser = { id: "u_b19_sharee", email: "s19@dock.test", name: "Sharee19" }
+  const outsider: TestUser = { id: "u_b19_out", email: "x19@dock.test", name: "Out19" }
+
+  it("notifies a workspace member + an artifact sharee, but NEVER a non-member", async () => {
+    const { app, meta: m } = makeAuthedApp(
+      "harden-b19",
+      [owner, member, sharee, outsider],
+      undefined,
+      { isolated: true },
+    )
+    // Owner provisions their workspace by publishing an org-private artifact.
+    const { short_id } = await (
+      await publishAs(app, "<h1>p</h1>", { title: "B19", visibility: "org" }, as(owner.email))
+    ).json()
+    const art = await m.getByShortId(short_id)
+    if (!art) throw new Error("artifact not found")
+    // member joins the workspace; sharee gets an explicit share; outsider stays a stranger.
+    await m.setMembership({ id: "m_b19", org_id: art.org_id, user_id: member.id, role: "editor" })
+    await m.setArtifactMember({
+      id: "am_b19",
+      artifact_id: art.id,
+      user_id: sharee.id,
+      role: "viewer",
+    })
+
+    // Owner @mentions all three (attacker-controlled body, as in the live repro).
+    const res = await app.request(
+      `/v1/artifacts/${short_id}/comments`,
+      jsonAs(as(owner.email), {
+        body_md: "CLICK http://evil.example",
+        mentions: [
+          { id: member.id, name: "Member19" },
+          { id: sharee.id, name: "Sharee19" },
+          { id: outsider.id, name: "Out19" },
+        ],
+      }),
+    )
+    expect(res.status).toBe(201)
+
+    // Collaborators are notified; the non-member is not (the spam/phishing is blocked).
+    expect((await m.listNotifications(member.id, 50)).length).toBe(1)
+    expect((await m.listNotifications(sharee.id, 50)).length).toBe(1)
+    expect((await m.listNotifications(outsider.id, 50)).length).toBe(0)
+  })
+
+  it("caps the number of distinct mentions parsed per comment", () => {
+    const many = Array.from({ length: MAX_MENTIONS + 25 }, (_, i) => ({
+      id: `u${i}`,
+      name: `n${i}`,
+    }))
+    expect(parseMentions(many)).toHaveLength(MAX_MENTIONS)
+  })
+})
+
+// B-018: an explicitly-provided visibility that isn't a known value is rejected, not
+// silently coerced to `link` (URL-readable). Absent visibility still defaults to link.
+describe("B-018: publish rejects an unknown visibility", () => {
+  const owner: TestUser = { id: "u_b18_owner", email: "o18@dock.test", name: "Owner18" }
+
+  it("400s on an unknown visibility; valid values store; absent defaults to link", async () => {
+    const { app } = makeAuthedApp("harden-b18", [owner])
+    const bad = await publishAs(
+      app,
+      "<h1>x</h1>",
+      { title: "v", visibility: "private" },
+      as(owner.email),
+    )
+    expect(bad.status).toBe(400)
+    const org = await (
+      await publishAs(app, "<h1>x</h1>", { title: "v2", visibility: "org" }, as(owner.email))
+    ).json()
+    expect(org.visibility).toBe("org")
+    const def = await (await publishAs(app, "<h1>x</h1>", { title: "v3" }, as(owner.email))).json()
+    expect(def.visibility).toBe("link")
   })
 })


### PR DESCRIPTION
## What

Bug-hunt findings from deep-testing the live deployment. All server-side authz/validation hardening — no schema or client changes. Common theme: **over-broad reads + identity/email off the wire** (the B-011/012/013 lineage), plus one input-validation footgun.

## Bugs fixed

| ID | Sev | Fix |
|----|-----|-----|
| **B-019** | S3 | **Cross-workspace mention-spam / phishing.** Comment `mentions[]` are client-supplied, and `notifyMentions` notified any user that merely *exists* — no access check. Any signed-in user could push an **attacker-controlled artifact title + comment preview** into **any** other user's bell + SSE, cross-workspace, no relationship (confirmed live). Now a mentioned human is notified only if they can **see** the artifact — a member or explicit sharee (collaborator set, 2 batched queries). Caps parsed mentions at 50. Not a read bypass (victim still 404s the artifact). |
| **B-020** | S3 | **View-analytics leaked viewer identities cross-workspace.** `GET /v1/artifacts/:shortId/analytics` was gated on `read` + not-anon — satisfied by any signed-in user on a public/link artifact — so a **non-member** could read the view counts + the **names of signed-in viewers** (confirmed live). Now collaborator-gated (mirrors the B-013 members-list fix); viewers resolve to a handle, never email. |
| **B-021** | S4 | **Email-on-the-wire in author/actor bylines** (migration miss). Publish/version author, comment author (via `actingUser`), and proposal approver/reviewer fell back to `name ?? email`, so a null-name user's **email** would surface as their public byline. Latent (0 live null-name accounts) but contradicts "email off the wire". Fallbacks now go `name → username → email` (the email arm is unreachable post-migration); presence drops its email-local-part fallback too. |
| **B-018** | S4 | **Publish silently coerced an unknown `visibility`** (e.g. `private`, ``) to `link` (URL-readable). Now `400`s on an explicitly-provided unknown visibility; absent still defaults to `link`; valid values unchanged. |

## Verification

- api: typecheck + **343 tests** + coverage (lines **83.9%**, above the 80 gate)
- New `harden.test.ts` cases for B-019 / B-020 / B-021 / B-018; existing `@mentions + notifications`, `view analytics`, proposals/reviews, and presence tests stay green

## Notes

- Full bug-hunt log (BUGS.md / STATE.md) lives on `chore/bug-hunt`; everything else it found was already fixed + deployed via #170–#173. Still open + out of scope here: **B-010** (no password reset — needs an email sender) and **B-007** (anon 401-vs-403 — cosmetic). One sub-item left noted-not-fixed: `oauthWorkspace`'s own-workspace-name seed uses the email local-part (own name only; would need threading `username` through the helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
