### PR TITLE
feat(api): consent-screen workspace picker for OAuth grants

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,10 @@ as you would; a lower-scoped one reads and proposes.
 Or drive it from the CLI:
 
 ```bash
-node packages/cli/bin/derive.js login      # OAuth sign-in
-node packages/cli/bin/derive.js publish    # share a versioned URL
-node packages/cli/bin/derive.js comments   # read the review threads, then revise and publish again
+npm i -g @derive-to/cli
+derive login       # OAuth sign-in
+derive publish     # share a versioned URL
+derive comments    # read the review threads, then revise and publish again
 ```
 
 MCP tools (five): `list_artifacts` (find), `read` (content), `catch_up` (what changed
@@ -149,10 +150,9 @@ plus the open feedback and version history), `comment` (leave/reply/resolve), an
 otherwise (or with `for_review:true`) it files a proposal a human approves. Full loop in
 [packages/mcp/SKILL.md](packages/mcp/SKILL.md).
 
-> The MCP server is on npm — connect a local agent with `npx -y @derive-to/mcp`
-> (set `DERIVE_SERVER`, and `DERIVE_TOKEN` for a static bearer). The `@derive-to/cli`
-> package isn't published yet — run the CLI from the repo (`node packages/cli/bin/derive.js`)
-> until it lands.
+> Both are on npm: `npm i -g @derive-to/cli` gives you the `derive` command, and
+> `npx -y @derive-to/mcp` connects a local agent over stdio (set `DERIVE_SERVER`,
+> and `DERIVE_TOKEN` for a static bearer).
 
 ## Embeds and unfurls
 

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -344,7 +344,7 @@ export function buildContext(deps: AppDeps) {
           const want = c.req.header("x-derive-workspace")
           if (want && want !== a.org_id) {
             const m = await meta.getMembership(want, owner)
-            if (m) a = { ...a, org_id: want, role: capRole(o.scopeRole, m.role) ?? "viewer" }
+            if (m) a = { ...a, org_id: want, role: capRole(o.scopeRole, m.role) }
           }
         }
       }

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -338,10 +338,14 @@ export function buildContext(deps: AppDeps) {
           // membership, re-homes the agent record itself — so activeWorkspace AND
           // every authorize() comparison agree on the target. Fail-closed: an
           // unknown or foreign id keeps the grant's default workspace. Registered
-          // workspace agents (no granting user) never roam.
+          // workspace agents (no granting user) never roam. The role is re-capped
+          // from the uncapped scope role against the TARGET's membership — the
+          // owner may hold a different role there than in the default workspace.
           const want = c.req.header("x-derive-workspace")
-          if (want && want !== a.org_id && (await meta.getMembership(want, owner)))
-            a = { ...a, org_id: want }
+          if (want && want !== a.org_id) {
+            const m = await meta.getMembership(want, owner)
+            if (m) a = { ...a, org_id: want, role: capRole(o.scopeRole, m.role) ?? "viewer" }
+          }
         }
       }
     }

--- a/apps/api/src/lib/oauth-agent.ts
+++ b/apps/api/src/lib/oauth-agent.ts
@@ -50,8 +50,10 @@ export function makeOauthAgent({ meta, auth, baseUrl, provisionPersonal }: Oauth
     email: string | null,
     name: string | null,
   ): Promise<{ org: string; memberRole: Role }> => {
-    const mine = await meta.listWorkspaces(userId)
-    const bound = clientId ? await meta.getOAuthClientWorkspace(userId, clientId) : null
+    const [mine, bound] = await Promise.all([
+      meta.listWorkspaces(userId),
+      clientId ? meta.getOAuthClientWorkspace(userId, clientId) : null,
+    ])
     const target = bound ? mine.find((w) => w.id === bound) : undefined
     if (target) return { org: target.id, memberRole: target.role }
     if (mine[0]) return { org: mine[0].id, memberRole: mine[0].role }
@@ -90,10 +92,10 @@ export function makeOauthAgent({ meta, auth, baseUrl, provisionPersonal }: Oauth
           org_id: ws.org,
           name: grant.clientName,
           token: "",
-          // Scopes propose the role; the owner's actual membership caps it. Without
-          // the cap, publish-scoped grants would act as editor in a workspace where
-          // the granting user is only a viewer.
-          role: capRole(scopeRole, ws.memberRole) ?? "viewer",
+          // Scopes propose the role; the owner's membership in the resolved
+          // workspace is the ceiling (a publish scope is not an editorship in a
+          // workspace where the granting user is only a viewer).
+          role: capRole(scopeRole, ws.memberRole),
           created_by: grant.userId,
           created_at: new Date().toISOString(),
         },
@@ -144,7 +146,7 @@ export function makeOauthAgent({ meta, auth, baseUrl, provisionPersonal }: Oauth
         org_id: ws.org,
         name: (await meta.getOAuthClientName(clientId)) || clientId || "An agent",
         token: "",
-        role: capRole(scopeRole, ws.memberRole) ?? "viewer",
+        role: capRole(scopeRole, ws.memberRole),
         created_by: userId,
         created_at: new Date().toISOString(),
       },

--- a/apps/api/src/lib/oauth-agent.ts
+++ b/apps/api/src/lib/oauth-agent.ts
@@ -1,13 +1,17 @@
-import type { AgentRecord, MetaStore, Role } from "@derive/core"
+import { type AgentRecord, capRole, type MetaStore, type Role } from "@derive/core"
 import { createLocalJWKSet, type JWTPayload, jwtVerify } from "jose"
 import type { Auth } from "../auth-config"
 import { sha256 } from "./crypto"
 
 /** What a valid OAuth access token resolves to: the synthetic agent record (a workspace
- *  principal) plus the id of the user who granted the consent. */
+ *  principal) plus the id of the user who granted the consent. `rec.role` is already
+ *  capped by the owner's membership role in `rec.org_id`; `scopeRole` keeps the uncapped
+ *  scope-derived role so an X-Derive-Workspace re-home can re-cap against the TARGET
+ *  workspace's membership instead of compounding caps. */
 export interface OauthAgentResolution {
   rec: AgentRecord
   ownerId: string
+  scopeRole: Role
 }
 
 interface OauthAgentDeps {
@@ -34,15 +38,25 @@ export function makeOauthAgent({ meta, auth, baseUrl, provisionPersonal }: Oauth
         ? "commenter"
         : "viewer"
 
-  // The agent runs in the granting user's workspace, provisioned on first touch
-  // exactly as the user's own first request would (multi mode, lazy).
+  // The workspace the agent runs in, and the owner's membership role there (the
+  // cap on the scope-derived role). Precedence: the workspace the user picked on
+  // the consent screen — keyed (user, client), honored only while they're still a
+  // member — then the first workspace (pre-picker grants), then a personal
+  // workspace provisioned on first touch exactly as the user's own first request
+  // would (multi mode, lazy; the user owns it).
   const oauthWorkspace = async (
     userId: string,
+    clientId: string,
     email: string | null,
     name: string | null,
-  ): Promise<string> => {
+  ): Promise<{ org: string; memberRole: Role }> => {
     const mine = await meta.listWorkspaces(userId)
-    return mine[0]?.id ?? (await provisionPersonal({ id: userId, email: email ?? "", name }))
+    const bound = clientId ? await meta.getOAuthClientWorkspace(userId, clientId) : null
+    const target = bound ? mine.find((w) => w.id === bound) : undefined
+    if (target) return { org: target.id, memberRole: target.role }
+    if (mine[0]) return { org: mine[0].id, memberRole: mine[0].role }
+    const org = await provisionPersonal({ id: userId, email: email ?? "", name })
+    return { org, memberRole: "owner" }
   }
 
   // Our own JWKS (served by the jwt plugin at /api/auth/jwks), read straight from
@@ -66,15 +80,20 @@ export function makeOauthAgent({ meta, auth, baseUrl, provisionPersonal }: Oauth
     const grant = await meta.getOAuthGrant(sha256(token))
     if (grant) {
       if (grant.expiresAt.getTime() <= Date.now()) return null
-      const org = await oauthWorkspace(grant.userId, grant.userEmail, grant.userName)
+      const ws = await oauthWorkspace(grant.userId, grant.clientId, grant.userEmail, grant.userName)
+      const scopeRole = roleFromScopes(grant.scopes)
       return {
         ownerId: grant.userId,
+        scopeRole,
         rec: {
           id: `oauth:${grant.clientId}`,
-          org_id: org,
+          org_id: ws.org,
           name: grant.clientName,
           token: "",
-          role: roleFromScopes(grant.scopes),
+          // Scopes propose the role; the owner's actual membership caps it. Without
+          // the cap, publish-scoped grants would act as editor in a workspace where
+          // the granting user is only a viewer.
+          role: capRole(scopeRole, ws.memberRole) ?? "viewer",
           created_by: grant.userId,
           created_at: new Date().toISOString(),
         },
@@ -115,15 +134,17 @@ export function makeOauthAgent({ meta, auth, baseUrl, provisionPersonal }: Oauth
       .filter(Boolean)
     const clientId = String(claims.azp ?? claims.client_id ?? "")
     const u = (await meta.getUsers([userId]))[0]
-    const org = await oauthWorkspace(userId, u?.email ?? null, u?.name ?? null)
+    const ws = await oauthWorkspace(userId, clientId, u?.email ?? null, u?.name ?? null)
+    const scopeRole = roleFromScopes(scopes)
     return {
       ownerId: userId,
+      scopeRole,
       rec: {
         id: `oauth:${clientId}`,
-        org_id: org,
+        org_id: ws.org,
         name: (await meta.getOAuthClientName(clientId)) || clientId || "An agent",
         token: "",
-        role: roleFromScopes(scopes),
+        role: capRole(scopeRole, ws.memberRole) ?? "viewer",
         created_by: userId,
         created_at: new Date().toISOString(),
       },

--- a/apps/api/src/oauth-consent.ts
+++ b/apps/api/src/oauth-consent.ts
@@ -49,10 +49,12 @@ export function consentHTML(props: {
 }): string {
   const name = esc(props.clientName || "An application")
   const workspaces = props.workspaces ?? []
-  // One workspace needs no choice (it's the resolver's fallback anyway); the
-  // picker only appears when there is a real decision to make.
+  // Rendered (and bound on Approve) even for a single workspace: pinning the
+  // choice keeps the grant from migrating when the user later joins a workspace
+  // that sorts ahead of it in listWorkspaces. Without a clientId there is
+  // nothing to bind, so no picker — a choice we couldn't persist would be lies.
   const picker =
-    workspaces.length > 1
+    workspaces.length > 0 && props.clientId
       ? `<label class="ws-label" for="ws">Workspace this agent acts in</label>
     <select id="ws" class="ws">${workspaces
       .map(
@@ -164,32 +166,41 @@ export function consentHTML(props: {
     var allow = document.getElementById("allow"), deny = document.getElementById("deny"), err = document.getElementById("err");
     // Show our branded "Connected" card, then hand the code back to the client.
     // The auth code is short-lived but a ~1.1s beat is well within its window.
-    function goConnected(to){
+    // With a warning there is no auto-redirect — it would sweep the message away
+    // before it could be read; the manual return link still works.
+    function goConnected(to, warning){
       var card = document.querySelector("main.card");
       if (card) card.innerHTML = CONNECTED;
       var back = document.getElementById("back");
       if (back) back.setAttribute("href", to);
+      if (warning){
+        var w = document.createElement("p");
+        w.className = "err";
+        w.textContent = warning;
+        var done = document.querySelector(".done");
+        if (done) done.appendChild(w);
+        return;
+      }
       setTimeout(function(){ window.location.href = to; }, 1100);
+    }
+    // Saved only AFTER the consent completes: an abandoned or denied consent must
+    // not re-point tokens the client already holds from an earlier grant. There is
+    // no race on the other side — the client can't mint a token until the browser
+    // delivers the code, which happens after this settles.
+    async function saveWorkspace(){
+      var ws = document.getElementById("ws");
+      if (!ws || !CLIENT_ID) return true;
+      try{
+        var b = await fetch("/oauth/consent/workspace", {
+          method:"POST", headers:{"content-type":"application/json"}, credentials:"include",
+          body: JSON.stringify({ client_id: CLIENT_ID, org_id: ws.value })
+        });
+        return b.ok;
+      }catch(e){ return false; }
     }
     async function decide(accept){
       allow.disabled = deny.disabled = true; err.textContent = "";
       try{
-        // Persist the workspace choice BEFORE completing the consent, so the very
-        // first request the client makes with its new token resolves to it. Fail
-        // closed: if the binding can't be saved, don't complete the grant into the
-        // wrong (first-workspace) default.
-        var ws = document.getElementById("ws");
-        if (accept && ws && CLIENT_ID){
-          var b = await fetch("/oauth/consent/workspace", {
-            method:"POST", headers:{"content-type":"application/json"}, credentials:"include",
-            body: JSON.stringify({ client_id: CLIENT_ID, org_id: ws.value })
-          });
-          if (!b.ok){
-            err.textContent = "Couldn't save the workspace choice. Try again.";
-            allow.disabled = deny.disabled = false;
-            return;
-          }
-        }
         var r = await fetch("/api/auth/oauth2/consent", {
           method:"POST", headers:{"content-type":"application/json"},
           credentials:"include", redirect:"manual",
@@ -204,7 +215,12 @@ export function consentHTML(props: {
           to = data && (data.url || data.redirectURI || data.location);
         }
         // On approve, linger on our confirmation; on deny, bounce straight back.
-        if (to){ if (accept) goConnected(to); else window.location.href = to; return; }
+        if (to){
+          if (!accept){ window.location.href = to; return; }
+          var saved = await saveWorkspace();
+          goConnected(to, saved ? "" : "The workspace choice didn't save — this agent will act in your default workspace. Reconnect to change it.");
+          return;
+        }
         err.textContent = (data && (data.error_description || data.error)) || "Something went wrong.";
       }catch(e){ err.textContent = "Network error. Try again."; }
       allow.disabled = deny.disabled = false;

--- a/apps/api/src/oauth-consent.ts
+++ b/apps/api/src/oauth-consent.ts
@@ -35,13 +35,32 @@ const esc = (s: string): string =>
   )
 
 /** The consent page HTML. `query` is the original authorize query string, echoed
- *  back to /oauth2/consent so the plugin can complete the authorization. */
+ *  back to /oauth2/consent so the plugin can complete the authorization. With
+ *  `workspaces` (the signed-in user's, when they have more than one), a picker
+ *  chooses which workspace the grant acts in; Approve persists the choice via
+ *  POST /oauth/consent/workspace before completing the consent. */
 export function consentHTML(props: {
   clientName: string
   scopes: string[]
   query: string
+  clientId?: string
+  workspaces?: { id: string; name: string }[]
+  selected?: string
 }): string {
   const name = esc(props.clientName || "An application")
+  const workspaces = props.workspaces ?? []
+  // One workspace needs no choice (it's the resolver's fallback anyway); the
+  // picker only appears when there is a real decision to make.
+  const picker =
+    workspaces.length > 1
+      ? `<label class="ws-label" for="ws">Workspace this agent acts in</label>
+    <select id="ws" class="ws">${workspaces
+      .map(
+        (w) =>
+          `<option value="${esc(w.id)}"${w.id === props.selected ? " selected" : ""}>${esc(w.name)}</option>`,
+      )
+      .join("")}</select>`
+      : ""
   const items = props.scopes
     .map((s) => {
       const write = WRITE_SCOPES.has(s)
@@ -84,6 +103,11 @@ export function consentHTML(props: {
   h1{font-family:var(--display);font-weight:600;font-size:22px;line-height:1.25;letter-spacing:-.02em;margin:0 0 7px}
   h1 b{color:var(--accent-ink);font-weight:700}
   .sub{color:var(--ink-soft);font-size:13.5px;margin:0 0 18px}
+  .ws-label{display:block;font-family:var(--mono);font-size:10.5px;font-weight:600;letter-spacing:.05em;
+    text-transform:uppercase;color:var(--muted);margin:0 0 6px}
+  select.ws{width:100%;margin:0 0 16px;padding:10px 12px;border:1px solid var(--line);border-radius:11px;
+    background:var(--panel-2);color:var(--ink);font:500 14px var(--sans);cursor:pointer}
+  select.ws:focus{outline:2px solid var(--accent-soft);border-color:var(--accent)}
   ul.scopes{list-style:none;margin:0 0 22px;padding:8px 16px;border:1px solid var(--line);border-radius:14px;background:var(--panel-2)}
   ul.scopes li{display:flex;gap:11px;align-items:flex-start;padding:9px 0;font-size:13.5px;color:var(--ink-soft)}
   ul.scopes li+li{border-top:1px solid var(--line-2)}
@@ -124,6 +148,7 @@ export function consentHTML(props: {
     <div class="brand">${BRAND_PAGE_MARK}<span class="name">Derive</span><span class="badge">Authorize</span></div>
     <h1><b>${name}</b> wants to act in your workspace</h1>
     <p class="sub">Approving lets this agent do the following as you, with a token that expires. You stay in control.</p>
+    ${picker}
     <ul class="scopes">${items}</ul>
     <div class="row">
       <button id="deny" class="btn ghost" type="button">Deny</button>
@@ -134,6 +159,7 @@ export function consentHTML(props: {
   </main>
   <script>
     var query = ${JSON.stringify(props.query)};
+    var CLIENT_ID = ${JSON.stringify(props.clientId ?? "")};
     var CONNECTED = ${JSON.stringify(connectedInner)};
     var allow = document.getElementById("allow"), deny = document.getElementById("deny"), err = document.getElementById("err");
     // Show our branded "Connected" card, then hand the code back to the client.
@@ -148,6 +174,22 @@ export function consentHTML(props: {
     async function decide(accept){
       allow.disabled = deny.disabled = true; err.textContent = "";
       try{
+        // Persist the workspace choice BEFORE completing the consent, so the very
+        // first request the client makes with its new token resolves to it. Fail
+        // closed: if the binding can't be saved, don't complete the grant into the
+        // wrong (first-workspace) default.
+        var ws = document.getElementById("ws");
+        if (accept && ws && CLIENT_ID){
+          var b = await fetch("/oauth/consent/workspace", {
+            method:"POST", headers:{"content-type":"application/json"}, credentials:"include",
+            body: JSON.stringify({ client_id: CLIENT_ID, org_id: ws.value })
+          });
+          if (!b.ok){
+            err.textContent = "Couldn't save the workspace choice. Try again.";
+            allow.disabled = deny.disabled = false;
+            return;
+          }
+        }
         var r = await fetch("/api/auth/oauth2/consent", {
           method:"POST", headers:{"content-type":"application/json"},
           credentials:"include", redirect:"manual",

--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -63,12 +63,18 @@ export const oauthRoutes = (ctx: AppContext) => {
     const clientId = c.req.query("client_id") ?? ""
     const scopes = (c.req.query("scope") ?? "").split(/\s+/).filter(Boolean)
     const clientName = (await meta.getOAuthClientName(clientId)) || clientId || "An application"
-    // The signed-in user's workspaces feed the picker (rendered only when there's
-    // a real choice); their active workspace — the one they're looking at in the
-    // app — is the preselection.
     const me = await currentUser(c)
     const mine = me ? await meta.listWorkspaces(me.id) : []
-    const selected = me && mine.length > 1 ? await activeWorkspace(c) : mine[0]?.id
+    // An existing (user, client) binding wins the preselection — re-consent must
+    // not re-point a deliberate earlier choice to whatever workspace the browser
+    // happens to be viewing. Only then the active workspace, then the first.
+    const bound = me && clientId ? await meta.getOAuthClientWorkspace(me.id, clientId) : null
+    const selected =
+      bound && mine.some((w) => w.id === bound)
+        ? bound
+        : mine.length > 1
+          ? await activeWorkspace(c)
+          : mine[0]?.id
     return c.html(
       consentHTML({
         clientName,
@@ -82,10 +88,17 @@ export const oauthRoutes = (ctx: AppContext) => {
   })
 
   // Persist the consent screen's workspace choice: this user's grants to this
-  // client act in org_id (resolved by oauthWorkspace, membership re-checked on
-  // every request). Session-only and membership-validated, so a hostile page
-  // can't bind someone else's client or a foreign workspace.
+  // client act in org_id. The binding is keyed by the session user, so it can
+  // only ever affect the caller's own grants; org_id is membership-checked.
   app.post("/oauth/consent/workspace", async (c) => {
+    // Strict same-origin. The consent page is served from this origin, so its
+    // fetch always carries a matching Origin header; a cross-site page never can
+    // — and in DERIVE_CROSS_SITE deployments the session cookie is SameSite=None,
+    // so without this check a text/plain form could smuggle a JSON body here
+    // with the victim's cookie attached.
+    const origin = c.req.header("origin")
+    if (!origin || origin !== new URL(c.req.url).origin)
+      return fail(c, 403, "cross-origin request refused")
     const me = await currentUser(c)
     if (!me) return fail(c, 401, "sign in to continue")
     const b = await readJson(

--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -1,13 +1,16 @@
 import { type Context, Hono } from "hono"
+import { z } from "zod"
 import { OAUTH_SCOPES } from "../auth-config"
 import type { AppContext } from "../context"
+import { fail, readJson } from "../lib/http"
 import { cliCallbackHTML } from "../oauth-cli-callback"
 import { consentHTML } from "../oauth-consent"
 
 /** OAuth/OIDC discovery at the well-known root, the branded consent + CLI-callback
- *  screens, and the public list of configured social sign-in providers. All read-only. */
+ *  screens, and the public list of configured social sign-in providers. Read-only,
+ *  except the consent screen's workspace binding (POST /oauth/consent/workspace). */
 export const oauthRoutes = (ctx: AppContext) => {
-  const { meta } = ctx
+  const { meta, currentUser, activeWorkspace } = ctx
   const app = new Hono()
 
   // OAuth 2.0 discovery at the well-known root (RFC 8414 + RFC 9728), mirroring
@@ -60,7 +63,39 @@ export const oauthRoutes = (ctx: AppContext) => {
     const clientId = c.req.query("client_id") ?? ""
     const scopes = (c.req.query("scope") ?? "").split(/\s+/).filter(Boolean)
     const clientName = (await meta.getOAuthClientName(clientId)) || clientId || "An application"
-    return c.html(consentHTML({ clientName, scopes, query: new URL(c.req.url).search }))
+    // The signed-in user's workspaces feed the picker (rendered only when there's
+    // a real choice); their active workspace — the one they're looking at in the
+    // app — is the preselection.
+    const me = await currentUser(c)
+    const mine = me ? await meta.listWorkspaces(me.id) : []
+    const selected = me && mine.length > 1 ? await activeWorkspace(c) : mine[0]?.id
+    return c.html(
+      consentHTML({
+        clientName,
+        scopes,
+        query: new URL(c.req.url).search,
+        clientId,
+        workspaces: mine.map((w) => ({ id: w.id, name: w.name })),
+        selected,
+      }),
+    )
+  })
+
+  // Persist the consent screen's workspace choice: this user's grants to this
+  // client act in org_id (resolved by oauthWorkspace, membership re-checked on
+  // every request). Session-only and membership-validated, so a hostile page
+  // can't bind someone else's client or a foreign workspace.
+  app.post("/oauth/consent/workspace", async (c) => {
+    const me = await currentUser(c)
+    if (!me) return fail(c, 401, "sign in to continue")
+    const b = await readJson(
+      c,
+      z.object({ client_id: z.string().min(1), org_id: z.string().min(1) }),
+    )
+    if (b instanceof Response) return b
+    if (!(await meta.getMembership(b.org_id, me.id))) return fail(c, 403, "forbidden")
+    await meta.setOAuthClientWorkspace(me.id, b.client_id, b.org_id)
+    return c.json({ ok: true })
   })
 
   // Hosted callback for the CLI/native OAuth flow (`derive login`). A command-line

--- a/apps/api/test/oauth-agent-role-cap.test.ts
+++ b/apps/api/test/oauth-agent-role-cap.test.ts
@@ -1,0 +1,64 @@
+import type { MetaStore } from "@derive/core"
+import { describe, expect, it } from "vitest"
+import { makeOauthAgent } from "../src/lib/oauth-agent"
+
+// The scope-derived role is a PROPOSAL; the granting user's actual membership in
+// the resolved workspace is the ceiling. Without the cap, a publish-scoped grant
+// bound (or re-homed) to a workspace where its user is only a viewer would act
+// as editor there. Unit-level against a stub store: the resolution logic is pure
+// dispatch over meta, so no app or database is needed.
+describe("oauth agent role capping + consent binding", () => {
+  const grant = {
+    userId: "u1",
+    userEmail: "u@x.test",
+    userName: "U",
+    clientId: "cli",
+    clientName: "Claude",
+    scopes: ["openid", "derive:read", "derive:publish"],
+    expiresAt: new Date(Date.now() + 60_000),
+  }
+  const stub = (over: Record<string, unknown> = {}): MetaStore =>
+    ({
+      getOAuthGrant: async () => grant,
+      listWorkspaces: async () => [
+        { id: "ws_one", name: "One", role: "owner" },
+        { id: "ws_two", name: "Two", role: "viewer" },
+      ],
+      getOAuthClientWorkspace: async () => null,
+      ...over,
+    }) as unknown as MetaStore
+
+  const resolve = (meta: MetaStore) =>
+    makeOauthAgent({
+      meta,
+      auth: undefined,
+      baseUrl: "http://derive.test",
+      provisionPersonal: async () => "ws_personal",
+    }).oauthAgent("tok")
+
+  it("keeps the scope role where the membership allows it", async () => {
+    const o = await resolve(stub())
+    expect(o?.rec.org_id).toBe("ws_one")
+    expect(o?.rec.role).toBe("editor") // publish scope, owner membership → editor
+    expect(o?.scopeRole).toBe("editor")
+  })
+
+  it("caps the scope role by the membership in the bound workspace", async () => {
+    const o = await resolve(stub({ getOAuthClientWorkspace: async () => "ws_two" }))
+    expect(o?.rec.org_id).toBe("ws_two")
+    expect(o?.rec.role).toBe("viewer") // publish scope, viewer membership → viewer
+    expect(o?.scopeRole).toBe("editor") // uncapped, for header re-homes to re-cap
+  })
+
+  it("ignores a binding to a workspace the user is no longer in", async () => {
+    const o = await resolve(stub({ getOAuthClientWorkspace: async () => "ws_gone" }))
+    expect(o?.rec.org_id).toBe("ws_one")
+    expect(o?.rec.role).toBe("editor")
+  })
+
+  it("provisions a personal workspace (as owner) when the user has none", async () => {
+    const o = await resolve(stub({ listWorkspaces: async () => [] }))
+    expect(o?.rec.org_id).toBe("ws_personal")
+    expect(o?.rec.role).toBe("editor")
+  })
+})

--- a/apps/api/test/oauth-consent.test.ts
+++ b/apps/api/test/oauth-consent.test.ts
@@ -37,6 +37,39 @@ describe("oauth consent screen", () => {
     expect(evil).toContain("&lt;script&gt;")
   })
 
+  it("renders the workspace picker when the user has more than one workspace", () => {
+    const multi = consentHTML({
+      clientName: "Claude Code",
+      scopes: ["openid"],
+      query: "",
+      clientId: "cli_1",
+      workspaces: [
+        { id: "w1", name: "Personal" },
+        { id: "w2", name: "Acme <evil>" },
+      ],
+      selected: "w2",
+    })
+    expect(multi).toContain('<select id="ws"')
+    expect(multi).toContain('value="w2" selected')
+    expect(multi).toContain("Acme &lt;evil&gt;") // workspace names are escaped
+    expect(multi).toContain('var CLIENT_ID = "cli_1"')
+    // Approve persists the choice before completing the consent, fail-closed.
+    expect(multi).toContain("/oauth/consent/workspace")
+  })
+
+  it("omits the picker when there is no real choice", () => {
+    const single = consentHTML({
+      clientName: "Claude Code",
+      scopes: ["openid"],
+      query: "",
+      clientId: "cli_1",
+      workspaces: [{ id: "w1", name: "Personal" }],
+      selected: "w1",
+    })
+    expect(single).not.toContain('<select id="ws"')
+    expect(html).not.toContain('<select id="ws"') // no workspaces prop at all
+  })
+
   // Emit preview HTML for visual review (both states), when a target dir is given.
   it("writes preview files", () => {
     const dir = process.env.CONSENT_PREVIEW_DIR

--- a/apps/api/test/oauth-consent.test.ts
+++ b/apps/api/test/oauth-consent.test.ts
@@ -20,7 +20,8 @@ describe("oauth consent screen", () => {
     expect(html).toContain("var CONNECTED =")
     expect(html).toContain("function goConnected(")
     // On approve we linger on our card; deny bounces straight back.
-    expect(html).toContain("if (accept) goConnected(to)")
+    expect(html).toContain("if (!accept){ window.location.href = to; return; }")
+    expect(html).toContain("goConnected(to, saved")
     // The success card is embedded JSON-encoded; decode it and assert its markup.
     const connected = JSON.parse(
       (html.match(/var CONNECTED = (".*?");/s)?.[1] as string) ?? '""',
@@ -37,7 +38,7 @@ describe("oauth consent screen", () => {
     expect(evil).toContain("&lt;script&gt;")
   })
 
-  it("renders the workspace picker when the user has more than one workspace", () => {
+  it("renders the workspace picker with the bound/active workspace preselected", () => {
     const multi = consentHTML({
       clientName: "Claude Code",
       scopes: ["openid"],
@@ -53,11 +54,13 @@ describe("oauth consent screen", () => {
     expect(multi).toContain('value="w2" selected')
     expect(multi).toContain("Acme &lt;evil&gt;") // workspace names are escaped
     expect(multi).toContain('var CLIENT_ID = "cli_1"')
-    // Approve persists the choice before completing the consent, fail-closed.
-    expect(multi).toContain("/oauth/consent/workspace")
+    // The binding is saved only after the consent POST succeeds — an abandoned
+    // or denied consent must not re-point tokens from an earlier grant.
+    expect(multi).toContain("var saved = await saveWorkspace()")
+    expect(multi).toContain("goConnected(to, saved")
   })
 
-  it("omits the picker when there is no real choice", () => {
+  it("renders (and binds) a single workspace too — the choice pins the grant", () => {
     const single = consentHTML({
       clientName: "Claude Code",
       scopes: ["openid"],
@@ -66,7 +69,18 @@ describe("oauth consent screen", () => {
       workspaces: [{ id: "w1", name: "Personal" }],
       selected: "w1",
     })
-    expect(single).not.toContain('<select id="ws"')
+    expect(single).toContain('<select id="ws"')
+    expect(single).toContain('value="w1" selected')
+  })
+
+  it("omits the picker when there is nothing to bind", () => {
+    const noClient = consentHTML({
+      clientName: "Claude Code",
+      scopes: ["openid"],
+      query: "",
+      workspaces: [{ id: "w1", name: "Personal" }], // no clientId
+    })
+    expect(noClient).not.toContain('<select id="ws"')
     expect(html).not.toContain('<select id="ws"') // no workspaces prop at all
   })
 

--- a/apps/api/test/oauth-workspace-targeting.test.ts
+++ b/apps/api/test/oauth-workspace-targeting.test.ts
@@ -7,11 +7,10 @@ import { createApp } from "../src/app"
 import { sha256 } from "../src/lib/crypto"
 import { dir, pub, quotaApp } from "./helpers"
 
-// An OAuth agent acts in its granting user's FIRST workspace by default
-// (oauthWorkspace picks mine[0]) — which made it impossible to publish into any
-// other workspace the user belongs to. X-Derive-Workspace overrides the target,
-// validated against the OWNER's membership and fail-closed. Found while
-// publishing the /derive plan into the wrong workspace with no way to move it.
+// Where an OAuth agent acts, in precedence order: the X-Derive-Workspace header
+// (per-request), the consent screen's (user, client) binding, then the granting
+// user's first workspace. Every step is validated against the OWNER's membership
+// and fails closed to the next.
 describe.skipIf(process.env.DERIVE_TEST_DB === "pg")("OAuth agent workspace targeting", () => {
   // One OAuth grant (tok_ws → u_owner) and TWO workspaces the owner belongs to:
   // ws_one (older, the grant's default) and ws_two (the intended target).
@@ -154,7 +153,7 @@ describe.skipIf(process.env.DERIVE_TEST_DB === "pg")("OAuth agent workspace targ
 
   // ---- POST /oauth/consent/workspace (the picker's persistence endpoint) ----
 
-  it("the binding endpoint requires a session and membership in the target", async () => {
+  it("the binding endpoint requires same-origin, a session, and membership", async () => {
     const amy = { id: "u_amy", email: "amy@x.test", name: "Amy" }
     const { app, meta } = quotaApp(
       "ws-bind-endpoint",
@@ -162,18 +161,44 @@ describe.skipIf(process.env.DERIVE_TEST_DB === "pg")("OAuth agent workspace targ
       [amy],
       [{ user_id: "u_amy", role: "editor" }],
     )
+    const sameOrigin = { origin: "http://localhost" } // hono's app.request base
     const post = (headers: Record<string, string>, orgId: string) =>
       app.request("/oauth/consent/workspace", {
         method: "POST",
         headers: { "content-type": "application/json", ...headers },
         body: JSON.stringify({ client_id: "cli", org_id: orgId }),
       })
+    const asAmy = { ...sameOrigin, "x-test-user": "amy@x.test" }
 
-    expect((await post({}, "default")).status).toBe(401) // no session
-    expect((await post({ "x-test-user": "amy@x.test" }, "ws_foreign")).status).toBe(403)
+    // Cross-site posts carry a foreign Origin (or none, from a text/plain form):
+    // both refused even with a live session, since SameSite=None deployments
+    // would otherwise let a hostile page rebind a victim's client.
+    expect((await post({ "x-test-user": "amy@x.test" }, "default")).status).toBe(403)
+    const evil = { ...asAmy, origin: "https://evil.example" }
+    expect((await post(evil, "default")).status).toBe(403)
+
+    expect((await post(sameOrigin, "default")).status).toBe(401) // no session
+    expect((await post(asAmy, "ws_foreign")).status).toBe(403) // not a member
     expect(await meta.getOAuthClientWorkspace("u_amy", "cli")).toBeNull()
 
-    expect((await post({ "x-test-user": "amy@x.test" }, "default")).status).toBe(200)
+    expect((await post(asAmy, "default")).status).toBe(200)
     expect(await meta.getOAuthClientWorkspace("u_amy", "cli")).toBe("default")
+  })
+
+  it("the consent screen preselects an existing binding over the active workspace", async () => {
+    const amy = { id: "u_amy", email: "amy@x.test", name: "Amy" }
+    const { app, meta } = quotaApp(
+      "ws-bind-preselect",
+      {},
+      [amy],
+      [{ user_id: "u_amy", role: "editor" }],
+    )
+    await meta.setOAuthClientWorkspace("u_amy", "cli", "default")
+    const res = await app.request("/oauth/consent?client_id=cli&scope=openid", {
+      headers: { "x-test-user": "amy@x.test" },
+    })
+    expect(res.status).toBe(200)
+    const page = await res.text()
+    expect(page).toContain('value="default" selected')
   })
 })

--- a/apps/api/test/oauth-workspace-targeting.test.ts
+++ b/apps/api/test/oauth-workspace-targeting.test.ts
@@ -5,7 +5,7 @@ import Database from "better-sqlite3"
 import { describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
 import { sha256 } from "../src/lib/crypto"
-import { dir, pub } from "./helpers"
+import { dir, pub, quotaApp } from "./helpers"
 
 // An OAuth agent acts in its granting user's FIRST workspace by default
 // (oauthWorkspace picks mine[0]) — which made it impossible to publish into any
@@ -111,5 +111,69 @@ describe.skipIf(process.env.DERIVE_TEST_DB === "pg")("OAuth agent workspace targ
     expect(res.status).toBe(200)
     const body = (await res.json()) as { workspaces: { id: string; name: string }[] }
     expect(body.workspaces.map((w) => w.id)).toEqual(["ws_one", "ws_two"])
+  })
+
+  // ---- Consent-time workspace binding (the consent screen's picker) ----------
+
+  it("a consent-time binding re-points the grant's default workspace", async () => {
+    const { app, meta } = twoWorkspaceApp("ws-bind-default")
+    await meta.setOAuthClientWorkspace("u_owner", "cli", "ws_two")
+    const res = await pub(app, "<h1>plan</h1>", { title: "Plan" }, undefined, bearer)
+    expect(res.status).toBe(201)
+    const { short_id } = (await res.json()) as { short_id: string }
+    expect((await meta.getByShortId(short_id))?.org_id).toBe("ws_two")
+  })
+
+  it("a binding to a workspace the owner has left falls back to the first", async () => {
+    const { app, meta } = twoWorkspaceApp("ws-bind-stale")
+    await meta.setOAuthClientWorkspace("u_owner", "cli", "ws_gone")
+    const res = await pub(app, "<h1>plan</h1>", { title: "Plan" }, undefined, bearer)
+    expect(res.status).toBe(201)
+    const { short_id } = (await res.json()) as { short_id: string }
+    expect((await meta.getByShortId(short_id))?.org_id).toBe("ws_one")
+  })
+
+  it("X-Derive-Workspace still overrides a consent-time binding", async () => {
+    const { app, meta } = twoWorkspaceApp("ws-bind-header")
+    await meta.setOAuthClientWorkspace("u_owner", "cli", "ws_two")
+    const res = await pub(app, "<h1>plan</h1>", { title: "Plan" }, undefined, {
+      ...bearer,
+      "x-derive-workspace": "ws_one",
+    })
+    expect(res.status).toBe(201)
+    const { short_id } = (await res.json()) as { short_id: string }
+    expect((await meta.getByShortId(short_id))?.org_id).toBe("ws_one")
+  })
+
+  it("re-consent re-points the binding (upsert on user+client)", async () => {
+    const { meta } = twoWorkspaceApp("ws-bind-upsert")
+    await meta.setOAuthClientWorkspace("u_owner", "cli", "ws_one")
+    await meta.setOAuthClientWorkspace("u_owner", "cli", "ws_two")
+    expect(await meta.getOAuthClientWorkspace("u_owner", "cli")).toBe("ws_two")
+  })
+
+  // ---- POST /oauth/consent/workspace (the picker's persistence endpoint) ----
+
+  it("the binding endpoint requires a session and membership in the target", async () => {
+    const amy = { id: "u_amy", email: "amy@x.test", name: "Amy" }
+    const { app, meta } = quotaApp(
+      "ws-bind-endpoint",
+      {},
+      [amy],
+      [{ user_id: "u_amy", role: "editor" }],
+    )
+    const post = (headers: Record<string, string>, orgId: string) =>
+      app.request("/oauth/consent/workspace", {
+        method: "POST",
+        headers: { "content-type": "application/json", ...headers },
+        body: JSON.stringify({ client_id: "cli", org_id: orgId }),
+      })
+
+    expect((await post({}, "default")).status).toBe(401) // no session
+    expect((await post({ "x-test-user": "amy@x.test" }, "ws_foreign")).status).toBe(403)
+    expect(await meta.getOAuthClientWorkspace("u_amy", "cli")).toBeNull()
+
+    expect((await post({ "x-test-user": "amy@x.test" }, "default")).status).toBe(200)
+    expect(await meta.getOAuthClientWorkspace("u_amy", "cli")).toBe("default")
   })
 })

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -157,6 +157,15 @@ CREATE TABLE IF NOT EXISTS agent_mention (
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 
+CREATE TABLE IF NOT EXISTS oauth_client_workspace (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  client_id TEXT NOT NULL,
+  org_id TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  UNIQUE (user_id, client_id)
+);
+
 CREATE TABLE IF NOT EXISTS artifact_favorite (
   id TEXT PRIMARY KEY,
   artifact_id TEXT NOT NULL,

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -52,6 +52,8 @@ export function maxRole(...roles: (Role | null | undefined)[]): Role | null {
  *  never rises above the role it was registered with — a workspace owner's
  *  agent registered as editor acts as editor, so no agent can `manage`
  *  (delete, transfer) regardless of whose authority it borrows. */
+export function capRole(role: Role, cap: Role): Role
+export function capRole(role: Role | null, cap: Role): Role | null
 export function capRole(role: Role | null, cap: Role): Role | null {
   if (!role) return null
   return RANK[role] > RANK[cap] ? cap : role

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -588,6 +588,11 @@ export interface MetaStore {
   getOAuthGrant(tokenHash: string): Promise<OAuthGrant | null>
   /** The display name of a registered OAuth client (for the consent screen). */
   getOAuthClientName(clientId: string): Promise<string | null>
+  /** Bind the workspace this user's grants to an OAuth client act in (the consent
+   *  screen's workspace picker). Upserts on (user, client): re-consent re-points. */
+  setOAuthClientWorkspace(userId: string, clientId: string, orgId: string): Promise<void>
+  /** The workspace a user bound an OAuth client to, or null (pre-picker grants). */
+  getOAuthClientWorkspace(userId: string, clientId: string): Promise<string | null>
   deleteAgent(id: string, orgId: string): Promise<void>
   /** Queue a mention into an agent's pull inbox. */
   createAgentMention(m: NewAgentMention): Promise<void>

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -77,7 +77,11 @@ export interface TypedTables {
  * isn't mirrored in @derive/core). Naming a table here is a deliberate opt-out of
  * shape parity — but it still has to be named, so it can't be forgotten.
  */
-export type JunctionTable = "artifactFavorite" | "artifactTag" | "collectionItem"
+export type JunctionTable =
+  | "artifactFavorite"
+  | "artifactTag"
+  | "collectionItem"
+  | "oauthClientWorkspace"
 
 type ClassifiedKey = keyof TypedTables | JunctionTable
 

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -215,6 +215,21 @@ export const agentMention = pgTable("agent_mention", {
   created_at: text("created_at").notNull().$defaultFn(isoNow),
 })
 
+// Which workspace an OAuth client's grants act in for one user — chosen on the
+// consent screen; re-consent upserts the row. Resolution falls back to the user's
+// first workspace when absent (pre-picker grants) or when membership has lapsed.
+export const oauthClientWorkspace = pgTable(
+  "oauth_client_workspace",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    client_id: text("client_id").notNull(),
+    org_id: text("org_id").notNull(),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [uniqueIndex("oauth_client_workspace_user_client").on(t.user_id, t.client_id)],
+)
+
 export const artifactFavorite = pgTable(
   "artifact_favorite",
   {
@@ -511,6 +526,7 @@ const TABLES = [
   notification,
   agent,
   agentMention,
+  oauthClientWorkspace,
   artifactFavorite,
   follow,
   artifactTag,

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -112,6 +112,7 @@ import {
   githubInstallation,
   membership,
   notification,
+  oauthClientWorkspace,
   orgSettings,
   PG_SCHEMA_STATEMENTS,
   proposal,
@@ -153,6 +154,7 @@ export const schema = {
   reviewRound,
   agent,
   agentMention,
+  oauthClientWorkspace,
   context,
   contextSession,
   sessionMessage,
@@ -1839,6 +1841,24 @@ export class PgMetaStore implements MetaStore {
     } catch {
       return null
     }
+  }
+  async setOAuthClientWorkspace(userId: string, clientId: string, orgId: string): Promise<void> {
+    await this.db
+      .insert(oauthClientWorkspace)
+      .values({ id: crypto.randomUUID(), user_id: userId, client_id: clientId, org_id: orgId })
+      .onConflictDoUpdate({
+        target: [oauthClientWorkspace.user_id, oauthClientWorkspace.client_id],
+        set: { org_id: orgId },
+      })
+  }
+  async getOAuthClientWorkspace(userId: string, clientId: string): Promise<string | null> {
+    const rows = await this.db
+      .select({ org_id: oauthClientWorkspace.org_id })
+      .from(oauthClientWorkspace)
+      .where(
+        and(eq(oauthClientWorkspace.user_id, userId), eq(oauthClientWorkspace.client_id, clientId)),
+      )
+    return rows[0]?.org_id ?? null
   }
   async pruneStaleOAuthClients(cutoffIso: string): Promise<number> {
     try {

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1868,6 +1868,12 @@ export class PgMetaStore implements MetaStore {
            AND "clientId" NOT IN (SELECT "clientId" FROM "oauthAccessToken")`,
         [cutoffIso],
       )
+      // Workspace bindings for clients that no longer exist (pruned above, or
+      // any earlier sweep) have nothing left to resolve against — sweep them too.
+      await this.pool.query(
+        `DELETE FROM oauth_client_workspace
+          WHERE client_id NOT IN (SELECT "clientId" FROM "oauthClient")`,
+      )
       return res.rowCount ?? 0
     } catch {
       return 0

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -110,6 +110,7 @@ import {
   githubInstallation,
   membership,
   notification,
+  oauthClientWorkspace,
   orgSettings,
   proposal,
   report,
@@ -180,6 +181,7 @@ export const schema = {
   reviewRound,
   agent,
   agentMention,
+  oauthClientWorkspace,
   context,
   contextSession,
   sessionMessage,
@@ -1730,6 +1732,32 @@ export function makeRepos(db: SqliteDb) {
       return null
     }
   }
+  const setOAuthClientWorkspace = async (
+    userId: string,
+    clientId: string,
+    orgId: string,
+  ): Promise<void> => {
+    await db
+      .insert(oauthClientWorkspace)
+      .values({ id: crypto.randomUUID(), user_id: userId, client_id: clientId, org_id: orgId })
+      .onConflictDoUpdate({
+        target: [oauthClientWorkspace.user_id, oauthClientWorkspace.client_id],
+        set: { org_id: orgId },
+      })
+      .run()
+  }
+  const getOAuthClientWorkspace = async (
+    userId: string,
+    clientId: string,
+  ): Promise<string | null> => {
+    const rows = await db
+      .select({ org_id: oauthClientWorkspace.org_id })
+      .from(oauthClientWorkspace)
+      .where(
+        and(eq(oauthClientWorkspace.user_id, userId), eq(oauthClientWorkspace.client_id, clientId)),
+      )
+    return rows[0]?.org_id ?? null
+  }
   const pruneStaleOAuthClients = async (cutoffIso: string): Promise<number> => {
     try {
       const r = (await db.run(sql`
@@ -2038,6 +2066,8 @@ export function makeRepos(db: SqliteDb) {
     getAgentByToken,
     getOAuthGrant,
     getOAuthClientName,
+    setOAuthClientWorkspace,
+    getOAuthClientWorkspace,
     pruneStaleOAuthClients,
     deleteAgent,
     createAgentMention,

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -1767,6 +1767,12 @@ export function makeRepos(db: SqliteDb) {
           and "clientId" not in (select "clientId" from "oauthConsent")
           and "clientId" not in (select "clientId" from "oauthAccessToken")
       `)) as RunResult
+      // Workspace bindings for clients that no longer exist (pruned above, or
+      // any earlier sweep) have nothing left to resolve against — sweep them too.
+      await db.run(sql`
+        delete from oauth_client_workspace
+        where client_id not in (select "clientId" from "oauthClient")
+      `)
       return r.changes ?? r.meta?.changes ?? 0
     } catch {
       // OAuth tables absent → nothing to reap.

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -236,7 +236,6 @@ export const agentMention = sqliteTable("agent_mention", {
   created_at: text("created_at").notNull().default(now),
 })
 
-// Per-user stars. One row per (artifact, user); favorites are personal, never shared.
 // Which workspace an OAuth client's grants act in for one user — chosen on the
 // consent screen; re-consent upserts the row. Resolution falls back to the user's
 // first workspace when absent (pre-picker grants) or when membership has lapsed.
@@ -252,6 +251,7 @@ export const oauthClientWorkspace = sqliteTable(
   (t) => [uniqueIndex("oauth_client_workspace_user_client").on(t.user_id, t.client_id)],
 )
 
+// Per-user stars. One row per (artifact, user); favorites are personal, never shared.
 export const artifactFavorite = sqliteTable(
   "artifact_favorite",
   {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -237,6 +237,21 @@ export const agentMention = sqliteTable("agent_mention", {
 })
 
 // Per-user stars. One row per (artifact, user); favorites are personal, never shared.
+// Which workspace an OAuth client's grants act in for one user — chosen on the
+// consent screen; re-consent upserts the row. Resolution falls back to the user's
+// first workspace when absent (pre-picker grants) or when membership has lapsed.
+export const oauthClientWorkspace = sqliteTable(
+  "oauth_client_workspace",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    client_id: text("client_id").notNull(),
+    org_id: text("org_id").notNull(),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [uniqueIndex("oauth_client_workspace_user_client").on(t.user_id, t.client_id)],
+)
+
 export const artifactFavorite = sqliteTable(
   "artifact_favorite",
   {
@@ -592,6 +607,7 @@ const TABLES = [
   notification,
   agent,
   agentMention,
+  oauthClientWorkspace,
   artifactFavorite,
   follow,
   artifactTag,


### PR DESCRIPTION
## Why

OAuth grants (both `derive login` opaque tokens and the JWTs remote MCP clients present) always resolved to the granting user's **first** workspace. The existing escape hatch — the `X-Derive-Workspace` header — is unreachable from MCP clients, which can't send custom headers. Net effect: an agent connected over OAuth could never reach a document in any other workspace. (Hit this in practice trying to read a doc in a second workspace over MCP.)

## What

- **Consent screen workspace picker** — shown only when the user has more than one workspace, preselected to their active (`derive_ws` cookie) workspace. Approve persists the choice **before** completing the consent, fail-closed: if the binding can't save, the grant doesn't complete into the wrong default.
- **`POST /oauth/consent/workspace`** — session-authed, membership-validated persistence for the picker. New `oauth_client_workspace` table (`(user, client) → org`, upsert on re-consent) across sqlite/pg/d1, parity-classified, D1 schema regenerated.
- **Resolution** (`lib/oauth-agent.ts`) — both token forms resolve through the binding, honored only while membership holds; falls back to first-workspace for pre-picker grants. `X-Derive-Workspace` still wins per-request.
- **Role-escalation fix** — the scope-derived role is now capped by the owner's actual membership role in the resolved workspace. Previously a publish-scoped grant re-homed into a workspace where its user is only a viewer acted as **editor** there. The uncapped scope role rides on the resolution so a header re-home re-caps against the *target* workspace instead of compounding caps.

## Testing

- 8 new integration tests (binding honored / stale-binding fallback / header precedence / upsert / endpoint 401-403-200) + 4 unit tests for role capping
- Full API suite 645/645, db suite, repo typecheck, precommit all green

Also carries a small docs commit: README now points at the published `@derive-to/mcp` + `@derive-to/cli` packages.