### PR TITLE
feat(web): reconceive home/profile/people/new + no-flash correctness sweep

### DIFF
--- a/apps/web/e2e/deep/new-guard.deep.spec.ts
+++ b/apps/web/e2e/deep/new-guard.deep.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "../fixtures"
+
+// The /new unsaved-draft guard, both directions: publishing must NAV to the artifact (the
+// guard bypasses its own save nav), while Cancel with a dirty draft must BLOCK. Regression
+// guard for the ref-vs-state race — a batched state flag would have fired the discard
+// dialog on the publish path itself, so this pins the ref-based bypass in place.
+test("publishing from /new navigates to the artifact, not the discard guard", async ({ owner }) => {
+  const p = owner
+  await p.goto("/new")
+  await p.getByTestId("artifact-source-editor").click()
+  await p.keyboard.type("# Publish me\n\nReal content.")
+  await p.getByTestId("artifact-title-input").fill("Publish me")
+  await p.getByTestId("artifact-publish-version").click()
+
+  // The save nav is allowed: we land on the artifact, and the discard dialog never shows.
+  await expect(p).toHaveURL(/\/artifacts\//, { timeout: 15_000 })
+  await expect(p.getByTestId("new-discard-confirm")).toHaveCount(0)
+})
+
+test("leaving /new with an unsaved draft blocks with the discard guard", async ({ owner }) => {
+  const p = owner
+  await p.goto("/new")
+  await p.getByTestId("artifact-source-editor").click()
+  await p.keyboard.type("# Draft\n\nUnsaved.")
+  await p.getByTestId("artifact-edit-cancel").click()
+
+  // The guard intercepts the departure.
+  await expect(p.getByTestId("new-discard-confirm")).toBeVisible()
+  // Keeping (cancel the dialog) stays on /new with the draft intact.
+  await p.getByTestId("confirm-dialog-cancel").click()
+  await expect(p).toHaveURL(/\/new/)
+  await expect(p.getByTestId("artifact-publish-version")).toBeVisible()
+})
+
+// An untouched /new (no input) must NOT block — leaving is free.
+test("leaving an untouched /new does not block", async ({ owner }) => {
+  const p = owner
+  await p.goto("/new")
+  await p.getByTestId("artifact-edit-cancel").click()
+  await expect(p).toHaveURL(/\/(?!new)/, { timeout: 10_000 })
+  await expect(p.getByTestId("new-discard-confirm")).toHaveCount(0)
+})

--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -111,7 +111,7 @@ function NavItem({
   icon: IconName
   label: string
   count?: number
-  to: "/favorites" | "/following" | "/people"
+  to: "/favorites" | "/following" | "/shared" | "/people"
   active: boolean
   testId?: string
 }) {
@@ -300,6 +300,7 @@ export function NavRail() {
   const isAll = onLibrary && !search.tag && !search.collection
   const isFav = loc.pathname === "/favorites"
   const isFollowing = loc.pathname === "/following"
+  const onShared = loc.pathname === "/shared"
   const onPeople = loc.pathname === "/people"
   const onSettings = loc.pathname.startsWith("/settings")
   const tags = summary?.tags ?? []
@@ -466,6 +467,15 @@ export function NavRail() {
                 to="/following"
                 active={isFollowing}
                 testId="nav-following"
+              />
+              {/* Shared with you — a durable named feed (things others gave you access to),
+                  a peer of the feeds above; not a home strip (that's the whole IA move). */}
+              <NavItem
+                icon="share"
+                label="Shared with you"
+                to="/shared"
+                active={onShared}
+                testId="nav-shared"
               />
               {/* People directory — the other fixed-feed route, a peer of the two feeds. */}
               <NavItem

--- a/apps/web/src/components/shared/card-grid.tsx
+++ b/apps/web/src/components/shared/card-grid.tsx
@@ -1,10 +1,12 @@
 import type { ReactNode } from "react"
 import { cn } from "@/lib/utils"
 
-// The library's card-grid geometry, defined once so the live grid, the virtualized
-// grid, and the skeleton can't drift apart: 260px-floor cards (a preview-forward
-// gallery — big enough to read the render) on a 16px column gutter, with a wider
-// 24px vertical rhythm so captions get air before the next row's preview.
+// The artifact card-grid geometry, defined once so the live grid, the virtualized
+// grid, and the skeleton can't drift apart — shared by the library feed AND the
+// profile Work grid (which is why it lives in shared/, not under one feature):
+// 260px-floor cards (a preview-forward gallery — big enough to read the render) on a
+// 16px column gutter, with a wider 24px vertical rhythm so captions get air before
+// the next row's preview.
 //
 // `min(100%, 260px)` is the overflow-safe floor: on a container narrower than one
 // card it drops to a single full-width column instead of forcing a scrollbar.

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -51,9 +51,11 @@ export type LibraryParams = {
   favorite?: boolean
   // Narrow to artifacts last changed by this GitHub login.
   author?: string
-  // "following" → the activity feed: artifacts in the active workspace matching
-  // your follows (followed authors + repo path prefixes).
-  scope?: "following"
+  // The named-feed scopes, each its own route (see LibraryView):
+  // "following" → the activity feed (followed authors + repo path prefixes);
+  // "shared" → artifacts explicitly shared with you (can span workspaces);
+  // "needs_feedback" → artifacts with an open thread you're tagged in or commented on.
+  scope?: "following" | "shared" | "needs_feedback"
 }
 export const libraryArtifactsQuery = (params: LibraryParams) =>
   infiniteQueryOptions({
@@ -71,17 +73,10 @@ export const libraryArtifactsQuery = (params: LibraryParams) =>
     refetchOnMount: "always",
   })
 
-// "Shared with you": artifacts explicitly shared with the caller (can span
-// workspaces). A flat first page (no infinite scroll) — the home section shows a
-// handful; opening one is the deep path.
-export const sharedArtifactsQuery = () =>
-  queryOptions({
-    queryKey: ["artifacts", "shared"] as const,
-    queryFn: () => api.listArtifacts({ scope: "shared", limit: 12 }).then((r) => r.artifacts),
-  })
-
 // Artifacts that need YOUR feedback: an open comment thread you're tagged in or have
-// commented on. Surfaced as a promoted strip at the top of the unfiltered home.
+// commented on. Read as a COUNT for the home's quiet triage line (the full list is the
+// /feedback feed, an infinite libraryArtifactsQuery({ scope: "needs_feedback" })). Kept a
+// flat capped fetch — the home only needs "is there anything, and how much".
 export const needsFeedbackArtifactsQuery = () =>
   queryOptions({
     queryKey: ["artifacts", "needs_feedback"] as const,

--- a/apps/web/src/pages/artifact/code-editor.tsx
+++ b/apps/web/src/pages/artifact/code-editor.tsx
@@ -9,6 +9,7 @@ import {
 } from "@codemirror/language"
 import { EditorState } from "@codemirror/state"
 import {
+  placeholder as cmPlaceholder,
   drawSelection,
   EditorView,
   highlightActiveLine,
@@ -46,10 +47,13 @@ export function CodeEditor({
   value,
   format,
   onChange,
+  placeholder,
 }: {
   value: string
   format: "md" | "html"
   onChange: (v: string) => void
+  /** First-use hint shown in the empty editor (the /new flow); omitted when editing. */
+  placeholder?: string
 }) {
   const host = useRef<HTMLDivElement>(null)
   const view = useRef<EditorView | null>(null)
@@ -81,6 +85,7 @@ export function CodeEditor({
           syntaxHighlighting(tokenHighlight, { fallback: true }),
           keymap.of([...defaultKeymap, ...historyKeymap]),
           format === "md" ? markdown() : html(),
+          ...(placeholder ? [cmPlaceholder(placeholder)] : []),
           EditorView.lineWrapping,
           EditorView.updateListener.of((u) => {
             if (u.docChanged) cb.current(u.state.doc.toString())

--- a/apps/web/src/pages/artifact/source-editor.tsx
+++ b/apps/web/src/pages/artifact/source-editor.tsx
@@ -35,6 +35,7 @@ export function SourceEditor({
   onPublish,
   onPropose,
   onTitle,
+  placeholder,
 }: {
   canPublish: boolean
   title: string
@@ -51,6 +52,8 @@ export function SourceEditor({
   // When set, the title becomes an editable field (the new-artifact flow at /new);
   // omitted for editing an existing artifact, where the title is shown read-only.
   onTitle?: (v: string) => void
+  // First-use hint for the empty editor (the /new flow); omitted when editing.
+  placeholder?: string
 }) {
   const [pane, setPane] = useState<"edit" | "preview">("edit")
   // Desktop preview-pane visibility (mobile uses the Edit/Preview tabs instead).
@@ -202,11 +205,12 @@ export function SourceEditor({
                 spellCheck={false}
                 aria-label="Artifact source"
                 data-testid="artifact-source-editor"
+                placeholder={placeholder}
                 className="h-full flex-1 resize-none border border-input bg-card px-5 py-4 font-mono text-sm text-foreground outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/40"
               />
             }
           >
-            <CodeEditor value={src} format={format} onChange={onSrc} />
+            <CodeEditor value={src} format={format} onChange={onSrc} placeholder={placeholder} />
           </Suspense>
         </div>
         <div

--- a/apps/web/src/pages/library/artifact-grid.tsx
+++ b/apps/web/src/pages/library/artifact-grid.tsx
@@ -1,9 +1,9 @@
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { type RefObject, useEffect, useRef, useState } from "react"
 import type { Artifact } from "@/api"
+import { CARD_GRID_COLS, MIN_CARD_PX } from "@/components/shared/card-grid"
 import { cn } from "@/lib/utils"
 import { ArtifactCard } from "./artifact-card"
-import { CARD_GRID_COLS, MIN_CARD_PX } from "./card-grid"
 
 // Grid geometry comes from card-grid.tsx (one source with the live grid and the
 // skeleton). We virtualize ROWS (each row = `columns` cards), so we derive the
@@ -52,7 +52,14 @@ export function ArtifactGrid({
 
   // How many cards fit per row, and how far the grid sits below the scroll
   // container's top (everything above it — search, publish card, heading — is
-  // the virtualizer's scrollMargin). Both recompute on resize.
+  // the virtualizer's scrollMargin). Recompute on resize AND on any above-grid
+  // height change: we observe the scroll container, the grid, and the scroll
+  // container's content wrapper (the PageShell measure element). That last one is
+  // the key — when content ABOVE the grid changes height (a header greeting/triage
+  // landing, filter pills wrapping) the grid moves without resizing itself, so
+  // observing only the grid would leave scrollMargin stale and every windowed row
+  // translated to the wrong offset. The wrapper's height DOES change, so observing
+  // it catches the drift.
   useEffect(() => {
     const grid = gridRef.current
     const scroll = scrollRef.current
@@ -68,6 +75,9 @@ export function ArtifactGrid({
     const ro = new ResizeObserver(measure)
     ro.observe(grid)
     ro.observe(scroll)
+    // The content wrapper between the scroll top and the grid — its height changes
+    // whenever above-grid content does, which a grid-only observer misses.
+    if (scroll.firstElementChild) ro.observe(scroll.firstElementChild)
     return () => ro.disconnect()
   }, [scrollRef])
 

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate, useSearch } from "@tanstack/react-router"
 import { FolderTree, List } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
@@ -19,10 +19,7 @@ import { useAuth } from "@/ctx"
 import {
   artifactQuery,
   collectionsQuery,
-  type LibraryParams,
-  libraryArtifactsQuery,
   needsFeedbackArtifactsQuery,
-  sharedArtifactsQuery,
   summaryQuery,
 } from "@/lib/queries"
 import { STORAGE_KEYS } from "@/lib/storage-keys"
@@ -30,10 +27,8 @@ import { useDelayedPending } from "@/lib/use-delayed-pending"
 import { useFollows } from "@/lib/use-follows"
 import { usePrefetchArtifact } from "@/lib/use-prefetch-artifact"
 import { refFor } from "../artifact/parse-ref"
-import { ArtifactCard } from "./artifact-card"
 import { ArtifactGrid } from "./artifact-grid"
 import { ArtifactRow, byRecency } from "./artifact-row"
-import { CardGrid } from "./card-grid"
 import { CollectionBar } from "./collection-bar"
 import { FolderGroups } from "./folder-groups"
 import { FollowingStrip } from "./following-strip"
@@ -43,22 +38,60 @@ import { PublishCard } from "./publish-card"
 import { LibraryCollectionsDialog, LibraryTagsDialog } from "./quick-organize"
 import { RepoPullRequests } from "./repo-pull-requests"
 import { ShareCollectionDialog } from "./share-collection-dialog"
+import { TriageBar } from "./triage-bar"
 import type { Filter, LibrarySearch, LibraryView } from "./types"
+import { useLibraryFeed } from "./use-library-feed"
 
-// The library surface, shared by three routes: "/" (all artifacts), "/favorites",
-// and "/following". The base feed comes from the route (the `view` prop); the
-// filters + search come from the URL query. The persistent AppShell (mounted once
-// around the router Outlet) owns the rail/pod and the auth gate, so this just
-// renders the library body.
+// The library surface, shared by five routes: "/" (your work), "/favorites",
+// "/following", "/shared", and "/feedback". The base feed comes from the route (the
+// `view` prop); the tag/collection/author filters + free-text search come from the URL
+// query. The persistent AppShell owns the rail/pod + auth gate, so this renders the
+// library body only. Reconceived from a 660-line god-component: the feed + its optimistic
+// mutations live in useLibraryFeed; the promoted "needs feedback" / "shared" card-strips
+// are their OWN routes now (a quiet triage line points at /feedback), so the home is one
+// job — your work, most-recently-updated.
 export function Library({ view }: { view: LibraryView }) {
   return <LibraryBody view={view} />
 }
 
+// Map a route view to the base library feed's scope param (all/favorites carry no scope;
+// favorites rides the `favorite` flag). Kept beside deriveFilter so the two stay in step.
+function scopeFor(view: LibraryView) {
+  return view === "following"
+    ? ("following" as const)
+    : view === "shared"
+      ? ("shared" as const)
+      : view === "feedback"
+        ? ("needs_feedback" as const)
+        : undefined
+}
+
+// The active filter = the base feed (from the route: `view`) unless it's the home
+// library, where a tag/collection query param narrows it. The named feeds are their own
+// routes, so their filters (tag/collection) can't apply.
+function deriveFilter(
+  view: LibraryView,
+  search: LibrarySearch,
+  collections: { id: string; title: string }[],
+): Filter {
+  if (view === "favorites") return { kind: "favorites" }
+  if (view === "following") return { kind: "following" }
+  if (view === "shared") return { kind: "shared" }
+  if (view === "feedback") return { kind: "feedback" }
+  if (search.tag) return { kind: "tag", tag: search.tag }
+  if (search.collection)
+    return {
+      kind: "collection",
+      id: search.collection,
+      title: collections.find((c) => c.id === search.collection)?.title ?? "Collection",
+    }
+  return { kind: "all" }
+}
+
 function LibraryBody({ view }: { view: LibraryView }) {
   const nav = useNavigate()
-  // Read the query params loosely: this one body renders under three routes, so it
-  // can't bind to a single route's search shape. The base feed is `view` (the route);
-  // tag/collection/q/author are the filters that compose on top (docs/decisions/0002).
+  // Read the query params loosely: this one body renders under five routes, so it can't
+  // bind to a single route's search shape.
   const search = useSearch({ strict: false }) as LibrarySearch
   const { me } = useAuth()
   const { data: summary } = useQuery({ ...summaryQuery(), enabled: !!me })
@@ -71,139 +104,92 @@ function LibraryBody({ view }: { view: LibraryView }) {
   const [shareCol, setShareCol] = useState<(typeof collections)[number] | null>(null)
   const [query, setQuery] = useState(search.query ?? "")
   const [debouncedQ, setDebouncedQ] = useState((search.query ?? "").trim())
-  // Folder vs flat-list view (synced collections). Off by default (a flat,
-  // most-recently-updated list is the default for a synced collection); remembered.
-  const [showFolders, setShowFolders] = useState(
-    () =>
-      typeof window !== "undefined" && localStorage.getItem(STORAGE_KEYS.libraryFolders) === "1",
-  )
-  const toggleFolders = (on: boolean) => {
-    setShowFolders(on)
-    localStorage.setItem(STORAGE_KEYS.libraryFolders, on ? "1" : "0")
-  }
-
-  // The active filter = the base feed (from the route: `view`) unless it's the home
-  // library, where a tag/collection query param narrows it. Favorites/Following are
-  // their own routes now, so tag/collection (which live only on "/") can't apply.
-  const filter: Filter =
-    view === "favorites"
-      ? { kind: "favorites" }
-      : view === "following"
-        ? { kind: "following" }
-        : search.tag
-          ? { kind: "tag", tag: search.tag }
-          : search.collection
-            ? {
-                kind: "collection",
-                id: search.collection,
-                title: collections.find((c) => c.id === search.collection)?.title ?? "Collection",
-              }
-            : { kind: "all" }
-
   useEffect(() => {
     const t = setTimeout(() => setDebouncedQ(query.trim()), 280)
     return () => clearTimeout(t)
   }, [query])
+  // "Searching" tracks the LIVE input, not the debounced value — so the greeting/publish/
+  // triage collapse the instant you type, not 280 ms later (the old whole-header jump).
+  // Results still key off the debounced value (network), so requests stay throttled.
+  const isSearching = query.trim().length > 0
 
-  // Server-side search + filter + keyset pagination, as one infinite query keyed
-  // by the active filter. Scrolling to the end pulls the next page.
-  const params: LibraryParams = {
+  const filter = deriveFilter(view, search, collections)
+
+  // Server-side search + filter + keyset pagination, plus the optimistic star/delete —
+  // all in the feed hook, keyed by the active filter.
+  const params = {
     q: debouncedQ || undefined,
     tag: search.tag,
     collection: search.collection,
     favorite: view === "favorites" || undefined,
     author: search.author,
-    scope: view === "following" ? "following" : undefined,
+    scope: scopeFor(view),
   }
-  const listQuery = libraryArtifactsQuery(params)
-  const { data, isPending, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useInfiniteQuery(listQuery)
-  // Hold the skeleton back ~150ms so a cache-warm / fast first load flashes nothing
-  // (keepPreviousData already keeps the current grid across filter changes, so this
-  // only ever gates the true first load).
+  const { query: feed, items, listQuery, toggleFavorite, deleteArtifact } = useLibraryFeed(params)
+  const { isPending, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } = feed
+  // Hold the skeleton back ~150 ms so a cache-warm / fast first load flashes nothing
+  // (keepPreviousData already keeps the current grid across filter changes).
   const showSkeleton = useDelayedPending(isPending)
-  const items = data?.pages.flatMap((p) => p.artifacts) ?? []
 
-  // A synced repo collection (artifacts carry a source_path) gets the folder/flat
-  // treatment: a flat, most-recently-updated list by default, with an optional folder
-  // view. Other lists (home, tags, favorites, hand-built collections) keep the grid.
-  const isSyncedCollection = filter.kind === "collection" && items.some((a) => a.source_path)
-  // Pull the whole collection so the sort + grouping see every doc (collections are
-  // finite and scoping keeps them small) — same as the folder view always did.
+  // A synced repo/PR collection gets the folder/flat treatment. Derive this from the
+  // collection's KNOWN kind (collections are preloaded in the route loader), NOT from
+  // whether a loaded item happens to carry a source_path — so the view can't render as a
+  // grid and then flip to flat/folders once the first synced item lands.
+  const activeCollection =
+    filter.kind === "collection" ? collections.find((c) => c.id === filter.id) : undefined
+  const isSyncedCollection = activeCollection?.kind === "repo" || activeCollection?.kind === "pr"
+  // Pull the whole collection so the sort + grouping see every doc (collections are finite
+  // and scoping keeps them small).
   useEffect(() => {
     if (isSyncedCollection && hasNextPage && !isFetchingNextPage) fetchNextPage()
   }, [isSyncedCollection, hasNextPage, isFetchingNextPage, fetchNextPage])
-  // Default order everywhere a synced collection renders: most recently updated first.
   const recencyItems = isSyncedCollection ? [...items].sort(byRecency) : items
 
-  // Star toggle is optimistic across every cached page; in the Favorites view an
-  // un-star drops the card. Reconcile against the server on failure.
-  const toggleFav = async (a: Artifact) => {
-    const on = !a.favorite
-    const drop = filter.kind === "favorites" && !on
-    qc.setQueryData(listQuery.queryKey, (old) =>
-      old
-        ? {
-            ...old,
-            pages: old.pages.map((pg) => ({
-              ...pg,
-              artifacts: pg.artifacts.flatMap((x) =>
-                x.short_id !== a.short_id ? [x] : drop ? [] : [{ ...x, favorite: on }],
-              ),
-            })),
-          }
-        : old,
-    )
+  // Folder-vs-flat is remembered PER COLLECTION (a JSON map under the one storage key),
+  // so opening a different synced repo starts at its own preference (flat by default)
+  // instead of inheriting the last collection's toggle.
+  const [folderPrefs, setFolderPrefs] = useState<Record<string, boolean>>(() => {
+    if (typeof window === "undefined") return {}
     try {
-      await api.favorite(a.short_id, on)
-      qc.invalidateQueries({ queryKey: summaryQuery().queryKey })
-    } catch (e) {
-      toast.error((e as Error).message)
-      qc.invalidateQueries({ queryKey: listQuery.queryKey })
+      return JSON.parse(localStorage.getItem(STORAGE_KEYS.libraryFolders) || "{}")
+    } catch {
+      return {}
     }
+  })
+  const showFolders = filter.kind === "collection" ? !!folderPrefs[filter.id] : false
+  const setShowFolders = (on: boolean) => {
+    if (filter.kind !== "collection") return
+    setFolderPrefs((prev) => {
+      const next = { ...prev, [filter.id]: on }
+      try {
+        localStorage.setItem(STORAGE_KEYS.libraryFolders, JSON.stringify(next))
+      } catch {
+        /* private mode — the in-memory pref still holds this session */
+      }
+      return next
+    })
   }
 
   const renameCollection = async (id: string, title: string) => {
     await api.renameCollection(id, title).catch((e) => toast.error((e as Error).message))
     qc.invalidateQueries({ queryKey: summaryQuery().queryKey })
+    qc.invalidateQueries({ queryKey: collectionsQuery().queryKey })
     nav({ to: "/", search: { collection: id } })
   }
   const deleteCollection = async (id: string) => {
     await api.deleteCollection(id).catch((e) => toast.error((e as Error).message))
+    qc.invalidateQueries({ queryKey: collectionsQuery().queryKey })
     nav({ to: "/", search: {} })
   }
 
-  // Destructive intent is confirmed in the shared ConfirmDialog, never
-  // window.confirm — rows only stage the artifact here.
+  // Destructive intent is confirmed in the shared ConfirmDialog — rows only stage here.
   const [pendingDelete, setPendingDelete] = useState<Artifact | null>(null)
-  const deleteArtifact = async (a: Artifact) => {
-    qc.setQueryData(listQuery.queryKey, (old) =>
-      old
-        ? {
-            ...old,
-            pages: old.pages.map((pg) => ({
-              ...pg,
-              artifacts: pg.artifacts.filter((x) => x.short_id !== a.short_id),
-            })),
-          }
-        : old,
-    )
-    try {
-      await api.deleteArtifact(a.short_id)
-      qc.invalidateQueries({ queryKey: summaryQuery().queryKey })
-      toast.success("Artifact deleted")
-    } catch (e) {
-      toast.error((e as Error).message)
-      qc.invalidateQueries({ queryKey: listQuery.queryKey })
-    }
-  }
 
-  // Quick organize from the card ⋯ menu. The dialogs own the API calls and
-  // report the result here; these handlers sync every cache that carries the
-  // artifact. When the change can alter the ACTIVE filter's membership
-  // (un-tagging on a tag view, removing on a collection view) we refetch
-  // instead of optimistically dropping the card — the dialogs roll back on
-  // failure, and a dropped card can't be rolled back in.
+  // Quick organize from the card ⋯ menu (edit tags / add to collection). The dialogs own
+  // the API calls and report the result here; these handlers sync the caches that render
+  // the artifact's tags/collections — the CURRENT view's feed page + the artifact detail —
+  // plus the rail counts. The named-feed caches (/shared, /feedback) aren't synced: they're
+  // not the visible view, and refetchOnMount:"always" makes them fresh on navigation.
   const [pendingTags, setPendingTags] = useState<Artifact | null>(null)
   const [pendingCollections, setPendingCollections] = useState<Artifact | null>(null)
   const tagsChanged = (shortId: string, tags: string[]) => {
@@ -218,12 +204,6 @@ function LibraryBody({ view }: { view: LibraryView }) {
           }
         : old,
     )
-    qc.setQueryData(sharedArtifactsQuery().queryKey, (old) =>
-      old?.map((x) => (x.short_id === shortId ? { ...x, tags } : x)),
-    )
-    qc.setQueryData(needsFeedbackArtifactsQuery().queryKey, (old) =>
-      old?.map((x) => (x.short_id === shortId ? { ...x, tags } : x)),
-    )
     qc.setQueryData(artifactQuery(shortId).queryKey, (a) => (a ? { ...a, tags } : a))
     // Tag counts in the rail come from the summary.
     qc.invalidateQueries({ queryKey: summaryQuery().queryKey })
@@ -236,19 +216,18 @@ function LibraryBody({ view }: { view: LibraryView }) {
     if (filter.kind === "collection") qc.invalidateQueries({ queryKey: listQuery.queryKey })
   }
 
-  // Filter by author. Keep the collection context (you're narrowing the synced
-  // repo you're already in) and drop it again via the clear pill.
+  // Filter by author. Keep the collection context (you're narrowing the synced repo you're
+  // already in) and drop it again via the clear pill.
   const pickAuthor = (login: string) => nav({ to: "/", search: { ...search, author: login } })
   const clearAuthor = () => {
     const { author: _drop, ...rest } = search
     nav({ to: "/", search: rest })
   }
+  const { follows, isFollowingAuthor, toggleAuthor, unfollow } = useFollows()
+  const followingAuthor = !!search.author && isFollowingAuthor(search.author)
 
-  const activeCollection =
-    filter.kind === "collection" ? collections.find((c) => c.id === filter.id) : undefined
-  // The in-collection PR viewer. On a repo mirror it lists that repo's open PR
-  // previews; on a PR preview it lists the siblings (so you can hop between PRs),
-  // with the one you're viewing highlighted. parentId is the repo collection.
+  // The in-collection PR viewer: on a repo mirror it lists that repo's open PR previews;
+  // on a PR preview it lists the siblings (so you can hop between PRs).
   const prParentId =
     activeCollection?.kind === "repo"
       ? activeCollection.id
@@ -260,11 +239,29 @@ function LibraryBody({ view }: { view: LibraryView }) {
         .filter((c) => c.kind === "pr" && c.parentId === prParentId)
         .sort((a, b) => (b.prNumber ?? 0) - (a.prNumber ?? 0))
     : []
-  // The collection's name from the sidebar list, falling back to the title the list
-  // response carries — so a collection in another workspace still shows its real name
-  // (not the generic "Collection") rather than relying on the active-workspace list.
   const collectionTitle =
-    activeCollection?.title ?? data?.pages?.[0]?.collection?.title ?? "Collection"
+    activeCollection?.title ?? feed.data?.pages?.[0]?.collection?.title ?? "Collection"
+
+  // The home greeting + the quiet triage line only exist on the unfiltered "/" view.
+  const homeView = filter.kind === "all" && !isSearching
+  const { data: feedbackData } = useQuery({ ...needsFeedbackArtifactsQuery(), enabled: homeView })
+  const feedbackCount = feedbackData?.length ?? 0
+
+  // The greeting NEVER branches on a pending query: the count is preloaded in the "/"
+  // route loader, so `summary` is present on the first paint. The `totalKnown` guard is
+  // belt-and-suspenders — if the count were ever unresolved we show a neutral "Welcome,"
+  // rather than mislabelling a returning user as brand-new.
+  const firstName =
+    me?.name?.trim().split(/\s+/)[0] ||
+    (me?.username ? `@${me.username}` : me?.email?.split("@")[0]) ||
+    "there"
+  const totalKnown = summary !== undefined
+  const greetingTitle = !totalKnown
+    ? `Welcome, ${firstName}.`
+    : summary.total === 0
+      ? `Welcome to Derive, ${firstName}.`
+      : `Welcome back, ${firstName}.`
+
   const heading =
     filter.kind === "all"
       ? "All artifacts"
@@ -272,156 +269,47 @@ function LibraryBody({ view }: { view: LibraryView }) {
         ? "Favorites"
         : filter.kind === "following"
           ? "Following"
-          : filter.kind === "tag"
-            ? `#${filter.tag}`
-            : collectionTitle
-  const headingCount = debouncedQ
+          : filter.kind === "shared"
+            ? "Shared with you"
+            : filter.kind === "feedback"
+              ? "Needs your feedback"
+              : filter.kind === "tag"
+                ? `#${filter.tag}`
+                : collectionTitle
+  // Only the counts the server can state authoritatively (preloaded summary / the
+  // collection's own count) get a number; the follow/shared/feedback feeds show none
+  // rather than a misleading "loaded-so-far" count that grows as you scroll.
+  const headingCount = isSearching
     ? items.length
     : filter.kind === "all"
-      ? (summary?.total ?? items.length)
+      ? summary?.total
       : filter.kind === "favorites"
-        ? (summary?.favorites ?? items.length)
+        ? summary?.favorites
         : filter.kind === "tag"
-          ? (summary?.tags.find((t) => t.tag === filter.tag)?.count ?? items.length)
+          ? summary?.tags.find((t) => t.tag === filter.tag)?.count
           : filter.kind === "collection"
-            ? (activeCollection?.count ?? items.length)
-            : items.length
+            ? activeCollection?.count
+            : undefined
 
-  const emptyProps = debouncedQ
-    ? {
-        icon: <Icon name="search" strokeWidth={1.75} />,
-        title: `No artifacts match “${debouncedQ}”.`,
-        description: "Try a different search.",
-      }
-    : filter.kind === "favorites"
-      ? {
-          icon: <Icon name="favorites" strokeWidth={1.75} />,
-          title: "No favorites yet.",
-          description: "Tap the star on any artifact to save it.",
-        }
-      : filter.kind === "following"
-        ? {
-            icon: <Icon name="following" strokeWidth={1.75} />,
-            title: "Nothing from people you follow yet.",
-            description: "Follow authors or folders to see their recent changes here.",
-            action: (
-              <Button
-                variant="outline"
-                size="sm"
-                data-testid="library-empty-browse-people"
-                onClick={() => nav({ to: "/people" })}
-              >
-                Browse people
-              </Button>
-            ),
-          }
-        : filter.kind === "tag"
-          ? {
-              icon: <Icon name="tag" strokeWidth={1.75} />,
-              title: `Nothing tagged #${filter.tag} yet.`,
-              description: "Tag artifacts to group them here.",
-            }
-          : filter.kind === "collection"
-            ? {
-                icon: <Icon name="collection" strokeWidth={1.75} />,
-                title: "This collection is empty.",
-                description: "Open an artifact and add it from its Collections menu.",
-              }
-            : {
-                icon: <Icon name="all" strokeWidth={1.75} />,
-                title: "Nothing yet.",
-                description: "Publish above, or run derive publish ./file.",
-                action: (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    data-testid="library-empty-write"
-                    onClick={() => nav({ to: "/new" })}
-                  >
-                    Write or paste
-                  </Button>
-                ),
-              }
+  const showPublish =
+    !isSearching && (filter.kind === "all" || filter.kind === "tag" || filter.kind === "favorites")
 
-  // A personal header on the (otherwise bare) home view: lead with the user's
-  // first name, falling back to their handle. Only on the unfiltered "all" list,
-  // not while searching or inside a filter/collection.
-  const firstName =
-    me?.name?.trim().split(/\s+/)[0] ||
-    (me?.username ? `@${me.username}` : me?.email?.split("@")[0]) ||
-    "there"
-  const totalCount = summary?.total ?? items.length
-  const showGreeting = filter.kind === "all" && !debouncedQ
-
-  // "Shared with you": things explicitly shared, surfaced on the unfiltered home
-  // above your own list. Only fetched there.
-  const homeView = filter.kind === "all" && !debouncedQ
-  const { data: sharedData } = useQuery({ ...sharedArtifactsQuery(), enabled: homeView })
-  const sharedItems = homeView ? (sharedData ?? []) : []
-
-  // "Needs your feedback": artifacts with an open thread you're tagged in or have
-  // commented on — promoted to the very top of the home so you act on them first.
-  const { data: feedbackData } = useQuery({ ...needsFeedbackArtifactsQuery(), enabled: homeView })
-  const feedbackItems = homeView ? (feedbackData ?? []) : []
-  const openFeedback = async (a: Artifact) => {
-    const on = !a.favorite
-    qc.setQueryData(needsFeedbackArtifactsQuery().queryKey, (old) =>
-      old?.map((x) => (x.short_id === a.short_id ? { ...x, favorite: on } : x)),
-    )
-    try {
-      await api.favorite(a.short_id, on)
-      qc.invalidateQueries({ queryKey: summaryQuery().queryKey })
-    } catch (e) {
-      toast.error((e as Error).message)
-      qc.invalidateQueries({ queryKey: needsFeedbackArtifactsQuery().queryKey })
-    }
-  }
-
-  // The caller's follows: drives the Following feed's manage strip + empty state,
-  // and the Follow/Following toggle on the active author-filter pill.
-  const { follows, isFollowingAuthor, toggleAuthor, unfollow } = useFollows()
-  const followingAuthor = !!search.author && isFollowingAuthor(search.author)
-
-  const openShared = async (a: Artifact) => {
-    const on = !a.favorite
-    qc.setQueryData(sharedArtifactsQuery().queryKey, (old) =>
-      old?.map((x) => (x.short_id === a.short_id ? { ...x, favorite: on } : x)),
-    )
-    try {
-      await api.favorite(a.short_id, on)
-      qc.invalidateQueries({ queryKey: summaryQuery().queryKey })
-    } catch (e) {
-      toast.error((e as Error).message)
-      qc.invalidateQueries({ queryKey: sharedArtifactsQuery().queryKey })
-    }
-  }
-
-  // The "how it works" guide is for a truly blank slate: nothing of your own AND
-  // nothing shared with you. If something's shared, that section carries the home.
-  const emptyHome =
-    homeView &&
-    !isPending &&
-    !isError &&
-    items.length === 0 &&
-    sharedItems.length === 0 &&
-    feedbackItems.length === 0
+  const emptyProps = emptyStateFor(filter, isSearching, debouncedQ, nav)
+  // The first-run guide is for a genuinely blank home (your work is empty and you're not
+  // mid-search). With the promoted strips gone from home, "all + empty" simply means
+  // first-run — no more racing three queries to decide.
+  const emptyHome = homeView && items.length === 0
 
   return (
     <PageShell scrollRef={scrollRef} width="wide">
-      {showGreeting && (
-        // The home greeting is the voice headline — the shared PageHeader (one
-        // register for every page title), not a hand-rolled clone of its class string.
+      {homeView && (
         <PageHeader
           className="mb-4"
           titleTestId="library-greeting"
-          title={
-            totalCount === 0 ? `Welcome to Derive, ${firstName}.` : `Welcome back, ${firstName}.`
-          }
+          title={greetingTitle}
           subtitle={
             <>
-              Your artifacts live here. Publish one below, or run{" "}
-              {/* The Kbd chip recipe (inline-flex mono 2xs on the muted wash) —
-                  inline code is machine register, not body copy. */}
+              Your artifacts live here — most recently updated first. Publish one below, or run{" "}
               <code className="inline-flex h-5 items-center rounded-sm bg-muted px-1 font-mono text-2xs font-medium text-foreground/70">
                 derive publish
               </code>
@@ -430,6 +318,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
           }
         />
       )}
+
       <div className="mb-4.5 flex flex-wrap items-center gap-2.5">
         <SearchField
           value={query}
@@ -440,9 +329,6 @@ function LibraryBody({ view }: { view: LibraryView }) {
           hotkey
           className="min-w-50 flex-1"
         />
-        {/* The clear-filter pill is for the home library's filters (a tag or a
-            collection) — a way back to All. Favorites/Following are their own routes
-            (with their own active rail rows), not filters you "clear" here. */}
         {(filter.kind === "tag" || filter.kind === "collection") && (
           <Button
             variant="outline"
@@ -460,8 +346,6 @@ function LibraryBody({ view }: { view: LibraryView }) {
             <Icon name="close" size={16} />
           </Button>
         )}
-        {/* Active author filter — independent of the tag/collection filter, so it
-              gets its own clearable pill, plus a Follow toggle for that author. */}
         {search.author && (
           <>
             <Button
@@ -474,7 +358,6 @@ function LibraryBody({ view }: { view: LibraryView }) {
               <Icon name="user" size={16} /> {search.author}
               <Icon name="close" size={16} />
             </Button>
-            {/* Quiet by design: the page's one filled primary lives in PublishCard. */}
             <Button
               variant={followingAuthor ? "secondary" : "outline"}
               size="sm"
@@ -501,68 +384,25 @@ function LibraryBody({ view }: { view: LibraryView }) {
         )}
       </div>
 
-      {/* Following feed: the manage strip of current follows (authors + paths),
-            each unfollowable, sits above the heading so it reads as the feed's
-            controls. Hidden (returns null) when you follow nothing. */}
+      {/* Following feed: the manage strip of current follows sits above the heading. */}
       {filter.kind === "following" && (
         <FollowingStrip follows={follows} onUnfollow={(kind, target) => unfollow(kind, target)} />
       )}
 
-      {filter.kind !== "collection" && filter.kind !== "following" && <PublishCard />}
+      {showPublish && <PublishCard />}
 
-      {feedbackItems.length > 0 && (
-        <section className="mb-6" data-testid="needs-your-feedback">
-          <SectionEyebrow
-            className="mb-3.5"
-            count={feedbackItems.length}
-            icon={<Icon name="comments" size={12} />}
-          >
-            Needs your feedback
-          </SectionEyebrow>
-          <CardGrid>
-            {feedbackItems.map((a) => (
-              <ArtifactCard
-                key={a.short_id}
-                artifact={a}
-                onOpen={() => nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })}
-                onToggleFavorite={() => openFeedback(a)}
-                onPickTag={(tag) => nav({ to: "/", search: { tag } })}
-                onEditTags={() => setPendingTags(a)}
-                onAddToCollection={() => setPendingCollections(a)}
-                onPrefetch={() => prefetch(a.short_id, a.current_version)}
-              />
-            ))}
-          </CardGrid>
-        </section>
-      )}
-
-      {sharedItems.length > 0 && (
-        <section className="mb-6" data-testid="shared-with-you">
-          <SectionEyebrow className="mb-3.5" count={sharedItems.length}>
-            Shared with you
-          </SectionEyebrow>
-          <CardGrid>
-            {sharedItems.map((a) => (
-              <ArtifactCard
-                key={a.short_id}
-                artifact={a}
-                onOpen={() => nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })}
-                onToggleFavorite={() => openShared(a)}
-                onPickTag={(tag) => nav({ to: "/", search: { tag } })}
-                onEditTags={() => setPendingTags(a)}
-                onAddToCollection={() => setPendingCollections(a)}
-                onPrefetch={() => prefetch(a.short_id, a.current_version)}
-              />
-            ))}
-          </CardGrid>
-        </section>
+      {/* The quiet triage line — one entry point to the /feedback feed, home only. */}
+      {homeView && feedbackCount > 0 && (
+        <div className="mb-6">
+          <TriageBar count={feedbackCount} />
+        </div>
       )}
 
       {filter.kind === "collection" ? (
         <>
           <CollectionBar
             title={heading}
-            count={headingCount}
+            count={headingCount ?? items.length}
             onShare={() => activeCollection && setShareCol(activeCollection)}
             onRename={(t) => renameCollection(filter.id, t)}
             onDelete={() => deleteCollection(filter.id)}
@@ -570,8 +410,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
           <RepoPullRequests prs={repoPrs} repo={activeCollection?.repo} activeId={filter.id} />
         </>
       ) : (
-        // Hide the "All artifacts · 0" heading on a brand-new empty home — the
-        // visual guide carries it instead.
+        // Hide the heading on a brand-new empty home — the visual guide carries it.
         !emptyHome && (
           <SectionEyebrow className="mb-3.5" count={headingCount}>
             {heading}
@@ -606,70 +445,22 @@ function LibraryBody({ view }: { view: LibraryView }) {
           <EmptyState {...emptyProps} />
         )
       ) : isSyncedCollection ? (
-        // A mirrored repo. Default to a flat, most-recently-updated list; folders are
-        // there as a toggle (off by default) so the tree is available but not forced.
-        <div className="flex flex-col gap-3">
-          <ToggleGroup
-            type="single"
-            variant="outline"
-            size="sm"
-            aria-label="View"
-            className="self-end"
-            value={showFolders ? "folders" : "list"}
-            onValueChange={(v) => v && toggleFolders(v === "folders")}
-          >
-            <ToggleGroupItem value="list" aria-label="List" data-testid="library-view-list">
-              <List aria-hidden />
-              List
-            </ToggleGroupItem>
-            <ToggleGroupItem
-              value="folders"
-              aria-label="Folders"
-              data-testid="library-view-folders"
-            >
-              <FolderTree aria-hidden />
-              Folders
-            </ToggleGroupItem>
-          </ToggleGroup>
-          {showFolders ? (
-            <FolderGroups
-              items={recencyItems}
-              hasNextPage={!!hasNextPage}
-              isFetchingNextPage={isFetchingNextPage}
-              onLoadMore={() => fetchNextPage()}
-              onOpen={(a) => nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })}
-              onToggleFavorite={toggleFav}
-              onPickTag={(tag) => nav({ to: "/", search: { tag } })}
-              onPickAuthor={pickAuthor}
-              onEditTags={setPendingTags}
-              onAddToCollection={setPendingCollections}
-              onDelete={setPendingDelete}
-              onPrefetch={(a) => prefetch(a.short_id, a.current_version)}
-            />
-          ) : (
-            <div className="flex flex-col gap-2" data-testid="library-flat-list">
-              {recencyItems.map((a) => (
-                <ArtifactRow
-                  key={a.short_id}
-                  artifact={a}
-                  onOpen={() => nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })}
-                  onToggleFavorite={() => toggleFav(a)}
-                  onPickTag={(tag) => nav({ to: "/", search: { tag } })}
-                  onPickAuthor={pickAuthor}
-                  onEditTags={() => setPendingTags(a)}
-                  onAddToCollection={() => setPendingCollections(a)}
-                  onDelete={() => setPendingDelete(a)}
-                  onPrefetch={() => prefetch(a.short_id, a.current_version)}
-                />
-              ))}
-              {(hasNextPage || isFetchingNextPage) && (
-                <div className="flex justify-center py-2">
-                  <Spinner />
-                </div>
-              )}
-            </div>
-          )}
-        </div>
+        <SyncedCollection
+          items={recencyItems}
+          showFolders={showFolders}
+          onToggle={setShowFolders}
+          hasNextPage={!!hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+          onLoadMore={() => fetchNextPage()}
+          onOpen={(a) => nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })}
+          onToggleFavorite={toggleFavorite}
+          onPickTag={(tag) => nav({ to: "/", search: { tag } })}
+          onPickAuthor={pickAuthor}
+          onEditTags={setPendingTags}
+          onAddToCollection={setPendingCollections}
+          onDelete={setPendingDelete}
+          onPrefetch={(a) => prefetch(a.short_id, a.current_version)}
+        />
       ) : (
         <>
           <ArtifactGrid
@@ -679,7 +470,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
             isFetchingNextPage={isFetchingNextPage}
             onLoadMore={() => fetchNextPage()}
             onOpen={(a) => nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })}
-            onToggleFavorite={toggleFav}
+            onToggleFavorite={toggleFavorite}
             onPickTag={(tag) => nav({ to: "/", search: { tag } })}
             onEditTags={setPendingTags}
             onAddToCollection={setPendingCollections}
@@ -697,6 +488,18 @@ function LibraryBody({ view }: { view: LibraryView }) {
       {shareCol && (
         <ShareCollectionDialog collection={shareCol} onClose={() => setShareCol(null)} />
       )}
+      <ConfirmDialog
+        open={!!pendingDelete}
+        onOpenChange={(o) => !o && setPendingDelete(null)}
+        title={`Delete “${pendingDelete?.title ?? pendingDelete?.short_id ?? ""}”?`}
+        description="This permanently deletes the artifact and its versions. This cannot be undone."
+        confirmLabel="Delete"
+        confirmTestId="library-delete-confirm"
+        onConfirm={() => {
+          if (pendingDelete) deleteArtifact(pendingDelete)
+        }}
+      />
+      {/* Quick-organize dialogs — opened from a card/row ⋯ menu (edit tags / collections). */}
       {pendingTags && (
         <LibraryTagsDialog
           artifact={pendingTags}
@@ -711,17 +514,175 @@ function LibraryBody({ view }: { view: LibraryView }) {
           onClose={() => setPendingCollections(null)}
         />
       )}
-      <ConfirmDialog
-        open={!!pendingDelete}
-        onOpenChange={(o) => !o && setPendingDelete(null)}
-        title={`Delete “${pendingDelete?.title ?? pendingDelete?.short_id ?? ""}”?`}
-        description="This permanently deletes the artifact and its versions. This cannot be undone."
-        confirmLabel="Delete"
-        confirmTestId="library-delete-confirm"
-        onConfirm={() => {
-          if (pendingDelete) deleteArtifact(pendingDelete)
-        }}
-      />
     </PageShell>
   )
+}
+
+// A mirrored repo/PR collection: a flat, most-recently-updated list by default, with the
+// folder tree available behind a toggle (off by default). Split out of the render switch
+// so the body reads top-to-bottom.
+function SyncedCollection({
+  items,
+  showFolders,
+  onToggle,
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+  onOpen,
+  onToggleFavorite,
+  onPickTag,
+  onPickAuthor,
+  onEditTags,
+  onAddToCollection,
+  onDelete,
+  onPrefetch,
+}: {
+  items: Artifact[]
+  showFolders: boolean
+  onToggle: (on: boolean) => void
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  onLoadMore: () => void
+  onOpen: (a: Artifact) => void
+  onToggleFavorite: (a: Artifact) => void
+  onPickTag: (tag: string) => void
+  onPickAuthor: (login: string) => void
+  onEditTags: (a: Artifact) => void
+  onAddToCollection: (a: Artifact) => void
+  onDelete: (a: Artifact) => void
+  onPrefetch: (a: Artifact) => void
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <ToggleGroup
+        type="single"
+        variant="outline"
+        size="sm"
+        aria-label="View"
+        className="self-end"
+        value={showFolders ? "folders" : "list"}
+        onValueChange={(v) => v && onToggle(v === "folders")}
+      >
+        <ToggleGroupItem value="list" aria-label="List" data-testid="library-view-list">
+          <List aria-hidden />
+          List
+        </ToggleGroupItem>
+        <ToggleGroupItem value="folders" aria-label="Folders" data-testid="library-view-folders">
+          <FolderTree aria-hidden />
+          Folders
+        </ToggleGroupItem>
+      </ToggleGroup>
+      {showFolders ? (
+        <FolderGroups
+          items={items}
+          hasNextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+          onLoadMore={onLoadMore}
+          onOpen={onOpen}
+          onToggleFavorite={onToggleFavorite}
+          onPickTag={onPickTag}
+          onPickAuthor={onPickAuthor}
+          onEditTags={onEditTags}
+          onAddToCollection={onAddToCollection}
+          onDelete={onDelete}
+          onPrefetch={onPrefetch}
+        />
+      ) : (
+        <div className="flex flex-col gap-2" data-testid="library-flat-list">
+          {items.map((a) => (
+            <ArtifactRow
+              key={a.short_id}
+              artifact={a}
+              onOpen={() => onOpen(a)}
+              onToggleFavorite={() => onToggleFavorite(a)}
+              onPickTag={onPickTag}
+              onPickAuthor={onPickAuthor}
+              onEditTags={() => onEditTags(a)}
+              onAddToCollection={() => onAddToCollection(a)}
+              onDelete={() => onDelete(a)}
+              onPrefetch={() => onPrefetch(a)}
+            />
+          ))}
+          {(hasNextPage || isFetchingNextPage) && (
+            <div className="flex justify-center py-2">
+              <Spinner />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// The empty state for each view/filter — three tones, never reused (research): searching
+// = corrective ("no match, try another"); a named feed = an explanatory nudge; the
+// inbox-zero /feedback = a positive "all caught up" with no CTA. The unfiltered empty
+// home is handled separately (the HowItWorks first-run guide), so "all" never lands here.
+function emptyStateFor(
+  filter: Filter,
+  isSearching: boolean,
+  debouncedQ: string,
+  nav: ReturnType<typeof useNavigate>,
+) {
+  if (isSearching)
+    return {
+      icon: <Icon name="search" strokeWidth={1.75} />,
+      title: `No artifacts match “${debouncedQ}”.`,
+      description: "Try a different search.",
+    }
+  switch (filter.kind) {
+    case "favorites":
+      return {
+        icon: <Icon name="favorites" strokeWidth={1.75} />,
+        title: "No favorites yet.",
+        description: "Tap the star on any artifact to save it.",
+      }
+    case "following":
+      return {
+        icon: <Icon name="following" strokeWidth={1.75} />,
+        title: "Nothing from people you follow yet.",
+        description: "Follow authors or folders to see their recent changes here.",
+        action: (
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="library-empty-browse-people"
+            onClick={() => nav({ to: "/people" })}
+          >
+            Browse people
+          </Button>
+        ),
+      }
+    case "shared":
+      return {
+        icon: <Icon name="share" strokeWidth={1.75} />,
+        title: "Nothing shared with you yet.",
+        description: "When someone shares an artifact with you, it shows up here.",
+      }
+    case "feedback":
+      // Inbox-zero: a positive tone, no action — you're done, not stuck.
+      return {
+        icon: <Icon name="check" strokeWidth={1.75} />,
+        title: "You’re all caught up.",
+        description: "Artifacts with an open thread that needs you show up here.",
+      }
+    case "tag":
+      return {
+        icon: <Icon name="tag" strokeWidth={1.75} />,
+        title: `Nothing tagged #${filter.tag} yet.`,
+        description: "Tag artifacts to group them here.",
+      }
+    case "collection":
+      return {
+        icon: <Icon name="collection" strokeWidth={1.75} />,
+        title: "This collection is empty.",
+        description: "Open an artifact and add it from its Collections menu.",
+      }
+    default:
+      return {
+        icon: <Icon name="all" strokeWidth={1.75} />,
+        title: "Nothing yet.",
+        description: "Publish above, or run derive publish ./file.",
+      }
+  }
 }

--- a/apps/web/src/pages/library/library-skeleton.tsx
+++ b/apps/web/src/pages/library/library-skeleton.tsx
@@ -1,6 +1,6 @@
+import { CardGrid } from "@/components/shared/card-grid"
 import { PageShell } from "@/components/shared/page-shell"
 import { Skeleton } from "@/components/ui/skeleton"
-import { CardGrid } from "./card-grid"
 
 // One card-shaped placeholder: the live ArtifactCard's box model — a 16:10 preview,
 // then a p-3.5 caption of a title line over a two-cluster provenance/activity meta

--- a/apps/web/src/pages/library/publish-card.tsx
+++ b/apps/web/src/pages/library/publish-card.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import { Upload } from "lucide-react"
 import { useRef, useState } from "react"
@@ -6,14 +7,17 @@ import { Icon } from "@/components/icons"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { toast } from "@/components/ui/sonner"
+import { collectionsQuery, summaryQuery } from "@/lib/queries"
 import { cn } from "@/lib/utils"
 import { refFor } from "../artifact/parse-ref"
 
 // The home launcher. "Write or paste" opens /new — the same editor as edit mode
 // (paste/write Markdown or HTML with a live preview). Dropping or choosing a file
-// publishes it directly. New artifacts default to Workspace (private) access.
+// publishes it directly. New artifacts are private by default (the server default
+// governs — no visibility sent); widen access from the artifact's Share menu.
 export function PublishCard() {
   const nav = useNavigate()
+  const qc = useQueryClient()
   const fileRef = useRef<HTMLInputElement>(null)
   const [busy, setBusy] = useState(false)
   const [dragging, setDragging] = useState(false)
@@ -39,6 +43,10 @@ export function PublishCard() {
     try {
       // No visibility: the server default (private) governs; widen from the Share dialog.
       const a = await api.publish(f, { title: f.name.replace(/\.[^.]+$/, "") })
+      // Freshen the library so the new artifact + bumped total are correct on return.
+      qc.invalidateQueries({ queryKey: summaryQuery().queryKey })
+      qc.invalidateQueries({ queryKey: collectionsQuery().queryKey })
+      qc.invalidateQueries({ queryKey: ["artifacts"] })
       nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })
     } catch (e) {
       toast.error((e as Error).message)

--- a/apps/web/src/pages/library/triage-bar.tsx
+++ b/apps/web/src/pages/library/triage-bar.tsx
@@ -1,0 +1,28 @@
+import { Link } from "@tanstack/react-router"
+import { Icon } from "@/components/icons"
+
+// The home's ONE quiet triage entry — a single clickable well that replaces the old
+// stacked "needs your feedback" card-strip. It links to the /feedback feed, so the home
+// stays "your work," one job (the whole IA move). Shown only when something actually
+// needs you; its count is preloaded in the home route loader, so this line paints
+// deterministically on the first frame — no late-landing shift that would drift the
+// virtualized grid below it. A well, not cards (the surfaces ladder: an interactive
+// well before a card).
+export function TriageBar({ count }: { count: number }) {
+  return (
+    <Link
+      to="/feedback"
+      data-testid="library-triage"
+      className="group flex items-center gap-2.5 rounded-lg bg-secondary px-3.5 py-2.5 text-sm ring-1 ring-transparent ring-inset outline-none hover:ring-input focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+    >
+      <Icon name="comments" size={16} className="text-muted-foreground" />
+      <span className="min-w-0 flex-1 truncate text-foreground">
+        <span className="font-medium tabular-nums">{count}</span>{" "}
+        {count === 1 ? "artifact needs" : "artifacts need"} your feedback
+      </span>
+      <span className="shrink-0 font-mono text-2xs text-muted-foreground group-hover:text-foreground">
+        View
+      </span>
+    </Link>
+  )
+}

--- a/apps/web/src/pages/library/types.ts
+++ b/apps/web/src/pages/library/types.ts
@@ -6,6 +6,12 @@ export type Filter =
   // The activity feed: artifacts in the active workspace whose current author or
   // source-path matches one of your follows.
   | { kind: "following" }
+  // "Shared with you": artifacts explicitly shared with the caller (can span
+  // workspaces). A durable named feed, not a home strip.
+  | { kind: "shared" }
+  // "Needs your feedback": artifacts with an open thread you're tagged in or have
+  // commented on — the triage feed.
+  | { kind: "feedback" }
   | { kind: "tag"; tag: string }
   | { kind: "collection"; id: string; title: string }
 
@@ -19,9 +25,9 @@ export type Summary = {
 }
 
 // The base library feed, chosen by ROUTE (path), not a query param: "/" = all,
-// "/favorites", "/following". Path = the feed you're viewing; query (LibrarySearch)
-// = how it's filtered. See routes/favorites.tsx + docs/decisions/0002.
-export type LibraryView = "all" | "favorites" | "following"
+// "/favorites", "/following", "/shared", "/feedback". Path = the feed you're viewing;
+// query (LibrarySearch) = how it's filtered. See routes/favorites.tsx + docs/decisions/0002.
+export type LibraryView = "all" | "favorites" | "following" | "shared" | "feedback"
 
 // The library's URL-encoded filters + search (query params on the home route), so
 // the persistent nav rail can drive them from any page and a filtered/searched

--- a/apps/web/src/pages/library/use-library-feed.ts
+++ b/apps/web/src/pages/library/use-library-feed.ts
@@ -1,0 +1,71 @@
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query"
+import { type Artifact, api } from "@/api"
+import { toast } from "@/components/ui/sonner"
+import { type LibraryParams, libraryArtifactsQuery, summaryQuery } from "@/lib/queries"
+
+// The library feed as a hook: the infinite keyset query plus the two optimistic
+// mutations that write across every cached page (star + delete). Lifted verbatim from
+// the old 660-line library body so the mutation correctness — optimistic write across
+// ALL pages, drop-on-unstar in the Favorites view, reconcile-against-server on failure
+// — is preserved, just relocated out of the god-component. Keyed by the active filter
+// params, so each view caches independently and switching views keeps the current grid
+// (keepPreviousData, set on the query factory).
+export function useLibraryFeed(params: LibraryParams) {
+  const qc = useQueryClient()
+  const listQuery = libraryArtifactsQuery(params)
+  const query = useInfiniteQuery(listQuery)
+  const items = query.data?.pages.flatMap((p) => p.artifacts) ?? []
+
+  // Star toggle is optimistic across every cached page; in the Favorites view an
+  // un-star drops the card (params.favorite tells us we're in that view). Reconcile
+  // against the server on failure.
+  const toggleFavorite = async (a: Artifact) => {
+    const on = !a.favorite
+    const drop = !!params.favorite && !on
+    qc.setQueryData(listQuery.queryKey, (old) =>
+      old
+        ? {
+            ...old,
+            pages: old.pages.map((pg) => ({
+              ...pg,
+              artifacts: pg.artifacts.flatMap((x) =>
+                x.short_id !== a.short_id ? [x] : drop ? [] : [{ ...x, favorite: on }],
+              ),
+            })),
+          }
+        : old,
+    )
+    try {
+      await api.favorite(a.short_id, on)
+      qc.invalidateQueries({ queryKey: summaryQuery().queryKey })
+    } catch (e) {
+      toast.error((e as Error).message)
+      qc.invalidateQueries({ queryKey: listQuery.queryKey })
+    }
+  }
+
+  // Delete is optimistic across every cached page too; reconcile on failure.
+  const deleteArtifact = async (a: Artifact) => {
+    qc.setQueryData(listQuery.queryKey, (old) =>
+      old
+        ? {
+            ...old,
+            pages: old.pages.map((pg) => ({
+              ...pg,
+              artifacts: pg.artifacts.filter((x) => x.short_id !== a.short_id),
+            })),
+          }
+        : old,
+    )
+    try {
+      await api.deleteArtifact(a.short_id)
+      qc.invalidateQueries({ queryKey: summaryQuery().queryKey })
+      toast.success("Artifact deleted")
+    } catch (e) {
+      toast.error((e as Error).message)
+      qc.invalidateQueries({ queryKey: listQuery.queryKey })
+    }
+  }
+
+  return { query, items, listQuery, toggleFavorite, deleteArtifact }
+}

--- a/apps/web/src/pages/new.tsx
+++ b/apps/web/src/pages/new.tsx
@@ -1,7 +1,10 @@
-import { useNavigate } from "@tanstack/react-router"
-import { useState } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { useBlocker, useNavigate } from "@tanstack/react-router"
+import { useRef, useState } from "react"
 import { api } from "@/api"
+import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { toast } from "@/components/ui/sonner"
+import { collectionsQuery, summaryQuery } from "@/lib/queries"
 import { refFor } from "./artifact/parse-ref"
 import { SourceEditor } from "./artifact/source-editor"
 
@@ -27,10 +30,28 @@ const detectFormat = (t: string): "md" | "html" => {
 // access from its Share menu) and opens it.
 export function NewArtifact() {
   const nav = useNavigate()
+  const qc = useQueryClient()
   const [src, setSrc] = useState("")
   const [title, setTitle] = useState("")
   const [message, setMessage] = useState("")
   const format = detectFormat(src)
+
+  // A draft is dirty once anything's been typed. Publishing must bypass the guard for its
+  // own nav to the artifact — via a REF, not state: publish() sets it and calls nav() in the
+  // same tick, so a batched state update wouldn't be reflected in the blocker's closure yet
+  // (the nav would fire the discard dialog on the very success path it's meant to allow).
+  // A ref updates synchronously, so shouldBlockFn sees the bypass immediately.
+  const publishing = useRef(false)
+  const dirty = !!(src.trim() || title.trim() || message.trim())
+
+  // Guard leaving with an unsaved draft — BOTH in-app navigation (rail click, Cancel) and
+  // a browser close/refresh (enableBeforeUnload). withResolver gives us proceed/reset to
+  // drive the shared ConfirmDialog instead of the browser's native prompt for in-app navs.
+  const blocker = useBlocker({
+    shouldBlockFn: () => dirty && !publishing.current,
+    enableBeforeUnload: () => dirty && !publishing.current,
+    withResolver: true,
+  })
 
   const publish = async () => {
     if (!src.trim()) {
@@ -44,6 +65,15 @@ export function NewArtifact() {
       const fields: Record<string, string> = { title: name }
       if (message.trim()) fields.message = message.trim()
       const a = await api.publish(new File([src], `inline.${ext}`, { type }), fields)
+      // Freshen the library so the new artifact + bumped total are correct on return,
+      // instead of relying only on the app-shell's nav-change invalidation.
+      qc.invalidateQueries({ queryKey: summaryQuery().queryKey })
+      qc.invalidateQueries({ queryKey: collectionsQuery().queryKey })
+      qc.invalidateQueries({ queryKey: ["artifacts"] })
+      // Drop the unsaved guard before navigating to the artifact (this nav is the save,
+      // not an abandon), so the blocker doesn't intercept it. Ref, so it's in effect the
+      // instant nav() runs — see the note on `publishing` above.
+      publishing.current = true
       nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })
     } catch (e) {
       toast.error((e as Error).message)
@@ -66,6 +96,22 @@ export function NewArtifact() {
         onCancel={() => nav({ to: "/" })}
         onPublish={publish}
         onPropose={() => {}}
+        placeholder="Write or paste Markdown or HTML — the preview updates as you type."
+      />
+      {/* The unsaved-draft confirm: fires for any blocked departure (Cancel, a rail click,
+          back). Discarding proceeds; keeping resets you to the editor with the draft intact. */}
+      <ConfirmDialog
+        open={blocker.status === "blocked"}
+        onOpenChange={(o) => {
+          if (!o && blocker.status === "blocked") blocker.reset()
+        }}
+        title="Discard this draft?"
+        description="You have unpublished changes. Leaving now discards them — this can't be undone."
+        confirmLabel="Discard"
+        confirmTestId="new-discard-confirm"
+        onConfirm={() => {
+          if (blocker.status === "blocked") blocker.proceed()
+        }}
       />
     </div>
   )

--- a/apps/web/src/pages/people.tsx
+++ b/apps/web/src/pages/people.tsx
@@ -17,15 +17,15 @@ import { colorForName } from "@/lib/avatar-tints"
 import { getInitials } from "@/lib/initials"
 import { peopleQuery, workspacePeopleQuery } from "@/lib/queries"
 import { useDelayedPending } from "@/lib/use-delayed-pending"
+import { cn } from "@/lib/utils"
 
-// The people results grid geometry, defined once so the live grid and its skeleton
-// can't drift. 240px min sizes each cell for a person row — an avatar + name beside a
-// Follow button, on one line.
-const PEOPLE_GRID = "grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-3"
-
-// The People directory — browse + search discoverable people and follow them. This is
-// the discovery surface the follow graph was missing: a way to FIND someone to follow,
-// not just stumble on an author chip. Empty query browses; typing searches (debounced).
+// The People directory — the discovery surface the follow graph needs: a way to FIND
+// someone to follow, not just stumble on an author chip. Reconceived as a scannable
+// directory of full-width rows (a directory's job is "read a name, follow" — list work,
+// not a card wall), with a deliberate BROWSE-by-default state: an empty query isn't
+// "nothing", it's the people you work with + everyone discoverable, framed as such.
+// Typing searches (debounced); the current results stay put (dimmed) while the next set
+// loads — never a flash.
 export function People() {
   const [q, setQ] = useState("")
   const [debounced, setDebounced] = useState("")
@@ -34,24 +34,31 @@ export function People() {
     return () => clearTimeout(t)
   }, [q])
 
-  const { data, isPending, isError, isFetching, refetch } = useQuery(peopleQuery(debounced))
-  // keepPreviousData holds the current results across searches, so isPending is only
-  // the true first load; gate the skeleton so a cache-warm open flashes nothing.
+  const { data, isPending, isError, isFetching, isPlaceholderData, refetch } = useQuery(
+    peopleQuery(debounced),
+  )
+  // keepPreviousData holds the current results across searches, so isPending is only the
+  // true first load; gate the skeleton so a cache-warm open flashes nothing.
   const showSkeleton = useDelayedPending(isPending)
   const people = data ?? []
+  const searching = debounced.length > 0
+  const browsing = !searching
 
-  // The people you actually work with lead the browse view (Slack's mental model);
-  // the global discoverable directory follows. A search collapses to one flat
-  // result list — sectioning search hits by workspace would just split matches.
+  // The people you actually work with lead the browse view (Slack's mental model); the
+  // global discoverable directory follows, de-duplicated against your workspace. A search
+  // collapses to one flat result list — sectioning matches by workspace would just split
+  // them. Regardless of discoverability, so teammates are always reachable here.
   const { data: mates = [] } = useQuery(workspacePeopleQuery())
-  const browsing = !debounced
   const mateHandles = new Set(mates.map((m) => m.username))
   const globalPeople = browsing ? people.filter((p) => !mateHandles.has(p.username)) : people
+  // Empty only when there's genuinely nothing for the current mode: a search shows its own
+  // "no match" regardless of teammates; browse is empty only if BOTH sources are.
+  const nothing = searching ? people.length === 0 : people.length === 0 && mates.length === 0
 
   return (
     <PageShell className="flex flex-col gap-5">
-      {/* Title + description + search form one tight header block (inner gaps);
-          the PageShell gap makes the larger step down to the results below. */}
+      {/* Title + description + search — one tight header block; the PageShell gap makes
+          the larger step down to the results. */}
       <div className="flex flex-col gap-4">
         <PageHeader title="People" subtitle="Find people on Derive and follow their work." />
         <SearchField
@@ -65,93 +72,108 @@ export function People() {
         />
       </div>
 
-      <div>
-        {isPending ? (
-          showSkeleton ? (
-            <PeopleResultsSkeleton />
-          ) : null
-        ) : isError ? (
-          // A failed fetch is status, not emptiness — the danger tone grammar.
-          <StatusPanel
-            tone="danger"
-            title="Couldn’t load people"
-            description="This is usually temporary."
-            action={
-              <Button
-                variant="outline"
-                size="sm"
-                data-testid="people-retry"
-                onClick={() => refetch()}
-              >
-                Try again
-              </Button>
+      {isPending ? (
+        showSkeleton ? (
+          <PeopleResultsSkeleton />
+        ) : null
+      ) : isError ? (
+        // A failed fetch is status, not emptiness — the danger tone grammar.
+        <StatusPanel
+          tone="danger"
+          title="Couldn’t load people"
+          description="This is usually temporary."
+          action={
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="people-retry"
+              onClick={() => refetch()}
+            >
+              Try again
+            </Button>
+          }
+        />
+      ) : nothing ? (
+        <div data-testid="people-empty">
+          <EmptyState
+            icon={<Icon name={searching ? "search" : "following"} strokeWidth={1.75} />}
+            // Two distinct tones: a search that found nothing is corrective ("try
+            // another"); the browse state finding nothing is explanatory, not an error.
+            title={searching ? `No people match “${debounced}”.` : "No discoverable people yet."}
+            description={
+              searching
+                ? "Try a different name or @handle."
+                : "People who turn on discoverability show up here."
             }
           />
-        ) : people.length === 0 && mates.length === 0 ? (
-          <div data-testid="people-empty">
-            <EmptyState
-              icon={<Icon name="following" strokeWidth={1.75} />}
-              title={debounced ? `No people match “${debounced}”.` : "No discoverable people yet."}
-              description={
-                debounced
-                  ? "Try a different name or @handle."
-                  : "People who turn on discoverability show up here."
-              }
+        </div>
+      ) : (
+        // Stale results stay visible but dim while the next search loads (placeholder
+        // data), so the directory never blanks mid-type.
+        <div
+          className={cn(
+            "flex flex-col gap-6",
+            isPlaceholderData && "opacity-60 transition-opacity",
+          )}
+        >
+          {/* Browse leads with the people you work with — teammates first, then the wider
+              directory. A search collapses to a single "Results" list. */}
+          {browsing && mates.length > 0 && (
+            <PeopleGroup label="Your workspaces" people={mates} testId="people-workspace" />
+          )}
+          {globalPeople.length > 0 && (
+            <PeopleGroup
+              label={searching ? "Results" : mates.length > 0 ? "Everyone on Derive" : "Everyone"}
+              people={globalPeople}
+              testId="people-results"
             />
-          </div>
-        ) : (
-          <div className="flex flex-col gap-6">
-            {browsing && mates.length > 0 && (
-              <section data-testid="people-workspace">
-                <SectionEyebrow className="mb-3" count={mates.length}>
-                  Your workspaces
-                </SectionEyebrow>
-                <ul role="list" className={PEOPLE_GRID}>
-                  {mates.map((p) => (
-                    <PersonCard key={p.username} person={p} />
-                  ))}
-                </ul>
-              </section>
-            )}
-            {globalPeople.length > 0 && (
-              <section>
-                {browsing && mates.length > 0 && (
-                  <SectionEyebrow className="mb-3" count={globalPeople.length}>
-                    Everyone on Derive
-                  </SectionEyebrow>
-                )}
-                <ul role="list" className={PEOPLE_GRID} data-testid="people-grid">
-                  {globalPeople.map((p) => (
-                    <PersonCard key={p.username} person={p} />
-                  ))}
-                </ul>
-              </section>
-            )}
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      )}
     </PageShell>
   )
 }
 
-// One directory row: identity links to the profile; Follow sits beside it (a sibling,
-// not nested in the link — no interactive-inside-interactive). FollowButton self-hides
-// for your own handle and signed-out viewers.
-function PersonCard({ person: p }: { person: PublicProfile }) {
+// One labelled directory section: a mono eyebrow + count over a list of person rows.
+// The count frames the state (browsing everyone vs a result set) as intentional.
+function PeopleGroup({
+  label,
+  people,
+  testId,
+}: {
+  label: string
+  people: PublicProfile[]
+  testId: string
+}) {
+  return (
+    <section>
+      <SectionEyebrow className="mb-3" count={people.length}>
+        {label}
+      </SectionEyebrow>
+      <ul role="list" data-testid={testId} className="flex flex-col gap-2">
+        {people.map((p) => (
+          <PersonRow key={p.username} person={p} />
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+// One directory row: identity links to the profile (stretched link over the whole row);
+// Follow sits beside it as a sibling — not nested in the link (no interactive-inside-
+// interactive). FollowButton self-hides for your own handle and signed-out viewers.
+function PersonRow({ person: p }: { person: PublicProfile }) {
   const initials = getInitials(p.name ?? p.username)
   return (
-    // Interactive card via the stretched link — the whole card is the click
-    // target, so the hover edge-brighten sits on a genuinely clickable surface.
-    <li className="relative flex items-center gap-3 rounded-xl border bg-card p-3 hover:border-foreground/25">
+    <li className="relative flex items-center gap-3 rounded-lg border bg-card px-3.5 py-3 hover:border-foreground/25">
       <Link
         to="/users/$handle"
         params={{ handle: p.username }}
         data-testid={`people-card-${p.username}`}
-        className="flex min-w-0 flex-1 items-center gap-3 rounded-lg outline-none after:absolute after:inset-0 after:rounded-xl focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+        className="flex min-w-0 flex-1 items-center gap-3 rounded-md outline-none after:absolute after:inset-0 after:rounded-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
       >
-        <Avatar className="size-9 shrink-0">
+        <Avatar className="size-10 shrink-0">
           {p.image && <AvatarImage src={p.image} alt={p.name ?? p.username} />}
-          {/* Identity tint (stable per person) + the outline frame images get. */}
           <AvatarFallback
             className="font-medium text-scrim-foreground outline-1 -outline-offset-1 outline-foreground/10"
             style={{ backgroundColor: colorForName(p.name ?? p.username) }}
@@ -159,15 +181,20 @@ function PersonCard({ person: p }: { person: PublicProfile }) {
             {initials}
           </AvatarFallback>
         </Avatar>
-        <span className="min-w-0">
-          {p.name && (
-            <span className="block truncate text-sm font-medium text-foreground">{p.name}</span>
-          )}
-          <span className="block truncate font-mono text-2xs text-muted-foreground">
-            @{p.username}
+        <span className="flex min-w-0 flex-col">
+          {/* Name + @handle share a line (name is the read, handle is the identity);
+              profession sits below as the muted one-liner — the "read one line" a
+              directory scan needs. */}
+          <span className="flex min-w-0 items-baseline gap-2">
+            {p.name && (
+              <span className="truncate text-sm font-medium text-foreground">{p.name}</span>
+            )}
+            <span className="shrink-0 truncate font-mono text-2xs text-muted-foreground">
+              @{p.username}
+            </span>
           </span>
           {p.profession && (
-            <span className="block truncate text-sm text-muted-foreground">{p.profession}</span>
+            <span className="truncate text-sm text-muted-foreground">{p.profession}</span>
           )}
         </span>
       </Link>
@@ -176,25 +203,25 @@ function PersonCard({ person: p }: { person: PublicProfile }) {
   )
 }
 
-const PERSON_CELLS = ["a", "b", "c", "d", "e", "f", "g", "h"]
+const PERSON_CELLS = ["a", "b", "c", "d", "e", "f"]
 
-// One person-row placeholder: PersonCard's box model — the p-3 row inset, a round
-// size-9 avatar, name + @handle lines, and a Follow-button-sized block (size sm → h-8)
-// — minus the card's border/background (those arrive with the person → zero CLS).
-function PersonSkeletonCell() {
+// One person-row placeholder: PersonRow's box model — the px-3.5 py-3 row inset, a round
+// size-10 avatar, a name/handle line over a profession line, and a Follow-button-sized
+// block (sm → h-8) — minus the border/background (those arrive with the person → zero CLS).
+function PersonSkeletonRow() {
   return (
-    <li className="flex items-center gap-3 p-3">
-      <Skeleton className="size-9 shrink-0 rounded-full" />
+    <li className="flex items-center gap-3 px-3.5 py-3">
+      <Skeleton className="size-10 shrink-0 rounded-full" />
       <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-        <Skeleton className="h-4 w-24" />
-        <Skeleton className="h-3 w-16" />
+        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-3.5 w-24" />
       </div>
       <Skeleton className="h-8 w-20 shrink-0 rounded-lg" />
     </li>
   )
 }
 
-// The results-region first-load placeholder — the SAME grid the live results use,
+// The results-region first-load placeholder — the SAME row stack the live results use,
 // filled with person-row silhouettes. The blocks are AT-hidden (baked into Skeleton);
 // the region announces via role="status" + sr-only. Shared by the in-component first
 // load and the route-level PeoplePending.
@@ -202,19 +229,19 @@ export function PeopleResultsSkeleton() {
   return (
     <div role="status">
       <span className="sr-only">Loading people…</span>
-      <ul className={PEOPLE_GRID}>
+      <ul className="flex flex-col gap-2">
         {PERSON_CELLS.map((k) => (
-          <PersonSkeletonCell key={k} />
+          <PersonSkeletonRow key={k} />
         ))}
       </ul>
     </div>
   )
 }
 
-// Route-level pending frame (the /people pendingComponent): the real static chrome —
-// the PageHeader (always "People") and a SearchField-well silhouette — over the results
+// Route-level pending frame (the /people pendingComponent): the real static chrome — the
+// PageHeader (always "People") and a SearchField-well silhouette — over the results
 // skeleton. Shown on a cold nav while the auth guard resolves; the in-component
-// PeopleResultsSkeleton (same grid) carries the data load, so the two are seamless.
+// PeopleResultsSkeleton (same rows) carries the data load, so the two are seamless.
 export function PeoplePending() {
   return (
     <PageShell className="flex flex-col gap-5">

--- a/apps/web/src/pages/profile/index.tsx
+++ b/apps/web/src/pages/profile/index.tsx
@@ -1,8 +1,10 @@
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
 import { getRouteApi, Link, useNavigate } from "@tanstack/react-router"
-import { useEffect, useRef, useState } from "react"
+import { LayoutGrid, List } from "lucide-react"
+import { type RefObject, useEffect, useRef, useState } from "react"
 import { ApiError } from "@/api"
 import { Icon } from "@/components/icons"
+import { CardGrid } from "@/components/shared/card-grid"
 import { EmptyState } from "@/components/shared/empty-state"
 import { FollowButton } from "@/components/shared/follow-button"
 import { PageShell } from "@/components/shared/page-shell"
@@ -19,37 +21,41 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { useAuth } from "@/ctx"
 import { colorForName } from "@/lib/avatar-tints"
 import { getInitials } from "@/lib/initials"
 import { profileArtifactsQuery, profilePeopleQuery, profileQuery } from "@/lib/queries"
-import { useDelayedPending } from "@/lib/use-delayed-pending"
-import { CardGrid } from "../library/card-grid"
 import { ProfilePending, ProfileWorkSkeleton } from "./skeleton"
-import { ProfileWorkCard } from "./work-card"
+import { ProfileWorkCard, ProfileWorkRow } from "./work-card"
 
 const route = getRouteApi("/users/$handle")
 
-// The rich public profile: an identity card (avatar, name, @handle, role, bio, GitHub
-// link), a stats row (works / followers / following), a Follow button, and a grid of
-// everything this person has worked on that the viewer is allowed to see. Single scroll;
-// the activity feed of people you follow lives at the library's Following view.
+// The rich public profile: an identity header (avatar, name, @handle, role, bio, GitHub
+// link), a stats row (works / followers / following), a Follow button, and the person's
+// work — everything the viewer is allowed to see, as a grid of live previews or a compact
+// list. Header-first: the identity is preloaded in the route loader, so it paints with
+// real data on the first frame (and a profile A→B nav never shows A's details while B
+// loads); only the work grid carries its own load state.
 export function Profile() {
   const { handle } = route.useParams()
   const { me, setMe } = useAuth()
   const nav = useNavigate()
   const [editing, setEditing] = useState(false)
+  // The profile is the scroll container; the Work grid's infinite-scroll sentinel
+  // observes against IT (not the viewport), so a short profile doesn't count its
+  // below-the-fold sentinel as "in view" and fire an immediate extra page fetch.
+  const scrollRef = useRef<HTMLDivElement>(null)
 
   const { data, isPending, isError, error, refetch } = useQuery(profileQuery(handle))
-  // Hold the frame back ~150ms so a cache-warm profile flashes nothing; the route's
-  // pendingComponent (same ProfilePending) already covers the cold-nav auth window.
-  const showPending = useDelayedPending(isPending)
 
-  if (isPending) return showPending ? <ProfilePending /> : null
+  // The identity is preloaded, so isPending here is only ever a genuine cold load; the
+  // route's ProfilePending (same skeleton) already covers that window, so a null here
+  // just avoids a double-frame.
+  if (isPending) return <ProfilePending />
 
-  // A transient fetch failure is status, not a genuine 404 — surface it as a
-  // recoverable danger panel (matching ProfileWork + People), never the bare
-  // "No such profile" empty state. Only a real 404 (or missing data) falls through.
+  // A transient fetch failure is status, not a genuine 404 — surface it as a recoverable
+  // danger panel (matching the Work section + People), never the bare "No such profile".
   if (isError && !(error instanceof ApiError && error.status === 404)) {
     return (
       <PageShell className="grid min-h-full place-items-center">
@@ -74,10 +80,6 @@ export function Profile() {
 
   if (isError || !data) {
     return (
-      // The shared EmptyState carries the voice grammar (Geist headline +
-      // supporting line); PageShell keeps it on the same reading measure as
-      // every other page, centered in the pane (a terminal 404 state, like the
-      // pending spinner — not an in-context empty pinned below a header).
       <PageShell className="grid min-h-full place-items-center">
         <div data-testid="profile-not-found">
           <EmptyState
@@ -99,16 +101,13 @@ export function Profile() {
   const stats = data.stats ?? { works: 0, followers: 0, following: 0 }
 
   return (
-    // The Work grid's IntersectionObserver sentinel observes against the
-    // viewport (null root), which still fires as the PageShell scrolls.
-    <PageShell className="flex flex-col gap-8">
-      {/* The identity header sits flush on the canvas — whitespace over a card,
-          per the surfaces doctrine (it's a page header, not a liftable object). */}
+    <PageShell scrollRef={scrollRef} className="flex flex-col gap-8">
+      {/* The identity header sits flush on the canvas — whitespace over a card, per the
+          surfaces doctrine (it's a page header, not a liftable object). */}
       <section data-testid="profile-card">
         <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:gap-6">
           <Avatar className="size-20 shrink-0 sm:size-24">
             {data.image && <AvatarImage src={data.image} alt={data.name ?? data.username} />}
-            {/* Identity tint (stable per person) + the outline frame images get. */}
             <AvatarFallback
               className="text-2xl font-medium text-scrim-foreground outline-1 -outline-offset-1 outline-foreground/10"
               style={{ backgroundColor: colorForName(data.name ?? data.username) }}
@@ -121,7 +120,6 @@ export function Profile() {
             <div className="flex items-start justify-between gap-3">
               <div className="min-w-0">
                 {data.name && (
-                  // A person's name is content, not chrome — Geist at display size.
                   <h1
                     className="truncate font-serif text-2xl font-medium tracking-tight text-foreground"
                     data-testid="profile-name"
@@ -136,7 +134,6 @@ export function Profile() {
                   @{data.username}
                 </p>
               </div>
-              {/* Self-hides for a signed-out viewer or your own profile. */}
               <FollowButton username={data.username} className="shrink-0" />
             </div>
 
@@ -165,7 +162,6 @@ export function Profile() {
               </a>
             )}
 
-            {/* Stats: works (static), followers + following (open a people dialog). */}
             <div className="mt-4 flex items-center gap-5 text-sm" data-testid="profile-stats">
               <Stat label="works" value={stats.works} />
               <PeopleStat
@@ -212,7 +208,12 @@ export function Profile() {
         </div>
       </section>
 
-      <ProfileWork handle={data.username} isMe={isMe} name={data.name ?? data.username} />
+      <ProfileWork
+        handle={data.username}
+        isMe={isMe}
+        name={data.name ?? data.username}
+        scrollRef={scrollRef}
+      />
     </PageShell>
   )
 }
@@ -227,7 +228,9 @@ function Stat({ label, value }: { label: string; value: number }) {
   )
 }
 
-// A clickable stat that opens a dialog listing the people, fetched lazily on open.
+// A clickable stat that opens a dialog listing the people, fetched lazily on open. The
+// dialog's own header count reflects the LOADED list (not the profile's cached stat), so
+// a just-changed follow can't show "12 followers" and open to an empty list.
 function PeopleStat({
   label,
   value,
@@ -257,7 +260,6 @@ function PeopleStat({
           <span className="text-muted-foreground">{label}</span>
         </button>
       </DialogTrigger>
-      {/* Title + the list itself are the content — no prose description (Radix opt-out). */}
       <DialogContent className="max-w-sm" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle className="capitalize">{label}</DialogTitle>
@@ -303,37 +305,72 @@ function PeopleStat({
   )
 }
 
-// The person's work — an infinite grid, paged by keyset cursor. A sentinel pulls the
-// next page as it scrolls into view.
-function ProfileWork({ handle, isMe, name }: { handle: string; isMe: boolean; name: string }) {
+// The person's work — an infinite grid/list, paged by keyset cursor. A sentinel pulls the
+// next page as it scrolls into view (observed against the profile's scroll container, so
+// a short profile doesn't fire an immediate extra fetch). Grid (live previews, the
+// portfolio default) or list (scan a prolific profile by title) via a session toggle.
+function ProfileWork({
+  handle,
+  isMe,
+  name,
+  scrollRef,
+}: {
+  handle: string
+  isMe: boolean
+  name: string
+  scrollRef: RefObject<HTMLDivElement | null>
+}) {
   const { data, isPending, isError, fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
     useInfiniteQuery(profileArtifactsQuery(handle))
-  const showSkeleton = useDelayedPending(isPending)
   const items = data?.pages.flatMap((p) => p.artifacts) ?? []
   const sentinel = useRef<HTMLDivElement>(null)
+  const [view, setView] = useState<"grid" | "list">("grid")
 
   useEffect(() => {
     const el = sentinel.current
     if (!el || !hasNextPage) return
-    const io = new IntersectionObserver((entries) => {
-      if (entries[0]?.isIntersecting && !isFetchingNextPage) fetchNextPage()
-    })
+    // Observe against the profile's scroll container (null → viewport only as a fallback
+    // before the ref attaches), so the sentinel counts as "in view" only when it actually
+    // enters the scroll viewport — not the moment it mounts below the fold on a short profile.
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && !isFetchingNextPage) fetchNextPage()
+      },
+      { root: scrollRef.current ?? null, rootMargin: "200px" },
+    )
     io.observe(el)
     return () => io.disconnect()
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage, scrollRef])
 
   return (
     <section className="flex flex-col gap-3">
-      <SectionEyebrow>Work</SectionEyebrow>
+      <div className="flex items-center justify-between gap-3">
+        <SectionEyebrow className="flex-1">Work</SectionEyebrow>
+        {/* The grid/list toggle only earns its place once there's work to reshape. */}
+        {!isPending && !isError && items.length > 0 && (
+          <ToggleGroup
+            type="single"
+            variant="outline"
+            size="sm"
+            aria-label="Work view"
+            value={view}
+            onValueChange={(v) => v && setView(v as "grid" | "list")}
+          >
+            <ToggleGroupItem value="grid" aria-label="Grid" data-testid="profile-work-view-grid">
+              <LayoutGrid aria-hidden />
+            </ToggleGroupItem>
+            <ToggleGroupItem value="list" aria-label="List" data-testid="profile-work-view-list">
+              <List aria-hidden />
+            </ToggleGroupItem>
+          </ToggleGroup>
+        )}
+      </div>
       {isPending ? (
-        showSkeleton ? (
-          <div role="status">
-            <span className="sr-only">Loading work…</span>
-            <ProfileWorkSkeleton />
-          </div>
-        ) : null
+        <div role="status">
+          <span className="sr-only">Loading work…</span>
+          <ProfileWorkSkeleton />
+        </div>
       ) : isError ? (
-        // A failed fetch is status, not emptiness — the danger tone grammar.
         <StatusPanel
           tone="danger"
           title="Couldn’t load this work"
@@ -363,14 +400,21 @@ function ProfileWork({ handle, isMe, name }: { handle: string; isMe: boolean; na
         </div>
       ) : (
         <>
-          {/* CardGrid owns the card-grid geometry; the wrapper only carries the testid. */}
-          <div data-testid="profile-work-grid">
-            <CardGrid>
+          {view === "grid" ? (
+            <div data-testid="profile-work-grid">
+              <CardGrid>
+                {items.map((a) => (
+                  <ProfileWorkCard key={a.short_id} artifact={a} />
+                ))}
+              </CardGrid>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2" data-testid="profile-work-list">
               {items.map((a) => (
-                <ProfileWorkCard key={a.short_id} artifact={a} />
+                <ProfileWorkRow key={a.short_id} artifact={a} />
               ))}
-            </CardGrid>
-          </div>
+            </div>
+          )}
           <div ref={sentinel} className="h-8" />
           {isFetchingNextPage && (
             <div className="flex justify-center py-2">

--- a/apps/web/src/pages/profile/skeleton.tsx
+++ b/apps/web/src/pages/profile/skeleton.tsx
@@ -1,7 +1,7 @@
+import { CardGrid } from "@/components/shared/card-grid"
 import { PageShell } from "@/components/shared/page-shell"
 import { SectionEyebrow } from "@/components/shared/section-eyebrow"
 import { Skeleton } from "@/components/ui/skeleton"
-import { CardGrid } from "../library/card-grid"
 import { CardSkeletonCell } from "../library/library-skeleton"
 
 const WORK_CELLS = ["a", "b", "c", "d", "e", "f"]
@@ -21,13 +21,13 @@ export function ProfileWorkSkeleton() {
   )
 }
 
-// The profile's first-load frame: the identity-header silhouette (a round avatar, the
-// name + @handle lines, a Follow-button-sized block, a profession line, a two-line bio,
-// and a stats row) over the real static "Work" eyebrow and a CardSkeletonCell grid.
-// Mirrors profile.tsx's box model (dims, gaps, radius, counts) but never its
-// borders/backgrounds/shadows — those arrive with the content, so omitting them yields
-// zero CLS. Used both as the route pendingComponent and the Profile component's
-// in-component first-load state, so the two are seamless.
+// The profile's first-load frame: the identity-header silhouette over the real static
+// "Work" eyebrow and a CardSkeletonCell grid. Reserves ONLY the always-present spine —
+// avatar, name line, @handle line, Follow-button block, and the stats row — and NOT the
+// optional profession/bio, which vary per profile: reserving them would over-tall a
+// sparse profile and shift it UP when the real (shorter) header lands. The optional lines
+// are additive, so a fuller profile grows DOWN (the natural direction) instead. Since the
+// header is preloaded in the route loader, this only ever shows on a genuine cold load.
 export function ProfilePending() {
   return (
     <PageShell className="flex flex-col gap-8">
@@ -48,14 +48,8 @@ export function ProfilePending() {
               {/* Follow button (size sm → h-8, rounded-lg). */}
               <Skeleton className="h-8 w-20 shrink-0 rounded-lg" />
             </div>
-            {/* Profession. */}
-            <Skeleton className="mt-3 h-4 w-40" />
-            {/* Bio (two lines). */}
-            <div className="mt-2 flex flex-col gap-1.5">
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-2/3" />
-            </div>
-            {/* Stats row (works / followers / following). */}
+            {/* Stats row (works / followers / following) — the next always-present line
+                after the handle. Profession + bio are deliberately not reserved. */}
             <div className="mt-4 flex items-center gap-5">
               <Skeleton className="h-4 w-14" />
               <Skeleton className="h-4 w-20" />

--- a/apps/web/src/pages/profile/work-card.tsx
+++ b/apps/web/src/pages/profile/work-card.tsx
@@ -2,12 +2,25 @@ import { Link } from "@tanstack/react-router"
 import type { Artifact } from "@/api"
 import { Icon } from "@/components/icons"
 import { Thumb } from "@/components/shared/thumb"
+import { Badge } from "@/components/ui/badge"
 import { artifactTypeLabel, dirOf } from "@/lib/artifact"
 import { ago } from "@/lib/time"
 import { refFor } from "../artifact/parse-ref"
 
-// One piece of a person's work on their profile. A focused, link-first card (no
-// favorite/delete chrome — those are library affordances): thumbnail, title, type +
+// A views chip (mono meta), shown only when an artifact has viewers. Shared by the
+// card + row so the two read identically.
+function Views({ n }: { n: number }) {
+  return (
+    <span className="inline-flex items-center gap-1 tabular-nums" title={`${n} viewers`}>
+      <Icon name="views" size={12} />
+      {n > 999 ? `${(n / 1000).toFixed(1)}k` : n}
+      <span className="sr-only"> views</span>
+    </span>
+  )
+}
+
+// One piece of a person's work on their profile, GRID form. A focused, link-first card
+// (no favorite/delete chrome — those are library affordances): thumbnail, title, type +
 // updated + views. The whole card is the link, so it preloads on hover and opens the
 // artifact. Mirrors the library card's look so the two read as one design.
 export function ProfileWorkCard({ artifact: a }: { artifact: Artifact }) {
@@ -53,18 +66,56 @@ export function ProfileWorkCard({ artifact: a }: { artifact: Artifact }) {
               </time>
             </span>
           )}
-          {a.views !== undefined && a.views > 0 && (
-            <span
-              className="ml-auto inline-flex items-center gap-1 tabular-nums"
-              title={`${a.views} viewers`}
-            >
-              <Icon name="views" size={12} />{" "}
-              {a.views > 999 ? `${(a.views / 1000).toFixed(1)}k` : a.views}
-              <span className="sr-only"> views</span>
-            </span>
-          )}
+          {a.views !== undefined && a.views > 0 && <Views n={a.views} />}
         </span>
       </div>
+    </Link>
+  )
+}
+
+// The same work, LIST form — a compact link row for scanning a prolific profile by
+// title (the grid/list toggle's other half). Link-first like the card; a leading
+// machine-register type chip, the title in voice, then updated + views as a mono meta
+// tail. Bordered rows (mirroring the library's ArtifactRow) so the two surfaces read as
+// one design, minus the library-only star/delete/author chrome.
+export function ProfileWorkRow({ artifact: a }: { artifact: Artifact }) {
+  const updated = a.updated_at ?? a.created_at ?? a.versions[0]?.created_at
+  const dir = a.source_path ? dirOf(a.source_path) : ""
+  return (
+    <Link
+      to="/artifacts/$ref"
+      params={{ ref: refFor(a) }}
+      data-testid={`profile-work-${a.short_id}`}
+      className="group flex items-center gap-3 rounded-lg border bg-card px-3.5 py-2.5 outline-none hover:bg-secondary focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring"
+    >
+      <Badge shape="pill" className="shrink-0">
+        {artifactTypeLabel(a)}
+      </Badge>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate font-serif text-base font-medium tracking-tight text-foreground">
+          {a.title ?? a.short_id}
+        </span>
+        {dir && (
+          <span
+            className="block truncate font-mono text-2xs text-muted-foreground"
+            title={a.source_path ?? ""}
+          >
+            {dir}/
+          </span>
+        )}
+      </span>
+      <span className="flex shrink-0 items-center gap-3 font-mono text-2xs text-muted-foreground">
+        {updated && (
+          <time
+            dateTime={new Date(updated).toISOString()}
+            title={new Date(updated).toLocaleString()}
+            className="hidden sm:inline"
+          >
+            {ago(updated)}
+          </time>
+        )}
+        {a.views !== undefined && a.views > 0 && <Views n={a.views} />}
+      </span>
     </Link>
   )
 }

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -11,11 +11,13 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WelcomeRouteImport } from './routes/welcome'
 import { Route as ShowcaseRouteImport } from './routes/showcase'
+import { Route as SharedRouteImport } from './routes/shared'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as PeopleRouteImport } from './routes/people'
 import { Route as NewRouteImport } from './routes/new'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as FollowingRouteImport } from './routes/following'
+import { Route as FeedbackRouteImport } from './routes/feedback'
 import { Route as FavoritesRouteImport } from './routes/favorites'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings.index'
@@ -31,6 +33,11 @@ const WelcomeRoute = WelcomeRouteImport.update({
 const ShowcaseRoute = ShowcaseRouteImport.update({
   id: '/showcase',
   path: '/showcase',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SharedRoute = SharedRouteImport.update({
+  id: '/shared',
+  path: '/shared',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SettingsRoute = SettingsRouteImport.update({
@@ -56,6 +63,11 @@ const LoginRoute = LoginRouteImport.update({
 const FollowingRoute = FollowingRouteImport.update({
   id: '/following',
   path: '/following',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FeedbackRoute = FeedbackRouteImport.update({
+  id: '/feedback',
+  path: '/feedback',
   getParentRoute: () => rootRouteImport,
 } as any)
 const FavoritesRoute = FavoritesRouteImport.update({
@@ -92,11 +104,13 @@ const ArtifactsRefRoute = ArtifactsRefRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/favorites': typeof FavoritesRoute
+  '/feedback': typeof FeedbackRoute
   '/following': typeof FollowingRoute
   '/login': typeof LoginRoute
   '/new': typeof NewRoute
   '/people': typeof PeopleRoute
   '/settings': typeof SettingsRouteWithChildren
+  '/shared': typeof SharedRoute
   '/showcase': typeof ShowcaseRoute
   '/welcome': typeof WelcomeRoute
   '/artifacts/$ref': typeof ArtifactsRefRoute
@@ -107,10 +121,12 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/favorites': typeof FavoritesRoute
+  '/feedback': typeof FeedbackRoute
   '/following': typeof FollowingRoute
   '/login': typeof LoginRoute
   '/new': typeof NewRoute
   '/people': typeof PeopleRoute
+  '/shared': typeof SharedRoute
   '/showcase': typeof ShowcaseRoute
   '/welcome': typeof WelcomeRoute
   '/artifacts/$ref': typeof ArtifactsRefRoute
@@ -122,11 +138,13 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/favorites': typeof FavoritesRoute
+  '/feedback': typeof FeedbackRoute
   '/following': typeof FollowingRoute
   '/login': typeof LoginRoute
   '/new': typeof NewRoute
   '/people': typeof PeopleRoute
   '/settings': typeof SettingsRouteWithChildren
+  '/shared': typeof SharedRoute
   '/showcase': typeof ShowcaseRoute
   '/welcome': typeof WelcomeRoute
   '/artifacts/$ref': typeof ArtifactsRefRoute
@@ -139,11 +157,13 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/favorites'
+    | '/feedback'
     | '/following'
     | '/login'
     | '/new'
     | '/people'
     | '/settings'
+    | '/shared'
     | '/showcase'
     | '/welcome'
     | '/artifacts/$ref'
@@ -154,10 +174,12 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/favorites'
+    | '/feedback'
     | '/following'
     | '/login'
     | '/new'
     | '/people'
+    | '/shared'
     | '/showcase'
     | '/welcome'
     | '/artifacts/$ref'
@@ -168,11 +190,13 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/favorites'
+    | '/feedback'
     | '/following'
     | '/login'
     | '/new'
     | '/people'
     | '/settings'
+    | '/shared'
     | '/showcase'
     | '/welcome'
     | '/artifacts/$ref'
@@ -184,11 +208,13 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   FavoritesRoute: typeof FavoritesRoute
+  FeedbackRoute: typeof FeedbackRoute
   FollowingRoute: typeof FollowingRoute
   LoginRoute: typeof LoginRoute
   NewRoute: typeof NewRoute
   PeopleRoute: typeof PeopleRoute
   SettingsRoute: typeof SettingsRouteWithChildren
+  SharedRoute: typeof SharedRoute
   ShowcaseRoute: typeof ShowcaseRoute
   WelcomeRoute: typeof WelcomeRoute
   ArtifactsRefRoute: typeof ArtifactsRefRoute
@@ -209,6 +235,13 @@ declare module '@tanstack/react-router' {
       path: '/showcase'
       fullPath: '/showcase'
       preLoaderRoute: typeof ShowcaseRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/shared': {
+      id: '/shared'
+      path: '/shared'
+      fullPath: '/shared'
+      preLoaderRoute: typeof SharedRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/settings': {
@@ -244,6 +277,13 @@ declare module '@tanstack/react-router' {
       path: '/following'
       fullPath: '/following'
       preLoaderRoute: typeof FollowingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/feedback': {
+      id: '/feedback'
+      path: '/feedback'
+      fullPath: '/feedback'
+      preLoaderRoute: typeof FeedbackRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/favorites': {
@@ -308,11 +348,13 @@ const SettingsRouteWithChildren = SettingsRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   FavoritesRoute: FavoritesRoute,
+  FeedbackRoute: FeedbackRoute,
   FollowingRoute: FollowingRoute,
   LoginRoute: LoginRoute,
   NewRoute: NewRoute,
   PeopleRoute: PeopleRoute,
   SettingsRoute: SettingsRouteWithChildren,
+  SharedRoute: SharedRoute,
   ShowcaseRoute: ShowcaseRoute,
   WelcomeRoute: WelcomeRoute,
   ArtifactsRefRoute: ArtifactsRefRoute,

--- a/apps/web/src/routes/feedback.tsx
+++ b/apps/web/src/routes/feedback.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { requireOnboarded } from "../lib/route-guards"
+import { Library } from "../pages/library"
+import { LibraryPending } from "../pages/library/library-skeleton"
+import type { LibrarySearch } from "../pages/library/types"
+
+// The Feedback feed: /feedback — artifacts with an open thread that @mentions you or that
+// you've commented on (the triage queue). A focused named feed the home surfaces as a
+// single quiet line; keeping it its own route (not a home strip) is what lets the home be
+// "your work," one job. Only free-text ?query= search composes on top. Path = the feed,
+// query = how it's filtered (docs/decisions/0002).
+export const Route = createFileRoute("/feedback")({
+  beforeLoad: requireOnboarded,
+  pendingComponent: LibraryPending,
+  validateSearch: (s: Record<string, unknown>): Pick<LibrarySearch, "query"> => ({
+    query: typeof s.query === "string" ? s.query : undefined,
+  }),
+  component: () => <Library view="feedback" />,
+})

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { needsFeedbackArtifactsQuery, summaryQuery } from "../lib/queries"
 import { requireOnboarded } from "../lib/route-guards"
 import { Library } from "../pages/library"
 import { LibraryPending } from "../pages/library/library-skeleton"
@@ -7,6 +8,23 @@ import type { LibrarySearch } from "../pages/library/types"
 export const Route = createFileRoute("/")({
   // Auth + first-run onboarding gate (anon → /login, un-onboarded → /welcome).
   beforeLoad: requireOnboarded,
+  // Preload the two data the home BRANCHES on, so both paint deterministically on the
+  // first frame: the summary count decides the greeting ("Welcome back" vs "Welcome to
+  // Derive" — a pending query would flash the new-user copy at every returning user), and
+  // the feedback count decides the triage line. Awaiting them here (they're small, and
+  // warm within staleTime → instant) also means the grid below never gets pushed down by
+  // a late-landing header, which would drift the virtualizer's scrollMargin. The
+  // shape-matched LibraryPending covers the cold-load window while this resolves.
+  loader: async ({ context: { queryClient } }) => {
+    // Best-effort: warm the cache for a deterministic first paint, but never let a failed
+    // preload BLOCK the home behind the route error boundary — the greeting/triage are
+    // non-critical (a failed summary just falls back to a neutral "Welcome," and the
+    // in-component useQuery retries), while the artifact list has its own error handling.
+    await Promise.all([
+      queryClient.ensureQueryData(summaryQuery()).catch(() => {}),
+      queryClient.ensureQueryData(needsFeedbackArtifactsQuery()).catch(() => {}),
+    ])
+  },
   // Shape-matched pending frame for the cold-load auth/loader window.
   pendingComponent: LibraryPending,
   // The home library. Its filters + free-text search live in the URL (LibrarySearch)

--- a/apps/web/src/routes/shared.tsx
+++ b/apps/web/src/routes/shared.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { requireOnboarded } from "../lib/route-guards"
+import { Library } from "../pages/library"
+import { LibraryPending } from "../pages/library/library-skeleton"
+import type { LibrarySearch } from "../pages/library/types"
+
+// The Shared feed: /shared — artifacts others have explicitly shared with you (can span
+// workspaces). A durable named feed and a peer of /favorites and /following (not a home
+// strip), so it reads as the destination it is: shareable, deep-linkable, and reachable
+// from the rail. Only free-text ?query= search composes on top. Path = the feed you're
+// viewing, query = how it's filtered (docs/decisions/0002).
+export const Route = createFileRoute("/shared")({
+  beforeLoad: requireOnboarded,
+  pendingComponent: LibraryPending,
+  validateSearch: (s: Record<string, unknown>): Pick<LibrarySearch, "query"> => ({
+    query: typeof s.query === "string" ? s.query : undefined,
+  }),
+  component: () => <Library view="shared" />,
+})

--- a/apps/web/src/routes/users.$handle.tsx
+++ b/apps/web/src/routes/users.$handle.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { profileArtifactsQuery, profileQuery } from "../lib/queries"
 import { Profile } from "../pages/profile"
 import { ProfilePending } from "../pages/profile/skeleton"
 
@@ -6,6 +7,18 @@ import { ProfilePending } from "../pages/profile/skeleton"
 // the shell; the shell treats /users/* as a public view, so a profile link is
 // shareable without a session (the API endpoint omits email).
 export const Route = createFileRoute("/users/$handle")({
+  // Warm the identity + first page of work so the header paints with REAL data on the
+  // first frame (header-first) — and so a profile A→B navigation never shows person A's
+  // details while B loads. prefetchQuery (not ensureQueryData) so a 404 caches as an
+  // error the component renders as "No such profile", instead of throwing to the route
+  // error boundary. Warm within staleTime → instant; cold → the shape-matched
+  // ProfilePending covers the wait.
+  loader: async ({ context: { queryClient }, params: { handle } }) => {
+    await Promise.all([
+      queryClient.prefetchQuery(profileQuery(handle)),
+      queryClient.prefetchInfiniteQuery(profileArtifactsQuery(handle)),
+    ])
+  },
   // Shape-matched pending frame for the cold-load window (same skeleton the Profile
   // component shows in-component, so the two are seamless).
   pendingComponent: ProfilePending,


### PR DESCRIPTION
## What

Reconceives the four surfaces the redesign series never truly touched — **Home/Library, Profile, People, New** — which had only ever received brand paint + the structural cleanup. Rebuilds the surface-local composition + information architecture on the preserved shared vocabulary and data engine, grounded in the design system + SOTA precedents (GitHub's 2025 dashboard split, Linear Inbox/My-Issues, Val Town, read.cv). Hard mandate throughout: **never flash empty or incorrect content.**

## Home / Library — split the 660-line god-page by temporal intent

- Home `/` is now **your work, recency-first, one job**. The two promoted card-strips become real infinite **scoped routes `/shared` + `/feedback`** (reusing the `listArtifacts` scope param), surfaced as a rail entry + one quiet triage line.
- Extracted `useLibraryFeed` (infinite query + optimistic star/delete) and `TriageBar`.

## No-flash correctness sweep

- **Greeting flash** — `undefined > 0` is `false`, so *every returning user* briefly flashed "Welcome to Derive". Fixed by preloading the deciding count in the route loader (best-effort, so a failed preload degrades to a neutral greeting rather than blocking the page).
- Collection view-kind derived from the known collection kind (no grid→flat flip after load); folder/flat toggle made per-collection.
- Virtualizer `scrollMargin` re-measures on above-grid height changes; the header no longer collapses 280ms late while searching.

## Profile

Header-first (identity preloaded, skeleton only the Work grid), a **grid/list toggle**, the infinite-scroll sentinel observes the scroll container (not the viewport), and a CLS-proof skeleton.

## People

A scannable **directory of rows** with an intentional "Everyone" / "Results" browse framing; stale results dim via placeholder data.

## New

An **unsaved-draft guard** (`useBlocker` over in-app nav + browser close — via a *ref* so the publish nav isn't blocked by its own save), explicit library-cache invalidation on publish, and a first-use editor placeholder. Covered by a new `new-guard` deep spec (both the block and the publish-bypass paths).

## Foundation

Promotes `card-grid` to `components/shared/` (Profile already cross-imported it).

## Testing

`tsc` · biome · token/testid/frontend linters · 100 unit · 55 e2e + 3 new `/new`-guard deep specs · prod build in budget. Every surface screenshot-verified with the screens harness in both themes × desktop/mobile (no flash on cold/warm load, filter/search, back-nav). All CI-enforced `data-testid`s preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
