### PR TITLE
fix(mcp+sharing): sweep anchors after MCP publish; accept username in share

### DIFF
--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -39,6 +39,7 @@ import type { Hono } from "hono"
 import { z } from "zod"
 import type { AppContext } from "./context"
 import { markAddressed } from "./lib/addressed"
+import { sweepAnchors } from "./lib/anchor-sweep"
 import {
   cleanPath,
   mergeBundleZip,
@@ -635,6 +636,15 @@ function buildServer(ctx: AppContext, agent: AgentRecord, ownerId: string | null
           },
           short_id,
         )
+        // Re-anchor existing threads: feedback whose quoted text changed flips to
+        // `outdated` (and back to `open` if the text reappears). Same sweep the
+        // HTTP route runs — MCP publish must call it too.
+        for (const t of await sweepAnchors(ctx.meta, ctx.blobs, artifact.id, version))
+          ctx.bus.publish(artifact.id, {
+            type: t.state === "outdated" ? "comment.outdated" : "comment.resolved",
+            thread_id: t.thread_id,
+            state: t.state,
+          })
         // A live publish that fixes feedback resolves those threads directly (no
         // approval step to wait on, unlike a proposal's `addressed`).
         const resolved: string[] = []

--- a/apps/api/src/routes/sharing.ts
+++ b/apps/api/src/routes/sharing.ts
@@ -55,16 +55,18 @@ export const sharingRoutes = (ctx: AppContext) => {
       z
         .object({
           // Share by @username or by email — either resolves to the account.
+          // `username` is accepted as an alias for `user` (both mean the @handle).
           user: z.string().min(1).optional(),
+          username: z.string().min(1).optional(),
           email: z.string().min(1).optional(),
           role: z.custom<Role>(isRole, "a valid role is required"),
         })
-        .refine((v) => v.user || v.email, "a username or email is required"),
+        .refine((v) => v.user || v.username || v.email, "a username or email is required"),
     )
     if (b instanceof Response) return b
     if (rank(b.role) > (await callerRank(c, artifact)))
       return fail(c, 403, "you can't grant a role above your own")
-    const id = await resolveUserRef(meta, (b.user ?? b.email) as string)
+    const id = await resolveUserRef(meta, (b.user ?? b.username ?? b.email) as string)
     const [user] = id ? await meta.getUsers([id]) : []
     if (!user) return fail(c, 404, "no Dock user with that username or email")
     await meta.setArtifactMember({


### PR DESCRIPTION
## Summary

Two bugs found during live E2E testing of the MCP + sharing flows on 2026-06-28:

- **MCP publish skips `sweepAnchors`** — after a version is published via the MCP `publish` tool, comment threads anchored to changed text stayed `open` instead of flipping to `outdated`. The HTTP route (`routes/artifacts.ts`) calls `sweepAnchors` correctly; the MCP path called `publishVersion()` directly and never ran the sweep. Fix: add `sweepAnchors` + bus events right after `publishVersion()` in `mcp.ts`, mirroring the HTTP route.

- **`username` silently rejected on share** — `PUT /v1/artifacts/:id/members` accepts `{user, email, role}` but the error message says "a username or email is required". Passing `{username: "bob"}` is stripped by zod as an unknown key, triggering that error. Fix: add `username` as an accepted alias, coalesced as `user ?? username ?? email` in the lookup call.

## Changes

- `apps/api/src/mcp.ts` — import `sweepAnchors`, call after `publishVersion()` with same bus-publish pattern as `routes/artifacts.ts`
- `apps/api/src/routes/sharing.ts` — add `username` field to the zod schema, update refine + resolveUserRef call

## Test plan

- [ ] MCP `publish` v2 that changes an anchored quote → thread flips to `outdated` in next `catch_up`
- [ ] MCP `publish` v3 that restores the original text → thread flips back to `open`
- [ ] `PUT /v1/artifacts/:id/members` with `{username: "bob", role: "editor"}` → resolves correctly (previously returned "a username or email is required")
- [ ] `PUT /v1/artifacts/:id/members` with `{user: "bob", role: "editor"}` and `{email: "bob@example.com", role: "editor"}` → still work (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)