### PR TITLE
CI/CD: auto-deploy main to derive.to after tests pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,58 +119,103 @@ jobs:
         run: pnpm lint:bundle
 
   # CD: ship main to the hosted tier (Workers + Hyperdrive/Neon, derive.to) once
-  # the correctness lanes pass. Mirrors `pnpm --filter @derive/api deploy`: both
-  # schemas (D1 + Postgres) are brought current BEFORE the worker flips, so a new
-  # version never serves against stale DDL; the e2e smoke suite is dispatched
-  # after. Secrets: CLOUDFLARE_API_TOKEN (account-scoped — the deploy needs
-  # Workers Scripts *and* D1 edit; a workers-only token fails the D1 schema
-  # step), CLOUDFLARE_ACCOUNT_ID, DATABASE_URL (the pg schema step's direct
-  # Neon connection — Hyperdrive is only for the worker's data path).
+  # check/pg/d1 + security pass. Schemas (D1 + Postgres) land BEFORE the worker
+  # flips, so a new version never serves against stale DDL. Coverage/bundle stay
+  # non-gating: quality ratchets shouldn't block a prod fix. The laptop path
+  # (`pnpm --filter @derive/api deploy`) remains for manual deploys; this job is
+  # the production path.
+  # Secrets — step-scoped, never job-wide (install/build run arbitrary package
+  # code that must not see them): CLOUDFLARE_API_TOKEN (account-scoped; the D1
+  # schema step needs D1 edit, which a workers-only token lacks),
+  # CLOUDFLARE_ACCOUNT_ID, DATABASE_URL (direct Neon — Hyperdrive is only the
+  # worker's data path).
   deploy:
-    # The repository guard keeps forks clean: a fork's push to main skips this
-    # job instead of failing against secrets it doesn't have.
-    if: github.repository == 'derive-to/derive' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [check, pg, d1]
+    if: github.repository == 'derive-to/derive' && github.event_name == 'push' # never PRs, never forks
+    needs: [check, pg, d1, security]
     runs-on: ubicloud-standard-2
-    # One deploy at a time, in order, never cancelled mid-flight — a schema
-    # applied for a worker that then didn't ship is the state to avoid.
+    # A running deploy is never cancelled — a schema applied for a worker that
+    # then didn't ship is the state to avoid. Queued runs are NOT ordered:
+    # GitHub keeps only the newest pending run per group, so intermediate green
+    # commits skip their deploy (latest wins), and the freshness check below
+    # stops a late-running older commit from rolling prod back.
     concurrency:
       group: deploy-production
       cancel-in-progress: false
     permissions:
       contents: read
-      actions: write # dispatches e2e-smoke.yml after the deploy
-    env:
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      actions: write # dispatches e2e-smoke.yml
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Job queue order is arrival, not commit order: a slow run for an older
+      # commit can start after a newer commit already shipped. Ship only when
+      # this commit is still main's head.
+      - name: Skip when superseded by a newer commit
+        id: head
+        run: |
+          git fetch --quiet origin main
+          if [ "$(git rev-parse origin/main)" != "$GITHUB_SHA" ]; then
+            echo "superseded by $(git rev-parse --short origin/main); skipping"
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        if: steps.head.outputs.stale != 'true'
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        if: steps.head.outputs.stale != 'true'
         with:
           node-version: 24
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+        if: steps.head.outputs.stale != 'true'
 
       - name: Build web client
+        if: steps.head.outputs.stale != 'true'
         run: pnpm --filter @derive/api build:web
 
       - name: Apply schemas (D1 + Postgres)
+        if: steps.head.outputs.stale != 'true'
         env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        # apply-pg-schema exits 0 without DATABASE_URL (a feature for D1-only
+        # self-hosters, a silent schema skip here) — so assert the secret first.
         run: |
+          : "${DATABASE_URL:?DATABASE_URL secret is unset — refusing to deploy without the pg schema step}"
           pnpm --filter @derive/api deploy:schema
           pnpm --filter @derive/api exec tsx migrate-auth-d1.ts --apply
           pnpm --filter @derive/api deploy:pg-schema
 
       - name: Deploy worker
+        if: steps.head.outputs.stale != 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: pnpm --filter @derive/api exec wrangler deploy
 
-      - name: Verify deploy
-        run: curl -sf --max-time 20 https://derive.to/healthz
+      # Retried, and includes a DB-backed route so the Hyperdrive→Neon path is
+      # exercised, not just the worker's static response. Version-blind (healthz
+      # doesn't echo a build id yet), so treat it as a smoke, not a proof.
+      - name: Verify prod
+        if: steps.head.outputs.stale != 'true'
+        run: |
+          for _ in 1 2 3 4 5 6 7 8 9 10; do
+            if curl -sf --max-time 15 https://derive.to/healthz > /dev/null &&
+               curl -sf --max-time 15 https://derive.to/v1/artifacts > /dev/null; then
+              exit 0
+            fi
+            sleep 6
+          done
+          echo "prod not healthy after deploy" >&2
+          exit 1
 
-      - name: Dispatch post-deploy smoke
+      # Regression signal on main HEAD (the suite runs against localhost dev
+      # servers in its own runner — it does NOT verify the deployment; the step
+      # above does that).
+      - name: Dispatch e2e suite
+        if: steps.head.outputs.stale != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh workflow run e2e-smoke.yml --ref main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,61 @@ jobs:
       - name: Bundle budget
         run: pnpm lint:bundle
 
+  # CD: ship main to the hosted tier (Workers + Hyperdrive/Neon, derive.to) once
+  # the correctness lanes pass. Mirrors `pnpm --filter @derive/api deploy`: both
+  # schemas (D1 + Postgres) are brought current BEFORE the worker flips, so a new
+  # version never serves against stale DDL; the e2e smoke suite is dispatched
+  # after. Secrets: CLOUDFLARE_API_TOKEN (account-scoped — the deploy needs
+  # Workers Scripts *and* D1 edit; a workers-only token fails the D1 schema
+  # step), CLOUDFLARE_ACCOUNT_ID, DATABASE_URL (the pg schema step's direct
+  # Neon connection — Hyperdrive is only for the worker's data path).
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [check, pg, d1]
+    runs-on: ubicloud-standard-2
+    # One deploy at a time, in order, never cancelled mid-flight — a schema
+    # applied for a worker that then didn't ship is the state to avoid.
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      actions: write # dispatches e2e-smoke.yml after the deploy
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build web client
+        run: pnpm --filter @derive/api build:web
+
+      - name: Apply schemas (D1 + Postgres)
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          pnpm --filter @derive/api deploy:schema
+          pnpm --filter @derive/api exec tsx migrate-auth-d1.ts --apply
+          pnpm --filter @derive/api deploy:pg-schema
+
+      - name: Deploy worker
+        run: pnpm --filter @derive/api exec wrangler deploy
+
+      - name: Verify deploy
+        run: curl -sf --max-time 20 https://derive.to/healthz
+
+      - name: Dispatch post-deploy smoke
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run e2e-smoke.yml --ref main
+
   # Supply-chain: a known-vulnerable production dependency, or a committed secret,
   # fails the build. Reads the lockfile + working tree, so no install is needed.
   security:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,10 @@ permissions:
 
 jobs:
   check:
-    # Ubicloud runners (cheaper than GitHub-hosted). Bump the suffix (-4, -8) for
-    # more cores; falls back to a label your org's Ubicloud integration provides.
-    runs-on: ubicloud-standard-2
+    # GitHub-hosted (free for public repos). The org's Ubicloud integration
+    # vanished 2026-07-02 and every ubicloud-* job queued forever; if it comes
+    # back, weigh it against keeping deploys vendor-independent before reverting.
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -40,7 +41,7 @@ jobs:
   # container, via scripts/test-pg.sh) so the hosted-tier driver is covered by
   # the full behavioral suite, not just typecheck + parity guards.
   pg:
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -59,7 +60,7 @@ jobs:
   # host the D1 driver, so this is the only place src/d1.ts is exercised at runtime —
   # the edge tier runs on it.
   d1:
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -78,7 +79,7 @@ jobs:
   # stores (@derive/storage), the MCP client, and the web app's pure logic (@derive/web;
   # its user flows are covered separately by the Playwright e2e suite).
   coverage:
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -104,7 +105,7 @@ jobs:
   # budget (see scripts/check-bundle.mjs), so phosphor / radix / cmdk weight can't
   # regress silently.
   bundle:
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -132,7 +133,7 @@ jobs:
   deploy:
     if: github.repository == 'derive-to/derive' && github.event_name == 'push' # never PRs, never forks
     needs: [check, pg, d1, security]
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     # A running deploy is never cancelled — a schema applied for a worker that
     # then didn't ship is the state to avoid. Queued runs are NOT ordered:
     # GitHub keeps only the newest pending run per group, so intermediate green
@@ -223,7 +224,7 @@ jobs:
   # Supply-chain: a known-vulnerable production dependency, or a committed secret,
   # fails the build. Reads the lockfile + working tree, so no install is needed.
   security:
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,9 @@ jobs:
   # step), CLOUDFLARE_ACCOUNT_ID, DATABASE_URL (the pg schema step's direct
   # Neon connection — Hyperdrive is only for the worker's data path).
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # The repository guard keeps forks clean: a fork's push to main skips this
+    # job instead of failing against secrets it doesn't have.
+    if: github.repository == 'derive-to/derive' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [check, pg, d1]
     runs-on: ubicloud-standard-2
     # One deploy at a time, in order, never cancelled mid-flight — a schema

--- a/.github/workflows/e2e-deep.yml
+++ b/.github/workflows/e2e-deep.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   deep:
-    runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -18,7 +18,7 @@ jobs:
     # 4 vCPU + 2 workers: the review/share specs each drive two browser contexts
     # (owner + member), so 4 workers on a 2-vCPU box oversubscribed the CPU and the UI
     # didn't paint within the expect timeout — the toBeVisible() flakes. Right-size it.
-    runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9


### PR DESCRIPTION
## What

Adds the CD half to our existing CI. On every push to main, once the three correctness lanes are green (`check`, `pg`, `d1`), a `deploy` job ships the hosted tier: build the SPA → apply both schemas (D1 + Postgres) → `wrangler deploy` → verify `/healthz` → dispatch the post-deploy e2e smoke suite (which was already designed to run post-deploy, per its own comments).

Laptop deploys keep working (`pnpm --filter @derive/api deploy`) — this is the same pipeline, just gated and automatic.

## Design notes

- **Schemas always land before the worker flips**, same invariant as the local deploy script: a new version never serves against stale DDL.
- **Deploys are serialized** (`concurrency: deploy-production`, `cancel-in-progress: false`). Two quick merges queue; nothing is cancelled between "schema applied" and "worker shipped."
- **Gated on `check` + `pg` + `d1`, not coverage/bundle/security.** Those still fail the workflow (and PRs), but a coverage-ratchet red shouldn't block shipping a prod fix. Easy to tighten later if we disagree.
- **Repo secrets** (already set): `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `DATABASE_URL`. The token must be account-scoped: the D1 schema step needs D1 *edit* — I validated the whole pipeline with a workers-only token first and it fails exactly there (auth error 10000 on d1 import). `DATABASE_URL` is the direct Neon connection for the schema step; Hyperdrive is only the worker's data path.
- Validated end to end by running every step of this job locally against prod before writing the YAML — including the failure modes (stale install → the shadcn css resolve error, wrong token scope).

## One ask

@rob had started connecting this repo to Cloudflare's **Workers Builds** in the dashboard — that connection should **not** be completed. Workers Builds deploys on push without gating on our test suite, and two deploy systems on the same worker means racing double-deploys. This job replaces it. (The API shows no active connection, so nothing to disconnect — just don't finish that flow.)