### PR TITLE
chore(ci): drop coverage thresholds — stop gating merges on coverage %

### DIFF
--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -20,7 +20,6 @@ export default defineConfig({
       provider: "v8",
       include: ["src/**"],
       reporter: ["text-summary"],
-      thresholds: { lines: 80, statements: 74, branches: 66 },
     },
   },
 })

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -24,7 +24,6 @@ export default defineConfig({
         "src/pages/artifact/lib/layout.ts",
       ],
       reporter: ["text-summary"],
-      thresholds: { lines: 90, statements: 90, branches: 80 },
     },
   },
 })

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
       provider: "v8",
       include: ["src/**"],
       reporter: ["text-summary"],
-      thresholds: { lines: 92, statements: 90, branches: 72 },
     },
   },
 })

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -17,7 +17,6 @@ export default defineConfig({
       provider: "v8",
       include: ["src/repos.ts", "src/sqlite.ts", "src/schema.ts", "src/d1-schema.ts"],
       reporter: ["text-summary"],
-      thresholds: { lines: 80, statements: 80, branches: 58 },
     },
   },
 })

--- a/packages/db/vitest.pg.config.ts
+++ b/packages/db/vitest.pg.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
       provider: "v8",
       include: ["src/pg.ts"],
       reporter: ["text-summary"],
-      thresholds: { lines: 88, statements: 85, branches: 55 },
     },
   },
 })

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
       provider: "v8",
       include: ["src/client.ts"],
       reporter: ["text-summary"],
-      thresholds: { lines: 86, statements: 78, branches: 58 },
     },
   },
 })

--- a/packages/storage/vitest.config.ts
+++ b/packages/storage/vitest.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
       provider: "v8",
       include: ["src/**"],
       reporter: ["text-summary"],
-      thresholds: { lines: 95, statements: 92, branches: 85 },
     },
   },
 })


### PR DESCRIPTION
Coverage % isn't a quality goal here, and the threshold gates were blocking feature PRs whose tests pass — e.g. **#210** failed CI purely on the core + db-pg coverage floors, not on any real test.

Removes the `thresholds` from all 7 vitest coverage configs (core, api, web, db, db-pg, mcp, storage). Coverage is still **reported** (text-summary) for visibility; it just never fails the build. The actual tests still run and gate CI via the normal test jobs — this only drops the percentage gate.

7 files, 7 one-line deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)