### PR TITLE
fix(mcp): 0.4.1 — republish with a resolved cli dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once it reache
   `CODE_OF_CONDUCT.md`, issue + PR templates, `.editorconfig`.
 
 ### Fixed
+- `@derive-to/mcp` 0.4.1 — republish with the `@derive-to/cli` dependency resolved to
+  a real version. 0.4.0 shipped it as the raw `workspace:*` protocol (published with
+  `npm` instead of `pnpm`), which is uninstallable; 0.4.0 is deprecated.
 - `derive init` no longer hardcodes `visibility: private` into the scaffolded
   `derive.json` — it now inherits the workspace's team-draft default (workspace
   access at seat role, not listed), so a scaffolded project's first publish is

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@derive-to/mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "Stdio MCP server for Derive — list, read, catch up on, comment on, and publish artifacts on a Derive instance.",
   "keywords": [


### PR DESCRIPTION
`@derive-to/mcp@0.4.0` was published with `npm publish` from the pnpm monorepo, so its `@derive-to/cli` dependency shipped as the raw `workspace:*` protocol:

\`\`\`
$ npm view @derive-to/mcp@0.4.0 dependencies
{ '@derive-to/cli': 'workspace:*', ... }
\`\`\`

That's uninstallable — `npx @derive-to/mcp` / `npm i @derive-to/mcp` fail with `Unsupported URL Type "workspace:"`. (`@derive-to/cli@0.3.0` is fine — no workspace deps.)

Bump to **0.4.1** and republish **with `pnpm publish`**, which rewrites `workspace:*` → the real version (verified via `pnpm pack`: `"@derive-to/cli": "0.3.0"`). Then deprecate 0.4.0.

No code change — version bump + changelog only.