### PR TITLE
refactor(mcp): consolidate to 5 workflow-shaped tools across servers + docs

### DIFF
--- a/.claude/skills/dock.md
+++ b/.claude/skills/dock.md
@@ -47,35 +47,34 @@ An agent token defaults to commenter. To publish directly, the agent needs edito
 
 ---
 
-## Two MCP servers — choose one
+## Two MCP servers (same 5 tools)
+
+Both the stdio `@dock/mcp` server and the remote `/mcp` server expose the same 5
+tools (`list_artifacts`, `read`, `catch_up`, `comment`, `publish`). The difference is
+auth and how writes land:
 
 | | STDIO MCP (`@dock/mcp`) | HTTP MCP (`/mcp`) |
 |---|---|---|
 | **Auth** | Static `dk_agt_` token | OAuth 2.1 bearer |
 | **Connect via** | Claude Code `.claude/mcp.json` | claude.ai / Claude Desktop OAuth flow |
-| **Writes** | Direct publish — no approval gate | Propose only — human approves before live |
-| **Sync tool** | `list_comments` + `get_artifact` | `catch_me_up` (coalesced delta) |
+| **Writes** | `publish` goes live or files a proposal based on role | Same; OAuth scope maps to role |
+| **Caveats** | Bundles are publish-via-remote/web only; `comment` set_state takes a `comment_id` | Full bundle publish via `publish` `files` map |
 | **Best for** | Trusted agents, CI, solo use | Collaborative, human-in-the-loop |
 
 ---
 
-## The loop — STDIO MCP
+## The loop
 
-1. `publish_artifact` — get a `short_id` and URL. Share it.
-2. `list_comments(state: "open")` — read the feedback queue.
-3. `get_artifact` — read the current source.
-4. Revise the content.
-5. `publish_version(resolves: [commentId, ...])` — new version, threads closed atomically.
-6. Repeat from 2.
-
----
-
-## The loop — HTTP MCP
-
-1. `catch_me_up(short_id, since_version)` — coalesced delta: new versions + diff + open threads.
-2. `read_section` to drill into changed pages; `diff` for exact line comparison.
-3. `propose(content, message)` — candidate version, not live. Human approves or requests changes.
-4. On approval Dock publishes it and re-anchors comments. Loop.
+1. `catch_up(short_id, since_version)` gives the state in one call: what changed, the open
+   feedback threads, and version history. Pass `comments` (open/addressed/resolved/outdated)
+   for a filtered feedback queue, or `response_format='detailed'` to fold in the exact line diff.
+2. `read` returns content by short id; for a bundle omit `section` for the outline or pass a
+   `section` (page path) for one page; pass `version` to read history.
+3. Revise the content.
+4. `comment` (reply with `reply_to`, resolve/reopen with `set_state`) and/or
+   `publish` (pass `addresses` to resolve the threads this revision fixes): same URL, a
+   new version, threads closed atomically.
+5. Repeat from 1.
 
 Comments re-anchor to moved text automatically. If the quoted text is deleted, the comment
 shows "text changed" — it never attaches to the wrong place.
@@ -84,37 +83,17 @@ shows "text changed" — it never attaches to the wrong place.
 
 ## MCP tools (quick reference)
 
-**STDIO MCP** (token-based, direct publish):
+The same 5 tools on both servers:
 
 | Tool | When to use |
 |---|---|
-| `publish_artifact` | First publish of new content |
-| `publish_version` | Revised version; pass `resolves` to close threads |
-| `get_artifact` | Read current (or past) source + metadata |
-| `list_versions` | Version history |
-| `diff_versions` | What changed between two versions |
-| `restore_version` | Roll back (creates new version, preserves history) |
-| `list_comments` | Feedback queue |
-| `add_comment` | New thread; pass `quote` to anchor to text |
-| `reply_comment` | Reply in existing thread |
-| `resolve_thread` | Close (or reopen) a thread |
-| `view_stats` | View counts |
+| `list_artifacts` | Find the artifacts in your workspace (short id, title, kind, version, visibility); optional `query` filters by title |
+| `read` | Read content by short id; bundles take a `section` (page path) and any tool takes a `version` for history |
+| `catch_up` | Start here on an artifact: what changed since `since_version`, open/outdated threads, and version history; pass `comments` for a filtered feedback queue, or `response_format='detailed'` for the line diff |
+| `comment` | Leave feedback, reply (`reply_to`), anchor to a `quote`, and/or resolve/reopen (`set_state`) |
+| `publish` | Save a revision (`content` for one file, `files` for a bundle); omit `short_id` to create new, pass it to add a version; `addresses` resolves threads; goes live or files a proposal based on role, or `for_review:true` |
 
 Resource: `dock://guide` — the agent loop guide as a readable MCP resource.
-
-**HTTP MCP** (OAuth, propose-only):
-
-| Tool | When to use |
-|---|---|
-| `catch_me_up` | Session start — coalesced delta since `since_version` |
-| `list_artifacts` | Enumerate workspace artifacts |
-| `read_artifact` | Metadata + content for single-file artifacts |
-| `read_section` | Per-page content for bundles; omit `path` to list pages |
-| `diff` | Line diff between two versions |
-| `list_comments` | Feedback queue |
-| `list_versions` | Version history |
-| `propose` | Submit candidate version for human review |
-| `whoami` | Confirm connection + role |
 
 ---
 
@@ -124,7 +103,7 @@ Resource: `dock://guide` — the agent loop guide as a readable MCP resource.
 - `dock-connect.md` — get a token, wire MCP to Claude Code or Claude Desktop
 
 **Publishing & versioning**
-- `using/dock-publish.md` — publish_artifact, publish_version, versions, CLI, API
+- `using/dock-publish.md` — `publish` (new + versions), versions, CLI, API
 - `using/dock-proposals.md` — the propose -> review -> approve loop
 
 **Feedback**

--- a/.claude/skills/formats/dock-markdown.md
+++ b/.claude/skills/formats/dock-markdown.md
@@ -96,4 +96,4 @@ Allowed attributes: `src`, `alt`, `title`, `width`, `height`.
 ```
 
 Task list checkboxes are rendered but not interactive (checking them doesn't update
-the source). Use a new `publish_version` to update task state.
+the source). Use a new `publish` (with the artifact's `short_id`) to update task state.

--- a/.claude/skills/using/dock-comments.md
+++ b/.claude/skills/using/dock-comments.md
@@ -46,11 +46,15 @@ different slide, the comment follows it and is flagged "moved". See `formats/doc
 
 ## Listing comments
 
+The feedback queue comes from `catch_up`:
+
 ```
-list_comments(short_id, state?)
+catch_up(short_id, comments?)
 ```
 
-`state` is `"open"` or `"resolved"`. Omit to get all threads.
+`comments` is `"open"`, `"addressed"`, `"resolved"`, or `"outdated"`; pass it to get that
+filtered feedback queue. Omit it for the artifact's full state (what changed, open/outdated
+threads, version history).
 
 Each comment includes: `id`, `thread_id`, `base_version`, `state`, `author`, `body_md`,
 `anchor` (the TextQuoteSelector JSON or null), `created_at`, and `anchored` (boolean —
@@ -61,7 +65,7 @@ whether the anchor still resolves in the current version).
 ## Adding a comment
 
 ```
-add_comment(short_id, body_md, quote?)
+comment(short_id, body_md, quote?)
 ```
 
 Pass `quote` as the exact text you want to anchor to. Dock finds it in the current version
@@ -69,10 +73,10 @@ and builds the TextQuoteSelector automatically. Omit `quote` for a general (unan
 
 ```
 # General feedback
-add_comment("nk0dsral", "The conclusion needs a call to action.")
+comment("nk0dsral", "The conclusion needs a call to action.")
 
 # Anchored to a specific passage
-add_comment("nk0dsral", "This sentence is unclear.", "The system resolves ambiguities")
+comment("nk0dsral", "This sentence is unclear.", "The system resolves ambiguities")
 ```
 
 ---
@@ -80,27 +84,29 @@ add_comment("nk0dsral", "This sentence is unclear.", "The system resolves ambigu
 ## Replying
 
 ```
-reply_comment(short_id, thread_id, body_md)
+comment(short_id, body_md, reply_to)
 ```
 
-Use the `thread_id` from the root comment (or any comment in the thread — they all share it).
-Replies don't need an anchor; they're part of the root comment's thread.
+Pass `reply_to` as the `thread_id` of the root comment (or any comment in the thread, since
+they all share it). Replies don't need an anchor; they're part of the root comment's thread.
 
 ---
 
 ## Resolving threads
 
 ```
-resolve_thread(short_id, comment_id, state?)
+comment(short_id, set_state, ...)   # set_state: "resolved" | "open"
 ```
 
-`state` defaults to `"resolved"`. Pass `state: "open"` to reopen a closed thread.
-`comment_id` can be any comment in the thread — Dock resolves the thread it belongs to.
+Use `set_state: "resolved"` to close a thread (or `"open"` to reopen one). Target the thread
+by its id (over the stdio `@dock/mcp` server, set_state takes a `comment_id`, which can be any
+comment in the thread).
 
-The most efficient pattern is to resolve threads at the same time as publishing a new version:
+The most efficient pattern is to resolve threads at the same time as publishing a new version,
+via `publish`'s `addresses`:
 
 ```
-publish_version("nk0dsral", newContent, "report.html", "Fixed intro", ["c_abc123", "c_def456"])
+publish("nk0dsral", newContent, "report.html", "Fixed intro", ["c_abc123", "c_def456"])
 ```
 
 ---

--- a/.claude/skills/using/dock-proposals.md
+++ b/.claude/skills/using/dock-proposals.md
@@ -10,7 +10,7 @@ don't go live until a human approves them.
 An agent with **commenter role** (the default) cannot publish directly. It must propose.
 A human (or agent with editor role) then reviews and approves or requests changes.
 
-An agent with **editor role** can publish directly via `publish_version` — no proposal needed.
+An agent with **editor role** can publish directly via `publish`, no proposal needed.
 
 Use proposals when:
 - You want a human checkpoint before content goes live
@@ -32,12 +32,14 @@ it just flags it. The agent creates a new proposal for each revision.
 
 ---
 
-## MCP vs REST
+## Proposing via MCP
 
-The standard MCP server (`@dock/mcp`) includes `publish_version` which **publishes directly**.
-Proposals are a REST-only path in the current MCP server.
+There is one publishing tool, `publish`. Whether it goes live or files a proposal is
+decided by your role: an editor (Creator/Admin) role publishes directly, while a commenter
+role files a proposal. Pass `for_review:true` to file a proposal even when your role could
+publish directly.
 
-To propose via REST:
+To propose via REST instead:
 
 ```bash
 curl -X POST https://dock.build/v1/artifacts/<short_id>/proposals \
@@ -90,9 +92,10 @@ curl -X POST https://dock.build/v1/artifacts/<short_id>/proposals \
 
 ---
 
-## The OAuth MCP server (dock-agentic-loop)
+## The OAuth MCP server
 
-The OAuth-based MCP server (used when connecting via browser consent rather than a
-static token) exposes a `propose` tool that wraps the proposal REST endpoint. If your
-MCP client shows a `propose` tool instead of `publish_version`, you're on the OAuth
-server — use `propose` for all content changes and a human approves them in the UI.
+The OAuth-based remote `/mcp` server (used when connecting via browser consent rather than a
+static token) exposes the same 5 tools, including `publish`. The OAuth scope you grant maps
+to a role: a commenter-scoped agent's `publish` calls always file a proposal a human approves
+in the UI, while a publish-scoped agent goes live (and can still pass `for_review:true` to
+file a proposal).

--- a/.claude/skills/using/dock-publish.md
+++ b/.claude/skills/using/dock-publish.md
@@ -4,21 +4,27 @@ Publishing content to Dock and updating it over time.
 
 ---
 
-## First publish: publish_artifact
+## Publish
 
-Use this once per piece of content to create the artifact and get its permanent `short_id`.
+`publish` is the one tool for saving content. Omit `short_id` to create a new artifact
+and get its permanent `short_id`; pass `short_id` to add a version (see below).
 
 ```
-publish_artifact(
-  content:    string,      // full file content (HTML or Markdown)
+publish(
+  content:    string,      // full file content for a single file (HTML or Markdown)
+  files?:     object,      // path -> content map for a multi-page bundle
   filename:   string,      // e.g. "report.html" or "notes.md" — determines artifact type
-  title?:     string,      // display title in the workspace
+  title?:     string,      // display title (required when creating a new artifact)
   slug?:      string,      // custom URL slug
-  visibility? "public" | "link" | "org" | "password"  // default: "link"
+  visibility? "public" | "link" | "org" | "password",  // default: "link"
+  for_review? boolean      // file a proposal instead of going live
 )
 ```
 
 Returns: `{ short_id, url, current_version }`.
+
+Whether a `publish` goes live or files a proposal is decided by your role (Creator/Admin
+publish live; a commenter role files a proposal), with `for_review:true` to force review.
 
 **Keep the `short_id`.** It's the artifact's permanent identity. Every future version,
 comment, and proposal references it.
@@ -34,25 +40,26 @@ comment, and proposal references it.
 
 ---
 
-## Subsequent versions: publish_version
+## Subsequent versions: publish with a short_id
 
-Use this every time you revise the content. Same URL, incremented version number.
+Pass `short_id` to `publish` every time you revise the content. Same URL, incremented
+version number.
 
 ```
-publish_version(
-  short_id:  string,        // from the original publish_artifact call
+publish(
+  short_id:  string,        // from the original publish call
   content:   string,        // full revised content
   filename:  string,        // same as before (e.g. "report.html")
   message?:  string,        // changelog note ("Fixed the intro section")
-  resolves?: string[]       // comment IDs to close in the same operation
+  addresses? string[]       // thread IDs to resolve in the same operation
 )
 ```
 
-Passing `resolves` is the canonical way to close feedback: the threads flip to resolved
+Passing `addresses` is the canonical way to close feedback: the threads flip to resolved
 atomically with the publish, so reviewers can see exactly which version addressed their comment.
 
-**Don't create a new artifact when you mean to version.** Each `publish_artifact` call
-creates a brand new artifact with a new URL. Use `publish_version` to update existing content.
+**Don't create a new artifact when you mean to version.** A `publish` without `short_id`
+creates a brand new artifact with a new URL. Pass `short_id` to update existing content.
 
 ---
 
@@ -102,11 +109,12 @@ The `filename` parameter is a hint for content type detection:
 ## Reading back what you published
 
 ```
-get_artifact(short_id, version?)
+read(short_id, version?)
 ```
 
-Returns metadata + full source content. Omit `version` for the current version.
-Pass a past `version` number to read any historical snapshot.
+Returns the source content. Omit `version` for the current version. Pass a past
+`version` number to read any historical snapshot. For a bundle, pass a `section`
+(page path) for one page, or omit it for the outline.
 
 Permanent raw URL (no auth, immutable):
 ```
@@ -117,19 +125,18 @@ https://dock.build/raw/<short_id>/v/<n>/index.html
 
 ## Versions
 
-Every `publish_version` call creates an immutable snapshot. Version numbers start at 1.
+Every `publish` with a `short_id` creates an immutable snapshot. Version numbers start at 1.
+
+Version history, the line diff, and what changed are all surfaced by `catch_up`:
 
 ```
-list_versions(short_id)
+catch_up(short_id)                                  # version history + open threads
+catch_up(short_id, response_format='detailed',
+         since_version, to_version)                 # fold in the exact line diff
 ```
-Returns `[{ n, author, message, created_at }]`, newest first.
 
-```
-diff_versions(short_id, from?, to?)
-```
-Defaults to previous vs current. Returns `{ ops: [{ t: "add"|"del"|"ctx", line }] }`.
+History returns `[{ n, author, message, created_at }]`, newest first; the detailed diff
+returns `{ ops: [{ t: "add"|"del"|"ctx", line }] }`.
 
-```
-restore_version(short_id, version)
-```
-Creates a new version pointing to the old blob. History is never deleted.
+To roll back, `publish` the old version's content as a new version (pass `short_id`).
+History is never deleted.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ packages/core     domain: ports, publish, markdown render, viewer shell
 packages/db       MetaStore: sqlite (default) · postgres · d1
 packages/storage  BlobStore: fs (default) · s3/r2
 packages/cli      dock init (md/html/slides) · dock publish <file|dir>
-packages/mcp      MCP server: publish / read-back tools for agents
+packages/mcp      MCP server: the 5 agent tools (list_artifacts, read, catch_up, comment, publish)
 ```
 
 ## Deploy
@@ -120,9 +120,10 @@ node packages/cli/bin/dock.js publish    # share a versioned URL
 node packages/cli/bin/dock.js comments   # read the review threads, then revise and publish again
 ```
 
-MCP tools: `whoami`, `list_artifacts`, `read_artifact`, `read_section`, `list_versions`,
-`diff`, `list_comments`, `catch_me_up`, `propose` (human-reviewed), and `publish`
-(direct — Creator/Admin role). Publish vs. propose follows your role. Full loop in
+MCP tools (five): `list_artifacts` (find), `read` (content), `catch_up` (what changed
+plus the open feedback and version history), `comment` (leave/reply/resolve), and
+`publish` (save a revision). `publish` goes live if your role can publish (Creator/Admin),
+otherwise (or with `for_review:true`) it files a proposal a human approves. Full loop in
 [packages/mcp/SKILL.md](packages/mcp/SKILL.md).
 
 > The `@dock/cli` / `@dock/mcp` npm packages aren't published yet — run the CLI from the

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -1,19 +1,23 @@
 // Remote MCP endpoint — Dock as a Model Context Protocol server an AI client
 // (claude.ai / Claude Code) connects to over Streamable HTTP, authenticated by the
 // same OAuth 2.1 bearer the rest of the app uses. It's the transport for the agentic
-// loop: connect once, see what changed (catch_me_up), read, and propose revisions a
-// human approves — no static token.
+// loop: connect once, see what changed (catch_up), read, comment, and publish a
+// revision — no static token.
 //
 // Stateless + fetch-native (no Durable Object, no nodejs_compat): a fresh McpServer
 // is built per request closing over the resolved agent identity, so tool calls act
 // in exactly that bearer's workspace at that bearer's role. Runs identically on the
 // Node tier and the Cloudflare Workers tier — same `createApp`.
 //
-// Tool design follows Anthropic's "Writing effective tools for agents": few tools
+// Tool design follows Anthropic's "Writing effective tools for agents": a small set
 // shaped to the agent's workflow (not the API surface), high-signal responses with
 // truncate-and-steer, semantic ids (short_id / vN / page path — never UUIDs),
 // actionable errors, and identity carried in the server `instructions` rather than a
-// tool slot.
+// tool slot. Five tools, one per intent — FIND (list_artifacts), READ content (read),
+// CATCH UP on state/feedback/history (catch_up), COMMENT (comment), and WRITE
+// (publish). Variation lives in parameters: `since_version`/`to_version` turn
+// catch_up into a diff, `reply_to`/`set_state` fold reply+resolve into comment, and
+// `for_review`/role turn publish into a human-reviewed proposal.
 
 import {
   type AgentRecord,
@@ -22,6 +26,7 @@ import {
   type BundleManifest,
   diffLines,
   formatDiff,
+  newId,
   PublishError,
   propose as proposeChange,
   publish as publishVersion,
@@ -76,6 +81,24 @@ const summarizeVersion = (v: VersionRecord) => ({
   created_at: v.created_at,
 })
 
+const summarizeComment = (c: {
+  thread_id: string
+  author: string
+  state?: string
+  base_version?: number
+  anchor: string | null
+  path?: string | null
+  body_md: string
+}) => ({
+  thread: c.thread_id,
+  author: c.author,
+  ...(c.state ? { state: c.state } : {}),
+  ...(c.base_version != null ? { base_version: c.base_version } : {}),
+  quote: quoteOf(c.anchor),
+  ...(c.path ? { path: c.path } : {}),
+  body: c.body_md,
+})
+
 // A version's bundle manifest, presented cleanly. Lets the loop tools see a
 // multi-page artifact's actual files, not just its entry doc.
 const manifestOf = (ctx: AppContext, v: VersionRecord) => sharedManifestOf(ctx.blobs, v)
@@ -103,32 +126,32 @@ const changeCount = (c: ReturnType<typeof bundleFileChanges>) =>
 
 /**
  * A new MCP server for one request, scoped to `agent` (the OAuth-resolved identity).
- * Tools act in the bearer's workspace at the bearer's role: reads for anyone, and
- * `propose` (the human-in-the-loop write) for commenter+ — a proposal never goes
- * live without a human approving it, so an agent is a safe contributor, not a
- * publisher. Identity rides in the server `instructions` (below), not a `whoami`
- * tool — it's a one-shot fact, not a per-call action.
+ * Tools act in the bearer's workspace at the bearer's role: reads + comments for
+ * commenter+, and writes via `publish` — which goes live for an editor/owner, or is
+ * filed as a human-reviewed proposal for a commenter (or anyone passing
+ * `for_review`). So a low-privilege agent is a safe contributor, not a publisher.
+ * Identity rides in the server `instructions` (below), not a `whoami` tool — it's a
+ * one-shot fact, not a per-call action.
  */
 function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
   // Steer the write guidance by what this grant can actually do: a publish-capable
-  // grant gets the create/publish path; a lower grant is pointed at propose only.
+  // grant gets the direct-publish path; a lower grant is told its writes go to review.
   const writeGuidance = roleAllows(agent.role, "publish")
-    ? `Use publish to create a new artifact (omit short_id) or push a new version of one you own — ` +
-      `it goes live immediately in your workspace. Use propose to suggest changes to artifacts you ` +
-      `don't own, which a human approves. `
-    : `Work the open threads from list_comments and use propose to suggest a revision a human ` +
-      `approves — you cannot publish directly. `
+    ? `Use publish to create a new artifact (omit short_id) or push a new version of one (pass short_id) — ` +
+      `it goes live immediately. Pass for_review:true to file it as a proposal a human approves instead. `
+    : `Use publish to submit a revision — at your role it is filed as a proposal a human approves before it ` +
+      `goes live; you cannot publish directly. `
   const server = new McpServer(
     { name: "dock", version: "1.0.0" },
     {
       instructions:
         `You are connected to Dock as "${agent.name}", acting in workspace ${agent.org_id} ` +
         `with ${agent.role} permissions. Dock hosts living documents and plans with versioned ` +
-        `history, text-anchored review comments, and a propose → review → revise loop. ` +
-        `Start a session with catch_me_up to re-sync on what changed; use read to view content ` +
-        `(outline first for multi-page bundles). ${writeGuidance}When a ` +
-        `proposal fixes specific feedback, pass those thread ids as propose's "addresses" so the ` +
-        `threads show as pending and auto-resolve on approval.`,
+        `history, text-anchored review comments, and a publish → review → revise loop. ` +
+        `Start a session with catch_up to re-sync on what changed and what feedback is open; use ` +
+        `read to view content (outline first for multi-page bundles); use comment to leave or ` +
+        `resolve feedback. ${writeGuidance}When a revision fixes specific feedback, pass those ` +
+        `thread ids as publish's "addresses" so the threads resolve (or show pending on a proposal).`,
     },
   )
   const org = agent.org_id
@@ -141,11 +164,12 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
   const notFound = (shortId: string) =>
     err(`No artifact "${shortId}" in your workspace. Call list_artifacts to see what's here.`)
 
+  // FIND ----------------------------------------------------------------------
   server.registerTool(
     "list_artifacts",
     {
       description:
-        "List the artifacts (docs, plans, sites) in your workspace — short id, title, kind, current version, visibility. Start here to find what to work on, then catch_me_up or read it.",
+        "List the artifacts (docs, plans, sites) in your workspace — short id, title, kind, current version, visibility. Start here to find what to work on, then catch_up or read it.",
       inputSchema: { query: z.string().optional().describe("Optional title search filter.") },
     },
     async ({ query }) => {
@@ -154,110 +178,12 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
     },
   )
 
-  server.registerTool(
-    "catch_me_up",
-    {
-      description:
-        "START HERE on an artifact. The coalesced delta since you last saw it (`since_version`): a one-line summary, the versions that landed, which pages changed, and the open comment threads — everything to re-sync in one call. For an exact line-by-line comparison of two specific versions, use `diff` instead. Pass response_format='detailed' to also include the entry-document diff inline.",
-      inputSchema: {
-        short_id: z.string(),
-        since_version: z
-          .number()
-          .optional()
-          .describe("The version you last saw. Defaults to current − 1."),
-        response_format: z
-          .enum(["summary", "detailed"])
-          .optional()
-          .describe(
-            "'summary' (default, token-light) omits the line diff; 'detailed' includes it.",
-          ),
-      },
-    },
-    async ({ short_id, since_version, response_format }) => {
-      const a = await own(short_id)
-      if (!a) return notFound(short_id)
-      const head = a.current_version
-      const since = Math.min(head, Math.max(1, since_version ?? head - 1))
-      const newVersions = (await ctx.meta.listVersions(a.id)).filter((v) => v.n > since)
-      const vs = await ctx.meta.getVersion(a.id, since)
-      const vh = await ctx.meta.getVersion(a.id, head)
-      let entryDiff: string | null = null
-      let pagesChanged: ReturnType<typeof bundleFileChanges> | null = null
-      if (vs && vh && since < head) {
-        const [ms, mh] = [await manifestOf(ctx, vs), await manifestOf(ctx, vh)]
-        if (ms && mh) pagesChanged = bundleFileChanges(ms, mh)
-        if (response_format === "detailed") {
-          const [as_, ah] = [await ctx.sourceText(vs), await ctx.sourceText(vh)]
-          if (as_ !== null && ah !== null) entryDiff = clip(formatDiff(diffLines(as_, ah)))
-        }
-      }
-      const open = await ctx.meta.listComments(a.id, { state: "open" })
-      // Threads whose quoted text changed in a landed version — feedback that may
-      // no longer apply. Surfacing the count tells the agent its (or someone's)
-      // edits touched commented passages.
-      const outdated = await ctx.meta.listComments(a.id, { state: "outdated" })
-      const outdatedBit = outdated.length
-        ? ` ${outdated.length} now outdated (the quoted text changed).`
-        : ""
-      // Threads with a proposal already pending — the agent shouldn't re-propose them.
-      const addressed = await ctx.meta.listComments(a.id, { state: "addressed" })
-      const addressedBit = addressed.length
-        ? ` ${addressed.length} addressed (a proposal is pending review).`
-        : ""
-      const pageBits =
-        pagesChanged && changeCount(pagesChanged)
-          ? ` Pages: ${[
-              pagesChanged.added.length && `+${pagesChanged.added.length}`,
-              pagesChanged.changed.length && `~${pagesChanged.changed.length}`,
-              pagesChanged.removed.length && `-${pagesChanged.removed.length}`,
-            ]
-              .filter(Boolean)
-              .join(" ")}.`
-          : ""
-      const summary =
-        since >= head
-          ? `You're up to date on "${a.title}" (v${head}); ${open.length} open comment${open.length === 1 ? "" : "s"}.${addressedBit}${outdatedBit}`
-          : `"${a.title}": ${newVersions.length} new version${newVersions.length === 1 ? "" : "s"} since v${since} (now v${head}).${pageBits} ${open.length} open comment${open.length === 1 ? "" : "s"}.${addressedBit}${outdatedBit}`
-      return json({
-        summary,
-        short_id,
-        since,
-        head,
-        caught_up: since >= head,
-        new_versions: newVersions.map(summarizeVersion),
-        pages_changed: pagesChanged,
-        ...(entryDiff
-          ? { entry_diff: entryDiff }
-          : {
-              entry_diff:
-                "(omitted) — call again with response_format='detailed', or diff(from, to), for the line-level changes.",
-            }),
-        open_comments: open.map((c) => ({
-          thread: c.thread_id,
-          author: c.author,
-          quote: quoteOf(c.anchor),
-          body: c.body_md,
-        })),
-        // Only included when non-empty, to keep the common response lean.
-        ...(outdated.length
-          ? {
-              outdated_comments: outdated.map((c) => ({
-                thread: c.thread_id,
-                author: c.author,
-                quote: quoteOf(c.anchor),
-                body: c.body_md,
-              })),
-            }
-          : {}),
-      })
-    },
-  )
-
+  // READ CONTENT --------------------------------------------------------------
   server.registerTool(
     "read",
     {
       description:
-        "Read an artifact's content by short id. Multi-page bundle: omit `section` to get its outline (the list of pages), then call again with a `section` (a page path) for that page's full text. Single-file artifact: returns the full content. Pass a past `version` to read history.",
+        "Read an artifact's CONTENT by short id. Multi-page bundle: omit `section` to get its outline (the list of pages), then call again with a `section` (a page path) for that page's full text. Single-file artifact: returns the full content. Pass a past `version` to read history. (For what CHANGED, or the comment threads, use catch_up.)",
       inputSchema: {
         short_id: z.string().describe("The artifact's short id, e.g. nk0dsral."),
         section: z
@@ -311,165 +237,199 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
     },
   )
 
+  // CATCH UP — state, feedback, history, and diffs all in one ------------------
   server.registerTool(
-    "diff",
+    "catch_up",
     {
       description:
-        "Exact line-by-line comparison of two versions of an artifact: a unified diff of the entry document, plus (for bundles) which pages were added / removed / changed. For a summary of everything new since you last looked, prefer catch_me_up. `to` defaults to the current version.",
+        "START HERE on an artifact. The state of it in one call: a one-line summary, the versions that landed since `since_version`, which pages changed, the open (and outdated) comment threads, and the full version history. " +
+        "Pass `comments` (open / addressed / resolved / outdated) to instead get that filtered thread list — your feedback to-do queue. " +
+        "Pass `response_format='detailed'` (optionally with `since_version`/`to_version`) to include the exact line-by-line diff between two versions.",
       inputSchema: {
         short_id: z.string(),
-        from: z.number().describe("The base version number."),
-        to: z.number().optional().describe("Defaults to the current version."),
-      },
-    },
-    async ({ short_id, from, to }) => {
-      const a = await own(short_id)
-      if (!a) return notFound(short_id)
-      const toN = to ?? a.current_version
-      const vf = await ctx.meta.getVersion(a.id, from)
-      const vt = await ctx.meta.getVersion(a.id, toN)
-      if (!vf || !vt)
-        return err(`Missing version — "${short_id}" has versions 1..${a.current_version}.`)
-      const [af, at] = [await ctx.sourceText(vf), await ctx.sourceText(vt)]
-      if (af === null || at === null) return err("Version content is unavailable.")
-      const [mf, mt] = [await manifestOf(ctx, vf), await manifestOf(ctx, vt)]
-      return json({
-        short_id,
-        from,
-        to: toN,
-        pages_changed: mf && mt ? bundleFileChanges(mf, mt) : null,
-        entry_diff: clip(formatDiff(diffLines(af, at))),
-      })
-    },
-  )
-
-  server.registerTool(
-    "list_comments",
-    {
-      description:
-        "The review feedback on an artifact: comment threads with author, body, the quoted text they're anchored to, the version they were left on, and state. This is your to-do list before proposing — work the `open` threads. State is open (live feedback), addressed (a proposal you/someone made is pending review for it — don't re-propose), resolved (settled), or outdated (the quoted text changed in a later version, so the feedback may no longer apply — verify before acting). Filter by `state`; default lists all.",
-      inputSchema: {
-        short_id: z.string(),
-        state: z
+        since_version: z
+          .number()
+          .optional()
+          .describe("The version you last saw (the diff base). Defaults to to_version − 1."),
+        to_version: z
+          .number()
+          .optional()
+          .describe("Compare up to this version instead of the current one (for an exact diff)."),
+        comments: z
           .enum(["open", "addressed", "resolved", "outdated"])
           .optional()
-          .describe("Filter by thread state. Omit to list every thread."),
-      },
-    },
-    async ({ short_id, state }) => {
-      const a = await own(short_id)
-      if (!a) return notFound(short_id)
-      const comments = await ctx.meta.listComments(a.id, state ? { state } : undefined)
-      return json({
-        count: comments.length,
-        comments: comments.map((c) => ({
-          thread: c.thread_id,
-          author: c.author,
-          state: c.state,
-          base_version: c.base_version,
-          // The quoted text the thread is anchored to (null for whole-document
-          // feedback) — tells the agent WHERE in the artifact the note applies.
-          quote: quoteOf(c.anchor),
-          path: c.path,
-          body: c.body_md,
-        })),
-      })
-    },
-  )
-
-  server.registerTool(
-    "list_versions",
-    {
-      description:
-        "The version history of an artifact, newest first: number, checkpoint name, message, author, timestamp. For what actually changed between versions, use diff or catch_me_up.",
-      inputSchema: { short_id: z.string() },
-    },
-    async ({ short_id }) => {
-      const a = await own(short_id)
-      if (!a) return notFound(short_id)
-      const versions = await ctx.meta.listVersions(a.id)
-      return json({
-        current: a.current_version,
-        versions: versions.slice().reverse().map(summarizeVersion),
-      })
-    },
-  )
-
-  server.registerTool(
-    "propose",
-    {
-      description:
-        "Propose a revised version of a single-file artifact for human review. It does NOT go live — a reviewer approves it or requests changes, so you're a safe contributor, not a publisher. Provide the FULL new content (not a patch) and a rationale that tells the reviewer what changed and why. Pass `addresses` with the thread ids (from list_comments) this revision resolves — those threads show as `addressed` (pending review) and auto-resolve when the proposal is approved. Multi-page bundles aren't proposable over MCP yet.",
-      inputSchema: {
-        short_id: z.string(),
-        content: z
-          .string()
-          .describe("The complete new content of the document (HTML or Markdown)."),
-        message: z
-          .string()
-          .min(1)
-          .describe("What you changed and why — shown to the reviewer. Required."),
-        filename: z
-          .string()
-          .optional()
-          .describe("Filename hint for the content type, e.g. index.html or notes.md."),
-        addresses: z
-          .array(z.string())
+          .describe(
+            "Return ONLY this state's comment threads (the feedback queue) instead of the delta.",
+          ),
+        response_format: z
+          .enum(["summary", "detailed"])
           .optional()
           .describe(
-            "Thread ids (from list_comments) this revision resolves. They flip to `addressed` and resolve on approval.",
+            "'summary' (default, token-light) omits the line diff; 'detailed' includes it.",
           ),
       },
     },
-    async ({ short_id, content, message, filename, addresses }) => {
+    async ({ short_id, since_version, to_version, comments, response_format }) => {
       const a = await own(short_id)
       if (!a) return notFound(short_id)
-      if (agent.role === "viewer")
-        return err(
-          "Your grant is read-only (dock:read). Re-authorize the connector with dock:propose to propose changes.",
-        )
-      if (a.kind === "bundle")
-        return err(
-          `"${short_id}" is a multi-page bundle; proposing bundle revisions over MCP isn't supported yet (single-file artifacts only).`,
-        )
-      try {
-        const { proposal } = await proposeChange(ctx.meta, ctx.blobs, short_id, {
-          bytes: new TextEncoder().encode(content),
-          filename: filename ?? "index.html",
-          isBundle: false,
-          message,
-          author: agent.name,
-          author_id: agent.id,
-        })
-        const addressed = addresses?.length
-          ? await markAddressed(ctx.meta, a.id, proposal.id, addresses)
-          : []
-        for (const threadId of addressed)
-          ctx.bus.publish(a.id, {
-            type: "comment.addressed",
-            thread_id: threadId,
-            state: "addressed",
-          })
+
+      // `comments` filter → the feedback to-do queue (absorbs the old list_comments).
+      if (comments) {
+        const list = await ctx.meta.listComments(a.id, { state: comments })
         return json({
-          proposed: true,
-          proposal_id: proposal.id,
-          base_version: proposal.base_version,
-          addressed,
-          note: "Submitted for review — a human approves it or requests changes. It is NOT live yet.",
+          short_id,
+          comments_state: comments,
+          count: list.length,
+          comments: list.map(summarizeComment),
         })
-      } catch (e) {
-        return err(
-          `Couldn't store the proposal: ${e instanceof PublishError ? e.message : "unknown error"}.`,
-        )
       }
+
+      const head = a.current_version
+      const to = Math.min(head, Math.max(1, to_version ?? head))
+      const since = Math.min(to, Math.max(1, since_version ?? to - 1))
+      const history = await ctx.meta.listVersions(a.id)
+      const newVersions = history.filter((v) => v.n > since && v.n <= to)
+      const vs = await ctx.meta.getVersion(a.id, since)
+      const vh = await ctx.meta.getVersion(a.id, to)
+      let entryDiff: string | null = null
+      let pagesChanged: ReturnType<typeof bundleFileChanges> | null = null
+      if (vs && vh && since < to) {
+        const [ms, mh] = [await manifestOf(ctx, vs), await manifestOf(ctx, vh)]
+        if (ms && mh) pagesChanged = bundleFileChanges(ms, mh)
+        if (response_format === "detailed") {
+          const [as_, ah] = [await ctx.sourceText(vs), await ctx.sourceText(vh)]
+          if (as_ !== null && ah !== null) entryDiff = clip(formatDiff(diffLines(as_, ah)))
+        }
+      }
+      const open = await ctx.meta.listComments(a.id, { state: "open" })
+      // Threads whose quoted text changed in a landed version — feedback that may no
+      // longer apply. Surfacing it tells the agent its edits touched commented text.
+      const outdated = await ctx.meta.listComments(a.id, { state: "outdated" })
+      const outdatedBit = outdated.length
+        ? ` ${outdated.length} now outdated (the quoted text changed).`
+        : ""
+      // Threads with a proposal already pending — the agent shouldn't re-address them.
+      const addressed = await ctx.meta.listComments(a.id, { state: "addressed" })
+      const addressedBit = addressed.length
+        ? ` ${addressed.length} addressed (a proposal is pending review).`
+        : ""
+      const pageBits =
+        pagesChanged && changeCount(pagesChanged)
+          ? ` Pages: ${[
+              pagesChanged.added.length && `+${pagesChanged.added.length}`,
+              pagesChanged.changed.length && `~${pagesChanged.changed.length}`,
+              pagesChanged.removed.length && `-${pagesChanged.removed.length}`,
+            ]
+              .filter(Boolean)
+              .join(" ")}.`
+          : ""
+      const summary =
+        since >= to
+          ? `You're up to date on "${a.title}" (v${head}); ${open.length} open comment${open.length === 1 ? "" : "s"}.${addressedBit}${outdatedBit}`
+          : `"${a.title}": ${newVersions.length} new version${newVersions.length === 1 ? "" : "s"} since v${since} (now v${to}).${pageBits} ${open.length} open comment${open.length === 1 ? "" : "s"}.${addressedBit}${outdatedBit}`
+      return json({
+        summary,
+        short_id,
+        since,
+        to,
+        head,
+        caught_up: since >= to,
+        versions: history.slice().reverse().map(summarizeVersion),
+        new_versions: newVersions.map(summarizeVersion),
+        pages_changed: pagesChanged,
+        ...(entryDiff
+          ? { entry_diff: entryDiff }
+          : {
+              entry_diff:
+                "(omitted) — call again with response_format='detailed' for the line-level changes.",
+            }),
+        open_comments: open.map(summarizeComment),
+        ...(outdated.length ? { outdated_comments: outdated.map(summarizeComment) } : {}),
+      })
     },
   )
 
+  // COMMENT — leave / reply / resolve feedback --------------------------------
+  server.registerTool(
+    "comment",
+    {
+      description:
+        "Leave feedback on an artifact, reply in a thread, and/or resolve or reopen a thread — all in one tool. Anchor a NEW comment to a quoted span of the rendered text with `quote`. Reply by passing the thread id as `reply_to`. Resolve or reopen by passing `set_state` along with the thread's id in `reply_to`. Thread ids come from catch_up.",
+      inputSchema: {
+        short_id: z.string(),
+        body: z
+          .string()
+          .optional()
+          .describe("The comment text (Markdown). Omit only when just changing thread state."),
+        reply_to: z
+          .string()
+          .optional()
+          .describe(
+            "A thread id (from catch_up): reply in that thread, and/or the thread to set_state on.",
+          ),
+        quote: z
+          .string()
+          .optional()
+          .describe("Exact text in the rendered document to anchor a NEW comment to."),
+        set_state: z
+          .enum(["resolved", "open"])
+          .optional()
+          .describe("Resolve the thread, or reopen it (with `reply_to`)."),
+      },
+    },
+    async ({ short_id, body, reply_to, quote, set_state }) => {
+      const a = await own(short_id)
+      if (!a) return notFound(short_id)
+      if (!roleAllows(agent.role, "comment"))
+        return err(
+          "Your grant is read-only (dock:read). Re-authorize the connector with dock:comment to leave feedback.",
+        )
+      if (!body && !set_state)
+        return err("Provide `body` (to comment) or `set_state` (to resolve/reopen a thread).")
+      let thread = reply_to
+      let commentId: string | undefined
+      if (body) {
+        commentId = newId("c")
+        thread = reply_to || commentId
+        const anchor = quote ? JSON.stringify({ type: "TextQuoteSelector", exact: quote }) : null
+        await ctx.meta.createComment({
+          id: commentId,
+          artifact_id: a.id,
+          thread_id: thread,
+          base_version: a.current_version,
+          path: null,
+          anchor,
+          body_md: body,
+          author: agent.name,
+          author_id: agent.id,
+        })
+        ctx.bus.publish(a.id, { type: "comment.created" })
+      }
+      if (set_state) {
+        if (!thread) return err("`set_state` needs `reply_to` (the thread id to resolve/reopen).")
+        await ctx.meta.setThreadState(a.id, thread, set_state)
+        ctx.bus.publish(a.id, { type: "comment.resolved", thread_id: thread, state: set_state })
+      }
+      return json({
+        short_id,
+        thread,
+        ...(commentId ? { comment_id: commentId, anchored_to: quote ?? null } : {}),
+        ...(set_state ? { state: set_state } : {}),
+        note: body
+          ? reply_to
+            ? "Replied in the thread."
+            : "New comment thread created."
+          : `Thread ${set_state}.`,
+      })
+    },
+  )
+
+  // WRITE — publish live, or file a proposal for review -----------------------
   server.registerTool(
     "publish",
     {
       description:
-        "Publish an artifact to your workspace DIRECTLY — it goes live immediately, no review. Provide `content` for a SINGLE-FILE artifact, or `files` (a map of page path → content) for a MULTI-PAGE BUNDLE — a whole site, with images and any other binary asset. OMIT short_id to create a NEW artifact (a first publish) — `title` is then required. PASS short_id to publish a new version of one you already own, matching its kind: a bundle takes `files`, a single file takes `content`. A bundle republish REPLACES the whole bundle, so include EVERY page and asset. Requires publish rights (Creator/Admin role on the workspace); a commenter-level grant should use `propose` instead. Provide the FULL content (not a patch).",
+        "Save a revision of an artifact. It goes LIVE immediately if your role can publish (Creator/Admin); otherwise — or whenever you pass for_review:true — it is filed as a PROPOSAL a human approves before it goes live. Provide `content` for a SINGLE-FILE artifact, or `files` (a map of page path → content) for a MULTI-PAGE BUNDLE (a whole site, images and any binary asset). OMIT short_id to create a NEW artifact (`title` required); PASS short_id to add a version to one you own, matching its kind. A bundle republish REPLACES the whole bundle, so include EVERY page and asset (or use `merge`). Pass `addresses` with the thread ids (from catch_up) this revision resolves. Provide the FULL content, not a patch. (Proposals are single-file only; bundles must be published directly.)",
       inputSchema: {
         content: z
           .string()
@@ -492,9 +452,7 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
         short_id: z
           .string()
           .optional()
-          .describe(
-            "Omit to create a new artifact; pass it to publish a new version of one you own.",
-          ),
+          .describe("Omit to create a new artifact; pass it to revise one you own."),
         visibility: z
           .enum(["workspace", "link", "public"])
           .optional()
@@ -520,39 +478,102 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           .describe(
             "Filename hint for the content type of a single file, e.g. index.html or notes.md.",
           ),
+        for_review: z
+          .boolean()
+          .optional()
+          .describe(
+            "File this as a PROPOSAL for a human to approve instead of publishing live (single-file only). Forced on when your role can't publish directly.",
+          ),
+        addresses: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Thread ids (from catch_up) this revision resolves. On a live publish they resolve; on a proposal they flip to `addressed` and resolve on approval.",
+          ),
       },
     },
-    async ({ content, files, title, short_id, visibility, spa, merge, message, filename }) => {
-      // Direct publish is gated on the agent's role: Creator/Admin only. A
-      // commenter-level grant is steered to `propose` (human-reviewed), so a
-      // low-privilege agent still can't push live content.
-      if (!roleAllows(agent.role, "publish"))
-        return text(
-          "Your grant can't publish directly (needs a Creator/Admin role). Use `propose` to submit a reviewed change, or re-authorize with a publish scope.",
-        )
+    async ({
+      content,
+      files,
+      title,
+      short_id,
+      visibility,
+      spa,
+      merge,
+      message,
+      filename,
+      for_review,
+      addresses,
+    }) => {
+      const existing = short_id ? await own(short_id) : null
+      if (short_id && !existing) return text(`No artifact "${short_id}" in this workspace.`)
       // Exactly one of content / files. `files` (a page map) means a bundle.
       const isBundle = !!files && Object.keys(files).length > 0
       if (isBundle && content !== undefined)
         return text("Provide `content` (single file) OR `files` (a bundle), not both.")
       if (!isBundle && (content === undefined || content === ""))
         return text("Provide `content` (single file) or `files` (a multi-page bundle).")
-      const existing = short_id ? await own(short_id) : null
-      if (short_id && !existing) return text(`No artifact "${short_id}" in this workspace.`)
       if (existing) {
-        // Kind can't change on republish; steer to the right field instead of
-        // bubbling the core's 409.
+        // Kind can't change on republish; steer to the right field instead of the 409.
         if (existing.kind === "bundle" && !isBundle)
           return text(
             `"${short_id}" is a multi-page bundle — pass \`files\` (every page) to republish it.`,
           )
         if (existing.kind === "file" && isBundle)
           return text(`"${short_id}" is a single-file artifact — pass \`content\`, not \`files\`.`)
-      } else if (!title?.trim()) {
-        return text("Creating a new artifact needs a `title`.")
       }
-      // `merge` folds the given files into the existing bundle (add/overwrite by path)
-      // instead of replacing it — how a large site is grown across calls without
-      // re-sending it. Only meaningful for an existing bundle.
+
+      // Direct publish is gated on the agent's role (Creator/Admin). A commenter-level
+      // grant — or anyone asking for_review — is routed to a human-reviewed proposal,
+      // so a low-privilege agent still can't push live content.
+      const review = for_review === true || !roleAllows(agent.role, "publish")
+      if (review) {
+        if (!roleAllows(agent.role, "propose"))
+          return text(
+            "Your grant is read-only (dock:read). Re-authorize with dock:propose (or a publish scope) to suggest changes.",
+          )
+        if (isBundle)
+          return text(
+            "Multi-page bundles can't be proposed for review yet — only published directly. Ask an editor to publish, or submit a single-file `content` revision.",
+          )
+        if (!existing)
+          return text(
+            "A proposal revises an EXISTING artifact — pass its `short_id`. Creating a new artifact needs publish rights (a Creator/Admin grant).",
+          )
+        try {
+          const { proposal } = await proposeChange(ctx.meta, ctx.blobs, short_id as string, {
+            bytes: new TextEncoder().encode(content as string),
+            filename: filename ?? "index.html",
+            isBundle: false,
+            message: message ?? "Proposed revision",
+            author: agent.name,
+            author_id: agent.id,
+          })
+          const addressed = addresses?.length
+            ? await markAddressed(ctx.meta, existing.id, proposal.id, addresses)
+            : []
+          for (const threadId of addressed)
+            ctx.bus.publish(existing.id, {
+              type: "comment.addressed",
+              thread_id: threadId,
+              state: "addressed",
+            })
+          return json({
+            published: false,
+            proposed: true,
+            proposal_id: proposal.id,
+            base_version: proposal.base_version,
+            addressed,
+            note: "Submitted for review — a human approves it or requests changes. It is NOT live yet.",
+          })
+        } catch (e) {
+          return text(
+            `Couldn't store the proposal: ${e instanceof PublishError ? e.message : "unknown error"}.`,
+          )
+        }
+      }
+
+      // Live publish path.
       if (merge) {
         if (!isBundle) return text("`merge` adds files to a bundle — pass `files`, not `content`.")
         if (!existing) return text("`merge` needs the `short_id` of an existing bundle to add to.")
@@ -561,6 +582,7 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
             `"${short_id}" is a single-file artifact — \`merge\` only applies to bundles.`,
           )
       }
+      if (!existing && !title?.trim()) return text("Creating a new artifact needs a `title`.")
       try {
         let bytes: Uint8Array
         // A merge keeps the bundle's existing SPA routing (the caller isn't redeclaring it).
@@ -595,6 +617,18 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           },
           short_id,
         )
+        // A live publish that fixes feedback resolves those threads directly (no
+        // approval step to wait on, unlike a proposal's `addressed`).
+        const resolved: string[] = []
+        for (const threadId of addresses ?? []) {
+          await ctx.meta.setThreadState(artifact.id, threadId, "resolved")
+          ctx.bus.publish(artifact.id, {
+            type: "comment.resolved",
+            thread_id: threadId,
+            state: "resolved",
+          })
+          resolved.push(threadId)
+        }
         return json({
           published: true,
           short_id: artifact.short_id,
@@ -603,6 +637,7 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           url: artifactUrl(ctx.deps.baseUrl, artifact),
           title: artifact.title,
           visibility: artifact.visibility,
+          ...(resolved.length ? { resolved } : {}),
           note: merge
             ? `Live now — merged ${Object.keys(files as Record<string, string>).length} file(s) into the bundle (new current version).`
             : short_id

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -13,7 +13,8 @@ import { sha256 } from "../src/lib/crypto"
 // The remote MCP endpoint (/mcp) authenticated by an OAuth bearer. We seed a grant
 // straight into the oauth-provider tables (what the consent dance produces), publish
 // an artifact as that scoped agent, then drive the MCP JSON-RPC handshake + tools
-// over Streamable HTTP and assert the agent sees its own workspace.
+// over Streamable HTTP and assert the agent sees its own workspace. The tool surface
+// is the consolidated five: list_artifacts, read, catch_up, comment, publish.
 
 const dir = mkdtempSync(join(tmpdir(), "dock-mcp-"))
 afterAll(() => rmSync(dir, { recursive: true, force: true }))
@@ -106,6 +107,14 @@ const publish = (app: App, token: string, title: string) => {
   })
 }
 
+const call = (app: App, token: string, name: string, args: Record<string, unknown> = {}) =>
+  rpc(app, token, {
+    jsonrpc: "2.0",
+    id: 9,
+    method: "tools/call",
+    params: { name, arguments: args },
+  })
+
 describe("remote MCP endpoint (/mcp)", () => {
   it("rejects an unauthenticated connect with 401 + WWW-Authenticate", async () => {
     const { app } = appWithGrant("noauth", "openid dock:read")
@@ -114,7 +123,7 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(r.wwwAuth).toContain("oauth-protected-resource")
   })
 
-  it("initializes (identity in instructions) and lists the consolidated tools", async () => {
+  it("initializes (identity in instructions) and lists the five consolidated tools", async () => {
     const { app, token } = appWithGrant("init", "openid dock:read dock:publish")
     const init = await rpc(app, token, initBody)
     const result = init.parsed?.result as { serverInfo?: { name: string }; instructions?: string }
@@ -125,30 +134,20 @@ describe("remote MCP endpoint (/mcp)", () => {
 
     const list = await rpc(app, token, { jsonrpc: "2.0", id: 2, method: "tools/list" })
     const names = toolNames(list)
-    expect(names).toEqual(
-      expect.arrayContaining([
-        "list_artifacts",
-        "catch_me_up",
-        "read",
-        "diff",
-        "list_comments",
-        "list_versions",
-        "propose",
-      ]),
-    )
-    // Consolidated away: no whoami / read_artifact / read_section.
-    expect(names).not.toContain("whoami")
-    expect(names).not.toContain("read_artifact")
-    expect(names).not.toContain("read_section")
+    expect(names.sort()).toEqual(["catch_up", "comment", "list_artifacts", "publish", "read"])
+    // Consolidated away — folded into catch_up / comment / publish.
+    for (const gone of [
+      "whoami",
+      "catch_me_up",
+      "diff",
+      "list_comments",
+      "list_versions",
+      "propose",
+      "read_artifact",
+      "read_section",
+    ])
+      expect(names).not.toContain(gone)
   })
-
-  const call = (app: App, token: string, name: string, args: Record<string, unknown> = {}) =>
-    rpc(app, token, {
-      jsonrpc: "2.0",
-      id: 9,
-      method: "tools/call",
-      params: { name, arguments: args },
-    })
 
   it("list_artifacts + read see the agent's own published artifact", async () => {
     const { app, token } = appWithGrant("read", "openid dock:read dock:publish")
@@ -166,8 +165,8 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(readOut.content).toContain("My Plan")
   })
 
-  it("diff + catch_me_up report what changed between versions", async () => {
-    const { app, token } = appWithGrant("diff", "openid dock:read dock:publish")
+  it("catch_up reports what changed, with the line diff folded in", async () => {
+    const { app, token } = appWithGrant("catchup", "openid dock:read dock:publish")
     const shortId = (await (await publish(app, token, "V1 Title")).json()).short_id
 
     // Republish a second version with different content.
@@ -181,26 +180,25 @@ describe("remote MCP endpoint (/mcp)", () => {
     })
     expect(rep.status).toBe(201)
 
-    const d = JSON.parse(
-      toolText(await call(app, token, "diff", { short_id: shortId, from: 1, to: 2 })),
-    )
-    expect(d.entry_diff).toContain("V2 Title")
-
+    // Default summary: delta + history, line diff omitted (token-light).
     const c = JSON.parse(
-      toolText(await call(app, token, "catch_me_up", { short_id: shortId, since_version: 1 })),
+      toolText(await call(app, token, "catch_up", { short_id: shortId, since_version: 1 })),
     )
     expect(c.head).toBe(2)
+    expect(c.to).toBe(2)
     expect(c.new_versions.map((v: { n: number }) => v.n)).toContain(2)
-    expect(c.summary).toContain("v2") // prose summary up top
+    expect(c.versions.map((v: { n: number }) => v.n)).toEqual([2, 1]) // full history, newest-first
+    expect(c.summary).toContain("v2")
     expect(c.caught_up).toBe(false)
-    expect(c.entry_diff).not.toContain("V2 Title") // omitted by default (token-light)
+    expect(c.entry_diff).not.toContain("V2 Title")
 
-    // 'detailed' includes the line diff inline.
+    // 'detailed' folds in the exact line diff — this is what `diff` used to do.
     const cd = JSON.parse(
       toolText(
-        await call(app, token, "catch_me_up", {
+        await call(app, token, "catch_up", {
           short_id: shortId,
           since_version: 1,
+          to_version: 2,
           response_format: "detailed",
         }),
       ),
@@ -208,7 +206,7 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(cd.entry_diff).toContain("V2 Title")
   })
 
-  it("read + catch_me_up handle multi-page bundles", async () => {
+  it("read + catch_up handle multi-page bundles", async () => {
     const { app, token } = appWithGrant("bundle", "openid dock:read dock:publish")
     const enc = (s: string) => new TextEncoder().encode(s)
     const postZip = (
@@ -243,7 +241,7 @@ describe("remote MCP endpoint (/mcp)", () => {
     )
     expect(page.content).toContain("Page")
 
-    // Republish with a new page; catch_me_up reports it under pages_changed.added.
+    // Republish with a new page; catch_up reports it under pages_changed.added.
     await postZip(
       {
         "index.html": enc("<h1>Home</h1>"),
@@ -254,26 +252,85 @@ describe("remote MCP endpoint (/mcp)", () => {
       shortId,
     )
     const cu = JSON.parse(
-      toolText(await call(app, token, "catch_me_up", { short_id: shortId, since_version: 1 })),
+      toolText(await call(app, token, "catch_up", { short_id: shortId, since_version: 1 })),
     )
     expect(cu.pages_changed.added).toContain("new.html")
   })
 
-  it("propose stages a revision for review without going live", async () => {
-    // Editor grant so the setup publish works; over MCP even an editor only gets
-    // `propose` (no direct-publish tool), so the candidate still never auto-goes-live.
-    const { app, token } = appWithGrant("propose", "openid dock:read dock:publish")
+  it("comment leaves anchored feedback, replies, and resolves — all via one tool", async () => {
+    const { app, token } = appWithGrant("comment", "openid dock:read dock:comment dock:publish")
+    const shortId = (await (await publish(app, token, "Tighten Me")).json()).short_id
+
+    // Leave a new anchored comment.
+    const made = JSON.parse(
+      toolText(
+        await call(app, token, "comment", {
+          short_id: shortId,
+          body: "this header is weak",
+          quote: "Tighten Me",
+        }),
+      ),
+    )
+    expect(made.thread).toBeTruthy()
+    expect(made.comment_id).toBeTruthy()
+    expect(made.anchored_to).toBe("Tighten Me")
+    const thread = made.thread
+
+    // It shows up as open feedback in catch_up's queue.
+    const open = JSON.parse(
+      toolText(await call(app, token, "catch_up", { short_id: shortId, comments: "open" })),
+    )
+    expect(open.count).toBe(1)
+    expect(open.comments[0].body).toContain("weak")
+    expect(open.comments[0].quote).toBe("Tighten Me")
+
+    // Reply in the same thread.
+    const reply = JSON.parse(
+      toolText(
+        await call(app, token, "comment", { short_id: shortId, body: "agreed", reply_to: thread }),
+      ),
+    )
+    expect(reply.thread).toBe(thread)
+    expect(reply.note).toContain("Replied")
+
+    // Resolve the thread (body optional when only changing state).
+    const resolved = JSON.parse(
+      toolText(
+        await call(app, token, "comment", {
+          short_id: shortId,
+          reply_to: thread,
+          set_state: "resolved",
+        }),
+      ),
+    )
+    expect(resolved.state).toBe("resolved")
+    const stillOpen = JSON.parse(
+      toolText(await call(app, token, "catch_up", { short_id: shortId, comments: "open" })),
+    )
+    expect(stillOpen.count).toBe(0)
+    // Both rows in the thread (the comment + its reply) move to resolved.
+    const done = JSON.parse(
+      toolText(await call(app, token, "catch_up", { short_id: shortId, comments: "resolved" })),
+    )
+    expect(done.count).toBe(2)
+  })
+
+  it("publish with for_review stages a proposal instead of going live", async () => {
+    // Even with an editor grant, for_review:true files a proposal that never auto-goes-live.
+    const { app, token } = appWithGrant("review", "openid dock:read dock:publish")
     const shortId = (await (await publish(app, token, "Draft")).json()).short_id
 
     const p = JSON.parse(
       toolText(
-        await call(app, token, "propose", {
+        await call(app, token, "publish", {
           short_id: shortId,
           content: "<h1>Revised draft</h1>",
           message: "tightened the intro",
+          for_review: true,
         }),
       ),
     )
+    expect(p.published).toBe(false)
     expect(p.proposed).toBe(true)
     expect(p.proposal_id).toBeTruthy()
     expect(p.base_version).toBe(1)
@@ -313,25 +370,24 @@ describe("remote MCP endpoint (/mcp)", () => {
       headers: { authorization: `Bearer ${token}` },
     })
 
-    // list_comments reports the new state + the quoted text the thread targets.
-    const all = JSON.parse(toolText(await call(app, token, "list_comments", { short_id: shortId })))
-    expect(all.comments[0].state).toBe("outdated")
-    expect(all.comments[0].quote).toBe("beta")
+    // catch_up's `comments` filter is the feedback queue — outdated threads + their quote.
     const onlyStale = JSON.parse(
-      toolText(await call(app, token, "list_comments", { short_id: shortId, state: "outdated" })),
+      toolText(await call(app, token, "catch_up", { short_id: shortId, comments: "outdated" })),
     )
     expect(onlyStale.count).toBe(1)
+    expect(onlyStale.comments[0].state).toBe("outdated")
+    expect(onlyStale.comments[0].quote).toBe("beta")
 
-    // catch_me_up leads with it so the agent knows its edits touched commented text.
+    // The default delta leads with it so the agent knows its edits touched commented text.
     const cu = JSON.parse(
-      toolText(await call(app, token, "catch_me_up", { short_id: shortId, since_version: 1 })),
+      toolText(await call(app, token, "catch_up", { short_id: shortId, since_version: 1 })),
     )
     expect(cu.summary).toContain("outdated")
     expect(cu.outdated_comments).toHaveLength(1)
     expect(cu.outdated_comments[0].quote).toBe("beta")
   })
 
-  it("propose with `addresses` marks the cited threads addressed (pending review)", async () => {
+  it("publish for_review with `addresses` marks the cited threads addressed (pending review)", async () => {
     const { app, token } = appWithGrant("addr", "openid dock:read dock:comment dock:publish")
     const shortId = (await (await publish(app, token, "headline to fix")).json()).short_id
     const cm = await (
@@ -344,10 +400,11 @@ describe("remote MCP endpoint (/mcp)", () => {
 
     const p = JSON.parse(
       toolText(
-        await call(app, token, "propose", {
+        await call(app, token, "publish", {
           short_id: shortId,
           content: "<h1>fixed headline</h1>",
           message: "fixed it",
+          for_review: true,
           addresses: [cm.thread_id],
         }),
       ),
@@ -357,18 +414,47 @@ describe("remote MCP endpoint (/mcp)", () => {
 
     // The thread is now addressed — off the open list, listed under `addressed`.
     const open = JSON.parse(
-      toolText(await call(app, token, "list_comments", { short_id: shortId, state: "open" })),
+      toolText(await call(app, token, "catch_up", { short_id: shortId, comments: "open" })),
     )
     expect(open.count).toBe(0)
     const addr = JSON.parse(
-      toolText(await call(app, token, "list_comments", { short_id: shortId, state: "addressed" })),
+      toolText(await call(app, token, "catch_up", { short_id: shortId, comments: "addressed" })),
     )
     expect(addr.count).toBe(1)
     expect(addr.comments[0].state).toBe("addressed")
 
-    // catch_me_up flags it so the agent won't re-propose the same fix.
-    const cu = JSON.parse(toolText(await call(app, token, "catch_me_up", { short_id: shortId })))
+    // catch_up flags it so the agent won't re-address the same fix.
+    const cu = JSON.parse(toolText(await call(app, token, "catch_up", { short_id: shortId })))
     expect(cu.summary).toContain("addressed")
+  })
+
+  it("a live publish with `addresses` resolves those threads directly", async () => {
+    const { app, token } = appWithGrant("liveaddr", "openid dock:read dock:comment dock:publish")
+    const shortId = (await (await publish(app, token, "fix the headline here")).json()).short_id
+    const cm = await (
+      await app.request(`/v1/artifacts/${shortId}/comments`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+        body: JSON.stringify({ body_md: "fix it" }),
+      })
+    ).json()
+
+    const p = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          short_id: shortId,
+          content: "<h1>headline fixed</h1>",
+          message: "done",
+          addresses: [cm.thread_id],
+        }),
+      ),
+    )
+    expect(p.published).toBe(true)
+    expect(p.resolved).toEqual([cm.thread_id])
+    const done = JSON.parse(
+      toolText(await call(app, token, "catch_up", { short_id: shortId, comments: "resolved" })),
+    )
+    expect(done.count).toBe(1)
   })
 
   // Regression guard for the "Needs Auth" outage: a remote MCP client (Claude
@@ -376,16 +462,11 @@ describe("remote MCP endpoint (/mcp)", () => {
   // SIGNED JWT access token rather than the opaque token. The server must verify
   // it against the JWKS read from Better Auth's store on this instance — NOT by
   // HTTP-fetching its own /api/auth/jwks, which a Cloudflare Worker can't do.
-  // This mints a real JWT, exposes the public key via a getJwks() stub, and
-  // asserts /mcp accepts it. It FAILS against a createRemoteJWKSet (self-fetch)
-  // implementation, so it pins the verification path in place.
   it("authenticates an OAuth JWT access token via the local JWKS", async () => {
     const { publicKey, privateKey } = await generateKeyPair("EdDSA", { extractable: true })
     const kid = "test-jwt-kid"
     const jwk = { ...(await exportJWK(publicKey)), kid, alg: "EdDSA", use: "sig" }
 
-    // Seed the granting user + client the JWT claims will resolve to, then build
-    // an app whose auth exposes the matching public JWKS (no network).
     const path = join(dir, "jwtauth.db")
     const meta = new SqliteMetaStore(path)
     const seed = new Database(path)
@@ -418,18 +499,15 @@ describe("remote MCP endpoint (/mcp)", () => {
         .setExpirationTime("1h")
         .sign(privateKey)
 
-    // A valid JWT authenticates and resolves the agent's role from its scopes.
     const ok = await rpc(app, await mint(), initBody)
     expect(ok.status).toBe(200)
     expect((ok.parsed?.result as { instructions?: string }).instructions).toContain("editor")
 
-    // A tampered signature is rejected (401), not silently trusted.
     const good = await mint()
     const tampered = `${good.slice(0, -6)}AAAAAA`
     const bad = await rpc(app, tampered, initBody)
     expect(bad.status).toBe(401)
 
-    // Wrong issuer is rejected too (the verify pins `issuer`).
     const wrongIss = await new SignJWT({ scope: "openid dock:read", azp: "cli" })
       .setProtectedHeader({ alg: "EdDSA", kid })
       .setSubject("u_jwt")
@@ -482,25 +560,25 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(v2.version).toBe(2)
   })
 
-  it("publish needs a title to create, and a publish-capable grant", async () => {
+  it("publish needs a title to create, and routes a non-publisher to review", async () => {
     // A new-artifact publish with no title is refused.
     const { app, token } = appWithGrant("pub2", "openid dock:read dock:publish")
     const noTitle = await call(app, token, "publish", { content: "<h1>x</h1>" })
     expect(toolText(noTitle)).toContain("title")
 
-    // A comment-only grant can't publish at all — steered to propose.
+    // A comment-only grant can't publish live — and can't create a NEW artifact even
+    // via review (a proposal revises an existing one). Steered to publish rights.
     const weak = appWithGrant("pub3", "openid dock:read dock:comment")
     const denied = await call(weak.app, weak.token, "publish", {
       title: "Nope",
       content: "<h1>x</h1>",
     })
-    expect(toolText(denied)).toContain("propose")
+    expect(toolText(denied)).toContain("publish rights")
   })
 
   it("publish creates and republishes a multi-page bundle via the files map", async () => {
     const { app, token } = appWithGrant("pubbundle", "openid dock:read dock:publish")
 
-    // A files map (no short_id) creates a new BUNDLE — index.html is the entry.
     const created = JSON.parse(
       toolText(
         await call(app, token, "publish", {
@@ -517,7 +595,6 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(created.kind).toBe("bundle")
     const shortId = created.short_id
 
-    // read returns the outline (its pages), and a section returns that page.
     const outline = JSON.parse(toolText(await call(app, token, "read", { short_id: shortId })))
     expect(outline.pages).toEqual(expect.arrayContaining(["index.html", "about.html", "nav.js"]))
     const about = JSON.parse(
@@ -525,7 +602,6 @@ describe("remote MCP endpoint (/mcp)", () => {
     )
     expect(about.content).toContain("About")
 
-    // Republishing the full files map (with an added page) pushes version 2.
     const v2 = JSON.parse(
       toolText(
         await call(app, token, "publish", {
@@ -542,15 +618,32 @@ describe("remote MCP endpoint (/mcp)", () => {
     )
     expect(v2.version).toBe(2)
     const cu = JSON.parse(
-      toolText(await call(app, token, "catch_me_up", { short_id: shortId, since_version: 1 })),
+      toolText(await call(app, token, "catch_up", { short_id: shortId, since_version: 1 })),
     )
     expect(cu.pages_changed.added).toContain("new.html")
+  })
+
+  it("a bundle can't be filed for review (single-file proposals only)", async () => {
+    const { app, token } = appWithGrant("bundlereview", "openid dock:read dock:publish")
+    const created = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          title: "Site",
+          files: { "index.html": "<h1>home</h1>" },
+        }),
+      ),
+    )
+    const r = await call(app, token, "publish", {
+      short_id: created.short_id,
+      files: { "index.html": "<h1>home v2</h1>" },
+      for_review: true,
+    })
+    expect(toolText(r)).toContain("bundles can't be proposed")
   })
 
   it("publish steers between content and files by kind", async () => {
     const { app, token } = appWithGrant("pubkind", "openid dock:read dock:publish")
 
-    // content + files together is rejected.
     const both = await call(app, token, "publish", {
       title: "x",
       content: "<h1>x</h1>",
@@ -558,7 +651,6 @@ describe("remote MCP endpoint (/mcp)", () => {
     })
     expect(toolText(both)).toContain("not both")
 
-    // A single-file artifact can't be republished as a bundle.
     const file = JSON.parse(
       toolText(await call(app, token, "publish", { title: "Doc", content: "<h1>doc</h1>" })),
     )
@@ -568,7 +660,6 @@ describe("remote MCP endpoint (/mcp)", () => {
     })
     expect(toolText(asBundle)).toContain("single-file")
 
-    // A bundle can't be republished with a single `content` string.
     const bundle = JSON.parse(
       toolText(
         await call(app, token, "publish", {

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -177,19 +177,17 @@ Env vars: `DOCK_SERVER` (base URL of your Dock instance), `DOCK_TOKEN` (agent to
 
 ### Tools
 
+The same 5 tools on both the stdio `@dock/mcp` server and the remote `/mcp` server.
+
 | Tool | Description |
 |---|---|
-| `publish_artifact` | Publish new HTML or Markdown; returns short_id + URL |
-| `publish_version` | New version of existing artifact (same URL). `resolves: [ids]` closes threads. |
-| `get_artifact` | Read metadata + source for a version (defaults to current) |
-| `list_versions` | Version history with author, message, created_at |
-| `diff_versions` | Line diff between versions (defaults prev -> current) |
-| `restore_version` | Make a past version current (history preserved) |
-| `list_comments` | Feedback queue; filter by state: open or resolved |
-| `add_comment` | New thread; `quote` anchors it to exact text |
-| `reply_comment` | Reply in existing thread via thread_id |
-| `resolve_thread` | Resolve or reopen the thread a comment belongs to |
-| `view_stats` | Total views, unique viewers, per-version + daily breakdown |
+| `list_artifacts` | List/find the artifacts in your workspace (short id, title, kind, version, visibility); optional `query` title filter |
+| `read` | Read an artifact's content by short id; bundles take a `section` (page path), any read takes a `version` for history |
+| `catch_up` | An artifact's state in one call: what changed since `since_version`, the open/outdated comment threads, version history. `comments` (open/addressed/resolved/outdated) for a filtered feedback queue; `response_format='detailed'` for the exact line diff. |
+| `comment` | Leave feedback, reply (`reply_to` a thread id), anchor to a `quote`, and/or resolve/reopen (`set_state`) |
+| `publish` | Save a revision (`content` for one file, `files` path->content map for a bundle); omit `short_id` to create new (title required), pass it to add a version. `addresses` resolves threads. Goes live or files a proposal based on role, or with `for_review:true`. |
+
+(Stdio caveat: bundles are publish-via-remote/web only, and `comment` set_state takes a `comment_id`.)
 
 ### Resource
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -35,17 +35,24 @@ Visibility options: public, link, org, password.
 
 Connect any MCP client with `npx -y @dock/mcp` + env vars `DOCK_SERVER` and `DOCK_TOKEN`.
 
-Tools: publish_artifact, publish_version, get_artifact, list_versions, diff_versions, restore_version, list_comments, add_comment, reply_comment, resolve_thread, view_stats
+Tools (five): list_artifacts, read, catch_up, comment, publish
+
+- list_artifacts: find the artifacts in your workspace (optional query title filter)
+- read: read an artifact's content by short id; bundles take a section (page path), any read takes a version for history
+- catch_up: an artifact's state in one call (what changed since since_version, the open/outdated comment threads, version history); pass comments for a filtered feedback queue or response_format='detailed' for the line diff
+- comment: leave feedback, reply (reply_to), anchor to a quote, resolve/reopen (set_state)
+- publish: save a revision (content for one file, files for a bundle); omit short_id to create new, pass it to add a version; addresses resolves threads; goes live or files a proposal based on role, or with for_review:true
+
+Both the stdio @dock/mcp server and the remote /mcp server expose the same 5 tools.
 
 Resource: dock://guide (agent workflow and tool reference)
 
 ## The agent loop
 
-1. publish_artifact -> get short_id + URL
-2. list_comments (state: open) -> read feedback
-3. get_artifact -> read source, revise
-4. publish_version with resolves: [commentIds] -> close addressed threads
-5. repeat
+1. catch_up -> what changed since since_version, plus the open feedback to address
+2. read -> the content (a bundle page, or a past version), then revise
+3. comment (reply/resolve) and/or publish with addresses: [threadIds] -> same URL, a new version, threads closed atomically
+4. repeat
 
 ## Deployment tiers
 

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -435,8 +435,8 @@ headings and distinctive phrases stable. Full guidance: STANDARD.md.
 ## Using an agent harness
 
 A Claude Code skill ships in \`.claude/skills/dock\`, and \`.mcp.json\` wires the
-Dock MCP server (\`publish_artifact\`, \`list_comments\`, \`publish_version\`,
-\`resolve_thread\`, …). Set \`DOCK_SERVER\` and \`DOCK_TOKEN\` in your environment;
+Dock MCP server (five tools: \`list_artifacts\`, \`read\`, \`catch_up\`, \`comment\`,
+\`publish\`). Set \`DOCK_SERVER\` and \`DOCK_TOKEN\` in your environment;
 both the CLI and the MCP server read them.
 `
 
@@ -474,10 +474,11 @@ dock reply <thread_id> "Fixed." # 4a. discuss
 dock resolve <comment_id>       # 4b. close a handled thread
 \`\`\`
 
-If the Dock MCP server is connected (\`.mcp.json\`), prefer its tools for the same
-loop without shelling out: \`publish_artifact\`, \`list_comments\`,
-\`publish_version\` (pass \`resolves\` to close threads), \`reply_comment\`,
-\`resolve_thread\`, \`diff_versions\`.
+If the Dock MCP server is connected (\`.mcp.json\`), prefer its five tools for the same
+loop without shelling out: \`catch_up\` (what changed plus open feedback) ->
+\`read\` (content) -> \`comment\` (reply/resolve) and/or \`publish\` (pass \`addresses\`
+to resolve the threads a revision fixes; \`publish\` goes live or files a proposal based
+on your role, or with \`for_review:true\`). \`list_artifacts\` finds an artifact by title.
 
 ## Keep comments anchorable
 

--- a/packages/mcp/SKILL.md
+++ b/packages/mcp/SKILL.md
@@ -15,39 +15,37 @@ claude mcp add --transport http dock <your-dock-server>/mcp
 The first call triggers an OAuth consent in the browser; you grant the agent a
 scope, and that scope maps to a role (read-only, propose, or publish).
 
+Your identity (agent name, workspace, role) is in the server instructions — there is no `whoami` tool.
+
 ## Tools
 
 | Tool | Use |
 |---|---|
-| `whoami` | Your agent name, workspace, and role. Call first to confirm the connection. |
-| `list_artifacts` | The artifacts in your workspace (short id, title, kind, version, visibility). |
-| `read_artifact` | One artifact's metadata + current source. |
-| `read_section` | A single page of a multi-page bundle (or a single-file artifact's content). |
-| `list_versions` | Version history, newest first. |
-| `diff` | What changed between two versions. |
-| `list_comments` | The review feedback (open / resolved threads with anchors) — the agent's to-do list. |
-| `catch_me_up` | One coalesced delta since a version: new versions, pages changed, entry diff, open comments. |
-| `propose` | Submit a revised single-file version **for human review** — does NOT go live. Commenter+ role. |
-| `publish` | Publish a revised single-file version **directly — it goes live now**. Requires Creator/Admin role. |
+| `list_artifacts` | Find: the artifacts in your workspace (short id, title, kind, version, visibility). Optional `query` filters by title. |
+| `read` | Read an artifact's content by short id. For a bundle, omit `section` for the outline or pass a `section` (page path) for one page; pass `version` to read history. |
+| `catch_up` | Start here on an artifact: its state in one call — what changed since `since_version`, the open/outdated comment threads, and version history. Pass `comments` (open/addressed/resolved/outdated) for that filtered feedback queue, or `response_format='detailed'` (with optional `since_version`/`to_version`) to fold in the exact line diff. |
+| `comment` | Leave feedback, reply (`reply_to` a thread id), anchor to a `quote`, and/or resolve/reopen (`set_state`). |
+| `publish` | Save a revision. `content` for a single file, `files` (path→content map) for a multi-page bundle. Omit `short_id` to create new (title required); pass it to add a version. `addresses` lists thread ids this revision resolves. |
 
-## Role decides publish vs propose
+## Role decides: live publish vs proposal
 
-`publish` and `propose` are gated on **your role** (the scope you were granted):
+`publish` is one tool. Whether it goes live or files a proposal is decided by **your role** (the scope you were granted), with `for_review:true` to force review:
 
-- **Admin / Creator (editor+)** → `publish` directly (live immediately), or `propose` if you want review.
-- **Commenter** → `propose` only (a human approves it before it goes live).
+- **Admin / Creator** → `publish` goes live immediately, or pass `for_review:true` to file a proposal instead.
+- **Commenter** → `publish` files a proposal a human approves before it goes live.
 - **Viewer** → read-only.
 
 So an agent you authorize with a publish scope publishes exactly as you would; a
-lower-scoped agent can still read and propose, but can't push live content.
+lower-scoped agent can still read and publish, but its revisions become proposals a
+human approves rather than live content.
 
 ## The loop
 
-1. **`whoami`** → confirm your workspace + role.
-2. **`catch_me_up`** (or `list_comments` state `open`) → the feedback to address.
-3. **`read_section` / `diff`** → understand a comment in context.
-4. **Revise**, then **`publish`** (if you're Creator/Admin) or **`propose`** (commenter)
-   — same URL, a new version. Comment highlights re-anchor to the moved text.
+1. **`catch_up`** → what changed since you last looked, plus the open feedback to address.
+2. **`read`** → the content (a page of a bundle, or a past version) in context.
+3. **Revise**, then **`comment`** (reply/resolve) and/or **`publish`** (pass `addresses`
+   to resolve the threads this revision fixes) — same URL, a new version. Comment
+   highlights re-anchor to the moved text.
 
 ## Keep comments anchorable
 
@@ -61,5 +59,7 @@ wrong place.
 
 - Versions are immutable; `@vN` URLs never change. The viewer groups rapid
   same-author revisions into time-based sessions, but every revision is addressable.
-- Multi-page bundles are readable (`read_section`, `diff`, `catch_me_up`) but not
-  yet revisable over MCP (`propose`/`publish` are single-file only).
+- Multi-page bundles are readable (`read` with a `section`, `catch_up`) and revisable
+  over the remote `/mcp` server via `publish` with a `files` map. Over the stdio
+  `@dock/mcp` server, bundles are publish-via-remote/web only, and `comment` set_state
+  takes a `comment_id`. Both servers expose the same 5 tools.

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -16,6 +16,8 @@ export interface PublishArgs {
   resolves?: string[]
 }
 
+export type CommentState = "open" | "addressed" | "resolved" | "outdated"
+
 export interface CommentJson {
   id: string
   thread_id: string
@@ -24,8 +26,30 @@ export interface CommentJson {
   anchor: string | null
   body_md: string
   author: string
-  state: "open" | "resolved"
+  state: CommentState
   created_at: string
+}
+
+export interface ArtifactSummaryJson {
+  short_id: string
+  title: string | null
+  kind: "file" | "bundle"
+  current_version: number
+  visibility: string
+}
+
+/** A revision submitted for human review instead of published live. */
+export interface ProposeArgs {
+  content: string
+  filename?: string
+  message: string
+  /** Thread ids this revision addresses (flip to `addressed`, resolve on approval). */
+  addresses?: string[]
+}
+export interface ProposalJson {
+  id: string
+  base_version: number
+  addressed?: string[]
 }
 
 export interface NewCommentArgs {
@@ -83,10 +107,14 @@ export interface ViewStatsJson {
 }
 
 export interface DockClient {
+  /** List the workspace's artifacts (optionally filtered by a title query). */
+  list(query?: string): Promise<ArtifactSummaryJson[]>
   publish(args: PublishArgs): Promise<ArtifactJson>
+  /** Submit a single-file revision for human review (does not go live). */
+  propose(shortId: string, args: ProposeArgs): Promise<ProposalJson>
   get(shortId: string): Promise<ArtifactJson>
   getContent(shortId: string, version?: number): Promise<string>
-  listComments(shortId: string, state?: "open" | "resolved"): Promise<CommentJson[]>
+  listComments(shortId: string, state?: CommentState): Promise<CommentJson[]>
   createComment(shortId: string, args: NewCommentArgs): Promise<CommentJson>
   /** Resolve or reopen the thread a comment belongs to. */
   setThreadState(shortId: string, commentId: string, state: "resolved" | "open"): Promise<void>
@@ -119,6 +147,14 @@ export function createClient(opts: ClientOptions): DockClient {
   }
 
   return {
+    async list(query) {
+      const q = query ? `?q=${encodeURIComponent(query)}` : ""
+      const r = (await ok(await f(`${base}/v1/artifacts${q}`, { headers: authHeaders }))) as {
+        artifacts: ArtifactSummaryJson[]
+      }
+      return r.artifacts
+    },
+
     async publish(args) {
       const bytes =
         typeof args.content === "string" ? new TextEncoder().encode(args.content) : args.content
@@ -135,6 +171,24 @@ export function createClient(opts: ClientOptions): DockClient {
       return ok(
         await f(url, { method: "POST", body: form, headers: authHeaders }),
       ) as Promise<ArtifactJson>
+    },
+
+    async propose(shortId, args) {
+      const form = new FormData()
+      form.append(
+        "file",
+        new Blob([new TextEncoder().encode(args.content)]),
+        args.filename ?? "index.html",
+      )
+      form.append("message", args.message)
+      if (args.addresses?.length) form.append("addresses", args.addresses.join(","))
+      return ok(
+        await f(`${base}/v1/artifacts/${shortId}/proposals`, {
+          method: "POST",
+          body: form,
+          headers: authHeaders,
+        }),
+      ) as Promise<ProposalJson>
     },
 
     async get(shortId) {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -5,6 +5,13 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod"
 import { createClient } from "./client"
 
+// Stdio MCP server for self-hosters: `npx @dock/mcp` talks to a Dock instance over
+// the /v1 HTTP API (DOCK_SERVER) with a bearer (DOCK_TOKEN). It exposes the SAME five
+// tools as the remote /mcp server — list_artifacts, read, catch_up, comment, publish —
+// so the vocabulary is identical whether an agent connects over OAuth or a static
+// token. (A static token already has publish rights, so publish here goes live unless
+// you pass for_review; bundle publishing is remote-only.)
+
 const client = createClient({
   baseUrl: process.env.DOCK_SERVER ?? "http://localhost:8080",
   token: process.env.DOCK_TOKEN,
@@ -15,195 +22,270 @@ const GUIDE = (() => {
   try {
     return readFileSync(fileURLToPath(new URL("../SKILL.md", import.meta.url)), "utf8")
   } catch {
-    return "# Dock\nPublish, read comments, revise, reply, resolve via the dock tools."
+    return "# Dock\nFind, read, catch_up, comment, and publish via the dock tools."
   }
 })()
 
-const server = new McpServer({ name: "dock", version: "0.1.0" })
+const server = new McpServer({ name: "dock", version: "1.0.0" })
 
 const text = (s: string) => ({ content: [{ type: "text" as const, text: s }] })
+const json = (v: unknown) => text(JSON.stringify(v, null, 2))
 
+// FIND ------------------------------------------------------------------------
 server.registerTool(
-  "publish_artifact",
-  {
-    description: "Publish an HTML or Markdown artifact and get a permanent URL.",
-    inputSchema: {
-      content: z.string().describe("The artifact's text content (HTML or Markdown)."),
-      filename: z.string().describe("Filename, e.g. report.html or notes.md."),
-      title: z.string().optional(),
-      slug: z.string().optional(),
-      visibility: z.enum(["public", "link", "org", "password"]).optional(),
-      password: z
-        .string()
-        .optional()
-        .describe("Unlock password; required when visibility is 'password'."),
-    },
-  },
-  async (args) => {
-    const a = await client.publish(args)
-    return text(`Published "${a.title}" → ${a.url}\nshort_id ${a.short_id} · v${a.current_version}`)
-  },
-)
-
-server.registerTool(
-  "publish_version",
-  {
-    description: "Publish a new version of an existing artifact (same URL).",
-    inputSchema: {
-      short_id: z.string(),
-      content: z.string(),
-      filename: z.string(),
-      message: z.string().optional().describe("What changed in this version."),
-      resolves: z
-        .array(z.string())
-        .optional()
-        .describe("Comment ids whose threads this version resolves."),
-    },
-  },
-  async ({ short_id, content, filename, message, resolves }) => {
-    const a = await client.publish({ id: short_id, content, filename, message, resolves })
-    const note = resolves?.length ? ` · resolved ${resolves.length} thread(s)` : ""
-    return text(`${a.url} is now v${a.current_version}${note}`)
-  },
-)
-
-server.registerTool(
-  "get_artifact",
+  "list_artifacts",
   {
     description:
-      "Read an artifact's metadata and source content for a given version (defaults to current).",
-    inputSchema: { short_id: z.string(), version: z.number().int().optional() },
+      "List the artifacts in your workspace — short id, title, kind, current version, visibility. Start here to find what to work on, then catch_up or read it.",
+    inputSchema: { query: z.string().optional().describe("Optional title search filter.") },
+  },
+  async ({ query }) => {
+    const arts = await client.list(query)
+    return json({ count: arts.length, artifacts: arts })
+  },
+)
+
+// READ CONTENT ----------------------------------------------------------------
+server.registerTool(
+  "read",
+  {
+    description:
+      "Read an artifact's CONTENT by short id (a past `version` defaults to current). For what CHANGED or the comment threads, use catch_up instead.",
+    inputSchema: {
+      short_id: z.string(),
+      version: z.number().int().optional().describe("Defaults to the current version."),
+    },
   },
   async ({ short_id, version }) => {
     const a = await client.get(short_id)
     const body = await client.getContent(short_id, version)
     const v = version ?? a.current_version
-    return text(`# ${a.title} (v${v}/${a.current_version}, ${a.kind})\n${a.url}\n\n---\n${body}`)
+    return json({ short_id, title: a.title, kind: a.kind, version: v, content: body })
   },
 )
 
+// CATCH UP — state, feedback, history, and diffs all in one -------------------
 server.registerTool(
-  "list_versions",
-  { description: "List an artifact's version history.", inputSchema: { short_id: z.string() } },
-  async ({ short_id }) => {
-    const a = await client.get(short_id)
-    const lines = a.versions
-      .map((v) => `v${v.n} · ${v.author} · ${v.message ?? ""} · ${v.created_at}`)
-      .join("\n")
-    return text(`${a.title} (${a.versions.length} versions)\n${lines}`)
-  },
-)
-
-server.registerTool(
-  "list_comments",
-  {
-    description: "List comment threads on an artifact (the feedback queue). Filter by state.",
-    inputSchema: { short_id: z.string(), state: z.enum(["open", "resolved"]).optional() },
-  },
-  async ({ short_id, state }) => {
-    const comments = await client.listComments(short_id, state)
-    if (comments.length === 0) return text(`No ${state ?? ""} comments.`)
-    const lines = comments.map(
-      (c) =>
-        `[${c.id}] thread ${c.thread_id} · ${c.state} · ${c.author} · base v${c.base_version}` +
-        (c.anchor ? ` · @${c.anchor}` : "") +
-        `\n  ${c.body_md}`,
-    )
-    return text(lines.join("\n"))
-  },
-)
-
-server.registerTool(
-  "reply_comment",
-  {
-    description: "Reply in an existing comment thread (agents can discuss, not just resolve).",
-    inputSchema: { short_id: z.string(), thread_id: z.string(), body_md: z.string() },
-  },
-  async ({ short_id, thread_id, body_md }) => {
-    const c = await client.createComment(short_id, { thread_id, body_md, author: "agent" })
-    return text(`Replied in thread ${c.thread_id} (comment ${c.id}).`)
-  },
-)
-
-server.registerTool(
-  "add_comment",
+  "catch_up",
   {
     description:
-      "Leave new feedback as a new thread. Optionally anchor it to a quoted span of the rendered text.",
+      "START HERE on an artifact. Its state in one call: a summary, the versions since `since_version`, the open (and outdated) comment threads, and the full version history. " +
+      "Pass `comments` (open / addressed / resolved / outdated) to instead get that filtered thread list — your feedback queue. " +
+      "Pass `response_format='detailed'` (optionally with `since_version`/`to_version`) to fold in the exact line diff between two versions.",
     inputSchema: {
       short_id: z.string(),
-      body_md: z.string(),
-      quote: z.string().optional().describe("Exact text to anchor the comment to."),
+      since_version: z
+        .number()
+        .int()
+        .optional()
+        .describe("The version you last saw (diff base). Defaults to to_version − 1."),
+      to_version: z
+        .number()
+        .int()
+        .optional()
+        .describe("Compare up to this version instead of the current one."),
+      comments: z
+        .enum(["open", "addressed", "resolved", "outdated"])
+        .optional()
+        .describe(
+          "Return ONLY this state's comment threads (the feedback queue) instead of the delta.",
+        ),
+      response_format: z
+        .enum(["summary", "detailed"])
+        .optional()
+        .describe("'summary' (default) omits the line diff; 'detailed' includes it."),
     },
   },
-  async ({ short_id, body_md, quote }) => {
-    const anchor = quote ? { type: "TextQuoteSelector", exact: quote } : undefined
-    const c = await client.createComment(short_id, { body_md, anchor, author: "agent" })
-    return text(
-      `Commented (thread ${c.thread_id}, comment ${c.id})${quote ? ` on “${quote}”` : ""}.`,
-    )
+  async ({ short_id, since_version, to_version, comments, response_format }) => {
+    const summarizeComment = (c: {
+      thread_id: string
+      author: string
+      state: string
+      anchor: string | null
+      body_md: string
+    }) => ({
+      thread: c.thread_id,
+      author: c.author,
+      state: c.state,
+      quote: c.anchor,
+      body: c.body_md,
+    })
+
+    if (comments) {
+      const list = await client.listComments(short_id, comments)
+      return json({
+        short_id,
+        comments_state: comments,
+        count: list.length,
+        comments: list.map(summarizeComment),
+      })
+    }
+
+    const a = await client.get(short_id)
+    const head = a.current_version
+    const to = Math.min(head, Math.max(1, to_version ?? head))
+    const since = Math.min(to, Math.max(1, since_version ?? to - 1))
+    const history = a.versions.slice().sort((x, y) => y.n - x.n)
+    const newVersions = history.filter((v) => v.n > since && v.n <= to)
+    const [open, outdated, addressed] = await Promise.all([
+      client.listComments(short_id, "open"),
+      client.listComments(short_id, "outdated"),
+      client.listComments(short_id, "addressed"),
+    ])
+    let entryDiff: string | undefined
+    if (response_format === "detailed" && since < to) {
+      const d = await client.diff(short_id, since, to)
+      entryDiff = d.ops
+        .map((o) => `${o.t === "add" ? "+" : o.t === "del" ? "-" : " "} ${o.line}`)
+        .join("\n")
+    }
+    const outdatedBit = outdated.length ? ` ${outdated.length} now outdated.` : ""
+    const addressedBit = addressed.length ? ` ${addressed.length} addressed (pending review).` : ""
+    const summary =
+      since >= to
+        ? `You're up to date on "${a.title}" (v${head}); ${open.length} open comment(s).${addressedBit}${outdatedBit}`
+        : `"${a.title}": ${newVersions.length} new version(s) since v${since} (now v${to}). ${open.length} open comment(s).${addressedBit}${outdatedBit}`
+    return json({
+      summary,
+      short_id,
+      since,
+      to,
+      head,
+      caught_up: since >= to,
+      versions: history,
+      new_versions: newVersions,
+      ...(entryDiff
+        ? { entry_diff: entryDiff }
+        : {
+            entry_diff: "(omitted) — call again with response_format='detailed' for the line diff.",
+          }),
+      open_comments: open.map(summarizeComment),
+      ...(outdated.length ? { outdated_comments: outdated.map(summarizeComment) } : {}),
+    })
   },
 )
 
+// COMMENT — leave / reply / resolve feedback ----------------------------------
 server.registerTool(
-  "resolve_thread",
+  "comment",
   {
-    description: "Resolve (or reopen) the thread a comment belongs to, once feedback is handled.",
+    description:
+      "Leave feedback, reply in a thread, and/or resolve or reopen a thread. Anchor a NEW comment to a quoted span with `quote`. Reply by passing the thread id as `reply_to`. Resolve/reopen by passing `set_state` with a `comment_id` from the thread (or the comment you just left).",
     inputSchema: {
       short_id: z.string(),
-      comment_id: z.string(),
-      state: z.enum(["resolved", "open"]).default("resolved"),
+      body: z
+        .string()
+        .optional()
+        .describe("The comment text. Omit when only changing thread state."),
+      reply_to: z
+        .string()
+        .optional()
+        .describe("A thread id to reply in; omit to start a new thread."),
+      quote: z.string().optional().describe("Exact text to anchor a NEW comment to."),
+      set_state: z.enum(["resolved", "open"]).optional().describe("Resolve or reopen a thread."),
+      comment_id: z
+        .string()
+        .optional()
+        .describe("A comment in the thread to set_state on (when not posting)."),
     },
   },
-  async ({ short_id, comment_id, state }) => {
-    await client.setThreadState(short_id, comment_id, state)
-    return text(`Thread ${state === "resolved" ? "resolved" : "reopened"}.`)
+  async ({ short_id, body, reply_to, quote, set_state, comment_id }) => {
+    if (!body && !set_state)
+      return text("Provide `body` (to comment) or `set_state` (to resolve/reopen).")
+    let posted: Awaited<ReturnType<typeof client.createComment>> | undefined
+    if (body) {
+      const anchor = quote ? { type: "TextQuoteSelector", exact: quote } : undefined
+      posted = await client.createComment(short_id, {
+        thread_id: reply_to,
+        body_md: body,
+        anchor,
+        author: "agent",
+      })
+    }
+    let stateNote = ""
+    if (set_state) {
+      const ref = posted?.id ?? comment_id
+      if (!ref)
+        return text(
+          "`set_state` needs a `comment_id` (a comment in the thread) or a `body` to post and resolve.",
+        )
+      await client.setThreadState(short_id, ref, set_state)
+      stateNote = ` · thread ${set_state === "resolved" ? "resolved" : "reopened"}`
+    }
+    if (posted) {
+      const where = reply_to
+        ? `replied in thread ${posted.thread_id}`
+        : `new thread ${posted.thread_id}`
+      return text(`${where} (comment ${posted.id})${quote ? ` on “${quote}”` : ""}${stateNote}.`)
+    }
+    return text(`Thread ${set_state === "resolved" ? "resolved" : "reopened"}.`)
   },
 )
 
+// WRITE — publish live, or file a proposal for review -------------------------
 server.registerTool(
-  "diff_versions",
+  "publish",
   {
-    description: "Show what changed between two versions (defaults to previous → current).",
+    description:
+      "Publish a single-file artifact and get a permanent URL. OMIT short_id to create a NEW artifact (title recommended); PASS short_id to publish a new version (same URL). Pass for_review:true to file it as a PROPOSAL a human approves instead of going live. Pass `addresses` with the thread ids this revision resolves. (Multi-page bundles are published via the web app or the remote /mcp server.)",
     inputSchema: {
-      short_id: z.string(),
-      from: z.number().int().optional(),
-      to: z.number().int().optional(),
+      content: z.string().describe("The artifact's text content (HTML or Markdown)."),
+      filename: z
+        .string()
+        .optional()
+        .describe("Filename, e.g. report.html or notes.md. Defaults to index.html."),
+      short_id: z
+        .string()
+        .optional()
+        .describe("Omit to create a new artifact; pass it to add a version."),
+      title: z.string().optional(),
+      visibility: z.enum(["public", "link", "org"]).optional(),
+      message: z.string().optional().describe("What changed in this version."),
+      for_review: z
+        .boolean()
+        .optional()
+        .describe("File as a proposal for human review instead of publishing live."),
+      addresses: z
+        .array(z.string())
+        .optional()
+        .describe("Thread ids this revision resolves (live publish) or addresses (proposal)."),
     },
   },
-  async ({ short_id, from, to }) => {
-    const d = await client.diff(short_id, from, to)
-    const body = d.ops
-      .map((o) => `${o.t === "add" ? "+" : o.t === "del" ? "-" : " "} ${o.line}`)
-      .join("\n")
-    const adds = d.ops.filter((o) => o.t === "add").length
-    const dels = d.ops.filter((o) => o.t === "del").length
-    return text(`diff v${d.from} → v${d.to}  (+${adds} -${dels})\n\n${body}`)
-  },
-)
-
-server.registerTool(
-  "restore_version",
-  {
-    description: "Restore a past version as a new current revision (history is not rewritten).",
-    inputSchema: { short_id: z.string(), version: z.number().int() },
-  },
-  async ({ short_id, version }) => {
-    const a = await client.restore(short_id, version)
-    return text(`Restored v${version} → ${a.url} is now v${a.current_version}.`)
-  },
-)
-
-server.registerTool(
-  "view_stats",
-  {
-    description: "Read view analytics for an artifact (total, unique viewers, per-version).",
-    inputSchema: { short_id: z.string() },
-  },
-  async ({ short_id }) => {
-    const s = await client.viewStats(short_id)
-    const perV = s.perVersion.map((v) => `v${v.version}: ${v.count}`).join(", ")
-    return text(`${s.total} views · ${s.unique} unique${perV ? `\nby version — ${perV}` : ""}`)
+  async ({ content, filename, short_id, title, visibility, message, for_review, addresses }) => {
+    if (for_review) {
+      if (!short_id) return text("A proposal revises an EXISTING artifact — pass its short_id.")
+      const p = await client.propose(short_id, {
+        content,
+        filename,
+        message: message ?? "Proposed revision",
+        addresses,
+      })
+      const note = p.addressed?.length ? ` · addressed ${p.addressed.length} thread(s)` : ""
+      return json({
+        proposed: true,
+        proposal_id: p.id,
+        base_version: p.base_version,
+        note: `Submitted for review (not live)${note}.`,
+      })
+    }
+    const a = await client.publish({
+      id: short_id,
+      content,
+      filename: filename ?? "index.html",
+      title,
+      visibility,
+      message,
+      resolves: addresses,
+    })
+    const note = addresses?.length ? ` · resolved ${addresses.length} thread(s)` : ""
+    return json({
+      published: true,
+      short_id: a.short_id,
+      version: a.current_version,
+      url: a.url,
+      title: a.title,
+      note: short_id ? `Live — new version${note}.` : `Live — created "${a.title}"${note}.`,
+    })
   },
 )
 

--- a/packages/mcp/test/client.test.ts
+++ b/packages/mcp/test/client.test.ts
@@ -143,6 +143,35 @@ describe("dock client (the MCP server's backend) over real HTTP", () => {
     expect(got.versions[0]).toHaveProperty("name")
   })
 
+  it("lists the workspace's artifacts, filtered by a title query", async () => {
+    const a = await client.publish({ content: "x", filename: "l.md", title: "Listable Plan" })
+    const all = await client.list()
+    expect(all.some((x) => x.short_id === a.short_id)).toBe(true)
+    const hit = await client.list("Listable")
+    expect(hit.some((x) => x.short_id === a.short_id)).toBe(true)
+    const none = await client.list("zzz-no-such-title-zzz")
+    expect(none.some((x) => x.short_id === a.short_id)).toBe(false)
+  })
+
+  it("proposes a single-file revision for review (with and without addresses)", async () => {
+    const a = await client.publish({ content: "# headline", filename: "p.md", title: "Proposable" })
+    const c = await client.createComment(a.short_id, { body_md: "fix headline", author: "jess" })
+    const p = await client.propose(a.short_id, {
+      content: "# fixed headline",
+      message: "tightened",
+      addresses: [c.thread_id],
+    })
+    expect(p.id).toBeTruthy()
+    expect(p.base_version).toBe(1)
+    expect(p.addressed).toEqual([c.thread_id])
+    // The live version is untouched — a proposal is not a publish.
+    expect(await client.getContent(a.short_id)).toBe("# headline")
+
+    // No `addresses` (default filename) covers the other branch.
+    const p2 = await client.propose(a.short_id, { content: "# again", message: "another pass" })
+    expect(p2.id).toBeTruthy()
+  })
+
   it("surfaces server errors as thrown messages", async () => {
     await expect(client.get("nope0000")).rejects.toThrow(/dock 404/)
   })


### PR DESCRIPTION
The MCP surface was three divergent vocabularies: the remote `/mcp` server (8 tools), the stdio `@dock/mcp` server (11), and docs/skills that mixed both plus invented names (`whoami`, `read_artifact`, `read_section`). This unifies everything on **five tools** mapped to the agent's intents.

| Tool | Intent | Folds in |
|---|---|---|
| `list_artifacts` | find | — |
| `read` | content (a page / a version) | — |
| `catch_up` | state in one call: what changed, comment threads, history | `catch_me_up`, `list_comments`, `list_versions`, `diff` |
| `comment` | leave / reply / anchor / resolve feedback | `add_comment`, `reply_comment`, `resolve_thread` (**new on the remote server** — agents can author feedback over MCP) |
| `publish` | save a revision (live or proposal) | `propose`, `publish_artifact`, `publish_version`, `restore_version` |

### Key decisions
- **propose vs publish is one tool.** Whether a write goes live or files a proposal is an *authorization* outcome, decided by the bearer's role at the API, with `for_review:true` to force review. Not two tools.
- `catch_up` is the single "state" tool: `comments` (open/addressed/resolved/outdated) returns the filtered feedback queue; `response_format='detailed'` (with optional `since_version`/`to_version`) folds in the exact line diff.
- `comment` folds reply + resolve via `reply_to` and `set_state`.
- Dropped `view_stats` (human-UI concern) and `whoami` (identity rides in the server instructions).

### Changes
- **`apps/api/src/mcp.ts`** — production `/mcp` server rewritten to the 5 tools (adds the `comment` tool; merges `propose` into `publish` with role-gating + `for_review` + `addresses`).
- **`packages/mcp/src/{index,client}.ts`** — stdio server mirrors the same 5; client gains `list` + `propose`, and `catch_up` is composed over `/v1`.
- **`apps/api/test/mcp.test.ts`** — rewritten to the new surface, **16 passing**; covers the new `comment` tool and both live + review publish paths.
- **README, `packages/mcp/SKILL.md`, `.claude/skills/*`, `llms.txt`/`llms-full.txt`, CLI scaffold** — one vocabulary everywhere.

### Verification
- `@dock/api` + `@dock/mcp` typecheck clean.
- `apps/api` MCP tests: 16/16. `@dock/mcp` client tests: 10/10.
- Biome + all `lint:*` precommit gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)