### PR TITLE
fix(profiles): ship-review punch-list — a11y, notifications, discovery, backfill

### DIFF
--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -80,6 +80,16 @@ if (cfg.databaseUrl) {
     .run()
 }
 
+// Backfill author_id on artifacts that predate the column: where a GitHub-synced
+// artifact's commit author (author_gh_id) maps to a Dock account, attribute it to that
+// user so their synced work surfaces on their profile + feed by author_id directly.
+// Idempotent — only fills nulls that have a known GitHub→user mapping; a no-op once done.
+// Runs after the auth tables exist. Hand-published pre-feature work without a GitHub
+// identity has no recoverable author and stays null (it re-stamps on its next publish).
+void meta.backfillAuthorIds().then((n) => {
+  if (n > 0) log.info(`backfilled author_id on ${n} artifact(s)`)
+})
+
 const defaultOrg = resolveDefaultOrg(cfg.dataDir)
 
 // One-time rekey of the pre-multi-workspace "local" sentinel onto the real

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -39,6 +39,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     versionWindowMs,
     bus,
     notify,
+    background,
     bearer,
     currentUser,
     actingUser,
@@ -279,11 +280,12 @@ export const artifactRoutes = (ctx: AppContext) => {
     const passwordHash = visibility === "password" && password ? hashPassword(password) : undefined
 
     try {
-      // The authenticated principal behind this publish (signed-in user or agent).
-      // Resolved once: `name` is the display author; `id` attributes the version to a
-      // Dock user so it shows on their profile + flows to their followers. A bare
-      // static-token publish has no principal → null id (stays off any human profile).
+      // The authenticated principal behind this publish (signed-in user or agent) — its
+      // `name` is the display author. The Dock-USER behind it (null for an agent / bare
+      // static token) is what we attribute work to: `author_id` keys a person's profile
+      // + their followers' feed, so it must be a real user id, never an agent principal.
       const actor = await actingUser(c)
+      const user = await currentUser(c)
       const { artifact, version } = await publish(
         meta,
         blobs,
@@ -301,7 +303,7 @@ export const artifactRoutes = (ctx: AppContext) => {
           // always attributed to a real principal (the token's optional `author`
           // label is the one headless exception).
           author: actor?.name ?? str(body["author"]),
-          authorId: actor?.id ?? null,
+          authorId: user?.id ?? null,
           name: str(body["name"]),
           orgId: org,
           visibility,
@@ -319,25 +321,33 @@ export const artifactRoutes = (ctx: AppContext) => {
         message: version.message,
         author: version.author,
       })
-      // Fan out to the publisher's followers: "someone you follow published X". Only for
-      // a real signed-in user (agent/token publishes have no human followers) and only
-      // for publicly-visible work, so a follow never leaks a private title. Bounded list.
-      if (actor?.id && artifact.visibility === "public") {
-        for (const follower of await meta.listFollowers(actor.id, 100)) {
-          if (follower.id === actor.id) continue
-          await meta.createNotification({
-            id: newId("ntf"),
-            user_id: follower.id,
-            actor: actor.name ?? "Someone",
-            kind: "publish",
-            artifact_id: artifact.id,
-            artifact_short_id: artifact.short_id,
-            artifact_title: artifact.title,
-            thread_id: "",
-            comment_id: "",
-            preview: artifact.title ?? "published an update",
-          })
-        }
+      // Fan out to the publisher's followers: "someone you follow published X". Gated to:
+      // a real signed-in USER (agents/tokens have no human followers), a publicly-visible
+      // artifact (a follow never surfaces a private title), and a NEW artifact only —
+      // `shortId` means a republish/new version, which would otherwise spam followers on
+      // every edit. Done in the background so a popular author's fan-out never adds to
+      // publish latency (it's off the response path, like the comment-mention fan-out).
+      if (!shortId && user?.id && artifact.visibility === "public") {
+        const author = user
+        background(
+          (async () => {
+            for (const follower of await meta.listFollowers(author.id, 200)) {
+              if (follower.id === author.id) continue
+              await meta.createNotification({
+                id: newId("ntf"),
+                user_id: follower.id,
+                actor: author.name ?? author.username ?? "Someone",
+                kind: "publish",
+                artifact_id: artifact.id,
+                artifact_short_id: artifact.short_id,
+                artifact_title: artifact.title,
+                thread_id: "",
+                comment_id: "",
+                preview: artifact.title ?? "published something new",
+              })
+            }
+          })(),
+        )
       }
       // Republish can resolve comment threads in the same call.
       const resolves = body["resolves"]

--- a/apps/api/src/routes/follows.ts
+++ b/apps/api/src/routes/follows.ts
@@ -48,7 +48,8 @@ export const followRoutes = (ctx: AppContext) => {
     const follows = await meta.listFollows(me.id, org)
     // Resolve each people-follow's target id → a public handle so the client can render
     // it (and match follow-state by username) without ever holding a raw user id. One
-    // batched lookup; author/path follows pass through untouched.
+    // batched lookup; author/path follows pass through untouched. The internal id is
+    // REPLACED by the handle in `target` on the way out — it never reaches the client.
     const userIds = follows.filter((f) => f.kind === "user").map((f) => f.target)
     const byId = new Map(
       userIds.length ? (await meta.getUsers(userIds)).map((u) => [u.id, u] as const) : [],
@@ -57,7 +58,16 @@ export const followRoutes = (ctx: AppContext) => {
       follows: follows.map((f) => {
         if (f.kind !== "user") return f
         const u = byId.get(f.target)
-        return { ...f, handle: u?.username ?? null, name: u?.name ?? null, image: u?.image ?? null }
+        const handle = u?.username ?? null
+        // target := the public handle (not the internal user id). The client keys
+        // people-follows by handle everywhere; the raw id stays server-side.
+        return {
+          ...f,
+          target: handle ?? "",
+          handle,
+          name: u?.name ?? null,
+          image: u?.image ?? null,
+        }
       }),
     })
   })

--- a/apps/api/src/routes/session.ts
+++ b/apps/api/src/routes/session.ts
@@ -102,6 +102,27 @@ export const sessionRoutes = (ctx: AppContext) => {
     })
   })
 
+  // The People directory — browse opted-in (discoverable) people to find someone to
+  // follow, the home the search backend never got. With `?q=` it searches; without, it
+  // BROWSES (the deliberate difference from /v1/users/search, which never enumerates).
+  // Discoverable is opt-in, so browsing only surfaces people who chose to be found.
+  // Signed-in only; public fields only (handle/name/avatar/role) — never email.
+  app.get("/v1/people", async (c) => {
+    if (!(await currentUser(c))) return fail(c, 401, "unauthenticated")
+    const q = (c.req.query("q") ?? "").trim()
+    const found = q
+      ? await meta.searchDiscoverableUsers(q, 60)
+      : await meta.listDiscoverableUsers(60)
+    return c.json({
+      users: found.map((u) => ({
+        username: u.username,
+        name: u.name,
+        image: u.image,
+        profession: u.profession ?? null,
+      })),
+    })
+  })
+
   // A public profile by handle — the GitHub-style discovery surface. Email is
   // intentionally omitted (private); the handle, name, avatar, stats, GitHub link, and
   // (for a signed-in viewer) whether they already follow are public. Readable by anyone.

--- a/apps/api/test/follows.test.ts
+++ b/apps/api/test/follows.test.ts
@@ -181,11 +181,13 @@ describe("people follow", () => {
     expect(ids).toContain(amyPublic) // cross-workspace public work surfaces
     expect(ids).not.toContain(amyPrivate) // private work stays hidden
 
-    // GET /v1/follows resolves the people-follow's target id back to a handle (so the
-    // client renders @amy + matches follow-state by username — never a raw id).
+    // GET /v1/follows resolves the people-follow to a public handle; the internal user id
+    // never reaches the client — `target` is REPLACED by the handle (matches the client's
+    // by-username keying), so amy.id appears nowhere in the response.
     const bobFollows = await (await app.request("/v1/follows", { headers: as(bob.email) })).json()
     const userFollow = bobFollows.follows.find((f: { kind: string }) => f.kind === "user")
-    expect(userFollow).toMatchObject({ kind: "user", target: amy.id, handle: "amy", name: "Amy" })
+    expect(userFollow).toMatchObject({ kind: "user", target: "amy", handle: "amy", name: "Amy" })
+    expect(JSON.stringify(bobFollows)).not.toContain(amy.id) // no raw user id on the wire
 
     // The profile reflects it: amy has 1 follower; bob (the viewer) follows her.
     const amyProfile = await (await app.request("/v1/users/amy", { headers: as(bob.email) })).json()

--- a/apps/api/test/profiles.test.ts
+++ b/apps/api/test/profiles.test.ts
@@ -277,6 +277,61 @@ describe("profile work-list (visibility-scoped)", () => {
   })
 })
 
+// The work-list is keyset-paginated (limit+1 over-fetch → next_cursor "<created_at>|<id>").
+// Isolated app so the count is exact (other tests' works don't bleed in).
+describe("profile work-list pagination (keyset)", () => {
+  const peg: TestUser = { id: "u_peg", email: "peg@d.test", name: "Peg", username: "peg" }
+  const { app, meta } = makeAuthedApp("profile-pagination", [peg])
+
+  it("pages public work by cursor; respects + caps the limit", async () => {
+    const N = 27 // > the default page of 24, so there's a real second page
+    for (let i = 0; i < N; i++) {
+      const a = await meta.createArtifact({
+        id: newId("a"),
+        short_id: newId("s"),
+        org_id: "default",
+        slug: null,
+        title: `Doc ${i}`,
+        visibility: "public",
+        kind: "file",
+        spa: 0,
+      })
+      await meta.addVersion(a.id, {
+        id: newId("v"),
+        blob_key: `blob_${newId("b")}`,
+        content_type: "text/markdown",
+        size_bytes: 1,
+        author: "Peg",
+        author_id: peg.id,
+        message: null,
+      })
+    }
+
+    // Page 1: exactly the default page size, with a cursor to continue.
+    const p1 = await (await app.request("/v1/users/peg/artifacts")).json()
+    expect(p1.artifacts.length).toBe(24)
+    expect(p1.next_cursor).toBeTruthy()
+
+    // Page 2: the remainder, and no further cursor.
+    const p2 = await (
+      await app.request(`/v1/users/peg/artifacts?cursor=${encodeURIComponent(p1.next_cursor)}`)
+    ).json()
+    expect(p2.artifacts.length).toBe(N - 24)
+    expect(p2.next_cursor).toBeNull()
+
+    // The two pages are disjoint and together cover every work (keyset correctness).
+    const ids = new Set(
+      [...p1.artifacts, ...p2.artifacts].map((a: { short_id: string }) => a.short_id),
+    )
+    expect(ids.size).toBe(N)
+
+    // An explicit limit is honored (and yields a cursor when more remain).
+    const small = await (await app.request("/v1/users/peg/artifacts?limit=5")).json()
+    expect(small.artifacts.length).toBe(5)
+    expect(small.next_cursor).toBeTruthy()
+  })
+})
+
 describe("discoverability (on by default) + people search", () => {
   // Nova never set the flag → discoverable by default (GitHub-style).
   const nova: TestUser = {
@@ -320,5 +375,35 @@ describe("discoverability (on by default) + people search", () => {
     expect(novaMe.user.discoverable).toBe(true) // session is the seeded (unset) flag → default on
     const doxMe = await (await app.request("/v1/me", { headers: as(dox.email) })).json()
     expect(doxMe.user.discoverable).toBe(false)
+  })
+})
+
+describe("people directory (/v1/people)", () => {
+  const ivy: TestUser = { id: "u_ivy", email: "ivy@d.test", name: "Ivy", username: "ivy" }
+  // Jay opted out — should never appear in browse or search.
+  const jay: TestUser = {
+    id: "u_jay",
+    email: "jay@d.test",
+    name: "Jay",
+    username: "jay",
+    discoverable: false,
+  }
+  const { app } = makeAuthedApp("people-dir", [ivy, jay])
+  const handles = (r: { users: { username: string }[] }) => r.users.map((u) => u.username)
+
+  it("browses discoverable people (empty q), searches, hides opt-outs, requires auth", async () => {
+    // Browse (no query) lists discoverable people — the difference from /v1/users/search,
+    // which returns nothing on an empty query.
+    const browse = await (await app.request("/v1/people", { headers: as(ivy.email) })).json()
+    expect(handles(browse)).toContain("ivy")
+    expect(handles(browse)).not.toContain("jay") // opted out
+    expect(browse.users[0]).not.toHaveProperty("email") // public fields only
+
+    // With a query it searches within the discoverable set.
+    const searched = await (await app.request("/v1/people?q=iv", { headers: as(ivy.email) })).json()
+    expect(handles(searched)).toEqual(["ivy"])
+
+    // Signed-in only — anonymous is refused.
+    expect((await app.request("/v1/people")).status).toBe(401)
   })
 })

--- a/apps/web/e2e/smoke/profile.smoke.spec.ts
+++ b/apps/web/e2e/smoke/profile.smoke.spec.ts
@@ -68,6 +68,27 @@ test("follow a person from the command-palette people search", async ({ owner, s
   await expect(bob.getByTestId(`follow-${maya.username}`)).toHaveAttribute("aria-pressed", "true")
 })
 
+// The People directory: browse discoverable people and follow one without first
+// visiting their profile — the discovery surface for the follow graph.
+test("browse + follow from the People directory", async ({ owner, secondUser }) => {
+  const bob = secondUser.page
+  const maya = (await (await owner.request.get("/v1/me")).json()).user as { username: string }
+
+  await bob.goto("/people")
+  await expect(bob.getByTestId("nav-people")).toBeVisible()
+  // The directory browses discoverable people (everyone is discoverable by default), so
+  // the owner shows up with an inline Follow.
+  const followBtn = bob.getByTestId(`follow-${maya.username}`)
+  await expect(followBtn).toBeVisible()
+  await expect(followBtn).toHaveAttribute("aria-pressed", "false")
+  await followBtn.click()
+  await expect(followBtn).toHaveAttribute("aria-pressed", "true") // optimistic flip
+
+  // The follow really landed — it shows on the person's profile.
+  await bob.goto(`/u/${maya.username}`)
+  await expect(bob.getByTestId(`follow-${maya.username}`)).toHaveAttribute("aria-pressed", "true")
+})
+
 // A person can't follow themselves: the Follow button never renders on your own profile.
 test("the Follow button is absent on your own profile", async ({ owner }) => {
   const me = (await (await owner.request.get("/v1/me")).json()).user as { username: string }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -513,6 +513,10 @@ export const api = {
   // Find opted-in people by @handle or name (signed-in; empty q → []).
   searchPeople: (q: string): Promise<{ users: PublicProfile[] }> =>
     f(`/v1/users/search?q=${encodeURIComponent(q)}`, opts()).then(j),
+  // The People directory: browse opted-in people (empty q) or search them (signed-in).
+  // Unlike searchPeople, an empty query BROWSES the discoverable set.
+  people: (q?: string): Promise<{ users: PublicProfile[] }> =>
+    f(`/v1/people${q ? `?q=${encodeURIComponent(q)}` : ""}`, opts()).then(j),
   // Upload a profile picture (raster image; server validates + stores it and sets
   // user.image to the served URL). Returns the new image URL.
   uploadAvatar: (file: File): Promise<{ image: string }> => {

--- a/apps/web/src/components/follow-button.tsx
+++ b/apps/web/src/components/follow-button.tsx
@@ -20,8 +20,11 @@ export function FollowButton({
   className?: string
 }) {
   const { me } = useAuth()
-  const { isFollowingUser, toggleUser, pendingFollow } = useFollows()
-  const [hover, setHover] = useState(false)
+  const { isFollowingUser, toggleUser, isTogglingUser } = useFollows()
+  // "peek" = pointer hover OR keyboard focus, so the destructive "Unfollow" intent is
+  // revealed for touch/keyboard users too — not hover-only (the old a11y bug: a focused
+  // or tapped "Following" button gave no hint that activating it unfollows).
+  const [peek, setPeek] = useState(false)
 
   // Nothing to do for a signed-out viewer or on your own profile.
   if (!me || me.username?.toLowerCase() === username.toLowerCase()) return null
@@ -34,31 +37,41 @@ export function FollowButton({
     e.preventDefault()
     toggleUser(username)
   }
+  // Reveal-on-interaction handlers shared by pointer + keyboard.
+  const reveal = {
+    onMouseEnter: () => setPeek(true),
+    onMouseLeave: () => setPeek(false),
+    onFocus: () => setPeek(true),
+    onBlur: () => setPeek(false),
+  }
 
   if (following) {
     return (
       <Button
         variant="outline"
         size="sm"
-        disabled={pendingFollow}
+        disabled={isTogglingUser(username)}
         data-testid={`follow-${username}`}
         aria-pressed
-        onMouseEnter={() => setHover(true)}
-        onMouseLeave={() => setHover(false)}
+        // Always announce the action (unfollow), independent of the visual peek state,
+        // so a screen-reader/keyboard user knows activating this unfollows.
+        aria-label={`Unfollow @${username}`}
+        {...reveal}
         onClick={onClick}
-        className={cn(sizing, hover && "border-destructive/40 text-destructive", className)}
+        className={cn(sizing, peek && "border-destructive/40 text-destructive", className)}
       >
-        <Icon name={hover ? "close" : "check"} size={xs ? 12 : 14} />
-        {hover ? "Unfollow" : "Following"}
+        <Icon name={peek ? "close" : "check"} size={xs ? 12 : 14} />
+        {peek ? "Unfollow" : "Following"}
       </Button>
     )
   }
   return (
     <Button
       size="sm"
-      disabled={pendingFollow}
+      disabled={isTogglingUser(username)}
       data-testid={`follow-${username}`}
       aria-pressed={false}
+      aria-label={`Follow @${username}`}
       onClick={onClick}
       className={cn(sizing, className)}
     >

--- a/apps/web/src/components/nav-rail.tsx
+++ b/apps/web/src/components/nav-rail.tsx
@@ -105,6 +105,7 @@ export function NavRail() {
   const isAll = onLibrary && !search.f && !search.scope && !search.tag && !search.collection
   const isFav = onLibrary && search.f === "favorites"
   const isFollowing = onLibrary && search.scope === "following"
+  const onPeople = loc.pathname === "/people"
   const tags = summary?.tags ?? []
   // Full content in the mobile drawer; only the avatar in the collapsed desktop rail.
   const railMode = collapsed && !isMobile
@@ -254,6 +255,22 @@ export function NavRail() {
           testId="nav-following"
           onClick={closeDrawer}
         />
+        {/* People directory — a real route, not a library filter, so it's its own Link
+            (SideItem always links to "/"). Find + follow discoverable people. */}
+        <Link
+          to="/people"
+          title="People"
+          aria-label="People"
+          data-testid="nav-people"
+          aria-current={onPeople ? "page" : undefined}
+          onClick={closeDrawer}
+          className={cn(ROW_BASE, onPeople && ROW_ACTIVE, railMode && ROW_RAIL)}
+        >
+          <span className="flex w-[18px] shrink-0 items-center justify-center">
+            <Icon name="user" size={18} />
+          </span>
+          {!railMode && <span className="overflow-hidden text-ellipsis">People</span>}
+        </Link>
         {!railMode && (
           <SideLabel
             action={

--- a/apps/web/src/lib/use-follows.ts
+++ b/apps/web/src/lib/use-follows.ts
@@ -1,7 +1,7 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { useMemo } from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useMemo, useState } from "react"
 import { toast } from "sonner"
-import { api, type FollowKind } from "@/api"
+import { api, type Follow, type FollowKind } from "@/api"
 import { followsQuery } from "./queries"
 
 // Path targets are stored verbatim as repo prefixes (e.g. "docs/plans/"); a
@@ -13,49 +13,95 @@ const normalizePath = (path: string): string => (path && !path.endsWith("/") ? `
 // `login.toLowerCase()`), so compare + send the lowercased login.
 const normalizeAuthor = (login: string): string => login.toLowerCase()
 
+// The canonical key for a follow — the same value the isFollowing* sets use. People are
+// keyed by @handle (the API returns the handle in `target` for user-follows; an
+// optimistic row carries it too), authors lowercased, paths slash-normalized.
+const keyOf = (f: Pick<Follow, "kind" | "target" | "handle">): string =>
+  f.kind === "user"
+    ? `user:${(f.handle ?? f.target).toLowerCase()}`
+    : f.kind === "author"
+      ? `author:${f.target.toLowerCase()}`
+      : `path:${normalizePath(f.target)}`
+
 /**
- * The caller's follows + the derived follow-state helpers and toggle actions.
- * One query (`followsQuery`) is the single source of truth: `isFollowingAuthor`
- * / `isFollowingPath` drive the Follow buttons, and `toggle*` add/remove then
- * invalidate the query so every toggle + the manage strip reflect the change.
+ * The caller's follows + the derived follow-state helpers and toggle actions. One query
+ * (`followsQuery`) is the source of truth. Toggles are OPTIMISTIC: the follows cache is
+ * edited on click so every Follow button flips instantly (then reconciled on settle),
+ * and pending state is tracked PER target so toggling one button never disables the rest.
  */
 export function useFollows() {
   const qc = useQueryClient()
+  const fq = followsQuery().queryKey
   const { data: follows = [] } = useQuery(followsQuery())
+  // Keys (kind:target) with an in-flight mutation — per-target so one toggle doesn't
+  // disable every other Follow button on the page.
+  const [pending, setPending] = useState<ReadonlySet<string>>(new Set())
+  const mark = (key: string, on: boolean) =>
+    setPending((prev) => {
+      const next = new Set(prev)
+      if (on) next.add(key)
+      else next.delete(key)
+      return next
+    })
 
   const { authors, paths, users } = useMemo(() => {
     const authors = new Set<string>()
     const paths = new Set<string>()
-    // People-follows store a user id in `target`, but the API resolves `handle` for them,
+    // People-follows store the @handle in `target` (the API resolves it from the id),
     // so we key follow-state by the (lowercased) username — what every Follow button has.
     const users = new Set<string>()
     for (const fol of follows) {
       if (fol.kind === "author") authors.add(fol.target)
       else if (fol.kind === "path") paths.add(fol.target)
-      else if (fol.kind === "user" && fol.handle) users.add(fol.handle.toLowerCase())
+      else if (fol.kind === "user") users.add((fol.handle ?? fol.target).toLowerCase())
     }
     return { authors, paths, users }
   }, [follows])
 
-  // A follow change shifts both the manage strip (follows) and any open profile (its
-  // stats + followed_by_me), so refresh both.
-  const invalidate = () => {
-    qc.invalidateQueries({ queryKey: followsQuery().queryKey })
+  // Optimistically edit the follows cache so the button flips before the round-trip;
+  // returns a rollback snapshot. `op` add inserts a placeholder row; remove filters it.
+  const optimistic = (op: "add" | "remove", kind: FollowKind, target: string): Follow[] => {
+    const prev = qc.getQueryData<Follow[]>(fq) ?? []
+    const key = keyOf({ kind, target, handle: kind === "user" ? target : null })
+    qc.setQueryData<Follow[]>(fq, (cur = []) => {
+      if (op === "remove") return cur.filter((f) => keyOf(f) !== key)
+      if (cur.some((f) => keyOf(f) === key)) return cur
+      const row: Follow = {
+        id: `optimistic:${key}`,
+        org_id: kind === "user" ? "*" : "",
+        user_id: "",
+        kind,
+        target,
+        created_at: new Date().toISOString(),
+        ...(kind === "user" ? { handle: target } : {}),
+      }
+      return [row, ...cur]
+    })
+    return prev
+  }
+
+  // A settled follow change also shifts any open profile (its stats + followed_by_me),
+  // so reconcile both query trees with the server once the mutation resolves.
+  const reconcile = () => {
+    qc.invalidateQueries({ queryKey: fq })
     qc.invalidateQueries({ queryKey: ["profile"] })
   }
 
-  const add = useMutation({
-    mutationFn: ({ kind, target }: { kind: FollowKind; target: string }) =>
-      api.addFollow(kind, target),
-    onSuccess: invalidate,
-    onError: (e) => toast.error((e as Error).message),
-  })
-  const remove = useMutation({
-    mutationFn: ({ kind, target }: { kind: FollowKind; target: string }) =>
-      api.removeFollow(kind, target),
-    onSuccess: invalidate,
-    onError: (e) => toast.error((e as Error).message),
-  })
+  const run = (op: "add" | "remove", kind: FollowKind, target: string) => {
+    const key = keyOf({ kind, target, handle: kind === "user" ? target : null })
+    mark(key, true)
+    const snapshot = optimistic(op, kind, target)
+    const call = op === "add" ? api.addFollow(kind, target) : api.removeFollow(kind, target)
+    void Promise.resolve(call)
+      .catch((e) => {
+        qc.setQueryData<Follow[]>(fq, snapshot) // rollback
+        toast.error((e as Error).message)
+      })
+      .finally(() => {
+        mark(key, false)
+        reconcile()
+      })
+  }
 
   return {
     follows,
@@ -64,25 +110,22 @@ export function useFollows() {
     // Flip the follow state for an author (by GitHub login).
     toggleAuthor: (login: string) => {
       const target = normalizeAuthor(login)
-      if (authors.has(target)) remove.mutate({ kind: "author", target })
-      else add.mutate({ kind: "author", target })
+      run(authors.has(target) ? "remove" : "add", "author", target)
     },
     // Flip the follow state for a repo path prefix (a folder).
     togglePath: (path: string) => {
       const target = normalizePath(path)
-      if (paths.has(target)) remove.mutate({ kind: "path", target })
-      else add.mutate({ kind: "path", target })
+      run(paths.has(target) ? "remove" : "add", "path", target)
     },
     // Are we following this person? (by @handle — the universal key for Follow buttons).
     isFollowingUser: (username: string) => users.has(username.toLowerCase()),
     // Flip the follow state for a person by @handle (state read from the live follows set).
     toggleUser: (username: string) => {
-      if (users.has(username.toLowerCase())) remove.mutate({ kind: "user", target: username })
-      else add.mutate({ kind: "user", target: username })
+      run(users.has(username.toLowerCase()) ? "remove" : "add", "user", username)
     },
-    // True while a follow mutation is in flight (disable the button).
-    pendingFollow: add.isPending || remove.isPending,
+    // Is THIS person's follow toggle mid-flight? (per-target, not a global flag).
+    isTogglingUser: (username: string) => pending.has(`user:${username.toLowerCase()}`),
     // Drop a follow directly (the manage strip's × buttons).
-    unfollow: (kind: FollowKind, target: string) => remove.mutate({ kind, target }),
+    unfollow: (kind: FollowKind, target: string) => run("remove", kind, target),
   }
 }

--- a/apps/web/src/pages/people.tsx
+++ b/apps/web/src/pages/people.tsx
@@ -1,0 +1,107 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
+import { useEffect, useState } from "react"
+import { api, type PublicProfile } from "@/api"
+import { FollowButton } from "@/components/follow-button"
+import { EmptyState } from "@/components/shared/empty-state"
+import { Spinner } from "@/components/shared/spinner"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Input } from "@/components/ui/input"
+
+// The People directory — browse + search discoverable people and follow them. This is
+// the discovery surface the follow graph was missing: a way to FIND someone to follow,
+// not just stumble on an author chip. Empty query browses; typing searches (debounced).
+export function People() {
+  const [q, setQ] = useState("")
+  const [debounced, setDebounced] = useState("")
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(q.trim()), 220)
+    return () => clearTimeout(t)
+  }, [q])
+
+  const { data, isPending, isError } = useQuery({
+    queryKey: ["people", debounced],
+    queryFn: () => api.people(debounced || undefined).then((r) => r.users),
+    placeholderData: keepPreviousData,
+  })
+  const people = data ?? []
+
+  return (
+    <div className="mx-auto w-full max-w-3xl p-6 sm:p-8">
+      <h1 className="font-display text-2xl font-semibold text-foreground">People</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Find people on Dock and follow their work.
+      </p>
+      <Input
+        type="search"
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+        placeholder="Search people by name or @handle…"
+        aria-label="Search people"
+        data-testid="people-search"
+        className="mt-4"
+      />
+
+      <div className="mt-5">
+        {isPending ? (
+          <div className="py-10">
+            <Spinner />
+          </div>
+        ) : isError ? (
+          <EmptyState>Couldn't load people right now.</EmptyState>
+        ) : people.length === 0 ? (
+          <div data-testid="people-empty">
+            <EmptyState>
+              {debounced
+                ? `No people match "${debounced}".`
+                : "No discoverable people yet. People who turn on discoverability show up here."}
+            </EmptyState>
+          </div>
+        ) : (
+          <ul
+            className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-3"
+            data-testid="people-grid"
+          >
+            {people.map((p) => (
+              <PersonCard key={p.username} person={p} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// One directory row: identity links to the profile; Follow sits beside it (a sibling,
+// not nested in the link — no interactive-inside-interactive). FollowButton self-hides
+// for your own handle and signed-out viewers.
+function PersonCard({ person: p }: { person: PublicProfile }) {
+  const initials = (p.name ?? p.username).slice(0, 2).toUpperCase()
+  return (
+    <li className="flex items-center gap-3 rounded-lg border border-border bg-card p-3 transition-colors hover:border-primary">
+      <Link
+        to="/u/$handle"
+        params={{ handle: p.username }}
+        data-testid={`people-card-${p.username}`}
+        className="flex min-w-0 flex-1 items-center gap-3 outline-none"
+      >
+        <Avatar className="size-9 shrink-0">
+          {p.image && <AvatarImage src={p.image} alt={p.name ?? p.username} />}
+          <AvatarFallback>{initials}</AvatarFallback>
+        </Avatar>
+        <span className="min-w-0">
+          {p.name && (
+            <span className="block truncate text-sm font-medium text-foreground">{p.name}</span>
+          )}
+          <span className="block truncate font-mono text-xs text-muted-foreground">
+            @{p.username}
+          </span>
+          {p.profession && (
+            <span className="block truncate text-2xs text-accent-foreground">{p.profession}</span>
+          )}
+        </span>
+      </Link>
+      <FollowButton username={p.username} size="xs" className="shrink-0" />
+    </li>
+  )
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WelcomeRouteImport } from './routes/welcome'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as PeopleRouteImport } from './routes/people'
 import { Route as NewRouteImport } from './routes/new'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as IndexRouteImport } from './routes/index'
@@ -25,6 +26,11 @@ const WelcomeRoute = WelcomeRouteImport.update({
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PeopleRoute = PeopleRouteImport.update({
+  id: '/people',
+  path: '/people',
   getParentRoute: () => rootRouteImport,
 } as any)
 const NewRoute = NewRouteImport.update({
@@ -57,6 +63,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/new': typeof NewRoute
+  '/people': typeof PeopleRoute
   '/settings': typeof SettingsRoute
   '/welcome': typeof WelcomeRoute
   '/a/$ref': typeof ARefRoute
@@ -66,6 +73,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/new': typeof NewRoute
+  '/people': typeof PeopleRoute
   '/settings': typeof SettingsRoute
   '/welcome': typeof WelcomeRoute
   '/a/$ref': typeof ARefRoute
@@ -76,6 +84,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/new': typeof NewRoute
+  '/people': typeof PeopleRoute
   '/settings': typeof SettingsRoute
   '/welcome': typeof WelcomeRoute
   '/a/$ref': typeof ARefRoute
@@ -87,6 +96,7 @@ export interface FileRouteTypes {
     | '/'
     | '/login'
     | '/new'
+    | '/people'
     | '/settings'
     | '/welcome'
     | '/a/$ref'
@@ -96,6 +106,7 @@ export interface FileRouteTypes {
     | '/'
     | '/login'
     | '/new'
+    | '/people'
     | '/settings'
     | '/welcome'
     | '/a/$ref'
@@ -105,6 +116,7 @@ export interface FileRouteTypes {
     | '/'
     | '/login'
     | '/new'
+    | '/people'
     | '/settings'
     | '/welcome'
     | '/a/$ref'
@@ -115,6 +127,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LoginRoute: typeof LoginRoute
   NewRoute: typeof NewRoute
+  PeopleRoute: typeof PeopleRoute
   SettingsRoute: typeof SettingsRoute
   WelcomeRoute: typeof WelcomeRoute
   ARefRoute: typeof ARefRoute
@@ -135,6 +148,13 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/settings'
       preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/people': {
+      id: '/people'
+      path: '/people'
+      fullPath: '/people'
+      preLoaderRoute: typeof PeopleRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/new': {
@@ -179,6 +199,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LoginRoute: LoginRoute,
   NewRoute: NewRoute,
+  PeopleRoute: PeopleRoute,
   SettingsRoute: SettingsRoute,
   WelcomeRoute: WelcomeRoute,
   ARefRoute: ARefRoute,

--- a/apps/web/src/routes/people.tsx
+++ b/apps/web/src/routes/people.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { People } from "../pages/people"
+
+// The People directory: /people — browse + search discoverable people and follow them.
+// In-app (the shell + nav rail point here); the API requires a signed-in user.
+export const Route = createFileRoute("/people")({
+  component: People,
+})

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -479,6 +479,10 @@ export interface MetaStore {
   /** People search: opted-in (discoverable) profiles matching `q` on username or
    *  name, capped to `limit`. Empty `q` returns nothing (no full enumeration). */
   searchDiscoverableUsers(q: string, limit: number): Promise<UserProfile[]>
+  /** Browse the people directory: opted-in (discoverable) profiles with a claimed handle,
+   *  ordered by handle, capped to `limit`. The browse counterpart to
+   *  searchDiscoverableUsers — powers the People page's default view. */
+  listDiscoverableUsers(limit: number): Promise<UserProfile[]>
 
   // ---- Notifications (in-app, one row per recipient) --------------------
   createNotification(n: NewNotification): Promise<void>
@@ -542,6 +546,13 @@ export interface MetaStore {
    *  sync backfill path to stamp an existing tracked artifact's author from its last
    *  commit without republishing. `null` clears all four columns. */
   setArtifactAuthor(artifactId: string, author: GithubAuthor | null): Promise<void>
+  /** One-shot, idempotent: fill `artifact.author_id` for rows that predate the column,
+   *  where the artifact's `author_gh_id` maps to a Dock account (Better Auth `account`,
+   *  providerId='github'). Only touches rows with a null author_id and a known mapping;
+   *  a no-op once applied. Returns the number of rows updated. Best-effort (0 if the auth
+   *  tables are absent). Pre-feature hand-published work without a GitHub identity has no
+   *  recoverable author and is left null. */
+  backfillAuthorIds(): Promise<number>
   createAuditLog(a: NewAuditLog): Promise<void>
   /** Moderation history, newest first. One workspace's, or — super-admin, orgId
    *  undefined — the whole instance's. Optionally narrowed to one artifact. */

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -159,6 +159,23 @@ export function createD1Store(d1: D1Database): MetaStore {
         return []
       }
     },
+    // Idempotent backfill (see sqlite.ts) — stamp author_id from a known author_gh_id→user mapping.
+    backfillAuthorIds: async (): Promise<number> => {
+      try {
+        const r = (await db.run(
+          sql`UPDATE artifact SET author_id = (
+                SELECT u.id FROM account a JOIN user u ON u.id = a.userId
+                WHERE a.providerId = 'github' AND a.accountId = artifact.author_gh_id LIMIT 1)
+              WHERE author_id IS NULL AND author_gh_id IS NOT NULL
+                AND EXISTS (
+                  SELECT 1 FROM account a JOIN user u ON u.id = a.userId
+                  WHERE a.providerId = 'github' AND a.accountId = artifact.author_gh_id)`,
+        )) as { meta?: { changes?: number } }
+        return r.meta?.changes ?? 0
+      } catch {
+        return 0
+      }
+    },
     getUserByUsername: async (username: string): Promise<UserProfile | null> => {
       try {
         return (
@@ -201,13 +218,25 @@ export function createD1Store(d1: D1Database): MetaStore {
       const s = q.trim().toLowerCase()
       if (!s) return []
       try {
-        const like = `%${s}%`
+        // Escape LIKE metacharacters so a literal %/_/\ matches itself, not "anything".
+        const like = `%${s.replace(/[\\%_]/g, (ch) => `\\${ch}`)}%`
         return (await db.all(
           // discoverable IS NOT 0 → true OR unset(null) both match (on by default);
           // only an explicit 0 (opted out) is excluded.
           sql`SELECT id, name, image, username, profession, about FROM user
               WHERE discoverable IS NOT 0 AND username IS NOT NULL
-                AND (lower(username) LIKE ${like} OR lower(name) LIKE ${like})
+                AND (lower(username) LIKE ${like} ESCAPE '\\' OR lower(name) LIKE ${like} ESCAPE '\\')
+              ORDER BY username LIMIT ${limit}`,
+        )) as UserProfile[]
+      } catch {
+        return []
+      }
+    },
+    listDiscoverableUsers: async (limit: number): Promise<UserProfile[]> => {
+      try {
+        return (await db.all(
+          sql`SELECT id, name, image, username, profession, about FROM user
+              WHERE discoverable IS NOT 0 AND username IS NOT NULL
               ORDER BY username LIMIT ${limit}`,
         )) as UserProfile[]
       } catch {

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1278,6 +1278,23 @@ export class PgMetaStore implements MetaStore {
       return []
     }
   }
+  // Idempotent backfill (see sqlite.ts) — stamp author_id from a known author_gh_id→user mapping.
+  async backfillAuthorIds(): Promise<number> {
+    try {
+      const res = await this.pool.query(
+        `UPDATE "artifact" SET author_id = (
+           SELECT u.id FROM "account" a JOIN "user" u ON u.id = a."userId"
+           WHERE a."providerId" = 'github' AND a."accountId" = "artifact".author_gh_id LIMIT 1)
+         WHERE author_id IS NULL AND author_gh_id IS NOT NULL
+           AND EXISTS (
+             SELECT 1 FROM "account" a JOIN "user" u ON u.id = a."userId"
+             WHERE a."providerId" = 'github' AND a."accountId" = "artifact".author_gh_id)`,
+      )
+      return res.rowCount ?? 0
+    } catch {
+      return 0
+    }
+  }
   async getUserByUsername(username: string): Promise<UserProfile | null> {
     try {
       const { rows } = await this.pool.query(
@@ -1334,7 +1351,9 @@ export class PgMetaStore implements MetaStore {
     const s = q.trim()
     if (!s) return []
     try {
-      const like = `%${s}%`
+      // Escape ILIKE metacharacters so a literal %/_/\ in the query matches itself —
+      // a search for "%" finds nothing, not everyone.
+      const like = `%${s.replace(/[\\%_]/g, (ch) => `\\${ch}`)}%`
       const { rows } = await this.pool.query(
         // discoverable IS NOT FALSE → true OR unset(null) both match (on by
         // default); only an explicit false (opted out) is excluded.
@@ -1343,6 +1362,19 @@ export class PgMetaStore implements MetaStore {
            AND (username ILIKE $1 OR name ILIKE $1)
          ORDER BY username LIMIT $2`,
         [like, limit],
+      )
+      return rows as UserProfile[]
+    } catch {
+      return []
+    }
+  }
+  async listDiscoverableUsers(limit: number): Promise<UserProfile[]> {
+    try {
+      const { rows } = await this.pool.query(
+        `SELECT id, name, image, username, profession, about FROM "user"
+         WHERE discoverable IS NOT FALSE AND username IS NOT NULL
+         ORDER BY username LIMIT $1`,
+        [limit],
       )
       return rows as UserProfile[]
     } catch {

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -276,6 +276,26 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
         return []
       }
     },
+    // Idempotent backfill: stamp author_id where a synced artifact's author_gh_id maps
+    // to a Dock account and author_id is still null. Correlated subquery; only fills
+    // rows with a known mapping, so it's a no-op once applied.
+    backfillAuthorIds: async (): Promise<number> => {
+      try {
+        return raw
+          .prepare(
+            `UPDATE artifact SET author_id = (
+               SELECT u.id FROM account a JOIN user u ON u.id = a.userId
+               WHERE a.providerId = 'github' AND a.accountId = artifact.author_gh_id LIMIT 1)
+             WHERE author_id IS NULL AND author_gh_id IS NOT NULL
+               AND EXISTS (
+                 SELECT 1 FROM account a JOIN user u ON u.id = a.userId
+                 WHERE a.providerId = 'github' AND a.accountId = artifact.author_gh_id)`,
+          )
+          .run().changes
+      } catch {
+        return 0
+      }
+    },
     getUserByUsername: async (username): Promise<UserProfile | null> => {
       try {
         return (
@@ -328,17 +348,34 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
       const s = q.trim().toLowerCase()
       if (!s) return []
       try {
-        const like = `%${s}%`
+        // Escape LIKE metacharacters so a literal %/_/\ in the query matches itself —
+        // a search for "%" finds nothing, not everyone.
+        const like = `%${s.replace(/[\\%_]/g, (ch) => `\\${ch}`)}%`
         return raw
           .prepare(
             // discoverable IS NOT 0 → true OR unset(null) both match (on by
             // default); only an explicit 0 (opted out) is excluded.
             `SELECT id, name, image, username, profession, about FROM user
              WHERE discoverable IS NOT 0 AND username IS NOT NULL
-               AND (lower(username) LIKE ? OR lower(name) LIKE ?)
+               AND (lower(username) LIKE ? ESCAPE '\\' OR lower(name) LIKE ? ESCAPE '\\')
              ORDER BY username LIMIT ?`,
           )
           .all(like, like, limit) as UserProfile[]
+      } catch {
+        return []
+      }
+    },
+    // Browse mode for the People directory: every discoverable, handle-claimed user,
+    // ordered by handle, capped. (The empty-query counterpart to the search above.)
+    listDiscoverableUsers: async (limit): Promise<UserProfile[]> => {
+      try {
+        return raw
+          .prepare(
+            `SELECT id, name, image, username, profession, about FROM user
+             WHERE discoverable IS NOT 0 AND username IS NOT NULL
+             ORDER BY username LIMIT ?`,
+          )
+          .all(limit) as UserProfile[]
       } catch {
         return []
       }

--- a/packages/db/test/pg-store.test.ts
+++ b/packages/db/test/pg-store.test.ts
@@ -151,6 +151,74 @@ if (PG_URL) {
           expect(await store.getUsers(["x"])).toEqual([])
           expect(await store.getUserByUsername("ghost")).toBeNull()
           expect(await store.searchDiscoverableUsers("a", 10)).toEqual([])
+          expect(await store.listDiscoverableUsers(10)).toEqual([])
+          expect(await store.listFollowers("u1", 10)).toEqual([])
+          expect(await store.listFollowing("u1", 10)).toEqual([])
+          expect(await store.backfillAuthorIds()).toBe(0)
+        },
+      )
+    })
+
+    it("browses discoverable people, resolves follower/following profiles, backfills author_id", async () => {
+      await inSchema(
+        async (boot, schema) => {
+          await boot.query(
+            `CREATE TABLE ${schema}."user" (id text primary key, email text, name text, image text, username text, discoverable boolean, profession text, about text)`,
+          )
+          await boot.query(
+            `CREATE TABLE ${schema}."account" (id text primary key, "accountId" text, "providerId" text, "userId" text)`,
+          )
+          await boot.query(
+            `INSERT INTO ${schema}."user"(id,name,username,discoverable,profession) VALUES
+               ('u1','Amy','amy',NULL,'Engineering'),('u2','Bo','bo',true,'Design'),
+               ('u3','Cy','cy',false,NULL),('u4','Dee',NULL,NULL,NULL)`,
+          )
+          await boot.query(
+            `INSERT INTO ${schema}."account"(id,"accountId","providerId","userId") VALUES ('acc','9999','github','u1')`,
+          )
+        },
+        async (store) => {
+          // Browse: discoverable + handle-claimed only, ordered by handle.
+          expect((await store.listDiscoverableUsers(10)).map((x) => x.username)).toEqual([
+            "amy",
+            "bo",
+          ])
+          // Follower / following lists resolve via the user-table JOIN (the pg-specific
+          // raw SQL — a column-case typo here would fail this).
+          await store.addFollow({
+            id: "f1",
+            org_id: "*",
+            user_id: "u2",
+            kind: "user",
+            target: "u1",
+          })
+          expect((await store.listFollowers("u1", 10)).map((x) => x.username)).toEqual(["bo"])
+          expect((await store.listFollowing("u2", 10)).map((x) => x.username)).toEqual(["amy"])
+          expect(await store.listFollowers("u2", 10)).toEqual([])
+          // Backfill author_id from author_gh_id → Dock user; idempotent.
+          const a = await store.createArtifact({
+            id: "a1",
+            short_id: "sh1",
+            org_id: "o",
+            slug: null,
+            title: "T",
+            visibility: "public",
+            kind: "file",
+            spa: 0,
+          })
+          await store.addVersion(a.id, {
+            id: "v1",
+            blob_key: "b",
+            content_type: "text/html",
+            size_bytes: 1,
+            author: "Amy",
+            author_gh_id: "9999",
+            message: null,
+          })
+          expect((await store.getArtifactById("a1"))?.author_id).toBeNull()
+          expect(await store.backfillAuthorIds()).toBe(1)
+          expect((await store.getArtifactById("a1"))?.author_id).toBe("u1")
+          expect(await store.backfillAuthorIds()).toBe(0)
         },
       )
     })

--- a/packages/db/test/sqlite-store.test.ts
+++ b/packages/db/test/sqlite-store.test.ts
@@ -141,6 +141,87 @@ describe("parseOAuthScopes", () => {
   })
 })
 
+// The people directory (browse), follower/following lists (the user-table JOIN), and the
+// author_id backfill all read Better Auth's `user`/`account` tables, so — like the
+// user-directory methods above — they're seeded + asserted per-dialect here.
+describe("sqlite store: people directory + follower lists + author backfill", () => {
+  it("tolerates the auth tables being absent (fresh store) → empty / zero", async () => {
+    const fresh = new SqliteMetaStore(":memory:")
+    expect(await fresh.listDiscoverableUsers(10)).toEqual([])
+    expect(await fresh.listFollowers("u1", 10)).toEqual([])
+    expect(await fresh.listFollowing("u1", 10)).toEqual([])
+    expect(await fresh.backfillAuthorIds()).toBe(0)
+    fresh.close()
+  })
+
+  it("browses discoverable people, resolves follower/following profiles, backfills author_id", async () => {
+    const { mkdtempSync, rmSync } = await import("node:fs")
+    const { tmpdir } = await import("node:os")
+    const { join } = await import("node:path")
+    const dir = mkdtempSync(join(tmpdir(), "dock-db-people-"))
+    const path = join(dir, "store.db")
+    const s = new SqliteMetaStore(path)
+    const raw = new Database(path)
+    raw.exec(
+      `CREATE TABLE user (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT, username TEXT, discoverable INTEGER, profession TEXT, about TEXT)`,
+    )
+    raw.exec(
+      `CREATE TABLE account (id TEXT PRIMARY KEY, "accountId" TEXT, "providerId" TEXT, "userId" TEXT)`,
+    )
+    const insU = raw.prepare(
+      `INSERT INTO user (id, name, username, discoverable, profession) VALUES (?,?,?,?,?)`,
+    )
+    insU.run("u1", "Amy", "amy", null, "Engineering") // discoverable (null = on by default)
+    insU.run("u2", "Bo", "bo", 1, "Design") // discoverable on
+    insU.run("u3", "Cy", "cy", 0, null) // opted out → excluded
+    insU.run("u4", "Dee", null, null, null) // no handle → excluded
+    raw
+      .prepare(`INSERT INTO account (id, "accountId", "providerId", "userId") VALUES (?,?,?,?)`)
+      .run("acc", "9999", "github", "u1")
+    raw.close()
+
+    // Browse: discoverable + handle-claimed only, ordered by handle. cy (opted out) and
+    // dee (no handle) are excluded.
+    expect((await s.listDiscoverableUsers(10)).map((u) => u.username)).toEqual(["amy", "bo"])
+
+    // Follower / following lists resolve to public profiles (the user-table JOIN happy
+    // path — the branch the cross-dialect contract can't reach without a user table).
+    await s.addFollow({ id: "f1", org_id: "*", user_id: "u2", kind: "user", target: "u1" }) // bo → amy
+    expect((await s.listFollowers("u1", 10)).map((u) => u.username)).toEqual(["bo"])
+    expect((await s.listFollowing("u2", 10)).map((u) => u.username)).toEqual(["amy"])
+    expect(await s.listFollowers("u2", 10)).toEqual([]) // nobody follows bo
+
+    // Backfill: a synced artifact whose author_gh_id maps to a Dock user gets author_id
+    // stamped; a second run is a no-op (idempotent).
+    const a = await s.createArtifact({
+      id: "a1",
+      short_id: "sh1",
+      org_id: "o",
+      slug: null,
+      title: "T",
+      visibility: "public",
+      kind: "file",
+      spa: 0,
+    })
+    await s.addVersion(a.id, {
+      id: "v1",
+      blob_key: "b",
+      content_type: "text/html",
+      size_bytes: 1,
+      author: "Amy",
+      author_gh_id: "9999",
+      message: null,
+    })
+    expect((await s.getArtifactById("a1"))?.author_id).toBeNull()
+    expect(await s.backfillAuthorIds()).toBe(1)
+    expect((await s.getArtifactById("a1"))?.author_id).toBe("u1")
+    expect(await s.backfillAuthorIds()).toBe(0) // idempotent — nothing left to fill
+
+    s.close()
+    rmSync(dir, { recursive: true, force: true })
+  })
+})
+
 // getOAuthGrant / getOAuthClientName / pruneStaleOAuthClients read Better Auth's
 // oauth-provider tables (created out of band by the auth migrator), so — like the
 // user-directory methods above — they're seeded and asserted per-dialect here.


### PR DESCRIPTION
Addresses the [Profiles II — Ship Review](https://dock.siftai.workers.dev/a/profiles-ii-ship-review-post-merge-mun1a3z9) punch-list. Fixes every actionable finding; two "P1s" turned out to be false positives (the review grepped the wrong files), verified in code.

### P1 — fixed
- **FollowButton a11y** — "Unfollow" was hover-only (broken on touch/keyboard). Now revealed on hover **or** focus, with a stable `aria-label="Unfollow @handle"` so SR/keyboard users always know what activating does.
- **`author_id` backfill** — idempotent boot pass stamps `author_id` where a synced artifact's `author_gh_id` maps to a Dock account, so pre-column work shows on profiles/feeds.

### P1 — false positives (already shipped; verified)
- *"No post-onboarding profile editing"* — Settings → Profile (`profile-section.tsx`) already edits username + role/about + discoverability (default tab).
- *"pg follower-JOIN untested"* — `scripts/test-pg.sh` runs the api suite against Postgres, so the follower/following assertions already exercise the pg JOIN. (Strengthened anyway.)

### P2 — fixed
- Publish notifications fire only on a **new artifact** (not every version) and fan out in the **background**, off the request path.
- **Optimistic** follow with **per-target** pending (one toggle no longer disables every Follow button).
- `GET /v1/follows` no longer returns the followed user's **internal id** — `target` is the public handle.
- **People directory** — new `/people` page (browse + search + inline Follow) + `GET /v1/people` + nav entry: the missing "find someone to follow" surface.

### P3 — fixed
- People-search LIKE/ILIKE metacharacters escaped; `author_id` stamped only for real users (never an agent/token).

### Tests
- Dialect store-contract tests (**sqlite + pg**): browse, follower/following JOIN happy-path, backfill (+ idempotency).
- `profiles.test`: work-list **keyset pagination** (27 works) + the `/v1/people` endpoint.
- `follows.test`: asserts the internal id never appears on the wire.
- **e2e**: People-directory browse+follow smoke; existing follow flow still green.

Verified locally: typecheck, lint, api 459, web 58, db coverage (88.4/65.7/90.8), core, the full **pg lane** (api 459 + db 67 against ephemeral Postgres), and 4 e2e.

**Deferred (flagged, not dropped):** the full Home recency-stream replan — a speculative redesign of the working library with real regression risk. The People directory delivers the review's discovery ask without that rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)