### PR TITLE
feat(sync): server-side GitHub sync with a giant, explicit progress bar

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Pre-commit: the fast half of CI's "check" job — biome (lint + format +
+# organize-imports) plus the custom guardrails — so a format/import/testid slip is
+# caught here instead of on a red CI run. Typecheck, tests, and knip stay in CI
+# (too slow to run on every commit).
+#
+# Enabled automatically via the package.json "prepare" script
+# (git config core.hooksPath .githooks) on `pnpm install`.
+if ! pnpm run precommit; then
+  echo ""
+  echo "✖ pre-commit checks failed. Auto-fix formatting + imports with:"
+  echo "    pnpm check:fix"
+  echo "then re-stage and commit. (Emergency bypass: git commit --no-verify)"
+  exit 1
+fi

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -163,6 +163,13 @@ export interface AppDeps {
    * Unset (e.g. tests) = no poke; the interval/cron backstop still drains the outbox.
    */
   pokeWebhooks?: () => void
+  /**
+   * Run a triggered GitHub sync server-side so it survives the user closing the tab.
+   * The edge entry pokes the per-source `RepoSyncRunner` Durable Object; the Node entry
+   * kicks a detached batch-loop. Unset (e.g. tests) ⇒ the route falls back to running
+   * the sync inline to completion, so a "Sync now" still finishes within the request.
+   */
+  startSync?: (sourceId: string) => void
 }
 
 /**

--- a/apps/api/src/lib/sync-runner.ts
+++ b/apps/api/src/lib/sync-runner.ts
@@ -1,0 +1,87 @@
+// Shared sync orchestration, decoupled from the HTTP route so the same code runs
+// the sync from: (1) the route (when no background runner is wired — tests/dev),
+// (2) the RepoSyncRunner Durable Object (Workers), and (3) the Node detached loop.
+// One bounded batch at a time; the caller loops until `remaining === 0`.
+
+import type { BlobStore, MetaStore, RepoSourceRecord } from "@dock/core"
+import { decryptSecret } from "./crypto"
+import { GitHubError } from "./github"
+import { installationToken } from "./github-app"
+import { MAX_UPLOAD_BYTES } from "./http"
+import { runSync, type SyncResult } from "./sync"
+
+/** Publishes per batch — bounds one run to a Worker/alarm budget. */
+export const SYNC_BATCH = 50
+
+/** No-op storage gate (background runs skip the workspace byte cap; the per-file
+ *  cap + the artifact-count cap at trigger time still apply). */
+const NO_STORAGE_LIMIT = async (): Promise<boolean> => false
+
+/** The read token for a source: a freshly-minted installation token (App path) or
+ *  the decrypted PAT (BYO path). Null when neither applies (a public repo). */
+export async function effectiveToken(
+  meta: MetaStore,
+  encryptionKey: string | undefined,
+  source: RepoSourceRecord,
+): Promise<string | null> {
+  if (source.installation_id) {
+    const app = encryptionKey ? await meta.getGithubApp() : null
+    if (!app || !encryptionKey)
+      throw new GitHubError(400, "GitHub App is not configured on this instance")
+    return installationToken(
+      app.app_id,
+      decryptSecret(app.private_key, encryptionKey),
+      source.installation_id,
+    )
+  }
+  return source.token && encryptionKey ? decryptSecret(source.token, encryptionKey) : source.token
+}
+
+/** Run ONE bounded batch for a source. Returns the result (incl. `remaining`). */
+export async function runSourceBatch(
+  meta: MetaStore,
+  blobs: BlobStore,
+  encryptionKey: string | undefined,
+  source: RepoSourceRecord,
+  overStorage: (incoming: number) => Promise<boolean> = NO_STORAGE_LIMIT,
+): Promise<SyncResult> {
+  const token = await effectiveToken(meta, encryptionKey, source)
+  return runSync(meta, blobs, { ...source, token }, new Date().toISOString(), {
+    maxBytes: MAX_UPLOAD_BYTES,
+    maxFiles: SYNC_BATCH,
+    overStorage,
+  })
+}
+
+/**
+ * Drive a source to completion: re-load it each batch (its file map grows) and run
+ * batches until nothing remains. Used by the Node detached loop and as the inline
+ * fallback in the route. The DO instead runs ONE batch per alarm (so it never holds
+ * a long-running task) — both reach the same end state because progress + the file
+ * map persist every batch. `maxBatches` is a runaway backstop.
+ */
+export async function runToCompletion(
+  meta: MetaStore,
+  blobs: BlobStore,
+  encryptionKey: string | undefined,
+  sourceId: string,
+  maxBatches = 500,
+): Promise<void> {
+  for (let i = 0; i < maxBatches; i++) {
+    const source = await meta.getRepoSource(sourceId)
+    if (!source) return
+    const res = await runSourceBatch(meta, blobs, encryptionKey, source)
+    if (res.remaining === 0) return
+  }
+}
+
+/** Is a source mid-sync? (drives the global "syncing" chip + Node restart-resume.) */
+export const isSyncing = (s: RepoSourceRecord): boolean => {
+  if (!s.progress) return false
+  try {
+    const phase = (JSON.parse(s.progress) as { phase?: string }).phase
+    return phase === "queued" || phase === "listing" || phase === "mirroring"
+  } catch {
+    return false
+  }
+}

--- a/apps/api/src/lib/sync.ts
+++ b/apps/api/src/lib/sync.ts
@@ -4,6 +4,7 @@ import {
   type MetaStore,
   publish,
   type RepoSourceRecord,
+  type SyncProgress,
 } from "@dock/core"
 import { zipSync } from "fflate"
 import { type BundlePlan, commonDir, planBundle } from "./bundle-from-repo"
@@ -158,20 +159,46 @@ export async function runSync(
       last_status: status,
     })
   }
-  // Count a publish and, every PROGRESS_EVERY, flush the partial map + a live
-  // "syncing N…" status. This makes the run incrementally durable (a killed run
-  // leaves a consistent map, never orphan artifacts) AND lets the UI poll progress.
+  // Live, pollable progress (the UI bar + global chip). `total` is set once the
+  // tree is listed; `done` is the size of the (incrementally persisted) map. Floored
+  // at the carried-forward count so a multi-batch sync never bounces backward: each
+  // batch starts with `next` empty but `prev` already holding the prior batches'
+  // work, so without the floor the bar would snap 50→0→100→0 between batches.
+  const prevCount = Object.keys(prev).length
+  let total = 0
+  const writeProgress = (phase: SyncProgress["phase"], message?: string) =>
+    meta.setRepoSourceProgress(
+      source.id,
+      JSON.stringify({
+        phase,
+        done: Math.max(Object.keys(next).length, prevCount),
+        total,
+        ...(message ? { message } : {}),
+        updatedAt: now,
+      } satisfies SyncProgress),
+    )
+
+  // Count a publish and, every PROGRESS_EVERY, flush the partial map + live status
+  // + progress. Incrementally durable (a killed run leaves a consistent map, never
+  // orphan artifacts) AND lets the UI poll a precise bar.
   const PROGRESS_EVERY = 15
   const onPublished = async () => {
     processed++
-    if (processed % PROGRESS_EVERY === 0) await persist(`syncing ${processed} files…`)
+    if (processed % PROGRESS_EVERY === 0) {
+      await persist(`syncing ${processed} files…`)
+      await writeProgress("mirroring")
+    }
   }
 
   try {
+    // First batch of a fresh source: show "connecting/listing" before the count.
+    if (Object.keys(prev).length === 0) await writeProgress("listing")
     const { entries, truncated } = await listTree(repo, source.ref, source.token)
     const shaByPath = new Map(entries.map((e) => [e.path, e.sha]))
     const docs = entries.filter((e) => matchesGlobs(e.path, globs))
     const docPaths = new Set(docs.map((d) => d.path))
+    total = docs.length
+    await writeProgress("mirroring")
 
     // Fetch + cache repo bytes by path (one fetch per blob across both phases).
     const byteCache = new Map<string, Uint8Array>()
@@ -414,10 +441,14 @@ export async function runSync(
         : "ok"
     if (tooLarge.length) status += ` (${tooLarge.length} file(s) skipped: too large or over quota)`
     await persist(status)
+    // Still "mirroring" while batches remain; "done" once the repo is fully synced.
+    await writeProgress(res.remaining > 0 ? "mirroring" : "done")
     return res
   } catch (err) {
     carryForward()
-    await persist(`error: ${err instanceof Error ? err.message : String(err)}`.slice(0, 300))
+    const message = err instanceof Error ? err.message : String(err)
+    await persist(`error: ${message}`.slice(0, 300))
+    await writeProgress("error", message.slice(0, 300))
     throw err
   }
 }

--- a/apps/api/src/node-sync.ts
+++ b/apps/api/src/node-sync.ts
@@ -1,0 +1,60 @@
+import type { BlobStore, MetaStore } from "@dock/core"
+import { isSyncing, runToCompletion } from "./lib/sync-runner"
+import { log } from "./log"
+
+/**
+ * Node / self-host counterpart to the `RepoSyncRunner` Durable Object: drives a
+ * triggered GitHub sync to completion in-process, detached from the HTTP request, so
+ * it survives the user navigating away (same UX + tab-independence as the edge tier,
+ * where the DO does this). The web UI polls the persisted `progress` either way.
+ *
+ * `start(sourceId)` kicks a background batch-loop (deduped, so a double "Sync now" or
+ * a webhook + manual trigger don't run two loops for one source). `resumeStalled()`
+ * re-launches any source left mid-sync — called on boot (a process restart mid-sync)
+ * and on a short interval (a self-heal backstop, mirroring the edge cron), made
+ * idempotent by the persisted file-map. The Worker can't run loops like this, so this
+ * module is Node-only (imported solely by node.ts, like webhooks-node.ts).
+ */
+export function createNodeSyncRunner(
+  meta: MetaStore,
+  blobs: BlobStore,
+  encryptionKey: string | undefined,
+) {
+  // Sources with a loop in flight, so a re-trigger (or the resume sweep) never starts
+  // a second loop for the same source. The detached loop clears its own entry.
+  const inFlight = new Set<string>()
+
+  const start = (sourceId: string): void => {
+    if (inFlight.has(sourceId)) return
+    inFlight.add(sourceId)
+    // Detached: never awaited, so the HTTP handler that triggered it returns at once.
+    void runToCompletion(meta, blobs, encryptionKey, sourceId)
+      .catch((err) =>
+        // runSync already persisted phase="error" for the UI; this only logs the
+        // loop giving up so a self-host operator sees it.
+        log.error("node sync runner failed", {
+          source: sourceId,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      )
+      .finally(() => inFlight.delete(sourceId))
+  }
+
+  // Re-launch every source whose persisted progress says it's mid-sync but has no loop
+  // running here (e.g. the process restarted). The file-map makes resume idempotent —
+  // already-synced docs are skipped, so this never re-creates or duplicates artifacts.
+  const resumeStalled = async (): Promise<void> => {
+    try {
+      const sources = await meta.listSyncingRepoSources()
+      const stalled = sources.filter((s) => isSyncing(s) && !inFlight.has(s.id))
+      if (stalled.length) log.info("resuming stalled syncs", { count: stalled.length })
+      for (const s of stalled) start(s.id)
+    } catch (err) {
+      log.error("resume stalled syncs failed", {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  return { start, resumeStalled }
+}

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -15,6 +15,7 @@ import { customDomainsFromEnv } from "./lib/cloudflare-saas"
 import { mountWeb } from "./lib/serve-web"
 import { makeShutdown } from "./lifecycle"
 import { log } from "./log"
+import { createNodeSyncRunner } from "./node-sync"
 import { startWebhookWorker } from "./webhooks"
 import { nodeDnsGuard } from "./webhooks-node"
 
@@ -115,6 +116,11 @@ const shellHtml = cfg.serveWeb ? readFileSync(cfg.webShell, "utf8") : undefined
 // internal corporate network, where a webhook URL could point at a private service.
 const webhookWorker = startWebhookWorker(meta, nodeDnsGuard)
 
+// GitHub-sync runner: drives a triggered sync to completion in-process (detached from
+// the request) so it survives the user navigating away — the self-host counterpart to
+// the edge `RepoSyncRunner` DO. Resumed below on boot + a short interval.
+const syncRunner = createNodeSyncRunner(meta, blobs, authSecret)
+
 const app = createApp({
   meta,
   blobs,
@@ -150,6 +156,8 @@ const app = createApp({
   commentRate: cfg.commentRate,
   // Deliver freshly enqueued events immediately instead of on the next interval.
   pokeWebhooks: webhookWorker.poke,
+  // Run a triggered GitHub sync in the background so it survives a closed tab.
+  startSync: syncRunner.start,
 })
 
 // Serve the bundled SPA from this process (single-container self-host). The API
@@ -180,6 +188,14 @@ const maintain = async () => {
 void maintain()
 pruneTimer = setInterval(maintain, 24 * 3600_000)
 pruneTimer.unref?.()
+
+// Resume any GitHub sync left mid-flight: once on boot (a restart mid-sync) and on a
+// short interval (a self-heal backstop, mirroring the edge cron). The persisted
+// file-map makes resume idempotent, and the runner dedupes already-running loops, so
+// this is safe to call repeatedly. unref'd so it never holds the process open.
+void syncRunner.resumeStalled()
+const syncResumeTimer = setInterval(() => void syncRunner.resumeStalled(), 60_000)
+syncResumeTimer.unref?.()
 
 // One-time cleanup of pre-existing owner self-views (the route no longer records
 // them). Pre-multi-workspace rows were rekeyed from "local" onto defaultOrg above,
@@ -235,6 +251,7 @@ const shutdown = makeShutdown({
   stopWorker: webhookWorker.stop,
   clearTimers: () => {
     if (pruneTimer) clearInterval(pruneTimer)
+    clearInterval(syncResumeTimer)
   },
   closeStores,
   log,

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -1,4 +1,4 @@
-import type { GitHubAppRecord, RepoSourceRecord } from "@dock/core"
+import type { GitHubAppRecord, RepoSourceRecord, SyncProgress } from "@dock/core"
 import { newId } from "@dock/core"
 import { Hono } from "hono"
 import { z } from "zod"
@@ -11,17 +11,15 @@ import {
   listInstallationRepos,
   verifyWebhookSignature,
 } from "../lib/github-app"
-import { fail, MAX_UPLOAD_BYTES, readJson } from "../lib/http"
-import { runSync } from "../lib/sync"
+import { fail, readJson } from "../lib/http"
+import { isSyncing, runToCompletion } from "../lib/sync-runner"
 import { log } from "../log"
 
 const DEFAULT_INCLUDES = "**/*.md,**/*.html"
-// Publishes per "Sync now" call. Bounds one batch to the Worker request budget;
-// the UI loops on `remaining` until the whole repo is mirrored.
-const SYNC_BATCH = 50
 
-/** Client-safe view of a source: the token is redacted and the (potentially
- *  large) file map collapses to a count. */
+/** Client-safe view of a source: the token is redacted and the (potentially large)
+ *  file map collapses to a count. The live `progress` JSON rides through in `...rest`
+ *  so the UI can render the bar straight off the list/status response. */
 const toJson = (s: RepoSourceRecord) => {
   let file_count = 0
   try {
@@ -32,6 +30,11 @@ const toJson = (s: RepoSourceRecord) => {
   const { token, files: _files, ...rest } = s
   return { ...rest, token: token ? "•••" : null, file_count }
 }
+
+/** The initial "queued" progress, written the instant a sync is triggered so the UI
+ *  shows the bar at once — before the first batch even lists the tree. */
+const queuedProgress = (now: string): string =>
+  JSON.stringify({ phase: "queued", done: 0, total: 0, updatedAt: now } satisfies SyncProgress)
 
 /** A GitHub redirect bound to the workspace + user who started the install. */
 interface InstallState {
@@ -55,7 +58,7 @@ interface GitHubWebhookPayload {
  * connection, the App install handshake, and drives the engine (lib/sync).
  */
 export const syncRoutes = (ctx: AppContext) => {
-  const { meta, deps, currentUser, activeWorkspace, workspaceCan, overStorage, background } = ctx
+  const { meta, deps, currentUser, activeWorkspace, workspaceCan, background } = ctx
   const app = new Hono()
 
   // The instance App, with its three secret columns decrypted for use. Null when
@@ -103,31 +106,21 @@ export const syncRoutes = (ctx: AppContext) => {
     }
   }
 
-  // The effective read token for a source: a freshly-minted installation token
-  // (App path) or the decrypted PAT (BYO path). Null when neither applies (a
-  // public repo synced without either).
-  const tokenForSource = async (source: RepoSourceRecord): Promise<string | null> => {
-    if (source.installation_id) {
-      const loaded = await loadApp()
-      if (!loaded) throw new GitHubError(400, "GitHub App is not configured on this instance")
-      return installationToken(loaded.app.app_id, loaded.pem, source.installation_id)
-    }
-    return source.token && deps.encryptionKey
-      ? decryptSecret(source.token, deps.encryptionKey)
-      : source.token
+  // Trigger a sync on the SERVER, not in the browser — so it survives the user
+  // closing the tab (their #1 complaint). Marks the source `queued` (the UI shows the
+  // bar immediately) and hands off to the background runner: the per-source
+  // `RepoSyncRunner` Durable Object on the edge, or the detached batch-loop on Node
+  // (both via `deps.startSync`). Token minting + the per-batch engine loop live in
+  // lib/sync-runner, shared by every tier. When no runner is wired (tests/dev),
+  // `inlineFallback` runs the whole sync in the background instead, so a self-host
+  // without a runner still mirrors. The engine persists progress every batch, polled
+  // by the UI.
+  const launch = async (source: RepoSourceRecord, inlineFallback: boolean): Promise<void> => {
+    await meta.setRepoSourceProgress(source.id, queuedProgress(new Date().toISOString()))
+    if (deps.startSync) deps.startSync(source.id)
+    else if (inlineFallback)
+      background(runToCompletion(meta, deps.blobs, deps.encryptionKey, source.id))
   }
-
-  // Run one source now (ONE bounded batch). Shared by the manual "Sync now" button
-  // and the webhook's push auto-sync. `maxFiles` caps the publishes per call so a
-  // huge repo can't exceed the Worker request budget; the result's `remaining` tells
-  // the caller to run again. runSync persists its partial map incrementally, so a
-  // mid-run failure can't orphan artifacts.
-  const syncOne = (source: RepoSourceRecord, token: string | null) =>
-    runSync(meta, deps.blobs, { ...source, token }, new Date().toISOString(), {
-      maxBytes: MAX_UPLOAD_BYTES,
-      maxFiles: SYNC_BATCH,
-      overStorage: (n) => overStorage(source.org_id, n),
-    })
 
   // ---- List + connection status -----------------------------------------
   app.get("/v1/sync/github", async (c) => {
@@ -325,10 +318,19 @@ export const syncRoutes = (ctx: AppContext) => {
       installation_id: installationId,
       created_by: createdBy,
     })
-    return c.json(toJson(source), 201)
+    // Kick the first sync server-side right away, so connecting a repo immediately
+    // shows the live bar (no separate "Sync now" needed). No inline fallback here —
+    // a no-runner env starts mirroring on the explicit /run instead.
+    await launch(source, false)
+    const fresh = (await meta.getRepoSource(source.id, org)) ?? source
+    return c.json(toJson(fresh), 201)
   })
 
   // ---- Manual "Sync now" ------------------------------------------------
+  // Triggers a server-side sync and returns at once (202) — the work runs on our
+  // servers (DO / Node loop), so the user can close the tab. The UI polls /status for
+  // the live bar. Without a runner wired (tests/dev), runs inline to completion and
+  // returns the finished source instead, so a self-host still mirrors synchronously.
   app.post("/v1/sync/github/:id/run", async (c) => {
     if (!(await workspaceCan(c, "publish"))) return fail(c, 403, "forbidden")
     const org = await activeWorkspace(c)
@@ -336,14 +338,52 @@ export const syncRoutes = (ctx: AppContext) => {
     if (!source) return fail(c, 404, "not found")
     if (deps.maxArtifacts && (await meta.countArtifacts(org)) >= deps.maxArtifacts)
       return fail(c, 409, "artifact quota reached")
+    if (deps.startSync) {
+      await launch(source, false)
+      const fresh = (await meta.getRepoSource(source.id, org)) ?? source
+      return c.json(toJson(fresh), 202)
+    }
     try {
       // A GitHub <500 is a bad repo/token/install (the caller's to fix → 400); else 502.
-      const token = await tokenForSource(source)
-      return c.json(await syncOne(source, token))
+      await meta.setRepoSourceProgress(source.id, queuedProgress(new Date().toISOString()))
+      await runToCompletion(meta, deps.blobs, deps.encryptionKey, source.id)
     } catch (err) {
       const userError = err instanceof GitHubError && err.status < 500
       return fail(c, userError ? 400 : 502, err instanceof Error ? err.message : "sync failed")
     }
+    const fresh = (await meta.getRepoSource(source.id, org)) ?? source
+    return c.json(toJson(fresh))
+  })
+
+  // ---- Status poll (drives the big progress bar) ------------------------
+  // Deliberately cheap: no GitHub round-trip (unlike the list endpoint's appIsLive
+  // check), just the persisted progress + status + count — so the UI polls it every
+  // ~1.5s while a sync runs without hammering GitHub.
+  app.get("/v1/sync/github/:id/status", async (c) => {
+    if (!(await workspaceCan(c, "comment"))) return fail(c, 403, "forbidden")
+    const org = await activeWorkspace(c)
+    const source = await meta.getRepoSource(c.req.param("id"), org)
+    if (!source) return fail(c, 404, "not found")
+    const view = toJson(source)
+    return c.json({
+      id: source.id,
+      repo: source.repo,
+      progress: view.progress ?? null,
+      last_status: source.last_status,
+      last_synced_at: source.last_synced_at,
+      file_count: view.file_count,
+    })
+  })
+
+  // ---- Active syncs in this workspace (drives the global chip) ----------
+  // Every source mid-sync (progress phase queued/listing/mirroring), so the app-shell
+  // chip can show "Syncing <repo> · 47/190" from any page. Static path, so it never
+  // collides with the `:id` routes above.
+  app.get("/v1/sync/github/active", async (c) => {
+    if (!(await workspaceCan(c, "comment"))) return fail(c, 403, "forbidden")
+    const org = await activeWorkspace(c)
+    const active = (await meta.listRepoSources(org)).filter(isSyncing).map(toJson)
+    return c.json({ active })
   })
 
   // ---- Disconnect -------------------------------------------------------
@@ -391,18 +431,10 @@ export const syncRoutes = (ctx: AppContext) => {
             s.repo.toLowerCase() === fullName.toLowerCase() &&
             (s.ref === branch || (s.ref === "HEAD" && branch === defaultBranch)),
         )
-        // Re-sync each match off the hot path; failures are persisted per-source.
-        for (const s of matched)
-          background(
-            tokenForSource(s)
-              .then((tok) => syncOne(s, tok))
-              .catch((err) =>
-                log.error("push auto-sync failed", {
-                  repo: s.repo,
-                  error: err instanceof Error ? err.message : String(err),
-                }),
-              ),
-          )
+        // Re-sync each match on the server (DO / Node loop), same as a manual run —
+        // so a push mirrors tab-independently and the bar shows up if anyone's looking.
+        // Progress + failures are persisted per-source by the engine.
+        for (const s of matched) await launch(s, true)
         if (matched.length) log.info("push auto-sync queued", { repo: fullName, n: matched.length })
       }
     } else if (event === "installation" && payload.action === "deleted") {

--- a/apps/api/src/sync-runner-do.ts
+++ b/apps/api/src/sync-runner-do.ts
@@ -2,8 +2,8 @@ import type { D1Database, DurableObjectState, R2Bucket } from "@cloudflare/worke
 import type { BlobStore, MetaStore } from "@dock/core"
 import { createD1Store } from "@dock/db/d1"
 import { R2BlobStore } from "@dock/storage"
-import { log } from "./log"
 import { runSourceBatch } from "./lib/sync-runner"
+import { log } from "./log"
 
 // While a source still has files to mirror, re-run on this cadence so a large repo
 // drains batch-by-batch without any one alarm holding a long-running task (the

--- a/apps/api/src/sync-runner-do.ts
+++ b/apps/api/src/sync-runner-do.ts
@@ -1,0 +1,115 @@
+import type { D1Database, DurableObjectState, R2Bucket } from "@cloudflare/workers-types"
+import type { BlobStore, MetaStore } from "@dock/core"
+import { createD1Store } from "@dock/db/d1"
+import { R2BlobStore } from "@dock/storage"
+import { log } from "./log"
+import { runSourceBatch } from "./lib/sync-runner"
+
+// While a source still has files to mirror, re-run on this cadence so a large repo
+// drains batch-by-batch without any one alarm holding a long-running task (the
+// per-batch file cap keeps each tick inside the Workers CPU budget). The engine
+// persists its file-map + progress every batch, so the DB row is the source of
+// truth and losing the DO only delays the next batch to the cron backstop.
+const TICK_MS = 1_200
+// A `/start` poke schedules the first batch almost immediately.
+const POKE_DELAY_MS = 200
+// A batch that throws (a GitHub blip mid-mirror) is retried with linear backoff;
+// the engine already persisted phase="error", so a recovering retry flips it back
+// to mirroring/done. Past this we stop and leave the error visible for the user.
+const MAX_RETRIES = 4
+
+/** The env the sync runner DO needs: D1 (MetaStore) + R2 (blobs) + the at-rest key. */
+export interface RepoSyncRunnerEnv {
+  DB: D1Database
+  BUCKET: R2Bucket
+  /** At-rest key for decrypting stored PATs / minting installation tokens. */
+  DOCK_AUTH_SECRET?: string
+}
+
+/**
+ * Server-side GitHub-sync runner for the Workers tier — one Durable Object instance
+ * per source (addressed `idFromName("sync:" + sourceId)`), so a sync runs to
+ * completion on OUR servers and survives the user closing the browser tab. It is the
+ * edge counterpart to the Node detached loop (`runToCompletion` kicked from node.ts):
+ * same bounded-batch engine (`runSourceBatch` → `runSync`), driven by a
+ * self-rescheduling alarm instead of an awaited loop, so no single alarm holds a
+ * long task.
+ *
+ * `fetch("/start?source=rs_…")` (poked by the Worker when a sync is triggered) records
+ * the source id and arms the alarm; `alarm()` runs ONE batch and reschedules while
+ * `remaining > 0`, then goes idle. The engine persists the file-map + a pollable
+ * `progress` JSON every batch (the UI's big bar reads it), so the DO holds no
+ * authoritative state — a lost instance or missed poke only delays the next batch to
+ * the cron backstop, and the persisted map makes every retry idempotent.
+ */
+export class RepoSyncRunner {
+  private meta: MetaStore
+  private blobs: BlobStore
+  private key: string | undefined
+
+  constructor(
+    private state: DurableObjectState,
+    env: RepoSyncRunnerEnv,
+  ) {
+    this.meta = createD1Store(env.DB)
+    this.blobs = new R2BlobStore(env.BUCKET)
+    this.key = env.DOCK_AUTH_SECRET
+  }
+
+  // The Worker pokes this with the source to sync. Persist the id (the alarm has no
+  // request context) and arm the alarm when none is pending — an alarm already set
+  // fires within a tick. Reset the retry counter so a fresh trigger starts clean.
+  async fetch(req: Request): Promise<Response> {
+    const sourceId = new URL(req.url).searchParams.get("source")
+    if (sourceId) {
+      await this.state.storage.put("source", sourceId)
+      await this.state.storage.put("retries", 0)
+    }
+    const pending = await this.state.storage.getAlarm()
+    if (pending === null) await this.state.storage.setAlarm(Date.now() + POKE_DELAY_MS)
+    return new Response("ok")
+  }
+
+  // One bounded batch, then reschedule while work remains so a big repo drains. The
+  // alarm must never strand: on a thrown batch, retry with backoff up to MAX_RETRIES
+  // (the engine already persisted phase="error"), then stop. On success it reschedules
+  // only while `remaining > 0`, so the DO goes idle the moment the repo is fully synced.
+  async alarm(): Promise<void> {
+    const sourceId = await this.state.storage.get<string>("source")
+    if (!sourceId) return // nothing queued (a stray cron/poke) — stay idle
+    try {
+      const source = await this.meta.getRepoSource(sourceId)
+      if (!source) {
+        await this.stop() // disconnected mid-sync — nothing left to do
+        return
+      }
+      const res = await runSourceBatch(this.meta, this.blobs, this.key, source)
+      if (res.remaining > 0) {
+        await this.state.storage.put("retries", 0)
+        await this.state.storage.setAlarm(Date.now() + TICK_MS)
+      } else {
+        await this.stop() // fully synced — go idle
+      }
+    } catch (err) {
+      const retries = (await this.state.storage.get<number>("retries")) ?? 0
+      if (retries >= MAX_RETRIES) {
+        log.error("sync runner gave up", {
+          source: sourceId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+        await this.stop() // phase="error" is already persisted for the UI
+        return
+      }
+      // Linear backoff; a recovering batch overwrites progress back to mirroring/done.
+      await this.state.storage.put("retries", retries + 1)
+      await this.state.storage.setAlarm(Date.now() + TICK_MS * (retries + 1))
+    }
+  }
+
+  // Clear queued state so a future poke starts fresh and no stale alarm fires.
+  private async stop(): Promise<void> {
+    await this.state.storage.delete("source")
+    await this.state.storage.delete("retries")
+    await this.state.storage.deleteAlarm()
+  }
+}

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -16,10 +16,12 @@ import { customDomainsFromEnv } from "./lib/cloudflare-saas"
 import { nativeLimiter } from "./lib/rate-limit"
 import { createDoBackplane, edgeCtx } from "./realtime-do"
 
-// The bound Durable Object classes — the realtime room (one per channel) and the webhook
-// outbox drainer (a single named instance) — re-exported so the Workers runtime can
-// instantiate them (see wrangler.toml `durable_objects.bindings`).
+// The bound Durable Object classes — the realtime room (one per channel), the webhook
+// outbox drainer (a single named instance), and the GitHub-sync runner (one per source)
+// — re-exported so the Workers runtime can instantiate them (see wrangler.toml
+// `durable_objects.bindings`).
 export { ArtifactRoom } from "./realtime-do"
+export { RepoSyncRunner } from "./sync-runner-do"
 export { WebhookOutbox } from "./webhook-do"
 
 // The webhook outbox DO is a singleton: every isolate pokes the same instance by a
@@ -55,6 +57,10 @@ export interface Env {
   ROOMS: DurableObjectNamespace
   // The webhook outbox drainer DO (a single named instance). Declared in wrangler.toml.
   WEBHOOK_OUTBOX: DurableObjectNamespace
+  // The GitHub-sync runner DO (one instance per source, by name). Declared in
+  // wrangler.toml. Drives a triggered sync to completion server-side so it survives
+  // the user navigating away — the edge counterpart to the Node detached loop.
+  SYNC_RUNNER: DurableObjectNamespace
   // Native per-colo rate-limit bindings (limit + 60s window declared in wrangler.toml
   // [[ratelimits]]). The edge counts against these instead of an in-process Map so a cap
   // holds across isolates within a location. RL_STRICT is shared by the two tight 3/60
@@ -82,6 +88,14 @@ export interface Env {
 function pokeOutbox(env: Env): Promise<unknown> {
   const stub = env.WEBHOOK_OUTBOX.get(env.WEBHOOK_OUTBOX.idFromName(OUTBOX_NAME))
   return stub.fetch("https://outbox/poke", { method: "POST" }).catch(() => {})
+}
+
+/** Poke the per-source sync runner DO so it starts (or resumes) mirroring on our
+ *  servers — tab-independent, so the user can close the page mid-sync. */
+function pokeSync(env: Env, sourceId: string): Promise<unknown> {
+  const stub = env.SYNC_RUNNER.get(env.SYNC_RUNNER.idFromName(`sync:${sourceId}`))
+  const url = `https://sync/start?source=${encodeURIComponent(sourceId)}`
+  return stub.fetch(url, { method: "POST" }).catch(() => {})
 }
 
 let app: ReturnType<typeof createApp> | null = null
@@ -141,6 +155,15 @@ export default {
         // riding waitUntil so the subrequest isn't cancelled when the response is sent.
         pokeWebhooks: () => {
           const p = pokeOutbox(env)
+          const c = edgeCtx.getStore()
+          if (c) c.waitUntil(p)
+          else void p
+        },
+        // Run a triggered GitHub sync server-side: poke the per-source runner DO so
+        // it mirrors to completion on our servers (tab-independent). waitUntil keeps
+        // the poke subrequest alive past the 202 response.
+        startSync: (sourceId) => {
+          const p = pokeSync(env, sourceId)
           const c = edgeCtx.getStore()
           if (c) c.waitUntil(p)
           else void p

--- a/apps/api/test/sync-routes.test.ts
+++ b/apps/api/test/sync-routes.test.ts
@@ -75,9 +75,12 @@ describe("sync routes", () => {
     ]
     blobs.r1 = "# Readme"
     const res = await postJson(`/v1/sync/github/${id}/run`, {})
+    // No background runner wired in tests → /run mirrors inline and returns the synced
+    // source: status 200, file_count reflects the one mirrored doc.
     expect(res.status).toBe(200)
-    const r = (await res.json()) as { added: number }
-    expect(r.added).toBe(1)
+    const r = (await res.json()) as { file_count: number; last_status: string }
+    expect(r.file_count).toBe(1)
+    expect(r.last_status).toBe("ok")
     expect(await meta.collectionArtifactIds(collectionId)).toHaveLength(1)
   })
 
@@ -93,6 +96,44 @@ describe("sync routes", () => {
     expect(detail.managed).toBe(true)
     const republish = await upload("readme.md", "# edited in Dock", {}, shortId)
     expect(republish.status).toBe(409)
+  })
+
+  it("status endpoint returns the live progress + file count (cheap poll)", async () => {
+    const res = await app.request(`/v1/sync/github/${id}/status`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      id: string
+      file_count: number
+      last_status: string | null
+      progress: string | null
+    }
+    expect(body.id).toBe(id)
+    expect(body.file_count).toBe(1) // the one doc mirrored by "Sync now" above
+    expect(body.last_status).toBe("ok")
+  })
+
+  it("active endpoint lists only sources mid-sync", async () => {
+    // Idle after the completed sync → not listed.
+    const idle = (await (await app.request("/v1/sync/github/active")).json()) as {
+      active: { id: string }[]
+    }
+    expect(idle.active.find((s) => s.id === id)).toBeUndefined()
+    // Mark it mirroring → now listed (drives the global chip); clear → gone again.
+    await meta.setRepoSourceProgress(
+      id,
+      JSON.stringify({
+        phase: "mirroring",
+        done: 1,
+        total: 5,
+        updatedAt: "2026-06-14T00:00:00.000Z",
+      }),
+    )
+    const busy = (await (await app.request("/v1/sync/github/active")).json()) as {
+      active: { id: string; progress: string | null }[]
+    }
+    const found = busy.active.find((s) => s.id === id)
+    expect(found?.progress).toContain('"phase":"mirroring"')
+    await meta.setRepoSourceProgress(id, null)
   })
 
   it("disconnects but keeps the mirrored docs", async () => {

--- a/apps/api/test/sync-runner.test.ts
+++ b/apps/api/test/sync-runner.test.ts
@@ -1,0 +1,102 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { newId, type RepoSourceRecord, type SyncProgress } from "@dock/core"
+import { SqliteMetaStore } from "@dock/db/sqlite"
+import { FsBlobStore } from "@dock/storage/fs"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { isSyncing, runToCompletion } from "../src/lib/sync-runner"
+
+// Same controllable fake GitHub as the engine test: a tree + raw bytes per sha.
+let tree: { path: string; sha: string; type: "blob" | "tree" }[] = []
+const blobs: Record<string, string> = {}
+
+const dir = mkdtempSync(join(tmpdir(), "dock-sync-runner-test-"))
+const meta = new SqliteMetaStore(join(dir, "runner.db"))
+const blobStore = new FsBlobStore(join(dir, "blobs"))
+
+beforeAll(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string | URL) => {
+      const s = String(url)
+      if (s.includes("/git/trees/"))
+        return new Response(JSON.stringify({ tree, truncated: false }), { status: 200 })
+      const m = s.match(/\/git\/blobs\/([^/?]+)/)
+      if (m) {
+        const body = blobs[m[1] as string]
+        return body == null
+          ? new Response("not found", { status: 404 })
+          : new Response(body, { status: 200 })
+      }
+      return new Response("nope", { status: 404 })
+    }),
+  )
+})
+afterAll(() => {
+  vi.unstubAllGlobals()
+  meta.close()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+// isSyncing only reads `.progress`, so a narrow stub is enough to unit-test it.
+const withProgress = (progress: string | null): RepoSourceRecord =>
+  ({ progress }) as unknown as RepoSourceRecord
+const prog = (phase: SyncProgress["phase"]): string =>
+  JSON.stringify({ phase, done: 1, total: 2, updatedAt: "2026-06-14T00:00:00.000Z" })
+
+describe("sync runner", () => {
+  it("runToCompletion loops batches until the whole repo is mirrored", async () => {
+    const col = await meta.createCollection({
+      id: newId("col"),
+      org_id: "local",
+      title: "loop",
+      created_by: "u",
+    })
+    const src = await meta.createRepoSource({
+      id: newId("rs"),
+      org_id: "local",
+      collection_id: col.id,
+      repo: "acme/loop",
+      ref: "main",
+      includes: "**/*.md",
+      created_by: "u",
+    })
+    // 60 docs > the 50/batch cap, so this only finishes if the runner loops past the
+    // first batch (the tab-independence guarantee: every file lands server-side).
+    tree = Array.from({ length: 60 }, (_, i) => ({
+      path: `l${i}.md`,
+      sha: `loop-${i}`,
+      type: "blob" as const,
+    }))
+    for (let i = 0; i < 60; i++) blobs[`loop-${i}`] = `# L${i}`
+
+    await runToCompletion(meta, blobStore, undefined, src.id)
+
+    const map = JSON.parse((await meta.getRepoSource(src.id))?.files ?? "{}") as Record<
+      string,
+      unknown
+    >
+    expect(Object.keys(map)).toHaveLength(60) // all mirrored despite the per-batch cap
+    const progress = JSON.parse(
+      (await meta.getRepoSource(src.id))?.progress ?? "null",
+    ) as SyncProgress | null
+    expect(progress).toMatchObject({ phase: "done", done: 60, total: 60 })
+  })
+
+  it("runToCompletion is a no-op when the source is gone (disconnected mid-sync)", async () => {
+    await expect(
+      runToCompletion(meta, blobStore, undefined, "rs_does_not_exist"),
+    ).resolves.toBeUndefined()
+  })
+
+  it("isSyncing is true only for the in-flight phases", () => {
+    expect(isSyncing(withProgress(prog("queued")))).toBe(true)
+    expect(isSyncing(withProgress(prog("listing")))).toBe(true)
+    expect(isSyncing(withProgress(prog("mirroring")))).toBe(true)
+    expect(isSyncing(withProgress(prog("done")))).toBe(false)
+    expect(isSyncing(withProgress(prog("error")))).toBe(false)
+    expect(isSyncing(withProgress(null))).toBe(false)
+    expect(isSyncing(withProgress("not json"))).toBe(false)
+  })
+})

--- a/apps/api/test/sync.test.ts
+++ b/apps/api/test/sync.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { newId, type RepoSourceRecord } from "@dock/core"
+import { newId, type RepoSourceRecord, type SyncProgress } from "@dock/core"
 import { SqliteMetaStore } from "@dock/db/sqlite"
 import { FsBlobStore } from "@dock/storage/fs"
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
@@ -302,5 +302,109 @@ describe("GitHub sync engine", () => {
     expect(r.remaining).toBe(0)
     const map = JSON.parse((await meta.getRepoSource(src.id))?.files ?? "{}") as FileMap
     expect(Object.keys(map).length).toBe(5) // every file mirrored, no duplicates
+  })
+
+  // ---- Live progress (the giant UI bar reads this) ----------------------
+  // setRepoSourceProgress is always called with a JSON string by the engine.
+  const progressPhases = (calls: [string, string | null][]): SyncProgress[] =>
+    calls.map(([, json]) => JSON.parse(json ?? "{}") as SyncProgress)
+
+  it("writes pollable progress through the phases (listing → mirroring → done)", async () => {
+    const col = await meta.createCollection({
+      id: newId("col"),
+      org_id: "local",
+      title: "prog",
+      created_by: "u",
+    })
+    const src = await meta.createRepoSource({
+      id: newId("rs"),
+      org_id: "local",
+      collection_id: col.id,
+      repo: "acme/prog",
+      ref: "main",
+      includes: "**/*.md",
+      created_by: "u",
+    })
+    tree = [
+      { path: "a.md", sha: "pg-a", type: "blob" },
+      { path: "b.md", sha: "pg-b", type: "blob" },
+    ]
+    blobs["pg-a"] = "# A"
+    blobs["pg-b"] = "# B"
+    const spy = vi.spyOn(meta, "setRepoSourceProgress")
+    await runSync(meta, blobStore, src, NOW)
+    const phases = progressPhases(spy.mock.calls)
+    spy.mockRestore()
+    // Fresh source → first a "listing" (before the count is known), then "mirroring",
+    // then a terminal "done" carrying the full count.
+    expect(phases[0]?.phase).toBe("listing")
+    expect(phases.some((p) => p.phase === "mirroring")).toBe(true)
+    const last = phases.at(-1)
+    expect(last).toMatchObject({ phase: "done", done: 2, total: 2 })
+  })
+
+  it("progress is monotonic across batches (never snaps backward)", async () => {
+    const col = await meta.createCollection({
+      id: newId("col"),
+      org_id: "local",
+      title: "mono",
+      created_by: "u",
+    })
+    const src = await meta.createRepoSource({
+      id: newId("rs"),
+      org_id: "local",
+      collection_id: col.id,
+      repo: "acme/mono",
+      ref: "main",
+      includes: "**/*.md",
+      created_by: "u",
+    })
+    tree = Array.from({ length: 5 }, (_, i) => ({
+      path: `m${i}.md`,
+      sha: `mono-${i}`,
+      type: "blob" as const,
+    }))
+    for (let i = 0; i < 5; i++) blobs[`mono-${i}`] = `# M${i}`
+    const limits = { maxBytes: 1e9, maxFiles: 2, overStorage: async () => false }
+    const spy = vi.spyOn(meta, "setRepoSourceProgress")
+    let s = (await meta.getRepoSource(src.id)) as RepoSourceRecord
+    let r = await runSync(meta, blobStore, s, NOW, limits)
+    let guard = 0
+    while (r.remaining > 0 && guard++ < 10) {
+      s = (await meta.getRepoSource(src.id)) as RepoSourceRecord
+      r = await runSync(meta, blobStore, s, NOW, limits)
+    }
+    const dones = progressPhases(spy.mock.calls).map((p) => p.done)
+    spy.mockRestore()
+    // The floor at the carried-forward count means `done` never drops between the
+    // batches — without it the bar would snap 2→0→4→0 at each batch's listTree.
+    for (let i = 1; i < dones.length; i++)
+      expect(dones[i]).toBeGreaterThanOrEqual(dones[i - 1] as number)
+    expect(dones.at(-1)).toBe(5)
+  })
+
+  it("error path sets progress phase=error", async () => {
+    const col = await meta.createCollection({
+      id: newId("col"),
+      org_id: "local",
+      title: "perr",
+      created_by: "u",
+    })
+    const src = await meta.createRepoSource({
+      id: newId("rs"),
+      org_id: "local",
+      collection_id: col.id,
+      repo: "acme/perr",
+      ref: "main",
+      includes: "**/*.md",
+      created_by: "u",
+    })
+    tree = [{ path: "z.md", sha: "perr-z", type: "blob" }]
+    delete blobs["perr-z"] // missing blob → fetchBlob 404 → runSync throws
+    await expect(runSync(meta, blobStore, src, NOW)).rejects.toThrow()
+    const prog = JSON.parse(
+      (await meta.getRepoSource(src.id))?.progress ?? "null",
+    ) as SyncProgress | null
+    expect(prog?.phase).toBe("error")
   })
 })

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -27,6 +27,13 @@ class_name = "ArtifactRoom"
 name = "WEBHOOK_OUTBOX"
 class_name = "WebhookOutbox"
 
+# The GitHub-sync runner (one instance per source, addressed by name). Its alarm
+# mirrors a repo batch-by-batch to completion server-side, so a sync survives the
+# user closing the tab — the edge counterpart to the Node detached batch-loop.
+[[durable_objects.bindings]]
+name = "SYNC_RUNNER"
+class_name = "RepoSyncRunner"
+
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["ArtifactRoom"]
@@ -34,6 +41,10 @@ new_sqlite_classes = ["ArtifactRoom"]
 [[migrations]]
 tag = "v2"
 new_sqlite_classes = ["WebhookOutbox"]
+
+[[migrations]]
+tag = "v3"
+new_sqlite_classes = ["RepoSyncRunner"]
 
 # Native rate limiting (per-colo). One binding per surface; the worker counts each
 # rate-limited request against the matching binding (apps/api/src/worker.ts). The window

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -79,8 +79,9 @@ export interface Artifact {
   source_path?: string | null
   /** First-published time. */
   created_at?: string
-  /** Last-updated time (bumped on each new version); drives recency sort + the label. */
-  updated_at?: string
+  /** Last-updated time (set on each new version; null until versioned). Read as
+   *  `updated_at ?? created_at`. Drives the recency sort + the "updated X" label. */
+  updated_at?: string | null
 }
 export interface Report {
   id: string

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -266,6 +266,35 @@ export interface RepoSource {
   created_by: string
   created_at: string
   file_count: number
+  /** Live sync state as a JSON string (parse with `parseProgress`); null when idle. */
+  progress: string | null
+}
+/** Live, pollable sync progress — the engine writes this every batch; the UI bar +
+ *  global chip read it. `done`/`total` are doc counts; `phase` drives the wording. */
+export interface SyncProgress {
+  phase: "queued" | "listing" | "mirroring" | "done" | "error"
+  done: number
+  total: number
+  message?: string
+  updatedAt: string
+}
+/** Parse a RepoSource.progress / SyncStatus.progress string; null if absent/malformed. */
+export const parseProgress = (raw: string | null | undefined): SyncProgress | null => {
+  if (!raw) return null
+  try {
+    return JSON.parse(raw) as SyncProgress
+  } catch {
+    return null
+  }
+}
+/** The cheap status-poll response (no GitHub round-trip) that drives the progress bar. */
+export interface SyncStatus {
+  id: string
+  repo: string
+  progress: string | null
+  last_status: string | null
+  last_synced_at: string | null
+  file_count: number
 }
 export interface GithubInstallation {
   installation_id: string
@@ -600,8 +629,15 @@ export const api = {
     if (includes) qs.set("includes", includes)
     return f(`/v1/sync/github/installations/${installationId}/preview?${qs}`, opts()).then(j)
   },
-  runRepoSync: (id: string): Promise<SyncResult> =>
+  // Trigger a sync. The work runs on the server (a Durable Object on the edge, a
+  // detached loop on Node), so this returns at once — poll `syncStatus` for the bar.
+  runRepoSync: (id: string): Promise<RepoSource> =>
     f(`/v1/sync/github/${id}/run`, opts({})).then(j),
+  // Cheap status poll for the live progress bar (no GitHub round-trip).
+  syncStatus: (id: string): Promise<SyncStatus> =>
+    f(`/v1/sync/github/${id}/status`, opts()).then(j),
+  // Sources currently mid-sync in this workspace (drives the global progress chip).
+  activeSyncs: (): Promise<{ active: RepoSource[] }> => f("/v1/sync/github/active", opts()).then(j),
   deleteRepoSource: (id: string): Promise<void> =>
     f(`/v1/sync/github/${id}`, { method: "DELETE", credentials: "include" }).then(() => undefined),
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -77,6 +77,10 @@ export interface Artifact {
   managed?: boolean
   /** Repo path for a synced artifact (e.g. "docs/plans/foo.md") — drives the folder view. */
   source_path?: string | null
+  /** First-published time. */
+  created_at?: string
+  /** Last-updated time (bumped on each new version); drives recency sort + the label. */
+  updated_at?: string
 }
 export interface Report {
   id: string

--- a/apps/web/src/components/nav-rail.tsx
+++ b/apps/web/src/components/nav-rail.tsx
@@ -11,6 +11,7 @@ import { Icon, type IconName } from "./icons"
 import { NotificationBell } from "./notification-bell"
 import { Logo } from "./shared/logo"
 import { useShell } from "./shell-context"
+import { SyncChip } from "./sync-chip"
 import { UserPod } from "./user-pod"
 
 // Shared nav-row look (also used by NotificationBell + the Settings link so the
@@ -310,6 +311,7 @@ export function NavRail() {
       </div>
 
       <div className="mt-auto flex flex-col gap-px border-t border-border-soft pt-2">
+        <SyncChip collapsed={railMode} />
         <NotificationBell collapsed={railMode} />
         <Link
           to="/settings"

--- a/apps/web/src/components/sync-chip.tsx
+++ b/apps/web/src/components/sync-chip.tsx
@@ -1,0 +1,80 @@
+import { useQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
+import { Loader2 } from "lucide-react"
+import { api, parseProgress } from "@/api"
+import { cn } from "@/lib/utils"
+
+/**
+ * Global sync indicator in the app shell, so a running GitHub sync is visible from
+ * ANY page — not just Settings. Polls the cheap `/active` endpoint (fast while a sync
+ * runs, relaxed when idle), renders the repo + a live mini bar, and deep-links to the
+ * GitHub settings tab (the full, giant bar). Renders nothing when nothing is syncing.
+ * This is the "no matter where I navigate, I can see it" piece.
+ */
+export function SyncChip({ collapsed }: { collapsed: boolean }) {
+  const { data } = useQuery({
+    queryKey: ["sync-active"],
+    queryFn: () => api.activeSyncs(),
+    // Tight cadence while a sync is in flight (smooth bar); relaxed when idle so the
+    // shell isn't polling hard forever — just often enough to notice a new sync start.
+    refetchInterval: (q) => (q.state.data?.active.length ? 1500 : 8000),
+    refetchOnWindowFocus: true,
+  })
+
+  const active = data?.active ?? []
+  if (active.length === 0) return null
+
+  const first = active[0]
+  if (!first) return null
+  const prog = parseProgress(first.progress)
+  const total = prog?.total ?? 0
+  const done = prog?.done ?? 0
+  const pct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : 0
+  const indeterminate = !prog || total === 0
+  const label = active.length > 1 ? `Syncing ${active.length} repos` : `Syncing ${first.repo}`
+  const detail =
+    total > 0 ? `${done}/${total}` : prog?.phase === "listing" ? "listing…" : "starting…"
+
+  // Collapsed rail: just the spinner, with the detail in the tooltip.
+  if (collapsed) {
+    return (
+      <Link
+        to="/settings"
+        search={{ tab: "github" }}
+        title={`${label} · ${detail}`}
+        aria-label={`${label} · ${detail}`}
+        data-testid="sync-chip"
+        className="flex items-center justify-center rounded-[9px] py-2.5 text-primary transition-colors hover:bg-hover"
+      >
+        <Loader2 className="size-[18px] animate-spin" aria-hidden />
+      </Link>
+    )
+  }
+
+  return (
+    <Link
+      to="/settings"
+      search={{ tab: "github" }}
+      data-testid="sync-chip"
+      title={`${label} · ${detail}`}
+      className="flex flex-col gap-1.5 rounded-[9px] border border-primary/30 bg-primary/5 px-2.5 py-2 transition-colors hover:bg-primary/10"
+    >
+      <div className="flex items-center gap-2 text-xs font-semibold text-foreground">
+        <Loader2 className="size-3.5 shrink-0 animate-spin text-primary" aria-hidden />
+        <span className="truncate">{label}</span>
+        <span className="ml-auto shrink-0 font-mono text-2xs tabular-nums text-muted-foreground">
+          {detail}
+        </span>
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-secondary">
+        <div
+          className={cn(
+            "h-full rounded-full bg-primary transition-all duration-500",
+            indeterminate && "w-1/3 animate-pulse",
+          )}
+          style={indeterminate ? undefined : { width: `${pct}%` }}
+        />
+      </div>
+    </Link>
+  )
+}

--- a/apps/web/src/pages/library/artifact-card.tsx
+++ b/apps/web/src/pages/library/artifact-card.tsx
@@ -10,12 +10,12 @@ import {
 import { ago } from "@/lib/time"
 import { cn } from "@/lib/utils"
 
-const dirOf = (path: string): string => {
+export const dirOf = (path: string): string => {
   const i = path.lastIndexOf("/")
   return i < 0 ? "" : path.slice(0, i)
 }
 
-function artifactTypeLabel(a: Artifact): string {
+export function artifactTypeLabel(a: Artifact): string {
   if (a.kind === "bundle") return "Site"
   const ct = a.current_content_type
   if (ct === "text/x-dock-deck") return "Deck"
@@ -116,7 +116,9 @@ export function ArtifactCard({
           <span className="rounded-[5px] border border-border-soft bg-secondary px-1.5 py-px">
             {artifactTypeLabel(a)}
           </span>
-          {a.versions[0]?.created_at && <span>updated {ago(a.versions[0].created_at)}</span>}
+          {(a.updated_at ?? a.versions[0]?.created_at) && (
+            <span>updated {ago(a.updated_at ?? a.versions[0]?.created_at ?? "")}</span>
+          )}
           {a.views !== undefined && a.views > 0 && (
             <span className="ml-auto inline-flex items-center gap-1" title={`${a.views} viewers`}>
               <Icon name="views" size={13} />{" "}

--- a/apps/web/src/pages/library/artifact-card.tsx
+++ b/apps/web/src/pages/library/artifact-card.tsx
@@ -116,8 +116,10 @@ export function ArtifactCard({
           <span className="rounded-[5px] border border-border-soft bg-secondary px-1.5 py-px">
             {artifactTypeLabel(a)}
           </span>
-          {(a.updated_at ?? a.versions[0]?.created_at) && (
-            <span>updated {ago(a.updated_at ?? a.versions[0]?.created_at ?? "")}</span>
+          {(a.updated_at ?? a.created_at ?? a.versions[0]?.created_at) && (
+            <span>
+              updated {ago(a.updated_at ?? a.created_at ?? a.versions[0]?.created_at ?? "")}
+            </span>
           )}
           {a.views !== undefined && a.views > 0 && (
             <span className="ml-auto inline-flex items-center gap-1" title={`${a.views} viewers`}>

--- a/apps/web/src/pages/library/artifact-row.tsx
+++ b/apps/web/src/pages/library/artifact-row.tsx
@@ -33,7 +33,7 @@ export function ArtifactRow({
   onPrefetch?: () => void
 }) {
   const isOwner = a.my_role === "owner"
-  const updated = a.updated_at ?? a.versions[0]?.created_at
+  const updated = a.updated_at ?? a.created_at ?? a.versions[0]?.created_at
   const dir = a.source_path ? dirOf(a.source_path) : ""
   const tags = a.tags ?? []
 

--- a/apps/web/src/pages/library/artifact-row.tsx
+++ b/apps/web/src/pages/library/artifact-row.tsx
@@ -1,0 +1,149 @@
+import { Folder } from "lucide-react"
+import type { Artifact } from "@/api"
+import { Icon } from "@/components/icons"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { ago } from "@/lib/time"
+import { cn } from "@/lib/utils"
+import { artifactTypeLabel, dirOf } from "./artifact-card"
+
+/**
+ * A compact list row for the library (the default for collections / synced repos,
+ * where a flat thumbnail grid is noise for hundreds of docs). Reads top-to-bottom:
+ * title, when it was last updated, then a meta line of type + folder location + tags.
+ * Same stretched-link + independently-clickable-controls pattern as ArtifactCard.
+ */
+export function ArtifactRow({
+  artifact: a,
+  onOpen,
+  onToggleFavorite,
+  onPickTag,
+  onDelete,
+  onPrefetch,
+}: {
+  artifact: Artifact
+  onOpen: () => void
+  onToggleFavorite: () => void
+  onPickTag: (tag: string) => void
+  onDelete?: () => void
+  onPrefetch?: () => void
+}) {
+  const isOwner = a.my_role === "owner"
+  const updated = a.updated_at ?? a.versions[0]?.created_at
+  const dir = a.source_path ? dirOf(a.source_path) : ""
+  const tags = a.tags ?? []
+
+  return (
+    <div className="group relative flex items-center gap-3 rounded-lg border border-border bg-card px-3.5 py-2.5 transition-colors hover:border-primary hover:bg-hover">
+      <button
+        type="button"
+        data-testid={`artifact-row-open-${a.short_id}`}
+        onClick={onOpen}
+        onMouseEnter={onPrefetch}
+        onFocus={onPrefetch}
+        aria-label={`Open ${a.title ?? a.short_id}`}
+        className="flex min-w-0 flex-1 flex-col gap-0.5 text-left outline-none after:absolute after:inset-0 after:z-[1] after:rounded-lg after:content-[''] focus-visible:after:outline-2 focus-visible:after:-outline-offset-2 focus-visible:after:outline-ring"
+      >
+        <span className="truncate font-display text-base font-semibold text-foreground transition-colors group-hover:text-primary">
+          {a.title ?? a.short_id}
+        </span>
+        {updated && (
+          <span className="font-mono text-2xs text-muted-foreground">updated {ago(updated)}</span>
+        )}
+        <span className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-2xs text-muted-foreground">
+          <span className="rounded-[5px] border border-border-soft bg-secondary px-1.5 py-px text-foreground">
+            {artifactTypeLabel(a)}
+          </span>
+          {dir && (
+            <span className="inline-flex items-center gap-1 truncate" title={a.source_path ?? ""}>
+              <Folder className="size-3 shrink-0 text-primary" aria-hidden />
+              {dir}/
+            </span>
+          )}
+          {a.views !== undefined && a.views > 0 && (
+            <span className="inline-flex items-center gap-1" title={`${a.views} viewers`}>
+              <Icon name="views" size={12} />
+              {a.views > 999 ? `${(a.views / 1000).toFixed(1)}k` : a.views}
+            </span>
+          )}
+        </span>
+      </button>
+
+      {/* Tags sit above the stretched link so they stay independently clickable. */}
+      {tags.length > 0 && (
+        <div className="relative z-20 hidden max-w-[40%] flex-wrap justify-end gap-1.5 sm:flex">
+          {tags.slice(0, 4).map((t) => (
+            <button
+              key={t}
+              type="button"
+              data-testid={`artifact-row-tag-${t}`}
+              onClick={(e) => {
+                e.stopPropagation()
+                onPickTag(t)
+              }}
+              className="rounded-md border border-border bg-card px-1.5 py-px font-mono text-2xs text-primary transition hover:border-primary"
+            >
+              #{t}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <button
+        type="button"
+        data-testid={`artifact-row-favorite-${a.short_id}`}
+        title={a.favorite ? "Remove from favorites" : "Add to favorites"}
+        aria-label="Toggle favorite"
+        aria-pressed={a.favorite}
+        onClick={(e) => {
+          e.stopPropagation()
+          onToggleFavorite()
+        }}
+        className={cn(
+          "relative z-20 grid size-7 shrink-0 place-items-center rounded-md border bg-card transition hover:border-primary",
+          a.favorite ? "border-gold text-gold" : "border-border text-muted-foreground opacity-90",
+        )}
+      >
+        <Icon name="star" size={14} className={cn(!a.favorite && "text-muted-foreground")} />
+      </button>
+
+      {isOwner && onDelete && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              data-testid={`artifact-row-more-${a.short_id}`}
+              aria-label="More actions"
+              onClick={(e) => e.stopPropagation()}
+              className="relative z-20 grid size-7 shrink-0 place-items-center rounded-md border border-border bg-card text-muted-foreground opacity-0 transition hover:border-primary group-hover:opacity-100 focus:opacity-100"
+            >
+              <Icon name="more" size={14} />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent onClick={(e) => e.stopPropagation()}>
+            <DropdownMenuItem
+              data-testid={`artifact-row-delete-${a.short_id}`}
+              className="text-destructive focus:text-destructive"
+              onSelect={() => onDelete()}
+            >
+              <Icon name="delete" size={16} />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </div>
+  )
+}
+
+/** Most-recently-updated first; falls back to created/version time, then title. */
+export const byRecency = (a: Artifact, b: Artifact): number => {
+  const ta = a.updated_at ?? a.created_at ?? a.versions[0]?.created_at ?? ""
+  const tb = b.updated_at ?? b.created_at ?? b.versions[0]?.created_at ?? ""
+  if (ta !== tb) return tb.localeCompare(ta)
+  return (a.title ?? a.short_id).localeCompare(b.title ?? b.short_id)
+}

--- a/apps/web/src/pages/library/folder-groups.tsx
+++ b/apps/web/src/pages/library/folder-groups.tsx
@@ -1,14 +1,13 @@
 import { ChevronRight, Folder } from "lucide-react"
-import { useEffect, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import type { Artifact } from "@/api"
 import { cn } from "@/lib/utils"
-import { ArtifactCard } from "./artifact-card"
+import { ArtifactRow } from "./artifact-row"
 
 const dirOf = (p: string): string => {
   const i = p.lastIndexOf("/")
   return i < 0 ? "" : p.slice(0, i)
 }
-const sortKey = (a: Artifact) => a.source_path ?? a.title ?? a.short_id
 
 interface Handlers {
   onOpen: (a: Artifact) => void
@@ -18,16 +17,15 @@ interface Handlers {
 }
 
 /**
- * A mirrored repo is a file tree, so its collection renders grouped by folder
- * (from each artifact's `source_path`) rather than one flat grid. Folders are
- * collapsible; the whole collection is loaded up front so the grouping is
- * complete (collections are finite, and scoping keeps them small).
+ * The opt-in folder view for a mirrored repo: artifacts grouped by their `source_path`
+ * folder, the tree ordered alphabetically (a file-explorer mental model) while items
+ * within a folder keep the incoming order (most-recently-updated first). Collapsible.
+ * The parent loads the whole collection up front, so every folder is complete.
  */
 export function FolderGroups({
   items,
   hasNextPage,
   isFetchingNextPage,
-  onLoadMore,
   ...handlers
 }: {
   items: Artifact[]
@@ -35,11 +33,6 @@ export function FolderGroups({
   isFetchingNextPage: boolean
   onLoadMore: () => void
 } & Handlers) {
-  // Pull the remaining pages so every folder is fully populated.
-  useEffect(() => {
-    if (hasNextPage && !isFetchingNextPage) onLoadMore()
-  }, [hasNextPage, isFetchingNextPage, onLoadMore])
-
   const groups = useMemo(() => {
     const m = new Map<string, Artifact[]>()
     for (const a of items) {
@@ -48,11 +41,12 @@ export function FolderGroups({
       if (arr) arr.push(a)
       else m.set(key, [a])
     }
+    // Folders alphabetical (structural tree); items keep the incoming recency order.
     return [...m.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([dir, arts]) => ({
         dir,
-        items: arts.sort((x, y) => sortKey(x).localeCompare(sortKey(y))),
+        items: arts,
       }))
   }, [items])
 
@@ -90,9 +84,9 @@ function FolderSection({ dir, items, ...handlers }: { dir: string; items: Artifa
         <span className="font-mono text-xs text-muted-foreground">· {items.length}</span>
       </button>
       {open && (
-        <div className="ml-6 mt-1.5 grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-3">
+        <div className="ml-6 mt-1.5 flex flex-col gap-2">
           {items.map((a) => (
-            <ArtifactCard
+            <ArtifactRow
               key={a.short_id}
               artifact={a}
               onOpen={() => handlers.onOpen(a)}

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -10,23 +10,23 @@ import { useShell } from "@/components/shell-context"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { useAuth } from "@/ctx"
-import { cn } from "@/lib/utils"
 import { type LibraryParams, libraryArtifactsQuery, sharedArtifactsQuery } from "@/lib/queries"
 import { usePrefetchArtifact } from "@/lib/use-prefetch-artifact"
+import { cn } from "@/lib/utils"
 import { ArtifactCard } from "./artifact-card"
 import { ArtifactGrid } from "./artifact-grid"
 import { ArtifactRow, byRecency } from "./artifact-row"
 import { CollectionBar } from "./collection-bar"
 import { FolderGroups } from "./folder-groups"
-
-// Remember the folder view preference across visits (off by default: a flat,
-// most-recently-updated list is the default for a synced collection).
-const FOLDERS_KEY = "dock:show-folders"
 import { HowItWorks } from "./how-it-works"
 import { LibrarySkeleton } from "./library-skeleton"
 import { PublishCard } from "./publish-card"
 import { ShareCollectionDialog } from "./share-collection-dialog"
 import type { Filter } from "./types"
+
+// Remember the folder view preference across visits (off by default: a flat,
+// most-recently-updated list is the default for a synced collection).
+const FOLDERS_KEY = "dock:show-folders"
 
 // Route component for "/". The persistent AppShell (mounted once around the
 // router Outlet) owns the rail/pod and the auth gate, so this just renders the

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -1,7 +1,7 @@
 import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate, useSearch } from "@tanstack/react-router"
-import { X } from "lucide-react"
-import { useEffect, useRef, useState } from "react"
+import { FolderTree, List, X } from "lucide-react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
 import { type Artifact, api } from "@/api"
 import { Icon } from "@/components/icons"
@@ -10,12 +10,18 @@ import { useShell } from "@/components/shell-context"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { useAuth } from "@/ctx"
+import { cn } from "@/lib/utils"
 import { type LibraryParams, libraryArtifactsQuery, sharedArtifactsQuery } from "@/lib/queries"
 import { usePrefetchArtifact } from "@/lib/use-prefetch-artifact"
 import { ArtifactCard } from "./artifact-card"
 import { ArtifactGrid } from "./artifact-grid"
+import { ArtifactRow, byRecency } from "./artifact-row"
 import { CollectionBar } from "./collection-bar"
 import { FolderGroups } from "./folder-groups"
+
+// Remember the folder view preference across visits (off by default: a flat,
+// most-recently-updated list is the default for a synced collection).
+const FOLDERS_KEY = "dock:show-folders"
 import { HowItWorks } from "./how-it-works"
 import { LibrarySkeleton } from "./library-skeleton"
 import { PublishCard } from "./publish-card"
@@ -43,6 +49,14 @@ function LibraryBody() {
   const [shareCol, setShareCol] = useState<(typeof collections)[number] | null>(null)
   const [query, setQuery] = useState(search.q ?? "")
   const [debouncedQ, setDebouncedQ] = useState((search.q ?? "").trim())
+  // Folder vs flat-list view (synced collections). Off by default; remembered.
+  const [showFolders, setShowFolders] = useState(
+    () => typeof window !== "undefined" && localStorage.getItem(FOLDERS_KEY) === "1",
+  )
+  const toggleFolders = (on: boolean) => {
+    setShowFolders(on)
+    localStorage.setItem(FOLDERS_KEY, on ? "1" : "0")
+  }
 
   // Derive the active filter from the URL search params.
   const filter: Filter =
@@ -75,6 +89,21 @@ function LibraryBody() {
   const { data, isPending, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery(listQuery)
   const items = data?.pages.flatMap((p) => p.artifacts) ?? []
+
+  // A synced repo collection (artifacts carry a source_path) gets the folder/flat
+  // treatment: a flat, most-recently-updated list by default, with an optional folder
+  // view. Other lists (home, tags, favorites, hand-built collections) keep the grid.
+  const isSyncedCollection = filter.kind === "collection" && items.some((a) => a.source_path)
+  // Pull the whole collection so the sort + grouping see every doc (collections are
+  // finite and scoping keeps them small) — same as the folder view always did.
+  useEffect(() => {
+    if (isSyncedCollection && hasNextPage && !isFetchingNextPage) fetchNextPage()
+  }, [isSyncedCollection, hasNextPage, isFetchingNextPage, fetchNextPage])
+  // Default order everywhere a synced collection renders: most recently updated first.
+  const recencyItems = useMemo(
+    () => (isSyncedCollection ? [...items].sort(byRecency) : items),
+    [isSyncedCollection, items],
+  )
 
   // Star toggle is optimistic across every cached page; in the Favorites view an
   // un-star drops the card. Reconcile against the server on failure.
@@ -339,18 +368,72 @@ function LibraryBody() {
           ) : (
             <EmptyState>{emptyMessage}</EmptyState>
           )
-        ) : filter.kind === "collection" && items.some((a) => a.source_path) ? (
-          // A mirrored repo: browse it as a folder tree instead of a flat grid.
-          <FolderGroups
-            items={items}
-            hasNextPage={!!hasNextPage}
-            isFetchingNextPage={isFetchingNextPage}
-            onLoadMore={() => fetchNextPage()}
-            onOpen={(a) => nav({ to: "/a/$ref", params: { ref: a.short_id } })}
-            onToggleFavorite={toggleFav}
-            onPickTag={(tag) => nav({ to: "/", search: { tag } })}
-            onPrefetch={(a) => prefetch(a.short_id, a.current_version)}
-          />
+        ) : isSyncedCollection ? (
+          // A mirrored repo. Default to a flat, most-recently-updated list; folders are
+          // there as a toggle (off by default) so the tree is available but not forced.
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center gap-1 self-end rounded-lg border border-border bg-card p-0.5">
+              <button
+                type="button"
+                data-testid="library-view-list"
+                onClick={() => toggleFolders(false)}
+                aria-pressed={!showFolders}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+                  !showFolders
+                    ? "bg-accent text-accent-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                <List className="size-3.5" aria-hidden /> List
+              </button>
+              <button
+                type="button"
+                data-testid="library-view-folders"
+                onClick={() => toggleFolders(true)}
+                aria-pressed={showFolders}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+                  showFolders
+                    ? "bg-accent text-accent-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                <FolderTree className="size-3.5" aria-hidden /> Folders
+              </button>
+            </div>
+            {showFolders ? (
+              <FolderGroups
+                items={recencyItems}
+                hasNextPage={!!hasNextPage}
+                isFetchingNextPage={isFetchingNextPage}
+                onLoadMore={() => fetchNextPage()}
+                onOpen={(a) => nav({ to: "/a/$ref", params: { ref: a.short_id } })}
+                onToggleFavorite={toggleFav}
+                onPickTag={(tag) => nav({ to: "/", search: { tag } })}
+                onPrefetch={(a) => prefetch(a.short_id, a.current_version)}
+              />
+            ) : (
+              <div className="flex flex-col gap-2" data-testid="library-flat-list">
+                {recencyItems.map((a) => (
+                  <ArtifactRow
+                    key={a.short_id}
+                    artifact={a}
+                    onOpen={() => nav({ to: "/a/$ref", params: { ref: a.short_id } })}
+                    onToggleFavorite={() => toggleFav(a)}
+                    onPickTag={(tag) => nav({ to: "/", search: { tag } })}
+                    onDelete={() => deleteArtifact(a)}
+                    onPrefetch={() => prefetch(a.short_id, a.current_version)}
+                  />
+                ))}
+                {(hasNextPage || isFetchingNextPage) && (
+                  <div className="py-2 text-center text-sm text-muted-foreground">
+                    Loading the rest…
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
         ) : (
           <>
             <ArtifactGrid

--- a/apps/web/src/pages/settings/github-section.tsx
+++ b/apps/web/src/pages/settings/github-section.tsx
@@ -1,13 +1,16 @@
 import { useQueryClient } from "@tanstack/react-query"
-import { CheckCircle2 } from "lucide-react"
-import { useCallback, useEffect, useState } from "react"
+import { AlertTriangle, CheckCircle2, Loader2 } from "lucide-react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 import {
   api,
   type GithubSyncStatus,
   type InstallationRepo,
+  parseProgress,
   type RepoSource,
   type SyncPreview,
+  type SyncProgress,
+  type SyncStatus,
 } from "@/api"
 import { EmptyState } from "@/components/shared/empty-state"
 import { Spinner } from "@/components/shared/spinner"
@@ -121,8 +124,8 @@ export function GithubSection() {
           GitHub App, or a one-off public repo). */}
       <AdvancedPat
         onCreated={() => {
-          toast.success("Repo connected — hit Sync now")
-          load()
+          toast.success("Repo connected — syncing")
+          refresh()
         }}
         onError={(m) => toast.error(m)}
       />
@@ -414,6 +417,37 @@ function RepoPicker({
   )
 }
 
+// Exact, human wording for each phase. The user wants zero guessing about what's
+// happening, so every state is spelled out — headline + a detail line.
+const phaseHeadline = (p: SyncProgress, repo: string): string => {
+  switch (p.phase) {
+    case "queued":
+      return "Starting on our servers…"
+    case "listing":
+      return "Connecting to GitHub, listing files…"
+    case "mirroring":
+      return p.total > 0 ? `Mirroring ${repo}` : "Mirroring files…"
+    case "done":
+      return "Sync complete"
+    case "error":
+      return "Sync failed"
+  }
+}
+const phaseDetail = (p: SyncProgress): string => {
+  switch (p.phase) {
+    case "queued":
+      return "Queued — the server is picking this up"
+    case "listing":
+      return "Scanning the repository tree"
+    case "mirroring":
+      return p.total > 0 ? `${p.done} of ${p.total} files mirrored` : "Fetching the file list…"
+    case "done":
+      return `${p.total || p.done} doc${(p.total || p.done) === 1 ? "" : "s"} mirrored`
+    case "error":
+      return p.message ?? "Unknown error"
+  }
+}
+
 function RepoSourceRow({
   source,
   onChanged,
@@ -423,37 +457,69 @@ function RepoSourceRow({
   onChanged: (m: string) => void
   onError: (m: string) => void
 }) {
-  const [busy, setBusy] = useState(false)
-  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null)
-  // Drive the sync in bounded batches: call run repeatedly until nothing remains,
-  // surfacing a live "done/total" so a large repo shows progress instead of hanging.
-  const sync = useCallback(async () => {
-    setBusy(true)
-    let done = 0
-    let total = 0
-    try {
-      for (;;) {
-        const r = await api.runRepoSync(source.id)
-        done += r.added + r.updated + r.skipped + r.renamed
-        if (total === 0) total = done + r.remaining
-        setProgress({ done: Math.min(done, total), total })
-        if (r.remaining === 0) break
+  // Local live status, seeded from the source's persisted progress so the bar renders
+  // instantly — even on a fresh page load mid-sync (the tab-independence proof). The
+  // poll overwrites it every ~1.5s while a sync runs.
+  const [status, setStatus] = useState<SyncStatus>(() => ({
+    id: source.id,
+    repo: source.repo,
+    progress: source.progress,
+    last_status: source.last_status,
+    last_synced_at: source.last_synced_at,
+    file_count: source.file_count,
+  }))
+  const prog = parseProgress(status.progress)
+  const phase = prog?.phase
+  const active = phase === "queued" || phase === "listing" || phase === "mirroring"
+  const errored = phase === "error" || (!active && (status.last_status ?? "").startsWith("error"))
+
+  // Poll the cheap status endpoint while a sync is active; stop on done/error. The
+  // server runs the sync (a Durable Object on the edge, a detached loop on Node), so
+  // this only reads progress — closing the tab never stops the work.
+  useEffect(() => {
+    if (!active) return
+    let alive = true
+    const iv = setInterval(async () => {
+      try {
+        const s = await api.syncStatus(source.id)
+        if (alive) setStatus(s)
+      } catch {
+        // transient network blip — keep polling; a real failure lands as phase=error
       }
-      onChanged(`Synced ${source.repo}: ${total} doc${total === 1 ? "" : "s"}`)
+    }, 1500)
+    return () => {
+      alive = false
+      clearInterval(iv)
+    }
+  }, [active, source.id])
+
+  // Fire the parent refresh exactly once when a sync finishes (active → done/error),
+  // so the library's collection count updates and a toast confirms the outcome.
+  const wasActive = useRef(active)
+  useEffect(() => {
+    if (wasActive.current && !active) {
+      if (phase === "done") onChanged(`Synced ${source.repo}`)
+      else if (phase === "error") onError(prog?.message ?? "Sync failed")
+    }
+    wasActive.current = active
+  }, [active, phase, prog?.message, source.repo, onChanged, onError])
+
+  const sync = async () => {
+    try {
+      // Trigger + adopt the server's state. With a runner this returns "queued" (the
+      // poll takes over); without one (self-host) it returns the finished source.
+      const r = await api.runRepoSync(source.id)
+      setStatus((s) => ({
+        ...s,
+        progress: r.progress,
+        last_status: r.last_status,
+        last_synced_at: r.last_synced_at,
+        file_count: r.file_count,
+      }))
     } catch (e) {
       onError((e as Error).message)
-    } finally {
-      setBusy(false)
-      setProgress(null)
     }
-  }, [source.id, source.repo, onChanged, onError])
-
-  // Auto-start the first sync when a freshly-connected repo appears. Run once on
-  // mount only — re-running on every sync()/last_synced_at change would loop.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional run-once
-  useEffect(() => {
-    if (!source.last_synced_at) sync()
-  }, [])
+  }
 
   const remove = async () => {
     try {
@@ -463,57 +529,115 @@ function RepoSourceRow({
       onError((e as Error).message)
     }
   }
-  const status = source.last_status ?? "never synced"
-  const errored = status.startsWith("error")
-  const pct =
-    progress && progress.total > 0 ? Math.round((progress.done / progress.total) * 100) : 0
+
+  const pct = prog && prog.total > 0 ? Math.min(100, Math.round((prog.done / prog.total) * 100)) : 0
+  // Queued / listing have no count yet → an indeterminate, pulsing bar.
+  const indeterminate = active && (!prog || prog.total === 0)
+
   return (
-    <Card data-testid={`github-row-${source.id}`} className="flex items-center gap-2.5 p-3.5">
-      <div className="min-w-0 flex-1">
-        <div className="truncate font-mono text-xs text-foreground">
-          {source.repo}
-          <span className="text-muted-foreground"> · {source.ref}</span>
-          {source.installation_id && <span className="text-muted-foreground"> · app</span>}
-        </div>
-        {progress ? (
-          <div
-            className="mt-1 flex items-center gap-2"
-            data-testid={`github-progress-${source.id}`}
-          >
-            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-secondary">
-              <div className="h-full bg-primary transition-all" style={{ width: `${pct}%` }} />
+    <Card data-testid={`github-row-${source.id}`} className="flex flex-col gap-3 p-3.5">
+      <div className="flex items-center gap-2.5">
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-mono text-xs text-foreground">
+            {source.repo}
+            <span className="text-muted-foreground"> · {source.ref}</span>
+            {source.installation_id && <span className="text-muted-foreground"> · app</span>}
+          </div>
+          {!active && !errored && (
+            <div className="mt-px flex items-center gap-1 truncate font-mono text-2xs text-muted-foreground">
+              {(status.last_status?.startsWith("ok") || status.last_synced_at) && (
+                <CheckCircle2 className="size-3 shrink-0 text-success" aria-hidden />
+              )}
+              {status.file_count} doc{status.file_count === 1 ? "" : "s"}
+              {status.last_synced_at
+                ? ` · synced ${ago(status.last_synced_at)}`
+                : " · never synced"}
             </div>
-            <span className="shrink-0 font-mono text-2xs text-muted-foreground">
-              {progress.done}/{progress.total}
-            </span>
-          </div>
-        ) : (
-          <div
-            className={`mt-px truncate font-mono text-2xs ${errored ? "text-destructive" : "text-muted-foreground"}`}
-          >
-            {source.file_count} doc{source.file_count === 1 ? "" : "s"} · {status}
-            {source.last_synced_at && ` · synced ${ago(source.last_synced_at)}`}
-          </div>
-        )}
+          )}
+        </div>
+        <Button
+          data-testid={`github-sync-${source.id}`}
+          variant="default"
+          size="sm"
+          onClick={sync}
+          disabled={active}
+        >
+          {active ? "Syncing…" : "Sync now"}
+        </Button>
+        <Button
+          data-testid={`github-remove-${source.id}`}
+          variant="ghost"
+          size="sm"
+          className="text-destructive hover:text-destructive"
+          onClick={remove}
+        >
+          Disconnect
+        </Button>
       </div>
-      <Button
-        data-testid={`github-sync-${source.id}`}
-        variant="default"
-        size="sm"
-        onClick={sync}
-        disabled={busy}
-      >
-        {busy ? "Syncing…" : "Sync now"}
-      </Button>
-      <Button
-        data-testid={`github-remove-${source.id}`}
-        variant="ghost"
-        size="sm"
-        className="text-destructive hover:text-destructive"
-        onClick={remove}
-      >
-        Disconnect
-      </Button>
+
+      {/* ACTIVE — the giant, explicit progress block. Every phase named, live counts,
+          a clear %, and a standing reassurance that it runs on the server. */}
+      {active && prog && (
+        <div
+          className="flex flex-col gap-2 rounded-lg border border-primary/30 bg-primary/5 p-3"
+          data-testid={`github-progress-${source.id}`}
+        >
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-2 text-sm font-semibold text-foreground">
+              <Loader2 className="size-4 shrink-0 animate-spin text-primary" aria-hidden />
+              <span className="truncate">{phaseHeadline(prog, source.repo)}</span>
+            </div>
+            {!indeterminate && (
+              <span className="shrink-0 font-mono text-sm font-semibold tabular-nums text-primary">
+                {pct}%
+              </span>
+            )}
+          </div>
+
+          <div className="h-2.5 w-full overflow-hidden rounded-full bg-secondary">
+            <div
+              className={`h-full rounded-full bg-primary transition-all duration-500 ${indeterminate ? "w-1/3 animate-pulse" : ""}`}
+              style={indeterminate ? undefined : { width: `${pct}%` }}
+            />
+          </div>
+
+          <div
+            className="font-mono text-2xs text-muted-foreground"
+            data-testid={`github-progress-detail-${source.id}`}
+          >
+            {phaseDetail(prog)}
+          </div>
+
+          <div className="flex items-center gap-1.5 text-2xs text-muted-foreground">
+            <CheckCircle2 className="size-3 shrink-0 text-success" aria-hidden />
+            Running on our servers — you can close this tab, it’ll keep going.
+          </div>
+        </div>
+      )}
+
+      {/* ERROR — red block with the message and a one-click retry. */}
+      {errored && !active && (
+        <div
+          className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3"
+          data-testid={`github-error-${source.id}`}
+        >
+          <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" aria-hidden />
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-semibold text-destructive">Sync failed</div>
+            <div className="mt-0.5 break-words font-mono text-2xs text-muted-foreground">
+              {prog?.message ?? status.last_status ?? "Unknown error"}
+            </div>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={sync}
+            data-testid={`github-retry-${source.id}`}
+          >
+            Try again
+          </Button>
+        </div>
+      )}
     </Card>
   )
 }

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -3,4 +3,13 @@ import { Settings } from "../pages/settings"
 
 export const Route = createFileRoute("/settings")({
   component: Settings,
+  // Identity validator: types an optional `?tab=` (so a typed Link can deep-link to a
+  // tab, e.g. the sync chip → GitHub) while preserving any other params the GitHub
+  // install redirect lands with (gh_install / gh_error, read from window.location).
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { tab?: string } & Record<string, unknown> => ({
+    ...search,
+    tab: typeof search.tab === "string" ? search.tab : undefined,
+  }),
 })

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS artifact (
   current_version INTEGER NOT NULL DEFAULT 0,
   current_content_type TEXT,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at TEXT,
   removed_at TEXT,
   source_path TEXT
 );

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -204,6 +204,7 @@ CREATE TABLE IF NOT EXISTS repo_source (
   files TEXT NOT NULL DEFAULT '{}',
   last_synced_at TEXT,
   last_status TEXT,
+  progress TEXT,
   created_by TEXT NOT NULL,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   FOREIGN KEY (collection_id) REFERENCES collection(id)

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS artifact (
   current_version INTEGER NOT NULL DEFAULT 0,
   current_content_type TEXT,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   removed_at TEXT,
   source_path TEXT
 );

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "format": "biome format --write",
     "check": "biome check",
     "check:fix": "biome check --write",
-    "ci": "biome ci && pnpm lint:tokens && pnpm lint:frontend && pnpm lint:testids && pnpm lint:api && pnpm lint:schema && pnpm lint:filesize && pnpm lint:deadcode"
+    "ci": "biome ci && pnpm lint:tokens && pnpm lint:frontend && pnpm lint:testids && pnpm lint:api && pnpm lint:schema && pnpm lint:filesize && pnpm lint:deadcode",
+    "precommit": "biome check && pnpm lint:tokens && pnpm lint:frontend && pnpm lint:testids && pnpm lint:api && pnpm lint:schema && pnpm lint:filesize",
+    "prepare": "git config core.hooksPath .githooks || true"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -43,9 +43,9 @@ export interface ArtifactRecord {
   /** Denormalized from the current version row — updated on every publish. */
   current_content_type: string | null
   created_at: string
-  /** Bumped on every new version (publish/sync); equals created_at until first revised.
-   *  Drives "most recently updated" ordering + the "updated X ago" label. */
-  updated_at: string
+  /** Set on every new version (publish/sync); null until first versioned (read it as
+   *  `updated_at ?? created_at`). Drives "most recently updated" sort + the label. */
+  updated_at: string | null
   /** A takedown tombstone: when set, the content is gone (410) but the record stays. */
   removed_at: string | null
   /** For a GitHub-synced artifact: its path within the repo (e.g. "docs/plans/foo.md").

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -286,10 +286,16 @@ export interface MetaStore {
     id: string,
     fields: { files: string; last_synced_at: string; last_status: string },
   ): Promise<void>
+  /** Write just the live `progress` JSON (cheap, frequent — drives the UI bar). */
+  setRepoSourceProgress(id: string, progress: string | null): Promise<void>
   deleteRepoSource(id: string, orgId: string): Promise<void>
   /** Every source backed by a GitHub App installation, across workspaces — the
    *  webhook router resolves push/repo events to the sources to re-sync. */
   listRepoSourcesByInstallation(installationId: string): Promise<RepoSourceRecord[]>
+  /** Every source with a non-null `progress`, across workspaces — the Node entry
+   *  resumes any left mid-sync on boot (a process restart) so it finishes
+   *  server-side. The caller filters to the still-running phases. */
+  listSyncingRepoSources(): Promise<RepoSourceRecord[]>
   /** Ids of every artifact mirrored from a sync source in this workspace —
    *  drives the read-only gate + the `managed` flag (synced docs aren't editable). */
   managedArtifactIds(orgId: string): Promise<string[]>
@@ -728,6 +734,20 @@ export interface NewCollectionMember {
  * tombstone vanished ones. The token is a read-only PAT (null for public repos)
  * and is never returned to clients (redacted in list responses).
  */
+/** Live, pollable progress for one repo sync (stored as JSON in repo_source.progress).
+ *  `phase` runs queued → listing → mirroring → done|error. The UI renders done/total. */
+export interface SyncProgress {
+  phase: "queued" | "listing" | "mirroring" | "done" | "error"
+  /** Docs mirrored so far. */
+  done: number
+  /** Total matching docs this run (0 until the tree is listed). */
+  total: number
+  /** Error text when phase === "error". */
+  message?: string
+  /** ISO time of this update (drives a "stalled?" check + resume on Node restart). */
+  updatedAt: string
+}
+
 export interface RepoSourceRecord {
   id: string
   org_id: string
@@ -747,6 +767,9 @@ export interface RepoSourceRecord {
   last_synced_at: string | null
   /** "ok" or "error: …" from the last run. */
   last_status: string | null
+  /** Live sync progress as JSON (see SyncProgress): phase + done/total, written
+   *  frequently during a run so the UI can poll a precise bar. Null = never run. */
+  progress: string | null
   created_by: string
   created_at: string
 }

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -43,6 +43,9 @@ export interface ArtifactRecord {
   /** Denormalized from the current version row — updated on every publish. */
   current_content_type: string | null
   created_at: string
+  /** Bumped on every new version (publish/sync); equals created_at until first revised.
+   *  Drives "most recently updated" ordering + the "updated X ago" label. */
+  updated_at: string
   /** A takedown tombstone: when set, the content is gone (410) but the record stays. */
   removed_at: string | null
   /** For a GitHub-synced artifact: its path within the repo (e.g. "docs/plans/foo.md").

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -312,6 +312,8 @@ export const toJson = (baseUrl: string, a: ArtifactRecord, versions: VersionReco
   locked: !!a.locked,
   current_version: a.current_version,
   created_at: a.created_at,
+  /** Bumped on each new version; drives "most recently updated" sort + the label. */
+  updated_at: a.updated_at,
   /** Repo path for a GitHub-synced artifact (drives the folder view); null otherwise. */
   source_path: a.source_path,
   versions: versions.map((v) => ({

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -261,6 +261,7 @@ export const repoSource = pgTable("repo_source", {
   files: text("files").notNull().default("{}"),
   last_synced_at: text("last_synced_at"),
   last_status: text("last_status"),
+  progress: text("progress"),
   created_by: text("created_by").notNull(),
   created_at: text("created_at").notNull().$defaultFn(isoNow),
 })

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -38,8 +38,8 @@ export const artifact = pgTable("artifact", {
   current_version: integer("current_version").notNull().default(0),
   current_content_type: text("current_content_type"),
   created_at: text("created_at").notNull().$defaultFn(isoNow),
-  // Bumped on every new version; drives "most recently updated" ordering + label.
-  updated_at: text("updated_at").notNull().$defaultFn(isoNow),
+  // Set on every new version; null until first versioned (coalesces to created_at).
+  updated_at: text("updated_at"),
   removed_at: text("removed_at"),
   source_path: text("source_path"),
 })

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -38,6 +38,8 @@ export const artifact = pgTable("artifact", {
   current_version: integer("current_version").notNull().default(0),
   current_content_type: text("current_content_type"),
   created_at: text("created_at").notNull().$defaultFn(isoNow),
+  // Bumped on every new version; drives "most recently updated" ordering + label.
+  updated_at: text("updated_at").notNull().$defaultFn(isoNow),
   removed_at: text("removed_at"),
   source_path: text("source_path"),
 })

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -225,7 +225,11 @@ export class PgMetaStore implements MetaStore {
       await tx.insert(version).values({ ...v, artifact_id: artifactId, n })
       await tx
         .update(artifact)
-        .set({ current_version: n, current_content_type: v.content_type })
+        .set({
+          current_version: n,
+          current_content_type: v.content_type,
+          updated_at: new Date().toISOString(),
+        })
         .where(eq(artifact.id, artifactId))
       const rows = await tx
         .select()

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -53,7 +53,7 @@ import type {
   WebhookRecord,
   WorkspaceRecord,
 } from "@dock/core"
-import { and, asc, count, desc, eq, inArray, isNull, lte, or, sql } from "drizzle-orm"
+import { and, asc, count, desc, eq, inArray, isNotNull, isNull, lte, or, sql } from "drizzle-orm"
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres"
 import { Pool } from "pg"
 import type { Exhaustive, Shapes } from "./parity"
@@ -790,6 +790,9 @@ export class PgMetaStore implements MetaStore {
   ): Promise<void> {
     await this.db.update(repoSource).set(fields).where(eq(repoSource.id, id))
   }
+  async setRepoSourceProgress(id: string, progress: string | null): Promise<void> {
+    await this.db.update(repoSource).set({ progress }).where(eq(repoSource.id, id))
+  }
   async deleteRepoSource(id: string, orgId: string): Promise<void> {
     await this.db.delete(repoSource).where(and(eq(repoSource.id, id), eq(repoSource.org_id, orgId)))
   }
@@ -806,6 +809,9 @@ export class PgMetaStore implements MetaStore {
       .from(repoSource)
       .where(eq(repoSource.installation_id, installationId))
       .orderBy(desc(repoSource.created_at))
+  }
+  async listSyncingRepoSources(): Promise<RepoSourceRecord[]> {
+    return this.db.select().from(repoSource).where(isNotNull(repoSource.progress))
   }
 
   // ---- GitHub App (instance credentials + per-workspace installations) -----

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -282,7 +282,11 @@ export function makeRepos(db: SqliteDb) {
       .run()
     await db
       .update(artifact)
-      .set({ current_version: n, current_content_type: v.content_type })
+      .set({
+        current_version: n,
+        current_content_type: v.content_type,
+        updated_at: new Date().toISOString(),
+      })
       .where(eq(artifact.id, artifactId))
       .run()
     return (await getVersion(artifactId, n)) as VersionRecord

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -56,6 +56,7 @@ import {
   desc,
   eq,
   inArray,
+  isNotNull,
   isNull,
   like,
   lt,
@@ -775,6 +776,9 @@ export function makeRepos(db: SqliteDb) {
   ): Promise<void> => {
     await db.update(repoSource).set(fields).where(eq(repoSource.id, id)).run()
   }
+  const setRepoSourceProgress = async (id: string, progress: string | null): Promise<void> => {
+    await db.update(repoSource).set({ progress }).where(eq(repoSource.id, id)).run()
+  }
   const deleteRepoSource = async (id: string, orgId: string): Promise<void> => {
     await db
       .delete(repoSource)
@@ -798,6 +802,8 @@ export function makeRepos(db: SqliteDb) {
       .where(eq(repoSource.installation_id, installationId))
       .orderBy(desc(repoSource.created_at))
       .all()
+  const listSyncingRepoSources = async (): Promise<RepoSourceRecord[]> =>
+    db.select().from(repoSource).where(isNotNull(repoSource.progress)).all()
 
   // ---- GitHub App (instance credentials + per-workspace installations) -----
   const getGithubApp = async (): Promise<GitHubAppRecord | null> =>
@@ -1207,8 +1213,10 @@ export function makeRepos(db: SqliteDb) {
     getRepoSource,
     listRepoSources,
     updateRepoSourceSync,
+    setRepoSourceProgress,
     deleteRepoSource,
     listRepoSourcesByInstallation,
+    listSyncingRepoSources,
     managedArtifactIds,
     getGithubApp,
     setGithubApp,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -42,6 +42,10 @@ export const artifact = sqliteTable("artifact", {
   current_version: integer("current_version").notNull().default(0),
   current_content_type: text("current_content_type"),
   created_at: text("created_at").notNull().default(now),
+  // Bumped on every new version (publish/sync). Drives "most recently updated"
+  // ordering + the "updated X ago" label. Defaults to the create time, so a
+  // never-revised artifact reads created == updated.
+  updated_at: text("updated_at").notNull().default(now),
   removed_at: text("removed_at"),
   source_path: text("source_path"),
 })

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -277,6 +277,7 @@ export const repoSource = sqliteTable("repo_source", {
   files: text("files").notNull().default("{}"),
   last_synced_at: text("last_synced_at"),
   last_status: text("last_status"),
+  progress: text("progress"),
   created_by: text("created_by").notNull(),
   created_at: text("created_at").notNull().default(now),
 })

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -42,10 +42,11 @@ export const artifact = sqliteTable("artifact", {
   current_version: integer("current_version").notNull().default(0),
   current_content_type: text("current_content_type"),
   created_at: text("created_at").notNull().default(now),
-  // Bumped on every new version (publish/sync). Drives "most recently updated"
-  // ordering + the "updated X ago" label. Defaults to the create time, so a
-  // never-revised artifact reads created == updated.
-  updated_at: text("updated_at").notNull().default(now),
+  // Set on every new version (publish/sync); null until first versioned. Drives the
+  // "most recently updated" sort + the "updated X ago" label, coalescing to created_at
+  // when null. Nullable + no default so it adds cleanly via ALTER ADD COLUMN on
+  // existing DBs (SQLite forbids a non-constant default there).
+  updated_at: text("updated_at"),
   removed_at: text("removed_at"),
   source_path: text("source_path"),
 })

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -78,7 +78,11 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
           .values({ ...v, artifact_id: artifactId, n: next })
           .run()
         tx.update(artifact)
-          .set({ current_version: next, current_content_type: v.content_type })
+          .set({
+            current_version: next,
+            current_content_type: v.content_type,
+            updated_at: new Date().toISOString(),
+          })
           .where(eq(artifact.id, artifactId))
           .run()
         return next

--- a/packages/db/test/ddl-generated.test.ts
+++ b/packages/db/test/ddl-generated.test.ts
@@ -53,7 +53,7 @@ for (const [dialect, { schema, statements }] of Object.entries(dialects)) {
     // dialect timestamp default — correct only because all of them are timestamps. A
     // non-timestamp $defaultFn fails here so the default handling gets revisited.
     it("only known timestamp columns use the non-constant default backstop", () => {
-      const known = new Set(["created_at", "next_attempt_at"])
+      const known = new Set(["created_at", "updated_at", "next_attempt_at"])
       for (const table of Object.values(schema as Record<string, Table>))
         for (const col of Object.values(getTableColumns(table)) as AnyCol[])
           if (isTimestampDefault(col))

--- a/packages/db/test/ddl-generated.test.ts
+++ b/packages/db/test/ddl-generated.test.ts
@@ -53,7 +53,7 @@ for (const [dialect, { schema, statements }] of Object.entries(dialects)) {
     // dialect timestamp default — correct only because all of them are timestamps. A
     // non-timestamp $defaultFn fails here so the default handling gets revisited.
     it("only known timestamp columns use the non-constant default backstop", () => {
-      const known = new Set(["created_at", "updated_at", "next_attempt_at"])
+      const known = new Set(["created_at", "next_attempt_at"])
       for (const table of Object.values(schema as Record<string, Table>))
         for (const col of Object.values(getTableColumns(table)) as AnyCol[])
           if (isTimestampDefault(col))

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -103,15 +103,15 @@ export function runStoreContract(
 
     it("appends versions, bumps current_version, lists newest data", async () => {
       const a = await store.createArtifact(newArtifact())
-      // A fresh artifact carries an updated_at (set to ~create time; the recency key).
-      expect(a.updated_at).toBeTruthy()
+      // updated_at is null until first versioned (read as updated_at ?? created_at).
+      expect(a.updated_at).toBeNull()
       const v1 = await store.addVersion(a.id, newVersion({ message: "first" }))
       const v2 = await store.addVersion(a.id, newVersion({ message: "second" }))
       expect(v1.n).toBe(1)
       expect(v2.n).toBe(2)
       const after = await store.getByShortId(a.short_id)
       expect(after?.current_version).toBe(2)
-      // A new version bumps updated_at forward (drives the recency sort + label).
+      // A new version sets updated_at (>= create time) — drives recency sort + label.
       expect(after?.updated_at && after.updated_at >= a.created_at).toBe(true)
       expect(await store.listVersions(a.id)).toHaveLength(2)
       expect((await store.getVersion(a.id, 1))?.message).toBe("first")

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -103,11 +103,16 @@ export function runStoreContract(
 
     it("appends versions, bumps current_version, lists newest data", async () => {
       const a = await store.createArtifact(newArtifact())
+      // A fresh artifact carries an updated_at (set to ~create time; the recency key).
+      expect(a.updated_at).toBeTruthy()
       const v1 = await store.addVersion(a.id, newVersion({ message: "first" }))
       const v2 = await store.addVersion(a.id, newVersion({ message: "second" }))
       expect(v1.n).toBe(1)
       expect(v2.n).toBe(2)
-      expect((await store.getByShortId(a.short_id))?.current_version).toBe(2)
+      const after = await store.getByShortId(a.short_id)
+      expect(after?.current_version).toBe(2)
+      // A new version bumps updated_at forward (drives the recency sort + label).
+      expect(after?.updated_at && after.updated_at >= a.created_at).toBe(true)
       expect(await store.listVersions(a.id)).toHaveLength(2)
       expect((await store.getVersion(a.id, 1))?.message).toBe("first")
       expect(await store.getVersion(a.id, 99)).toBeNull()

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -276,6 +276,26 @@ export function runStoreContract(
       })
       expect(await store.managedArtifactIds(ORG)).toContain(art.id)
 
+      // Live progress: a cheap JSON column the engine writes every batch (the UI bar
+      // polls it). Null until a sync starts; listed cross-org so the Node entry can
+      // resume mid-flight syncs on boot; cleared back to null when done.
+      expect((await store.getRepoSource(src.id, ORG))?.progress).toBeNull()
+      expect(await store.listSyncingRepoSources()).toHaveLength(0)
+      await store.setRepoSourceProgress(
+        src.id,
+        JSON.stringify({
+          phase: "mirroring",
+          done: 3,
+          total: 10,
+          updatedAt: "2026-06-14T00:00:00.000Z",
+        }),
+      )
+      expect((await store.getRepoSource(src.id, ORG))?.progress).toContain('"phase":"mirroring"')
+      expect((await store.listSyncingRepoSources()).map((s) => s.id)).toContain(src.id)
+      await store.setRepoSourceProgress(src.id, null)
+      expect((await store.getRepoSource(src.id, ORG))?.progress).toBeNull()
+      expect(await store.listSyncingRepoSources()).toHaveLength(0)
+
       // Rename re-homes the artifact: retitle + clear any tombstone.
       await store.setArtifactRemoved(art.id, "2026-06-14T00:00:00.000Z")
       await store.setArtifactTitle(art.id, "docs/b.md")


### PR DESCRIPTION
## Problem
The sync run-loop lived in the browser (`RepoSourceRow` looped `runRepoSync`), so navigating away killed it and the row sat on "0 docs, never synced, Syncing..." with no bar for ~15s. That is the "stuck" sync.

## What changed
**Server-side, tab-independent**
- New `RepoSyncRunner` Durable Object (one per source) drives a sync to completion via self-rescheduling alarms (the proven `WebhookOutbox` pattern). It is the edge counterpart to a Node detached loop.
- Node self-host: a detached batch-loop (`node-sync.ts`) plus boot + 60s `resumeStalled()`, so a process restart mid-sync resumes. Idempotent via the persisted file-map.
- Routes hand off and return 202; `/run` falls back to an inline run when no runner is wired (tests/dev self-host). Connect and webhook push-sync launch too.

**Progress**
- New nullable `repo_source.progress` JSON (`{phase, done, total, message}`), written every batch (listing, mirroring, done/error). `done` is floored at the carried count so a multi-batch bar never snaps backward.
- Cheap `GET /:id/status` (poll) and `GET /active` (workspace) endpoints.

**UI**
- Settings row: a prominent bar with % and live counts, every phase named, and a standing "Running on our servers, you can close this tab, it'll keep going." Terminal done/error states with a Try-again button. Polls `/status`, no browser loop.
- Global sync chip in the app shell (polls `/active`), visible from any page, deep-links to the GitHub settings tab.

## Validation
Ran the real flow on Node self-host (not just unit tests):
- **Not blocking**: connect returns `queued` instantly; after 15s of total client silence the sync was `done 8/8` (the detached loop did it).
- **Survives server death**: killed the server mid-sync at 50/112, restarted, and `resumeStalled()` finished it to 112/112 with zero re-triggering (`resuming stalled syncs { count: 1 }` in the boot log).
- Multi-batch (112 files), real titles + `source_path`, error path, `/active` + `/status` all verified.
- 526 tests green, full typecheck + lint clean.

Already deployed to the live edge for testing (DO migration v3 + the `progress` column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)