### PR TITLE
perf(og): cache the OG thumbnail hard (1d + 1w stale-while-revalidate)

### DIFF
--- a/apps/api/src/routes/embeds.ts
+++ b/apps/api/src/routes/embeds.ts
@@ -73,7 +73,8 @@ export const embedRoutes = (ctx: AppContext) => {
 
   // The OG card image. SVG: zero-dep and identical on Node + Worker. A gated or
   // missing artifact gets a generic locked card (no title leak), still 200 so the
-  // unfurl shows something. Short cache: the card carries live version/comment counts.
+  // unfurl shows something. Cached hard (see the Cache-Control below) — the live
+  // version/comment counts on the card are allowed to lag for an unfurl preview.
   app.get("/v1/og/:ref", async (c) => {
     const artifact = await readable(c, c.req.param("ref"))
     const svg = artifact
@@ -87,7 +88,12 @@ export const embedRoutes = (ctx: AppContext) => {
         })
     return c.body(svg, 200, {
       "Content-Type": "image/svg+xml; charset=utf-8",
-      "Cache-Control": "public, max-age=600",
+      // Cache the thumbnail hard: only anon crawlers hit this (the app never does), and
+      // a gated artifact renders a title-less locked card, so there's nothing private to
+      // cache at the shared edge. 1 day fresh + a week of serve-stale-while-revalidate
+      // keeps regenerations rare while the card still refreshes in the background. The
+      // live version/comment counts can lag up to a day here — fine for an unfurl.
+      "Cache-Control": "public, max-age=86400, stale-while-revalidate=604800",
       "X-Content-Type-Options": "nosniff",
     })
   })


### PR DESCRIPTION
Bumps the OG card (`/v1/og/:ref`) cache from `max-age=600` (10 min) to `public, max-age=86400, stale-while-revalidate=604800` (1 day fresh + 1 week serve-stale-while-revalidating) — ~100× fewer regenerations, served from the browser/CF edge.

**Safe to cache long here:** the web app never fetches `/v1/og` (only anon crawlers do, via the `og:image` meta), and a gated artifact (`org`/`password`) fails `readable()` for anon → renders a **title-less locked card**. So the shared edge cache only ever holds the anon-appropriate view — no private title is cached.

**Tradeoff (freshness, not privacy):** the live version/comment counts on the card — and a rename/takedown — can lag up to ~a day. A removed artifact's *page* already stops emitting the `og:image` meta, so new unfurls show no card; SWR refreshes the rest in the background.

Left `embed` + `oembed` at 10 min since they reflect changing content. For zero-staleness later, a versioned OG URL (`?v=<version>`, cached `immutable`) is the clean follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)