### PR TITLE
chore(auth): extend OAuth access-token TTL from 1h to 24h

### DIFF
--- a/apps/api/src/auth-config.ts
+++ b/apps/api/src/auth-config.ts
@@ -202,7 +202,12 @@ export function makeAuth(db: AuthDb, baseUrl: string, secret: string, hooks: Aut
         // endpoint is rate-limited (/api/auth/*) and a client is inert until a human
         // consents, so the only surface is spam client rows.
         allowUnauthenticatedClientRegistration: true,
-        accessTokenExpiresIn: 60 * 60, // 1h
+        // 24h, not the textbook 1h: these are opaque tokens resolved by DB hash on
+        // every request (see storeTokens below), so revocation is immediate no matter
+        // the TTL - the short-expiry rationale for bearer JWTs doesn't apply. A day
+        // saves agent CLIs (sessions typically hours apart) a refresh round-trip per
+        // session; the rotating refresh token below still bounds abandoned clients.
+        accessTokenExpiresIn: 60 * 60 * 24, // 24h
         // Refresh tokens rotate + reset their window on every use (see createUserTokens),
         // so this is an INACTIVITY timeout, not a hard cap: active clients (MCP, browser)
         // never re-auth; you only re-consent after 30 days of no use.


### PR DESCRIPTION
## Why

Agent/MCP CLI sessions are typically hours apart, so with a 1h access-token TTL nearly every session starts on an expired token and pays a refresh round-trip (with rotation bookkeeping) before doing anything.

The standard short-TTL rationale doesn't apply to Derive's tokens: they are **opaque, stored hashed, and resolved by DB lookup on every request** (`storeTokens` + context.ts bridge), so revocation is immediate no matter the TTL. Deleting the token row kills a stolen token instantly; a 24h expiry only bounds tokens nobody noticed leaking, and the rotating 30d refresh window still expires abandoned clients.

## Change

- `accessTokenExpiresIn`: 1h -> 24h, with a comment recording the reasoning.
- Refresh TTL (30d idle, rotating) unchanged.

## Testing

- `pnpm --filter @derive/api typecheck` clean (node + worker tsconfigs)
- Full api suite: 85 files / 623 tests pass, including `oauth.test.ts` and `oauth-refresh-rotation.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)