### PR TITLE
Guard additive-only schema policy at D1 deploy (NOT-NULL-no-default)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,18 @@ you miss.
   `PG_SCHEMA_STATEMENTS` mirrors it with `CREATE TABLE IF NOT EXISTS` + `ALTER TABLE …
   ADD COLUMN IF NOT EXISTS`.
 - **D1**: `deploy/d1-schema.sql` is generated from `SCHEMA_STATEMENTS` — never hand-edit it;
-  run `pnpm --filter @dock/db gen:d1-schema`.
+  run `pnpm --filter @dock/db gen:d1-schema`. D1 can't apply schema at boot (the edge forbids
+  the `sqlite_master` introspection the Node tier uses), so `pnpm deploy` runs
+  [apply-d1-schema.mjs](apps/api/scripts/apply-d1-schema.mjs) first: it creates missing
+  tables/indexes, then diffs each live table's columns and `ADD COLUMN`s the missing ones — so
+  an existing D1 (yours or a self-hoster's) picks up new columns on the next deploy.
+
+**A new column must be nullable or carry a constant `DEFAULT`.** SQLite/D1 reject `ADD COLUMN`
+of a `NOT NULL` column with no default on a populated table, so a `NOT NULL`-without-default add
+would break every existing database. `apply-d1-schema.mjs` refuses such an add and aborts the
+deploy before touching the DB (planning logic + tests:
+[d1-schema-plan.mjs](apps/api/scripts/d1-schema-plan.mjs)). Need a non-null column? Add it
+nullable (optionally backfill, then tighten in a later, separately-reviewed change).
 
 **Adding a column:**
 

--- a/apps/api/scripts/apply-d1-schema.mjs
+++ b/apps/api/scripts/apply-d1-schema.mjs
@@ -16,6 +16,7 @@ import { execFileSync } from "node:child_process"
 import { readFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
+import { parseExpectedColumns, planColumnAdds } from "./d1-schema-plan.mjs"
 
 const DB = process.env.DOCK_D1_NAME ?? "dock"
 const TARGET = process.argv.includes("--local") ? "--local" : "--remote"
@@ -31,20 +32,7 @@ const wrangler = (args, capture = false) =>
 
 // Parse expected columns (+ their full definitions) per table from the generated schema.
 const sql = readFileSync(schemaPath, "utf8")
-const expected = {}
-const re = /CREATE TABLE IF NOT EXISTS (\w+) \(([\s\S]*?)\n\s*\);/g
-let m = re.exec(sql)
-while (m) {
-  const cols = {}
-  for (const raw of m[2].split("\n")) {
-    const line = raw.trim().replace(/,$/, "")
-    if (!line || /^(UNIQUE|PRIMARY|FOREIGN|CHECK|CONSTRAINT)\b/i.test(line)) continue
-    const col = line.split(/\s+/)[0]
-    if (/^\w+$/.test(col)) cols[col] = line
-  }
-  expected[m[1]] = cols
-  m = re.exec(sql)
-}
+const expected = parseExpectedColumns(sql)
 
 console.log(`[d1] applying schema to "${DB}" (${TARGET})`)
 // 1. Create any missing tables/indexes. IF NOT EXISTS → no-op for existing ones.
@@ -68,10 +56,21 @@ for (const batch of chunk(Object.keys(expected), 5)) {
   }
 }
 
-const alters = []
-for (const [tbl, cols] of Object.entries(expected))
-  for (const [col, def] of Object.entries(cols))
-    if (live[tbl] && !live[tbl].has(col)) alters.push(`ALTER TABLE ${tbl} ADD COLUMN ${def};`)
+const { alters, unsafe } = planColumnAdds(expected, live)
+
+// Dock's schema policy is additive-only: a column added to an existing table must be
+// nullable or carry a constant DEFAULT (SQLite/D1 reject ADD COLUMN of a NOT NULL column
+// with no default on populated rows). Abort BEFORE running any ALTER so a policy slip
+// fails the deploy cleanly with an actionable message instead of half-applying the batch.
+if (unsafe.length) {
+  console.error(`[d1] refusing to add ${unsafe.length} NOT NULL column(s) without a default:`)
+  for (const u of unsafe) console.error(`  ${u.tbl}.${u.col}  →  ${u.def}`)
+  console.error(
+    "[d1] make the column nullable or give it a constant DEFAULT (additive-only schema\n" +
+      "     policy — see CONTRIBUTING.md → Database migrations). Database left untouched.",
+  )
+  process.exit(1)
+}
 
 if (alters.length === 0) {
   console.log("[d1] columns already current — nothing to add")

--- a/apps/api/scripts/d1-schema-plan.mjs
+++ b/apps/api/scripts/d1-schema-plan.mjs
@@ -1,0 +1,52 @@
+// Pure planning for the D1 schema apply (apply-d1-schema.mjs). Side-effect-free so it's
+// unit-tested (d1-schema-plan.test.ts) without invoking wrangler; the apply script wraps
+// these with the live D1 I/O.
+
+/**
+ * Parse `{ table: { column: "<full column def line>" } }` from a generated d1-schema.sql.
+ * Only real column lines are kept — table-level constraints (UNIQUE/PRIMARY/FOREIGN/…) and
+ * blank lines are skipped.
+ */
+export const parseExpectedColumns = (sql) => {
+  const expected = {}
+  const re = /CREATE TABLE IF NOT EXISTS (\w+) \(([\s\S]*?)\n\s*\);/g
+  let m = re.exec(sql)
+  while (m) {
+    const cols = {}
+    for (const raw of m[2].split("\n")) {
+      const line = raw.trim().replace(/,$/, "")
+      if (!line || /^(UNIQUE|PRIMARY|FOREIGN|CHECK|CONSTRAINT)\b/i.test(line)) continue
+      const col = line.split(/\s+/)[0]
+      if (/^\w+$/.test(col)) cols[col] = line
+    }
+    expected[m[1]] = cols
+    m = re.exec(sql)
+  }
+  return expected
+}
+
+/**
+ * A column ADDED to an existing (populated) table must be nullable or carry a constant
+ * DEFAULT — SQLite/D1 reject `ADD COLUMN` of a NOT NULL column with no default. Dock's
+ * schema policy is additive-only (CONTRIBUTING.md → Database migrations); this is the
+ * deploy-time backstop for it.
+ */
+export const isUnsafeAdd = (def) => /\bNOT NULL\b/i.test(def) && !/\bDEFAULT\b/i.test(def)
+
+/**
+ * Diff the expected columns against the live DB (`{ table: Set<column> }`) and split the
+ * missing ones into safe `ALTER … ADD COLUMN` statements and `unsafe` adds (NOT NULL with
+ * no default) that must not be attempted — the caller aborts the deploy if any are unsafe,
+ * before running a single ALTER, so the database is left untouched.
+ */
+export const planColumnAdds = (expected, live) => {
+  const alters = []
+  const unsafe = []
+  for (const [tbl, cols] of Object.entries(expected))
+    for (const [col, def] of Object.entries(cols))
+      if (live[tbl] && !live[tbl].has(col)) {
+        if (isUnsafeAdd(def)) unsafe.push({ tbl, col, def })
+        else alters.push(`ALTER TABLE ${tbl} ADD COLUMN ${def};`)
+      }
+  return { alters, unsafe }
+}

--- a/apps/api/src/lib/sync.ts
+++ b/apps/api/src/lib/sync.ts
@@ -10,7 +10,14 @@ import {
 import { zipSync } from "fflate"
 import { type BundlePlan, commonDir, planBundle } from "./bundle-from-repo"
 import { sha256 } from "./crypto"
-import { fetchBlob, fetchBlobsBatch, lastCommitDate, listTree, matchesGlobs, parseRepo } from "./github"
+import {
+  fetchBlob,
+  fetchBlobsBatch,
+  lastCommitDate,
+  listTree,
+  matchesGlobs,
+  parseRepo,
+} from "./github"
 
 // Pre-warm the byte cache via BATCHED GraphQL reads rather than one GET per file:
 // GitHub bills an aliased multi-blob query at ~1 rate-limit point (vs 1 per file) and

--- a/apps/api/test/d1-schema-plan.test.ts
+++ b/apps/api/test/d1-schema-plan.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+// @ts-expect-error — plain .mjs deploy helper, no types; tested for behavior only.
+import { isUnsafeAdd, parseExpectedColumns, planColumnAdds } from "../scripts/d1-schema-plan.mjs"
+
+const SCHEMA = `-- header
+CREATE TABLE IF NOT EXISTS artifact (
+  id TEXT PRIMARY KEY,
+  short_id TEXT NOT NULL UNIQUE,
+  title TEXT,
+  author_login TEXT,
+  UNIQUE (short_id)
+);
+
+CREATE TABLE IF NOT EXISTS version (
+  id TEXT PRIMARY KEY,
+  artifact_id TEXT NOT NULL,
+  n INTEGER NOT NULL DEFAULT 0,
+  author_login TEXT,
+  FOREIGN KEY (artifact_id) REFERENCES artifact(id)
+);
+
+CREATE INDEX IF NOT EXISTS artifact_org ON artifact (org_id);
+`
+
+describe("parseExpectedColumns", () => {
+  it("extracts real columns per table and skips table-level constraints", () => {
+    const expected = parseExpectedColumns(SCHEMA)
+    expect(Object.keys(expected)).toEqual(["artifact", "version"])
+    expect(Object.keys(expected.artifact)).toEqual(["id", "short_id", "title", "author_login"])
+    // UNIQUE/FOREIGN lines are not columns.
+    expect(expected.artifact).not.toHaveProperty("UNIQUE")
+    expect(expected.version).not.toHaveProperty("FOREIGN")
+    expect(expected.artifact.author_login).toBe("author_login TEXT")
+  })
+})
+
+describe("isUnsafeAdd", () => {
+  it("flags NOT NULL with no default; allows nullable or constant-default", () => {
+    expect(isUnsafeAdd("kind TEXT NOT NULL")).toBe(true)
+    expect(isUnsafeAdd("author_login TEXT")).toBe(false)
+    expect(isUnsafeAdd("n INTEGER NOT NULL DEFAULT 0")).toBe(false)
+    expect(isUnsafeAdd("spa INTEGER DEFAULT 0")).toBe(false)
+  })
+})
+
+describe("planColumnAdds", () => {
+  const expected = {
+    artifact: { id: "id TEXT PRIMARY KEY", title: "title TEXT", author_login: "author_login TEXT" },
+  }
+
+  it("emits ALTERs only for columns missing on the live table", () => {
+    const live = { artifact: new Set(["id", "title"]) }
+    const { alters, unsafe } = planColumnAdds(expected, live)
+    expect(alters).toEqual(["ALTER TABLE artifact ADD COLUMN author_login TEXT;"])
+    expect(unsafe).toEqual([])
+  })
+
+  it("adds nothing when the live table already has every column", () => {
+    const live = { artifact: new Set(["id", "title", "author_login"]) }
+    expect(planColumnAdds(expected, live)).toEqual({ alters: [], unsafe: [] })
+  })
+
+  it("collects an unsafe NOT-NULL-no-default add instead of emitting an ALTER", () => {
+    const exp = { artifact: { kind: "kind TEXT NOT NULL" } }
+    const live = { artifact: new Set(["id"]) }
+    const { alters, unsafe } = planColumnAdds(exp, live)
+    expect(alters).toEqual([])
+    expect(unsafe).toEqual([{ tbl: "artifact", col: "kind", def: "kind TEXT NOT NULL" }])
+  })
+
+  it("skips tables absent from the live DB (created fresh, no ALTER needed)", () => {
+    const { alters, unsafe } = planColumnAdds(expected, {})
+    expect(alters).toEqual([])
+    expect(unsafe).toEqual([])
+  })
+})


### PR DESCRIPTION
## Why

While planning GitHub author-tracking (which adds columns), we checked whether Dock's migration system is OSS-ready. It mostly is: schema is **additive-only**, applied idempotently per dialect — SQLite/Postgres at boot, **D1 at deploy** via `apply-d1-schema.mjs` (creates missing tables, then diffs each live table's columns and `ADD COLUMN`s the missing ones). So existing D1 databases *do* get new columns on the next deploy. 

The one unguarded slip: a column added to an existing table that is **`NOT NULL` with no constant `DEFAULT`**. SQLite/D1 reject `ADD COLUMN` of such a column on populated rows, so `apply-d1-schema.mjs` would error mid-deploy and **half-apply** the batch — a cryptic break for self-hosters upgrading on Cloudflare. This PR closes that gap and writes the policy down.

## What

- **Extract the planning into a pure module** `apps/api/scripts/d1-schema-plan.mjs` (`parseExpectedColumns` + `planColumnAdds`), splitting missing columns into safe `ALTER`s and `unsafe` (NOT NULL, no default) adds. Side-effect-free → unit-testable without wrangler.
- **`apply-d1-schema.mjs` aborts before running any `ALTER`** when an unsafe add is present, with an actionable message — the database is left untouched rather than half-migrated.
- **Unit tests** for the planner (parse, unsafe-detection, diff).
- **CONTRIBUTING.md**: document that a new column must be nullable or carry a constant `DEFAULT`, and how each dialect applies additive changes (incl. the D1 deploy path).

## Scope / non-goals

- Keeps the zero-config, **additive-only** model (the deliberate choice — no migration framework, one-command self-host). No move to versioned up/down migrations.
- No schema change; no behavior change for compliant (additive) columns — `planColumnAdds` produces the same ALTERs as before, just with the unsafe-abort added.
- The `chore` commit reflows one pre-existing long import in `sync.ts` so the precommit hook is green (no behavior change).

## Tests

`apps/api/test/d1-schema-plan.test.ts` — 6 cases. Full `@dock/api` suite green (417), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)