### PR TITLE
Collection share v2: Invited/Workspace toggle, matching artifact ShareDialog

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -860,6 +860,24 @@
           "count": {
             "type": "number"
           },
+          "workspace_access": {
+            "type": "string",
+            "enum": [
+              "none",
+              "member"
+            ]
+          },
+          "my_role": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "viewer",
+              "commenter",
+              "editor",
+              "owner",
+              null
+            ]
+          },
           "kind": {
             "type": "string",
             "enum": [
@@ -3940,6 +3958,48 @@
         "responses": {
           "204": {
             "description": "The collection was deleted."
+          }
+        }
+      }
+    },
+    "/v1/collections/{id}/access": {
+      "patch": {
+        "tags": [
+          "Collections"
+        ],
+        "summary": "Change a collection's workspace access.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The new access.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "workspace_access": {
+                      "type": "string",
+                      "enum": [
+                        "none",
+                        "member"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "workspace_access"
+                  ]
+                }
+              }
+            }
           }
         }
       }

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -729,22 +729,29 @@ export function buildContext(deps: AppDeps) {
   }
 
   // A caller's role on a collection: the static token is owner; otherwise the
-  // creator, else their explicit collection-member role, else null (no access).
-  // Shared by the collections routes and the artifact listing (collection scoping).
+  // creator, else their explicit collection-member role, else — when the
+  // collection's own workspace_access is `member` — their workspace SEAT role,
+  // else null (no access). Shared by the collections routes and the artifact
+  // listing (collection scoping).
   const collectionRole = async (c: Context, col: CollectionRecord): Promise<Role | null> => {
     if (isToken(c)) return "owner"
     const me = await currentUser(c)
     if (!me) return null
     if (col.created_by === me.id) return "owner"
-    // A collection lives in a workspace, so its members reach it at their SEAT role —
-    // the team collaborates on the workspace's collections, not just their creator's
-    // (mirrors an artifact's workspace_access=member). An explicit collection share
-    // (which can cross workspaces) folds in alongside, higher wins. This governs who
-    // can view/manage the COLLECTION only; artifact access still propagates purely
-    // from explicit collection membership (collectionRolesForArtifact), so a seat here
-    // never hands out access to the artifacts inside.
+    // A collection lives in a workspace, so — same share experience as an
+    // artifact's workspace_access — its members reach it at their SEAT role when
+    // it's workspace-open; an invite-only collection (workspace_access=none)
+    // grants nothing from mere membership, matching Invited. An explicit
+    // collection share (which can cross workspaces) folds in alongside either
+    // way, higher wins. This governs who can view/manage the COLLECTION only;
+    // artifact access still propagates purely from explicit collection
+    // membership (collectionRolesForArtifact), so a seat here never hands out
+    // access to the artifacts inside.
     const explicit = (await meta.getCollectionMember(col.id, me.id))?.role ?? null
-    const seat = (await meta.getMembership(col.org_id, me.id))?.role ?? null
+    const seat =
+      col.workspace_access === "member"
+        ? ((await meta.getMembership(col.org_id, me.id))?.role ?? null)
+        : null
     return maxRole(explicit, seat)
   }
 

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -212,6 +212,8 @@ export const artifactRoutes = (ctx: AppContext) => {
       let collectionAccess = false
       // Carry the collection's title so the client can label the view even when the
       // collection lives in another workspace (it's absent from the local sidebar list).
+      // Only for a caller who actually has access — otherwise the title (and the fact
+      // this id resolves at all) leaks to anyone who can guess/pass a collectionId.
       let collectionInfo: { id: string; title: string } | undefined
       if (collectionId) {
         const col = await meta.getCollection(collectionId)
@@ -220,9 +222,12 @@ export const artifactRoutes = (ctx: AppContext) => {
         // its members into an id IN(): a large collection (hundreds of items) would blow
         // D1's 100-bound-parameter cap and 500 the whole listing.
         listOrg = col.org_id
-        collectionInfo = { id: col.id, title: col.title }
-        collectionAccess =
-          (await isMember(c, col.org_id)) || (await collectionRole(c, col)) !== null
+        // collectionRole is the single source of truth (it already folds in the workspace
+        // seat, conditionally on the collection's OWN workspace_access — see context.ts):
+        // plain isMember(org) would grant access to an Invited-only collection to every
+        // workspace member, defeating the toggle entirely.
+        collectionAccess = (await collectionRole(c, col)) !== null
+        if (collectionAccess) collectionInfo = { id: col.id, title: col.title }
       }
       // Author filter narrows to artifacts last changed by a GitHub login, scoped to the
       // listing's workspace (after collection scope has settled listOrg). Mirrors ?tag=.

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -45,6 +45,15 @@ export const collectionRoutes = (ctx: AppContext) => {
       created_by: z.string(),
       created_at: z.string(),
       count: z.number(),
+      /** The collection's own share experience — same vocabulary and dialog
+       *  pattern as an artifact's workspace_access, no link_role/listed (see
+       *  CollectionRecord.workspace_access). */
+      workspace_access: z.enum(["none", "member"]).optional(),
+      /** The caller's role on the collection itself (creator/explicit share/seat,
+       *  whichever's highest) — drives the Share dialog's manage-vs-read-only
+       *  split. Null if they can't see it at all (never returned in that case,
+       *  since the list already filters those out). */
+      my_role: z.enum(["viewer", "commenter", "editor", "owner"]).nullable().optional(),
       /** Where it came from: "repo" = a GitHub repo mirror, "pr" = a read-only PR preview
        *  nested under its repo, "manual" = user-created. */
       kind: z.enum(["manual", "repo", "pr"]).optional(),
@@ -73,7 +82,7 @@ export const collectionRoutes = (ctx: AppContext) => {
     return { srcByCollection, branchByRepo }
   }
   const enrich = (
-    col: CollectionRecord & { count: number },
+    col: CollectionRecord & { count: number; my_role: Role | null },
     srcByCollection: Map<string, Src>,
     branchByRepo: Map<string, string>,
   ) => {
@@ -119,7 +128,16 @@ export const collectionRoutes = (ctx: AppContext) => {
         meta.listRepoSources(org),
       ])
       const { srcByCollection, branchByRepo } = sourceMaps(sources)
-      return c.json({ collections: cols.map((col) => enrich(col, srcByCollection, branchByRepo)) })
+      // Same share experience as an artifact: an invite-only collection
+      // (workspace_access=none) only lists for its creator or an explicit
+      // collectionMember — collectionRole is the single source of truth for that,
+      // shared with the members endpoint's own visibility gate.
+      const roles = await Promise.all(cols.map((col) => collectionRole(c, col)))
+      const collections = cols
+        .map((col, i) => ({ col, role: roles[i] ?? null }))
+        .filter(({ role }) => role !== null)
+        .map(({ col, role }) => enrich({ ...col, my_role: role }, srcByCollection, branchByRepo))
+      return c.json({ collections })
     },
   )
 
@@ -151,6 +169,10 @@ export const collectionRoutes = (ctx: AppContext) => {
         org_id: await activeWorkspace(c),
         title,
         created_by: createdBy,
+        // Same factory default as an artifact: workspace-open. (Unlike an
+        // artifact, there's no per-org default to consult yet — collections are
+        // simpler, always workspace_access=member on create.)
+        workspace_access: "member",
       })
       // The creator joins as owner: they manage it, and (like any member) their
       // role propagates to the collection's artifacts.
@@ -162,7 +184,7 @@ export const collectionRoutes = (ctx: AppContext) => {
       })
       // A brand-new collection is empty (count 0) and user-created (manual) — return the
       // full shape so the client can drop it straight into its list without a refetch.
-      return c.json({ ...col, count: 0, kind: "manual" as const }, 201)
+      return c.json({ ...col, count: 0, my_role: "owner" as const, kind: "manual" as const }, 201)
     },
   )
 
@@ -192,12 +214,49 @@ export const collectionRoutes = (ctx: AppContext) => {
       if (!updated) return bail(fail(c, 404, "not found"))
       // Return the SAME enriched shape as the list, so every collection response is one
       // type. Count + origin are unchanged by a rename; re-derive them (rare op).
-      const [ids, sources] = await Promise.all([
+      const [ids, sources, role] = await Promise.all([
         meta.collectionArtifactIds(updated.id),
         meta.listRepoSources(updated.org_id),
+        collectionRole(c, updated),
       ])
       const { srcByCollection, branchByRepo } = sourceMaps(sources)
-      return c.json(enrich({ ...updated, count: ids.length }, srcByCollection, branchByRepo))
+      return c.json(
+        enrich({ ...updated, count: ids.length, my_role: role }, srcByCollection, branchByRepo),
+      )
+    },
+  )
+
+  // Change a collection's share experience — the Share dialog's Invited/Workspace
+  // toggle. Same one-question shape as an artifact's /access, minus link_role/
+  // listed (a collection isn't individually link-servable content, so its share
+  // dialog skips the Anyone segment — see access-model.md and the collection
+  // table's workspace_access comment). Applies immediately, no Save button.
+  app.openapi(
+    createRoute({
+      method: "patch",
+      path: "/v1/collections/{id}/access",
+      tags: ["Collections"],
+      summary: "Change a collection's workspace access.",
+      request: { params: z.object({ id: z.string() }) },
+      responses: {
+        200: {
+          description: "The new access.",
+          content: {
+            "application/json": {
+              schema: z.object({ workspace_access: z.enum(["none", "member"]) }),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const col = await meta.getCollection(c.req.param("id"))
+      if (!col) return bail(fail(c, 404, "not found"))
+      if (!(await canManageCollection(c, col, "manage"))) return bail(fail(c, 403, "forbidden"))
+      const b = await readJson(c, z.object({ workspaceAccess: z.enum(["none", "member"]) }))
+      if (b instanceof Response) return bail(b)
+      await meta.setCollectionAccess(col.id, b.workspaceAccess)
+      return c.json({ workspace_access: b.workspaceAccess })
     },
   )
 

--- a/apps/api/test/collection-access.test.ts
+++ b/apps/api/test/collection-access.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest"
+import { as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// A collection's own share experience (docs/plans/access-model.md, extended to
+// collections): workspace_access none|member, same Invited/Workspace toggle the
+// Share dialog exposes for artifacts. Companion to the seat-folding coverage in
+// collections.test.ts.
+
+const ana: TestUser = { id: "u_ca_ana", email: "ana@ca.test", name: "Ana" }
+const ben: TestUser = { id: "u_ca_ben", email: "ben@ca.test", name: "Ben" }
+const cara: TestUser = { id: "u_ca_cara", email: "cara@ca.test", name: "Cara" }
+
+describe("a collection's own workspace access", () => {
+  // ana is the Admin/owner of "default"; ben and cara are editors there
+  // (makeAuthedApp's default team seeding: users[0] = owner, the rest = defaultRole).
+  const { app, meta } = makeAuthedApp("ca", [ana, ben, cara], "editor")
+
+  const create = async (title: string, actor: Record<string, string>) => {
+    const r = await app.request("/v1/collections", jsonAs(actor, { title }))
+    return r.json()
+  }
+  const setAccess = (colId: string, workspaceAccess: string, actor: Record<string, string>) =>
+    app.request(`/v1/collections/${colId}/access`, {
+      ...jsonAs(actor, { workspaceAccess }),
+      method: "PATCH",
+    })
+
+  it("defaults to workspace-open; toggling to Invited hides it from plain members", async () => {
+    const col = await create("Team docs", as(ana.email))
+    expect(col.workspace_access).toBe("member")
+    expect(col.my_role).toBe("owner")
+
+    // Ben, a plain workspace editor with no explicit collectionMember row, sees
+    // it in the list and can open the roster — the seat-fold this PR builds on.
+    const listedForBen = await (
+      await app.request("/v1/collections", { headers: as(ben.email) })
+    ).json()
+    expect(listedForBen.collections.map((c: { id: string }) => c.id)).toContain(col.id)
+    expect(
+      (await app.request(`/v1/collections/${col.id}/members`, { headers: as(ben.email) })).status,
+    ).toBe(200)
+
+    // Ana (owner) flips it to Invited.
+    const flipped = await setAccess(col.id, "none", as(ana.email))
+    expect(flipped.status).toBe(200)
+    expect((await flipped.json()).workspace_access).toBe("none")
+
+    // Ben loses it entirely — not in the list, 404 on the roster — same as a
+    // stranger to a private artifact, not merely hidden-but-reachable.
+    const listedAfter = await (
+      await app.request("/v1/collections", { headers: as(ben.email) })
+    ).json()
+    expect(listedAfter.collections.map((c: { id: string }) => c.id)).not.toContain(col.id)
+    expect(
+      (await app.request(`/v1/collections/${col.id}/members`, { headers: as(ben.email) })).status,
+    ).toBe(404)
+
+    // Ana (the creator) still has it, and it still lists for her.
+    const listedForAna = await (
+      await app.request("/v1/collections", { headers: as(ana.email) })
+    ).json()
+    expect(listedForAna.collections.map((c: { id: string }) => c.id)).toContain(col.id)
+  })
+
+  it("an explicit share still reaches an Invited collection", async () => {
+    const col = await create("Invite only", as(ana.email))
+    await setAccess(col.id, "none", as(ana.email))
+    // Cara has no seat-fold now, but Ana adds her by hand.
+    expect(
+      (await app.request(`/v1/collections/${col.id}/members`, { headers: as(cara.email) })).status,
+    ).toBe(404)
+    await app.request(`/v1/collections/${col.id}/members`, {
+      ...jsonAs(as(ana.email), { user: cara.email, role: "viewer" }),
+      method: "PUT",
+    })
+    const seenByCara = await app.request(`/v1/collections/${col.id}/members`, {
+      headers: as(cara.email),
+    })
+    expect(seenByCara.status).toBe(200)
+    expect(
+      (await seenByCara.json()).members.find((m: { user_id: string }) => m.user_id === cara.id)
+        ?.role,
+    ).toBe("viewer")
+  })
+
+  it("only a manager can change the access — a plain editor can't widen or narrow it", async () => {
+    const col = await create("Ana's call", as(ana.email))
+    // Cara is a workspace editor (seat-folds to "editor" on the collection, per
+    // collectionRole) but that's below the "manage" bar this route gates on —
+    // same bar as delete/member add/remove.
+    expect((await setAccess(col.id, "none", as(cara.email))).status).toBe(403)
+    expect((await meta.getCollection(col.id))?.workspace_access).toBe("member")
+  })
+
+  // Regression: the /v1/artifacts feed's own collection-scoping check used to grant
+  // access from PLAIN workspace membership (`isMember(org)`), independent of the
+  // collection's own workspace_access — so toggling a collection to Invited hid it
+  // from the Collections list/dialog but the feed endpoint that actually lists its
+  // artifacts kept serving them (and the collection's title) to every workspace
+  // member regardless. Caught live: a seat-only member's browser tab, already
+  // sitting on the collection, kept rendering it after the toggle.
+  it("toggling to Invited also hides the collection's artifacts from the feed listing", async () => {
+    const col = await create("Roadmap", as(ana.email))
+    const { short_id } = await (
+      await publishAs(app, "<p>plans</p>", { title: "Q3 plan", listed: "workspace" }, as(ana.email))
+    ).json()
+    await app.request(`/v1/collections/${col.id}/items/${short_id}`, {
+      method: "PUT",
+      headers: as(ana.email),
+    })
+
+    // Ben (seat-folded editor, no explicit share) sees it while the collection is
+    // workspace-open — same feed a workspace member browses today.
+    const openFeed = await (
+      await app.request(`/v1/artifacts?collection=${col.id}`, { headers: as(ben.email) })
+    ).json()
+    expect(openFeed.artifacts.map((a: { short_id: string }) => a.short_id)).toEqual([short_id])
+    expect(openFeed.collection?.title).toBe("Roadmap")
+
+    await setAccess(col.id, "none", as(ana.email))
+
+    const invitedFeed = await (
+      await app.request(`/v1/artifacts?collection=${col.id}`, { headers: as(ben.email) })
+    ).json()
+    expect(invitedFeed.artifacts).toEqual([])
+    // The collection's title doesn't leak to a caller who no longer has a role on it.
+    expect(invitedFeed.collection).toBeUndefined()
+  })
+})

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -1959,6 +1959,47 @@ export interface paths {
         };
         trace?: never;
     };
+    "/v1/collections/{id}/access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Change a collection's workspace access. */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The new access. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            workspace_access: "none" | "member";
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/v1/collections/{id}/items/{shortId}": {
         parameters: {
             query?: never;
@@ -4692,6 +4733,10 @@ export interface components {
             created_by: string;
             created_at: string;
             count: number;
+            /** @enum {string} */
+            workspace_access?: "none" | "member";
+            /** @enum {string|null} */
+            my_role?: "viewer" | "commenter" | "editor" | "owner" | null;
             /** @enum {string} */
             kind?: "manual" | "repo" | "pr";
             parentId?: string;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -712,6 +712,13 @@ export const api = {
     f(`/v1/collections/${id}`, { ...opts({ title }), method: "PATCH" }).then(j),
   deleteCollection: (id: string): Promise<void> =>
     f(`/v1/collections/${id}`, { method: "DELETE", credentials: "include" }).then(() => undefined),
+  // Change a collection's share experience — the Share dialog's Invited/Workspace
+  // toggle. Same one-question shape as an artifact's setAccess, no link_role/listed.
+  setCollectionAccess: (
+    id: string,
+    workspaceAccess: WorkspaceAccess,
+  ): Promise<{ workspace_access: WorkspaceAccess }> =>
+    f(`/v1/collections/${id}/access`, { ...opts({ workspaceAccess }), method: "PATCH" }).then(j),
   addToCollection: (collectionId: string, shortId: string): Promise<void> =>
     f(`/v1/collections/${collectionId}/items/${shortId}`, { ...opts(), method: "PUT" }).then(
       () => undefined,

--- a/apps/web/src/components/shared/access-segment-toggle.tsx
+++ b/apps/web/src/components/shared/access-segment-toggle.tsx
@@ -1,0 +1,45 @@
+import { Icon, type IconName } from "@/components/icons"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+
+// The "who can open this" segmented control both the artifact ShareDialog and the
+// collection ShareDialog open with — same shape (a ToggleGroup of icon + label
+// segments, applies immediately, no Save), different segment lists (an artifact
+// adds Anyone; a collection stops at Invited/Workspace since it isn't
+// individually link-servable content). Pulled out so the two dialogs can't drift
+// on this shared piece — a style tweak here reaches both.
+export function AccessSegmentToggle<T extends string>({
+  segments,
+  value,
+  onChange,
+  disabled,
+  testId,
+}: {
+  segments: { value: T; label: string; icon: IconName }[]
+  value: T
+  onChange: (next: T) => void
+  disabled?: boolean
+  testId: string
+}) {
+  return (
+    <ToggleGroup
+      type="single"
+      value={value}
+      onValueChange={(v) => v && onChange(v as T)}
+      data-testid={testId}
+      className="w-full gap-[3px] rounded-lg bg-secondary p-[3px]"
+    >
+      {segments.map((s) => (
+        <ToggleGroupItem
+          key={s.value}
+          value={s.value}
+          disabled={disabled}
+          data-testid={`${testId}-${s.value}`}
+          className="h-8 flex-1 gap-1.5 rounded-md text-muted-foreground hover:bg-transparent hover:text-foreground data-[state=on]:bg-card data-[state=on]:text-foreground data-[state=on]:shadow-(--shadow-sm)"
+        >
+          <Icon name={s.icon} />
+          {s.label}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+  )
+}

--- a/apps/web/src/components/shared/person-search-input.tsx
+++ b/apps/web/src/components/shared/person-search-input.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useRef, useState } from "react"
+import { api, type PublicProfile } from "@/api"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Input } from "@/components/ui/input"
+import { getInitials } from "@/lib/initials"
+import { cn } from "@/lib/utils"
+
+// A GitHub-style @handle typeahead for "add a person by username or email":
+// debounced discoverable-people search, arrow-key highlight, Enter picks the
+// highlighted suggestion — or, with nothing highlighted, falls through to the
+// enclosing <form>'s submit (so a non-discoverable person stays addable by
+// typing their exact @handle/email and hitting Add/Enter). Render inside a
+// <form onSubmit={...}> and wire the Add button yourself; this owns only the
+// input + suggestion popover. Mirrors the artifact ShareDialog's own (hand-
+// rolled, duplicated) typeahead — extracted here so a third copy doesn't happen.
+export function PersonSearchInput({
+  value,
+  onChange,
+  placeholder = "Add people by @username or email…",
+  ariaLabel = "Username or email",
+  testId = "person-search",
+  className,
+}: {
+  value: string
+  onChange: (v: string) => void
+  placeholder?: string
+  ariaLabel?: string
+  /** Prefixes every data-testid/element id this renders — keep unique per surface. */
+  testId?: string
+  className?: string
+}) {
+  const [suggest, setSuggest] = useState<PublicProfile[]>([])
+  const [active, setActive] = useState(-1)
+  // The value we just picked, so the follow-up search for it doesn't reopen the menu.
+  const picked = useRef("")
+
+  useEffect(() => {
+    const term = value.trim()
+    if (!term || term === picked.current) {
+      setSuggest([])
+      return
+    }
+    let alive = true
+    const t = setTimeout(() => {
+      api
+        .searchPeople(term)
+        .then((r) => {
+          if (alive) {
+            setSuggest(r.users)
+            setActive(-1)
+          }
+        })
+        .catch(() => alive && setSuggest([]))
+    }, 180)
+    return () => {
+      alive = false
+      clearTimeout(t)
+    }
+  }, [value])
+
+  const pick = (u: PublicProfile) => {
+    picked.current = `@${u.username}`
+    onChange(`@${u.username}`)
+    setSuggest([])
+    setActive(-1)
+  }
+  // ↑/↓ to move, Enter to pick the highlighted suggestion, Esc to close the menu.
+  // With no highlight, Enter falls through to the form submit (free-text add).
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (suggest.length === 0) return
+    if (e.key === "ArrowDown") {
+      e.preventDefault()
+      setActive((i) => Math.min(i + 1, suggest.length - 1))
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault()
+      setActive((i) => Math.max(i - 1, -1))
+    } else if (e.key === "Enter" && active >= 0 && suggest[active]) {
+      e.preventDefault()
+      pick(suggest[active])
+    } else if (e.key === "Escape") {
+      e.preventDefault()
+      e.stopPropagation()
+      setSuggest([])
+    }
+  }
+
+  return (
+    <div className={cn("relative flex-1", className)}>
+      {/* WAI-APG combobox wiring: the input announces the popup and the
+          arrow-key highlight (aria-activedescendant). */}
+      <Input
+        data-testid={testId}
+        type="text"
+        autoCapitalize="none"
+        autoCorrect="off"
+        autoComplete="off"
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        role="combobox"
+        aria-expanded={suggest.length > 0}
+        aria-autocomplete="list"
+        aria-controls={`${testId}-list`}
+        aria-activedescendant={
+          active >= 0 && suggest[active] ? `${testId}-opt-${active}` : undefined
+        }
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        className="w-full"
+      />
+      {suggest.length > 0 && (
+        <div
+          data-testid={`${testId}-suggest`}
+          id={`${testId}-list`}
+          role="listbox"
+          aria-label="People suggestions"
+          className="absolute inset-x-0 top-[calc(100%+4px)] z-40 max-h-56 overflow-y-auto rounded-xl bg-popover p-1 shadow-[var(--shadow-pop)] ring-1 ring-foreground/10"
+        >
+          {suggest.map((u, i) => (
+            <button
+              key={u.username}
+              type="button"
+              data-testid={`${testId}-suggest-item`}
+              id={`${testId}-opt-${i}`}
+              role="option"
+              aria-selected={i === active}
+              // Keep the input focused so the click registers without blurring first.
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => pick(u)}
+              onMouseEnter={() => setActive(i)}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left outline-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring",
+                i === active ? "bg-accent" : "hover:bg-accent",
+              )}
+            >
+              <Avatar className="size-6">
+                {u.image && <AvatarImage src={u.image} alt={u.name ?? u.username} />}
+                <AvatarFallback>{getInitials(u.name ?? u.username)}</AvatarFallback>
+              </Avatar>
+              <span className="min-w-0 flex-1">
+                {u.name && (
+                  <span className="block truncate text-sm font-medium text-foreground">
+                    {u.name}
+                  </span>
+                )}
+                <span className="block truncate font-mono text-2xs text-muted-foreground">
+                  @{u.username}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
-import { useState } from "react"
+import { useRef, useState } from "react"
 import {
   API_BASE,
   type ArtifactDomain,
@@ -103,6 +103,12 @@ export function ShareButton({
   const [email, setEmail] = useState("")
   const [role, setRole] = useState<Role>("editor")
   const [busy, setBusy] = useState(false)
+  // A ref, not just the `busy` state: state updates are batched/async, so a burst
+  // of synchronous native submit events (Enter held down, or auto-repeating —
+  // see PersonSearchInput's documented submit-fallthrough) can all read the SAME
+  // stale `busy=false` closure before the first call's setBusy(true) re-renders.
+  // The ref flips synchronously, so only the first of a burst gets through.
+  const adding = useRef(false)
   const [err, setErr] = useState<string | null>(null)
   // Access draft: the three fields, plus the lock (password) state for the world link.
   const [wsAccess, setWsAccess] = useState<WorkspaceAccess>(workspaceAccess ?? "member")
@@ -299,8 +305,10 @@ export function ShareButton({
 
   const add = async (e: React.FormEvent) => {
     e.preventDefault()
+    if (adding.current) return
     const addr = email.trim()
     if (!addr) return
+    adding.current = true
     setBusy(true)
     setErr(null)
     try {
@@ -310,6 +318,7 @@ export function ShareButton({
     } catch (x) {
       setErr(x instanceof Error ? x.message : "Could not share")
     } finally {
+      adding.current = false
       setBusy(false)
     }
   }

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
-import { useEffect, useRef, useState } from "react"
+import { useState } from "react"
 import {
   API_BASE,
   type ArtifactDomain,
@@ -8,15 +8,16 @@ import {
   api,
   type LinkRole,
   type Listed,
-  type PublicProfile,
   type Role,
   type WorkspaceAccess,
 } from "@/api"
 import { Icon, type IconName } from "@/components/icons"
+import { AccessSegmentToggle } from "@/components/shared/access-segment-toggle"
+import { PersonSearchInput } from "@/components/shared/person-search-input"
 import { ROLE_LABELS, RoleSelect } from "@/components/shared/role-select"
 import { Eyebrow, SectionEyebrow } from "@/components/shared/section-eyebrow"
 import { Spinner } from "@/components/shared/spinner"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
@@ -35,11 +36,9 @@ import {
 } from "@/components/ui/select-menu"
 import { toast } from "@/components/ui/sonner"
 import { Switch } from "@/components/ui/switch"
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { useAuth } from "@/ctx"
 import { getInitials } from "@/lib/initials"
 import { artifactQuery, workspaceQuery } from "@/lib/queries"
-import { cn } from "@/lib/utils"
 
 // Access is ONE primary question — who can open this — projected from the v2
 // triple (workspace_access, link_role, listed; see access-model.md). Each segment
@@ -105,13 +104,6 @@ export function ShareButton({
   const [role, setRole] = useState<Role>("editor")
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
-  // GitHub-style handle typeahead for the add-person field. Suggestions come from
-  // the discoverable-people search (handle/name, never email); a non-discoverable
-  // user is still addable by typing their exact @handle/email and clicking Add.
-  const [suggest, setSuggest] = useState<PublicProfile[]>([])
-  const [active, setActive] = useState(-1)
-  // The value we just picked, so the follow-up search for it doesn't reopen the menu.
-  const picked = useRef("")
   // Access draft: the three fields, plus the lock (password) state for the world link.
   const [wsAccess, setWsAccess] = useState<WorkspaceAccess>(workspaceAccess ?? "member")
   const [lRole, setLRole] = useState<LinkRole>(linkRole ?? "none")
@@ -305,58 +297,6 @@ export function ShareButton({
     qc.invalidateQueries({ queryKey: ["artifacts"] })
   }
 
-  // Debounced people-search for the add field. Skip when empty or when the term is
-  // exactly what we just picked (so a pick doesn't immediately reopen the menu).
-  useEffect(() => {
-    const term = email.trim()
-    if (!term || term === picked.current) {
-      setSuggest([])
-      return
-    }
-    let alive = true
-    const t = setTimeout(() => {
-      api
-        .searchPeople(term)
-        .then((r) => {
-          if (alive) {
-            setSuggest(r.users)
-            setActive(-1)
-          }
-        })
-        .catch(() => alive && setSuggest([]))
-    }, 180)
-    return () => {
-      alive = false
-      clearTimeout(t)
-    }
-  }, [email])
-
-  const pick = (u: PublicProfile) => {
-    picked.current = `@${u.username}`
-    setEmail(`@${u.username}`)
-    setSuggest([])
-    setActive(-1)
-  }
-  // ↑/↓ to move, Enter to pick the highlighted suggestion, Esc to close the menu.
-  // With no highlight, Enter falls through to the form submit (free-text add).
-  const onAddKeyDown = (e: React.KeyboardEvent) => {
-    if (suggest.length === 0) return
-    if (e.key === "ArrowDown") {
-      e.preventDefault()
-      setActive((i) => Math.min(i + 1, suggest.length - 1))
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault()
-      setActive((i) => Math.max(i - 1, -1))
-    } else if (e.key === "Enter" && active >= 0 && suggest[active]) {
-      e.preventDefault()
-      pick(suggest[active])
-    } else if (e.key === "Escape") {
-      e.preventDefault()
-      e.stopPropagation()
-      setSuggest([])
-    }
-  }
-
   const add = async (e: React.FormEvent) => {
     e.preventDefault()
     const addr = email.trim()
@@ -366,8 +306,6 @@ export function ShareButton({
     try {
       await api.setMember(shortId, addr, role)
       setEmail("")
-      picked.current = ""
-      setSuggest([])
       await synced()
     } catch (x) {
       setErr(x instanceof Error ? x.message : "Could not share")
@@ -484,26 +422,13 @@ export function ShareButton({
               <div className="mt-2 flex flex-col">
                 {/* One primary choice — the widest reach. Each segment sets the
                     (workspace_access, link_role, listed) triple — see pickSegment. */}
-                <ToggleGroup
-                  type="single"
+                <AccessSegmentToggle
+                  segments={SEGMENTS}
                   value={segment}
-                  onValueChange={(v) => v && pickSegment(v as Segment)}
-                  data-testid="share-access"
-                  className="w-full gap-[3px] rounded-lg bg-secondary p-[3px]"
-                >
-                  {SEGMENTS.map((s) => (
-                    <ToggleGroupItem
-                      key={s.value}
-                      value={s.value}
-                      disabled={savingVis}
-                      data-testid={`share-access-${s.value}`}
-                      className="h-8 flex-1 gap-1.5 rounded-md text-muted-foreground hover:bg-transparent hover:text-foreground data-[state=on]:bg-card data-[state=on]:text-foreground data-[state=on]:shadow-(--shadow-sm)"
-                    >
-                      <Icon name={s.icon} />
-                      {s.label}
-                    </ToggleGroupItem>
-                  ))}
-                </ToggleGroup>
+                  onChange={pickSegment}
+                  disabled={savingVis}
+                  testId="share-access"
+                />
 
                 {segment === "invite" && (
                   <p className="mt-3 text-sm text-muted-foreground">
@@ -748,73 +673,12 @@ export function ShareButton({
             <div className="mt-3 flex flex-col gap-2">
               {canManage ? (
                 <form onSubmit={add} className="flex items-center gap-1.5">
-                  <div className="relative flex-1">
-                    {/* WAI-APG combobox wiring: the input announces the popup and the
-                    arrow-key highlight (aria-activedescendant). */}
-                    <Input
-                      data-testid="share-email"
-                      type="text"
-                      autoCapitalize="none"
-                      autoCorrect="off"
-                      autoComplete="off"
-                      placeholder="Add people by @username or email…"
-                      aria-label="Username or email"
-                      role="combobox"
-                      aria-expanded={suggest.length > 0}
-                      aria-autocomplete="list"
-                      aria-controls="share-suggest-list"
-                      aria-activedescendant={
-                        active >= 0 && suggest[active] ? `share-suggest-opt-${active}` : undefined
-                      }
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                      onKeyDown={onAddKeyDown}
-                      className="w-full"
-                    />
-                    {suggest.length > 0 && (
-                      <div
-                        data-testid="share-suggest"
-                        id="share-suggest-list"
-                        role="listbox"
-                        aria-label="People suggestions"
-                        className="absolute inset-x-0 top-[calc(100%+4px)] z-40 max-h-56 overflow-y-auto rounded-xl bg-popover p-1 shadow-[var(--shadow-pop)] ring-1 ring-foreground/10"
-                      >
-                        {suggest.map((u, i) => (
-                          <button
-                            key={u.username}
-                            type="button"
-                            data-testid="share-suggest-item"
-                            id={`share-suggest-opt-${i}`}
-                            role="option"
-                            aria-selected={i === active}
-                            // Keep the input focused so the click registers without blurring first.
-                            onMouseDown={(e) => e.preventDefault()}
-                            onClick={() => pick(u)}
-                            onMouseEnter={() => setActive(i)}
-                            className={cn(
-                              "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left outline-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring",
-                              i === active ? "bg-accent" : "hover:bg-accent",
-                            )}
-                          >
-                            <Avatar className="size-6">
-                              {u.image && <AvatarImage src={u.image} alt={u.name ?? u.username} />}
-                              <AvatarFallback>{getInitials(u.name ?? u.username)}</AvatarFallback>
-                            </Avatar>
-                            <span className="min-w-0 flex-1">
-                              {u.name && (
-                                <span className="block truncate text-sm font-medium text-foreground">
-                                  {u.name}
-                                </span>
-                              )}
-                              <span className="block truncate font-mono text-2xs text-muted-foreground">
-                                @{u.username}
-                              </span>
-                            </span>
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  </div>
+                  <PersonSearchInput
+                    value={email}
+                    onChange={setEmail}
+                    placeholder="Add people by @username or email…"
+                    testId="share-email"
+                  />
                   <div data-testid="share-role" className="w-28 shrink-0">
                     <RoleSelect
                       value={role}

--- a/apps/web/src/pages/library/share-collection-dialog.tsx
+++ b/apps/web/src/pages/library/share-collection-dialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 import { type ArtifactMember, api, type Collection, type Role, type WorkspaceAccess } from "@/api"
 import { Icon, type IconName } from "@/components/icons"
+import { AccessSegmentToggle } from "@/components/shared/access-segment-toggle"
 import { EmptyState } from "@/components/shared/empty-state"
 import { PersonSearchInput } from "@/components/shared/person-search-input"
 import { ROLE_LABELS, RoleSelect } from "@/components/shared/role-select"
@@ -15,7 +16,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { toast } from "@/components/ui/sonner"
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 
 // Same share experience as an artifact (docs/plans/access-model.md), minus the
 // Anyone segment — a collection isn't individually link-servable content, it's a
@@ -137,26 +137,13 @@ export function ShareCollectionDialog({
             </SectionEyebrow>
             {canManage ? (
               <div className="mt-2 flex flex-col">
-                <ToggleGroup
-                  type="single"
+                <AccessSegmentToggle
+                  segments={SEGMENTS}
                   value={wsAccess === "member" ? "workspace" : "invite"}
-                  onValueChange={(v) => v && applyAccess(v === "workspace" ? "member" : "none")}
-                  data-testid="collection-share-access"
-                  className="w-full gap-[3px] rounded-lg bg-secondary p-[3px]"
-                >
-                  {SEGMENTS.map((s) => (
-                    <ToggleGroupItem
-                      key={s.value}
-                      value={s.value}
-                      disabled={savingAccess}
-                      data-testid={`collection-share-access-${s.value}`}
-                      className="h-8 flex-1 gap-1.5 rounded-md text-muted-foreground hover:bg-transparent hover:text-foreground data-[state=on]:bg-card data-[state=on]:text-foreground data-[state=on]:shadow-(--shadow-sm)"
-                    >
-                      <Icon name={s.icon} />
-                      {s.label}
-                    </ToggleGroupItem>
-                  ))}
-                </ToggleGroup>
+                  onChange={(v) => applyAccess(v === "workspace" ? "member" : "none")}
+                  disabled={savingAccess}
+                  testId="collection-share-access"
+                />
                 {wsAccess === "none" ? (
                   <p className="mt-3 text-sm text-muted-foreground">
                     Only the people you add below can open this.

--- a/apps/web/src/pages/library/share-collection-dialog.tsx
+++ b/apps/web/src/pages/library/share-collection-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { type ArtifactMember, api, type Collection, type Role, type WorkspaceAccess } from "@/api"
 import { Icon, type IconName } from "@/components/icons"
 import { AccessSegmentToggle } from "@/components/shared/access-segment-toggle"
@@ -41,6 +41,12 @@ export function ShareCollectionDialog({
   const [email, setEmail] = useState("")
   const [role, setRole] = useState<Role>("editor")
   const [busy, setBusy] = useState(false)
+  // A ref, not just the `busy` state: state updates are batched/async, so a burst
+  // of synchronous native submit events (Enter held down, or auto-repeating —
+  // see PersonSearchInput's documented submit-fallthrough) can all read the SAME
+  // stale `busy=false` closure before the first call's setBusy(true) re-renders.
+  // The ref flips synchronously, so only the first of a burst gets through.
+  const adding = useRef(false)
   const [wsAccess, setWsAccess] = useState<WorkspaceAccess>(collection.workspace_access ?? "member")
   const [savingAccess, setSavingAccess] = useState(false)
 
@@ -81,8 +87,10 @@ export function ShareCollectionDialog({
 
   const add = async (e: React.FormEvent) => {
     e.preventDefault()
+    if (adding.current) return
     const addr = email.trim()
     if (!addr) return
+    adding.current = true
     setBusy(true)
     try {
       await api.setCollectionMember(collection.id, addr, role)
@@ -91,6 +99,7 @@ export function ShareCollectionDialog({
     } catch (x) {
       toast.error(x instanceof Error ? x.message : "Couldn't share")
     } finally {
+      adding.current = false
       setBusy(false)
     }
   }

--- a/apps/web/src/pages/library/share-collection-dialog.tsx
+++ b/apps/web/src/pages/library/share-collection-dialog.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useState } from "react"
-import { type ArtifactMember, api, type Collection, type Role } from "@/api"
-import { Icon } from "@/components/icons"
+import { type ArtifactMember, api, type Collection, type Role, type WorkspaceAccess } from "@/api"
+import { Icon, type IconName } from "@/components/icons"
 import { EmptyState } from "@/components/shared/empty-state"
-import { RoleSelect } from "@/components/shared/role-select"
+import { PersonSearchInput } from "@/components/shared/person-search-input"
+import { ROLE_LABELS, RoleSelect } from "@/components/shared/role-select"
+import { SectionEyebrow } from "@/components/shared/section-eyebrow"
+import { Spinner } from "@/components/shared/spinner"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -11,11 +14,22 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { Input } from "@/components/ui/input"
 import { toast } from "@/components/ui/sonner"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 
-// Share a collection: add people by email at a role. A member's role applies to
-// every artifact in the collection (the headline of collection-level sharing).
+// Same share experience as an artifact (docs/plans/access-model.md), minus the
+// Anyone segment — a collection isn't individually link-servable content, it's a
+// grouping of other artifacts, each with its own access. So just the one
+// question: invite-only, or does the workspace reach it at each member's seat?
+type Segment = "invite" | "workspace"
+const SEGMENTS: { value: Segment; label: string; icon: IconName }[] = [
+  { value: "invite", label: "Invited", icon: "lock" },
+  { value: "workspace", label: "Workspace", icon: "workspace" },
+]
+
+// Share a collection: who can open it at all (Invited vs Workspace, applies
+// immediately, no Save — mirrors the artifact ShareDialog), plus the people
+// roster whose role applies to every artifact inside it.
 export function ShareCollectionDialog({
   collection,
   onClose,
@@ -27,6 +41,15 @@ export function ShareCollectionDialog({
   const [email, setEmail] = useState("")
   const [role, setRole] = useState<Role>("editor")
   const [busy, setBusy] = useState(false)
+  const [wsAccess, setWsAccess] = useState<WorkspaceAccess>(collection.workspace_access ?? "member")
+  const [savingAccess, setSavingAccess] = useState(false)
+
+  // Unlike an artifact (editors can share — GDocs model), a collection's access
+  // and membership routes are owner-only on the backend (same bar as delete —
+  // pre-dates this dialog, see collections.ts's canManageCollection(..., "manage")
+  // calls). Match that here: an editor would otherwise see live-looking controls
+  // that 403 on every action.
+  const canManage = collection.my_role === "owner"
 
   const load = () => {
     api
@@ -39,6 +62,23 @@ export function ShareCollectionDialog({
     load()
   }, [collection.id])
 
+  // Applies immediately — a Save button between a toggle and its effect is
+  // friction with no safety benefit (same call the artifact dialog makes).
+  const applyAccess = async (next: WorkspaceAccess) => {
+    const prev = wsAccess
+    setWsAccess(next)
+    setSavingAccess(true)
+    try {
+      const r = await api.setCollectionAccess(collection.id, next)
+      setWsAccess(r.workspace_access)
+    } catch (x) {
+      setWsAccess(prev)
+      toast.error(x instanceof Error ? x.message : "Couldn't update access")
+    } finally {
+      setSavingAccess(false)
+    }
+  }
+
   const add = async (e: React.FormEvent) => {
     e.preventDefault()
     const addr = email.trim()
@@ -49,7 +89,7 @@ export function ShareCollectionDialog({
       setEmail("")
       load()
     } catch (x) {
-      toast.error((x as Error).message)
+      toast.error(x instanceof Error ? x.message : "Couldn't share")
     } finally {
       setBusy(false)
     }
@@ -62,6 +102,17 @@ export function ShareCollectionDialog({
     }
     load()
   }
+  // Re-role an existing member in place — setCollectionMember upserts server-side,
+  // so this is the same call the Add form makes, just keyed by their handle.
+  const change = async (m: ArtifactMember, next: Role) => {
+    if (next === m.role || !m.handle) return
+    try {
+      await api.setCollectionMember(collection.id, m.handle, next)
+    } catch (x) {
+      toast.error(x instanceof Error ? x.message : "Couldn't update their role")
+    }
+    load()
+  }
 
   return (
     <Dialog
@@ -70,70 +121,137 @@ export function ShareCollectionDialog({
         if (!o) onClose()
       }}
     >
-      <DialogContent>
+      <DialogContent aria-describedby={undefined}>
         <DialogHeader>
-          <DialogTitle>Share “{collection.title}”</DialogTitle>
+          <DialogTitle className="line-clamp-1 pr-6">Share “{collection.title}”</DialogTitle>
           <DialogDescription>
             People here get this role on{" "}
             <b className="font-medium text-foreground">every artifact</b> in the collection.
           </DialogDescription>
         </DialogHeader>
 
-        {/* DialogContent's grid gap spaces the sections — no child margins. */}
-        <form onSubmit={add} className="flex gap-1.5">
-          <Input
-            type="text"
-            autoCapitalize="none"
-            autoCorrect="off"
-            data-testid="collection-share-email"
-            placeholder="@username or email"
-            aria-label="Username or email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className="min-w-0 flex-1"
-          />
-          <RoleSelect
-            value={role}
-            onChange={setRole}
-            data-testid="collection-share-role"
-            className="w-26 shrink-0"
-          />
-          {/* Add is this dialog's one filled primary. */}
-          <Button variant="default" type="submit" data-testid="collection-share-add" loading={busy}>
-            {busy ? "Adding…" : "Add"}
-          </Button>
-        </form>
-
-        {members.length === 0 ? (
-          <EmptyState className="p-6">No one shared yet.</EmptyState>
-        ) : (
-          <div className="flex flex-col gap-1.5">
-            {members.map((m) => (
-              <div key={m.user_id} className="flex items-center gap-2">
-                <div className="min-w-0 flex-1">
-                  <div className="truncate text-sm font-medium text-foreground">
-                    {m.name ?? (m.handle ? `@${m.handle}` : m.user_id)}
-                  </div>
-                  {m.name && m.handle && (
-                    <div className="truncate font-mono text-2xs text-muted-foreground">
-                      @{m.handle}
-                    </div>
-                  )}
-                </div>
-                <span className="font-mono text-2xs text-muted-foreground">{m.role}</span>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  data-testid={`collection-share-remove-${m.user_id}`}
-                  onClick={() => remove(m)}
-                  aria-label={`Remove ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
+        <div className="flex flex-col gap-6">
+          <div>
+            <SectionEyebrow action={savingAccess && <Spinner className="size-3" />}>
+              Who can open this
+            </SectionEyebrow>
+            {canManage ? (
+              <div className="mt-2 flex flex-col">
+                <ToggleGroup
+                  type="single"
+                  value={wsAccess === "member" ? "workspace" : "invite"}
+                  onValueChange={(v) => v && applyAccess(v === "workspace" ? "member" : "none")}
+                  data-testid="collection-share-access"
+                  className="w-full gap-[3px] rounded-lg bg-secondary p-[3px]"
                 >
-                  <Icon name="close" />
-                </Button>
+                  {SEGMENTS.map((s) => (
+                    <ToggleGroupItem
+                      key={s.value}
+                      value={s.value}
+                      disabled={savingAccess}
+                      data-testid={`collection-share-access-${s.value}`}
+                      className="h-8 flex-1 gap-1.5 rounded-md text-muted-foreground hover:bg-transparent hover:text-foreground data-[state=on]:bg-card data-[state=on]:text-foreground data-[state=on]:shadow-(--shadow-sm)"
+                    >
+                      <Icon name={s.icon} />
+                      {s.label}
+                    </ToggleGroupItem>
+                  ))}
+                </ToggleGroup>
+                {wsAccess === "none" ? (
+                  <p className="mt-3 text-sm text-muted-foreground">
+                    Only the people you add below can open this.
+                  </p>
+                ) : (
+                  <p className="mt-3 text-sm text-muted-foreground">
+                    Everyone in the workspace opens this at their role — admins manage, editors
+                    edit, commenters comment.
+                  </p>
+                )}
               </div>
-            ))}
+            ) : (
+              <p className="mt-2 text-sm text-muted-foreground">
+                {wsAccess === "member"
+                  ? "Everyone in the workspace can open this."
+                  : "Only people added below can open this."}
+              </p>
+            )}
           </div>
-        )}
+
+          <div>
+            <SectionEyebrow>People with access</SectionEyebrow>
+            {canManage && (
+              <form onSubmit={add} className="mt-2 flex gap-1.5">
+                <PersonSearchInput
+                  value={email}
+                  onChange={setEmail}
+                  placeholder="@username or email"
+                  testId="collection-share-email"
+                  className="min-w-0"
+                />
+                <RoleSelect
+                  value={role}
+                  onChange={setRole}
+                  data-testid="collection-share-role"
+                  className="w-28 shrink-0"
+                />
+                {/* Add is this dialog's one filled primary. */}
+                <Button
+                  variant="default"
+                  type="submit"
+                  data-testid="collection-share-add"
+                  loading={busy}
+                >
+                  {busy ? "Adding…" : "Add"}
+                </Button>
+              </form>
+            )}
+
+            {members.length === 0 ? (
+              <EmptyState className="mt-2 p-6">No one shared yet.</EmptyState>
+            ) : (
+              <div className="mt-2 flex flex-col gap-1.5">
+                {members.map((m) => (
+                  <div key={m.user_id} className="flex items-center gap-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium text-foreground">
+                        {m.name ?? (m.handle ? `@${m.handle}` : m.user_id)}
+                      </div>
+                      {m.name && m.handle && (
+                        <div className="truncate font-mono text-2xs text-muted-foreground">
+                          @{m.handle}
+                        </div>
+                      )}
+                    </div>
+                    {canManage ? (
+                      <>
+                        <RoleSelect
+                          value={m.role}
+                          onChange={(next) => change(m, next)}
+                          data-testid={`collection-share-member-role-${m.user_id}`}
+                          aria-label={`Role for ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
+                          className="w-28 shrink-0"
+                        />
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          data-testid={`collection-share-remove-${m.user_id}`}
+                          onClick={() => remove(m)}
+                          aria-label={`Remove ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
+                        >
+                          <Icon name="close" />
+                        </Button>
+                      </>
+                    ) : (
+                      <span className="shrink-0 text-sm text-muted-foreground">
+                        {ROLE_LABELS[m.role]}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
       </DialogContent>
     </Dialog>
   )

--- a/apps/web/src/pages/library/share-collection-dialog.tsx
+++ b/apps/web/src/pages/library/share-collection-dialog.tsx
@@ -227,15 +227,23 @@ export function ShareCollectionDialog({
                           aria-label={`Role for ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
                           className="w-28 shrink-0"
                         />
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          data-testid={`collection-share-remove-${m.user_id}`}
-                          onClick={() => remove(m)}
-                          aria-label={`Remove ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
-                        >
-                          <Icon name="close" />
-                        </Button>
+                        {/* The creator's own row is fixed — unlike an artifact's
+                            "last owner" member row, a collection's creator is
+                            permanently owner via created_by regardless of member
+                            rows (collectionRole checks it first), so removing this
+                            row wouldn't revoke access — it would just make them
+                            vanish from their own roster. Nothing to offer. */}
+                        {m.user_id !== collection.created_by && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            data-testid={`collection-share-remove-${m.user_id}`}
+                            onClick={() => remove(m)}
+                            aria-label={`Remove ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
+                          >
+                            <Icon name="close" />
+                          </Button>
+                        )}
                       </>
                     ) : (
                       <span className="shrink-0 text-sm text-muted-foreground">

--- a/apps/web/src/pages/settings/members-section.tsx
+++ b/apps/web/src/pages/settings/members-section.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { useState } from "react"
+import { useRef, useState } from "react"
 import { type ArtifactMember, api, type Role } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { PersonSearchInput } from "@/components/shared/person-search-input"
@@ -30,14 +30,22 @@ export function MembersSection({ meId }: { meId: string }) {
   const [email, setEmail] = useState("")
   const [addRole, setAddRole] = useState<Role>("commenter")
   const [adding, setAdding] = useState(false)
+  // A ref, not just the `adding` state: state updates are batched/async, so a
+  // burst of synchronous native submit events (Enter held down, or auto-
+  // repeating — see PersonSearchInput's documented submit-fallthrough) can all
+  // read the SAME stale `false` closure before the first call's setAdding(true)
+  // re-renders. The ref flips synchronously, so only the first gets through.
+  const addingRef = useRef(false)
   const [removing, setRemoving] = useState<ArtifactMember | null>(null)
 
   const isAdmin = ws?.role === "owner"
 
   const addMember = async (e: React.FormEvent) => {
     e.preventDefault()
+    if (addingRef.current) return
     const em = email.trim()
     if (!em) return
+    addingRef.current = true
     setAdding(true)
     try {
       const r = await api.inviteToWorkspace(em, addRole)
@@ -55,6 +63,7 @@ export function MembersSection({ meId }: { meId: string }) {
     } catch (e) {
       toast.error((e as Error).message)
     } finally {
+      addingRef.current = false
       setAdding(false)
     }
   }

--- a/apps/web/src/pages/settings/members-section.tsx
+++ b/apps/web/src/pages/settings/members-section.tsx
@@ -1,12 +1,12 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { useEffect, useRef, useState } from "react"
-import { type ArtifactMember, api, type PublicProfile, type Role } from "@/api"
+import { useState } from "react"
+import { type ArtifactMember, api, type Role } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
+import { PersonSearchInput } from "@/components/shared/person-search-input"
 import { SettingsGroup } from "@/components/shared/settings-group"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import {
   Select,
   SelectContent,
@@ -17,7 +17,6 @@ import {
 import { toast } from "@/components/ui/sonner"
 import { getInitials } from "@/lib/initials"
 import { workspaceInvitesQuery, workspaceQuery } from "@/lib/queries"
-import { cn } from "@/lib/utils"
 import { roleLabel, roleValue, WS_ROLES } from "./roles"
 import { SettingsListSkeleton } from "./settings-list-skeleton"
 import { SettingsSection } from "./settings-section"
@@ -31,83 +30,18 @@ export function MembersSection({ meId }: { meId: string }) {
   const [email, setEmail] = useState("")
   const [addRole, setAddRole] = useState<Role>("commenter")
   const [adding, setAdding] = useState(false)
-  // Discoverable-people typeahead for the add field — find teammates by @handle
-  // or name (only those who left people-search on). Free-text (a full email for
-  // someone not discoverable) still works via the Add button.
-  const [suggest, setSuggest] = useState<PublicProfile[]>([])
-  const [active, setActive] = useState(-1)
-  const picked = useRef("")
   const [removing, setRemoving] = useState<ArtifactMember | null>(null)
 
   const isAdmin = ws?.role === "owner"
 
-  // Debounced people-search; skip when empty or when the term is exactly what we
-  // just picked (so a pick doesn't immediately reopen the menu).
-  useEffect(() => {
-    const term = email.trim()
-    if (!term || term === picked.current) {
-      setSuggest([])
-      return
-    }
-    let alive = true
-    const t = setTimeout(() => {
-      api
-        .searchPeople(term)
-        .then((r) => {
-          if (!alive) return
-          setSuggest(r.users)
-          setActive(-1)
-        })
-        .catch(() => {
-          if (alive) setSuggest([])
-        })
-    }, 180)
-    return () => {
-      alive = false
-      clearTimeout(t)
-    }
-  }, [email])
-
-  const pick = (u: PublicProfile) => {
-    picked.current = `@${u.username}`
-    setEmail(`@${u.username}`)
-    setSuggest([])
-    setActive(-1)
-  }
-
-  // ↑/↓ to move, Enter to pick the highlighted suggestion, Esc to close. With no
-  // highlight, Enter falls through to the free-text add.
-  const onAddKeyDown = (e: React.KeyboardEvent) => {
-    if (suggest.length === 0) {
-      if (e.key === "Enter") addMember()
-      return
-    }
-    if (e.key === "ArrowDown") {
-      e.preventDefault()
-      setActive((i) => Math.min(i + 1, suggest.length - 1))
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault()
-      setActive((i) => Math.max(i - 1, -1))
-    } else if (e.key === "Enter" && active >= 0 && suggest[active]) {
-      e.preventDefault()
-      pick(suggest[active])
-    } else if (e.key === "Enter") {
-      addMember()
-    } else if (e.key === "Escape") {
-      e.preventDefault()
-      setSuggest([])
-      setActive(-1)
-    }
-  }
-
-  const addMember = async () => {
+  const addMember = async (e: React.FormEvent) => {
+    e.preventDefault()
     const em = email.trim()
     if (!em) return
     setAdding(true)
     try {
       const r = await api.inviteToWorkspace(em, addRole)
       setEmail("")
-      setSuggest([])
       if (r.kind === "member") {
         toast.success("Member added")
         qc.invalidateQueries({ queryKey: workspaceQuery().queryKey })
@@ -158,58 +92,15 @@ export function MembersSection({ meId }: { meId: string }) {
       description="Who's in this workspace and what they can do. Admins add people, Creators publish artifacts, Viewers read and comment."
     >
       {isAdmin && (
-        <div className="flex flex-wrap gap-2">
-          <div className="relative min-w-50 flex-1">
-            <Input
-              data-testid="member-email"
-              autoCapitalize="none"
-              autoCorrect="off"
-              autoComplete="off"
-              aria-label="Username of a Derive user, or an email to invite"
-              placeholder="@username or email to invite"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              onKeyDown={onAddKeyDown}
-              className="w-full"
-            />
-            {suggest.length > 0 && (
-              <div
-                data-testid="member-suggest"
-                className="absolute inset-x-0 top-[calc(100%+4px)] z-40 max-h-56 overflow-y-auto rounded-xl bg-popover p-1 shadow-[var(--shadow-pop)] ring-1 ring-foreground/10"
-              >
-                {suggest.map((u, i) => (
-                  <button
-                    key={u.username}
-                    type="button"
-                    data-testid="member-suggest-item"
-                    onMouseDown={(e) => e.preventDefault()}
-                    onClick={() => pick(u)}
-                    onMouseEnter={() => setActive(i)}
-                    className={cn(
-                      "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left outline-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring",
-                      i === active && "bg-accent",
-                    )}
-                  >
-                    <Avatar className="size-6">
-                      {u.image && <AvatarImage src={u.image} alt={u.name ?? u.username} />}
-                      <AvatarFallback>{getInitials(u.name ?? u.username)}</AvatarFallback>
-                    </Avatar>
-                    <span className="min-w-0 flex-1">
-                      {u.name && (
-                        <span className="block truncate text-sm font-medium text-foreground">
-                          {u.name}
-                        </span>
-                      )}
-                      <span className="block truncate font-mono text-2xs text-muted-foreground">
-                        @{u.username}
-                        {u.profession ? ` · ${u.profession}` : ""}
-                      </span>
-                    </span>
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
+        <form onSubmit={addMember} className="flex flex-wrap gap-2">
+          <PersonSearchInput
+            value={email}
+            onChange={setEmail}
+            placeholder="@username or email to invite"
+            ariaLabel="Username of a Derive user, or an email to invite"
+            testId="member-email"
+            className="min-w-50"
+          />
           <Select value={addRole} onValueChange={(v) => setAddRole(v as Role)}>
             <SelectTrigger
               data-testid="member-role"
@@ -228,15 +119,15 @@ export function MembersSection({ meId }: { meId: string }) {
           </Select>
           <Button
             data-testid="member-add"
+            type="submit"
             variant="secondary"
             size="sm"
-            onClick={addMember}
             loading={adding}
             disabled={adding || !email.trim()}
           >
             {adding ? "Adding…" : "Add"}
           </Button>
-        </div>
+        </form>
       )}
 
       {!ws ? (

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -231,7 +231,8 @@ CREATE TABLE IF NOT EXISTS collection (
   org_id TEXT NOT NULL DEFAULT 'local',
   title TEXT NOT NULL,
   created_by TEXT NOT NULL,
-  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  workspace_access TEXT NOT NULL DEFAULT 'member'
 );
 
 CREATE TABLE IF NOT EXISTS collection_item (

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -470,6 +470,8 @@ export interface CollectionStore {
    *  ids ⇒ []. Use this over a per-id getCollection loop. */
   getCollections(ids: string[]): Promise<CollectionRecord[]>
   updateCollection(id: string, fields: { title?: string }): Promise<CollectionRecord | null>
+  /** Change a collection's share experience (see CollectionRecord.workspace_access). */
+  setCollectionAccess(id: string, workspaceAccess: WorkspaceAccess): Promise<void>
   /** Remove a collection and its items + member rows. */
   deleteCollection(id: string): Promise<void>
   /** Collections with their item counts, newest first; scoped to a workspace when orgId is given. */
@@ -1336,12 +1338,20 @@ export interface CollectionRecord {
   title: string
   created_by: string
   created_at: string
+  /** The collection's own share experience — same vocabulary as an artifact's
+   *  workspace_access, no link_role/listed (a collection isn't individually
+   *  link-servable content). `member` = every workspace member reaches it at
+   *  their seat role; `none` = invite-only (collectionMember rows only). */
+  workspace_access: WorkspaceAccess
 }
 export interface NewCollection {
   id: string
   org_id: string
   title: string
   created_by: string
+  /** Omitted falls to the store's column default (`member`, unlike an artifact's
+   *  fail-closed `none` — see CollectionRecord.workspace_access). */
+  workspace_access?: WorkspaceAccess
 }
 export interface DomainRecord {
   host: string

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -324,6 +324,9 @@ export const collection = pgTable("collection", {
   title: text("title").notNull(),
   created_by: text("created_by").notNull(),
   created_at: text("created_at").notNull().$defaultFn(isoNow),
+  // See the sqlite dialect's schema.ts for the full comment. Defaults to `member`
+  // (not artifact's fail-closed `none`) to match collections' existing behavior.
+  workspace_access: text("workspace_access").$type<WorkspaceAccess>().notNull().default("member"),
 })
 export const collectionItem = pgTable(
   "collection_item",

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1237,6 +1237,12 @@ export class PgMetaStore implements MetaStore {
       .returning()
     return rows[0] ?? null
   }
+  async setCollectionAccess(id: string, workspaceAccess: WorkspaceAccess): Promise<void> {
+    await this.db
+      .update(collection)
+      .set({ workspace_access: workspaceAccess })
+      .where(eq(collection.id, id))
+  }
   async deleteCollection(id: string): Promise<void> {
     await this.db.transaction(async (tx) => {
       await tx.delete(collectionItem).where(eq(collectionItem.collection_id, id))

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -1370,6 +1370,16 @@ export function makeRepos(db: SqliteDb) {
         .get()) ?? null
     )
   }
+  const setCollectionAccess = async (
+    id: string,
+    workspaceAccess: WorkspaceAccess,
+  ): Promise<void> => {
+    await db
+      .update(collection)
+      .set({ workspace_access: workspaceAccess })
+      .where(eq(collection.id, id))
+      .run()
+  }
   // Sequential cascade (used by D1). better-sqlite3 overrides with a transaction.
   const deleteCollection = async (id: string): Promise<void> => {
     await db.delete(collectionItem).where(eq(collectionItem.collection_id, id)).run()
@@ -2372,6 +2382,7 @@ export function makeRepos(db: SqliteDb) {
     getCollection,
     getCollections,
     updateCollection,
+    setCollectionAccess,
     deleteCollection,
     listCollections,
     collectionArtifactIds,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -363,6 +363,15 @@ export const collection = sqliteTable("collection", {
   title: text("title").notNull(),
   created_by: text("created_by").notNull(),
   created_at: text("created_at").notNull().default(now),
+  // Same share experience as an artifact's workspace_access, minus link_role/listed —
+  // a collection is a grouping of other artifacts, each with its own access, not
+  // individually link-servable content (see access-model.md). `member` = every
+  // workspace member reaches it at their seat role; `none` = invite-only
+  // (collectionMember rows only). Defaults to `member` (not artifact's fail-closed
+  // `none`) because that's collections' existing behavior today — collectionRole
+  // already folds in the caller's seat unconditionally, so an ADD COLUMN migration
+  // defaulting every existing row to `member` changes nothing for anyone.
+  workspace_access: text("workspace_access").$type<WorkspaceAccess>().notNull().default("member"),
 })
 
 export const collectionItem = sqliteTable(


### PR DESCRIPTION
## Summary
- Collections get their own `workspace_access` (`member`|`none`), toggled from a Share dialog that matches the artifact ShareDialog's segmented Invited/Workspace UX from #336 — minus the world-link segment, since a collection isn't individually link-servable content.
- `collectionRole` now folds in the caller's workspace seat only when the collection is workspace-open; an explicit collection share still reaches an Invited collection either way.
- Supersedes the `collectionWorkspaceShare`-table approach from #319, which v2's unconditional seat-folding made redundant.

Two real bugs turned up while verifying the new dialog live in a browser (screenshots, not just unit tests):
- The dialog showed manage controls (toggle, add-person, role edit) to any editor, but collections' access/member routes are owner-only server-side (unlike artifacts, where editors can share). `canManage` is now owner-only to match.
- `GET /v1/artifacts?collection=` computed collection access as `isMember(workspace) OR collectionRole`, so any workspace member could still read an Invited-only collection's title and artifact listing through the feed endpoint regardless of the toggle — silently defeating the whole feature for that endpoint. Fixed to rely on `collectionRole` alone.

## Test plan
- [x] `pnpm typecheck && pnpm lint` clean
- [x] `pnpm test` — 809 tests (SQLite)
- [x] `scripts/test-pg.sh` — full API suite + db-package contract tests against ephemeral Postgres
- [x] Live browser verification: created a collection, toggled Invited/Workspace, searched/added/removed a member, edited a role in place, confirmed a revoked member gets a genuine 404 (not merely hidden) on both the collection and its feed listing
- [x] New regression test (`apps/api/test/collection-access.test.ts`) covering the feed-endpoint leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)