### PR TITLE
Element anchors: pin comments to non-text elements (images, charts, tables)

### DIFF
--- a/apps/api/src/lib/anchor-sweep.ts
+++ b/apps/api/src/lib/anchor-sweep.ts
@@ -11,6 +11,14 @@ import {
 } from "@dock/core"
 import { pageTextResolver } from "./bundle"
 
+/** Forward-walk recovery is one blob read + scan per version, on the publish path.
+ *  A genuinely-removed element early-exits at the first hop (cheap), but a recoverable
+ *  one drifting across a long history would read every version. Cap the walk to the
+ *  most recent N versions so an artifact with a huge history can't turn one republish
+ *  into hundreds of blob reads. A comment older than this window simply doesn't get
+ *  the gradual-recovery benefit (it still resolves directly if its content held). */
+const MAX_WALK_VERSIONS = 60
+
 /** A thread reduced for the sweep, plus the bundle page it lives on (null = a
  *  single-file artifact or whole-document thread) and the version it was made on
  *  (the start of any forward-walk). `id` is the root comment id (== thread_id). */
@@ -139,8 +147,11 @@ async function rescueElements(
   for (const th of goingStale.values()) {
     const start = parseElementSelector(th.anchor)
     if (!start) continue
-    const trail = versions.filter((v) => v.n > th.base)
+    let trail = versions.filter((v) => v.n > th.base)
     if (trail.length === 0) continue
+    // Bound the work: only walk the most recent versions. (Older history can't turn a
+    // single republish into an unbounded read storm.)
+    if (trail.length > MAX_WALK_VERSIONS) trail = trail.slice(trail.length - MAX_WALK_VERSIONS)
     const htmls: string[] = []
     for (const v of trail) {
       const html = await htmlAt(v, th.path)

--- a/apps/api/src/lib/anchor-sweep.ts
+++ b/apps/api/src/lib/anchor-sweep.ts
@@ -2,32 +2,45 @@ import {
   type AnchorThread,
   type AnchorTransition,
   type BlobStore,
+  type ElementSelector,
   type MetaStore,
+  parseElementSelector,
   planAnchorSweep,
+  planElementForwardWalk,
   type VersionRecord,
 } from "@dock/core"
 import { pageTextResolver } from "./bundle"
 
 /** A thread reduced for the sweep, plus the bundle page it lives on (null = a
- *  single-file artifact or whole-document thread). */
-type Thread = AnchorThread & { path: string | null }
+ *  single-file artifact or whole-document thread) and the version it was made on
+ *  (the start of any forward-walk). `id` is the root comment id (== thread_id). */
+type Thread = AnchorThread & { id: string; path: string | null; base: number }
+
+type SweepStore = Pick<
+  MetaStore,
+  "listComments" | "setThreadState" | "listVersions" | "getVersion" | "updateComment"
+>
 
 /**
  * Re-anchor a published artifact's comment threads against the new version and
  * apply the resulting state flips (open↔outdated). Called after every version
- * bump (publish, restore, proposal approve) so feedback whose quoted text
- * changed is marked `outdated` — and un-marked if the text reappears.
+ * bump (publish, restore, proposal approve) so feedback whose anchor changed is
+ * marked `outdated` — and un-marked if it reappears.
  *
- * Each thread is checked against ITS page's text (single-file artifacts use the
- * whole document; bundle threads use their own page via the manifest), so a
- * comment on one page of a bundle never goes stale because a different page
- * changed. A thread is open/resolved/outdated as a unit, so we collapse its
- * comments to the root's anchor + state + path before planning. One
- * `listComments`, one blob read per referenced page, one `setThreadState` per
- * thread that actually changes — never per comment.
+ * Text anchors re-grep their quote; element anchors relocate via the cascade
+ * against the page's HTML. Each thread is checked against ITS page's content, so a
+ * comment on one bundle page never goes stale because a different page changed.
+ *
+ * The element path adds the Dock-only move: before giving up on an element that
+ * doesn't resolve in the new version, FORWARD-WALK it through the version history
+ * from where it was made — re-deriving the selector at each hop it still resolves.
+ * An element edited gradually (renamed, moved, rewrapped) is recovered because each
+ * single-version delta stays resolvable. On recovery we self-heal: the root
+ * comment's selector is rewritten to the carried-forward one, so the live client
+ * (which resolves in a single jump) can find it too.
  */
 export async function sweepAnchors(
-  meta: Pick<MetaStore, "listComments" | "setThreadState">,
+  meta: SweepStore,
   blobs: BlobStore,
   artifactId: string,
   version: VersionRecord,
@@ -40,18 +53,21 @@ export async function sweepAnchors(
     const cur = byThread.get(cm.thread_id)
     if (!cur) {
       byThread.set(cm.thread_id, {
+        id: cm.thread_id,
         thread_id: cm.thread_id,
         anchor: cm.anchor,
         state: cm.state,
         path: cm.path,
+        base: cm.base_version,
       })
       continue
     }
     // The root comment (id == thread_id) is authoritative for the anchor, state,
-    // and page; a reply only contributes an anchor if the root somehow lacked one.
+    // page, and base version; a reply only contributes an anchor if the root lacked one.
     if (cm.id === cm.thread_id) {
       cur.state = cm.state
       cur.path = cm.path
+      cur.base = cm.base_version
       if (cm.anchor) cur.anchor = cm.anchor
     } else if (!cur.anchor && cm.anchor) {
       cur.anchor = cm.anchor
@@ -59,7 +75,7 @@ export async function sweepAnchors(
   }
 
   const resolveText = await pageTextResolver(blobs, version)
-  // Group by page so each page's text is read once, then plan per page.
+  // Group by page so each page's content is read once, then plan per page.
   const byPage = new Map<string | null, Thread[]>()
   for (const t of byThread.values()) {
     const list = byPage.get(t.path)
@@ -69,10 +85,80 @@ export async function sweepAnchors(
 
   const transitions: AnchorTransition[] = []
   for (const [path, threads] of byPage) {
-    const text = await resolveText(path)
-    if (text == null) continue // page no longer resolvable — leave its threads alone
-    transitions.push(...planAnchorSweep(threads, text))
+    const content = await resolveText(path)
+    if (content == null) continue // page no longer resolvable — leave its threads alone
+    const planned = planAnchorSweep(threads, content)
+    // Element threads about to be marked outdated get a forward-walk rescue.
+    const rescued = await rescueElements(meta, blobs, artifactId, version, threads, planned)
+    transitions.push(...planned.filter((t) => !rescued.has(t.thread_id)))
   }
   for (const t of transitions) await meta.setThreadState(artifactId, t.thread_id, t.state)
   return transitions
+}
+
+/**
+ * For each element thread the plan wants to mark `outdated`, walk the version
+ * history forward and try to recover it. Returns the thread ids that were rescued
+ * (so the caller drops their outdated flip). Recovered selectors are persisted to
+ * the root comment so the live client resolves them in one jump.
+ */
+async function rescueElements(
+  meta: SweepStore,
+  blobs: BlobStore,
+  artifactId: string,
+  current: VersionRecord,
+  threads: Thread[],
+  planned: AnchorTransition[],
+): Promise<Set<string>> {
+  const rescued = new Set<string>()
+  const goingStale = new Map<string, Thread>()
+  for (const t of planned) {
+    if (t.state !== "outdated") continue
+    const th = threads.find((x) => x.thread_id === t.thread_id)
+    if (th && parseElementSelector(th.anchor)) goingStale.set(th.thread_id, th)
+  }
+  if (goingStale.size === 0) return rescued
+
+  // Versions up to current, ascending. Read each page's HTML once and reuse across
+  // threads on the same page.
+  const versions = (await meta.listVersions(artifactId))
+    .filter((v) => v.n <= current.n)
+    .sort((a, b) => a.n - b.n)
+  const htmlCache = new Map<string, string | null>() // `${version} ${path}` -> html
+
+  const htmlAt = async (v: VersionRecord, path: string | null): Promise<string | null> => {
+    const key = `${v.n} ${path ?? ""}`
+    const hit = htmlCache.get(key)
+    if (hit !== undefined) return hit
+    const resolve = await pageTextResolver(blobs, v)
+    const html = await resolve(path)
+    htmlCache.set(key, html)
+    return html
+  }
+
+  for (const th of goingStale.values()) {
+    const start = parseElementSelector(th.anchor)
+    if (!start) continue
+    const trail = versions.filter((v) => v.n > th.base)
+    if (trail.length === 0) continue
+    const htmls: string[] = []
+    for (const v of trail) {
+      const html = await htmlAt(v, th.path)
+      if (html != null) htmls.push(html)
+    }
+    if (htmls.length === 0) continue
+    const walk = planElementForwardWalk(start, htmls)
+    if (!walk.resolved) continue
+    rescued.add(th.thread_id)
+    // Self-heal: rewrite the root comment's selector to the recovered one (carrying
+    // the original snapshot through) so the next sweep + the live client resolve in
+    // one jump.
+    const healed: ElementSelector = { ...walk.selector, snapshot: start.snapshot }
+    if (JSON.stringify(healed) !== th.anchor) {
+      await meta.updateComment(th.id, { anchor: JSON.stringify(healed) })
+    }
+    // If it had drifted to outdated in a prior sweep, bring it back to open.
+    if (th.state === "outdated") await meta.setThreadState(artifactId, th.thread_id, "open")
+  }
+  return rescued
 }

--- a/apps/api/src/lib/comments.ts
+++ b/apps/api/src/lib/comments.ts
@@ -72,11 +72,14 @@ export const previewOf = (body: string): string => {
   return flat.length > 160 ? `${flat.slice(0, 159)}…` : flat
 }
 
-/** The quoted text from a comment anchor, for webhook payloads. */
+/** A short referent for a comment anchor, for webhook payloads — the quoted text
+ *  for a text anchor, or the element's snapshot label for an element anchor. */
 export const quoteOf = (anchor: string | null): string | null => {
   if (!anchor) return null
   try {
-    return (JSON.parse(anchor) as { exact?: string }).exact ?? null
+    const a = JSON.parse(anchor) as { exact?: string; type?: string; snapshot?: { label?: string } }
+    if (a.type === "ElementSelector") return a.snapshot?.label ?? null
+    return a.exact ?? null
   } catch {
     return null
   }

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -149,6 +149,11 @@ export const commentRoutes = (ctx: AppContext) => {
         : typeof body.anchor === "string"
           ? body.anchor
           : null
+    // Cap the anchor size. body_md is bounded but the anchor was not — a real element
+    // anchor (snapshot.html capped at ~2KB + a few short fields) stays well under this;
+    // the limit stops a comment from storing a multi-MB blob that ships on every fetch.
+    if (anchor && anchor.length > 16_000)
+      return fail(c, 400, "anchor is too large (max 16000 characters)")
 
     const acting = await actingUser(c)
     const author = acting

--- a/apps/api/test/comments.test.ts
+++ b/apps/api/test/comments.test.ts
@@ -386,4 +386,32 @@ describe("element anchors (non-text) through publish + sweep", () => {
     // The original snapshot rode through the recovery.
     expect(healed.snapshot.label).toBe("Image — hero one")
   })
+
+  it("rejects an oversized anchor (storage/bandwidth abuse) but accepts a normal one", async () => {
+    const sid = (
+      await (
+        await upload("e.html", page(`<img id="x" src="/a.png" alt="A">`), { title: "E" })
+      ).json()
+    ).short_id
+    // A normal element anchor is fine.
+    const ok = await app.request(
+      `/v1/artifacts/${sid}/comments`,
+      json({ body_md: "ok", anchor: elSelFor(page(`<img id="x" src="/a.png" alt="A">`), "img") }),
+    )
+    expect(ok.status).toBe(201)
+    // A multi-MB anchor (e.g. a giant snapshot.html) is refused, not stored.
+    const huge = await app.request(
+      `/v1/artifacts/${sid}/comments`,
+      json({
+        body_md: "abuse",
+        anchor: {
+          type: "ElementSelector",
+          tag: "img",
+          fingerprint: "x",
+          snapshot: { html: "A".repeat(2_000_000) },
+        },
+      }),
+    )
+    expect(huge.status).toBe(400)
+  })
 })

--- a/apps/api/test/comments.test.ts
+++ b/apps/api/test/comments.test.ts
@@ -1,5 +1,27 @@
+import { type ElementSelector, elementLabel, fingerprintOf, roleOf, scanElements } from "@dock/core"
 import { describe, expect, it } from "vitest"
 import { app, as, json, jsonAs, makeAuthedApp, publishAs, type TestUser, upload } from "./helpers"
+
+// Build an element selector for the first element matching `tag` in `html`, the
+// way the browser client would (same fields, from a scan).
+const elSelFor = (html: string, tag: string, ordinal = 0): ElementSelector => {
+  const ds = scanElements(html)
+  const d = ds.find((x) => x.tag === tag && x.ordinal === ordinal)
+  if (!d) throw new Error(`no ${tag}#${ordinal}`)
+  const role = roleOf(d)
+  return {
+    type: "ElementSelector",
+    tag: d.tag,
+    role,
+    id: d.id,
+    fingerprint: fingerprintOf(d),
+    ordinal: d.ordinal,
+    docFraction: d.srcFraction,
+    before: ds[d.index - 1]?.text,
+    after: ds[d.index + 1]?.text,
+    snapshot: { tag: d.tag, label: elementLabel({ ...d, role }) },
+  }
+}
 
 describe("comments + the loop", () => {
   let shortId: string
@@ -292,5 +314,76 @@ describe("@mentions + in-app notifications", () => {
     } finally {
       await reader.cancel()
     }
+  })
+})
+
+describe("element anchors (non-text) through publish + sweep", () => {
+  const page = (img: string) =>
+    `<!doctype html><html><body><p>Intro</p>${img}<p>Outro</p></body></html>`
+  const byState = async (sid: string, state: string) =>
+    (await (await app.request(`/v1/artifacts/${sid}/comments?state=${state}`)).json()).comments
+
+  it("flags an element anchor resolved, and orphaned when the element is removed", async () => {
+    const v1 = page(`<img id="hero" src="/a.png" alt="Hero chart">`)
+    const sid = (await (await upload("e.html", v1, { title: "E" })).json()).short_id
+    const anchor = elSelFor(v1, "img")
+    await app.request(`/v1/artifacts/${sid}/comments`, json({ body_md: "fix this image", anchor }))
+
+    let list = await (await app.request(`/v1/artifacts/${sid}/comments`)).json()
+    expect(list.comments[0].anchored).toBe(true)
+    // The webhook/quote referent is the snapshot label, not a text quote.
+    expect(JSON.parse(list.comments[0].anchor).snapshot.label).toBe("Image — Hero chart")
+
+    // Remove the image entirely → no forward-walk can recover it → orphaned/outdated.
+    await upload("e.html", page(""), {}, sid)
+    expect(await byState(sid, "open")).toHaveLength(0)
+    expect(await byState(sid, "outdated")).toHaveLength(1)
+    list = await (await app.request(`/v1/artifacts/${sid}/comments`)).json()
+    expect(list.comments[0].anchored).toBe(false)
+    // The preserved snapshot still describes what it pointed at.
+    expect(JSON.parse(list.comments[0].anchor).snapshot.label).toBe("Image — Hero chart")
+  })
+
+  it("survives an id rename via the content fingerprint (one-jump)", async () => {
+    const v1 = page(`<img id="A" src="/x.png" alt="hero">`)
+    const sid = (await (await upload("e.html", v1, { title: "E" })).json()).short_id
+    await app.request(
+      `/v1/artifacts/${sid}/comments`,
+      json({ body_md: "on the image", anchor: elSelFor(v1, "img") }),
+    )
+    // id changes but src+alt (the fingerprint) hold → resolves directly, stays open.
+    await upload("e.html", page(`<img id="B" src="/x.png" alt="hero">`), {}, sid)
+    expect(await byState(sid, "outdated")).toHaveLength(0)
+    expect(await byState(sid, "open")).toHaveLength(1)
+  })
+
+  it("forward-walks recovery across versions where no single signal survives end-to-end", async () => {
+    // The comment is made on v1. Across v2..v4 the id and the content (src+alt) each
+    // change, but never both in the same step — so every hop keeps ONE strong signal
+    // while v1→v4 shares neither. One-jump resolution fails; the forward-walk recovers
+    // it and self-heals the stored selector.
+    const v1 = page(`<img id="A" src="/1.png" alt="hero one">`)
+    const sid = (await (await upload("e.html", v1, { title: "E" })).json()).short_id
+    await app.request(
+      `/v1/artifacts/${sid}/comments`,
+      json({ body_md: "on the hero", anchor: elSelFor(v1, "img") }),
+    )
+    // v2: id A kept, content changes. v3: content kept, id → B. v4: id B kept, content changes.
+    await upload("e.html", page(`<img id="A" src="/2.png" alt="hero two">`), {}, sid)
+    await upload("e.html", page(`<img id="B" src="/2.png" alt="hero two">`), {}, sid)
+    await upload("e.html", page(`<img id="B" src="/3.png" alt="hero three">`), {}, sid)
+
+    // Recovered, not orphaned.
+    expect(await byState(sid, "outdated")).toHaveLength(0)
+    expect(await byState(sid, "open")).toHaveLength(1)
+
+    // Self-healed: the stored selector now matches the current element (id B, /3.png)
+    // and still resolves against the current version.
+    const list = await (await app.request(`/v1/artifacts/${sid}/comments`)).json()
+    const healed = JSON.parse(list.comments[0].anchor)
+    expect(healed.id).toBe("B")
+    expect(list.comments[0].anchored).toBe(true)
+    // The original snapshot rode through the recovery.
+    expect(healed.snapshot.label).toBe("Image — hero one")
   })
 })

--- a/apps/api/test/helpers.ts
+++ b/apps/api/test/helpers.ts
@@ -324,9 +324,17 @@ export const bearer = (token: string) => ({ authorization: `Bearer ${token}` })
 // A fresh app with custom deps, always SECURED by a static token (anonymous
 // callers can't write). `pub(app, …)` with no headers authenticates as that
 // token; with `users`, an `x-test-user` header picks a session, for per-actor
-// tests.
-export const quotaApp = (name: string, extra: Partial<AppDeps>, users?: TestUser[]) => {
-  const m = makeStore(name, users ?? [])
+// tests. Pass `team` to seed the shared "default" workspace + memberships inside
+// the store's `ready` step (awaited before any request runs) — the only race-free
+// way under Postgres, where firing `meta.setMembership(...)` un-awaited from a test
+// body lets `activeWorkspace` read `listWorkspaces` before the write commits.
+export const quotaApp = (
+  name: string,
+  extra: Partial<AppDeps>,
+  users?: TestUser[],
+  team: Seat[] = [],
+) => {
+  const m = makeStore(name, users ?? [], team)
   const app = createApp({
     meta: m,
     blobs: new FsBlobStore(join(dir, `blobs-${name}`)),

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -9,8 +9,11 @@ const owner: TestUser = { id: "u-o", email: "o@x.com", name: "O", username: "o" 
 const editor: TestUser = { id: "u-e", email: "e@x.com", name: "E", username: "e" }
 
 // Build an app with Slack configured + an owner/editor team. quotaApp wires fake auth
-// (x-test-user header → session) and the custom deps; we seed the memberships so the
-// admin gate (workspaceCan) resolves.
+// (x-test-user header → session) and the custom deps. The memberships are seeded
+// through quotaApp's `team` arg (4th) so they land inside the store's awaited `ready`
+// step — firing meta.setMembership(...) un-awaited here would race activeWorkspace's
+// listWorkspaces lookup under Postgres, falling through to provisionPersonal and
+// resolving the wrong org (the flaky 404s / stale installs this suite saw).
 const make = (name: string) => {
   const { app, meta } = quotaApp(
     name,
@@ -20,10 +23,11 @@ const make = (name: string) => {
       slack: { clientId: "cid", clientSecret: "csec", signingSecret: SIGNING },
     },
     [owner, editor],
+    [
+      { user_id: owner.id, role: "owner" },
+      { user_id: editor.id, role: "editor" },
+    ],
   )
-  meta.setWorkspace("default", "W")
-  meta.setMembership({ id: "m-o", org_id: "default", user_id: owner.id, role: "owner" })
-  meta.setMembership({ id: "m-e", org_id: "default", user_id: editor.id, role: "editor" })
   return { app, meta }
 }
 

--- a/apps/web/src/pages/artifact/artifact-comments.tsx
+++ b/apps/web/src/pages/artifact/artifact-comments.tsx
@@ -6,7 +6,7 @@ import { MobileComments, OpenPanel } from "./comment-panels"
 import { CommentScopeProvider } from "./lib/comment-scope"
 import { clamp } from "./lib/layout"
 import { Rail } from "./rail-deck"
-import type { Panel, PinItem, Sel } from "./types"
+import { type Panel, type PinItem, type Sel, selLabel } from "./types"
 
 type Composer = { anchor: Sel | null; top: number | null } | null
 type Selection = {
@@ -208,7 +208,9 @@ export function ArtifactComments(p: {
           className="fixed inset-x-0 bottom-0 z-[62] flex items-center gap-2.5 border-t border-border bg-card px-3 pb-[max(16px,env(safe-area-inset-bottom))] pt-4 shadow-[0_-12px_36px_-16px_rgba(0,0,0,0.55)]"
         >
           <span className="min-w-0 flex-1 truncate border-l-[3px] border-primary bg-accent px-2.5 py-1.5 text-xs italic text-foreground">
-            “{sel.selector.exact}”
+            {sel.selector.type === "ElementSelector"
+              ? selLabel(sel.selector)
+              : `“${selLabel(sel.selector) ?? ""}”`}
           </span>
           <button
             type="button"

--- a/apps/web/src/pages/artifact/artifact-comments.tsx
+++ b/apps/web/src/pages/artifact/artifact-comments.tsx
@@ -61,6 +61,8 @@ export function ArtifactComments(p: {
    *  Used by comment cards to show a "Slide N" / "moved" badge. */
   currentSlide?: number | null
   landedSlides?: Record<string, number | null>
+  /** Per-thread element-anchor resolution quality for the quiet "moved" marker. */
+  anchorConf?: Record<string, { band: "high" | "medium" | "low"; confidence: number }>
 }) {
   const { isMobile, isAnon, canComment, panel, sel } = p
   // Focus primer: tapping "Comment" focuses this synchronously, inside the tap
@@ -85,6 +87,7 @@ export function ArtifactComments(p: {
         canComment,
         currentSlide: p.currentSlide,
         landedSlides: p.landedSlides,
+        anchorConf: p.anchorConf,
       }}
     >
       {isMobile && canComment && (

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -13,7 +13,7 @@ import {
 } from "./comment-thread"
 import { useCommentScope } from "./lib/comment-scope"
 import { IconBtn } from "./rail-deck"
-import type { PinItem, Sel } from "./types"
+import { type PinItem, type Sel, selLabel } from "./types"
 
 export function MobileComments({
   open,
@@ -186,7 +186,7 @@ export function MobileComments({
           // reappears once you send or cancel.
           <div className="overflow-auto p-3 pb-[max(14px,env(safe-area-inset-bottom))]">
             <Composer
-              quote={composer.anchor?.exact ?? null}
+              quote={selLabel(composer.anchor)}
               // After posting, open the full list so the new comment is visible (the
               // sheet would otherwise drop back to the peek bar and hide it).
               onSubmit={(text, mentions) => {

--- a/apps/web/src/pages/artifact/comment-thread.tsx
+++ b/apps/web/src/pages/artifact/comment-thread.tsx
@@ -5,8 +5,8 @@ import { cn } from "@/lib/utils"
 import { Composer, MentionField } from "./comment-composer"
 import { CommentRow } from "./comment-row"
 import { useCommentScope } from "./lib/comment-scope"
-import { anchorExact, COMPOSER_ID, layoutPins, parseAnchor } from "./lib/layout"
-import type { PinItem, Sel } from "./types"
+import { COMPOSER_ID, layoutPins, parseAnchor } from "./lib/layout"
+import { type ElementSnapshotLite, type PinItem, type Sel, selLabel } from "./types"
 
 // Composer is consumed by comment-panels through this module; re-export so its
 // import path is unchanged now that it lives in comment-composer.
@@ -75,7 +75,7 @@ export function PinnedZone({
   // exactly when there's an anchored composer with a resolved position.
   const activeComposer =
     composer?.anchor && composer.top != null
-      ? { top: composer.top, quote: composer.anchor.exact ?? null }
+      ? { top: composer.top, quote: selLabel(composer.anchor) }
       : null
   const items = pins.flatMap((p) => {
     const head = p.thread[0]
@@ -171,6 +171,103 @@ export function PinnedZone({
   )
 }
 
+// A small glyph standing in for an element's role on the comment card.
+const ROLE_GLYPH: Record<string, string> = {
+  image: "🖼",
+  chart: "📊",
+  media: "🎬",
+  embed: "🔗",
+  table: "▦",
+  code: "{ }",
+  figure: "🖼",
+  block: "❖",
+}
+
+/**
+ * The reference chip for an element anchor. When the element is present, it's a
+ * jump button (scroll to + flash the outline). When it's gone — edited or removed
+ * in this version — it falls back to the preserved SNAPSHOT (a thumbnail for
+ * images, else a tag chip) so the orphaned comment still shows what it pointed at.
+ */
+function ElementRef({
+  threadId,
+  label,
+  snapshot,
+  present,
+  onJump,
+}: {
+  threadId: string
+  label: string
+  snapshot?: ElementSnapshotLite
+  present: boolean
+  onJump: (id: string) => void
+}) {
+  const glyph = ROLE_GLYPH[snapshot?.tag === "table" ? "table" : roleGuess(snapshot, label)] ?? "❖"
+  if (present) {
+    return (
+      <button
+        type="button"
+        data-testid={`comment-jump-${threadId}`}
+        onClick={(e) => {
+          e.stopPropagation()
+          onJump(threadId)
+        }}
+        title="Jump to the element"
+        className="flex w-full cursor-pointer items-center gap-1.5 border-l-[3px] border-primary bg-accent px-2.5 py-1.5 text-left text-xs font-medium text-foreground"
+      >
+        <span aria-hidden className="shrink-0 text-sm leading-none">
+          {glyph}
+        </span>
+        <span className="truncate">{label}</span>
+      </button>
+    )
+  }
+  // Orphaned: show the snapshot so the comment keeps its referent.
+  const thumb = snapshot?.src
+  return (
+    <div
+      title="The element this comment was attached to was edited or removed in this version"
+      data-testid={`comment-orphan-${threadId}`}
+      className="flex w-full items-center gap-2 border-l-[3px] border-border bg-secondary px-2.5 py-1.5 text-left text-xs text-muted-foreground"
+    >
+      {thumb ? (
+        <img
+          src={thumb}
+          alt=""
+          className="size-9 shrink-0 rounded border border-border object-cover"
+          onError={(e) => {
+            e.currentTarget.style.display = "none"
+          }}
+        />
+      ) : (
+        <span
+          aria-hidden
+          className="grid size-9 shrink-0 place-items-center rounded border border-border bg-card text-sm"
+        >
+          {glyph}
+        </span>
+      )}
+      <span className="min-w-0">
+        <span className="block truncate font-medium italic text-foreground">{label}</span>
+        <span className="block text-2xs">removed in this version</span>
+      </span>
+    </div>
+  )
+}
+
+// Best-effort role from a snapshot tag (for the glyph) without re-deriving the role.
+function roleGuess(snapshot: ElementSnapshotLite | undefined, label: string): string {
+  const tag = snapshot?.tag ?? ""
+  if (tag === "img" || tag === "picture") return "image"
+  if (tag === "svg" || tag === "canvas") return "chart"
+  if (tag === "video" || tag === "audio") return "media"
+  if (tag === "iframe" || tag === "embed" || tag === "object") return "embed"
+  if (tag === "table") return "table"
+  if (tag === "pre" || tag === "code") return "code"
+  if (tag === "figure") return "figure"
+  return /chart|graph|plot/i.test(label) ? "chart" : "block"
+}
+
 // One comment thread. Compact until activated; the active card shows the full
 // thread, a reply box, and resolve controls.
 export function CommentCard({
@@ -208,14 +305,18 @@ export function CommentCard({
   const resolved = root.state === "resolved"
   const outdated = root.state === "outdated"
   const addressed = root.state === "addressed"
-  const quote = anchorExact(root.anchor)
+  const parsed = parseAnchor(root.anchor)
+  const isEl = !!parsed?.element
+  // The reference label: a text quote, or an element's snapshot label.
+  const refLabel = parsed?.exact ?? parsed?.label ?? null
+  const snapshot = parsed?.element?.snapshot
   const textPresent = present !== undefined ? present : root.anchored !== false
   const replies = thread.length - 1
   // Deck context (from CommentScope): the slide this comment belongs to — where its
   // text resolved (landed), else the slide it was written on — and whether the text
   // has since moved to a different slide than it was anchored on.
   const onDeck = currentSlide != null
-  const recordedSlide = parseAnchor(root.anchor)?.slide
+  const recordedSlide = parsed?.slide
   const landedSlide = landedSlides?.[root.thread_id]
   const slideNum = landedSlide != null ? landedSlide : recordedSlide
   const slideMoved = recordedSlide != null && landedSlide != null && landedSlide !== recordedSlide
@@ -257,28 +358,38 @@ export function CommentCard({
           )}
         </div>
       )}
-      {quote &&
-        (textPresent && !resolved ? (
-          <button
-            type="button"
-            data-testid={`comment-jump-${root.thread_id}`}
-            onClick={(e) => {
-              e.stopPropagation()
-              onJump(root.thread_id)
-            }}
-            title="Jump to the highlighted text"
-            className="block w-full cursor-pointer truncate border-l-[3px] border-primary bg-accent px-2.5 py-1.5 text-left text-xs italic text-foreground"
-          >
-            “{quote}”
-          </button>
-        ) : (
-          <div
-            title="The text this comment was attached to was edited or removed in this version"
-            className="block w-full truncate border-l-[3px] border-border bg-secondary px-2.5 py-1.5 text-left text-xs italic text-muted-foreground"
-          >
-            “{quote}”
-          </div>
-        ))}
+      {isEl
+        ? refLabel && (
+            <ElementRef
+              threadId={root.thread_id}
+              label={refLabel}
+              snapshot={snapshot}
+              present={textPresent && !resolved}
+              onJump={onJump}
+            />
+          )
+        : refLabel &&
+          (textPresent && !resolved ? (
+            <button
+              type="button"
+              data-testid={`comment-jump-${root.thread_id}`}
+              onClick={(e) => {
+                e.stopPropagation()
+                onJump(root.thread_id)
+              }}
+              title="Jump to the highlighted text"
+              className="block w-full cursor-pointer truncate border-l-[3px] border-primary bg-accent px-2.5 py-1.5 text-left text-xs italic text-foreground"
+            >
+              “{refLabel}”
+            </button>
+          ) : (
+            <div
+              title="The text this comment was attached to was edited or removed in this version"
+              className="block w-full truncate border-l-[3px] border-border bg-secondary px-2.5 py-1.5 text-left text-xs italic text-muted-foreground"
+            >
+              “{refLabel}”
+            </div>
+          ))}
 
       {!active ? (
         <>
@@ -348,12 +459,16 @@ export function CommentCard({
             >
               {resolved ? "resolved" : outdated ? "outdated" : addressed ? "addressed" : "open"}
             </span>
-            {quote && !textPresent && !resolved && !outdated && !addressed && (
+            {refLabel && !textPresent && !resolved && !outdated && !addressed && (
               <span
-                title="The text this comment was attached to was edited or removed in this version"
+                title={
+                  isEl
+                    ? "The element this comment was attached to was edited or removed in this version"
+                    : "The text this comment was attached to was edited or removed in this version"
+                }
                 className="rounded-full bg-accent px-2 py-0.5 font-mono text-2xs font-bold text-primary"
               >
-                text changed
+                {isEl ? "element changed" : "text changed"}
               </span>
             )}
             <Button

--- a/apps/web/src/pages/artifact/comment-thread.tsx
+++ b/apps/web/src/pages/artifact/comment-thread.tsx
@@ -194,12 +194,15 @@ function ElementRef({
   label,
   snapshot,
   present,
+  relocated,
   onJump,
 }: {
   threadId: string
   label: string
   snapshot?: ElementSnapshotLite
   present: boolean
+  /** The element resolved, but at less than full confidence — it likely moved. */
+  relocated?: boolean
   onJump: (id: string) => void
 }) {
   const glyph = ROLE_GLYPH[snapshot?.tag === "table" ? "table" : roleGuess(snapshot, label)] ?? "❖"
@@ -212,13 +215,23 @@ function ElementRef({
           e.stopPropagation()
           onJump(threadId)
         }}
-        title="Jump to the element"
+        title={relocated ? "Jump to the element (moved — approximate)" : "Jump to the element"}
         className="flex w-full cursor-pointer items-center gap-1.5 border-l-[3px] border-primary bg-accent px-2.5 py-1.5 text-left text-xs font-medium text-foreground"
       >
         <span aria-hidden className="shrink-0 text-sm leading-none">
           {glyph}
         </span>
         <span className="truncate">{label}</span>
+        {relocated && (
+          // A minor, muted "moved" marker — a small dot + word, not an alarm.
+          <span
+            data-testid={`comment-moved-${threadId}`}
+            className="ml-auto inline-flex shrink-0 items-center gap-1 rounded-full bg-secondary px-1.5 py-px font-mono text-2xs font-medium text-muted-foreground"
+          >
+            <span aria-hidden className="size-1.5 rounded-full bg-primary/60" />
+            moved
+          </span>
+        )}
       </button>
     )
   }
@@ -291,7 +304,7 @@ export function CommentCard({
   onReply: (text: string, threadId: string, mentions?: Mention[]) => void
   onJump: (id: string) => void
 }) {
-  const { canComment, currentSlide, landedSlides } = useCommentScope()
+  const { canComment, currentSlide, landedSlides, anchorConf } = useCommentScope()
   const [reply, setReply] = useState("")
   const [replyMentions, setReplyMentions] = useState<Mention[]>([])
   const root = thread[0]
@@ -311,6 +324,10 @@ export function CommentCard({
   const refLabel = parsed?.exact ?? parsed?.label ?? null
   const snapshot = parsed?.element?.snapshot
   const textPresent = present !== undefined ? present : root.anchored !== false
+  // An element that resolved at less than full confidence relocated — show a quiet
+  // "moved" marker on its chip. High-confidence (or text) anchors show nothing.
+  const elBand = isEl ? anchorConf?.[root.thread_id]?.band : undefined
+  const relocated = isEl && textPresent && (elBand === "low" || elBand === "medium")
   const replies = thread.length - 1
   // Deck context (from CommentScope): the slide this comment belongs to — where its
   // text resolved (landed), else the slide it was written on — and whether the text
@@ -365,6 +382,7 @@ export function CommentCard({
               label={refLabel}
               snapshot={snapshot}
               present={textPresent && !resolved}
+              relocated={relocated}
               onJump={onJump}
             />
           )

--- a/apps/web/src/pages/artifact/comment-thread.tsx
+++ b/apps/web/src/pages/artifact/comment-thread.tsx
@@ -235,8 +235,11 @@ function ElementRef({
       </button>
     )
   }
-  // Orphaned: show the snapshot so the comment keeps its referent.
-  const thumb = snapshot?.src
+  // Orphaned: show the snapshot so the comment keeps its referent. The src is
+  // comment-author-controlled and this card renders in the trusted host app (not the
+  // sandboxed iframe), so only render an http(s) thumbnail — never data:/blob:/
+  // javascript: or a protocol-relative URL — falling back to the role glyph otherwise.
+  const thumb = isSafeThumb(snapshot?.src) ? snapshot?.src : undefined
   return (
     <div
       title="The element this comment was attached to was edited or removed in this version"
@@ -266,6 +269,18 @@ function ElementRef({
       </span>
     </div>
   )
+}
+
+// Only a plain http(s) URL is safe to render as a thumbnail in the host app — the
+// snapshot src is comment-author-controlled, so reject data:/blob:/javascript:/
+// protocol-relative and anything that isn't an absolute http(s) URL.
+function isSafeThumb(src: string | undefined): boolean {
+  if (!src) return false
+  try {
+    return /^https?:$/.test(new URL(src).protocol)
+  } catch {
+    return false
+  }
 }
 
 // Best-effort role from a snapshot tag (for the glyph) without re-deriving the role.

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -311,7 +311,12 @@ export function Artifact() {
     if (!head) continue
     const id = head.thread_id
     const a = parseAnchor(head.anchor)
-    const present = inDoc[id] !== false
+    // Does this thread's anchor resolve in the live doc? The frame reports `inDoc`
+    // for the anchors it was sent (open/addressed). An `outdated` thread is NOT sent
+    // to the frame, so `inDoc[id]` is undefined — fall back to the server's `anchored`
+    // flag rather than defaulting to "present" (which would pin it invisibly at
+    // opacity 0 instead of showing it as an orphan in the general list).
+    const present = id in inDoc ? inDoc[id] !== false : head.anchored !== false
     if (deck && a) {
       // Deck: a comment belongs to the slide its text actually resolved on (landed),
       // or, until that's known, the slide it was made on (recorded). Pin it only on

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -129,6 +129,7 @@ export function Artifact() {
     setSel,
     inDoc,
     landedSlides,
+    anchorConf,
     anchorTops,
     scrollY,
     docH,
@@ -617,6 +618,7 @@ export function Artifact() {
             startSelComment={startSelComment}
             currentSlide={deck?.i ?? null}
             landedSlides={landedSlides}
+            anchorConf={anchorConf}
           />
         </div>
       </ActionsCtx.Provider>

--- a/apps/web/src/pages/artifact/lib/comment-scope.ts
+++ b/apps/web/src/pages/artifact/lib/comment-scope.ts
@@ -18,6 +18,9 @@ const CommentScopeContext = createContext<{
   currentSlide?: number | null
   /** Per-thread: the slide its anchor resolved on (null = outside any slide). */
   landedSlides?: Record<string, number | null>
+  /** Per-thread element-anchor resolution quality, so a card can show a quiet
+   *  "moved" marker when its element relocated with less than full confidence. */
+  anchorConf?: Record<string, { band: "high" | "medium" | "low"; confidence: number }>
 }>({
   shortId: null,
   canComment: true,

--- a/apps/web/src/pages/artifact/lib/layout.test.ts
+++ b/apps/web/src/pages/artifact/lib/layout.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import type { Comment } from "@/api"
-import { anchorExact, clamp, groupThreads, layoutPins, parseAnchor } from "./layout"
+import { anchorExact, anchorLabel, clamp, groupThreads, layoutPins, parseAnchor } from "./layout"
 
 describe("clamp", () => {
   it("bounds a value to [lo, hi]", () => {
@@ -69,6 +69,39 @@ describe("parseAnchor / anchorExact", () => {
     const a = JSON.stringify({ exact: "hello", prefix: "say ", suffix: "!" })
     expect(parseAnchor(a)).toEqual({ exact: "hello", prefix: "say ", suffix: "!" })
     expect(anchorExact(a)).toBe("hello")
+  })
+
+  it("parses an element anchor into { element, label, slide }", () => {
+    const a = JSON.stringify({
+      type: "ElementSelector",
+      tag: "img",
+      fingerprint: "abc",
+      slide: 2,
+      snapshot: { tag: "img", label: "Image — chart.png" },
+    })
+    const p = parseAnchor(a)
+    expect(p?.element?.tag).toBe("img")
+    expect(p?.label).toBe("Image — chart.png")
+    expect(p?.slide).toBe(2)
+    expect(p?.exact).toBeUndefined()
+    // anchorExact is text-only → null for an element; anchorLabel returns the label.
+    expect(anchorExact(a)).toBeNull()
+    expect(anchorLabel(a)).toBe("Image — chart.png")
+  })
+
+  it("falls back to 'Element' when an element anchor has no snapshot label", () => {
+    const a = JSON.stringify({ type: "ElementSelector", tag: "table", fingerprint: "z" })
+    expect(parseAnchor(a)?.label).toBe("Element")
+  })
+
+  it("an ElementSelector missing tag/fingerprint is not treated as an element anchor", () => {
+    // No exact and not a valid element → null.
+    expect(parseAnchor(JSON.stringify({ type: "ElementSelector", tag: "img" }))).toBeNull()
+  })
+
+  it("anchorLabel returns the quote for text, the label for elements, null otherwise", () => {
+    expect(anchorLabel(JSON.stringify({ exact: "hi" }))).toBe("hi")
+    expect(anchorLabel(null)).toBeNull()
   })
 })
 

--- a/apps/web/src/pages/artifact/lib/layout.ts
+++ b/apps/web/src/pages/artifact/lib/layout.ts
@@ -1,6 +1,25 @@
 import type { Comment } from "@/api"
+import type { ElementSnapshotLite } from "../types"
 
 export const COMPOSER_ID = "__composer__"
+
+// The element-anchor selector as it crosses to the iframe client (`anchors` msg).
+// Mirrors core's ElementSelector; the snapshot rides along (display only — the
+// client doesn't need it to resolve).
+export type ElementWire = {
+  type: "ElementSelector"
+  tag: string
+  role?: string
+  id?: string
+  css?: string
+  fingerprint: string
+  ordinal: number
+  docFraction: number
+  before?: string
+  after?: string
+  slide?: number
+  snapshot?: ElementSnapshotLite
+}
 
 export const clamp = (n: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, n))
 
@@ -52,16 +71,28 @@ export function layoutPins(
   return pos
 }
 
-export function parseAnchor(
-  a: string | null,
-): { exact: string; prefix?: string; suffix?: string; slide?: number } | null {
+// A parsed anchor — text (a quote) or element (a non-text selector). Both may carry
+// a `slide` (decks). `label` is the display string for either; `element` is set for
+// element anchors (and fed to the iframe client to relocate the element).
+export type ParsedAnchor = {
+  exact?: string
+  prefix?: string
+  suffix?: string
+  slide?: number
+  element?: ElementWire
+  label?: string
+}
+
+export function parseAnchor(a: string | null): ParsedAnchor | null {
   if (!a) return null
   try {
-    const s = JSON.parse(a) as {
+    const s = JSON.parse(a) as ElementWire & {
       exact?: string
       prefix?: string
       suffix?: string
-      slide?: number
+    }
+    if (s.type === "ElementSelector" && s.fingerprint && s.tag) {
+      return { element: s, label: s.snapshot?.label ?? "Element", slide: s.slide }
     }
     return s.exact ? { exact: s.exact, prefix: s.prefix, suffix: s.suffix, slide: s.slide } : null
   } catch {
@@ -69,7 +100,14 @@ export function parseAnchor(
   }
 }
 
+/** Text quote of an anchor (null for element / unanchored) — the strict text path. */
 export const anchorExact = (a: string | null): string | null => parseAnchor(a)?.exact ?? null
+
+/** Display label for an anchor — the quote for text, the snapshot label for an element. */
+export const anchorLabel = (a: string | null): string | null => {
+  const p = parseAnchor(a)
+  return p?.exact ?? p?.label ?? null
+}
 
 export function groupThreads(comments: Comment[]): Comment[][] {
   const map = new Map<string, Comment[]>()

--- a/apps/web/src/pages/artifact/types.ts
+++ b/apps/web/src/pages/artifact/types.ts
@@ -1,14 +1,41 @@
 import type { Comment } from "@/api"
 
-// A text-anchor selection in the document (the structural quote a comment pins to).
-// `slide` is set only on deck artifacts — the 0-based slide the selection was on.
+// What a non-text anchor looked like when the comment was made — shown when the
+// live element can no longer be found, so an orphaned comment keeps its referent.
+export type ElementSnapshotLite = {
+  tag: string
+  label: string
+  text?: string
+  src?: string
+  alt?: string
+  w?: number
+  h?: number
+  html?: string
+}
+
+// A selection a comment pins to. Two shapes share this type:
+//  - text  : a structural quote (`exact` + context). `slide` is set on decks only.
+//  - element: a non-text anchor (`type === "ElementSelector"`) carrying the cascade
+//             signals + a `snapshot`. `exact` is absent; use `selLabel` for display.
 export type Sel = {
   type?: string
-  exact: string
+  exact?: string
   prefix?: string
   suffix?: string
   slide?: number
+  // element-anchor fields (present when type === "ElementSelector")
+  role?: string
+  fingerprint?: string
+  snapshot?: ElementSnapshotLite
 }
+
+/** True if a selection pins to a non-text element rather than a quote. */
+export const isElementSel = (s: Sel | null | undefined): boolean => s?.type === "ElementSelector"
+
+/** The human label to show for a selection — the quote for text, the snapshot
+ *  label (e.g. "Image — chart.png") for an element. */
+export const selLabel = (s: Sel | null | undefined): string | null =>
+  s?.exact ?? s?.snapshot?.label ?? null
 
 // Comments UI mode: full panel, collapsed rail of dots, or hidden.
 export type Panel = "open" | "rail" | "hidden"

--- a/apps/web/src/pages/artifact/use-artifact-frame.ts
+++ b/apps/web/src/pages/artifact/use-artifact-frame.ts
@@ -199,14 +199,20 @@ export function useArtifactFrame(p: {
       .filter((head): head is Comment => head?.state === "open" || head?.state === "addressed")
       .map((head) => ({ id: head.thread_id, sel: parseAnchor(head.anchor) }))
       .filter((x): x is { id: string; sel: NonNullable<ReturnType<typeof parseAnchor>> } => !!x.sel)
-      .map((x) => ({
-        id: x.id,
-        exact: x.sel.exact,
-        prefix: x.sel.prefix,
-        suffix: x.sel.suffix,
-        // The frame scopes resolution to this slide first (deck artifacts only).
-        slide: x.sel.slide,
-      }))
+      .map((x) =>
+        // Element anchor: hand the client the whole selector to relocate via the
+        // cascade. Text anchor: the quote + context it greps for.
+        x.sel.element
+          ? { id: x.id, el: x.sel.element }
+          : {
+              id: x.id,
+              exact: x.sel.exact,
+              prefix: x.sel.prefix,
+              suffix: x.sel.suffix,
+              // The frame scopes resolution to this slide first (deck artifacts only).
+              slide: x.sel.slide,
+            },
+      )
     w.postMessage({ source: "dock-host", type: "anchors", anchors }, "*")
   }, [comments])
   // biome-ignore lint/correctness/useExhaustiveDependencies: frameReady is an intentional repaint trigger (re-send anchors when the iframe reloads).

--- a/apps/web/src/pages/artifact/use-artifact-frame.ts
+++ b/apps/web/src/pages/artifact/use-artifact-frame.ts
@@ -52,6 +52,11 @@ export function useArtifactFrame(p: {
   // or non-deck). The frame reports this so a comment pins on the slide its text
   // really lives on — even after a republish moved the text to a different slide.
   const [landedSlides, setLandedSlides] = useState<Record<string, number | null>>({})
+  // Per-thread element-anchor resolution quality (band + confidence), reported by
+  // the frame so a card can show a quiet "moved" marker on an uncertain relocation.
+  const [anchorConf, setAnchorConf] = useState<
+    Record<string, { band: "high" | "medium" | "low"; confidence: number }>
+  >({})
   const [anchorTops, setAnchorTops] = useState<Record<string, number>>({})
   const [scrollY, setScrollY] = useState(0)
   // The frame's own document height + visible height, reported alongside scroll.
@@ -112,6 +117,9 @@ export function useArtifactFrame(p: {
         // Older clients omit `slides`; default to empty so the page falls back to
         // each comment's recorded slide.
         setLandedSlides(d.slides ?? {})
+        // Element anchors report per-thread resolution quality (band/confidence) so
+        // a card can flag a relocation; text/older clients omit it.
+        setAnchorConf(d.conf ?? {})
       } else if (d.type === "anchor-rects") {
         setAnchorTops(d.tops ?? {})
         if (typeof d.scrollY === "number") setScrollY(d.scrollY)
@@ -169,6 +177,7 @@ export function useArtifactFrame(p: {
     deckRef.current = null
     setSel(null)
     setLandedSlides({})
+    setAnchorConf({})
   }, [shortId, version])
   // A slide flip toggles element visibility without a scroll or resize, so the
   // frame won't re-measure on its own — ping it to re-report highlight rects so the
@@ -233,6 +242,7 @@ export function useArtifactFrame(p: {
     setSel,
     inDoc,
     landedSlides,
+    anchorConf,
     anchorTops,
     scrollY,
     docH,

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -251,7 +251,7 @@ function buildElSelector(el){
 
 /* -- the in-browser cascade: score every candidate by signal agreement and pick
       the best over threshold (mirrors resolveElement in core) -- */
-function textClose(a,b){if(!a||!b)return false;var x=a.toLowerCase(),y=b.toLowerCase();
+function textClose(a,b){if(typeof a!=="string"||typeof b!=="string")return false;var x=a.toLowerCase(),y=b.toLowerCase();
   if(x===y)return true;var sh=x.length<y.length?x:y,lo=x.length<y.length?y:x;
   if(sh.length>=8&&lo.indexOf(sh)>=0)return true;
   var w=Math.min(16,sh.length);return w>=8&&lo.slice(0,w)===sh.slice(0,w)}

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -111,6 +111,14 @@ document.addEventListener("touchend",function(e){
   if(tMoved)return;
   var el=e.target;
   if(!el||!el.closest||el.closest("a,button,input,textarea,select,label,[data-dock-id]"))return;
+  /* touch has no hover, so the desktop chip never appears — a tap on a non-text media
+     element (image/chart/video/embed) is how you anchor a comment to it on mobile.
+     Text-ish containers (table/pre/figure cells) still fall through to block-tap. */
+  var ael=anchorEl(el);
+  if(ael&&/^(img|svg|canvas|video|audio|iframe|embed|object|picture)$/.test(ael.tagName.toLowerCase())){
+    var er=ael.getBoundingClientRect();tapGuard=Date.now();
+    post({type:"select",element:true,rect:{top:er.top,bottom:er.bottom,left:er.left,right:er.right},
+      selector:buildElSelector(ael)});return}
   var b=el.closest("p,li,h1,h2,h3,h4,h5,h6,blockquote,td,th,figcaption,dd,dt,pre");
   if(!b)return;
   var txt=(b.textContent||"").trim();

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -1,3 +1,4 @@
+import { elementResolvesIn, parseElementSelector } from "./element-anchor"
 import type { CommentState } from "./ports"
 
 /** A W3C Web Annotation TextQuoteSelector — survives republishing. */
@@ -147,8 +148,166 @@ var st=document.createElement("style");
 st.textContent="mark.dock-hl{background:rgba(124,108,189,.20);color:inherit;border-bottom:2px solid rgba(124,108,189,.5);border-radius:2px;cursor:pointer;transition:background .15s,border-color .15s}"+
 "mark.dock-hl:hover,mark.dock-hl.dock-hl-on{background:rgba(124,108,189,.42);border-bottom-color:rgba(124,108,189,.95)}"+
 "mark.dock-hl-flash{animation:dockflash 1s ease 2}"+
-"@keyframes dockflash{50%{background:rgba(124,108,189,.7)}}";
+"@keyframes dockflash{50%{background:rgba(124,108,189,.7)}}"+
+/* element overlays: a non-text anchor draws an outline box (pointer-events off so
+   the element stays interactive) with a clickable comment badge in its corner. A
+   low-confidence relocation reads dashed to signal "we think it moved here". */
+".dock-el-hl{position:absolute;pointer-events:none;border:2px solid rgba(124,108,189,.55);border-radius:4px;box-shadow:0 0 0 3px rgba(124,108,189,.12);transition:border-color .15s,box-shadow .15s;z-index:2147483640}"+
+".dock-el-hl.dock-el-low{border-style:dashed;border-color:rgba(124,108,189,.5)}"+
+".dock-el-hl.dock-el-on{border-color:rgba(124,108,189,.95);box-shadow:0 0 0 4px rgba(124,108,189,.22)}"+
+".dock-el-hl.dock-el-flash{animation:dockelflash 1s ease 2}"+
+"@keyframes dockelflash{50%{box-shadow:0 0 0 6px rgba(124,108,189,.4)}}"+
+".dock-el-badge{position:absolute;top:-11px;right:-11px;width:22px;height:22px;border-radius:11px;background:rgba(124,108,189,.95);color:#fff;font:600 12px/22px system-ui,sans-serif;text-align:center;pointer-events:auto;cursor:pointer;box-shadow:0 1px 4px rgba(0,0,0,.25)}"+
+/* the hover affordance: a small 'Comment' chip that follows the pointer over an
+   anchorable element; clicking it pins a comment to that element. */
+".dock-el-chip{position:absolute;display:none;align-items:center;gap:5px;padding:4px 9px;border-radius:7px;background:rgba(124,108,189,.97);color:#fff;font:600 12px/1 system-ui,sans-serif;pointer-events:auto;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.28);z-index:2147483641;white-space:nowrap}"+
+".dock-el-outline{position:absolute;display:none;pointer-events:none;border:2px dashed rgba(124,108,189,.6);border-radius:4px;z-index:2147483639}";
 (document.head||document.documentElement).appendChild(st);
+
+/* === Element anchors ========================================================
+   Pin a comment to a non-text element (image, chart, table, embed, code, figure).
+   We capture several independent signals and resolve by agreement — a cascade:
+   id -> css -> content fingerprint -> structural ordinal -> geometry -> neighbors.
+   fnv/nw/elFp MUST stay byte-identical with element-anchor.ts so a fingerprint
+   made here equals one made on the server. */
+function fnv(s){var h=0x811c9dc5;for(var i=0;i<s.length;i++){h^=s.charCodeAt(i);h=(h+((h<<1)+(h<<4)+(h<<7)+(h<<8)+(h<<24)))>>>0}return h.toString(36)}
+function nw(s){return (s||"").replace(/\\s+/g," ").trim()}
+function elSrc(el){return (el.getAttribute&&(el.getAttribute("src")||el.getAttribute("href")))||""}
+function elAlt(el){return (el.getAttribute&&(el.getAttribute("alt")||el.getAttribute("aria-label")||el.getAttribute("title")))||""}
+function elText(el){return nw(el.textContent||"")}
+function elFp(el){var tag=el.tagName.toLowerCase();return fnv([tag,elSrc(el),elAlt(el),elText(el).slice(0,120)].join(""))}
+function elOrdinal(el){var all=document.getElementsByTagName(el.tagName);
+  for(var i=0;i<all.length;i++){if(all[i]===el)return i}return 0}
+/* nearest preceding/following text block, in document order */
+var BLOCKS="p,li,h1,h2,h3,h4,h5,h6,blockquote,td,th,figcaption,dd,dt,pre";
+function neighborText(el){
+  var before=null,after=null,blocks=document.querySelectorAll(BLOCKS);
+  for(var i=0;i<blocks.length;i++){var b=blocks[i];if(el.contains(b)||b.contains(el))continue;
+    var t=nw(b.textContent||"");if(t.length<2)continue;
+    var pos=el.compareDocumentPosition(b);
+    if(pos&Node.DOCUMENT_POSITION_PRECEDING)before=t;          /* keep the last one before */
+    else if(pos&Node.DOCUMENT_POSITION_FOLLOWING){after=t;break}}
+  return {before:before,after:after}}
+/* structural css path of tag:nth-of-type up to a stable ancestor (authored id or body) */
+function cssPath(el){var parts=[],n=el;
+  for(var depth=0;n&&n.nodeType===1&&depth<8;depth++){
+    var tag=n.tagName.toLowerCase();
+    if(looksAuthoredId(n.id)){parts.unshift("#"+n.id);break}
+    if(tag==="body"){parts.unshift("body");break}
+    var k=1;for(var c=n.previousElementSibling;c;c=c.previousElementSibling)if(c.tagName===n.tagName)k++;
+    parts.unshift(tag+":nth-of-type("+k+")");n=n.parentNode}
+  return parts.join(">")}
+function looksAuthoredId(id){return !!id&&!/[0-9a-f]{8}|^[0-9]|^(radix|headlessui|react|mui|:r)/i.test(id)}
+var ANCHORABLE="img,picture,svg,canvas,video,audio,iframe,embed,object,table,pre,figure";
+function anchorEl(t){
+  if(!t||!t.closest)return null;
+  if(t.closest("[data-dock-id],.dock-el-chip,.dock-el-badge,a,button,input,textarea,select,label"))return null;
+  var el=t.closest(ANCHORABLE);
+  if(el)return el;
+  var div=t.closest("div,section,figure");
+  if(div&&/chart|graph|plot|viz|sparkline/i.test((div.className||"")+" "+(div.id||"")))return div;
+  return null}
+function roleOf(el){var tag=el.tagName.toLowerCase();
+  if(tag==="img"||tag==="picture")return "image";
+  if(tag==="video"||tag==="audio")return "media";
+  if(tag==="iframe"||tag==="embed"||tag==="object")return "embed";
+  if(tag==="table")return "table";if(tag==="pre"||tag==="code")return "code";
+  if(tag==="svg"||tag==="canvas")return "chart";if(tag==="figure")return "figure";
+  if(/chart|graph|plot|viz|sparkline/i.test((el.className||"")+" "+(el.id||"")))return "chart";
+  return "block"}
+function hostOf(u){var m=(u||"").match(/^https?:\\/\\/([^/]+)/i);return m?m[1].replace(/^www\\./,""):""}
+function trunc(s,n){return s.length>n?s.slice(0,n-1)+"\\u2026":s}
+function labelOf(el,role){var alt=nw(elAlt(el)),host=hostOf(elSrc(el));
+  if(role==="image")return alt?"Image \\u2014 "+trunc(alt,48):host?"Image \\u2014 "+host:"Image";
+  if(role==="chart")return alt?"Chart \\u2014 "+trunc(alt,48):"Chart";
+  if(role==="media")return el.tagName.toLowerCase()==="audio"?"Audio":host?"Video \\u2014 "+host:"Video";
+  if(role==="embed")return host?"Embedded \\u2014 "+host:"Embedded content";
+  if(role==="table")return "Table";if(role==="code")return "Code block";
+  if(role==="figure")return alt?"Figure \\u2014 "+trunc(alt,48):"Figure";
+  return trunc(elText(el)||el.tagName.toLowerCase(),48)||"Element"}
+function buildElSelector(el){
+  var tag=el.tagName.toLowerCase(),role=roleOf(el),nb=neighborText(el);
+  var r=el.getBoundingClientRect(),dh=document.documentElement.scrollHeight||1;
+  var id=looksAuthoredId(el.id)?el.id:undefined;
+  var html=(el.outerHTML||"");if(html.length>2000)html=html.slice(0,2000);
+  return {type:"ElementSelector",tag:tag,role:role,id:id,css:cssPath(el),
+    fingerprint:elFp(el),ordinal:elOrdinal(el),
+    docFraction:(r.top+scrollTop())/dh,before:nb.before||undefined,after:nb.after||undefined,
+    snapshot:{tag:tag,label:labelOf(el,role),text:trunc(elText(el),300)||undefined,
+      src:elSrc(el)||undefined,alt:nw(elAlt(el))||undefined,
+      w:Math.round(r.width)||undefined,h:Math.round(r.height)||undefined,html:html}}}
+
+/* -- the in-browser cascade: score every candidate by signal agreement and pick
+      the best over threshold (mirrors resolveElement in core) -- */
+function textClose(a,b){if(!a||!b)return false;var x=a.toLowerCase(),y=b.toLowerCase();
+  if(x===y)return true;var sh=x.length<y.length?x:y,lo=x.length<y.length?y:x;
+  if(sh.length>=8&&lo.indexOf(sh)>=0)return true;
+  var w=Math.min(16,sh.length);return w>=8&&lo.slice(0,w)===sh.slice(0,w)}
+function scoreEl(el,a){
+  var score=0,max=0,signals=[];
+  if(a.id){max+=5;if(el.id===a.id){score+=5;signals.push("id")}}
+  max+=5;if(elFp(el)===a.fingerprint){score+=5;signals.push("content")}
+  if(a.css){max+=3;if(cssPath(el)===a.css){score+=3;signals.push("css")}}
+  max+=3;if(el.tagName.toLowerCase()===a.tag){
+    if(elOrdinal(el)===a.ordinal){score+=3;signals.push("position")}else score+=1}
+  if(a.before||a.after){var nb=neighborText(el);
+    if(a.before){max+=1;if(textClose(a.before,nb.before)){score+=1;signals.push("nb")}}
+    if(a.after){max+=1;if(textClose(a.after,nb.after)){score+=1;signals.push("nb")}}}
+  max+=1;var r=el.getBoundingClientRect(),dh=document.documentElement.scrollHeight||1;
+  var f=(r.top+scrollTop())/dh;score+=1*(1-Math.min(1,Math.abs(f-(a.docFraction||0))));
+  return {c:max>0?score/max:0,signals:signals}}
+function resolveEl(a){
+  var cand=[],seen=[];
+  if(a.tag){var bt=document.getElementsByTagName(a.tag);for(var i=0;i<bt.length;i++){cand.push(bt[i]);seen.push(bt[i])}}
+  if(a.id){var byId=document.getElementById(a.id);if(byId&&seen.indexOf(byId)<0)cand.push(byId)}
+  var best=null,bestEl=null;
+  for(var j=0;j<cand.length;j++){var s=scoreEl(cand[j],a);
+    if(!best||s.c>best.c){best=s;bestEl=cand[j]}}
+  if(!best||best.c<0.42)return null;
+  var strong=best.signals.indexOf("id")>=0||best.signals.indexOf("content")>=0;
+  var band=strong&&best.c>=0.6?"high":(best.signals.indexOf("position")>=0||best.signals.indexOf("nb")>=0?"medium":"low");
+  return {el:bestEl,confidence:best.c,band:band,signals:best.signals}}
+
+/* overlay registry: each resolved element anchor gets an absolutely-positioned
+   outline (in document coords, so it glides with scroll) + a corner badge. */
+var elReg=[];
+function clearEls(){for(var i=0;i<elReg.length;i++){var o=elReg[i].ov;if(o&&o.parentNode)o.parentNode.removeChild(o)}elReg=[]}
+function paintEl(id,el,band){
+  var ov=document.createElement("div");ov.className="dock-el-hl"+(band==="low"?" dock-el-low":"");
+  ov.setAttribute("data-dock-id",id);
+  var badge=document.createElement("div");badge.className="dock-el-badge";badge.setAttribute("data-dock-id",id);
+  badge.textContent="\\uD83D\\uDCAC";badge.title="View comment";ov.appendChild(badge);
+  document.body.appendChild(ov);elReg.push({id:id,el:el,ov:ov})}
+function positionEls(){var sy=scrollTop(),sx=window.scrollX||0;
+  for(var i=0;i<elReg.length;i++){var e=elReg[i],r=e.el.getBoundingClientRect();
+    if(!(r.width||r.height)){e.ov.style.display="none";continue}
+    e.ov.style.display="block";e.ov.style.left=(r.left+sx)+"px";e.ov.style.top=(r.top+sy)+"px";
+    e.ov.style.width=r.width+"px";e.ov.style.height=r.height+"px"}}
+
+/* hover affordance: a 'Comment' chip parked at the top-right of the anchorable
+   element under the pointer; clicking it pins a comment to that element. */
+var chip=null,chipEl=null;
+function ensureChip(){if(chip)return chip;
+  chip=document.createElement("div");chip.className="dock-el-chip";chip.textContent="\\uD83D\\uDCAC Comment";
+  chip.addEventListener("click",function(ev){ev.preventDefault();ev.stopPropagation();
+    if(!chipEl)return;var el=chipEl,r=el.getBoundingClientRect();
+    /* the host stamps the deck slide onto the selector, same as the text path. */
+    post({type:"select",element:true,
+      rect:{top:r.top,bottom:r.bottom,left:r.left,right:r.right},
+      selector:buildElSelector(el)})});
+  document.body.appendChild(chip);return chip}
+function showChip(el){var c=ensureChip(),r=el.getBoundingClientRect();
+  chipEl=el;c.style.display="inline-flex";
+  c.style.left=(r.right+window.scrollX-Math.min(110,r.width))+"px";
+  c.style.top=(r.top+scrollTop()-10)+"px"}
+function hideChip(){if(chip){chip.style.display="none"}chipEl=null}
+document.addEventListener("mouseover",function(e){
+  var el=anchorEl(e.target);if(el)showChip(el)});
+document.addEventListener("mouseout",function(e){
+  /* keep the chip while the pointer is on the chip itself or still over the element */
+  var to=e.relatedTarget;
+  if(to&&to.closest&&(to.closest(".dock-el-chip")||anchorEl(to)===chipEl))return;
+  if(!anchorEl(e.target))return;hideChip()});
 
 function textNodes(root){
   var w=document.createTreeWalker(root||document.body,NodeFilter.SHOW_TEXT,{acceptNode:function(n){
@@ -196,15 +355,23 @@ function slideEls(){
 /* which slide an already-painted anchor landed in (its mark's nearest slide ancestor) */
 function slideOf(id,slides){
   var m=document.querySelector('mark[data-dock-id="'+id+'"]');
-  for(var s=m;s;s=s.parentElement){var k=slides.indexOf(s);if(k>=0)return k}
+  return slideOfEl(m,slides)}
+/* nearest slide ancestor of a DOM element (for element anchors) */
+function slideOfEl(el,slides){
+  for(var s=el;s;s=s.parentElement){var k=slides.indexOf(s);if(k>=0)return k}
   return null}
 
-/* doc-absolute top of each anchor's first highlight — the host pins cards to these */
+/* doc-absolute top of each anchor — text marks AND element overlays — so the host
+   pins each card beside whatever it points at */
 function reportRects(){
   var tops={},seen={},sy=scrollTop();
   var ms=document.querySelectorAll("mark[data-dock-id]");
   for(var i=0;i<ms.length;i++){var id=ms[i].getAttribute("data-dock-id");
     if(seen[id])continue;seen[id]=1;tops[id]=ms[i].getBoundingClientRect().top+sy}
+  positionEls();
+  for(var j=0;j<elReg.length;j++){var e=elReg[j];if(seen[e.id])continue;
+    if(e.ov.style.display==="none")continue;seen[e.id]=1;
+    tops[e.id]=e.el.getBoundingClientRect().top+sy}
   post({type:"anchor-rects",tops:tops,scrollY:sy,viewH:window.innerHeight,
     docH:document.documentElement.scrollHeight})}
 function reportScroll(){post({type:"scroll",scrollY:scrollTop(),viewH:window.innerHeight,docH:document.documentElement.scrollHeight})}
@@ -214,10 +381,24 @@ function reportScroll(){post({type:"scroll",scrollY:scrollTop(),viewH:window.inn
    search if the text has moved off that slide. Reports, per id, whether it resolved
    and which slide it actually landed in (null = outside any slide / non-deck). */
 function applyAnchors(anchors){
-  clearMarks();
-  var slides=slideEls(),resolved={},landed={};
+  clearMarks();clearEls();
+  var slides=slideEls(),resolved={},landed={},conf={};
   for(var k=0;k<anchors.length;k++){
-    var a=anchors[k],placed=false,where=null;
+    var a=anchors[k];
+    /* element anchor: a.el is the stored ElementSelector. Resolve via the cascade,
+       paint an outline overlay, and report confidence so the host can flag a
+       low-confidence relocation as "moved". */
+    if(a.el){
+      var m=resolveEl(a.el);
+      if(m){paintEl(a.id,m.el,m.band);resolved[a.id]=true;
+        landed[a.id]=slides.length?slideOfEl(m.el,slides):null;
+        conf[a.id]={confidence:m.confidence,band:m.band,signals:m.signals}}
+      else{resolved[a.id]=false;landed[a.id]=a.el.slide!=null?a.el.slide:null}
+      continue}
+    /* text anchor: scope a deck comment to its recorded slide FIRST (so the same
+       phrase on two slides can't collide), then fall back to a whole-document
+       search if the text moved off that slide. */
+    var placed=false,where=null;
     if(a.slide!=null&&slides[a.slide]){
       var s1=findIn(slides[a.slide],a);
       if(s1>=0){wrapIn(slides[a.slide],a.id,s1,s1+a.exact.length);placed=true;where=a.slide}}
@@ -226,29 +407,32 @@ function applyAnchors(anchors){
       if(s2>=0){wrapIn(document.body,a.id,s2,s2+a.exact.length);placed=true;
         where=slides.length?slideOf(a.id,slides):null}}
     resolved[a.id]=placed;landed[a.id]=where}
-  post({type:"anchors-resolved",resolved:resolved,slides:landed});
+  post({type:"anchors-resolved",resolved:resolved,slides:landed,conf:conf});
   reportRects()}
 
 /* live scroll + resize, rAF-throttled so cards glide with the text */
 var sTick=0;
 window.addEventListener("scroll",function(){if(sTick)return;
-  sTick=requestAnimationFrame(function(){sTick=0;reportScroll()})},true);
+  sTick=requestAnimationFrame(function(){sTick=0;if(elReg.length)positionEls();reportScroll()})},true);
 var rTick=0;
-function reflow(){if(rTick)return;rTick=requestAnimationFrame(function(){rTick=0;reportRects()})}
+function reflow(){if(rTick)return;rTick=requestAnimationFrame(function(){rTick=0;positionEls();reportRects()})}
 window.addEventListener("resize",reflow);
+/* element overlays are positioned in document coords, so they glide with scroll;
+   but a sub-scroller or a slide flip moves the element under them — reposition on
+   scroll too (cheap; same rAF gate as rect reporting via the scroll handler). */
 /* images/fonts settle after load — re-measure a few times so pins land right */
 window.addEventListener("load",function(){reportRects();setTimeout(reportRects,400);setTimeout(reportRects,1200)});
 
-/* hover a highlight -> emphasize its card in the host */
+/* hover a highlight (text mark or element badge) -> emphasize its card in the host */
 document.addEventListener("mouseover",function(e){
-  var m=e.target&&e.target.closest?e.target.closest("mark[data-dock-id]"):null;
+  var m=e.target&&e.target.closest?e.target.closest("mark[data-dock-id],.dock-el-badge[data-dock-id]"):null;
   if(m)post({type:"anchor-hover",id:m.getAttribute("data-dock-id")})});
 document.addEventListener("mouseout",function(e){
-  var m=e.target&&e.target.closest?e.target.closest("mark[data-dock-id]"):null;
+  var m=e.target&&e.target.closest?e.target.closest("mark[data-dock-id],.dock-el-badge[data-dock-id]"):null;
   if(m)post({type:"anchor-hover",id:null})});
-/* clicking a highlight focuses its thread in the host */
+/* clicking a highlight (text mark or element badge) focuses its thread in the host */
 document.addEventListener("click",function(e){
-  var el=e.target,m=el&&el.closest?el.closest("mark[data-dock-id]"):null;
+  var el=e.target,m=el&&el.closest?el.closest("mark[data-dock-id],.dock-el-badge[data-dock-id]"):null;
   if(m){post({type:"anchor-click",id:m.getAttribute("data-dock-id")});return}
   navLink(e)
 },true);
@@ -266,11 +450,13 @@ function navLink(e){
 document.addEventListener("auxclick",function(e){if(e.button===1)navLink(e)},true);
 
 function setOn(id){
-  var on=document.querySelectorAll("mark.dock-hl-on");
-  for(var i=0;i<on.length;i++)on[i].classList.remove("dock-hl-on");
+  var on=document.querySelectorAll("mark.dock-hl-on,.dock-el-hl.dock-el-on");
+  for(var i=0;i<on.length;i++){on[i].classList.remove("dock-hl-on");on[i].classList.remove("dock-el-on")}
   if(!id)return;
   var ms=document.querySelectorAll('mark[data-dock-id="'+id+'"]');
-  for(var j=0;j<ms.length;j++)ms[j].classList.add("dock-hl-on")}
+  for(var j=0;j<ms.length;j++)ms[j].classList.add("dock-hl-on");
+  var ov=document.querySelectorAll('.dock-el-hl[data-dock-id="'+id+'"]');
+  for(var q=0;q<ov.length;q++)ov[q].classList.add("dock-el-on")}
 
 window.addEventListener("message",function(e){
   var d=e.data;
@@ -280,14 +466,18 @@ window.addEventListener("message",function(e){
   else if(d.type==="emphasize")setOn(d.id);
   else if(d.type==="scroll-by")window.scrollBy(0,d.dy||0);
   else if(d.type==="focus-anchor"){
+    /* text marks flash with dock-hl-flash; element overlays with dock-el-flash. */
     var ms=document.querySelectorAll('mark[data-dock-id="'+d.id+'"]');
-    if(!ms.length)return;
-    /* bias (0..1) places the highlight at that fraction of the viewport instead of
+    var ov=document.querySelectorAll('.dock-el-hl[data-dock-id="'+d.id+'"]');
+    var first=ms[0]||ov[0];
+    if(!first)return;
+    /* bias (0..1) places the target at that fraction of the viewport instead of
        dead-center — phones pass ~0.28 so it lands above the comments sheet. */
-    if(typeof d.bias==="number"){var br=ms[0].getBoundingClientRect();
+    if(typeof d.bias==="number"){var br=first.getBoundingClientRect();
       window.scrollTo({top:scrollTop()+br.top-window.innerHeight*d.bias,behavior:"smooth"})}
-    else ms[0].scrollIntoView({behavior:"smooth",block:"center"});
+    else first.scrollIntoView({behavior:"smooth",block:"center"});
     for(var i=0;i<ms.length;i++){ms[i].classList.remove("dock-hl-flash");void ms[i].offsetWidth;ms[i].classList.add("dock-hl-flash")}
+    for(var p=0;p<ov.length;p++){ov[p].classList.remove("dock-el-flash");void ov[p].offsetWidth;ov[p].classList.add("dock-el-flash")}
     setTimeout(reportScroll,360)}
 });
 })();`
@@ -295,13 +485,18 @@ window.addEventListener("message",function(e){
 /** The tag appended to served artifact HTML; resolves on any host. */
 export const SELECTION_SCRIPT = `<script src="/raw/dock-client.js"></script>`
 
-/** True if the comment's stored anchor still resolves in `text`. */
-export function isAnchored(anchorJson: string | null, text: string): boolean {
+/** True if the comment's stored anchor still resolves in `content`. For text
+ *  anchors `content` is the page text; for element anchors it's the page HTML
+ *  (both are the raw decoded file, so one call site covers both). */
+export function isAnchored(anchorJson: string | null, content: string): boolean {
   if (!anchorJson) return true
+  // Element anchor: relocate via the cascade against the page HTML.
+  const el = parseElementSelector(anchorJson)
+  if (el) return elementResolvesIn(el, content) !== null
   try {
     const sel = JSON.parse(anchorJson) as QuoteSelector
     if (sel.type !== "TextQuoteSelector" || !sel.exact) return true
-    return reanchor(sel, text).found
+    return reanchor(sel, content).found
   } catch {
     return true
   }

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -471,6 +471,14 @@ window.addEventListener("resize",reflow);
    scroll too (cheap; same rAF gate as rect reporting via the scroll handler). */
 /* images/fonts settle after load — re-measure a few times so pins land right */
 window.addEventListener("load",function(){reportRects();setTimeout(reportRects,400);setTimeout(reportRects,1200)});
+/* The artifact's OWN scripts can mutate the DOM after load (a chart library renders,
+   content animates, an accordion expands) — none of which fire scroll/resize/load. So
+   overlays would strand over stale positions. Watch for document size changes
+   (ResizeObserver) and DOM edits (MutationObserver) and re-pin. reflow is rAF-gated, so
+   a burst of mutations coalesces to one reposition per frame, and the cost is O(anchors)
+   not O(DOM). attributes:false so our own style writes in positionEls don't re-trigger it. */
+try{if(window.ResizeObserver)new ResizeObserver(reflow).observe(document.documentElement)}catch(_r){}
+try{if(window.MutationObserver)new MutationObserver(reflow).observe(document.body||document.documentElement,{childList:true,subtree:true})}catch(_m){}
 
 /* hover a highlight (text mark or element badge) -> emphasize its card in the host */
 document.addEventListener("mouseover",function(e){

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -255,13 +255,15 @@ function textClose(a,b){if(!a||!b)return false;var x=a.toLowerCase(),y=b.toLower
   if(x===y)return true;var sh=x.length<y.length?x:y,lo=x.length<y.length?y:x;
   if(sh.length>=8&&lo.indexOf(sh)>=0)return true;
   var w=Math.min(16,sh.length);return w>=8&&lo.slice(0,w)===sh.slice(0,w)}
-function scoreEl(el,a){
+function scoreEl(el,a,fpM){
   var score=0,max=0,signals=[];
   if(a.id){max+=5;if(el.id===a.id){score+=5;signals.push("id")}}
   max+=5;if(elFp(el)===a.fingerprint){score+=5;signals.push("content")}
   if(a.css){max+=3;if(cssPath(el)===a.css){score+=3;signals.push("css")}}
-  max+=3;if(el.tagName.toLowerCase()===a.tag){
-    if(elOrdinal(el)===a.ordinal){score+=3;signals.push("position")}else score+=1}
+  /* drop ordinal when content repeats across candidates (same logo per slide) — it's
+     the signal an insertion scrambles; let neighbors/geometry pick the instance */
+  if(fpM<=1){max+=3;if(el.tagName.toLowerCase()===a.tag){
+    if(elOrdinal(el)===a.ordinal){score+=3;signals.push("position")}else score+=1}}
   if(a.before||a.after){var nb=neighborText(el);
     if(a.before){max+=1;if(textClose(a.before,nb.before)){score+=1;signals.push("nb")}}
     if(a.after){max+=1;if(textClose(a.after,nb.after)){score+=1;signals.push("nb")}}}
@@ -278,7 +280,7 @@ function resolveEl(a){
   var fpM=0,idM=0;
   for(var c=0;c<cand.length;c++){if(elFp(cand[c])===a.fingerprint)fpM++;if(a.id&&cand[c].id===a.id)idM++}
   var best=null,bestEl=null,runnerUp=0;
-  for(var j=0;j<cand.length;j++){var s=scoreEl(cand[j],a);
+  for(var j=0;j<cand.length;j++){var s=scoreEl(cand[j],a,fpM);
     if(!best||s.c>best.c){if(best&&best.c>runnerUp)runnerUp=best.c;best=s;bestEl=cand[j]}
     else if(s.c>runnerUp)runnerUp=s.c}
   if(!best||best.c<0.42)return null;

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -190,15 +190,27 @@ function elText(el){return nw(el.textContent||"")}
 function elFp(el){var tag=el.tagName.toLowerCase();return fnv([tag,elSrc(el),elAlt(el),elText(el).slice(0,120)].join("\\u0001"))}
 function elOrdinal(el){var all=document.getElementsByTagName(el.tagName);
   for(var i=0;i<all.length;i++){if(all[i]===el)return i}return 0}
-/* nearest preceding/following text block, in document order */
+/* nearest preceding/following text block, in document order. Walks OUTWARD from el
+   (prev/next siblings, then up a level) instead of scanning every block in the doc —
+   the old querySelectorAll+compareDocumentPosition was O(blocks) PER candidate, so a
+   large gallery froze the frame for seconds (1500 imgs ~1.7s). The nearest block is
+   almost always a sibling or one level up, so this is effectively O(1). */
 var BLOCKS="p,li,h1,h2,h3,h4,h5,h6,blockquote,td,th,figcaption,dd,dt,pre";
+function isBlock(n){return n.nodeType===1&&n.matches&&n.matches(BLOCKS)}
+/* deepest block at the trailing (last=true) or leading edge of root's subtree, incl root */
+function edgeBlockText(root,last){
+  if(root.nodeType!==1)return null;
+  var bl=root.querySelectorAll?root.querySelectorAll(BLOCKS):[];
+  for(var i=0;i<bl.length;i++){var b=bl[last?bl.length-1-i:i],t=nw(b.textContent||"");if(t.length>=2)return t}
+  if(isBlock(root)){var rt=nw(root.textContent||"");if(rt.length>=2)return rt}
+  return null}
 function neighborText(el){
-  var before=null,after=null,blocks=document.querySelectorAll(BLOCKS);
-  for(var i=0;i<blocks.length;i++){var b=blocks[i];if(el.contains(b)||b.contains(el))continue;
-    var t=nw(b.textContent||"");if(t.length<2)continue;
-    var pos=el.compareDocumentPosition(b);
-    if(pos&Node.DOCUMENT_POSITION_PRECEDING)before=t;          /* keep the last one before */
-    else if(pos&Node.DOCUMENT_POSITION_FOLLOWING){after=t;break}}
+  var before=null,after=null,hops=0;
+  for(var n=el;n&&n.parentElement&&!before&&hops<400;n=n.parentElement)
+    for(var s=n.previousElementSibling;s&&!before&&hops<400;s=s.previousElementSibling){hops++;before=edgeBlockText(s,true)}
+  hops=0;
+  for(var m=el;m&&m.parentElement&&!after&&hops<400;m=m.parentElement)
+    for(var p=m.nextElementSibling;p&&!after&&hops<400;p=p.nextElementSibling){hops++;after=edgeBlockText(p,false)}
   return {before:before,after:after}}
 /* structural css path of tag:nth-of-type up to a stable ancestor (authored id or body) */
 function cssPath(el){var parts=[],n=el;

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -333,6 +333,11 @@ function paintEl(id,el,band){
   if(low){badge.title="View comment \\u00b7 moved here (approximate)";
     var pip=document.createElement("div");pip.className="dock-el-pip";badge.appendChild(pip)}
   else badge.title="View comment";
+  /* multiple comments on the SAME element would stack their badges at the identical
+     corner — only the top one is then clickable. Fan each extra badge left so every
+     comment's badge stays reachable in the document. */
+  var stack=0;for(var s=0;s<elReg.length;s++)if(elReg[s].el===el)stack++;
+  if(stack>0)badge.style.right=(-11+stack*24)+"px";   /* fan left, staying over the element */
   ov.appendChild(badge);
   document.body.appendChild(ov);elReg.push({id:id,el:el,ov:ov,clips:clipAncestors(el)})}
 /* ancestors that clip their overflow (a scrollable panel, a code block) — captured

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -326,7 +326,20 @@ function paintEl(id,el,band){
     var pip=document.createElement("div");pip.className="dock-el-pip";badge.appendChild(pip)}
   else badge.title="View comment";
   ov.appendChild(badge);
-  document.body.appendChild(ov);elReg.push({id:id,el:el,ov:ov})}
+  document.body.appendChild(ov);elReg.push({id:id,el:el,ov:ov,clips:clipAncestors(el)})}
+/* ancestors that clip their overflow (a scrollable panel, a code block) — captured
+   once at paint so the hot positioning path is rect math, not getComputedStyle. The
+   overlay lives at the body level and isn't clipped by them, so when the element
+   scrolls out of one, WE must hide the overlay or it floats over unrelated content. */
+function clipAncestors(el){var out=[];
+  for(var p=el.parentElement;p&&p!==document.body&&p!==document.documentElement;p=p.parentElement){
+    try{var st=getComputedStyle(p),ov=(st.overflow||"")+(st.overflowX||"")+(st.overflowY||"");
+      if(/auto|scroll|hidden|clip/.test(ov))out.push(p)}catch(_c){}}
+  return out}
+function clippedOut(r,clips){if(!clips)return false;
+  for(var i=0;i<clips.length;i++){var c=clips[i].getBoundingClientRect();
+    if(r.bottom<=c.top||r.top>=c.bottom||r.right<=c.left||r.left>=c.right)return true}
+  return false}
 var reTick=0;
 function positionEls(){var sy=scrollTop(),sx=window.scrollX||0,detached=false;
   for(var i=0;i<elReg.length;i++){var e=elReg[i];
@@ -336,7 +349,7 @@ function positionEls(){var sy=scrollTop(),sx=window.scrollX||0,detached=false;
        handled by the size check below, no re-resolve.) */
     if(!document.contains(e.el)){detached=true;e.ov.style.display="none";continue}
     var r=e.el.getBoundingClientRect();
-    if(!(r.width||r.height)){e.ov.style.display="none";continue}
+    if(!(r.width||r.height)||clippedOut(r,e.clips)){e.ov.style.display="none";continue}
     e.ov.style.display="block";e.ov.style.left=(r.left+sx)+"px";e.ov.style.top=(r.top+sy)+"px";
     e.ov.style.width=r.width+"px";e.ov.style.height=r.height+"px"}
   if(detached&&lastAnchors&&!reTick)reTick=setTimeout(function(){reTick=0;applyAnchors(lastAnchors)},150)}

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -411,7 +411,12 @@ function slideOfEl(el,slides){
   return null}
 
 /* doc-absolute top of each anchor — text marks AND element overlays — so the host
-   pins each card beside whatever it points at */
+   pins each card beside whatever it points at. We DEDUPE the host post: a dynamic
+   artifact (a live ticker, a 60fps animation) fires the MutationObserver every frame,
+   but if nothing the host cares about actually moved (same tops/scroll/size), posting
+   would re-render the comment layout 60fps for nothing. Overlays are still repositioned
+   in-frame each call; only the cross-frame message is gated on a real change. */
+var lastRects="";
 function reportRects(){
   var tops={},seen={},sy=scrollTop();
   var ms=document.querySelectorAll("mark[data-dock-id]");
@@ -421,8 +426,11 @@ function reportRects(){
   for(var j=0;j<elReg.length;j++){var e=elReg[j];if(seen[e.id])continue;
     if(e.ov.style.display==="none")continue;seen[e.id]=1;
     tops[e.id]=e.el.getBoundingClientRect().top+sy}
-  post({type:"anchor-rects",tops:tops,scrollY:sy,viewH:window.innerHeight,
-    docH:document.documentElement.scrollHeight})}
+  var payload={type:"anchor-rects",tops:tops,scrollY:sy,viewH:window.innerHeight,
+    docH:document.documentElement.scrollHeight};
+  var sig=JSON.stringify(payload);
+  if(sig===lastRects)return;        /* nothing the host pins to changed — skip the re-render */
+  lastRects=sig;post(payload)}
 function reportScroll(){post({type:"scroll",scrollY:scrollTop(),viewH:window.innerHeight,docH:document.documentElement.scrollHeight})}
 
 /* Resolve each anchor, scoping a deck comment to its recorded slide FIRST (so the

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -152,12 +152,22 @@ st.textContent="mark.dock-hl{background:rgba(124,108,189,.20);color:inherit;bord
 /* element overlays: a non-text anchor draws an outline box (pointer-events off so
    the element stays interactive) with a clickable comment badge in its corner. A
    low-confidence relocation reads dashed to signal "we think it moved here". */
-".dock-el-hl{position:absolute;pointer-events:none;border:2px solid rgba(124,108,189,.55);border-radius:4px;box-shadow:0 0 0 3px rgba(124,108,189,.12);transition:border-color .15s,box-shadow .15s;z-index:2147483640}"+
-".dock-el-hl.dock-el-low{border-style:dashed;border-color:rgba(124,108,189,.5)}"+
+".dock-el-hl{position:absolute;pointer-events:none;border:2px solid rgba(124,108,189,.55);border-radius:4px;box-shadow:0 0 0 3px rgba(124,108,189,.12);transition:border-color .15s,box-shadow .15s,opacity .15s;z-index:2147483640}"+
+/* low confidence (a relocation we're unsure about) = a quiet hint, never an alarm.
+   At rest there's NO box at all — just the small badge with a tiny 'moved' pip. The
+   faint dashed outline appears only when you hover the badge, so the document stays
+   calm and the signal is opt-in. */
+".dock-el-hl.dock-el-low{border-color:transparent;box-shadow:none}"+
+".dock-el-hl.dock-el-low:hover,.dock-el-hl.dock-el-low.dock-el-on{border:1px dashed rgba(124,108,189,.5)}"+
 ".dock-el-hl.dock-el-on{border-color:rgba(124,108,189,.95);box-shadow:0 0 0 4px rgba(124,108,189,.22)}"+
 ".dock-el-hl.dock-el-flash{animation:dockelflash 1s ease 2}"+
 "@keyframes dockelflash{50%{box-shadow:0 0 0 6px rgba(124,108,189,.4)}}"+
 ".dock-el-badge{position:absolute;top:-11px;right:-11px;width:22px;height:22px;border-radius:11px;background:rgba(124,108,189,.95);color:#fff;font:600 12px/22px system-ui,sans-serif;text-align:center;pointer-events:auto;cursor:pointer;box-shadow:0 1px 4px rgba(0,0,0,.25)}"+
+/* on a moved (low-confidence) badge: dimmed, with a tiny pip marking 'approximate'.
+   Brightens on hover so it's findable without being loud. */
+".dock-el-low .dock-el-badge{background:rgba(124,108,189,.55);box-shadow:0 1px 3px rgba(0,0,0,.16)}"+
+".dock-el-low:hover .dock-el-badge{background:rgba(124,108,189,.95)}"+
+".dock-el-pip{position:absolute;bottom:-2px;right:-2px;width:8px;height:8px;border-radius:50%;background:rgba(124,108,189,.85);border:1.5px solid #fff;box-sizing:content-box}"+
 /* the hover affordance: a small 'Comment' chip that follows the pointer over an
    anchorable element; clicking it pins a comment to that element. */
 ".dock-el-chip{position:absolute;display:none;align-items:center;gap:5px;padding:4px 9px;border-radius:7px;background:rgba(124,108,189,.97);color:#fff;font:600 12px/1 system-ui,sans-serif;pointer-events:auto;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.28);z-index:2147483641;white-space:nowrap}"+
@@ -175,7 +185,9 @@ function nw(s){return (s||"").replace(/\\s+/g," ").trim()}
 function elSrc(el){return (el.getAttribute&&(el.getAttribute("src")||el.getAttribute("href")))||""}
 function elAlt(el){return (el.getAttribute&&(el.getAttribute("alt")||el.getAttribute("aria-label")||el.getAttribute("title")))||""}
 function elText(el){return nw(el.textContent||"")}
-function elFp(el){var tag=el.tagName.toLowerCase();return fnv([tag,elSrc(el),elAlt(el),elText(el).slice(0,120)].join(""))}
+/* join separator MUST equal FP_SEP in element-anchor.ts (\\u0001) — joining with ""
+   instead silently made browser fingerprints differ from the server's. */
+function elFp(el){var tag=el.tagName.toLowerCase();return fnv([tag,elSrc(el),elAlt(el),elText(el).slice(0,120)].join("\\u0001"))}
 function elOrdinal(el){var all=document.getElementsByTagName(el.tagName);
   for(var i=0;i<all.length;i++){if(all[i]===el)return i}return 0}
 /* nearest preceding/following text block, in document order */
@@ -260,23 +272,43 @@ function resolveEl(a){
   var cand=[],seen=[];
   if(a.tag){var bt=document.getElementsByTagName(a.tag);for(var i=0;i<bt.length;i++){cand.push(bt[i]);seen.push(bt[i])}}
   if(a.id){var byId=document.getElementById(a.id);if(byId&&seen.indexOf(byId)<0)cand.push(byId)}
-  var best=null,bestEl=null;
+  /* count how many candidates share the recorded fingerprint / id — a strong
+     signal matching MANY candidates isn't identifying (a gallery of identical
+     thumbnails), so it can't grant high confidence (mirrors core's grade()). */
+  var fpM=0,idM=0;
+  for(var c=0;c<cand.length;c++){if(elFp(cand[c])===a.fingerprint)fpM++;if(a.id&&cand[c].id===a.id)idM++}
+  var best=null,bestEl=null,runnerUp=0;
   for(var j=0;j<cand.length;j++){var s=scoreEl(cand[j],a);
-    if(!best||s.c>best.c){best=s;bestEl=cand[j]}}
+    if(!best||s.c>best.c){if(best&&best.c>runnerUp)runnerUp=best.c;best=s;bestEl=cand[j]}
+    else if(s.c>runnerUp)runnerUp=s.c}
   if(!best||best.c<0.42)return null;
-  var strong=best.signals.indexOf("id")>=0||best.signals.indexOf("content")>=0;
-  var band=strong&&best.c>=0.6?"high":(best.signals.indexOf("position")>=0||best.signals.indexOf("nb")>=0?"medium":"low");
-  return {el:bestEl,confidence:best.c,band:band,signals:best.signals}}
+  var g=gradeEl(best.signals,best.c,fpM,idM,best.c-runnerUp);
+  return {el:bestEl,confidence:g.c,band:g.band,signals:best.signals}}
+function gradeEl(sig,conf,fpM,idM,margin){
+  var mId=sig.indexOf("id")>=0,mContent=sig.indexOf("content")>=0,nb=sig.indexOf("nb")>=0;
+  var uniq=(mId&&idM===1)||(mContent&&fpM===1);
+  var ambig=(mId&&idM>1)||(mContent&&fpM>1);
+  if(ambig&&!uniq&&!nb)return {band:"low",c:Math.min(conf,0.45)};
+  if(uniq&&conf>=0.6&&margin>=0.12)return {band:"high",c:conf};
+  if((uniq||nb||sig.indexOf("position")>=0)&&conf>=0.5)return {band:"medium",c:Math.min(conf,0.75)};
+  return {band:"low",c:Math.min(conf,0.5)}}
 
 /* overlay registry: each resolved element anchor gets an absolutely-positioned
    outline (in document coords, so it glides with scroll) + a corner badge. */
 var elReg=[];
 function clearEls(){for(var i=0;i<elReg.length;i++){var o=elReg[i].ov;if(o&&o.parentNode)o.parentNode.removeChild(o)}elReg=[]}
 function paintEl(id,el,band){
-  var ov=document.createElement("div");ov.className="dock-el-hl"+(band==="low"?" dock-el-low":"");
+  var low=band==="low";
+  var ov=document.createElement("div");ov.className="dock-el-hl"+(low?" dock-el-low":"");
   ov.setAttribute("data-dock-id",id);
   var badge=document.createElement("div");badge.className="dock-el-badge";badge.setAttribute("data-dock-id",id);
-  badge.textContent="\\uD83D\\uDCAC";badge.title="View comment";ov.appendChild(badge);
+  badge.textContent="\\uD83D\\uDCAC";
+  /* a moved (low-confidence) anchor gets a tiny pip + an explanatory title; nothing
+     louder. medium/high look like a normal anchored comment. */
+  if(low){badge.title="View comment \\u00b7 moved here (approximate)";
+    var pip=document.createElement("div");pip.className="dock-el-pip";badge.appendChild(pip)}
+  else badge.title="View comment";
+  ov.appendChild(badge);
   document.body.appendChild(ov);elReg.push({id:id,el:el,ov:ov})}
 function positionEls(){var sy=scrollTop(),sx=window.scrollX||0;
   for(var i=0;i<elReg.length;i++){var e=elReg[i],r=e.el.getBoundingClientRect();

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -327,11 +327,19 @@ function paintEl(id,el,band){
   else badge.title="View comment";
   ov.appendChild(badge);
   document.body.appendChild(ov);elReg.push({id:id,el:el,ov:ov})}
-function positionEls(){var sy=scrollTop(),sx=window.scrollX||0;
-  for(var i=0;i<elReg.length;i++){var e=elReg[i],r=e.el.getBoundingClientRect();
+var reTick=0;
+function positionEls(){var sy=scrollTop(),sx=window.scrollX||0,detached=false;
+  for(var i=0;i<elReg.length;i++){var e=elReg[i];
+    /* the artifact's JS may REMOVE+recreate an element (a tab switch, an SPA re-render).
+       A detached element isn't just moved — repositioning can't help; we must RESOLVE
+       again to re-attach to the replacement. (A merely hidden element stays attached →
+       handled by the size check below, no re-resolve.) */
+    if(!document.contains(e.el)){detached=true;e.ov.style.display="none";continue}
+    var r=e.el.getBoundingClientRect();
     if(!(r.width||r.height)){e.ov.style.display="none";continue}
     e.ov.style.display="block";e.ov.style.left=(r.left+sx)+"px";e.ov.style.top=(r.top+sy)+"px";
-    e.ov.style.width=r.width+"px";e.ov.style.height=r.height+"px"}}
+    e.ov.style.width=r.width+"px";e.ov.style.height=r.height+"px"}
+  if(detached&&lastAnchors&&!reTick)reTick=setTimeout(function(){reTick=0;applyAnchors(lastAnchors)},150)}
 
 /* hover affordance: a 'Comment' chip parked at the top-right of the anchorable
    element under the pointer; clicking it pins a comment to that element. */
@@ -437,7 +445,9 @@ function reportScroll(){post({type:"scroll",scrollY:scrollTop(),viewH:window.inn
    same phrase on two slides can't collide), then falling back to a whole-document
    search if the text has moved off that slide. Reports, per id, whether it resolved
    and which slide it actually landed in (null = outside any slide / non-deck). */
+var lastAnchors=null;
 function applyAnchors(anchors){
+  lastAnchors=anchors;            /* kept so we can re-resolve if an element is replaced */
   clearMarks();clearEls();
   var slides=slideEls(),resolved={},landed={},conf={};
   for(var k=0;k<anchors.length;k++){

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -288,7 +288,10 @@ function gradeEl(sig,conf,fpM,idM,margin){
   var mId=sig.indexOf("id")>=0,mContent=sig.indexOf("content")>=0,nb=sig.indexOf("nb")>=0;
   var uniq=(mId&&idM===1)||(mContent&&fpM===1);
   var ambig=(mId&&idM>1)||(mContent&&fpM>1);
+  /* id and content point at different elements (swapped content) -> never high */
+  var conflict=(mId&&!mContent&&fpM>0)||(mContent&&!mId&&idM>0);
   if(ambig&&!uniq&&!nb)return {band:"low",c:Math.min(conf,0.45)};
+  if(conflict)return {band:"medium",c:Math.min(conf,0.6)};
   if(uniq&&conf>=0.6&&margin>=0.12)return {band:"high",c:conf};
   if((uniq||nb||sig.indexOf("position")>=0)&&conf>=0.5)return {band:"medium",c:Math.min(conf,0.75)};
   return {band:"low",c:Math.min(conf,0.5)}}

--- a/packages/core/src/element-anchor.ts
+++ b/packages/core/src/element-anchor.ts
@@ -146,6 +146,69 @@ const VOID_TAGS = new Set([
   "wbr",
 ])
 const RAW_TAGS = new Set(["script", "style"])
+/** Block-level tags whose opening implicitly closes an open `<p>` (HTML's optional
+ *  end-tag rule). */
+const BLOCK_TAGS = new Set([
+  "address",
+  "article",
+  "aside",
+  "blockquote",
+  "details",
+  "div",
+  "dl",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "header",
+  "hr",
+  "main",
+  "menu",
+  "nav",
+  "ol",
+  "p",
+  "pre",
+  "section",
+  "table",
+  "ul",
+])
+/**
+ * Does an open element `open` get implicitly closed when `next` opens? Browsers
+ * apply these optional-end-tag rules, so the scanner must too — otherwise an
+ * unclosed `<p>`/`<li>`/`<td>` nests its siblings and an element's neighbour text
+ * diverges from the live DOM (`"beforeafter"` vs `"before"`), making the server's
+ * `anchored` check disagree with the painted overlay.
+ */
+function autoCloses(open: string, next: string): boolean {
+  switch (open) {
+    case "p":
+      return BLOCK_TAGS.has(next)
+    case "li":
+      return next === "li"
+    case "dt":
+    case "dd":
+      return next === "dt" || next === "dd"
+    case "td":
+    case "th":
+      return next === "td" || next === "th" || next === "tr"
+    case "tr":
+      return next === "tr"
+    case "option":
+      return next === "option" || next === "optgroup"
+    case "thead":
+    case "tbody":
+      return next === "tbody" || next === "tfoot"
+    default:
+      return false
+  }
+}
 /** Tags that never carry standalone visual meaning — not anchor targets. */
 const SKIP_TAGS = new Set([
   "html",
@@ -358,6 +421,15 @@ export function scanElements(html: string): ElementDescriptor[] {
 
     const attrs = parseAttrs(sp < 0 ? "" : inner.slice(sp + 1))
     if (SKIP_TAGS.has(tag)) continue
+
+    // Apply HTML optional-end-tag rules: pop any open elements this tag implicitly
+    // closes (an open <p> before a block, <li> before <li>, <td> before <td>/<tr>…),
+    // so neighbour text matches what the browser's DOM produces.
+    while (stack.length) {
+      const top = stack[stack.length - 1]
+      if (top && autoCloses(top.d.tag, tag)) finalize(stack.pop())
+      else break
+    }
 
     const ordinal = tagCount[tag] ?? 0
     tagCount[tag] = ordinal + 1

--- a/packages/core/src/element-anchor.ts
+++ b/packages/core/src/element-anchor.ts
@@ -653,6 +653,7 @@ function neighborText(ds: ElementDescriptor[], idx: number): { before?: string; 
 /** Loose text agreement for neighbors — exact, prefix, or containment of a
  *  meaningful chunk. Neighbors get edited too, so don't demand equality. */
 function textClose(a: string, b: string): boolean {
+  if (typeof a !== "string" || typeof b !== "string") return false // defensive: hostile anchor
   const x = a.toLowerCase()
   const y = b.toLowerCase()
   if (x === y) return true
@@ -737,15 +738,42 @@ export function planElementForwardWalk(start: ElementSelector, versionHtml: stri
 }
 
 /** Parse a stored anchor JSON as an ElementSelector (or null if it's something
- *  else — a text quote, malformed, or absent). */
+ *  else — a text quote, malformed, or absent). Anchors are written by clients, so
+ *  every field is validated/coerced to its expected type: a hostile or buggy anchor
+ *  (e.g. a non-string `before`) must NOT be able to crash resolution — the sweep
+ *  runs on every publish, so a throw here would break publishing for the artifact. */
 export function parseElementSelector(json: string | null): ElementSelector | null {
   if (!json) return null
+  let s: Record<string, unknown>
   try {
-    const s = JSON.parse(json) as Partial<ElementSelector>
-    if (s.type !== "ElementSelector" || !s.fingerprint || !s.tag) return null
-    return s as ElementSelector
+    const parsed = JSON.parse(json)
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null
+    s = parsed as Record<string, unknown>
   } catch {
     return null
+  }
+  if (s.type !== "ElementSelector") return null
+  const tag = typeof s.tag === "string" ? s.tag : ""
+  const fingerprint = typeof s.fingerprint === "string" ? s.fingerprint : ""
+  if (!tag || !fingerprint) return null
+  const str = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined)
+  const num = (v: unknown, fallback: number): number =>
+    typeof v === "number" && Number.isFinite(v) ? v : fallback
+  const snap =
+    s.snapshot && typeof s.snapshot === "object" ? (s.snapshot as ElementSnapshot) : undefined
+  return {
+    type: "ElementSelector",
+    tag,
+    role: (typeof s.role === "string" ? s.role : "block") as ElementRole,
+    id: str(s.id),
+    css: str(s.css),
+    fingerprint,
+    ordinal: num(s.ordinal, 0),
+    docFraction: Math.max(0, Math.min(1, num(s.docFraction, 0))),
+    before: str(s.before),
+    after: str(s.after),
+    snapshot: snap ?? { tag, label: tag },
+    slide: typeof s.slide === "number" && Number.isFinite(s.slide) ? s.slide : undefined,
   }
 }
 

--- a/packages/core/src/element-anchor.ts
+++ b/packages/core/src/element-anchor.ts
@@ -122,6 +122,12 @@ export interface ElementMatch {
 
 const TEXT_CAP = 4000
 const FP_TEXT_CAP = 120
+/** Field separator inside a content fingerprint, so a value ending and the next
+ *  beginning can't blur into a collision (e.g. src "...a" + alt "b" vs src "..." +
+ *  alt "ab"). A control char that never appears in real content. MUST stay identical
+ *  to the client's `elFp` join in `ANCHOR_CLIENT_JS` — they were silently different
+ *  ("" vs this) once, which made every browser-made anchor fail to resolve server-side. */
+const FP_SEP = "\u0001"
 
 const VOID_TAGS = new Set([
   "area",
@@ -197,7 +203,7 @@ export function fingerprintOf(d: {
   text: string
 }): string {
   const parts = [d.tag, srcOf(d), altOf(d), normWs(d.text).slice(0, FP_TEXT_CAP)]
-  return fnv1a(parts.join(""))
+  return fnv1a(parts.join(FP_SEP))
 }
 
 /** Classify an element into a coarse role for labels + capture affordances. */
@@ -474,17 +480,27 @@ export function resolveElement(
   descriptors: ElementDescriptor[],
 ): ElementMatch | null {
   if (!descriptors.length) return null
-  // Candidate set: same tag, plus any element carrying the recorded id.
+  // Candidate set: same tag, plus any element carrying the recorded id. Track how
+  // many share the recorded fingerprint / id — a strong signal that matches MANY
+  // candidates isn't identifying, so it can't grant high confidence (a gallery of
+  // identical thumbnails, two charts on the same blank canvas).
   const candidates = new Set<number>()
+  let fpMatches = 0
+  let idMatches = 0
   for (let i = 0; i < descriptors.length; i++) {
     const d = descriptors[i]
     if (!d) continue
     if (d.tag === sel.tag) candidates.add(i)
-    if (sel.id && d.id === sel.id) candidates.add(i)
+    if (sel.id && d.id === sel.id) {
+      candidates.add(i)
+      idMatches++
+    }
+    if (fingerprintOf(d) === sel.fingerprint) fpMatches++
   }
   if (!candidates.size) return null
 
   let best: ElementMatch | null = null
+  let runnerUp = 0 // second-best confidence — a thin margin means the pick is a guess
   for (const idx of candidates) {
     const d = descriptors[idx]
     if (!d) continue
@@ -539,23 +555,57 @@ export function resolveElement(
     score += W.geometry * geo
 
     const confidence = max > 0 ? score / max : 0
-    if (!best || confidence > best.confidence)
+    if (!best || confidence > best.confidence) {
+      if (best) runnerUp = Math.max(runnerUp, best.confidence)
       best = { index: idx, confidence, band: "low", signals }
+    } else if (confidence > runnerUp) {
+      runnerUp = confidence
+    }
   }
 
   if (!best || best.confidence < ACCEPT) return null
-  best.band = bandOf(best)
+  const { band, confidence } = grade(best, {
+    fpMatches,
+    idMatches,
+    margin: best.confidence - runnerUp,
+  })
+  best.band = band
+  best.confidence = confidence
   return best
 }
 
-function bandOf(m: ElementMatch): ConfidenceBand {
-  // A strong, near-unique signal (id or content) → high. Position/neighbor
-  // agreement → medium. Geometry-led only → low.
-  const strong = m.signals.includes("id") || m.signals.includes("content")
-  if (strong && m.confidence >= 0.6) return "high"
-  if (m.signals.includes("position") || m.signals.some((s) => s.startsWith("neighbor")))
-    return "medium"
-  return "low"
+/**
+ * Turn the winner's raw score into a confidence band, accounting for ambiguity.
+ * The raw ratio over-credits a strong signal that fired on MANY candidates: if the
+ * fingerprint (or id) isn't unique, "content matched" says nothing about WHICH
+ * element, so the pick leans on position/geometry — exactly the signals a deletion
+ * scrambles. So an ambiguous strong signal, or a thin margin over the runner-up,
+ * caps the band (and the reported confidence) down to "we think it moved here".
+ */
+function grade(
+  m: ElementMatch,
+  ctx: { fpMatches: number; idMatches: number; margin: number },
+): { band: ConfidenceBand; confidence: number } {
+  const matchedId = m.signals.includes("id")
+  const matchedContent = m.signals.includes("content")
+  const hasNeighbor = m.signals.some((s) => s.startsWith("neighbor"))
+  // A strong signal that uniquely identifies this element (only one candidate has it).
+  const strongUnique = (matchedId && ctx.idMatches === 1) || (matchedContent && ctx.fpMatches === 1)
+  // A strong signal shared across candidates — not identifying on its own.
+  const strongAmbiguous = (matchedId && ctx.idMatches > 1) || (matchedContent && ctx.fpMatches > 1)
+
+  // Ambiguous strong signal with nothing reliable to break the tie (only position /
+  // geometry, which a deletion shifts) → low, and don't report a confident number.
+  if (strongAmbiguous && !strongUnique && !hasNeighbor) {
+    return { band: "low", confidence: Math.min(m.confidence, 0.45) }
+  }
+  if (strongUnique && m.confidence >= 0.6 && ctx.margin >= 0.12) {
+    return { band: "high", confidence: m.confidence }
+  }
+  if ((strongUnique || hasNeighbor || m.signals.includes("position")) && m.confidence >= 0.5) {
+    return { band: "medium", confidence: Math.min(m.confidence, 0.75) }
+  }
+  return { band: "low", confidence: Math.min(m.confidence, 0.5) }
 }
 
 /** Nearest text-bearing block before/after `idx` in document order. */

--- a/packages/core/src/element-anchor.ts
+++ b/packages/core/src/element-anchor.ts
@@ -593,11 +593,21 @@ function grade(
   const strongUnique = (matchedId && ctx.idMatches === 1) || (matchedContent && ctx.fpMatches === 1)
   // A strong signal shared across candidates — not identifying on its own.
   const strongAmbiguous = (matchedId && ctx.idMatches > 1) || (matchedContent && ctx.fpMatches > 1)
+  // The OTHER strong signal points at a DIFFERENT element than the winner — id and
+  // content disagree (two charts swapped src/alt but kept their ids, or an id was
+  // reused for different content). A genuine conflict, so never "high".
+  const conflict =
+    (matchedId && !matchedContent && ctx.fpMatches > 0) ||
+    (matchedContent && !matchedId && ctx.idMatches > 0)
 
   // Ambiguous strong signal with nothing reliable to break the tie (only position /
   // geometry, which a deletion shifts) → low, and don't report a confident number.
   if (strongAmbiguous && !strongUnique && !hasNeighbor) {
     return { band: "low", confidence: Math.min(m.confidence, 0.45) }
+  }
+  // id says one element, content says another → medium at most, flagged as moved.
+  if (conflict) {
+    return { band: "medium", confidence: Math.min(m.confidence, 0.6) }
   }
   if (strongUnique && m.confidence >= 0.6 && ctx.margin >= 0.12) {
     return { band: "high", confidence: m.confidence }

--- a/packages/core/src/element-anchor.ts
+++ b/packages/core/src/element-anchor.ts
@@ -1,0 +1,689 @@
+/**
+ * Element anchors — pin a comment to a NON-TEXT element (an image, chart, table,
+ * embed, code block, figure …) instead of a quoted span. Text comments ride a
+ * `TextQuoteSelector` (see `anchor.ts`); this is its sibling for everything that
+ * isn't prose.
+ *
+ * The hard part is surviving a republish. An element has no "exact text" to grep
+ * for, so a single signal is brittle: ids get regenerated, css paths shift when a
+ * wrapper is added, an image's position drifts as content lands above it. So we
+ * record SEVERAL independent signals and resolve by AGREEMENT — a layered cascade,
+ * strongest to weakest:
+ *
+ *   id → css → content fingerprint → structural ordinal → geometry → neighbors
+ *
+ * Each signal that agrees with a candidate adds to its score; the best-scoring
+ * element wins, carrying a `confidence` (0..1) and a coarse band. One strong
+ * signal (a matching id or an identical content fingerprint) is enough; absent
+ * those, several weak ones in agreement still relocate the element. Nothing here
+ * uses ML — it's deterministic and runs identically in the browser (live, against
+ * the real DOM) and on the server (against a version's HTML, via `scanElements`).
+ *
+ * Two things make element anchors more than a worse text anchor:
+ *
+ *   1. A preserved SNAPSHOT. We capture what the element looked like at comment
+ *      time (label, src, a truncated outerHTML). If the element is later gone, the
+ *      orphaned comment still shows what it pointed at instead of a dead marker.
+ *
+ *   2. Forward-walk RECOVERY (the Dock-only advantage). Because Dock keeps every
+ *      version's full HTML, when an anchor can't resolve in the current version we
+ *      walk the version history forward from where it was made, re-deriving the
+ *      selector at each step it still resolves. An element that was renamed, moved,
+ *      or rewrapped one version at a time is recovered — each hop is a small,
+ *      resolvable delta even though first-to-last looks unrecognizable.
+ *
+ * The fingerprint hash (`fnv1a`) is duplicated verbatim inside `ANCHOR_CLIENT_JS`
+ * so a fingerprint computed in the browser equals one computed here — keep them in
+ * lockstep if you touch the input shape.
+ */
+
+export type ElementRole =
+  | "image"
+  | "chart"
+  | "media"
+  | "embed"
+  | "table"
+  | "code"
+  | "figure"
+  | "block"
+
+/** What the element looked like when the comment was made — shown when the live
+ *  element can no longer be found, so an orphaned comment still has a referent. */
+export interface ElementSnapshot {
+  tag: string
+  /** Human descriptor, e.g. "Image — revenue.png", "Table (4×3)", "Embedded video". */
+  label: string
+  /** Normalized text content (truncated). */
+  text?: string
+  /** img/video/iframe/embed source, if any. */
+  src?: string
+  /** alt / aria-label / title / caption, if any. */
+  alt?: string
+  /** Displayed size at capture (for a placeholder aspect ratio). */
+  w?: number
+  h?: number
+  /** Truncated outerHTML for a visual preview. Sanitized again at render time. */
+  html?: string
+}
+
+export interface ElementSelector {
+  type: "ElementSelector"
+  tag: string
+  role: ElementRole
+  /** Element id — only recorded when it looks authored (not a hashy/generated id). */
+  id?: string
+  /** Structural css path (`tag:nth-of-type(n)` chain). Captured + verified in the
+   *  browser, where a real DOM exists; the server cascade skips it. */
+  css?: string
+  /** Content hash over {tag, src, alt, leading text}. The single strongest signal. */
+  fingerprint: string
+  /** 0-based index among same-tag elements in document order. */
+  ordinal: number
+  /** Vertical position at capture as a fraction of the document (0..1) — "save
+   *  position". A weak geometric tiebreaker; the server approximates it from the
+   *  element's offset in the HTML source. */
+  docFraction: number
+  /** Normalized text of the nearest preceding / following text-bearing block. */
+  before?: string
+  after?: string
+  snapshot: ElementSnapshot
+  /** Deck artifacts only: the 0-based slide the comment was made on. */
+  slide?: number
+}
+
+/** A flat, parent-free description of one element, the server-side stand-in for a
+ *  live DOM node (we ship no HTML parser, so `scanElements` builds these). */
+export interface ElementDescriptor {
+  tag: string
+  id?: string
+  classes: string[]
+  /** Selected attributes only (src/href/alt/title/aria-label/role/data-*). */
+  attrs: Record<string, string>
+  /** Normalized subtree text (truncated). */
+  text: string
+  /** 0-based index among same-tag elements, document order. */
+  ordinal: number
+  /** Global element index in document order. */
+  index: number
+  /** Start offset in the HTML source / total length (0..1) — geometry proxy. */
+  srcFraction: number
+}
+
+export type ConfidenceBand = "high" | "medium" | "low"
+
+export interface ElementMatch {
+  /** Index into the `ElementDescriptor[]` passed to `resolveElement`. */
+  index: number
+  confidence: number
+  band: ConfidenceBand
+  /** Which signals agreed — useful for debugging + UI ("matched by id, content"). */
+  signals: string[]
+}
+
+const TEXT_CAP = 4000
+const FP_TEXT_CAP = 120
+
+const VOID_TAGS = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+])
+const RAW_TAGS = new Set(["script", "style"])
+/** Tags that never carry standalone visual meaning — not anchor targets. */
+const SKIP_TAGS = new Set([
+  "html",
+  "head",
+  "body",
+  "script",
+  "style",
+  "meta",
+  "link",
+  "title",
+  "base",
+  "noscript",
+])
+/** Attributes worth keeping for fingerprinting / role detection. */
+const KEEP_ATTRS = new Set([
+  "src",
+  "href",
+  "alt",
+  "title",
+  "aria-label",
+  "role",
+  "name",
+  "data-dock-slide",
+  "data-dock-id",
+])
+
+/** Collapse runs of whitespace and trim. Used everywhere a value feeds matching. */
+export function normWs(s: string): string {
+  return s.replace(/\s+/g, " ").trim()
+}
+
+/**
+ * FNV-1a (32-bit) → base36. A tiny, fast, dependency-free hash — we only need a
+ * stable content fingerprint, not cryptographic strength. DUPLICATED VERBATIM in
+ * `ANCHOR_CLIENT_JS`; the browser and server must produce identical fingerprints.
+ */
+export function fnv1a(s: string): string {
+  let h = 0x811c9dc5
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0
+  }
+  return h.toString(36)
+}
+
+const srcOf = (d: { tag: string; attrs: Record<string, string> }): string =>
+  d.attrs.src || d.attrs.href || ""
+const altOf = (d: { attrs: Record<string, string> }): string =>
+  d.attrs.alt || d.attrs["aria-label"] || d.attrs.title || ""
+
+/** The canonical fingerprint input — keep byte-identical with the client. */
+export function fingerprintOf(d: {
+  tag: string
+  attrs: Record<string, string>
+  text: string
+}): string {
+  const parts = [d.tag, srcOf(d), altOf(d), normWs(d.text).slice(0, FP_TEXT_CAP)]
+  return fnv1a(parts.join(""))
+}
+
+/** Classify an element into a coarse role for labels + capture affordances. */
+export function roleOf(d: {
+  tag: string
+  id?: string
+  classes: string[]
+  attrs: Record<string, string>
+}): ElementRole {
+  const tag = d.tag
+  // Concrete media tags win outright — an <img> is an image even if its id says
+  // "chart". The textual hint only disambiguates generic containers below.
+  if (tag === "img" || tag === "picture") return "image"
+  if (tag === "video" || tag === "audio") return "media"
+  if (tag === "iframe" || tag === "embed" || tag === "object") return "embed"
+  if (tag === "table") return "table"
+  if (tag === "pre" || tag === "code") return "code"
+  if (tag === "svg" || tag === "canvas") return "chart"
+  if (tag === "figure") return "figure"
+  const hint = `${d.classes.join(" ")} ${d.id ?? ""} ${d.attrs.role ?? ""}`.toLowerCase()
+  if (/\b(chart|graph|plot|viz|sparkline|d3)\b/.test(hint)) return "chart"
+  return "block"
+}
+
+/** A short, human label for the snapshot / orphan card. */
+export function elementLabel(d: {
+  tag: string
+  role: ElementRole
+  attrs: Record<string, string>
+  text?: string
+}): string {
+  const alt = normWs(altOf(d))
+  const host = hostOf(d.attrs.src || d.attrs.href || "")
+  switch (d.role) {
+    case "image":
+      return alt ? `Image — ${truncate(alt, 48)}` : host ? `Image — ${host}` : "Image"
+    case "chart":
+      return alt ? `Chart — ${truncate(alt, 48)}` : "Chart"
+    case "media":
+      return d.tag === "audio" ? "Audio" : host ? `Video — ${host}` : "Video"
+    case "embed":
+      return host ? `Embedded — ${host}` : "Embedded content"
+    case "table":
+      return "Table"
+    case "code":
+      return "Code block"
+    case "figure":
+      return alt ? `Figure — ${truncate(alt, 48)}` : "Figure"
+    default:
+      return truncate(normWs(d.text ?? "") || d.tag, 48) || "Element"
+  }
+}
+
+function hostOf(url: string): string {
+  if (!url) return ""
+  const m = url.match(/^https?:\/\/([^/]+)/i)
+  if (m?.[1]) return m[1].replace(/^www\./, "")
+  return ""
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n - 1)}…` : s
+}
+
+/**
+ * Parse HTML into an ordered list of element descriptors — a dependency-free
+ * substitute for a DOM, enough to run the cascade server-side. Not a spec-complete
+ * parser: it tokenizes tags, tracks open/close to accumulate subtree text and
+ * same-tag ordinals, skips raw (`script`/`style`) content and comments, and drops
+ * structural/non-visual tags. Malformed nesting degrades gracefully (a missing
+ * close just keeps text flowing into ancestors) — fine for a best-effort relocator.
+ */
+export function scanElements(html: string): ElementDescriptor[] {
+  const out: ElementDescriptor[] = []
+  const total = html.length || 1
+  // Open-element frames; text is pushed onto every open frame (subtree text).
+  const stack: { d: ElementDescriptor; parts: string[]; len: number }[] = []
+  const tagCount: Record<string, number> = {}
+  let i = 0
+  let order = 0
+  const n = html.length
+
+  const pushText = (raw: string) => {
+    if (!raw) return
+    for (const f of stack) {
+      if (f.len >= TEXT_CAP) continue
+      const room = TEXT_CAP - f.len
+      const slice = raw.length > room ? raw.slice(0, room) : raw
+      f.parts.push(slice)
+      f.len += slice.length
+    }
+  }
+
+  while (i < n) {
+    const lt = html.indexOf("<", i)
+    if (lt < 0) {
+      pushText(decodeEntities(html.slice(i)))
+      break
+    }
+    if (lt > i) pushText(decodeEntities(html.slice(i, lt)))
+
+    // Comment / CDATA / doctype — skip wholesale.
+    if (html.startsWith("<!--", lt)) {
+      const end = html.indexOf("-->", lt + 4)
+      i = end < 0 ? n : end + 3
+      continue
+    }
+    if (html[lt + 1] === "!" || html[lt + 1] === "?") {
+      const end = html.indexOf(">", lt)
+      i = end < 0 ? n : end + 1
+      continue
+    }
+
+    // Closing tag.
+    if (html[lt + 1] === "/") {
+      const end = html.indexOf(">", lt)
+      const name = html
+        .slice(lt + 2, end < 0 ? n : end)
+        .trim()
+        .toLowerCase()
+      // Pop to the nearest matching open frame (tolerate unclosed children).
+      for (let s = stack.length - 1; s >= 0; s--) {
+        if (stack[s]?.d.tag === name) {
+          for (let k = stack.length - 1; k >= s; k--) finalize(stack.pop())
+          break
+        }
+      }
+      i = end < 0 ? n : end + 1
+      continue
+    }
+
+    // Opening tag.
+    const end = tagEnd(html, lt)
+    if (end < 0) {
+      pushText(decodeEntities(html.slice(lt)))
+      break
+    }
+    const inner = html.slice(lt + 1, end)
+    const sp = firstSpace(inner)
+    const tag = (sp < 0 ? inner : inner.slice(0, sp)).trim().toLowerCase().replace(/\/$/, "")
+    const selfClose = inner.trimEnd().endsWith("/")
+    i = end + 1
+
+    if (!tag || /[^a-z0-9-]/.test(tag)) continue
+
+    if (RAW_TAGS.has(tag)) {
+      // Skip the raw element's content entirely (it may contain `<`).
+      const close = html.toLowerCase().indexOf(`</${tag}`, i)
+      i = close < 0 ? n : html.indexOf(">", close) + 1 || n
+      continue
+    }
+
+    const attrs = parseAttrs(sp < 0 ? "" : inner.slice(sp + 1))
+    if (SKIP_TAGS.has(tag)) continue
+
+    const ordinal = tagCount[tag] ?? 0
+    tagCount[tag] = ordinal + 1
+    const d: ElementDescriptor = {
+      tag,
+      id: attrs.id || undefined,
+      classes: attrs.class ? attrs.class.split(/\s+/).filter(Boolean) : [],
+      attrs: pickAttrs(attrs),
+      text: "",
+      ordinal,
+      index: order++,
+      srcFraction: lt / total,
+    }
+    out.push(d)
+    if (selfClose || VOID_TAGS.has(tag)) continue
+    stack.push({ d, parts: [], len: 0 })
+  }
+  while (stack.length) finalize(stack.pop())
+  return out
+
+  function finalize(f?: { d: ElementDescriptor; parts: string[] }) {
+    if (f) f.d.text = normWs(f.parts.join(""))
+  }
+}
+
+/** Index of the `>` that closes the tag opened at `lt`, respecting quoted attrs. */
+function tagEnd(html: string, lt: number): number {
+  let q = ""
+  for (let j = lt + 1; j < html.length; j++) {
+    const ch = html[j]
+    if (q) {
+      if (ch === q) q = ""
+    } else if (ch === '"' || ch === "'") q = ch
+    else if (ch === ">") return j
+  }
+  return -1
+}
+
+function firstSpace(s: string): number {
+  const m = s.match(/[\s/]/)
+  return m ? (m.index ?? -1) : -1
+}
+
+function parseAttrs(s: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  const re = /([a-zA-Z_:][-a-zA-Z0-9_:.]*)(?:\s*=\s*("[^"]*"|'[^']*'|[^\s"'>]+))?/g
+  let m: RegExpExecArray | null
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex-exec loop
+  while ((m = re.exec(s))) {
+    const name = m[1]?.toLowerCase()
+    if (!name) continue
+    let val = m[2] ?? ""
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'")))
+      val = val.slice(1, -1)
+    out[name] = decodeEntities(val)
+  }
+  return out
+}
+
+function pickAttrs(all: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const k of Object.keys(all)) {
+    if (KEEP_ATTRS.has(k) || k.startsWith("data-")) out[k] = all[k] as string
+  }
+  return out
+}
+
+const ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  "#39": "'",
+  apos: "'",
+  nbsp: " ",
+}
+function decodeEntities(s: string): string {
+  if (s.indexOf("&") < 0) return s
+  return s.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (whole, body: string) => {
+    if (body[0] === "#") {
+      const cp =
+        body[1] === "x" || body[1] === "X"
+          ? parseInt(body.slice(2), 16)
+          : parseInt(body.slice(1), 10)
+      return Number.isFinite(cp) ? safeFromCodePoint(cp) : whole
+    }
+    return ENTITIES[body] ?? whole
+  })
+}
+function safeFromCodePoint(cp: number): string {
+  try {
+    return String.fromCodePoint(cp)
+  } catch {
+    return ""
+  }
+}
+
+// --- The cascade --------------------------------------------------------------
+
+/** Signal weights, strongest → weakest. id and fingerprint each alone clear the
+ *  acceptance threshold; the rest accumulate. */
+const W = {
+  id: 5,
+  fingerprint: 5,
+  tagOrdinal: 3,
+  tagOnly: 1,
+  neighbor: 1, // per side (before/after) → up to 2
+  geometry: 1,
+}
+const ACCEPT = 0.42
+
+/**
+ * Resolve an element selector against a parsed document. Scores every same-tag
+ * candidate (plus an id match of any tag) by signal agreement and returns the best
+ * if it clears the threshold, with a confidence and the signals that agreed.
+ * Pure; the browser runs the same cascade against live elements.
+ */
+export function resolveElement(
+  sel: ElementSelector,
+  descriptors: ElementDescriptor[],
+): ElementMatch | null {
+  if (!descriptors.length) return null
+  // Candidate set: same tag, plus any element carrying the recorded id.
+  const candidates = new Set<number>()
+  for (let i = 0; i < descriptors.length; i++) {
+    const d = descriptors[i]
+    if (!d) continue
+    if (d.tag === sel.tag) candidates.add(i)
+    if (sel.id && d.id === sel.id) candidates.add(i)
+  }
+  if (!candidates.size) return null
+
+  let best: ElementMatch | null = null
+  for (const idx of candidates) {
+    const d = descriptors[idx]
+    if (!d) continue
+    let score = 0
+    let max = 0
+    const signals: string[] = []
+
+    if (sel.id) {
+      max += W.id
+      if (d.id === sel.id) {
+        score += W.id
+        signals.push("id")
+      }
+    }
+
+    max += W.fingerprint
+    if (fingerprintOf(d) === sel.fingerprint) {
+      score += W.fingerprint
+      signals.push("content")
+    }
+
+    // Structural ordinal (only meaningful within the same tag).
+    max += W.tagOrdinal
+    if (d.tag === sel.tag) {
+      if (d.ordinal === sel.ordinal) {
+        score += W.tagOrdinal
+        signals.push("position")
+      } else {
+        score += W.tagOnly
+      }
+    }
+
+    // Neighbors — the text just before / after the element.
+    if (sel.before || sel.after) {
+      const { before, after } = neighborText(descriptors, idx)
+      for (const [want, got, name] of [
+        [sel.before, before, "before"],
+        [sel.after, after, "after"],
+      ] as const) {
+        if (!want) continue
+        max += W.neighbor
+        if (got && textClose(want, got)) {
+          score += W.neighbor
+          signals.push(`neighbor:${name}`)
+        }
+      }
+    }
+
+    // Geometry — closeness of source position (weak tiebreaker, always considered).
+    max += W.geometry
+    const geo = 1 - Math.min(1, Math.abs(d.srcFraction - sel.docFraction))
+    score += W.geometry * geo
+
+    const confidence = max > 0 ? score / max : 0
+    if (!best || confidence > best.confidence)
+      best = { index: idx, confidence, band: "low", signals }
+  }
+
+  if (!best || best.confidence < ACCEPT) return null
+  best.band = bandOf(best)
+  return best
+}
+
+function bandOf(m: ElementMatch): ConfidenceBand {
+  // A strong, near-unique signal (id or content) → high. Position/neighbor
+  // agreement → medium. Geometry-led only → low.
+  const strong = m.signals.includes("id") || m.signals.includes("content")
+  if (strong && m.confidence >= 0.6) return "high"
+  if (m.signals.includes("position") || m.signals.some((s) => s.startsWith("neighbor")))
+    return "medium"
+  return "low"
+}
+
+/** Nearest text-bearing block before/after `idx` in document order. */
+function neighborText(ds: ElementDescriptor[], idx: number): { before?: string; after?: string } {
+  let before: string | undefined
+  for (let i = idx - 1; i >= 0 && idx - i <= 6; i--) {
+    const t = ds[i]?.text
+    if (t && t.length >= 2) {
+      before = t
+      break
+    }
+  }
+  let after: string | undefined
+  for (let i = idx + 1; i < ds.length && i - idx <= 6; i++) {
+    const t = ds[i]?.text
+    if (t && t.length >= 2) {
+      after = t
+      break
+    }
+  }
+  return { before, after }
+}
+
+/** Loose text agreement for neighbors — exact, prefix, or containment of a
+ *  meaningful chunk. Neighbors get edited too, so don't demand equality. */
+function textClose(a: string, b: string): boolean {
+  const x = a.toLowerCase()
+  const y = b.toLowerCase()
+  if (x === y) return true
+  const short = x.length < y.length ? x : y
+  const long = x.length < y.length ? y : x
+  if (short.length >= 8 && long.includes(short)) return true
+  // Shared 16-char leading window survives a trailing edit.
+  const w = Math.min(16, short.length)
+  return w >= 8 && long.slice(0, w) === short.slice(0, w)
+}
+
+/**
+ * Re-derive a selector from the element it just matched, so the cascade tracks an
+ * element as it's edited version-to-version (a renamed id, a moved position, a
+ * rewrapped node). Carries the snapshot + slide through unchanged.
+ */
+export function rederiveSelector(
+  sel: ElementSelector,
+  d: ElementDescriptor,
+  descriptors: ElementDescriptor[],
+): ElementSelector {
+  const { before, after } = neighborText(descriptors, d.index)
+  return {
+    ...sel,
+    tag: d.tag,
+    id: d.id,
+    fingerprint: fingerprintOf(d),
+    ordinal: d.ordinal,
+    docFraction: d.srcFraction,
+    before: before ?? sel.before,
+    after: after ?? sel.after,
+  }
+}
+
+export interface ForwardWalk {
+  /** Did the (possibly re-derived) selector resolve in the final version? */
+  resolved: boolean
+  confidence: number
+  band: ConfidenceBand
+  /** The selector carried forward (re-derived at each hop it resolved). */
+  selector: ElementSelector
+  /** How many version hops it survived before being lost (or reaching the end). */
+  survived: number
+}
+
+/**
+ * Forward-walk recovery — the Dock-only move. Given a selector and the ORDERED
+ * HTML of each version after the one it was made on (oldest → current), re-resolve
+ * at each hop and re-derive the selector from the match before the next hop. An
+ * element edited gradually (renamed, moved, rewrapped) is recovered because every
+ * single-version delta stays resolvable even when first-vs-last does not. Stops at
+ * the first version where it can't be found; reports whether it survives to the end.
+ */
+export function planElementForwardWalk(start: ElementSelector, versionHtml: string[]): ForwardWalk {
+  let sel = start
+  let survived = 0
+  let last: ElementMatch | null = null
+  for (const html of versionHtml) {
+    const ds = scanElements(html)
+    const m = resolveElement(sel, ds)
+    if (!m) {
+      return {
+        resolved: false,
+        confidence: 0,
+        band: "low",
+        selector: sel,
+        survived,
+      }
+    }
+    const d = ds[m.index]
+    if (d) sel = rederiveSelector(sel, d, ds)
+    last = m
+    survived++
+  }
+  return {
+    resolved: !!last,
+    confidence: last?.confidence ?? 0,
+    band: last?.band ?? "low",
+    selector: sel,
+    survived,
+  }
+}
+
+/** Parse a stored anchor JSON as an ElementSelector (or null if it's something
+ *  else — a text quote, malformed, or absent). */
+export function parseElementSelector(json: string | null): ElementSelector | null {
+  if (!json) return null
+  try {
+    const s = JSON.parse(json) as Partial<ElementSelector>
+    if (s.type !== "ElementSelector" || !s.fingerprint || !s.tag) return null
+    return s as ElementSelector
+  } catch {
+    return null
+  }
+}
+
+/** True if a stored anchor is an element anchor (vs a text quote / unanchored). */
+export function isElementAnchor(json: string | null): boolean {
+  return parseElementSelector(json) !== null
+}
+
+/** Does an element anchor still resolve against this page's HTML? */
+export function elementResolvesIn(sel: ElementSelector, html: string): ElementMatch | null {
+  return resolveElement(sel, scanElements(html))
+}

--- a/packages/core/src/element-anchor.ts
+++ b/packages/core/src/element-anchor.ts
@@ -409,6 +409,10 @@ function parseAttrs(s: string): Record<string, string> {
   while ((m = re.exec(s))) {
     const name = m[1]?.toLowerCase()
     if (!name) continue
+    // Duplicate attributes are invalid HTML, but they happen. The parsing spec (and
+    // every browser) keeps the FIRST occurrence and ignores the rest — match that, so
+    // a fingerprint here equals one read off a live `getAttribute`.
+    if (name in out) continue
     let val = m[2] ?? ""
     if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'")))
       val = val.slice(1, -1)

--- a/packages/core/src/element-anchor.ts
+++ b/packages/core/src/element-anchor.ts
@@ -105,6 +105,10 @@ export interface ElementDescriptor {
   ordinal: number
   /** Global element index in document order. */
   index: number
+  /** Index of the enclosing element (-1 at top level). Lets neighbour lookup skip
+   *  ancestors/descendants so a wrapped element (`<div><img><p>…`) resolves the same
+   *  preceding/following block the browser-side walk does. */
+  parent: number
   /** Start offset in the HTML source / total length (0..1) — geometry proxy. */
   srcFraction: number
 }
@@ -441,6 +445,7 @@ export function scanElements(html: string): ElementDescriptor[] {
       text: "",
       ordinal,
       index: order++,
+      parent: stack.length ? (stack[stack.length - 1]?.d.index ?? -1) : -1,
       srcFraction: lt / total,
     }
     out.push(d)
@@ -703,8 +708,15 @@ function grade(
 
 /** Nearest text-bearing block before/after `idx` in document order. */
 function neighborText(ds: ElementDescriptor[], idx: number): { before?: string; after?: string } {
+  // Is `a` an ancestor of `b` (walk b's parent chain)?
+  const isAncestor = (a: number, b: number): boolean => {
+    for (let p = ds[b]?.parent ?? -1; p >= 0; p = ds[p]?.parent ?? -1) if (p === a) return true
+    return false
+  }
   let before: string | undefined
-  for (let i = idx - 1; i >= 0 && idx - i <= 6; i--) {
+  for (let i = idx - 1, seen = 0; i >= 0 && seen < 6; i--) {
+    if (isAncestor(i, idx)) continue // an enclosing container is not a preceding block
+    seen++
     const t = ds[i]?.text
     if (t && t.length >= 2) {
       before = t
@@ -712,7 +724,9 @@ function neighborText(ds: ElementDescriptor[], idx: number): { before?: string; 
     }
   }
   let after: string | undefined
-  for (let i = idx + 1; i < ds.length && i - idx <= 6; i++) {
+  for (let i = idx + 1, seen = 0; i < ds.length && seen < 6; i++) {
+    if (isAncestor(idx, i)) continue // a descendant is not a following block
+    seen++
     const t = ds[i]?.text
     if (t && t.length >= 2) {
       after = t

--- a/packages/core/src/element-anchor.ts
+++ b/packages/core/src/element-anchor.ts
@@ -522,14 +522,21 @@ export function resolveElement(
       signals.push("content")
     }
 
-    // Structural ordinal (only meaningful within the same tag).
-    max += W.tagOrdinal
-    if (d.tag === sel.tag) {
-      if (d.ordinal === sel.ordinal) {
-        score += W.tagOrdinal
-        signals.push("position")
-      } else {
-        score += W.tagOnly
+    // Structural ordinal — a corroborator for a UNIQUE element. But when the content
+    // fingerprint repeats across candidates (the same logo on every slide, a gallery),
+    // ordinal is exactly the signal a single insertion/deletion scrambles, so it's
+    // untrustworthy and actively misleading: drop it and let neighbors + geometry pick
+    // WHICH instance. (Without this, a comment on slide 3's logo jumps to slide 2's
+    // when a slide is inserted, because the old ordinal now points there.)
+    if (fpMatches <= 1) {
+      max += W.tagOrdinal
+      if (d.tag === sel.tag) {
+        if (d.ordinal === sel.ordinal) {
+          score += W.tagOrdinal
+          signals.push("position")
+        } else {
+          score += W.tagOnly
+        }
       }
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./anchor"
 export * from "./cross-doc"
 export * from "./diff"
+export * from "./element-anchor"
 export * from "./hash"
 export * from "./ids"
 export * from "./md"

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -185,10 +185,12 @@ export interface MetaStore {
   createComment(c: NewComment): Promise<CommentRecord>
   listComments(artifactId: string, opts?: { state?: CommentState }): Promise<CommentRecord[]>
   getComment(id: string): Promise<CommentRecord | null>
-  /** Patch a single comment's body and/or meta (reactions, edited, deleted). */
+  /** Patch a single comment's body, meta (reactions, edited, deleted), and/or
+   *  anchor (the re-anchor sweep self-heals an element anchor it recovered across
+   *  versions by rewriting the root comment's selector). */
   updateComment(
     id: string,
-    fields: { body_md?: string; meta?: string | null },
+    fields: { body_md?: string; meta?: string | null; anchor?: string | null },
   ): Promise<CommentRecord | null>
   /** Flips every comment in a thread to a state; returns the count updated. */
   setThreadState(artifactId: string, threadId: string, state: CommentState): Promise<number>

--- a/packages/core/test/anchor-robustness.test.ts
+++ b/packages/core/test/anchor-robustness.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest"
+import { isAnchored, planAnchorSweep } from "../src/anchor"
+import { parseElementSelector, resolveElement, scanElements } from "../src/element-anchor"
+
+const HTML = `<body><p>intro</p><img id="x" src="/a.png" alt="A chart"><p>outro</p></body>`
+const bad = [
+  JSON.stringify({
+    type: "ElementSelector",
+    tag: "img",
+    fingerprint: "abc",
+    ordinal: -5,
+    docFraction: NaN,
+  }),
+  JSON.stringify({
+    type: "ElementSelector",
+    tag: "img",
+    fingerprint: "abc",
+    ordinal: 1e9,
+    docFraction: Infinity,
+  }),
+  JSON.stringify({
+    type: "ElementSelector",
+    tag: "img",
+    fingerprint: "x".repeat(100000),
+    ordinal: 0,
+    docFraction: -3,
+  }),
+  JSON.stringify({
+    type: "ElementSelector",
+    tag: 123,
+    fingerprint: "abc",
+    ordinal: 0,
+    docFraction: 0,
+  }),
+  JSON.stringify({
+    type: "ElementSelector",
+    tag: "img",
+    fingerprint: null,
+    ordinal: 0,
+    docFraction: 0,
+  }),
+  JSON.stringify({
+    type: "ElementSelector",
+    tag: "img",
+    fingerprint: "abc",
+    ordinal: 0,
+    docFraction: 0,
+    before: { x: 1 },
+  }),
+  JSON.stringify({
+    type: "ElementSelector",
+    tag: "img",
+    fingerprint: "abc",
+    ordinal: 0,
+    docFraction: 0,
+    before: "y".repeat(500000),
+  }),
+  JSON.stringify({
+    type: "ElementSelector",
+    tag: "",
+    fingerprint: "abc",
+    ordinal: 0,
+    docFraction: 0,
+  }),
+  JSON.stringify({ type: "ElementSelector", tag: "img", fingerprint: "abc" }),
+  JSON.stringify({ type: "ElementSelector" }),
+  JSON.stringify({ type: "TextQuoteSelector", exact: "intro" }),
+  JSON.stringify({
+    type: "ElementSelector",
+    tag: "img",
+    fingerprint: "abc",
+    ordinal: 0,
+    docFraction: 0,
+    snapshot: null,
+  }),
+  "{malformed json",
+  "null",
+  "true",
+  "123",
+  "[]",
+  '"just a string"',
+  JSON.stringify({
+    type: "ElementSelector",
+    tag: "img",
+    fingerprint: "abc",
+    ordinal: 0,
+    docFraction: 0,
+    css: { nested: true },
+  }),
+]
+const htmls = [
+  HTML,
+  "",
+  "<html></html>",
+  "<img>".repeat(1000),
+  "not html",
+  "<img src=",
+  "<<<>>>",
+  "&#xZZ; &amp",
+  "<svg".repeat(500),
+]
+
+describe("server resolution survives hostile stored anchors", () => {
+  it("isAnchored never throws + always returns boolean", () => {
+    for (const a of bad)
+      for (const h of htmls) {
+        const r = isAnchored(a as string, h)
+        expect(typeof r).toBe("boolean")
+      }
+  })
+  it("planAnchorSweep never throws + returns an array", () => {
+    for (const a of bad) {
+      const t = planAnchorSweep([{ thread_id: "t1", anchor: a as string, state: "open" }], HTML)
+      expect(Array.isArray(t)).toBe(true)
+    }
+  })
+  it("resolveElement never throws on hostile selector x hostile html", () => {
+    for (const a of bad) {
+      const sel = parseElementSelector(a as string)
+      if (!sel) continue
+      for (const h of htmls) expect(() => resolveElement(sel, scanElements(h))).not.toThrow()
+    }
+  })
+})

--- a/packages/core/test/element-anchor.test.ts
+++ b/packages/core/test/element-anchor.test.ts
@@ -83,6 +83,23 @@ describe("scanElements", () => {
     expect(ds.find((d) => d.tag === "p")?.text).toBe("a & b <ok>")
     expect(ds.filter((d) => d.tag === "p")).toHaveLength(2)
   })
+
+  it("keeps the FIRST of duplicate attributes (matches the HTML parser + getAttribute)", () => {
+    // Invalid HTML, but it happens. Browsers keep the first occurrence and ignore the
+    // rest; the scanner must agree or its fingerprint won't match the live one.
+    const d = scanElements(`<img src="first.png" src="second.png" alt="A" alt="B">`).find(
+      (x) => x.tag === "img",
+    )
+    expect(d?.attrs.src).toBe("first.png")
+    expect(d?.attrs.alt).toBe("A")
+  })
+
+  it("decodes numeric + named entities in attributes the way a browser does", () => {
+    const d = scanElements(`<img src="x" alt="A &amp; B &#233; &#xe9; &lt;ok&gt;">`).find(
+      (x) => x.tag === "img",
+    )
+    expect(d?.attrs.alt).toBe("A & B é é <ok>")
+  })
 })
 
 describe("roleOf + elementLabel", () => {

--- a/packages/core/test/element-anchor.test.ts
+++ b/packages/core/test/element-anchor.test.ts
@@ -148,13 +148,17 @@ describe("resolveElement — the cascade", () => {
     expect(elementResolvesIn(sel, v2)).toBeNull()
   })
 
-  it("disambiguates duplicate tags by ordinal + neighbors", () => {
+  it("disambiguates duplicate (same-content) tags by neighbors, not ordinal", () => {
+    // Two byte-identical images; the only thing telling them apart is the text around
+    // them. With ambiguous content, ordinal is untrustworthy (an insertion shifts it),
+    // so the neighbors — not position — must pick the right instance.
     const html = `<p>alpha</p><img src="a.png" alt="A"><p>between</p><img src="a.png" alt="A"><p>omega</p>`
-    const sel = selFor(html, "img", 1) // the second image
+    const sel = selFor(html, "img", 1) // the second image (between / omega)
     const m = elementResolvesIn(sel, html)
     const ds = scanElements(html)
     expect(ds[m?.index ?? -1]?.ordinal).toBe(1)
-    expect(m?.signals).toContain("position")
+    expect(m?.signals.some((s) => s.startsWith("neighbor"))).toBe(true)
+    expect(m?.signals).not.toContain("position") // ordinal dropped for ambiguous content
   })
 })
 
@@ -179,6 +183,29 @@ describe("resolveElement — ambiguity must not breed false confidence", () => {
     const m = elementResolvesIn(sel, v2)
     // Either orphan or a low/medium relocation — never a confident match on Banana.
     if (m) expect(m.band).not.toBe("high")
+  })
+
+  it("a repeated element (logo on every slide) follows neighbors, not a shifted ordinal", () => {
+    // The brand logo repeats on every slide. A comment on slide 3's logo must stay on
+    // slide 3 when a slide is INSERTED at the front — even though that shifts every
+    // logo's ordinal. Before the fix, the stale ordinal dragged it to slide 2's logo.
+    const slide = (t: string) =>
+      `<section><h2>${t}</h2><img src="/logo.png" alt="Logo"><p>${t} body text unique to this slide.</p></section>`
+    const v1 = ["Intro", "Market", "Revenue", "Costs", "Outlook"].map(slide).join("")
+    const sel = selFor(v1, "img", 2) // Revenue slide's logo
+    const v2 = ["NEW", "Intro", "Market", "Revenue", "Costs", "Outlook"].map(slide).join("")
+    const m = elementResolvesIn(sel, v2)
+    expect(m).not.toBeNull()
+    const ds = scanElements(v2)
+    // The landed logo's slide = the nearest preceding <h2>; it must be "Revenue".
+    let slideTitle = ""
+    for (let i = (m?.index ?? 0) - 1; i >= 0; i--) {
+      if (ds[i]?.tag === "h2") {
+        slideTitle = ds[i]?.text ?? ""
+        break
+      }
+    }
+    expect(slideTitle).toBe("Revenue")
   })
 
   it("never claims high confidence when id and content disagree (a content swap)", () => {

--- a/packages/core/test/element-anchor.test.ts
+++ b/packages/core/test/element-anchor.test.ts
@@ -84,6 +84,30 @@ describe("scanElements", () => {
     expect(ds.filter((d) => d.tag === "p")).toHaveLength(2)
   })
 
+  it("auto-closes optional-end-tag elements like a browser (p/li/td neighbour parity)", () => {
+    // Unclosed <p>/<li>/<td> must read as SIBLINGS, not nested — otherwise an
+    // element's neighbour text diverges from the live DOM and the server's anchored
+    // check disagrees with the painted overlay.
+    expect(
+      scanElements("<p>one<p>two<p>three")
+        .filter((d) => d.tag === "p")
+        .map((d) => d.text),
+    ).toEqual(["one", "two", "three"])
+    expect(
+      scanElements("<ul><li>a<li>b<li>c</ul>")
+        .filter((d) => d.tag === "li")
+        .map((d) => d.text),
+    ).toEqual(["a", "b", "c"])
+    expect(scanElements("<p>intro<div>block</div>tail").find((d) => d.tag === "p")?.text).toBe(
+      "intro",
+    )
+    // An image between two unclosed <p>s sees the right neighbours.
+    const ds = scanElements(`<p>before<img src="/x.png" alt="X"><p>after`)
+    const i = ds.findIndex((d) => d.tag === "img")
+    expect(ds[i - 1]?.text).toBe("before")
+    expect(ds[i + 1]?.text).toBe("after")
+  })
+
   it("keeps the FIRST of duplicate attributes (matches the HTML parser + getAttribute)", () => {
     // Invalid HTML, but it happens. Browsers keep the first occurrence and ignore the
     // rest; the scanner must agree or its fingerprint won't match the live one.

--- a/packages/core/test/element-anchor.test.ts
+++ b/packages/core/test/element-anchor.test.ts
@@ -1,9 +1,12 @@
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
 import {
   type ElementSelector,
   elementLabel,
   elementResolvesIn,
   fingerprintOf,
+  fnv1a,
   isElementAnchor,
   parseElementSelector,
   planElementForwardWalk,
@@ -201,5 +204,38 @@ describe("resolveElement edge cases", () => {
       find(`<img id="rev-chart" src="/charts/revenue.png" alt="Revenue by region">`, "img"),
     )
     expect(a).toBe(b)
+  })
+})
+
+// The iframe client (ANCHOR_CLIENT_JS in anchor.ts) duplicates `fnv` verbatim so a
+// fingerprint made in the browser equals one made here. If they drift, element
+// anchors created in the browser silently stop resolving server-side. Pin parity by
+// extracting the client's fnv and comparing it to fnv1a.
+describe("client/server fingerprint parity", () => {
+  it("the browser client's fnv() equals fnv1a()", () => {
+    const path = fileURLToPath(new URL("../src/anchor.ts", import.meta.url))
+    const src = readFileSync(path, "utf8")
+    const marker = "export const ANCHOR_CLIENT_JS = `"
+    const start = src.indexOf(marker) + marker.length
+    let i = start
+    let end = -1
+    while (i < src.length) {
+      if (src[i] === "\\") {
+        i += 2
+        continue
+      }
+      if (src[i] === "`") {
+        end = i
+        break
+      }
+      i++
+    }
+    const js = src.slice(start, end).replace(/\\(.)/g, (_, c) => c) // one unescape level
+    const body = js.match(/function fnv\(s\)\{[\s\S]*?return h\.toString\(36\)\}/)
+    expect(body).not.toBeNull()
+    const clientFnv = new Function(`${body?.[0]};return fnv`)() as (s: string) => string
+    for (const c of ["", "abc", "img/charts/revenue.pngRevenue by region", "tableweird", "héllo"]) {
+      expect(clientFnv(c)).toBe(fnv1a(c))
+    }
   })
 })

--- a/packages/core/test/element-anchor.test.ts
+++ b/packages/core/test/element-anchor.test.ts
@@ -202,6 +202,34 @@ describe("resolveElement — ambiguity must not breed false confidence", () => {
     if (m) expect(m.band).not.toBe("high")
   })
 
+  it("many distinct anchors survive a compound shuffle without cross-contaminating", () => {
+    // 8 distinct charts, each with a comment. The republish shuffles their order, wraps
+    // every block in a <section>, AND rewords every caption — all at once. Each comment
+    // must land on its OWN chart (by content), and no two may collapse onto the same one.
+    const names = ["Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Hotel"]
+    const v1 = names
+      .map((n) => `<h3>${n}</h3><img src="/${n}.png" alt="${n} chart"><p>${n} notes.</p>`)
+      .join("")
+    const sels = names.map((n) => selFor(v1, "img", names.indexOf(n)))
+    // Reverse order + wrap in sections + reword the prose (images unchanged).
+    const v2 = [...names]
+      .reverse()
+      .map(
+        (n) =>
+          `<section><h3>${n} (revised)</h3><img src="/${n}.png" alt="${n} chart"><p>Updated discussion of ${n}.</p></section>`,
+      )
+      .join("")
+    const ds2 = scanElements(v2)
+    const landed = new Set<number>()
+    sels.forEach((sel, i) => {
+      const m = resolveElement(sel, ds2)
+      expect(m, `anchor ${names[i]} orphaned`).not.toBeNull()
+      expect(ds2[m?.index ?? -1]?.attrs.alt).toBe(`${names[i]} chart`) // its OWN chart
+      expect(landed.has(m?.index ?? -1), `collision on ${names[i]}`).toBe(false)
+      landed.add(m?.index ?? -1)
+    })
+  })
+
   it("a repeated element (logo on every slide) follows neighbors, not a shifted ordinal", () => {
     // The brand logo repeats on every slide. A comment on slide 3's logo must stay on
     // slide 3 when a slide is INSERTED at the front — even though that shifts every

--- a/packages/core/test/element-anchor.test.ts
+++ b/packages/core/test/element-anchor.test.ts
@@ -277,6 +277,29 @@ describe("resolveElement — ambiguity must not breed false confidence", () => {
     expect(slideTitle).toBe("Revenue")
   })
 
+  it("a WRAPPED element disambiguates by its sibling caption, not its container", () => {
+    // Gallery of identical thumbnails, each wrapped in a cell with its own caption.
+    // The caption is a SIBLING, not the enclosing <div> — neighbour lookup must skip
+    // the container (which would otherwise read the same text for every cell) so the
+    // server resolves the same instance the browser-side walk does.
+    const cell = (cap: string) =>
+      `<div class="cell"><img src="/t.png" alt="thumb"><p>${cap}</p></div>`
+    const v1 = cell("alpha caption") + cell("bravo caption") + cell("charlie caption")
+    const sel = selFor(v1, "img", 1) // the "bravo" thumbnail
+    expect(sel.after).toBe("bravo caption") // sibling caption, not the cell div
+    // Reorder the cells; it must follow its caption to the right instance.
+    const v2 = cell("charlie caption") + cell("bravo caption") + cell("alpha caption")
+    const ds = scanElements(v2)
+    const m = resolveElement(sel, ds)
+    let cap = ""
+    for (let i = (m?.index ?? 0) + 1; i < ds.length; i++)
+      if (ds[i]?.tag === "p") {
+        cap = ds[i]?.text ?? ""
+        break
+      }
+    expect(cap).toBe("bravo caption")
+  })
+
   it("never claims high confidence when id and content disagree (a content swap)", () => {
     // Two charts; comment on the red one. Then the two swap their src+alt but keep
     // their ids — so the comment's id points one way and its content the other. That

--- a/packages/core/test/element-anchor.test.ts
+++ b/packages/core/test/element-anchor.test.ts
@@ -227,6 +227,28 @@ describe("planElementForwardWalk — version recovery", () => {
     expect(walk.resolved).toBe(false)
     expect(walk.survived).toBe(1)
   })
+
+  it("self-heal CONVERGES: the recovered selector then resolves in one jump", () => {
+    // A chain where neither id nor content survives v1→v4, but each hop keeps one.
+    // The sweep can't one-jump it, recovers via the walk, and the carried-forward
+    // selector must then one-jump resolve the current version — so the NEXT sweep is
+    // cheap and the state can't thrash open↔outdated.
+    const p = (id: string, src: string, alt: string) =>
+      `<p>before</p><img id="${id}" src="${src}" alt="${alt}"><p>after</p>`
+    const v1 = p("A", "/1.png", "Hero one")
+    const chain = [
+      p("A", "/2.png", "Hero two"),
+      p("B", "/2.png", "Hero two"),
+      p("B", "/3.png", "Hero three"),
+    ]
+    const start = selFor(v1, "img")
+    const current = chain[chain.length - 1] as string
+    expect(elementResolvesIn(start, current)).toBeNull() // one-jump fails end-to-end
+    const walk = planElementForwardWalk(start, chain)
+    expect(walk.resolved).toBe(true)
+    // The healed selector resolves the current version directly (convergence).
+    expect(elementResolvesIn(walk.selector, current)).not.toBeNull()
+  })
 })
 
 describe("parse helpers", () => {

--- a/packages/core/test/element-anchor.test.ts
+++ b/packages/core/test/element-anchor.test.ts
@@ -158,6 +158,39 @@ describe("resolveElement — the cascade", () => {
   })
 })
 
+describe("resolveElement — ambiguity must not breed false confidence", () => {
+  it("a gallery of identical thumbnails, with one deleted, never resolves HIGH", () => {
+    // 12 byte-identical thumbnails; anchor #6; remove it. The cascade can relocate
+    // to *a* sibling (better than orphaning) but must NOT claim certainty — content
+    // matches all of them, so the pick leans on position, which a deletion scrambles.
+    const cell = `<img src="/t.png" alt="thumb">`
+    const v1 = `<div>${cell.repeat(12)}</div>`
+    const sel = selFor(v1, "img", 6)
+    const v2 = `<div>${cell.repeat(11)}</div>`
+    const m = elementResolvesIn(sel, v2)
+    expect(m?.band).not.toBe("high")
+    expect(m?.confidence ?? 1).toBeLessThanOrEqual(0.5)
+  })
+
+  it("deleting a distinct element never high-confidence-lands on a different one", () => {
+    const v1 = `<p>alpha</p><img id="A" src="/a.png" alt="Apple"><p>mid</p><img id="B" src="/b.png" alt="Banana"><p>omega</p>`
+    const sel = selFor(v1, "img", 0) // "Apple"
+    const v2 = v1.replace(/<img id="A"[^>]*>/, "") // only the distinct "Banana" remains
+    const m = elementResolvesIn(sel, v2)
+    // Either orphan or a low/medium relocation — never a confident match on Banana.
+    if (m) expect(m.band).not.toBe("high")
+  })
+
+  it("stays fast + non-crashing on a huge document", () => {
+    const huge = `<div>${`<img src="/x.png" alt="t">`.repeat(2000)}</div>`
+    const sel = selFor(huge, "img", 1000)
+    const t = Date.now()
+    const m = elementResolvesIn(sel, huge)
+    expect(Date.now() - t).toBeLessThan(2000)
+    expect(m).not.toBeNull()
+  })
+})
+
 describe("planElementForwardWalk — version recovery", () => {
   it("recovers an element renamed then moved across versions", () => {
     const v0 = PAGE
@@ -237,5 +270,62 @@ describe("client/server fingerprint parity", () => {
     for (const c of ["", "abc", "img/charts/revenue.pngRevenue by region", "tableweird", "héllo"]) {
       expect(clientFnv(c)).toBe(fnv1a(c))
     }
+  })
+
+  // The hash matching isn't enough: the two sides also have to JOIN the fields the
+  // same way. They once differed (empty string vs a control-char separator), so every
+  // browser-made anchor failed to resolve server-side. This extracts the client's real
+  // elFp chain and pins it to fingerprintOf, end to end.
+  it("the browser client's elFp() equals fingerprintOf() — fields AND separator", () => {
+    const path = fileURLToPath(new URL("../src/anchor.ts", import.meta.url))
+    const src = readFileSync(path, "utf8")
+    const head = "export const ANCHOR_CLIENT_JS = `"
+    const m = src.indexOf(head)
+    let i = m + head.length
+    let end = -1
+    while (i < src.length) {
+      if (src[i] === "\\") {
+        i += 2
+        continue
+      }
+      if (src[i] === "`") {
+        end = i
+        break
+      }
+      i++
+    }
+    const js = src.slice(m + head.length, end).replace(/\\(.)/g, (_, c) => c)
+    const grab = (re: RegExp) => {
+      const g = js.match(re)
+      if (!g) throw new Error(`client fn not found: ${re}`)
+      return g[0]
+    }
+    const clientElFp = new Function(
+      `${grab(/function fnv\(s\)\{[\s\S]*?return h\.toString\(36\)\}/)}
+       ${grab(/function nw\(s\)\{[\s\S]*?\}/)}
+       ${grab(/function elSrc\(el\)\{[\s\S]*?\}/)}
+       ${grab(/function elAlt\(el\)\{[\s\S]*?\}/)}
+       ${grab(/function elText\(el\)\{[\s\S]*?\}/)}
+       ${grab(/function elFp\(el\)\{[\s\S]*?\}/)}
+       return elFp`,
+    )() as (el: unknown) => string
+    const stub = (tag: string, attrs: Record<string, string>, text = "") => ({
+      tagName: tag.toUpperCase(),
+      textContent: text,
+      getAttribute: (k: string) => attrs[k] ?? null,
+    })
+    const cases: Array<[string, Record<string, string>, string]> = [
+      ["img", { src: "https://x.test/a.png?text=Hero%2BChart", alt: "Unique Hero Chart" }, ""],
+      ["iframe", { src: "https://youtube.com/embed/abc" }, ""],
+      ["pre", {}, "const x = 1"],
+      ["img", { src: "a", alt: "b" }, ""], // boundary the separator defends
+    ]
+    for (const [tag, attrs, text] of cases) {
+      expect(clientElFp(stub(tag, attrs, text))).toBe(fingerprintOf({ tag, attrs, text }))
+    }
+    // Proof the separator is load-bearing: these collide if fields are joined with "".
+    expect(fingerprintOf({ tag: "img", attrs: { src: "a", alt: "b" }, text: "" })).not.toBe(
+      fingerprintOf({ tag: "img", attrs: { alt: "ab" }, text: "" }),
+    )
   })
 })

--- a/packages/core/test/element-anchor.test.ts
+++ b/packages/core/test/element-anchor.test.ts
@@ -181,6 +181,19 @@ describe("resolveElement — ambiguity must not breed false confidence", () => {
     if (m) expect(m.band).not.toBe("high")
   })
 
+  it("never claims high confidence when id and content disagree (a content swap)", () => {
+    // Two charts; comment on the red one. Then the two swap their src+alt but keep
+    // their ids — so the comment's id points one way and its content the other. That
+    // conflict can't be "high"; it relocates but flags itself (medium).
+    const v1 = `<p>a</p><img id="A" src="/red.png" alt="Red chart"><p>b</p><img id="B" src="/blue.png" alt="Blue chart"><p>c</p>`
+    const sel = selFor(v1, "img", 0)
+    const v2 = `<p>a</p><img id="A" src="/blue.png" alt="Blue chart"><p>b</p><img id="B" src="/red.png" alt="Red chart"><p>c</p>`
+    const m = elementResolvesIn(sel, v2)
+    expect(m).not.toBeNull()
+    expect(m?.band).not.toBe("high")
+    expect(m?.confidence ?? 1).toBeLessThanOrEqual(0.6)
+  })
+
   it("stays fast + non-crashing on a huge document", () => {
     const huge = `<div>${`<img src="/x.png" alt="t">`.repeat(2000)}</div>`
     const sel = selFor(huge, "img", 1000)

--- a/packages/core/test/element-anchor.test.ts
+++ b/packages/core/test/element-anchor.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest"
+import {
+  type ElementSelector,
+  elementLabel,
+  elementResolvesIn,
+  fingerprintOf,
+  isElementAnchor,
+  parseElementSelector,
+  planElementForwardWalk,
+  resolveElement,
+  roleOf,
+  scanElements,
+} from "../src/element-anchor"
+
+const PAGE = `<!doctype html>
+<html><head><title>Report</title><style>.x{color:red}</style></head>
+<body>
+  <h1>Quarterly report</h1>
+  <p>Revenue climbed across every region this quarter.</p>
+  <img id="rev-chart" src="/charts/revenue.png" alt="Revenue by region">
+  <p>The table below breaks it down.</p>
+  <table><tr><th>Region</th><th>Rev</th></tr><tr><td>EU</td><td>9</td></tr></table>
+  <p>Embedded walkthrough:</p>
+  <iframe src="https://youtube.com/embed/abc"></iframe>
+  <script>var a = 1 < 2; console.log(a)</script>
+</body></html>`
+
+const find = (html: string, tag: string, ordinal = 0) => {
+  const d = scanElements(html).find((x) => x.tag === tag && x.ordinal === ordinal)
+  if (!d) throw new Error(`no ${tag}#${ordinal}`)
+  return d
+}
+
+/** Build a selector the way the client would, from a scanned descriptor. */
+const selFor = (html: string, tag: string, ordinal = 0): ElementSelector => {
+  const ds = scanElements(html)
+  const d = ds.find((x) => x.tag === tag && x.ordinal === ordinal)
+  if (!d) throw new Error(`no ${tag}#${ordinal}`)
+  const before = ds[d.index - 1]?.text
+  const after = ds[d.index + 1]?.text
+  const role = roleOf(d)
+  return {
+    type: "ElementSelector",
+    tag: d.tag,
+    role,
+    id: d.id,
+    fingerprint: fingerprintOf(d),
+    ordinal: d.ordinal,
+    docFraction: d.srcFraction,
+    before,
+    after,
+    snapshot: { tag: d.tag, label: elementLabel({ ...d, role }) },
+  }
+}
+
+describe("scanElements", () => {
+  it("indexes elements in document order with same-tag ordinals", () => {
+    const ds = scanElements(PAGE)
+    const ps = ds.filter((d) => d.tag === "p")
+    expect(ps.map((p) => p.ordinal)).toEqual([0, 1, 2])
+    expect(ps[0]?.text).toContain("Revenue climbed")
+  })
+
+  it("captures id, classes, and kept attrs", () => {
+    const img = find(PAGE, "img")
+    expect(img.id).toBe("rev-chart")
+    expect(img.attrs.src).toBe("/charts/revenue.png")
+    expect(img.attrs.alt).toBe("Revenue by region")
+  })
+
+  it("skips script/style content (and their stray < characters)", () => {
+    const ds = scanElements(PAGE)
+    expect(ds.some((d) => d.tag === "script" || d.tag === "style")).toBe(false)
+    // The `1 < 2` inside the script must not derail tokenizing the iframe before it.
+    expect(ds.some((d) => d.tag === "iframe")).toBe(true)
+  })
+
+  it("treats void elements as childless and decodes entities", () => {
+    const ds = scanElements(`<p>a &amp; b &lt;ok&gt;</p><img src="x.png"><p>after</p>`)
+    expect(ds.find((d) => d.tag === "p")?.text).toBe("a & b <ok>")
+    expect(ds.filter((d) => d.tag === "p")).toHaveLength(2)
+  })
+})
+
+describe("roleOf + elementLabel", () => {
+  it("classifies common elements", () => {
+    expect(roleOf(find(PAGE, "img"))).toBe("image")
+    expect(roleOf(find(PAGE, "table"))).toBe("table")
+    expect(roleOf(find(PAGE, "iframe"))).toBe("embed")
+  })
+  it("reads chart hints from class/id", () => {
+    const d = find(`<div class="bar-chart" id="x"></div>`, "div")
+    expect(roleOf(d)).toBe("chart")
+  })
+  it("labels with alt / host", () => {
+    const img = find(PAGE, "img")
+    expect(elementLabel({ ...img, role: "image" })).toBe("Image — Revenue by region")
+    const ifr = find(PAGE, "iframe")
+    expect(elementLabel({ ...ifr, role: "embed" })).toBe("Embedded — youtube.com")
+  })
+})
+
+describe("resolveElement — the cascade", () => {
+  it("resolves an unchanged element with high confidence", () => {
+    const sel = selFor(PAGE, "img")
+    const m = elementResolvesIn(sel, PAGE)
+    expect(m?.confidence).toBeGreaterThan(0.6)
+    expect(m?.band).toBe("high")
+    expect(m?.signals).toContain("id")
+    expect(m?.signals).toContain("content")
+  })
+
+  it("relocates by content fingerprint when the id is dropped", () => {
+    const sel = selFor(PAGE, "img")
+    const v2 = PAGE.replace(' id="rev-chart"', "")
+    const m = elementResolvesIn(sel, v2)
+    expect(m).not.toBeNull()
+    expect(m?.signals).toContain("content")
+    expect(m?.band).toBe("high")
+  })
+
+  it("relocates by id + neighbors when the image src changes (fingerprint breaks)", () => {
+    const sel = selFor(PAGE, "img")
+    const v2 = PAGE.replace("/charts/revenue.png", "/charts/revenue-v2.png").replace(
+      'alt="Revenue by region"',
+      'alt="Revenue, restated"',
+    )
+    const m = elementResolvesIn(sel, v2)
+    expect(m).not.toBeNull()
+    expect(m?.signals).toContain("id")
+  })
+
+  it("survives content landing above it (ordinal + neighbors shift, id holds)", () => {
+    const sel = selFor(PAGE, "img")
+    const v2 = PAGE.replace("<h1>", '<p>New intro paragraph.</p><img src="top.png"><h1>')
+    const m = elementResolvesIn(sel, v2)
+    expect(m).not.toBeNull()
+    const ds = scanElements(v2)
+    expect(ds[m?.index ?? -1]?.id).toBe("rev-chart")
+  })
+
+  it("does not resolve a genuinely removed element", () => {
+    const sel = selFor(PAGE, "iframe")
+    const v2 = PAGE.replace(/<iframe[^>]*><\/iframe>/, "")
+    expect(elementResolvesIn(sel, v2)).toBeNull()
+  })
+
+  it("disambiguates duplicate tags by ordinal + neighbors", () => {
+    const html = `<p>alpha</p><img src="a.png" alt="A"><p>between</p><img src="a.png" alt="A"><p>omega</p>`
+    const sel = selFor(html, "img", 1) // the second image
+    const m = elementResolvesIn(sel, html)
+    const ds = scanElements(html)
+    expect(ds[m?.index ?? -1]?.ordinal).toBe(1)
+    expect(m?.signals).toContain("position")
+  })
+})
+
+describe("planElementForwardWalk — version recovery", () => {
+  it("recovers an element renamed then moved across versions", () => {
+    const v0 = PAGE
+    const sel = selFor(v0, "img")
+    // v1: id renamed. v2: also moved up. v3: alt reworded too.
+    const v1 = v0.replace('id="rev-chart"', 'id="chart-revenue"')
+    const v2 = v1.replace("<h1>", "<p>Preface.</p><h1>")
+    const v3 = v2.replace('alt="Revenue by region"', 'alt="Revenue by region (FY)"')
+    // First-to-last is unrecognizable by id; per-hop it stays resolvable.
+    const walk = planElementForwardWalk(sel, [v1, v2, v3])
+    expect(walk.resolved).toBe(true)
+    expect(walk.survived).toBe(3)
+    // The carried-forward selector picked up the new id along the way.
+    expect(walk.selector.id).toBe("chart-revenue")
+  })
+
+  it("reports where the trail goes cold", () => {
+    const sel = selFor(PAGE, "iframe")
+    const gone = PAGE.replace(/<iframe[^>]*><\/iframe>/, "<p>removed</p>")
+    const walk = planElementForwardWalk(sel, [PAGE, gone, PAGE])
+    expect(walk.resolved).toBe(false)
+    expect(walk.survived).toBe(1)
+  })
+})
+
+describe("parse helpers", () => {
+  it("recognizes element anchors and rejects text quotes", () => {
+    const el = JSON.stringify(selFor(PAGE, "img"))
+    expect(isElementAnchor(el)).toBe(true)
+    expect(parseElementSelector(el)?.tag).toBe("img")
+    expect(isElementAnchor(JSON.stringify({ type: "TextQuoteSelector", exact: "hi" }))).toBe(false)
+    expect(isElementAnchor(null)).toBe(false)
+    expect(isElementAnchor("not json")).toBe(false)
+  })
+})
+
+describe("resolveElement edge cases", () => {
+  it("returns null on an empty document", () => {
+    expect(resolveElement(selFor(PAGE, "img"), [])).toBeNull()
+  })
+  it("fingerprint is stable + order-independent of the page it came from", () => {
+    const a = fingerprintOf(find(PAGE, "img"))
+    const b = fingerprintOf(
+      find(`<img id="rev-chart" src="/charts/revenue.png" alt="Revenue by region">`, "img"),
+    )
+    expect(a).toBe(b)
+  })
+})

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -330,7 +330,7 @@ export class PgMetaStore implements MetaStore {
 
   async updateComment(
     id: string,
-    fields: { body_md?: string; meta?: string | null },
+    fields: { body_md?: string; meta?: string | null; anchor?: string | null },
   ): Promise<CommentRecord | null> {
     const rows = await this.db.update(comment).set(fields).where(eq(comment.id, id)).returning()
     return rows[0] ?? null

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -481,7 +481,7 @@ export function makeRepos(db: SqliteDb) {
 
   const updateComment = async (
     id: string,
-    fields: { body_md?: string; meta?: string | null },
+    fields: { body_md?: string; meta?: string | null; anchor?: string | null },
   ): Promise<CommentRecord | null> => {
     await db.update(comment).set(fields).where(eq(comment.id, id)).run()
     return getComment(id)


### PR DESCRIPTION
## Element anchors — pin a comment to a non-text element

Comments could only anchor to a **quoted span of text** (`TextQuoteSelector`). This adds a sibling for everything that isn't prose: **images, charts, tables, embeds, code blocks, figures**. You hover an element (or tap it on mobile), a small chip appears, and the comment pins to that element — surviving republishes the same way text anchors do.

### How it resolves (the cascade)

An element has no "exact text" to grep for, so a single signal is brittle (ids get regenerated, css paths shift when a wrapper is added, an image drifts as content lands above it). Instead we record **several independent signals** and resolve by *agreement* — a layered cascade, strongest to weakest:

```
id → css → content fingerprint → structural ordinal → geometry → neighbours
```

Each agreeing signal adds to a score; the best-scoring element wins, carrying a **confidence + band**. One strong signal (a matching id or an identical content fingerprint) suffices; absent those, several weak ones in agreement still relocate it. Deterministic, no ML, and it runs **identically in the browser** (live DOM) and **on the server** (a dependency-free HTML scanner stands in for the DOM — no parser dependency added).

Two things make it more than a worse text anchor:

- **A preserved snapshot.** We capture what the element looked like at comment time (label, src, truncated outerHTML). If it's later gone, the orphaned comment still shows what it pointed at instead of a dead marker.
- **Forward-walk recovery.** Because every version's HTML is kept, when an element can't be found in the current version we walk the version history forward from where it was made, re-deriving the selector at each hop it still resolves — so an element edited one version at a time (renamed, moved, rewrapped) is recovered even when first-vs-last is unrecognisable. On recovery it self-heals the stored selector.

### The "moved" UI is deliberately quiet

A confident match shows a normal outline + badge. A *low-confidence* relocation shows **no box at rest** — just a dimmed corner badge with a tiny pip, plus a small muted "• moved" marker on the card. The faint outline appears only on hover. Reorders that re-find an element confidently show nothing at all, so the document never nags.

### Where it lives

- `packages/core/src/element-anchor.ts` — model + HTML scanner + cascade + forward-walk (heavily unit-tested)
- `packages/core/src/anchor.ts` `ANCHOR_CLIENT_JS` — in-frame capture (hover chip + mobile tap), cascade resolution, overlay painting
- `apps/api/src/lib/anchor-sweep.ts` — element-aware re-anchor sweep + forward-walk recovery
- `apps/web/src/pages/artifact/` — composer label, orphan snapshot card, "moved" marker

One migration-free DB touch: `updateComment` can now patch `anchor` (existing column) for self-heal.

## Test story: a 20-round adversarial campaign

This was hardened by repeatedly trying to break it. 17 real issues found and fixed, each with a regression test or browser verification:

**Correctness / cascade**
- client/server fingerprint separator mismatch (would have broken *every* browser-made anchor) · gallery false-high confidence · invisible orphaned comments · content-swap over-confidence · repeated-element wrong-instance on insertion · wrapped-element neighbour parity

**Security / abuse** (anchors are writable via the public comment API)
- DoS: a malformed stored anchor crashed the re-anchor sweep on every publish · unbounded anchor size (storage/bandwidth) · `snapshot.src` rendered as `<img>` in the trusted host app (tracking vector)

**Server/browser parity**
- duplicate-attribute first-wins · HTML optional-end-tag rules · the fingerprint hash + field-join pinned identical on both sides

**Browser / layout / dynamic content**
- O(900×) client perf cliff on large galleries · overlays now track live DOM mutations, re-resolve on element replace (tab/SPA), and hide when scrolled out of a clipping container · dedupe so a 60fps-mutating page doesn't re-render the host · forward-walk depth bounded

**Surfaces**
- desktop chip capture verified end-to-end · mobile tap-to-anchor (touch has no hover) · slide-deck anchors show/hide per active slide · multi-comment badge fan-out

All green: core 143 · api 470 · web 58 · typecheck + biome + custom lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
