### PR TITLE
test(web): cover client comment renderer mdToHtml (XSS-safe inline markdown)

### DIFF
--- a/apps/web/src/pages/artifact/lib/markdown.test.ts
+++ b/apps/web/src/pages/artifact/lib/markdown.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+import type { Mention } from "@/api"
+import { mdToHtml } from "./markdown"
+
+const m = (...names: string[]): Mention[] =>
+  names.map((name, i) => ({ id: `u${i}`, name }) as Mention)
+
+describe("mdToHtml — XSS safety (escape first, then transform)", () => {
+  it("escapes raw HTML so it can never render as markup", () => {
+    const out = mdToHtml("<script>alert(1)</script>")
+    expect(out).toContain("&lt;script&gt;")
+    expect(out).not.toContain("<script>")
+  })
+
+  it("escapes HTML even inside inline code", () => {
+    expect(mdToHtml("`<img src=x onerror=alert(1)>`")).toBe(
+      "<code>&lt;img src=x onerror=alert(1)&gt;</code>",
+    )
+  })
+
+  it("escapes ampersands and quotes", () => {
+    expect(mdToHtml('a & "b"')).toBe("a &amp; &quot;b&quot;")
+  })
+
+  it("only linkifies http(s) URLs — a javascript: link stays inert text", () => {
+    const out = mdToHtml("[click](javascript:alert(1))")
+    expect(out).not.toContain("<a")
+    expect(out).not.toContain('href="javascript')
+  })
+})
+
+describe("mdToHtml — inline markdown", () => {
+  it("renders bold, italic, strikethrough, and inline code", () => {
+    expect(mdToHtml("**b**")).toBe("<strong>b</strong>")
+    expect(mdToHtml("a *i* b")).toContain("<em>i</em>")
+    expect(mdToHtml("~~s~~")).toBe("<del>s</del>")
+    expect(mdToHtml("`c`")).toBe("<code>c</code>")
+  })
+
+  it("renders a markdown link with a safe target and rel", () => {
+    expect(mdToHtml("[site](https://example.com/x)")).toBe(
+      '<a href="https://example.com/x" target="_blank" rel="noopener noreferrer">site</a>',
+    )
+  })
+
+  it("autolinks a bare http(s) URL", () => {
+    expect(mdToHtml("see https://x.com now")).toContain(
+      '<a href="https://x.com" target="_blank" rel="noopener noreferrer">https://x.com</a>',
+    )
+  })
+
+  it("turns newlines into <br/>", () => {
+    expect(mdToHtml("line1\nline2")).toBe("line1<br/>line2")
+  })
+})
+
+describe("mdToHtml — @mentions", () => {
+  it("highlights only names from the known mention set", () => {
+    expect(mdToHtml("hi @Alice", m("Alice"))).toBe('hi <span class="mention">@Alice</span>')
+    // @Bob is not in the set, so it stays plain text.
+    expect(mdToHtml("hi @Bob", m("Alice"))).toBe("hi @Bob")
+  })
+
+  it("prefers the longest matching name (full name wins over a prefix)", () => {
+    expect(mdToHtml("@Alice", m("Al", "Alice"))).toBe('<span class="mention">@Alice</span>')
+  })
+
+  it("treats mention names literally (regex metachars are escaped)", () => {
+    // "a.b" must match literally, not as "a<any>b".
+    expect(mdToHtml("@a.b", m("a.b"))).toBe('<span class="mention">@a.b</span>')
+    expect(mdToHtml("@axb", m("a.b"))).toBe("@axb")
+  })
+
+  it("does nothing special when no mentions are supplied", () => {
+    expect(mdToHtml("hi @Alice")).toBe("hi @Alice")
+  })
+})


### PR DESCRIPTION
Draft. `apps/web/src/pages/artifact/lib/markdown.ts` (`mdToHtml`) renders **comment bodies to HTML in the SPA** and is explicitly the "escape first, then transform" XSS guard — but had no test. Comment text is user content rendered as markup, so the suite leans on that security boundary. (First test to land in `apps/web`'s suite from this series; complements the server-side `md.ts` XSS test #231.)

### What it locks down
- **XSS-safe**: escapes raw HTML (a `<script>` never renders), escapes HTML **even inside inline code**, and escapes `&`/quotes.
- **Link safety**: only linkifies `http(s)` URLs — a `javascript:` link stays inert text (no `<a>`, no `javascript:` href); rendered links carry `target="_blank" rel="noopener noreferrer"` (anti-tabnabbing).
- **Inline markdown**: bold / italic / strikethrough / inline code, bare-URL autolinks, newlines → `<br/>`.
- **@mentions**: highlights **only names in the known set** (an unknown `@handle` stays plain text), prefers the **longest** matching name (full name beats a prefix), and **escapes regex metachars** in names so `a.b` matches literally rather than as `a<any>b`.

The escape-inside-code, javascript-link-inert, and literal-mention-matching cases are the high-signal ones — each is a real injection or mismatch vector if the renderer regressed.

12 assertions, pure (no DOM), runs in CI via `pnpm -r test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)