### PR TITLE
General-access comment permission (auth-gated; anonymous stays view-only)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,8 +41,9 @@ the bundled SPA when present.
 
 - **Auth** is [Better Auth](https://better-auth.com) under `/api/auth/*`; a static
   `DOCK_TOKEN` authorizes CI/agents. `packages/core/src/permissions.ts` is the one
-  authorization gate (`can(actor, action, visibility)`); every route resolves an
-  `Actor` and asks it.
+  authorization gate (`can(actor, action, visibility, generalRole)`); every route
+  resolves an `Actor` and asks it. `effectiveRole` there is the source of truth for the
+  access matrix (anonymous is always view-only; see SECURITY.md).
 - **Workspaces** are keyed by a real `org_id` (never a magic constant). Every
   signed-in user owns a personal workspace (provisioned on first login) and can
   create/switch; the active workspace is resolved per request (cookie → membership

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,11 +21,26 @@ release; please run a recent build.
 
 Dock ships safe defaults, but a few choices matter for an internet-facing deploy:
 
-- **Anonymous callers are always read-only.** They may view public/link artifacts
-  and join live presence (a server-assigned handle + cursor) — nothing else. There is
-  no "open" mode that elevates anonymous callers to owners. To write, a caller must
-  sign in (Better Auth is always available, even zero-config) or present a static
-  `DOCK_TOKEN`; set `DOCK_TOKEN` for headless CI/agent automation.
+- **Anonymous callers are always read-only.** This is the load-bearing access
+  invariant: an anonymous (no-account) caller is never more than a viewer. Anything past
+  view (comment, propose, publish, share, manage) requires an authenticated identity, so
+  there is no "open" mode that elevates an anonymous caller. To write, a caller signs in
+  (Better Auth is always available, even zero-config) or presents a static `DOCK_TOKEN`
+  (set it for headless CI/agent automation). General access (the shared link) can grant a
+  reacher view or comment; the comment grant only lifts a *signed-in* reacher to commenter,
+  never an anonymous one. The effective capability by who's asking:
+
+  | General access (the link)     | Anonymous (no account)         | Signed in via link (no explicit grant) | Member / explicit share        |
+  |--------------------------------|--------------------------------|----------------------------------------|--------------------------------|
+  | Anyone with link, **view**     | View                           | View                                   | Their role (at least view)     |
+  | Anyone with link, **comment**  | View only (sign in to comment) | View + comment                         | Their role (at least comment)  |
+  | Public (listed), view/comment  | same as link row               | same as link row                       | Their role                     |
+  | Password, view/comment         | Unlock, then as above          | Unlock, then as above                  | Their role (no password needed)|
+  | Workspace only (org)           | No access                      | No access                              | Their role (members only)      |
+
+  `packages/core/src/permissions.ts` (`effectiveRole`) is the single source of truth for
+  this table, enforced on every request by the one `can()` gate and surfaced in the UI so
+  no comment affordance is shown to someone who can't comment.
 - **Set `DOCK_AUTH_SECRET`.** Generated and persisted automatically for single-node
   self-host; you must set it explicitly for multi-instance deployments so every node
   shares the same session-signing secret.

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -519,9 +519,11 @@ export function buildContext(deps: AppDeps) {
     return { kind: "user", userId: me.id, artifactRole, orgRole, unlocked }
   }
 
-  /** Authorize an action against a specific artifact. */
+  /** Authorize an action against a specific artifact. The artifact's general-access role
+   *  is threaded in so an authenticated link-reacher can earn `comment` while an anonymous
+   *  one stays clamped to view (see effectiveRole). */
   const authorize = (c: Context, action: Action, a: ArtifactRecord): Promise<boolean> =>
-    actorFor(c, a).then((actor) => can(actor, action, a.visibility))
+    actorFor(c, a).then((actor) => can(actor, action, a.visibility, a.general_role))
 
   /**
    * True when the caller is an anonymous visitor — they may view public content

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -246,7 +246,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     // an anonymous probe can't learn anything (a non-member gets no access).
     const actor = await actorFor(c, artifact ?? ({ id: "", visibility: "org" } as ArtifactRecord))
     if (!artifact) return fail(c, 404, "not found")
-    if (!can(actor, "read", artifact.visibility))
+    if (!can(actor, "read", artifact.visibility, artifact.general_role))
       // A password artifact isn't hidden, it's lockable: tell the client to prompt
       // for the password (401) rather than claim it doesn't exist (404).
       return artifact.visibility === "password"
@@ -266,7 +266,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     return c.json({
       ...toJson(deps.baseUrl, artifact, versions),
       sessions: groupSessions(versions, versionWindowMs),
-      my_role: effectiveRole(actor, artifact.visibility),
+      my_role: effectiveRole(actor, artifact.visibility, artifact.general_role),
       tags,
       favorite,
       collections,
@@ -281,21 +281,28 @@ export const artifactRoutes = (ctx: AppContext) => {
     })
   })
 
-  // Change general access (visibility) after publish — the Share dialog's
-  // "general access" control. Editors+ (share), per the GDocs model. Enabling
-  // `password` needs a password (or keeps the existing one); any other visibility
-  // clears the stored hash.
+  // Change general access (visibility + the general-access role) after publish — the
+  // Share dialog's "general access" control. Editors+ (share), per the GDocs model.
+  // `generalRole` is the floor the link grants a reacher (viewer = view-only, commenter =
+  // authenticated reachers may comment; anonymous stays view-only regardless). Enabling
+  // `password` needs a password (or keeps the existing one); any other visibility clears
+  // the stored hash.
   app.patch("/v1/artifacts/:shortId/visibility", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact) return fail(c, 404, "not found")
     if (!(await authorize(c, "share", artifact))) return fail(c, 403, "forbidden")
     const b = await readJson(
       c,
-      z.object({ visibility: z.string(), password: z.string().optional() }),
+      z.object({
+        visibility: z.string(),
+        password: z.string().optional(),
+        generalRole: z.enum(["viewer", "commenter"]).optional(),
+      }),
     )
     if (b instanceof Response) return b
     const visibility = visibilityOf(b.visibility)
     if (!visibility) return fail(c, 400, "invalid visibility")
+    const generalRole = b.generalRole ?? "viewer"
     let passwordHash: string | null = null
     if (visibility === "password") {
       if (b.password) passwordHash = hashPassword(b.password)
@@ -303,8 +310,8 @@ export const artifactRoutes = (ctx: AppContext) => {
         passwordHash = artifact.password_hash
       else return fail(c, 400, "a password is required for password visibility")
     }
-    await meta.setVisibility(artifact.id, visibility, passwordHash)
-    return c.json({ visibility })
+    await meta.setVisibility(artifact.id, visibility, passwordHash, generalRole)
+    return c.json({ visibility, general_role: generalRole })
   })
 
   // Unlock a `password` artifact: verify the password and drop a cookie whose

--- a/apps/api/test/comment-access.test.ts
+++ b/apps/api/test/comment-access.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest"
+import { as, json, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// The general-access comment grant, enforced end to end at the route layer (the
+// companion to packages/core's effectiveRole matrix). The invariant under test: an
+// anonymous caller can never comment, no matter the grant — auth is the gate — while a
+// signed-in caller reaching purely via the link rises to commenter when the link allows
+// it. Mirrors the access matrix in SECURITY.md.
+describe("comment access via the general-access link", () => {
+  const alice: TestUser = { id: "u_ca_alice", email: "alice@ca.test", name: "Alice" }
+  // Bob is signed in but reaches Alice's artifact purely via the link (his own isolated
+  // workspace → no membership, no share): the "signed in via link" column.
+  const bob: TestUser = { id: "u_ca_bob", email: "bob@ca.test", name: "Bob" }
+  const { app } = makeAuthedApp("comment-access", [alice, bob], undefined, { isolated: true })
+
+  const setAccess = (shortId: string, generalRole: "viewer" | "commenter") =>
+    app.request(`/v1/artifacts/${shortId}/visibility`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json", ...as(alice.email) },
+      body: JSON.stringify({ visibility: "link", generalRole }),
+    })
+  const comment = (shortId: string, headers: Record<string, string>) =>
+    app.request(`/v1/artifacts/${shortId}/comments`, jsonAs(headers, { body_md: "hi" }))
+  const view = (shortId: string, headers?: Record<string, string>) =>
+    app.request(`/v1/artifacts/${shortId}`, headers ? { headers } : undefined)
+
+  it("view link: anyone reaching may read, nobody reaching may comment", async () => {
+    await app.request("/v1/me", { headers: as(alice.email) }) // provision Alice's workspace
+    const shortId = (await (await publishAs(app, "<h1>doc</h1>", {}, as(alice.email))).json())
+      .short_id
+    expect((await setAccess(shortId, "viewer")).ok).toBe(true)
+
+    // Reads succeed for a signed-in reacher and for an anonymous visitor.
+    expect((await view(shortId, as(bob.email))).status).toBe(200)
+    expect((await view(shortId)).status).toBe(200)
+    // Comments are refused for both — a view link grants only viewer.
+    expect((await comment(shortId, as(bob.email))).status).toBe(403)
+    expect(
+      (await app.request(`/v1/artifacts/${shortId}/comments`, json({ body_md: "hi" }))).status,
+    ).toBe(403)
+  })
+
+  it("comment link: a signed-in reacher comments; an anonymous one is forced to auth", async () => {
+    await app.request("/v1/me", { headers: as(alice.email) })
+    const shortId = (await (await publishAs(app, "<h1>doc2</h1>", {}, as(alice.email))).json())
+      .short_id
+    expect((await setAccess(shortId, "commenter")).ok).toBe(true)
+
+    // Signed in via the link → commenter → may comment.
+    expect((await comment(shortId, as(bob.email))).ok).toBe(true)
+    // Anonymous → still viewer → 403 even on a comment link (the invariant).
+    expect(
+      (await app.request(`/v1/artifacts/${shortId}/comments`, json({ body_md: "no" }))).status,
+    ).toBe(403)
+
+    // my_role reflects the grant per caller; the GET returns the persisted general_role.
+    const bobView = await (await view(shortId, as(bob.email))).json()
+    expect(bobView.my_role).toBe("commenter")
+    expect(bobView.general_role).toBe("commenter")
+    const anonView = await (await view(shortId)).json()
+    expect(anonView.my_role).toBe("viewer")
+  })
+
+  it("revoking the comment grant locks commenting again", async () => {
+    await app.request("/v1/me", { headers: as(alice.email) })
+    const shortId = (await (await publishAs(app, "<h1>doc3</h1>", {}, as(alice.email))).json())
+      .short_id
+    expect((await setAccess(shortId, "commenter")).ok).toBe(true)
+    expect((await comment(shortId, as(bob.email))).ok).toBe(true)
+    // Flip back to view-only: the same reacher can no longer comment.
+    expect((await setAccess(shortId, "viewer")).ok).toBe(true)
+    expect((await comment(shortId, as(bob.email))).status).toBe(403)
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -25,12 +25,17 @@ export interface VersionSession {
   created_at: string
 }
 export type Role = "viewer" | "commenter" | "editor" | "owner"
+/** What general access (the link) grants a reacher: view-only or comment. */
+export type GeneralRole = "viewer" | "commenter"
 export interface Artifact {
   short_id: string
   url: string
   title: string | null
   kind: "file" | "bundle"
   visibility: string
+  /** The role the general-access link grants (view vs comment). Anonymous reachers are
+   *  always clamped to view regardless; commenting requires signing in. */
+  general_role?: GeneralRole
   current_version: number
   versions: {
     n: number
@@ -378,18 +383,20 @@ export const api = {
   // cookie and subsequent reads of this artifact succeed.
   unlock: (id: string, password: string): Promise<{ ok: true }> =>
     f(`/v1/artifacts/${id}/unlock`, opts({ password })).then(j),
-  // Change general access (visibility) from the Share dialog. A password is
-  // required when enabling `password` visibility for the first time.
+  // Change general access from the Share dialog: visibility + the general-access role
+  // (view vs comment). A password is required when enabling `password` visibility for
+  // the first time. Anonymous reachers stay view-only regardless of generalRole.
   setVisibility: (
     id: string,
     visibility: string,
+    generalRole?: GeneralRole,
     password?: string,
-  ): Promise<{ visibility: string }> =>
+  ): Promise<{ visibility: string; general_role: GeneralRole }> =>
     f(`/v1/artifacts/${id}/visibility`, {
       method: "PATCH",
       credentials: "include",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ visibility, password }),
+      body: JSON.stringify({ visibility, generalRole, password }),
     }).then(j),
   diff: (id: string, from: number, to: number): Promise<Diff> =>
     f(`/v1/artifacts/${id}/diff?from=${from}&to=${to}&format=json`, opts()).then(j),

--- a/apps/web/src/components/ShareDialog.tsx
+++ b/apps/web/src/components/ShareDialog.tsx
@@ -2,7 +2,14 @@ import { useQueryClient } from "@tanstack/react-query"
 import { Lock, Share2, X } from "lucide-react"
 import { useState } from "react"
 import { toast } from "sonner"
-import { API_BASE, type ArtifactDomain, type ArtifactMember, api, type Role } from "@/api"
+import {
+  API_BASE,
+  type ArtifactDomain,
+  type ArtifactMember,
+  api,
+  type GeneralRole,
+  type Role,
+} from "@/api"
 import { EmptyState } from "@/components/shared/empty-state"
 import { RoleSelect } from "@/components/shared/role-select"
 import { Button } from "@/components/ui/button"
@@ -54,10 +61,12 @@ export function ShareButton({
   shortId,
   myRole,
   visibility,
+  generalRole,
 }: {
   shortId: string
   myRole?: Role | null
   visibility: string
+  generalRole?: GeneralRole
 }) {
   const qc = useQueryClient()
   const [members, setMembers] = useState<ArtifactMember[]>([])
@@ -66,8 +75,10 @@ export function ShareButton({
   const [role, setRole] = useState<Role>("editor")
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
-  // General access (visibility) draft + a password when enabling/changing password.
+  // General access draft: visibility + the link's permission (view vs comment), plus a
+  // password when enabling/changing password.
   const [vis, setVis] = useState(visibility)
+  const [genRole, setGenRole] = useState<GeneralRole>(generalRole ?? "viewer")
   const [pw, setPw] = useState("")
   const [savingVis, setSavingVis] = useState(false)
 
@@ -101,11 +112,14 @@ export function ShareButton({
     }
   }
 
+  // Reach visibilities (anyone with the link / public / password) carry a general-access
+  // permission; "workspace only" does not, so the view/comment control hides for it.
+  const reach = vis === "link" || vis === "public" || vis === "password"
   const saveVisibility = async () => {
     setSavingVis(true)
     setErr(null)
     try {
-      await api.setVisibility(shortId, vis, vis === "password" && pw ? pw : undefined)
+      await api.setVisibility(shortId, vis, genRole, vis === "password" && pw ? pw : undefined)
       setPw("")
       // Refresh the artifact (drives the toolbar/visibility) and the library.
       qc.invalidateQueries({ queryKey: ["artifact", shortId] })
@@ -118,7 +132,7 @@ export function ShareButton({
   }
   // Enabling password needs a password; an unchanged selection has nothing to save.
   const needsPw = vis === "password" && visibility !== "password" && !pw
-  const visUnchanged = vis === visibility && !pw
+  const visUnchanged = vis === visibility && genRole === (generalRole ?? "viewer") && !pw
 
   const load = () =>
     api
@@ -367,6 +381,18 @@ export function ShareButton({
                         </option>
                       ))}
                     </select>
+                    {reach && (
+                      <select
+                        aria-label="Link permission"
+                        data-testid="share-general-role"
+                        value={genRole}
+                        onChange={(e) => setGenRole(e.target.value as GeneralRole)}
+                        className="rounded-md border border-input bg-card px-2 py-2 text-sm text-foreground outline-none transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring"
+                      >
+                        <option value="viewer">Can view</option>
+                        <option value="commenter">Can comment</option>
+                      </select>
+                    )}
                     <Button
                       data-testid="share-visibility-save"
                       variant="primary"
@@ -393,6 +419,7 @@ export function ShareButton({
                   )}
                   <p className="mt-1.5 font-mono text-2xs text-muted-foreground">
                     {ACCESS.find((a) => a.value === vis)?.blurb}
+                    {reach && genRole === "commenter" && " Signed-in visitors can comment."}
                   </p>
                 </>
               ) : (

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -21,7 +21,7 @@ const loginRoute = getRouteApi("/login")
 export function Login() {
   const { me, loading, setMe } = useAuth()
   const nav = useNavigate()
-  const { signup: wantSignup } = loginRoute.useSearch()
+  const { signup: wantSignup, return_to: returnTo } = loginRoute.useSearch()
   const [mode, setMode] = useState<"login" | "signup">(wantSignup ? "signup" : "login")
   const [name, setName] = useState("")
   const [email, setEmail] = useState("")
@@ -37,12 +37,16 @@ export function Login() {
     const search = typeof window !== "undefined" ? window.location.search : ""
     if (new URLSearchParams(search).has("client_id")) {
       window.location.href = `/api/auth/oauth2/authorize${search}`
+    } else if (typeof returnTo === "string") {
+      // Back to where sign-in was prompted (e.g. a shared artifact's "sign in to
+      // comment"). Validated same-origin relative by the route, so this is safe.
+      window.location.href = returnTo
     } else {
       nav({ to: "/" })
     }
   }
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: afterAuth only reads nav (stable) + the URL; keyed to the auth state.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: afterAuth reads nav (stable), the URL, and returnTo (stable from search); keyed to the auth state.
   useEffect(() => {
     if (!loading && me) afterAuth()
   }, [loading, me])

--- a/apps/web/src/pages/artifact/artifact-comments.tsx
+++ b/apps/web/src/pages/artifact/artifact-comments.tsx
@@ -28,6 +28,9 @@ export function ArtifactComments(p: {
   shortId: string
   isMobile: boolean
   isAnon: boolean
+  /** May the caller create comments here (commenter+)? Gates every write affordance;
+   *  reading stays open to any authenticated viewer. */
+  canComment: boolean
   docLive: boolean
   panel: Panel
   asideWidth: number
@@ -55,7 +58,7 @@ export function ArtifactComments(p: {
   jumpTo: (threadId: string) => void
   startSelComment: () => void
 }) {
-  const { isMobile, isAnon, panel, sel } = p
+  const { isMobile, isAnon, canComment, panel, sel } = p
   // Focus primer: tapping "Comment" focuses this synchronously, inside the tap
   // gesture, so iOS raises the keyboard; the composer's autofocus then takes over
   // and the keyboard stays up. (iOS won't open the keyboard for a focus that lands
@@ -72,8 +75,8 @@ export function ArtifactComments(p: {
   }
 
   return (
-    <CommentScopeProvider value={{ shortId: p.shortId }}>
-      {isMobile && !isAnon && (
+    <CommentScopeProvider value={{ shortId: p.shortId, canComment }}>
+      {isMobile && canComment && (
         // Always mounted so the Comment tap can focus it synchronously (see `primer`).
         // text-base (16px) avoids iOS's zoom-on-focus.
         <textarea
@@ -159,7 +162,7 @@ export function ArtifactComments(p: {
           mouse can reach it and there is no native callout in the way). On phones
           this would land under iOS's own selection menu, so mobile uses the bottom
           bar below instead. Clicking opens the panel and starts a pinned composer. */}
-      {!isMobile && !isAnon && p.docLive && sel && !p.composer && (
+      {!isMobile && canComment && p.docLive && sel && !p.composer && (
         <button
           type="button"
           className="fixed z-50 inline-flex items-center gap-2 whitespace-nowrap rounded-full border border-primary bg-card px-3.5 py-2 text-sm font-semibold text-primary shadow-[var(--shadow)] transition-colors hover:bg-primary hover:text-primary-foreground"
@@ -188,7 +191,7 @@ export function ArtifactComments(p: {
           pinned below iOS's own selection menu and big enough to thumb. It shows
           the quote so you know what you're attaching to; Comment opens the sheet
           composer, ✕ clears the selection. */}
-      {isMobile && !isAnon && p.docLive && sel && !p.composer && (
+      {isMobile && canComment && p.docLive && sel && !p.composer && (
         <div
           data-testid="mobile-comment-bar"
           className="fixed inset-x-0 bottom-0 z-[62] flex items-center gap-2.5 border-t border-border bg-card px-3 pb-[max(16px,env(safe-area-inset-bottom))] pt-4 shadow-[0_-12px_36px_-16px_rgba(0,0,0,0.55)]"

--- a/apps/web/src/pages/artifact/artifact-top-bar.tsx
+++ b/apps/web/src/pages/artifact/artifact-top-bar.tsx
@@ -1,4 +1,4 @@
-import type { Role } from "@/api"
+import type { GeneralRole, Role } from "@/api"
 import { Icon } from "@/components/icons"
 import { ShareButton } from "@/components/ShareDialog"
 import { Button } from "@/components/ui/button"
@@ -21,6 +21,7 @@ export function ArtifactTopBar(props: {
   shortId: string
   myRole?: Role | null
   visibility: string
+  generalRole?: GeneralRole
   favorite: boolean
   tags: string[]
   collections: string[]
@@ -56,7 +57,12 @@ export function ArtifactTopBar(props: {
         inCollections={props.collections}
         onChange={props.onCollections}
       />
-      <ShareButton shortId={shortId} myRole={props.myRole} visibility={props.visibility} />
+      <ShareButton
+        shortId={shortId}
+        myRole={props.myRole}
+        visibility={props.visibility}
+        generalRole={props.generalRole}
+      />
       <ReportButton shortId={shortId} />
       <DropdownMenu>
         <DropdownMenuTrigger asChild>

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -10,6 +10,7 @@ import {
   PinnedZone,
   ResolvedSection,
 } from "./comment-thread"
+import { useCommentScope } from "./lib/comment-scope"
 import { IconBtn } from "./rail-deck"
 import type { PinItem, Sel } from "./types"
 
@@ -50,6 +51,7 @@ export function MobileComments({
   // list). Composing overrides both with a compact composer bar pinned above the
   // keyboard (see the height + `kb` style below), so the box sits flush above the
   // keyboard with the document visible above — no awkward half-height middle state.
+  const { canComment } = useCommentScope()
   const [size, setSize] = useState<"peek" | "full">("peek")
   useEffect(() => {
     if (open) setSize("peek")
@@ -149,17 +151,19 @@ export function MobileComments({
             </span>
           )}
           <span className="flex-1" />
-          <Button
-            variant="outline"
-            size="sm"
-            data-testid="comments-sheet-new"
-            onClick={() => {
-              setSize("full")
-              onNewGeneral()
-            }}
-          >
-            ＋ New
-          </Button>
+          {canComment && (
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="comments-sheet-new"
+              onClick={() => {
+                setSize("full")
+                onNewGeneral()
+              }}
+            >
+              ＋ New
+            </Button>
+          )}
           <IconBtn
             big
             title={size === "peek" ? "Expand" : "Collapse"}
@@ -282,6 +286,7 @@ export function OpenPanel(props: {
     onSubmitNew,
     onCancelNew,
   } = props
+  const { canComment } = useCommentScope()
   const generalComposer = composer && !composer.anchor
   const empty = openCount === 0 && resolved.length === 0 && !composer
 
@@ -295,9 +300,11 @@ export function OpenPanel(props: {
           </span>
         )}
         <span className="flex-1" />
-        <IconBtn title="New comment" testId="comment-new" onClick={onNewGeneral}>
-          ＋
-        </IconBtn>
+        {canComment && (
+          <IconBtn title="New comment" testId="comment-new" onClick={onNewGeneral}>
+            ＋
+          </IconBtn>
+        )}
         <IconBtn title="Minimize to rail (c)" onClick={onMinimize}>
           ⟩
         </IconBtn>

--- a/apps/web/src/pages/artifact/comment-thread.tsx
+++ b/apps/web/src/pages/artifact/comment-thread.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { Composer, MentionField } from "./comment-composer"
 import { CommentRow } from "./comment-row"
+import { useCommentScope } from "./lib/comment-scope"
 import { anchorExact, COMPOSER_ID, layoutPins } from "./lib/layout"
 import type { PinItem, Sel } from "./types"
 
@@ -193,6 +194,7 @@ export function CommentCard({
   onReply: (text: string, threadId: string, mentions?: Mention[]) => void
   onJump: (id: string) => void
 }) {
+  const { canComment } = useCommentScope()
   const [reply, setReply] = useState("")
   const [replyMentions, setReplyMentions] = useState<Mention[]>([])
   const root = thread[0]
@@ -265,34 +267,36 @@ export function CommentCard({
               <CommentRow key={c.id} c={c} />
             ))}
           </div>
-          <div className="flex gap-1.5 border-t border-border-soft px-3 py-2">
-            {/* biome-ignore lint/a11y/noStaticElementInteractions: stopPropagation wrapper, not an interactive control */}
-            {/* biome-ignore lint/a11y/useKeyWithClickEvents: stopPropagation wrapper, not an interactive control */}
-            <div className="flex-1" onClick={(e) => e.stopPropagation()}>
-              <MentionField
-                testId="comment-reply-input"
-                value={reply}
-                onChange={setReply}
-                mentions={replyMentions}
-                onMentions={setReplyMentions}
-                onSubmit={sendReply}
-                placeholder="Reply… (@ to mention)"
-                autoFocus
-              />
+          {canComment && (
+            <div className="flex gap-1.5 border-t border-border-soft px-3 py-2">
+              {/* biome-ignore lint/a11y/noStaticElementInteractions: stopPropagation wrapper, not an interactive control */}
+              {/* biome-ignore lint/a11y/useKeyWithClickEvents: stopPropagation wrapper, not an interactive control */}
+              <div className="flex-1" onClick={(e) => e.stopPropagation()}>
+                <MentionField
+                  testId="comment-reply-input"
+                  value={reply}
+                  onChange={setReply}
+                  mentions={replyMentions}
+                  onMentions={setReplyMentions}
+                  onSubmit={sendReply}
+                  placeholder="Reply… (@ to mention)"
+                  autoFocus
+                />
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!reply.trim()}
+                data-testid="comment-reply-send"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  sendReply(replyMentions.filter((m) => reply.includes(`@${m.name}`)))
+                }}
+              >
+                Reply
+              </Button>
             </div>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={!reply.trim()}
-              data-testid="comment-reply-send"
-              onClick={(e) => {
-                e.stopPropagation()
-                sendReply(replyMentions.filter((m) => reply.includes(`@${m.name}`)))
-              }}
-            >
-              Reply
-            </Button>
-          </div>
+          )}
           <div className="flex items-center gap-1.5 bg-secondary px-3 py-1.5">
             <span
               className={cn(

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -22,6 +22,7 @@ import {
 } from "./artifact-states"
 import { ArtifactTopBar } from "./artifact-top-bar"
 import { ActionsCtx } from "./comment-actions"
+import { canCommentWithRole, shouldPromptSignInToComment } from "./lib/comment-access"
 import { groupThreads, parseAnchor } from "./lib/layout"
 import { parseRef } from "./parse-ref"
 import { PasswordGate } from "./password-gate"
@@ -230,6 +231,12 @@ export function Artifact() {
   // The API gates every one of those for anon (anonLocked); hiding them here keeps
   // the chrome honest so there's no dead/forbidden affordance to bump into.
   const isAnon = !me
+  // Commenting needs commenter+ (matches the API's `comment` gate). A signed-in viewer
+  // reading via a view-only link sees comments but gets no write affordance. An
+  // anonymous visitor never qualifies — on a comment-enabled link they get a "sign in
+  // to comment" prompt instead (auth is the gate; see the access matrix).
+  const canComment = canCommentWithRole(art.my_role)
+  const promptSignInToComment = shouldPromptSignInToComment(isAnon, art.general_role, !!art.removed)
 
   // Sort threads into pinned (anchored & present in this live doc), general
   // (unanchored or orphaned), and resolved. Pins drive both the margin cards
@@ -308,6 +315,7 @@ export function Artifact() {
                 shortId={shortId}
                 myRole={art.my_role}
                 visibility={art.visibility}
+                generalRole={art.general_role}
                 favorite={!!art.favorite}
                 tags={art.tags ?? []}
                 collections={art.collections ?? []}
@@ -444,12 +452,27 @@ export function Artifact() {
                   : "Show comments"}
               </button>
             )}
+            {/* Anonymous visitor on a comment-enabled link: commenting forces auth (anon
+                stays view-only). Offer sign-in, returning here afterward. */}
+            {promptSignInToComment && (
+              <button
+                type="button"
+                onClick={() => nav({ to: "/login", search: { return_to: `/a/${shortId}` } })}
+                title="Sign in to comment"
+                data-testid="sign-in-to-comment"
+                className="absolute bottom-[18px] right-[18px] flex h-11 items-center gap-2 rounded-full border border-border bg-card px-4 text-sm font-semibold text-foreground shadow-[var(--shadow)]"
+              >
+                <Icon name="comments" size={18} />
+                Sign in to comment
+              </button>
+            )}
           </div>
 
           <ArtifactComments
             shortId={shortId}
             isMobile={isMobile}
             isAnon={isAnon}
+            canComment={canComment}
             docLive={docLive}
             panel={panel}
             asideWidth={asideWidth}

--- a/apps/web/src/pages/artifact/lib/comment-access.test.ts
+++ b/apps/web/src/pages/artifact/lib/comment-access.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+import { canCommentWithRole, shouldPromptSignInToComment } from "./comment-access"
+
+// The UI side of the access matrix (the API is the hard gate; these decide which
+// affordances render). Mirrors SECURITY.md and the core permissions matrix.
+describe("canCommentWithRole (write-affordance gate)", () => {
+  it("commenter and above may comment; viewer / no-access may not", () => {
+    expect(canCommentWithRole("owner")).toBe(true)
+    expect(canCommentWithRole("editor")).toBe(true)
+    expect(canCommentWithRole("commenter")).toBe(true)
+    expect(canCommentWithRole("viewer")).toBe(false)
+    expect(canCommentWithRole(null)).toBe(false)
+    expect(canCommentWithRole(undefined)).toBe(false)
+  })
+})
+
+describe("shouldPromptSignInToComment (anonymous CTA)", () => {
+  it("offers sign-in only to an anon visitor on a live comment-enabled link", () => {
+    expect(shouldPromptSignInToComment(true, "commenter", false)).toBe(true)
+  })
+  it("stays hidden when signing in wouldn't help, when signed in, or when removed", () => {
+    expect(shouldPromptSignInToComment(true, "viewer", false)).toBe(false) // view-only link
+    expect(shouldPromptSignInToComment(true, undefined, false)).toBe(false) // no general access
+    expect(shouldPromptSignInToComment(false, "commenter", false)).toBe(false) // already signed in
+    expect(shouldPromptSignInToComment(true, "commenter", true)).toBe(false) // tombstoned
+  })
+})

--- a/apps/web/src/pages/artifact/lib/comment-access.ts
+++ b/apps/web/src/pages/artifact/lib/comment-access.ts
@@ -1,0 +1,21 @@
+import type { GeneralRole, Role } from "@/api"
+
+/**
+ * The UI side of the access matrix (the API is the hard gate; these keep the UI from
+ * offering a comment action that would 403). Kept pure + standalone so the matrix is
+ * unit-tested directly.
+ */
+
+/** May a caller with this effective role create comments/replies? Mirrors the API's
+ *  `comment` gate: commenter or above. Drives every write affordance in the comment UI. */
+export const canCommentWithRole = (role: Role | null | undefined): boolean =>
+  role === "commenter" || role === "editor" || role === "owner"
+
+/** Should an anonymous visitor be offered "sign in to comment"? Only when the link's
+ *  general access actually grants comment (so signing in would lift them to commenter)
+ *  and the artifact is live. Anonymous never comments directly: auth is the gate. */
+export const shouldPromptSignInToComment = (
+  isAnon: boolean,
+  generalRole: GeneralRole | undefined,
+  removed: boolean,
+): boolean => isAnon && generalRole === "commenter" && !removed

--- a/apps/web/src/pages/artifact/lib/comment-scope.ts
+++ b/apps/web/src/pages/artifact/lib/comment-scope.ts
@@ -1,12 +1,19 @@
 import { createContext, useContext } from "react"
 
 /**
- * The artifact a comment composer belongs to, provided once by ArtifactComments
- * and read deep down by MentionField — so the @mention picker can scope its
- * directory to this thread's people without threading a prop through every
- * panel/card/composer in between. null when composing outside any artifact.
+ * Comment-tree scope, provided once by ArtifactComments and read deep down without
+ * threading props through every panel/card/composer:
+ *  - `shortId`: the artifact, so MentionField scopes its @mention directory to this
+ *    thread's people (null when composing outside any artifact).
+ *  - `canComment`: may the caller create comments/replies here? Gates every write
+ *    affordance (new-comment buttons, reply boxes). Reading is unaffected. The API is
+ *    the hard gate; this keeps the UI from offering a comment action that would 403.
+ *    Defaults true so non-artifact consumers are unaffected.
  */
-const CommentScopeContext = createContext<{ shortId: string | null }>({ shortId: null })
+const CommentScopeContext = createContext<{ shortId: string | null; canComment: boolean }>({
+  shortId: null,
+  canComment: true,
+})
 
 export const CommentScopeProvider = CommentScopeContext.Provider
 export const useCommentScope = () => useContext(CommentScopeContext)

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -20,6 +20,15 @@ export const Route = createFileRoute("/login")({
   validateSearch: (s: Record<string, unknown>): Record<string, string | boolean> => {
     const out: Record<string, string | boolean> = {}
     if (s.signup) out.signup = true
+    // Where to land after sign-in (e.g. the shared artifact whose "sign in to comment"
+    // CTA sent us here). Same-origin relative paths only — never `//host` or an absolute
+    // URL — so it can't be weaponized into an open redirect.
+    if (
+      typeof s.return_to === "string" &&
+      s.return_to.startsWith("/") &&
+      !s.return_to.startsWith("//")
+    )
+      out.return_to = s.return_to
     for (const k of OAUTH_KEYS) if (typeof s[k] === "string") out[k] = s[k] as string
     return out
   },

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS artifact (
     title TEXT,
     visibility TEXT NOT NULL DEFAULT 'link',
     password_hash TEXT,
+    general_role TEXT NOT NULL DEFAULT 'viewer',
     kind TEXT NOT NULL,
     spa INTEGER NOT NULL DEFAULT 0,
     current_version INTEGER NOT NULL DEFAULT 0,

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -12,6 +12,10 @@ import type { Visibility } from "./ports"
  */
 export type Role = "viewer" | "commenter" | "editor" | "owner"
 
+/** The roles general access (a shared link) can grant a reacher: view-only or comment.
+ *  A strict subset of Role — general access never hands out editor/owner. */
+export type GeneralRole = "viewer" | "commenter"
+
 /** What an actor wants to do. Kept coarse on purpose; `can()` is the only gate. */
 export type Action = "read" | "comment" | "propose" | "publish" | "approve" | "share" | "manage"
 
@@ -60,27 +64,49 @@ export interface Actor {
 }
 
 /**
- * The actor's effective role on an artifact of this visibility:
- *   per-artifact share  →  workspace membership  →  visibility floor.
- * null means no access at all.
+ * The actor's effective role on an artifact, the max of their explicit standing and
+ * the general-access floor:
+ *   per-artifact share  →  workspace membership  →  general-access floor (by reach).
+ * null means no access at all. This function is the single source of truth for the
+ * access matrix; SECURITY.md documents the same table for humans.
+ *
+ *   General access (the link)    Anonymous              Signed in via link    Member / share
+ *   ───────────────────────────  ─────────────────────  ────────────────────  ────────────────
+ *   link / public · view         view                   view                  their role (>= view)
+ *   link / public · comment      view (sign in to cmt)  view + comment        their role (>= cmt)
+ *   password · view|comment      unlock, then as above  unlock, then above    their role (no pw)
+ *   workspace only (org)         no access              no access             their role (members)
+ *
+ * Invariant: an anonymous caller is never more than `viewer`. Anything past view
+ * (comment, propose, publish, share, manage) needs an authenticated identity — a
+ * signed-in user or a `DOCK_TOKEN`. There is deliberately no "trusted anonymous" path.
  */
-export function effectiveRole(actor: Actor, visibility: Visibility): Role | null {
+export function effectiveRole(
+  actor: Actor,
+  visibility: Visibility,
+  generalRole: GeneralRole = "viewer",
+): Role | null {
   if (actor.kind === "token") return "owner"
-  if (actor.kind === "user") {
-    const explicit = actor.artifactRole ?? actor.orgRole
-    if (explicit) return explicit
-  }
-  // No membership / anonymous: public + link are world-readable as a viewer; a
-  // `password` artifact opens to a viewer only once the caller has unlocked it
-  // (entered the password). There is deliberately no "trusted anonymous" path —
-  // an unauthenticated caller can never be elevated to a writing role.
-  if (visibility === "public" || visibility === "link") return "viewer"
-  if (visibility === "password") return actor.unlocked ? "viewer" : null
-  return null
+  // A per-artifact share or workspace membership — authenticated callers only.
+  const explicit = actor.kind === "user" ? (actor.artifactRole ?? actor.orgRole) : null
+  // The general-access floor for a reacher with no higher explicit grant. Only an
+  // authenticated reacher gets the configured general role; an anonymous reacher is
+  // clamped to `viewer` — never elevated to a writing role without an account.
+  const reach: Role = actor.kind === "user" ? generalRole : "viewer"
+  let floor: Role | null = null
+  if (visibility === "public" || visibility === "link") floor = reach
+  else if (visibility === "password") floor = actor.unlocked ? reach : null
+  // org/private grant nothing by reach — only an explicit role opens them.
+  return maxRole(explicit, floor)
 }
 
 /** The one authorization gate. */
-export function can(actor: Actor, action: Action, visibility: Visibility): boolean {
-  const role = effectiveRole(actor, visibility)
+export function can(
+  actor: Actor,
+  action: Action,
+  visibility: Visibility,
+  generalRole: GeneralRole = "viewer",
+): boolean {
+  const role = effectiveRole(actor, visibility, generalRole)
   return role !== null && roleAllows(role, action)
 }

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -2,7 +2,7 @@
  * Core owns the ports; packages/db and packages/storage provide the adapters.
  * Everything here must run on Node AND Cloudflare Workers — no Node APIs.
  */
-import type { Role } from "./permissions"
+import type { GeneralRole, Role } from "./permissions"
 
 export interface BlobStore {
   /** Content-addressed put; returns the sha256 hex key. Idempotent. */
@@ -31,6 +31,10 @@ export interface ArtifactRecord {
   visibility: Visibility
   /** Salted hash of the unlock password for `password` visibility; null otherwise. */
   password_hash: string | null
+  /** The role general access (the link) grants a reacher with no higher explicit grant.
+   *  `viewer` (default) = view-only; `commenter` = authenticated reachers may comment.
+   *  Anonymous reachers are always clamped to `viewer` regardless (see effectiveRole). */
+  general_role: GeneralRole
   kind: ArtifactKind
   spa: 0 | 1
   current_version: number
@@ -79,6 +83,8 @@ export interface NewArtifact {
   visibility: Visibility
   /** Salted unlock-password hash; set only for `password` visibility. */
   password_hash?: string | null
+  /** General-access role; defaults to `viewer` (view-only) when omitted. */
+  general_role?: GeneralRole
   kind: ArtifactKind
   spa: 0 | 1
 }
@@ -95,12 +101,13 @@ export interface NewVersion {
 
 export interface MetaStore {
   createArtifact(a: NewArtifact): Promise<ArtifactRecord>
-  /** Change an artifact's general access (visibility), setting/clearing the unlock
-   *  password hash (null for any non-`password` visibility). */
+  /** Change an artifact's general access: visibility, the unlock password hash (null for
+   *  any non-`password` visibility), and the general-access role (view vs comment). */
   setVisibility(
     artifactId: string,
     visibility: Visibility,
     passwordHash: string | null,
+    generalRole: GeneralRole,
   ): Promise<void>
   getByShortId(shortId: string): Promise<ArtifactRecord | null>
   /** Load an artifact by its internal id (used by domain mode's host lookup). */

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -289,6 +289,7 @@ export const toJson = (baseUrl: string, a: ArtifactRecord, versions: VersionReco
   title: a.title,
   kind: a.kind,
   visibility: a.visibility,
+  general_role: a.general_role,
   spa: !!a.spa,
   current_version: a.current_version,
   created_at: a.created_at,

--- a/packages/core/test/permissions.test.ts
+++ b/packages/core/test/permissions.test.ts
@@ -63,3 +63,62 @@ describe("can", () => {
     expect(can({ kind: "anon" }, "comment", "link")).toBe(false)
   })
 })
+
+// The general-access (the link) comment grant, every cell of the access matrix. The
+// invariant under test: an anonymous reacher is NEVER more than viewer; the comment grant
+// only lifts a signed-in reacher to commenter. Mirrors the table in SECURITY.md.
+describe("general access comment grant (access matrix)", () => {
+  const anon: Actor = { kind: "anon" }
+  // A signed-in caller reaching purely via the link, with no explicit share/membership.
+  const reacher: Actor = { kind: "user", userId: "u9" }
+
+  it("view link: everyone reaching is viewer, nobody can comment", () => {
+    for (const v of ["link", "public"] as const) {
+      expect(effectiveRole(anon, v, "viewer")).toBe("viewer")
+      expect(effectiveRole(reacher, v, "viewer")).toBe("viewer")
+      expect(can(anon, "comment", v, "viewer")).toBe(false)
+      expect(can(reacher, "comment", v, "viewer")).toBe(false)
+    }
+  })
+
+  it("comment link: anon stays viewer (forced auth), a signed-in reacher becomes commenter", () => {
+    for (const v of ["link", "public"] as const) {
+      expect(effectiveRole(anon, v, "commenter")).toBe("viewer")
+      expect(can(anon, "comment", v, "commenter")).toBe(false) // anon never elevated
+      expect(can(anon, "read", v, "commenter")).toBe(true)
+      expect(effectiveRole(reacher, v, "commenter")).toBe("commenter")
+      expect(can(reacher, "comment", v, "commenter")).toBe(true)
+    }
+  })
+
+  it("the comment floor is a max with the explicit role, never a demotion", () => {
+    // A viewer-member is lifted to commenter by a comment link...
+    expect(effectiveRole({ kind: "user", orgRole: "viewer" }, "link", "commenter")).toBe(
+      "commenter",
+    )
+    // ...but a higher explicit role is untouched.
+    expect(effectiveRole({ kind: "user", orgRole: "editor" }, "link", "commenter")).toBe("editor")
+    expect(effectiveRole({ kind: "user", artifactRole: "owner" }, "link", "commenter")).toBe(
+      "owner",
+    )
+  })
+
+  it("password: the comment grant follows unlock, and never elevates anon", () => {
+    expect(effectiveRole(anon, "password", "commenter")).toBe(null) // locked
+    expect(effectiveRole({ kind: "anon", unlocked: true }, "password", "commenter")).toBe("viewer")
+    expect(can({ kind: "anon", unlocked: true }, "comment", "password", "commenter")).toBe(false)
+    expect(
+      effectiveRole({ kind: "user", userId: "u", unlocked: true }, "password", "commenter"),
+    ).toBe("commenter")
+  })
+
+  it("workspace-only (org) grants nothing by reach, regardless of the comment grant", () => {
+    expect(effectiveRole(anon, "org", "commenter")).toBe(null)
+    expect(effectiveRole(reacher, "org", "commenter")).toBe(null)
+  })
+
+  it("defaults to view-only when no general role is given (back-compat)", () => {
+    expect(effectiveRole(reacher, "link")).toBe("viewer")
+    expect(can(reacher, "comment", "link")).toBe(false)
+  })
+})

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -6,6 +6,7 @@ import type {
   DeliveryStatus,
   DomainKind,
   DomainStatus,
+  GeneralRole,
   NotificationKind,
   ProposalState,
   ReportState,
@@ -29,6 +30,7 @@ export const artifact = pgTable("artifact", {
   title: text("title"),
   visibility: text("visibility").$type<Visibility>().notNull().default("link"),
   password_hash: text("password_hash"),
+  general_role: text("general_role").$type<GeneralRole>().notNull().default("viewer"),
   kind: text("kind").$type<ArtifactKind>().notNull(),
   spa: integer("spa").$type<0 | 1>().notNull().default(0),
   current_version: integer("current_version").notNull().default(0),
@@ -322,6 +324,7 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
     title TEXT,
     visibility TEXT NOT NULL DEFAULT 'link',
     password_hash TEXT,
+    general_role TEXT NOT NULL DEFAULT 'viewer',
     kind TEXT NOT NULL,
     spa INTEGER NOT NULL DEFAULT 0,
     current_version INTEGER NOT NULL DEFAULT 0,
@@ -330,6 +333,7 @@ export const PG_SCHEMA_STATEMENTS: string[] = [
   )`,
   `ALTER TABLE artifact ADD COLUMN IF NOT EXISTS removed_at TEXT`,
   `ALTER TABLE artifact ADD COLUMN IF NOT EXISTS password_hash TEXT`,
+  `ALTER TABLE artifact ADD COLUMN IF NOT EXISTS general_role TEXT NOT NULL DEFAULT 'viewer'`,
   // Library feed: scope by org_id + keyset order on (created_at, id) desc. One
   // composite serves both; Postgres backward-scans it for the DESC order.
   `CREATE INDEX IF NOT EXISTS artifact_org_created ON artifact (org_id, created_at, id)`,

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -12,6 +12,7 @@ import type {
   DeliveryStatus,
   DomainRecord,
   DomainStatus,
+  GeneralRole,
   ListArtifactsOpts,
   MembershipRecord,
   MetaStore,
@@ -183,10 +184,11 @@ export class PgMetaStore implements MetaStore {
     artifactId: string,
     visibility: Visibility,
     passwordHash: string | null,
+    generalRole: GeneralRole,
   ): Promise<void> {
     await this.db
       .update(artifact)
-      .set({ visibility, password_hash: passwordHash })
+      .set({ visibility, password_hash: passwordHash, general_role: generalRole })
       .where(eq(artifact.id, artifactId))
   }
 

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -12,6 +12,7 @@ import type {
   DeliveryStatus,
   DomainRecord,
   DomainStatus,
+  GeneralRole,
   ListArtifactsOpts,
   MembershipRecord,
   NewAgent,
@@ -232,10 +233,11 @@ export function makeRepos(db: SqliteDb) {
     artifactId: string,
     visibility: Visibility,
     passwordHash: string | null,
+    generalRole: GeneralRole,
   ): Promise<void> => {
     await db
       .update(artifact)
-      .set({ visibility, password_hash: passwordHash })
+      .set({ visibility, password_hash: passwordHash, general_role: generalRole })
       .where(eq(artifact.id, artifactId))
       .run()
   }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -6,6 +6,7 @@ import type {
   DeliveryStatus,
   DomainKind,
   DomainStatus,
+  GeneralRole,
   NotificationKind,
   ProposalState,
   ReportState,
@@ -28,6 +29,10 @@ export const artifact = sqliteTable("artifact", {
   title: text("title"),
   visibility: text("visibility").$type<Visibility>().notNull().default("link"),
   password_hash: text("password_hash"),
+  // The role general access (the link) grants a reacher with no higher explicit
+  // grant. viewer = view-only (default); commenter = authed reachers may comment
+  // (anonymous reachers are always clamped to viewer — see effectiveRole).
+  general_role: text("general_role").$type<GeneralRole>().notNull().default("viewer"),
   kind: text("kind").$type<ArtifactKind>().notNull(),
   spa: integer("spa").$type<0 | 1>().notNull().default(0),
   current_version: integer("current_version").notNull().default(0),
@@ -351,6 +356,7 @@ export const SCHEMA_STATEMENTS: string[] = [
     title TEXT,
     visibility TEXT NOT NULL DEFAULT 'link',
     password_hash TEXT,
+    general_role TEXT NOT NULL DEFAULT 'viewer',
     kind TEXT NOT NULL,
     spa INTEGER NOT NULL DEFAULT 0,
     current_version INTEGER NOT NULL DEFAULT 0,
@@ -620,6 +626,7 @@ export const MIGRATION_STATEMENTS: string[] = [
   `ALTER TABLE proposal ADD COLUMN decision_note TEXT`,
   `ALTER TABLE artifact ADD COLUMN removed_at TEXT`,
   `ALTER TABLE artifact ADD COLUMN password_hash TEXT`,
+  `ALTER TABLE artifact ADD COLUMN general_role TEXT NOT NULL DEFAULT 'viewer'`,
   `ALTER TABLE version ADD COLUMN size_bytes INTEGER NOT NULL DEFAULT 0`,
   `ALTER TABLE webhook ADD COLUMN org_id TEXT NOT NULL DEFAULT 'default'`,
   `ALTER TABLE report ADD COLUMN org_id TEXT NOT NULL DEFAULT 'default'`,

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -111,12 +111,20 @@ export function runStoreContract(
       expect(await store.listArtifacts({ ids: [] })).toEqual([])
     })
 
-    it("changes visibility (sets/clears the password hash)", async () => {
+    it("changes visibility + general-access role (sets/clears the password hash)", async () => {
       const a = await store.createArtifact(newArtifact())
-      await store.setVisibility(a.id, "password", "hash123")
+      expect(a.general_role).toBe("viewer") // defaults to view-only
+      await store.setVisibility(a.id, "password", "hash123", "viewer")
       expect(await store.getByShortId(a.short_id)).toMatchObject({ visibility: "password" })
-      await store.setVisibility(a.id, "link", null)
-      expect(await store.getByShortId(a.short_id)).toMatchObject({ visibility: "link" })
+      // Flip to a comment link: visibility + general_role both round-trip.
+      await store.setVisibility(a.id, "link", null, "commenter")
+      expect(await store.getByShortId(a.short_id)).toMatchObject({
+        visibility: "link",
+        general_role: "commenter",
+      })
+      // And back to view-only.
+      await store.setVisibility(a.id, "link", null, "viewer")
+      expect((await store.getByShortId(a.short_id))?.general_role).toBe("viewer")
     })
 
     it("counts storage bytes once per distinct blob (content-addressed)", async () => {


### PR DESCRIPTION
General access (the shared link) was view-only. It can now grant **comment** too, with a hard least-privilege rule: **only an authenticated caller ever rises above view.** An anonymous (no-account) reacher is always clamped to viewer; to comment they must sign in. Anything past view (comment, propose, publish, share, manage) requires auth.

## The access matrix
| General access (the link)        | Anonymous (no account)         | Signed in via link (no explicit grant) | Member / explicit share        |
|----------------------------------|--------------------------------|----------------------------------------|--------------------------------|
| Anyone with link, **view**       | View                           | View                                   | Their role (at least view)     |
| Anyone with link, **comment**    | View only (sign in to comment) | View + comment                         | Their role (at least comment)  |
| Public (listed), view/comment    | same as link row               | same as link row                       | Their role                     |
| Password, view/comment           | Unlock, then as above          | Unlock, then as above                  | Their role (no password needed)|
| Workspace only (org)             | No access                      | No access                              | Their role (members only)      |

`packages/core/src/permissions.ts` (`effectiveRole`) is the single source of truth, documented there + in `SECURITY.md` + `ARCHITECTURE.md`.

## The change
- **db**: `general_role` (viewer|commenter, default viewer) on artifact — sqlite + pg schema, forward-only ALTERs, repos/pg `setVisibility`, regenerated `deploy/d1-schema.sql` (the edge `apply-d1-schema` step diff-applies it to live D1).
- **core**: `effectiveRole(actor, visibility, generalRole)` becomes `maxRole(explicit, floor)`, where the reach floor is the general role for an authenticated reacher but always `viewer` for an anonymous one. Behavior-preserving for every prior case.
- **api**: `authorize` threads `artifact.general_role` (covers the comment POST and every route); GET returns `general_role` + `my_role`; PATCH `/visibility` accepts/persists `generalRole`.
- **web**: ShareDialog view/comment selector on the general-access row; the comment composer + reply affordances gate on `canComment` (via the comment-scope context), so no comment action shows to someone who can't comment; an anonymous visitor on a comment link gets a **"Sign in to comment"** CTA that returns here after login (`return_to`, validated same-origin).

## Enforced at every layer (full test matrix)
- **core** `permissions.test.ts`: every cell (anon vs signed-in reacher vs member; view/comment; link/public/password/org; the max-not-demote rule; the anon clamp).
- **api** `comment-access.test.ts`: comment/read per actor x visibility x grant — signed-in reacher comments on a comment link, anonymous is 403 even there, the grant persists + drives `my_role`, revoking re-locks.
- **web** `lib/comment-access.test.ts`: the UI gating helpers (`canCommentWithRole`, `shouldPromptSignInToComment`).
- **store** contract: `general_role` round-trips through `setVisibility`.

Verification: `pnpm typecheck`, full `pnpm test` (core 66, api 320, web 51, db 48, +storage/cli/mcp), `pnpm --filter @dock/db gen:d1-schema` clean, and `pnpm run ci` (biome + knip + guards) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)