### PR TITLE
fix(ci): 15s testTimeout for the pg lane — schema bootstrap crosses 5s on runners

### DIFF
--- a/scripts/test-pg.sh
+++ b/scripts/test-pg.sh
@@ -45,7 +45,11 @@ export TEST_DATABASE_URL="$URL"
 
 echo "→ running apps/api suite against Postgres"
 cd "$ROOT/apps/api"
-pnpm exec vitest run --no-file-parallelism "$@"
+# The first test in each file pays the Postgres schema bootstrap (DROP SCHEMA
+# CASCADE + full DDL replay via the helpers' deferred store) — on a CI runner
+# that alone can cross vitest's default 5s testTimeout as the schema grows.
+# Relax the timeout for this lane only; the SQLite lane keeps the 5s default.
+pnpm exec vitest run --no-file-parallelism --testTimeout=15000 "$@"
 
 # Also run @derive/db's store contract against the same Postgres — the only place
 # pg.ts (the hosted-tier driver) is covered + gated by the db package's own suite.


### PR DESCRIPTION
Unblocks the deploy that failed on [run 28953316907](https://github.com/derive-to/derive/actions/runs/28953316907).

## Diagnosis

The pg job failed with `Test timed out in 5000ms` on **the first test** of `workspace.test.ts`, `profiles.test.ts`, and the comments suite (the other two comment failures are cascades — the thread the later tests reply to was never created). Not a functional break: the same tests pass on the SQLite lane and pass against a real Postgres locally.

The first test in each file pays the helpers' Postgres bootstrap — `DROP SCHEMA CASCADE`, recreate, full DDL replay through the deferred-Proxy store — charged against vitest's default 5s `testTimeout`. That cost has grown with the schema and sat just under the line; #332's DDL additions (`render_job` table, preview columns + index) plus runner variance tipped it over.

## Fix

`--testTimeout=15000` on the vitest invocation in `scripts/test-pg.sh`, so it's scoped to the pg lane. The SQLite suite keeps the tight 5s default.

Verified locally: `pnpm test:pg` green.