### PR TITLE
Move an artifact to a different workspace

### DIFF
--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -664,6 +664,9 @@ export const artifactRoutes = (ctx: AppContext) => {
       })),
       sessions: groupSessions(versions, versionWindowMs),
       my_role: effectiveRole(actor, artifact.visibility, artifact.general_role),
+      // The artifact's current workspace — the move dialog needs this to exclude
+      // it from the destination picker.
+      org_id: artifact.org_id,
       tags,
       favorite,
       collections,
@@ -741,6 +744,29 @@ export const artifactRoutes = (ctx: AppContext) => {
     if (!(await authorize(c, "manage", artifact))) return fail(c, 403, "forbidden")
     await meta.deleteArtifact(artifact.id, artifact.org_id)
     return c.body(null, 204)
+  })
+
+  // Move to a different workspace you belong to. Owner-only (the `manage` gate —
+  // same as delete). No role requirement on the destination: you can move into a
+  // workspace where you're just a viewer/editor. A future org-level "block
+  // cross-workspace moves" policy is a single guard here, not a new subsystem.
+  app.post("/v1/artifacts/:shortId/move", async (c) => {
+    const artifact = await meta.getByShortId(c.req.param("shortId"))
+    if (!artifact) return fail(c, 404, "not found")
+    if (!(await authorize(c, "manage", artifact))) return fail(c, 403, "forbidden")
+    const b = await readJson(c, z.object({ targetOrgId: z.string().min(1) }))
+    if (b instanceof Response) return b
+    if (b.targetOrgId === artifact.org_id) return fail(c, 400, "already in that workspace")
+    const me = await currentUser(c)
+    if (!me) return fail(c, 401, "unauthenticated")
+    if (!(await meta.getMembership(b.targetOrgId, me.id)))
+      return fail(c, 403, "you're not a member of that workspace")
+    // A bound custom domain routes by artifact_id; moving orgs out from under it
+    // would silently break live traffic, so refuse rather than cascade.
+    if ((await meta.getArtifactDomains(artifact.id)).length > 0)
+      return fail(c, 409, "remove the custom domain before moving this artifact")
+    await meta.moveArtifactOrg(artifact.id, b.targetOrgId)
+    return c.json({ org_id: b.targetOrgId })
   })
 
   // Unlock a `password` artifact: verify the password and drop a cookie whose

--- a/apps/api/test/move-artifact.test.ts
+++ b/apps/api/test/move-artifact.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest"
+import { as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// POST /v1/artifacts/:shortId/move — owner-only, destination is any workspace
+// you belong to (any role). Companion to the "default" workspace tests in
+// workspace.test.ts; this suite seeds its own extra workspaces per case.
+
+const ana: TestUser = { id: "u_move_ana", email: "ana@move.test", name: "Ana" }
+const ben: TestUser = { id: "u_move_ben", email: "ben@move.test", name: "Ben" }
+
+describe("move an artifact to a different workspace", () => {
+  // ana is the Admin/owner of "default"; ben is an editor there (makeAuthedApp's
+  // default team seeding: users[0] = owner, the rest = defaultRole).
+  const { app, meta } = makeAuthedApp("move-artifact", [ana, ben], "editor")
+
+  it("owner-only, and only into a workspace you're a member of", async () => {
+    const a = await (await publishAs(app, "<h1>doc</h1>", {}, as(ana.email))).json()
+
+    // Ben is an editor, not an owner — refused before even checking the target.
+    const forbidden = await app.request(
+      `/v1/artifacts/${a.short_id}/move`,
+      jsonAs(as(ben.email), { targetOrgId: "nope" }),
+    )
+    expect(forbidden.status).toBe(403)
+
+    // A real workspace, but Ana isn't a member of it — still refused.
+    await meta.setWorkspace("not-anas", "Not Ana's")
+    const notMember = await app.request(
+      `/v1/artifacts/${a.short_id}/move`,
+      jsonAs(as(ana.email), { targetOrgId: "not-anas" }),
+    )
+    expect(notMember.status).toBe(403)
+
+    // Ana joins "acme" as an editor (not owner) — the destination needs no role
+    // floor, so the move still succeeds.
+    await meta.setWorkspace("acme", "Acme")
+    await meta.setMembership({ id: "m_ana_acme", org_id: "acme", user_id: ana.id, role: "editor" })
+    const moved = await app.request(
+      `/v1/artifacts/${a.short_id}/move`,
+      jsonAs(as(ana.email), { targetOrgId: "acme" }),
+    )
+    expect(moved.status).toBe(200)
+    expect((await moved.json()).org_id).toBe("acme")
+
+    // The detail response reflects the new workspace. Ana's role stays "owner"
+    // here — not because of her (editor) membership in "acme", but because
+    // publishing wrote her a per-artifact owner share, which a move doesn't
+    // touch (a direct share is independent of org membership, same as a
+    // private-artifact invite outlives the sharer's own workspace role).
+    const detail = await (
+      await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(ana.email) })
+    ).json()
+    expect(detail.org_id).toBe("acme")
+    expect(detail.my_role).toBe("owner")
+
+    // Moving into the workspace it's already in is a no-op error, not a 200.
+    const noop = await app.request(
+      `/v1/artifacts/${a.short_id}/move`,
+      jsonAs(as(ana.email), { targetOrgId: "acme" }),
+    )
+    expect(noop.status).toBe(400)
+  })
+
+  it("leaves any collection it was in, and refuses when a custom domain is bound", async () => {
+    const a = await (await publishAs(app, "<h1>doc2</h1>", {}, as(ana.email))).json()
+    const art = await meta.getByShortId(a.short_id)
+    if (!art) throw new Error("missing artifact")
+    const col = await meta.createCollection({
+      id: "c_move_test",
+      org_id: "default",
+      title: "Move test",
+      created_by: ana.id,
+    })
+    await meta.addCollectionItem(col.id, art.id)
+    expect(await meta.collectionIdsForArtifact(art.id)).toContain(col.id)
+
+    await meta.setWorkspace("acme2", "Acme 2")
+    await meta.setMembership({ id: "m_ana_acme2", org_id: "acme2", user_id: ana.id, role: "owner" })
+    const moved = await app.request(
+      `/v1/artifacts/${a.short_id}/move`,
+      jsonAs(as(ana.email), { targetOrgId: "acme2" }),
+    )
+    expect(moved.status).toBe(200)
+    expect(await meta.collectionIdsForArtifact(art.id)).toEqual([])
+
+    // A second artifact, bound to a custom domain: the move is refused rather
+    // than silently orphaning the domain's routing.
+    const b = await (await publishAs(app, "<h1>doc3</h1>", {}, as(ana.email))).json()
+    const bArt = await meta.getByShortId(b.short_id)
+    if (!bArt) throw new Error("missing artifact")
+    await meta.setDomain({
+      host: "doc3.move-test.derive.to",
+      artifact_id: bArt.id,
+      org_id: "default",
+      kind: "subdomain",
+    })
+    const blocked = await app.request(
+      `/v1/artifacts/${b.short_id}/move`,
+      jsonAs(as(ana.email), { targetOrgId: "acme2" }),
+    )
+    expect(blocked.status).toBe(409)
+  })
+})

--- a/apps/api/test/move-artifact.test.ts
+++ b/apps/api/test/move-artifact.test.ts
@@ -100,4 +100,31 @@ describe("move an artifact to a different workspace", () => {
     )
     expect(blocked.status).toBe(409)
   })
+
+  it("detaches an org-scoped webhook that targeted it, falling back to org-wide", async () => {
+    const a = await (await publishAs(app, "<h1>doc4</h1>", {}, as(ana.email))).json()
+    const art = await meta.getByShortId(a.short_id)
+    if (!art) throw new Error("missing artifact")
+    const hook = await meta.createWebhook({
+      id: "wh_move_test",
+      org_id: "default",
+      artifact_id: art.id,
+      url: "https://example.com/hook",
+      secret: "s",
+      kind: "generic",
+      events: "*",
+    })
+    expect(hook.artifact_id).toBe(art.id)
+
+    await meta.setWorkspace("acme3", "Acme 3")
+    await meta.setMembership({ id: "m_ana_acme3", org_id: "acme3", user_id: ana.id, role: "owner" })
+    const moved = await app.request(
+      `/v1/artifacts/${a.short_id}/move`,
+      jsonAs(as(ana.email), { targetOrgId: "acme3" }),
+    )
+    expect(moved.status).toBe(200)
+
+    const after = await meta.getWebhook(hook.id, "default")
+    expect(after?.artifact_id).toBeNull()
+  })
 })

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -109,6 +109,8 @@ export interface Artifact {
   views?: number
   /** The current caller's effective role on this artifact (null = no access). */
   my_role?: Role | null
+  /** The artifact's current workspace (absent on a removed-tombstone response). */
+  org_id?: string
   /** Browse tags (workspace-wide). */
   tags?: string[]
   /** Whether the current user has starred this artifact. */
@@ -850,6 +852,9 @@ export const api = {
       ...opts({ locked }),
       method: "PATCH",
     }).then(j),
+  // Move to a different workspace you belong to. Owner-only server-side.
+  moveArtifact: (id: string, targetOrgId: string): Promise<{ org_id: string }> =>
+    f(`/v1/artifacts/${id}/move`, opts({ targetOrgId })).then(j),
   diff: (id: string, from: number, to: number): Promise<Diff> =>
     f(`/v1/artifacts/${id}/diff?from=${from}&to=${to}&format=json`, opts()).then(j),
   restore: (id: string, version: number): Promise<Artifact> =>

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -6,6 +6,7 @@
 // muted, unfavourited star); pass weight="fill" for a filled state (favorited
 // star, pinned pin) — it fills the glyph with the current ink.
 import {
+  ArrowRightLeft,
   AtSign,
   Ban,
   BarChart3,
@@ -101,6 +102,7 @@ const REG = {
   present: Maximize,
   lock: Lock,
   unlock: LockOpen,
+  move: ArrowRightLeft,
   globe: Globe,
   // comment toolbar / menu
   react: Smile,

--- a/apps/web/src/pages/artifact/artifact-top-bar.tsx
+++ b/apps/web/src/pages/artifact/artifact-top-bar.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { cn } from "@/lib/utils"
-import { ReportDialog, StarButton } from "./header-actions"
+import { MoveToWorkspaceDialog, ReportDialog, StarButton } from "./header-actions"
 import { ShareButton } from "./share-dialog"
 
 /**
@@ -28,6 +28,9 @@ import { ShareButton } from "./share-dialog"
  */
 export function ArtifactTopBar(props: {
   shortId: string
+  /** The artifact's current workspace — threaded to the move dialog so it can
+   *  exclude the current workspace from the destination picker. */
+  orgId?: string
   myRole?: Role | null
   visibility: string
   generalRole?: GeneralRole
@@ -53,6 +56,8 @@ export function ArtifactTopBar(props: {
   canLock: boolean
   /** Whether the artifact is currently locked (changes go through approval). */
   locked: boolean
+  /** Owner-only: may move this artifact to a different workspace. */
+  canMove: boolean
   onFavorite: (fav: boolean) => void
   onTags: (tags: string[]) => void
   onCollections: (ids: string[]) => void
@@ -70,6 +75,7 @@ export function ArtifactTopBar(props: {
   const [reportOpen, setReportOpen] = useState(false)
   const [tagsOpen, setTagsOpen] = useState(false)
   const [collectionsOpen, setCollectionsOpen] = useState(false)
+  const [moveOpen, setMoveOpen] = useState(false)
   return (
     <>
       {/* Actions cluster — the filled Share leads (the one primary), then the favorited
@@ -171,6 +177,11 @@ export function ArtifactTopBar(props: {
                 {props.locked ? "Unlock changes" : "Lock changes"}
               </DropdownMenuItem>
             )}
+            {props.canMove && (
+              <DropdownMenuItem data-testid="artifact-move" onSelect={() => setMoveOpen(true)}>
+                <Icon name="move" size={16} /> Move to workspace…
+              </DropdownMenuItem>
+            )}
             <DropdownMenuSeparator />
             <DropdownMenuItem data-testid="artifact-report" onSelect={() => setReportOpen(true)}>
               <Icon name="report" size={16} /> Report artifact
@@ -217,6 +228,12 @@ export function ArtifactTopBar(props: {
         onOpenChange={setCollectionsOpen}
       />
       <ReportDialog shortId={shortId} open={reportOpen} onOpenChange={setReportOpen} />
+      <MoveToWorkspaceDialog
+        shortId={shortId}
+        currentOrgId={props.orgId}
+        open={moveOpen}
+        onOpenChange={setMoveOpen}
+      />
     </>
   )
 }

--- a/apps/web/src/pages/artifact/header-actions.tsx
+++ b/apps/web/src/pages/artifact/header-actions.tsx
@@ -1,3 +1,4 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
 import { api } from "@/api"
 import { Icon } from "@/components/icons"
@@ -6,11 +7,20 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { toast } from "@/components/ui/sonner"
 import { Textarea } from "@/components/ui/textarea"
+import { artifactQuery, workspacesQuery } from "@/lib/queries"
 
 // Favorite is the one property kept VISIBLE in the header — the filled star is a
 // glanceable state (you see at a glance that this artifact is starred), and a
@@ -134,6 +144,95 @@ export function ReportDialog({
               </Button>
             </div>
           </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// Move-to-workspace dialog: owner-only (the ⋯ menu hides the trigger otherwise).
+// Destination is any workspace you belong to, any role — not just ones you own.
+// Opened from the ⋯ menu (controlled).
+export function MoveToWorkspaceDialog({
+  shortId,
+  currentOrgId,
+  open,
+  onOpenChange,
+}: {
+  shortId: string
+  currentOrgId: string | undefined
+  open: boolean
+  onOpenChange: (o: boolean) => void
+}) {
+  const qc = useQueryClient()
+  const { data: workspaces } = useQuery({ ...workspacesQuery(), enabled: open })
+  const [target, setTarget] = useState<string>("")
+  const [busy, setBusy] = useState(false)
+  const options = (workspaces?.workspaces ?? []).filter((w) => w.id !== currentOrgId)
+  const move = async () => {
+    if (!target || busy) return
+    setBusy(true)
+    try {
+      await api.moveArtifact(shortId, target)
+      await qc.invalidateQueries({ queryKey: artifactQuery(shortId).queryKey })
+      const name = options.find((w) => w.id === target)?.name ?? "the workspace"
+      toast.success(`Moved to ${name}`)
+      onOpenChange(false)
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't move this artifact")
+    } finally {
+      setBusy(false)
+    }
+  }
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Move to workspace</DialogTitle>
+          <DialogDescription>
+            Moves this artifact into another workspace you belong to. Comments, versions, and
+            history come with it; it leaves any collections here.
+          </DialogDescription>
+        </DialogHeader>
+        {options.length === 0 ? (
+          <div className="text-sm text-muted-foreground">
+            You're not a member of any other workspace yet.
+          </div>
+        ) : (
+          <Select value={target} onValueChange={setTarget}>
+            <SelectTrigger className="w-full" data-testid="move-workspace-select">
+              <SelectValue placeholder="Select a workspace" />
+            </SelectTrigger>
+            <SelectContent>
+              {options.map((w) => (
+                <SelectItem key={w.id} value={w.id}>
+                  {w.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+        {options.length > 0 && (
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onOpenChange(false)}
+              data-testid="move-workspace-cancel"
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="default"
+              size="sm"
+              onClick={move}
+              loading={busy}
+              disabled={!target}
+              data-testid="move-workspace-submit"
+            >
+              {busy ? "Moving…" : "Move"}
+            </Button>
+          </DialogFooter>
         )}
       </DialogContent>
     </Dialog>

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -325,6 +325,7 @@ export function Artifact() {
   // Lock: any editor can toggle it (advanced menu). While locked, even an editor
   // must propose — `effectiveCanPublish` flips the edit flow to the propose path.
   const canLock = canPublish
+  const canMove = art.my_role === "owner"
   const isLocked = !!art.locked
   const effectiveCanPublish = canPublish && !isLocked
   // A logged-out visitor on a public/link artifact: strictly view-only. They get
@@ -542,6 +543,7 @@ export function Artifact() {
           {!isAnon && (
             <ArtifactTopBar
               shortId={shortId}
+              orgId={art.org_id}
               myRole={art.my_role}
               visibility={art.visibility}
               generalRole={art.general_role}
@@ -568,6 +570,7 @@ export function Artifact() {
               reader={reader}
               onReaderToggle={() => setReader((r) => !r)}
               canLock={canLock}
+              canMove={canMove}
               locked={isLocked}
               onPresent={toggleFullscreen}
               onLockToggle={async () => {

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -670,6 +670,11 @@ export interface MetaStore {
    *  Ownership check is the caller's responsibility. For moderation takedowns
    *  use setArtifactRemoved() instead — that tombstones without deleting. */
   deleteArtifact(id: string, orgId: string): Promise<void>
+  /** Move an artifact to a different workspace: updates org_id, drops it from any
+   *  collections (org-scoped groupings), and detaches any org-scoped webhook that
+   *  targeted it specifically (falls back to org-wide). Ownership + destination
+   *  membership checks are the caller's responsibility. */
+  moveArtifactOrg(artifactId: string, targetOrgId: string): Promise<void>
   /** Set or clear an artifact's takedown tombstone (the record is never deleted). */
   setArtifactRemoved(id: string, removedAt: string | null): Promise<void>
   /** Take an artifact down atomically: tombstone the artifact, resolve every open

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -2134,6 +2134,16 @@ export class PgMetaStore implements MetaStore {
     })
   }
 
+  // Atomic move: org_id flips, collection membership and any artifact-targeted
+  // webhook detach, all in one commit.
+  async moveArtifactOrg(artifactId: string, targetOrgId: string): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      await tx.update(artifact).set({ org_id: targetOrgId }).where(eq(artifact.id, artifactId))
+      await tx.delete(collectionItem).where(eq(collectionItem.artifact_id, artifactId))
+      await tx.update(webhook).set({ artifact_id: null }).where(eq(webhook.artifact_id, artifactId))
+    })
+  }
+
   // Atomic takedown: tombstone + bulk open-report resolution + audit entry in one
   // transaction, so a failure mid-way rolls back instead of leaving a half-applied
   // takedown. The single bulk UPDATE replaces the route's per-report loop (N+1).

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -2042,6 +2042,20 @@ export function makeRepos(db: SqliteDb) {
     await db.delete(artifact).where(eq(artifact.id, id)).run()
   }
 
+  // Sequential move (used by D1). better-sqlite3 + pg override with a transaction.
+  const moveArtifactOrg = async (artifactId: string, targetOrgId: string): Promise<void> => {
+    await db.update(artifact).set({ org_id: targetOrgId }).where(eq(artifact.id, artifactId)).run()
+    // Collections are org-scoped groupings; the artifact leaves all of them.
+    await db.delete(collectionItem).where(eq(collectionItem.artifact_id, artifactId)).run()
+    // An org-scoped webhook that targeted this one artifact falls back to org-wide
+    // rather than keep firing across a workspace boundary.
+    await db
+      .update(webhook)
+      .set({ artifact_id: null })
+      .where(eq(webhook.artifact_id, artifactId))
+      .run()
+  }
+
   // Sequential takedown (used by D1, which has no multi-statement transaction in
   // this driver). better-sqlite3 + pg override this with a real transaction; the
   // single bulk report UPDATE (vs the old per-report loop) is the same here.
@@ -2100,6 +2114,7 @@ export function makeRepos(db: SqliteDb) {
     storageBytes,
     tagCounts,
     deleteArtifact,
+    moveArtifactOrg,
     setArtifactRemoved,
     setArtifactTitle,
     setArtifactSourcePath,

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -33,6 +33,7 @@ import {
   SCHEMA_STATEMENTS,
   sessionMessage,
   version,
+  webhook,
 } from "./schema"
 
 const VIEW_WINDOW_MS = 30 * 86400_000
@@ -155,6 +156,19 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
         db.delete(notification).where(eq(notification.artifact_id, id)).run()
         db.delete(agentMention).where(eq(agentMention.artifact_id, id)).run()
         db.delete(artifact).where(eq(artifact.id, id)).run()
+      })()
+    },
+
+    // Atomic move: org_id flips, collection membership and any artifact-targeted
+    // webhook detach, all in one commit.
+    moveArtifactOrg: async (artifactId: string, targetOrgId: string): Promise<void> => {
+      raw.transaction(() => {
+        db.update(artifact).set({ org_id: targetOrgId }).where(eq(artifact.id, artifactId)).run()
+        db.delete(collectionItem).where(eq(collectionItem.artifact_id, artifactId)).run()
+        db.update(webhook)
+          .set({ artifact_id: null })
+          .where(eq(webhook.artifact_id, artifactId))
+          .run()
       })()
     },
 


### PR DESCRIPTION
## Summary
- Adds `POST /v1/artifacts/:shortId/move` — owner-only (the same `manage` gate as delete), destination is any workspace the caller belongs to (any role, not just owner). Refuses with 409 if a custom domain is bound to the artifact rather than silently orphaning its routing.
- `moveArtifactOrg` port method + all three DB driver implementations (D1/base sequential, better-sqlite3 transaction, Postgres transaction), mirroring the existing `deleteArtifact` triple. Flips `org_id`, drops the artifact from any collections (org-scoped groupings), detaches any org-scoped webhook that targeted it specifically.
- Web: "Move to workspace…" in the artifact ⋯ menu's Manage cluster (owner-only), a new `MoveToWorkspaceDialog` (single dialog, pick + Move — no type-to-confirm).
- `GET /v1/artifacts/:shortId` now returns `org_id` so the client can exclude the current workspace from the destination picker.

## Test plan
- [x] `apps/api/test/move-artifact.test.ts`: owner-only, destination-membership-required, leaves any collection, refuses when a custom domain is bound
- [x] Full API suite (690 tests) + db package suite pass
- [x] `pnpm typecheck` clean across the monorepo; `biome check` / all `lint:*` scripts clean
- [x] Verified live in the browser: signed up, published a doc, created a second workspace, moved it via the actual UI, confirmed the success toast and that it left the source workspace's list

🤖 Generated with [Claude Code](https://claude.com/claude-code)