### PR TITLE
Agents borrow their registrant's standing — no agent rows in share rosters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once it reache
   artifacts and existing `derive.json` files (which carry an explicit value) are
   unaffected; GitHub-mirror syncs stay workspace-visible. The CLI prints the
   published visibility and how to widen it.
-- **Agents publish on behalf of the person who registered them.** The `agent`
-  table gains `created_by`; a registered agent's publishes are attributed
-  (`author_id`) and owned (the owner-member row) by that user, with the agent
-  itself added as editor so it can keep operating on the artifact — matching how
-  OAuth agents already carried their granting user. Applies to the HTTP route and
-  the remote-MCP publish alike. Agents created before the
-  column publish as themselves; recreate the agent to link it.
+- **Agents act as their registrant.** The `agent` table gains `created_by`; an
+  agent's publishes are attributed (`author_id`) and owned by that user, and the
+  agent's per-artifact standing is *derived* from the human's member rows —
+  capped at the agent's registered role and bound to its home workspace. Agents
+  hold no member rows, so share rosters stay a human contract, and no agent can
+  `manage` (delete/transfer) anything. Applies to the HTTP routes and the
+  remote-MCP tools alike (MCP reads and listings now also scope `private`
+  artifacts to the agent's human). Agents created before the column act as
+  themselves; recreate the agent to link it.
 - **`discoverable` is real profile privacy now.** Turning it off hides your
   profile page, work list, and follow lists from everyone except people who share
   a workspace with you (they 404, same as an unknown handle). Follower/following

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -7,6 +7,7 @@ import {
   type BundleManifest,
   type CollectionRecord,
   can,
+  capRole,
   DEFAULT_VERSION_WINDOW_MS,
   isBundleContentType,
   type MetaStore,
@@ -496,16 +497,29 @@ export function buildContext(deps: AppDeps) {
     if (isToken(c)) return { kind: "token" }
     const ag = await agentFor(c)
     if (ag) {
-      const am = await meta.getArtifactMember(a.id, ag.id)
-      // An agent (registered token or OAuth-consent grant) carries its role ONLY
-      // within its OWN workspace, never onto an artifact owned by another one — it
-      // can resolve any artifact by its global short_id, so binding here is the
-      // gate. Mirrors the human branch below: orgRole is scoped to the ARTIFACT's
-      // workspace; on a foreign artifact it drops to the visibility floor while its
-      // own per-artifact shares (artifactRole) still apply. Without this an agent's
-      // home-workspace editor role would let it publish/share/mutate anything.
+      // An agent acts AS ITS REGISTRANT, capped at its registered role and bound
+      // to its home workspace. Its per-artifact standing DERIVES from the human's
+      // member rows — agents hold no rows of their own (an agent in a share
+      // roster is a category error: you share with people; agents borrow). The
+      // cap means no agent reaches `manage` (registration tops out at editor),
+      // and the workspace binding keeps tokens scoped per ADR-0001. Rows written
+      // to an agent id before this model (or by hand) still count, uncapped —
+      // they were explicit grants.
+      const own = await meta.getArtifactMember(a.id, ag.id)
+      let derived: Role | null = null
+      const ownerId = onBehalfCache.get(c) ?? null
+      if (ownerId && ag.org_id === a.org_id) {
+        const m = await meta.getArtifactMember(a.id, ownerId)
+        const cRoles = await meta.collectionRolesForArtifact(a.id, ownerId)
+        derived = capRole(maxRole(m?.role ?? null, ...cRoles), ag.role)
+      }
       const orgRole = ag.org_id === a.org_id ? ag.role : null
-      return { kind: "user", userId: ag.id, artifactRole: am?.role ?? null, orgRole }
+      return {
+        kind: "user",
+        userId: ag.id,
+        artifactRole: maxRole(own?.role ?? null, derived),
+        orgRole,
+      }
     }
     const me = await currentUser(c)
     if (!me) return { kind: "anon", unlocked }

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -163,10 +163,17 @@ function buildServer(
   )
   const org = agent.org_id
 
-  // Resolve a short id within the caller's workspace (never another org's artifact).
+  // Resolve a short id within the caller's workspace (never another org's
+  // artifact). `private` narrows further: the agent sees it only through its
+  // human's standing (or a legacy row of its own) — a teammate's private draft
+  // is as invisible over MCP as it is over HTTP.
   const own = async (shortId: string): Promise<ArtifactRecord | null> => {
     const a = await ctx.meta.getByShortId(shortId)
-    return a && a.org_id === org ? a : null
+    if (!a || a.org_id !== org) return null
+    if (a.visibility !== "private") return a
+    if (actingFor && (await ctx.meta.getArtifactMember(a.id, actingFor.id))) return a
+    if (await ctx.meta.getArtifactMember(a.id, agent.id)) return a
+    return null
   }
   const notFound = (shortId: string) =>
     err(`No artifact "${shortId}" in your workspace. Call list_artifacts to see what's here.`)
@@ -180,7 +187,12 @@ function buildServer(
       inputSchema: { query: z.string().optional().describe("Optional title search filter.") },
     },
     async ({ query }) => {
-      const arts = await ctx.meta.listArtifacts({ orgId: org, q: query })
+      // viewerId keeps private rows scoped to the agent's human (mirrors `own`).
+      const arts = await ctx.meta.listArtifacts({
+        orgId: org,
+        q: query,
+        viewerId: actingFor?.id ?? agent.id,
+      })
       return json({ count: arts.length, artifacts: arts.map(summarizeArtifact) })
     },
   )
@@ -663,24 +675,15 @@ function buildServer(
           },
           short_id,
         )
-        // Ownership, same as the HTTP route: the human owns it, the agent keeps an
-        // editor row so it can republish (essential for private artifacts).
-        if (!short_id) {
-          if (actingFor)
-            await ctx.meta.setArtifactMember({
-              id: newId("am"),
-              artifact_id: artifact.id,
-              user_id: actingFor.id,
-              role: "owner",
-            })
-          if (agent.id !== actingFor?.id)
-            await ctx.meta.setArtifactMember({
-              id: newId("am"),
-              artifact_id: artifact.id,
-              user_id: agent.id,
-              role: actingFor ? "editor" : "owner",
-            })
-        }
+        // Ownership, same as the HTTP route: one row, the human the agent acts
+        // for (the agent borrows that standing — no agent rows in the roster).
+        if (!short_id)
+          await ctx.meta.setArtifactMember({
+            id: newId("am"),
+            artifact_id: artifact.id,
+            user_id: actingFor?.id ?? agent.id,
+            role: "owner",
+          })
         // Re-anchor existing threads: feedback whose quoted text changed flips to
         // `outdated` (and back to `open` if the text reappears). Same sweep the
         // HTTP route runs — MCP publish must call it too.

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -4,6 +4,7 @@ import {
   type BundleManifest,
   bundleDoc,
   can,
+  capRole,
   diffLines,
   effectiveRole,
   formatDiff,
@@ -72,10 +73,11 @@ export const artifactRoutes = (ctx: AppContext) => {
     // finds work. Anonymous stays 401: nothing in the product lists tokenless.
     const agent = me ? null : await agentFor(c)
     if (!me && !agent && !isToken(c)) return fail(c, 401, "unauthenticated")
-    // The acting principal. Listing must mirror can(read), and actorFor resolves
-    // an agent's per-artifact shares by the AGENT's id (its registrant's rows
-    // don't transfer) — so member-row checks below key on this id, never onBehalf.
-    const actorId = me?.id ?? agent?.id ?? null
+    // Whose member rows count. Listing must mirror can(read): an agent derives
+    // its standing from its registrant's rows (capped at its registered role —
+    // see actorFor), so a linked agent's key is the REGISTRANT; an agent with
+    // no registrant on record falls back to its own legacy rows.
+    const memberKey = me?.id ?? agent?.created_by ?? agent?.id ?? null
     const limit = Math.min(100, Math.max(1, Number(c.req.query("limit")) || 30))
     // Opaque compound cursor "<created_at>|<id>" — the id tiebreak keeps paging
     // correct when many artifacts share a created_at.
@@ -180,7 +182,7 @@ export const artifactRoutes = (ctx: AppContext) => {
       publicOnly: shared || following ? false : publicOnly,
       // Private artifacts appear only for their explicit members; the operator
       // token sees everything (viewerId omitted).
-      viewerId: isOperator ? undefined : (actorId ?? undefined),
+      viewerId: isOperator ? undefined : (memberKey ?? undefined),
     })
     const hasMore = rows.length > limit
     const page = hasMore ? rows.slice(0, limit) : rows
@@ -200,7 +202,8 @@ export const artifactRoutes = (ctx: AppContext) => {
     const feedback = me ? await meta.commentSignals(pageIds, me.id) : {}
     // The viewer's per-artifact shares across the page, one query — folded into
     // my_role below so shared and private rows gate their quick actions correctly.
-    const shareRoles = actorId ? await meta.artifactRolesFor(actorId, pageIds) : {}
+    // For a linked agent these are the registrant's rows, so the cap applies.
+    const shareRoles = memberKey ? await meta.artifactRolesFor(memberKey, pageIds) : {}
     return c.json({
       artifacts: page.map((a) => ({
         ...toJson(deps.baseUrl, a, []),
@@ -214,11 +217,14 @@ export const artifactRoutes = (ctx: AppContext) => {
         my_role: isOperator
           ? "owner"
           : effectiveRole(
-              actorId
+              memberKey
                 ? {
                     kind: "user",
-                    userId: actorId,
-                    artifactRole: shareRoles[a.id] ?? null,
+                    userId: memberKey,
+                    artifactRole:
+                      agent?.created_by != null
+                        ? capRole(shareRoles[a.id] ?? null, agent.role)
+                        : (shareRoles[a.id] ?? null),
                     orgRole: a.org_id === listOrg ? baselineRole : null,
                   }
                 : { kind: "anon" },
@@ -359,28 +365,21 @@ export const artifactRoutes = (ctx: AppContext) => {
         },
         shortId,
       )
-      // Ownership on creation. The HUMAN behind the publish becomes the owner-member
-      // (an agent publishes on behalf of whoever registered it), which is what makes
-      // `private` work — workspace role grants nothing there. The agent principal
-      // additionally gets an editor row so it can keep operating on the artifact
-      // (republish, address review) even when it's private. An agent with no
-      // registrant on record (created_by null) owns as itself.
-      if (!shortId) {
-        if (onBehalf)
-          await meta.setArtifactMember({
-            id: newId("am"),
-            artifact_id: artifact.id,
-            user_id: onBehalf,
-            role: "owner",
-          })
-        if (actor && actor.id !== onBehalf)
-          await meta.setArtifactMember({
-            id: newId("am"),
-            artifact_id: artifact.id,
-            user_id: actor.id,
-            role: onBehalf ? "editor" : "owner",
-          })
-      }
+      // Ownership on creation: ONE row, the human behind the publish (an agent
+      // publishes on behalf of whoever registered it) — this is what makes
+      // `private` work, since workspace role grants nothing there. The agent
+      // needs no row: it borrows its registrant's standing, capped at its
+      // registered role (see actorFor). An agent with no registrant on record
+      // owns as itself. Members stay a human sharing contract — no robots in
+      // the roster.
+      const ownerId = onBehalf ?? actor?.id ?? null
+      if (!shortId && ownerId)
+        await meta.setArtifactMember({
+          id: newId("am"),
+          artifact_id: artifact.id,
+          user_id: ownerId,
+          role: "owner",
+        })
       bus.publish(artifact.id, {
         type: "version.published",
         n: version.n,

--- a/apps/api/test/visibility.test.ts
+++ b/apps/api/test/visibility.test.ts
@@ -28,8 +28,8 @@ describe("publish defaults to private", () => {
   })
 })
 
-describe("agents publish on behalf of who registered them", () => {
-  it("the registering user owns the publish; the agent keeps editor access", async () => {
+describe("agents act as their registrant, capped at their registered role", () => {
+  it("the registrant owns the publish; the agent borrows access with no roster row", async () => {
     const { app } = makeAuthedApp("vis-agent", [ana, ben], "editor")
     await app.request("/v1/me", { headers: as(ana.email) }) // provision the workspace
     const reg = await (
@@ -57,6 +57,25 @@ describe("agents publish on behalf of who registered them", () => {
       await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(ana.email) })
     ).json()
     expect(hers.my_role).toBe("owner")
+
+    // The share roster is a human contract: Ana is the only member — the agent
+    // borrows her standing rather than holding a row of its own.
+    const roster = await (
+      await app.request(`/v1/artifacts/${a.short_id}/members`, { headers: as(ana.email) })
+    ).json()
+    expect(roster.members).toHaveLength(1)
+    expect(roster.members[0].user_id).toBe(ana.id)
+
+    // Borrowed standing is capped at the agent's registered role: editor can
+    // republish but never manage — the agent cannot delete its own publish.
+    expect(
+      (
+        await app.request(`/v1/artifacts/${a.short_id}`, {
+          method: "DELETE",
+          headers: { authorization: `Bearer ${reg.token}` },
+        })
+      ).status,
+    ).toBe(403)
     expect(
       (await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(ben.email) })).status,
     ).toBe(404)
@@ -75,8 +94,8 @@ describe("agents publish on behalf of who registered them", () => {
     const list = await (await app.request("/v1/artifacts", { headers: as(ana.email) })).json()
     expect(list.artifacts.map((x: { short_id: string }) => x.short_id)).toContain(a.short_id)
 
-    // The agent lists too (MCP list_artifacts rides this) and sees its own
-    // private publish — its editor member-row passes the private filter.
+    // The agent lists too (MCP list_artifacts rides this) and sees the private
+    // publish through its registrant's owner row, capped to its own rank.
     const agentList = await (
       await app.request("/v1/artifacts", {
         headers: { authorization: `Bearer ${reg.token}` },
@@ -87,6 +106,47 @@ describe("agents publish on behalf of who registered them", () => {
 
     // Anonymous listing stays 401.
     expect((await app.request("/v1/artifacts")).status).toBe(401)
+  })
+
+  it("the agent can work on what its human made by hand — and not on a teammate's private draft", async () => {
+    const { app } = makeAuthedApp("vis-agent-derived", [ana, ben], "editor")
+    await app.request("/v1/me", { headers: as(ana.email) })
+    const reg = await (
+      await app.request("/v1/agents", {
+        method: "POST",
+        headers: { "content-type": "application/json", ...as(ana.email) },
+        body: JSON.stringify({ name: "Scribe", role: "editor" }),
+      })
+    ).json()
+
+    // Ana publishes a private draft herself; her agent republishes it.
+    const hers = await (
+      await publishAs(app, "<h1>draft</h1>", { visibility: "private" }, as(ana.email))
+    ).json()
+    const form = new FormData()
+    form.append("file", new Blob([new TextEncoder().encode("<h1>v2</h1>")]), "draft.html")
+    expect(
+      (
+        await app.request(`/v1/artifacts/${hers.short_id}/versions`, {
+          method: "POST",
+          body: form,
+          headers: { authorization: `Bearer ${reg.token}` },
+        })
+      ).status,
+    ).toBe(201)
+
+    // Ben's private draft stays invisible to Ana's agent — derived standing is
+    // Ana's, and Ana has none here.
+    const bens = await (
+      await publishAs(app, "<h1>secret</h1>", { visibility: "private" }, as(ben.email))
+    ).json()
+    expect(
+      (
+        await app.request(`/v1/artifacts/${bens.short_id}`, {
+          headers: { authorization: `Bearer ${reg.token}` },
+        })
+      ).status,
+    ).toBe(404)
   })
 })
 

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -48,6 +48,15 @@ export function maxRole(...roles: (Role | null | undefined)[]): Role | null {
   return best
 }
 
+/** Clamp a role to a ceiling. An agent borrows its registrant's standing but
+ *  never rises above the role it was registered with — a workspace owner's
+ *  agent registered as editor acts as editor, so no agent can `manage`
+ *  (delete, transfer) regardless of whose authority it borrows. */
+export function capRole(role: Role | null, cap: Role): Role | null {
+  if (!role) return null
+  return RANK[role] > RANK[cap] ? cap : role
+}
+
 /**
  * Who is making a request, with their standing already resolved from the store.
  * Every surface (web session, static token, MCP agent) becomes one of these.


### PR DESCRIPTION
Rob flagged the smell: an agent-published doc showed the agent itself in the Share dialog's People list. You don't share *with* an agent — the roster is a human contract. The row was capability plumbing leaking into the sharing model.

## The model

**An agent acts as its registrant, capped at its registered role, bound to its home workspace.** One sentence, enforced in one place (`actorFor`): per-artifact standing derives from the human's member rows via `capRole(registrantStanding, agent.role)`. Publish writes a single owner row — the human. Agents hold no rows (legacy rows still count; they were explicit grants).

The cap preserves the invariant we verified on prod: registration tops out at editor, so **no agent can `manage`** (delete/transfer) regardless of whose authority it borrows.

## What this fixes beyond the roster

- **Agents can now work on anything their human owns** — including private artifacts the human published by hand (previously the agent only had rows on its own publishes).
- **Two MCP privacy holes**: `read`/`catch_up` gated by workspace only, and `list_artifacts` listed the org unfiltered — a teammate's **private** draft was readable and listed over MCP while 404ing over HTTP. Both now scope private artifacts to the agent's human, mirroring HTTP.
- Deleted agents no longer strand member rows going forward (ownership always lands on a human).

## Cleanup for existing data

Only a handful of prod artifacts carry agent editor rows (written since #274). They're harmless (still honored as explicit grants) and removable in one click from the Share dialog — e.g. the "Scribe" row Rob spotted.

## Testing

`visibility.test.ts`: roster contains only the human; agent republishes its private publish via borrowed standing; agent DELETE → 403 (cap holds); agent republishes a private artifact its human made **by hand**; a teammate's private draft stays 404 to the agent; agent listing shows derived `my_role: editor`. Full gate green; share/visibility e2e green.