### PR TITLE
Artifact workbench rebuild + connection-based presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ otherwise (or with `for_review:true`) it files a proposal a human approves. Full
 
 ## Embeds and unfurls
 
-Every share link (`/a/:ref`) unfurls as a rich card in Slack, Discord, X, and
+Every share link (`/artifacts/:ref`) unfurls as a rich card in Slack, Discord, X, and
 Notion, and can be dropped into any page. The server adds OG/Twitter meta to the
-artifact's `/a/:ref` HTML and exposes:
+artifact's `/artifacts/:ref` HTML and exposes:
 
 - `GET /v1/og/:ref` — the card image (1200×630 SVG; private artifacts get a
   no-leak locked card)

--- a/apps/api/src/bus.ts
+++ b/apps/api/src/bus.ts
@@ -50,22 +50,71 @@ export interface Viewer {
   role: string | null
 }
 
-/** Ephemeral presence per artifact: viewer id → {viewer, last-seen ms}. Lost on
- *  restart. Keyed by id so multiple tabs of one person collapse to a single row. */
+/** Ephemeral presence per artifact. A viewer is present while they hold ≥1 open SSE
+ *  stream — join on connect, leave the instant that stream closes, so a departure
+ *  (tab-close or crash) reflects in ~a second, not after the heartbeat TTL. The TTL
+ *  is the backstop for a STREAMLESS caller (a bare `POST /presence` with no `/events`
+ *  open, e.g. a test). Keyed by viewer id, so multiple tabs collapse to one row.
+ *  Lost on restart. */
 export class Presence {
-  private viewers = new Map<string, Map<string, { v: Viewer; t: number }>>()
+  private rooms = new Map<string, Map<string, { v: Viewer; t: number; streams: Set<string> }>>()
   constructor(private ttlMs = 45_000) {}
 
-  /** Records a heartbeat and returns the live viewers. */
-  heartbeat(artifactId: string, viewer: Viewer, now: number): Viewer[] {
-    let m = this.viewers.get(artifactId)
+  private room(artifactId: string) {
+    let m = this.rooms.get(artifactId)
     if (!m) {
       m = new Map()
-      this.viewers.set(artifactId, m)
+      this.rooms.set(artifactId, m)
     }
-    m.set(viewer.id, { v: viewer, t: now })
-    for (const [id, e] of m) if (now - e.t > this.ttlMs) m.delete(id)
+    return m
+  }
+  // A streamed viewer stays until their last stream closes; a streamless one ages
+  // out on the TTL. So a live SSE viewer is never pruned mid-session.
+  private list(
+    m: Map<string, { v: Viewer; t: number; streams: Set<string> }>,
+    now: number,
+  ): Viewer[] {
+    for (const [id, e] of m) if (e.streams.size === 0 && now - e.t > this.ttlMs) m.delete(id)
     return [...m.values()].map((e) => e.v)
+  }
+
+  /** A heartbeat keep-alive (and the streamless join path): upsert + refresh. */
+  heartbeat(artifactId: string, viewer: Viewer, now: number): Viewer[] {
+    const m = this.room(artifactId)
+    const e = m.get(viewer.id)
+    if (e) {
+      e.v = viewer
+      e.t = now
+    } else {
+      m.set(viewer.id, { v: viewer, t: now, streams: new Set() })
+    }
+    return this.list(m, now)
+  }
+
+  /** An SSE stream opened — present until it closes. */
+  join(artifactId: string, viewer: Viewer, streamKey: string, now: number): Viewer[] {
+    const m = this.room(artifactId)
+    const e = m.get(viewer.id)
+    if (e) {
+      e.v = viewer
+      e.t = now
+      e.streams.add(streamKey)
+    } else {
+      m.set(viewer.id, { v: viewer, t: now, streams: new Set([streamKey]) })
+    }
+    return this.list(m, now)
+  }
+
+  /** An SSE stream closed — drop the viewer once it was their last one. */
+  leave(artifactId: string, viewerId: string, streamKey: string, now: number): Viewer[] {
+    const m = this.rooms.get(artifactId)
+    if (!m) return []
+    const e = m.get(viewerId)
+    if (e) {
+      e.streams.delete(streamKey)
+      if (e.streams.size === 0) m.delete(viewerId)
+    }
+    return this.list(m, now)
   }
 }
 
@@ -73,6 +122,18 @@ export class Presence {
  *  resolves asynchronously, so callers await the result either way. */
 export interface PresenceStore {
   heartbeat(channel: string, viewer: Viewer, now: number): Viewer[] | Promise<Viewer[]>
+  join(
+    channel: string,
+    viewer: Viewer,
+    streamKey: string,
+    now: number,
+  ): Viewer[] | Promise<Viewer[]>
+  leave(
+    channel: string,
+    viewerId: string,
+    streamKey: string,
+    now: number,
+  ): Viewer[] | Promise<Viewer[]>
 }
 
 /**
@@ -87,7 +148,9 @@ export interface Backplane {
   publish(channel: string, e: DeriveEvent): void
   subscribe(channel: string, cb: (e: DeriveEvent) => void): () => void
   presence: PresenceStore
-  handleStream?(c: Context, channel: string): Response | Promise<Response> | null
+  // `viewer` is present only for the artifact `/events` stream (presence rides its
+  // lifecycle); the notification channel (`u:<id>`) has no presence and omits it.
+  handleStream?(c: Context, channel: string, viewer?: Viewer): Response | Promise<Response> | null
 }
 
 /** Default backplane: in-memory bus + presence, single process. The route owns

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -114,15 +114,15 @@ export interface AppDeps {
   serveWeb?: boolean
   /**
    * The SPA shell HTML (index.html), when this process serves the bundled web app.
-   * Lets the server-rendered `/a/:ref` route return the shell with per-artifact
+   * Lets the server-rendered `/artifacts/:ref` route return the shell with per-artifact
    * unfurl meta injected, so crawlers (which don't run JS) get OG/Twitter cards.
-   * Unset = no injection (API-only, or the edge Worker where assets serve `/a/*`).
+   * Unset = no injection (API-only, or the edge Worker where assets serve `/artifacts/*`).
    */
   shell?: string
   /**
    * Async shell provider for runtimes that can't read the SPA shell synchronously:
    * the edge Worker fetches `index.html` from its static-assets binding. Used to
-   * inject unfurl meta into `/a/:ref` when `shell` (the sync string) isn't set.
+   * inject unfurl meta into `/artifacts/:ref` when `shell` (the sync string) isn't set.
    * Returns null if the shell can't be read (the route then serves it untouched).
    */
   shellFetch?: () => Promise<string | null>

--- a/apps/api/src/github-app-setup.ts
+++ b/apps/api/src/github-app-setup.ts
@@ -145,6 +145,6 @@ export function setupResultHTML(props: { ok: boolean; slug?: string; error?: str
     `<span class="badge ok">Connected</span>`,
     `<h1>Your GitHub App is ready</h1>
     <p class="sub">${props.slug ? `<code>${esc(props.slug)}</code> ` : ""}is set up. Head back to Settings to install it on your repos.</p>
-    <p class="foot"><a class="btn" href="/settings?tab=github">Back to Settings</a></p>`,
+    <p class="foot"><a class="btn" href="/settings/github">Back to Settings</a></p>`,
   )
 }

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -74,7 +74,7 @@ export const commentDeepLink = (
   artifact: ArtifactRecord,
   threadId: string,
 ): string =>
-  `${baseUrl.replace(/\/$/, "")}/a/${artifact.short_id}?c=${encodeURIComponent(threadId)}`
+  `${baseUrl.replace(/\/$/, "")}/artifacts/${artifact.short_id}?comment=${encodeURIComponent(threadId)}`
 
 export interface CommentEmailInput {
   author: string

--- a/apps/api/src/lib/github-comments.ts
+++ b/apps/api/src/lib/github-comments.ts
@@ -220,7 +220,7 @@ const MARK = "via Derive"
 /** Render the comment body posted to GitHub: the Derive author + body + a deep link back,
  *  tagged so the inbound webhook can recognise our own posts as a backstop to `meta`. */
 const ghBody = (baseUrl: string, artifact: ArtifactRecord, cm: CommentRecord): string => {
-  const link = `${baseUrl.replace(/\/$/, "")}/a/${artifact.short_id}?c=${encodeURIComponent(cm.thread_id)}`
+  const link = `${baseUrl.replace(/\/$/, "")}/artifacts/${artifact.short_id}?comment=${encodeURIComponent(cm.thread_id)}`
   return `**${cm.author}** commented in [Derive](${link}):\n\n${cm.body_md}\n\n_— ${MARK}_`
 }
 

--- a/apps/api/src/lib/serve-web.ts
+++ b/apps/api/src/lib/serve-web.ts
@@ -4,7 +4,7 @@ import type { Hono } from "hono"
 /**
  * The single source of truth for which request paths the API/server owns. Every
  * other GET falls back to the SPA shell so the client router handles it (deep
- * links, refresh, /a/:ref, /settings, …).
+ * links, refresh, /artifacts/:ref, /settings, …).
  *
  * The same contract is declared in two other places that can't import a value —
  * the Cloudflare Worker (`wrangler.toml` `run_worker_first`) and the Vite dev
@@ -30,12 +30,12 @@ const API_EXACT = [
 ] as const
 
 // Page prefixes the SERVER renders before handing off to the SPA, but that are NOT
-// API paths: `/a/:ref` (per-artifact unfurl meta) and `/u/:handle` (per-profile unfurl
+// API paths: `/artifacts/:ref` (per-artifact unfurl meta) and `/users/:handle` (per-profile unfurl
 // meta) are served as the SPA shell with OpenGraph/Twitter meta injected for crawlers
 // (which don't run JS). The edge Worker must run first on these to inject; the dev proxy
 // and `isApiPath` deliberately ignore them (in dev the SPA owns the page, and an
 // unmatched one still falls back to the shell, never JSON).
-const SERVER_PAGE_PREFIXES = ["/a", "/u", "/settings/github"] as const
+const SERVER_PAGE_PREFIXES = ["/artifacts", "/users", "/settings/github"] as const
 
 /** Server-owned path tokens in declaration order (as the dev proxy lists them). */
 export const API_PATHS: readonly string[] = [...API_PREFIXES, ...API_EXACT]

--- a/apps/api/src/lib/slack-comments.ts
+++ b/apps/api/src/lib/slack-comments.ts
@@ -42,7 +42,7 @@ export const enqueueSlackComment = async (
   if (parseMeta(cm.meta).slack) return // came from Slack — don't echo back
   const install = await meta.getSlackInstall(artifact.org_id)
   if (!install?.default_channel) return
-  const link = `${baseUrl.replace(/\/$/, "")}/a/${artifact.short_id}?c=${encodeURIComponent(cm.thread_id)}`
+  const link = `${baseUrl.replace(/\/$/, "")}/artifacts/${artifact.short_id}?comment=${encodeURIComponent(cm.thread_id)}`
   const payload: SlackCommentPayload = {
     orgId: artifact.org_id,
     artifactId: artifact.id,

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -131,7 +131,7 @@ const blobs: BlobStore = cfg.objectStoreUrl
   ? s3FromUrl(cfg.objectStoreUrl)
   : new FsBlobStore(join(cfg.dataDir, "blobs"))
 
-// The SPA shell, read once: passed to createApp (so /a/:ref can inject unfurl
+// The SPA shell, read once: passed to createApp (so /artifacts/:ref can inject unfurl
 // meta) and to mountWeb (the client-router fallback). Only when serving the web.
 const shellHtml = cfg.serveWeb ? readFileSync(cfg.webShell, "utf8") : undefined
 

--- a/apps/api/src/realtime-do.ts
+++ b/apps/api/src/realtime-do.ts
@@ -24,34 +24,88 @@ const frame = (event: string, data: string) => enc.encode(`event: ${event}\ndata
  * Realtime room: one Durable Object per channel (an artifact id, or `u:<userId>`
  * for the notification bell). It owns the SSE connections for that channel and
  * broadcasts events to them, so fan-out works across Worker isolates — every
- * client for a channel reaches the same DO. Presence is tracked here too.
+ * client for a channel reaches the same DO.
  *
- * Plain SSE (not WebSocket) keeps the existing EventSource client unchanged; an
- * alarm pings open streams so intermediaries don't drop idle connections. This is
- * the connection-owning half of the Backplane port (see bus.ts).
+ * Presence is tied to those connections: a viewer is present while they hold ≥1 open
+ * `/events` stream. Connect registers them (identity rides a query param, derived
+ * server-side upstream); `cancel()` — which fires the instant the SSE client
+ * disconnects — drops them and re-broadcasts, so a tab-close or crash reflects in
+ * ~a second (the ping doubles as the crash detector). A bare `POST /heartbeat`
+ * (a streamless caller with no `/events` open) is the TTL-backstopped fallback.
  */
 export class ArtifactRoom {
   private streams = new Set<ReadableStreamDefaultController<Uint8Array>>()
-  private viewers = new Map<string, { v: Viewer; t: number }>()
+  // Each open stream's viewer id, so a closed stream drops the right viewer.
+  private streamViewer = new Map<ReadableStreamDefaultController<Uint8Array>, string>()
+  // Roster: viewer id → identity + open-stream count. Present while `n > 0`; a
+  // streamless heartbeat (n === 0) ages out on the TTL.
+  private viewers = new Map<string, { v: Viewer; t: number; n: number }>()
   constructor(private state: DurableObjectState) {}
+
+  private roster(now: number): Viewer[] {
+    for (const [id, e] of this.viewers)
+      if (e.n === 0 && now - e.t > PRESENCE_TTL_MS) this.viewers.delete(id)
+    return [...this.viewers.values()].map((e) => e.v)
+  }
+
+  private broadcastPresence(): void {
+    const f = frame(
+      "presence",
+      JSON.stringify({ type: "presence", viewers: this.roster(Date.now()) }),
+    )
+    for (const c of this.streams)
+      try {
+        c.enqueue(f)
+      } catch {
+        this.drop(c)
+      }
+  }
+
+  // Forget a closed/dead stream; if it was the viewer's last, drop them. Returns
+  // whether the roster changed (so the caller can decide to re-broadcast).
+  private drop(c: ReadableStreamDefaultController<Uint8Array>): boolean {
+    if (!this.streams.delete(c)) return false
+    const vid = this.streamViewer.get(c)
+    this.streamViewer.delete(c)
+    if (vid == null) return false
+    const e = this.viewers.get(vid)
+    if (e && --e.n <= 0) {
+      this.viewers.delete(vid)
+      return true
+    }
+    return false
+  }
 
   async fetch(req: Request): Promise<Response> {
     const url = new URL(req.url)
 
-    // SSE connect: hold an open stream for this client.
+    // SSE connect: hold an open stream, register the viewer, tell everyone.
     if (req.method === "GET") {
-      const streams = this.streams
+      const viewer = JSON.parse(url.searchParams.get("v") ?? "null") as Viewer | null
+      const room = this
       const storage = this.state.storage
       let ctrl: ReadableStreamDefaultController<Uint8Array>
       const body = new ReadableStream<Uint8Array>({
         start(c) {
           ctrl = c
-          streams.add(c)
+          room.streams.add(c)
           c.enqueue(frame("ready", "{}"))
-          if (streams.size === 1) void storage.setAlarm(Date.now() + PING_MS)
+          if (room.streams.size === 1) void storage.setAlarm(Date.now() + PING_MS)
+          if (viewer) {
+            room.streamViewer.set(c, viewer.id)
+            const e = room.viewers.get(viewer.id)
+            if (e) {
+              e.v = viewer
+              e.t = Date.now()
+              e.n++
+            } else {
+              room.viewers.set(viewer.id, { v: viewer, t: Date.now(), n: 1 })
+            }
+            room.broadcastPresence()
+          }
         },
         cancel() {
-          streams.delete(ctrl)
+          if (room.drop(ctrl)) room.broadcastPresence()
         },
       })
       return new Response(body, {
@@ -68,46 +122,55 @@ export class ArtifactRoom {
       const raw = await req.text()
       const ev = JSON.parse(raw) as DeriveEvent
       const f = frame(ev.type, raw)
-      for (const c of this.streams) {
+      for (const c of this.streams)
         try {
           c.enqueue(f)
         } catch {
-          this.streams.delete(c)
+          this.drop(c)
         }
-      }
       return new Response("ok")
     }
 
-    // Presence heartbeat: record + return the live viewers.
+    // Presence heartbeat (keep-alive / streamless join): upsert + return the roster.
     if (req.method === "POST" && url.pathname.endsWith("/heartbeat")) {
       const { viewer, now } = (await req.json()) as { viewer: Viewer; now: number }
-      this.viewers.set(viewer.id, { v: viewer, t: now })
-      for (const [id, e] of this.viewers) if (now - e.t > PRESENCE_TTL_MS) this.viewers.delete(id)
-      return Response.json([...this.viewers.values()].map((e) => e.v))
+      const e = this.viewers.get(viewer.id)
+      if (e) {
+        e.v = viewer
+        e.t = now
+      } else {
+        this.viewers.set(viewer.id, { v: viewer, t: now, n: 0 })
+      }
+      return Response.json(this.roster(now))
     }
 
     return new Response("not found", { status: 404 })
   }
 
-  // Keep-alive: ping open streams (SSE comment), reschedule while any remain.
+  // Keep-alive: ping open streams; a stream that's gone drops its viewer (the crash
+  // backstop, since a hard-killed client may never fire `cancel`). Reschedule while
+  // any remain.
   async alarm(): Promise<void> {
     const ping = enc.encode(": ping\n\n")
-    for (const c of this.streams) {
+    let changed = false
+    for (const c of this.streams)
       try {
         c.enqueue(ping)
       } catch {
-        this.streams.delete(c)
+        if (this.drop(c)) changed = true
       }
-    }
+    if (changed) this.broadcastPresence()
     if (this.streams.size > 0) await this.state.storage.setAlarm(Date.now() + PING_MS)
   }
 }
 
 /**
  * Durable Object backplane (the Workers adapter). Routes the SSE stream to the
- * per-channel DO, fans events out through it, and tracks presence in it. `subscribe`
- * is unused — the DO owns the streams, so `handleStream` returns the DO's Response
- * and the route never falls back to local SSE.
+ * per-channel DO, fans events out through it, and tracks presence in it via the
+ * stream lifecycle. `subscribe` is unused — the DO owns the streams, so `handleStream`
+ * returns the DO's Response and the route never falls back to local SSE. Presence
+ * `join`/`leave` are likewise handled inside the DO (connect/cancel), so the route
+ * never calls them here; only `heartbeat` (the streamless path) round-trips.
  *
  * The `as unknown as Response` casts reconcile the two Response types in scope here
  * (the Workers `DurableObjectStub.fetch` Response vs the ambient global one); the
@@ -123,6 +186,10 @@ export function createDoBackplane(rooms: DurableObjectNamespace): Backplane {
       })
       return (await res.json()) as Viewer[]
     },
+    // The DO drives join/leave off its own SSE connect/cancel, so these are never
+    // called for the DO path (the route only calls them when handleStream is absent).
+    join: () => [],
+    leave: () => [],
   }
   return {
     publish(channel, e) {
@@ -137,8 +204,10 @@ export function createDoBackplane(rooms: DurableObjectNamespace): Backplane {
       return () => {}
     },
     presence,
-    handleStream(_c: Context, channel: string) {
-      return stub(channel).fetch("https://do/sse", { method: "GET" }) as unknown as Response
+    handleStream(_c: Context, channel: string, viewer?: Viewer) {
+      // Only /events carries a viewer; the notification channel has no presence.
+      const q = viewer ? `?v=${encodeURIComponent(JSON.stringify(viewer))}` : ""
+      return stub(channel).fetch(`https://do/sse${q}`, { method: "GET" }) as unknown as Response
     },
   }
 }

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -61,7 +61,7 @@ export const artifactRoutes = (ctx: AppContext) => {
   const app = new Hono()
 
   // Newest-first, keyset-paginated (?cursor=<created_at>&limit=N), with optional
-  // server-side ?q= (title search), ?tag=, and ?favorite=true. Returns
+  // server-side ?query= (title search), ?tag=, and ?favorite=true. Returns
   // { artifacts, next_cursor }. tag/favorite resolve to an id set first.
   app.get("/v1/artifacts", async (c) => {
     const me = await currentUser(c)
@@ -78,7 +78,7 @@ export const artifactRoutes = (ctx: AppContext) => {
         : undefined
     // Cap the search term: it goes into a SQL LIKE, and an oversized value tripped
     // an unhandled DB error (a long-q 500). No real title search needs > 200 chars.
-    const q = c.req.query("q")?.trim().slice(0, 200) || undefined
+    const q = c.req.query("query")?.trim().slice(0, 200) || undefined
     const tag = c.req.query("tag")?.trim() || undefined
     const collectionId = c.req.query("collection")?.trim() || undefined
     const favOnly = c.req.query("favorite") === "true"
@@ -145,7 +145,7 @@ export const artifactRoutes = (ctx: AppContext) => {
 
     // A listing only shows non-public artifacts to a MEMBER of that workspace (or the
     // operator token). Anyone else — anonymous, or a signed-in user who isn't a member
-    // — sees public artifacts only, so org/link titles never leak via the list or ?q=.
+    // — sees public artifacts only, so org/link titles never leak via the list or ?query=.
     // For a collection, collection access (member/creator/share) also unlocks it.
     const publicOnly = collectionId
       ? !collectionAccess
@@ -418,7 +418,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     if (artifact.removed_at)
       return c.json({
         short_id: artifact.short_id,
-        url: `${deps.baseUrl.replace(/\/$/, "")}/a/${artifact.short_id}`,
+        url: `${deps.baseUrl.replace(/\/$/, "")}/artifacts/${artifact.short_id}`,
         title: null,
         kind: artifact.kind,
         visibility: artifact.visibility,

--- a/apps/api/src/routes/embeds.ts
+++ b/apps/api/src/routes/embeds.ts
@@ -23,16 +23,16 @@ import type { AppContext } from "../context"
 import { fail } from "../lib/http"
 
 /**
- * Unfurl + embed surface. Turns a `/a/:ref` share link into a rich card and an
+ * Unfurl + embed surface. Turns a `/artifacts/:ref` share link into a rich card and an
  * embeddable iframe, so a Derive link looks good in Slack / Discord / X / Notion and
  * can be dropped into any page. Three public, anonymous-readable endpoints under
- * `/v1` (worker-first in both runtimes) plus a server-rendered `/a/:ref` that
+ * `/v1` (worker-first in both runtimes) plus a server-rendered `/artifacts/:ref` that
  * injects OG/Twitter meta into the SPA shell for crawlers (which don't run JS):
  *
  *   GET /v1/og/:ref        the OG card image (SVG, 1200x630)
  *   GET /v1/oembed?url=…   the oEmbed document (rich; a sandboxed iframe)
  *   GET /v1/embed/:ref     the embeddable view (iframe target)
- *   GET /a/:ref            the SPA shell with per-artifact unfurl meta injected
+ *   GET /artifacts/:ref            the SPA shell with per-artifact unfurl meta injected
  *
  * Visibility is honored against the *request* actor: a crawler is anonymous, so
  * org/password artifacts never leak a title — they get a generic locked card.
@@ -51,7 +51,7 @@ export const embedRoutes = (ctx: AppContext) => {
       meta.listComments(artifact.id),
       meta.getVersion(artifact.id, artifact.current_version),
     ])
-    const ref = artifactUrl(baseUrl, artifact).slice(`${baseUrl}/a/`.length)
+    const ref = artifactUrl(baseUrl, artifact).slice(`${baseUrl}/artifacts/`.length)
     return {
       title: artifact.title ?? "Untitled",
       kindLabel: kindLabel(version?.content_type, artifact.kind === "bundle"),
@@ -125,7 +125,7 @@ export const embedRoutes = (ctx: AppContext) => {
 
   // The profile OG card image (SVG, 1200x630). Anonymous-readable; a missing handle gets
   // a generic Derive card (still 200 so the unfurl shows something). Cached hard.
-  app.get("/v1/og/u/:handle", async (c) => {
+  app.get("/v1/og/users/:handle", async (c) => {
     const card = await profileCardFor(c.req.param("handle"))
     const svg = ogProfileCardSvg(
       card ?? {
@@ -153,7 +153,7 @@ export const embedRoutes = (ctx: AppContext) => {
     let ref: string
     try {
       const path = new URL(url).pathname
-      const m = path.match(/^\/a\/([^/]+)$/)
+      const m = path.match(/^\/artifacts\/([^/]+)$/)
       if (!m?.[1]) return fail(c, 404, "not an artifact url")
       ref = decodeURIComponent(m[1])
     } catch {
@@ -192,7 +192,7 @@ export const embedRoutes = (ctx: AppContext) => {
   const getShell = async (): Promise<string | null> =>
     ctx.deps.shell ?? (ctx.deps.shellFetch ? await ctx.deps.shellFetch() : null)
   if (ctx.deps.shell || ctx.deps.shellFetch)
-    app.get("/a/:ref", async (c) => {
+    app.get("/artifacts/:ref", async (c) => {
       const shell = await getShell()
       if (!shell) return c.notFound()
       const ref = c.req.param("ref")
@@ -201,20 +201,21 @@ export const embedRoutes = (ctx: AppContext) => {
       // injects NO unfurl meta, so the removed title doesn't live on for crawlers.
       if (!artifact || artifact.removed_at) return c.html(shell)
       // Canonicalise any non-canonical ref (bare id, stale name, legacy order) to
-      // /a/<name>-<shortId> so the browser/crawler holds the readable URL. 302 (not 301)
+      // /artifacts/<name>-<shortId> so the browser/crawler holds the readable URL. 302 (not 301)
       // so a later rename re-canonicalises instead of being cached. Only ever for an
       // artifact the actor may read (readable() already authorised), so a gated title
       // can't leak via the redirect. Preserves the @vN suffix and the query string.
       const { version } = parseRef(ref)
       const canonical = version ? `${refFor(artifact)}@v${version}` : refFor(artifact)
-      if (ref !== canonical) return c.redirect(`/a/${canonical}${new URL(c.req.url).search}`, 302)
+      if (ref !== canonical)
+        return c.redirect(`/artifacts/${canonical}${new URL(c.req.url).search}`, 302)
       return c.html(injectHead(shell, unfurlMetaTags(await infoFor(artifact))))
     })
   // Server-rendered profile URL: the SPA shell with profile OG/Twitter meta injected for
   // crawlers (which don't run JS). Humans get the SPA as usual (the meta is inert). Only
   // public profile fields go into the head; an unclaimed handle serves the bare shell.
   if (ctx.deps.shell || ctx.deps.shellFetch)
-    app.get("/u/:handle", async (c) => {
+    app.get("/users/:handle", async (c) => {
       const shell = await getShell()
       if (!shell) return c.notFound()
       const card = await profileCardFor(c.req.param("handle"))
@@ -226,15 +227,15 @@ export const embedRoutes = (ctx: AppContext) => {
             username: card.username,
             name: card.name,
             description: profileSummary(card),
-            pageUrl: `${baseUrl}/u/${card.username}`,
-            imageUrl: `${baseUrl}/v1/og/u/${card.username}`,
+            pageUrl: `${baseUrl}/users/${card.username}`,
+            imageUrl: `${baseUrl}/v1/og/users/${card.username}`,
           }),
         ),
       )
     })
-  // A copy-pasted share link with a trailing slash ("/a/slug-id/") would otherwise
+  // A copy-pasted share link with a trailing slash ("/artifacts/slug-id/") would otherwise
   // 404; canonicalize it to the no-slash form.
-  app.get("/a/:ref/", (c) => c.redirect(`/a/${c.req.param("ref")}`, 301))
+  app.get("/artifacts/:ref/", (c) => c.redirect(`/artifacts/${c.req.param("ref")}`, 301))
 
   return app
 }

--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -1,5 +1,5 @@
 import { effectiveRole } from "@derive/core"
-import { Hono } from "hono"
+import { type Context, Hono } from "hono"
 import { streamSSE } from "hono/streaming"
 import { z } from "zod"
 import type { Viewer } from "../bus"
@@ -21,19 +21,53 @@ export const realtimeRoutes = (ctx: AppContext) => {
   } = ctx
   const app = new Hono()
 
+  // Server-derived presence identity (never client-supplied): a signed-in user by
+  // their public @handle, an anonymous viewer by a stable friendly handle keyed to
+  // their viewer cookie (no PII, no impersonation). `role` is their effective role on
+  // this artifact, so name/role can't be forged either. Shared by the SSE-lifecycle
+  // presence (join/leave) and the heartbeat backstop.
+  const deriveViewer = async (
+    c: Context,
+    artifact: Parameters<typeof actorFor>[1],
+  ): Promise<Viewer> => {
+    const me = await currentUser(c)
+    const role = effectiveRole(await actorFor(c, artifact), artifact.visibility)
+    return me
+      ? { id: me.id, name: me.username ?? "someone", role }
+      : { id: anonViewerId(c), name: anonName(anonViewerId(c)), role }
+  }
+  // Per-connection key so a viewer's multiple tabs ref-count correctly on the
+  // in-process backplane (the DO keys presence on the stream object itself).
+  let streamSeq = 0
+
   app.get("/v1/artifacts/:shortId/events", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact || !(await authorize(c, "read", artifact))) return c.text("not found", 404)
-    // A Durable Object backplane owns the stream itself (edge); relay adapters
-    // (in-process, Redis) return null and we hold the SSE here.
-    const direct = backplane.handleStream?.(c, artifact.id)
+    const viewer = await deriveViewer(c, artifact)
+    // A Durable Object backplane owns the stream itself (edge) AND tracks presence off
+    // its connect/disconnect lifecycle; relay adapters (in-process, Redis) return null,
+    // so we hold the SSE here and drive presence around it.
+    const direct = backplane.handleStream?.(c, artifact.id, viewer)
     if (direct) return direct
     c.header("Access-Control-Allow-Origin", "*")
+    const streamKey = `s${++streamSeq}`
     return streamSSE(c, async (stream) => {
       const unsub = bus.subscribe(artifact.id, (e) => {
         void stream.writeSSE({ event: e.type, data: JSON.stringify(e) })
       })
-      stream.onAbort(unsub)
+      // Present for as long as this stream stays open; leave the moment it aborts —
+      // so a tab-close reflects for everyone in ~a second, not after the TTL.
+      bus.publish(artifact.id, {
+        type: "presence",
+        viewers: await presence.join(artifact.id, viewer, streamKey, Date.now()),
+      })
+      stream.onAbort(async () => {
+        unsub()
+        bus.publish(artifact.id, {
+          type: "presence",
+          viewers: await presence.leave(artifact.id, viewer.id, streamKey, Date.now()),
+        })
+      })
       await stream.writeSSE({
         event: "ready",
         data: JSON.stringify({ short_id: artifact.short_id }),
@@ -45,23 +79,14 @@ export const realtimeRoutes = (ctx: AppContext) => {
     })
   })
 
+  // Presence heartbeat — the TTL-backstopped keep-alive. Most viewers are tracked by
+  // their live /events stream (join/leave above); this keeps a streamless caller (or a
+  // viewer between reconnects) on the roster, and stays anon-allowed — the one write an
+  // anonymous viewer may do beyond reading (lockdown in app.ts).
   app.post("/v1/artifacts/:shortId/presence", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact || !(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
-    // Presence identity is built entirely server-side, never client-supplied: a
-    // signed-in user by their account (name + email), an anonymous viewer by a
-    // stable, friendly handle (`helpful-kitty-95`) keyed to their viewer cookie and
-    // no email, so nobody can impersonate or spam names. `role` is their effective
-    // role on this artifact (so email/role can't be forged either). Presence is the
-    // only thing an anonymous caller may do beyond reading (lockdown in app.ts).
-    const me = await currentUser(c)
-    const role = effectiveRole(await actorFor(c, artifact), artifact.visibility)
-    const viewer: Viewer = me
-      ? // Handle-based identity, never PII: presence reaches anonymous co-viewers and
-        // rides the wildcard-CORS /events SSE. Always the public @handle (every account
-        // has one post-migration); never any part of the email, even the local-part.
-        { id: me.id, name: me.username ?? "someone", role }
-      : { id: anonViewerId(c), name: anonName(anonViewerId(c)), role }
+    const viewer = await deriveViewer(c, artifact)
     const viewers = await presence.heartbeat(artifact.id, viewer, Date.now())
     bus.publish(artifact.id, { type: "presence", viewers })
     return c.json({ viewers })

--- a/apps/api/src/routes/session.ts
+++ b/apps/api/src/routes/session.ts
@@ -90,7 +90,7 @@ export const sessionRoutes = (ctx: AppContext) => {
   // Registered before /v1/users/:handle so "search" isn't read as a handle.
   app.get("/v1/users/search", async (c) => {
     if (!(await currentUser(c))) return fail(c, 401, "unauthenticated")
-    const q = (c.req.query("q") ?? "").trim()
+    const q = (c.req.query("query") ?? "").trim()
     if (!q) return c.json({ users: [] })
     const found = await meta.searchDiscoverableUsers(q, 20)
     return c.json({
@@ -104,13 +104,13 @@ export const sessionRoutes = (ctx: AppContext) => {
   })
 
   // The People directory — browse opted-in (discoverable) people to find someone to
-  // follow, the home the search backend never got. With `?q=` it searches; without, it
+  // follow, the home the search backend never got. With `?query=` it searches; without, it
   // BROWSES (the deliberate difference from /v1/users/search, which never enumerates).
   // Discoverable is opt-in, so browsing only surfaces people who chose to be found.
   // Signed-in only; public fields only (handle/name/avatar/role) — never email.
   app.get("/v1/people", async (c) => {
     if (!(await currentUser(c))) return fail(c, 401, "unauthenticated")
-    const q = (c.req.query("q") ?? "").trim()
+    const q = (c.req.query("query") ?? "").trim()
     const found = q
       ? await meta.searchDiscoverableUsers(q, 60)
       : await meta.listDiscoverableUsers(60)
@@ -265,7 +265,7 @@ export const sessionRoutes = (ctx: AppContext) => {
 
   // Directory for the @mention picker — people AND agents, so an agent can be
   // @mentioned like anyone. Authenticated callers only (a signed-in user or the
-  // static token); an anonymous visitor can never enumerate anyone. Optional ?q=
+  // static token); an anonymous visitor can never enumerate anyone. Optional ?query=
   // filters by name/email prefix.
   //
   // Scope: with ?artifact=<shortId> (and read access to it) the directory is the
@@ -277,7 +277,7 @@ export const sessionRoutes = (ctx: AppContext) => {
     const me = await currentUser(c)
     const isToken = safeEqual(bearer(c), deps.token)
     if (!me && !isToken) return fail(c, 401, "unauthenticated")
-    const q = (c.req.query("q") ?? "").trim().toLowerCase()
+    const q = (c.req.query("query") ?? "").trim().toLowerCase()
 
     const shortId = c.req.query("artifact")
     const found = shortId ? await meta.getByShortId(shortId) : null

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -57,10 +57,11 @@ export const slackRoutes = (ctx: AppContext) => {
         default_channel: null,
         created_at: new Date().toISOString(),
       } satisfies SlackInstallRecord)
-      return c.redirect("/settings?tab=slack")
+      // Slack lives under the Integrations section (there is no standalone Slack page).
+      return c.redirect("/settings/integrations")
     } catch (err) {
       log.warn("slack oauth failed", { error: err instanceof Error ? err.message : String(err) })
-      return c.redirect("/settings?tab=slack&error=oauth")
+      return c.redirect("/settings/integrations?error=oauth")
     }
   })
 

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -478,7 +478,7 @@ export const syncRoutes = (ctx: AppContext) => {
   app.get("/v1/sync/github/callback", async (c) => {
     const installationId = c.req.query("installation_id")
     const stateRaw = c.req.query("state") ?? ""
-    const settingsUrl = new URL("/settings?tab=github", deps.baseUrl)
+    const settingsUrl = new URL("/settings/github", deps.baseUrl)
     if (!deps.encryptionKey || !installationId) {
       settingsUrl.searchParams.set("gh_error", "install_failed")
       return c.redirect(settingsUrl.toString())

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -87,7 +87,11 @@ export const webhookRoutes = (ctx: AppContext) => {
     const sample = JSON.stringify({
       event: "version.published",
       at: new Date().toISOString(),
-      artifact: { short_id: "sample00", title: "Test artifact", url: `${deps.baseUrl}/a/sample00` },
+      artifact: {
+        short_id: "sample00",
+        title: "Test artifact",
+        url: `${deps.baseUrl}/artifacts/sample00`,
+      },
       data: { version: 1, message: "test delivery from Derive", author: "derive" },
     })
     await meta.enqueueDelivery({

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -83,7 +83,7 @@ export interface Env {
   RL_COMMENT: RateLimit
   RL_STRICT: RateLimit
   // The static-assets binding: lets the Worker read the SPA shell to inject unfurl
-  // meta into /a/:ref (the share URL). Declared in wrangler.toml `[assets] binding`.
+  // meta into /artifacts/:ref (the share URL). Declared in wrangler.toml `[assets] binding`.
   ASSETS: Fetcher
   BASE_URL?: string
   DERIVE_AUTH_SECRET?: string
@@ -121,7 +121,7 @@ function pokeSync(env: Env, sourceId: string): Promise<unknown> {
 
 let app: ReturnType<typeof createApp> | null = null
 // The SPA shell, fetched from ASSETS once per isolate and reused (it's immutable for
-// a deployment). Injected with per-artifact unfurl meta on each /a/:ref request.
+// a deployment). Injected with per-artifact unfurl meta on each /artifacts/:ref request.
 let shellCache: string | null = null
 
 // The request handler behind both tiers. Split from `fetch` so the pg tier can
@@ -214,14 +214,14 @@ const handle = (req: Request, env: Env, ctx: ExecutionContext): Response | Promi
           if (c) c.waitUntil(p)
           else void p
         },
-        // Read the SPA shell from static assets so /a/:ref can carry unfurl meta.
+        // Read the SPA shell from static assets so /artifacts/:ref can carry unfurl meta.
         // Cached per isolate; null on any miss leaves the shell untouched.
         shellFetch: async () => {
           if (shellCache !== null) return shellCache
           try {
             // Fetch "/" (the canonical shell URL), NOT "/index.html": Static Assets
             // 307-redirects /index.html -> /, so a non-2xx would null the shell and
-            // drop unfurl/OG injection on /a/:ref (crawlers/social cards get no meta).
+            // drop unfurl/OG injection on /artifacts/:ref (crawlers/social cards get no meta).
             const res = await env.ASSETS.fetch(new URL("/", baseUrl).toString())
             shellCache = res.ok ? await res.text() : null
           } catch {

--- a/apps/api/test/agents.test.ts
+++ b/apps/api/test/agents.test.ts
@@ -47,7 +47,7 @@ describe("agents: @mention → pull inbox → propose → ack", () => {
   })
 
   it("the agent shows up in the @mention directory", async () => {
-    const dir = await (await app.request("/v1/users?q=clau", { headers: as(owner.email) })).json()
+    const dir = await (await app.request("/v1/users?query=clau", { headers: as(owner.email) })).json()
     expect(dir.users).toContainEqual(
       expect.objectContaining({ id: agentId, name: "Claude", kind: "agent" }),
     )

--- a/apps/api/test/artifacts.test.ts
+++ b/apps/api/test/artifacts.test.ts
@@ -129,13 +129,13 @@ describe("publish html file", () => {
     expect(res.status).toBe(201)
     const json = await res.json()
     shortId = json.short_id
-    expect(json.url).toBe(`http://derive.test/a/q1-review-${shortId}`)
+    expect(json.url).toBe(`http://derive.test/artifacts/q1-review-${shortId}`)
     expect(json.kind).toBe("file")
     expect(json.current_version).toBe(1)
   })
 
   it("serves artifact metadata and sandboxed raw content", async () => {
-    // The viewer at /a/:ref is the SPA (client-rendered); the server exposes the
+    // The viewer at /artifacts/:ref is the SPA (client-rendered); the server exposes the
     // artifact's metadata over the data API and the bytes over the sandboxed /raw.
     const detail = await app.request(`/v1/artifacts/${shortId}`)
     expect(detail.status).toBe(200)
@@ -308,7 +308,7 @@ describe("server-side search + cursor pagination", () => {
   it("searches by title server-side, case-insensitive", async () => {
     await upload("s1.md", "x", { title: "Quarterly ZZUNIQUE Report" })
     await upload("s2.md", "x", { title: "Totally unrelated" })
-    const r = await (await app.request("/v1/artifacts?q=zzunique")).json()
+    const r = await (await app.request("/v1/artifacts?query=zzunique")).json()
     const titles = r.artifacts.map((a: { title: string | null }) => a.title)
     expect(titles).toContain("Quarterly ZZUNIQUE Report")
     expect(titles.every((t: string | null) => /zzunique/i.test(t ?? ""))).toBe(true)
@@ -316,12 +316,12 @@ describe("server-side search + cursor pagination", () => {
 
   it("paginates newest-first with a keyset cursor (no overlap)", async () => {
     for (const n of ["A", "B", "C"]) await upload(`pg${n}.md`, "x", { title: `PGSEED ${n}` })
-    const p1 = await (await app.request("/v1/artifacts?q=PGSEED&limit=2")).json()
+    const p1 = await (await app.request("/v1/artifacts?query=PGSEED&limit=2")).json()
     expect(p1.artifacts).toHaveLength(2)
     expect(typeof p1.next_cursor).toBe("string")
     const p2 = await (
       await app.request(
-        `/v1/artifacts?q=PGSEED&limit=2&cursor=${encodeURIComponent(p1.next_cursor)}`,
+        `/v1/artifacts?query=PGSEED&limit=2&cursor=${encodeURIComponent(p1.next_cursor)}`,
       )
     ).json()
     expect(p2.artifacts).toHaveLength(1)

--- a/apps/api/test/comments.test.ts
+++ b/apps/api/test/comments.test.ts
@@ -178,7 +178,7 @@ describe("@mentions + in-app notifications", () => {
   const { app, meta: m } = makeAuthedApp("mentions", [alice, bob], "editor")
   let shortId: string
 
-  it("lists provisioned workspace members in the mention directory, filtered by ?q=", async () => {
+  it("lists provisioned workspace members in the mention directory, filtered by ?query=", async () => {
     shortId = (await (await publishAs(app, "<h1>doc</h1>", {}, as(alice.email))).json()).short_id
     await app.request("/v1/me", { headers: as(bob.email) }) // provisions bob as a member
     const all = await (await app.request("/v1/users", { headers: as(alice.email) })).json()
@@ -187,11 +187,11 @@ describe("@mentions + in-app notifications", () => {
     expect(ids).toContain(bob.id)
 
     const filtered = await (
-      await app.request("/v1/users?q=bob", { headers: as(alice.email) })
+      await app.request("/v1/users?query=bob", { headers: as(alice.email) })
     ).json()
     expect(filtered.users).toHaveLength(1)
     // The directory identifies people by handle + name, never email (you can still
-    // FIND someone by their address via ?q=, but it is never returned).
+    // FIND someone by their address via ?query=, but it is never returned).
     expect(filtered.users[0]).toMatchObject({ id: bob.id, name: "Bob" })
     expect(filtered.users[0].email).toBeUndefined()
   })

--- a/apps/api/test/cross-doc.test.ts
+++ b/apps/api/test/cross-doc.test.ts
@@ -72,8 +72,8 @@ describe("cross-document links between synced sibling artifacts", () => {
 
     const body = await (await app.request("/raw/cdprod1/v/1/index.html")).text()
 
-    // The sibling link → its canonical /a/<slug>-<short_id> URL + the interception marker.
-    expect(body).toContain('href="/a/ct-walkthrough-cdwalk1"')
+    // The sibling link → its canonical /artifacts/<slug>-<short_id> URL + the interception marker.
+    expect(body).toContain('href="/artifacts/ct-walkthrough-cdwalk1"')
     expect(body).toContain('data-derive-nav="ct-walkthrough-cdwalk1"')
     // A link with no sibling, an external link, and an in-page anchor are left as-is.
     expect(body).toContain('href="missing.html"')

--- a/apps/api/test/email.test.ts
+++ b/apps/api/test/email.test.ts
@@ -15,10 +15,10 @@ describe("email content", () => {
     })
     expect(subject).toBe("Ann commented on Roadmap")
     const link = commentDeepLink("https://derive.to", artifact, "t_123")
-    expect(link).toBe("https://derive.to/a/spec0001?c=t_123")
+    expect(link).toBe("https://derive.to/artifacts/spec0001?comment=t_123")
     expect(html).toContain(link)
     expect(html).toContain("the second milestone")
-    expect(text).toContain("View in Derive: https://derive.to/a/spec0001?c=t_123")
+    expect(text).toContain("View in Derive: https://derive.to/artifacts/spec0001?comment=t_123")
   })
 
   it("uses mention phrasing when the email is for a mention", () => {

--- a/apps/api/test/embeds.test.ts
+++ b/apps/api/test/embeds.test.ts
@@ -25,7 +25,7 @@ describe("unfurl + embed", () => {
   it("oembed returns a rich response with a sandboxed iframe", async () => {
     const short = await idOf(await upload("o.md", "# Hi", { visibility: "public", title: "Deck" }))
     const res = await app.request(
-      `/v1/oembed?url=${encodeURIComponent(`http://derive.test/a/${short}`)}`,
+      `/v1/oembed?url=${encodeURIComponent(`http://derive.test/artifacts/${short}`)}`,
     )
     expect(res.status).toBe(200)
     const body = await res.json()
@@ -53,7 +53,7 @@ describe("unfurl + embed", () => {
       await upload("priv.md", "# secret", { visibility: "org", title: "Secret" }),
     )
     const res = await anonApp.request(
-      `/v1/oembed?url=${encodeURIComponent(`http://derive.test/a/${short}`)}`,
+      `/v1/oembed?url=${encodeURIComponent(`http://derive.test/artifacts/${short}`)}`,
     )
     expect(res.status).toBe(404)
   })
@@ -83,7 +83,7 @@ describe("unfurl + embed", () => {
     expect(svg).toContain("private")
   })
 
-  it("injects unfurl meta into the /a/:ref shell for a public artifact", async () => {
+  it("injects unfurl meta into the /artifacts/:ref shell for a public artifact", async () => {
     const a = createApp({
       meta,
       blobs: new FsBlobStore(join(dir, "blobs-embed-shell")),
@@ -95,7 +95,9 @@ describe("unfurl + embed", () => {
       await upload("s.md", "# Hi", { visibility: "public", title: "Shared Page" }),
     )
     // A bare ref 302s to the canonical name-first URL; the unfurl meta lives there.
-    const bare = await a.request(`/a/${short}`, { headers: { authorization: "Bearer tok" } })
+    const bare = await a.request(`/artifacts/${short}`, {
+      headers: { authorization: "Bearer tok" },
+    })
     expect(bare.status).toBe(302)
     const res = await a.request(bare.headers.get("location") ?? "", {
       headers: { authorization: "Bearer tok" },
@@ -122,7 +124,9 @@ describe("unfurl + embed", () => {
       await upload("sf.md", "# Hi", { visibility: "public", title: "Worker Page" }),
     )
     // A bare ref 302s to the canonical name-first URL; the unfurl meta lives there.
-    const bare = await a.request(`/a/${short}`, { headers: { authorization: "Bearer tok" } })
+    const bare = await a.request(`/artifacts/${short}`, {
+      headers: { authorization: "Bearer tok" },
+    })
     expect(bare.status).toBe(302)
     const res = await a.request(bare.headers.get("location") ?? "", {
       headers: { authorization: "Bearer tok" },
@@ -144,14 +148,14 @@ describe("unfurl + embed", () => {
     const short = await idOf(
       await upload("s2.md", "# secret", { visibility: "org", title: "Private Page" }),
     )
-    const res = await a.request(`/a/${short}`) // anonymous (no token header)
+    const res = await a.request(`/artifacts/${short}`) // anonymous (no token header)
     const html = await res.text()
     expect(html).not.toContain("og:title")
     expect(html).not.toContain("Private Page")
   })
 })
 
-describe("profile unfurl (/u/:handle)", () => {
+describe("profile unfurl (/users/:handle)", () => {
   const nia: TestUser = {
     id: "u_og_nia",
     email: "ognia@d.test",
@@ -185,7 +189,7 @@ describe("profile unfurl (/u/:handle)", () => {
 
   it("renders the profile OG card SVG (name + work count)", async () => {
     await seedWork()
-    const res = await authed.request("/v1/og/u/niao")
+    const res = await authed.request("/v1/og/users/niao")
     expect(res.status).toBe(200)
     expect(res.headers.get("content-type")).toContain("image/svg+xml")
     const svg = await res.text()
@@ -195,7 +199,7 @@ describe("profile unfurl (/u/:handle)", () => {
     expect(svg).toContain("1 work")
   })
 
-  it("injects profile OG meta into the /u/:handle shell for crawlers", async () => {
+  it("injects profile OG meta into the /users/:handle shell for crawlers", async () => {
     const a = createApp({
       meta: m,
       blobs: new FsBlobStore(join(dir, "blobs-og-profile-shell")),
@@ -205,17 +209,17 @@ describe("profile unfurl (/u/:handle)", () => {
       shell: SHELL,
       defaultOrgId: "default",
     })
-    const res = await a.request("/u/niao")
+    const res = await a.request("/users/niao")
     expect(res.status).toBe(200)
     const html = await res.text()
     expect(html).toContain('property="og:type" content="profile"')
     expect(html).toContain("Nia Okoye (@niao)")
-    expect(html).toContain("/v1/og/u/niao")
+    expect(html).toContain("/v1/og/users/niao")
     expect(html).toContain("id=root") // still the SPA shell for humans
   })
 
   it("serves a generic card + bare shell for an unclaimed handle (no leak)", async () => {
-    const svg = await (await app.request("/v1/og/u/ghosthandle")).text()
+    const svg = await (await app.request("/v1/og/users/ghosthandle")).text()
     expect(svg).toContain("<svg")
     const a = createApp({
       meta,
@@ -224,7 +228,7 @@ describe("profile unfurl (/u/:handle)", () => {
       token: "tok",
       shell: SHELL,
     })
-    const html = await (await a.request("/u/ghosthandle")).text()
+    const html = await (await a.request("/users/ghosthandle")).text()
     expect(html).not.toContain("og:type")
     expect(html).toContain("id=root")
   })

--- a/apps/api/test/harden.test.ts
+++ b/apps/api/test/harden.test.ts
@@ -24,9 +24,9 @@ describe("read-path exposure hardening", () => {
     expect(mem.artifacts.map((a: { title: string }) => a.title)).toContain("OrgSecret")
   })
 
-  it("B-015: an oversized ?q= is capped, not a 500", async () => {
+  it("B-015: an oversized ?query= is capped, not a 500", async () => {
     const { app } = makeAuthedApp("harden-q", [owner])
-    const res = await app.request(`/v1/artifacts?q=${"a".repeat(5000)}`, {
+    const res = await app.request(`/v1/artifacts?query=${"a".repeat(5000)}`, {
       headers: as(owner.email),
     })
     expect(res.status).toBe(200)

--- a/apps/api/test/profiles.test.ts
+++ b/apps/api/test/profiles.test.ts
@@ -360,7 +360,7 @@ describe("discoverability (on by default) + people search", () => {
   const { app } = makeAuthedApp("discover", [nova, dox])
   const handles = (r: { users: { username: string }[] }) => r.users.map((u) => u.username)
   const search = async (q: string, by?: string) =>
-    (await app.request(`/v1/users/search?q=${q}`, by ? { headers: as(by) } : {})).json()
+    (await app.request(`/v1/users/search?query=${q}`, by ? { headers: as(by) } : {})).json()
 
   it("finds default-on users (never email), hides opt-outs; needs a query + auth", async () => {
     // Nova is findable without ever opting in; the opted-out Dox never appears.
@@ -370,7 +370,7 @@ describe("discoverability (on by default) + people search", () => {
     expect(handles(await search("dox", nova.email))).toHaveLength(0)
     // Empty query returns nothing (no full enumeration); anonymous is refused.
     expect(handles(await search("", nova.email))).toHaveLength(0)
-    expect((await app.request("/v1/users/search?q=nov")).status).toBe(401)
+    expect((await app.request("/v1/users/search?query=nov")).status).toBe(401)
   })
 
   it("opting back in makes you findable; opting out hides you", async () => {
@@ -409,7 +409,7 @@ describe("people directory (/v1/people)", () => {
     expect(browse.users[0]).not.toHaveProperty("email") // public fields only
 
     // With a query it searches within the discoverable set.
-    const searched = await (await app.request("/v1/people?q=iv", { headers: as(ivy.email) })).json()
+    const searched = await (await app.request("/v1/people?query=iv", { headers: as(ivy.email) })).json()
     expect(handles(searched)).toEqual(["ivy"])
 
     // Signed-in only — anonymous is refused.

--- a/apps/api/test/security.test.ts
+++ b/apps/api/test/security.test.ts
@@ -39,7 +39,7 @@ describe("security: sandbox serving origin (A4)", () => {
   it("the sandbox host exposes ONLY raw bytes — never the API, auth, or the app", async () => {
     expect((await app.request("http://sandbox.test/v1/artifacts")).status).toBe(404)
     expect((await app.request("http://sandbox.test/api/auth/get-session")).status).toBe(404)
-    expect((await app.request(`http://sandbox.test/a/${shortId}`)).status).toBe(404)
+    expect((await app.request(`http://sandbox.test/artifacts/${shortId}`)).status).toBe(404)
     // Health stays reachable on the sandbox host (for its own monitoring).
     expect((await app.request("http://sandbox.test/healthz")).status).toBe(200)
   })

--- a/apps/api/test/serve-web.test.ts
+++ b/apps/api/test/serve-web.test.ts
@@ -30,14 +30,14 @@ describe("serve-web: SPA vs API path contract", () => {
       "/.well-known/oauth-protected-resource",
     ])
       expect(isApiPath(p)).toBe(true)
-    for (const p of ["/", "/a/abc123", "/login", "/settings/agents", "/library"])
+    for (const p of ["/", "/artifacts/abc123", "/login", "/settings/agents", "/library"])
       expect(isApiPath(p)).toBe(false)
   })
 
   it("falls back to the SPA shell for non-API GETs, JSON 404 for unknown API paths", async () => {
     const app = makeApp("SHELL_MARKER")
     expect((await app.request("/v1/ping")).status).toBe(200) // a real API route still wins
-    for (const p of ["/", "/a/xyz", "/settings/agents"]) {
+    for (const p of ["/", "/artifacts/xyz", "/settings/agents"]) {
       const r = await app.request(p)
       expect(r.status).toBe(200)
       expect(await r.text()).toContain("SHELL_MARKER") // deep client links → shell

--- a/apps/api/test/sync-app.test.ts
+++ b/apps/api/test/sync-app.test.ts
@@ -131,7 +131,7 @@ describe("github app install callback", () => {
     )
     expect(res.status).toBe(302)
     const loc = res.headers.get("location") ?? ""
-    expect(loc).toContain("/settings?tab=github")
+    expect(loc).toContain("/settings/github")
     expect(loc).toContain("gh_install=991")
     expect(await meta.getGithubInstallation("991")).toMatchObject({ org_id: "default" })
   })

--- a/apps/api/test/vitals.test.ts
+++ b/apps/api/test/vitals.test.ts
@@ -8,7 +8,7 @@ describe("POST /v1/vitals", () => {
   it("accepts a beacon from an anonymous visitor (204, no body)", async () => {
     const r = await anonApp.request(
       "/v1/vitals",
-      json({ name: "LCP", value: 1234.5, rating: "good", id: "v1-abc", path: "/a/xyz" }),
+      json({ name: "LCP", value: 1234.5, rating: "good", id: "v1-abc", path: "/artifacts/xyz" }),
     )
     expect(r.status).toBe(204)
     expect(await r.text()).toBe("")

--- a/apps/api/test/webhook-adapter.test.ts
+++ b/apps/api/test/webhook-adapter.test.ts
@@ -37,7 +37,7 @@ const makeDelivery = (over: Partial<DeliveryRecord> = {}): DeliveryRecord => ({
   payload: JSON.stringify({
     event: "version.published",
     at: "2026-01-01T00:00:00Z",
-    artifact: { short_id: "sample00", title: "Spec", url: "http://h/a/sample00" },
+    artifact: { short_id: "sample00", title: "Spec", url: "http://h/artifacts/sample00" },
     data: { version: 1 },
   }),
   status: "pending",

--- a/apps/api/test/webhooks.test.ts
+++ b/apps/api/test/webhooks.test.ts
@@ -29,7 +29,7 @@ describe("webhook formatting + signing", () => {
     expect(p.artifact).toEqual({
       short_id: "sample00",
       title: "Spec",
-      url: "http://h/a/spec-sample00",
+      url: "http://h/artifacts/spec-sample00",
     })
     expect(p.data.author).toBe("ann")
   })

--- a/apps/api/test/workspace-scoping.test.ts
+++ b/apps/api/test/workspace-scoping.test.ts
@@ -55,8 +55,8 @@ describe("workspace scoping: collections + favorites", () => {
     // for a collection in another workspace (not in the active sidebar list).
     expect(body.collection).toMatchObject({ id: colId, title: "B Collection" })
 
-    // in-collection search (?q=) works the same way.
-    const res2 = await app.request(`/v1/artifacts?collection=${colId}&q=Doc%20in%20B`, {
+    // in-collection search (?query=) works the same way.
+    const res2 = await app.request(`/v1/artifacts?collection=${colId}&query=Doc%20in%20B`, {
       headers: as(owner.email),
     })
     expect((await res2.json()).artifacts.map((a: { short_id: string }) => a.short_id)).toContain(

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -123,11 +123,11 @@ namespace_id = "1005"
 crons = ["* * * * *"]
 
 # The web SPA (apps/web) ships from this same Worker via Static Assets, so the whole
-# app — login, library, settings, the /a/:ref artifact viewer — lives same-origin with
+# app — login, library, settings, the /artifacts/:ref artifact viewer — lives same-origin with
 # the API (no CORS, first-party cookies). Prepare the build first:
 # `pnpm --filter @derive/api build:web` (builds apps/web and preps dist/client for Workers:
 # _shell.html -> index.html, drops the Pages _redirects).
-# The API/data paths run the Worker first; so do /a/* and /u/* — the share + profile
+# The API/data paths run the Worker first; so do /artifacts/* and /users/* — the share + profile
 # URLs, where the Worker serves the SPA shell with per-artifact / per-profile OG/unfurl
 # meta injected for crawlers (it reads the shell via the ASSETS binding). Every other
 # path serves a static asset,
@@ -136,7 +136,7 @@ crons = ["* * * * *"]
 [assets]
 directory = "../web/dist/client"
 binding = "ASSETS"
-run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/oauth/*", "/settings/github/*", "/a/*", "/u/*", "/healthz", "/mcp", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource", "/.well-known/openid-configuration"]
+run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/oauth/*", "/settings/github/*", "/artifacts/*", "/users/*", "/healthz", "/mcp", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource", "/.well-known/openid-configuration"]
 not_found_handling = "single-page-application"
 
 # Public hosts: the derive.to apex is canonical, app.derive.to an alias. Cloudflare

--- a/apps/web/e2e/deep/comments-mobile.deep.spec.ts
+++ b/apps/web/e2e/deep/comments-mobile.deep.spec.ts
@@ -14,7 +14,7 @@ test("tap a paragraph to comment: bar + composer, anchored to the block", async 
     "m.md",
     "# Mobile\n\nFirst paragraph, short.\n\nSecond paragraph here with enough text to anchor a comment onto cleanly on a phone.",
   )
-  await page.goto(`/a/${shortId}`)
+  await page.goto(`/artifacts/${shortId}`)
   // Let the sandbox iframe load + the anchor client wire up.
   await page.waitForTimeout(2000)
 
@@ -49,7 +49,7 @@ test("the bottom bar dismisses without commenting", async ({ page }) => {
     "m.md",
     "# Doc\n\nA paragraph to tap and then dismiss.",
   )
-  await page.goto(`/a/${shortId}`)
+  await page.goto(`/artifacts/${shortId}`)
   await page.waitForTimeout(2000)
 
   await page.frameLocator("iframe").getByText("A paragraph to tap").tap()
@@ -61,7 +61,7 @@ test("the bottom bar dismisses without commenting", async ({ page }) => {
 test("collapse the full list to a peek bar, and reopen", async ({ page }) => {
   await signUp(page)
   const shortId = await publishArtifact(page, "m.md", "# Doc\n\nA paragraph to comment on here.")
-  await page.goto(`/a/${shortId}`)
+  await page.goto(`/artifacts/${shortId}`)
   await page.waitForTimeout(2000)
 
   // Post a comment; the sheet opens to the full list so the new comment shows.
@@ -76,7 +76,7 @@ test("collapse the full list to a peek bar, and reopen", async ({ page }) => {
   await page.getByTestId("comments-sheet-backdrop").tap({ position: { x: 180, y: 36 } })
   await expect(page.getByText("First note.")).toHaveCount(0)
   await expect(page.getByText("Comments", { exact: true })).toBeVisible()
-  await expect(page.getByTestId("comments-sheet-resize")).toHaveAttribute("title", "Expand")
+  await expect(page.getByTestId("comments-sheet-resize")).toHaveAttribute("aria-label", "Expand")
 
   // Tap the peek bar's expand control -> the full list returns.
   await page.getByTestId("comments-sheet-resize").tap()

--- a/apps/web/e2e/deep/deck-comments.deep.spec.ts
+++ b/apps/web/e2e/deep/deck-comments.deep.spec.ts
@@ -97,7 +97,7 @@ test.describe("deck comments — slide-scoped anchoring", () => {
     const dup = await anchorComment(owner, shortId, "dup-on-slide-2", "Shared phrase alpha", 2)
     const s1 = await anchorComment(owner, shortId, "on-slide-1", "Roadmap for the year", 1)
 
-    await owner.goto(`/a/${shortId}`)
+    await owner.goto(`/artifacts/${shortId}`)
     await expect(owner.getByTestId("deck-position")).toHaveText("1 / 5")
 
     // The crux: the duplicate-text comment resolves to slide 2 → "Slide 3", NOT the
@@ -128,7 +128,7 @@ test.describe("deck comments — slide-scoped anchoring", () => {
     // Out-of-range slide index → global fallback still finds the text (slide 4).
     const oob = await anchorComment(owner, shortId, "oob-comment", "Appendix with extra", 99)
 
-    await owner.goto(`/a/${shortId}`)
+    await owner.goto(`/artifacts/${shortId}`)
 
     await expect(owner.getByTestId(`comment-slide-${moved}`)).toHaveText("Slide 4")
     await expect(owner.getByTestId(`comment-moved-${moved}`)).toBeVisible()
@@ -143,7 +143,7 @@ test.describe("deck comments — slide-scoped anchoring", () => {
     )
     await anchorComment(owner, shortId, "jump-target", "Third slide outro", 2)
 
-    await owner.goto(`/a/${shortId}`)
+    await owner.goto(`/artifacts/${shortId}`)
     await expect(owner.getByTestId("deck-position")).toHaveText("1 / 3")
     // Activating the card flips the deck to the comment's slide (goto).
     await owner.getByText("jump-target").first().click()
@@ -155,7 +155,7 @@ test.describe("deck comments — slide-scoped anchoring", () => {
     const shortId = await publishDeck(owner, deckHtml(v1))
     const id = await anchorComment(owner, shortId, "follows-text", "Beta roadmap unique line", 1)
 
-    await owner.goto(`/a/${shortId}`)
+    await owner.goto(`/artifacts/${shortId}`)
     await expect(owner.getByTestId(`comment-slide-${id}`)).toHaveText("Slide 2")
     await expect(owner.getByTestId(`comment-moved-${id}`)).toHaveCount(0)
 
@@ -182,7 +182,7 @@ window.addEventListener('message',function(e){var d=e.data;if(!d||d.source!=='de
 if(d.action==='next')show(i+1);else if(d.action==='prev')show(i-1);else if(d.action==='goto')show(d.n)});show(0);r()})();</script></body></html>`
     const shortId = await publishDeck(owner, html)
     const id = await anchorComment(owner, shortId, "doc-order", "Two beta unique", 1)
-    await owner.goto(`/a/${shortId}`)
+    await owner.goto(`/artifacts/${shortId}`)
     await expect(owner.getByTestId(`comment-slide-${id}`)).toHaveText("Slide 2")
   })
 })

--- a/apps/web/e2e/deep/pr-previews.deep.spec.ts
+++ b/apps/web/e2e/deep/pr-previews.deep.spec.ts
@@ -59,7 +59,7 @@ test("PR previews render in the GitHub settings tab", async ({ owner }) => {
     await route.fulfill({ json: SYNC_PAYLOAD })
   })
 
-  await owner.goto("/settings?tab=github")
+  await owner.goto("/settings/github")
 
   await expect(owner.getByText("Pull request previews")).toBeVisible()
   // Both previews render. The title drops the "PR #<n>:" prefix the API adds; the

--- a/apps/web/e2e/deep/presence-popover.deep.spec.ts
+++ b/apps/web/e2e/deep/presence-popover.deep.spec.ts
@@ -31,7 +31,7 @@ test("the presence stack opens a popover listing each viewer by handle and role"
   await openArtifact(owner, id)
 
   // A second account opens the same artifact → they join presence (heartbeat).
-  await secondUser.page.goto(`/a/${id}`)
+  await secondUser.page.goto(`/artifacts/${id}`)
   await expect(secondUser.page.getByText("Comments", { exact: true })).toBeVisible()
 
   // The second user's server-assigned public handle — the identity presence shows.

--- a/apps/web/e2e/deep/review.deep.spec.ts
+++ b/apps/web/e2e/deep/review.deep.spec.ts
@@ -13,7 +13,7 @@ test("owner reviews proposals: toggles views, approves one, requests changes on 
   await proposeEdit(secondUser.page.request, id, "Tighten the intro", "# Doc\n\ntighter intro")
   await proposeEdit(secondUser.page.request, id, "Fix the footer", "# Doc\n\nbody\n\nfixed footer")
 
-  await owner.goto(`/a/${id}`)
+  await owner.goto(`/artifacts/${id}`)
   // Review lives in the artifact's "⋯ More" menu while proposals are open.
   await owner.getByTestId("artifact-more").click()
   await owner.getByTestId("artifact-review").click()

--- a/apps/web/e2e/deep/share.deep.spec.ts
+++ b/apps/web/e2e/deep/share.deep.spec.ts
@@ -9,11 +9,11 @@ test("owner shares an artifact, changes the role, and removes the member", async
   const id = await publishArtifact(owner) // owner publishes (link visibility)
 
   // The non-owner (second user) opens the artifact: no share affordance.
-  await secondUser.page.goto(`/a/${id}`)
+  await secondUser.page.goto(`/artifacts/${id}`)
   await expect(secondUser.page.getByTestId("share-trigger")).toBeHidden()
 
   // The owner opens the dialog: starts empty.
-  await owner.goto(`/a/${id}`)
+  await owner.goto(`/artifacts/${id}`)
   await owner.getByTestId("share-trigger").click()
   await expect(owner.getByTestId("share-email")).toBeVisible()
   await expect(owner.getByTestId("share-empty")).toBeVisible()

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -61,7 +61,7 @@ export async function publishArtifact(
 // Open an artifact's page and wait for the comment panel to be ready — the
 // deterministic "artifact view is interactive" gate every comment test needs.
 export async function openArtifact(page: Page, shortId: string): Promise<void> {
-  await page.goto(`/a/${shortId}`)
+  await page.goto(`/artifacts/${shortId}`)
   await expect(page.getByText("Comments", { exact: true })).toBeVisible()
 }
 

--- a/apps/web/e2e/screens/dashboard.screens.ts
+++ b/apps/web/e2e/screens/dashboard.screens.ts
@@ -263,7 +263,7 @@ test("capture the dashboard across themes and viewports", async ({ page: p }) =>
     await shot(`favorites-${theme}-desktop`)
 
     // An artifact page (open the metrics dashboard — visual render)
-    await p.goto(`/a/${ids[2]}`)
+    await p.goto(`/artifacts/${ids[2]}`)
     await settle(p)
     await shot(`artifact-${theme}-desktop`)
 

--- a/apps/web/e2e/screens/extra.screens.ts
+++ b/apps/web/e2e/screens/extra.screens.ts
@@ -82,7 +82,7 @@ test("capture the remaining surfaces", async ({ page: p }) => {
   const id = ((await res.json()) as { short_id: string }).short_id
 
   // Artifact with an open comment thread.
-  await p.goto(`/a/${id}`)
+  await p.goto(`/artifacts/${id}`)
   await settle(p)
   await p.getByTestId("comment-new").click()
   await p.getByTestId("composer-input").fill("First pass looks good — one note on the intro.")

--- a/apps/web/e2e/smoke/profile.smoke.spec.ts
+++ b/apps/web/e2e/smoke/profile.smoke.spec.ts
@@ -24,7 +24,7 @@ test("follow a person → their public work shows on the profile and in the foll
   const shortId = ((await published.json()) as { short_id: string }).short_id
 
   // Bob visits Maya's profile (he's in a different workspace) — her public work is listed.
-  await bob.goto(`/u/${maya.username}`)
+  await bob.goto(`/users/${maya.username}`)
   await expect(bob.getByTestId("profile-card")).toBeVisible()
   await expect(bob.getByTestId(`profile-work-${shortId}`)).toBeVisible()
 
@@ -37,11 +37,11 @@ test("follow a person → their public work shows on the profile and in the foll
 
   // Her public work now appears in Bob's Following feed — even though it lives in Maya's
   // workspace, not Bob's (the cross-workspace people-follow path).
-  await bob.goto("/?scope=following")
+  await bob.goto("/following")
   await expect(bob.getByTestId(`artifact-card-open-${shortId}`)).toBeVisible()
 
   // The follow persists across a reload (it's server state, not just local).
-  await bob.goto(`/u/${maya.username}`)
+  await bob.goto(`/users/${maya.username}`)
   await expect(bob.getByTestId(`follow-${maya.username}`)).toHaveAttribute("aria-pressed", "true")
 })
 
@@ -64,7 +64,7 @@ test("follow a person from the command-palette people search", async ({ owner, s
   await expect(followBtn).toHaveAttribute("aria-pressed", "true")
 
   // And the follow really landed: it shows on the person's profile.
-  await bob.goto(`/u/${maya.username}`)
+  await bob.goto(`/users/${maya.username}`)
   await expect(bob.getByTestId(`follow-${maya.username}`)).toHaveAttribute("aria-pressed", "true")
 })
 
@@ -85,14 +85,14 @@ test("browse + follow from the People directory", async ({ owner, secondUser }) 
   await expect(followBtn).toHaveAttribute("aria-pressed", "true") // optimistic flip
 
   // The follow really landed — it shows on the person's profile.
-  await bob.goto(`/u/${maya.username}`)
+  await bob.goto(`/users/${maya.username}`)
   await expect(bob.getByTestId(`follow-${maya.username}`)).toHaveAttribute("aria-pressed", "true")
 })
 
 // A person can't follow themselves: the Follow button never renders on your own profile.
 test("the Follow button is absent on your own profile", async ({ owner }) => {
   const me = (await (await owner.request.get("/v1/me")).json()).user as { username: string }
-  await owner.goto(`/u/${me.username}`)
+  await owner.goto(`/users/${me.username}`)
   await expect(owner.getByTestId("profile-card")).toBeVisible()
   await expect(owner.getByTestId(`follow-${me.username}`)).toHaveCount(0)
   // …but you can edit your own handle from there.

--- a/apps/web/e2e/smoke/review.smoke.spec.ts
+++ b/apps/web/e2e/smoke/review.smoke.spec.ts
@@ -8,7 +8,7 @@ test("owner approves a proposed change", async ({ owner, secondUser }) => {
   await shareArtifact(owner.request, shortId, secondUser.email, "commenter")
   await proposeEdit(secondUser.page.request, shortId, "Tighten the intro", "# Doc\n\ntighter intro")
 
-  await owner.goto(`/a/${shortId}`)
+  await owner.goto(`/artifacts/${shortId}`)
   await owner.getByTestId("artifact-more").click()
   await owner.getByTestId("artifact-review").click()
   await expect(owner.getByTestId("review-title")).toBeVisible()

--- a/apps/web/e2e/smoke/share.smoke.spec.ts
+++ b/apps/web/e2e/smoke/share.smoke.spec.ts
@@ -3,7 +3,7 @@ import { expect, publishArtifact, test } from "../fixtures"
 // Owner shares an artifact with a teammate; the member row lands in the dialog.
 test("owner shares an artifact and the member appears", async ({ owner, secondUser }) => {
   const shortId = await publishArtifact(owner)
-  await owner.goto(`/a/${shortId}`)
+  await owner.goto(`/artifacts/${shortId}`)
 
   await owner.getByTestId("share-trigger").click()
   await expect(owner.getByTestId("share-empty")).toBeVisible()

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -21,11 +21,11 @@ export interface PublicProfile {
   image: string | null
   /** Coarse team role; null if unset. (People-search results omit `about`.) */
   profession?: string | null
-  /** One-line "what you do" blurb; only present on the full /u/:handle profile. */
+  /** One-line "what you do" blurb; only present on the full /users/:handle profile. */
   about?: string | null
-  /** GitHub login, when known (the full /u/:handle profile only); null otherwise. */
+  /** GitHub login, when known (the full /users/:handle profile only); null otherwise. */
   github_login?: string | null
-  /** Work / follower / following counts (the full /u/:handle profile only). */
+  /** Work / follower / following counts (the full /users/:handle profile only). */
   stats?: { works: number; followers: number; following: number }
   /** Whether the signed-in viewer already follows this person (full profile only). */
   followed_by_me?: boolean
@@ -560,11 +560,11 @@ export const api = {
     f("/v1/me/discoverable", opts({ discoverable })).then(j),
   // Find opted-in people by @handle or name (signed-in; empty q → []).
   searchPeople: (q: string): Promise<{ users: PublicProfile[] }> =>
-    f(`/v1/users/search?q=${encodeURIComponent(q)}`, opts()).then(j),
+    f(`/v1/users/search?query=${encodeURIComponent(q)}`, opts()).then(j),
   // The People directory: browse opted-in people (empty q) or search them (signed-in).
   // Unlike searchPeople, an empty query BROWSES the discoverable set.
   people: (q?: string): Promise<{ users: PublicProfile[] }> =>
-    f(`/v1/people${q ? `?q=${encodeURIComponent(q)}` : ""}`, opts()).then(j),
+    f(`/v1/people${q ? `?query=${encodeURIComponent(q)}` : ""}`, opts()).then(j),
   // Upload a profile picture (raster image; server validates + stores it and sets
   // user.image to the served URL). Returns the new image URL.
   uploadAvatar: (file: File): Promise<{ image: string }> => {
@@ -614,7 +614,7 @@ export const api = {
     collection?: { id: string; title: string }
   }> => {
     const qs = new URLSearchParams()
-    if (params?.q) qs.set("q", params.q)
+    if (params?.q) qs.set("query", params.q)
     if (params?.tag) qs.set("tag", params.tag)
     if (params?.collection) qs.set("collection", params.collection)
     if (params?.favorite) qs.set("favorite", "true")
@@ -929,7 +929,7 @@ export const api = {
   // @ someone on the thread even if they're not in your workspace.
   users: (q?: string, artifact?: string): Promise<{ users: DirUser[] }> => {
     const p = new URLSearchParams()
-    if (q) p.set("q", q)
+    if (q) p.set("query", q)
     if (artifact) p.set("artifact", artifact)
     const qs = p.toString()
     return f(`/v1/users${qs ? `?${qs}` : ""}`, opts()).then(j)

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -60,11 +60,15 @@ export function AppShell({ children }: { children: ReactNode }) {
   const [collections, setCollections] = useState<Collection[]>([])
   const [workspaces, setWorkspaces] = useState<Workspaces | null>(null)
 
-  // Public pages render for anonymous visitors too: artifact pages (/a/:ref,
-  // read-only with a sign-up CTA — the viral path) and profiles (/u/:handle,
+  // Public pages render for anonymous visitors too: artifact pages (/artifacts/:ref,
+  // read-only with a sign-up CTA — the viral path) and profiles (/users/:handle,
   // GitHub-style shareable). Every other route requires a session.
   const pathname = useRouterState({ select: (s) => s.location.pathname })
-  const publicView = pathname.startsWith("/a/") || pathname.startsWith("/u/")
+  const publicView = pathname.startsWith("/artifacts/") || pathname.startsWith("/users/")
+  // An anonymous visitor on a shared artifact gets the chrome-light PublicViewer
+  // (its own slim public header) — drop the app nav rail entirely so the render is
+  // the whole page (the viral view; research: the render is the hero).
+  const bareArtifact = !me && pathname.startsWith("/artifacts/")
 
   // Auth gate: bounce to /login on auth-only routes once we know there's no session.
   useEffect(() => {
@@ -74,7 +78,7 @@ export function AppShell({ children }: { children: ReactNode }) {
   // First-run onboarding gate: a signed-in user who hasn't set a role yet (and
   // hasn't finished/skipped onboarding) gets the dedicated /welcome step. A role
   // being set, or the onboarded flag, clears it — so it shows once after signup,
-  // never loops. Public views (/a, /u) are left alone.
+  // never loops. Public views (/artifacts, /users) are left alone.
   useEffect(() => {
     if (loading || !me || publicView) return
     let onboarded = false
@@ -227,6 +231,19 @@ export function AppShell({ children }: { children: ReactNode }) {
   // connect-your-tools) instead, so the shell only ever renders for onboarded or
   // skipped users.
 
+  // Chrome-light shell for an anon shared artifact: no rail, no mobile top bar —
+  // the PublicViewer owns its own header/footer and the render fills the frame.
+  if (bareArtifact)
+    return (
+      <ShellCtx.Provider value={value}>
+        <TooltipProvider>
+          <div id="main-content" className="isolate flex h-full min-h-0 flex-col outline-none">
+            {children}
+          </div>
+        </TooltipProvider>
+      </ShellCtx.Provider>
+    )
+
   return (
     <ShellCtx.Provider value={value}>
       {/* Tooltips ride the sidebar's collapsed icon rows (the official
@@ -312,10 +329,12 @@ function MobileTopBar({
 // A pathname switch, not route metadata — labels are chrome, not content.
 function PageLabel({ pathname }: { pathname: string }) {
   if (pathname === "/") return "Library"
+  if (pathname === "/favorites") return "Favorites"
+  if (pathname === "/following") return "Following"
   if (pathname === "/people") return "People"
   if (pathname === "/new") return "New artifact"
   if (pathname.startsWith("/settings")) return "Settings"
-  if (pathname.startsWith("/a/")) return "Artifact"
-  if (pathname.startsWith("/u/")) return "Profile"
+  if (pathname.startsWith("/artifacts/")) return "Artifact"
+  if (pathname.startsWith("/users/")) return "Profile"
   return "Derive"
 }

--- a/apps/web/src/components/author-chip.tsx
+++ b/apps/web/src/components/author-chip.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/utils"
 //
 // Three shapes, picked by the props:
 //  - `onClick`  → a button (used to filter the list by this author).
-//  - `handle`   → a Link to the author's /u/<handle> profile.
+//  - `handle`   → a Link to the author's /users/<handle> profile.
 //  - neither    → plain, non-interactive text.
 export interface AuthorChipProps {
   name: string | null
@@ -99,7 +99,7 @@ export function AuthorChip({
   if (handle) {
     return (
       <Link
-        to="/u/$handle"
+        to="/users/$handle"
         params={{ handle }}
         data-testid={testId}
         aria-label={`View @${handle}'s profile`}

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -19,8 +19,8 @@ import { refFor } from "@/pages/artifact/parse-ref"
 import { Icon } from "./icons"
 import { useShell } from "./shell-context"
 
-// ⌘K palette: jump to any artifact (server search) or to a view (All / Favorites),
-// a collection, or another workspace — from anywhere, including inside an artifact.
+// ⌘K palette: jump to any artifact (server search) or to a feed (All / Favorites /
+// Following), a collection, or another workspace — from anywhere, incl. inside an artifact.
 // Artifact search is async, so cmdk's built-in filtering is off and we render
 // exactly the rows we want; the static rows are filtered against the query here.
 export function CommandPalette() {
@@ -97,6 +97,7 @@ export function CommandPalette() {
     : []
   const showAll = "all artifacts".includes(q) || "library".includes(q)
   const showFav = "favorites".includes(q)
+  const showFollowing = "following".includes(q)
 
   return (
     <CommandDialog
@@ -115,7 +116,7 @@ export function CommandPalette() {
         <CommandList>
           <CommandEmpty>{loading ? "Searching…" : "No results."}</CommandEmpty>
 
-          {(showAll || showFav) && (
+          {(showAll || showFav || showFollowing) && (
             <CommandGroup heading="Jump to">
               {showAll && (
                 <CommandItem
@@ -128,9 +129,17 @@ export function CommandPalette() {
               {showFav && (
                 <CommandItem
                   value="jump-favorites"
-                  onSelect={() => go(() => nav({ to: "/", search: { f: "favorites" } }))}
+                  onSelect={() => go(() => nav({ to: "/favorites" }))}
                 >
                   <Icon name="favorites" size={16} /> Favorites
+                </CommandItem>
+              )}
+              {showFollowing && (
+                <CommandItem
+                  value="jump-following"
+                  onSelect={() => go(() => nav({ to: "/following" }))}
+                >
+                  <Icon name="following" size={16} /> Following
                 </CommandItem>
               )}
             </CommandGroup>
@@ -142,7 +151,9 @@ export function CommandPalette() {
                 <CommandItem
                   key={a.short_id}
                   value={`artifact-${a.short_id}`}
-                  onSelect={() => go(() => nav({ to: "/a/$ref", params: { ref: refFor(a) } }))}
+                  onSelect={() =>
+                    go(() => nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } }))
+                  }
                   onMouseEnter={() => prefetch(a.short_id, a.current_version)}
                   onFocus={() => prefetch(a.short_id, a.current_version)}
                 >
@@ -163,7 +174,7 @@ export function CommandPalette() {
                   key={u.username}
                   value={`person-${u.username}`}
                   onSelect={() =>
-                    go(() => nav({ to: "/u/$handle", params: { handle: u.username } }))
+                    go(() => nav({ to: "/users/$handle", params: { handle: u.username } }))
                   }
                 >
                   <Avatar className="size-5">

--- a/apps/web/src/components/nav-rail.tsx
+++ b/apps/web/src/components/nav-rail.tsx
@@ -91,6 +91,46 @@ function FilterItem({
   )
 }
 
+// A fixed-feed nav row: navigates to a top-level ROUTE (a named feed like /favorites
+// or /following, or the /people directory) rather than a library filter. The path IS
+// the destination — the FilterItem counterpart for feeds that earned their own route
+// (docs/decisions/0002). The optional count badge only inks once nonzero (a zero is noise).
+function NavItem({
+  icon,
+  label,
+  count,
+  to,
+  active,
+  testId,
+}: {
+  icon: IconName
+  label: string
+  count?: number
+  to: "/favorites" | "/following" | "/people"
+  active: boolean
+  testId?: string
+}) {
+  const { setOpenMobile } = useSidebar()
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton asChild isActive={active} tooltip={label}>
+        <Link
+          to={to}
+          aria-label={label}
+          data-testid={testId}
+          aria-current={active ? "page" : undefined}
+          onClick={() => setOpenMobile(false)}
+          className={cn(ROW_ICON, (count ?? 0) > 0 && "pr-7")}
+        >
+          <Icon name={icon} />
+          <span>{label}</span>
+          {(count ?? 0) > 0 && <SidebarMenuBadge className={COUNT_BADGE}>{count}</SidebarMenuBadge>}
+        </Link>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  )
+}
+
 // The brand header shared by the signed-in and anon rails: wordmark (the app's
 // one wordmark — there is no top bar on desktop), the collapse trigger (desktop
 // only; app-shell renders its own `library-menu` hamburger on mobile, and the
@@ -178,9 +218,11 @@ export function NavRail() {
   const loc = useLocation()
   const search = loc.search as LibrarySearch
   const onLibrary = loc.pathname === "/"
-  const isAll = onLibrary && !search.f && !search.scope && !search.tag && !search.collection
-  const isFav = onLibrary && search.f === "favorites"
-  const isFollowing = onLibrary && search.scope === "following"
+  // Feeds are routes now; the home library reads "active > All" only when no tag/
+  // collection filter narrows it. (A ?query= search doesn't change which feed you're in.)
+  const isAll = onLibrary && !search.tag && !search.collection
+  const isFav = loc.pathname === "/favorites"
+  const isFollowing = loc.pathname === "/following"
   const onPeople = loc.pathname === "/people"
   const onSettings = loc.pathname === "/settings"
   const tags = summary?.tags ?? []
@@ -329,38 +371,29 @@ export function NavRail() {
                 active={isAll}
                 testId="sidebar-all"
               />
-              <FilterItem
+              <NavItem
                 icon="favorites"
                 label="Favorites"
                 count={summary?.favorites}
-                search={{ f: "favorites" }}
+                to="/favorites"
                 active={isFav}
                 testId="sidebar-favorites"
               />
-              <FilterItem
+              <NavItem
                 icon="following"
                 label="Following"
-                search={{ scope: "following" }}
+                to="/following"
                 active={isFollowing}
                 testId="nav-following"
               />
-              {/* People directory — a real route, not a library filter (FilterItem
-                  always links to "/"). Find + follow people. */}
-              <SidebarMenuItem>
-                <SidebarMenuButton asChild isActive={onPeople} tooltip="People">
-                  <Link
-                    to="/people"
-                    aria-label="People"
-                    data-testid="nav-people"
-                    aria-current={onPeople ? "page" : undefined}
-                    onClick={closeMobile}
-                    className={ROW_ICON}
-                  >
-                    <Icon name="user" />
-                    <span>People</span>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
+              {/* People directory — the other fixed-feed route, a peer of the two feeds. */}
+              <NavItem
+                icon="user"
+                label="People"
+                to="/people"
+                active={onPeople}
+                testId="nav-people"
+              />
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>

--- a/apps/web/src/components/notification-bell.tsx
+++ b/apps/web/src/components/notification-bell.tsx
@@ -18,7 +18,7 @@ import { Icon } from "./icons"
 
 // Notifications: an unread badge + a panel of recent @mentions, kept live over
 // SSE. Lives in the rail's utility menu (a SidebarMenuItem); clicking an item
-// deep-links to its comment thread (?c=) and marks it read. Built on the
+// deep-links to its comment thread (?comment=) and marks it read. Built on the
 // Popover primitive with a SidebarMenuButton trigger.
 export function NotificationBell() {
   const { me } = useAuth()
@@ -68,14 +68,14 @@ export function NotificationBell() {
     }
     // A follow notification has no artifact — open the follower's profile instead.
     if (n.kind === "follow") {
-      nav({ to: "/u/$handle", params: { handle: n.actor } })
+      nav({ to: "/users/$handle", params: { handle: n.actor } })
       return
     }
     nav({
-      to: "/a/$ref",
+      to: "/artifacts/$ref",
       params: { ref: refFor({ short_id: n.artifact_short_id, title: n.artifact_title }) },
       // A share/publish notification has no thread; open the artifact itself.
-      search: n.thread_id ? { c: n.thread_id } : {},
+      search: n.thread_id ? { comment: n.thread_id } : {},
     })
   }
 

--- a/apps/web/src/components/shared/floating-control.tsx
+++ b/apps/web/src/components/shared/floating-control.tsx
@@ -3,17 +3,18 @@ import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
 // A control that floats over the sandboxed render (the comments FAB, the focus-mode
-// exit, the "comment on selection" pill). The render is an opaque white iframe, so
-// the fill must stay OPAQUE: the outline/ghost hover washes are meant to sit over a
-// surface and would erase a pill floating over the iframe. So composite the neutral
-// hover step into the opaque card instead (darkens in light, lightens in dark — the
-// same ink direction as --secondary). One recipe so every floating control matches.
+// exit). It carries the floating-surface grammar — opaque bg-card + `ring-1
+// ring-foreground/10` + shadow — so it matches menus, popovers, and the render mat
+// rather than the plain button outline. The fill must stay OPAQUE: the ghost hover
+// wash is meant to sit over a surface and would erase a pill floating over the opaque
+// iframe, so composite the neutral hover step into the card instead (darkens in light,
+// lightens in dark — the `--secondary` ink direction). One recipe, every control matches.
 export function FloatingControl({ className, ...props }: ComponentProps<typeof Button>) {
   return (
     <Button
-      variant="outline"
+      variant="ghost"
       className={cn(
-        "rounded-full bg-card shadow-[var(--shadow)] hover:bg-[color-mix(in_oklab,var(--card)_95%,var(--foreground))]",
+        "rounded-full bg-card shadow-[var(--shadow)] ring-1 ring-foreground/10 hover:bg-[color-mix(in_oklab,var(--card)_95%,var(--foreground))]",
         className,
       )}
       {...props}

--- a/apps/web/src/components/shared/floating-control.tsx
+++ b/apps/web/src/components/shared/floating-control.tsx
@@ -1,0 +1,22 @@
+import type { ComponentProps } from "react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+// A control that floats over the sandboxed render (the comments FAB, the focus-mode
+// exit, the "comment on selection" pill). The render is an opaque white iframe, so
+// the fill must stay OPAQUE: the outline/ghost hover washes are meant to sit over a
+// surface and would erase a pill floating over the iframe. So composite the neutral
+// hover step into the opaque card instead (darkens in light, lightens in dark — the
+// same ink direction as --secondary). One recipe so every floating control matches.
+export function FloatingControl({ className, ...props }: ComponentProps<typeof Button>) {
+  return (
+    <Button
+      variant="outline"
+      className={cn(
+        "rounded-full bg-card shadow-[var(--shadow)] hover:bg-[color-mix(in_oklab,var(--card)_95%,var(--foreground))]",
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/apps/web/src/components/sync-chip.tsx
+++ b/apps/web/src/components/sync-chip.tsx
@@ -46,8 +46,8 @@ export function SyncChip() {
       <SidebarMenuItem>
         <SidebarMenuButton asChild tooltip={`${label} · ${detail}`}>
           <Link
-            to="/settings"
-            search={{ tab: "github" }}
+            to="/settings/$section"
+            params={{ section: "github" }}
             aria-label={`${label} · ${detail}`}
             data-testid="sync-chip"
             className="text-primary [&_svg]:text-primary"
@@ -64,8 +64,8 @@ export function SyncChip() {
   return (
     <SidebarMenuItem className="pb-1">
       <Link
-        to="/settings"
-        search={{ tab: "github" }}
+        to="/settings/$section"
+        params={{ section: "github" }}
         data-testid="sync-chip"
         className="flex flex-col gap-1.5 rounded-lg border border-primary/30 bg-primary/5 px-2.5 py-2 outline-none hover:bg-primary/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
       >

--- a/apps/web/src/components/user-pod.tsx
+++ b/apps/web/src/components/user-pod.tsx
@@ -45,7 +45,7 @@ export function UserPod({
   const multi = !!workspaces?.multi
 
   const goProfile = () => {
-    if (me.username) nav({ to: "/u/$handle", params: { handle: me.username } })
+    if (me.username) nav({ to: "/users/$handle", params: { handle: me.username } })
   }
   const goSettings = () => nav({ to: "/settings" })
   const signOut = async () => {

--- a/apps/web/src/pages/artifact/artifact-actions.ts
+++ b/apps/web/src/pages/artifact/artifact-actions.ts
@@ -207,7 +207,7 @@ export function artifactActions(p: {
         .catch((e) => toast.error((e as Error).message))
     },
     copyLink: (threadId) => {
-      const url = `${window.location.origin}${window.location.pathname}?c=${threadId}`
+      const url = `${window.location.origin}${window.location.pathname}?comment=${threadId}`
       navigator.clipboard
         ?.writeText(url)
         .then(() => toast.success("Link copied"))

--- a/apps/web/src/pages/artifact/artifact-document.tsx
+++ b/apps/web/src/pages/artifact/artifact-document.tsx
@@ -36,7 +36,6 @@ export function ArtifactDocument({
   onDeckPrev,
   onDeckNext,
   onFullscreen,
-  bare,
 }: {
   shown: number
   currentVersion: number
@@ -59,8 +58,6 @@ export function ArtifactDocument({
   onDeckPrev: () => void
   onDeckNext: () => void
   onFullscreen: () => void
-  /** Focus mode: full-bleed render, no mat gap/frame. */
-  bare?: boolean
 }) {
   const past = shown !== currentVersion
   return (
@@ -112,7 +109,6 @@ export function ArtifactDocument({
           rawSrc={rawSrc}
           title={title}
           version={shown}
-          bare={bare}
           frameRef={frameRef}
           wrapRef={presentWrapRef}
           onFrameLoad={onFrameLoad}

--- a/apps/web/src/pages/artifact/artifact-document.tsx
+++ b/apps/web/src/pages/artifact/artifact-document.tsx
@@ -108,6 +108,7 @@ export function ArtifactDocument({
         <RenderStage
           rawSrc={rawSrc}
           title={title}
+          version={shown}
           frameRef={frameRef}
           wrapRef={presentWrapRef}
           onFrameLoad={onFrameLoad}

--- a/apps/web/src/pages/artifact/artifact-document.tsx
+++ b/apps/web/src/pages/artifact/artifact-document.tsx
@@ -36,6 +36,7 @@ export function ArtifactDocument({
   onDeckPrev,
   onDeckNext,
   onFullscreen,
+  bare,
 }: {
   shown: number
   currentVersion: number
@@ -58,6 +59,8 @@ export function ArtifactDocument({
   onDeckPrev: () => void
   onDeckNext: () => void
   onFullscreen: () => void
+  /** Focus mode: full-bleed render, no mat gap/frame. */
+  bare?: boolean
 }) {
   const past = shown !== currentVersion
   return (
@@ -109,6 +112,7 @@ export function ArtifactDocument({
           rawSrc={rawSrc}
           title={title}
           version={shown}
+          bare={bare}
           frameRef={frameRef}
           wrapRef={presentWrapRef}
           onFrameLoad={onFrameLoad}

--- a/apps/web/src/pages/artifact/artifact-document.tsx
+++ b/apps/web/src/pages/artifact/artifact-document.tsx
@@ -5,12 +5,14 @@ import { CursorLayer } from "./cursors/cursor-layer"
 import type { CursorLayerHandle } from "./cursors/use-live-cursors"
 import { DiffView } from "./diff-view"
 import { DeckBar } from "./rail-deck"
+import { RenderStage } from "./render-stage"
 
 /**
- * The document surface: a history banner when viewing a past version, then either
- * the line diff or the sandboxed iframe (with the live-cursor overlay + the deck
- * bar for slide artifacts). The refs are owned by the page (its anchor/presence/
- * fullscreen effects drive them) and passed in.
+ * The document surface: a past-version banner when off the live version, then the
+ * line diff or the matted live render (RenderStage owns the sandboxed iframe + its
+ * boot/failure states; the deck bar and live-cursor overlay ride inside the mat).
+ * The refs are owned by the page (its anchor/presence/fullscreen effects drive
+ * them) and threaded in.
  */
 export function ArtifactDocument({
   shown,
@@ -60,20 +62,15 @@ export function ArtifactDocument({
   const past = shown !== currentVersion
   return (
     <>
-      {/* History-viewing banner: only when looking at a past version. The current
-          version just shows the artifact, no version chrome. */}
+      {/* Off the live version: a brand-tinted strip (the sync-chip grammar — being
+          off-current is a "this matters" moment, not a status warning). */}
       {past && (
-        // A brand-tinted strip (the sync-chip grammar): being off the live version
-        // is a "this matters" moment, not a status warning.
         <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5 border-b border-primary/30 bg-primary/5 px-4 py-2 text-sm">
           <span className="font-medium text-primary">Viewing an earlier version</span>
           <span className="text-muted-foreground">·</span>
           <Button
             variant="link"
             data-testid="artifact-toggle-diff"
-            // In-flow with the banner text: strip the control box, keep the link
-            // recipe. Persistent underline (not the variant's hover-only) so the
-            // ink link stays legible as a control beside the ink banner label.
             className="h-auto p-0 underline"
             onClick={onToggleDiff}
           >
@@ -89,8 +86,6 @@ export function ArtifactDocument({
           >
             {restoring ? "Restoring…" : "Restore this version"}
           </Button>
-          {/* Secondary, not filled: the toolbar's Share is the page's one ink
-              primary — a second filled button in the history banner would compete. */}
           <Button
             variant="secondary"
             size="sm"
@@ -110,30 +105,29 @@ export function ArtifactDocument({
           toLabel="current"
         />
       ) : (
-        <div ref={presentWrapRef} className="relative flex min-h-0 flex-1 flex-col bg-white">
-          <iframe
-            ref={frameRef}
-            onLoad={onFrameLoad}
-            title={title}
-            src={rawSrc}
-            allow="fullscreen"
-            sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
-            className="flex-1 border-0 bg-white"
-          />
-          {deck && (
-            <DeckBar
-              deck={deck}
-              onPrev={onDeckPrev}
-              onNext={onDeckNext}
-              onFullscreen={onFullscreen}
-            />
-          )}
-          {/* Live peer cursors (Figma/Notion style). The iframe is a separate opaque
-              origin, so its anchor script forwards pointer moves/leave/tap out via
-              postMessage; the overlay eases them in here in the parent, over the
-              frame. Anon viewers too. */}
-          <CursorLayer layer={cursor} onScrollDoc={onScrollDoc} />
-        </div>
+        <RenderStage
+          rawSrc={rawSrc}
+          title={title}
+          frameRef={frameRef}
+          wrapRef={presentWrapRef}
+          onFrameLoad={onFrameLoad}
+          overlays={
+            <>
+              {deck && (
+                <DeckBar
+                  deck={deck}
+                  onPrev={onDeckPrev}
+                  onNext={onDeckNext}
+                  onFullscreen={onFullscreen}
+                />
+              )}
+              {/* Live peer cursors ease in here, over the framed render (the iframe is
+                  a separate opaque origin — its script forwards pointer moves out via
+                  postMessage). Anon viewers too. */}
+              <CursorLayer layer={cursor} onScrollDoc={onScrollDoc} />
+            </>
+          }
+        />
       )}
     </>
   )

--- a/apps/web/src/pages/artifact/artifact-top-bar.tsx
+++ b/apps/web/src/pages/artifact/artifact-top-bar.tsx
@@ -1,3 +1,4 @@
+import { Maximize2 } from "lucide-react"
 import { useState } from "react"
 import type { GeneralRole, Role } from "@/api"
 import { Icon } from "@/components/icons"
@@ -61,12 +62,13 @@ export function ArtifactTopBar(props: {
   onToggleComments: () => void
   onPresent: () => void
   onLockToggle: () => void
+  /** Enter focus/hero mode — strip the chrome to just the render. */
+  onFocus: () => void
 }) {
   const { shortId, openProposals, proposalsTotal } = props
   const [reportOpen, setReportOpen] = useState(false)
   const [tagsOpen, setTagsOpen] = useState(false)
   const [collectionsOpen, setCollectionsOpen] = useState(false)
-  const hasView = props.showReader || props.isDeck
   return (
     <>
       {/* Actions cluster — the filled Share leads (the one primary), then the favorited
@@ -100,7 +102,11 @@ export function ArtifactTopBar(props: {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent>
-            {/* View modes (contextual) — a check marks the active one. */}
+            {/* View modes — focus strips the chrome to just the render; a check marks
+                the active reader toggle. */}
+            <DropdownMenuItem data-testid="artifact-focus" onSelect={props.onFocus}>
+              <Maximize2 className="size-4" /> Focus mode
+            </DropdownMenuItem>
             {props.showReader && (
               <DropdownMenuItem data-testid="artifact-reader" onSelect={props.onReaderToggle}>
                 <Icon name="reader" size={16} /> Reader
@@ -112,7 +118,7 @@ export function ArtifactTopBar(props: {
                 <Icon name="present" size={16} /> Present
               </DropdownMenuItem>
             )}
-            {hasView && <DropdownMenuSeparator />}
+            <DropdownMenuSeparator />
 
             {/* Organize — open as dialogs. */}
             <DropdownMenuItem data-testid="artifact-tags" onSelect={() => setTagsOpen(true)}>

--- a/apps/web/src/pages/artifact/artifact-top-bar.tsx
+++ b/apps/web/src/pages/artifact/artifact-top-bar.tsx
@@ -105,7 +105,7 @@ export function ArtifactTopBar(props: {
             {/* View modes — focus strips the chrome to just the render; a check marks
                 the active reader toggle. */}
             <DropdownMenuItem data-testid="artifact-focus" onSelect={props.onFocus}>
-              <Maximize2 className="size-4" /> Focus mode
+              <Maximize2 className="size-4" aria-hidden /> Focus mode
             </DropdownMenuItem>
             {props.showReader && (
               <DropdownMenuItem data-testid="artifact-reader" onSelect={props.onReaderToggle}>

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -24,6 +24,7 @@ import {
   ResolvedSection,
 } from "./comment-thread"
 import { useCommentScope } from "./lib/comment-scope"
+import { MAT_GAP_PX } from "./render-stage"
 import { type PinItem, type Sel, selLabel } from "./types"
 
 type Tab = "comments" | "personal"
@@ -454,7 +455,9 @@ export function OpenPanel(props: {
         <PinnedZone
           pins={pinned}
           personal={tab === "personal"}
-          topInset={headerH}
+          // The render floats in a matted frame (a MAT_GAP_PX top gap on desktop),
+          // so shift the pins down by that much to re-align with their highlights.
+          topInset={Math.max(0, headerH - MAT_GAP_PX)}
           scrollY={scrollY}
           onScrollDoc={onScrollDoc}
           composer={composer}

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -24,7 +24,6 @@ import {
   ResolvedSection,
 } from "./comment-thread"
 import { useCommentScope } from "./lib/comment-scope"
-import { MAT_GAP_PX } from "./render-stage"
 import { type PinItem, type Sel, selLabel } from "./types"
 
 type Tab = "comments" | "personal"
@@ -455,9 +454,7 @@ export function OpenPanel(props: {
         <PinnedZone
           pins={pinned}
           personal={tab === "personal"}
-          // The render floats in a matted frame (a MAT_GAP_PX top gap on desktop),
-          // so shift the pins down by that much to re-align with their highlights.
-          topInset={Math.max(0, headerH - MAT_GAP_PX)}
+          topInset={headerH}
           scrollY={scrollY}
           onScrollDoc={onScrollDoc}
           composer={composer}

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -555,14 +555,13 @@ export function Artifact() {
               {art.updated_at ? ` · updated ${ago(art.updated_at)}` : ""}
             </span>
           </div>
-          {/* Collaboration — presence facepile + your cursor, one ambient cluster,
-              held apart from the actions by spacing (no vertical rule). */}
-          {!isMobile && (
-            <div className="flex items-center gap-0.5">
-              <Presence viewers={live.viewers} selfId={me?.id} />
-              <CursorButton />
-            </div>
-          )}
+          {/* Collaboration — presence facepile + your cursor. Presence rides even the
+              phone header (compact) so multiplayer identity never vanishes on mobile;
+              the cursor picker stays desktop-only (no hovering cursor to style on touch). */}
+          <div className="flex items-center gap-0.5">
+            <Presence viewers={live.viewers} selfId={me?.id} compact={isMobile} />
+            {!isMobile && <CursorButton />}
+          </div>
           {!isAnon && (
             <ArtifactTopBar
               shortId={shortId}

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -1,10 +1,12 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate, useParams } from "@tanstack/react-router"
+import { Minimize2 } from "lucide-react"
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react"
 import { API_BASE, ApiError, api, type Comment } from "@/api"
 import { CursorButton } from "@/components/cursor/cursor-button"
 import { Icon } from "@/components/icons"
-import { Button } from "@/components/ui/button"
+import { FloatingControl } from "@/components/shared/floating-control"
+import { useSidebar } from "@/components/ui/sidebar"
 import { toast } from "@/components/ui/sonner"
 import { useAuth } from "@/ctx"
 import { artifactQuery, commentsQuery } from "@/lib/queries"
@@ -61,23 +63,35 @@ function DocFab({
   children: React.ReactNode
 }) {
   return (
-    <Button
-      variant="outline"
+    <FloatingControl
       size="lg"
       title={title}
       data-testid={testId}
       onClick={onClick}
-      // Floats over the white document, so the fill must stay opaque: the
-      // outline variant's hover:bg-secondary is a ~4% wash meant to sit over a
-      // surface, and over the iframe it would erase the pill. Composite the
-      // neutral hover step into the opaque card instead (darkens in light,
-      // lightens in dark — same ink direction as --secondary).
-      className="absolute right-4.5 bottom-4.5 rounded-full bg-card tabular-nums shadow-[var(--shadow)] hover:bg-[color-mix(in_oklab,var(--card)_95%,var(--foreground))]"
+      className="absolute right-4.5 bottom-4.5 tabular-nums"
     >
       <Icon name="comments" size={16} />
       {children}
-    </Button>
+    </FloatingControl>
   )
+}
+
+// Focus mode also collapses the app nav rail (the render is the hero — the rail is
+// the shell's, not the page's, so this authed-only helper drives it through the
+// sidebar context). Restores the viewer's prior rail state on exit.
+function FocusRailSync({ focus }: { focus: boolean }) {
+  const { open, setOpen } = useSidebar()
+  const prior = useRef(open)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: react to focus flips only, not rail toggles.
+  useEffect(() => {
+    if (focus) {
+      prior.current = open
+      setOpen(false)
+    } else if (prior.current) {
+      setOpen(true)
+    }
+  }, [focus])
+  return null
 }
 
 export function Artifact() {
@@ -98,6 +112,16 @@ export function Artifact() {
   // password prompt rather than the not-found state or a bounce to login.
   const locked = failed && error instanceof ApiError && error.status === 401
   const [editing, setEditing] = useState(false)
+  // Focus/hero mode — strip the workbench chrome to just the matted render (Esc exits).
+  const [focus, setFocus] = useState(false)
+  useEffect(() => {
+    if (!focus) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setFocus(false)
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [focus])
   const [reviewing, setReviewing] = useState(false)
   // Which "⋯ More" surface is open (large dialog / drawer).
   const [surface, setSurface] = useState<null | "insights" | "history">(null)
@@ -532,13 +556,21 @@ export function Artifact() {
       {/* data-artifact-view: while the workbench is mounted, globals.css drops the
           film-grain overlay so Derive's material steps back inside the author's document. */}
       <div data-artifact-view className="flex min-h-0 flex-1 flex-col">
+        <FocusRailSync focus={focus} />
         {/* The workbench bar — full-width now (sidebar-first shell), so the
               comments panel docks BELOW it instead of squeezing it into the
               remaining width. The page owns its toolbar: the artifact title (the
               Geist content register) on the left, presence/cursors + the header
               actions on the right. shrink-0 keeps the split row below it on the
               min-h-0 flex-1 height chain. */}
-        <div className="flex shrink-0 items-center gap-3 border-b border-border px-4 py-2.5 max-sm:flex-wrap max-sm:px-3">
+        {/* The header stays mounted but hidden in focus mode — unmounting it while
+            its ⋯ menu is mid-close trips a Radix ref-composition loop. */}
+        <div
+          className={cn(
+            "flex shrink-0 items-center gap-3 border-b border-border px-4 py-2.5 max-sm:flex-wrap max-sm:px-3",
+            focus && "hidden",
+          )}
+        >
           {/* Identity — a two-line document header, the reframe: the artifact title,
               then a machine-register state line (type · version · freshness). The
               bar's job is to say WHAT you're viewing and its state, not to be a run
@@ -626,6 +658,7 @@ export function Artifact() {
               onReview={() => setReviewing(true)}
               onStartEdit={startEdit}
               onToggleComments={() => setPanel((pn) => (pn === "open" ? "hidden" : "open"))}
+              onFocus={() => setFocus(true)}
             />
           )}
         </div>
@@ -639,7 +672,7 @@ export function Artifact() {
               // that space so the document stays visible above it (and a
               // jumped-to highlight lands in view, not behind the sheet).
               "relative flex min-w-0 flex-1 flex-col transition-[padding] duration-200",
-              isMobile && panel === "open" && "pb-[50vh]",
+              isMobile && !focus && panel === "open" && "pb-[50vh]",
             )}
           >
             {art.bundle && !editing && (
@@ -663,6 +696,7 @@ export function Artifact() {
               />
             ) : (
               <ArtifactDocument
+                bare={focus}
                 shown={shown}
                 currentVersion={art.current_version}
                 title={art.title ?? shortId}
@@ -691,7 +725,7 @@ export function Artifact() {
                 onFullscreen={toggleFullscreen}
               />
             )}
-            {!isAnon && panel === "hidden" && (
+            {!isAnon && !focus && panel === "hidden" && (
               <DocFab
                 title="Show comments (c)"
                 testId="artifact-comments-fab"
@@ -720,47 +754,62 @@ export function Artifact() {
                 Sign in to comment
               </DocFab>
             )}
+            {/* Focus mode: the one way back (the header is hidden). Esc also exits. */}
+            {focus && (
+              <FloatingControl
+                size="sm"
+                data-testid="artifact-focus-exit"
+                aria-label="Exit focus mode"
+                onClick={() => setFocus(false)}
+                className="absolute top-3 right-3 z-10"
+              >
+                <Minimize2 className="size-4" />
+                Exit focus
+              </FloatingControl>
+            )}
           </div>
 
-          <ArtifactComments
-            shortId={shortId}
-            isMobile={isMobile}
-            isAnon={isAnon}
-            canComment={canComment}
-            docLive={docLive}
-            panel={panel}
-            tab={commentTab}
-            setTab={setCommentTab}
-            personalCount={personalCount}
-            publicCount={publicCount}
-            asideWidth={asideWidth}
-            openCount={openCount}
-            scrollY={scrollY}
-            onScrollDoc={scrollBy}
-            pinned={pinned}
-            general={general}
-            resolved={resolvedThreads}
-            openThreads={openThreads}
-            activeThread={activeThread}
-            hoverThread={hoverThread}
-            inDoc={inDoc}
-            composer={composer}
-            sel={sel}
-            setPanel={setPanel}
-            setComposer={setComposer}
-            setSel={setSel}
-            setActiveThread={setActiveThread}
-            setHoverThread={setHoverThread}
-            activate={activateThread}
-            toggleResolve={toggleResolve}
-            reply={reply}
-            submitNew={submitNew}
-            jumpTo={jumpTo}
-            startSelComment={startSelComment}
-            currentSlide={deck?.i ?? null}
-            landedSlides={landedSlides}
-            anchorConf={anchorConf}
-          />
+          {!focus && (
+            <ArtifactComments
+              shortId={shortId}
+              isMobile={isMobile}
+              isAnon={isAnon}
+              canComment={canComment}
+              docLive={docLive}
+              panel={panel}
+              tab={commentTab}
+              setTab={setCommentTab}
+              personalCount={personalCount}
+              publicCount={publicCount}
+              asideWidth={asideWidth}
+              openCount={openCount}
+              scrollY={scrollY}
+              onScrollDoc={scrollBy}
+              pinned={pinned}
+              general={general}
+              resolved={resolvedThreads}
+              openThreads={openThreads}
+              activeThread={activeThread}
+              hoverThread={hoverThread}
+              inDoc={inDoc}
+              composer={composer}
+              sel={sel}
+              setPanel={setPanel}
+              setComposer={setComposer}
+              setSel={setSel}
+              setActiveThread={setActiveThread}
+              setHoverThread={setHoverThread}
+              activate={activateThread}
+              toggleResolve={toggleResolve}
+              reply={reply}
+              submitNew={submitNew}
+              jumpTo={jumpTo}
+              startSelComment={startSelComment}
+              currentSlide={deck?.i ?? null}
+              landedSlides={landedSlides}
+              anchorConf={anchorConf}
+            />
+          )}
         </div>
       </div>
     </ActionsCtx.Provider>

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -28,6 +28,7 @@ import { canCommentWithRole, shouldPromptSignInToComment } from "./lib/comment-a
 import { groupThreads, parseAnchor } from "./lib/layout"
 import { parseRef, refFor } from "./parse-ref"
 import { PasswordGate } from "./password-gate"
+import { PublicViewer } from "./public-viewer"
 import { Presence } from "./rail-deck"
 import { SourceEditor } from "./source-editor"
 import type { PinItem, Sel } from "./types"
@@ -80,7 +81,7 @@ function DocFab({
 }
 
 export function Artifact() {
-  const { ref } = useParams({ from: "/a/$ref" })
+  const { ref } = useParams({ from: "/artifacts/$ref" })
   const { shortId, version } = parseRef(ref)
   const { me, loading } = useAuth()
   const nav = useNavigate()
@@ -110,7 +111,7 @@ export function Artifact() {
   const [editTitle, setEditTitle] = useState("")
 
   // Canonicalise the URL client-side: once the artifact is loaded, rewrite any
-  // non-canonical ref (bare id, stale name, legacy order) to /a/<name>-<shortId> so
+  // non-canonical ref (bare id, stale name, legacy order) to /artifacts/<name>-<shortId> so
   // the browser holds the readable URL. replace:true so Back doesn't bounce through
   // the old ref; preserves the @vN suffix and the current search.
   useEffect(() => {
@@ -119,7 +120,7 @@ export function Artifact() {
       ? `${refFor({ short_id: shortId, title: art.title })}@v${version}`
       : refFor({ short_id: shortId, title: art.title })
     if (ref !== canonical)
-      nav({ to: "/a/$ref", params: { ref: canonical }, search: (s) => s, replace: true })
+      nav({ to: "/artifacts/$ref", params: { ref: canonical }, search: (s) => s, replace: true })
   }, [art, ref, version, shortId, nav])
 
   // Comments UI state shared across the page, the panel, and the iframe bridge.
@@ -196,8 +197,8 @@ export function Artifact() {
     onNavigate: (ref, newTab) => {
       // Same-origin SPA route. A modified/middle click opens it un-sandboxed in a new
       // tab (the frame's own new tab would inherit the sandbox and break the app).
-      if (newTab) window.open(`/a/${ref}`, "_blank", "noopener")
-      else nav({ to: "/a/$ref", params: { ref } })
+      if (newTab) window.open(`/artifacts/${ref}`, "_blank", "noopener")
+      else nav({ to: "/artifacts/$ref", params: { ref } })
     },
   })
 
@@ -260,13 +261,13 @@ export function Artifact() {
     if (!loading && !me && failed && !locked && gated) nav({ to: "/login" })
   }, [loading, me, failed, locked, error, nav])
 
-  // Deep link: ?c=<thread> opens the panel, activates that thread, and jumps to
+  // Deep link: ?comment=<thread> opens the panel, activates that thread, and jumps to
   // its text. Runs once, after comments are in.
   const deepLinked = useRef(false)
   useEffect(() => {
     if (deepLinked.current || comments.length === 0) return
     deepLinked.current = true
-    const cid = new URLSearchParams(window.location.search).get("c")
+    const cid = new URLSearchParams(window.location.search).get("comment")
     const target = cid ? comments.find((c) => c.thread_id === cid) : undefined
     if (target) {
       // Open the tab the thread lives on, or its anchor won't be live in the doc.
@@ -419,7 +420,10 @@ export function Artifact() {
     load,
     refetchComments,
     onRestoredJump: () =>
-      nav({ to: "/a/$ref", params: { ref: refFor({ short_id: shortId, title: art.title }) } }),
+      nav({
+        to: "/artifacts/$ref",
+        params: { ref: refFor({ short_id: shortId, title: art.title }) },
+      }),
     setEditing,
     setSrc,
     setTitle: setEditTitle,
@@ -440,6 +444,49 @@ export function Artifact() {
   // On phones the comments live in a slide-up sheet, so the in-flow aside has
   // no width and the document gets the full screen.
   const asideWidth = isMobile ? 0 : panel === "open" ? 340 : 0
+
+  // Anonymous visitor → the chrome-light public/viral viewer (the app shell has
+  // dropped the rail). The render is the hero; a slim public header carries the
+  // brand, the creator byline, presence, and the growth verbs. The comment/editor
+  // chrome is absent — the API gates every write for anon anyway.
+  if (isAnon)
+    return (
+      <PublicViewer
+        art={art}
+        returnTo={`/artifacts/${ref}`}
+        viewers={live.viewers}
+        isMobile={isMobile}
+      >
+        <ArtifactDocument
+          shown={shown}
+          currentVersion={art.current_version}
+          title={art.title ?? shortId}
+          rawSrc={rawSrc}
+          view={view}
+          diff={diff}
+          diffFailed={diffFailed}
+          onDiffRetry={retryDiff}
+          restoring={restoring}
+          deck={deck}
+          frameRef={frame}
+          presentWrapRef={presentWrap}
+          cursor={live.cursor}
+          onScrollDoc={scrollBy}
+          onFrameLoad={onFrameLoad}
+          onToggleDiff={() => setView(view === "diff" ? "preview" : "diff")}
+          onRestore={() => restore(shown)}
+          onBackToCurrent={() =>
+            nav({
+              to: "/artifacts/$ref",
+              params: { ref: refFor({ short_id: shortId, title: art.title }) },
+            })
+          }
+          onDeckPrev={() => deckCmd("prev")}
+          onDeckNext={() => deckCmd("next")}
+          onFullscreen={toggleFullscreen}
+        />
+      </PublicViewer>
+    )
 
   return (
     <ActionsCtx.Provider value={actions}>
@@ -473,7 +520,7 @@ export function Artifact() {
             goTo={(n) => {
               const base = refFor({ short_id: shortId, title: art.title })
               nav({
-                to: "/a/$ref",
+                to: "/artifacts/$ref",
                 params: { ref: n === art.current_version ? base : `${base}@v${n}` },
               })
             }}
@@ -636,7 +683,7 @@ export function Artifact() {
                 onRestore={() => restore(shown)}
                 onBackToCurrent={() =>
                   nav({
-                    to: "/a/$ref",
+                    to: "/artifacts/$ref",
                     params: { ref: refFor({ short_id: shortId, title: art.title }) },
                   })
                 }
@@ -665,7 +712,9 @@ export function Artifact() {
                 onClick={() =>
                   nav({
                     to: "/login",
-                    search: { return_to: `/a/${refFor({ short_id: shortId, title: art.title })}` },
+                    search: {
+                      return_to: `/artifacts/${refFor({ short_id: shortId, title: art.title })}`,
+                    },
                   })
                 }
               >

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -697,7 +697,6 @@ export function Artifact() {
               />
             ) : (
               <ArtifactDocument
-                bare={focus}
                 shown={shown}
                 currentVersion={art.current_version}
                 title={art.title ?? shortId}

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -6,6 +6,7 @@ import { API_BASE, ApiError, api, type Comment } from "@/api"
 import { CursorButton } from "@/components/cursor/cursor-button"
 import { Icon } from "@/components/icons"
 import { FloatingControl } from "@/components/shared/floating-control"
+import { Kbd } from "@/components/ui/kbd"
 import { useSidebar } from "@/components/ui/sidebar"
 import { toast } from "@/components/ui/sonner"
 import { useAuth } from "@/ctx"
@@ -763,8 +764,9 @@ export function Artifact() {
                 onClick={() => setFocus(false)}
                 className="absolute top-3 right-3 z-10"
               >
-                <Minimize2 className="size-4" />
+                <Minimize2 className="size-4" aria-hidden />
                 Exit focus
+                <Kbd className="max-sm:hidden">Esc</Kbd>
               </FloatingControl>
             )}
           </div>

--- a/apps/web/src/pages/artifact/parse-ref.ts
+++ b/apps/web/src/pages/artifact/parse-ref.ts
@@ -14,7 +14,7 @@ export const parseRef = (ref: string): { shortId: string; version?: number } => 
   return { shortId, version: v ? Number(v) : undefined }
 }
 
-/** Ordered, de-duped short-id candidates for a `/a/:ref`: the trailing token first
+/** Ordered, de-duped short-id candidates for a `/artifacts/:ref`: the trailing token first
  *  (name-first links), then the leading token (legacy short-id-first). Resolve by
  *  trying each in order so any link form finds the right artifact — even a name whose
  *  tail looks like an id. Falls back to the whole base when neither token is id-shaped. */
@@ -36,7 +36,7 @@ const slugify = (s: string): string =>
     .replace(/^-+|-+$/g, "")
     .slice(0, 48)
 
-/** Readable `/a/:ref`: `<name>-<shortId>`. Name from an explicit slug or the current
+/** Readable `/artifacts/:ref`: `<name>-<shortId>`. Name from an explicit slug or the current
  *  title; decorative (parseRef resolves by the short id), so renames still work. */
 export const refFor = (a: {
   short_id: string

--- a/apps/web/src/pages/artifact/public-viewer.tsx
+++ b/apps/web/src/pages/artifact/public-viewer.tsx
@@ -79,8 +79,8 @@ export function PublicViewer({
           </div>
         </div>
 
-        {/* A shared link that's being viewed feels alive. */}
-        {!isMobile && <Presence viewers={viewers} selfId={selfId} />}
+        {/* A shared link that's being viewed feels alive — even on a phone (compact). */}
+        <Presence viewers={viewers} selfId={selfId} compact={isMobile} />
 
         {/* The growth verb (the page's one filled primary) + a quiet sign-in. */}
         <Button asChild variant="default" size="sm" data-testid="public-make-your-own">

--- a/apps/web/src/pages/artifact/public-viewer.tsx
+++ b/apps/web/src/pages/artifact/public-viewer.tsx
@@ -1,0 +1,115 @@
+import { Link } from "@tanstack/react-router"
+import type { ReactNode } from "react"
+import type { Artifact, Viewer } from "@/api"
+import { Logo } from "@/components/shared/logo"
+import { Button } from "@/components/ui/button"
+import { ago } from "@/lib/time"
+import { artifactTypeLabel } from "@/pages/library/artifact-card"
+import { Presence } from "./rail-deck"
+
+// The public / viral viewer — the chrome-light experience an anonymous visitor
+// gets on a shared /artifacts/ link (the growth loop). The render is the whole page; a
+// slim public header carries the Derive brand (→ home), the artifact's identity +
+// a CREATOR BYLINE (attribution drives sharing), live presence, and the growth
+// verbs (Make your own · Sign in); a quiet "Made with Derive" mark closes it. No
+// workbench chrome (research: never gate the view; the render is the hero; the
+// verb is the growth loop). The page wires the render machinery and passes it in
+// as `children`.
+export function PublicViewer({
+  art,
+  returnTo,
+  viewers,
+  selfId,
+  isMobile,
+  children,
+}: {
+  art: Artifact
+  /** The current /artifacts/<ref> path, so Sign in returns here afterward. */
+  returnTo: string
+  viewers: Viewer[]
+  selfId?: string
+  isMobile: boolean
+  /** The render (ArtifactDocument) — the page owns its refs/bridge and threads it in. */
+  children: ReactNode
+}) {
+  const author = art.author
+  const authorName = author?.name ?? author?.login ?? null
+
+  return (
+    <div data-artifact-view className="flex min-h-0 flex-1 flex-col bg-background">
+      {/* The slim public header — brand · identity + byline · presence · the verbs. */}
+      <header className="flex shrink-0 items-center gap-3 border-b border-border px-4 py-2.5 max-sm:px-3">
+        <Link
+          to="/"
+          aria-label="Derive home"
+          className="flex shrink-0 items-center gap-1.5 rounded-md text-foreground outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+        >
+          <Logo size={20} />
+          <span className="font-serif text-base font-medium tracking-tight max-sm:sr-only">
+            Derive
+          </span>
+        </Link>
+
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <h1
+            className="truncate font-serif text-base font-medium leading-tight tracking-tight"
+            title={art.title ?? undefined}
+          >
+            {art.title ?? "Untitled"}
+          </h1>
+          <div className="truncate font-mono text-2xs tabular-nums text-muted-foreground">
+            {authorName &&
+              (author?.handle ? (
+                <>
+                  by{" "}
+                  <Link
+                    to="/users/$handle"
+                    params={{ handle: author.handle }}
+                    className="text-foreground hover:underline"
+                  >
+                    {authorName}
+                  </Link>{" "}
+                  ·{" "}
+                </>
+              ) : (
+                <>by {authorName} · </>
+              ))}
+            {artifactTypeLabel(art)} · v{art.current_version}
+            {art.updated_at ? ` · ${ago(art.updated_at)}` : ""}
+          </div>
+        </div>
+
+        {/* A shared link that's being viewed feels alive. */}
+        {!isMobile && <Presence viewers={viewers} selfId={selfId} />}
+
+        {/* The growth verb (the page's one filled primary) + a quiet sign-in. */}
+        <Button asChild variant="default" size="sm" data-testid="public-make-your-own">
+          <Link to="/login" search={{ signup: true, return_to: "/new" }}>
+            {isMobile ? "Make yours" : "Make your own"}
+          </Link>
+        </Button>
+        <Button
+          asChild
+          variant="ghost"
+          size="sm"
+          data-testid="public-sign-in"
+          className="max-sm:sr-only"
+        >
+          <Link to="/login" search={{ return_to: returnTo }}>
+            Sign in
+          </Link>
+        </Button>
+      </header>
+
+      {/* The render is the hero — it owns the rest of the height. */}
+      <div className="relative flex min-h-0 flex-1 flex-col">{children}</div>
+
+      {/* A quiet, permanent brand mark (the "Made in Framer" idiom — attribution +
+          a soft nudge, never a wall). */}
+      <footer className="flex shrink-0 items-center justify-center gap-1.5 border-t border-border-soft py-1.5 font-mono text-2xs text-muted-foreground">
+        <Logo size={12} />
+        Made with Derive
+      </footer>
+    </div>
+  )
+}

--- a/apps/web/src/pages/artifact/rail-deck.tsx
+++ b/apps/web/src/pages/artifact/rail-deck.tsx
@@ -77,12 +77,21 @@ const presenceTint = (self: boolean) =>
 // wildcard-CORS SSE), so nothing here is spoofable or leaky. Hidden when you're
 // the only viewer. Built on the shared Popover, so it dismisses on outside/iframe
 // click.
-export function Presence({ viewers, selfId }: { viewers: Viewer[]; selfId?: string }) {
+export function Presence({
+  viewers,
+  selfId,
+  compact,
+}: {
+  viewers: Viewer[]
+  selfId?: string
+  /** Tight header (mobile): fewer avatars + a count only, no "viewing" word. */
+  compact?: boolean
+}) {
   const self = viewers.find((v) => v.id === selfId) ?? null
   const others = viewers.filter((v) => v.id !== selfId)
   if (others.length === 0) return null
   const ordered = self ? [self, ...others] : others
-  const shown = ordered.slice(0, 4)
+  const shown = ordered.slice(0, compact ? 3 : 4)
   const extra = ordered.length - shown.length
   return (
     <Popover>
@@ -107,7 +116,8 @@ export function Presence({ viewers, selfId }: { viewers: Viewer[]; selfId?: stri
           </AvatarGroup>
           <span className="flex items-center gap-1 font-mono text-2xs tabular-nums text-muted-foreground">
             <span className="size-1.5 rounded-full bg-muted-foreground" />
-            {ordered.length} viewing{extra > 0 ? ` (+${extra})` : ""}
+            {ordered.length}
+            {compact ? "" : ` viewing${extra > 0 ? ` (+${extra})` : ""}`}
           </span>
         </Button>
       </PopoverTrigger>

--- a/apps/web/src/pages/artifact/render-stage.tsx
+++ b/apps/web/src/pages/artifact/render-stage.tsx
@@ -161,16 +161,22 @@ export function RenderStage({
               className="max-w-sm"
               action={
                 <Button variant="outline" data-testid="render-retry" onClick={retry}>
-                  Retry
+                  Try again
                 </Button>
               }
             />
           </div>
         )}
 
-        {/* Soft "updated in place" cue after a new version auto-swaps in. */}
+        {/* Soft "updated in place" cue after a new version auto-swaps in. Announced
+            politely so a screen-reader viewer hears the swap too — matching the boot
+            state's live region (the render's own status must be legible, not silent). */}
         {updatedTo != null && (
-          <div className="pointer-events-none absolute inset-x-0 top-3 z-10 flex justify-center">
+          <div
+            role="status"
+            aria-live="polite"
+            className="pointer-events-none absolute inset-x-0 top-3 z-10 flex justify-center"
+          >
             <span className="animate-in fade-in slide-in-from-top-1 rounded-full bg-card px-3 py-1 font-mono text-2xs text-muted-foreground shadow-[var(--shadow)] ring-1 ring-foreground/10">
               Updated · v{updatedTo}
             </span>

--- a/apps/web/src/pages/artifact/render-stage.tsx
+++ b/apps/web/src/pages/artifact/render-stage.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type RefObject, useEffect, useState } from "react"
+import { type ReactNode, type RefObject, useEffect, useRef, useState } from "react"
 import { Icon } from "@/components/icons"
 import { Spinner } from "@/components/shared/spinner"
 import { StatusPanel } from "@/components/shared/status-panel"
@@ -34,6 +34,7 @@ export const MAT_GAP_PX = 12
 export function RenderStage({
   rawSrc,
   title,
+  version,
   frameRef,
   wrapRef,
   onFrameLoad,
@@ -44,6 +45,9 @@ export function RenderStage({
 }: {
   rawSrc: string
   title: string
+  /** The shown version — when it steps UP (a new version published in place), a
+   *  soft "Updated" badge flashes over the render (research: auto-swap + soft cue). */
+  version?: number
   frameRef: RefObject<HTMLIFrameElement | null>
   /** The fullscreen/present target — the mat itself. */
   wrapRef: RefObject<HTMLDivElement | null>
@@ -79,6 +83,22 @@ export function RenderStage({
     setPhase("booting")
     setAttempt((n) => n + 1)
   }
+
+  // "Updated" cue: when the shown version steps up (a peer published a new version
+  // and the render auto-swapped in place), flash a soft, non-blocking badge instead
+  // of jolting the viewer (research: soft cue, never a modal). Skips the initial
+  // mount and any backward navigation (viewing an earlier version).
+  const prevVersion = useRef<number | undefined>(undefined)
+  const [updatedTo, setUpdatedTo] = useState<number | null>(null)
+  useEffect(() => {
+    if (version == null) return
+    const prev = prevVersion.current
+    prevVersion.current = version
+    if (prev == null || version <= prev) return
+    setUpdatedTo(version)
+    const t = setTimeout(() => setUpdatedTo(null), 3500)
+    return () => clearTimeout(t)
+  }, [version])
 
   return (
     <div
@@ -145,6 +165,15 @@ export function RenderStage({
                 </Button>
               }
             />
+          </div>
+        )}
+
+        {/* Soft "updated in place" cue after a new version auto-swaps in. */}
+        {updatedTo != null && (
+          <div className="pointer-events-none absolute inset-x-0 top-3 z-10 flex justify-center">
+            <span className="animate-in fade-in slide-in-from-top-1 rounded-full bg-card px-3 py-1 font-mono text-2xs text-muted-foreground shadow-[var(--shadow)] ring-1 ring-foreground/10">
+              Updated · v{updatedTo}
+            </span>
           </div>
         )}
 

--- a/apps/web/src/pages/artifact/render-stage.tsx
+++ b/apps/web/src/pages/artifact/render-stage.tsx
@@ -12,6 +12,13 @@ import { cn } from "@/lib/utils"
 // must be legible, not indistinguishable from "still loading").
 const BOOT_TIMEOUT_MS = 15_000
 
+// The desktop mat gap around the framed render (must match the `sm:p-3` below —
+// p-3 = 0.75rem = 12px). Exported so the comment margin can compensate: pins live
+// in the aside and anchor to the render's top, so shifting the render down by the
+// mat gap would misalign them by exactly this much unless the pinned zone accounts
+// for it (see comment-panels OpenPanel → PinnedZone topInset).
+export const MAT_GAP_PX = 12
+
 /**
  * The render stage — the artifact is the hero, framed as a matted object floating
  * on the workbench canvas (research: "the render is the hero; full-bleed inside a

--- a/apps/web/src/pages/artifact/render-stage.tsx
+++ b/apps/web/src/pages/artifact/render-stage.tsx
@@ -12,24 +12,17 @@ import { cn } from "@/lib/utils"
 // must be legible, not indistinguishable from "still loading").
 const BOOT_TIMEOUT_MS = 15_000
 
-// The desktop mat gap around the framed render (must match the `sm:p-3` below —
-// p-3 = 0.75rem = 12px). Exported so the comment margin can compensate: pins live
-// in the aside and anchor to the render's top, so shifting the render down by the
-// mat gap would misalign them by exactly this much unless the pinned zone accounts
-// for it (see comment-panels OpenPanel → PinnedZone topInset).
-export const MAT_GAP_PX = 12
-
 /**
- * The render stage — the artifact is the hero, framed as a matted object floating
- * on the workbench canvas (research: "the render is the hero; full-bleed inside a
- * matted panel"). The panel is a rounded, hairline-outlined white surface
- * (`outline-foreground/10`, no border — the images rule) with a soft shadow in
- * light / just the surface step + outline in dark. Boot and failure are explicit
- * states rendered INSIDE the mat so the frame's geometry never jumps.
+ * The render stage — the artifact is the hero. The sandboxed iframe fills the stage
+ * edge-to-edge (research: "the render is the hero; the iframe fills the panel
+ * edge-to-edge, zero internal padding"), framed by the workbench header above it and
+ * clipped to the content card's rounded corners (the shell's SidebarInset is
+ * `overflow-hidden rounded-xl`). NO mat gap: an artifact carries its own background,
+ * which can be any color, so a gap would frame a dark artifact in an awkward light
+ * border. Boot + failure are explicit states rendered inside so geometry never jumps.
  *
  * The frame/wrapper refs are owned by the page (the postMessage bridge + fullscreen
- * drive them) and passed in. `overlays` (deck bar, cursor layer, past-version
- * banner) mount inside the mat in later phases.
+ * drive them) and passed in. `overlays` (deck bar, cursor layer) mount inside.
  */
 export function RenderStage({
   rawSrc,
@@ -40,7 +33,6 @@ export function RenderStage({
   onFrameLoad,
   banner,
   overlays,
-  bare,
   className,
 }: {
   rawSrc: string
@@ -49,16 +41,14 @@ export function RenderStage({
    *  soft "Updated" badge flashes over the render (research: auto-swap + soft cue). */
   version?: number
   frameRef: RefObject<HTMLIFrameElement | null>
-  /** The fullscreen/present target — the mat itself. */
+  /** The fullscreen/present target — the render surface itself. */
   wrapRef: RefObject<HTMLDivElement | null>
   /** Called on the iframe's own `load` (the page's bridge handshakes off it). */
   onFrameLoad?: () => void
   /** A strip above the render (the past-version banner). */
   banner?: ReactNode
-  /** Absolutely-positioned children inside the mat (deck bar, cursor overlay). */
+  /** Absolutely-positioned children inside the render (deck bar, cursor overlay). */
   overlays?: ReactNode
-  /** Full-bleed, no mat gap (mobile / focus mode want max render area). */
-  bare?: boolean
   className?: string
 }) {
   // Boot/failure state is per-source: a new rawSrc (version swap, retry) resets it.
@@ -101,25 +91,12 @@ export function RenderStage({
   }, [version])
 
   return (
-    <div
-      className={cn(
-        "relative flex min-h-0 flex-1 flex-col",
-        // The mat gap: the framed render floats on the workbench canvas on desktop;
-        // full-bleed on phones / focus mode where every pixel of render counts.
-        bare ? "p-0" : "p-0 sm:p-3",
-        className,
-      )}
-    >
+    <div className={cn("relative flex min-h-0 flex-1 flex-col", className)}>
       {banner}
-      <div
-        ref={wrapRef}
-        className={cn(
-          "relative flex min-h-0 flex-1 flex-col overflow-hidden bg-white outline-1 -outline-offset-1 outline-foreground/10",
-          // Framed as a matted object off the canvas; dark drops the shadow (the
-          // surface step + outline carry it), matching the elevation rules.
-          bare ? "rounded-none outline-0" : "rounded-xl shadow-[var(--shadow)]",
-        )}
-      >
+      {/* The render fills edge-to-edge; the content card's rounded overflow-hidden
+          clips it, and the header above carries its top edge. bg-white is the
+          backdrop the boot state paints on before the iframe takes over. */}
+      <div ref={wrapRef} className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-white">
         <iframe
           key={attempt}
           ref={frameRef}

--- a/apps/web/src/pages/artifact/render-stage.tsx
+++ b/apps/web/src/pages/artifact/render-stage.tsx
@@ -1,0 +1,148 @@
+import { type ReactNode, type RefObject, useEffect, useState } from "react"
+import { Icon } from "@/components/icons"
+import { Spinner } from "@/components/shared/spinner"
+import { StatusPanel } from "@/components/shared/status-panel"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+// How long we wait for the sandboxed render to fire `load` before calling it a
+// failed boot. A cache-warm artifact paints in well under a second; this only
+// catches a genuinely stuck/broken render so the viewer never stares at a blank
+// white frame (NN/g #1 — visibility of system status; the render's own failure
+// must be legible, not indistinguishable from "still loading").
+const BOOT_TIMEOUT_MS = 15_000
+
+/**
+ * The render stage — the artifact is the hero, framed as a matted object floating
+ * on the workbench canvas (research: "the render is the hero; full-bleed inside a
+ * matted panel"). The panel is a rounded, hairline-outlined white surface
+ * (`outline-foreground/10`, no border — the images rule) with a soft shadow in
+ * light / just the surface step + outline in dark. Boot and failure are explicit
+ * states rendered INSIDE the mat so the frame's geometry never jumps.
+ *
+ * The frame/wrapper refs are owned by the page (the postMessage bridge + fullscreen
+ * drive them) and passed in. `overlays` (deck bar, cursor layer, past-version
+ * banner) mount inside the mat in later phases.
+ */
+export function RenderStage({
+  rawSrc,
+  title,
+  frameRef,
+  wrapRef,
+  onFrameLoad,
+  banner,
+  overlays,
+  bare,
+  className,
+}: {
+  rawSrc: string
+  title: string
+  frameRef: RefObject<HTMLIFrameElement | null>
+  /** The fullscreen/present target — the mat itself. */
+  wrapRef: RefObject<HTMLDivElement | null>
+  /** Called on the iframe's own `load` (the page's bridge handshakes off it). */
+  onFrameLoad?: () => void
+  /** A strip above the render (the past-version banner). */
+  banner?: ReactNode
+  /** Absolutely-positioned children inside the mat (deck bar, cursor overlay). */
+  overlays?: ReactNode
+  /** Full-bleed, no mat gap (mobile / focus mode want max render area). */
+  bare?: boolean
+  className?: string
+}) {
+  // Boot/failure state is per-source: a new rawSrc (version swap, retry) resets it.
+  const [phase, setPhase] = useState<"booting" | "ready" | "failed">("booting")
+  const [attempt, setAttempt] = useState(0)
+  useEffect(() => {
+    setPhase("booting")
+  }, [])
+
+  // Arm the stuck-boot timeout while booting; clear it the moment the frame loads.
+  useEffect(() => {
+    if (phase !== "booting") return
+    const t = setTimeout(() => setPhase("failed"), BOOT_TIMEOUT_MS)
+    return () => clearTimeout(t)
+  }, [phase])
+
+  const handleLoad = () => {
+    setPhase("ready")
+    onFrameLoad?.()
+  }
+  const retry = () => {
+    setPhase("booting")
+    setAttempt((n) => n + 1)
+  }
+
+  return (
+    <div
+      className={cn(
+        "relative flex min-h-0 flex-1 flex-col",
+        // The mat gap: the framed render floats on the workbench canvas on desktop;
+        // full-bleed on phones / focus mode where every pixel of render counts.
+        bare ? "p-0" : "p-0 sm:p-3",
+        className,
+      )}
+    >
+      {banner}
+      <div
+        ref={wrapRef}
+        className={cn(
+          "relative flex min-h-0 flex-1 flex-col overflow-hidden bg-white outline-1 -outline-offset-1 outline-foreground/10",
+          // Framed as a matted object off the canvas; dark drops the shadow (the
+          // surface step + outline carry it), matching the elevation rules.
+          bare ? "rounded-none outline-0" : "rounded-xl shadow-[var(--shadow)]",
+        )}
+      >
+        <iframe
+          key={attempt}
+          ref={frameRef}
+          onLoad={handleLoad}
+          title={title}
+          src={rawSrc}
+          allow="fullscreen"
+          // touch-action: pan-y lets the outer page scroll instead of the iframe
+          // trapping the gesture on a phone (research's scroll-trap fix); the frame
+          // opts into its own pan only inside an explicit zoom mode.
+          sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
+          className="min-h-0 flex-1 touch-pan-y border-0 bg-white"
+        />
+
+        {/* Boot — a calm centered spinner over the white canvas until the render's
+            own `load` fires. Announced politely; not a full skeleton because the
+            artifact's shape is unknowable. */}
+        {phase === "booting" && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="absolute inset-0 grid place-items-center bg-white"
+          >
+            <div className="flex flex-col items-center gap-3">
+              <Spinner />
+              <span className="font-mono text-2xs text-muted-foreground">Loading preview…</span>
+            </div>
+          </div>
+        )}
+
+        {/* Failure — an explicit terminal state with Retry, never a blank frame. */}
+        {phase === "failed" && (
+          <div className="absolute inset-0 grid place-items-center bg-background p-6">
+            <StatusPanel
+              tone="danger"
+              icon={<Icon name="removed" strokeWidth={1.75} />}
+              title="Preview didn’t load"
+              description="The render took too long or failed to start. This is usually temporary."
+              className="max-w-sm"
+              action={
+                <Button variant="outline" data-testid="render-retry" onClick={retry}>
+                  Retry
+                </Button>
+              }
+            />
+          </div>
+        )}
+
+        {overlays}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -39,19 +39,23 @@ import { LibrarySkeleton } from "./library-skeleton"
 import { PublishCard } from "./publish-card"
 import { RepoPullRequests } from "./repo-pull-requests"
 import { ShareCollectionDialog } from "./share-collection-dialog"
-import type { Filter } from "./types"
+import type { Filter, LibrarySearch, LibraryView } from "./types"
 
-// Route component for "/". The persistent AppShell (mounted once around the
-// router Outlet) owns the rail/pod and the auth gate, so this just renders the
-// library body. The filter lives in the URL, so the body reads it from search
-// rather than local state.
-export function Library() {
-  return <LibraryBody />
+// The library surface, shared by three routes: "/" (all artifacts), "/favorites",
+// and "/following". The base feed comes from the route (the `view` prop); the
+// filters + search come from the URL query. The persistent AppShell (mounted once
+// around the router Outlet) owns the rail/pod and the auth gate, so this just
+// renders the library body.
+export function Library({ view }: { view: LibraryView }) {
+  return <LibraryBody view={view} />
 }
 
-function LibraryBody() {
+function LibraryBody({ view }: { view: LibraryView }) {
   const nav = useNavigate()
-  const search = useSearch({ from: "/" })
+  // Read the query params loosely: this one body renders under three routes, so it
+  // can't bind to a single route's search shape. The base feed is `view` (the route);
+  // tag/collection/q/author are the filters that compose on top (docs/decisions/0002).
+  const search = useSearch({ strict: false }) as LibrarySearch
   const { me } = useAuth()
   const { summary, collections, refreshSummary } = useShell()
   const prefetch = usePrefetchArtifact()
@@ -60,8 +64,8 @@ function LibraryBody() {
   const scrollRef = useRef<HTMLDivElement>(null)
 
   const [shareCol, setShareCol] = useState<(typeof collections)[number] | null>(null)
-  const [query, setQuery] = useState(search.q ?? "")
-  const [debouncedQ, setDebouncedQ] = useState((search.q ?? "").trim())
+  const [query, setQuery] = useState(search.query ?? "")
+  const [debouncedQ, setDebouncedQ] = useState((search.query ?? "").trim())
   // Folder vs flat-list view (synced collections). Off by default (a flat,
   // most-recently-updated list is the default for a synced collection); remembered.
   const [showFolders, setShowFolders] = useState(
@@ -73,11 +77,13 @@ function LibraryBody() {
     localStorage.setItem(STORAGE_KEYS.libraryFolders, on ? "1" : "0")
   }
 
-  // Derive the active filter from the URL search params.
+  // The active filter = the base feed (from the route: `view`) unless it's the home
+  // library, where a tag/collection query param narrows it. Favorites/Following are
+  // their own routes now, so tag/collection (which live only on "/") can't apply.
   const filter: Filter =
-    search.f === "favorites"
+    view === "favorites"
       ? { kind: "favorites" }
-      : search.scope === "following"
+      : view === "following"
         ? { kind: "following" }
         : search.tag
           ? { kind: "tag", tag: search.tag }
@@ -100,9 +106,9 @@ function LibraryBody() {
     q: debouncedQ || undefined,
     tag: search.tag,
     collection: search.collection,
-    favorite: search.f === "favorites" || undefined,
+    favorite: view === "favorites" || undefined,
     author: search.author,
-    scope: filter.kind === "following" ? "following" : undefined,
+    scope: view === "following" ? "following" : undefined,
   }
   const listQuery = libraryArtifactsQuery(params)
   const { data, isPending, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
@@ -390,22 +396,17 @@ function LibraryBody() {
           hotkey
           className="min-w-50 flex-1"
         />
-        {filter.kind !== "all" && (
+        {/* The clear-filter pill is for the home library's filters (a tag or a
+            collection) — a way back to All. Favorites/Following are their own routes
+            (with their own active rail rows), not filters you "clear" here. */}
+        {(filter.kind === "tag" || filter.kind === "collection") && (
           <Button
             variant="outline"
             size="sm"
             data-testid="library-clear-filter"
             onClick={() => nav({ to: "/", search: {} })}
           >
-            {filter.kind === "favorites" ? (
-              <>
-                <Icon name="favorites" size={16} /> Favorites
-              </>
-            ) : filter.kind === "following" ? (
-              <>
-                <Icon name="following" size={16} /> Following
-              </>
-            ) : filter.kind === "tag" ? (
+            {filter.kind === "tag" ? (
               `#${filter.tag}`
             ) : (
               <>
@@ -479,7 +480,7 @@ function LibraryBody() {
               <ArtifactCard
                 key={a.short_id}
                 artifact={a}
-                onOpen={() => nav({ to: "/a/$ref", params: { ref: refFor(a) } })}
+                onOpen={() => nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })}
                 onToggleFavorite={() => openFeedback(a)}
                 onPickTag={(tag) => nav({ to: "/", search: { tag } })}
                 onPrefetch={() => prefetch(a.short_id, a.current_version)}
@@ -499,7 +500,7 @@ function LibraryBody() {
               <ArtifactCard
                 key={a.short_id}
                 artifact={a}
-                onOpen={() => nav({ to: "/a/$ref", params: { ref: refFor(a) } })}
+                onOpen={() => nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })}
                 onToggleFavorite={() => openShared(a)}
                 onPickTag={(tag) => nav({ to: "/", search: { tag } })}
                 onPrefetch={() => prefetch(a.short_id, a.current_version)}
@@ -586,7 +587,7 @@ function LibraryBody() {
               hasNextPage={!!hasNextPage}
               isFetchingNextPage={isFetchingNextPage}
               onLoadMore={() => fetchNextPage()}
-              onOpen={(a) => nav({ to: "/a/$ref", params: { ref: refFor(a) } })}
+              onOpen={(a) => nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })}
               onToggleFavorite={toggleFav}
               onPickTag={(tag) => nav({ to: "/", search: { tag } })}
               onPickAuthor={pickAuthor}
@@ -598,7 +599,7 @@ function LibraryBody() {
                 <ArtifactRow
                   key={a.short_id}
                   artifact={a}
-                  onOpen={() => nav({ to: "/a/$ref", params: { ref: refFor(a) } })}
+                  onOpen={() => nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })}
                   onToggleFavorite={() => toggleFav(a)}
                   onPickTag={(tag) => nav({ to: "/", search: { tag } })}
                   onPickAuthor={pickAuthor}
@@ -622,7 +623,7 @@ function LibraryBody() {
             hasNextPage={!!hasNextPage}
             isFetchingNextPage={isFetchingNextPage}
             onLoadMore={() => fetchNextPage()}
-            onOpen={(a) => nav({ to: "/a/$ref", params: { ref: refFor(a) } })}
+            onOpen={(a) => nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })}
             onToggleFavorite={toggleFav}
             onPickTag={(tag) => nav({ to: "/", search: { tag } })}
             onDelete={setPendingDelete}

--- a/apps/web/src/pages/library/publish-card.tsx
+++ b/apps/web/src/pages/library/publish-card.tsx
@@ -38,7 +38,7 @@ export function PublishCard() {
     setBusy(true)
     try {
       const a = await api.publish(f, { title: f.name.replace(/\.[^.]+$/, ""), visibility: "org" })
-      nav({ to: "/a/$ref", params: { ref: refFor(a) } })
+      nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })
     } catch (e) {
       toast.error((e as Error).message)
       setBusy(false)

--- a/apps/web/src/pages/library/types.ts
+++ b/apps/web/src/pages/library/types.ts
@@ -18,16 +18,21 @@ export type Summary = {
   workspace: string
 }
 
-// The library filter, encoded in the URL so the persistent nav rail can navigate
-// to a view (Favorites / a tag / a collection) from any page and so a filtered
-// library is shareable and survives reload. `q` is the free-text search.
+// The base library feed, chosen by ROUTE (path), not a query param: "/" = all,
+// "/favorites", "/following". Path = the feed you're viewing; query (LibrarySearch)
+// = how it's filtered. See routes/favorites.tsx + docs/decisions/0002.
+export type LibraryView = "all" | "favorites" | "following"
+
+// The library's URL-encoded filters + search (query params on the home route), so
+// the persistent nav rail can drive them from any page and a filtered/searched
+// library is shareable and survives reload. These compose ON TOP of the base view
+// (a tag within all, a search within favorites). The named feeds themselves are
+// routes, not params — see LibraryView.
 export type LibrarySearch = {
-  f?: "favorites"
-  // "following" → the activity feed (followed authors + repo path prefixes).
-  scope?: "following"
   tag?: string
   collection?: string
-  q?: string
+  // Free-text title search; composes with any view.
+  query?: string
   // Narrow to artifacts last changed by this GitHub login (synced collections).
   author?: string
 }

--- a/apps/web/src/pages/new.tsx
+++ b/apps/web/src/pages/new.tsx
@@ -44,7 +44,7 @@ export function NewArtifact() {
       const fields: Record<string, string> = { title: name, visibility: "org" }
       if (message.trim()) fields.message = message.trim()
       const a = await api.publish(new File([src], `inline.${ext}`, { type }), fields)
-      nav({ to: "/a/$ref", params: { ref: refFor(a) } })
+      nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })
     } catch (e) {
       toast.error((e as Error).message)
     }

--- a/apps/web/src/pages/people.tsx
+++ b/apps/web/src/pages/people.tsx
@@ -111,7 +111,7 @@ function PersonCard({ person: p }: { person: PublicProfile }) {
     // target, so the hover edge-brighten sits on a genuinely clickable surface.
     <li className="relative flex items-center gap-3 rounded-xl border bg-card p-3 hover:border-foreground/25">
       <Link
-        to="/u/$handle"
+        to="/users/$handle"
         params={{ handle: p.username }}
         data-testid={`people-card-${p.username}`}
         className="flex min-w-0 flex-1 items-center gap-3 rounded-lg outline-none after:absolute after:inset-0 after:rounded-xl focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"

--- a/apps/web/src/pages/profile-work-card.tsx
+++ b/apps/web/src/pages/profile-work-card.tsx
@@ -14,7 +14,7 @@ export function ProfileWorkCard({ artifact: a }: { artifact: Artifact }) {
   const updated = a.updated_at ?? a.created_at ?? a.versions[0]?.created_at
   return (
     <Link
-      to="/a/$ref"
+      to="/artifacts/$ref"
       params={{ ref: refFor(a) }}
       data-testid={`profile-work-${a.short_id}`}
       // Interactive card, mirroring the library card exactly: a resting soft shadow

--- a/apps/web/src/pages/profile.tsx
+++ b/apps/web/src/pages/profile.tsx
@@ -26,7 +26,7 @@ import { profileArtifactsQuery, profileQuery } from "@/lib/queries"
 import { CardGrid } from "./library/card-grid"
 import { ProfileWorkCard } from "./profile-work-card"
 
-const route = getRouteApi("/u/$handle")
+const route = getRouteApi("/users/$handle")
 
 // The rich public profile: an identity card (avatar, name, @handle, role, bio, GitHub
 // link), a stats row (works / followers / following), a Follow button, and a grid of
@@ -187,7 +187,7 @@ export function Profile() {
                       onClaimed={(username) => {
                         setMe(me ? { ...me, username } : me)
                         setEditing(false)
-                        nav({ to: "/u/$handle", params: { handle: username } })
+                        nav({ to: "/users/$handle", params: { handle: username } })
                       }}
                     />
                   </div>
@@ -267,7 +267,7 @@ function PeopleStat({
             {people.map((p) => (
               <li key={p.username}>
                 <Link
-                  to="/u/$handle"
+                  to="/users/$handle"
                   params={{ handle: p.username }}
                   onClick={() => setOpen(false)}
                   className="flex items-center gap-3 rounded-md p-2 outline-none hover:bg-secondary focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring"

--- a/apps/web/src/pages/settings/index.tsx
+++ b/apps/web/src/pages/settings/index.tsx
@@ -17,21 +17,22 @@ import { ReportsSection } from "./reports-section"
 import { SettingsNav, type SettingsNavGroup } from "./settings-nav"
 import { WebhooksSection } from "./webhooks-section"
 
-// The route owns the typed `?tab=` search; getRouteApi avoids a circular import
-// back to routes/settings.tsx while still giving typed useSearch/useNavigate.
-const route = getRouteApi("/settings")
+// The active section rides the URL path (/settings/$section); getRouteApi avoids a
+// circular import back to routes/settings.$section.tsx while still giving typed
+// useParams/useNavigate.
+const route = getRouteApi("/settings/$section")
 
 // Settings, reconceived as a scope-grouped two-pane: a sticky category rail
 // (Account · Workspace · Developer · Moderation) beside a readable detail column,
-// reflowing to a horizontal strip on a narrow pane. The active section rides the
-// URL's `?tab=` (deep-linkable, back-button-friendly) rather than the old local
-// window.location hack — and the GitHub App install still lands on
-// `/settings?tab=github&gh_install=…` unchanged. AppShell gates auth, so `me` is
-// present whenever Settings renders.
+// reflowing to a horizontal strip on a narrow pane. The active section is a path
+// segment (/settings/$section) — deep-linkable, back-button-friendly, and a peer of
+// the server's own /settings/github/app/* pages — and the GitHub App install lands on
+// `/settings/github?gh_install=…`. AppShell gates auth, so `me` is present whenever
+// Settings renders.
 export function Settings() {
   const { me } = useAuth()
   const [reports, setReports] = useState<Report[] | null>(null)
-  const { tab } = route.useSearch()
+  const { section } = route.useParams()
   const nav = route.useNavigate()
 
   const loadReports = useCallback(
@@ -96,11 +97,12 @@ export function Settings() {
     })
   }
 
-  // Guard the `?tab=` against unknown/stale values (e.g. `reports` after the last
-  // report clears) — fall back to Profile so the pane never strands blank.
+  // Guard the `$section` against unknown/stale values (e.g. `reports` after the last
+  // report clears, or a hand-typed path) — fall back to Profile so the pane never
+  // strands blank.
   const ids = groups.flatMap((g) => g.items.map((i) => i.id))
-  const active = tab && ids.includes(tab) ? tab : "profile"
-  const select = (id: string) => nav({ search: (prev) => ({ ...prev, tab: id }) })
+  const active = ids.includes(section) ? section : "profile"
+  const select = (id: string) => nav({ to: "/settings/$section", params: { section: id } })
 
   return (
     <PageShell width="wide">

--- a/apps/web/src/pages/settings/reports-section.tsx
+++ b/apps/web/src/pages/settings/reports-section.tsx
@@ -57,7 +57,7 @@ function ReportRow({
         <div className="text-sm font-medium text-foreground">
           {report.reason}{" "}
           <a
-            href={`/a/${report.artifact_short_id}`}
+            href={`/artifacts/${report.artifact_short_id}`}
             className="font-mono text-2xs font-medium text-primary"
           >
             {report.artifact_short_id}

--- a/apps/web/src/pages/settings/settings-nav.tsx
+++ b/apps/web/src/pages/settings/settings-nav.tsx
@@ -3,7 +3,7 @@ import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { cn } from "@/lib/utils"
 
 export type SettingsNavItem = {
-  /** The section id — mirrors the `?tab=` value. */
+  /** The section id — mirrors the `/settings/$section` path value. */
   id: string
   label: string
   testId: string

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -15,9 +15,13 @@ import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as PeopleRouteImport } from './routes/people'
 import { Route as NewRouteImport } from './routes/new'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as FollowingRouteImport } from './routes/following'
+import { Route as FavoritesRouteImport } from './routes/favorites'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as UHandleRouteImport } from './routes/u.$handle'
-import { Route as ARefRouteImport } from './routes/a.$ref'
+import { Route as SettingsIndexRouteImport } from './routes/settings.index'
+import { Route as UsersHandleRouteImport } from './routes/users.$handle'
+import { Route as SettingsSectionRouteImport } from './routes/settings.$section'
+import { Route as ArtifactsRefRouteImport } from './routes/artifacts.$ref'
 
 const WelcomeRoute = WelcomeRouteImport.update({
   id: '/welcome',
@@ -49,102 +53,146 @@ const LoginRoute = LoginRouteImport.update({
   path: '/login',
   getParentRoute: () => rootRouteImport,
 } as any)
+const FollowingRoute = FollowingRouteImport.update({
+  id: '/following',
+  path: '/following',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FavoritesRoute = FavoritesRouteImport.update({
+  id: '/favorites',
+  path: '/favorites',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const UHandleRoute = UHandleRouteImport.update({
-  id: '/u/$handle',
-  path: '/u/$handle',
+const SettingsIndexRoute = SettingsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => SettingsRoute,
+} as any)
+const UsersHandleRoute = UsersHandleRouteImport.update({
+  id: '/users/$handle',
+  path: '/users/$handle',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ARefRoute = ARefRouteImport.update({
-  id: '/a/$ref',
-  path: '/a/$ref',
+const SettingsSectionRoute = SettingsSectionRouteImport.update({
+  id: '/$section',
+  path: '/$section',
+  getParentRoute: () => SettingsRoute,
+} as any)
+const ArtifactsRefRoute = ArtifactsRefRouteImport.update({
+  id: '/artifacts/$ref',
+  path: '/artifacts/$ref',
   getParentRoute: () => rootRouteImport,
 } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/favorites': typeof FavoritesRoute
+  '/following': typeof FollowingRoute
   '/login': typeof LoginRoute
   '/new': typeof NewRoute
   '/people': typeof PeopleRoute
-  '/settings': typeof SettingsRoute
+  '/settings': typeof SettingsRouteWithChildren
   '/showcase': typeof ShowcaseRoute
   '/welcome': typeof WelcomeRoute
-  '/a/$ref': typeof ARefRoute
-  '/u/$handle': typeof UHandleRoute
+  '/artifacts/$ref': typeof ArtifactsRefRoute
+  '/settings/$section': typeof SettingsSectionRoute
+  '/users/$handle': typeof UsersHandleRoute
+  '/settings/': typeof SettingsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/favorites': typeof FavoritesRoute
+  '/following': typeof FollowingRoute
   '/login': typeof LoginRoute
   '/new': typeof NewRoute
   '/people': typeof PeopleRoute
-  '/settings': typeof SettingsRoute
   '/showcase': typeof ShowcaseRoute
   '/welcome': typeof WelcomeRoute
-  '/a/$ref': typeof ARefRoute
-  '/u/$handle': typeof UHandleRoute
+  '/artifacts/$ref': typeof ArtifactsRefRoute
+  '/settings/$section': typeof SettingsSectionRoute
+  '/users/$handle': typeof UsersHandleRoute
+  '/settings': typeof SettingsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/favorites': typeof FavoritesRoute
+  '/following': typeof FollowingRoute
   '/login': typeof LoginRoute
   '/new': typeof NewRoute
   '/people': typeof PeopleRoute
-  '/settings': typeof SettingsRoute
+  '/settings': typeof SettingsRouteWithChildren
   '/showcase': typeof ShowcaseRoute
   '/welcome': typeof WelcomeRoute
-  '/a/$ref': typeof ARefRoute
-  '/u/$handle': typeof UHandleRoute
+  '/artifacts/$ref': typeof ArtifactsRefRoute
+  '/settings/$section': typeof SettingsSectionRoute
+  '/users/$handle': typeof UsersHandleRoute
+  '/settings/': typeof SettingsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/favorites'
+    | '/following'
     | '/login'
     | '/new'
     | '/people'
     | '/settings'
     | '/showcase'
     | '/welcome'
-    | '/a/$ref'
-    | '/u/$handle'
+    | '/artifacts/$ref'
+    | '/settings/$section'
+    | '/users/$handle'
+    | '/settings/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/favorites'
+    | '/following'
     | '/login'
     | '/new'
     | '/people'
-    | '/settings'
     | '/showcase'
     | '/welcome'
-    | '/a/$ref'
-    | '/u/$handle'
+    | '/artifacts/$ref'
+    | '/settings/$section'
+    | '/users/$handle'
+    | '/settings'
   id:
     | '__root__'
     | '/'
+    | '/favorites'
+    | '/following'
     | '/login'
     | '/new'
     | '/people'
     | '/settings'
     | '/showcase'
     | '/welcome'
-    | '/a/$ref'
-    | '/u/$handle'
+    | '/artifacts/$ref'
+    | '/settings/$section'
+    | '/users/$handle'
+    | '/settings/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  FavoritesRoute: typeof FavoritesRoute
+  FollowingRoute: typeof FollowingRoute
   LoginRoute: typeof LoginRoute
   NewRoute: typeof NewRoute
   PeopleRoute: typeof PeopleRoute
-  SettingsRoute: typeof SettingsRoute
+  SettingsRoute: typeof SettingsRouteWithChildren
   ShowcaseRoute: typeof ShowcaseRoute
   WelcomeRoute: typeof WelcomeRoute
-  ARefRoute: typeof ARefRoute
-  UHandleRoute: typeof UHandleRoute
+  ArtifactsRefRoute: typeof ArtifactsRefRoute
+  UsersHandleRoute: typeof UsersHandleRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -191,6 +239,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LoginRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/following': {
+      id: '/following'
+      path: '/following'
+      fullPath: '/following'
+      preLoaderRoute: typeof FollowingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/favorites': {
+      id: '/favorites'
+      path: '/favorites'
+      fullPath: '/favorites'
+      preLoaderRoute: typeof FavoritesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -198,33 +260,63 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/u/$handle': {
-      id: '/u/$handle'
-      path: '/u/$handle'
-      fullPath: '/u/$handle'
-      preLoaderRoute: typeof UHandleRouteImport
+    '/settings/': {
+      id: '/settings/'
+      path: '/'
+      fullPath: '/settings/'
+      preLoaderRoute: typeof SettingsIndexRouteImport
+      parentRoute: typeof SettingsRoute
+    }
+    '/users/$handle': {
+      id: '/users/$handle'
+      path: '/users/$handle'
+      fullPath: '/users/$handle'
+      preLoaderRoute: typeof UsersHandleRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/a/$ref': {
-      id: '/a/$ref'
-      path: '/a/$ref'
-      fullPath: '/a/$ref'
-      preLoaderRoute: typeof ARefRouteImport
+    '/settings/$section': {
+      id: '/settings/$section'
+      path: '/$section'
+      fullPath: '/settings/$section'
+      preLoaderRoute: typeof SettingsSectionRouteImport
+      parentRoute: typeof SettingsRoute
+    }
+    '/artifacts/$ref': {
+      id: '/artifacts/$ref'
+      path: '/artifacts/$ref'
+      fullPath: '/artifacts/$ref'
+      preLoaderRoute: typeof ArtifactsRefRouteImport
       parentRoute: typeof rootRouteImport
     }
   }
 }
 
+interface SettingsRouteChildren {
+  SettingsSectionRoute: typeof SettingsSectionRoute
+  SettingsIndexRoute: typeof SettingsIndexRoute
+}
+
+const SettingsRouteChildren: SettingsRouteChildren = {
+  SettingsSectionRoute: SettingsSectionRoute,
+  SettingsIndexRoute: SettingsIndexRoute,
+}
+
+const SettingsRouteWithChildren = SettingsRoute._addFileChildren(
+  SettingsRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  FavoritesRoute: FavoritesRoute,
+  FollowingRoute: FollowingRoute,
   LoginRoute: LoginRoute,
   NewRoute: NewRoute,
   PeopleRoute: PeopleRoute,
-  SettingsRoute: SettingsRoute,
+  SettingsRoute: SettingsRouteWithChildren,
   ShowcaseRoute: ShowcaseRoute,
   WelcomeRoute: WelcomeRoute,
-  ARefRoute: ARefRoute,
-  UHandleRoute: UHandleRoute,
+  ArtifactsRefRoute: ArtifactsRefRoute,
+  UsersHandleRoute: UsersHandleRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/artifacts.$ref.tsx
+++ b/apps/web/src/routes/artifacts.$ref.tsx
@@ -3,10 +3,10 @@ import { artifactQuery, commentsQuery, prefetchArtifactRaw } from "../lib/querie
 import { Artifact } from "../pages/artifact"
 import { candidateShortIds, parseRef } from "../pages/artifact/parse-ref"
 
-export const Route = createFileRoute("/a/$ref")({
-  // `c` deep-links to a comment thread (opens the panel + focuses its anchor).
-  validateSearch: (s: Record<string, unknown>): { c?: string } =>
-    typeof s.c === "string" ? { c: s.c } : {},
+export const Route = createFileRoute("/artifacts/$ref")({
+  // `comment` deep-links to a comment thread (opens the panel + focuses its anchor).
+  validateSearch: (s: Record<string, unknown>): { comment?: string } =>
+    typeof s.comment === "string" ? { comment: s.comment } : {},
   // Warm the artifact + its comments (and the rendered HTML the iframe loads) so
   // an intent-preloaded link opens instantly. Best-effort: the page owns the
   // auth redirect and the not-found / removed states, so a failed fetch here

--- a/apps/web/src/routes/favorites.tsx
+++ b/apps/web/src/routes/favorites.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Library } from "../pages/library"
+import type { LibrarySearch } from "../pages/library/types"
+
+// The Favorites feed: /favorites — the artifacts you've starred. A fixed, named feed
+// earns its own path (not a ?param on "/"), so it reads as the destination it is:
+// shareable, deep-linkable, and a peer of /following and /people in the rail. Only
+// free-text search (?query=) composes on top; the tag/collection filters belong to the
+// home library, not this feed. Path = the feed you're viewing, query = how it's
+// filtered (docs/decisions/0002).
+export const Route = createFileRoute("/favorites")({
+  validateSearch: (s: Record<string, unknown>): Pick<LibrarySearch, "query"> => ({
+    query: typeof s.query === "string" ? s.query : undefined,
+  }),
+  component: () => <Library view="favorites" />,
+})

--- a/apps/web/src/routes/following.tsx
+++ b/apps/web/src/routes/following.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Library } from "../pages/library"
+import type { LibrarySearch } from "../pages/library/types"
+
+// The Following feed: /following — recent work from the authors and folders you
+// follow (the activity feed the follow graph powers; see lib/use-follows). Like
+// /favorites, a fixed named feed earns its own path; only ?query= search composes on
+// top. Path = the feed you're viewing, query = how it's filtered (docs/decisions/0002).
+export const Route = createFileRoute("/following")({
+  validateSearch: (s: Record<string, unknown>): Pick<LibrarySearch, "query"> => ({
+    query: typeof s.query === "string" ? s.query : undefined,
+  }),
+  component: () => <Library view="following" />,
+})

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -3,15 +3,15 @@ import { Library } from "../pages/library"
 import type { LibrarySearch } from "../pages/library/types"
 
 export const Route = createFileRoute("/")({
-  // Filter + search live in the URL (see LibrarySearch) so the nav rail can drive
-  // them from any page and a filtered/searched library is shareable.
+  // The home library. Its filters + free-text search live in the URL (LibrarySearch)
+  // so the nav rail can drive them from anywhere and a filtered/searched library is
+  // shareable. The named feeds (Favorites, Following) are their OWN routes, not params
+  // here — path = the feed you're viewing, query = how it's filtered (docs/decisions/0002).
   validateSearch: (s: Record<string, unknown>): LibrarySearch => ({
-    f: s.f === "favorites" ? "favorites" : undefined,
-    scope: s.scope === "following" ? "following" : undefined,
     tag: typeof s.tag === "string" ? s.tag : undefined,
     collection: typeof s.collection === "string" ? s.collection : undefined,
-    q: typeof s.q === "string" ? s.q : undefined,
+    query: typeof s.query === "string" ? s.query : undefined,
     author: typeof s.author === "string" ? s.author : undefined,
   }),
-  component: Library,
+  component: () => <Library view="all" />,
 })

--- a/apps/web/src/routes/settings.$section.tsx
+++ b/apps/web/src/routes/settings.$section.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Settings } from "../pages/settings"
+
+// A settings section as a path segment: /settings/$section (profile, members, github…).
+// The transient GitHub-install signals (gh_install / gh_error) still ride as query
+// params — they're a one-shot handshake, not a place — and are read from
+// window.location by the GitHub section. The passthrough validator keeps them from
+// being stripped off the URL before that section consumes them.
+export const Route = createFileRoute("/settings/$section")({
+  validateSearch: (search: Record<string, unknown>): Record<string, unknown> => ({ ...search }),
+  component: Settings,
+})

--- a/apps/web/src/routes/settings.index.tsx
+++ b/apps/web/src/routes/settings.index.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute, redirect } from "@tanstack/react-router"
+
+// /settings has no content of its own — the sections are the places. Land on the
+// first section (Profile) so the pane is never blank; deep links go straight to a
+// section (/settings/github, …).
+export const Route = createFileRoute("/settings/")({
+  beforeLoad: () => {
+    throw redirect({ to: "/settings/$section", params: { section: "profile" } })
+  },
+})

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -1,15 +1,10 @@
-import { createFileRoute } from "@tanstack/react-router"
-import { Settings } from "../pages/settings"
+import { createFileRoute, Outlet } from "@tanstack/react-router"
 
+// Settings is a section-per-place area: /settings/profile, /settings/members,
+// /settings/github, … Each section is a distinct place, so it's a path segment, not a
+// ?tab= query — consistent with /favorites, /following, and the server's own
+// /settings/github/app/* pages (docs/decisions/0002). This layout just hosts the
+// section routes; the index redirects to the first section and $section renders one.
 export const Route = createFileRoute("/settings")({
-  component: Settings,
-  // Identity validator: types an optional `?tab=` (so a typed Link can deep-link to a
-  // tab, e.g. the sync chip → GitHub) while preserving any other params the GitHub
-  // install redirect lands with (gh_install / gh_error, read from window.location).
-  validateSearch: (
-    search: Record<string, unknown>,
-  ): { tab?: string } & Record<string, unknown> => ({
-    ...search,
-    tab: typeof search.tab === "string" ? search.tab : undefined,
-  }),
+  component: () => <Outlet />,
 })

--- a/apps/web/src/routes/u.$handle.tsx
+++ b/apps/web/src/routes/u.$handle.tsx
@@ -1,9 +1,0 @@
-import { createFileRoute } from "@tanstack/react-router"
-import { Profile } from "../pages/profile"
-
-// Public profile by handle: /u/:handle (Profiles & Accounts v1). Rendered inside
-// the shell; the shell treats /u/* as a public view, so a profile link is
-// shareable without a session (the API endpoint omits email).
-export const Route = createFileRoute("/u/$handle")({
-  component: Profile,
-})

--- a/apps/web/src/routes/users.$handle.tsx
+++ b/apps/web/src/routes/users.$handle.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Profile } from "../pages/profile"
+
+// Public profile by handle: /users/:handle (Profiles & Accounts v1). Rendered inside
+// the shell; the shell treats /users/* as a public view, so a profile link is
+// shareable without a session (the API endpoint omits email).
+export const Route = createFileRoute("/users/$handle")({
+  component: Profile,
+})

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
   },
   server: {
     port: 3090,
-    // /a is the SPA's own route — only proxy API + raw artifact bytes + the
+    // /artifacts is the SPA's own route — only proxy API + raw artifact bytes + the
     // server-rendered OAuth consent page.
     proxy: Object.fromEntries(
       [

--- a/docs/decisions/0001-hosted-tier-tenancy.md
+++ b/docs/decisions/0001-hosted-tier-tenancy.md
@@ -32,8 +32,8 @@ Why not for Derive:
 - **Tenancy shape.** Nemonic's tenant boundary comes free from Slack (one team =
   one workspace; users live in exactly one DO; no global identity). Derive is the
   inverse: users belong to multiple workspaces, everyone gets a personal
-  workspace at signup, and the core surfaces are global — anonymous `/a/:ref`
-  links, `/u/` profiles, cross-workspace shares, eventually search. Each of those
+  workspace at signup, and the core surfaces are global — anonymous `/artifacts/:ref`
+  links, `/users/` profiles, cross-workspace shares, eventually search. Each of those
   would need a control-plane index kept consistent with thousands of DOs.
 - **Ops and global visibility** (the deciding argument in the thread): schema
   migrations are one statement on one database instead of a lazy fleet-wide

--- a/docs/decisions/0002-url-model-paths-vs-query.md
+++ b/docs/decisions/0002-url-model-paths-vs-query.md
@@ -1,0 +1,108 @@
+# ADR 0002 — URL model: named feeds are paths, filters are query params
+
+**Status:** accepted (2026-07-03, mert)
+
+## Context
+
+The web SPA (TanStack Router, `apps/web/src/routes/*`) grew a set of ad-hoc URL
+conventions on the home route `/`. The library carried six search params, and the
+mutually-exclusive "which feed am I looking at" choice was spread across two keys
+with mismatched names:
+
+- `/?f=favorites` — the favorites feed (`f`, an abbreviation)
+- `/?scope=following` — the following feed (`scope`, a full word)
+- `/?tag=`, `/?collection=`, `/?q=`, `/?author=` — filters + search
+
+Three problems followed:
+
+1. **Two keys, one concept.** `f` and `scope` select the same kind of thing (a
+   feed), yet one is a cryptic letter and one a word. Each key had exactly one legal
+   value (`f` was only ever `favorites`; `scope` only ever `following`) — the tell
+   that these are *values of one dimension*, not dimensions of their own.
+2. **Non-canonical URLs.** Nothing forbade `/?f=favorites&scope=following&tag=x`.
+   A priority `if/else` silently picked a winner, so two different URLs could render
+   the identical screen.
+3. **Peer nav, split mechanisms.** In the rail's top tier, *All · Favorites ·
+   Following · People* sit as siblings, but the first three were `/?…` query states
+   while People was a real `/people` route — four peers, two URL models.
+
+## Decision
+
+**Path = the place you're viewing (a noun). Query = how that place is filtered or
+searched (adjectives).**
+
+- **Fixed, singular, self-contained feeds are routes:** `/` (all artifacts),
+  `/favorites`, `/following`, `/people`. Each has its own heading, empty state, and
+  semantics — they are destinations, not filters.
+- **Parameterized filters that compose over the shared library grid stay query
+  params on `/`:** `?tag=`, `?collection=`, `?author=`, `?q=`. They refine the same
+  view and combine with search, which is exactly what query params are for.
+- The base feed is chosen by the **route**; the `Library` body takes a `view` prop
+  (`"all" | "favorites" | "following"`) and reads the filters from search
+  (`useSearch({ strict: false })`, since one body renders under three routes).
+
+The rail's top tier is now structurally uniform (four route links). The library's
+search schema drops `f` and `scope`; `/favorites` and `/following` accept only `?q=`.
+
+**Settings sections follow the same rule.** A settings section (Profile, Members,
+GitHub, …) is a place, not a filter — so it is a path segment, `/settings/$section`,
+not `/settings?tab=`. This also harmonizes the client with the server's own settings
+paths (`/settings/github/app/new`, `/settings/github/app/created`). `/settings`
+redirects to the first section; the one-shot GitHub-install signals (`gh_install`,
+`gh_error`) stay query params, because a handshake token is a modifier, not a place.
+
+## No abbreviations in human-facing URLs
+
+The product is **pre-production** — nothing has shipped, so no links exist in the
+world to break. That removes the one constraint that would otherwise protect terse
+public share URLs, so every human-facing abbreviation was expanded to a full word,
+consistent with the API's own resource names (`/v1/artifacts`, `/v1/users`):
+
+| Was | Now | Surfaces updated in lockstep |
+|---|---|---|
+| `/a/:ref` | `/artifacts/:ref` | routes; every in-app link; the server unfurl / embed / oembed / canonical-redirect handlers; the email / Slack / GitHub / webhook / MCP link-builders (`artifactUrl` in `core`); cross-doc in-artifact links (`core/cross-doc.ts`); the 3-place edge contract (`serve-web.ts` + `wrangler.toml` + Vite proxy) |
+| `/u/:handle` | `/users/:handle` | routes; links; the profile unfurl + the OG-image endpoint (`/v1/og/users/:handle`) |
+| `?c=<thread>` | `?comment=<thread>` | the artifact route; notification-bell; the copy-comment-link action; the email / Slack / GitHub builders |
+| `?q=` | `?query=` | the library + people search routes; `api.ts`; the `/v1/artifacts`, `/v1/users`, `/v1/people`, `/v1/users/search` handlers; the MCP client |
+
+Note the oembed handler parses the ref out of the URL with a **regex**
+(`/^\/artifacts\/([^/]+)$/`) — a string-rename misses that, so the API test suite is
+the guard (it asserts the exact public URLs). Internal `q` field names in `core`/`db`
+stay `q`; only the URL-facing param changed.
+
+## Kept terse (machine plumbing + genuine standards)
+
+Not everything is a human-facing URL. These stay short — pragmatic, not dogmatic:
+
+- **`/raw/:shortId/v/:n/*`** and **`/raw/:shortId/p/:proposalId/*`** — the sandboxed
+  byte-serving paths. Auto-generated, embedded *inside* published artifact HTML for
+  relative asset resolution, never hand-typed. Renaming risks breaking asset loading
+  for zero human-facing gain.
+- **`/v1/og/*`** — the OpenGraph image endpoints. `og` is the protocol's proper name;
+  crawler-facing and invisible to users.
+- **`/v1`, `oauth`, `mcp`, `api`, `.well-known`, `id`, `ref`** (a code-level param
+  name, not a URL segment), **`healthz`/`readyz`** — universal standards.
+- The **API** still takes `scope: "following"` on the wire (`api.listArtifacts`) —
+  a server-query param, a different layer from the client URL.
+
+## Rejected alternatives
+
+- **Just unify the query keys** (`/?view=favorites`, `/?view=following`): the
+  smallest diff, and it kills the `f`/`scope` naming bug — but it leaves the deeper
+  inconsistency (Favorites/Following as query while People is a path) in place.
+- **Full resourceful paths** (`/tags/$tag`, `/collections/$id` too): the most
+  internally consistent, but tags/collections *compose* with `?author=`/`?q=` as
+  filters of the same grid, and their `?collection=` links are already shared —
+  promoting them changes shareable URLs and threads nested routes through the
+  collection toolbar + PR-nesting rail for marginal benefit. Kept as query params.
+
+## Consequences
+
+- New client paths need **no server change** — the SPA catch-all already serves the
+  shell for any non-API GET (`mountWeb`, `serve-web.ts`), so deep-links and refresh
+  on `/favorites` / `/following` just work.
+- Shared/bookmarked `/?f=favorites` or `/?scope=following` links stop selecting the
+  feed after this change (they resolve to the unfiltered home). Acceptable: these
+  are session-gated personal feeds, not public shareables.
+- The rule is the guard against regression: a new "feed" is a route; a new way to
+  *slice* the library is a query param.

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -545,7 +545,7 @@ document.addEventListener("click",function(e){
 /* Cross-document links: a relative <a> the server resolved to a sibling artifact
    (data-derive-nav="<ref>"). The sandboxed frame can't navigate the host, so hand the
    click off for an in-app transition (or a new tab on a modified / middle click —
-   the host opens that un-sandboxed). preventDefault stops the frame loading /a/… into
+   the host opens that un-sandboxed). preventDefault stops the frame loading /artifacts/… into
    itself. Only marked links are touched; ordinary and in-page links are untouched. */
 function navLink(e){
   var a=e.target&&e.target.closest?e.target.closest("a[data-derive-nav]"):null;

--- a/packages/core/src/cross-doc.test.ts
+++ b/packages/core/src/cross-doc.test.ts
@@ -65,10 +65,10 @@ describe("rewriteCrossDocLinks", () => {
     ["docs/plans/competitor-tracking/competitive.html", "competitor-tracking-competitive-aaaaaa11"],
   ])
 
-  it("rewrites resolved siblings to /a/<ref> and tags them for interception", () => {
+  it("rewrites resolved siblings to /artifacts/<ref> and tags them for interception", () => {
     const out = rewriteCrossDocLinks(`<a href="walkthrough.html">Walkthrough</a>`, SRC, refByPath)
     expect(out).toBe(
-      `<a href="/a/competitor-tracking-walkthrough-kbthvh7s" data-derive-nav="competitor-tracking-walkthrough-kbthvh7s">Walkthrough</a>`,
+      `<a href="/artifacts/competitor-tracking-walkthrough-kbthvh7s" data-derive-nav="competitor-tracking-walkthrough-kbthvh7s">Walkthrough</a>`,
     )
   })
 
@@ -78,7 +78,7 @@ describe("rewriteCrossDocLinks", () => {
       SRC,
       refByPath,
     )
-    expect(out).toContain(`href="/a/competitor-tracking-competitive-aaaaaa11"`)
+    expect(out).toContain(`href="/artifacts/competitor-tracking-competitive-aaaaaa11"`)
     expect(out).toContain(`class="tab"`)
     expect(out).toContain(`data-x="1"`)
     expect(out).toContain(`data-derive-nav="competitor-tracking-competitive-aaaaaa11"`)

--- a/packages/core/src/cross-doc.ts
+++ b/packages/core/src/cross-doc.ts
@@ -62,7 +62,7 @@ export const collectSiblingPaths = (html: string, sourcePath: string): string[] 
 
 /**
  * Rewrite each relative `<a href>` that resolves to a known sibling: point it at the
- * sibling's `/a/<ref>` URL and tag it `data-derive-nav="<ref>"` so the iframe client
+ * sibling's `/artifacts/<ref>` URL and tag it `data-derive-nav="<ref>"` so the iframe client
  * intercepts the click for an in-app transition. `refByPath` maps a resolved repo
  * path → its artifact ref (`<slug>-<short_id>`); paths absent from it are left as-is.
  * Already-tagged anchors are skipped so the pass is idempotent.
@@ -78,6 +78,6 @@ export const rewriteCrossDocLinks = (
     const path = resolveSiblingPath(sourcePath, href)
     const ref = path && refByPath.get(path)
     if (!ref) return tag
-    return `<a${pre} href=${q}/a/${ref}${q} data-derive-nav=${q}${ref}${q}${post}>`
+    return `<a${pre} href=${q}/artifacts/${ref}${q} data-derive-nav=${q}${ref}${q}${post}>`
   })
 }

--- a/packages/core/src/ids.test.ts
+++ b/packages/core/src/ids.test.ts
@@ -26,7 +26,7 @@ describe("slugify", () => {
   })
 })
 
-describe("parseRef — /a/:ref → { shortId, version }", () => {
+describe("parseRef — /artifacts/:ref → { shortId, version }", () => {
   it("reads a bare short id and a name-first ref", () => {
     expect(parseRef("abc12345")).toEqual({ shortId: "abc12345", version: undefined })
     expect(parseRef("my-title-abc12345")).toEqual({ shortId: "abc12345", version: undefined })
@@ -60,7 +60,7 @@ describe("candidateShortIds — resolve-in-order for ambiguous refs", () => {
   })
 })
 
-describe("refFor — build a readable /a/:ref", () => {
+describe("refFor — build a readable /artifacts/:ref", () => {
   it("prefers an explicit slug, else slugifies the title, else bare short id", () => {
     expect(refFor({ short_id: "abc12345", slug: "my-doc" })).toBe("my-doc-abc12345")
     expect(refFor({ short_id: "abc12345", title: "My Doc!" })).toBe("my-doc-abc12345")

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -20,7 +20,7 @@ export const slugify = (s: string): string =>
  *   my-title-abc12345@v4  → { shortId: "abc12345", version: 4 }
  * The short id is taken from the last token, falling back to the first (legacy
  * short-id-first links) then the whole ref. Mirrors the SPA's own `parse-ref.ts`
- * (kept separate so the client bundle doesn't pull in core) so the same `/a/:ref`
+ * (kept separate so the client bundle doesn't pull in core) so the same `/artifacts/:ref`
  * link resolves identically on the server and the client.
  */
 export const parseRef = (ref: string): { shortId: string; version?: number } => {
@@ -33,7 +33,7 @@ export const parseRef = (ref: string): { shortId: string; version?: number } => 
   return { shortId, version: v ? Number(v) : undefined }
 }
 
-/** Ordered, de-duped short-id candidates for a `/a/:ref`: the trailing token first
+/** Ordered, de-duped short-id candidates for a `/artifacts/:ref`: the trailing token first
  *  (name-first links), then the leading token (legacy short-id-first). Resolve by
  *  trying each in order so any link form finds the right artifact — even a name whose
  *  tail looks like an id. Falls back to the whole base when neither token is id-shaped. */
@@ -47,7 +47,7 @@ export const candidateShortIds = (ref: string): string[] => {
   return out.length ? out : [base]
 }
 
-/** Build a readable `/a/:ref`: `<name>-<shortId>`, the name from an explicit slug or
+/** Build a readable `/artifacts/:ref`: `<name>-<shortId>`, the name from an explicit slug or
  *  the current title. Decorative — `parseRef` resolves by the trailing short id, so
  *  renames and stale names still resolve. */
 export const refFor = (a: {

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -380,7 +380,7 @@ export async function approveProposal(
 // Name-first ref: the slug reads first, the short id is the final token. parseRef
 // reverses it (the short id is always the last hyphen segment).
 export const artifactUrl = (baseUrl: string, a: ArtifactRecord): string =>
-  `${baseUrl}/a/${refFor(a)}`
+  `${baseUrl}/artifacts/${refFor(a)}`
 
 export const toJson = (baseUrl: string, a: ArtifactRecord, versions: VersionRecord[]) => ({
   short_id: a.short_id,

--- a/packages/core/src/unfurl.test.ts
+++ b/packages/core/src/unfurl.test.ts
@@ -19,7 +19,7 @@ const info: UnfurlInfo = {
   kindLabel: "Markdown",
   versionCount: 3,
   commentCount: 1,
-  pageUrl: "http://derive.test/a/my-report-abc12345",
+  pageUrl: "http://derive.test/artifacts/my-report-abc12345",
   imageUrl: "http://derive.test/v1/og/abc12345",
   oembedUrl: "http://derive.test/v1/oembed?url=http%3A%2F%2Fderive.test%2Fa%2Fabc12345",
   embedUrl: "http://derive.test/v1/embed/abc12345",
@@ -146,14 +146,14 @@ describe("profileMetaTags", () => {
       username: "maya",
       name: "Maya <Chen>",
       description: "Engineering · 4 works · on Derive",
-      pageUrl: "http://derive.test/u/maya",
-      imageUrl: "http://derive.test/v1/og/u/maya",
+      pageUrl: "http://derive.test/users/maya",
+      imageUrl: "http://derive.test/v1/og/users/maya",
     })
     expect(html).toContain('property="og:type" content="profile"')
     expect(html).toContain('property="profile:username" content="maya"')
     expect(html).toContain("Maya &lt;Chen&gt; (@maya)") // name + handle, angle brackets escaped
     expect(html).toContain('name="twitter:card" content="summary_large_image"')
-    expect(html).toContain('content="http://derive.test/v1/og/u/maya"')
+    expect(html).toContain('content="http://derive.test/v1/og/users/maya"')
     expect(html).not.toContain("Maya <Chen>") // no unescaped markup leaks
   })
   it("falls back to just the handle when the name is null", () => {
@@ -161,8 +161,8 @@ describe("profileMetaTags", () => {
       username: "ada",
       name: null,
       description: "on Derive",
-      pageUrl: "http://derive.test/u/ada",
-      imageUrl: "http://derive.test/v1/og/u/ada",
+      pageUrl: "http://derive.test/users/ada",
+      imageUrl: "http://derive.test/v1/og/users/ada",
     })
     expect(html).toContain('content="@ada"')
   })

--- a/packages/core/src/unfurl.ts
+++ b/packages/core/src/unfurl.ts
@@ -17,7 +17,7 @@ export interface UnfurlInfo {
   kindLabel: string
   versionCount: number
   commentCount: number
-  /** Canonical share URL (`/a/:ref`). */
+  /** Canonical share URL (`/artifacts/:ref`). */
   pageUrl: string
   /** Absolute OG image URL (`/v1/og/:ref`). */
   imageUrl: string
@@ -173,7 +173,7 @@ export interface OgCard {
   reveal?: boolean
 }
 
-// ---- Profile unfurl (people pages: /u/:handle) -----------------------------
+// ---- Profile unfurl (people pages: /users/:handle) -----------------------------
 
 /** Everything a profile unfurl card / meta block needs about one person. */
 export interface ProfileCard {

--- a/packages/core/src/username.ts
+++ b/packages/core/src/username.ts
@@ -16,7 +16,7 @@ export const USERNAME_MAX = 30
 const USERNAME_RE = /^[a-z0-9](?:[a-z0-9]|[-_](?=[a-z0-9])){1,29}$/
 
 // Handles that would collide with a top-level route or carry reserved meaning.
-// Lowercased. Profiles live at /u/:handle today, but reserving these keeps a
+// Lowercased. Profiles live at /users/:handle today, but reserving these keeps a
 // handle safe even as more top-level routes (a vanity /:handle, /following, …)
 // get added later.
 export const RESERVED_USERNAMES: ReadonlySet<string> = new Set([

--- a/packages/core/test/publish.test.ts
+++ b/packages/core/test/publish.test.ts
@@ -344,15 +344,17 @@ describe("publish: URL + JSON helpers", () => {
 
   it("artifactUrl is name-first: explicit slug, else slug-from-title, else bare", () => {
     // Name-first refs (#130): <name>-<short_id>.
-    expect(artifactUrl("https://derive.test", artifact)).toBe("https://derive.test/a/my-doc-abc123")
+    expect(artifactUrl("https://derive.test", artifact)).toBe(
+      "https://derive.test/artifacts/my-doc-abc123",
+    )
     // No explicit slug → derive the name from the current title (so links stay readable
     // and rename-safe without a backfill).
     expect(artifactUrl("https://derive.test", { ...artifact, slug: null })).toBe(
-      "https://derive.test/a/my-doc-abc123",
+      "https://derive.test/artifacts/my-doc-abc123",
     )
     // No slug and no title → the bare short id.
     expect(artifactUrl("https://derive.test", { ...artifact, slug: null, title: null })).toBe(
-      "https://derive.test/a/abc123",
+      "https://derive.test/artifacts/abc123",
     )
   })
 
@@ -360,7 +362,7 @@ describe("publish: URL + JSON helpers", () => {
     const json = toJson("https://derive.test", artifact, [])
     expect(json).toMatchObject({
       short_id: "abc123",
-      url: "https://derive.test/a/my-doc-abc123",
+      url: "https://derive.test/artifacts/my-doc-abc123",
       kind: "file",
       spa: false,
       current_version: 2,

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -148,7 +148,7 @@ export function createClient(opts: ClientOptions): DeriveClient {
 
   return {
     async list(query) {
-      const q = query ? `?q=${encodeURIComponent(query)}` : ""
+      const q = query ? `?query=${encodeURIComponent(query)}` : ""
       const r = (await ok(await f(`${base}/v1/artifacts${q}`, { headers: authHeaders }))) as {
         artifacts: ArtifactSummaryJson[]
       }


### PR DESCRIPTION
Rebuilds the artifact workbench on top of the Nemonic design system (now in `main` via #260), plus a collaboration/presence audit. 8 focused commits.

## Artifact page — from-scratch SOTA rebuild
- **URL routing model (ADR 0002)** — named feeds become routes (`/favorites`, `/following`, `/people`); filters stay query params; `/a`→`/artifacts`, `/u`→`/users`; settings nested routes.
- **Edge-to-edge render** — the render is the hero (explicit boot / "Preview didn't load — Try again" / soft "Updated" states). Fills the stage edge-to-edge, clipped by the content card: an artifact carries its own background, so a floating mat gap framed a *dark* artifact in an awkward light border.
- **Public / viral viewer** — a chrome-light anonymous surface on shared links (brand → home, creator byline, "Make your own", "Made with Derive"), no nav rail. Never gate the view; the verb is the growth loop.
- **Mobile collaboration** — presence (compact) now rides the phone header.
- **Focus / hero mode** — strips the chrome + collapses the rail to just the render (Esc / a floating exit).
- **Unify floating chrome** — a shared `FloatingControl` (comments FAB + focus-exit).
- **Design-audit polish** — a11y (`aria-live` on the version cue, `aria-hidden` on raw lucide), copy ("Try again"), floating-surface hairlines.
- **Comment pin alignment** to the render.

## Collaboration — connection-based presence
Auditing surfaced a real flaw: a viewer who closed their tab lingered in everyone's facepile for **~60s** (heartbeat + 45s TTL, no leave signal). Reworked presence to ride the SSE connection lifecycle — you're present while you hold an open `/events` stream, and you leave the instant it closes (the Durable Object's `cancel()` / the in-process `stream.onAbort`), ref-counted for multi-tab. Heartbeat + TTL stay as the streamless backstop; the keep-alive ping is the crash detector. **Measured: 59.2s → 0.0s.** Entirely server-side.

## Verification
- **web** 89 unit + tsc · **api** 614 unit + tsc (the `bus`/`anonymous`/`analytics` presence contracts stay green) · token/testid/frontend linters · biome.
- **e2e** smoke (all) + deep (all) — presence join/leave, live cursors, cross-user comment sync, version auto-swap, comments (optimistic/mobile/deck), review, share, responsive.
- Verified visually via the screens harness across dark/light + mobile (edge-to-edge render, public viewer, mobile presence, focus mode, pin alignment, live collaboration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
