### PR TITLE
fix(deploy): Hetzner cutover findings — cache-volume ownership + work-dir env

### DIFF
--- a/deploy/runner.Dockerfile
+++ b/deploy/runner.Dockerfile
@@ -37,7 +37,14 @@ RUN cd /opt/derive-cli && npm install --omit=dev && npm install -g /opt/derive-c
 
 # Non-root: the container is the boundary, but the model still runs with
 # --dangerously-skip-permissions inside it — no reason for that to be root.
-RUN useradd -m runner && mkdir -p /work && chown runner:runner /work
+# The cache dirs are pre-created OWNED BY runner so compose named volumes
+# mounted there inherit that ownership — a volume on a nonexistent mountpoint
+# initializes root-owned, npx/uvx die on EACCES the instant they spawn, and
+# every MCP server silently never comes up (found the hard way on the first
+# Hetzner cutover).
+RUN useradd -m runner && mkdir -p /work && chown runner:runner /work \
+    && mkdir -p /home/runner/.npm /home/runner/.cache/uv \
+    && chown -R runner:runner /home/runner/.npm /home/runner/.cache
 COPY --chmod=755 deploy/runner-entrypoint.sh /usr/local/bin/runner-entrypoint.sh
 USER runner
 

--- a/deploy/runner.compose.example.yml
+++ b/deploy/runner.compose.example.yml
@@ -21,8 +21,22 @@ services:
       # RUNNER_TIMEOUT_MS: "600000"
     env_file:
       - ./analytics.env
+    # The context dir's own .env (the MCP servers' credentials) — loaded by the
+    # RUNNER so the spawned model inherits it. compose's env_file above only
+    # covers the runner's own config; without this line every data tool is
+    # silently absent and the context escalates everything.
+    command: ["serve", "--env-file", "/work/.env"]
     volumes:
       # The cloned context project's context/ dir: .mcp.json, references/, and
       # the repos/ clone cache (persists across restarts). Optional — without
       # it the manifest + repo pointers still arrive from the server.
       - /srv/contexts/analytics/context:/work
+      # Package caches outlive container recreation: MCP servers spawn via
+      # npx/uvx per answer, and a cold fetch on a small box loses the race
+      # against the MCP connect timeout.
+      - npm-cache-analytics:/home/runner/.npm
+      - uv-cache-analytics:/home/runner/.cache/uv
+
+volumes:
+  npm-cache-analytics:
+  uv-cache-analytics:


### PR DESCRIPTION
Analytics is live on the Hetzner box (first production answer: 357 distinct orgs via **Snowflake** — the source that had never worked anywhere before today). These are the two image/example fixes the cutover surfaced:

1. **Named cache volumes mounted root-owned** — the mountpoints didn't exist in the image, so Docker initialized the volumes as root, `npx`/`uvx` died on `EACCES` at spawn, and every MCP server was silently absent (the model sees no tools and escalates). The dirs now exist in the image owned by `runner`, which named volumes inherit. Verified: fresh build shows uid 1001 on both mountpoints.
2. **The compose example never delivered the context's MCP credentials** — `env_file` covers the runner's own config; the context dir's `.env` must reach the *spawned model*, which is the runner's `--env-file` job. The example now ships `command: [serve, --env-file, /work/.env]`.

Plus cache volumes in the example (cold fetches on 2 vCPUs lose the race against the MCP connect timeout) and a note that MCP connects are async in current claude — diagnosis on the box was repeatedly confounded by probes answering faster than cold servers could connect.

Box compose already runs this shape; this PR makes the repo's example match reality.