### PR TITLE
feat(cli): repo pointers — a context's corpus arrives by clone

### DIFF
--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -269,7 +269,8 @@ if (cmd === "context") {
     }
     let up
     try {
-      up = readTarget(target)
+      // repos/ is the runner's clone workspace — pointer state, never source.
+      up = readTarget(target, ["repos"])
     } catch (e) {
       console.error(`error: ${e.message}`)
       process.exit(1)
@@ -579,7 +580,7 @@ if (flags.json) {
   // for the recipient.
   if (json.visibility === "org" || json.visibility === "private")
     console.log(
-      `  ${json.visibility === "org" ? "workspace-only" : "invite-only"} — pass --visibility link (or use the Share dialog) to make the URL readable by others`,
+      `  ${json.visibility === "org" ? "workspace-only" : "invite-only"} — pass --visibility public (or use the Share dialog) to widen the audience`,
     )
   if (flags.review)
     console.log(`  ↩ review requested — the human reviews in the app, then Send back`)

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -385,7 +385,17 @@ Extra detail the skill loads on demand — keep SKILL.md lean and push the long 
 (edge cases, tables, examples) into reference files like this one.
 `
 
-const starterManifest = (title) => `# ${title} — context manifest
+const starterManifest = (title) => `---
+# Repo pointers: the runner clones these into repos/ at boot and tells the
+# model what's there (and at which SHA). Uncomment to declare them — they
+# travel with every push, so a fresh box needs nothing pre-installed.
+# repos:
+#   - url: https://github.com/you/data-notebooks
+#     ref: main
+#     description: what's in it, one line the model will read
+---
+
+# ${title} — context manifest
 
 This file is the runner's system prompt. Editing it (and pushing) reconfigures
 the agent's judgment with no redeploy — the next answer uses the new version.
@@ -439,8 +449,10 @@ const STARTER_CONTEXT_ENV = `# Secrets the context's MCP servers need (see .mcp.
 `
 
 const CONTEXT_GITIGNORE = `# Secrets never leave the machine: .env holds the context's credentials, .derive/
-# holds the agent token minted by the first push.
+# holds the agent token minted by the first push. repos/ is the runner's clone
+# workspace — pointer state, never source.
 context/.env
+context/repos/
 .derive/
 `
 

--- a/packages/cli/src/publish.js
+++ b/packages/cli/src/publish.js
@@ -14,8 +14,10 @@ const isEnvSecret = (name) =>
 
 /** Recursively collect a directory into {relativePath: bytes} for zipping.
  *  Returns the files plus the .env-rule exclusions in `skipped`, so the caller
- *  can make the "your secrets stayed local" contract visible. */
-export function collectDir(dir, base = dir, out = { files: {}, skipped: [] }) {
+ *  can make the "your secrets stayed local" contract visible. `skipTopDirs`
+ *  drops named TOP-LEVEL directories (context push uses it for repos/ — the
+ *  runner's clone workspace is pointer state, not source). */
+export function collectDir(dir, base = dir, out = { files: {}, skipped: [] }, skipTopDirs = []) {
   for (const name of readdirSync(dir)) {
     if (
       name === ".DS_Store" ||
@@ -30,17 +32,19 @@ export function collectDir(dir, base = dir, out = { files: {}, skipped: [] }) {
       continue
     }
     const st = statSync(path)
-    if (st.isDirectory()) collectDir(path, base, out)
-    else out.files[relative(base, path).split("\\").join("/")] = readFileSync(path)
+    if (st.isDirectory()) {
+      if (dir === base && skipTopDirs.includes(name)) continue
+      collectDir(path, base, out)
+    } else out.files[relative(base, path).split("\\").join("/")] = readFileSync(path)
   }
   return out
 }
 
 /** Read the publish target (file or directory) into upload bytes.
  *  Directories zip client-side; the server unpacks them into a bundle. */
-export function readTarget(target) {
+export function readTarget(target, skipTopDirs = []) {
   if (statSync(target).isDirectory()) {
-    const { files, skipped } = collectDir(target)
+    const { files, skipped } = collectDir(target, target, undefined, skipTopDirs)
     if (Object.keys(files).length === 0) throw new Error(`${target} is empty`)
     return { bytes: zipSync(files), filename: `${basename(target)}.zip`, skipped }
   }
@@ -58,7 +62,8 @@ export async function uploadArtifact(p, bytes, filename, extra = {}) {
   if (p.message) form.append("message", p.message)
   if (p.name) form.append("name", p.name)
   if (p.visibility) form.append("visibility", p.visibility)
-  // --password is a per-publish secret for `--visibility password`; never put it in
+  // --password gates a public publish behind a passphrase (the server hashes it;
+  // the legacy `--visibility password` spelling still maps). Never put it in
   // derive.json (it isn't a config field), only pass it on the command line.
   if (p.password) form.append("password", p.password)
   for (const [k, v] of Object.entries(extra)) form.append(k, v)

--- a/packages/cli/src/runner.js
+++ b/packages/cli/src/runner.js
@@ -9,7 +9,8 @@
 // Ported from packages/runner (TS) into the published CLI so `derive runner
 // serve` works from a bare npx on any machine — one package, no build step.
 import { spawn } from "node:child_process"
-import { readFileSync, statSync } from "node:fs"
+import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs"
+import { dirname, join } from "node:path"
 
 // ---- config -----------------------------------------------------------------
 
@@ -142,12 +143,11 @@ export class DeriveClient {
     })
   }
 
-  /** Publish a model-produced visual as a link-visible artifact. Link (not
+  /** Publish a model-produced visual as a workspace-visible artifact. Org (not
    *  private): the artifact lands in the AGENT'S REGISTRANT'S library (the
    *  on-behalf model), so a private one would be unreadable to the very asker
-   *  it was made for. Workspace-visible: askers are workspace members, and a
-   *  chart answering a question is workspace work — the library is where it
-   *  belongs. */
+   *  it was made for — and askers are workspace members, so a chart answering
+   *  their question is workspace work. */
   async publishArtifact(title, html) {
     const form = new FormData()
     form.set("file", new Blob([html], { type: "text/html" }), "chart.html")
@@ -163,6 +163,124 @@ export class DeriveClient {
     if (!res.ok) throw new Error(`publish → ${res.status}: ${await res.text()}`)
     return res.json()
   }
+}
+
+// ---- repo pointers --------------------------------------------------------------
+
+/** Split a manifest into its body (the system prompt) and the repo pointers in
+ *  its frontmatter. Pointers live INSIDE the manifest on purpose: they version
+ *  with the judgment they support, and a bare `runner serve <ctx>` on a fresh
+ *  box learns them from the server — nothing has to exist on disk first.
+ *  Deliberately narrow: only the `repos:` list is read (url required; ref and
+ *  description optional); everything else in the frontmatter is ignored, and a
+ *  manifest without frontmatter passes through untouched. */
+export function parseManifest(md) {
+  const m = md.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/)
+  if (!m) return { body: md, repos: [] }
+  const unquote = (v) => {
+    const t = v.trim()
+    const q = t[0]
+    return t.length >= 2 && (q === '"' || q === "'") && t.at(-1) === q ? t.slice(1, -1) : t
+  }
+  const repos = []
+  let inRepos = false
+  let cur = null
+  for (const line of (m[1] ?? "").split(/\r?\n/)) {
+    if (/^repos:\s*$/.test(line)) {
+      inRepos = true
+      continue
+    }
+    if (inRepos && /^\S/.test(line)) inRepos = false // next top-level key
+    if (!inRepos) continue
+    const item = line.match(/^\s*-\s+(\w+):\s*(.+)$/)
+    const kv = line.match(/^\s+(\w+):\s*(.+)$/)
+    if (item) {
+      cur = { [item[1]]: unquote(item[2]) }
+      repos.push(cur)
+    } else if (kv && cur) cur[kv[1]] = unquote(kv[2])
+  }
+  return {
+    body: md.slice(m[0].length),
+    repos: repos
+      .filter(
+        (r) => typeof r.url === "string" && /^(https:\/\/|ssh:\/\/|git@|file:\/\/)/.test(r.url),
+      )
+      .map((r) => ({ url: r.url, ref: r.ref ?? null, description: r.description ?? "" })),
+  }
+}
+
+/** Directory name for a cloned pointer: the last two URL segments (owner-repo),
+ *  so same-named repos from different owners don't collide. */
+export const repoSlug = (url) => {
+  const segs = url
+    .replace(/\.git$/, "")
+    .replace(/\/+$/, "")
+    .split(/[/:]/)
+    .filter(Boolean)
+  return segs
+    .slice(-2)
+    .join("-")
+    .replace(/[^A-Za-z0-9._-]/g, "-")
+}
+
+const git = (args, timeout = 300_000) =>
+  new Promise((resolve) => {
+    const p = spawn("git", args, { stdio: ["ignore", "pipe", "pipe"], timeout })
+    let out = ""
+    let err = ""
+    p.stdout.on("data", (b) => {
+      out += b
+    })
+    p.stderr.on("data", (b) => {
+      err += b
+    })
+    p.on("close", (code) => resolve({ code, out: out.trim(), err: err.trim() }))
+    p.on("error", (e) => resolve({ code: -1, out: "", err: String(e) }))
+  })
+
+/** Clone or update each pointer into `<cwd>/repos/<slug>` (shallow, detached at
+ *  the ref's tip) and return the catalog with resolved SHAs. Boot-time only —
+ *  a manifest edit that adds a repo applies on the next start, like every other
+ *  piece of host state. A failed pointer is loud but NON-fatal: the runner
+ *  still answers, the catalog marks the repo unavailable so the model can say
+ *  so, and private-repo auth rides whatever git already has on this host
+ *  (gh auth, ssh keys, GH_TOKEN credential helper). */
+export async function syncRepos(repos, cwd) {
+  const catalog = []
+  for (const r of repos) {
+    const dir = join(cwd, "repos", repoSlug(r.url))
+    let res
+    if (existsSync(join(dir, ".git"))) {
+      res = await git(["-C", dir, "fetch", "--depth", "1", "origin", ...(r.ref ? [r.ref] : [])])
+      if (res.code === 0) res = await git(["-C", dir, "checkout", "-q", "--detach", "FETCH_HEAD"])
+    } else {
+      mkdirSync(dirname(dir), { recursive: true })
+      res = await git(["clone", "--depth", "1", ...(r.ref ? ["--branch", r.ref] : []), r.url, dir])
+    }
+    if (res.code !== 0) {
+      console.error(`[runner] repo ${r.url}: ${res.err.slice(0, 200) || "git failed"}`)
+      catalog.push({ ...r, dir, sha: null })
+      continue
+    }
+    const sha = await git(["-C", dir, "rev-parse", "--short=12", "HEAD"])
+    catalog.push({ ...r, dir, sha: sha.code === 0 ? sha.out : null })
+    console.log(`[runner] repo ${repoSlug(r.url)} @ ${sha.out} (${r.ref ?? "default branch"})`)
+  }
+  return catalog
+}
+
+/** The prompt block that tells the model what's on disk and at which SHA. An
+ *  unavailable repo is stated outright — a silent gap would read as "the
+ *  corpus has nothing on this", which is a wrong answer, not a missing one. */
+export function repoCatalogBlock(catalog) {
+  if (catalog.length === 0) return ""
+  const lines = catalog.map((r) => {
+    const rel = `repos/${repoSlug(r.url)}`
+    return r.sha
+      ? `- ${rel} — ${r.description || r.url} (${r.ref ?? "default"} @ ${r.sha})`
+      : `- ${rel} — ${r.description || r.url} — UNAVAILABLE this run (clone failed); say so when an answer would need it`
+  })
+  return `\n\n## Repositories (cloned into your working directory)\n\n${lines.join("\n")}`
 }
 
 // ---- Claude subprocess ---------------------------------------------------------
@@ -359,7 +477,7 @@ const MOCK_ANSWER = {
   artifact: null,
 }
 
-async function serveSession(client, session, manifest, cfg) {
+async function serveSession(client, session, manifest, cfg, repoMeta = []) {
   const asked = session.messages.at(-1)?.body_md?.slice(0, 80) ?? "?"
   console.log(`[runner] session ${session.id}: "${asked}"`)
   const result = cfg.mock
@@ -382,6 +500,9 @@ async function serveSession(client, session, manifest, cfg) {
     query: a.query,
     confidence: a.confidence,
     caveats: a.caveats,
+    // Provenance: which corpus tips this answer was computed against — the
+    // difference between "the data says X" and "the data as of ab12cd3 says X".
+    ...(repoMeta.length ? { repos: repoMeta } : {}),
     ...(a.escalate ? { escalation_reason: a.escalation_reason ?? "escalated" } : {}),
   }
   // Publish the answer's visual, if it produced one. A publish failure demotes
@@ -433,12 +554,20 @@ export async function serve(cfg) {
   const client = new DeriveClient(cfg.server, cfg.token)
   const info = await client.getContext(cfg.contextId)
   if (!info.manifest_md && !cfg.manifestFile) throw new Error("context has no readable manifest")
-  if (cfg.manifestFile) readFileSync(cfg.manifestFile, "utf8") // fail at startup, not first answer
+  const readManifest = () =>
+    cfg.manifestFile ? readFileSync(cfg.manifestFile, "utf8") : (info.manifest_md ?? "")
+  const boot = parseManifest(readManifest()) // throws on a bad manifestFile — at startup, not first answer
   console.log(
     `[runner] serving "${info.name}" (${cfg.contextId}) on ${cfg.server} — ` +
       `${cfg.manifestFile ? `manifest LOCAL ${cfg.manifestFile}` : `manifest v${info.manifest_version}`}, ` +
       `${cfg.mock ? "MOCK" : `${cfg.claudeBin} (${cfg.model})`}, poll ${cfg.pollMs}ms`,
   )
+  // Pointers sync at boot, like every other piece of host state — a manifest
+  // edit that adds one applies on the next start (the catalog in the prompt is
+  // per-boot truth, and mid-run re-clones would change corpus SHAs between
+  // answers in the same session).
+  const catalog = await syncRepos(boot.repos, cfg.cwd)
+  const repoMeta = catalog.filter((r) => r.sha).map((r) => ({ url: r.url, sha: r.sha }))
 
   for (;;) {
     try {
@@ -455,16 +584,19 @@ export async function serve(cfg) {
       if (sessions.length > 0) {
         // Re-read the manifest only when the queue has work — an edit applies
         // from the next answer, and idle polls stay one call. In dev mode the
-        // working-tree file wins, same freshness contract.
-        const manifest = cfg.manifestFile
+        // working-tree file wins, same freshness contract. The repo catalog is
+        // appended from the BOOT sync — the frontmatter may promise new repos,
+        // but the prompt only ever claims what's actually on disk.
+        const md = cfg.manifestFile
           ? readFileSync(cfg.manifestFile, "utf8")
-          : ((await client.getContext(cfg.contextId)).manifest_md ?? info.manifest_md)
+          : ((await client.getContext(cfg.contextId)).manifest_md ?? info.manifest_md ?? "")
+        const manifest = parseManifest(md).body + repoCatalogBlock(catalog)
         // Sequential on purpose: one runner, one model, no fan-out — fairness
         // comes from the queue's oldest-first order. One session's failure must
         // not starve the rest of the batch.
         for (const s of sessions) {
           try {
-            await serveSession(client, s, manifest, cfg)
+            await serveSession(client, s, manifest, cfg, repoMeta)
           } catch (err) {
             console.error(`[runner] session ${s.id}: ${err.message}`)
           }
@@ -511,6 +643,7 @@ export async function doctor(cfg) {
     bad("server", `${cfg.server} unreachable (${e.message})`)
   }
 
+  let repos = []
   if (!cfg.token || !cfg.contextId) {
     // Partial config: still worth running the local checks below.
     bad(
@@ -523,9 +656,22 @@ export async function doctor(cfg) {
       info.manifest_md
         ? ok("context + manifest", `"${info.name}" manifest v${info.manifest_version}`)
         : bad("manifest", "context resolves but its manifest is unreadable")
+      repos = parseManifest(info.manifest_md ?? "").repos
     } catch (e) {
       bad("token/context", `cannot resolve ${cfg.contextId} (${e.message.slice(0, 120)})`)
     }
+  }
+
+  // Each pointer is probed without cloning — a typo'd URL or missing repo auth
+  // should fail here, not at the first boot on a fresh box.
+  for (const r of repos) {
+    const probe = await git(
+      ["ls-remote", "--heads", "--tags", r.url, ...(r.ref ? [r.ref] : [])],
+      30_000,
+    )
+    if (probe.code !== 0) bad(`repo ${repoSlug(r.url)}`, probe.err.slice(0, 120) || "unreachable")
+    else if (r.ref && !probe.out) bad(`repo ${repoSlug(r.url)}`, `ref "${r.ref}" not found`)
+    else ok(`repo ${repoSlug(r.url)}`, r.ref ?? "default branch")
   }
 
   // A missing cwd makes spawn fail with the same ENOENT as a missing binary —

--- a/packages/cli/test/config.test.js
+++ b/packages/cli/test/config.test.js
@@ -127,9 +127,12 @@ describe("scaffold", () => {
     expect(names).toContain("context/references/example.md")
     expect(names).toContain("context/.mcp.json")
     expect(names).toContain("context/.env.example")
-    // .env and the minted agent token must never reach git.
+    // .env, the minted agent token, and the clone workspace must never reach git.
     expect(files[".gitignore"]).toContain("context/.env")
     expect(files[".gitignore"]).toContain(".derive/")
+    expect(files[".gitignore"]).toContain("context/repos/")
+    // The repo-pointer example ships commented out — scaffolds must parse to zero repos.
+    expect(files["context/MANIFEST.md"]).toContain("# repos:")
     const cfg = JSON.parse(files[CONFIG_FILE])
     expect(cfg.entry).toBe("context")
     expect(cfg.context).toEqual({ id: null, agent_id: null, name: "Analytics" })

--- a/packages/cli/test/publish.test.js
+++ b/packages/cli/test/publish.test.js
@@ -32,6 +32,20 @@ describe("collectDir", () => {
     ])
     expect(skipped.sort()).toEqual([".env", ".env.production", "references/.env"])
   })
+
+  it("skipTopDirs drops the runner's clone workspace at the top level only", () => {
+    const d = tmp()
+    mkdirSync(join(d, "repos", "acme-eda"), { recursive: true })
+    mkdirSync(join(d, "references", "repos"), { recursive: true })
+    writeFileSync(join(d, "MANIFEST.md"), "# m")
+    writeFileSync(join(d, "repos", "acme-eda", "big.md"), "clone contents")
+    writeFileSync(
+      join(d, "references", "repos", "note.md"),
+      "a doc that happens to be named repos/",
+    )
+    const { files } = collectDir(d, d, undefined, ["repos"])
+    expect(Object.keys(files).sort()).toEqual(["MANIFEST.md", "references/repos/note.md"])
+  })
 })
 
 describe("readTarget", () => {

--- a/packages/cli/test/runner.test.js
+++ b/packages/cli/test/runner.test.js
@@ -1,4 +1,5 @@
-import { mkdtempSync, writeFileSync } from "node:fs"
+import { execSync } from "node:child_process"
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { describe, expect, it } from "vitest"
@@ -7,7 +8,11 @@ import {
   loadRunnerConfig,
   OUTPUT_CONTRACT,
   parseAnswer,
+  parseManifest,
   renderServiceUnit,
+  repoCatalogBlock,
+  repoSlug,
+  syncRepos,
 } from "../src/runner.js"
 
 describe("parseAnswer", () => {
@@ -141,6 +146,89 @@ describe("loadRunnerConfig", () => {
     )
     expect(cfg.manifestFile).toBe("/work/context/MANIFEST.md")
   })
+})
+
+describe("repo pointers", () => {
+  it("parses repos out of frontmatter and strips it from the prompt body", () => {
+    const md = `---
+repos:
+  - url: https://github.com/churnkey/churnkey-labs
+    ref: main
+    description: "the eda corpus"
+  - url: git@github.com:acme/private-notes.git
+other_key: ignored
+---
+
+# The manifest body`
+    const { body, repos } = parseManifest(md)
+    expect(body).toBe("\n# The manifest body")
+    expect(repos).toEqual([
+      {
+        url: "https://github.com/churnkey/churnkey-labs",
+        ref: "main",
+        description: "the eda corpus",
+      },
+      { url: "git@github.com:acme/private-notes.git", ref: null, description: "" },
+    ])
+  })
+
+  it("passes a manifest without frontmatter through untouched", () => {
+    expect(parseManifest("# Plain")).toEqual({ body: "# Plain", repos: [] })
+  })
+
+  it("the scaffolded example stays inert (commented) and junk urls are dropped", () => {
+    const commented = "---\n# repos:\n#   - url: https://github.com/you/x\n---\nbody"
+    expect(parseManifest(commented).repos).toEqual([])
+    const junk = "---\nrepos:\n  - url: not-a-url\n---\nbody"
+    expect(parseManifest(junk).repos).toEqual([])
+  })
+
+  it("slugs are owner-repo so same-named repos from different owners don't collide", () => {
+    expect(repoSlug("https://github.com/churnkey/eda")).toBe("churnkey-eda")
+    expect(repoSlug("https://github.com/acme/eda.git")).toBe("acme-eda")
+    expect(repoSlug("git@github.com:acme/eda.git")).toBe("acme-eda")
+  })
+
+  it("the catalog block names what's on disk and states what isn't", () => {
+    expect(repoCatalogBlock([])).toBe("")
+    const block = repoCatalogBlock([
+      { url: "https://github.com/a/ok", ref: "main", description: "docs", sha: "ab12cd34ef56" },
+      { url: "https://github.com/a/gone", ref: null, description: "", sha: null },
+    ])
+    expect(block).toContain("repos/a-ok — docs (main @ ab12cd34ef56)")
+    expect(block).toContain("repos/a-gone")
+    expect(block).toContain("UNAVAILABLE")
+  })
+
+  it("syncRepos clones at boot and follows the tip on the next boot", async () => {
+    const src = mkdtempSync(join(tmpdir(), "runner-repo-src-"))
+    const cwd = mkdtempSync(join(tmpdir(), "runner-repo-cwd-"))
+    const sh = (cmd) => execSync(cmd, { cwd: src, stdio: "pipe" })
+    sh("git init -q -b main && git config user.email t@t && git config user.name t")
+    writeFileSync(join(src, "notes.md"), "v1")
+    sh("git add . && git commit -qm one")
+    const repos = [{ url: `file://${src}`, ref: "main", description: "notes" }]
+
+    const first = await syncRepos(repos, cwd)
+    expect(first[0].sha).toMatch(/^[0-9a-f]{12}$/)
+    expect(readFileSync(join(cwd, "repos", repoSlug(repos[0].url), "notes.md"), "utf8")).toBe("v1")
+
+    writeFileSync(join(src, "notes.md"), "v2")
+    sh("git add . && git commit -qm two")
+    const second = await syncRepos(repos, cwd)
+    expect(second[0].sha).not.toBe(first[0].sha)
+    expect(readFileSync(join(cwd, "repos", repoSlug(repos[0].url), "notes.md"), "utf8")).toBe("v2")
+  }, 30_000)
+
+  it("a dead pointer is loud but non-fatal: catalog entry with sha null", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "runner-repo-cwd-"))
+    const out = await syncRepos(
+      [{ url: "file:///nonexistent/repo", ref: null, description: "" }],
+      cwd,
+    )
+    expect(out).toHaveLength(1)
+    expect(out[0].sha).toBeNull()
+  }, 30_000)
 })
 
 describe("output contract + service units", () => {


### PR DESCRIPTION
Sprint 1 item 4 (plan bzjg35x0): the load-bearing off-laptop piece — the Analytics context's eda corpus stops being Rob's Mac and starts being a pointer any box can materialize.

## Where pointers live (one deviation from the plan)

The plan said `derive.json`, but `derive.json` never travels with a push. Pointers live in **MANIFEST.md frontmatter** instead:

```yaml
---
repos:
  - url: https://github.com/churnkey/churnkey-labs
    ref: main
    description: the eda corpus — notebooks + metric definitions
---
```

Three properties fall out: pointers **version with the judgment they support**, they reach the runner through `manifest_md` itself (a bare `derive runner serve <ctx>` on a fresh box learns them from the server — nothing on disk first), and `context dev` picks them up from the working tree like everything else.

## Behavior

- **Boot**: shallow clone (or fetch + detach at the ref tip) into `<cwd>/repos/<owner-repo>`; SHAs logged. Sync is boot-only — mid-run re-clones would change corpus SHAs between answers in one session.
- **Prompt**: a repo catalog (path, description, ref @ SHA) is appended to every system prompt — from the boot sync, so the prompt only ever claims what's actually on disk. A failed pointer is loud but **non-fatal**, and the catalog marks it UNAVAILABLE so the model says so — a silent gap would read as "the corpus has nothing on this", which is a wrong answer, not a missing one.
- **Provenance**: answer meta carries `repos: [{url, sha}]` — the difference between "the data says X" and "the data as of ab12cd3 says X".
- **Doctor**: `git ls-remote` probes each pointer (URL typo, missing auth, bad ref) at preflight instead of first boot.
- **Hygiene**: `context push` excludes top-level `repos/` (clone workspace, never source); the scaffold's .gitignore covers it; private-repo auth rides whatever git already has on the host.

The frontmatter parser is deliberately narrow — only the `repos:` list is read, the scaffold example ships commented-out (parses to zero repos), junk URLs are dropped.

## Also

Two #316 stragglers: the runner's `publishArtifact` comment still argued for the retired link visibility, and the publish summary still advised `--visibility link`.

## Verified

- 54 CLI tests (incl. real-git integration: clone at boot, tip-follow on next boot, dead pointer → sha null) + full ci + typecheck
- Live smoke: `context dev --mock` with a file:// pointer — parsed from the working-tree manifest, cloned into `context/repos/`, SHA logged