### PR TITLE
feat(cli): derive context push / dev + context template

### DIFF
--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // derive — scaffold, publish, and run the review loop against a Derive server.
-//   derive init [dir] [--template md|html|slides|site] [--title t]
+//   derive init [dir] [--template md|html|slides|site|skill|context] [--title t]
 //   derive login [--local] [--server url]   OAuth sign-in (default https://derive.to); saves a token
 //   derive publish [file|dir] [--id --title --slug --spa --message --name --visibility --server --token]
 //   derive comments [--id]                 list the artifact's comment threads
@@ -12,13 +12,13 @@
 //   derive send-back [--id] [--note m]     (human) return your answers to the agent
 //   derive approve [--id] [--note m]       (human) approve — the build go-signal
 //   derive runner serve|doctor|install     run a context's answer daemon (npx-able anywhere)
+//   derive context push|dev                ship a context dir as its manifest / tune it live
 import { spawn } from "node:child_process"
 import { createHash, randomBytes } from "node:crypto"
-import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs"
-import { basename, join, relative } from "node:path"
+import { existsSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
 import { createInterface } from "node:readline"
 import { fileURLToPath } from "node:url"
-import { zipSync } from "fflate"
 import {
   CONFIG_FILE,
   formatComments,
@@ -29,8 +29,11 @@ import {
   saveToken,
   scaffold,
   TEMPLATES,
+  writeContextConfig,
   writeId,
 } from "../src/config.js"
+import { createAgent, createContext, saveAgentToken } from "../src/context.js"
+import { readTarget, uploadArtifact } from "../src/publish.js"
 
 const args = process.argv.slice(2)
 const cmd = args.shift()
@@ -61,10 +64,13 @@ if (cmd === "init") {
   const { created, skipped } = scaffold(dir, flags.title ?? "My artifact", template)
   for (const f of created) console.log(`  + ${f}`)
   for (const f of skipped) console.log(`  · ${f} (exists, kept)`)
-  const entry = created.find((f) => f !== CONFIG_FILE && f !== "AGENTS.md") ?? "the entry"
+  // The starter the user should open next — not the config/convention files.
+  const meta = [CONFIG_FILE, "derive.schema.json", "AGENTS.md", ".gitignore"]
+  const entry = created.find((f) => !meta.includes(f) && !f.startsWith(".")) ?? "the entry"
+  const next = template === "context" ? "derive context push" : "derive publish"
   console.log(
     created.length
-      ? `\nReady (${template}). Edit ${entry}, then run \`derive publish\`.`
+      ? `\nReady (${template}). Edit ${entry}, then run \`${next}\`.`
       : `\nNothing to do — ${CONFIG_FILE} already here.`,
   )
   process.exit(0)
@@ -215,6 +221,131 @@ if (cmd === "runner") {
   } catch (e) {
     // Startup failures (bad token, missing manifest) get the house one-liner,
     // not a stack trace; `runner doctor` is the diagnostic.
+    console.error(`error: ${e.message}`)
+    process.exit(1)
+  }
+}
+
+// ---- derive context (push / dev) --------------------------------------------
+// A context is a directory: MANIFEST.md (the runner's system prompt),
+// references/, .mcp.json (the context's tools), .env (stays local, always).
+// `push` ships that directory as the context's manifest bundle; the first push
+// also mints the answering agent and creates the context, so afterwards a push
+// is just a new manifest version — the context's pointer never moves. `dev`
+// answers real sessions with the WORKING TREE manifest: edit, save, next
+// answer uses it, push when it behaves.
+if (cmd === "context") {
+  const sub = positional.shift()
+  if (!["push", "dev"].includes(sub ?? "")) {
+    console.error(`usage:
+  derive context push [dir]    publish the context dir (minus .env*); first push wires agent + context
+  derive context dev  [dir]    run the answer loop on the working-tree manifest [--mock] [--context ctx_id]`)
+    process.exit(1)
+  }
+  const dir = positional[0] ?? "."
+  let cfg = null
+  try {
+    cfg = loadConfig(dir)
+  } catch (e) {
+    console.error(`error: ${e.message}`)
+    process.exit(1)
+  }
+  if (!cfg?.context) {
+    console.error(
+      `error: ${join(dir, CONFIG_FILE)} has no "context" block — scaffold one with \`derive init --template context\``,
+    )
+    process.exit(1)
+  }
+  const p = resolvePublish(flags, cfg)
+  p.token = flags.token ?? process.env.DERIVE_TOKEN ?? (await freshToken(p.server))
+  const target = join(dir, cfg.entry ?? "context")
+  const name = cfg.context.name ?? cfg.title ?? "My context"
+  const tokenFile = join(dir, ".derive", "agent-token")
+
+  if (sub === "push") {
+    if (!p.token) {
+      console.error("error: not signed in — run `derive login` first")
+      process.exit(1)
+    }
+    let up
+    try {
+      up = readTarget(target)
+    } catch (e) {
+      console.error(`error: ${e.message}`)
+      process.exit(1)
+    }
+    const { res, json } = await uploadArtifact(p, up.bytes, up.filename)
+    if (!res.ok) {
+      console.error(`error (${res.status}): ${json.error ?? res.statusText}`)
+      process.exit(1)
+    }
+    if (!p.id && json.short_id) writeId(dir, json.short_id)
+    const shortId = p.id ?? json.short_id
+    console.log(`✓ manifest ${shortId} v${json.current_version}`)
+    for (const s of up.skipped) console.log(`  · ${s} stayed local (secrets never ship)`)
+
+    try {
+      let agentId = cfg.context.agent_id
+      if (!agentId) {
+        const agent = await createAgent(p.server, p.token, name)
+        agentId = agent.id
+        const tokPath = saveAgentToken(dir, agent.token)
+        writeContextConfig(dir, { agent_id: agentId })
+        console.log(
+          `✓ agent "${name}" (${agentId}) — token saved to ${tokPath} (shown nowhere else)`,
+        )
+      }
+      let ctxId = cfg.context.id
+      if (!ctxId) {
+        const created = await createContext(p.server, p.token, {
+          name,
+          agent_id: agentId,
+          manifest_short_id: shortId,
+        })
+        ctxId = created.id
+        writeContextConfig(dir, { id: ctxId })
+        console.log(`✓ context "${name}" (${ctxId})`)
+      }
+      // The manifest's roster is the ask roster — an invite-only manifest means
+      // only its owner can open a session.
+      if (json.visibility === "private")
+        console.log(
+          `  invite-only — share the manifest (Share dialog, or --visibility org) so teammates can ask`,
+        )
+      console.log(
+        `\nRun it:\n  derive runner serve ${ctxId} --token-file ${tokenFile} --cwd ${target}\nTune it:\n  derive context dev`,
+      )
+    } catch (e) {
+      console.error(`error: ${e.message}`)
+      process.exit(1)
+    }
+    process.exit(0)
+  }
+
+  // dev: the runner, pointed at this working tree.
+  const ctxId = flags.context ?? cfg.context.id
+  if (!ctxId) {
+    console.error(
+      "error: no context id — `derive context push` once (it pins context.id), or pass --context",
+    )
+    process.exit(1)
+  }
+  const devFlags = {
+    ...flags,
+    context: ctxId,
+    server: p.server,
+    cwd: flags.cwd ?? target,
+    "manifest-file": flags["manifest-file"] ?? join(target, "MANIFEST.md"),
+  }
+  if (!flags.token && !flags["token-file"] && existsSync(tokenFile))
+    devFlags["token-file"] = tokenFile
+  const envFile = join(target, ".env")
+  if (!flags["env-file"] && existsSync(envFile)) devFlags["env-file"] = envFile
+  const { loadRunnerConfig, serve } = await import("../src/runner.js")
+  try {
+    const rcfg = loadRunnerConfig(process.env, devFlags)
+    await serve(rcfg) // runs until killed
+  } catch (e) {
     console.error(`error: ${e.message}`)
     process.exit(1)
   }
@@ -373,7 +504,7 @@ if (LOOP.includes(cmd)) {
 
 if (cmd !== "publish") {
   console.error(`usage:
-  derive init [dir] [--template md|html|slides|site] [--title t]
+  derive init [dir] [--template md|html|slides|site|skill|context] [--title t]
   derive login [--local] [--server url]    OAuth sign-in (defaults to https://derive.to); saves a persistent token
   derive publish [file|dir] [--id X] [--title t] [--slug s] [--spa] [--message m] [--name "x"] [--visibility v] [--password p] [--server url] [--token t] [--json]
   derive comments [--id X]                 list comment threads
@@ -384,7 +515,8 @@ if (cmd !== "publish") {
   derive status [--id X] [--json]          review-round state + open threads (the loop's poll target)
   derive send-back [--id X] [--note m]     (human) return your answers to the waiting agent
   derive approve [--id X] [--note m]       (human) approve — the build go-signal
-  derive runner serve|doctor|install       run a context's answer daemon (\`derive runner\` for flags)`)
+  derive runner serve|doctor|install       run a context's answer daemon (\`derive runner\` for flags)
+  derive context push|dev                  ship a context dir as its manifest / tune it on the working tree`)
   process.exit(cmd ? 1 : 0)
 }
 
@@ -405,61 +537,26 @@ if (!p.target) {
   process.exit(1)
 }
 
-const collect = (dir, base, out = {}) => {
-  for (const name of readdirSync(dir)) {
-    if (
-      name === ".DS_Store" ||
-      name === "node_modules" ||
-      name.startsWith(".git") ||
-      name === CONFIG_FILE
-    )
-      continue
-    const path = join(dir, name)
-    const st = statSync(path)
-    if (st.isDirectory()) collect(path, base, out)
-    else out[relative(base, path).split("\\").join("/")] = readFileSync(path)
-  }
-  return out
-}
-
-let bytes
-let filename
-const st = statSync(p.target)
-if (st.isDirectory()) {
-  const files = collect(p.target, p.target)
-  if (Object.keys(files).length === 0) {
-    console.error(`error: ${p.target} is empty`)
-    process.exit(1)
-  }
-  bytes = zipSync(files)
-  filename = `${basename(p.target)}.zip`
-} else {
-  bytes = readFileSync(p.target)
-  filename = basename(p.target)
-}
-
-const form = new FormData()
-form.append("file", new Blob([bytes]), filename)
-if (p.title) form.append("title", p.title)
-if (p.slug) form.append("slug", p.slug)
-if (p.spa) form.append("spa", "true")
-if (p.message) form.append("message", p.message)
-if (p.name) form.append("name", p.name)
-if (p.visibility) form.append("visibility", p.visibility)
-// --password is a per-publish secret for `--visibility password`; never put it in
-// derive.json (it isn't a config field), only pass it on the command line.
-if (p.password) form.append("password", p.password)
-if (flags.review) form.append("request_review", "true")
-
 p.token = flags.token ?? process.env.DERIVE_TOKEN ?? (await freshToken(p.server))
-const url = p.id ? `${p.server}/v1/artifacts/${p.id}/versions` : `${p.server}/v1/artifacts`
-const headers = p.token ? { authorization: `Bearer ${p.token}` } : {}
-const res = await fetch(url, { method: "POST", body: form, headers })
-const json = await res.json().catch(() => ({}))
+let up
+try {
+  up = readTarget(p.target)
+} catch (e) {
+  console.error(`error: ${e.message}`)
+  process.exit(1)
+}
+const { res, json } = await uploadArtifact(
+  p,
+  up.bytes,
+  up.filename,
+  flags.review ? { request_review: "true" } : {},
+)
 if (!res.ok) {
   console.error(`error (${res.status}): ${json.error ?? res.statusText}`)
   process.exit(1)
 }
+// stderr so `--json` stdout stays parseable.
+for (const s of up.skipped) console.error(`  · ${s} stayed local (.env files never ship)`)
 
 // First publish of a configured project: remember the id so the next publish
 // targets the same artifact with zero flags.

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -115,7 +115,7 @@ export const defaultConfig = (title = "My artifact", entry = "index.md") => ({
   id: null,
 })
 
-export const TEMPLATES = ["md", "html", "slides", "site", "skill"]
+export const TEMPLATES = ["md", "html", "slides", "site", "skill", "context"]
 
 /** Read derive.json from `dir`, or null if absent. Throws on malformed JSON. */
 export function loadConfig(dir = ".") {
@@ -160,6 +160,16 @@ export function writeId(dir, id) {
   return config
 }
 
+/** Merge server-assigned context wiring (id, agent_id) into derive.json's
+ *  context block, preserving everything else — the context-side twin of writeId. */
+export function writeContextConfig(dir, patch) {
+  const path = join(dir, CONFIG_FILE)
+  const config = loadConfig(dir) ?? defaultConfig()
+  config.context = { ...config.context, ...patch }
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`)
+  return config
+}
+
 // Each template's entry (what `derive publish` targets) + the starter file(s) it
 // writes. `site` is a multi-file bundle (entry is a directory). derive.json,
 // derive.schema.json, and AGENTS.md are added to every template.
@@ -186,6 +196,23 @@ const STARTERS = {
       "skill/references/example.md": STARTER_SKILL_REFERENCE,
     }),
   },
+  // A Derive context: one directory that is the runner's whole world — MANIFEST.md
+  // (the system prompt), references/ (docs the model reads from disk), .mcp.json
+  // (the context's data-source tools), and .env (secrets — stays local, always).
+  // `derive context push` ships everything in it except .env*.
+  context: {
+    entry: "context",
+    files: (t) => ({
+      "context/MANIFEST.md": starterManifest(t),
+      "context/references/example.md": STARTER_CONTEXT_REFERENCE,
+      "context/.mcp.json": `${JSON.stringify({ mcpServers: {} }, null, 2)}\n`,
+      "context/.env.example": STARTER_CONTEXT_ENV,
+      ".gitignore": CONTEXT_GITIGNORE,
+    }),
+    // The context block pins the server-side wiring (context id, agent id) the
+    // way `id` pins the artifact — filled in by the first `derive context push`.
+    extend: (config, title) => ({ ...config, context: { id: null, agent_id: null, name: title } }),
+  },
 }
 
 /**
@@ -197,8 +224,11 @@ const STARTERS = {
  */
 export function scaffoldFiles(title = "My artifact", template = "md") {
   const t = STARTERS[template] ?? STARTERS.md
+  const config = t.extend
+    ? t.extend(defaultConfig(title, t.entry), title)
+    : defaultConfig(title, t.entry)
   return {
-    [CONFIG_FILE]: `${JSON.stringify(defaultConfig(title, t.entry), null, 2)}\n`,
+    [CONFIG_FILE]: `${JSON.stringify(config, null, 2)}\n`,
     "derive.schema.json": `${JSON.stringify(DERIVE_SCHEMA, null, 2)}\n`,
     ...t.files(title),
     "AGENTS.md": AGENTS_MD,
@@ -247,6 +277,15 @@ export const DERIVE_SCHEMA = {
       description: "Artifact short id; set automatically on first publish.",
     },
     server: { type: "string", description: "Derive server URL (overrides DERIVE_SERVER)." },
+    context: {
+      type: "object",
+      description: "Context wiring (context projects only); ids are set by the first push.",
+      properties: {
+        id: { type: ["string", "null"], description: "Context id (ctx_…)." },
+        agent_id: { type: ["string", "null"], description: "The answering agent's id (ag_…)." },
+        name: { type: "string", description: "Context name shown to askers." },
+      },
+    },
   },
 }
 
@@ -339,6 +378,65 @@ const STARTER_SKILL_REFERENCE = `# Reference
 
 Extra detail the skill loads on demand — keep SKILL.md lean and push the long tail
 (edge cases, tables, examples) into reference files like this one.
+`
+
+const starterManifest = (title) => `# ${title} — context manifest
+
+This file is the runner's system prompt. Editing it (and pushing) reconfigures
+the agent's judgment with no redeploy — the next answer uses the new version.
+
+## Who you are
+
+Describe the agent in a sentence: what it knows, who asks it questions, and on
+whose behalf it answers.
+
+## Data sources
+
+Name each source the runner's tools reach (see \`.mcp.json\` in this directory)
+and what it's authoritative for. Say what is READ-ONLY — the tools should
+enforce it, but the manifest is where the intent lives.
+
+## Judgment
+
+The decision rules a good analyst would apply: which source wins when two
+disagree, what "active" or "churned" mean here, units and timezones, the
+denominators that make a percentage honest.
+
+## References
+
+Files in \`references/\` sit next to this manifest in the runner's working
+directory — point at them by relative path ("read references/schema.md before
+writing SQL") and the model reads them on demand. Keep this file lean; push the
+long tail there.
+
+## Escalation
+
+When to answer with \`escalate: true\` instead of guessing: thresholds, topics
+that need a human (pricing, legal, anything contractual), and who the human is.
+
+## Answer style
+
+Concise summary first, then supporting detail. State caveats explicitly. Include
+the query used when a number came from one.
+`
+
+const STARTER_CONTEXT_REFERENCE = `# Reference
+
+Files here travel with \`derive context push\` (versioned alongside the manifest)
+and sit in the runner's working directory — the manifest should point at them by
+relative path. Schema notes, metric definitions, worked examples: the long tail
+that would bloat MANIFEST.md lives here.
+`
+
+const STARTER_CONTEXT_ENV = `# Secrets the context's MCP servers need (see .mcp.json). Copy to .env and fill
+# in — .env stays on this machine: push excludes it and .gitignore covers it.
+# EXAMPLE_API_KEY=
+`
+
+const CONTEXT_GITIGNORE = `# Secrets never leave the machine: .env holds the context's credentials, .derive/
+# holds the agent token minted by the first push.
+context/.env
+.derive/
 `
 
 const starterMd = (title) => `# ${title}

--- a/packages/cli/src/context.js
+++ b/packages/cli/src/context.js
@@ -1,0 +1,78 @@
+// Server wiring for `derive context push`: mint the answering agent and create
+// the context on first push. Both are idempotent from derive.json's point of
+// view — once the ids are pinned there, pushes are pure artifact versions.
+import { mkdirSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+
+const post = async (server, token, path, body) => {
+  const res = await fetch(`${server}${path}`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  const json = await res.json().catch(() => ({}))
+  return { res, json }
+}
+
+/** Mint the context's answering agent (role editor — it publishes the charts
+ *  its answers link). The raw token comes back exactly once; the caller must
+ *  persist it immediately. */
+export async function createAgent(server, token, name) {
+  const { res, json } = await post(server, token, "/v1/agents", { name, role: "editor" })
+  // 401: agent/context management currently needs a signed-in user — the CLI's
+  // OAuth token resolves as an on-behalf agent, which these routes don't accept
+  // yet. The manifest still pushed; only the one-time wiring is manual.
+  if (res.status === 401 || res.status === 403)
+    throw new Error(
+      `this token can't manage agents (${res.status}) — wire it once in the console:\n` +
+        `  1. ${server} → Settings → Agents → New agent ("${name}", role editor); save its token to .derive/agent-token\n` +
+        `  2. ${server} → Contexts → New context → pick the agent + this manifest\n` +
+        `  3. put the agent id in derive.json (context.agent_id) and the context id in context.id\n` +
+        `after that, every push is just a manifest version — no wiring, no console`,
+    )
+  if (res.status === 409)
+    throw new Error(
+      `an agent named "${name}" already exists — set its id as context.agent_id in derive.json (its token was shown when it was created)`,
+    )
+  if (!res.ok) throw new Error(`agent creation failed (${res.status}): ${json.error ?? "unknown"}`)
+  return { id: json.id, token: json.token }
+}
+
+/** Create the context wiring agent → manifest. On a name collision, adopt the
+ *  existing context if it already points at this manifest (a lost derive.json
+ *  should re-pin, not dead-end). */
+export async function createContext(server, token, { name, agent_id, manifest_short_id }) {
+  const { res, json } = await post(server, token, "/v1/contexts", {
+    name,
+    agent_id,
+    manifest_short_id,
+  })
+  if (res.ok) return json
+  if (res.status === 401)
+    throw new Error(
+      `this token can't create contexts (401) — create it once in the console (${server} → Contexts → New, agent + manifest ${manifest_short_id}), then set context.id in derive.json`,
+    )
+  if (res.status === 409) {
+    const list = await fetch(`${server}/v1/contexts`, {
+      headers: { authorization: `Bearer ${token}` },
+    })
+    const existing = ((await list.json().catch(() => ({}))).contexts ?? []).find(
+      (x) => x.name === name && x.manifest_short_id === manifest_short_id,
+    )
+    if (existing) return existing
+    throw new Error(
+      `a context named "${name}" already exists with a different manifest — rename in derive.json (context.name) or delete the old context`,
+    )
+  }
+  throw new Error(`context creation failed (${res.status}): ${json.error ?? "unknown"}`)
+}
+
+/** Persist the agent token where the runner's --token-file expects it: outside
+ *  the pushed directory, owner-only, covered by the scaffold's .gitignore. */
+export function saveAgentToken(dir, token) {
+  const tokDir = join(dir, ".derive")
+  mkdirSync(tokDir, { recursive: true })
+  const path = join(tokDir, "agent-token")
+  writeFileSync(path, `${token}\n`, { mode: 0o600 })
+  return path
+}

--- a/packages/cli/src/publish.js
+++ b/packages/cli/src/publish.js
@@ -1,0 +1,70 @@
+// The upload half of `derive publish`, extracted so `derive context push`
+// publishes the same way (create-or-version by id) without duplicating the
+// collect/zip/request logic.
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import { basename, join, relative } from "node:path"
+import { zipSync } from "fflate"
+import { CONFIG_FILE } from "./config.js"
+
+// Secrets never ship: .env and .env.* stay local. .env.example is the one
+// conventionally secret-free name, so it travels — it documents what a new
+// host must provide.
+const isEnvSecret = (name) =>
+  name === ".env" || (name.startsWith(".env.") && name !== ".env.example")
+
+/** Recursively collect a directory into {relativePath: bytes} for zipping.
+ *  Returns the files plus the .env-rule exclusions in `skipped`, so the caller
+ *  can make the "your secrets stayed local" contract visible. */
+export function collectDir(dir, base = dir, out = { files: {}, skipped: [] }) {
+  for (const name of readdirSync(dir)) {
+    if (
+      name === ".DS_Store" ||
+      name === "node_modules" ||
+      name.startsWith(".git") ||
+      name === CONFIG_FILE
+    )
+      continue
+    const path = join(dir, name)
+    if (isEnvSecret(name)) {
+      out.skipped.push(relative(base, path).split("\\").join("/"))
+      continue
+    }
+    const st = statSync(path)
+    if (st.isDirectory()) collectDir(path, base, out)
+    else out.files[relative(base, path).split("\\").join("/")] = readFileSync(path)
+  }
+  return out
+}
+
+/** Read the publish target (file or directory) into upload bytes.
+ *  Directories zip client-side; the server unpacks them into a bundle. */
+export function readTarget(target) {
+  if (statSync(target).isDirectory()) {
+    const { files, skipped } = collectDir(target)
+    if (Object.keys(files).length === 0) throw new Error(`${target} is empty`)
+    return { bytes: zipSync(files), filename: `${basename(target)}.zip`, skipped }
+  }
+  return { bytes: readFileSync(target), filename: basename(target), skipped: [] }
+}
+
+/** POST the upload: a new artifact, or a new version when `id` is set.
+ *  Returns { res, json } — HTTP-level failures are the caller's to present. */
+export async function uploadArtifact(p, bytes, filename, extra = {}) {
+  const form = new FormData()
+  form.append("file", new Blob([bytes]), filename)
+  if (p.title) form.append("title", p.title)
+  if (p.slug) form.append("slug", p.slug)
+  if (p.spa) form.append("spa", "true")
+  if (p.message) form.append("message", p.message)
+  if (p.name) form.append("name", p.name)
+  if (p.visibility) form.append("visibility", p.visibility)
+  // --password is a per-publish secret for `--visibility password`; never put it in
+  // derive.json (it isn't a config field), only pass it on the command line.
+  if (p.password) form.append("password", p.password)
+  for (const [k, v] of Object.entries(extra)) form.append(k, v)
+  const url = p.id ? `${p.server}/v1/artifacts/${p.id}/versions` : `${p.server}/v1/artifacts`
+  const headers = p.token ? { authorization: `Bearer ${p.token}` } : {}
+  const res = await fetch(url, { method: "POST", body: form, headers })
+  const json = await res.json().catch(() => ({}))
+  return { res, json }
+}

--- a/packages/cli/src/runner.js
+++ b/packages/cli/src/runner.js
@@ -80,6 +80,10 @@ export function loadRunnerConfig(env = process.env, flags = {}, { partial = fals
     timeoutMs: positiveMs(flags.timeout ?? env.RUNNER_TIMEOUT_MS, 600_000, 10_000),
     pollMs: positiveMs(flags.poll ?? env.RUNNER_POLL_MS, 5_000, 500),
     mock: flags.mock === "true" || env.RUNNER_MOCK === "1",
+    // Dev mode (`derive context dev`): the system prompt comes from this local
+    // file instead of the pushed manifest — edit, save, and the next answer
+    // uses it, no push. Sessions and answers still go through the server.
+    manifestFile: flags["manifest-file"] ?? null,
     // Carried so `runner install` can reproduce this exact config in a unit —
     // a rendered service that silently dropped the env files would boot a
     // runner whose MCP servers have no credentials.
@@ -427,10 +431,12 @@ async function serveSession(client, session, manifest, cfg) {
 export async function serve(cfg) {
   const client = new DeriveClient(cfg.server, cfg.token)
   const info = await client.getContext(cfg.contextId)
-  if (!info.manifest_md) throw new Error("context has no readable manifest")
+  if (!info.manifest_md && !cfg.manifestFile) throw new Error("context has no readable manifest")
+  if (cfg.manifestFile) readFileSync(cfg.manifestFile, "utf8") // fail at startup, not first answer
   console.log(
     `[runner] serving "${info.name}" (${cfg.contextId}) on ${cfg.server} — ` +
-      `manifest v${info.manifest_version}, ${cfg.mock ? "MOCK" : `${cfg.claudeBin} (${cfg.model})`}, poll ${cfg.pollMs}ms`,
+      `${cfg.manifestFile ? `manifest LOCAL ${cfg.manifestFile}` : `manifest v${info.manifest_version}`}, ` +
+      `${cfg.mock ? "MOCK" : `${cfg.claudeBin} (${cfg.model})`}, poll ${cfg.pollMs}ms`,
   )
 
   for (;;) {
@@ -447,9 +453,11 @@ export async function serve(cfg) {
       })
       if (sessions.length > 0) {
         // Re-read the manifest only when the queue has work — an edit applies
-        // from the next answer, and idle polls stay one call.
-        const fresh = await client.getContext(cfg.contextId)
-        const manifest = fresh.manifest_md ?? info.manifest_md
+        // from the next answer, and idle polls stay one call. In dev mode the
+        // working-tree file wins, same freshness contract.
+        const manifest = cfg.manifestFile
+          ? readFileSync(cfg.manifestFile, "utf8")
+          : ((await client.getContext(cfg.contextId)).manifest_md ?? info.manifest_md)
         // Sequential on purpose: one runner, one model, no fan-out — fairness
         // comes from the queue's oldest-first order. One session's failure must
         // not starve the rest of the batch.
@@ -580,6 +588,7 @@ export function renderServiceUnit(cfg, binPath, platform = process.platform) {
   ]
   if (cfg.tokenFile) argv.push("--token-file", cfg.tokenFile)
   if (cfg.envFiles?.length) argv.push("--env-file", cfg.envFiles.join(","))
+  if (cfg.manifestFile) argv.push("--manifest-file", cfg.manifestFile)
   if (platform === "darwin") {
     // Paths with &, <, > (think "/Users/x/R&D") would render a plist launchctl
     // rejects outright.

--- a/packages/cli/test/config.test.js
+++ b/packages/cli/test/config.test.js
@@ -14,6 +14,7 @@ import {
   scaffoldFiles,
   TEMPLATES,
   tokenFor,
+  writeContextConfig,
   writeId,
 } from "../src/config.js"
 
@@ -104,7 +105,7 @@ describe("scaffold", () => {
   })
 
   it("exposes the templates", () => {
-    expect(TEMPLATES).toEqual(["md", "html", "slides", "site", "skill"])
+    expect(TEMPLATES).toEqual(["md", "html", "slides", "site", "skill", "context"])
     expect(Object.keys(scaffoldFiles("T", "slides"))).toContain("slides.html")
   })
 
@@ -117,6 +118,38 @@ describe("scaffold", () => {
     const md = files["skill/SKILL.md"]
     expect(md).toMatch(/^---\nname: my-cool-skill\n/) // title slugified to a skill name
     expect(md).toContain("description:")
+  })
+
+  it("scaffolds a context: manifest + references + tools + env hygiene", () => {
+    const files = scaffoldFiles("Analytics", "context")
+    const names = Object.keys(files)
+    expect(names).toContain("context/MANIFEST.md")
+    expect(names).toContain("context/references/example.md")
+    expect(names).toContain("context/.mcp.json")
+    expect(names).toContain("context/.env.example")
+    // .env and the minted agent token must never reach git.
+    expect(files[".gitignore"]).toContain("context/.env")
+    expect(files[".gitignore"]).toContain(".derive/")
+    const cfg = JSON.parse(files[CONFIG_FILE])
+    expect(cfg.entry).toBe("context")
+    expect(cfg.context).toEqual({ id: null, agent_id: null, name: "Analytics" })
+  })
+})
+
+describe("writeContextConfig", () => {
+  it("merges wiring ids into the context block, preserving everything else", () => {
+    const d = tmp()
+    writeFileSync(
+      join(d, CONFIG_FILE),
+      JSON.stringify({ title: "T", entry: "context", id: "abc", context: { id: null, name: "T" } }),
+    )
+    writeContextConfig(d, { agent_id: "ag_1" })
+    const cfg = writeContextConfig(d, { id: "ctx_1" })
+    expect(cfg).toMatchObject({
+      title: "T",
+      id: "abc",
+      context: { id: "ctx_1", agent_id: "ag_1", name: "T" },
+    })
   })
 })
 

--- a/packages/cli/test/publish.test.js
+++ b/packages/cli/test/publish.test.js
@@ -1,0 +1,55 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { collectDir, readTarget } from "../src/publish.js"
+
+const dirs = []
+const tmp = () => {
+  const d = mkdtempSync(join(tmpdir(), "derive-publish-"))
+  dirs.push(d)
+  return d
+}
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+
+describe("collectDir", () => {
+  it("keeps .env* out of the upload — anywhere in the tree — and reports it", () => {
+    const d = tmp()
+    mkdirSync(join(d, "references"))
+    writeFileSync(join(d, "MANIFEST.md"), "# m")
+    writeFileSync(join(d, ".env"), "SECRET=1")
+    writeFileSync(join(d, ".env.production"), "SECRET=2")
+    writeFileSync(join(d, ".env.example"), "SECRET=")
+    writeFileSync(join(d, "references", ".env"), "SECRET=3")
+    writeFileSync(join(d, "references", "schema.md"), "# s")
+    const { files, skipped } = collectDir(d)
+    expect(Object.keys(files).sort()).toEqual([
+      ".env.example",
+      "MANIFEST.md",
+      "references/schema.md",
+    ])
+    expect(skipped.sort()).toEqual([".env", ".env.production", "references/.env"])
+  })
+})
+
+describe("readTarget", () => {
+  it("zips a directory (carrying the skip list) and passes a file through", () => {
+    const d = tmp()
+    writeFileSync(join(d, "MANIFEST.md"), "# m")
+    writeFileSync(join(d, ".env"), "SECRET=1")
+    const dir = readTarget(d)
+    expect(dir.filename).toMatch(/\.zip$/)
+    expect(dir.skipped).toEqual([".env"])
+    const file = readTarget(join(d, "MANIFEST.md"))
+    expect(file.filename).toBe("MANIFEST.md")
+    expect(file.skipped).toEqual([])
+  })
+
+  it("rejects a directory with nothing publishable in it", () => {
+    const d = tmp()
+    writeFileSync(join(d, ".env"), "SECRET=1")
+    expect(() => readTarget(d)).toThrow(/empty/)
+  })
+})

--- a/packages/cli/test/runner.test.js
+++ b/packages/cli/test/runner.test.js
@@ -133,6 +133,14 @@ describe("loadRunnerConfig", () => {
     expect(cfg.token).toBe("")
     expect(cfg.contextId).toBe("")
   })
+
+  it("carries --manifest-file (dev mode) into the config", () => {
+    const cfg = loadRunnerConfig(
+      { DERIVE_TOKEN: "t" },
+      { context: "ctx_x", "manifest-file": "/work/context/MANIFEST.md" },
+    )
+    expect(cfg.manifestFile).toBe("/work/context/MANIFEST.md")
+  })
 })
 
 describe("output contract + service units", () => {
@@ -148,11 +156,13 @@ describe("output contract + service units", () => {
     )
     cfg.tokenFile = "/secrets/tok"
     cfg.envFiles = ["/work/.env", "/work/extra.env"]
+    cfg.manifestFile = "/work/context/MANIFEST.md"
     const mac = renderServiceUnit(cfg, "/opt/cli/bin/derive.js", "darwin")
     expect(mac.unit).toContain("<string>ctx_abc</string>")
     expect(mac.unit).toContain("<string>--token-file</string>")
     expect(mac.unit).toContain("<string>/work/.env,/work/extra.env</string>")
     expect(mac.unit).toContain("<string>2400000</string>") // timeout survives into the unit
+    expect(mac.unit).toContain("<string>--manifest-file</string>")
     expect(mac.path).toContain("to.derive.runner.abc")
     const linux = renderServiceUnit(cfg, "/opt/cli/bin/derive.js", "linux")
     expect(linux.unit).toContain("ExecStart=")

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -81,8 +81,10 @@ const MAX_BUNDLE_UNZIPPED_BYTES = 50 * 1024 * 1024 // 50 MB
  * Choose a bundle's entry page. An HTML site enters at its root `index.html`, else
  * its shallowest `.html`. A doc/skill bundle with no HTML (a Claude Code skill is a
  * folder of `SKILL.md` + scripts/refs, no HTML) falls back to `SKILL.md`, then
- * `README.md`, then the shallowest markdown file — markdown entries render through
- * the markdown path at serve time. Null when the bundle has neither HTML nor markdown.
+ * `MANIFEST.md` (a context source dir — the entry is the runner's system prompt, and
+ * a stray root README must not hijack it), then `README.md`, then the shallowest
+ * markdown file — markdown entries render through the markdown path at serve time.
+ * Null when the bundle has neither HTML nor markdown.
  */
 export const pickBundleEntry = (paths: string[]): string | null => {
   const shallowest = (pred: (p: string) => boolean): string | undefined =>
@@ -91,6 +93,7 @@ export const pickBundleEntry = (paths: string[]): string | null => {
   const html = shallowest((p) => p.endsWith(".html"))
   if (html) return html
   if (paths.includes("/SKILL.md")) return "/SKILL.md"
+  if (paths.includes("/MANIFEST.md")) return "/MANIFEST.md"
   if (paths.includes("/README.md")) return "/README.md"
   return shallowest((p) => /\.(md|markdown)$/i.test(p)) ?? null
 }

--- a/packages/core/test/publish.test.ts
+++ b/packages/core/test/publish.test.ts
@@ -263,6 +263,20 @@ describe("publish: bundles (zip)", () => {
     )
     expect(mc.entry).toBe("/top.md")
   })
+
+  it("a context source dir enters at MANIFEST.md even when a README sits beside it", async () => {
+    // The entry is the runner's system prompt — a docs README must not hijack it.
+    const blobs = makeBlobs()
+    const a = await publish(
+      makeMeta(),
+      blobs,
+      bundle({ "MANIFEST.md": "# m", "README.md": "# r", "references/schema.md": "# s" }),
+    )
+    const ma = JSON.parse(
+      new TextDecoder().decode((await blobs.get(a.version.blob_key)) ?? undefined),
+    )
+    expect(ma.entry).toBe("/MANIFEST.md")
+  })
 })
 
 describe("publish: republish an existing artifact", () => {


### PR DESCRIPTION
Sprint 1 item 3 (plan bzjg35x0 v2): a context becomes a directory you can clone.

## The model

One directory is the runner's whole world:

```
context/
  MANIFEST.md    # the system prompt — the bundle's entry file
  references/    # docs the model reads from cwd by relative path
  .mcp.json      # the context's data-source tools — travels with the push
  .env           # secrets — stays local, ALWAYS (excluded + gitignored)
```

The dir publishes as a **bundle artifact** and the context points at it — the entire artifact machinery (versions, sharing, pull) is reused, and since `push` versions the *same* artifact, the context's pointer never moves. `GET /v1/contexts/:id` already serves a bundle's entry file as `manifest_md` via `sourceText`, so the runner needs zero changes.

## Verbs

- `derive init --template context` — scaffold (manifest skeleton distilled from the two live pilots, env hygiene wired: .gitignore covers `context/.env` + `.derive/`)
- `derive context push [dir]` — ship the dir (minus `.env*`) as the manifest; first push mints the answering agent (editor role, token → `.derive/agent-token`, 0600) and creates the context; later pushes are pure manifest versions
- `derive context dev [dir]` — the runner with `--manifest-file`: answers real sessions using the **working tree** manifest; edit → save → next answer uses it; push when it behaves

## Server change (one line)

`pickBundleEntry` prefers `/MANIFEST.md` over `/README.md` — the entry is the runner's system prompt, and the README any git-hosted context dir naturally grows must not hijack it.

## Also

- publish upload core extracted to `src/publish.js` (shared by `publish` + `context push`); `.env`/`.env.*` (except `.env.example`) excluded from **every** directory upload, with the skip printed
- `init`'s "edit X next" hint no longer points at `derive.schema.json`

## Known gap → follow-up PR

The CLI's OAuth token resolves as an on-behalf **agent**, and `POST /v1/agents` / `POST /v1/contexts` are user-gated — so first-push wiring 403s from the CLI and degrades to printing the exact console steps. The fix is an auth-model extension (a manage-grade scope through the consent screen + these routes accepting the on-behalf principal, role-capped by membership) and deserves its own review given #301 just hardened that surface.

## Verified

- 46 CLI + 276 core unit tests; full `pnpm run ci` + typecheck green
- Against derive.to: bundle push (v1), version push (v2), `pull` round-trips MANIFEST.md, secrets-skip printed, 403 degradation prints the wiring steps
- `context dev --mock` against the live Analytics context: serves with `manifest LOCAL context/MANIFEST.md`