### PR TITLE
feat(comments): "Needs your feedback" signals — reconciled from #210 (dup follow dropped)

### DIFF
--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -102,6 +102,13 @@ export const artifactRoutes = (ctx: AppContext) => {
       if (!me) return c.json({ artifacts: [], next_cursor: null })
       narrow(await meta.followedArtifactIds(me.id, await activeWorkspace(c)))
     }
+    // scope=needs_feedback → artifacts in the active workspace with an open thread you're
+    // tagged in or have commented on. Drives the home's "Needs your feedback" section.
+    const needsFeedback = c.req.query("scope") === "needs_feedback"
+    if (needsFeedback) {
+      if (!me) return c.json({ artifacts: [], next_cursor: null })
+      narrow(await meta.artifactIdsNeedingFeedback(me.id, await activeWorkspace(c)))
+    }
     if (tag) narrow(await meta.artifactIdsByTag(tag))
     if (favOnly) narrow(favIds)
 
@@ -169,6 +176,9 @@ export const artifactRoutes = (ctx: AppContext) => {
     const handleByGhId = await resolveHandles(meta, [
       ...new Set(page.map((a) => a.author_gh_id).filter((x): x is string => !!x)),
     ])
+    // Per-artifact comment signals for the viewer (open-thread count + tagged/authored
+    // flags) — drives the inline comment badge and the "needs your feedback" featuring.
+    const feedback = me ? await meta.commentSignals(pageIds, me.id) : {}
     return c.json({
       artifacts: page.map((a) => ({
         ...toJson(deps.baseUrl, a, []),
@@ -178,6 +188,8 @@ export const artifactRoutes = (ctx: AppContext) => {
         // The current author as a resolved profile (name/login/avatar + Dock handle), so
         // the list can render the last editor + filter by them.
         author: authorProfile(a, handleByGhId),
+        // open_threads + mentions_me + i_participated (defaults for anon / no signals).
+        ...(feedback[a.id] ?? { open_threads: 0, mentions_me: false, i_participated: false }),
       })),
       next_cursor,
       ...(collectionInfo ? { collection: collectionInfo } : {}),

--- a/apps/api/test/comment-signals.test.ts
+++ b/apps/api/test/comment-signals.test.ts
@@ -1,0 +1,146 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { publish } from "@dock/core"
+import { SqliteMetaStore } from "@dock/db/sqlite"
+import { FsBlobStore } from "@dock/storage/fs"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+
+// Backend for the "Needs your feedback" feature: per-artifact comment signals (open
+// thread count + whether the viewer is tagged in or authored an open thread), and the
+// set of artifacts needing the viewer's feedback. Mentions live in comment.meta JSON;
+// "needs feedback" = tagged OR authored, in an OPEN thread only.
+
+const dir = mkdtempSync(join(tmpdir(), "dock-comment-signals-"))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+const ME = "user_me"
+const OTHER = "user_other"
+const mentionMeta = (id: string) => JSON.stringify({ mentions: [{ id, name: "Me" }] })
+
+let meta: SqliteMetaStore
+let ids: { mentioned: string; authored: string; uninvolved: string; resolved: string }
+
+beforeAll(async () => {
+  meta = new SqliteMetaStore(join(dir, "signals.db"))
+  const blobs = new FsBlobStore(join(dir, "blobs"))
+  const mk = async (title: string) =>
+    (
+      await publish(meta, blobs, {
+        bytes: new TextEncoder().encode("<p>x</p>"),
+        filename: "a.html",
+        isBundle: false,
+        title,
+        author: "seed",
+      })
+    ).artifact.id
+
+  // A1: an open thread that @mentions me (authored by someone else) + a second open
+  // thread, so open_threads must count DISTINCT threads (2), not comments.
+  const mentioned = await mk("A1")
+  await meta.createComment({
+    id: "c1",
+    artifact_id: mentioned,
+    thread_id: "t1",
+    base_version: 1,
+    body_md: "hey @me",
+    author: "Other",
+    author_id: OTHER,
+  })
+  await meta.updateComment("c1", { meta: mentionMeta(ME) })
+  await meta.createComment({
+    id: "c1b",
+    artifact_id: mentioned,
+    thread_id: "t1b",
+    base_version: 1,
+    body_md: "another thread",
+    author: "Other",
+    author_id: OTHER,
+  })
+
+  // A2: an open thread I authored (no mention).
+  const authored = await mk("A2")
+  await meta.createComment({
+    id: "c2",
+    artifact_id: authored,
+    thread_id: "t2",
+    base_version: 1,
+    body_md: "my note",
+    author: "Me",
+    author_id: ME,
+  })
+
+  // A3: an open thread by someone else that doesn't involve me (count only).
+  const uninvolved = await mk("A3")
+  await meta.createComment({
+    id: "c3",
+    artifact_id: uninvolved,
+    thread_id: "t3",
+    base_version: 1,
+    body_md: "unrelated",
+    author: "Other",
+    author_id: OTHER,
+  })
+
+  // A4: a RESOLVED thread that mentions me — must NOT count (only open threads do).
+  const resolved = await mk("A4")
+  await meta.createComment({
+    id: "c4",
+    artifact_id: resolved,
+    thread_id: "t4",
+    base_version: 1,
+    body_md: "old",
+    author: "Other",
+    author_id: OTHER,
+  })
+  await meta.updateComment("c4", { meta: mentionMeta(ME) })
+  await meta.setThreadState(resolved, "t4", "resolved")
+
+  ids = { mentioned, authored, uninvolved, resolved }
+})
+
+describe("commentSignals", () => {
+  it("reports distinct open threads + tagged/authored flags per artifact", async () => {
+    const sig = await meta.commentSignals(
+      [ids.mentioned, ids.authored, ids.uninvolved, ids.resolved],
+      ME,
+    )
+    expect(sig[ids.mentioned]).toEqual({
+      open_threads: 2,
+      mentions_me: true,
+      i_participated: false,
+    })
+    expect(sig[ids.authored]).toEqual({ open_threads: 1, mentions_me: false, i_participated: true })
+    expect(sig[ids.uninvolved]).toEqual({
+      open_threads: 1,
+      mentions_me: false,
+      i_participated: false,
+    })
+    // Resolved-only artifact has no open threads → no entry at all.
+    expect(sig[ids.resolved]).toBeUndefined()
+  })
+
+  it("a null viewer gets counts but no personal flags", async () => {
+    const sig = await meta.commentSignals([ids.mentioned, ids.authored], null)
+    expect(sig[ids.mentioned]).toEqual({
+      open_threads: 2,
+      mentions_me: false,
+      i_participated: false,
+    })
+    expect(sig[ids.authored]).toEqual({
+      open_threads: 1,
+      mentions_me: false,
+      i_participated: false,
+    })
+  })
+})
+
+describe("artifactIdsNeedingFeedback", () => {
+  it("returns artifacts where I'm tagged or authored an OPEN thread — nothing else", async () => {
+    const got = await meta.artifactIdsNeedingFeedback(ME, "local")
+    expect([...got].sort()).toEqual([ids.mentioned, ids.authored].sort())
+    // Not the uninvolved one, and not the resolved one (even though it tagged me).
+    expect(got).not.toContain(ids.uninvolved)
+    expect(got).not.toContain(ids.resolved)
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -83,6 +83,12 @@ export interface Artifact {
   open_proposals?: number
   /** Count of non-withdrawn proposals (open + decided) — gates the Proposals entry. */
   proposals_total?: number
+  /** Open comment threads on this artifact (drives the inline comment indicator). */
+  open_threads?: number
+  /** An open thread on this artifact @mentions the current user — "needs your feedback". */
+  mentions_me?: boolean
+  /** The current user authored a comment in an open thread on this artifact. */
+  i_participated?: boolean
   /** Collection ids this artifact belongs to (detail endpoint). */
   collections?: string[]
   /** Taken down by a moderator: the content is gone (410), the record stays. */
@@ -553,8 +559,9 @@ export const api = {
     author?: string
     /** "shared" → only artifacts explicitly shared with you (across workspaces).
      *  "following" → artifacts in the active workspace matching your follows
-     *  (followed GitHub authors + repo path prefixes) — the activity feed. */
-    scope?: "shared" | "following"
+     *  (followed GitHub authors + repo path prefixes) — the activity feed.
+     *  "needs_feedback" → artifacts with an open thread you're tagged in or commented on. */
+    scope?: "shared" | "following" | "needs_feedback"
     cursor?: string
     limit?: number
   }): Promise<{

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -42,6 +42,15 @@ export const sharedArtifactsQuery = () =>
     queryFn: () => api.listArtifacts({ scope: "shared", limit: 12 }).then((r) => r.artifacts),
   })
 
+// Artifacts that need YOUR feedback: an open comment thread you're tagged in or have
+// commented on. Surfaced as a promoted strip at the top of the unfiltered home.
+export const needsFeedbackArtifactsQuery = () =>
+  queryOptions({
+    queryKey: ["artifacts", "needs_feedback"] as const,
+    queryFn: () =>
+      api.listArtifacts({ scope: "needs_feedback", limit: 12 }).then((r) => r.artifacts),
+  })
+
 // The caller's follows (GitHub authors + repo path prefixes) for the active
 // workspace. Drives the Following-feed empty state, the manage strip, and the
 // isFollowing* sets that toggle the Follow buttons. One source of truth: every

--- a/apps/web/src/pages/library/artifact-card.tsx
+++ b/apps/web/src/pages/library/artifact-card.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { ago } from "@/lib/time"
 import { cn } from "@/lib/utils"
+import { CommentSignal } from "./comment-signal"
 
 export const dirOf = (path: string): string => {
   const i = path.lastIndexOf("/")
@@ -52,7 +53,16 @@ export function ArtifactCard({
   const hasAuthor = !!(author?.name || author?.login || a.author_login || a.author_name)
 
   return (
-    <div className="group relative flex cursor-pointer flex-col gap-2 rounded-lg border border-border bg-card p-3.5 transition-all motion-safe:hover:-translate-y-0.5 hover:border-primary hover:shadow-[var(--shadow)] active:translate-y-0">
+    <div
+      className={cn(
+        "group relative flex cursor-pointer flex-col gap-2 rounded-lg border border-border bg-card p-3.5 transition-all motion-safe:hover:-translate-y-0.5 hover:border-primary hover:shadow-[var(--shadow)] active:translate-y-0",
+        // Needs-your-feedback items stand out in the grid: a tagged item gets the full
+        // accent + ring; one you're just in the thread on gets a softer accent border.
+        a.mentions_me
+          ? "border-primary ring-1 ring-primary/30"
+          : a.i_participated && "border-primary/60",
+      )}
+    >
       <div className="relative">
         <Thumb id={a.short_id} v={a.current_version} />
         <button
@@ -125,13 +135,16 @@ export function ArtifactCard({
               updated {ago(a.updated_at ?? a.created_at ?? a.versions[0]?.created_at ?? "")}
             </span>
           )}
-          {a.views !== undefined && a.views > 0 && (
-            <span className="ml-auto inline-flex items-center gap-1" title={`${a.views} viewers`}>
-              <Icon name="views" size={13} />{" "}
-              {a.views > 999 ? `${(a.views / 1000).toFixed(1)}k` : a.views}
-              <span className="sr-only"> views</span>
-            </span>
-          )}
+          <span className="ml-auto inline-flex items-center gap-2">
+            <CommentSignal artifact={a} />
+            {a.views !== undefined && a.views > 0 && (
+              <span className="inline-flex items-center gap-1" title={`${a.views} viewers`}>
+                <Icon name="views" size={13} />{" "}
+                {a.views > 999 ? `${(a.views / 1000).toFixed(1)}k` : a.views}
+                <span className="sr-only"> views</span>
+              </span>
+            )}
+          </span>
         </span>
       </button>
       {hasAuthor && (

--- a/apps/web/src/pages/library/artifact-row.tsx
+++ b/apps/web/src/pages/library/artifact-row.tsx
@@ -12,6 +12,7 @@ import {
 import { ago } from "@/lib/time"
 import { cn } from "@/lib/utils"
 import { artifactTypeLabel, dirOf } from "./artifact-card"
+import { CommentSignal } from "./comment-signal"
 
 /**
  * A compact list row for the library (the default for collections / synced repos,
@@ -49,7 +50,14 @@ export function ArtifactRow({
   const hasAuthor = !!(author?.name || authorLogin || a.author_name)
 
   return (
-    <div className="group relative flex items-center gap-3 rounded-lg border border-border bg-card px-3.5 py-2.5 transition-colors hover:border-primary hover:bg-hover">
+    <div
+      className={cn(
+        "group relative flex items-center gap-3 rounded-lg border border-border bg-card px-3.5 py-2.5 transition-colors hover:border-primary hover:bg-hover",
+        a.mentions_me
+          ? "border-primary ring-1 ring-primary/30"
+          : a.i_participated && "border-primary/60",
+      )}
+    >
       <button
         type="button"
         data-testid={`artifact-row-open-${a.short_id}`}
@@ -81,6 +89,7 @@ export function ArtifactRow({
               {a.views > 999 ? `${(a.views / 1000).toFixed(1)}k` : a.views}
             </span>
           )}
+          <CommentSignal artifact={a} size={12} className="relative z-20" />
         </span>
       </button>
 

--- a/apps/web/src/pages/library/comment-signal.tsx
+++ b/apps/web/src/pages/library/comment-signal.tsx
@@ -1,0 +1,57 @@
+import type { Artifact } from "@/api"
+import { Icon } from "@/components/icons"
+import { cn } from "@/lib/utils"
+
+type Signals = Pick<Artifact, "open_threads" | "mentions_me" | "i_participated">
+
+/** True when an item needs YOUR feedback: you're tagged in, or you authored, an open
+ *  thread. Drives both the loud badge and the promoted "Needs your feedback" section. */
+export const needsMyFeedback = (a: Signals): boolean => !!(a.mentions_me || a.i_participated)
+
+/** Inline comment indicator for a list item. Plain comment activity reads quietly
+ *  (a muted count, like views); an item that needs your feedback gets a loud accent
+ *  chip — "Tagged you" (you were @mentioned) outranks "You're in this" (you commented).
+ *  Renders nothing when there's no comment activity at all. */
+export function CommentSignal({
+  artifact: a,
+  size = 13,
+  className,
+}: {
+  artifact: Signals
+  size?: number
+  className?: string
+}) {
+  const open = a.open_threads ?? 0
+  if (open === 0 && !a.mentions_me && !a.i_participated) return null
+
+  const tagged = !!a.mentions_me
+  const featured = tagged || !!a.i_participated
+  const label = tagged ? "Tagged you" : a.i_participated ? "You're in this" : null
+  const title = tagged
+    ? "You're tagged in an open thread"
+    : a.i_participated
+      ? "You commented in an open thread"
+      : `${open} open comment thread${open === 1 ? "" : "s"}`
+
+  return (
+    <span
+      data-testid="comment-signal"
+      data-featured={featured ? (tagged ? "tagged" : "participating") : undefined}
+      title={title}
+      className={cn(
+        "inline-flex items-center gap-1 rounded-md font-medium",
+        featured && "px-1.5 py-px",
+        tagged
+          ? "bg-primary/15 text-primary ring-1 ring-inset ring-primary/35"
+          : a.i_participated
+            ? "text-primary"
+            : "text-muted-foreground",
+        className,
+      )}
+    >
+      <Icon name="comments" size={size} />
+      {open > 0 && <span>{open}</span>}
+      {label && <span>{label}</span>}
+    </span>
+  )
+}

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -10,7 +10,12 @@ import { useShell } from "@/components/shell-context"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { useAuth } from "@/ctx"
-import { type LibraryParams, libraryArtifactsQuery, sharedArtifactsQuery } from "@/lib/queries"
+import {
+  type LibraryParams,
+  libraryArtifactsQuery,
+  needsFeedbackArtifactsQuery,
+  sharedArtifactsQuery,
+} from "@/lib/queries"
 import { useFollows } from "@/lib/use-follows"
 import { usePrefetchArtifact } from "@/lib/use-prefetch-artifact"
 import { cn } from "@/lib/utils"
@@ -238,6 +243,24 @@ function LibraryBody() {
   const { data: sharedData } = useQuery({ ...sharedArtifactsQuery(), enabled: homeView })
   const sharedItems = homeView ? (sharedData ?? []) : []
 
+  // "Needs your feedback": artifacts with an open thread you're tagged in or have
+  // commented on — promoted to the very top of the home so you act on them first.
+  const { data: feedbackData } = useQuery({ ...needsFeedbackArtifactsQuery(), enabled: homeView })
+  const feedbackItems = homeView ? (feedbackData ?? []) : []
+  const openFeedback = async (a: Artifact) => {
+    const on = !a.favorite
+    qc.setQueryData(needsFeedbackArtifactsQuery().queryKey, (old) =>
+      old?.map((x) => (x.short_id === a.short_id ? { ...x, favorite: on } : x)),
+    )
+    try {
+      await api.favorite(a.short_id, on)
+      refreshSummary()
+    } catch (e) {
+      toast.error((e as Error).message)
+      qc.invalidateQueries({ queryKey: needsFeedbackArtifactsQuery().queryKey })
+    }
+  }
+
   // The caller's follows: drives the Following feed's manage strip + empty state,
   // and the Follow/Following toggle on the active author-filter pill.
   const { follows, isFollowingAuthor, toggleAuthor, unfollow } = useFollows()
@@ -260,7 +283,12 @@ function LibraryBody() {
   // The "how it works" guide is for a truly blank slate: nothing of your own AND
   // nothing shared with you. If something's shared, that section carries the home.
   const emptyHome =
-    homeView && !isPending && !isError && items.length === 0 && sharedItems.length === 0
+    homeView &&
+    !isPending &&
+    !isError &&
+    items.length === 0 &&
+    sharedItems.length === 0 &&
+    feedbackItems.length === 0
 
   return (
     <div ref={scrollRef} className="flex-1 overflow-y-auto">
@@ -378,6 +406,30 @@ function LibraryBody() {
         )}
 
         {filter.kind !== "collection" && filter.kind !== "following" && <PublishCard />}
+
+        {feedbackItems.length > 0 && (
+          <section className="mb-6" data-testid="needs-your-feedback">
+            <h2 className="mb-3.5 flex items-center gap-2 font-display text-lg font-semibold">
+              <Icon name="comments" size={18} className="text-primary" />
+              Needs your feedback
+              <span className="text-base font-normal text-muted-foreground">
+                · {feedbackItems.length}
+              </span>
+            </h2>
+            <div className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-3.5">
+              {feedbackItems.map((a) => (
+                <ArtifactCard
+                  key={a.short_id}
+                  artifact={a}
+                  onOpen={() => nav({ to: "/a/$ref", params: { ref: refFor(a) } })}
+                  onToggleFavorite={() => openFeedback(a)}
+                  onPickTag={(tag) => nav({ to: "/", search: { tag } })}
+                  onPrefetch={() => prefetch(a.short_id, a.current_version)}
+                />
+              ))}
+            </div>
+          </section>
+        )}
 
         {sharedItems.length > 0 && (
           <section className="mb-6" data-testid="shared-with-you">

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -192,6 +192,17 @@ export interface MetaStore {
   ): Promise<CommentRecord | null>
   /** Flips every comment in a thread to a state; returns the count updated. */
   setThreadState(artifactId: string, threadId: string, state: CommentState): Promise<number>
+  /** Per-artifact comment signals for `userId` over a set of artifact ids, in one
+   *  query: open-thread count plus whether the viewer is tagged in or has authored an
+   *  open thread (drives the "needs your feedback" featuring). A null userId gets
+   *  counts only. */
+  commentSignals(
+    artifactIds: string[],
+    userId: string | null,
+  ): Promise<Record<string, CommentSignals>>
+  /** Artifact ids in `orgId` with an open thread the user is tagged in or authored —
+   *  the "needs your feedback" set the home section is built from. */
+  artifactIdsNeedingFeedback(userId: string, orgId: string): Promise<string[]>
 
   /**
    * Newest-first artifact page. `cursor` is keyset pagination on created_at
@@ -1097,6 +1108,16 @@ export interface ViewStats {
 //             the re-anchor sweep on every version bump; flips back to `open` if
 //             the quoted text reappears. Never overwrites `resolved`/`addressed`.
 export type CommentState = "open" | "addressed" | "resolved" | "outdated"
+
+/** Per-artifact comment signals for a viewer (see `MetaStore.commentSignals`).
+ *  `open_threads` is the count of distinct OPEN threads; `mentions_me` / `i_participated`
+ *  flag that the viewer is tagged in or has authored an open thread on this artifact —
+ *  the two things that make it "need your feedback". */
+export interface CommentSignals {
+  open_threads: number
+  mentions_me: boolean
+  i_participated: boolean
+}
 
 export interface CommentRecord {
   id: string

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -7,6 +7,7 @@ import type {
   CollectionMemberRecord,
   CollectionRecord,
   CommentRecord,
+  CommentSignals,
   CommentState,
   DeliveryRecord,
   DeliveryStatus,
@@ -349,6 +350,76 @@ export class PgMetaStore implements MetaStore {
       .where(and(eq(comment.artifact_id, artifactId), eq(comment.thread_id, threadId)))
       .returning({ id: comment.id })
     return rows.length
+  }
+
+  // Mirrors the sqlite path: mentions live in meta.mentions (JSON), matched in code.
+  private commentMentionsUser(metaJson: string | null, userId: string): boolean {
+    if (!metaJson) return false
+    try {
+      const m = JSON.parse(metaJson) as { mentions?: { id?: string }[] }
+      return Array.isArray(m.mentions) && m.mentions.some((x) => x?.id === userId)
+    } catch {
+      return false
+    }
+  }
+
+  async commentSignals(
+    artifactIds: string[],
+    userId: string | null,
+  ): Promise<Record<string, CommentSignals>> {
+    const out: Record<string, CommentSignals> = {}
+    if (artifactIds.length === 0) return out
+    const rows = await this.db
+      .select({
+        artifact_id: comment.artifact_id,
+        thread_id: comment.thread_id,
+        state: comment.state,
+        author_id: comment.author_id,
+        meta: comment.meta,
+      })
+      .from(comment)
+      .where(inArray(comment.artifact_id, artifactIds))
+    const threads: Record<string, Set<string>> = {}
+    for (const r of rows) {
+      if (r.state !== "open") continue
+      let sig = out[r.artifact_id]
+      if (!sig) {
+        sig = { open_threads: 0, mentions_me: false, i_participated: false }
+        out[r.artifact_id] = sig
+      }
+      let set = threads[r.artifact_id]
+      if (!set) {
+        set = new Set()
+        threads[r.artifact_id] = set
+      }
+      set.add(r.thread_id)
+      if (userId) {
+        if (r.author_id === userId) sig.i_participated = true
+        if (!sig.mentions_me && this.commentMentionsUser(r.meta, userId)) sig.mentions_me = true
+      }
+    }
+    for (const [id, set] of Object.entries(threads)) {
+      const sig = out[id]
+      if (sig) sig.open_threads = set.size
+    }
+    return out
+  }
+
+  async artifactIdsNeedingFeedback(userId: string, orgId: string): Promise<string[]> {
+    const rows = await this.db
+      .select({
+        artifact_id: comment.artifact_id,
+        author_id: comment.author_id,
+        meta: comment.meta,
+      })
+      .from(comment)
+      .innerJoin(artifact, eq(artifact.id, comment.artifact_id))
+      .where(and(eq(comment.state, "open"), eq(artifact.org_id, orgId)))
+    const ids = new Set<string>()
+    for (const r of rows) {
+      if (r.author_id === userId || this.commentMentionsUser(r.meta, userId)) ids.add(r.artifact_id)
+    }
+    return [...ids]
   }
 
   listArtifacts(opts?: ListArtifactsOpts): Promise<ArtifactRecord[]> {

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -7,6 +7,7 @@ import type {
   CollectionMemberRecord,
   CollectionRecord,
   CommentRecord,
+  CommentSignals,
   CommentState,
   DeliveryRecord,
   DeliveryStatus,
@@ -507,6 +508,86 @@ export function makeRepos(db: SqliteDb) {
       .where(and(eq(comment.artifact_id, artifactId), eq(comment.thread_id, threadId)))
       .run()) as RunResult
     return res.changes ?? res.meta?.changes ?? 0
+  }
+
+  // Does this comment's meta JSON tag `userId`? Mentions live in meta.mentions
+  // (a {id,name}[]), so they can't be filtered in SQL cheaply — matched in code.
+  const commentMentionsUser = (metaJson: string | null, userId: string): boolean => {
+    if (!metaJson) return false
+    try {
+      const m = JSON.parse(metaJson) as { mentions?: { id?: string }[] }
+      return Array.isArray(m.mentions) && m.mentions.some((x) => x?.id === userId)
+    } catch {
+      return false
+    }
+  }
+
+  // Per-artifact comment signals for a viewer over a page of artifacts. ONE query;
+  // state is filtered in code (not SQL) so the bound-parameter count stays at the page
+  // size — D1 caps it at 100 and tagsForArtifacts already rides that edge. open_threads
+  // counts distinct OPEN threads; the flags drive "needs your feedback" featuring.
+  const commentSignals = async (
+    artifactIds: string[],
+    userId: string | null,
+  ): Promise<Record<string, CommentSignals>> => {
+    const out: Record<string, CommentSignals> = {}
+    if (artifactIds.length === 0) return out
+    const rows = await db
+      .select({
+        artifact_id: comment.artifact_id,
+        thread_id: comment.thread_id,
+        state: comment.state,
+        author_id: comment.author_id,
+        meta: comment.meta,
+      })
+      .from(comment)
+      .where(inArray(comment.artifact_id, artifactIds))
+      .all()
+    const threads: Record<string, Set<string>> = {}
+    for (const r of rows) {
+      if (r.state !== "open") continue
+      let sig = out[r.artifact_id]
+      if (!sig) {
+        sig = { open_threads: 0, mentions_me: false, i_participated: false }
+        out[r.artifact_id] = sig
+      }
+      let set = threads[r.artifact_id]
+      if (!set) {
+        set = new Set()
+        threads[r.artifact_id] = set
+      }
+      set.add(r.thread_id)
+      if (userId) {
+        if (r.author_id === userId) sig.i_participated = true
+        if (!sig.mentions_me && commentMentionsUser(r.meta, userId)) sig.mentions_me = true
+      }
+    }
+    for (const [id, set] of Object.entries(threads)) {
+      const sig = out[id]
+      if (sig) sig.open_threads = set.size
+    }
+    return out
+  }
+
+  // Artifact ids in `orgId` with an OPEN thread the viewer is tagged in or authored —
+  // the "needs your feedback" set. Scans the workspace's open comments (bounded by
+  // open-comment volume) and reduces in code, since the mention match is JSON.
+  const artifactIdsNeedingFeedback = async (userId: string, orgId: string): Promise<string[]> => {
+    const rows = await db
+      .select({
+        artifact_id: comment.artifact_id,
+        author_id: comment.author_id,
+        meta: comment.meta,
+      })
+      .from(comment)
+      .innerJoin(artifact, eq(artifact.id, comment.artifact_id))
+      .where(and(eq(comment.state, "open"), eq(artifact.org_id, orgId)))
+      .all()
+    const ids = new Set<string>()
+    for (const r of rows) {
+      if (r.author_id === userId || commentMentionsUser(r.meta, userId)) ids.add(r.artifact_id)
+    }
+    return [...ids]
   }
 
   // ---- Webhooks + outbox -------------------------------------------------
@@ -1528,6 +1609,8 @@ export function makeRepos(db: SqliteDb) {
     updateComment,
     listComments,
     setThreadState,
+    commentSignals,
+    artifactIdsNeedingFeedback,
     createWebhook,
     listWebhooks,
     getWebhook,

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -249,6 +249,57 @@ export function runStoreContract(
       expect(await store.listComments(a.id, { state: "open" })).toHaveLength(0)
       expect(await store.listComments(a.id, { state: "resolved" })).toHaveLength(1)
     })
+
+    it("computes per-artifact comment signals for a viewer (open threads, mentions, participation)", async () => {
+      const me = `u_${uuid()}`
+      const other = `u_${uuid()}`
+      const a = await store.createArtifact(newArtifact())
+      const mention = JSON.stringify({ mentions: [{ id: me, name: "Me" }] })
+      // t1: OPEN, authored by other, @mentions me → mentions_me.
+      const c1 = await store.createComment({
+        id: uuid(),
+        artifact_id: a.id,
+        thread_id: "t1",
+        base_version: 1,
+        body_md: "hi",
+        author: "other",
+        author_id: other,
+      })
+      await store.updateComment(c1.id, { meta: mention })
+      // t2: OPEN, authored by me → i_participated.
+      await store.createComment({
+        id: uuid(),
+        artifact_id: a.id,
+        thread_id: "t2",
+        base_version: 1,
+        body_md: "mine",
+        author: "me",
+        author_id: me,
+      })
+      // t3: RESOLVED, mentions me → must NOT count (only open threads signal).
+      const c3 = await store.createComment({
+        id: uuid(),
+        artifact_id: a.id,
+        thread_id: "t3",
+        base_version: 1,
+        body_md: "done",
+        author: "other",
+        author_id: other,
+      })
+      await store.updateComment(c3.id, { meta: mention })
+      await store.setThreadState(a.id, "t3", "resolved")
+
+      // The viewer sees 2 open threads, is mentioned, and participated.
+      const sig = (await store.commentSignals([a.id], me))[a.id]
+      expect(sig).toEqual({ open_threads: 2, mentions_me: true, i_participated: true })
+      // An anonymous viewer gets the thread count but no personal flags.
+      const anon = (await store.commentSignals([a.id], null))[a.id]
+      expect(anon).toEqual({ open_threads: 2, mentions_me: false, i_participated: false })
+      // Empty input ⇒ {}; an artifact with no comments has no entry.
+      expect(await store.commentSignals([], me)).toEqual({})
+      const blank = await store.createArtifact(newArtifact())
+      expect((await store.commentSignals([blank.id], me))[blank.id]).toBeUndefined()
+    })
   })
 
   describe(`${label}: shares, favorites, tags`, () => {


### PR DESCRIPTION
Reconciles **#210** against `main` now that find/follow shipped (#214/#218).

#210 bundled two things: **comment-visibility signals** ("Needs your feedback") and a **find/follow people** implementation. Our find/follow is already merged and strictly more complete (People directory, optimistic toggle, a11y, `author_id` backfill, OG cards, notifications). So:

- **Dropped #210's find/follow** (its two follow commits) — ours is canonical; keeping both would be two implementations of the same feature.
- **Kept the net-new comment-signals feature** — cherry-picked onto current `main` (clean auto-merge against our changes; verified).

### What this adds (comment signals)
- `MetaStore.commentSignals` (batched, both stores) hydrates each `GET /v1/artifacts` item with `{ open_threads, mentions_me, i_participated }`; `scope=needs_feedback` for the home strip.
- A `CommentSignal` badge on every card/row — quiet count by default, loud **"Tagged you" / "You're in this"** when an open thread needs you — plus a promoted **"Needs your feedback"** section atop the home.
- Trigger = tagged **or** participated, in an **open** thread.

### Reconciliation note
The duplicate follow code is intentionally absent — `follows.ts`, `use-follows.ts`, `profile.tsx`, the People directory, etc. remain the versions merged via #214/#218. No `author_id`/schema churn here (that already landed).

### Tests
- Carried `comment-signals.test.ts` (api).
- **Added** a cross-dialect `commentSignals` **store-contract test** (sqlite + d1 + pg): open-thread count, @mention, participation, resolved-thread exclusion, anon/empty — so the pg coverage gate covers `pg.ts`'s `commentSignals`.

Verified locally: typecheck, lint (+ all gates), api **466**, web **58**, db coverage, the full **pg lane** (api 466 + db 68 against ephemeral Postgres, coverage gate green), and **13/13 e2e smoke** (our follow flow + the new badges coexist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)