### PR TITLE
feat(contexts): runner liveness — the console knows when the runner is gone

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1593,6 +1593,10 @@
           },
           "created_at": {
             "type": "string"
+          },
+          "runner_seen_at": {
+            "type": "string",
+            "nullable": true
           }
         },
         "required": [
@@ -1601,7 +1605,8 @@
           "agent_id",
           "manifest_short_id",
           "created_by",
-          "created_at"
+          "created_at",
+          "runner_seen_at"
         ]
       },
       "Session": {

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -9,6 +9,7 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
 import { bail, fail, readJson } from "../lib/http"
+import { log } from "../log"
 
 /**
  * Contexts (askable agent setups) + sessions (ask-conversations with one).
@@ -42,6 +43,9 @@ export const contextRoutes = (ctx: AppContext) => {
       manifest_short_id: z.string().nullable(),
       created_by: z.string(),
       created_at: z.string(),
+      // When the runner last polled the queue (stamped there, ~minutely) — the
+      // console derives online/offline from this client-side. Null = never.
+      runner_seen_at: z.string().nullable(),
     })
     .openapi("ContextInfo")
 
@@ -86,6 +90,7 @@ export const contextRoutes = (ctx: AppContext) => {
     manifest_short_id: manifestShortId,
     created_by: x.created_by,
     created_at: x.created_at,
+    runner_seen_at: x.runner_seen_at,
   })
 
   const messageJson = (m: SessionMessageRecord) => {
@@ -582,6 +587,21 @@ export const contextRoutes = (ctx: AppContext) => {
       if (!agent) return bail(fail(c, 401, "agent token required"))
       const x = await meta.getContext(c.req.param("id"))
       if (!x || x.agent_id !== agent.id) return bail(fail(c, 404, "not found"))
+      // Liveness IS this poll — no heartbeat protocol. Stamp at most once a
+      // minute (the poll is ~5s; a write per poll would be pure churn, and the
+      // console's 90s "online" window tolerates the gap). Best-effort: a failed
+      // stamp must not 500 the queue — the runner's real job comes first.
+      const now = new Date()
+      if (!x.runner_seen_at || now.getTime() - new Date(x.runner_seen_at).getTime() > 60_000) {
+        try {
+          await meta.touchContextSeen(x.id, now.toISOString())
+        } catch (err) {
+          log.warn("runner liveness stamp failed", {
+            context: x.id,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
       const limit = Math.min(20, Math.max(1, Number(c.req.query("limit")) || 10))
       const sessions = await meta.pendingSessions(x.id, limit)
       // One query for every pending session's transcript, then group by session_id —

--- a/apps/api/test/contexts.test.ts
+++ b/apps/api/test/contexts.test.ts
@@ -333,3 +333,51 @@ describe("sessions: the ask → answer → follow-up loop", () => {
     expect(settled.session.state).toBe("answered")
   })
 })
+
+describe("runner liveness: the queue poll stamps runner_seen_at, throttled", () => {
+  const owner: TestUser = { id: "u_rl_own", email: "rlown@derive.test", name: "Owner" }
+  const { app, meta } = makeAuthedApp("contexts-liveness", [owner])
+
+  it("the first poll stamps; polls inside the 60s window don't; stale re-stamps", async () => {
+    await app.request("/v1/me", { headers: as(owner.email) })
+    const ag = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Analyst" }))
+    ).json()
+    const manifestShortId = (await (await publishAs(app, "# Manifest", {}, as(owner.email))).json())
+      .short_id
+    const x = await (
+      await app.request(
+        "/v1/contexts",
+        jsonAs(as(owner.email), {
+          name: "Analytics",
+          agent_id: ag.id,
+          manifest_short_id: manifestShortId,
+        }),
+      )
+    ).json()
+    expect(x.runner_seen_at).toBeNull() // never polled
+
+    const seenAt = async () =>
+      (await (await app.request(`/v1/contexts/${x.id}`, { headers: as(owner.email) })).json())
+        .runner_seen_at
+    await app.request(`/v1/contexts/${x.id}/queue`, { headers: bearer(ag.token) })
+    const first = await seenAt()
+    expect(first).toBeTruthy()
+
+    // Backdating (rather than back-to-back polls, whose stamps could collide on
+    // the same millisecond) makes the throttle branch unambiguous: 30s old is
+    // inside the window and must survive the poll; 2m old must be replaced.
+    await meta.touchContextSeen(x.id, new Date(Date.now() - 30_000).toISOString())
+    const fresh = await seenAt()
+    await app.request(`/v1/contexts/${x.id}/queue`, { headers: bearer(ag.token) })
+    expect(await seenAt()).toBe(fresh)
+
+    await meta.touchContextSeen(x.id, new Date(Date.now() - 120_000).toISOString())
+    await app.request(`/v1/contexts/${x.id}/queue`, { headers: bearer(ag.token) })
+    expect((await seenAt()) > fresh).toBe(true)
+
+    // Both user-facing reads carry the stamp (the console + directory render it).
+    const list = await (await app.request("/v1/contexts", { headers: as(owner.email) })).json()
+    expect(list.contexts[0].runner_seen_at).toBe(await seenAt())
+  })
+})

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -4911,6 +4911,7 @@ export interface components {
             manifest_short_id: string | null;
             created_by: string;
             created_at: string;
+            runner_seen_at: string | null;
         };
         Session: {
             id: string;

--- a/apps/web/src/pages/context/console.tsx
+++ b/apps/web/src/pages/context/console.tsx
@@ -34,7 +34,10 @@ export function ContextConsole() {
 function Console({ id }: { id: string }) {
   const { me } = useAuth()
   const qc = useQueryClient()
-  const { data: context } = useQuery(contextQuery(id))
+  // Polled (unlike the one-shot route loader fetch): runner_seen_at only moves
+  // when the server re-reads the row, and liveness going STALE is exactly the
+  // signal this page exists to show.
+  const { data: context } = useQuery({ ...contextQuery(id), refetchInterval: 60_000 })
   const { data: sessions } = useQuery(contextSessionsQuery(id))
 
   // The session on screen: sticky once picked; defaults to the most recent.
@@ -60,6 +63,7 @@ function Console({ id }: { id: string }) {
         <h1 className="font-serif text-2xl font-medium tracking-tight text-foreground">
           {context.name}
         </h1>
+        <RunnerLiveness seenAt={context.runner_seen_at} />
         {context.manifest_short_id && (
           <Link
             to="/artifacts/$ref"
@@ -145,6 +149,40 @@ function Console({ id }: { id: string }) {
         )}
       </Tabs>
     </PageShell>
+  )
+}
+
+// Whether the context's runner is alive, derived from the queue poll's stamp
+// (runner_seen_at) — no heartbeat protocol. Thresholds follow the write path:
+// the runner polls ~5s but the server stamps at most once a minute, so online
+// = seen within 90s (throttle + grace); within 10 minutes reads as recently
+// seen; anything older (or never) is offline.
+function RunnerLiveness({ seenAt }: { seenAt: string | null }) {
+  // Re-evaluate on a clock, not only on refetch: a dead runner stops CHANGING
+  // the stamp, and unchanged query data never re-renders this component.
+  const [, setTick] = useState(0)
+  useEffect(() => {
+    const t = setInterval(() => setTick((n) => n + 1), 30_000)
+    return () => clearInterval(t)
+  }, [])
+  const age = seenAt ? Date.now() - new Date(seenAt).getTime() : Number.POSITIVE_INFINITY
+  const [dot, label] =
+    seenAt && age < 90_000
+      ? ["bg-success", "runner online"]
+      : seenAt && age < 600_000
+        ? ["bg-warning", `seen ${ago(seenAt)}`]
+        : [
+            "bg-muted-foreground",
+            `runner offline — ${seenAt ? `seen ${ago(seenAt)}` : "never seen"}`,
+          ]
+  return (
+    <span
+      data-testid="console-runner-liveness"
+      className="flex items-center gap-1.5 text-xs text-muted-foreground"
+    >
+      <span className={cn("size-1.5 rounded-full", dot)} aria-hidden />
+      {label}
+    </span>
   )
 }
 

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -377,6 +377,7 @@ CREATE TABLE IF NOT EXISTS context (
   manifest_artifact_id TEXT NOT NULL,
   created_by TEXT NOT NULL,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  runner_seen_at TEXT,
   UNIQUE (org_id, name),
   FOREIGN KEY (manifest_artifact_id) REFERENCES artifact(id)
 );

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -618,6 +618,9 @@ export interface ContextStore {
   listContexts(orgId: string): Promise<ContextRecord[]>
   /** Remove a context and its sessions + messages, scoped to its workspace. */
   deleteContext(id: string, orgId: string): Promise<void>
+  /** Stamp `runner_seen_at` (the queue route's liveness mark). The caller decides
+   *  WHEN — the write throttle lives there, next to the poll cadence it paces. */
+  touchContextSeen(id: string, at: string): Promise<void>
   createSession(s: NewSession): Promise<SessionRecord>
   getSession(id: string): Promise<SessionRecord | null>
   /** Sessions on a context, newest first; `askerId` narrows to one person's. */
@@ -1157,6 +1160,9 @@ export interface ContextRecord {
   manifest_artifact_id: string
   created_by: string
   created_at: string
+  /** When the runner last polled the queue (ISO), throttle-stamped there — the
+   *  console's liveness signal. Null = never polled (or a pre-column row). */
+  runner_seen_at: string | null
 }
 export interface NewContext {
   id: string

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -494,6 +494,8 @@ export const context = pgTable(
       .references(() => artifact.id),
     created_by: text("created_by").notNull(),
     created_at: text("created_at").notNull().$defaultFn(isoNow),
+    // Last runner queue poll, throttle-stamped — see schema.ts for the contract.
+    runner_seen_at: text("runner_seen_at"),
   },
   (t) => [uniqueIndex("context_org_name").on(t.org_id, t.name)],
 )

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1646,6 +1646,11 @@ export class PgMetaStore implements MetaStore {
     await this.db.delete(contextSession).where(eq(contextSession.context_id, id))
     await this.db.delete(context).where(eq(context.id, id))
   }
+  // A no-op on an unknown id, deliberately: the caller already 404'd before
+  // stamping, and liveness is best-effort — never worth a throw.
+  async touchContextSeen(id: string, at: string): Promise<void> {
+    await this.db.update(context).set({ runner_seen_at: at }).where(eq(context.id, id))
+  }
   async createSession(s: NewSession): Promise<SessionRecord> {
     const rows = await this.db.insert(contextSession).values(s).returning()
     return one(rows)

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -1782,6 +1782,11 @@ export function makeRepos(db: SqliteDb) {
     await db.delete(contextSession).where(eq(contextSession.context_id, id)).run()
     await db.delete(context).where(eq(context.id, id)).run()
   }
+  // A no-op on an unknown id, deliberately: the caller already 404'd before
+  // stamping, and liveness is best-effort — never worth a throw.
+  const touchContextSeen = async (id: string, at: string): Promise<void> => {
+    await db.update(context).set({ runner_seen_at: at }).where(eq(context.id, id)).run()
+  }
   const createSession = async (s: NewSession): Promise<SessionRecord> =>
     (await db.insert(contextSession).values(s).returning().get()) as SessionRecord
   const getSession = async (id: string): Promise<SessionRecord | null> =>
@@ -2432,6 +2437,7 @@ export function makeRepos(db: SqliteDb) {
     getContext,
     listContexts,
     deleteContext,
+    touchContextSeen,
     createSession,
     getSession,
     listSessions,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -586,6 +586,11 @@ export const context = sqliteTable(
       .references(() => artifact.id),
     created_by: text("created_by").notNull(),
     created_at: text("created_at").notNull().default(now),
+    // Last time this context's runner polled its queue — liveness derived from the
+    // poll itself, no separate heartbeat. Stamped at most once a minute (the queue
+    // route throttles; the poll is ~5s) so the row isn't churned. Nullable (never
+    // polled + clean ALTER ADD COLUMN); the console renders online/offline from it.
+    runner_seen_at: text("runner_seen_at"),
   },
   (t) => [uniqueIndex("context_org_name").on(t.org_id, t.name)],
 )

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1334,6 +1334,15 @@ export function runStoreContract(
       expect(await store.listContexts(`other_${uuid()}`)).toHaveLength(0)
     })
 
+    it("touchContextSeen stamps runner_seen_at; an unknown id is a quiet no-op", async () => {
+      const ctx = await newContext()
+      expect(ctx.runner_seen_at).toBeNull()
+      const at = new Date().toISOString()
+      await store.touchContextSeen(ctx.id, at)
+      expect((await store.getContext(ctx.id))?.runner_seen_at).toBe(at)
+      await expect(store.touchContextSeen(uuid(), at)).resolves.toBeUndefined()
+    })
+
     it("rejects a duplicate context name within a workspace", async () => {
       const ctx = await newContext()
       await expect(


### PR DESCRIPTION
The pulled-forward sprint item, now load-bearing: both pilot runners live on a remote box, so "is the runner stuck?" shouldn't require ssh.

## Design

**The poll IS the heartbeat.** The runner already hits `GET /v1/contexts/:id/queue` every ~5s; the server now remembers it — a nullable `runner_seen_at` on the context row, stamped in the queue route **at most once a minute** (the row is already loaded, so the throttle costs one comparison; a write per poll would be pure churn). Best-effort: a failed stamp logs a warning and never 500s the poll — the runner's real job comes first.

Both user-facing context GETs return the stamp, and the console renders it next to the context name:

- 🟢 **runner online** — seen < 90s (60s throttle + grace)
- 🟡 **seen Xm ago** — < 10 minutes
- ⚪ **runner offline — seen Xm ago / never seen**

Two staleness traps handled in the console: the context query polls (`refetchInterval: 60s`) because a dead runner stops *changing* the data, and the component re-evaluates on a 30s local clock because unchanged query data never re-renders it — without both, a dead runner would read "online" forever.

## Plumbing

All three store dialects (sqlite/D1/pg — the additive column rides the generated DDL, `lint:schema` green), `touchContextSeen` on the MetaStore port with the throttle deliberately in the caller, OpenAPI spec + generated web types regenerated (`lint:api-types` green), design tokens only.

## Tests

Queue poll stamps; a 30s-old stamp is left untouched (backdated via the store, so the throttle assertion can't false-pass on same-millisecond stamps); a 2m-old stamp is replaced; both GETs expose it; store contract test across dialects. Full gates: typecheck, `pnpm run ci`, 811 api tests, 1553 repo-wide.