### PR TITLE
test(db): restore coverage gates for the new profile/follower methods

### DIFF
--- a/packages/core/src/unfurl.test.ts
+++ b/packages/core/src/unfurl.test.ts
@@ -6,6 +6,9 @@ import {
   kindLabel,
   oembedResponse,
   ogCardSvg,
+  ogProfileCardSvg,
+  profileMetaTags,
+  profileSummary,
   type UnfurlInfo,
   unfurlDescription,
   unfurlMetaTags,
@@ -114,5 +117,91 @@ describe("oembedResponse / embedIframe", () => {
   })
   it("escapes the iframe src and title", () => {
     expect(embedIframe('http://x/"onload="', { title: '"<x>' })).toContain("&quot;onload=&quot;")
+  })
+})
+
+describe("profileSummary", () => {
+  it("includes the role when set and pluralizes works/followers", () => {
+    expect(
+      profileSummary({
+        username: "maya",
+        name: "Maya",
+        profession: "Engineering",
+        works: 4,
+        followers: 1,
+      }),
+    ).toBe("Engineering · 4 works · 1 follower · on Dock")
+  })
+  it("omits the role when unset and singularizes a count of one", () => {
+    expect(
+      profileSummary({ username: "ada", name: null, profession: null, works: 1, followers: 0 }),
+    ).toBe("1 work · 0 followers · on Dock")
+  })
+})
+
+describe("profileMetaTags", () => {
+  it("emits profile OG/Twitter tags with the name + handle, all escaped", () => {
+    const html = profileMetaTags({
+      username: "maya",
+      name: "Maya <Chen>",
+      description: "Engineering · 4 works · on Dock",
+      pageUrl: "http://dock.test/u/maya",
+      imageUrl: "http://dock.test/v1/og/u/maya",
+    })
+    expect(html).toContain('property="og:type" content="profile"')
+    expect(html).toContain('property="profile:username" content="maya"')
+    expect(html).toContain("Maya &lt;Chen&gt; (@maya)") // name + handle, angle brackets escaped
+    expect(html).toContain('name="twitter:card" content="summary_large_image"')
+    expect(html).toContain('content="http://dock.test/v1/og/u/maya"')
+    expect(html).not.toContain("Maya <Chen>") // no unescaped markup leaks
+  })
+  it("falls back to just the handle when the name is null", () => {
+    const html = profileMetaTags({
+      username: "ada",
+      name: null,
+      description: "on Dock",
+      pageUrl: "http://dock.test/u/ada",
+      imageUrl: "http://dock.test/v1/og/u/ada",
+    })
+    expect(html).toContain('content="@ada"')
+  })
+})
+
+describe("ogProfileCardSvg", () => {
+  it("renders the name, handle, summary, and first+last initials", () => {
+    const svg = ogProfileCardSvg({
+      username: "maya",
+      name: "Maya Chen",
+      profession: "Engineering",
+      works: 12,
+      followers: 48,
+    })
+    expect(svg).toContain("<svg")
+    expect(svg).toContain("Maya Chen")
+    expect(svg).toContain("@maya")
+    expect(svg).toContain(">MC<") // first+last initial in the avatar disc
+    expect(svg).toContain("12 works · 48 followers · on Dock")
+  })
+  it("escapes the name in the card markup", () => {
+    const svg = ogProfileCardSvg({
+      username: "co",
+      name: "Ada & Co",
+      profession: null,
+      works: 0,
+      followers: 0,
+    })
+    expect(svg).toContain("Ada &amp; Co")
+    expect(svg).not.toContain("Ada & Co") // raw ampersand never leaks into the SVG
+  })
+  it("uses the handle (and its initials) when the name is null", () => {
+    const svg = ogProfileCardSvg({
+      username: "ada",
+      name: null,
+      profession: null,
+      works: 0,
+      followers: 0,
+    })
+    expect(svg).toContain("@ada")
+    expect(svg).toContain(">AD<") // initials derived from the username
   })
 })

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -529,6 +529,87 @@ export function runStoreContract(
     })
   })
 
+  describe(`${label}: people profiles (works, shared orgs, follower counts)`, () => {
+    it("lists + counts a person's work, gated by visibility (public always; shared orgs widen)", async () => {
+      const author = `u_author_${uuid()}`
+      const homeOrg = `${ORG}_pp_home_${uuid()}`
+      const ghId = `gh-${uuid()}` // distinctive, unused by any other test
+      // Public work, hand-authored (author_id) in the author's workspace.
+      const pub = await store.createArtifact(newArtifact({ org_id: homeOrg, visibility: "public" }))
+      await store.addVersion(pub.id, newVersion({ author: "Author", author_id: author }))
+      // Org-visible (non-public) work by the same author.
+      const orgWork = await store.createArtifact(
+        newArtifact({ org_id: homeOrg, visibility: "org" }),
+      )
+      await store.addVersion(orgWork.id, newVersion({ author: "Author", author_id: author }))
+      // Public work attributed by a linked GitHub id (no author_id) — matched via ghIds.
+      const ghWork = await store.createArtifact(
+        newArtifact({ org_id: homeOrg, visibility: "public" }),
+      )
+      await store.addVersion(
+        ghWork.id,
+        newVersion({ author: "Gh", author_login: "gh", author_gh_id: ghId }),
+      )
+
+      // Anonymous viewer (no shared orgs): public work only — both author_id + gh-id matches.
+      const anon = await store.listUserWorks(author, [ghId], {})
+      const anonIds = anon.map((a) => a.id)
+      expect(anonIds).toContain(pub.id)
+      expect(anonIds).toContain(ghWork.id)
+      expect(anonIds).not.toContain(orgWork.id) // non-public, no shared workspace
+      expect(await store.countUserWorks(author, [ghId], {})).toBe(anon.length)
+
+      // A viewer who shares the author's workspace also sees the org-visible work.
+      const shared = await store.listUserWorks(author, [], { visibleOrgIds: [homeOrg] })
+      expect(shared.map((a) => a.id)).toContain(orgWork.id)
+      expect(await store.countUserWorks(author, [], { visibleOrgIds: [homeOrg] })).toBe(
+        shared.length,
+      )
+
+      // No author_id match and no linked gh ids → nothing.
+      expect(await store.listUserWorks(`u_${uuid()}`, [], {})).toEqual([])
+    })
+
+    it("computes the shared-workspace set between two users", async () => {
+      const a = `u_${uuid()}`
+      const b = `u_${uuid()}`
+      const shared = `${ORG}_shared_${uuid()}`
+      const onlyA = `${ORG}_onlyA_${uuid()}`
+      await store.setMembership({ id: uuid(), org_id: shared, user_id: a, role: "editor" })
+      await store.setMembership({ id: uuid(), org_id: shared, user_id: b, role: "viewer" })
+      await store.setMembership({ id: uuid(), org_id: onlyA, user_id: a, role: "owner" })
+      const orgs = await store.sharedOrgIds(a, b)
+      expect(orgs).toContain(shared)
+      expect(orgs).not.toContain(onlyA) // only `a` is a member there
+    })
+
+    it("derives a user's GitHub login from their authored artifacts (null when unknown)", async () => {
+      const gh = await store.createArtifact(newArtifact())
+      await store.addVersion(
+        gh.id,
+        newVersion({ author: "Octo", author_login: "octocat", author_gh_id: "583231-pp" }),
+      )
+      expect(await store.githubLoginForUser(`u_${uuid()}`, ["583231-pp"])).toBe("octocat")
+      expect(await store.githubLoginForUser(`u_${uuid()}`, [])).toBeNull() // no linked ids
+      expect(await store.githubLoginForUser(`u_${uuid()}`, ["no-such-gh"])).toBeNull() // no match
+    })
+
+    it("counts a person's followers and following (people-follows only)", async () => {
+      const maya = `u_maya_${uuid()}`
+      const f1 = `u_${uuid()}`
+      const f2 = `u_${uuid()}`
+      await store.addFollow({ id: uuid(), org_id: "*", user_id: f1, kind: "user", target: maya })
+      await store.addFollow({ id: uuid(), org_id: "*", user_id: f2, kind: "user", target: maya })
+      await store.addFollow({ id: uuid(), org_id: "*", user_id: maya, kind: "user", target: f1 })
+      expect(await store.countFollowers(maya)).toBe(2)
+      expect(await store.countFollowing(maya)).toBe(1)
+      // listFollowers/Following resolve names via Better Auth's user table, which this
+      // contract store doesn't provision — they degrade to [] safely (no throw).
+      expect(Array.isArray(await store.listFollowers(maya, 50))).toBe(true)
+      expect(Array.isArray(await store.listFollowing(maya, 50))).toBe(true)
+    })
+  })
+
   describe(`${label}: collections`, () => {
     it("creates a collection, adds/removes items, tracks membership roles", async () => {
       const a = await store.createArtifact(newArtifact())


### PR DESCRIPTION
Follow-up to #214. The new query methods (`listUserWorks`, `countUserWorks`, `sharedOrgIds`, `githubLoginForUser`, `countFollowers`/`countFollowing`, `listFollowers`/`listFollowing`) landed without store-contract exercise, so the post-merge coverage gates went red:
- `repos.ts` (sqlite lane) branches **57.87% < 58%**
- `pg.ts` (pg lane) lines **83.41% < 88%**, statements **79.91% < 85%**

(`pnpm test` doesn't enforce thresholds — only CI does — so it slipped through locally.)

Adds a "people profiles" contract block that runs against **sqlite + d1 + pg**, lifting both lanes at once: works list + count (visibility gate — public always, shared orgs widen), shared-workspace set, GitHub-login derivation (hit + null), and follower/following counts (+ the safe-degrade list paths).

Verified locally: db branches **57.87% → 65.74%**; the full pg lane (457 api + 66 db tests against an ephemeral Postgres) passes with **no coverage error**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)