### PR TITLE
feat(mcp): first publish — let the MCP create a new artifact in your workspace

### DIFF
--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -18,6 +18,7 @@
 import {
   type AgentRecord,
   type ArtifactRecord,
+  artifactUrl,
   type BundleManifest,
   diffLines,
   formatDiff,
@@ -104,6 +105,14 @@ const changeCount = (c: ReturnType<typeof bundleFileChanges>) =>
  * tool — it's a one-shot fact, not a per-call action.
  */
 function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
+  // Steer the write guidance by what this grant can actually do: a publish-capable
+  // grant gets the create/publish path; a lower grant is pointed at propose only.
+  const writeGuidance = roleAllows(agent.role, "publish")
+    ? `Use publish to create a new artifact (omit short_id) or push a new version of one you own — ` +
+      `it goes live immediately in your workspace. Use propose to suggest changes to artifacts you ` +
+      `don't own, which a human approves. `
+    : `Work the open threads from list_comments and use propose to suggest a revision a human ` +
+      `approves — you cannot publish directly. `
   const server = new McpServer(
     { name: "dock", version: "1.0.0" },
     {
@@ -112,8 +121,7 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
         `with ${agent.role} permissions. Dock hosts living documents and plans with versioned ` +
         `history, text-anchored review comments, and a propose → review → revise loop. ` +
         `Start a session with catch_me_up to re-sync on what changed; use read to view content ` +
-        `(outline first for multi-page bundles); work the open threads from list_comments and use ` +
-        `propose to suggest a revision a human approves — you cannot publish directly. When a ` +
+        `(outline first for multi-page bundles). ${writeGuidance}When a ` +
         `proposal fixes specific feedback, pass those thread ids as propose's "addresses" so the ` +
         `threads show as pending and auto-resolve on approval.`,
     },
@@ -456,22 +464,35 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
     "publish",
     {
       description:
-        "Publish a revised version of a single-file artifact DIRECTLY — it goes live immediately. Requires publish rights (Creator/Admin role on the workspace); a commenter-level grant should use `propose` instead. Provide the FULL new content (not a patch) and a version message. (Multi-page bundles aren't publishable over MCP yet.)",
+        "Publish a single-file artifact to your workspace DIRECTLY — it goes live immediately, no review. OMIT short_id to create a NEW artifact (a first publish) — `title` is then required. PASS short_id to publish a new version of one you already own. Requires publish rights (Creator/Admin role on the workspace); a commenter-level grant should use `propose` instead. Provide the FULL content (not a patch). (Multi-page bundles aren't publishable over MCP yet.)",
       inputSchema: {
-        short_id: z.string(),
-        content: z
+        content: z.string().describe("The complete document content (HTML or Markdown)."),
+        title: z
           .string()
-          .describe("The complete new content of the document (HTML or Markdown)."),
-        message: z.string().describe("What changed — recorded as the version message."),
+          .optional()
+          .describe(
+            "Title for a NEW artifact (required when creating). On republish, renames only if provided.",
+          ),
+        short_id: z
+          .string()
+          .optional()
+          .describe(
+            "Omit to create a new artifact; pass it to publish a new version of one you own.",
+          ),
+        visibility: z
+          .enum(["workspace", "link", "public"])
+          .optional()
+          .describe(
+            "Who can see a NEW artifact: workspace (your team, default), link (anyone with the link), or public (discoverable). Ignored on republish.",
+          ),
+        message: z.string().optional().describe("What changed — recorded as the version message."),
         filename: z
           .string()
           .optional()
           .describe("Filename hint for the content type, e.g. index.html or notes.md."),
       },
     },
-    async ({ short_id, content, message, filename }) => {
-      const a = await own(short_id)
-      if (!a) return text(`No artifact "${short_id}" in this workspace.`)
+    async ({ content, title, short_id, visibility, message, filename }) => {
       // Direct publish is gated on the agent's role: Creator/Admin only. A
       // commenter-level grant is steered to `propose` (human-reviewed), so a
       // low-privilege agent still can't push live content.
@@ -479,27 +500,44 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
         return text(
           "Your grant can't publish directly (needs a Creator/Admin role). Use `propose` to submit a reviewed change, or re-authorize with a publish scope.",
         )
-      if (a.kind === "bundle")
-        return text(
-          `"${short_id}" is a multi-page bundle; publishing bundle revisions over MCP isn't supported yet (single-file artifacts only).`,
-        )
+      if (short_id) {
+        const a = await own(short_id)
+        if (!a) return text(`No artifact "${short_id}" in this workspace.`)
+        if (a.kind === "bundle")
+          return text(
+            `"${short_id}" is a multi-page bundle; publishing bundle revisions over MCP isn't supported yet (single-file artifacts only).`,
+          )
+      } else if (!title?.trim()) {
+        return text("Creating a new artifact needs a `title`.")
+      }
       try {
-        const { version } = await publishVersion(
+        const { artifact, version } = await publishVersion(
           ctx.meta,
           ctx.blobs,
           {
             bytes: new TextEncoder().encode(content),
             filename: filename ?? "index.html",
             isBundle: false,
+            title: title?.trim(),
             message,
             author: agent.name,
+            // New artifacts land in the granting user's workspace, private to the
+            // team by default (never link-public unless they ask).
+            orgId: agent.org_id,
+            visibility: visibility === "link" ? "link" : visibility === "public" ? "public" : "org",
           },
           short_id,
         )
         return json({
           published: true,
+          short_id: artifact.short_id,
           version: version.n,
-          note: "Live now — this published a new current version of the artifact.",
+          url: artifactUrl(ctx.deps.baseUrl, artifact),
+          title: artifact.title,
+          visibility: artifact.visibility,
+          note: short_id
+            ? "Live now — published a new current version."
+            : "Live now — created a new artifact in your workspace.",
         })
       } catch (e) {
         const msg = e instanceof PublishError ? e.message : "could not publish"

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -438,4 +438,62 @@ describe("remote MCP endpoint (/mcp)", () => {
       .sign(privateKey)
     expect((await rpc(app, wrongIss, initBody)).status).toBe(401)
   })
+
+  it("publish creates a NEW artifact (first publish) and then a new version of it", async () => {
+    const { app, token } = appWithGrant("pub", "openid dock:read dock:publish")
+
+    // First publish — no short_id, so it creates a brand-new artifact.
+    const created = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          title: "My First Doc",
+          content: "<h1>hello world</h1>",
+        }),
+      ),
+    )
+    expect(created.published).toBe(true)
+    expect(created.version).toBe(1)
+    expect(created.title).toBe("My First Doc")
+    expect(created.short_id).toBeTruthy()
+    expect(created.url).toContain(created.short_id)
+    expect(created.visibility).toBe("org") // workspace-private by default
+
+    // It's really there: list_artifacts + read see it live.
+    const list = JSON.parse(toolText(await call(app, token, "list_artifacts")))
+    expect(list.artifacts.some((a: { short_id: string }) => a.short_id === created.short_id)).toBe(
+      true,
+    )
+    const read = JSON.parse(
+      toolText(await call(app, token, "read", { short_id: created.short_id })),
+    )
+    expect(read.content).toContain("hello world")
+
+    // Publishing again WITH the short_id pushes a new version (not a second artifact).
+    const v2 = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          short_id: created.short_id,
+          content: "<h1>hello again</h1>",
+          message: "tweak",
+        }),
+      ),
+    )
+    expect(v2.short_id).toBe(created.short_id)
+    expect(v2.version).toBe(2)
+  })
+
+  it("publish needs a title to create, and a publish-capable grant", async () => {
+    // A new-artifact publish with no title is refused.
+    const { app, token } = appWithGrant("pub2", "openid dock:read dock:publish")
+    const noTitle = await call(app, token, "publish", { content: "<h1>x</h1>" })
+    expect(toolText(noTitle)).toContain("title")
+
+    // A comment-only grant can't publish at all — steered to propose.
+    const weak = appWithGrant("pub3", "openid dock:read dock:comment")
+    const denied = await call(weak.app, weak.token, "publish", {
+      title: "Nope",
+      content: "<h1>x</h1>",
+    })
+    expect(toolText(denied)).toContain("propose")
+  })
 })


### PR DESCRIPTION
The `publish` tool required a `short_id`, so over MCP an agent could push new versions of *existing* artifacts but **couldn't create one** — there was no way to do a first publish. This closes that gap.

`short_id` is now **optional**:
- **Omit it** (with a `title`) → creates a new single-file artifact, **live in your workspace**, and returns its `short_id` + `url` so the agent can hand you a link.
- **Pass it** → publishes a new version, as before.

New artifacts default to **`org` visibility** (workspace-private); `link` / `public` are opt-in. Still **editor-gated** (`roleAllows(…, "publish")`) — a commenter-level grant is steered to `propose`. The server `instructions` are now **role-aware**: a publish-capable grant gets the create/publish guidance instead of the stale "you cannot publish directly."

### Tests
- first publish creates a new artifact, `list_artifacts` + `read` see it live, then a second `publish` with the `short_id` pushes v2;
- creating without a `title` is refused;
- a comment-only grant can't publish (pointed at `propose`).
- 11 mcp tests green; typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)