### PR TITLE
ci: move flaky smoke suite out of the PR gate to post-deploy

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,24 +1,24 @@
 name: e2e smoke
 
 # The fast critical-path suite: one happy path per surface (sign up, publish →
-# comment → resolve, library, share, settings, theme, review) — runs in well
-# under two minutes.
+# comment → resolve, library, share, settings, theme, review).
 #
-# Runs on every PR (the pre-merge gate, so a broken critical path can't land),
-# on every push to main (the post-merge backstop), and on demand. Fast enough
-# (~2 min) that it gates a PR without slowing review.
+# NOT a PR gate yet — the suite still flakes under CI CPU contention (multi-context
+# owner+member specs starving on a small runner), so it must not block merges. It runs
+# POST-DEPLOY instead: `pnpm run deploy` triggers it on a successful deploy, and it can
+# be run on demand (workflow_dispatch). Re-add `pull_request:` once it's reliably green.
 on:
   workflow_dispatch:
-  pull_request:
-  push:
-    branches: [main]
 
 permissions:
   contents: read
 
 jobs:
   smoke:
-    runs-on: ubicloud-standard-2
+    # 4 vCPU + 2 workers: the review/share specs each drive two browser contexts
+    # (owner + member), so 4 workers on a 2-vCPU box oversubscribed the CPU and the UI
+    # didn't paint within the expect timeout — the toBeVisible() flakes. Right-size it.
+    runs-on: ubicloud-standard-4
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -33,7 +33,7 @@ jobs:
         run: pnpm --filter @dock/web exec playwright install --with-deps chromium
 
       - name: Smoke suite
-        run: pnpm --filter @dock/web test:e2e:smoke
+        run: pnpm --filter @dock/web test:e2e:smoke -- --workers=2
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,7 +18,8 @@
     "build:web": "pnpm --filter @dock/web build && node scripts/prep-edge-assets.mjs",
     "deploy:schema": "node scripts/apply-d1-schema.mjs",
     "migrate:auth": "tsx migrate-auth-d1.ts",
-    "deploy": "pnpm build:web && pnpm deploy:schema && tsx migrate-auth-d1.ts --apply && wrangler deploy",
+    "deploy": "pnpm build:web && pnpm deploy:schema && tsx migrate-auth-d1.ts --apply && wrangler deploy && pnpm deploy:smoke",
+    "deploy:smoke": "gh workflow run e2e-smoke.yml --ref main || echo 'post-deploy smoke not triggered (gh CLI unavailable) — run: gh workflow run e2e-smoke.yml'",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.worker.json",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"


### PR DESCRIPTION
Smoke flakes under CI CPU contention (review/share specs each drive two browser contexts; 4 workers on a 2-vCPU runner starve the CPU past the 10s expect timeout, so a different test fails each run). Not ready to gate merges.

- e2e-smoke.yml: workflow_dispatch only (drop pull_request + push-to-main). Runs post-deploy via the deploy script (deploy:smoke), plus on demand.
- Likely flake fix: ubicloud-standard-4 + --workers=2 (≈1 browser/core for the two-context specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)