### PR TITLE
Agents can list artifacts; deploy probe fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,14 +202,20 @@ jobs:
       - name: Verify prod
         if: steps.head.outputs.stale != 'true'
         run: |
+          # Healthy = the worker answers AND the database path answers. The listing
+          # is auth-gated (401 for a tokenless probe), so assert "not a 5xx/timeout"
+          # rather than success — a dead Postgres path shows up as 500 here while
+          # /healthz stays green (it doesn't touch the DB; the July 4 outage proved
+          # both properties).
           for _ in 1 2 3 4 5 6 7 8 9 10; do
+            db=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 https://derive.to/v1/artifacts || echo 000)
             if curl -sf --max-time 15 https://derive.to/healthz > /dev/null &&
-               curl -sf --max-time 15 https://derive.to/v1/artifacts > /dev/null; then
+               [ "$db" -ge 200 ] && [ "$db" -lt 500 ]; then
               exit 0
             fi
             sleep 6
           done
-          echo "prod not healthy after deploy" >&2
+          echo "prod not healthy after deploy (last /v1/artifacts status: $db)" >&2
           exit 1
 
       # Regression signal on main HEAD (the suite runs against localhost dev

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -51,6 +51,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     privateOwnerId,
     activeWorkspace,
     actorFor,
+    agentFor,
     authorize,
     workspaceCan,
     collectionRole,
@@ -67,7 +68,14 @@ export const artifactRoutes = (ctx: AppContext) => {
   // { artifacts, next_cursor }. tag/favorite resolve to an id set first.
   app.get("/v1/artifacts", async (c) => {
     const me = await currentUser(c)
-    if (!me && !isToken(c)) return fail(c, 401, "unauthenticated")
+    // Registered/OAuth agents list too — their library is how MCP list_artifacts
+    // finds work. Anonymous stays 401: nothing in the product lists tokenless.
+    const agent = me ? null : await agentFor(c)
+    if (!me && !agent && !isToken(c)) return fail(c, 401, "unauthenticated")
+    // The acting principal. Listing must mirror can(read), and actorFor resolves
+    // an agent's per-artifact shares by the AGENT's id (its registrant's rows
+    // don't transfer) — so member-row checks below key on this id, never onBehalf.
+    const actorId = me?.id ?? agent?.id ?? null
     const limit = Math.min(100, Math.max(1, Number(c.req.query("limit")) || 30))
     // Opaque compound cursor "<created_at>|<id>" — the id tiebreak keeps paging
     // correct when many artifacts share a created_at.
@@ -143,14 +151,20 @@ export const artifactRoutes = (ctx: AppContext) => {
 
     // The caller's baseline standing in the listing's workspace — reused for the
     // public-only clamp below and the per-row `my_role` (which needs the ROLE, so
-    // the membership row is fetched rather than the boolean isMember helper).
+    // the boolean isMember helper doesn't fit). A user's standing is their
+    // membership row; an agent's is its registered role, valid only in its home
+    // workspace (the same scoping actorFor applies).
     const isOperator = isToken(c)
-    const myMembership = me ? await meta.getMembership(listOrg, me.id) : null
+    const baselineRole = me
+      ? ((await meta.getMembership(listOrg, me.id))?.role ?? null)
+      : agent && agent.org_id === listOrg
+        ? agent.role
+        : null
     // A listing only shows non-public artifacts to a MEMBER of that workspace (or the
-    // operator token). Anyone else — anonymous, or a signed-in user who isn't a member
-    // — sees public artifacts only, so org/link titles never leak via the list or ?query=.
+    // operator token). Anyone else — a non-member user, a foreign-workspace agent —
+    // sees public artifacts only, so org/link titles never leak via the list or ?query=.
     // For a collection, collection access (member/creator/share) also unlocks it.
-    const publicOnly = collectionId ? !collectionAccess : !(isOperator || !!myMembership)
+    const publicOnly = collectionId ? !collectionAccess : !(isOperator || baselineRole !== null)
     const rows = await meta.listArtifacts({
       limit: limit + 1,
       cursor,
@@ -166,7 +180,7 @@ export const artifactRoutes = (ctx: AppContext) => {
       publicOnly: shared || following ? false : publicOnly,
       // Private artifacts appear only for their explicit members; the operator
       // token sees everything (viewerId omitted).
-      viewerId: isOperator ? undefined : (me?.id ?? undefined),
+      viewerId: isOperator ? undefined : (actorId ?? undefined),
     })
     const hasMore = rows.length > limit
     const page = hasMore ? rows.slice(0, limit) : rows
@@ -186,7 +200,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     const feedback = me ? await meta.commentSignals(pageIds, me.id) : {}
     // The viewer's per-artifact shares across the page, one query — folded into
     // my_role below so shared and private rows gate their quick actions correctly.
-    const shareRoles = me ? await meta.artifactRolesFor(me.id, pageIds) : {}
+    const shareRoles = actorId ? await meta.artifactRolesFor(actorId, pageIds) : {}
     return c.json({
       artifacts: page.map((a) => ({
         ...toJson(deps.baseUrl, a, []),
@@ -200,12 +214,12 @@ export const artifactRoutes = (ctx: AppContext) => {
         my_role: isOperator
           ? "owner"
           : effectiveRole(
-              me
+              actorId
                 ? {
                     kind: "user",
-                    userId: me.id,
+                    userId: actorId,
                     artifactRole: shareRoles[a.id] ?? null,
-                    orgRole: a.org_id === listOrg ? (myMembership?.role ?? null) : null,
+                    orgRole: a.org_id === listOrg ? baselineRole : null,
                   }
                 : { kind: "anon" },
               a.visibility,

--- a/apps/api/test/visibility.test.ts
+++ b/apps/api/test/visibility.test.ts
@@ -74,6 +74,19 @@ describe("agents publish on behalf of who registered them", () => {
     // And it lands in Ana's own library listing.
     const list = await (await app.request("/v1/artifacts", { headers: as(ana.email) })).json()
     expect(list.artifacts.map((x: { short_id: string }) => x.short_id)).toContain(a.short_id)
+
+    // The agent lists too (MCP list_artifacts rides this) and sees its own
+    // private publish — its editor member-row passes the private filter.
+    const agentList = await (
+      await app.request("/v1/artifacts", {
+        headers: { authorization: `Bearer ${reg.token}` },
+      })
+    ).json()
+    const row = agentList.artifacts.find((x: { short_id: string }) => x.short_id === a.short_id)
+    expect(row?.my_role).toBe("editor")
+
+    // Anonymous listing stays 401.
+    expect((await app.request("/v1/artifacts")).status).toBe(401)
   })
 })
 


### PR DESCRIPTION
Two issues surfaced by the first post-merge deploy of #274:

1. **The deploy failed only at "Verify prod"** — the probe expected a 200 from `GET /v1/artifacts`, which is now auth-gated (401 for a tokenless curl since the `isToken` cleanup, given `DERIVE_TOKEN` is unset on hosted). The worker + schemas had deployed fine. The probe now asserts the DB path answers with a non-5xx — which still catches the real failure mode from the July 4 outage (DB path 500s while `/healthz` stays green).

2. **Probing prod exposed a real regression: agents 401 on the listing.** The route only resolved session users, so a registered/OAuth agent's bearer fell through to the anonymous gate — MCP `list_artifacts` was dead on hosted. The route now resolves the acting agent: registered role = baseline standing in its home workspace; the private-row filter and per-row `my_role` key on the agent's principal id (the same identity `actorFor` authorizes, so the list never shows what the detail would 404). Anonymous stays 401.

Regression-tested: the on-behalf agent suite now covers the agent listing its own private publish (`my_role: editor`) and anonymous 401. Full gate green.