### PR TITLE
Hosted tier: Workers + Hyperdrive + Postgres, live at derive.to

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ playwright-report/
 # Local dev/test API data (sqlite DB + blobs)
 apps/api/.ab-data/
 apps/api/.e2e-data/
+

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -259,20 +259,37 @@ Durable Objects on the edge but move metadata to Postgres. R2 stays for blobs.
 
 When to switch: D1 has a 10 GB storage limit per database and single-region writes. If
 your workspace grows beyond that, or you need cross-region write performance, point the
-Worker at a Postgres instance instead.
+Worker at a Postgres instance instead. This is the tier the hosted product runs.
+
+The Worker reaches Postgres through [Hyperdrive](https://developers.cloudflare.com/hyperdrive/)
+(Cloudflare's connection pooler — a Worker opens a fresh short-lived connection per
+request, which raw Postgres handles badly; Hyperdrive holds the real server-side pool
+and the per-request dial goes to a colo-local proxy). The binding's presence is the
+switch: `HYPERDRIVE` bound ⇒ the Postgres path; unbound ⇒ D1.
 
 ```bash
-wrangler secret put DATABASE_URL      # postgres://user:pass@host/db
-wrangler r2 bucket create derive-blobs  # if not already created
+wrangler hyperdrive create derive-pg \
+  --connection-string='postgres://user:pass@host/db?sslmode=require'
+# put the returned id into [[hyperdrive]] in wrangler.toml
+wrangler r2 bucket create derive-blobs   # if not already created
 wrangler secret put DERIVE_AUTH_SECRET
-pnpm build:web
-wrangler deploy
+pnpm --filter @derive/api deploy         # build:web → schemas (D1 + pg) → wrangler deploy → smoke
 ```
 
-With `DATABASE_URL` set, the Worker uses the Postgres backend (via `packages/db`) instead
-of D1. Durable Objects (`ArtifactRoom`, `WebhookOutbox`) continue handling realtime
-fan-out and the webhook outbox drain — those stay on the edge regardless.
+`deploy:pg-schema` (part of `deploy`, or standalone) brings Postgres fully current
+before the new Worker goes live — the pg twin of the D1 deploy's two schema steps: it
+applies the app DDL (idempotent) and reconciles the Better Auth schema, reading
+`DATABASE_URL` from the environment or the repo-root `.env`. Like the D1 tier, the edge
+never applies schema at runtime (the Node tier does, on boot).
 
-The `[[d1_databases]]` binding in `wrangler.toml` is still required by the Workers runtime
-even when `DATABASE_URL` overrides it at app startup. Leave the binding in place; the D1
-database itself will be idle.
+Durable Objects (`ArtifactRoom`, `WebhookOutbox`, `RepoSyncRunner`) continue handling
+realtime fan-out, the webhook outbox drain, and GitHub sync — those stay on the edge
+regardless, and the outbox/sync DOs read the same Postgres through Hyperdrive.
+
+The `[[d1_databases]]` binding in `wrangler.toml` is still required by the Workers
+runtime even when `HYPERDRIVE` takes over at app startup. Leave the binding in place;
+the D1 database itself will be idle.
+
+PlanetScale note: its connection strings end in `sslrootcert=system`, which
+node-postgres reads as a file path — drop that parameter (keep `sslmode`); the deploy
+scripts already tolerate it.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -268,9 +268,13 @@ and the per-request dial goes to a colo-local proxy). The binding's presence is 
 switch: `HYPERDRIVE` bound ⇒ the Postgres path; unbound ⇒ D1.
 
 ```bash
-wrangler hyperdrive create derive-pg \
+wrangler hyperdrive create derive-pg --caching-disabled \
   --connection-string='postgres://user:pass@host/db?sslmode=require'
 # put the returned id into [[hyperdrive]] in wrangler.toml
+# --caching-disabled is required, not a tuning choice: Hyperdrive caches SELECT
+# results (~60s) by default, and Derive reads its own writes — workspace
+# resolution and artifact read-back return stale results under caching (on first
+# login this provisioned a new workspace on every request until the TTL expired).
 wrangler r2 bucket create derive-blobs   # if not already created
 wrangler secret put DERIVE_AUTH_SECRET
 pnpm --filter @derive/api deploy         # build:web → schemas (D1 + pg) → wrangler deploy → smoke

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,7 +18,8 @@
     "build:web": "pnpm --filter @derive/web build && node scripts/prep-edge-assets.mjs",
     "deploy:schema": "node scripts/apply-d1-schema.mjs",
     "migrate:auth": "tsx migrate-auth-d1.ts",
-    "deploy": "pnpm build:web && pnpm deploy:schema && tsx migrate-auth-d1.ts --apply && wrangler deploy && pnpm deploy:smoke",
+    "deploy": "pnpm build:web && pnpm deploy:schema && tsx migrate-auth-d1.ts --apply && pnpm deploy:pg-schema && wrangler deploy && pnpm deploy:smoke",
+    "deploy:pg-schema": "tsx scripts/apply-pg-schema.ts",
     "deploy:smoke": "gh workflow run e2e-smoke.yml --ref main || echo 'post-deploy smoke not triggered (gh CLI unavailable) — run: gh workflow run e2e-smoke.yml'",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.worker.json",
     "test": "vitest run",
@@ -37,6 +38,7 @@
     "drizzle-orm": "^0.45.2",
     "hono": "^4.6.0",
     "hono-rate-limiter": "^0.5.3",
+    "kysely": "^0.29.2",
     "pg": "^8.13.1",
     "zod": "^4.4.3",
     "jose": "^6.1.0"

--- a/apps/api/scripts/apply-pg-schema.ts
+++ b/apps/api/scripts/apply-pg-schema.ts
@@ -1,0 +1,56 @@
+import { join } from "node:path"
+import { PgMetaStore } from "@derive/db/pg"
+import { Pool } from "pg"
+import { makeAuth, migrateAuth } from "../src/auth-config"
+
+// Bring the hosted tier's Postgres fully current before a Worker deploy — the pg
+// twin of `apply-d1-schema.mjs` + `migrate-auth-d1.ts`. The Workers entry never
+// applies schema at runtime (the Node tier does on boot), so this runs out of band:
+// `pnpm deploy:pg-schema`, or as part of `pnpm deploy:pg`. Both steps are
+// idempotent — they create the whole schema on a brand-new database and reconcile
+// an existing one, so a deploy can never ship code against a stale schema.
+//
+// Reads DATABASE_URL from the environment, falling back to the repo-root .env
+// (same lookup as node.ts).
+
+for (const envPath of [join(import.meta.dirname, "../../../.env"), ".env"]) {
+  try {
+    process.loadEnvFile(envPath)
+    break
+  } catch {
+    /* no .env at this path — carry on */
+  }
+}
+
+const raw = process.env.DATABASE_URL
+if (!raw) {
+  // A D1-only deploy has no Postgres to migrate; `pnpm deploy` runs both schema
+  // steps unconditionally, so this exits clean instead of failing that path.
+  console.log("DATABASE_URL not set — skipping pg schema")
+  process.exit(0)
+}
+// node-postgres reads `sslrootcert` as a file path; the `system` keyword some
+// providers emit (Neon, PlanetScale) breaks it. Dropping the param falls back to
+// the default CA bundle — the same verification for a public-CA cert.
+const u = new URL(raw)
+if (u.searchParams.get("sslrootcert") === "system") u.searchParams.delete("sslrootcert")
+const url = u.toString()
+
+// App schema: PgMetaStore.create applies PG_SCHEMA_STATEMENTS (idempotent DDL).
+const store = await PgMetaStore.create(url, (e) => console.error("pool error:", e.message))
+console.log("app schema applied")
+
+// Better Auth schema: derived from the live auth config (the single source of
+// truth), reconciled by Better Auth's own migrator. baseUrl/secret are dummies —
+// only the table shapes matter here.
+const pool = new Pool({ connectionString: url, connectionTimeoutMillis: 10_000 })
+pool.on("error", (e) => console.error("auth pool error:", e.message))
+const auth = makeAuth(pool, "http://localhost:8080", "schema-apply-not-a-real-secret", {})
+await migrateAuth(auth)
+// Better Auth can't add UNIQUE to an existing column; enforce it here (both the
+// Node boot and this script apply the same backstop — see node.ts).
+await pool.query(`CREATE UNIQUE INDEX IF NOT EXISTS user_username ON "user" (username)`)
+console.log("auth schema applied")
+
+await store.close()
+await pool.end()

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -496,12 +496,16 @@ export function buildContext(deps: AppDeps) {
   }
 
   // A signed-in user's own workspace, created on demand (multi mode, first login).
+  // The id is derived from the user id, not random: an SPA boot fires several
+  // requests in parallel, and on a first login each can miss the membership read
+  // and provision. setWorkspace/setMembership are upserts, so concurrent
+  // provisions converge on one row instead of racing to create siblings.
   const provisionPersonal = async (me: {
     id: string
     email: string
     name: string | null
   }): Promise<string> => {
-    const id = newId("ws")
+    const id = `ws_p_${me.id}`
     const base = (me.name ?? me.email).split("@")[0] || "My"
     await meta.setWorkspace(id, `${base}'s Workspace`)
     await meta.setMembership({ id: newId("m"), org_id: id, user_id: me.id, role: "owner" })

--- a/apps/api/src/edge-pg.ts
+++ b/apps/api/src/edge-pg.ts
@@ -1,0 +1,60 @@
+import { AsyncLocalStorage } from "node:async_hooks"
+import type { D1Database, Hyperdrive } from "@cloudflare/workers-types"
+import type { MetaStore } from "@derive/core"
+import { createD1Store } from "@derive/db/d1"
+import { PgMetaStore } from "@derive/db/pg"
+import { Pool } from "pg"
+
+/**
+ * Postgres plumbing for the Workers tier (the HYPERDRIVE binding).
+ *
+ * A Workers TCP socket belongs to the invocation (request or DO event) that
+ * opened it — the TCP twin of the stale-binding problem request-d1.ts documents.
+ * So pools are invocation-scoped, and cheaply so: node-postgres connects lazily,
+ * and the dial goes to the colo-local Hyperdrive proxy, which owns the real
+ * server-side connections.
+ */
+
+/** One invocation's pool. Callers own the lifecycle: DO ticks end() it when the
+ *  tick's work is fully awaited; the fetch path never end()s (see worker.ts) and
+ *  relies on the idle timeout + context teardown instead. */
+export const hyperdrivePool = (hd: Hyperdrive): Pool => {
+  const pool = new Pool({
+    connectionString: hd.connectionString,
+    max: 5,
+    statement_timeout: 30_000,
+    connectionTimeoutMillis: 10_000,
+    // Idle sockets reap themselves, so a pool nobody end()s doesn't hold its
+    // invocation open longer than its last query.
+    idleTimeoutMillis: 5_000,
+  })
+  // An idle-socket error on an invocation-scoped pool just means that socket is
+  // gone; without a listener node-postgres escalates it to an isolate crash.
+  pool.on("error", () => {})
+  return pool
+}
+
+/** MetaStore for one DO tick: Postgres (fresh pool, released via `close`) when
+ *  HYPERDRIVE is bound, else the DO-lifetime-stable D1 binding (no-op close). */
+export const tickStore = (env: {
+  DB: D1Database
+  HYPERDRIVE?: Hyperdrive
+}): { store: MetaStore; close: () => Promise<void> } => {
+  if (!env.HYPERDRIVE) return { store: createD1Store(env.DB), close: async () => {} }
+  const pool = hyperdrivePool(env.HYPERDRIVE)
+  return { store: PgMetaStore.fromPool(pool), close: () => pool.end() }
+}
+
+/** The fetch path's request-scoped pool, bound in worker.ts via `requestPg.run`.
+ *  `livePgPool` forwards to the in-flight request's pool so the store and Better
+ *  Auth — both built once per isolate — never capture a dead pool. */
+export const requestPg = new AsyncLocalStorage<Pool>()
+
+export const livePgPool = new Proxy({} as Pool, {
+  get(_target, prop) {
+    const pool = requestPg.getStore()
+    if (!pool) throw new Error("requestPg: no Postgres pool bound for this request")
+    const value = Reflect.get(pool as object, prop)
+    return typeof value === "function" ? value.bind(pool) : value
+  },
+})

--- a/apps/api/src/sync-runner-do.ts
+++ b/apps/api/src/sync-runner-do.ts
@@ -1,7 +1,12 @@
-import type { D1Database, DurableObjectState, R2Bucket } from "@cloudflare/workers-types"
-import type { BlobStore, MetaStore } from "@derive/core"
-import { createD1Store } from "@derive/db/d1"
+import type {
+  D1Database,
+  DurableObjectState,
+  Hyperdrive,
+  R2Bucket,
+} from "@cloudflare/workers-types"
+import type { BlobStore } from "@derive/core"
 import { R2BlobStore } from "@derive/storage"
+import { tickStore } from "./edge-pg"
 import { runSourceBatch } from "./lib/sync-runner"
 import { log } from "./log"
 
@@ -22,9 +27,12 @@ const RETRY_BACKOFF_MS = 1_200
 // Past this many consecutive throws we stop and leave the error visible for the user.
 const MAX_RETRIES = 4
 
-/** The env the sync runner DO needs: D1 (MetaStore) + R2 (blobs) + the at-rest key. */
+/** The env the sync runner DO needs: the datastore bindings for the per-batch
+ *  MetaStore (Postgres when HYPERDRIVE is bound, else D1 — see edge-pg.ts) +
+ *  R2 (blobs) + the at-rest key. */
 export interface RepoSyncRunnerEnv {
   DB: D1Database
+  HYPERDRIVE?: Hyperdrive
   BUCKET: R2Bucket
   /** At-rest key for decrypting stored PATs / minting installation tokens. */
   DERIVE_AUTH_SECRET?: string
@@ -47,15 +55,13 @@ export interface RepoSyncRunnerEnv {
  * the cron backstop, and the persisted map makes every retry idempotent.
  */
 export class RepoSyncRunner {
-  private meta: MetaStore
   private blobs: BlobStore
   private key: string | undefined
 
   constructor(
     private state: DurableObjectState,
-    env: RepoSyncRunnerEnv,
+    private env: RepoSyncRunnerEnv,
   ) {
-    this.meta = createD1Store(env.DB)
     this.blobs = new R2BlobStore(env.BUCKET)
     this.key = env.DERIVE_AUTH_SECRET
   }
@@ -81,13 +87,19 @@ export class RepoSyncRunner {
   async alarm(): Promise<void> {
     const sourceId = await this.state.storage.get<string>("source")
     if (!sourceId) return // nothing queued (a stray cron/poke) — stay idle
+    // Store construction stays inside the try: a throw anywhere must land in the
+    // retry/backoff path, or the batch loop strands until the next user trigger.
+    let close = async () => {}
     try {
-      const source = await this.meta.getRepoSource(sourceId)
+      const opened = tickStore(this.env)
+      close = opened.close
+      const meta = opened.store
+      const source = await meta.getRepoSource(sourceId)
       if (!source) {
         await this.stop() // disconnected mid-sync — nothing left to do
         return
       }
-      const res = await runSourceBatch(this.meta, this.blobs, this.key, source)
+      const res = await runSourceBatch(meta, this.blobs, this.key, source)
       if (res.remaining > 0) {
         await this.state.storage.put("retries", 0)
         await this.state.storage.setAlarm(Date.now() + TICK_MS)
@@ -107,6 +119,8 @@ export class RepoSyncRunner {
       // Linear backoff; a recovering batch overwrites progress back to mirroring/done.
       await this.state.storage.put("retries", retries + 1)
       await this.state.storage.setAlarm(Date.now() + RETRY_BACKOFF_MS * (retries + 1))
+    } finally {
+      await close()
     }
   }
 

--- a/apps/api/src/webhook-do.ts
+++ b/apps/api/src/webhook-do.ts
@@ -1,5 +1,6 @@
-import type { D1Database, DurableObjectState } from "@cloudflare/workers-types"
-import { createD1Store } from "@derive/db/d1"
+import type { D1Database, DurableObjectState, Hyperdrive } from "@cloudflare/workers-types"
+import type { MetaStore } from "@derive/core"
+import { tickStore } from "./edge-pg"
 import { cloudflareEmailSender, type SendEmailBinding } from "./email-cf"
 import { emailDeliverySender } from "./lib/email"
 import { makeGithubCommentSender } from "./lib/github-comments"
@@ -15,11 +16,13 @@ const TICK_MS = 1_500
 // ~this long rather than waiting up to a cron tick.
 const POKE_DELAY_MS = 250
 
-/** The env the outbox DO needs: the D1 binding it builds a MetaStore from, plus the
+/** The env the outbox DO needs: the datastore bindings it builds a per-tick MetaStore
+ *  from (Postgres when HYPERDRIVE is bound, else D1 — see edge-pg.ts), plus the
  *  optional Cloudflare Email Service binding + from-address used to deliver email-kind
  *  rows (absent ⇒ email rows are a delivered no-op on this tier). */
 export interface WebhookOutboxEnv {
   DB: D1Database
+  HYPERDRIVE?: Hyperdrive
   SEND_EMAIL?: SendEmailBinding
   EMAIL_FROM?: string
   // The auth secret doubles as the at-rest encryption key for stored GitHub App
@@ -41,24 +44,24 @@ export interface WebhookOutboxEnv {
  * so losing it (or a missed poke) only delays delivery to the next cron backstop.
  */
 export class WebhookOutbox {
-  private store: ReturnType<typeof createD1Store>
-  private senders: ChannelSenders
-
   constructor(
     private state: DurableObjectState,
-    env: WebhookOutboxEnv,
-  ) {
-    this.store = createD1Store(env.DB)
-    // First-party channel senders for this tier. Email when the Cloudflare Email
-    // Service binding is bound; GitHub PR comment write-back when the auth secret
-    // (the App-credential encryption key) is present.
-    this.senders = {
+    private env: WebhookOutboxEnv,
+  ) {}
+
+  // First-party channel senders for this tier, rebuilt per tick (they capture the
+  // tick's store). Email when the Cloudflare Email Service binding is bound; GitHub
+  // PR comment write-back when the auth secret (the App-credential encryption key)
+  // is present.
+  private senders(store: MetaStore): ChannelSenders {
+    const env = this.env
+    return {
       ...(env.SEND_EMAIL && env.EMAIL_FROM
         ? { email: emailDeliverySender(cloudflareEmailSender(env.SEND_EMAIL, env.EMAIL_FROM)) }
         : {}),
-      github_review_comment: makeGithubCommentSender(this.store, env.DERIVE_AUTH_SECRET),
-      github_issue_comment: makeGithubCommentSender(this.store, env.DERIVE_AUTH_SECRET),
-      slack_app: makeSlackSender(this.store, env.DERIVE_AUTH_SECRET),
+      github_review_comment: makeGithubCommentSender(store, env.DERIVE_AUTH_SECRET),
+      github_issue_comment: makeGithubCommentSender(store, env.DERIVE_AUTH_SECRET),
+      slack_app: makeSlackSender(store, env.DERIVE_AUTH_SECRET),
     }
   }
 
@@ -74,11 +77,18 @@ export class WebhookOutbox {
   // retries fire without waiting for the next poke/cron. Errors must not strand the
   // alarm — on failure, reschedule so the loop self-heals.
   async alarm(): Promise<void> {
+    // Store construction stays inside the try: a throw anywhere must still land in
+    // the catch's re-arm, or the drain loop strands until the cron backstop.
+    let close = async () => {}
     try {
-      const claimed = await runDeliveryTick(this.store, edgeGuard, this.senders)
+      const opened = tickStore(this.env)
+      close = opened.close
+      const claimed = await runDeliveryTick(opened.store, edgeGuard, this.senders(opened.store))
       if (claimed > 0) await this.state.storage.setAlarm(Date.now() + TICK_MS)
     } catch {
       await this.state.storage.setAlarm(Date.now() + TICK_MS)
+    } finally {
+      await close()
     }
   }
 }

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -3,17 +3,21 @@ import type {
   DurableObjectNamespace,
   ExecutionContext,
   Fetcher,
+  Hyperdrive,
   R2Bucket,
   RateLimit,
   ScheduledController,
 } from "@cloudflare/workers-types"
 import { createD1Store } from "@derive/db/d1"
+import { PgMetaStore } from "@derive/db/pg"
 import { R2BlobStore } from "@derive/storage"
 import { drizzleAdapter } from "better-auth/adapters/drizzle"
 import { drizzle } from "drizzle-orm/d1"
+import { PostgresDialect } from "kysely"
 import { createApp } from "./app"
-import { makeAuth } from "./auth-config"
+import { type AuthDb, makeAuth } from "./auth-config"
 import { authSchema } from "./auth-schema"
+import { hyperdrivePool, livePgPool, requestPg } from "./edge-pg"
 import type { SendEmailBinding } from "./email-cf"
 import { customDomainsFromEnv } from "./lib/cloudflare-saas"
 import { nativeLimiter } from "./lib/rate-limit"
@@ -57,6 +61,10 @@ const OUTBOX_NAME = "outbox"
  */
 export interface Env {
   DB: D1Database
+  // Hyperdrive → Postgres (the hosted tier). Bound ⇒ metadata + auth live in
+  // Postgres and DB (D1) sits idle (the binding stays because the runtime requires
+  // every declared binding to resolve). Unbound ⇒ D1 is the store (the default).
+  HYPERDRIVE?: Hyperdrive
   BUCKET: R2Bucket
   ROOMS: DurableObjectNamespace
   // The webhook outbox drainer DO (a single named instance). Declared in wrangler.toml.
@@ -116,113 +124,129 @@ let app: ReturnType<typeof createApp> | null = null
 // a deployment). Injected with per-artifact unfurl meta on each /a/:ref request.
 let shellCache: string | null = null
 
-export default {
-  fetch(req: Request, env: Env, ctx: ExecutionContext): Response | Promise<Response> {
-    // Bind THIS request's D1 for the entire handler — including the one-time app/auth
-    // construction below — so liveD1 always resolves to a live binding, never a stale one.
-    return requestD1.run(env.DB, () => {
-      if (!app) {
-        // No insecure default on the edge: a hardcoded, public session-signing key
-        // would let anyone forge a valid session. The Node path generates+persists
-        // one when unset, but a stateless Worker can't, so it must be bound. Fail
-        // closed (a 500 on every request) rather than boot with a forgeable secret.
-        const secret = env.DERIVE_AUTH_SECRET
-        if (!secret || secret.length < 16)
-          throw new Error("DERIVE_AUTH_SECRET (>= 16 chars) is required on the edge")
-        const baseUrl = env.BASE_URL ?? new URL(req.url).origin
-        // Both stores talk to D1 through `liveD1` (the requestD1 ALS proxy), never a
-        // captured `env.DB` — a captured binding goes stale once its originating request
-        // context is reclaimed and then hangs every query. liveD1 always resolves to the
-        // in-flight request's binding (set via requestD1.run below).
-        const meta = createD1Store(liveD1)
-        // Better Auth on Drizzle's first-class D1 driver (drizzle-orm/d1) — the same
-        // driver the app store uses, and no kysely-d1. The drizzle adapter defaults
-        // transaction:false, so it never issues an interactive transaction to D1.
-        const auth = makeAuth(
-          drizzleAdapter(drizzle(liveD1, { schema: authSchema }), {
+// The request handler behind both tiers. Split from `fetch` so the pg tier can
+// wrap it in a request-scoped pool without indenting the whole body.
+const handle = (req: Request, env: Env, ctx: ExecutionContext): Response | Promise<Response> => {
+  // Bind THIS request's D1 for the entire handler — including the one-time app/auth
+  // construction below — so liveD1 always resolves to a live binding, never a stale one.
+  return requestD1.run(env.DB, () => {
+    if (!app) {
+      // No insecure default on the edge: a hardcoded, public session-signing key
+      // would let anyone forge a valid session. The Node path generates+persists
+      // one when unset, but a stateless Worker can't, so it must be bound. Fail
+      // closed (a 500 on every request) rather than boot with a forgeable secret.
+      const secret = env.DERIVE_AUTH_SECRET
+      if (!secret || secret.length < 16)
+        throw new Error("DERIVE_AUTH_SECRET (>= 16 chars) is required on the edge")
+      const baseUrl = env.BASE_URL ?? new URL(req.url).origin
+      // Both stores talk to their backend through a request-scoped proxy (liveD1 /
+      // livePgPool), never a captured binding or socket — anything captured at
+      // construction goes stale once its originating request context is reclaimed
+      // and then hangs every query. The proxies always resolve to the in-flight
+      // request's handle (bound via requestD1.run / requestPg.run in fetch).
+      const meta = env.HYPERDRIVE ? PgMetaStore.fromPool(livePgPool) : createD1Store(liveD1)
+      // Auth datastore: Postgres rides Better Auth's Kysely core on an explicit
+      // PostgresDialect (declared, not duck-typed — livePgPool is a Proxy). D1 rides
+      // Drizzle's first-class D1 driver — the same driver the app store uses, and no
+      // kysely-d1; the drizzle adapter defaults transaction:false, so it never issues
+      // an interactive transaction to D1.
+      const authDb: AuthDb = env.HYPERDRIVE
+        ? { dialect: new PostgresDialect({ pool: livePgPool }), type: "postgres" }
+        : drizzleAdapter(drizzle(liveD1, { schema: authSchema }), {
             provider: "sqlite",
             schema: authSchema,
-          }),
-          baseUrl,
-          secret,
-          { usernameTaken: (u) => meta.getUserByUsername(u).then(Boolean) },
-        )
-        app = createApp({
-          meta,
-          blobs: new R2BlobStore(env.BUCKET),
-          backplane: createDoBackplane(env.ROOMS),
-          baseUrl,
-          auth,
-          // Encrypt stored GitHub PATs at rest with the edge auth secret.
-          encryptionKey: secret,
-          slack:
-            env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET && env.SLACK_SIGNING_SECRET
-              ? {
-                  clientId: env.SLACK_CLIENT_ID,
-                  clientSecret: env.SLACK_CLIENT_SECRET,
-                  signingSecret: env.SLACK_SIGNING_SECRET,
-                }
-              : undefined,
-          superAdmins: (env.DERIVE_SUPERADMIN_EMAILS ?? "")
-            .split(",")
-            .map((s) => s.trim().toLowerCase())
-            .filter(Boolean),
-          defaultOrgId: "default",
-          subdomainBase:
-            env.DERIVE_SUBDOMAIN_BASE?.toLowerCase().replace(/^\.+|\.+$/g, "") || undefined,
-          customDomains: customDomainsFromEnv(env),
-          // Enable rate limiting on the edge, counted by Cloudflare's native per-colo
-          // limiter (a plain in-memory Map would cap per isolate only). The native binding's
-          // window is fixed at 60s, so unlock / oauth-register run a tighter per-minute cap
-          // here than the long-window in-process defaults (see wrangler.toml [[ratelimits]]).
-          rateLimit: true,
-          rateLimiters: {
-            auth: nativeLimiter(env.RL_AUTH, 60),
-            write: nativeLimiter(env.RL_WRITE, 60),
-            publish: nativeLimiter(env.RL_PUBLISH, 60),
-            comment: nativeLimiter(env.RL_COMMENT, 60),
-            // Both ride RL_STRICT (3/60); the prefix keeps their counts separate.
-            unlock: nativeLimiter(env.RL_STRICT, 60, "unlock"),
-            oauthRegister: nativeLimiter(env.RL_STRICT, 60, "oauth-register"),
-          },
-          // Deliver freshly enqueued events now: poke the outbox DO so its alarm fires,
-          // riding waitUntil so the subrequest isn't cancelled when the response is sent.
-          pokeWebhooks: () => {
-            const p = pokeOutbox(env)
-            const c = edgeCtx.getStore()
-            if (c) c.waitUntil(p)
-            else void p
-          },
-          // Run a triggered GitHub sync server-side: poke the per-source runner DO so
-          // it mirrors to completion on our servers (tab-independent). waitUntil keeps
-          // the poke subrequest alive past the 202 response.
-          startSync: (sourceId) => {
-            const p = pokeSync(env, sourceId)
-            const c = edgeCtx.getStore()
-            if (c) c.waitUntil(p)
-            else void p
-          },
-          // Read the SPA shell from static assets so /a/:ref can carry unfurl meta.
-          // Cached per isolate; null on any miss leaves the shell untouched.
-          shellFetch: async () => {
-            if (shellCache !== null) return shellCache
-            try {
-              // Fetch "/" (the canonical shell URL), NOT "/index.html": Static Assets
-              // 307-redirects /index.html -> /, so a non-2xx would null the shell and
-              // drop unfurl/OG injection on /a/:ref (crawlers/social cards get no meta).
-              const res = await env.ASSETS.fetch(new URL("/", baseUrl).toString())
-              shellCache = res.ok ? await res.text() : null
-            } catch {
-              shellCache = null
-            }
-            return shellCache
-          },
-        })
-      }
-      // Run within the per-request context so the DO backplane's publish can waitUntil.
-      const ready = app
-      return edgeCtx.run(ctx, () => ready.fetch(req))
-    })
+          })
+      const auth = makeAuth(authDb, baseUrl, secret, {
+        usernameTaken: (u) => meta.getUserByUsername(u).then(Boolean),
+      })
+      app = createApp({
+        meta,
+        blobs: new R2BlobStore(env.BUCKET),
+        backplane: createDoBackplane(env.ROOMS),
+        baseUrl,
+        auth,
+        // Encrypt stored GitHub PATs at rest with the edge auth secret.
+        encryptionKey: secret,
+        slack:
+          env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET && env.SLACK_SIGNING_SECRET
+            ? {
+                clientId: env.SLACK_CLIENT_ID,
+                clientSecret: env.SLACK_CLIENT_SECRET,
+                signingSecret: env.SLACK_SIGNING_SECRET,
+              }
+            : undefined,
+        superAdmins: (env.DERIVE_SUPERADMIN_EMAILS ?? "")
+          .split(",")
+          .map((s) => s.trim().toLowerCase())
+          .filter(Boolean),
+        defaultOrgId: "default",
+        subdomainBase:
+          env.DERIVE_SUBDOMAIN_BASE?.toLowerCase().replace(/^\.+|\.+$/g, "") || undefined,
+        customDomains: customDomainsFromEnv(env),
+        // Enable rate limiting on the edge, counted by Cloudflare's native per-colo
+        // limiter (a plain in-memory Map would cap per isolate only). The native binding's
+        // window is fixed at 60s, so unlock / oauth-register run a tighter per-minute cap
+        // here than the long-window in-process defaults (see wrangler.toml [[ratelimits]]).
+        rateLimit: true,
+        rateLimiters: {
+          auth: nativeLimiter(env.RL_AUTH, 60),
+          write: nativeLimiter(env.RL_WRITE, 60),
+          publish: nativeLimiter(env.RL_PUBLISH, 60),
+          comment: nativeLimiter(env.RL_COMMENT, 60),
+          // Both ride RL_STRICT (3/60); the prefix keeps their counts separate.
+          unlock: nativeLimiter(env.RL_STRICT, 60, "unlock"),
+          oauthRegister: nativeLimiter(env.RL_STRICT, 60, "oauth-register"),
+        },
+        // Deliver freshly enqueued events now: poke the outbox DO so its alarm fires,
+        // riding waitUntil so the subrequest isn't cancelled when the response is sent.
+        pokeWebhooks: () => {
+          const p = pokeOutbox(env)
+          const c = edgeCtx.getStore()
+          if (c) c.waitUntil(p)
+          else void p
+        },
+        // Run a triggered GitHub sync server-side: poke the per-source runner DO so
+        // it mirrors to completion on our servers (tab-independent). waitUntil keeps
+        // the poke subrequest alive past the 202 response.
+        startSync: (sourceId) => {
+          const p = pokeSync(env, sourceId)
+          const c = edgeCtx.getStore()
+          if (c) c.waitUntil(p)
+          else void p
+        },
+        // Read the SPA shell from static assets so /a/:ref can carry unfurl meta.
+        // Cached per isolate; null on any miss leaves the shell untouched.
+        shellFetch: async () => {
+          if (shellCache !== null) return shellCache
+          try {
+            // Fetch "/" (the canonical shell URL), NOT "/index.html": Static Assets
+            // 307-redirects /index.html -> /, so a non-2xx would null the shell and
+            // drop unfurl/OG injection on /a/:ref (crawlers/social cards get no meta).
+            const res = await env.ASSETS.fetch(new URL("/", baseUrl).toString())
+            shellCache = res.ok ? await res.text() : null
+          } catch {
+            shellCache = null
+          }
+          return shellCache
+        },
+      })
+    }
+    // Run within the per-request context so the DO backplane's publish can waitUntil.
+    const ready = app
+    return edgeCtx.run(ctx, () => ready.fetch(req))
+  })
+}
+
+export default {
+  fetch(req: Request, env: Env, ctx: ExecutionContext): Response | Promise<Response> {
+    // Postgres tier: bind a request-scoped pool (see edge-pg.ts) for livePgPool to
+    // resolve. Never end()ed here — `background()` fan-out (context.ts) keeps
+    // querying it on waitUntil after the response, so an eager end() would cut
+    // notifications/webhooks off mid-flight. Idle sockets reap themselves and the
+    // rest dies with the request context.
+    if (env.HYPERDRIVE)
+      return requestPg.run(hyperdrivePool(env.HYPERDRIVE), () => handle(req, env, ctx))
+    return handle(req, env, ctx)
   },
 
   // Cron backstop (wrangler.toml `[triggers] crons`): the outbox DO goes idle once it

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -23,6 +23,10 @@ database_id = "3c076a21-de54-4cf8-b352-7c8430a9ab79"
 # id is account-scoped and not a secret — the DATABASE_URL lives inside the
 # Hyperdrive config (`wrangler hyperdrive create`). Schema is applied at deploy
 # time by `pnpm deploy:pg-schema`.
+# ⚠ Query caching MUST stay disabled on this config (--caching-disabled).
+# Hyperdrive caches SELECT results ~60s by default; this app reads its own
+# writes (workspace resolution, artifact read-back), and cached-stale reads made
+# first-login provision a workspace per request until the TTL expired.
 [[hyperdrive]]
 binding = "HYPERDRIVE"
 id = "10b9d78afcdb46ad8f8db7ad449fb2b3"

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -2,16 +2,30 @@
 name = "derive"
 main = "src/worker.ts"
 compatibility_date = "2024-11-01"
-compatibility_flags = ["nodejs_compat"]
+# populate_process_env mirrors vars + secrets into process.env (automatic only at
+# compat dates ≥ 2025-04-01) — auth-config reads its optional providers
+# (GOOGLE_*, GITHUB_LOGIN_*, OIDC_*) there, same as on Node.
+compatibility_flags = ["nodejs_compat", "nodejs_compat_populate_process_env"]
 
 [[d1_databases]]
 binding = "DB"
 database_name = "derive"
-# This is Sift's prod D1 id. A D1 id is not a secret (it's inert without a
+# The Derive Cloudflare account's D1. A D1 id is not a secret (it's inert without a
 # Cloudflare API token scoped to the account), so it lives here so `pnpm run
 # deploy` is one step. Self-hosting Derive? Run `wrangler d1 create derive` and put
-# your own id here. See DEPLOY.md.
-database_id = "63229e09-fdf4-4232-807d-1c60fabd9a39"
+# your own id here. See DEPLOY.md. NOTE: with the HYPERDRIVE binding below, metadata
+# + auth live in Postgres and this database sits idle — the binding stays only
+# because the runtime requires every declared binding to resolve.
+database_id = "3c076a21-de54-4cf8-b352-7c8430a9ab79"
+
+# Hyperdrive → Neon Postgres (the hosted tier's metadata + auth store). Bound ⇒
+# the worker takes the Postgres path; remove the binding to fall back to D1. The
+# id is account-scoped and not a secret — the DATABASE_URL lives inside the
+# Hyperdrive config (`wrangler hyperdrive create`). Schema is applied at deploy
+# time by `pnpm deploy:pg-schema`.
+[[hyperdrive]]
+binding = "HYPERDRIVE"
+id = "10b9d78afcdb46ad8f8db7ad449fb2b3"
 
 [[r2_buckets]]
 binding = "BUCKET"
@@ -120,6 +134,19 @@ directory = "../web/dist/client"
 binding = "ASSETS"
 run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/oauth/*", "/settings/github/*", "/a/*", "/u/*", "/healthz", "/mcp", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource", "/.well-known/openid-configuration"]
 not_found_handling = "single-page-application"
+
+# Public hosts: the derive.to apex is canonical, app.derive.to an alias. Cloudflare
+# auto-creates the DNS records + edge certs. baseUrl falls back to the request
+# origin, so the workers.dev origin keeps serving for smoke tests.
+# NB: must be [[routes]] — a bare `routes = [...]` below a table header belongs to
+# that table and is silently ignored.
+[[routes]]
+pattern = "derive.to"
+custom_domain = true
+
+[[routes]]
+pattern = "app.derive.to"
+custom_domain = true
 
 # baseUrl falls back to the request origin when unset. Secured by Better Auth; set
 # DERIVE_AUTH_SECRET via `wrangler secret put`. Cross-instance realtime fan-out uses

--- a/docs/decisions/0001-hosted-tier-tenancy.md
+++ b/docs/decisions/0001-hosted-tier-tenancy.md
@@ -1,0 +1,80 @@
+# ADR 0001 — Hosted tier: shared Postgres, central auth, DOs as utility compute
+
+**Status:** accepted (Slack thread, 2026-07-02 — rob / anir / mert)
+
+## Decision
+
+The hosted (cloud) tier runs as:
+
+- **Compute:** Cloudflare Workers (the existing `apps/api/src/worker.ts` entry).
+- **Metadata:** one shared **Postgres** for production (currently Neon, behind
+  Cloudflare Hyperdrive). D1 stays as an adapter for local dev and staging (it is
+  SQLite-flavored and cheap to spin up), not for prod.
+- **Blobs:** one shared R2 bucket (unchanged).
+- **Durable Objects:** utility compute only — realtime rooms, webhook outbox,
+  sync runners. Nothing is hard-bound to a DO as a datastore.
+- **Auth:** central. One account, many workspaces (unchanged from today's model).
+- **Tokens:** workspace-bound. Credentials are minted under one account but each
+  write token is scoped to a single workspace (extending the existing `agent`
+  table pattern), and the CLI/MCP client keeps a local `workspace → token` map so
+  an agent always writes to an explicitly chosen workspace.
+
+## Rejected alternative: per-workspace Durable Object databases
+
+Proposal (mert): each workspace gets its own DO with a private SQLite database;
+a central "control" D1 holds users/sessions/memberships and routes each request
+to the right workspace DO. A complete reference implementation exists in
+Nemonic (control D1 + `WorkspaceDO`, fail-closed router, lazy additive-only
+per-DO migrations, hand-rolled daily snapshots to R2).
+
+Why not for Derive:
+
+- **Tenancy shape.** Nemonic's tenant boundary comes free from Slack (one team =
+  one workspace; users live in exactly one DO; no global identity). Derive is the
+  inverse: users belong to multiple workspaces, everyone gets a personal
+  workspace at signup, and the core surfaces are global — anonymous `/a/:ref`
+  links, `/u/` profiles, cross-workspace shares, eventually search. Each of those
+  would need a control-plane index kept consistent with thousands of DOs.
+- **Ops and global visibility** (the deciding argument in the thread): schema
+  migrations are one statement on one database instead of a lazy fleet-wide
+  rollout that must tolerate every historical schema version; support, billing
+  metering, analytics, and one-off data fixes are single SQL queries instead of
+  fan-outs or bespoke fleet tooling; managed Postgres gives point-in-time
+  recovery out of the box (DO-SQLite has none — Nemonic had to build its own
+  snapshot/restore).
+- **Isolation was metadata-only anyway:** blobs stay in one shared R2 bucket in
+  either design.
+- **Ceilings:** a DO is single-threaded with a 10 GB cap; Derive's heaviest
+  traffic is agent/CI publishing concentrated on a single workspace — the
+  heaviest (paying) tenant hits the per-DO ceiling first.
+
+What we adopted from the proposal: the workspace-bound token model (Nemonic's
+PAT semantics), which structurally prevents an agent publishing to the wrong
+workspace — the failure actually observed while dogfooding.
+
+## Revisit triggers
+
+Reopen the per-workspace-DO (or other hard-isolation) question only when one of
+these is concrete, not before:
+
+1. An enterprise deal blocked on physically separated tenant data that a
+   **dedicated single-tenant instance** (the existing Lite/Node container as a
+   premium SKU) cannot satisfy.
+2. A data-residency requirement (tenant data pinned to a region) that shared
+   Postgres placement cannot satisfy.
+3. Sustained Postgres scale pain (size, write throughput, or noisy-neighbor
+   contention) that vertical scaling and read replicas do not resolve.
+
+Nothing is thrown away if we shard later: central auth + memberships + routing
+is exactly the control plane that architecture requires.
+
+## Follow-ups (tracked as issues)
+
+1. ~~Wire Postgres into the Workers entry.~~ Done 2026-07-02: Hyperdrive → Neon
+   via `lib/edge-pg.ts`, live at derive.to; DEPLOY.md "Cloudflare Scale" documents
+   it.
+2. **Workspace-bound tokens, both halves.** Server: per-user workspace-scoped
+   tokens (extend the `agent` token pattern; scope or retire the instance-wide
+   `DERIVE_TOKEN`). Client: `workspace → token` config in the CLI and MCP server.
+3. **CI for the hosted path.** A workerd/Miniflare D1 lane exists in `ci.yml`;
+   extend coverage to the full worker entry and add a Workers+Postgres lane.

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -210,6 +210,13 @@ export class PgMetaStore implements MetaStore {
     })
     pool.on("error", (err) => onError?.(err))
     for (const stmt of PG_SCHEMA_STATEMENTS) await pool.query(stmt)
+    return PgMetaStore.fromPool(pool)
+  }
+
+  /** Wrap an existing pool without applying schema — the Workers path, where pools
+   *  are invocation-scoped (see apps/api edge-pg.ts) and DDL runs at deploy
+   *  time (apply-pg-schema.ts). */
+  static fromPool(pool: Pool): PgMetaStore {
     return new PgMetaStore(pool, drizzle(pool, { schema }))
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       jose:
         specifier: ^6.1.0
         version: 6.2.3
+      kysely:
+        specifier: ^0.29.2
+        version: 0.29.2
       pg:
         specifier: ^8.13.1
         version: 8.21.0
@@ -3201,8 +3204,8 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
-  deslop-js@0.5.8:
-    resolution: {integrity: sha512-Vq9D2x4dAIW24zcH55DTrl3/vi13UNKfXgw0yj7ULTssZ6KOdw/oyBHtlvE94KFC9yYEhgFTrGjaqqZKvV9pwA==}
+  deslop-js@0.6.0:
+    resolution: {integrity: sha512-MAFw9r+5WUNthgy6J6HtVKdk6B7orqGMOTBiBYz3YMI7WJNM5nE8cfQgp+ZoS7gnD1DQalEW5GqqA/emUSmD8w==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -4064,8 +4067,8 @@ packages:
   oxc-resolver@11.20.0:
     resolution: {integrity: sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==}
 
-  oxlint-plugin-react-doctor@0.5.8:
-    resolution: {integrity: sha512-L0jveKAMbqF1qAqA2Ksu8aH0/Q8FDQxLwXmHYgALa2XlsxEUuamJ+1Da2MhPWJ2ahn+ekFbnWK20qixxD+fw6A==}
+  oxlint-plugin-react-doctor@0.6.0:
+    resolution: {integrity: sha512-oByEUczXDnxO5ZsevbOscpFlpmya7dnH6Nne5StYy02AJtyEDAiCSKkXj21GDMjDDkD42708LRfWXRAY32IL9w==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint@1.66.0:
@@ -4245,8 +4248,8 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-doctor@0.5.8:
-    resolution: {integrity: sha512-gDXDQ+48KeFq2jkVgsUhQ67oQ+kUMdnIaA+YeS9VXXZFXSg9wxY5dDxurEpILSh8RwO06W8p6uCnTR+wn5B/GA==}
+  react-doctor@0.6.0:
+    resolution: {integrity: sha512-AqsoQqKQve8Zahxs48hXJuFgMcdY0AdV0fcO5eTdAKZQ/QICEoMCf0bTwxPKwN9Ix/4wWiAR+dNkBcm0ouFq+Q==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -4623,6 +4626,11 @@ packages:
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -7369,14 +7377,14 @@ snapshots:
 
   depd@2.0.0: {}
 
-  deslop-js@0.5.8:
+  deslop-js@0.6.0:
     dependencies:
       '@oxc-project/types': 0.132.0
       fast-glob: 3.3.3
       minimatch: 10.2.5
       oxc-parser: 0.132.0
       oxc-resolver: 11.20.0
-      typescript: 6.0.3
+      typescript: 5.9.3
 
   detect-libc@2.1.2: {}
 
@@ -8210,7 +8218,7 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.20.0
       '@oxc-resolver/binding-win32-x64-msvc': 11.20.0
 
-  oxlint-plugin-react-doctor@0.5.8:
+  oxlint-plugin-react-doctor@0.6.0:
     dependencies:
       '@typescript-eslint/types': 8.61.1
       eslint-scope: 9.1.2
@@ -8390,24 +8398,25 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-doctor@0.5.8(eslint@10.5.0(jiti@2.7.0)):
+  react-doctor@0.6.0(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@sentry/node': 10.58.0
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.5.8
+      deslop-js: 0.6.0
       eslint-plugin-react-hooks: 7.1.1(eslint@10.5.0(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.66.0
-      oxlint-plugin-react-doctor: 0.5.8
+      oxlint-plugin-react-doctor: 0.6.0
       prompts: 2.4.2
-      typescript: 6.0.3
+      typescript: 5.9.3
       vscode-languageserver: 9.0.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
+      yaml: 2.9.0
     transitivePeerDependencies:
       - '@opentelemetry/exporter-trace-otlp-http'
       - eslint
@@ -8457,7 +8466,7 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.5.8(eslint@10.5.0(jiti@2.7.0))
+      react-doctor: 0.6.0(eslint@10.5.0(jiti@2.7.0))
       react-dom: 19.2.7(react@19.2.7)
       react-grab: 0.1.47(react@19.2.7)
     optionalDependencies:
@@ -8850,6 +8859,8 @@ snapshots:
       content-type: 2.0.0
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  typescript@5.9.3: {}
 
   typescript@6.0.3: {}
 


### PR DESCRIPTION
## What

Production wiring for the hosted tier we agreed on in Slack: Cloudflare Workers in front of one shared Postgres (Neon, behind Hyperdrive), R2 for blobs, central auth, Durable Objects staying on utility duty. The decision and its revisit triggers are written down in `docs/decisions/0001-hosted-tier-tenancy.md` so we don't relitigate it in a month.

This is deployed and serving at [derive.to](https://derive.to) (apex + `app.derive.to`), smoke-tested end to end: signup → publish → anonymous share link, all against Postgres.

## How

The worker was D1-only; DEPLOY.md described a `DATABASE_URL` path that didn't exist. The gap is closed with one new module, `apps/api/src/edge-pg.ts`:

- **Request-scoped pools.** A Workers TCP socket can't outlive the invocation that opened it — the TCP twin of the stale-D1-binding problem `request-d1.ts` already documents. So each request gets a fresh `Pool` dialed at the colo-local Hyperdrive proxy (which owns the real server connections), exposed through the same AsyncLocalStorage-proxy pattern as D1. App store and Better Auth are still built once per isolate; they just never capture a socket.
- **Pools are never `end()`ed on the fetch path — deliberately.** `background()` (context.ts) defers notification/webhook fan-out onto `waitUntil` *after* the response, querying the same pool; an eager `end()` cuts that work off mid-flight. Idle sockets reap themselves via `idleTimeoutMillis`; the rest dies with the request context.
- **DO ticks open short-lived pools.** `WebhookOutbox` and `RepoSyncRunner` build a per-tick store via `tickStore()` (inside the `try`, so a construction failure still lands in the re-arm/backoff path) and close it in `finally`. D1 path unchanged — binding presence (`HYPERDRIVE`) is the switch.
- **Auth on pg** rides Better Auth's Kysely core with an explicit `PostgresDialect` (declared, not duck-typed — the pool is a Proxy).

Deploy pipeline: `pnpm deploy` now applies **both** schemas (D1 + pg) before `wrangler deploy`, then triggers smoke. `apply-pg-schema.ts` is the pg twin of the D1 schema steps — idempotent, exits clean when `DATABASE_URL` is unset so D1-only self-hosters aren't affected.

## Heads-up (anir)

- `wrangler.toml` now points at the **Derive account's** D1/Hyperdrive/R2, not the Sift D1 id. Your dogfood instance on the Sift account keeps running, but a `wrangler deploy` from this branch targets the new prod. Data on dock.siftai wasn't migrated — fresh start was the plan; shout if anything there needs to come across.
- New compat flag `nodejs_compat_populate_process_env`: our compat date predates automatic `process.env` population, and auth-config reads its optional providers (`GOOGLE_*`, `GITHUB_LOGIN_*`, `OIDC_*`) from there. Google sign-in is live on prod behind this.

## Gotchas encountered, encoded in the diff

- A bare `routes = [...]` below a table header in wrangler.toml is silently swallowed by that table — hence `[[routes]]` and the comment.
- Neon/PlanetScale-style `sslrootcert=system` is read by node-postgres as a literal file path; the schema script strips it via URL parsing (regex stripping corrupts the URL when the param comes first).

## Verification

- `pnpm typecheck` (Node + worker tsconfigs), full API suite (605 tests), `pnpm precommit` green.
- Live smoke on the deployed worker: healthz, email signup, artifact publish, anonymous `/a/` read, Google OAuth authorize URL minting.
- Not yet covered by CI: the worker entry against Postgres. Tracked as follow-up 3 in the ADR — next infra task after workspace-bound tokens.