### PR TITLE
fix(oauth): self-heal a stale client_id on /authorize instead of dead-ending

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,6 +1,7 @@
 import { type ArtifactRecord, parseRef } from "@derive/core"
 import { type Context, Hono } from "hono"
 import { compress } from "hono/compress"
+import { OAUTH_ANON_CLIENT_TTL_MS } from "./auth-config"
 import { type AppDeps, buildContext } from "./context"
 import { cacheControlFor, corsFor, fail, TOMBSTONE } from "./lib/http"
 import { observability } from "./lib/observability"
@@ -249,12 +250,13 @@ export function createApp(deps: AppDeps): Hono {
   }
 
   // After an anonymous registration, opportunistically reap abandoned anonymous
-  // clients (never consented, no tokens, > 1 day old). Best-effort and async so it
-  // never delays the response; runs on both the Node and the (cron-less) edge tier.
+  // clients (never consented, no tokens, > OAUTH_ANON_CLIENT_TTL_MS old). Best-effort
+  // and async so it never delays the response; runs on both the Node and the
+  // (cron-less) edge tier.
   app.use("/api/auth/oauth2/register", async (c, next) => {
     await next()
     if (c.req.method === "POST" && c.res.status < 300) {
-      const cutoff = new Date(Date.now() - 24 * 3_600_000).toISOString()
+      const cutoff = new Date(Date.now() - OAUTH_ANON_CLIENT_TTL_MS).toISOString()
       void ctx.meta.pruneStaleOAuthClients(cutoff).catch(() => 0)
     }
   })
@@ -262,6 +264,50 @@ export function createApp(deps: AppDeps): Hono {
   // Better Auth owns /api/auth/* (sign-up/in/out, OAuth, OIDC/SSO, session).
   if (deps.auth) {
     const auth = deps.auth
+    // Self-heal a stale client_id on /authorize instead of dead-ending the human on
+    // the oauth-provider's bare "invalid_client / client_id is required" error page
+    // (that message fires both when client_id is missing AND when it's present but
+    // unresolvable — see getClient in the plugin). The common cause: an agent
+    // (Claude.ai, another MCP client) self-registered via DCR but its human didn't
+    // finish the browser consent before pruneStaleOAuthClients reaped the row — the
+    // agent has no way to know its client_id died and just keeps sending it, and
+    // nothing the human does in the connector UI fixes it without knowing to
+    // disconnect/reconnect. Any other cause of a missing row (a wiped local DB,
+    // manual cleanup) hits the same recovery path. When the client_id on an
+    // /authorize request doesn't resolve, silently register a fresh public client
+    // for the same redirect_uri/scope and continue the flow under the new id — the
+    // human only ever sees the consent screen, never the error.
+    app.use("/api/auth/oauth2/authorize", async (c, next) => {
+      const url = new URL(c.req.url)
+      const clientId = url.searchParams.get("client_id")
+      const redirectUri = url.searchParams.get("redirect_uri")
+      const responseType = url.searchParams.get("response_type")
+      const needsHealing =
+        clientId &&
+        redirectUri &&
+        responseType === "code" &&
+        !(await ctx.meta.oauthClientExists(clientId))
+      if (needsHealing) {
+        try {
+          const registered = await auth.api.registerOAuthClient({
+            body: {
+              redirect_uris: [redirectUri],
+              scope: url.searchParams.get("scope") ?? undefined,
+              client_name: "recovered-client",
+              token_endpoint_auth_method: "none",
+            },
+          })
+          url.searchParams.set("client_id", registered.client_id)
+          return c.redirect(url.toString(), 302)
+        } catch (err) {
+          log.error("oauth self-heal: re-registration failed", {
+            error: err instanceof Error ? err.message : String(err),
+          })
+          // Fall through: the normal authorize handler errors as before.
+        }
+      }
+      await next()
+    })
     app.on(["GET", "POST"], "/api/auth/*", (c) => auth.handler(c.req.raw))
   }
 

--- a/apps/api/src/auth-config.ts
+++ b/apps/api/src/auth-config.ts
@@ -77,6 +77,18 @@ export const OAUTH_SCOPES = [
   "derive:review",
 ] as const
 
+// How long an anonymous DCR-registered client (a headless agent that self-registered
+// but hasn't had its human complete browser consent yet) survives before
+// pruneStaleOAuthClients reaps it. An unconsented client is inert — it can't be used
+// for anything without that consent — so this is pure DB hygiene against abandoned/spam
+// registrations, not a security boundary. It used to be 24h, which was short enough that
+// a real agent connector (Claude.ai, etc.) could register, sit unconsented over a
+// weekend, and come back to a client_id that no longer existed — a dead end the human
+// had no way to diagnose. 30 days matches the existing OAuth refresh-token idle window
+// (see accessTokenExpiresIn below) and makes that failure mode a near-non-issue; the
+// authorize self-heal in app.ts (see `oauthClientExists`) covers what's left.
+export const OAUTH_ANON_CLIENT_TTL_MS = 30 * 24 * 3600_000
+
 const env = (k: string) => process.env[k]
 
 /**

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -9,7 +9,7 @@ import { serve } from "@hono/node-server"
 import Database from "better-sqlite3"
 import { Pool } from "pg"
 import { createApp } from "./app"
-import { type AuthDb, makeAuth, migrateAuth } from "./auth-config"
+import { type AuthDb, makeAuth, migrateAuth, OAUTH_ANON_CLIENT_TTL_MS } from "./auth-config"
 import { loadConfig, resolveAuthSecret, resolveDefaultOrg } from "./config"
 import { workspacesBlockingDeletion } from "./lib/account"
 import { customDomainsFromEnv } from "./lib/cloudflare-saas"
@@ -271,7 +271,9 @@ if (cfg.serveWeb && shellHtml !== undefined)
 // prune keeps the append-only view table bounded. 0 disables pruning entirely.
 // Daily maintenance: prune the rolling view window (when retention is on) and reap
 // abandoned anonymous OAuth clients (open-DCR rows never consented, holding no
-// tokens, > 1 day old). The reaper runs regardless of view retention.
+// tokens, > OAUTH_ANON_CLIENT_TTL_MS old). The reaper runs regardless of view
+// retention; the authorize-time self-heal in app.ts covers a client that slips
+// through anyway.
 let pruneTimer: ReturnType<typeof setInterval> | undefined
 const maintain = async () => {
   if (cfg.retentionDays > 0)
@@ -279,7 +281,7 @@ const maintain = async () => {
       .pruneViews(new Date(Date.now() - cfg.retentionDays * 86400_000).toISOString())
       .catch(() => 0)
   await meta
-    .pruneStaleOAuthClients(new Date(Date.now() - 24 * 3600_000).toISOString())
+    .pruneStaleOAuthClients(new Date(Date.now() - OAUTH_ANON_CLIENT_TTL_MS).toISOString())
     .catch(() => 0)
 }
 void maintain()

--- a/apps/api/test/oauth-authorize-selfheal.test.ts
+++ b/apps/api/test/oauth-authorize-selfheal.test.ts
@@ -1,0 +1,108 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { SqliteMetaStore } from "@derive/db/sqlite"
+import { FsBlobStore } from "@derive/storage/fs"
+import Database from "better-sqlite3"
+import { afterAll, describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { makeAuth, migrateAuth } from "../src/auth-config"
+
+// Regression coverage for the "invalid_client / client_id is required" dead end
+// (see reference_derive_oauth_stale_client_id): an agent (Claude.ai, another MCP
+// client) holds a client_id from a DCR registration that no longer resolves —
+// typically reaped by pruneStaleOAuthClients because its human never finished the
+// browser consent — and keeps sending it. Without self-heal, /authorize dead-ends on
+// the oauth-provider's generic error page with no recovery path visible to the
+// human. The app.ts middleware re-registers a fresh client for the same
+// redirect_uri and continues the flow transparently.
+
+const dir = mkdtempSync(join(tmpdir(), "derive-oauth-selfheal-"))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+const BASE = "http://localhost"
+const REDIRECT = "http://localhost/cb"
+
+async function freshApp(name: string) {
+  const path = join(dir, `${name}.db`)
+  const meta = new SqliteMetaStore(path)
+  const db = new Database(path)
+  db.pragma("journal_mode = WAL")
+  const auth = makeAuth(db, BASE, "test-secret-0123456789-abcdefghijklmnopqrstuv")
+  await migrateAuth(auth)
+  const app = createApp({
+    meta,
+    blobs: new FsBlobStore(join(dir, `${name}-blobs`)),
+    baseUrl: BASE,
+    auth,
+  })
+  return { app, meta, auth }
+}
+
+async function registerClient(app: ReturnType<typeof createApp>): Promise<string> {
+  const res = await app.request("/api/auth/oauth2/register", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ client_name: "RealClient", redirect_uris: [REDIRECT] }),
+  })
+  expect(res.status, "DCR should succeed").toBeLessThan(300)
+  return ((await res.json()) as { client_id: string }).client_id
+}
+
+const authorizeUrl = (clientId: string) =>
+  `/api/auth/oauth2/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}` +
+  `&redirect_uri=${encodeURIComponent(REDIRECT)}&scope=openid+derive%3Aread` +
+  `&state=xyz&code_challenge=abc123&code_challenge_method=S256`
+
+describe("authorize self-heals a client_id that no longer resolves", () => {
+  it("re-registers a fresh client and redirects under the new id instead of erroring", async () => {
+    const { app, meta } = await freshApp("heal")
+
+    const res = await app.request(authorizeUrl("ghost-client-that-was-pruned"), {
+      redirect: "manual",
+    })
+
+    expect(res.status).toBe(302)
+    const location = new URL(res.headers.get("location") ?? "", BASE)
+    expect(location.pathname).not.toBe("/api/auth/error")
+    const newClientId = location.searchParams.get("client_id")
+    expect(newClientId).toBeTruthy()
+    expect(newClientId).not.toBe("ghost-client-that-was-pruned")
+    await expect(meta.oauthClientExists(newClientId as string)).resolves.toBe(true)
+
+    // Following the healed redirect must not loop back into another heal — the new
+    // client_id now resolves, so the request proceeds into the real flow.
+    const follow = await app.request(location.pathname + location.search, { redirect: "manual" })
+    expect(follow.status).toBe(302)
+    const followLocation = new URL(follow.headers.get("location") ?? "", BASE)
+    expect(followLocation.pathname).not.toBe("/api/auth/error")
+    expect(followLocation.searchParams.get("client_id") ?? newClientId).toBe(newClientId)
+  })
+
+  it("a real, still-registered client_id passes through unchanged", async () => {
+    const { app } = await freshApp("real")
+    const clientId = await registerClient(app)
+
+    const res = await app.request(authorizeUrl(clientId), { redirect: "manual" })
+
+    expect(res.status).toBe(302)
+    const location = new URL(res.headers.get("location") ?? "", BASE)
+    expect(location.pathname).not.toBe("/api/auth/error")
+    // Untouched: still the client we registered, not silently swapped.
+    expect(location.searchParams.get("client_id") ?? clientId).toBe(clientId)
+  })
+
+  it("a request missing client_id entirely is left to the normal error path (nothing to heal)", async () => {
+    const { app } = await freshApp("missing")
+
+    const res = await app.request(
+      `/api/auth/oauth2/authorize?response_type=code&redirect_uri=${encodeURIComponent(REDIRECT)}`,
+      { redirect: "manual" },
+    )
+
+    // No client_id at all means there's no redirect_uri/client pair worth healing —
+    // our middleware's guard requires clientId truthy, so this falls straight through
+    // to the oauth-provider's own (non-heal-able) rejection.
+    expect(res.status).toBe(400)
+  })
+})

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -624,6 +624,10 @@ export interface MetaStore {
   getOAuthGrant(tokenHash: string): Promise<OAuthGrant | null>
   /** The display name of a registered OAuth client (for the consent screen). */
   getOAuthClientName(clientId: string): Promise<string | null>
+  /** Does this client_id still have a row? Backs the /authorize self-heal: a client_id an
+   *  agent is holding can go stale (reaped by pruneStaleOAuthClients, or any other loss of
+   *  the row) without the agent knowing, so /authorize checks this before trusting it. */
+  oauthClientExists(clientId: string): Promise<boolean>
   /** The agents a USER has authorized via the browser consent (one per client), so they can
    *  review + revoke what may act on their behalf. Reads Better Auth's oauth-provider tables;
    *  empty when they aren't present. */

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1887,6 +1887,17 @@ export class PgMetaStore implements MetaStore {
       return null
     }
   }
+  async oauthClientExists(clientId: string): Promise<boolean> {
+    try {
+      const { rows } = await this.pool.query(
+        `SELECT 1 FROM "oauthClient" WHERE "clientId" = $1 LIMIT 1`,
+        [clientId],
+      )
+      return rows.length > 0
+    } catch {
+      return false
+    }
+  }
   async setOAuthClientWorkspace(userId: string, clientId: string, orgId: string): Promise<void> {
     await this.db
       .insert(oauthClientWorkspace)

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -1793,6 +1793,16 @@ export function makeRepos(db: SqliteDb) {
       return null
     }
   }
+  const oauthClientExists = async (clientId: string): Promise<boolean> => {
+    try {
+      const r = await db.get(
+        sql`select 1 as one from "oauthClient" where "clientId" = ${clientId} limit 1`,
+      )
+      return !!r
+    } catch {
+      return false
+    }
+  }
   const setOAuthClientWorkspace = async (
     userId: string,
     clientId: string,
@@ -2265,6 +2275,7 @@ export function makeRepos(db: SqliteDb) {
     getAgentByToken,
     getOAuthGrant,
     getOAuthClientName,
+    oauthClientExists,
     listUserGrants,
     revokeUserGrant,
     setOAuthClientWorkspace,


### PR DESCRIPTION
## Summary
- An agent's `client_id` can go stale without it knowing about it — the common case is a DCR registration whose human never finished browser consent before `pruneStaleOAuthClients` reaped the row (see comment in `node.ts`). The agent keeps replaying the dead id and `/authorize` dead-ends on the oauth-provider's generic `invalid_client` / `client_id is required` page — the plugin reuses that exact string whether `client_id` is missing entirely or present-but-unresolvable (`getClient` returns null), so it reads as a malformed request when it's really just an expired registration. There was no recovery path visible to the human beyond disconnecting/reconnecting the connector, which nothing in the UI tells them to do.
- `/authorize` now checks whether the incoming `client_id` still resolves before handing off to the oauth-provider. If it doesn't (but `redirect_uri` + `response_type=code` are present), it silently re-registers a fresh public client for the same redirect target/scope and 302s back into the same flow under the new id — the human only ever sees the consent screen.
- Also bumps the anonymous-DCR retention from 24h to 30 days (matching the existing OAuth refresh-token idle window) so this triggers far less often to begin with. An unconsented client can't do anything — no token issues without a human's browser consent — so the short TTL was pure DB hygiene against abandoned/spam rows, not a security boundary, and it was short enough to break a legitimate slow-to-consent connector.

## Test plan
- [x] `pnpm typecheck` clean across the monorepo
- [x] `pnpm lint` / `biome check` clean on all touched files
- [x] New `apps/api/test/oauth-authorize-selfheal.test.ts`: stale client_id re-registers + redirects under a new id (and the follow-up request doesn't loop back into another heal); a real still-registered client_id passes through untouched; a request missing `client_id` entirely is left to the normal (non-heal-able) rejection
- [x] Full existing OAuth/auth suite (`oauth.test.ts`, `oauth-consent`, `oauth-refresh-rotation`, `oauth-workspace-targeting`, `oauth-agent-role-cap`, `auth-config`, `auth-recovery`, `auth-origin`) — 49/49 passing, no regressions
- [x] Full `apps/api` test suite — 694/694 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)