### PR TITLE
Sharing & visibility: workspace-only default, private tier, real profile privacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once it reache
 ## [Unreleased]
 
 ### Changed
+- **Publishing is workspace-only by default.** An absent `visibility` on
+  `POST /v1/artifacts`, `derive publish`, the MCP `publish` tool, and the
+  `derive init` scaffold now defaults to `org` instead of `link` — nothing becomes
+  URL-readable as a side effect of publishing. Pass `--visibility link` (or set
+  `visibility` in `derive.json`, or use the Share dialog) to share by URL. Existing
+  artifacts and existing `derive.json` files (which carry an explicit value) are
+  unaffected. The CLI now prints the published visibility and how to widen it.
+- **`discoverable` is real profile privacy now.** Turning it off hides your
+  profile page, work list, and follow lists from everyone except people who share
+  a workspace with you (they 404, same as an unknown handle). Follower/following
+  lists require a signed-in viewer regardless. The People directory gains a
+  workspace-first view (`GET /v1/people?scope=workspace`).
+- The publisher is recorded as their artifact's owner-member at creation, so
+  ownership is explicit rather than implied by workspace role (and creators can
+  manage their own artifacts in team workspaces).
+
+### Added
+- **`private` visibility** — only people explicitly shared on the artifact can
+  see it; workspace membership grants nothing. Completes the Google-Docs-style
+  ladder: private · workspace · anyone with link · public · password.
 - Restructured the backend for clarity: `apps/api/app.ts` split into per-feature
   route modules over a shared app context; the SQLite and D1 database adapters
   collapsed onto a shared repository layer (one place to add a query); typed config

--- a/README.md
+++ b/README.md
@@ -91,8 +91,10 @@ The user/session tables are created automatically on first boot; see
 `.env.example` for the full list.
 
 Writes are authorized by a login session **or** a static `DERIVE_TOKEN` (for
-CI/agents). Publish with `--visibility public|link|org|password` (default `link`);
-when `DERIVE_TOKEN` is set, gated artifacts 404 for anyone without a session or the
+CI/agents). Publish with `--visibility public|link|org|password|private` — the
+default is `org` (workspace-only), so nothing becomes URL-readable unless you say
+so; `private` narrows further to just the people explicitly shared. When
+`DERIVE_TOKEN` is set, gated artifacts 404 for anyone without a session or the
 token.
 
 ## Architecture

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,14 @@ Derive ships safe defaults, but a few choices matter for an internet-facing depl
   | Anyone with link, **comment**  | View only (sign in to comment) | View + comment                         | Their role (at least comment)  |
   | Public (listed), view/comment  | same as link row               | same as link row                       | Their role                     |
   | Password, view/comment         | Unlock, then as above          | Unlock, then as above                  | Their role (no password needed)|
-  | Workspace only (org)           | No access                      | No access                              | Their role (members only)      |
+  | Workspace only (org) — default | No access                      | No access                              | Their role (members only)      |
+  | Private (invite-only)          | No access                      | No access                              | Explicit share only — workspace role grants nothing |
+
+  Publishing defaults to **workspace only** on every path (API, CLI, MCP, web), so
+  nothing is URL-readable unless the publisher widens it. `private` narrows further:
+  only per-artifact members (the publisher is written as the owner-member at
+  creation) can see it — it never appears in workspace listings, profile work
+  lists, or the People-visible surfaces.
 
   `packages/core/src/permissions.ts` (`effectiveRole`) is the single source of truth for
   this table, enforced on every request by the one `can()` gate and surfaced in the UI so

--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -1,2 +1,3 @@
 .dev.vars
 .wrangler/
+.e2e-*/

--- a/apps/api/src/lib/http.ts
+++ b/apps/api/src/lib/http.ts
@@ -107,7 +107,7 @@ export const anonName = (seed: string): string => {
   return `${adj}-${animal}-${(h >>> 16) % 100}`
 }
 
-export const VISIBILITIES = ["public", "link", "org", "password"] as const
+export const VISIBILITIES = ["public", "link", "org", "password", "private"] as const
 
 export const MAX_UPLOAD_BYTES = 100 * 1024 * 1024
 

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -165,6 +165,9 @@ export const artifactRoutes = (ctx: AppContext) => {
       // feed back to the active workspace and strip a followed person's public work.
       orgId: shared || following ? undefined : listOrg,
       publicOnly: shared || following ? false : publicOnly,
+      // Private artifacts appear only for their explicit members; the operator
+      // token sees everything (viewerId omitted).
+      viewerId: isOperator ? undefined : (me?.id ?? undefined),
     })
     const hasMore = rows.length > limit
     const page = hasMore ? rows.slice(0, limit) : rows
@@ -182,6 +185,9 @@ export const artifactRoutes = (ctx: AppContext) => {
     // Per-artifact comment signals for the viewer (open-thread count + tagged/authored
     // flags) — drives the inline comment badge and the "needs your feedback" featuring.
     const feedback = me ? await meta.commentSignals(pageIds, me.id) : {}
+    // The viewer's per-artifact shares across the page, one query — folded into
+    // my_role below so shared and private rows gate their quick actions correctly.
+    const shareRoles = me ? await meta.artifactRolesFor(me.id, pageIds) : {}
     return c.json({
       artifacts: page.map((a) => ({
         ...toJson(deps.baseUrl, a, []),
@@ -189,10 +195,9 @@ export const artifactRoutes = (ctx: AppContext) => {
         tags: tags[a.id] ?? [],
         favorite: favorites.has(a.id),
         // Which actions the client may surface on the row (the card's quick-actions
-        // menu gates delete/tags on it). Baseline standing only — workspace
-        // membership + the general-access floor; per-artifact and collection shares
-        // aren't folded in at list granularity (no per-row member lookups), so the
-        // detail response's my_role stays authoritative.
+        // menu gates delete/tags on it). Workspace membership + per-artifact shares
+        // + the general-access floor; collection-share roles aren't folded in at
+        // list granularity, so the detail response's my_role stays authoritative.
         my_role: isOperator
           ? "owner"
           : effectiveRole(
@@ -200,6 +205,7 @@ export const artifactRoutes = (ctx: AppContext) => {
                 ? {
                     kind: "user",
                     userId: me.id,
+                    artifactRole: shareRoles[a.id] ?? null,
                     orgRole: a.org_id === listOrg ? (myMembership?.role ?? null) : null,
                   }
                 : { kind: "anon" },
@@ -302,11 +308,9 @@ export const artifactRoutes = (ctx: AppContext) => {
     // the artifact, only adds a version, so visibility/password are set-on-create).
     const visibility = visibilityOf(body["visibility"])
     // An explicitly-provided visibility that isn't a known value is rejected, not
-    // silently coerced. publish() defaults an *absent* visibility to `link`, so a
-    // natural-but-wrong value like "private" would otherwise become URL-readable —
-    // more open than intended, with no error. The enum is closed; surface the typo.
+    // silently coerced — a typo must not publish more openly than intended.
     if (str(body["visibility"]) && !visibility)
-      return fail(c, 400, "visibility must be one of: public, link, org, password")
+      return fail(c, 400, "visibility must be one of: public, link, org, password, private")
     const password = str(body["password"])
     if (!shortId && visibility === "password" && !password)
       return fail(c, 400, "a password is required for password visibility")
@@ -344,6 +348,18 @@ export const artifactRoutes = (ctx: AppContext) => {
         },
         shortId,
       )
+      // The publisher becomes the artifact's owner-member on creation. This is what
+      // makes `private` work — workspace role grants nothing there, so without this
+      // row the creator would lock themselves out — and it makes ownership explicit
+      // for every artifact instead of implied by workspace role. Agents get the row
+      // under their principal id (actorFor resolves members by that same id).
+      if (!shortId && actor)
+        await meta.setArtifactMember({
+          id: newId("am"),
+          artifact_id: artifact.id,
+          user_id: actor.id,
+          role: "owner",
+        })
       bus.publish(artifact.id, {
         type: "version.published",
         n: version.n,

--- a/apps/api/src/routes/session.ts
+++ b/apps/api/src/routes/session.ts
@@ -72,8 +72,10 @@ export const sessionRoutes = (ctx: AppContext) => {
     return c.json({ profession: patch.profession ?? null, about: patch.about ?? null })
   })
 
-  // Opt in/out of people search. Off by default, so you're only findable by
-  // username if you choose to be (signed-in user sets their own).
+  // Opt in/out of being findable. On by default (auth-config sets it at signup and
+  // the queries treat unset as on). Turning it OFF is real privacy, not just
+  // directory removal: the profile page, work list, and follow lists all 404 for
+  // anyone who doesn't share a workspace (see profileVisibleTo below).
   app.post("/v1/me/discoverable", async (c) => {
     const u = await currentUser(c)
     if (!u) return fail(c, 401, "unauthenticated")
@@ -109,11 +111,18 @@ export const sessionRoutes = (ctx: AppContext) => {
   // Discoverable is opt-in, so browsing only surfaces people who chose to be found.
   // Signed-in only; public fields only (handle/name/avatar/role) — never email.
   app.get("/v1/people", async (c) => {
-    if (!(await currentUser(c))) return fail(c, 401, "unauthenticated")
+    const me = await currentUser(c)
+    if (!me) return fail(c, 401, "unauthenticated")
     const q = (c.req.query("query") ?? "").trim()
-    const found = q
-      ? await meta.searchDiscoverableUsers(q, 60)
-      : await meta.listDiscoverableUsers(60)
+    // ?scope=workspace → the people you actually work with (any shared workspace),
+    // discoverable or not — membership already implies you can see each other.
+    // Default → the global discoverable directory, as before.
+    const found =
+      c.req.query("scope") === "workspace"
+        ? await meta.listWorkspaceMates(me.id, 60)
+        : q
+          ? await meta.searchDiscoverableUsers(q, 60)
+          : await meta.listDiscoverableUsers(60)
     return c.json({
       users: found.map((u) => ({
         username: u.username,
@@ -124,13 +133,31 @@ export const sessionRoutes = (ctx: AppContext) => {
     })
   })
 
+  // Whether this viewer may see this profile at all. Discoverable (the default) ⇒
+  // yes, anyone — a public artifact's author chip must resolve to a profile.
+  // Discoverable OFF ⇒ only the person themselves and people who share a workspace
+  // with them; everyone else gets the same 404 as an unknown handle, so an opted-out
+  // account can't be confirmed to exist by probing handles.
+  const profileVisibleTo = async (
+    c: Parameters<typeof currentUser>[0],
+    p: { id: string; discoverable?: boolean | number | null },
+  ): Promise<boolean> => {
+    if (p.discoverable !== false && p.discoverable !== 0) return true
+    const me = await currentUser(c)
+    if (!me) return false
+    if (me.id === p.id) return true
+    return (await meta.sharedOrgIds(me.id, p.id)).length > 0
+  }
+
   // A public profile by handle — the GitHub-style discovery surface. Email is
   // intentionally omitted (private); the handle, name, avatar, stats, GitHub link, and
-  // (for a signed-in viewer) whether they already follow are public. Readable by anyone.
+  // (for a signed-in viewer) whether they already follow are public. Readable by anyone
+  // while the account is discoverable; hidden otherwise (profileVisibleTo).
   app.get("/v1/users/:handle", async (c) => {
     const handle = normalizeUsername(c.req.param("handle"))
     const p = await meta.getUserByUsername(handle)
     if (!p) return fail(c, 404, "no profile with that username")
+    if (!(await profileVisibleTo(c, p))) return fail(c, 404, "no profile with that username")
     const me = await currentUser(c)
     const ghIds = await meta.githubIdsForUser(p.id)
     // A signed-in viewer also sees the owner's non-public work in workspaces they share.
@@ -170,6 +197,7 @@ export const sessionRoutes = (ctx: AppContext) => {
   app.get("/v1/users/:handle/artifacts", async (c) => {
     const p = await meta.getUserByUsername(normalizeUsername(c.req.param("handle")))
     if (!p) return fail(c, 404, "no profile with that username")
+    if (!(await profileVisibleTo(c, p))) return fail(c, 404, "no profile with that username")
     const me = await currentUser(c)
     const ghIds = await meta.githubIdsForUser(p.id)
     const sharedOrgs = me ? await meta.sharedOrgIds(me.id, p.id) : []
@@ -215,14 +243,21 @@ export const sessionRoutes = (ctx: AppContext) => {
     image: string | null
     profession?: string | null
   }) => ({ username: u.username, name: u.name, image: u.image, profession: u.profession ?? null })
+  // The follow graph is for participants: sign in to read it. (The counts on the
+  // profile stay public; who exactly follows whom does not — that's the part a
+  // crawler could mine.)
   app.get("/v1/users/:handle/followers", async (c) => {
+    if (!(await currentUser(c))) return fail(c, 401, "unauthenticated")
     const p = await meta.getUserByUsername(normalizeUsername(c.req.param("handle")))
     if (!p) return fail(c, 404, "no profile with that username")
+    if (!(await profileVisibleTo(c, p))) return fail(c, 404, "no profile with that username")
     return c.json({ users: (await meta.listFollowers(p.id, 100)).map(publicCard) })
   })
   app.get("/v1/users/:handle/following", async (c) => {
+    if (!(await currentUser(c))) return fail(c, 401, "unauthenticated")
     const p = await meta.getUserByUsername(normalizeUsername(c.req.param("handle")))
     if (!p) return fail(c, 404, "no profile with that username")
+    if (!(await profileVisibleTo(c, p))) return fail(c, 404, "no profile with that username")
     return c.json({ users: (await meta.listFollowing(p.id, 100)).map(publicCard) })
   })
 

--- a/apps/api/src/routes/sharing.ts
+++ b/apps/api/src/routes/sharing.ts
@@ -69,6 +69,15 @@ export const sharingRoutes = (ctx: AppContext) => {
     const id = await resolveUserRef(meta, (b.user ?? b.username ?? b.email) as string)
     const [user] = id ? await meta.getUsers([id]) : []
     if (!user) return fail(c, 404, "no Derive user with that username or email")
+    // An artifact keeps at least one owner-member: downgrading the sole owner
+    // would orphan it — on `private` visibility, irrecoverably (workspace role
+    // grants nothing there, so no one could share it back open).
+    if (b.role !== "owner") {
+      const members = await meta.listArtifactMembers(artifact.id)
+      const owners = members.filter((m) => m.role === "owner")
+      if (owners.length === 1 && owners[0]?.user_id === user.id)
+        return fail(c, 400, "an artifact keeps at least one owner")
+    }
     await meta.setArtifactMember({
       id: newId("am"),
       artifact_id: artifact.id,
@@ -107,11 +116,13 @@ export const sharingRoutes = (ctx: AppContext) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact) return fail(c, 404, "not found")
     if (!(await authorize(c, "share", artifact))) return fail(c, 403, "forbidden")
-    const target = (await meta.listArtifactMembers(artifact.id)).find(
-      (m) => m.user_id === c.req.param("userId"),
-    )
+    const members = await meta.listArtifactMembers(artifact.id)
+    const target = members.find((m) => m.user_id === c.req.param("userId"))
     if (target && rank(target.role) > (await callerRank(c, artifact)))
       return fail(c, 403, "you can't remove a collaborator who outranks you")
+    // Same invariant as the role-change guard above: never remove the last owner.
+    if (target?.role === "owner" && members.filter((m) => m.role === "owner").length === 1)
+      return fail(c, 400, "an artifact keeps at least one owner")
     await meta.removeArtifactMember(artifact.id, c.req.param("userId"))
     return c.body(null, 204)
   })

--- a/apps/api/test/analytics.test.ts
+++ b/apps/api/test/analytics.test.ts
@@ -21,7 +21,7 @@ import {
 
 describe("view analytics", () => {
   it("de-dups rapid re-opens and aggregates uniques, per-version, recent viewers", async () => {
-    const { short_id } = await (await upload("a.md", "# A")).json()
+    const { short_id } = await (await upload("a.md", "# A", { visibility: "link" })).json()
     await upload("a.md", "# A v2", { message: "v2" }, short_id) // now at v2
 
     // Three rapid opens from one anonymous viewer (cookie reused) collapse to ONE
@@ -179,7 +179,9 @@ describe("analytics: identity + retention", () => {
   const { app, meta: m } = makeAuthedApp("analytics-id", [ann, bob], "commenter")
 
   it("excludes the owner's own opens; counts a viewer (by name + avatar) and anon", async () => {
-    const sid = (await (await publishAs(app, "<h1>v</h1>", {}, as(ann.email))).json()).short_id
+    const sid = (
+      await (await publishAs(app, "<h1>v</h1>", { visibility: "link" }, as(ann.email))).json()
+    ).short_id
     // Ann is the workspace owner (first member). Her own opens don't count.
     for (let i = 0; i < 2; i++)
       await app.request(`/v1/artifacts/${sid}/view`, jsonAs(as(ann.email), { version: 1 }))
@@ -245,6 +247,7 @@ describe("analytics: identity + retention", () => {
     })
     const fd = new FormData()
     fd.append("file", new Blob([new TextEncoder().encode("# x")]), "x.md")
+    fd.append("visibility", "link")
     // Publish as the token (owner); the view below is anonymous so it sets the cookie.
     const { short_id } = await (
       await xs.request("/v1/artifacts", { method: "POST", body: fd, headers: bearer(TEST_TOKEN) })

--- a/apps/api/test/harden.test.ts
+++ b/apps/api/test/harden.test.ts
@@ -147,25 +147,25 @@ describe("B-019: @mention notifies only collaborators", () => {
 })
 
 // B-018: an explicitly-provided visibility that isn't a known value is rejected, not
-// silently coerced to `link` (URL-readable). Absent visibility still defaults to link.
+// silently coerced. Absent visibility defaults to `org` (workspace-only).
 describe("B-018: publish rejects an unknown visibility", () => {
   const owner: TestUser = { id: "u_b18_owner", email: "o18@derive.test", name: "Owner18" }
 
-  it("400s on an unknown visibility; valid values store; absent defaults to link", async () => {
+  it("400s on an unknown visibility; valid values store; absent defaults to org", async () => {
     const { app } = makeAuthedApp("harden-b18", [owner])
     const bad = await publishAs(
       app,
       "<h1>x</h1>",
-      { title: "v", visibility: "private" },
+      { title: "v", visibility: "secret" },
       as(owner.email),
     )
     expect(bad.status).toBe(400)
-    const org = await (
-      await publishAs(app, "<h1>x</h1>", { title: "v2", visibility: "org" }, as(owner.email))
+    const link = await (
+      await publishAs(app, "<h1>x</h1>", { title: "v2", visibility: "link" }, as(owner.email))
     ).json()
-    expect(org.visibility).toBe("org")
+    expect(link.visibility).toBe("link")
     const def = await (await publishAs(app, "<h1>x</h1>", { title: "v3" }, as(owner.email))).json()
-    expect(def.visibility).toBe("link")
+    expect(def.visibility).toBe("org")
   })
 })
 

--- a/apps/api/test/http-helpers.test.ts
+++ b/apps/api/test/http-helpers.test.ts
@@ -78,8 +78,9 @@ describe("str / visibilityOf — input coercion", () => {
   })
 
   it("visibilityOf accepts only the known visibilities", () => {
-    for (const v of ["public", "link", "org", "password"]) expect(visibilityOf(v)).toBe(v)
-    for (const bad of ["private", "", "PUBLIC", null, 3]) expect(visibilityOf(bad)).toBeUndefined()
+    for (const v of ["public", "link", "org", "password", "private"])
+      expect(visibilityOf(v)).toBe(v)
+    for (const bad of ["secret", "", "PUBLIC", null, 3]) expect(visibilityOf(bad)).toBeUndefined()
   })
 })
 

--- a/apps/api/test/moderation.test.ts
+++ b/apps/api/test/moderation.test.ts
@@ -10,7 +10,13 @@ describe("moderation: report → takedown (410) → reinstate + audit (C4a)", ()
   it("anyone can report a public artifact; reason is required", async () => {
     await app.request("/v1/me", { headers: as(owner.email) })
     await app.request("/v1/me", { headers: as(dev.email) })
-    shortId = (await (await publishAs(app, "<h1>spammy</h1>", {}, as(owner.email))).json()).short_id
+    // Link-visible on purpose: the takedown assertions below read anonymously
+    // (the 410 must outrank the read gate on a reachable artifact).
+    shortId = (
+      await (
+        await publishAs(app, "<h1>spammy</h1>", { visibility: "link" }, as(owner.email))
+      ).json()
+    ).short_id
     // Anonymous (no session) can't report at all — refused at the door.
     expect(
       (await app.request(`/v1/artifacts/${shortId}/report`, jsonAs({}, { reason: "x" }))).status,

--- a/apps/api/test/profiles.test.ts
+++ b/apps/api/test/profiles.test.ts
@@ -270,18 +270,24 @@ describe("profile work-list (visibility-scoped)", () => {
     expect(carlProfile.user.stats.works).toBe(2)
   })
 
-  it("exposes follower/following lists as public profiles (no ids/email)", async () => {
+  it("exposes follower/following lists to signed-in viewers (no ids/email); anon gets 401", async () => {
     // carl follows amy.
     await app.request("/v1/follows", {
       method: "POST",
       headers: { "content-type": "application/json", ...as(carl.email) },
       body: JSON.stringify({ kind: "user", target: "amyw" }),
     })
-    const followers = await (await app.request("/v1/users/amyw/followers")).json()
+    // The follow graph is for participants — an anonymous crawler can't read it.
+    expect((await app.request("/v1/users/amyw/followers")).status).toBe(401)
+    const followers = await (
+      await app.request("/v1/users/amyw/followers", { headers: as(carl.email) })
+    ).json()
     expect(followers.users.map((u: { username: string }) => u.username)).toContain("carlw")
     expect(followers.users[0]).not.toHaveProperty("email")
     expect(followers.users[0]).not.toHaveProperty("id")
-    const following = await (await app.request("/v1/users/carlw/following")).json()
+    const following = await (
+      await app.request("/v1/users/carlw/following", { headers: as(carl.email) })
+    ).json()
     expect(following.users.map((u: { username: string }) => u.username)).toContain("amyw")
   })
 })

--- a/apps/api/test/sharing.test.ts
+++ b/apps/api/test/sharing.test.ts
@@ -34,7 +34,9 @@ describe("artifact share → notification", () => {
   })
 
   it("does not notify when you share with yourself", async () => {
-    expect((await share(alice.email, "editor", alice.email)).status).toBe(201)
+    // Owner-role: Alice is the artifact's sole owner-member (written at publish),
+    // and the last owner can't be downgraded — a self-share stays owner.
+    expect((await share(alice.email, "owner", alice.email)).status).toBe(201)
     const aliceN = await (
       await app.request("/v1/notifications", { headers: as(alice.email) })
     ).json()

--- a/apps/api/test/visibility.test.ts
+++ b/apps/api/test/visibility.test.ts
@@ -142,3 +142,28 @@ describe("/v1/people?scope=workspace", () => {
     expect(all.users.map((u: { username: string }) => u.username)).not.toContain("outv")
   })
 })
+
+describe("the last owner is immovable", () => {
+  it("refuses to remove or downgrade the sole owner-member", async () => {
+    const { app } = makeAuthedApp("vis-last-owner", [ana], "editor")
+    const a = await (
+      await publishAs(app, "<h1>mine</h1>", { visibility: "private" }, as(ana.email))
+    ).json()
+    const del = await app.request(`/v1/artifacts/${a.short_id}/members/${ana.id}`, {
+      method: "DELETE",
+      headers: as(ana.email),
+    })
+    expect(del.status).toBe(400)
+    const demote = await app.request(`/v1/artifacts/${a.short_id}/members`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", ...as(ana.email) },
+      body: JSON.stringify({ user: "anav", role: "viewer" }),
+    })
+    expect(demote.status).toBe(400)
+    // Still the owner; still readable.
+    const detail = await (
+      await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(ana.email) })
+    ).json()
+    expect(detail.my_role).toBe("owner")
+  })
+})

--- a/apps/api/test/visibility.test.ts
+++ b/apps/api/test/visibility.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest"
+import { as, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// The sharing & visibility model end-to-end: the workspace-only default, the
+// `private` (invite-only) tier, and profile privacy (discoverable as a real
+// switch). Companion to the effectiveRole table tests in @derive/core.
+
+const ana: TestUser = { id: "u_vis_ana", email: "ana@vis.test", name: "Ana", username: "anav" }
+const ben: TestUser = { id: "u_vis_ben", email: "ben@vis.test", name: "Ben", username: "benv" }
+
+describe("publish defaults to workspace-only", () => {
+  it("no visibility field ⇒ org; the artifact is unreadable anonymously", async () => {
+    const { app } = makeAuthedApp("vis-default", [ana, ben], "editor")
+    const a = await (await publishAs(app, "<h1>draft</h1>", {}, as(ana.email))).json()
+    expect(a.visibility).toBe("org")
+    // Anonymous (no session header): the detail 404s and the bytes don't serve.
+    expect((await app.request(`/v1/artifacts/${a.short_id}`)).status).toBe(404)
+    expect((await app.request(`/raw/${a.short_id}/v/1/index.html`)).status).toBe(404)
+    // A workspace member reads it fine.
+    expect(
+      (await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(ben.email) })).status,
+    ).toBe(200)
+  })
+})
+
+describe("private: only invited people", () => {
+  it("hides a private artifact from workspace members until shared", async () => {
+    const { app } = makeAuthedApp("vis-private", [ana, ben], "editor")
+    const a = await (
+      await publishAs(app, "<h1>secret</h1>", { visibility: "private" }, as(ana.email))
+    ).json()
+
+    // The creator owns it (the owner-member row written at publish).
+    const mine = await (
+      await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(ana.email) })
+    ).json()
+    expect(mine.my_role).toBe("owner")
+
+    // Ben is a workspace EDITOR and still can't see it — org role grants nothing
+    // on private. Detail, bytes, and the library listing all stay dark.
+    expect(
+      (await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(ben.email) })).status,
+    ).toBe(404)
+    expect(
+      (await app.request(`/raw/${a.short_id}/v/1/index.html`, { headers: as(ben.email) })).status,
+    ).toBe(404)
+    const list = await (await app.request("/v1/artifacts", { headers: as(ben.email) })).json()
+    expect(list.artifacts.map((x: { short_id: string }) => x.short_id)).not.toContain(a.short_id)
+    // The creator's own listing shows it.
+    const own = await (await app.request("/v1/artifacts", { headers: as(ana.email) })).json()
+    expect(own.artifacts.map((x: { short_id: string }) => x.short_id)).toContain(a.short_id)
+
+    // An explicit share opens it — and it lands in Ben's shared feed.
+    const share = await app.request(`/v1/artifacts/${a.short_id}/members`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", ...as(ana.email) },
+      body: JSON.stringify({ user: "benv", role: "commenter" }),
+    })
+    expect(share.status).toBe(201)
+    expect(
+      (await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(ben.email) })).status,
+    ).toBe(200)
+    const shared = await (
+      await app.request("/v1/artifacts?scope=shared", { headers: as(ben.email) })
+    ).json()
+    expect(shared.artifacts.map((x: { short_id: string }) => x.short_id)).toContain(a.short_id)
+  })
+
+  it("never lists a private artifact on the author's profile, even to themselves", async () => {
+    const { app } = makeAuthedApp("vis-private-profile", [ana], "editor")
+    await publishAs(app, "<h1>secret</h1>", { visibility: "private" }, as(ana.email))
+    const works = await (
+      await app.request("/v1/users/anav/artifacts", { headers: as(ana.email) })
+    ).json()
+    expect(works.artifacts).toEqual([])
+  })
+
+  it("your own work never shows in your shared-with-you feed", async () => {
+    const { app } = makeAuthedApp("vis-own-shared", [ana], "editor")
+    await publishAs(app, "<h1>mine</h1>", {}, as(ana.email))
+    const shared = await (
+      await app.request("/v1/artifacts?scope=shared", { headers: as(ana.email) })
+    ).json()
+    expect(shared.artifacts).toEqual([])
+  })
+})
+
+describe("profile privacy: discoverable off hides the profile", () => {
+  // Cara opted out; Dre shares a workspace with her, Eve does not.
+  const cara: TestUser = {
+    id: "u_vis_cara",
+    email: "cara@vis.test",
+    name: "Cara",
+    username: "carav",
+    discoverable: false,
+  }
+  const dre: TestUser = { id: "u_vis_dre", email: "dre@vis.test", name: "Dre", username: "drev" }
+
+  it("404s for anonymous and unrelated viewers; workspace-mates and self still see it", async () => {
+    const { app } = makeAuthedApp("vis-profile", [cara, dre], "editor")
+    const eveApp = makeAuthedApp("vis-profile-eve", [
+      { id: "u_vis_eve", email: "eve@vis.test", name: "Eve", username: "evev" },
+    ]).app
+
+    // Anonymous: same 404 as an unknown handle — existence isn't confirmable.
+    expect((await app.request("/v1/users/carav")).status).toBe(404)
+    expect((await app.request("/v1/users/carav/artifacts")).status).toBe(404)
+    // A workspace-mate still resolves her (they already see each other's work).
+    expect((await app.request("/v1/users/carav", { headers: as(dre.email) })).status).toBe(200)
+    // Herself, of course.
+    expect((await app.request("/v1/users/carav", { headers: as(cara.email) })).status).toBe(200)
+    // A signed-in stranger in another workspace: 404 (isolated app = no shared org).
+    expect((await eveApp.request("/v1/users/carav", { headers: as("eve@vis.test") })).status).toBe(
+      404,
+    )
+  })
+
+  it("a discoverable profile stays anonymous-readable (the author-chip contract)", async () => {
+    const { app } = makeAuthedApp("vis-profile-on", [ana])
+    expect((await app.request("/v1/users/anav")).status).toBe(200)
+  })
+})
+
+describe("/v1/people?scope=workspace", () => {
+  it("lists workspace-mates regardless of discoverability; global browse still honors it", async () => {
+    const opted: TestUser = {
+      id: "u_vis_out",
+      email: "out@vis.test",
+      name: "Out",
+      username: "outv",
+      discoverable: false,
+    }
+    const { app } = makeAuthedApp("vis-people", [ana, opted], "editor")
+    const ws = await (
+      await app.request("/v1/people?scope=workspace", { headers: as(ana.email) })
+    ).json()
+    expect(ws.users.map((u: { username: string }) => u.username)).toContain("outv")
+    // Not yourself.
+    expect(ws.users.map((u: { username: string }) => u.username)).not.toContain("anav")
+    // The global directory still hides the opt-out.
+    const all = await (await app.request("/v1/people", { headers: as(ana.email) })).json()
+    expect(all.users.map((u: { username: string }) => u.username)).not.toContain("outv")
+  })
+})

--- a/apps/web/e2e/deep/share.deep.spec.ts
+++ b/apps/web/e2e/deep/share.deep.spec.ts
@@ -12,11 +12,14 @@ test("owner shares an artifact, changes the role, and removes the member", async
   await secondUser.page.goto(`/artifacts/${id}`)
   await expect(secondUser.page.getByTestId("share-trigger")).toBeHidden()
 
-  // The owner opens the dialog: starts empty.
+  // The owner opens the dialog: the roster starts with themselves — the
+  // publisher is written as the owner-member at creation.
   await owner.goto(`/artifacts/${id}`)
   await owner.getByTestId("share-trigger").click()
   await expect(owner.getByTestId("share-email")).toBeVisible()
-  await expect(owner.getByTestId("share-empty")).toBeVisible()
+  const rows = owner.locator('[data-testid^="share-member-row-"]')
+  await expect(rows).toHaveCount(1)
+  await expect(rows.first()).toContainText("(you)")
 
   // Share with the teammate as a commenter.
   await owner.getByTestId("share-email").fill(secondUser.email)
@@ -24,17 +27,17 @@ test("owner shares an artifact, changes the role, and removes the member", async
   await owner.getByRole("option", { name: "Commenter", exact: true }).click()
   await owner.getByTestId("share-add").click()
 
-  const row = owner.locator('[data-testid^="share-member-row-"]')
-  await expect(row).toHaveCount(1)
-  await expect(row).not.toContainText(secondUser.email) // handle leads; the private email never renders
-  await expect(owner.locator('[data-testid^="share-member-role-"]')).toContainText("Commenter")
+  const teammate = rows.filter({ hasNotText: "(you)" })
+  await expect(rows).toHaveCount(2)
+  await expect(teammate).not.toContainText(secondUser.email) // handle leads; the private email never renders
+  await expect(teammate.locator('[data-testid^="share-member-role-"]')).toContainText("Commenter")
 
   // Promote them to editor.
-  await owner.locator('[data-testid^="share-member-role-"]').click()
+  await teammate.locator('[data-testid^="share-member-role-"]').click()
   await owner.getByRole("option", { name: "Editor", exact: true }).click()
-  await expect(owner.locator('[data-testid^="share-member-role-"]')).toContainText("Editor")
+  await expect(teammate.locator('[data-testid^="share-member-role-"]')).toContainText("Editor")
 
-  // Remove them: back to the empty state.
-  await owner.locator('[data-testid^="share-member-remove-"]').click()
-  await expect(owner.getByTestId("share-empty")).toBeVisible()
+  // Remove them: back to just the owner.
+  await teammate.locator('[data-testid^="share-member-remove-"]').click()
+  await expect(rows).toHaveCount(1)
 })

--- a/apps/web/e2e/deep/visibility.deep.spec.ts
+++ b/apps/web/e2e/deep/visibility.deep.spec.ts
@@ -1,0 +1,111 @@
+import { Buffer } from "node:buffer"
+import type { Page } from "@playwright/test"
+import { expect, test } from "../fixtures"
+
+// The sharing & visibility model through the real UI: the workspace-only
+// default, the general-access picker (the share dialog's Google-Docs ladder),
+// private (invite-only), and profile privacy. Server-side authz is pinned in
+// apps/api/test/visibility.test.ts; this drives the surfaces.
+
+// Publish WITHOUT a visibility — the spec subject is the default itself, so
+// this deliberately bypasses the helper (which pins visibility: link).
+async function publishDefault(page: Page, name = "draft.md"): Promise<string> {
+  let shortId = ""
+  await expect(async () => {
+    const res = await page.request.post("/v1/artifacts", {
+      multipart: { file: { name, mimeType: "text/markdown", buffer: Buffer.from("# Draft") } },
+    })
+    expect(res.ok()).toBeTruthy()
+    shortId = ((await res.json()) as { short_id: string }).short_id
+  }).toPass({ timeout: 10_000 })
+  return shortId
+}
+
+test("a default publish is workspace-only: invisible to another user until the link is opened up", async ({
+  owner,
+  secondUser,
+}) => {
+  const id = await publishDefault(owner)
+
+  // The other user (their own workspace) can't open it.
+  await secondUser.page.goto(`/artifacts/${id}`)
+  await expect(secondUser.page.getByText("Draft")).toBeHidden()
+
+  // The owner widens access to "Anyone with the link" from the share dialog.
+  await owner.goto(`/artifacts/${id}`)
+  await owner.getByTestId("share-trigger").click()
+  await owner.getByTestId("share-visibility").click()
+  await owner.getByRole("option", { name: "Anyone with the link" }).click()
+  await owner.getByTestId("share-visibility-save").click()
+  // The save round-trip re-enables the button; the trigger glyph flips to globe.
+  await expect(owner.getByTestId("share-visibility-save")).toBeDisabled()
+
+  // Now the second user can read it.
+  await secondUser.page.reload()
+  await expect(secondUser.page.getByText("Draft").first()).toBeVisible()
+})
+
+test("the copy-link row carries the canonical URL", async ({ owner }) => {
+  const id = await publishDefault(owner)
+  await owner.goto(`/artifacts/${id}`)
+  await owner.getByTestId("share-trigger").click()
+  await expect(owner.getByTestId("share-url")).toHaveValue(new RegExp(`/artifacts/.*${id}`))
+})
+
+test("private hides an artifact from a workspace member until they're invited", async ({
+  owner,
+  secondUser,
+}) => {
+  // Both users in ONE workspace: the owner invites the second user into theirs
+  // via the workspace members flow is heavyweight here, so instead assert the
+  // API-level contract the UI rides: publish private, share, and watch the
+  // second user's access flip. (Cross-workspace 404s are already covered by the
+  // default-visibility test above; same-workspace exclusion is pinned in the
+  // API tests.)
+  let id = ""
+  await expect(async () => {
+    const res = await owner.request.post("/v1/artifacts", {
+      multipart: {
+        file: { name: "secret.md", mimeType: "text/markdown", buffer: Buffer.from("# Secret") },
+        visibility: "private",
+      },
+    })
+    expect(res.ok()).toBeTruthy()
+    id = ((await res.json()) as { short_id: string }).short_id
+  }).toPass({ timeout: 10_000 })
+
+  await secondUser.page.goto(`/artifacts/${id}`)
+  await expect(secondUser.page.getByText("Secret")).toBeHidden()
+
+  // The owner's share dialog shows Private as the current access and them as
+  // the owner-member; inviting the teammate opens it up.
+  await owner.goto(`/artifacts/${id}`)
+  await owner.getByTestId("share-trigger").click()
+  await expect(owner.getByTestId("share-visibility")).toContainText("Private")
+  await expect(owner.locator('[data-testid^="share-member-row-"]').first()).toContainText("(you)")
+  await owner.getByTestId("share-email").fill(secondUser.email)
+  await owner.getByTestId("share-add").click()
+  await expect(owner.locator('[data-testid^="share-member-row-"]')).toHaveCount(2)
+
+  await secondUser.page.reload()
+  await expect(secondUser.page.getByText("Secret").first()).toBeVisible()
+})
+
+test("turning off the public profile hides it from strangers", async ({ owner, secondUser }) => {
+  const me = (await (await owner.request.get("/v1/me")).json()) as {
+    user: { username: string }
+  }
+  // The stranger can open the profile while it's public…
+  await secondUser.page.goto(`/users/${me.user.username}`)
+  await expect(secondUser.page.getByTestId("profile-name")).toBeVisible()
+
+  // …the owner flips discoverability off in Settings…
+  await owner.goto("/settings")
+  const toggle = owner.getByTestId("account-discoverable")
+  await toggle.click()
+  await expect(toggle).toHaveAttribute("data-state", "unchecked")
+
+  // …and the profile now renders its not-found state for the stranger.
+  await secondUser.page.reload()
+  await expect(secondUser.page.getByTestId("profile-name")).toBeHidden()
+})

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -50,6 +50,10 @@ export async function publishArtifact(
     const res = await page.request.post("/v1/artifacts", {
       multipart: {
         file: { name, mimeType: "text/markdown", buffer: Buffer.from(body) },
+        // Link-visible explicitly: most specs hand the artifact to a second user
+        // or an anonymous page, and the server default is now workspace-only.
+        // Specs about the default itself publish without this.
+        visibility: "link",
       },
     })
     expect(res.ok(), `publish failed: ${res.status()}`).toBeTruthy()

--- a/apps/web/e2e/smoke/profile.smoke.spec.ts
+++ b/apps/web/e2e/smoke/profile.smoke.spec.ts
@@ -53,9 +53,10 @@ test("follow a person from the command-palette people search", async ({ owner, s
 
   await bob.goto("/")
   await bob.getByTestId("open-command-palette").click()
-  // Owner's display name is "E2E Tester" (secondUser is "Second User"), so "Tester"
-  // resolves to exactly one discoverable person.
-  await bob.getByPlaceholder(/Search artifacts, people/).fill("Tester")
+  // Search the exact handle: a parallel run holds dozens of "E2E Tester"
+  // fixture accounts, and the people search caps its results — a name search
+  // can't guarantee THIS run's account makes the cut.
+  await bob.getByPlaceholder(/Search artifacts, people/).fill(maya.username)
 
   const followBtn = bob.getByTestId(`follow-${maya.username}`)
   await expect(followBtn).toBeVisible()
@@ -76,8 +77,10 @@ test("browse + follow from the People directory", async ({ owner, secondUser }) 
 
   await bob.goto("/people")
   await expect(bob.getByTestId("nav-people")).toBeVisible()
-  // The directory browses discoverable people (everyone is discoverable by default), so
-  // the owner shows up with an inline Follow.
+  // Search for the exact handle rather than relying on the capped browse list —
+  // a parallel run accumulates dozens of same-named fixture accounts, and the
+  // 60-row browse (username-ordered) can't guarantee this run's user is in it.
+  await bob.getByTestId("people-search").fill(maya.username)
   const followBtn = bob.getByTestId(`follow-${maya.username}`)
   await expect(followBtn).toBeVisible()
   await expect(followBtn).toHaveAttribute("aria-pressed", "false")

--- a/apps/web/e2e/smoke/share.smoke.spec.ts
+++ b/apps/web/e2e/smoke/share.smoke.spec.ts
@@ -6,17 +6,20 @@ test("owner shares an artifact and the member appears", async ({ owner, secondUs
   await owner.goto(`/artifacts/${shortId}`)
 
   await owner.getByTestId("share-trigger").click()
-  await expect(owner.getByTestId("share-empty")).toBeVisible()
+  // The roster opens with the publisher's own owner row.
+  const rows = owner.locator('[data-testid^="share-member-row-"]')
+  await expect(rows).toHaveCount(1)
+  await expect(rows.first()).toContainText("(you)")
 
   await owner.getByTestId("share-email").fill(secondUser.email)
   await owner.getByTestId("share-role").click()
   await owner.getByRole("option", { name: "Commenter", exact: true }).click()
   await owner.getByTestId("share-add").click()
 
-  const row = owner.locator('[data-testid^="share-member-row-"]')
-  await expect(row).toHaveCount(1)
+  const row = rows.filter({ hasText: "Second User" })
+  await expect(rows).toHaveCount(2)
   // You still share BY email (the input above), but the member row identifies people
   // by name / @handle and never echoes the email back (read-path PII hardening).
-  await expect(row).toContainText("Second User")
+  await expect(row).toHaveCount(1)
   await expect(row).not.toContainText(secondUser.email)
 })

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -591,6 +591,9 @@ export const api = {
   // Unlike searchPeople, an empty query BROWSES the discoverable set.
   people: (q?: string): Promise<{ users: PublicProfile[] }> =>
     f(`/v1/people${q ? `?query=${encodeURIComponent(q)}` : ""}`, opts()).then(j),
+  // The people you share a workspace with — the directory's leading section.
+  workspacePeople: (): Promise<{ users: PublicProfile[] }> =>
+    f("/v1/people?scope=workspace", opts()).then(j),
   // Upload a profile picture (raster image; server validates + stores it and sets
   // user.image to the served URL). Returns the new image URL.
   uploadAvatar: (file: File): Promise<{ image: string }> => {
@@ -772,12 +775,17 @@ export const api = {
   // Follows (track GitHub authors + repo path prefixes) — the activity feed is
   // listArtifacts({ scope: "following" }). All scoped to the active workspace.
   listFollows: (): Promise<{ follows: Follow[] }> => f("/v1/follows", opts()).then(j),
+  // keepalive: a follow toggle is optimistic fire-and-forget, and the click often
+  // immediately precedes a navigation (a palette result row navigates on select) —
+  // without keepalive a full-document load aborts the POST mid-flight and the
+  // follow silently never lands. Tiny body, well under the keepalive 64KB cap.
   addFollow: (kind: FollowKind, target: string): Promise<{ follow: Follow }> =>
-    f("/v1/follows", opts({ kind, target })).then(j),
+    f("/v1/follows", { ...opts({ kind, target }), keepalive: true }).then(j),
   removeFollow: (kind: FollowKind, target: string): Promise<void> =>
     f("/v1/follows", {
       ...opts({ kind, target }),
       method: "DELETE",
+      keepalive: true,
     }).then(() => undefined),
 
   deleteArtifact: (id: string): Promise<void> =>

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -22,6 +22,7 @@ import {
   Folder,
   Folders,
   GitPullRequest,
+  Globe,
   History,
   Layers,
   Link,
@@ -91,6 +92,7 @@ const REG = {
   present: Maximize,
   lock: Lock,
   unlock: LockOpen,
+  globe: Globe,
   // comment toolbar / menu
   react: Smile,
   pencil: Pencil,

--- a/apps/web/src/components/showcase/showcase.tsx
+++ b/apps/web/src/components/showcase/showcase.tsx
@@ -1008,6 +1008,54 @@ function ConfirmDemo() {
   )
 }
 
+/** The share dialog's general-access ladder — the five visibility steps as the
+ *  dialog renders them (glyph + label + consequence), most private first. Static
+ *  data; the live control is ShareButton's Select in pages/artifact/share-dialog. */
+function GeneralAccessDemo() {
+  const steps: { icon: IconName; label: string; blurb: string; current?: boolean }[] = [
+    {
+      icon: "lock",
+      label: "Private",
+      blurb: "Only people added. Workspace membership grants nothing.",
+    },
+    {
+      icon: "workspace",
+      label: "Workspace only",
+      blurb: "Only members of this workspace.",
+      current: true,
+    },
+    { icon: "link", label: "Anyone with the link", blurb: "Anyone with the link can view." },
+    { icon: "globe", label: "Public — listed", blurb: "In the public directory and indexable." },
+    { icon: "lock", label: "Password protected", blurb: "Anyone with the link and the password." },
+  ]
+  return (
+    <div className="max-w-md rounded-xl border border-border bg-card p-1.5">
+      {steps.map((s) => (
+        <div
+          key={s.label}
+          className={cn(
+            "flex items-start gap-2.5 rounded-lg px-2.5 py-2",
+            s.current && "bg-accent",
+          )}
+        >
+          <Icon name={s.icon} className="mt-0.5 shrink-0 text-muted-foreground" />
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+              {s.label}
+              {s.current && (
+                <Badge variant="secondary" className="text-2xs">
+                  Default
+                </Badge>
+              )}
+            </div>
+            <p className="text-sm text-muted-foreground">{s.blurb}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 /** Status panel — the tinted callout across its tones and both layouts. */
 function StatusPanelDemo() {
   return (
@@ -1264,6 +1312,12 @@ export function Showcase() {
             note="The one destructive-confirm surface — the dialog carries the gravity, not a loud red fill."
           >
             <ConfirmDemo />
+          </Row>
+          <Row
+            title="General access"
+            note="The share dialog's visibility ladder, most private to most open. Each step is a glyph + label + one-line consequence; the Share trigger echoes the glyph (globe = the URL alone reads, lock = invite-only)."
+          >
+            <GeneralAccessDemo />
           </Row>
           <Row
             title="Status panel"

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -141,6 +141,16 @@ export const peopleQuery = (query: string) =>
     placeholderData: keepPreviousData,
   })
 
+// The directory's "your workspaces" section — people you already work with,
+// listed ahead of the global browse (and regardless of their discoverability).
+export const workspacePeopleQuery = () =>
+  queryOptions({
+    // Not ["people", <query>] — a literal search for "workspace" must not
+    // collide with this cache entry.
+    queryKey: ["workspace-people"] as const,
+    queryFn: () => api.workspacePeople().then((r) => r.users),
+  })
+
 // The active-sync poll behind the rail's SyncChip. Fast cadence while a sync runs
 // (smooth progress bar), relaxed when idle; unlike the app default this DOES refetch
 // on focus, so returning to the tab surfaces a sync that started elsewhere.

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -85,7 +85,7 @@ const ACCESS: { value: string; label: string; blurb: string; icon: IconName }[] 
 // The state glyph the Share trigger carries so exposure is legible without
 // opening the dialog: a globe when the URL alone reads (link/public), a lock
 // for invite-only, the plain share glyph for workspace/password.
-export const visibilityIcon = (visibility: string): IconName =>
+const visibilityIcon = (visibility: string): IconName =>
   visibility === "public" || visibility === "link"
     ? "globe"
     : visibility === "private"

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -1,4 +1,4 @@
-import { useQueryClient } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useEffect, useRef, useState } from "react"
 import {
   API_BASE,
@@ -9,7 +9,7 @@ import {
   type PublicProfile,
   type Role,
 } from "@/api"
-import { Icon } from "@/components/icons"
+import { Icon, type IconName } from "@/components/icons"
 import { EmptyState } from "@/components/shared/empty-state"
 import { ROLE_LABELS, RoleSelect } from "@/components/shared/role-select"
 import { Eyebrow } from "@/components/shared/section-eyebrow"
@@ -34,6 +34,7 @@ import {
 } from "@/components/ui/select"
 import { toast } from "@/components/ui/sonner"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { useAuth } from "@/ctx"
 import { getInitials } from "@/lib/initials"
 import { artifactQuery } from "@/lib/queries"
 import { cn } from "@/lib/utils"
@@ -45,17 +46,51 @@ const BLURB: Record<Role, string> = {
   owner: "Full control, incl. sharing",
 }
 
-// General access (visibility) options, in order of decreasing reach.
-const ACCESS: { value: string; label: string; blurb: string }[] = [
-  { value: "public", label: "Public — listed", blurb: "In the public directory and indexable." },
-  { value: "link", label: "Anyone with the link", blurb: "Anyone with the link can view." },
-  { value: "org", label: "Workspace only", blurb: "Only members of this workspace." },
+// General access (visibility) options, in order of increasing reach — the ladder
+// reads top-to-bottom from most private to most open, each with the glyph the
+// Share trigger echoes.
+const ACCESS: { value: string; label: string; blurb: string; icon: IconName }[] = [
+  {
+    value: "private",
+    label: "Private",
+    blurb: "Only people added above. Workspace membership grants nothing.",
+    icon: "lock",
+  },
+  {
+    value: "org",
+    label: "Workspace only",
+    blurb: "Only members of this workspace.",
+    icon: "workspace",
+  },
+  {
+    value: "link",
+    label: "Anyone with the link",
+    blurb: "Anyone with the link can view.",
+    icon: "link",
+  },
+  {
+    value: "public",
+    label: "Public — listed",
+    blurb: "In the public directory and indexable.",
+    icon: "globe",
+  },
   {
     value: "password",
     label: "Password protected",
     blurb: "Anyone with the link and the password.",
+    icon: "lock",
   },
 ]
+
+// The state glyph the Share trigger carries so exposure is legible without
+// opening the dialog: a globe when the URL alone reads (link/public), a lock
+// for invite-only, the plain share glyph for workspace/password.
+export const visibilityIcon = (visibility: string): IconName =>
+  visibility === "public" || visibility === "link"
+    ? "globe"
+    : visibility === "private"
+      ? "lock"
+      : "share"
 
 /**
  * Per-artifact sharing, opened from the artifact header. Follows the Google Docs
@@ -76,6 +111,7 @@ export function ShareButton({
   generalRole?: GeneralRole
 }) {
   const qc = useQueryClient()
+  const { me } = useAuth()
   const [members, setMembers] = useState<ArtifactMember[]>([])
   const [email, setEmail] = useState("")
   const [role, setRole] = useState<Role>("editor")
@@ -107,6 +143,13 @@ export function ShareButton({
 
   // GDocs model: owners and editors manage access; everyone else gets view-only.
   const canManage = myRole === "owner" || myRole === "editor"
+
+  // The canonical share URL — the server-built artifact URL when the detail is
+  // cached (it is, on the artifact page), else reconstructed from the short id.
+  const { data: art } = useQuery({ ...artifactQuery(shortId), enabled: false })
+  const shareUrl =
+    art?.url ??
+    `${typeof window === "undefined" ? "" : window.location.origin}/artifacts/${shortId}`
 
   // Embed snippet: an iframe of the embeddable view. Same-origin by default; the
   // split-deploy SPA points at the API origin via API_BASE. The embed only shows
@@ -305,9 +348,10 @@ export function ShareButton({
       <DialogTrigger asChild>
         {/* The artifact page's ONE filled-ink primary — the toolbar's single focal
             point (design-system.md: one filled primary per page; ink is where the
-            eye lands). Everything else in the bar is ghost. */}
+            eye lands). Everything else in the bar is ghost. The glyph carries the
+            exposure state: globe = the URL alone reads, lock = invite-only. */}
         <Button data-testid="share-trigger" variant="default" size="sm">
-          <Icon name="share" />
+          <Icon name={visibilityIcon(visibility)} />
           Share
         </Button>
       </DialogTrigger>
@@ -333,6 +377,27 @@ export function ShareButton({
 
           {/* ---- People: who can access + general access ---- */}
           <TabsContent value="people">
+            {/* Copy link — the #1 share action, first and always available. Whether
+                the recipient can OPEN it is the general-access setting below. */}
+            <div className="mb-3.5 flex items-center gap-1.5">
+              <Input
+                readOnly
+                data-testid="share-url"
+                aria-label="Artifact link"
+                value={shareUrl}
+                onFocus={(e) => e.currentTarget.select()}
+                className="flex-1 bg-secondary font-mono"
+              />
+              <Button
+                data-testid="share-url-copy"
+                variant="secondary"
+                size="sm"
+                onClick={() => copyUrl(shareUrl)}
+              >
+                <Icon name="link" />
+                Copy link
+              </Button>
+            </div>
             {canManage ? (
               <>
                 <form onSubmit={add} className="flex items-center gap-1.5">
@@ -460,6 +525,9 @@ export function ShareButton({
                       <div className="min-w-0 flex-1">
                         <div className="truncate text-sm font-medium text-foreground">
                           {m.name ?? (m.handle ? `@${m.handle}` : m.user_id)}
+                          {m.user_id === me?.id && (
+                            <span className="text-muted-foreground"> (you)</span>
+                          )}
                         </div>
                         {m.name && m.handle && (
                           <div className="truncate font-mono text-2xs text-muted-foreground">
@@ -467,7 +535,12 @@ export function ShareButton({
                           </div>
                         )}
                       </div>
-                      {canManage ? (
+                      {/* The sole owner's row is fixed — the server refuses to
+                          downgrade or remove the last owner, so don't offer it. */}
+                      {canManage &&
+                      !(
+                        m.role === "owner" && members.filter((x) => x.role === "owner").length === 1
+                      ) ? (
                         <>
                           <div data-testid={`share-member-role-${m.user_id}`} className="w-23">
                             <RoleSelect
@@ -520,6 +593,7 @@ export function ShareButton({
                       <SelectContent>
                         {ACCESS.map((a) => (
                           <SelectItem key={a.value} value={a.value}>
+                            <Icon name={a.icon} className="text-muted-foreground" />
                             {a.label}
                           </SelectItem>
                         ))}

--- a/apps/web/src/pages/library/quick-organize.tsx
+++ b/apps/web/src/pages/library/quick-organize.tsx
@@ -7,7 +7,21 @@ import { artifactQuery } from "@/lib/queries"
 // Library-level mounts for the card ⋯ menu's organize actions. The shared
 // dialogs own the API calls; these wrappers own the state the dialogs render
 // from, and report changes up so LibraryBody can sync its caches. Mounted only
-// while staged (`{pending && <…/>}`), the same pattern as ShareCollectionDialog.
+// while staged (`{pending && <…/>}`).
+
+// Close by letting Radix finish first: the dialog holds a pointer-events lock
+// on <body> until its exit transition ends, and unmounting it mid-close leaks
+// the lock — the page keeps rendering but stops accepting clicks. So flip
+// `open` (Radix animates out and releases), THEN unmount.
+function useDialogClose(onClose: () => void) {
+  const [open, setOpen] = useState(true)
+  const onOpenChange = (o: boolean) => {
+    if (o) return
+    setOpen(false)
+    window.setTimeout(onClose, 200)
+  }
+  return { open, onOpenChange }
+}
 
 export function LibraryTagsDialog({
   artifact,
@@ -18,6 +32,7 @@ export function LibraryTagsDialog({
   onChange: (shortId: string, tags: string[]) => void
   onClose: () => void
 }) {
+  const close = useDialogClose(onClose)
   // Tags ride on the list payload; local state keeps the dialog's chips live
   // across its optimistic + server-normalized onChange calls.
   const [tags, setTags] = useState(artifact.tags ?? [])
@@ -30,10 +45,7 @@ export function LibraryTagsDialog({
         setTags(t)
         onChange(artifact.short_id, t)
       }}
-      open
-      onOpenChange={(o) => {
-        if (!o) onClose()
-      }}
+      {...close}
     />
   )
 }
@@ -47,6 +59,7 @@ export function LibraryCollectionsDialog({
   onChange: (shortId: string, ids: string[]) => void
   onClose: () => void
 }) {
+  const close = useDialogClose(onClose)
   // Collection membership rides only on the detail payload, so fetch it on
   // open — one cached request, usually already warmed by the card-hover
   // prefetch. Until the first toggle, membership reads straight off the query.
@@ -60,10 +73,7 @@ export function LibraryCollectionsDialog({
         setIds(next)
         onChange(artifact.short_id, next)
       }}
-      open
-      onOpenChange={(o) => {
-        if (!o) onClose()
-      }}
+      {...close}
     />
   )
 }

--- a/apps/web/src/pages/people.tsx
+++ b/apps/web/src/pages/people.tsx
@@ -8,13 +8,14 @@ import { FollowButton } from "@/components/shared/follow-button"
 import { PageHeader } from "@/components/shared/page-header"
 import { PageShell } from "@/components/shared/page-shell"
 import { SearchField } from "@/components/shared/search-field"
+import { SectionEyebrow } from "@/components/shared/section-eyebrow"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { colorForName } from "@/lib/avatar-tints"
 import { getInitials } from "@/lib/initials"
-import { peopleQuery } from "@/lib/queries"
+import { peopleQuery, workspacePeopleQuery } from "@/lib/queries"
 import { useDelayedPending } from "@/lib/use-delayed-pending"
 
 // The people results grid geometry, defined once so the live grid and its skeleton
@@ -38,6 +39,14 @@ export function People() {
   // the true first load; gate the skeleton so a cache-warm open flashes nothing.
   const showSkeleton = useDelayedPending(isPending)
   const people = data ?? []
+
+  // The people you actually work with lead the browse view (Slack's mental model);
+  // the global discoverable directory follows. A search collapses to one flat
+  // result list — sectioning search hits by workspace would just split matches.
+  const { data: mates = [] } = useQuery(workspacePeopleQuery())
+  const browsing = !debounced
+  const mateHandles = new Set(mates.map((m) => m.username))
+  const globalPeople = browsing ? people.filter((p) => !mateHandles.has(p.username)) : people
 
   return (
     <PageShell className="flex flex-col gap-5">
@@ -78,7 +87,7 @@ export function People() {
               </Button>
             }
           />
-        ) : people.length === 0 ? (
+        ) : people.length === 0 && mates.length === 0 ? (
           <div data-testid="people-empty">
             <EmptyState
               icon={<Icon name="following" strokeWidth={1.75} />}
@@ -91,11 +100,34 @@ export function People() {
             />
           </div>
         ) : (
-          <ul role="list" className={PEOPLE_GRID} data-testid="people-grid">
-            {people.map((p) => (
-              <PersonCard key={p.username} person={p} />
-            ))}
-          </ul>
+          <div className="flex flex-col gap-6">
+            {browsing && mates.length > 0 && (
+              <section data-testid="people-workspace">
+                <SectionEyebrow className="mb-3" count={mates.length}>
+                  Your workspaces
+                </SectionEyebrow>
+                <ul role="list" className={PEOPLE_GRID}>
+                  {mates.map((p) => (
+                    <PersonCard key={p.username} person={p} />
+                  ))}
+                </ul>
+              </section>
+            )}
+            {globalPeople.length > 0 && (
+              <section>
+                {browsing && mates.length > 0 && (
+                  <SectionEyebrow className="mb-3" count={globalPeople.length}>
+                    Everyone on Derive
+                  </SectionEyebrow>
+                )}
+                <ul role="list" className={PEOPLE_GRID} data-testid="people-grid">
+                  {globalPeople.map((p) => (
+                    <PersonCard key={p.username} person={p} />
+                  ))}
+                </ul>
+              </section>
+            )}
+          </div>
         )}
       </div>
     </PageShell>

--- a/apps/web/src/pages/settings/profile-section.tsx
+++ b/apps/web/src/pages/settings/profile-section.tsx
@@ -89,8 +89,8 @@ export function ProfileSection() {
       <SettingsGroup title="Discoverability">
         <SettingRow
           htmlFor="account-discoverable"
-          label="List me in people search"
-          description={`On by default. Your @${me.username ?? "handle"}, name, role, and photo appear in people search; turn it off to hide yourself.`}
+          label="Public profile"
+          description={`On by default. Your profile at @${me.username ?? "handle"} — name, role, photo, and public work — is visible to anyone, and you appear in people search. Turn it off and only people who share a workspace with you can see it.`}
         >
           <Switch
             id="account-discoverable"

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS artifact (
   org_id TEXT NOT NULL DEFAULT 'local',
   slug TEXT,
   title TEXT,
-  visibility TEXT NOT NULL DEFAULT 'link',
+  visibility TEXT NOT NULL DEFAULT 'org',
   password_hash TEXT,
   general_role TEXT NOT NULL DEFAULT 'viewer',
   kind TEXT NOT NULL,

--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -315,6 +315,14 @@ if (flags.json) {
   console.log(JSON.stringify(json))
 } else {
   console.log(`✓ ${json.url}`)
-  console.log(`  short_id ${json.short_id} · v${json.current_version} · ${json.kind}`)
+  console.log(
+    `  short_id ${json.short_id} · v${json.current_version} · ${json.kind} · ${json.visibility}`,
+  )
+  // Publishing is workspace-only by default; say so, so nobody mails a URL
+  // that 404s for the recipient.
+  if (json.visibility === "org" || json.visibility === "private")
+    console.log(
+      `  ${json.visibility === "org" ? "workspace-only" : "invite-only"} — pass --visibility link (or use the Share dialog) to make the URL readable by others`,
+    )
   if (savedId) console.log(`  saved id to ${CONFIG_FILE} — future publishes target this artifact`)
 }

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -45,12 +45,14 @@ export function tokenFor(server) {
   return loadCredentials()[originOf(server)]?.token ?? null
 }
 
-/** The derive.json a fresh project starts with (no id until first publish). */
+/** The derive.json a fresh project starts with (no id until first publish).
+ *  Workspace-only visibility, like every other publish path — a scaffolded
+ *  project opts into URL sharing by editing this field, not by accident. */
 export const defaultConfig = (title = "My artifact", entry = "index.md") => ({
   $schema: "./derive.schema.json",
   title,
   entry,
-  visibility: "link",
+  visibility: "org",
   spa: false,
   id: null,
 })
@@ -176,7 +178,7 @@ export const DERIVE_SCHEMA = {
   properties: {
     title: { type: "string", description: "Artifact title." },
     entry: { type: "string", description: "File or directory `derive publish` targets." },
-    visibility: { enum: ["public", "link", "org", "password"], default: "link" },
+    visibility: { enum: ["public", "link", "org", "password", "private"], default: "org" },
     spa: {
       type: "boolean",
       description: "Serve a single-page-app fallback for unknown paths.",

--- a/packages/cli/test/config.test.js
+++ b/packages/cli/test/config.test.js
@@ -40,7 +40,7 @@ describe("scaffold", () => {
       "index.md",
     ])
     const cfg = JSON.parse(readFileSync(join(d, CONFIG_FILE), "utf8"))
-    expect(cfg).toMatchObject({ title: "Report", entry: "index.md", id: null, visibility: "link" })
+    expect(cfg).toMatchObject({ title: "Report", entry: "index.md", id: null, visibility: "org" })
     // The MCP config + skill are present and reference the published server.
     expect(JSON.parse(readFileSync(join(d, ".mcp.json"), "utf8")).mcpServers.derive.args).toContain(
       "@derive/mcp",

--- a/packages/core/src/permissions.test.ts
+++ b/packages/core/src/permissions.test.ts
@@ -14,7 +14,7 @@ import {
 import type { Visibility } from "./ports"
 
 const ACTIONS: Action[] = ["read", "comment", "propose", "publish", "approve", "share", "manage"]
-const VISIBILITIES: Visibility[] = ["public", "link", "password", "org"]
+const VISIBILITIES: Visibility[] = ["public", "link", "password", "org", "private"]
 const WRITE_ACTIONS: Action[] = ["comment", "propose", "publish", "approve", "share", "manage"]
 
 // The authoritative access matrix: the minimum role each action requires. This is
@@ -122,6 +122,21 @@ describe("effectiveRole — the documented access table", () => {
     expect(effectiveRole(user({ orgRole: "viewer" }), "link", "commenter")).toBe("commenter")
     // ...but an editor stays editor (max of explicit and floor).
     expect(effectiveRole(user({ orgRole: "editor" }), "link", "commenter")).toBe("editor")
+  })
+
+  it("private admits only per-artifact members — workspace role grants nothing", () => {
+    // The distinction from org: a workspace editor cannot see a teammate's
+    // private draft, but an explicit share (or the creator's owner-member row,
+    // written at publish) opens it. Collection shares ride artifactRole too.
+    expect(effectiveRole(user({ orgRole: "owner" }), "private")).toBeNull()
+    expect(effectiveRole(user({ orgRole: "editor" }), "private", "commenter")).toBeNull()
+    expect(effectiveRole(user({ artifactRole: "owner" }), "private")).toBe("owner")
+    expect(effectiveRole(user({ artifactRole: "commenter", orgRole: "editor" }), "private")).toBe(
+      "commenter",
+    )
+    expect(effectiveRole(anon, "private")).toBeNull()
+    // The operator token stays owner everywhere.
+    expect(effectiveRole(token, "private")).toBe("owner")
   })
 })
 

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -88,7 +88,15 @@ export function effectiveRole(
 ): Role | null {
   if (actor.kind === "token") return "owner"
   // A per-artifact share or workspace membership — authenticated callers only.
-  const explicit = actor.kind === "user" ? (actor.artifactRole ?? actor.orgRole) : null
+  // `private` is the exception: workspace membership grants nothing there, so a
+  // team-workspace draft stays invisible to teammates until explicitly shared
+  // (per-artifact and collection shares both ride artifactRole).
+  const explicit =
+    actor.kind === "user"
+      ? visibility === "private"
+        ? actor.artifactRole
+        : (actor.artifactRole ?? actor.orgRole)
+      : null
   // The general-access floor for a reacher with no higher explicit grant. Only an
   // authenticated reacher gets the configured general role; an anonymous reacher is
   // clamped to `viewer` — never elevated to a writing role without an account.

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -13,7 +13,9 @@ export interface BlobStore {
 export type ArtifactKind = "file" | "bundle"
 // `password`: world-reachable by URL like `link`, but the bytes stay gated until
 // the visitor enters the password (then a viewer; members/owners see it by role).
-export type Visibility = "public" | "link" | "org" | "password"
+// `private`: only per-artifact members (the publisher becomes the owner-member at
+// creation) — workspace membership grants nothing, unlike `org`.
+export type Visibility = "public" | "link" | "org" | "password" | "private"
 
 /** A platform subdomain (`name.derived.app`) or a customer's own domain. */
 export type DomainKind = "subdomain" | "custom"
@@ -89,6 +91,10 @@ export interface ListArtifactsOpts {
   /** Only `public` artifacts. Set for anonymous / non-member callers so a workspace
    *  listing never leaks `org`/`link`/`password` titles to someone who can't open them. */
   publicOnly?: boolean
+  /** Who is reading the list. `private` artifacts only appear for their explicit
+   *  members, so the query needs the viewer to check membership against. Omitted ⇒
+   *  a trusted caller (the operator token / internal jobs) that sees everything. */
+  viewerId?: string
   /** Profile work-list visibility gate: a row is included when it is `public` OR its
    *  `org_id` is in this set (the workspaces the viewer shares with the profile owner).
    *  An empty/omitted set with a profile query ⇒ public-only. Used by `listUserWorks`
@@ -350,6 +356,9 @@ export interface MetaStore {
   listFollowing(userId: string, limit: number): Promise<UserProfile[]>
   /** Tags per artifact, batched (no N+1). Missing ids map to no entry. */
   tagsForArtifacts(artifactIds: string[]): Promise<Record<string, string[]>>
+  /** The user's per-artifact share roles across a page of artifacts, one query —
+   *  lets a listing fold shares into `my_role` without a per-row member lookup. */
+  artifactRolesFor(userId: string, artifactIds: string[]): Promise<Record<string, Role>>
   /** Replace an artifact's full tag set (deduped, trimmed, lowercased upstream). */
   setArtifactTags(artifactId: string, tags: string[]): Promise<void>
 
@@ -523,6 +532,10 @@ export interface MetaStore {
    *  ordered by handle, capped to `limit`. The browse counterpart to
    *  searchDiscoverableUsers — powers the People page's default view. */
   listDiscoverableUsers(limit: number): Promise<UserProfile[]>
+  /** Distinct people sharing any workspace with `userId` (themselves excluded) —
+   *  the People page's "your workspaces" section. Membership already implies you
+   *  can see each other, so `discoverable` doesn't apply here. */
+  listWorkspaceMates(userId: string, limit: number): Promise<UserProfile[]>
 
   // ---- Notifications (in-app, one row per recipient) --------------------
   createNotification(n: NewNotification): Promise<void>
@@ -843,6 +856,10 @@ export interface UserProfile {
   profession?: string | null
   /** One-line "what you do" blurb; null if unset. */
   about?: string | null
+  /** Findable in the People directory AND profile-visible to strangers. False hides
+   *  the profile from everyone but workspace-mates; unset/null reads as true (the
+   *  pre-column accounts). SQLite/D1 store it as 0/1, so number rides along. */
+  discoverable?: boolean | number | null
 }
 
 /** `mention`/`comment`/`share` are artifact-anchored. `follow` (someone followed you)

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -262,7 +262,10 @@ export async function publish(
     org_id: input.orgId ?? "local",
     slug: input.slug ? slugify(input.slug) : slugify(title) || null,
     title,
-    visibility: input.visibility ?? "link",
+    // Workspace-only unless the publisher says otherwise — nothing becomes
+    // URL-readable as a side effect of publishing. Widening is an explicit act
+    // (the Share dialog, --visibility link, or visibility in derive.json).
+    visibility: input.visibility ?? "org",
     password_hash: input.passwordHash ?? null,
     kind,
     spa: input.spa ? 1 : 0,

--- a/packages/core/test/publish.test.ts
+++ b/packages/core/test/publish.test.ts
@@ -113,7 +113,9 @@ describe("publish: single file", () => {
     const { artifact, version } = await publish(meta, blobs, file("<h1>hi</h1>"))
     expect(artifact.kind).toBe("file")
     expect(artifact.title).toBe("page") // ".html" stripped
-    expect(artifact.visibility).toBe("link")
+    // Publishing without a visibility stays workspace-only — nothing becomes
+    // URL-readable by default.
+    expect(artifact.visibility).toBe("org")
     expect(version.n).toBe(1)
     expect(version.content_type).toBe("text/html")
     expect(new TextDecoder().decode((await blobs.get(version.blob_key)) ?? undefined)).toBe(

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -180,7 +180,7 @@ export function createD1Store(d1: D1Database): MetaStore {
       try {
         return (
           ((await db.get(
-            sql`SELECT id, name, image, username, profession, about FROM user WHERE username = ${username}`,
+            sql`SELECT id, name, image, username, profession, about, discoverable FROM user WHERE username = ${username}`,
           )) as UserProfile) ?? null
         )
       } catch {
@@ -238,6 +238,21 @@ export function createD1Store(d1: D1Database): MetaStore {
           sql`SELECT id, name, image, username, profession, about FROM user
               WHERE discoverable IS NOT 0 AND username IS NOT NULL
               ORDER BY username LIMIT ${limit}`,
+        )) as UserProfile[]
+      } catch {
+        return []
+      }
+    },
+
+    listWorkspaceMates: async (userId: string, limit: number): Promise<UserProfile[]> => {
+      try {
+        return (await db.all(
+          sql`SELECT DISTINCT u.id, u.name, u.image, u.username, u.profession, u.about
+              FROM membership m1
+              JOIN membership m2 ON m2.org_id = m1.org_id AND m2.user_id != m1.user_id
+              JOIN user u ON u.id = m2.user_id
+              WHERE m1.user_id = ${userId} AND u.username IS NOT NULL
+              ORDER BY u.username LIMIT ${limit}`,
         )) as UserProfile[]
       } catch {
         return []

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -32,7 +32,7 @@ export const artifact = pgTable("artifact", {
   org_id: text("org_id").notNull().default("local"),
   slug: text("slug"),
   title: text("title"),
-  visibility: text("visibility").$type<Visibility>().notNull().default("link"),
+  visibility: text("visibility").$type<Visibility>().notNull().default("org"),
   password_hash: text("password_hash"),
   general_role: text("general_role").$type<GeneralRole>().notNull().default("viewer"),
   kind: text("kind").$type<ArtifactKind>().notNull(),

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -75,6 +75,7 @@ import {
   isNotNull,
   isNull,
   lte,
+  ne,
   or,
   sql,
 } from "drizzle-orm"
@@ -752,13 +753,31 @@ export class PgMetaStore implements MetaStore {
   listArtifactMembers(artifactId: string): Promise<ArtifactMemberRecord[]> {
     return this.db.select().from(artifactMember).where(eq(artifactMember.artifact_id, artifactId))
   }
+  async artifactRolesFor(userId: string, artifactIds: string[]): Promise<Record<string, Role>> {
+    if (artifactIds.length === 0) return {}
+    const rows = await this.db
+      .select({ artifact_id: artifactMember.artifact_id, role: artifactMember.role })
+      .from(artifactMember)
+      .where(
+        and(eq(artifactMember.user_id, userId), inArray(artifactMember.artifact_id, artifactIds)),
+      )
+    return Object.fromEntries(rows.map((r) => [r.artifact_id, r.role]))
+  }
   // Artifacts explicitly shared with a user (per-artifact membership) — can span
-  // workspaces; drives the home's "Shared with you" section.
+  // workspaces; drives the home's "Shared with you" section. Excludes what they
+  // authored: the creator's own owner-member row (written at publish) is
+  // ownership, not a share (see repos.ts).
   async artifactIdsSharedWith(userId: string): Promise<string[]> {
     const rows = await this.db
       .select({ id: artifactMember.artifact_id })
       .from(artifactMember)
-      .where(eq(artifactMember.user_id, userId))
+      .innerJoin(artifact, eq(artifact.id, artifactMember.artifact_id))
+      .where(
+        and(
+          eq(artifactMember.user_id, userId),
+          or(isNull(artifact.author_id), ne(artifact.author_id, userId)),
+        ),
+      )
     return rows.map((r) => r.id)
   }
   async setArtifactMember(m: NewArtifactMember): Promise<ArtifactMemberRecord> {
@@ -959,9 +978,13 @@ export class PgMetaStore implements MetaStore {
     } else {
       conds.push(eq(artifact.author_id, userId))
     }
+    // Private drafts never ride a profile, shared workspace or not (see repos.ts).
     const orgs = opts.visibleOrgIds ?? []
     if (orgs.length > 0) {
-      const v = or(eq(artifact.visibility, "public"), inArray(artifact.org_id, orgs))
+      const v = or(
+        eq(artifact.visibility, "public"),
+        and(inArray(artifact.org_id, orgs), ne(artifact.visibility, "private")),
+      )
       if (v) conds.push(v)
     } else {
       conds.push(eq(artifact.visibility, "public"))
@@ -1446,7 +1469,7 @@ export class PgMetaStore implements MetaStore {
   async getUserByUsername(username: string): Promise<UserProfile | null> {
     try {
       const { rows } = await this.pool.query(
-        `SELECT id, name, image, username, profession, about FROM "user" WHERE username = $1`,
+        `SELECT id, name, image, username, profession, about, discoverable FROM "user" WHERE username = $1`,
         [username],
       )
       return (rows[0] as UserProfile) ?? null
@@ -1523,6 +1546,23 @@ export class PgMetaStore implements MetaStore {
          WHERE discoverable IS NOT FALSE AND username IS NOT NULL
          ORDER BY username LIMIT $1`,
         [limit],
+      )
+      return rows as UserProfile[]
+    } catch {
+      return []
+    }
+  }
+
+  async listWorkspaceMates(userId: string, limit: number): Promise<UserProfile[]> {
+    try {
+      const { rows } = await this.pool.query(
+        `SELECT DISTINCT u.id, u.name, u.image, u.username, u.profession, u.about
+         FROM membership m1
+         JOIN membership m2 ON m2.org_id = m1.org_id AND m2.user_id != m1.user_id
+         JOIN "user" u ON u.id = m2.user_id
+         WHERE m1.user_id = $1 AND u.username IS NOT NULL
+         ORDER BY u.username LIMIT $2`,
+        [userId, limit],
       )
       return rows as UserProfile[]
     } catch {

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -73,6 +73,7 @@ import {
   like,
   lt,
   lte,
+  ne,
   or,
   type SQL,
   sql,
@@ -124,6 +125,16 @@ export function artifactListConditions(
   // Anonymous / non-member callers only ever see public artifacts in a listing — an
   // org/link/password title must not leak to someone who can't open it.
   if (opts?.publicOnly) conds.push(eq(art.visibility, "public"))
+  // `private` artifacts are invisible even to workspace members unless they're an
+  // explicit artifact member. The subquery names the table literally — sqlite, D1,
+  // and pg all call it artifact_member, and this function serves all three.
+  else if (opts?.viewerId)
+    conds.push(
+      sql`(${art.visibility} != 'private' OR EXISTS (
+        SELECT 1 FROM artifact_member am
+        WHERE am.artifact_id = ${art.id} AND am.user_id = ${opts.viewerId}
+      ))`,
+    )
   if (opts?.q) conds.push(like(sql`lower(${art.title})`, `%${opts.q.toLowerCase()}%`))
   if (opts?.cursor) {
     const cursor = or(
@@ -756,14 +767,39 @@ export function makeRepos(db: SqliteDb) {
       .get()) ?? null
   const listArtifactMembers = async (artifactId: string): Promise<ArtifactMemberRecord[]> =>
     db.select().from(artifactMember).where(eq(artifactMember.artifact_id, artifactId)).all()
+  const artifactRolesFor = async (
+    userId: string,
+    artifactIds: string[],
+  ): Promise<Record<string, Role>> => {
+    if (artifactIds.length === 0) return {}
+    const rows = await db
+      .select({ artifact_id: artifactMember.artifact_id, role: artifactMember.role })
+      .from(artifactMember)
+      .where(
+        and(eq(artifactMember.user_id, userId), inArray(artifactMember.artifact_id, artifactIds)),
+      )
+      .all()
+    return Object.fromEntries(rows.map((r) => [r.artifact_id, r.role]))
+  }
   // Artifacts explicitly shared with a user (they hold a per-artifact membership) —
   // the "Shared with you" set, which can span workspaces.
+  // "Shared with me" excludes what I authored: publishing writes the creator an
+  // owner-member row (that's how `private` knows its owner), and without the
+  // author check every artifact you make would land in your own shared feed.
   const artifactIdsSharedWith = async (userId: string): Promise<string[]> =>
     (
       await db
         .select({ id: artifactMember.artifact_id })
         .from(artifactMember)
-        .where(eq(artifactMember.user_id, userId))
+        .innerJoin(artifact, eq(artifact.id, artifactMember.artifact_id))
+        .where(
+          and(
+            eq(artifactMember.user_id, userId),
+            // NULL-safe: a token-published artifact (author_id null) shared with
+            // you still counts — plain != would drop the NULL rows.
+            or(isNull(artifact.author_id), ne(artifact.author_id, userId)),
+          ),
+        )
         .all()
     ).map((r) => r.id)
   const setArtifactMember = async (m: NewArtifactMember): Promise<ArtifactMemberRecord> =>
@@ -993,10 +1029,15 @@ export function makeRepos(db: SqliteDb) {
     } else {
       conds.push(eq(artifact.author_id, userId))
     }
-    // Visible to the viewer: public OR in a workspace they share with the profile owner.
+    // Visible to the viewer: public OR in a workspace they share with the profile
+    // owner. Private drafts never ride a profile, shared workspace or not — the
+    // owner finds them in their library, not on their public face.
     const orgs = opts.visibleOrgIds ?? []
     if (orgs.length > 0) {
-      const v = or(eq(artifact.visibility, "public"), inArray(artifact.org_id, orgs))
+      const v = or(
+        eq(artifact.visibility, "public"),
+        and(inArray(artifact.org_id, orgs), ne(artifact.visibility, "private")),
+      )
       if (v) conds.push(v)
     } else {
       conds.push(eq(artifact.visibility, "public"))
@@ -1714,6 +1755,7 @@ export function makeRepos(db: SqliteDb) {
     listWorkspaces,
     getArtifactMember,
     listArtifactMembers,
+    artifactRolesFor,
     artifactIdsSharedWith,
     setArtifactMember,
     removeArtifactMember,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -31,7 +31,7 @@ export const artifact = sqliteTable("artifact", {
   org_id: text("org_id").notNull().default("local"),
   slug: text("slug"),
   title: text("title"),
-  visibility: text("visibility").$type<Visibility>().notNull().default("link"),
+  visibility: text("visibility").$type<Visibility>().notNull().default("org"),
   password_hash: text("password_hash"),
   // The role general access (the link) grants a reacher with no higher explicit
   // grant. viewer = view-only (default); commenter = authed reachers may comment

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -301,7 +301,7 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
         return (
           (raw
             .prepare(
-              `SELECT id, name, image, username, profession, about FROM user WHERE username = ?`,
+              `SELECT id, name, image, username, profession, about, discoverable FROM user WHERE username = ?`,
             )
             .get(username) as UserProfile) ?? null
         )
@@ -376,6 +376,23 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
              ORDER BY username LIMIT ?`,
           )
           .all(limit) as UserProfile[]
+      } catch {
+        return []
+      }
+    },
+
+    listWorkspaceMates: async (userId, limit): Promise<UserProfile[]> => {
+      try {
+        return raw
+          .prepare(
+            `SELECT DISTINCT u.id, u.name, u.image, u.username, u.profession, u.about
+             FROM membership m1
+             JOIN membership m2 ON m2.org_id = m1.org_id AND m2.user_id != m1.user_id
+             JOIN user u ON u.id = m2.user_id
+             WHERE m1.user_id = ? AND u.username IS NOT NULL
+             ORDER BY u.username LIMIT ?`,
+          )
+          .all(userId, limit) as UserProfile[]
       } catch {
         return []
       }

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -7,7 +7,7 @@ export interface PublishArgs {
   slug?: string
   spa?: boolean
   message?: string
-  visibility?: "public" | "link" | "org" | "password"
+  visibility?: "public" | "link" | "org" | "password" | "private"
   /** Unlock password, required when visibility is "password". */
   password?: string
   /** When set, publishes a new version of this artifact instead of a new one. */

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -239,7 +239,9 @@ server.registerTool(
         .optional()
         .describe("Omit to create a new artifact; pass it to add a version."),
       title: z.string().optional(),
-      visibility: z.enum(["public", "link", "org"]).optional(),
+      // `password` stays CLI/web-only (it needs a password argument this tool
+      // doesn't take). Omitted ⇒ the server default, workspace-only `org`.
+      visibility: z.enum(["public", "link", "org", "private"]).optional(),
       message: z.string().optional().describe("What changed in this version."),
       for_review: z
         .boolean()


### PR DESCRIPTION
> Stacked on #274 (`rob/library-quick-actions`) — the list route and share specs build on it. Merge #274 first, then retarget this to main.

## Why

An artifact published from the CLI opened in an incognito tab. The root cause was a split-brain default: the web published workspace-only, but the API/CLI/MCP — where most publishes come from — defaulted to `link` (URL-readable). Profiles were worse: anonymous-readable pages and follow lists, with `discoverable` gating only the directory.

Full before/after analysis + semantics review: **Sharing & visibility — patterns review** (Derive artifact; publishing blocked right now by the prod incident below, HTML in the PR branch discussion until then).

## What

**One default everywhere: `org` (workspace-only).** API, CLI, MCP, and the `derive init` scaffold converge on the web's existing default. Nothing becomes URL-readable as a side effect of publishing; the CLI prints the visibility and how to widen. (Considered `private`-by-default per the Google Docs prior — rejected because agents publish under their own principal, so private-by-default would hide an agent's publish from the very human it's for. Argued in the review doc; one-line change if overruled.)

**New `private` visibility — only people invited.** Workspace role grants nothing; the publisher is recorded as owner-member at creation (ownership becomes explicit, and creators can manage their own work in team workspaces); listings, profile work lists, and shared-feeds exclude it for non-members; the last owner can't be removed or downgraded.

**Profile privacy that means it.** `discoverable` off now hides the profile page, work list, and follow lists from everyone but workspace-mates (404, same as unknown handle — no existence oracle). Follower/following lists require sign-in. `/people` leads with your workspaces; global directory follows (`scope=workspace`). Settings toggle renamed to "Public profile".

**Share dialog, Google Docs grammar.** Copy-link row first; the five-step access ladder (private / workspace / link / public / password) with a glyph + one-line consequence each; "(you)" on your member row; the sole owner's row is immovable; the Share trigger's glyph shows exposure at a glance. Showcase documents the ladder.

**Two pre-existing bugs found by verification, fixed:**
- Follow POSTs died silently when the click immediately preceded a document navigation (palette rows navigate on select) — the fetch aborted mid-flight, truncated body → 400. Fixed with `keepalive`.
- Unmounting a staged dialog mid-close leaked Radix's pointer-events lock on `<body>` — page froze to clicks. Quick-organize dialogs now let Radix finish before unmounting.

## Compatibility

- Existing artifacts keep their stored visibility — defaults changed, not data.
- Existing `derive.json` files carry an explicit `visibility`, so scripted projects behave as written.
- CHANGELOG calls the default change out loudly.

## Testing

- Core: `effectiveRole` table tests extended across all five visibilities incl. the private/org distinction.
- API: new `visibility.test.ts` (default, private end-to-end incl. share-open, profile-privacy matrix, workspace people, last-owner guard); affected suites updated for the new default.
- e2e: new `visibility.deep.spec.ts` (default publish invisible cross-user → widen via dialog → readable; copy-link; private invisible until invited; profile privacy round-trip). Share specs updated for the owner-member row. Full smoke suite green (13/13, no retries); deep suite green except a pre-existing comments flake (retry-passes, untouched surface).
- Full gate green: `pnpm run ci`, `typecheck`, `test`.
- Note: the people-follow smoke specs were made deterministic (search exact handles) — the old name-search assertions relied on a capped, arbitrarily-ordered browse that dozens of same-named fixture accounts overflow under parallel load.