### PR TITLE
2FA setup: scan a QR, not a raw key

### DIFF
--- a/apps/web/e2e/deep/2fa.deep.spec.ts
+++ b/apps/web/e2e/deep/2fa.deep.spec.ts
@@ -1,0 +1,61 @@
+import { createHmac } from "node:crypto"
+import { expect, test } from "@playwright/test"
+import { signUp } from "../helpers"
+
+// End-to-end proof of the TOTP two-factor setup: enable, read the secret the QR encodes,
+// generate a REAL code from it, and confirm the server activates 2FA. Because the QR and the
+// manual key are both derived from the same otpauth:// URI, a code that the server accepts
+// proves the QR is valid too — not just that an <svg> rendered.
+
+// RFC 4648 base32 decode (A–Z, 2–7) — authenticator secrets are base32.
+function base32Decode(s: string): Buffer {
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+  let bits = 0
+  let value = 0
+  const out: number[] = []
+  for (const c of s.toUpperCase().replace(/[^A-Z2-7]/g, "")) {
+    value = (value << 5) | alphabet.indexOf(c)
+    bits += 5
+    if (bits >= 8) {
+      out.push((value >>> (bits - 8)) & 0xff)
+      bits -= 8
+    }
+  }
+  return Buffer.from(out)
+}
+
+// RFC 6238 TOTP — SHA1, 6 digits, 30s step (Better Auth's TOTP defaults).
+function totp(secret: string, at = Date.now()): string {
+  const buf = Buffer.alloc(8)
+  buf.writeBigUInt64BE(BigInt(Math.floor(at / 1000 / 30)))
+  const hmac = createHmac("sha1", base32Decode(secret)).update(buf).digest()
+  // Dynamic truncation (RFC 4226): the low nibble of the last byte picks a 4-byte window;
+  // readUInt32BE gives that window big-endian, and masking the top bit is the `& 0x7f`.
+  const offset = hmac.readUInt8(hmac.length - 1) & 0x0f
+  const bin = hmac.readUInt32BE(offset) & 0x7fffffff
+  return (bin % 1_000_000).toString().padStart(6, "0")
+}
+
+test("[deep] TOTP two-factor: enable via the QR-backed secret, end to end", async ({ page }) => {
+  await signUp(page)
+  await page.goto("/settings")
+  await page.getByTestId("settings-tab-security").click()
+
+  await page.getByTestId("2fa-enable").click()
+  await page.getByTestId("2fa-password").fill("e2e-pass-1234")
+  await page.getByTestId("2fa-start").click()
+
+  // The QR is the primary path; reveal the manual key (the same secret the QR encodes) to
+  // read it out for a real code.
+  await expect(page.getByTestId("2fa-qr")).toBeVisible()
+  await page.getByTestId("2fa-show-key").click()
+  const secret = ((await page.getByTestId("2fa-secret").textContent()) ?? "").trim()
+  expect(secret).toMatch(/^[A-Z2-7]{16,}$/)
+
+  await page.getByTestId("2fa-confirm-code").fill(totp(secret))
+  await page.getByTestId("2fa-confirm").click()
+
+  // The server accepted a code generated from the displayed secret ⇒ 2FA is genuinely on:
+  // the row flips from Enable to Disable.
+  await expect(page.getByTestId("2fa-disable")).toBeVisible()
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "lucide-react": "^1.18.0",
     "marked": "^18.0.5",
     "next-themes": "^0.4.6",
+    "qrcode.react": "^4.2.0",
     "radix-ui": "^1.6.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/apps/web/src/pages/settings/security-section.tsx
+++ b/apps/web/src/pages/settings/security-section.tsx
@@ -405,7 +405,12 @@ function EnableTwoFactor({ onDone }: { onDone: () => Promise<void> }) {
                 // purpose: QRCodeSVG defaults to black-on-white, and a dark-mode QR on the dark
                 // canvas is unreliable to scan. The p-3 padding is the required margin.
                 <div data-testid="2fa-qr" className="rounded-lg border border-border bg-white p-3">
-                  <QRCodeSVG value={totpURI} size={168} marginSize={0} />
+                  <QRCodeSVG
+                    value={totpURI}
+                    size={168}
+                    marginSize={0}
+                    title="Two-factor authentication setup QR code"
+                  />
                 </div>
               )}
               {!showKey ? (

--- a/apps/web/src/pages/settings/security-section.tsx
+++ b/apps/web/src/pages/settings/security-section.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
+import { QRCodeSVG } from "qrcode.react"
 import { useEffect, useState } from "react"
 import { ApiError, type AuthCapabilities, api } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
@@ -286,7 +287,9 @@ function EnableTwoFactor({ onDone }: { onDone: () => Promise<void> }) {
   const [step, setStep] = useState<"password" | "confirm">("password")
   const [password, setPassword] = useState("")
   const [code, setCode] = useState("")
+  const [totpURI, setTotpURI] = useState("")
   const [secret, setSecret] = useState("")
+  const [showKey, setShowKey] = useState(false)
   const [backup, setBackup] = useState<string[]>([])
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState("")
@@ -295,7 +298,9 @@ function EnableTwoFactor({ onDone }: { onDone: () => Promise<void> }) {
     setStep("password")
     setPassword("")
     setCode("")
+    setTotpURI("")
     setSecret("")
+    setShowKey(false)
     setBackup([])
     setErr("")
   }
@@ -306,7 +311,9 @@ function EnableTwoFactor({ onDone }: { onDone: () => Promise<void> }) {
     try {
       const res = await authClient.twoFactor.enable({ password })
       if (res?.error || !res?.data) throw new Error(res?.error?.message ?? "Could not start setup.")
-      // totpURI is otpauth://totp/Derive:email?secret=…&issuer=Derive — pull the manual key.
+      // totpURI is otpauth://totp/Derive:email?secret=…&issuer=Derive — the QR encodes it
+      // directly; pull the secret out too for the manual "can't scan?" fallback.
+      setTotpURI(res.data.totpURI)
       setSecret(new URL(res.data.totpURI).searchParams.get("secret") ?? "")
       setBackup(res.data.backupCodes ?? [])
       setStep("confirm")
@@ -353,7 +360,7 @@ function EnableTwoFactor({ onDone }: { onDone: () => Promise<void> }) {
           <DialogDescription>
             {step === "password"
               ? "Confirm your password to begin."
-              : "Add the key to your authenticator app, save your backup codes, then confirm a code."}
+              : "Scan the QR code with your authenticator app, save your backup codes, then enter a code to confirm."}
           </DialogDescription>
         </DialogHeader>
         {err && <StatusPanel tone="danger" layout="inline" title={err} />}
@@ -389,14 +396,40 @@ function EnableTwoFactor({ onDone }: { onDone: () => Promise<void> }) {
               confirm()
             }}
           >
-            <div className="flex flex-col gap-1.5">
-              <div className="text-sm font-medium text-foreground">Setup key</div>
-              <code
-                data-testid="2fa-secret"
-                className="block break-all rounded-md bg-secondary px-2.5 py-1.5 font-mono text-2xs text-foreground"
-              >
-                {secret}
-              </code>
+            <div className="flex flex-col items-center gap-3">
+              {/* The QR is the primary path: authenticator apps scan the otpauth:// URI. It
+                  renders dark-on-white regardless of theme so it always scans — a dark-mode
+                  QR on the dark canvas is unreliable. */}
+              {totpURI && (
+                // White card + padding is the QR's quiet zone. It stays white in dark mode on
+                // purpose: QRCodeSVG defaults to black-on-white, and a dark-mode QR on the dark
+                // canvas is unreliable to scan. The p-3 padding is the required margin.
+                <div data-testid="2fa-qr" className="rounded-lg border border-border bg-white p-3">
+                  <QRCodeSVG value={totpURI} size={168} marginSize={0} />
+                </div>
+              )}
+              {!showKey ? (
+                <button
+                  type="button"
+                  data-testid="2fa-show-key"
+                  className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                  onClick={() => setShowKey(true)}
+                >
+                  Can’t scan? Enter the key manually
+                </button>
+              ) : (
+                <div className="flex w-full flex-col gap-1.5">
+                  <div className="text-xs font-medium text-muted-foreground">
+                    Setup key — type this into your app instead
+                  </div>
+                  <code
+                    data-testid="2fa-secret"
+                    className="block break-all rounded-md bg-secondary px-2.5 py-1.5 font-mono text-2xs text-foreground"
+                  >
+                    {secret}
+                  </code>
+                </div>
+              )}
             </div>
             {backup.length > 0 && (
               <div className="flex flex-col gap-1.5">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.7)
       radix-ui:
         specifier: ^1.6.1
         version: 1.6.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -5122,6 +5125,11 @@ packages:
   pvutils@1.1.5:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
@@ -10418,6 +10426,10 @@ snapshots:
       tslib: 2.8.1
 
   pvutils@1.1.5: {}
+
+  qrcode.react@4.2.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   qs@6.15.2:
     dependencies:


### PR DESCRIPTION
## What & why

The two-factor setup dialog showed only the base32 **setup key** — users had to
hand-type a 32-character string into their authenticator app. Every authenticator
(Google Authenticator, 1Password, Authy, …) scans a QR, so the QR should be the primary
path.

## Changes

- Render the `otpauth://` URI (already returned by `twoFactor.enable()`, previously
  thrown away after extracting the key) as a **QR code** via `qrcode.react`.
- The QR is a **white, dark-on-white card** — it stays light in dark mode on purpose, so
  it scans reliably in any theme (a dark-mode QR on the dark canvas doesn't).
- The manual key is demoted to a **"Can't scan? Enter the key manually"** fallback,
  revealed on demand.
- Step copy updated to "Scan the QR code with your authenticator app…".

## Testing

- [x] Verified with a screenshot of the live dialog (QR renders + scans)
- [x] `pnpm typecheck`, `biome`, design-token / test-id / frontend lint gates pass
- [x] `pnpm -C apps/web build` bundles `qrcode.react` cleanly
- New dep: `qrcode.react` (client-side SVG QR, no network — fits the self-hosted-assets posture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)