### PR TITLE
Track GitHub commit authors on synced artifacts (attribute, map, filter)

### DIFF
--- a/apps/api/src/lib/github.ts
+++ b/apps/api/src/lib/github.ts
@@ -97,11 +97,81 @@ const fetchRetrying = async (url: string, init: RequestInit, attempts = 3): Prom
   }
 }
 
+/** A GitHub commit's author, as far as the Commits API reveals it. `login`/`ghId`/
+ *  `avatar` come from the TOP-LEVEL `author` (the GitHub account; null when GitHub can't
+ *  map the commit email to one); `name`/`email` come from `commit.author` (the raw git
+ *  identity, always present). All fields nullable so a partial commit never throws. */
+export interface CommitAuthor {
+  login: string | null
+  ghId: string | null
+  name: string | null
+  email: string | null
+  avatar: string | null
+}
+
+/** The shape of one element of the Commits API list response (the bits we read). */
+interface CommitListEntry {
+  commit?: {
+    committer?: { date?: string }
+    author?: { name?: string; email?: string }
+  }
+  author?: { login?: string; id?: number; avatar_url?: string } | null
+}
+
+/** Pure parser: turn the Commits API list response into the committer date + author.
+ *  Exported for unit testing the extraction without a network round-trip. Empty/missing
+ *  history → { date: null, author: null }. */
+export function parseLastCommit(data: CommitListEntry[] | null | undefined): {
+  date: string | null
+  author: CommitAuthor | null
+} {
+  const head = data?.[0]
+  if (!head) return { date: null, author: null }
+  const date = head.commit?.committer?.date ?? null
+  const top = head.author ?? null
+  const git = head.commit?.author ?? null
+  // No identity at all (neither the GitHub account nor the raw git author) → null author.
+  if (!top && !git?.name && !git?.email) return { date, author: null }
+  return {
+    date,
+    author: {
+      login: top?.login ?? null,
+      ghId: top?.id != null ? String(top.id) : null,
+      avatar: top?.avatar_url ?? null,
+      name: git?.name ?? null,
+      email: git?.email ?? null,
+    },
+  }
+}
+
 /**
- * The committer date of the most recent commit that touched `path` on `ref` — the
- * file's true last-change time, which drives a synced artifact's "updated" (the git
- * tree carries no dates, so this is a separate call). Best-effort: returns null on any
- * error or an empty history so a date lookup can never fail a sync.
+ * The most recent commit that touched `path` on `ref`: its committer date (the file's
+ * true last-change time, driving a synced artifact's "updated") AND its author. The git
+ * tree carries neither, so this is a separate Commits API call. Best-effort: returns
+ * { date: null, author: null } on any error or an empty history so a sync never fails.
+ */
+export async function lastCommit(
+  repo: RepoRef,
+  path: string,
+  ref: string,
+  token: string | null,
+): Promise<{ date: string | null; author: CommitAuthor | null }> {
+  const url = `${API}/repos/${repo.owner}/${repo.name}/commits?path=${encodeURIComponent(
+    path,
+  )}&sha=${encodeURIComponent(ref)}&per_page=1`
+  try {
+    const res = await fetchRetrying(url, { headers: headers(token, "application/vnd.github+json") })
+    if (!res.ok) return { date: null, author: null }
+    return parseLastCommit((await res.json()) as CommitListEntry[])
+  } catch {
+    return { date: null, author: null }
+  }
+}
+
+/**
+ * The committer date of the most recent commit that touched `path` on `ref` — a thin
+ * wrapper over {@link lastCommit} kept for callers that only need the date. Best-effort:
+ * null on any error or empty history.
  */
 export async function lastCommitDate(
   repo: RepoRef,
@@ -109,17 +179,7 @@ export async function lastCommitDate(
   ref: string,
   token: string | null,
 ): Promise<string | null> {
-  const url = `${API}/repos/${repo.owner}/${repo.name}/commits?path=${encodeURIComponent(
-    path,
-  )}&sha=${encodeURIComponent(ref)}&per_page=1`
-  try {
-    const res = await fetchRetrying(url, { headers: headers(token, "application/vnd.github+json") })
-    if (!res.ok) return null
-    const data = (await res.json()) as { commit?: { committer?: { date?: string } } }[]
-    return data[0]?.commit?.committer?.date ?? null
-  } catch {
-    return null
-  }
+  return (await lastCommit(repo, path, ref, token)).date
 }
 
 /** Raw bytes of one blob by its git sha. */

--- a/apps/api/src/lib/sync.ts
+++ b/apps/api/src/lib/sync.ts
@@ -1,6 +1,7 @@
 import {
   type ArtifactRecord,
   type BlobStore,
+  type GithubAuthor,
   type MetaStore,
   mapPoolSettled,
   publish,
@@ -10,7 +11,15 @@ import {
 import { zipSync } from "fflate"
 import { type BundlePlan, commonDir, planBundle } from "./bundle-from-repo"
 import { sha256 } from "./crypto"
-import { fetchBlob, fetchBlobsBatch, lastCommitDate, listTree, matchesGlobs, parseRepo } from "./github"
+import {
+  type CommitAuthor,
+  fetchBlob,
+  fetchBlobsBatch,
+  lastCommit,
+  listTree,
+  matchesGlobs,
+  parseRepo,
+} from "./github"
 
 // Pre-warm the byte cache via BATCHED GraphQL reads rather than one GET per file:
 // GitHub bills an aliased multi-blob query at ~1 rate-limit point (vs 1 per file) and
@@ -42,6 +51,11 @@ export interface SyncedFile {
    *  first time we resolve it; `""` records an attempt that found none (so we don't
    *  retry forever); absent means not yet sourced → the date backfill will fill it. */
   updatedAt?: string
+  /** Whether the source file's last-commit AUTHOR has been sourced (mirrored into the
+   *  artifact's author_* columns). Mirrors `updatedAt`'s semantics: `true` once attempted
+   *  (a real author or none), absent means not yet sourced → the author backfill fills it.
+   *  Date + author are fetched in a single Commits call, so the two sentinels move together. */
+  authorSourced?: boolean
 }
 type FileMap = Record<string, SyncedFile>
 
@@ -214,26 +228,49 @@ export async function runSync(
     }
   }
 
-  // Mirror the source file's last-commit date into the artifact's `updated_at`, so the
-  // card shows when the SOURCE last changed, not when Dock ingested it (the git tree
-  // carries no dates — this is one extra Commits API call per file). Records the result
-  // on the map entry: a real date, or `""` when none resolved, so a re-sync never
-  // re-fetches a file it already sourced. Best-effort — a null leaves publish's `now()`.
-  const stampDate = async (artifactId: string, repoPath: string, entry: SyncedFile) => {
-    const date = await lastCommitDate(repo, repoPath, source.ref, source.token)
-    if (date) await meta.setArtifactUpdatedAt(artifactId, date)
-    entry.updatedAt = date ?? ""
+  // A commit author becomes the artifact's denormalized author only when GitHub gave us
+  // *something* to attribute to (a login or a git author name); a fully-empty commit
+  // author leaves the columns null. The display name prefers the GitHub login, then the
+  // raw git author name.
+  const toGithubAuthor = (a: CommitAuthor | null): GithubAuthor | null => {
+    if (!a || (!a.login && !a.name)) return null
+    return { name: a.name ?? a.login, login: a.login, avatar: a.avatar, ghId: a.ghId }
   }
-  // The existing tracked files were synced before dates were sourced (`updatedAt`
+
+  // Mirror the source file's last-commit date AND author into the artifact (the card's
+  // "updated" + "who last changed this"). The git tree carries neither, so this is one
+  // Commits API call per file — fetched ONCE here and reused for both. Records the result
+  // on the map entry (date sentinel + authorSourced) so a re-sync never re-fetches a file
+  // it already sourced. Best-effort: a null date leaves publish's now(); a null author
+  // clears the columns. Returns the resolved author so the publish path can store it
+  // per-version too without a second call.
+  const stampCommit = async (
+    artifactId: string,
+    repoPath: string,
+    entry: SyncedFile,
+  ): Promise<GithubAuthor | null> => {
+    const { date, author } = await lastCommit(repo, repoPath, source.ref, source.token)
+    if (date) await meta.setArtifactUpdatedAt(artifactId, date)
+    const gh = toGithubAuthor(author)
+    await meta.setArtifactAuthor(artifactId, gh)
+    entry.updatedAt = date ?? ""
+    entry.authorSourced = true
+    return gh
+  }
+  // The existing tracked files were synced before date/author were sourced (`updatedAt`
   // absent). Backfill them lazily — bounded per run so one sync doesn't make hundreds
   // of Commits calls; the leftover counts as `remaining`, so the runner continues until
-  // every file is dated. Unbounded in tests (no `limits`).
+  // every file is sourced. Unbounded in tests (no `limits`).
   const DATE_BACKFILL_PER_RUN = limits ? 150 : Number.POSITIVE_INFINITY
   let datesBackfilled = 0
-  const backfillDate = async (entry: SyncedFile, repoPath: string) => {
-    if (entry.updatedAt !== undefined || datesBackfilled >= DATE_BACKFILL_PER_RUN) return
+  const backfillCommit = async (entry: SyncedFile, repoPath: string) => {
+    // Fetch when EITHER sentinel is unset: a brand-new entry (neither set) or a legacy
+    // one dated before authors existed (`updatedAt` set, `authorSourced` absent). The
+    // single Commits call fills both, so they converge after one backfill.
+    const needs = entry.updatedAt === undefined || entry.authorSourced === undefined
+    if (!needs || datesBackfilled >= DATE_BACKFILL_PER_RUN) return
     datesBackfilled++
-    await stampDate(entry.artifact_id, repoPath, entry)
+    await stampCommit(entry.artifact_id, repoPath, entry)
   }
 
   try {
@@ -391,12 +428,23 @@ export async function runSync(
       members?: Record<string, string>,
     ) => {
       const kind: SyncedFile["kind"] = isBundle ? "bundle" : "file"
+      // Source the commit ONCE up front: its author is recorded on the version + the
+      // artifact at publish time (replacing the literal "GitHub sync"), and its date is
+      // reused for the updated_at stamp below — no second Commits call. Best-effort.
+      const { date, author } = await lastCommit(repo, repoPath, source.ref, source.token)
+      const gh = toGithubAuthor(author)
+      // Display name: the GitHub login, else the git author name, else "GitHub sync" when
+      // GitHub gave us no identity at all (keeps the prior behavior for unmappable commits).
+      const displayName = gh?.login ?? gh?.name ?? "GitHub sync"
       const input = {
         bytes,
         filename,
         isBundle,
         title,
-        author: "GitHub sync",
+        author: displayName,
+        authorLogin: gh?.login ?? null,
+        authorAvatar: gh?.avatar ?? null,
+        authorGhId: gh?.ghId ?? null,
         message: `sync ${source.ref}@${sha.slice(0, 7)}`,
         orgId: source.org_id,
       }
@@ -413,17 +461,19 @@ export async function runSync(
       }
       await meta.setArtifactRemoved(artifact.id, null)
       await meta.setArtifactSourcePath(artifact.id, repoPath)
-      const entry: SyncedFile = {
+      // A changed/new file: stamp its last-commit date now (the forward fix; a fresh full
+      // sync dates everything as it publishes, within the maxFiles batch). The author is
+      // already on the artifact (denormalized by addVersion) + the version row.
+      if (date) await meta.setArtifactUpdatedAt(artifact.id, date)
+      next[repoPath] = {
         artifact_id: artifact.id,
         short_id: artifact.short_id,
         sha,
         kind,
         members,
+        updatedAt: date ?? "",
+        authorSourced: true,
       }
-      // A changed/new file: source its last-commit date now (this is the forward fix;
-      // a fresh full sync dates everything as it publishes, within the maxFiles batch).
-      await stampDate(artifact.id, repoPath, entry)
-      next[repoPath] = entry
       await onPublished()
     }
 
@@ -474,7 +524,7 @@ export async function runSync(
         for (const m of plan.members) memberShas[m.repoPath] = shaByPath.get(m.repoPath) ?? ""
         const composite = compositeSha(memberShas)
         if (before?.kind === "bundle" && before.sha === composite) {
-          await backfillDate(before, e.path) // source its date if it predates the feature
+          await backfillCommit(before, e.path) // source its date + author if it predates the feature
           next[e.path] = before
           res.skipped++
           continue
@@ -511,7 +561,7 @@ export async function runSync(
 
       // Single file. Unchanged → skip; pure rename → re-home; else publish.
       if (before && before.kind !== "bundle" && before.sha === e.sha) {
-        await backfillDate(before, e.path) // source its date if it predates the feature
+        await backfillCommit(before, e.path) // source its date + author if it predates the feature
         next[e.path] = before
         res.skipped++
         continue
@@ -604,9 +654,12 @@ export async function runSync(
       }
       return n.kind === "bundle" || n.sha !== e.sha
     }).length
-    // Files not yet date-sourced (the backfill hit its per-run cap) keep the run
-    // "remaining" so the runner re-invokes until every artifact carries a real date.
-    const dateRemaining = Object.values(next).filter((n) => n.updatedAt === undefined).length
+    // Files not yet commit-sourced (the backfill hit its per-run cap) keep the run
+    // "remaining" so the runner re-invokes until every artifact carries a real date +
+    // author. Either sentinel missing counts (they're filled together).
+    const dateRemaining = Object.values(next).filter(
+      (n) => n.updatedAt === undefined || n.authorSourced === undefined,
+    ).length
     res.remaining = publishRemaining + dateRemaining
 
     let status = capped

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -54,6 +54,36 @@ export const artifactRoutes = (ctx: AppContext) => {
   } = ctx
   const app = new Hono()
 
+  // Resolve a set of GitHub numeric user ids to Dock handles (usernames) in ONE batched
+  // query — gh_id → handle, only for committers who signed in with GitHub. Empty set ⇒ {}.
+  const resolveHandles = async (ghIds: string[]): Promise<Record<string, string | null>> => {
+    const out: Record<string, string | null> = {}
+    if (ghIds.length === 0) return out
+    for (const u of await meta.usersByGithubIds(ghIds)) out[u.gh_id] = u.username
+    return out
+  }
+
+  // The artifact's current author as a resolved profile: name/login/avatar from the
+  // denormalized columns, plus the Dock `handle` when the committer is a known user.
+  // Null when the artifact has no recorded author at all.
+  const authorProfile = (
+    a: ArtifactRecord,
+    handleByGhId: Record<string, string | null>,
+  ): {
+    name: string | null
+    login: string | null
+    avatar: string | null
+    handle: string | null
+  } | null => {
+    if (!a.author_name && !a.author_login && !a.author_gh_id) return null
+    return {
+      name: a.author_name,
+      login: a.author_login,
+      avatar: a.author_avatar,
+      handle: a.author_gh_id ? (handleByGhId[a.author_gh_id] ?? null) : null,
+    }
+  }
+
   // Newest-first, keyset-paginated (?cursor=<created_at>&limit=N), with optional
   // server-side ?q= (title search), ?tag=, and ?favorite=true. Returns
   // { artifacts, next_cursor }. tag/favorite resolve to an id set first.
@@ -76,6 +106,8 @@ export const artifactRoutes = (ctx: AppContext) => {
     const tag = c.req.query("tag")?.trim() || undefined
     const collectionId = c.req.query("collection")?.trim() || undefined
     const favOnly = c.req.query("favorite") === "true"
+    // ?author=<github login> narrows to artifacts whose current author is that login.
+    const author = c.req.query("author")?.trim().slice(0, 100) || undefined
 
     const favIds = me ? await meta.listUserFavoriteIds(me.id) : []
     const favorites = new Set(favIds)
@@ -116,6 +148,9 @@ export const artifactRoutes = (ctx: AppContext) => {
         (!!me && !!(await meta.getMembership(col.org_id, me.id))) ||
         (await collectionRole(c, col)) !== null
     }
+    // Author filter narrows to artifacts last changed by a GitHub login, scoped to the
+    // listing's workspace (after collection scope has settled listOrg). Mirrors ?tag=.
+    if (author) narrow(await meta.artifactIdsByAuthor(listOrg, author))
     if (ids && ids.length === 0) return c.json({ artifacts: [], next_cursor: null })
 
     // A listing only shows non-public artifacts to a MEMBER of that workspace (or the
@@ -147,12 +182,20 @@ export const artifactRoutes = (ctx: AppContext) => {
     const pageIds = page.map((a) => a.id)
     const counts = analyticsOn ? await meta.viewCounts(pageIds) : {}
     const tags = await meta.tagsForArtifacts(pageIds)
+    // Resolve the page's distinct author gh_ids to Dock handles in ONE batched query (no
+    // N+1) so each row can show "who last changed this" with a link to the Dock profile.
+    const handleByGhId = await resolveHandles([
+      ...new Set(page.map((a) => a.author_gh_id).filter((x): x is string => !!x)),
+    ])
     return c.json({
       artifacts: page.map((a) => ({
         ...toJson(deps.baseUrl, a, []),
         views: counts[a.id] ?? 0,
         tags: tags[a.id] ?? [],
         favorite: favorites.has(a.id),
+        // The current author as a resolved profile (name/login/avatar + Dock handle), so
+        // the list can render the last editor + filter by them.
+        author: authorProfile(a, handleByGhId),
       })),
       next_cursor,
       ...(collectionInfo ? { collection: collectionInfo } : {}),
@@ -366,13 +409,30 @@ export const artifactRoutes = (ctx: AppContext) => {
     const favorite = me ? (await meta.listUserFavoriteIds(me)).includes(artifact.id) : false
     const collections = await meta.collectionIdsForArtifact(artifact.id)
     const proposals = await meta.listProposals(artifact.id)
+    // Resolve the GitHub author(s) to Dock profiles: collect every distinct gh_id on the
+    // artifact + its versions, map them in ONE query, and attach a `handle` (the Dock
+    // username) when the committer signed in with GitHub. Additive — the raw author_*
+    // fields stay on the response regardless.
+    const ghIds = new Set<string>()
+    if (artifact.author_gh_id) ghIds.add(artifact.author_gh_id)
+    for (const v of versions) if (v.author_gh_id) ghIds.add(v.author_gh_id)
+    const handleByGhId = await resolveHandles([...ghIds])
+    const base = toJson(deps.baseUrl, artifact, versions)
     // `versions` stays at revision granularity (machines/agents); `sessions` is
     // the time-grouped view the UI shows by default. `my_role` tells the client
     // which actions to surface; `open_proposals` badges the review queue while
     // `proposals_total` (everything but withdrawn) gates the Proposals entry so a
     // proposer can return to read feedback after their candidate leaves the queue.
     return c.json({
-      ...toJson(deps.baseUrl, artifact, versions),
+      ...base,
+      // Resolved author profile for the current author (null when there's none, or the
+      // committer never signed in with GitHub — then `handle` is null but name/login/avatar
+      // still describe the GitHub identity). The frontend prefers this over the raw fields.
+      author: authorProfile(artifact, handleByGhId),
+      versions: base.versions.map((v) => ({
+        ...v,
+        handle: v.author_gh_id ? (handleByGhId[v.author_gh_id] ?? null) : null,
+      })),
       sessions: groupSessions(versions, versionWindowMs),
       my_role: effectiveRole(actor, artifact.visibility, artifact.general_role),
       tags,

--- a/apps/api/test/author-tracking.test.ts
+++ b/apps/api/test/author-tracking.test.ts
@@ -1,0 +1,244 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { newId, type RepoSourceRecord } from "@dock/core"
+import { SqliteMetaStore } from "@dock/db/sqlite"
+import { FsBlobStore } from "@dock/storage/fs"
+import Database from "better-sqlite3"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { createApp } from "../src/app"
+import { runSync } from "../src/lib/sync"
+
+// ---- GitHub repo fake (one repo's tree + blobs + last-commit per path) ------
+let tree: { path: string; sha: string; type: "blob" | "tree" }[] = []
+// repo path → the commit element the Commits API returns (date + authors).
+const commits: Record<
+  string,
+  {
+    commit?: { committer?: { date?: string }; author?: { name?: string; email?: string } }
+    author?: { login?: string; id?: number; avatar_url?: string } | null
+  }
+> = {}
+const blobs: Record<string, string> = {}
+
+const dir = mkdtempSync(join(tmpdir(), "dock-author-test-"))
+const dbPath = join(dir, "a.db")
+const meta = new SqliteMetaStore(dbPath)
+const blobStore = new FsBlobStore(join(dir, "blobs"))
+const app = createApp({ meta, blobs: blobStore, baseUrl: "http://dock.test", token: "tok" })
+const NOW = "2026-06-17T00:00:00.000Z"
+const auth = { authorization: "Bearer tok" }
+
+beforeAll(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string | URL) => {
+      const s = String(url)
+      if (s.includes("/git/trees/")) return new Response(JSON.stringify({ tree, truncated: false }))
+      if (s.includes("/commits?")) {
+        const path = new URL(s).searchParams.get("path") ?? ""
+        const c = commits[path]
+        return new Response(JSON.stringify(c ? [c] : []))
+      }
+      const m = s.match(/\/git\/blobs\/([^/?]+)/)
+      if (m) {
+        const body = blobs[m[1] as string]
+        return body == null ? new Response("nf", { status: 404 }) : new Response(body)
+      }
+      return new Response("nope", { status: 404 })
+    }),
+  )
+})
+afterAll(() => {
+  vi.unstubAllGlobals()
+  meta.close()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+const mkSource = async (repo: string): Promise<RepoSourceRecord> => {
+  const col = await meta.createCollection({
+    id: newId("col"),
+    org_id: "default",
+    title: repo,
+    created_by: "u",
+  })
+  return meta.createRepoSource({
+    id: newId("rs"),
+    org_id: "default",
+    collection_id: col.id,
+    repo,
+    ref: "main",
+    includes: "**/*.md",
+    created_by: "u",
+  })
+}
+
+describe("GitHub author tracking — sync capture", () => {
+  it("stamps the commit author on both the version and the artifact", async () => {
+    const src = await mkSource("acme/repo-a")
+    tree = [{ path: "intro.md", sha: "sha-a-1", type: "blob" }]
+    blobs["sha-a-1"] = "# Intro"
+    commits["intro.md"] = {
+      commit: {
+        committer: { date: "2025-05-05T05:05:05Z" },
+        author: { name: "Ada Lovelace", email: "ada@example.com" },
+      },
+      author: { login: "ada", id: 4242, avatar_url: "https://avatars/ada.png" },
+    }
+
+    await runSync(meta, blobStore, src, NOW)
+
+    const map = JSON.parse((await meta.getRepoSource(src.id))?.files ?? "{}") as Record<
+      string,
+      { artifact_id: string; short_id: string; authorSourced?: boolean; updatedAt?: string }
+    >
+    const ent = map["intro.md"]
+    expect(ent?.authorSourced).toBe(true)
+    expect(ent?.updatedAt).toBe("2025-05-05T05:05:05Z")
+
+    // Artifact: denormalized current author + date.
+    const art = await meta.getByShortId(ent?.short_id ?? "")
+    expect(art?.author_name).toBe("ada") // display name prefers the login
+    expect(art?.author_login).toBe("ada")
+    expect(art?.author_gh_id).toBe("4242")
+    expect(art?.author_avatar).toBe("https://avatars/ada.png")
+    expect(art?.updated_at).toBe("2025-05-05T05:05:05Z")
+
+    // Version row: the GitHub identity is stored per-version too.
+    const v = await meta.getVersion(art?.id ?? "", 1)
+    expect(v?.author).toBe("ada")
+    expect(v?.author_login).toBe("ada")
+    expect(v?.author_gh_id).toBe("4242")
+  })
+
+  it("falls back to the git author name (then 'GitHub sync') when GitHub maps no account", async () => {
+    const src = await mkSource("acme/repo-b")
+    tree = [
+      { path: "named.md", sha: "sha-b-1", type: "blob" },
+      { path: "bare.md", sha: "sha-b-2", type: "blob" },
+    ]
+    blobs["sha-b-1"] = "# Named"
+    blobs["sha-b-2"] = "# Bare"
+    // A commit with a git author name but no resolved GitHub account.
+    commits["named.md"] = {
+      commit: {
+        committer: { date: "2024-02-02T02:02:02Z" },
+        author: { name: "Grace Hopper", email: "grace@example.com" },
+      },
+      author: null,
+    }
+    // No identity at all → keep the legacy "GitHub sync" display name.
+    commits["bare.md"] = { commit: { committer: { date: "2024-03-03T03:03:03Z" } } }
+
+    await runSync(meta, blobStore, src, NOW)
+    const map = JSON.parse((await meta.getRepoSource(src.id))?.files ?? "{}") as Record<
+      string,
+      { short_id: string }
+    >
+
+    const named = await meta.getByShortId(map["named.md"]?.short_id ?? "")
+    expect(named?.author_name).toBe("Grace Hopper")
+    expect(named?.author_login).toBeNull()
+    expect(named?.author_gh_id).toBeNull()
+
+    const bare = await meta.getByShortId(map["bare.md"]?.short_id ?? "")
+    expect(bare?.author_name).toBe("GitHub sync")
+    expect(bare?.author_login).toBeNull()
+  })
+})
+
+describe("GitHub author tracking — model + list filter", () => {
+  it("artifactIdsByAuthor filters by login (case-insensitive), scoped to the org", async () => {
+    // Two artifacts authored by "ada" already exist from repo-a; publish one by another
+    // login + one in another org to prove scoping + login matching.
+    const other = await meta.createArtifact({
+      id: newId("a"),
+      short_id: newId("s"),
+      org_id: "default",
+      slug: null,
+      title: "by-bob",
+      visibility: "link",
+      kind: "file",
+      spa: 0,
+    })
+    await meta.addVersion(other.id, {
+      id: newId("v"),
+      blob_key: await blobStore.put(new TextEncoder().encode("x")),
+      content_type: "text/markdown",
+      size_bytes: 1,
+      author: "bob",
+      author_login: "bob",
+      author_avatar: null,
+      author_gh_id: "9001",
+      message: null,
+    })
+
+    const ada = await meta.artifactIdsByAuthor("default", "ADA") // case-insensitive
+    expect(ada.length).toBe(1)
+    const bob = await meta.artifactIdsByAuthor("default", "bob")
+    expect(bob).toEqual([other.id])
+    expect(await meta.artifactIdsByAuthor("default", "nobody")).toEqual([])
+    expect(await meta.artifactIdsByAuthor("other-org", "ada")).toEqual([])
+  })
+
+  it("?author= narrows the artifact list", async () => {
+    const all = await (await app.request("/v1/artifacts?limit=100", { headers: auth })).json()
+    const byBob = await (
+      await app.request("/v1/artifacts?author=bob&limit=100", { headers: auth })
+    ).json()
+    expect(all.artifacts.length).toBeGreaterThan(byBob.artifacts.length)
+    expect(
+      byBob.artifacts.every((a: { author_login: string | null }) => a.author_login === "bob"),
+    ).toBe(true)
+    // The list carries the denormalized author fields for the UI.
+    expect(byBob.artifacts[0].author_name).toBe("bob")
+    expect(byBob.artifacts[0].author).toMatchObject({ login: "bob", name: "bob" })
+  })
+})
+
+describe("GitHub author tracking — user mapping", () => {
+  it("usersByGithubIds maps an account row to its Dock user", async () => {
+    // Seed Better Auth's user + account tables directly via the raw sqlite handle.
+    const raw = new Database(dbPath)
+    raw.exec(
+      `CREATE TABLE IF NOT EXISTS user (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT, username TEXT, discoverable INTEGER, profession TEXT, about TEXT)`,
+    )
+    raw.exec(
+      `CREATE TABLE IF NOT EXISTS account (id TEXT PRIMARY KEY, accountId TEXT, providerId TEXT, userId TEXT)`,
+    )
+    raw
+      .prepare(`INSERT OR IGNORE INTO user (id, name, image, username) VALUES (?,?,?,?)`)
+      .run("u-ada", "Ada L.", "https://img/ada", "ada-handle")
+    raw
+      .prepare(`INSERT OR IGNORE INTO account (id, accountId, providerId, userId) VALUES (?,?,?,?)`)
+      .run("acc-1", "4242", "github", "u-ada")
+    raw.close()
+
+    const rows = await meta.usersByGithubIds(["4242", "9999"])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      gh_id: "4242",
+      id: "u-ada",
+      username: "ada-handle",
+      name: "Ada L.",
+      image: "https://img/ada",
+    })
+
+    // The single-artifact API resolves the handle onto the author profile.
+    const ada = (await meta.artifactIdsByAuthor("default", "ada"))[0] as string
+    const art = await meta.getArtifactById(ada)
+    const detail = await (
+      await app.request(`/v1/artifacts/${art?.short_id}`, { headers: auth })
+    ).json()
+    expect(detail.author).toMatchObject({ login: "ada", handle: "ada-handle" })
+    expect(detail.versions[0]).toMatchObject({ author_login: "ada", handle: "ada-handle" })
+  })
+
+  it("returns [] for empty input or when the tables are absent", async () => {
+    expect(await meta.usersByGithubIds([])).toEqual([])
+    // A fresh store with no user/account tables resolves gracefully to [].
+    const m2 = new SqliteMetaStore(join(dir, "empty.db"))
+    expect(await m2.usersByGithubIds(["1"])).toEqual([])
+    m2.close()
+  })
+})

--- a/apps/api/test/github-author.test.ts
+++ b/apps/api/test/github-author.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+import { parseLastCommit } from "../src/lib/github"
+
+// The Commits API response carries the date under commit.committer, the raw git author
+// under commit.author (always present), and the resolved GitHub account under the
+// TOP-LEVEL author (null when GitHub can't map the commit email). parseLastCommit pulls
+// all three into one { date, author } without a network round-trip.
+describe("parseLastCommit", () => {
+  it("extracts date + full author when GitHub mapped the commit to an account", () => {
+    const { date, author } = parseLastCommit([
+      {
+        commit: {
+          committer: { date: "2025-03-04T05:06:07Z" },
+          author: { name: "Ada Lovelace", email: "ada@example.com" },
+        },
+        author: { login: "ada", id: 4242, avatar_url: "https://avatars/ada.png" },
+      },
+    ])
+    expect(date).toBe("2025-03-04T05:06:07Z")
+    expect(author).toEqual({
+      login: "ada",
+      ghId: "4242", // numeric id stringified (matches account.accountId)
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      avatar: "https://avatars/ada.png",
+    })
+  })
+
+  it("falls back to the git author name/email when the top-level account is null", () => {
+    const { date, author } = parseLastCommit([
+      {
+        commit: {
+          committer: { date: "2024-01-01T00:00:00Z" },
+          author: { name: "Grace Hopper", email: "grace@example.com" },
+        },
+        author: null, // GitHub couldn't map the email → no account
+      },
+    ])
+    expect(date).toBe("2024-01-01T00:00:00Z")
+    expect(author).toEqual({
+      login: null,
+      ghId: null,
+      name: "Grace Hopper",
+      email: "grace@example.com",
+      avatar: null,
+    })
+  })
+
+  it("returns a null author when there's no identity at all (date may still resolve)", () => {
+    const { date, author } = parseLastCommit([
+      { commit: { committer: { date: "2023-12-31T23:59:59Z" } } },
+    ])
+    expect(date).toBe("2023-12-31T23:59:59Z")
+    expect(author).toBeNull()
+  })
+
+  it("returns nulls for an empty / missing history", () => {
+    expect(parseLastCommit([])).toEqual({ date: null, author: null })
+    expect(parseLastCommit(null)).toEqual({ date: null, author: null })
+    expect(parseLastCommit(undefined)).toEqual({ date: null, author: null })
+  })
+})

--- a/apps/api/test/sync.test.ts
+++ b/apps/api/test/sync.test.ts
@@ -342,6 +342,12 @@ describe("GitHub sync engine", () => {
     const sid = map["dated.md"]?.short_id as string
     expect((await meta.getByShortId(sid))?.updated_at).toBe("2025-01-02T03:04:05Z")
     expect(map["dated.md"]?.updatedAt).toBe("2025-01-02T03:04:05Z")
+    // This mock returns only a committer date (no author) → the author falls back to the
+    // legacy "GitHub sync" display name and the GitHub fields stay null. The author is
+    // marked sourced so a re-sync won't re-fetch.
+    expect((await meta.getByShortId(sid))?.author_name).toBe("GitHub sync")
+    expect((await meta.getByShortId(sid))?.author_login).toBeNull()
+    expect(map["dated.md"]?.authorSourced).toBe(true)
 
     // Backfill: simulate a legacy entry synced before dates existed (updatedAt absent)
     // by stripping it from the map + resetting the row, then re-sync (sha unchanged).

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -52,6 +52,14 @@ export interface Artifact {
     n: number
     content_type?: string
     author: string
+    /** The GitHub identity behind this version (sync only): login, avatar URL, numeric
+     *  user id (text). Null for manual/anonymous/unmappable publishes. */
+    author_login?: string | null
+    author_avatar?: string | null
+    author_gh_id?: string | null
+    /** The Dock handle of this version's GitHub author, when they signed in with GitHub
+     *  (single-artifact detail only); null otherwise. */
+    handle?: string | null
     message: string | null
     name: string | null
     created_at: string
@@ -82,6 +90,21 @@ export interface Artifact {
   /** Last-updated time (set on each new version; null until versioned). Read as
    *  `updated_at ?? created_at`. Drives the recency sort + the "updated X" label. */
   updated_at?: string | null
+  /** The CURRENT (last) author, denormalized — for a GitHub-synced artifact these mirror
+   *  the last commit's author. Drives "who last changed this" + the ?author= filter. */
+  author_name?: string | null
+  author_login?: string | null
+  author_avatar?: string | null
+  author_gh_id?: string | null
+  /** The current author resolved to a profile: the raw GitHub identity plus the Dock
+   *  `handle` (username) when the committer signed in with GitHub. Null when there's no
+   *  recorded author. Prefer this over the raw fields for rendering. */
+  author?: {
+    name: string | null
+    login: string | null
+    avatar: string | null
+    handle: string | null
+  } | null
 }
 export interface Report {
   id: string
@@ -449,6 +472,8 @@ export const api = {
     tag?: string
     collection?: string
     favorite?: boolean
+    /** Narrow to artifacts last changed by this GitHub login. */
+    author?: string
     /** "shared" → only artifacts explicitly shared with you (across workspaces). */
     scope?: "shared"
     cursor?: string
@@ -465,6 +490,7 @@ export const api = {
     if (params?.tag) qs.set("tag", params.tag)
     if (params?.collection) qs.set("collection", params.collection)
     if (params?.favorite) qs.set("favorite", "true")
+    if (params?.author) qs.set("author", params.author)
     if (params?.scope) qs.set("scope", params.scope)
     if (params?.cursor) qs.set("cursor", params.cursor)
     if (params?.limit) qs.set("limit", String(params.limit))

--- a/apps/web/src/components/author-chip.tsx
+++ b/apps/web/src/components/author-chip.tsx
@@ -1,0 +1,94 @@
+import { Link } from "@tanstack/react-router"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { cn } from "@/lib/utils"
+
+// One author, rendered as a tiny avatar + name — the "who last changed this" /
+// "who authored this version" chip. Fields come straight off the resolved
+// `author` (and the per-version author_* fields): a GitHub identity, plus the
+// Dock `handle` when that committer signed into Dock.
+//
+// Three shapes, picked by the props:
+//  - `onClick`  → a button (used to filter the list by this author).
+//  - `handle`   → a Link to the author's /u/<handle> profile.
+//  - neither    → plain, non-interactive text.
+export interface AuthorChipProps {
+  name: string | null
+  login: string | null
+  avatar: string | null
+  /** The Dock username, when this GitHub user signed in — drives the profile link. */
+  handle: string | null
+  /** "sm" (default) sits in a meta line; "xs" is the tightest variant. */
+  size?: "xs" | "sm"
+  /** When set, the chip is a button (e.g. to filter the list by `login`). */
+  onClick?: () => void
+  /** Stable id for the interactive variants (button / link). */
+  "data-testid"?: string
+  className?: string
+}
+
+const initialsOf = (label: string): string => label.slice(0, 2).toUpperCase()
+
+export function AuthorChip({
+  name,
+  login,
+  avatar,
+  handle,
+  size = "sm",
+  onClick,
+  "data-testid": testId,
+  className,
+}: AuthorChipProps) {
+  const label = name ?? login ?? "Unknown"
+  const avatarSize = size === "xs" ? "size-4" : "size-5"
+  const base = cn(
+    "inline-flex min-w-0 max-w-full items-center gap-1.5 font-mono text-2xs text-muted-foreground",
+    className,
+  )
+
+  const inner = (
+    <>
+      <Avatar className={cn(avatarSize, "shrink-0")}>
+        {avatar && <AvatarImage src={avatar} alt={label} />}
+        <AvatarFallback>{initialsOf(label)}</AvatarFallback>
+      </Avatar>
+      <span className="truncate">{label}</span>
+    </>
+  )
+
+  // Click-to-filter wins: a button that doesn't trigger the row's stretched link.
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        data-testid={testId}
+        title={`Filter by ${label}`}
+        onClick={(e) => {
+          e.stopPropagation()
+          onClick()
+        }}
+        className={cn(base, "rounded-md transition-colors hover:text-foreground")}
+      >
+        {inner}
+      </button>
+    )
+  }
+
+  // Known Dock user → link to their profile.
+  if (handle) {
+    return (
+      <Link
+        to="/u/$handle"
+        params={{ handle }}
+        data-testid={testId}
+        title={`@${handle}`}
+        onClick={(e) => e.stopPropagation()}
+        className={cn(base, "transition-colors hover:text-foreground")}
+      >
+        {inner}
+      </Link>
+    )
+  }
+
+  // Anonymous / unmapped author: plain text, no link.
+  return <span className={base}>{inner}</span>
+}

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -11,6 +11,8 @@ export type LibraryParams = {
   tag?: string
   collection?: string
   favorite?: boolean
+  // Narrow to artifacts last changed by this GitHub login.
+  author?: string
 }
 export const libraryArtifactsQuery = (params: LibraryParams) =>
   infiniteQueryOptions({

--- a/apps/web/src/pages/artifact/insights-history.tsx
+++ b/apps/web/src/pages/artifact/insights-history.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react"
 import { type Analytics, type Artifact as Art, api } from "@/api"
+import { AuthorChip } from "@/components/author-chip"
 import { Icon } from "@/components/icons"
 import { ColoredAvatar } from "@/components/shared/colored-avatar"
 import { Spinner } from "@/components/shared/spinner"
@@ -189,6 +190,10 @@ export function HistoryDrawer({
         name: v.name,
         created_at: v.created_at,
       }))
+  // A session is the latest version in a time group; its `n` is that version, so
+  // we resolve the rich author identity (avatar, login, the Dock handle for the
+  // profile link) from the matching version.
+  const versionByN = new Map(art.versions.map((v) => [v.n, v]))
   let lastDay = ""
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -210,47 +215,66 @@ export function HistoryDrawer({
                     {header}
                   </div>
                 )}
-                <button
-                  type="button"
-                  data-testid={`history-version-${s.n}`}
-                  onClick={() => {
-                    goTo(s.n)
-                    onOpenChange(false)
-                  }}
+                {/* Stretched-link row: the select button covers the row (::after) while
+                    the author chip sits above it (z-20) so its profile link stays
+                    independently clickable — no anchor nested in a button. */}
+                <div
                   className={cn(
-                    "mb-px block w-full rounded-md px-2 py-2 text-left transition-colors hover:bg-hover",
+                    "group relative mb-px rounded-md px-2 py-2 transition-colors hover:bg-hover",
                     cur && "bg-accent",
                   )}
                 >
-                  <div className="flex items-center gap-1.5">
-                    {s.name ? (
-                      <Icon name="pin" size={13} />
-                    ) : (
-                      <span className="size-1.5 shrink-0 rounded-full bg-muted-foreground" />
-                    )}
-                    <span
-                      className={cn(
-                        "truncate text-sm font-semibold",
-                        cur ? "text-primary" : "text-foreground",
+                  <button
+                    type="button"
+                    data-testid={`history-version-${s.n}`}
+                    onClick={() => {
+                      goTo(s.n)
+                      onOpenChange(false)
+                    }}
+                    className="block w-full text-left outline-none after:absolute after:inset-0 after:z-[1] after:rounded-md after:content-[''] focus-visible:after:outline-2 focus-visible:after:-outline-offset-2 focus-visible:after:outline-ring"
+                  >
+                    <div className="flex items-center gap-1.5">
+                      {s.name ? (
+                        <Icon name="pin" size={13} />
+                      ) : (
+                        <span className="size-1.5 shrink-0 rounded-full bg-muted-foreground" />
                       )}
-                    >
-                      {s.name ?? clock(s.created_at)}
-                    </span>
-                    {s.n === art.current_version && (
-                      <span className="rounded-full bg-success/15 px-1.5 py-px font-mono text-2xs font-bold text-success">
-                        current
+                      <span
+                        className={cn(
+                          "truncate text-sm font-semibold",
+                          cur ? "text-primary" : "text-foreground",
+                        )}
+                      >
+                        {s.name ?? clock(s.created_at)}
                       </span>
-                    )}
-                    {s.count > 1 && (
-                      <span className="ml-auto font-mono text-2xs text-muted-foreground">
-                        {s.count} edits
-                      </span>
-                    )}
-                  </div>
-                  <div className="mt-0.5 pl-[18px] font-mono text-2xs text-muted-foreground">
-                    {s.author}
-                  </div>
-                </button>
+                      {s.n === art.current_version && (
+                        <span className="rounded-full bg-success/15 px-1.5 py-px font-mono text-2xs font-bold text-success">
+                          current
+                        </span>
+                      )}
+                      {s.count > 1 && (
+                        <span className="ml-auto font-mono text-2xs text-muted-foreground">
+                          {s.count} edits
+                        </span>
+                      )}
+                    </div>
+                  </button>
+                  {(() => {
+                    const v = versionByN.get(s.n)
+                    return (
+                      <div className="relative z-20 mt-0.5 flex pl-[18px]">
+                        <AuthorChip
+                          name={s.author || v?.author || null}
+                          login={v?.author_login ?? null}
+                          avatar={v?.author_avatar ?? null}
+                          handle={v?.handle ?? null}
+                          size="xs"
+                          data-testid={`history-version-author-${s.n}`}
+                        />
+                      </div>
+                    )
+                  })()}
+                </div>
               </div>
             )
           })}

--- a/apps/web/src/pages/library/artifact-card.tsx
+++ b/apps/web/src/pages/library/artifact-card.tsx
@@ -1,4 +1,5 @@
 import type { Artifact } from "@/api"
+import { AuthorChip } from "@/components/author-chip"
 import { Icon } from "@/components/icons"
 import { Thumb } from "@/components/shared/thumb"
 import {
@@ -46,6 +47,9 @@ export function ArtifactCard({
   onPrefetch?: () => void
 }) {
   const isOwner = a.my_role === "owner"
+  // "Who last changed this" — only synced artifacts carry an author.
+  const author = a.author ?? null
+  const hasAuthor = !!(author?.name || author?.login || a.author_login || a.author_name)
 
   return (
     <div className="group relative flex cursor-pointer flex-col gap-2 rounded-lg border border-border bg-card p-3.5 transition-all motion-safe:hover:-translate-y-0.5 hover:border-primary hover:shadow-[var(--shadow)] active:translate-y-0">
@@ -130,6 +134,17 @@ export function ArtifactCard({
           )}
         </span>
       </button>
+      {hasAuthor && (
+        <div className="relative z-20 flex min-w-0">
+          <AuthorChip
+            name={author?.name ?? a.author_name ?? null}
+            login={author?.login ?? a.author_login ?? null}
+            avatar={author?.avatar ?? a.author_avatar ?? null}
+            handle={author?.handle ?? null}
+            data-testid={`artifact-card-author-${a.short_id}`}
+          />
+        </div>
+      )}
       {(a.tags ?? []).length > 0 && (
         <div className="relative z-20 flex flex-wrap gap-1.5">
           {(a.tags ?? []).slice(0, 6).map((t) => (

--- a/apps/web/src/pages/library/artifact-row.tsx
+++ b/apps/web/src/pages/library/artifact-row.tsx
@@ -1,5 +1,6 @@
 import { Folder } from "lucide-react"
 import type { Artifact } from "@/api"
+import { AuthorChip } from "@/components/author-chip"
 import { Icon } from "@/components/icons"
 import {
   DropdownMenu,
@@ -22,6 +23,7 @@ export function ArtifactRow({
   onOpen,
   onToggleFavorite,
   onPickTag,
+  onPickAuthor,
   onDelete,
   onPrefetch,
 }: {
@@ -29,6 +31,9 @@ export function ArtifactRow({
   onOpen: () => void
   onToggleFavorite: () => void
   onPickTag: (tag: string) => void
+  // Clicking the author filters the list by their GitHub login. Omit to render
+  // the author as a non-filtering chip (still links to a known profile).
+  onPickAuthor?: (login: string) => void
   onDelete?: () => void
   onPrefetch?: () => void
 }) {
@@ -36,6 +41,11 @@ export function ArtifactRow({
   const updated = a.updated_at ?? a.created_at ?? a.versions[0]?.created_at
   const dir = a.source_path ? dirOf(a.source_path) : ""
   const tags = a.tags ?? []
+  // "Who last changed this": prefer the resolved author (carries the Dock handle),
+  // fall back to the denormalized fields. Present only for synced artifacts.
+  const author = a.author ?? null
+  const authorLogin = author?.login ?? a.author_login ?? null
+  const hasAuthor = !!(author?.name || authorLogin || a.author_name)
 
   return (
     <div className="group relative flex items-center gap-3 rounded-lg border border-border bg-card px-3.5 py-2.5 transition-colors hover:border-primary hover:bg-hover">
@@ -72,6 +82,21 @@ export function ArtifactRow({
           )}
         </span>
       </button>
+
+      {/* "Who last changed this" — above the stretched link so the click-to-filter
+          button (and the profile link) stay independently clickable. */}
+      {hasAuthor && (
+        <div className="relative z-20 hidden shrink-0 items-center sm:flex">
+          <AuthorChip
+            name={author?.name ?? a.author_name ?? null}
+            login={authorLogin}
+            avatar={author?.avatar ?? a.author_avatar ?? null}
+            handle={author?.handle ?? null}
+            onClick={onPickAuthor && authorLogin ? () => onPickAuthor(authorLogin) : undefined}
+            data-testid={`artifact-row-author-${a.short_id}`}
+          />
+        </div>
+      )}
 
       {/* Tags sit above the stretched link so they stay independently clickable. */}
       {tags.length > 0 && (

--- a/apps/web/src/pages/library/folder-groups.tsx
+++ b/apps/web/src/pages/library/folder-groups.tsx
@@ -13,6 +13,7 @@ interface Handlers {
   onOpen: (a: Artifact) => void
   onToggleFavorite: (a: Artifact) => void
   onPickTag: (tag: string) => void
+  onPickAuthor: (login: string) => void
   onPrefetch: (a: Artifact) => void
 }
 
@@ -92,6 +93,7 @@ function FolderSection({ dir, items, ...handlers }: { dir: string; items: Artifa
               onOpen={() => handlers.onOpen(a)}
               onToggleFavorite={() => handlers.onToggleFavorite(a)}
               onPickTag={handlers.onPickTag}
+              onPickAuthor={handlers.onPickAuthor}
               onPrefetch={() => handlers.onPrefetch(a)}
             />
           ))}

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -84,6 +84,7 @@ function LibraryBody() {
     tag: search.tag,
     collection: search.collection,
     favorite: search.f === "favorites" || undefined,
+    author: search.author,
   }
   const listQuery = libraryArtifactsQuery(params)
   const { data, isPending, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
@@ -163,6 +164,14 @@ function LibraryBody() {
       toast.error((e as Error).message)
       qc.invalidateQueries({ queryKey: listQuery.queryKey })
     }
+  }
+
+  // Filter by author. Keep the collection context (you're narrowing the synced
+  // repo you're already in) and drop it again via the clear pill.
+  const pickAuthor = (login: string) => nav({ to: "/", search: { ...search, author: login } })
+  const clearAuthor = () => {
+    const { author: _drop, ...rest } = search
+    nav({ to: "/", search: rest })
   }
 
   const activeCollection =
@@ -300,6 +309,20 @@ function LibraryBody() {
               <X />
             </Button>
           )}
+          {/* Active author filter — independent of the tag/collection filter, so it
+              gets its own clearable pill. */}
+          {search.author && (
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="library-author-filter-clear"
+              title={`Clear author filter: ${search.author}`}
+              onClick={clearAuthor}
+            >
+              <Icon name="user" size={15} /> {search.author}
+              <X />
+            </Button>
+          )}
         </div>
 
         {filter.kind !== "collection" && <PublishCard />}
@@ -411,6 +434,7 @@ function LibraryBody() {
                 onOpen={(a) => nav({ to: "/a/$ref", params: { ref: a.short_id } })}
                 onToggleFavorite={toggleFav}
                 onPickTag={(tag) => nav({ to: "/", search: { tag } })}
+                onPickAuthor={pickAuthor}
                 onPrefetch={(a) => prefetch(a.short_id, a.current_version)}
               />
             ) : (
@@ -422,6 +446,7 @@ function LibraryBody() {
                     onOpen={() => nav({ to: "/a/$ref", params: { ref: a.short_id } })}
                     onToggleFavorite={() => toggleFav(a)}
                     onPickTag={(tag) => nav({ to: "/", search: { tag } })}
+                    onPickAuthor={pickAuthor}
                     onDelete={() => deleteArtifact(a)}
                     onPrefetch={() => prefetch(a.short_id, a.current_version)}
                   />

--- a/apps/web/src/pages/library/types.ts
+++ b/apps/web/src/pages/library/types.ts
@@ -23,4 +23,6 @@ export type LibrarySearch = {
   tag?: string
   collection?: string
   q?: string
+  // Narrow to artifacts last changed by this GitHub login (synced collections).
+  author?: string
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -10,6 +10,7 @@ export const Route = createFileRoute("/")({
     tag: typeof s.tag === "string" ? s.tag : undefined,
     collection: typeof s.collection === "string" ? s.collection : undefined,
     q: typeof s.q === "string" ? s.q : undefined,
+    author: typeof s.author === "string" ? s.author : undefined,
   }),
   component: Library,
 })

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -20,7 +20,11 @@ CREATE TABLE IF NOT EXISTS artifact (
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   updated_at TEXT,
   removed_at TEXT,
-  source_path TEXT
+  source_path TEXT,
+  author_name TEXT,
+  author_login TEXT,
+  author_avatar TEXT,
+  author_gh_id TEXT
 );
 
 CREATE TABLE IF NOT EXISTS version (
@@ -31,6 +35,9 @@ CREATE TABLE IF NOT EXISTS version (
   content_type TEXT NOT NULL,
   size_bytes INTEGER NOT NULL DEFAULT 0,
   author TEXT NOT NULL,
+  author_login TEXT,
+  author_avatar TEXT,
+  author_gh_id TEXT,
   message TEXT,
   name TEXT,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -52,6 +52,15 @@ export interface ArtifactRecord {
    *  The structural "location" — drives the folder/tree view — kept distinct from the
    *  human `title`. Null for artifacts not mirrored from a repo. */
   source_path: string | null
+  /** The CURRENT (last) author, denormalized from the latest version row for the list
+   *  view + author filtering. `author_name` is the display name (commit author name,
+   *  "GitHub sync", or a user display name); `author_login`/`author_avatar`/`author_gh_id`
+   *  carry the GitHub login, avatar URL, and numeric user id (text) for a synced version.
+   *  All null for legacy/anonymous/non-synced rows. */
+  author_name: string | null
+  author_login: string | null
+  author_avatar: string | null
+  author_gh_id: string | null
 }
 
 export interface ListArtifactsOpts {
@@ -86,6 +95,12 @@ export interface VersionRecord {
   /** Byte length of the uploaded payload, summed per workspace for storage quotas. */
   size_bytes: number
   author: string
+  /** The GitHub identity behind this version, when it came from a sync: the commit
+   *  author's login, avatar URL, and numeric user id (text). All null for a manual or
+   *  anonymous publish, or a commit GitHub can't map to an account. */
+  author_login: string | null
+  author_avatar: string | null
+  author_gh_id: string | null
   message: string | null
   /** A named checkpoint (Docs-style). Null = an ordinary auto-saved revision. */
   name: string | null
@@ -113,6 +128,10 @@ export interface NewVersion {
   content_type: string
   size_bytes?: number
   author: string
+  /** The GitHub identity behind this version (sync only); null/omitted otherwise. */
+  author_login?: string | null
+  author_avatar?: string | null
+  author_gh_id?: string | null
   message: string | null
   name?: string | null
 }
@@ -161,6 +180,9 @@ export interface MetaStore {
   listArtifacts(opts?: ListArtifactsOpts): Promise<ArtifactRecord[]>
   /** Artifact ids carrying a tag (server-side tag filtering). */
   artifactIdsByTag(tag: string): Promise<string[]>
+  /** Artifact ids in a workspace whose current author_login matches `login`
+   *  (case-insensitive) — the author list-filter. Empty when nothing matches. */
+  artifactIdsByAuthor(orgId: string, login: string): Promise<string[]>
   /** Total artifact count, scoped to a workspace when orgId is given. */
   countArtifacts(orgId?: string): Promise<number>
   /**
@@ -363,6 +385,11 @@ export interface MetaStore {
   // ---- User directory (reads Better Auth's `user` table) ----------------
   findUserByEmail(email: string): Promise<UserDir | null>
   getUsers(ids: string[]): Promise<UserDir[]>
+  /** Map GitHub numeric user ids (as strings) to the Dock accounts that signed in with
+   *  GitHub — joins Better Auth's `account` (providerId='github', accountId IN ids) to
+   *  `user`. Lets a synced artifact's commit author resolve to a Dock profile/handle.
+   *  Returns [] for empty input or when the auth tables are absent. */
+  usersByGithubIds(ghIds: string[]): Promise<GithubUserMapping[]>
   /** Resolve a public profile by its handle (username); null if unclaimed. */
   getUserByUsername(username: string): Promise<UserProfile | null>
   /** Claim or replace a user's handle. Returns "taken" when another account
@@ -440,6 +467,10 @@ export interface MetaStore {
    *  date), so the card's "updated" reflects the SOURCE's last change, not when Dock
    *  ingested it. Publish bumps updated_at to now; the sync calls this after to correct it. */
   setArtifactUpdatedAt(id: string, updatedAt: string): Promise<void>
+  /** Set the artifact's denormalized current author (its author_* columns). Used by the
+   *  sync backfill path to stamp an existing tracked artifact's author from its last
+   *  commit without republishing. `null` clears all four columns. */
+  setArtifactAuthor(artifactId: string, author: GithubAuthor | null): Promise<void>
   createAuditLog(a: NewAuditLog): Promise<void>
   /** Moderation history, newest first. One workspace's, or — super-admin, orgId
    *  undefined — the whole instance's. Optionally narrowed to one artifact. */
@@ -610,6 +641,27 @@ export interface NewProposal {
   author: string
   author_id?: string | null
   base_version: number
+}
+
+/** A GitHub commit author, denormalized onto an artifact / stored per version.
+ *  `name` is the display name; `login`/`avatar` are the GitHub handle + avatar URL;
+ *  `ghId` is the numeric GitHub user id as a string (matches account.accountId). Any
+ *  field may be null when GitHub can't map the commit email to an account. */
+export interface GithubAuthor {
+  name: string | null
+  login: string | null
+  avatar: string | null
+  ghId: string | null
+}
+
+/** A GitHub numeric user id resolved to the Dock account that signed in with it
+ *  (Better Auth `account` joined to `user`). `username` is the public handle. */
+export interface GithubUserMapping {
+  gh_id: string
+  id: string
+  name: string | null
+  image: string | null
+  username: string | null
 }
 
 /** A person, as needed for sharing UIs. Sourced from Better Auth's user table. */

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -34,6 +34,13 @@ export interface PublishInput {
   spa?: boolean
   message?: string
   author?: string
+  /** The GitHub identity behind this publish (sync only): the commit author's login,
+   *  avatar URL, and numeric user id (text). Stored per-version and denormalized as the
+   *  artifact's current author. Omitted/null for a manual or anonymous publish — then
+   *  only the `author` display name is recorded. */
+  authorLogin?: string | null
+  authorAvatar?: string | null
+  authorGhId?: string | null
   /** The workspace the new artifact belongs to (multi-workspace). */
   orgId?: string
   visibility?: Visibility
@@ -189,6 +196,9 @@ export async function publish(
       content_type: contentType,
       size_bytes: input.bytes.length,
       author,
+      author_login: input.authorLogin ?? null,
+      author_avatar: input.authorAvatar ?? null,
+      author_gh_id: input.authorGhId ?? null,
       message: input.message ?? null,
       name: input.name ?? null,
     })
@@ -217,6 +227,9 @@ export async function publish(
     content_type: contentType,
     size_bytes: input.bytes.length,
     author,
+    author_login: input.authorLogin ?? null,
+    author_avatar: input.authorAvatar ?? null,
+    author_gh_id: input.authorGhId ?? null,
     message: input.message ?? "first publish",
     name: input.name ?? null,
   })
@@ -335,11 +348,23 @@ export const toJson = (baseUrl: string, a: ArtifactRecord, versions: VersionReco
   updated_at: a.updated_at,
   /** Repo path for a GitHub-synced artifact (drives the folder view); null otherwise. */
   source_path: a.source_path,
+  /** The CURRENT (last) author, denormalized — drives "who last changed this" + the
+   *  author filter in the list. For a GitHub-synced artifact these mirror the last
+   *  commit's author; null for legacy/anonymous/non-synced rows. The route may attach a
+   *  resolved `author` profile object (with the Dock handle) on top of these. */
+  author_name: a.author_name,
+  author_login: a.author_login,
+  author_avatar: a.author_avatar,
+  author_gh_id: a.author_gh_id,
   versions: versions.map((v) => ({
     n: v.n,
     sha256: v.blob_key,
     content_type: v.content_type,
     author: v.author,
+    /** The GitHub identity behind this version (sync only); null otherwise. */
+    author_login: v.author_login,
+    author_avatar: v.author_avatar,
+    author_gh_id: v.author_gh_id,
     message: v.message,
     name: v.name,
     created_at: v.created_at,

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -1,5 +1,12 @@
 import type { D1Database } from "@cloudflare/workers-types"
-import type { MetaStore, NewView, UserDir, UserProfile, ViewStats } from "@dock/core"
+import type {
+  GithubUserMapping,
+  MetaStore,
+  NewView,
+  UserDir,
+  UserProfile,
+  ViewStats,
+} from "@dock/core"
 import { sql } from "drizzle-orm"
 import { drizzle } from "drizzle-orm/d1"
 import { makeRepos, schema } from "./repos"
@@ -130,6 +137,24 @@ export function createD1Store(d1: D1Database): MetaStore {
         return (await db.all(
           sql`SELECT id, email, name, image, username, profession, about FROM user WHERE id IN (${list})`,
         )) as UserDir[]
+      } catch {
+        return []
+      }
+    },
+    // Map GitHub numeric user ids to Dock accounts (account.accountId → user), scoped to
+    // the github social provider. Best-effort — [] when the Better Auth tables are absent.
+    usersByGithubIds: async (ghIds: string[]): Promise<GithubUserMapping[]> => {
+      if (ghIds.length === 0) return []
+      try {
+        const list = sql.join(
+          ghIds.map((id) => sql`${id}`),
+          sql`, `,
+        )
+        return (await db.all(
+          sql`SELECT a.accountId gh_id, u.id, u.name, u.image, u.username
+              FROM account a JOIN user u ON u.id = a.userId
+              WHERE a.providerId = 'github' AND a.accountId IN (${list})`,
+        )) as GithubUserMapping[]
       } catch {
         return []
       }

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -42,6 +42,13 @@ export const artifact = pgTable("artifact", {
   updated_at: text("updated_at"),
   removed_at: text("removed_at"),
   source_path: text("source_path"),
+  // The CURRENT (last) author, denormalized from the latest version for the list view +
+  // author filtering. For a GitHub-synced artifact these mirror the last commit's author.
+  // All nullable (legacy/anonymous/non-synced rows). Mirrors schema.ts.
+  author_name: text("author_name"),
+  author_login: text("author_login"),
+  author_avatar: text("author_avatar"),
+  author_gh_id: text("author_gh_id"),
 })
 
 export const version = pgTable(
@@ -56,6 +63,12 @@ export const version = pgTable(
     content_type: text("content_type").notNull(),
     size_bytes: integer("size_bytes").notNull().default(0),
     author: text("author").notNull(),
+    // The GitHub identity behind this version, when synced (login / avatar / numeric
+    // user id as text). All nullable — manual/anonymous/unmappable publishes leave them
+    // null and `author` carries the display name. Mirrors schema.ts.
+    author_login: text("author_login"),
+    author_avatar: text("author_avatar"),
+    author_gh_id: text("author_gh_id"),
     message: text("message"),
     name: text("name"),
     created_at: text("created_at").notNull().$defaultFn(isoNow),

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -15,6 +15,8 @@ import type {
   GeneralRole,
   GitHubAppRecord,
   GitHubInstallationRecord,
+  GithubAuthor,
+  GithubUserMapping,
   ListArtifactsOpts,
   MembershipRecord,
   MetaStore,
@@ -242,6 +244,11 @@ export class PgMetaStore implements MetaStore {
           current_version: n,
           current_content_type: v.content_type,
           updated_at: new Date().toISOString(),
+          // Denormalize the new version's author onto the artifact (its CURRENT author).
+          author_name: v.author,
+          author_login: v.author_login ?? null,
+          author_avatar: v.author_avatar ?? null,
+          author_gh_id: v.author_gh_id ?? null,
         })
         .where(eq(artifact.id, artifactId))
       const rows = await tx
@@ -341,6 +348,20 @@ export class PgMetaStore implements MetaStore {
       .select({ id: artifactTag.artifact_id })
       .from(artifactTag)
       .where(eq(artifactTag.tag, tag))
+    return rows.map((r) => r.id)
+  }
+  // Author filter (mirrors artifactIdsByTag + the SQLite path). Case-insensitive match
+  // on the denormalized current author_login, scoped to the workspace.
+  async artifactIdsByAuthor(orgId: string, login: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ id: artifact.id })
+      .from(artifact)
+      .where(
+        and(
+          eq(artifact.org_id, orgId),
+          eq(sql`lower(${artifact.author_login})`, login.toLowerCase()),
+        ),
+      )
     return rows.map((r) => r.id)
   }
   async countArtifacts(orgId?: string): Promise<number> {
@@ -994,6 +1015,23 @@ export class PgMetaStore implements MetaStore {
       return []
     }
   }
+  // Map GitHub numeric user ids to Dock accounts ("account".accountId → "user"), scoped
+  // to the github social provider. Best-effort — [] when the Better Auth tables are absent.
+  async usersByGithubIds(ghIds: string[]): Promise<GithubUserMapping[]> {
+    if (ghIds.length === 0) return []
+    try {
+      const ph = ghIds.map((_, i) => `$${i + 1}`).join(",")
+      const { rows } = await this.pool.query(
+        `SELECT a."accountId" gh_id, u.id, u.name, u.image, u.username
+         FROM "account" a JOIN "user" u ON u.id = a."userId"
+         WHERE a."providerId" = 'github' AND a."accountId" IN (${ph})`,
+        ghIds,
+      )
+      return rows as GithubUserMapping[]
+    } catch {
+      return []
+    }
+  }
   async getUserByUsername(username: string): Promise<UserProfile | null> {
     try {
       const { rows } = await this.pool.query(
@@ -1247,6 +1285,17 @@ export class PgMetaStore implements MetaStore {
   }
   async setArtifactUpdatedAt(id: string, updatedAt: string): Promise<void> {
     await this.db.update(artifact).set({ updated_at: updatedAt }).where(eq(artifact.id, id))
+  }
+  async setArtifactAuthor(artifactId: string, author: GithubAuthor | null): Promise<void> {
+    await this.db
+      .update(artifact)
+      .set({
+        author_name: author?.name ?? null,
+        author_login: author?.login ?? null,
+        author_avatar: author?.avatar ?? null,
+        author_gh_id: author?.ghId ?? null,
+      })
+      .where(eq(artifact.id, artifactId))
   }
   async createAuditLog(a: NewAuditLog): Promise<void> {
     await this.db.insert(auditLog).values(a)

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -15,6 +15,7 @@ import type {
   GeneralRole,
   GitHubAppRecord,
   GitHubInstallationRecord,
+  GithubAuthor,
   ListArtifactsOpts,
   MembershipRecord,
   NewAgent,
@@ -287,6 +288,13 @@ export function makeRepos(db: SqliteDb) {
         current_version: n,
         current_content_type: v.content_type,
         updated_at: new Date().toISOString(),
+        // Denormalize the new version's author onto the artifact (its CURRENT author),
+        // for the list view + author filter. `author_name` is always the display name;
+        // the GitHub fields are null for a manual/anonymous publish.
+        author_name: v.author,
+        author_login: v.author_login ?? null,
+        author_avatar: v.author_avatar ?? null,
+        author_gh_id: v.author_gh_id ?? null,
       })
       .where(eq(artifact.id, artifactId))
       .run()
@@ -352,6 +360,22 @@ export function makeRepos(db: SqliteDb) {
         .all()
     ).map((r) => r.id)
 
+  // Author filter for the list (mirrors artifactIdsByTag). Case-insensitive match on the
+  // denormalized current author_login, scoped to the workspace.
+  const artifactIdsByAuthor = async (orgId: string, login: string): Promise<string[]> =>
+    (
+      await db
+        .select({ id: artifact.id })
+        .from(artifact)
+        .where(
+          and(
+            eq(artifact.org_id, orgId),
+            eq(sql`lower(${artifact.author_login})`, login.toLowerCase()),
+          ),
+        )
+        .all()
+    ).map((r) => r.id)
+
   const countArtifacts = async (orgId?: string): Promise<number> => {
     const q = db.select({ c: count() }).from(artifact)
     return (await (orgId ? q.where(eq(artifact.org_id, orgId)) : q).get())?.c ?? 0
@@ -396,6 +420,21 @@ export function makeRepos(db: SqliteDb) {
   }
   const setArtifactUpdatedAt = async (id: string, updatedAt: string): Promise<void> => {
     await db.update(artifact).set({ updated_at: updatedAt }).where(eq(artifact.id, id)).run()
+  }
+  const setArtifactAuthor = async (
+    artifactId: string,
+    author: GithubAuthor | null,
+  ): Promise<void> => {
+    await db
+      .update(artifact)
+      .set({
+        author_name: author?.name ?? null,
+        author_login: author?.login ?? null,
+        author_avatar: author?.avatar ?? null,
+        author_gh_id: author?.ghId ?? null,
+      })
+      .where(eq(artifact.id, artifactId))
+      .run()
   }
 
   // ---- Comments + threads ------------------------------------------------
@@ -1195,6 +1234,7 @@ export function makeRepos(db: SqliteDb) {
     reclassifyVersion,
     listArtifacts,
     artifactIdsByTag,
+    artifactIdsByAuthor,
     countArtifacts,
     storageBytes,
     tagCounts,
@@ -1203,6 +1243,7 @@ export function makeRepos(db: SqliteDb) {
     setArtifactTitle,
     setArtifactSourcePath,
     setArtifactUpdatedAt,
+    setArtifactAuthor,
     createComment,
     getComment,
     updateComment,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -49,6 +49,15 @@ export const artifact = sqliteTable("artifact", {
   updated_at: text("updated_at"),
   removed_at: text("removed_at"),
   source_path: text("source_path"),
+  // The CURRENT (last) author, denormalized from the latest version row for the list
+  // view + author filtering. For a GitHub-synced artifact these mirror the last commit's
+  // author: `author_name`/`author_login`/`author_avatar` are the display name, GitHub
+  // login, and avatar URL; `author_gh_id` is the GitHub numeric user id (text) used to
+  // map back to a Dock account. All nullable (legacy/anonymous/non-synced rows).
+  author_name: text("author_name"),
+  author_login: text("author_login"),
+  author_avatar: text("author_avatar"),
+  author_gh_id: text("author_gh_id"),
 })
 
 export const version = sqliteTable(
@@ -63,6 +72,13 @@ export const version = sqliteTable(
     content_type: text("content_type").notNull(),
     size_bytes: integer("size_bytes").notNull().default(0),
     author: text("author").notNull(),
+    // The GitHub identity behind this version, when it came from a sync: the commit
+    // author's login, avatar URL, and numeric user id (text). All nullable — a manual
+    // publish, an anonymous one, or a commit GitHub can't map to an account leaves them
+    // null and `author` carries the display name (commit author name / "GitHub sync").
+    author_login: text("author_login"),
+    author_avatar: text("author_avatar"),
+    author_gh_id: text("author_gh_id"),
     message: text("message"),
     name: text("name"),
     created_at: text("created_at").notNull().default(now),

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -1,4 +1,5 @@
 import type {
+  GithubUserMapping,
   MetaStore,
   NewVersion,
   UserDir,
@@ -82,6 +83,11 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
             current_version: next,
             current_content_type: v.content_type,
             updated_at: new Date().toISOString(),
+            // Denormalize the new version's author onto the artifact (its CURRENT author).
+            author_name: v.author,
+            author_login: v.author_login ?? null,
+            author_avatar: v.author_avatar ?? null,
+            author_gh_id: v.author_gh_id ?? null,
           })
           .where(eq(artifact.id, artifactId))
           .run()
@@ -247,6 +253,24 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
             `SELECT id, email, name, image, username, profession, about FROM user WHERE id IN (${ph})`,
           )
           .all(...ids) as UserDir[]
+      } catch {
+        return []
+      }
+    },
+    // Map GitHub numeric user ids to the Dock accounts that signed in with GitHub:
+    // account.accountId (the stringified GitHub id) → user. providerId='github' scopes
+    // it to the social provider. Best-effort — [] when the Better Auth tables are absent.
+    usersByGithubIds: async (ghIds): Promise<GithubUserMapping[]> => {
+      if (ghIds.length === 0) return []
+      try {
+        const ph = ghIds.map(() => "?").join(",")
+        return raw
+          .prepare(
+            `SELECT a.accountId gh_id, u.id, u.name, u.image, u.username
+             FROM account a JOIN user u ON u.id = a.userId
+             WHERE a.providerId = 'github' AND a.accountId IN (${ph})`,
+          )
+          .all(...ghIds) as GithubUserMapping[]
       } catch {
         return []
       }


### PR DESCRIPTION
## Why

Synced GitHub artifacts attributed every version to the literal string **"GitHub sync"** — you couldn't see who actually changed a file. This captures the real commit author, maps it to a Dock profile when possible, and surfaces it across the app. It's the substrate for the next step (following authors / paths + an activity feed).

## Capture — free, on a call we already make

The sync already fetches each file's last-commit date (`GET /repos/.../commits?path=`). That same response carries the author, which we were discarding. `github.ts#lastCommit` now returns the date **and** the author (GitHub login, numeric id, avatar, name/email). `sync.ts` uses it at publish time for new/changed files and backfills existing tracked files in a one-time sweep (mirroring the date sweep). Best-effort — a failed author lookup never fails a sync. Display-name precedence: GitHub login → git author name → `"GitHub sync"`.

## Store — additive, nullable (no destructive migration)

- `version` gains `author_login`, `author_avatar`, `author_gh_id`.
- `artifact` gains `author_name`, `author_login`, `author_avatar`, `author_gh_id` — the **current/last** author, denormalized in `addVersion` so the list can show + filter it without an N+1.
- Mirrored in both dialects (`schema.ts` + `pg-schema.ts`), Records updated (parity guard), `deploy/d1-schema.sql` regenerated. All nullable → migrates automatically on every dialect (and passes the additive-only guard from #202).

## Map — GitHub identity → Dock profile

`meta.usersByGithubIds` joins Better Auth's `account` (`providerId='github'`, `accountId` = the GitHub numeric id) → `user`. So a committer who signed into Dock with GitHub resolves to their `@handle`. Resolved in the artifact + list responses with **one batched lookup per page** (no N+1); graceful `[]` when the Better Auth tables are absent.

## Filter + display (the "show who did what + filter" ask)

- `GET /v1/artifacts?author=<login>` narrows the list (`meta.artifactIdsByAuthor`, org-scoped).
- A reusable **`AuthorChip`** (avatar + name; links to `/u/<handle>` when mapped) shows **who last changed each file** in the synced-collection view (**click to filter**), and **who authored each version** in the history drawer. Active author-filter pill, clearable, stacks on a collection filter.

## API shape (additive)

Artifacts (list + detail): `author_name/login/avatar/gh_id` + a resolved `author: { name, login, avatar, handle|null } | null`. Detail versions also carry `author_login/avatar/gh_id` + resolved `handle`.

## Tests

GitHub author parsing; sync capture lands on both version + artifact; name/`"GitHub sync"` fallbacks; `artifactIdsByAuthor` + `?author=` narrowing + org scoping; `usersByGithubIds` mapping + handle resolution (+ graceful empty when Better Auth tables absent). All dialects mirrored (pg mirrors sqlite; `test:pg` not run locally).

## Checks

`pnpm typecheck`, `pnpm lint`, `lint:tokens/testids/frontend/api/schema` all green. Tests: api 421, db 102/2-skip, core, mcp, storage all pass. `deploy/d1-schema.sql` regenerated + snapshot in sync.

## Notes / non-goals

- **Visual check pending a deploy**: meaningful author data lives on the deployed (D1) instance, and this is PR-only/no-deploy — so the UI was verified via tests + the lint guards (tokens/testids/frontend), not a screenshot. Easy to confirm on a preview.
- Independent of #201 (cross-doc links) and #202 (additive-only guard); all branch off `main`.
- Next (per plan): follow authors + paths → activity feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)