### PR TITLE
chore(ci): disable e2e smoke + e2e deep automatic runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,6 @@ jobs:
       cancel-in-progress: false
     permissions:
       contents: read
-      actions: write # dispatches e2e-smoke.yml
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -234,14 +233,10 @@ jobs:
           echo "prod not healthy after deploy (last /v1/artifacts status: $db)" >&2
           exit 1
 
-      # Regression signal on main HEAD (the suite runs against localhost dev
-      # servers in its own runner — it does NOT verify the deployment; the step
-      # above does that).
-      - name: Dispatch e2e suite
-        if: steps.head.outputs.stale != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh workflow run e2e-smoke.yml --ref main
+      # e2e smoke's post-deploy auto-dispatch is disabled for now (still flaky
+      # under CI CPU contention — see e2e-smoke.yml). Run it manually with
+      # `gh workflow run e2e-smoke.yml --ref main` when a regression signal is
+      # actually wanted.
 
   # Supply-chain: a known-vulnerable production dependency, or a committed secret,
   # fails the build. Reads the lockfile + working tree, so no install is needed.

--- a/.github/workflows/e2e-deep.yml
+++ b/.github/workflows/e2e-deep.yml
@@ -4,12 +4,10 @@ name: e2e deep (nightly)
 # review flow, settings tabs, share roles, library search/favorites/collections)
 # plus a responsive/mobile pass. Heavier than smoke; intended to run NIGHTLY.
 #
-# Runs nightly (and on demand). Heavier than smoke, so it's a scheduled
-# regression sweep rather than a per-PR gate.
+# DISABLED on CI for now (no automatic trigger — manual only via
+# workflow_dispatch). Re-add `schedule:` once it's worth the nightly runner time.
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 7 * * *" # 07:00 UTC nightly
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -3,10 +3,11 @@ name: e2e smoke
 # The fast critical-path suite: one happy path per surface (sign up, publish →
 # comment → resolve, library, share, settings, theme, review).
 #
-# NOT a PR gate yet — the suite still flakes under CI CPU contention (multi-context
-# owner+member specs starving on a small runner), so it must not block merges. It runs
-# POST-DEPLOY instead: `pnpm run deploy` triggers it on a successful deploy, and it can
-# be run on demand (workflow_dispatch). Re-add `pull_request:` once it's reliably green.
+# DISABLED on CI for now (no automatic trigger — manual only via
+# workflow_dispatch; `pnpm run deploy` no longer chains it post-deploy either).
+# The suite still flakes under CI CPU contention (multi-context owner+member
+# specs starving on a small runner). Re-add `pull_request:` once it's reliably
+# green, and re-chain `deploy:smoke` into apps/api's `deploy` script.
 on:
   workflow_dispatch:
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,7 +18,7 @@
     "build:web": "pnpm --filter @derive/web build && node scripts/prep-edge-assets.mjs",
     "deploy:schema": "node scripts/apply-d1-schema.mjs",
     "migrate:auth": "tsx migrate-auth-d1.ts",
-    "deploy": "pnpm build:web && pnpm deploy:schema && tsx migrate-auth-d1.ts --apply && pnpm deploy:pg-schema && wrangler deploy && pnpm deploy:smoke",
+    "deploy": "pnpm build:web && pnpm deploy:schema && tsx migrate-auth-d1.ts --apply && pnpm deploy:pg-schema && wrangler deploy",
     "deploy:pg-schema": "tsx scripts/apply-pg-schema.ts",
     "deploy:smoke": "gh workflow run e2e-smoke.yml --ref main || echo 'post-deploy smoke not triggered (gh CLI unavailable) — run: gh workflow run e2e-smoke.yml'",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.worker.json",


### PR DESCRIPTION
## Summary
- Neither suite was a PR gate, but both still fired automatically: `e2e-deep` on its nightly cron, `e2e-smoke` via two separate post-deploy dispatches (ci.yml's own `deploy` job, and apps/api's `deploy` script chain calling `gh workflow run` independently).
- Dropped the cron trigger and both auto-dispatches. `workflow_dispatch` stays on both workflows, so either suite can still be run on demand.
- Removed the now-unused `actions: write` permission from ci.yml's `deploy` job (nothing else in that job needs it).

## Test plan
- [x] YAML/JSON syntax validated for all four edited files
- [x] `pnpm run ci` green in a fresh worktree off latest main