### PR TITLE
feat(api): upload image bytes for bundles (asset:<hash> refs)

### DIFF
--- a/.claude/skills/using/derive-publish.md
+++ b/.claude/skills/using/derive-publish.md
@@ -106,6 +106,42 @@ The `filename` parameter is a hint for content type detection:
 
 ---
 
+## Images & binary assets in a bundle
+
+A bundle's `files` map carries binary assets (screenshots, images, fonts) alongside the
+HTML/CSS/JS pages. Each `files` value is one of:
+
+- **text** — a plain string (a page).
+- **base64 data URI** — `"shot.png": "data:image/png;base64,iVBORw0K…"`. Fine for a small
+  icon, but a real screenshot balloons the tool call and you have to transcribe the
+  base64 exactly.
+- **asset handle (preferred for real images)** — upload the raw bytes first, then
+  reference the returned handle:
+
+  ```
+  # 1. Stream the bytes up as binary — no base64, nothing to transcribe.
+  curl -s -X POST "$DERIVE_URL/v1/assets" \
+    -H "authorization: Bearer $DERIVE_TOKEN" \
+    -H "content-type: image/png" \
+    --data-binary @shot.png
+  # → { "key": "9f86d081…", "ref": "asset:9f86d081…", "type": "image/png", "size": 20531 }
+
+  # 2. Reference the handle in publish (the map stays tiny):
+  publish(files = {
+    "index.html": "<img src=shot.png>",
+    "shot.png":   "asset:9f86d081…"
+  })
+  ```
+
+  `POST /v1/assets` accepts a raw binary body (as above) or a multipart `file` field, and
+  stores the bytes content-addressed (identical bytes dedup to one blob; re-uploading is
+  free). Supported: PNG, JPEG, GIF, WebP (max 25 MB each; SVG is rejected). The asset is
+  served with the doc's own visibility once published — it is not a public URL on its own.
+
+  Mix and match: base64 for a tiny inline icon, `asset:` handles for the screenshots.
+
+---
+
 ## Reading back what you published
 
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once it reache
   and structured logging introduced. No behavior change.
 
 ### Added
+- Binary asset uploads for bundles: `POST /v1/assets` stores raw image bytes
+  content-addressed (dedup by hash) and returns an `asset:<hash>` handle; a `publish`
+  `files` value may now be that handle instead of an inline base64 data URI. An agent
+  streams a screenshot up as binary (no base64 transcription) and references the tiny
+  handle in the publish. PNG/JPEG/GIF/WebP, 25 MB each; served with the doc's visibility.
 - Repository hygiene: `ARCHITECTURE.md`, `CONTRIBUTING.md`, `SECURITY.md`,
   `CODE_OF_CONDUCT.md`, issue + PR templates, `.editorconfig`.
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -16,6 +16,7 @@ import { cliCallbackHTML } from "./oauth-cli-callback"
 import { consentHTML } from "./oauth-consent"
 import { agentRoutes } from "./routes/agents"
 import { analyticsRoutes } from "./routes/analytics"
+import { assetRoutes } from "./routes/assets"
 import { artifactRoutes } from "./routes/artifacts"
 import { collectionRoutes } from "./routes/collections"
 import { commentRoutes } from "./routes/comments"
@@ -448,6 +449,7 @@ export function createApp(deps: AppDeps): Hono {
     workspaceRoutes,
     agentRoutes,
     artifactRoutes,
+    assetRoutes,
     sharingRoutes,
     favoriteRoutes,
     followRoutes,

--- a/apps/api/src/lib/bundle.ts
+++ b/apps/api/src/lib/bundle.ts
@@ -15,6 +15,13 @@ export const cleanPath = (p: string): string => p.replace(/^\//, "")
 // carry parameters (;charset=…), so match through to the required `;base64,` marker.
 const DATA_URI_BASE64 = /^data:[\w.+-]*\/?[\w.+-]*(?:;[\w.+-]+=[\w.+-]+)*;base64,/i
 
+// An asset reference — `asset:<64-hex sha256>`. A binary asset uploaded ahead of time
+// to POST /v1/assets (which returns exactly this string) is referenced by its
+// content-hash instead of inlined as base64. Lets an agent carry real screenshots in a
+// bundle without transcribing multi-MB base64 into the publish call — the bytes were
+// already streamed up as raw binary; the map only carries the 71-char handle.
+const ASSET_REF = /^asset:([0-9a-f]{64})$/i
+
 const base64ToBytes = (b64: string): Uint8Array => {
   const bin = atob(b64.replace(/\s+/g, ""))
   const out = new Uint8Array(bin.length)
@@ -23,19 +30,40 @@ const base64ToBytes = (b64: string): Uint8Array => {
 }
 
 /**
- * Decode a {path: content} map to {path: bytes}: a value that is a base64 data: URI
- * (`data:image/png;base64,…`) becomes raw bytes, everything else is UTF-8 text — so
- * screenshots, fonts, and any binary asset that makes up a site ride the SAME map as
- * the HTML/CSS/JS pages, carried over MCP without inlining multi-MB base64 into one
- * HTML string. The served content-type comes from the path extension (mimeFor), so
+ * Decode a {path: content} map to {path: bytes}. A value is, in priority order:
+ *  - an `asset:<sha256>` reference (from POST /v1/assets) → the stored blob's bytes,
+ *  - a base64 data: URI (`data:image/png;base64,…`) → raw decoded bytes,
+ *  - anything else → UTF-8 text.
+ * So HTML/CSS/JS pages, base64-inlined assets, AND pre-uploaded binary assets all ride
+ * the SAME map. The served content-type comes from the path extension (mimeFor), so
  * binary entries must be named with a real extension (shot.png, logo.svg, font.woff2).
  *
- * Throws if a value looks like a base64 data: URI but isn't decodable.
+ * `blobs` is required to resolve `asset:` references (omit it only where the map is
+ * known to be inline-only). Throws on a bad base64 data: URI or an unknown asset.
  */
-export const decodeBundleFiles = (files: Record<string, string>): Record<string, Uint8Array> => {
+export const decodeBundleFiles = async (
+  files: Record<string, string>,
+  blobs?: BlobStore,
+): Promise<Record<string, Uint8Array>> => {
   const enc = new TextEncoder()
   const entries: Record<string, Uint8Array> = {}
   for (const [path, value] of Object.entries(files)) {
+    const asset = ASSET_REF.exec(value.trim())
+    if (asset?.[1]) {
+      if (!blobs)
+        throw new PublishError(
+          400,
+          `asset references are not supported in this context ("${path}")`,
+        )
+      const bytes = await blobs.get(asset[1].toLowerCase())
+      if (!bytes)
+        throw new PublishError(
+          400,
+          `unknown asset for "${path}" — upload it to /v1/assets and reference the returned handle`,
+        )
+      entries[path] = bytes
+      continue
+    }
     const marker = DATA_URI_BASE64.exec(value)
     if (!marker) {
       entries[path] = enc.encode(value)
@@ -53,9 +81,12 @@ export const decodeBundleFiles = (files: Record<string, string>): Record<string,
 /**
  * Pack a {path: content} map into a zip the core publish path ingests exactly like an
  * HTTP bundle upload (it re-validates size, file count, paths, and entry point).
+ * `blobs` resolves any `asset:` references in the map.
  */
-export const zipBundleFiles = (files: Record<string, string>): Uint8Array =>
-  zipSync(decodeBundleFiles(files))
+export const zipBundleFiles = async (
+  files: Record<string, string>,
+  blobs?: BlobStore,
+): Promise<Uint8Array> => zipSync(await decodeBundleFiles(files, blobs))
 
 /**
  * Build the zip for an INCREMENTAL bundle publish: every file already in the bundle
@@ -76,7 +107,7 @@ export const mergeBundleZip = async (
     const bytes = await blobs.get(entry.key)
     if (bytes) entries[cleanPath(path)] = bytes
   }
-  for (const [path, bytes] of Object.entries(decodeBundleFiles(newFiles))) {
+  for (const [path, bytes] of Object.entries(await decodeBundleFiles(newFiles, blobs))) {
     entries[cleanPath(path)] = bytes
   }
   return zipSync(entries)

--- a/apps/api/src/lib/image.ts
+++ b/apps/api/src/lib/image.ts
@@ -5,6 +5,11 @@
 
 export const MAX_AVATAR_BYTES = 2 * 1024 * 1024 // 2 MB
 
+// A standalone bundle asset (a screenshot, a diagram) can be much larger than an
+// avatar but is still bounded well under the 100MB raw-upload / 50MB unzipped-bundle
+// caps, so one asset can never fill a bundle on its own.
+export const MAX_ASSET_BYTES = 25 * 1024 * 1024 // 25 MB
+
 export type ImageType = "image/png" | "image/jpeg" | "image/gif" | "image/webp"
 
 /** Identify a supported raster image by its magic bytes, or null if unsupported. */

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -460,7 +460,7 @@ function buildServer(ctx: AppContext, agent: AgentRecord, ownerId: string | null
           .record(z.string(), z.string())
           .optional()
           .describe(
-            'A MULTI-PAGE bundle as a map of path → content — the whole site. Text pages are plain strings; binary assets (screenshots, images, fonts) are base64 data: URIs, e.g. {"index.html":"<img src=shot.png>","styles.css":"…","shot.png":"data:image/png;base64,iVBORw0K…","logo.svg":"…"}. The root index.html (else the shallowest .html) becomes the entry page; pages reference assets by relative path. Served content-type comes from the file extension, so give binary entries a real extension (.png/.jpg/.svg/.woff2). A plain republish REPLACES the bundle (include every page and asset). The map travels in one call, so keep each call to a few MB; for a large or image-heavy site, publish the pages first, then add assets in batches with `merge` (below).',
+            'A MULTI-PAGE bundle as a map of path → content — the whole site. Each value is one of: a text page (plain string); a base64 data: URI for a small inline binary ("shot.png":"data:image/png;base64,iVBORw0K…"); or — PREFERRED for real images — an "asset:<hash>" handle returned by uploading the raw bytes to POST /v1/assets first ("shot.png":"asset:9f86d0818…"). The asset handle keeps the call tiny: stream each screenshot up as raw binary (no base64 transcription), then reference the handles here. Example: {"index.html":"<img src=shot.png>","styles.css":"…","shot.png":"asset:9f86d0818…","logo.png":"data:image/png;base64,iVBORw0K…"}. The root index.html (else the shallowest .html) becomes the entry page; pages reference assets by relative path. Served content-type comes from the file extension, so give binary entries a real extension (.png/.jpg/.webp/.woff2). A plain republish REPLACES the bundle (include every page and asset). Keep each call to a few MB; for many/large images, upload them to /v1/assets and reference the handles (or publish pages first, then `merge` asset batches).',
           ),
         title: z
           .string()
@@ -616,7 +616,7 @@ function buildServer(ctx: AppContext, agent: AgentRecord, ownerId: string | null
           bytes = await mergeBundleZip(ctx.blobs, manifest, files as Record<string, string>)
           bundleSpa = manifest.spa
         } else {
-          bytes = zipBundleFiles(files as Record<string, string>)
+          bytes = await zipBundleFiles(files as Record<string, string>, ctx.blobs)
         }
         const { artifact, version } = await publishVersion(
           ctx.meta,

--- a/apps/api/src/routes/assets.ts
+++ b/apps/api/src/routes/assets.ts
@@ -1,0 +1,60 @@
+import { Hono } from "hono"
+import type { AppContext } from "../context"
+import { fail } from "../lib/http"
+import { MAX_ASSET_BYTES, sniffImageType } from "../lib/image"
+
+/**
+ * Standalone binary assets for bundles. An agent uploads the raw bytes of a
+ * screenshot here (a plain binary POST — no base64 transcription), gets back a
+ * content-addressed `asset:<hash>` handle, and references that handle in a `publish`
+ * `files` map (resolved by decodeBundleFiles). This is the images-without-base64 path:
+ * the transport that can't carry megabytes of binary in a JSON tool call streams them
+ * as bytes instead, and the tiny handle rides the publish.
+ *
+ * Bytes are stored content-addressed (identical bytes dedup to one blob) but not yet
+ * attached to any version — the storage quota only counts them once a publish
+ * references them, so an unused upload costs nothing.
+ */
+export const assetRoutes = (ctx: AppContext) => {
+  const { blobs, workspaceCan, activeWorkspace, overStorage } = ctx
+  const app = new Hono()
+
+  app.post("/v1/assets", async (c) => {
+    // Anyone who can publish to their workspace can stage an asset for it. (The
+    // anonymous write-lockdown already blocks unauthenticated POSTs.)
+    if (!(await workspaceCan(c, "publish"))) return fail(c, 403, "forbidden")
+
+    const declared = Number(c.req.header("content-length") ?? 0)
+    if (declared > MAX_ASSET_BYTES + 4096) return fail(c, 413, "asset too large (max 25MB)")
+
+    // Accept either a multipart `file` field (browsers, the CLI's FormData) or a raw
+    // binary body (curl --data-binary @shot.png), so an agent can stream bytes the
+    // simplest way it has.
+    const contentType = c.req.header("content-type") ?? ""
+    let bytes: Uint8Array
+    if (contentType.includes("multipart/form-data")) {
+      const file = (await c.req.parseBody()).file
+      if (!(file instanceof File)) return fail(c, 400, "multipart field 'file' required")
+      bytes = new Uint8Array(await file.arrayBuffer())
+    } else {
+      bytes = new Uint8Array(await c.req.arrayBuffer())
+    }
+
+    if (bytes.byteLength === 0) return fail(c, 400, "empty asset body")
+    if (bytes.byteLength > MAX_ASSET_BYTES) return fail(c, 413, "asset too large (max 25MB)")
+
+    // Trust the bytes, not the declared type — and only store a plain raster image (no
+    // SVG: served from our origin it could carry script), mirroring the avatar path.
+    const type = sniffImageType(bytes)
+    if (!type) return fail(c, 400, "unsupported asset (use PNG, JPEG, GIF, or WebP)")
+
+    const org = await activeWorkspace(c)
+    if (await overStorage(org, bytes.byteLength)) return fail(c, 413, "storage quota exceeded")
+
+    const key = await blobs.put(bytes)
+    // `ref` is the exact string to drop into a publish `files` value.
+    return c.json({ key, ref: `asset:${key}`, type, size: bytes.byteLength })
+  })
+
+  return app
+}

--- a/apps/api/test/assets.test.ts
+++ b/apps/api/test/assets.test.ts
@@ -1,0 +1,68 @@
+import { join } from "node:path"
+import { FsBlobStore } from "@derive/storage/fs"
+import { describe, expect, it } from "vitest"
+import { anonApp, app, dir } from "./helpers"
+
+// POST /v1/assets is the "images without base64" path: an agent streams the raw bytes
+// of a screenshot up as binary (no transcription), gets back a content-addressed
+// `asset:<hash>` handle, and references that handle in a `publish` files map — where
+// decodeBundleFiles resolves it back to these exact bytes (see bundle-assets.test.ts).
+
+// A real 1x1 transparent PNG.
+const PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+const PNG_BYTES = new Uint8Array(Buffer.from(PNG_B64, "base64"))
+
+const postAsset = (body: BodyInit, contentType?: string) =>
+  app.request("/v1/assets", {
+    method: "POST",
+    ...(contentType ? { headers: { "content-type": contentType } } : {}),
+    body,
+  })
+
+describe("POST /v1/assets", () => {
+  it("stores raw-binary image bytes and returns a content-addressed asset handle", async () => {
+    const res = await postAsset(PNG_BYTES, "image/png")
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.type).toBe("image/png")
+    expect(body.size).toBe(PNG_BYTES.byteLength)
+    expect(body.key).toMatch(/^[0-9a-f]{64}$/)
+    expect(body.ref).toBe(`asset:${body.key}`)
+
+    // The exact bytes are stored at that key, ready for a publish to reference.
+    const blobs = new FsBlobStore(join(dir, "blobs"))
+    const stored = await blobs.get(body.key)
+    expect(stored).toBeTruthy()
+    expect(new Uint8Array(stored as Uint8Array)).toEqual(PNG_BYTES)
+  })
+
+  it("accepts a multipart file field and dedups identical bytes to the same key", async () => {
+    const raw = await (await postAsset(PNG_BYTES, "image/png")).json()
+    const fd = new FormData()
+    fd.append("file", new Blob([PNG_BYTES as BlobPart], { type: "image/png" }), "shot.png")
+    const res = await postAsset(fd)
+    expect(res.status).toBe(200)
+    // Content-addressed: the same bytes hash to the same key regardless of transport.
+    expect((await res.json()).key).toBe(raw.key)
+  })
+
+  it("trusts the bytes, not the type — rejects a non-image with a 400", async () => {
+    const res = await postAsset(new TextEncoder().encode("<svg>not raster</svg>"), "image/png")
+    expect(res.status).toBe(400)
+  })
+
+  it("rejects an empty body", async () => {
+    const res = await postAsset(new Uint8Array(), "image/png")
+    expect(res.status).toBe(400)
+  })
+
+  it("is closed to anonymous callers (the write-lockdown)", async () => {
+    const res = await anonApp.request("/v1/assets", {
+      method: "POST",
+      headers: { "content-type": "image/png" },
+      body: PNG_BYTES,
+    })
+    expect(res.status).toBe(403)
+  })
+})

--- a/apps/api/test/bundle-assets.test.ts
+++ b/apps/api/test/bundle-assets.test.ts
@@ -25,12 +25,12 @@ const PNG_BYTES = new Uint8Array(Buffer.from(PNG_B64, "base64"))
 const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
 
 describe("zipBundleFiles carries binary assets, not just text", () => {
-  it("decodes a base64 data: URI to raw bytes and keeps text pages as UTF-8", () => {
+  it("decodes a base64 data: URI to raw bytes and keeps text pages as UTF-8", async () => {
     const files = {
       "index.html": "<h1>Réport</h1><img src=shot.png>", // non-ASCII to prove UTF-8 text
       "shot.png": `data:image/png;base64,${PNG_B64}`,
     }
-    const unzipped = unzipSync(zipBundleFiles(files))
+    const unzipped = unzipSync(await zipBundleFiles(files))
 
     // The image is intact binary — the actual PNG, not the UTF-8 bytes of the data
     // URI string (which is what the old text-only packer produced).
@@ -42,9 +42,38 @@ describe("zipBundleFiles carries binary assets, not just text", () => {
     expect(new TextDecoder().decode(unzipped["index.html"])).toBe(files["index.html"])
   })
 
-  it("throws an actionable error on a malformed base64 data: URI", () => {
-    expect(() => zipBundleFiles({ "x.png": "data:image/png;base64,@@not base64@@" })).toThrow(
-      /invalid base64 data URI for "x\.png"/,
+  it("throws an actionable error on a malformed base64 data: URI", async () => {
+    await expect(
+      zipBundleFiles({ "x.png": "data:image/png;base64,@@not base64@@" }),
+    ).rejects.toThrow(/invalid base64 data URI for "x\.png"/)
+  })
+})
+
+describe("an asset: reference resolves a pre-uploaded blob (images without base64)", () => {
+  it("pulls the stored bytes for asset:<hash>, keeping text pages as text", async () => {
+    const blobs = new FsBlobStore(join(dir, "ref-blobs"))
+    // Simulate POST /v1/assets having stored the screenshot already.
+    const key = await blobs.put(PNG_BYTES)
+    const files = {
+      "index.html": "<img src=shot.png>",
+      "shot.png": `asset:${key}`,
+    }
+    const unzipped = unzipSync(await zipBundleFiles(files, blobs))
+    expect(Array.from((unzipped["shot.png"] as Uint8Array).slice(0, 8))).toEqual(PNG_SIGNATURE)
+    expect(unzipped["shot.png"]).toEqual(PNG_BYTES)
+    expect(new TextDecoder().decode(unzipped["index.html"])).toBe("<img src=shot.png>")
+  })
+
+  it("rejects an unknown asset handle with an actionable 400", async () => {
+    const blobs = new FsBlobStore(join(dir, "ref-blobs2"))
+    await expect(zipBundleFiles({ "x.png": `asset:${"0".repeat(64)}` }, blobs)).rejects.toThrow(
+      /unknown asset for "x\.png"/,
+    )
+  })
+
+  it("rejects an asset reference when no blob store is available", async () => {
+    await expect(zipBundleFiles({ "x.png": `asset:${"a".repeat(64)}` })).rejects.toThrow(
+      /asset references are not supported/,
     )
   })
 })
@@ -59,7 +88,7 @@ describe("a binary bundle publishes and serves the asset with the right type", (
     }
 
     const { version } = await publish(meta, blobs, {
-      bytes: zipBundleFiles(files),
+      bytes: await zipBundleFiles(files),
       filename: "site.zip",
       isBundle: true,
       title: "Site",
@@ -91,7 +120,7 @@ describe("incremental merge grows a bundle without re-sending it", () => {
 
     // First publish: an index page + one screenshot.
     const first = await publish(meta, blobs, {
-      bytes: zipBundleFiles({
+      bytes: await zipBundleFiles({
         "index.html": "<img src=a.png>",
         "a.png": `data:image/png;base64,${PNG_B64}`,
       }),

--- a/apps/api/test/bundle-assets.test.ts
+++ b/apps/api/test/bundle-assets.test.ts
@@ -64,6 +64,34 @@ describe("an asset: reference resolves a pre-uploaded blob (images without base6
     expect(new TextDecoder().decode(unzipped["index.html"])).toBe("<img src=shot.png>")
   })
 
+  it("publishes a multi-file bundle referencing an asset handle end to end (the MCP path)", async () => {
+    // Exactly what MCP `publish` does for a bundle: build the zip from a {path: content}
+    // map via zipBundleFiles(files, blobs), then hand it to the core publish path.
+    const meta = new SqliteMetaStore(join(dir, "asset-pub.db"))
+    const blobs = new FsBlobStore(join(dir, "asset-pub-blobs"))
+    const key = await blobs.put(PNG_BYTES) // POST /v1/assets stored the screenshot
+    const { version } = await publish(meta, blobs, {
+      bytes: await zipBundleFiles(
+        { "index.html": "<!doctype html><img src=shot.png>", "shot.png": `asset:${key}` },
+        blobs,
+      ),
+      filename: "site.zip",
+      isBundle: true,
+      title: "Site",
+      author: "Tester",
+    })
+    const manifest = await manifestOf(blobs, version)
+    expect(manifest, "published as a bundle").not.toBeNull()
+    const png = manifest?.files["/shot.png"]
+    expect(png?.type).toBe("image/png") // served type from the .png extension
+    const stored = await blobs.get(png?.key as string)
+    expect(new Uint8Array(stored as Uint8Array)).toEqual(PNG_BYTES) // exact bytes, no base64
+    const entry = manifest?.files[manifest.entry]
+    const html = new TextDecoder().decode((await blobs.get(entry?.key as string)) as Uint8Array)
+    expect(html).toContain("<img src=shot.png>")
+    meta.close()
+  })
+
   it("rejects an unknown asset handle with an actionable 400", async () => {
     const blobs = new FsBlobStore(join(dir, "ref-blobs2"))
     await expect(zipBundleFiles({ "x.png": `asset:${"0".repeat(64)}` }, blobs)).rejects.toThrow(


### PR DESCRIPTION
## Problem

Publishing a bundle with real screenshots requires inlining each image as a base64 `data:` URI in the `publish` `files` map. Over the MCP transport that means an agent has to reproduce multi-MB of base64 verbatim inside one tool call — which it can't do reliably (a single wrong character corrupts the image). Today's only mitigation is splitting base64 across `merge` calls; it doesn't remove the transcription.

## Change

Add a bytes-first path, reusing the existing content-addressed blob store (`BlobStore.put` → sha256, automatic dedup) — no new storage concepts.

- **`POST /v1/assets`** — stream an image up as a raw binary body (`--data-binary @shot.png`) or a multipart `file` field, get back a content-addressed handle:
  ```json
  { "key": "9f86d081…", "ref": "asset:9f86d081…", "type": "image/png", "size": 20531 }
  ```
  Magic-byte sniff (PNG/JPEG/GIF/WebP; SVG rejected, mirroring `POST /v1/me/avatar`), 25 MB cap, workspace-quota checked, gated by `workspaceCan("publish")` under the anonymous write-lockdown.
- **`decodeBundleFiles`** now resolves an `asset:<hash>` value to the stored blob's bytes (alongside base64 data URIs and text). A publish references the tiny handle instead of re-sending the image:
  ```
  publish(files = { "index.html": "<img src=shot.png>", "shot.png": "asset:9f86d081…" })
  ```
  The image lands in the bundle and is served with the doc's own visibility (not a public URL on its own). Uploading is idempotent; an unreferenced upload isn't counted against quota until a publish uses it.

## Agent flow

1. `curl -X POST $DERIVE_URL/v1/assets -H "authorization: Bearer $TOKEN" -H "content-type: image/png" --data-binary @shot.png` → `asset:<hash>`
2. `publish` with the handle in `files`.

## Notes / scope

- The MCP `publish` tool description documents the handle form; `using/derive-publish.md` shows the two-step flow; CHANGELOG updated.
- `decodeBundleFiles` / `zipBundleFiles` became async (they resolve blobs) — the one src caller (`mcp.ts`) and the bundle tests are updated.
- No change to the stdio MCP server (still single-file only) or the CLI (already uploads whole bundles as multipart binary).

## Tests

Endpoint contract (raw-binary + multipart, hash dedup, non-image/empty/anonymous rejects) and decode resolution (resolves a stored blob, unknown → 400, no-blobs → 400), plus the existing base64 bundle tests carried onto the now-async helpers. **Full api suite green (613 tests)**, worker typecheck + biome lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)