### PR TITLE
fix(auth): 30-day idle refresh window for MCP/OAuth

### DIFF
--- a/apps/api/src/auth-config.ts
+++ b/apps/api/src/auth-config.ts
@@ -203,7 +203,10 @@ export function makeAuth(db: AuthDb, baseUrl: string, secret: string, hooks: Aut
         // consents, so the only surface is spam client rows.
         allowUnauthenticatedClientRegistration: true,
         accessTokenExpiresIn: 60 * 60, // 1h
-        refreshTokenExpiresIn: 60 * 60 * 24 * 7, // 7d
+        // Refresh tokens rotate + reset their window on every use (see createUserTokens),
+        // so this is an INACTIVITY timeout, not a hard cap: active clients (MCP, browser)
+        // never re-auth; you only re-consent after 30 days of no use.
+        refreshTokenExpiresIn: 60 * 60 * 24 * 30, // 30d (idle)
         scopes: [...OAUTH_SCOPES],
         // Accept the resource indicators MCP clients send (else token exchange 400s).
         validAudiences: mcpAudiences,


### PR DESCRIPTION
Access tokens stay **1h** (auto-refreshed). Refresh tokens already **rotate and reset their window on every use** (`createUserTokens` mints a fresh refresh token with `exp = now + refreshTokenExpiresIn` on the `refresh_token` grant), so this value is an **inactivity timeout, not a hard cap**.

Bump **7d → 30d**: active MCP/browser clients keep rolling forward and only re-consent after a full month of no use.

One line in `auth-config.ts`. typecheck + all guards green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)