### PR TITLE
docs(plans): collaboration layer, layered anchoring, new comment modes

### DIFF
--- a/docs/plans/collab-modes-and-publish-gate.md
+++ b/docs/plans/collab-modes-and-publish-gate.md
@@ -1,0 +1,115 @@
+# Dock: new collaboration modes and the publish gate
+
+Today every comment on Dock is the same kind: public, human-to-human, a discussion.
+That is one quadrant of a larger space. This plan adds the missing quadrants and a
+quality gate, all on the anchor primitive from
+[element-anchors.md](./element-anchors.md). Companion to
+[collaboration-layer.md](./collaboration-layer.md).
+
+## Two axes
+
+A comment has two independent properties:
+
+- **Visibility:** private (just me and my agent) or public (the whole team).
+- **Intent:** an instruction (something to act on, then resolve) or a discussion
+  (a thread to talk through).
+
+Existing comments are public discussion. The two modes below fill the rest, and
+both reuse the layered anchor and the existing `add_comment` plumbing. The work is a
+comment `kind`, a visibility scope, and the review UI.
+
+## Mode A: private-to-your-agent comments
+
+The same anchored comment, scoped to the author and their agent. Nobody else sees
+it, and because comments are already an overlay served separately from the artifact
+bytes, **it can never leak into a shared file.** The portability principle is also
+the privacy guarantee.
+
+What it is for: driving revisions while you are still iterating, before you share
+anything publicly. You anchor "redo this chart, the axis is wrong" to the chart;
+your agent reads it over MCP, revises, and resolves it, the same publish to read
+comments to revise loop that already exists, just on a private channel.
+
+These are instructions, so they **drain**: an addressed private comment resolves and
+clears, rather than living forever as a discussion thread.
+
+Data shape: a `visibility: "private"` flag on the comment and an `intent:
+"instruction"` kind. Private comments are filtered out of every list a non-author
+sees, server-side, and are never included in a published version's resolved-thread
+trail.
+
+## Mode B: agent-authored uncertainty
+
+The inverse direction, and the more novel one. The agent leaves anchored markers on
+its **own** output wherever it guessed: "assumed Q3 here, confirm," "could not find
+the real figure, placeholder." A distinct comment kind, authored by the agent,
+surfaced to you as you review.
+
+Why it matters: you review the flagged-risk spots instead of re-reading everything.
+It turns the agent into a participant that reports its own confidence, not just a
+generator that hands you a wall of output and hopes.
+
+The plumbing already exists: agents can `add_comment` with an anchor today. So this
+is mostly a new `intent: "uncertainty"` kind plus review UI that treats it as
+**confirm / dismiss** rather than a discussion thread. Confirming clears it;
+dismissing can hand the spot back to the agent as a private instruction (Mode A),
+closing the loop.
+
+## The publish gate
+
+A headless layout audit that runs **at publish time**, before a share link goes out.
+Dock has nothing here today.
+
+The audit inspects the rendered output for:
+
+- page horizontal overflow
+- element overflow (content wider than its scroll container)
+- clipped text (content hidden by `overflow: hidden`, excluding intentional
+  ellipsis or line-clamp truncation)
+- overlapping text (two elements colliding over readable text)
+
+Each finding carries a `selector`, a `kind`, an overflow measurement, and a
+`severity` (warning or error on a small pixel threshold). On an error-severity
+finding we **warn or block** before publishing, naming the specific elements, rather
+than letting a visibly broken artifact reach a teammate.
+
+It is a pre-publish check, not a runtime nag: silent on success, one quiet panel on
+failure listing exactly what overflowed or clipped. Implementation runs the audit in
+the same sandboxed render path the viewer already uses, so it sees the artifact the
+way a reader will.
+
+## How the pieces fit the lifecycle
+
+1. **Drafting (private).** You and your agent iterate. Private instructions (Mode A)
+   drive revisions; the agent flags its own doubts (Mode B). Nothing is shared.
+2. **Publishing.** The layout gate runs. A broken layout is caught here, not by a
+   reviewer.
+3. **Reviewing (public).** You share; public discussion comments open. The same
+   anchors, now visible to the team.
+
+The private and public layers are the same mechanic with visibility flipped, which
+is why this is depth on the existing share flow, not a separate product.
+
+## What stays true
+
+All of this rides the overlay model. Private comments, agent-uncertainty markers,
+and the audit operate beside the artifact bytes, never inside them. The shared file
+stays self-contained, portable, and identical everywhere it is opened.
+
+## Phasing
+
+1. `visibility` and `intent` fields on comments; server-side filtering of private
+   comments; CLI/MCP support for setting them.
+2. Mode B review UI (confirm / dismiss) and the dismiss-to-private-instruction loop.
+3. The publish-gate audit in the render path; the pre-publish panel; block-or-warn
+   policy (default warn, opt-in block per workspace).
+
+## Open questions
+
+- Does a private comment survive when you later publish, becoming visible, or stay
+  private forever? Proposed: private is sticky; "promote to public" is an explicit
+  action, never automatic, so nothing leaks by surprise.
+- Agent identity on Mode B markers: one agent, or attributed per agent/run? Start
+  with a single "agent" author, like `add_comment` today.
+- Should the publish gate ever hard-block, or only warn? Default warn; let a
+  workspace opt into blocking on error-severity findings.

--- a/docs/plans/collaboration-layer.md
+++ b/docs/plans/collaboration-layer.md
@@ -1,0 +1,83 @@
+# Dock: the collaboration layer
+
+Dock is where a team of humans and AI work together on a shared artifact. Sharing
+is the foundation. Collaboration is what we build on top of it.
+
+The frame for everything below: **the artifact is the meeting point.** Sharing got
+everyone into the same room. The rest is how they actually work together on the
+thing in front of them, humans and agents alike, on the artifact and not beside it.
+
+This doc is the north star. Two companion plans break out the concrete work:
+
+- [element-anchors.md](./element-anchors.md) - let a comment land on a chart,
+  image, diagram, or slide region, not just prose, and make every anchor a layered
+  cascade so feedback survives revisions instead of vanishing when content moves.
+- [collab-modes-and-publish-gate.md](./collab-modes-and-publish-gate.md) - private
+  agent comments, agent-authored uncertainty, and a layout audit at publish time.
+
+## What already exists (the spine)
+
+We are not starting from zero. The collaboration spine is already in place, and on
+the one axis that matters most (feedback surviving a revision) it is already good:
+
+- **Versioned sharing.** Every artifact has a permanent URL, content-addressed
+  versions, and a sandboxed viewer. This is the foundation.
+- **Anchored comments.** Comments anchor to a W3C `TextQuoteSelector`
+  (`exact` plus `prefix`/`suffix` context) and re-anchor on every republish: exact
+  match with context first, then exact anywhere, else marked "text changed." A real
+  three-tier rehydration strategy, not a brittle character offset.
+- **The anchor-client protocol.** A served (not inlined) `/raw/dock-client.js`
+  talks to the sandboxed iframe over `postMessage` (`select`, `anchors-resolved`,
+  `anchor-click`). The comment layer evolves independently of frozen artifact
+  bytes, so portability is already solved. See [STANDARD.md](../../STANDARD.md).
+- **The review loop.** Proposals (candidate versions awaiting review), approve,
+  reply, resolve, reopen. Agents run the same loop over MCP and the CLI.
+- **Teams.** Workspaces, memberships, roles, realtime presence over SSE.
+
+## The thesis
+
+Most "share a doc" tools stop at read-only. Dock's bet is that the shared artifact
+becomes a workspace the moment feedback lands **on** it, anchored to a specific
+spot, from any participant: a teammate, a reviewer, or an agent. AI is a
+participant in that conversation, not just the thing that generated the page.
+
+That reframes the three moves below. They are not "comment features." Each one
+extends what a participant can do on the shared object:
+
+| Move | What it unlocks | Plan |
+|---|---|---|
+| Layered anchoring | React to the visual parts of an artifact, and keep every comment attached as content moves | [element-anchors.md](./element-anchors.md) |
+| New collaboration modes | Talk privately to your own agent; let the agent flag its own doubts | [collab-modes-and-publish-gate.md](./collab-modes-and-publish-gate.md) |
+| Publish gate | Keep a broken-looking artifact from ever reaching a teammate | [collab-modes-and-publish-gate.md](./collab-modes-and-publish-gate.md) |
+
+## What we are deliberately not doing
+
+- **Not throwing away the existing anchoring.** Text quotes and their republish
+  rehydration stay exactly as they are. The layered-anchoring plan wraps more
+  fallback locators around that proven core and extends it to non-text elements; it
+  does not replace `TextQuoteSelector`.
+- **Not repositioning Dock.** This is depth on the existing share flow, not a new
+  product. Sharing stays the front door.
+- **Not baking chrome into artifacts.** See the principle below.
+
+## The principle that holds it together
+
+Comments and chrome are an **overlay, served separately, never baked into the
+artifact bytes.** The shared file renders identically whether you open it on Dock,
+download it, or hit the raw URL. Every move respects this: it is what keeps
+artifacts portable, and it is also what keeps private feedback from ever leaking
+into a public file. When a plan below proposes new data, the test it must pass is:
+*does the published artifact byte-for-byte stay the same?* If not, it goes in the
+overlay, not the file.
+
+## Sequencing
+
+1. **Layered anchoring** first. It closes the real gaps in the core primitive
+   (non-text targets, and durability as content moves), and the later modes are more
+   useful once any part of an artifact can carry a comment that survives revisions.
+2. **New collaboration modes** second. Private agent comments and agent uncertainty
+   reuse the anchor primitive (text and, after step 1, element) and the existing
+   `add_comment` plumbing; the work is mostly a comment `kind`, a visibility scope,
+   and the review UI.
+3. **Publish gate** as a fast follow. It is independent of the other two and cheap:
+   a headless audit at publish, surfaced as a pre-publish check.

--- a/docs/plans/element-anchors.md
+++ b/docs/plans/element-anchors.md
@@ -1,0 +1,199 @@
+# Dock: layered anchoring (beyond a single text quote)
+
+Two gaps in Dock's anchor model, fixed together:
+
+1. A comment can only attach to a **text quote** today. Our own
+   [STANDARD.md](../../STANDARD.md) admits it: "baked-in screenshots can't be
+   commented on." Charts, images, diagrams, and slide regions cannot carry
+   feedback, even though they are the parts of a rich artifact people most want to
+   react to.
+2. An anchor is a **single locator**. When the underlying content moves or is
+   rewritten, a lone selector either resolves or it does not, and when it does not,
+   the comment is simply lost.
+
+This plan does both: it adds a non-text anchor kind, and it makes every anchor a
+**cascade of independent locators** plus a preserved snapshot, so a comment degrades
+gracefully instead of disappearing. Companion to
+[collaboration-layer.md](./collaboration-layer.md).
+
+## What we keep
+
+- The anchor-client protocol runs inside the sandboxed iframe and speaks
+  `postMessage` (`select`, `anchors-resolved`, `anchor-click`).
+- Text comments anchor to a W3C `TextQuoteSelector` and re-resolve on republish by
+  exact-with-context, then exact-anywhere. That stays as **Layer 2 for text**.
+- Highlights and overlays live in the served client, never in the artifact bytes.
+
+We are adding a second anchor kind alongside the text quote, and we are adding more
+**layers** under both kinds. A comment's anchor becomes a tagged union:
+
+```
+type Anchor =
+  | { kind: "text";    text: TextQuoteSelector; layers: AnchorLayers }
+  | { kind: "element"; layers: AnchorLayers }
+```
+
+## The layered anchor
+
+Every anchor captures several independent locators at comment time, strongest to
+weakest. None of them is load-bearing on its own.
+
+```
+AnchorLayers = {
+  // L0 - explicit durable handle (author opt-in). Survives almost anything.
+  anchorId?: string          // value of data-dock-anchor
+
+  // L1 - precise path. Best when the DOM is stable.
+  css?: string               // depth-capped, e.g. "main > figure:nth-of-type(2)"
+
+  // L2 - content identity. Finds "the same thing" wherever it moved.
+  fingerprint: {
+    tag: string              // "img" | "svg" | "figure" | "canvas" | "p" | ...
+    src?: string             // image src basename
+    hash?: string            // content hash: same-origin bytes, or normalized markup
+    label?: string           // alt / aria-label / title / <figcaption> text
+    textHash?: string        // hash of normalized innerText, for text-bearing blocks
+  }
+
+  // L3 - structure. "the 2nd chart under 'Revenue'".
+  ordinal: {
+    section?: string         // nearest preceding heading text
+    kindIndex: number        // index among same-tag elements, in document order
+  }
+
+  // L4 - geometry. The "save position as stuff moves" layer.
+  position: {
+    docFraction: number      // element top as a fraction of total doc height (0..1)
+    rect: { w: number; h: number; ar: number }  // size + aspect ratio
+  }
+
+  // L5 - neighbors. "between these two still-stable things".
+  neighbors?: { prev?: SignalLite; next?: SignalLite }
+}
+```
+
+`css` uses a depth-capped selector walk: up a few levels, short-circuit on a stable
+`id`, disambiguate same-tag siblings with `:nth-of-type`. It is the least durable
+field, which is exactly why it is only one layer of several.
+
+## Resolution: a scored cascade
+
+On the live client and server-side at republish, run every layer that is present,
+collect the element(s) each one points to, and **score candidates by agreement**:
+
+1. Each layer that resolves contributes its candidate(s), weighted (L0 highest, L4
+   lowest).
+2. An element that several layers independently point to wins. Agreement is the
+   signal, not any single locator.
+3. The top candidate's combined score sets a **confidence**:
+   - **High** (a strong layer plus agreement): carry the comment silently.
+   - **Medium** (only weak layers, or layers disagree): carry it, but mark
+     "re-anchored, confirm?" so a human or the agent verifies rather than trusting.
+   - **None above threshold**: the target is gone. Do not silently move it.
+
+This is the same philosophy text anchoring already uses (context first, then looser
+match, then give up honestly), generalized to many locators and made explicit about
+confidence.
+
+## When the target is gone
+
+A lost comment should never just vanish. Two recoveries, in order:
+
+### 1. Preserve the target (snapshot)
+
+At comment time we also store, **in the overlay, never in the artifact bytes**, a
+small record of what was anchored:
+
+```
+Snapshot = {
+  outline: string        // short outerHTML excerpt, or the quoted text
+  thumb?: string         // tiny data-URL render for an image/chart (optional)
+  context: string        // preceding heading + neighbor text
+  madeOnVersion: number  // the artifact version this anchor was created against
+}
+```
+
+An orphaned comment then **shows what it pointed at** ("was on the Q3 Revenue chart,
+under 'Performance', about 40% down the page"), with the thumbnail if we have one,
+instead of a bare "element changed." The agent reading comments over MCP receives
+the same snapshot, so it can relocate the intent itself.
+
+### 2. Recover via version history (Dock's advantage)
+
+Dock keeps every version server-side, which the in-iframe-only tools do not. So an
+orphaned anchor has one more move: re-resolve it against the **exact version it was
+made on** (`madeOnVersion`), where every layer still matches perfectly, identify the
+original element there, then walk the diff **forward** to its most likely successor
+in the current version. A comment made three versions ago can be carried forward
+hop by hop instead of dropped because the latest DOM drifted too far at once.
+
+## Authoring guidance (mirrors the text-quote rules)
+
+One optional addition to STANDARD.md section 1, alongside "keep headings and
+distinctive phrases stable":
+
+- **Put `data-dock-anchor="…"` on charts, figures, and slide regions you expect
+  feedback on.** It becomes Layer 0, the strongest handle, and makes an element
+  anchor as durable as a stable heading. Never required: without it the lower layers
+  still apply.
+
+## Protocol additions
+
+Additive to STANDARD.md section 2. Old clients and old artifacts keep working; they
+simply never send or receive the new fields.
+
+### Artifact frame to host (`source: "dock"`)
+
+- `select` may carry an element anchor (`kind: "element"`) with the captured layers
+  when the user picks an element instead of text. The user enters **element-pick
+  mode**: hovering paints a soft outline around the smallest anchorable element
+  under the cursor; clicking posts the anchor. Selecting text, or pressing the key
+  again, exits the mode.
+
+### Host to artifact frame (`source: "dock-host"`)
+
+- `anchors` gains element entries plus a per-anchor `confidence`. The client paints
+  an element anchor as an **outline overlay** (absolutely positioned, so we never
+  mutate the artifact DOM) instead of a `<mark>` wrap, and renders medium-confidence
+  anchors with a "confirm?" affordance. `anchor-click` is posted on click as today.
+- `focus-anchor` scrolls to and flashes an element anchor like a text one.
+
+## UX flow
+
+- **Entering.** One affordance, not a toolbar: a "comment on element" toggle in the
+  existing selection toolbar plus a keyboard shortcut. Until you start, the artifact
+  looks untouched.
+- **Picking.** Hover paints a soft outline on the smallest anchorable element
+  (img, svg, figure, canvas, or an explicit `data-dock-anchor` box). Modifier-hover
+  walks up to the parent if you meant the whole figure, not the image inside it.
+- **Commenting.** Click drops a margin pin and opens the **same composer** used for
+  text anchors.
+- **Reviewing.** Element and text comments share one pin rail. Re-anchored
+  (medium-confidence) pins show a small "confirm" dot; orphaned pins collapse to a
+  "could not place" group at the top that still renders each snapshot, so nothing is
+  silently lost.
+
+## Phasing
+
+1. **Capture.** `AnchorLayers` capture in the served client for both kinds (no UI
+   yet); store and round-trip through `add_comment` and republish.
+2. **Cascade.** The scored resolver and confidence, on client and server. Snapshot
+   storage in the overlay.
+3. **Gone case.** Orphan group UI with snapshots; version-history forward-walk
+   recovery.
+4. **Element UI.** Pick-mode, outline overlay, unified pin rail, confirm affordance.
+5. **Docs.** STANDARD.md note for `data-dock-anchor`.
+
+## Open questions
+
+- Layer weights and the high/medium thresholds want real artifacts to tune. Start
+  conservative (favor "confirm?" over silent moves) and adjust.
+- `fingerprint.hash` for same-origin image bytes is easy; cross-origin or
+  canvas-rendered charts may only give us `rect` + `label`. Acceptable: those just
+  lean on lower layers.
+- Version-history forward-walk cost: walking many hops server-side on every stale
+  anchor could be heavy. Cache the resolved mapping per (anchor, version) so it is
+  computed once.
+- Geometry layer for reflowable artifacts (Markdown at different widths): store
+  `docFraction` rather than pixels so it stays meaningful across viewport sizes,
+  which the schema already does.


### PR DESCRIPTION
Three forward-looking design plans under `docs/plans/`. Docs only, no code changes.

The framing: **Dock is where a team of humans and AI work together on a shared artifact.** Sharing is the foundation already in place; these plans deepen the collaboration that rides on top of it. None of them reposition what Dock is.

### What's here

- **[collaboration-layer.md](docs/plans/collaboration-layer.md)** - the north star. What already exists (versioned sharing, anchored comments with `TextQuoteSelector` rehydration, the review loop, teams) and the three moves that build on it. Establishes the load-bearing principle: feedback is an overlay served beside the artifact bytes, never baked in, so shared files stay portable.

- **[element-anchors.md](docs/plans/element-anchors.md)** - the core engine work. Two gaps fixed together:
  1. Anchors can only attach to text today; extend them to non-text elements (charts, images, diagrams, slide regions).
  2. An anchor is a single locator that vanishes when content moves; make every anchor a **scored cascade** of independent locators (explicit `data-dock-anchor` id, css path, content fingerprint, structural ordinal, geometry/document-fraction, neighbors). Candidates are scored by agreement and carried with a confidence. For the gone case: a preserved **snapshot** so an orphaned comment still shows what it pointed at, plus **version-history forward-walk recovery** (a Dock advantage local tools lack).

- **[collab-modes-and-publish-gate.md](docs/plans/collab-modes-and-publish-gate.md)** - two new collaboration modes on the same anchor primitive (private-to-your-agent instructions, and agent-authored uncertainty markers), plus a headless layout audit at publish time so a broken-looking artifact never reaches a teammate.

### Scope

Plans for discussion, not implementation. Each ends with phasing and open questions. Sequencing: layered anchoring first (it is the core primitive everything else rests on), then the new modes, then the publish gate as a fast follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)