### PR TITLE
feat(deploy): the runner container — owner-operated compute in a box

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,22 @@ jobs:
       - name: Bundle budget
         run: pnpm lint:bundle
 
+  # The runner image builds from packages/cli — this catches a CLI change that
+  # breaks the container (deps, bin layout) before someone finds out on a box.
+  # Build-only, non-gating like coverage/bundle; no registry push.
+  runner-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Build runner image
+        run: docker build -f deploy/runner.Dockerfile -t derive-runner:ci .
+      - name: Runner starts and reports config errors cleanly
+        # No token/context on purpose: a healthy image exits 1 with the house
+        # one-liner, not a stack trace — proves node, the CLI, and its deps wired.
+        run: |
+          out=$(docker run --rm derive-runner:ci serve 2>&1) && exit 1 || true
+          echo "$out" | grep -q "error: a context id and an agent token are required"
+
   # CD: ship main to the hosted tier (Workers + Hyperdrive/Neon, derive.to) once
   # check/pg/d1 + security pass. Schemas (D1 + Postgres) land BEFORE the worker
   # flips, so a new version never serves against stale DDL. Coverage/bundle stay

--- a/deploy/runner-entrypoint.sh
+++ b/deploy/runner-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# GH_TOKEN → git credential helper, so private repo pointers clone at boot.
+# No-op without the token; failure is non-fatal (public pointers still work,
+# and doctor's ls-remote probe reports exactly which pointer can't auth).
+if [ -n "$GH_TOKEN" ]; then
+  gh auth setup-git 2>/dev/null || true
+fi
+exec derive runner "$@"

--- a/deploy/runner.Dockerfile
+++ b/deploy/runner.Dockerfile
@@ -1,0 +1,49 @@
+# The context runner, containerized — owner-operated compute in a box. The
+# container boundary IS the sandbox: the model runs headless with permissions
+# skipped inside, so the walls are the image contents, the mounted context dir,
+# and the env you hand it. Derive-the-company still holds no keys.
+#
+# Config is purely environment (12-factor): DERIVE_SERVER / DERIVE_CONTEXT /
+# DERIVE_TOKEN, RUNNER_MODEL / RUNNER_TIMEOUT_MS / RUNNER_POLL_MS,
+# ANTHROPIC_API_KEY (the model), GH_TOKEN (private repo pointers + gh), plus
+# whatever the context's .mcp.json expects. See runner.compose.example.yml.
+FROM node:24-slim
+
+# git: repo pointers clone at boot. python3 + gh: what context manifests most
+# commonly shell out to (doctor checks both, warn-only).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl git python3 \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+       -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Claude Code from npm (pin via build arg when reproducibility matters more
+# than freshness); the Derive CLI from THIS checkout, so the image always runs
+# the runner that shipped with the repo that built it — no npm-publish lag.
+ARG CLAUDE_CODE_VERSION=latest
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+COPY packages/cli /opt/derive-cli
+# Global-install of a directory symlinks it without installing its deps —
+# install them in place first.
+RUN cd /opt/derive-cli && npm install --omit=dev && npm install -g /opt/derive-cli
+
+# Non-root: the container is the boundary, but the model still runs with
+# --dangerously-skip-permissions inside it — no reason for that to be root.
+RUN useradd -m runner && mkdir -p /work && chown runner:runner /work
+COPY --chmod=755 deploy/runner-entrypoint.sh /usr/local/bin/runner-entrypoint.sh
+USER runner
+
+# /work is the context directory. Mount the cloned context project's context/
+# dir here (compose example) so .mcp.json, references/, and the repos/ clone
+# cache travel by git + volume, never by image rebuild. Unmounted also works:
+# the manifest and repo pointers still arrive from the server — the context
+# just has no local .mcp.json tools.
+WORKDIR /work
+ENV RUNNER_CWD=/work
+
+ENTRYPOINT ["runner-entrypoint.sh"]
+# `docker compose run --rm <svc> doctor` preflights the exact same image + env.
+CMD ["serve"]

--- a/deploy/runner.Dockerfile.dockerignore
+++ b/deploy/runner.Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+# Scoped to runner.Dockerfile (BuildKit per-Dockerfile ignore): the image only
+# needs the CLI package + the entrypoint, so don't ship the monorepo to the daemon.
+*
+!packages/cli
+!deploy/runner-entrypoint.sh
+packages/cli/node_modules

--- a/deploy/runner.compose.example.yml
+++ b/deploy/runner.compose.example.yml
@@ -1,0 +1,27 @@
+# One runner service per context. Copy, rename per context, and fill in:
+#
+#   docker compose -f runner.compose.example.yml run --rm analytics doctor
+#   docker compose -f runner.compose.example.yml up -d analytics
+#
+# The env file carries the secrets (never in this file, never in the image):
+#   DERIVE_TOKEN=dk_agt_…          the context's agent token
+#   ANTHROPIC_API_KEY=sk-ant-…     the model
+#   GH_TOKEN=ghp_…                 private repo pointers + gh (optional)
+#   …plus whatever the context's .mcp.json expects
+services:
+  analytics:
+    build:
+      context: ..
+      dockerfile: deploy/runner.Dockerfile
+    restart: unless-stopped
+    environment:
+      DERIVE_CONTEXT: ctx_change_me
+      # RUNNER_MODEL: sonnet
+      # RUNNER_TIMEOUT_MS: "600000"
+    env_file:
+      - ./analytics.env
+    volumes:
+      # The cloned context project's context/ dir: .mcp.json, references/, and
+      # the repos/ clone cache (persists across restarts). Optional — without
+      # it the manifest + repo pointers still arrive from the server.
+      - /srv/contexts/analytics/context:/work


### PR DESCRIPTION
Sprint 1 item 5 (plan bzjg35x0): the container boundary replaces the deferred macOS-user containment — it IS the sandbox the headless `--dangerously-skip-permissions` run lives inside. Owner-operated compute stays the line: derive-the-company holds no keys.

## The image (`deploy/runner.Dockerfile`)

node:24-slim + **git** (repo pointers clone at boot) + **gh** + **python3** + **Claude Code** (npm, pinnable via `CLAUDE_CODE_VERSION`) + the **Derive CLI installed from this checkout** — the image always runs the runner that shipped with the repo that built it, no npm-publish lag. Non-root. Config is purely env (12-factor): `DERIVE_CONTEXT`/`DERIVE_TOKEN`, `RUNNER_*`, `ANTHROPIC_API_KEY`, `GH_TOKEN`, plus whatever the context's `.mcp.json` expects.

- **`/work` is the context dir** — compose mounts the cloned context project's `context/` there, so `.mcp.json`, `references/`, and the `repos/` clone cache travel by git + volume, never by image rebuild. Unmounted also works: manifest + repo pointers arrive from the server regardless.
- **Entrypoint** wires `GH_TOKEN` into git's credential helper so private pointers clone; no-op without it.
- **`runner.compose.example.yml`**: one service per context; secrets ride an env file; `docker compose run --rm <svc> doctor` preflights the exact image + env that will serve.
- **Per-Dockerfile `.dockerignore`** (BuildKit) ships only `packages/cli` + the entrypoint to the daemon — the app image's build context is untouched.
- **CI**: build-only `runner-image` job + a start smoke — a healthy image exits 1 with the house config one-liner, proving node + CLI + deps are wired. Non-gating, like coverage/bundle.

## Verified locally

- `doctor` inside the container: all six checks green against the live Analytics context
- mock `serve` boots and polls from inside the container
- the CI smoke assertion reproduced locally

## Sets up item 6 (Hetzner migration)

The box needs: docker, a clone of each context project, an env file per context (`DERIVE_TOKEN`, `ANTHROPIC_API_KEY` — note: the Mac daemons ride Claude subscription auth today, so the container path needs a real API key — and `GH_TOKEN` if pointers go private), then `compose up -d`.