### PR TITLE
test(api): cover the crypto primitives (state tokens, secret encryption, passwords)

### DIFF
--- a/apps/api/test/crypto.test.ts
+++ b/apps/api/test/crypto.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest"
+import {
+  decryptSecret,
+  encryptSecret,
+  hashPassword,
+  safeEqual,
+  sha256,
+  signState,
+  unlockCookie,
+  unlockToken,
+  verifyPassword,
+  verifyState,
+} from "../src/lib/crypto"
+
+describe("sha256", () => {
+  it("matches known SHA-256 vectors (hex)", () => {
+    expect(sha256("")).toBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+    expect(sha256("abc")).toBe("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+  })
+})
+
+describe("signState / verifyState — signed, expiring state tokens", () => {
+  const secret = "server-secret"
+  const T = 1_700_000_000_000
+
+  it("round-trips the payload and stamps iat", () => {
+    const token = signState({ org: "o1", user: "u1" }, secret, T)
+    const out = verifyState<{ org: string; user: string; iat: number }>(token, secret, undefined, T)
+    expect(out).toMatchObject({ org: "o1", user: "u1", iat: T })
+  })
+
+  it("rejects a tampered body or signature", () => {
+    const token = signState({ org: "o1" }, secret, T)
+    const [body, sig] = token.split(".")
+    expect(verifyState(`${body}x.${sig}`, secret, undefined, T)).toBeNull()
+    expect(verifyState(`${body}.${sig}x`, secret, undefined, T)).toBeNull()
+  })
+
+  it("rejects a token signed with a different secret (binds to the auth secret)", () => {
+    const token = signState({ org: "o1" }, secret, T)
+    expect(verifyState(token, "other-secret", undefined, T)).toBeNull()
+  })
+
+  it("rejects an expired token and one with a future iat (clock-skew guard)", () => {
+    const maxAge = 15 * 60_000
+    const token = signState({ org: "o1" }, secret, T)
+    // Verified just past the window -> expired.
+    expect(verifyState(token, secret, maxAge, T + maxAge + 1)).toBeNull()
+    // A token whose iat is well in the future of the verifier -> rejected.
+    const future = signState({ org: "o1" }, secret, T + 120_000)
+    expect(verifyState(future, secret, maxAge, T)).toBeNull()
+  })
+
+  it("returns null for a malformed token", () => {
+    expect(verifyState("nodot", secret)).toBeNull()
+    expect(verifyState("a.b.c", secret)).toBeNull()
+  })
+})
+
+describe("encryptSecret / decryptSecret — AES-256-GCM at rest", () => {
+  const pass = "passphrase"
+
+  it("round-trips, including unicode", () => {
+    const blob = encryptSecret("ghp_secret-token", pass)
+    expect(decryptSecret(blob, pass)).toBe("ghp_secret-token")
+    expect(decryptSecret(encryptSecret("héllo 🔒", pass), pass)).toBe("héllo 🔒")
+  })
+
+  it("produces a v1 envelope that hides the plaintext and is non-deterministic", () => {
+    const a = encryptSecret("topsecret", pass)
+    const b = encryptSecret("topsecret", pass)
+    expect(a.startsWith("v1.")).toBe(true)
+    expect(a.split(".")).toHaveLength(4)
+    expect(a).not.toContain("topsecret")
+    expect(a).not.toBe(b) // fresh random IV each time
+  })
+
+  it("does not reveal the plaintext under a wrong key or tampering (fails closed)", () => {
+    const blob = encryptSecret("topsecret", pass)
+    // Wrong key: returns the (still-encrypted) blob, never the plaintext.
+    expect(decryptSecret(blob, "wrong")).not.toBe("topsecret")
+    // Tampered ciphertext fails the GCM auth tag and is not decoded to plaintext.
+    const p = blob.split(".")
+    const tampered = `${p.slice(0, 3).join(".")}.${(p[3] ?? "").slice(0, -2)}AA`
+    expect(decryptSecret(tampered, pass)).not.toBe("topsecret")
+  })
+
+  it("passes through a value stored before encryption was configured", () => {
+    expect(decryptSecret("plain-legacy-value", pass)).toBe("plain-legacy-value")
+  })
+})
+
+describe("hashPassword / verifyPassword — salted, hashed at rest", () => {
+  it("verifies the right password and rejects the wrong one", () => {
+    const stored = hashPassword("hunter2")
+    expect(verifyPassword("hunter2", stored)).toBe(true)
+    expect(verifyPassword("Hunter2", stored)).toBe(false)
+  })
+
+  it("salts: the same password hashes differently every time", () => {
+    const a = hashPassword("same")
+    const b = hashPassword("same")
+    expect(a).not.toBe(b)
+    expect(a.split(".")).toHaveLength(2)
+    // Both still verify despite different salts.
+    expect(verifyPassword("same", a)).toBe(true)
+    expect(verifyPassword("same", b)).toBe(true)
+  })
+
+  it("rejects null / empty / malformed stored values", () => {
+    for (const bad of [null, undefined, "", "nodot", "salt.", ".digest"])
+      expect(verifyPassword("x", bad)).toBe(false)
+  })
+})
+
+describe("safeEqual — constant-time compare", () => {
+  it("is true only for equal strings, and never for an unset/empty secret", () => {
+    expect(safeEqual("token", "token")).toBe(true)
+    expect(safeEqual("token", "tokeN")).toBe(false)
+    expect(safeEqual("token", undefined)).toBe(false)
+    // An empty secret is treated as unset and never matches (even an empty input).
+    expect(safeEqual("", "")).toBe(false)
+  })
+})
+
+describe("unlock tokens", () => {
+  it("derives a deterministic unlock token that invalidates when the hash changes", () => {
+    const t1 = unlockToken("art1", "hashA")
+    expect(unlockToken("art1", "hashA")).toBe(t1) // stable
+    expect(unlockToken("art1", "hashB")).not.toBe(t1) // password changed -> cookie invalid
+    expect(unlockToken("art2", "hashA")).not.toBe(t1) // per-artifact
+  })
+
+  it("names the unlock cookie per artifact", () => {
+    expect(unlockCookie("ab12cd34")).toBe("dku_ab12cd34")
+  })
+})


### PR DESCRIPTION
Draft. `apps/api/src/lib/crypto.ts` holds the app's **security primitives** and had no dedicated unit test (other suites only borrow `sha256` as a helper). Each is tested at its security boundary, not just for happy-path round-trips.

### What it locks down
- **`sha256`** — pinned against known SHA-256 vectors.
- **`signState` / `verifyState`** (GitHub install state): round-trips the payload + `iat`, and **rejects** a tampered body or signature, a different secret, an **expired** token, and a **future-dated `iat`** (clock-skew guard). Time is injected (`nowMs`), so no flakiness.
- **`encryptSecret` / `decryptSecret`** (AES-256-GCM PATs at rest): round-trips incl. unicode; the `v1.` envelope **hides the plaintext and is non-deterministic** (fresh random IV); a **wrong key or tampered ciphertext fails closed** (never yields the plaintext); a legacy plaintext value passes through.
- **`hashPassword` / `verifyPassword`** (artifact passwords): verifies the right password, rejects the wrong one, **salts** (same password → different hash each time), and rejects null/empty/malformed stored values.
- **`safeEqual`**: equal-only, and an **unset or empty** secret never matches.
- **`unlockToken`**: deterministic, per-artifact, and **invalidates when the password hash changes**.

These guard replay/expiry on OAuth state, secrets-at-rest, and shared-link auth, so the tamper/expiry/fails-closed assertions are the high-signal ones. Writing this also pinned that an empty secret is treated as unset by `safeEqual`.

16 assertions, runs in CI via `pnpm -r test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)