### PR TITLE
test: unit suite for core/api/web pure logic + security boundaries

### DIFF
--- a/apps/api/test/addressed-helpers.test.ts
+++ b/apps/api/test/addressed-helpers.test.ts
@@ -1,0 +1,136 @@
+import type { CommentRecord, CommentState } from "@dock/core"
+import { beforeEach, describe, expect, it } from "vitest"
+import { markAddressed, releaseAddressed } from "../src/lib/addressed"
+import { parseMeta } from "../src/lib/comments"
+
+// Unit-level guards for the addressed/release helpers. The end-to-end lifecycle
+// (propose -> addressed -> approve/withdraw) is covered by addressed.test.ts; this
+// pins the edge cases that integration test doesn't exercise — resolved-skip,
+// cross-artifact-skip, multi-proposal isolation, and meta preservation.
+
+// A focused in-memory comment store with the same semantics the helpers rely on
+// (setThreadState flips EVERY row sharing a thread id).
+class FakeStore {
+  rows: CommentRecord[] = []
+  async getComment(id: string): Promise<CommentRecord | null> {
+    return this.rows.find((r) => r.id === id) ?? null
+  }
+  async updateComment(
+    id: string,
+    fields: { body_md?: string; meta?: string | null },
+  ): Promise<CommentRecord | null> {
+    const r = this.rows.find((x) => x.id === id)
+    if (!r) return null
+    Object.assign(r, fields)
+    return r
+  }
+  async setThreadState(artifactId: string, threadId: string, state: CommentState): Promise<number> {
+    let n = 0
+    for (const r of this.rows)
+      if (r.artifact_id === artifactId && r.thread_id === threadId) {
+        r.state = state
+        n++
+      }
+    return n
+  }
+  async listComments(
+    artifactId: string,
+    opts?: { state?: CommentState },
+  ): Promise<CommentRecord[]> {
+    return this.rows.filter(
+      (r) => r.artifact_id === artifactId && (!opts?.state || r.state === opts.state),
+    )
+  }
+}
+
+const ART = "art1"
+const row = (over: Partial<CommentRecord> & { id: string }): CommentRecord => ({
+  artifact_id: ART,
+  thread_id: over.id, // default: a root comment (id === thread_id)
+  base_version: 1,
+  path: null,
+  anchor: null,
+  body_md: "feedback",
+  author: "jess",
+  author_id: "u1",
+  state: "open",
+  created_at: "2026-01-01T00:00:00.000Z",
+  meta: null,
+  ...over,
+})
+
+let store: FakeStore
+const rowOf = (id: string) => store.rows.find((r) => r.id === id)
+const stateOf = (id: string) => rowOf(id)?.state
+const addressedBy = (id: string) => parseMeta(rowOf(id)?.meta ?? null).addressed_by
+
+beforeEach(() => {
+  store = new FakeStore()
+})
+
+describe("markAddressed", () => {
+  it("flips open roots to addressed and tags them with the proposal id", async () => {
+    store.rows = [row({ id: "t1" }), row({ id: "t2" })]
+    const marked = await markAddressed(store, ART, "p1", ["t1", "t2"])
+    expect(marked).toEqual(["t1", "t2"])
+    expect(stateOf("t1")).toBe("addressed")
+    expect(addressedBy("t1")).toBe("p1")
+    expect(addressedBy("t2")).toBe("p1")
+  })
+
+  it("skips missing threads, threads on another artifact, and already-resolved threads", async () => {
+    store.rows = [
+      row({ id: "other", artifact_id: "art2" }), // different artifact
+      row({ id: "resolved1", state: "resolved" }), // already settled
+      row({ id: "ok" }), // the only addressable one
+    ]
+    const marked = await markAddressed(store, ART, "p1", ["missing", "other", "resolved1", "ok"])
+    expect(marked).toEqual(["ok"])
+    expect(stateOf("resolved1")).toBe("resolved") // settled feedback stays settled
+    expect(stateOf("ok")).toBe("addressed")
+  })
+
+  it("preserves existing meta when adding the tag", async () => {
+    store.rows = [row({ id: "t1", meta: JSON.stringify({ reactions: { "👍": ["u2"] } }) })]
+    await markAddressed(store, ART, "p1", ["t1"])
+    const md = parseMeta(rowOf("t1")?.meta ?? null)
+    expect(md.reactions).toEqual({ "👍": ["u2"] })
+    expect(md.addressed_by).toBe("p1")
+  })
+})
+
+describe("releaseAddressed", () => {
+  it("resolves the threads a proposal addressed and clears the tag (approve)", async () => {
+    store.rows = [row({ id: "t1" }), row({ id: "t2" })]
+    await markAddressed(store, ART, "p1", ["t1", "t2"])
+    const released = await releaseAddressed(store, ART, "p1", "resolved")
+    expect(released.sort()).toEqual(["t1", "t2"])
+    expect(stateOf("t1")).toBe("resolved")
+    expect(addressedBy("t1")).toBeUndefined()
+  })
+
+  it("reopens the threads when a proposal is withdrawn / sent back (open)", async () => {
+    store.rows = [row({ id: "t1" })]
+    await markAddressed(store, ART, "p1", ["t1"])
+    await releaseAddressed(store, ART, "p1", "open")
+    expect(stateOf("t1")).toBe("open")
+    expect(addressedBy("t1")).toBeUndefined()
+  })
+
+  it("only releases threads addressed by THIS proposal", async () => {
+    store.rows = [row({ id: "t1" }), row({ id: "t2" })]
+    await markAddressed(store, ART, "p1", ["t1"])
+    await markAddressed(store, ART, "p2", ["t2"])
+    const released = await releaseAddressed(store, ART, "p1", "resolved")
+    expect(released).toEqual(["t1"])
+    expect(stateOf("t2")).toBe("addressed") // still pending under p2
+    expect(addressedBy("t2")).toBe("p2")
+  })
+
+  it("is a no-op once nothing is tagged (idempotent)", async () => {
+    store.rows = [row({ id: "t1" })]
+    await markAddressed(store, ART, "p1", ["t1"])
+    await releaseAddressed(store, ART, "p1", "resolved")
+    expect(await releaseAddressed(store, ART, "p1", "resolved")).toEqual([])
+  })
+})

--- a/apps/api/test/comment-helpers.test.ts
+++ b/apps/api/test/comment-helpers.test.ts
@@ -1,0 +1,160 @@
+import type { CommentRecord } from "@dock/core"
+import { describe, expect, it } from "vitest"
+import {
+  commentJson,
+  MAX_MENTIONS,
+  parseMentions,
+  parseMeta,
+  previewOf,
+  quoteOf,
+} from "../src/lib/comments"
+
+describe("parseMentions — defensive against bad clients", () => {
+  it("returns [] for anything that isn't an array", () => {
+    for (const bad of [null, undefined, "x", 5, {}, true]) expect(parseMentions(bad)).toEqual([])
+  })
+
+  it("requires a non-empty string id and a string name (an empty name is allowed)", () => {
+    const input = [
+      null,
+      "nope",
+      { id: "no-name" }, // name missing -> rejected
+      { name: "no-id" }, // id missing -> rejected
+      { id: "", name: "empty-id" }, // empty id -> rejected
+      { id: 7, name: "num-id" }, // non-string id -> rejected
+      { id: "u1", name: "" }, // empty NAME is allowed; id is the key that matters
+      { id: "u2", name: "Valid" },
+    ]
+    expect(parseMentions(input)).toEqual([
+      { id: "u1", name: "" },
+      { id: "u2", name: "Valid" },
+    ])
+  })
+
+  it("dedupes by id, keeping the first occurrence, and preserves order", () => {
+    const input = [
+      { id: "a", name: "Ana" },
+      { id: "b", name: "Bo" },
+      { id: "a", name: "Ana again" },
+    ]
+    expect(parseMentions(input)).toEqual([
+      { id: "a", name: "Ana" },
+      { id: "b", name: "Bo" },
+    ])
+  })
+
+  it("caps the result at MAX_MENTIONS distinct mentions", () => {
+    const input = Array.from({ length: MAX_MENTIONS + 25 }, (_, i) => ({
+      id: `u${i}`,
+      name: `n${i}`,
+    }))
+    expect(parseMentions(input)).toHaveLength(MAX_MENTIONS)
+  })
+})
+
+describe("quoteOf — anchor quote extraction", () => {
+  it("returns the anchor's exact text", () => {
+    expect(quoteOf(JSON.stringify({ type: "TextQuoteSelector", exact: "the headline" }))).toBe(
+      "the headline",
+    )
+  })
+
+  it("returns null for a null, malformed, or exact-less anchor", () => {
+    expect(quoteOf(null)).toBeNull()
+    expect(quoteOf("{not json")).toBeNull()
+    expect(quoteOf(JSON.stringify({ type: "TextQuoteSelector" }))).toBeNull()
+  })
+})
+
+describe("previewOf — single-line notification preview", () => {
+  it("collapses whitespace and trims", () => {
+    expect(previewOf("  the\nquick \t brown   fox  ")).toBe("the quick brown fox")
+  })
+
+  it("leaves a short body intact, including at the 160-char boundary", () => {
+    const exactly160 = "x".repeat(160)
+    expect(previewOf(exactly160)).toBe(exactly160)
+  })
+
+  it("truncates a long body to 159 chars plus an ellipsis", () => {
+    const preview = previewOf("y".repeat(200))
+    expect(preview).toHaveLength(160)
+    expect(preview.endsWith("…")).toBe(true)
+    expect(preview.slice(0, -1)).toBe("y".repeat(159))
+  })
+})
+
+describe("parseMeta", () => {
+  it("returns {} for null or malformed JSON, and the parsed object otherwise", () => {
+    expect(parseMeta(null)).toEqual({})
+    expect(parseMeta("{oops")).toEqual({})
+    expect(parseMeta(JSON.stringify({ edited_at: "t", deleted: true }))).toEqual({
+      edited_at: "t",
+      deleted: true,
+    })
+  })
+})
+
+const cm = (over: Partial<CommentRecord> = {}): CommentRecord => ({
+  id: "c1",
+  artifact_id: "a1",
+  thread_id: "t1",
+  base_version: 1,
+  path: null,
+  anchor: null,
+  body_md: "hello there",
+  author: "jess",
+  author_id: "u1",
+  state: "open",
+  created_at: "2026-01-01T00:00:00.000Z",
+  meta: null,
+  ...over,
+})
+
+describe("commentJson — wire shape", () => {
+  it("drops the raw meta blob and surfaces clean defaults", () => {
+    const out = commentJson(cm())
+    expect(out).not.toHaveProperty("meta")
+    expect(out.body_md).toBe("hello there")
+    expect(out.reactions).toEqual({})
+    expect(out.edited).toBe(false)
+    expect(out.edited_at).toBeNull()
+    expect(out.deleted).toBe(false)
+    expect(out.mentions).toEqual([])
+    expect(out).not.toHaveProperty("anchored")
+  })
+
+  it("unpacks reactions, edited, and mentions from meta", () => {
+    const out = commentJson(
+      cm({
+        meta: JSON.stringify({
+          reactions: { "👍": ["u2"] },
+          edited_at: "2026-01-02T00:00:00.000Z",
+          mentions: [{ id: "u9", name: "Sky" }],
+        }),
+      }),
+    )
+    expect(out.reactions).toEqual({ "👍": ["u2"] })
+    expect(out.edited).toBe(true)
+    expect(out.edited_at).toBe("2026-01-02T00:00:00.000Z")
+    expect(out.mentions).toEqual([{ id: "u9", name: "Sky" }])
+  })
+
+  it("blanks the body and mentions of a deleted comment (no content leak)", () => {
+    const out = commentJson(
+      cm({
+        body_md: "secret content",
+        meta: JSON.stringify({ deleted: true, mentions: [{ id: "u9", name: "Sky" }] }),
+      }),
+    )
+    expect(out.deleted).toBe(true)
+    expect(out.body_md).toBe("")
+    expect(out.mentions).toEqual([])
+  })
+
+  it("includes the anchored flag only when it is passed", () => {
+    expect(commentJson(cm(), true).anchored).toBe(true)
+    expect(commentJson(cm(), false).anchored).toBe(false)
+    expect(commentJson(cm())).not.toHaveProperty("anchored")
+  })
+})

--- a/apps/api/test/crypto.test.ts
+++ b/apps/api/test/crypto.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest"
+import {
+  decryptSecret,
+  encryptSecret,
+  hashPassword,
+  safeEqual,
+  sha256,
+  signState,
+  unlockCookie,
+  unlockToken,
+  verifyPassword,
+  verifyState,
+} from "../src/lib/crypto"
+
+describe("sha256", () => {
+  it("matches known SHA-256 vectors (hex)", () => {
+    expect(sha256("")).toBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+    expect(sha256("abc")).toBe("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+  })
+})
+
+describe("signState / verifyState — signed, expiring state tokens", () => {
+  const secret = "server-secret"
+  const T = 1_700_000_000_000
+
+  it("round-trips the payload and stamps iat", () => {
+    const token = signState({ org: "o1", user: "u1" }, secret, T)
+    const out = verifyState<{ org: string; user: string; iat: number }>(token, secret, undefined, T)
+    expect(out).toMatchObject({ org: "o1", user: "u1", iat: T })
+  })
+
+  it("rejects a tampered body or signature", () => {
+    const token = signState({ org: "o1" }, secret, T)
+    const [body, sig] = token.split(".")
+    expect(verifyState(`${body}x.${sig}`, secret, undefined, T)).toBeNull()
+    expect(verifyState(`${body}.${sig}x`, secret, undefined, T)).toBeNull()
+  })
+
+  it("rejects a token signed with a different secret (binds to the auth secret)", () => {
+    const token = signState({ org: "o1" }, secret, T)
+    expect(verifyState(token, "other-secret", undefined, T)).toBeNull()
+  })
+
+  it("rejects an expired token and one with a future iat (clock-skew guard)", () => {
+    const maxAge = 15 * 60_000
+    const token = signState({ org: "o1" }, secret, T)
+    // Verified just past the window -> expired.
+    expect(verifyState(token, secret, maxAge, T + maxAge + 1)).toBeNull()
+    // A token whose iat is well in the future of the verifier -> rejected.
+    const future = signState({ org: "o1" }, secret, T + 120_000)
+    expect(verifyState(future, secret, maxAge, T)).toBeNull()
+  })
+
+  it("returns null for a malformed token", () => {
+    expect(verifyState("nodot", secret)).toBeNull()
+    expect(verifyState("a.b.c", secret)).toBeNull()
+  })
+})
+
+describe("encryptSecret / decryptSecret — AES-256-GCM at rest", () => {
+  const pass = "passphrase"
+
+  it("round-trips, including unicode", () => {
+    const blob = encryptSecret("ghp_secret-token", pass)
+    expect(decryptSecret(blob, pass)).toBe("ghp_secret-token")
+    expect(decryptSecret(encryptSecret("héllo 🔒", pass), pass)).toBe("héllo 🔒")
+  })
+
+  it("produces a v1 envelope with a 12-byte IV that hides the plaintext", () => {
+    const parts = encryptSecret("topsecret", pass).split(".")
+    expect(parts[0]).toBe("v1")
+    expect(parts).toHaveLength(4) // v1.iv.tag.ciphertext
+    // A 12-byte GCM IV is embedded — 12 bytes is exactly 16 base64url chars (no
+    // padding). The round-trip test proves decryption uses it; freshness per call
+    // is node's randomBytes contract, not ours.
+    expect(parts[1]).toMatch(/^[\w-]{16}$/)
+    expect(parts.join(".")).not.toContain("topsecret")
+  })
+
+  it("does not reveal the plaintext under a wrong key or tampering (fails closed)", () => {
+    const blob = encryptSecret("topsecret", pass)
+    // Wrong key: returns the (still-encrypted) blob, never the plaintext.
+    expect(decryptSecret(blob, "wrong")).not.toBe("topsecret")
+    // Tampered ciphertext fails the GCM auth tag and is not decoded to plaintext.
+    const p = blob.split(".")
+    const tampered = `${p.slice(0, 3).join(".")}.${(p[3] ?? "").slice(0, -2)}AA`
+    expect(decryptSecret(tampered, pass)).not.toBe("topsecret")
+  })
+
+  it("passes through a value stored before encryption was configured", () => {
+    expect(decryptSecret("plain-legacy-value", pass)).toBe("plain-legacy-value")
+  })
+})
+
+describe("hashPassword / verifyPassword — salted, hashed at rest", () => {
+  it("verifies the right password and rejects the wrong one", () => {
+    const stored = hashPassword("hunter2")
+    expect(verifyPassword("hunter2", stored)).toBe(true)
+    expect(verifyPassword("Hunter2", stored)).toBe(false)
+  })
+
+  it("stores a salt alongside the sha256 digest, and verifies against it", () => {
+    const [salt, digest] = hashPassword("same").split(".")
+    expect(salt).toBeTruthy() // a per-hash salt is prepended (its randomness is node's job)
+    expect(digest).toMatch(/^[0-9a-f]{64}$/) // sha256 hex
+    expect(verifyPassword("same", hashPassword("same"))).toBe(true)
+  })
+
+  it("rejects null / empty / malformed stored values", () => {
+    for (const bad of [null, undefined, "", "nodot", "salt.", ".digest"])
+      expect(verifyPassword("x", bad)).toBe(false)
+  })
+})
+
+describe("safeEqual — constant-time compare", () => {
+  it("is true only for equal strings, and never for an unset/empty secret", () => {
+    expect(safeEqual("token", "token")).toBe(true)
+    expect(safeEqual("token", "tokeN")).toBe(false)
+    expect(safeEqual("token", undefined)).toBe(false)
+    // An empty secret is treated as unset and never matches (even an empty input).
+    expect(safeEqual("", "")).toBe(false)
+  })
+})
+
+describe("unlock tokens", () => {
+  it("derives a deterministic unlock token that invalidates when the hash changes", () => {
+    const t1 = unlockToken("art1", "hashA")
+    expect(unlockToken("art1", "hashA")).toBe(t1) // stable
+    expect(unlockToken("art1", "hashB")).not.toBe(t1) // password changed -> cookie invalid
+    expect(unlockToken("art2", "hashA")).not.toBe(t1) // per-artifact
+  })
+
+  it("names the unlock cookie per artifact", () => {
+    expect(unlockCookie("ab12cd34")).toBe("dku_ab12cd34")
+  })
+})

--- a/apps/api/test/http-helpers.test.ts
+++ b/apps/api/test/http-helpers.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest"
+import {
+  anonName,
+  isWorkspaceRole,
+  rewriteAbsoluteUrls,
+  str,
+  toBody,
+  visibilityOf,
+} from "../src/lib/http"
+
+describe("rewriteAbsoluteUrls — keep bundle pages inside their path scope", () => {
+  const p = "/raw/abc/v/1"
+
+  it("prefixes root-absolute URLs in the relevant attributes", () => {
+    expect(rewriteAbsoluteUrls('<a href="/about">', p)).toBe(`<a href="${p}/about">`)
+    expect(rewriteAbsoluteUrls("<img src='/logo.png'>", p)).toBe(`<img src='${p}/logo.png'>`)
+    expect(rewriteAbsoluteUrls('<form action="/submit">', p)).toBe(`<form action="${p}/submit">`)
+    expect(rewriteAbsoluteUrls('<video poster="/p.png">', p)).toBe(`<video poster="${p}/p.png">`)
+  })
+
+  it("prefixes CSS url(...) references, quoted or bare", () => {
+    expect(rewriteAbsoluteUrls("background:url(/bg.png)", p)).toBe(`background:url(${p}/bg.png)`)
+    expect(rewriteAbsoluteUrls("background:url('/bg.png')", p)).toBe(
+      `background:url('${p}/bg.png')`,
+    )
+  })
+
+  it("does NOT touch protocol-relative or absolute URLs (no escape, no double-rewrite)", () => {
+    expect(rewriteAbsoluteUrls('<a href="//cdn.example.com/x">', p)).toBe(
+      '<a href="//cdn.example.com/x">',
+    )
+    expect(rewriteAbsoluteUrls('<a href="https://example.com/x">', p)).toBe(
+      '<a href="https://example.com/x">',
+    )
+  })
+
+  it("leaves relative URLs and unrelated attributes alone", () => {
+    expect(rewriteAbsoluteUrls('<a href="about.html">', p)).toBe('<a href="about.html">')
+    expect(rewriteAbsoluteUrls('<a data-x="/y">', p)).toBe('<a data-x="/y">')
+  })
+})
+
+describe("anonName — deterministic friendly name from a seed", () => {
+  it("is stable for a given seed", () => {
+    expect(anonName("viewer-1")).toBe(anonName("viewer-1"))
+  })
+
+  it("has an adjective-animal-NN shape with a two-digit suffix", () => {
+    const name = anonName("seed")
+    expect(name).toMatch(/-\d{1,2}$/)
+    expect(name.split("-").length).toBeGreaterThanOrEqual(3)
+  })
+
+  it("varies across seeds (not a constant)", () => {
+    const names = new Set(Array.from({ length: 20 }, (_, i) => anonName(`viewer-${i}`)))
+    expect(names.size).toBeGreaterThan(1)
+  })
+})
+
+describe("isWorkspaceRole — the Admin/Creator/Viewer workspace roles", () => {
+  it("accepts owner/editor/commenter and rejects a bare viewer and junk", () => {
+    expect(isWorkspaceRole("owner")).toBe(true)
+    expect(isWorkspaceRole("editor")).toBe(true)
+    expect(isWorkspaceRole("commenter")).toBe(true)
+    // A read-only "viewer" is not offered as a workspace role (a Viewer can comment).
+    expect(isWorkspaceRole("viewer")).toBe(false)
+    for (const bad of ["admin", "", null, undefined, 1, {}])
+      expect(isWorkspaceRole(bad)).toBe(false)
+  })
+})
+
+describe("str / visibilityOf — input coercion", () => {
+  it("str returns a non-empty string or undefined", () => {
+    expect(str("x")).toBe("x")
+    expect(str("")).toBeUndefined()
+    expect(str(5)).toBeUndefined()
+    expect(str(null)).toBeUndefined()
+  })
+
+  it("visibilityOf accepts only the known visibilities", () => {
+    for (const v of ["public", "link", "org", "password"]) expect(visibilityOf(v)).toBe(v)
+    for (const bad of ["private", "", "PUBLIC", null, 3]) expect(visibilityOf(bad)).toBeUndefined()
+  })
+})
+
+describe("toBody — Uint8Array to a detached ArrayBuffer copy", () => {
+  it("copies the bytes and does not alias the source", () => {
+    const src = Uint8Array.from([1, 2, 3])
+    const buf = toBody(src)
+    expect(new Uint8Array(buf)).toEqual(Uint8Array.from([1, 2, 3]))
+    src[0] = 99 // mutate the source after the copy
+    expect(new Uint8Array(buf)[0]).toBe(1) // copy is unaffected
+  })
+})

--- a/apps/api/test/image.test.ts
+++ b/apps/api/test/image.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+import { MAX_AVATAR_BYTES, sniffImageType } from "../src/lib/image"
+
+const bytes = (...vals: number[]) => Uint8Array.from(vals)
+const text = (s: string) => new TextEncoder().encode(s)
+
+// Minimal real magic-byte headers for each accepted raster format.
+const PNG = bytes(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a)
+const JPEG = bytes(0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10)
+const GIF89a = text("GIF89a")
+const GIF87a = text("GIF87a")
+const WEBP = bytes(0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50) // RIFF....WEBP
+
+describe("sniffImageType — accepts only raster images, by magic bytes", () => {
+  it("identifies each supported format from its header", () => {
+    expect(sniffImageType(PNG)).toBe("image/png")
+    expect(sniffImageType(JPEG)).toBe("image/jpeg")
+    expect(sniffImageType(GIF89a)).toBe("image/gif")
+    expect(sniffImageType(GIF87a)).toBe("image/gif") // both GIF8 variants
+    expect(sniffImageType(WEBP)).toBe("image/webp")
+  })
+
+  it("ignores trailing bytes after a valid header", () => {
+    expect(sniffImageType(bytes(...PNG, 1, 2, 3, 4, 5))).toBe("image/png")
+  })
+
+  it("rejects SVG outright (it can carry script -> stored XSS)", () => {
+    expect(
+      sniffImageType(text('<svg xmlns="http://www.w3.org/2000/svg"><script/></svg>')),
+    ).toBeNull()
+    expect(sniffImageType(text('<?xml version="1.0"?><svg>'))).toBeNull()
+  })
+
+  it("rejects non-image payloads (html, plain text, empty)", () => {
+    expect(sniffImageType(text("<!doctype html><html></html>"))).toBeNull()
+    expect(sniffImageType(text("just some text"))).toBeNull()
+    expect(sniffImageType(bytes())).toBeNull()
+  })
+
+  it("does not mistake another RIFF container (WAV) for a WEBP image", () => {
+    // Same RIFF prefix, but the subtype at bytes 8..11 is WAVE, not WEBP.
+    const wav = bytes(0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x41, 0x56, 0x45)
+    expect(sniffImageType(wav)).toBeNull()
+  })
+
+  it("rejects a truncated header that can't be verified in full", () => {
+    expect(sniffImageType(bytes(0x89, 0x50))).toBeNull() // partial PNG (needs >= 8)
+    expect(sniffImageType(bytes(0xff, 0xd8))).toBeNull() // partial JPEG (needs >= 3)
+    expect(sniffImageType(WEBP.slice(0, 11))).toBeNull() // RIFF + WEB, one byte short
+  })
+
+  it("does not trust a forged header beyond its own bytes", () => {
+    // PNG magic but only 4 bytes present -> the length guard still rejects it.
+    expect(sniffImageType(bytes(0x89, 0x50, 0x4e, 0x47))).toBeNull()
+  })
+})
+
+describe("MAX_AVATAR_BYTES", () => {
+  it("is 2 MB", () => {
+    expect(MAX_AVATAR_BYTES).toBe(2 * 1024 * 1024)
+  })
+})

--- a/apps/api/test/serve-content.test.ts
+++ b/apps/api/test/serve-content.test.ts
@@ -1,0 +1,206 @@
+import { type BlobStore, BUNDLE_CONTENT_TYPE, type BundleManifest } from "@dock/core"
+import type { Context } from "hono"
+import { describe, expect, it, vi } from "vitest"
+import { RAW_HEADERS } from "../src/lib/http"
+import { serveContent } from "../src/lib/serve-content"
+
+const enc = (s: string) => new TextEncoder().encode(s)
+
+// Fake BlobStore — serveContent only ever calls get().
+const blobStore = (entries: Record<string, Uint8Array | string>): BlobStore => {
+  const map = new Map<string, Uint8Array>()
+  for (const [k, v] of Object.entries(entries)) map.set(k, typeof v === "string" ? enc(v) : v)
+  return { get: async (key: string) => map.get(key) ?? null } as unknown as BlobStore
+}
+
+// Minimal Hono context: serveContent only calls c.body / c.text, each yielding a Response.
+const ctx = (): Context =>
+  ({
+    body: (data: BodyInit | null, status = 200, headers?: Record<string, string>) =>
+      new Response(data, { status, headers }),
+    text: (msg: string, status = 200, headers?: Record<string, string>) =>
+      new Response(msg, { status, headers: headers ?? {} }),
+  }) as unknown as Context
+
+const CSP = RAW_HEADERS["Content-Security-Policy"]
+const IMMUTABLE = "public, max-age=31536000, immutable"
+
+// The opaque-origin sandbox headers must ride EVERY response serveContent produces.
+const expectSandbox = (res: Response, cache: string = IMMUTABLE) => {
+  expect(res.headers.get("content-security-policy")).toBe(CSP)
+  expect(res.headers.get("x-content-type-options")).toBe("nosniff")
+  expect(res.headers.get("x-robots-tag")).toBe("noindex")
+  expect(res.headers.get("cache-control")).toBe(cache)
+}
+
+const SCRIPT = "/raw/dock-client.js" // the appended anchor client (SELECTION_SCRIPT)
+
+describe("serveContent — single-file artifacts", () => {
+  it("serves an HTML file with the anchor client and the sandbox headers", async () => {
+    const res = await serveContent(
+      ctx(),
+      blobStore({ k: "<h1>Hi</h1>" }),
+      { blob_key: "k", content_type: "text/html" },
+      "Title",
+      "/",
+      "",
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toContain("text/html")
+    const body = await res.text()
+    expect(body).toContain("<h1>Hi</h1>")
+    expect(body).toContain(SCRIPT)
+    expectSandbox(res)
+  })
+
+  it("renders markdown to HTML", async () => {
+    const res = await serveContent(
+      ctx(),
+      blobStore({ k: "# Hello" }),
+      { blob_key: "k", content_type: "text/markdown" },
+      "Doc",
+      "/",
+      "",
+    )
+    expect(res.headers.get("content-type")).toContain("text/html")
+    const body = await res.text()
+    expect(body).toContain("<h1")
+    expect(body).toContain(SCRIPT)
+  })
+
+  it("self-heals a blob mislabeled markdown that is actually a full HTML document", async () => {
+    const onMismatch = vi.fn()
+    const html =
+      "<!DOCTYPE html><html><head><style>b{}</style></head><body>real content</body></html>"
+    const res = await serveContent(
+      ctx(),
+      blobStore({ k: html }),
+      { blob_key: "k", content_type: "text/markdown" },
+      null,
+      "/",
+      "",
+      IMMUTABLE,
+      onMismatch,
+    )
+    expect(onMismatch).toHaveBeenCalledOnce()
+    expect(res.headers.get("content-type")).toContain("text/html")
+    const body = await res.text()
+    // Served verbatim (the <style> survives — the markdown path would have stripped it),
+    // never the blank page.
+    expect(body).toContain("<style>b{}</style>")
+    expect(body).toContain("real content")
+    expect(body).toContain(SCRIPT)
+  })
+
+  it("serves ?raw.md as the markdown source verbatim, without the anchor client", async () => {
+    const res = await serveContent(
+      ctx(),
+      blobStore({ k: "# raw source" }),
+      { blob_key: "k", content_type: "text/markdown" },
+      "Doc",
+      "/",
+      "raw.md",
+    )
+    expect(res.headers.get("content-type")).toContain("text/markdown")
+    const body = await res.text()
+    expect(body).toBe("# raw source")
+    expect(body).not.toContain(SCRIPT)
+  })
+
+  it("uses the gated Cache-Control for a non-public artifact (never immutable)", async () => {
+    const res = await serveContent(
+      ctx(),
+      blobStore({ k: "<h1>x</h1>" }),
+      { blob_key: "k", content_type: "text/html" },
+      null,
+      "/",
+      "",
+      "private, no-store",
+    )
+    expectSandbox(res, "private, no-store")
+  })
+
+  it("applies the serve-time HTML transform before appending the anchor client", async () => {
+    const upper = async (h: string) => h.replace("real", "XFORMED")
+    const res = await serveContent(
+      ctx(),
+      blobStore({ k: "<p>real</p>" }),
+      { blob_key: "k", content_type: "text/html" },
+      null,
+      "/",
+      "",
+      IMMUTABLE,
+      undefined,
+      upper,
+    )
+    const body = await res.text()
+    expect(body).toContain("XFORMED")
+    expect(body).toContain(SCRIPT)
+  })
+})
+
+describe("serveContent — bundles", () => {
+  const manifest: BundleManifest = {
+    entry: "/index.html",
+    spa: false,
+    files: {
+      "/index.html": { key: "k_idx", type: "text/html; charset=utf-8" },
+      "/style.css": { key: "k_css", type: "text/css; charset=utf-8" },
+      "/img.png": { key: "k_img", type: "image/png" },
+    },
+  }
+  const prefix = "/raw/abc/v/1/"
+  const bundleBlobs = (over: Partial<Record<string, Uint8Array | string>> = {}) =>
+    blobStore({
+      kManifest: JSON.stringify(manifest),
+      k_idx: '<a href="/deep">home</a>',
+      k_css: "a{color:red}",
+      k_img: Uint8Array.from([1, 2, 3, 4]),
+      ...over,
+    })
+  const content = { blob_key: "kManifest", content_type: BUNDLE_CONTENT_TYPE }
+
+  it("serves the entry page: scope-rewritten links + the anchor client", async () => {
+    const res = await serveContent(ctx(), bundleBlobs(), content, "Site", prefix, "")
+    expect(res.headers.get("content-type")).toContain("text/html")
+    const body = await res.text()
+    expect(body).toContain('href="/raw/abc/v/1/deep"') // root-absolute link kept in scope
+    expect(body).toContain(SCRIPT)
+    expectSandbox(res)
+  })
+
+  it("serves a CSS page rewritten but WITHOUT the anchor client", async () => {
+    const res = await serveContent(ctx(), bundleBlobs(), content, "Site", prefix, "style.css")
+    expect(res.headers.get("content-type")).toContain("text/css")
+    const body = await res.text()
+    expect(body).toBe("a{color:red}")
+    expect(body).not.toContain(SCRIPT)
+  })
+
+  it("serves a binary asset with its own content type, bytes intact", async () => {
+    const res = await serveContent(ctx(), bundleBlobs(), content, "Site", prefix, "img.png")
+    expect(res.headers.get("content-type")).toBe("image/png")
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(Uint8Array.from([1, 2, 3, 4]))
+  })
+
+  it("404s an unknown bundle path, still with the sandbox headers", async () => {
+    const res = await serveContent(ctx(), bundleBlobs(), content, "Site", prefix, "nope.html")
+    expect(res.status).toBe(404)
+    expect(res.headers.get("content-security-policy")).toBe(CSP)
+  })
+
+  it("falls back to the entry page for an SPA route with no matching file", async () => {
+    const spaManifest: BundleManifest = { ...manifest, spa: true }
+    const res = await serveContent(
+      ctx(),
+      bundleBlobs({ kManifest: JSON.stringify(spaManifest) }),
+      content,
+      "Site",
+      prefix,
+      "app/some/route",
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toContain("text/html")
+    expect(await res.text()).toContain("home") // the entry document
+  })
+})

--- a/apps/web/src/lib/username.test.ts
+++ b/apps/web/src/lib/username.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import {
+  normalizeUsername,
+  suggestUsername,
+  USERNAME_MAX,
+  USERNAME_MIN,
+  usernameError,
+} from "./username"
+
+describe("normalizeUsername", () => {
+  it("trims and lowercases", () => {
+    expect(normalizeUsername("  Alice  ")).toBe("alice")
+    expect(normalizeUsername("BoB")).toBe("bob")
+  })
+})
+
+describe("usernameError", () => {
+  it("accepts well-formed usernames (returns null)", () => {
+    for (const ok of ["ab", "alice", "a-b", "a_b", "user123", "a1", "ALICE"])
+      expect(usernameError(ok), ok).toBeNull()
+  })
+
+  it("rejects too short / too long with the length checked first", () => {
+    expect(usernameError("a")).toMatch(/at least 2/)
+    expect(usernameError("")).toMatch(/at least 2/)
+    expect(usernameError("a".repeat(USERNAME_MAX + 1))).toMatch(/30 characters or fewer/)
+    // "a" is also reserved, but the length message wins (length is checked first).
+    expect(usernameError("a")).not.toMatch(/reserved/)
+  })
+
+  it("rejects bad shape: leading/trailing or doubled separators, and stray chars", () => {
+    for (const bad of ["-ab", "ab-", "_ab", "ab_", "a--b", "a__b", "a b", "a.b", "ab!"])
+      expect(usernameError(bad), bad).toMatch(/letters, numbers/)
+  })
+
+  it("rejects reserved names (after normalization)", () => {
+    for (const r of ["admin", "dock", "ME", "Settings", "api"])
+      expect(usernameError(r), r).toMatch(/reserved/)
+  })
+})
+
+describe("suggestUsername", () => {
+  it("derives from a display name", () => {
+    expect(suggestUsername("Alice Smith")).toBe("alice-smith")
+    expect(suggestUsername("Bob")).toBe("bob")
+  })
+
+  it("derives from an email local-part", () => {
+    expect(suggestUsername("john.doe@example.com")).toBe("john-doe")
+  })
+
+  it("never collapses an all-punctuation / empty input to a reserved word", () => {
+    expect(suggestUsername("!!!")).toBe("newuser") // not "user"
+    expect(suggestUsername("@example.com")).toBe("newuser") // empty local-part
+  })
+
+  it("pads a too-short stem past the minimum", () => {
+    expect(suggestUsername("a")).toBe("auser")
+    expect(suggestUsername("x@y.com")).toBe("xuser")
+    expect(suggestUsername("a").length).toBeGreaterThanOrEqual(USERNAME_MIN)
+  })
+
+  it("caps the suggestion at the maximum length with no trailing separator", () => {
+    const long = suggestUsername("a".repeat(50))
+    expect(long.length).toBeLessThanOrEqual(USERNAME_MAX)
+    expect(long.endsWith("-")).toBe(false)
+    expect(long.endsWith("_")).toBe(false)
+  })
+})

--- a/apps/web/src/pages/artifact/lib/markdown.test.ts
+++ b/apps/web/src/pages/artifact/lib/markdown.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+import type { Mention } from "@/api"
+import { mdToHtml } from "./markdown"
+
+const m = (...names: string[]): Mention[] =>
+  names.map((name, i) => ({ id: `u${i}`, name }) as Mention)
+
+describe("mdToHtml — XSS safety (escape first, then transform)", () => {
+  it("escapes raw HTML so it can never render as markup", () => {
+    const out = mdToHtml("<script>alert(1)</script>")
+    expect(out).toContain("&lt;script&gt;")
+    expect(out).not.toContain("<script>")
+  })
+
+  it("escapes HTML even inside inline code", () => {
+    expect(mdToHtml("`<img src=x onerror=alert(1)>`")).toBe(
+      "<code>&lt;img src=x onerror=alert(1)&gt;</code>",
+    )
+  })
+
+  it("escapes ampersands and quotes", () => {
+    expect(mdToHtml('a & "b"')).toBe("a &amp; &quot;b&quot;")
+  })
+
+  it("only linkifies http(s) URLs — a javascript: link stays inert text", () => {
+    const out = mdToHtml("[click](javascript:alert(1))")
+    expect(out).not.toContain("<a")
+    expect(out).not.toContain('href="javascript')
+  })
+})
+
+describe("mdToHtml — inline markdown", () => {
+  it("renders bold, italic, strikethrough, and inline code", () => {
+    expect(mdToHtml("**b**")).toBe("<strong>b</strong>")
+    expect(mdToHtml("a *i* b")).toContain("<em>i</em>")
+    expect(mdToHtml("~~s~~")).toBe("<del>s</del>")
+    expect(mdToHtml("`c`")).toBe("<code>c</code>")
+  })
+
+  it("renders a markdown link with a safe target and rel", () => {
+    expect(mdToHtml("[site](https://example.com/x)")).toBe(
+      '<a href="https://example.com/x" target="_blank" rel="noopener noreferrer">site</a>',
+    )
+  })
+
+  it("autolinks a bare http(s) URL", () => {
+    expect(mdToHtml("see https://x.com now")).toContain(
+      '<a href="https://x.com" target="_blank" rel="noopener noreferrer">https://x.com</a>',
+    )
+  })
+
+  it("turns newlines into <br/>", () => {
+    expect(mdToHtml("line1\nline2")).toBe("line1<br/>line2")
+  })
+})
+
+describe("mdToHtml — @mentions", () => {
+  it("highlights only names from the known mention set", () => {
+    expect(mdToHtml("hi @Alice", m("Alice"))).toBe('hi <span class="mention">@Alice</span>')
+    // @Bob is not in the set, so it stays plain text.
+    expect(mdToHtml("hi @Bob", m("Alice"))).toBe("hi @Bob")
+  })
+
+  it("prefers the longest matching name (full name wins over a prefix)", () => {
+    expect(mdToHtml("@Alice", m("Al", "Alice"))).toBe('<span class="mention">@Alice</span>')
+  })
+
+  it("treats mention names literally (regex metachars are escaped)", () => {
+    // "a.b" must match literally, not as "a<any>b".
+    expect(mdToHtml("@a.b", m("a.b"))).toBe('<span class="mention">@a.b</span>')
+    expect(mdToHtml("@axb", m("a.b"))).toBe("@axb")
+  })
+
+  it("does nothing special when no mentions are supplied", () => {
+    expect(mdToHtml("hi @Alice")).toBe("hi @Alice")
+  })
+})

--- a/packages/core/src/anchor.test.ts
+++ b/packages/core/src/anchor.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest"
+import {
+  type AnchorThread,
+  isAnchored,
+  planAnchorSweep,
+  type QuoteSelector,
+  quoteSelector,
+  reanchor,
+} from "./anchor"
+
+const json = (s: QuoteSelector) => JSON.stringify(s)
+
+describe("quoteSelector", () => {
+  it("captures the exact span plus up to 24 chars of context on each side", () => {
+    const text = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOP"
+    const start = 30
+    const sel = quoteSelector(text, start, 3)
+    expect(sel.exact).toBe(text.slice(30, 33))
+    expect(sel.prefix).toBe(text.slice(6, 30)) // exactly 24 chars
+    expect(sel.prefix).toHaveLength(24)
+    expect(sel.suffix).toBe(text.slice(33, 57)) // clamped to end of string
+  })
+
+  it("clamps the prefix at the start of the text", () => {
+    const sel = quoteSelector("hello world", 0, 5)
+    expect(sel.exact).toBe("hello")
+    expect(sel.prefix).toBe("")
+    expect(sel.suffix).toBe(" world")
+  })
+
+  it("round-trips: a freshly built selector reanchors at its own position", () => {
+    const text = "the quick brown fox jumps over the lazy dog"
+    const at = text.indexOf("brown")
+    const r = reanchor(quoteSelector(text, at, 5), text)
+    expect(r).toEqual({ found: true, index: at })
+  })
+})
+
+describe("reanchor — deterministic resolution order", () => {
+  it("returns the index of the exact span itself, not the context", () => {
+    const text = "alpha beta gamma"
+    const sel = quoteSelector(text, text.indexOf("beta"), 4)
+    const r = reanchor(sel, text)
+    expect(r.found).toBe(true)
+    expect(text.slice(r.index, r.index + sel.exact.length)).toBe("beta")
+  })
+
+  it("prefers the context match, disambiguating a phrase that repeats", () => {
+    // "cat" appears twice; the selector's context belongs to the SECOND one.
+    const text = "the cat sat. the cat ran."
+    const second = text.lastIndexOf("cat")
+    const sel = quoteSelector(text, second, 3)
+    const r = reanchor(sel, text)
+    // Exact-anywhere alone would return the FIRST cat (index 4); context wins.
+    expect(r.index).toBe(second)
+    expect(r.index).not.toBe(text.indexOf("cat"))
+  })
+
+  it("falls back to exact-anywhere when the surrounding context has changed", () => {
+    const sel: QuoteSelector = {
+      type: "TextQuoteSelector",
+      exact: "needle",
+      prefix: "this prefix is long gone ",
+      suffix: " and so is this suffix",
+    }
+    const text = "a haystack with a needle hidden inside"
+    const r = reanchor(sel, text)
+    expect(r).toEqual({ found: true, index: text.indexOf("needle") })
+  })
+
+  it("reports not-found (orphaned) when the exact text is gone", () => {
+    const sel = quoteSelector("keep this phrase around", 5, 4)
+    expect(reanchor(sel, "a totally different document")).toEqual({ found: false, index: -1 })
+  })
+
+  it("treats an empty exact as unresolvable", () => {
+    expect(reanchor({ type: "TextQuoteSelector", exact: "" }, "anything")).toEqual({
+      found: false,
+      index: -1,
+    })
+  })
+
+  it("works with no context fields (exact-only selector)", () => {
+    const r = reanchor({ type: "TextQuoteSelector", exact: "two" }, "one two three")
+    expect(r).toEqual({ found: true, index: 4 })
+  })
+})
+
+describe("isAnchored", () => {
+  const text = "the report covers Q3 revenue"
+
+  it("treats a whole-document (null) anchor as always anchored", () => {
+    expect(isAnchored(null, text)).toBe(true)
+  })
+
+  it("is true when the quote still resolves, false when it is gone", () => {
+    expect(isAnchored(json(quoteSelector(text, text.indexOf("Q3"), 2)), text)).toBe(true)
+    expect(isAnchored(json(quoteSelector(text, text.indexOf("Q3"), 2)), "rewritten copy")).toBe(
+      false,
+    )
+  })
+
+  it("fails open (anchored=true) on malformed or non-quote anchors", () => {
+    expect(isAnchored("not json at all", text)).toBe(true)
+    expect(isAnchored(JSON.stringify({ type: "RangeSelector" }), text)).toBe(true)
+    expect(isAnchored(JSON.stringify({ type: "TextQuoteSelector", exact: "" }), text)).toBe(true)
+  })
+})
+
+describe("planAnchorSweep — the open <-> outdated state machine", () => {
+  const v1 = "intro about alpha, then a section on beta, ending on gamma"
+  const anchorTo = (word: string) => json(quoteSelector(v1, v1.indexOf(word), word.length))
+
+  it("flips an open thread to outdated when its quoted text disappears", () => {
+    const threads: AnchorThread[] = [{ thread_id: "t1", anchor: anchorTo("beta"), state: "open" }]
+    const v2 = "intro about alpha, then a section on BETA-RENAMED, ending on gamma"
+    expect(planAnchorSweep(threads, v2)).toEqual([{ thread_id: "t1", state: "outdated" }])
+  })
+
+  it("reopens an outdated thread when its text comes back", () => {
+    const threads: AnchorThread[] = [
+      { thread_id: "t1", anchor: anchorTo("beta"), state: "outdated" },
+    ]
+    expect(planAnchorSweep(threads, v1)).toEqual([{ thread_id: "t1", state: "open" }])
+  })
+
+  it("leaves a still-resolving open thread and a still-missing outdated thread untouched", () => {
+    const threads: AnchorThread[] = [
+      { thread_id: "stable", anchor: anchorTo("alpha"), state: "open" },
+      { thread_id: "stillgone", anchor: anchorTo("beta"), state: "outdated" },
+    ]
+    const v2 = "intro about alpha, then a section on (removed), ending on gamma"
+    expect(planAnchorSweep(threads, v2)).toEqual([])
+  })
+
+  it("never touches resolved threads or whole-document (un-anchored) threads", () => {
+    const threads: AnchorThread[] = [
+      { thread_id: "resolved", anchor: anchorTo("beta"), state: "resolved" },
+      { thread_id: "wholedoc", anchor: null, state: "open" },
+    ]
+    // "beta" is gone and the whole-doc thread is open, yet neither flips.
+    expect(planAnchorSweep(threads, "nothing matches here")).toEqual([])
+  })
+
+  it("returns one transition per affected thread, only for the threads that changed", () => {
+    const threads: AnchorThread[] = [
+      { thread_id: "gone", anchor: anchorTo("beta"), state: "open" }, // -> outdated
+      { thread_id: "back", anchor: anchorTo("gamma"), state: "outdated" }, // -> open
+      { thread_id: "fine", anchor: anchorTo("alpha"), state: "open" }, // unchanged
+    ]
+    const v2 = "intro about alpha, then a section on (gone), ending on gamma"
+    expect(planAnchorSweep(threads, v2)).toEqual([
+      { thread_id: "gone", state: "outdated" },
+      { thread_id: "back", state: "open" },
+    ])
+  })
+})

--- a/packages/core/src/diff.test.ts
+++ b/packages/core/src/diff.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest"
+import { type DiffOp, diffLines, formatDiff } from "./diff"
+
+// The defining property of a correct line diff: dropping the additions and
+// rejoining recovers the OLD text exactly; dropping the deletions recovers the NEW
+// text. (ctx lines belong to both, add only to new, del only to old.)
+const oldFrom = (ops: DiffOp[]) =>
+  ops
+    .filter((o) => o.t !== "add")
+    .map((o) => o.line)
+    .join("\n")
+const newFrom = (ops: DiffOp[]) =>
+  ops
+    .filter((o) => o.t !== "del")
+    .map((o) => o.line)
+    .join("\n")
+
+describe("diffLines — reconstruction invariant", () => {
+  const cases: [string, string][] = [
+    ["", ""],
+    ["", "a\nb"],
+    ["a\nb", ""],
+    ["same\ntext", "same\ntext"],
+    ["1\n2\n3", "1\n3"], // a deletion in the middle
+    ["1\n3", "1\n2\n3"], // an insertion in the middle
+    ["x", "y"], // a full one-line replace
+    ["a\nb\nc", "c\nb\na"], // a reorder
+    ["alpha\nbeta\ngamma", "alpha\nBETA\ngamma\ndelta"], // change + append
+    ["the\nquick\nbrown\nfox", "the\nslow\nbrown\ncat"], // two scattered changes
+  ]
+
+  it.each(cases)("rebuilds both sides for %j -> %j", (a, b) => {
+    const ops = diffLines(a, b)
+    expect(oldFrom(ops)).toBe(a)
+    expect(newFrom(ops)).toBe(b)
+  })
+})
+
+describe("diffLines — shape of the result", () => {
+  it("marks identical text entirely as context, one op per line", () => {
+    const ops = diffLines("one\ntwo\nthree", "one\ntwo\nthree")
+    expect(ops).toEqual([
+      { t: "ctx", line: "one" },
+      { t: "ctx", line: "two" },
+      { t: "ctx", line: "three" },
+    ])
+  })
+
+  it("keeps the surrounding lines as context around a single edit", () => {
+    expect(diffLines("1\n2\n3", "1\n3")).toEqual([
+      { t: "ctx", line: "1" },
+      { t: "del", line: "2" },
+      { t: "ctx", line: "3" },
+    ])
+  })
+
+  it("maximizes context: the number of ctx ops equals the LCS length", () => {
+    // LCS of (1,2,3,4) and (1,3,4,5) is (1,3,4) -> 3 context lines.
+    const ops = diffLines("1\n2\n3\n4", "1\n3\n4\n5")
+    expect(ops.filter((o) => o.t === "ctx").map((o) => o.line)).toEqual(["1", "3", "4"])
+  })
+
+  it("emits deletions before additions on a changed line (stable tie-break)", () => {
+    expect(diffLines("x", "y")).toEqual([
+      { t: "del", line: "x" },
+      { t: "add", line: "y" },
+    ])
+  })
+
+  it("treats a pure append as context + additions, never deletions", () => {
+    const ops = diffLines("intro", "intro\nbody\noutro")
+    expect(ops.some((o) => o.t === "del")).toBe(false)
+    expect(ops.filter((o) => o.t === "add").map((o) => o.line)).toEqual(["body", "outro"])
+  })
+})
+
+describe("formatDiff", () => {
+  it("prefixes each op: two spaces for context, + for add, - for del", () => {
+    const ops: DiffOp[] = [
+      { t: "ctx", line: "kept" },
+      { t: "del", line: "gone" },
+      { t: "add", line: "new" },
+    ]
+    expect(formatDiff(ops)).toBe("  kept\n- gone\n+ new")
+  })
+
+  it("renders an empty diff as an empty string", () => {
+    expect(formatDiff([])).toBe("")
+  })
+
+  it("round-trips through diffLines into a readable unified diff", () => {
+    expect(formatDiff(diffLines("a\nb\nc", "a\nB\nc"))).toBe("  a\n- b\n+ B\n  c")
+  })
+})

--- a/packages/core/src/ids.test.ts
+++ b/packages/core/src/ids.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+import { candidateShortIds, newId, newShortId, parseRef, refFor, slugify } from "./ids"
+
+describe("newShortId / newId — generated identifiers", () => {
+  it("shape: a short id is 8 base36 chars; a prefixed id is <prefix>_<16>", () => {
+    expect(newShortId()).toMatch(/^[0-9a-z]{8}$/)
+    expect(newId("c")).toMatch(/^c_[0-9a-z]{16}$/)
+    // Uniqueness is nanoid's contract; we only pin the format our code wraps it in.
+  })
+})
+
+describe("slugify", () => {
+  it("lowercases, collapses non-alphanumerics to single dashes, and trims them", () => {
+    expect(slugify("  Hello, World!  ")).toBe("hello-world")
+    expect(slugify("Q3 — Revenue (final)")).toBe("q3-revenue-final")
+  })
+
+  it("drops non-ascii and returns empty for all-symbol input", () => {
+    expect(slugify("café")).toBe("caf") // non-ascii stripped
+    expect(slugify("___")).toBe("")
+    expect(slugify("")).toBe("")
+  })
+
+  it("caps the slug at 48 characters", () => {
+    expect(slugify("a".repeat(60))).toHaveLength(48)
+  })
+})
+
+describe("parseRef — /a/:ref → { shortId, version }", () => {
+  it("reads a bare short id and a name-first ref", () => {
+    expect(parseRef("abc12345")).toEqual({ shortId: "abc12345", version: undefined })
+    expect(parseRef("my-title-abc12345")).toEqual({ shortId: "abc12345", version: undefined })
+  })
+
+  it("parses the @vN version suffix", () => {
+    expect(parseRef("my-title-abc12345@v4")).toEqual({ shortId: "abc12345", version: 4 })
+  })
+
+  it("falls back to the leading token for a legacy short-id-first ref", () => {
+    // trailing "title" is too short to be id-shaped, so the leading id wins.
+    expect(parseRef("abc12345-title")).toEqual({ shortId: "abc12345", version: undefined })
+  })
+
+  it("returns the whole base when no token is id-shaped", () => {
+    expect(parseRef("hi")).toEqual({ shortId: "hi", version: undefined })
+  })
+})
+
+describe("candidateShortIds — resolve-in-order for ambiguous refs", () => {
+  it("offers the trailing token first, then the leading, de-duped", () => {
+    expect(candidateShortIds("my-title-abc12345")).toEqual(["abc12345"])
+    // Both tokens look like ids (a title whose tail is id-shaped): try trailing first.
+    expect(candidateShortIds("abc12345-report99")).toEqual(["report99", "abc12345"])
+    // A bare id resolves to a single candidate (not duplicated).
+    expect(candidateShortIds("abc12345")).toEqual(["abc12345"])
+  })
+
+  it("falls back to the whole base when neither token is id-shaped", () => {
+    expect(candidateShortIds("hi")).toEqual(["hi"])
+  })
+})
+
+describe("refFor — build a readable /a/:ref", () => {
+  it("prefers an explicit slug, else slugifies the title, else bare short id", () => {
+    expect(refFor({ short_id: "abc12345", slug: "my-doc" })).toBe("my-doc-abc12345")
+    expect(refFor({ short_id: "abc12345", title: "My Doc!" })).toBe("my-doc-abc12345")
+    expect(refFor({ short_id: "abc12345" })).toBe("abc12345")
+    // slug wins over title.
+    expect(refFor({ short_id: "abc12345", slug: "chosen", title: "Ignored" })).toBe(
+      "chosen-abc12345",
+    )
+  })
+
+  it("round-trips: a built ref parses back to the same short id", () => {
+    const short = newShortId()
+    const ref = refFor({ short_id: short, title: "Quarterly Revenue Review" })
+    expect(parseRef(ref).shortId).toBe(short)
+    expect(candidateShortIds(ref)).toContain(short)
+  })
+})

--- a/packages/core/src/md.test.ts
+++ b/packages/core/src/md.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest"
+import { escapeHtml, renderMarkdown } from "./md"
+
+// The body content (between <main>…</main>) is the user-controlled markdown after
+// sanitization — assert against this so the page's own (trusted) script tag and
+// chrome don't muddy the checks.
+const bodyOf = (html: string) => html.split("<main>")[1]?.split("</main>")[0] ?? ""
+
+describe("renderMarkdown — renders ordinary markdown", () => {
+  it("turns common markdown into the expected HTML", async () => {
+    const body = bodyOf(
+      await renderMarkdown("# Title\n\n**bold** and `code` and [x](https://a.com)", null),
+    )
+    expect(body).toContain("<h1")
+    expect(body).toContain("Title</h1>")
+    expect(body).toContain("<strong>bold</strong>")
+    expect(body).toContain("<code>code</code>")
+    expect(body).toContain('href="https://a.com"')
+  })
+
+  it("renders GFM tables", async () => {
+    const body = bodyOf(await renderMarkdown("| a | b |\n|---|---|\n| 1 | 2 |", null))
+    expect(body).toContain("<table")
+    expect(body).toContain("<td>1</td>")
+  })
+})
+
+describe("renderMarkdown — XSS sanitization (the security guard)", () => {
+  it("escapes a raw <script> tag instead of emitting it", async () => {
+    const html = await renderMarkdown("<script>alert(1)</script>", null)
+    expect(bodyOf(html)).toContain("&lt;script&gt;")
+    // No executable script wrapping the payload made it through.
+    expect(html).not.toMatch(/<script>[^<]*alert\(1\)/i)
+  })
+
+  it("strips event-handler attributes from inline HTML", async () => {
+    const body = bodyOf(await renderMarkdown('<img src="x.png" onerror="alert(2)">', null))
+    expect(body).toContain("<img")
+    expect(body).not.toMatch(/onerror\s*=/i)
+    expect(body).not.toContain("alert(2)")
+  })
+
+  it("keeps the source on an ordinary markdown image", async () => {
+    const body = bodyOf(await renderMarkdown("![pic](https://cdn.test/p.png)", null))
+    expect(body).toMatch(/<img[^>]+src="https:\/\/cdn\.test\/p\.png"/)
+  })
+
+  it("neutralizes javascript: URLs in links", async () => {
+    const html = await renderMarkdown('<a href="javascript:alert(3)">click</a>', null)
+    expect(html).not.toMatch(/javascript:/i)
+  })
+
+  it("escapes a disallowed tag (iframe) rather than rendering it", async () => {
+    const body = bodyOf(await renderMarkdown('<iframe src="evil"></iframe>', null))
+    expect(body).not.toMatch(/<iframe/i)
+    expect(body).toContain("&lt;iframe")
+  })
+})
+
+describe("renderMarkdown — document shell", () => {
+  it("wraps the body in a full HTML document with the anchor client", async () => {
+    const html = await renderMarkdown("hello", "My Doc")
+    expect(html.startsWith("<!doctype html>")).toBe(true)
+    expect(html).toContain("<main>")
+    expect(html).toContain("<title>My Doc</title>")
+    expect(html).toContain("/raw/dock-client.js") // SELECTION_SCRIPT
+  })
+
+  it("defaults a null title to Document", async () => {
+    expect(await renderMarkdown("hi", null)).toContain("<title>Document</title>")
+  })
+
+  it("escapes the title so it can't break out of <title> or inject script", async () => {
+    const html = await renderMarkdown("body", "</title><script>alert(1)</script>")
+    expect(html).toContain("&lt;/title&gt;&lt;script&gt;alert(1)&lt;/script&gt;")
+    expect(html).not.toContain("</title><script>alert(1)")
+  })
+})
+
+describe("escapeHtml", () => {
+  it("escapes &, <, >, and double quotes", () => {
+    expect(escapeHtml('&<>"')).toBe("&amp;&lt;&gt;&quot;")
+  })
+
+  it("escapes the ampersand first so entities are not double-escaped", () => {
+    expect(escapeHtml("<")).toBe("&lt;")
+    expect(escapeHtml("a & b")).toBe("a &amp; b")
+  })
+
+  it("leaves plain text and single quotes untouched", () => {
+    expect(escapeHtml("hello world")).toBe("hello world")
+    expect(escapeHtml("it's fine")).toBe("it's fine")
+  })
+})

--- a/packages/core/src/permissions.test.ts
+++ b/packages/core/src/permissions.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest"
+import {
+  type Action,
+  type Actor,
+  can,
+  effectiveRole,
+  type GeneralRole,
+  isRole,
+  maxRole,
+  ROLES,
+  type Role,
+  roleAllows,
+} from "./permissions"
+import type { Visibility } from "./ports"
+
+const ACTIONS: Action[] = ["read", "comment", "propose", "publish", "approve", "share", "manage"]
+const VISIBILITIES: Visibility[] = ["public", "link", "password", "org"]
+const WRITE_ACTIONS: Action[] = ["comment", "propose", "publish", "approve", "share", "manage"]
+
+// The authoritative access matrix: the minimum role each action requires. This is
+// the security contract — duplicated from NEEDS in permissions.ts on purpose so a
+// change to the gate must be a DELIBERATE change here too, never a silent drift.
+const MIN_ROLE: Record<Action, Role> = {
+  read: "viewer",
+  comment: "commenter",
+  propose: "commenter",
+  publish: "editor",
+  approve: "editor",
+  share: "editor",
+  manage: "owner",
+}
+
+const rank = (r: Role) => ROLES.indexOf(r)
+
+describe("roleAllows — the action/role matrix", () => {
+  it("permits exactly the roles at or above each action's minimum", () => {
+    for (const action of ACTIONS) {
+      for (const role of ROLES) {
+        const expected = rank(role) >= rank(MIN_ROLE[action])
+        expect(roleAllows(role, action), `${role} → ${action}`).toBe(expected)
+      }
+    }
+  })
+
+  it("is monotonic: a higher role can do everything a lower role can", () => {
+    for (let i = 0; i < ROLES.length - 1; i++) {
+      const lower = ROLES[i] as Role
+      const higher = ROLES[i + 1] as Role
+      for (const action of ACTIONS)
+        if (roleAllows(lower, action))
+          expect(roleAllows(higher, action), `${higher} ⊇ ${lower} for ${action}`).toBe(true)
+    }
+  })
+
+  it("encodes the review gate: a commenter may propose but not publish or approve", () => {
+    expect(roleAllows("commenter", "propose")).toBe(true)
+    expect(roleAllows("commenter", "publish")).toBe(false)
+    expect(roleAllows("commenter", "approve")).toBe(false)
+  })
+
+  it("keeps manage owner-only", () => {
+    expect(roleAllows("editor", "manage")).toBe(false)
+    expect(roleAllows("owner", "manage")).toBe(true)
+  })
+})
+
+describe("maxRole", () => {
+  it("returns the highest role and ignores null/undefined", () => {
+    expect(maxRole("viewer", "editor", "commenter")).toBe("editor")
+    expect(maxRole(null, "commenter", undefined)).toBe("commenter")
+    expect(maxRole("owner", "viewer")).toBe("owner")
+  })
+
+  it("returns null when nothing is supplied", () => {
+    expect(maxRole()).toBeNull()
+    expect(maxRole(null, undefined)).toBeNull()
+  })
+})
+
+describe("isRole", () => {
+  it("accepts the four roles and rejects everything else", () => {
+    for (const role of ROLES) expect(isRole(role)).toBe(true)
+    for (const v of ["admin", "", "VIEWER", null, undefined, 2, {}]) expect(isRole(v)).toBe(false)
+  })
+})
+
+const anon: Actor = { kind: "anon" }
+const token: Actor = { kind: "token" }
+const user = (over: Partial<Actor> = {}): Actor => ({ kind: "user", userId: "u1", ...over })
+
+describe("effectiveRole — the documented access table", () => {
+  it("a DOCK_TOKEN actor is always owner, on every visibility", () => {
+    for (const v of VISIBILITIES) expect(effectiveRole(token, v)).toBe("owner")
+  })
+
+  it("link/public grant the general-access floor to a signed-in reacher", () => {
+    // Default floor is view; a comment link lifts a signed-in reacher to commenter.
+    expect(effectiveRole(user(), "link")).toBe("viewer")
+    expect(effectiveRole(user(), "link", "commenter")).toBe("commenter")
+    expect(effectiveRole(user(), "public", "commenter")).toBe("commenter")
+  })
+
+  it("password gates the floor behind unlock", () => {
+    expect(effectiveRole(user(), "password", "commenter")).toBeNull()
+    expect(effectiveRole(user({ unlocked: true }), "password", "commenter")).toBe("commenter")
+  })
+
+  it("org/private grants nothing by reach — only an explicit role opens it", () => {
+    expect(effectiveRole(user(), "org", "commenter")).toBeNull()
+    expect(effectiveRole(user({ orgRole: "editor" }), "org")).toBe("editor")
+  })
+
+  it("an explicit per-artifact share is authoritative over the workspace role", () => {
+    // A share beats membership — both to widen it...
+    expect(effectiveRole(user({ artifactRole: "editor", orgRole: "viewer" }), "org")).toBe("editor")
+    // ...and to narrow it (the artifact share replaces the org role, not maxes with it).
+    expect(effectiveRole(user({ artifactRole: "viewer", orgRole: "editor" }), "org")).toBe("viewer")
+  })
+
+  it("the general-access floor can lift an explicit role but never lower it", () => {
+    // On a comment link, an org viewer is lifted to commenter by the floor...
+    expect(effectiveRole(user({ orgRole: "viewer" }), "link", "commenter")).toBe("commenter")
+    // ...but an editor stays editor (max of explicit and floor).
+    expect(effectiveRole(user({ orgRole: "editor" }), "link", "commenter")).toBe("editor")
+  })
+})
+
+describe("effectiveRole — the anonymous invariant", () => {
+  it("never elevates an anonymous caller above viewer, for ANY visibility or general role", () => {
+    const generalRoles: GeneralRole[] = ["viewer", "commenter"]
+    for (const v of VISIBILITIES) {
+      for (const g of generalRoles) {
+        for (const unlocked of [false, true]) {
+          const role = effectiveRole({ kind: "anon", unlocked }, v, g)
+          expect(role === null || role === "viewer", `anon ${v}/${g}/unlocked=${unlocked}`).toBe(
+            true,
+          )
+        }
+      }
+    }
+  })
+
+  it("gives an anon caller view on an open link, and no access on org", () => {
+    expect(effectiveRole(anon, "link", "commenter")).toBe("viewer")
+    expect(effectiveRole(anon, "public")).toBe("viewer")
+    expect(effectiveRole(anon, "org", "commenter")).toBeNull()
+    expect(effectiveRole(anon, "password", "commenter")).toBeNull()
+  })
+})
+
+describe("can — the one authorization gate", () => {
+  it("denies every write action to an anonymous caller, on every visibility", () => {
+    // Even a comment-general-access link does not let an account-less caller write.
+    for (const v of VISIBILITIES)
+      for (const action of WRITE_ACTIONS)
+        expect(can(anon, action, v, "commenter"), `anon ${action} on ${v}`).toBe(false)
+  })
+
+  it("lets an anon caller read an open link but not a private one", () => {
+    expect(can(anon, "read", "link")).toBe(true)
+    expect(can(anon, "read", "org")).toBe(false)
+  })
+
+  it("routes a commenter through propose, never publish", () => {
+    const commenter = user({ orgRole: "commenter" })
+    expect(can(commenter, "comment", "org")).toBe(true)
+    expect(can(commenter, "propose", "org")).toBe(true)
+    expect(can(commenter, "publish", "org")).toBe(false)
+    expect(can(commenter, "approve", "org")).toBe(false)
+  })
+
+  it("lets a token (CI/agent) do everything", () => {
+    for (const action of ACTIONS) expect(can(token, action, "org")).toBe(true)
+  })
+
+  it("a bare viewer can read but not comment", () => {
+    expect(can(user({ orgRole: "viewer" }), "read", "org")).toBe(true)
+    expect(can(user({ orgRole: "viewer" }), "comment", "org")).toBe(false)
+  })
+})

--- a/packages/core/src/pool.test.ts
+++ b/packages/core/src/pool.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest"
+import { mapPool, mapPoolSettled } from "./pool"
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+
+// A fn instrumented to record peak concurrency: bump a counter on entry, hold for a
+// tick so workers actually overlap, then drop it. `peak` is the max ever in flight.
+function concurrencyProbe() {
+  let inFlight = 0
+  let peak = 0
+  const run = async () => {
+    inFlight++
+    peak = Math.max(peak, inFlight)
+    await delay(5)
+    inFlight--
+  }
+  return {
+    run,
+    get peak() {
+      return peak
+    },
+  }
+}
+
+describe("mapPool", () => {
+  it("collects results in input order regardless of completion order", async () => {
+    // Earlier items finish LAST (longer delay), yet results stay positional.
+    const out = await mapPool([0, 1, 2, 3, 4], 5, async (n) => {
+      await delay((5 - n) * 4)
+      return n * 10
+    })
+    expect(out).toEqual([0, 10, 20, 30, 40])
+  })
+
+  it("runs every item exactly once, with the right index", async () => {
+    const seen: Array<[unknown, number]> = []
+    await mapPool(["a", "b", "c", "d"], 2, async (item, i) => {
+      seen.push([item, i])
+    })
+    expect(seen.sort((x, y) => x[1] - y[1])).toEqual([
+      ["a", 0],
+      ["b", 1],
+      ["c", 2],
+      ["d", 3],
+    ])
+  })
+
+  it("never exceeds the concurrency limit, and uses it fully", async () => {
+    const probe = concurrencyProbe()
+    await mapPool(
+      Array.from({ length: 12 }, (_, i) => i),
+      3,
+      probe.run,
+    )
+    // 12 items, limit 3 -> at most 3 in flight, and it should saturate to exactly 3.
+    expect(probe.peak).toBe(3)
+  })
+
+  it("caps in-flight at the item count when the limit exceeds it", async () => {
+    const probe = concurrencyProbe()
+    await mapPool([1, 2], 10, probe.run)
+    expect(probe.peak).toBe(2)
+  })
+
+  it("clamps a zero/negative limit to a single worker", async () => {
+    const probe = concurrencyProbe()
+    const out = await mapPool([1, 2, 3], 0, async (n) => {
+      await probe.run()
+      return n
+    })
+    expect(probe.peak).toBe(1) // serialized, never zero workers (which would hang)
+    expect(out).toEqual([1, 2, 3])
+  })
+
+  it("returns [] for empty input without calling fn", async () => {
+    let calls = 0
+    const out = await mapPool([], 4, async () => {
+      calls++
+    })
+    expect(out).toEqual([])
+    expect(calls).toBe(0)
+  })
+
+  it("rejects on the first error", async () => {
+    await expect(
+      mapPool([1, 2, 3, 4], 2, async (n) => {
+        if (n === 3) throw new Error("boom")
+        return n
+      }),
+    ).rejects.toThrow("boom")
+  })
+})
+
+describe("mapPoolSettled", () => {
+  it("processes every item even when some reject, and resolves to void", async () => {
+    const processed: number[] = []
+    const result = await mapPoolSettled([1, 2, 3, 4, 5], 2, async (n) => {
+      processed.push(n)
+      if (n % 2 === 0) throw new Error(`fail ${n}`)
+    })
+    expect(result).toBeUndefined()
+    expect(processed.sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it("honors the concurrency limit", async () => {
+    const probe = concurrencyProbe()
+    await mapPoolSettled(
+      Array.from({ length: 9 }, (_, i) => i),
+      4,
+      probe.run,
+    )
+    expect(probe.peak).toBe(4)
+  })
+})

--- a/packages/core/src/publish.test.ts
+++ b/packages/core/src/publish.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import { looksLikeHtmlDocument } from "./publish"
+
+// looksLikeHtmlDocument is the trigger for serve-content's "never serve a blank
+// page" self-heal: a blob mislabeled text/markdown whose bytes are really a full
+// HTML document is served verbatim as HTML instead of run through the markdown
+// renderer (which would strip <head>/<style>/scripts and show white). So the
+// boundary that matters is full-document vs. not — false positives would serve a
+// fragment as a document; false negatives bring the blank screen back.
+
+describe("looksLikeHtmlDocument", () => {
+  it("detects a full HTML document, case-insensitively", () => {
+    expect(looksLikeHtmlDocument("<!doctype html><html></html>")).toBe(true)
+    expect(looksLikeHtmlDocument('<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">')).toBe(true)
+    expect(looksLikeHtmlDocument("<html lang=en><body>hi</body></html>")).toBe(true)
+    expect(looksLikeHtmlDocument("<HTML>")).toBe(true)
+  })
+
+  it("ignores a leading BOM and surrounding whitespace", () => {
+    expect(looksLikeHtmlDocument("﻿<!doctype html>")).toBe(true)
+    expect(looksLikeHtmlDocument("\n\n   <!doctype html>")).toBe(true)
+    expect(looksLikeHtmlDocument("   <html>")).toBe(true)
+  })
+
+  it("is false for markdown and plain text", () => {
+    expect(looksLikeHtmlDocument("# Heading\n\nsome **markdown**")).toBe(false)
+    expect(looksLikeHtmlDocument("just text")).toBe(false)
+    expect(looksLikeHtmlDocument("")).toBe(false)
+  })
+
+  it("is false for an HTML fragment (not a whole document)", () => {
+    // A snippet is not a document; rendering it as markdown is correct.
+    expect(looksLikeHtmlDocument("<div>fragment</div>")).toBe(false)
+    expect(looksLikeHtmlDocument("<p>a paragraph</p>")).toBe(false)
+    expect(looksLikeHtmlDocument("<h1>title</h1>")).toBe(false)
+  })
+
+  it("only inspects the very start: a leading comment or XML prolog hides the doc", () => {
+    // Documented limitation — detection keys on the first non-space token.
+    expect(looksLikeHtmlDocument("<!-- note --><!doctype html><html></html>")).toBe(false)
+    expect(looksLikeHtmlDocument('<?xml version="1.0"?><svg></svg>')).toBe(false)
+  })
+})

--- a/packages/core/src/sessions.test.ts
+++ b/packages/core/src/sessions.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest"
+import { DEFAULT_VERSION_WINDOW_MS, groupSessions } from "./sessions"
+
+const BASE = Date.parse("2026-01-01T00:00:00.000Z")
+const at = (min: number) => new Date(BASE + min * 60_000).toISOString()
+// A version record with just the fields groupSessions reads.
+const mk = (n: number, min: number, author = "alice", name: string | null = null) => ({
+  n,
+  author,
+  name,
+  created_at: at(min),
+})
+
+describe("groupSessions", () => {
+  it("collapses a burst of same-author revisions into one session", () => {
+    const sessions = groupSessions([mk(1, 0), mk(2, 10), mk(3, 20)])
+    expect(sessions).toEqual([
+      // n is the latest (view this one), from_n the earliest, created_at the latest.
+      { n: 3, from_n: 1, count: 3, author: "alice", name: null, created_at: at(20) },
+    ])
+  })
+
+  it("starts a new session when the author changes, even within the window", () => {
+    const sessions = groupSessions([mk(1, 0, "alice"), mk(2, 1, "bob")])
+    // Newest-first: bob's session leads.
+    expect(sessions.map((s) => ({ n: s.n, author: s.author, count: s.count }))).toEqual([
+      { n: 2, author: "bob", count: 1 },
+      { n: 1, author: "alice", count: 1 },
+    ])
+  })
+
+  it("splits on a gap longer than the window, merges one exactly at the boundary", () => {
+    // Default window is 30 min: a 30-min gap merges (<=), a 31-min gap splits.
+    expect(groupSessions([mk(1, 0), mk(2, 30)])).toHaveLength(1)
+    const split = groupSessions([mk(1, 0), mk(2, 31)])
+    expect(split.map((s) => s.n)).toEqual([2, 1])
+  })
+
+  it("respects a custom window", () => {
+    const windowMs = 5 * 60_000
+    expect(groupSessions([mk(1, 0), mk(2, 4)], windowMs)).toHaveLength(1)
+    expect(groupSessions([mk(1, 0), mk(2, 6)], windowMs)).toHaveLength(2)
+  })
+
+  it("pins a named checkpoint: it neither absorbs neighbors nor is absorbed", () => {
+    // Same author, all within the window, but the middle one is named.
+    const sessions = groupSessions([mk(1, 0), mk(2, 5, "alice", "Release"), mk(3, 10)])
+    expect(sessions.map((s) => ({ n: s.n, name: s.name, count: s.count }))).toEqual([
+      { n: 3, name: null, count: 1 },
+      { n: 2, name: "Release", count: 1 },
+      { n: 1, name: null, count: 1 },
+    ])
+  })
+
+  it("is robust to unsorted input (groups by revision number, not array order)", () => {
+    const shuffled = groupSessions([mk(3, 20), mk(1, 0), mk(2, 10)])
+    expect(shuffled).toEqual([
+      { n: 3, from_n: 1, count: 3, author: "alice", name: null, created_at: at(20) },
+    ])
+  })
+
+  it("tracks from_n / count / created_at across several sessions, newest-first", () => {
+    const sessions = groupSessions([
+      mk(1, 0), // session A: 1..2
+      mk(2, 5),
+      mk(3, 200), // session B (gap): 3 alone
+      mk(4, 205, "bob"), // session C (author change): 4..5
+      mk(5, 210, "bob"),
+    ])
+    expect(sessions).toEqual([
+      { n: 5, from_n: 4, count: 2, author: "bob", name: null, created_at: at(210) },
+      { n: 3, from_n: 3, count: 1, author: "alice", name: null, created_at: at(200) },
+      { n: 2, from_n: 1, count: 2, author: "alice", name: null, created_at: at(5) },
+    ])
+  })
+
+  it("handles the empty and singleton cases", () => {
+    expect(groupSessions([])).toEqual([])
+    expect(groupSessions([mk(7, 0)])).toEqual([
+      { n: 7, from_n: 7, count: 1, author: "alice", name: null, created_at: at(0) },
+    ])
+  })
+
+  it("does not mutate the input array", () => {
+    const input = [mk(2, 10), mk(1, 0)]
+    const snapshot = JSON.parse(JSON.stringify(input))
+    groupSessions(input)
+    expect(input).toEqual(snapshot)
+  })
+
+  it("exposes a 30-minute default window", () => {
+    expect(DEFAULT_VERSION_WINDOW_MS).toBe(30 * 60_000)
+  })
+})


### PR DESCRIPTION
One PR consolidating focused unit tests for previously-untested pure modules across the stack. Each suite pins **real behavior and security boundaries**, not coverage. All pure (fakes for Context/BlobStore/MetaStore), runs in CI via `pnpm -r test`.

### core
- **permissions** — action/role matrix, monotonicity, and the *anonymous-caller invariant* (never above viewer; every write denied without an account).
- **anchor** — `reanchor` resolution order (context-first), `isAnchored` fail-open, the open↔outdated sweep state machine.
- **diff** — the reconstruction invariant + LCS-maximal context.
- **sessions** — version-session grouping (window / author / named-checkpoint rules).
- **md** — markdown render + XSS sanitizer (script / handler / `javascript:` stripped).
- **pool** — bounded-concurrency ordering + *measured* peak-in-flight + error semantics.
- **ids** — `parseRef` / `candidateShortIds` / `refFor` incl. round-trip + ambiguous tails.
- **publish** — `looksLikeHtmlDocument` (the serve-content self-heal trigger).

### apps/api
- **crypto** — signed/expiring state tokens, AES-256-GCM at rest, salted passwords, constant-time compare (tamper / expiry / fails-closed).
- **serve-content** — opaque-origin sandbox headers on *every* response, markdown self-heal, bundle resolution (rewrite / binary / 404 / SPA).
- **comment-helpers** — mention cap/dedup, quote/preview, deleted-body blanking.
- **addressed-helpers** — `markAddressed`/`releaseAddressed` edge cases + proposal isolation.
- **image** — avatar magic-byte sniffing (SVG rejected, WAV-isn't-WEBP).
- **http-helpers** — `rewriteAbsoluteUrls` path-scope guard + role/coercion helpers.

### apps/web
- **markdown** — client comment renderer `mdToHtml` (escape-first XSS safety).
- **username** — validation matrix + suggestion (the SPA mirror of core's rules).

**Verification:** `@dock/core` 80, `@dock/api` 214, `@dock/web` 583 — all green. Biome + every `lint:*` gate pass.

Replaces the previously-split PRs #227–#242 (now closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)