### PR TITLE
fix(ci): knip false-positive on openapi-typescript

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -6,7 +6,8 @@
       "ignoreDependencies": ["cloudflare"]
     },
     "apps/web": {
-      "entry": ["src/components/ui/**", "e2e/**/*.screens.ts"]
+      "entry": ["src/components/ui/**", "e2e/**/*.screens.ts"],
+      "ignoreDependencies": ["openapi-typescript"]
     },
     "packages/core": {
       "entry": ["src/anchor-client.ts"]


### PR DESCRIPTION
`pnpm run ci` is red on main: knip flags `openapi-typescript` (apps/web) as an unused devDependency, but it's the `gen:api-types` script binary from #331 — this config has `binaries: off`, so script-only usage isn't traced. Added to `ignoreDependencies`, the same treatment `cloudflare` gets. knip exits 0 after.