### PR TITLE
feat(cli,mcp): onboarding batch — cloud defaults, contexts born with the derive MCP

### DIFF
--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -226,6 +226,10 @@ function buildServer(
   ctx: AppContext,
   agent: AgentRecord,
   actingFor: { id: string; name: string | null } | null,
+  // The bound workspace's display name — the id alone reads as line noise in the
+  // model's one-shot identity brief, and "which workspace am I in?" is the first
+  // question an agent asks itself before writing anywhere.
+  workspaceName: string | null,
   // The granting user (OAuth grantor, or a dk_agt_ token's creator) whose
   // memberships bound which workspaces this connection can roam — null for a
   // legacy token with no known owner, which stays pinned to its one workspace.
@@ -253,7 +257,9 @@ function buildServer(
       instructions:
         `You are connected to Derive as "${agent.name}"${
           actingFor ? ` on behalf of ${actingFor.name ?? "your user"}` : ""
-        }, acting in workspace ${agent.org_id} ` +
+        }, acting in workspace ${
+          workspaceName ? `"${workspaceName}" (${agent.org_id})` : agent.org_id
+        } ` +
         `with ${agent.role} permissions. Derive hosts living documents and plans with versioned ` +
         `history, text-anchored review comments, and a publish → review → revise loop. ` +
         `Start a session with catch_up to re-sync on what changed and what feedback is open; use ` +
@@ -1499,7 +1505,16 @@ export function mountMcp(app: Hono, ctx: AppContext): void {
     const grant = await ctx.oauthGrant(c)
     const scopeForCap = grant?.scopeRole ?? agent.role
     const boundWorkspaces = grant?.boundWorkspaces ?? []
-    const server = buildServer(ctx, agent, actingFor, ownerId, scopeForCap, boundWorkspaces)
+    const workspaceName = (await ctx.meta.getWorkspace(agent.org_id))?.name ?? null
+    const server = buildServer(
+      ctx,
+      agent,
+      actingFor,
+      workspaceName,
+      ownerId,
+      scopeForCap,
+      boundWorkspaces,
+    )
     const transport = new StreamableHTTPTransport()
     await server.connect(transport)
     return transport.handleRequest(c)

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -136,6 +136,10 @@ describe("remote MCP endpoint (/mcp)", () => {
     // Identity rides in the server instructions, not a whoami tool.
     expect(result.instructions).toContain("Claude")
     expect(result.instructions).toContain("editor")
+    // The workspace announces itself by NAME (the id alone is line noise to the
+    // model). This grant has no memberships, so it landed in the provisioned
+    // personal workspace — "Owner's Workspace".
+    expect(result.instructions).toContain(`workspace "Owner's Workspace" (ws_`)
     // The instructions teach the switcher: one login reaches every workspace.
     expect(result.instructions).toContain("list_workspaces")
 

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -617,7 +617,12 @@ const STARTERS = {
     files: (t) => ({
       "context/MANIFEST.md": starterManifest(t),
       "context/references/example.md": STARTER_CONTEXT_REFERENCE,
-      "context/.mcp.json": `${JSON.stringify({ mcpServers: {} }, null, 2)}\n`,
+      // Born able to read the library it serves: the derive MCP ships in every
+      // context's toolset (a runner's DERIVE_TOKEN rides the same env ref), so
+      // "some context exists here: derive.to/…" is followable from day one —
+      // the pilot Companion shipped without this and couldn't read a linked
+      // scope doc it had standing for. Add the context's own data sources here.
+      "context/.mcp.json": `${JSON.stringify(MCP_CONFIG, null, 2)}\n`,
       "context/.env.example": STARTER_CONTEXT_ENV,
       ".gitignore": CONTEXT_GITIGNORE,
     }),
@@ -666,7 +671,9 @@ const MCP_CONFIG = {
       command: "npx",
       args: ["-y", "@derive-to/mcp"],
       env: {
-        DERIVE_SERVER: envRef("DERIVE_SERVER", "http://localhost:8080"),
+        // Cloud by default: a scaffolded project talks to derive.to unless the
+        // env says otherwise. (The localhost fallback predated launch.)
+        DERIVE_SERVER: envRef("DERIVE_SERVER", CLOUD_SERVER),
         DERIVE_ACCOUNT: envRef("DERIVE_ACCOUNT"),
         DERIVE_WORKSPACE: envRef("DERIVE_WORKSPACE"),
         DERIVE_TOKEN: envRef("DERIVE_TOKEN"),

--- a/packages/cli/test/config.test.js
+++ b/packages/cli/test/config.test.js
@@ -65,9 +65,10 @@ describe("scaffold", () => {
     // (workspace access, unlisted), not invite-only.
     expect(cfg.visibility).toBeUndefined()
     // The MCP config + skill are present and reference the published server.
-    expect(JSON.parse(readFileSync(join(d, ".mcp.json"), "utf8")).mcpServers.derive.args).toContain(
-      "@derive-to/mcp",
-    )
+    const mcp = JSON.parse(readFileSync(join(d, ".mcp.json"), "utf8")).mcpServers.derive
+    expect(mcp.args).toContain("@derive-to/mcp")
+    // Cloud by default — the localhost fallback predated launch.
+    expect(mcp.env.DERIVE_SERVER).toContain("https://derive.to")
     expect(readFileSync(join(d, ".claude/skills/derive/SKILL.md"), "utf8")).toContain(
       "name: derive-publish",
     )
@@ -150,6 +151,12 @@ describe("scaffold", () => {
     expect(names).toContain("context/references/example.md")
     expect(names).toContain("context/.mcp.json")
     expect(names).toContain("context/.env.example")
+    // Born able to read the library it serves: the derive MCP ships in every
+    // context's toolset (field lesson — the pilot Companion had standing to
+    // read a linked scope doc and no tool to do it with).
+    const ctxMcp = JSON.parse(files["context/.mcp.json"]).mcpServers
+    expect(ctxMcp.derive.args).toContain("@derive-to/mcp")
+    expect(ctxMcp.derive.env.DERIVE_SERVER).toContain("https://derive.to")
     // .env, the minted agent token, and the clone workspace must never reach git.
     expect(files[".gitignore"]).toContain("context/.env")
     expect(files[".gitignore"]).toContain(".derive/")

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 import {
+  CLOUD_SERVER,
   findAccountWorkspace,
   freshToken,
   getAccount,
@@ -14,8 +15,8 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod"
 import { createClient } from "./client"
 
-// Stdio MCP server for self-hosters: `npx @derive-to/mcp` talks to a Derive instance over
-// the /v1 HTTP API (DERIVE_SERVER). It exposes the SAME tools as the remote /mcp
+// Stdio MCP server: `npx @derive-to/mcp` talks to a Derive instance over
+// the /v1 HTTP API (DERIVE_SERVER, default the hosted cloud). It exposes the SAME tools as the remote /mcp
 // server — list_workspaces, list_artifacts, read, catch_up, comment, publish — so the
 // vocabulary is identical whether an agent connects over OAuth or a static token.
 //
@@ -29,7 +30,9 @@ import { createClient } from "./client"
 // changing that pin. DERIVE_TOKEN remains an escape hatch for a static bearer (CI,
 // no local login) — DERIVE_WORKSPACE has no effect there, since a static token
 // already acts as every workspace's owner.
-const server_ = process.env.DERIVE_SERVER ?? "http://localhost:8080"
+// Cloud by default, like the CLI: `npx @derive-to/mcp` from npm is a hosted-tier
+// user until DERIVE_SERVER says otherwise. (The localhost default predated launch.)
+const server_ = process.env.DERIVE_SERVER ?? CLOUD_SERVER
 
 /** {token, workspace} for the client below — see the module doc comment for the
  *  precedence. Kept out of `createClient` itself so a resolution failure fails


### PR DESCRIPTION
Sprint 1 item 7, the last planned item. Half of it turned out to be already shipped by #308 (the stdio MCP reads the `derive login` credentials store — sign in once, every project's MCP works); this PR is the rest, plus one field lesson from yesterday:

- **Cloud defaults.** The scaffolded `.mcp.json` and the stdio MCP's own `DERIVE_SERVER` fallback now point at the hosted cloud instead of `localhost:8080` — those defaults predated launch, and someone running `npx @derive-to/mcp` off npm is a hosted-tier user until the env says otherwise.
- **Contexts are born able to read the library they serve.** The context template's `.mcp.json` ships with the derive MCP wired to the env refs the runner container already carries (`DERIVE_TOKEN` = the agent token; dev-mode falls back to the human's login store). Field-proven gap: the pilot Companion was handed "context exists here: derive.to/…" in a review request, had an agent token with standing to read that doc, and no tool to do it with — it fetched the SPA shell and reported the page unreadable. Both live pilots got this file by hand yesterday; the template makes it standard issue.
- **The workspace announces itself by name.** The remote MCP's identity brief now reads `acting in workspace \"Derive\" (ws_…)` instead of the bare id — the id is line noise in a model's one-shot identity brief, and "which workspace am I in" is the first question an agent asks itself before writing anywhere.

Tests: scaffold defaults pinned (both templates), workspace-name-in-instructions pinned against the provisioned personal workspace. 101 CLI + 19 MCP + 25 api-MCP tests; full ci + typecheck green.

**This closes Sprint 1.** Items 1–7 plus 3b and the pulled-forward liveness are all merged or (this one) up.