### PR TITLE
fix: collection listing 500 (scope by JOIN, not a 433-id IN over D1's param cap)

### DIFF
--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -106,7 +106,9 @@ export const artifactRoutes = (ctx: AppContext) => {
     if (collectionId) {
       const col = await meta.getCollection(collectionId)
       if (!col) return c.json({ artifacts: [], next_cursor: null })
-      narrow(await meta.collectionArtifactIds(collectionId))
+      // Scope to the collection via a JOIN in listArtifacts (below), NOT by expanding
+      // its members into an id IN(): a large collection (hundreds of items) would blow
+      // D1's 100-bound-parameter cap and 500 the whole listing.
       listOrg = col.org_id
       collectionInfo = { id: col.id, title: col.title }
       collectionAccess =
@@ -131,6 +133,7 @@ export const artifactRoutes = (ctx: AppContext) => {
       cursor,
       q,
       ids,
+      collectionId,
       // Shared-with-me spans workspaces; an explicit member can always see them, so
       // drop the workspace + public-only restrictions for that scope.
       orgId: shared ? undefined : listOrg,

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -66,6 +66,10 @@ export interface ListArtifactsOpts {
   q?: string
   /** Restrict to these artifact ids (tag / favorite filters resolve to ids). Empty ⇒ none. */
   ids?: string[]
+  /** Scope to a collection by JOINing its membership rather than materializing every
+   *  member id into an `IN (...)`. A large collection (hundreds of items) would blow
+   *  D1's 100-bound-parameter cap and 500 — the join binds one parameter regardless. */
+  collectionId?: string
   /** Scope to one workspace (multi-workspace). Omitted ⇒ every workspace. */
   orgId?: string
   /** Only `public` artifacts. Set for anonymous / non-member callers so a workspace

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -53,7 +53,20 @@ import type {
   WebhookRecord,
   WorkspaceRecord,
 } from "@dock/core"
-import { and, asc, count, desc, eq, inArray, isNotNull, isNull, lte, or, sql } from "drizzle-orm"
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  getTableColumns,
+  inArray,
+  isNotNull,
+  isNull,
+  lte,
+  or,
+  sql,
+} from "drizzle-orm"
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres"
 import { Pool } from "pg"
 import type { Exhaustive, Shapes } from "./parity"
@@ -304,6 +317,18 @@ export class PgMetaStore implements MetaStore {
   listArtifacts(opts?: ListArtifactsOpts): Promise<ArtifactRecord[]> {
     if (opts?.ids && opts.ids.length === 0) return Promise.resolve([])
     const conds = artifactListConditions(artifact, opts)
+    // Collection scope is a JOIN, not an `id IN (…members)` — mirrors the SQLite/D1
+    // path in repos.ts so behavior matches across dialects (and never trips a param cap).
+    if (opts?.collectionId) {
+      conds.push(eq(collectionItem.collection_id, opts.collectionId))
+      const q = this.db
+        .select(getTableColumns(artifact))
+        .from(artifact)
+        .innerJoin(collectionItem, eq(collectionItem.artifact_id, artifact.id))
+        .where(and(...conds))
+        .orderBy(desc(artifact.created_at), desc(artifact.id))
+      return opts.limit ? q.limit(opts.limit) : q
+    }
     const q = this.db
       .select()
       .from(artifact)

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -55,6 +55,7 @@ import {
   count,
   desc,
   eq,
+  getTableColumns,
   inArray,
   isNotNull,
   isNull,
@@ -322,6 +323,18 @@ export function makeRepos(db: SqliteDb) {
   const listArtifacts = async (opts?: ListArtifactsOpts): Promise<ArtifactRecord[]> => {
     if (opts?.ids && opts.ids.length === 0) return []
     const conds = artifactListConditions(artifact, opts)
+    // Collection scope is a JOIN, never an `id IN (…members)`: a big collection would
+    // otherwise bind one parameter per member and trip D1's 100-param cap (a 500).
+    if (opts?.collectionId) {
+      conds.push(eq(collectionItem.collection_id, opts.collectionId))
+      const rows = db
+        .select(getTableColumns(artifact))
+        .from(artifact)
+        .innerJoin(collectionItem, eq(collectionItem.artifact_id, artifact.id))
+        .where(and(...conds))
+        .orderBy(desc(artifact.created_at), desc(artifact.id))
+      return opts.limit ? rows.limit(opts.limit).all() : rows.all()
+    }
     const rows = db
       .select()
       .from(artifact)

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -226,6 +226,13 @@ export function runStoreContract(
       expect(await store.collectionIdsForArtifact(a.id)).toContain(col.id)
       expect((await store.listCollections(ORG)).find((c) => c.id === col.id)?.count).toBe(1)
 
+      // listArtifacts scopes to a collection by JOIN (not an id IN(...) of every member):
+      // it returns only members, and an artifact outside the collection is excluded.
+      const outside = await store.createArtifact(newArtifact())
+      const inCol = await store.listArtifacts({ collectionId: col.id, orgId: ORG })
+      expect(inCol.map((x) => x.id)).toContain(a.id)
+      expect(inCol.map((x) => x.id)).not.toContain(outside.id)
+
       await store.setCollectionMember({
         id: uuid(),
         collection_id: col.id,


### PR DESCRIPTION
`GET /v1/artifacts?collection=<id>` 500'd for any sizable collection (e.g. "GitHub: Niftory/sift", 433 items) — refreshing the collection view always failed.

**Cause:** the route expanded every member id into `listArtifacts`' `ids` → `id IN (?, … ×433)`, exceeding **D1's 100-bound-parameter-per-query cap**. Only D1 hit it; SQLite/Postgres allow far more params, so the test suite stayed green.

**Fix:** scope the collection with an `INNER JOIN collection_item` (one bound param, any size). `listArtifacts` gains a `collectionId` opt (repos.ts → SQLite/D1, pg.ts → Postgres); the route passes it instead of narrowing into `ids`. Cross-dialect store-contract test covers the scoping.

405/405 api, 102 db, typecheck + all lint gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)