### PR TITLE
AI-native MCP tooling: Markdown reads, heading sections, surgical edits, semantic diffs

### DIFF
--- a/apps/api/src/lib/edits.ts
+++ b/apps/api/src/lib/edits.ts
@@ -1,0 +1,77 @@
+import {
+  type ArtifactRecord,
+  applyEdits,
+  type DocEdit,
+  EditError,
+  type VersionRecord,
+} from "@derive/core"
+
+/** A conflict with the artifact's actual state (wrong kind, or it moved past the
+ *  version you read) — distinct from a malformed edit itself (bad JSON, 0/multi-match)
+ *  so REST callers can map it to 409 instead of 400, matching the pre-consolidation
+ *  status codes this helper's callers already committed to in their tests. */
+export class EditConflictError extends EditError {}
+
+export interface MaterializeEditsDeps {
+  getVersion: (artifactId: string, n: number) => Promise<VersionRecord | null>
+  sourceText: (v: Pick<VersionRecord, "blob_key" | "content_type">) => Promise<string | null>
+}
+
+export interface MaterializedEdits {
+  content: string
+  filename: string
+}
+
+/**
+ * Turn an `edits` request into stored-revision bytes: validate the artifact can take
+ * edits at all (single-file, `base_version` still fresh), load its current source,
+ * apply the edits, and infer a content-type-preserving filename. Shared by the MCP
+ * `publish` tool and the REST `/versions` + `/proposals` routes — the three surfaces
+ * that offer `edits` — so the semantics and error text can't drift between them the
+ * way they had (mismatched wording, and the MCP path silently skipping the size/
+ * storage-quota check the REST routes both apply after calling this).
+ *
+ * Throws `EditConflictError` for a state conflict (409-shaped), plain `EditError` for
+ * a malformed edit (400-shaped) — never a partial/silent failure. Callers translate
+ * to their own error shape (MCP `err()`, REST `fail(c, status, …)`); check
+ * `instanceof EditConflictError` BEFORE `instanceof EditError` (it's a subclass).
+ */
+export async function materializeEdits(
+  deps: MaterializeEditsDeps,
+  artifact: Pick<ArtifactRecord, "id" | "short_id" | "kind" | "current_version">,
+  edits: DocEdit[],
+  baseVersion: number | undefined,
+): Promise<MaterializedEdits> {
+  if (artifact.kind !== "file")
+    throw new EditConflictError(
+      `"${artifact.short_id}" is a multi-page bundle — \`edits\` applies to single-file artifacts; republish the changed page via \`files\` (+ \`merge\`).`,
+    )
+  if (baseVersion !== undefined && baseVersion !== artifact.current_version)
+    throw new EditConflictError(
+      `"${artifact.short_id}" moved to v${artifact.current_version} while you were editing (you read v${baseVersion}) — catch_up, re-read, then retry.`,
+    )
+  const cur = await deps.getVersion(artifact.id, artifact.current_version)
+  const src = cur ? await deps.sourceText(cur) : null
+  if (!cur || src === null)
+    throw new EditError(`Couldn't load the current source of "${artifact.short_id}".`)
+  const content = applyEdits(src, edits)
+  // Keep the artifact's content type: the sniffer types by filename first, and the
+  // default index.html would silently re-type an edited markdown doc as HTML.
+  const filename =
+    (cur.content_type.split(";")[0]?.trim() ?? cur.content_type) === "text/markdown"
+      ? "index.md"
+      : "index.html"
+  return { content, filename }
+}
+
+/** Parse a `base_version` value from an untyped form field: `undefined` when absent,
+ *  `EditError` (not silent NaN-passthrough) when present but not a clean integer —
+ *  a malformed field must fail loudly, not coerce to NaN and reject every edit as
+ *  "moved to vNaN" regardless of whether the artifact actually moved. */
+export function parseBaseVersion(raw: string | undefined): number | undefined {
+  if (!raw) return undefined
+  const n = Number(raw)
+  if (!Number.isInteger(n) || n < 1)
+    throw new EditError(`base_version "${raw}" is not a valid version number.`)
+  return n
+}

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -22,9 +22,11 @@
 import {
   type AgentRecord,
   type ArtifactRecord,
+  applyEdits,
   artifactUrl,
   type BundleManifest,
   diffLines,
+  EditError,
   formatDiff,
   newId,
   type OutlineSection,
@@ -818,7 +820,7 @@ function buildServer(
     "publish",
     {
       description:
-        "Save a revision of an artifact. It goes LIVE immediately if your role can publish (Creator/Admin); otherwise — or whenever you pass for_review:true — it is filed as a PROPOSAL a human approves before it goes live. Provide `content` for a SINGLE-FILE artifact, or `files` (a map of page path → content) for a MULTI-PAGE BUNDLE (a whole site, images and any binary asset). OMIT short_id to create a NEW artifact (`title` required); PASS short_id to add a version to one you own, matching its kind. A bundle republish REPLACES the whole bundle, so include EVERY page and asset (or use `merge`). Pass `addresses` with the thread ids (from catch_up) this revision resolves. Provide the FULL content, not a patch. (Proposals are single-file only; bundles must be published directly.)",
+        "Save a revision of an artifact. It goes LIVE immediately if your role can publish (Creator/Admin); otherwise — or whenever you pass for_review:true — it is filed as a PROPOSAL a human approves before it goes live. To CHANGE PART of a single-file artifact, prefer `edits` (exact-match search/replace against the stored source — read format:'html' first) over resending everything. Otherwise provide the full `content` for a SINGLE-FILE artifact, or `files` (a map of page path → content) for a MULTI-PAGE BUNDLE (a whole site, images and any binary asset). OMIT short_id to create a NEW artifact (`title` required); PASS short_id to add a version to one you own, matching its kind. A bundle republish REPLACES the whole bundle, so include EVERY page and asset (or use `merge`). Pass `addresses` with the thread ids (from catch_up) this revision resolves. (Proposals are single-file only; bundles must be published directly.)",
       inputSchema: {
         content: z
           .string()
@@ -885,10 +887,31 @@ function buildServer(
           .describe(
             "After a LIVE publish, open a review round asking your human to review this version — the /derive loop. They answer inline and hit Send back (or Approve); poll catch_up's `review` for the state. No effect on a proposal (that already IS a review).",
           ),
+        edits: z
+          .array(
+            z.object({
+              old_str: z
+                .string()
+                .describe(
+                  "Exact text from the STORED SOURCE (read format:'html' first on an HTML artifact — the markdown view will not match). Must occur exactly once.",
+                ),
+              new_str: z.string().describe("Replacement text. Empty string deletes."),
+            }),
+          )
+          .optional()
+          .describe(
+            "Surgical revision of a SINGLE-FILE artifact without resending it: exact-match search/replace against the current stored source, applied in order (each edit sees the previous one's result). Errors — applying nothing — if any old_str matches zero or multiple times; add surrounding context to disambiguate. Requires `short_id`; use INSTEAD of `content`. Composes with for_review, addresses, message, request_review.",
+          ),
+        base_version: z
+          .number()
+          .optional()
+          .describe(
+            "Safety check for `edits`: pass the version you read; the publish errors instead of applying when the artifact has moved past it.",
+          ),
       },
     },
     async ({
-      content,
+      content: contentIn,
       files,
       title,
       short_id,
@@ -900,15 +923,51 @@ function buildServer(
       for_review,
       addresses,
       request_review,
+      edits,
+      base_version,
     }) => {
+      let content = contentIn
       const existing = short_id ? await own(short_id) : null
       if (short_id && !existing) return text(`No artifact "${short_id}" in this workspace.`)
+
+      // `edits` — materialize the full new content up front, then fall through to the
+      // untouched publish/proposal pipeline (sweep, addresses, receipts all inherit).
+      let editsApplied = 0
+      if (edits !== undefined) {
+        if (content !== undefined || files)
+          return err("Provide `edits` OR `content`/`files`, not both.")
+        if (!existing) return err("`edits` revises an EXISTING artifact — pass its `short_id`.")
+        if (existing.kind !== "file")
+          return err(
+            `"${short_id}" is a multi-page bundle — \`edits\` applies to single-file artifacts; republish the changed page via \`files\` + \`merge\`.`,
+          )
+        if (base_version !== undefined && base_version !== existing.current_version)
+          return err(
+            `"${short_id}" moved to v${existing.current_version} while you were editing (you read v${base_version}) — catch_up, re-read, then retry.`,
+          )
+        const cur = await ctx.meta.getVersion(existing.id, existing.current_version)
+        const src = cur ? await ctx.sourceText(cur) : null
+        if (cur === null || src === null)
+          return err(`Couldn't load the current source of "${short_id}".`)
+        try {
+          content = applyEdits(src, edits)
+        } catch (e) {
+          if (e instanceof EditError) return err(e.message)
+          throw e
+        }
+        editsApplied = edits.length
+        // Keep the artifact's content type: the sniffer types by filename, and the
+        // default index.html would silently re-type an edited markdown doc as HTML.
+        if (!filename)
+          filename = baseType(cur.content_type) === "text/markdown" ? "index.md" : "index.html"
+      }
+
       // Exactly one of content / files. `files` (a page map) means a bundle.
       const isBundle = !!files && Object.keys(files).length > 0
       if (isBundle && content !== undefined)
         return text("Provide `content` (single file) OR `files` (a bundle), not both.")
       if (!isBundle && (content === undefined || content === ""))
-        return text("Provide `content` (single file) or `files` (a multi-page bundle).")
+        return text("Provide `content` (single file), `files` (a multi-page bundle), or `edits`.")
       if (existing) {
         // Kind can't change on republish; steer to the right field instead of the 409.
         if (existing.kind === "bundle" && !isBundle)
@@ -963,6 +1022,7 @@ function buildServer(
             proposal_id: proposal.id,
             base_version: proposal.base_version,
             addressed,
+            ...(editsApplied ? { edits_applied: editsApplied } : {}),
             note: "Submitted for review — a human approves it or requests changes. It is NOT live yet.",
           })
         } catch (e) {
@@ -1160,6 +1220,7 @@ function buildServer(
           url,
           title: artifact.title,
           visibility: artifact.visibility,
+          ...(editsApplied ? { edits_applied: editsApplied } : {}),
           ...(resolved.length ? { resolved } : {}),
           ...(actingFor ? { opened_in_tab: openedInTab } : {}),
           note:

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -510,7 +510,7 @@ function buildServer(
       description:
         "START HERE on an artifact. The state of it in one call: a one-line summary, the versions that landed since `since_version`, which pages changed, the open (and outdated) comment threads, and the full version history. " +
         "Pass `comments` (open / addressed / resolved / outdated) to instead get that filtered thread list — your feedback to-do queue. " +
-        "Pass `response_format='detailed'` (optionally with `since_version`/`to_version`) to include the exact line-by-line diff between two versions. " +
+        "Pass `response_format='detailed'` (optionally with `since_version`/`to_version`) to include a line-by-line diff between two versions — of their READABLE Markdown form, not raw HTML, so it shows what changed rather than tag noise. " +
         "WAITING ON A REVIEW? Pass `wait` (seconds, max 50): the call blocks until the human sends back / approves / comments (or the time runs out), then returns the fresh state. Chain wait calls instead of sleeping between polls — feedback reaches you in seconds.",
       inputSchema: {
         short_id: z.string(),
@@ -618,7 +618,14 @@ function buildServer(
         if (ms && mh) pagesChanged = bundleFileChanges(ms, mh)
         if (response_format === "detailed") {
           const [as_, ah] = [await ctx.sourceText(vs), await ctx.sourceText(vh)]
-          if (as_ !== null && ah !== null) entryDiff = clip(formatDiff(diffLines(as_, ah)))
+          if (as_ !== null && ah !== null) {
+            // Diff the READABLE form, not raw source: HTML tag noise drowns a
+            // real change, and minified one-line HTML produces one useless
+            // del/add pair. Markdown conversion re-introduces line structure so
+            // the diff answers what an agent actually asks — what changed.
+            const md = diffLines(toMarkdown(as_, vs.content_type), toMarkdown(ah, vh.content_type))
+            entryDiff = `diff of markdown conversion (semantic view):\n\n${clip(formatDiff(md))}`
+          }
         }
       }
       const open = await ctx.meta.listComments(a.id, { state: "open" })

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -124,6 +124,26 @@ const formatLabel = (contentType: string, format: ReadFormat): string => {
   return format === "html" ? "html (source)" : "text (visible text)"
 }
 
+// Images a read can inline as a real MCP image block (vision models see the mockup
+// screenshot instead of PNG bytes decoded as garbage text). Larger ones return
+// metadata + the served URL — open it in a browser instead.
+const IMAGE_INLINE_MAX = 1_000_000
+const B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+// Dependency-free base64 (no Buffer — this file runs on the Workers tier).
+const toBase64 = (bytes: Uint8Array): string => {
+  let out = ""
+  for (let i = 0; i < bytes.length; i += 3) {
+    const a = bytes[i] as number
+    const b = bytes[i + 1]
+    const c = bytes[i + 2]
+    out += B64[a >> 2]
+    out += B64[((a & 3) << 4) | ((b ?? 0) >> 4)]
+    out += b === undefined ? "=" : B64[((b & 15) << 2) | ((c ?? 0) >> 6)]
+    out += c === undefined ? "=" : B64[c & 63]
+  }
+  return out
+}
+
 const summarizeArtifact = (a: ArtifactRecord) => ({
   short_id: a.short_id,
   title: a.title,
@@ -407,6 +427,32 @@ function buildServer(
       const file = manifest.files[pagePath] ?? manifest.files[`/${cleanPath(pagePath)}`]
       if (!file) return err(`No page "${pagePath}" in "${short_id}". Pages: ${pages.join(", ")}.`)
       const bytes = await ctx.blobs.get(file.key)
+
+      // An image page is an IMAGE, not text: inline it as a real image block (small
+      // ones), or point at the served URL. Never decode PNG bytes as a string.
+      if (baseType(file.type).startsWith("image/")) {
+        const pageUrl = `${ctx.deps.baseUrl}/raw/${short_id}/v/${n}/${cleanPath(pagePath)}`
+        const size = bytes?.length ?? 0
+        if (!bytes || size > IMAGE_INLINE_MAX)
+          return json({
+            short_id,
+            section: cleanPath(pagePath),
+            type: file.type,
+            bytes: size,
+            url: pageUrl,
+            note: "Too large to inline over MCP — open the url to view it.",
+          })
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `${cleanPath(pagePath)} (${file.type}, ${size} bytes) — served at ${pageUrl}`,
+            },
+            { type: "image" as const, data: toBase64(bytes), mimeType: baseType(file.type) },
+          ],
+        }
+      }
+
       const raw = bytes ? new TextDecoder().decode(bytes) : ""
       const isText = isTextType(file.type)
       const meta = {

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -22,12 +22,12 @@
 import {
   type AgentRecord,
   type ArtifactRecord,
-  applyEdits,
   artifactUrl,
   type BundleManifest,
   diffLines,
   EditError,
   formatDiff,
+  isHtmlLike,
   newId,
   type OutlineSection,
   outlineOf,
@@ -54,7 +54,9 @@ import {
   zipBundleFiles,
 } from "./lib/bundle"
 import { parseMeta, quoteOf, REACTIONS } from "./lib/comments"
+import { type MaterializedEdits, materializeEdits } from "./lib/edits"
 import { buildReviewEmail } from "./lib/email"
+import { MAX_UPLOAD_BYTES } from "./lib/http"
 import { notifyCommentBells } from "./lib/notify-comment"
 import { enqueueChannelDelivery } from "./webhooks"
 
@@ -116,13 +118,14 @@ const baseType = (t: string) => t.split(";")[0]?.trim() ?? t
 const isTextType = (t: string) => baseType(t) === "text/html" || baseType(t) === "text/markdown"
 const present = (source: string, contentType: string, format: ReadFormat): string => {
   if (format === "html") return source
-  if (format === "text") return baseType(contentType) === "text/html" ? pageText(source) : source
+  if (format === "text") return isHtmlLike(contentType) ? pageText(source) : source
   return toMarkdown(source, contentType)
 }
 const formatLabel = (contentType: string, format: ReadFormat): string => {
-  const ct = contentType.split(";")[0]?.trim() ?? contentType
   if (format === "markdown")
-    return ct === "text/html" ? "markdown (converted from text/html)" : "markdown (source)"
+    return isHtmlLike(contentType)
+      ? `markdown (converted from ${baseType(contentType)})`
+      : "markdown (source)"
   return format === "html" ? "html (source)" : "text (visible text)"
 }
 
@@ -296,7 +299,7 @@ function buildServer(
           .string()
           .optional()
           .describe(
-            'What to read. Single-file doc: a heading slug from the outline (e.g. rollout-plan). Bundle: a page path (agentic-loop.html), optionally with a slug (agentic-loop.html#risks). Pass "*" to force the full (clipped) document. Omit it: small docs return whole, large docs return their outline.',
+            'What to read. Single-file doc: a heading slug from the outline (e.g. rollout-plan). Bundle: a page path (agentic-loop.html), optionally with a slug (agentic-loop.html#risks). Pass "*" (or "page.html#*" for a bundle page) to force the full (clipped) document/page. Omit it: small docs/pages return whole, large ones return their outline.',
           ),
         format: z
           .enum(["markdown", "html", "text"])
@@ -341,6 +344,9 @@ function buildServer(
                 : `"${short_id}" has no headings to section by — read it whole (omit \`section\`).`,
             )
           }
+          // Also feeds clipDoc's steer below — a single section can itself be huge
+          // (e.g. the last one, which runs to </body>), so it needs the same
+          // MAX_CHARS ceiling the whole-doc path gets, not an unbounded return.
           const outline = outlineOf(src, ct)
           const i = outline.findIndex((s) => s.slug === section)
           const body = present(slice, ct, fmt)
@@ -350,7 +356,7 @@ function buildServer(
               section: `${section} (${i + 1} of ${outline.length})`,
               chars: body.length,
             },
-            body,
+            clipDoc(body, outline),
           )
         }
         const body = present(src, ct, fmt)
@@ -369,10 +375,14 @@ function buildServer(
               sections: outline,
               next: 'Large document — call read again with a `section` slug for just that part, or section:"*" for the full clipped text. To revise it, publish with `edits` instead of resending content.',
             })
+          // No headings to summarize by — fall through to a plain (clipped) return,
+          // reusing the already-computed (empty) outline instead of asking again.
+          return doc({ ...meta, chars: body.length }, clipDoc(body, outline))
         }
-        const outline = outlineOf(src, ct)
-        const clipped = clipDoc(body, outline)
-        return doc({ ...meta, chars: body.length }, clipped)
+        // Under FULL_DOC_MAX: clipDoc's MAX_CHARS ceiling is far above this body's
+        // size, so it can never truncate — skip computing an outline it won't use.
+        const outline = body.length > MAX_CHARS ? outlineOf(src, ct) : []
+        return doc({ ...meta, chars: body.length }, clipDoc(body, outline))
       }
 
       // Bundle.
@@ -385,18 +395,27 @@ function buildServer(
           .sort((x, y) => x.split("/").length - y.split("/").length || x.localeCompare(y))
         const entry = cleanPath(manifest.entry)
         const inspect = [entry, ...textPages.filter((p) => p !== entry)].slice(0, 25)
-        const detail = new Map<string, { chars: number; headings: OutlineSection[] }>()
-        for (const p of inspect) {
-          const file = manifest.files[p] ?? manifest.files[`/${p}`]
-          if (!file) continue
-          const bytes = await ctx.blobs.get(file.key)
-          if (!bytes) continue
-          const text_ = new TextDecoder().decode(bytes)
-          detail.set(p, {
-            chars: toMarkdown(text_, file.type).length,
-            headings: outlineOf(text_, file.type),
-          })
-        }
+        // The blob reads are independent — fetch them all at once instead of one
+        // round trip at a time (up to 25 pages, otherwise serialized latency).
+        const detailEntries = await Promise.all(
+          inspect.map(
+            async (p): Promise<[string, { chars: number; headings: OutlineSection[] }] | null> => {
+              const file = manifest.files[p] ?? manifest.files[`/${p}`]
+              if (!file) return null
+              const bytes = await ctx.blobs.get(file.key)
+              if (!bytes) return null
+              const text_ = new TextDecoder().decode(bytes)
+              return [
+                p,
+                {
+                  chars: toMarkdown(text_, file.type).length,
+                  headings: outlineOf(text_, file.type),
+                },
+              ]
+            },
+          ),
+        )
+        const detail = new Map(detailEntries.filter((e) => e !== null))
         return json({
           short_id,
           title: a.title,
@@ -426,10 +445,13 @@ function buildServer(
         })
       }
 
-      // A page (optionally page#slug — split on the LAST '#').
+      // A page (optionally page#slug — split on the LAST '#'). "#*" forces the
+      // page's full (clipped) content, the same bypass single-file section:"*" is.
       const hash = section.lastIndexOf("#")
       const pagePath = hash > 0 ? section.slice(0, hash) : section
-      const slug = hash > 0 ? section.slice(hash + 1) : null
+      const rawSlug = hash > 0 ? section.slice(hash + 1) : null
+      const slug = rawSlug === "*" ? null : rawSlug
+      const forceFull = rawSlug === "*"
       const file = manifest.files[pagePath] ?? manifest.files[`/${cleanPath(pagePath)}`]
       if (!file) return err(`No page "${pagePath}" in "${short_id}". Pages: ${pages.join(", ")}.`)
       const bytes = await ctx.blobs.get(file.key)
@@ -481,6 +503,7 @@ function buildServer(
               : `"${pagePath}" has no headings to section by — read the whole page.`,
           )
         }
+        const outline = outlineOf(raw, file.type)
         const body = present(slice, file.type, fmt)
         return doc(
           {
@@ -489,12 +512,36 @@ function buildServer(
             format: formatLabel(file.type, fmt),
             chars: body.length,
           },
-          body,
+          clipDoc(body, outline),
         )
       }
       // css/js/json/etc always return source — conversion only applies to text pages.
       const body = isText ? present(raw, file.type, fmt) : raw
-      const outline = isText ? outlineOf(raw, file.type) : []
+      // Same outline-first threshold the single-file path applies: a bundle page can
+      // be just as large as a standalone doc, so it gets the same treatment instead
+      // of only ever cutting at the much higher MAX_CHARS ceiling below.
+      if (isText && !slug && !forceFull && body.length > FULL_DOC_MAX) {
+        const outline = outlineOf(raw, file.type)
+        if (outline.length)
+          return json({
+            short_id,
+            title: a.title,
+            kind: "bundle",
+            version: n,
+            section: cleanPath(pagePath),
+            source: file.type,
+            format: fmt,
+            doc_chars: body.length,
+            url,
+            sections: outline,
+            next: `Large page — call read again with \`section\` set to "${cleanPath(pagePath)}#slug" for just that part, or "${cleanPath(pagePath)}#*" for the full clipped text.`,
+          })
+        return doc(
+          { ...meta, section: cleanPath(pagePath), chars: body.length },
+          clipDoc(body, outline),
+        )
+      }
+      const outline = isText && body.length > MAX_CHARS ? outlineOf(raw, file.type) : []
       return doc(
         {
           ...meta,
@@ -948,29 +995,28 @@ function buildServer(
         if (content !== undefined || files)
           return err("Provide `edits` OR `content`/`files`, not both.")
         if (!existing) return err("`edits` revises an EXISTING artifact — pass its `short_id`.")
-        if (existing.kind !== "file")
-          return err(
-            `"${short_id}" is a multi-page bundle — \`edits\` applies to single-file artifacts; republish the changed page via \`files\` + \`merge\`.`,
-          )
-        if (base_version !== undefined && base_version !== existing.current_version)
-          return err(
-            `"${short_id}" moved to v${existing.current_version} while you were editing (you read v${base_version}) — catch_up, re-read, then retry.`,
-          )
-        const cur = await ctx.meta.getVersion(existing.id, existing.current_version)
-        const src = cur ? await ctx.sourceText(cur) : null
-        if (cur === null || src === null)
-          return err(`Couldn't load the current source of "${short_id}".`)
+        let materialized: MaterializedEdits
         try {
-          content = applyEdits(src, edits)
+          materialized = await materializeEdits(
+            { getVersion: ctx.meta.getVersion.bind(ctx.meta), sourceText: ctx.sourceText },
+            existing,
+            edits,
+            base_version,
+          )
         } catch (e) {
           if (e instanceof EditError) return err(e.message)
           throw e
         }
+        // Same size/storage ceiling the REST /versions and /proposals routes apply
+        // after materializing edits — without this the MCP tool could write an
+        // over-quota version the HTTP surfaces would have rejected.
+        const editedBytes = new TextEncoder().encode(materialized.content).length
+        if (editedBytes > MAX_UPLOAD_BYTES) return err("Edited content is too large.")
+        if (await ctx.overStorage(org, editedBytes))
+          return err(`"${short_id}"'s workspace storage quota is exceeded.`)
+        content = materialized.content
         editsApplied = edits.length
-        // Keep the artifact's content type: the sniffer types by filename, and the
-        // default index.html would silently re-type an edited markdown doc as HTML.
-        if (!filename)
-          filename = baseType(cur.content_type) === "text/markdown" ? "index.md" : "index.html"
+        if (!filename) filename = materialized.filename
       }
 
       // Exactly one of content / files. `files` (a page map) means a bundle.

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -27,10 +27,15 @@ import {
   diffLines,
   formatDiff,
   newId,
+  type OutlineSection,
+  outlineOf,
   PublishError,
+  pageText,
   propose as proposeChange,
   publish as publishVersion,
   roleAllows,
+  sectionOf,
+  toMarkdown,
   type VersionRecord,
 } from "@derive/core"
 import { StreamableHTTPTransport } from "@hono/mcp"
@@ -69,8 +74,55 @@ const err = (s: string) => ({
 const MAX_CHARS = 80_000
 const clip = (s: string) =>
   s.length > MAX_CHARS
-    ? `${s.slice(0, MAX_CHARS)}\n\n…[truncated ${s.length - MAX_CHARS} chars — read a specific section]`
+    ? `${s.slice(0, MAX_CHARS)}\n\n…[truncated ${s.length - MAX_CHARS} chars — narrow the range]`
     : s
+
+// Above this, a section-less read of a sectionable doc returns its OUTLINE instead of
+// a blind dump: ~9k tokens leaves room to read on, small enough that most docs still
+// arrive whole. Measured on the formatted body, not the raw source.
+const FULL_DOC_MAX = 30_000
+
+// clip(), but the truncation steer names sections that actually resolve.
+const clipDoc = (s: string, sections: OutlineSection[]) => {
+  if (s.length <= MAX_CHARS) return s
+  const steer = sections.length
+    ? `read a section instead: ${sections
+        .slice(0, 12)
+        .map((x) => x.slug)
+        .join(", ")}${sections.length > 12 ? ", …" : ""}`
+    : "no headings to section by — read a past `version`, or ask for the raw file"
+  return `${s.slice(0, MAX_CHARS)}\n\n…[truncated ${s.length - MAX_CHARS} of ${s.length} chars — ${steer}]`
+}
+
+// A content-bearing response: a frontmatter-style header, a blank line, then the RAW
+// body — one text block, real newlines, never JSON-escaped. When a client spills it
+// to a file, that file is line-oriented and greppable (the old JSON envelope turned a
+// 68k-char document into one escaped line). Receipts and outlines stay `json()`.
+const doc = (meta: Record<string, string | number | null | undefined>, body: string) => {
+  const head = Object.entries(meta)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join("\n")
+  return text(`---\n${head}\n---\n\n${body}`)
+}
+
+// The reading form for stored source at a given format. `markdown` converts HTML;
+// `text` is the flat visible text (exactly what comment quotes anchor against);
+// `html` is the exact source. Markdown/plain sources ARE their own visible text.
+type ReadFormat = "markdown" | "html" | "text"
+const baseType = (t: string) => t.split(";")[0]?.trim() ?? t
+const isTextType = (t: string) => baseType(t) === "text/html" || baseType(t) === "text/markdown"
+const present = (source: string, contentType: string, format: ReadFormat): string => {
+  if (format === "html") return source
+  if (format === "text") return baseType(contentType) === "text/html" ? pageText(source) : source
+  return toMarkdown(source, contentType)
+}
+const formatLabel = (contentType: string, format: ReadFormat): string => {
+  const ct = contentType.split(";")[0]?.trim() ?? contentType
+  if (format === "markdown")
+    return ct === "text/html" ? "markdown (converted from text/html)" : "markdown (source)"
+  return format === "html" ? "html (source)" : "text (visible text)"
+}
 
 const summarizeArtifact = (a: ArtifactRecord) => ({
   short_id: a.short_id,
@@ -211,17 +263,26 @@ function buildServer(
     "read",
     {
       description:
-        "Read an artifact's CONTENT by short id. Multi-page bundle: omit `section` to get its outline (the list of pages), then call again with a `section` (a page path) for that page's full text. Single-file artifact: returns the full content. Pass a past `version` to read history. (For what CHANGED, or the comment threads, use catch_up.)",
+        "Read an artifact's CONTENT by short id, as Markdown by default (HTML is converted; the styling noise is dropped). Small docs return whole; a LARGE doc returns its heading OUTLINE first — call again with a `section` slug for just that part. Multi-page bundle: omit `section` for the page outline, then pass a page path (optionally `page.html#slug`). Pass format:'html' for the exact source (required before publish `edits`), or a past `version` for history. (For what CHANGED, or the comment threads, use catch_up.)",
       inputSchema: {
         short_id: z.string().describe("The artifact's short id, e.g. nk0dsral."),
         section: z
           .string()
           .optional()
-          .describe("A bundle page path, e.g. agentic-loop.html. Omit to get the outline first."),
+          .describe(
+            'What to read. Single-file doc: a heading slug from the outline (e.g. rollout-plan). Bundle: a page path (agentic-loop.html), optionally with a slug (agentic-loop.html#risks). Pass "*" to force the full (clipped) document. Omit it: small docs return whole, large docs return their outline.',
+          ),
+        format: z
+          .enum(["markdown", "html", "text"])
+          .optional()
+          .describe(
+            "markdown (default): HTML converted to structured Markdown — headings, lists, tables, code fences; Markdown sources return as-is. html: the exact stored source — read this BEFORE publish `edits` on an HTML artifact (edits match raw source). text: flat visible text, exactly what comment `quote`s anchor against.",
+          ),
         version: z.number().optional().describe("Defaults to the current version."),
       },
     },
-    async ({ short_id, section, version }) => {
+    async ({ short_id, section, format, version }) => {
+      const fmt: ReadFormat = format ?? "markdown"
       const a = await own(short_id)
       if (!a) return notFound(short_id)
       const n = version ?? a.current_version
@@ -229,39 +290,168 @@ function buildServer(
         return err(`No version ${n} for "${short_id}" — it has versions 1..${a.current_version}.`)
       const v = await ctx.meta.getVersion(a.id, n)
       if (!v) return err(`Version ${n} of "${short_id}" is unavailable.`)
+      const url = artifactUrl(ctx.deps.baseUrl, a)
       const manifest = await manifestOf(ctx, v)
+
       if (!manifest) {
-        // Single-file artifact — return its content.
-        const body = await ctx.sourceText(v)
-        return json({
+        // Single-file artifact.
+        const src = (await ctx.sourceText(v)) ?? ""
+        const ct = v.content_type
+        const meta = {
           short_id,
           title: a.title,
+          version: `${n}${n === a.current_version ? " (current)" : ""}`,
           kind: a.kind,
-          version: n,
-          content: clip(body ?? ""),
-        })
+          format: formatLabel(ct, fmt),
+          url,
+        }
+        if (section && section !== "*") {
+          const slice = sectionOf(src, ct, section)
+          if (slice === null) {
+            const slugs = outlineOf(src, ct).map((s) => s.slug)
+            return err(
+              slugs.length
+                ? `No section "${section}" in "${short_id}" v${n} — sections: ${slugs.join(", ")}.`
+                : `"${short_id}" has no headings to section by — read it whole (omit \`section\`).`,
+            )
+          }
+          const outline = outlineOf(src, ct)
+          const i = outline.findIndex((s) => s.slug === section)
+          const body = present(slice, ct, fmt)
+          return doc(
+            {
+              ...meta,
+              section: `${section} (${i + 1} of ${outline.length})`,
+              chars: body.length,
+            },
+            body,
+          )
+        }
+        const body = present(src, ct, fmt)
+        if (!section && body.length > FULL_DOC_MAX) {
+          const outline = outlineOf(src, ct)
+          if (outline.length)
+            return json({
+              short_id,
+              title: a.title,
+              kind: a.kind,
+              version: n,
+              source: ct,
+              format: fmt,
+              doc_chars: body.length,
+              url,
+              sections: outline,
+              next: 'Large document — call read again with a `section` slug for just that part, or section:"*" for the full clipped text. To revise it, publish with `edits` instead of resending content.',
+            })
+        }
+        const outline = outlineOf(src, ct)
+        const clipped = clipDoc(body, outline)
+        return doc({ ...meta, chars: body.length }, clipped)
       }
+
+      // Bundle.
       const pages = Object.keys(manifest.files).map(cleanPath)
-      if (!section)
+      if (!section) {
+        // Outline: every page, plus sizes + headings for the shallowest text pages
+        // (each costs a blob read — the manifest has no sizes — so cap the sweep).
+        const textPages = pages
+          .filter((p) => isTextType(manifest.files[p]?.type ?? manifest.files[`/${p}`]?.type ?? ""))
+          .sort((x, y) => x.split("/").length - y.split("/").length || x.localeCompare(y))
+        const entry = cleanPath(manifest.entry)
+        const inspect = [entry, ...textPages.filter((p) => p !== entry)].slice(0, 25)
+        const detail = new Map<string, { chars: number; headings: OutlineSection[] }>()
+        for (const p of inspect) {
+          const file = manifest.files[p] ?? manifest.files[`/${p}`]
+          if (!file) continue
+          const bytes = await ctx.blobs.get(file.key)
+          if (!bytes) continue
+          const text_ = new TextDecoder().decode(bytes)
+          detail.set(p, {
+            chars: toMarkdown(text_, file.type).length,
+            headings: outlineOf(text_, file.type),
+          })
+        }
         return json({
           short_id,
           title: a.title,
           kind: "bundle",
           version: n,
-          entry: cleanPath(manifest.entry),
-          pages,
-          next: "Call read again with a `section` (one of the pages above) for that page's content.",
+          entry,
+          url,
+          pages: pages.map((p) => {
+            const type = manifest.files[p]?.type ?? manifest.files[`/${p}`]?.type
+            const d = detail.get(p)
+            return {
+              path: p,
+              type,
+              ...(d
+                ? {
+                    chars: d.chars,
+                    headings: d.headings.map((h) => ({
+                      slug: h.slug,
+                      level: h.level,
+                      text: h.text,
+                    })),
+                  }
+                : {}),
+            }
+          }),
+          next: "Call read again with a `section` (a page path above, optionally page.html#slug for one heading's part) for content.",
         })
-      const file = manifest.files[section] ?? manifest.files[`/${cleanPath(section)}`]
-      if (!file) return err(`No page "${section}" in "${short_id}". Pages: ${pages.join(", ")}.`)
+      }
+
+      // A page (optionally page#slug — split on the LAST '#').
+      const hash = section.lastIndexOf("#")
+      const pagePath = hash > 0 ? section.slice(0, hash) : section
+      const slug = hash > 0 ? section.slice(hash + 1) : null
+      const file = manifest.files[pagePath] ?? manifest.files[`/${cleanPath(pagePath)}`]
+      if (!file) return err(`No page "${pagePath}" in "${short_id}". Pages: ${pages.join(", ")}.`)
       const bytes = await ctx.blobs.get(file.key)
-      return json({
+      const raw = bytes ? new TextDecoder().decode(bytes) : ""
+      const isText = isTextType(file.type)
+      const meta = {
         short_id,
-        version: n,
-        section: cleanPath(section),
+        title: a.title,
+        version: `${n}${n === a.current_version ? " (current)" : ""}`,
+        kind: "bundle",
+        url,
         type: file.type,
-        content: clip(bytes ? new TextDecoder().decode(bytes) : ""),
-      })
+      }
+      if (slug) {
+        if (!isText)
+          return err(`"${pagePath}" is ${file.type} — heading sections only apply to text pages.`)
+        const slice = sectionOf(raw, file.type, slug)
+        if (slice === null) {
+          const slugs = outlineOf(raw, file.type).map((s) => s.slug)
+          return err(
+            slugs.length
+              ? `No section "${slug}" in "${pagePath}" — sections: ${slugs.join(", ")}.`
+              : `"${pagePath}" has no headings to section by — read the whole page.`,
+          )
+        }
+        const body = present(slice, file.type, fmt)
+        return doc(
+          {
+            ...meta,
+            section: `${cleanPath(pagePath)}#${slug}`,
+            format: formatLabel(file.type, fmt),
+            chars: body.length,
+          },
+          body,
+        )
+      }
+      // css/js/json/etc always return source — conversion only applies to text pages.
+      const body = isText ? present(raw, file.type, fmt) : raw
+      const outline = isText ? outlineOf(raw, file.type) : []
+      return doc(
+        {
+          ...meta,
+          section: cleanPath(pagePath),
+          format: isText ? formatLabel(file.type, fmt) : file.type,
+          chars: body.length,
+        },
+        clipDoc(body, outline),
+      )
     },
   )
 

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -237,9 +237,13 @@ function buildServer(
         `with ${agent.role} permissions. Derive hosts living documents and plans with versioned ` +
         `history, text-anchored review comments, and a publish → review → revise loop. ` +
         `Start a session with catch_up to re-sync on what changed and what feedback is open; use ` +
-        `read to view content (outline first for multi-page bundles); use comment to leave or ` +
-        `resolve feedback. ${writeGuidance}When a revision fixes specific feedback, pass those ` +
-        `thread ids as publish's "addresses" so the threads resolve (or show pending on a proposal).`,
+        `read to view content — it returns Markdown by default (HTML is converted) and an outline ` +
+        `first for large documents or bundles, so pull sections by heading slug or page path once ` +
+        `you know what you want; pass format:'html' for the exact source. Use comment to leave or ` +
+        `resolve feedback. ${writeGuidance}To change PART of an artifact, prefer publish's edits ` +
+        `(exact-match search/replace against the stored source) over resending everything. When a ` +
+        `revision fixes specific feedback, pass those thread ids as publish's "addresses" so the ` +
+        `threads resolve (or show pending on a proposal).`,
     },
   )
   const org = agent.org_id

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -1,6 +1,5 @@
 import {
   type ArtifactRecord,
-  applyEdits,
   artifactUrl,
   type BundleDoc,
   type BundleManifest,
@@ -12,6 +11,7 @@ import {
   effectiveRole,
   formatDiff,
   groupSessions,
+  isHtmlLike,
   isMarkdownBundle,
   newId,
   outlineOf,
@@ -31,6 +31,12 @@ import { publishSweepEvents } from "../lib/anchor-sweep"
 import { authorProfile, resolveHandles } from "../lib/author"
 import { cleanPath, manifestOf } from "../lib/bundle"
 import { hashPassword, signState, unlockCookie, unlockToken, verifyPassword } from "../lib/crypto"
+import {
+  EditConflictError,
+  type MaterializedEdits,
+  materializeEdits,
+  parseBaseVersion,
+} from "../lib/edits"
 import { buildReviewEmail } from "../lib/email"
 import {
   DEFAULT_WORKSPACE_NAME,
@@ -43,6 +49,28 @@ import {
   visibilityOf,
 } from "../lib/http"
 import { enqueueChannelDelivery } from "../webhooks"
+
+// Bundle asset types the /content route serves with their real Content-Type. Not
+// image/svg+xml: an SVG is a scriptable document when a browser navigates to it
+// directly, and this route (unlike /raw/, which sandboxes every asset behind a CSP)
+// has no such isolation — anything off this list serves as application/octet-stream.
+const SAFE_BINARY_CONTENT_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/avif",
+  "image/x-icon",
+  "image/vnd.microsoft.icon",
+  "font/woff",
+  "font/woff2",
+  "font/ttf",
+  "font/otf",
+  "text/css",
+  "application/javascript",
+  "text/javascript",
+  "application/json",
+])
 
 /** The artifact lifecycle: browse + summary, publish/republish, detail, restore,
  *  source read-back, and version diffs. */
@@ -355,38 +383,33 @@ export const artifactRoutes = (ctx: AppContext) => {
     if (typeof editsField === "string") {
       if (!shortId || !existing)
         return fail(c, 400, "edits revises an EXISTING artifact — POST to its /versions endpoint")
-      if (existing.kind !== "file")
-        return fail(c, 409, "edits applies to single-file artifacts only")
-      const baseVersionField = str(body["base_version"])
-      const baseVersion = baseVersionField ? Number(baseVersionField) : undefined
-      if (baseVersion !== undefined && baseVersion !== existing.current_version)
-        return fail(
-          c,
-          409,
-          `"${shortId}" moved to v${existing.current_version} (you read v${baseVersion}) — re-read and retry`,
-        )
       let edits: { old_str: string; new_str: string }[]
       try {
         edits = JSON.parse(editsField)
       } catch {
         return fail(c, 400, "edits must be a JSON array of {old_str,new_str}")
       }
-      const cur = await meta.getVersion(existing.id, existing.current_version)
-      const src = cur ? await sourceText(cur) : null
-      if (!cur || src === null) return fail(c, 500, "blob missing")
-      let materialized: string
+      let materialized: MaterializedEdits
       try {
-        materialized = applyEdits(src, edits)
+        const baseVersion = parseBaseVersion(str(body["base_version"]))
+        materialized = await materializeEdits(
+          { getVersion: meta.getVersion.bind(meta), sourceText },
+          existing,
+          edits,
+          baseVersion,
+        )
       } catch (e) {
-        return fail(c, 400, e instanceof EditError ? e.message : "edit failed")
+        if (e instanceof EditConflictError) return fail(c, 409, e.message)
+        return fail(
+          c,
+          e instanceof EditError ? 400 : 500,
+          e instanceof Error ? e.message : "edit failed",
+        )
       }
-      bytes = new TextEncoder().encode(materialized)
+      bytes = new TextEncoder().encode(materialized.content)
       if (bytes.length > MAX_UPLOAD_BYTES) return fail(c, 413, "upload too large")
       if (await overStorage(org, bytes.length)) return fail(c, 413, "storage quota exceeded")
-      filename =
-        (cur.content_type.split(";")[0]?.trim() ?? cur.content_type) === "text/markdown"
-          ? "index.md"
-          : "index.html"
+      filename = materialized.filename
       isBundle = false
     } else {
       const file = body["file"]
@@ -949,10 +972,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     const outline = c.req.query("outline") === "1"
     const present = (source: string, contentType: string): string => {
       if (!format) return source
-      if (format === "text")
-        return (contentType.split(";")[0]?.trim() ?? contentType) === "text/html"
-          ? pageText(source)
-          : source
+      if (format === "text") return isHtmlLike(contentType) ? pageText(source) : source
       return toMarkdown(source, contentType)
     }
 
@@ -997,8 +1017,12 @@ export const artifactRoutes = (ctx: AppContext) => {
         })),
       })
     }
-    const pagePath = section ? (section.split("#")[0] as string) : cleanPath(manifest.entry)
-    const slug = section?.includes("#") ? section.slice(section.indexOf("#") + 1) : null
+    // Split on the LAST '#' — matches the MCP `read` tool's page#slug parsing, so a
+    // page path/slug resolves to the same (pagePath, slug) pair on both surfaces.
+    const hash = section ? section.lastIndexOf("#") : -1
+    const pagePath =
+      hash > 0 ? (section as string).slice(0, hash) : (section ?? cleanPath(manifest.entry))
+    const slug = hash > 0 ? (section as string).slice(hash + 1) : null
     const file = manifest.files[pagePath] ?? manifest.files[`/${cleanPath(pagePath)}`]
     if (!file) return fail(c, 404, `no page "${pagePath}"`)
     const bytes = await blobs.get(file.key)
@@ -1006,7 +1030,15 @@ export const artifactRoutes = (ctx: AppContext) => {
     const fileBaseType = file.type.split(";")[0]?.trim() ?? file.type
     const isText = fileBaseType === "text/html" || fileBaseType === "text/markdown"
     if (!isText) {
-      c.header("Content-Type", file.type)
+      // This route is a machine content API, not a rendering surface (unlike /raw/,
+      // which applies a CSP sandbox to every bundle asset it serves). Native
+      // Content-Type is safe for the SAFE set below; anything else — most notably
+      // image/svg+xml, which a direct navigation renders as a scriptable document —
+      // is served inert instead of trusting the stored type verbatim.
+      c.header(
+        "Content-Type",
+        SAFE_BINARY_CONTENT_TYPES.has(fileBaseType) ? file.type : "application/octet-stream",
+      )
       c.header("X-Derive-Format", "raw")
       return c.body(toBody(bytes))
     }

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -1,5 +1,6 @@
 import {
   type ArtifactRecord,
+  applyEdits,
   artifactUrl,
   type BundleDoc,
   type BundleManifest,
@@ -7,15 +8,20 @@ import {
   can,
   capRole,
   diffLines,
+  EditError,
   effectiveRole,
   formatDiff,
   groupSessions,
   isMarkdownBundle,
   newId,
+  outlineOf,
   PublishError,
+  pageText,
   publish,
   renderMarkdown,
+  sectionOf,
   toJson,
+  toMarkdown,
 } from "@derive/core"
 import { type Context, Hono } from "hono"
 import { setCookie } from "hono/cookie"
@@ -23,6 +29,7 @@ import { z } from "zod"
 import type { AppContext } from "../context"
 import { publishSweepEvents } from "../lib/anchor-sweep"
 import { authorProfile, resolveHandles } from "../lib/author"
+import { cleanPath, manifestOf } from "../lib/bundle"
 import { hashPassword, signState, unlockCookie, unlockToken, verifyPassword } from "../lib/crypto"
 import { buildReviewEmail } from "../lib/email"
 import {
@@ -32,6 +39,7 @@ import {
   readJson,
   str,
   TOMBSTONE,
+  toBody,
   visibilityOf,
 } from "../lib/http"
 import { enqueueChannelDelivery } from "../webhooks"
@@ -335,18 +343,65 @@ export const artifactRoutes = (ctx: AppContext) => {
     if (len > MAX_UPLOAD_BYTES) return fail(c, 413, "upload too large")
 
     const body = await c.req.parseBody()
-    const file = body["file"]
-    if (!(file instanceof File)) return fail(c, 400, "multipart field 'file' required")
 
-    const bytes = new Uint8Array(await file.arrayBuffer())
-    // The content-length header is advisory (a client can omit/understate it),
-    // so re-check the actual buffered size — the hard cap before anything stores.
-    if (bytes.length > MAX_UPLOAD_BYTES) return fail(c, 413, "upload too large")
-    if (await overStorage(org, bytes.length)) return fail(c, 413, "storage quota exceeded")
-    const isBundle =
-      /\.zip$/i.test(file.name) ||
-      body["kind"] === "bundle" ||
-      (bytes[0] === 0x50 && bytes[1] === 0x4b && (bytes[2] === 3 || bytes[2] === 5))
+    // `edits` — a token-cheap revision (stdio/API parity with the MCP publish
+    // tool's `edits`): exact-match search/replace against the current stored
+    // source instead of a re-uploaded `file`. Materialize the full content, then
+    // fall through to the same publish path everything else uses.
+    const editsField = body["edits"]
+    let bytes: Uint8Array
+    let filename: string
+    let isBundle: boolean
+    if (typeof editsField === "string") {
+      if (!shortId || !existing)
+        return fail(c, 400, "edits revises an EXISTING artifact — POST to its /versions endpoint")
+      if (existing.kind !== "file")
+        return fail(c, 409, "edits applies to single-file artifacts only")
+      const baseVersionField = str(body["base_version"])
+      const baseVersion = baseVersionField ? Number(baseVersionField) : undefined
+      if (baseVersion !== undefined && baseVersion !== existing.current_version)
+        return fail(
+          c,
+          409,
+          `"${shortId}" moved to v${existing.current_version} (you read v${baseVersion}) — re-read and retry`,
+        )
+      let edits: { old_str: string; new_str: string }[]
+      try {
+        edits = JSON.parse(editsField)
+      } catch {
+        return fail(c, 400, "edits must be a JSON array of {old_str,new_str}")
+      }
+      const cur = await meta.getVersion(existing.id, existing.current_version)
+      const src = cur ? await sourceText(cur) : null
+      if (!cur || src === null) return fail(c, 500, "blob missing")
+      let materialized: string
+      try {
+        materialized = applyEdits(src, edits)
+      } catch (e) {
+        return fail(c, 400, e instanceof EditError ? e.message : "edit failed")
+      }
+      bytes = new TextEncoder().encode(materialized)
+      if (bytes.length > MAX_UPLOAD_BYTES) return fail(c, 413, "upload too large")
+      if (await overStorage(org, bytes.length)) return fail(c, 413, "storage quota exceeded")
+      filename =
+        (cur.content_type.split(";")[0]?.trim() ?? cur.content_type) === "text/markdown"
+          ? "index.md"
+          : "index.html"
+      isBundle = false
+    } else {
+      const file = body["file"]
+      if (!(file instanceof File)) return fail(c, 400, "multipart field 'file' required")
+      bytes = new Uint8Array(await file.arrayBuffer())
+      // The content-length header is advisory (a client can omit/understate it),
+      // so re-check the actual buffered size — the hard cap before anything stores.
+      if (bytes.length > MAX_UPLOAD_BYTES) return fail(c, 413, "upload too large")
+      if (await overStorage(org, bytes.length)) return fail(c, 413, "storage quota exceeded")
+      filename = file.name
+      isBundle =
+        /\.zip$/i.test(file.name) ||
+        body["kind"] === "bundle" ||
+        (bytes[0] === 0x50 && bytes[1] === 0x4b && (bytes[2] === 3 || bytes[2] === 5))
+    }
 
     // A password is a lock on a public link — hashed at create; a republish keeps
     // whatever the artifact already has (publish() never re-creates the artifact,
@@ -388,7 +443,7 @@ export const artifactRoutes = (ctx: AppContext) => {
         blobs,
         {
           bytes,
-          filename: file.name,
+          filename,
           isBundle,
           title: str(body["title"]),
           slug: str(body["slug"]),
@@ -869,6 +924,12 @@ export const artifactRoutes = (ctx: AppContext) => {
 
   // Source read-back for machines: returns an artifact's text content for any
   // version, as plain text (?v=N selects a version; defaults to current).
+  //
+  // ?format=markdown|text renders instead of returning raw source (default: raw,
+  // for existing byte-exact consumers). ?outline=1 returns a JSON heading/page
+  // outline instead of content. ?section=<slug|page|page#slug> returns just that
+  // part. X-Derive-* response headers double as a capability probe for older
+  // clients that predate these params (self-hosted stdio server parity).
   app.get("/v1/artifacts/:shortId/content", async (c) => {
     const artifact = await meta.getByShortId(c.req.param("shortId"))
     if (!artifact || artifact.current_version === 0 || !(await authorize(c, "read", artifact)))
@@ -878,14 +939,91 @@ export const artifactRoutes = (ctx: AppContext) => {
     if (!Number.isInteger(v)) return fail(c, 400, "bad version")
     const version = await meta.getVersion(artifact.id, v)
     if (!version) return fail(c, 404, `no version ${v}`)
-    const src = await sourceText(version)
-    if (src === null) return fail(c, 500, "blob missing")
-    c.header("Content-Type", "text/plain; charset=utf-8")
-    c.header("X-Content-Type-Options", "nosniff")
+
+    const formatQ = c.req.query("format")
+    const format = formatQ === "markdown" || formatQ === "text" ? formatQ : null
+    // "*" forces full content — the escape hatch a caller uses after already
+    // seeing (or skipping) the outline, same sentinel the MCP `read` tool takes.
+    const sectionQ = c.req.query("section")
+    const section = sectionQ && sectionQ !== "*" ? sectionQ : null
+    const outline = c.req.query("outline") === "1"
+    const present = (source: string, contentType: string): string => {
+      if (!format) return source
+      if (format === "text")
+        return (contentType.split(";")[0]?.trim() ?? contentType) === "text/html"
+          ? pageText(source)
+          : source
+      return toMarkdown(source, contentType)
+    }
+
     c.header("Access-Control-Allow-Origin", "*")
+    c.header("X-Content-Type-Options", "nosniff")
     c.header("X-Derive-Version", String(v))
     c.header("X-Derive-Kind", artifact.kind)
-    return c.body(src)
+
+    const manifest = await manifestOf(blobs, version)
+    if (!manifest) {
+      // Single-file artifact.
+      const src = await sourceText(version)
+      if (src === null) return fail(c, 500, "blob missing")
+      if (outline) {
+        c.header("X-Derive-Format", "outline")
+        return c.json({ sections: outlineOf(src, version.content_type) })
+      }
+      if (section) {
+        const slice = sectionOf(src, version.content_type, section)
+        if (slice === null) return fail(c, 404, `no section "${section}"`)
+        const body = present(slice, version.content_type)
+        c.header("X-Derive-Format", format ?? "raw")
+        c.header("X-Derive-Section", section)
+        c.header("Content-Type", "text/plain; charset=utf-8")
+        return c.body(body)
+      }
+      const body = present(src, version.content_type)
+      c.header("X-Derive-Format", format ?? "raw")
+      c.header("X-Derive-Sections", String(outlineOf(src, version.content_type).length))
+      c.header("Content-Type", "text/plain; charset=utf-8")
+      return c.body(body)
+    }
+
+    // Bundle.
+    if (outline) {
+      c.header("X-Derive-Format", "outline")
+      return c.json({
+        entry: cleanPath(manifest.entry),
+        pages: Object.keys(manifest.files).map((p) => ({
+          path: cleanPath(p),
+          type: manifest.files[p]?.type,
+        })),
+      })
+    }
+    const pagePath = section ? (section.split("#")[0] as string) : cleanPath(manifest.entry)
+    const slug = section?.includes("#") ? section.slice(section.indexOf("#") + 1) : null
+    const file = manifest.files[pagePath] ?? manifest.files[`/${cleanPath(pagePath)}`]
+    if (!file) return fail(c, 404, `no page "${pagePath}"`)
+    const bytes = await blobs.get(file.key)
+    if (!bytes) return fail(c, 500, "blob missing")
+    const fileBaseType = file.type.split(";")[0]?.trim() ?? file.type
+    const isText = fileBaseType === "text/html" || fileBaseType === "text/markdown"
+    if (!isText) {
+      c.header("Content-Type", file.type)
+      c.header("X-Derive-Format", "raw")
+      return c.body(toBody(bytes))
+    }
+    const raw = new TextDecoder().decode(bytes)
+    if (slug) {
+      const slice = sectionOf(raw, file.type, slug)
+      if (slice === null) return fail(c, 404, `no section "${slug}" in "${pagePath}"`)
+      c.header("X-Derive-Format", format ?? "raw")
+      c.header("X-Derive-Section", `${pagePath}#${slug}`)
+      c.header("Content-Type", "text/plain; charset=utf-8")
+      return c.body(present(slice, file.type))
+    }
+    c.header("X-Derive-Format", format ?? "raw")
+    c.header("X-Derive-Section", pagePath)
+    c.header("X-Derive-Sections", String(outlineOf(raw, file.type).length))
+    c.header("Content-Type", "text/plain; charset=utf-8")
+    return c.body(present(raw, file.type))
   })
 
   // Live editor preview: render a markdown draft to the exact published HTML.
@@ -919,7 +1057,13 @@ export const artifactRoutes = (ctx: AppContext) => {
     if (!vf || !vt) return fail(c, 404, "version not found")
     const [a, b] = [await sourceText(vf), await sourceText(vt)]
     if (a === null || b === null) return fail(c, 500, "blob missing")
-    const ops = diffLines(a, b)
+    // ?content=markdown diffs the readable form (HTML converted) instead of raw
+    // source — kills tag noise and fixes minified one-line HTML producing a
+    // single useless del/add pair. Default stays raw bytes for existing consumers.
+    const ops =
+      c.req.query("content") === "markdown"
+        ? diffLines(toMarkdown(a, vf.content_type), toMarkdown(b, vt.content_type))
+        : diffLines(a, b)
 
     c.header("Access-Control-Allow-Origin", "*")
     c.header("X-Derive-From", String(from))

--- a/apps/api/src/routes/proposals.ts
+++ b/apps/api/src/routes/proposals.ts
@@ -1,7 +1,9 @@
 import {
   type ArtifactRecord,
+  applyEdits,
   approveProposal,
   diffLines,
+  EditError,
   type ProposalRecord,
   PublishError,
   propose,
@@ -100,19 +102,66 @@ export const proposalRoutes = (ctx: AppContext) => {
     if (len > MAX_UPLOAD_BYTES) return fail(c, 413, "upload too large")
 
     const body = await c.req.parseBody()
-    const file = body.file
-    if (!(file instanceof File)) return fail(c, 400, "multipart field 'file' required")
-    const bytes = new Uint8Array(await file.arrayBuffer())
-    // content-length is advisory; re-check the actual buffered size (hard cap).
-    if (bytes.length > MAX_UPLOAD_BYTES) return fail(c, 413, "upload too large")
-    // Proposals store a blob immediately, so they count toward the storage cap
-    // of the artifact's workspace.
-    if (await overStorage(artifact.org_id, bytes.length))
-      return fail(c, 413, "storage quota exceeded")
-    const isBundle =
-      /\.zip$/i.test(file.name) ||
-      body.kind === "bundle" ||
-      (bytes[0] === 0x50 && bytes[1] === 0x4b && (bytes[2] === 3 || bytes[2] === 5))
+
+    // `edits` — exact-match search/replace against the current stored source,
+    // same contract and helper as a direct-publish `edits` revision (parity with
+    // the MCP publish tool). Materializes full content, then flows into the same
+    // propose() call as a `file` upload would.
+    const editsField = body.edits
+    let bytes: Uint8Array
+    let filename: string
+    let isBundle: boolean
+    if (typeof editsField === "string") {
+      if (artifact.kind !== "file")
+        return fail(c, 409, "edits applies to single-file artifacts only")
+      const baseVersionField = str(body.base_version)
+      const baseVersion = baseVersionField ? Number(baseVersionField) : undefined
+      if (baseVersion !== undefined && baseVersion !== artifact.current_version)
+        return fail(
+          c,
+          409,
+          `"${artifact.short_id}" moved to v${artifact.current_version} (you read v${baseVersion}) — re-read and retry`,
+        )
+      let edits: { old_str: string; new_str: string }[]
+      try {
+        edits = JSON.parse(editsField)
+      } catch {
+        return fail(c, 400, "edits must be a JSON array of {old_str,new_str}")
+      }
+      const cur = await meta.getVersion(artifact.id, artifact.current_version)
+      const src = cur ? await sourceText(cur) : null
+      if (!cur || src === null) return fail(c, 500, "blob missing")
+      let materialized: string
+      try {
+        materialized = applyEdits(src, edits)
+      } catch (e) {
+        return fail(c, 400, e instanceof EditError ? e.message : "edit failed")
+      }
+      bytes = new TextEncoder().encode(materialized)
+      if (bytes.length > MAX_UPLOAD_BYTES) return fail(c, 413, "upload too large")
+      if (await overStorage(artifact.org_id, bytes.length))
+        return fail(c, 413, "storage quota exceeded")
+      filename =
+        (cur.content_type.split(";")[0]?.trim() ?? cur.content_type) === "text/markdown"
+          ? "index.md"
+          : "index.html"
+      isBundle = false
+    } else {
+      const file = body.file
+      if (!(file instanceof File)) return fail(c, 400, "multipart field 'file' required")
+      bytes = new Uint8Array(await file.arrayBuffer())
+      // content-length is advisory; re-check the actual buffered size (hard cap).
+      if (bytes.length > MAX_UPLOAD_BYTES) return fail(c, 413, "upload too large")
+      // Proposals store a blob immediately, so they count toward the storage cap
+      // of the artifact's workspace.
+      if (await overStorage(artifact.org_id, bytes.length))
+        return fail(c, 413, "storage quota exceeded")
+      filename = file.name
+      isBundle =
+        /\.zip$/i.test(file.name) ||
+        body.kind === "bundle" ||
+        (bytes[0] === 0x50 && bytes[1] === 0x4b && (bytes[2] === 3 || bytes[2] === 5))
+    }
 
     const acting = await actingUser(c)
     const author = acting ? acting.name : str(body.author) || "anonymous"
@@ -124,7 +173,7 @@ export const proposalRoutes = (ctx: AppContext) => {
     try {
       const { proposal } = await propose(meta, blobs, artifact.short_id, {
         bytes,
-        filename: file.name,
+        filename,
         isBundle,
         spa: body.spa === "true" || body.spa === "1",
         message: str(body.message),

--- a/apps/api/src/routes/proposals.ts
+++ b/apps/api/src/routes/proposals.ts
@@ -1,6 +1,5 @@
 import {
   type ArtifactRecord,
-  applyEdits,
   approveProposal,
   diffLines,
   EditError,
@@ -13,6 +12,12 @@ import { z } from "zod"
 import type { AppContext } from "../context"
 import { markAddressed, releaseAddressed } from "../lib/addressed"
 import { publishSweepEvents } from "../lib/anchor-sweep"
+import {
+  EditConflictError,
+  type MaterializedEdits,
+  materializeEdits,
+  parseBaseVersion,
+} from "../lib/edits"
 import { fail, MAX_UPLOAD_BYTES, readJson, str } from "../lib/http"
 
 /** Parse a comma-separated id list (the `addresses` multipart field). */
@@ -112,39 +117,34 @@ export const proposalRoutes = (ctx: AppContext) => {
     let filename: string
     let isBundle: boolean
     if (typeof editsField === "string") {
-      if (artifact.kind !== "file")
-        return fail(c, 409, "edits applies to single-file artifacts only")
-      const baseVersionField = str(body.base_version)
-      const baseVersion = baseVersionField ? Number(baseVersionField) : undefined
-      if (baseVersion !== undefined && baseVersion !== artifact.current_version)
-        return fail(
-          c,
-          409,
-          `"${artifact.short_id}" moved to v${artifact.current_version} (you read v${baseVersion}) — re-read and retry`,
-        )
       let edits: { old_str: string; new_str: string }[]
       try {
         edits = JSON.parse(editsField)
       } catch {
         return fail(c, 400, "edits must be a JSON array of {old_str,new_str}")
       }
-      const cur = await meta.getVersion(artifact.id, artifact.current_version)
-      const src = cur ? await sourceText(cur) : null
-      if (!cur || src === null) return fail(c, 500, "blob missing")
-      let materialized: string
+      let materialized: MaterializedEdits
       try {
-        materialized = applyEdits(src, edits)
+        const baseVersion = parseBaseVersion(str(body.base_version))
+        materialized = await materializeEdits(
+          { getVersion: meta.getVersion.bind(meta), sourceText },
+          artifact,
+          edits,
+          baseVersion,
+        )
       } catch (e) {
-        return fail(c, 400, e instanceof EditError ? e.message : "edit failed")
+        if (e instanceof EditConflictError) return fail(c, 409, e.message)
+        return fail(
+          c,
+          e instanceof EditError ? 400 : 500,
+          e instanceof Error ? e.message : "edit failed",
+        )
       }
-      bytes = new TextEncoder().encode(materialized)
+      bytes = new TextEncoder().encode(materialized.content)
       if (bytes.length > MAX_UPLOAD_BYTES) return fail(c, 413, "upload too large")
       if (await overStorage(artifact.org_id, bytes.length))
         return fail(c, 413, "storage quota exceeded")
-      filename =
-        (cur.content_type.split(";")[0]?.trim() ?? cur.content_type) === "text/markdown"
-          ? "index.md"
-          : "index.html"
+      filename = materialized.filename
       isBundle = false
     } else {
       const file = body.file

--- a/apps/api/test/content-params.test.ts
+++ b/apps/api/test/content-params.test.ts
@@ -71,6 +71,42 @@ describe("/v1/artifacts/:shortId/content — format, section, outline params", (
     expect(slug).not.toContain("Part Two")
   })
 
+  it("splits page#slug on the LAST '#', matching the MCP read tool (regression: REST used to split on the first)", async () => {
+    const zip = zipSync({
+      "index.html": new TextEncoder().encode("<h1>Home</h1>"),
+      // A page path that itself contains a '#' (pathological but must parse the
+      // same way on every surface, since the same section string reads it).
+      "a#b.html": new TextEncoder().encode("<h1>X</h1><h2>Target</h2><p>found it</p>"),
+    })
+    const { short_id } = await (await upload("hashsite.zip", zip)).json()
+    const res = await app.request(
+      `/v1/artifacts/${short_id}/content?section=${encodeURIComponent("a#b.html#target")}&format=markdown`,
+    )
+    expect(res.headers.get("x-derive-section")).toBe("a#b.html#target")
+    expect(await res.text()).toContain("found it")
+  })
+
+  it("serves a non-safe bundle asset (e.g. SVG) as application/octet-stream, not its native type (regression: this route has no CSP sandbox, unlike /raw/, so a native image/svg+xml Content-Type let a direct navigation render it as a scriptable document)", async () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+    const zip = zipSync({
+      "index.html": new TextEncoder().encode("<h1>Home</h1>"),
+      "shot.svg": new TextEncoder().encode(svg),
+    })
+    const { short_id } = await (await upload("svgsite.zip", zip)).json()
+    const res = await app.request(`/v1/artifacts/${short_id}/content?section=shot.svg`)
+    expect(res.headers.get("content-type")).toBe("application/octet-stream")
+    expect(await res.text()).toBe(svg)
+
+    // A genuinely safe image type still serves with its real Content-Type.
+    const zip2 = zipSync({
+      "index.html": new TextEncoder().encode("<h1>Home</h1>"),
+      "shot.png": new Uint8Array([137, 80, 78, 71]), // PNG magic bytes, contents don't matter here
+    })
+    const { short_id: id2 } = await (await upload("pngsite.zip", zip2)).json()
+    const pngRes = await app.request(`/v1/artifacts/${id2}/content?section=shot.png`)
+    expect(pngRes.headers.get("content-type")).toBe("image/png")
+  })
+
   it("diff: default is raw source lines; ?content=markdown diffs the readable form", async () => {
     const v1 =
       "<html><head><style>x{color:red}</style></head><body><p>alpha bravo</p></body></html>"
@@ -140,5 +176,19 @@ describe("/v1 publish + proposals — edits form field", () => {
     const live = await (await app.request(`/v1/artifacts/${short_id}/content`)).text()
     expect(live).toContain("keep this")
     expect(live).not.toContain("changed this")
+  })
+
+  it("versions: a malformed base_version fails clearly (400) instead of silently coercing to NaN and always rejecting (regression)", async () => {
+    const { short_id } = await (await upload("badbase.html", "<h1>x</h1><p>y</p>")).json()
+    const res = await app.request(`/v1/artifacts/${short_id}/versions`, {
+      method: "POST",
+      headers: bearer,
+      body: new URLSearchParams({
+        edits: JSON.stringify([{ old_str: "y", new_str: "z" }]),
+        base_version: "not-a-number",
+      }),
+    })
+    expect(res.status).toBe(400)
+    expect(await res.text()).toContain("not a valid version number")
   })
 })

--- a/apps/api/test/content-params.test.ts
+++ b/apps/api/test/content-params.test.ts
@@ -1,0 +1,144 @@
+import { zipSync } from "fflate"
+import { describe, expect, it } from "vitest"
+import { app, TEST_TOKEN, upload } from "./helpers"
+
+const bearer = { authorization: `Bearer ${TEST_TOKEN}` }
+
+describe("/v1/artifacts/:shortId/content — format, section, outline params", () => {
+  it("defaults to raw source; format=markdown converts; format=text is flat text", async () => {
+    const html =
+      "<html><head><style>body{color:red}</style></head><body><h1>Doc</h1><p>hi</p></body></html>"
+    const { short_id } = await (await upload("index.html", html)).json()
+
+    const raw = await (await app.request(`/v1/artifacts/${short_id}/content`)).text()
+    expect(raw).toBe(html)
+
+    const mdRes = await app.request(`/v1/artifacts/${short_id}/content?format=markdown`)
+    expect(mdRes.headers.get("x-derive-format")).toBe("markdown")
+    const md = await mdRes.text()
+    expect(md).toContain("# Doc")
+    expect(md).not.toContain("color:red")
+
+    const flat = await (await app.request(`/v1/artifacts/${short_id}/content?format=text`)).text()
+    expect(flat).toContain("hi")
+    expect(flat).not.toContain("# Doc")
+  })
+
+  it("?outline=1 returns the heading spine; ?section=<slug> returns just that part", async () => {
+    const html = "<h1>Top</h1><h2>Alpha</h2><p>a-body</p><h2>Beta</h2><p>b-body</p>"
+    const { short_id } = await (await upload("index.html", html)).json()
+
+    const outline = await (await app.request(`/v1/artifacts/${short_id}/content?outline=1`)).json()
+    expect(outline.sections.map((s: { slug: string }) => s.slug)).toEqual(["top", "alpha", "beta"])
+
+    const sec = await app.request(`/v1/artifacts/${short_id}/content?section=alpha`)
+    expect(sec.headers.get("x-derive-section")).toBe("alpha")
+    const text = await sec.text()
+    expect(text).toContain("a-body")
+    expect(text).not.toContain("b-body")
+
+    const missing = await app.request(`/v1/artifacts/${short_id}/content?section=nope`)
+    expect(missing.status).toBe(404)
+  })
+
+  it("bundle pages: outline, a page, and page#slug", async () => {
+    const zip = zipSync({
+      "index.html": new TextEncoder().encode("<h1>Home</h1>"),
+      "about.html": new TextEncoder().encode(
+        "<h1>About</h1><h2>Part One</h2><p>one</p><h2>Part Two</h2><p>two</p>",
+      ),
+    })
+    const { short_id } = await (await upload("site.zip", zip)).json()
+
+    const outline = await (await app.request(`/v1/artifacts/${short_id}/content?outline=1`)).json()
+    expect(outline.pages.map((p: { path: string }) => p.path).sort()).toEqual([
+      "about.html",
+      "index.html",
+    ])
+
+    const page = await (
+      await app.request(`/v1/artifacts/${short_id}/content?section=about.html&format=markdown`)
+    ).text()
+    expect(page).toContain("## Part Two")
+
+    // page#slug — a sibling section stops at the next heading of the same level.
+    const slugRes = await app.request(
+      `/v1/artifacts/${short_id}/content?section=about.html%23part-one&format=markdown`,
+    )
+    expect(slugRes.headers.get("x-derive-section")).toBe("about.html#part-one")
+    const slug = await slugRes.text()
+    expect(slug).toContain("one")
+    expect(slug).not.toContain("Part Two")
+  })
+
+  it("diff: default is raw source lines; ?content=markdown diffs the readable form", async () => {
+    const v1 =
+      "<html><head><style>x{color:red}</style></head><body><p>alpha bravo</p></body></html>"
+    const v2 =
+      "<html><head><style>x{color:blue}</style></head><body><p>alpha BRAVO</p></body></html>"
+    const { short_id } = await (await upload("d.html", v1)).json()
+    await upload("d.html", v2, {}, short_id)
+
+    const raw = await (await app.request(`/v1/artifacts/${short_id}/diff?from=1&to=2`)).text()
+    expect(raw).toContain("<style>")
+
+    const semantic = await (
+      await app.request(`/v1/artifacts/${short_id}/diff?from=1&to=2&content=markdown`)
+    ).text()
+    expect(semantic).toContain("BRAVO")
+    expect(semantic).not.toContain("<style>")
+  })
+})
+
+describe("/v1 publish + proposals — edits form field", () => {
+  it("versions: edits materializes a new version without a file upload", async () => {
+    const { short_id } = await (
+      await upload("e.html", "<h1>Title</h1><p>alpha beta gamma</p>")
+    ).json()
+
+    const res = await app.request(`/v1/artifacts/${short_id}/versions`, {
+      method: "POST",
+      headers: bearer,
+      body: new URLSearchParams({
+        edits: JSON.stringify([{ old_str: "beta", new_str: "BETA" }]),
+      }),
+    })
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.published).toBe(2)
+
+    const content = await (await app.request(`/v1/artifacts/${short_id}/content`)).text()
+    expect(content).toContain("alpha BETA gamma")
+  })
+
+  it("versions: edits rejects a stale base_version", async () => {
+    const { short_id } = await (await upload("e2.html", "<h1>x</h1><p>one</p>")).json()
+    await upload("e2.html", "<h1>x</h1><p>two</p>", {}, short_id) // now v2
+
+    const res = await app.request(`/v1/artifacts/${short_id}/versions`, {
+      method: "POST",
+      headers: bearer,
+      body: new URLSearchParams({
+        edits: JSON.stringify([{ old_str: "two", new_str: "TWO" }]),
+        base_version: "1",
+      }),
+    })
+    expect(res.status).toBe(409)
+  })
+
+  it("proposals: edits stages a proposal from the materialized text, live version untouched", async () => {
+    const { short_id } = await (await upload("e3.html", "<h1>x</h1><p>keep this</p>")).json()
+
+    const direct = await app.request(`/v1/artifacts/${short_id}/proposals`, {
+      method: "POST",
+      headers: bearer,
+      body: new URLSearchParams({
+        edits: JSON.stringify([{ old_str: "keep this", new_str: "changed this" }]),
+      }),
+    })
+    expect(direct.status).toBe(201)
+    const live = await (await app.request(`/v1/artifacts/${short_id}/content`)).text()
+    expect(live).toContain("keep this")
+    expect(live).not.toContain("changed this")
+  })
+})

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -19,7 +19,11 @@ import { sha256 } from "../src/lib/crypto"
 const dir = mkdtempSync(join(tmpdir(), "derive-mcp-"))
 afterAll(() => rmSync(dir, { recursive: true, force: true }))
 
-function appWithGrant(name: string, scopes: string) {
+function appWithGrant(
+  name: string,
+  scopes: string,
+  extra: Partial<Parameters<typeof createApp>[0]> = {},
+) {
   const path = join(dir, `${name}.db`)
   const meta = new SqliteMetaStore(path)
   const db = new Database(path)
@@ -47,6 +51,7 @@ function appWithGrant(name: string, scopes: string) {
     blobs: new FsBlobStore(join(dir, `${name}-blobs`)),
     baseUrl: "http://derive.test",
     token: "tok",
+    ...extra,
   })
   return { app, token: `tok_${name}` }
 }
@@ -393,6 +398,83 @@ describe("remote MCP endpoint (/mcp)", () => {
     const one = toolText(await call(app, token, "read", { short_id: bigId, section: "sect-7" }))
     expect(one).toContain("## Sect 7")
     expect(one).toContain("section: sect-7 (9 of 41)")
+  })
+
+  it("read: a single section that's itself huge is clipped, not returned unbounded (regression)", async () => {
+    const { app, token } = appWithGrant("readhugesection", "openid derive:read derive:publish")
+    // One heading whose own content exceeds the 80k MAX_CHARS ceiling on its own —
+    // sectionOf runs it to </body>, so a naive return would ship it all unbounded.
+    const hugeSection = `<h1>Top</h1><h2>Huge</h2><p>${"lorem ipsum dolor sit amet ".repeat(4000)}</p>`
+    const form = new FormData()
+    form.append(
+      "file",
+      new Blob([new TextEncoder().encode(`<html><body>${hugeSection}</body></html>`)]),
+      "index.html",
+    )
+    form.append("title", "Huge Section Doc")
+    const shortId = (
+      await (
+        await app.request("/v1/artifacts", {
+          method: "POST",
+          body: form,
+          headers: { authorization: `Bearer ${token}` },
+        })
+      ).json()
+    ).short_id
+    const section = toolText(await call(app, token, "read", { short_id: shortId, section: "huge" }))
+    expect(section).toContain("…[truncated")
+  })
+
+  it("read: format:text on a deck artifact returns flat visible text, not raw markup (regression)", async () => {
+    const { app, token } = appWithGrant("readdeck", "openid derive:read derive:publish")
+    // Must NOT start with <html>/<!doctype html> (that sniffs as plain text/html) —
+    // real deck content declares the protocol name, which is enough to type-sniff it.
+    const deck = "derive-deck\n<h1>Slide</h1><p>hello there</p>"
+    const form = new FormData()
+    form.append("file", new Blob([new TextEncoder().encode(deck)]), "deck.html")
+    form.append("title", "Deck")
+    const shortId = (
+      await (
+        await app.request("/v1/artifacts", {
+          method: "POST",
+          body: form,
+          headers: { authorization: `Bearer ${token}` },
+        })
+      ).json()
+    ).short_id
+    const md = toolText(await call(app, token, "read", { short_id: shortId, section: "*" }))
+    expect(md).toContain("format: markdown (converted from text/x-derive-deck)")
+    expect(md).toContain("# Slide")
+    const flat = toolText(
+      await call(app, token, "read", { short_id: shortId, format: "text", section: "*" }),
+    )
+    expect(flat).not.toContain("<h1>")
+    expect(flat).toContain("hello there")
+  })
+
+  it("read: a bundle page over the outline threshold goes outline-first too, with a #* bypass", async () => {
+    const { app, token } = appWithGrant("readbundlebig", "openid derive:read derive:publish")
+    const bigPage = Array.from(
+      { length: 40 },
+      (_, i) => `<h2>Screen ${i}</h2><p>${"lorem ipsum ".repeat(120)}</p>`,
+    ).join("")
+    const created = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          title: "Big Bundle",
+          files: { "index.html": "<h1>Home</h1>", "big.html": `<h1>Big</h1>${bigPage}` },
+        }),
+      ),
+    )
+    const outline = JSON.parse(
+      toolText(await call(app, token, "read", { short_id: created.short_id, section: "big.html" })),
+    )
+    expect(Array.isArray(outline.sections)).toBe(true)
+    expect(outline.sections.length).toBeGreaterThan(30)
+    const forced = toolText(
+      await call(app, token, "read", { short_id: created.short_id, section: "big.html#*" }),
+    )
+    expect(forced).toContain("# Big")
   })
 
   it("read: an image page returns a real MCP image block, not bytes-as-text", async () => {
@@ -878,6 +960,26 @@ describe("remote MCP endpoint (/mcp)", () => {
       await call(app, token, "read", { short_id: shortId, format: "html" }),
     )
     expect(stillLive).not.toContain("GAMMA") // the proposal never touched the live version
+  })
+
+  it("publish edits: over the workspace storage quota is rejected, same as content/files (regression: the MCP edits path used to skip this check)", async () => {
+    const { app, token } = appWithGrant("editsquota", "openid derive:read derive:publish", {
+      maxBytes: 200,
+    })
+    const created = JSON.parse(
+      toolText(
+        await call(app, token, "publish", { title: "Small", content: "<h1>x</h1><p>y</p>" }),
+      ),
+    )
+    const rejected = await call(app, token, "publish", {
+      short_id: created.short_id,
+      edits: [{ old_str: "y", new_str: "y".repeat(500) }],
+    })
+    expect(toolText(rejected)).toMatch(/storage quota/i)
+    const stillOriginal = toolText(
+      await call(app, token, "read", { short_id: created.short_id, format: "html" }),
+    )
+    expect(stillOriginal).not.toContain("y".repeat(500))
   })
 
   it("publish needs a title to create, and routes a non-publisher to review", async () => {

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -207,6 +207,49 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(cd.entry_diff).toContain("V2 Title")
   })
 
+  it("catch_up detailed diffs the markdown conversion, not raw HTML tag noise", async () => {
+    const { app, token } = appWithGrant("catchupmd", "openid derive:read derive:publish")
+    const v1 =
+      "<html><head><style>body{color:red}</style></head><body>" +
+      "<h1>Doc</h1><p>alpha bravo charlie</p></body></html>"
+    const v2 =
+      "<html><head><style>body{color:blue}</style></head><body>" +
+      "<h1>Doc</h1><p>alpha BRAVO charlie</p></body></html>"
+    const form1 = new FormData()
+    form1.append("file", new Blob([new TextEncoder().encode(v1)]), "index.html")
+    form1.append("title", "Semantic")
+    const shortId = (
+      await (
+        await app.request("/v1/artifacts", {
+          method: "POST",
+          body: form1,
+          headers: { authorization: `Bearer ${token}` },
+        })
+      ).json()
+    ).short_id
+    const form2 = new FormData()
+    form2.append("file", new Blob([new TextEncoder().encode(v2)]), "index.html")
+    await app.request(`/v1/artifacts/${shortId}/versions`, {
+      method: "POST",
+      body: form2,
+      headers: { authorization: `Bearer ${token}` },
+    })
+    const cd = JSON.parse(
+      toolText(
+        await call(app, token, "catch_up", {
+          short_id: shortId,
+          since_version: 1,
+          to_version: 2,
+          response_format: "detailed",
+        }),
+      ),
+    )
+    expect(cd.entry_diff).toContain("diff of markdown conversion")
+    expect(cd.entry_diff).toContain("BRAVO")
+    expect(cd.entry_diff).not.toContain("<p")
+    expect(cd.entry_diff).not.toContain("color:")
+  })
+
   it("read + catch_up handle multi-page bundles", async () => {
     const { app, token } = appWithGrant("bundle", "openid derive:read derive:publish")
     const enc = (s: string) => new TextEncoder().encode(s)

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -159,10 +159,11 @@ describe("remote MCP endpoint (/mcp)", () => {
     const listOut = JSON.parse(toolText(list))
     expect(listOut.artifacts.some((a: { short_id: string }) => a.short_id === shortId)).toBe(true)
 
-    const read = await call(app, token, "read", { short_id: shortId })
-    const readOut = JSON.parse(toolText(read))
-    expect(readOut.title).toBe("My Plan")
-    expect(readOut.content).toContain("My Plan")
+    // Content reads are a frontmatter header + the markdown body — NOT a JSON envelope.
+    const read = toolText(await call(app, token, "read", { short_id: shortId }))
+    expect(read).toContain("title: My Plan")
+    expect(read).toContain("# My Plan")
+    expect(read).not.toContain("\\n")
   })
 
   it("catch_up reports what changed, with the line diff folded in", async () => {
@@ -232,14 +233,17 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(pj.kind).toBe("bundle")
     const shortId = pj.short_id
 
-    // No section → outline (the bundle's pages).
+    // No section → outline (the bundle's pages, with per-page headings for text pages).
     const pages = JSON.parse(toolText(await call(app, token, "read", { short_id: shortId })))
-    expect(pages.pages).toEqual(expect.arrayContaining(["index.html", "page.html"]))
-    // A section → that page's content.
-    const page = JSON.parse(
-      toolText(await call(app, token, "read", { short_id: shortId, section: "page.html" })),
+    expect(pages.pages.map((p: { path: string }) => p.path)).toEqual(
+      expect.arrayContaining(["index.html", "page.html"]),
     )
-    expect(page.content).toContain("Page")
+    // A section → that page's content (frontmatter envelope, converted to markdown).
+    const page = toolText(
+      await call(app, token, "read", { short_id: shortId, section: "page.html" }),
+    )
+    expect(page).toContain("section: page.html")
+    expect(page).toContain("Page")
 
     // Republish with a new page; catch_up reports it under pages_changed.added.
     await postZip(
@@ -255,6 +259,115 @@ describe("remote MCP endpoint (/mcp)", () => {
       toolText(await call(app, token, "catch_up", { short_id: shortId, since_version: 1 })),
     )
     expect(cu.pages_changed.added).toContain("new.html")
+  })
+
+  it("read: formats, heading sections, and the outline-first threshold", async () => {
+    const { app, token } = appWithGrant("readfmt", "openid derive:read derive:publish")
+    const html =
+      "<!DOCTYPE html><html><head><style>body{color:red}</style></head><body>" +
+      "<h1>Doc</h1><p>intro &amp; more</p>" +
+      "<h2>Alpha</h2><p>alpha body</p><h2>Beta</h2><p>beta body</p></body></html>"
+    const form = new FormData()
+    form.append("file", new Blob([new TextEncoder().encode(html)]), "index.html")
+    form.append("title", "Fmt Doc")
+    const shortId = (
+      await (
+        await app.request("/v1/artifacts", {
+          method: "POST",
+          body: form,
+          headers: { authorization: `Bearer ${token}` },
+        })
+      ).json()
+    ).short_id
+
+    // Default read: markdown conversion, style noise gone, entities decoded.
+    const md = toolText(await call(app, token, "read", { short_id: shortId }))
+    expect(md).toContain("format: markdown (converted from text/html)")
+    expect(md).toContain("# Doc")
+    expect(md).toContain("intro & more")
+    expect(md).not.toContain("color:red")
+
+    // format:"html" is the exact stored source.
+    const raw = toolText(await call(app, token, "read", { short_id: shortId, format: "html" }))
+    expect(raw).toContain(html)
+
+    // format:"text" is the flat visible text (what comment quotes anchor against).
+    const flat = toolText(await call(app, token, "read", { short_id: shortId, format: "text" }))
+    expect(flat).toContain("alpha body")
+    expect(flat).not.toContain("# Doc")
+
+    // A heading slug reads just that section; an unknown slug names the real ones.
+    const alpha = toolText(await call(app, token, "read", { short_id: shortId, section: "alpha" }))
+    expect(alpha).toContain("## Alpha")
+    expect(alpha).toContain("alpha body")
+    expect(alpha).not.toContain("beta body")
+    const bad = toolText(await call(app, token, "read", { short_id: shortId, section: "nope" }))
+    expect(bad).toContain("doc, alpha, beta")
+
+    // page#slug works within a bundle page.
+    const bundleHtml = "<h1>Home</h1><h2>Part One</h2><p>one</p><h2>Part Two</h2><p>two</p>"
+    const bcreated = JSON.parse(
+      toolText(
+        await call(app, token, "publish", { title: "B", files: { "index.html": bundleHtml } }),
+      ),
+    )
+    const part = toolText(
+      await call(app, token, "read", {
+        short_id: bcreated.short_id,
+        section: "index.html#part-one",
+      }),
+    )
+    expect(part).toContain("## Part One")
+    expect(part).not.toContain("two")
+
+    // A big sectioned doc goes outline-first; section:"*" forces the clipped body.
+    const bigBody = Array.from(
+      { length: 40 },
+      (_, i) => `<h2>Sect ${i}</h2><p>${"lorem ipsum ".repeat(120)}</p>`,
+    ).join("")
+    const bigForm = new FormData()
+    bigForm.append(
+      "file",
+      new Blob([new TextEncoder().encode(`<html><body><h1>Big</h1>${bigBody}</body></html>`)]),
+      "index.html",
+    )
+    bigForm.append("title", "Big Doc")
+    const bigId = (
+      await (
+        await app.request("/v1/artifacts", {
+          method: "POST",
+          body: bigForm,
+          headers: { authorization: `Bearer ${token}` },
+        })
+      ).json()
+    ).short_id
+    const outline = JSON.parse(toolText(await call(app, token, "read", { short_id: bigId })))
+    expect(outline.sections.length).toBe(41)
+    expect(outline.sections[1]).toMatchObject({ slug: "sect-0", level: 2 })
+    expect(outline.doc_chars).toBeGreaterThan(30_000)
+    const starred = toolText(await call(app, token, "read", { short_id: bigId, section: "*" }))
+    expect(starred).toContain("# Big")
+    const one = toolText(await call(app, token, "read", { short_id: bigId, section: "sect-7" }))
+    expect(one).toContain("## Sect 7")
+    expect(one).toContain("section: sect-7 (9 of 41)")
+  })
+
+  it("read: a markdown artifact returns its source untouched under the default format", async () => {
+    const { app, token } = appWithGrant("readmd", "openid derive:read derive:publish")
+    const md = "# Notes\n\nSome *markdown* here.\n\n## Sub\n\ntail\n"
+    const created = JSON.parse(
+      toolText(
+        await call(app, token, "publish", { title: "Notes", content: md, filename: "notes.md" }),
+      ),
+    )
+    const read = toolText(await call(app, token, "read", { short_id: created.short_id }))
+    expect(read).toContain("format: markdown (source)")
+    expect(read).toContain("Some *markdown* here.")
+    const sub = toolText(
+      await call(app, token, "read", { short_id: created.short_id, section: "sub" }),
+    )
+    expect(sub).toContain("## Sub")
+    expect(sub).not.toContain("*markdown*")
   })
 
   it("comment leaves anchored feedback, replies, and resolves — all via one tool", async () => {
@@ -348,10 +461,10 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(list.proposals[0].on_behalf_of).toMatchObject({ name: "Owner" })
 
     // The live version is untouched — a proposal is not a publish.
-    const read = JSON.parse(toolText(await call(app, token, "read", { short_id: shortId })))
-    expect(read.version).toBe(1)
-    expect(read.content).toContain("Draft")
-    expect(read.content).not.toContain("Revised")
+    const read = toolText(await call(app, token, "read", { short_id: shortId }))
+    expect(read).toContain("version: 1 (current)")
+    expect(read).toContain("Draft")
+    expect(read).not.toContain("Revised")
   })
 
   it("surfaces outdated feedback after a republish drops the quoted text", async () => {
@@ -572,10 +685,8 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(list.artifacts.some((a: { short_id: string }) => a.short_id === created.short_id)).toBe(
       true,
     )
-    const read = JSON.parse(
-      toolText(await call(app, token, "read", { short_id: created.short_id })),
-    )
-    expect(read.content).toContain("hello world")
+    const read = toolText(await call(app, token, "read", { short_id: created.short_id }))
+    expect(read).toContain("hello world")
 
     // Publishing again WITH the short_id pushes a new version (not a second artifact).
     const v2 = JSON.parse(
@@ -627,11 +738,13 @@ describe("remote MCP endpoint (/mcp)", () => {
     const shortId = created.short_id
 
     const outline = JSON.parse(toolText(await call(app, token, "read", { short_id: shortId })))
-    expect(outline.pages).toEqual(expect.arrayContaining(["index.html", "about.html", "nav.js"]))
-    const about = JSON.parse(
-      toolText(await call(app, token, "read", { short_id: shortId, section: "about.html" })),
+    expect(outline.pages.map((p: { path: string }) => p.path)).toEqual(
+      expect.arrayContaining(["index.html", "about.html", "nav.js"]),
     )
-    expect(about.content).toContain("About")
+    const about = toolText(
+      await call(app, token, "read", { short_id: shortId, section: "about.html" }),
+    )
+    expect(about).toContain("About")
 
     const v2 = JSON.parse(
       toolText(

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -731,6 +731,112 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(v2.version).toBe(2)
   })
 
+  it("publish edits: exact-match search/replace instead of resending content", async () => {
+    const { app, token } = appWithGrant("pubedits", "openid derive:read derive:publish")
+    const created = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          title: "Edit Me",
+          content: "<h1>Title</h1><p>alpha beta gamma</p>",
+        }),
+      ),
+    )
+    const shortId = created.short_id
+
+    // Happy path: applies in order, second edit sees the first edit's result.
+    const edited = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          short_id: shortId,
+          edits: [
+            { old_str: "beta", new_str: "BETA" },
+            { old_str: "alpha BETA", new_str: "x y" },
+          ],
+        }),
+      ),
+    )
+    expect(edited.published).toBe(true)
+    expect(edited.version).toBe(2)
+    expect(edited.edits_applied).toBe(2)
+    const read = toolText(await call(app, token, "read", { short_id: shortId, format: "html" }))
+    expect(read).toContain("x y gamma")
+
+    // 0-match and multi-match are both rejected, naming the failing edit; nothing applies.
+    const zero = await call(app, token, "publish", {
+      short_id: shortId,
+      edits: [{ old_str: "nope-nowhere", new_str: "y" }],
+    })
+    expect(toolText(zero)).toMatch(/Edit 1 of 1 failed.*not found/)
+    const multi = await call(app, token, "publish", {
+      short_id: shortId,
+      edits: [
+        { old_str: "y gamma", new_str: "z" },
+        { old_str: "Title", new_str: "T" },
+        { old_str: "y gamma", new_str: "again" },
+      ],
+    })
+    expect(toolText(multi)).toMatch(/Edit \d of 3 failed/)
+    const afterFailed = toolText(
+      await call(app, token, "read", { short_id: shortId, format: "html" }),
+    )
+    expect(afterFailed).toContain("x y gamma") // unchanged — a failed batch applies nothing
+
+    // base_version conflict: the artifact is at v2, but the agent read v1.
+    const stale = await call(app, token, "publish", {
+      short_id: shortId,
+      base_version: 1,
+      edits: [{ old_str: "Title", new_str: "T2" }],
+    })
+    expect(toolText(stale)).toMatch(/moved to v2/)
+
+    // edits + content is rejected; edits with no short_id is rejected.
+    expect(
+      toolText(
+        await call(app, token, "publish", {
+          short_id: shortId,
+          edits: [{ old_str: "x", new_str: "y" }],
+          content: "<h1>nope</h1>",
+        }),
+      ),
+    ).toContain("not both")
+    expect(
+      toolText(await call(app, token, "publish", { edits: [{ old_str: "x", new_str: "y" }] })),
+    ).toContain("EXISTING artifact")
+
+    // edits on a bundle is rejected.
+    const bundle = JSON.parse(
+      toolText(
+        await call(app, token, "publish", { title: "B", files: { "index.html": "<h1>b</h1>" } }),
+      ),
+    )
+    expect(
+      toolText(
+        await call(app, token, "publish", {
+          short_id: bundle.short_id,
+          edits: [{ old_str: "b", new_str: "c" }],
+        }),
+      ),
+    ).toContain("multi-page bundle")
+
+    // edits + for_review files a proposal with the materialized text, not live.
+    const proposal = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          short_id: shortId,
+          for_review: true,
+          edits: [{ old_str: "gamma", new_str: "GAMMA" }],
+        }),
+      ),
+    )
+    expect(proposal.published).toBe(false)
+    expect(proposal.proposed).toBe(true)
+    expect(proposal.edits_applied).toBe(1)
+    const stillLive = toolText(
+      await call(app, token, "read", { short_id: shortId, format: "html" }),
+    )
+    expect(stillLive).not.toContain("GAMMA") // the proposal never touched the live version
+  })
+
   it("publish needs a title to create, and routes a non-publisher to review", async () => {
     // A new-artifact publish with no title is refused.
     const { app, token } = appWithGrant("pub2", "openid derive:read derive:publish")

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -352,6 +352,35 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(one).toContain("section: sect-7 (9 of 41)")
   })
 
+  it("read: an image page returns a real MCP image block, not bytes-as-text", async () => {
+    const { app, token } = appWithGrant("readimg", "openid derive:read derive:publish")
+    const png =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+    const created = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          title: "Mockups",
+          files: {
+            "index.html": '<h1>Screens</h1><img src="shot.png">',
+            "shot.png": `data:image/png;base64,${png}`,
+          },
+        }),
+      ),
+    )
+    const r = await call(app, token, "read", { short_id: created.short_id, section: "shot.png" })
+    const content = (
+      r.parsed?.result as {
+        content: { type: string; text?: string; data?: string; mimeType?: string }[]
+      }
+    ).content
+    expect(content[0]?.type).toBe("text")
+    expect(content[0]?.text).toContain("shot.png")
+    expect(content[0]?.text).toContain(`/raw/${created.short_id}/v/1/shot.png`)
+    expect(content[1]?.type).toBe("image")
+    expect(content[1]?.mimeType).toBe("image/png")
+    expect(content[1]?.data).toBe(png)
+  })
+
   it("read: a markdown artifact returns its source untouched under the default format", async () => {
     const { app, token } = appWithGrant("readmd", "openid derive:read derive:publish")
     const md = "# Notes\n\nSome *markdown* here.\n\n## Sub\n\ntail\n"

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -64,6 +64,22 @@ const NAMED: Record<string, string> = {
   nbsp: " ",
 }
 
+/** Decode numeric character references and the common named entities the browser
+ *  would. Unknown named entities pass through untouched. Shared by `pageText` and
+ *  the doc-text markdown conversion so both read an `&amp;` the same way. */
+export function decodeEntities(s: string): string {
+  return s.replace(ENTITY, (whole, body: string) => {
+    if (body[0] === "#") {
+      const cp =
+        body[1] === "x" || body[1] === "X"
+          ? Number.parseInt(body.slice(2), 16)
+          : Number.parseInt(body.slice(1), 10)
+      return Number.isFinite(cp) ? String.fromCodePoint(cp) : whole
+    }
+    return NAMED[body] ?? whole
+  })
+}
+
 /**
  * The visible text of an HTML page, for matching a text quote server-side — the
  * counterpart to the browser client's text-node concatenation. Drops script/style/
@@ -73,20 +89,9 @@ const NAMED: Record<string, string> = {
  * NOT a full HTML parser; findQuote's whitespace tolerance absorbs the small differences.
  */
 export function pageText(html: string): string {
-  return html
-    .replace(INVISIBLE_TAGS, " ")
-    .replace(HTML_COMMENT, " ")
-    .replace(ANY_TAG, " ")
-    .replace(ENTITY, (whole, body: string) => {
-      if (body[0] === "#") {
-        const cp =
-          body[1] === "x" || body[1] === "X"
-            ? Number.parseInt(body.slice(2), 16)
-            : Number.parseInt(body.slice(1), 10)
-        return Number.isFinite(cp) ? String.fromCodePoint(cp) : whole
-      }
-      return NAMED[body] ?? whole
-    })
+  return decodeEntities(
+    html.replace(INVISIBLE_TAGS, " ").replace(HTML_COMMENT, " ").replace(ANY_TAG, " "),
+  )
 }
 
 // The comment-anchor client that runs inside the sandboxed artifact iframe. It is real,

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -55,6 +55,11 @@ const INVISIBLE_TAGS = /<(script|style|noscript)\b[^>]*>[\s\S]*?<\/\1>/gi
 const HTML_COMMENT = /<!--[\s\S]*?-->/g
 const ANY_TAG = /<[^>]+>/g
 const ENTITY = /&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g
+// The five XML entities plus the common named entities real prose/documentation
+// actually uses (typographic punctuation, arrows, symbols) — found missing when
+// deep-testing the converter against real Sift/Derive docs, which use middot,
+// ndash, rarr, and curly quotes throughout. Unknown named entities still pass
+// through untouched; this just widens what "known" covers.
 const NAMED: Record<string, string> = {
   amp: "&",
   lt: "<",
@@ -62,6 +67,30 @@ const NAMED: Record<string, string> = {
   quot: '"',
   apos: "'",
   nbsp: " ",
+  mdash: "—",
+  ndash: "–",
+  hellip: "…",
+  middot: "·",
+  bull: "•",
+  rsquo: "’",
+  lsquo: "‘",
+  rdquo: "”",
+  ldquo: "“",
+  copy: "©",
+  reg: "®",
+  trade: "™",
+  deg: "°",
+  times: "×",
+  divide: "÷",
+  plusmn: "±",
+  rarr: "→",
+  larr: "←",
+  uarr: "↑",
+  darr: "↓",
+  shy: "­",
+  ensp: " ",
+  emsp: " ",
+  thinsp: " ",
 }
 
 /** Decode numeric character references and the common named entities the browser

--- a/packages/core/src/doc-text.test.ts
+++ b/packages/core/src/doc-text.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest"
+import { decodeEntities, pageText } from "./anchor"
+import {
+  applyEdits,
+  docOutline,
+  EditError,
+  headingSlug,
+  htmlToMarkdown,
+  outlineOf,
+  sectionOf,
+  sectionSlice,
+  toMarkdown,
+} from "./doc-text"
+
+const doc = (body: string) =>
+  `<!DOCTYPE html><html><head><title>T</title><style>body{color:red}</style></head><body>${body}</body></html>`
+
+describe("htmlToMarkdown", () => {
+  it("converts headings h1–h6", () => {
+    const md = htmlToMarkdown(doc("<h1>One</h1><h2>Two</h2><h3>Three</h3><h6>Six</h6>"))
+    expect(md).toBe("# One\n\n## Two\n\n### Three\n\n###### Six")
+  })
+
+  it("drops head, style, script, svg, noscript subtrees whole", () => {
+    const md = htmlToMarkdown(
+      doc(
+        "<script>let x = '<p>fake</p>'</script><svg><text>vector</text></svg>" +
+          "<noscript><p>fallback</p></noscript><p>real</p>",
+      ),
+    )
+    expect(md).toBe("real")
+  })
+
+  it("renders inline emphasis, code, links, and images", () => {
+    const md = htmlToMarkdown(
+      doc(
+        "<p>Use <strong>bold</strong>, <em>italics</em>, <code>a`b</code>, " +
+          '<a href="https://x.test/y">a link</a>, and <img src="pic.png" alt="a pic">.</p>',
+      ),
+    )
+    expect(md).toBe(
+      "Use **bold**, *italics*, ``a`b``, [a link](https://x.test/y), and ![a pic](pic.png).",
+    )
+  })
+
+  it("keeps heading slugs on text content when headings contain inline tags", () => {
+    const out = docOutline(doc("<h2>The <code>read</code> tool</h2>"))
+    expect(out[0]?.text).toBe("The read tool")
+    expect(out[0]?.slug).toBe("the-read-tool")
+  })
+
+  it("renders nested and ordered lists with counters", () => {
+    const md = htmlToMarkdown(
+      doc("<ul><li>a</li><li>b<ol><li>b1</li><li>b2<ul><li>deep</li></ul></li></ol></li></ul>"),
+    )
+    expect(md).toBe("- a\n\n- b\n\n  1. b1\n\n  2. b2\n\n    - deep")
+  })
+
+  it("renders fenced code with language, decoded entities, preserved newlines", () => {
+    const md = htmlToMarkdown(
+      doc(
+        '<pre><code class="language-ts">const a = 1\nif (a &lt; 2) run(&quot;x&quot;)</code></pre>',
+      ),
+    )
+    expect(md).toBe('```ts\nconst a = 1\nif (a < 2) run("x")\n```')
+  })
+
+  it("escalates the fence when code contains backtick runs", () => {
+    const md = htmlToMarkdown(doc("<pre><code>```\ninner\n```</code></pre>"))
+    expect(md.startsWith("````\n")).toBe(true)
+    expect(md.endsWith("\n````")).toBe(true)
+  })
+
+  it("strips highlight spans inside pre but keeps their text", () => {
+    const md = htmlToMarkdown(
+      doc('<pre><code><span class="cm">// note</span>\n<span>x()</span></code></pre>'),
+    )
+    expect(md).toBe("```\n// note\nx()\n```")
+  })
+
+  it("renders pipe tables with escaped pipes and align attrs", () => {
+    const md = htmlToMarkdown(
+      doc(
+        '<table><thead><tr><th>Name</th><th align="right">N</th></tr></thead>' +
+          "<tbody><tr><td>a|b</td><td>1</td></tr></tbody></table>",
+      ),
+    )
+    expect(md).toBe("| Name | N |\n| --- | ---: |\n| a\\|b | 1 |")
+  })
+
+  it("renders nested blockquotes, hr, and br hard breaks", () => {
+    expect(
+      htmlToMarkdown(
+        doc("<blockquote><p>outer</p><blockquote><p>inner</p></blockquote></blockquote>"),
+      ),
+    ).toBe("> outer\n\n> > inner")
+    expect(htmlToMarkdown(doc("<p>a</p><hr><p>b</p>"))).toBe("a\n\n---\n\nb")
+    expect(htmlToMarkdown(doc("<p>line one<br>line two</p>"))).toBe("line one\nline two")
+  })
+
+  it("decodes named, decimal, and hex entities; unknown ones pass through", () => {
+    const md = htmlToMarkdown(doc("<p>&amp; &#65; &#x42; &nosuch; &nbsp;done</p>"))
+    expect(md).toBe("& A B &nosuch; done")
+  })
+
+  it("collapses whitespace outside pre", () => {
+    expect(htmlToMarkdown(doc("<p>a\n   b\t\tc</p>"))).toBe("a b c")
+  })
+
+  it("turns minified one-line HTML into multi-line markdown", () => {
+    const min = doc(
+      "<h1>Title</h1><p>Intro text.</p><h2>Part</h2><ul><li>one</li><li>two</li></ul>",
+    )
+    expect(min.includes("\n")).toBe(false)
+    expect(htmlToMarkdown(min)).toBe("# Title\n\nIntro text.\n\n## Part\n\n- one\n\n- two")
+  })
+
+  it("treats unknown tags as transparent", () => {
+    expect(htmlToMarkdown(doc('<p><span class="x">kept</span> <mark>also</mark></p>'))).toBe(
+      "kept also",
+    )
+  })
+})
+
+describe("headingSlug + slugger", () => {
+  it("slugifies GitHub-style", () => {
+    expect(headingSlug("PR-6: The Registry Fix!")).toBe("pr-6-the-registry-fix")
+    expect(headingSlug("Café après ski")).toBe("cafe-apres-ski")
+    expect(headingSlug("???")).toBe("")
+  })
+
+  it("dedups repeated headings across a document", () => {
+    const out = docOutline(doc("<h2>Goals</h2><h2>Goals</h2><h2>Goals</h2>"))
+    expect(out.map((s) => s.slug)).toEqual(["goals", "goals-1", "goals-2"])
+  })
+})
+
+describe("docOutline + sectionSlice", () => {
+  const body =
+    "<h1>Top</h1><p>intro</p>" +
+    "<h2>Alpha</h2><p>alpha text</p><h3>Alpha sub</h3><p>sub text</p>" +
+    "<h2>Beta</h2><p>beta text</p>"
+  const html = doc(body)
+
+  it("lists h1–h3 with levels and sizes", () => {
+    const out = docOutline(html)
+    expect(out.map((s) => [s.level, s.slug])).toEqual([
+      [1, "top"],
+      [2, "alpha"],
+      [3, "alpha-sub"],
+      [2, "beta"],
+    ])
+    for (const s of out) expect(s.chars).toBeGreaterThan(0)
+  })
+
+  it("slices a section up to the next same-or-higher heading", () => {
+    const alpha = sectionSlice(html, "alpha")
+    expect(alpha).toContain("<h2>Alpha</h2>")
+    expect(alpha).toContain("Alpha sub") // its own h3 belongs to it
+    expect(alpha).not.toContain("Beta")
+  })
+
+  it("runs the last section to </body> and stays a byte-identical substring", () => {
+    const beta = sectionSlice(html, "beta")
+    expect(beta).toBe("<h2>Beta</h2><p>beta text</p>")
+    expect(html.includes(beta as string)).toBe(true)
+  })
+
+  it("returns null for an unknown slug and [] for a heading-less doc", () => {
+    expect(sectionSlice(html, "nope")).toBeNull()
+    expect(docOutline(doc("<p>just prose</p>"))).toEqual([])
+  })
+
+  it("handles a large many-heading document", () => {
+    const parts = Array.from({ length: 36 }, (_, i) => `<h2>Sect ${i}</h2><p>text ${i}</p>`).join(
+      "",
+    )
+    expect(docOutline(doc(parts))).toHaveLength(36)
+  })
+})
+
+describe("markdown twins (outlineOf / sectionOf / toMarkdown)", () => {
+  const md =
+    "# Top\n\nintro\n\n```\n# not a heading\n```\n\n## Alpha\n\nalpha text\n\n## Beta\n\nbeta text\n"
+
+  it("passes markdown through toMarkdown untouched", () => {
+    expect(toMarkdown(md, "text/markdown")).toBe(md)
+  })
+
+  it("outlines ATX headings, ignoring code fences", () => {
+    expect(outlineOf(md, "text/markdown").map((s) => s.slug)).toEqual(["top", "alpha", "beta"])
+  })
+
+  it("slices markdown sections by slug", () => {
+    expect(sectionOf(md, "text/markdown", "alpha")).toBe("## Alpha\n\nalpha text\n")
+  })
+
+  it("dispatches HTML content types to the HTML side", () => {
+    const html = doc("<h2>Only</h2><p>x</p>")
+    expect(outlineOf(html, "text/html").map((s) => s.slug)).toEqual(["only"])
+    expect(sectionOf(html, "text/html", "only")).toContain("<h2>Only</h2>")
+    expect(toMarkdown(html, "text/html")).toBe("## Only\n\nx")
+  })
+})
+
+describe("applyEdits", () => {
+  it("applies edits sequentially, each seeing the prior result", () => {
+    expect(
+      applyEdits("a b c", [
+        { old_str: "b", new_str: "B" },
+        { old_str: "a B", new_str: "x" },
+      ]),
+    ).toBe("x c")
+  })
+
+  it("allows an empty new_str (deletion)", () => {
+    expect(applyEdits("keep drop keep2", [{ old_str: " drop", new_str: "" }])).toBe("keep keep2")
+  })
+
+  it("rejects zero-match and multi-match, naming the edit", () => {
+    expect(() => applyEdits("abc", [{ old_str: "zz", new_str: "y" }])).toThrow(
+      /Edit 1 of 1 failed.*not found/,
+    )
+    expect(() => applyEdits("x x", [{ old_str: "x", new_str: "y" }])).toThrow(/matched 2 times/)
+    expect(() => applyEdits("abc", [])).toThrow(EditError)
+  })
+
+  it("treats new_str with replacement patterns literally", () => {
+    expect(applyEdits("cost", [{ old_str: "cost", new_str: "$& and $1" }])).toBe("$& and $1")
+  })
+})
+
+describe("decodeEntities extraction keeps pageText behavior", () => {
+  it("decodes the same entity forms pageText always did", () => {
+    expect(decodeEntities("&amp;&#65;&#x42;&nosuch;")).toBe("&AB&nosuch;")
+    expect(pageText("<p>a &lt; b</p><script>x</script>")).toContain("a < b")
+    expect(pageText("<p>x</p><script>secret()</script>")).not.toContain("secret")
+  })
+})

--- a/packages/core/src/doc-text.test.ts
+++ b/packages/core/src/doc-text.test.ts
@@ -88,6 +88,42 @@ describe("htmlToMarkdown", () => {
     expect(md).toBe("| Name | N |\n| --- | ---: |\n| a\\|b | 1 |")
   })
 
+  it("wraps inline <code> found inside table cells (regression: found via real Sift docs)", () => {
+    const md = htmlToMarkdown(
+      doc(
+        "<table><tr><th>ID</th><th>Loc</th></tr>" +
+          '<tr><td>A-1</td><td>passes <code>orgId:""</code> into <code>filter-sql-builders.ts:64</code></td></tr>' +
+          "</table>",
+      ),
+    )
+    expect(md).toBe(
+      '| ID | Loc |\n| --- | --- |\n| A-1 | passes `orgId:""` into `filter-sql-builders.ts:64` |',
+    )
+    // No stray backtick fragments leaked after the table (the bug also corrupted
+    // trailing output, not just the missing backticks).
+    expect(md.trim().endsWith("|")).toBe(true)
+  })
+
+  it("keeps table structure intact when a cell contains block tags (regression: <p>/heading in a <td> used to corrupt the table)", () => {
+    const md = htmlToMarkdown(
+      doc(
+        "<h1>Doc</h1><table><tr><th>A</th><th>B</th></tr>" +
+          "<tr><td><p>one</p><p>two</p></td><td><h2>heading</h2>text</td></tr>" +
+          "<tr><td>x</td><td><hr>y</td></tr></table><h2>After</h2><p>tail</p>",
+      ),
+    )
+    const lines = md.split("\n\n")
+    expect(lines[0]).toBe("# Doc")
+    // The table renders as exactly one block: header + separator + 2 data rows,
+    // all on contiguous lines — no stray out-of-band pushes split it apart.
+    const tableBlock = lines.find((l) => l.startsWith("| A | B |"))
+    expect(tableBlock?.split("\n")).toHaveLength(4)
+    expect(tableBlock).toContain("| heading")
+    expect(tableBlock).toContain("| y |")
+    expect(lines.at(-2)).toBe("## After")
+    expect(lines.at(-1)).toBe("tail")
+  })
+
   it("renders nested blockquotes, hr, and br hard breaks", () => {
     expect(
       htmlToMarkdown(
@@ -101,6 +137,13 @@ describe("htmlToMarkdown", () => {
   it("decodes named, decimal, and hex entities; unknown ones pass through", () => {
     const md = htmlToMarkdown(doc("<p>&amp; &#65; &#x42; &nosuch; &nbsp;done</p>"))
     expect(md).toBe("& A B &nosuch; done")
+  })
+
+  it("decodes common typographic entities (regression: real Sift/Derive docs use these throughout)", () => {
+    const md = htmlToMarkdown(
+      doc("<p>v2 &mdash; final &middot; wave 1&ndash;3 &hellip; see &rarr; &ldquo;done&rdquo;</p>"),
+    )
+    expect(md).toBe("v2 — final · wave 1–3 … see → “done”")
   })
 
   it("collapses whitespace outside pre", () => {

--- a/packages/core/src/doc-text.test.ts
+++ b/packages/core/src/doc-text.test.ts
@@ -124,6 +124,24 @@ describe("htmlToMarkdown", () => {
     expect(lines.at(-1)).toBe("tail")
   })
 
+  it("degrades a <pre><code> block inside a table cell to inline backticks (regression: it used to switch tokenizer modes and inject a fenced block into the top-level output, corrupting the table)", () => {
+    const md = htmlToMarkdown(
+      doc(
+        "<table><tr><th>A</th><th>B</th></tr><tr><td>cmd</td><td><pre><code>run x</code></pre></td></tr></table>",
+      ),
+    )
+    expect(md).toBe("| A | B |\n| --- | --- |\n| cmd | `run x` |")
+  })
+
+  it("an unclosed <blockquote> inside a table cell doesn't leak quote-depth state into content after the table (regression)", () => {
+    const md = htmlToMarkdown(
+      doc(
+        "<h1>Doc</h1><table><tr><td><blockquote>note</td><td>b</td></tr></table><h2>After</h2><p>tail</p>",
+      ),
+    )
+    expect(md).toBe("# Doc\n\n| note | b |\n| --- | --- |\n\n## After\n\ntail")
+  })
+
   it("renders nested blockquotes, hr, and br hard breaks", () => {
     expect(
       htmlToMarkdown(
@@ -220,6 +238,16 @@ describe("docOutline + sectionSlice", () => {
     )
     expect(docOutline(doc(parts))).toHaveLength(36)
   })
+
+  it("ignores headings that live inside dropped subtrees — a <script> template string or a <template> tag must not become a phantom outline entry (regression)", () => {
+    const withScript = doc(
+      '<script>const s = "<h2>Fake</h2>"</script><template><h2>Also fake</h2></template><h1>Real</h1><p>x</p>',
+    )
+    const outline = docOutline(withScript)
+    expect(outline.map((s) => s.text)).toEqual(["Real"])
+    // And the section it DOES find slices and converts cleanly, with no leaked markup.
+    expect(sectionSlice(withScript, "real")).toContain("<h1>Real</h1>")
+  })
 })
 
 describe("markdown twins (outlineOf / sectionOf / toMarkdown)", () => {
@@ -270,6 +298,13 @@ describe("applyEdits", () => {
 
   it("treats new_str with replacement patterns literally", () => {
     expect(applyEdits("cost", [{ old_str: "cost", new_str: "$& and $1" }])).toBe("$& and $1")
+  })
+
+  it("counts a self-overlapping needle as its single non-overlapping match, not ambiguous (regression)", () => {
+    // "aa" appears at offsets 0 and 1 in "aaa" — those overlap. A real replace only
+    // ever makes the one match String.replace itself would find; the old counter
+    // (advancing by 1 char) double-counted the overlap and rejected this as multi-match.
+    expect(applyEdits("aaa", [{ old_str: "aa", new_str: "b" }])).toBe("ba")
   })
 })
 

--- a/packages/core/src/doc-text.ts
+++ b/packages/core/src/doc-text.ts
@@ -148,7 +148,32 @@ export function htmlToMarkdown(html: string): string {
     return quote + indent + lead
   }
 
+  // A table cell is a flat inline run (pipe-table syntax can't hold block content),
+  // so every "current buffer" operation — appending text, wrapping <code> — must
+  // target the active cell instead of the top-level `inline` string whenever one is
+  // open. Without this, a <code> (or any inline tag) inside a <td> silently loses
+  // its wrapping (the open/close pair reads/writes the wrong buffer, leaking stale
+  // fragments after the table), and a stray block tag (<p>, <div>, a heading) inside
+  // a cell — real HTML the sanitizer permits — would flush the WRONG buffer straight
+  // into the document's top-level `out` array, corrupting the table structure.
+  const activeCell = (): string[] | null => (table?.cell && table.row?.length ? table.row : null)
+  const inCell = () => activeCell() !== null
+
+  const bufGet = (): string => {
+    const cell = activeCell()
+    return cell ? (cell[cell.length - 1] as string) : inline
+  }
+  const bufSet = (s: string) => {
+    const cell = activeCell()
+    if (cell) cell[cell.length - 1] = s
+    else inline = s
+  }
+
   const flush = () => {
+    // Block structure (paragraphs, headings, lists, quotes) has no meaning inside a
+    // pipe-table cell — skip the out-array push/reset; the cell's accumulated text
+    // stays put and inline runs (its own tags) keep going through `append`.
+    if (inCell()) return
     const text = inline.replace(/[ \t]+/g, " ").trim()
     inline = ""
     codeStarts.length = 0
@@ -165,11 +190,9 @@ export function htmlToMarkdown(html: string): string {
   }
 
   const append = (s: string) => {
-    if (table?.cell && table.row?.length) {
-      table.row[table.row.length - 1] += s
-    } else {
-      inline += s
-    }
+    const cell = activeCell()
+    if (cell) cell[cell.length - 1] += s
+    else inline += s
   }
 
   const dropStack: string[] = []
@@ -234,6 +257,10 @@ export function htmlToMarkdown(html: string): string {
       case "h4":
       case "h5":
       case "h6": {
+        // A heading has no meaning inside a table cell (pipe-table syntax can't hold
+        // one) — ignore the tag; its text still flows into the cell as plain text via
+        // the normal emitText/append path.
+        if (inCell()) break
         if (!tag.closing) {
           flush()
           headingLevel = Number(tag.name[1])
@@ -266,6 +293,7 @@ export function htmlToMarkdown(html: string): string {
         append("\n")
         break
       case "hr":
+        if (inCell()) break // no block content inside a pipe-table cell
         flush()
         out.push(`${blockPrefix()}---`)
         itemPrefix = ""
@@ -296,12 +324,13 @@ export function htmlToMarkdown(html: string): string {
         break
       case "code": {
         if (!tag.closing) {
-          codeStarts.push(inline.length)
+          codeStarts.push(bufGet().length)
         } else {
           const start = codeStarts.pop()
           if (start !== undefined) {
-            const body = inline.slice(start)
-            inline = inline.slice(0, start) + codeSpan(body.trim())
+            const buf = bufGet()
+            const body = buf.slice(start)
+            bufSet(buf.slice(0, start) + codeSpan(body.trim()))
           }
         }
         break

--- a/packages/core/src/doc-text.ts
+++ b/packages/core/src/doc-text.ts
@@ -90,6 +90,42 @@ const attrOf = (attrs: string, name: string): string | null => {
 const DROP = new Set(["head", "style", "script", "noscript", "svg", "template", "iframe"])
 // Void tags that never close (outside the ones we render specially).
 const IGNORE_VOID = new Set(["meta", "link", "base", "input", "source", "track", "wbr", "col"])
+// Block-level tags: meaningless inside a pipe-table cell (that syntax can't hold block
+// content). A SINGLE dispatch-point check against this set — rather than a per-case
+// guard sprinkled through the switch below — means a future block tag added to the
+// switch can't reintroduce the table-corruption bug class this set exists to prevent:
+// flushing the wrong buffer, or (worse) a mode-switching tag like `pre` capturing
+// subsequent cell tokens into a fenced block pushed straight into the document's
+// top-level output, splitting the table mid-render.
+const BLOCK_ONLY = new Set([
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "p",
+  "div",
+  "section",
+  "article",
+  "header",
+  "footer",
+  "main",
+  "figure",
+  "figcaption",
+  "aside",
+  "details",
+  "summary",
+  "dl",
+  "dt",
+  "dd",
+  "hr",
+  "blockquote",
+  "ul",
+  "ol",
+  "li",
+  "pre",
+])
 
 // ---------------------------------------------------------------------------------
 // HTML → Markdown
@@ -250,6 +286,12 @@ export function htmlToMarkdown(html: string): string {
       continue
     }
 
+    // A block-level tag has no meaning inside a table cell (pipe-table syntax can't
+    // hold one): ignore its structural effect entirely — its own text still reaches
+    // the cell as plain text via the normal emitText/append path. One check up front
+    // instead of a guard duplicated per switch case (see BLOCK_ONLY's comment).
+    if (inCell() && BLOCK_ONLY.has(tag.name)) continue
+
     switch (tag.name) {
       case "h1":
       case "h2":
@@ -257,10 +299,6 @@ export function htmlToMarkdown(html: string): string {
       case "h4":
       case "h5":
       case "h6": {
-        // A heading has no meaning inside a table cell (pipe-table syntax can't hold
-        // one) — ignore the tag; its text still flows into the cell as plain text via
-        // the normal emitText/append path.
-        if (inCell()) break
         if (!tag.closing) {
           flush()
           headingLevel = Number(tag.name[1])
@@ -293,7 +331,6 @@ export function htmlToMarkdown(html: string): string {
         append("\n")
         break
       case "hr":
-        if (inCell()) break // no block content inside a pipe-table cell
         flush()
         out.push(`${blockPrefix()}---`)
         itemPrefix = ""
@@ -443,14 +480,27 @@ interface HeadingSpan {
 }
 
 const HEADING = /<h([1-3])\b[^>]*>([\s\S]*?)<\/h\1>/gi
+// A DROP subtree with its full content — same tag set htmlToMarkdown drops whole.
+// Used to mask out `<script>`/`<template>`/… content before scanning for headings,
+// since the regex scan below has no tokenizer state and would otherwise happily
+// match an `<h2>` sitting inside a script string or an unrendered template.
+const DROP_SUBTREE = new RegExp(`<(${[...DROP].join("|")})\\b[^>]*>[\\s\\S]*?<\\/\\1>`, "gi")
 
 const headingSpans = (html: string): HeadingSpan[] => {
   const slug = slugger()
   const spans: HeadingSpan[] = []
-  // Headings inside dropped subtrees (a <template> …) would be false spine entries;
-  // artifact docs don't nest headings there, and a stray one only adds a dead slug.
+  // Ranges to exclude: a heading whose match starts inside one of these never became
+  // part of the rendered document, so it must not become an outline entry (whose
+  // sectionSlice would then start mid-subtree — see the DROP_SUBTREE comment above).
+  const dropRanges: [number, number][] = []
+  DROP_SUBTREE.lastIndex = 0
+  for (let dm = DROP_SUBTREE.exec(html); dm; dm = DROP_SUBTREE.exec(html))
+    dropRanges.push([dm.index, dm.index + dm[0].length])
+  const inDropRange = (pos: number) => dropRanges.some(([s, e]) => pos >= s && pos < e)
+
   HEADING.lastIndex = 0
   for (let m = HEADING.exec(html); m; m = HEADING.exec(html)) {
+    if (inDropRange(m.index)) continue
     const text = collapse(decodeEntities((m[2] as string).replace(/<[^>]+>/g, " "))).trim()
     if (!text) continue
     spans.push({ level: Number(m[1]), text, slug: slug(text), start: m.index })
@@ -534,7 +584,12 @@ const mdSectionEnd = (src: string, hs: MdHeading[], i: number): number => {
 // ---------------------------------------------------------------------------------
 // Content-type facade — what the servers call
 
-const isHtmlLike = (contentType: string): boolean => {
+/** Content types this module treats as HTML-in, Markdown-out (converted by
+ *  htmlToMarkdown/docOutline/sectionSlice) rather than passed through as-is.
+ *  Exported so callers deciding how to present a `format` (e.g. whether "text"
+ *  needs pageText-style stripping) stay in sync with what actually gets converted —
+ *  a local `=== "text/html"` check would silently drift on decks. */
+export const isHtmlLike = (contentType: string): boolean => {
   const ct = contentType.split(";")[0]?.trim()
   return ct === "text/html" || ct === "text/x-derive-deck"
 }
@@ -570,9 +625,13 @@ export const sectionOf = (source: string, contentType: string, slug: string): st
 
 export class EditError extends Error {}
 
+// Non-overlapping occurrence count — advances past the whole match, not by one char,
+// so a self-overlapping needle ("aa" in "aaa") counts as the single non-overlapping
+// match a real replace would make, not a spuriously "ambiguous" 2.
 const countOccurrences = (haystack: string, needle: string): number => {
   let count = 0
-  for (let i = haystack.indexOf(needle); i !== -1; i = haystack.indexOf(needle, i + 1)) count++
+  for (let i = haystack.indexOf(needle); i !== -1; i = haystack.indexOf(needle, i + needle.length))
+    count++
   return count
 }
 

--- a/packages/core/src/doc-text.ts
+++ b/packages/core/src/doc-text.ts
@@ -1,0 +1,577 @@
+// Presenting stored artifact content to an AI consumer: HTML → structured Markdown,
+// a heading outline with stable slugs, raw section slices those slugs address, and
+// exact-match edits. `anchor.ts` is about MATCHING text (comment quotes); this module
+// is about READING and REVISING it — the shared piece is the entity decoder.
+//
+// Everything here is dependency-free and DOM-free (no jsdom/turndown — the api must
+// run on the Workers tier). The vocabulary is bounded: artifact HTML is either our
+// own markdown render (the `sanitizeHtml` whitelist in md.ts) or agent-authored
+// reports using the same block tags, so a tokenizer over that tag set is small and
+// testable — the same trade `pageText`/`reflow.ts` already make.
+
+import { decodeEntities } from "./anchor"
+
+/** One heading in a document's h1–h3 spine. `chars` is the size of the section's
+ *  MARKDOWN conversion (heading included) — what a read of that section costs. */
+export interface OutlineSection {
+  level: number
+  text: string
+  slug: string
+  chars: number
+}
+
+/** One exact-match replacement (the Edit-tool contract: unique match or error). */
+export interface DocEdit {
+  old_str: string
+  new_str: string
+}
+
+// ---------------------------------------------------------------------------------
+// Slugs
+
+/** GitHub-style heading slug: lowercase, keep letters/numbers/space/hyphen/underscore,
+ *  spaces → hyphens. No length cap (headings must stay unambiguous — unlike the
+ *  URL-oriented `ids.slugify`). Dedup across a document via `Slugger`. */
+export const headingSlug = (text: string): string =>
+  text
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N} _-]+/gu, "")
+    .trim()
+    .replace(/[ _]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "")
+
+/** Per-document slug dedup: second "goals" becomes "goals-1", then "goals-2" … */
+const slugger = () => {
+  const seen = new Map<string, number>()
+  return (text: string): string => {
+    const base = headingSlug(text) || "section"
+    const n = seen.get(base) ?? 0
+    seen.set(base, n + 1)
+    return n === 0 ? base : `${base}-${n}`
+  }
+}
+
+// ---------------------------------------------------------------------------------
+// HTML tokenizer (shared by the converter and the heading scanner)
+
+interface Tag {
+  name: string
+  attrs: string
+  closing: boolean
+  selfClosing: boolean
+  start: number
+  end: number
+}
+
+// Comments, declarations (<!DOCTYPE …>), and element tags.
+const TOKEN = /<!--[\s\S]*?-->|<![^>]*>|<\/?[a-zA-Z][^>]*>/g
+
+const parseTag = (raw: string, start: number): Tag | null => {
+  const m = /^<(\/?)([a-zA-Z][a-zA-Z0-9-]*)([\s\S]*?)(\/?)>$/.exec(raw)
+  if (!m) return null
+  return {
+    name: (m[2] as string).toLowerCase(),
+    attrs: m[3] as string,
+    closing: m[1] === "/",
+    selfClosing: m[4] === "/",
+    start,
+    end: start + raw.length,
+  }
+}
+
+const attrOf = (attrs: string, name: string): string | null => {
+  const m = new RegExp(`\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s>]+))`, "i").exec(attrs)
+  return m ? (m[2] ?? m[3] ?? m[4] ?? "") : null
+}
+
+// Subtrees an agent never wants: layout, behavior, vector art, fallbacks.
+const DROP = new Set(["head", "style", "script", "noscript", "svg", "template", "iframe"])
+// Void tags that never close (outside the ones we render specially).
+const IGNORE_VOID = new Set(["meta", "link", "base", "input", "source", "track", "wbr", "col"])
+
+// ---------------------------------------------------------------------------------
+// HTML → Markdown
+
+const collapse = (s: string) => s.replace(/[ \t\r\n]+/g, " ")
+
+/** Wrap inline-code content in enough backticks that its own backtick runs survive. */
+const codeSpan = (s: string): string => {
+  const runs = s.match(/`+/g)
+  const fence = "`".repeat((runs ? Math.max(...runs.map((r) => r.length)) : 0) + 1)
+  const pad = s.startsWith("`") || s.endsWith("`") || s === "" ? " " : ""
+  return `${fence}${pad}${s}${pad}${fence}`
+}
+
+/** Fence long enough that the block's own backtick runs survive. */
+const fenceFor = (s: string): string => {
+  const runs = s.match(/`{3,}/g)
+  return "`".repeat(Math.max(3, ...(runs ? runs.map((r) => r.length + 1) : [3])))
+}
+
+const langOf = (attrs: string): string => {
+  const cls = attrOf(attrs, "class") ?? ""
+  const m = /(?:^|\s)(?:language|lang)-([\w+-]+)/.exec(cls)
+  return m ? (m[1] as string) : ""
+}
+
+/**
+ * Structure-preserving HTML → Markdown for the artifact vocabulary: headings, lists
+ * (nested, ordered counters), tables (pipe, alignment), fenced code (language tag,
+ * entities decoded, newlines preserved), blockquotes, links, images, emphasis, hr.
+ * Unknown tags are transparent (tag dropped, text kept); DROP subtrees vanish whole.
+ * Real newlines throughout — a minified one-line document comes out multi-line.
+ */
+export function htmlToMarkdown(html: string): string {
+  const out: string[] = []
+  let inline = ""
+  let quoteDepth = 0
+  const listStack: { ordered: boolean; index: number }[] = []
+  let headingLevel = 0
+  let itemPrefix = "" // pending "- " / "3. " for the innermost open <li>
+
+  // pre / inline-code state
+  let pre: { lang: string; buf: string } | null = null
+  const codeStarts: number[] = [] // inline `<code>` open offsets into `inline`
+  const linkHrefs: (string | null)[] = []
+
+  // table state
+  let table: { rows: string[][]; aligns: string[]; row: string[] | null; cell: boolean } | null =
+    null
+
+  const blockPrefix = () => {
+    const quote = "> ".repeat(quoteDepth)
+    if (!listStack.length) return quote
+    const indent = "  ".repeat(listStack.length - 1)
+    const lead = itemPrefix || "  ".repeat(1) // continuation inside an li aligns under it
+    return quote + indent + lead
+  }
+
+  const flush = () => {
+    const text = inline.replace(/[ \t]+/g, " ").trim()
+    inline = ""
+    codeStarts.length = 0
+    if (!text) return
+    // <br> hard breaks arrive as \n in the buffer; keep them, trim each line.
+    const lines = text
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l, i, a) => l || (i > 0 && i < a.length - 1))
+    const prefix = blockPrefix()
+    const cont = itemPrefix ? "> ".repeat(quoteDepth) + "  ".repeat(listStack.length) : prefix
+    out.push(lines.map((l, i) => (i === 0 ? prefix : cont) + l).join("\n"))
+    itemPrefix = ""
+  }
+
+  const append = (s: string) => {
+    if (table?.cell && table.row?.length) {
+      table.row[table.row.length - 1] += s
+    } else {
+      inline += s
+    }
+  }
+
+  const dropStack: string[] = []
+  TOKEN.lastIndex = 0
+  let last = 0
+  let m = TOKEN.exec(html)
+  const emitText = (raw: string) => {
+    if (dropStack.length || !raw) return
+    if (pre) {
+      pre.buf += decodeEntities(raw)
+    } else if (raw.trim() || /[ \t\r\n]/.test(raw)) {
+      const text = decodeEntities(collapse(raw))
+      if (text !== " " || inline || table?.cell) append(text)
+    }
+  }
+
+  while (true) {
+    const chunkEnd = m ? m.index : html.length
+    emitText(html.slice(last, chunkEnd))
+    if (!m) break
+    last = TOKEN.lastIndex
+    const raw = m[0]
+    m = TOKEN.exec(html)
+    if (raw.startsWith("<!")) continue
+    const tag = parseTag(raw, chunkEnd)
+    if (!tag) continue
+
+    // Dropped subtrees: track depth of the SAME tag so nesting can't leak content.
+    if (dropStack.length) {
+      if (tag.name === dropStack[dropStack.length - 1]) {
+        if (tag.closing) dropStack.pop()
+        else if (!tag.selfClosing) dropStack.push(tag.name)
+      }
+      continue
+    }
+    if (DROP.has(tag.name)) {
+      if (!tag.closing && !tag.selfClosing) dropStack.push(tag.name)
+      continue
+    }
+    if (IGNORE_VOID.has(tag.name)) continue
+
+    // Whole-block <pre> capture (tags inside are highlight spans — text only).
+    if (pre) {
+      if (tag.name === "pre" && tag.closing) {
+        const body = pre.buf.replace(/^\n/, "").replace(/\n[ \t]*$/, "")
+        const fence = fenceFor(body)
+        out.push(`${blockPrefix()}${fence}${pre.lang}\n${body}\n${fence}`)
+        itemPrefix = ""
+        pre = null
+      } else if (tag.name === "code" && !tag.closing && !pre.lang) {
+        pre.lang = langOf(tag.attrs)
+      } else if (tag.name === "br") {
+        pre.buf += "\n"
+      }
+      continue
+    }
+
+    switch (tag.name) {
+      case "h1":
+      case "h2":
+      case "h3":
+      case "h4":
+      case "h5":
+      case "h6": {
+        if (!tag.closing) {
+          flush()
+          headingLevel = Number(tag.name[1])
+        } else {
+          const text = inline.replace(/[ \t]+/g, " ").trim()
+          inline = ""
+          if (text) out.push(`${"> ".repeat(quoteDepth)}${"#".repeat(headingLevel)} ${text}`)
+          headingLevel = 0
+        }
+        break
+      }
+      case "p":
+      case "div":
+      case "section":
+      case "article":
+      case "header":
+      case "footer":
+      case "main":
+      case "figure":
+      case "figcaption":
+      case "aside":
+      case "details":
+      case "summary":
+      case "dl":
+      case "dt":
+      case "dd":
+        flush()
+        break
+      case "br":
+        append("\n")
+        break
+      case "hr":
+        flush()
+        out.push(`${blockPrefix()}---`)
+        itemPrefix = ""
+        break
+      case "blockquote":
+        flush()
+        quoteDepth = Math.max(0, quoteDepth + (tag.closing ? -1 : 1))
+        break
+      case "ul":
+      case "ol":
+        flush()
+        if (!tag.closing) listStack.push({ ordered: tag.name === "ol", index: 0 })
+        else listStack.pop()
+        break
+      case "li": {
+        flush()
+        if (!tag.closing) {
+          const top = listStack[listStack.length - 1]
+          itemPrefix = top?.ordered ? `${++top.index}. ` : "- "
+        }
+        break
+      }
+      case "pre":
+        if (!tag.closing) {
+          flush()
+          pre = { lang: langOf(tag.attrs), buf: "" }
+        }
+        break
+      case "code": {
+        if (!tag.closing) {
+          codeStarts.push(inline.length)
+        } else {
+          const start = codeStarts.pop()
+          if (start !== undefined) {
+            const body = inline.slice(start)
+            inline = inline.slice(0, start) + codeSpan(body.trim())
+          }
+        }
+        break
+      }
+      case "strong":
+      case "b":
+        append("**")
+        break
+      case "em":
+      case "i":
+        append("*")
+        break
+      case "del":
+      case "s":
+      case "strike":
+        append("~~")
+        break
+      case "a": {
+        if (!tag.closing) {
+          const href = attrOf(tag.attrs, "href")
+          const usable = href && !href.startsWith("javascript:") ? href : null
+          linkHrefs.push(usable)
+          if (usable) append("[")
+        } else {
+          const href = linkHrefs.pop()
+          if (href) append(`](${href})`)
+        }
+        break
+      }
+      case "img": {
+        const src = attrOf(tag.attrs, "src") ?? ""
+        const alt = attrOf(tag.attrs, "alt") ?? ""
+        if (src) append(`![${alt}](${src})`)
+        break
+      }
+      // Tables ------------------------------------------------------------------
+      case "table":
+        if (!tag.closing) {
+          flush()
+          table = { rows: [], aligns: [], row: null, cell: false }
+        } else if (table) {
+          const rows = table.rows.filter((r) => r.length)
+          if (rows.length) {
+            const width = Math.max(...rows.map((r) => r.length))
+            const norm = rows.map((r) => [...r, ...Array(width - r.length).fill("")])
+            const clean = (c: string) => collapse(c).trim().replace(/\|/g, "\\|")
+            const line = (r: string[]) => `| ${r.map(clean).join(" | ")} |`
+            const aligns = table.aligns
+            const sep = `| ${Array.from({ length: width }, (_, i) => aligns[i] ?? "---").join(" | ")} |`
+            const p = blockPrefix()
+            out.push(
+              [line(norm[0] as string[]), sep, ...norm.slice(1).map(line)]
+                .map((l) => p + l)
+                .join("\n"),
+            )
+            itemPrefix = ""
+          }
+          table = null
+        }
+        break
+      case "tr":
+        if (table) {
+          if (!tag.closing) table.row = []
+          else if (table.row) {
+            table.rows.push(table.row)
+            table.row = null
+          }
+        }
+        break
+      case "th":
+      case "td":
+        if (table?.row) {
+          if (!tag.closing) {
+            table.row.push("")
+            table.cell = true
+            if (table.rows.length === 0) {
+              const align = (attrOf(tag.attrs, "align") ?? "").toLowerCase()
+              table.aligns.push(
+                align === "center"
+                  ? ":---:"
+                  : align === "right"
+                    ? "---:"
+                    : align === "left"
+                      ? ":---"
+                      : "---",
+              )
+            }
+          } else {
+            table.cell = false
+          }
+        }
+        break
+      default:
+        // Unknown tags (span, mark, sup, sub, thead, tbody, …) are transparent.
+        break
+    }
+  }
+  flush()
+  return out.join("\n\n").trim()
+}
+
+// ---------------------------------------------------------------------------------
+// Heading spans → outline + raw section slices (HTML side)
+
+interface HeadingSpan {
+  level: number
+  text: string
+  slug: string
+  start: number // offset of the heading's opening "<hN"
+}
+
+const HEADING = /<h([1-3])\b[^>]*>([\s\S]*?)<\/h\1>/gi
+
+const headingSpans = (html: string): HeadingSpan[] => {
+  const slug = slugger()
+  const spans: HeadingSpan[] = []
+  // Headings inside dropped subtrees (a <template> …) would be false spine entries;
+  // artifact docs don't nest headings there, and a stray one only adds a dead slug.
+  HEADING.lastIndex = 0
+  for (let m = HEADING.exec(html); m; m = HEADING.exec(html)) {
+    const text = collapse(decodeEntities((m[2] as string).replace(/<[^>]+>/g, " "))).trim()
+    if (!text) continue
+    spans.push({ level: Number(m[1]), text, slug: slug(text), start: m.index })
+  }
+  return spans
+}
+
+const sectionEnd = (html: string, spans: HeadingSpan[], i: number): number => {
+  const level = (spans[i] as HeadingSpan).level
+  for (let j = i + 1; j < spans.length; j++) {
+    const next = spans[j] as HeadingSpan
+    if (next.level <= level) return next.start
+  }
+  const body = html.lastIndexOf("</body>")
+  return body > (spans[i] as HeadingSpan).start ? body : html.length
+}
+
+/** The h1–h3 spine of an HTML document. Empty array = unsectionable (no headings). */
+export function docOutline(html: string): OutlineSection[] {
+  const spans = headingSpans(html)
+  return spans.map((s, i) => ({
+    level: s.level,
+    text: s.text,
+    slug: s.slug,
+    chars: htmlToMarkdown(html.slice(s.start, sectionEnd(html, spans, i))).length,
+  }))
+}
+
+/** Raw-HTML slice for `slug`: from its heading tag to the next heading of the same or
+ *  higher level (or </body>). Byte-identical substring of the source, so a section an
+ *  agent reads with format:"html" is exactly the text publish `edits` will match. */
+export function sectionSlice(html: string, slug: string): string | null {
+  const spans = headingSpans(html)
+  const i = spans.findIndex((s) => s.slug === slug)
+  if (i < 0) return null
+  return html.slice((spans[i] as HeadingSpan).start, sectionEnd(html, spans, i))
+}
+
+// ---------------------------------------------------------------------------------
+// Markdown twins (source IS what agents read and edit — slice the source itself)
+
+interface MdHeading {
+  level: number
+  text: string
+  slug: string
+  start: number // offset of the line start
+}
+
+const mdHeadings = (src: string): MdHeading[] => {
+  const slug = slugger()
+  const out: MdHeading[] = []
+  let fence: string | null = null
+  let offset = 0
+  for (const line of src.split("\n")) {
+    const f = /^\s*(`{3,}|~{3,})/.exec(line)
+    if (f) {
+      const run = f[1] as string
+      if (!fence) fence = run.slice(0, 1).repeat(3)
+      else if (run.startsWith(fence)) fence = null
+    } else if (!fence) {
+      const h = /^(#{1,3})\s+(.+?)\s*#*\s*$/.exec(line)
+      if (h) {
+        const text = (h[2] as string).trim()
+        out.push({ level: (h[1] as string).length, text, slug: slug(text), start: offset })
+      }
+    }
+    offset += line.length + 1
+  }
+  return out
+}
+
+const mdSectionEnd = (src: string, hs: MdHeading[], i: number): number => {
+  const level = (hs[i] as MdHeading).level
+  for (let j = i + 1; j < hs.length; j++) {
+    const next = hs[j] as MdHeading
+    if (next.level <= level) return next.start
+  }
+  return src.length
+}
+
+// ---------------------------------------------------------------------------------
+// Content-type facade — what the servers call
+
+const isHtmlLike = (contentType: string): boolean => {
+  const ct = contentType.split(";")[0]?.trim()
+  return ct === "text/html" || ct === "text/x-derive-deck"
+}
+
+/** The agent-readable form of stored source: HTML converts to Markdown, everything
+ *  else (markdown, plain text) already IS the readable form and passes through. */
+export const toMarkdown = (source: string, contentType: string): string =>
+  isHtmlLike(contentType) ? htmlToMarkdown(source) : source
+
+/** Outline for any text source (h1–h3 for HTML, ATX `#`–`###` for markdown). */
+export const outlineOf = (source: string, contentType: string): OutlineSection[] => {
+  if (isHtmlLike(contentType)) return docOutline(source)
+  const hs = mdHeadings(source)
+  return hs.map((h, i) => ({
+    level: h.level,
+    text: h.text,
+    slug: h.slug,
+    chars: mdSectionEnd(source, hs, i) - h.start,
+  }))
+}
+
+/** The SOURCE slice a section slug addresses (raw HTML or raw markdown). */
+export const sectionOf = (source: string, contentType: string, slug: string): string | null => {
+  if (isHtmlLike(contentType)) return sectionSlice(source, slug)
+  const hs = mdHeadings(source)
+  const i = hs.findIndex((h) => h.slug === slug)
+  if (i < 0) return null
+  return source.slice((hs[i] as MdHeading).start, mdSectionEnd(source, hs, i)).replace(/\n+$/, "\n")
+}
+
+// ---------------------------------------------------------------------------------
+// Exact-match edits (the Edit-tool contract)
+
+export class EditError extends Error {}
+
+const countOccurrences = (haystack: string, needle: string): number => {
+  let count = 0
+  for (let i = haystack.indexOf(needle); i !== -1; i = haystack.indexOf(needle, i + 1)) count++
+  return count
+}
+
+/**
+ * Apply `edits` to `src` in order, each seeing the previous edit's result. Every
+ * `old_str` must match EXACTLY ONCE or the whole batch is rejected (nothing partial
+ * ever lands) with an error naming the failing edit — the agent adds surrounding
+ * context and retries. Same contract as the coding Edit tool, so agents already
+ * know how to recover.
+ */
+export function applyEdits(src: string, edits: DocEdit[]): string {
+  if (!edits.length)
+    throw new EditError("`edits` is empty — provide at least one {old_str, new_str}.")
+  let result = src
+  for (const [i, e] of edits.entries()) {
+    const label = `Edit ${i + 1} of ${edits.length}`
+    if (!e.old_str) throw new EditError(`${label} failed: old_str is empty.`)
+    const n = countOccurrences(result, e.old_str)
+    if (n === 0)
+      throw new EditError(
+        `${label} failed: old_str not found in the current source. Re-read the artifact ` +
+          `(format:"html" for HTML content) and copy the text exactly.`,
+      )
+    if (n > 1)
+      throw new EditError(
+        `${label} failed: old_str matched ${n} times — include more surrounding context so it is unique.`,
+      )
+    result = result.replace(e.old_str, () => e.new_str)
+  }
+  return result
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./anchor"
 export * from "./cross-doc"
 export * from "./diff"
+export * from "./doc-text"
 export * from "./element-anchor"
 export * from "./hash"
 export * from "./ids"

--- a/packages/mcp/SKILL.md
+++ b/packages/mcp/SKILL.md
@@ -22,10 +22,10 @@ Your identity (agent name, workspace, role) is in the server instructions — th
 | Tool | Use |
 |---|---|
 | `list_artifacts` | Find: the artifacts in your workspace (short id, title, kind, version, visibility). Optional `query` filters by title. |
-| `read` | Read an artifact's content by short id. For a bundle, omit `section` for the outline or pass a `section` (page path) for one page; pass `version` to read history. |
-| `catch_up` | Start here on an artifact: its state in one call — what changed since `since_version`, the open/outdated comment threads, the `review` round state, and version history. Pass `comments` (open/addressed/resolved/outdated) for that filtered feedback queue, or `response_format='detailed'` (with optional `since_version`/`to_version`) to fold in the exact line diff. Waiting on a review? Pass `wait` (seconds, max 50) to long-poll: the call blocks until the human sends back / approves / comments — chain these instead of sleeping. |
+| `read` | Read an artifact's content by short id, as **Markdown by default** (HTML is converted — headings, lists, tables, code fences; the styling noise is dropped). Omit `section` and a small doc/bundle returns whole; a **large one returns its outline first** (heading slugs for a single-file doc, page paths for a bundle) — call again with a `section` (a slug, a bundle page, `page.html#slug`, or `"*"` for the full clipped document). Pass `format:'html'` for the exact stored source (needed before publish `edits`) or `format:'text'` for flat visible text (what comment `quote`s anchor against). Pass `version` to read history. An image page in a bundle comes back as a real image, not garbage text. |
+| `catch_up` | Start here on an artifact: its state in one call — what changed since `since_version`, the open/outdated comment threads, the `review` round state, and version history. Pass `comments` (open/addressed/resolved/outdated) for that filtered feedback queue, or `response_format='detailed'` (with optional `since_version`/`to_version`) to fold in a line diff — of the **readable Markdown form**, not raw HTML, so it shows what changed instead of tag noise. Waiting on a review? Pass `wait` (seconds, max 50) to long-poll: the call blocks until the human sends back / approves / comments — chain these instead of sleeping. |
 | `comment` | Leave feedback, reply (`reply_to` a thread id), anchor to a `quote`, react (`react: "👍"` with `reply_to` — the loop's lightweight ack, landing on the thread's latest human comment), and/or resolve/reopen (`set_state`). |
-| `publish` | Save a revision. `content` for a single file, `files` (path→content map) for a multi-page bundle. Omit `short_id` to create new (title required); pass it to add a version. `addresses` lists thread ids this revision resolves; `request_review:true` opens a review round for your human. New artifacts land **private** by default (the human you act for owns the draft) — they promote via the share dialog, so don't pass a wider `visibility` unasked. The result's `opened_in_tab` says whether an open Derive tab caught the push; when false, open the `url` for the user if they should see it now. |
+| `publish` | Save a revision. `content` for a single file, `files` (path→content map) for a multi-page bundle, or **`edits`** (`[{old_str, new_str}]`) to revise part of a single-file artifact without resending it. Omit `short_id` to create new (title required); pass it to add a version. `addresses` lists thread ids this revision resolves; `request_review:true` opens a review round for your human. New artifacts land **private** by default (the human you act for owns the draft) — they promote via the share dialog, so don't pass a wider `visibility` unasked. The result's `opened_in_tab` says whether an open Derive tab caught the push; when false, open the `url` for the user if they should see it now. |
 
 ## Role decides: live publish vs proposal
 
@@ -54,6 +54,54 @@ human approves rather than live content.
    `addresses` + `request_review:true` for the next round. The human never
    resolves threads — you settle thread state.
 
+## Reading big documents
+
+`read` never hands you a wall of JSON-escaped HTML. A content-bearing response is
+a small frontmatter header (short id, title, version, format, section, size, url)
+followed by a blank line and the raw body — real newlines, greppable if a client
+spills it to a file. When a document is large, `read` (no `section`) returns its
+heading outline instead of the full text:
+
+```
+{ "sections": [
+    { "slug": "why-one-engine", "level": 2, "text": "Why: one engine", "chars": 2210 },
+    { "slug": "pr-6-the-fix",   "level": 2, "text": "PR-6: the fix",   "chars": 4812 }
+  ], "next": "Call read again with a section slug…" }
+```
+
+Pull just the part you need: `read(short_id, { section: "pr-6-the-fix" })`. Pass
+`section: "*"` to force the full (clipped) document when you genuinely need it all.
+
+## Edit, don't resend
+
+Once you've read a section, revise it with `publish`'s `edits` instead of
+resending the whole artifact:
+
+```
+publish(short_id, { edits: [{ old_str: "exact text from the source", new_str: "replacement" }] })
+```
+
+Each `old_str` must match **exactly once** in the current stored source — the
+same contract as a coding Edit tool. If it doesn't match (or matches more than
+once), nothing is applied and the error names which edit failed, so you add more
+surrounding context and retry. For an HTML artifact, read with `format:'html'`
+first — the Markdown view won't match raw source. Pass `base_version` (the
+version you read) to fail fast instead of silently editing a version you never saw.
+
+## Mockups & screens
+
+Reading Markdown by default doesn't flatten design work:
+
+- **See it rendered**: every `read` response's frontmatter carries the artifact's
+  `url` — open it in a real browser (or a browser-automation tool) to view or
+  screenshot the live page.
+- **See its structure/copy**: the default Markdown read.
+- **See a screenshot inline**: reading an image page of a bundle (`section:
+  "shot.png"`) returns a real image content block, not decoded bytes as text.
+- **Edit it**: `read(section, format:'html')` for the exact markup, then
+  `publish({ edits })` for a surgical change — a label, a color token — without
+  resending the whole design.
+
 ## Keep comments anchorable
 
 Anchors are text quotes with surrounding context, matched in the rendered
@@ -66,10 +114,16 @@ wrong place.
 
 - Versions are immutable; `@vN` URLs never change. The viewer groups rapid
   same-author revisions into time-based sessions, but every revision is addressable.
-- Multi-page bundles are readable (`read` with a `section`, `catch_up`) and revisable
+- Multi-page bundles are readable on both servers (`read` with a `section` — a page
+  path, or `page.html#slug` for one heading's part; `catch_up`) but revisable only
   over the remote `/mcp` server via `publish` with a `files` map. Over the stdio
-  `@derive-to/mcp` server, bundles are publish-via-remote/web only, and `comment` set_state
-  takes a `comment_id`. Both servers expose the same 5 tools.
+  `@derive-to/mcp` server, bundles are publish-via-remote/web only, and `comment`
+  set_state takes a `comment_id`. `edits` (single-file only) works on both. Both
+  servers expose the same 5 tools.
+- An older self-hosted Derive server that predates `format`/`section`/`outline`
+  responds to `read` with a note that it returned the full raw artifact instead —
+  the stdio client detects this from a missing response header and degrades rather
+  than silently misreading a section.
 - The stdio server shares the machine's `derive login` — no token to paste. It acts as
   your stored default account/workspace unless `DERIVE_ACCOUNT`/`DERIVE_WORKSPACE`
   pin the project to a specific one (id or name; set in `.mcp.json`'s `env`). Still no

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@derive-to/mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Stdio MCP server for Derive — list, read, catch up on, comment on, and publish artifacts on a Derive instance.",
   "keywords": [

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -1,8 +1,15 @@
 /** HTTP client for a Derive server. Shared by the MCP server and any tooling. */
 
+/** One exact-match search/replace edit (the Edit-tool contract). */
+export interface DocEdit {
+  old_str: string
+  new_str: string
+}
+
 export interface PublishArgs {
-  content: string | Uint8Array
-  filename: string
+  /** Full content for a fresh publish/republish. Omit when using `edits` instead. */
+  content?: string | Uint8Array
+  filename?: string
   title?: string
   slug?: string
   spa?: boolean
@@ -16,6 +23,11 @@ export interface PublishArgs {
   resolves?: string[]
   /** Open a review round for this version (the /derive loop's ask). */
   requestReview?: boolean
+  /** Exact-match search/replace against the current stored source, INSTEAD of
+   *  `content` — revises without resending the whole artifact. Requires `id`. */
+  edits?: DocEdit[]
+  /** Safety check for `edits`: reject if the artifact moved past this version. */
+  baseVersion?: number
 }
 
 export type CommentState = "open" | "addressed" | "resolved" | "outdated"
@@ -44,11 +56,16 @@ export interface ArtifactSummaryJson {
 
 /** A revision submitted for human review instead of published live. */
 export interface ProposeArgs {
-  content: string
+  /** Full content for the proposal. Omit when using `edits` instead. */
+  content?: string
   filename?: string
   message: string
   /** Thread ids this revision addresses (flip to `addressed`, resolve on approval). */
   addresses?: string[]
+  /** Exact-match search/replace against the current stored source, INSTEAD of
+   *  `content`. */
+  edits?: DocEdit[]
+  baseVersion?: number
 }
 export interface ProposalJson {
   id: string
@@ -123,6 +140,32 @@ export interface ViewStatsJson {
   recent: { viewer: string; kind: "user" | "anon"; at: string }[]
 }
 
+export interface ContentOpts {
+  version?: number
+  /** A heading slug (single-file) or page path (bundle, optionally page#slug). */
+  section?: string
+  format?: "markdown" | "text"
+}
+
+/** A content read: the body plus the server's X-Derive-* capability headers, so a
+ *  caller can tell an older self-hosted server (no headers at all) from a real
+ *  raw-format response and degrade gracefully instead of misreading intent. */
+export interface ContentResult {
+  text: string
+  /** Null when the server predates these params (no X-Derive-Format header). */
+  format: string | null
+  section: string | null
+  sectionCount: number | null
+  supportsParams: boolean
+}
+
+export interface OutlineSectionJson {
+  level: number
+  text: string
+  slug: string
+  chars: number
+}
+
 export interface DeriveClient {
   /** List the workspace's artifacts (optionally filtered by a title query). */
   list(query?: string): Promise<ArtifactSummaryJson[]>
@@ -130,13 +173,20 @@ export interface DeriveClient {
   /** Submit a single-file revision for human review (does not go live). */
   propose(shortId: string, args: ProposeArgs): Promise<ProposalJson>
   get(shortId: string): Promise<ArtifactJson>
-  getContent(shortId: string, version?: number): Promise<string>
+  getContent(shortId: string, opts?: ContentOpts): Promise<ContentResult>
+  /** The heading (single-file) or page (bundle) outline. Empty `sections` on an
+   *  older server that doesn't understand `?outline=1` (it 400s or ignores it). */
+  getOutline(
+    shortId: string,
+    version?: number,
+  ): Promise<{ sections: OutlineSectionJson[]; pages: { path: string; type?: string }[] | null }>
   listComments(shortId: string, state?: CommentState): Promise<CommentJson[]>
   createComment(shortId: string, args: NewCommentArgs): Promise<CommentJson>
   /** Resolve or reopen the thread a comment belongs to. */
   setThreadState(shortId: string, commentId: string, state: "resolved" | "open"): Promise<void>
-  /** Line diff between two versions (defaults: current-1 → current). */
-  diff(shortId: string, from?: number, to?: number): Promise<DiffJson>
+  /** Line diff between two versions (defaults: current-1 → current). `content:
+   *  "markdown"` diffs the readable Markdown form instead of raw source. */
+  diff(shortId: string, from?: number, to?: number, content?: "raw" | "markdown"): Promise<DiffJson>
   /** The artifact's review rounds (newest first) + the pending one, if any. */
   getReview(
     shortId: string,
@@ -185,10 +235,18 @@ export function createClient(opts: ClientOptions): DeriveClient {
     },
 
     async publish(args) {
-      const bytes =
-        typeof args.content === "string" ? new TextEncoder().encode(args.content) : args.content
       const form = new FormData()
-      form.append("file", new Blob([bytes as BlobPart]), args.filename)
+      if (args.edits) {
+        // Surgical revision: no file upload, the server materializes it from the
+        // current stored source. Requires an existing artifact (args.id).
+        form.append("edits", JSON.stringify(args.edits))
+        if (args.baseVersion != null) form.append("base_version", String(args.baseVersion))
+        if (args.filename) form.append("filename", args.filename)
+      } else {
+        const bytes =
+          typeof args.content === "string" ? new TextEncoder().encode(args.content) : args.content
+        form.append("file", new Blob([bytes as BlobPart]), args.filename ?? "index.html")
+      }
       if (args.title) form.append("title", args.title)
       if (args.slug) form.append("slug", args.slug)
       if (args.message) form.append("message", args.message)
@@ -205,11 +263,16 @@ export function createClient(opts: ClientOptions): DeriveClient {
 
     async propose(shortId, args) {
       const form = new FormData()
-      form.append(
-        "file",
-        new Blob([new TextEncoder().encode(args.content)]),
-        args.filename ?? "index.html",
-      )
+      if (args.edits) {
+        form.append("edits", JSON.stringify(args.edits))
+        if (args.baseVersion != null) form.append("base_version", String(args.baseVersion))
+      } else {
+        form.append(
+          "file",
+          new Blob([new TextEncoder().encode(args.content ?? "")]),
+          args.filename ?? "index.html",
+        )
+      }
       form.append("message", args.message)
       if (args.addresses?.length) form.append("addresses", args.addresses.join(","))
       return ok(
@@ -227,14 +290,44 @@ export function createClient(opts: ClientOptions): DeriveClient {
       ) as Promise<ArtifactJson>
     },
 
-    async getContent(shortId, version) {
-      const q = version ? `?v=${version}` : ""
-      const res = await f(`${base}/v1/artifacts/${shortId}/content${q}`, { headers: authHeaders })
+    async getContent(shortId, opts) {
+      const q = new URLSearchParams()
+      if (opts?.version) q.set("v", String(opts.version))
+      if (opts?.section) q.set("section", opts.section)
+      if (opts?.format) q.set("format", opts.format)
+      const qs = q.toString()
+      const res = await f(`${base}/v1/artifacts/${shortId}/content${qs ? `?${qs}` : ""}`, {
+        headers: authHeaders,
+      })
       if (!res.ok) {
         const body = (await res.json().catch(() => ({}))) as { error?: string }
         throw new Error(`derive ${res.status}: ${body.error ?? res.statusText}`)
       }
-      return res.text()
+      const format = res.headers.get("x-derive-format")
+      return {
+        text: await res.text(),
+        format,
+        section: res.headers.get("x-derive-section"),
+        sectionCount: res.headers.has("x-derive-sections")
+          ? Number(res.headers.get("x-derive-sections"))
+          : null,
+        // No X-Derive-Format header at all = a server that predates these params
+        // (an older self-hosted instance) — the caller should treat this as raw
+        // whole-artifact content and not assume format/section were honored.
+        supportsParams: format !== null,
+      }
+    },
+
+    async getOutline(shortId, version) {
+      const q = new URLSearchParams({ outline: "1" })
+      if (version) q.set("v", String(version))
+      const res = await f(`${base}/v1/artifacts/${shortId}/content?${q}`, { headers: authHeaders })
+      if (!res.ok) return { sections: [], pages: null }
+      const body = (await res.json()) as {
+        sections?: OutlineSectionJson[]
+        pages?: { path: string; type?: string }[]
+      }
+      return { sections: body.sections ?? [], pages: body.pages ?? null }
     },
 
     async listComments(shortId, state) {
@@ -265,10 +358,11 @@ export function createClient(opts: ClientOptions): DeriveClient {
       )
     },
 
-    async diff(shortId, from, to) {
+    async diff(shortId, from, to, content) {
       const q = new URLSearchParams({ format: "json" })
       if (from != null) q.set("from", String(from))
       if (to != null) q.set("to", String(to))
+      if (content === "markdown") q.set("content", "markdown")
       return ok(
         await f(`${base}/v1/artifacts/${shortId}/diff?${q}`, { headers: authHeaders }),
       ) as Promise<DiffJson>

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -102,6 +102,20 @@ const server = new McpServer({ name: "derive", version: "1.0.0" })
 
 const text = (s: string) => ({ content: [{ type: "text" as const, text: s }] })
 const json = (v: unknown) => text(JSON.stringify(v, null, 2))
+const err = (s: string) => ({
+  content: [{ type: "text" as const, text: s }],
+  isError: true as const,
+})
+
+// A content-bearing response: a frontmatter-style header, a blank line, then the
+// RAW body — never JSON-escaped (parity with the remote server's envelope).
+const doc = (meta: Record<string, string | number | null | undefined>, body: string) => {
+  const head = Object.entries(meta)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join("\n")
+  return text(`---\n${head}\n---\n\n${body}`)
+}
 
 // FIND ------------------------------------------------------------------------
 server.registerTool(
@@ -122,17 +136,72 @@ server.registerTool(
   "read",
   {
     description:
-      "Read an artifact's CONTENT by short id (a past `version` defaults to current). For what CHANGED or the comment threads, use catch_up instead.",
+      "Read an artifact's CONTENT by short id, as Markdown by default (HTML is converted). Omit `section` to see the outline first (heading slugs for a single-file doc, page paths for a bundle) — call again with a `section` (or \"*\" for the full document) once you know what you want. Pass `format:'html'` for the exact source (needed before publish `edits`), or a past `version` for history. For what CHANGED or the comment threads, use catch_up instead. (Older self-hosted servers that predate these params return the whole artifact regardless of section/format — noted in the response when that happens.)",
     inputSchema: {
       short_id: z.string(),
+      section: z
+        .string()
+        .optional()
+        .describe(
+          'A heading slug (single-file) or page path (bundle, optionally page#slug). Pass "*" for the full document.',
+        ),
+      format: z
+        .enum(["markdown", "text"])
+        .optional()
+        .describe("markdown (default, HTML converted) or text (flat visible text)."),
       version: z.number().int().optional().describe("Defaults to the current version."),
     },
   },
-  async ({ short_id, version }) => {
+  async ({ short_id, section, format, version }) => {
     const a = await client.get(short_id)
-    const body = await client.getContent(short_id, version)
     const v = version ?? a.current_version
-    return json({ short_id, title: a.title, kind: a.kind, version: v, content: body })
+
+    // No section: show the outline first (mirrors the remote server's
+    // outline-before-blind-dump behavior). Falls back to full content when the
+    // artifact has no headings/pages, or the server predates `?outline=1`.
+    if (!section) {
+      const outline = await client.getOutline(short_id, version)
+      if (outline.sections.length || outline.pages) {
+        return json({
+          short_id,
+          title: a.title,
+          kind: a.kind,
+          version: v,
+          ...(outline.sections.length ? { sections: outline.sections } : {}),
+          ...(outline.pages ? { pages: outline.pages } : {}),
+          next:
+            outline.sections.length || outline.pages?.length
+              ? 'Call read again with a `section` (a slug/page above), or section:"*" for the full document.'
+              : undefined,
+        })
+      }
+    }
+
+    try {
+      const result = await client.getContent(short_id, {
+        version,
+        section,
+        format: format ?? "markdown",
+      })
+      if (!result.supportsParams)
+        return doc(
+          { short_id, title: a.title, kind: a.kind, version: v },
+          `${result.text}\n\n[note: this server predates section/format params — returning the full raw artifact.]`,
+        )
+      return doc(
+        {
+          short_id,
+          title: a.title,
+          kind: a.kind,
+          version: v,
+          ...(result.format ? { format: result.format } : {}),
+          ...(result.section ? { section: result.section } : {}),
+        },
+        result.text,
+      )
+    } catch (e) {
+      return err(e instanceof Error ? e.message : "read failed")
+    }
   },
 )
 
@@ -143,7 +212,7 @@ server.registerTool(
     description:
       "START HERE on an artifact. Its state in one call: a summary, the review round, the versions since `since_version`, the open (and outdated) comment threads, and the full version history. " +
       "Pass `comments` (open / addressed / resolved / outdated) to instead get that filtered thread list — your feedback queue. " +
-      "Pass `response_format='detailed'` (optionally with `since_version`/`to_version`) to fold in the exact line diff between two versions. " +
+      "Pass `response_format='detailed'` (optionally with `since_version`/`to_version`) to fold in a line diff between two versions — of their readable Markdown form, not raw HTML. " +
       "WAITING ON A REVIEW? Pass `wait` (seconds, max 50) to block until the human sends back or approves — chain these instead of sleeping between polls.",
     inputSchema: {
       short_id: z.string(),
@@ -270,7 +339,9 @@ server.registerTool(
       : ""
     let entryDiff: string | undefined
     if (response_format === "detailed" && since < to) {
-      const d = await client.diff(short_id, since, to)
+      // Diff the readable Markdown form, not raw HTML — kills tag noise and
+      // avoids a minified one-line document producing one useless del/add pair.
+      const d = await client.diff(short_id, since, to, "markdown")
       entryDiff = d.ops
         .map((o) => `${o.t === "add" ? "+" : o.t === "del" ? "-" : " "} ${o.line}`)
         .join("\n")
@@ -399,9 +470,33 @@ server.registerTool(
   "publish",
   {
     description:
-      "Publish a single-file artifact and get a permanent URL. OMIT short_id to create a NEW artifact (title recommended); PASS short_id to publish a new version (same URL). Pass for_review:true to file it as a PROPOSAL a human approves instead of going live. Pass `addresses` with the thread ids this revision resolves. (Multi-page bundles are published via the web app or the remote /mcp server.)",
+      "Publish a single-file artifact and get a permanent URL. OMIT short_id to create a NEW artifact (title recommended); PASS short_id to publish a new version (same URL). To CHANGE PART of an existing artifact, prefer `edits` (exact-match search/replace against the stored source — read format:'html' first) over resending everything via `content`. Pass for_review:true to file it as a PROPOSAL a human approves instead of going live. Pass `addresses` with the thread ids this revision resolves. (Multi-page bundles are published via the web app or the remote /mcp server.)",
     inputSchema: {
-      content: z.string().describe("The artifact's text content (HTML or Markdown)."),
+      content: z
+        .string()
+        .optional()
+        .describe("The artifact's full text content (HTML or Markdown). Use this OR `edits`."),
+      edits: z
+        .array(
+          z.object({
+            old_str: z
+              .string()
+              .describe(
+                "Exact text from the STORED SOURCE (read format:'html' first on an HTML artifact). Must occur exactly once.",
+              ),
+            new_str: z.string().describe("Replacement text. Empty string deletes."),
+          }),
+        )
+        .optional()
+        .describe(
+          "Surgical revision without resending the artifact: exact-match search/replace against the current stored source, applied in order. Errors (applying nothing) if any old_str matches zero or multiple times. Requires `short_id`; use INSTEAD of `content`.",
+        ),
+      base_version: z
+        .number()
+        .optional()
+        .describe(
+          "Safety check for `edits`: pass the version you read; errors instead of applying if the artifact moved past it.",
+        ),
       filename: z
         .string()
         .optional()
@@ -433,6 +528,8 @@ server.registerTool(
   },
   async ({
     content,
+    edits,
+    base_version,
     filename,
     short_id,
     title,
@@ -442,32 +539,47 @@ server.registerTool(
     addresses,
     request_review,
   }) => {
+    if (content !== undefined && edits) return text("Provide `content` OR `edits`, not both.")
     if (for_review) {
       if (!short_id) return text("A proposal revises an EXISTING artifact — pass its short_id.")
-      const p = await client.propose(short_id, {
-        content,
-        filename,
-        message: message ?? "Proposed revision",
-        addresses,
-      })
-      const note = p.addressed?.length ? ` · addressed ${p.addressed.length} thread(s)` : ""
-      return json({
-        proposed: true,
-        proposal_id: p.id,
-        base_version: p.base_version,
-        note: `Submitted for review (not live)${note}.`,
-      })
+      try {
+        const p = await client.propose(short_id, {
+          content,
+          edits,
+          baseVersion: base_version,
+          filename,
+          message: message ?? "Proposed revision",
+          addresses,
+        })
+        const note = p.addressed?.length ? ` · addressed ${p.addressed.length} thread(s)` : ""
+        return json({
+          proposed: true,
+          proposal_id: p.id,
+          base_version: p.base_version,
+          note: `Submitted for review (not live)${note}.`,
+        })
+      } catch (e) {
+        return err(e instanceof Error ? e.message : "propose failed")
+      }
     }
-    const a = await client.publish({
-      id: short_id,
-      content,
-      filename: filename ?? "index.html",
-      title,
-      visibility,
-      message,
-      resolves: addresses,
-      requestReview: request_review,
-    })
+    if (edits && !short_id) return text("`edits` revises an EXISTING artifact — pass its short_id.")
+    let a: Awaited<ReturnType<typeof client.publish>>
+    try {
+      a = await client.publish({
+        id: short_id,
+        content,
+        edits,
+        baseVersion: base_version,
+        filename: filename ?? (edits ? undefined : "index.html"),
+        title,
+        visibility,
+        message,
+        resolves: addresses,
+        requestReview: request_review,
+      })
+    } catch (e) {
+      return err(e instanceof Error ? e.message : "publish failed")
+    }
     const note = addresses?.length ? ` · resolved ${addresses.length} thread(s)` : ""
     const openNote =
       a.opened_in_tab === false

--- a/packages/mcp/test/client.test.ts
+++ b/packages/mcp/test/client.test.ts
@@ -45,7 +45,7 @@ describe("derive client (the MCP server's backend) over real HTTP", () => {
     shortId = a.short_id
     expect(a.current_version).toBe(1)
     expect(a.kind).toBe("file")
-    expect(await client.getContent(shortId)).toBe("# Hello")
+    expect((await client.getContent(shortId)).text).toBe("# Hello")
   })
 
   it("publishes a new version and reads each version back", async () => {
@@ -56,8 +56,8 @@ describe("derive client (the MCP server's backend) over real HTTP", () => {
       message: "update",
     })
     expect(a.current_version).toBe(2)
-    expect(await client.getContent(shortId, 1)).toBe("# Hello")
-    expect(await client.getContent(shortId, 2)).toBe("# Hello v2")
+    expect((await client.getContent(shortId, { version: 1 })).text).toBe("# Hello")
+    expect((await client.getContent(shortId, { version: 2 })).text).toBe("# Hello v2")
   })
 
   it("lists version history with messages", async () => {
@@ -131,8 +131,8 @@ describe("derive client (the MCP server's backend) over real HTTP", () => {
     await client.publish({ id: a.short_id, content: "changed", filename: "r.md", message: "v2" })
     const restored = await client.restore(a.short_id, 1)
     expect(restored.current_version).toBe(3)
-    expect(await client.getContent(a.short_id)).toBe("original")
-    expect(await client.getContent(a.short_id, 1)).toBe("original") // history intact
+    expect((await client.getContent(a.short_id)).text).toBe("original")
+    expect((await client.getContent(a.short_id, { version: 1 })).text).toBe("original") // history intact
   })
 
   it("includes time-grouped sessions and version names on the detail endpoint", async () => {
@@ -165,7 +165,7 @@ describe("derive client (the MCP server's backend) over real HTTP", () => {
     expect(p.base_version).toBe(1)
     expect(p.addressed).toEqual([c.thread_id])
     // The live version is untouched — a proposal is not a publish.
-    expect(await client.getContent(a.short_id)).toBe("# headline")
+    expect((await client.getContent(a.short_id)).text).toBe("# headline")
 
     // No `addresses` (default filename) covers the other branch.
     const p2 = await client.propose(a.short_id, { content: "# again", message: "another pass" })
@@ -174,6 +174,95 @@ describe("derive client (the MCP server's backend) over real HTTP", () => {
 
   it("surfaces server errors as thrown messages", async () => {
     await expect(client.get("nope0000")).rejects.toThrow(/derive 404/)
+  })
+
+  it("getContent: format/section params round-trip, with capability headers", async () => {
+    const html =
+      "<html><head><style>x{color:red}</style></head><body><h1>Doc</h1><h2>Alpha</h2><p>a</p><h2>Beta</h2><p>b</p></body></html>"
+    const a = await client.publish({ content: html, filename: "fmt.html", title: "Fmt" })
+
+    const raw = await client.getContent(a.short_id)
+    expect(raw.text).toBe(html)
+    expect(raw.supportsParams).toBe(true)
+    expect(raw.format).toBe("raw")
+
+    const md = await client.getContent(a.short_id, { format: "markdown" })
+    expect(md.text).toContain("# Doc")
+    expect(md.text).not.toContain("color:red")
+    expect(md.format).toBe("markdown")
+
+    const sec = await client.getContent(a.short_id, { section: "alpha", format: "markdown" })
+    expect(sec.text).toContain("a")
+    expect(sec.text).not.toContain("Beta")
+    expect(sec.section).toBe("alpha")
+  })
+
+  it("getOutline: heading slugs for a single-file doc", async () => {
+    const a = await client.publish({
+      content: "<h1>Top</h1><h2>Alpha</h2><p>x</p><h2>Beta</h2><p>y</p>",
+      filename: "outline.html",
+      title: "Outline",
+    })
+    const outline = await client.getOutline(a.short_id)
+    expect(outline.sections.map((s) => s.slug)).toEqual(["top", "alpha", "beta"])
+    expect(outline.pages).toBeNull()
+  })
+
+  it("publish edits: materializes a revision without resending content", async () => {
+    const a = await client.publish({
+      content: "<h1>Title</h1><p>alpha beta gamma</p>",
+      filename: "edit.html",
+      title: "Editable",
+    })
+    const v2 = await client.publish({
+      id: a.short_id,
+      edits: [{ old_str: "beta", new_str: "BETA" }],
+    })
+    expect(v2.current_version).toBe(2)
+    expect((await client.getContent(a.short_id)).text).toContain("alpha BETA gamma")
+
+    // A stale base_version is rejected before anything applies.
+    await expect(
+      client.publish({
+        id: a.short_id,
+        edits: [{ old_str: "BETA", new_str: "nope" }],
+        baseVersion: 1,
+      }),
+    ).rejects.toThrow(/derive 409/)
+  })
+
+  it("propose edits: stages a proposal from materialized text, live version untouched", async () => {
+    const a = await client.publish({
+      content: "<h1>x</h1><p>keep this</p>",
+      filename: "pe.html",
+      title: "Propose Edits",
+    })
+    const p = await client.propose(a.short_id, {
+      edits: [{ old_str: "keep this", new_str: "changed this" }],
+      message: "tweak",
+    })
+    expect(p.id).toBeTruthy()
+    const live = await client.getContent(a.short_id)
+    expect(live.text).toContain("keep this")
+    expect(live.text).not.toContain("changed this")
+  })
+
+  it("diff: content=markdown diffs the readable form", async () => {
+    const a = await client.publish({
+      content:
+        "<html><head><style>x{color:red}</style></head><body><p>alpha bravo</p></body></html>",
+      filename: "diffmd.html",
+      title: "Diff MD",
+    })
+    await client.publish({
+      id: a.short_id,
+      content:
+        "<html><head><style>x{color:blue}</style></head><body><p>alpha BRAVO</p></body></html>",
+    })
+    const semantic = await client.diff(a.short_id, 1, 2, "markdown")
+    const text = semantic.ops.map((o) => o.line).join("\n")
+    expect(text).toContain("BRAVO")
+    expect(text).not.toContain("<style>")
   })
 })
 


### PR DESCRIPTION
## Summary

Derive's MCP tools are the primary way agents (Claude Code, claude.ai) read and revise living documents. A real session hit a concrete failure: `read` on a 67KB single-file HTML artifact returned a pretty-printed JSON envelope whose `content` field was one JSON-escaped string — a single 68,155-character line where every newline was a literal `\n`. It overflowed the client's tool-result limit into a spill file that line-based tools (grep, awk) couldn't navigate. Revising even one sentence required resending the entire document.

This PR makes every MCP tool token-cheap, navigable, and lossless for an AI caller, while keeping the five-tool vocabulary intact (`list_artifacts`, `read`, `catch_up`, `comment`, `publish` — every improvement is a parameter, no new tools).

- **`read`** now speaks Markdown by default (HTML converted, styling noise dropped), returns a heading **outline first** for large documents instead of a blind dump, and addresses content by **heading slug** (`section: "rollout-plan"`) or bundle **page path** (`page.html#slug`). `format:"html"` remains the byte-exact escape hatch. The response envelope is a frontmatter header + raw body — never JSON-escaped, so a client that spills it to a file gets something grep-able.
- **Images** in bundles come back as real MCP image content blocks instead of PNG bytes decoded as garbage text.
- **`publish`** gains `edits: [{old_str, new_str}]` — the same exact-match-or-error contract as the coding Edit tool — so a one-sentence fix costs tokens proportional to the change, not the document. `base_version` guards against editing a version you never saw.
- **`catch_up`**'s detailed diff is now semantic (diffs the Markdown conversion, not raw HTML), so a change shows up as the sentence that changed, not tag noise.
- **`/v1` REST routes** and the **stdio self-host server** (`packages/mcp`, bumped to 0.3.0) get full parity with the remote server.

## What's in each commit

1. `packages/core/src/doc-text.ts` (new) — dependency-free, Workers-safe HTML→Markdown converter, heading outline/slugger, section slicer, exact-match `applyEdits`
2. `read` rewrite: Markdown-by-default, outline-first, section addressing, frontmatter envelope
3. Bundle images → real MCP image content blocks
4. `publish` gains `edits`
5. `catch_up` semantic diff
6. `/v1` param parity + stdio server parity + docs (`SKILL.md`)
7. **Bugfix**: real-world testing against actual production Sift/Derive documents (not synthetic fixtures) surfaced a table-cell corruption bug and a missing common-entity gap in the converter — both fixed with regression tests
8. **Code review pass**: an 8-angle parallel review (correctness × 3, reuse, simplification, efficiency, altitude, conventions) of the full diff surfaced 14 verified findings; this commit fixes all of them — see commit message for the full list, headlined by:
   - A block-tag-in-table-cell corruption bug the earlier fix only partially covered (now a single dispatch-point guard that can't be circumvented by a future case)
   - Unclipped section reads that could return unbounded content past the size ceiling
   - The MCP `edits` path silently skipping the size/storage-quota check both REST routes already had — fixed by consolidating the previously-triplicated `edits` materialization logic (which had already drifted on error wording) into one shared helper
   - A bundle-asset content-type regression where a non-text asset (e.g. SVG) served with its native, unsandboxed type via the new `/content?section=` route — hardened to a safe-type allowlist

## Test plan

- [x] `pnpm typecheck` clean (Node + Workers tsconfig) at every commit
- [x] `pnpm check` (biome) + full `precommit` gate (design tokens, frontend conventions, testids, API error shape, schema, hyperdrive, filesize, anchor-client) clean
- [x] 312 core tests + 95 api test files + 19 mcp tests, all green — every fix in this PR has a dedicated regression test
- [x] Deep manual verification against **real** production Sift/Derive documents (not synthetic fixtures) driven over actual MCP JSON-RPC: the 67KB doc that motivated this PR, a dense internal doc with 19-row tables and inline code, and a real image bundle — outline generation, section isolation, `edits`, and the semantic diff all verified correct
- [x] Live E2E over real HTTP against a scratch local dev server (SQLite + FS blobs, no shared database touched): publish → outline → section read → `edits` → semantic diff, plus a real image round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)