### PR TITLE
Follow GitHub authors + repo paths, with an activity feed

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -22,6 +22,7 @@ import { commentRoutes } from "./routes/comments"
 import { domainRoutes } from "./routes/domains"
 import { embedRoutes } from "./routes/embeds"
 import { favoriteRoutes } from "./routes/favorites"
+import { followRoutes } from "./routes/follows"
 import { moderationRoutes } from "./routes/moderation"
 import { notificationRoutes } from "./routes/notifications"
 import { proposalRoutes } from "./routes/proposals"
@@ -447,6 +448,7 @@ export function createApp(deps: AppDeps): Hono {
     artifactRoutes,
     sharingRoutes,
     favoriteRoutes,
+    followRoutes,
     collectionRoutes,
     syncRoutes,
     vitalsRoutes,

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -123,6 +123,13 @@ export const artifactRoutes = (ctx: AppContext) => {
       if (!me) return c.json({ artifacts: [], next_cursor: null })
       narrow(await meta.artifactIdsSharedWith(me.id))
     }
+    // scope=following → artifacts in the active workspace whose current author or repo
+    // path matches one of my follows (authors + path prefixes). The activity feed.
+    const following = c.req.query("scope") === "following"
+    if (following) {
+      if (!me) return c.json({ artifacts: [], next_cursor: null })
+      narrow(await meta.followedArtifactIds(me.id, await activeWorkspace(c)))
+    }
     if (tag) narrow(await meta.artifactIdsByTag(tag))
     if (favOnly) narrow(favIds)
 

--- a/apps/api/src/routes/follows.ts
+++ b/apps/api/src/routes/follows.ts
@@ -1,0 +1,62 @@
+import { type FollowKind, newId } from "@dock/core"
+import { Hono } from "hono"
+import { z } from "zod"
+import type { AppContext } from "../context"
+import { fail, readJson } from "../lib/http"
+
+/** Follows (per-user: track GitHub authors + repo path prefixes). The followed set
+ *  drives the `scope=following` activity feed in GET /v1/artifacts. Workspace-scoped
+ *  to the caller's active workspace; all endpoints require a signed-in user. */
+export const followRoutes = (ctx: AppContext) => {
+  const { meta, currentUser, activeWorkspace } = ctx
+  const app = new Hono()
+
+  // Author targets are normalized to lowercase so they match the (lowercased)
+  // author_login comparison in followedArtifactIds; path targets are kept verbatim.
+  const normalizeTarget = (kind: FollowKind, target: string): string =>
+    kind === "author" ? target.trim().toLowerCase() : target.trim()
+
+  const followBody = z.object({
+    kind: z.enum(["author", "path"]),
+    target: z.string().min(1, "target is required"),
+  })
+
+  app.get("/v1/follows", async (c) => {
+    const me = await currentUser(c)
+    if (!me) return fail(c, 401, "unauthenticated")
+    const org = await activeWorkspace(c)
+    return c.json({ follows: await meta.listFollows(me.id, org) })
+  })
+
+  app.post("/v1/follows", async (c) => {
+    const me = await currentUser(c)
+    if (!me) return fail(c, 401, "unauthenticated")
+    const b = await readJson(c, followBody)
+    if (b instanceof Response) return b
+    const target = normalizeTarget(b.kind, b.target)
+    if (!target) return fail(c, 400, "target is required")
+    const org = await activeWorkspace(c)
+    const follow = await meta.addFollow({
+      id: newId("fl"),
+      org_id: org,
+      user_id: me.id,
+      kind: b.kind,
+      target,
+    })
+    return c.json({ follow }, 201)
+  })
+
+  app.delete("/v1/follows", async (c) => {
+    const me = await currentUser(c)
+    if (!me) return fail(c, 401, "unauthenticated")
+    const b = await readJson(c, followBody)
+    if (b instanceof Response) return b
+    const target = normalizeTarget(b.kind, b.target)
+    if (!target) return fail(c, 400, "target is required")
+    const org = await activeWorkspace(c)
+    await meta.removeFollow(me.id, org, b.kind, target)
+    return c.body(null, 204)
+  })
+
+  return app
+}

--- a/apps/api/test/follows.test.ts
+++ b/apps/api/test/follows.test.ts
@@ -1,0 +1,124 @@
+import { newId } from "@dock/core"
+import { describe, expect, it } from "vitest"
+import { as, makeAuthedApp, type TestUser } from "./helpers"
+
+// End-to-end: drive the follows route + scope=following as a real session user (via
+// the `x-test-user` fake-auth harness — see helpers.ts). Amy is the workspace owner so
+// she can publish; she follows an author + a path and reads her activity feed back.
+const amy: TestUser = { id: "u-amy", email: "amy@x.com", name: "Amy", username: "amy" }
+const bob: TestUser = { id: "u-bob", email: "bob@x.com", name: "Bob", username: "bob" }
+const { app, meta } = makeAuthedApp("follows", [amy, bob])
+
+// Publish an artifact in the shared "default" workspace authored by `login`, optionally
+// at a repo `sourcePath`, then return its short_id (the id the list JSON exposes). Goes
+// through the store so we can stamp the author login + source path deterministically (the
+// feed keys on those denormalized columns).
+const publish = async (
+  title: string,
+  login: string,
+  sourcePath: string | null,
+): Promise<string> => {
+  const a = await meta.createArtifact({
+    id: newId("a"),
+    short_id: newId("s"),
+    org_id: "default",
+    slug: null,
+    title,
+    visibility: "link",
+    kind: "file",
+    spa: 0,
+  })
+  await meta.addVersion(a.id, {
+    id: newId("v"),
+    blob_key: `blob_${newId("b")}`,
+    content_type: "text/markdown",
+    size_bytes: 1,
+    author: login,
+    author_login: login,
+    author_avatar: null,
+    author_gh_id: null,
+    message: null,
+  })
+  if (sourcePath) await meta.setArtifactSourcePath(a.id, sourcePath)
+  return a.short_id
+}
+
+const post = (headers: Record<string, string>, body: unknown) =>
+  app.request("/v1/follows", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  })
+
+describe("follows route", () => {
+  it("requires a signed-in user (GET 401; anonymous write blocked 403)", async () => {
+    // GET is open to the route, which 401s a caller with no session.
+    expect((await app.request("/v1/follows")).status).toBe(401)
+    // A non-GET /v1/* by a non-principal is blocked by the global write gate (403)
+    // before the route runs — anonymous can't write a follow.
+    expect((await post({}, { kind: "author", target: "x" })).status).toBe(403)
+  })
+
+  it("validates kind + non-empty target", async () => {
+    expect((await post(as(amy.email), { kind: "nope", target: "x" })).status).toBe(400)
+    expect((await post(as(amy.email), { kind: "author", target: "" })).status).toBe(400)
+    expect((await post(as(amy.email), { kind: "author" })).status).toBe(400)
+  })
+
+  it("adds (idempotent), lists, and removes follows; author target is lowercased", async () => {
+    // Author target is stored lowercased to match the author_login comparison.
+    const r1 = await post(as(amy.email), { kind: "author", target: "Ada" })
+    expect(r1.status).toBe(201)
+    const f1 = (await r1.json()).follow
+    expect(f1).toMatchObject({ kind: "author", target: "ada", user_id: amy.id, org_id: "default" })
+    // Re-adding the same follow is idempotent — same row id, still 201.
+    const r2 = await post(as(amy.email), { kind: "author", target: "ada" })
+    expect((await r2.json()).follow.id).toBe(f1.id)
+
+    // A path follow is stored verbatim.
+    await post(as(amy.email), { kind: "path", target: "docs/plans" })
+    const list = await (await app.request("/v1/follows", { headers: as(amy.email) })).json()
+    expect(
+      list.follows.map((f: { kind: string; target: string }) => `${f.kind}:${f.target}`).sort(),
+    ).toEqual(["author:ada", "path:docs/plans"])
+
+    // Follows are per-user: bob sees none of amy's.
+    const bobList = await (await app.request("/v1/follows", { headers: as(bob.email) })).json()
+    expect(bobList.follows).toEqual([])
+
+    // DELETE removes a single follow (204).
+    const del = await app.request("/v1/follows", {
+      method: "DELETE",
+      headers: { "content-type": "application/json", ...as(amy.email) },
+      body: JSON.stringify({ kind: "author", target: "ada" }),
+    })
+    expect(del.status).toBe(204)
+    const after = await (await app.request("/v1/follows", { headers: as(amy.email) })).json()
+    expect(after.follows.map((f: { target: string }) => f.target)).toEqual(["docs/plans"])
+  })
+
+  it("scope=following returns artifacts matching the user's follows (author + path), per-user", async () => {
+    const byAda = await publish("By Ada", "ada", null)
+    const inPlans = await publish("In Plans", "bob", "docs/plans/q3.md")
+    const neither = await publish("Neither", "carol", "src/x.ts")
+
+    // Carol-follower amy already has a "docs/plans" follow from the prior test; add the
+    // author follow back. (Tests share the workspace; we assert via inclusion.)
+    await post(as(amy.email), { kind: "author", target: "ada" })
+
+    const res = await app.request("/v1/artifacts?scope=following&limit=100", {
+      headers: as(amy.email),
+    })
+    expect(res.status).toBe(200)
+    const ids = (await res.json()).artifacts.map((a: { short_id: string }) => a.short_id)
+    expect(ids).toContain(byAda) // followed author (case-insensitive)
+    expect(ids).toContain(inPlans) // followed path prefix
+    expect(ids).not.toContain(neither) // neither matches
+
+    // bob follows nothing → empty feed (not "everyone's").
+    const bobFeed = await app.request("/v1/artifacts?scope=following&limit=100", {
+      headers: as(bob.email),
+    })
+    expect((await bobFeed.json()).artifacts).toEqual([])
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -123,6 +123,17 @@ export interface Collection {
   created_at: string
   count: number
 }
+export type FollowKind = "author" | "path"
+/** A per-user follow: a GitHub author (kind="author", target=login) or a repo path
+ *  prefix (kind="path", target=path prefix). Drives the `scope=following` feed. */
+export interface Follow {
+  id: string
+  org_id: string
+  user_id: string
+  kind: FollowKind
+  target: string
+  created_at: string
+}
 export type ProposalState = "open" | "approved" | "changes_requested" | "withdrawn"
 export interface Proposal {
   id: string
@@ -474,8 +485,10 @@ export const api = {
     favorite?: boolean
     /** Narrow to artifacts last changed by this GitHub login. */
     author?: string
-    /** "shared" → only artifacts explicitly shared with you (across workspaces). */
-    scope?: "shared"
+    /** "shared" → only artifacts explicitly shared with you (across workspaces).
+     *  "following" → artifacts in the active workspace matching your follows
+     *  (followed GitHub authors + repo path prefixes) — the activity feed. */
+    scope?: "shared" | "following"
     cursor?: string
     limit?: number
   }): Promise<{
@@ -618,6 +631,17 @@ export const api = {
     f(`/v1/artifacts/${id}/favorite`, { ...opts(), method: on ? "PUT" : "DELETE" }).then(j),
   setTags: (id: string, tags: string[]): Promise<{ tags: string[] }> =>
     f(`/v1/artifacts/${id}/tags`, { ...opts({ tags }), method: "PUT" }).then(j),
+
+  // Follows (track GitHub authors + repo path prefixes) — the activity feed is
+  // listArtifacts({ scope: "following" }). All scoped to the active workspace.
+  listFollows: (): Promise<{ follows: Follow[] }> => f("/v1/follows", opts()).then(j),
+  addFollow: (kind: FollowKind, target: string): Promise<{ follow: Follow }> =>
+    f("/v1/follows", opts({ kind, target })).then(j),
+  removeFollow: (kind: FollowKind, target: string): Promise<void> =>
+    f("/v1/follows", {
+      ...opts({ kind, target }),
+      method: "DELETE",
+    }).then(() => undefined),
 
   deleteArtifact: (id: string): Promise<void> =>
     f(`/v1/artifacts/${id}`, { method: "DELETE", credentials: "include" }).then(() => undefined),

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -42,6 +42,7 @@ import {
   TagIcon,
   TrashIcon,
   UserIcon,
+  UsersThreeIcon,
   XIcon,
 } from "@phosphor-icons/react"
 import { cn } from "@/lib/utils"
@@ -55,6 +56,8 @@ const REG = {
   home: [HouseIcon, "text-primary"],
   all: [StackIcon, "text-primary"],
   favorites: [StarIcon, "text-gold"],
+  // The activity feed of followed authors + repo paths.
+  following: [UsersThreeIcon, "text-primary"],
   collections: [FoldersIcon, "text-collection"],
   collection: [FolderSimpleIcon, "text-collection"],
   tag: [TagIcon, "text-tag"],

--- a/apps/web/src/components/nav-rail.tsx
+++ b/apps/web/src/components/nav-rail.tsx
@@ -102,8 +102,9 @@ export function NavRail() {
   const loc = useLocation()
   const search = loc.search as LibrarySearch
   const onLibrary = loc.pathname === "/"
-  const isAll = onLibrary && !search.f && !search.tag && !search.collection
+  const isAll = onLibrary && !search.f && !search.scope && !search.tag && !search.collection
   const isFav = onLibrary && search.f === "favorites"
+  const isFollowing = onLibrary && search.scope === "following"
   const tags = summary?.tags ?? []
   // Full content in the mobile drawer; only the avatar in the collapsed desktop rail.
   const railMode = collapsed && !isMobile
@@ -239,6 +240,15 @@ export function NavRail() {
           active={isFav}
           collapsed={railMode}
           testId="sidebar-favorites"
+          onClick={closeDrawer}
+        />
+        <SideItem
+          icon="following"
+          label="Following"
+          search={{ scope: "following" }}
+          active={isFollowing}
+          collapsed={railMode}
+          testId="nav-following"
           onClick={closeDrawer}
         />
         {!railMode && (

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -13,6 +13,9 @@ export type LibraryParams = {
   favorite?: boolean
   // Narrow to artifacts last changed by this GitHub login.
   author?: string
+  // "following" → the activity feed: artifacts in the active workspace matching
+  // your follows (followed authors + repo path prefixes).
+  scope?: "following"
 }
 export const libraryArtifactsQuery = (params: LibraryParams) =>
   infiniteQueryOptions({
@@ -37,6 +40,16 @@ export const sharedArtifactsQuery = () =>
   queryOptions({
     queryKey: ["artifacts", "shared"] as const,
     queryFn: () => api.listArtifacts({ scope: "shared", limit: 12 }).then((r) => r.artifacts),
+  })
+
+// The caller's follows (GitHub authors + repo path prefixes) for the active
+// workspace. Drives the Following-feed empty state, the manage strip, and the
+// isFollowing* sets that toggle the Follow buttons. One source of truth: every
+// add/remove invalidates this key so the toggles + strip refetch.
+export const followsQuery = () =>
+  queryOptions({
+    queryKey: ["follows"] as const,
+    queryFn: () => api.listFollows().then((r) => r.follows),
   })
 
 // Typed query options shared by route loaders (ensureQueryData, for intent

--- a/apps/web/src/lib/use-follows.ts
+++ b/apps/web/src/lib/use-follows.ts
@@ -1,0 +1,70 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useMemo } from "react"
+import { toast } from "sonner"
+import { api, type FollowKind } from "@/api"
+import { followsQuery } from "./queries"
+
+// Path targets are stored verbatim as repo prefixes (e.g. "docs/plans/"); a
+// trailing slash keeps a LIKE prefix% from matching a sibling like "docs/plan2".
+// Normalize once so the toggle's add/remove and the isFollowingPath check agree.
+const normalizePath = (path: string): string => (path && !path.endsWith("/") ? `${path}/` : path)
+
+// Author targets are stored lowercased (the backend matches on
+// `login.toLowerCase()`), so compare + send the lowercased login.
+const normalizeAuthor = (login: string): string => login.toLowerCase()
+
+/**
+ * The caller's follows + the derived follow-state helpers and toggle actions.
+ * One query (`followsQuery`) is the single source of truth: `isFollowingAuthor`
+ * / `isFollowingPath` drive the Follow buttons, and `toggle*` add/remove then
+ * invalidate the query so every toggle + the manage strip reflect the change.
+ */
+export function useFollows() {
+  const qc = useQueryClient()
+  const { data: follows = [] } = useQuery(followsQuery())
+
+  const { authors, paths } = useMemo(() => {
+    const authors = new Set<string>()
+    const paths = new Set<string>()
+    for (const fol of follows) {
+      if (fol.kind === "author") authors.add(fol.target)
+      else paths.add(fol.target)
+    }
+    return { authors, paths }
+  }, [follows])
+
+  const invalidate = () => qc.invalidateQueries({ queryKey: followsQuery().queryKey })
+
+  const add = useMutation({
+    mutationFn: ({ kind, target }: { kind: FollowKind; target: string }) =>
+      api.addFollow(kind, target),
+    onSuccess: invalidate,
+    onError: (e) => toast.error((e as Error).message),
+  })
+  const remove = useMutation({
+    mutationFn: ({ kind, target }: { kind: FollowKind; target: string }) =>
+      api.removeFollow(kind, target),
+    onSuccess: invalidate,
+    onError: (e) => toast.error((e as Error).message),
+  })
+
+  return {
+    follows,
+    isFollowingAuthor: (login: string) => authors.has(normalizeAuthor(login)),
+    isFollowingPath: (path: string) => paths.has(normalizePath(path)),
+    // Flip the follow state for an author (by GitHub login).
+    toggleAuthor: (login: string) => {
+      const target = normalizeAuthor(login)
+      if (authors.has(target)) remove.mutate({ kind: "author", target })
+      else add.mutate({ kind: "author", target })
+    },
+    // Flip the follow state for a repo path prefix (a folder).
+    togglePath: (path: string) => {
+      const target = normalizePath(path)
+      if (paths.has(target)) remove.mutate({ kind: "path", target })
+      else add.mutate({ kind: "path", target })
+    },
+    // Drop a follow directly (the manage strip's × buttons).
+    unfollow: (kind: FollowKind, target: string) => remove.mutate({ kind, target }),
+  }
+}

--- a/apps/web/src/pages/library/folder-groups.tsx
+++ b/apps/web/src/pages/library/folder-groups.tsx
@@ -1,6 +1,8 @@
 import { ChevronRight, Folder } from "lucide-react"
 import { useMemo, useState } from "react"
 import type { Artifact } from "@/api"
+import { Icon } from "@/components/icons"
+import { useFollows } from "@/lib/use-follows"
 import { cn } from "@/lib/utils"
 import { ArtifactRow } from "./artifact-row"
 
@@ -34,6 +36,9 @@ export function FolderGroups({
   isFetchingNextPage: boolean
   onLoadMore: () => void
 } & Handlers) {
+  // Follow state for the per-folder toggle: one query for the whole tree, derived
+  // into the isFollowingPath check + the togglePath action each header drives.
+  const { isFollowingPath, togglePath } = useFollows()
   const groups = useMemo(() => {
     const m = new Map<string, Artifact[]>()
     for (const a of items) {
@@ -54,7 +59,14 @@ export function FolderGroups({
   return (
     <div className="flex flex-col gap-3">
       {groups.map((g) => (
-        <FolderSection key={g.dir} dir={g.dir} items={g.items} {...handlers} />
+        <FolderSection
+          key={g.dir}
+          dir={g.dir}
+          items={g.items}
+          following={isFollowingPath(g.dir)}
+          onToggleFollow={() => togglePath(g.dir)}
+          {...handlers}
+        />
       ))}
       {(hasNextPage || isFetchingNextPage) && (
         <div className="py-2 text-center text-sm text-muted-foreground">Loading the rest…</div>
@@ -63,27 +75,63 @@ export function FolderGroups({
   )
 }
 
-function FolderSection({ dir, items, ...handlers }: { dir: string; items: Artifact[] } & Handlers) {
+function FolderSection({
+  dir,
+  items,
+  following,
+  onToggleFollow,
+  ...handlers
+}: {
+  dir: string
+  items: Artifact[]
+  following: boolean
+  onToggleFollow: () => void
+} & Handlers) {
   const [open, setOpen] = useState(true)
+  // Only a real repo path prefix is followable — the "/" repo-root and the "Other"
+  // bucket (non-synced artifacts) aren't path prefixes the feed can match.
+  const followable = dir !== "/" && dir !== "Other"
   return (
-    <div>
-      <button
-        type="button"
-        data-testid={`folder-toggle-${dir}`}
-        onClick={() => setOpen((o) => !o)}
-        className="flex w-full items-center gap-2 rounded-md py-1.5 text-left hover:text-foreground"
-      >
-        <ChevronRight
-          className={cn(
-            "size-4 shrink-0 text-muted-foreground transition-transform",
-            open && "rotate-90",
-          )}
-          aria-hidden
-        />
-        <Folder className="size-4 shrink-0 text-primary" aria-hidden />
-        <span className="truncate font-mono text-sm font-medium text-foreground">{dir}</span>
-        <span className="font-mono text-xs text-muted-foreground">· {items.length}</span>
-      </button>
+    <div className="group/folder">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          data-testid={`folder-toggle-${dir}`}
+          onClick={() => setOpen((o) => !o)}
+          className="flex min-w-0 flex-1 items-center gap-2 rounded-md py-1.5 text-left hover:text-foreground"
+        >
+          <ChevronRight
+            className={cn(
+              "size-4 shrink-0 text-muted-foreground transition-transform",
+              open && "rotate-90",
+            )}
+            aria-hidden
+          />
+          <Folder className="size-4 shrink-0 text-primary" aria-hidden />
+          <span className="truncate font-mono text-sm font-medium text-foreground">{dir}</span>
+          <span className="font-mono text-xs text-muted-foreground">· {items.length}</span>
+        </button>
+        {followable && (
+          <button
+            type="button"
+            data-testid={`folder-follow-${dir}`}
+            aria-pressed={following}
+            title={
+              following ? `Unfollow ${dir}/` : `Follow ${dir}/ to see its changes in your feed`
+            }
+            onClick={onToggleFollow}
+            className={cn(
+              "inline-flex shrink-0 items-center gap-1 rounded-md border px-2 py-1 font-mono text-2xs transition-colors",
+              following
+                ? "border-primary text-primary"
+                : "border-border text-muted-foreground opacity-0 hover:text-foreground group-hover/folder:opacity-100 focus-visible:opacity-100",
+            )}
+          >
+            <Icon name={following ? "check" : "following"} size={13} />
+            {following ? "Following" : "Follow"}
+          </button>
+        )}
+      </div>
       {open && (
         <div className="ml-6 mt-1.5 flex flex-col gap-2">
           {items.map((a) => (

--- a/apps/web/src/pages/library/following-strip.tsx
+++ b/apps/web/src/pages/library/following-strip.tsx
@@ -1,0 +1,44 @@
+import { X } from "lucide-react"
+import type { Follow } from "@/api"
+
+// The top-of-feed "following" summary + manage surface: the caller's current
+// follows as chips — @<login> for authors, <path> for paths — each with an
+// unfollow (×). Doubles as the manage-follows surface, so the feed and the
+// settings live in one place.
+export function FollowingStrip({
+  follows,
+  onUnfollow,
+}: {
+  follows: Follow[]
+  onUnfollow: (kind: Follow["kind"], target: string) => void
+}) {
+  if (follows.length === 0) return null
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-1.5" data-testid="following-strip">
+      <span className="mr-0.5 font-mono text-2xs uppercase tracking-[0.07em] text-muted-foreground">
+        Following
+      </span>
+      {follows.map((fol) => {
+        const label = fol.kind === "author" ? `@${fol.target}` : fol.target
+        return (
+          <span
+            key={`${fol.kind}:${fol.target}`}
+            className="inline-flex items-center gap-1 rounded-md border border-border bg-card py-0.5 pl-2 pr-1 font-mono text-2xs text-foreground"
+          >
+            {label}
+            <button
+              type="button"
+              data-testid={`following-unfollow-${fol.kind}-${fol.target}`}
+              title={`Unfollow ${label}`}
+              aria-label={`Unfollow ${label}`}
+              onClick={() => onUnfollow(fol.kind, fol.target)}
+              className="grid size-4 place-items-center rounded text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <X className="size-3" aria-hidden />
+            </button>
+          </span>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { useAuth } from "@/ctx"
 import { type LibraryParams, libraryArtifactsQuery, sharedArtifactsQuery } from "@/lib/queries"
+import { useFollows } from "@/lib/use-follows"
 import { usePrefetchArtifact } from "@/lib/use-prefetch-artifact"
 import { cn } from "@/lib/utils"
 import { refFor } from "../artifact/parse-ref"
@@ -19,6 +20,7 @@ import { ArtifactGrid } from "./artifact-grid"
 import { ArtifactRow, byRecency } from "./artifact-row"
 import { CollectionBar } from "./collection-bar"
 import { FolderGroups } from "./folder-groups"
+import { FollowingStrip } from "./following-strip"
 import { HowItWorks } from "./how-it-works"
 import { LibrarySkeleton } from "./library-skeleton"
 import { PublishCard } from "./publish-card"
@@ -63,15 +65,17 @@ function LibraryBody() {
   const filter: Filter =
     search.f === "favorites"
       ? { kind: "favorites" }
-      : search.tag
-        ? { kind: "tag", tag: search.tag }
-        : search.collection
-          ? {
-              kind: "collection",
-              id: search.collection,
-              title: collections.find((c) => c.id === search.collection)?.title ?? "Collection",
-            }
-          : { kind: "all" }
+      : search.scope === "following"
+        ? { kind: "following" }
+        : search.tag
+          ? { kind: "tag", tag: search.tag }
+          : search.collection
+            ? {
+                kind: "collection",
+                id: search.collection,
+                title: collections.find((c) => c.id === search.collection)?.title ?? "Collection",
+              }
+            : { kind: "all" }
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedQ(query.trim()), 280)
@@ -86,6 +90,7 @@ function LibraryBody() {
     collection: search.collection,
     favorite: search.f === "favorites" || undefined,
     author: search.author,
+    scope: filter.kind === "following" ? "following" : undefined,
   }
   const listQuery = libraryArtifactsQuery(params)
   const { data, isPending, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
@@ -187,9 +192,11 @@ function LibraryBody() {
       ? "All artifacts"
       : filter.kind === "favorites"
         ? "Favorites"
-        : filter.kind === "tag"
-          ? `#${filter.tag}`
-          : collectionTitle
+        : filter.kind === "following"
+          ? "Following"
+          : filter.kind === "tag"
+            ? `#${filter.tag}`
+            : collectionTitle
   const headingCount = debouncedQ
     ? items.length
     : filter.kind === "all"
@@ -198,17 +205,21 @@ function LibraryBody() {
         ? (summary?.favorites ?? items.length)
         : filter.kind === "tag"
           ? (summary?.tags.find((t) => t.tag === filter.tag)?.count ?? items.length)
-          : (activeCollection?.count ?? items.length)
+          : filter.kind === "collection"
+            ? (activeCollection?.count ?? items.length)
+            : items.length
 
   const emptyMessage = debouncedQ
     ? `No artifacts match “${debouncedQ}”.`
     : filter.kind === "favorites"
       ? "No favorites yet. Tap the star on any artifact to save it."
-      : filter.kind === "tag"
-        ? `Nothing tagged #${filter.tag} yet.`
-        : filter.kind === "collection"
-          ? "This collection is empty. Open an artifact and add it from its Collections menu."
-          : "Nothing yet. Publish above, or run dock publish ./file."
+      : filter.kind === "following"
+        ? "Follow authors or folders to see their recent changes here."
+        : filter.kind === "tag"
+          ? `Nothing tagged #${filter.tag} yet.`
+          : filter.kind === "collection"
+            ? "This collection is empty. Open an artifact and add it from its Collections menu."
+            : "Nothing yet. Publish above, or run dock publish ./file."
 
   // A personal header on the (otherwise bare) home view: lead with the user's
   // first name, falling back to their handle. Only on the unfiltered "all" list,
@@ -226,6 +237,11 @@ function LibraryBody() {
   const homeView = filter.kind === "all" && !debouncedQ
   const { data: sharedData } = useQuery({ ...sharedArtifactsQuery(), enabled: homeView })
   const sharedItems = homeView ? (sharedData ?? []) : []
+
+  // The caller's follows: drives the Following feed's manage strip + empty state,
+  // and the Follow/Following toggle on the active author-filter pill.
+  const { follows, isFollowingAuthor, toggleAuthor, unfollow } = useFollows()
+  const followingAuthor = !!search.author && isFollowingAuthor(search.author)
 
   const openShared = async (a: Artifact) => {
     const on = !a.favorite
@@ -300,6 +316,10 @@ function LibraryBody() {
                 <>
                   <Icon name="favorites" size={15} /> Favorites
                 </>
+              ) : filter.kind === "following" ? (
+                <>
+                  <Icon name="following" size={15} /> Following
+                </>
               ) : filter.kind === "tag" ? (
                 `#${filter.tag}`
               ) : (
@@ -311,22 +331,53 @@ function LibraryBody() {
             </Button>
           )}
           {/* Active author filter — independent of the tag/collection filter, so it
-              gets its own clearable pill. */}
+              gets its own clearable pill, plus a Follow toggle for that author. */}
           {search.author && (
-            <Button
-              variant="outline"
-              size="sm"
-              data-testid="library-author-filter-clear"
-              title={`Clear author filter: ${search.author}`}
-              onClick={clearAuthor}
-            >
-              <Icon name="user" size={15} /> {search.author}
-              <X />
-            </Button>
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                data-testid="library-author-filter-clear"
+                title={`Clear author filter: ${search.author}`}
+                onClick={clearAuthor}
+              >
+                <Icon name="user" size={15} /> {search.author}
+                <X />
+              </Button>
+              <Button
+                variant={followingAuthor ? "secondary" : "primary"}
+                size="sm"
+                data-testid={`library-follow-author-${search.author}`}
+                aria-pressed={followingAuthor}
+                title={
+                  followingAuthor
+                    ? `Unfollow @${search.author}`
+                    : `Follow @${search.author} to see their changes in your feed`
+                }
+                onClick={() => search.author && toggleAuthor(search.author)}
+              >
+                {followingAuthor ? (
+                  <>
+                    <Icon name="check" size={15} /> Following
+                  </>
+                ) : (
+                  <>
+                    <Icon name="following" size={15} /> Follow @{search.author}
+                  </>
+                )}
+              </Button>
+            </>
           )}
         </div>
 
-        {filter.kind !== "collection" && <PublishCard />}
+        {/* Following feed: the manage strip of current follows (authors + paths),
+            each unfollowable, sits above the heading so it reads as the feed's
+            controls. Hidden (returns null) when you follow nothing. */}
+        {filter.kind === "following" && (
+          <FollowingStrip follows={follows} onUnfollow={(kind, target) => unfollow(kind, target)} />
+        )}
+
+        {filter.kind !== "collection" && filter.kind !== "following" && <PublishCard />}
 
         {sharedItems.length > 0 && (
           <section className="mb-6" data-testid="shared-with-you">

--- a/apps/web/src/pages/library/types.ts
+++ b/apps/web/src/pages/library/types.ts
@@ -3,6 +3,9 @@
 export type Filter =
   | { kind: "all" }
   | { kind: "favorites" }
+  // The activity feed: artifacts in the active workspace whose current author or
+  // source-path matches one of your follows.
+  | { kind: "following" }
   | { kind: "tag"; tag: string }
   | { kind: "collection"; id: string; title: string }
 
@@ -20,6 +23,8 @@ export type Summary = {
 // library is shareable and survives reload. `q` is the free-text search.
 export type LibrarySearch = {
   f?: "favorites"
+  // "following" → the activity feed (followed authors + repo path prefixes).
+  scope?: "following"
   tag?: string
   collection?: string
   q?: string

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -7,6 +7,7 @@ export const Route = createFileRoute("/")({
   // them from any page and a filtered/searched library is shareable.
   validateSearch: (s: Record<string, unknown>): LibrarySearch => ({
     f: s.f === "favorites" ? "favorites" : undefined,
+    scope: s.scope === "following" ? "following" : undefined,
     tag: typeof s.tag === "string" ? s.tag : undefined,
     collection: typeof s.collection === "string" ? s.collection : undefined,
     q: typeof s.q === "string" ? s.q : undefined,

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -163,6 +163,16 @@ CREATE TABLE IF NOT EXISTS artifact_favorite (
   FOREIGN KEY (artifact_id) REFERENCES artifact(id)
 );
 
+CREATE TABLE IF NOT EXISTS follow (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  target TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  UNIQUE (user_id, org_id, kind, target)
+);
+
 CREATE TABLE IF NOT EXISTS artifact_tag (
   id TEXT PRIMARY KEY,
   artifact_id TEXT NOT NULL,

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -289,6 +289,18 @@ export interface MetaStore {
   listUserFavoriteIds(userId: string, orgId?: string): Promise<string[]>
   setFavorite(artifactId: string, userId: string): Promise<void>
   removeFavorite(artifactId: string, userId: string): Promise<void>
+
+  // ---- Follows (per-user: track GitHub authors + repo path prefixes) -----
+  /** Record a follow (idempotent on (user, org, kind, target)); returns the row. */
+  addFollow(f: NewFollow): Promise<FollowRecord>
+  removeFollow(userId: string, orgId: string, kind: FollowKind, target: string): Promise<void>
+  /** A user's follows in a workspace, newest first. */
+  listFollows(userId: string, orgId: string): Promise<FollowRecord[]>
+  /** Artifact ids in `orgId` (not removed) whose current author_login is one of the
+   *  user's followed logins (case-insensitive) OR whose source_path starts with one of
+   *  the user's followed path prefixes — the activity feed. Empty when the user follows
+   *  nothing. */
+  followedArtifactIds(userId: string, orgId: string): Promise<string[]>
   /** Tags per artifact, batched (no N+1). Missing ids map to no entry. */
   tagsForArtifacts(artifactIds: string[]): Promise<Record<string, string[]>>
   /** Replace an artifact's full tag set (deduped, trimmed, lowercased upstream). */
@@ -486,6 +498,28 @@ export interface MetaStore {
     orgId: string | undefined,
     opts?: { artifactId?: string; limit?: number },
   ): Promise<AuditLogRecord[]>
+}
+
+/** What a user follows: a GitHub author (`target` = the login) or a repo path
+ *  prefix (`target` = a path prefix, e.g. "docs/plans"). */
+export type FollowKind = "author" | "path"
+/** A per-user follow — the same shape of relation as a favorite, but keyed on a
+ *  (kind, target) pair instead of an artifact id. Drives the "following" feed. */
+export interface FollowRecord {
+  id: string
+  org_id: string
+  user_id: string
+  kind: FollowKind
+  /** For `author`: the GitHub login (stored lowercased). For `path`: a repo path prefix. */
+  target: string
+  created_at: string
+}
+export interface NewFollow {
+  id: string
+  org_id: string
+  user_id: string
+  kind: FollowKind
+  target: string
 }
 
 export type ReportState = "open" | "actioned" | "dismissed"

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -23,6 +23,7 @@ import type {
   CommentRecord,
   DeliveryRecord,
   DomainRecord,
+  FollowRecord,
   GitHubAppRecord,
   GitHubInstallationRecord,
   MembershipRecord,
@@ -49,6 +50,7 @@ export interface TypedTables {
   workspace: WorkspaceRecord
   artifactMember: ArtifactMemberRecord
   notification: NotificationRecord
+  follow: FollowRecord
   proposal: ProposalRecord
   agent: AgentRecord
   agentMention: AgentMentionRecord

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -6,6 +6,7 @@ import type {
   DeliveryStatus,
   DomainKind,
   DomainStatus,
+  FollowKind,
   GeneralRole,
   NotificationKind,
   ProposalState,
@@ -216,6 +217,20 @@ export const artifactFavorite = pgTable(
   (t) => [uniqueIndex("artifact_favorite_user").on(t.artifact_id, t.user_id)],
 )
 
+// Per-user follows. One row per (user, org, kind, target). Mirrors schema.ts.
+export const follow = pgTable(
+  "follow",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    user_id: text("user_id").notNull(),
+    kind: text("kind").$type<FollowKind>().notNull(),
+    target: text("target").notNull(),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [uniqueIndex("follow_user_target").on(t.user_id, t.org_id, t.kind, t.target)],
+)
+
 export const artifactTag = pgTable(
   "artifact_tag",
   {
@@ -377,6 +392,7 @@ const TABLES = [
   agent,
   agentMention,
   artifactFavorite,
+  follow,
   artifactTag,
   collection,
   collectionItem,

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -12,6 +12,8 @@ import type {
   DeliveryStatus,
   DomainRecord,
   DomainStatus,
+  FollowKind,
+  FollowRecord,
   GeneralRole,
   GitHubAppRecord,
   GitHubInstallationRecord,
@@ -30,6 +32,7 @@ import type {
   NewComment,
   NewDelivery,
   NewDomain,
+  NewFollow,
   NewMembership,
   NewNotification,
   NewProposal,
@@ -85,6 +88,7 @@ import {
   collectionMember,
   comment,
   domain,
+  follow,
   githubApp,
   githubInstallation,
   membership,
@@ -119,6 +123,7 @@ export const schema = {
   artifactMember,
   notification,
   artifactFavorite,
+  follow,
   artifactTag,
   proposal,
   agent,
@@ -148,6 +153,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   workspace: true,
   artifactMember: true,
   notification: true,
+  follow: true,
   proposal: true,
   agent: true,
   agentMention: true,
@@ -712,6 +718,74 @@ export class PgMetaStore implements MetaStore {
       .where(
         and(eq(artifactFavorite.artifact_id, artifactId), eq(artifactFavorite.user_id, userId)),
       )
+  }
+
+  // ---- Follows (track GitHub authors + repo path prefixes) ---------------
+  // Mirrors the sqlite path: insert-or-ignore on the unique key, then read back.
+  async addFollow(f: NewFollow): Promise<FollowRecord> {
+    await this.db
+      .insert(follow)
+      .values(f)
+      .onConflictDoNothing({
+        target: [follow.user_id, follow.org_id, follow.kind, follow.target],
+      })
+    const rows = await this.db
+      .select()
+      .from(follow)
+      .where(
+        and(
+          eq(follow.user_id, f.user_id),
+          eq(follow.org_id, f.org_id),
+          eq(follow.kind, f.kind),
+          eq(follow.target, f.target),
+        ),
+      )
+    return one(rows)
+  }
+  async removeFollow(
+    userId: string,
+    orgId: string,
+    kind: FollowKind,
+    target: string,
+  ): Promise<void> {
+    await this.db
+      .delete(follow)
+      .where(
+        and(
+          eq(follow.user_id, userId),
+          eq(follow.org_id, orgId),
+          eq(follow.kind, kind),
+          eq(follow.target, target),
+        ),
+      )
+  }
+  listFollows(userId: string, orgId: string): Promise<FollowRecord[]> {
+    return this.db
+      .select()
+      .from(follow)
+      .where(and(eq(follow.user_id, userId), eq(follow.org_id, orgId)))
+      .orderBy(desc(follow.created_at), desc(follow.id))
+  }
+  // The "following" feed id set: live artifacts whose current author is a followed
+  // login (case-insensitive) OR whose source_path starts with a followed path prefix.
+  // Mirrors the sqlite path exactly (split → OR of inArray + escaped LIKE).
+  async followedArtifactIds(userId: string, orgId: string): Promise<string[]> {
+    const follows = await this.listFollows(userId, orgId)
+    const logins = follows.filter((f) => f.kind === "author").map((f) => f.target.toLowerCase())
+    const prefixes = follows.filter((f) => f.kind === "path").map((f) => f.target)
+    if (logins.length === 0 && prefixes.length === 0) return []
+    const conds = []
+    if (logins.length > 0) conds.push(inArray(sql`lower(${artifact.author_login})`, logins))
+    for (const p of prefixes) {
+      const escaped = p.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_")
+      conds.push(sql`${artifact.source_path} like ${`${escaped}%`} escape '\\'`)
+    }
+    const match = conds.length === 1 ? conds[0] : or(...conds)
+    const rows = await this.db
+      .select({ id: artifact.id })
+      .from(artifact)
+      .where(and(eq(artifact.org_id, orgId), isNull(artifact.removed_at), match))
+    return rows.map((r) => r.id)
   }
   async tagsForArtifacts(artifactIds: string[]): Promise<Record<string, string[]>> {
     if (artifactIds.length === 0) return {}

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -12,6 +12,8 @@ import type {
   DeliveryStatus,
   DomainRecord,
   DomainStatus,
+  FollowKind,
+  FollowRecord,
   GeneralRole,
   GitHubAppRecord,
   GitHubInstallationRecord,
@@ -28,6 +30,7 @@ import type {
   NewComment,
   NewDelivery,
   NewDomain,
+  NewFollow,
   NewMembership,
   NewNotification,
   NewProposal,
@@ -82,6 +85,7 @@ import {
   collectionMember,
   comment,
   domain,
+  follow,
   githubApp,
   githubInstallation,
   membership,
@@ -135,6 +139,7 @@ export const schema = {
   artifactMember,
   notification,
   artifactFavorite,
+  follow,
   artifactTag,
   proposal,
   agent,
@@ -164,6 +169,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   workspace: true,
   artifactMember: true,
   notification: true,
+  follow: true,
   proposal: true,
   agent: true,
   agentMention: true,
@@ -713,6 +719,81 @@ export function makeRepos(db: SqliteDb) {
       )
       .run()
   }
+
+  // ---- Follows (track GitHub authors + repo path prefixes) ---------------
+  // Insert-or-ignore on the (user, org, kind, target) unique key (idempotent, like
+  // setFavorite), then read the row back so the caller always gets the persisted follow.
+  const addFollow = async (f: NewFollow): Promise<FollowRecord> => {
+    await db
+      .insert(follow)
+      .values(f)
+      .onConflictDoNothing({
+        target: [follow.user_id, follow.org_id, follow.kind, follow.target],
+      })
+      .run()
+    return (await db
+      .select()
+      .from(follow)
+      .where(
+        and(
+          eq(follow.user_id, f.user_id),
+          eq(follow.org_id, f.org_id),
+          eq(follow.kind, f.kind),
+          eq(follow.target, f.target),
+        ),
+      )
+      .get()) as FollowRecord
+  }
+  const removeFollow = async (
+    userId: string,
+    orgId: string,
+    kind: FollowKind,
+    target: string,
+  ): Promise<void> => {
+    await db
+      .delete(follow)
+      .where(
+        and(
+          eq(follow.user_id, userId),
+          eq(follow.org_id, orgId),
+          eq(follow.kind, kind),
+          eq(follow.target, target),
+        ),
+      )
+      .run()
+  }
+  const listFollows = async (userId: string, orgId: string): Promise<FollowRecord[]> =>
+    db
+      .select()
+      .from(follow)
+      .where(and(eq(follow.user_id, userId), eq(follow.org_id, orgId)))
+      .orderBy(desc(follow.created_at), desc(follow.id))
+      .all()
+  // The "following" feed's id set: live artifacts in the workspace whose CURRENT author
+  // is a followed login (case-insensitive) OR whose source_path starts with a followed
+  // path prefix. Splits the follows into the two sub-conditions and ORs them.
+  const followedArtifactIds = async (userId: string, orgId: string): Promise<string[]> => {
+    const follows = await listFollows(userId, orgId)
+    const logins = follows.filter((f) => f.kind === "author").map((f) => f.target.toLowerCase())
+    const prefixes = follows.filter((f) => f.kind === "path").map((f) => f.target)
+    if (logins.length === 0 && prefixes.length === 0) return []
+    const conds: SQL[] = []
+    if (logins.length > 0) conds.push(inArray(sql`lower(${artifact.author_login})`, logins))
+    // A path prefix is a LIKE 'prefix%'. Escape LIKE metacharacters in the prefix and
+    // declare the escape char so a path that happens to contain % or _ matches literally.
+    for (const p of prefixes) {
+      const escaped = p.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_")
+      conds.push(sql`${artifact.source_path} like ${`${escaped}%`} escape '\\'`)
+    }
+    const match = conds.length === 1 ? conds[0] : or(...conds)
+    const rows = await db
+      .select({ id: artifact.id })
+      .from(artifact)
+      .where(and(eq(artifact.org_id, orgId), isNull(artifact.removed_at), match))
+      .all()
+    return rows.map((r) => r.id)
+  }
+
   const tagsForArtifacts = async (artifactIds: string[]): Promise<Record<string, string[]>> => {
     if (artifactIds.length === 0) return {}
     const rows = await db
@@ -1299,6 +1380,10 @@ export function makeRepos(db: SqliteDb) {
     listUserFavoriteIds,
     setFavorite,
     removeFavorite,
+    addFollow,
+    removeFollow,
+    listFollows,
+    followedArtifactIds,
     tagsForArtifacts,
     setArtifactTags,
     createCollection,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -6,6 +6,7 @@ import type {
   DeliveryStatus,
   DomainKind,
   DomainStatus,
+  FollowKind,
   GeneralRole,
   NotificationKind,
   ProposalState,
@@ -227,6 +228,22 @@ export const artifactFavorite = sqliteTable(
   (t) => [uniqueIndex("artifact_favorite_user").on(t.artifact_id, t.user_id)],
 )
 
+// Per-user follows. One row per (user, org, kind, target); a follow tracks either a
+// GitHub author (kind="author", target=login) or a repo path prefix (kind="path",
+// target=path prefix). Drives the "following" activity feed. Idempotent on the tuple.
+export const follow = sqliteTable(
+  "follow",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    user_id: text("user_id").notNull(),
+    kind: text("kind").$type<FollowKind>().notNull(),
+    target: text("target").notNull(),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [uniqueIndex("follow_user_target").on(t.user_id, t.org_id, t.kind, t.target)],
+)
+
 // Browse tags. One row per (artifact, tag); workspace-wide, not per-user.
 export const artifactTag = sqliteTable(
   "artifact_tag",
@@ -418,6 +435,7 @@ const TABLES = [
   agent,
   agentMention,
   artifactFavorite,
+  follow,
   artifactTag,
   collection,
   collectionItem,

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -286,6 +286,125 @@ export function runStoreContract(
     })
   })
 
+  describe(`${label}: follows (authors + paths)`, () => {
+    it("adds (idempotent), lists, and removes a follow", async () => {
+      const user = `u_${uuid()}`
+      const a1 = await store.addFollow({
+        id: uuid(),
+        org_id: ORG,
+        user_id: user,
+        kind: "author",
+        target: "ada",
+      })
+      expect(a1).toMatchObject({ kind: "author", target: "ada", org_id: ORG, user_id: user })
+      // A repeat add on the same (user, org, kind, target) is a no-op that returns the
+      // SAME row (idempotent on the unique key, like setFavorite).
+      const a2 = await store.addFollow({
+        id: uuid(),
+        org_id: ORG,
+        user_id: user,
+        kind: "author",
+        target: "ada",
+      })
+      expect(a2.id).toBe(a1.id)
+      const p1 = await store.addFollow({
+        id: uuid(),
+        org_id: ORG,
+        user_id: user,
+        kind: "path",
+        target: "docs/plans",
+      })
+      const list = await store.listFollows(user, ORG)
+      expect(list.map((f) => `${f.kind}:${f.target}`).sort()).toEqual([
+        "author:ada",
+        "path:docs/plans",
+      ])
+      // Removing one leaves the other; removing by the wrong kind is a no-op.
+      await store.removeFollow(user, ORG, "author", "nobody")
+      expect(await store.listFollows(user, ORG)).toHaveLength(2)
+      await store.removeFollow(user, ORG, "author", "ada")
+      const after = await store.listFollows(user, ORG)
+      expect(after.map((f) => f.id)).toEqual([p1.id])
+    })
+
+    it("returns [] from followedArtifactIds when the user follows nothing", async () => {
+      expect(await store.followedArtifactIds(`u_${uuid()}`, ORG)).toEqual([])
+    })
+
+    it("matches artifacts by followed author (case-insensitive) and by path prefix, org-scoped", async () => {
+      const user = `u_${uuid()}`
+      // An artifact authored by "Ada" (login "ada").
+      const byAda = await store.createArtifact(newArtifact())
+      await store.addVersion(byAda.id, newVersion({ author: "Ada", author_login: "Ada" }))
+      // An artifact under docs/plans/ (a followed path prefix), authored by someone else.
+      const inPlans = await store.createArtifact(newArtifact())
+      await store.addVersion(inPlans.id, newVersion({ author: "bob", author_login: "bob" }))
+      await store.setArtifactSourcePath(inPlans.id, "docs/plans/q3.md")
+      // A non-matching artifact: different author, path outside the followed prefix.
+      const other = await store.createArtifact(newArtifact())
+      await store.addVersion(other.id, newVersion({ author: "carol", author_login: "carol" }))
+      await store.setArtifactSourcePath(other.id, "src/index.ts")
+      // The same author + path in ANOTHER org (must be excluded by the org scope).
+      const otherOrg = `${ORG}_feed_other`
+      const elsewhere = await store.createArtifact(newArtifact({ org_id: otherOrg }))
+      await store.addVersion(elsewhere.id, newVersion({ author: "Ada", author_login: "ada" }))
+      await store.setArtifactSourcePath(elsewhere.id, "docs/plans/elsewhere.md")
+
+      // Follow author "ada" (lowercased target) + path prefix "docs/plans".
+      await store.addFollow({
+        id: uuid(),
+        org_id: ORG,
+        user_id: user,
+        kind: "author",
+        target: "ada",
+      })
+      await store.addFollow({
+        id: uuid(),
+        org_id: ORG,
+        user_id: user,
+        kind: "path",
+        target: "docs/plans",
+      })
+
+      const ids = await store.followedArtifactIds(user, ORG)
+      expect(ids).toContain(byAda.id) // author match, case-insensitive (login "Ada")
+      expect(ids).toContain(inPlans.id) // path-prefix match
+      expect(ids).not.toContain(other.id) // neither author nor path matches
+      expect(ids).not.toContain(elsewhere.id) // matches but in another org
+
+      // Author-only follow set: no path follow → only the author match comes back.
+      const authorOnly = `u_${uuid()}`
+      await store.addFollow({
+        id: uuid(),
+        org_id: ORG,
+        user_id: authorOnly,
+        kind: "author",
+        target: "ada",
+      })
+      const authorIds = await store.followedArtifactIds(authorOnly, ORG)
+      expect(authorIds).toContain(byAda.id)
+      expect(authorIds).not.toContain(inPlans.id)
+
+      // Path-only follow set: no author follow → only the path match comes back.
+      const pathOnly = `u_${uuid()}`
+      await store.addFollow({
+        id: uuid(),
+        org_id: ORG,
+        user_id: pathOnly,
+        kind: "path",
+        target: "docs/plans",
+      })
+      const pathIds = await store.followedArtifactIds(pathOnly, ORG)
+      expect(pathIds).toContain(inPlans.id)
+      expect(pathIds).not.toContain(byAda.id)
+
+      // A removed (tombstoned) artifact drops out of the feed.
+      await store.setArtifactRemoved(byAda.id, new Date().toISOString())
+      expect(await store.followedArtifactIds(authorOnly, ORG)).not.toContain(byAda.id)
+      await store.setArtifactRemoved(byAda.id, null)
+    })
+  })
+
   describe(`${label}: collections`, () => {
     it("creates a collection, adds/removes items, tracks membership roles", async () => {
       const a = await store.createArtifact(newArtifact())

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -403,6 +403,47 @@ export function runStoreContract(
       expect(await store.followedArtifactIds(authorOnly, ORG)).not.toContain(byAda.id)
       await store.setArtifactRemoved(byAda.id, null)
     })
+
+    it("treats a path follow as a literal prefix: respects folder boundaries + escapes LIKE metachars", async () => {
+      // A folder follow (trailing slash) matches files INSIDE the folder…
+      const user = `u_${uuid()}`
+      const inside = await store.createArtifact(newArtifact())
+      await store.addVersion(inside.id, newVersion())
+      await store.setArtifactSourcePath(inside.id, "docs/plans/q3.md")
+      // …but NOT a sibling folder that merely shares the prefix string.
+      const sibling = await store.createArtifact(newArtifact())
+      await store.addVersion(sibling.id, newVersion())
+      await store.setArtifactSourcePath(sibling.id, "docs/plans2/x.md")
+      await store.addFollow({
+        id: uuid(),
+        org_id: ORG,
+        user_id: user,
+        kind: "path",
+        target: "docs/plans/",
+      })
+      const ids = await store.followedArtifactIds(user, ORG)
+      expect(ids).toContain(inside.id)
+      expect(ids).not.toContain(sibling.id) // "docs/plans2/…" is not under "docs/plans/"
+
+      // A "_" in the prefix is matched literally, not as the LIKE single-char wildcard.
+      const esc = `u_${uuid()}`
+      const literal = await store.createArtifact(newArtifact())
+      await store.addVersion(literal.id, newVersion())
+      await store.setArtifactSourcePath(literal.id, "a_b/notes.md")
+      const wildcardish = await store.createArtifact(newArtifact())
+      await store.addVersion(wildcardish.id, newVersion())
+      await store.setArtifactSourcePath(wildcardish.id, "axb/notes.md")
+      await store.addFollow({
+        id: uuid(),
+        org_id: ORG,
+        user_id: esc,
+        kind: "path",
+        target: "a_b/",
+      })
+      const escIds = await store.followedArtifactIds(esc, ORG)
+      expect(escIds).toContain(literal.id)
+      expect(escIds).not.toContain(wildcardish.id) // "_" escaped → literal, not "any char"
+    })
   })
 
   describe(`${label}: collections`, () => {


### PR DESCRIPTION
## Why

Author tracking (just shipped) told you *who* changed a synced doc. This lets you **follow the authors and the repo folders you care about** and get a **feed of their recent changes** — "the things I care about, in one place."

## Model — mirrors the favorites relation

- New **`follow`** table: `(id, org_id, user_id, kind: "author" | "path", target, created_at)`, unique on `(user_id, org_id, kind, target)` → follows are idempotent. Additive (new table, auto-created on every dialect), mirrored in both schema files, parity-checked, `deploy/d1-schema.sql` regenerated.
- `addFollow` / `removeFollow` / `listFollows`, and **`followedArtifactIds(user, org)`** — artifact ids whose current `author_login` is a followed login (case-insensitive `IN`) **or** whose `source_path` starts with a followed path prefix (escaped `LIKE … ESCAPE`). Org-scoped, non-removed. In `repos.ts` (sqlite/d1) + `pg.ts`.

## API

- `GET` / `POST` / `DELETE` `/v1/follows` (active workspace).
- `GET /v1/artifacts?scope=following` — **the feed**: reuses the existing list pagination + member/public access gating (mirrors `scope=shared`), narrowed to `followedArtifactIds`. So the feed page is just the library list with a new scope — no parallel surface.

## UI

- A **"Following"** nav entry → the feed, with an empty state ("follow authors or folders to see their recent changes here").
- A **manage strip**: your current follows as `@login` / `path/` chips, each unfollowable.
- **Follow / Following toggles**: authors (on the active author-filter pill) and repo folders (folder-view headers). A single `listFollows` query drives toggle state, invalidated on every add/remove.

## Tests

- `store-contract.ts` follows block (runs on **sqlite + d1**): add/idempotent/list/remove; `followedArtifactIds` matches by followed author (case-insensitive) and by followed path prefix, excludes non-matches, is org-scoped, empty when following nothing.
- `apps/api/test/follows.test.ts`: the follows route + `scope=following` end-to-end.
- **`@dock/db` branch coverage 64.39%** (gate 58%) — kept healthy this time.

## Checks

`pnpm typecheck`, `pnpm lint`, `lint:tokens/testids/frontend/api/schema` all green. Tests: api 436, db 112/2-skip, core 92, storage 16, mcp 10, web/cli pass. `pg` mirrors sqlite (verified by CI's pg job).

## Notes / non-goals

- **No visual screenshot** (no-deploy; feed data lives on the deployed instance) — verified via tests + lint guards.
- Feed is artifact-level ("doc X, last changed by a followed author/path") using the denormalized current author — not a per-version event stream. Notifications (push to the bell, with per-sync batching) are the natural next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)