### PR TITLE
Console: answers render as full GFM + copy-as-markdown

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,6 +35,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "lucide-react": "^1.18.0",
+    "marked": "^18.0.5",
     "next-themes": "^0.4.6",
     "radix-ui": "^1.6.1",
     "react": "^19.2.7",
@@ -42,7 +43,8 @@
     "shadcn": "^4.12.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
-    "web-vitals": "^5.3.0"
+    "web-vitals": "^5.3.0",
+    "xss": "^1.0.15"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",

--- a/apps/web/src/pages/context/console.tsx
+++ b/apps/web/src/pages/context/console.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, useParams } from "@tanstack/react-router"
+import { Copy as CopyIcon } from "lucide-react"
 import { useEffect, useState } from "react"
 import { ApiError, api, type Session, type SessionMessage, type SessionMeta } from "@/api"
 import { Icon } from "@/components/icons"
@@ -16,6 +17,7 @@ import { contextQuery, contextSessionsQuery, sessionQuery } from "@/lib/queries"
 import { ago } from "@/lib/time"
 import { cn } from "@/lib/utils"
 import { mdToHtml } from "../artifact/lib/markdown"
+import { answerMdToHtml } from "./lib/answer-md"
 
 // The context console: ask, read the answer (with the query/confidence/caveats the
 // runner attaches), follow up. One conversation at a time — older sessions are a
@@ -336,10 +338,36 @@ function safeMeta(meta: SessionMeta | null) {
   }
 }
 
+// GFM chrome for rendered answers, kept local via arbitrary variants (tokens
+// only — the design-token check applies). Tables and fences are the two block
+// forms models actually produce that need styling beyond cmt-body's inline set.
+const ANSWER_PROSE = cn(
+  "text-sm [word-break:break-word] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+  "[&_p]:my-2 [&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-2 [&_ol]:list-decimal [&_ol]:pl-5",
+  "[&_h1]:text-base [&_h1]:font-semibold [&_h2]:text-sm [&_h2]:font-semibold [&_h3]:text-sm [&_h3]:font-medium",
+  "[&_table]:my-2 [&_table]:w-full [&_table]:text-xs",
+  "[&_th]:border-b [&_th]:px-2 [&_th]:py-1.5 [&_th]:text-left [&_th]:font-medium",
+  "[&_td]:border-b [&_td]:border-border/50 [&_td]:px-2 [&_td]:py-1.5 [&_td]:tabular-nums",
+  "[&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-secondary [&_pre]:p-2.5 [&_pre]:font-mono [&_pre]:text-xs",
+  "[&_code]:font-mono [&_code]:text-xs [&_blockquote]:border-l-2 [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground",
+)
+
 function MessageRow({ m, contextName }: { m: SessionMessage; contextName: string }) {
   const [showQuery, setShowQuery] = useState(false)
+  const [copied, setCopied] = useState(false)
   const fromAgent = m.author_kind === "agent"
   const meta = safeMeta(m.meta)
+  // Answers travel onward as markdown (into docs, Slack, a PR) — copy the
+  // SOURCE, not the rendered text.
+  const copyMd = async () => {
+    try {
+      await navigator.clipboard.writeText(m.body_md)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      toast.error("Couldn't copy")
+    }
+  }
   return (
     <div
       data-testid="console-message"
@@ -348,6 +376,18 @@ function MessageRow({ m, contextName }: { m: SessionMessage; contextName: string
       <div className="mb-1 flex items-center gap-2 text-xs text-muted-foreground">
         <span className="font-medium">{fromAgent ? contextName : "You"}</span>
         <span>{ago(m.created_at)}</span>
+        {fromAgent && (
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            data-testid="console-copy-md"
+            aria-label="Copy answer as markdown"
+            onClick={copyMd}
+            className="text-muted-foreground"
+          >
+            {copied ? <Icon name="check" className="text-success" /> : <CopyIcon />}
+          </Button>
+        )}
         {meta.escalation && (
           <Badge variant="outline" data-testid="console-escalated">
             Escalated — {meta.escalation}
@@ -359,11 +399,19 @@ function MessageRow({ m, contextName }: { m: SessionMessage; contextName: string
           </span>
         )}
       </div>
-      <div
-        className="cmt-body text-sm [word-break:break-word]"
-        // biome-ignore lint/security/noDangerouslySetInnerHtml: input is escaped first in mdToHtml.
-        dangerouslySetInnerHTML={{ __html: mdToHtml(m.body_md) }}
-      />
+      {fromAgent ? (
+        <div
+          className={ANSWER_PROSE}
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized in answerMdToHtml (xss whitelist).
+          dangerouslySetInnerHTML={{ __html: answerMdToHtml(m.body_md) }}
+        />
+      ) : (
+        <div
+          className="cmt-body text-sm [word-break:break-word]"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: input is escaped first in mdToHtml.
+          dangerouslySetInnerHTML={{ __html: mdToHtml(m.body_md) }}
+        />
+      )}
       {meta.artifacts.length > 0 && (
         <div className="mt-2 flex flex-wrap gap-1.5">
           {meta.artifacts.map((a) => (

--- a/apps/web/src/pages/context/lib/answer-md.test.ts
+++ b/apps/web/src/pages/context/lib/answer-md.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import { answerMdToHtml } from "./answer-md"
+
+describe("answerMdToHtml", () => {
+  it("renders GFM tables and fenced code (what the comment renderer can't)", () => {
+    const md = "| Provider | Orgs |\n|---|---:|\n| Stripe | 2,739 |\n\n```sql\nselect 1\n```"
+    const html = answerMdToHtml(md)
+    expect(html).toContain("<table>")
+    expect(html).toContain('<td align="right">2,739</td>')
+    expect(html).toContain("<pre>")
+    expect(html).toContain("select 1")
+  })
+
+  it("strips scripts, event handlers, and inline style — model output is untrusted", () => {
+    const html = answerMdToHtml(
+      'x\n\n<script>alert(1)</script>\n\n<img src=x onerror=alert(1)>\n\n<p style="position:fixed">y</p>',
+    )
+    expect(html).not.toContain("<script")
+    expect(html).not.toContain("onerror")
+    expect(html).not.toContain("style=")
+  })
+})

--- a/apps/web/src/pages/context/lib/answer-md.ts
+++ b/apps/web/src/pages/context/lib/answer-md.ts
@@ -1,0 +1,29 @@
+import { marked } from "marked"
+// xss is CJS; named ESM imports fail under interop (same note as core/md.ts).
+import xssPkg from "xss"
+
+const { FilterXSS, whiteList } = xssPkg as unknown as typeof import("xss")
+
+// Answers are full GFM (the models write tables, fences, headings), which the
+// comment renderer (mdToHtml — deliberately inline-only) can't carry. Same
+// pipeline as core/md.ts: marked → xss whitelist. Mirrored rather than imported
+// because core's md module drags the sandbox doc-shell + selection script along,
+// none of which belongs in the app bundle.
+const sanitizer = new FilterXSS({
+  whiteList: {
+    ...whiteList,
+    a: ["href", "target", "rel", "title"],
+    code: ["class"],
+    pre: ["class"],
+    th: ["align"],
+    td: ["align"],
+    del: [],
+    sup: [],
+    sub: [],
+  },
+})
+
+/** Render an answer's markdown to sanitized HTML. Sync (no async marked extensions). */
+export function answerMdToHtml(md: string): string {
+  return sanitizer.process(marked.parse(md, { gfm: true, async: false }))
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       lucide-react:
         specifier: ^1.18.0
         version: 1.18.0(react@19.2.7)
+      marked:
+        specifier: ^18.0.5
+        version: 18.0.5
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -191,6 +194,9 @@ importers:
       web-vitals:
         specifier: ^5.3.0
         version: 5.3.0
+      xss:
+        specifier: ^1.0.15
+        version: 1.0.15
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7


### PR DESCRIPTION
The second half of the pilot-polish pair — this commit was pushed to #293's branch moments after it was squash-merged, so it never landed; recovered and re-cut cleanly onto main.

- Agent answers render through marked + the xss whitelist (the artifact pipeline from core/md.ts, mirrored so the sandbox doc-shell stays out of the bundle) — tables with aligned numeric columns, fenced code, blockquotes. Asker messages keep the light inline renderer.
- Copy-as-markdown on every answer: copies the source `body_md` (answers travel onward into docs/Slack/PRs), verified by clipboard round-trip against the running app — byte-exact.
- Unit tests: GFM rendering + script/handler/style stripping (model output is untrusted). Bundle budget clean (deps ride the lazy console chunk).