### PR TITLE
fix(sync): "updated" reflects the source last-commit date, not Dock ingest time

### DIFF
--- a/apps/api/src/lib/github.ts
+++ b/apps/api/src/lib/github.ts
@@ -76,6 +76,31 @@ export async function listTree(
   return { entries, truncated: !!data.truncated }
 }
 
+/**
+ * The committer date of the most recent commit that touched `path` on `ref` — the
+ * file's true last-change time, which drives a synced artifact's "updated" (the git
+ * tree carries no dates, so this is a separate call). Best-effort: returns null on any
+ * error or an empty history so a date lookup can never fail a sync.
+ */
+export async function lastCommitDate(
+  repo: RepoRef,
+  path: string,
+  ref: string,
+  token: string | null,
+): Promise<string | null> {
+  const url = `${API}/repos/${repo.owner}/${repo.name}/commits?path=${encodeURIComponent(
+    path,
+  )}&sha=${encodeURIComponent(ref)}&per_page=1`
+  try {
+    const res = await fetch(url, { headers: headers(token, "application/vnd.github+json") })
+    if (!res.ok) return null
+    const data = (await res.json()) as { commit?: { committer?: { date?: string } } }[]
+    return data[0]?.commit?.committer?.date ?? null
+  } catch {
+    return null
+  }
+}
+
 /** Raw bytes of one blob by its git sha. */
 export async function fetchBlob(
   repo: RepoRef,

--- a/apps/api/src/lib/sync.ts
+++ b/apps/api/src/lib/sync.ts
@@ -9,7 +9,7 @@ import {
 import { zipSync } from "fflate"
 import { type BundlePlan, commonDir, planBundle } from "./bundle-from-repo"
 import { sha256 } from "./crypto"
-import { fetchBlob, listTree, matchesGlobs, parseRepo } from "./github"
+import { fetchBlob, lastCommitDate, listTree, matchesGlobs, parseRepo } from "./github"
 
 /** Per-path mirror state, persisted as JSON in repo_source.files. */
 export interface SyncedFile {
@@ -26,6 +26,11 @@ export interface SyncedFile {
   /** For a bundle: each member's repo path → its blob sha, so we can tell which
    *  members changed and reconstruct the bundle without re-scanning when stable. */
   members?: Record<string, string>
+  /** The source file's last-commit date, mirrored into the artifact's `updated_at`
+   *  (so the card shows the SOURCE's last change, not Dock's ingest time). Set the
+   *  first time we resolve it; `""` records an attempt that found none (so we don't
+   *  retry forever); absent means not yet sourced → the date backfill will fill it. */
+  updatedAt?: string
 }
 type FileMap = Record<string, SyncedFile>
 
@@ -198,6 +203,28 @@ export async function runSync(
     }
   }
 
+  // Mirror the source file's last-commit date into the artifact's `updated_at`, so the
+  // card shows when the SOURCE last changed, not when Dock ingested it (the git tree
+  // carries no dates — this is one extra Commits API call per file). Records the result
+  // on the map entry: a real date, or `""` when none resolved, so a re-sync never
+  // re-fetches a file it already sourced. Best-effort — a null leaves publish's `now()`.
+  const stampDate = async (artifactId: string, repoPath: string, entry: SyncedFile) => {
+    const date = await lastCommitDate(repo, repoPath, source.ref, source.token)
+    if (date) await meta.setArtifactUpdatedAt(artifactId, date)
+    entry.updatedAt = date ?? ""
+  }
+  // The existing tracked files were synced before dates were sourced (`updatedAt`
+  // absent). Backfill them lazily — bounded per run so one sync doesn't make hundreds
+  // of Commits calls; the leftover counts as `remaining`, so the runner continues until
+  // every file is dated. Unbounded in tests (no `limits`).
+  const DATE_BACKFILL_PER_RUN = limits ? 150 : Number.POSITIVE_INFINITY
+  let datesBackfilled = 0
+  const backfillDate = async (entry: SyncedFile, repoPath: string) => {
+    if (entry.updatedAt !== undefined || datesBackfilled >= DATE_BACKFILL_PER_RUN) return
+    datesBackfilled++
+    await stampDate(entry.artifact_id, repoPath, entry)
+  }
+
   try {
     // First batch of a fresh source: show "connecting/listing" before the count.
     if (Object.keys(prev).length === 0) await writeProgress("listing")
@@ -314,7 +341,17 @@ export async function runSync(
       }
       await meta.setArtifactRemoved(artifact.id, null)
       await meta.setArtifactSourcePath(artifact.id, repoPath)
-      next[repoPath] = { artifact_id: artifact.id, short_id: artifact.short_id, sha, kind, members }
+      const entry: SyncedFile = {
+        artifact_id: artifact.id,
+        short_id: artifact.short_id,
+        sha,
+        kind,
+        members,
+      }
+      // A changed/new file: source its last-commit date now (this is the forward fix;
+      // a fresh full sync dates everything as it publishes, within the maxFiles batch).
+      await stampDate(artifact.id, repoPath, entry)
+      next[repoPath] = entry
       await onPublished()
     }
 
@@ -338,6 +375,7 @@ export async function runSync(
         for (const m of plan.members) memberShas[m.repoPath] = shaByPath.get(m.repoPath) ?? ""
         const composite = compositeSha(memberShas)
         if (before?.kind === "bundle" && before.sha === composite) {
+          await backfillDate(before, e.path) // source its date if it predates the feature
           next[e.path] = before
           res.skipped++
           continue
@@ -374,6 +412,7 @@ export async function runSync(
 
       // Single file. Unchanged → skip; pure rename → re-home; else publish.
       if (before && before.kind !== "bundle" && before.sha === e.sha) {
+        await backfillDate(before, e.path) // source its date if it predates the feature
         next[e.path] = before
         res.skipped++
         continue
@@ -454,7 +493,7 @@ export async function runSync(
     if (truncated || capped) carryForward()
 
     // Docs still needing work: not consumed, and not already current in `next`.
-    res.remaining = docs.filter((e) => {
+    const publishRemaining = docs.filter((e) => {
       if (consumed.has(e.path)) return false
       const n = next[e.path]
       if (!n) return true
@@ -466,6 +505,10 @@ export async function runSync(
       }
       return n.kind === "bundle" || n.sha !== e.sha
     }).length
+    // Files not yet date-sourced (the backfill hit its per-run cap) keep the run
+    // "remaining" so the runner re-invokes until every artifact carries a real date.
+    const dateRemaining = Object.values(next).filter((n) => n.updatedAt === undefined).length
+    res.remaining = publishRemaining + dateRemaining
 
     let status = capped
       ? `synced ${processed} this run · ${res.remaining} pending`

--- a/apps/api/test/sync.test.ts
+++ b/apps/api/test/sync.test.ts
@@ -14,6 +14,8 @@ type FileMap = Record<string, SyncedFile>
 let tree: { path: string; sha: string; type: "blob" | "tree" }[] = []
 let truncated = false
 const blobs: Record<string, string> = {}
+// repo path → the last-commit date the Commits API reports for it.
+const commitDates: Record<string, string> = {}
 
 const dir = mkdtempSync(join(tmpdir(), "dock-sync-test-"))
 const meta = new SqliteMetaStore(join(dir, "sync.db"))
@@ -27,6 +29,13 @@ beforeAll(() => {
       const s = String(url)
       if (s.includes("/git/trees/"))
         return new Response(JSON.stringify({ tree, truncated }), { status: 200 })
+      if (s.includes("/commits?")) {
+        const path = new URL(s).searchParams.get("path") ?? ""
+        const date = commitDates[path]
+        return new Response(JSON.stringify(date ? [{ commit: { committer: { date } } }] : []), {
+          status: 200,
+        })
+      }
       const m = s.match(/\/git\/blobs\/([^/?]+)/)
       if (m) {
         const body = blobs[m[1] as string]
@@ -302,6 +311,51 @@ describe("GitHub sync engine", () => {
     expect(r.remaining).toBe(0)
     const map = JSON.parse((await meta.getRepoSource(src.id))?.files ?? "{}") as FileMap
     expect(Object.keys(map).length).toBe(5) // every file mirrored, no duplicates
+  })
+
+  // ---- Source date → artifact.updated_at -------------------------------
+  it("stamps updated_at from the source file's last-commit date, and backfills legacy entries", async () => {
+    const col = await meta.createCollection({
+      id: newId("col"),
+      org_id: "local",
+      title: "dates",
+      created_by: "u",
+    })
+    const src = await meta.createRepoSource({
+      id: newId("rs"),
+      org_id: "local",
+      collection_id: col.id,
+      repo: "acme/dates",
+      ref: "main",
+      includes: "**/*.md",
+      created_by: "u",
+    })
+    tree = [{ path: "dated.md", sha: "dt-1", type: "blob" }]
+    blobs["dt-1"] = "# Dated"
+    commitDates["dated.md"] = "2025-01-02T03:04:05Z"
+
+    const load = async () => (await meta.getRepoSource(src.id)) as RepoSourceRecord
+
+    // Forward: a freshly published file carries the SOURCE date, not the sync `NOW`.
+    await runSync(meta, blobStore, src, NOW)
+    const map = JSON.parse((await load()).files) as FileMap
+    const sid = map["dated.md"]?.short_id as string
+    expect((await meta.getByShortId(sid))?.updated_at).toBe("2025-01-02T03:04:05Z")
+    expect(map["dated.md"]?.updatedAt).toBe("2025-01-02T03:04:05Z")
+
+    // Backfill: simulate a legacy entry synced before dates existed (updatedAt absent)
+    // by stripping it from the map + resetting the row, then re-sync (sha unchanged).
+    const legacy = { ...map["dated.md"] } as SyncedFile
+    legacy.updatedAt = undefined
+    await meta.updateRepoSourceSync(src.id, {
+      files: JSON.stringify({ "dated.md": legacy }),
+      last_synced_at: NOW,
+      last_status: "ok",
+    })
+    await meta.setArtifactUpdatedAt(legacy.artifact_id, NOW) // wrong (ingest-time) date
+    commitDates["dated.md"] = "2024-09-09T09:09:09Z"
+    await runSync(meta, blobStore, await load(), NOW)
+    expect((await meta.getByShortId(sid))?.updated_at).toBe("2024-09-09T09:09:09Z")
   })
 
   // ---- Live progress (the giant UI bar reads this) ----------------------

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -436,6 +436,10 @@ export interface MetaStore {
   setArtifactTitle(id: string, title: string): Promise<void>
   /** Set the repo path of a GitHub-synced artifact (its folder/tree "location"). */
   setArtifactSourcePath(id: string, sourcePath: string | null): Promise<void>
+  /** Override "updated_at" with an external timestamp (a synced file's last-commit
+   *  date), so the card's "updated" reflects the SOURCE's last change, not when Dock
+   *  ingested it. Publish bumps updated_at to now; the sync calls this after to correct it. */
+  setArtifactUpdatedAt(id: string, updatedAt: string): Promise<void>
   createAuditLog(a: NewAuditLog): Promise<void>
   /** Moderation history, newest first. One workspace's, or — super-admin, orgId
    *  undefined — the whole instance's. Optionally narrowed to one artifact. */

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1245,6 +1245,9 @@ export class PgMetaStore implements MetaStore {
   async setArtifactSourcePath(id: string, sourcePath: string | null): Promise<void> {
     await this.db.update(artifact).set({ source_path: sourcePath }).where(eq(artifact.id, id))
   }
+  async setArtifactUpdatedAt(id: string, updatedAt: string): Promise<void> {
+    await this.db.update(artifact).set({ updated_at: updatedAt }).where(eq(artifact.id, id))
+  }
   async createAuditLog(a: NewAuditLog): Promise<void> {
     await this.db.insert(auditLog).values(a)
   }

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -394,6 +394,9 @@ export function makeRepos(db: SqliteDb) {
   const setArtifactSourcePath = async (id: string, sourcePath: string | null): Promise<void> => {
     await db.update(artifact).set({ source_path: sourcePath }).where(eq(artifact.id, id)).run()
   }
+  const setArtifactUpdatedAt = async (id: string, updatedAt: string): Promise<void> => {
+    await db.update(artifact).set({ updated_at: updatedAt }).where(eq(artifact.id, id)).run()
+  }
 
   // ---- Comments + threads ------------------------------------------------
   const getComment = async (id: string): Promise<CommentRecord | null> =>
@@ -1199,6 +1202,7 @@ export function makeRepos(db: SqliteDb) {
     setArtifactRemoved,
     setArtifactTitle,
     setArtifactSourcePath,
+    setArtifactUpdatedAt,
     createComment,
     getComment,
     updateComment,


### PR DESCRIPTION
A synced artifact's card showed when it landed in Dock, not when the source file last changed — the git Trees API carries no dates, so the version timestamp was the sync time.

**Fix**
- `github.ts`: `lastCommitDate(repo, path, ref, token)` — committer date of the most recent commit touching a path (one Commits API call, best-effort/null-safe).
- `sync.ts`: on publish, stamp the artifact's `updated_at` with the source date; for files synced before this existed, **backfill lazily** — bounded 150/run, the rest counted as `remaining` so the runner re-invokes until every file is dated (the `updatedAt` map field, `""` = attempted/none, guarantees convergence).
- `MetaStore.setArtifactUpdatedAt` (repos.ts + pg.ts).
- Tests: forward stamp + legacy backfill; github mock gains a commits handler.

The backfill runs inside the normal sync (uses the GitHub App token), so the existing collection corrects itself over the next sync(s).

406/406 api, 102 db, typecheck + all lint gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)