### PR TITLE
fix(comments): reserve the sheet's real height on mobile, not a static pb-[50vh]

### DIFF
--- a/apps/web/e2e/deep/mobile-comment-gap.deep.spec.ts
+++ b/apps/web/e2e/deep/mobile-comment-gap.deep.spec.ts
@@ -1,0 +1,61 @@
+import { devices, expect, test } from "@playwright/test"
+import { publishArtifact, signUp } from "../helpers"
+
+// Regression: after posting a comment on a phone the document column must not
+// reserve more bottom space than the comment sheet actually occupies. A static
+// `pb-[50vh]` reservation left a large black dead-band below the document
+// whenever the sheet rested at its slim "peek" height (the state you land in
+// after submit / collapse). The reservation must track the sheet's real height.
+test.use({ ...devices["Pixel 7"] })
+
+// How much empty space sits between where the document column ends (its reserved
+// padding) and the top of the comment sheet. This IS the black band.
+async function deadBandPx(page: import("@playwright/test").Page) {
+  return page.evaluate(() => {
+    const iframe = document.querySelector("iframe")
+    // Walk up from the document to the flex column that carries the reservation.
+    let el: HTMLElement | null = iframe?.parentElement ?? null
+    let paddingBottom = 0
+    while (el) {
+      const pb = Number.parseFloat(getComputedStyle(el).paddingBottom) || 0
+      if (pb > 24) {
+        paddingBottom = pb
+        break
+      }
+      el = el.parentElement
+    }
+    const sheet = document.querySelector<HTMLElement>('[role="dialog"][aria-label="Comments"]')
+    const sheetHeight = sheet ? sheet.getBoundingClientRect().height : 0
+    return { paddingBottom, sheetHeight, band: Math.max(0, paddingBottom - sheetHeight) }
+  })
+}
+
+test("no black dead-band under the document after commenting on mobile", async ({ page }) => {
+  await signUp(page)
+  // A short doc makes the reserved bottom space impossible to hide behind scroll.
+  const shortId = await publishArtifact(page, "m.md", "# Doc\n\nA paragraph to comment on here.")
+  await page.goto(`/artifacts/${shortId}`)
+  await page.waitForTimeout(2000)
+
+  // Post a comment; the sheet opens to the full list to show it.
+  await page.frameLocator("iframe").getByText("A paragraph to comment").tap()
+  await page.getByTestId("mobile-comment-start").tap()
+  await page.getByTestId("composer-input").fill("First note.")
+  await page.getByTestId("composer-submit").tap()
+  await expect(page.getByText("First note.")).toBeVisible()
+
+  // Collapse to the peek bar — the resting state you're left in after commenting.
+  await page.getByTestId("comments-sheet-backdrop").tap({ position: { x: 180, y: 36 } })
+  await expect(page.getByTestId("comments-sheet-resize")).toHaveAttribute("aria-label", "Expand")
+  await page.waitForTimeout(400) // let the padding transition settle
+
+  await page.screenshot({
+    path: "/Users/aniraga/Projects/screenshots/derive-mobile-comment-peek.png",
+  })
+
+  const { paddingBottom, sheetHeight, band } = await deadBandPx(page)
+  // The reserved padding should hug the sheet's real height, not overshoot it.
+  // Allow a small tolerance for the grip/rounding; the bug reserved ~50vh (~380px
+  // of black) above a ~74px peek bar.
+  expect(band, `padding-bottom ${paddingBottom}px vs sheet ${sheetHeight}px`).toBeLessThan(48)
+})

--- a/apps/web/src/pages/artifact/artifact-comments.tsx
+++ b/apps/web/src/pages/artifact/artifact-comments.tsx
@@ -33,6 +33,9 @@ export function ArtifactComments(p: {
    *  reading stays open to any authenticated viewer. */
   canComment: boolean
   reviewCard?: ReactNode
+  /** Phones only: px the comment sheet occupies at the viewport bottom, so the page
+   *  can reserve that under the document (0 when the sheet is closed). */
+  onSheetHeight?: (px: number) => void
   docLive: boolean
   panel: Panel
   asideWidth: number
@@ -170,6 +173,7 @@ export function ArtifactComments(p: {
             onSubmitNew={p.submitNew}
             onCancelNew={cancelNew}
             reviewCard={p.reviewCard}
+            onHeightChange={p.onSheetHeight}
           />
         )}
         {/* Desktop: the "comment on selection" pill floats beside the selection (the

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -38,6 +38,7 @@ export function MobileComments({
   onNewGeneral,
   onSubmitNew,
   onCancelNew,
+  onHeightChange,
 }: {
   open: boolean
   openThreads: Comment[][]
@@ -48,6 +49,10 @@ export function MobileComments({
   onSubmitNew: (text: string, mentions?: Mention[]) => void
   onCancelNew: () => void
   reviewCard?: ReactNode
+  /** How much of the viewport bottom the sheet currently occupies, in px (0 when
+   *  closed). The page reserves exactly this under the document so no black band
+   *  is left below it. */
+  onHeightChange?: (px: number) => void
 }) {
   // Two states only: peek (a slim "Comments (N)" bar — the default) and full (the
   // list). Composing overrides both with a compact composer bar pinned above the
@@ -101,6 +106,35 @@ export function MobileComments({
   useEffect(() => {
     if (!composer) (document.activeElement as HTMLElement | null)?.blur?.()
   }, [composer])
+  // Report how much of the viewport bottom the sheet occupies so the page can
+  // reserve exactly that under the document — no more, no less. A static reserve
+  // (the old `pb-[50vh]`) left a tall black band below the document whenever the
+  // sheet rested at its slim peek height. Measuring the sheet's top to the layout-
+  // viewport bottom folds in every state: the open/close slide (a transform), the
+  // peek<->full height change, and the keyboard-pinned composer (its inset is
+  // included). A rAF loop while open tracks it frame-accurately (idle cost is one
+  // cheap fixed-element rect read per frame); closed reports 0 and stops.
+  useEffect(() => {
+    if (!open) {
+      onHeightChange?.(0)
+      return
+    }
+    let raf = 0
+    let last = -1
+    const tick = () => {
+      const el = sheetRef.current
+      if (el) {
+        const inset = Math.max(0, Math.round(window.innerHeight - el.getBoundingClientRect().top))
+        if (inset !== last) {
+          last = inset
+          onHeightChange?.(inset)
+        }
+      }
+      raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [open, onHeightChange])
   const empty = openThreads.length === 0 && resolved.length === 0 && !composer
   // The grip toggles peek <-> full.
   const grip = () => setSize((s) => (s === "peek" ? "full" : "peek"))

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -131,6 +131,9 @@ export function Artifact() {
   const [restoring, setRestoring] = useState(false)
   const [reader, setReader] = useState(false)
   const [src, setSrc] = useState("")
+  // Phones: px the comment sheet occupies at the bottom, reported by MobileComments.
+  // The document column reserves exactly this so nothing black is left beneath it.
+  const [sheetInset, setSheetInset] = useState(0)
   // Editable title while editing (seeded from the artifact in startEdit); editors
   // can rename, and it republishes with the new name.
   const [editTitle, setEditTitle] = useState("")
@@ -603,13 +606,16 @@ export function Artifact() {
                 under the toolbar rather than beside it. */}
         <div className="flex min-h-0 flex-1">
           <div
-            className={cn(
-              // On phones, the comments sheet sits in the bottom half — reserve
-              // that space so the document stays visible above it (and a
-              // jumped-to highlight lands in view, not behind the sheet).
-              "relative flex min-w-0 flex-1 flex-col transition-[padding] duration-200",
-              isMobile && !focus && panel === "open" && "pb-[50vh]",
-            )}
+            className="relative flex min-w-0 flex-1 flex-col"
+            // On phones the comments sheet sits at the bottom — reserve exactly the
+            // space it occupies so the document stays visible above it (and a
+            // jumped-to highlight lands in view, not behind the sheet), with no
+            // black band below. `sheetInset` tracks the sheet's real height (peek
+            // bar, full list, or keyboard-pinned composer), so this never over- or
+            // under-reserves the way a fixed `pb-[50vh]` did.
+            style={
+              isMobile && !focus && panel === "open" ? { paddingBottom: sheetInset } : undefined
+            }
           >
             {art.bundle && !editing && (
               <BundleBar bundle={art.bundle} shortId={shortId} version={shown} />
@@ -688,6 +694,7 @@ export function Artifact() {
                 // Top of the comments rail, not its own pane; members who can act only.
                 canComment ? <ReviewCard shortId={shortId} canApprove={canPublish} /> : undefined
               }
+              onSheetHeight={setSheetInset}
               docLive={docLive}
               panel={panel}
               asideWidth={asideWidth}


### PR DESCRIPTION
## Problem

After posting a comment on a phone, the document left a tall **black dead-band** below itself (see the reported screenshot). The document column reserved a fixed `pb-[50vh]` whenever the comment panel was open — but the sheet rests at its slim **~74px "peek"** height (the state you land in right after submit / collapse), so ~half the viewport of padding sat empty over the app background.

Reproduced through the existing Pixel 7 e2e harness: the document reserved **419.5px** of padding above a **74px** sheet → a **345.5px** black band.

| Before | After |
|---|---|
| ~345px black band under the doc | document fills down to the peek bar |

## Fix

`MobileComments` now reports how much of the viewport bottom it actually occupies — measured from the sheet's top to the layout-viewport bottom, so the **peek bar, full list, and keyboard-pinned composer** are all covered — tracked frame-accurately by a rAF loop while open. The document column reserves *exactly* that (`paddingBottom: sheetInset`) instead of guessing `50vh`, so the reserved space always hugs the sheet with nothing black beneath it, in every state.

- `comment-panels.tsx` — publish real occupied height (`onHeightChange`)
- `artifact-comments.tsx` — thread it through (`onSheetHeight`)
- `index.tsx` — reserve the measured inset

## Testing

- New regression test drives the real Pixel 7 comment flow and asserts the reserved padding hugs the sheet height (old code left ~345px of dead-band).
- All 3 existing mobile comment specs pass.
- Typecheck, biome, and every precommit lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)