### PR TITLE
test(db): restore branch-coverage gate after author-tracking

### DIFF
--- a/packages/db/test/sqlite-store.test.ts
+++ b/packages/db/test/sqlite-store.test.ts
@@ -75,6 +75,54 @@ describe("sqlite store: user directory (Better Auth `user` table)", () => {
     s.close()
     rmSync(dir, { recursive: true, force: true })
   })
+
+  it("maps GitHub account ids to Dock users (account → user join); tolerates absent tables", async () => {
+    // Absent Better Auth tables → graceful empty (fresh store); empty input short-circuits.
+    const fresh = new SqliteMetaStore(":memory:")
+    expect(await fresh.usersByGithubIds(["4242"])).toEqual([])
+    expect(await fresh.usersByGithubIds([])).toEqual([])
+    fresh.close()
+
+    const { mkdtempSync, rmSync } = await import("node:fs")
+    const { tmpdir } = await import("node:os")
+    const { join } = await import("node:path")
+    const dir = mkdtempSync(join(tmpdir(), "dock-db-gh-"))
+    const path = join(dir, "store.db")
+    const s = new SqliteMetaStore(path)
+    const raw = new Database(path)
+    raw.exec(
+      `CREATE TABLE user (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT, username TEXT, discoverable INTEGER, profession TEXT, about TEXT)`,
+    )
+    // Better Auth's account table: camelCase columns, one row per linked provider.
+    raw.exec(
+      `CREATE TABLE account (id TEXT PRIMARY KEY, "accountId" TEXT, "providerId" TEXT, "userId" TEXT)`,
+    )
+    raw
+      .prepare(`INSERT INTO user (id, name, image, username) VALUES (?,?,?,?)`)
+      .run("u1", "Ada", "https://cdn/ada.png", "ada-handle")
+    raw
+      .prepare(`INSERT INTO account (id, "accountId", "providerId", "userId") VALUES (?,?,?,?)`)
+      .run("acc-gh", "4242", "github", "u1")
+    // A non-GitHub provider for the same user must NOT match.
+    raw
+      .prepare(`INSERT INTO account (id, "accountId", "providerId", "userId") VALUES (?,?,?,?)`)
+      .run("acc-goog", "g-1", "google", "u1")
+    raw.close()
+
+    expect(await s.usersByGithubIds(["4242", "missing"])).toEqual([
+      {
+        gh_id: "4242",
+        id: "u1",
+        name: "Ada",
+        image: "https://cdn/ada.png",
+        username: "ada-handle",
+      },
+    ])
+    expect(await s.usersByGithubIds([])).toEqual([])
+
+    s.close()
+    rmSync(dir, { recursive: true, force: true })
+  })
 })
 
 // Scope strings reach us two ways: Better Auth's oauth-provider stores a JSON array,

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -153,6 +153,81 @@ export function runStoreContract(
     })
   })
 
+  describe(`${label}: author attribution (GitHub-synced)`, () => {
+    it("denormalizes the version author onto the artifact, clearing GitHub fields on a non-GitHub edit", async () => {
+      const a = await store.createArtifact(newArtifact())
+      const v1 = await store.addVersion(
+        a.id,
+        newVersion({
+          author: "Ada Lovelace",
+          author_login: "ada",
+          author_avatar: "https://avatars/ada.png",
+          author_gh_id: "4242",
+        }),
+      )
+      // The version row carries the full GitHub author…
+      expect(v1).toMatchObject({
+        author: "Ada Lovelace",
+        author_login: "ada",
+        author_avatar: "https://avatars/ada.png",
+        author_gh_id: "4242",
+      })
+      // …and it's denormalized onto the artifact as the current author.
+      expect(await store.getByShortId(a.short_id)).toMatchObject({
+        author_name: "Ada Lovelace",
+        author_login: "ada",
+        author_avatar: "https://avatars/ada.png",
+        author_gh_id: "4242",
+      })
+
+      // A later edit with no GitHub identity overwrites the current author and clears
+      // the GitHub fields (the `?? null` denormalization branches).
+      await store.addVersion(a.id, newVersion({ author: "bob" }))
+      expect(await store.getByShortId(a.short_id)).toMatchObject({
+        author_name: "bob",
+        author_login: null,
+        author_avatar: null,
+        author_gh_id: null,
+      })
+      // The historical v1 keeps its own author; v2 has none.
+      expect((await store.getVersion(a.id, 1))?.author_login).toBe("ada")
+      expect((await store.getVersion(a.id, 2))?.author_login).toBeNull()
+    })
+
+    it("filters artifacts by author login (case-insensitive, org-scoped)", async () => {
+      const mine = await store.createArtifact(newArtifact())
+      await store.addVersion(mine.id, newVersion({ author: "Ada", author_login: "ada" }))
+      expect(await store.artifactIdsByAuthor(ORG, "ada")).toContain(mine.id)
+      expect(await store.artifactIdsByAuthor(ORG, "ADA")).toContain(mine.id) // case-insensitive
+      expect(await store.artifactIdsByAuthor(ORG, "grace")).not.toContain(mine.id) // other login
+      expect(await store.artifactIdsByAuthor(`${ORG}_other`, "ada")).not.toContain(mine.id) // other org
+    })
+
+    it("sets and clears the current author directly (the backfill path)", async () => {
+      const a = await store.createArtifact(newArtifact())
+      await store.setArtifactAuthor(a.id, {
+        name: "Grace Hopper",
+        login: "grace",
+        avatar: "https://avatars/grace.png",
+        ghId: "99",
+      })
+      expect(await store.getByShortId(a.short_id)).toMatchObject({
+        author_name: "Grace Hopper",
+        author_login: "grace",
+        author_avatar: "https://avatars/grace.png",
+        author_gh_id: "99",
+      })
+      // Null clears every author field.
+      await store.setArtifactAuthor(a.id, null)
+      expect(await store.getByShortId(a.short_id)).toMatchObject({
+        author_name: null,
+        author_login: null,
+        author_avatar: null,
+        author_gh_id: null,
+      })
+    })
+  })
+
   describe(`${label}: comments + threads`, () => {
     it("creates comments, filters by state, resolves a whole thread", async () => {
       const a = await store.createArtifact(newArtifact())


### PR DESCRIPTION
## Why

The post-merge `main` CI for #203 went red on the **`coverage`** job: `@dock/db` branch coverage fell to **57.86%**, just under the 58% ratchet. #203's author code in `@dock/db` (the `addVersion` denormalization, `setArtifactAuthor`, `artifactIdsByAuthor`, `usersByGithubIds`) was exercised by tests in `apps/api` — a different package's coverage scope — so the new branches in `packages/db` counted as uncovered. Every other check (typecheck, lint, **pg**, d1, bundle, security) passed; this is purely a missing-coverage gap, no runtime issue.

## Fix (test-only)

- **`store-contract.ts`** (runs against both the sqlite and d1 stores): version author is denormalized onto the artifact and cleared on a later non-GitHub edit (the `?? null` branches); `artifactIdsByAuthor` is case-insensitive + org-scoped; `setArtifactAuthor` sets and clears.
- **`sqlite-store.test.ts`**: `usersByGithubIds` maps `account` → `user`, short-circuits empty input, and tolerates absent Better Auth tables.

**Branches 57.86% → 62.94%** (statements/functions/lines also up); 106 db tests pass. No source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)