### PR TITLE
Resolve relative cross-document links between synced artifacts

### DIFF
--- a/apps/api/src/lib/cross-doc.ts
+++ b/apps/api/src/lib/cross-doc.ts
@@ -1,0 +1,36 @@
+import type { ArtifactRecord, MetaStore } from "@dock/core"
+import { collectSiblingPaths, rewriteCrossDocLinks } from "@dock/core"
+
+/**
+ * The serve-time HTML transform that turns a GitHub-synced artifact's relative
+ * cross-document links (`<a href="walkthrough.html">`, or a markdown `[x](./x.md)`
+ * rendered to one) into in-app navigations to the sibling artifact each resolves to.
+ *
+ * Resolution keys on `source_path`: a relative href resolves against this artifact's
+ * repo path, and a sibling is any artifact in the same workspace published at that
+ * exact path. Returns undefined when the artifact isn't synced (no `source_path`) —
+ * there's nothing to resolve against, so serving stays untouched.
+ *
+ * One bounded query per served page (the distinct sibling paths actually linked, not
+ * the whole repo); a page with no resolvable links makes no query at all.
+ */
+export const crossDocTransform = (
+  meta: Pick<MetaStore, "siblingsBySourcePaths">,
+  artifact: Pick<ArtifactRecord, "org_id" | "source_path">,
+): ((html: string) => Promise<string>) | undefined => {
+  const sourcePath = artifact.source_path
+  if (!sourcePath) return undefined
+  return async (html) => {
+    const paths = collectSiblingPaths(html, sourcePath).filter((p) => p !== sourcePath)
+    if (paths.length === 0) return html
+    const siblings = await meta.siblingsBySourcePaths(artifact.org_id, paths)
+    if (siblings.length === 0) return html
+    const refByPath = new Map<string, string>()
+    // Skip a self-link (a doc referencing its own path) — re-navigating to the page
+    // you're on is pointless and would just reload the frame.
+    for (const s of siblings)
+      if (s.source_path !== sourcePath)
+        refByPath.set(s.source_path, s.slug ? `${s.slug}-${s.short_id}` : s.short_id)
+    return rewriteCrossDocLinks(html, sourcePath, refByPath)
+  }
+}

--- a/apps/api/src/lib/serve-content.ts
+++ b/apps/api/src/lib/serve-content.ts
@@ -33,8 +33,14 @@ export const serveContent = async (
    *  full HTML document). The caller uses this to self-heal the stored content_type
    *  so the mislabel is fixed permanently, not just rendered-around each view. */
   onMismatch?: () => void,
+  /** Serve-time rewrite applied to every HTML body this produces (a raw HTML file,
+   *  markdown-rendered output, or a mislabeled-HTML markdown blob) before the anchor
+   *  client is appended. Resolves a synced artifact's relative cross-document links
+   *  into in-app navigations; omitted ⇒ identity. */
+  transformHtml?: (html: string) => Promise<string>,
 ) => {
   const headers = { ...RAW_HEADERS, "Cache-Control": cacheControl }
+  const tx = (doc: string) => (transformHtml ? transformHtml(doc) : Promise.resolve(doc))
   let path = rawPath
   if (content.content_type === BUNDLE_CONTENT_TYPE) {
     const manifestBytes = await blobs.get(content.blob_key)
@@ -79,19 +85,19 @@ export const serveContent = async (
     // the label says — the type sniff is a hint, this is the backstop.
     if (looksLikeHtmlDocument(text)) {
       onMismatch?.()
-      return c.body(text + SELECTION_SCRIPT, 200, {
+      return c.body((await tx(text)) + SELECTION_SCRIPT, 200, {
         ...headers,
         "Content-Type": "text/html; charset=utf-8",
       })
     }
-    const html = await renderMarkdown(text, title)
+    const html = await tx(await renderMarkdown(text, title))
     return c.body(html, 200, { ...headers, "Content-Type": "text/html; charset=utf-8" })
   }
 
   // html file artifact — any path serves the document (+ selection capture)
   const ct = mimeFor(path || "index.html")
   if (ct.startsWith("text/html")) {
-    const html = new TextDecoder().decode(data) + SELECTION_SCRIPT
+    const html = (await tx(new TextDecoder().decode(data))) + SELECTION_SCRIPT
     return c.body(html, 200, { ...headers, "Content-Type": ct })
   }
   return c.body(toBody(data), 200, { ...headers, "Content-Type": ct })

--- a/apps/api/src/lib/sync.ts
+++ b/apps/api/src/lib/sync.ts
@@ -10,7 +10,14 @@ import {
 import { zipSync } from "fflate"
 import { type BundlePlan, commonDir, planBundle } from "./bundle-from-repo"
 import { sha256 } from "./crypto"
-import { fetchBlob, fetchBlobsBatch, lastCommitDate, listTree, matchesGlobs, parseRepo } from "./github"
+import {
+  fetchBlob,
+  fetchBlobsBatch,
+  lastCommitDate,
+  listTree,
+  matchesGlobs,
+  parseRepo,
+} from "./github"
 
 // Pre-warm the byte cache via BATCHED GraphQL reads rather than one GET per file:
 // GitHub bills an aliased multi-blob query at ~1 rate-limit point (vs 1 per file) and

--- a/apps/api/src/routes/raw.ts
+++ b/apps/api/src/routes/raw.ts
@@ -1,6 +1,7 @@
 import { ANCHOR_CLIENT_JS } from "@dock/core"
 import { Hono } from "hono"
 import type { AppContext } from "../context"
+import { crossDocTransform } from "../lib/cross-doc"
 import { cacheControlFor, TOMBSTONE } from "../lib/http"
 import { serveContent } from "../lib/serve-content"
 
@@ -45,6 +46,10 @@ export const rawRoutes = (ctx: AppContext) => {
       // every view repairs it — the publish-time sniff stops new ones, this drains
       // the backlog as artifacts are opened, with no manual maintenance step needed.
       () => background(meta.reclassifyVersion(artifact.id, n, "text/html")),
+      // Resolve relative cross-document links to sibling artifacts (synced folders),
+      // so a tab like `walkthrough.html` navigates to the walkthrough artifact instead
+      // of re-serving this page. No-op unless this artifact is GitHub-synced.
+      crossDocTransform(meta, artifact),
     )
   })
 

--- a/apps/api/test/cross-doc.test.ts
+++ b/apps/api/test/cross-doc.test.ts
@@ -1,0 +1,125 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { newId } from "@dock/core"
+import { SqliteMetaStore } from "@dock/db/sqlite"
+import { FsBlobStore } from "@dock/storage/fs"
+import { afterAll, describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+
+const dir = mkdtempSync(join(tmpdir(), "dock-crossdoc-"))
+const meta = new SqliteMetaStore(join(dir, "c.db"))
+const blobs = new FsBlobStore(join(dir, "blobs"))
+const app = createApp({ meta, blobs, baseUrl: "http://dock.test", token: "tok" })
+const enc = (s: string) => new TextEncoder().encode(s)
+
+afterAll(() => {
+  meta.close()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+/** A synced HTML file artifact: published, version 1, with an optional repo path. */
+const seedHtml = async (opts: {
+  shortId: string
+  slug: string | null
+  html: string
+  sourcePath?: string
+}) => {
+  const key = await blobs.put(enc(opts.html))
+  const a = await meta.createArtifact({
+    id: newId("a"),
+    short_id: opts.shortId,
+    org_id: "default",
+    slug: opts.slug,
+    title: opts.shortId,
+    visibility: "public",
+    kind: "file",
+    spa: 0,
+  })
+  await meta.addVersion(a.id, {
+    id: newId("v"),
+    blob_key: key,
+    content_type: "text/html",
+    size_bytes: opts.html.length,
+    author: "t",
+    message: null,
+  })
+  if (opts.sourcePath) await meta.setArtifactSourcePath(a.id, opts.sourcePath)
+  return a
+}
+
+const PRODUCT = `<!doctype html><html><body>
+<a href="walkthrough.html">Walkthrough</a>
+<a href="missing.html">Missing</a>
+<a href="https://fonts.googleapis.com">Font</a>
+<a href="#top">Top</a>
+</body></html>`
+
+describe("cross-document links between synced sibling artifacts", () => {
+  it("rewrites a relative link that resolves to a sibling into an in-app navigation", async () => {
+    await seedHtml({
+      shortId: "cdwalk1",
+      slug: "ct-walkthrough",
+      html: "<html><body><h1>Walkthrough</h1></body></html>",
+      sourcePath: "docs/plans/ct/walkthrough.html",
+    })
+    await seedHtml({
+      shortId: "cdprod1",
+      slug: "ct-product",
+      html: PRODUCT,
+      sourcePath: "docs/plans/ct/product.html",
+    })
+
+    const body = await (await app.request("/raw/cdprod1/v/1/index.html")).text()
+
+    // The sibling link → its canonical /a/<slug>-<short_id> URL + the interception marker.
+    expect(body).toContain('href="/a/ct-walkthrough-cdwalk1"')
+    expect(body).toContain('data-dock-nav="ct-walkthrough-cdwalk1"')
+    // A link with no sibling, an external link, and an in-page anchor are left as-is.
+    expect(body).toContain('href="missing.html"')
+    expect(body).toContain('href="https://fonts.googleapis.com"')
+    expect(body).toContain('href="#top"')
+    expect(body).not.toContain('data-dock-nav="ct-product') // never self-links
+  })
+
+  it("leaves relative links untouched for a non-synced artifact (no source_path)", async () => {
+    await seedHtml({ shortId: "cdnone1", slug: "loose", html: PRODUCT }) // no sourcePath
+    const body = await (await app.request("/raw/cdnone1/v/1/index.html")).text()
+    expect(body).toContain('href="walkthrough.html"')
+    expect(body).not.toContain("data-dock-nav")
+  })
+
+  it("does not resolve across workspaces — a same-path sibling in another org is invisible", async () => {
+    const key = await blobs.put(enc("<html><body>other-org walkthrough</body></html>"))
+    const other = await meta.createArtifact({
+      id: newId("a"),
+      short_id: "cdother1",
+      org_id: "other-org",
+      slug: "other-walk",
+      title: "other",
+      visibility: "public",
+      kind: "file",
+      spa: 0,
+    })
+    await meta.addVersion(other.id, {
+      id: newId("v"),
+      blob_key: key,
+      content_type: "text/html",
+      size_bytes: 10,
+      author: "t",
+      message: null,
+    })
+    // Same repo path as cdprod1's sibling, but a different org.
+    await meta.setArtifactSourcePath(other.id, "docs/plans/other/walkthrough.html")
+
+    await seedHtml({
+      shortId: "cdprod2",
+      slug: "ct2-product",
+      html: `<html><body><a href="walkthrough.html">W</a></body></html>`,
+      sourcePath: "docs/plans/other/product.html", // org "default", not "other-org"
+    })
+    const body = await (await app.request("/raw/cdprod2/v/1/index.html")).text()
+    expect(body).toContain('href="walkthrough.html"') // unresolved — cross-org match ignored
+    expect(body).not.toContain("data-dock-nav")
+  })
+})

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -130,6 +130,12 @@ export function Artifact() {
     setHoverThread,
     setActiveThread,
     setPanel,
+    onNavigate: (ref, newTab) => {
+      // Same-origin SPA route. A modified/middle click opens it un-sandboxed in a new
+      // tab (the frame's own new tab would inherit the sandbox and break the app).
+      if (newTab) window.open(`/a/${ref}`, "_blank", "noopener")
+      else nav({ to: "/a/$ref", params: { ref } })
+    },
   })
 
   // Preview vs. line-diff for the shown version, plus the fetched diff. See

--- a/apps/web/src/pages/artifact/use-artifact-frame.ts
+++ b/apps/web/src/pages/artifact/use-artifact-frame.ts
@@ -36,9 +36,13 @@ export function useArtifactFrame(p: {
   setHoverThread: Dispatch<SetStateAction<string | null>>
   setActiveThread: Dispatch<SetStateAction<string | null>>
   setPanel: Dispatch<SetStateAction<Panel>>
+  // A cross-document link inside the frame was clicked: the server resolved it to a
+  // sibling artifact `ref`. The frame is sandboxed and can't navigate the host, so it
+  // hands the click here for an SPA transition (or a new tab on a modified click).
+  onNavigate: (ref: string, newTab: boolean) => void
 }) {
   const { comments, shortId, version, hoverThread, onPointerMove, onPointerLeave, onTap } = p
-  const { setHoverThread, setActiveThread, setPanel } = p
+  const { setHoverThread, setActiveThread, setPanel, onNavigate } = p
   const frame = useRef<HTMLIFrameElement>(null)
   const presentWrap = useRef<HTMLDivElement>(null)
   const [frameReady, setFrameReady] = useState(0)
@@ -127,11 +131,13 @@ export function useArtifactFrame(p: {
         onTap(d.x, d.y, deckRef.current?.i)
       } else if (d.type === "cursor-leave") {
         onPointerLeave()
+      } else if (d.type === "navigate" && typeof d.ref === "string") {
+        onNavigate(d.ref, !!d.newTab)
       }
     }
     window.addEventListener("message", onMsg)
     return () => window.removeEventListener("message", onMsg)
-  }, [onPointerMove, onPointerLeave, onTap, setHoverThread, setActiveThread, setPanel])
+  }, [onPointerMove, onPointerLeave, onTap, setHoverThread, setActiveThread, setPanel, onNavigate])
 
   // Two-way hover: emphasize the matching highlight in the doc when a comment
   // card is hovered (the inbound anchor-hover sets the same state the other way).

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -249,8 +249,21 @@ document.addEventListener("mouseout",function(e){
 /* clicking a highlight focuses its thread in the host */
 document.addEventListener("click",function(e){
   var el=e.target,m=el&&el.closest?el.closest("mark[data-dock-id]"):null;
-  if(m)post({type:"anchor-click",id:m.getAttribute("data-dock-id")})
+  if(m){post({type:"anchor-click",id:m.getAttribute("data-dock-id")});return}
+  navLink(e)
 },true);
+/* Cross-document links: a relative <a> the server resolved to a sibling artifact
+   (data-dock-nav="<ref>"). The sandboxed frame can't navigate the host, so hand the
+   click off for an in-app transition (or a new tab on a modified / middle click —
+   the host opens that un-sandboxed). preventDefault stops the frame loading /a/… into
+   itself. Only marked links are touched; ordinary and in-page links are untouched. */
+function navLink(e){
+  var a=e.target&&e.target.closest?e.target.closest("a[data-dock-nav]"):null;
+  if(!a)return;
+  e.preventDefault();
+  post({type:"navigate",ref:a.getAttribute("data-dock-nav"),
+    newTab:!!(e.metaKey||e.ctrlKey||e.shiftKey||e.button===1)})}
+document.addEventListener("auxclick",function(e){if(e.button===1)navLink(e)},true);
 
 function setOn(id){
   var on=document.querySelectorAll("mark.dock-hl-on");

--- a/packages/core/src/cross-doc.test.ts
+++ b/packages/core/src/cross-doc.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest"
+import { collectSiblingPaths, resolveSiblingPath, rewriteCrossDocLinks } from "./cross-doc"
+
+const SRC = "docs/plans/competitor-tracking/product.html"
+
+describe("resolveSiblingPath", () => {
+  it("resolves a bare sibling filename against the source dir", () => {
+    expect(resolveSiblingPath(SRC, "walkthrough.html")).toBe(
+      "docs/plans/competitor-tracking/walkthrough.html",
+    )
+  })
+
+  it("normalizes ./ and ../ segments", () => {
+    expect(resolveSiblingPath(SRC, "./competitive.html")).toBe(
+      "docs/plans/competitor-tracking/competitive.html",
+    )
+    expect(resolveSiblingPath(SRC, "../other/x.html")).toBe("docs/plans/other/x.html")
+  })
+
+  it("drops a query and hash, keying on the file path", () => {
+    expect(resolveSiblingPath(SRC, "walkthrough.html#step-3")).toBe(
+      "docs/plans/competitor-tracking/walkthrough.html",
+    )
+    expect(resolveSiblingPath(SRC, "walkthrough.html?v=2")).toBe(
+      "docs/plans/competitor-tracking/walkthrough.html",
+    )
+  })
+
+  it("treats a root-absolute path as repo-root relative", () => {
+    expect(resolveSiblingPath(SRC, "/readme.md")).toBe("readme.md")
+  })
+
+  it("ignores in-page anchors, absolute, scheme and protocol-relative URLs", () => {
+    expect(resolveSiblingPath(SRC, "#section")).toBeNull()
+    expect(resolveSiblingPath(SRC, "https://example.com/x.html")).toBeNull()
+    expect(resolveSiblingPath(SRC, "//cdn.example.com/x")).toBeNull()
+    expect(resolveSiblingPath(SRC, "mailto:a@b.com")).toBeNull()
+    expect(resolveSiblingPath(SRC, "tel:+1555")).toBeNull()
+    expect(resolveSiblingPath(SRC, "")).toBeNull()
+  })
+})
+
+describe("collectSiblingPaths", () => {
+  it("collects distinct sibling paths from anchor hrefs only", () => {
+    const html = `
+      <a href="product.html">Product</a>
+      <a href="walkthrough.html">Walkthrough</a>
+      <a href="walkthrough.html">again</a>
+      <a href="https://fonts.googleapis.com">font</a>
+      <link href="theme.css" rel="stylesheet">`
+    expect(collectSiblingPaths(html, SRC)).toEqual([
+      "docs/plans/competitor-tracking/product.html",
+      "docs/plans/competitor-tracking/walkthrough.html",
+    ])
+  })
+
+  it("returns nothing when there are no relative anchors", () => {
+    expect(collectSiblingPaths(`<a href="https://x.com">x</a>`, SRC)).toEqual([])
+  })
+})
+
+describe("rewriteCrossDocLinks", () => {
+  const refByPath = new Map([
+    ["docs/plans/competitor-tracking/walkthrough.html", "competitor-tracking-walkthrough-kbthvh7s"],
+    ["docs/plans/competitor-tracking/competitive.html", "competitor-tracking-competitive-aaaaaa11"],
+  ])
+
+  it("rewrites resolved siblings to /a/<ref> and tags them for interception", () => {
+    const out = rewriteCrossDocLinks(`<a href="walkthrough.html">Walkthrough</a>`, SRC, refByPath)
+    expect(out).toBe(
+      `<a href="/a/competitor-tracking-walkthrough-kbthvh7s" data-dock-nav="competitor-tracking-walkthrough-kbthvh7s">Walkthrough</a>`,
+    )
+  })
+
+  it("preserves other attributes around the href", () => {
+    const out = rewriteCrossDocLinks(
+      `<a class="tab" href="competitive.html" data-x="1">Competitive</a>`,
+      SRC,
+      refByPath,
+    )
+    expect(out).toContain(`href="/a/competitor-tracking-competitive-aaaaaa11"`)
+    expect(out).toContain(`class="tab"`)
+    expect(out).toContain(`data-x="1"`)
+    expect(out).toContain(`data-dock-nav="competitor-tracking-competitive-aaaaaa11"`)
+  })
+
+  it("leaves links with no known sibling, anchors, and external links untouched", () => {
+    const html = `<a href="unknown.html">u</a><a href="#x">x</a><a href="https://x.com">e</a>`
+    expect(rewriteCrossDocLinks(html, SRC, refByPath)).toBe(html)
+  })
+
+  it("is idempotent — a second pass changes nothing", () => {
+    const once = rewriteCrossDocLinks(`<a href="walkthrough.html">w</a>`, SRC, refByPath)
+    expect(rewriteCrossDocLinks(once, SRC, refByPath)).toBe(once)
+  })
+
+  it("no-ops on an empty ref map", () => {
+    const html = `<a href="walkthrough.html">w</a>`
+    expect(rewriteCrossDocLinks(html, SRC, new Map())).toBe(html)
+  })
+})

--- a/packages/core/src/cross-doc.ts
+++ b/packages/core/src/cross-doc.ts
@@ -1,0 +1,83 @@
+/**
+ * Cross-document links between sibling artifacts.
+ *
+ * A folder mirrored from GitHub becomes many SEPARATE artifacts (each `.html` /
+ * `.md` is its own short_id), but the source files reference each other with plain
+ * relative links — `<a href="walkthrough.html">`, or a markdown `[x](./walkthrough.md)`
+ * rendered to the same. Inside the sandboxed viewer iframe (src `/raw/<id>/v/<n>/…`)
+ * such a link resolves to a path UNDER the current artifact, which the raw server
+ * serves as the same single blob — so clicking a tab just re-renders the page you're
+ * already on.
+ *
+ * The fix resolves each relative link against the source file's repo path and, when
+ * it lands on a sibling artifact (same workspace, that exact `source_path`), rewrites
+ * it to that sibling's in-app URL plus a `data-dock-nav` marker. The iframe client
+ * intercepts marked links and the host does an SPA transition (see `anchor.ts` /
+ * `use-artifact-frame.ts`). Links with no sibling are left untouched.
+ *
+ * Pure + dialect-free so it's unit-tested without a DB; the caller supplies the
+ * `source_path → ref` map it resolved from the artifact table.
+ */
+
+/**
+ * Resolve a link's `href`, as written in `sourcePath`'s file, to the repo path it
+ * points at — or null when it isn't an in-repo relative document link (an in-page
+ * `#anchor`, an absolute/scheme/protocol-relative URL). Relative segments (`./`,
+ * `../`) are normalized; a query/hash is dropped (the lookup keys on the file path).
+ */
+export const resolveSiblingPath = (sourcePath: string, href: string): string | null => {
+  const h = href.trim()
+  if (!h || h.startsWith("#")) return null
+  if (h.startsWith("//")) return null // protocol-relative → another origin
+  if (/^[a-z][a-z0-9+.-]*:/i.test(h)) return null // http:, mailto:, tel:, data:, …
+  try {
+    // A throwaway origin lets the URL parser do the `./` + `../` normalization for us,
+    // resolving against the source file's directory exactly as a browser would.
+    const base = new URL(`https://dock.local/${sourcePath}`)
+    const resolved = new URL(h, base)
+    if (resolved.origin !== base.origin) return null
+    const path = decodeURIComponent(resolved.pathname).replace(/^\/+/, "")
+    return path || null
+  } catch {
+    return null
+  }
+}
+
+/** Match an `<a>` opening tag and capture (attrs-before, quote, href, attrs-after). */
+const A_TAG = /<a\b([^>]*?)\shref=(["'])([^"']*)\2([^>]*?)>/gi
+
+/**
+ * Every distinct sibling repo path a document's `<a href>`s point at — what the
+ * caller looks up in the artifact table to build the `source_path → ref` map for
+ * {@link rewriteCrossDocLinks}. Deduped; order is first-seen.
+ */
+export const collectSiblingPaths = (html: string, sourcePath: string): string[] => {
+  const seen = new Set<string>()
+  for (const m of html.matchAll(A_TAG)) {
+    const path = resolveSiblingPath(sourcePath, m[3] ?? "")
+    if (path) seen.add(path)
+  }
+  return [...seen]
+}
+
+/**
+ * Rewrite each relative `<a href>` that resolves to a known sibling: point it at the
+ * sibling's `/a/<ref>` URL and tag it `data-dock-nav="<ref>"` so the iframe client
+ * intercepts the click for an in-app transition. `refByPath` maps a resolved repo
+ * path → its artifact ref (`<slug>-<short_id>`); paths absent from it are left as-is.
+ * Already-tagged anchors are skipped so the pass is idempotent.
+ */
+export const rewriteCrossDocLinks = (
+  html: string,
+  sourcePath: string,
+  refByPath: ReadonlyMap<string, string>,
+): string => {
+  if (refByPath.size === 0) return html
+  return html.replace(A_TAG, (tag, pre: string, q: string, href: string, post: string) => {
+    if (/\sdata-dock-nav=/i.test(pre) || /\sdata-dock-nav=/i.test(post)) return tag
+    const path = resolveSiblingPath(sourcePath, href)
+    const ref = path && refByPath.get(path)
+    if (!ref) return tag
+    return `<a${pre} href=${q}/a/${ref}${q} data-dock-nav=${q}${ref}${q}${post}>`
+  })
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./anchor"
+export * from "./cross-doc"
 export * from "./diff"
 export * from "./hash"
 export * from "./ids"

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -132,6 +132,14 @@ export interface MetaStore {
   getByShortId(shortId: string): Promise<ArtifactRecord | null>
   /** Load an artifact by its internal id (used by domain mode's host lookup). */
   getArtifactById(id: string): Promise<ArtifactRecord | null>
+  /** GitHub-synced artifacts in `orgId` whose `source_path` is one of `paths` —
+   *  resolves relative cross-document links (a sibling `.html`/`.md`) to the
+   *  artifact each points at. Returns only what the link rewrite needs. Empty
+   *  `paths` ⇒ none. */
+  siblingsBySourcePaths(
+    orgId: string,
+    paths: string[],
+  ): Promise<{ short_id: string; slug: string | null; source_path: string }[]>
   /** Appends the next version and bumps current_version. */
   addVersion(artifactId: string, v: NewVersion): Promise<VersionRecord>
   listVersions(artifactId: string): Promise<VersionRecord[]>

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -226,6 +226,28 @@ export class PgMetaStore implements MetaStore {
     return rows[0] ?? null
   }
 
+  async siblingsBySourcePaths(
+    orgId: string,
+    paths: string[],
+  ): Promise<{ short_id: string; slug: string | null; source_path: string }[]> {
+    if (paths.length === 0) return []
+    const rows = await this.db
+      .select({
+        short_id: artifact.short_id,
+        slug: artifact.slug,
+        source_path: artifact.source_path,
+      })
+      .from(artifact)
+      .where(
+        and(
+          eq(artifact.org_id, orgId),
+          inArray(artifact.source_path, paths),
+          isNull(artifact.removed_at),
+        ),
+      )
+    return rows.filter((r): r is typeof r & { source_path: string } => r.source_path != null)
+  }
+
   async addVersion(artifactId: string, v: NewVersion): Promise<VersionRecord> {
     return this.db.transaction(async (tx) => {
       const cur = await tx

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -237,6 +237,29 @@ export function makeRepos(db: SqliteDb) {
   const getArtifactById = async (id: string): Promise<ArtifactRecord | null> =>
     (await db.select().from(artifact).where(eq(artifact.id, id)).get()) ?? null
 
+  const siblingsBySourcePaths = async (
+    orgId: string,
+    paths: string[],
+  ): Promise<{ short_id: string; slug: string | null; source_path: string }[]> => {
+    if (paths.length === 0) return []
+    const rows = await db
+      .select({
+        short_id: artifact.short_id,
+        slug: artifact.slug,
+        source_path: artifact.source_path,
+      })
+      .from(artifact)
+      .where(
+        and(
+          eq(artifact.org_id, orgId),
+          inArray(artifact.source_path, paths),
+          isNull(artifact.removed_at),
+        ),
+      )
+      .all()
+    return rows.filter((r): r is typeof r & { source_path: string } => r.source_path != null)
+  }
+
   const createArtifact = async (a: NewArtifact): Promise<ArtifactRecord> => {
     await db.insert(artifact).values(a).run()
     return (await getByShortId(a.short_id)) as ArtifactRecord
@@ -1189,6 +1212,7 @@ export function makeRepos(db: SqliteDb) {
     setLocked,
     getByShortId,
     getArtifactById,
+    siblingsBySourcePaths,
     addVersion,
     listVersions,
     getVersion,


### PR DESCRIPTION
## The problem

A GitHub-synced folder of HTML/Markdown files becomes **many separate artifacts** in Dock, but the source files cross-link each other with bare relative paths — e.g. the competitor-tracking pages link with `<a href="walkthrough.html">`.

Inside the sandboxed viewer iframe (`src=/raw/<id>/v/<n>/index.html`), `walkthrough.html` resolves to `/raw/<id>/v/<n>/walkthrough.html`, and the raw server serves **the same single blob for any sub-path** of a single-file artifact. So clicking a tab just re-rendered the page you were already on ("it assumes it's within the same HTML").

Repro: https://dock.siftai.workers.dev/a/competitor-tracking-product-lfztov6k → the tabs (Product / Technical / Competitive / Walkthrough) all stayed on Product.

## The fix

These links are deterministic to resolve: each synced artifact carries its repo path in `source_path`. A relative href resolved against that path (`docs/plans/competitor-tracking/walkthrough.html`) identifies the sibling artifact uniquely.

At serve time, a relative `<a href>` that lands on a sibling **in the same workspace** is rewritten to the sibling's `/a/<slug>-<short_id>` URL plus a `data-dock-nav` marker. The sandboxed iframe client intercepts marked clicks and the host does a TanStack SPA transition (a modified/middle click opens it un-sandboxed in a new tab). Links with no matching sibling are left untouched; non-synced artifacts are unaffected.

Generalizes to synced **Markdown** too (`[x](./walkthrough.md)` → rendered `<a>`).

## Layers

- **`@dock/core` (pure, unit-tested)** — `resolveSiblingPath` / `collectSiblingPaths` / `rewriteCrossDocLinks`.
- **`MetaStore.siblingsBySourcePaths`** — one bounded query per served page (keyed on the links actually present, not repo size); workspace-scoped. Added to the SQLite repos (inherited by D1) and `PgMetaStore`.
- **`serve-content` / `raw`** — apply the rewrite to raw-HTML, markdown-rendered, and mislabeled-HTML output before the anchor client is appended; built only when the artifact is synced.
- **`anchor.ts` client + `use-artifact-frame` + artifact page** — intercept the click (capture phase + `auxclick`), `postMessage` to the host, SPA-navigate.

## Notes / non-goals

- **No sandbox change** — keeps the opaque-origin CSP; navigation rides the existing `postMessage` channel rather than widening `allow-top-navigation`.
- **No schema migration** — resolution uses the existing `source_path` column.
- Resolution is workspace-scoped, so a same-path file in another org never matches (covered by a test).
- `chore` commit reflows one long import in `sync.ts` (pre-existing; the precommit hook / CI flagged it) so the branch is green — no behavior change.
- Not yet handled (possible follow-ups): preserving a link's `#fragment`, cross-doc links inside multi-file **bundles**, and resolution for manually-published (non-synced) artifacts.

## Tests

- `packages/core/src/cross-doc.test.ts` — 12 cases (resolution, collection, rewrite, idempotency).
- `apps/api/test/cross-doc.test.ts` — end-to-end through the raw route, incl. **cross-workspace isolation** and the non-synced control.
- Full suite green; `typecheck`, `lint`, and per-file `biome ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)