### PR TITLE
feat(github): one-step repo connect after install + document social sign-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,7 +76,7 @@ DATA_DIR=./data
 # DOCK_MAX_ARTIFACTS=1000
 # DOCK_MAX_BYTES=1073741824
 
-# Optional Google sign-in.
+# Optional Google sign-in. Callback URL: <BASE_URL>/api/auth/callback/google
 # GOOGLE_CLIENT_ID=
 # GOOGLE_CLIENT_SECRET=
 

--- a/README.md
+++ b/README.md
@@ -64,10 +64,25 @@ in-browser publishing, and the comment loop — comments are authored as you, an
 Markdown/HTML artifacts can be edited inline to publish a new version.
 
 Accounts are handled by [Better Auth](https://better-auth.com): email + password
-works with zero config; set `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` for Google
-sign-in, or `OIDC_ISSUER`/`OIDC_CLIENT_ID`/`OIDC_CLIENT_SECRET` to wire enterprise
-SSO (Okta, Entra, Auth0, Keycloak — anything OIDC). The user/session tables are
-created automatically on first boot. See `.env.example` for the full list.
+works with zero config. Add social sign-in by setting a provider's OAuth
+credentials; the matching "Continue with…" button then appears on `/login`
+automatically:
+
+- **GitHub** (a natural fit, since Dock mirrors GitHub repos): create an OAuth app
+  at GitHub → Settings → Developer settings → OAuth Apps → New, set the callback to
+  `<BASE_URL>/api/auth/callback/github`, then set `GITHUB_LOGIN_CLIENT_ID` and
+  `GITHUB_LOGIN_CLIENT_SECRET`. This is a plain OAuth app, separate from the
+  repo-sync GitHub App you register in Settings → GitHub.
+- **Google**: create an OAuth client (Web) in Google Cloud Console, set the
+  redirect to `<BASE_URL>/api/auth/callback/google`, then set `GOOGLE_CLIENT_ID`
+  and `GOOGLE_CLIENT_SECRET`.
+- **Enterprise SSO**: set `OIDC_ISSUER`/`OIDC_CLIENT_ID`/`OIDC_CLIENT_SECRET`
+  (Okta, Entra, Auth0, Keycloak, anything OIDC).
+
+Provide these as environment variables for the Node/Docker deploy, or as secrets
+for the Worker deploy (`wrangler secret put GITHUB_LOGIN_CLIENT_ID`, and so on).
+The user/session tables are created automatically on first boot; see
+`.env.example` for the full list.
 
 Writes are authorized by a login session **or** a static `DOCK_TOKEN` (for
 CI/agents). Publish with `--visibility public|link|org|password` (default `link`);

--- a/apps/web/src/pages/settings/github-section.tsx
+++ b/apps/web/src/pages/settings/github-section.tsx
@@ -78,6 +78,12 @@ const takeInstallParams = (): { install?: string; error?: string } => {
   return { install, error }
 }
 
+// Open the repo picker automatically the first time a configured + installed
+// workspace lands here without a repo connected yet (once per browser session), so
+// connecting is one step instead of "find the account button, then pick". Stops once
+// any repo is connected.
+const AUTO_PICKER_KEY = "dock:gh-auto-picker"
+
 export function GithubSection() {
   const qc = useQueryClient()
   const [status, setStatus] = useState<GithubSyncStatus | null>(null)
@@ -109,6 +115,18 @@ export function GithubSection() {
     if (error) toast.error(error === "install_expired" ? "Install link expired" : "Install failed")
     if (install) setPickerInstall(install)
   }, [])
+
+  // Onboarding shortcut: an App is configured and installed but no repo is connected
+  // yet → open the picker for the first installation so the user goes straight to
+  // choosing a repo. Once per session (so a return visit isn't hijacked) and never
+  // once a repo exists or the redirect already opened a picker.
+  useEffect(() => {
+    if (!status?.app.configured || pickerInstall || status.sources.length > 0) return
+    const first = status.installations[0]
+    if (!first || sessionStorage.getItem(AUTO_PICKER_KEY)) return
+    sessionStorage.setItem(AUTO_PICKER_KEY, "1")
+    setPickerInstall(first.installation_id)
+  }, [status, pickerInstall])
 
   const appConfigured = status?.app.configured ?? false
 


### PR DESCRIPTION
## Make GitHub onboarding easy

Two small things, no login-page redesign.

### Connect a repo in one step
When the GitHub App is configured and installed but **no repo is connected yet**, Settings → GitHub now opens the repo picker automatically for the first installation (once per browser session). You land straight on "choose a repo" instead of hunting for the account button. It never fires once a repo exists, or when the post-install `?gh_install` redirect already opened a picker.

### Social sign-in is already built — now it's documented
`makeAuth` already wires **GitHub** and **Google** as Better Auth social providers, `/v1/auth/providers` toggles them, and `Login.tsx` already renders the "Continue with…" buttons. They were just undocumented and off (no OAuth-app creds). This PR documents exactly how to turn each on:
- README "accounts" section now lists **GitHub / Google / OIDC**, the steps to create each OAuth app, the exact callback URLs (`<BASE_URL>/api/auth/callback/<provider>`), and how to provide secrets (env for Node/Docker, `wrangler secret put` for the Worker).
- `.env.example` gains the Google callback URL for parity with the GitHub one.

No code change to the login page (the buttons already exist). Slack sign-in is **not** included (Better Auth has no native Slack provider; it would need an OIDC `genericOAuth` provider) — easy to add later if wanted.

### Checks
Typecheck, biome, and all guardrails (design-tokens / testids / frontend / api / schema) green locally.

Note: the auto-open behavior is simple client logic; browser-verifying it needs a seeded `github_app` + installation row, which I skipped here. Happy to attach a seeded screenshot on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)