### PR TITLE
feat(auth): derive:manage scope — context push wires itself from the CLI

### DIFF
--- a/apps/api/src/auth-config.ts
+++ b/apps/api/src/auth-config.ts
@@ -75,6 +75,7 @@ export const OAUTH_SCOPES = [
   "derive:propose",
   "derive:publish",
   "derive:review",
+  "derive:manage",
 ] as const
 
 // How long an anonymous DCR-registered client (a headless agent that self-registered

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -362,6 +362,11 @@ export function buildContext(deps: AppDeps) {
   // human the agent acts for, resolved in lockstep and surfaced on the agent Principal.
   const agentCache = new WeakMap<Context, AgentRecord | null>()
   const onBehalfOfCache = new WeakMap<Context, string | null>()
+  // The OAuth grant behind an agent principal, when there is one — registered
+  // dk_agt_ tokens leave this unset. Managemently-scoped routes read it to tell
+  // the two apart: a grant carries the consenting user's scopes; a registered
+  // token carries only a runtime role.
+  const oauthGrantCache = new WeakMap<Context, { ownerId: string; scopeRole: Role }>()
   const agentFor = async (c: Context): Promise<AgentRecord | null> => {
     if (agentCache.has(c)) return agentCache.get(c) ?? null
     const b = bearer(c)
@@ -381,6 +386,7 @@ export function buildContext(deps: AppDeps) {
         if (o) {
           a = o.rec
           owner = o.ownerId
+          oauthGrantCache.set(c, { ownerId: o.ownerId, scopeRole: o.scopeRole })
           // An OAuth agent may act in any workspace its granting user belongs to:
           // an explicit X-Derive-Workspace header, validated against the OWNER's
           // membership, re-homes the agent record itself — so activeWorkspace AND
@@ -408,6 +414,21 @@ export function buildContext(deps: AppDeps) {
   // A thin read of the one Principal, so the delegation rule lives in exactly one place.
   const privateOwnerId = async (c: Context): Promise<string | null> =>
     principalOwnerId(await resolvePrincipal(c))
+
+  // The human allowed to MANAGE through this request: a signed-in user, or an
+  // OAuth grant whose scopes reach manage-grade (scopeRole owner — only
+  // derive:manage maps there), acting as its grantor. Registered dk_agt_ tokens
+  // are runtime principals (answer sessions, publish charts) and never
+  // management ones — a stolen runner token must not be able to rewire or tear
+  // down the surfaces it serves. Capability gates still apply on top: the
+  // grant's role stays capped by the grantor's actual membership.
+  const managementPrincipal = async (c: Context): Promise<string | null> => {
+    const me = await currentUser(c)
+    if (me) return me.id
+    await agentFor(c) // resolves the bearer and fills the grant cache
+    const grant = oauthGrantCache.get(c)
+    return grant && grant.scopeRole === "owner" ? grant.ownerId : null
+  }
 
   // The acting identity (agent or signed-in user) for authorship bylines; null when
   // anonymous. Agents author as their name, never spoofing a person. Also a Principal read.
@@ -706,6 +727,7 @@ export function buildContext(deps: AppDeps) {
     resolvePrincipal,
     actingUser,
     privateOwnerId,
+    managementPrincipal,
     limited,
     overStorage,
     ensureMembership,

--- a/apps/api/src/lib/oauth-agent.ts
+++ b/apps/api/src/lib/oauth-agent.ts
@@ -41,12 +41,17 @@ export function makeOauthAgent({
 }: OauthAgentDeps) {
   // The least-privilege role an OAuth-granted scope set maps to: publish/review earn
   // editor; propose/comment earn commenter; read alone is viewer.
+  // derive:manage maps to owner-grade, but scopeRole is always capped by the
+  // grantor's ACTUAL membership role (capRole below) — the scope can widen what
+  // the grant may attempt, never what the human could do themselves.
   const roleFromScopes = (scopes: string[]): Role =>
-    scopes.includes("derive:publish") || scopes.includes("derive:review")
-      ? "editor"
-      : scopes.includes("derive:propose") || scopes.includes("derive:comment")
-        ? "commenter"
-        : "viewer"
+    scopes.includes("derive:manage")
+      ? "owner"
+      : scopes.includes("derive:publish") || scopes.includes("derive:review")
+        ? "editor"
+        : scopes.includes("derive:propose") || scopes.includes("derive:comment")
+          ? "commenter"
+          : "viewer"
 
   // The workspace the agent runs in, and the owner's membership role there (the
   // cap on the scope-derived role). Precedence: the workspace the user picked on

--- a/apps/api/src/oauth-consent.ts
+++ b/apps/api/src/oauth-consent.ts
@@ -18,6 +18,7 @@ const SCOPE_LABELS: Record<string, string> = {
   "derive:propose": "Propose new versions (you approve before they go live)",
   "derive:publish": "Publish new versions directly",
   "derive:review": "Approve or request changes on proposals",
+  "derive:manage": "Manage agents and contexts (only as far as your workspace role allows)",
 }
 
 // Scopes that let the agent change something get a distinct accent tick; read-only
@@ -27,6 +28,7 @@ const WRITE_SCOPES = new Set([
   "derive:propose",
   "derive:publish",
   "derive:review",
+  "derive:manage",
 ])
 
 const esc = (s: string): string =>

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -8,7 +8,7 @@ import { fail, readJson } from "../lib/http"
 
 /** Agent registry (Admin-managed) + the agent's pull inbox of @mentions. */
 export const agentRoutes = (ctx: AppContext) => {
-  const { meta, activeWorkspace, agentFor, currentUser, requireUser, workspaceCan } = ctx
+  const { meta, activeWorkspace, agentFor, privateOwnerId, requireUser, workspaceCan } = ctx
   const app = new Hono()
 
   const agentJson = (a: AgentRecord) => ({
@@ -52,7 +52,9 @@ export const agentRoutes = (ctx: AppContext) => {
         role,
         // The agent publishes on behalf of whoever registered it: their id keys
         // attribution (author_id) and ownership (the owner-member row) at publish.
-        created_by: (await currentUser(c))?.id ?? null,
+        // privateOwnerId so a `derive context push` registration (an OAuth agent
+        // with the manage scope) attributes to the GRANTOR, not to nobody.
+        created_by: (await privateOwnerId(c)) ?? null,
       })
       // The only place the raw token is ever exposed.
       return c.json({ ...agentJson(agent), token }, 201)

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -26,6 +26,7 @@ export const contextRoutes = (ctx: AppContext) => {
     agentFor,
     authorize,
     currentUser,
+    managementPrincipal,
     requireUser,
     sourceText,
     workspaceCan,
@@ -85,8 +86,14 @@ export const contextRoutes = (ctx: AppContext) => {
   // workspace, and share-standing on the manifest — creating a context makes the
   // manifest's roster govern who can ask, which is a sharing decision.
   app.post("/v1/contexts", async (c) => {
-    const me = await requireUser(c)
-    if (me instanceof Response) return me
+    // Management principals only: a signed-in user, or an OAuth grant carrying
+    // derive:manage (`derive context push`) acting as its grantor — that human
+    // keys created_by. Registered dk_agt_ runner tokens are deliberately NOT
+    // accepted here (nor on list/delete): they're runtime principals, and a
+    // stolen one must not be able to rewire ask surfaces. The capability gate
+    // still applies on top with the grant's membership-capped role.
+    const owner = await managementPrincipal(c)
+    if (!owner) return fail(c, 401, "unauthenticated")
     if (!(await workspaceCan(c, "publish"))) return fail(c, 403, "forbidden")
     const b = await readJson(
       c,
@@ -110,7 +117,7 @@ export const contextRoutes = (ctx: AppContext) => {
         name: b.name,
         agent_id: b.agent_id,
         manifest_artifact_id: manifest.id,
-        created_by: me.id,
+        created_by: owner,
       })
       return c.json(contextJson(created, manifest.short_id), 201)
     } catch {
@@ -119,8 +126,10 @@ export const contextRoutes = (ctx: AppContext) => {
   })
 
   app.get("/v1/contexts", async (c) => {
-    const me = await requireUser(c)
-    if (me instanceof Response) return me
+    // Management principals only (see POST): the list exposes every context's
+    // wiring (agent ids, creators), which GET /:id deliberately hides from
+    // agents that aren't the context's own.
+    if (!(await managementPrincipal(c))) return fail(c, 401, "unauthenticated")
     if (!(await workspaceCan(c, "read"))) return fail(c, 403, "forbidden")
     const rows = await meta.listContexts(await activeWorkspace(c))
     const contexts = await Promise.all(
@@ -161,15 +170,18 @@ export const contextRoutes = (ctx: AppContext) => {
   })
 
   app.delete("/v1/contexts/:id", async (c) => {
-    const me = await requireUser(c)
-    if (me instanceof Response) return me
+    // Management principals only (see POST) — the created_by match below must
+    // never be reachable by the runner's own token, whose registrant usually
+    // IS the context creator.
+    const owner = await managementPrincipal(c)
+    if (!owner) return fail(c, 401, "unauthenticated")
     const x = await meta.getContext(c.req.param("id"))
     // workspaceCan reads the CALLER's active workspace, so it only authorizes
     // deletes of that workspace's contexts — without the org check, a manager of
     // workspace B would pass it and reach into workspace A. Cross-workspace
     // callers get the same 404 as a missing id.
     if (!x || x.org_id !== (await activeWorkspace(c))) return fail(c, 404, "not found")
-    if (x.created_by !== me.id && !(await workspaceCan(c, "manage")))
+    if (x.created_by !== owner && !(await workspaceCan(c, "manage")))
       return fail(c, 403, "forbidden")
     await meta.deleteContext(x.id, x.org_id)
     return c.body(null, 204)

--- a/apps/api/test/oauth-agent-role-cap.test.ts
+++ b/apps/api/test/oauth-agent-role-cap.test.ts
@@ -51,6 +51,17 @@ describe("oauth agent role capping + consent binding", () => {
     expect(o?.scopeRole).toBe("editor") // uncapped, for header re-homes to re-cap
   })
 
+  it("derive:manage proposes owner — and the membership ceiling still holds", async () => {
+    const manage = { ...grant, scopes: ["openid", "derive:read", "derive:manage"] }
+    const asOwner = await resolve(stub({ getOAuthGrant: async () => manage }))
+    expect(asOwner?.scopeRole).toBe("owner")
+    expect(asOwner?.rec.role).toBe("owner") // owner membership → the scope holds
+    const asViewer = await resolve(
+      stub({ getOAuthGrant: async () => manage, getOAuthClientWorkspace: async () => "ws_two" }),
+    )
+    expect(asViewer?.rec.role).toBe("viewer") // manage scope can't outrank the human
+  })
+
   it("ignores a binding to a workspace the user is no longer in", async () => {
     const o = await resolve(stub({ getOAuthClientWorkspace: async () => "ws_gone" }))
     expect(o?.rec.org_id).toBe("ws_one")

--- a/apps/api/test/oauth-consent.test.ts
+++ b/apps/api/test/oauth-consent.test.ts
@@ -16,6 +16,16 @@ describe("oauth consent screen", () => {
     expect(html).toContain("Propose new versions")
   })
 
+  it("labels the manage scope — a manage-grade grant must never render as an unknown blob", () => {
+    const managed = consentHTML({
+      clientName: "Derive CLI",
+      scopes: ["openid", "derive:manage"],
+      query: "",
+    })
+    expect(managed).toContain("Manage agents and contexts")
+    expect(managed).toContain("only as far as your workspace role allows")
+  })
+
   it("ships the branded post-approve confirmation card + the goConnected handoff", () => {
     expect(html).toContain("var CONNECTED =")
     expect(html).toContain("function goConnected(")

--- a/apps/api/test/oauth-context-management.test.ts
+++ b/apps/api/test/oauth-context-management.test.ts
@@ -1,0 +1,192 @@
+import { join } from "node:path"
+import { SqliteMetaStore } from "@derive/db/sqlite"
+import { FsBlobStore } from "@derive/storage/fs"
+import Database from "better-sqlite3"
+import { describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { sha256 } from "../src/lib/crypto"
+import { dir, pub } from "./helpers"
+
+// `derive context push` end to end over OAuth: an access token with the
+// derive:manage scope, held by a workspace admin, can mint the answering agent
+// and create the context — attributed to the GRANTOR, exactly like publish.
+// The two ceilings hold independently: no manage scope → 403 regardless of
+// membership; manage scope but non-admin membership → 403 regardless of scope.
+describe.skipIf(process.env.DERIVE_TEST_DB === "pg")("OAuth context management", () => {
+  // One workspace; u_admin owns it, u_editor is an editor. Three grants:
+  // tok_full (admin + manage), tok_nomanage (admin, publish-only scopes),
+  // tok_editor (editor + manage).
+  function managedApp(name: string) {
+    const path = join(dir, `${name}.db`)
+    const meta = new SqliteMetaStore(path)
+    const db = new Database(path)
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS "user" (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT);
+      CREATE TABLE IF NOT EXISTS "oauthClient" (clientId TEXT PRIMARY KEY, name TEXT);
+      CREATE TABLE IF NOT EXISTS "oauthAccessToken" (token TEXT PRIMARY KEY, clientId TEXT, userId TEXT, scopes TEXT, expiresAt TEXT);
+    `)
+    const user = db.prepare(`INSERT OR IGNORE INTO "user"(id,email,name) VALUES(?,?,?)`)
+    user.run("u_admin", "admin@x.test", "Admin")
+    user.run("u_editor", "editor@x.test", "Editor")
+    db.prepare(
+      `INSERT OR IGNORE INTO "oauthClient"(clientId,name) VALUES('cli','Derive CLI')`,
+    ).run()
+    const tok = db.prepare(
+      `INSERT INTO "oauthAccessToken"(token,clientId,userId,scopes,expiresAt) VALUES(?,?,?,?,?)`,
+    )
+    const exp = new Date(Date.now() + 3_600_000).toISOString()
+    const scopes = (list: string[]) => JSON.stringify(["openid", "derive:read", ...list])
+    tok.run(sha256("tok_full"), "cli", "u_admin", scopes(["derive:publish", "derive:manage"]), exp)
+    tok.run(sha256("tok_nomanage"), "cli", "u_admin", scopes(["derive:publish"]), exp)
+    tok.run(
+      sha256("tok_editor"),
+      "cli",
+      "u_editor",
+      scopes(["derive:publish", "derive:manage"]),
+      exp,
+    )
+    // ws_main is the grant default (oldest); ws_side exists to prove the
+    // re-home cap: u_admin owns main but is only an editor over there.
+    const ws = db.prepare(`INSERT INTO workspace(id,name,created_at) VALUES(?,?,?)`)
+    ws.run("ws_main", "Main", "2020-01-01T00:00:00.000Z")
+    ws.run("ws_side", "Side", "2021-01-01T00:00:00.000Z")
+    const mem = db.prepare(
+      `INSERT INTO membership(id,org_id,user_id,role,created_at) VALUES(?,?,?,?,?)`,
+    )
+    mem.run("m_admin", "ws_main", "u_admin", "owner", "2020-01-01T00:00:00.000Z")
+    mem.run("m_editor", "ws_main", "u_editor", "editor", "2020-01-02T00:00:00.000Z")
+    mem.run("m_side", "ws_side", "u_admin", "editor", "2021-01-01T00:00:00.000Z")
+    db.close()
+    const app = createApp({
+      meta,
+      blobs: new FsBlobStore(join(dir, `${name}-blobs`)),
+      baseUrl: "http://derive.test",
+      token: "tok",
+    })
+    return { app, meta }
+  }
+
+  const auth = (t: string) => ({
+    authorization: `Bearer ${t}`,
+    "content-type": "application/json",
+  })
+  const mintAgent = (app: ReturnType<typeof managedApp>["app"], t: string, name = "Analytics") =>
+    app.request("/v1/agents", { method: "POST", headers: auth(t), body: JSON.stringify({ name }) })
+
+  it("the push flow: mint agent → publish manifest → create context, all one grant", async () => {
+    const { app, meta } = managedApp("ctx-mgmt-flow")
+    const ag = await mintAgent(app, "tok_full")
+    expect(ag.status).toBe(201)
+    const agent = (await ag.json()) as { id: string; token: string; created_at: string }
+    expect(agent.token).toMatch(/^dk_agt_/)
+    expect((await meta.listAgents("ws_main"))[0]?.created_by).toBe("u_admin") // the grantor
+
+    const man = await pub(app, "# manifest", { title: "Analytics manifest" }, undefined, {
+      authorization: "Bearer tok_full",
+    })
+    expect(man.status).toBe(201)
+    const { short_id } = (await man.json()) as { short_id: string }
+
+    const res = await app.request("/v1/contexts", {
+      method: "POST",
+      headers: auth("tok_full"),
+      body: JSON.stringify({ name: "Analytics", agent_id: agent.id, manifest_short_id: short_id }),
+    })
+    expect(res.status).toBe(201)
+    const created = (await res.json()) as { id: string; created_by: string }
+    expect(created.created_by).toBe("u_admin")
+
+    // The OAuth creator can also list and delete what it made.
+    const list = await app.request("/v1/contexts", { headers: auth("tok_full") })
+    expect(list.status).toBe(200)
+    const del = await app.request(`/v1/contexts/${created.id}`, {
+      method: "DELETE",
+      headers: auth("tok_full"),
+    })
+    expect(del.status).toBe(204)
+  })
+
+  it("no manage scope → 403, even for a workspace owner", async () => {
+    const { app } = managedApp("ctx-mgmt-noscope")
+    expect((await mintAgent(app, "tok_nomanage")).status).toBe(403)
+  })
+
+  it("a publish-only grant can't create contexts either — manage is the key, not publish", async () => {
+    const { app } = managedApp("ctx-mgmt-pubonly")
+    const res = await app.request("/v1/contexts", {
+      method: "POST",
+      headers: auth("tok_nomanage"),
+      body: JSON.stringify({ name: "X", agent_id: "ag_x", manifest_short_id: "abc" }),
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it("the minted runner token is a runtime principal: no context list/create/delete", async () => {
+    // The exact stolen-runner-token scenario: the registrant (u_admin) created
+    // the context, so a naive created_by match would hand its own agent the
+    // delete. The routes must refuse the registered token outright.
+    const { app } = managedApp("ctx-mgmt-runner")
+    const agent = (await (await mintAgent(app, "tok_full")).json()) as {
+      id: string
+      token: string
+    }
+    const man = await pub(app, "# manifest", { title: "M" }, undefined, {
+      authorization: "Bearer tok_full",
+    })
+    const { short_id } = (await man.json()) as { short_id: string }
+    const created = (await (
+      await app.request("/v1/contexts", {
+        method: "POST",
+        headers: auth("tok_full"),
+        body: JSON.stringify({ name: "A", agent_id: agent.id, manifest_short_id: short_id }),
+      })
+    ).json()) as { id: string }
+
+    const runner = auth(agent.token)
+    expect((await app.request("/v1/contexts", { headers: runner })).status).toBe(401)
+    const create = await app.request("/v1/contexts", {
+      method: "POST",
+      headers: runner,
+      body: JSON.stringify({ name: "B", agent_id: agent.id, manifest_short_id: short_id }),
+    })
+    expect(create.status).toBe(401)
+    const del = await app.request(`/v1/contexts/${created.id}`, {
+      method: "DELETE",
+      headers: runner,
+    })
+    expect(del.status).toBe(401)
+    // Its runtime surface is untouched: the runner still reads its own wiring.
+    const own = await app.request(`/v1/contexts/${created.id}`, { headers: runner })
+    expect(own.status).toBe(200)
+  })
+
+  it("re-homing a manage grant re-caps by the target workspace's membership", async () => {
+    const { app } = managedApp("ctx-mgmt-rehome")
+    const res = await app.request("/v1/agents", {
+      method: "POST",
+      headers: { ...auth("tok_full"), "x-derive-workspace": "ws_side" },
+      body: JSON.stringify({ name: "Side" }),
+    })
+    expect(res.status).toBe(403) // owner scope, but only editor over there
+  })
+
+  it("manage scope can't outrank the human: editor member → 403 on agents", async () => {
+    const { app } = managedApp("ctx-mgmt-editor")
+    expect((await mintAgent(app, "tok_editor")).status).toBe(403)
+  })
+
+  it("no human behind the request → no context: anon 403 (global gate), static token 401", async () => {
+    const { app } = managedApp("ctx-mgmt-anon")
+    const body = JSON.stringify({ name: "X", agent_id: "ag_x", manifest_short_id: "abc" })
+    const anon = await app.request("/v1/contexts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    })
+    expect(anon.status).toBe(403) // the /v1 anonymous-write gate, before the route
+    // The static token is a principal but resolves to no human — created_by
+    // would be nobody, so the route itself refuses.
+    const tok = await app.request("/v1/contexts", { method: "POST", headers: auth("tok"), body })
+    expect(tok.status).toBe(401)
+  })
+})

--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // derive — scaffold, publish, and run the review loop against a Derive server.
 //   derive init [dir] [--template md|html|slides|site|skill|context] [--title t]
-//   derive login [--local] [--server url]   OAuth sign-in (default https://derive.to); saves a token
+//   derive login [--local] [--server url] [--manage]   OAuth sign-in; --manage adds the agent/context admin grant
 //   derive publish [file|dir] [--id --title --slug --spa --message --name --visibility --server --token]
 //   derive comments [--id]                 list the artifact's comment threads
 //   derive pull [short_id] [--v N] [--out f]  print an artifact's source (bundles: entry file)
@@ -47,6 +47,7 @@ for (let i = 0; i < args.length; i++) {
   else if (a === "--local") flags.local = "true"
   else if (a === "--json") flags.json = "true"
   else if (a === "--mock") flags.mock = "true"
+  else if (a === "--manage") flags.manage = "true"
   // Repeatable: `--env-file a --env-file b` stacks (equivalent to --env-file a,b).
   else if (a === "--env-file")
     flags["env-file"] = flags["env-file"] ? `${flags["env-file"]},${args[++i]}` : args[++i]
@@ -87,9 +88,15 @@ if (cmd === "login") {
     b.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
   const server = resolveServer(flags)
   const redirect = `${server}/oauth/cli-callback`
+  // derive:manage (opt-in via --manage) lets `derive context push` mint the
+  // answering agent and create the context. Opt-in, not default: it raises a
+  // leaked token's blast radius from editor to your full workspace authority,
+  // so only sessions that actually manage contexts should carry it.
   const scope =
     flags.scope ??
-    "openid offline_access derive:read derive:comment derive:propose derive:publish derive:review"
+    `openid offline_access derive:read derive:comment derive:propose derive:publish derive:review${
+      flags.manage === "true" ? " derive:manage" : ""
+    }`
   const verifier = b64url(randomBytes(64))
   const challenge = b64url(createHash("sha256").update(verifier).digest())
   const state = b64url(randomBytes(16))
@@ -506,7 +513,7 @@ if (LOOP.includes(cmd)) {
 if (cmd !== "publish") {
   console.error(`usage:
   derive init [dir] [--template md|html|slides|site|skill|context] [--title t]
-  derive login [--local] [--server url]    OAuth sign-in (defaults to https://derive.to); saves a persistent token
+  derive login [--local] [--server url] [--manage]   OAuth sign-in; --manage adds the agent/context admin grant (context push wiring)
   derive publish [file|dir] [--id X] [--title t] [--slug s] [--spa] [--message m] [--name "x"] [--visibility v] [--password p] [--server url] [--token t] [--json]
   derive comments [--id X]                 list comment threads
   derive pull [short_id] [--v N] [--out f] print an artifact's source (bundles: entry file only)

--- a/packages/cli/src/context.js
+++ b/packages/cli/src/context.js
@@ -19,16 +19,18 @@ const post = async (server, token, path, body) => {
  *  persist it immediately. */
 export async function createAgent(server, token, name) {
   const { res, json } = await post(server, token, "/v1/agents", { name, role: "editor" })
-  // 401: agent/context management currently needs a signed-in user — the CLI's
-  // OAuth token resolves as an on-behalf agent, which these routes don't accept
-  // yet. The manifest still pushed; only the one-time wiring is manual.
+  // 401/403: the token lacks the manage grant (derive:manage is opt-in at
+  // login) or the user isn't workspace admin. The manifest still pushed; only
+  // the one-time wiring is blocked.
   if (res.status === 401 || res.status === 403)
     throw new Error(
-      `this token can't manage agents (${res.status}) — wire it once in the console:\n` +
-        `  1. ${server} → Settings → Agents → New agent ("${name}", role editor); save its token to .derive/agent-token\n` +
-        `  2. ${server} → Contexts → New context → pick the agent + this manifest\n` +
-        `  3. put the agent id in derive.json (context.agent_id) and the context id in context.id\n` +
-        `after that, every push is just a manifest version — no wiring, no console`,
+      `this token can't manage agents (${res.status}).\n` +
+        `  If you're a workspace admin: re-run \`derive login --manage\` (the manage grant is opt-in).\n` +
+        `  Otherwise, wire it once in the console:\n` +
+        `    1. ${server} → Settings → Agents → New agent ("${name}", role editor); save its token to .derive/agent-token\n` +
+        `    2. ${server} → Contexts → New context → pick the agent + this manifest\n` +
+        `    3. put the agent id in derive.json (context.agent_id) and the context id in context.id\n` +
+        `  After that, every push is just a manifest version — no wiring, no console.`,
     )
   if (res.status === 409)
     throw new Error(


### PR DESCRIPTION
Sprint 1 item 3b (plan bzjg35x0 v3): closes the gap #312 shipped around — the CLI's OAuth token resolves as an on-behalf agent, and context/agent management was user-gated, so `derive context push` could publish the manifest but had to print console steps for the one-time wiring. After this: `derive login --manage`, then push mints the agent and creates the context in one command.

## The rule

**Context management accepts exactly two principal classes**: a signed-in user, or an OAuth grant carrying `derive:manage` acting as its grantor. Registered `dk_agt_` runner tokens are runtime principals (poll, answer, publish charts) and are refused outright on the management routes.

- `roleFromScopes` maps `derive:manage` → owner-grade — **always capped by the grantor's actual membership** in the resolved workspace. Every resolution path re-caps: consent binding, first-workspace fallback, provisionPersonal, and the `X-Derive-Workspace` re-home. The scope widens what a grant may *attempt*, never what the human could do.
- `created_by` attributes to the grantor via `privateOwnerId`, exactly like publish attribution.
- **Opt-in at login** (`derive login --manage`), not the default scope set: a leaked everyday CLI token stays editor-capped; only sessions that actually manage contexts carry owner-grade reach.

## The adversarial review earned its cost

Run before this PR opened (verdict on the first draft: *do not ship as-is*). It caught that a naive `requireUser` → `privateOwnerId` swap let a **stolen runner token**: (1) DELETE the very contexts it serves — the registrant's `created_by` matched, short-circuiting past every role check; (2) CREATE contexts at editor role; (3) enumerate every context's wiring via the list route. All three are closed by the management-principal rule (`managementPrincipal` in context.ts), and the review's other findings landed too: the manage scope is opt-in (blast-radius), and `GET /v1/contexts` now matches `GET /:id`'s agent gating.

Verified against `@better-auth/oauth-provider` source: scope broadening always re-prompts consent (no silent escalation of existing grants), refresh never upgrades scopes, and the CLI re-registers its client each login so pre-scope clients can't break.

## Tests

- Both ceilings independently: manage scope + editor membership → 403; owner membership without the scope → 403 (and publish-only grants can't create contexts — manage is the key, not publish)
- The full push flow over one grant: mint agent → publish manifest → create context → delete, all attributed to the grantor
- **The stolen-runner-token scenario**: the minted `dk_agt_` token 401s on list/create/delete while still reading its own wiring
- The re-home cap end-to-end: manage grant + `X-Derive-Workspace` into an editor-membership workspace → 403
- Consent renders the manage label ("only as far as your workspace role allows")

Full `pnpm run ci` + typecheck green; 54 CLI tests green.