### PR TITLE
Smooth out the dev setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ dist/
 .wrangler/
 .tanstack/
 
+# Local env files (secrets) — the committed template is .env.example
+.env
+.env.*
+!.env.example
+
 # e2e (Playwright)
 .e2e-data/
 test-results/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,19 +7,23 @@ must pass, and how we structure commits and PRs.
 
 Requires Node 24+ and pnpm 10+.
 
-The dev stack is two servers, each in its own terminal:
+The dev stack is two servers — run both with one command:
 
 ```bash
 pnpm install
-pnpm dev          # API    → http://localhost:8090  (SQLite + local disk, zero config)
-pnpm dev:web      # web UI → http://localhost:3090  ← open this in the browser
+pnpm dev:all      # API on :8090 + web UI on :3090 → open http://localhost:3090
+
+# or run them separately:
+#   pnpm dev       # API    → http://localhost:8090  (SQLite + local disk, zero config)
+#   pnpm dev:web   # web UI → http://localhost:3090
 ```
 
 The API alone serves only a placeholder page; the web UI proxies its API calls,
 so open the web port. (Container/deploy builds serve both from one origin on 8080.)
 
 By default the API uses embedded SQLite and the local filesystem — no external
-services. Postgres + S3/R2 are opt-in via env (see [DEPLOY.md](DEPLOY.md)).
+services. Postgres + S3/R2 are opt-in via env: copy `.env.example` to `.env`
+(git-ignored, auto-loaded in dev) and fill in what you need. See [DEPLOY.md](DEPLOY.md).
 
 ## The gate
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ API; view it rendered and sandboxed. Self-host it, or use the hosted tier.
 
 ## Quickstart (dev)
 
-The dev stack is two servers — the API and the web UI. Run each in its own terminal:
+The dev stack is two servers — the API and the web UI:
 
 ```bash
 pnpm install
-pnpm dev                                  # 1. API      → http://localhost:8090
-pnpm dev:web                              # 2. web UI    → http://localhost:3090  ← open this
+pnpm dev:all                              # both servers → open http://localhost:3090
+
+# or run them in separate terminals:
+#   pnpm dev       # API    → http://localhost:8090
+#   pnpm dev:web   # web UI → http://localhost:3090  ← open this
 
 # scaffold a project (templates: md · html · slides)
 node packages/cli/bin/derive.js init my-doc --template slides

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, readFileSync } from "node:fs"
-import { join, relative } from "node:path"
+import { join, relative, resolve } from "node:path"
 import type { BlobStore, MetaStore } from "@derive/core"
 import { PgMetaStore } from "@derive/db/pg"
 import { SqliteMetaStore } from "@derive/db/sqlite"
@@ -21,6 +21,19 @@ import { log } from "./log"
 import { createNodeSyncRunner } from "./node-sync"
 import { type ChannelSenders, startWebhookWorker } from "./webhooks"
 import { nodeDnsGuard } from "./webhooks-node"
+
+// Best-effort load a local .env (repo root, then cwd) before reading config, so
+// wiring up Postgres / OAuth / S3 locally is just editing .env instead of exporting
+// vars each shell. Real deployments inject env vars directly, so a missing file is
+// expected — hence the swallowed throw.
+for (const envPath of [join(import.meta.dirname, "../../../.env"), resolve(".env")]) {
+  try {
+    process.loadEnvFile(envPath)
+    break
+  } catch {
+    /* no .env at this path — carry on */
+  }
+}
 
 const cfg = loadConfig()
 mkdirSync(join(cfg.dataDir, "blobs"), { recursive: true })

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "dev": "pnpm --filter @derive/api dev",
     "dev:web": "pnpm --filter @derive/web dev",
+    "dev:all": "pnpm --parallel --filter \"./apps/*\" dev",
     "start": "pnpm --filter @derive/api start",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",


### PR DESCRIPTION
Follow-up to #256. Small quality-of-life pass on the local dev experience.

- **`pnpm dev:all`** — runs the API and web dev servers together (`pnpm --parallel --filter "./apps/*" dev`), so the two-server stack is one command instead of two terminals. No new dependency.
- **Auto-load `.env` in dev** — the Node entrypoint best-effort loads a local `.env` (repo root, then cwd) before reading config, so wiring up Postgres/OAuth/S3 locally is just editing `.env` rather than exporting vars each shell. Real deployments inject env vars directly, so a missing file is expected.
- **Git-ignore `.env*`** (keeping `.env.example` tracked) — closes a gap where a local env file with secrets wasn't ignored.
- README + CONTRIBUTING updated to lead with `dev:all`.

Verified locally: `dev:all` brings both servers up (web 3090 + API 8090, proxy healthy), a root `.env` with `PORT=8091` is picked up by the API, and biome/typecheck pass.