### PR TITLE
chore(test): raise coverage floors after the #244 unit suite

### DIFF
--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -14,13 +14,17 @@ import { defineConfig } from "vitest/config"
 // secret gate, the extracted shutdown in lifecycle.ts, auth-config providers): the
 // suite now reports ~82% lines / 75% stmts / 68% branches. Floor sits just under
 // that so a regression fails but normal noise doesn't.
+//
+// Raised again after the #244 lib unit suite (crypto, serve-content, comment +
+// addressed helpers, image, http-helpers): now ~82% lines / 78% stmts / 68%
+// branches. Floor kept ~1pt under to absorb Node 22 (local) vs 24 (CI) drift.
 export default defineConfig({
   test: {
     coverage: {
       provider: "v8",
       include: ["src/**"],
       reporter: ["text-summary"],
-      thresholds: { lines: 80, statements: 74, branches: 66 },
+      thresholds: { lines: 81, statements: 76, branches: 67 },
     },
   },
 })

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -2,11 +2,16 @@ import { fileURLToPath } from "node:url"
 import { defineConfig } from "vitest/config"
 
 // Unit tests for the web app's PURE logic — ref parsing, relative time, the
-// optimistic reaction toggle, role mapping, class merge, and the comment-pin
-// layout. A standalone config (NOT the TanStack Start vite config) so tests don't
-// boot the SSR/router plugins. The user-facing flows are covered by the Playwright
-// e2e suite (e2e/); this gate is scoped to the unit-testable helpers, so a regression
-// in that logic fails CI without pretending to measure the React components.
+// optimistic reaction toggle, role mapping, class merge, the comment-pin layout,
+// the client comment renderer (XSS-safe markdown), and username validation. A
+// standalone config (NOT the TanStack Start vite config) so tests don't boot the
+// SSR/router plugins. The user-facing flows are covered by the Playwright e2e suite
+// (e2e/); this gate is scoped to the unit-testable helpers, so a regression in that
+// logic fails CI without pretending to measure the React components.
+//
+// Floor raised after the #244 unit suite added markdown + username coverage: the
+// 8-file include now reports ~98% lines / 97% stmts / 85% branches; thresholds sit
+// just under that as a ratchet floor.
 export default defineConfig({
   resolve: { alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) } },
   test: {
@@ -21,9 +26,11 @@ export default defineConfig({
         "src/pages/settings/roles.ts",
         "src/lib/utils.ts",
         "src/pages/artifact/lib/layout.ts",
+        "src/pages/artifact/lib/markdown.ts",
+        "src/lib/username.ts",
       ],
       reporter: ["text-summary"],
-      thresholds: { lines: 90, statements: 90, branches: 80 },
+      thresholds: { lines: 97, statements: 96, branches: 84 },
     },
   },
 })

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -3,13 +3,17 @@ import { defineConfig } from "vitest/config"
 // Coverage gate on the shared domain logic: publish/storeContent (bundle entry +
 // path cleaning), anchors, diff, unfurl, permissions, mime, hash, ids, md. ports.ts
 // is type-only. Thresholds sit just under the current numbers as a ratchet floor.
+//
+// Raised after the #244 unit suite (permissions, anchor, diff, sessions, md, pool,
+// ids, looksLikeHtmlDocument): now ~97% lines / 95% stmts / 82% branches. Pure
+// logic, so these are stable across Node majors.
 export default defineConfig({
   test: {
     coverage: {
       provider: "v8",
       include: ["src/**"],
       reporter: ["text-summary"],
-      thresholds: { lines: 92, statements: 90, branches: 72 },
+      thresholds: { lines: 96, statements: 94, branches: 81 },
     },
   },
 })


### PR DESCRIPTION
Draft. Config-only follow-up to **#244** (the merged unit suite). Those tests pushed real coverage above the existing per-package ratchet floors; this **locks in the gains** so they can't silently regress, and gates the two newly-tested web modules.

The repo already uses a ratchet-floor pattern (thresholds "just under current… meant to be raised over time"). This just raises the floors and extends the web allowlist — no source or test changes.

| package | scope | measured (Node 22) | floor: was → now |
|---|---|---|---|
| `@dock/core` | `src/**` | 97% L / 95% S / 82% B | 92/90/72 → **96/94/81** |
| `@dock/api` | `src/**` | 82% L / 78% S / 68% B | 80/74/66 → **81/76/67** |
| `@dock/web` | 8-file allowlist | 98% L / 97% S / 85% B | 90/90/80 → **97/96/84** |

**web** also adds two now-tested source files to `coverage.include`:
- `src/pages/artifact/lib/markdown.ts` — the XSS-safe client comment renderer
- `src/lib/username.ts` — username validation

### Notes
- Floors set ~1pt under the measured numbers to absorb **Node 22 (local) vs Node 24 (CI)** coverage-v8 drift. core is pure logic (no drift). If a CI step still fails by a fraction, drop that one threshold by 1.
- Only raised, never lowered — every metric's floor moved up or stayed.
- The CI `coverage` job already runs `test:coverage` for all packages; no workflow change.

**Verification:** `pnpm --filter @dock/core --filter @dock/api --filter @dock/web test:coverage` all exit 0 with no threshold ERROR; biome + all `lint:*` gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)