### PR TITLE
feat(profiles): people profiles, following, feed + OG cards

### DIFF
--- a/apps/api/src/lib/author.ts
+++ b/apps/api/src/lib/author.ts
@@ -1,0 +1,37 @@
+import type { ArtifactRecord, MetaStore } from "@dock/core"
+
+/** The current author of an artifact as a resolved profile: the denormalized
+ *  name/login/avatar plus the Dock `handle` when the committer signed in with GitHub. */
+export interface ResolvedAuthor {
+  name: string | null
+  login: string | null
+  avatar: string | null
+  handle: string | null
+}
+
+/** Resolve a set of GitHub numeric user ids to Dock handles (usernames) in ONE batched
+ *  query — gh_id → handle, only for committers who signed in with GitHub. Empty set ⇒ {}.
+ *  Shared by the artifact list and the profile work-list so both render the same chip. */
+export const resolveHandles = async (
+  meta: MetaStore,
+  ghIds: string[],
+): Promise<Record<string, string | null>> => {
+  const out: Record<string, string | null> = {}
+  if (ghIds.length === 0) return out
+  for (const u of await meta.usersByGithubIds(ghIds)) out[u.gh_id] = u.username
+  return out
+}
+
+/** The artifact's current author as a resolved profile; null when it has no author at all. */
+export const authorProfile = (
+  a: ArtifactRecord,
+  handleByGhId: Record<string, string | null>,
+): ResolvedAuthor | null => {
+  if (!a.author_name && !a.author_login && !a.author_gh_id) return null
+  return {
+    name: a.author_name,
+    login: a.author_login,
+    avatar: a.author_avatar,
+    handle: a.author_gh_id ? (handleByGhId[a.author_gh_id] ?? null) : null,
+  }
+}

--- a/apps/api/src/lib/serve-web.ts
+++ b/apps/api/src/lib/serve-web.ts
@@ -30,11 +30,12 @@ const API_EXACT = [
 ] as const
 
 // Page prefixes the SERVER renders before handing off to the SPA, but that are NOT
-// API paths: `/a/:ref` is served as the SPA shell with per-artifact unfurl meta
-// injected (crawlers don't run JS). The edge Worker must run first on these to
-// inject; the dev proxy and `isApiPath` deliberately ignore them (in dev the SPA
-// owns the page, and an unmatched one still falls back to the shell, never JSON).
-const SERVER_PAGE_PREFIXES = ["/a", "/settings/github"] as const
+// API paths: `/a/:ref` (per-artifact unfurl meta) and `/u/:handle` (per-profile unfurl
+// meta) are served as the SPA shell with OpenGraph/Twitter meta injected for crawlers
+// (which don't run JS). The edge Worker must run first on these to inject; the dev proxy
+// and `isApiPath` deliberately ignore them (in dev the SPA owns the page, and an
+// unmatched one still falls back to the shell, never JSON).
+const SERVER_PAGE_PREFIXES = ["/a", "/u", "/settings/github"] as const
 
 /** Server-owned path tokens in declaration order (as the dev proxy lists them). */
 export const API_PATHS: readonly string[] = [...API_PREFIXES, ...API_EXACT]

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -147,10 +147,13 @@ export const artifactRoutes = (ctx: AppContext) => {
       q,
       ids,
       collectionId,
-      // Shared-with-me spans workspaces; an explicit member can always see them, so
-      // drop the workspace + public-only restrictions for that scope.
-      orgId: shared ? undefined : listOrg,
-      publicOnly: shared ? false : publicOnly,
+      // `shared` and `following` both resolve to an id set that ALREADY encodes the
+      // correct cross-workspace + visibility scope (an explicit share; or a followed
+      // author/path in this workspace + a followed person's public work anywhere). So
+      // drop the workspace + public-only restrictions, which would otherwise re-clip the
+      // feed back to the active workspace and strip a followed person's public work.
+      orgId: shared || following ? undefined : listOrg,
+      publicOnly: shared || following ? false : publicOnly,
     })
     const hasMore = rows.length > limit
     const page = hasMore ? rows.slice(0, limit) : rows

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -16,6 +16,7 @@ import { setCookie } from "hono/cookie"
 import { z } from "zod"
 import type { AppContext } from "../context"
 import { sweepAnchors } from "../lib/anchor-sweep"
+import { authorProfile, resolveHandles } from "../lib/author"
 import { hashPassword, safeEqual, unlockCookie, unlockToken, verifyPassword } from "../lib/crypto"
 import {
   DEFAULT_WORKSPACE_NAME,
@@ -53,36 +54,6 @@ export const artifactRoutes = (ctx: AppContext) => {
     sourceText,
   } = ctx
   const app = new Hono()
-
-  // Resolve a set of GitHub numeric user ids to Dock handles (usernames) in ONE batched
-  // query — gh_id → handle, only for committers who signed in with GitHub. Empty set ⇒ {}.
-  const resolveHandles = async (ghIds: string[]): Promise<Record<string, string | null>> => {
-    const out: Record<string, string | null> = {}
-    if (ghIds.length === 0) return out
-    for (const u of await meta.usersByGithubIds(ghIds)) out[u.gh_id] = u.username
-    return out
-  }
-
-  // The artifact's current author as a resolved profile: name/login/avatar from the
-  // denormalized columns, plus the Dock `handle` when the committer is a known user.
-  // Null when the artifact has no recorded author at all.
-  const authorProfile = (
-    a: ArtifactRecord,
-    handleByGhId: Record<string, string | null>,
-  ): {
-    name: string | null
-    login: string | null
-    avatar: string | null
-    handle: string | null
-  } | null => {
-    if (!a.author_name && !a.author_login && !a.author_gh_id) return null
-    return {
-      name: a.author_name,
-      login: a.author_login,
-      avatar: a.author_avatar,
-      handle: a.author_gh_id ? (handleByGhId[a.author_gh_id] ?? null) : null,
-    }
-  }
 
   // Newest-first, keyset-paginated (?cursor=<created_at>&limit=N), with optional
   // server-side ?q= (title search), ?tag=, and ?favorite=true. Returns
@@ -191,7 +162,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     const tags = await meta.tagsForArtifacts(pageIds)
     // Resolve the page's distinct author gh_ids to Dock handles in ONE batched query (no
     // N+1) so each row can show "who last changed this" with a link to the Dock profile.
-    const handleByGhId = await resolveHandles([
+    const handleByGhId = await resolveHandles(meta, [
       ...new Set(page.map((a) => a.author_gh_id).filter((x): x is string => !!x)),
     ])
     return c.json({
@@ -305,6 +276,11 @@ export const artifactRoutes = (ctx: AppContext) => {
     const passwordHash = visibility === "password" && password ? hashPassword(password) : undefined
 
     try {
+      // The authenticated principal behind this publish (signed-in user or agent).
+      // Resolved once: `name` is the display author; `id` attributes the version to a
+      // Dock user so it shows on their profile + flows to their followers. A bare
+      // static-token publish has no principal → null id (stays off any human profile).
+      const actor = await actingUser(c)
       const { artifact, version } = await publish(
         meta,
         blobs,
@@ -321,7 +297,8 @@ export const artifactRoutes = (ctx: AppContext) => {
           // person. Anonymous callers can't reach this route at all, so a publish is
           // always attributed to a real principal (the token's optional `author`
           // label is the one headless exception).
-          author: (await actingUser(c))?.name ?? str(body["author"]),
+          author: actor?.name ?? str(body["author"]),
+          authorId: actor?.id ?? null,
           name: str(body["name"]),
           orgId: org,
           visibility,
@@ -339,6 +316,26 @@ export const artifactRoutes = (ctx: AppContext) => {
         message: version.message,
         author: version.author,
       })
+      // Fan out to the publisher's followers: "someone you follow published X". Only for
+      // a real signed-in user (agent/token publishes have no human followers) and only
+      // for publicly-visible work, so a follow never leaks a private title. Bounded list.
+      if (actor?.id && artifact.visibility === "public") {
+        for (const follower of await meta.listFollowers(actor.id, 100)) {
+          if (follower.id === actor.id) continue
+          await meta.createNotification({
+            id: newId("ntf"),
+            user_id: follower.id,
+            actor: actor.name ?? "Someone",
+            kind: "publish",
+            artifact_id: artifact.id,
+            artifact_short_id: artifact.short_id,
+            artifact_title: artifact.title,
+            thread_id: "",
+            comment_id: "",
+            preview: artifact.title ?? "published an update",
+          })
+        }
+      }
       // Republish can resolve comment threads in the same call.
       const resolves = body["resolves"]
       if (shortId && typeof resolves === "string" && resolves) {
@@ -423,7 +420,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     const ghIds = new Set<string>()
     if (artifact.author_gh_id) ghIds.add(artifact.author_gh_id)
     for (const v of versions) if (v.author_gh_id) ghIds.add(v.author_gh_id)
-    const handleByGhId = await resolveHandles([...ghIds])
+    const handleByGhId = await resolveHandles(meta, [...ghIds])
     const base = toJson(deps.baseUrl, artifact, versions)
     // `versions` stays at revision granularity (machines/agents); `sessions` is
     // the time-grouped view the UI shows by default. `my_role` tells the client
@@ -560,6 +557,7 @@ export const artifactRoutes = (ctx: AppContext) => {
       // stays consistent (and dedup'd, since it reuses the same blob_key).
       size_bytes: src.size_bytes,
       author: me ? (me.name ?? me.username ?? me.email) : "anonymous",
+      author_id: me?.id ?? null,
       message: `Restored v${src.n}`,
       name: null,
     })

--- a/apps/api/src/routes/embeds.ts
+++ b/apps/api/src/routes/embeds.ts
@@ -5,9 +5,14 @@ import {
   escapeHtml,
   injectHead,
   kindLabel,
+  normalizeUsername,
   oembedResponse,
   ogCardSvg,
+  ogProfileCardSvg,
+  type ProfileCard,
   parseRef,
+  profileMetaTags,
+  profileSummary,
   refFor,
   type UnfurlInfo,
   unfurlDescription,
@@ -98,6 +103,46 @@ export const embedRoutes = (ctx: AppContext) => {
     })
   })
 
+  // Everything a profile unfurl needs, gathered from the public profile + its stats.
+  // Null when the handle isn't claimed (the caller renders a generic card).
+  const profileCardFor = async (handle: string): Promise<ProfileCard | null> => {
+    const p = await meta.getUserByUsername(normalizeUsername(handle))
+    if (!p) return null
+    const ghIds = await meta.githubIdsForUser(p.id)
+    // Public-only counts here (no viewer) — an unfurl must never reflect private work.
+    const [works, followers] = await Promise.all([
+      meta.countUserWorks(p.id, ghIds, {}),
+      meta.countFollowers(p.id),
+    ])
+    return {
+      username: p.username,
+      name: p.name,
+      profession: p.profession ?? null,
+      works,
+      followers,
+    }
+  }
+
+  // The profile OG card image (SVG, 1200x630). Anonymous-readable; a missing handle gets
+  // a generic Dock card (still 200 so the unfurl shows something). Cached hard.
+  app.get("/v1/og/u/:handle", async (c) => {
+    const card = await profileCardFor(c.req.param("handle"))
+    const svg = ogProfileCardSvg(
+      card ?? {
+        username: c.req.param("handle"),
+        name: null,
+        profession: null,
+        works: 0,
+        followers: 0,
+      },
+    )
+    return c.body(svg, 200, {
+      "Content-Type": "image/svg+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=86400, stale-while-revalidate=604800",
+      "X-Content-Type-Options": "nosniff",
+    })
+  })
+
   // oEmbed (https://oembed.com): consumers POST our discovered endpoint with the
   // artifact `url`. Only JSON is implemented. Private/missing → 404, per spec.
   app.get("/v1/oembed", async (c) => {
@@ -164,6 +209,28 @@ export const embedRoutes = (ctx: AppContext) => {
       const canonical = version ? `${refFor(artifact)}@v${version}` : refFor(artifact)
       if (ref !== canonical) return c.redirect(`/a/${canonical}${new URL(c.req.url).search}`, 302)
       return c.html(injectHead(shell, unfurlMetaTags(await infoFor(artifact))))
+    })
+  // Server-rendered profile URL: the SPA shell with profile OG/Twitter meta injected for
+  // crawlers (which don't run JS). Humans get the SPA as usual (the meta is inert). Only
+  // public profile fields go into the head; an unclaimed handle serves the bare shell.
+  if (ctx.deps.shell || ctx.deps.shellFetch)
+    app.get("/u/:handle", async (c) => {
+      const shell = await getShell()
+      if (!shell) return c.notFound()
+      const card = await profileCardFor(c.req.param("handle"))
+      if (!card) return c.html(shell)
+      return c.html(
+        injectHead(
+          shell,
+          profileMetaTags({
+            username: card.username,
+            name: card.name,
+            description: profileSummary(card),
+            pageUrl: `${baseUrl}/u/${card.username}`,
+            imageUrl: `${baseUrl}/v1/og/u/${card.username}`,
+          }),
+        ),
+      )
     })
   // A copy-pasted share link with a trailing slash ("/a/slug-id/") would otherwise
   // 404; canonicalize it to the no-slash form.

--- a/apps/api/src/routes/follows.ts
+++ b/apps/api/src/routes/follows.ts
@@ -45,7 +45,21 @@ export const followRoutes = (ctx: AppContext) => {
     const me = await currentUser(c)
     if (!me) return fail(c, 401, "unauthenticated")
     const org = await activeWorkspace(c)
-    return c.json({ follows: await meta.listFollows(me.id, org) })
+    const follows = await meta.listFollows(me.id, org)
+    // Resolve each people-follow's target id → a public handle so the client can render
+    // it (and match follow-state by username) without ever holding a raw user id. One
+    // batched lookup; author/path follows pass through untouched.
+    const userIds = follows.filter((f) => f.kind === "user").map((f) => f.target)
+    const byId = new Map(
+      userIds.length ? (await meta.getUsers(userIds)).map((u) => [u.id, u] as const) : [],
+    )
+    return c.json({
+      follows: follows.map((f) => {
+        if (f.kind !== "user") return f
+        const u = byId.get(f.target)
+        return { ...f, handle: u?.username ?? null, name: u?.name ?? null, image: u?.image ?? null }
+      }),
+    })
   })
 
   app.post("/v1/follows", async (c) => {

--- a/apps/api/src/routes/follows.ts
+++ b/apps/api/src/routes/follows.ts
@@ -1,12 +1,13 @@
-import { type FollowKind, newId } from "@dock/core"
-import { Hono } from "hono"
+import { type FollowKind, GLOBAL_FOLLOW_ORG, newId, normalizeUsername } from "@dock/core"
+import { type Context, Hono } from "hono"
 import { z } from "zod"
 import type { AppContext } from "../context"
 import { fail, readJson } from "../lib/http"
 
-/** Follows (per-user: track GitHub authors + repo path prefixes). The followed set
- *  drives the `scope=following` activity feed in GET /v1/artifacts. Workspace-scoped
- *  to the caller's active workspace; all endpoints require a signed-in user. */
+/** Follows (per-user: GitHub authors, repo path prefixes, and people). The followed set
+ *  drives the `scope=following` activity feed in GET /v1/artifacts. Author/path follows
+ *  are scoped to the caller's active workspace; people (`user`) follows are global
+ *  (org_id = "*"). All endpoints require a signed-in user. */
 export const followRoutes = (ctx: AppContext) => {
   const { meta, currentUser, activeWorkspace } = ctx
   const app = new Hono()
@@ -17,9 +18,28 @@ export const followRoutes = (ctx: AppContext) => {
     kind === "author" ? target.trim().toLowerCase() : target.trim()
 
   const followBody = z.object({
-    kind: z.enum(["author", "path"]),
+    kind: z.enum(["author", "path", "user"]),
     target: z.string().min(1, "target is required"),
   })
+
+  // Resolve a follow request to its stored (target, org_id). For a person-follow the
+  // client sends a username; we resolve it to the user id (kept off the wire) and store
+  // it globally. Self-follow and unknown handles are rejected. Returns a Response on error.
+  const resolve = async (
+    c: Context,
+    me: { id: string },
+    b: { kind: FollowKind; target: string },
+  ): Promise<{ target: string; orgId: string; followedUserId?: string } | Response> => {
+    if (b.kind === "user") {
+      const profile = await meta.getUserByUsername(normalizeUsername(b.target))
+      if (!profile) return fail(c, 404, "no profile with that username")
+      if (profile.id === me.id) return fail(c, 400, "you can't follow yourself")
+      return { target: profile.id, orgId: GLOBAL_FOLLOW_ORG, followedUserId: profile.id }
+    }
+    const target = normalizeTarget(b.kind, b.target)
+    if (!target) return fail(c, 400, "target is required")
+    return { target, orgId: await activeWorkspace(c) }
+  }
 
   app.get("/v1/follows", async (c) => {
     const me = await currentUser(c)
@@ -33,16 +53,30 @@ export const followRoutes = (ctx: AppContext) => {
     if (!me) return fail(c, 401, "unauthenticated")
     const b = await readJson(c, followBody)
     if (b instanceof Response) return b
-    const target = normalizeTarget(b.kind, b.target)
-    if (!target) return fail(c, 400, "target is required")
-    const org = await activeWorkspace(c)
+    const r = await resolve(c, me, b)
+    if (r instanceof Response) return r
     const follow = await meta.addFollow({
       id: newId("fl"),
-      org_id: org,
+      org_id: r.orgId,
       user_id: me.id,
       kind: b.kind,
-      target,
+      target: r.target,
     })
+    // Tell the followed person someone followed them (no artifact anchor).
+    if (r.followedUserId && r.followedUserId !== me.id) {
+      await meta.createNotification({
+        id: newId("ntf"),
+        user_id: r.followedUserId,
+        actor: me.username ?? me.name ?? "Someone",
+        kind: "follow",
+        artifact_id: "",
+        artifact_short_id: "",
+        artifact_title: null,
+        thread_id: "",
+        comment_id: "",
+        preview: "started following you",
+      })
+    }
     return c.json({ follow }, 201)
   })
 
@@ -51,10 +85,9 @@ export const followRoutes = (ctx: AppContext) => {
     if (!me) return fail(c, 401, "unauthenticated")
     const b = await readJson(c, followBody)
     if (b instanceof Response) return b
-    const target = normalizeTarget(b.kind, b.target)
-    if (!target) return fail(c, 400, "target is required")
-    const org = await activeWorkspace(c)
-    await meta.removeFollow(me.id, org, b.kind, target)
+    const r = await resolve(c, me, b)
+    if (r instanceof Response) return r
+    await meta.removeFollow(me.id, r.orgId, b.kind, r.target)
     return c.body(null, 204)
   })
 

--- a/apps/api/src/routes/session.ts
+++ b/apps/api/src/routes/session.ts
@@ -1,7 +1,8 @@
-import { can, normalizeUsername, usernameError } from "@dock/core"
+import { can, normalizeUsername, toJson, usernameError } from "@dock/core"
 import { Hono } from "hono"
 import { z } from "zod"
 import type { AppContext } from "../context"
+import { authorProfile, resolveHandles } from "../lib/author"
 import { safeEqual } from "../lib/crypto"
 import { fail, IMMUTABLE_CACHE, readJson, toBody } from "../lib/http"
 import { MAX_AVATAR_BYTES, sniffImageType } from "../lib/image"
@@ -18,6 +19,7 @@ export const sessionRoutes = (ctx: AppContext) => {
     activeWorkspace,
     authorize,
     actorFor,
+    analyticsOn,
   } = ctx
   const app = new Hono()
 
@@ -101,12 +103,29 @@ export const sessionRoutes = (ctx: AppContext) => {
   })
 
   // A public profile by handle — the GitHub-style discovery surface. Email is
-  // intentionally omitted (private); the handle, name, and avatar are public, so
-  // this is readable by anyone (the GET passes the anon lockdown).
+  // intentionally omitted (private); the handle, name, avatar, stats, GitHub link, and
+  // (for a signed-in viewer) whether they already follow are public. Readable by anyone.
   app.get("/v1/users/:handle", async (c) => {
     const handle = normalizeUsername(c.req.param("handle"))
     const p = await meta.getUserByUsername(handle)
     if (!p) return fail(c, 404, "no profile with that username")
+    const me = await currentUser(c)
+    const ghIds = await meta.githubIdsForUser(p.id)
+    // A signed-in viewer also sees the owner's non-public work in workspaces they share.
+    const sharedOrgs = me ? await meta.sharedOrgIds(me.id, p.id) : []
+    const [works, followers, following, githubLogin] = await Promise.all([
+      meta.countUserWorks(p.id, ghIds, { visibleOrgIds: sharedOrgs }),
+      meta.countFollowers(p.id),
+      meta.countFollowing(p.id),
+      meta.githubLoginForUser(p.id, ghIds),
+    ])
+    // Already following? People-follows are global, so listFollows (which folds in the
+    // org "*" rows) carries them regardless of the viewer's active workspace.
+    let followedByMe = false
+    if (me && me.id !== p.id) {
+      const mine = await meta.listFollows(me.id, await activeWorkspace(c))
+      followedByMe = mine.some((f) => f.kind === "user" && f.target === p.id)
+    }
     return c.json({
       user: {
         username: p.username,
@@ -114,8 +133,75 @@ export const sessionRoutes = (ctx: AppContext) => {
         image: p.image,
         profession: p.profession ?? null,
         about: p.about ?? null,
+        github_login: githubLogin,
+        stats: { works, followers, following },
+        followed_by_me: followedByMe,
       },
     })
+  })
+
+  // A person's work — the artifacts they've authored (hand-published or via a linked
+  // GitHub commit), newest first, keyset-paginated (?cursor=<created_at>|<id>&limit=N).
+  // Visibility-gated IN SQL: an anonymous viewer sees only public work; a signed-in
+  // viewer also sees non-public work in workspaces they share with the owner. Safe to
+  // serve unauthenticated because the gate lives in the query, not the caller.
+  app.get("/v1/users/:handle/artifacts", async (c) => {
+    const p = await meta.getUserByUsername(normalizeUsername(c.req.param("handle")))
+    if (!p) return fail(c, 404, "no profile with that username")
+    const me = await currentUser(c)
+    const ghIds = await meta.githubIdsForUser(p.id)
+    const sharedOrgs = me ? await meta.sharedOrgIds(me.id, p.id) : []
+    const limit = Math.min(50, Math.max(1, Number(c.req.query("limit")) || 24))
+    const rawCursor = c.req.query("cursor")
+    const sep = rawCursor?.indexOf("|") ?? -1
+    const cursor =
+      rawCursor && sep > 0
+        ? { created_at: rawCursor.slice(0, sep), id: rawCursor.slice(sep + 1) }
+        : undefined
+    const rows = await meta.listUserWorks(p.id, ghIds, {
+      limit: limit + 1,
+      cursor,
+      visibleOrgIds: sharedOrgs,
+    })
+    const hasMore = rows.length > limit
+    const page = hasMore ? rows.slice(0, limit) : rows
+    const last = page[page.length - 1]
+    const next_cursor = hasMore && last ? `${last.created_at}|${last.id}` : null
+    const pageIds = page.map((a) => a.id)
+    const counts = analyticsOn ? await meta.viewCounts(pageIds) : {}
+    const tags = await meta.tagsForArtifacts(pageIds)
+    const handleByGhId = await resolveHandles(meta, [
+      ...new Set(page.map((a) => a.author_gh_id).filter((x): x is string => !!x)),
+    ])
+    return c.json({
+      artifacts: page.map((a) => ({
+        ...toJson(deps.baseUrl, a, []),
+        views: counts[a.id] ?? 0,
+        tags: tags[a.id] ?? [],
+        author: authorProfile(a, handleByGhId),
+      })),
+      next_cursor,
+    })
+  })
+
+  // The people who follow / are followed by this user, as public profiles (handle +
+  // name + avatar + role; never ids or email). Powers the profile's followers/following
+  // dialogs. The internal user id is stripped here so it never reaches a client.
+  const publicCard = (u: {
+    username: string
+    name: string | null
+    image: string | null
+    profession?: string | null
+  }) => ({ username: u.username, name: u.name, image: u.image, profession: u.profession ?? null })
+  app.get("/v1/users/:handle/followers", async (c) => {
+    const p = await meta.getUserByUsername(normalizeUsername(c.req.param("handle")))
+    if (!p) return fail(c, 404, "no profile with that username")
+    return c.json({ users: (await meta.listFollowers(p.id, 100)).map(publicCard) })
+  })
+  app.get("/v1/users/:handle/following", async (c) => {
+    const p = await meta.getUserByUsername(normalizeUsername(c.req.param("handle")))
+    if (!p) return fail(c, 404, "no profile with that username")
+    return c.json({ users: (await meta.listFollowing(p.id, 100)).map(publicCard) })
   })
 
   // Upload your profile picture. We take only raster images (identified by their

--- a/apps/api/test/embeds.test.ts
+++ b/apps/api/test/embeds.test.ts
@@ -1,8 +1,9 @@
 import { join } from "node:path"
+import { newId } from "@dock/core"
 import { FsBlobStore } from "@dock/storage/fs"
 import { describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
-import { anonApp, app, dir, meta, upload } from "./helpers"
+import { anonApp, app, dir, makeAuthedApp, meta, type TestUser, upload } from "./helpers"
 
 const idOf = async (res: Response): Promise<string> => (await res.json()).short_id
 const SHELL =
@@ -147,5 +148,84 @@ describe("unfurl + embed", () => {
     const html = await res.text()
     expect(html).not.toContain("og:title")
     expect(html).not.toContain("Private Page")
+  })
+})
+
+describe("profile unfurl (/u/:handle)", () => {
+  const nia: TestUser = {
+    id: "u_og_nia",
+    email: "ognia@d.test",
+    name: "Nia Okoye",
+    username: "niao",
+  }
+  const { app: authed, meta: m } = makeAuthedApp("og-profile", [nia])
+
+  // One public artifact authored by Nia, so the card/stats show "1 work".
+  const seedWork = async () => {
+    const art = await m.createArtifact({
+      id: newId("a"),
+      short_id: newId("s"),
+      org_id: "default",
+      slug: null,
+      title: "Nia's doc",
+      visibility: "public",
+      kind: "file",
+      spa: 0,
+    })
+    await m.addVersion(art.id, {
+      id: newId("v"),
+      blob_key: `blob_${newId("b")}`,
+      content_type: "text/markdown",
+      size_bytes: 1,
+      author: "Nia Okoye",
+      author_id: nia.id,
+      message: null,
+    })
+  }
+
+  it("renders the profile OG card SVG (name + work count)", async () => {
+    await seedWork()
+    const res = await authed.request("/v1/og/u/niao")
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toContain("image/svg+xml")
+    const svg = await res.text()
+    expect(svg).toContain("<svg")
+    expect(svg).toContain("Nia Okoye")
+    expect(svg).toContain("@niao")
+    expect(svg).toContain("1 work")
+  })
+
+  it("injects profile OG meta into the /u/:handle shell for crawlers", async () => {
+    const a = createApp({
+      meta: m,
+      blobs: new FsBlobStore(join(dir, "blobs-og-profile-shell")),
+      baseUrl: "http://dock.test",
+      token: "tok",
+      auth: undefined,
+      shell: SHELL,
+      defaultOrgId: "default",
+    })
+    const res = await a.request("/u/niao")
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain('property="og:type" content="profile"')
+    expect(html).toContain("Nia Okoye (@niao)")
+    expect(html).toContain("/v1/og/u/niao")
+    expect(html).toContain("id=root") // still the SPA shell for humans
+  })
+
+  it("serves a generic card + bare shell for an unclaimed handle (no leak)", async () => {
+    const svg = await (await app.request("/v1/og/u/ghosthandle")).text()
+    expect(svg).toContain("<svg")
+    const a = createApp({
+      meta,
+      blobs: new FsBlobStore(join(dir, "blobs-og-profile-ghost")),
+      baseUrl: "http://dock.test",
+      token: "tok",
+      shell: SHELL,
+    })
+    const html = await (await a.request("/u/ghosthandle")).text()
+    expect(html).not.toContain("og:type")
+    expect(html).toContain("id=root")
   })
 })

--- a/apps/api/test/follows.test.ts
+++ b/apps/api/test/follows.test.ts
@@ -170,6 +170,12 @@ describe("people follow", () => {
     const ids = (await feed.json()).artifacts.map((a: { short_id: string }) => a.short_id)
     expect(ids).toContain(amyWork)
 
+    // GET /v1/follows resolves the people-follow's target id back to a handle (so the
+    // client renders @amy + matches follow-state by username — never a raw id).
+    const bobFollows = await (await app.request("/v1/follows", { headers: as(bob.email) })).json()
+    const userFollow = bobFollows.follows.find((f: { kind: string }) => f.kind === "user")
+    expect(userFollow).toMatchObject({ kind: "user", target: amy.id, handle: "amy", name: "Amy" })
+
     // The profile reflects it: amy has 1 follower; bob (the viewer) follows her.
     const amyProfile = await (await app.request("/v1/users/amy", { headers: as(bob.email) })).json()
     expect(amyProfile.user.stats.followers).toBe(1)

--- a/apps/api/test/follows.test.ts
+++ b/apps/api/test/follows.test.ts
@@ -122,3 +122,72 @@ describe("follows route", () => {
     expect((await bobFeed.json()).artifacts).toEqual([])
   })
 })
+
+// People-follow: bob follows Amy by handle, her hand-published (author_id) public work
+// flows into his feed, and the profile reflects follower/following + followed_by_me.
+describe("people follow", () => {
+  // Publish a PUBLIC artifact authored by a Dock user (stamps author_id), via the store.
+  const publishByUser = async (title: string, userId: string): Promise<string> => {
+    const a = await meta.createArtifact({
+      id: newId("a"),
+      short_id: newId("s"),
+      org_id: "default",
+      slug: null,
+      title,
+      visibility: "public",
+      kind: "file",
+      spa: 0,
+    })
+    await meta.addVersion(a.id, {
+      id: newId("v"),
+      blob_key: `blob_${newId("b")}`,
+      content_type: "text/markdown",
+      size_bytes: 1,
+      author: "Amy",
+      author_id: userId,
+      message: null,
+    })
+    return a.short_id
+  }
+
+  it("rejects self-follow (400) and an unknown handle (404)", async () => {
+    expect((await post(as(amy.email), { kind: "user", target: "amy" })).status).toBe(400)
+    expect((await post(as(amy.email), { kind: "user", target: "ghost" })).status).toBe(404)
+  })
+
+  it("follows a person by handle; their public work enters the follower's feed", async () => {
+    const amyWork = await publishByUser("Amy's plan", amy.id)
+
+    // bob follows amy (by username; stored as her id, globally).
+    const r = await post(as(bob.email), { kind: "user", target: "Amy" })
+    expect(r.status).toBe(201)
+    expect((await r.json()).follow).toMatchObject({ kind: "user", target: amy.id, org_id: "*" })
+
+    // Amy's public work now shows in bob's activity feed.
+    const feed = await app.request("/v1/artifacts?scope=following&limit=100", {
+      headers: as(bob.email),
+    })
+    const ids = (await feed.json()).artifacts.map((a: { short_id: string }) => a.short_id)
+    expect(ids).toContain(amyWork)
+
+    // The profile reflects it: amy has 1 follower; bob (the viewer) follows her.
+    const amyProfile = await (await app.request("/v1/users/amy", { headers: as(bob.email) })).json()
+    expect(amyProfile.user.stats.followers).toBe(1)
+    expect(amyProfile.user.followed_by_me).toBe(true)
+
+    // amy sees a "follow" notification from bob (by his handle).
+    const notifs = await (await app.request("/v1/notifications", { headers: as(amy.email) })).json()
+    expect(notifs.notifications[0]).toMatchObject({ kind: "follow", actor: "bob" })
+
+    // Unfollow removes it (and the follower count drops back).
+    const del = await app.request("/v1/follows", {
+      method: "DELETE",
+      headers: { "content-type": "application/json", ...as(bob.email) },
+      body: JSON.stringify({ kind: "user", target: "amy" }),
+    })
+    expect(del.status).toBe(204)
+    const after = await (await app.request("/v1/users/amy", { headers: as(bob.email) })).json()
+    expect(after.user.stats.followers).toBe(0)
+    expect(after.user.followed_by_me).toBe(false)
+  })
+})

--- a/apps/api/test/follows.test.ts
+++ b/apps/api/test/follows.test.ts
@@ -126,15 +126,22 @@ describe("follows route", () => {
 // People-follow: bob follows Amy by handle, her hand-published (author_id) public work
 // flows into his feed, and the profile reflects follower/following + followed_by_me.
 describe("people follow", () => {
-  // Publish a PUBLIC artifact authored by a Dock user (stamps author_id), via the store.
-  const publishByUser = async (title: string, userId: string): Promise<string> => {
+  // Publish an artifact authored by a Dock user (stamps author_id), via the store. `org`
+  // defaults to amy's OWN workspace (not bob's active "default"), so the feed assertions
+  // exercise the cross-workspace people-follow path — the real-world case.
+  const publishByUser = async (
+    title: string,
+    userId: string,
+    visibility: "public" | "link" = "public",
+    org = "amy_ws",
+  ): Promise<string> => {
     const a = await meta.createArtifact({
       id: newId("a"),
       short_id: newId("s"),
-      org_id: "default",
+      org_id: org,
       slug: null,
       title,
-      visibility: "public",
+      visibility,
       kind: "file",
       spa: 0,
     })
@@ -155,20 +162,24 @@ describe("people follow", () => {
     expect((await post(as(amy.email), { kind: "user", target: "ghost" })).status).toBe(404)
   })
 
-  it("follows a person by handle; their public work enters the follower's feed", async () => {
-    const amyWork = await publishByUser("Amy's plan", amy.id)
+  it("follows a person; their public work flows into the feed across workspaces, private stays hidden", async () => {
+    // Amy publishes in HER OWN workspace ("amy_ws") — NOT bob's active "default".
+    const amyPublic = await publishByUser("Amy's plan", amy.id, "public")
+    const amyPrivate = await publishByUser("Amy's secret", amy.id, "link")
 
     // bob follows amy (by username; stored as her id, globally).
     const r = await post(as(bob.email), { kind: "user", target: "Amy" })
     expect(r.status).toBe(201)
     expect((await r.json()).follow).toMatchObject({ kind: "user", target: amy.id, org_id: "*" })
 
-    // Amy's public work now shows in bob's activity feed.
+    // Amy's PUBLIC work shows in bob's feed even though it lives in another workspace;
+    // her private (link) work never leaks. (Bob's active workspace is "default".)
     const feed = await app.request("/v1/artifacts?scope=following&limit=100", {
       headers: as(bob.email),
     })
     const ids = (await feed.json()).artifacts.map((a: { short_id: string }) => a.short_id)
-    expect(ids).toContain(amyWork)
+    expect(ids).toContain(amyPublic) // cross-workspace public work surfaces
+    expect(ids).not.toContain(amyPrivate) // private work stays hidden
 
     // GET /v1/follows resolves the people-follow's target id back to a handle (so the
     // client renders @amy + matches follow-state by username — never a raw id).

--- a/apps/api/test/profiles.test.ts
+++ b/apps/api/test/profiles.test.ts
@@ -1,3 +1,4 @@
+import { newId } from "@dock/core"
 import { describe, expect, it } from "vitest"
 import { as, jsonAs, makeAuthedApp, type TestUser } from "./helpers"
 
@@ -27,6 +28,10 @@ describe("usernames + public profiles", () => {
       image: "x.png",
       profession: null,
       about: null,
+      // Enriched profile: GitHub link (none here), stats, and viewer follow state.
+      github_login: null,
+      stats: { works: 0, followers: 0, following: 0 },
+      followed_by_me: false,
     })
     expect(user).not.toHaveProperty("email")
 
@@ -191,6 +196,84 @@ describe("profile avatars", () => {
     const fd = new FormData()
     fd.append("file", new Blob([PNG as BlobPart], { type: "image/png" }), "x.png")
     expect((await app.request("/v1/me/avatar", { method: "POST", body: fd })).status).toBe(403)
+  })
+})
+
+describe("profile work-list (visibility-scoped)", () => {
+  const amy: TestUser = { id: "u_pw_amy", email: "pwamy@d.test", name: "Amy W", username: "amyw" }
+  const carl: TestUser = {
+    id: "u_pw_carl",
+    email: "pwcarl@d.test",
+    name: "Carl",
+    username: "carlw",
+  }
+  // amy + carl share the "default" workspace (amy owner, carl editor).
+  const { app, meta } = makeAuthedApp("profile-works", [amy, carl])
+
+  // A hand-published artifact authored by `userId` (stamps author_id), at a visibility.
+  const work = async (title: string, userId: string, visibility: "public" | "link") => {
+    const a = await meta.createArtifact({
+      id: newId("a"),
+      short_id: newId("s"),
+      org_id: "default",
+      slug: null,
+      title,
+      visibility,
+      kind: "file",
+      spa: 0,
+    })
+    await meta.addVersion(a.id, {
+      id: newId("v"),
+      blob_key: `blob_${newId("b")}`,
+      content_type: "text/markdown",
+      size_bytes: 1,
+      author: "Amy W",
+      author_id: userId,
+      message: null,
+    })
+    return a.short_id
+  }
+
+  it("shows public work to anyone; non-public only to a shared-workspace viewer", async () => {
+    const pub = await work("Amy public", amy.id, "public")
+    const priv = await work("Amy link-only", amy.id, "link")
+
+    // Anonymous viewer: public work only (the link-only title never leaks).
+    const anon = await (await app.request("/v1/users/amyw/artifacts")).json()
+    const anonIds = anon.artifacts.map((a: { short_id: string }) => a.short_id)
+    expect(anonIds).toContain(pub)
+    expect(anonIds).not.toContain(priv)
+
+    // Carl shares the workspace with amy → he also sees the link-only work.
+    const shared = await (
+      await app.request("/v1/users/amyw/artifacts", { headers: as(carl.email) })
+    ).json()
+    const sharedIds = shared.artifacts.map((a: { short_id: string }) => a.short_id)
+    expect(sharedIds).toContain(pub)
+    expect(sharedIds).toContain(priv)
+
+    // Stats track the same gate: 1 public work for anon, 2 for the shared viewer.
+    const anonProfile = await (await app.request("/v1/users/amyw")).json()
+    expect(anonProfile.user.stats.works).toBe(1)
+    const carlProfile = await (
+      await app.request("/v1/users/amyw", { headers: as(carl.email) })
+    ).json()
+    expect(carlProfile.user.stats.works).toBe(2)
+  })
+
+  it("exposes follower/following lists as public profiles (no ids/email)", async () => {
+    // carl follows amy.
+    await app.request("/v1/follows", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...as(carl.email) },
+      body: JSON.stringify({ kind: "user", target: "amyw" }),
+    })
+    const followers = await (await app.request("/v1/users/amyw/followers")).json()
+    expect(followers.users.map((u: { username: string }) => u.username)).toContain("carlw")
+    expect(followers.users[0]).not.toHaveProperty("email")
+    expect(followers.users[0]).not.toHaveProperty("id")
+    const following = await (await app.request("/v1/users/carlw/following")).json()
+    expect(following.users.map((u: { username: string }) => u.username)).toContain("amyw")
   })
 })
 

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -100,15 +100,16 @@ crons = ["* * * * *"]
 # the API (no CORS, first-party cookies). Prepare the build first:
 # `pnpm --filter @dock/api build:web` (builds apps/web and preps dist/client for Workers:
 # _shell.html -> index.html, drops the Pages _redirects).
-# The API/data paths run the Worker first; so does /a/* — the share URL, where the
-# Worker serves the SPA shell with per-artifact OG/unfurl meta injected for crawlers
-# (it reads the shell via the ASSETS binding). Every other path serves a static asset,
+# The API/data paths run the Worker first; so do /a/* and /u/* — the share + profile
+# URLs, where the Worker serves the SPA shell with per-artifact / per-profile OG/unfurl
+# meta injected for crawlers (it reads the shell via the ASSETS binding). Every other
+# path serves a static asset,
 # and non-asset routes fall back to the SPA shell (index.html) so the client router
 # owns the page. The SPA is the one and only frontend (no server-rendered viewer).
 [assets]
 directory = "../web/dist/client"
 binding = "ASSETS"
-run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/oauth/*", "/settings/github/*", "/a/*", "/healthz", "/mcp", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource", "/.well-known/openid-configuration"]
+run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/oauth/*", "/settings/github/*", "/a/*", "/u/*", "/healthz", "/mcp", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource", "/.well-known/openid-configuration"]
 not_found_handling = "single-page-application"
 
 # baseUrl falls back to the request origin when unset. Secured by Better Auth; set

--- a/apps/web/e2e/smoke/profile.smoke.spec.ts
+++ b/apps/web/e2e/smoke/profile.smoke.spec.ts
@@ -1,0 +1,56 @@
+import { Buffer } from "node:buffer"
+import { expect, test } from "../fixtures"
+
+// The people layer end-to-end: an author's public work shows on their profile, a second
+// person (in their OWN workspace) can follow them, and that follow flows the author's
+// public work into the follower's activity feed — across workspaces. This is the path
+// the cross-workspace feed bug lived on, so it's a smoke-level regression guard.
+test("follow a person → their public work shows on the profile and in the follower's feed", async ({
+  owner,
+  secondUser,
+}) => {
+  const bob = secondUser.page
+
+  // Maya (owner) — read her auto-assigned handle and publish a PUBLIC artifact.
+  const maya = (await (await owner.request.get("/v1/me")).json()).user as { username: string }
+  const published = await owner.request.post("/v1/artifacts", {
+    multipart: {
+      file: { name: "q3-plan.md", mimeType: "text/markdown", buffer: Buffer.from("# Q3 Plan") },
+      title: "Q3 Plan",
+      visibility: "public",
+    },
+  })
+  expect(published.ok()).toBeTruthy()
+  const shortId = ((await published.json()) as { short_id: string }).short_id
+
+  // Bob visits Maya's profile (he's in a different workspace) — her public work is listed.
+  await bob.goto(`/u/${maya.username}`)
+  await expect(bob.getByTestId("profile-card")).toBeVisible()
+  await expect(bob.getByTestId(`profile-work-${shortId}`)).toBeVisible()
+
+  // Follow her — the button flips to the followed state and the follower count ticks up.
+  const followBtn = bob.getByTestId(`follow-${maya.username}`)
+  await expect(followBtn).toHaveAttribute("aria-pressed", "false")
+  await followBtn.click()
+  await expect(followBtn).toHaveAttribute("aria-pressed", "true")
+  await expect(bob.getByTestId("profile-stat-followers")).toContainText("1")
+
+  // Her public work now appears in Bob's Following feed — even though it lives in Maya's
+  // workspace, not Bob's (the cross-workspace people-follow path).
+  await bob.goto("/?scope=following")
+  await expect(bob.getByTestId(`artifact-card-open-${shortId}`)).toBeVisible()
+
+  // The follow persists across a reload (it's server state, not just local).
+  await bob.goto(`/u/${maya.username}`)
+  await expect(bob.getByTestId(`follow-${maya.username}`)).toHaveAttribute("aria-pressed", "true")
+})
+
+// A person can't follow themselves: the Follow button never renders on your own profile.
+test("the Follow button is absent on your own profile", async ({ owner }) => {
+  const me = (await (await owner.request.get("/v1/me")).json()).user as { username: string }
+  await owner.goto(`/u/${me.username}`)
+  await expect(owner.getByTestId("profile-card")).toBeVisible()
+  await expect(owner.getByTestId(`follow-${me.username}`)).toHaveCount(0)
+  // …but you can edit your own handle from there.
+  await expect(owner.getByTestId("profile-edit")).toBeVisible()
+})

--- a/apps/web/e2e/smoke/profile.smoke.spec.ts
+++ b/apps/web/e2e/smoke/profile.smoke.spec.ts
@@ -45,6 +45,29 @@ test("follow a person → their public work shows on the profile and in the foll
   await expect(bob.getByTestId(`follow-${maya.username}`)).toHaveAttribute("aria-pressed", "true")
 })
 
+// Ambient follow: you can follow a person straight from the command-palette people
+// search, without going to their profile first.
+test("follow a person from the command-palette people search", async ({ owner, secondUser }) => {
+  const bob = secondUser.page
+  const maya = (await (await owner.request.get("/v1/me")).json()).user as { username: string }
+
+  await bob.goto("/")
+  await bob.getByTestId("open-command-palette").click()
+  // Owner's display name is "E2E Tester" (secondUser is "Second User"), so "Tester"
+  // resolves to exactly one discoverable person.
+  await bob.getByPlaceholder(/Search artifacts, people/).fill("Tester")
+
+  const followBtn = bob.getByTestId(`follow-${maya.username}`)
+  await expect(followBtn).toBeVisible()
+  await expect(followBtn).toHaveAttribute("aria-pressed", "false")
+  await followBtn.click()
+  await expect(followBtn).toHaveAttribute("aria-pressed", "true")
+
+  // And the follow really landed: it shows on the person's profile.
+  await bob.goto(`/u/${maya.username}`)
+  await expect(bob.getByTestId(`follow-${maya.username}`)).toHaveAttribute("aria-pressed", "true")
+})
+
 // A person can't follow themselves: the Follow button never renders on your own profile.
 test("the Follow button is absent on your own profile", async ({ owner }) => {
   const me = (await (await owner.request.get("/v1/me")).json()).user as { username: string }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -23,6 +23,12 @@ export interface PublicProfile {
   profession?: string | null
   /** One-line "what you do" blurb; only present on the full /u/:handle profile. */
   about?: string | null
+  /** GitHub login, when known (the full /u/:handle profile only); null otherwise. */
+  github_login?: string | null
+  /** Work / follower / following counts (the full /u/:handle profile only). */
+  stats?: { works: number; followers: number; following: number }
+  /** Whether the signed-in viewer already follows this person (full profile only). */
+  followed_by_me?: boolean
 }
 export interface VersionSession {
   n: number
@@ -123,9 +129,10 @@ export interface Collection {
   created_at: string
   count: number
 }
-export type FollowKind = "author" | "path"
-/** A per-user follow: a GitHub author (kind="author", target=login) or a repo path
- *  prefix (kind="path", target=path prefix). Drives the `scope=following` feed. */
+export type FollowKind = "author" | "path" | "user"
+/** A per-user follow: a GitHub author (kind="author", target=login), a repo path
+ *  prefix (kind="path", target=path prefix), or a person (kind="user", target=username
+ *  on the wire). Drives the `scope=following` feed. */
 export interface Follow {
   id: string
   org_id: string
@@ -247,8 +254,9 @@ export interface DirUser {
 export interface Notification {
   id: string
   user_id: string
+  /** Who triggered it. For `follow`/`publish` this is the person's @handle. */
   actor: string
-  kind: "mention" | "comment" | "share"
+  kind: "mention" | "comment" | "share" | "follow" | "publish"
   artifact_id: string
   artifact_short_id: string
   artifact_title: string | null
@@ -462,9 +470,30 @@ export const api = {
   // bad shape — both surface their message via ApiError.
   setUsername: (username: string): Promise<{ username: string }> =>
     f("/v1/me/username", opts({ username })).then(j),
-  // A public profile by handle (no email). Readable without a session.
+  // A public profile by handle (no email). Readable without a session; for a signed-in
+  // viewer it also carries stats + followed_by_me.
   profile: (handle: string): Promise<{ user: PublicProfile }> =>
     f(`/v1/users/${encodeURIComponent(handle)}`, { credentials: "include" }).then(j),
+  // A person's work — public artifacts they authored, plus shared-workspace work for a
+  // signed-in viewer. Keyset-paginated; readable without a session.
+  profileArtifacts: (
+    handle: string,
+    cursor?: string,
+    limit?: number,
+  ): Promise<{ artifacts: Artifact[]; next_cursor: string | null }> => {
+    const qs = new URLSearchParams()
+    if (cursor) qs.set("cursor", cursor)
+    if (limit) qs.set("limit", String(limit))
+    const s = qs.toString()
+    return f(`/v1/users/${encodeURIComponent(handle)}/artifacts${s ? `?${s}` : ""}`, {
+      credentials: "include",
+    }).then(j)
+  },
+  // People who follow / are followed by this user (public profiles; no ids or email).
+  profileFollowers: (handle: string): Promise<{ users: PublicProfile[] }> =>
+    f(`/v1/users/${encodeURIComponent(handle)}/followers`, { credentials: "include" }).then(j),
+  profileFollowing: (handle: string): Promise<{ users: PublicProfile[] }> =>
+    f(`/v1/users/${encodeURIComponent(handle)}/following`, { credentials: "include" }).then(j),
   // Set your team role + "what you do" blurb (onboarding + Settings → Profile).
   // Omitted fields are left untouched; "" clears a field.
   setProfile: (fields: {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -138,8 +138,14 @@ export interface Follow {
   org_id: string
   user_id: string
   kind: FollowKind
+  /** For author/path: the login / path prefix. For user: the followed person's id. */
   target: string
   created_at: string
+  /** Present for kind="user": the followed person's public handle/name/avatar, resolved
+   *  server-side so the client renders them (and matches follow-state) without raw ids. */
+  handle?: string | null
+  name?: string | null
+  image?: string | null
 }
 export type ProposalState = "open" | "approved" | "changes_requested" | "withdrawn"
 export interface Proposal {

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "@tanstack/react-router"
 import { useCallback, useEffect, useState } from "react"
 import { type Artifact, api, type PublicProfile } from "@/api"
+import { FollowButton } from "@/components/follow-button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import {
   Command,
@@ -165,6 +166,8 @@ export function CommandPalette() {
                   </Avatar>
                   <span className="flex-1 truncate">{u.name ?? u.username}</span>
                   <span className="font-mono text-2xs text-muted-foreground">@{u.username}</span>
+                  {/* Follow without leaving the palette (self-hides for your own handle). */}
+                  <FollowButton username={u.username} size="xs" />
                 </CommandItem>
               ))}
             </CommandGroup>

--- a/apps/web/src/components/follow-button.tsx
+++ b/apps/web/src/components/follow-button.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react"
+import { Icon } from "@/components/icons"
+import { Button } from "@/components/ui/button"
+import { useFollows } from "@/lib/use-follows"
+import { cn } from "@/lib/utils"
+
+// Follow / Following toggle for a person. State comes from the profile's
+// `followed_by_me` (people-follows store a user id, so the follows list can't map a
+// username to state); the toggle add/removes by username and invalidates the profile
+// so the count + button stay live. Render only for a signed-in viewer on someone
+// else's profile — the parent decides that.
+export function FollowButton({
+  username,
+  isFollowing,
+  className,
+}: {
+  username: string
+  isFollowing: boolean
+  className?: string
+}) {
+  const { toggleUser, pendingFollow } = useFollows()
+  const [hover, setHover] = useState(false)
+
+  // Following: a quiet outline that flips to a destructive "Unfollow" on hover.
+  if (isFollowing) {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={pendingFollow}
+        data-testid="follow-button"
+        aria-pressed
+        onMouseEnter={() => setHover(true)}
+        onMouseLeave={() => setHover(false)}
+        onClick={() => toggleUser(username, true)}
+        className={cn(hover && "border-destructive/40 text-destructive", className)}
+      >
+        <Icon name={hover ? "close" : "check"} size={14} />
+        {hover ? "Unfollow" : "Following"}
+      </Button>
+    )
+  }
+  return (
+    <Button
+      size="sm"
+      disabled={pendingFollow}
+      data-testid="follow-button"
+      aria-pressed={false}
+      onClick={() => toggleUser(username, false)}
+      className={className}
+    >
+      <Icon name="plus" size={14} />
+      Follow
+    </Button>
+  )
+}

--- a/apps/web/src/components/follow-button.tsx
+++ b/apps/web/src/components/follow-button.tsx
@@ -1,41 +1,54 @@
-import { useState } from "react"
+import { type MouseEvent, useState } from "react"
 import { Icon } from "@/components/icons"
 import { Button } from "@/components/ui/button"
+import { useAuth } from "@/ctx"
 import { useFollows } from "@/lib/use-follows"
 import { cn } from "@/lib/utils"
 
-// Follow / Following toggle for a person. State comes from the profile's
-// `followed_by_me` (people-follows store a user id, so the follows list can't map a
-// username to state); the toggle add/removes by username and invalidates the profile
-// so the count + button stay live. Render only for a signed-in viewer on someone
-// else's profile — the parent decides that.
+// A self-contained Follow / Following toggle for a person, keyed by @handle. Drop it in
+// anywhere an author appears — it reads the signed-in viewer + the live follows set, and
+// renders NOTHING when it doesn't apply (signed-out, or your own handle). Follow-state
+// and the toggle both come from useFollows, so every instance stays in sync. Clicks
+// stopPropagation so it works inside a card/link/command-item without triggering it.
 export function FollowButton({
   username,
-  isFollowing,
+  size = "sm",
   className,
 }: {
   username: string
-  isFollowing: boolean
+  size?: "sm" | "xs"
   className?: string
 }) {
-  const { toggleUser, pendingFollow } = useFollows()
+  const { me } = useAuth()
+  const { isFollowingUser, toggleUser, pendingFollow } = useFollows()
   const [hover, setHover] = useState(false)
 
-  // Following: a quiet outline that flips to a destructive "Unfollow" on hover.
-  if (isFollowing) {
+  // Nothing to do for a signed-out viewer or on your own profile.
+  if (!me || me.username?.toLowerCase() === username.toLowerCase()) return null
+
+  const following = isFollowingUser(username)
+  const xs = size === "xs"
+  const sizing = xs ? "h-6 gap-1 px-2 text-2xs" : ""
+  const onClick = (e: MouseEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
+    toggleUser(username)
+  }
+
+  if (following) {
     return (
       <Button
         variant="outline"
         size="sm"
         disabled={pendingFollow}
-        data-testid="follow-button"
+        data-testid={`follow-${username}`}
         aria-pressed
         onMouseEnter={() => setHover(true)}
         onMouseLeave={() => setHover(false)}
-        onClick={() => toggleUser(username, true)}
-        className={cn(hover && "border-destructive/40 text-destructive", className)}
+        onClick={onClick}
+        className={cn(sizing, hover && "border-destructive/40 text-destructive", className)}
       >
-        <Icon name={hover ? "close" : "check"} size={14} />
+        <Icon name={hover ? "close" : "check"} size={xs ? 12 : 14} />
         {hover ? "Unfollow" : "Following"}
       </Button>
     )
@@ -44,12 +57,12 @@ export function FollowButton({
     <Button
       size="sm"
       disabled={pendingFollow}
-      data-testid="follow-button"
+      data-testid={`follow-${username}`}
       aria-pressed={false}
-      onClick={() => toggleUser(username, false)}
-      className={className}
+      onClick={onClick}
+      className={cn(sizing, className)}
     >
-      <Icon name="plus" size={14} />
+      <Icon name="plus" size={xs ? 12 : 14} />
       Follow
     </Button>
   )

--- a/apps/web/src/components/notification-bell.tsx
+++ b/apps/web/src/components/notification-bell.tsx
@@ -55,10 +55,15 @@ export function NotificationBell({ collapsed }: { collapsed?: boolean }) {
         .then((r) => setUnread(r.unread))
         .catch(() => {})
     }
+    // A follow notification has no artifact — open the follower's profile instead.
+    if (n.kind === "follow") {
+      nav({ to: "/u/$handle", params: { handle: n.actor } })
+      return
+    }
     nav({
       to: "/a/$ref",
       params: { ref: refFor({ short_id: n.artifact_short_id, title: n.artifact_title }) },
-      // A share notification has no thread; open the artifact itself.
+      // A share/publish notification has no thread; open the artifact itself.
       search: n.thread_id ? { c: n.thread_id } : {},
     })
   }
@@ -136,7 +141,14 @@ export function NotificationBell({ collapsed }: { collapsed?: boolean }) {
                 <span className="min-w-0 flex-1">
                   <span className="block text-sm text-foreground">
                     <strong>{n.actor}</strong>{" "}
-                    {n.kind === "share" ? (
+                    {n.kind === "follow" ? (
+                      "started following you"
+                    ) : n.kind === "publish" ? (
+                      <>
+                        published{" "}
+                        {n.artifact_title ? <strong>{n.artifact_title}</strong> : "an update"}
+                      </>
+                    ) : n.kind === "share" ? (
                       <>
                         shared{" "}
                         {n.artifact_title ? <strong>{n.artifact_title}</strong> : "an artifact"}
@@ -154,9 +166,13 @@ export function NotificationBell({ collapsed }: { collapsed?: boolean }) {
                       </>
                     )}
                   </span>
-                  <span className="my-px block truncate text-xs text-muted-foreground">
-                    {n.preview}
-                  </span>
+                  {/* The preview is a snippet for mention/comment; for follow/publish the
+                      main line already says it all, so skip the duplicate. */}
+                  {(n.kind === "mention" || n.kind === "comment") && (
+                    <span className="my-px block truncate text-xs text-muted-foreground">
+                      {n.preview}
+                    </span>
+                  )}
                   <span className="block font-mono text-2xs text-muted-foreground">
                     {ago(n.created_at)}
                   </span>

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -52,6 +52,27 @@ export const followsQuery = () =>
     queryFn: () => api.listFollows().then((r) => r.follows),
   })
 
+// A public profile by handle — identity card + stats + (for a signed-in viewer)
+// followed_by_me. Keyed by handle; invalidated on any follow change so the stats +
+// Follow button stay live. retry:false so a 404 (no such handle) renders immediately.
+export const profileQuery = (handle: string) =>
+  queryOptions({
+    queryKey: ["profile", handle] as const,
+    queryFn: () => api.profile(handle).then((r) => r.user),
+    retry: false,
+  })
+
+// A person's work as an infinite query — public artifacts they authored, plus
+// shared-workspace work for a signed-in viewer. Keyset cursor drives infinite scroll.
+const PROFILE_PAGE = 24
+export const profileArtifactsQuery = (handle: string) =>
+  infiniteQueryOptions({
+    queryKey: ["profile-artifacts", handle] as const,
+    queryFn: ({ pageParam }) => api.profileArtifacts(handle, pageParam || undefined, PROFILE_PAGE),
+    initialPageParam: "",
+    getNextPageParam: (last) => last.next_cursor ?? undefined,
+  })
+
 // Typed query options shared by route loaders (ensureQueryData, for intent
 // preloading) and components (useQuery). One source of truth for keys +
 // fetchers, so a preloaded route and the page that renders it resolve to the

--- a/apps/web/src/lib/use-follows.ts
+++ b/apps/web/src/lib/use-follows.ts
@@ -28,12 +28,19 @@ export function useFollows() {
     const paths = new Set<string>()
     for (const fol of follows) {
       if (fol.kind === "author") authors.add(fol.target)
-      else paths.add(fol.target)
+      else if (fol.kind === "path") paths.add(fol.target)
+      // `user` follows store a user id (not a username) and drive `followed_by_me` on
+      // the profile response instead — they aren't keyed here.
     }
     return { authors, paths }
   }, [follows])
 
-  const invalidate = () => qc.invalidateQueries({ queryKey: followsQuery().queryKey })
+  // A follow change shifts both the manage strip (follows) and any open profile (its
+  // stats + followed_by_me), so refresh both.
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: followsQuery().queryKey })
+    qc.invalidateQueries({ queryKey: ["profile"] })
+  }
 
   const add = useMutation({
     mutationFn: ({ kind, target }: { kind: FollowKind; target: string }) =>
@@ -64,6 +71,14 @@ export function useFollows() {
       if (paths.has(target)) remove.mutate({ kind: "path", target })
       else add.mutate({ kind: "path", target })
     },
+    // Flip the follow state for a person. The current state comes from the profile's
+    // `followed_by_me` (people-follows store a user id, not the username we send here).
+    toggleUser: (username: string, isFollowing: boolean) => {
+      if (isFollowing) remove.mutate({ kind: "user", target: username })
+      else add.mutate({ kind: "user", target: username })
+    },
+    // True while a follow mutation is in flight (disable the button).
+    pendingFollow: add.isPending || remove.isPending,
     // Drop a follow directly (the manage strip's × buttons).
     unfollow: (kind: FollowKind, target: string) => remove.mutate({ kind, target }),
   }

--- a/apps/web/src/lib/use-follows.ts
+++ b/apps/web/src/lib/use-follows.ts
@@ -23,16 +23,18 @@ export function useFollows() {
   const qc = useQueryClient()
   const { data: follows = [] } = useQuery(followsQuery())
 
-  const { authors, paths } = useMemo(() => {
+  const { authors, paths, users } = useMemo(() => {
     const authors = new Set<string>()
     const paths = new Set<string>()
+    // People-follows store a user id in `target`, but the API resolves `handle` for them,
+    // so we key follow-state by the (lowercased) username — what every Follow button has.
+    const users = new Set<string>()
     for (const fol of follows) {
       if (fol.kind === "author") authors.add(fol.target)
       else if (fol.kind === "path") paths.add(fol.target)
-      // `user` follows store a user id (not a username) and drive `followed_by_me` on
-      // the profile response instead — they aren't keyed here.
+      else if (fol.kind === "user" && fol.handle) users.add(fol.handle.toLowerCase())
     }
-    return { authors, paths }
+    return { authors, paths, users }
   }, [follows])
 
   // A follow change shifts both the manage strip (follows) and any open profile (its
@@ -71,10 +73,11 @@ export function useFollows() {
       if (paths.has(target)) remove.mutate({ kind: "path", target })
       else add.mutate({ kind: "path", target })
     },
-    // Flip the follow state for a person. The current state comes from the profile's
-    // `followed_by_me` (people-follows store a user id, not the username we send here).
-    toggleUser: (username: string, isFollowing: boolean) => {
-      if (isFollowing) remove.mutate({ kind: "user", target: username })
+    // Are we following this person? (by @handle — the universal key for Follow buttons).
+    isFollowingUser: (username: string) => users.has(username.toLowerCase()),
+    // Flip the follow state for a person by @handle (state read from the live follows set).
+    toggleUser: (username: string) => {
+      if (users.has(username.toLowerCase())) remove.mutate({ kind: "user", target: username })
       else add.mutate({ kind: "user", target: username })
     },
     // True while a follow mutation is in flight (disable the button).

--- a/apps/web/src/pages/library/artifact-row.tsx
+++ b/apps/web/src/pages/library/artifact-row.tsx
@@ -1,6 +1,7 @@
 import { Folder } from "lucide-react"
 import type { Artifact } from "@/api"
 import { AuthorChip } from "@/components/author-chip"
+import { FollowButton } from "@/components/follow-button"
 import { Icon } from "@/components/icons"
 import {
   DropdownMenu,
@@ -95,6 +96,9 @@ export function ArtifactRow({
             onClick={onPickAuthor && authorLogin ? () => onPickAuthor(authorLogin) : undefined}
             data-testid={`artifact-row-author-${a.short_id}`}
           />
+          {/* Ambient follow: when the author is a known Dock person, follow them right
+              from the row (self-hides for your own work / signed-out). */}
+          {author?.handle && <FollowButton username={author.handle} size="xs" className="ml-2" />}
         </div>
       )}
 

--- a/apps/web/src/pages/library/following-strip.tsx
+++ b/apps/web/src/pages/library/following-strip.tsx
@@ -2,9 +2,9 @@ import { X } from "lucide-react"
 import type { Follow } from "@/api"
 
 // The top-of-feed "following" summary + manage surface: the caller's current
-// follows as chips — @<login> for authors, <path> for paths — each with an
-// unfollow (×). Doubles as the manage-follows surface, so the feed and the
-// settings live in one place.
+// follows as chips — @<login> for GitHub authors, @<handle> for people, <path> for
+// paths — each with an unfollow (×). Doubles as the manage-follows surface, so the
+// feed and the settings live in one place.
 export function FollowingStrip({
   follows,
   onUnfollow,
@@ -19,7 +19,15 @@ export function FollowingStrip({
         Following
       </span>
       {follows.map((fol) => {
-        const label = fol.kind === "author" ? `@${fol.target}` : fol.target
+        // People-follows store a user id in `target` but carry a resolved `handle`; label
+        // them @handle and unfollow BY handle (the server resolves it back to the id).
+        const label =
+          fol.kind === "author"
+            ? `@${fol.target}`
+            : fol.kind === "user"
+              ? `@${fol.handle ?? fol.target}`
+              : fol.target
+        const unfollowTarget = fol.kind === "user" ? (fol.handle ?? fol.target) : fol.target
         return (
           <span
             key={`${fol.kind}:${fol.target}`}
@@ -28,10 +36,10 @@ export function FollowingStrip({
             {label}
             <button
               type="button"
-              data-testid={`following-unfollow-${fol.kind}-${fol.target}`}
+              data-testid={`following-unfollow-${fol.kind}-${unfollowTarget}`}
               title={`Unfollow ${label}`}
               aria-label={`Unfollow ${label}`}
-              onClick={() => onUnfollow(fol.kind, fol.target)}
+              onClick={() => onUnfollow(fol.kind, unfollowTarget)}
               className="grid size-4 place-items-center rounded text-muted-foreground transition-colors hover:text-foreground"
             >
               <X className="size-3" aria-hidden />

--- a/apps/web/src/pages/profile-work-card.tsx
+++ b/apps/web/src/pages/profile-work-card.tsx
@@ -1,0 +1,49 @@
+import { Link } from "@tanstack/react-router"
+import type { Artifact } from "@/api"
+import { Icon } from "@/components/icons"
+import { Thumb } from "@/components/shared/thumb"
+import { ago } from "@/lib/time"
+import { refFor } from "./artifact/parse-ref"
+import { artifactTypeLabel, dirOf } from "./library/artifact-card"
+
+// One piece of a person's work on their profile. A focused, link-first card (no
+// favorite/delete chrome — those are library affordances): thumbnail, title, type +
+// updated + views. The whole card is the link, so it preloads on hover and opens the
+// artifact. Mirrors the library card's look so the two read as one design.
+export function ProfileWorkCard({ artifact: a }: { artifact: Artifact }) {
+  return (
+    <Link
+      to="/a/$ref"
+      params={{ ref: refFor(a) }}
+      data-testid={`profile-work-${a.short_id}`}
+      className="group flex cursor-pointer flex-col gap-2 rounded-lg border border-border bg-card p-3.5 outline-none transition-all motion-safe:hover:-translate-y-0.5 hover:border-primary hover:shadow-[var(--shadow)] focus-visible:border-primary active:translate-y-0"
+    >
+      <Thumb id={a.short_id} v={a.current_version} />
+      <span className="truncate font-display text-lg font-semibold text-foreground transition-colors group-hover:text-primary">
+        {a.title ?? a.short_id}
+      </span>
+      {a.source_path && dirOf(a.source_path) && (
+        <span className="truncate font-mono text-2xs text-muted-foreground" title={a.source_path}>
+          {dirOf(a.source_path)}/
+        </span>
+      )}
+      <span className="flex items-center gap-2 font-mono text-xs text-muted-foreground">
+        <span className="rounded-[5px] border border-border-soft bg-secondary px-1.5 py-px">
+          {artifactTypeLabel(a)}
+        </span>
+        {(a.updated_at ?? a.created_at ?? a.versions[0]?.created_at) && (
+          <span>
+            updated {ago(a.updated_at ?? a.created_at ?? a.versions[0]?.created_at ?? "")}
+          </span>
+        )}
+        {a.views !== undefined && a.views > 0 && (
+          <span className="ml-auto inline-flex items-center gap-1" title={`${a.views} viewers`}>
+            <Icon name="views" size={13} />{" "}
+            {a.views > 999 ? `${(a.views / 1000).toFixed(1)}k` : a.views}
+            <span className="sr-only"> views</span>
+          </span>
+        )}
+      </span>
+    </Link>
+  )
+}

--- a/apps/web/src/pages/profile.tsx
+++ b/apps/web/src/pages/profile.tsx
@@ -81,14 +81,8 @@ export function Profile() {
                   @{data.username}
                 </p>
               </div>
-              {/* Follow only renders for a signed-in viewer on someone else's profile. */}
-              {me && !isMe && (
-                <FollowButton
-                  username={data.username}
-                  isFollowing={!!data.followed_by_me}
-                  className="shrink-0"
-                />
-              )}
+              {/* Self-hides for a signed-out viewer or your own profile. */}
+              <FollowButton username={data.username} className="shrink-0" />
             </div>
 
             {data.profession && (

--- a/apps/web/src/pages/profile.tsx
+++ b/apps/web/src/pages/profile.tsx
@@ -1,32 +1,39 @@
-import { useQuery } from "@tanstack/react-query"
-import { getRouteApi, useNavigate } from "@tanstack/react-router"
-import { useState } from "react"
-import { api } from "@/api"
-import { CenteredSpinner } from "@/components/shared/spinner"
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
+import { getRouteApi, Link, useNavigate } from "@tanstack/react-router"
+import { useEffect, useRef, useState } from "react"
+import { api, type PublicProfile } from "@/api"
+import { FollowButton } from "@/components/follow-button"
+import { Icon } from "@/components/icons"
+import { EmptyState } from "@/components/shared/empty-state"
+import { CenteredSpinner, Spinner } from "@/components/shared/spinner"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
 import { UsernameForm } from "@/components/username-form"
 import { useAuth } from "@/ctx"
+import { profileArtifactsQuery, profileQuery } from "@/lib/queries"
+import { ProfileWorkCard } from "./profile-work-card"
 
 const route = getRouteApi("/u/$handle")
 
-// A basic public profile (Profiles & Accounts v1): avatar, display name, and the
-// @handle. Email stays private. The richer profile (your public artifacts,
-// following, a customizable page) is intentionally out of scope here — this is
-// the identity card the rest of that work builds on. When it's your own profile,
-// you can rename your handle inline.
+// The rich public profile: an identity card (avatar, name, @handle, role, bio, GitHub
+// link), a stats row (works / followers / following), a Follow button, and a grid of
+// everything this person has worked on that the viewer is allowed to see. Single scroll;
+// the activity feed of people you follow lives at the library's Following view.
 export function Profile() {
   const { handle } = route.useParams()
   const { me, setMe } = useAuth()
   const nav = useNavigate()
   const [editing, setEditing] = useState(false)
 
-  const { data, isPending, isError } = useQuery({
-    queryKey: ["profile", handle],
-    queryFn: () => api.profile(handle).then((r) => r.user),
-    retry: false,
-  })
+  const { data, isPending, isError } = useQuery(profileQuery(handle))
 
   if (isPending) return <CenteredSpinner />
 
@@ -45,66 +52,255 @@ export function Profile() {
 
   const isMe = !!me?.username && me.username === data.username
   const initials = (data.name ?? data.username).slice(0, 2).toUpperCase()
+  const stats = data.stats ?? { works: 0, followers: 0, following: 0 }
 
   return (
-    <div className="mx-auto w-full max-w-xl p-6 sm:p-10">
-      <Card className="flex flex-col items-center gap-4 p-8 text-center" data-testid="profile-card">
-        <Avatar className="size-20">
-          {data.image && <AvatarImage src={data.image} alt={data.name ?? data.username} />}
-          <AvatarFallback className="text-lg">{initials}</AvatarFallback>
-        </Avatar>
-        <div className="min-w-0">
-          {data.name && (
-            <h1
-              className="font-display text-2xl font-semibold text-foreground"
-              data-testid="profile-name"
-            >
-              {data.name}
-            </h1>
-          )}
-          <p className="text-sm font-medium text-muted-foreground" data-testid="profile-username">
-            @{data.username}
-          </p>
-          {data.profession && (
-            <p
-              className="mt-1 text-sm font-medium text-accent-foreground"
-              data-testid="profile-role"
-            >
-              {data.profession}
-            </p>
-          )}
-        </div>
+    <div className="mx-auto w-full max-w-3xl p-6 sm:p-8">
+      <Card className="p-6 sm:p-7" data-testid="profile-card">
+        <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:gap-6">
+          <Avatar className="size-20 shrink-0 sm:size-24">
+            {data.image && <AvatarImage src={data.image} alt={data.name ?? data.username} />}
+            <AvatarFallback className="text-2xl">{initials}</AvatarFallback>
+          </Avatar>
 
-        {data.about && (
-          <p className="max-w-sm text-sm text-muted-foreground" data-testid="profile-about">
-            {data.about}
-          </p>
-        )}
+          <div className="min-w-0 flex-1">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                {data.name && (
+                  <h1
+                    className="truncate font-display text-2xl font-semibold text-foreground"
+                    data-testid="profile-name"
+                  >
+                    {data.name}
+                  </h1>
+                )}
+                <p
+                  className="text-sm font-medium text-muted-foreground"
+                  data-testid="profile-username"
+                >
+                  @{data.username}
+                </p>
+              </div>
+              {/* Follow only renders for a signed-in viewer on someone else's profile. */}
+              {me && !isMe && (
+                <FollowButton
+                  username={data.username}
+                  isFollowing={!!data.followed_by_me}
+                  className="shrink-0"
+                />
+              )}
+            </div>
 
-        {isMe &&
-          (editing ? (
-            <div className="w-full max-w-xs pt-2">
-              <UsernameForm
-                initial={data.username}
-                submitLabel="Save username"
-                onClaimed={(username) => {
-                  setMe(me ? { ...me, username } : me)
-                  setEditing(false)
-                  nav({ to: "/u/$handle", params: { handle: username } })
-                }}
+            {data.profession && (
+              <p
+                className="mt-2 text-sm font-medium text-accent-foreground"
+                data-testid="profile-role"
+              >
+                {data.profession}
+              </p>
+            )}
+            {data.about && (
+              <p className="mt-1.5 text-sm text-muted-foreground" data-testid="profile-about">
+                {data.about}
+              </p>
+            )}
+            {data.github_login && (
+              <a
+                href={`https://github.com/${data.github_login}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-testid="profile-github"
+                className="mt-2.5 inline-flex items-center gap-1.5 font-mono text-xs text-muted-foreground transition-colors hover:text-primary"
+              >
+                <Icon name="link" size={13} />@{data.github_login} on GitHub
+              </a>
+            )}
+
+            {/* Stats: works (static), followers + following (open a people dialog). */}
+            <div className="mt-4 flex items-center gap-5 text-sm" data-testid="profile-stats">
+              <Stat label="works" value={stats.works} />
+              <PeopleStat
+                label="followers"
+                value={stats.followers}
+                handle={data.username}
+                load={() => api.profileFollowers(data.username).then((r) => r.users)}
+              />
+              <PeopleStat
+                label="following"
+                value={stats.following}
+                handle={data.username}
+                load={() => api.profileFollowing(data.username).then((r) => r.users)}
               />
             </div>
-          ) : (
-            <Button
-              variant="outline"
-              size="sm"
-              data-testid="profile-edit"
-              onClick={() => setEditing(true)}
-            >
-              Change username
-            </Button>
-          ))}
+
+            {isMe && (
+              <div className="mt-4">
+                {editing ? (
+                  <div className="max-w-xs">
+                    <UsernameForm
+                      initial={data.username}
+                      submitLabel="Save username"
+                      onClaimed={(username) => {
+                        setMe(me ? { ...me, username } : me)
+                        setEditing(false)
+                        nav({ to: "/u/$handle", params: { handle: username } })
+                      }}
+                    />
+                  </div>
+                ) : (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    data-testid="profile-edit"
+                    onClick={() => setEditing(true)}
+                  >
+                    Change username
+                  </Button>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
       </Card>
+
+      <ProfileWork handle={data.username} isMe={isMe} name={data.name ?? data.username} />
     </div>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <span className="inline-flex items-baseline gap-1">
+      <span className="font-semibold text-foreground">{value}</span>
+      <span className="text-muted-foreground">{label}</span>
+    </span>
+  )
+}
+
+// A clickable stat that opens a dialog listing the people, fetched lazily on open.
+function PeopleStat({
+  label,
+  value,
+  handle,
+  load,
+}: {
+  label: string
+  value: number
+  handle: string
+  load: () => Promise<PublicProfile[]>
+}) {
+  const [open, setOpen] = useState(false)
+  const { data: people, isPending } = useQuery({
+    queryKey: ["profile-people", handle, label],
+    queryFn: load,
+    enabled: open,
+  })
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          disabled={value === 0}
+          data-testid={`profile-stat-${label}`}
+          className="inline-flex items-baseline gap-1 rounded transition-colors hover:text-primary disabled:cursor-default disabled:hover:text-current"
+        >
+          <span className="font-semibold text-foreground">{value}</span>
+          <span className="text-muted-foreground">{label}</span>
+        </button>
+      </DialogTrigger>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="capitalize">{label}</DialogTitle>
+        </DialogHeader>
+        {isPending ? (
+          <div className="py-6">
+            <Spinner />
+          </div>
+        ) : people && people.length > 0 ? (
+          <ul className="flex max-h-80 flex-col gap-1 overflow-y-auto">
+            {people.map((p) => (
+              <li key={p.username}>
+                <Link
+                  to="/u/$handle"
+                  params={{ handle: p.username }}
+                  onClick={() => setOpen(false)}
+                  className="flex items-center gap-3 rounded-md p-2 transition-colors hover:bg-hover"
+                >
+                  <Avatar className="size-8">
+                    {p.image && <AvatarImage src={p.image} alt={p.name ?? p.username} />}
+                    <AvatarFallback>
+                      {(p.name ?? p.username).slice(0, 2).toUpperCase()}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span className="min-w-0">
+                    {p.name && <span className="block truncate text-sm font-medium">{p.name}</span>}
+                    <span className="block truncate font-mono text-xs text-muted-foreground">
+                      @{p.username}
+                    </span>
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="py-6 text-center text-sm text-muted-foreground">No one yet.</p>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// The person's work — an infinite grid, paged by keyset cursor. A sentinel pulls the
+// next page as it scrolls into view.
+function ProfileWork({ handle, isMe, name }: { handle: string; isMe: boolean; name: string }) {
+  const { data, isPending, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery(profileArtifactsQuery(handle))
+  const items = data?.pages.flatMap((p) => p.artifacts) ?? []
+  const sentinel = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = sentinel.current
+    if (!el || !hasNextPage) return
+    const io = new IntersectionObserver((entries) => {
+      if (entries[0]?.isIntersecting && !isFetchingNextPage) fetchNextPage()
+    })
+    io.observe(el)
+    return () => io.disconnect()
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+
+  return (
+    <section className="mt-7">
+      <h2 className="mb-3 font-display text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+        Work
+      </h2>
+      {isPending ? (
+        <div className="py-10">
+          <Spinner />
+        </div>
+      ) : isError ? (
+        <EmptyState>Couldn't load this work right now.</EmptyState>
+      ) : items.length === 0 ? (
+        <div data-testid="profile-work-empty">
+          <EmptyState>
+            {isMe
+              ? "You haven't published anything public yet. Your public work shows up here."
+              : `${name} hasn't published anything public yet.`}
+          </EmptyState>
+        </div>
+      ) : (
+        <>
+          <div
+            className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-3"
+            data-testid="profile-work-grid"
+          >
+            {items.map((a) => (
+              <ProfileWorkCard key={a.short_id} artifact={a} />
+            ))}
+          </div>
+          <div ref={sentinel} className="h-8" />
+          {isFetchingNextPage && <Spinner />}
+        </>
+      )}
+    </section>
   )
 }

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -24,7 +24,8 @@ CREATE TABLE IF NOT EXISTS artifact (
   author_name TEXT,
   author_login TEXT,
   author_avatar TEXT,
-  author_gh_id TEXT
+  author_gh_id TEXT,
+  author_id TEXT
 );
 
 CREATE TABLE IF NOT EXISTS version (
@@ -38,6 +39,7 @@ CREATE TABLE IF NOT EXISTS version (
   author_login TEXT,
   author_avatar TEXT,
   author_gh_id TEXT,
+  author_id TEXT,
   message TEXT,
   name TEXT,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -61,6 +61,11 @@ export interface ArtifactRecord {
   author_login: string | null
   author_avatar: string | null
   author_gh_id: string | null
+  /** The Dock user who last published this artifact by hand (the signed-in publisher).
+   *  Null for GitHub-synced versions (attributed via `author_gh_id` instead), bare
+   *  static-token publishes, and legacy rows. Lets a person's profile + people-follow
+   *  surface their hand-published work. */
+  author_id: string | null
 }
 
 export interface ListArtifactsOpts {
@@ -84,6 +89,11 @@ export interface ListArtifactsOpts {
   /** Only `public` artifacts. Set for anonymous / non-member callers so a workspace
    *  listing never leaks `org`/`link`/`password` titles to someone who can't open them. */
   publicOnly?: boolean
+  /** Profile work-list visibility gate: a row is included when it is `public` OR its
+   *  `org_id` is in this set (the workspaces the viewer shares with the profile owner).
+   *  An empty/omitted set with a profile query ⇒ public-only. Used by `listUserWorks`
+   *  so a person's profile never leaks non-public work the viewer can't open. */
+  visibleOrgIds?: string[]
 }
 
 export interface VersionRecord {
@@ -101,6 +111,8 @@ export interface VersionRecord {
   author_login: string | null
   author_avatar: string | null
   author_gh_id: string | null
+  /** The Dock user who published this version by hand; null for sync/anon/legacy. */
+  author_id: string | null
   message: string | null
   /** A named checkpoint (Docs-style). Null = an ordinary auto-saved revision. */
   name: string | null
@@ -132,6 +144,8 @@ export interface NewVersion {
   author_login?: string | null
   author_avatar?: string | null
   author_gh_id?: string | null
+  /** The Dock user who published this version by hand; null/omitted for sync/anon. */
+  author_id?: string | null
   message: string | null
   name?: string | null
 }
@@ -290,17 +304,28 @@ export interface MetaStore {
   setFavorite(artifactId: string, userId: string): Promise<void>
   removeFavorite(artifactId: string, userId: string): Promise<void>
 
-  // ---- Follows (per-user: track GitHub authors + repo path prefixes) -----
+  // ---- Follows (per-user: track GitHub authors, repo paths, and people) --
   /** Record a follow (idempotent on (user, org, kind, target)); returns the row. */
   addFollow(f: NewFollow): Promise<FollowRecord>
   removeFollow(userId: string, orgId: string, kind: FollowKind, target: string): Promise<void>
-  /** A user's follows in a workspace, newest first. */
+  /** A user's follows for the Following management UI: their `author`/`path` follows in
+   *  `orgId` PLUS their global `user` (people) follows (org_id = "*"), newest first. */
   listFollows(userId: string, orgId: string): Promise<FollowRecord[]>
-  /** Artifact ids in `orgId` (not removed) whose current author_login is one of the
-   *  user's followed logins (case-insensitive) OR whose source_path starts with one of
-   *  the user's followed path prefixes — the activity feed. Empty when the user follows
-   *  nothing. */
+  /** Artifact ids in `orgId` (not removed) surfaced by this user's follows — the activity
+   *  feed. A row qualifies when its current author_login is a followed login
+   *  (case-insensitive), its source_path starts with a followed path prefix, OR its
+   *  author (by `author_id` or linked GitHub id) is a followed person. Empty when the
+   *  user follows nothing. Stays scoped to `orgId`, so private cross-workspace work a
+   *  followed person did never enters the feed. */
   followedArtifactIds(userId: string, orgId: string): Promise<string[]>
+  /** How many people follow this user (kind='user', target=userId). */
+  countFollowers(userId: string): Promise<number>
+  /** How many people this user follows (kind='user', user_id=userId). */
+  countFollowing(userId: string): Promise<number>
+  /** People who follow this user, as public profiles, newest follow first. */
+  listFollowers(userId: string, limit: number): Promise<UserProfile[]>
+  /** People this user follows, as public profiles, newest follow first. */
+  listFollowing(userId: string, limit: number): Promise<UserProfile[]>
   /** Tags per artifact, batched (no N+1). Missing ids map to no entry. */
   tagsForArtifacts(artifactIds: string[]): Promise<Record<string, string[]>>
   /** Replace an artifact's full tag set (deduped, trimmed, lowercased upstream). */
@@ -417,6 +442,24 @@ export interface MetaStore {
    *  `user`. Lets a synced artifact's commit author resolve to a Dock profile/handle.
    *  Returns [] for empty input or when the auth tables are absent. */
   usersByGithubIds(ghIds: string[]): Promise<GithubUserMapping[]>
+  /** The GitHub numeric user ids (account.accountId, as strings) a Dock user has linked
+   *  via Better Auth's `account` (providerId='github'). Inverse of `usersByGithubIds`.
+   *  Returns [] when none or the auth tables are absent. */
+  githubIdsForUser(userId: string): Promise<string[]>
+  /** A Dock user's GitHub login, derived from any artifact whose `author_gh_id` is one of
+   *  their linked GitHub ids (we don't store the login on `account`). Null when unknown —
+   *  used only to show a GitHub link on the profile. */
+  githubLoginForUser(userId: string, ghIds: string[]): Promise<string | null>
+  /** Org ids where BOTH users hold a membership — the shared-workspace set that widens a
+   *  viewer's profile visibility beyond public. Empty for an anonymous viewer. */
+  sharedOrgIds(viewerId: string, targetUserId: string): Promise<string[]>
+  /** A person's work for their profile: artifacts (not removed) authored by them — either
+   *  `author_id = userId` OR `author_gh_id ∈ ghIds` (their linked GitHub commits) — gated
+   *  by `visibleOrgIds` (public OR a shared workspace). Newest first, keyset-paginated via
+   *  `opts.cursor`/`opts.limit`. */
+  listUserWorks(userId: string, ghIds: string[], opts: ListArtifactsOpts): Promise<ArtifactRecord[]>
+  /** Count of a person's visible work (same predicate as `listUserWorks`) for the stats row. */
+  countUserWorks(userId: string, ghIds: string[], opts: ListArtifactsOpts): Promise<number>
   /** Resolve a public profile by its handle (username); null if unclaimed. */
   getUserByUsername(username: string): Promise<UserProfile | null>
   /** Claim or replace a user's handle. Returns "taken" when another account
@@ -507,9 +550,14 @@ export interface MetaStore {
   ): Promise<AuditLogRecord[]>
 }
 
-/** What a user follows: a GitHub author (`target` = the login) or a repo path
- *  prefix (`target` = a path prefix, e.g. "docs/plans"). */
-export type FollowKind = "author" | "path"
+/** What a user follows: a GitHub author (`target` = the login), a repo path prefix
+ *  (`target` = a path prefix, e.g. "docs/plans"), or a Dock person (`target` = their
+ *  user id). `author`/`path` follows are workspace-scoped; `user` follows are global
+ *  (stored with `org_id = "*"`) since a person's work spans workspaces. */
+export type FollowKind = "author" | "path" | "user"
+/** Sentinel org_id for `user` (people) follows — they are global, not workspace-scoped,
+ *  so a person's work surfaces regardless of which workspace the follower is viewing. */
+export const GLOBAL_FOLLOW_ORG = "*"
 /** A per-user follow — the same shape of relation as a favorite, but keyed on a
  *  (kind, target) pair instead of an artifact id. Drives the "following" feed. */
 export interface FollowRecord {
@@ -517,7 +565,8 @@ export interface FollowRecord {
   org_id: string
   user_id: string
   kind: FollowKind
-  /** For `author`: the GitHub login (stored lowercased). For `path`: a repo path prefix. */
+  /** For `author`: the GitHub login (stored lowercased). For `path`: a repo path prefix.
+   *  For `user`: the followed Dock user id (verbatim). */
   target: string
   created_at: string
 }
@@ -744,7 +793,10 @@ export interface UserProfile {
   about?: string | null
 }
 
-export type NotificationKind = "mention" | "comment" | "share"
+/** `mention`/`comment`/`share` are artifact-anchored. `follow` (someone followed you)
+ *  and `publish` (someone you follow published) are the social kinds — `follow` carries
+ *  no artifact (its artifact_* fields are ""), `publish` points at the new artifact. */
+export type NotificationKind = "mention" | "comment" | "share" | "follow" | "publish"
 export interface NotificationRecord {
   id: string
   user_id: string

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -311,12 +311,13 @@ export interface MetaStore {
   /** A user's follows for the Following management UI: their `author`/`path` follows in
    *  `orgId` PLUS their global `user` (people) follows (org_id = "*"), newest first. */
   listFollows(userId: string, orgId: string): Promise<FollowRecord[]>
-  /** Artifact ids in `orgId` (not removed) surfaced by this user's follows — the activity
-   *  feed. A row qualifies when its current author_login is a followed login
-   *  (case-insensitive), its source_path starts with a followed path prefix, OR its
-   *  author (by `author_id` or linked GitHub id) is a followed person. Empty when the
-   *  user follows nothing. Stays scoped to `orgId`, so private cross-workspace work a
-   *  followed person did never enters the feed. */
+  /** Artifact ids (not removed) surfaced by this user's follows — the activity feed.
+   *  Two scopes: author/path follows match within the active workspace `orgId` (a followed
+   *  author_login, case-insensitive, or a source_path prefix); people follows match a
+   *  followed person's PUBLIC work in ANY workspace (by `author_id` or their linked GitHub
+   *  ids) — a person you follow usually publishes in their own workspace, not yours. The
+   *  people scope is gated to `public`, so following someone never exposes their private
+   *  cross-workspace work. Empty when the user follows nothing. */
   followedArtifactIds(userId: string, orgId: string): Promise<string[]>
   /** How many people follow this user (kind='user', target=userId). */
   countFollowers(userId: string): Promise<number>

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -41,6 +41,11 @@ export interface PublishInput {
   authorLogin?: string | null
   authorAvatar?: string | null
   authorGhId?: string | null
+  /** The Dock user publishing this by hand (the signed-in publisher). Stored per-version
+   *  and denormalized as the artifact's current `author_id`, so the person's profile and
+   *  people-follow surface their hand-published work. Omitted/null for sync and bare
+   *  static-token publishes. */
+  authorId?: string | null
   /** The workspace the new artifact belongs to (multi-workspace). */
   orgId?: string
   visibility?: Visibility
@@ -199,6 +204,7 @@ export async function publish(
       author_login: input.authorLogin ?? null,
       author_avatar: input.authorAvatar ?? null,
       author_gh_id: input.authorGhId ?? null,
+      author_id: input.authorId ?? null,
       message: input.message ?? null,
       name: input.name ?? null,
     })
@@ -230,6 +236,7 @@ export async function publish(
     author_login: input.authorLogin ?? null,
     author_avatar: input.authorAvatar ?? null,
     author_gh_id: input.authorGhId ?? null,
+    author_id: input.authorId ?? null,
     message: input.message ?? "first publish",
     name: input.name ?? null,
   })
@@ -315,6 +322,9 @@ export async function approveProposal(
     content_type: proposal.content_type,
     size_bytes: stored?.length ?? 0,
     author: proposal.author,
+    // Attribute the live version to the proposer (who did the work), not the approver,
+    // so it shows up on the proposer's profile. Null for legacy/anonymous proposals.
+    author_id: proposal.author_id ?? null,
     message: proposal.message ?? "Approved proposal",
     name: null,
   })

--- a/packages/core/src/unfurl.ts
+++ b/packages/core/src/unfurl.ts
@@ -164,6 +164,93 @@ export interface OgCard {
   reveal?: boolean
 }
 
+// ---- Profile unfurl (people pages: /u/:handle) -----------------------------
+
+/** Everything a profile unfurl card / meta block needs about one person. */
+export interface ProfileCard {
+  username: string
+  name: string | null
+  profession: string | null
+  works: number
+  followers: number
+}
+
+/** One-line profile description: "Engineering · 12 works · 48 followers · on Dock". */
+export const profileSummary = (c: ProfileCard): string => {
+  const parts: string[] = []
+  if (c.profession) parts.push(c.profession)
+  parts.push(plural(c.works, "work"))
+  parts.push(plural(c.followers, "follower"))
+  return `${parts.join(" · ")} · on Dock`
+}
+
+/** Initials for the avatar disc — first+last of the name, else the first two chars. */
+const profileInitials = (name: string | null, username: string): string => {
+  const src = (name?.trim() || username).trim()
+  const parts = src.split(/\s+/).filter(Boolean)
+  const chars =
+    parts.length >= 2 ? `${parts[0]?.[0] ?? ""}${parts.at(-1)?.[0] ?? ""}` : src.slice(0, 2)
+  return chars.toUpperCase() || "?"
+}
+
+/** The OG/Twitter `<head>` tags for a public profile. og:type=profile; values escaped. */
+export const profileMetaTags = (i: {
+  username: string
+  name: string | null
+  description: string
+  pageUrl: string
+  imageUrl: string
+}): string => {
+  const title = escapeHtml(i.name ? `${i.name} (@${i.username})` : `@${i.username}`)
+  const d = escapeHtml(i.description)
+  const url = escapeHtml(i.pageUrl)
+  const img = escapeHtml(i.imageUrl)
+  return [
+    `<meta property="og:type" content="profile">`,
+    `<meta property="og:site_name" content="Dock">`,
+    `<meta property="profile:username" content="${escapeHtml(i.username)}">`,
+    `<meta property="og:title" content="${title}">`,
+    `<meta property="og:description" content="${d}">`,
+    `<meta property="og:url" content="${url}">`,
+    `<meta property="og:image" content="${img}">`,
+    `<meta property="og:image:width" content="1200">`,
+    `<meta property="og:image:height" content="630">`,
+    `<meta name="twitter:card" content="summary_large_image">`,
+    `<meta name="twitter:title" content="${title}">`,
+    `<meta name="twitter:description" content="${d}">`,
+    `<meta name="twitter:image" content="${img}">`,
+  ].join("\n")
+}
+
+/** The profile OG card as a standalone SVG (1200x630, Dock palette). Self-contained —
+ *  an initials disc, not a remote avatar — so it renders identically on every crawler. */
+export const ogProfileCardSvg = (card: ProfileCard): string => {
+  const sans = "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+  const mono = "'SF Mono', ui-monospace, Menlo, Consolas, monospace"
+  const name = svgEscape(card.name?.trim() || `@${card.username}`)
+  const handle = svgEscape(`@${card.username}`)
+  const initials = svgEscape(profileInitials(card.name, card.username))
+  const summary = svgEscape(profileSummary(card))
+  const cx = 200
+  const cy = 320
+  const r = 110
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${OG_W}" height="${OG_H}" viewBox="0 0 ${OG_W} ${OG_H}" role="img" aria-label="${name}">
+  <rect width="${OG_W}" height="${OG_H}" fill="#f6f0e3"/>
+  <rect x="0" y="0" width="${OG_W}" height="10" fill="#655999"/>
+  <g font-family="${mono}" font-size="26" fill="#4f447e" font-weight="600">
+    <rect x="90" y="74" width="42" height="42" rx="10" fill="#2a2540"/>
+    <path d="M111 84l13 13v18h-8.5v-10.4h-9V115H94v-18z" fill="none" stroke="#8a7dc0" stroke-width="2.6" stroke-linejoin="round"/>
+    <text x="150" y="105" letter-spacing="1">DOCK</text>
+  </g>
+  <circle cx="${cx}" cy="${cy}" r="${r}" fill="#2a2540"/>
+  <text x="${cx}" y="${cy + 28}" text-anchor="middle" font-family="${sans}" font-size="84" font-weight="700" fill="#cabffb" letter-spacing="2">${initials}</text>
+  <text x="350" y="300" font-family="${sans}" font-size="68" font-weight="700" fill="#2a2540" letter-spacing="-1">${name}</text>
+  <text x="350" y="360" font-family="${mono}" font-size="32" fill="#655999">${handle}</text>
+  <text x="350" y="430" font-family="${mono}" font-size="28" fill="#6b6680">${summary}</text>
+  <text x="${OG_W - 90}" y="105" text-anchor="end" font-family="${mono}" font-size="24" fill="#928da3">dock.build</text>
+</svg>`
+}
+
 /** The OG card as a standalone SVG document string. */
 export const ogCardSvg = (card: OgCard): string => {
   const reveal = card.reveal !== false

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -50,6 +50,9 @@ export const artifact = pgTable("artifact", {
   author_login: text("author_login"),
   author_avatar: text("author_avatar"),
   author_gh_id: text("author_gh_id"),
+  // The Dock user who last published this by hand; null for sync/token/legacy. Mirrors
+  // schema.ts — drives the profile work-list + people-follow.
+  author_id: text("author_id"),
 })
 
 export const version = pgTable(
@@ -70,6 +73,8 @@ export const version = pgTable(
     author_login: text("author_login"),
     author_avatar: text("author_avatar"),
     author_gh_id: text("author_gh_id"),
+    // The Dock user who published this version by hand; null for sync/anon/legacy.
+    author_id: text("author_id"),
     message: text("message"),
     name: text("name"),
     created_at: text("created_at").notNull().$defaultFn(isoNow),

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -786,29 +786,38 @@ export class PgMetaStore implements MetaStore {
   }
   // The "following" feed id set: live artifacts whose current author is a followed login
   // (case-insensitive), whose source_path starts with a followed path prefix, OR whose
-  // author (author_id / linked GitHub id) is a followed person. Mirrors the sqlite path.
+  // author/path follows match within the active workspace; people follows match a
+  // followed person's PUBLIC work across ANY workspace. Mirrors the sqlite path.
   async followedArtifactIds(userId: string, orgId: string): Promise<string[]> {
     const follows = await this.listFollows(userId, orgId)
     const logins = follows.filter((f) => f.kind === "author").map((f) => f.target.toLowerCase())
     const prefixes = follows.filter((f) => f.kind === "path").map((f) => f.target)
     const people = follows.filter((f) => f.kind === "user").map((f) => f.target)
     if (logins.length === 0 && prefixes.length === 0 && people.length === 0) return []
-    const conds = []
-    if (logins.length > 0) conds.push(inArray(sql`lower(${artifact.author_login})`, logins))
+    const branches = []
+    const wsConds = []
+    if (logins.length > 0) wsConds.push(inArray(sql`lower(${artifact.author_login})`, logins))
     for (const p of prefixes) {
       const escaped = p.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_")
-      conds.push(sql`${artifact.source_path} like ${`${escaped}%`} escape '\\'`)
+      wsConds.push(sql`${artifact.source_path} like ${`${escaped}%`} escape '\\'`)
+    }
+    if (wsConds.length > 0) {
+      const wsMatch = wsConds.length === 1 ? wsConds[0] : or(...wsConds)
+      if (wsMatch) branches.push(and(eq(artifact.org_id, orgId), wsMatch))
     }
     if (people.length > 0) {
-      conds.push(inArray(artifact.author_id, people))
+      const authorConds = [inArray(artifact.author_id, people)]
       const ghIds = (await this.githubIdsForUsers(people)).map((g) => g.toLowerCase())
-      if (ghIds.length > 0) conds.push(inArray(sql`lower(${artifact.author_gh_id})`, ghIds))
+      if (ghIds.length > 0) authorConds.push(inArray(sql`lower(${artifact.author_gh_id})`, ghIds))
+      const authored = authorConds.length === 1 ? authorConds[0] : or(...authorConds)
+      if (authored) branches.push(and(eq(artifact.visibility, "public"), authored))
     }
-    const match = conds.length === 1 ? conds[0] : or(...conds)
+    if (branches.length === 0) return []
+    const match = branches.length === 1 ? branches[0] : or(...branches)
     const rows = await this.db
       .select({ id: artifact.id })
       .from(artifact)
-      .where(and(eq(artifact.org_id, orgId), isNull(artifact.removed_at), match))
+      .where(and(isNull(artifact.removed_at), match))
     return rows.map((r) => r.id)
   }
   // ---- People profiles: works, shared workspaces, follower/following -----

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -58,6 +58,7 @@ import type {
   WebhookRecord,
   WorkspaceRecord,
 } from "@dock/core"
+import { GLOBAL_FOLLOW_ORG } from "@dock/core"
 import {
   and,
   asc,
@@ -277,6 +278,7 @@ export class PgMetaStore implements MetaStore {
           author_login: v.author_login ?? null,
           author_avatar: v.author_avatar ?? null,
           author_gh_id: v.author_gh_id ?? null,
+          author_id: v.author_id ?? null,
         })
         .where(eq(artifact.id, artifactId))
       const rows = await tx
@@ -759,26 +761,48 @@ export class PgMetaStore implements MetaStore {
         ),
       )
   }
+  // Author/path follows in this workspace PLUS the user's global people-follows (org "*").
   listFollows(userId: string, orgId: string): Promise<FollowRecord[]> {
     return this.db
       .select()
       .from(follow)
-      .where(and(eq(follow.user_id, userId), eq(follow.org_id, orgId)))
+      .where(and(eq(follow.user_id, userId), inArray(follow.org_id, [orgId, GLOBAL_FOLLOW_ORG])))
       .orderBy(desc(follow.created_at), desc(follow.id))
   }
-  // The "following" feed id set: live artifacts whose current author is a followed
-  // login (case-insensitive) OR whose source_path starts with a followed path prefix.
-  // Mirrors the sqlite path exactly (split → OR of inArray + escaped LIKE).
+  // GitHub numeric ids a set of Dock users linked (raw account read; [] if absent).
+  private async githubIdsForUsers(userIds: string[]): Promise<string[]> {
+    if (userIds.length === 0) return []
+    try {
+      const ph = userIds.map((_, i) => `$${i + 1}`).join(",")
+      const { rows } = await this.pool.query(
+        `SELECT a."accountId" gh_id FROM "account" a
+         WHERE a."providerId" = 'github' AND a."userId" IN (${ph})`,
+        userIds,
+      )
+      return (rows as { gh_id: string }[]).map((r) => r.gh_id).filter(Boolean)
+    } catch {
+      return []
+    }
+  }
+  // The "following" feed id set: live artifacts whose current author is a followed login
+  // (case-insensitive), whose source_path starts with a followed path prefix, OR whose
+  // author (author_id / linked GitHub id) is a followed person. Mirrors the sqlite path.
   async followedArtifactIds(userId: string, orgId: string): Promise<string[]> {
     const follows = await this.listFollows(userId, orgId)
     const logins = follows.filter((f) => f.kind === "author").map((f) => f.target.toLowerCase())
     const prefixes = follows.filter((f) => f.kind === "path").map((f) => f.target)
-    if (logins.length === 0 && prefixes.length === 0) return []
+    const people = follows.filter((f) => f.kind === "user").map((f) => f.target)
+    if (logins.length === 0 && prefixes.length === 0 && people.length === 0) return []
     const conds = []
     if (logins.length > 0) conds.push(inArray(sql`lower(${artifact.author_login})`, logins))
     for (const p of prefixes) {
       const escaped = p.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_")
       conds.push(sql`${artifact.source_path} like ${`${escaped}%`} escape '\\'`)
+    }
+    if (people.length > 0) {
+      conds.push(inArray(artifact.author_id, people))
+      const ghIds = (await this.githubIdsForUsers(people)).map((g) => g.toLowerCase())
+      if (ghIds.length > 0) conds.push(inArray(sql`lower(${artifact.author_gh_id})`, ghIds))
     }
     const match = conds.length === 1 ? conds[0] : or(...conds)
     const rows = await this.db
@@ -786,6 +810,123 @@ export class PgMetaStore implements MetaStore {
       .from(artifact)
       .where(and(eq(artifact.org_id, orgId), isNull(artifact.removed_at), match))
     return rows.map((r) => r.id)
+  }
+  // ---- People profiles: works, shared workspaces, follower/following -----
+  githubIdsForUser(userId: string): Promise<string[]> {
+    return this.githubIdsForUsers([userId])
+  }
+  async githubLoginForUser(_userId: string, ghIds: string[]): Promise<string | null> {
+    if (ghIds.length === 0) return null
+    const rows = await this.db
+      .select({ login: artifact.author_login })
+      .from(artifact)
+      .where(and(inArray(artifact.author_gh_id, ghIds), isNotNull(artifact.author_login)))
+      .limit(1)
+    return rows[0]?.login ?? null
+  }
+  async sharedOrgIds(viewerId: string, targetUserId: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ org: membership.org_id })
+      .from(membership)
+      .where(
+        and(
+          eq(membership.user_id, viewerId),
+          inArray(
+            membership.org_id,
+            this.db
+              .select({ o: membership.org_id })
+              .from(membership)
+              .where(eq(membership.user_id, targetUserId)),
+          ),
+        ),
+      )
+    return rows.map((r) => r.org)
+  }
+  private userWorksConds(userId: string, ghIds: string[], opts: ListArtifactsOpts) {
+    const conds = [...artifactListConditions(artifact, opts), isNull(artifact.removed_at)]
+    if (ghIds.length > 0) {
+      const m = or(
+        eq(artifact.author_id, userId),
+        inArray(
+          sql`lower(${artifact.author_gh_id})`,
+          ghIds.map((g) => g.toLowerCase()),
+        ),
+      )
+      if (m) conds.push(m)
+    } else {
+      conds.push(eq(artifact.author_id, userId))
+    }
+    const orgs = opts.visibleOrgIds ?? []
+    if (orgs.length > 0) {
+      const v = or(eq(artifact.visibility, "public"), inArray(artifact.org_id, orgs))
+      if (v) conds.push(v)
+    } else {
+      conds.push(eq(artifact.visibility, "public"))
+    }
+    return conds
+  }
+  async listUserWorks(
+    userId: string,
+    ghIds: string[],
+    opts: ListArtifactsOpts,
+  ): Promise<ArtifactRecord[]> {
+    const q = this.db
+      .select()
+      .from(artifact)
+      .where(and(...this.userWorksConds(userId, ghIds, opts)))
+      .orderBy(desc(artifact.created_at), desc(artifact.id))
+    return opts.limit ? q.limit(opts.limit) : q
+  }
+  async countUserWorks(userId: string, ghIds: string[], opts: ListArtifactsOpts): Promise<number> {
+    const rows = await this.db
+      .select({ c: count() })
+      .from(artifact)
+      .where(
+        and(
+          ...this.userWorksConds(userId, ghIds, { ...opts, cursor: undefined, limit: undefined }),
+        ),
+      )
+    return rows[0]?.c ?? 0
+  }
+  async countFollowers(userId: string): Promise<number> {
+    const rows = await this.db
+      .select({ c: count() })
+      .from(follow)
+      .where(and(eq(follow.kind, "user"), eq(follow.target, userId)))
+    return rows[0]?.c ?? 0
+  }
+  async countFollowing(userId: string): Promise<number> {
+    const rows = await this.db
+      .select({ c: count() })
+      .from(follow)
+      .where(and(eq(follow.kind, "user"), eq(follow.user_id, userId)))
+    return rows[0]?.c ?? 0
+  }
+  private async profilesForFollow(
+    column: "user_id" | "target",
+    userId: string,
+    limit: number,
+  ): Promise<UserProfile[]> {
+    try {
+      const join = column === "target" ? `u.id = f.target` : `u.id = f.user_id`
+      const pick = column === "target" ? `f.user_id = $1` : `f.target = $1`
+      const { rows } = await this.pool.query(
+        `SELECT u.id, u.name, u.image, u.username, u.profession, u.about
+         FROM follow f JOIN "user" u ON ${join}
+         WHERE f.kind = 'user' AND ${pick} AND u.username IS NOT NULL
+         ORDER BY f.created_at DESC, f.id DESC LIMIT $2`,
+        [userId, limit],
+      )
+      return rows as UserProfile[]
+    } catch {
+      return []
+    }
+  }
+  listFollowing(userId: string, limit: number): Promise<UserProfile[]> {
+    return this.profilesForFollow("target", userId, limit)
+  }
+  listFollowers(userId: string, limit: number): Promise<UserProfile[]> {
+    return this.profilesForFollow("user_id", userId, limit)
   }
   async tagsForArtifacts(artifactIds: string[]): Promise<Record<string, string[]>> {
     if (artifactIds.length === 0) return {}

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -47,11 +47,13 @@ import type {
   RepoSourceRecord,
   Role,
   TakedownInput,
+  UserProfile,
   VersionRecord,
   Visibility,
   WebhookRecord,
   WorkspaceRecord,
 } from "@dock/core"
+import { GLOBAL_FOLLOW_ORG } from "@dock/core"
 import {
   and,
   asc,
@@ -324,6 +326,7 @@ export function makeRepos(db: SqliteDb) {
         author_login: v.author_login ?? null,
         author_avatar: v.author_avatar ?? null,
         author_gh_id: v.author_gh_id ?? null,
+        author_id: v.author_id ?? null,
       })
       .where(eq(artifact.id, artifactId))
       .run()
@@ -762,21 +765,42 @@ export function makeRepos(db: SqliteDb) {
       )
       .run()
   }
+  // A user's follows for the management UI: their author/path follows in this workspace
+  // PLUS their global people-follows (org_id = "*"), newest first.
   const listFollows = async (userId: string, orgId: string): Promise<FollowRecord[]> =>
     db
       .select()
       .from(follow)
-      .where(and(eq(follow.user_id, userId), eq(follow.org_id, orgId)))
+      .where(and(eq(follow.user_id, userId), inArray(follow.org_id, [orgId, GLOBAL_FOLLOW_ORG])))
       .orderBy(desc(follow.created_at), desc(follow.id))
       .all()
-  // The "following" feed's id set: live artifacts in the workspace whose CURRENT author
-  // is a followed login (case-insensitive) OR whose source_path starts with a followed
-  // path prefix. Splits the follows into the two sub-conditions and ORs them.
+  // The GitHub numeric ids a set of Dock users linked via Better Auth (raw account read;
+  // the auth tables live in the same DB but aren't in the drizzle schema). [] if absent.
+  const githubIdsForUsers = async (userIds: string[]): Promise<string[]> => {
+    if (userIds.length === 0) return []
+    try {
+      const list = sql.join(
+        userIds.map((id) => sql`${id}`),
+        sql`, `,
+      )
+      const rows = (await db.all(
+        sql`SELECT a.accountId gh_id FROM account a
+            WHERE a.providerId = 'github' AND a.userId IN (${list})`,
+      )) as { gh_id: string }[]
+      return rows.map((r) => r.gh_id).filter(Boolean)
+    } catch {
+      return []
+    }
+  }
+  // The "following" feed's id set: live artifacts in the workspace surfaced by this user's
+  // follows — a followed login (case-insensitive), a followed path prefix, OR a followed
+  // person (matched by the artifact's denormalized author_id or the person's GitHub ids).
   const followedArtifactIds = async (userId: string, orgId: string): Promise<string[]> => {
     const follows = await listFollows(userId, orgId)
     const logins = follows.filter((f) => f.kind === "author").map((f) => f.target.toLowerCase())
     const prefixes = follows.filter((f) => f.kind === "path").map((f) => f.target)
-    if (logins.length === 0 && prefixes.length === 0) return []
+    const people = follows.filter((f) => f.kind === "user").map((f) => f.target)
+    if (logins.length === 0 && prefixes.length === 0 && people.length === 0) return []
     const conds: SQL[] = []
     if (logins.length > 0) conds.push(inArray(sql`lower(${artifact.author_login})`, logins))
     // A path prefix is a LIKE 'prefix%'. Escape LIKE metacharacters in the prefix and
@@ -784,6 +808,11 @@ export function makeRepos(db: SqliteDb) {
     for (const p of prefixes) {
       const escaped = p.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_")
       conds.push(sql`${artifact.source_path} like ${`${escaped}%`} escape '\\'`)
+    }
+    if (people.length > 0) {
+      conds.push(inArray(artifact.author_id, people))
+      const ghIds = (await githubIdsForUsers(people)).map((g) => g.toLowerCase())
+      if (ghIds.length > 0) conds.push(inArray(sql`lower(${artifact.author_gh_id})`, ghIds))
     }
     const match = conds.length === 1 ? conds[0] : or(...conds)
     const rows = await db
@@ -793,6 +822,137 @@ export function makeRepos(db: SqliteDb) {
       .all()
     return rows.map((r) => r.id)
   }
+
+  // ---- People profiles: works, shared workspaces, follower/following -----
+  // The GitHub numeric ids one Dock user linked (raw account read; [] if absent).
+  const githubIdsForUser = (userId: string): Promise<string[]> => githubIdsForUsers([userId])
+  // A Dock user's GitHub login, derived from any artifact whose author_gh_id is one of
+  // their linked ids (we don't store the login on `account`). Null when unknown.
+  const githubLoginForUser = async (_userId: string, ghIds: string[]): Promise<string | null> => {
+    if (ghIds.length === 0) return null
+    const row = await db
+      .select({ login: artifact.author_login })
+      .from(artifact)
+      .where(and(inArray(artifact.author_gh_id, ghIds), isNotNull(artifact.author_login)))
+      .limit(1)
+      .get()
+    return row?.login ?? null
+  }
+  // Org ids where BOTH users hold a membership — widens a viewer's profile visibility.
+  const sharedOrgIds = async (viewerId: string, targetUserId: string): Promise<string[]> => {
+    const rows = await db
+      .select({ org: membership.org_id })
+      .from(membership)
+      .where(
+        and(
+          eq(membership.user_id, viewerId),
+          inArray(
+            membership.org_id,
+            db
+              .select({ o: membership.org_id })
+              .from(membership)
+              .where(eq(membership.user_id, targetUserId)),
+          ),
+        ),
+      )
+      .all()
+    return rows.map((r) => r.org)
+  }
+  // The WHERE for a person's visible work: not removed, authored by them (author_id or a
+  // linked GitHub id), and visible to the viewer (public OR in a shared workspace).
+  const userWorksConds = (userId: string, ghIds: string[], opts: ListArtifactsOpts): SQL[] => {
+    // artifactListConditions handles the keyset cursor (created_at,id); we add the rest.
+    const conds: SQL[] = [...artifactListConditions(artifact, opts), isNull(artifact.removed_at)]
+    // Authored by them: author_id is the person, OR a linked GitHub id wrote a synced version.
+    if (ghIds.length > 0) {
+      const m = or(
+        eq(artifact.author_id, userId),
+        inArray(
+          sql`lower(${artifact.author_gh_id})`,
+          ghIds.map((g) => g.toLowerCase()),
+        ),
+      )
+      if (m) conds.push(m)
+    } else {
+      conds.push(eq(artifact.author_id, userId))
+    }
+    // Visible to the viewer: public OR in a workspace they share with the profile owner.
+    const orgs = opts.visibleOrgIds ?? []
+    if (orgs.length > 0) {
+      const v = or(eq(artifact.visibility, "public"), inArray(artifact.org_id, orgs))
+      if (v) conds.push(v)
+    } else {
+      conds.push(eq(artifact.visibility, "public"))
+    }
+    return conds
+  }
+  const listUserWorks = async (
+    userId: string,
+    ghIds: string[],
+    opts: ListArtifactsOpts,
+  ): Promise<ArtifactRecord[]> => {
+    const rows = db
+      .select()
+      .from(artifact)
+      .where(and(...userWorksConds(userId, ghIds, opts)))
+      .orderBy(desc(artifact.created_at), desc(artifact.id))
+    return opts.limit ? rows.limit(opts.limit).all() : rows.all()
+  }
+  const countUserWorks = async (
+    userId: string,
+    ghIds: string[],
+    opts: ListArtifactsOpts,
+  ): Promise<number> =>
+    (
+      await db
+        .select({ c: count() })
+        .from(artifact)
+        .where(
+          and(...userWorksConds(userId, ghIds, { ...opts, cursor: undefined, limit: undefined })),
+        )
+        .get()
+    )?.c ?? 0
+  const countFollowers = async (userId: string): Promise<number> =>
+    (
+      await db
+        .select({ c: count() })
+        .from(follow)
+        .where(and(eq(follow.kind, "user"), eq(follow.target, userId)))
+        .get()
+    )?.c ?? 0
+  const countFollowing = async (userId: string): Promise<number> =>
+    (
+      await db
+        .select({ c: count() })
+        .from(follow)
+        .where(and(eq(follow.kind, "user"), eq(follow.user_id, userId)))
+        .get()
+    )?.c ?? 0
+  // Resolve a set of follow rows (people) to public profiles via the raw user table.
+  const profilesForFollow = async (
+    column: "user_id" | "target",
+    userId: string,
+    limit: number,
+  ): Promise<UserProfile[]> => {
+    try {
+      const join = column === "target" ? sql`u.id = f.target` : sql`u.id = f.user_id`
+      const pick = column === "target" ? sql`f.user_id = ${userId}` : sql`f.target = ${userId}`
+      return (await db.all(
+        sql`SELECT u.id, u.name, u.image, u.username, u.profession, u.about
+            FROM follow f JOIN user u ON ${join}
+            WHERE f.kind = 'user' AND ${pick} AND u.username IS NOT NULL
+            ORDER BY f.created_at DESC, f.id DESC LIMIT ${limit}`,
+      )) as UserProfile[]
+    } catch {
+      return []
+    }
+  }
+  // People this user follows: rows where f.user_id = userId, joined on f.target → user.
+  const listFollowing = (userId: string, limit: number): Promise<UserProfile[]> =>
+    profilesForFollow("target", userId, limit)
+  // People who follow this user: rows where f.target = userId, joined on f.user_id → user.
+  const listFollowers = (userId: string, limit: number): Promise<UserProfile[]> =>
+    profilesForFollow("user_id", userId, limit)
 
   const tagsForArtifacts = async (artifactIds: string[]): Promise<Record<string, string[]>> => {
     if (artifactIds.length === 0) return {}
@@ -1384,6 +1544,15 @@ export function makeRepos(db: SqliteDb) {
     removeFollow,
     listFollows,
     followedArtifactIds,
+    countFollowers,
+    countFollowing,
+    listFollowers,
+    listFollowing,
+    githubIdsForUser,
+    githubLoginForUser,
+    sharedOrgIds,
+    listUserWorks,
+    countUserWorks,
     tagsForArtifacts,
     setArtifactTags,
     createCollection,

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -792,33 +792,47 @@ export function makeRepos(db: SqliteDb) {
       return []
     }
   }
-  // The "following" feed's id set: live artifacts in the workspace surfaced by this user's
-  // follows — a followed login (case-insensitive), a followed path prefix, OR a followed
-  // person (matched by the artifact's denormalized author_id or the person's GitHub ids).
+  // The "following" feed's id set (live artifacts only). Two scopes ORed together:
+  //  · author/path follows match within the ACTIVE workspace (your repo-sync feed) —
+  //    a followed login (case-insensitive) or a followed source_path prefix.
+  //  · people follows match a followed person's PUBLIC work across ANY workspace
+  //    (by the artifact's denormalized author_id, or their linked GitHub ids), since a
+  //    person you follow usually publishes in their own workspace, not yours. Gated to
+  //    `public`, so following someone never surfaces their private cross-workspace work.
   const followedArtifactIds = async (userId: string, orgId: string): Promise<string[]> => {
     const follows = await listFollows(userId, orgId)
     const logins = follows.filter((f) => f.kind === "author").map((f) => f.target.toLowerCase())
     const prefixes = follows.filter((f) => f.kind === "path").map((f) => f.target)
     const people = follows.filter((f) => f.kind === "user").map((f) => f.target)
     if (logins.length === 0 && prefixes.length === 0 && people.length === 0) return []
-    const conds: SQL[] = []
-    if (logins.length > 0) conds.push(inArray(sql`lower(${artifact.author_login})`, logins))
+    const branches: SQL[] = []
+    // Workspace branch: author/path matches, scoped to the active workspace.
+    const wsConds: SQL[] = []
+    if (logins.length > 0) wsConds.push(inArray(sql`lower(${artifact.author_login})`, logins))
     // A path prefix is a LIKE 'prefix%'. Escape LIKE metacharacters in the prefix and
     // declare the escape char so a path that happens to contain % or _ matches literally.
     for (const p of prefixes) {
       const escaped = p.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_")
-      conds.push(sql`${artifact.source_path} like ${`${escaped}%`} escape '\\'`)
+      wsConds.push(sql`${artifact.source_path} like ${`${escaped}%`} escape '\\'`)
     }
+    if (wsConds.length > 0) {
+      const wsMatch = wsConds.length === 1 ? wsConds[0] : or(...wsConds)
+      if (wsMatch) branches.push(and(eq(artifact.org_id, orgId), wsMatch) as SQL)
+    }
+    // People branch: a followed person's public work, in any workspace.
     if (people.length > 0) {
-      conds.push(inArray(artifact.author_id, people))
+      const authorConds: SQL[] = [inArray(artifact.author_id, people)]
       const ghIds = (await githubIdsForUsers(people)).map((g) => g.toLowerCase())
-      if (ghIds.length > 0) conds.push(inArray(sql`lower(${artifact.author_gh_id})`, ghIds))
+      if (ghIds.length > 0) authorConds.push(inArray(sql`lower(${artifact.author_gh_id})`, ghIds))
+      const authored = authorConds.length === 1 ? authorConds[0] : or(...authorConds)
+      if (authored) branches.push(and(eq(artifact.visibility, "public"), authored) as SQL)
     }
-    const match = conds.length === 1 ? conds[0] : or(...conds)
+    if (branches.length === 0) return []
+    const match = branches.length === 1 ? branches[0] : or(...branches)
     const rows = await db
       .select({ id: artifact.id })
       .from(artifact)
-      .where(and(eq(artifact.org_id, orgId), isNull(artifact.removed_at), match))
+      .where(and(isNull(artifact.removed_at), match))
       .all()
     return rows.map((r) => r.id)
   }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -59,6 +59,10 @@ export const artifact = sqliteTable("artifact", {
   author_login: text("author_login"),
   author_avatar: text("author_avatar"),
   author_gh_id: text("author_gh_id"),
+  // The Dock user who last published this by hand (the signed-in publisher). Null for
+  // GitHub-synced versions (attributed via author_gh_id), static-token, and legacy rows.
+  // Drives the profile work-list + people-follow. Nullable so it ALTER ADDs cleanly.
+  author_id: text("author_id"),
 })
 
 export const version = sqliteTable(
@@ -80,6 +84,8 @@ export const version = sqliteTable(
     author_login: text("author_login"),
     author_avatar: text("author_avatar"),
     author_gh_id: text("author_gh_id"),
+    // The Dock user who published this version by hand; null for sync/anon/legacy.
+    author_id: text("author_id"),
     message: text("message"),
     name: text("name"),
     created_at: text("created_at").notNull().default(now),

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -88,6 +88,7 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
             author_login: v.author_login ?? null,
             author_avatar: v.author_avatar ?? null,
             author_gh_id: v.author_gh_id ?? null,
+            author_id: v.author_id ?? null,
           })
           .where(eq(artifact.id, artifactId))
           .run()

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -446,6 +446,89 @@ export function runStoreContract(
     })
   })
 
+  describe(`${label}: follows (people, cross-workspace)`, () => {
+    it("surfaces a followed person's PUBLIC work in ANY workspace, hides their private work", async () => {
+      const follower = `u_${uuid()}`
+      const followerOrg = `${ORG}_follower_ws` // the viewer's OWN workspace (not the author's)
+      const maya = `u_maya_${uuid()}`
+      const mayaOrg = `${ORG}_maya_ws` // the author publishes in HER workspace
+
+      // Maya's PUBLIC work, in her own workspace (author_id stamped on hand-publish).
+      const pub = await store.createArtifact(newArtifact({ org_id: mayaOrg, visibility: "public" }))
+      await store.addVersion(pub.id, newVersion({ author: "Maya", author_id: maya }))
+      // Maya's PRIVATE (link) work — must NOT leak into a follower's feed.
+      const priv = await store.createArtifact(newArtifact({ org_id: mayaOrg, visibility: "link" }))
+      await store.addVersion(priv.id, newVersion({ author: "Maya", author_id: maya }))
+      // Someone else's public work in another workspace — not followed, must not appear.
+      const other = await store.createArtifact(
+        newArtifact({ org_id: `${ORG}_other_ws`, visibility: "public" }),
+      )
+      await store.addVersion(
+        other.id,
+        newVersion({ author: "Nora", author_id: `u_nora_${uuid()}` }),
+      )
+
+      // The follower follows Maya the PERSON (people-follows are global, org_id "*").
+      await store.addFollow({
+        id: uuid(),
+        org_id: "*",
+        user_id: follower,
+        kind: "user",
+        target: maya,
+      })
+
+      // The feed is queried with the FOLLOWER's active workspace — which is NOT Maya's.
+      const ids = await store.followedArtifactIds(follower, followerOrg)
+      expect(ids).toContain(pub.id) // public work, surfaced across workspaces
+      expect(ids).not.toContain(priv.id) // private work never leaks
+      expect(ids).not.toContain(other.id) // not a followed person
+
+      // A tombstoned public work drops out of the feed.
+      await store.setArtifactRemoved(pub.id, new Date().toISOString())
+      expect(await store.followedArtifactIds(follower, followerOrg)).not.toContain(pub.id)
+      await store.setArtifactRemoved(pub.id, null)
+    })
+
+    it("combines an author follow (workspace-scoped) with a person follow (public, anywhere)", async () => {
+      const user = `u_${uuid()}`
+      const homeOrg = `${ORG}_home_ws`
+      const person = `u_person_${uuid()}`
+      const farOrg = `${ORG}_far_ws`
+
+      // An author-login match in the user's OWN workspace (workspace-scoped branch).
+      const local = await store.createArtifact(newArtifact({ org_id: homeOrg }))
+      await store.addVersion(local.id, newVersion({ author: "Ada", author_login: "ada" }))
+      // The same login in another workspace — author follows stay workspace-scoped, excluded.
+      const localElsewhere = await store.createArtifact(newArtifact({ org_id: farOrg }))
+      await store.addVersion(localElsewhere.id, newVersion({ author: "Ada", author_login: "ada" }))
+      // A followed person's public work in a far workspace (person branch, any workspace).
+      const personPub = await store.createArtifact(
+        newArtifact({ org_id: farOrg, visibility: "public" }),
+      )
+      await store.addVersion(personPub.id, newVersion({ author: "Pat", author_id: person }))
+
+      await store.addFollow({
+        id: uuid(),
+        org_id: homeOrg,
+        user_id: user,
+        kind: "author",
+        target: "ada",
+      })
+      await store.addFollow({
+        id: uuid(),
+        org_id: "*",
+        user_id: user,
+        kind: "user",
+        target: person,
+      })
+
+      const ids = await store.followedArtifactIds(user, homeOrg)
+      expect(ids).toContain(local.id) // author match in the active workspace
+      expect(ids).not.toContain(localElsewhere.id) // author match in another workspace — excluded
+      expect(ids).toContain(personPub.id) // followed person's public work, anywhere
+    })
+  })
+
   describe(`${label}: collections`, () => {
     it("creates a collection, adds/removes items, tracks membership roles", async () => {
       const a = await store.createArtifact(newArtifact())


### PR DESCRIPTION
Turns Dock's identity cards into a real people layer: rich profiles, follow, an activity feed, OG link-preview cards, and ambient follow buttons.

## What you get
- **Rich profile** at `/u/:handle` — single-scroll header (avatar, role, bio, verified GitHub link, Works · Followers · Following), a Follow button, and an infinite grid of everything the person has built, **visibility-scoped** to what the viewer may see (public to anyone; shared-workspace work to members).
- **Follow people** — `kind:"user"` follows (global, since a person's work spans workspaces). A followed person's **public** work flows into the existing Following feed across workspaces.
- **Ambient Follow** — one self-contained `<FollowButton>` (self-hides for anon / your own handle) in the profile header, the command-palette people search, and library list-row authors. The Following manage strip shows people as `@handle` chips.
- **OG link-preview cards** — `/u/:handle` unfurls in Slack/X/iMessage with `ogProfileCardSvg` + injected crawler meta (`/u/*` joins `run_worker_first`).
- **Notifications** — "started following you" and "someone you follow published X" (public-gated fan-out).

## Data
- `author_id` (Dock user) added to `artifact` + `version`, stamped on hand-publish (forward-only `ALTER ADD`; D1 schema regenerated). GitHub-synced work stays attributed via `author_gh_id`.

## Notable fix (caught in verification)
The following feed only surfaced a person's work if it lived in *your* workspace — broken for the normal cross-workspace follow. Fixed at both layers (`followedArtifactIds` + the `scope=following` listing): people-follows now surface a person's **public** work in any workspace, private never leaks.

## Coverage
- **Unit** — `store-contract` (SQLite + D1 + Postgres): cross-workspace public surfaces, private hidden, tombstoned drops out; author + person follows combine.
- **Integration** — `follows.test`, `profiles.test`, `embeds.test` (profile stats/visibility, follow rules, OG card + crawler shell).
- **e2e** — new `profile.smoke.spec` (3 real-browser tests): cross-workspace follow flow, own-profile, command-palette ambient follow.

Typecheck, lint (+ all custom gates), 688 unit/integration + 3 e2e green. Verified live end-to-end (profile, feed, follow, notifications, OG, crawler meta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)