### PR TITLE
Facelift: bring auth, directory, profile & settings onto the design language

### DIFF
--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -1,8 +1,9 @@
 import { getRouteApi, useNavigate } from "@tanstack/react-router"
-import { Check } from "lucide-react"
 import type { FormEvent } from "react"
 import { useEffect, useState } from "react"
 import { api } from "@/api"
+import { Icon } from "@/components/icons"
+import { FormField } from "@/components/shared/form-field"
 import { Logo } from "@/components/shared/logo"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -93,26 +94,26 @@ export function Login() {
   return (
     <div className="grid min-h-screen lg:grid-cols-2">
       {/* Brand + value panel — desktop only; the form carries a compact brand on mobile. */}
-      <aside className="hidden flex-col justify-between bg-secondary p-10 text-secondary-foreground lg:flex">
+      <aside className="hidden flex-col justify-between bg-secondary p-12 text-secondary-foreground lg:flex">
         <div className="flex items-center gap-2.5">
-          <Logo size={30} />
-          <span className="font-display text-xl font-semibold">Derive</span>
+          <Logo size={26} />
+          <span className="font-display text-lg font-semibold tracking-tight">Derive</span>
         </div>
         <div className="max-w-md">
-          <h1 className="font-display text-3xl font-semibold leading-tight text-foreground">
+          <h1 className="font-display text-3xl font-medium leading-[1.15] tracking-tight text-foreground">
             The permanent home for your AI artifacts.
           </h1>
-          <p className="mt-3 text-sm text-muted-foreground">
+          <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
             Give any HTML page, doc, or built site a lasting URL, version history, and a review loop
             your team and your agents can actually use.
           </p>
-          <ul className="mt-6 flex flex-col gap-3">
+          <ul className="mt-9 flex flex-col gap-4">
             {FEATURES.map(([title, desc]) => (
-              <li key={title} className="flex gap-2.5">
-                <Check className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden />
-                <div className="flex flex-col">
-                  <span className="text-sm font-semibold text-foreground">{title}</span>
-                  <span className="text-xs text-muted-foreground">{desc}</span>
+              <li key={title} className="flex gap-3">
+                <Icon name="check" size={15} className="mt-0.5 shrink-0 text-muted-foreground" />
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-sm font-medium text-foreground">{title}</span>
+                  <span className="text-xs leading-relaxed text-muted-foreground">{desc}</span>
                 </div>
               </li>
             ))}
@@ -144,7 +145,7 @@ export function Login() {
                 {signup ? "Start publishing artifacts in seconds." : "Sign in to your workspace."}
               </CardDescription>
             </CardHeader>
-            <CardContent className="flex flex-col gap-3">
+            <CardContent className="flex flex-col gap-4">
               {(providers?.google || providers?.github) && (
                 <>
                   <div className="flex flex-col gap-2">
@@ -182,7 +183,7 @@ export function Login() {
                   </div>
                 </>
               )}
-              <form onSubmit={submit} className="flex flex-col gap-3">
+              <form onSubmit={submit} className="flex flex-col gap-4">
                 {err && (
                   <div
                     data-testid="login-error"
@@ -193,11 +194,7 @@ export function Login() {
                   </div>
                 )}
                 {signup && (
-                  <label
-                    htmlFor="login-name"
-                    className="flex flex-col gap-1.5 text-sm font-medium text-foreground"
-                  >
-                    Name
+                  <FormField label="Name" htmlFor="login-name">
                     <Input
                       id="login-name"
                       data-testid="login-name"
@@ -205,13 +202,9 @@ export function Login() {
                       onChange={(e) => setName(e.target.value)}
                       placeholder="Your name"
                     />
-                  </label>
+                  </FormField>
                 )}
-                <label
-                  htmlFor="login-email"
-                  className="flex flex-col gap-1.5 text-sm font-medium text-foreground"
-                >
-                  Email
+                <FormField label="Email" htmlFor="login-email">
                   <Input
                     id="login-email"
                     data-testid="login-email"
@@ -221,12 +214,8 @@ export function Login() {
                     onChange={(e) => setEmail(e.target.value)}
                     placeholder="you@company.com"
                   />
-                </label>
-                <label
-                  htmlFor="login-password"
-                  className="flex flex-col gap-1.5 text-sm font-medium text-foreground"
-                >
-                  Password
+                </FormField>
+                <FormField label="Password" htmlFor="login-password">
                   <Input
                     id="login-password"
                     data-testid="login-password"
@@ -237,7 +226,7 @@ export function Login() {
                     onChange={(e) => setPassword(e.target.value)}
                     placeholder="At least 8 characters"
                   />
-                </label>
+                </FormField>
                 <Button
                   data-testid="login-submit"
                   variant="primary"
@@ -256,7 +245,7 @@ export function Login() {
                   data-testid="login-toggle"
                   variant="link"
                   type="button"
-                  className="h-auto p-0 align-baseline text-sm font-semibold"
+                  className="h-auto p-0 align-baseline text-sm font-medium"
                   onClick={() => setMode(signup ? "login" : "signup")}
                 >
                   {signup ? "Sign in" : "Create an account"}

--- a/apps/web/src/pages/people.tsx
+++ b/apps/web/src/pages/people.tsx
@@ -29,7 +29,7 @@ export function People() {
 
   return (
     <div className="mx-auto w-full max-w-3xl p-6 sm:p-8">
-      <h1 className="font-display text-2xl font-semibold text-foreground">People</h1>
+      <h1 className="font-display text-2xl font-medium tracking-tight text-foreground">People</h1>
       <p className="mt-1 text-sm text-muted-foreground">
         Find people on Derive and follow their work.
       </p>
@@ -79,7 +79,7 @@ export function People() {
 function PersonCard({ person: p }: { person: PublicProfile }) {
   const initials = getInitials(p.name ?? p.username)
   return (
-    <li className="flex items-center gap-3 rounded-lg border border-border bg-card p-3 transition-colors hover:border-primary">
+    <li className="flex items-center gap-3 rounded-lg border border-border bg-card p-3 transition-colors hover:bg-hover">
       <Link
         to="/u/$handle"
         params={{ handle: p.username }}
@@ -98,7 +98,7 @@ function PersonCard({ person: p }: { person: PublicProfile }) {
             @{p.username}
           </span>
           {p.profession && (
-            <span className="block truncate text-2xs text-accent-foreground">{p.profession}</span>
+            <span className="block truncate text-2xs text-muted-foreground">{p.profession}</span>
           )}
         </span>
       </Link>

--- a/apps/web/src/pages/profile.tsx
+++ b/apps/web/src/pages/profile.tsx
@@ -42,7 +42,9 @@ export function Profile() {
     return (
       <div className="grid h-full place-items-center p-6">
         <div className="max-w-sm text-center" data-testid="profile-not-found">
-          <h1 className="font-display text-xl font-semibold text-foreground">No such profile</h1>
+          <h1 className="font-display text-xl font-medium tracking-tight text-foreground">
+            No such profile
+          </h1>
           <p className="mt-2 text-sm text-muted-foreground">
             There's no Derive user with the handle <span className="font-medium">@{handle}</span>.
           </p>
@@ -69,7 +71,7 @@ export function Profile() {
               <div className="min-w-0">
                 {data.name && (
                   <h1
-                    className="truncate font-display text-2xl font-semibold text-foreground"
+                    className="truncate font-display text-2xl font-medium tracking-tight text-foreground"
                     data-testid="profile-name"
                   >
                     {data.name}
@@ -88,7 +90,7 @@ export function Profile() {
 
             {data.profession && (
               <p
-                className="mt-2 text-sm font-medium text-accent-foreground"
+                className="mt-2 text-sm font-medium text-muted-foreground"
                 data-testid="profile-role"
               >
                 {data.profession}
@@ -263,7 +265,7 @@ function ProfileWork({ handle, isMe, name }: { handle: string; isMe: boolean; na
 
   return (
     <section className="mt-7">
-      <h2 className="mb-3 font-display text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+      <h2 className="mb-3 font-mono text-2xs uppercase tracking-[0.08em] text-muted-foreground">
         Work
       </h2>
       {isPending ? (

--- a/apps/web/src/pages/settings/agents-section.tsx
+++ b/apps/web/src/pages/settings/agents-section.tsx
@@ -183,7 +183,7 @@ function AgentRow({
         <Bot className="size-4" aria-hidden />
       </span>
       <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
+        <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">
           @{agent.name}
           <Badge variant="accent" className="font-mono">
             {agent.role}

--- a/apps/web/src/pages/settings/index.tsx
+++ b/apps/web/src/pages/settings/index.tsx
@@ -52,7 +52,7 @@ export function Settings() {
   return (
     <div className="flex-1 overflow-y-auto">
       <main className="mx-auto max-w-3xl px-5 pb-16 pt-7">
-        <h1 className="font-display text-2xl font-semibold">Settings</h1>
+        <h1 className="font-display text-2xl font-medium tracking-tight">Settings</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           Your profile, workspace, and integrations.
         </p>

--- a/apps/web/src/pages/settings/profile-section.tsx
+++ b/apps/web/src/pages/settings/profile-section.tsx
@@ -67,7 +67,7 @@ export function ProfileSection() {
                 {me.image && <AvatarImage src={me.image} alt="Your avatar" />}
                 <AvatarFallback className="rounded-full bg-card text-muted-foreground">
                   {me.name ? (
-                    <span className="font-display text-xl font-semibold">{initials}</span>
+                    <span className="font-display text-xl font-medium">{initials}</span>
                   ) : (
                     <Camera className="size-5" aria-hidden />
                   )}

--- a/apps/web/src/pages/settings/workspace-section.tsx
+++ b/apps/web/src/pages/settings/workspace-section.tsx
@@ -329,7 +329,7 @@ export function WorkspaceSection({ meId }: { meId: string }) {
                       </Avatar>
                       <span className="min-w-0 flex-1">
                         {u.name && (
-                          <span className="block truncate text-sm font-semibold text-foreground">
+                          <span className="block truncate text-sm font-medium text-foreground">
                             {u.name}
                           </span>
                         )}
@@ -384,7 +384,7 @@ export function WorkspaceSection({ meId }: { meId: string }) {
                 <User className="size-4" aria-hidden />
               </span>
               <div className="min-w-0 flex-1">
-                <div className="text-sm font-semibold text-foreground">
+                <div className="text-sm font-medium text-foreground">
                   {m.name ?? (m.handle ? `@${m.handle}` : m.user_id)}
                   {m.user_id === meId && (
                     <span className="font-normal text-muted-foreground"> (you)</span>

--- a/apps/web/src/pages/welcome.tsx
+++ b/apps/web/src/pages/welcome.tsx
@@ -100,7 +100,7 @@ export function Welcome() {
     <div className="min-h-full overflow-y-auto bg-background">
       <div className="mx-auto w-full max-w-2xl px-5 py-10 sm:py-14">
         <div className="mb-6">
-          <h1 className="font-display text-2xl font-semibold text-foreground sm:text-3xl">
+          <h1 className="font-display text-2xl font-medium tracking-tight text-foreground sm:text-3xl">
             Welcome to Derive, {firstName}.
           </h1>
           <p className="mt-1.5 text-sm text-muted-foreground">
@@ -111,7 +111,7 @@ export function Welcome() {
 
         {/* 1 — Profile: photo + handle + role + bio, one block, one save */}
         <Card className="p-5">
-          <div className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+          <div className="font-mono text-2xs uppercase tracking-[0.08em] text-muted-foreground">
             Step 1 · Your profile
           </div>
           <WelcomeProfile />
@@ -120,7 +120,7 @@ export function Welcome() {
         {/* 2 — Connect your tools (paste-into-an-agent) */}
         <Card className="mt-4 p-5">
           <div className="flex items-center justify-between gap-3">
-            <div className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <div className="font-mono text-2xs uppercase tracking-[0.08em] text-muted-foreground">
               Step 2 · Connect your tools
             </div>
             {/* Compact Self-host mode switch — swaps the snippet in place for the
@@ -247,7 +247,7 @@ function WelcomeProfile() {
             {me.image && <AvatarImage src={me.image} alt="Your avatar" />}
             <AvatarFallback className="rounded-full bg-card text-muted-foreground">
               {me.name ? (
-                <span className="font-display text-xl font-semibold">{initials}</span>
+                <span className="font-display text-xl font-medium">{initials}</span>
               ) : (
                 <Camera className="size-5" aria-hidden />
               )}


### PR DESCRIPTION
Follow-up to the foundation facelift (#258), extending the same design language to the pages that pass didn't touch.

## What changed
- **Login** — hand-rolled field labels → `FormField`; lucide `Check` → the `Icon` vocab; medium/tracked headline; roomier spacing (`p-12`, `gap-4`).
- **Welcome** — medium/tracked heading; mono eyebrows for the step labels; lighter avatar initials.
- **People / Profile** — medium/tracked headings; subtler card hover (background tint over an accent border); dropped the stale `text-accent-foreground` on role lines.
- **Settings** — medium/tracked page title; person & agent names aligned to the app-wide `font-medium` weight; lighter decorative avatar initials.

The settings sections were already largely on-language (section labels match the `SectionHeader` weight, cards/tokens throughout), so the changes there are consistency touch-ups rather than a rebuild.

## Verification
`biome check`, `lint:tokens`, `lint:frontend`, `lint:testids`, `lint:api`, `lint:schema`, `lint:filesize`, `typecheck`, `knip` — all green. Web tests: 89 passed. No testids or behavior changed.