### PR TITLE
Fix workspace scoping: collection listing, favorites count, card overflow

### DIFF
--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -6,6 +6,7 @@ import {
   type BlobStore,
   BUNDLE_CONTENT_TYPE,
   type BundleManifest,
+  type CollectionRecord,
   can,
   DEFAULT_VERSION_WINDOW_MS,
   type MetaStore,
@@ -620,6 +621,17 @@ export function buildContext(deps: AppDeps) {
     return data ? new TextDecoder().decode(data) : null
   }
 
+  // A caller's role on a collection: the static token is owner; otherwise the
+  // creator, else their explicit collection-member role, else null (no access).
+  // Shared by the collections routes and the artifact listing (collection scoping).
+  const collectionRole = async (c: Context, col: CollectionRecord): Promise<Role | null> => {
+    if (deps.token && safeEqual(bearer(c), deps.token)) return "owner"
+    const me = await currentUser(c)
+    if (!me) return null
+    if (col.created_by === me.id) return "owner"
+    return (await meta.getCollectionMember(col.id, me.id))?.role ?? null
+  }
+
   return {
     deps,
     meta,
@@ -655,6 +667,7 @@ export function buildContext(deps: AppDeps) {
     isSuperAdmin,
     workspaceRole,
     workspaceCan,
+    collectionRole,
     sourceText,
   }
 }

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -45,6 +45,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     actorFor,
     authorize,
     workspaceCan,
+    collectionRole,
     limited,
     overStorage,
     publishLimiter,
@@ -91,18 +92,36 @@ export const artifactRoutes = (ctx: AppContext) => {
       narrow(await meta.artifactIdsSharedWith(me.id))
     }
     if (tag) narrow(await meta.artifactIdsByTag(tag))
-    if (collectionId) narrow(await meta.collectionArtifactIds(collectionId))
     if (favOnly) narrow(favIds)
+
+    // A collection's artifacts live in the COLLECTION's workspace, not necessarily
+    // your active one — so scope the listing to the collection's org (gated by
+    // access), or a direct/cold link to a collection in another workspace reads as
+    // empty. Unknown collection ⇒ nothing.
+    let listOrg = await activeWorkspace(c)
+    let collectionAccess = false
+    if (collectionId) {
+      const col = await meta.getCollection(collectionId)
+      if (!col) return c.json({ artifacts: [], next_cursor: null })
+      narrow(await meta.collectionArtifactIds(collectionId))
+      listOrg = col.org_id
+      collectionAccess =
+        (deps.token && safeEqual(bearer(c), deps.token)) ||
+        (!!me && !!(await meta.getMembership(col.org_id, me.id))) ||
+        (await collectionRole(c, col)) !== null
+    }
     if (ids && ids.length === 0) return c.json({ artifacts: [], next_cursor: null })
 
-    const orgId = await activeWorkspace(c)
     // A listing only shows non-public artifacts to a MEMBER of that workspace (or the
     // operator token). Anyone else — anonymous, or a signed-in user who isn't a member
     // — sees public artifacts only, so org/link titles never leak via the list or ?q=.
-    const publicOnly = !(
-      (deps.token && safeEqual(bearer(c), deps.token)) ||
-      (!!me && !!(await meta.getMembership(orgId, me.id)))
-    )
+    // For a collection, collection access (member/creator/share) also unlocks it.
+    const publicOnly = collectionId
+      ? !collectionAccess
+      : !(
+          (deps.token && safeEqual(bearer(c), deps.token)) ||
+          (!!me && !!(await meta.getMembership(listOrg, me.id)))
+        )
     const rows = await meta.listArtifacts({
       limit: limit + 1,
       cursor,
@@ -110,7 +129,7 @@ export const artifactRoutes = (ctx: AppContext) => {
       ids,
       // Shared-with-me spans workspaces; an explicit member can always see them, so
       // drop the workspace + public-only restrictions for that scope.
-      orgId: shared ? undefined : orgId,
+      orgId: shared ? undefined : listOrg,
       publicOnly: shared ? false : publicOnly,
     })
     const hasMore = rows.length > limit
@@ -150,7 +169,10 @@ export const artifactRoutes = (ctx: AppContext) => {
     const [total, tags, favIds, ws] = await Promise.all([
       meta.countArtifacts(org),
       meta.tagCounts(org),
-      me ? meta.listUserFavoriteIds(me.id) : Promise.resolve([]),
+      // Scope the favorites count to THIS workspace's live artifacts — the favorites
+      // view is workspace-scoped, so a favorite of an artifact in another workspace
+      // must not inflate the count (otherwise "Favorites · 1" with an empty list).
+      me ? meta.listUserFavoriteIds(me.id, org) : Promise.resolve([]),
       meta.getWorkspace(org),
     ])
     tags.sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -100,11 +100,15 @@ export const artifactRoutes = (ctx: AppContext) => {
     // empty. Unknown collection ⇒ nothing.
     let listOrg = await activeWorkspace(c)
     let collectionAccess = false
+    // Carry the collection's title so the client can label the view even when the
+    // collection lives in another workspace (it's absent from the local sidebar list).
+    let collectionInfo: { id: string; title: string } | undefined
     if (collectionId) {
       const col = await meta.getCollection(collectionId)
       if (!col) return c.json({ artifacts: [], next_cursor: null })
       narrow(await meta.collectionArtifactIds(collectionId))
       listOrg = col.org_id
+      collectionInfo = { id: col.id, title: col.title }
       collectionAccess =
         (deps.token && safeEqual(bearer(c), deps.token)) ||
         (!!me && !!(await meta.getMembership(col.org_id, me.id))) ||
@@ -148,6 +152,7 @@ export const artifactRoutes = (ctx: AppContext) => {
         favorite: favorites.has(a.id),
       })),
       next_cursor,
+      ...(collectionInfo ? { collection: collectionInfo } : {}),
     })
   })
 

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -16,19 +16,18 @@ import { resolveUserRef } from "../lib/resolve-user"
 /** Collections: shareable groups of artifacts. A member's role on a collection
  *  propagates to every artifact inside it (see collectionRolesForArtifact). */
 export const collectionRoutes = (ctx: AppContext) => {
-  const { meta, deps, bearer, currentUser, activeWorkspace, workspaceCan, authorize } = ctx
+  const {
+    meta,
+    deps,
+    bearer,
+    currentUser,
+    activeWorkspace,
+    workspaceCan,
+    authorize,
+    collectionRole,
+  } = ctx
   const app = new Hono()
 
-  // A user's role on a collection: the static token is owner; otherwise the
-  // creator/member role. Anonymous (no session) has no role — never elevated.
-  const collectionRole = async (c: Context, col: CollectionRecord): Promise<Role | null> => {
-    if (deps.token && safeEqual(bearer(c), deps.token)) return "owner"
-    const me = await currentUser(c)
-    if (!me) return null
-    if (col.created_by === me.id) return "owner"
-    const m = await meta.getCollectionMember(col.id, me.id)
-    return m?.role ?? null
-  }
   const canManageCollection = async (c: Context, col: CollectionRecord, action: Action) =>
     roleAllows((await collectionRole(c, col)) ?? "viewer", action)
 

--- a/apps/api/test/workspace-scoping.test.ts
+++ b/apps/api/test/workspace-scoping.test.ts
@@ -1,0 +1,95 @@
+import { beforeAll, describe, expect, it } from "vitest"
+import { as, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// Listing/counting must stay consistent with workspace scoping: a collection's
+// artifacts live in the COLLECTION's workspace, and the favorites count must match
+// the (workspace-scoped) favorites list. Regression tests for the two scoping bugs.
+describe("workspace scoping: collections + favorites", () => {
+  const owner: TestUser = { id: "u_ws_owner", email: "owner@ws.test", name: "Owner" }
+  const outsider: TestUser = { id: "u_ws_out", email: "out@ws.test", name: "Outsider" }
+  // Both seed into the shared "default" workspace (owner = admin); their ACTIVE
+  // workspace (no cookie) is "default".
+  const { app, meta } = makeAuthedApp("ws-scoping", [owner, outsider])
+
+  // A second workspace B with one artifact + a collection holding it. owner is a
+  // member of B; outsider is not. Seeded once for the whole describe.
+  const colId = "col_inB"
+  beforeAll(async () => {
+    await meta.setWorkspace("wsB", "Workspace B")
+    await meta.setMembership({ id: "m_wsB_owner", org_id: "wsB", user_id: owner.id, role: "owner" })
+    const art = await meta.createArtifact({
+      id: "a_inB",
+      short_id: "binb01",
+      org_id: "wsB",
+      slug: null,
+      title: "Doc in B",
+      visibility: "link",
+      kind: "file",
+      spa: 0,
+    })
+    await meta.addVersion(art.id, {
+      id: "v_inB",
+      blob_key: "k_inB",
+      content_type: "text/html",
+      size_bytes: 1,
+      author: "Owner",
+      message: null,
+    })
+    const col = await meta.createCollection({
+      id: "col_inB",
+      org_id: "wsB",
+      title: "B Collection",
+      created_by: owner.id,
+    })
+    await meta.addCollectionItem(col.id, art.id)
+  })
+
+  it("loads a collection's artifacts from the collection's workspace, regardless of active ws", async () => {
+    // owner's active workspace is "default", but the collection lives in wsB. The
+    // listing must scope to wsB (it used to scope to the active ws → empty).
+    const res = await app.request(`/v1/artifacts?collection=${colId}`, { headers: as(owner.email) })
+    expect(res.status).toBe(200)
+    const ids = (await res.json()).artifacts.map((a: { short_id: string }) => a.short_id)
+    expect(ids).toContain("binb01")
+
+    // in-collection search (?q=) works the same way.
+    const res2 = await app.request(`/v1/artifacts?collection=${colId}&q=Doc%20in%20B`, {
+      headers: as(owner.email),
+    })
+    expect((await res2.json()).artifacts.map((a: { short_id: string }) => a.short_id)).toContain(
+      "binb01",
+    )
+
+    // outsider isn't a member of wsB and holds no collection share → no non-public
+    // artifacts (the "link"-visibility doc is hidden).
+    const res3 = await app.request(`/v1/artifacts?collection=${colId}`, {
+      headers: as(outsider.email),
+    })
+    expect((await res3.json()).artifacts).toEqual([])
+
+    // unknown collection id → empty, not a crash.
+    const res4 = await app.request(`/v1/artifacts?collection=col_nope`, {
+      headers: as(owner.email),
+    })
+    expect((await res4.json()).artifacts).toEqual([])
+  })
+
+  it("favorites count matches the workspace-scoped list (no cross-workspace inflation)", async () => {
+    // Favorite the wsB artifact while active in "default".
+    await meta.setFavorite("a_inB", owner.id)
+    // Publish + favorite an artifact in the active ("default") workspace.
+    const here = await (await publishAs(app, "<h1>here</h1>", {}, as(owner.email))).json()
+    await meta.setFavorite((await meta.getByShortId(here.short_id))?.id ?? "", owner.id)
+
+    // /v1/tags is the active workspace's summary → counts only the default-ws favorite.
+    const tags = await (await app.request("/v1/tags", { headers: as(owner.email) })).json()
+    expect(tags.favorites).toBe(1)
+
+    // …and that count equals the favorites list length (the bug was count=2, list=1).
+    const list = await (
+      await app.request("/v1/artifacts?favorite=true", { headers: as(owner.email) })
+    ).json()
+    expect(list.artifacts).toHaveLength(1)
+    expect(list.artifacts[0].short_id).toBe(here.short_id)
+  })
+})

--- a/apps/api/test/workspace-scoping.test.ts
+++ b/apps/api/test/workspace-scoping.test.ts
@@ -49,8 +49,11 @@ describe("workspace scoping: collections + favorites", () => {
     // listing must scope to wsB (it used to scope to the active ws → empty).
     const res = await app.request(`/v1/artifacts?collection=${colId}`, { headers: as(owner.email) })
     expect(res.status).toBe(200)
-    const ids = (await res.json()).artifacts.map((a: { short_id: string }) => a.short_id)
-    expect(ids).toContain("binb01")
+    const body = await res.json()
+    expect(body.artifacts.map((a: { short_id: string }) => a.short_id)).toContain("binb01")
+    // The response carries the collection's title so the view can label itself even
+    // for a collection in another workspace (not in the active sidebar list).
+    expect(body.collection).toMatchObject({ id: colId, title: "B Collection" })
 
     // in-collection search (?q=) works the same way.
     const res2 = await app.request(`/v1/artifacts?collection=${colId}&q=Doc%20in%20B`, {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -383,7 +383,13 @@ export const api = {
     scope?: "shared"
     cursor?: string
     limit?: number
-  }): Promise<{ artifacts: Artifact[]; next_cursor: string | null }> => {
+  }): Promise<{
+    artifacts: Artifact[]
+    next_cursor: string | null
+    /** Present when listing by `collection` — the collection's id + title, so the
+     *  view can label itself even for a collection in another workspace. */
+    collection?: { id: string; title: string }
+  }> => {
     const qs = new URLSearchParams()
     if (params?.q) qs.set("q", params.q)
     if (params?.tag) qs.set("tag", params.tag)

--- a/apps/web/src/pages/library/artifact-card.tsx
+++ b/apps/web/src/pages/library/artifact-card.tsx
@@ -95,9 +95,9 @@ export function ArtifactCard({
         onMouseEnter={onPrefetch}
         onFocus={onPrefetch}
         aria-label={`Open ${a.title ?? a.short_id}`}
-        className="flex w-full flex-col gap-1.5 text-left outline-none after:absolute after:inset-0 after:z-[1] after:rounded-lg after:content-[''] focus-visible:after:outline-2 focus-visible:after:-outline-offset-2 focus-visible:after:outline-ring"
+        className="flex w-full min-w-0 flex-col gap-1.5 text-left outline-none after:absolute after:inset-0 after:z-[1] after:rounded-lg after:content-[''] focus-visible:after:outline-2 focus-visible:after:-outline-offset-2 focus-visible:after:outline-ring"
       >
-        <span className="font-display text-lg font-semibold text-foreground transition-colors group-hover:text-primary">
+        <span className="truncate font-display text-lg font-semibold text-foreground transition-colors group-hover:text-primary">
           {a.title ?? a.short_id}
         </span>
         <span className="flex items-center gap-2 font-mono text-xs text-muted-foreground">

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -137,6 +137,11 @@ function LibraryBody() {
 
   const activeCollection =
     filter.kind === "collection" ? collections.find((c) => c.id === filter.id) : undefined
+  // The collection's name from the sidebar list, falling back to the title the list
+  // response carries — so a collection in another workspace still shows its real name
+  // (not the generic "Collection") rather than relying on the active-workspace list.
+  const collectionTitle =
+    activeCollection?.title ?? data?.pages?.[0]?.collection?.title ?? "Collection"
   const heading =
     filter.kind === "all"
       ? "All artifacts"
@@ -144,7 +149,7 @@ function LibraryBody() {
         ? "Favorites"
         : filter.kind === "tag"
           ? `#${filter.tag}`
-          : filter.title
+          : collectionTitle
   const headingCount = debouncedQ
     ? items.length
     : filter.kind === "all"
@@ -259,7 +264,7 @@ function LibraryBody() {
                 `#${filter.tag}`
               ) : (
                 <>
-                  <Icon name="collection" size={15} /> {filter.title}
+                  <Icon name="collection" size={15} /> {collectionTitle}
                 </>
               )}
               <X />

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -239,8 +239,9 @@ export interface MetaStore {
   removeArtifactMember(artifactId: string, userId: string): Promise<void>
 
   // ---- Favorites (per-user stars) + tags (browse metadata) ---------------
-  /** Artifact ids this user has starred. */
-  listUserFavoriteIds(userId: string): Promise<string[]>
+  /** Artifact ids this user has starred. With `orgId`, scoped to that workspace's
+   *  live (non-removed) artifacts — for the workspace-scoped favorites count. */
+  listUserFavoriteIds(userId: string, orgId?: string): Promise<string[]>
   setFavorite(artifactId: string, userId: string): Promise<void>
   removeFavorite(artifactId: string, userId: string): Promise<void>
   /** Tags per artifact, batched (no N+1). Missing ids map to no entry. */

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -585,7 +585,23 @@ export class PgMetaStore implements MetaStore {
   }
 
   // ---- Favorites + tags --------------------------------------------------
-  async listUserFavoriteIds(userId: string): Promise<string[]> {
+  async listUserFavoriteIds(userId: string, orgId?: string): Promise<string[]> {
+    // With orgId, join to the artifact so the count reflects only live artifacts in
+    // that workspace (a favorite of a removed or other-workspace artifact is dropped).
+    if (orgId !== undefined) {
+      const rows = await this.db
+        .select({ id: artifactFavorite.artifact_id })
+        .from(artifactFavorite)
+        .innerJoin(artifact, eq(artifact.id, artifactFavorite.artifact_id))
+        .where(
+          and(
+            eq(artifactFavorite.user_id, userId),
+            eq(artifact.org_id, orgId),
+            isNull(artifact.removed_at),
+          ),
+        )
+      return rows.map((r) => r.id)
+    }
     const rows = await this.db
       .select({ id: artifactFavorite.artifact_id })
       .from(artifactFavorite)

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -559,14 +559,32 @@ export function makeRepos(db: SqliteDb) {
   }
 
   // ---- Favorites + tags --------------------------------------------------
-  const listUserFavoriteIds = async (userId: string): Promise<string[]> =>
-    (
+  const listUserFavoriteIds = async (userId: string, orgId?: string): Promise<string[]> => {
+    // With orgId, join to the artifact so the count reflects only live artifacts in
+    // that workspace (a favorite of a removed or other-workspace artifact is dropped).
+    if (orgId !== undefined) {
+      const rows = await db
+        .select({ id: artifactFavorite.artifact_id })
+        .from(artifactFavorite)
+        .innerJoin(artifact, eq(artifact.id, artifactFavorite.artifact_id))
+        .where(
+          and(
+            eq(artifactFavorite.user_id, userId),
+            eq(artifact.org_id, orgId),
+            isNull(artifact.removed_at),
+          ),
+        )
+        .all()
+      return rows.map((r) => r.id)
+    }
+    return (
       await db
         .select({ id: artifactFavorite.artifact_id })
         .from(artifactFavorite)
         .where(eq(artifactFavorite.user_id, userId))
         .all()
     ).map((r) => r.id)
+  }
   const setFavorite = async (artifactId: string, userId: string): Promise<void> => {
     await db
       .insert(artifactFavorite)


### PR DESCRIPTION
## What

Three workspace-scoping bugs in the artifact list/summary, all the same shape — what was *counted/linked* didn't match what was *listed*:

- **Collection link / in-collection search returned empty** unless you were already in the collection's workspace. Collection items live in the collection's `org_id`, but `GET /v1/artifacts` scoped results to your *active* workspace. Now: when a collection is requested, the listing scopes to the **collection's** `org_id`, gated by access (workspace member, operator token, or collection creator/member). Direct links + `?q=` search now work from any workspace. The response also carries the collection's `{id, title}` so the view shows its real name even when it lives in another workspace.
- **Favorites showed "· N" but listed nothing** — the count (`listUserFavoriteIds(me.id)`) was user-wide across all workspaces while the list is workspace-scoped, so a favorite of an artifact in another workspace (confirmed: one in org `default`) inflated the count. `listUserFavoriteIds(userId, orgId)` now joins to live artifacts in that workspace; `/v1/tags` passes the active workspace.
- **Long card titles overflowed** the card — `truncate` + `min-w-0`.

`collectionRole` moved into `AppContext` so the list route and collections route share one access gate.

## Verified
- New `apps/api/test/workspace-scoping.test.ts`: cross-workspace collection listing + title + non-member denial + favorites count == list.
- Background audit of every route: 0 leaks, 0 cross-workspace violations, 0 count/list mismatches.
- Deep local two-workspace run (API + browser): lists/search/favorites/collections all correctly scoped; cross-workspace collection link loads its artifacts + real name.

Full suite green (api 49 files); typecheck + lint clean. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)