### PR TITLE
test(core): cover the line-diff engine (diffLines + formatDiff)

### DIFF
--- a/packages/core/src/diff.test.ts
+++ b/packages/core/src/diff.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest"
+import { type DiffOp, diffLines, formatDiff } from "./diff"
+
+// The defining property of a correct line diff: dropping the additions and
+// rejoining recovers the OLD text exactly; dropping the deletions recovers the NEW
+// text. (ctx lines belong to both, add only to new, del only to old.)
+const oldFrom = (ops: DiffOp[]) =>
+  ops
+    .filter((o) => o.t !== "add")
+    .map((o) => o.line)
+    .join("\n")
+const newFrom = (ops: DiffOp[]) =>
+  ops
+    .filter((o) => o.t !== "del")
+    .map((o) => o.line)
+    .join("\n")
+
+describe("diffLines — reconstruction invariant", () => {
+  const cases: [string, string][] = [
+    ["", ""],
+    ["", "a\nb"],
+    ["a\nb", ""],
+    ["same\ntext", "same\ntext"],
+    ["1\n2\n3", "1\n3"], // a deletion in the middle
+    ["1\n3", "1\n2\n3"], // an insertion in the middle
+    ["x", "y"], // a full one-line replace
+    ["a\nb\nc", "c\nb\na"], // a reorder
+    ["alpha\nbeta\ngamma", "alpha\nBETA\ngamma\ndelta"], // change + append
+    ["the\nquick\nbrown\nfox", "the\nslow\nbrown\ncat"], // two scattered changes
+  ]
+
+  it.each(cases)("rebuilds both sides for %j -> %j", (a, b) => {
+    const ops = diffLines(a, b)
+    expect(oldFrom(ops)).toBe(a)
+    expect(newFrom(ops)).toBe(b)
+  })
+})
+
+describe("diffLines — shape of the result", () => {
+  it("marks identical text entirely as context, one op per line", () => {
+    const ops = diffLines("one\ntwo\nthree", "one\ntwo\nthree")
+    expect(ops).toEqual([
+      { t: "ctx", line: "one" },
+      { t: "ctx", line: "two" },
+      { t: "ctx", line: "three" },
+    ])
+  })
+
+  it("keeps the surrounding lines as context around a single edit", () => {
+    expect(diffLines("1\n2\n3", "1\n3")).toEqual([
+      { t: "ctx", line: "1" },
+      { t: "del", line: "2" },
+      { t: "ctx", line: "3" },
+    ])
+  })
+
+  it("maximizes context: the number of ctx ops equals the LCS length", () => {
+    // LCS of (1,2,3,4) and (1,3,4,5) is (1,3,4) -> 3 context lines.
+    const ops = diffLines("1\n2\n3\n4", "1\n3\n4\n5")
+    expect(ops.filter((o) => o.t === "ctx").map((o) => o.line)).toEqual(["1", "3", "4"])
+  })
+
+  it("emits deletions before additions on a changed line (stable tie-break)", () => {
+    expect(diffLines("x", "y")).toEqual([
+      { t: "del", line: "x" },
+      { t: "add", line: "y" },
+    ])
+  })
+
+  it("treats a pure append as context + additions, never deletions", () => {
+    const ops = diffLines("intro", "intro\nbody\noutro")
+    expect(ops.some((o) => o.t === "del")).toBe(false)
+    expect(ops.filter((o) => o.t === "add").map((o) => o.line)).toEqual(["body", "outro"])
+  })
+})
+
+describe("formatDiff", () => {
+  it("prefixes each op: two spaces for context, + for add, - for del", () => {
+    const ops: DiffOp[] = [
+      { t: "ctx", line: "kept" },
+      { t: "del", line: "gone" },
+      { t: "add", line: "new" },
+    ]
+    expect(formatDiff(ops)).toBe("  kept\n- gone\n+ new")
+  })
+
+  it("renders an empty diff as an empty string", () => {
+    expect(formatDiff([])).toBe("")
+  })
+
+  it("round-trips through diffLines into a readable unified diff", () => {
+    expect(formatDiff(diffLines("a\nb\nc", "a\nB\nc"))).toBe("  a\n- b\n+ B\n  c")
+  })
+})


### PR DESCRIPTION
Draft. `packages/core/src/diff.ts` (LCS line diff) powers the version-compare view and the MCP `catch_up` detailed diff, and had **no tests**. Built around the defining property of a correct diff, not coverage.

### What it locks down
- **Reconstruction invariant** (table-driven over 10 pairs: empty, identical, mid insert/delete, full replace, reorder, scattered edits): dropping the `add` ops rebuilds the **old** text exactly; dropping the `del` ops rebuilds the **new** text. Any op mislabeled, dropped, or out of order fails this.
- **Shape**: identical text is all context; a single edit keeps its neighbors as context; the **ctx-op count equals the LCS length** (the algorithm maximizes context, not just produces *a* valid diff); a changed line emits **del before add** (stable tie-break); a pure append never emits a deletion.
- **`formatDiff`**: the `  ` / `+ ` / `- ` prefixes, empty-ops → empty string, and a `diffLines → formatDiff` round-trip.

The reconstruction property is the high-signal one: it holds for any correct diff and breaks loudly on the regressions that matter (a line silently lost from the compare view).

18 assertions, all pure, runs in CI via `pnpm -r test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)