### PR TITLE
Contexts + sessions: data layer and API for the ask loop

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -14,6 +14,7 @@ import { artifactRoutes } from "./routes/artifacts"
 import { assetRoutes } from "./routes/assets"
 import { collectionRoutes } from "./routes/collections"
 import { commentRoutes } from "./routes/comments"
+import { contextRoutes } from "./routes/contexts"
 import { domainRoutes } from "./routes/domains"
 import { embedRoutes } from "./routes/embeds"
 import { favoriteRoutes } from "./routes/favorites"
@@ -300,6 +301,7 @@ export function createApp(deps: AppDeps): Hono {
     proposalRoutes,
     reviewRoutes,
     commentRoutes,
+    contextRoutes,
     realtimeRoutes,
     analyticsRoutes,
     notificationRoutes,

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -1,0 +1,304 @@
+import {
+  type ContextRecord,
+  newId,
+  type SessionMessageRecord,
+  type SessionRecord,
+  type SessionState,
+} from "@derive/core"
+import { Hono } from "hono"
+import { z } from "zod"
+import type { AppContext } from "../context"
+import { fail, readJson } from "../lib/http"
+
+/**
+ * Contexts (askable agent setups) + sessions (ask-conversations with one).
+ *
+ * A context links a registered agent to its manifest artifact; the manifest's
+ * share roster is the ask grant (v1: viewer on the manifest = can ask). Sessions
+ * are private to the asker and the context owner — 404 to everyone else, so their
+ * existence never leaks. The runner drains `open` sessions from the queue endpoint
+ * with the agent's own bearer and answers through the messages endpoint.
+ */
+export const contextRoutes = (ctx: AppContext) => {
+  const { meta, activeWorkspace, agentFor, authorize, currentUser, requireUser, workspaceCan } = ctx
+  const app = new Hono()
+
+  const contextJson = (x: ContextRecord, manifestShortId: string | null) => ({
+    id: x.id,
+    name: x.name,
+    agent_id: x.agent_id,
+    manifest_short_id: manifestShortId,
+    created_by: x.created_by,
+    created_at: x.created_at,
+  })
+
+  const messageJson = (m: SessionMessageRecord) => ({
+    id: m.id,
+    author_kind: m.author_kind,
+    author_id: m.author_id,
+    body_md: m.body_md,
+    // Stored as TEXT (see ports); parsed here so clients never re-parse.
+    meta: m.meta ? (JSON.parse(m.meta) as unknown) : null,
+    created_at: m.created_at,
+  })
+
+  const sessionJson = (s: SessionRecord) => ({
+    id: s.id,
+    context_id: s.context_id,
+    asker_id: s.asker_id,
+    context_version: s.context_version,
+    state: s.state,
+    created_at: s.created_at,
+    updated_at: s.updated_at ?? s.created_at,
+  })
+
+  /** A session's context + manifest, or null when either half is gone. */
+  const contextOf = async (s: SessionRecord) => {
+    const x = await meta.getContext(s.context_id)
+    if (!x) return null
+    const manifest = await meta.getArtifactById(x.manifest_artifact_id)
+    return manifest ? { context: x, manifest } : null
+  }
+
+  // Create a context: wire an agent to a manifest artifact. Editor+ in the
+  // workspace, and share-standing on the manifest — creating a context makes the
+  // manifest's roster govern who can ask, which is a sharing decision.
+  app.post("/v1/contexts", async (c) => {
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    if (!(await workspaceCan(c, "publish"))) return fail(c, 403, "forbidden")
+    const b = await readJson(
+      c,
+      z.object({
+        name: z.string().trim().min(1).max(80),
+        agent_id: z.string(),
+        manifest_short_id: z.string(),
+      }),
+    )
+    if (b instanceof Response) return b
+    const org = await activeWorkspace(c)
+    const agents = await meta.listAgents(org)
+    if (!agents.some((a) => a.id === b.agent_id)) return fail(c, 404, "no such agent")
+    const manifest = await meta.getByShortId(b.manifest_short_id)
+    if (!manifest || manifest.org_id !== org || !(await authorize(c, "share", manifest)))
+      return fail(c, 404, "no such artifact")
+    try {
+      const created = await meta.createContext({
+        id: newId("ctx"),
+        org_id: org,
+        name: b.name,
+        agent_id: b.agent_id,
+        manifest_artifact_id: manifest.id,
+        created_by: me.id,
+      })
+      return c.json(contextJson(created, manifest.short_id), 201)
+    } catch {
+      return fail(c, 409, "a context with that name already exists")
+    }
+  })
+
+  app.get("/v1/contexts", async (c) => {
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    if (!(await workspaceCan(c, "read"))) return fail(c, 403, "forbidden")
+    const rows = await meta.listContexts(await activeWorkspace(c))
+    const contexts = await Promise.all(
+      rows.map(async (x) =>
+        contextJson(x, (await meta.getArtifactById(x.manifest_artifact_id))?.short_id ?? null),
+      ),
+    )
+    return c.json({ contexts })
+  })
+
+  app.get("/v1/contexts/:id", async (c) => {
+    const x = await meta.getContext(c.req.param("id"))
+    if (!x) return fail(c, 404, "not found")
+    // Visible to whoever can read the manifest (users) — or to the context's own
+    // agent, which needs its wiring (name, manifest) to run.
+    const agent = await agentFor(c)
+    const manifest = await meta.getArtifactById(x.manifest_artifact_id)
+    const allowed = agent
+      ? agent.id === x.agent_id
+      : manifest !== null && (await authorize(c, "read", manifest))
+    if (!allowed) return fail(c, 404, "not found")
+    return c.json(contextJson(x, manifest?.short_id ?? null))
+  })
+
+  app.delete("/v1/contexts/:id", async (c) => {
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    const x = await meta.getContext(c.req.param("id"))
+    if (!x) return fail(c, 404, "not found")
+    if (x.created_by !== me.id && !(await workspaceCan(c, "manage")))
+      return fail(c, 403, "forbidden")
+    await meta.deleteContext(x.id, x.org_id)
+    return c.body(null, 204)
+  })
+
+  // Ask: open a session with the first question. The ask grant is read on the
+  // manifest, so sharing the manifest is sharing the context.
+  app.post("/v1/contexts/:id/sessions", async (c) => {
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    const x = await meta.getContext(c.req.param("id"))
+    const manifest = x ? await meta.getArtifactById(x.manifest_artifact_id) : null
+    if (!x || !manifest || !(await authorize(c, "read", manifest))) return fail(c, 404, "not found")
+    const b = await readJson(c, z.object({ body_md: z.string().trim().min(1).max(20_000) }))
+    if (b instanceof Response) return b
+    const session = await meta.createSession({
+      id: newId("ses"),
+      context_id: x.id,
+      org_id: x.org_id,
+      asker_id: me.id,
+      context_version: manifest.current_version,
+    })
+    const first = await meta.addSessionMessage(
+      {
+        id: newId("sm"),
+        session_id: session.id,
+        author_kind: "asker",
+        author_id: me.id,
+        body_md: b.body_md,
+      },
+      "open",
+    )
+    return c.json({ session: sessionJson(session), messages: [messageJson(first)] }, 201)
+  })
+
+  // A context's sessions: the owner sees every session (the activity view);
+  // anyone else sees only their own.
+  app.get("/v1/contexts/:id/sessions", async (c) => {
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    const x = await meta.getContext(c.req.param("id"))
+    const manifest = x ? await meta.getArtifactById(x.manifest_artifact_id) : null
+    if (!x || !manifest || !(await authorize(c, "read", manifest))) return fail(c, 404, "not found")
+    const limit = Math.min(100, Math.max(1, Number(c.req.query("limit")) || 50))
+    const sessions = await meta.listSessions(x.id, {
+      askerId: x.created_by === me.id ? undefined : me.id,
+      limit,
+    })
+    return c.json({ sessions: sessions.map(sessionJson) })
+  })
+
+  // One session with its transcript — the asker's and the context owner's view.
+  app.get("/v1/sessions/:id", async (c) => {
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    const s = await meta.getSession(c.req.param("id"))
+    const linked = s ? await contextOf(s) : null
+    if (!s || !linked || (s.asker_id !== me.id && linked.context.created_by !== me.id))
+      return fail(c, 404, "not found")
+    const messages = await meta.listSessionMessages(s.id)
+    return c.json({
+      session: sessionJson(s),
+      context: { id: linked.context.id, name: linked.context.name },
+      messages: messages.map(messageJson),
+    })
+  })
+
+  // Append a turn. The asker's message re-opens the session (back on the queue);
+  // the context's agent settles it (answered, or escalated when its draft went to
+  // review, or failed when the run crashed).
+  app.post("/v1/sessions/:id/messages", async (c) => {
+    const s = await meta.getSession(c.req.param("id"))
+    const linked = s ? await contextOf(s) : null
+    if (!s || !linked) return fail(c, 404, "not found")
+    // Authorization decides before state does: a caller with no standing gets the
+    // same 404 whether the session is open or closed — 409 would leak its state.
+    const closed = (): Response | null =>
+      s.state === "closed" ? fail(c, 409, "session is closed") : null
+
+    const agent = await agentFor(c)
+    if (agent) {
+      if (agent.id !== linked.context.agent_id) return fail(c, 404, "not found")
+      const gone = closed()
+      if (gone) return gone
+      const b = await readJson(
+        c,
+        z.object({
+          body_md: z.string().trim().min(1).max(100_000),
+          meta: z.unknown().optional(),
+          state: z.enum(["answered", "escalated", "failed"]).optional(),
+        }),
+      )
+      if (b instanceof Response) return b
+      const m = await meta.addSessionMessage(
+        {
+          id: newId("sm"),
+          session_id: s.id,
+          author_kind: "agent",
+          author_id: agent.id,
+          body_md: b.body_md,
+          meta: b.meta === undefined ? null : JSON.stringify(b.meta),
+        },
+        b.state ?? "answered",
+      )
+      return c.json({ message: messageJson(m) }, 201)
+    }
+
+    const me = await currentUser(c)
+    if (!me) return fail(c, 401, "unauthenticated")
+    if (s.asker_id !== me.id) return fail(c, 404, "not found")
+    const gone = closed()
+    if (gone) return gone
+    const b = await readJson(c, z.object({ body_md: z.string().trim().min(1).max(20_000) }))
+    if (b instanceof Response) return b
+    const m = await meta.addSessionMessage(
+      {
+        id: newId("sm"),
+        session_id: s.id,
+        author_kind: "asker",
+        author_id: me.id,
+        body_md: b.body_md,
+      },
+      "open",
+    )
+    return c.json({ message: messageJson(m) }, 201)
+  })
+
+  // Close (asker or owner) / fail without a message (the runner's crash path).
+  app.patch("/v1/sessions/:id", async (c) => {
+    const s = await meta.getSession(c.req.param("id"))
+    const linked = s ? await contextOf(s) : null
+    if (!s || !linked) return fail(c, 404, "not found")
+
+    const agent = await agentFor(c)
+    if (agent) {
+      if (agent.id !== linked.context.agent_id) return fail(c, 404, "not found")
+      const b = await readJson(c, z.object({ state: z.literal("failed") }))
+      if (b instanceof Response) return b
+      const updated = await meta.setSessionState(s.id, b.state as SessionState)
+      return updated ? c.json({ session: sessionJson(updated) }) : fail(c, 404, "not found")
+    }
+
+    const me = await currentUser(c)
+    if (!me) return fail(c, 401, "unauthenticated")
+    if (s.asker_id !== me.id && linked.context.created_by !== me.id)
+      return fail(c, 404, "not found")
+    const b = await readJson(c, z.object({ state: z.literal("closed") }))
+    if (b instanceof Response) return b
+    const updated = await meta.setSessionState(s.id, b.state as SessionState)
+    return updated ? c.json({ session: sessionJson(updated) }) : fail(c, 404, "not found")
+  })
+
+  // The runner's queue: open sessions, oldest first, transcripts embedded so one
+  // poll is one round-trip. Auth = the context's own agent bearer (the inbox model).
+  app.get("/v1/contexts/:id/queue", async (c) => {
+    const agent = await agentFor(c)
+    if (!agent) return fail(c, 401, "agent token required")
+    const x = await meta.getContext(c.req.param("id"))
+    if (!x || x.agent_id !== agent.id) return fail(c, 404, "not found")
+    const limit = Math.min(20, Math.max(1, Number(c.req.query("limit")) || 10))
+    const sessions = await meta.pendingSessions(x.id, limit)
+    const out = await Promise.all(
+      sessions.map(async (s) => ({
+        ...sessionJson(s),
+        messages: (await meta.listSessionMessages(s.id)).map(messageJson),
+      })),
+    )
+    return c.json({ sessions: out })
+  })
+
+  return app
+}

--- a/apps/api/test/contexts.test.ts
+++ b/apps/api/test/contexts.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from "vitest"
+import { as, bearer, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// Contexts + sessions: the ask → answer → follow-up loop, its permission edges,
+// and the runner's queue. The ask grant is "viewer on the manifest artifact", so
+// the sharing machinery is exercised here too (a private manifest gates asking).
+describe("contexts: create + wire an agent to a manifest", () => {
+  const owner: TestUser = { id: "u_cx_own", email: "cxown@derive.test", name: "Owner" }
+  const dev: TestUser = { id: "u_cx_dev", email: "cxdev@derive.test", name: "Dev" }
+  const { app } = makeAuthedApp("contexts-create", [owner, dev], "commenter")
+
+  let agentId: string
+  let manifestShortId: string
+
+  it("an owner wires an agent to a manifest; the result carries both", async () => {
+    await app.request("/v1/me", { headers: as(owner.email) })
+    await app.request("/v1/me", { headers: as(dev.email) })
+    const ag = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Analyst" }))
+    ).json()
+    agentId = ag.id
+    manifestShortId = (
+      await (await publishAs(app, "# Analytics manifest", {}, as(owner.email))).json()
+    ).short_id
+    const res = await app.request(
+      "/v1/contexts",
+      jsonAs(as(owner.email), {
+        name: "Analytics",
+        agent_id: agentId,
+        manifest_short_id: manifestShortId,
+      }),
+    )
+    expect(res.status).toBe(201)
+    const x = await res.json()
+    expect(x).toMatchObject({
+      name: "Analytics",
+      agent_id: agentId,
+      manifest_short_id: manifestShortId,
+    })
+
+    const list = await (await app.request("/v1/contexts", { headers: as(owner.email) })).json()
+    expect(list.contexts).toHaveLength(1)
+  })
+
+  it("a duplicate name is 409; an unknown agent or manifest is 404", async () => {
+    const dup = await app.request(
+      "/v1/contexts",
+      jsonAs(as(owner.email), {
+        name: "Analytics",
+        agent_id: agentId,
+        manifest_short_id: manifestShortId,
+      }),
+    )
+    expect(dup.status).toBe(409)
+    expect(
+      (
+        await app.request(
+          "/v1/contexts",
+          jsonAs(as(owner.email), {
+            name: "X",
+            agent_id: "ag_nope",
+            manifest_short_id: manifestShortId,
+          }),
+        )
+      ).status,
+    ).toBe(404)
+    expect(
+      (
+        await app.request(
+          "/v1/contexts",
+          jsonAs(as(owner.email), { name: "X", agent_id: agentId, manifest_short_id: "zzzzzzzz" }),
+        )
+      ).status,
+    ).toBe(404)
+  })
+
+  it("a commenter cannot create a context (workspace publish gate)", async () => {
+    const res = await app.request(
+      "/v1/contexts",
+      jsonAs(as(dev.email), {
+        name: "Rogue",
+        agent_id: agentId,
+        manifest_short_id: manifestShortId,
+      }),
+    )
+    expect(res.status).toBe(403)
+  })
+})
+
+describe("sessions: the ask → answer → follow-up loop", () => {
+  const owner: TestUser = { id: "u_ss_own", email: "ssown@derive.test", name: "Owner" }
+  const daniel: TestUser = { id: "u_ss_dan", email: "ssdan@derive.test", name: "Daniel" }
+  const stranger: TestUser = { id: "u_ss_str", email: "ssstr@derive.test", name: "Stranger" }
+  const { app } = makeAuthedApp("contexts-loop", [owner, daniel, stranger], "commenter")
+
+  let contextId: string
+  let sessionId: string
+  let agentToken: string
+  let manifestShortId: string
+
+  it("setup: agent + PRIVATE manifest + context; asking is gated on the manifest", async () => {
+    await app.request("/v1/me", { headers: as(owner.email) })
+    await app.request("/v1/me", { headers: as(daniel.email) })
+    await app.request("/v1/me", { headers: as(stranger.email) })
+    const ag = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Analyst", role: "editor" }))
+    ).json()
+    agentToken = ag.token
+    manifestShortId = (
+      await (await publishAs(app, "# Manifest", { visibility: "private" }, as(owner.email))).json()
+    ).short_id
+    const x = await (
+      await app.request(
+        "/v1/contexts",
+        jsonAs(as(owner.email), {
+          name: "Analytics",
+          agent_id: ag.id,
+          manifest_short_id: manifestShortId,
+        }),
+      )
+    ).json()
+    contextId = x.id
+
+    // Private manifest, no member row: Daniel can't ask (and can't tell it exists).
+    const denied = await app.request(
+      `/v1/contexts/${contextId}/sessions`,
+      jsonAs(as(daniel.email), { body_md: "churn for March?" }),
+    )
+    expect(denied.status).toBe(404)
+
+    // Share the manifest with Daniel → the context becomes askable.
+    await app.request(`/v1/artifacts/${manifestShortId}/members`, {
+      method: "PUT",
+      headers: { ...as(owner.email), "content-type": "application/json" },
+      body: JSON.stringify({ email: daniel.email, role: "viewer" }),
+    })
+    const asked = await app.request(
+      `/v1/contexts/${contextId}/sessions`,
+      jsonAs(as(daniel.email), { body_md: "churn for March?" }),
+    )
+    expect(asked.status).toBe(201)
+    const opened = await asked.json()
+    sessionId = opened.session.id
+    expect(opened.session.state).toBe("open")
+    expect(opened.messages).toHaveLength(1)
+  })
+
+  it("the runner drains the queue (transcript embedded) and answers with meta", async () => {
+    const q = await (
+      await app.request(`/v1/contexts/${contextId}/queue`, { headers: bearer(agentToken) })
+    ).json()
+    expect(q.sessions).toHaveLength(1)
+    expect(q.sessions[0].messages[0].body_md).toBe("churn for March?")
+
+    const answered = await app.request(
+      `/v1/sessions/${sessionId}/messages`,
+      jsonAs(bearer(agentToken), {
+        body_md: "March enterprise churn was 3.1%.",
+        meta: { query: "select …", confidence: 0.88, caveats: ["small sample"] },
+      }),
+    )
+    expect(answered.status).toBe(201)
+    expect((await answered.json()).message.meta.confidence).toBe(0.88)
+
+    // Answered → off the queue; the asker's view carries the parsed meta.
+    const drained = await (
+      await app.request(`/v1/contexts/${contextId}/queue`, { headers: bearer(agentToken) })
+    ).json()
+    expect(drained.sessions).toHaveLength(0)
+    const view = await (
+      await app.request(`/v1/sessions/${sessionId}`, { headers: as(daniel.email) })
+    ).json()
+    expect(view.session.state).toBe("answered")
+    expect(view.messages[1].meta.caveats).toEqual(["small sample"])
+  })
+
+  it("a follow-up re-opens the session; closing takes it off the queue for good", async () => {
+    const followUp = await app.request(
+      `/v1/sessions/${sessionId}/messages`,
+      jsonAs(as(daniel.email), { body_md: "and February?" }),
+    )
+    expect(followUp.status).toBe(201)
+    const q = await (
+      await app.request(`/v1/contexts/${contextId}/queue`, { headers: bearer(agentToken) })
+    ).json()
+    expect(q.sessions).toHaveLength(1)
+
+    const closed = await app.request(`/v1/sessions/${sessionId}`, {
+      method: "PATCH",
+      headers: { ...as(daniel.email), "content-type": "application/json" },
+      body: JSON.stringify({ state: "closed" }),
+    })
+    expect(closed.status).toBe(200)
+    expect(
+      (
+        await app.request(
+          `/v1/sessions/${sessionId}/messages`,
+          jsonAs(as(daniel.email), { body_md: "one more" }),
+        )
+      ).status,
+    ).toBe(409)
+  })
+
+  it("sessions are private: asker + context owner only; the roster viewer is not enough", async () => {
+    // The stranger holds no view at all; even sharing the manifest with them
+    // (roster viewer = may ASK) must not expose Daniel's session.
+    await app.request(`/v1/artifacts/${manifestShortId}/members`, {
+      method: "PUT",
+      headers: { ...as(owner.email), "content-type": "application/json" },
+      body: JSON.stringify({ email: stranger.email, role: "viewer" }),
+    })
+    expect(
+      (await app.request(`/v1/sessions/${sessionId}`, { headers: as(stranger.email) })).status,
+    ).toBe(404)
+    expect(
+      (await app.request(`/v1/sessions/${sessionId}`, { headers: as(owner.email) })).status,
+    ).toBe(200)
+
+    // Listing: the owner sees Daniel's session; the stranger sees only their own (none).
+    const ownerList = await (
+      await app.request(`/v1/contexts/${contextId}/sessions`, { headers: as(owner.email) })
+    ).json()
+    expect(ownerList.sessions).toHaveLength(1)
+    const strangerList = await (
+      await app.request(`/v1/contexts/${contextId}/sessions`, { headers: as(stranger.email) })
+    ).json()
+    expect(strangerList.sessions).toHaveLength(0)
+  })
+
+  it("a foreign agent can neither read the queue nor answer", async () => {
+    const other = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Imposter" }))
+    ).json()
+    expect(
+      (await app.request(`/v1/contexts/${contextId}/queue`, { headers: bearer(other.token) }))
+        .status,
+    ).toBe(404)
+    expect(
+      (
+        await app.request(
+          `/v1/sessions/${sessionId}/messages`,
+          jsonAs(bearer(other.token), { body_md: "let me in" }),
+        )
+      ).status,
+    ).toBe(404)
+  })
+
+  it("the runner can mark a crashed run failed without posting a message", async () => {
+    const asked = await (
+      await app.request(
+        `/v1/contexts/${contextId}/sessions`,
+        jsonAs(as(daniel.email), { body_md: "will this crash?" }),
+      )
+    ).json()
+    const failed = await app.request(`/v1/sessions/${asked.session.id}`, {
+      method: "PATCH",
+      headers: { ...bearer(agentToken), "content-type": "application/json" },
+      body: JSON.stringify({ state: "failed" }),
+    })
+    expect(failed.status).toBe(200)
+    expect((await failed.json()).session.state).toBe("failed")
+  })
+})

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -326,6 +326,47 @@ CREATE TABLE IF NOT EXISTS review_round (
 
 CREATE INDEX IF NOT EXISTS review_round_artifact ON review_round (artifact_id, requested_for);
 
+CREATE TABLE IF NOT EXISTS context (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  manifest_artifact_id TEXT NOT NULL,
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  UNIQUE (org_id, name),
+  FOREIGN KEY (manifest_artifact_id) REFERENCES artifact(id)
+);
+
+CREATE TABLE IF NOT EXISTS context_session (
+  id TEXT PRIMARY KEY,
+  context_id TEXT NOT NULL,
+  org_id TEXT NOT NULL,
+  asker_id TEXT NOT NULL,
+  context_version INTEGER NOT NULL,
+  state TEXT NOT NULL DEFAULT 'open',
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at TEXT,
+  FOREIGN KEY (context_id) REFERENCES context(id)
+);
+
+CREATE INDEX IF NOT EXISTS context_session_queue ON context_session (context_id, state, created_at);
+
+CREATE INDEX IF NOT EXISTS context_session_asker ON context_session (asker_id, created_at);
+
+CREATE TABLE IF NOT EXISTS session_message (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  author_kind TEXT NOT NULL,
+  author_id TEXT NOT NULL,
+  body_md TEXT NOT NULL,
+  meta TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  FOREIGN KEY (session_id) REFERENCES context_session(id)
+);
+
+CREATE INDEX IF NOT EXISTS session_message_session ON session_message (session_id, created_at);
+
 CREATE TABLE IF NOT EXISTS report (
   id TEXT PRIMARY KEY,
   org_id TEXT NOT NULL DEFAULT 'default',

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -492,6 +492,33 @@ export interface MetaStore {
     fields: { state: Extract<ReviewRoundState, "sent_back" | "approved">; note?: string | null },
   ): Promise<ReviewRoundRecord | null>
 
+  // ---- Contexts + sessions (ask a context; its runner answers) -----------
+  createContext(x: NewContext): Promise<ContextRecord>
+  getContext(id: string): Promise<ContextRecord | null>
+  /** A workspace's contexts, newest first. */
+  listContexts(orgId: string): Promise<ContextRecord[]>
+  /** Remove a context and its sessions + messages, scoped to its workspace. */
+  deleteContext(id: string, orgId: string): Promise<void>
+  createSession(s: NewSession): Promise<SessionRecord>
+  getSession(id: string): Promise<SessionRecord | null>
+  /** Sessions on a context, newest first; `askerId` narrows to one person's. */
+  listSessions(
+    contextId: string,
+    opts?: { askerId?: string; limit?: number },
+  ): Promise<SessionRecord[]>
+  /** The runner's queue: `open` sessions on a context, oldest first. A plain
+   *  polling read — claiming/leasing is unnecessary while a context has one
+   *  runner (the daniel-prototype topology); revisit if runners multiply. */
+  pendingSessions(contextId: string, limit: number): Promise<SessionRecord[]>
+  /** Set a session's state and bump updated_at; null if the session is unknown. */
+  setSessionState(id: string, state: SessionState): Promise<SessionRecord | null>
+  /** Append a message and set the session's state in the same call (the turn flip:
+   *  an asker message re-opens; an agent message settles to answered/escalated).
+   *  The caller decides the state — the store just applies both writes. */
+  addSessionMessage(m: NewSessionMessage, state: SessionState): Promise<SessionMessageRecord>
+  /** A session's transcript, oldest first. */
+  listSessionMessages(sessionId: string): Promise<SessionMessageRecord[]>
+
   // ---- User directory (reads Better Auth's `user` table) ----------------
   findUserByEmail(email: string): Promise<UserDir | null>
   getUsers(ids: string[]): Promise<UserDir[]>
@@ -846,6 +873,90 @@ export interface NewReviewRound {
   requested_by: string
   requested_for: string
   note?: string | null
+}
+
+/**
+ * A context: a named, askable agent setup — the registered agent that runs it
+ * linked to the manifest artifact that defines it (instructions, referenced docs,
+ * connection definitions). The manifest is a normal versioned artifact, so
+ * sharing, review, and history come from the artifact machinery; v1's ask grant
+ * is "viewer on the manifest". Credentials are never part of a context — they
+ * live wherever its runner executes.
+ */
+export interface ContextRecord {
+  id: string
+  org_id: string
+  name: string
+  /** The registered agent that answers this context's sessions (plain column —
+   *  an agent row may be deleted out from under a context; the queue just goes
+   *  quiet until a new agent is wired). */
+  agent_id: string
+  /** The versioned definition. Hard FK: a context cannot outlive its manifest. */
+  manifest_artifact_id: string
+  created_by: string
+  created_at: string
+}
+export interface NewContext {
+  id: string
+  org_id: string
+  name: string
+  agent_id: string
+  manifest_artifact_id: string
+  created_by: string
+}
+
+/** A session's lifecycle. `state` also encodes whose turn it is: `open` means the
+ *  runner owes a reply (the queue predicate); an asker follow-up on an `answered`
+ *  session flips it back to `open`. `escalated` = the runner filed its draft for
+ *  the owner's approval; `failed` = the run crashed (surfaced, never auto-retried);
+ *  `closed` = the asker or owner ended it. */
+export type SessionState = "open" | "answered" | "escalated" | "failed" | "closed"
+
+/** Who wrote a session message: the human asking, or the context's agent. */
+export type SessionMessageAuthor = "asker" | "agent"
+
+/** One ask-conversation with a context, on behalf of one asker. Private to the
+ *  asker and the context owner — session content is bounded by whatever the
+ *  runner's credentials can reach, so it never gets artifact-style visibility. */
+export interface SessionRecord {
+  id: string
+  context_id: string
+  org_id: string
+  asker_id: string
+  /** The manifest version the session started against (provenance). */
+  context_version: number
+  state: SessionState
+  created_at: string
+  /** Bumped on every message/state change; null until then (read as ?? created_at). */
+  updated_at: string | null
+}
+export interface NewSession {
+  id: string
+  context_id: string
+  org_id: string
+  asker_id: string
+  context_version: number
+}
+
+export interface SessionMessageRecord {
+  id: string
+  session_id: string
+  author_kind: SessionMessageAuthor
+  /** The asker's user id, or the agent's id — stable identity, like comment.author_id. */
+  author_id: string
+  body_md: string
+  /** JSON blob from the runner: { query?, confidence?, caveats?, artifacts?, escalation? }.
+   *  TEXT like comment.meta — parsed by clients, never by the store. */
+  meta: string | null
+  created_at: string
+}
+export interface NewSessionMessage {
+  id: string
+  session_id: string
+  author_kind: SessionMessageAuthor
+  author_id: string
+  body_md: string
+  meta?: string | null
 }
 
 /** A GitHub commit author, denormalized onto an artifact / stored per version.

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -21,6 +21,7 @@ import type {
   CollectionMemberRecord,
   CollectionRecord,
   CommentRecord,
+  ContextRecord,
   DeliveryRecord,
   DomainRecord,
   FollowRecord,
@@ -32,6 +33,8 @@ import type {
   ReportRecord,
   RepoSourceRecord,
   ReviewRoundRecord,
+  SessionMessageRecord,
+  SessionRecord,
   VersionRecord,
   WebhookRecord,
   WorkspaceRecord,
@@ -56,6 +59,9 @@ export interface TypedTables {
   reviewRound: ReviewRoundRecord
   agent: AgentRecord
   agentMention: AgentMentionRecord
+  context: ContextRecord
+  contextSession: SessionRecord
+  sessionMessage: SessionMessageRecord
   collection: CollectionRecord
   collectionMember: CollectionMemberRecord
   repoSource: RepoSourceRecord

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -14,6 +14,8 @@ import type {
   ReportState,
   ReviewRoundState,
   Role,
+  SessionMessageAuthor,
+  SessionState,
   Visibility,
   WebhookKind,
 } from "@derive/core"
@@ -408,6 +410,61 @@ export const reviewRound = pgTable(
   (t) => [index("review_round_artifact").on(t.artifact_id, t.requested_for)],
 )
 
+// A context: an askable agent setup — agent + manifest artifact. Mirror of the
+// sqlite def; see schema.ts for the design notes (loose agent_id, hard manifest FK,
+// context_session naming vs Better Auth's `session` table).
+export const context = pgTable(
+  "context",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    name: text("name").notNull(),
+    agent_id: text("agent_id").notNull(),
+    manifest_artifact_id: text("manifest_artifact_id")
+      .notNull()
+      .references(() => artifact.id),
+    created_by: text("created_by").notNull(),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [uniqueIndex("context_org_name").on(t.org_id, t.name)],
+)
+
+export const contextSession = pgTable(
+  "context_session",
+  {
+    id: text("id").primaryKey(),
+    context_id: text("context_id")
+      .notNull()
+      .references(() => context.id),
+    org_id: text("org_id").notNull(),
+    asker_id: text("asker_id").notNull(),
+    context_version: integer("context_version").notNull(),
+    state: text("state").$type<SessionState>().notNull().default("open"),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+    updated_at: text("updated_at"),
+  },
+  (t) => [
+    index("context_session_queue").on(t.context_id, t.state, t.created_at),
+    index("context_session_asker").on(t.asker_id, t.created_at),
+  ],
+)
+
+export const sessionMessage = pgTable(
+  "session_message",
+  {
+    id: text("id").primaryKey(),
+    session_id: text("session_id")
+      .notNull()
+      .references(() => contextSession.id),
+    author_kind: text("author_kind").$type<SessionMessageAuthor>().notNull(),
+    author_id: text("author_id").notNull(),
+    body_md: text("body_md").notNull(),
+    meta: text("meta"),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [index("session_message_session").on(t.session_id, t.created_at)],
+)
+
 export const report = pgTable("report", {
   id: text("id").primaryKey(),
   org_id: text("org_id").notNull().default("default"),
@@ -469,6 +526,9 @@ const TABLES = [
   domain,
   proposal,
   reviewRound,
+  context,
+  contextSession,
+  sessionMessage,
   report,
   auditLog,
 ]

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -10,6 +10,7 @@ import type {
   CommentRecord,
   CommentSignals,
   CommentState,
+  ContextRecord,
   DeliveryRecord,
   DeliveryStatus,
   DomainRecord,
@@ -32,6 +33,7 @@ import type {
   NewCollection,
   NewCollectionMember,
   NewComment,
+  NewContext,
   NewDelivery,
   NewDomain,
   NewFollow,
@@ -41,6 +43,8 @@ import type {
   NewReport,
   NewRepoSource,
   NewReviewRound,
+  NewSession,
+  NewSessionMessage,
   NewVersion,
   NewView,
   NewWebhook,
@@ -55,6 +59,9 @@ import type {
   ReviewRoundRecord,
   ReviewRoundState,
   Role,
+  SessionMessageRecord,
+  SessionRecord,
+  SessionState,
   SlackInstallRecord,
   SlackThreadLinkRecord,
   TakedownInput,
@@ -97,6 +104,8 @@ import {
   collectionItem,
   collectionMember,
   comment,
+  context,
+  contextSession,
   domain,
   follow,
   githubApp,
@@ -109,6 +118,7 @@ import {
   report,
   repoSource,
   reviewRound,
+  sessionMessage,
   slackInstall,
   slackThreadLink,
   version,
@@ -143,6 +153,9 @@ export const schema = {
   reviewRound,
   agent,
   agentMention,
+  context,
+  contextSession,
+  sessionMessage,
   collection,
   collectionItem,
   collectionMember,
@@ -173,6 +186,9 @@ const _schemaShapes: Shapes<typeof schema> = {
   reviewRound: true,
   agent: true,
   agentMention: true,
+  context: true,
+  contextSession: true,
+  sessionMessage: true,
   collection: true,
   collectionMember: true,
   repoSource: true,
@@ -1457,6 +1473,109 @@ export class PgMetaStore implements MetaStore {
       .where(eq(reviewRound.id, id))
       .returning()
     return rows[0] ?? null
+  }
+
+  // ---- Contexts + sessions -------------------------------------------------
+  async createContext(x: NewContext): Promise<ContextRecord> {
+    const rows = await this.db.insert(context).values(x).returning()
+    return one(rows)
+  }
+  async getContext(id: string): Promise<ContextRecord | null> {
+    const rows = await this.db.select().from(context).where(eq(context.id, id)).limit(1)
+    return rows[0] ?? null
+  }
+  listContexts(orgId: string): Promise<ContextRecord[]> {
+    return this.db
+      .select()
+      .from(context)
+      .where(eq(context.org_id, orgId))
+      .orderBy(desc(context.created_at))
+  }
+  // Sequential cascade (messages → sessions → context), like deleteCollection.
+  // The org scope gates the WHOLE cascade, not just the context row — otherwise a
+  // wrong-workspace call would wipe another tenant's sessions and leave the context.
+  async deleteContext(id: string, orgId: string): Promise<void> {
+    const owned = await this.db
+      .select({ id: context.id })
+      .from(context)
+      .where(and(eq(context.id, id), eq(context.org_id, orgId)))
+      .limit(1)
+    if (owned.length === 0) return
+    const sessions = await this.db
+      .select({ id: contextSession.id })
+      .from(contextSession)
+      .where(eq(contextSession.context_id, id))
+    if (sessions.length > 0)
+      await this.db.delete(sessionMessage).where(
+        inArray(
+          sessionMessage.session_id,
+          sessions.map((s) => s.id),
+        ),
+      )
+    await this.db.delete(contextSession).where(eq(contextSession.context_id, id))
+    await this.db.delete(context).where(eq(context.id, id))
+  }
+  async createSession(s: NewSession): Promise<SessionRecord> {
+    const rows = await this.db.insert(contextSession).values(s).returning()
+    return one(rows)
+  }
+  async getSession(id: string): Promise<SessionRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(contextSession)
+      .where(eq(contextSession.id, id))
+      .limit(1)
+    return rows[0] ?? null
+  }
+  listSessions(
+    contextId: string,
+    opts?: { askerId?: string; limit?: number },
+  ): Promise<SessionRecord[]> {
+    const where = opts?.askerId
+      ? and(eq(contextSession.context_id, contextId), eq(contextSession.asker_id, opts.askerId))
+      : eq(contextSession.context_id, contextId)
+    return this.db
+      .select()
+      .from(contextSession)
+      .where(where)
+      .orderBy(desc(contextSession.created_at))
+      .limit(opts?.limit ?? 50)
+  }
+  pendingSessions(contextId: string, limit: number): Promise<SessionRecord[]> {
+    return this.db
+      .select()
+      .from(contextSession)
+      .where(and(eq(contextSession.context_id, contextId), eq(contextSession.state, "open")))
+      .orderBy(asc(contextSession.created_at))
+      .limit(limit)
+  }
+  async setSessionState(id: string, state: SessionState): Promise<SessionRecord | null> {
+    const rows = await this.db
+      .update(contextSession)
+      .set({ state, updated_at: new Date().toISOString() })
+      .where(eq(contextSession.id, id))
+      .returning()
+    return rows[0] ?? null
+  }
+  // Two writes, no transaction — house pattern (createReviewRound). If the state
+  // write is lost to a crash, the next poll or message repairs it.
+  async addSessionMessage(
+    m: NewSessionMessage,
+    state: SessionState,
+  ): Promise<SessionMessageRecord> {
+    const rows = await this.db.insert(sessionMessage).values(m).returning()
+    await this.db
+      .update(contextSession)
+      .set({ state, updated_at: new Date().toISOString() })
+      .where(eq(contextSession.id, m.session_id))
+    return one(rows)
+  }
+  listSessionMessages(sessionId: string): Promise<SessionMessageRecord[]> {
+    return this.db
+      .select()
+      .from(sessionMessage)
+      .where(eq(sessionMessage.session_id, sessionId))
+      .orderBy(asc(sessionMessage.created_at))
   }
 
   // ---- User directory (Better Auth's "user" table; raw, may be absent) ---

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -10,6 +10,7 @@ import type {
   CommentRecord,
   CommentSignals,
   CommentState,
+  ContextRecord,
   DeliveryRecord,
   DeliveryStatus,
   DomainRecord,
@@ -30,6 +31,7 @@ import type {
   NewCollection,
   NewCollectionMember,
   NewComment,
+  NewContext,
   NewDelivery,
   NewDomain,
   NewFollow,
@@ -39,6 +41,8 @@ import type {
   NewReport,
   NewRepoSource,
   NewReviewRound,
+  NewSession,
+  NewSessionMessage,
   NewVersion,
   NewWebhook,
   NotificationRecord,
@@ -52,6 +56,9 @@ import type {
   ReviewRoundRecord,
   ReviewRoundState,
   Role,
+  SessionMessageRecord,
+  SessionRecord,
+  SessionState,
   SlackInstallRecord,
   SlackThreadLinkRecord,
   TakedownInput,
@@ -95,6 +102,8 @@ import {
   collectionItem,
   collectionMember,
   comment,
+  context,
+  contextSession,
   domain,
   follow,
   githubApp,
@@ -106,6 +115,7 @@ import {
   report,
   repoSource,
   reviewRound,
+  sessionMessage,
   slackInstall,
   slackThreadLink,
   version,
@@ -170,6 +180,9 @@ export const schema = {
   reviewRound,
   agent,
   agentMention,
+  context,
+  contextSession,
+  sessionMessage,
   collection,
   collectionItem,
   collectionMember,
@@ -200,6 +213,9 @@ const _schemaShapes: Shapes<typeof schema> = {
   reviewRound: true,
   agent: true,
   agentMention: true,
+  context: true,
+  contextSession: true,
+  sessionMessage: true,
   collection: true,
   collectionMember: true,
   repoSource: true,
@@ -1518,6 +1534,106 @@ export function makeRepos(db: SqliteDb) {
       .returning()
       .get()) ?? null
 
+  // ---- Contexts + sessions -------------------------------------------------
+  const createContext = async (x: NewContext): Promise<ContextRecord> =>
+    (await db.insert(context).values(x).returning().get()) as ContextRecord
+  const getContext = async (id: string): Promise<ContextRecord | null> =>
+    (await db.select().from(context).where(eq(context.id, id)).get()) ?? null
+  const listContexts = async (orgId: string): Promise<ContextRecord[]> =>
+    db
+      .select()
+      .from(context)
+      .where(eq(context.org_id, orgId))
+      .orderBy(desc(context.created_at))
+      .all()
+  // Sequential cascade (messages → sessions → context), like deleteCollection.
+  // The org scope gates the WHOLE cascade, not just the context row — otherwise a
+  // wrong-workspace call would wipe another tenant's sessions and leave the context.
+  const deleteContext = async (id: string, orgId: string): Promise<void> => {
+    const owned = await db
+      .select({ id: context.id })
+      .from(context)
+      .where(and(eq(context.id, id), eq(context.org_id, orgId)))
+      .get()
+    if (!owned) return
+    const sessions = await db
+      .select({ id: contextSession.id })
+      .from(contextSession)
+      .where(eq(contextSession.context_id, id))
+      .all()
+    if (sessions.length > 0)
+      await db
+        .delete(sessionMessage)
+        .where(
+          inArray(
+            sessionMessage.session_id,
+            sessions.map((s) => s.id),
+          ),
+        )
+        .run()
+    await db.delete(contextSession).where(eq(contextSession.context_id, id)).run()
+    await db.delete(context).where(eq(context.id, id)).run()
+  }
+  const createSession = async (s: NewSession): Promise<SessionRecord> =>
+    (await db.insert(contextSession).values(s).returning().get()) as SessionRecord
+  const getSession = async (id: string): Promise<SessionRecord | null> =>
+    (await db.select().from(contextSession).where(eq(contextSession.id, id)).get()) ?? null
+  const listSessions = async (
+    contextId: string,
+    opts?: { askerId?: string; limit?: number },
+  ): Promise<SessionRecord[]> => {
+    const where = opts?.askerId
+      ? and(eq(contextSession.context_id, contextId), eq(contextSession.asker_id, opts.askerId))
+      : eq(contextSession.context_id, contextId)
+    return db
+      .select()
+      .from(contextSession)
+      .where(where)
+      .orderBy(desc(contextSession.created_at))
+      .limit(opts?.limit ?? 50)
+      .all()
+  }
+  const pendingSessions = async (contextId: string, limit: number): Promise<SessionRecord[]> =>
+    db
+      .select()
+      .from(contextSession)
+      .where(and(eq(contextSession.context_id, contextId), eq(contextSession.state, "open")))
+      .orderBy(asc(contextSession.created_at))
+      .limit(limit)
+      .all()
+  const setSessionState = async (id: string, state: SessionState): Promise<SessionRecord | null> =>
+    (await db
+      .update(contextSession)
+      .set({ state, updated_at: new Date().toISOString() })
+      .where(eq(contextSession.id, id))
+      .returning()
+      .get()) ?? null
+  // Two writes, no transaction — house pattern (createReviewRound). If the state
+  // write is lost to a crash, the next poll or message repairs it.
+  const addSessionMessage = async (
+    m: NewSessionMessage,
+    state: SessionState,
+  ): Promise<SessionMessageRecord> => {
+    const row = (await db
+      .insert(sessionMessage)
+      .values(m)
+      .returning()
+      .get()) as SessionMessageRecord
+    await db
+      .update(contextSession)
+      .set({ state, updated_at: new Date().toISOString() })
+      .where(eq(contextSession.id, m.session_id))
+      .run()
+    return row
+  }
+  const listSessionMessages = async (sessionId: string): Promise<SessionMessageRecord[]> =>
+    db
+      .select()
+      .from(sessionMessage)
+      .where(eq(sessionMessage.session_id, sessionId))
+      .orderBy(asc(sessionMessage.created_at))
+      .all()
+
   // ---- Notifications -----------------------------------------------------
   const createNotification = async (n: NewNotification): Promise<void> => {
     await db.insert(notification).values(n).run()
@@ -1875,6 +1991,17 @@ export function makeRepos(db: SqliteDb) {
     getPendingRound,
     listReviewRounds,
     resolveReviewRound,
+    createContext,
+    getContext,
+    listContexts,
+    deleteContext,
+    createSession,
+    getSession,
+    listSessions,
+    pendingSessions,
+    setSessionState,
+    addSessionMessage,
+    listSessionMessages,
     getProposal,
     listProposals,
     decideProposal,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -14,6 +14,8 @@ import type {
   ReportState,
   ReviewRoundState,
   Role,
+  SessionMessageAuthor,
+  SessionState,
   Visibility,
   WebhookKind,
 } from "@derive/core"
@@ -481,6 +483,69 @@ export const reviewRound = sqliteTable(
   (t) => [index("review_round_artifact").on(t.artifact_id, t.requested_for)],
 )
 
+// A context: a named, askable agent setup — the registered agent that answers it
+// linked to the manifest artifact that defines it. Sharing the manifest IS sharing
+// the context (v1: viewer on the manifest = can ask), so the share machinery is
+// reused wholesale. `agent_id` is a plain column (an agent may be deleted out from
+// under a context); the manifest FK is hard — a context can't outlive its definition.
+export const context = sqliteTable(
+  "context",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    name: text("name").notNull(),
+    agent_id: text("agent_id").notNull(),
+    manifest_artifact_id: text("manifest_artifact_id")
+      .notNull()
+      .references(() => artifact.id),
+    created_by: text("created_by").notNull(),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [uniqueIndex("context_org_name").on(t.org_id, t.name)],
+)
+
+// One ask-conversation with a context. Named context_session because Better Auth
+// owns a `session` table in the same database. `state` doubles as the turn signal:
+// `open` = the runner owes a reply, which makes the queue read one indexed predicate
+// instead of a last-message join.
+export const contextSession = sqliteTable(
+  "context_session",
+  {
+    id: text("id").primaryKey(),
+    context_id: text("context_id")
+      .notNull()
+      .references(() => context.id),
+    org_id: text("org_id").notNull(),
+    asker_id: text("asker_id").notNull(),
+    context_version: integer("context_version").notNull(),
+    state: text("state").$type<SessionState>().notNull().default("open"),
+    created_at: text("created_at").notNull().default(now),
+    updated_at: text("updated_at"),
+  },
+  (t) => [
+    index("context_session_queue").on(t.context_id, t.state, t.created_at),
+    index("context_session_asker").on(t.asker_id, t.created_at),
+  ],
+)
+
+// A session's transcript, one row per turn. `meta` is the runner's structured
+// payload (query, confidence, caveats, artifact refs) as TEXT JSON, like comment.meta.
+export const sessionMessage = sqliteTable(
+  "session_message",
+  {
+    id: text("id").primaryKey(),
+    session_id: text("session_id")
+      .notNull()
+      .references(() => contextSession.id),
+    author_kind: text("author_kind").$type<SessionMessageAuthor>().notNull(),
+    author_id: text("author_id").notNull(),
+    body_md: text("body_md").notNull(),
+    meta: text("meta"),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [index("session_message_session").on(t.session_id, t.created_at)],
+)
+
 // Abuse reports against public artifacts; anyone can file one.
 export const report = sqliteTable("report", {
   id: text("id").primaryKey(),
@@ -542,6 +607,9 @@ const TABLES = [
   domain,
   proposal,
   reviewRound,
+  context,
+  contextSession,
+  sessionMessage,
   report,
   auditLog,
 ]

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1028,6 +1028,141 @@ export function runStoreContract(
     })
   })
 
+  describe(`${label}: contexts + sessions`, () => {
+    const newContext = async () => {
+      const manifest = await store.createArtifact(newArtifact({ kind: "bundle" }))
+      return store.createContext({
+        id: uuid(),
+        org_id: ORG,
+        name: `analytics_${uuid().slice(0, 8)}`,
+        agent_id: uuid(),
+        manifest_artifact_id: manifest.id,
+        created_by: "rob",
+      })
+    }
+
+    it("creates a context, lists it by workspace, resolves by id", async () => {
+      const ctx = await newContext()
+      expect(await store.getContext(ctx.id)).toMatchObject({ name: ctx.name })
+      expect((await store.listContexts(ORG)).some((x) => x.id === ctx.id)).toBe(true)
+      expect(await store.listContexts(`other_${uuid()}`)).toHaveLength(0)
+    })
+
+    it("rejects a duplicate context name within a workspace", async () => {
+      const ctx = await newContext()
+      await expect(
+        store.createContext({
+          id: uuid(),
+          org_id: ORG,
+          name: ctx.name,
+          agent_id: uuid(),
+          manifest_artifact_id: ctx.manifest_artifact_id,
+          created_by: "rob",
+        }),
+      ).rejects.toThrow()
+    })
+
+    it("runs a session through the ask → answer → follow-up → close turn cycle", async () => {
+      const ctx = await newContext()
+      const s = await store.createSession({
+        id: uuid(),
+        context_id: ctx.id,
+        org_id: ORG,
+        asker_id: "daniel",
+        context_version: 1,
+      })
+      expect(s.state).toBe("open")
+
+      // The asker's question is already "open"; the agent's answer settles it.
+      await store.addSessionMessage(
+        {
+          id: uuid(),
+          session_id: s.id,
+          author_kind: "asker",
+          author_id: "daniel",
+          body_md: "churn?",
+        },
+        "open",
+      )
+      expect(await store.pendingSessions(ctx.id, 10)).toHaveLength(1)
+      await store.addSessionMessage(
+        {
+          id: uuid(),
+          session_id: s.id,
+          author_kind: "agent",
+          author_id: "ag_x",
+          body_md: "32%",
+          meta: JSON.stringify({ query: "select …", confidence: 0.9 }),
+        },
+        "answered",
+      )
+      expect(await store.pendingSessions(ctx.id, 10)).toHaveLength(0)
+      expect((await store.getSession(s.id))?.state).toBe("answered")
+      expect((await store.getSession(s.id))?.updated_at).not.toBeNull()
+
+      // A follow-up re-opens (back on the queue); closing takes it off for good.
+      await store.addSessionMessage(
+        {
+          id: uuid(),
+          session_id: s.id,
+          author_kind: "asker",
+          author_id: "daniel",
+          body_md: "and Feb?",
+        },
+        "open",
+      )
+      expect(await store.pendingSessions(ctx.id, 10)).toHaveLength(1)
+      expect(await store.setSessionState(s.id, "closed")).toMatchObject({ state: "closed" })
+      expect(await store.pendingSessions(ctx.id, 10)).toHaveLength(0)
+
+      const transcript = await store.listSessionMessages(s.id)
+      expect(transcript.map((m) => m.author_kind)).toEqual(["asker", "agent", "asker"])
+      expect(JSON.parse(transcript[1].meta ?? "{}").confidence).toBe(0.9)
+    })
+
+    it("scopes session listings to one asker and orders the queue oldest first", async () => {
+      const ctx = await newContext()
+      const ask = (asker: string) =>
+        store.createSession({
+          id: uuid(),
+          context_id: ctx.id,
+          org_id: ORG,
+          asker_id: asker,
+          context_version: 1,
+        })
+      const first = await ask("daniel")
+      await ask("sarah")
+      expect(await store.listSessions(ctx.id)).toHaveLength(2)
+      expect(await store.listSessions(ctx.id, { askerId: "daniel" })).toHaveLength(1)
+      expect((await store.pendingSessions(ctx.id, 10))[0]?.id).toBe(first.id)
+      expect(await store.pendingSessions(ctx.id, 1)).toHaveLength(1)
+    })
+
+    it("deleteContext cascades sessions and messages, scoped to its workspace", async () => {
+      const ctx = await newContext()
+      const s = await store.createSession({
+        id: uuid(),
+        context_id: ctx.id,
+        org_id: ORG,
+        asker_id: "daniel",
+        context_version: 1,
+      })
+      await store.addSessionMessage(
+        { id: uuid(), session_id: s.id, author_kind: "asker", author_id: "daniel", body_md: "hi" },
+        "open",
+      )
+      // Wrong workspace: a no-op — the scope gates the whole cascade, so another
+      // tenant's delete can't wipe the sessions either.
+      await store.deleteContext(ctx.id, `other_${uuid()}`)
+      expect(await store.getContext(ctx.id)).not.toBeNull()
+      expect(await store.getSession(s.id)).not.toBeNull()
+      await store.deleteContext(ctx.id, ORG)
+      expect(await store.getContext(ctx.id)).toBeNull()
+      expect(await store.getSession(s.id)).toBeNull()
+      expect(await store.listSessionMessages(s.id)).toHaveLength(0)
+    })
+  })
+
   describe(`${label}: deleteArtifact`, () => {
     it("hard-deletes the artifact row and all FK-dependent rows", async () => {
       const a = await store.createArtifact(newArtifact())


### PR DESCRIPTION
First of four PRs for the contexts/sessions build (RFC: derive.to `gep1zr9b`). This one is the foundation: three tables across all three store dialects, and the routes for the ask → answer → follow-up loop. No UI, no runner yet — those are PRs 2/3.

## The model, in one paragraph

A **context** wires a registered agent to its **manifest artifact** — the versioned definition. Sharing the manifest *is* sharing the context: v1's ask grant is "viewer on the manifest", so the existing share dialog/roster governs who can ask with zero permission-model changes. A **session** is one ask-conversation, private to the asker and the context owner (404 to everyone else — existence never leaks). `session.state` doubles as the turn signal: `open` = the runner owes a reply, which makes the runner's queue one indexed predicate instead of a last-message join.

## Data layer

- `context`, `context_session`, `session_message` in schema.ts + pg-schema.ts (+ regenerated `deploy/d1-schema.sql`), classified in parity's `TypedTables`, implemented in repos.ts and pg.ts.
- `context_session` (not `session`): Better Auth owns a `session` table in the same database.
- House rules followed: TEXT JSON `meta` (mirrors `comment.meta`), ISO-text timestamps, caller-generated ids (`ctx_`/`ses_`/`sm_`), unique-name-per-workspace via a real unique index, hard FK only where the parent is a hard dependency (manifest, session), loose `agent_id`.
- `deleteContext` gates the **whole cascade** on the org scope — a wrong-workspace call is a no-op rather than wiping sessions and leaving the row (a contract test pins this).

## Routes (`/v1/contexts`, `/v1/sessions`)

- `POST /v1/contexts` — editor+ in the workspace **and** share-standing on the manifest (creating a context makes the manifest's roster govern asking — that's a sharing decision).
- `POST /v1/contexts/:id/sessions` — ask; gated on manifest read. `GET /v1/sessions/:id` — asker/owner only. `POST /v1/sessions/:id/messages` — asker re-opens; the context's agent settles (`answered` default, `escalated`, `failed`), with structured `meta` (query/confidence/caveats) parsed server-side.
- `GET /v1/contexts/:id/queue` — the runner's poll: open sessions oldest-first, transcripts embedded, authed by the context's own agent bearer (the `/v1/agent/inbox` model; deliberately poll-not-hold per the Workers constraints).
- Authorization decides before state does: a foreign agent posting to a closed session gets 404, not a state-leaking 409 (a test caught the original ordering).

## Tests

- 5 contract tests in the shared store suite (run on sqlite, pg, and D1-in-workerd): turn cycle, queue ordering/scoping, asker filtering, unique names, scoped cascade delete.
- 9 API tests: create/permission edges, private-manifest ask gating via the real share endpoint, queue drain with embedded transcript, meta round-trip, follow-up re-open, close semantics, session privacy (roster viewer ≠ session access), foreign-agent 404s, crash-path `failed`.

Local gates: `pnpm run ci`, `pnpm typecheck`, full `pnpm test` (632 api / 143 db), and the D1 lane all green. The pg lane needs Docker (not running locally) — covered by the required CI job.

## Deliberately deferred

Console UI (PR 3), runner (PR 2), bus/SSE events for live message push (v1 polls), operator-token access to session routes, and the ask-vs-read permission amendment (RFC §7 Q1 — the viewer-can-ask cheat holds inside one team).