### PR TITLE
Email is for interrupts: mentions, review requests, and shares — never the admin blast

### DIFF
--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -139,6 +139,57 @@ export const buildInviteEmail = (input: {
   return { to: input.to, subject: `Join ${input.workspace} on Derive`, html, text }
 }
 
+/** Render a review-request email — an agent finished a revision and is blocked on
+ *  its human. The one notification that most deserves to interrupt: the recipient
+ *  may have no tab open, and the loop is waiting on them. */
+export const buildReviewEmail = (
+  baseUrl: string,
+  artifact: ArtifactRecord,
+  input: { requestedBy: string; version: number; note?: string | null },
+): { subject: string; html: string; text: string } => {
+  const title = artifact.title ?? artifact.short_id
+  const link = `${baseUrl.replace(/\/$/, "")}/artifacts/${artifact.short_id}`
+  const subject = `${input.requestedBy} requested your review of ${title}`
+  const note = input.note ? truncate(input.note, 600) : null
+  const html = `<!doctype html><html><body style="font-family:-apple-system,Segoe UI,Roboto,sans-serif;color:#1a1a1a;line-height:1.5">
+  <p><strong>${escapeHtml(input.requestedBy)}</strong> requested your review of <a href="${escapeHtml(link)}">${escapeHtml(title)}</a> (v${input.version}).</p>
+  ${note ? `<p style="white-space:pre-wrap">${escapeHtml(note)}</p>` : ""}
+  <p><a href="${escapeHtml(link)}" style="display:inline-block;background:#111;color:#fff;padding:8px 16px;border-radius:6px;text-decoration:none">Review in Derive</a></p>
+  <hr style="border:none;border-top:1px solid #eee;margin:24px 0"/>
+  <p style="color:#999;font-size:12px">You're receiving this because the revision is waiting on your review.</p>
+  </body></html>`
+  const text = [
+    `${input.requestedBy} requested your review of ${title} (v${input.version}).`,
+    note ? `\n${note}` : "",
+    `\nReview in Derive: ${link}`,
+  ]
+    .filter(Boolean)
+    .join("\n")
+  return { subject, html, text }
+}
+
+/** Render a share email — someone explicitly added the recipient to an artifact.
+ *  Deliberate and personal, so it clears the interrupt bar. */
+export const buildShareEmail = (
+  baseUrl: string,
+  artifact: ArtifactRecord,
+  input: { sharedBy: string; role: string },
+): { subject: string; html: string; text: string } => {
+  const title = artifact.title ?? artifact.short_id
+  const link = `${baseUrl.replace(/\/$/, "")}/artifacts/${artifact.short_id}`
+  const subject = `${input.sharedBy} shared ${title} with you`
+  const html = `<!doctype html><html><body style="font-family:-apple-system,Segoe UI,Roboto,sans-serif;color:#1a1a1a;line-height:1.5">
+  <p><strong>${escapeHtml(input.sharedBy)}</strong> shared <a href="${escapeHtml(link)}">${escapeHtml(title)}</a> with you${input.role === "viewer" ? "" : ` as ${escapeHtml(input.role)}`}.</p>
+  <p><a href="${escapeHtml(link)}" style="display:inline-block;background:#111;color:#fff;padding:8px 16px;border-radius:6px;text-decoration:none">Open in Derive</a></p>
+  <hr style="border:none;border-top:1px solid #eee;margin:24px 0"/>
+  <p style="color:#999;font-size:12px">You're receiving this because you were added to this artifact.</p>
+  </body></html>`
+  const text = [`${input.sharedBy} shared ${title} with you.`, `\nOpen in Derive: ${link}`].join(
+    "\n",
+  )
+  return { subject, html, text }
+}
+
 export interface CommentEmailInput {
   author: string
   body: string

--- a/apps/api/src/lib/notify-email.ts
+++ b/apps/api/src/lib/notify-email.ts
@@ -2,13 +2,12 @@
 // deliveries onto the outbox (kind="email"). Kept out of the route handler so the
 // recipient policy lives in one place.
 //
-// Recipient policy (intentionally NOT "every workspace member on every comment", which
-// would be spam): a person is emailed when they are
-//   - @mentioned in the comment (a "mention" email), or
-//   - already a participant in the thread (authored an earlier comment in it), or
-//   - a workspace owner/admin (so the people who run the space hear about activity).
-// The comment's author is never emailed about their own comment. Per-user opt-out is
-// applied by the caller's preference gate (added with the Settings UI).
+// Recipient policy: email is reserved for what's worth interrupting for, and for a
+// comment that means being @MENTIONED — someone deliberately pulled you in. Thread
+// replies reach participants as bell notifications (the route writes those); an
+// earlier policy also emailed every workspace owner on every comment, which turned
+// admins' inboxes into a firehose the moment agents multiplied comment volume.
+// The comment's author is never emailed about their own comment.
 
 import type { ArtifactRecord, CommentRecord, MetaStore } from "@derive/core"
 import { enqueueChannelDelivery } from "../webhooks"
@@ -30,20 +29,7 @@ export const enqueueCommentEmails = async (
 ): Promise<void> => {
   const { meta, baseUrl } = deps
 
-  // Thread participants: distinct authors of earlier comments in the same thread.
-  const threadAuthors = new Set(
-    (await meta.listComments(artifact.id))
-      .filter((c) => c.thread_id === comment.thread_id && c.author_id)
-      .map((c) => c.author_id as string),
-  )
-  // Workspace owners.
-  const owners = new Set(
-    (await meta.listMemberships(artifact.org_id))
-      .filter((m) => m.role === "owner")
-      .map((m) => m.user_id),
-  )
-
-  const recipientIds = new Set<string>([...opts.mentionIds, ...threadAuthors, ...owners])
+  const recipientIds = new Set<string>(opts.mentionIds)
   recipientIds.delete("") // guard
   if (opts.actorId) recipientIds.delete(opts.actorId)
   if (recipientIds.size === 0) return
@@ -54,20 +40,18 @@ export const enqueueCommentEmails = async (
     users
       .filter((u) => u.email)
       .map((u) => {
-        const mention = opts.mentionIds.has(u.id)
         const content = buildCommentEmail(baseUrl, artifact, {
           author: comment.author,
           body: comment.body_md,
           quote,
           threadId: comment.thread_id,
-          mention,
+          mention: true,
         })
-        return enqueueChannelDelivery(
-          meta,
-          "email",
-          mention ? "comment.mention" : "comment.created",
-          { to: u.email, toName: u.name ?? undefined, ...content },
-        )
+        return enqueueChannelDelivery(meta, "email", "comment.mention", {
+          to: u.email,
+          toName: u.name ?? undefined,
+          ...content,
+        })
       }),
   )
 }

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -47,6 +47,8 @@ import {
   zipBundleFiles,
 } from "./lib/bundle"
 import { parseMeta, quoteOf, REACTIONS } from "./lib/comments"
+import { buildReviewEmail } from "./lib/email"
+import { enqueueChannelDelivery } from "./webhooks"
 
 const text = (s: string) => ({ content: [{ type: "text" as const, text: s }] })
 // Bound a best-effort promise (the tab-delivery receipt) so it can never stall a
@@ -836,6 +838,22 @@ function buildServer(
             version: version.n,
             requested_by: agent.name,
           })
+          // The review request is the one event that earns an email: the loop is
+          // blocked on the human, who may have no tab open (same policy as the
+          // HTTP publish path). `settings` is only pre-loaded on a create, so a
+          // republish (where most review rounds happen) fetches the gate here.
+          if ((settings ?? (await ctx.meta.getOrgSettings(org))).emailNotifications) {
+            const [r] = await ctx.meta.getUsers([actingFor.id])
+            if (r?.email)
+              await enqueueChannelDelivery(ctx.meta, "email", "review.requested", {
+                to: r.email,
+                toName: r.name ?? undefined,
+                ...buildReviewEmail(ctx.deps.baseUrl, artifact, {
+                  requestedBy: agent.name,
+                  version: version.n,
+                }),
+              })
+          }
         }
         const url = artifactUrl(ctx.deps.baseUrl, artifact)
         // Bell entry for the human behind the grant, so a push reaches them even

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -24,6 +24,7 @@ import type { AppContext } from "../context"
 import { publishSweepEvents } from "../lib/anchor-sweep"
 import { authorProfile, resolveHandles } from "../lib/author"
 import { hashPassword, signState, unlockCookie, unlockToken, verifyPassword } from "../lib/crypto"
+import { buildReviewEmail } from "../lib/email"
 import {
   DEFAULT_WORKSPACE_NAME,
   fail,
@@ -33,6 +34,7 @@ import {
   TOMBSTONE,
   visibilityOf,
 } from "../lib/http"
+import { enqueueChannelDelivery } from "../webhooks"
 
 /** The artifact lifecycle: browse + summary, publish/republish, detail, restore,
  *  source read-back, and version diffs. */
@@ -503,6 +505,22 @@ export const artifactRoutes = (ctx: AppContext) => {
             version: version.n,
             requested_by: actor?.name ?? "An agent",
           })
+          // The review request is the one event that earns an email: the loop is
+          // blocked on the reviewer, who may have no tab open. Never for your own
+          // request on yourself (a human publishing with request_review).
+          if (reviewer !== actor?.id && (await meta.getOrgSettings(org)).emailNotifications) {
+            const [r] = await meta.getUsers([reviewer])
+            if (r?.email)
+              await enqueueChannelDelivery(meta, "email", "review.requested", {
+                to: r.email,
+                toName: r.name ?? undefined,
+                ...buildReviewEmail(deps.baseUrl, artifact, {
+                  requestedBy: actor?.name ?? "An agent",
+                  version: version.n,
+                  note: str(body["review_note"]) ?? null,
+                }),
+              })
+          }
         }
       }
       // The MCP loop over HTTP: an AGENT-credentialed publish (a registered

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -220,6 +220,35 @@ export const commentRoutes = (ctx: AppContext) => {
             quote: quoteOf(created.anchor),
             thread_id: created.thread_id,
           })
+        // A reply reaches the thread's earlier authors as a bell row (email is
+        // mention-only — see notify-email.ts). Mentioned people already got the
+        // stronger mention row above; the author never hears about themselves.
+        const mentionIds = new Set(mentions.map((m) => m.id))
+        const participants = new Set(
+          (await meta.listComments(artifact.id))
+            .filter((cm) => cm.thread_id === created.thread_id && cm.author_id)
+            .map((cm) => cm.author_id as string),
+        )
+        for (const uid of participants) {
+          if (uid === (acting?.id ?? null) || mentionIds.has(uid)) continue
+          const row = {
+            id: newId("n"),
+            user_id: uid,
+            actor: created.author,
+            kind: "comment" as const,
+            artifact_id: artifact.id,
+            artifact_short_id: artifact.short_id,
+            artifact_title: artifact.title,
+            thread_id: created.thread_id,
+            comment_id: created.id,
+            preview: previewOf(created.body_md),
+          }
+          await meta.createNotification(row)
+          bus.publish(`u:${uid}`, {
+            type: "notification",
+            notification: { ...row, read: 0, created_at: new Date().toISOString() },
+          })
+        }
         // Channel fan-out is gated per workspace (Settings -> integrations toggles).
         const settings = await meta.getOrgSettings(artifact.org_id)
         if (settings.emailNotifications)

--- a/apps/api/src/routes/sharing.ts
+++ b/apps/api/src/routes/sharing.ts
@@ -2,13 +2,15 @@ import { type ArtifactRecord, effectiveRole, isRole, newId, ROLES, type Role } f
 import { type Context, Hono } from "hono"
 import { z } from "zod"
 import type { AppContext } from "../context"
+import { buildShareEmail } from "../lib/email"
 import { fail, readJson } from "../lib/http"
 import { resolveUserRef } from "../lib/resolve-user"
+import { enqueueChannelDelivery } from "../webhooks"
 
 /** Per-artifact role overrides (a share). Managing shares requires `share`
  *  (editor+, GDocs model); the share's role beats the caller's workspace baseline. */
 export const sharingRoutes = (ctx: AppContext) => {
-  const { meta, defaultRole, authorize, actorFor, actingUser, bus } = ctx
+  const { meta, deps, defaultRole, authorize, actorFor, actingUser, bus } = ctx
   const app = new Hono()
 
   // A sharer can never grant — or remove — a role above their own. An editor (who
@@ -106,6 +108,18 @@ export const sharingRoutes = (ctx: AppContext) => {
         type: "notification",
         notification: { ...row, read: 0, created_at: new Date().toISOString() },
       })
+      // A share is deliberate and personal — it clears the email bar (the doc may
+      // be the recipient's first contact with this workspace, so a bell alone can
+      // sit unseen). Same workspace gate as the other notification emails.
+      if (user.email && (await meta.getOrgSettings(artifact.org_id)).emailNotifications)
+        await enqueueChannelDelivery(meta, "email", "artifact.shared", {
+          to: user.email,
+          toName: user.name ?? undefined,
+          ...buildShareEmail(deps.baseUrl, artifact, {
+            sharedBy: sharer.name ?? "Someone",
+            role: b.role,
+          }),
+        })
     }
     // Echo the public handle, never the email — otherwise sharing by @handle would
     // be a handle→email oracle (resolve anyone's email by sharing an artifact with them).

--- a/apps/api/test/comment-fanout.test.ts
+++ b/apps/api/test/comment-fanout.test.ts
@@ -3,9 +3,14 @@ import { DEFAULT_ORG_SETTINGS } from "@derive/core"
 import { describe, expect, it } from "vitest"
 import { as, jsonAs, makeAuthedApp, pub, type TestUser } from "./helpers"
 
-// Posting a comment fans out onto the outbox: an email to eligible recipients and a
-// Slack post when connected — each gated by the workspace toggles. We drive the real
-// route and inspect the enqueued outbox rows by kind.
+// The other interrupt-worthy emails ride the same outbox: a review request (the
+// loop is blocked on its human) and an explicit share. Pinned here beside the
+// comment policy so the whole "what emails" contract lives in one file.
+
+// Posting a comment fans out onto the outbox: an email to @MENTIONED people only
+// (a plain comment reaches thread participants as bell rows, never email — the
+// interrupt bar), and a Slack post when connected — each gated by the workspace
+// toggles. We drive the real route and inspect the enqueued outbox rows by kind.
 const owner: TestUser = { id: "u-own", email: "own@x.com", name: "Owner", username: "own" }
 const editor: TestUser = { id: "u-ed", email: "ed@x.com", name: "Ed", username: "edd" }
 
@@ -23,20 +28,60 @@ const newArtifact = async (app: ReturnType<typeof makeAuthedApp>["app"]) => {
   return (await r.json()).short_id as string
 }
 
-const comment = (app: ReturnType<typeof makeAuthedApp>["app"], shortId: string, who: string) =>
-  app.request(`/v1/artifacts/${shortId}/comments`, jsonAs(as(who), { body_md: "a note" }))
+const comment = (
+  app: ReturnType<typeof makeAuthedApp>["app"],
+  shortId: string,
+  who: string,
+  mentions?: { id: string; name: string }[],
+) =>
+  app.request(
+    `/v1/artifacts/${shortId}/comments`,
+    jsonAs(as(who), { body_md: "a note", ...(mentions ? { mentions } : {}) }),
+  )
 
 describe("comment channel fan-out", () => {
-  it("enqueues an email to the workspace owner when a non-owner comments", async () => {
+  it("a plain comment emails NO ONE — not even workspace owners", async () => {
+    // The old policy blasted every workspace owner on every comment; with agents
+    // multiplying comment volume that made admins' inboxes the firehose. Owners
+    // hear about plain activity like everyone else: bell rows, not email.
     const { app, meta } = makeAuthedApp("fanout-email", [owner, editor], "editor")
     const shortId = await newArtifact(app)
     const res = await comment(app, shortId, editor.email)
     expect(res.status).toBe(201)
     const kinds = (await claim(meta)).map((d) => d.kind)
-    expect(kinds).toContain("email")
+    expect(kinds).not.toContain("email")
   })
 
-  it("does not email when the email toggle is off", async () => {
+  it("a reply reaches earlier thread authors as a bell row, and only them", async () => {
+    const { app, meta } = makeAuthedApp("fanout-bell", [owner, editor], "editor")
+    const shortId = await newArtifact(app)
+    // Owner opens the thread; editor replies into it.
+    const first = await (await comment(app, shortId, owner.email)).json()
+    await app.request(
+      `/v1/artifacts/${shortId}/comments`,
+      jsonAs(as(editor.email), { body_md: "replying", thread_id: first.thread_id }),
+    )
+    const rows = await meta.listNotifications(owner.id, 10)
+    const reply = rows.find((n) => n.kind === "comment")
+    expect(reply).toBeTruthy()
+    expect(reply?.thread_id).toBe(first.thread_id)
+    // The replier never hears about their own comment.
+    expect((await meta.listNotifications(editor.id, 10)).map((n) => n.kind)).not.toContain(
+      "comment",
+    )
+  })
+
+  it("a mention emails the mentioned person (and no one else)", async () => {
+    const { app, meta } = makeAuthedApp("fanout-mention", [owner, editor], "editor")
+    const shortId = await newArtifact(app)
+    const res = await comment(app, shortId, editor.email, [{ id: owner.id, name: "Owner" }])
+    expect(res.status).toBe(201)
+    const emails = (await claim(meta)).filter((d) => d.kind === "email")
+    expect(emails).toHaveLength(1)
+    expect(emails[0]?.payload).toContain(owner.email)
+  })
+
+  it("does not email a mention when the email toggle is off", async () => {
     const { app, meta } = makeAuthedApp("fanout-email-off", [owner, editor], "editor")
     await meta.setOrgSettings("default", {
       ...DEFAULT_ORG_SETTINGS,
@@ -47,7 +92,7 @@ describe("comment channel fan-out", () => {
       slackPost: true,
     })
     const shortId = await newArtifact(app)
-    await comment(app, shortId, editor.email)
+    await comment(app, shortId, editor.email, [{ id: owner.id, name: "Owner" }])
     const kinds = (await claim(meta)).map((d) => d.kind)
     expect(kinds).not.toContain("email")
   })
@@ -92,5 +137,49 @@ describe("comment channel fan-out", () => {
     await comment(app, shortId, owner.email)
     const kinds = (await claim(meta)).map((d) => d.kind)
     expect(kinds).not.toContain("slack_app")
+  })
+})
+
+describe("review-request + share emails", () => {
+  it("an agent's review request emails the human it acts for", async () => {
+    const { app, meta } = makeAuthedApp("fanout-review", [owner, editor], "editor")
+    const reg = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Scribe", role: "editor" }))
+    ).json()
+    const res = await pub(app, "# plan", { request_review: "true", title: "Plan" }, undefined, {
+      authorization: `Bearer ${reg.token}`,
+    })
+    expect(res.status).toBe(201)
+    const emails = (await claim(meta)).filter((d) => d.kind === "email")
+    expect(emails).toHaveLength(1)
+    expect(emails[0]?.payload).toContain(owner.email)
+    expect(emails[0]?.payload).toContain("requested your review")
+  })
+
+  it("a human's own request_review never emails themselves", async () => {
+    const { app, meta } = makeAuthedApp("fanout-review-self", [owner], "editor")
+    const res = await pub(
+      app,
+      "# plan",
+      { request_review: "true", title: "Plan" },
+      undefined,
+      as(owner.email),
+    )
+    expect(res.status).toBe(201)
+    expect((await claim(meta)).map((d) => d.kind)).not.toContain("email")
+  })
+
+  it("sharing an artifact emails the person you added", async () => {
+    const { app, meta } = makeAuthedApp("fanout-share", [owner, editor], "editor")
+    const shortId = await newArtifact(app)
+    const res = await app.request(`/v1/artifacts/${shortId}/members`, {
+      ...jsonAs(as(owner.email), { user: editor.username, role: "commenter" }),
+      method: "PUT",
+    })
+    expect(res.status).toBe(201)
+    const emails = (await claim(meta)).filter((d) => d.kind === "email")
+    expect(emails).toHaveLength(1)
+    expect(emails[0]?.payload).toContain(editor.email)
+    expect(emails[0]?.payload).toContain("shared")
   })
 })


### PR DESCRIPTION
## Why

Email volume was noise-heavy by design: the comment fan-out emailed **every workspace owner on every comment** ("so the people who run the space hear about activity") plus every thread participant per reply — a policy that inverts the moment agents multiply comment volume, since a workspace owner is emailed for essentially everything, including their own agents' review chatter. Meanwhile the one event genuinely blocked on a human — **an agent requesting review** — sent no email at all, only a bell. The system emailed the noise and didn't email the signal.

Principle this PR encodes: **email is for interrupts.** Something is email-worthy when someone deliberately pulled you in, or the work is blocked on you, and you may not have a tab open. Everything else is the bell.

## What changed

| Event | Before | After |
|---|---|---|
| Plain comment | Email to all workspace owners + thread participants | **No email.** Thread participants get bell rows (the previously-unused `comment` notification kind — they previously got *nothing* unless mentioned) |
| @mention | Email + bell | Email + bell (unchanged — someone pulled you in) |
| Agent requests review | Bell only | **Email + bell**, on both the HTTP and remote-MCP publish paths. Never for your own `request_review` on yourself |
| Explicit share | Bell only | **Email + bell** (may be the recipient's first contact with the workspace; a bell alone can sit unseen) |
| Invites, auth flows | Email | Unchanged |

- All notification emails stay behind the workspace `emailNotifications` gate (the MCP path now fetches the gate on republish too, where most review rounds happen — previously `settings` was only loaded on create).
- `notify-email.ts`'s recipient policy simplifies to mentions-only; its old header comment claimed a per-user preference gate "applied by the caller" that never existed — the comment now describes reality.
- Two new templates (`buildReviewEmail`, `buildShareEmail`) in the existing house style.
- The bell UI already renders the `comment` kind (its existing "commented" fallback), so no web changes.

## Not in this PR (recorded next steps)

Per-user email preference (Mentions & review requests / All activity / None) and thread-reply coalescing for the all-activity tier — the defaults above land first because they're what pre-launch users will form habits around; the preference adds choice on top.

## Testing

- `comment-fanout.test.ts` rewritten as the recipient-policy contract: plain comment emails no one (the owner-blast case pinned as a regression test), replies bell earlier thread authors and never the replier, a mention emails exactly the mentioned person, toggle-off suppresses, an agent's review request emails its human (and a human's self-request doesn't), a share emails the person added.
- Full API suite: **700 tests green**. Typecheck + lint gates clean. mcp-loop and share e2e specs pass (publish/review/share paths touched here).
