### PR TITLE
fix(api): back the issue_comment event with issues:read in the App manifest

### DIFF
--- a/apps/api/src/github-app-setup.ts
+++ b/apps/api/src/github-app-setup.ts
@@ -56,12 +56,19 @@ ${body}</main></body></html>`
 // the `installation`/`new_permissions_accepted` webhook + a live GET /app re-check
 // confirm it. So this constant drives "what we want"; GitHub holds "what we have".
 //
-// contents+metadata (read) mirror docs; pull_requests is now WRITE — Derive posts a PR
+// contents+metadata (read) mirror docs; pull_requests is WRITE — Derive posts a PR
 // review/issue comment when someone comments on a PR-sourced artifact, and receives
 // `pull_request` + comment events to preview PR docs and mirror PR comments back into
 // Derive (the bidirectional collaboration loop). push + pull_request drive auto-sync.
+// issues:READ backs the `issue_comment` event. GitHub's manifest-creation validator maps
+// that event to the Issues permission (NOT Pull requests), so omitting it fails creation
+// with "Default events are not supported by permissions: issue_comment". Read is enough:
+// we only RECEIVE issue_comment events. Posting a PR conversation comment goes through
+// pull_requests:write — the target is always a PR (see prSourceForArtifact), never a bare
+// issue — so we never need issues:write.
 export const REQUIRED_PERMISSIONS: Record<string, string> = {
   contents: "read",
+  issues: "read",
   metadata: "read",
   pull_requests: "write",
 }
@@ -124,7 +131,7 @@ export function manifestFormHTML(props: { baseUrl: string; state: string }): str
       <input type="hidden" name="manifest" value="${esc(manifestJson)}"/>
       <button class="btn" type="submit">Continue to GitHub</button>
     </form>
-    <p class="foot">Derive asks for <strong>Contents: read</strong>, <strong>Metadata: read</strong> to mirror your docs, and <strong>Pull requests: write</strong> to sync comments to and from PRs.</p>
+    <p class="foot">Derive asks for <strong>Contents: read</strong> and <strong>Metadata: read</strong> to mirror your docs, <strong>Issues: read</strong> to receive PR comment events, and <strong>Pull requests: write</strong> to sync comments to and from PRs.</p>
     <script>setTimeout(function(){document.getElementById("f").submit()},400)</script>`,
   )
 }

--- a/apps/api/test/github-manifest.test.ts
+++ b/apps/api/test/github-manifest.test.ts
@@ -4,6 +4,8 @@ import { buildManifest } from "../src/github-app-setup"
 // Locks the exact manifest shape GitHub accepts. We regressed on each of these
 // during the live rollout, so each assertion maps to a real failure we hit:
 //   - default_events with installation/installation_repositories → "unsupported"
+//   - issue_comment event without the issues permission → "Default events are not
+//     supported by permissions: issue_comment" (GitHub maps it to Issues, not PRs)
 //   - public:false → couldn't install on an organization
 //   - setup_url at the settings page → post-install callback never ran
 describe("GitHub App manifest", () => {
@@ -22,9 +24,10 @@ describe("GitHub App manifest", () => {
     expect(m.public).toBe(true)
   })
 
-  it("requests read contents + metadata and write pull_requests, nothing more", () => {
+  it("requests read contents/issues/metadata and write pull_requests, nothing more", () => {
     expect(m.default_permissions).toEqual({
       contents: "read",
+      issues: "read",
       metadata: "read",
       pull_requests: "write",
     })

--- a/apps/api/test/sync-app.test.ts
+++ b/apps/api/test/sync-app.test.ts
@@ -177,6 +177,7 @@ describe("github app auto-heal (GET /app verification)", () => {
     status: number,
     perms: Record<string, string> = {
       contents: "read",
+      issues: "read",
       metadata: "read",
       pull_requests: "write",
     },


### PR DESCRIPTION
## Problem
Creating the GitHub App from our manifest fails with:

> Invalid GitHub App configuration — The configuration does not appear to be a valid GitHub App manifest.
> Error: Default events are not supported by permissions: issue_comment

## Cause
GitHub's App-manifest **creation** validator maps the `issue_comment` event to the **Issues** permission, not Pull requests — even though at runtime PR conversation comments are delivered and posted under `pull_requests`. Our manifest subscribed to `issue_comment` in `default_events` with no `issues` permission, so GitHub rejected the whole manifest.

## Fix
Add `issues: read` to `REQUIRED_PERMISSIONS` (the single source of truth that both the born manifest and the live-App sync diff consume). Read is enough:
- We only **receive** `issue_comment` events.
- Posting a PR conversation comment still goes through the existing `pull_requests: write` — the target is always a PR (see `prSourceForArtifact`), never a bare issue, so no `issues: write` is needed.

Because `sync.ts` / the settings banner diff against `REQUIRED_PERMISSIONS`, existing installs are automatically prompted to accept `Issues: read`. New manifest submissions now validate.

## Changes
- `github-app-setup.ts` — add `issues: read`; explain the validator quirk; update setup-page copy.
- `github-manifest.test.ts` — update the locked permission assertion + regression note.
- `sync-app.test.ts` — add `issues: read` to the "all perms" fixture.

## Verification
- api suite: 614/614 pass
- `tsc --noEmit` clean (app + worker tsconfigs)
- biome clean on changed files

Runtime behavior is unchanged; this only unblocks manifest creation. Apps already created from the old manifest gain the scope via the settings banner / per-install approval.