### PR TITLE
Simplify sharing & workspaces: the two-axis ladder, Created by me, workspace at first need

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,22 +36,24 @@ Derive ships safe defaults, but a few choices matter for an internet-facing depl
   | Anyone with link, **comment**  | View only (sign in to comment) | View + comment                         | Their role (at least comment)  |
   | Public (listed), view/comment  | same as link row               | same as link row                       | Their role                     |
   | Password, view/comment         | Unlock, then as above          | Unlock, then as above                  | Their role (no password needed)|
-  | Workspace only (org)           | No access                      | No access                              | Their role (members only)      |
+  | Workspace (org)                | No access                      | No access                              | Their role (members only)      |
   | Private (invite-only) — default | No access                     | No access                              | Explicit share only — workspace role grants nothing |
-  | Unlisted, view/comment         | No access                      | No access (non-members)                | Members with the link: view/comment; explicit shares: their role |
+  | Unlisted (workspace, link only), view/comment | No access       | No access (non-members)                | Members with the link: view/comment; explicit shares: their role |
 
   A signed-in human's publish defaults to **private**: only the publisher (written
   as the owner-member at creation) can see a fresh artifact. AGENT-credentialed
   publishes — the /mcp server, and any /v1 publish carrying a registered agent
   token or OAuth bearer (the CLI and stdio-shim paths) — default to **unlisted**,
   a workspace setting (`defaultAgentVisibility`): hidden from every listing, but a
-  workspace member with the link gets the workspace's default general role — the
-  agent-draft state between private and workspace. Reach is only ever workspace-
-  inward of private's explicit-share-only model plus the link requirement, and the
-  setting restores private-by-default in one click. Private and unlisted artifacts never appear in workspace listings,
-  profile work lists, or the People-visible surfaces (unlisted has one dedicated
-  owner-scoped library filter). Widening (workspace, link, public) is always an
-  explicit act. GitHub-mirror syncs publish workspace-visible — a mirrored repo
+  workspace member with the link gets the workspace's default general role. It's
+  the same who × listed-or-link-only pairing as public/link, one tier down: a
+  workspace audience that stays out of the shared library until surfaced. Reach is
+  only ever workspace-inward of private's explicit-share-only model plus the link
+  requirement, and the setting restores private-by-default in one click. Private
+  and unlisted artifacts never appear in workspace listings, profile work lists,
+  or the People-visible surfaces (the library's "Created by me" filter still finds
+  your own regardless of visibility). Widening (workspace, link, public) is always
+  an explicit act. GitHub-mirror syncs publish workspace-visible — a mirrored repo
   is a workspace resource, not a personal draft.
 
   `packages/core/src/permissions.ts` (`effectiveRole`) is the single source of truth for

--- a/apps/api/src/lib/http.ts
+++ b/apps/api/src/lib/http.ts
@@ -7,9 +7,15 @@ import type { z } from "zod"
  * The one error-response shape. Routes return `fail(c, status, message)` rather
  * than a bare `c.json({ error }, status)`, so the error contract lives in one
  * place. Enforced by the no-ad-hoc-error guard (scripts/check-api.mjs).
+ * `extra` carries machine-readable context a client renders a flow around (e.g.
+ * the invite accept page's email_mismatch confirm) — never secrets, always additive.
  */
-export const fail = (c: Context, status: ContentfulStatusCode, message: string) =>
-  c.json({ error: message }, status)
+export const fail = (
+  c: Context,
+  status: ContentfulStatusCode,
+  message: string,
+  extra?: Record<string, unknown>,
+) => c.json({ error: message, ...extra }, status)
 
 /**
  * Parse + validate a JSON request body against a zod schema. Returns the typed,

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -170,7 +170,7 @@ function buildServer(
   // Resolve a short id within the caller's workspace (never another org's
   // artifact). `private` AND `unlisted` narrow further: the agent touches them
   // only through its human's standing (or a legacy row of its own) — a
-  // teammate's draft is as untouchable over MCP as its listings are invisible.
+  // teammate's unlisted doc is as untouchable over MCP as its listings are invisible.
   // (Members reach a teammate's unlisted doc through the web link at the
   // view/comment floor; agent tools are write-capable, so they stay stricter.)
   const own = async (shortId: string): Promise<ArtifactRecord | null> => {
@@ -189,13 +189,13 @@ function buildServer(
     "list_artifacts",
     {
       description:
-        "List the artifacts (docs, plans, sites) in your workspace — short id, title, kind, current version, visibility. Includes your own unlisted drafts (hidden from humans' listings, but you always find your work). Start here to find what to work on, then catch_up or read it.",
+        "List the artifacts (docs, plans, sites) in your workspace — short id, title, kind, current version, visibility. Includes your own unlisted (link-only) publishes — hidden from the shared library, but you always find your work. Start here to find what to work on, then catch_up or read it.",
       inputSchema: { query: z.string().optional().describe("Optional title search filter.") },
     },
     async ({ query }) => {
       // viewerId keeps private rows scoped to the agent's human (mirrors `own`);
-      // "include" folds in that human's own unlisted drafts, so the agent can
-      // always find the work it published even though listings hide it.
+      // "include" folds in that human's own unlisted work, so the agent can
+      // always find what it published even though listings hide it.
       const arts = await ctx.meta.listArtifacts({
         orgId: org,
         q: query,
@@ -601,7 +601,7 @@ function buildServer(
           .enum(["unlisted", "private", "workspace", "link", "public"])
           .optional()
           .describe(
-            "Who can see a NEW artifact: unlisted (a DRAFT: hidden from the library, one link away for workspace members — the usual default for agent publishes), private (you and people you invite), workspace (your team, listed), link (anyone with the link), or public (discoverable). Omit to use the workspace's agent default. Ignored on republish — the human promotes via the share dialog.",
+            "Who can see a NEW artifact: unlisted (workspace members with the link — hidden from the shared library until a human surfaces it; the usual default for agent publishes), private (you and people you invite), workspace (your team, listed), link (anyone with the link), or public (discoverable). Omit to use the workspace's agent default. Ignored on republish — the human promotes via the share dialog.",
           ),
         spa: z
           .boolean()

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -271,8 +271,15 @@ export const artifactRoutes = (ctx: AppContext) => {
     // empty summary with no workspace name, so it can't be used to enumerate a private
     // workspace's name + size.
     if (!(await isMember(c, org)))
-      return c.json({ total: 0, favorites: 0, mine: 0, tags: [], workspace: null })
-    const [total, tags, favIds, ws, mine] = await Promise.all([
+      return c.json({
+        total: 0,
+        favorites: 0,
+        mine: 0,
+        mine_link_only: 0,
+        tags: [],
+        workspace: null,
+      })
+    const [total, tags, favIds, ws, mine, mineLinkOnly] = await Promise.all([
       meta.countArtifacts(org),
       meta.tagCounts(org),
       // Scope the favorites count to THIS workspace's live artifacts — the favorites
@@ -282,12 +289,16 @@ export const artifactRoutes = (ctx: AppContext) => {
       meta.getWorkspace(org),
       // The caller's owned artifacts — the "Created by me" filter's badge.
       me ? meta.countOwnedBy(org, me.id) : Promise.resolve(0),
+      // …and how many of those are still link-only: the "waiting on you to
+      // surface it" signal (agent publishes land unlisted until promoted).
+      me ? meta.countOwnedBy(org, me.id, "unlisted") : Promise.resolve(0),
     ])
     tags.sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
     return c.json({
       total,
       favorites: favIds.length,
       mine,
+      mine_link_only: mineLinkOnly,
       tags,
       workspace: ws?.name ?? DEFAULT_WORKSPACE_NAME,
     })

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -367,7 +367,7 @@ export const artifactRoutes = (ctx: AppContext) => {
       const onBehalf = await privateOwnerId(c)
       // An AGENT-credentialed create (registered token / OAuth bearer — the CLI
       // and stdio-shim paths) lands with the workspace's agent default when no
-      // visibility was asked for: usually `unlisted`, the draft state. A
+      // visibility was asked for: usually `unlisted`, workspace link-only. A
       // signed-in human's own publish keeps the private default.
       const agentPrincipal = await agentFor(c)
       const resolvedVisibility =

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -125,9 +125,13 @@ export const artifactRoutes = (ctx: AppContext) => {
       if (!me) return c.json({ artifacts: [], next_cursor: null })
       narrow(await meta.artifactIdsNeedingFeedback(me.id, await activeWorkspace(c)))
     }
-    // scope=unlisted → the caller's own unlisted drafts in this workspace: the
-    // library's Unlisted filter. Ordinary listings hide unlisted entirely.
-    const unlistedScope = c.req.query("scope") === "unlisted"
+    // scope=mine → everything the caller published by hand in this workspace,
+    // any visibility included — the library's "Created by me" filter.
+    const mineScope = c.req.query("scope") === "mine"
+    if (mineScope) {
+      if (!me) return c.json({ artifacts: [], next_cursor: null })
+      narrow(await meta.artifactIdsByAuthorId(await activeWorkspace(c), me.id))
+    }
     if (tag) narrow(await meta.artifactIdsByTag(tag))
     if (favOnly) narrow(favIds)
 
@@ -171,10 +175,9 @@ export const artifactRoutes = (ctx: AppContext) => {
     // sees public artifacts only, so org/link titles never leak via the list or ?query=.
     // For a collection, collection access (member/creator/share) also unlocks it.
     const publicOnly = collectionId ? !collectionAccess : !(isOperator || baselineRole !== null)
-    // The Unlisted filter is a members-only view of their OWN drafts — a caller
-    // with no standing here (or no member rows to match) has none by definition.
-    if (unlistedScope && (publicOnly || !memberKey))
-      return c.json({ artifacts: [], next_cursor: null })
+    // "Created by me" is a members-only view of the caller's OWN authored work —
+    // a caller with no standing here (or no member rows to match) has none by definition.
+    if (mineScope && (publicOnly || !memberKey)) return c.json({ artifacts: [], next_cursor: null })
     const rows = await meta.listArtifacts({
       limit: limit + 1,
       cursor,
@@ -191,13 +194,12 @@ export const artifactRoutes = (ctx: AppContext) => {
       // Private artifacts appear only for their explicit members; the operator
       // token sees everything (viewerId omitted).
       viewerId: isOperator ? undefined : (memberKey ?? undefined),
-      // Agents get their registrant's unlisted drafts folded back in (an agent
-      // must always find the work it published — the stdio shim's list rides
-      // this route). Shared-with-you and needs-feedback are deliberate human
-      // signals (an explicit share, a thread you're in), so a member's unlisted
-      // docs surface there too. Ordinary listings stay clean — the Unlisted
-      // feed is the finder.
-      unlisted: unlistedScope ? "only" : agent || shared || needsFeedback ? "include" : undefined,
+      // Agents fold their registrant's unlisted work back in (an agent must always
+      // find what it published — the stdio shim's list rides this route). Shared,
+      // needs-feedback, and mine are equally deliberate signals — an explicit
+      // share, a thread you're in, your own authorship — so unlisted docs surface
+      // there too. Ordinary listings stay clean; that's what the filter is for.
+      unlisted: agent || shared || needsFeedback || mineScope ? "include" : undefined,
     })
     const hasMore = rows.length > limit
     const page = hasMore ? rows.slice(0, limit) : rows
@@ -268,8 +270,8 @@ export const artifactRoutes = (ctx: AppContext) => {
     // empty summary with no workspace name, so it can't be used to enumerate a private
     // workspace's name + size.
     if (!(await isMember(c, org)))
-      return c.json({ total: 0, favorites: 0, unlisted: 0, tags: [], workspace: null })
-    const [total, tags, favIds, ws, unlisted] = await Promise.all([
+      return c.json({ total: 0, favorites: 0, mine: 0, tags: [], workspace: null })
+    const [total, tags, favIds, ws, mine] = await Promise.all([
       meta.countArtifacts(org),
       meta.tagCounts(org),
       // Scope the favorites count to THIS workspace's live artifacts — the favorites
@@ -277,15 +279,14 @@ export const artifactRoutes = (ctx: AppContext) => {
       // must not inflate the count (otherwise "Favorites · 1" with an empty list).
       me ? meta.listUserFavoriteIds(me.id, org) : Promise.resolve([]),
       meta.getWorkspace(org),
-      // The caller's own unlisted drafts — the Unlisted filter's badge. Zero hides
-      // the filter, so it only exists when there's something in it.
-      me ? meta.countUnlistedFor(org, me.id) : Promise.resolve(0),
+      // The caller's own authored artifacts — the "Created by me" filter's badge.
+      me ? meta.countAuthoredBy(org, me.id) : Promise.resolve(0),
     ])
     tags.sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
     return c.json({
       total,
       favorites: favIds.length,
-      unlisted,
+      mine,
       tags,
       workspace: ws?.name ?? DEFAULT_WORKSPACE_NAME,
     })

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -125,12 +125,13 @@ export const artifactRoutes = (ctx: AppContext) => {
       if (!me) return c.json({ artifacts: [], next_cursor: null })
       narrow(await meta.artifactIdsNeedingFeedback(me.id, await activeWorkspace(c)))
     }
-    // scope=mine → everything the caller published by hand in this workspace,
-    // any visibility included — the library's "Created by me" filter.
+    // scope=mine → everything the caller owns in this workspace (their owner
+    // member row — written at creation for the human behind the publish, agents
+    // included), any visibility — the library's "Created by me" filter.
     const mineScope = c.req.query("scope") === "mine"
     if (mineScope) {
       if (!me) return c.json({ artifacts: [], next_cursor: null })
-      narrow(await meta.artifactIdsByAuthorId(await activeWorkspace(c), me.id))
+      narrow(await meta.artifactIdsOwnedBy(await activeWorkspace(c), me.id))
     }
     if (tag) narrow(await meta.artifactIdsByTag(tag))
     if (favOnly) narrow(favIds)
@@ -279,8 +280,8 @@ export const artifactRoutes = (ctx: AppContext) => {
       // must not inflate the count (otherwise "Favorites · 1" with an empty list).
       me ? meta.listUserFavoriteIds(me.id, org) : Promise.resolve([]),
       meta.getWorkspace(org),
-      // The caller's own authored artifacts — the "Created by me" filter's badge.
-      me ? meta.countAuthoredBy(org, me.id) : Promise.resolve(0),
+      // The caller's owned artifacts — the "Created by me" filter's badge.
+      me ? meta.countOwnedBy(org, me.id) : Promise.resolve(0),
     ])
     tags.sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
     return c.json({

--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -285,7 +285,8 @@ export const workspaceRoutes = (ctx: AppContext) => {
     // Possession still authorizes (self-hosts without email verification must keep
     // working), but a mismatched account is SURFACED, not silently joined: the
     // holder must explicitly confirm they meant to accept under this identity.
-    // The machine-readable shape lets the accept page render the warning inline.
+    // The web accept page pre-warns from the preview and sends the confirm with
+    // the click; the machine-readable 409 is for headless callers.
     if (inv.email && inv.email.toLowerCase() !== me.email.toLowerCase()) {
       const b = await readJson(c, z.object({ confirm_mismatch: z.boolean().optional() }))
       // A malformed/absent body counts as "not confirmed", not a 400 — the 409
@@ -362,7 +363,7 @@ export const workspaceRoutes = (ctx: AppContext) => {
       // agents (no granting user) still see only their own workspace.
       const owner = await privateOwnerId(c)
       const mine = owner ? await meta.listWorkspaces(owner) : []
-      if (mine.length && owner)
+      if (owner && mine.length)
         return c.json({
           multi: true,
           active,

--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -282,6 +282,17 @@ export const workspaceRoutes = (ctx: AppContext) => {
     const inv = await meta.getInvitationByToken(sha256(c.req.param("token")))
     if (!inv || inv.accepted_at || new Date(inv.expires_at).getTime() < Date.now())
       return fail(c, 404, "this invitation is invalid or has expired")
+    // Possession still authorizes (self-hosts without email verification must keep
+    // working), but a mismatched account is SURFACED, not silently joined: the
+    // holder must explicitly confirm they meant to accept under this identity.
+    // The machine-readable shape lets the accept page render the warning inline.
+    if (inv.email && inv.email.toLowerCase() !== me.email.toLowerCase()) {
+      const b = await readJson(c, z.object({ confirm_mismatch: z.boolean().optional() }))
+      // A malformed/absent body counts as "not confirmed", not a 400 — the 409
+      // carries the flow either way.
+      const confirmed = !(b instanceof Response) && b.confirm_mismatch === true
+      if (!confirmed) return fail(c, 409, "email_mismatch", { invited_email: inv.email })
+    }
     const existing = await meta.getMembership(inv.org_id, me.id)
     if (!existing)
       await meta.setMembership({
@@ -336,30 +347,41 @@ export const workspaceRoutes = (ctx: AppContext) => {
     if (role === null) return fail(c, 401, "unauthenticated")
     const active = await activeWorkspace(c)
     const me = await currentUser(c)
+    // `personal` marks the caller's auto-provisioned workspace (its id is
+    // deterministic — ws_p_<userId>, see provisionPersonal) so clients can label
+    // it "Personal" and pin it, instead of leaking "X's Workspace" plumbing.
+    const wsJson = (w: { id: string; name: string; role: Role }, ownerId: string) => ({
+      id: w.id,
+      name: w.name,
+      role: w.role,
+      personal: w.id === `ws_p_${ownerId}`,
+    })
     if (!me) {
       // An OAuth agent lists its granting user's workspaces — the discovery
       // surface for choosing an X-Derive-Workspace target. Registered workspace
       // agents (no granting user) still see only their own workspace.
       const owner = await privateOwnerId(c)
       const mine = owner ? await meta.listWorkspaces(owner) : []
-      if (mine.length)
+      if (mine.length && owner)
         return c.json({
           multi: true,
           active,
-          workspaces: mine.map((w) => ({ id: w.id, name: w.name, role: w.role })),
+          workspaces: mine.map((w) => wsJson(w, owner)),
         })
       const ws = await meta.getWorkspace(active)
       return c.json({
         multi: true,
         active,
-        workspaces: [{ id: active, name: ws?.name ?? DEFAULT_WORKSPACE_NAME, role }],
+        workspaces: [
+          { id: active, name: ws?.name ?? DEFAULT_WORKSPACE_NAME, role, personal: false },
+        ],
       })
     }
     const mine = await meta.listWorkspaces(me.id)
     return c.json({
       multi: true,
       active,
-      workspaces: mine.map((w) => ({ id: w.id, name: w.name, role: w.role })),
+      workspaces: mine.map((w) => wsJson(w, me.id)),
     })
   })
 

--- a/apps/api/test/invitations.test.ts
+++ b/apps/api/test/invitations.test.ts
@@ -70,9 +70,21 @@ describe("workspace invitations", () => {
     expect(preview.workspace).toBeTruthy()
     expect(preview.role).toBe("commenter")
 
-    // Accept as the outsider → they join.
-    const acc = await app.request(`/v1/invites/${token}/accept`, {
+    // The outsider holds the link but is signed in under a DIFFERENT email than
+    // the invite named — the mismatch is surfaced, not silently joined.
+    const refused = await app.request(`/v1/invites/${token}/accept`, {
       ...jsonAs(as(outsider.email), {}),
+      method: "POST",
+    })
+    expect(refused.status).toBe(409)
+    const mismatch = await refused.json()
+    expect(mismatch.error).toBe("email_mismatch")
+    expect(mismatch.invited_email).toBe("joiner@derive.test")
+
+    // An explicit confirm accepts anyway (token possession still authorizes —
+    // self-hosts without verified email keep working).
+    const acc = await app.request(`/v1/invites/${token}/accept`, {
+      ...jsonAs(as(outsider.email), { confirm_mismatch: true }),
       method: "POST",
     })
     expect(acc.status).toBe(200)
@@ -81,7 +93,7 @@ describe("workspace invitations", () => {
 
     // The invite is spent — a second accept 404s, and it's gone from the pending list.
     const again = await app.request(`/v1/invites/${token}/accept`, {
-      ...jsonAs(as(outsider.email), {}),
+      ...jsonAs(as(outsider.email), { confirm_mismatch: true }),
       method: "POST",
     })
     expect(again.status).toBe(404)

--- a/apps/api/test/visibility.test.ts
+++ b/apps/api/test/visibility.test.ts
@@ -106,6 +106,12 @@ describe("agents act as their registrant, capped at their registered role", () =
       await app.request("/v1/artifacts?scope=mine", { headers: as(ana.email) })
     ).json()
     expect(mine.artifacts.map((x: { short_id: string }) => x.short_id)).toContain(a.short_id)
+    // The summary counts it as hers — and as still link-only (the pending badge).
+    // Note the agent republish above: ownership keys on her owner row, so a
+    // revision by someone else never evicts it from "Created by me".
+    const summary = await (await app.request("/v1/tags", { headers: as(ana.email) })).json()
+    expect(summary.mine).toBeGreaterThanOrEqual(1)
+    expect(summary.mine_link_only).toBeGreaterThanOrEqual(1)
 
     // The agent lists too (MCP list_artifacts rides this) and sees the unlisted
     // publish through its registrant's owner row, capped to its own rank.

--- a/apps/api/test/visibility.test.ts
+++ b/apps/api/test/visibility.test.ts
@@ -98,15 +98,14 @@ describe("agents act as their registrant, capped at their registered role", () =
         })
       ).status,
     ).toBe(201)
-    // Ana's ORDINARY listing hides the draft (unlisted is hidden even from its
-    // owner there — the dedicated feed is the finder), while scope=unlisted is
-    // exactly her drafts.
+    // Ana's ORDINARY listing hides the unlisted publish (hidden even from its
+    // owner there — "Created by me" is the finder, any visibility included).
     const list = await (await app.request("/v1/artifacts", { headers: as(ana.email) })).json()
     expect(list.artifacts.map((x: { short_id: string }) => x.short_id)).not.toContain(a.short_id)
-    const drafts = await (
-      await app.request("/v1/artifacts?scope=unlisted", { headers: as(ana.email) })
+    const mine = await (
+      await app.request("/v1/artifacts?scope=mine", { headers: as(ana.email) })
     ).json()
-    expect(drafts.artifacts.map((x: { short_id: string }) => x.short_id)).toContain(a.short_id)
+    expect(mine.artifacts.map((x: { short_id: string }) => x.short_id)).toContain(a.short_id)
 
     // The agent lists too (MCP list_artifacts rides this) and sees the unlisted
     // publish through its registrant's owner row, capped to its own rank.

--- a/apps/api/test/workspace.test.ts
+++ b/apps/api/test/workspace.test.ts
@@ -203,6 +203,8 @@ describe("multi-workspace: isolation, switch, create, provision", () => {
     expect(a.multi).toBe(true)
     expect(a.workspaces).toHaveLength(1)
     expect(a.workspaces[0].role).toBe("owner")
+    // Flagged personal so clients render "Personal" instead of the plumbing name.
+    expect(a.workspaces[0].personal).toBe(true)
     const b = await (await app.request("/v1/workspaces", { headers: as(bo.email) })).json()
     // Bo gets his OWN workspace, distinct from Ada's.
     expect(b.workspaces[0].id).not.toBe(a.workspaces[0].id)
@@ -235,6 +237,9 @@ describe("multi-workspace: isolation, switch, create, provision", () => {
     ).json()
     expect(spaces.active).toBe(acmeId)
     expect(spaces.workspaces).toHaveLength(2)
+    // A created (team) workspace is never flagged personal.
+    const acme = spaces.workspaces.find((w: { id: string }) => w.id === acmeId)
+    expect(acme?.personal).toBe(false)
   })
 
   it("switches back to a workspace you belong to; rejects one you don't", async () => {

--- a/apps/web/e2e/deep/mcp-loop.deep.spec.ts
+++ b/apps/web/e2e/deep/mcp-loop.deep.spec.ts
@@ -4,10 +4,10 @@ import { STORAGE_KEYS } from "../../src/lib/storage-keys"
 import { expect, test } from "../fixtures"
 
 // The strong MCP loop, browser side: an agent-credentialed publish auto-opens the
-// owner's tab (a created draft navigates; a revision live-reloads with the review
-// card repainting), agent publishes land unlisted (hidden from Everything, one
-// link away, but findable under Created by me) until the share dialog promotes
-// them, and the per-device toggle downgrades auto-open to a notification. The
+// owner's tab (a created artifact navigates; a revision live-reloads with the review
+// card repainting), agent publishes land unlisted (hidden from the All artifacts
+// feed, one link away, but findable under Created by me) until the share dialog
+// promotes them, and the per-device toggle downgrades auto-open to a notification. The
 // agent side is the real token + API — the same calls the MCP server and CLI
 // make — so the loop under test is the shipped one, not a mock.
 
@@ -88,7 +88,7 @@ test.describe("the MCP loop — auto-open, live rounds, unlisted publishes", () 
     await expect(owner.getByTestId("review-card")).toBeVisible({ timeout: 10_000 })
   })
 
-  test("unlisted publishes hide from Everything until the share dialog promotes them; the toggle quiets auto-open", async ({
+  test("unlisted publishes hide from All artifacts until the share dialog promotes them; the toggle quiets auto-open", async ({
     owner,
   }) => {
     const agent = await createAgent(owner.request, "Drafter")
@@ -107,7 +107,7 @@ test.describe("the MCP loop — auto-open, live rounds, unlisted publishes", () 
     await owner.waitForTimeout(1000)
     await expect(owner).toHaveURL(/\/$/) // still home — the toggle held navigation
 
-    // Hidden from Everything, but Created by me (always present on home, even
+    // Hidden from All artifacts, but Created by me (always present on home, even
     // before the owner has authored anything) has it, with a live count — the
     // agent published on the owner's behalf, so it counts as theirs.
     await expect(owner.getByTestId("library-tab-mine")).toBeVisible()
@@ -116,7 +116,7 @@ test.describe("the MCP loop — auto-open, live rounds, unlisted publishes", () 
     await expect(owner).toHaveURL(/tab=mine/)
     await expect(owner.getByText("Hidden Draft").first()).toBeVisible()
 
-    // Promote: share dialog → Workspace. One gesture, now it lists in Everything too.
+    // Promote: share dialog → Workspace. One gesture, now it lists in All artifacts too.
     await owner.goto(`/artifacts/${created.short_id}`)
     await owner.getByTestId("share-trigger").click()
     await owner.getByTestId("share-visibility").click()

--- a/apps/web/e2e/deep/mcp-loop.deep.spec.ts
+++ b/apps/web/e2e/deep/mcp-loop.deep.spec.ts
@@ -5,11 +5,11 @@ import { expect, test } from "../fixtures"
 
 // The strong MCP loop, browser side: an agent-credentialed publish auto-opens the
 // owner's tab (a created draft navigates; a revision live-reloads with the review
-// card repainting), drafts land unlisted (hidden from the library, one link away
-// in the Unlisted feed) until the share dialog promotes them, and the per-device
-// toggle downgrades auto-open to a notification. The agent side is the real
-// token + API — the same calls the MCP server and CLI make — so the loop under
-// test is the shipped one, not a mock.
+// card repainting), agent publishes land unlisted (hidden from Everything, one
+// link away, but findable under Created by me) until the share dialog promotes
+// them, and the per-device toggle downgrades auto-open to a notification. The
+// agent side is the real token + API — the same calls the MCP server and CLI
+// make — so the loop under test is the shipped one, not a mock.
 
 async function createAgent(
   req: APIRequestContext,
@@ -43,7 +43,7 @@ async function agentPublish(
   return (await res.json()) as { short_id: string; visibility: string; opened_in_tab?: boolean }
 }
 
-test.describe("the MCP loop — auto-open, live rounds, unlisted drafts", () => {
+test.describe("the MCP loop — auto-open, live rounds, unlisted publishes", () => {
   test("a created agent draft auto-opens the tab; a revision live-reloads and repaints the review card", async ({
     owner,
   }) => {
@@ -88,14 +88,14 @@ test.describe("the MCP loop — auto-open, live rounds, unlisted drafts", () => 
     await expect(owner.getByTestId("review-card")).toBeVisible({ timeout: 10_000 })
   })
 
-  test("unlisted drafts hide from the library until the share dialog promotes them; the toggle quiets auto-open", async ({
+  test("unlisted publishes hide from Everything until the share dialog promotes them; the toggle quiets auto-open", async ({
     owner,
   }) => {
     const agent = await createAgent(owner.request, "Drafter")
     await owner.goto("/")
     await expect(owner.getByTestId("notif-bell")).toBeVisible()
     // Auto-open off (the Appearance toggle writes the same key) → a created
-    // draft must NOT yank navigation; it lands as a notification instead.
+    // publish must NOT yank navigation; it lands as a notification instead.
     await owner.evaluate((key) => localStorage.setItem(key, "off"), STORAGE_KEYS.autoOpen)
     await owner.waitForTimeout(500)
 
@@ -107,25 +107,27 @@ test.describe("the MCP loop — auto-open, live rounds, unlisted drafts", () => 
     await owner.waitForTimeout(1000)
     await expect(owner).toHaveURL(/\/$/) // still home — the toggle held navigation
 
-    // Hidden from the All grid, but the Drafts tab (always present on home,
-    // even before the first draft existed) has it, with a live count.
-    await expect(owner.getByTestId("library-tab-drafts")).toBeVisible()
+    // Hidden from Everything, but Created by me (always present on home, even
+    // before the owner has authored anything) has it, with a live count — the
+    // agent published on the owner's behalf, so it counts as theirs.
+    await expect(owner.getByTestId("library-tab-mine")).toBeVisible()
     await expect(owner.getByText("Hidden Draft")).toHaveCount(0)
-    await owner.getByTestId("library-tab-drafts").click()
-    await expect(owner).toHaveURL(/tab=drafts/)
+    await owner.getByTestId("library-tab-mine").click()
+    await expect(owner).toHaveURL(/tab=mine/)
     await expect(owner.getByText("Hidden Draft").first()).toBeVisible()
 
-    // Promote: share dialog → Workspace only. One gesture, now it lists.
+    // Promote: share dialog → Workspace. One gesture, now it lists in Everything too.
     await owner.goto(`/artifacts/${created.short_id}`)
     await owner.getByTestId("share-trigger").click()
     await owner.getByTestId("share-visibility").click()
-    await owner.getByRole("menuitemradio", { name: "Workspace only" }).click()
+    await owner.getByRole("menuitemradio", { name: "Workspace", exact: true }).click()
     await owner.keyboard.press("Escape")
 
     await owner.goto("/")
     await expect(owner.getByText("Hidden Draft").first()).toBeVisible({ timeout: 10_000 })
-    // The Drafts tab stays (always-on chrome, the teaching surface) — it's just
-    // empty again now that the doc was promoted to the workspace.
-    await expect(owner.getByTestId("library-tab-drafts")).toBeVisible()
+    // Created by me is authorship, not visibility — it keeps finding the doc
+    // no matter how widely it's since been shared.
+    await owner.getByTestId("library-tab-mine").click()
+    await expect(owner.getByText("Hidden Draft").first()).toBeVisible()
   })
 })

--- a/apps/web/e2e/deep/visibility.deep.spec.ts
+++ b/apps/web/e2e/deep/visibility.deep.spec.ts
@@ -31,13 +31,13 @@ test("a default publish is private: invisible to another user until the link is 
   await secondUser.page.goto(`/artifacts/${id}`)
   await expect(secondUser.page.getByText("Draft")).toBeHidden()
 
-  // The owner widens access to "Anyone with the link" from the share dialog —
+  // The owner widens access to "Public — link only" from the share dialog —
   // the pick applies instantly (no Save button); wait for the PATCH to land.
   await owner.goto(`/artifacts/${id}`)
   await owner.getByTestId("share-trigger").click()
   const saved = owner.waitForResponse((r) => r.url().includes("/visibility") && r.ok())
   await owner.getByTestId("share-visibility").click()
-  await owner.getByRole("menuitemradio", { name: "Anyone with the link" }).click()
+  await owner.getByRole("menuitemradio", { name: "Public — link only" }).click()
   await saved
 
   // Now the second user can read it.

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -320,6 +320,11 @@ export interface WorkspaceSummary {
   /** The caller's auto-provisioned personal workspace — shown as "Personal", pinned first. */
   personal: boolean
 }
+/** The one display rule for workspace names: the personal workspace renders as
+ *  "Personal" everywhere — its stored name is provisioning plumbing, not a name
+ *  the user chose. */
+export const workspaceDisplayName = (w: { name: string; personal: boolean }): string =>
+  w.personal ? "Personal" : w.name
 /** The switcher payload: whether multi-workspace is on, the active id, the list. */
 export interface Workspaces {
   multi: boolean

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -317,6 +317,8 @@ export interface WorkspaceSummary {
   id: string
   name: string
   role: Role
+  /** The caller's auto-provisioned personal workspace — shown as "Personal", pinned first. */
+  personal: boolean
 }
 /** The switcher payload: whether multi-workspace is on, the active id, the list. */
 export interface Workspaces {
@@ -1068,8 +1070,16 @@ export const api = {
   // The accept page: preview an invite by token, then join.
   previewInvite: (token: string): Promise<InvitePreview> =>
     f(`/v1/invites/${encodeURIComponent(token)}`, opts()).then(j),
-  acceptInvite: (token: string): Promise<{ org_id: string; role: Role }> =>
-    f(`/v1/invites/${encodeURIComponent(token)}/accept`, opts({})).then(j),
+  // confirmMismatch: the holder is signed in under a different email than the
+  // invite named — the server 409s until they explicitly accept anyway.
+  acceptInvite: (
+    token: string,
+    confirmMismatch?: boolean,
+  ): Promise<{ org_id: string; role: Role }> =>
+    f(
+      `/v1/invites/${encodeURIComponent(token)}/accept`,
+      opts(confirmMismatch ? { confirm_mismatch: true } : {}),
+    ).then(j),
   setWorkspaceMemberRole: (userId: string, role: Role): Promise<{ user_id: string; role: Role }> =>
     f(`/v1/workspace/members/${userId}`, { ...opts({ role }), method: "PATCH" }).then(j),
   removeWorkspaceMember: (userId: string): Promise<void> =>

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -787,8 +787,10 @@ export const api = {
     /** "shared" → only artifacts explicitly shared with you (across workspaces).
      *  "following" → artifacts in the active workspace matching your follows
      *  (followed GitHub authors + repo path prefixes) — the activity feed.
-     *  "needs_feedback" → artifacts with an open thread you're tagged in or commented on. */
-    scope?: "shared" | "following" | "needs_feedback" | "unlisted"
+     *  "needs_feedback" → artifacts with an open thread you're tagged in or commented on.
+     *  "mine" → everything you published by hand in the active workspace, any
+     *  visibility included — the library's "Created by me" filter. */
+    scope?: "shared" | "following" | "needs_feedback" | "mine"
     cursor?: string
     limit?: number
   }): Promise<{
@@ -813,8 +815,8 @@ export const api = {
   browseSummary: (): Promise<{
     total: number
     favorites: number
-    /** The caller's own unlisted drafts — badges the library's Unlisted feed. */
-    unlisted: number
+    /** The caller's own authored artifacts — badges the library's "Created by me" filter. */
+    mine: number
     tags: { tag: string; count: number }[]
     workspace: string
   }> => f("/v1/tags", opts()).then(j),

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -815,8 +815,10 @@ export const api = {
   browseSummary: (): Promise<{
     total: number
     favorites: number
-    /** The caller's own authored artifacts — badges the library's "Created by me" filter. */
+    /** The caller's owned artifacts — badges the library's "Created by me" filter. */
     mine: number
+    /** How many of those are still link-only (unlisted) — the pending signal. */
+    mine_link_only: number
     tags: { tag: string; count: number }[]
     workspace: string
   }> => f("/v1/tags", opts()).then(j),

--- a/apps/web/src/components/chrome/app-shell.tsx
+++ b/apps/web/src/components/chrome/app-shell.tsx
@@ -125,13 +125,23 @@ export function AppShell({ children }: { children: ReactNode }) {
       /* surfaced elsewhere */
     }
   }
-  const createWorkspace = async (name: string) => {
-    try {
-      await api.createWorkspace(name)
-      window.location.reload()
-    } catch {
-      /* surfaced elsewhere */
+  const createWorkspace = async (name: string, invites: string[] = []) => {
+    // createWorkspace switches the active-workspace cookie server-side, so the
+    // invites that follow land in the NEW workspace. Per-email failures don't
+    // abort the flow (a bad address shouldn't strand the workspace) — Members
+    // shows the roster + pending list, so we land there when invites were sent.
+    await api.createWorkspace(name)
+    let invited = false
+    for (const email of invites) {
+      try {
+        await api.inviteToWorkspace(email, "editor")
+        invited = true
+      } catch {
+        /* re-addable from Members */
+      }
     }
+    if (invited) window.location.assign("/settings/members")
+    else window.location.reload()
   }
   // Deleting may swap the active workspace (the server switches the cookie when you
   // delete the one you're in), so reload to pick up the new active context.

--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -93,11 +93,10 @@ export function CommandPalette() {
 
   const q = query.trim().toLowerCase()
   const matchedCollections = collections.filter((c) => c.title.toLowerCase().includes(q))
-  const otherWorkspaces = workspaces?.multi
-    ? workspaces.workspaces.filter(
-        (w) => w.id !== workspaces.active && w.name.toLowerCase().includes(q),
-      )
-    : []
+  // Personal shows (and searches) under its display name, same as the user pod.
+  const otherWorkspaces = (workspaces?.workspaces ?? [])
+    .map((w) => ({ ...w, display: w.personal ? "Personal" : w.name }))
+    .filter((w) => w.id !== workspaces?.active && w.display.toLowerCase().includes(q))
   const showAll = "all artifacts".includes(q) || "library".includes(q)
   const showFav = "favorites".includes(q)
   const showFollowing = "following".includes(q)
@@ -227,7 +226,7 @@ export function CommandPalette() {
                   onSelect={() => go(() => switchWorkspace(w.id))}
                 >
                   <Icon name="workspace" size={16} />
-                  <span className="flex-1 truncate">{w.name}</span>
+                  <span className="flex-1 truncate">{w.display}</span>
                 </CommandItem>
               ))}
             </CommandGroup>

--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -126,7 +126,7 @@ export function CommandPalette() {
                   value="jump-all"
                   onSelect={() => go(() => nav({ to: "/", search: {} }))}
                 >
-                  <Icon name="all" size={16} /> All artifacts
+                  <Icon name="all" size={16} /> Everything
                 </CommandItem>
               )}
               {showFav && (

--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -126,7 +126,7 @@ export function CommandPalette() {
                   value="jump-all"
                   onSelect={() => go(() => nav({ to: "/", search: {} }))}
                 >
-                  <Icon name="all" size={16} /> Everything
+                  <Icon name="all" size={16} /> All artifacts
                 </CommandItem>
               )}
               {showFav && (

--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
-import { type Artifact, api, type PublicProfile } from "@/api"
+import { type Artifact, api, type PublicProfile, workspaceDisplayName } from "@/api"
 import { Icon } from "@/components/icons"
 import { FollowButton } from "@/components/shared/follow-button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -95,7 +95,7 @@ export function CommandPalette() {
   const matchedCollections = collections.filter((c) => c.title.toLowerCase().includes(q))
   // Personal shows (and searches) under its display name, same as the user pod.
   const otherWorkspaces = (workspaces?.workspaces ?? [])
-    .map((w) => ({ ...w, display: w.personal ? "Personal" : w.name }))
+    .map((w) => ({ ...w, display: workspaceDisplayName(w) }))
     .filter((w) => w.id !== workspaces?.active && w.display.toLowerCase().includes(q))
   const showAll = "all artifacts".includes(q) || "library".includes(q)
   const showFav = "favorites".includes(q)

--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -448,7 +448,7 @@ export function NavRail() {
             <SidebarMenu>
               <FilterItem
                 icon="all"
-                label="Everything"
+                label="All artifacts"
                 count={summary?.total}
                 search={{}}
                 active={isAll}

--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -711,7 +711,13 @@ export function NavRail() {
         <SidebarMenu>
           <SidebarMenuItem>
             <UserPod
-              workspaceLabel={summary?.workspace ?? ""}
+              // The personal workspace's stored name is provisioning plumbing
+              // ("X's Workspace") — the subtitle says "Personal" instead.
+              workspaceLabel={
+                workspaces?.workspaces.find((w) => w.id === workspaces.active)?.personal
+                  ? "Personal"
+                  : (summary?.workspace ?? "")
+              }
               workspaces={workspaces ?? null}
               onSwitchWorkspace={switchWorkspace}
             />

--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -290,6 +290,10 @@ export function NavRail() {
     enabled: !!me,
   })
   const { data: workspaces } = useQuery({ ...workspacesQuery(), enabled: !!me })
+  // The pod subtitle: "Personal" for the auto-provisioned workspace (its stored
+  // name is provisioning plumbing), else the summary's workspace name.
+  const activeWs = workspaces?.workspaces.find((w) => w.id === workspaces.active)
+  const workspaceLabel = activeWs?.personal ? "Personal" : (summary?.workspace ?? "")
   const { setOpenMobile } = useSidebar()
   const nav = useNavigate()
   const loc = useLocation()
@@ -711,13 +715,7 @@ export function NavRail() {
         <SidebarMenu>
           <SidebarMenuItem>
             <UserPod
-              // The personal workspace's stored name is provisioning plumbing
-              // ("X's Workspace") — the subtitle says "Personal" instead.
-              workspaceLabel={
-                workspaces?.workspaces.find((w) => w.id === workspaces.active)?.personal
-                  ? "Personal"
-                  : (summary?.workspace ?? "")
-              }
+              workspaceLabel={workspaceLabel}
               workspaces={workspaces ?? null}
               onSwitchWorkspace={switchWorkspace}
             />

--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -448,7 +448,7 @@ export function NavRail() {
             <SidebarMenu>
               <FilterItem
                 icon="all"
-                label="All artifacts"
+                label="Everything"
                 count={summary?.total}
                 search={{}}
                 active={isAll}

--- a/apps/web/src/components/chrome/shell-context.ts
+++ b/apps/web/src/components/chrome/shell-context.ts
@@ -11,7 +11,9 @@ export interface ShellValue {
   paletteOpen: boolean
   setPaletteOpen: (open: boolean) => void
   switchWorkspace: (id: string) => void
-  createWorkspace: (name: string) => void
+  /** Create + switch; optional invite emails go out before the reload (one flow —
+   *  naming a workspace and bringing the team are the same gesture). */
+  createWorkspace: (name: string, invites?: string[]) => Promise<void>
   deleteWorkspace: (id: string) => void
 }
 

--- a/apps/web/src/components/chrome/user-pod.tsx
+++ b/apps/web/src/components/chrome/user-pod.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router"
-import { api, type Workspaces } from "@/api"
+import { api, type Workspaces, workspaceDisplayName } from "@/api"
 import { Icon } from "@/components/icons"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import {
@@ -48,9 +48,7 @@ export function UserPod({
   // the "Create a workspace" action instead). The server's `multi` flag is
   // always-on plumbing; real membership count is the signal.
   const multi = (workspaces?.workspaces.length ?? 0) > 1
-  // The personal workspace shows as "Personal", pinned first — it's provisioned
-  // plumbing, not a name the user chose (stable sort keeps the rest in order).
-  const wsName = (w: { name: string; personal: boolean }) => (w.personal ? "Personal" : w.name)
+  // Personal pins first; the stable sort keeps the rest in listing order.
   const sorted = [...(workspaces?.workspaces ?? [])].sort(
     (a, b) => Number(b.personal) - Number(a.personal),
   )
@@ -152,7 +150,7 @@ export function UserPod({
                 ) : (
                   <span className="size-4 shrink-0" />
                 )}
-                <span className="truncate">{wsName(w)}</span>
+                <span className="truncate">{workspaceDisplayName(w)}</span>
               </DropdownMenuItem>
             ))}
             <DropdownMenuItem data-testid="menu-new-workspace" onSelect={goNewWorkspace}>

--- a/apps/web/src/components/chrome/user-pod.tsx
+++ b/apps/web/src/components/chrome/user-pod.tsx
@@ -27,7 +27,8 @@ import { ThemeSwitch } from "./theme-switch"
 // breaks (after identity, before sign out); the mono Workspace/Theme labels are the
 // dividers for their own sections. Selecting an item auto-closes the menu (Radix),
 // so no manual open state. Keeps the e2e ids: user-menu-trigger, menu-signout, and
-// theme-option-* (inside ThemeSwitch). Creating a NEW workspace lives in Settings.
+// theme-option-* (inside ThemeSwitch). "New workspace" deep-links to the Settings
+// create dialog — the pod is the entry point, Settings stays the venue.
 export function UserPod({
   workspaceLabel,
   workspaces,
@@ -42,12 +43,29 @@ export function UserPod({
   if (!me) return null
 
   const initials = getInitials(me.name ?? me.email)
-  const multi = !!workspaces?.multi
+  // The switcher earns its place only when there's something to switch between —
+  // a solo account never sees ambient workspace chrome (the concept arrives as
+  // the "Create a workspace" action instead). The server's `multi` flag is
+  // always-on plumbing; real membership count is the signal.
+  const multi = (workspaces?.workspaces.length ?? 0) > 1
+  // The personal workspace shows as "Personal", pinned first — it's provisioned
+  // plumbing, not a name the user chose (stable sort keeps the rest in order).
+  const wsName = (w: { name: string; personal: boolean }) => (w.personal ? "Personal" : w.name)
+  const sorted = [...(workspaces?.workspaces ?? [])].sort(
+    (a, b) => Number(b.personal) - Number(a.personal),
+  )
 
   const goProfile = () => {
     if (me.username) nav({ to: "/users/$handle", params: { handle: me.username } })
   }
   const goSettings = () => nav({ to: "/settings" })
+  // Deep-link into Settings → General with the create dialog open (one-shot param).
+  const goNewWorkspace = () =>
+    nav({
+      to: "/settings/$section",
+      params: { section: "general" },
+      search: { "new-workspace": "1" },
+    })
   const signOut = async () => {
     await api.logout().catch(() => {})
     setMe(null)
@@ -115,27 +133,37 @@ export function UserPod({
           </DropdownMenuItem>
         </DropdownMenuGroup>
 
-        {/* CONTEXT — the workspace switcher, only when you're in more than one (a
-            single-workspace account reaches it through Settings). The mono label is
-            the section divider; the check carries the active one (neutral, no CTA). */}
-        {multi && (
+        {/* CONTEXT — the workspace switcher, only when you're in more than one.
+            The mono label is the section divider; the check carries the active one
+            (neutral, no CTA); "Personal" pins first. A solo account gets just the
+            first-need affordance — the workspace concept arrives as an action. */}
+        {multi ? (
           <DropdownMenuGroup>
             <DropdownMenuLabel>Workspace</DropdownMenuLabel>
-            {workspaces?.workspaces.map((w) => (
+            {sorted.map((w) => (
               <DropdownMenuItem
                 key={w.id}
                 data-testid={`workspace-${w.id}`}
-                aria-current={w.id === workspaces.active ? "true" : undefined}
+                aria-current={w.id === workspaces?.active ? "true" : undefined}
                 onSelect={() => onSwitchWorkspace(w.id)}
               >
-                {w.id === workspaces.active ? (
+                {w.id === workspaces?.active ? (
                   <Icon name="check" size={16} />
                 ) : (
                   <span className="size-4 shrink-0" />
                 )}
-                <span className="truncate">{w.name}</span>
+                <span className="truncate">{wsName(w)}</span>
               </DropdownMenuItem>
             ))}
+            <DropdownMenuItem data-testid="menu-new-workspace" onSelect={goNewWorkspace}>
+              <Icon name="plus" size={16} /> New workspace
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+        ) : (
+          <DropdownMenuGroup>
+            <DropdownMenuItem data-testid="menu-new-workspace" onSelect={goNewWorkspace}>
+              <Icon name="plus" size={16} /> Create a workspace…
+            </DropdownMenuItem>
           </DropdownMenuGroup>
         )}
 

--- a/apps/web/src/components/showcase/showcase.tsx
+++ b/apps/web/src/components/showcase/showcase.tsx
@@ -764,7 +764,7 @@ function SectionLabelDemo() {
         count={128}
         action={<span className="font-mono text-2xs text-muted-foreground">Browse all →</span>}
       >
-        Everything
+        All artifacts
       </SectionEyebrow>
     </div>
   )

--- a/apps/web/src/components/showcase/showcase.tsx
+++ b/apps/web/src/components/showcase/showcase.tsx
@@ -463,7 +463,7 @@ function ViewToggleDemo() {
 function BadgesDemo() {
   return (
     <div className="flex flex-wrap items-center gap-2.5">
-      <Badge variant="default">Draft</Badge>
+      <Badge variant="default">New</Badge>
       <Badge variant="brand">Shared</Badge>
       <Badge variant="success">Published</Badge>
       <Badge variant="warning">Sync stale</Badge>
@@ -764,7 +764,7 @@ function SectionLabelDemo() {
         count={128}
         action={<span className="font-mono text-2xs text-muted-foreground">Browse all →</span>}
       >
-        All artifacts
+        Everything
       </SectionEyebrow>
     </div>
   )
@@ -1008,9 +1008,9 @@ function ConfirmDemo() {
   )
 }
 
-/** The share dialog's general-access ladder — the five visibility steps as the
- *  dialog renders them (glyph + label + consequence), most private first. Static
- *  data; the live control is ShareButton's Select in pages/artifact/share-dialog. */
+/** The share dialog's general-access ladder — the visibility steps as the dialog
+ *  renders them (glyph + label + consequence), grouped as who × listed-or-link-only.
+ *  Static data; the live control is ShareButton's Select in pages/artifact/share-dialog. */
 function GeneralAccessDemo() {
   const steps: { icon: IconName; label: string; blurb: string; current?: boolean }[] = [
     {
@@ -1021,11 +1021,16 @@ function GeneralAccessDemo() {
     },
     {
       icon: "workspace",
-      label: "Workspace only",
-      blurb: "Only members of this workspace.",
+      label: "Workspace",
+      blurb: "Every workspace member can find it in the shared library.",
+    },
+    {
+      icon: "link",
+      label: "Workspace — link only",
+      blurb: "Workspace members with the link. Stays out of the shared library.",
     },
     { icon: "link", label: "Anyone with the link", blurb: "Anyone with the link can view." },
-    { icon: "globe", label: "Public — listed", blurb: "In the public directory and indexable." },
+    { icon: "globe", label: "Public", blurb: "In the public directory and indexable." },
     { icon: "lock", label: "Password protected", blurb: "Anyone with the link and the password." },
   ]
   return (

--- a/apps/web/src/components/showcase/showcase.tsx
+++ b/apps/web/src/components/showcase/showcase.tsx
@@ -1008,8 +1008,8 @@ function ConfirmDemo() {
   )
 }
 
-/** The share dialog's general-access ladder — the visibility steps as the dialog
- *  renders them (glyph + label + consequence), grouped as who × listed-or-link-only.
+/** The share dialog's general access — WHO (private / workspace / public) crossed
+ *  with listed-or-link-only, listed first in each pair (glyph + label + consequence).
  *  Static data; the live control is ShareButton's Select in pages/artifact/share-dialog. */
 function GeneralAccessDemo() {
   const steps: { icon: IconName; label: string; blurb: string; current?: boolean }[] = [
@@ -1029,8 +1029,12 @@ function GeneralAccessDemo() {
       label: "Workspace — link only",
       blurb: "Workspace members with the link. Stays out of the shared library.",
     },
-    { icon: "link", label: "Anyone with the link", blurb: "Anyone with the link can view." },
     { icon: "globe", label: "Public", blurb: "In the public directory and indexable." },
+    {
+      icon: "link",
+      label: "Public — link only",
+      blurb: "Anyone with the link can view. Not listed anywhere.",
+    },
     { icon: "lock", label: "Password protected", blurb: "Anyone with the link and the password." },
   ]
   return (

--- a/apps/web/src/components/ui/select-menu.tsx
+++ b/apps/web/src/components/ui/select-menu.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuContent,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { cn } from "@/lib/utils"
@@ -92,4 +93,7 @@ function SelectMenuItem({
   return <DropdownMenuRadioItem className={cn("py-1.5 pr-8 pl-2", className)} {...props} />
 }
 
-export { SelectMenu, SelectMenuContent, SelectMenuItem, SelectMenuTrigger }
+// A visual break between option groups (radio semantics are unaffected).
+const SelectMenuSeparator = DropdownMenuSeparator
+
+export { SelectMenu, SelectMenuContent, SelectMenuItem, SelectMenuSeparator, SelectMenuTrigger }

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -54,8 +54,9 @@ export type LibraryParams = {
   // The named-feed scopes, each its own route (see LibraryView):
   // "following" → the activity feed (followed authors + repo path prefixes);
   // "shared" → artifacts explicitly shared with you (can span workspaces);
-  // "needs_feedback" → artifacts with an open thread you're tagged in or commented on.
-  scope?: "following" | "shared" | "needs_feedback" | "unlisted"
+  // "needs_feedback" → artifacts with an open thread you're tagged in or commented on;
+  // "mine" → everything you've published by hand, any visibility included.
+  scope?: "following" | "shared" | "needs_feedback" | "mine"
 }
 export const libraryArtifactsQuery = (params: LibraryParams) =>
   infiniteQueryOptions({

--- a/apps/web/src/pages/accept-invite.tsx
+++ b/apps/web/src/pages/accept-invite.tsx
@@ -48,6 +48,16 @@ export function AcceptInvite() {
     retry: false,
   })
 
+  // The invite named an email; the signed-in account has a different one. The
+  // token still authorizes (self-hosts run without verified email), but the
+  // mismatch is surfaced and acceptance must be explicit — the server 409s
+  // without the confirm flag.
+  const mismatch = !!(
+    me &&
+    preview?.email &&
+    preview.email.toLowerCase() !== me.email.toLowerCase()
+  )
+
   const accept = async () => {
     // Not signed in → send them to sign in, returning here to finish.
     if (!me) {
@@ -57,7 +67,7 @@ export function AcceptInvite() {
     setAccepting(true)
     setErr("")
     try {
-      await api.acceptInvite(token)
+      await api.acceptInvite(token, mismatch)
       // The roster/active-workspace may change — refresh, then land in the app.
       qc.invalidateQueries({ queryKey: workspaceQuery().queryKey })
       nav({ to: "/" })
@@ -94,6 +104,7 @@ export function AcceptInvite() {
       signedIn={!!me}
       accepting={accepting}
       err={err}
+      mismatchEmail={mismatch ? (me?.email ?? null) : null}
       onAccept={accept}
     />
   )
@@ -104,12 +115,15 @@ function Invitation({
   signedIn,
   accepting,
   err,
+  mismatchEmail,
   onAccept,
 }: {
   preview: InvitePreview
   signedIn: boolean
   accepting: boolean
   err: string
+  /** Set when the signed-in email differs from the invited one — renders the warning. */
+  mismatchEmail: string | null
   onAccept: () => void
 }) {
   return (
@@ -123,6 +137,16 @@ function Invitation({
           <Badge variant="secondary">{roleLabel(preview.role)}</Badge>
         </p>
       </div>
+      {mismatchEmail && (
+        <div data-testid="invite-mismatch" className="w-full">
+          <StatusPanel
+            tone="warning"
+            layout="inline"
+            title={`This invite was sent to ${preview.email}`}
+            description={`You're signed in as ${mismatchEmail}. You can accept anyway, or sign in with the invited address first.`}
+          />
+        </div>
+      )}
       {err && (
         <div data-testid="invite-error" className="w-full">
           <StatusPanel tone="danger" layout="inline" title={err} />
@@ -135,7 +159,13 @@ function Invitation({
         loading={accepting}
         onClick={onAccept}
       >
-        {signedIn ? (accepting ? "Joining…" : "Accept invitation") : "Sign in to accept"}
+        {signedIn
+          ? accepting
+            ? "Joining…"
+            : mismatchEmail
+              ? "Accept anyway"
+              : "Accept invitation"
+          : "Sign in to accept"}
       </Button>
     </Shell>
   )

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -35,9 +35,10 @@ import { getInitials } from "@/lib/initials"
 import { artifactQuery } from "@/lib/queries"
 import { cn } from "@/lib/utils"
 
-// General access (visibility) options, in order of increasing reach — the ladder
-// reads top-to-bottom from most private to most open, each with the glyph the
-// Share trigger echoes.
+// General access (visibility) options, grouped as two dimensions rather than one
+// flat ladder: WHO (private / workspace / anyone) and, for workspace and anyone,
+// whether it's listed in the shared library or reachable by link only. Each pair
+// (workspace/workspace-link-only, anyone/anyone-link-only) sits adjacent below.
 const ACCESS: { value: string; label: string; blurb: string; icon: IconName }[] = [
   {
     value: "private",
@@ -46,16 +47,16 @@ const ACCESS: { value: string; label: string; blurb: string; icon: IconName }[] 
     icon: "lock",
   },
   {
-    value: "unlisted",
-    label: "Draft — workspace with link",
-    blurb: "Workspace members with the link. Stays out of the library until shared.",
-    icon: "link",
+    value: "org",
+    label: "Workspace",
+    blurb: "Every workspace member can find it in the shared library.",
+    icon: "workspace",
   },
   {
-    value: "org",
-    label: "Workspace only",
-    blurb: "Only members of this workspace.",
-    icon: "workspace",
+    value: "unlisted",
+    label: "Workspace — link only",
+    blurb: "Workspace members with the link. Stays out of the shared library.",
+    icon: "link",
   },
   {
     value: "link",
@@ -65,7 +66,7 @@ const ACCESS: { value: string; label: string; blurb: string; icon: IconName }[] 
   },
   {
     value: "public",
-    label: "Public — listed",
+    label: "Public",
     blurb: "In the public directory and indexable.",
     icon: "globe",
   },

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { useEffect, useRef, useState } from "react"
+import { Fragment, useEffect, useRef, useState } from "react"
 import {
   API_BASE,
   type ArtifactDomain,
@@ -27,6 +27,7 @@ import {
   SelectMenu,
   SelectMenuContent,
   SelectMenuItem,
+  SelectMenuSeparator,
   SelectMenuTrigger,
 } from "@/components/ui/select-menu"
 import { toast } from "@/components/ui/sonner"
@@ -35,48 +36,58 @@ import { getInitials } from "@/lib/initials"
 import { artifactQuery } from "@/lib/queries"
 import { cn } from "@/lib/utils"
 
-// General access (visibility) options, grouped as two dimensions rather than one
-// flat ladder: WHO (private / workspace / anyone) and, for workspace and anyone,
-// whether it's listed in the shared library or reachable by link only. Each pair
-// (workspace/workspace-link-only, anyone/anyone-link-only) sits adjacent below.
-const ACCESS: { value: string; label: string; blurb: string; icon: IconName }[] = [
-  {
-    value: "private",
-    label: "Private",
-    blurb: "Only people added above. Workspace membership grants nothing.",
-    icon: "lock",
-  },
-  {
-    value: "org",
-    label: "Workspace",
-    blurb: "Every workspace member can find it in the shared library.",
-    icon: "workspace",
-  },
-  {
-    value: "unlisted",
-    label: "Workspace — link only",
-    blurb: "Workspace members with the link. Stays out of the shared library.",
-    icon: "link",
-  },
-  {
-    value: "link",
-    label: "Anyone with the link",
-    blurb: "Anyone with the link can view.",
-    icon: "link",
-  },
-  {
-    value: "public",
-    label: "Public",
-    blurb: "In the public directory and indexable.",
-    icon: "globe",
-  },
-  {
-    value: "password",
-    label: "Password protected",
-    blurb: "Anyone with the link and the password.",
-    icon: "lock",
-  },
+// General access (visibility) options as two dimensions, not one flat ladder:
+// WHO (private / workspace / public) crossed with listed-or-link-only for the
+// workspace and public tiers. Each inner array renders as a menu group with a
+// separator between groups, so the pairs read as pairs: listed first, link-only
+// second, same order in both tiers. Password trails as a modifier-style rung.
+const ACCESS_GROUPS: { value: string; label: string; blurb: string; icon: IconName }[][] = [
+  [
+    {
+      value: "private",
+      label: "Private",
+      blurb: "Only people added above. Workspace membership grants nothing.",
+      icon: "lock",
+    },
+  ],
+  [
+    {
+      value: "org",
+      label: "Workspace",
+      blurb: "Every workspace member can find it in the shared library.",
+      icon: "workspace",
+    },
+    {
+      value: "unlisted",
+      label: "Workspace — link only",
+      blurb: "Workspace members with the link. Stays out of the shared library.",
+      icon: "link",
+    },
+  ],
+  [
+    {
+      value: "public",
+      label: "Public",
+      blurb: "In the public directory and indexable.",
+      icon: "globe",
+    },
+    {
+      value: "link",
+      label: "Public — link only",
+      blurb: "Anyone with the link can view. Not listed anywhere.",
+      icon: "link",
+    },
+  ],
+  [
+    {
+      value: "password",
+      label: "Password protected",
+      blurb: "Anyone with the link and the password.",
+      icon: "lock",
+    },
+  ],
 ]
+const ACCESS = ACCESS_GROUPS.flat()
 
 // The state glyph the Share trigger carries so exposure is legible without
 // opening the dialog: a globe when the URL alone reads (link/public), a lock
@@ -427,11 +438,16 @@ export function ShareButton({
                       {currentAccess?.label ?? vis}
                     </SelectMenuTrigger>
                     <SelectMenuContent>
-                      {ACCESS.map((a) => (
-                        <SelectMenuItem key={a.value} value={a.value}>
-                          <Icon name={a.icon} className="text-muted-foreground" />
-                          {a.label}
-                        </SelectMenuItem>
+                      {ACCESS_GROUPS.map((group, gi) => (
+                        <Fragment key={group[0]?.value ?? gi}>
+                          {gi > 0 && <SelectMenuSeparator />}
+                          {group.map((a) => (
+                            <SelectMenuItem key={a.value} value={a.value}>
+                              <Icon name={a.icon} className="text-muted-foreground" />
+                              {a.label}
+                            </SelectMenuItem>
+                          ))}
+                        </Fragment>
                       ))}
                     </SelectMenuContent>
                   </SelectMenu>
@@ -762,7 +778,7 @@ export function ShareButton({
               <p className="mt-1.5 text-sm text-muted-foreground">
                 {linkAccessible
                   ? "Paste into any page — live, with a link back to Derive."
-                  : "Set access to “Anyone with the link” or “Public” for the embed to load for others."}
+                  : "Set access to “Public” or “Public — link only” for the embed to load for others."}
               </p>
             </div>
 

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -1,4 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useNavigate } from "@tanstack/react-router"
 import { Fragment, useEffect, useRef, useState } from "react"
 import {
   API_BASE,
@@ -33,7 +34,7 @@ import {
 import { toast } from "@/components/ui/sonner"
 import { useAuth } from "@/ctx"
 import { getInitials } from "@/lib/initials"
-import { artifactQuery } from "@/lib/queries"
+import { artifactQuery, workspaceQuery } from "@/lib/queries"
 import { cn } from "@/lib/utils"
 
 // General access (visibility) options as two dimensions, not one flat ladder:
@@ -187,6 +188,21 @@ export function ShareButton({
   // ACCESS at every place the icon/label/blurb is needed.
   const currentAccess = ACCESS.find((a) => a.value === vis)
   const visibilityAccess = ACCESS.find((a) => a.value === visibility)
+  // A workspace of one makes the team rungs meaningless (both collapse to
+  // Private-with-extra-words), so a solo account gets a three-rung menu and a
+  // create-a-workspace hint where the team rungs would be — the concept's first
+  // appearance is the moment it answers "how do I show this to my team?".
+  // Default to NOT solo while the roster loads, so rungs never flash out.
+  const nav = useNavigate()
+  const { data: workspace } = useQuery(workspaceQuery())
+  const solo = workspace ? workspace.members.length <= 1 : false
+  // Keep a team rung visible when it's the artifact's CURRENT state (or the
+  // in-flight pick), so the select never renders a value it doesn't contain.
+  const accessGroups = solo
+    ? ACCESS_GROUPS.map((g) =>
+        g.filter((a) => !["org", "unlisted"].includes(a.value) || a.value === vis),
+      ).filter((g) => g.length > 0)
+    : ACCESS_GROUPS
   // Reach visibilities (anyone with the link / public / password) carry a general-access
   // permission; private/workspace do not, so the view/comment control hides for them.
   const reach = vis === "link" || vis === "public" || vis === "password"
@@ -438,7 +454,7 @@ export function ShareButton({
                       {currentAccess?.label ?? vis}
                     </SelectMenuTrigger>
                     <SelectMenuContent>
-                      {ACCESS_GROUPS.map((group, gi) => (
+                      {accessGroups.map((group, gi) => (
                         <Fragment key={group[0]?.value ?? gi}>
                           {gi > 0 && <SelectMenuSeparator />}
                           {group.map((a) => (
@@ -540,6 +556,29 @@ export function ShareButton({
                     </Button>
                   )}
                 </p>
+                {/* First-need on-ramp: the hidden team rungs, explained at the
+                    exact moment they'd have been useful. */}
+                {solo && (
+                  <p className="text-sm text-muted-foreground">
+                    Working with a team?{" "}
+                    <Button
+                      variant="link"
+                      size="xs"
+                      data-testid="share-create-workspace"
+                      className="px-0"
+                      onClick={() =>
+                        nav({
+                          to: "/settings/$section",
+                          params: { section: "general" },
+                          search: { "new-workspace": "1" },
+                        })
+                      }
+                    >
+                      Create a workspace
+                    </Button>{" "}
+                    to share with them.
+                  </p>
+                )}
               </div>
             ) : (
               <p className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
@@ -553,7 +592,7 @@ export function ShareButton({
             <SectionEyebrow count={members.length || undefined}>People with access</SectionEyebrow>
             {members.length === 0 ? (
               <p data-testid="share-empty" className="px-2 py-2.5 text-sm text-muted-foreground">
-                {canManage ? "No one shared yet." : "Just you and the workspace."}
+                {canManage ? "No one shared yet." : "No one else has been added."}
               </p>
             ) : (
               <div className="-mx-2 mt-1 flex flex-col">

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -188,21 +188,15 @@ export function ShareButton({
   // ACCESS at every place the icon/label/blurb is needed.
   const currentAccess = ACCESS.find((a) => a.value === vis)
   const visibilityAccess = ACCESS.find((a) => a.value === visibility)
-  // A workspace of one makes the team rungs meaningless (both collapse to
-  // Private-with-extra-words), so a solo account gets a three-rung menu and a
-  // create-a-workspace hint where the team rungs would be — the concept's first
-  // appearance is the moment it answers "how do I show this to my team?".
-  // Default to NOT solo while the roster loads, so rungs never flash out.
+  // A solo account keeps the FULL ladder — the workspace tier is not meaningless
+  // for a workspace of one: org vs unlisted is what lists a doc in (or hides it
+  // from) your own library, and promoting an agent's link-only publish to
+  // Workspace is the core loop's blessing gesture. The first-need affordance is
+  // the hint below instead: the word "workspace" first appears as the answer to
+  // "how do I show this to my team?". Default NOT solo while the roster loads.
   const nav = useNavigate()
   const { data: workspace } = useQuery(workspaceQuery())
   const solo = workspace ? workspace.members.length <= 1 : false
-  // Keep a team rung visible when it's the artifact's CURRENT state (or the
-  // in-flight pick), so the select never renders a value it doesn't contain.
-  const accessGroups = solo
-    ? ACCESS_GROUPS.map((g) =>
-        g.filter((a) => !["org", "unlisted"].includes(a.value) || a.value === vis),
-      ).filter((g) => g.length > 0)
-    : ACCESS_GROUPS
   // Reach visibilities (anyone with the link / public / password) carry a general-access
   // permission; private/workspace do not, so the view/comment control hides for them.
   const reach = vis === "link" || vis === "public" || vis === "password"
@@ -454,7 +448,7 @@ export function ShareButton({
                       {currentAccess?.label ?? vis}
                     </SelectMenuTrigger>
                     <SelectMenuContent>
-                      {accessGroups.map((group, gi) => (
+                      {ACCESS_GROUPS.map((group, gi) => (
                         <Fragment key={group[0]?.value ?? gi}>
                           {gi > 0 && <SelectMenuSeparator />}
                           {group.map((a) => (

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -188,17 +188,17 @@ export function ShareButton({
   // ACCESS at every place the icon/label/blurb is needed.
   const currentAccess = ACCESS.find((a) => a.value === vis)
   const visibilityAccess = ACCESS.find((a) => a.value === visibility)
-  // A solo account keeps the FULL ladder — the workspace tier is not meaningless
-  // for a workspace of one: org vs unlisted is what lists a doc in (or hides it
-  // from) your own library, and promoting an agent's link-only publish to
-  // Workspace is the core loop's blessing gesture. The first-need affordance is
-  // the hint below instead: the word "workspace" first appears as the answer to
-  // "how do I show this to my team?". Default NOT solo while the roster loads.
   const nav = useNavigate()
-  const { data: workspace } = useQuery(workspaceQuery())
+  // Solo drives only the create-a-workspace hint, never the ladder itself — the
+  // workspace rungs stay meaningful for a workspace of one (org vs unlisted is
+  // what lists a doc in your own library, and promoting an agent's link-only
+  // publish to Workspace is the loop's blessing gesture). Managers only, and
+  // not-solo while the roster loads, so nothing flashes.
+  const { data: workspace } = useQuery({ ...workspaceQuery(), enabled: canManage })
   const solo = workspace ? workspace.members.length <= 1 : false
-  // Reach visibilities (anyone with the link / public / password) carry a general-access
-  // permission; private/workspace do not, so the view/comment control hides for them.
+  // Reach visibilities (link / public / password — anyone can arrive) carry a
+  // general-access permission; private/workspace do not, so the view/comment
+  // control hides for them.
   const reach = vis === "link" || vis === "public" || vis === "password"
   // Unlisted carries the same view/comment choice, but the reachers are workspace
   // members only (the default comes from workspace settings; this is the per-doc override).
@@ -449,7 +449,7 @@ export function ShareButton({
                     </SelectMenuTrigger>
                     <SelectMenuContent>
                       {ACCESS_GROUPS.map((group, gi) => (
-                        <Fragment key={group[0]?.value ?? gi}>
+                        <Fragment key={group[0]?.value}>
                           {gi > 0 && <SelectMenuSeparator />}
                           {group.map((a) => (
                             <SelectMenuItem key={a.value} value={a.value}>
@@ -550,8 +550,8 @@ export function ShareButton({
                     </Button>
                   )}
                 </p>
-                {/* First-need on-ramp: the hidden team rungs, explained at the
-                    exact moment they'd have been useful. */}
+                {/* First-need on-ramp: the word "workspace" earns its first
+                    appearance by answering "how do I show this to my team?". */}
                 {solo && (
                   <p className="text-sm text-muted-foreground">
                     Working with a team?{" "}

--- a/apps/web/src/pages/library/artifact-card.tsx
+++ b/apps/web/src/pages/library/artifact-card.tsx
@@ -241,6 +241,13 @@ export function ArtifactCard({
             )}
           </span>
           <span className="ml-auto inline-flex shrink-0 items-center gap-2.5">
+            {/* Link-only work is invisible in the shared library — the chip says so
+                wherever the doc DOES surface (Created by me, Shared with you). */}
+            {a.visibility === "unlisted" && (
+              <Badge shape="pill" variant="outline" title="Workspace members with the link only">
+                <Icon name="link" size={12} /> Link only
+              </Badge>
+            )}
             <CommentSignal artifact={a} size={12} compact />
             {a.views !== undefined && a.views > 0 && (
               <span className="inline-flex items-center gap-1" title={`${a.views} viewers`}>

--- a/apps/web/src/pages/library/artifact-row.tsx
+++ b/apps/web/src/pages/library/artifact-row.tsx
@@ -91,6 +91,13 @@ export function ArtifactRow({
         )}
         <span className="flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-2xs tabular-nums text-muted-foreground">
           <Badge shape="pill">{artifactTypeLabel(a)}</Badge>
+          {/* Link-only work is invisible in the shared library — the chip says so
+              wherever the doc DOES surface (Created by me, Shared with you). */}
+          {a.visibility === "unlisted" && (
+            <Badge shape="pill" variant="outline" title="Workspace members with the link only">
+              <Icon name="link" size={12} /> Link only
+            </Badge>
+          )}
           {dir && (
             <span className="inline-flex items-center gap-1 truncate" title={a.source_path ?? ""}>
               {/* Neutral metadata — a folder path is not a brand moment. */}

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -432,6 +432,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
           active={filter.kind === "mine" ? "mine" : "all"}
           total={summary?.total}
           mine={summary?.mine}
+          pending={summary?.mine_link_only}
         />
       ) : (
         // Hide the heading on a brand-new empty home — the visual guide carries it.
@@ -640,18 +641,23 @@ function SyncedCollection({
 
 // The home library's two tabs: everything, and just what you created. Always
 // both — a basic ownership filter is useful independent of whether it's ever
-// empty. Route stays "/", the tab rides ?tab=mine.
+// empty. Route stays "/", the tab rides ?tab=mine. `pending` is the count of
+// your still-link-only docs — the signal the old Drafts badge carried ("your
+// agent published; waiting on you to surface it"), rendered as an accent pill
+// beside the neutral total so it reads as actionable, not as more inventory.
 function LibraryTabs({
   active,
   total,
   mine,
+  pending,
 }: {
   active: "all" | "mine"
   total?: number
   mine?: number
+  pending?: number
 }) {
   const nav = useNavigate()
-  const tab = (id: "all" | "mine", label: string, count?: number) => (
+  const tab = (id: "all" | "mine", label: string, count?: number, accent?: number) => (
     <button
       type="button"
       data-testid={`library-tab-${id}`}
@@ -670,12 +676,20 @@ function LibraryTabs({
       {count != null && (
         <span className="font-mono text-2xs tabular-nums text-muted-foreground">{count}</span>
       )}
+      {accent != null && accent > 0 && (
+        <span
+          title={`${accent} link-only — visible to you and link-holders until shared wider`}
+          className="rounded-full bg-primary/10 px-1.5 font-mono text-2xs tabular-nums text-primary"
+        >
+          {accent}
+        </span>
+      )}
     </button>
   )
   return (
     <div className="mb-3.5 flex items-center gap-5 border-b border-border-soft">
       {tab("all", "All artifacts", total)}
-      {tab("mine", "Created by me", mine)}
+      {tab("mine", "Created by me", mine, pending)}
     </div>
   )
 }

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -425,9 +425,8 @@ function LibraryBody({ view }: { view: LibraryView }) {
           <RepoPullRequests prs={repoPrs} repo={activeCollection?.repo} activeId={filter.id} />
         </>
       ) : view === "all" && !isSearching ? (
-        // Always both tabs, even over the first-run guide — a generic filter
-        // beats a special-cased one, and an empty "Created by you" tab is a
-        // fine place to land before you've published anything.
+        // Always both tabs, even over the first-run guide — an empty "Created
+        // by me" tab is a fine place to land before you've published anything.
         <LibraryTabs
           active={filter.kind === "mine" ? "mine" : "all"}
           total={summary?.total}
@@ -639,12 +638,10 @@ function SyncedCollection({
   )
 }
 
-// The home library's two tabs: everything, and just what you created. Always
-// both — a basic ownership filter is useful independent of whether it's ever
-// empty. Route stays "/", the tab rides ?tab=mine. `pending` is the count of
-// your still-link-only docs — the signal the old Drafts badge carried ("your
-// agent published; waiting on you to surface it"), rendered as an accent pill
-// beside the neutral total so it reads as actionable, not as more inventory.
+// The home library's two tabs: everything, and just what you created. Route
+// stays "/", the tab rides ?tab=mine. `pending` counts your still-link-only
+// docs — the "waiting on you to surface it" signal the old Drafts badge
+// carried — shown as an accent pill beside the neutral total.
 function LibraryTabs({
   active,
   total,
@@ -678,7 +675,7 @@ function LibraryTabs({
       )}
       {accent != null && accent > 0 && (
         <span
-          title={`${accent} link-only — visible to you and link-holders until shared wider`}
+          title={`${accent} link-only — hidden from the shared library until shared wider`}
           className="rounded-full bg-primary/10 px-1.5 font-mono text-2xs tabular-nums text-primary"
         >
           {accent}

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -266,7 +266,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
 
   const heading =
     filter.kind === "all"
-      ? "Everything"
+      ? "All artifacts"
       : filter.kind === "favorites"
         ? "Favorites"
         : filter.kind === "following"
@@ -674,7 +674,7 @@ function LibraryTabs({
   )
   return (
     <div className="mb-3.5 flex items-center gap-5 border-b border-border-soft">
-      {tab("all", "Everything", total)}
+      {tab("all", "All artifacts", total)}
       {tab("mine", "Created by me", mine)}
     </div>
   )

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -79,7 +79,7 @@ function deriveFilter(
   if (view === "following") return { kind: "following" }
   if (view === "shared") return { kind: "shared" }
   if (view === "feedback") return { kind: "feedback" }
-  if (search.tab === "drafts") return { kind: "unlisted" }
+  if (search.tab === "mine") return { kind: "mine" }
   if (search.tag) return { kind: "tag", tag: search.tag }
   if (search.collection)
     return {
@@ -125,7 +125,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
     collection: search.collection,
     favorite: view === "favorites" || undefined,
     author: search.author,
-    scope: filter.kind === "unlisted" ? ("unlisted" as const) : scopeFor(view),
+    scope: filter.kind === "mine" ? ("mine" as const) : scopeFor(view),
   }
   const { query: feed, items, listQuery, toggleFavorite, deleteArtifact } = useLibraryFeed(params)
   const { isPending, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } = feed
@@ -266,7 +266,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
 
   const heading =
     filter.kind === "all"
-      ? "All artifacts"
+      ? "Everything"
       : filter.kind === "favorites"
         ? "Favorites"
         : filter.kind === "following"
@@ -275,8 +275,8 @@ function LibraryBody({ view }: { view: LibraryView }) {
             ? "Shared with you"
             : filter.kind === "feedback"
               ? "Needs your feedback"
-              : filter.kind === "unlisted"
-                ? "Drafts"
+              : filter.kind === "mine"
+                ? "Created by me"
                 : filter.kind === "tag"
                   ? `#${filter.tag}`
                   : collectionTitle
@@ -289,8 +289,8 @@ function LibraryBody({ view }: { view: LibraryView }) {
       ? summary?.total
       : filter.kind === "favorites"
         ? summary?.favorites
-        : filter.kind === "unlisted"
-          ? summary?.unlisted
+        : filter.kind === "mine"
+          ? summary?.mine
           : filter.kind === "tag"
             ? summary?.tags.find((t) => t.tag === filter.tag)?.count
             : filter.kind === "collection"
@@ -425,13 +425,13 @@ function LibraryBody({ view }: { view: LibraryView }) {
           <RepoPullRequests prs={repoPrs} repo={activeCollection?.repo} activeId={filter.id} />
         </>
       ) : view === "all" && !isSearching ? (
-        // Always both tabs, even over the first-run guide — an agent's first
-        // draft can exist before any shared artifact does, and the empty Drafts
-        // tab is itself how the concept gets discovered (round-1 decision).
+        // Always both tabs, even over the first-run guide — a generic filter
+        // beats a special-cased one, and an empty "Created by you" tab is a
+        // fine place to land before you've published anything.
         <LibraryTabs
-          active={filter.kind === "unlisted" ? "drafts" : "all"}
+          active={filter.kind === "mine" ? "mine" : "all"}
           total={summary?.total}
-          drafts={summary?.unlisted}
+          mine={summary?.mine}
         />
       ) : (
         // Hide the heading on a brand-new empty home — the visual guide carries it.
@@ -638,26 +638,26 @@ function SyncedCollection({
   )
 }
 
-// The home library's two tabs: your shared work and your drafts. Always both —
-// the empty Drafts tab is how the concept gets discovered (see the sidebar-
-// cleanup plan's round-1 decisions). Route stays "/", the tab rides ?tab=drafts.
+// The home library's two tabs: everything, and just what you created. Always
+// both — a basic ownership filter is useful independent of whether it's ever
+// empty. Route stays "/", the tab rides ?tab=mine.
 function LibraryTabs({
   active,
   total,
-  drafts,
+  mine,
 }: {
-  active: "all" | "drafts"
+  active: "all" | "mine"
   total?: number
-  drafts?: number
+  mine?: number
 }) {
   const nav = useNavigate()
-  const tab = (id: "all" | "drafts", label: string, count?: number) => (
+  const tab = (id: "all" | "mine", label: string, count?: number) => (
     <button
       type="button"
       data-testid={`library-tab-${id}`}
       aria-current={active === id ? "page" : undefined}
       onClick={() =>
-        nav({ to: "/", search: (s) => ({ ...s, tab: id === "drafts" ? "drafts" : undefined }) })
+        nav({ to: "/", search: (s) => ({ ...s, tab: id === "mine" ? "mine" : undefined }) })
       }
       className={cn(
         "flex items-center gap-1.5 border-b-2 pb-2 text-sm font-medium transition-colors",
@@ -674,8 +674,8 @@ function LibraryTabs({
   )
   return (
     <div className="mb-3.5 flex items-center gap-5 border-b border-border-soft">
-      {tab("all", "All artifacts", total)}
-      {tab("drafts", "Drafts", drafts)}
+      {tab("all", "Everything", total)}
+      {tab("mine", "Created by me", mine)}
     </div>
   )
 }
@@ -725,12 +725,12 @@ function emptyStateFor(
         title: "Nothing shared with you yet.",
         description: "When someone shares an artifact with you, it shows up here.",
       }
-    case "unlisted":
+    case "mine":
       return {
         icon: <Icon name="sparkles" strokeWidth={1.75} />,
-        title: "No drafts yet.",
+        title: "Nothing you've created yet.",
         description:
-          "Your agent's drafts land here until you share them — everything it writes stays out of the team's way until you say so.",
+          "Publish something, or connect an agent — everything you or your agents create shows up here, whatever its audience.",
         action: (
           <Button
             variant="outline"

--- a/apps/web/src/pages/library/types.ts
+++ b/apps/web/src/pages/library/types.ts
@@ -12,9 +12,10 @@ export type Filter =
   // "Needs your feedback": artifacts with an open thread you're tagged in or have
   // commented on — the triage feed.
   | { kind: "feedback" }
-  // Everything you've published by hand in the active workspace, any visibility
-  // included (a workspace-link-only doc surfaces here even though it's hidden
-  // from the plain "all" feed).
+  // "Created by me": every artifact you own in the active workspace (your owner
+  // member row — written at creation, agents' on-behalf publishes included), any
+  // visibility. A link-only doc surfaces here even though the plain "all" feed
+  // hides it.
   | { kind: "mine" }
   | { kind: "tag"; tag: string }
   | { kind: "collection"; id: string; title: string }

--- a/apps/web/src/pages/library/types.ts
+++ b/apps/web/src/pages/library/types.ts
@@ -26,6 +26,8 @@ export type Summary = {
   total: number
   favorites: number
   mine: number
+  // Owned docs still at link-only visibility — the "waiting to be shared" signal.
+  mine_link_only: number
   tags: TagCount[]
   workspace: string
 }

--- a/apps/web/src/pages/library/types.ts
+++ b/apps/web/src/pages/library/types.ts
@@ -12,8 +12,10 @@ export type Filter =
   // "Needs your feedback": artifacts with an open thread you're tagged in or have
   // commented on — the triage feed.
   | { kind: "feedback" }
-  // Your own unlisted drafts (agent publishes land here until shared wider).
-  | { kind: "unlisted" }
+  // Everything you've published by hand in the active workspace, any visibility
+  // included (a workspace-link-only doc surfaces here even though it's hidden
+  // from the plain "all" feed).
+  | { kind: "mine" }
   | { kind: "tag"; tag: string }
   | { kind: "collection"; id: string; title: string }
 
@@ -22,7 +24,7 @@ export type TagCount = { tag: string; count: number }
 export type Summary = {
   total: number
   favorites: number
-  unlisted: number
+  mine: number
   tags: TagCount[]
   workspace: string
 }
@@ -44,8 +46,8 @@ export type LibrarySearch = {
   query?: string
   // Narrow to artifacts last changed by this GitHub login (synced collections).
   author?: string
-  // The home library's second tab: your own drafts (the `unlisted` visibility,
-  // renamed for humans). A query param, not a route — a view of YOUR OWN work
-  // is a filter on the home library, not a separate feed (docs/decisions/0002).
-  tab?: "drafts"
+  // The home library's second tab: everything YOU created, any visibility. A
+  // query param, not a route — a view of your own work is a filter on the home
+  // library, not a separate feed (docs/decisions/0002).
+  tab?: "mine"
 }

--- a/apps/web/src/pages/settings/general-section.tsx
+++ b/apps/web/src/pages/settings/general-section.tsx
@@ -242,8 +242,8 @@ function SharingDefaults() {
   return (
     <SettingsGroup>
       <SettingRow
-        label="Draft link permission"
-        description="What a workspace member opening a draft's link can do. Each doc can override this in its share dialog."
+        label="Workspace link permission"
+        description="What a workspace member opening a link-only doc can do. Each doc can override this in its share dialog."
       >
         <SelectMenu
           value={settings.defaultUnlistedRole}

--- a/apps/web/src/pages/settings/general-section.tsx
+++ b/apps/web/src/pages/settings/general-section.tsx
@@ -38,6 +38,8 @@ export function GeneralSection() {
   const [savingName, setSavingName] = useState(false)
   const [createOpen, setCreateOpen] = useState(false)
   const [newName, setNewName] = useState("")
+  const [newInvites, setNewInvites] = useState("")
+  const [creating, setCreating] = useState(false)
   const [delName, setDelName] = useState("")
   const [deleting, setDeleting] = useState(false)
 
@@ -47,16 +49,37 @@ export function GeneralSection() {
     if (ws) setName(ws.name)
   }, [ws])
 
+  // ?new-workspace=1 auto-opens the create dialog — the deep link the user pod and
+  // the share dialog's first-need hint navigate to. One-shot: consumed + stripped
+  // (same pattern as the GitHub section's gh_install handshake params).
+  useEffect(() => {
+    const url = new URL(window.location.href)
+    if (url.searchParams.get("new-workspace")) {
+      setCreateOpen(true)
+      url.searchParams.delete("new-workspace")
+      window.history.replaceState(null, "", url)
+    }
+  }, [])
+
   const isAdmin = ws?.role === "owner"
 
   // Create a brand-new workspace — a deliberate, infrequent action that lives
-  // here rather than in the rail's switcher. createWorkspace reloads into it.
-  const createSubmit = () => {
+  // here rather than in the rail's switcher. One flow: name it and (optionally)
+  // invite the team in the same gesture; createWorkspace switches + reloads.
+  const createSubmit = async () => {
     const t = newName.trim()
-    if (!t) return
-    createWorkspace(t)
-    setNewName("")
-    setCreateOpen(false)
+    if (!t || creating) return
+    const invites = newInvites
+      .split(/[\s,;]+/)
+      .map((s) => s.trim())
+      .filter((s) => s.includes("@"))
+    setCreating(true)
+    try {
+      await createWorkspace(t, invites)
+    } catch (e) {
+      toast.error((e as Error).message)
+      setCreating(false)
+    }
   }
 
   const saveName = async () => {
@@ -104,7 +127,9 @@ export function GeneralSection() {
           <DialogContent>
             <DialogHeader>
               <DialogTitle>Create a workspace</DialogTitle>
-              <DialogDescription>Starts empty. You'll be the owner.</DialogDescription>
+              <DialogDescription>
+                A shared library for a team. You'll be the owner.
+              </DialogDescription>
             </DialogHeader>
             <Input
               autoFocus
@@ -115,6 +140,18 @@ export function GeneralSection() {
               onChange={(e) => setNewName(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && createSubmit()}
               maxLength={80}
+            />
+            {/* Naming a workspace and bringing the team are one gesture — the
+                invites are optional, but asking here means nobody has to discover
+                Members as a separate second step. */}
+            <Input
+              value={newInvites}
+              placeholder="Invite teammates — emails, comma-separated (optional)"
+              aria-label="Invite teammates by email"
+              data-testid="workspace-new-invites"
+              onChange={(e) => setNewInvites(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && createSubmit()}
+              className="mt-2"
             />
             <div className="mt-3 flex justify-end gap-2">
               <Button
@@ -127,10 +164,11 @@ export function GeneralSection() {
               <Button
                 variant="default"
                 onClick={createSubmit}
-                disabled={!newName.trim()}
+                disabled={!newName.trim() || creating}
+                loading={creating}
                 data-testid="workspace-create-submit"
               >
-                Create
+                {creating ? "Creating…" : "Create"}
               </Button>
             </div>
           </DialogContent>

--- a/apps/web/src/pages/settings/general-section.tsx
+++ b/apps/web/src/pages/settings/general-section.tsx
@@ -263,7 +263,7 @@ function SharingDefaults() {
       </SettingRow>
       <SettingRow
         label="Agent publishes as"
-        description="Where a new artifact published by a connected agent lands. Draft keeps its work out of the library until shared."
+        description="Where a new artifact published by a connected agent lands. Workspace — link only keeps it out of the shared library until you decide to surface it."
       >
         <SelectMenu
           value={settings.defaultAgentVisibility}
@@ -278,7 +278,7 @@ function SharingDefaults() {
             {AGENT_VIS_LABELS[settings.defaultAgentVisibility] ?? settings.defaultAgentVisibility}
           </SelectMenuTrigger>
           <SelectMenuContent>
-            <SelectMenuItem value="unlisted">Draft</SelectMenuItem>
+            <SelectMenuItem value="unlisted">Workspace — link only</SelectMenuItem>
             <SelectMenuItem value="private">Private</SelectMenuItem>
             <SelectMenuItem value="org">Workspace</SelectMenuItem>
           </SelectMenuContent>
@@ -289,7 +289,7 @@ function SharingDefaults() {
 }
 
 const AGENT_VIS_LABELS: Record<string, string> = {
-  unlisted: "Draft",
+  unlisted: "Workspace — link only",
   private: "Private",
   org: "Workspace",
   link: "Anyone with the link",

--- a/apps/web/src/pages/settings/general-section.tsx
+++ b/apps/web/src/pages/settings/general-section.tsx
@@ -292,6 +292,6 @@ const AGENT_VIS_LABELS: Record<string, string> = {
   unlisted: "Workspace — link only",
   private: "Private",
   org: "Workspace",
-  link: "Anyone with the link",
+  link: "Public — link only",
   public: "Public",
 }

--- a/apps/web/src/pages/settings/general-section.tsx
+++ b/apps/web/src/pages/settings/general-section.tsx
@@ -69,6 +69,9 @@ export function GeneralSection() {
   const createSubmit = async () => {
     const t = newName.trim()
     if (!t || creating) return
+    // Loose parse: split on commas/whitespace, keep anything @-shaped. The server
+    // validates properly; a stray non-email token is dropped rather than blocking
+    // the create (invites are re-sendable from Members).
     const invites = newInvites
       .split(/[\s,;]+/)
       .map((s) => s.trim())

--- a/apps/web/src/pages/welcome.tsx
+++ b/apps/web/src/pages/welcome.tsx
@@ -343,6 +343,13 @@ function Onboarding({ me }: { me: Account }) {
             {saving ? "Finishing…" : "Continue to Derive"}
           </Button>
         </div>
+
+        {/* One non-branching line for the team evaluator — no fork, no step, no
+            state. Teams are created at first need (Settings, or the share
+            dialog's hint), not chosen at signup. */}
+        <p className="text-center text-sm text-muted-foreground">
+          Working with a team? Create a workspace and invite them anytime from Settings.
+        </p>
       </div>
     </div>
   )

--- a/apps/web/src/pages/welcome.tsx
+++ b/apps/web/src/pages/welcome.tsx
@@ -344,9 +344,8 @@ function Onboarding({ me }: { me: Account }) {
           </Button>
         </div>
 
-        {/* One non-branching line for the team evaluator — no fork, no step, no
-            state. Teams are created at first need (Settings, or the share
-            dialog's hint), not chosen at signup. */}
+        {/* Deliberately a line, not a step: teams are created at first need
+            (Settings, or the share dialog's hint), never chosen at signup. */}
         <p className="text-center text-sm text-muted-foreground">
           Working with a team? Create a workspace and invite them anytime from Settings.
         </p>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -36,7 +36,7 @@ export const Route = createFileRoute("/")({
     collection: typeof s.collection === "string" ? s.collection : undefined,
     query: typeof s.query === "string" ? s.query : undefined,
     author: typeof s.author === "string" ? s.author : undefined,
-    tab: s.tab === "drafts" ? "drafts" : undefined,
+    tab: s.tab === "mine" ? "mine" : undefined,
   }),
   component: () => <Library view="all" />,
 })

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -36,7 +36,9 @@ export const Route = createFileRoute("/")({
     collection: typeof s.collection === "string" ? s.collection : undefined,
     query: typeof s.query === "string" ? s.query : undefined,
     author: typeof s.author === "string" ? s.author : undefined,
-    tab: s.tab === "mine" ? "mine" : undefined,
+    // "drafts" is the tab's retired name — old bookmarks and agent-emitted
+    // links keep landing on the same view.
+    tab: s.tab === "mine" || s.tab === "drafts" ? "mine" : undefined,
   }),
   component: () => <Library view="all" />,
 })

--- a/apps/web/src/routes/unlisted.tsx
+++ b/apps/web/src/routes/unlisted.tsx
@@ -1,11 +1,11 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
 
-// Drafts moved into the home library as a tab (decided on the sidebar-cleanup
-// plan): a lifecycle state of your own work is a filter on All artifacts, not a
-// rail-level feed. This route survives purely as a redirect so deep links and
-// the agent's "open this draft's home" fallback keep working.
+// The former "Drafts" tab is now "Created by me" — an authorship filter, not a
+// visibility lifecycle state, so it lives in the home library as a tab rather
+// than a rail-level feed. This route survives purely as a redirect so old deep
+// links and the agent's "open this draft's home" fallback keep working.
 export const Route = createFileRoute("/unlisted")({
   beforeLoad: () => {
-    throw redirect({ to: "/", search: { tab: "drafts" } })
+    throw redirect({ to: "/", search: { tab: "mine" } })
   },
 })

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -450,6 +450,8 @@ CREATE INDEX IF NOT EXISTS agent_mention_inbox ON agent_mention (agent_id, state
 
 CREATE INDEX IF NOT EXISTS favorite_user ON artifact_favorite (user_id);
 
+CREATE INDEX IF NOT EXISTS artifact_member_by_user ON artifact_member (user_id);
+
 CREATE INDEX IF NOT EXISTS tag_name ON artifact_tag (tag);
 
 CREATE INDEX IF NOT EXISTS collection_item_artifact ON collection_item (artifact_id);

--- a/docs/plans/auth-workspace-implementation.md
+++ b/docs/plans/auth-workspace-implementation.md
@@ -108,11 +108,14 @@ Checklist convention: `[x]` done on this branch · `[ ]` still to do.
 
 ## Workstream D — workspace at first need
 
-- [x] **D1. Solo ladder collapse.** In the share dialog, when the active
-  workspace has one member (from the existing `GET /v1/workspace` roster via
-  `workspaceQuery`), hide the `org` and `unlisted` rungs (unless one is the
-  artifact's *current* visibility) and render a quiet footer hint: "Working
-  with a team? Create a workspace to share with them" → Settings → General.
+- [x] **D1. Solo share-dialog hint** (REVISED — the collapse was wrong). First
+  build hid the `org`/`unlisted` rungs for single-member workspaces; the
+  mcp-loop e2e caught the flaw: for a workspace of one those rungs are NOT
+  meaningless — org vs unlisted is what lists a doc in (or hides it from) your
+  own library, and promoting an agent's link-only publish to Workspace is the
+  core loop's blessing gesture. Solo accounts keep the full grouped ladder;
+  the first-need affordance is the footer hint alone: "Working with a team?
+  Create a workspace to share with them" → Settings → General.
 - [x] **D2. One-flow create + invite.** The create-workspace dialog
   (`general-section.tsx`) gains an optional "Invite teammates" field
   (comma/space-separated emails). Flow: `POST /v1/workspaces` (switches the

--- a/docs/plans/auth-workspace-implementation.md
+++ b/docs/plans/auth-workspace-implementation.md
@@ -1,0 +1,197 @@
+# Auth/workspace/sharing simplification — implementation plan
+
+Companion to [auth-workspace-simplification.md](./auth-workspace-simplification.md)
+— read that first for the *why*. This doc is the concrete *what to touch*, in three
+independently-shippable phases. (CLI/MCP `whoami` + multi-workspace credentials is
+its own track — see Anir's PR — and isn't in this plan.)
+
+## Phase 0: invite-accept email mismatch
+
+`POST /v1/invites/:token/accept` (`apps/api/src/routes/workspace.ts:279-295`) joins
+the signed-in caller to the workspace at the invited role without ever comparing
+`inv.email` to the caller's own email. The design comment right above it
+(`workspace.ts:260-262`, *"the token IS the secret ... mirroring the
+password-artifact model"*) makes clear this was a deliberate choice, not an
+oversight — so the fix is to **surface the mismatch, not silently block on it**,
+keeping the no-email-verification-required self-host case working.
+
+- **API** (`apps/api/src/routes/workspace.ts`):
+  - `GET /v1/invites/:token` (`:263-275`) already returns `inv.email` in the
+    preview payload — no change needed there.
+  - `POST /v1/invites/:token/accept` (`:279-295`): if `inv.email` is set and
+    doesn't case-insensitively match the caller's `me.email`, require an explicit
+    `{ confirm_mismatch: true }` in the body; otherwise return `409` with a
+    machine-readable `{ error: "email_mismatch", invited_email: inv.email }` instead
+    of joining. Matching or absent `inv.email` behaves exactly as today.
+- **Web** (`apps/web/src/pages/accept-invite.tsx:51-56` and the accept action):
+  when the preview's `email` differs from the signed-in `me.email`, show an
+  inline warning ("This invite was sent to `x@y.com` — you're signed in as
+  `a@b.com`.") with an explicit "Continue anyway" before calling accept with
+  `confirm_mismatch: true`.
+- **Tests** (`apps/api/test/workspace.test.ts`): add a mismatched-email case
+  (expect `409` without the flag, `200` with it) alongside the existing
+  matching-email accept test.
+
+Ships alone, no dependency on phases 1/2.
+
+## Phase 1: relabel the visibility ladder, retire the Drafts tab
+
+No schema change — `private`/`org`/`unlisted`/`link`/`public`/`password`
+(`packages/core/src/ports.ts:21`) stay exactly as they are underneath. This is
+copy + UI grouping + one cross-surface consistency bug.
+
+### 1a. Share dialog copy + grouping
+
+`apps/web/src/pages/artifact/share-dialog.tsx:41-78` — the `ACCESS` array:
+
+| value | old label | new label |
+|---|---|---|
+| `private` | Private | Private *(unchanged)* |
+| `org` | Workspace only | Workspace |
+| `unlisted` | Draft — workspace with link | Workspace — link only |
+| `link` | Anyone with the link | Anyone with the link *(unchanged)* |
+| `public` | Public — listed | Public |
+| `password` | Password protected | Password protected *(unchanged)* |
+
+Reorder the array so `org`/`unlisted` sit as an adjacent pair and `link`/`public`
+sit as an adjacent pair (they already do, modulo the label swap) — optionally add
+a small group divider/subheading ("Workspace" over the first pair, "Anyone" over
+the second) so the who × listed-or-link-only structure is visible, not just
+implied by list order. Treat the divider as polish, not a blocker.
+
+`apps/web/src/pages/settings/general-section.tsx:281,292` — `AGENT_VIS_LABELS`:
+update the `unlisted → "Draft"` entry to `"Workspace — link only"` so the
+"agent publishes as" setting uses the same vocabulary as the share dialog.
+
+### 1b. Library: drop the Drafts tab, add "Created by me"
+
+`apps/web/src/pages/library/index.tsx`:
+
+- `deriveFilter` (`:73-91`): drop the `search.tab === "drafts"` branch (`:82`)
+  and the `unlisted` scope shortcut in `params` (`:128`).
+- `LibraryTabs` (`:644-681`): currently a 2-tab row, "All artifacts" / "Drafts"
+  (`:677-678`). Replace with "Everything" / "Created by me". Wire "Created by
+  me" through the **existing** author-filter plumbing — `pickAuthor`
+  (`:223`, already used when you click an author chip) sets `search.author`,
+  which already flows into `params.author` (`:127`) and the server query. "Created
+  by me" is just `pickAuthor(me.username)` with its own tab affordance instead of
+  a chip click.
+  - "Shared with me" does **not** need new work — it already exists as the
+    `/shared` route (`nav-rail.tsx:470-472`, heading "Shared with you" at
+    `index.tsx:275`). Decide whether it also gets a shortcut inside this tab row
+    or stays a separate rail item; either is fine, note the decision in the PR.
+- `heading`/`headingCount` (`:267-298`) and `emptyStateFor` (`:699+`, the
+  `unlisted` case around `:728`): drop the `unlisted` branches, add an
+  "author === me" branch if the new tab needs its own heading/empty copy.
+- Update the stale comment at `:641-643` ("the empty Drafts tab is how the
+  concept gets discovered") — that rationale is gone.
+- `apps/web/src/pages/library/types.ts:47-50`: update the comment describing
+  `unlisted` as "drafts, renamed for humans" to match the new framing.
+
+### 1c. Cross-surface consistency + stale copy
+
+- `packages/cli/src/config.js:239` — the `derive.json` visibility enum is
+  missing `unlisted`: `["public", "link", "org", "password", "private"]` →
+  add `"unlisted"`. Independent bug, fix regardless of the naming change.
+- `packages/mcp/src/index.ts:344-345` — update the comment ("a DRAFT: hidden
+  from the library...") to the new framing (hidden from the workspace library,
+  reachable by link for members).
+- `apps/web/src/components/showcase/showcase.tsx:466-470` — the design-system
+  demo shows a "Draft" badge next to "Published" as if they're lifecycle
+  opposites. Remove or relabel so the showcase stops teaching the wrong mental
+  model.
+- `SECURITY.md:32-59` — update the `unlisted` row's wording (currently "the
+  agent-draft state between private and workspace") to match.
+
+### Tests
+
+`apps/web/e2e/deep/library.deep.spec.ts`, `smoke/library.smoke.spec.ts`,
+`deep/visibility.deep.spec.ts`, `deep/share.deep.spec.ts` — rename/update any
+assertions keyed on `data-testid="library-tab-drafts"` or the old "Draft" copy;
+add coverage for the new `library-tab-created-by-me` (or equivalent) test-id.
+
+## Phase 2: signup fork + hide "workspace" language for solo accounts
+
+This phase is more product-judgment than mechanics — flagging open decisions
+inline rather than pretending they're already resolved.
+
+### 2a. Signup fork
+
+`apps/web/src/pages/welcome.tsx` is already the post-signup onboarding step
+(profile, avatar, profession — no workspace question today). Add a first screen:
+**"Personal account" / "Create a company account."**
+
+- Personal → no change, proceed to the existing profile fields; the silently
+  auto-provisioned `ws_p_<userId>` workspace (`apps/api/src/context.ts:451-461`)
+  stays as-is and is never labeled "workspace" in the UI (see 2b).
+- Company → prompt for a workspace name (and optionally teammate emails right
+  there, reusing `POST /v1/workspace/invites`), then call the existing
+  `POST /v1/workspaces` (`apps/api/src/routes/workspace.ts:367-381`), which
+  switches the active-workspace cookie to the new one.
+
+**Decision needed:** the auto-provisioned personal workspace still gets created
+first (it's the fallback every workspace-scoped call relies on, including
+paths that never touch `/welcome` — CLI, MCP, agents). For a "company" signup
+this leaves two workspace rows: the invisible personal one and the new named
+one. Recommendation: leave the personal one in place rather than trying to
+suppress/merge it — it's harmless once it's not labeled "workspace" anywhere
+(2b), and avoiding a race with whatever pre-`/welcome` API calls already fire
+`activeWorkspace()` is not worth the complexity. Confirm this is acceptable
+before building 2a.
+
+### 2b. Hide "workspace" language for single-member workspaces
+
+Needs a cheap way to know "is the active workspace solo" on the client —
+check whether `GET /v1/workspaces` (`workspace.ts:331-364`) already exposes a
+member count; if not, add one. Then:
+
+- `apps/web/src/components/chrome/app-shell.tsx` (switcher, `:59-140`): only
+  render the switcher when the caller belongs to more than one workspace.
+  Note: earlier research found a vestigial `multi` flag that's hard-coded
+  `true` everywhere (`workspace.ts:72,347,353,360`) with a comment calling the
+  switcher "dormant in single mode" (`apps/web/src/api.ts:1076`) — that dead
+  single/multi toggle should either be wired to real membership count here or
+  removed; don't leave a third half-implemented flag alongside the new check.
+- `apps/web/src/pages/settings/general-section.tsx:34-57`: relabel the
+  "Workspace" section "Account" when solo; only surface workspace-name editing
+  and the switcher once there's a second member or the account was created via
+  the "company" fork.
+
+### Tests
+
+`apps/web/e2e/deep/chrome.deep.spec.ts` (switcher visibility),
+`smoke/auth.smoke.spec.ts` / `deep/auth.deep.spec.ts` (signup fork),
+`deep/settings.deep.spec.ts` (Account vs Workspace labeling) — extend for both
+the solo and multi-member cases; a fresh signup in the e2e harness is
+single-member by default, so the "hide workspace language" assertions are the
+default path and multi-member needs an explicit second invite in the test.
+
+## Dev loop (each phase)
+
+```bash
+cd apps/api && PORT=8200 DATA_DIR="$PWD/.data-mine" \
+  DERIVE_WEB_ORIGIN=http://localhost:3200 BASE_URL=http://localhost:3200 pnpm dev
+cd apps/web && DERIVE_API=http://localhost:8200 pnpm exec vite --port 3200 --strictPort
+```
+
+Sign up fresh (first user on a fresh DB = workspace owner); invite a second
+account to exercise the multi-member paths.
+
+## Verify (gate for "done," each phase)
+
+- `pnpm typecheck` — clean.
+- `pnpm lint` (biome) — clean; `pnpm lint:testids` if new test-ids were added.
+- `pnpm -r test` — API unit tests (`apps/api/test/*`) green, including the new
+  Phase 0 mismatch cases.
+- Relevant Playwright specs green:
+  `cd apps/web && pnpm exec playwright test e2e/deep/library.deep.spec.ts e2e/deep/share.deep.spec.ts e2e/deep/visibility.deep.spec.ts e2e/deep/chrome.deep.spec.ts e2e/deep/auth.deep.spec.ts e2e/deep/settings.deep.spec.ts`
+  (parallel worktrees: set distinct `PW_WEB_PORT`/`PW_API_PORT`).
+- Screenshot the share dialog and library home in all 4 themes.
+
+## Ship
+
+- One PR per phase — they're independently useful and independently risky
+  (Phase 0 is a security fix, Phase 1 is pure UI, Phase 2 touches onboarding).
+- Own branch off `main`: `fix/invite-email-mismatch`,
+  `refactor/visibility-relabel`, `feat/signup-fork`.
+- No external references in commits/PRs (product-only).

--- a/docs/plans/auth-workspace-implementation.md
+++ b/docs/plans/auth-workspace-implementation.md
@@ -1,172 +1,158 @@
-# Auth/workspace/sharing simplification — implementation plan
+# Auth/workspace/sharing simplification — round 2 working doc
 
 Companion to [auth-workspace-simplification.md](./auth-workspace-simplification.md)
-— read that first for the *why*. This doc is the concrete *what to touch*, in three
-independently-shippable phases. (CLI/MCP `whoami` + multi-workspace credentials is
-its own track — see Anir's PR — and isn't in this plan.)
+— read that first for the *why*. This doc is the living plan for PR #314, which
+now carries the whole first tranche: the review fixes to the original relabel
+work, the two-axis share dialog, the pending-work signal, and workspace-at-first-
+need. (CLI/MCP `whoami` + multi-workspace credentials stays its own track —
+**PR #308**, which lands `derive.json` workspace targeting, multi-account
+credentials, and `X-Derive-Workspace` plumbing client-side.)
 
-## Phase 0: invite-accept email mismatch
+**Overlap with #308** (whoever merges second rebases; all trivial):
+`GET /v1/workspaces` (#308 adds `account`, we add `personal` per entry),
+`packages/cli/src/config.js` (our enum fix vs. their store rewrite),
+`packages/mcp/src/index.ts` (our copy fix vs. their auth rewiring).
 
-`POST /v1/invites/:token/accept` (`apps/api/src/routes/workspace.ts:279-295`) joins
-the signed-in caller to the workspace at the invited role without ever comparing
-`inv.email` to the caller's own email. The design comment right above it
-(`workspace.ts:260-262`, *"the token IS the secret ... mirroring the
-password-artifact model"*) makes clear this was a deliberate choice, not an
-oversight — so the fix is to **surface the mismatch, not silently block on it**,
-keeping the no-email-verification-required self-host case working.
+Checklist convention: `[x]` done on this branch · `[ ]` still to do.
 
-- **API** (`apps/api/src/routes/workspace.ts`):
-  - `GET /v1/invites/:token` (`:263-275`) already returns `inv.email` in the
-    preview payload — no change needed there.
-  - `POST /v1/invites/:token/accept` (`:279-295`): if `inv.email` is set and
-    doesn't case-insensitively match the caller's `me.email`, require an explicit
-    `{ confirm_mismatch: true }` in the body; otherwise return `409` with a
-    machine-readable `{ error: "email_mismatch", invited_email: inv.email }` instead
-    of joining. Matching or absent `inv.email` behaves exactly as today.
-- **Web** (`apps/web/src/pages/accept-invite.tsx:51-56` and the accept action):
-  when the preview's `email` differs from the signed-in `me.email`, show an
-  inline warning ("This invite was sent to `x@y.com` — you're signed in as
-  `a@b.com`.") with an explicit "Continue anyway" before calling accept with
-  `confirm_mismatch: true`.
-- **Tests** (`apps/api/test/workspace.test.ts`): add a mismatched-email case
-  (expect `409` without the flag, `200` with it) alongside the existing
-  matching-email accept test.
+## Decisions locked (2026-07-07, Rob)
 
-Ships alone, no dependency on phases 1/2.
+1. **Identity model stays**: one account, many workspaces. No per-company
+   accounts, no multi-email (post-launch, GitHub-style verified emails).
+2. **All six visibility values stay** — presented as two axes: WHO (private /
+   workspace / anyone) × LISTED-OR-LINK-ONLY (for the workspace and anyone
+   tiers). "Draft" as a word is retired everywhere.
+3. **The signup fork is CUT** (the old Phase 2a). No workspace question at
+   signup or in `/welcome`. The workspace concept materializes *at first need*:
+   the share dialog's team rungs (solo users see a create-a-workspace hint
+   instead), one create-workspace flow with invites included, and the switcher
+   only once ≥2 workspaces exist. `/welcome` gets one non-branching pointer
+   line. Post-launch growth lever: domain discovery ("3 people from churnkey.co
+   are already here"), not self-reported intent.
+4. **"Created by me" keys on the owner member row**, not the `author_id`
+   denorm (which `addVersion` overwrites with the latest publisher — including
+   NULL on token republishes). Google Drive's "Owned by me" precedent: stable
+   under republish, agent-aware (the owner row is written for the on-behalf
+   human at creation), transfer-aware. Co-owners added via the share roster
+   see the doc under their own "Created by me" too — accepted.
+5. **"Everything" reverts to "All artifacts"** — the one feed that deliberately
+   hides link-only work must not be named Everything.
 
-## Phase 1: relabel the visibility ladder, retire the Drafts tab
+## Workstream A — fixes to the round-1 relabel (review findings)
 
-No schema change — `private`/`org`/`unlisted`/`link`/`public`/`password`
-(`packages/core/src/ports.ts:21`) stay exactly as they are underneath. This is
-copy + UI grouping + one cross-surface consistency bug.
+- [ ] **A1. Owner-row semantics.** Replace `artifactIdsByAuthorId` /
+  `countAuthoredBy` with `artifactIdsOwnedBy(orgId, userId)` /
+  `countOwnedBy(orgId, userId, visibility?)` keyed on
+  `artifact_member(user_id, role='owner')` joined to `artifact.org_id`.
+  Sites: `packages/core/src/ports.ts` (interface), `packages/db/src/repos.ts`
+  (sqlite+d1), `packages/db/src/pg.ts`, `apps/api/src/routes/artifacts.ts`
+  (`scope=mine` narrow + `/v1/tags` summary). The optional `visibility` arg
+  also powers workstream C's pending count.
+- [ ] **A2. Republish-stability contract tests.** In
+  `packages/db/test/store-contract.ts`: an artifact whose owner row is user A
+  stays in A's ids/count after (i) `addVersion` authored by user B and (ii)
+  `addVersion` with `author_id: null` (the token/CI republish). These are the
+  cases that broke the `author_id` approach.
+- [ ] **A3. Index.** `index("artifact_member_by_user").on(t.user_id)` in
+  `schema.ts` + `pg-schema.ts` (boot DDL generates CREATE INDEX from the table
+  defs, so no separate migration). `countOwnedBy` runs on every `/v1/tags`.
+- [ ] **A4. Remote MCP copy.** `apps/api/src/mcp.ts` — the publish tool's
+  visibility description still says "a DRAFT: hidden from the library" and
+  `list_artifacts` says "your own unlisted drafts". Reword to the
+  link-only framing (the stdio shim in `packages/mcp` was already done).
+- [ ] **A5. "Draft link permission" label.** `general-section.tsx` — the
+  `defaultUnlistedRole` row still says Draft; rename to the link-only
+  vocabulary (label + aria-label).
+- [ ] **A6. `?tab=drafts` alias.** `routes/index.tsx` validateSearch maps the
+  legacy `tab=drafts` → `mine` instead of dropping it (old bookmarks,
+  agent-emitted links).
+- [ ] **A7. Revert "Everything" → "All artifacts"** (nav-rail, command-palette,
+  library heading + tabs, showcase eyebrow demo, e2e copy).
+- [ ] **A8. Stray comment sweep** — `routes/artifacts.ts` "the draft state"
+  comment and any remaining user-facing "draft" in the renamed surfaces.
 
-### 1a. Share dialog copy + grouping
+## Workstream B — the two-axis dialog
 
-`apps/web/src/pages/artifact/share-dialog.tsx:41-78` — the `ACCESS` array:
+- [ ] **B1. Grouped dropdown.** `share-dialog.tsx` `ACCESS` becomes grouped
+  sections rendered with separators (extend `ui/select-menu.tsx` with a
+  `SelectMenuSeparator` wrapper over the existing dropdown primitive):
 
-| value | old label | new label |
-|---|---|---|
-| `private` | Private | Private *(unchanged)* |
-| `org` | Workspace only | Workspace |
-| `unlisted` | Draft — workspace with link | Workspace — link only |
-| `link` | Anyone with the link | Anyone with the link *(unchanged)* |
-| `public` | Public — listed | Public |
-| `password` | Password protected | Password protected *(unchanged)* |
+  | | label | value |
+  |---|---|---|
+  | · | Private | `private` |
+  | ─ | Workspace | `org` |
+  | | Workspace — link only | `unlisted` |
+  | ─ | Public | `public` |
+  | | Public — link only | `link` |
+  | ─ | Password protected | `password` |
 
-Reorder the array so `org`/`unlisted` sit as an adjacent pair and `link`/`public`
-sit as an adjacent pair (they already do, modulo the label swap) — optionally add
-a small group divider/subheading ("Workspace" over the first pair, "Anyone" over
-the second) so the who × listed-or-link-only structure is visible, not just
-implied by list order. Treat the divider as polish, not a blocker.
+  The 2×2 reads: listed first, link-only second, in each audience pair.
+  `link` is renamed **"Public — link only"** (exact YouTube semantics; the
+  blurb keeps "Anyone with the link can view" so the familiar phrase
+  survives). Icons: listed rungs carry the audience glyph
+  (workspace/globe), link-only rungs carry the link glyph. Password stays a
+  trailing modifier-style rung (folding it into a checkbox on the link rungs
+  is a later, larger change).
+- [ ] **B2. Showcase `GeneralAccessDemo`** mirrors the same grouping/labels.
 
-`apps/web/src/pages/settings/general-section.tsx:281,292` — `AGENT_VIS_LABELS`:
-update the `unlisted → "Draft"` entry to `"Workspace — link only"` so the
-"agent publishes as" setting uses the same vocabulary as the share dialog.
+## Workstream C — pending-work signal in Created by me
 
-### 1b. Library: drop the Drafts tab, add "Created by me"
+- [ ] **C1. Summary count.** `/v1/tags` adds `mine_link_only` =
+  `countOwnedBy(org, me, "unlisted")`. Types in `api.ts` + `library/types.ts`.
+- [ ] **C2. Tab badge.** The Created by me tab keeps its total count; when
+  `mine_link_only > 0` it also shows a small accent count — the "waiting on
+  you to surface it" signal the old Drafts badge carried.
+- [ ] **C3. Row chip.** In the Created by me feed, `unlisted` rows show a
+  quiet "Link only" chip so pending work is scannable in place. (Check the
+  card component for an existing chip/badge slot; reuse it.)
 
-`apps/web/src/pages/library/index.tsx`:
+## Workstream D — workspace at first need
 
-- `deriveFilter` (`:73-91`): drop the `search.tab === "drafts"` branch (`:82`)
-  and the `unlisted` scope shortcut in `params` (`:128`).
-- `LibraryTabs` (`:644-681`): currently a 2-tab row, "All artifacts" / "Drafts"
-  (`:677-678`). Replace with "Everything" / "Created by me". Wire "Created by
-  me" through the **existing** author-filter plumbing — `pickAuthor`
-  (`:223`, already used when you click an author chip) sets `search.author`,
-  which already flows into `params.author` (`:127`) and the server query. "Created
-  by me" is just `pickAuthor(me.username)` with its own tab affordance instead of
-  a chip click.
-  - "Shared with me" does **not** need new work — it already exists as the
-    `/shared` route (`nav-rail.tsx:470-472`, heading "Shared with you" at
-    `index.tsx:275`). Decide whether it also gets a shortcut inside this tab row
-    or stays a separate rail item; either is fine, note the decision in the PR.
-- `heading`/`headingCount` (`:267-298`) and `emptyStateFor` (`:699+`, the
-  `unlisted` case around `:728`): drop the `unlisted` branches, add an
-  "author === me" branch if the new tab needs its own heading/empty copy.
-- Update the stale comment at `:641-643` ("the empty Drafts tab is how the
-  concept gets discovered") — that rationale is gone.
-- `apps/web/src/pages/library/types.ts:47-50`: update the comment describing
-  `unlisted` as "drafts, renamed for humans" to match the new framing.
+- [ ] **D1. Solo ladder collapse.** In the share dialog, when the active
+  workspace has one member (from the existing `GET /v1/workspace` roster via
+  `workspaceQuery`), hide the `org` and `unlisted` rungs (unless one is the
+  artifact's *current* visibility) and render a quiet footer hint: "Working
+  with a team? Create a workspace to share with them" → Settings → General.
+- [ ] **D2. One-flow create + invite.** The create-workspace dialog
+  (`general-section.tsx`) gains an optional "Invite teammates" field
+  (comma/space-separated emails). Flow: `POST /v1/workspaces` (switches the
+  cookie server-side) → `POST /v1/workspace/invites` per email (now scoped to
+  the new workspace) → reload. Skippable — empty field behaves exactly as
+  today.
+- [ ] **D3. User-pod entry point.** "New workspace" item in the pod menu
+  (below the switcher section; also present for solo accounts) → navigates to
+  Settings → General with a search param that auto-opens the create dialog.
+- [ ] **D4. Personal pinned.** `GET /v1/workspaces` marks the caller's
+  personal workspace (`id === ws_p_<userId>`) with `personal: true` (both the
+  human branch and the OAuth-agent owner branch). Web: `WorkspaceSummary`
+  gains the flag; switcher + command palette display it as **"Personal"**,
+  sorted first; the nav-rail subtitle shows "Personal" when it's active.
+- [ ] **D5. `/welcome` pointer.** One muted, non-branching line near the
+  connect-agent step: "Working with a team? Create a workspace and invite
+  them anytime from Settings."
 
-### 1c. Cross-surface consistency + stale copy
+## Workstream E — invite-accept email mismatch (old Phase 0, unchanged spec)
 
-- `packages/cli/src/config.js:239` — the `derive.json` visibility enum is
-  missing `unlisted`: `["public", "link", "org", "password", "private"]` →
-  add `"unlisted"`. Independent bug, fix regardless of the naming change.
-- `packages/mcp/src/index.ts:344-345` — update the comment ("a DRAFT: hidden
-  from the library...") to the new framing (hidden from the workspace library,
-  reachable by link for members).
-- `apps/web/src/components/showcase/showcase.tsx:466-470` — the design-system
-  demo shows a "Draft" badge next to "Published" as if they're lifecycle
-  opposites. Remove or relabel so the showcase stops teaching the wrong mental
-  model.
-- `SECURITY.md:32-59` — update the `unlisted` row's wording (currently "the
-  agent-draft state between private and workspace") to match.
+- [ ] **E1. API.** `POST /v1/invites/:token/accept`: when `inv.email` is set
+  and doesn't case-insensitively match `me.email`, return
+  `409 { error: "email_mismatch", invited_email }` unless the body carries
+  `{ confirm_mismatch: true }`. Matching/absent email: unchanged.
+- [ ] **E2. Web.** `accept-invite.tsx`: on preview-email ≠ session-email, show
+  the inline warning + "Continue anyway" that resends with the flag.
+- [ ] **E3. Test.** `apps/api/test/workspace.test.ts`: 409 without flag, 200
+  with it.
 
-### Tests
+## Deferred (explicitly NOT this PR)
 
-`apps/web/e2e/deep/library.deep.spec.ts`, `smoke/library.smoke.spec.ts`,
-`deep/visibility.deep.spec.ts`, `deep/share.deep.spec.ts` — rename/update any
-assertions keyed on `data-testid="library-tab-drafts"` or the old "Draft" copy;
-add coverage for the new `library-tab-created-by-me` (or equivalent) test-id.
+- Hide-workspace-language polish for solo accounts beyond the ladder (the old
+  Phase 2b: "Account" vs "Workspace" settings labels, switcher chrome rules).
+- Defaults-by-location (human publish in a team workspace defaults to `org`).
+- Roles collapse (Admin / Member / Viewer; retire the vestigial `viewer`).
+- Password as a checkbox on the link rungs instead of a sixth rung.
+- Domain discovery at signup.
+- CLI/MCP workspace targeting (`derive.json` workspace field) — PR #308.
 
-## Phase 2: signup fork + hide "workspace" language for solo accounts
-
-This phase is more product-judgment than mechanics — flagging open decisions
-inline rather than pretending they're already resolved.
-
-### 2a. Signup fork
-
-`apps/web/src/pages/welcome.tsx` is already the post-signup onboarding step
-(profile, avatar, profession — no workspace question today). Add a first screen:
-**"Personal account" / "Create a company account."**
-
-- Personal → no change, proceed to the existing profile fields; the silently
-  auto-provisioned `ws_p_<userId>` workspace (`apps/api/src/context.ts:451-461`)
-  stays as-is and is never labeled "workspace" in the UI (see 2b).
-- Company → prompt for a workspace name (and optionally teammate emails right
-  there, reusing `POST /v1/workspace/invites`), then call the existing
-  `POST /v1/workspaces` (`apps/api/src/routes/workspace.ts:367-381`), which
-  switches the active-workspace cookie to the new one.
-
-**Decision needed:** the auto-provisioned personal workspace still gets created
-first (it's the fallback every workspace-scoped call relies on, including
-paths that never touch `/welcome` — CLI, MCP, agents). For a "company" signup
-this leaves two workspace rows: the invisible personal one and the new named
-one. Recommendation: leave the personal one in place rather than trying to
-suppress/merge it — it's harmless once it's not labeled "workspace" anywhere
-(2b), and avoiding a race with whatever pre-`/welcome` API calls already fire
-`activeWorkspace()` is not worth the complexity. Confirm this is acceptable
-before building 2a.
-
-### 2b. Hide "workspace" language for single-member workspaces
-
-Needs a cheap way to know "is the active workspace solo" on the client —
-check whether `GET /v1/workspaces` (`workspace.ts:331-364`) already exposes a
-member count; if not, add one. Then:
-
-- `apps/web/src/components/chrome/app-shell.tsx` (switcher, `:59-140`): only
-  render the switcher when the caller belongs to more than one workspace.
-  Note: earlier research found a vestigial `multi` flag that's hard-coded
-  `true` everywhere (`workspace.ts:72,347,353,360`) with a comment calling the
-  switcher "dormant in single mode" (`apps/web/src/api.ts:1076`) — that dead
-  single/multi toggle should either be wired to real membership count here or
-  removed; don't leave a third half-implemented flag alongside the new check.
-- `apps/web/src/pages/settings/general-section.tsx:34-57`: relabel the
-  "Workspace" section "Account" when solo; only surface workspace-name editing
-  and the switcher once there's a second member or the account was created via
-  the "company" fork.
-
-### Tests
-
-`apps/web/e2e/deep/chrome.deep.spec.ts` (switcher visibility),
-`smoke/auth.smoke.spec.ts` / `deep/auth.deep.spec.ts` (signup fork),
-`deep/settings.deep.spec.ts` (Account vs Workspace labeling) — extend for both
-the solo and multi-member cases; a fresh signup in the e2e harness is
-single-member by default, so the "hide workspace language" assertions are the
-default path and multi-member needs an explicit second invite in the test.
-
-## Dev loop (each phase)
+## Dev loop
 
 ```bash
 cd apps/api && PORT=8200 DATA_DIR="$PWD/.data-mine" \
@@ -174,24 +160,20 @@ cd apps/api && PORT=8200 DATA_DIR="$PWD/.data-mine" \
 cd apps/web && DERIVE_API=http://localhost:8200 pnpm exec vite --port 3200 --strictPort
 ```
 
-Sign up fresh (first user on a fresh DB = workspace owner); invite a second
-account to exercise the multi-member paths.
+## Verify (gate for "done")
 
-## Verify (gate for "done," each phase)
-
-- `pnpm typecheck` — clean.
-- `pnpm lint` (biome) — clean; `pnpm lint:testids` if new test-ids were added.
-- `pnpm -r test` — API unit tests (`apps/api/test/*`) green, including the new
-  Phase 0 mismatch cases.
-- Relevant Playwright specs green:
-  `cd apps/web && pnpm exec playwright test e2e/deep/library.deep.spec.ts e2e/deep/share.deep.spec.ts e2e/deep/visibility.deep.spec.ts e2e/deep/chrome.deep.spec.ts e2e/deep/auth.deep.spec.ts e2e/deep/settings.deep.spec.ts`
-  (parallel worktrees: set distinct `PW_WEB_PORT`/`PW_API_PORT`).
-- Screenshot the share dialog and library home in all 4 themes.
+- `pnpm typecheck`, `pnpm lint`, `pnpm lint:testids` — clean.
+- `pnpm -r test` — including the new A2 contract cases (sqlite; `pnpm test:pg`
+  for the Postgres adapter when Docker is available) and E3.
+- Playwright: `library.deep`, `share.deep`, `visibility.deep`, `chrome.deep`,
+  `settings.deep`, `mcp-loop.deep` (+ smoke for library/auth).
+- Screenshot the grouped share dialog (solo + team) and the library tabs.
 
 ## Ship
 
-- One PR per phase — they're independently useful and independently risky
-  (Phase 0 is a security fix, Phase 1 is pure UI, Phase 2 touches onboarding).
-- Own branch off `main`: `fix/invite-email-mismatch`,
-  `refactor/visibility-relabel`, `feat/signup-fork`.
-- No external references in commits/PRs (product-only).
+One PR (#314), commits grouped by workstream so each is reviewable alone:
+`fix: created-by-me keys on the owner row`, `fix: finish the draft→link-only
+rename`, `feat: two-axis share dialog`, `feat: pending-work signal`,
+`feat: workspace at first need`, `fix: invite email mismatch surfaced`,
+`docs: round-2 plan`. PR description rewritten at the end to match reality.
+No Claude attribution anywhere.

--- a/docs/plans/auth-workspace-implementation.md
+++ b/docs/plans/auth-workspace-implementation.md
@@ -40,7 +40,7 @@ Checklist convention: `[x]` done on this branch · `[ ]` still to do.
 
 ## Workstream A — fixes to the round-1 relabel (review findings)
 
-- [ ] **A1. Owner-row semantics.** Replace `artifactIdsByAuthorId` /
+- [x] **A1. Owner-row semantics.** Replace `artifactIdsByAuthorId` /
   `countAuthoredBy` with `artifactIdsOwnedBy(orgId, userId)` /
   `countOwnedBy(orgId, userId, visibility?)` keyed on
   `artifact_member(user_id, role='owner')` joined to `artifact.org_id`.
@@ -48,32 +48,32 @@ Checklist convention: `[x]` done on this branch · `[ ]` still to do.
   (sqlite+d1), `packages/db/src/pg.ts`, `apps/api/src/routes/artifacts.ts`
   (`scope=mine` narrow + `/v1/tags` summary). The optional `visibility` arg
   also powers workstream C's pending count.
-- [ ] **A2. Republish-stability contract tests.** In
+- [x] **A2. Republish-stability contract tests.** In
   `packages/db/test/store-contract.ts`: an artifact whose owner row is user A
   stays in A's ids/count after (i) `addVersion` authored by user B and (ii)
   `addVersion` with `author_id: null` (the token/CI republish). These are the
   cases that broke the `author_id` approach.
-- [ ] **A3. Index.** `index("artifact_member_by_user").on(t.user_id)` in
+- [x] **A3. Index.** `index("artifact_member_by_user").on(t.user_id)` in
   `schema.ts` + `pg-schema.ts` (boot DDL generates CREATE INDEX from the table
   defs, so no separate migration). `countOwnedBy` runs on every `/v1/tags`.
-- [ ] **A4. Remote MCP copy.** `apps/api/src/mcp.ts` — the publish tool's
+- [x] **A4. Remote MCP copy.** `apps/api/src/mcp.ts` — the publish tool's
   visibility description still says "a DRAFT: hidden from the library" and
   `list_artifacts` says "your own unlisted drafts". Reword to the
   link-only framing (the stdio shim in `packages/mcp` was already done).
-- [ ] **A5. "Draft link permission" label.** `general-section.tsx` — the
+- [x] **A5. "Draft link permission" label.** `general-section.tsx` — the
   `defaultUnlistedRole` row still says Draft; rename to the link-only
   vocabulary (label + aria-label).
-- [ ] **A6. `?tab=drafts` alias.** `routes/index.tsx` validateSearch maps the
+- [x] **A6. `?tab=drafts` alias.** `routes/index.tsx` validateSearch maps the
   legacy `tab=drafts` → `mine` instead of dropping it (old bookmarks,
   agent-emitted links).
-- [ ] **A7. Revert "Everything" → "All artifacts"** (nav-rail, command-palette,
+- [x] **A7. Revert "Everything" → "All artifacts"** (nav-rail, command-palette,
   library heading + tabs, showcase eyebrow demo, e2e copy).
-- [ ] **A8. Stray comment sweep** — `routes/artifacts.ts` "the draft state"
+- [x] **A8. Stray comment sweep** — `routes/artifacts.ts` "the draft state"
   comment and any remaining user-facing "draft" in the renamed surfaces.
 
 ## Workstream B — the two-axis dialog
 
-- [ ] **B1. Grouped dropdown.** `share-dialog.tsx` `ACCESS` becomes grouped
+- [x] **B1. Grouped dropdown.** `share-dialog.tsx` `ACCESS` becomes grouped
   sections rendered with separators (extend `ui/select-menu.tsx` with a
   `SelectMenuSeparator` wrapper over the existing dropdown primitive):
 
@@ -93,53 +93,53 @@ Checklist convention: `[x]` done on this branch · `[ ]` still to do.
   (workspace/globe), link-only rungs carry the link glyph. Password stays a
   trailing modifier-style rung (folding it into a checkbox on the link rungs
   is a later, larger change).
-- [ ] **B2. Showcase `GeneralAccessDemo`** mirrors the same grouping/labels.
+- [x] **B2. Showcase `GeneralAccessDemo`** mirrors the same grouping/labels.
 
 ## Workstream C — pending-work signal in Created by me
 
-- [ ] **C1. Summary count.** `/v1/tags` adds `mine_link_only` =
+- [x] **C1. Summary count.** `/v1/tags` adds `mine_link_only` =
   `countOwnedBy(org, me, "unlisted")`. Types in `api.ts` + `library/types.ts`.
-- [ ] **C2. Tab badge.** The Created by me tab keeps its total count; when
+- [x] **C2. Tab badge.** The Created by me tab keeps its total count; when
   `mine_link_only > 0` it also shows a small accent count — the "waiting on
   you to surface it" signal the old Drafts badge carried.
-- [ ] **C3. Row chip.** In the Created by me feed, `unlisted` rows show a
+- [x] **C3. Row chip.** In the Created by me feed, `unlisted` rows show a
   quiet "Link only" chip so pending work is scannable in place. (Check the
   card component for an existing chip/badge slot; reuse it.)
 
 ## Workstream D — workspace at first need
 
-- [ ] **D1. Solo ladder collapse.** In the share dialog, when the active
+- [x] **D1. Solo ladder collapse.** In the share dialog, when the active
   workspace has one member (from the existing `GET /v1/workspace` roster via
   `workspaceQuery`), hide the `org` and `unlisted` rungs (unless one is the
   artifact's *current* visibility) and render a quiet footer hint: "Working
   with a team? Create a workspace to share with them" → Settings → General.
-- [ ] **D2. One-flow create + invite.** The create-workspace dialog
+- [x] **D2. One-flow create + invite.** The create-workspace dialog
   (`general-section.tsx`) gains an optional "Invite teammates" field
   (comma/space-separated emails). Flow: `POST /v1/workspaces` (switches the
   cookie server-side) → `POST /v1/workspace/invites` per email (now scoped to
   the new workspace) → reload. Skippable — empty field behaves exactly as
   today.
-- [ ] **D3. User-pod entry point.** "New workspace" item in the pod menu
+- [x] **D3. User-pod entry point.** "New workspace" item in the pod menu
   (below the switcher section; also present for solo accounts) → navigates to
   Settings → General with a search param that auto-opens the create dialog.
-- [ ] **D4. Personal pinned.** `GET /v1/workspaces` marks the caller's
+- [x] **D4. Personal pinned.** `GET /v1/workspaces` marks the caller's
   personal workspace (`id === ws_p_<userId>`) with `personal: true` (both the
   human branch and the OAuth-agent owner branch). Web: `WorkspaceSummary`
   gains the flag; switcher + command palette display it as **"Personal"**,
   sorted first; the nav-rail subtitle shows "Personal" when it's active.
-- [ ] **D5. `/welcome` pointer.** One muted, non-branching line near the
+- [x] **D5. `/welcome` pointer.** One muted, non-branching line near the
   connect-agent step: "Working with a team? Create a workspace and invite
   them anytime from Settings."
 
 ## Workstream E — invite-accept email mismatch (old Phase 0, unchanged spec)
 
-- [ ] **E1. API.** `POST /v1/invites/:token/accept`: when `inv.email` is set
+- [x] **E1. API.** `POST /v1/invites/:token/accept`: when `inv.email` is set
   and doesn't case-insensitively match `me.email`, return
   `409 { error: "email_mismatch", invited_email }` unless the body carries
   `{ confirm_mismatch: true }`. Matching/absent email: unchanged.
-- [ ] **E2. Web.** `accept-invite.tsx`: on preview-email ≠ session-email, show
+- [x] **E2. Web.** `accept-invite.tsx`: on preview-email ≠ session-email, show
   the inline warning + "Continue anyway" that resends with the flag.
-- [ ] **E3. Test.** `apps/api/test/workspace.test.ts`: 409 without flag, 200
+- [x] **E3. Test.** `apps/api/test/workspace.test.ts`: 409 without flag, 200
   with it.
 
 ## Deferred (explicitly NOT this PR)

--- a/docs/plans/auth-workspace-simplification.md
+++ b/docs/plans/auth-workspace-simplification.md
@@ -1,0 +1,190 @@
+# Simplifying auth, workspaces, and sharing before launch
+
+Status: proposal, not decided. Written for team review ahead of launch.
+
+We're about to put this in front of new users, and the auth/workspace/sharing
+surface feels more complicated than it needs to be. This doc is a diagnosis and
+a set of concrete proposals, not a finished spec — the point is to agree on
+direction, then break out implementation plans for whichever pieces we take on
+before launch.
+
+## The good news: the identity model underneath is already right
+
+Today, Derive is **one global account per email, able to belong to any number
+of workspaces** — `user.email` is globally unique, and workspace membership is
+a `(workspace, user) → role` row with no cap on how many workspaces one person
+can belong to.
+
+That's the same model Slack, Notion, and GitHub organizations use, and it's the
+correct one. The alternative — a separate account per company, the way Google
+Accounts work (`alice@gmail.com` and `alice@churnkey.co` as two unrelated
+identities you switch between with an avatar picker) — isn't a design people
+actually like. It's a historical accident (a Google Account *is* a mailbox),
+and the pain it causes (incognito windows, "which account is this doc under,"
+no shared history between your personal and work identity) is exactly the kind
+of thing people complain about, not something to copy.
+
+**So: someone working at two companies should have one Derive account with two
+workspace memberships, not two logins.** We don't need to rebuild this part —
+it's already correct. The complexity people are feeling is coming from three
+specific seams in how it's surfaced, not from the underlying shape.
+
+## Where the complexity actually comes from
+
+### 1. The personal workspace pretends to be a "workspace," invisibly
+
+Every signup silently provisions a workspace (internally `ws_p_<userId>`,
+named `"X's Workspace"`) the first time any workspace-scoped call needs one —
+not at signup, not as a choice. It's real plumbing (every artifact needs a
+workspace to belong to), but the moment a user creates a *second*, real team
+workspace, the UI starts showing both with identical language: a switcher, a
+"Workspace" label, "workspace settings." The user never chose the first one
+and has no mental model for why it exists or how it relates to the one they
+did choose.
+
+Compare:
+
+- **GitHub** doesn't wrap your personal account in an invisible "personal
+  org." Repos live at `github.com/rob/repo`. The word "organization" only
+  enters your vocabulary when you deliberately create one.
+- **Notion** does wrap everyone in a workspace, but it asks explicitly at
+  signup — *"Just for you, or with a team?"* — so the wrapper is a decision
+  you remember making, not plumbing you discover later.
+- **Slack** workspaces are always named and visible, but nobody has an
+  invisible "personal Slack."
+
+Derive currently does neither: it auto-creates the wrapper *and* later
+surfaces "workspace" language for it as if it were a deliberate choice.
+
+**Agreed direction:** for a workspace with exactly one member, drop the word
+"workspace" from the UI entirely — call it "Your Library," no switcher, no
+"workspace settings," just "Account." The switcher and the term "workspace"
+only appear once a second member exists, on either side (yours or one you've
+joined). At signup, replace the silent auto-provision with an explicit fork:
+**"Personal account" or "Create a company account"** (Rob: happy to ask this
+at signup if it earns its keep setting up the right semantics — same idea as
+Notion's "just for you / with a team," worded around what it actually
+provisions here). Same underlying row gets created either way, but now it's a
+decision the user remembers making, and we can use the answer to set sensible
+defaults (e.g. a company account can prompt for teammates' emails right there,
+a personal account skips that entirely).
+
+### 2. "Draft" isn't a lifecycle state — it's an unnamed feed/listing axis
+
+Revised after discussion. My first pass treated "Draft" as a mislabeled
+lifecycle status and suggested peeling it off into a separate review-status
+boolean. Rob's pushback is right: we don't want to add a new concept here, and
+"unlisted within the workspace" is actually a real, already-useful thing he
+wants to keep — not something to replace with new complexity. Rethinking it in
+the broader context of the visibility ladder, not in isolation:
+
+Artifact visibility today has six levels: `private`, `org`, `unlisted`,
+`link`, `public`, `password`. Look at the two ends of that ladder that are
+already uncontroversial:
+
+- **`public`** = anyone can open it, **and** it's listed/searchable.
+- **`link`** = anyone can open it, but it's **not** listed anywhere — you only
+  get there with the URL.
+
+That's one audience tier (`anyone`) crossed with one independent axis: *is
+this surfaced in a shared feed, or only reachable if someone hands you the
+link.* Nobody finds that pairing confusing — it's the YouTube
+public/unlisted/private model, and it's intuitive.
+
+`org` and `unlisted` are the exact same pairing, one tier down, at
+`workspace` instead of `anyone`:
+
+- **`org`** = any workspace member can open it, **and** it shows up in the
+  shared workspace library.
+- **`unlisted`** = any workspace member can open it if they have the link,
+  but it does **not** show up in the shared workspace library.
+
+That's not a lifecycle state at all — it's "keep this out of the team feed
+until I decide to surface it," which is a completely reasonable thing to want
+(a scratch doc, an agent's output you haven't looked at yet, something you're
+sharing with one person by link without broadcasting it to the whole
+workspace). The reason it currently *reads* as a lifecycle/"draft" concept is
+that we only applied the listed/unlisted split at the `anyone` tier and gave
+it a real name there (`public` vs `link`), but at the `workspace` tier we
+never named the same split — we called the unlisted variant "Draft" instead,
+which drags in an unrelated WIP-vs-finished connotation nothing else in the
+product supports (there's no `status` field; every artifact is fully live the
+instant it's written).
+
+So this is a naming/consistency problem, not a missing-feature problem — and
+the fix is to stop treating it as a flat 6-item ladder and present it as what
+it already structurally is: two real audience tiers (`workspace`, `anyone`),
+each with an independent "shown in the library feed?" toggle, plus `private`
+(explicit members only, no feed question applies) and `password` (a lock on
+top of the `anyone` tier). No new fields, no boolean, nothing added — just
+naming the axis that `public`/`link` already prove works, and applying it
+consistently to the `workspace` tier instead of borrowing the word "Draft"
+for it.
+
+**Proposal:** keep `private` / `org` / `unlisted` / `link` / `public` /
+`password` exactly as they are underneath. In the UI, present visibility as
+two dimensions — *who* (Private / Workspace / Anyone) and, for Workspace and
+Anyone, *listed in the library or link-only* — rather than one flat ladder
+with a mislabeled rung. Retire "Draft" as a name; call the workspace/link-only
+state something like "Workspace — link only" or "Hidden from library" so it
+reads as the same kind of choice as `public` vs `link`, not as a different
+kind of thing.
+
+**Consequence: retire the Drafts tab.** Today the library has a dedicated
+"Drafts" tab that's just a filter for `visibility === "unlisted"` — a
+special-cased top-level nav item for one visibility value. Once "unlisted"
+stops being a distinct lifecycle concept and becomes one setting among
+several on the same ladder, it doesn't deserve its own tab any more than
+"link" or "password" do. Replace it with a small set of generic filters that
+apply across all content, the way Google Drive (My Drive / Shared with me) or
+GitHub (all repos / owned by me) do it:
+
+- **Everything** — everything you have access to
+- **Created by me**
+- **Shared with me** — explicit shares that aren't yours
+
+Visibility (workspace/private/link-only/etc.) becomes a facet you can filter
+by within any of those, not a top-level tab — so "show me the stuff that's
+workspace-only and link-only" is still one click away, it's just not a
+first-class nav item competing with "who owns this."
+
+### 3. CLI/MCP auth has no "who am I," and can't hold two workspace logins at once
+
+**Already in flight** — Anir has a PR up for this. Flagging the underlying
+problem here for context, not as an open proposal: `derive login` stores
+exactly one token per server with no workspace field, so working across two
+workspaces on the same machine today means destructively re-logging-in or
+juggling `--token`/env vars by hand, with no `whoami` to answer "which
+workspace am I authenticated as right now." Anir's PR is the place to hash out
+the actual shape (credential keying, `whoami`, profile switching) — no need to
+duplicate that discussion here.
+
+## A bug worth fixing regardless of any of the above
+
+Independent of this whole discussion: accepting a workspace invite never
+checks that the accepting account's email matches the invited email. Anyone
+holding a valid, unexpired invite token can accept it while signed into *any*
+Derive account, including one that has nothing to do with the invited address.
+This should get fixed on its own before launch, not bundled into the redesign.
+
+## Suggested sequencing
+
+1. **Now, cheap, high leverage:** fix the invite email-match gap; re-present
+   the visibility ladder as (who) × (listed in library or link-only) and
+   retire "Draft" as a name; replace the Drafts tab with generic
+   Everything/Created by me/Shared with me filters — no schema change, just
+   UI grouping and copy.
+2. **Before launch:** hide "workspace" language for single-member workspaces;
+   add the explicit "Personal / Create a company account" fork at signup.
+3. **Already in flight:** CLI/MCP `whoami` and multi-workspace credential
+   handling — see Anir's PR.
+
+## Open questions for the team
+
+- Does "Workspace — link only" (or similar naming) read clearly once it's
+  grouped with `public`/`link` under one "listed vs. link-only" axis, or does
+  it need a different word entirely?
+- Is the signup fork ("Personal" vs "Create a company account") worth the
+  extra screen, or should we infer it from whether an invite is pending?
+- Any objection to workspace identity staying single-account-many-memberships,
+  vs. revisiting that shape entirely?

--- a/docs/plans/auth-workspace-simplification.md
+++ b/docs/plans/auth-workspace-simplification.md
@@ -177,7 +177,39 @@ This should get fixed on its own before launch, not bundled into the redesign.
 2. **Before launch:** hide "workspace" language for single-member workspaces;
    add the explicit "Personal / Create a company account" fork at signup.
 3. **Already in flight:** CLI/MCP `whoami` and multi-workspace credential
-   handling — see Anir's PR.
+   handling — see PR #308.
+
+## Decisions (2026-07-07, Rob — supersedes the open questions below)
+
+Reviewed with the round-1 implementation (PR #314) in hand. Outcomes:
+
+- **Identity model confirmed**: single account, many memberships. Not
+  revisiting. Multi-email per account is a post-launch follow-up.
+- **Two-axis presentation confirmed as the destination**, and the dropdown
+  gets real grouping now (separator-chunked pairs), not just relabeled rows.
+  The `link` rung is renamed **"Public — link only"** so the two pairs read
+  as the same axis (Workspace / Workspace — link only · Public / Public —
+  link only). Password stays a sixth rung for now; folding it into a
+  checkbox on the link rungs is a later change.
+- **The signup fork is cut.** No "Personal / company account" question at
+  signup or in `/welcome` — the question is asked before the user can answer
+  it, and its failure mode (a team-of-one workspace next to the invisible
+  personal one, switcher on day zero) recreates the ghost-workspace problem.
+  Instead, **workspace-at-first-need**: solo users get a collapsed share
+  ladder with a "create a workspace" hint where the team rungs would be;
+  create-workspace becomes one flow (name + optional invites); "New
+  workspace" is reachable from the user pod; the personal workspace is
+  labeled **"Personal"** and pinned once a switcher exists. `/welcome` gets
+  one non-branching pointer line. The eventual growth mechanism is domain
+  discovery ("3 people from churnkey.co are already on Derive"), not
+  self-report.
+- **"Created by me" keys on the owner member row**, not the `author_id`
+  denorm (which republish clobbers — including to NULL on token publishes).
+  Google Drive's "Owned by me" semantics.
+- **"Everything" reverts to "All artifacts"** — don't name the one feed that
+  hides link-only work "Everything."
+- The invite email-mismatch fix ships in the same PR (#314) as a
+  surface-the-mismatch flow, per the phase-0 spec in the implementation doc.
 
 ## Open questions for the team
 

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -236,7 +236,10 @@ export const DERIVE_SCHEMA = {
   properties: {
     title: { type: "string", description: "Artifact title." },
     entry: { type: "string", description: "File or directory `derive publish` targets." },
-    visibility: { enum: ["public", "link", "org", "password", "private"], default: "private" },
+    visibility: {
+      enum: ["public", "link", "org", "password", "private", "unlisted"],
+      default: "private",
+    },
     spa: {
       type: "boolean",
       description: "Serve a single-page-app fallback for unknown paths.",

--- a/packages/core/src/permissions.test.ts
+++ b/packages/core/src/permissions.test.ts
@@ -125,7 +125,7 @@ describe("effectiveRole — the documented access table", () => {
   })
 
   it("unlisted opens for workspace members at the general role — nobody else", () => {
-    // The agent-draft state: a member WITH THE LINK gets the workspace's default
+    // Workspace link-only: a member WITH THE LINK gets the workspace's default
     // (view or comment). Their workspace role itself grants nothing (that would
     // be `org`), so an unlisted doc never rides membership into listings/standing.
     expect(effectiveRole(user({ orgRole: "viewer" }), "unlisted")).toBe("viewer")

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -89,9 +89,9 @@ export interface Actor {
  *   workspace only (org)         no access              no access             their role (members)
  *   unlisted · view|comment      no access              members only: v/c     their role (>= floor)
  *
- * `unlisted` is the agent-draft state: hidden from every listing, but a workspace
- * member WITH THE LINK gets the general role (view or comment) — the "shared to
- * workspace, on the go" reach. Non-members and anonymous visitors get nothing.
+ * `unlisted` is workspace link-only (the usual agent-publish default): hidden from
+ * every listing, but a workspace member WITH THE LINK gets the general role
+ * (view or comment). Non-members and anonymous visitors get nothing.
  *
  * Invariant: an anonymous caller is never more than `viewer`. Anything past view
  * (comment, propose, publish, share, manage) needs an authenticated identity — a

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -234,11 +234,14 @@ export interface MetaStore {
   /** Artifact ids in a workspace whose current author_login matches `login`
    *  (case-insensitive) — the author list-filter. Empty when nothing matches. */
   artifactIdsByAuthor(orgId: string, login: string): Promise<string[]>
+  /** Artifact ids in a workspace published by this Derive user (author_id) —
+   *  the library's "Created by me" filter, regardless of visibility. */
+  artifactIdsByAuthorId(orgId: string, userId: string): Promise<string[]>
   /** Total artifact count, scoped to a workspace when orgId is given. */
   countArtifacts(orgId?: string): Promise<number>
-  /** The viewer's own `unlisted` drafts in a workspace (explicit-member rows) —
-   *  the badge count for the library's Unlisted filter. */
-  countUnlistedFor(orgId: string, userId: string): Promise<number>
+  /** Count of artifacts in a workspace published by this Derive user (author_id) —
+   *  the badge count for the library's "Created by me" filter. */
+  countAuthoredBy(orgId: string, userId: string): Promise<number>
   /**
    * The storage-quota meter for one workspace: bytes counted once per distinct
    * blob (content is content-addressed, so republishes/restores of identical

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -15,7 +15,8 @@ export type ArtifactKind = "file" | "bundle"
 // the visitor enters the password (then a viewer; members/owners see it by role).
 // `private`: only per-artifact members (the publisher becomes the owner-member at
 // creation) — workspace membership grants nothing, unlike `org`.
-// `unlisted`: the agent-draft state — hidden from every listing, but a workspace
+// `unlisted`: workspace link-only (the usual agent-publish default) — hidden
+// from every listing, but a workspace
 // member WITH THE LINK gets the general role (view or comment, the workspace's
 // default). Between `private` (explicit shares only) and `org` (listed for all).
 export type Visibility = "public" | "link" | "org" | "password" | "private" | "unlisted"

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -100,10 +100,10 @@ export interface ListArtifactsOpts {
   viewerId?: string
   /** How `unlisted` rows behave for a viewer-scoped listing. Default (omitted) =
    *  exclude: unlisted is hidden from every ordinary listing, even the owner's —
-   *  they have the dedicated filter. "include" folds the viewer's own unlisted
-   *  drafts in (MCP list_artifacts, so an agent always finds its work); "only" is
-   *  the library's Unlisted filter. Ignored without `viewerId` except "only". */
-  unlisted?: "exclude" | "include" | "only"
+   *  "Created by me" is the finder. "include" folds the viewer's own unlisted
+   *  work in (MCP list_artifacts + the deliberate shared/feedback/mine signals,
+   *  so you always find what's yours). Ignored without `viewerId`. */
+  unlisted?: "exclude" | "include"
   /** Profile work-list visibility gate: a row is included when it is `public` OR its
    *  `org_id` is in this set (the workspaces the viewer shares with the profile owner).
    *  An empty/omitted set with a profile query ⇒ public-only. Used by `listUserWorks`
@@ -234,14 +234,17 @@ export interface MetaStore {
   /** Artifact ids in a workspace whose current author_login matches `login`
    *  (case-insensitive) — the author list-filter. Empty when nothing matches. */
   artifactIdsByAuthor(orgId: string, login: string): Promise<string[]>
-  /** Artifact ids in a workspace published by this Derive user (author_id) —
-   *  the library's "Created by me" filter, regardless of visibility. */
-  artifactIdsByAuthorId(orgId: string, userId: string): Promise<string[]>
+  /** Artifact ids in a workspace this user holds an OWNER member row on — the
+   *  library's "Created by me" filter, any visibility. Keyed on the roster (one
+   *  row, written at creation for the human behind the publish), NOT the
+   *  `author_id` denorm: every republish rewrites that to the newest version's
+   *  author — null for a token publish — so it can't anchor "yours". */
+  artifactIdsOwnedBy(orgId: string, userId: string): Promise<string[]>
   /** Total artifact count, scoped to a workspace when orgId is given. */
   countArtifacts(orgId?: string): Promise<number>
-  /** Count of artifacts in a workspace published by this Derive user (author_id) —
-   *  the badge count for the library's "Created by me" filter. */
-  countAuthoredBy(orgId: string, userId: string): Promise<number>
+  /** Count of the artifacts `artifactIdsOwnedBy` would return — the "Created by
+   *  me" badge. `visibility` narrows to one rung (the link-only pending count). */
+  countOwnedBy(orgId: string, userId: string, visibility?: Visibility): Promise<number>
   /**
    * The storage-quota meter for one workspace: bytes counted once per distinct
    * blob (content is content-addressed, so republishes/restores of identical

--- a/packages/db/src/ddl.ts
+++ b/packages/db/src/ddl.ts
@@ -138,6 +138,8 @@ export const PERF_INDEXES: string[] = [
   `CREATE INDEX IF NOT EXISTS notification_user_time ON notification (user_id, created_at)`,
   `CREATE INDEX IF NOT EXISTS agent_mention_inbox ON agent_mention (agent_id, state, created_at)`,
   `CREATE INDEX IF NOT EXISTS favorite_user ON artifact_favorite (user_id)`,
+  // The "Created by me" filter/badge walks a user's owner rows on every summary fetch.
+  `CREATE INDEX IF NOT EXISTS artifact_member_by_user ON artifact_member (user_id)`,
   `CREATE INDEX IF NOT EXISTS tag_name ON artifact_tag (tag)`,
   `CREATE INDEX IF NOT EXISTS collection_item_artifact ON collection_item (artifact_id)`,
   `CREATE INDEX IF NOT EXISTS collection_member_user ON collection_member (user_id)`,

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -511,13 +511,22 @@ export class PgMetaStore implements MetaStore {
       )
     return rows.map((r) => r.id)
   }
-  // "Created by me" filter — every artifact this Derive user published by hand in
-  // the workspace, regardless of visibility (mirrors the SQLite path).
-  async artifactIdsByAuthorId(orgId: string, userId: string): Promise<string[]> {
+  // "Created by me" — every artifact this user holds an OWNER member row on in the
+  // workspace, any visibility. Roster-keyed, not author_id-keyed (mirrors the
+  // SQLite path — see repos.ts for why the denorm can't anchor "yours").
+  async artifactIdsOwnedBy(orgId: string, userId: string): Promise<string[]> {
     const rows = await this.db
       .select({ id: artifact.id })
       .from(artifact)
-      .where(and(eq(artifact.org_id, orgId), eq(artifact.author_id, userId)))
+      .innerJoin(
+        artifactMember,
+        and(
+          eq(artifactMember.artifact_id, artifact.id),
+          eq(artifactMember.user_id, userId),
+          eq(artifactMember.role, "owner"),
+        ),
+      )
+      .where(eq(artifact.org_id, orgId))
     return rows.map((r) => r.id)
   }
   async countArtifacts(orgId?: string): Promise<number> {
@@ -525,11 +534,24 @@ export class PgMetaStore implements MetaStore {
     const rows = await (orgId ? q.where(eq(artifact.org_id, orgId)) : q)
     return Number(rows[0]?.c ?? 0)
   }
-  async countAuthoredBy(orgId: string, userId: string): Promise<number> {
+  async countOwnedBy(orgId: string, userId: string, visibility?: Visibility): Promise<number> {
     const rows = await this.db
       .select({ c: count() })
       .from(artifact)
-      .where(and(eq(artifact.org_id, orgId), eq(artifact.author_id, userId)))
+      .innerJoin(
+        artifactMember,
+        and(
+          eq(artifactMember.artifact_id, artifact.id),
+          eq(artifactMember.user_id, userId),
+          eq(artifactMember.role, "owner"),
+        ),
+      )
+      .where(
+        and(
+          eq(artifact.org_id, orgId),
+          visibility ? eq(artifact.visibility, visibility) : undefined,
+        ),
+      )
     return Number(rows[0]?.c ?? 0)
   }
   async storageBytes(orgId: string): Promise<number> {

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -511,23 +511,25 @@ export class PgMetaStore implements MetaStore {
       )
     return rows.map((r) => r.id)
   }
+  // "Created by me" filter — every artifact this Derive user published by hand in
+  // the workspace, regardless of visibility (mirrors the SQLite path).
+  async artifactIdsByAuthorId(orgId: string, userId: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ id: artifact.id })
+      .from(artifact)
+      .where(and(eq(artifact.org_id, orgId), eq(artifact.author_id, userId)))
+    return rows.map((r) => r.id)
+  }
   async countArtifacts(orgId?: string): Promise<number> {
     const q = this.db.select({ c: count() }).from(artifact)
     const rows = await (orgId ? q.where(eq(artifact.org_id, orgId)) : q)
     return Number(rows[0]?.c ?? 0)
   }
-  async countUnlistedFor(orgId: string, userId: string): Promise<number> {
+  async countAuthoredBy(orgId: string, userId: string): Promise<number> {
     const rows = await this.db
       .select({ c: count() })
       .from(artifact)
-      .where(
-        and(
-          eq(artifact.org_id, orgId),
-          eq(artifact.visibility, "unlisted"),
-          sql`EXISTS (SELECT 1 FROM artifact_member am
-            WHERE am.artifact_id = ${artifact.id} AND am.user_id = ${userId})`,
-        ),
-      )
+      .where(and(eq(artifact.org_id, orgId), eq(artifact.author_id, userId)))
     return Number(rows[0]?.c ?? 0)
   }
   async storageBytes(orgId: string): Promise<number> {

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -514,18 +514,18 @@ export class PgMetaStore implements MetaStore {
   // "Created by me" — every artifact this user holds an OWNER member row on in the
   // workspace, any visibility. Roster-keyed, not author_id-keyed (mirrors the
   // SQLite path — see repos.ts for why the denorm can't anchor "yours").
+  private ownerRowJoin(userId: string) {
+    return and(
+      eq(artifactMember.artifact_id, artifact.id),
+      eq(artifactMember.user_id, userId),
+      eq(artifactMember.role, "owner"),
+    )
+  }
   async artifactIdsOwnedBy(orgId: string, userId: string): Promise<string[]> {
     const rows = await this.db
       .select({ id: artifact.id })
       .from(artifact)
-      .innerJoin(
-        artifactMember,
-        and(
-          eq(artifactMember.artifact_id, artifact.id),
-          eq(artifactMember.user_id, userId),
-          eq(artifactMember.role, "owner"),
-        ),
-      )
+      .innerJoin(artifactMember, this.ownerRowJoin(userId))
       .where(eq(artifact.org_id, orgId))
     return rows.map((r) => r.id)
   }
@@ -538,14 +538,7 @@ export class PgMetaStore implements MetaStore {
     const rows = await this.db
       .select({ c: count() })
       .from(artifact)
-      .innerJoin(
-        artifactMember,
-        and(
-          eq(artifactMember.artifact_id, artifact.id),
-          eq(artifactMember.user_id, userId),
-          eq(artifactMember.role, "owner"),
-        ),
-      )
+      .innerJoin(artifactMember, this.ownerRowJoin(userId))
       .where(
         and(
           eq(artifact.org_id, orgId),
@@ -1038,7 +1031,7 @@ export class PgMetaStore implements MetaStore {
     } else {
       conds.push(eq(artifact.author_id, userId))
     }
-    // Private and unlisted drafts never ride a profile, shared workspace or not
+    // Private and unlisted work never rides a profile, shared workspace or not
     // (see repos.ts).
     const orgs = opts.visibleOrgIds ?? []
     if (orgs.length > 0) {

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -1101,7 +1101,7 @@ export function makeRepos(db: SqliteDb) {
       conds.push(eq(artifact.author_id, userId))
     }
     // Visible to the viewer: public OR in a workspace they share with the profile
-    // owner. Private and unlisted drafts never ride a profile, shared workspace or
+    // owner. Private and unlisted work never rides a profile, shared workspace or
     // not — the owner finds them in their library, not on their public face.
     const orgs = opts.visibleOrgIds ?? []
     if (orgs.length > 0) {

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -472,24 +472,30 @@ export function makeRepos(db: SqliteDb) {
         .all()
     ).map((r) => r.id)
 
+  // "Created by me" filter for the list — every artifact this Derive user published
+  // by hand in the workspace, regardless of visibility (unlike the author-login
+  // filter above, which is GitHub-commit-attribution and workspace-agnostic of who
+  // owns the artifact in Derive).
+  const artifactIdsByAuthorId = async (orgId: string, userId: string): Promise<string[]> =>
+    (
+      await db
+        .select({ id: artifact.id })
+        .from(artifact)
+        .where(and(eq(artifact.org_id, orgId), eq(artifact.author_id, userId)))
+        .all()
+    ).map((r) => r.id)
+
   const countArtifacts = async (orgId?: string): Promise<number> => {
     const q = db.select({ c: count() }).from(artifact)
     return (await (orgId ? q.where(eq(artifact.org_id, orgId)) : q).get())?.c ?? 0
   }
 
-  const countUnlistedFor = async (orgId: string, userId: string): Promise<number> =>
+  const countAuthoredBy = async (orgId: string, userId: string): Promise<number> =>
     (
       await db
         .select({ c: count() })
         .from(artifact)
-        .where(
-          and(
-            eq(artifact.org_id, orgId),
-            eq(artifact.visibility, "unlisted"),
-            sql`EXISTS (SELECT 1 FROM artifact_member am
-              WHERE am.artifact_id = ${artifact.id} AND am.user_id = ${userId})`,
-          ),
-        )
+        .where(and(eq(artifact.org_id, orgId), eq(artifact.author_id, userId)))
         .get()
     )?.c ?? 0
 
@@ -2095,8 +2101,9 @@ export function makeRepos(db: SqliteDb) {
     listArtifacts,
     artifactIdsByTag,
     artifactIdsByAuthor,
+    artifactIdsByAuthorId,
     countArtifacts,
-    countUnlistedFor,
+    countAuthoredBy,
     storageBytes,
     tagCounts,
     deleteArtifact,

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -153,18 +153,15 @@ export function artifactListConditions(
         WHERE am.artifact_id = ${art.id} AND am.user_id = ${opts.viewerId}
       )`
     conds.push(sql`(${art.visibility} != 'private' OR ${isMember})`)
-    // `unlisted` hides from every ordinary listing — even the owner's (they have
-    // the dedicated filter). "include" folds the viewer's own drafts back in (MCP
-    // list_artifacts, so an agent always finds its work); "only" IS the filter.
+    // `unlisted` hides from every ordinary listing — even the owner's ("Created
+    // by me" is the finder). "include" folds the viewer's own back in (MCP
+    // list_artifacts + the deliberate shared/feedback/mine signals).
     // Ownership = an explicit artifact_member row, the same contract `private` uses.
-    if (opts.unlisted === "only") conds.push(sql`(${art.visibility} = 'unlisted' AND ${isMember})`)
-    else if (opts.unlisted === "include")
+    if (opts.unlisted === "include")
       conds.push(sql`(${art.visibility} != 'unlisted' OR ${isMember})`)
     else conds.push(sql`${art.visibility} != 'unlisted'`)
   }
-  // A trusted caller (operator token / internal jobs, no viewerId) sees everything;
-  // "only" still narrows so the scoped filter works for that path too.
-  else if (opts?.unlisted === "only") conds.push(eq(art.visibility, "unlisted"))
+  // A trusted caller (operator token / internal jobs, no viewerId) sees everything.
   if (opts?.q) conds.push(like(sql`lower(${art.title})`, `%${opts.q.toLowerCase()}%`))
   if (opts?.cursor) {
     const cursor = or(
@@ -472,16 +469,24 @@ export function makeRepos(db: SqliteDb) {
         .all()
     ).map((r) => r.id)
 
-  // "Created by me" filter for the list — every artifact this Derive user published
-  // by hand in the workspace, regardless of visibility (unlike the author-login
-  // filter above, which is GitHub-commit-attribution and workspace-agnostic of who
-  // owns the artifact in Derive).
-  const artifactIdsByAuthorId = async (orgId: string, userId: string): Promise<string[]> =>
+  // "Created by me" for the list — every artifact this user holds an OWNER member
+  // row on in the workspace, any visibility. The roster row is written once at
+  // creation for the human behind the publish (agents included), so the filter
+  // survives republishes; the author_id denorm doesn't (addVersion rewrites it to
+  // the newest version's author — null for a token publish). The author-login
+  // filter above stays byline-based deliberately: it's GitHub-commit attribution.
+  const ownedBy = (userId: string) =>
+    and(eq(artifactMember.user_id, userId), eq(artifactMember.role, "owner"))
+  const artifactIdsOwnedBy = async (orgId: string, userId: string): Promise<string[]> =>
     (
       await db
         .select({ id: artifact.id })
         .from(artifact)
-        .where(and(eq(artifact.org_id, orgId), eq(artifact.author_id, userId)))
+        .innerJoin(
+          artifactMember,
+          and(eq(artifactMember.artifact_id, artifact.id), ownedBy(userId)),
+        )
+        .where(eq(artifact.org_id, orgId))
         .all()
     ).map((r) => r.id)
 
@@ -490,12 +495,25 @@ export function makeRepos(db: SqliteDb) {
     return (await (orgId ? q.where(eq(artifact.org_id, orgId)) : q).get())?.c ?? 0
   }
 
-  const countAuthoredBy = async (orgId: string, userId: string): Promise<number> =>
+  const countOwnedBy = async (
+    orgId: string,
+    userId: string,
+    visibility?: Visibility,
+  ): Promise<number> =>
     (
       await db
         .select({ c: count() })
         .from(artifact)
-        .where(and(eq(artifact.org_id, orgId), eq(artifact.author_id, userId)))
+        .innerJoin(
+          artifactMember,
+          and(eq(artifactMember.artifact_id, artifact.id), ownedBy(userId)),
+        )
+        .where(
+          and(
+            eq(artifact.org_id, orgId),
+            visibility ? eq(artifact.visibility, visibility) : undefined,
+          ),
+        )
         .get()
     )?.c ?? 0
 
@@ -2101,9 +2119,9 @@ export function makeRepos(db: SqliteDb) {
     listArtifacts,
     artifactIdsByTag,
     artifactIdsByAuthor,
-    artifactIdsByAuthorId,
+    artifactIdsOwnedBy,
     countArtifacts,
-    countAuthoredBy,
+    countOwnedBy,
     storageBytes,
     tagCounts,
     deleteArtifact,

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -198,16 +198,6 @@ export function runStoreContract(
         ),
       ).not.toContain(draft.id)
 
-      // "only": exactly the viewer's own unlisted drafts — the library filter.
-      expect(
-        (await store.listArtifacts({ orgId: org, viewerId: owner, unlisted: "only" })).map(
-          (x) => x.id,
-        ),
-      ).toEqual([draft.id])
-      expect(await store.listArtifacts({ orgId: org, viewerId: other, unlisted: "only" })).toEqual(
-        [],
-      )
-
       // A trusted caller (no viewerId — operator/internal) still sees everything.
       expect((await store.listArtifacts({ orgId: org })).map((x) => x.id)).toContain(draft.id)
       // publicOnly (anonymous listings) never shows it.
@@ -276,22 +266,68 @@ export function runStoreContract(
       expect(await store.artifactIdsByAuthor(`${ORG}_other`, "ada")).not.toContain(mine.id) // other org
     })
 
-    it("filters + counts artifacts by author_id (the library's Created-by-me filter)", async () => {
-      const me = `u_authored_${uuid()}`
-      const someoneElse = `u_authored_other_${uuid()}`
-      const org = `${ORG}_authored_${uuid()}`
+    it("filters + counts artifacts by owner row (the library's Created-by-me filter)", async () => {
+      const me = `u_owned_${uuid()}`
+      const someoneElse = `u_owned_other_${uuid()}`
+      const org = `${ORG}_owned_${uuid()}`
       const mine = await store.createArtifact(
         newArtifact({ org_id: org, visibility: "private", author_id: me }),
       )
-      await store.createArtifact(
+      await store.setArtifactMember({
+        id: uuid(),
+        artifact_id: mine.id,
+        user_id: me,
+        role: "owner",
+      })
+      const theirs = await store.createArtifact(
         newArtifact({ org_id: org, visibility: "org", author_id: someoneElse }),
       )
-      expect(await store.artifactIdsByAuthorId(org, me)).toEqual([mine.id])
-      expect(await store.artifactIdsByAuthorId(org, someoneElse)).not.toContain(mine.id)
-      expect(await store.countAuthoredBy(org, me)).toBe(1)
-      expect(await store.countAuthoredBy(org, someoneElse)).toBe(1)
-      // Scoped to the workspace — a same-author artifact elsewhere doesn't leak in.
-      expect(await store.countAuthoredBy(`${org}_other`, me)).toBe(0)
+      await store.setArtifactMember({
+        id: uuid(),
+        artifact_id: theirs.id,
+        user_id: someoneElse,
+        role: "owner",
+      })
+      // A non-owner share row must NOT put someone else's doc under "Created by me".
+      await store.setArtifactMember({
+        id: uuid(),
+        artifact_id: theirs.id,
+        user_id: me,
+        role: "editor",
+      })
+      expect(await store.artifactIdsOwnedBy(org, me)).toEqual([mine.id])
+      expect(await store.artifactIdsOwnedBy(org, someoneElse)).toEqual([theirs.id])
+      expect(await store.countOwnedBy(org, me)).toBe(1)
+      expect(await store.countOwnedBy(org, someoneElse)).toBe(1)
+      // The visibility narrow (the link-only pending badge).
+      expect(await store.countOwnedBy(org, me, "private")).toBe(1)
+      expect(await store.countOwnedBy(org, me, "unlisted")).toBe(0)
+      // Scoped to the workspace — an owner row elsewhere doesn't leak in.
+      expect(await store.countOwnedBy(`${org}_other`, me)).toBe(0)
+    })
+
+    it("keeps Created-by-me stable across republishes by others (owner row, not author_id)", async () => {
+      // The exact flows that broke the author_id-keyed filter: a teammate
+      // republishes your doc, then CI republishes with no author at all. The
+      // artifact's denormalized author_id moves (to them, then to null) — the
+      // owner row doesn't, and the filter keys on the row.
+      const me = `u_owned_stable_${uuid()}`
+      const org = `${ORG}_owned_stable_${uuid()}`
+      const a = await store.createArtifact(
+        newArtifact({ org_id: org, visibility: "unlisted", author_id: me }),
+      )
+      await store.setArtifactMember({ id: uuid(), artifact_id: a.id, user_id: me, role: "owner" })
+
+      await store.addVersion(
+        a.id,
+        newVersion({ author: "Teammate", author_id: `u_other_${uuid()}` }),
+      )
+      expect(await store.artifactIdsOwnedBy(org, me)).toEqual([a.id])
+
+      await store.addVersion(a.id, newVersion({ author: "ci", author_id: null }))
+      expect((await store.getArtifactById(a.id))?.author_id).toBeNull() // the denorm moved…
+      expect(await store.artifactIdsOwnedBy(org, me)).toEqual([a.id]) // …the filter didn't
+      expect(await store.countOwnedBy(org, me, "unlisted")).toBe(1)
     })
 
     it("sets and clears the current author directly (the backfill path)", async () => {

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -154,7 +154,7 @@ export function runStoreContract(
     })
   })
 
-  describe(`${label}: unlisted listings (the agent-draft state)`, () => {
+  describe(`${label}: unlisted listings (workspace, link only)`, () => {
     it("hides unlisted from ordinary listings, folds the owner's back in on demand", async () => {
       const owner = `u_ul_owner_${uuid()}`
       const other = `u_ul_other_${uuid()}`
@@ -207,10 +207,6 @@ export function runStoreContract(
       expect(await store.listArtifacts({ orgId: org, viewerId: other, unlisted: "only" })).toEqual(
         [],
       )
-
-      // The badge count matches the filter.
-      expect(await store.countUnlistedFor(org, owner)).toBe(1)
-      expect(await store.countUnlistedFor(org, other)).toBe(0)
 
       // A trusted caller (no viewerId — operator/internal) still sees everything.
       expect((await store.listArtifacts({ orgId: org })).map((x) => x.id)).toContain(draft.id)
@@ -278,6 +274,24 @@ export function runStoreContract(
       expect(await store.artifactIdsByAuthor(ORG, "ADA")).toContain(mine.id) // case-insensitive
       expect(await store.artifactIdsByAuthor(ORG, "grace")).not.toContain(mine.id) // other login
       expect(await store.artifactIdsByAuthor(`${ORG}_other`, "ada")).not.toContain(mine.id) // other org
+    })
+
+    it("filters + counts artifacts by author_id (the library's Created-by-me filter)", async () => {
+      const me = `u_authored_${uuid()}`
+      const someoneElse = `u_authored_other_${uuid()}`
+      const org = `${ORG}_authored_${uuid()}`
+      const mine = await store.createArtifact(
+        newArtifact({ org_id: org, visibility: "private", author_id: me }),
+      )
+      await store.createArtifact(
+        newArtifact({ org_id: org, visibility: "org", author_id: someoneElse }),
+      )
+      expect(await store.artifactIdsByAuthorId(org, me)).toEqual([mine.id])
+      expect(await store.artifactIdsByAuthorId(org, someoneElse)).not.toContain(mine.id)
+      expect(await store.countAuthoredBy(org, me)).toBe(1)
+      expect(await store.countAuthoredBy(org, someoneElse)).toBe(1)
+      // Scoped to the workspace — a same-author artifact elsewhere doesn't leak in.
+      expect(await store.countAuthoredBy(`${org}_other`, me)).toBe(0)
     })
 
     it("sets and clears the current author directly (the backfill path)", async () => {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -341,7 +341,8 @@ server.registerTool(
       title: z.string().optional(),
       // `password` stays CLI/web-only (it needs a password argument this tool
       // doesn't take). Omitted ⇒ the workspace's agent default (usually
-      // `unlisted` — a DRAFT: hidden from the library, one link away for members).
+      // `unlisted` — workspace members with the link, hidden from the shared
+      // library until a human decides to surface it).
       visibility: z.enum(["unlisted", "public", "link", "org", "private"]).optional(),
       message: z.string().optional().describe("What changed in this version."),
       for_review: z


### PR DESCRIPTION
## Why

The sharing/workspace model felt more complicated than it needed to be going into launch. Diagnosis and decisions live in [`docs/plans/auth-workspace-simplification.md`](docs/plans/auth-workspace-simplification.md) (the *why*, plus the decision log) and [`docs/plans/auth-workspace-implementation.md`](docs/plans/auth-workspace-implementation.md) (the working checklist for this PR). Two principles run through everything here:

1. **"Draft" was a mislabeled audience setting, not a lifecycle state.** `public` vs `link` already prove that *who can open it* and *is it listed in a shared feed* are two independent axes nobody finds confusing. `org` vs `unlisted` is the exact same pairing one tier down — it only read as a lifecycle concept because we named the split at the "anyone" tier but borrowed the word "Draft" at the workspace tier. Same six visibility values underneath; the presentation now says what the model does.
2. **The workspace concept arrives at first need, not at signup.** The earlier proposal's signup fork ("Personal / company account") is cut: it asks the question before the user can act on the answer, and its failure mode (a team-of-one next to the invisible personal workspace, switcher on day zero) recreates the exact ghost-workspace confusion this work is killing. Instead the concept materializes where it answers a question in front of the user — the share dialog, one create+invite flow, the user pod.

## What changed

**Visibility ladder — two axes, grouped (UI only, no schema/migration):**
- The share dialog's general-access menu groups into separator-chunked pairs — **Private · [Workspace / Workspace — link only] · [Public / Public — link only] · Password** — listed first, link-only second, in each tier. `link` is relabeled **"Public — link only"** so the pairs read as one axis (the blurb keeps "anyone with the link can view"). `general-section.tsx`, the showcase demo, `SECURITY.md`, and both MCP servers' tool descriptions use the same vocabulary; the last "Draft" strings (remote `mcp.ts` tool descriptions, the "Draft link permission" setting row) are gone.
- The CLI's `derive.json` schema gains the missing `unlisted` enum value (a real cross-surface bug, independent of naming).
- The canonical model docs (`permissions.ts` access matrix, `ports.ts` `Visibility` doc, the permissions test) stop teaching "the agent-draft state" — they now use the same link-only vocabulary as the UI, so the code's own documentation and the product speak one language.

**Library — Drafts tab → "Created by me", keyed on ownership, with the pending signal kept:**
- The home tabs are **All artifacts / Created by me**. "Created by me" is `scope=mine` on `GET /v1/artifacts`, keyed on the caller's **owner member row** — *not* the `author_id` denorm, which `addVersion` rewrites to the newest version's author (including NULL on a token/CI republish), so an author-keyed filter would lose docs every time a teammate or automation republished. The owner row is written once at creation for the human behind the publish (agents' on-behalf work included) and doesn't move. Google Drive's "Owned by me" semantics. Contract tests pin the two republish cases that break the author-keyed approach.
- The old Drafts badge answered "what's waiting on me?" — that signal survives: the summary counts the caller's still-link-only docs, the Created by me tab shows it as an accent pill beside the neutral total, and link-only rows carry a quiet **"Link only"** chip wherever they surface.
- New `MetaStore` methods `artifactIdsOwnedBy` / `countOwnedBy(orgId, userId, visibility?)` in both the SQLite/D1 and Postgres backends; the now-unused `unlisted:"only"` list mode is retired; `artifact_member(user_id)` gets an index (the badge probe runs on every summary fetch). Legacy `/unlisted` and `?tab=drafts` links land on the renamed tab.

**Workspace at first need:**
- A solo account's share dialog carries a first-need hint — *"Working with a team? Create a workspace to share with them"* — deep-linking to the create flow. (An earlier build also hid the two workspace rungs for solo accounts; the mcp-loop e2e caught that as a real regression — for a workspace of one, org vs unlisted still controls whether a doc lists in your own library, and promoting an agent's link-only publish to Workspace is the loop's blessing gesture. The full ladder stays; the hint is the affordance.)
- **One create flow:** the create-workspace dialog takes optional teammate emails; create switches the cookie server-side, invites go to the new workspace, and you land on Members when invites went out. The user pod carries the entry point ("New workspace" / "Create a workspace…" for solo), deep-linking to the Settings dialog via a one-shot `?new-workspace=1`.
- The personal workspace is flagged `personal` by `GET /v1/workspaces` and renders as **"Personal"**, pinned first, in the switcher, command palette, and rail subtitle — no more "rob's Workspace" plumbing leak (one shared `workspaceDisplayName` rule, not per-surface ternaries). The switcher renders only at ≥2 memberships (the server's always-on `multi` flag no longer drives chrome).
- `/welcome` gains one non-branching line pointing team evaluators at workspace creation. No fork, no step, no state.

**Invite accept — the email mismatch is surfaced (the pre-launch bug from the plan doc):**
- Accepting an invite while signed in under a different email than the invite named now returns `409 {error: "email_mismatch", invited_email}` until the request carries `confirm_mismatch: true`. The accept page shows the warning inline ("This invite was sent to x@y — you're signed in as a@b") and relabels the button **"Accept anyway."** Token possession still authorizes — self-hosts without verified email keep working. `fail()` gains an optional structured-extra param so the error stays inside the one error contract.

## What deliberately didn't change

- The six visibility *values* (`private`/`org`/`unlisted`/`link`/`public`/`password`) — presentation and semantics of the filters, not a re-architecture.
- Identity: one account, many workspaces (confirmed as the model; multi-email per account is post-launch).
- CLI/MCP multi-workspace credentials — that's **#308** (overlaps noted in the implementation doc: `GET /v1/workspaces`, `packages/cli/src/config.js`, `packages/mcp/src/index.ts` — whoever merges second rebases, all trivial).
- Deferred, recorded in the plan doc: solo "workspace language" polish beyond the ladder, defaults-by-location, the roles collapse, password-as-modifier, domain discovery at signup.

## Testing

- `pnpm typecheck` clean across all packages; `biome check` + every lint gate (`tokens`/`frontend`/`testids`/`api`/`schema`/`hyperdrive`/`filesize`/`anchor-client`) green via precommit on every commit.
- **1,297 unit tests pass** across all packages, including: new store-contract coverage for owner-row filtering + the two republish-stability cases (teammate republish, token republish with `author_id: null`); `scope=mine` + summary pending-count assertions in the API visibility tests; the `personal` flag in the workspace tests; the invite mismatch 409→confirm→200 flow (the old accept test *was* the mismatch case — it now asserts the new contract).
- Postgres adapter suite (`pnpm test:pg`) rides CI (Docker not available locally at review time); the pg implementation mirrors the SQLite predicate and is exercised by the shared store-contract there.
- Playwright deep specs for library, share, visibility, chrome, settings, and the MCP loop run against this branch; all pass except one `share.deep.spec.ts` case (a role-promotion dropdown strict-mode violation — two role menus resolve at once) which **fails identically on `main`**, verified by checking out main and re-running: pre-existing, not a regression here. The mcp-loop spec earned its keep twice — it exercises the renamed tab and the owner-row filter surviving promotion, and it caught the solo-ladder collapse regression during development. The mcp-loop/visibility/chrome specs were re-run green after the final review-pass commit.
