### PR TITLE
refactor(web): rework the share dialog — fix self-closing bug, reorder to general access → people → add

### DIFF
--- a/apps/web/e2e/deep/share.deep.spec.ts
+++ b/apps/web/e2e/deep/share.deep.spec.ts
@@ -24,7 +24,7 @@ test("owner shares an artifact, changes the role, and removes the member", async
   // Share with the teammate as a commenter.
   await owner.getByTestId("share-email").fill(secondUser.email)
   await owner.getByTestId("share-role").click()
-  await owner.getByRole("option", { name: "Commenter", exact: true }).click()
+  await owner.getByRole("menuitemradio", { name: "Commenter", exact: true }).click()
   await owner.getByTestId("share-add").click()
 
   const teammate = rows.filter({ hasNotText: "(you)" })
@@ -34,7 +34,7 @@ test("owner shares an artifact, changes the role, and removes the member", async
 
   // Promote them to editor.
   await teammate.locator('[data-testid^="share-member-role-"]').click()
-  await owner.getByRole("option", { name: "Editor", exact: true }).click()
+  await owner.getByRole("menuitemradio", { name: "Editor", exact: true }).click()
   await expect(teammate.locator('[data-testid^="share-member-role-"]')).toContainText("Editor")
 
   // Remove them: back to just the owner.

--- a/apps/web/e2e/deep/visibility.deep.spec.ts
+++ b/apps/web/e2e/deep/visibility.deep.spec.ts
@@ -37,7 +37,7 @@ test("a default publish is private: invisible to another user until the link is 
   await owner.getByTestId("share-trigger").click()
   const saved = owner.waitForResponse((r) => r.url().includes("/visibility") && r.ok())
   await owner.getByTestId("share-visibility").click()
-  await owner.getByRole("option", { name: "Anyone with the link" }).click()
+  await owner.getByRole("menuitemradio", { name: "Anyone with the link" }).click()
   await saved
 
   // Now the second user can read it.

--- a/apps/web/e2e/smoke/share.smoke.spec.ts
+++ b/apps/web/e2e/smoke/share.smoke.spec.ts
@@ -13,7 +13,7 @@ test("owner shares an artifact and the member appears", async ({ owner, secondUs
 
   await owner.getByTestId("share-email").fill(secondUser.email)
   await owner.getByTestId("share-role").click()
-  await owner.getByRole("option", { name: "Commenter", exact: true }).click()
+  await owner.getByRole("menuitemradio", { name: "Commenter", exact: true }).click()
   await owner.getByTestId("share-add").click()
 
   const row = rows.filter({ hasText: "Second User" })

--- a/apps/web/src/components/shared/role-select.tsx
+++ b/apps/web/src/components/shared/role-select.tsx
@@ -1,11 +1,10 @@
 import type { Role } from "@/api"
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+  SelectMenu,
+  SelectMenuContent,
+  SelectMenuItem,
+  SelectMenuTrigger,
+} from "@/components/ui/select-menu"
 
 const ROLES: Role[] = ["viewer", "commenter", "editor", "owner"]
 
@@ -18,35 +17,36 @@ export const ROLE_LABELS: Record<Role, string> = {
   owner: "Owner",
 }
 
-// The role picker — the ROLES list over the canonical shadcn Select, kept as one
-// thin wrapper so every share surface reads the same options with the same API.
+// The role picker — the ROLES list over SelectMenu, not the real Select. Both
+// call sites (this dialog and the collection share dialog) live inside a modal
+// Dialog, and Radix's Select can't opt out of the outside-pointer-events lock
+// that fights a host Dialog (see ui/select-menu.tsx). One thin wrapper so every
+// share surface reads the same options with the same API.
 export function RoleSelect({
   value,
   onChange,
   className,
-  name = "role",
   "aria-label": ariaLabel = "Role",
   "data-testid": testId,
 }: {
   value: Role
   onChange: (role: Role) => void
   className?: string
-  name?: string
   "aria-label"?: string
   "data-testid"?: string
 }) {
   return (
-    <Select name={name} value={value} onValueChange={(v) => onChange(v as Role)}>
-      <SelectTrigger aria-label={ariaLabel} data-testid={testId} className={className}>
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent>
+    <SelectMenu value={value} onValueChange={(v) => onChange(v as Role)}>
+      <SelectMenuTrigger aria-label={ariaLabel} data-testid={testId} className={className}>
+        {ROLE_LABELS[value]}
+      </SelectMenuTrigger>
+      <SelectMenuContent>
         {ROLES.map((r) => (
-          <SelectItem key={r} value={r}>
+          <SelectMenuItem key={r} value={r}>
             {ROLE_LABELS[r]}
-          </SelectItem>
+          </SelectMenuItem>
         ))}
-      </SelectContent>
-    </Select>
+      </SelectMenuContent>
+    </SelectMenu>
   )
 }

--- a/apps/web/src/components/ui/select-menu.tsx
+++ b/apps/web/src/components/ui/select-menu.tsx
@@ -1,0 +1,95 @@
+import { ChevronDownIcon } from "lucide-react"
+import type * as React from "react"
+import { createContext, use } from "react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { cn } from "@/lib/utils"
+
+// A Select-alike for pickers that live inside a Dialog. Radix's real Select
+// unconditionally disables outside pointer events on its content
+// (@radix-ui/react-select has no `modal` escape hatch), which cascades a
+// `pointer-events: none` onto every layer beneath it — including a host
+// Dialog's own content. The next click anywhere in the dialog that isn't the
+// select's own popup then hits the Dialog's overlay instead and dismisses it.
+// DropdownMenu's non-modal mode (the default posture here) never disables
+// outside pointer events, so it composes cleanly inside a modal Dialog. Same
+// trigger/content recipe as ui/select.tsx, minus the parts (native form
+// fallback, item-aligned positioning) that don't apply to a menu.
+
+const SelectMenuContext = createContext<{
+  value: string
+  onValueChange: (value: string) => void
+} | null>(null)
+
+function SelectMenu({
+  value,
+  onValueChange,
+  children,
+}: {
+  value: string
+  onValueChange: (value: string) => void
+  children: React.ReactNode
+}) {
+  return (
+    <SelectMenuContext.Provider value={{ value, onValueChange }}>
+      <DropdownMenu modal={false}>{children}</DropdownMenu>
+    </SelectMenuContext.Provider>
+  )
+}
+
+function SelectMenuTrigger({
+  className,
+  disabled,
+  children,
+  ...props
+}: React.ComponentProps<"button">) {
+  return (
+    <DropdownMenuTrigger asChild>
+      <button
+        {...props}
+        type="button"
+        disabled={disabled}
+        className={cn(
+          "flex h-8 w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap shadow-(--shadow-sm) outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/40 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 dark:bg-input/30 dark:disabled:bg-input/80 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+          className,
+        )}
+      >
+        <span className="flex min-w-0 flex-1 items-center gap-1.5 truncate">{children}</span>
+        <ChevronDownIcon className="text-muted-foreground" />
+      </button>
+    </DropdownMenuTrigger>
+  )
+}
+
+function SelectMenuContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuContent>) {
+  const ctx = use(SelectMenuContext)
+  if (!ctx) throw new Error("SelectMenuContent must be used within SelectMenu")
+  return (
+    <DropdownMenuContent
+      className={cn("min-w-(--radix-popper-anchor-width)", className)}
+      {...props}
+    >
+      <DropdownMenuRadioGroup value={ctx.value} onValueChange={ctx.onValueChange}>
+        {children}
+      </DropdownMenuRadioGroup>
+    </DropdownMenuContent>
+  )
+}
+
+function SelectMenuItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuRadioItem>) {
+  return <DropdownMenuRadioItem className={cn("py-1.5 pr-8 pl-2", className)} {...props} />
+}
+
+export { SelectMenu, SelectMenuContent, SelectMenuItem, SelectMenuTrigger }

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/api"
 import { Icon, type IconName } from "@/components/icons"
 import { ROLE_LABELS, RoleSelect } from "@/components/shared/role-select"
-import { Eyebrow } from "@/components/shared/section-eyebrow"
+import { Eyebrow, SectionEyebrow } from "@/components/shared/section-eyebrow"
 import { Spinner } from "@/components/shared/spinner"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
@@ -24,12 +24,11 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+  SelectMenu,
+  SelectMenuContent,
+  SelectMenuItem,
+  SelectMenuTrigger,
+} from "@/components/ui/select-menu"
 import { toast } from "@/components/ui/sonner"
 import { useAuth } from "@/ctx"
 import { getInitials } from "@/lib/initials"
@@ -165,6 +164,11 @@ export function ShareButton({
     }
   }
 
+  // The ladder entry for the draft pick (editable) and the server's own value
+  // (view-only render) — looked up once and reused, rather than re-scanning
+  // ACCESS at every place the icon/label/blurb is needed.
+  const currentAccess = ACCESS.find((a) => a.value === vis)
+  const visibilityAccess = ACCESS.find((a) => a.value === visibility)
   // Reach visibilities (anyone with the link / public / password) carry a general-access
   // permission; private/workspace do not, so the view/comment control hides for them.
   const reach = vis === "link" || vis === "public" || vis === "password"
@@ -379,312 +383,328 @@ export function ShareButton({
           Share
         </Button>
       </DialogTrigger>
-      {/* One surface, Docs-shaped: add people → who has access → general access,
-          with a copy-link footer. Embed + domains fold behind a disclosure — the
+      {/* One surface: general access → who has access → add more, with a
+          copy-link footer. The order reads top-down as one flow — the
+          coarse-grained setting first, then the roster it governs, then the
+          way to extend it. Embed + domains fold behind a disclosure — the
           dialog's job is access, and everything applies as it's chosen (no Save). */}
-      <DialogContent className="sm:max-w-md" aria-describedby={undefined}>
+      <DialogContent className="sm:max-w-lg" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle className="line-clamp-1 pr-6">
             {art?.title ? `Share “${art.title}”` : "Share"}
           </DialogTitle>
         </DialogHeader>
 
-        {canManage ? (
-          <form onSubmit={add} className="flex items-center gap-1.5">
-            <div className="relative flex-1">
-              {/* WAI-APG combobox wiring: the input announces the popup and the
-                  arrow-key highlight (aria-activedescendant). */}
-              <Input
-                data-testid="share-email"
-                type="text"
-                autoCapitalize="none"
-                autoCorrect="off"
-                autoComplete="off"
-                placeholder="Add people by @username or email…"
-                aria-label="Username or email"
-                role="combobox"
-                aria-expanded={suggest.length > 0}
-                aria-autocomplete="list"
-                aria-controls="share-suggest-list"
-                aria-activedescendant={
-                  active >= 0 && suggest[active] ? `share-suggest-opt-${active}` : undefined
-                }
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                onKeyDown={onAddKeyDown}
-                className="w-full"
-              />
-              {suggest.length > 0 && (
-                <div
-                  data-testid="share-suggest"
-                  id="share-suggest-list"
-                  role="listbox"
-                  aria-label="People suggestions"
-                  className="absolute inset-x-0 top-[calc(100%+4px)] z-40 max-h-56 overflow-y-auto rounded-xl bg-popover p-1 shadow-[var(--shadow-pop)] ring-1 ring-foreground/10"
-                >
-                  {suggest.map((u, i) => (
-                    <button
-                      key={u.username}
-                      type="button"
-                      data-testid="share-suggest-item"
-                      id={`share-suggest-opt-${i}`}
-                      role="option"
-                      aria-selected={i === active}
-                      // Keep the input focused so the click registers without blurring first.
-                      onMouseDown={(e) => e.preventDefault()}
-                      onClick={() => pick(u)}
-                      onMouseEnter={() => setActive(i)}
-                      className={cn(
-                        "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left outline-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring",
-                        i === active ? "bg-accent" : "hover:bg-accent",
-                      )}
+        <div className="flex flex-col gap-6">
+          <div>
+            <SectionEyebrow action={savingVis && <Spinner className="size-3" />}>
+              General access
+            </SectionEyebrow>
+            {canManage ? (
+              <div className="mt-2 flex flex-col gap-2 rounded-lg bg-secondary p-3">
+                <div className="flex gap-1.5">
+                  <SelectMenu value={vis} onValueChange={pickVisibility}>
+                    <SelectMenuTrigger
+                      aria-label="General access"
+                      data-testid="share-visibility"
+                      disabled={savingVis}
+                      className="flex-1 bg-card"
                     >
-                      <Avatar className="size-6">
-                        {u.image && <AvatarImage src={u.image} alt={u.name ?? u.username} />}
-                        <AvatarFallback>{getInitials(u.name ?? u.username)}</AvatarFallback>
-                      </Avatar>
-                      <span className="min-w-0 flex-1">
-                        {u.name && (
-                          <span className="block truncate text-sm font-medium text-foreground">
-                            {u.name}
-                          </span>
-                        )}
-                        <span className="block truncate font-mono text-2xs text-muted-foreground">
-                          @{u.username}
-                        </span>
-                      </span>
-                    </button>
-                  ))}
+                      <Icon
+                        name={currentAccess?.icon ?? "share"}
+                        className="text-muted-foreground"
+                      />
+                      {currentAccess?.label ?? vis}
+                    </SelectMenuTrigger>
+                    <SelectMenuContent>
+                      {ACCESS.map((a) => (
+                        <SelectMenuItem key={a.value} value={a.value}>
+                          <Icon name={a.icon} className="text-muted-foreground" />
+                          {a.label}
+                        </SelectMenuItem>
+                      ))}
+                    </SelectMenuContent>
+                  </SelectMenu>
+                  {reach && (
+                    <SelectMenu
+                      value={genRole}
+                      onValueChange={(v) => pickGenRole(v as GeneralRole)}
+                    >
+                      <SelectMenuTrigger
+                        aria-label="Link permission"
+                        data-testid="share-general-role"
+                        disabled={savingVis}
+                        className="bg-card"
+                      >
+                        {genRole === "commenter" ? "Can comment" : "Can view"}
+                      </SelectMenuTrigger>
+                      <SelectMenuContent>
+                        <SelectMenuItem value="viewer">Can view</SelectMenuItem>
+                        <SelectMenuItem value="commenter">Can comment</SelectMenuItem>
+                      </SelectMenuContent>
+                    </SelectMenu>
+                  )}
                 </div>
-              )}
-            </div>
-            <div data-testid="share-role" className="w-26 shrink-0">
-              <RoleSelect
-                value={role}
-                onChange={setRole}
-                aria-label="Role for new member"
-                className="w-full"
-              />
-            </div>
-            <Button
-              data-testid="share-add"
-              variant="default"
-              size="sm"
-              type="submit"
-              loading={busy}
-            >
-              {busy ? "Adding…" : "Add"}
-            </Button>
-          </form>
-        ) : (
-          <div
-            data-testid="share-viewonly"
-            className="flex items-center gap-2 rounded-lg bg-secondary px-3 py-2 text-sm text-muted-foreground"
-          >
-            <Icon name="lock" />
-            View only · ask an owner or editor to change access.
+                {pendingPw ? (
+                  <div className="flex gap-1.5">
+                    <Input
+                      type="password"
+                      data-testid="share-visibility-password"
+                      placeholder="Set a password"
+                      aria-label="Password"
+                      value={pw}
+                      onChange={(e) => setPw(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && pw) void applyVisibility("password", genRole, pw)
+                      }}
+                      className="flex-1"
+                    />
+                    <Button
+                      data-testid="share-visibility-save"
+                      variant="secondary"
+                      size="sm"
+                      disabled={!pw}
+                      loading={savingVis}
+                      onClick={() => void applyVisibility("password", genRole, pw)}
+                    >
+                      {savingVis ? "Setting…" : "Set password"}
+                    </Button>
+                  </div>
+                ) : vis === "password" && pwOpen ? (
+                  <div className="flex gap-1.5">
+                    <Input
+                      type="password"
+                      data-testid="share-visibility-password"
+                      placeholder="New password"
+                      aria-label="New password"
+                      value={pw}
+                      onChange={(e) => setPw(e.target.value)}
+                      className="flex-1"
+                    />
+                    <Button
+                      data-testid="share-visibility-save"
+                      variant="secondary"
+                      size="sm"
+                      disabled={!pw}
+                      loading={savingVis}
+                      onClick={() => void applyVisibility("password", genRole, pw)}
+                    >
+                      {savingVis ? "Setting…" : "Set"}
+                    </Button>
+                  </div>
+                ) : null}
+                <p className="text-sm text-muted-foreground">
+                  {pendingPw ? "Applies once a password is set." : (currentAccess?.blurb ?? "")}
+                  {!pendingPw &&
+                    reach &&
+                    genRole === "commenter" &&
+                    " Signed-in visitors can comment."}
+                  {!pendingPw && vis === "password" && (
+                    <Button
+                      variant="link"
+                      size="xs"
+                      data-testid="share-password-change"
+                      className="ml-1 px-0"
+                      onClick={() => setPwOpen(true)}
+                    >
+                      Change password
+                    </Button>
+                  )}
+                </p>
+              </div>
+            ) : (
+              <p className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
+                <Icon name={visibilityAccess?.icon ?? "share"} />
+                {visibilityAccess?.label ?? visibility}
+              </p>
+            )}
           </div>
-        )}
-        {err && (
-          <p data-testid="share-error" role="alert" className="text-sm text-destructive">
-            {err}
-          </p>
-        )}
 
-        <div>
-          <Eyebrow as="div" className="mb-1">
-            People with access
-          </Eyebrow>
-          {members.length === 0 ? (
-            <p data-testid="share-empty" className="px-2 py-1.5 text-sm text-muted-foreground">
-              {canManage ? "No one shared yet." : "Just you and the workspace."}
-            </p>
-          ) : (
-            <div className="-mx-2 flex flex-col">
-              {members.map((m) => (
-                <div
-                  key={m.user_id}
-                  data-testid={`share-member-row-${m.user_id}`}
-                  className="flex items-center gap-2.5 rounded-lg px-2 py-1.5 hover:bg-secondary"
-                >
-                  <Avatar className="size-6 shrink-0">
-                    <AvatarFallback className="text-2xs">
-                      {getInitials(m.name ?? m.handle ?? "?")}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate text-sm font-medium text-foreground">
-                      {m.name ?? (m.handle ? `@${m.handle}` : m.user_id)}
-                      {m.user_id === me?.id && (
-                        <span className="text-muted-foreground"> (you)</span>
+          <div>
+            <SectionEyebrow count={members.length || undefined}>People with access</SectionEyebrow>
+            {members.length === 0 ? (
+              <p data-testid="share-empty" className="px-2 py-2.5 text-sm text-muted-foreground">
+                {canManage ? "No one shared yet." : "Just you and the workspace."}
+              </p>
+            ) : (
+              <div className="-mx-2 mt-1 flex flex-col">
+                {members.map((m) => (
+                  <div
+                    key={m.user_id}
+                    data-testid={`share-member-row-${m.user_id}`}
+                    className="flex items-center gap-3 rounded-lg px-2 py-2 hover:bg-secondary"
+                  >
+                    <Avatar className="size-8 shrink-0">
+                      <AvatarFallback className="text-xs">
+                        {getInitials(m.name ?? m.handle ?? "?")}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium text-foreground">
+                        {m.name ?? (m.handle ? `@${m.handle}` : m.user_id)}
+                        {m.user_id === me?.id && (
+                          <span className="text-muted-foreground"> (you)</span>
+                        )}
+                      </div>
+                      {m.name && m.handle && (
+                        <div className="truncate font-mono text-2xs text-muted-foreground">
+                          @{m.handle}
+                        </div>
                       )}
                     </div>
-                    {m.name && m.handle && (
-                      <div className="truncate font-mono text-2xs text-muted-foreground">
-                        @{m.handle}
+                    {/* The sole owner's row is fixed — the server refuses to downgrade
+                      or remove the last owner, so don't offer it. */}
+                    {canManage &&
+                    !(
+                      m.role === "owner" && members.filter((x) => x.role === "owner").length === 1
+                    ) ? (
+                      <>
+                        <div
+                          data-testid={`share-member-role-${m.user_id}`}
+                          className="w-25 shrink-0"
+                        >
+                          <RoleSelect
+                            value={m.role}
+                            onChange={(next) => change(m, next)}
+                            aria-label={`Role for ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
+                            className="w-full"
+                          />
+                        </div>
+                        <Button
+                          data-testid={`share-member-remove-${m.user_id}`}
+                          variant="ghost"
+                          size="icon-sm"
+                          onClick={() => remove(m)}
+                          aria-label={`Remove ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
+                        >
+                          <Icon name="close" />
+                        </Button>
+                      </>
+                    ) : (
+                      <span
+                        data-testid={`share-member-role-${m.user_id}`}
+                        className="shrink-0 text-sm text-muted-foreground"
+                      >
+                        {ROLE_LABELS[m.role]}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Adding people is the natural next step after seeing who already has
+                access — the roster reads top-to-bottom as one flow: who's in, then
+                bring in more. */}
+            <div className="mt-3 flex flex-col gap-2">
+              {canManage ? (
+                <form onSubmit={add} className="flex items-center gap-1.5">
+                  <div className="relative flex-1">
+                    {/* WAI-APG combobox wiring: the input announces the popup and the
+                    arrow-key highlight (aria-activedescendant). */}
+                    <Input
+                      data-testid="share-email"
+                      type="text"
+                      autoCapitalize="none"
+                      autoCorrect="off"
+                      autoComplete="off"
+                      placeholder="Add people by @username or email…"
+                      aria-label="Username or email"
+                      role="combobox"
+                      aria-expanded={suggest.length > 0}
+                      aria-autocomplete="list"
+                      aria-controls="share-suggest-list"
+                      aria-activedescendant={
+                        active >= 0 && suggest[active] ? `share-suggest-opt-${active}` : undefined
+                      }
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      onKeyDown={onAddKeyDown}
+                      className="w-full"
+                    />
+                    {suggest.length > 0 && (
+                      <div
+                        data-testid="share-suggest"
+                        id="share-suggest-list"
+                        role="listbox"
+                        aria-label="People suggestions"
+                        className="absolute inset-x-0 top-[calc(100%+4px)] z-40 max-h-56 overflow-y-auto rounded-xl bg-popover p-1 shadow-[var(--shadow-pop)] ring-1 ring-foreground/10"
+                      >
+                        {suggest.map((u, i) => (
+                          <button
+                            key={u.username}
+                            type="button"
+                            data-testid="share-suggest-item"
+                            id={`share-suggest-opt-${i}`}
+                            role="option"
+                            aria-selected={i === active}
+                            // Keep the input focused so the click registers without blurring first.
+                            onMouseDown={(e) => e.preventDefault()}
+                            onClick={() => pick(u)}
+                            onMouseEnter={() => setActive(i)}
+                            className={cn(
+                              "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left outline-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring",
+                              i === active ? "bg-accent" : "hover:bg-accent",
+                            )}
+                          >
+                            <Avatar className="size-6">
+                              {u.image && <AvatarImage src={u.image} alt={u.name ?? u.username} />}
+                              <AvatarFallback>{getInitials(u.name ?? u.username)}</AvatarFallback>
+                            </Avatar>
+                            <span className="min-w-0 flex-1">
+                              {u.name && (
+                                <span className="block truncate text-sm font-medium text-foreground">
+                                  {u.name}
+                                </span>
+                              )}
+                              <span className="block truncate font-mono text-2xs text-muted-foreground">
+                                @{u.username}
+                              </span>
+                            </span>
+                          </button>
+                        ))}
                       </div>
                     )}
                   </div>
-                  {/* The sole owner's row is fixed — the server refuses to downgrade
-                      or remove the last owner, so don't offer it. */}
-                  {canManage &&
-                  !(
-                    m.role === "owner" && members.filter((x) => x.role === "owner").length === 1
-                  ) ? (
-                    <>
-                      <div data-testid={`share-member-role-${m.user_id}`} className="w-23 shrink-0">
-                        <RoleSelect
-                          value={m.role}
-                          onChange={(next) => change(m, next)}
-                          aria-label={`Role for ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
-                          className="w-full"
-                        />
-                      </div>
-                      <Button
-                        data-testid={`share-member-remove-${m.user_id}`}
-                        variant="ghost"
-                        size="icon-sm"
-                        onClick={() => remove(m)}
-                        aria-label={`Remove ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
-                      >
-                        <Icon name="close" />
-                      </Button>
-                    </>
-                  ) : (
-                    <span
-                      data-testid={`share-member-role-${m.user_id}`}
-                      className="shrink-0 text-sm text-muted-foreground"
-                    >
-                      {ROLE_LABELS[m.role]}
-                    </span>
-                  )}
+                  <div data-testid="share-role" className="w-28 shrink-0">
+                    <RoleSelect
+                      value={role}
+                      onChange={setRole}
+                      aria-label="Role for new member"
+                      className="w-full"
+                    />
+                  </div>
+                  <Button
+                    data-testid="share-add"
+                    variant="default"
+                    size="sm"
+                    type="submit"
+                    loading={busy}
+                  >
+                    {busy ? "Adding…" : "Add"}
+                  </Button>
+                </form>
+              ) : (
+                <div
+                  data-testid="share-viewonly"
+                  className="flex items-center gap-2 rounded-lg bg-secondary px-3 py-2 text-sm text-muted-foreground"
+                >
+                  <Icon name="lock" />
+                  View only · ask an owner or editor to change access.
                 </div>
-              ))}
+              )}
+              {err && (
+                <p data-testid="share-error" role="alert" className="text-sm text-destructive">
+                  {err}
+                </p>
+              )}
             </div>
-          )}
-        </div>
-
-        <div>
-          <div className="mb-1 flex items-center gap-2">
-            <Eyebrow as="div">General access</Eyebrow>
-            {savingVis && <Spinner className="size-3" />}
           </div>
-          {canManage ? (
-            <>
-              <div className="flex gap-1.5">
-                <Select value={vis} onValueChange={pickVisibility} disabled={savingVis}>
-                  <SelectTrigger
-                    aria-label="General access"
-                    data-testid="share-visibility"
-                    className="flex-1"
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {ACCESS.map((a) => (
-                      <SelectItem key={a.value} value={a.value}>
-                        <Icon name={a.icon} className="text-muted-foreground" />
-                        {a.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {reach && (
-                  <Select
-                    value={genRole}
-                    onValueChange={(v) => pickGenRole(v as GeneralRole)}
-                    disabled={savingVis}
-                  >
-                    <SelectTrigger aria-label="Link permission" data-testid="share-general-role">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="viewer">Can view</SelectItem>
-                      <SelectItem value="commenter">Can comment</SelectItem>
-                    </SelectContent>
-                  </Select>
-                )}
-              </div>
-              {pendingPw ? (
-                <div className="mt-1.5 flex gap-1.5">
-                  <Input
-                    type="password"
-                    data-testid="share-visibility-password"
-                    placeholder="Set a password"
-                    aria-label="Password"
-                    value={pw}
-                    onChange={(e) => setPw(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" && pw) void applyVisibility("password", genRole, pw)
-                    }}
-                    className="flex-1"
-                  />
-                  <Button
-                    data-testid="share-visibility-save"
-                    variant="secondary"
-                    size="sm"
-                    disabled={!pw}
-                    loading={savingVis}
-                    onClick={() => void applyVisibility("password", genRole, pw)}
-                  >
-                    {savingVis ? "Setting…" : "Set password"}
-                  </Button>
-                </div>
-              ) : vis === "password" && pwOpen ? (
-                <div className="mt-1.5 flex gap-1.5">
-                  <Input
-                    type="password"
-                    data-testid="share-visibility-password"
-                    placeholder="New password"
-                    aria-label="New password"
-                    value={pw}
-                    onChange={(e) => setPw(e.target.value)}
-                    className="flex-1"
-                  />
-                  <Button
-                    data-testid="share-visibility-save"
-                    variant="secondary"
-                    size="sm"
-                    disabled={!pw}
-                    loading={savingVis}
-                    onClick={() => void applyVisibility("password", genRole, pw)}
-                  >
-                    {savingVis ? "Setting…" : "Set"}
-                  </Button>
-                </div>
-              ) : null}
-              <p className="mt-1.5 text-sm text-muted-foreground">
-                {pendingPw
-                  ? "Applies once a password is set."
-                  : (ACCESS.find((a) => a.value === vis)?.blurb ?? "")}
-                {!pendingPw &&
-                  reach &&
-                  genRole === "commenter" &&
-                  " Signed-in visitors can comment."}
-                {!pendingPw && vis === "password" && (
-                  <Button
-                    variant="link"
-                    size="xs"
-                    data-testid="share-password-change"
-                    className="ml-1 px-0"
-                    onClick={() => setPwOpen(true)}
-                  >
-                    Change password
-                  </Button>
-                )}
-              </p>
-            </>
-          ) : (
-            <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
-              <Icon name={ACCESS.find((a) => a.value === visibility)?.icon ?? "share"} />
-              {ACCESS.find((a) => a.value === visibility)?.label ?? visibility}
-            </p>
-          )}
         </div>
 
         {/* Footer: the universal action on the left, distribution mechanics folded
             behind a quiet disclosure on the right. */}
-        <div className="flex items-center justify-between border-t border-border pt-3">
+        <div className="flex items-center justify-between border-t border-border pt-4">
           <Button data-testid="share-url-copy" variant="outline" size="sm" onClick={copyLink}>
             <Icon name={copiedLink ? "check" : "link"} />
             {copiedLink ? "Copied" : "Copy link"}


### PR DESCRIPTION
## Summary

- **Fixes a real bug**: opening the visibility or role dropdown inside the share dialog and clicking anywhere else in the dialog (not the dropdown itself) silently closed the whole modal. Root cause: Radix's `Select` unconditionally sets `disableOutsidePointerEvents` on its content with no way to opt out, which cascades a `pointer-events: none` onto every layer below it — including the host Dialog. The next click that isn't on the select's own popup lands on the Dialog's overlay and dismisses it. Replaced the two in-dialog pickers with a new `SelectMenu` (`apps/web/src/components/ui/select-menu.tsx`), built on `DropdownMenu`'s non-modal mode, which never touches outside-pointer-events. `RoleSelect` now uses it too, so the same fix covers the collection share dialog for free.
- **Reorders the dialog** to read as one flow: General access (the coarse-grained setting) → People with access (the roster it governs) → Add people (flows naturally after seeing who's already in) — instead of an add-row floating above a list it hadn't been introduced to yet.
- **Visual pass**: wider dialog, section rules with counts (`People with access · 3`), bigger avatars, General access grouped into its own well so the two selects read as one control instead of two loose ones.

## Test plan

- [x] `pnpm --filter @derive/web typecheck`
- [x] `pnpm exec biome check` / `lint:tokens` / `lint:testids` (all clean)
- [x] Manually verified against a local dev server: opening a select and clicking elsewhere in the dialog no longer closes it; picking a value still applies; add/promote/remove/visibility flows all still work from their new positions
- [x] Updated the three e2e specs that asserted `role=option` on the role picker to `role=menuitemradio` (the primitive changed from Select to a DropdownMenu-backed radio group) — `share.smoke.spec.ts`, `visibility.deep.spec.ts`, `share.deep.spec.ts`