### PR TITLE
fix: raw content sub-resources 404 in Chrome for non-public artifacts

### DIFF
--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -23,7 +23,7 @@ import { z } from "zod"
 import type { AppContext } from "../context"
 import { publishSweepEvents } from "../lib/anchor-sweep"
 import { authorProfile, resolveHandles } from "../lib/author"
-import { hashPassword, unlockCookie, unlockToken, verifyPassword } from "../lib/crypto"
+import { hashPassword, signState, unlockCookie, unlockToken, verifyPassword } from "../lib/crypto"
 import {
   DEFAULT_WORKSPACE_NAME,
   fail,
@@ -678,6 +678,15 @@ export const artifactRoutes = (ctx: AppContext) => {
       // Mirrored from a GitHub sync source → read-only in Derive (the client hides
       // Edit/Propose; the publish/propose routes also refuse it server-side).
       managed: (await meta.managedArtifactIds(artifact.org_id)).includes(artifact.id),
+      // The content iframe is sandboxed with no `allow-same-origin` (opaque origin —
+      // it must not be able to touch derive.to cookies/storage), which means it also has
+      // no origin of its own to send OUR session cookie back on, and Chrome refuses to
+      // attach cookies to requests from an opaque origin at all (even same-site) — every
+      // sub-resource (image, css, ...) in a non-public bundle 404s there. `read` access
+      // was just proven above, so mint a short-lived capability the SPA embeds in the raw
+      // URL's path (raw.ts's `t/:token` route + RAW_TOKEN_MAX_AGE_MS) — path, not query,
+      // so relative asset references inherit it with zero HTML rewriting.
+      raw_token: signState({ rid: artifact.id }, deps.encryptionKey ?? ""),
     })
   })
 

--- a/apps/api/src/routes/raw.ts
+++ b/apps/api/src/routes/raw.ts
@@ -1,14 +1,22 @@
-import { ANCHOR_CLIENT_JS } from "@derive/core"
+import { ANCHOR_CLIENT_JS, type ArtifactRecord } from "@derive/core"
+import type { Context } from "hono"
 import { Hono } from "hono"
 import type { AppContext } from "../context"
 import { crossDocTransform } from "../lib/cross-doc"
+import { verifyState } from "../lib/crypto"
 import { cacheControlFor, TOMBSTONE } from "../lib/http"
 import { serveContent } from "../lib/serve-content"
+
+// How long a minted raw_token (artifacts.ts's GET detail response) stays good for. It
+// doesn't re-check role/visibility live the way the cookie path's authorize() does, so
+// it's kept short — long enough to browse one sitting of a multi-page/image bundle,
+// short enough to bound exposure if the URL leaks (browser history, a proxy log, ...).
+const RAW_TOKEN_MAX_AGE_MS = 5 * 60 * 1000
 
 /** The sandbox: raw artifact + proposal bytes under /raw/*. Served with an
  *  opaque-origin CSP; a proposal renders exactly like the live version will. */
 export const rawRoutes = (ctx: AppContext) => {
-  const { meta, blobs, authorize, background } = ctx
+  const { meta, blobs, deps, authorize, background } = ctx
   const app = new Hono()
 
   // The comment-anchor client, referenced by URL from artifact HTML. Artifact
@@ -21,17 +29,15 @@ export const rawRoutes = (ctx: AppContext) => {
     }),
   )
 
-  app.get("/raw/:shortId/v/:n/*", async (c) => {
-    const shortId = c.req.param("shortId")
-    const n = Number(c.req.param("n"))
-    const artifact = await meta.getByShortId(shortId)
-    if (!artifact || !Number.isInteger(n) || !(await authorize(c, "read", artifact)))
-      return c.text("not found", 404)
+  // Shared by both entry points below (cookie-authorized and token-authorized): once
+  // `artifact` is known readable, serve version `n` under `prefix`. `prefix` carries
+  // whatever the entry point needs relative asset references to inherit — for the
+  // token route that's the `/t/:token` segment, so a bundle's own `<img src="x.png">`
+  // requests automatically replay the same proof of access with no HTML rewriting.
+  const serveVersion = async (c: Context, artifact: ArtifactRecord, n: number, prefix: string) => {
     if (artifact.removed_at) return c.text(TOMBSTONE, 410)
     const version = await meta.getVersion(artifact.id, n)
     if (!version) return c.text("not found", 404)
-
-    const prefix = `/raw/${shortId}/v/${c.req.param("n")}/`
     const path = decodeURIComponent(c.req.path.slice(prefix.length))
     // `?reader=1` (the in-app Reader toggle) re-renders the content clean + responsive.
     const reader = ["1", "true"].includes(c.req.query("reader") ?? "")
@@ -55,6 +61,47 @@ export const rawRoutes = (ctx: AppContext) => {
       true,
       reader,
     )
+  }
+
+  // The sandboxed content iframe's own entry point: a signed capability in the PATH
+  // (not a query param — a relative URL resolves against its base's path only, so a
+  // query-string token wouldn't reach a bundle's own `screenshots/x.png`-style
+  // references, but a path segment does, automatically, for every nested asset) takes
+  // the place of the cookie the opaque-origin iframe can't carry. Falls back to the
+  // live cookie check on an invalid/expired token, so a stale or hand-typed link isn't
+  // a hard dead end for a caller who genuinely still has access.
+  //
+  // Registered BEFORE the plain `/v/:n/*` route below: that pattern's trailing wildcard
+  // is a syntactic superset of this one (it would happily swallow `t/<token>/...` as
+  // part of its own `*`), so the more specific route must win the match, not just the
+  // auth check — registration order is the explicit tiebreaker, not left to the router.
+  app.get("/raw/:shortId/v/:n/t/:token/*", async (c) => {
+    const shortId = c.req.param("shortId")
+    const n = Number(c.req.param("n"))
+    const artifact = await meta.getByShortId(shortId)
+    if (!artifact || !Number.isInteger(n)) return c.text("not found", 404)
+    const claim = verifyState<{ rid: string }>(
+      c.req.param("token"),
+      deps.encryptionKey ?? "",
+      RAW_TOKEN_MAX_AGE_MS,
+    )
+    const ok = claim?.rid === artifact.id || (await authorize(c, "read", artifact))
+    if (!ok) return c.text("not found", 404)
+    return serveVersion(
+      c,
+      artifact,
+      n,
+      `/raw/${shortId}/v/${c.req.param("n")}/t/${c.req.param("token")}/`,
+    )
+  })
+
+  app.get("/raw/:shortId/v/:n/*", async (c) => {
+    const shortId = c.req.param("shortId")
+    const n = Number(c.req.param("n"))
+    const artifact = await meta.getByShortId(shortId)
+    if (!artifact || !Number.isInteger(n) || !(await authorize(c, "read", artifact)))
+      return c.text("not found", 404)
+    return serveVersion(c, artifact, n, `/raw/${shortId}/v/${c.req.param("n")}/`)
   })
 
   // Render a proposed version exactly like a live one, so review is of the

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -129,6 +129,13 @@ export interface Artifact {
   removed?: boolean
   /** Mirrored from a GitHub sync source → read-only in Derive (Edit/Propose hidden). */
   managed?: boolean
+  /** Short-lived signed capability for the /raw content iframe (detail endpoint only).
+   *  The iframe is sandboxed with no `allow-same-origin`, so it has no origin to attach
+   *  cookies to — Chrome refuses to send them for its requests even same-site, breaking
+   *  every non-public bundle's sub-resources (images, css, ...) there (Safari is more
+   *  lenient). This token lets the SPA embed proof-of-access directly in the raw URL's
+   *  PATH, so relative asset references inherit it automatically with no HTML rewriting. */
+  raw_token?: string
   /** Present when this bundle's entry is markdown — a skill (entry SKILL.md) or a
    *  plain docs folder. Drives the file tree + (for skills) the identity chrome.
    *  Detail endpoint only; absent for HTML "site" bundles. */

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -131,6 +131,9 @@ export function Artifact() {
   const [restoring, setRestoring] = useState(false)
   const [reader, setReader] = useState(false)
   const [src, setSrc] = useState("")
+  // See the `rawSrc` construction below: pins the raw-content token per (shortId,
+  // version) so a metadata refetch doesn't force the preview iframe to reload.
+  const pinnedRawToken = useRef<{ shortId: string; version: number; token: string } | null>(null)
   // Phones: px the comment sheet occupies at the bottom, reported by MobileComments.
   // The document column reserves exactly this so nothing black is left beneath it.
   const [sheetInset, setSheetInset] = useState(0)
@@ -313,7 +316,36 @@ export function Artifact() {
   const editable = art.kind === "file" && shown === art.current_version
   // Reader view re-renders a non-responsive HTML artifact clean + mobile-friendly
   // (server applies it on `?reader=1`). Off by default; the top-bar toggle flips it.
-  const rawSrc = `${API_BASE}/raw/${shortId}/v/${shown}/index.html${reader ? "?reader=1" : ""}`
+  //
+  // The `t/:raw_token` segment is the sandboxed iframe's own proof of access: it has no
+  // `allow-same-origin` (by design — the content must never touch our cookies/storage),
+  // so it has no origin to send our session cookie back on, and Chrome refuses to attach
+  // cookies to opaque-origin requests at all, even same-site (Safari is more lenient) —
+  // every sub-resource in a non-public bundle silently 404s there without this. Falls
+  // back to the plain cookie-authorized URL if a token isn't available yet (e.g. the
+  // detail fetch hasn't resolved) or on a legacy cached response missing the field.
+  //
+  // The token is freshly signed on EVERY artifact-detail fetch (a favorite toggle, a
+  // tag edit, a background refetch — none of which change the rendered content), but
+  // `rawSrc` feeds the iframe's `src`: a new value forces a full reload. Pin the first
+  // token seen for this (shortId, version) in a ref and keep using it — even after the
+  // query refetches and `art.raw_token` changes underneath — so the mounted preview
+  // only ever reloads for a reason (a real version change), not a coincidental refetch.
+  if (
+    art.raw_token &&
+    (!pinnedRawToken.current ||
+      pinnedRawToken.current.shortId !== shortId ||
+      pinnedRawToken.current.version !== shown)
+  )
+    pinnedRawToken.current = { shortId, version: shown, token: art.raw_token }
+  const rawToken =
+    pinnedRawToken.current?.shortId === shortId && pinnedRawToken.current.version === shown
+      ? pinnedRawToken.current.token
+      : undefined
+  const rawBase = rawToken
+    ? `${API_BASE}/raw/${shortId}/v/${shown}/t/${rawToken}`
+    : `${API_BASE}/raw/${shortId}/v/${shown}`
+  const rawSrc = `${rawBase}/index.html${reader ? "?reader=1" : ""}`
   // Editors publish directly; commenters propose a candidate for review.
   const canPublish = art.my_role === "editor" || art.my_role === "owner"
   // md vs html drives syntax highlighting + how the live preview renders.


### PR DESCRIPTION
## Summary

The artifact preview renders in an iframe `sandbox`ed with no `allow-same-origin` — correct and deliberate, so untrusted artifact content can never touch a viewer's `derive.to` session cookie or storage. But that also leaves the iframe with no origin of its own to attach a cookie to, and **Chrome refuses to send cookies for any request originating from an opaque origin, even to a same-site target**. Safari is more lenient about this exact case. The practical effect: every sub-resource (image, CSS, ...) in any non-public bundle silently 404s in Chrome — only the top-level navigation happened to work, since that part is a real top-level-ish frame navigation the browser treats differently.

Found via a real repro: a walkthrough bundle's screenshots loaded fine on Safari, not at all on Chrome.

## Fix

- A short-lived (5 min) signed capability (`signState`/`verifyState`, reusing the existing GitHub-OAuth-state HMAC pattern — no new crypto primitive) minted in the artifact detail response (`GET /v1/artifacts/:shortId`).
- Embedded as a **path** segment, not a query param: `/raw/:shortId/v/:n/t/:token/*`. Relative URLs don't inherit a base's query string on resolution, but they do inherit its path — so a bundle's own `<img src="x.png">` references automatically replay the same proof of access with zero HTML rewriting.
- Falls back to the existing cookie-based `authorize()` check on a missing/invalid/expired token, so a bookmarked or hand-typed `/raw/...` URL (no token) keeps working exactly as before.
- Registered before the existing wildcard route explicitly, since that route's trailing `*` is a syntactic superset that would otherwise swallow `t/<token>/...` requests too — order is the tiebreaker, not left to the router.

**Regression caught while testing, also fixed here:** the token is freshly re-signed on every artifact-detail fetch (a favorite toggle, a tag edit, any background refetch), and naively always using the latest one made the mounted preview iframe reload on every one of those, even though the actual content hadn't changed. Fixed by pinning the first token seen per `(shortId, version)` in a ref on the frontend; later refetches for the same version keep using it.

## Test plan

- [x] `pnpm run ci` green (biome + design-tokens + frontend + testids + api + schema + hyperdrive + filesize + anchor-client + deadcode)
- [x] `pnpm typecheck` green across all workspace packages
- [x] `pnpm test` — full suite green, 0 regressions
- [x] Manually verified end-to-end with a real bundle+image locally: image renders inside the sandboxed iframe via the token path
- [x] Verified directly via curl (bypasses any browser-specific behavior): the token alone (zero cookies) returns the content; a tampered signature 404s; the same token replayed against a *different* artifact's URL 404s; the legacy cookie-only route is completely unchanged
- [x] Verified the pin: toggled favorite (confirmed server-side flag flipped + a fresh token was minted) and confirmed the mounted iframe's `src` did NOT change

🤖 Generated with [Claude Code](https://claude.com/claude-code)