### PR TITLE
fix(auth): stop refresh-token rotation from nuking the token family on a concurrent/replayed refresh

### DIFF
--- a/apps/api/test/oauth-refresh-rotation.test.ts
+++ b/apps/api/test/oauth-refresh-rotation.test.ts
@@ -1,0 +1,189 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import Database from "better-sqlite3"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { makeAuth, migrateAuth } from "../src/auth-config"
+import { sha256 } from "../src/lib/crypto"
+
+// Regression test for the MCP/OAuth "sign back in every few hours" bug.
+//
+// Claude Code's Dock access token is a 1h JWT, so it must hit the refresh grant
+// roughly hourly under active use. The oauth-provider rotates refresh tokens on
+// every use and, on detecting a *reused* (already-revoked) token, calls
+// invalidateRefreshFamily — which deletes EVERY refresh + access token for that
+// (client, user). A concurrent refresh (an MCP client firing several requests at
+// expiry) or a retry of a refresh whose 200 response was lost presents the just-
+// rotated parent a second time, so the family — including the legitimate child
+// token issued microseconds earlier — is wiped, and the client is forced to
+// re-register a brand-new OAuth client and re-consent. Observed in prod as 11
+// client registrations in 4 days.
+//
+// The dock-patch(refresh-rotation-grace) adds a short grace window: a token revoked
+// within the window is treated as a benign concurrent rotation — the request still
+// fails (the reused token is never honored) but the family is left intact, so the
+// winning refresh keeps the session alive. Genuine reuse outside the window still
+// invalidates the family.
+
+const dir = mkdtempSync(join(tmpdir(), "dock-oauth-refresh-"))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+type Auth = ReturnType<typeof makeAuth>
+type Ctx = Awaited<Auth["$context"]>
+
+const BASE = "http://dock.test"
+const SCOPES = ["openid", "offline_access", "dock:read"]
+
+const tokenReq = (auth: Auth, body: Record<string, string>) =>
+  auth.handler(
+    new Request(`${BASE}/api/auth/oauth2/token`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams(body).toString(),
+    }),
+  )
+
+// Register a real public MCP-style client via Dynamic Client Registration so it
+// passes validateClientCredentials (token_endpoint_auth_method=none) and is allowed
+// the refresh_token grant — exactly how Claude Code registers against Dock.
+async function registerClient(auth: Auth): Promise<string> {
+  const res = await auth.handler(
+    new Request(`${BASE}/api/auth/oauth2/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        client_name: "RaceClient",
+        redirect_uris: ["http://localhost/cb"],
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        token_endpoint_auth_method: "none",
+        scope: SCOPES.join(" "),
+      }),
+    }),
+  )
+  expect(res.status, "DCR should succeed").toBeLessThan(300)
+  const j = (await res.json()) as { client_id: string }
+  expect(j.client_id).toBeTruthy()
+  return j.client_id
+}
+
+async function createUser(ctx: Ctx, email: string): Promise<string> {
+  const now = new Date()
+  const u = (await ctx.adapter.create({
+    model: "user",
+    data: { email, name: "Race", emailVerified: true, createdAt: now, updatedAt: now },
+  })) as { id: string }
+  return u.id
+}
+
+// Seed a refresh token straight into the oauth-provider table the way a completed
+// authorize→consent→token dance would, so we exercise the refresh grant without the
+// full PKCE/consent flow (irrelevant to the rotation bug). Stored hashed exactly as
+// the plugin stores it (Dock's storeTokens.hash = sha256), so presenting `plaintext`
+// resolves to this row.
+async function seedRefreshToken(
+  ctx: Ctx,
+  opts: { plaintext: string; clientId: string; userId: string; revoked?: Date | null },
+): Promise<void> {
+  await ctx.adapter.create({
+    model: "oauthRefreshToken",
+    data: {
+      token: sha256(opts.plaintext),
+      clientId: opts.clientId,
+      userId: opts.userId,
+      referenceId: opts.userId,
+      scopes: SCOPES,
+      expiresAt: new Date(Date.now() + 30 * 86_400_000),
+      createdAt: new Date(),
+      revoked: opts.revoked ?? null,
+      authTime: null,
+      sessionId: null,
+    },
+  })
+}
+
+function freshAuth(name: string): Auth {
+  const db = new Database(join(dir, `${name}.db`))
+  db.pragma("journal_mode = WAL")
+  db.pragma("busy_timeout = 5000")
+  return makeAuth(db, BASE, "test-secret-0123456789-abcdefghijklmnopqrstuv")
+}
+
+describe("OAuth refresh-token rotation survives a concurrent/replayed refresh", () => {
+  let auth: Auth
+  let ctx: Ctx
+  let clientId: string
+  let userId: string
+
+  beforeAll(async () => {
+    auth = freshAuth("grace")
+    await migrateAuth(auth)
+    ctx = await auth.$context
+    clientId = await registerClient(auth)
+    userId = await createUser(ctx, "race@dock.test")
+  })
+
+  it("a reused (just-rotated) refresh token is rejected but the live child survives", async () => {
+    const RT = "rt_parent_aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    await seedRefreshToken(ctx, { plaintext: RT, clientId, userId })
+
+    // First refresh succeeds and rotates RT -> RT2 (RT is now revoked).
+    const r1 = await tokenReq(auth, {
+      grant_type: "refresh_token",
+      refresh_token: RT,
+      client_id: clientId,
+    })
+    expect(r1.status, "first refresh should succeed").toBe(200)
+    const RT2 = ((await r1.json()) as { refresh_token?: string }).refresh_token
+    expect(RT2, "rotation should issue a new refresh token").toBeTruthy()
+
+    // Concurrent/replayed refresh presents the just-rotated parent again. It must be
+    // rejected (the reused token is never honored)...
+    const r2 = await tokenReq(auth, {
+      grant_type: "refresh_token",
+      refresh_token: RT,
+      client_id: clientId,
+    })
+    expect(r2.status, "reused parent token must be rejected").toBe(400)
+
+    // ...but it must NOT have nuked the family: the child issued by the first refresh
+    // still works. Without the grace patch, invalidateRefreshFamily deletes RT2's row
+    // and this returns 400 ("session not found") — the forced re-consent.
+    const r3 = await tokenReq(auth, {
+      grant_type: "refresh_token",
+      refresh_token: RT2 as string,
+      client_id: clientId,
+    })
+    expect(r3.status, "the live child token must survive the reuse attempt").toBe(200)
+  })
+
+  it("genuine reuse outside the grace window still invalidates the family", async () => {
+    const RT_OLD = "rt_old_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    const RT_LIVE = "rt_live_cccccccccccccccccccccccccccc"
+    // A token revoked well before the grace window (a real replay), plus a live
+    // sibling in the same family.
+    await seedRefreshToken(ctx, {
+      plaintext: RT_OLD,
+      clientId,
+      userId,
+      revoked: new Date(Date.now() - 5 * 60_000),
+    })
+    await seedRefreshToken(ctx, { plaintext: RT_LIVE, clientId, userId })
+
+    const reuse = await tokenReq(auth, {
+      grant_type: "refresh_token",
+      refresh_token: RT_OLD,
+      client_id: clientId,
+    })
+    expect(reuse.status, "stale reused token rejected").toBe(400)
+
+    // The whole family is invalidated, so even the live sibling no longer works —
+    // reuse-detection is preserved for genuine replay.
+    const live = await tokenReq(auth, {
+      grant_type: "refresh_token",
+      refresh_token: RT_LIVE,
+      client_id: clientId,
+    })
+    expect(live.status, "family invalidated on real reuse").toBe(400)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "overrides": {
       "esbuild": ">=0.25.0",
       "drizzle-orm": "0.45.2"
+    },
+    "patchedDependencies": {
+      "@better-auth/oauth-provider@1.6.19": "patches/@better-auth__oauth-provider@1.6.19.patch"
     }
   },
   "scripts": {

--- a/patches/@better-auth__oauth-provider@1.6.19.patch
+++ b/patches/@better-auth__oauth-provider@1.6.19.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 49d6fd4862b4b8299416184faa1c538d123d0495..a72fc8650d2ee66d493c84a5b4716dbb17b0fd27 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -772,7 +772,20 @@ async function handleRefreshTokenGrant(ctx, opts) {
+ 		error: "invalid_grant"
+ 	});
+ 	if (refreshToken.revoked) {
+-		await invalidateRefreshFamily(ctx, client_id, refreshToken.userId);
++		// dock-patch(refresh-rotation-grace): a refresh token revoked only moments ago
++		// was almost certainly rotated by a *concurrent* refresh from the same client
++		// (an MCP client firing several requests at access-token expiry, or retrying a
++		// refresh whose 200 response it never received) — not replayed by an attacker.
++		// The default here nukes the entire token family, which also destroys the
++		// freshly-rotated child token and forces a full re-consent (observed as Dock
++		// re-registering a new OAuth client every few hours). Within a short grace
++		// window, fail just THIS request and leave the family (incl. the new child)
++		// intact so the winning refresh keeps the session alive. Outside the window it
++		// is treated as genuine reuse and the family is invalidated exactly as before.
++		const __revokedAtMs = new Date(refreshToken.revoked).getTime();
++		const __DOCK_REFRESH_ROTATION_GRACE_MS = 30000;
++		const __concurrentRotation = Number.isFinite(__revokedAtMs) && Date.now() - __revokedAtMs <= __DOCK_REFRESH_ROTATION_GRACE_MS;
++		if (!__concurrentRotation) await invalidateRefreshFamily(ctx, client_id, refreshToken.userId);
+ 		throw new APIError("BAD_REQUEST", {
+ 			error_description: "invalid refresh token",
+ 			error: "invalid_grant"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,11 @@ overrides:
   esbuild: '>=0.25.0'
   drizzle-orm: 0.45.2
 
+patchedDependencies:
+  '@better-auth/oauth-provider@1.6.19':
+    hash: c2f442a67a02da9e2a8658669518810332d267f8b229d96d93c5e0e3c3dc5022
+    path: patches/@better-auth__oauth-provider@1.6.19.patch
+
 importers:
 
   .:
@@ -29,7 +34,7 @@ importers:
     dependencies:
       '@better-auth/oauth-provider':
         specifier: 1.6.19
-        version: 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.6(zod@4.4.3))
+        version: 1.6.19(patch_hash=c2f442a67a02da9e2a8658669518810332d267f8b229d96d93c5e0e3c3dc5022)(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.6(zod@4.4.3))
       '@dock/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -4966,7 +4971,7 @@ snapshots:
       '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/oauth-provider@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.6(zod@4.4.3))':
+  '@better-auth/oauth-provider@1.6.19(patch_hash=c2f442a67a02da9e2a8658669518810332d267f8b229d96d93c5e0e3c3dc5022)(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.6(zod@4.4.3))':
     dependencies:
       '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2


### PR DESCRIPTION
## The bug

Users (Claude Code → Dock MCP) had to re-auth every few hours. The access token is a stateless 1h JWT, so the refresh grant runs ~hourly. The oauth-provider rotates the refresh token on every use and, on seeing an already-revoked (reused) token, calls `invalidateRefreshFamily` — deleting **every** refresh + access token for that (client, user). A concurrent refresh (an MCP client firing several requests at expiry) or a retry of a refresh whose `200` response was lost presents the just-rotated parent a second time → the whole family (including the legitimate child issued microseconds earlier) is wiped → the client re-registers a new OAuth client and re-consents. Prod showed **11 client registrations in 4 days** with valid-but-orphaned tokens. The plugin itself flags `TODO(invalidate-family-race): the two deleteMany calls are not atomic`; on Cloudflare D1 there are no interactive transactions to close the window.

## The fix

`pnpm patch @better-auth/oauth-provider@1.6.19`: a refresh token revoked within a **30s grace window** is treated as a benign concurrent rotation — the request still fails (the reused token is never honored) but the family is left intact, so the winning refresh keeps the session alive. Genuine reuse outside the window still invalidates the family (reuse-detection preserved).

## Tests

`apps/api/test/oauth-refresh-rotation.test.ts` boots the real patched plugin against the actual token endpoint: a reused parent is rejected (400) but the rotated child survives (200); reuse beyond the grace window still invalidates the family. Verified red without the patch (`child: expected 400 to be 200`). Full `apps/api` suite passing.

## Notes
- Not yet deployed. The `#198` (Drizzle D1 driver) and `#207` (refresh window 7d→30d) changes were red herrings for this symptom — both are live and fine, but 7d already dwarfs "a few hours."
- Dependency patch — re-check on better-auth upgrades; worth an upstream issue for the non-atomic family invalidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)