### PR TITLE
feat(github): post a sticky Dock preview link on the PR

### DIFF
--- a/apps/api/src/lib/github-comments.ts
+++ b/apps/api/src/lib/github-comments.ts
@@ -70,6 +70,75 @@ export async function createIssueComment(
   return ((await res.json()) as { id: number }).id
 }
 
+// An invisible (HTML-comment) marker on the single Dock-managed "preview" comment, so we
+// edit it in place on each sync instead of spamming the PR thread with a new one.
+const PREVIEW_MARK = "<!-- dock-preview -->"
+
+interface IssueComment {
+  id: number
+  body?: string
+}
+
+/** A PR's conversation (issue) comments, first ~3 pages — enough to find our own near
+ *  the top. */
+async function listIssueComments(
+  repo: RepoRef,
+  prNumber: number,
+  token: string,
+): Promise<IssueComment[]> {
+  const out: IssueComment[] = []
+  for (let page = 1; page <= 3; page++) {
+    const url = `${API}/repos/${repo.owner}/${repo.name}/issues/${prNumber}/comments?per_page=100&page=${page}`
+    const res = await fetch(url, { headers: headers(token) })
+    if (!res.ok) throw new GitHubWriteError(res.status, `list issue comments HTTP ${res.status}`)
+    const batch = (await res.json()) as IssueComment[]
+    out.push(...batch)
+    if (batch.length < 100) break
+  }
+  return out
+}
+
+/** Edit an existing issue comment's body. */
+async function updateIssueComment(
+  repo: RepoRef,
+  commentId: number,
+  body: string,
+  token: string,
+): Promise<void> {
+  const url = `${API}/repos/${repo.owner}/${repo.name}/issues/comments/${commentId}`
+  const res = await fetch(url, {
+    method: "PATCH",
+    headers: headers(token),
+    body: JSON.stringify({ body }),
+  })
+  if (!res.ok)
+    throw new GitHubWriteError(
+      res.status,
+      `update issue comment HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    )
+}
+
+/** The id of the Dock-managed preview comment among a PR's comments (by our marker), or
+ *  null when we haven't posted one yet. Pure — exported for testing. */
+export const findPreviewComment = (comments: IssueComment[]): number | null =>
+  comments.find((c) => c.body?.includes(PREVIEW_MARK))?.id ?? null
+
+/** Post or update the single Dock-managed "preview" comment on a PR. The marker makes it
+ *  sticky (subsequent syncs edit the same comment). The `MARK` footer keeps the inbound
+ *  mirror from ingesting it back as a Dock comment. Caller swallows errors — a failed
+ *  comment never blocks the preview sync. */
+export async function upsertPreviewComment(
+  repo: RepoRef,
+  prNumber: number,
+  body: string,
+  token: string,
+): Promise<void> {
+  const full = `${body}\n\n<sub>${MARK} · kept in sync with the PR</sub>\n${PREVIEW_MARK}`
+  const existingId = findPreviewComment(await listIssueComments(repo, prNumber, token))
+  if (existingId != null) await updateIssueComment(repo, existingId, full, token)
+  else await createIssueComment(repo, prNumber, full, token)
+}
+
 /** Post an inline PR review comment on a file+line of the head commit. Throws on 422
  *  (the line isn't part of the PR diff) so the caller can fall back to an issue comment. */
 export async function createReviewComment(

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -14,7 +14,7 @@ import {
   listInstallationRepos,
   verifyWebhookSignature,
 } from "../lib/github-app"
-import { ingestGithubPrComment } from "../lib/github-comments"
+import { ingestGithubPrComment, upsertPreviewComment } from "../lib/github-comments"
 import { fail, readJson } from "../lib/http"
 import { effectiveToken, isSyncing, runToCompletion } from "../lib/sync-runner"
 import { log } from "../log"
@@ -188,13 +188,13 @@ export const syncRoutes = (ctx: AppContext) => {
     prNumber: number,
     prTitle: string,
     headSha: string,
-  ): Promise<void> => {
+  ): Promise<{ collectionId: string }> => {
     const title = `PR #${prNumber}: ${prTitle.trim() || "(untitled)"}`.slice(0, 200)
     if (existing) {
       await meta.updateRepoSourceSync(existing.id, { ref: headSha })
       await meta.updateCollection(existing.collection_id, { title })
       await launch(existing, true)
-      return
+      return { collectionId: existing.collection_id }
     }
     const col = await meta.createCollection({
       id: newId("col"),
@@ -221,6 +221,15 @@ export const syncRoutes = (ctx: AppContext) => {
       created_by: branch.created_by,
     })
     await launch(source, true)
+    return { collectionId: col.id }
+  }
+
+  // The body of the sticky "preview" comment Dock posts on a PR: a friendly line + a
+  // deep link into the preview collection. No em dashes (customer-facing copy).
+  const previewCommentBody = (collectionId: string, docCount: number): string => {
+    const link = `${deps.baseUrl.replace(/\/$/, "")}/?collection=${collectionId}`
+    const docs = `${docCount} doc${docCount === 1 ? "" : "s"}`
+    return `📦 **Dock preview** of this PR: ${docs} rendered with versions, comments, and review.\n\n👉 [Open the preview in Dock](${link})`
   }
 
   // Tear down a preview WITHOUT graduating it: tombstone its artifacts, drop the source
@@ -785,7 +794,30 @@ export const syncRoutes = (ctx: AppContext) => {
             // a preview; it's removable from the UI today (DELETE /v1/sync/github/:id) —
             // an automated reconciler is a noted follow-up.
             const merged = !!payload.pull_request?.merged
-            if (preview) await (merged ? graduatePreview(preview) : removePrPreview(preview))
+            if (preview) {
+              // Resolve the sticky comment to its final state before tearing the
+              // preview down (best-effort, same toggle as the open path).
+              if ((await meta.getOrgSettings(branch.org_id)).githubPreviewLink) {
+                const parsed = parseRepo(fullName)
+                if (parsed) {
+                  try {
+                    const token = await effectiveToken(meta, deps.encryptionKey, branch)
+                    const link = `${deps.baseUrl.replace(/\/$/, "")}/?collection=${branch.collection_id}`
+                    const body = merged
+                      ? `✅ **Merged.** These docs are now part of [${branch.repo} in Dock](${link}).`
+                      : "📦 **Dock preview** removed (this PR was closed without merging)."
+                    if (token) await upsertPreviewComment(parsed, prNumber, body, token)
+                  } catch (err) {
+                    log.warn("pr preview comment (close) skipped", {
+                      repo: fullName,
+                      pr: prNumber,
+                      error: err instanceof Error ? err.message : String(err),
+                    })
+                  }
+                }
+              }
+              await (merged ? graduatePreview(preview) : removePrPreview(preview))
+            }
             log.info("pr preview closed", { repo: fullName, pr: prNumber, merged })
           } else if (action === "opened" || action === "reopened" || action === "synchronize") {
             const headSha = payload.pull_request?.head?.sha
@@ -807,7 +839,7 @@ export const syncRoutes = (ctx: AppContext) => {
                 if (changedDocs.length === 0) {
                   if (preview) await removePrPreview(preview)
                 } else {
-                  await upsertPrPreview(
+                  const { collectionId } = await upsertPrPreview(
                     branch,
                     preview,
                     prNumber,
@@ -819,6 +851,23 @@ export const syncRoutes = (ctx: AppContext) => {
                     pr: prNumber,
                     docs: changedDocs.length,
                   })
+                  // Sticky preview comment on the PR (best-effort, workspace-toggleable).
+                  if (token && (await meta.getOrgSettings(branch.org_id)).githubPreviewLink) {
+                    try {
+                      await upsertPreviewComment(
+                        parsed,
+                        prNumber,
+                        previewCommentBody(collectionId, changedDocs.length),
+                        token,
+                      )
+                    } catch (err) {
+                      log.warn("pr preview comment skipped", {
+                        repo: fullName,
+                        pr: prNumber,
+                        error: err instanceof Error ? err.message : String(err),
+                      })
+                    }
+                  }
                 }
               } catch (err) {
                 log.warn("pr preview skipped", {

--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -149,6 +149,7 @@ export const workspaceRoutes = (ctx: AppContext) => {
           emailNotifications: z.boolean(),
           githubPostComments: z.boolean(),
           githubMirrorComments: z.boolean(),
+          githubPreviewLink: z.boolean(),
           slackPost: z.boolean(),
         })
         .partial(),

--- a/apps/api/test/comment-fanout.test.ts
+++ b/apps/api/test/comment-fanout.test.ts
@@ -41,6 +41,7 @@ describe("comment channel fan-out", () => {
       emailNotifications: false,
       githubPostComments: true,
       githubMirrorComments: true,
+      githubPreviewLink: true,
       slackPost: true,
     })
     const shortId = await newArtifact(app)
@@ -81,6 +82,7 @@ describe("comment channel fan-out", () => {
       emailNotifications: true,
       githubPostComments: true,
       githubMirrorComments: true,
+      githubPreviewLink: true,
       slackPost: false,
     })
     const shortId = await newArtifact(app)

--- a/apps/api/test/github-comments.test.ts
+++ b/apps/api/test/github-comments.test.ts
@@ -8,11 +8,25 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest"
 import { parseMeta } from "../src/lib/comments"
 import {
   enqueueGithubPrComment,
+  findPreviewComment,
   ingestGithubPrComment,
   lineFromDiffHunk,
   lineOfQuote,
   prSourceForArtifact,
 } from "../src/lib/github-comments"
+
+describe("sticky preview comment", () => {
+  it("finds the Dock-managed comment by its hidden marker, else null", () => {
+    const comments = [
+      { id: 1, body: "looks good" },
+      { id: 2, body: "📦 Dock preview …\n<!-- dock-preview -->" },
+      { id: 3, body: "another reply" },
+    ]
+    expect(findPreviewComment(comments)).toBe(2)
+    expect(findPreviewComment([{ id: 9, body: "no marker here" }])).toBe(null)
+    expect(findPreviewComment([{ id: 9 }])).toBe(null) // tolerates a bodyless comment
+  })
+})
 
 describe("anchor/line mapping", () => {
   it("finds the 1-based line of a quote's first non-empty line", () => {

--- a/apps/api/test/github-webhook-comments.test.ts
+++ b/apps/api/test/github-webhook-comments.test.ts
@@ -148,6 +148,7 @@ describe("github → dock comment mirroring (webhook)", () => {
       emailNotifications: true,
       githubPostComments: true,
       githubMirrorComments: false,
+      githubPreviewLink: true,
       slackPost: true,
     })
     const r = await post(app, "pull_request_review_comment", reviewCommentPayload())

--- a/apps/api/test/integrations-settings.test.ts
+++ b/apps/api/test/integrations-settings.test.ts
@@ -14,6 +14,7 @@ describe("workspace integration settings", () => {
       emailNotifications: true,
       githubPostComments: true,
       githubMirrorComments: true,
+      githubPreviewLink: true,
       slackPost: true,
     })
   })

--- a/apps/api/test/sync-pr.test.ts
+++ b/apps/api/test/sync-pr.test.ts
@@ -53,6 +53,10 @@ const postWebhook = (action: string, pr: Record<string, unknown>) => {
 
 // What `GET /pulls/:n/files` returns — mutated per test to drive different change sets.
 let prFiles: { filename: string; status: string }[] = []
+// In-memory GitHub issue (PR conversation) comments, keyed by PR number — the sticky
+// preview comment writes here so tests can assert post-once + edit-in-place.
+const ghComments: Record<string, { id: number; body: string }[]> = {}
+let ghCommentSeq = 0
 // The repo tree at any ref: markdown docs + one non-doc (excluded by the globs).
 // promote-me.md / edit-me.md back the merge-graduation tests.
 const tree = [
@@ -95,6 +99,28 @@ beforeAll(async () => {
       // lastCommit (best-effort) + GraphQL batch (force the REST blob fallback).
       if (s.includes("/commits?")) return new Response("[]", { status: 200 })
       if (s.endsWith("/graphql")) return new Response("nope", { status: 404 })
+      // Sticky preview comment: list / create / edit (scoped per PR number).
+      const icList = s.match(/\/issues\/(\d+)\/comments/)
+      if (icList?.[1] && method === "GET")
+        return new Response(JSON.stringify(ghComments[icList[1]] ?? []), { status: 200 })
+      if (icList?.[1] && method === "POST") {
+        const b = JSON.parse(String(init?.body ?? "{}")) as { body: string }
+        const id = ++ghCommentSeq
+        const pr = icList[1]
+        if (!ghComments[pr]) ghComments[pr] = []
+        ghComments[pr].push({ id, body: b.body })
+        return new Response(JSON.stringify({ id }), { status: 201 })
+      }
+      const icPatch = s.match(/\/issues\/comments\/(\d+)/)
+      if (icPatch?.[1] && method === "PATCH") {
+        const id = Number(icPatch[1])
+        const b = JSON.parse(String(init?.body ?? "{}")) as { body: string }
+        for (const arr of Object.values(ghComments)) {
+          const c = arr.find((x) => x.id === id)
+          if (c) c.body = b.body
+        }
+        return new Response(JSON.stringify({ id }), { status: 200 })
+      }
       return new Response("nf", { status: 404 })
     }),
   )
@@ -283,5 +309,60 @@ describe("github pr previews", () => {
     expect(after?.current_version ?? 0).toBeGreaterThan(beforeVersion) // PR version folded in
     const comments = await meta.listComments(canonicalId)
     expect(comments.some((c) => c.body_md === "ship it")).toBe(true) // review carried over
+  })
+})
+
+describe("github pr preview: sticky comment on the PR", () => {
+  it("opened: posts ONE comment linking to the preview collection", async () => {
+    prFiles = [{ filename: "docs/guide.md", status: "modified" }]
+    await postWebhook("opened", { number: 20, title: "Doc PR", head: { sha: "s20" } })
+    const p = await preview(20)
+    if (!p) throw new Error("no preview")
+    const comments = ghComments["20"] ?? []
+    expect(comments).toHaveLength(1)
+    expect(comments[0]?.body).toContain(`/?collection=${p.collection_id}`)
+    expect(comments[0]?.body).toContain("<!-- dock-preview -->") // sticky marker
+    expect(comments[0]?.body).toContain("1 doc")
+    expect(comments[0]?.body).not.toContain("—") // no em dashes in customer-facing copy
+  })
+
+  it("synchronize: edits the same comment in place (no duplicate)", async () => {
+    prFiles = [
+      { filename: "docs/guide.md", status: "modified" },
+      { filename: "docs/other.md", status: "modified" },
+    ]
+    await postWebhook("synchronize", { number: 20, title: "Doc PR", head: { sha: "s21" } })
+    const comments = ghComments["20"] ?? []
+    expect(comments).toHaveLength(1) // still one — sticky, not spammed
+    expect(comments[0]?.body).toContain("2 docs")
+  })
+
+  it("closed without merge: resolves the comment to a removed note", async () => {
+    await postWebhook("closed", { number: 20, title: "Doc PR", head: { sha: "s21" } })
+    const comments = ghComments["20"] ?? []
+    expect(comments).toHaveLength(1)
+    expect(comments[0]?.body.toLowerCase()).toContain("removed")
+  })
+
+  it("respects the workspace toggle: no comment when githubPreviewLink is off", async () => {
+    await meta.setOrgSettings(ORG, {
+      emailNotifications: true,
+      githubPostComments: true,
+      githubMirrorComments: true,
+      githubPreviewLink: false,
+      slackPost: true,
+    })
+    prFiles = [{ filename: "docs/guide.md", status: "modified" }]
+    await postWebhook("opened", { number: 21, title: "No comment", head: { sha: "s30" } })
+    expect(await preview(21)).toBeDefined() // preview still created
+    expect(ghComments["21"]).toBeUndefined() // but no PR comment posted
+    // Restore for any later assertions.
+    await meta.setOrgSettings(ORG, {
+      emailNotifications: true,
+      githubPostComments: true,
+      githubMirrorComments: true,
+      githubPreviewLink: true,
+      slackPost: true,
+    })
   })
 })

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -217,6 +217,7 @@ export interface OrgSettings {
   emailNotifications: boolean
   githubPostComments: boolean
   githubMirrorComments: boolean
+  githubPreviewLink: boolean
   slackPost: boolean
 }
 /** Slack connection status for the Settings UI. */

--- a/apps/web/src/pages/settings/integrations-section.tsx
+++ b/apps/web/src/pages/settings/integrations-section.tsx
@@ -132,6 +132,13 @@ export function IntegrationsSection() {
             onChange={flip("githubMirrorComments")}
           />
           <Toggle
+            id="github-preview-link"
+            label="Comment a preview link on PRs"
+            hint="When a pull request opens, post (and keep updated) a comment linking to the Dock preview of its docs."
+            on={settings.githubPreviewLink}
+            onChange={flip("githubPreviewLink")}
+          />
+          <Toggle
             id="slack-post"
             label="Post activity to Slack"
             hint="Send comments to the connected Slack channel; replies there post back to Dock."

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1016,6 +1016,9 @@ export interface OrgSettings {
   githubPostComments: boolean
   /** Mirror PR comments made on GitHub back into the Dock artifact. */
   githubMirrorComments: boolean
+  /** When a PR opens (and on each push), post + keep updated a single comment on the
+   *  pull request linking to the Dock preview of its docs. */
+  githubPreviewLink: boolean
   /** Post Dock activity to the connected Slack workspace. */
   slackPost: boolean
 }
@@ -1024,6 +1027,7 @@ export const DEFAULT_ORG_SETTINGS: OrgSettings = {
   emailNotifications: true,
   githubPostComments: true,
   githubMirrorComments: true,
+  githubPreviewLink: true,
   slackPost: true,
 }
 


### PR DESCRIPTION
## Comment the Dock preview link when a PR opens

Closes the loop on PR previews: until now a PR preview collection was created silently and only discoverable in Settings. Now Dock announces it **on the pull request itself**.

### Behavior
- **On open / each push:** post a single comment on the PR linking to the Dock preview of its changed docs (`📦 Dock preview of this PR: N docs …`). It's **sticky** — an invisible `<!-- dock-preview -->` marker means subsequent pushes **edit the same comment** instead of spamming the thread.
- **On close:** resolve the comment in place — merged → "Merged. These docs are now part of \<repo\> in Dock"; closed-without-merge → "preview removed".
- **Loop-safe:** carries the `via Dock` marker + posts as the App bot, so the inbound comment mirror never re-ingests it.
- **Best-effort:** a comment failure is logged and never blocks the preview sync.

### Toggle
New `githubPreviewLink` workspace setting (default **on**), surfaced as a switch in **Settings → Integrations** ("Comment a preview link on PRs"). The sync hook is gated on it.

### Notes
- Builds on the `pull_requests: write` permission added by the integrations work (#215). No schema change (toggle rides the existing `org_settings` JSON).
- No em dashes in the customer-facing comment copy.

### Tests / checks
- End-to-end via the PR-webhook suite: post-once on open, edit-in-place on sync, resolve on close, and **no comment when the toggle is off**; plus a `findPreviewComment` unit test.
- Local: typecheck, `pnpm run ci` (biome + all guardrails), full unit suite (518 API tests), API + pg + d1 + all coverage gates, web build + bundle — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)