### PR TITLE
The Activity Layer: workspace feed + home teaser

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -8,6 +8,7 @@ import { inMemoryRateLimiters, ipRateLimit } from "./lib/rate-limit"
 import { serveContent } from "./lib/serve-content"
 import { log } from "./log"
 import { mountMcp } from "./mcp"
+import { activityRoutes } from "./routes/activity"
 import { agentRoutes } from "./routes/agents"
 import { analyticsRoutes } from "./routes/analytics"
 import { artifactRoutes } from "./routes/artifacts"
@@ -299,6 +300,7 @@ export function createApp(deps: AppDeps): Hono {
     workspaceRoutes,
     agentRoutes,
     artifactRoutes,
+    activityRoutes,
     assetRoutes,
     sharingRoutes,
     favoriteRoutes,

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -1,5 +1,6 @@
 import {
   type Action,
+  type ActivityKind,
   type Actor,
   type AgentRecord,
   type ArtifactRecord,
@@ -19,6 +20,7 @@ import {
   principalOwnerId,
   type Role,
   roleAllows,
+  type Visibility,
 } from "@derive/core"
 import type { Context } from "hono"
 import { getCookie, setCookie } from "hono/cookie"
@@ -267,6 +269,36 @@ export function buildContext(deps: AppDeps) {
     else await guarded
   }
 
+  // Visibility tiers the whole workspace can see. An unlisted draft or a private/
+  // password-gated doc must never leak its existence into the shared Activity feed —
+  // this is the one gate every recordActivity call site shares.
+  const FEED_VISIBLE: ReadonlySet<Visibility> = new Set(["public", "link", "org"])
+
+  // Append one row to the workspace Activity feed — best-effort like notify(), never
+  // blocks or fails the request it's called from.
+  const recordActivity = (
+    a: ArtifactRecord,
+    kind: ActivityKind,
+    actor: { id: string | null; name: string; kind: "user" | "agent" },
+    fields?: { thread_id?: string | null; version_n?: number | null; preview?: string | null },
+  ): Promise<void> => {
+    if (!FEED_VISIBLE.has(a.visibility)) return Promise.resolve()
+    return background(
+      meta.recordActivity({
+        id: newId("ac"),
+        org_id: a.org_id,
+        kind,
+        artifact_id: a.id,
+        artifact_short_id: a.short_id,
+        artifact_title: a.title,
+        actor: actor.name,
+        actor_id: actor.id,
+        actor_kind: actor.kind,
+        ...fields,
+      }),
+    )
+  }
+
   const bearer = (c: Context): string => {
     const h = c.req.header("authorization") ?? ""
     return h.startsWith("Bearer ") ? h.slice(7) : ""
@@ -413,6 +445,19 @@ export function buildContext(deps: AppDeps) {
   // anonymous. Agents author as their name, never spoofing a person. Also a Principal read.
   const actingUser = async (c: Context): Promise<{ id: string; name: string } | null> =>
     principalActor(await resolvePrincipal(c))
+
+  // Like actingUser, but tagged with whether it's a registered agent or a real person —
+  // recordActivity's call sites need this to render the feed's AGENT chip.
+  const activityActor = async (
+    c: Context,
+  ): Promise<{ id: string; name: string; kind: "user" | "agent" } | null> => {
+    const p = await resolvePrincipal(c)
+    return p.kind === "agent"
+      ? { id: p.agent.id, name: p.agent.name, kind: "agent" }
+      : p.kind === "human"
+        ? { id: p.user.id, name: p.user.name ?? p.user.username ?? p.user.email, kind: "user" }
+        : null
+  }
 
   // A stable rate-limit key for the caller: the signed-in user / agent if known,
   // otherwise their IP so anonymous floods are still bounded.
@@ -699,10 +744,12 @@ export function buildContext(deps: AppDeps) {
     unlockLimiter,
     notify,
     background,
+    recordActivity,
     currentUser,
     agentFor,
     resolvePrincipal,
     actingUser,
+    activityActor,
     privateOwnerId,
     limited,
     overStorage,

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -10,6 +10,7 @@ import {
   can,
   capRole,
   DEFAULT_VERSION_WINDOW_MS,
+  FEED_VISIBLE_TIERS,
   isAuthenticated,
   isBundleContentType,
   type MetaStore,
@@ -271,8 +272,11 @@ export function buildContext(deps: AppDeps) {
 
   // Visibility tiers the whole workspace can see. An unlisted draft or a private/
   // password-gated doc must never leak its existence into the shared Activity feed —
-  // this is the one gate every recordActivity call site shares.
-  const FEED_VISIBLE: ReadonlySet<Visibility> = new Set(["public", "link", "org"])
+  // this is the one gate every recordActivity call site shares. Sourced from
+  // FEED_VISIBLE_TIERS (core), the SAME constant the read path (listActivity's join
+  // in repos.ts/pg.ts) filters by — a downgrade to a narrower tier stops serving
+  // already-recorded rows too, not just new ones.
+  const FEED_VISIBLE: ReadonlySet<Visibility> = new Set(FEED_VISIBLE_TIERS)
 
   // Append one row to the workspace Activity feed — best-effort like notify(), never
   // blocks or fails the request it's called from.

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -1,0 +1,33 @@
+import { Hono } from "hono"
+import type { AppContext } from "../context"
+import { fail } from "../lib/http"
+
+/** The workspace Activity feed: everything recorded (publishes, comments, resolved
+ *  threads, shares, proposal decisions, first reads) across every artifact, newest
+ *  first. Read-only; the rows are written at each action's own route. */
+export const activityRoutes = (ctx: AppContext) => {
+  const { meta, activeWorkspace, workspaceRole } = ctx
+  const app = new Hono()
+
+  app.get("/v1/activity", async (c) => {
+    const role = await workspaceRole(c)
+    if (role === null) return fail(c, 401, "unauthenticated")
+    const org = await activeWorkspace(c)
+    const limit = Math.min(100, Math.max(1, Number(c.req.query("limit")) || 30))
+    // Opaque compound cursor "<created_at>|<id>" — same shape as listArtifacts.
+    const rawCursor = c.req.query("cursor")
+    const sep = rawCursor?.indexOf("|") ?? -1
+    const cursor =
+      rawCursor && sep > 0
+        ? { created_at: rawCursor.slice(0, sep), id: rawCursor.slice(sep + 1) }
+        : undefined
+    const items = await meta.listActivity(org, { limit: limit + 1, cursor })
+    const hasMore = items.length > limit
+    const page = hasMore ? items.slice(0, limit) : items
+    const last = page[page.length - 1]
+    const next_cursor = hasMore && last ? `${last.created_at}|${last.id}` : null
+    return c.json({ items: page, next_cursor })
+  })
+
+  return app
+}

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -6,8 +6,21 @@ import type { AppContext } from "../context"
 import { fail, readJson, VIEW_DEDUP_MS } from "../lib/http"
 
 /** View recording (de-duped, owner self-views excluded) + per-artifact stats. */
+// The dawn of time, for a viewedSince check that really means "ever" (first-view
+// detection for the Activity feed) rather than the short refresh-dedup window.
+const EPOCH = new Date(0).toISOString()
+
 export const analyticsRoutes = (ctx: AppContext) => {
-  const { meta, deps, analyticsOn, currentUser, actorFor, requireArtifact, authorize } = ctx
+  const {
+    meta,
+    deps,
+    analyticsOn,
+    currentUser,
+    actorFor,
+    recordActivity,
+    requireArtifact,
+    authorize,
+  } = ctx
   const app = new Hono()
 
   // Record a view. The viewer is the logged-in user, or a stable anonymous id
@@ -54,6 +67,11 @@ export const analyticsRoutes = (ctx: AppContext) => {
     // De-dup: skip if this viewer already saw this version recently (a refresh).
     const since = new Date(Date.now() - VIEW_DEDUP_MS).toISOString()
     if (await meta.viewedSince(artifact.id, viewer, version, since)) return c.body(null, 204)
+    // A read is feed-worthy only the FIRST time a NAMED person sees this version —
+    // anonymous reads stay an aggregate count (never a feed row with an identity),
+    // and every later open by the same person is a refresh, not new activity.
+    const isFirstNamedView =
+      kind === "user" && !(await meta.viewedSince(artifact.id, viewer, version, EPOCH))
     await meta.recordView({
       id: newId("v"),
       artifact_id: artifact.id,
@@ -61,6 +79,13 @@ export const analyticsRoutes = (ctx: AppContext) => {
       viewer,
       viewer_kind: kind,
     })
+    if (isFirstNamedView && me)
+      recordActivity(
+        artifact,
+        "view",
+        { id: me.id, name: me.name ?? me.username ?? me.email, kind: "user" },
+        { version_n: version },
+      )
     return c.body(null, 204)
   })
 

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -46,10 +46,12 @@ export const artifactRoutes = (ctx: AppContext) => {
     bus,
     notify,
     background,
+    recordActivity,
     isMember,
     isToken,
     currentUser,
     actingUser,
+    activityActor,
     privateOwnerId,
     activeWorkspace,
     actorFor,
@@ -433,6 +435,8 @@ export const artifactRoutes = (ctx: AppContext) => {
         message: version.message,
         author: version.author,
       })
+      const publishActor = await activityActor(c)
+      if (publishActor) recordActivity(artifact, "publish", publishActor, { version_n: version.n })
       // Fan out to the publisher's followers: "someone you follow published X". Gated
       // to a known HUMAN behind the publish (their followers are who care — an agent
       // publish fans out to the followers of the person it acts for), a publicly-
@@ -801,6 +805,8 @@ export const artifactRoutes = (ctx: AppContext) => {
       author: version.author,
     })
     bus.publish(artifact.id, { type: "version.published", n: version.n, message: version.message })
+    const restoreActor = await activityActor(c)
+    if (restoreActor) recordActivity(artifact, "publish", restoreActor, { version_n: version.n })
     // Restoring an old blob is a content change too — re-anchor threads against it.
     await publishSweepEvents(meta, blobs, bus, artifact.id, version)
     const fresh = (await meta.getByShortId(artifact.short_id)) as ArtifactRecord

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -478,6 +478,8 @@ export const artifactRoutes = (ctx: AppContext) => {
           if (cm && cm.artifact_id === artifact.id) {
             await meta.setThreadState(artifact.id, cm.thread_id, "resolved")
             bus.publish(artifact.id, { type: "comment.resolved", thread_id: cm.thread_id })
+            if (publishActor)
+              recordActivity(artifact, "resolve", publishActor, { thread_id: cm.thread_id })
           }
         }
       }

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -33,7 +33,9 @@ export const commentRoutes = (ctx: AppContext) => {
     bus,
     notify,
     background,
+    recordActivity,
     actingUser,
+    activityActor,
     anonLocked,
     requireArtifact,
     authorize,
@@ -203,6 +205,12 @@ export const commentRoutes = (ctx: AppContext) => {
     // fan-out, so they run after the response instead of stacking sequential D1
     // round-trips onto the post (the "couple of seconds to send" people felt).
     bus.publish(artifact.id, { type: "comment.created" })
+    const commentActor = await activityActor(c)
+    if (commentActor)
+      recordActivity(artifact, "comment", commentActor, {
+        thread_id: created.thread_id,
+        preview: previewOf(created.body_md),
+      })
     await background(
       (async () => {
         await notify(artifact, "comment.created", {
@@ -274,6 +282,13 @@ export const commentRoutes = (ctx: AppContext) => {
     const updated = await meta.setThreadState(artifact.id, cm.thread_id, state)
     bus.publish(artifact.id, { type: "comment.resolved", thread_id: cm.thread_id, state })
     await notify(artifact, "comment.resolved", { state, thread_id: cm.thread_id })
+    // Only the positive resolution is feed-worthy — reopening a thread isn't a "win"
+    // moment the workspace needs surfaced.
+    if (state === "resolved") {
+      const resolveActor = await activityActor(c)
+      if (resolveActor)
+        recordActivity(artifact, "resolve", resolveActor, { thread_id: cm.thread_id })
+    }
     return c.json({ thread_id: cm.thread_id, state, updated })
   })
 

--- a/apps/api/src/routes/proposals.ts
+++ b/apps/api/src/routes/proposals.ts
@@ -29,8 +29,10 @@ export const proposalRoutes = (ctx: AppContext) => {
     deps,
     bus,
     notify,
+    recordActivity,
     currentUser,
     actingUser,
+    activityActor,
     privateOwnerId,
     anonLocked,
     requireArtifact,
@@ -231,6 +233,12 @@ export const proposalRoutes = (ctx: AppContext) => {
         version: version.n,
         approver,
       })
+      const approveActor = await activityActor(c)
+      if (approveActor)
+        recordActivity(artifact, "proposal", approveActor, {
+          version_n: version.n,
+          preview: "approved",
+        })
       const fresh = (await meta.getProposal(proposal.id)) as ProposalRecord
       return c.json({ ...(await proposalJson(artifact, fresh)), published: version.n })
     } catch (err) {
@@ -261,6 +269,9 @@ export const proposalRoutes = (ctx: AppContext) => {
     for (const threadId of await releaseAddressed(meta, artifact.id, proposal.id, "open"))
       bus.publish(artifact.id, { type: "comment.addressed", thread_id: threadId, state: "open" })
     await notify(artifact, "proposal.changes_requested", { proposal_id: proposal.id, reviewer })
+    const changesActor = await activityActor(c)
+    if (changesActor)
+      recordActivity(artifact, "proposal", changesActor, { preview: "requested changes" })
     const fresh = (await meta.getProposal(proposal.id)) as ProposalRecord
     return c.json(await proposalJson(artifact, fresh))
   })

--- a/apps/api/src/routes/sharing.ts
+++ b/apps/api/src/routes/sharing.ts
@@ -8,7 +8,8 @@ import { resolveUserRef } from "../lib/resolve-user"
 /** Per-artifact role overrides (a share). Managing shares requires `share`
  *  (editor+, GDocs model); the share's role beats the caller's workspace baseline. */
 export const sharingRoutes = (ctx: AppContext) => {
-  const { meta, defaultRole, authorize, actorFor, actingUser, bus } = ctx
+  const { meta, defaultRole, authorize, actorFor, actingUser, activityActor, recordActivity, bus } =
+    ctx
   const app = new Hono()
 
   // A sharer can never grant — or remove — a role above their own. An editor (who
@@ -107,6 +108,9 @@ export const sharingRoutes = (ctx: AppContext) => {
         notification: { ...row, read: 0, created_at: new Date().toISOString() },
       })
     }
+    const shareActor = await activityActor(c)
+    if (shareActor)
+      recordActivity(artifact, "share", shareActor, { preview: `Shared as ${b.role}` })
     // Echo the public handle, never the email — otherwise sharing by @handle would
     // be a handle→email oracle (resolve anyone's email by sharing an artifact with them).
     return c.json({ user_id: user.id, handle: user.username, name: user.name, role: b.role }, 201)

--- a/apps/api/test/activity.test.ts
+++ b/apps/api/test/activity.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest"
+import { as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+describe("workspace Activity feed", () => {
+  const alice: TestUser = { id: "u_act_alice", email: "aa@derive.test", name: "Alice" }
+  const bob: TestUser = { id: "u_act_bob", email: "ab@derive.test", name: "Bob" }
+  const { app } = makeAuthedApp("activity", [alice, bob], "editor")
+
+  it("requires a signed-in caller", async () => {
+    const res = await app.request("/v1/activity")
+    expect(res.status).toBe(401)
+  })
+
+  it("records a publish and a comment for an org-visible artifact, newest first", async () => {
+    const { short_id } = await (
+      await publishAs(app, "<h1>doc</h1>", { visibility: "org" }, as(alice.email))
+    ).json()
+    await app.request(
+      `/v1/artifacts/${short_id}/comments`,
+      jsonAs(as(bob.email), { body_md: "looks good" }),
+    )
+
+    const feed = await (await app.request("/v1/activity", { headers: as(alice.email) })).json()
+    expect(feed.items[0]).toMatchObject({
+      kind: "comment",
+      actor: "Bob",
+      artifact_short_id: short_id,
+      preview: "looks good",
+    })
+    expect(feed.items[1]).toMatchObject({
+      kind: "publish",
+      actor: "Alice",
+      artifact_short_id: short_id,
+      version_n: 1,
+    })
+  })
+
+  it("never records activity for a private or unlisted artifact", async () => {
+    const before = (await (await app.request("/v1/activity", { headers: as(alice.email) })).json())
+      .items.length
+    await publishAs(app, "<h1>secret</h1>", { visibility: "private" }, as(alice.email))
+    await publishAs(app, "<h1>draft</h1>", { visibility: "unlisted" }, as(alice.email))
+    const after = (await (await app.request("/v1/activity", { headers: as(alice.email) })).json())
+      .items.length
+    expect(after).toBe(before)
+  })
+
+  it("stops serving an artifact's activity once it's downgraded below the feed-visible tiers", async () => {
+    const { short_id } = await (
+      await publishAs(app, "<h1>fade</h1>", { visibility: "org" }, as(alice.email))
+    ).json()
+    const seen = async () => {
+      const res = await app.request("/v1/activity?limit=100", { headers: as(alice.email) })
+      const j = (await res.json()) as { items: { artifact_short_id: string }[] }
+      return j.items.some((i) => i.artifact_short_id === short_id)
+    }
+    expect(await seen()).toBe(true)
+
+    const patched = await app.request(`/v1/artifacts/${short_id}/visibility`, {
+      ...jsonAs(as(alice.email), { visibility: "private" }),
+      method: "PATCH",
+    })
+    expect(patched.status).toBe(200)
+    expect(await seen()).toBe(false)
+  })
+
+  it("deleting an artifact with recorded activity succeeds and drops its rows from the feed", async () => {
+    const { short_id } = await (
+      await publishAs(app, "<h1>ephemeral</h1>", { visibility: "org" }, as(alice.email))
+    ).json()
+    const before = (
+      await (await app.request("/v1/activity?limit=100", { headers: as(alice.email) })).json()
+    ).items as { artifact_short_id: string }[]
+    expect(before.some((i) => i.artifact_short_id === short_id)).toBe(true)
+
+    const del = await app.request(`/v1/artifacts/${short_id}`, {
+      method: "DELETE",
+      headers: as(alice.email),
+    })
+    expect(del.status).toBe(204)
+
+    const after = (
+      await (await app.request("/v1/activity?limit=100", { headers: as(alice.email) })).json()
+    ).items as { artifact_short_id: string }[]
+    expect(after.some((i) => i.artifact_short_id === short_id)).toBe(false)
+  })
+
+  it("records a resolve when a republish bundles thread resolutions via `resolves`", async () => {
+    const { short_id } = await (
+      await publishAs(app, "<h1>thread</h1>", { visibility: "org" }, as(alice.email))
+    ).json()
+    const cm = await (
+      await app.request(
+        `/v1/artifacts/${short_id}/comments`,
+        jsonAs(as(bob.email), { body_md: "please fix the typo" }),
+      )
+    ).json()
+
+    await publishAs(app, "<h1>thread fixed</h1>", { resolves: cm.id }, as(alice.email), short_id)
+
+    const feed = await (
+      await app.request("/v1/activity?limit=100", { headers: as(alice.email) })
+    ).json()
+    const resolved = feed.items.find(
+      (i: { kind: string; thread_id: string | null }) =>
+        i.kind === "resolve" && i.thread_id === cm.thread_id,
+    )
+    expect(resolved).toMatchObject({ actor: "Alice", artifact_short_id: short_id })
+  })
+
+  it("paginates with a keyset cursor", async () => {
+    for (let i = 0; i < 3; i++)
+      await publishAs(app, `<h1>page ${i}</h1>`, { visibility: "org" }, as(alice.email))
+    const first = await (
+      await app.request("/v1/activity?limit=2", { headers: as(alice.email) })
+    ).json()
+    expect(first.items).toHaveLength(2)
+    expect(first.next_cursor).toBeTruthy()
+
+    const second = await (
+      await app.request(`/v1/activity?limit=2&cursor=${encodeURIComponent(first.next_cursor)}`, {
+        headers: as(alice.email),
+      })
+    ).json()
+    const firstIds = new Set(first.items.map((i: { id: string }) => i.id))
+    for (const item of second.items) expect(firstIds.has(item.id)).toBe(false)
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -397,6 +397,22 @@ export interface Notification {
   read: 0 | 1
   created_at: string
 }
+/** One row in the workspace Activity feed. */
+export interface ActivityItem {
+  id: string
+  org_id: string
+  kind: "publish" | "comment" | "resolve" | "share" | "proposal" | "view"
+  artifact_id: string
+  artifact_short_id: string
+  artifact_title: string | null
+  thread_id: string | null
+  version_n: number | null
+  actor: string
+  actor_id: string | null
+  actor_kind: "user" | "agent"
+  preview: string | null
+  created_at: string
+}
 export interface Webhook {
   id: string
   artifact_id: string | null
@@ -809,6 +825,17 @@ export const api = {
     if (params?.limit) qs.set("limit", String(params.limit))
     const s = qs.toString()
     return f(`/v1/artifacts${s ? `?${s}` : ""}`, opts()).then(j)
+  },
+  // The workspace Activity feed — newest first, keyset-paginated like listArtifacts.
+  listActivity: (params?: {
+    cursor?: string
+    limit?: number
+  }): Promise<{ items: ActivityItem[]; next_cursor: string | null }> => {
+    const qs = new URLSearchParams()
+    if (params?.cursor) qs.set("cursor", params.cursor)
+    if (params?.limit) qs.set("limit", String(params.limit))
+    const s = qs.toString()
+    return f(`/v1/activity${s ? `?${s}` : ""}`, opts()).then(j)
   },
   browseSummary: (): Promise<{
     total: number

--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -111,7 +111,7 @@ function NavItem({
   icon: IconName
   label: string
   count?: number
-  to: "/favorites" | "/following" | "/shared" | "/people" | "/contexts"
+  to: "/favorites" | "/following" | "/shared" | "/people" | "/contexts" | "/activity"
   active: boolean
   testId?: string
 }) {
@@ -302,6 +302,7 @@ export function NavRail() {
   const onShared = loc.pathname === "/shared"
   // People + its Activity sub-view (the /following feed) are one tab; the row lights for both.
   const onPeople = loc.pathname === "/people" || loc.pathname === "/following"
+  const onActivity = loc.pathname === "/activity"
   const onContexts = loc.pathname.startsWith("/contexts")
   const onSettings = loc.pathname.startsWith("/settings")
   const tags = summary?.tags ?? []
@@ -480,6 +481,15 @@ export function NavRail() {
                 to="/people"
                 active={onPeople}
                 testId="nav-people"
+              />
+              {/* The workspace's "what happened" — every recorded publish, comment,
+                  resolved thread, share, and proposal decision, across every artifact. */}
+              <NavItem
+                icon="activity"
+                label="Activity"
+                to="/activity"
+                active={onActivity}
+                testId="nav-activity"
               />
               <NavItem
                 icon="context"

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -6,6 +6,7 @@
 // muted, unfavourited star); pass weight="fill" for a filled state (favorited
 // star, pinned pin) — it fills the glyph with the current ink.
 import {
+  Activity,
   AtSign,
   Ban,
   BarChart3,
@@ -60,6 +61,8 @@ const REG = {
   // nav
   all: Layers,
   favorites: Star,
+  // The workspace Activity feed — everything that happened, across every artifact.
+  activity: Activity,
   // The activity feed of followed authors + repo paths.
   following: Users,
   collections: Folders,

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -93,6 +93,25 @@ export const followingPreviewQuery = () =>
     queryFn: () => api.listArtifacts({ scope: "following", limit: 6 }).then((r) => r.artifacts),
   })
 
+// The full workspace Activity feed (/activity) — infinite, keyset-paginated, like
+// libraryArtifactsQuery.
+export const activityFeedQuery = () =>
+  infiniteQueryOptions({
+    queryKey: ["activity"] as const,
+    queryFn: ({ pageParam }) => api.listActivity({ cursor: pageParam || undefined, limit: 30 }),
+    initialPageParam: "",
+    getNextPageParam: (last) => last.next_cursor ?? undefined,
+  })
+
+// A small, flat, capped slice of the Activity feed for the home's quiet one-line link
+// (the TriageBar counterpart — "N recent" plus the single latest story). The full feed
+// is the infinite activityFeedQuery above.
+export const recentActivityQuery = () =>
+  queryOptions({
+    queryKey: ["activity", "recent"] as const,
+    queryFn: () => api.listActivity({ limit: 8 }).then((r) => r.items),
+  })
+
 // The caller's follows (GitHub authors + repo path prefixes) for the active
 // workspace. Drives the Following-feed empty state, the manage strip, and the
 // isFollowing* sets that toggle the Follow buttons. One source of truth: every

--- a/apps/web/src/lib/time.ts
+++ b/apps/web/src/lib/time.ts
@@ -7,3 +7,16 @@ export const ago = (iso: string): string => {
   if (s < 86400) return `${Math.floor(s / 3600)}h ago`
   return `${Math.floor(s / 86400)}d ago`
 }
+
+// Day-bucket header shared by the version history drawer and the Activity feed:
+// "Today" / "Yesterday" / "Jul 3".
+export const dayLabel = (iso: string): string => {
+  const d = new Date(iso)
+  const today = new Date()
+  const y = new Date(today)
+  y.setDate(today.getDate() - 1)
+  const same = (a: Date, b: Date) => a.toDateString() === b.toDateString()
+  if (same(d, today)) return "Today"
+  if (same(d, y)) return "Yesterday"
+  return d.toLocaleDateString([], { month: "short", day: "numeric" })
+}

--- a/apps/web/src/pages/activity/index.tsx
+++ b/apps/web/src/pages/activity/index.tsx
@@ -1,0 +1,156 @@
+import { useInfiniteQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
+import { Icon, type IconName } from "@/components/icons"
+import { EmptyState } from "@/components/shared/empty-state"
+import { PageHeader } from "@/components/shared/page-header"
+import { PageShell } from "@/components/shared/page-shell"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
+import { CenteredSpinner } from "@/components/shared/spinner"
+import { StatusPanel } from "@/components/shared/status-panel"
+import { Button } from "@/components/ui/button"
+import { colorForName } from "@/lib/avatar-tints"
+import { activityFeedQuery } from "@/lib/queries"
+import { ago, dayLabel } from "@/lib/time"
+import { refFor } from "@/pages/artifact/parse-ref"
+import { coalesceActivity, describeActivity } from "./lib"
+
+// The tinted kind glyph — the ONE deliberate spot of color per row, riding the
+// calm categorical tints (never a hue on the chrome itself). Publish/view read as
+// "info" (insights blue); comment keeps its own tint; resolve/proposal share the
+// "positive outcome" green.
+const KIND_STYLE: Record<string, { icon: IconName; tint: string }> = {
+  publish: { icon: "history", tint: "bg-insights/10 text-insights" },
+  comment: { icon: "comments", tint: "bg-comments/10 text-comments" },
+  resolve: { icon: "check", tint: "bg-review/10 text-review" },
+  share: { icon: "share", tint: "bg-share/10 text-share" },
+  proposal: { icon: "review", tint: "bg-review/10 text-review" },
+  view: { icon: "views", tint: "bg-insights/10 text-insights" },
+}
+
+// The workspace Activity feed: everything recorded (publishes, comments, resolved
+// threads, shares, proposal decisions, first reads), day-grouped and coalesced —
+// one story per (actor, artifact, kind) run, not one row per raw event.
+export function ActivityPage() {
+  const { data, isPending, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery(activityFeedQuery())
+  const items = data?.pages.flatMap((p) => p.items) ?? []
+  const coalesced = coalesceActivity(items)
+  const days = new Map<string, typeof coalesced>()
+  for (const a of coalesced) {
+    const label = dayLabel(a.created_at)
+    const arr = days.get(label) ?? []
+    arr.push(a)
+    days.set(label, arr)
+  }
+
+  return (
+    <PageShell width="wide">
+      <PageHeader
+        className="mb-5"
+        title="Activity"
+        subtitle="Everything that's happened across your workspace."
+      />
+      {isPending ? (
+        <CenteredSpinner />
+      ) : isError ? (
+        <StatusPanel
+          tone="danger"
+          title="Couldn't load activity"
+          description="This is usually temporary."
+          action={
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="activity-retry"
+              onClick={() => refetch()}
+            >
+              Try again
+            </Button>
+          }
+        />
+      ) : coalesced.length === 0 ? (
+        <EmptyState
+          icon={<Icon name="activity" strokeWidth={1.75} />}
+          title="Nothing has happened yet."
+          description="Publishes, comments, and reviews across your workspace show up here."
+        />
+      ) : (
+        <div className="flex flex-col gap-6">
+          {Array.from(days.entries()).map(([label, rows]) => (
+            <section key={label}>
+              <Eyebrow as="h2" className="mb-2">
+                {label}
+              </Eyebrow>
+              <div className="flex flex-col gap-0 divide-y divide-border-soft rounded-lg border border-border bg-card">
+                {rows.map((a) => (
+                  <ActivityRow key={a.ids[0]} a={a} />
+                ))}
+              </div>
+            </section>
+          ))}
+          {hasNextPage && (
+            <div className="flex justify-center py-2">
+              <Button
+                variant="outline"
+                size="sm"
+                data-testid="activity-load-more"
+                onClick={() => fetchNextPage()}
+                disabled={isFetchingNextPage}
+              >
+                {isFetchingNextPage ? "Loading…" : "Load more"}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+    </PageShell>
+  )
+}
+
+function ActivityRow({ a }: { a: ReturnType<typeof coalesceActivity>[number] }) {
+  const { action, detail } = describeActivity(a)
+  const style = KIND_STYLE[a.kind] ?? {
+    icon: "activity" as const,
+    tint: "bg-muted text-muted-foreground",
+  }
+  const initial = a.actor.trim().charAt(0).toUpperCase()
+  return (
+    <div className="flex items-center gap-3 px-3.5 py-2.5 text-sm">
+      <span
+        className={`flex size-6 shrink-0 items-center justify-center rounded-md ${style.tint}`}
+        aria-hidden
+      >
+        <Icon name={style.icon} size={13} />
+      </span>
+      <span
+        className="flex size-4 shrink-0 items-center justify-center rounded-full text-2xs font-semibold text-scrim-foreground"
+        style={{ backgroundColor: colorForName(a.actor) }}
+        aria-hidden
+      >
+        {initial}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="text-foreground">
+          <span className="font-medium">{a.actor}</span>
+          {a.actor_kind === "agent" && (
+            <span className="ml-1 rounded-sm border border-border px-1 font-mono text-2xs text-muted-foreground align-middle">
+              AGENT
+            </span>
+          )}{" "}
+          {action}{" "}
+          <Link
+            to="/artifacts/$ref"
+            params={{ ref: refFor({ short_id: a.artifact_short_id, title: a.artifact_title }) }}
+            className="font-medium underline decoration-border-soft underline-offset-2 hover:decoration-foreground"
+          >
+            {a.artifact_title ?? a.artifact_short_id}
+          </Link>
+        </span>
+        {detail && <span className="block truncate text-2xs text-muted-foreground">{detail}</span>}
+      </span>
+      <time dateTime={a.created_at} className="shrink-0 font-mono text-2xs text-muted-foreground">
+        {ago(a.created_at)}
+      </time>
+    </div>
+  )
+}

--- a/apps/web/src/pages/activity/lib.ts
+++ b/apps/web/src/pages/activity/lib.ts
@@ -1,0 +1,107 @@
+import type { ActivityItem } from "@/api"
+
+export interface CoalescedActivity {
+  kind: ActivityItem["kind"]
+  actor: string
+  actor_id: string | null
+  actor_kind: "user" | "agent"
+  artifact_id: string
+  artifact_short_id: string
+  artifact_title: string | null
+  thread_id: string | null
+  count: number
+  versionMin: number | null
+  versionMax: number | null
+  preview: string | null
+  created_at: string
+  ids: string[]
+}
+
+// Merge consecutive rows from the SAME actor, on the SAME artifact, doing the SAME
+// kind of thing into one story — "Claude published 3 revisions", not three rows.
+// Items are already newest-first (the API's order); only ADJACENT runs merge, so
+// something else happening in between (a different doc, a different person) still
+// breaks the run into separate beats.
+export function coalesceActivity(items: ActivityItem[]): CoalescedActivity[] {
+  const out: CoalescedActivity[] = []
+  for (const item of items) {
+    const last = out[out.length - 1]
+    const sameRun =
+      last &&
+      last.kind === item.kind &&
+      last.artifact_id === item.artifact_id &&
+      (item.actor_id ? last.actor_id === item.actor_id : last.actor === item.actor)
+    if (sameRun && last) {
+      last.count += 1
+      last.ids.push(item.id)
+      if (item.version_n != null) {
+        last.versionMin =
+          last.versionMin == null ? item.version_n : Math.min(last.versionMin, item.version_n)
+        last.versionMax =
+          last.versionMax == null ? item.version_n : Math.max(last.versionMax, item.version_n)
+      }
+      // Keep the MOST RECENT preview (items arrive newest-first, so the first one
+      // seen for this run already is the most recent — nothing to do here).
+      continue
+    }
+    out.push({
+      kind: item.kind,
+      actor: item.actor,
+      actor_id: item.actor_id,
+      actor_kind: item.actor_kind,
+      artifact_id: item.artifact_id,
+      artifact_short_id: item.artifact_short_id,
+      artifact_title: item.artifact_title,
+      thread_id: item.thread_id,
+      count: 1,
+      versionMin: item.version_n,
+      versionMax: item.version_n,
+      preview: item.preview,
+      created_at: item.created_at,
+      ids: [item.id],
+    })
+  }
+  return out
+}
+
+/** The verb phrase + optional detail line for one coalesced story, e.g.
+ *  { action: "published 3 revisions of", detail: "v5 → v8" }. The caller appends the
+ *  artifact title as a link after `action`. */
+export function describeActivity(a: CoalescedActivity): { action: string; detail?: string } {
+  switch (a.kind) {
+    case "publish": {
+      const range =
+        a.versionMin != null && a.versionMax != null && a.versionMin !== a.versionMax
+          ? `v${a.versionMin} → v${a.versionMax}`
+          : a.versionMax != null
+            ? `v${a.versionMax}`
+            : undefined
+      return a.count > 1
+        ? { action: `published ${a.count} revisions of`, detail: range }
+        : { action: range ? `published ${range} of` : "published" }
+    }
+    case "comment":
+      return {
+        action: a.count > 1 ? `commented ${a.count} times on` : "commented on",
+        detail: a.preview ?? undefined,
+      }
+    case "resolve":
+      return { action: a.count > 1 ? `resolved ${a.count} threads on` : "resolved a thread on" }
+    case "share":
+      return { action: "shared", detail: a.preview ?? undefined }
+    case "proposal":
+      return a.preview === "approved"
+        ? {
+            action: "approved a proposal on",
+            detail: a.versionMax != null ? `v${a.versionMax} went live` : undefined,
+          }
+        : { action: "requested changes on a proposal on" }
+    case "view":
+      return {
+        action: "read",
+        detail: a.versionMax != null ? `first read of v${a.versionMax}` : undefined,
+      }
+    default:
+      return { action: "acted on" }
+  }
+}

--- a/apps/web/src/pages/artifact/insights-history.tsx
+++ b/apps/web/src/pages/artifact/insights-history.tsx
@@ -9,7 +9,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { Skeleton } from "@/components/ui/skeleton"
 import { getInitials } from "@/lib/initials"
-import { ago } from "@/lib/time"
+import { ago, dayLabel } from "@/lib/time"
 import { cn } from "@/lib/utils"
 
 // Stat grid per the surfaces doctrine: siblings separated by hairline dividers,
@@ -216,16 +216,6 @@ export function Insights({
 // checkpoints pinned), not every raw revision. Controlled by "⋯ More".
 const clock = (iso: string) =>
   new Date(iso).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })
-const dayLabel = (iso: string): string => {
-  const d = new Date(iso)
-  const today = new Date()
-  const y = new Date(today)
-  y.setDate(today.getDate() - 1)
-  const same = (a: Date, b: Date) => a.toDateString() === b.toDateString()
-  if (same(d, today)) return "Today"
-  if (same(d, y)) return "Yesterday"
-  return d.toLocaleDateString([], { month: "short", day: "numeric" })
-}
 
 export function HistoryDrawer({
   art,

--- a/apps/web/src/pages/library/activity-bar.tsx
+++ b/apps/web/src/pages/library/activity-bar.tsx
@@ -1,0 +1,30 @@
+import { Link } from "@tanstack/react-router"
+import { Icon } from "@/components/icons"
+import { ago } from "@/lib/time"
+import type { CoalescedActivity } from "../activity/lib"
+import { describeActivity } from "../activity/lib"
+
+// The home's quiet link to the Activity feed — the TriageBar counterpart for "what
+// happened" rather than "what needs you". Shows the single most recent story as a
+// one-line teaser; disappears entirely when the workspace has no activity yet
+// (never an empty "nothing happened" line — see TriageBar's same restraint).
+export function ActivityBar({ latest }: { latest: CoalescedActivity }) {
+  const { action } = describeActivity(latest)
+  return (
+    <Link
+      to="/activity"
+      data-testid="library-activity-bar"
+      className="group flex items-center gap-2.5 rounded-lg bg-secondary px-3.5 py-2.5 text-sm ring-1 ring-transparent ring-inset outline-none hover:ring-input focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+    >
+      <Icon name="activity" size={16} className="text-muted-foreground" />
+      <span className="min-w-0 flex-1 truncate text-foreground">
+        <span className="font-medium">{latest.actor}</span> {action}{" "}
+        <span className="font-medium">{latest.artifact_title ?? latest.artifact_short_id}</span>
+        <span className="text-muted-foreground"> · {ago(latest.created_at)}</span>
+      </span>
+      <span className="shrink-0 font-mono text-2xs text-muted-foreground group-hover:text-foreground">
+        View
+      </span>
+    </Link>
+  )
+}

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -20,6 +20,7 @@ import {
   artifactQuery,
   collectionsQuery,
   needsFeedbackArtifactsQuery,
+  recentActivityQuery,
   summaryQuery,
 } from "@/lib/queries"
 import { STORAGE_KEYS } from "@/lib/storage-keys"
@@ -27,7 +28,9 @@ import { useDelayedPending } from "@/lib/use-delayed-pending"
 import { useFollows } from "@/lib/use-follows"
 import { usePrefetchArtifact } from "@/lib/use-prefetch-artifact"
 import { cn } from "@/lib/utils"
+import { coalesceActivity } from "../activity/lib"
 import { refFor } from "../artifact/parse-ref"
+import { ActivityBar } from "./activity-bar"
 import { ArtifactGrid } from "./artifact-grid"
 import { ArtifactRow, byRecency } from "./artifact-row"
 import { CollectionBar } from "./collection-bar"
@@ -248,6 +251,10 @@ function LibraryBody({ view }: { view: LibraryView }) {
   const homeView = filter.kind === "all" && !isSearching
   const { data: feedbackData } = useQuery({ ...needsFeedbackArtifactsQuery(), enabled: homeView })
   const feedbackCount = feedbackData?.length ?? 0
+  // The Activity link's single most-recent story — a flat, capped fetch (never
+  // the infinite feed); coalesced the same way the full /activity page is.
+  const { data: recentActivity } = useQuery({ ...recentActivityQuery(), enabled: homeView })
+  const latestActivity = recentActivity ? coalesceActivity(recentActivity)[0] : undefined
 
   // The greeting NEVER branches on a pending query: the count is preloaded in the "/"
   // route loader, so `summary` is present on the first paint. The `totalKnown` guard is
@@ -406,10 +413,13 @@ function LibraryBody({ view }: { view: LibraryView }) {
 
       {showPublish && <PublishCard />}
 
-      {/* The quiet triage line — one entry point to the /feedback feed, home only. */}
-      {homeView && feedbackCount > 0 && (
-        <div className="mb-6">
-          <TriageBar count={feedbackCount} />
+      {/* The quiet triage line — one entry point to the /feedback feed — and the
+          Activity teaser — one entry point to /activity — home only. Triage
+          (needs you) sits above Activity (FYI): action before ambient context. */}
+      {homeView && (feedbackCount > 0 || latestActivity) && (
+        <div className="mb-6 flex flex-col gap-2">
+          {feedbackCount > 0 && <TriageBar count={feedbackCount} />}
+          {latestActivity && <ActivityBar latest={latestActivity} />}
         </div>
       )}
 

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as FollowingRouteImport } from './routes/following'
 import { Route as FeedbackRouteImport } from './routes/feedback'
 import { Route as FavoritesRouteImport } from './routes/favorites'
+import { Route as ActivityRouteImport } from './routes/activity'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings.index'
 import { Route as ContextsIndexRouteImport } from './routes/contexts.index'
@@ -90,6 +91,11 @@ const FavoritesRoute = FavoritesRouteImport.update({
   path: '/favorites',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ActivityRoute = ActivityRouteImport.update({
+  id: '/activity',
+  path: '/activity',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -133,6 +139,7 @@ const ArtifactsRefRoute = ArtifactsRefRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/activity': typeof ActivityRoute
   '/favorites': typeof FavoritesRoute
   '/feedback': typeof FeedbackRoute
   '/following': typeof FollowingRoute
@@ -155,6 +162,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/activity': typeof ActivityRoute
   '/favorites': typeof FavoritesRoute
   '/feedback': typeof FeedbackRoute
   '/following': typeof FollowingRoute
@@ -177,6 +185,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/activity': typeof ActivityRoute
   '/favorites': typeof FavoritesRoute
   '/feedback': typeof FeedbackRoute
   '/following': typeof FollowingRoute
@@ -201,6 +210,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/activity'
     | '/favorites'
     | '/feedback'
     | '/following'
@@ -223,6 +233,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/activity'
     | '/favorites'
     | '/feedback'
     | '/following'
@@ -244,6 +255,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/activity'
     | '/favorites'
     | '/feedback'
     | '/following'
@@ -267,6 +279,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ActivityRoute: typeof ActivityRoute
   FavoritesRoute: typeof FavoritesRoute
   FeedbackRoute: typeof FeedbackRoute
   FollowingRoute: typeof FollowingRoute
@@ -372,6 +385,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof FavoritesRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/activity': {
+      id: '/activity'
+      path: '/activity'
+      fullPath: '/activity'
+      preLoaderRoute: typeof ActivityRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -447,6 +467,7 @@ const SettingsRouteWithChildren = SettingsRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ActivityRoute: ActivityRoute,
   FavoritesRoute: FavoritesRoute,
   FeedbackRoute: FeedbackRoute,
   FollowingRoute: FollowingRoute,

--- a/apps/web/src/routes/activity.tsx
+++ b/apps/web/src/routes/activity.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { requireOnboarded } from "../lib/route-guards"
+import { ActivityPage } from "../pages/activity"
+
+// The workspace Activity feed: /activity — everything recorded across every
+// artifact (publishes, comments, resolved threads, shares, proposal decisions,
+// first reads), day-grouped. A fixed named feed like /favorites and /following;
+// it earns its own route rather than a library scope (it isn't artifact cards,
+// it's an event log).
+export const Route = createFileRoute("/activity")({
+  beforeLoad: requireOnboarded,
+  component: ActivityPage,
+})

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -414,6 +414,25 @@ CREATE TABLE IF NOT EXISTS audit_log (
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 
+CREATE TABLE IF NOT EXISTS activity (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  artifact_id TEXT NOT NULL,
+  artifact_short_id TEXT NOT NULL,
+  artifact_title TEXT,
+  thread_id TEXT,
+  version_n INTEGER,
+  actor TEXT NOT NULL,
+  actor_id TEXT,
+  actor_kind TEXT NOT NULL DEFAULT 'user',
+  preview TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  FOREIGN KEY (artifact_id) REFERENCES artifact(id)
+);
+
+CREATE INDEX IF NOT EXISTS activity_org_time ON activity (org_id, created_at, id);
+
 CREATE TABLE IF NOT EXISTS principal (
     id TEXT PRIMARY KEY,
     org_id TEXT NOT NULL,

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -504,6 +504,15 @@ export interface MetaStore {
     fields: { state: Extract<ReviewRoundState, "sent_back" | "approved">; note?: string | null },
   ): Promise<ReviewRoundRecord | null>
 
+  // ---- Activity feed (the workspace's "what happened") -------------------
+  recordActivity(a: NewActivity): Promise<void>
+  /** Newest-first, keyset-paginated (like listArtifacts) — everything recorded for
+   *  this workspace, regardless of which artifact. */
+  listActivity(
+    orgId: string,
+    opts?: { limit?: number; cursor?: { created_at: string; id: string } },
+  ): Promise<ActivityRecord[]>
+
   // ---- Contexts + sessions (ask a context; its runner answers) -----------
   createContext(x: NewContext): Promise<ContextRecord>
   getContext(id: string): Promise<ContextRecord | null>
@@ -1471,6 +1480,47 @@ export interface NewView {
   version: number
   viewer: string
   viewer_kind: "user" | "anon"
+}
+
+/** What the workspace Activity feed shows. `view` rows are written only for a NAMED
+ *  viewer's first read of a version (anonymous reads stay aggregate counts, never a
+ *  feed row); every other kind mirrors an existing domain event. */
+export type ActivityKind = "publish" | "comment" | "resolve" | "share" | "proposal" | "view"
+
+export interface ActivityRecord {
+  id: string
+  org_id: string
+  kind: ActivityKind
+  artifact_id: string
+  /** Denormalized at write time (the notification-row pattern) so the feed never joins
+   *  artifact on read; a later rename doesn't rewrite history. */
+  artifact_short_id: string
+  artifact_title: string | null
+  thread_id: string | null
+  version_n: number | null
+  /** Display name of who/what did it. */
+  actor: string
+  /** Stable user/agent id, when known (null for a legacy/anonymous row). */
+  actor_id: string | null
+  actor_kind: "user" | "agent"
+  /** A short one-line detail (a quoted comment snippet, "approved", a share role). */
+  preview: string | null
+  created_at: string
+}
+
+export interface NewActivity {
+  id: string
+  org_id: string
+  kind: ActivityKind
+  artifact_id: string
+  artifact_short_id: string
+  artifact_title: string | null
+  thread_id?: string | null
+  version_n?: number | null
+  actor: string
+  actor_id?: string | null
+  actor_kind?: "user" | "agent"
+  preview?: string | null
 }
 
 export interface ViewStats {

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1487,6 +1487,13 @@ export interface NewView {
  *  feed row); every other kind mirrors an existing domain event. */
 export type ActivityKind = "publish" | "comment" | "resolve" | "share" | "proposal" | "view"
 
+/** Visibility tiers the whole workspace can read — the Activity feed's one gate,
+ *  shared by the write path (never record for anything narrower) and the read path
+ *  (never SERVE a row whose artifact has since been narrowed below this, e.g. a
+ *  post-hoc downgrade to private). A single exported source so it can't drift into
+ *  a second hand-copied Set at either call site. */
+export const FEED_VISIBLE_TIERS: readonly Visibility[] = ["public", "link", "org"]
+
 export interface ActivityRecord {
   id: string
   org_id: string

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -13,6 +13,7 @@
 //      flags exactly which table broke.
 
 import type {
+  ActivityRecord,
   AgentMentionRecord,
   AgentRecord,
   ArtifactMemberRecord,
@@ -46,6 +47,7 @@ export type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : f
 
 /** Drizzle tables that mirror a core Record type — their shape is parity-checked. */
 export interface TypedTables {
+  activity: ActivityRecord
   artifact: ArtifactRecord
   version: VersionRecord
   comment: CommentRecord

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -1,4 +1,5 @@
 import type {
+  ActivityKind,
   AgentMentionState,
   ArtifactKind,
   AuditAction,
@@ -502,6 +503,30 @@ export const sessionMessage = pgTable(
   (t) => [index("session_message_session").on(t.session_id, t.created_at)],
 )
 
+// The workspace Activity feed; mirror of the sqlite def — see schema.ts for the
+// denormalization + visibility-gate design notes.
+export const activity = pgTable(
+  "activity",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    kind: text("kind").$type<ActivityKind>().notNull(),
+    artifact_id: text("artifact_id")
+      .notNull()
+      .references(() => artifact.id),
+    artifact_short_id: text("artifact_short_id").notNull(),
+    artifact_title: text("artifact_title"),
+    thread_id: text("thread_id"),
+    version_n: integer("version_n"),
+    actor: text("actor").notNull(),
+    actor_id: text("actor_id"),
+    actor_kind: text("actor_kind").$type<"user" | "agent">().notNull().default("user"),
+    preview: text("preview"),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [index("activity_org_time").on(t.org_id, t.created_at, t.id)],
+)
+
 export const report = pgTable("report", {
   id: text("id").primaryKey(),
   org_id: text("org_id").notNull().default("default"),
@@ -570,6 +595,7 @@ const TABLES = [
   sessionMessage,
   report,
   auditLog,
+  activity,
 ]
 
 /** Build the Postgres boot DDL: generated table/index CREATEs + placeholder tables

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -78,7 +78,7 @@ import type {
   WebhookRecord,
   WorkspaceRecord,
 } from "@derive/core"
-import { DEFAULT_ORG_SETTINGS, GLOBAL_FOLLOW_ORG } from "@derive/core"
+import { DEFAULT_ORG_SETTINGS, FEED_VISIBLE_TIERS, GLOBAL_FOLLOW_ORG } from "@derive/core"
 import {
   and,
   asc,
@@ -1516,7 +1516,7 @@ export class PgMetaStore implements MetaStore {
     orgId: string,
     opts?: { limit?: number; cursor?: { created_at: string; id: string } },
   ): Promise<ActivityRecord[]> {
-    const conds = [eq(activity.org_id, orgId)]
+    const conds = [eq(activity.org_id, orgId), inArray(artifact.visibility, FEED_VISIBLE_TIERS)]
     if (opts?.cursor) {
       const cursor = or(
         lt(activity.created_at, opts.cursor.created_at),
@@ -1524,9 +1524,12 @@ export class PgMetaStore implements MetaStore {
       )
       if (cursor) conds.push(cursor)
     }
+    // INNER JOIN, filtered live against the artifact's CURRENT visibility — see
+    // repos.ts's listActivity for the full reasoning (mirrors it exactly).
     const rows = this.db
-      .select()
+      .select(getTableColumns(activity))
       .from(activity)
+      .innerJoin(artifact, eq(artifact.id, activity.artifact_id))
       .where(and(...conds))
       .orderBy(desc(activity.created_at), desc(activity.id))
     return opts?.limit ? rows.limit(opts.limit) : rows
@@ -2160,6 +2163,7 @@ export class PgMetaStore implements MetaStore {
       await tx.delete(report).where(eq(report.artifact_id, id))
       await tx.delete(notification).where(eq(notification.artifact_id, id))
       await tx.delete(agentMention).where(eq(agentMention.artifact_id, id))
+      await tx.delete(activity).where(eq(activity.artifact_id, id))
       await tx.delete(artifact).where(eq(artifact.id, id))
     })
   }

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1,4 +1,5 @@
 import type {
+  ActivityRecord,
   AgentMentionRecord,
   AgentRecord,
   ArtifactMemberRecord,
@@ -26,6 +27,7 @@ import type {
   ListArtifactsOpts,
   MembershipRecord,
   MetaStore,
+  NewActivity,
   NewAgent,
   NewAgentMention,
   NewArtifact,
@@ -87,6 +89,7 @@ import {
   inArray,
   isNotNull,
   isNull,
+  lt,
   lte,
   ne,
   or,
@@ -96,6 +99,7 @@ import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres"
 import { Pool } from "pg"
 import type { Exhaustive, Shapes } from "./parity"
 import {
+  activity,
   agent,
   agentMention,
   artifact,
@@ -142,6 +146,7 @@ const one = <T>(rows: T[]): T => {
 // Exported so the pg schema-conformance test can diff these defs against the
 // columns PG_SCHEMA_STATEMENTS actually creates in a real Postgres.
 export const schema = {
+  activity,
   artifact,
   version,
   comment,
@@ -179,6 +184,7 @@ export const schema = {
 // a pg column that drifts from its core Record → compile error here.
 const _schemaExhaustive: Exhaustive<typeof schema> = true
 const _schemaShapes: Shapes<typeof schema> = {
+  activity: true,
   artifact: true,
   version: true,
   comment: true,
@@ -1500,6 +1506,30 @@ export class PgMetaStore implements MetaStore {
       .where(eq(reviewRound.id, id))
       .returning()
     return rows[0] ?? null
+  }
+
+  // ---- Activity feed -------------------------------------------------------
+  async recordActivity(a: NewActivity): Promise<void> {
+    await this.db.insert(activity).values(a)
+  }
+  listActivity(
+    orgId: string,
+    opts?: { limit?: number; cursor?: { created_at: string; id: string } },
+  ): Promise<ActivityRecord[]> {
+    const conds = [eq(activity.org_id, orgId)]
+    if (opts?.cursor) {
+      const cursor = or(
+        lt(activity.created_at, opts.cursor.created_at),
+        and(eq(activity.created_at, opts.cursor.created_at), lt(activity.id, opts.cursor.id)),
+      )
+      if (cursor) conds.push(cursor)
+    }
+    const rows = this.db
+      .select()
+      .from(activity)
+      .where(and(...conds))
+      .orderBy(desc(activity.created_at), desc(activity.id))
+    return opts?.limit ? rows.limit(opts.limit) : rows
   }
 
   // ---- Contexts + sessions -------------------------------------------------

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -73,7 +73,7 @@ import type {
   WebhookRecord,
   WorkspaceRecord,
 } from "@derive/core"
-import { DEFAULT_ORG_SETTINGS, GLOBAL_FOLLOW_ORG } from "@derive/core"
+import { DEFAULT_ORG_SETTINGS, FEED_VISIBLE_TIERS, GLOBAL_FOLLOW_ORG } from "@derive/core"
 import {
   and,
   asc,
@@ -1586,7 +1586,7 @@ export function makeRepos(db: SqliteDb) {
     orgId: string,
     opts?: { limit?: number; cursor?: { created_at: string; id: string } },
   ): Promise<ActivityRecord[]> => {
-    const conds = [eq(activity.org_id, orgId)]
+    const conds = [eq(activity.org_id, orgId), inArray(artifact.visibility, FEED_VISIBLE_TIERS)]
     if (opts?.cursor) {
       const cursor = or(
         lt(activity.created_at, opts.cursor.created_at),
@@ -1594,9 +1594,16 @@ export function makeRepos(db: SqliteDb) {
       )
       if (cursor) conds.push(cursor)
     }
+    // INNER JOIN, filtered live against the artifact's CURRENT visibility — not just
+    // the visibility at write time. A doc later narrowed to private/unlisted/password
+    // stops serving its already-recorded rows too (recordActivity's write-time gate
+    // alone only stops NEW rows); a deleted artifact's orphaned rows (there
+    // shouldn't be any post-deleteArtifact, but this is cheap defense in depth) drop
+    // out the same way, since there's no matching artifact row to join.
     const rows = db
-      .select()
+      .select(getTableColumns(activity))
       .from(activity)
+      .innerJoin(artifact, eq(artifact.id, activity.artifact_id))
       .where(and(...conds))
       .orderBy(desc(activity.created_at), desc(activity.id))
     return (opts?.limit ? rows.limit(opts.limit) : rows).all() as Promise<ActivityRecord[]>
@@ -2068,6 +2075,7 @@ export function makeRepos(db: SqliteDb) {
     await db.delete(report).where(eq(report.artifact_id, id)).run()
     await db.delete(notification).where(eq(notification.artifact_id, id)).run()
     await db.delete(agentMention).where(eq(agentMention.artifact_id, id)).run()
+    await db.delete(activity).where(eq(activity.artifact_id, id)).run()
     await db.delete(artifact).where(eq(artifact.id, id)).run()
   }
 

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -1,4 +1,5 @@
 import type {
+  ActivityRecord,
   AgentMentionRecord,
   AgentRecord,
   ArtifactMemberRecord,
@@ -24,6 +25,7 @@ import type {
   InvitationRecord,
   ListArtifactsOpts,
   MembershipRecord,
+  NewActivity,
   NewAgent,
   NewAgentMention,
   NewArtifact,
@@ -94,6 +96,7 @@ import {
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core"
 import type { Exhaustive, Shapes } from "./parity"
 import {
+  activity,
   agent,
   agentMention,
   artifact,
@@ -180,6 +183,7 @@ export function artifactListConditions(
 
 /** The drizzle schema object — shared by the better-sqlite3 and D1 drivers. */
 export const schema = {
+  activity,
   artifact,
   version,
   comment,
@@ -217,6 +221,7 @@ export const schema = {
 // table that isn't classified, or a column that drifts, fails to compile here.
 const _schemaExhaustive: Exhaustive<typeof schema> = true
 const _schemaShapes: Shapes<typeof schema> = {
+  activity: true,
   artifact: true,
   version: true,
   comment: true,
@@ -1573,6 +1578,30 @@ export function makeRepos(db: SqliteDb) {
       .returning()
       .get()) ?? null
 
+  // ---- Activity feed -------------------------------------------------------
+  const recordActivity = async (a: NewActivity): Promise<void> => {
+    await db.insert(activity).values(a).run()
+  }
+  const listActivity = async (
+    orgId: string,
+    opts?: { limit?: number; cursor?: { created_at: string; id: string } },
+  ): Promise<ActivityRecord[]> => {
+    const conds = [eq(activity.org_id, orgId)]
+    if (opts?.cursor) {
+      const cursor = or(
+        lt(activity.created_at, opts.cursor.created_at),
+        and(eq(activity.created_at, opts.cursor.created_at), lt(activity.id, opts.cursor.id)),
+      )
+      if (cursor) conds.push(cursor)
+    }
+    const rows = db
+      .select()
+      .from(activity)
+      .where(and(...conds))
+      .orderBy(desc(activity.created_at), desc(activity.id))
+    return (opts?.limit ? rows.limit(opts.limit) : rows).all() as Promise<ActivityRecord[]>
+  }
+
   // ---- Contexts + sessions -------------------------------------------------
   const createContext = async (x: NewContext): Promise<ContextRecord> =>
     (await db.insert(context).values(x).returning().get()) as ContextRecord
@@ -2202,6 +2231,8 @@ export function makeRepos(db: SqliteDb) {
     getPendingRound,
     listReviewRounds,
     resolveReviewRound,
+    recordActivity,
+    listActivity,
     createContext,
     getContext,
     listContexts,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,4 +1,5 @@
 import type {
+  ActivityKind,
   AgentMentionState,
   ArtifactKind,
   AuditAction,
@@ -586,6 +587,33 @@ export const sessionMessage = sqliteTable(
   (t) => [index("session_message_session").on(t.session_id, t.created_at)],
 )
 
+// The workspace Activity feed: one row per notable thing that happened, denormalized
+// like `notification` (artifact_short_id/title snapshotted at write time — a feed
+// entry never joins artifact, and a later rename doesn't rewrite history). Written
+// only for artifacts visible to the whole workspace (never unlisted/private) — see
+// the write-site gate in context.ts's recordActivity.
+export const activity = sqliteTable(
+  "activity",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    kind: text("kind").$type<ActivityKind>().notNull(),
+    artifact_id: text("artifact_id")
+      .notNull()
+      .references(() => artifact.id),
+    artifact_short_id: text("artifact_short_id").notNull(),
+    artifact_title: text("artifact_title"),
+    thread_id: text("thread_id"),
+    version_n: integer("version_n"),
+    actor: text("actor").notNull(),
+    actor_id: text("actor_id"),
+    actor_kind: text("actor_kind").$type<"user" | "agent">().notNull().default("user"),
+    preview: text("preview"),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [index("activity_org_time").on(t.org_id, t.created_at, t.id)],
+)
+
 // Abuse reports against public artifacts; anyone can file one.
 export const report = sqliteTable("report", {
   id: text("id").primaryKey(),
@@ -654,6 +682,7 @@ const TABLES = [
   sessionMessage,
   report,
   auditLog,
+  activity,
 ]
 
 const ddl = generateDdl(TABLES, getTableConfig, {

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -12,6 +12,7 @@ import { and, eq, inArray } from "drizzle-orm"
 import { drizzle } from "drizzle-orm/better-sqlite3"
 import { makeRepos, schema } from "./repos"
 import {
+  activity,
   agentMention,
   artifact,
   artifactFavorite,
@@ -154,6 +155,7 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
         db.delete(report).where(eq(report.artifact_id, id)).run()
         db.delete(notification).where(eq(notification.artifact_id, id)).run()
         db.delete(agentMention).where(eq(agentMention.artifact_id, id)).run()
+        db.delete(activity).where(eq(activity.artifact_id, id)).run()
         db.delete(artifact).where(eq(artifact.id, id)).run()
       })()
     },


### PR DESCRIPTION
## Summary
- Persists a new `activity` table (denormalized like `notification`, mirrored across SQLite/D1/Postgres) fed from 6 existing action routes: publish (×2 sites), comment create/resolve, proposal approve/request-changes, share, and a named viewer's first read of a version.
- Gated to `org`/`link`/`public` visibility — an unlisted draft or private doc never leaks its existence into the shared feed.
- New `GET /v1/activity` (cursor-paginated, same keyset shape as `listArtifacts`) and a new `/activity` page: day-grouped, coalescing consecutive same-actor/same-artifact/same-kind rows into one story ("published 2 revisions of Q3 roadmap · v2 → v3", not two rows).
- Home gets **one quiet link**, not a module: a TriageBar-style line showing the single latest story with a "View" link to the full feed — sits below the existing feedback triage line, disappears entirely when nothing's happened.

Follows the design in ["The Activity Layer: making Derive feel alive"](https://derive.to/artifacts/the-activity-layer-making-derive-feel-alive-gf3ofx15) and its [mockups](https://derive.to/artifacts/the-activity-layer-mockups-3j0va7xa) — this PR is stages 1+2 (spine + feed) plus the requested home link. Following-lens, proposals-in-the-bell, and the weekly digest are named follow-ups, not in scope here.

**Walkthrough with real screenshots:** https://derive.to/artifacts/the-activity-layer-shipped-walkthrough-iorihh89. (Images currently 404 on Chrome — unrelated platform bug found while testing this, fixed separately in #313.)

## Test plan
- [x] `pnpm run ci` green (biome + design-tokens + frontend + testids + api + schema + hyperdrive + filesize + anchor-client + deadcode)
- [x] `pnpm typecheck` green across all 8 workspace packages
- [x] `pnpm test` — 683 pre-existing tests pass, 0 regressions
- [x] Manually verified end-to-end: signed up, published an artifact, set it to workspace visibility, commented, republished twice — confirmed the feed coalesces the two republishes into one "2 revisions" story and the home teaser links to it
- [ ] Following-lens / proposal-into-bell / digest — deliberately out of scope, tracked as follow-ups


🤖 Generated with [Claude Code](https://claude.com/claude-code)




---

## Self-review before merge

Ran an 8-angle review (correctness, removed-behavior, cross-file, reuse, simplification, efficiency, altitude, conventions) and verified the top findings directly against the code and a real ephemeral Postgres. Two real bugs fixed as a follow-up commit:

- **`deleteArtifact` never cleaned up the new `activity` table.** All three dialect implementations were missing it — on Postgres this threw a hard FK-violation and aborted the delete of any artifact that ever had activity recorded; on SQLite/D1 it silently orphaned rows. Fixed in all three (`packages/db/src/repos.ts`, `sqlite.ts`, `pg.ts`), verified against a real Postgres container.
- **A visibility downgrade didn't retroactively hide already-recorded activity.** The write-time gate stopped new rows for a private/unlisted/password artifact, but nothing re-checked an artifact's *current* visibility on read, so a doc downgraded after the fact kept leaking its title + comment previews to the whole workspace forever. Fixed by making `listActivity` join against `artifact` and filter on live visibility, sourced from one new shared constant (`FEED_VISIBLE_TIERS`) so the write and read gates can't drift apart.
- Also: republishing with the `resolves` field (bundling thread resolution into a republish) wasn't recording a "resolve" activity, unlike the dedicated resolve endpoint doing the same state change.
- Added test coverage for `GET /v1/activity` (there was none): auth gate, both visibility gates, deletion, resolves-via-republish, cursor pagination — run against both embedded SQLite and a real Postgres container.

Two other findings were investigated and intentionally left as-is: `activityActor` returning null for the token principal matches `actingUser`/`principalActor`'s existing behavior, and the `?limit=0` falsy-zero coercion is the same pattern already used verbatim in the established `GET /v1/artifacts` handler — fixing either in isolation would diverge from convention rather than fix a bug unique to this PR.
