### PR TITLE
Comments bell their natural audience: your threads and your content, on both paths

### DIFF
--- a/apps/api/src/lib/notify-comment.ts
+++ b/apps/api/src/lib/notify-comment.ts
@@ -1,0 +1,64 @@
+// Bell fan-out for a new comment. Kept out of the route handlers so the HTTP and
+// MCP comment paths share one recipient policy (they drifted before: MCP comments
+// reached no one without an open tab).
+//
+// A comment bells you when it lands on YOUR territory:
+//   - you authored an earlier comment in the thread (you're in the conversation), or
+//   - you hold an owner row on the artifact (it's your content — the owner row is
+//     written at publish for the human behind it, agents' on-behalf work included).
+// The comment's author never hears about themselves, and anyone already covered by
+// a stronger mention row is skipped. Bell only — email is reserved for interrupts
+// (mentions / review requests / shares; see notify-email.ts).
+
+import type { ArtifactRecord, CommentRecord, MetaStore } from "@derive/core"
+import { newId } from "@derive/core"
+import type { Backplane } from "../bus"
+import { previewOf } from "./comments"
+
+export interface CommentBellDeps {
+  meta: MetaStore
+  bus: Backplane
+}
+
+/** Create + stream the bell rows for one comment. Best-effort: callers run it in
+ *  background() so a lookup failure never reaches the request. */
+export const notifyCommentBells = async (
+  deps: CommentBellDeps,
+  artifact: ArtifactRecord,
+  comment: CommentRecord,
+  opts: { mentionIds: Set<string>; actorId: string | null },
+): Promise<void> => {
+  const { meta, bus } = deps
+
+  const participants = (await meta.listComments(artifact.id))
+    .filter((c) => c.thread_id === comment.thread_id && c.author_id)
+    .map((c) => c.author_id as string)
+  const owners = (await meta.listArtifactMembers(artifact.id))
+    .filter((m) => m.role === "owner")
+    .map((m) => m.user_id)
+
+  const recipients = new Set<string>([...participants, ...owners])
+  recipients.delete("")
+  if (opts.actorId) recipients.delete(opts.actorId)
+  for (const id of opts.mentionIds) recipients.delete(id)
+
+  for (const uid of recipients) {
+    const row = {
+      id: newId("n"),
+      user_id: uid,
+      actor: comment.author,
+      kind: "comment" as const,
+      artifact_id: artifact.id,
+      artifact_short_id: artifact.short_id,
+      artifact_title: artifact.title,
+      thread_id: comment.thread_id,
+      comment_id: comment.id,
+      preview: previewOf(comment.body_md),
+    }
+    await meta.createNotification(row)
+    bus.publish(`u:${uid}`, {
+      type: "notification",
+      notification: { ...row, read: 0, created_at: new Date().toISOString() },
+    })
+  }
+}

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -48,6 +48,7 @@ import {
 } from "./lib/bundle"
 import { parseMeta, quoteOf, REACTIONS } from "./lib/comments"
 import { buildReviewEmail } from "./lib/email"
+import { notifyCommentBells } from "./lib/notify-comment"
 import { enqueueChannelDelivery } from "./webhooks"
 
 const text = (s: string) => ({ content: [{ type: "text" as const, text: s }] })
@@ -519,6 +520,15 @@ function buildServer(
           author_id: agent.id,
         })
         ctx.bus.publish(a.id, { type: "comment.created" })
+        // Same bell fan-out as the HTTP route: thread participants + the
+        // artifact's owners hear the agent's reply even with no tab open.
+        // (Previously this path belled no one.) The MCP tool has no mentions.
+        const created = await ctx.meta.getComment(commentId)
+        if (created)
+          await notifyCommentBells({ meta: ctx.meta, bus: ctx.bus }, a, created, {
+            mentionIds: new Set(),
+            actorId: agent.id,
+          })
       }
       // The ack: land the emoji on the thread's newest comment by someone ELSE
       // (the human being acknowledged), falling back to its newest comment.

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -20,6 +20,7 @@ import {
 } from "../lib/comments"
 import { enqueueGithubPrComment } from "../lib/github-comments"
 import { fail, readJson } from "../lib/http"
+import { notifyCommentBells } from "../lib/notify-comment"
 import { enqueueCommentEmails } from "../lib/notify-email"
 import { enqueueSlackComment } from "../lib/slack-comments"
 
@@ -220,35 +221,12 @@ export const commentRoutes = (ctx: AppContext) => {
             quote: quoteOf(created.anchor),
             thread_id: created.thread_id,
           })
-        // A reply reaches the thread's earlier authors as a bell row (email is
-        // mention-only — see notify-email.ts). Mentioned people already got the
-        // stronger mention row above; the author never hears about themselves.
-        const mentionIds = new Set(mentions.map((m) => m.id))
-        const participants = new Set(
-          (await meta.listComments(artifact.id))
-            .filter((cm) => cm.thread_id === created.thread_id && cm.author_id)
-            .map((cm) => cm.author_id as string),
-        )
-        for (const uid of participants) {
-          if (uid === (acting?.id ?? null) || mentionIds.has(uid)) continue
-          const row = {
-            id: newId("n"),
-            user_id: uid,
-            actor: created.author,
-            kind: "comment" as const,
-            artifact_id: artifact.id,
-            artifact_short_id: artifact.short_id,
-            artifact_title: artifact.title,
-            thread_id: created.thread_id,
-            comment_id: created.id,
-            preview: previewOf(created.body_md),
-          }
-          await meta.createNotification(row)
-          bus.publish(`u:${uid}`, {
-            type: "notification",
-            notification: { ...row, read: 0, created_at: new Date().toISOString() },
-          })
-        }
+        // Bell the comment's natural audience — thread participants + the
+        // artifact's owners (your content) — shared with the MCP path.
+        await notifyCommentBells({ meta, bus }, artifact, created, {
+          mentionIds: new Set(mentions.map((m) => m.id)),
+          actorId: acting?.id ?? null,
+        })
         // Channel fan-out is gated per workspace (Settings -> integrations toggles).
         const settings = await meta.getOrgSettings(artifact.org_id)
         if (settings.emailNotifications)

--- a/apps/api/test/comment-fanout.test.ts
+++ b/apps/api/test/comment-fanout.test.ts
@@ -52,7 +52,7 @@ describe("comment channel fan-out", () => {
     expect(kinds).not.toContain("email")
   })
 
-  it("a reply reaches earlier thread authors as a bell row, and only them", async () => {
+  it("a reply bells earlier thread authors; the replier never hears themselves", async () => {
     const { app, meta } = makeAuthedApp("fanout-bell", [owner, editor], "editor")
     const shortId = await newArtifact(app)
     // Owner opens the thread; editor replies into it.
@@ -62,13 +62,22 @@ describe("comment channel fan-out", () => {
       jsonAs(as(editor.email), { body_md: "replying", thread_id: first.thread_id }),
     )
     const rows = await meta.listNotifications(owner.id, 10)
-    const reply = rows.find((n) => n.kind === "comment")
+    const reply = rows.find((n) => n.kind === "comment" && n.thread_id === first.thread_id)
     expect(reply).toBeTruthy()
-    expect(reply?.thread_id).toBe(first.thread_id)
     // The replier never hears about their own comment.
     expect((await meta.listNotifications(editor.id, 10)).map((n) => n.kind)).not.toContain(
       "comment",
     )
+  })
+
+  it("a fresh comment on your artifact bells you — it's your content", async () => {
+    const { app, meta } = makeAuthedApp("fanout-owner-bell", [owner, editor], "editor")
+    const shortId = await newArtifact(app)
+    // Editor opens a NEW thread (owner has no comment in it, no mention).
+    const res = await comment(app, shortId, editor.email)
+    expect(res.status).toBe(201)
+    const rows = await meta.listNotifications(owner.id, 10)
+    expect(rows.some((n) => n.kind === "comment")).toBe(true)
   })
 
   it("a mention emails the mentioned person (and no one else)", async () => {

--- a/apps/api/test/mcp-loop.test.ts
+++ b/apps/api/test/mcp-loop.test.ts
@@ -348,3 +348,21 @@ describe("catch_up `wait` long-poll", () => {
     expect((out.review as { state: string }).state).toBe("pending")
   })
 })
+
+describe("comment bells (the MCP path)", () => {
+  it("an agent's comment on the human's artifact bells them — parity with HTTP", async () => {
+    const { app, meta, token } = loopApp("comment-bell")
+    const created = await call(app, token, "publish", {
+      content: "<h1>Doc</h1>",
+      title: "Doc",
+    })
+    // The publish itself belled u_o (kind publish/review); an agent COMMENT on
+    // the doc must too — before the shared fan-out, this path belled no one.
+    await call(app, token, "comment", {
+      short_id: created.short_id,
+      body: "I have a question about the intro.",
+    })
+    const rows = await meta.listNotifications("u_o", 10)
+    expect(rows.some((n) => n.kind === "comment")).toBe(true)
+  })
+})


### PR DESCRIPTION
## Why

#318 reserved email for interrupts and gave thread replies bell rows — but two bell gaps remained. A fresh comment on **your own artifact** reached you only if you were mentioned or already in the thread. And the **MCP comment tool belled no one at all**: an agent replying to your review feedback was invisible unless you had a tab open on that artifact.

## What changed

One shared fan-out (`lib/notify-comment.ts`) now serves both the HTTP comment route and the MCP comment tool. A comment bells you when it lands on your territory:

- you authored an earlier comment in the thread (you're in the conversation), or
- you hold an owner row on the artifact (it's your content — covers agents' on-behalf publishes, since the owner row is written for the human behind them).

The author never hears about themselves; anyone covered by a stronger mention row is skipped. **Email policy is untouched** — these are bell rows only (the bell UI already renders the `comment` kind).

## Testing

- comment-fanout: a fresh comment on your artifact bells you; replies bell earlier thread authors and never the replier.
- mcp-loop: an agent's comment via the MCP tool bells the human it acts for — pinned as the parity regression test (this path previously created zero rows).
- Full API suite: 702 green; typecheck + lint gates clean.