### PR TITLE
perf(db): index comment(artifact_id, state) for comment-signal scans

### DIFF
--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -352,6 +352,8 @@ CREATE INDEX IF NOT EXISTS domain_artifact ON domain (artifact_id);
 
 CREATE INDEX IF NOT EXISTS proposal_artifact_state ON proposal (artifact_id, state);
 
+CREATE INDEX IF NOT EXISTS comment_artifact_state ON comment (artifact_id, state);
+
 CREATE INDEX IF NOT EXISTS report_state ON report (state, created_at);
 
 CREATE INDEX IF NOT EXISTS audit_artifact ON audit_log (artifact_id, created_at);

--- a/packages/db/src/ddl.ts
+++ b/packages/db/src/ddl.ts
@@ -144,6 +144,7 @@ export const PERF_INDEXES: string[] = [
   `CREATE INDEX IF NOT EXISTS repo_source_org ON repo_source (org_id)`,
   `CREATE INDEX IF NOT EXISTS domain_artifact ON domain (artifact_id)`,
   `CREATE INDEX IF NOT EXISTS proposal_artifact_state ON proposal (artifact_id, state)`,
+  `CREATE INDEX IF NOT EXISTS comment_artifact_state ON comment (artifact_id, state)`,
   `CREATE INDEX IF NOT EXISTS report_state ON report (state, created_at)`,
   `CREATE INDEX IF NOT EXISTS audit_artifact ON audit_log (artifact_id, created_at)`,
 ]


### PR DESCRIPTION
## What
Adds a composite index `comment_artifact_state ON comment (artifact_id, state)` so the "Needs your feedback" comment-signal queries stop doing full table scans on hot routes.

## Why
The comment-signals layer (#219) runs two queries on every library/home load:
- **`commentSignals`** — `WHERE artifact_id IN (...)` (badge counts per card)
- **`artifactIdsNeedingFeedback`** — `JOIN artifact ON artifact_id` + `WHERE state = 'open'` (the promoted "Needs your feedback" section)

Both hit `comment` unindexed → table scans that grow linearly with total comment volume. Flagged P1 in the post-merge Dock review ([jptpqhea](https://dock.siftai.workers.dev/a/comment-signals-reconciliation-review-219-jptpqhea)).

## How
One line in `PERF_INDEXES` (`ddl.ts`). Leading `artifact_id` serves both the `IN` lookup and the join; trailing `state` covers the open-thread residual filter. Same shape as the existing `proposal_artifact_state`.

- Additive + idempotent (`CREATE INDEX IF NOT EXISTS`)
- Applies across all three dialects (sqlite / D1 / pg) via the shared `PERF_INDEXES`
- `deploy/d1-schema.sql` regenerated via `gen:d1-schema` (not hand-edited)

## Verification
- `pnpm typecheck` clean (7 projects)
- db suite 122 passed (incl. d1-schema snapshot + sqlite/d1 contract)
- api suite 466 passed (sqlite)
- pg lane: api-on-pg + pg-store + pg-schema-conformance 68 passed; coverage 90.99% lines / 87.3% stmts (above gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)