### PR TITLE
mcp: agent reads its own user's personal comments (follow-up to #246)

### DIFF
--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -133,7 +133,7 @@ const changeCount = (c: ReturnType<typeof bundleFileChanges>) =>
  * Identity rides in the server `instructions` (below), not a `whoami` tool — it's a
  * one-shot fact, not a per-call action.
  */
-function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
+function buildServer(ctx: AppContext, agent: AgentRecord, ownerId: string | null): McpServer {
   // Steer the write guidance by what this grant can actually do: a publish-capable
   // grant gets the direct-publish path; a lower grant is told its writes go to review.
   const writeGuidance = roleAllows(agent.role, "publish")
@@ -275,7 +275,7 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
 
       // `comments` filter → the feedback to-do queue (absorbs the old list_comments).
       if (comments) {
-        const list = await ctx.meta.listComments(a.id, { state: comments })
+        const list = await ctx.meta.listComments(a.id, { state: comments, viewerOwnerId: ownerId })
         return json({
           short_id,
           comments_state: comments,
@@ -301,15 +301,21 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           if (as_ !== null && ah !== null) entryDiff = clip(formatDiff(diffLines(as_, ah)))
         }
       }
-      const open = await ctx.meta.listComments(a.id, { state: "open" })
+      const open = await ctx.meta.listComments(a.id, { state: "open", viewerOwnerId: ownerId })
       // Threads whose quoted text changed in a landed version — feedback that may no
       // longer apply. Surfacing it tells the agent its edits touched commented text.
-      const outdated = await ctx.meta.listComments(a.id, { state: "outdated" })
+      const outdated = await ctx.meta.listComments(a.id, {
+        state: "outdated",
+        viewerOwnerId: ownerId,
+      })
       const outdatedBit = outdated.length
         ? ` ${outdated.length} now outdated (the quoted text changed).`
         : ""
       // Threads with a proposal already pending — the agent shouldn't re-address them.
-      const addressed = await ctx.meta.listComments(a.id, { state: "addressed" })
+      const addressed = await ctx.meta.listComments(a.id, {
+        state: "addressed",
+        viewerOwnerId: ownerId,
+      })
       const addressedBit = addressed.length
         ? ` ${addressed.length} addressed (a proposal is pending review).`
         : ""
@@ -386,6 +392,16 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
         )
       if (!body && !set_state)
         return err("Provide `body` (to comment) or `set_state` (to resolve/reopen a thread).")
+      // A reply / state change inherits the TARGET thread's visibility: an agent must
+      // not post a public reply into a personal thread (that would leak it), and may
+      // only touch a personal thread that belongs to its own user. New top-level
+      // comments stay public feedback.
+      const target = reply_to ? await ctx.meta.getComment(reply_to) : null
+      if (target?.visibility === "personal" && target.owner_id !== ownerId)
+        return err("No such thread in your workspace.")
+      const visibility: "public" | "personal" =
+        target?.visibility === "personal" ? "personal" : "public"
+      const owner_id = visibility === "personal" ? ownerId : null
       let thread = reply_to
       let commentId: string | undefined
       if (body) {
@@ -402,6 +418,8 @@ function buildServer(ctx: AppContext, agent: AgentRecord): McpServer {
           body_md: body,
           author: agent.name,
           author_id: agent.id,
+          visibility,
+          owner_id,
         })
         ctx.bus.publish(a.id, { type: "comment.created" })
       }
@@ -671,7 +689,7 @@ export function mountMcp(app: Hono, ctx: AppContext): void {
         { "WWW-Authenticate": `Bearer resource_metadata="${meta}"` },
       )
     }
-    const server = buildServer(ctx, agent)
+    const server = buildServer(ctx, agent, await ctx.privateOwnerId(c))
     const transport = new StreamableHTTPTransport()
     await server.connect(transport)
     return transport.handleRequest(c)

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -675,3 +675,92 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(toolText(asFile)).toContain("bundle")
   })
 })
+
+describe("remote MCP — catch_up scopes personal comments to the granting user", () => {
+  // An app with one OAuth grant (tok_owner → user u_owner) and store access, so the
+  // test can seed comments + a registered workspace agent directly.
+  function grantedApp(name: string) {
+    const path = join(dir, `${name}.db`)
+    const meta = new SqliteMetaStore(path)
+    const db = new Database(path)
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS "user" (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT);
+      CREATE TABLE IF NOT EXISTS "oauthClient" (clientId TEXT PRIMARY KEY, name TEXT);
+      CREATE TABLE IF NOT EXISTS "oauthAccessToken" (token TEXT PRIMARY KEY, clientId TEXT, userId TEXT, scopes TEXT, expiresAt TEXT);
+    `)
+    db.prepare(
+      `INSERT OR IGNORE INTO "user"(id,email,name) VALUES('u_owner','owner@x.test','Owner')`,
+    ).run()
+    db.prepare(`INSERT OR IGNORE INTO "oauthClient"(clientId,name) VALUES('cli','Claude')`).run()
+    db.prepare(
+      `INSERT INTO "oauthAccessToken"(token,clientId,userId,scopes,expiresAt) VALUES(?,?,?,?,?)`,
+    ).run(
+      sha256("tok_owner"),
+      "cli",
+      "u_owner",
+      JSON.stringify(["openid", "dock:read", "dock:publish", "dock:comment"]),
+      new Date(Date.now() + 3_600_000).toISOString(),
+    )
+    db.close()
+    const app = createApp({
+      meta,
+      blobs: new FsBlobStore(join(dir, `${name}-blobs`)),
+      baseUrl: "http://dock.test",
+      token: "tok",
+    })
+    return { app, meta }
+  }
+
+  it("the agent really sees its own user's personal note; a workspace agent sees public only", async () => {
+    const { app, meta } = grantedApp("mcp-personal")
+    const shortId = (await (await publish(app, "tok_owner", "Launch Plan")).json()).short_id
+    const art = await meta.getByShortId(shortId)
+    if (!art) throw new Error("artifact not found")
+    await meta.createComment({
+      id: "c_pub",
+      artifact_id: art.id,
+      thread_id: "c_pub",
+      base_version: art.current_version,
+      body_md: "public feedback here",
+      author: "Owner",
+      author_id: "u_owner",
+      visibility: "public",
+      owner_id: null,
+    })
+    await meta.createComment({
+      id: "c_pers",
+      artifact_id: art.id,
+      thread_id: "c_pers",
+      base_version: art.current_version,
+      body_md: "PERSONAL confirm Q4 with finance",
+      author: "Owner",
+      author_id: "u_owner",
+      visibility: "personal",
+      owner_id: "u_owner",
+    })
+    // A registered workspace agent in the SAME workspace, but with no granting user.
+    await meta.createAgent({
+      id: "ag_ws",
+      org_id: art.org_id,
+      name: "WorkspaceBot",
+      token: sha256("tok_wsagent"),
+      role: "commenter",
+    })
+
+    // u_owner's authed agent: catch_up surfaces BOTH (it knows the personal one).
+    const mine = JSON.parse(
+      toolText(await call(app, "tok_owner", "catch_up", { short_id: shortId })),
+    )
+    const mineBlob = JSON.stringify(mine.open_comments)
+    expect(mineBlob).toContain("public feedback here")
+    expect(mineBlob).toContain("PERSONAL")
+
+    // Registered workspace agent: public only — the personal note is invisible.
+    const ws = JSON.parse(
+      toolText(await call(app, "tok_wsagent", "catch_up", { short_id: shortId })),
+    )
+    const wsBlob = JSON.stringify(ws.open_comments)
+    expect(wsBlob).toContain("public feedback here")
+    expect(wsBlob).not.toContain("PERSONAL")
+  })
+})


### PR DESCRIPTION
Follow-up to #246 (personal comments). That PR merged with the MCP read path still **public-only** — the consolidation (#226) had no owner-scoping, so an agent connecting over MCP could not see the personal instructions a user left for it. This wires up that loop.

## What changes
- `buildServer` carries the **granting user** (`ownerId = privateOwnerId(c)` from the OAuth grant); a registered workspace agent has none.
- `catch_up` (the "take them all" call) passes `viewerOwnerId` on its comment reads (open / outdated / addressed + the comments queue), so an authed agent gets **all** of *its own user's* personal notes on the artifact in one call. A workspace agent still sees public only (fail-closed).
- The `comment` tool **inherits the target thread's visibility**: an agent can't post a public reply into a personal thread (which would leak it), and can only touch a personal thread that belongs to its own user.

## Why
This is the personal-iteration loop: you draft a plan → publish to Dock → leave a handful of personal comments for your AI → your authed agent calls `catch_up`, sees them all, acts, and proposes a revision.

## Tests
`mcp.test.ts`: an OAuth agent's `catch_up` surfaces its user's personal note; a registered workspace agent in the same workspace sees public only. 600 api tests green; typecheck + ci clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)