### PR TITLE
Feat/selfhost previews

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,13 +50,10 @@ DATA_DIR=./data
 # DERIVE_SANDBOX_URL=https://usercontent.example.com
 
 # --- Artifact preview screenshots -----------------------------------------
-# Preview rendering (the OG screenshot at /v1/og/:ref) only runs where a
-# Cloudflare Browser Rendering binding is present (the hosted Workers tier).
-# Self-host / Node deployments do NOT render previews in this release — the
-# render queue is simply never enqueued (renderPreviews stays false in node.ts).
-# A bring-your-own Playwright adapter is a planned follow-up for self-hosters.
-# No env var is needed to disable previews: the absence of the BROWSER binding
-# in wrangler.toml is the switch.
+# Render preview screenshots on this Node deploy (requires a Playwright Chromium —
+# bundled in the Docker image; on a bare Node host run
+# `pnpm --filter @derive/api exec playwright install chromium`).
+# DERIVE_PREVIEWS=true
 
 # Vanity subdomains (domain mode): a base domain whose wildcard (*.<base>) points
 # at this server. An artifact assigned `q3-review.<base>` is then served at that

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -99,7 +99,7 @@ the default role. Sign up at `/login`.
 | `DERIVE_CROSS_SITE` | `false` | `true` for `SameSite=None; Secure` cookies (split deploy only) |
 | `DERIVE_TOKEN` | (none) | Static bearer token for CI/agents. One of the two ways to write (the other is a sign-in session); anonymous callers are always read-only (public/link artifacts), never owners. |
 | `DERIVE_WEB_DIR` | (auto) | Override the bundled SPA path |
-| `DERIVE_PREVIEWS` | `false` | `true` to enable server-side Playwright screenshot generation for share cards (Docker image bundles Chromium; bare-Node hosts must run `playwright install chromium` once) |
+| `DERIVE_PREVIEWS` | `false` | `true` to enable server-side Playwright screenshot generation for share cards (Docker image bundles Chromium; bare-Node hosts must run `playwright install --with-deps chromium` once) |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | (none) | Google sign-in |
 | `OIDC_ISSUER` / `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` / `OIDC_PROVIDER_ID` | (none) | Enterprise SSO |
 
@@ -110,10 +110,13 @@ share cards (Open Graph images, link unfurls).
 
 - **Docker image**: Chromium is already bundled. Set the env var and you're done — no
   extra steps.
-- **Bare-Node host**: run once after install to download the browser binary:
+- **Bare-Node host**: run once after install to download the browser binary **and its
+  system libraries** (`--with-deps` installs the shared libs Chromium needs — libnss3,
+  libatk, etc. — on Debian/Ubuntu; without them the browser fails to launch at runtime):
   ```bash
-  corepack pnpm --filter @derive/api exec playwright install chromium
+  corepack pnpm --filter @derive/api exec playwright install --with-deps chromium
   ```
+  On a non-apt host, install the equivalent system libraries yourself.
 - **`BASE_URL` is required**: the renderer fetches the artifact's `/raw` URL over HTTP, so
   `BASE_URL` must be set to the public origin of the instance (or at least the internal
   origin the Node process can reach itself on). Without it the renderer cannot build the

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -99,8 +99,27 @@ the default role. Sign up at `/login`.
 | `DERIVE_CROSS_SITE` | `false` | `true` for `SameSite=None; Secure` cookies (split deploy only) |
 | `DERIVE_TOKEN` | (none) | Static bearer token for CI/agents. One of the two ways to write (the other is a sign-in session); anonymous callers are always read-only (public/link artifacts), never owners. |
 | `DERIVE_WEB_DIR` | (auto) | Override the bundled SPA path |
+| `DERIVE_PREVIEWS` | `false` | `true` to enable server-side Playwright screenshot generation for share cards (Docker image bundles Chromium; bare-Node hosts must run `playwright install chromium` once) |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | (none) | Google sign-in |
 | `OIDC_ISSUER` / `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` / `OIDC_PROVIDER_ID` | (none) | Enterprise SSO |
+
+### Preview screenshots (optional)
+
+Set `DERIVE_PREVIEWS=true` to enable server-side screenshot generation for artifact
+share cards (Open Graph images, link unfurls).
+
+- **Docker image**: Chromium is already bundled. Set the env var and you're done — no
+  extra steps.
+- **Bare-Node host**: run once after install to download the browser binary:
+  ```bash
+  corepack pnpm --filter @derive/api exec playwright install chromium
+  ```
+- **`BASE_URL` is required**: the renderer fetches the artifact's `/raw` URL over HTTP, so
+  `BASE_URL` must be set to the public origin of the instance (or at least the internal
+  origin the Node process can reach itself on). Without it the renderer cannot build the
+  absolute URL and previews will not be generated.
+
+Preview rendering runs in the same Node process as the API (no sidecar needed).
 
 ### OAuth / SSO (optional)
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -42,7 +42,8 @@
     "kysely": "^0.29.2",
     "pg": "^8.13.1",
     "zod": "^4.4.3",
-    "jose": "^6.1.0"
+    "jose": "^6.1.0",
+    "playwright": "^1.61.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260615.1",

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -66,6 +66,12 @@ export interface Config {
   webDir: string
   webShell: string
   serveWeb: boolean
+  /** Opt-in Node/Playwright preview rendering. When true, startPreviewWorker is
+   *  started in node.ts and render jobs are enqueued on publish. Requires a
+   *  locally-installed Playwright Chromium (bundled in the Docker image; bare Node
+   *  hosts run `pnpm --filter @derive/api exec playwright install chromium`).
+   *  Default false — no rendering on self-host unless explicitly enabled. */
+  previews: boolean
   /** From-address for notification emails (e.g. "Derive <notifications@derive.to>").
    *  Unset ⇒ email notifications are logged, not sent (the zero-config default). */
   emailFrom?: string
@@ -129,6 +135,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     // Comma-separated operator emails (case-insensitive). More than one person
     // can run + host a deployment, so this is a list, not a single owner.
     superAdmins: superAdminsFromEnv(env),
+    previews: env.DERIVE_PREVIEWS === "true",
     analytics: env.DERIVE_ANALYTICS !== "false",
     rateLimit: env.DERIVE_RATE_LIMIT !== "false",
     sandboxOrigin: env.DERIVE_SANDBOX_URL,

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -19,6 +19,8 @@ import { makeSlackSender } from "./lib/slack-comments"
 import { makeShutdown } from "./lifecycle"
 import { log } from "./log"
 import { createNodeSyncRunner } from "./node-sync"
+import { playwrightRenderer } from "./preview-node"
+import { startPreviewWorker } from "./previews"
 import { type ChannelSenders, startWebhookWorker } from "./webhooks"
 import { nodeDnsGuard } from "./webhooks-node"
 
@@ -158,6 +160,20 @@ const channelSenders: ChannelSenders = {
 }
 const webhookWorker = startWebhookWorker(meta, nodeDnsGuard, channelSenders)
 
+// Preview render worker: an in-process interval + poke that renders screenshot jobs via
+// Playwright Chromium. Only started when DERIVE_PREVIEWS=true; when off the render queue
+// is never enqueued (renderPreviews stays false below) and no worker runs.
+const previewWorker = cfg.previews
+  ? startPreviewWorker({
+      meta,
+      blobs,
+      renderer: playwrightRenderer(),
+      baseUrl: cfg.baseUrl,
+      sandboxOrigin: cfg.sandboxOrigin,
+      secret: authSecret,
+    })
+  : undefined
+
 // GitHub-sync runner: drives a triggered sync to completion in-process (detached from
 // the request) so it survives the user navigating away — the self-host counterpart to
 // the edge `RepoSyncRunner` DO. Resumed below on boot + a short interval.
@@ -199,6 +215,9 @@ const app = createApp({
   commentRate: cfg.commentRate,
   // Deliver freshly enqueued events immediately instead of on the next interval.
   pokeWebhooks: webhookWorker.poke,
+  // Enqueue a render job on publish and drain on demand when previews are enabled.
+  renderPreviews: cfg.previews,
+  pokePreviews: previewWorker?.poke,
   // Run a triggered GitHub sync in the background so it survives a closed tab.
   startSync: syncRunner.start,
 })
@@ -291,7 +310,10 @@ const shutdown = makeShutdown({
     closeIdleConnections:
       "closeIdleConnections" in server ? () => server.closeIdleConnections() : undefined,
   },
-  stopWorker: webhookWorker.stop,
+  stopWorker: () => {
+    webhookWorker.stop()
+    previewWorker?.stop()
+  },
   clearTimers: () => {
     if (pruneTimer) clearInterval(pruneTimer)
     clearInterval(syncResumeTimer)

--- a/apps/api/src/preview-node.ts
+++ b/apps/api/src/preview-node.ts
@@ -1,0 +1,21 @@
+import { chromium } from "playwright"
+import type { Renderer, ScreenshotOpts } from "./previews"
+
+/** A Renderer backed by a locally-installed Playwright Chromium. Node self-host only —
+ *  never imported by the edge build. Each screenshot runs in a fresh isolated context. */
+export const playwrightRenderer = (): Renderer => ({
+  screenshot: async (url: string, opts: ScreenshotOpts): Promise<Uint8Array> => {
+    const browser = await chromium.launch({ headless: true })
+    try {
+      const context = await browser.newContext({
+        viewport: { width: opts.width, height: opts.height },
+      })
+      const page = await context.newPage()
+      await page.goto(url, { waitUntil: "networkidle", timeout: opts.timeoutMs })
+      const buf = await page.screenshot({ type: "png", fullPage: !!opts.fullPage })
+      return new Uint8Array(buf)
+    } finally {
+      await browser.close()
+    }
+  },
+})

--- a/apps/api/test/config.test.ts
+++ b/apps/api/test/config.test.ts
@@ -103,6 +103,15 @@ describe("config: field mapping", () => {
     expect(off.rateLimit).toBe(false)
   })
 
+  it("previews defaults false and turns on only when DERIVE_PREVIEWS='true'", () => {
+    // Default: unset → false
+    expect(loadConfig({ ...base }).previews).toBe(false)
+    // Explicitly false → still false
+    expect(loadConfig({ ...base, DERIVE_PREVIEWS: "false" }).previews).toBe(false)
+    // Opt-in → true
+    expect(loadConfig({ ...base, DERIVE_PREVIEWS: "true" }).previews).toBe(true)
+  })
+
   it("parses superAdmins as a trimmed, lowercased, comma-separated list", () => {
     const c = loadConfig({ ...base, DERIVE_SUPERADMIN_EMAILS: " Amy@X.com , bob@y.com ,," })
     expect(c.superAdmins).toEqual(["amy@x.com", "bob@y.com"])

--- a/apps/api/test/preview-token.test.ts
+++ b/apps/api/test/preview-token.test.ts
@@ -11,7 +11,8 @@ import { signPreviewToken, verifyPreviewToken } from "../src/lib/preview-token"
 // ---- Unit tests: token sign/verify -----------------------------------------
 
 describe("preview token", () => {
-  const secret = "s3cr3t-long-enough"
+  // A throwaway HMAC key for the sign/verify tests, not a real credential.
+  const secret = "s3cr3t-long-enough" // gitleaks:allow
 
   it("verifies before expiry", async () => {
     const exp = 10_000

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -9,6 +9,13 @@ COPY . .
 # better-sqlite3 v11 ships prebuilt binaries; pg is pure JS — no compiler needed.
 RUN pnpm install --frozen-lockfile --prod=false
 
+# Install Playwright's Chromium + its OS libraries (apt) so DERIVE_PREVIEWS=true works
+# out of the box. --with-deps installs the system libraries that Chromium requires
+# (libnss3, libatk, etc.) via apt — fine here because the base image is Debian slim
+# and we're running as root. PLAYWRIGHT_BROWSERS_PATH stays at the default (~/.cache/ms-playwright)
+# which the runtime Node process (also root) resolves identically at startup.
+RUN corepack pnpm --filter @derive/api exec playwright install --with-deps chromium
+
 # Build the SPA into apps/web/dist/client. VITE_DERIVE_API is intentionally unset
 # so the bundle calls the API same-origin (no CORS, no cross-site cookies). The
 # Node entry auto-detects this build and serves it. ipv4first keeps TanStack

--- a/docs/plans/preview-selfhost.md
+++ b/docs/plans/preview-selfhost.md
@@ -1,0 +1,58 @@
+# Self-host preview rendering (Playwright)
+
+Status: design · 2026-07-05 · branch `feat/preview-selfhost` (stacked on `feat/artifact-previews`)
+
+## Problem
+
+Preview screenshots render only on the hosted Cloudflare tier (the `PreviewRenderer` Durable Object + Cloudflare Browser Rendering). Self-hosted Node deployments have no renderer: `renderPreviews` is unset, so no jobs are enqueued and no previews are ever produced. Self-hosters should be able to turn previews on.
+
+## What already exists (base branch)
+
+- `apps/api/src/previews.ts` — the runtime-neutral worker: `Renderer` port, `runRenderTick(deps)`, `startPreviewWorker(deps, intervalMs)`, and `RenderTickDeps { meta, blobs, renderer, baseUrl, sandboxOrigin?, secret }`. `runRenderTick` already mints the `pv` token and builds the `/raw?pv=` URL, so a renderer only implements `screenshot(url, opts)`.
+- The Cloudflare adapter (`preview-cf.ts`) is the reference shape.
+- `AppDeps.renderPreviews` / `pokePreviews` already gate enqueue + wake the worker.
+
+## Goal
+
+A Node/Playwright renderer, wired in `node.ts`, opt-in via env, with Chromium bundled in the Docker image so it works out of the box.
+
+## Non-goals
+
+- Changing the render pipeline, queue, or token (all reused unchanged).
+- Enabling previews by default on self-host (Chromium is heavy; opt-in only).
+- A remote-browser (`DERIVE_BROWSER_WS`) option — can be added later behind the same port.
+
+## Architecture
+
+### The adapter (Task 1)
+
+`apps/api/src/preview-node.ts` (Node-only; imported ONLY by `node.ts`, never by the edge build): `playwrightRenderer()` returns a `Renderer` whose `screenshot(url, opts)` launches Chromium via Playwright, renders in an isolated context, and returns PNG bytes:
+
+- Launch a shared `chromium` browser lazily on first use (or per call — start per-call for correctness, matching `preview-cf.ts` which launches per screenshot; a warm singleton is a later optimization). Use an isolated `browser.newContext()` with no shared state, `setViewportSize({ width, height })`, `page.goto(url, { waitUntil: "networkidle", timeout: opts.timeoutMs })`, `page.screenshot({ type: "png", fullPage: !!opts.fullPage })`, and close the context/browser in `finally`. Constrain the context (no persistent storage).
+- `playwright` is added to `apps/api` dependencies (Chromium binary provided by the image; see Task 2).
+
+### Node wiring (Task 1)
+
+In `apps/api/src/node.ts`, mirror the webhook-worker wiring:
+
+- Add a config flag: `config.ts` gains `previews: boolean` from `DERIVE_PREVIEWS === "true"` (default false). Follow the existing optional-flag pattern (`analytics`, `rateLimit`).
+- When `cfg.previews`: build `const previewWorker = startPreviewWorker({ meta, blobs, renderer: playwrightRenderer(), baseUrl: cfg.baseUrl, sandboxOrigin: cfg.sandboxOrigin, secret: authSecret })`, and pass `renderPreviews: true` + `pokePreviews: previewWorker.poke` into `createApp`. When off, leave `renderPreviews` unset (today's behavior) and don't start the worker or import Playwright at module load (import it lazily inside the enabled branch, or top-level is fine since node.ts is Node-only).
+- Add `previewWorker.stop()` to the shutdown sequence alongside `webhookWorker.stop()`.
+
+### Docker (Task 2)
+
+`deploy/Dockerfile`: after installing node deps, run `pnpm --filter @derive/api exec playwright install --with-deps chromium` (or the equivalent for the image's base) so the Chromium binary + its OS libs are present. Keep this in the image that self-hosters run. Document in `.env.example` / DEPLOY.md that previews are enabled with `DERIVE_PREVIEWS=true` and require the bundled Chromium (present in the Docker image; non-Docker Node hosts run `playwright install chromium` once).
+
+## Security & isolation
+
+Same model as hosted: the renderer loads gated `/raw` via the short-lived `pv` token that `runRenderTick` mints (the adapter does nothing token-related). Render untrusted artifact HTML in an isolated, ephemeral browser context with no shared cookies/storage; the container's network egress is the operator's to constrain.
+
+## Testing
+
+- The real browser is not unit-tested (mirrors how the CF adapter is deploy/smoke-verified). Unit-test the WIRING: with `DERIVE_PREVIEWS=true`, `node.ts`'s app-construction path sets `renderPreviews: true` and starts a worker; with it unset, it does not. Test with a fake renderer / by asserting the config + deps, not by launching Chromium.
+- `config.ts`: `DERIVE_PREVIEWS=true` → `previews: true`; unset/other → false.
+- A local smoke test (documented, not CI): `DERIVE_PREVIEWS=true` self-host, publish an HTML artifact, confirm `/v1/og/:ref` returns a PNG.
+
+## Rollout
+
+Independent PR targeting `feat/artifact-previews`. Off by default, so it changes nothing for existing self-host deployments until `DERIVE_PREVIEWS=true` is set.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       pg:
         specifier: ^8.13.1
         version: 8.21.0
+      playwright:
+        specifier: ^1.61.0
+        version: 1.61.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
# Self-host preview rendering (Playwright)

Stacked on `feat/artifact-previews` (merge that first). Lets self-hosted Node deployments render preview screenshots, which until now only worked on the hosted Cloudflare tier.

## What & why

Previews render via a browser, and the hosted path uses Cloudflare Browser Rendering (a Durable Object). Self-host had no renderer, so `renderPreviews` was off and no screenshots were produced. This adds a Playwright/Chromium renderer for Node, opt-in via `DERIVE_PREVIEWS=true`.

## How it works

- **Reuses everything**: the `Renderer` port, `runRenderTick`, and `startPreviewWorker` from the base branch. `runRenderTick` already mints the short-lived `pv` token and builds the `/raw?pv=` URL, so the new adapter only implements `screenshot(url, opts)`.
- **`apps/api/src/preview-node.ts`** (Node-only leaf): `playwrightRenderer()` launches headless Chromium, renders in a fresh isolated context, returns PNG bytes, and closes the browser on every path.
- **`node.ts` wiring** mirrors the webhook worker: when `DERIVE_PREVIEWS=true`, it starts a preview worker with the Playwright renderer, sets `renderPreviews`/`pokePreviews`, and stops it on shutdown. Off by default → zero behavior change.
- **Docker**: the image runs `playwright install --with-deps chromium`, so `DERIVE_PREVIEWS=true` works out of the box. Bare-Node hosts run that command once (documented in DEPLOY.md); `BASE_URL` must be set.

## Edge safety

`playwright` is Node-only and confined to `preview-node.ts`, imported only by `node.ts`. It never reaches the Workers build: the worker entry (`worker.ts` → `preview-do` → `preview-cf`/`previews`) touches no `playwright`, and `tsconfig.worker.json` excludes `preview-node.ts`. Both typecheck configs pass.

## Testing

- 1215 tests passing; `tsc` clean for `@derive/api` (base + worker configs) and `@derive/web`; Biome + schema-check green.
- New: config test for the `DERIVE_PREVIEWS` flag (unset/false/true). The real browser isn't unit-tested (same as the Cloudflare adapter); the `renderPreviews` gating is covered by the base branch's `preview-trigger` test.
- The Docker Chromium install is verified by inspection; a real `docker build` + a `DERIVE_PREVIEWS=true` smoke test (publish → `/v1/og` returns a PNG) is the deployer's verification step.

## Notes

- Off by default, so existing self-host deployments are unaffected until they set `DERIVE_PREVIEWS=true`.
- A remote-browser option (`DERIVE_BROWSER_WS`) can be added later behind the same `Renderer` port if scaled self-host needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
