### PR TITLE
Pilot polish: sonnet default, GFM answers, copy-as-markdown

### DIFF
--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -19,9 +19,11 @@ RUNNER_CWD=/path/to/repo     # where claude runs — its .mcp.json supplies the 
 pnpm --filter @derive/runner start
 ```
 
-Optional: `RUNNER_POLL_MS` (default 5000), `RUNNER_TIMEOUT_MS` (default 600000),
-`CLAUDE_BIN`, and `RUNNER_MOCK=1` (skip Claude, post a canned answer — wiring
-smoke test).
+Optional: `RUNNER_MODEL` (default `sonnet` — an asker is waiting, and data Q&A
+is tool-call-bound, so latency beats depth; set `opus` for harder analytical
+contexts), `RUNNER_POLL_MS` (default 5000), `RUNNER_TIMEOUT_MS` (default
+600000), `CLAUDE_BIN`, and `RUNNER_MOCK=1` (skip Claude, post a canned answer —
+wiring smoke test).
 
 Register the agent as **editor** if the context should publish charts: answers
 can carry a visual the runner publishes as an artifact, and publishing needs

--- a/packages/runner/src/claude.ts
+++ b/packages/runner/src/claude.ts
@@ -120,6 +120,7 @@ export function parseAnswer(text: string): { answer?: RunnerAnswer; error?: stri
 export interface ClaudeOpts {
   bin: string
   cwd: string
+  model: string
   timeoutMs: number
   systemPrompt: string
   prompt: string
@@ -131,6 +132,8 @@ export function runClaude(opts: ClaudeOpts): Promise<RunResult> {
   const args = [
     "-p",
     opts.prompt,
+    "--model",
+    opts.model,
     "--output-format",
     "stream-json",
     "--verbose",

--- a/packages/runner/src/config.ts
+++ b/packages/runner/src/config.ts
@@ -12,6 +12,10 @@ export interface RunnerConfig {
   /** Where `claude -p` runs — the repo whose .mcp.json/tools the answers need. */
   cwd: string
   claudeBin: string
+  /** Model for answer runs. Defaults to sonnet: an asker is sitting in the
+   *  console waiting, and data Q&A is tool-call-bound — latency buys more here
+   *  than the top model's depth does. RUNNER_MODEL overrides per context. */
+  model: string
   timeoutMs: number
   pollMs: number
   /** Skip Claude and post a canned answer — verifies the wiring without a model. */
@@ -38,6 +42,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): RunnerConfig {
     contextId,
     cwd: env.RUNNER_CWD ?? process.cwd(),
     claudeBin: env.CLAUDE_BIN ?? "claude",
+    model: env.RUNNER_MODEL ?? "sonnet",
     timeoutMs: positiveMs(env.RUNNER_TIMEOUT_MS, 600_000, 10_000),
     pollMs: positiveMs(env.RUNNER_POLL_MS, 5_000, 500),
     mock: env.RUNNER_MOCK === "1",

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -33,6 +33,7 @@ async function serveSession(
     : await runClaude({
         bin: cfg.claudeBin,
         cwd: cfg.cwd,
+        model: cfg.model,
         timeoutMs: cfg.timeoutMs,
         systemPrompt: manifest,
         prompt: buildPrompt(session.messages),
@@ -101,7 +102,7 @@ async function main(): Promise<void> {
   if (!info.manifest_md) throw new Error("context has no readable manifest")
   console.log(
     `[runner] serving "${info.name}" (${cfg.contextId}) — manifest v${info.manifest_version}, ` +
-      `${cfg.mock ? "MOCK" : cfg.claudeBin}, poll ${cfg.pollMs}ms`,
+      `${cfg.mock ? "MOCK" : `${cfg.claudeBin} (${cfg.model})`}, poll ${cfg.pollMs}ms`,
   )
 
   for (;;) {


### PR DESCRIPTION
Three pilot-feedback items in one small PR:

- **RUNNER_MODEL, defaulting to sonnet** — an asker is waiting in the console and data Q&A is tool-call-bound; latency beats depth. Override per context (`RUNNER_MODEL=opus`) for heavier analytical workloads. The serving log line names the model.
- **Answers render as full GFM** — models write tables and fenced code, which the comment-grade inline renderer can't carry. Agent messages go through marked + the xss whitelist (the same pipeline core/md.ts uses for artifacts, mirrored so the sandbox doc-shell stays out of the bundle; budget clean). Unit tests cover tables/fences rendering + script/handler/style stripping.
- **Copy-as-markdown** on every answer — copies the source `body_md`, not rendered text, since answers travel onward into docs/Slack/PRs. Verified with a clipboard round-trip against the running app (exact match), plus a screenshot of a table+fence answer rendering on-brand.