### PR TITLE
fix(web): GFM task-list checkboxes survive the answer sanitizer

### DIFF
--- a/apps/web/src/pages/context/lib/answer-md.test.ts
+++ b/apps/web/src/pages/context/lib/answer-md.test.ts
@@ -11,6 +11,14 @@ describe("answerMdToHtml", () => {
     expect(html).toContain("select 1")
   })
 
+  it("renders GFM task lists (checkbox inputs survive the whitelist)", () => {
+    const html = answerMdToHtml("- [x] verified against warehouse\n- [ ] pending sign-off")
+    expect(html).toContain('type="checkbox"')
+    expect(html).toContain("checked")
+    // …but only the task-list shape: other input types stay stripped attributes-wise.
+    expect(answerMdToHtml('<input type="text" onfocus="alert(1)">')).not.toContain("onfocus")
+  })
+
   it("strips scripts, event handlers, and inline style — model output is untrusted", () => {
     const html = answerMdToHtml(
       'x\n\n<script>alert(1)</script>\n\n<img src=x onerror=alert(1)>\n\n<p style="position:fixed">y</p>',

--- a/apps/web/src/pages/context/lib/answer-md.ts
+++ b/apps/web/src/pages/context/lib/answer-md.ts
@@ -20,6 +20,10 @@ const sanitizer = new FilterXSS({
     del: [],
     sup: [],
     sub: [],
+    // GFM task lists render as <input type="checkbox" checked disabled> — same
+    // entry core/md.ts carries. Found by the Review Companion context reviewing
+    // the PR that introduced this file.
+    input: ["type", "checked", "disabled"],
   },
 })
 


### PR DESCRIPTION
The whitelist mirrored core/md.ts but dropped its input entry
(type/checked/disabled), so marked's task-list checkboxes were stripped from
rendered answers. Found by the Review Companion context while reviewing #294 —
the PR that introduced the gap — during its own dress rehearsal.
