### PR TITLE
Round 4: the link grant (audience x capability, orthogonal to visibility)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,33 +26,51 @@ Derive ships safe defaults, but a few choices matter for an internet-facing depl
   view (comment, propose, publish, share, manage) requires an authenticated identity, so
   there is no "open" mode that elevates an anonymous caller. To write, a caller signs in
   (Better Auth is always available, even zero-config) or presents a static `DERIVE_TOKEN`
-  (set it for headless CI/agent automation). General access (the shared link) can grant a
-  reacher view or comment; the comment grant only lifts a *signed-in* reacher to commenter,
-  never an anonymous one. The effective capability by who's asking:
+  (set it for headless CI/agent automation).
 
-  | Visibility                     | Anonymous (no account)         | Signed in via link (no explicit grant) | Member / explicit share        |
-  |--------------------------------|--------------------------------|----------------------------------------|--------------------------------|
-  | Public, **view**               | View                           | View                                   | Their role (at least view)     |
-  | Public, **comment**            | View only (sign in to comment) | View + comment                         | Their role (at least comment)  |
-  | Public + password (the lock)   | Unlock, then as above          | Unlock, then as above                  | Their role (no password needed)|
-  | Workspace (org)                | No access                      | No access                              | Their role (members only)      |
-  | Private — default              | No access                      | No access                              | Explicit share only — workspace role grants nothing |
+  Access is two independent axes (round 4, docs/plans/link-grant.md). **Where it's
+  listed** (`visibility`: private / org / public) governs discoverability — feeds,
+  libraries, and whether workspace membership alone grants standing (it does at
+  org/public, never at private). **What the link grants** (`link_audience` ×
+  `link_role`) governs reach: who the bare URL works for (`org` = signed-in members
+  of the artifact's workspace, `public` = anyone) and what it confers (`none` =
+  inert, invite-only; viewer / commenter / editor). Writing grants only lift a
+  *signed-in* holder the audience admits — never an anonymous one. The effective
+  capability by who's asking, for any visibility:
 
-  Three visibilities, one modifier: a password on a public artifact gates its
-  reach until unlocked (members and explicit shares never need it), and a locked
-  artifact's bytes are never shared-cacheable. There is no listing axis —
-  "public" means the link works, full stop.
+  | Link grant                | Anonymous (no account) | Signed in outside the workspace | Workspace member       | Explicit share          |
+  |---------------------------|------------------------|---------------------------------|------------------------|-------------------------|
+  | Inert (`none`) — sealed   | No access              | No access                       | Their standing¹        | Their share role        |
+  | Workspace · view/comment/edit | No access          | No access                       | max(standing¹, grant)  | max(share, grant²)      |
+  | Anyone · view             | View                   | View                            | max(standing¹, view)   | max(share, view)        |
+  | Anyone · comment          | View (sign in to comment) | View + comment               | max(standing¹, comment)| max(share, comment)     |
+  | Anyone · edit             | View (sign in to edit) | Editor                          | max(standing¹, edit)   | max(share, edit)        |
 
-  Every publish defaults to **private**: only the publisher (written as the
-  owner-member at creation) can see a fresh artifact. That includes AGENT
+  ¹ Standing = membership role at org/public visibility; NOTHING at private (a
+  workspace owner still cannot open a teammate's sealed private draft by role
+  alone). ² A shared-with outsider is not in a workspace audience; their share
+  role alone applies.
+
+  One coherence rule: a **public listing requires a public link at viewer or
+  above** — "public means the link works, full stop"; listed-but-unopenable
+  states are unrepresentable. One modifier: a password on a public listing gates
+  the link floor until unlocked (members and explicit shares never need it), and
+  a locked artifact's bytes are never shared-cacheable.
+
+  Every publish defaults to a **private listing with a Workspace · can-comment
+  link**: nothing is listed anywhere, teammates handed the URL can open and
+  comment, and no one outside the workspace can reach it. That includes AGENT
   publishes — the /mcp server, and any /v1 publish carrying a registered agent
-  token or OAuth bearer (the CLI and stdio-shim paths) — governed by the
-  workspace's `defaultAgentVisibility` (private, or workspace for teams that
-  want agent work landing shared). Private artifacts never appear in another
-  viewer's listings, profiles, or People surfaces (your own library and the
-  "Created by me" filter always find your own). Widening (workspace, public) is
-  always an explicit act. GitHub-mirror syncs publish workspace-visible — a
-  mirrored repo is a workspace resource, not a personal draft.
+  token or OAuth bearer (the CLI and stdio-shim paths) — where the listing is
+  governed by `defaultAgentVisibility` and the link pair by the same workspace
+  defaults (`defaultLinkAudience` · `defaultLinkRole`; a bare public publish gets
+  the classic public · viewer pair, never the workspace role). Existing artifacts
+  are never retroactively widened by changing a default. Private artifacts never
+  appear in another viewer's listings, profiles, or People surfaces (your own
+  library and the "Created by me" filter always find your own). Widening —
+  listing wider, or opening the link to Anyone — is always an explicit act.
+  GitHub-mirror syncs publish workspace-visible — a mirrored repo is a workspace
+  resource, not a personal draft.
 
   `packages/core/src/permissions.ts` (`effectiveRole`) is the single source of truth for
   this table, enforced on every request by the one `can()` gate and surfaced in the UI so

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -605,11 +605,12 @@ export function buildContext(deps: AppDeps) {
     return { kind: "user", userId: me.id, artifactRole, orgRole, locked, unlocked }
   }
 
-  /** Authorize an action against a specific artifact. The artifact's general-access role
-   *  is threaded in so an authenticated link-reacher can earn `comment` while an anonymous
-   *  one stays clamped to view (see effectiveRole). */
+  /** Authorize an action against a specific artifact. The artifact's link grant pair
+   *  (round 4: link_audience = who the URL works for, link_role = what it confers,
+   *  at any visibility) is threaded in so a holder the audience admits can earn up
+   *  to that role while an anonymous one stays clamped to view (see effectiveRole). */
   const authorize = (c: Context, action: Action, a: ArtifactRecord): Promise<boolean> =>
-    actorFor(c, a).then((actor) => can(actor, action, a.visibility, a.general_role))
+    actorFor(c, a).then((actor) => can(actor, action, a.visibility, a.link_role, a.link_audience))
 
   /**
    * True when the caller is an anonymous visitor — they may view public content

--- a/apps/api/src/lib/http.ts
+++ b/apps/api/src/lib/http.ts
@@ -1,4 +1,4 @@
-import type { Role, Visibility } from "@derive/core"
+import type { LinkAudience, LinkRole, Role, Visibility } from "@derive/core"
 import type { Context } from "hono"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
 import type { z } from "zod"
@@ -192,6 +192,32 @@ export const visibilityOf = (v: unknown): Visibility | undefined =>
     ? (VISIBILITIES as readonly string[]).includes(v)
       ? (v as Visibility)
       : LEGACY_VISIBILITY[v]
+    : undefined
+
+/** The link grant (round 4): what merely holding an artifact's URL confers
+ *  (link_role) × who the URL works for (link_audience), independent of
+ *  visibility. See docs/plans/link-grant.md. */
+export const LINK_ROLES = ["none", "viewer", "commenter", "editor"] as const
+export const LINK_AUDIENCES = ["org", "public"] as const
+
+/** Legacy wire alias: pre-round-4 clients sent `general_role`, which only ever
+ *  carried `viewer`/`commenter` (the public-only reach select). Both values are
+ *  already valid LinkRole literals, so no remapping — this alias just accepts
+ *  the old field name at the same values, never `none`/`editor` (those never
+ *  existed on the old field). */
+export const linkRoleOf = (v: unknown): LinkRole | undefined =>
+  typeof v === "string" && (LINK_ROLES as readonly string[]).includes(v)
+    ? (v as LinkRole)
+    : undefined
+
+/** Friendly audience spellings map onto the canonical pair: the MCP tools say
+ *  `workspace`, humans might say `everyone`. */
+const AUDIENCE_ALIASES: Record<string, LinkAudience> = { workspace: "org", everyone: "public" }
+export const linkAudienceOf = (v: unknown): LinkAudience | undefined =>
+  typeof v === "string"
+    ? (LINK_AUDIENCES as readonly string[]).includes(v)
+      ? (v as LinkAudience)
+      : AUDIENCE_ALIASES[v]
     : undefined
 
 /**

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -78,6 +78,8 @@ const summarizeArtifact = (a: ArtifactRecord) => ({
   kind: a.kind,
   version: a.current_version,
   visibility: a.visibility,
+  link_role: a.link_role,
+  link_audience: a.link_audience,
   removed: !!a.removed_at,
 })
 
@@ -610,7 +612,19 @@ function buildServer(
           .enum(["private", "workspace", "public"])
           .optional()
           .describe(
-            "Who can open a NEW artifact: private (the human you act for + people they add — the usual default for agent publishes; they promote it when ready), workspace (their team), or public (the link works for anyone). Omit to use the workspace's agent default. Ignored on republish — the human promotes via the share dialog.",
+            "Where a NEW artifact is LISTED: private (no feeds/libraries — the usual default for agent publishes; a human promotes it when ready), workspace (the team library), or public. Omit to use the workspace's agent default. Ignored on republish — the human promotes via the share dialog.",
+          ),
+        link_role: z
+          .enum(["none", "viewer", "commenter", "editor"])
+          .optional()
+          .describe(
+            "What a NEW artifact's LINK grants holders its audience admits, independent of `visibility` — a private artifact can still have a live, unlisted link. none (invite-only), viewer, commenter (the usual default), or editor. Anonymous holders are always clamped to viewer. Omit to use the workspace's default. Ignored on republish.",
+          ),
+        link_audience: z
+          .enum(["workspace", "public"])
+          .optional()
+          .describe(
+            "WHO a NEW artifact's link works for: workspace (signed-in members of this workspace — the usual default; the 'unlisted but my team can open my link' state) or public (anyone holding the URL). Omit to use the workspace's default. Ignored on republish.",
           ),
         spa: z
           .boolean()
@@ -657,6 +671,8 @@ function buildServer(
       title,
       short_id,
       visibility,
+      link_role,
+      link_audience,
       spa,
       merge,
       message,
@@ -766,6 +782,36 @@ function buildServer(
         // agent doesn't say — unlisted by default: out of the team library, one
         // link away for the human. Sharing wider stays a deliberate human act.
         const settings = short_id ? null : await ctx.meta.getOrgSettings(org)
+        const resolvedVisibility =
+          visibility === "public"
+            ? "public"
+            : visibility === "workspace"
+              ? "org"
+              : visibility === "private"
+                ? "private"
+                : (settings?.defaultAgentVisibility ?? "private")
+        // The link grant pair — set-on-create like visibility (a republish never
+        // re-stamps): explicit args > the workspace's defaults. Coherence: a
+        // public listing means the link works for the world (see the plan's state
+        // table) — an explicit contradiction errors, defaults resolve coherent.
+        let resolvedLinkRole = short_id ? undefined : (link_role ?? settings?.defaultLinkRole)
+        let resolvedLinkAudience = short_id
+          ? undefined
+          : link_audience === "workspace"
+            ? ("org" as const)
+            : (link_audience ?? settings?.defaultLinkAudience)
+        if (!short_id && resolvedVisibility === "public") {
+          if (link_audience === "workspace")
+            return text(
+              "A public artifact's link works for everyone — drop link_audience or use public.",
+            )
+          if (link_role === "none")
+            return text("A public artifact's link must grant at least viewer.")
+          resolvedLinkAudience = "public"
+          // Classic public pair unless explicitly widened — the workspace default
+          // role is for the workspace audience, never a world link (see the route).
+          resolvedLinkRole = link_role ?? "viewer"
+        }
         const { artifact, version } = await publishVersion(
           ctx.meta,
           ctx.blobs,
@@ -783,14 +829,9 @@ function buildServer(
             // New artifacts land in the granting user's workspace, never wider
             // than asked (the workspace's agent default when unspecified).
             orgId: agent.org_id,
-            visibility:
-              visibility === "public"
-                ? "public"
-                : visibility === "workspace"
-                  ? "org"
-                  : visibility === "private"
-                    ? "private"
-                    : (settings?.defaultAgentVisibility ?? "private"),
+            visibility: resolvedVisibility,
+            linkRole: resolvedLinkRole,
+            linkAudience: resolvedLinkAudience,
           },
           short_id,
         )
@@ -924,6 +965,8 @@ function buildServer(
           url,
           title: artifact.title,
           visibility: artifact.visibility,
+          link_role: artifact.link_role,
+          link_audience: artifact.link_audience,
           ...(resolved.length ? { resolved } : {}),
           ...(actingFor ? { opened_in_tab: openedInTab } : {}),
           note:

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -200,6 +200,26 @@ if (defaultOrg !== "local") {
   }
 }
 
+// One-time backfill of the round-4 link grant pair (see docs/plans/link-grant.md).
+// The ALTER ADD COLUMNs land every existing row at the fail-closed defaults
+// (`none` / `org`) — correct for org/private rows (their links were already dead,
+// and they stay dead: no retroactive widening). But a public artifact's link WAS
+// live for anyone at its legacy `general_role`, so this restores exactly that
+// reach onto the new pair: audience `public`, role from `general_role`. Byte-
+// identical behavior before and after. Idempotent — re-running re-applies the
+// same values to public rows, a no-op after the first boot.
+if (cfg.databaseUrl) {
+  const pool = authDb as Pool
+  await pool.query(
+    `UPDATE artifact SET link_role = general_role, link_audience = 'public' WHERE visibility = 'public'`,
+  )
+} else {
+  const db = authDb as Database.Database
+  db.prepare(
+    `UPDATE artifact SET link_role = general_role, link_audience = 'public' WHERE visibility = 'public'`,
+  ).run()
+}
+
 // Blobs: S3/R2 when OBJECT_STORE_URL is set, else local disk (zero-config).
 const blobs: BlobStore = cfg.objectStoreUrl
   ? s3FromUrl(cfg.objectStoreUrl)

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -21,7 +21,11 @@ export const analyticsRoutes = (ctx: AppContext) => {
     // the same). `manage` requires the owner role, so this is exactly "is owner";
     // editors/commenters/viewers and anonymous openers still count.
     const actor = await actorFor(c, artifact)
-    if (actor.kind !== "anon" && can(actor, "manage", artifact.visibility)) return c.body(null, 204)
+    if (
+      actor.kind !== "anon" &&
+      can(actor, "manage", artifact.visibility, artifact.link_role, artifact.link_audience)
+    )
+      return c.body(null, 204)
     const me = await currentUser(c)
     let viewer: string
     let kind: "user" | "anon"

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -28,6 +28,8 @@ import { buildReviewEmail } from "../lib/email"
 import {
   DEFAULT_WORKSPACE_NAME,
   fail,
+  linkAudienceOf,
+  linkRoleOf,
   MAX_UPLOAD_BYTES,
   readJson,
   str,
@@ -227,8 +229,8 @@ export const artifactRoutes = (ctx: AppContext) => {
         favorite: favorites.has(a.id),
         // Which actions the client may surface on the row (the card's quick-actions
         // menu gates delete/tags on it). Workspace membership + per-artifact shares
-        // + the general-access floor; collection-share roles aren't folded in at
-        // list granularity, so the detail response's my_role stays authoritative.
+        // + the link floor; collection-share roles aren't folded in at list
+        // granularity, so the detail response's my_role stays authoritative.
         my_role: isOperator
           ? "owner"
           : effectiveRole(
@@ -244,7 +246,8 @@ export const artifactRoutes = (ctx: AppContext) => {
                   }
                 : { kind: "anon" },
               a.visibility,
-              a.general_role,
+              a.link_role,
+              a.link_audience,
             ),
         // The current author as a resolved profile (name/login/avatar + Derive handle), so
         // the list can render the last editor + filter by them.
@@ -364,6 +367,18 @@ export const artifactRoutes = (ctx: AppContext) => {
     if (!shortId && rawVisibility === "password" && !password)
       return fail(c, 400, "a password is required for password visibility")
     const passwordHash = visibility === "public" && password ? hashPassword(password) : undefined
+    // The link grant pair (round 4): who the URL works for × what it confers.
+    // `link_role`/`link_audience` are the current fields; `general_role` is accepted
+    // as a legacy alias for the role (pre-round-4 clients only ever sent
+    // viewer/commenter, both valid LinkRole literals — see linkRoleOf).
+    const rawLinkRole = str(body["link_role"]) ?? str(body["general_role"])
+    const linkRole = linkRoleOf(rawLinkRole)
+    if (rawLinkRole && !linkRole)
+      return fail(c, 400, "link_role must be one of: none, viewer, commenter, editor")
+    const rawLinkAudience = str(body["link_audience"])
+    const linkAudience = linkAudienceOf(rawLinkAudience)
+    if (rawLinkAudience && !linkAudience)
+      return fail(c, 400, "link_audience must be one of: org, public")
 
     try {
       // The authenticated principal behind this publish (signed-in user or agent) — its
@@ -376,13 +391,38 @@ export const artifactRoutes = (ctx: AppContext) => {
       // An AGENT-credentialed create (registered token / OAuth bearer — the CLI
       // and stdio-shim paths) lands with the workspace's agent default when no
       // visibility was asked for: usually `private` — the human promotes. A
-      // signed-in human's own publish keeps the same private default.
+      // signed-in human's own publish keeps the same private default. One org-settings
+      // read on a NEW artifact covers all the defaults (agent visibility + the link pair).
       const agentPrincipal = await agentFor(c)
+      const settings = !shortId ? await meta.getOrgSettings(org) : null
       const resolvedVisibility =
-        visibility ??
-        (agentPrincipal && !shortId
-          ? (await meta.getOrgSettings(org)).defaultAgentVisibility
-          : undefined)
+        visibility ?? (agentPrincipal && !shortId ? settings?.defaultAgentVisibility : undefined)
+      // Set-on-create like visibility: a republish never re-stamps the link pair.
+      // Each half resolves: explicit request field > the workspace's default > the
+      // factory default (org · commenter, resolved inside getOrgSettings).
+      let resolvedLinkRole = !shortId ? (linkRole ?? settings?.defaultLinkRole) : undefined
+      let resolvedLinkAudience = !shortId
+        ? (linkAudience ?? settings?.defaultLinkAudience)
+        : undefined
+      // Coherence: public visibility means the link works for the world, full stop
+      // (states 15/16 of the table in docs/plans/link-grant.md are unrepresentable).
+      // An EXPLICIT contradiction is rejected, not coerced. A bare
+      // `visibility=public` publish gets the classic public pair (public · viewer,
+      // exactly the pre-round-4 contract) — the WORKSPACE default role is chosen
+      // for the workspace audience and must not silently ride onto a world link;
+      // widening a public link past view stays an explicit act.
+      if (!shortId && resolvedVisibility === "public") {
+        if (linkAudience === "org")
+          return fail(
+            c,
+            400,
+            "a public artifact's link works for everyone — link_audience must be public",
+          )
+        if (linkRole === "none")
+          return fail(c, 400, "a public artifact's link must grant at least viewer")
+        resolvedLinkAudience = "public"
+        resolvedLinkRole = linkRole ?? "viewer"
+      }
       const { artifact, version } = await publish(
         meta,
         blobs,
@@ -405,6 +445,8 @@ export const artifactRoutes = (ctx: AppContext) => {
           orgId: org,
           visibility: resolvedVisibility,
           passwordHash,
+          linkRole: resolvedLinkRole,
+          linkAudience: resolvedLinkAudience,
         },
         shortId,
       )
@@ -599,7 +641,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     // an anonymous probe can't learn anything (a non-member gets no access).
     const actor = await actorFor(c, artifact ?? ({ id: "", visibility: "org" } as ArtifactRecord))
     if (!artifact) return fail(c, 404, "not found")
-    if (!can(actor, "read", artifact.visibility, artifact.general_role))
+    if (!can(actor, "read", artifact.visibility, artifact.link_role, artifact.link_audience))
       // A locked public artifact isn't hidden, it's lockable: tell the client to
       // prompt for the password (401) rather than claim it doesn't exist (404).
       return artifact.visibility === "public" && artifact.password_hash
@@ -622,7 +664,15 @@ export const artifactRoutes = (ctx: AppContext) => {
         created_at: artifact.created_at,
         versions: [],
         sessions: [],
-        my_role: effectiveRole(actor, artifact.visibility),
+        // link_role threaded even on a tombstone: a removed public/commenter-link
+        // artifact must not silently under-report a link-reacher's role (see
+        // docs/plans/link-grant.md — this omission is exactly what round 4 closes).
+        my_role: effectiveRole(
+          actor,
+          artifact.visibility,
+          artifact.link_role,
+          artifact.link_audience,
+        ),
         tags: [],
         favorite: false,
         collections: [],
@@ -679,7 +729,12 @@ export const artifactRoutes = (ctx: AppContext) => {
         handle: v.author_gh_id ? (handleByGhId[v.author_gh_id] ?? null) : null,
       })),
       sessions: groupSessions(versions, versionWindowMs),
-      my_role: effectiveRole(actor, artifact.visibility, artifact.general_role),
+      my_role: effectiveRole(
+        actor,
+        artifact.visibility,
+        artifact.link_role,
+        artifact.link_audience,
+      ),
       // The artifact's current workspace — the move dialog needs this to exclude
       // it from the destination picker.
       org_id: artifact.org_id,
@@ -709,12 +764,15 @@ export const artifactRoutes = (ctx: AppContext) => {
     })
   })
 
-  // Change general access (visibility + the general-access role) after publish — the
-  // Share dialog's "general access" control. Editors+ (share), per the GDocs model.
-  // `generalRole` is the floor the link grants a reacher (viewer = view-only, commenter =
-  // authenticated reachers may comment; anonymous stays view-only regardless). Enabling
-  // `password` needs a password (or keeps the existing one); any other visibility clears
-  // the stored hash.
+  // Change where it's listed (visibility) and/or the link grant pair (round 4:
+  // linkAudience = who the URL works for, linkRole = what it confers) after
+  // publish — the Share dialog's two controls. Editors+ (share), per the GDocs
+  // model. The pair is independent of visibility: a private artifact can carry a
+  // live workspace-only or world link. Anonymous holders stay clamped to view and
+  // never enter an org audience. Omitting a field PRESERVES the artifact's current
+  // value (this is an update, not a create — resolving defaults belongs to
+  // publish() alone). Enabling `password` needs a password (or keeps the existing
+  // one); any other visibility clears the stored hash.
   app.patch("/v1/artifacts/:shortId/visibility", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact) return fail(c, 404, "not found")
@@ -724,19 +782,39 @@ export const artifactRoutes = (ctx: AppContext) => {
       z.object({
         visibility: z.string(),
         password: z.string().optional(),
+        linkRole: z.enum(["none", "viewer", "commenter", "editor"]).optional(),
+        linkAudience: z.enum(["org", "public"]).optional(),
+        // Legacy wire alias (pre-round-4 clients) — a strict subset of linkRole's
+        // range, so no remapping needed, just an old field name.
         generalRole: z.enum(["viewer", "commenter"]).optional(),
       }),
     )
     if (b instanceof Response) return b
     const visibility = visibilityOf(b.visibility)
     if (!visibility) return fail(c, 400, "invalid visibility")
-    const generalRole = b.generalRole ?? "viewer"
+    let linkRole = b.linkRole ?? b.generalRole ?? artifact.link_role
+    let linkAudience = b.linkAudience ?? artifact.link_audience
+    // Coherence: public listing means the link works for the world, full stop.
+    // An explicit contradiction is a 400; carried-over current values resolve to
+    // the nearest coherent state (matching what a legacy visibility=public or
+    // visibility=password change always meant: world-readable).
+    if (visibility === "public") {
+      if (b.linkAudience === "org")
+        return fail(
+          c,
+          400,
+          "a public artifact's link works for everyone — linkAudience must be public",
+        )
+      if (b.linkRole === "none")
+        return fail(c, 400, "a public artifact's link must grant at least viewer")
+      linkAudience = "public"
+      if (linkRole === "none") linkRole = "viewer"
+    }
     // The password is a lock on the public link. On `public`: a supplied
     // password (re)sets the hash; omitting it keeps the existing lock (so
-    // flipping view↔comment doesn't drop it); an explicit empty string clears
-    // it. Leaving `public` always clears — a lock on org/private is meaningless
-    // (both are already explicit-standing-only) and a stale hash must not
-    // resurrect if the doc later goes public again.
+    // changing the link grant doesn't drop it); an explicit empty string clears
+    // it. Leaving `public` always clears — a lock off public is meaningless and a
+    // stale hash must not resurrect if the doc later goes public again.
     let passwordHash: string | null = null
     if (visibility === "public") {
       if (b.password) passwordHash = hashPassword(b.password)
@@ -746,8 +824,13 @@ export const artifactRoutes = (ctx: AppContext) => {
     // carry a password (or already have one) or the lock would silently vanish.
     if (b.visibility === "password" && !passwordHash)
       return fail(c, 400, "a password is required for password visibility")
-    await meta.setVisibility(artifact.id, visibility, passwordHash, generalRole)
-    return c.json({ visibility, general_role: generalRole, locked: !!passwordHash })
+    await meta.setVisibility(artifact.id, visibility, passwordHash, linkRole, linkAudience)
+    return c.json({
+      visibility,
+      link_role: linkRole,
+      link_audience: linkAudience,
+      locked: !!passwordHash,
+    })
   })
 
   // Lock / unlock an artifact. Any editor (publish rights) can flip it. While

--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -31,7 +31,12 @@ export const realtimeRoutes = (ctx: AppContext) => {
     artifact: Parameters<typeof actorFor>[1],
   ): Promise<Viewer> => {
     const me = await currentUser(c)
-    const role = effectiveRole(await actorFor(c, artifact), artifact.visibility)
+    const role = effectiveRole(
+      await actorFor(c, artifact),
+      artifact.visibility,
+      artifact.link_role,
+      artifact.link_audience,
+    )
     return me
       ? { id: me.id, name: me.username ?? "someone", role }
       : { id: anonViewerId(c), name: anonName(anonViewerId(c)), role }

--- a/apps/api/src/routes/session.ts
+++ b/apps/api/src/routes/session.ts
@@ -324,7 +324,14 @@ export const sessionRoutes = (ctx: AppContext) => {
     // access. A pure read-only viewer gets just themselves.
     if (
       artifact &&
-      (isToken(c) || can(await actorFor(c, artifact), "comment", artifact.visibility))
+      (isToken(c) ||
+        can(
+          await actorFor(c, artifact),
+          "comment",
+          artifact.visibility,
+          artifact.link_role,
+          artifact.link_audience,
+        ))
     ) {
       for (const m of await meta.listArtifactMembers(artifact.id)) ids.add(m.user_id)
       for (const cm of await meta.listComments(artifact.id)) if (cm.author_id) ids.add(cm.author_id)

--- a/apps/api/src/routes/sharing.ts
+++ b/apps/api/src/routes/sharing.ts
@@ -19,7 +19,7 @@ export const sharingRoutes = (ctx: AppContext) => {
   // confers `manage`) and DELETE the real owner, seizing the artifact.
   const rank = (r: Role | null): number => (r ? ROLES.indexOf(r) : -1)
   const callerRank = async (c: Context, a: ArtifactRecord): Promise<number> =>
-    rank(effectiveRole(await actorFor(c, a), a.visibility))
+    rank(effectiveRole(await actorFor(c, a), a.visibility, a.link_role, a.link_audience))
 
   app.get("/v1/artifacts/:shortId/members", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))

--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -329,6 +329,11 @@ export const workspaceRoutes = (ctx: AppContext) => {
           // `public` is deliberately not offered: an agent default should never
           // make work world-readable without a human's per-doc decision.
           defaultAgentVisibility: z.enum(["private", "org"]),
+          // The link grant pair NEW publishes land with (round 4): who the URL
+          // works for x what it confers. Factory: org . commenter ("Workspace .
+          // can comment"). Changing these never touches existing artifacts.
+          defaultLinkRole: z.enum(["none", "viewer", "commenter", "editor"]),
+          defaultLinkAudience: z.enum(["org", "public"]),
         })
         .partial(),
     )

--- a/apps/api/test/comment-access.test.ts
+++ b/apps/api/test/comment-access.test.ts
@@ -53,10 +53,13 @@ describe("comment access via the general-access link", () => {
       (await app.request(`/v1/artifacts/${shortId}/comments`, json({ body_md: "no" }))).status,
     ).toBe(403)
 
-    // my_role reflects the grant per caller; the GET returns the persisted general_role.
+    // my_role reflects the grant per caller; the GET returns the persisted link
+    // pair (the legacy generalRole PATCH above landed on link_role, audience
+    // forced public by the coherence rule).
     const bobView = await (await view(shortId, as(bob.email))).json()
     expect(bobView.my_role).toBe("commenter")
-    expect(bobView.general_role).toBe("commenter")
+    expect(bobView.link_role).toBe("commenter")
+    expect(bobView.link_audience).toBe("public")
     const anonView = await (await view(shortId)).json()
     expect(anonView.my_role).toBe("viewer")
   })
@@ -70,5 +73,67 @@ describe("comment access via the general-access link", () => {
     // Flip back to view-only: the same reacher can no longer comment.
     expect((await setAccess(shortId, "viewer")).ok).toBe(true)
     expect((await comment(shortId, as(bob.email))).status).toBe(403)
+  })
+})
+
+// The workspace-audience link (round 4, scenario 1): a private artifact's URL
+// admits workspace members at the link's grant — the review loop works on a
+// pasted link — while outsiders and anonymous stay out entirely.
+describe("comment access via the workspace link", () => {
+  const dana: TestUser = {
+    id: "u_ca_dana",
+    email: "dana@ca.test",
+    name: "Dana",
+    username: "danac",
+  }
+  const memo: TestUser = {
+    id: "u_ca_memo",
+    email: "memo@ca.test",
+    name: "Memo",
+    username: "memoc",
+  }
+  // Otto signs in to the SAME app but never joins Dana's workspace (isolated:
+  // everyone provisions their own; Dana then invites only Memo) — the
+  // signed-in-outsider column of the state table.
+  const otto: TestUser = { id: "u_ca_otto", email: "otto@ca.test", name: "Otto" }
+  const { app } = makeAuthedApp("comment-access-org", [dana, memo, otto], undefined, {
+    isolated: true,
+  })
+
+  it("a member comments on a private doc via the default link; an outsider gets 404", async () => {
+    await app.request("/v1/me", { headers: as(dana.email) }) // provision Dana's workspace
+    await app.request("/v1/me", { headers: as(otto.email) }) // Otto provisions his own
+    // Dana seats Memo in her workspace; Otto stays outside.
+    expect(
+      (
+        await app.request("/v1/workspace/members", {
+          ...jsonAs(as(dana.email), { user: "memoc", role: "commenter" }),
+          method: "PUT",
+        })
+      ).ok,
+    ).toBe(true)
+
+    // The factory default pair (org · commenter) — no fields sent.
+    const a = await (await publishAs(app, "<h1>draft</h1>", {}, as(dana.email))).json()
+    expect(a.visibility).toBe("private")
+    expect(a.link_role).toBe("commenter")
+    expect(a.link_audience).toBe("org")
+
+    // Memo (workspace member, no share) comments through the link.
+    expect(
+      (
+        await app.request(
+          `/v1/artifacts/${a.short_id}/comments`,
+          jsonAs(as(memo.email), { body_md: "left a note via the pasted link" }),
+        )
+      ).ok,
+    ).toBe(true)
+
+    // Otto is signed in but outside the workspace: the same URL is inert (404,
+    // indistinguishable from not existing). Anonymous likewise.
+    expect(
+      (await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(otto.email) })).status,
+    ).toBe(404)
+    expect((await app.request(`/v1/artifacts/${a.short_id}`)).status).toBe(404)
   })
 })

--- a/apps/api/test/contexts.test.ts
+++ b/apps/api/test/contexts.test.ts
@@ -106,8 +106,18 @@ describe("sessions: the ask → answer → follow-up loop", () => {
       await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Analyst", role: "editor" }))
     ).json()
     agentToken = ag.token
+    // link_role none = true invite-only: the round-4 workspace-default link would
+    // otherwise admit Daniel (a member) before the explicit share — this test is
+    // about the manifest GATE, so the link stays inert.
     manifestShortId = (
-      await (await publishAs(app, "# Manifest", { visibility: "private" }, as(owner.email))).json()
+      await (
+        await publishAs(
+          app,
+          "# Manifest",
+          { visibility: "private", link_role: "none" },
+          as(owner.email),
+        )
+      ).json()
     ).short_id
     const x = await (
       await app.request(

--- a/apps/api/test/cross-doc.test.ts
+++ b/apps/api/test/cross-doc.test.ts
@@ -33,6 +33,8 @@ const seedHtml = async (opts: {
     slug: opts.slug,
     title: opts.shortId,
     visibility: "public",
+    link_role: "viewer",
+    link_audience: "public",
     kind: "file",
     spa: 0,
   })
@@ -98,6 +100,8 @@ describe("cross-document links between synced sibling artifacts", () => {
       slug: "other-walk",
       title: "other",
       visibility: "public",
+      link_role: "viewer",
+      link_audience: "public",
       kind: "file",
       spa: 0,
     })

--- a/apps/api/test/integrations-settings.test.ts
+++ b/apps/api/test/integrations-settings.test.ts
@@ -17,6 +17,9 @@ describe("workspace integration settings", () => {
       githubPreviewLink: true,
       slackPost: true,
       defaultAgentVisibility: "private",
+      // Round 4: the link grant NEW publishes land with — Workspace · can comment.
+      defaultLinkRole: "commenter",
+      defaultLinkAudience: "org",
     })
   })
 

--- a/apps/api/test/link-grant.test.ts
+++ b/apps/api/test/link-grant.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest"
+import { as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// The round-4 link grant pair at the route layer: default resolution (explicit >
+// workspace setting > factory), the public-coherence rule (states 15/16 of the
+// table in docs/plans/link-grant.md are unrepresentable), set-on-create, and the
+// PATCH update semantics. The access matrix itself is covered in @derive/core;
+// scenario end-to-ends live in visibility.test.ts + comment-access.test.ts.
+describe("the link grant pair: defaults, coherence, updates", () => {
+  const ana: TestUser = { id: "u_lg_ana", email: "ana@lg.test", name: "Ana", username: "anal" }
+
+  const patchAccess = (
+    app: ReturnType<typeof makeAuthedApp>["app"],
+    shortId: string,
+    body: Record<string, unknown>,
+  ) =>
+    app.request(`/v1/artifacts/${shortId}/visibility`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json", ...as(ana.email) },
+      body: JSON.stringify(body),
+    })
+
+  it("factory default: private listing + Workspace · can comment", async () => {
+    const { app } = makeAuthedApp("lg-factory", [ana], "editor")
+    const a = await (await publishAs(app, "<h1>d</h1>", {}, as(ana.email))).json()
+    expect(a).toMatchObject({
+      visibility: "private",
+      link_role: "commenter",
+      link_audience: "org",
+    })
+  })
+
+  it("the workspace default overrides the factory; an explicit field beats both", async () => {
+    const { app } = makeAuthedApp("lg-settings", [ana], "editor")
+    await app.request("/v1/workspace/settings", {
+      method: "PATCH",
+      headers: { "content-type": "application/json", ...as(ana.email) },
+      body: JSON.stringify({ defaultLinkRole: "viewer", defaultLinkAudience: "public" }),
+    })
+    // Workspace default applies (an unlisted world view-link — scenario 2 as policy).
+    const a = await (await publishAs(app, "<h1>a</h1>", {}, as(ana.email))).json()
+    expect(a).toMatchObject({ link_role: "viewer", link_audience: "public" })
+    // Explicit request fields beat the setting.
+    const b = await (
+      await publishAs(
+        app,
+        "<h1>b</h1>",
+        { link_role: "editor", link_audience: "org" },
+        as(ana.email),
+      )
+    ).json()
+    expect(b).toMatchObject({ link_role: "editor", link_audience: "org" })
+  })
+
+  it("a bare visibility=public publish gets the classic pair (public · viewer), never the workspace role", async () => {
+    const { app } = makeAuthedApp("lg-public-bare", [ana], "editor")
+    // The workspace default (commenter) is chosen for the WORKSPACE audience — a
+    // world link must not silently inherit it (pre-round-4 public = view-only link).
+    const a = await (
+      await publishAs(app, "<h1>p</h1>", { visibility: "public" }, as(ana.email))
+    ).json()
+    expect(a).toMatchObject({
+      visibility: "public",
+      link_role: "viewer",
+      link_audience: "public",
+    })
+    // Explicitly widening a public link still works.
+    const b = await (
+      await publishAs(
+        app,
+        "<h1>q</h1>",
+        { visibility: "public", link_role: "commenter" },
+        as(ana.email),
+      )
+    ).json()
+    expect(b).toMatchObject({ link_role: "commenter", link_audience: "public" })
+  })
+
+  it("coherence: public + org audience / none role are 400s, on publish and PATCH", async () => {
+    const { app } = makeAuthedApp("lg-coherence", [ana], "editor")
+    expect(
+      (
+        await publishAs(
+          app,
+          "<h1>x</h1>",
+          { visibility: "public", link_audience: "org" },
+          as(ana.email),
+        )
+      ).status,
+    ).toBe(400)
+    expect(
+      (
+        await publishAs(
+          app,
+          "<h1>x</h1>",
+          { visibility: "public", link_role: "none" },
+          as(ana.email),
+        )
+      ).status,
+    ).toBe(400)
+    const a = await (await publishAs(app, "<h1>x</h1>", {}, as(ana.email))).json()
+    expect(
+      (await patchAccess(app, a.short_id, { visibility: "public", linkAudience: "org" })).status,
+    ).toBe(400)
+    expect(
+      (await patchAccess(app, a.short_id, { visibility: "public", linkRole: "none" })).status,
+    ).toBe(400)
+  })
+
+  it("PATCH updates the pair independently and preserves omitted halves", async () => {
+    const { app } = makeAuthedApp("lg-patch", [ana], "editor")
+    const a = await (await publishAs(app, "<h1>d</h1>", {}, as(ana.email))).json()
+    // Widen the audience, keep the role.
+    let r = await (
+      await patchAccess(app, a.short_id, { visibility: "private", linkAudience: "public" })
+    ).json()
+    expect(r).toMatchObject({ link_role: "commenter", link_audience: "public" })
+    // Change the role, keep the audience.
+    r = await (
+      await patchAccess(app, a.short_id, { visibility: "private", linkRole: "viewer" })
+    ).json()
+    expect(r).toMatchObject({ link_role: "viewer", link_audience: "public" })
+    // Bare visibility change: both halves carried over.
+    r = await (await patchAccess(app, a.short_id, { visibility: "org" })).json()
+    expect(r).toMatchObject({ link_role: "viewer", link_audience: "public" })
+    // Dial to inert (invite-only): the URL stops working for a non-member holder.
+    await patchAccess(app, a.short_id, { visibility: "private", linkRole: "none" })
+    expect((await app.request(`/v1/artifacts/${a.short_id}`)).status).toBe(404)
+  })
+
+  it("going public coerces a carried-over inert/org link to the classic public pair", async () => {
+    const { app } = makeAuthedApp("lg-public-carry", [ana], "editor")
+    const a = await (
+      await publishAs(app, "<h1>d</h1>", { link_role: "none" }, as(ana.email))
+    ).json()
+    // No explicit link fields with the flip: current none/org resolve to viewer/public
+    // (what a legacy visibility=public change always meant: world-readable).
+    const r = await (await patchAccess(app, a.short_id, { visibility: "public" })).json()
+    expect(r).toMatchObject({
+      visibility: "public",
+      link_role: "viewer",
+      link_audience: "public",
+    })
+    expect((await app.request(`/v1/artifacts/${a.short_id}`)).status).toBe(200)
+  })
+
+  it("the pair is set-on-create: a republish never re-stamps it", async () => {
+    const { app } = makeAuthedApp("lg-republish", [ana], "editor")
+    const a = await (await publishAs(app, "<h1>v1</h1>", {}, as(ana.email))).json()
+    // Change the workspace default AFTER the publish; republishing must not widen.
+    await app.request("/v1/workspace/settings", {
+      method: "PATCH",
+      headers: { "content-type": "application/json", ...as(ana.email) },
+      body: JSON.stringify({ defaultLinkAudience: "public" }),
+    })
+    const v2 = await (
+      await publishAs(
+        app,
+        "<h1>v2</h1>",
+        { link_role: "editor", link_audience: "public" }, // ignored on republish
+        as(ana.email),
+        a.short_id,
+      )
+    ).json()
+    expect(v2).toMatchObject({ link_role: "commenter", link_audience: "org" })
+  })
+
+  it("legacy vocabulary: general_role + visibility=link keep working", async () => {
+    const { app } = makeAuthedApp("lg-legacy", [ana], "editor")
+    // Old field name on publish, with public visibility (the only place it traveled).
+    const a = await (
+      await publishAs(
+        app,
+        "<h1>l</h1>",
+        { visibility: "public", general_role: "commenter" },
+        as(ana.email),
+      )
+    ).json()
+    expect(a).toMatchObject({ link_role: "commenter", link_audience: "public" })
+    // Pre-collapse visibility=link maps to public (round 3) and lands the classic pair.
+    const b = await (
+      await publishAs(app, "<h1>m</h1>", { visibility: "link" }, as(ana.email))
+    ).json()
+    expect(b).toMatchObject({
+      visibility: "public",
+      link_role: "viewer",
+      link_audience: "public",
+    })
+    // Legacy PATCH generalRole still lands on the pair.
+    const r = await (
+      await patchAccess(app, a.short_id, { visibility: "public", generalRole: "viewer" })
+    ).json()
+    expect(r).toMatchObject({ link_role: "viewer", link_audience: "public" })
+  })
+
+  it("an agent publish resolves the same default chain (draft listing, live workspace link)", async () => {
+    const { app } = makeAuthedApp("lg-agent", [ana], "editor")
+    await app.request("/v1/me", { headers: as(ana.email) })
+    const reg = await (
+      await app.request("/v1/agents", jsonAs(as(ana.email), { name: "Scribe", role: "editor" }))
+    ).json()
+    const form = new FormData()
+    form.append("file", new Blob([new TextEncoder().encode("# memo")]), "memo.md")
+    const a = await (
+      await app.request("/v1/artifacts", {
+        method: "POST",
+        body: form,
+        headers: { authorization: `Bearer ${reg.token}` },
+      })
+    ).json()
+    // defaultAgentVisibility keeps the draft out of the library; the link pair is
+    // the workspace default, so the human's teammates can open the paste.
+    expect(a).toMatchObject({
+      visibility: "private",
+      link_role: "commenter",
+      link_audience: "org",
+    })
+  })
+})

--- a/apps/api/test/raw-self-heal.test.ts
+++ b/apps/api/test/raw-self-heal.test.ts
@@ -32,6 +32,8 @@ const seedMislabeled = async (shortId: string) => {
     slug: null,
     title: "Frozen Bench",
     visibility: "public",
+    link_role: "viewer",
+    link_audience: "public",
     kind: "file",
     spa: 0,
   })
@@ -78,6 +80,8 @@ describe("raw render never white-screens + self-heals a mislabeled blob", () => 
       slug: null,
       title: "Notes",
       visibility: "public",
+      link_role: "viewer",
+      link_audience: "public",
       kind: "file",
       spa: 0,
     })

--- a/apps/api/test/visibility.test.ts
+++ b/apps/api/test/visibility.test.ts
@@ -8,23 +8,61 @@ import { as, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 const ana: TestUser = { id: "u_vis_ana", email: "ana@vis.test", name: "Ana", username: "anav" }
 const ben: TestUser = { id: "u_vis_ben", email: "ben@vis.test", name: "Ben", username: "benv" }
 
-describe("publish defaults to private", () => {
-  it("no visibility field ⇒ private; unreadable to anonymous AND workspace members", async () => {
+describe("publish defaults to private + a workspace comment link (round 4)", () => {
+  it("no fields ⇒ private listing, link works for workspace members at commenter", async () => {
     const { app } = makeAuthedApp("vis-default", [ana, ben], "editor")
     const a = await (await publishAs(app, "<h1>draft</h1>", {}, as(ana.email))).json()
     expect(a.visibility).toBe("private")
-    // Anonymous: the detail 404s and the bytes don't serve.
+    // The round-4 factory default: the URL works inside the workspace, at comment.
+    expect(a.link_role).toBe("commenter")
+    expect(a.link_audience).toBe("org")
+    // Anonymous: the detail 404s and the bytes don't serve — anon is never in an
+    // org audience.
     expect((await app.request(`/v1/artifacts/${a.short_id}`)).status).toBe(404)
     expect((await app.request(`/raw/${a.short_id}/v/1/index.html`)).status).toBe(404)
-    // Even a workspace EDITOR can't see it — private means invited people only.
-    expect(
-      (await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(ben.email) })).status,
-    ).toBe(404)
+    // A workspace member HOLDING THE URL just opens it, at the link's grant —
+    // Anir's scenario 1: unlisted, but a pasted link never dead-ends a teammate.
+    const bens = await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(ben.email) })
+    expect(bens.status).toBe(200)
+    expect((await bens.json()).my_role).toBe("commenter")
+    // Unlisted stays unlisted: Ben's library never shows it (the link is the only way in).
+    const bensList = await (await app.request("/v1/artifacts", { headers: as(ben.email) })).json()
+    expect(bensList.artifacts.map((x: { short_id: string }) => x.short_id)).not.toContain(
+      a.short_id,
+    )
     // The publisher owns it (the owner-member row written at publish).
     const mine = await (
       await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(ana.email) })
     ).json()
     expect(mine.my_role).toBe("owner")
+  })
+
+  it("link_role none ⇒ true invite-only: the URL is inert even inside the workspace", async () => {
+    const { app } = makeAuthedApp("vis-none", [ana, ben], "editor")
+    const a = await (
+      await publishAs(app, "<h1>draft</h1>", { link_role: "none" }, as(ana.email))
+    ).json()
+    expect(a.link_role).toBe("none")
+    expect(
+      (await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(ben.email) })).status,
+    ).toBe(404)
+  })
+
+  it("a public-audience link on a private artifact reaches anyone — scenario 2", async () => {
+    const { app } = makeAuthedApp("vis-world-link", [ana], "editor")
+    const a = await (
+      await publishAs(
+        app,
+        "<h1>unlisted</h1>",
+        { link_role: "viewer", link_audience: "public" },
+        as(ana.email),
+      )
+    ).json()
+    expect(a.visibility).toBe("private")
+    // Anonymous holder reads (clamped to view); it is still listed nowhere.
+    const anonView = await app.request(`/v1/artifacts/${a.short_id}`)
+    expect(anonView.status).toBe(200)
+    expect((await anonView.json()).my_role).toBe("viewer")
   })
 })
 
@@ -77,11 +115,11 @@ describe("agents act as their registrant, capped at their registered role", () =
         })
       ).status,
     ).toBe(403)
-    // Private's contract for a teammate: neither the link nor any listing —
-    // the draft is Ana's until she shares or promotes it.
-    expect(
-      (await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(ben.email) })).status,
-    ).toBe(404)
+    // Private's contract for a teammate (round 4): never LISTED — but the URL
+    // works at the workspace default grant (commenter), so a pasted link opens.
+    const bensView = await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(ben.email) })
+    expect(bensView.status).toBe(200)
+    expect((await bensView.json()).my_role).toBe("commenter")
     const bensList = await (await app.request("/v1/artifacts", { headers: as(ben.email) })).json()
     expect(bensList.artifacts.map((x: { short_id: string }) => x.short_id)).not.toContain(
       a.short_id,
@@ -153,14 +191,42 @@ describe("agents act as their registrant, capped at their registered role", () =
       ).status,
     ).toBe(201)
 
-    // Ben's private draft stays invisible to Ana's agent — derived standing is
-    // Ana's, and Ana has none here.
+    // Ben's private draft: Ana's agent is a workspace principal, so the default
+    // workspace link admits it at COMMENTER (round 4) — reading via the URL works,
+    // exactly like any teammate holding the link...
     const bens = await (
       await publishAs(app, "<h1>secret</h1>", { visibility: "private" }, as(ben.email))
     ).json()
+    const read = await app.request(`/v1/artifacts/${bens.short_id}`, {
+      headers: { authorization: `Bearer ${reg.token}` },
+    })
+    expect(read.status).toBe(200)
+    expect((await read.json()).my_role).toBe("commenter")
+    // ...but WORKING on it still needs editor standing, which the link never
+    // grants here — derived standing is Ana's, and Ana has none on Ben's draft.
+    const form3 = new FormData()
+    form3.append("file", new Blob([new TextEncoder().encode("<h1>hijack</h1>")]), "draft.html")
     expect(
       (
-        await app.request(`/v1/artifacts/${bens.short_id}`, {
+        await app.request(`/v1/artifacts/${bens.short_id}/versions`, {
+          method: "POST",
+          body: form3,
+          headers: { authorization: `Bearer ${reg.token}` },
+        })
+      ).status,
+    ).toBe(403)
+    // An inert link (`none`) keeps even the read closed — true invite-only.
+    const sealed = await (
+      await publishAs(
+        app,
+        "<h1>sealed</h1>",
+        { visibility: "private", link_role: "none" },
+        as(ben.email),
+      )
+    ).json()
+    expect(
+      (
+        await app.request(`/v1/artifacts/${sealed.short_id}`, {
           headers: { authorization: `Bearer ${reg.token}` },
         })
       ).status,
@@ -168,11 +234,18 @@ describe("agents act as their registrant, capped at their registered role", () =
   })
 })
 
-describe("private: only invited people", () => {
-  it("hides a private artifact from workspace members until shared", async () => {
+describe("private: invite-only when the link is inert", () => {
+  it("hides an inert-link private artifact from workspace members until shared", async () => {
     const { app } = makeAuthedApp("vis-private", [ana, ben], "editor")
+    // link_role none = round 1 of the state table: true invite-only, the pre-round-4
+    // `private` contract. (The DEFAULT link is org·commenter — covered above.)
     const a = await (
-      await publishAs(app, "<h1>secret</h1>", { visibility: "private" }, as(ana.email))
+      await publishAs(
+        app,
+        "<h1>secret</h1>",
+        { visibility: "private", link_role: "none" },
+        as(ana.email),
+      )
     ).json()
 
     // The creator owns it (the owner-member row written at publish).
@@ -182,7 +255,8 @@ describe("private: only invited people", () => {
     expect(mine.my_role).toBe("owner")
 
     // Ben is a workspace EDITOR and still can't see it — org role grants nothing
-    // on private. Detail, bytes, and the library listing all stay dark.
+    // on private, and the inert link admits no one. Detail, bytes, and the
+    // library listing all stay dark.
     expect(
       (await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(ben.email) })).status,
     ).toBe(404)

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -76,8 +76,12 @@ export interface VersionSession {
   created_at: string
 }
 export type Role = "viewer" | "commenter" | "editor" | "owner"
-/** What general access (the link) grants a reacher: view-only or comment. */
-export type GeneralRole = "viewer" | "commenter"
+/** The link grant pair (round 4): what merely holding the URL grants a reacher the
+ *  audience admits (`none` = the link is inert, invite-only), and who the URL works
+ *  for (`org` = signed-in members of the artifact's workspace, `public` = anyone).
+ *  Anonymous holders are always clamped to view. */
+export type LinkRole = "none" | "viewer" | "commenter" | "editor"
+export type LinkAudience = "org" | "public"
 export interface Artifact {
   short_id: string
   url: string
@@ -87,9 +91,9 @@ export interface Artifact {
   /** Locked: direct publishes are rejected; even editors must propose changes. */
   locked?: boolean
   visibility: string
-  /** The role the general-access link grants (view vs comment). Anonymous reachers are
-   *  always clamped to view regardless; commenting requires signing in. */
-  general_role?: GeneralRole
+  /** The link grant pair: what the URL confers x who it works for. */
+  link_role?: LinkRole
+  link_audience?: LinkAudience
   /** The public link carries a password (the lock). Never the password itself. */
   password_protected?: boolean
   current_version: number
@@ -316,6 +320,9 @@ export interface OrgSettings {
   slackPost: boolean
   /** Where a NEW agent (MCP) publish lands when the agent doesn't say. */
   defaultAgentVisibility: "private" | "org"
+  /** The link grant pair NEW publishes land with (round 4). Factory: org . commenter. */
+  defaultLinkRole: LinkRole
+  defaultLinkAudience: LinkAudience
 }
 /** Slack connection status for the Settings UI. */
 export interface SlackStatus {
@@ -860,18 +867,24 @@ export const api = {
   // cookie and subsequent reads of this artifact succeed.
   unlock: (id: string, password: string): Promise<{ ok: true }> =>
     f(`/v1/artifacts/${id}/unlock`, opts({ password })).then(j),
-  // Change general access from the Share dialog: visibility + the general-access role
-  // (view vs comment). A password is required when enabling `password` visibility for
-  // the first time. Anonymous reachers stay view-only regardless of generalRole.
+  // Change access from the Share dialog: where it's listed (visibility) and the link
+  // grant pair (who the URL works for x what it confers). Omitted link fields keep
+  // the artifact's current values. Anonymous reachers stay view-only regardless.
   setVisibility: (
     id: string,
     visibility: string,
-    generalRole?: GeneralRole,
+    linkRole?: LinkRole,
+    linkAudience?: LinkAudience,
     // A string (re)sets the lock on a public link; "" clears it; undefined keeps it.
     password?: string,
-  ): Promise<{ visibility: string; general_role: GeneralRole; locked: boolean }> =>
+  ): Promise<{
+    visibility: string
+    link_role: LinkRole
+    link_audience: LinkAudience
+    locked: boolean
+  }> =>
     f(`/v1/artifacts/${id}/visibility`, {
-      ...opts({ visibility, generalRole, password }),
+      ...opts({ visibility, linkRole, linkAudience, password }),
       method: "PATCH",
     }).then(j),
   setLocked: (id: string, locked: boolean): Promise<{ locked: boolean }> =>

--- a/apps/web/src/pages/artifact/artifact-top-bar.tsx
+++ b/apps/web/src/pages/artifact/artifact-top-bar.tsx
@@ -1,6 +1,6 @@
 import { Maximize2 } from "lucide-react"
 import { useState } from "react"
-import type { GeneralRole, Role } from "@/api"
+import type { LinkAudience, LinkRole, Role } from "@/api"
 import { Icon } from "@/components/icons"
 import { CollectionsDialog, TagsDialog } from "@/components/shared/organize-dialogs"
 import { Button } from "@/components/ui/button"
@@ -33,7 +33,9 @@ export function ArtifactTopBar(props: {
   orgId?: string
   myRole?: Role | null
   visibility: string
-  generalRole?: GeneralRole
+  /** The link grant pair (round 4): what the URL confers x who it works for. */
+  linkRole?: LinkRole
+  linkAudience?: LinkAudience
   passwordProtected?: boolean
   favorite: boolean
   tags: string[]
@@ -87,7 +89,8 @@ export function ArtifactTopBar(props: {
           shortId={shortId}
           myRole={props.myRole}
           visibility={props.visibility}
-          generalRole={props.generalRole}
+          linkRole={props.linkRole}
+          linkAudience={props.linkAudience}
           passwordProtected={props.passwordProtected}
         />
         <StarButton shortId={shortId} favorite={props.favorite} onChange={props.onFavorite} />

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -371,7 +371,7 @@ export function Artifact() {
   // anonymous visitor never qualifies — on a comment-enabled link they get a "sign in
   // to comment" prompt instead (auth is the gate; see the access matrix).
   const canComment = canCommentWithRole(art.my_role)
-  const promptSignInToComment = shouldPromptSignInToComment(isAnon, art.general_role, !!art.removed)
+  const promptSignInToComment = shouldPromptSignInToComment(isAnon, art.link_role, !!art.removed)
 
   // Sort threads into pinned (anchored & present in this live doc), general
   // (unanchored / orphaned / off-slide), and resolved — pure, from the frame's
@@ -578,7 +578,8 @@ export function Artifact() {
               orgId={art.org_id}
               myRole={art.my_role}
               visibility={art.visibility}
-              generalRole={art.general_role}
+              linkRole={art.link_role}
+              linkAudience={art.link_audience}
               passwordProtected={!!art.password_protected}
               favorite={!!art.favorite}
               tags={art.tags ?? []}

--- a/apps/web/src/pages/artifact/lib/comment-access.ts
+++ b/apps/web/src/pages/artifact/lib/comment-access.ts
@@ -1,4 +1,4 @@
-import type { GeneralRole, Role } from "@/api"
+import type { LinkRole, Role } from "@/api"
 
 /**
  * The UI side of the access matrix (the API is the hard gate; these keep the UI from
@@ -11,11 +11,13 @@ import type { GeneralRole, Role } from "@/api"
 export const canCommentWithRole = (role: Role | null | undefined): boolean =>
   role === "commenter" || role === "editor" || role === "owner"
 
-/** Should an anonymous visitor be offered "sign in to comment"? Only when the link's
- *  general access actually grants comment (so signing in would lift them to commenter)
- *  and the artifact is live. Anonymous never comments directly: auth is the gate. */
+/** Should an anonymous visitor be offered "sign in to comment"? Only when the link
+ *  actually grants comment or more (so signing in would lift them past viewer) and
+ *  the artifact is live. If an anonymous visitor can SEE the doc at all, the link's
+ *  audience already admitted them, so only the role matters here. Anonymous never
+ *  comments directly: auth is the gate. */
 export const shouldPromptSignInToComment = (
   isAnon: boolean,
-  generalRole: GeneralRole | undefined,
+  linkRole: LinkRole | undefined,
   removed: boolean,
-): boolean => isAnon && generalRole === "commenter" && !removed
+): boolean => isAnon && (linkRole === "commenter" || linkRole === "editor") && !removed

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -55,7 +55,7 @@ const LINK_ROLE_LABELS: Record<Exclude<LinkRole, "none">, string> = {
 }
 const linkBlurb = (audience: string, role: LinkRole): string => {
   if (audience === "invited" || role === "none")
-    return "The link is inert — only people added below can open it."
+    return "The link is inert: only people added below can open it."
   const who = audience === "org" ? "Anyone in this workspace with the link" : "Anyone with the link"
   if (role === "viewer") return `${who} can view.`
   const what = role === "editor" ? "edit" : "comment"
@@ -70,7 +70,7 @@ const LISTING: { value: string; label: string; blurb: string; icon: IconName }[]
   {
     value: "private",
     label: "Not listed",
-    blurb: "In no feeds or libraries — the link above decides who can open it.",
+    blurb: "In no feeds or libraries. The link above decides who can open it.",
     icon: "lock",
   },
   {
@@ -82,7 +82,7 @@ const LISTING: { value: string; label: string; blurb: string; icon: IconName }[]
   {
     value: "public",
     label: "Public",
-    blurb: "Listed publicly — the link works for anyone.",
+    blurb: "Listed publicly. The link works for anyone.",
     icon: "globe",
   },
 ]

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -38,65 +38,55 @@ import { getInitials } from "@/lib/initials"
 import { artifactQuery, workspaceQuery } from "@/lib/queries"
 import { cn } from "@/lib/utils"
 
-// The LINK is the primary control (round 4, docs/plans/link-grant.md): who the
-// URL works for (the audience) × what it grants (the role). "Only invited" is the
-// audience select's spelling of link_role none — the link is inert and the roster
-// below is the only way in. A password is a LOCK on a public listing's link (the
-// checkbox under the listing ladder), not an audience.
-const LINK_AUDIENCES: { value: string; label: string; icon: IconName }[] = [
-  { value: "invited", label: "Only invited", icon: "lock" },
-  { value: "org", label: "Workspace", icon: "workspace" },
-  { value: "public", label: "Anyone", icon: "globe" },
-]
-const LINK_ROLE_LABELS: Record<Exclude<LinkRole, "none">, string> = {
-  viewer: "Can view",
-  commenter: "Can comment",
-  editor: "Can edit",
-}
-const linkBlurb = (audience: string, role: LinkRole): string => {
-  if (audience === "invited" || role === "none")
-    return "The link is inert: only people added below can open it."
-  const who = audience === "org" ? "Anyone in this workspace with the link" : "Anyone with the link"
-  if (role === "viewer") return `${who} can view.`
-  const what = role === "editor" ? "edit" : "comment"
-  return audience === "org"
-    ? `${who} can view and ${what}.`
-    : `${who} can view; signed-in visitors can ${what}.`
-}
-
-// Where it's listed — the secondary control. Discoverability only: the link above
-// decides who can OPEN it.
-const LISTING: { value: string; label: string; blurb: string; icon: IconName }[] = [
+// General access: three audiences, each answering one question — who can open
+// the link. A password is a LOCK on the public option (the checkbox below the
+// select), not a fourth audience.
+const ACCESS: { value: string; label: string; blurb: string; icon: IconName }[] = [
   {
     value: "private",
-    label: "Not listed",
-    blurb: "In no feeds or libraries. The link above decides who can open it.",
+    label: "Private",
+    blurb: "Only people added above. Workspace membership grants nothing.",
     icon: "lock",
   },
   {
     value: "org",
-    label: "Workspace library",
+    label: "Workspace",
     blurb: "Every workspace member can find it in the shared library.",
     icon: "workspace",
   },
   {
     value: "public",
     label: "Public",
-    blurb: "Listed publicly. The link works for anyone.",
+    blurb: "The link works for anyone.",
     icon: "globe",
   },
 ]
 
 // The state glyph the Share trigger carries so exposure is legible without
-// opening the dialog: a globe when the URL alone reads for the world, a lock
-// when the link is inert (invite-only), the plain share glyph for
-// workspace-scoped reach.
-const visibilityIcon = (visibility: string, role?: LinkRole, audience?: LinkAudience): IconName =>
-  visibility === "public" || (audience === "public" && role && role !== "none")
-    ? "globe"
-    : !role || role === "none"
-      ? "lock"
-      : "share"
+// opening the dialog: a globe when the URL alone reads, a lock for invite-only,
+// the plain share glyph for workspace.
+const visibilityIcon = (visibility: string): IconName =>
+  visibility === "public" ? "globe" : visibility === "private" ? "lock" : "share"
+
+// Link access: who the link works for (independent of General access above —
+// it can open this even when General access is Private), and what it grants
+// them. "No one" turns the link off entirely.
+const LINK_AUDIENCE: { value: string; label: string; icon: IconName }[] = [
+  { value: "none", label: "No one", icon: "lock" },
+  { value: "org", label: "Workspace", icon: "workspace" },
+  { value: "public", label: "Public", icon: "globe" },
+]
+const LINK_ROLE_LABEL: Record<Exclude<LinkRole, "none">, string> = {
+  viewer: "Can view",
+  commenter: "Can comment",
+  editor: "Can edit",
+}
+const linkAccessSummary = (audience: string, role: LinkRole): string | null => {
+  if (audience === "none" || role === "none") return null
+  const who = audience === "org" ? "Anyone in the workspace" : "Anyone"
+  const what = role === "viewer" ? "view" : role === "editor" ? "edit" : "comment"
+  return `${who} can ${what}.`
+}
 
 /**
  * Per-artifact sharing, opened from the artifact header. Follows the Google Docs
@@ -116,7 +106,7 @@ export function ShareButton({
   shortId: string
   myRole?: Role | null
   visibility: string
-  /** The link grant pair (round 4): what the URL confers × who it works for. */
+  /** Link access: what the link grants, and who it works for. */
   linkRole?: LinkRole
   linkAudience?: LinkAudience
   /** The public link carries a password (the lock). */
@@ -136,10 +126,11 @@ export function ShareButton({
   const [active, setActive] = useState(-1)
   // The value we just picked, so the follow-up search for it doesn't reopen the menu.
   const picked = useRef("")
-  // Access draft: the listing (visibility) + the link grant pair, plus the lock
-  // (password) state for a public listing's link.
+  // General access draft: visibility + the link's permission (view vs comment), plus
+  // the lock (password) state for a public link.
   const [vis, setVis] = useState(visibility)
-  const [lRole, setLRole] = useState<LinkRole>(linkRole ?? "none")
+  const [lRole, setLRole] = useState<LinkRole>(linkRole ?? "viewer")
+  // Link access draft: who the link works for, independent of General access.
   const [lAudience, setLAudience] = useState<LinkAudience>(linkAudience ?? "org")
   const [pw, setPw] = useState("")
   const [savingVis, setSavingVis] = useState(false)
@@ -181,11 +172,7 @@ export function ShareButton({
   // for others when the artifact is link- or world-readable.
   const origin = API_BASE || (typeof window === "undefined" ? "" : window.location.origin)
   const embedSnippet = `<iframe src="${origin}/v1/embed/${shortId}" width="100%" height="480" style="border:0;border-radius:12px" loading="lazy" title="Derive artifact" allowfullscreen></iframe>`
-  // An embed loads for strangers only when the URL alone reads for the world:
-  // a public listing, or a public-audience link on any listing.
-  const linkAccessible =
-    visibility === "public" ||
-    ((linkAudience ?? "org") === "public" && (linkRole ?? "none") !== "none")
+  const linkAccessible = visibility === "public"
   const copyEmbed = async () => {
     try {
       await navigator.clipboard.writeText(embedSnippet)
@@ -197,20 +184,26 @@ export function ShareButton({
     }
   }
 
-  // The listing-ladder entry for the draft pick (editable) and the server's own
-  // value (view-only render) — looked up once and reused.
-  const currentListing = LISTING.find((a) => a.value === vis)
-  const visibilityListing = LISTING.find((a) => a.value === visibility)
+  // The ladder entry for the draft pick (editable) and the server's own value
+  // (view-only render) — looked up once and reused, rather than re-scanning
+  // ACCESS at every place the icon/label/blurb is needed.
+  const currentAccess = ACCESS.find((a) => a.value === vis)
+  const visibilityAccess = ACCESS.find((a) => a.value === visibility)
   const nav = useNavigate()
-  // Solo drives only the create-a-workspace hint, never the controls — the
-  // Workspace audience stays meaningful for a workspace of one. Managers only,
-  // and not-solo while the roster loads, so nothing flashes.
+  // Solo drives only the create-a-workspace hint, never the ladder itself — the
+  // Workspace row stays meaningful for a workspace of one (it's what lists a doc
+  // in your own library, and promoting an agent's private draft to Workspace is
+  // the loop's blessing gesture). Managers only, and not-solo while the roster
+  // loads, so nothing flashes.
   const { data: workspace } = useQuery({ ...workspaceQuery(), enabled: canManage })
   const solo = workspace ? workspace.members.length <= 1 : false
-  // The audience select's value: "invited" is its spelling of an inert link.
-  const audienceValue = lRole === "none" ? "invited" : lAudience
-  // A public LISTING forces a world link (the coherence rule): the audience
-  // select pins to Anyone and the role select floors at viewer.
+  // Only public reach carries a general-access permission (what the link grants);
+  // private/workspace resolve by explicit standing, so the control hides there.
+  const showRole = vis === "public"
+  // Link access derivations: "none" is its audience select's spelling of the
+  // link being off. A public General access forces a public link underneath
+  // (the coherence rule) — the audience select mirrors and locks to that.
+  const linkAudienceValue = lRole === "none" ? "none" : lAudience
   const publicListed = vis === "public"
   // Everything applies the moment it's picked — a Save button between a select
   // and its effect is friction with no safety benefit (the change is one more
@@ -226,8 +219,9 @@ export function ShareButton({
     setErr(null)
     try {
       const r = await api.setVisibility(shortId, nextVis, nextRole, nextAudience, password)
-      // Mirror the server's resolution (going public coerces the pair to a
-      // coherent state — see the route), not just the local intent.
+      // A public General access forces the link to Public underneath (the
+      // server's coherence rule) — mirror its answer so Link access below
+      // never shows a stale audience/role after that coercion.
       setLRole(r.link_role)
       setLAudience(r.link_audience)
       setHasLock(!!r.locked)
@@ -241,7 +235,7 @@ export function ShareButton({
       setErr(x instanceof Error ? x.message : "Couldn't update access")
       // The selects reflect the server again, not the failed intent.
       setVis(visibility)
-      setLRole(linkRole ?? "none")
+      setLRole(linkRole ?? "viewer")
       setLAudience(linkAudience ?? "org")
     } finally {
       setSavingVis(false)
@@ -251,24 +245,23 @@ export function ShareButton({
     setVis(v)
     setLockDraft(false)
     // Leaving public clears the lock server-side; mirror that locally so
-    // returning to public starts unlocked. Going public: the server coerces the
-    // link to public · ≥viewer; send the current pair and mirror its answer.
+    // returning to public starts unlocked.
     if (v !== "public") setHasLock(false)
     void applyVisibility(v, lRole, lAudience)
   }
-  // The audience pick: "invited" means an inert link (role none, audience kept);
-  // picking a real audience with an inert role turns the link on at the product
-  // default capability (comment — Derive is a review loop).
-  const pickAudience = (a: string) => {
+  const pickGenRole = (r: LinkRole) => {
+    setLRole(r)
+    void applyVisibility(vis, r, lAudience)
+  }
+  // Link access: who the link works for. "No one" turns the link off (role
+  // none); picking a real audience with the link currently off turns it back
+  // on at Can comment, same as a fresh publish's default.
+  const pickLinkAudience = (a: string) => {
     const nextAudience: LinkAudience = a === "public" ? "public" : "org"
-    const nextRole: LinkRole = a === "invited" ? "none" : lRole === "none" ? "commenter" : lRole
+    const nextRole: LinkRole = a === "none" ? "none" : lRole === "none" ? "commenter" : lRole
     setLAudience(nextAudience)
     setLRole(nextRole)
     void applyVisibility(vis, nextRole, nextAudience)
-  }
-  const pickLinkRole = (r: LinkRole) => {
-    setLRole(r)
-    void applyVisibility(vis, r, lAudience)
   }
   // The lock checkbox: checking reveals the password input (applies on Set);
   // unchecking clears the lock immediately (an explicit empty password).
@@ -436,7 +429,7 @@ export function ShareButton({
         if (o) {
           setErr(null)
           setVis(visibility)
-          setLRole(linkRole ?? "none")
+          setLRole(linkRole ?? "viewer")
           setLAudience(linkAudience ?? "org")
           setPw("")
           setPwOpen(false)
@@ -456,7 +449,7 @@ export function ShareButton({
             eye lands). Everything else in the bar is ghost. The glyph carries the
             exposure state: globe = the URL alone reads, lock = invite-only. */}
         <Button data-testid="share-trigger" variant="default" size="sm">
-          <Icon name={visibilityIcon(visibility, linkRole, linkAudience)} />
+          <Icon name={visibilityIcon(visibility)} />
           Share
         </Button>
       </DialogTrigger>
@@ -473,39 +466,28 @@ export function ShareButton({
         </DialogHeader>
 
         <div className="flex flex-col gap-6">
-          {/* The LINK — the primary control. Who the URL works for × what it
-              grants; the listing ladder below only governs discoverability. */}
           <div>
             <SectionEyebrow action={savingVis && <Spinner className="size-3" />}>
-              Link access
+              General access
             </SectionEyebrow>
             {canManage ? (
               <div className="mt-2 flex flex-col gap-2 rounded-lg bg-secondary p-3">
                 <div className="flex gap-1.5">
-                  <SelectMenu
-                    value={publicListed ? "public" : audienceValue}
-                    onValueChange={pickAudience}
-                  >
+                  <SelectMenu value={vis} onValueChange={pickVisibility}>
                     <SelectMenuTrigger
-                      aria-label="Who the link works for"
-                      data-testid="share-link-audience"
-                      disabled={savingVis || publicListed}
+                      aria-label="General access"
+                      data-testid="share-visibility"
+                      disabled={savingVis}
                       className="flex-1 bg-card"
                     >
                       <Icon
-                        name={
-                          LINK_AUDIENCES.find(
-                            (a) => a.value === (publicListed ? "public" : audienceValue),
-                          )?.icon ?? "share"
-                        }
+                        name={currentAccess?.icon ?? "share"}
                         className="text-muted-foreground"
                       />
-                      {LINK_AUDIENCES.find(
-                        (a) => a.value === (publicListed ? "public" : audienceValue),
-                      )?.label ?? audienceValue}
+                      {currentAccess?.label ?? vis}
                     </SelectMenuTrigger>
                     <SelectMenuContent>
-                      {LINK_AUDIENCES.map((a) => (
+                      {ACCESS.map((a) => (
                         <SelectMenuItem key={a.value} value={a.value}>
                           <Icon name={a.icon} className="text-muted-foreground" />
                           {a.label}
@@ -513,98 +495,25 @@ export function ShareButton({
                       ))}
                     </SelectMenuContent>
                   </SelectMenu>
-                  {audienceValue !== "invited" && (
-                    <SelectMenu value={lRole} onValueChange={(v) => pickLinkRole(v as LinkRole)}>
+                  {showRole && (
+                    <SelectMenu value={lRole} onValueChange={(v) => pickGenRole(v as LinkRole)}>
                       <SelectMenuTrigger
-                        aria-label="What the link grants"
-                        data-testid="share-link-role"
+                        aria-label="Link permission"
+                        data-testid="share-general-role"
                         disabled={savingVis}
                         className="bg-card"
                       >
-                        {lRole === "none" ? "Can view" : LINK_ROLE_LABELS[lRole]}
+                        {lRole === "commenter" ? "Can comment" : "Can view"}
                       </SelectMenuTrigger>
                       <SelectMenuContent>
                         <SelectMenuItem value="viewer">Can view</SelectMenuItem>
                         <SelectMenuItem value="commenter">Can comment</SelectMenuItem>
-                        <SelectMenuItem value="editor">Can edit</SelectMenuItem>
                       </SelectMenuContent>
                     </SelectMenu>
                   )}
                 </div>
-                <p className="text-sm text-muted-foreground">
-                  {linkBlurb(publicListed ? "public" : audienceValue, lRole)}
-                  {audienceValue === "public" &&
-                    !publicListed &&
-                    " It stays out of every feed and library."}
-                </p>
-                {/* First-need on-ramp: the word "workspace" earns its first
-                    appearance by answering "how do I show this to my team?". */}
-                {solo && (
-                  <p className="text-sm text-muted-foreground">
-                    Working with a team?{" "}
-                    <Button
-                      variant="link"
-                      size="xs"
-                      data-testid="share-create-workspace"
-                      className="px-0"
-                      onClick={() =>
-                        nav({
-                          to: "/settings/$section",
-                          params: { section: "general" },
-                          search: { "new-workspace": "1" },
-                        })
-                      }
-                    >
-                      Create a workspace
-                    </Button>{" "}
-                    to share with them.
-                  </p>
-                )}
-              </div>
-            ) : (
-              <p className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
-                <Icon name={visibilityIcon(visibility, linkRole, linkAudience)} />
-                {linkBlurb(
-                  visibility === "public"
-                    ? "public"
-                    : (linkRole ?? "none") === "none"
-                      ? "invited"
-                      : (linkAudience ?? "org"),
-                  linkRole ?? "none",
-                )}
-              </p>
-            )}
-          </div>
-
-          {/* Where it's listed — discoverability only. */}
-          <div>
-            <SectionEyebrow>Where it's listed</SectionEyebrow>
-            {canManage ? (
-              <div className="mt-2 flex flex-col gap-2 rounded-lg bg-secondary p-3">
-                <SelectMenu value={vis} onValueChange={pickVisibility}>
-                  <SelectMenuTrigger
-                    aria-label="Where it's listed"
-                    data-testid="share-visibility"
-                    disabled={savingVis}
-                    className="flex-1 bg-card"
-                  >
-                    <Icon
-                      name={currentListing?.icon ?? "share"}
-                      className="text-muted-foreground"
-                    />
-                    {currentListing?.label ?? vis}
-                  </SelectMenuTrigger>
-                  <SelectMenuContent>
-                    {LISTING.map((a) => (
-                      <SelectMenuItem key={a.value} value={a.value}>
-                        <Icon name={a.icon} className="text-muted-foreground" />
-                        {a.label}
-                      </SelectMenuItem>
-                    ))}
-                  </SelectMenuContent>
-                </SelectMenu>
-                {/* The lock — a modifier on a public listing's link, not an audience.
-                    Members and people added below never need the password. */}
+                {/* The lock — a modifier on the public link, not an audience.
+                    Members and people added above never need the password. */}
                 {vis === "public" && (
                   <label className="flex items-center gap-2 text-sm text-foreground">
                     <Checkbox
@@ -647,7 +556,11 @@ export function ShareButton({
                 <p className="text-sm text-muted-foreground">
                   {lockDraft && !hasLock
                     ? "The lock applies once a password is set."
-                    : (currentListing?.blurb ?? "")}
+                    : (currentAccess?.blurb ?? "")}
+                  {!lockDraft &&
+                    vis === "public" &&
+                    lRole === "commenter" &&
+                    " Signed-in visitors can comment."}
                   {!lockDraft && vis === "public" && hasLock && !pwOpen && (
                     <Button
                       variant="link"
@@ -660,11 +573,117 @@ export function ShareButton({
                     </Button>
                   )}
                 </p>
+                {/* First-need on-ramp: the word "workspace" earns its first
+                    appearance by answering "how do I show this to my team?". */}
+                {solo && (
+                  <p className="text-sm text-muted-foreground">
+                    Working with a team?{" "}
+                    <Button
+                      variant="link"
+                      size="xs"
+                      data-testid="share-create-workspace"
+                      className="px-0"
+                      onClick={() =>
+                        nav({
+                          to: "/settings/$section",
+                          params: { section: "general" },
+                          search: { "new-workspace": "1" },
+                        })
+                      }
+                    >
+                      Create a workspace
+                    </Button>{" "}
+                    to share with them.
+                  </p>
+                )}
               </div>
             ) : (
               <p className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
-                <Icon name={visibilityListing?.icon ?? "share"} />
-                {visibilityListing?.label ?? visibility}
+                <Icon name={visibilityAccess?.icon ?? "share"} />
+                {visibilityAccess?.label ?? visibility}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <SectionEyebrow action={savingVis && <Spinner className="size-3" />}>
+              Link access
+            </SectionEyebrow>
+            {canManage ? (
+              <div className="mt-2 flex flex-col gap-2 rounded-lg bg-secondary p-3">
+                {linkAccessSummary(linkAudienceValue, lRole) && (
+                  <p className="text-sm font-medium text-foreground">
+                    {linkAccessSummary(linkAudienceValue, lRole)}
+                  </p>
+                )}
+                <div className="flex gap-1.5">
+                  <SelectMenu
+                    value={publicListed ? "public" : linkAudienceValue}
+                    onValueChange={pickLinkAudience}
+                  >
+                    <SelectMenuTrigger
+                      aria-label="Who the link works for"
+                      data-testid="share-link-audience"
+                      disabled={savingVis || publicListed}
+                      className="flex-1 bg-card"
+                    >
+                      <Icon
+                        name={
+                          LINK_AUDIENCE.find(
+                            (a) => a.value === (publicListed ? "public" : linkAudienceValue),
+                          )?.icon ?? "share"
+                        }
+                        className="text-muted-foreground"
+                      />
+                      {LINK_AUDIENCE.find(
+                        (a) => a.value === (publicListed ? "public" : linkAudienceValue),
+                      )?.label ?? linkAudienceValue}
+                    </SelectMenuTrigger>
+                    <SelectMenuContent>
+                      {LINK_AUDIENCE.map((a) => (
+                        <SelectMenuItem key={a.value} value={a.value}>
+                          <Icon name={a.icon} className="text-muted-foreground" />
+                          {a.label}
+                        </SelectMenuItem>
+                      ))}
+                    </SelectMenuContent>
+                  </SelectMenu>
+                  {linkAudienceValue !== "none" && (
+                    <SelectMenu value={lRole} onValueChange={(v) => pickGenRole(v as LinkRole)}>
+                      <SelectMenuTrigger
+                        aria-label="What the link grants"
+                        data-testid="share-link-role"
+                        disabled={savingVis}
+                        className="bg-card"
+                      >
+                        {lRole === "none" ? "Can view" : LINK_ROLE_LABEL[lRole]}
+                      </SelectMenuTrigger>
+                      <SelectMenuContent>
+                        <SelectMenuItem value="viewer">Can view</SelectMenuItem>
+                        <SelectMenuItem value="commenter">Can comment</SelectMenuItem>
+                        <SelectMenuItem value="editor">Can edit</SelectMenuItem>
+                      </SelectMenuContent>
+                    </SelectMenu>
+                  )}
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  People with the link can open this, even when General access above is Private.
+                </p>
+              </div>
+            ) : (
+              <p className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
+                <Icon
+                  name={
+                    LINK_AUDIENCE.find(
+                      (a) =>
+                        a.value === (visibility === "public" ? "public" : (linkAudience ?? "org")),
+                    )?.icon ?? "share"
+                  }
+                />
+                {linkAccessSummary(
+                  visibility === "public" ? "public" : (linkAudience ?? "org"),
+                  linkRole ?? "viewer",
+                ) ?? "No one — only people added below can open it."}
               </p>
             )}
           </div>
@@ -898,7 +917,7 @@ export function ShareButton({
               <p className="mt-1.5 text-sm text-muted-foreground">
                 {linkAccessible
                   ? "Paste into any page — live, with a link back to Derive."
-                  : "Set the link to work for Anyone for the embed to load for others."}
+                  : "Set access to “Public” or “Public — link only” for the embed to load for others."}
               </p>
             </div>
 

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -6,7 +6,8 @@ import {
   type ArtifactDomain,
   type ArtifactMember,
   api,
-  type GeneralRole,
+  type LinkAudience,
+  type LinkRole,
   type PublicProfile,
   type Role,
 } from "@/api"
@@ -37,35 +38,65 @@ import { getInitials } from "@/lib/initials"
 import { artifactQuery, workspaceQuery } from "@/lib/queries"
 import { cn } from "@/lib/utils"
 
-// General access: three audiences, each answering one question — who can open
-// the link. A password is a LOCK on the public option (the checkbox below the
-// select), not a fourth audience.
-const ACCESS: { value: string; label: string; blurb: string; icon: IconName }[] = [
+// The LINK is the primary control (round 4, docs/plans/link-grant.md): who the
+// URL works for (the audience) × what it grants (the role). "Only invited" is the
+// audience select's spelling of link_role none — the link is inert and the roster
+// below is the only way in. A password is a LOCK on a public listing's link (the
+// checkbox under the listing ladder), not an audience.
+const LINK_AUDIENCES: { value: string; label: string; icon: IconName }[] = [
+  { value: "invited", label: "Only invited", icon: "lock" },
+  { value: "org", label: "Workspace", icon: "workspace" },
+  { value: "public", label: "Anyone", icon: "globe" },
+]
+const LINK_ROLE_LABELS: Record<Exclude<LinkRole, "none">, string> = {
+  viewer: "Can view",
+  commenter: "Can comment",
+  editor: "Can edit",
+}
+const linkBlurb = (audience: string, role: LinkRole): string => {
+  if (audience === "invited" || role === "none")
+    return "The link is inert — only people added below can open it."
+  const who = audience === "org" ? "Anyone in this workspace with the link" : "Anyone with the link"
+  if (role === "viewer") return `${who} can view.`
+  const what = role === "editor" ? "edit" : "comment"
+  return audience === "org"
+    ? `${who} can view and ${what}.`
+    : `${who} can view; signed-in visitors can ${what}.`
+}
+
+// Where it's listed — the secondary control. Discoverability only: the link above
+// decides who can OPEN it.
+const LISTING: { value: string; label: string; blurb: string; icon: IconName }[] = [
   {
     value: "private",
-    label: "Private",
-    blurb: "Only people added above. Workspace membership grants nothing.",
+    label: "Not listed",
+    blurb: "In no feeds or libraries — the link above decides who can open it.",
     icon: "lock",
   },
   {
     value: "org",
-    label: "Workspace",
+    label: "Workspace library",
     blurb: "Every workspace member can find it in the shared library.",
     icon: "workspace",
   },
   {
     value: "public",
     label: "Public",
-    blurb: "The link works for anyone.",
+    blurb: "Listed publicly — the link works for anyone.",
     icon: "globe",
   },
 ]
 
 // The state glyph the Share trigger carries so exposure is legible without
-// opening the dialog: a globe when the URL alone reads, a lock for invite-only,
-// the plain share glyph for workspace.
-const visibilityIcon = (visibility: string): IconName =>
-  visibility === "public" ? "globe" : visibility === "private" ? "lock" : "share"
+// opening the dialog: a globe when the URL alone reads for the world, a lock
+// when the link is inert (invite-only), the plain share glyph for
+// workspace-scoped reach.
+const visibilityIcon = (visibility: string, role?: LinkRole, audience?: LinkAudience): IconName =>
+  visibility === "public" || (audience === "public" && role && role !== "none")
+    ? "globe"
+    : !role || role === "none"
+      ? "lock"
+      : "share"
 
 /**
  * Per-artifact sharing, opened from the artifact header. Follows the Google Docs
@@ -78,13 +109,16 @@ export function ShareButton({
   shortId,
   myRole,
   visibility,
-  generalRole,
+  linkRole,
+  linkAudience,
   passwordProtected = false,
 }: {
   shortId: string
   myRole?: Role | null
   visibility: string
-  generalRole?: GeneralRole
+  /** The link grant pair (round 4): what the URL confers × who it works for. */
+  linkRole?: LinkRole
+  linkAudience?: LinkAudience
   /** The public link carries a password (the lock). */
   passwordProtected?: boolean
 }) {
@@ -102,10 +136,11 @@ export function ShareButton({
   const [active, setActive] = useState(-1)
   // The value we just picked, so the follow-up search for it doesn't reopen the menu.
   const picked = useRef("")
-  // General access draft: visibility + the link's permission (view vs comment), plus
-  // the lock (password) state for a public link.
+  // Access draft: the listing (visibility) + the link grant pair, plus the lock
+  // (password) state for a public listing's link.
   const [vis, setVis] = useState(visibility)
-  const [genRole, setGenRole] = useState<GeneralRole>(generalRole ?? "viewer")
+  const [lRole, setLRole] = useState<LinkRole>(linkRole ?? "none")
+  const [lAudience, setLAudience] = useState<LinkAudience>(linkAudience ?? "org")
   const [pw, setPw] = useState("")
   const [savingVis, setSavingVis] = useState(false)
   // The lock as the server knows it, kept locally current as we set/clear it.
@@ -146,7 +181,11 @@ export function ShareButton({
   // for others when the artifact is link- or world-readable.
   const origin = API_BASE || (typeof window === "undefined" ? "" : window.location.origin)
   const embedSnippet = `<iframe src="${origin}/v1/embed/${shortId}" width="100%" height="480" style="border:0;border-radius:12px" loading="lazy" title="Derive artifact" allowfullscreen></iframe>`
-  const linkAccessible = visibility === "public"
+  // An embed loads for strangers only when the URL alone reads for the world:
+  // a public listing, or a public-audience link on any listing.
+  const linkAccessible =
+    visibility === "public" ||
+    ((linkAudience ?? "org") === "public" && (linkRole ?? "none") !== "none")
   const copyEmbed = async () => {
     try {
       await navigator.clipboard.writeText(embedSnippet)
@@ -158,31 +197,39 @@ export function ShareButton({
     }
   }
 
-  // The ladder entry for the draft pick (editable) and the server's own value
-  // (view-only render) — looked up once and reused, rather than re-scanning
-  // ACCESS at every place the icon/label/blurb is needed.
-  const currentAccess = ACCESS.find((a) => a.value === vis)
-  const visibilityAccess = ACCESS.find((a) => a.value === visibility)
+  // The listing-ladder entry for the draft pick (editable) and the server's own
+  // value (view-only render) — looked up once and reused.
+  const currentListing = LISTING.find((a) => a.value === vis)
+  const visibilityListing = LISTING.find((a) => a.value === visibility)
   const nav = useNavigate()
-  // Solo drives only the create-a-workspace hint, never the ladder itself — the
-  // Workspace row stays meaningful for a workspace of one (it's what lists a doc
-  // in your own library, and promoting an agent's private draft to Workspace is
-  // the loop's blessing gesture). Managers only, and not-solo while the roster
-  // loads, so nothing flashes.
+  // Solo drives only the create-a-workspace hint, never the controls — the
+  // Workspace audience stays meaningful for a workspace of one. Managers only,
+  // and not-solo while the roster loads, so nothing flashes.
   const { data: workspace } = useQuery({ ...workspaceQuery(), enabled: canManage })
   const solo = workspace ? workspace.members.length <= 1 : false
-  // Only public reach carries a general-access permission (what the link grants);
-  // private/workspace resolve by explicit standing, so the control hides there.
-  const showRole = vis === "public"
+  // The audience select's value: "invited" is its spelling of an inert link.
+  const audienceValue = lRole === "none" ? "invited" : lAudience
+  // A public LISTING forces a world link (the coherence rule): the audience
+  // select pins to Anyone and the role select floors at viewer.
+  const publicListed = vis === "public"
   // Everything applies the moment it's picked — a Save button between a select
   // and its effect is friction with no safety benefit (the change is one more
   // select away from undone). The lock is the one exception: checking the box
   // reveals the input, and nothing applies until Set password.
-  const applyVisibility = async (nextVis: string, nextRole: GeneralRole, password?: string) => {
+  const applyVisibility = async (
+    nextVis: string,
+    nextRole: LinkRole,
+    nextAudience: LinkAudience,
+    password?: string,
+  ) => {
     setSavingVis(true)
     setErr(null)
     try {
-      const r = await api.setVisibility(shortId, nextVis, nextRole, password)
+      const r = await api.setVisibility(shortId, nextVis, nextRole, nextAudience, password)
+      // Mirror the server's resolution (going public coerces the pair to a
+      // coherent state — see the route), not just the local intent.
+      setLRole(r.link_role)
+      setLAudience(r.link_audience)
       setHasLock(!!r.locked)
       setLockDraft(false)
       setPw("")
@@ -194,7 +241,8 @@ export function ShareButton({
       setErr(x instanceof Error ? x.message : "Couldn't update access")
       // The selects reflect the server again, not the failed intent.
       setVis(visibility)
-      setGenRole(generalRole ?? "viewer")
+      setLRole(linkRole ?? "none")
+      setLAudience(linkAudience ?? "org")
     } finally {
       setSavingVis(false)
     }
@@ -203,19 +251,30 @@ export function ShareButton({
     setVis(v)
     setLockDraft(false)
     // Leaving public clears the lock server-side; mirror that locally so
-    // returning to public starts unlocked.
+    // returning to public starts unlocked. Going public: the server coerces the
+    // link to public · ≥viewer; send the current pair and mirror its answer.
     if (v !== "public") setHasLock(false)
-    void applyVisibility(v, genRole)
+    void applyVisibility(v, lRole, lAudience)
   }
-  const pickGenRole = (r: GeneralRole) => {
-    setGenRole(r)
-    void applyVisibility(vis, r)
+  // The audience pick: "invited" means an inert link (role none, audience kept);
+  // picking a real audience with an inert role turns the link on at the product
+  // default capability (comment — Derive is a review loop).
+  const pickAudience = (a: string) => {
+    const nextAudience: LinkAudience = a === "public" ? "public" : "org"
+    const nextRole: LinkRole = a === "invited" ? "none" : lRole === "none" ? "commenter" : lRole
+    setLAudience(nextAudience)
+    setLRole(nextRole)
+    void applyVisibility(vis, nextRole, nextAudience)
+  }
+  const pickLinkRole = (r: LinkRole) => {
+    setLRole(r)
+    void applyVisibility(vis, r, lAudience)
   }
   // The lock checkbox: checking reveals the password input (applies on Set);
   // unchecking clears the lock immediately (an explicit empty password).
   const toggleLock = (on: boolean) => {
     if (on) setLockDraft(true)
-    else if (hasLock) void applyVisibility("public", genRole, "")
+    else if (hasLock) void applyVisibility("public", lRole, lAudience, "")
     else setLockDraft(false)
   }
   const copyLink = async () => {
@@ -377,7 +436,8 @@ export function ShareButton({
         if (o) {
           setErr(null)
           setVis(visibility)
-          setGenRole(generalRole ?? "viewer")
+          setLRole(linkRole ?? "none")
+          setLAudience(linkAudience ?? "org")
           setPw("")
           setPwOpen(false)
           // Re-seed the lock from the server's state and drop any half-typed
@@ -396,7 +456,7 @@ export function ShareButton({
             eye lands). Everything else in the bar is ghost. The glyph carries the
             exposure state: globe = the URL alone reads, lock = invite-only. */}
         <Button data-testid="share-trigger" variant="default" size="sm">
-          <Icon name={visibilityIcon(visibility)} />
+          <Icon name={visibilityIcon(visibility, linkRole, linkAudience)} />
           Share
         </Button>
       </DialogTrigger>
@@ -413,28 +473,39 @@ export function ShareButton({
         </DialogHeader>
 
         <div className="flex flex-col gap-6">
+          {/* The LINK — the primary control. Who the URL works for × what it
+              grants; the listing ladder below only governs discoverability. */}
           <div>
             <SectionEyebrow action={savingVis && <Spinner className="size-3" />}>
-              General access
+              Link access
             </SectionEyebrow>
             {canManage ? (
               <div className="mt-2 flex flex-col gap-2 rounded-lg bg-secondary p-3">
                 <div className="flex gap-1.5">
-                  <SelectMenu value={vis} onValueChange={pickVisibility}>
+                  <SelectMenu
+                    value={publicListed ? "public" : audienceValue}
+                    onValueChange={pickAudience}
+                  >
                     <SelectMenuTrigger
-                      aria-label="General access"
-                      data-testid="share-visibility"
-                      disabled={savingVis}
+                      aria-label="Who the link works for"
+                      data-testid="share-link-audience"
+                      disabled={savingVis || publicListed}
                       className="flex-1 bg-card"
                     >
                       <Icon
-                        name={currentAccess?.icon ?? "share"}
+                        name={
+                          LINK_AUDIENCES.find(
+                            (a) => a.value === (publicListed ? "public" : audienceValue),
+                          )?.icon ?? "share"
+                        }
                         className="text-muted-foreground"
                       />
-                      {currentAccess?.label ?? vis}
+                      {LINK_AUDIENCES.find(
+                        (a) => a.value === (publicListed ? "public" : audienceValue),
+                      )?.label ?? audienceValue}
                     </SelectMenuTrigger>
                     <SelectMenuContent>
-                      {ACCESS.map((a) => (
+                      {LINK_AUDIENCES.map((a) => (
                         <SelectMenuItem key={a.value} value={a.value}>
                           <Icon name={a.icon} className="text-muted-foreground" />
                           {a.label}
@@ -442,85 +513,29 @@ export function ShareButton({
                       ))}
                     </SelectMenuContent>
                   </SelectMenu>
-                  {showRole && (
-                    <SelectMenu
-                      value={genRole}
-                      onValueChange={(v) => pickGenRole(v as GeneralRole)}
-                    >
+                  {audienceValue !== "invited" && (
+                    <SelectMenu value={lRole} onValueChange={(v) => pickLinkRole(v as LinkRole)}>
                       <SelectMenuTrigger
-                        aria-label="Link permission"
-                        data-testid="share-general-role"
+                        aria-label="What the link grants"
+                        data-testid="share-link-role"
                         disabled={savingVis}
                         className="bg-card"
                       >
-                        {genRole === "commenter" ? "Can comment" : "Can view"}
+                        {lRole === "none" ? "Can view" : LINK_ROLE_LABELS[lRole]}
                       </SelectMenuTrigger>
                       <SelectMenuContent>
                         <SelectMenuItem value="viewer">Can view</SelectMenuItem>
                         <SelectMenuItem value="commenter">Can comment</SelectMenuItem>
+                        <SelectMenuItem value="editor">Can edit</SelectMenuItem>
                       </SelectMenuContent>
                     </SelectMenu>
                   )}
                 </div>
-                {/* The lock — a modifier on the public link, not an audience.
-                    Members and people added above never need the password. */}
-                {vis === "public" && (
-                  <label className="flex items-center gap-2 text-sm text-foreground">
-                    <Checkbox
-                      checked={hasLock || lockDraft}
-                      disabled={savingVis}
-                      aria-label="Require a password"
-                      data-testid="share-lock-toggle"
-                      onCheckedChange={(v) => toggleLock(v === true)}
-                    />
-                    Require a password
-                  </label>
-                )}
-                {vis === "public" && (lockDraft || (hasLock && pwOpen)) && (
-                  <div className="flex gap-1.5">
-                    <Input
-                      type="password"
-                      data-testid="share-visibility-password"
-                      placeholder={hasLock ? "New password" : "Set a password"}
-                      aria-label="Password"
-                      value={pw}
-                      onChange={(e) => setPw(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" && pw) void applyVisibility("public", genRole, pw)
-                      }}
-                      className="flex-1"
-                    />
-                    <Button
-                      data-testid="share-visibility-save"
-                      variant="secondary"
-                      size="sm"
-                      disabled={!pw}
-                      loading={savingVis}
-                      onClick={() => void applyVisibility("public", genRole, pw)}
-                    >
-                      {savingVis ? "Setting…" : "Set password"}
-                    </Button>
-                  </div>
-                )}
                 <p className="text-sm text-muted-foreground">
-                  {lockDraft && !hasLock
-                    ? "The lock applies once a password is set."
-                    : (currentAccess?.blurb ?? "")}
-                  {!lockDraft &&
-                    vis === "public" &&
-                    genRole === "commenter" &&
-                    " Signed-in visitors can comment."}
-                  {!lockDraft && vis === "public" && hasLock && !pwOpen && (
-                    <Button
-                      variant="link"
-                      size="xs"
-                      data-testid="share-password-change"
-                      className="ml-1 px-0"
-                      onClick={() => setPwOpen(true)}
-                    >
-                      Change password
-                    </Button>
-                  )}
+                  {linkBlurb(publicListed ? "public" : audienceValue, lRole)}
+                  {audienceValue === "public" &&
+                    !publicListed &&
+                    " It stays out of every feed and library."}
                 </p>
                 {/* First-need on-ramp: the word "workspace" earns its first
                     appearance by answering "how do I show this to my team?". */}
@@ -548,8 +563,108 @@ export function ShareButton({
               </div>
             ) : (
               <p className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
-                <Icon name={visibilityAccess?.icon ?? "share"} />
-                {visibilityAccess?.label ?? visibility}
+                <Icon name={visibilityIcon(visibility, linkRole, linkAudience)} />
+                {linkBlurb(
+                  visibility === "public"
+                    ? "public"
+                    : (linkRole ?? "none") === "none"
+                      ? "invited"
+                      : (linkAudience ?? "org"),
+                  linkRole ?? "none",
+                )}
+              </p>
+            )}
+          </div>
+
+          {/* Where it's listed — discoverability only. */}
+          <div>
+            <SectionEyebrow>Where it's listed</SectionEyebrow>
+            {canManage ? (
+              <div className="mt-2 flex flex-col gap-2 rounded-lg bg-secondary p-3">
+                <SelectMenu value={vis} onValueChange={pickVisibility}>
+                  <SelectMenuTrigger
+                    aria-label="Where it's listed"
+                    data-testid="share-visibility"
+                    disabled={savingVis}
+                    className="flex-1 bg-card"
+                  >
+                    <Icon
+                      name={currentListing?.icon ?? "share"}
+                      className="text-muted-foreground"
+                    />
+                    {currentListing?.label ?? vis}
+                  </SelectMenuTrigger>
+                  <SelectMenuContent>
+                    {LISTING.map((a) => (
+                      <SelectMenuItem key={a.value} value={a.value}>
+                        <Icon name={a.icon} className="text-muted-foreground" />
+                        {a.label}
+                      </SelectMenuItem>
+                    ))}
+                  </SelectMenuContent>
+                </SelectMenu>
+                {/* The lock — a modifier on a public listing's link, not an audience.
+                    Members and people added below never need the password. */}
+                {vis === "public" && (
+                  <label className="flex items-center gap-2 text-sm text-foreground">
+                    <Checkbox
+                      checked={hasLock || lockDraft}
+                      disabled={savingVis}
+                      aria-label="Require a password"
+                      data-testid="share-lock-toggle"
+                      onCheckedChange={(v) => toggleLock(v === true)}
+                    />
+                    Require a password
+                  </label>
+                )}
+                {vis === "public" && (lockDraft || (hasLock && pwOpen)) && (
+                  <div className="flex gap-1.5">
+                    <Input
+                      type="password"
+                      data-testid="share-visibility-password"
+                      placeholder={hasLock ? "New password" : "Set a password"}
+                      aria-label="Password"
+                      value={pw}
+                      onChange={(e) => setPw(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && pw)
+                          void applyVisibility("public", lRole, lAudience, pw)
+                      }}
+                      className="flex-1"
+                    />
+                    <Button
+                      data-testid="share-visibility-save"
+                      variant="secondary"
+                      size="sm"
+                      disabled={!pw}
+                      loading={savingVis}
+                      onClick={() => void applyVisibility("public", lRole, lAudience, pw)}
+                    >
+                      {savingVis ? "Setting…" : "Set password"}
+                    </Button>
+                  </div>
+                )}
+                <p className="text-sm text-muted-foreground">
+                  {lockDraft && !hasLock
+                    ? "The lock applies once a password is set."
+                    : (currentListing?.blurb ?? "")}
+                  {!lockDraft && vis === "public" && hasLock && !pwOpen && (
+                    <Button
+                      variant="link"
+                      size="xs"
+                      data-testid="share-password-change"
+                      className="ml-1 px-0"
+                      onClick={() => setPwOpen(true)}
+                    >
+                      Change password
+                    </Button>
+                  )}
+                </p>
+              </div>
+            ) : (
+              <p className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
+                <Icon name={visibilityListing?.icon ?? "share"} />
+                {visibilityListing?.label ?? visibility}
               </p>
             )}
           </div>
@@ -783,7 +898,7 @@ export function ShareButton({
               <p className="mt-1.5 text-sm text-muted-foreground">
                 {linkAccessible
                   ? "Paste into any page — live, with a link back to Derive."
-                  : "Set access to “Public” or “Public — link only” for the embed to load for others."}
+                  : "Set the link to work for Anyone for the embed to load for others."}
               </p>
             </div>
 

--- a/apps/web/src/pages/settings/general-section.tsx
+++ b/apps/web/src/pages/settings/general-section.tsx
@@ -303,8 +303,53 @@ function SharingDefaults() {
           </SelectMenuContent>
         </SelectMenu>
       </SettingRow>
+      <SettingRow
+        label="New artifact links"
+        description="What a freshly published artifact's URL grants, and to whom. Changing this never touches existing artifacts."
+      >
+        <div className="flex gap-1.5">
+          <SelectMenu
+            value={settings.defaultLinkAudience}
+            onValueChange={(v) =>
+              set("defaultLinkAudience", v as OrgSettings["defaultLinkAudience"])
+            }
+          >
+            <SelectMenuTrigger
+              aria-label="Default link audience"
+              data-testid="default-link-audience"
+            >
+              {settings.defaultLinkAudience === "public" ? "Anyone" : "Workspace"}
+            </SelectMenuTrigger>
+            <SelectMenuContent>
+              <SelectMenuItem value="org">Workspace</SelectMenuItem>
+              <SelectMenuItem value="public">Anyone</SelectMenuItem>
+            </SelectMenuContent>
+          </SelectMenu>
+          <SelectMenu
+            value={settings.defaultLinkRole}
+            onValueChange={(v) => set("defaultLinkRole", v as OrgSettings["defaultLinkRole"])}
+          >
+            <SelectMenuTrigger aria-label="Default link grant" data-testid="default-link-role">
+              {LINK_ROLE_LABELS[settings.defaultLinkRole] ?? settings.defaultLinkRole}
+            </SelectMenuTrigger>
+            <SelectMenuContent>
+              <SelectMenuItem value="none">Inert (invite-only)</SelectMenuItem>
+              <SelectMenuItem value="viewer">Can view</SelectMenuItem>
+              <SelectMenuItem value="commenter">Can comment</SelectMenuItem>
+              <SelectMenuItem value="editor">Can edit</SelectMenuItem>
+            </SelectMenuContent>
+          </SelectMenu>
+        </div>
+      </SettingRow>
     </SettingsGroup>
   )
+}
+
+const LINK_ROLE_LABELS: Record<string, string> = {
+  none: "Inert (invite-only)",
+  viewer: "Can view",
+  commenter: "Can comment",
+  editor: "Can edit",
 }
 
 const AGENT_VIS_LABELS: Record<string, string> = {

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -12,6 +12,8 @@ CREATE TABLE IF NOT EXISTS artifact (
   visibility TEXT NOT NULL DEFAULT 'private',
   password_hash TEXT,
   general_role TEXT NOT NULL DEFAULT 'viewer',
+  link_role TEXT NOT NULL DEFAULT 'none',
+  link_audience TEXT NOT NULL DEFAULT 'org',
   kind TEXT NOT NULL,
   spa INTEGER NOT NULL DEFAULT 0,
   locked INTEGER NOT NULL DEFAULT 0,

--- a/docs/plans/link-grant.md
+++ b/docs/plans/link-grant.md
@@ -1,0 +1,123 @@
+# Round 4: the link grant (audience × capability)
+
+Follow-up to [visibility-collapse.md](./visibility-collapse.md) (round 3, #316).
+Round 3 collapsed visibility to three listing states and retired the `link`
+tier, which also deleted link-reach entirely: a private artifact's URL was dead,
+so every link pasted to a teammate dead-ended. Round 4 restores reach as its own
+axis. Reach was never a listing property either, so it becomes a first-class
+pair instead of a visibility value.
+
+## The one-sentence model
+
+> **Where it's listed** (private · workspace · public) says who can find it.
+> **What the link grants** (`link_audience` × `link_role`) says who the URL
+> works for and what it confers. The two never touch.
+
+## Decisions (2026-07-08, Anir)
+
+1. **The link grant is a PAIR on every artifact.** `link_audience`: `org`
+   (signed-in members of the artifact's workspace) or `public` (any holder).
+   `link_role`: `none` (inert, invite-only), `viewer`, `commenter`, `editor`.
+   Together they express the three-stop dial: the link works for no one /
+   people in my workspace / everyone, at a capability.
+2. **Visibility stays a pure listing ladder.** Membership semantics unchanged:
+   `org`/`public` fold in the member's workspace role; `private` grants members
+   nothing by membership (a workspace owner still cannot open a teammate's
+   sealed draft by role alone). The org-audience link uses membership as the
+   audience KEY, not the grant: it hands a member `link_role`, never their
+   workspace role.
+3. **Anonymous stays clamped to viewer, and is never in an org audience.**
+   The no-trusted-anonymous invariant from round 3 is untouched.
+4. **Factory default: `private` listing + `org · commenter` link ("Workspace ·
+   can comment").** A pasted link never dead-ends a teammate, and Derive is a
+   review loop, so the link hands over the conversation, not just the read.
+   Workspace-settable (`defaultLinkAudience` · `defaultLinkRole`); explicit
+   request fields beat the setting. Set-on-create: a republish never re-stamps.
+   **No retroactive widening**: changing a default never touches existing rows.
+5. **Coherence rule (the only write-time constraint):** `visibility=public`
+   requires a `public` link at `viewer` or above (GitHub semantics: public means
+   the link works, full stop). An explicit contradiction is a 400, never a
+   silent coercion. A bare `visibility=public` publish gets the classic
+   **public · viewer** pair, NOT the workspace default role: the workspace
+   default is chosen for the workspace audience and must never silently ride
+   onto a world link (widening a public link past view stays an explicit act).
+6. **The role ladder stays pure.** A link-granted editor is an editor: publish,
+   approve, share (Google Docs semantics). No clamped pseudo-roles.
+7. **Password lock scope unchanged.** Settable on a public listing only,
+   suspends the link floor until unlocked; members and explicit shares never
+   need it. Extending the lock to non-public link-bearing docs is deferred.
+8. **Agent (MCP) publishes resolve the SAME default chain.**
+   `defaultAgentVisibility` keeps governing the listing only: a draft stays out
+   of the library until promoted, but its link works for the workspace it was
+   handed to. That paste-loop is the reason this round exists.
+
+## The full state table (the spec; SECURITY.md mirrors it)
+
+"—" = no access (reads 404). "Member" = member of the artifact's workspace
+holding the URL (or finding it where listed). Invited shares always keep
+`max(share role, floor)` and are never blocked by a lock.
+
+| # | visibility | link grant | Listed where | Anon + URL | Outsider + URL | Workspace member | Verdict |
+|---|---|---|---|---|---|---|---|
+| 1 | private | none | nowhere¹ | — | — | — | invite-only (pre-round-4 private) |
+| 2 | private | org · viewer | nowhere | — | — | view | **scenario 1** |
+| 3 | private | org · commenter | nowhere | — | — | view + comment | **THE DEFAULT** |
+| 4 | private | org · editor | nowhere | — | — | edit/publish | trusted-team drafts |
+| 5 | private | public · viewer | nowhere | view | view | view | **scenario 2** (unlisted world link) |
+| 6 | private | public · commenter | nowhere | view | comment | comment | scenario 2, commentable |
+| 7 | private | public · editor | nowhere | view | edit | edit | anyone-with-link edits, opt-in |
+| 8 | org | none | workspace library | — | — | membership role | team doc, link inert outside |
+| 9 | org | org · viewer | workspace library | — | — | membership role² | valid, floor is a no-op |
+| 10 | org | org · commenter | workspace library | — | — | membership role² | valid, floor is a no-op |
+| 11 | org | org · editor | workspace library | — | — | max(role, edit) | team-editable |
+| 12 | org | public · viewer | workspace library | view | view | membership role | team doc + external view link |
+| 13 | org | public · commenter | workspace library | view | comment | membership role | team doc + external feedback |
+| 14 | org | public · editor | workspace library | view | edit | max(role, edit) | coherent, risky, deliberate |
+| 15 | public | none | — | — | — | — | **FORBIDDEN** (listed but unopenable) |
+| 16 | public | org · any | — | — | — | — | **FORBIDDEN** (listed to world, link members-only) |
+| 17 | public | public · viewer | library + world | view³ | view³ | max(role, view) | classic public · view (lockable) |
+| 18 | public | public · commenter | library + world | view³ | comment³ | max(role, comment) | classic public · comment (lockable) |
+| 19 | public | public · editor | library + world | view³ | edit³ | max(role, edit) | wiki mode, opt-in |
+
+¹ Private appears in the owner's own library only (round-3 `mine_private`).
+² Workspace roles are owner/editor/commenter (no bare viewer), so only the
+editor floor ever lifts a member. ³ A password lock suspends these columns until
+unlocked; members and invited shares pass by role regardless.
+
+17 valid states, 4 forbidden, 0 ambiguous.
+
+## Resolution (packages/core/src/permissions.ts, the one gate)
+
+```
+access = max( explicit standing , link floor )
+
+explicit: artifactRole (share/collection) always; orgRole at org/public
+          visibility only (nothing at private)
+floor:    none => no floor; holder must be in the audience (public admits all,
+          org admits signed-in members of the artifact's workspace); anonymous
+          clamps to viewer; a lock suspends the floor until unlocked
+```
+
+## Storage + migration
+
+- `artifact.link_role TEXT NOT NULL DEFAULT 'none'` and
+  `artifact.link_audience TEXT NOT NULL DEFAULT 'org'`: fail-closed column
+  defaults; publish() always stamps resolved values. `general_role` is orphaned,
+  not dropped (expand/contract). DDL is generated from the drizzle defs
+  (sqlite/pg/d1 in lockstep).
+- Boot backfill (node.ts, idempotent, next to the round-3 remap):
+  `UPDATE artifact SET link_role = general_role, link_audience = 'public' WHERE
+  visibility = 'public'`. Public rows keep byte-identical reach; org/private
+  links were dead and stay dead.
+- Wire compat: publish + PATCH accept legacy `general_role`/`generalRole` as a
+  role alias; `visibilityOf` keeps the round-3 legacy map (`link → public`,
+  which now lands the classic public · viewer pair).
+
+## Deferred (recorded, deliberate)
+
+- Password lock on non-public link-bearing docs (natural now that private links
+  exist).
+- A request-access flow on inert links (blocked visitor pings the owner).
+- Per-user default link pair (no user-settings store exists yet).
+- Clamping `share` out of link-derived editors, only if the pure ladder proves
+  scary in practice.

--- a/docs/plans/link-grant.md
+++ b/docs/plans/link-grant.md
@@ -113,6 +113,20 @@ floor:    none => no floor; holder must be in the audience (public admits all,
   role alias; `visibilityOf` keeps the round-3 legacy map (`link → public`,
   which now lands the classic public · viewer pair).
 
+## Share dialog (`apps/web/src/pages/artifact/share-dialog.tsx`)
+
+The dialog is additive, not redesigned: **General access** (visibility —
+Private/Workspace/Public, plus the Public-only Can view/Can comment select) is
+byte-identical to the pre-round-4 dialog. **Link access** is a new section
+below it — who the link works for (`No one` / `Workspace` / `Public`, never
+"unlisted") and what it grants (`Can view` / `Can comment` / `Can edit`) —
+that applies even when General access is Private. Both sections write the
+same underlying `link_role`/`link_audience`; a public General access still
+forces the link to Public underneath (the coherence rule), and Link access
+mirrors that instead of going stale. An earlier version of this PR merged the
+two into one control — reverted after review; the split favors muscle memory
+and a smaller mental model per change over a single denser control.
+
 ## Deferred (recorded, deliberate)
 
 - Password lock on non-public link-bearing docs (natural now that private links

--- a/packages/core/src/permissions.test.ts
+++ b/packages/core/src/permissions.test.ts
@@ -4,8 +4,9 @@ import {
   type Actor,
   can,
   effectiveRole,
-  type GeneralRole,
   isRole,
+  type LinkAudience,
+  type LinkRole,
   maxRole,
   ROLES,
   type Role,
@@ -16,6 +17,8 @@ import type { Visibility } from "./ports"
 const ACTIONS: Action[] = ["read", "comment", "propose", "publish", "approve", "share", "manage"]
 const VISIBILITIES: Visibility[] = ["public", "org", "private"]
 const WRITE_ACTIONS: Action[] = ["comment", "propose", "publish", "approve", "share", "manage"]
+const LINK_ROLES: LinkRole[] = ["none", "viewer", "commenter", "editor"]
+const LINK_AUDIENCES: LinkAudience[] = ["org", "public"]
 
 // The authoritative access matrix: the minimum role each action requires. This is
 // the security contract — duplicated from NEEDS in permissions.ts on purpose so a
@@ -93,28 +96,85 @@ describe("effectiveRole — the documented access table", () => {
     for (const v of VISIBILITIES) expect(effectiveRole(token, v)).toBe("owner")
   })
 
-  it("public grants the general-access floor to a signed-in reacher", () => {
-    // Default floor is view; a comment link lifts a signed-in reacher to commenter.
-    expect(effectiveRole(user(), "public")).toBe("viewer")
-    expect(effectiveRole(user(), "public", "commenter")).toBe("commenter")
+  it("omitted link params default to none + org — a caller fails closed, not open", () => {
+    // Round 4: the DB columns default to `none`/`org`, and so do these parameters —
+    // a code path that forgets to pass the artifact's link pair gets NO floor,
+    // never the old `viewer` default. See docs/plans/link-grant.md.
+    expect(effectiveRole(user(), "public")).toBeNull()
+    expect(effectiveRole(anon, "public")).toBeNull()
   })
 
-  it("a password (the lock) gates the public floor behind unlock", () => {
-    expect(effectiveRole(user({ locked: true }), "public", "commenter")).toBeNull()
-    expect(effectiveRole(user({ locked: true, unlocked: true }), "public", "commenter")).toBe(
+  // ACCEPTANCE — the two scenarios this round exists for (Anir, verbatim):
+  // 1. "I publish an item — it is not discoverable — it is accessible by link
+  //     only in my workspace."
+  // 2. "I publish an item — it is not discoverable — it is accessible by link
+  //     publicly."
+  it("SCENARIO 1: private + org-audience link — workspace members with the URL, no one else", () => {
+    // A member of the artifact's workspace holding the URL gets the link's grant.
+    expect(effectiveRole(user({ orgRole: "commenter" }), "private", "viewer", "org")).toBe("viewer")
+    expect(effectiveRole(user({ orgRole: "editor" }), "private", "commenter", "org")).toBe(
       "commenter",
     )
-    // The lock gates REACH only — members and explicit shares pass by role.
+    // The default grant (workspace · can comment) lets any member comment.
+    expect(can(user({ orgRole: "commenter" }), "comment", "private", "commenter", "org")).toBe(true)
+    // A signed-in OUTSIDER holding the same URL gets nothing.
+    expect(effectiveRole(user(), "private", "commenter", "org")).toBeNull()
+    // Anonymous gets nothing — never in an org audience.
+    expect(effectiveRole(anon, "private", "commenter", "org")).toBeNull()
+  })
+
+  it("SCENARIO 2: private + public-audience link — any holder, anon clamped to view", () => {
+    expect(effectiveRole(anon, "private", "viewer", "public")).toBe("viewer")
+    expect(effectiveRole(user(), "private", "viewer", "public")).toBe("viewer")
+    expect(effectiveRole(user(), "private", "commenter", "public")).toBe("commenter")
+    expect(effectiveRole(anon, "private", "commenter", "public")).toBe("viewer")
+    expect(can(anon, "comment", "private", "commenter", "public")).toBe(false)
+  })
+
+  it("membership is the audience KEY, not the grant — an org link hands members linkRole only", () => {
+    // A workspace OWNER holding a private doc's org·viewer link gets VIEWER: the
+    // round-3 privacy invariant (membership grants nothing at private) stands;
+    // the link grants what the link says, to those the audience admits.
+    expect(effectiveRole(user({ orgRole: "owner" }), "private", "viewer", "org")).toBe("viewer")
+    expect(effectiveRole(user({ orgRole: "owner" }), "private", "none", "org")).toBeNull()
+  })
+
+  it("`none` grants nothing by the link, at any visibility and audience", () => {
+    for (const v of VISIBILITIES)
+      for (const a of LINK_AUDIENCES) {
+        expect(effectiveRole(user(), v, "none", a), `user ${v}/${a}`).toBeNull()
+        expect(effectiveRole(anon, v, "none", a), `anon ${v}/${a}`).toBeNull()
+      }
+  })
+
+  it("`editor` is a real link grant — publish/approve/share ride the pure role ladder", () => {
+    expect(effectiveRole(user(), "private", "editor", "public")).toBe("editor")
+    expect(can(user(), "publish", "private", "editor", "public")).toBe(true)
+    expect(can(user(), "share", "private", "editor", "public")).toBe(true)
+    expect(can(user(), "manage", "private", "editor", "public")).toBe(false) // editor, not owner
+    // Org-audience editor link: members edit (state 4/11), outsiders never.
+    expect(effectiveRole(user({ orgRole: "commenter" }), "org", "editor", "org")).toBe("editor")
+    expect(effectiveRole(user(), "org", "editor", "org")).toBeNull()
+  })
+
+  it("a password (the lock) gates the link floor behind unlock", () => {
+    expect(effectiveRole(user({ locked: true }), "public", "commenter", "public")).toBeNull()
+    expect(
+      effectiveRole(user({ locked: true, unlocked: true }), "public", "commenter", "public"),
+    ).toBe("commenter")
+    // The lock gates the FLOOR only — members and explicit shares pass by role.
     expect(effectiveRole(user({ locked: true, orgRole: "editor" }), "public")).toBe("editor")
     expect(effectiveRole(user({ locked: true, artifactRole: "commenter" }), "public")).toBe(
       "commenter",
     )
-    // A lock is meaningless off public: org/private are already explicit-only.
-    expect(effectiveRole(user({ locked: true, orgRole: "viewer" }), "org")).toBe("viewer")
+    // A lock with no explicit standing is a hard `null`, not a demotion to viewer.
+    expect(
+      effectiveRole(user({ locked: true, unlocked: false }), "private", "editor", "public"),
+    ).toBeNull()
   })
 
-  it("org/private grants nothing by reach — only an explicit role opens it", () => {
-    expect(effectiveRole(user(), "org", "commenter")).toBeNull()
+  it("org/private grant nothing by MEMBERSHIP alone — only an explicit role opens it", () => {
+    expect(effectiveRole(user(), "org")).toBeNull()
     expect(effectiveRole(user({ orgRole: "editor" }), "org")).toBe("editor")
   })
 
@@ -125,19 +185,31 @@ describe("effectiveRole — the documented access table", () => {
     expect(effectiveRole(user({ artifactRole: "viewer", orgRole: "editor" }), "org")).toBe("viewer")
   })
 
-  it("the general-access floor can lift an explicit role but never lower it", () => {
+  it("the link floor can lift an explicit role but never lower it", () => {
     // On a comment link, an org viewer is lifted to commenter by the floor...
-    expect(effectiveRole(user({ orgRole: "viewer" }), "public", "commenter")).toBe("commenter")
+    expect(effectiveRole(user({ orgRole: "viewer" }), "public", "commenter", "public")).toBe(
+      "commenter",
+    )
     // ...but an editor stays editor (max of explicit and floor).
-    expect(effectiveRole(user({ orgRole: "editor" }), "public", "commenter")).toBe("editor")
+    expect(effectiveRole(user({ orgRole: "editor" }), "public", "commenter", "public")).toBe(
+      "editor",
+    )
+    // An invited share is lifted by the floor too, never lowered.
+    expect(effectiveRole(user({ artifactRole: "viewer" }), "private", "commenter", "org")).toBe(
+      "viewer", // outsider share: not in the org audience, keeps their share role
+    )
+    expect(
+      effectiveRole(
+        user({ artifactRole: "viewer", orgRole: "commenter" }),
+        "private",
+        "commenter",
+        "org",
+      ),
+    ).toBe("commenter") // member share: floor lifts viewer share to commenter
   })
 
-  it("private admits only per-artifact members — workspace role grants nothing", () => {
-    // The distinction from org: a workspace editor cannot see a teammate's
-    // private draft, but an explicit share (or the creator's owner-member row,
-    // written at publish) opens it. Collection shares ride artifactRole too.
+  it("private admits only shares by standing — and the link floor works independently", () => {
     expect(effectiveRole(user({ orgRole: "owner" }), "private")).toBeNull()
-    expect(effectiveRole(user({ orgRole: "editor" }), "private", "commenter")).toBeNull()
     expect(effectiveRole(user({ artifactRole: "owner" }), "private")).toBe("owner")
     expect(effectiveRole(user({ artifactRole: "commenter", orgRole: "editor" }), "private")).toBe(
       "commenter",
@@ -149,43 +221,53 @@ describe("effectiveRole — the documented access table", () => {
 })
 
 describe("effectiveRole — the anonymous invariant", () => {
-  it("never elevates an anonymous caller above viewer, for ANY visibility, lock, or general role", () => {
-    const generalRoles: GeneralRole[] = ["viewer", "commenter"]
-    for (const v of VISIBILITIES) {
-      for (const g of generalRoles) {
-        for (const locked of [false, true]) {
-          for (const unlocked of [false, true]) {
-            const role = effectiveRole({ kind: "anon", locked, unlocked }, v, g)
-            expect(
-              role === null || role === "viewer",
-              `anon ${v}/${g}/locked=${locked}/unlocked=${unlocked}`,
-            ).toBe(true)
-          }
-        }
-      }
-    }
+  it("never elevates anon above viewer, for ANY visibility, audience, role, or lock", () => {
+    for (const v of VISIBILITIES)
+      for (const g of LINK_ROLES)
+        for (const a of LINK_AUDIENCES)
+          for (const locked of [false, true])
+            for (const unlocked of [false, true]) {
+              const role = effectiveRole({ kind: "anon", locked, unlocked }, v, g, a)
+              expect(
+                role === null || role === "viewer",
+                `anon ${v}/${g}/${a}/locked=${locked}/unlocked=${unlocked}`,
+              ).toBe(true)
+            }
   })
 
-  it("gives an anon caller view on a public link, and no access on org or a lock", () => {
-    expect(effectiveRole(anon, "public")).toBe("viewer")
-    expect(effectiveRole(anon, "public", "commenter")).toBe("viewer")
-    expect(effectiveRole(anon, "org", "commenter")).toBeNull()
-    expect(effectiveRole({ kind: "anon", locked: true }, "public", "commenter")).toBeNull()
-    expect(effectiveRole({ kind: "anon", locked: true, unlocked: true }, "public")).toBe("viewer")
+  it("anon reaches view ONLY through a public audience — an org audience is a locked door", () => {
+    expect(effectiveRole(anon, "private", "viewer", "public")).toBe("viewer")
+    expect(effectiveRole(anon, "private", "editor", "public")).toBe("viewer") // clamp, not editor
+    expect(effectiveRole(anon, "org", "commenter", "org")).toBeNull()
+    expect(effectiveRole(anon, "public", "none", "public")).toBeNull()
+    expect(
+      effectiveRole({ kind: "anon", locked: true }, "public", "commenter", "public"),
+    ).toBeNull()
+    expect(
+      effectiveRole({ kind: "anon", locked: true, unlocked: true }, "public", "viewer", "public"),
+    ).toBe("viewer")
   })
 })
 
 describe("can — the one authorization gate", () => {
-  it("denies every write action to an anonymous caller, on every visibility", () => {
-    // Even a comment-general-access link does not let an account-less caller write.
+  it("denies every write action to an anonymous caller, on every visibility, grant, and audience", () => {
+    // Not even an editor-grant public link lets an account-less caller write.
     for (const v of VISIBILITIES)
-      for (const action of WRITE_ACTIONS)
-        expect(can(anon, action, v, "commenter"), `anon ${action} on ${v}`).toBe(false)
+      for (const g of LINK_ROLES)
+        for (const a of LINK_AUDIENCES)
+          for (const action of WRITE_ACTIONS)
+            expect(can(anon, action, v, g, a), `anon ${action} on ${v}/${g}/${a}`).toBe(false)
   })
 
-  it("lets an anon caller read a public doc but not a workspace one", () => {
-    expect(can(anon, "read", "public")).toBe(true)
+  it("lets an anon caller read via a public-audience viewer link, never via an org one", () => {
+    expect(can(anon, "read", "public", "viewer", "public")).toBe(true)
+    expect(can(anon, "read", "public", "viewer", "org")).toBe(false)
     expect(can(anon, "read", "org")).toBe(false)
+  })
+
+  it("omitted link params deny read too — `can` fails closed the same as effectiveRole", () => {
+    expect(can(anon, "read", "public")).toBe(false)
+    expect(can(user(), "read", "public")).toBe(false)
   })
 
   it("routes a commenter through propose, never publish", () => {

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -12,8 +12,28 @@ import type { Visibility } from "./ports"
  */
 export type Role = "viewer" | "commenter" | "editor" | "owner"
 
-/** The roles general access (a shared link) can grant a reacher: view-only or comment.
- *  A strict subset of Role — general access never hands out editor/owner. */
+/** The link grant (round 4, docs/plans/link-grant.md) is a PAIR on every artifact,
+ *  orthogonal to visibility (which is purely a listing ladder):
+ *
+ *    link_audience — WHO the URL works for:  `org` (signed-in members of the
+ *                    artifact's workspace) or `public` (any holder).
+ *    link_role     — WHAT it grants them:    `none` (inert, invite-only),
+ *                    `viewer`, `commenter`, or `editor`.
+ *
+ *  Together they express the three-stop dial: "the link works for no one /
+ *  people in my workspace / everyone", at a capability. A `private` (unlisted)
+ *  artifact with an `org`-audience link is the product default: invisible in
+ *  every feed and library, but a teammate who's handed the URL just opens it.
+ *  Anonymous holders are always clamped to `viewer` (and are never in an `org`
+ *  audience at all) — see effectiveRole. */
+export type LinkRole = "none" | "viewer" | "commenter" | "editor"
+/** Who a link works for: the artifact's workspace (signed-in members only) or
+ *  everyone. Meaningless while `link_role` is `none`. */
+export type LinkAudience = "org" | "public"
+/** @deprecated round 4 retired this in favor of `LinkRole` (a strict superset: adds
+ *  `none` and `editor`, and applies at every visibility, not just `public`). Kept
+ *  only to type the orphaned `general_role` DB column — expand/contract, not
+ *  dropped (CONTRIBUTING.md). No code reads or writes it anymore. */
 export type GeneralRole = "viewer" | "commenter"
 
 /** What an actor wants to do. Kept coarse on purpose; `can()` is the only gate. */
@@ -78,56 +98,67 @@ export interface Actor {
 
 /**
  * The actor's effective role on an artifact, the max of their explicit standing and
- * the general-access floor:
- *   per-artifact share  →  workspace membership  →  general-access floor (by reach).
+ * the link floor:
+ *
+ *   access = max( explicit standing , link floor )
+ *
  * null means no access at all. This function is the single source of truth for the
- * access matrix; SECURITY.md documents the same table for humans.
+ * access matrix; SECURITY.md documents the full 21-state table for humans.
  *
- *   Visibility                   Anonymous              Signed in via link    Member / share
- *   ───────────────────────────  ─────────────────────  ────────────────────  ────────────────
- *   public · view                view                   view                  their role (>= view)
- *   public · comment             view (sign in to cmt)  view + comment        their role (>= cmt)
- *   public + password            unlock, then as above  unlock, then above    their role (no pw)
- *   workspace (org)              no access              no access             their role (members)
- *   private (default)            no access              no access             explicit share only
+ * EXPLICIT STANDING — a per-artifact share / collection share (artifactRole)
+ * always counts; the workspace membership role (orgRole) counts at `org`/`public`
+ * visibility only. At `private`, membership grants NOTHING (round-3 draft
+ * privacy: a workspace OWNER still cannot open a teammate's private draft by
+ * role alone — only a share or the link).
  *
- * Three visibilities, one modifier: `public` means the link works for anyone
- * (at the doc's general role, view or comment); a password on a public doc
- * gates the reach floor until unlocked — members and explicit shares never
- * need the password. `org` is the team: membership alone grants access, at the
- * member's own role. `private` grants nothing by membership — only explicit
- * shares (per-artifact and collection shares both ride artifactRole), which is
- * what keeps an agent's draft out of teammates' reach until promoted.
+ * THE LINK FLOOR (round 4, docs/plans/link-grant.md) — what merely holding the
+ * URL confers, orthogonal to where the artifact is listed:
+ *   - linkRole `none` → no floor (the link is inert; audience irrelevant).
+ *   - the holder must be IN THE AUDIENCE: `public` admits every holder;
+ *     `org` admits only signed-in members of the ARTIFACT's workspace
+ *     (actor.orgRole != null) — anonymous is never in an `org` audience.
+ *   - an anonymous holder is always clamped to `viewer` — never elevated to a
+ *     writing role without an account.
+ *   - a password (the lock, `public` visibility only) suspends the floor until
+ *     unlocked; explicit standing is untouched, so members and shares never
+ *     need the password.
  *
- * Invariant: an anonymous caller is never more than `viewer`. Anything past view
- * (comment, propose, publish, share, manage) needs an authenticated identity — a
- * signed-in user or a `DERIVE_TOKEN`. There is deliberately no "trusted anonymous" path.
+ * The pair expresses the three-stop dial: the link works for no one (`none`) /
+ * people in my workspace (`org` audience) / everyone (`public` audience), at a
+ * capability. A `private` (unlisted) artifact with an org-audience link is the
+ * product default: invisible in every feed and library, but a teammate who is
+ * handed the URL just opens it.
+ *
+ * Invariant: an anonymous caller is never more than `viewer`, regardless of the
+ * grant. Anything past view (comment, propose, publish, share, manage) needs an
+ * authenticated identity — a signed-in user or a `DERIVE_TOKEN`. There is
+ * deliberately no "trusted anonymous" path.
  */
 export function effectiveRole(
   actor: Actor,
   visibility: Visibility,
-  generalRole: GeneralRole = "viewer",
+  linkRole: LinkRole = "none",
+  linkAudience: LinkAudience = "org",
 ): Role | null {
   if (actor.kind === "token") return "owner"
   // A per-artifact share or workspace membership — authenticated callers only.
   // `private` is the exception: workspace membership grants nothing there by
   // itself, so a team-workspace draft stays out of teammates' standing until
-  // explicitly shared.
+  // explicitly shared (or reached through the link floor below).
   const explicit =
     actor.kind === "user"
       ? visibility === "private"
         ? actor.artifactRole
         : (actor.artifactRole ?? actor.orgRole)
       : null
-  // The general-access floor for a reacher with no higher explicit grant. Only an
-  // authenticated reacher gets the configured general role; an anonymous reacher is
-  // clamped to `viewer` — never elevated to a writing role without an account. A
-  // password (the lock) suspends the floor until unlocked; explicit standing above
-  // is untouched, so members and shares never need the password.
-  const reach: Role = actor.kind === "user" ? generalRole : "viewer"
-  const floor: Role | null =
-    visibility === "public" ? (actor.locked && !actor.unlocked ? null : reach) : null
-  // org/private grant nothing by reach — only an explicit role opens them.
+  // Is this holder in the link's audience? `public` admits everyone; `org` admits
+  // only signed-in members of the artifact's workspace. Membership is the audience
+  // KEY here, not the grant — an org-audience link hands a member linkRole, never
+  // their workspace role (private stays private-by-role).
+  const inAudience = linkAudience === "public" || (actor.kind === "user" && actor.orgRole != null)
+  const reach: Role | null =
+    linkRole === "none" || !inAudience ? null : actor.kind === "user" ? linkRole : "viewer"
+  const floor: Role | null = actor.locked && !actor.unlocked ? null : reach
   return maxRole(explicit, floor)
 }
 
@@ -136,8 +167,9 @@ export function can(
   actor: Actor,
   action: Action,
   visibility: Visibility,
-  generalRole: GeneralRole = "viewer",
+  linkRole: LinkRole = "none",
+  linkAudience: LinkAudience = "org",
 ): boolean {
-  const role = effectiveRole(actor, visibility, generalRole)
+  const role = effectiveRole(actor, visibility, linkRole, linkAudience)
   return role !== null && roleAllows(role, action)
 }

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -2,7 +2,7 @@
  * Core owns the ports; packages/db and packages/storage provide the adapters.
  * Everything here must run on Node AND Cloudflare Workers — no Node APIs.
  */
-import type { GeneralRole, Role } from "./permissions"
+import type { GeneralRole, LinkAudience, LinkRole, Role } from "./permissions"
 
 export interface BlobStore {
   /** Content-addressed put; returns the sha256 hex key. Idempotent. */
@@ -11,17 +11,20 @@ export interface BlobStore {
 }
 
 export type ArtifactKind = "file" | "bundle"
-// Three audiences, each answering one question: who can open the link.
-// `private`: only per-artifact members (the publisher becomes the owner-member at
-// creation) — workspace membership grants nothing. The agent-draft default.
-// `org`: the team — any workspace member, at their membership role, listed in
-// the workspace library.
-// `public`: anyone with the URL. A `password_hash` on a public artifact is a
-// LOCK, not a visibility: the reach floor stays gated until unlocked, while
-// members and explicit shares pass by role. There is no listing axis —
-// broadcast is not a per-artifact state.
+// Three listing states, each answering one question: where does this show up.
+// `private`: no feeds, no libraries — only per-artifact members (the publisher
+// becomes the owner-member at creation) see it; workspace membership grants
+// nothing. The agent-draft default.
+// `org`: the workspace library — any workspace member, at their membership role.
+// `public`: the workspace-agnostic directory (when one exists).
+// Visibility is orthogonal to reach: see `link_role` (round 4, LinkRole) below
+// for what merely holding the artifact's URL grants, independent of where it's
+// listed. A `password_hash` on a public artifact is a LOCK on the link floor
+// (round 3 + round 4), not a visibility: gated until unlocked, while members
+// and explicit shares pass by role.
 // (Pre-collapse rows migrate at boot: unlisted→private, link→public,
-// password→public with the hash kept. See docs/plans/visibility-collapse.md.)
+// password→public with the hash kept. See docs/plans/visibility-collapse.md
+// and docs/plans/link-grant.md.)
 export type Visibility = "public" | "org" | "private"
 
 /** A platform subdomain (`name.derived.app`) or a customer's own domain. */
@@ -38,12 +41,25 @@ export interface ArtifactRecord {
   slug: string | null
   title: string | null
   visibility: Visibility
-  /** Salted hash of the unlock password for `password` visibility; null otherwise. */
+  /** Salted hash of the unlock password locking a `public` artifact's link; null otherwise. */
   password_hash: string | null
-  /** The role general access (the link) grants a reacher with no higher explicit grant.
-   *  `viewer` (default) = view-only; `commenter` = authenticated reachers may comment.
-   *  Anonymous reachers are always clamped to `viewer` regardless (see effectiveRole). */
+  /** @deprecated retired by round 4's `link_role`. Orphaned, not dropped
+   *  (expand/contract, CONTRIBUTING.md): the column stays so existing rows and the
+   *  DDL stay consistent across dialects, but no code reads or writes it anymore —
+   *  it exists purely to keep this Record's shape matching the drizzle table
+   *  (packages/db/src/parity.ts's exact-shape check). */
   general_role: GeneralRole
+  /** The link grant, half 1 of 2 (round 4): what merely holding this artifact's URL
+   *  grants a reacher the audience admits, at ANY visibility. `none` (default) = the
+   *  link is inert, invite-only; `viewer`/`commenter`/`editor` grant that role.
+   *  Anonymous holders are always clamped to `viewer` (see effectiveRole). */
+  link_role: LinkRole
+  /** The link grant, half 2 of 2: WHO the URL works for. `org` (default) = signed-in
+   *  members of this artifact's workspace only — the "unlisted, but my team can open
+   *  my link" state; `public` = any holder. Irrelevant while link_role is `none`.
+   *  Coherence: `public` visibility requires a `public` audience at viewer or above
+   *  (enforced at the write paths, not here). */
+  link_audience: LinkAudience
   kind: ArtifactKind
   spa: 0 | 1
   /** Locked: direct publishes are rejected; changes must go through a proposal. */
@@ -139,10 +155,16 @@ export interface NewArtifact {
   slug: string | null
   title: string | null
   visibility: Visibility
-  /** Salted unlock-password hash; set only for `password` visibility. */
+  /** Salted unlock-password hash locking a `public` link; null/omitted otherwise. */
   password_hash?: string | null
-  /** General-access role; defaults to `viewer` (view-only) when omitted. */
-  general_role?: GeneralRole
+  /** The link grant pair (round 4). Omitted defaults are fail-closed at the store
+   *  layer — `none` (inert link) + `org` (narrowest audience) — a caller that wants
+   *  reach must say so explicitly. `publish()` always resolves and stamps values
+   *  (explicit request fields > the org's defaults > the factory default
+   *  `org · commenter`) before calling `createArtifact`, so this optionality is a
+   *  store-level safety net, not the product default. */
+  link_role?: LinkRole
+  link_audience?: LinkAudience
   kind: ArtifactKind
   spa: 0 | 1
 }
@@ -165,14 +187,15 @@ export interface NewVersion {
 
 export interface MetaStore {
   createArtifact(a: NewArtifact): Promise<ArtifactRecord>
-  /** Change an artifact's general access: visibility, the password hash locking a
-   *  public link (null clears; meaningless off `public`), and the general-access
-   *  role (view vs comment). */
+  /** Change an artifact's listing (visibility), the password hash locking a public
+   *  link (null clears; meaningless off `public`), and the link grant pair (round 4:
+   *  who the URL works for × what it confers). */
   setVisibility(
     artifactId: string,
     visibility: Visibility,
     passwordHash: string | null,
-    generalRole: GeneralRole,
+    linkRole: LinkRole,
+    linkAudience: LinkAudience,
   ): Promise<void>
   /** Toggle the change-lock: when locked, direct publishes are rejected. */
   setLocked(artifactId: string, locked: 0 | 1): Promise<void>
@@ -1325,6 +1348,14 @@ export interface OrgSettings {
    *  say. Private by default: an agent's draft is the human's until they promote
    *  it — sharing wider is the deliberate act (the blessing gesture). */
   defaultAgentVisibility: Visibility
+  /** The link grant a NEW publish lands with when the publisher doesn't say
+   *  (round 4, "the link grant" — see docs/plans/link-grant.md). Factory default
+   *  `org · commenter` ("Workspace · can comment"): a pasted link never dead-ends
+   *  a teammate, and Derive is a review loop, so the link hands over the whole
+   *  conversation, not just the read — while staying inert outside the workspace.
+   *  Existing artifacts are never retroactively widened by changing these. */
+  defaultLinkRole: LinkRole
+  defaultLinkAudience: LinkAudience
 }
 
 export const DEFAULT_ORG_SETTINGS: OrgSettings = {
@@ -1334,6 +1365,8 @@ export const DEFAULT_ORG_SETTINGS: OrgSettings = {
   githubPreviewLink: true,
   slackPost: true,
   defaultAgentVisibility: "private",
+  defaultLinkRole: "commenter",
+  defaultLinkAudience: "org",
 }
 
 /** A connected Slack workspace (one per Derive workspace). `bot_token` is the OAuth bot

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -1,6 +1,7 @@
 import { unzipSync } from "fflate"
 import { newId, newShortId, refFor, slugify } from "./ids"
 import { mimeFor } from "./mime"
+import type { LinkAudience, LinkRole } from "./permissions"
 import {
   type ArtifactKind,
   type ArtifactRecord,
@@ -53,6 +54,15 @@ export interface PublishInput {
   visibility?: Visibility
   /** Salted unlock-password hash, set by the route for `password` visibility. */
   passwordHash?: string | null
+  /** The link grant pair (round 4) for a NEW artifact: what the URL confers ×
+   *  who it works for. Set-on-create like visibility — ignored on a republish
+   *  (shortId), which never re-stamps them. The route is responsible for
+   *  resolving the default chain (explicit request fields > the org's defaults >
+   *  the factory `org · commenter`) AND the public-coherence rule before calling
+   *  publish(); omitted values fall through to the store's fail-closed defaults
+   *  (`none` / `org`). */
+  linkRole?: LinkRole
+  linkAudience?: LinkAudience
   /** Names this publish a pinned checkpoint (Docs-style). */
   name?: string
 }
@@ -271,6 +281,8 @@ export async function publish(
     // act (the Share dialog, --visibility, or visibility in derive.json).
     visibility: input.visibility ?? "private",
     password_hash: input.passwordHash ?? null,
+    link_role: input.linkRole,
+    link_audience: input.linkAudience,
     kind,
     spa: input.spa ? 1 : 0,
   })
@@ -399,7 +411,8 @@ export const toJson = (baseUrl: string, a: ArtifactRecord, versions: VersionReco
   kind: a.kind,
   current_content_type: a.current_content_type,
   visibility: a.visibility,
-  general_role: a.general_role,
+  link_role: a.link_role,
+  link_audience: a.link_audience,
   // A password on the public link (never the hash itself). Distinct from
   // `locked`, which is the publish lock (changes must go through proposals).
   password_protected: !!a.password_hash,

--- a/packages/core/test/permissions.test.ts
+++ b/packages/core/test/permissions.test.ts
@@ -37,16 +37,23 @@ describe("effectiveRole resolution", () => {
   it("falls back to the workspace role when there's no share", () => {
     expect(effectiveRole(user({ orgRole: "commenter" }), "org")).toBe("commenter")
   })
-  it("a non-member gets viewer on public, nothing on org, nothing behind a lock", () => {
-    expect(effectiveRole(user({}), "public")).toBe("viewer")
+  it("a non-member gets nothing anywhere with no link grant, and never past viewer on a lock", () => {
+    // Round 4: the link pair defaults to none/org (fail closed) — a bare reacher
+    // needs an explicit public-audience grant, not an implicit `viewer`.
+    expect(effectiveRole(user({}), "public")).toBe(null)
+    expect(effectiveRole(user({}), "public", "viewer", "public")).toBe("viewer")
+    expect(effectiveRole(user({}), "public", "viewer", "org")).toBe(null) // not a member
     expect(effectiveRole(user({}), "org")).toBe(null)
-    expect(effectiveRole(user({ locked: true }), "public")).toBe(null)
+    expect(effectiveRole(user({ locked: true }), "public", "viewer", "public")).toBe(null)
   })
-  it("a static token is owner; an anonymous caller is always read-only", () => {
+  it("a static token is owner; an anonymous caller is always read-only, never above viewer", () => {
     expect(effectiveRole({ kind: "token" }, "org")).toBe("owner")
-    // No "open"/trusted-anonymous path exists: anon never gets a writing role.
+    // No "open"/trusted-anonymous path exists: anon never gets a writing role,
+    // even on an editor-grant public link — and never enters an org audience.
     expect(effectiveRole({ kind: "anon" }, "org")).toBe(null)
-    expect(effectiveRole({ kind: "anon" }, "public")).toBe("viewer")
+    expect(effectiveRole({ kind: "anon" }, "public", "viewer", "public")).toBe("viewer")
+    expect(effectiveRole({ kind: "anon" }, "private", "editor", "public")).toBe("viewer")
+    expect(effectiveRole({ kind: "anon" }, "private", "editor", "org")).toBe(null)
   })
 })
 
@@ -56,71 +63,99 @@ describe("can", () => {
     expect(can({ kind: "user", artifactRole: "commenter" }, "publish", "org")).toBe(false)
     expect(can({ kind: "user", artifactRole: "commenter" }, "comment", "org")).toBe(true)
   })
-  it("a public-link viewer reads but cannot comment", () => {
-    expect(can({ kind: "anon" }, "read", "public")).toBe(true)
-    expect(can({ kind: "anon" }, "comment", "public")).toBe(false)
+  it("a public-audience viewer link reads but cannot comment", () => {
+    expect(can({ kind: "anon" }, "read", "public", "viewer", "public")).toBe(true)
+    expect(can({ kind: "anon" }, "comment", "public", "viewer", "public")).toBe(false)
   })
 })
 
-// The general-access (the link) comment grant, every cell of the access matrix. The
-// invariant under test: an anonymous reacher is NEVER more than viewer; the comment grant
-// only lifts a signed-in reacher to commenter. Mirrors the table in SECURITY.md.
-describe("general access comment grant (access matrix)", () => {
+// The link grant (round 4: audience × capability, at ANY visibility), every cell
+// of the access matrix. The invariants under test: an anonymous reacher is NEVER
+// more than viewer and never enters an org audience; grants only lift signed-in
+// holders the audience admits. Mirrors SECURITY.md and docs/plans/link-grant.md.
+describe("the link grant (access matrix)", () => {
   const anon: Actor = { kind: "anon" }
   // A signed-in caller reaching purely via the link, with no explicit share/membership.
   const reacher: Actor = { kind: "user", userId: "u9" }
+  // A signed-in member of the artifact's workspace (the org-audience key).
+  const member: Actor = { kind: "user", userId: "u10", orgRole: "commenter" }
 
-  it("view link: everyone reaching is viewer, nobody can comment", () => {
-    expect(effectiveRole(anon, "public", "viewer")).toBe("viewer")
-    expect(effectiveRole(reacher, "public", "viewer")).toBe("viewer")
-    expect(can(anon, "comment", "public", "viewer")).toBe(false)
-    expect(can(reacher, "comment", "public", "viewer")).toBe(false)
+  it("public-audience view link: everyone reaching is viewer, nobody can comment", () => {
+    expect(effectiveRole(anon, "public", "viewer", "public")).toBe("viewer")
+    expect(effectiveRole(reacher, "public", "viewer", "public")).toBe("viewer")
+    expect(can(anon, "comment", "public", "viewer", "public")).toBe(false)
+    expect(can(reacher, "comment", "public", "viewer", "public")).toBe(false)
   })
 
-  it("comment link: anon stays viewer (forced auth), a signed-in reacher becomes commenter", () => {
-    expect(effectiveRole(anon, "public", "commenter")).toBe("viewer")
-    expect(can(anon, "comment", "public", "commenter")).toBe(false) // anon never elevated
-    expect(can(anon, "read", "public", "commenter")).toBe(true)
-    expect(effectiveRole(reacher, "public", "commenter")).toBe("commenter")
-    expect(can(reacher, "comment", "public", "commenter")).toBe(true)
+  it("public-audience comment link: anon stays viewer (forced auth), signed-in becomes commenter", () => {
+    expect(effectiveRole(anon, "public", "commenter", "public")).toBe("viewer")
+    expect(can(anon, "comment", "public", "commenter", "public")).toBe(false) // anon never elevated
+    expect(can(anon, "read", "public", "commenter", "public")).toBe(true)
+    expect(effectiveRole(reacher, "public", "commenter", "public")).toBe("commenter")
+    expect(can(reacher, "comment", "public", "commenter", "public")).toBe(true)
   })
 
-  it("the comment floor is a max with the explicit role, never a demotion", () => {
-    // A viewer-member is lifted to commenter by a comment link...
-    expect(effectiveRole({ kind: "user", orgRole: "viewer" }, "public", "commenter")).toBe(
-      "commenter",
-    )
-    // ...but a higher explicit role is untouched.
-    expect(effectiveRole({ kind: "user", orgRole: "editor" }, "public", "commenter")).toBe("editor")
-    expect(effectiveRole({ kind: "user", artifactRole: "owner" }, "public", "commenter")).toBe(
-      "owner",
-    )
+  it("org-audience link: members in, outsiders and anon out — at any visibility", () => {
+    // Private + workspace link (scenario 1): the member gets the grant...
+    expect(effectiveRole(member, "private", "commenter", "org")).toBe("commenter")
+    // ...an outsider and anon get nothing from the same URL.
+    expect(effectiveRole(reacher, "private", "commenter", "org")).toBeNull()
+    expect(effectiveRole(anon, "private", "commenter", "org")).toBeNull()
+    // Org visibility: the org-audience floor is a no-op below the membership role.
+    expect(effectiveRole(member, "org", "viewer", "org")).toBe("commenter")
+    expect(effectiveRole(member, "org", "editor", "org")).toBe("editor") // lift
   })
 
-  it("a lock: the comment grant follows unlock, and never elevates anon", () => {
-    expect(effectiveRole({ ...anon, locked: true }, "public", "commenter")).toBe(null) // locked
+  it("the floor is a max with the explicit role, never a demotion", () => {
     expect(
-      effectiveRole({ kind: "anon", locked: true, unlocked: true }, "public", "commenter"),
+      effectiveRole({ kind: "user", orgRole: "viewer" }, "public", "commenter", "public"),
+    ).toBe("commenter")
+    expect(
+      effectiveRole({ kind: "user", orgRole: "editor" }, "public", "commenter", "public"),
+    ).toBe("editor")
+    expect(
+      effectiveRole({ kind: "user", artifactRole: "owner" }, "public", "commenter", "public"),
+    ).toBe("owner")
+  })
+
+  it("a lock: the grant follows unlock, and never elevates anon", () => {
+    expect(effectiveRole({ ...anon, locked: true }, "public", "commenter", "public")).toBe(null)
+    expect(
+      effectiveRole(
+        { kind: "anon", locked: true, unlocked: true },
+        "public",
+        "commenter",
+        "public",
+      ),
     ).toBe("viewer")
     expect(
-      can({ kind: "anon", locked: true, unlocked: true }, "comment", "public", "commenter"),
+      can(
+        { kind: "anon", locked: true, unlocked: true },
+        "comment",
+        "public",
+        "commenter",
+        "public",
+      ),
     ).toBe(false)
     expect(
       effectiveRole(
         { kind: "user", userId: "u", locked: true, unlocked: true },
         "public",
         "commenter",
+        "public",
       ),
     ).toBe("commenter")
   })
 
-  it("workspace-only (org) grants nothing by reach, regardless of the comment grant", () => {
-    expect(effectiveRole(anon, "org", "commenter")).toBe(null)
-    expect(effectiveRole(reacher, "org", "commenter")).toBe(null)
+  it("the link floor is NOT public-visibility-only — org and private carry it too (round 4)", () => {
+    expect(effectiveRole(anon, "org", "commenter", "public")).toBe("viewer") // anon clamped
+    expect(effectiveRole(reacher, "org", "commenter", "public")).toBe("commenter")
+    expect(effectiveRole(reacher, "private", "editor", "public")).toBe("editor")
   })
 
-  it("defaults to view-only when no general role is given (back-compat)", () => {
-    expect(effectiveRole(reacher, "public")).toBe("viewer")
+  it("`none` / omitted defaults grant nothing, on any visibility — fail closed", () => {
+    expect(effectiveRole(reacher, "public")).toBe(null)
     expect(can(reacher, "comment", "public")).toBe(false)
+    expect(effectiveRole(reacher, "public", "none", "public")).toBe(null)
   })
 })

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -9,6 +9,8 @@ import type {
   DomainStatus,
   FollowKind,
   GeneralRole,
+  LinkAudience,
+  LinkRole,
   NotificationKind,
   ProposalState,
   ReportState,
@@ -36,7 +38,11 @@ export const artifact = pgTable("artifact", {
   title: text("title"),
   visibility: text("visibility").$type<Visibility>().notNull().default("private"),
   password_hash: text("password_hash"),
+  // RETIRED — orphaned, not dropped. Mirrors schema.ts (see the comment there).
   general_role: text("general_role").$type<GeneralRole>().notNull().default("viewer"),
+  // Mirrors schema.ts: the link grant pair (round 4), fail-closed defaults.
+  link_role: text("link_role").$type<LinkRole>().notNull().default("none"),
+  link_audience: text("link_audience").$type<LinkAudience>().notNull().default("org"),
   kind: text("kind").$type<ArtifactKind>().notNull(),
   spa: integer("spa").$type<0 | 1>().notNull().default(0),
   locked: integer("locked").$type<0 | 1>().notNull().default(0),

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -17,12 +17,13 @@ import type {
   DomainStatus,
   FollowKind,
   FollowRecord,
-  GeneralRole,
   GitHubAppRecord,
   GitHubInstallationRecord,
   GithubAuthor,
   GithubUserMapping,
   InvitationRecord,
+  LinkAudience,
+  LinkRole,
   ListArtifactsOpts,
   MembershipRecord,
   MetaStore,
@@ -265,11 +266,17 @@ export class PgMetaStore implements MetaStore {
     artifactId: string,
     visibility: Visibility,
     passwordHash: string | null,
-    generalRole: GeneralRole,
+    linkRole: LinkRole,
+    linkAudience: LinkAudience,
   ): Promise<void> {
     await this.db
       .update(artifact)
-      .set({ visibility, password_hash: passwordHash, general_role: generalRole })
+      .set({
+        visibility,
+        password_hash: passwordHash,
+        link_role: linkRole,
+        link_audience: linkAudience,
+      })
       .where(eq(artifact.id, artifactId))
   }
 

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -17,11 +17,12 @@ import type {
   DomainStatus,
   FollowKind,
   FollowRecord,
-  GeneralRole,
   GitHubAppRecord,
   GitHubInstallationRecord,
   GithubAuthor,
   InvitationRecord,
+  LinkAudience,
+  LinkRole,
   ListArtifactsOpts,
   MembershipRecord,
   NewAgent,
@@ -274,7 +275,10 @@ export const parseOAuthScopes = (s: string | string[] | null): string[] => {
  *  written before the visibility collapse: a legacy agent default of `unlisted`
  *  is today's `private`, `link`/`public` clamp to `org` (an agent default must
  *  never world-publish), and the retired defaultUnlistedRole key is dropped.
- *  Shared by both drivers so old blobs read identically everywhere. */
+ *  The round-4 link-grant defaults normalize the same way: an unknown or missing
+ *  value reads as the factory default (`commenter` / `org`), so a stale blob can
+ *  never widen a workspace's default link. Shared by both drivers so old blobs
+ *  read identically everywhere. */
 export const parseOrgSettings = (raw: string | null): OrgSettings => {
   let parsed: Partial<OrgSettings> & { defaultUnlistedRole?: unknown } = {}
   try {
@@ -284,7 +288,21 @@ export const parseOrgSettings = (raw: string | null): OrgSettings => {
   const v = rest.defaultAgentVisibility as string | undefined
   const defaultAgentVisibility: OrgSettings["defaultAgentVisibility"] =
     v === "org" || v === "link" || v === "public" ? "org" : "private"
-  return { ...DEFAULT_ORG_SETTINGS, ...rest, defaultAgentVisibility }
+  const lr = rest.defaultLinkRole as string | undefined
+  const defaultLinkRole: OrgSettings["defaultLinkRole"] =
+    lr === "none" || lr === "viewer" || lr === "commenter" || lr === "editor"
+      ? lr
+      : DEFAULT_ORG_SETTINGS.defaultLinkRole
+  const la = rest.defaultLinkAudience as string | undefined
+  const defaultLinkAudience: OrgSettings["defaultLinkAudience"] =
+    la === "org" || la === "public" ? la : DEFAULT_ORG_SETTINGS.defaultLinkAudience
+  return {
+    ...DEFAULT_ORG_SETTINGS,
+    ...rest,
+    defaultAgentVisibility,
+    defaultLinkRole,
+    defaultLinkAudience,
+  }
 }
 
 export const collectManagedIds = (rows: { files: string }[]): string[] => {
@@ -350,11 +368,17 @@ export function makeRepos(db: SqliteDb) {
     artifactId: string,
     visibility: Visibility,
     passwordHash: string | null,
-    generalRole: GeneralRole,
+    linkRole: LinkRole,
+    linkAudience: LinkAudience,
   ): Promise<void> => {
     await db
       .update(artifact)
-      .set({ visibility, password_hash: passwordHash, general_role: generalRole })
+      .set({
+        visibility,
+        password_hash: passwordHash,
+        link_role: linkRole,
+        link_audience: linkAudience,
+      })
       .where(eq(artifact.id, artifactId))
       .run()
   }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -9,6 +9,8 @@ import type {
   DomainStatus,
   FollowKind,
   GeneralRole,
+  LinkAudience,
+  LinkRole,
   NotificationKind,
   ProposalState,
   ReportState,
@@ -42,10 +44,20 @@ export const artifact = sqliteTable("artifact", {
   title: text("title"),
   visibility: text("visibility").$type<Visibility>().notNull().default("private"),
   password_hash: text("password_hash"),
-  // The role general access (the link) grants a reacher with no higher explicit
-  // grant. viewer = view-only (default); commenter = authed reachers may comment
-  // (anonymous reachers are always clamped to viewer — see effectiveRole).
+  // RETIRED by round 4's link_role below. Orphaned, not dropped (expand/contract —
+  // see CONTRIBUTING.md): no code reads or writes this anymore. Kept so existing
+  // rows and the DDL stay consistent, and so ArtifactRecord's shape (which still
+  // carries it, deprecated) matches this table exactly (see ./parity).
   general_role: text("general_role").$type<GeneralRole>().notNull().default("viewer"),
+  // The link grant pair (round 4): what merely holding this artifact's URL confers
+  // (link_role) × who the URL works for (link_audience: `org` = signed-in members
+  // of this workspace, `public` = anyone), at ANY visibility. Defaults are
+  // fail-closed — `none` (inert) + `org` (narrowest) — so a row that's never
+  // explicitly stamped grants nothing; publish() always resolves and stamps real
+  // values. Anonymous holders are clamped to viewer and never enter an org
+  // audience — see effectiveRole.
+  link_role: text("link_role").$type<LinkRole>().notNull().default("none"),
+  link_audience: text("link_audience").$type<LinkAudience>().notNull().default("org"),
   kind: text("kind").$type<ArtifactKind>().notNull(),
   spa: integer("spa").$type<0 | 1>().notNull().default(0),
   // When locked, direct publishes are rejected — changes must go through the

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -128,25 +128,67 @@ export function runStoreContract(
       expect(await store.listArtifacts({ ids: [] })).toEqual([])
     })
 
-    it("changes visibility + general-access role (sets/clears the password lock)", async () => {
+    it("changes visibility + the link grant pair (sets/clears the password lock)", async () => {
       const a = await store.createArtifact(newArtifact())
-      expect(a.general_role).toBe("viewer") // defaults to view-only
-      // A locked public doc: visibility public + a password hash.
-      await store.setVisibility(a.id, "public", "hash123", "viewer")
+      // The store-level defaults are fail-closed — `none` (inert) + `org`
+      // (narrowest audience) — a caller that never stamps the pair gets no reach.
+      // See docs/plans/link-grant.md and the general_role orphaning note in schema.ts.
+      expect(a.link_role).toBe("none")
+      expect(a.link_audience).toBe("org")
+      expect(a.general_role).toBe("viewer") // retired column, still defaults — unread by app code
+      // A locked public doc: visibility public + a password hash + a world link.
+      await store.setVisibility(a.id, "public", "hash123", "viewer", "public")
       expect(await store.getByShortId(a.short_id)).toMatchObject({
         visibility: "public",
         password_hash: "hash123",
+        link_role: "viewer",
+        link_audience: "public",
       })
-      // Unlock it and grant comment: hash cleared, general_role round-trips.
-      await store.setVisibility(a.id, "public", null, "commenter")
+      // Unlock it and grant comment: hash cleared, the pair round-trips.
+      await store.setVisibility(a.id, "public", null, "commenter", "public")
       expect(await store.getByShortId(a.short_id)).toMatchObject({
         visibility: "public",
         password_hash: null,
-        general_role: "commenter",
+        link_role: "commenter",
+        link_audience: "public",
       })
-      // And back to view-only.
-      await store.setVisibility(a.id, "public", null, "viewer")
-      expect((await store.getByShortId(a.short_id))?.general_role).toBe("viewer")
+      // Grant editor — the full round-4 range, including the value general_role
+      // never had.
+      await store.setVisibility(a.id, "public", null, "editor", "public")
+      expect((await store.getByShortId(a.short_id))?.link_role).toBe("editor")
+      // And back to inert.
+      await store.setVisibility(a.id, "public", null, "none", "org")
+      expect(await store.getByShortId(a.short_id)).toMatchObject({
+        link_role: "none",
+        link_audience: "org",
+      })
+    })
+
+    it("the link pair is independent of visibility — a private artifact carries live links", async () => {
+      const a = await store.createArtifact(newArtifact({ visibility: "private" }))
+      expect(a.link_role).toBe("none")
+      // Scenario 1's row: unlisted + workspace-audience comment link.
+      await store.setVisibility(a.id, "private", null, "commenter", "org")
+      expect(await store.getByShortId(a.short_id)).toMatchObject({
+        visibility: "private",
+        link_role: "commenter",
+        link_audience: "org",
+      })
+      // Scenario 2's row: unlisted + world-audience view link.
+      await store.setVisibility(a.id, "private", null, "viewer", "public")
+      expect(await store.getByShortId(a.short_id)).toMatchObject({
+        visibility: "private",
+        link_role: "viewer",
+        link_audience: "public",
+      })
+    })
+
+    it("createArtifact stamps an explicit link pair (the publish() path)", async () => {
+      const a = await store.createArtifact(
+        newArtifact({ visibility: "private", link_role: "commenter", link_audience: "org" }),
+      )
+      expect(a.link_role).toBe("commenter")
+      expect(a.link_audience).toBe("org")
     })
 
     it("counts storage bytes once per distinct blob (content-addressed)", async () => {


### PR DESCRIPTION
## What

Every artifact now carries a **link grant pair**, orthogonal to visibility:

| Field | Values | Question |
|---|---|---|
| \`visibility\` | \`private\` / \`org\` / \`public\` | Where is it listed? (unchanged, round 3) |
| \`link_audience\` | \`org\` / \`public\` | Who does the URL work for? |
| \`link_role\` | \`none\` / \`viewer\` / \`commenter\` / \`editor\` | What does it grant them? |

The two scenarios this exists for:

1. **Private, link works inside my workspace** (\`private\` + \`org . commenter\`) — the new publish default: a pasted link never dead-ends a teammate, and it hands them the review loop, not just the read.
2. **Private, link works for anyone** (\`private\` + \`public . viewer/commenter\`) — the Loom-style link that isn't shown anywhere but still opens for whoever holds it.

Gate: \`access = max(explicit standing, link floor)\`. Anonymous is clamped to viewer and never enters an org audience; membership is the org audience's KEY, not the grant (a workspace owner still cannot open a teammate's sealed draft by role alone). Full 21-state table in \`docs/plans/link-grant.md\` + SECURITY.md — 17 valid states, 4 forbidden by the one coherence rule (public listing requires a public link at viewer or above; explicit contradictions 400).

## Decisions worth review

- **Bare \`visibility=public\` publishes get the classic \`public . viewer\` pair**, NOT the workspace default role — the workspace default is chosen for the workspace audience and must not silently widen a world link (this also keeps the B-012 roster-privacy contract).
- **Defaults are settings**: \`OrgSettings.defaultLinkAudience/defaultLinkRole\` (factory: Workspace . can comment). Set-on-create; republish never re-stamps; changing a default never touches existing rows.
- **Backfill**: existing public rows get \`public . general_role\` (byte-identical reach); org/private links were dead and stay dead. \`general_role\` is orphaned, not dropped.
- **Legacy compat**: \`general_role\`/\`generalRole\` wire fields and pre-collapse \`visibility=link\` keep working (kept round 3's \`link -> public\` map; the truer \`private + public.viewer\` remap was considered and skipped to avoid changing round-3 behavior twice — flagging per plan).
- **Agents** are workspace principals: an agent can now READ a teammate's private draft via the workspace link (like any member holding the URL) but still cannot write to it.

## UI

**Reverted to the pre-round-4 dialog + one additive section** (55d9731), after an earlier merged-row version read worse in review. **General access** (Private / Workspace / Public, plus the Public-only Can view/Can comment select) is byte-for-byte the dialog you already know — nothing else in it changed. **Link access** is new, directly below it: who the link works for (**No one / Workspace / Public** — never "unlisted") and what it grants (**Can view / Can comment / Can edit**), and it works even while General access is Private. A public General access still forces the link to Public underneath (the coherence rule); Link access mirrors that instead of showing a stale value. Workspace settings gain a "New artifact links" row. MCP publish gains \`link_role\` + \`link_audience\`.

Screenshots + a live e2e walkthrough (booted a real server, real Better Auth sessions, drove the dialog in a real browser): **[derive.to walkthrough](https://derive.to/artifacts/the-link-grant-local-e2e-walkthrough-4xzinbxb)** · full model + state table: **[derive.to plan doc](https://derive.to/artifacts/round-4-the-link-grant-nv4q2801)**.

## Tests

- Core: full matrix (visibility x audience x role x actor x lock), anonymous invariant loop, both scenarios named.
- API: new \`link-grant.test.ts\` (default chain, coherence 400s, PATCH carry-over semantics, legacy aliases, set-on-create, agent chain); visibility/comment-access/contexts updated to the new contract with inert-link (\`none\`) fixtures where invite-only was the premise.
- Gate: \`pnpm typecheck && pnpm run ci && pnpm test\` all green (1,402 tests).

Design doc: docs/plans/link-grant.md (follow-up to visibility-collapse.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
