### PR TITLE
fix(mobile): org switching + all drawer menus; remove cursor from profile menu

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -253,7 +253,8 @@ export function AppShell({ children }: { children: ReactNode }) {
                 tabIndex={drawerOpen ? 0 : -1}
                 onClick={() => setDrawerOpen(false)}
                 className={cn(
-                  "fixed inset-0 z-[60] bg-black/35 transition-opacity",
+                  // Below the drawer (z-45) and the overlay layer (z-50); above page content.
+                  "fixed inset-0 z-[44] bg-black/35 transition-opacity",
                   drawerOpen ? "opacity-100" : "pointer-events-none opacity-0",
                 )}
               />

--- a/apps/web/src/components/nav-rail.tsx
+++ b/apps/web/src/components/nav-rail.tsx
@@ -132,7 +132,10 @@ export function NavRail() {
     "flex flex-col gap-px overflow-y-auto border-r border-border bg-card py-3.5 transition-[transform,flex-basis,width] duration-200",
     isMobile
       ? cn(
-          "fixed inset-y-0 left-0 z-[61] w-[266px] basis-[266px] px-2.5 shadow-[0_0_44px_-10px_rgba(0,0,0,0.45)]",
+          // Sits BELOW the Radix overlay layer (z-50) so menus opened from inside the
+          // drawer — the workspace switcher, the command palette — render above it, not
+          // behind it. Still above page content + the backdrop.
+          "fixed inset-y-0 left-0 z-[45] w-[266px] basis-[266px] px-2.5 shadow-[0_0_44px_-10px_rgba(0,0,0,0.45)]",
           drawerOpen ? "translate-x-0" : "-translate-x-[105%]",
         )
       : collapsed

--- a/apps/web/src/components/user-pod.tsx
+++ b/apps/web/src/components/user-pod.tsx
@@ -5,7 +5,6 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { useAuth } from "@/ctx"
 import { cn } from "@/lib/utils"
-import { CursorSwitch } from "./cursor/cursor-switch"
 import { Icon } from "./icons"
 import { ThemeSwitch } from "./theme-switch"
 
@@ -156,12 +155,6 @@ export function UserPod({
         <div className={SECTION}>Theme</div>
         <div className="px-1 pb-1">
           <ThemeSwitch />
-        </div>
-        <div className="my-1 h-px bg-border-soft" />
-
-        <div className={SECTION}>Cursor</div>
-        <div className="px-1 pb-1">
-          <CursorSwitch />
         </div>
         <div className="my-1 h-px bg-border-soft" />
 


### PR DESCRIPTION
## What was broken

On mobile, **switching workspaces did nothing visible**. Root cause is a z-index layering bug, and it's systemic: the off-canvas nav **drawer is `z-[61]`** (backdrop `z-[60]`), but **every Radix overlay** — popover, dropdown, dialog, sheet, command palette, tooltip — is **`z-50`**. So any menu opened from *inside* the drawer renders **behind** it:

- the **workspace switcher** (a popover in the account pod) → opened behind the drawer → looked like nothing happened
- the **command palette** (⌘K / Search) → same fault when opened with the drawer up

## The fix (one coherent change)

Drop the nav drawer below the overlay layer: **drawer `z-[45]`, backdrop `z-[44]`** — still above page content, now below the `z-50` overlays. Every menu, the workspace switcher, and the command palette now render **above** the drawer. One layering correction fixes the whole class of "menu opened from the mobile drawer is invisible."

## Also: remove Cursor from the profile menu

The account/profile menu (`user-pod`) had a **Cursor** section — not important enough to live there. Removed it. The per-artifact cursor control (`CursorButton` in the artifact toolbar) is untouched.

## Verified on a 390px viewport (real local build)

- **Org switching** — open drawer → account pod → **workspace switcher popover shows above the drawer**, tapping a workspace switches (pod relabels, drawer closes) ✅
- **Command palette** — opens full-width above everything ✅
- **Artifact viewer** + top-bar actions, **comments bottom sheet**, **more-actions** dropdown ✅
- **Settings** — scrollable tabs + single-column forms ✅
- **Profile menu** — no Cursor item; **desktop** menu unchanged ✅

## Notes

- Scope is the systemic occlusion bug + the two explicit asks; verified across the primary flows rather than exhaustively every screen.
- The follow/feed UI (PR #205) lives in the same nav drawer and **inherits this fix**; I'll give it the same pass when it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)