### PR TITLE
feat(sync): delete docs on disconnect — keep vs wipe dialog

### DIFF
--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -608,8 +608,19 @@ export const syncRoutes = (ctx: AppContext) => {
     const org = await activeWorkspace(c)
     const source = await meta.getRepoSource(c.req.param("id"), org)
     if (!source) return fail(c, 404, "not found")
-    // Disconnect only: keep the collection + mirrored artifacts so the docs stay
-    // readable. They simply stop updating.
+    if (c.req.query("wipe") === "true") {
+      // Delete every artifact this source manages, then its collection.
+      try {
+        const map = JSON.parse(source.files || "{}") as Record<string, { artifact_id?: string }>
+        for (const entry of Object.values(map)) {
+          if (entry.artifact_id) await meta.deleteArtifact(entry.artifact_id, org)
+        }
+      } catch {
+        /* malformed files map — skip */
+      }
+      await meta.deleteCollection(source.collection_id)
+    }
+    // Default: keep the collection + artifacts so the docs stay readable.
     await meta.deleteRepoSource(source.id, org)
     return c.body(null, 204)
   })

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -707,8 +707,11 @@ export const api = {
     f(`/v1/sync/github/${id}/status`, opts()).then(j),
   // Sources currently mid-sync in this workspace (drives the global progress chip).
   activeSyncs: (): Promise<{ active: RepoSource[] }> => f("/v1/sync/github/active", opts()).then(j),
-  deleteRepoSource: (id: string): Promise<void> =>
-    f(`/v1/sync/github/${id}`, { method: "DELETE", credentials: "include" }).then(() => undefined),
+  deleteRepoSource: (id: string, wipe?: boolean): Promise<void> =>
+    f(`/v1/sync/github/${id}${wipe ? "?wipe=true" : ""}`, {
+      method: "DELETE",
+      credentials: "include",
+    }).then(() => undefined),
 
   // Workspace name + members (Admin / Creator / Viewer = owner / editor / commenter)
   getWorkspace: (): Promise<Workspace> => f("/v1/workspace", opts()).then(j),

--- a/apps/web/src/pages/settings/github-section.tsx
+++ b/apps/web/src/pages/settings/github-section.tsx
@@ -593,12 +593,19 @@ function RepoSourceRow({
     }
   }
 
-  const remove = async () => {
+  const [disconnectDialog, setDisconnectDialog] = useState(false)
+  const [wipeBusy, setWipeBusy] = useState(false)
+
+  const remove = async (wipe: boolean) => {
+    setWipeBusy(true)
     try {
-      await api.deleteRepoSource(source.id)
-      onChanged("Repo disconnected (docs kept)")
+      await api.deleteRepoSource(source.id, wipe)
+      setDisconnectDialog(false)
+      onChanged(wipe ? "Repo disconnected and docs deleted" : "Repo disconnected (docs kept)")
     } catch (e) {
       onError((e as Error).message)
+    } finally {
+      setWipeBusy(false)
     }
   }
 
@@ -641,11 +648,43 @@ function RepoSourceRow({
           variant="ghost"
           size="sm"
           className="text-destructive hover:text-destructive"
-          onClick={remove}
+          onClick={() => setDisconnectDialog(true)}
         >
           Disconnect
         </Button>
       </div>
+
+      {disconnectDialog && (
+        <Dialog open onOpenChange={(o) => !o && setDisconnectDialog(false)}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Disconnect {source.repo}?</DialogTitle>
+              <DialogDescription>
+                Choose what happens to the {status.file_count} synced doc
+                {status.file_count === 1 ? "" : "s"}.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="mt-2 flex flex-col gap-2">
+              <Button
+                variant="outline"
+                disabled={wipeBusy}
+                data-testid={`github-disconnect-keep-${source.id}`}
+                onClick={() => remove(false)}
+              >
+                Keep docs — stop syncing, docs stay readable
+              </Button>
+              <Button
+                variant="destructive"
+                disabled={wipeBusy}
+                data-testid={`github-disconnect-wipe-${source.id}`}
+                onClick={() => remove(true)}
+              >
+                {wipeBusy ? "Deleting…" : "Delete docs — remove all synced content"}
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
 
       {/* ACTIVE — the giant, explicit progress block. Every phase named, live counts,
           a clear %, and a standing reassurance that it runs on the server. */}


### PR DESCRIPTION
## Summary

- Disconnect now shows a dialog instead of silently keeping docs
- **Keep docs** — existing behavior; collection + artifacts stay readable, just stop syncing
- **Delete docs** — wipes all synced artifacts and the collection cleanly (no orphaned artifacts)

## Changes

- `DELETE /v1/sync/github/:id?wipe=true` — reads artifact IDs from the source's `files` JSON, deletes each via `meta.deleteArtifact`, then deletes the collection
- `api.ts` — `deleteRepoSource` accepts optional `wipe` param
- `github-section.tsx` — Disconnect button opens a dialog with both options

## Test plan

- [ ] Disconnect a synced repo with "Keep docs" → source removed, collection + artifacts still visible
- [ ] Disconnect a synced repo with "Delete docs" → source, collection, and all artifacts gone with no orphans

🤖 Generated with [Claude Code](https://claude.com/claude-code)