### PR TITLE
feat(mcp): publish bundles with images + incremental merge over MCP

### DIFF
--- a/apps/api/src/lib/bundle.ts
+++ b/apps/api/src/lib/bundle.ts
@@ -2,6 +2,7 @@ import {
   type BlobStore,
   BUNDLE_CONTENT_TYPE,
   type BundleManifest,
+  PublishError,
   type VersionRecord,
 } from "@dock/core"
 import { zipSync } from "fflate"
@@ -22,19 +23,16 @@ const base64ToBytes = (b64: string): Uint8Array => {
 }
 
 /**
- * Pack a {path: content} map into a zip the core publish path ingests exactly like
- * an HTTP bundle upload (it re-validates size, file count, paths, and entry point).
- *
- * A value is stored as raw bytes when it is a base64 data: URI
- * (`data:image/png;base64,…`) and as UTF-8 text otherwise — so screenshots, fonts,
- * and any binary asset that makes up a site ride the SAME map as the HTML/CSS/JS
- * pages, carried over MCP without inlining multi-MB base64 into one HTML string. The
- * served content-type comes from the path extension (mimeFor), so binary entries
- * must be named with a real extension (shot.png, logo.svg, font.woff2).
+ * Decode a {path: content} map to {path: bytes}: a value that is a base64 data: URI
+ * (`data:image/png;base64,…`) becomes raw bytes, everything else is UTF-8 text — so
+ * screenshots, fonts, and any binary asset that makes up a site ride the SAME map as
+ * the HTML/CSS/JS pages, carried over MCP without inlining multi-MB base64 into one
+ * HTML string. The served content-type comes from the path extension (mimeFor), so
+ * binary entries must be named with a real extension (shot.png, logo.svg, font.woff2).
  *
  * Throws if a value looks like a base64 data: URI but isn't decodable.
  */
-export const zipBundleFiles = (files: Record<string, string>): Uint8Array => {
+export const decodeBundleFiles = (files: Record<string, string>): Record<string, Uint8Array> => {
   const enc = new TextEncoder()
   const entries: Record<string, Uint8Array> = {}
   for (const [path, value] of Object.entries(files)) {
@@ -46,8 +44,40 @@ export const zipBundleFiles = (files: Record<string, string>): Uint8Array => {
     try {
       entries[path] = base64ToBytes(value.slice(marker[0].length))
     } catch {
-      throw new Error(`invalid base64 data URI for "${path}"`)
+      throw new PublishError(400, `invalid base64 data URI for "${path}"`)
     }
+  }
+  return entries
+}
+
+/**
+ * Pack a {path: content} map into a zip the core publish path ingests exactly like an
+ * HTTP bundle upload (it re-validates size, file count, paths, and entry point).
+ */
+export const zipBundleFiles = (files: Record<string, string>): Uint8Array =>
+  zipSync(decodeBundleFiles(files))
+
+/**
+ * Build the zip for an INCREMENTAL bundle publish: every file already in the bundle
+ * (read back from its blob) with `newFiles` overlaid on top by path — same path
+ * overwrites, others are kept. Lets a caller add or replace a few files without
+ * re-sending the whole site; the core publish path then republishes the union as one
+ * new version, re-running all its size/file-count/entry-point checks. Paths are
+ * normalised (leading slash stripped) so a new "shot.png" overwrites an existing
+ * "/shot.png" rather than duplicating it.
+ */
+export const mergeBundleZip = async (
+  blobs: BlobStore,
+  manifest: BundleManifest,
+  newFiles: Record<string, string>,
+): Promise<Uint8Array> => {
+  const entries: Record<string, Uint8Array> = {}
+  for (const [path, entry] of Object.entries(manifest.files)) {
+    const bytes = await blobs.get(entry.key)
+    if (bytes) entries[cleanPath(path)] = bytes
+  }
+  for (const [path, bytes] of Object.entries(decodeBundleFiles(newFiles))) {
+    entries[cleanPath(path)] = bytes
   }
   return zipSync(entries)
 }

--- a/apps/api/src/lib/bundle.ts
+++ b/apps/api/src/lib/bundle.ts
@@ -4,10 +4,53 @@ import {
   type BundleManifest,
   type VersionRecord,
 } from "@dock/core"
+import { zipSync } from "fflate"
 
 // Bundle manifests store paths with a leading slash (/index.html); present them
 // cleanly to callers, and accept either form on the way back in.
 export const cleanPath = (p: string): string => p.replace(/^\//, "")
+
+// A base64 data: URI — data:image/png;base64,…. The mediatype is optional and may
+// carry parameters (;charset=…), so match through to the required `;base64,` marker.
+const DATA_URI_BASE64 = /^data:[\w.+-]*\/?[\w.+-]*(?:;[\w.+-]+=[\w.+-]+)*;base64,/i
+
+const base64ToBytes = (b64: string): Uint8Array => {
+  const bin = atob(b64.replace(/\s+/g, ""))
+  const out = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+  return out
+}
+
+/**
+ * Pack a {path: content} map into a zip the core publish path ingests exactly like
+ * an HTTP bundle upload (it re-validates size, file count, paths, and entry point).
+ *
+ * A value is stored as raw bytes when it is a base64 data: URI
+ * (`data:image/png;base64,…`) and as UTF-8 text otherwise — so screenshots, fonts,
+ * and any binary asset that makes up a site ride the SAME map as the HTML/CSS/JS
+ * pages, carried over MCP without inlining multi-MB base64 into one HTML string. The
+ * served content-type comes from the path extension (mimeFor), so binary entries
+ * must be named with a real extension (shot.png, logo.svg, font.woff2).
+ *
+ * Throws if a value looks like a base64 data: URI but isn't decodable.
+ */
+export const zipBundleFiles = (files: Record<string, string>): Uint8Array => {
+  const enc = new TextEncoder()
+  const entries: Record<string, Uint8Array> = {}
+  for (const [path, value] of Object.entries(files)) {
+    const marker = DATA_URI_BASE64.exec(value)
+    if (!marker) {
+      entries[path] = enc.encode(value)
+      continue
+    }
+    try {
+      entries[path] = base64ToBytes(value.slice(marker[0].length))
+    } catch {
+      throw new Error(`invalid base64 data URI for "${path}"`)
+    }
+  }
+  return zipSync(entries)
+}
 
 // A version's bundle manifest (null when it isn't a bundle / is unreadable).
 export async function manifestOf(

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -30,26 +30,15 @@ import {
 } from "@dock/core"
 import { StreamableHTTPTransport } from "@hono/mcp"
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
-import { zipSync } from "fflate"
 import type { Hono } from "hono"
 import { z } from "zod"
 import type { AppContext } from "./context"
 import { markAddressed } from "./lib/addressed"
-import { cleanPath, manifestOf as sharedManifestOf } from "./lib/bundle"
+import { cleanPath, manifestOf as sharedManifestOf, zipBundleFiles } from "./lib/bundle"
 import { quoteOf } from "./lib/comments"
 
 const text = (s: string) => ({ content: [{ type: "text" as const, text: s }] })
 const json = (v: unknown) => text(JSON.stringify(v, null, 2))
-
-// Pack a {path: content} map into a zip the core publish path can ingest exactly
-// like an HTTP bundle upload (it re-validates size, paths, and entry point). Text
-// pages only — binary assets still go through the multipart/zip HTTP route.
-const zipFromFiles = (files: Record<string, string>): Uint8Array => {
-  const enc = new TextEncoder()
-  const entries: Record<string, Uint8Array> = {}
-  for (const [path, content] of Object.entries(files)) entries[path] = enc.encode(content)
-  return zipSync(entries)
-}
 // An actionable error the model can recover from (per the MCP spec, isError text is
 // fed back to the agent so it self-corrects), rather than an opaque failure.
 const err = (s: string) => ({
@@ -475,7 +464,7 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
     "publish",
     {
       description:
-        "Publish an artifact to your workspace DIRECTLY — it goes live immediately, no review. Provide `content` for a SINGLE-FILE artifact, or `files` (a map of page path → content) for a MULTI-PAGE BUNDLE. OMIT short_id to create a NEW artifact (a first publish) — `title` is then required. PASS short_id to publish a new version of one you already own, matching its kind: a bundle takes `files`, a single file takes `content`. A bundle republish REPLACES the whole bundle, so include EVERY page. Requires publish rights (Creator/Admin role on the workspace); a commenter-level grant should use `propose` instead. Provide the FULL content (not a patch).",
+        "Publish an artifact to your workspace DIRECTLY — it goes live immediately, no review. Provide `content` for a SINGLE-FILE artifact, or `files` (a map of page path → content) for a MULTI-PAGE BUNDLE — a whole site, with images and any other binary asset. OMIT short_id to create a NEW artifact (a first publish) — `title` is then required. PASS short_id to publish a new version of one you already own, matching its kind: a bundle takes `files`, a single file takes `content`. A bundle republish REPLACES the whole bundle, so include EVERY page and asset. Requires publish rights (Creator/Admin role on the workspace); a commenter-level grant should use `propose` instead. Provide the FULL content (not a patch).",
       inputSchema: {
         content: z
           .string()
@@ -487,7 +476,7 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           .record(z.string(), z.string())
           .optional()
           .describe(
-            'A MULTI-PAGE bundle as a map of page path → content, e.g. {"index.html":"…","about.html":"…","nav.js":"…"}. The root index.html (else the shallowest .html) becomes the entry page. A republish REPLACES the bundle, so include every page. Text pages only — zip-upload via the HTTP API for binary assets.',
+            'A MULTI-PAGE bundle as a map of path → content — the whole site. Text pages are plain strings; binary assets (screenshots, images, fonts) are base64 data: URIs, e.g. {"index.html":"<img src=shot.png>","styles.css":"…","shot.png":"data:image/png;base64,iVBORw0K…","logo.svg":"…"}. The root index.html (else the shallowest .html) becomes the entry page; pages reference assets by relative path. Served content-type comes from the file extension, so give binary entries a real extension (.png/.jpg/.svg/.woff2). A republish REPLACES the bundle, so include every page and asset. The whole map travels in one call, so keep total content to a few MB — compress/resize screenshots rather than shipping originals.',
           ),
         title: z
           .string()
@@ -556,7 +545,7 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           ctx.blobs,
           {
             bytes: isBundle
-              ? zipFromFiles(files as Record<string, string>)
+              ? zipBundleFiles(files as Record<string, string>)
               : new TextEncoder().encode(content as string),
             filename: isBundle ? `${title?.trim() || "bundle"}.zip` : (filename ?? "index.html"),
             isBundle,

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -34,7 +34,12 @@ import type { Hono } from "hono"
 import { z } from "zod"
 import type { AppContext } from "./context"
 import { markAddressed } from "./lib/addressed"
-import { cleanPath, manifestOf as sharedManifestOf, zipBundleFiles } from "./lib/bundle"
+import {
+  cleanPath,
+  mergeBundleZip,
+  manifestOf as sharedManifestOf,
+  zipBundleFiles,
+} from "./lib/bundle"
 import { quoteOf } from "./lib/comments"
 
 const text = (s: string) => ({ content: [{ type: "text" as const, text: s }] })
@@ -476,7 +481,7 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           .record(z.string(), z.string())
           .optional()
           .describe(
-            'A MULTI-PAGE bundle as a map of path → content — the whole site. Text pages are plain strings; binary assets (screenshots, images, fonts) are base64 data: URIs, e.g. {"index.html":"<img src=shot.png>","styles.css":"…","shot.png":"data:image/png;base64,iVBORw0K…","logo.svg":"…"}. The root index.html (else the shallowest .html) becomes the entry page; pages reference assets by relative path. Served content-type comes from the file extension, so give binary entries a real extension (.png/.jpg/.svg/.woff2). A republish REPLACES the bundle, so include every page and asset. The whole map travels in one call, so keep total content to a few MB — compress/resize screenshots rather than shipping originals.',
+            'A MULTI-PAGE bundle as a map of path → content — the whole site. Text pages are plain strings; binary assets (screenshots, images, fonts) are base64 data: URIs, e.g. {"index.html":"<img src=shot.png>","styles.css":"…","shot.png":"data:image/png;base64,iVBORw0K…","logo.svg":"…"}. The root index.html (else the shallowest .html) becomes the entry page; pages reference assets by relative path. Served content-type comes from the file extension, so give binary entries a real extension (.png/.jpg/.svg/.woff2). A plain republish REPLACES the bundle (include every page and asset). The map travels in one call, so keep each call to a few MB; for a large or image-heavy site, publish the pages first, then add assets in batches with `merge` (below).',
           ),
         title: z
           .string()
@@ -502,6 +507,12 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           .describe(
             "For a NEW bundle only: serve unknown paths from the entry page (single-page-app routing). Default false.",
           ),
+        merge: z
+          .boolean()
+          .optional()
+          .describe(
+            "Add/overwrite the given `files` INTO the existing bundle instead of replacing it (default false). Build a large site across several calls without re-sending it: publish the pages first, then merge in batches of assets — each call carries only the new files. Requires `short_id` of a bundle; same-path files overwrite, the rest are kept.",
+          ),
         message: z.string().optional().describe("What changed — recorded as the version message."),
         filename: z
           .string()
@@ -511,7 +522,7 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           ),
       },
     },
-    async ({ content, files, title, short_id, visibility, spa, message, filename }) => {
+    async ({ content, files, title, short_id, visibility, spa, merge, message, filename }) => {
       // Direct publish is gated on the agent's role: Creator/Admin only. A
       // commenter-level grant is steered to `propose` (human-reviewed), so a
       // low-privilege agent still can't push live content.
@@ -525,31 +536,55 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
         return text("Provide `content` (single file) OR `files` (a bundle), not both.")
       if (!isBundle && (content === undefined || content === ""))
         return text("Provide `content` (single file) or `files` (a multi-page bundle).")
-      if (short_id) {
-        const a = await own(short_id)
-        if (!a) return text(`No artifact "${short_id}" in this workspace.`)
+      const existing = short_id ? await own(short_id) : null
+      if (short_id && !existing) return text(`No artifact "${short_id}" in this workspace.`)
+      if (existing) {
         // Kind can't change on republish; steer to the right field instead of
         // bubbling the core's 409.
-        if (a.kind === "bundle" && !isBundle)
+        if (existing.kind === "bundle" && !isBundle)
           return text(
             `"${short_id}" is a multi-page bundle — pass \`files\` (every page) to republish it.`,
           )
-        if (a.kind === "file" && isBundle)
+        if (existing.kind === "file" && isBundle)
           return text(`"${short_id}" is a single-file artifact — pass \`content\`, not \`files\`.`)
       } else if (!title?.trim()) {
         return text("Creating a new artifact needs a `title`.")
       }
+      // `merge` folds the given files into the existing bundle (add/overwrite by path)
+      // instead of replacing it — how a large site is grown across calls without
+      // re-sending it. Only meaningful for an existing bundle.
+      if (merge) {
+        if (!isBundle) return text("`merge` adds files to a bundle — pass `files`, not `content`.")
+        if (!existing) return text("`merge` needs the `short_id` of an existing bundle to add to.")
+        if (existing.kind !== "bundle")
+          return text(
+            `"${short_id}" is a single-file artifact — \`merge\` only applies to bundles.`,
+          )
+      }
       try {
+        let bytes: Uint8Array
+        // A merge keeps the bundle's existing SPA routing (the caller isn't redeclaring it).
+        let bundleSpa = isBundle ? !!spa : undefined
+        if (!isBundle) {
+          bytes = new TextEncoder().encode(content as string)
+        } else if (merge && existing) {
+          const v = await ctx.meta.getVersion(existing.id, existing.current_version)
+          const manifest = v && (await manifestOf(ctx, v))
+          if (!manifest)
+            return text(`Couldn't read the current bundle for "${short_id}" to merge into.`)
+          bytes = await mergeBundleZip(ctx.blobs, manifest, files as Record<string, string>)
+          bundleSpa = manifest.spa
+        } else {
+          bytes = zipBundleFiles(files as Record<string, string>)
+        }
         const { artifact, version } = await publishVersion(
           ctx.meta,
           ctx.blobs,
           {
-            bytes: isBundle
-              ? zipBundleFiles(files as Record<string, string>)
-              : new TextEncoder().encode(content as string),
+            bytes,
             filename: isBundle ? `${title?.trim() || "bundle"}.zip` : (filename ?? "index.html"),
             isBundle,
-            spa: isBundle ? !!spa : undefined,
+            spa: bundleSpa,
             title: title?.trim(),
             message,
             author: agent.name,
@@ -568,9 +603,11 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           url: artifactUrl(ctx.deps.baseUrl, artifact),
           title: artifact.title,
           visibility: artifact.visibility,
-          note: short_id
-            ? "Live now — published a new current version."
-            : "Live now — created a new artifact in your workspace.",
+          note: merge
+            ? `Live now — merged ${Object.keys(files as Record<string, string>).length} file(s) into the bundle (new current version).`
+            : short_id
+              ? "Live now — published a new current version."
+              : "Live now — created a new artifact in your workspace.",
         })
       } catch (e) {
         const msg = e instanceof PublishError ? e.message : "could not publish"

--- a/apps/api/test/bundle-assets.test.ts
+++ b/apps/api/test/bundle-assets.test.ts
@@ -1,12 +1,12 @@
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { publish } from "@dock/core"
+import { type BundleManifest, publish } from "@dock/core"
 import { SqliteMetaStore } from "@dock/db/sqlite"
 import { FsBlobStore } from "@dock/storage/fs"
 import { unzipSync } from "fflate"
 import { afterAll, describe, expect, it } from "vitest"
-import { manifestOf, zipBundleFiles } from "../src/lib/bundle"
+import { manifestOf, mergeBundleZip, zipBundleFiles } from "../src/lib/bundle"
 
 // MCP `publish` builds its bundle zip from a {path: content} map. Pages are text,
 // but a real site also has images, fonts, etc. — binary that UTF-8 encoding would
@@ -81,5 +81,54 @@ describe("a binary bundle publishes and serves the asset with the right type", (
     expect(manifest?.entry).toBe("/index.html")
     const html = new TextDecoder().decode((await blobs.get(entry?.key as string)) as Uint8Array)
     expect(html).toContain("<img src=shot.png>")
+  })
+})
+
+describe("incremental merge grows a bundle without re-sending it", () => {
+  it("keeps existing files, adds new ones, overwrites same-path, bumps the version", async () => {
+    const meta = new SqliteMetaStore(join(dir, "merge.db"))
+    const blobs = new FsBlobStore(join(dir, "merge-blobs"))
+
+    // First publish: an index page + one screenshot.
+    const first = await publish(meta, blobs, {
+      bytes: zipBundleFiles({
+        "index.html": "<img src=a.png>",
+        "a.png": `data:image/png;base64,${PNG_B64}`,
+      }),
+      filename: "site.zip",
+      isBundle: true,
+      title: "Site",
+      author: "t",
+    })
+    const m1 = (await manifestOf(blobs, first.version)) as BundleManifest
+    expect(Object.keys(m1.files).sort()).toEqual(["/a.png", "/index.html"])
+
+    // The incremental call carries ONLY the delta — a new b.png plus an updated
+    // index.html. a.png is never re-sent; mergeBundleZip reads it back from its blob.
+    const unionZip = await mergeBundleZip(blobs, m1, {
+      "index.html": "<img src=a.png><img src=b.png>",
+      "b.png": `data:image/png;base64,${PNG_B64}`,
+    })
+    const second = await publish(
+      meta,
+      blobs,
+      { bytes: unionZip, filename: "site.zip", isBundle: true, author: "t" },
+      first.artifact.short_id,
+    )
+    const m2 = (await manifestOf(blobs, second.version)) as BundleManifest
+
+    // Existing asset preserved, new asset added, page overwritten — one new version.
+    expect(Object.keys(m2.files).sort()).toEqual(["/a.png", "/b.png", "/index.html"])
+    expect(m2.files["/b.png"]?.type).toBe("image/png")
+    expect(second.version.n).toBe(2)
+
+    // a.png bytes are intact (came back from its blob, never re-sent over the wire).
+    const aBytes = (await blobs.get(m2.files["/a.png"]?.key as string)) as Uint8Array
+    expect(new Uint8Array(aBytes)).toEqual(PNG_BYTES)
+    // index.html reflects the overwrite.
+    const html = new TextDecoder().decode(
+      (await blobs.get(m2.files["/index.html"]?.key as string)) as Uint8Array,
+    )
+    expect(html).toContain("b.png")
   })
 })

--- a/apps/api/test/bundle-assets.test.ts
+++ b/apps/api/test/bundle-assets.test.ts
@@ -1,0 +1,85 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { publish } from "@dock/core"
+import { SqliteMetaStore } from "@dock/db/sqlite"
+import { FsBlobStore } from "@dock/storage/fs"
+import { unzipSync } from "fflate"
+import { afterAll, describe, expect, it } from "vitest"
+import { manifestOf, zipBundleFiles } from "../src/lib/bundle"
+
+// MCP `publish` builds its bundle zip from a {path: content} map. Pages are text,
+// but a real site also has images, fonts, etc. — binary that UTF-8 encoding would
+// corrupt. zipBundleFiles carries base64 data: URI values as raw bytes so the whole
+// site (pages + assets) rides one `files` map over MCP, and the core publish path
+// stores + serves each asset with the right content-type. This is the fix for
+// "Dock's MCP publish can't carry screenshots."
+
+const dir = mkdtempSync(join(tmpdir(), "dock-bundle-assets-"))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+// A real 1x1 transparent PNG (starts with the 8-byte PNG signature).
+const PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+const PNG_BYTES = new Uint8Array(Buffer.from(PNG_B64, "base64"))
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+
+describe("zipBundleFiles carries binary assets, not just text", () => {
+  it("decodes a base64 data: URI to raw bytes and keeps text pages as UTF-8", () => {
+    const files = {
+      "index.html": "<h1>Réport</h1><img src=shot.png>", // non-ASCII to prove UTF-8 text
+      "shot.png": `data:image/png;base64,${PNG_B64}`,
+    }
+    const unzipped = unzipSync(zipBundleFiles(files))
+
+    // The image is intact binary — the actual PNG, not the UTF-8 bytes of the data
+    // URI string (which is what the old text-only packer produced).
+    const shot = unzipped["shot.png"] as Uint8Array
+    expect(Array.from(shot.slice(0, 8))).toEqual(PNG_SIGNATURE)
+    expect(shot).toEqual(PNG_BYTES)
+
+    // Text page survives as UTF-8 (multi-byte é round-trips).
+    expect(new TextDecoder().decode(unzipped["index.html"])).toBe(files["index.html"])
+  })
+
+  it("throws an actionable error on a malformed base64 data: URI", () => {
+    expect(() => zipBundleFiles({ "x.png": "data:image/png;base64,@@not base64@@" })).toThrow(
+      /invalid base64 data URI for "x\.png"/,
+    )
+  })
+})
+
+describe("a binary bundle publishes and serves the asset with the right type", () => {
+  it("stores the PNG as image/png and preserves its bytes end to end", async () => {
+    const meta = new SqliteMetaStore(join(dir, "site.db"))
+    const blobs = new FsBlobStore(join(dir, "blobs"))
+    const files = {
+      "index.html": "<!doctype html><img src=shot.png>",
+      "shot.png": `data:image/png;base64,${PNG_B64}`,
+    }
+
+    const { version } = await publish(meta, blobs, {
+      bytes: zipBundleFiles(files),
+      filename: "site.zip",
+      isBundle: true,
+      title: "Site",
+      author: "Tester",
+    })
+
+    const manifest = await manifestOf(blobs, version)
+    expect(manifest, "published as a bundle").not.toBeNull()
+    const png = manifest?.files["/shot.png"]
+    // content-type is inferred from the .png extension by the core publish path.
+    expect(png?.type).toBe("image/png")
+
+    const stored = await blobs.get(png?.key as string)
+    expect(stored, "blob is present").toBeTruthy()
+    expect(new Uint8Array(stored as Uint8Array)).toEqual(PNG_BYTES)
+
+    // The html entry page is intact too.
+    const entry = manifest?.files[manifest.entry]
+    expect(manifest?.entry).toBe("/index.html")
+    const html = new TextDecoder().decode((await blobs.get(entry?.key as string)) as Uint8Array)
+    expect(html).toContain("<img src=shot.png>")
+  })
+})


### PR DESCRIPTION
## What

MCP `publish` can now carry a whole site — text pages **plus images and any binary asset** — and grow a large bundle incrementally across calls. Fixes "Dock's MCP publish can't carry screenshots."

### Binary bundle assets (`9b7e1f0`)
`zipFromFiles` UTF-8-encoded every value, so the `files` map was text-only; screenshots had no path over MCP, and inlining base64 into one HTML string blew the JSON-RPC payload. Moved the packer to `lib/bundle` as `zipBundleFiles`: a base64 `data:` URI value is decoded to raw bytes, everything else stays UTF-8. The core publish path already stores blobs, infers content-type from the path extension, and serves them — so `{ "index.html": "<img src=shot.png>", "shot.png": "data:image/png;base64,…" }` just works.

### Incremental `merge` (`9938880`)
The whole map travels in one JSON-RPC call (~few-MB ceiling). `merge: true` lets the agent build a large site across calls: the server reads the current bundle back from its blobs, overlays the provided files by path, and republishes the **union** as one new version — so the wire carries only the delta. Same-path overwrites, the rest are kept; SPA routing is preserved. Bad base64 now throws `PublishError` so the tool returns an actionable message.

## Tests
`apps/api/test/bundle-assets.test.ts`: a data URI round-trips as the intact PNG (signature bytes, not the UTF-8 of the string); a malformed URI throws; an end-to-end publish stores the PNG as `image/png`; and a merge keeps existing files, adds new ones, overwrites same-path, and bumps the version. Verified red without the fix. Full `apps/api` suite: **440 passing**; typecheck (both configs) + biome clean.

## Notes
- **Already deployed** to the live worker (`dock.siftai.workers.dev`, version `cb238171`) from this branch (worker + assets only, no D1 migration — zero schema delta). Merging reconciles `main` with prod.
- Clients must **reconnect the Dock MCP connection** to pick up the new `merge` param (cached tool schema); binary publishing works without a reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)