### PR TITLE
fix(contexts)!: ask-access is workspace-scoped on the context, never the manifest

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2,8 +2,103 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Derive API",
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "description": "Derive's HTTP API. Every response shape here is the single source of truth for the web client — generated from the same Zod schemas that back this reference, so the docs never drift from the running API.\n\n**Auth:** a session cookie (browser) or a bearer token (agents and the CLI). Most write routes are scoped to the caller's active workspace. The `/v1` paths are the stable product surface; `/openapi.json` serves this spec and `/docs` renders it."
   },
+  "tags": [
+    {
+      "name": "Artifacts",
+      "description": "Documents (files and bundles): browse, publish, version, restore, and control access."
+    },
+    {
+      "name": "Comments",
+      "description": "Threaded, anchored comments with reactions, edits, and resolution."
+    },
+    {
+      "name": "Proposals",
+      "description": "Suggested revisions awaiting review — the propose → approve / request-changes flow."
+    },
+    {
+      "name": "Review",
+      "description": "Review rounds on an artifact: request a review, send it back, or approve."
+    },
+    {
+      "name": "Collections",
+      "description": "Shareable groups of artifacts, each with its own members."
+    },
+    {
+      "name": "Sharing",
+      "description": "Per-artifact collaborator roles (shares) layered over the workspace baseline."
+    },
+    {
+      "name": "Contexts",
+      "description": "Askable agent setups: wire an agent to a manifest, then open Q&A sessions against it."
+    },
+    {
+      "name": "Agents",
+      "description": "Registered agents (bearer tokens) and the OAuth agents a user has authorized."
+    },
+    {
+      "name": "Assets",
+      "description": "Standalone binary image assets referenced from bundles."
+    },
+    {
+      "name": "Favorites",
+      "description": "The caller's favorited artifacts."
+    },
+    {
+      "name": "Follows",
+      "description": "Follow people and repo paths to build the activity feed."
+    },
+    {
+      "name": "Notifications",
+      "description": "The caller's in-app notification feed."
+    },
+    {
+      "name": "Session",
+      "description": "Identity: the signed-in user, public profiles, and the people directory."
+    },
+    {
+      "name": "Workspace",
+      "description": "The workspace itself: members, settings, invitations, and switching."
+    },
+    {
+      "name": "Domains",
+      "description": "Custom domains and vanity subdomains bound to artifacts."
+    },
+    {
+      "name": "Sync",
+      "description": "GitHub repository mirroring: connect a repo and keep its docs in sync."
+    },
+    {
+      "name": "Slack",
+      "description": "Slack connection status and integration toggles."
+    },
+    {
+      "name": "Webhooks",
+      "description": "Outgoing webhooks and their delivery log."
+    },
+    {
+      "name": "OAuth",
+      "description": "OAuth 2.1 authorization-server endpoints and sign-in capabilities."
+    },
+    {
+      "name": "Realtime",
+      "description": "Live presence and cursor sharing on an artifact."
+    },
+    {
+      "name": "Analytics",
+      "description": "Aggregate view statistics for an artifact."
+    },
+    {
+      "name": "Moderation",
+      "description": "Abuse reports and takedown / reinstate actions."
+    },
+    {
+      "name": "Vitals",
+      "description": "Client-reported web-vitals ingestion."
+    }
+  ],
   "components": {
     "schemas": {
       "PublicProfile": {
@@ -18,22 +113,27 @@
           },
           "image": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Avatar URL; null if none is set."
           },
           "profession": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Self-set team role ('what you do'); null if unset."
           },
           "about": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "One-line bio; on the full profile only, null if unset."
           },
           "github_login": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Linked GitHub login; full profile only, null if not linked."
           },
           "teammate": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True when the viewer shares a workspace with this user."
           },
           "stats": {
             "type": "object",
@@ -44,10 +144,12 @@
             },
             "required": [
               "works"
-            ]
+            ],
+            "description": "Authored-works count; present only for teammates."
           },
           "followed_by_me": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the signed-in viewer follows this user."
           }
         },
         "required": [
@@ -60,35 +162,42 @@
         "type": "object",
         "properties": {
           "short_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Stable public id — the /a/<short_id> URL slug."
           },
           "url": {
-            "type": "string"
+            "type": "string",
+            "description": "Canonical public URL of the artifact."
           },
           "title": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Display title; null when untitled or taken down."
           },
           "kind": {
             "type": "string",
             "enum": [
               "file",
               "bundle"
-            ]
+            ],
+            "description": "file = single file; bundle = multi-file archive (skill, site, or docs folder)."
           },
           "current_content_type": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "MIME type of the current version's content."
           },
           "locked": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "When true, direct publishes are blocked — changes go through review."
           },
           "workspace_access": {
             "type": "string",
             "enum": [
               "none",
               "member"
-            ]
+            ],
+            "description": "v2 access: member = workspace seats reach it at their role; none = they don't."
           },
           "link_role": {
             "type": "string",
@@ -97,7 +206,8 @@
               "viewer",
               "commenter",
               "editor"
-            ]
+            ],
+            "description": "v2 access: what merely holding the world link confers (none = no link)."
           },
           "listed": {
             "type": "string",
@@ -105,22 +215,28 @@
               "none",
               "workspace",
               "public"
-            ]
+            ],
+            "description": "v2 access: where it surfaces for discovery — nowhere, the workspace, or public."
           },
           "password_protected": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "true when the world link is password-locked (the password is never returned)."
           },
           "org_id": {
-            "type": "string"
+            "type": "string",
+            "description": "The artifact's workspace id; drives move-to-workspace."
           },
           "raw_token": {
-            "type": "string"
+            "type": "string",
+            "description": "Signed, short-lived token for fetching raw content; detail responses only."
           },
           "spa": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "true when the bundle is a single-page app (all paths route to the entry)."
           },
           "current_version": {
-            "type": "number"
+            "type": "number",
+            "description": "Latest version number; 0 before any content is published."
           },
           "versions": {
             "type": "array",
@@ -131,14 +247,17 @@
                   "type": "number"
                 },
                 "content_type": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "MIME type of this version's content."
                 },
                 "author": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Display byline; heals to the author's current name."
                 },
                 "author_login": {
                   "type": "string",
-                  "nullable": true
+                  "nullable": true,
+                  "description": "Committer's GitHub login; null when not a GitHub commit."
                 },
                 "author_avatar": {
                   "type": "string",
@@ -146,19 +265,23 @@
                 },
                 "author_gh_id": {
                   "type": "string",
-                  "nullable": true
+                  "nullable": true,
+                  "description": "Committer's GitHub user id; null when not a GitHub commit."
                 },
                 "handle": {
                   "type": "string",
-                  "nullable": true
+                  "nullable": true,
+                  "description": "Committer's Derive @handle; null unless they signed in with GitHub."
                 },
                 "message": {
                   "type": "string",
-                  "nullable": true
+                  "nullable": true,
+                  "description": "Version (commit) message; null when none given."
                 },
                 "name": {
                   "type": "string",
-                  "nullable": true
+                  "nullable": true,
+                  "description": "Optional version label; null when unnamed."
                 },
                 "created_at": {
                   "type": "string"
@@ -177,10 +300,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/VersionSession"
-            }
+            },
+            "description": "Versions grouped into time-clustered sessions for the UI (newest-first)."
           },
           "views": {
-            "type": "number"
+            "type": "number",
+            "description": "Total views; present only when analytics is enabled."
           },
           "my_role": {
             "type": "string",
@@ -191,7 +316,8 @@
               "editor",
               "owner",
               null
-            ]
+            ],
+            "description": "The caller's effective permission tier; null when they have none."
           },
           "tags": {
             "type": "array",
@@ -200,54 +326,68 @@
             }
           },
           "favorite": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "true when the caller has favorited this."
           },
           "has_preview": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "true when the current version has a ready screenshot preview."
           },
           "open_proposals": {
-            "type": "number"
+            "type": "number",
+            "description": "Count of open (pending-review) proposals."
           },
           "proposals_total": {
-            "type": "number"
+            "type": "number",
+            "description": "Count of all proposals except withdrawn ones."
           },
           "open_threads": {
-            "type": "number"
+            "type": "number",
+            "description": "Count of open (unresolved) comment threads."
           },
           "mentions_me": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "true when an open thread @mentions the calling user."
           },
           "i_participated": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "true when the caller authored or commented in a thread here."
           },
           "collections": {
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Ids of the collections that include this artifact."
           },
           "removed": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "true when the artifact has been taken down (tombstone)."
           },
           "managed": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "true when mirrored from a GitHub sync — read-only in Derive."
           },
           "bundle": {
             "type": "object",
             "properties": {
               "isSkill": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "true when the bundle is a skill (entry SKILL.md)."
               },
               "name": {
                 "type": "string",
-                "nullable": true
+                "nullable": true,
+                "description": "Skill/bundle name; null when not declared."
               },
               "description": {
                 "type": "string",
-                "nullable": true
+                "nullable": true,
+                "description": "Skill/bundle description; null when not declared."
               },
               "entry": {
-                "type": "string"
+                "type": "string",
+                "description": "Path of the entry document rendered first."
               },
               "files": {
                 "type": "array",
@@ -265,7 +405,8 @@
                     "path",
                     "type"
                   ]
-                }
+                },
+                "description": "The bundle's file tree (path + MIME type) for navigation."
               }
             },
             "required": [
@@ -274,34 +415,41 @@
               "description",
               "entry",
               "files"
-            ]
+            ],
+            "description": "Present for a markdown bundle (skill or docs folder): entry, file tree, identity."
           },
           "source_path": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Source path (e.g. the repo path of a synced artifact); null when none."
           },
           "created_at": {
             "type": "string"
           },
           "updated_at": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Last-update timestamp; null when never updated since creation."
           },
           "author_name": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Raw current-author name; the resolved `author` object is preferred."
           },
           "author_login": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Raw current-author GitHub login; null when not from GitHub."
           },
           "author_avatar": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Raw current-author avatar URL; null when none."
           },
           "author_gh_id": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Raw current-author GitHub id; null when not from GitHub."
           },
           "author": {
             "type": "object",
@@ -313,7 +461,8 @@
               },
               "login": {
                 "type": "string",
-                "nullable": true
+                "nullable": true,
+                "description": "GitHub login; null if never signed in with GitHub."
               },
               "avatar": {
                 "type": "string",
@@ -321,7 +470,8 @@
               },
               "handle": {
                 "type": "string",
-                "nullable": true
+                "nullable": true,
+                "description": "Derive @handle; null when the author has none."
               }
             },
             "required": [
@@ -329,7 +479,8 @@
               "login",
               "avatar",
               "handle"
-            ]
+            ],
+            "description": "Resolved current-author profile; preferred over the raw author_* fields."
           }
         },
         "required": [
@@ -345,23 +496,28 @@
         "type": "object",
         "properties": {
           "n": {
-            "type": "number"
+            "type": "number",
+            "description": "Newest version number in this grouped session."
           },
           "from_n": {
-            "type": "number"
+            "type": "number",
+            "description": "Oldest version number in this grouped session."
           },
           "count": {
-            "type": "number"
+            "type": "number",
+            "description": "How many versions this session groups."
           },
           "author": {
             "type": "string"
           },
           "name": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Session label; null when unnamed."
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "description": "Timestamp of the newest version in the group."
           }
         },
         "required": [
@@ -377,7 +533,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "description": "User id, or the agent id when kind is agent."
           },
           "name": {
             "type": "string",
@@ -385,18 +542,21 @@
           },
           "handle": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "The @handle; null for agents (and users without one)."
           },
           "kind": {
             "type": "string",
             "enum": [
               "user",
               "agent"
-            ]
+            ],
+            "description": "Whether this entry is a person (user) or an agent."
           },
           "profession": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "The person's role; null for agents."
           }
         },
         "required": [
@@ -413,15 +573,18 @@
           },
           "handle": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Public @handle; null when the user has none."
           },
           "name": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Display name; null when unset."
           },
           "profession": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Joined only on workspace-member payloads; absent on artifact/collection lists."
           },
           "role": {
             "type": "string",
@@ -430,7 +593,8 @@
               "commenter",
               "editor",
               "owner"
-            ]
+            ],
+            "description": "Permission tier, ascending: viewer < commenter < editor < owner."
           }
         },
         "required": [
@@ -456,7 +620,8 @@
               "commenter",
               "editor",
               "owner"
-            ]
+            ],
+            "description": "The caller's role in this workspace (owner = Admin)."
           },
           "members": {
             "type": "array",
@@ -481,7 +646,8 @@
                 "type": "string",
                 "enum": [
                   "member"
-                ]
+                ],
+                "description": "The invitee already had an account and was added directly."
               },
               "member": {
                 "$ref": "#/components/schemas/ArtifactMember"
@@ -499,13 +665,15 @@
                 "type": "string",
                 "enum": [
                   "invite"
-                ]
+                ],
+                "description": "No account yet — a pending invite was created instead."
               },
               "invite": {
                 "$ref": "#/components/schemas/Invite"
               },
               "accept_url": {
-                "type": "string"
+                "type": "string",
+                "description": "The link the invitee follows to accept."
               }
             },
             "required": [
@@ -532,13 +700,15 @@
               "commenter",
               "editor",
               "owner"
-            ]
+            ],
+            "description": "The role the invitee will receive (owner = Admin)."
           },
           "created_at": {
             "type": "string"
           },
           "expires_at": {
-            "type": "string"
+            "type": "string",
+            "description": "When the invite expires (7-day TTL)."
           }
         },
         "required": [
@@ -553,7 +723,8 @@
         "type": "object",
         "properties": {
           "workspace": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the workspace this invite joins."
           },
           "role": {
             "type": "string",
@@ -562,14 +733,17 @@
               "commenter",
               "editor",
               "owner"
-            ]
+            ],
+            "description": "The role this invite grants (owner = Admin)."
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "description": "The email address the invite was addressed to."
           },
           "inviter": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "The inviter's display name; null if unknown."
           }
         },
         "required": [
@@ -583,32 +757,32 @@
         "type": "object",
         "properties": {
           "emailNotifications": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "When true, send workspace email notifications."
           },
           "githubPostComments": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "When true, post Derive comments onto the linked GitHub PR."
           },
           "githubMirrorComments": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "When true, mirror GitHub PR comments back into Derive."
           },
           "githubPreviewLink": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "When true, add a preview link to the linked GitHub PR."
           },
           "slackPost": {
-            "type": "boolean"
-          },
-          "slackEvents": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "boolean"
-            }
+            "type": "boolean",
+            "description": "When true, post events to Slack."
           },
           "defaultWorkspaceAccess": {
             "type": "string",
             "enum": [
               "none",
               "member"
-            ]
+            ],
+            "description": "Access a new publish lands with: none, or member (factory default)."
           },
           "defaultLinkRole": {
             "type": "string",
@@ -617,7 +791,8 @@
               "viewer",
               "commenter",
               "editor"
-            ]
+            ],
+            "description": "Share-link role a new publish lands with (factory default: none)."
           },
           "defaultListed": {
             "type": "string",
@@ -625,7 +800,8 @@
               "none",
               "workspace",
               "public"
-            ]
+            ],
+            "description": "Listing a new publish lands with: none (default), workspace, or public."
           }
         },
         "required": [
@@ -643,10 +819,12 @@
         "type": "object",
         "properties": {
           "multi": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether multi-workspace mode is enabled."
           },
           "active": {
-            "type": "string"
+            "type": "string",
+            "description": "Id of the workspace this request resolved to."
           },
           "account": {
             "$ref": "#/components/schemas/AccountSummary"
@@ -674,7 +852,8 @@
           },
           "handle": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "The account's @handle; null if unclaimed."
           },
           "name": {
             "type": "string",
@@ -685,7 +864,8 @@
           "id",
           "handle",
           "name"
-        ]
+        ],
+        "description": "The owner's identity (id + handle); null for anonymous callers."
       },
       "WorkspaceSummary": {
         "type": "object",
@@ -703,10 +883,12 @@
               "commenter",
               "editor",
               "owner"
-            ]
+            ],
+            "description": "The caller's role in this workspace (owner = Admin)."
           },
           "personal": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True for the auto-provisioned personal workspace (id ws_p_<userId>)."
           }
         },
         "required": [
@@ -732,7 +914,8 @@
               "commenter",
               "editor",
               "owner"
-            ]
+            ],
+            "description": "Permission level; commenter proposes only, editor can write, owner never allowed"
           },
           "created_at": {
             "type": "string"
@@ -749,7 +932,8 @@
         "type": "object",
         "properties": {
           "clientId": {
-            "type": "string"
+            "type": "string",
+            "description": "OAuth client id of the authorized agent (e.g. an MCP client like Claude)"
           },
           "clientName": {
             "type": "string"
@@ -758,7 +942,8 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "The OAuth scopes this agent was granted"
           },
           "grantedAt": {
             "type": "string"
@@ -775,10 +960,12 @@
         "type": "object",
         "properties": {
           "key": {
-            "type": "string"
+            "type": "string",
+            "description": "The blob hash (content-addressed storage key)"
           },
           "ref": {
-            "type": "string"
+            "type": "string",
+            "description": "The exact \"asset:<hash>\" string to drop into a publish files map"
           },
           "type": {
             "type": "string",
@@ -787,10 +974,12 @@
               "image/jpeg",
               "image/gif",
               "image/webp"
-            ]
+            ],
+            "description": "The sniffed image MIME type (PNG, JPEG, GIF, or WebP)"
           },
           "size": {
-            "type": "number"
+            "type": "number",
+            "description": "The asset's size in bytes"
           }
         },
         "required": [
@@ -807,10 +996,12 @@
             "type": "string"
           },
           "org_id": {
-            "type": "string"
+            "type": "string",
+            "description": "The workspace this follow is scoped to; \"*\" (global) for people-follows"
           },
           "user_id": {
-            "type": "string"
+            "type": "string",
+            "description": "The follower (the signed-in user who owns this follow)"
           },
           "kind": {
             "type": "string",
@@ -818,25 +1009,30 @@
               "author",
               "path",
               "user"
-            ]
+            ],
+            "description": "What's followed: a GitHub author, a repo path prefix, or a person"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "description": "The followed value: author login, path prefix, or (people) public @handle"
           },
           "created_at": {
             "type": "string"
           },
           "handle": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "For people-follows, the followed person's public @handle; absent otherwise"
           },
           "name": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "For people-follows, the followed person's display name; absent otherwise"
           },
           "image": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "For people-follows, the followed person's avatar URL; absent otherwise"
           }
         },
         "required": [
@@ -858,20 +1054,23 @@
             "type": "string"
           },
           "created_by": {
-            "type": "string"
+            "type": "string",
+            "description": "Creator's user id (\"anon\" if created anonymously)."
           },
           "created_at": {
             "type": "string"
           },
           "count": {
-            "type": "number"
+            "type": "number",
+            "description": "Number of artifacts in the collection."
           },
           "workspace_access": {
             "type": "string",
             "enum": [
               "none",
               "member"
-            ]
+            ],
+            "description": "Workspace share scope: \"member\" (all members) or \"none\" (invite-only)."
           },
           "my_role": {
             "type": "string",
@@ -882,7 +1081,8 @@
               "editor",
               "owner",
               null
-            ]
+            ],
+            "description": "Caller's own role on the collection; drives the Share dialog. Null if none."
           },
           "kind": {
             "type": "string",
@@ -890,16 +1090,20 @@
               "manual",
               "repo",
               "pr"
-            ]
+            ],
+            "description": "Origin: \"manual\" (user-made), \"repo\" (GitHub mirror), or \"pr\" (PR preview)."
           },
           "parentId": {
-            "type": "string"
+            "type": "string",
+            "description": "For a PR preview: the repo collection it nests under, when connected."
           },
           "prNumber": {
-            "type": "number"
+            "type": "number",
+            "description": "For a PR preview: the pull-request number."
           },
           "repo": {
-            "type": "string"
+            "type": "string",
+            "description": "For repo/PR collections: the \"owner/name\" slug."
           }
         },
         "required": [
@@ -917,25 +1121,30 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/RepoSource"
-            }
+            },
+            "description": "Branch mirrors, one per connected repo."
           },
           "prs": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/PrPreview"
-            }
+            },
+            "description": "PR previews, one per pull request being mirrored."
           },
           "app": {
             "type": "object",
             "properties": {
               "configured": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "True when a live GitHub App is set up on this server."
               },
               "slug": {
-                "type": "string"
+                "type": "string",
+                "description": "The App's GitHub slug for install links; absent when unconfigured."
               },
               "upToDate": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "True when the App has every required permission and event."
               },
               "missing": {
                 "type": "object",
@@ -944,36 +1153,43 @@
                     "type": "object",
                     "additionalProperties": {
                       "type": "string"
-                    }
+                    },
+                    "description": "Scope → level still to grant (e.g. contents → read)."
                   },
                   "events": {
                     "type": "array",
                     "items": {
                       "type": "string"
-                    }
+                    },
+                    "description": "Webhook event names still to subscribe to."
                   }
                 },
                 "required": [
                   "permissions",
                   "events"
-                ]
+                ],
+                "description": "Permissions and events still to grant; absent when up to date."
               },
               "permissionsUrl": {
-                "type": "string"
+                "type": "string",
+                "description": "GitHub URL to adjust the App's permissions; absent when unconfigured."
               },
               "approveUrl": {
-                "type": "string"
+                "type": "string",
+                "description": "GitHub URL to install or approve the App; absent when unconfigured."
               }
             },
             "required": [
               "configured"
-            ]
+            ],
+            "description": "The instance GitHub App's setup and permission state."
           },
           "installations": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/GithubInstallation"
-            }
+            },
+            "description": "This workspace's App installations (entry points to the repo picker)."
           }
         },
         "required": [
@@ -990,32 +1206,40 @@
             "type": "string"
           },
           "collection_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Collection the repo's docs are mirrored into."
           },
           "repo": {
-            "type": "string"
+            "type": "string",
+            "description": "The connected GitHub repo, as owner/name."
           },
           "ref": {
-            "type": "string"
+            "type": "string",
+            "description": "Branch or tag to mirror; \"HEAD\" tracks the default branch."
           },
           "includes": {
-            "type": "string"
+            "type": "string",
+            "description": "Comma-separated glob patterns selecting which files to mirror."
           },
           "token": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Redacted to \"•••\" when a PAT is stored; null for App-backed sources."
           },
           "installation_id": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "GitHub App installation backing this source; null when using a PAT."
           },
           "last_synced_at": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "When the last sync finished; null if it has never synced."
           },
           "last_status": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Outcome of the last sync run; null if it has never synced."
           },
           "created_by": {
             "type": "string"
@@ -1024,11 +1248,13 @@
             "type": "string"
           },
           "file_count": {
-            "type": "number"
+            "type": "number",
+            "description": "How many files are currently mirrored from the repo."
           },
           "progress": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Live sync progress as a JSON blob driving the bar; null when none recorded."
           }
         },
         "required": [
@@ -1054,31 +1280,39 @@
             "type": "string"
           },
           "collection_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Collection holding this PR's previewed docs."
           },
           "repo": {
-            "type": "string"
+            "type": "string",
+            "description": "The connected GitHub repo, as owner/name."
           },
           "pr_number": {
-            "type": "number"
+            "type": "number",
+            "description": "The pull request number this preview mirrors."
           },
           "title": {
-            "type": "string"
+            "type": "string",
+            "description": "The PR's title, used as the preview's display name."
           },
           "last_status": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Outcome of the last sync run; null if it has never synced."
           },
           "last_synced_at": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "When the last sync finished; null if it has never synced."
           },
           "file_count": {
-            "type": "number"
+            "type": "number",
+            "description": "How many of the PR's changed docs are mirrored."
           },
           "progress": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Live sync progress as a JSON blob driving the bar; null when none recorded."
           }
         },
         "required": [
@@ -1097,11 +1331,13 @@
         "type": "object",
         "properties": {
           "installation_id": {
-            "type": "string"
+            "type": "string",
+            "description": "GitHub's numeric App installation id, as a string."
           },
           "account_login": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "The org/user the App is installed on; null until GitHub reports it."
           }
         },
         "required": [
@@ -1113,17 +1349,21 @@
         "type": "object",
         "properties": {
           "full_name": {
-            "type": "string"
+            "type": "string",
+            "description": "The repository's full name, as owner/name."
           },
           "private": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True when the repo is private on GitHub."
           },
           "default_branch": {
-            "type": "string"
+            "type": "string",
+            "description": "The repo's default branch (e.g. main)."
           },
           "pushed_at": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "When the repo was last pushed to; null if unknown. Drives sort order."
           }
         },
         "required": [
@@ -1137,19 +1377,24 @@
         "type": "object",
         "properties": {
           "total": {
-            "type": "number"
+            "type": "number",
+            "description": "Total files matching the include globs."
           },
           "md": {
-            "type": "number"
+            "type": "number",
+            "description": "How many matches are Markdown files."
           },
           "html": {
-            "type": "number"
+            "type": "number",
+            "description": "How many matches are HTML files."
           },
           "other": {
-            "type": "number"
+            "type": "number",
+            "description": "Matches that are neither Markdown nor HTML."
           },
           "truncated": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True when GitHub capped the tree, so counts are a lower bound."
           }
         },
         "required": [
@@ -1167,22 +1412,27 @@
             "type": "string"
           },
           "repo": {
-            "type": "string"
+            "type": "string",
+            "description": "The connected GitHub repo, as owner/name."
           },
           "progress": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Live sync progress as a JSON blob driving the bar; null when none recorded."
           },
           "last_status": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Outcome of the last sync run; null if it has never synced."
           },
           "last_synced_at": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "When the last sync finished; null if it has never synced."
           },
           "file_count": {
-            "type": "number"
+            "type": "number",
+            "description": "How many files are currently mirrored from the repo."
           }
         },
         "required": [
@@ -1198,27 +1448,30 @@
         "type": "object",
         "properties": {
           "available": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True if this instance has Slack configured at all"
           },
           "connected": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True if this workspace has connected a Slack team"
           },
           "team_name": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "The connected Slack team's name, or null if not connected"
           },
           "default_channel": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "The channel Derive posts to, or null if unset"
           },
           "needs_reauth": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the stored bot token needs a re-auth (an auth error since connecting)"
           },
-          "linked": {
-            "type": "boolean"
-          },
-          "mention_dm": {
-            "type": "boolean"
+          "slack_dm": {
+            "type": "boolean",
+            "description": "The caller's \"DM me for interrupts\" preference (mentions, review requests, shares)"
           }
         },
         "required": [
@@ -1227,8 +1480,7 @@
           "team_name",
           "default_channel",
           "needs_reauth",
-          "linked",
-          "mention_dm"
+          "slack_dm"
         ]
       },
       "Report": {
@@ -1244,15 +1496,18 @@
             "type": "string"
           },
           "reason": {
-            "type": "string"
+            "type": "string",
+            "description": "The reporter's stated reason for the report"
           },
           "detail": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Optional extra detail from the reporter, or null"
           },
           "reporter": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "The reporter's IP (best-effort), or null; abuse reports are anonymous/public"
           },
           "state": {
             "type": "string",
@@ -1260,7 +1515,8 @@
               "open",
               "actioned",
               "dismissed"
-            ]
+            ],
+            "description": "open (awaiting review), actioned (taken down), or dismissed (no action)"
           },
           "created_at": {
             "type": "string"
@@ -1293,18 +1549,22 @@
               "takedown",
               "reinstate",
               "dismiss"
-            ]
+            ],
+            "description": "What happened: report filed, takedown, reinstate, or dismiss"
           },
           "artifact_id": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "The artifact acted on, or null if not artifact-specific"
           },
           "actor": {
-            "type": "string"
+            "type": "string",
+            "description": "Who performed it: a user's name, or an IP/'anonymous' for public reports"
           },
           "detail": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Context such as the report reason or takedown note, or null"
           },
           "created_at": {
             "type": "string"
@@ -1329,10 +1589,12 @@
               "ctx",
               "add",
               "del"
-            ]
+            ],
+            "description": "Line op: ctx = unchanged context, add = added, del = removed."
           },
           "line": {
-            "type": "string"
+            "type": "string",
+            "description": "The line's text; the +/- marker lives in `t`, not here."
           }
         },
         "required": [
@@ -1353,10 +1615,12 @@
               "approved",
               "changes_requested",
               "withdrawn"
-            ]
+            ],
+            "description": "Review state: open, approved (went live), changes_requested, or withdrawn."
           },
           "author": {
-            "type": "string"
+            "type": "string",
+            "description": "Proposer's display name; \"anonymous\" if not signed in."
           },
           "on_behalf_of": {
             "type": "object",
@@ -1374,43 +1638,52 @@
             "required": [
               "handle",
               "name"
-            ]
+            ],
+            "description": "When an agent proposed, the human it acted on behalf of; null for a direct human proposal."
           },
           "message": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Proposer's cover message; null if none."
           },
           "base_version": {
-            "type": "number"
+            "type": "number",
+            "description": "Artifact version this proposal was authored against."
           },
           "kind": {
             "type": "string",
             "enum": [
               "file",
               "bundle"
-            ]
+            ],
+            "description": "Content shape: a single file or a multi-file bundle."
           },
           "decided_by": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Who approved/requested-changes/withdrew it; null while still open."
           },
           "decided_version": {
             "type": "number",
-            "nullable": true
+            "nullable": true,
+            "description": "The version it went live as when approved; null otherwise."
           },
           "decision_note": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Reviewer's note on the decision; null while open or if none."
           },
           "decided_at": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "When it was decided; null while still open."
           },
           "created_at": {
             "type": "string"
           },
           "preview_url": {
-            "type": "string"
+            "type": "string",
+            "description": "URL that renders the proposed content like a live version."
           },
           "diff": {
             "type": "object",
@@ -1428,7 +1701,8 @@
             "required": [
               "base_version",
               "ops"
-            ]
+            ],
+            "description": "Line diff vs the base version; present only on the single-proposal fetch."
           }
         },
         "required": [
@@ -1456,13 +1730,16 @@
             "type": "string"
           },
           "version": {
-            "type": "number"
+            "type": "number",
+            "description": "The artifact version this round is reviewing."
           },
           "requested_by": {
-            "type": "string"
+            "type": "string",
+            "description": "Who asked for the review (usually the agent that published)."
           },
           "requested_for": {
-            "type": "string"
+            "type": "string",
+            "description": "The person asked to answer or approve this round."
           },
           "state": {
             "type": "string",
@@ -1470,18 +1747,21 @@
               "pending",
               "sent_back",
               "approved"
-            ]
+            ],
+            "description": "Round state: pending, sent_back (answers returned), or approved (the go-signal)."
           },
           "note": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Free-text note attached to the round; null if none."
           },
           "created_at": {
             "type": "string"
           },
           "resolved_at": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "When it was sent back or approved; null while pending."
           }
         },
         "required": [
@@ -1503,24 +1783,30 @@
             "type": "string"
           },
           "thread_id": {
-            "type": "string"
+            "type": "string",
+            "description": "The thread this comment belongs to; equals id for the thread's root comment."
           },
           "base_version": {
-            "type": "number"
+            "type": "number",
+            "description": "Artifact version this comment was anchored against."
           },
           "path": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "File within a bundle the comment targets; null if not file-scoped."
           },
           "anchor": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Serialized text-quote or element anchor locating the comment; null if unanchored."
           },
           "body_md": {
-            "type": "string"
+            "type": "string",
+            "description": "Comment body in Markdown; blanked when the comment is deleted."
           },
           "author": {
-            "type": "string"
+            "type": "string",
+            "description": "Author's display name; \"anonymous\" for an anonymous poster."
           },
           "state": {
             "type": "string",
@@ -1529,13 +1815,15 @@
               "addressed",
               "resolved",
               "outdated"
-            ]
+            ],
+            "description": "Thread state: open, addressed (a proposal in review claims to fix it), resolved, or outdated (the quoted text changed)."
           },
           "created_at": {
             "type": "string"
           },
           "anchored": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the anchor still resolves against the current version (list only)."
           },
           "reactions": {
             "type": "object",
@@ -1544,23 +1832,28 @@
               "items": {
                 "type": "string"
               }
-            }
+            },
+            "description": "Emoji → list of reactor display names."
           },
           "edited": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True if the body was edited after posting."
           },
           "edited_at": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "When the comment was last edited; null if never."
           },
           "deleted": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True if soft-deleted; the row stays but the body is blanked."
           },
           "mentions": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Mention"
-            }
+            },
+            "description": "Users or agents @mentioned in the comment body."
           }
         },
         "required": [
@@ -1579,7 +1872,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "description": "Id of the mentioned person or agent."
           },
           "name": {
             "type": "string"
@@ -1600,11 +1894,13 @@
             "type": "string"
           },
           "agent_id": {
-            "type": "string"
+            "type": "string",
+            "description": "The registered agent this context routes asks to."
           },
           "manifest_short_id": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Short id of the linked manifest artifact; null if it can't be resolved."
           },
           "created_by": {
             "type": "string"
@@ -1614,14 +1910,16 @@
           },
           "runner_seen_at": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "When the runner last polled the queue (~minutely); null = never. Drives online/offline."
           },
           "ask_policy": {
             "type": "string",
             "enum": [
               "workspace",
               "invited"
-            ]
+            ],
+            "description": "Who in the workspace may ask: any member, or the invited roster. Never outside the workspace."
           }
         },
         "required": [
@@ -1648,7 +1946,8 @@
             "type": "string"
           },
           "context_version": {
-            "type": "number"
+            "type": "number",
+            "description": "The manifest version this session was opened against."
           },
           "state": {
             "type": "string",
@@ -1658,13 +1957,15 @@
               "escalated",
               "failed",
               "closed"
-            ]
+            ],
+            "description": "open = awaiting the agent; answered; escalated = draft went to review; failed = run crashed; closed = ended by asker/owner."
           },
           "created_at": {
             "type": "string"
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "description": "Last state/message change; equals created_at when never updated."
           }
         },
         "required": [
@@ -1688,13 +1989,16 @@
             "enum": [
               "asker",
               "agent"
-            ]
+            ],
+            "description": "Who wrote it: asker (the human) or agent (the context's runner)."
           },
           "author_id": {
-            "type": "string"
+            "type": "string",
+            "description": "The asker's user id, or the agent id when author_kind is agent."
           },
           "body_md": {
-            "type": "string"
+            "type": "string",
+            "description": "The message body as Markdown."
           },
           "meta": {
             "$ref": "#/components/schemas/SessionMeta"
@@ -1718,21 +2022,25 @@
         "properties": {
           "query": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "The underlying query the agent ran to produce this answer."
           },
           "confidence": {
             "type": "number",
-            "nullable": true
+            "nullable": true,
+            "description": "The agent's confidence in the answer, 0-1 (shown as a percentage)."
           },
           "caveats": {
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Caveats or limitations the agent flagged on its answer."
           },
           "escalation_reason": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Why the agent escalated to a human instead of answering."
           },
           "artifacts": {
             "type": "array",
@@ -1750,22 +2058,27 @@
                 "short_id",
                 "title"
               ]
-            }
+            },
+            "description": "Artifacts the agent cited, each linkable by short_id."
           }
-        }
+        },
+        "description": "Structured answer payload on agent messages; null on asker messages."
       },
       "Viewer": {
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "description": "The viewer's id: a signed-in user's id, or a stable anonymous viewer id"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Display name: a user's @handle, or a friendly handle for anonymous viewers"
           },
           "role": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "The viewer's effective role on this artifact, or null if they have none"
           }
         },
         "required": [
@@ -1778,13 +2091,16 @@
         "type": "object",
         "properties": {
           "total": {
-            "type": "number"
+            "type": "number",
+            "description": "Total recorded views across all versions (de-duped opens)"
           },
           "unique": {
-            "type": "number"
+            "type": "number",
+            "description": "Distinct viewers; a signed-in person or anon cookie counts once"
           },
           "anonViewers": {
-            "type": "number"
+            "type": "number",
+            "description": "How many of the unique viewers are anonymous"
           },
           "perVersion": {
             "type": "array",
@@ -1795,7 +2111,8 @@
                   "type": "number"
                 },
                 "count": {
-                  "type": "number"
+                  "type": "number",
+                  "description": "Views recorded for that version"
                 }
               },
               "required": [
@@ -1810,10 +2127,12 @@
               "type": "object",
               "properties": {
                 "day": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Calendar day bucket (YYYY-MM-DD)"
                 },
                 "count": {
-                  "type": "number"
+                  "type": "number",
+                  "description": "Views recorded on that day"
                 }
               },
               "required": [
@@ -1828,21 +2147,25 @@
               "type": "object",
               "properties": {
                 "viewer": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Display name (resolved @handle for users), or the anon viewer id"
                 },
                 "kind": {
                   "type": "string",
                   "enum": [
                     "user",
                     "anon"
-                  ]
+                  ],
+                  "description": "Whether the viewer is a signed-in user or anonymous"
                 },
                 "at": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "When they last viewed (ISO timestamp)"
                 },
                 "avatar": {
                   "type": "string",
-                  "nullable": true
+                  "nullable": true,
+                  "description": "The user's avatar URL, or null/absent for anonymous viewers"
                 }
               },
               "required": [
@@ -1869,10 +2192,12 @@
             "type": "string"
           },
           "user_id": {
-            "type": "string"
+            "type": "string",
+            "description": "The recipient this notification belongs to"
           },
           "actor": {
-            "type": "string"
+            "type": "string",
+            "description": "Who triggered it; for follow/publish this is the person's @handle"
           },
           "kind": {
             "type": "string",
@@ -1883,26 +2208,32 @@
               "follow",
               "publish",
               "review"
-            ]
+            ],
+            "description": "What happened: mention, comment, share, follow, publish, or review"
           },
           "artifact_id": {
             "type": "string"
           },
           "artifact_short_id": {
-            "type": "string"
+            "type": "string",
+            "description": "The artifact's public short id for links; empty for follows (no anchor)"
           },
           "artifact_title": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "The artifact's title, or null if untitled or not artifact-anchored"
           },
           "thread_id": {
-            "type": "string"
+            "type": "string",
+            "description": "The comment thread anchor; empty when not comment-related"
           },
           "comment_id": {
-            "type": "string"
+            "type": "string",
+            "description": "The specific comment anchor; empty when not comment-related"
           },
           "preview": {
-            "type": "string"
+            "type": "string",
+            "description": "Short text preview shown in the notification bell"
           },
           "read": {
             "anyOf": [
@@ -1918,7 +2249,8 @@
                   1
                 ]
               }
-            ]
+            ],
+            "description": "Whether the user has read it: 0 unread, 1 read"
           },
           "created_at": {
             "type": "string"
@@ -1947,24 +2279,29 @@
           },
           "artifact_id": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "The artifact this webhook is scoped to, or null to fire on all workspace events"
           },
           "url": {
-            "type": "string"
+            "type": "string",
+            "description": "The destination endpoint deliveries are POSTed to"
           },
           "kind": {
             "type": "string",
             "enum": [
               "generic",
               "slack"
-            ]
+            ],
+            "description": "Delivery format: generic posts signed JSON, slack posts a Block Kit message"
           },
           "events": {
-            "type": "string"
+            "type": "string",
+            "description": "Comma-separated event types to deliver, or \"*\" for all events"
           },
           "label": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Optional human-readable label, or null if unnamed"
           },
           "active": {
             "anyOf": [
@@ -1980,7 +2317,8 @@
                   1
                 ]
               }
-            ]
+            ],
+            "description": "Whether deliveries are enabled (1) or paused (0)"
           },
           "created_at": {
             "type": "string"
@@ -2012,14 +2350,17 @@
               "pending",
               "delivered",
               "dead"
-            ]
+            ],
+            "description": "Delivery state: pending (awaiting/retrying), delivered (succeeded), dead (gave up)"
           },
           "attempts": {
-            "type": "number"
+            "type": "number",
+            "description": "Number of delivery attempts made so far"
           },
           "last_error": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "The most recent failure message, or null if none"
           },
           "created_at": {
             "type": "string"
@@ -2038,17 +2379,20 @@
         "type": "object",
         "properties": {
           "host": {
-            "type": "string"
+            "type": "string",
+            "description": "The hostname the artifact is served at."
           },
           "url": {
-            "type": "string"
+            "type": "string",
+            "description": "That host with scheme, ready to link to."
           },
           "kind": {
             "type": "string",
             "enum": [
               "subdomain",
               "custom"
-            ]
+            ],
+            "description": "\"subdomain\" = a vanity <label>.<base>; \"custom\" = a workspace custom domain."
           },
           "status": {
             "type": "string",
@@ -2056,7 +2400,8 @@
               "active",
               "pending",
               "error"
-            ]
+            ],
+            "description": "\"active\" = serving; \"pending\" = awaiting DNS/cert; \"error\" = validation failed."
           },
           "created_at": {
             "type": "string"
@@ -2074,7 +2419,8 @@
         "type": "object",
         "properties": {
           "host": {
-            "type": "string"
+            "type": "string",
+            "description": "The custom domain attached to the workspace."
           },
           "status": {
             "type": "string",
@@ -2082,13 +2428,15 @@
               "active",
               "pending",
               "error"
-            ]
+            ],
+            "description": "\"active\" = serving; \"pending\" = awaiting DNS/cert; \"error\" = validation failed."
           },
           "records": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/DomainDnsRecord"
-            }
+            },
+            "description": "DNS records to add while pending; absent once the domain is active."
           },
           "created_at": {
             "type": "string"
@@ -2104,13 +2452,16 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": "string"
+            "type": "string",
+            "description": "DNS record type to create (e.g. CNAME)."
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "The name/host to create the DNS record at."
           },
           "value": {
-            "type": "string"
+            "type": "string",
+            "description": "The value the DNS record should point at."
           }
         },
         "required": [
@@ -2123,38 +2474,47 @@
         "type": "object",
         "properties": {
           "password": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True if email + password sign-in is available (always on here)"
           },
           "google": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True if Google sign-in is configured"
           },
           "github": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True if GitHub sign-in is configured"
           },
           "oidc": {
             "type": "object",
             "nullable": true,
             "properties": {
               "providerId": {
-                "type": "string"
+                "type": "string",
+                "description": "The provider id used to initiate SSO"
               },
               "label": {
-                "type": "string"
+                "type": "string",
+                "description": "Human-readable label for the SSO button"
               }
             },
             "required": [
               "providerId",
               "label"
-            ]
+            ],
+            "description": "The enterprise OIDC/SSO provider, or null if none is configured"
           },
           "emailVerification": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True if verification emails can be sent (a mail transport is configured)"
           },
           "passwordReset": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True if password-reset emails can be sent"
           },
           "passkey": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True if passkey (WebAuthn) sign-in works on this instance"
           }
         },
         "required": [
@@ -2200,27 +2560,34 @@
                         },
                         "username": {
                           "type": "string",
-                          "nullable": true
+                          "nullable": true,
+                          "description": "The @handle; null until claimed at onboarding."
                         },
                         "discoverable": {
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Whether the user is findable in people search."
                         },
                         "profession": {
                           "type": "string",
-                          "nullable": true
+                          "nullable": true,
+                          "description": "Self-set team role; null if unset."
                         },
                         "about": {
                           "type": "string",
-                          "nullable": true
+                          "nullable": true,
+                          "description": "One-line bio; null if unset."
                         },
                         "onboarded": {
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Whether first-run onboarding is complete."
                         },
                         "emailVerified": {
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Whether the account email is verified."
                         },
                         "role": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "The caller's role in the active workspace: viewer, commenter, editor, or owner (Admin)."
                         }
                       },
                       "required": [
@@ -2237,7 +2604,8 @@
                       ]
                     },
                     "multi": {
-                      "type": "boolean"
+                      "type": "boolean",
+                      "description": "Whether multi-workspace mode is enabled."
                     }
                   },
                   "required": [
@@ -2295,11 +2663,13 @@
                   "properties": {
                     "profession": {
                       "type": "string",
-                      "nullable": true
+                      "nullable": true,
+                      "description": "Saved team role; null when cleared."
                     },
                     "about": {
                       "type": "string",
-                      "nullable": true
+                      "nullable": true,
+                      "description": "Saved bio; null when cleared."
                     }
                   },
                   "required": [
@@ -2501,7 +2871,8 @@
                     },
                     "next_cursor": {
                       "type": "string",
-                      "nullable": true
+                      "nullable": true,
+                      "description": "Opaque cursor for the next page; null when there are no more."
                     }
                   },
                   "required": [
@@ -2530,7 +2901,8 @@
                   "type": "object",
                   "properties": {
                     "image": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "The served (absolute) avatar URL."
                     }
                   },
                   "required": [
@@ -3184,7 +3556,8 @@
                     },
                     "next_cursor": {
                       "type": "string",
-                      "nullable": true
+                      "nullable": true,
+                      "description": "Opaque cursor for the next page; null on the last page."
                     },
                     "collection": {
                       "type": "object",
@@ -3199,7 +3572,8 @@
                       "required": [
                         "id",
                         "title"
-                      ]
+                      ],
+                      "description": "The scoped collection; present only when listing one (?collection=)."
                     }
                   },
                   "required": [
@@ -3228,16 +3602,20 @@
                   "type": "object",
                   "properties": {
                     "total": {
-                      "type": "number"
+                      "type": "number",
+                      "description": "Total artifacts in the workspace."
                     },
                     "favorites": {
-                      "type": "number"
+                      "type": "number",
+                      "description": "The caller's favorite count in this workspace."
                     },
                     "mine": {
-                      "type": "number"
+                      "type": "number",
+                      "description": "Count of artifacts the caller owns ('Created by me')."
                     },
                     "mine_private": {
-                      "type": "number"
+                      "type": "number",
+                      "description": "Owned artifacts not surfaced anywhere yet (listed=none)."
                     },
                     "tags": {
                       "type": "array",
@@ -3255,11 +3633,13 @@
                           "tag",
                           "count"
                         ]
-                      }
+                      },
+                      "description": "Per-tag artifact counts for the workspace."
                     },
                     "workspace": {
                       "type": "string",
-                      "nullable": true
+                      "nullable": true,
+                      "description": "Workspace display name; null for a non-member (empty summary)."
                     }
                   },
                   "required": [
@@ -3357,7 +3737,8 @@
                       "enum": [
                         "none",
                         "member"
-                      ]
+                      ],
+                      "description": "New workspace access: member = seats reach it; none = they don't."
                     },
                     "link_role": {
                       "type": "string",
@@ -3366,7 +3747,8 @@
                         "viewer",
                         "commenter",
                         "editor"
-                      ]
+                      ],
+                      "description": "New world-link role; none = no link."
                     },
                     "listed": {
                       "type": "string",
@@ -3374,10 +3756,12 @@
                         "none",
                         "workspace",
                         "public"
-                      ]
+                      ],
+                      "description": "New discovery listing: nowhere, the workspace, or public."
                     },
                     "locked": {
-                      "type": "boolean"
+                      "type": "boolean",
+                      "description": "true when the world link is now password-locked."
                     }
                   },
                   "required": [
@@ -3537,7 +3921,8 @@
                       "type": "object",
                       "properties": {
                         "published": {
-                          "type": "number"
+                          "type": "number",
+                          "description": "The new version number created by the restore."
                         }
                       },
                       "required": [
@@ -3631,13 +4016,15 @@
                         "commenter",
                         "editor",
                         "owner"
-                      ]
+                      ],
+                      "description": "Workspace baseline role applied to anyone without an explicit share."
                     },
                     "members": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/ArtifactMember"
-                      }
+                      },
+                      "description": "Collaborators with an explicit per-artifact role share."
                     }
                   },
                   "required": [
@@ -4022,7 +4409,8 @@
                       "enum": [
                         "none",
                         "member"
-                      ]
+                      ],
+                      "description": "The collection's new workspace share scope."
                     }
                   },
                   "required": [
@@ -4135,7 +4523,8 @@
                   "type": "object",
                   "properties": {
                     "created_by": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "User id of the collection's creator."
                     },
                     "members": {
                       "type": "array",
@@ -4843,7 +5232,8 @@
                           "type": "array",
                           "items": {
                             "type": "string"
-                          }
+                          },
+                          "description": "Thread ids this proposal flipped to addressed (pending review)."
                         }
                       },
                       "required": [
@@ -4987,7 +5377,8 @@
                       "type": "object",
                       "properties": {
                         "published": {
-                          "type": "number"
+                          "type": "number",
+                          "description": "The version number the approved proposal became live as."
                         }
                       },
                       "required": [
@@ -5182,7 +5573,8 @@
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/ReviewRound"
-                      }
+                      },
+                      "description": "All review rounds, newest first."
                     },
                     "pending": {
                       "allOf": [
@@ -5190,7 +5582,8 @@
                           "$ref": "#/components/schemas/ReviewRound"
                         },
                         {
-                          "nullable": true
+                          "nullable": true,
+                          "description": "The current unsettled round, or null if none is pending."
                         }
                       ]
                     }
@@ -5329,10 +5722,12 @@
                       "enum": [
                         "open",
                         "resolved"
-                      ]
+                      ],
+                      "description": "The thread's new state: resolved, or open when reopened."
                     },
                     "updated": {
-                      "type": "number"
+                      "type": "number",
+                      "description": "Number of comments in the thread whose state changed."
                     }
                   },
                   "required": [
@@ -6386,13 +6781,15 @@
                   "properties": {
                     "base": {
                       "type": "string",
-                      "nullable": true
+                      "nullable": true,
+                      "description": "Base host subdomains hang off (e.g. derive.to); null if disabled."
                     },
                     "domains": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/ArtifactDomain"
-                      }
+                      },
+                      "description": "The artifact's own vanity subdomains, managed here."
                     },
                     "workspace_domains": {
                       "type": "array",
@@ -6403,14 +6800,16 @@
                             "type": "string"
                           },
                           "url": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "This artifact's URL on that domain, including its ref."
                           }
                         },
                         "required": [
                           "host",
                           "url"
                         ]
-                      }
+                      },
+                      "description": "Workspace custom domains this artifact is served at (read-only)."
                     }
                   },
                   "required": [
@@ -6524,17 +6923,20 @@
                   "type": "object",
                   "properties": {
                     "enabled": {
-                      "type": "boolean"
+                      "type": "boolean",
+                      "description": "True when this server supports custom domains."
                     },
                     "cname_target": {
                       "type": "string",
-                      "nullable": true
+                      "nullable": true,
+                      "description": "The CNAME target to point domains at; null when they're disabled."
                     },
                     "domains": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/WorkspaceDomain"
-                      }
+                      },
+                      "description": "The workspace's attached custom domains."
                     }
                   },
                   "required": [
@@ -6567,7 +6969,8 @@
                       "type": "object",
                       "properties": {
                         "cname_target": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "The CNAME target to point your domain at."
                         }
                       },
                       "required": [
@@ -6592,7 +6995,8 @@
                       "type": "object",
                       "properties": {
                         "cname_target": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "The CNAME target to point your domain at."
                         }
                       },
                       "required": [

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2,103 +2,8 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Derive API",
-    "version": "1.0.0",
-    "description": "Derive's HTTP API. Every response shape here is the single source of truth for the web client — generated from the same Zod schemas that back this reference, so the docs never drift from the running API.\n\n**Auth:** a session cookie (browser) or a bearer token (agents and the CLI). Most write routes are scoped to the caller's active workspace. The `/v1` paths are the stable product surface; `/openapi.json` serves this spec and `/docs` renders it."
+    "version": "1.0.0"
   },
-  "tags": [
-    {
-      "name": "Artifacts",
-      "description": "Documents (files and bundles): browse, publish, version, restore, and control access."
-    },
-    {
-      "name": "Comments",
-      "description": "Threaded, anchored comments with reactions, edits, and resolution."
-    },
-    {
-      "name": "Proposals",
-      "description": "Suggested revisions awaiting review — the propose → approve / request-changes flow."
-    },
-    {
-      "name": "Review",
-      "description": "Review rounds on an artifact: request a review, send it back, or approve."
-    },
-    {
-      "name": "Collections",
-      "description": "Shareable groups of artifacts, each with its own members."
-    },
-    {
-      "name": "Sharing",
-      "description": "Per-artifact collaborator roles (shares) layered over the workspace baseline."
-    },
-    {
-      "name": "Contexts",
-      "description": "Askable agent setups: wire an agent to a manifest, then open Q&A sessions against it."
-    },
-    {
-      "name": "Agents",
-      "description": "Registered agents (bearer tokens) and the OAuth agents a user has authorized."
-    },
-    {
-      "name": "Assets",
-      "description": "Standalone binary image assets referenced from bundles."
-    },
-    {
-      "name": "Favorites",
-      "description": "The caller's favorited artifacts."
-    },
-    {
-      "name": "Follows",
-      "description": "Follow people and repo paths to build the activity feed."
-    },
-    {
-      "name": "Notifications",
-      "description": "The caller's in-app notification feed."
-    },
-    {
-      "name": "Session",
-      "description": "Identity: the signed-in user, public profiles, and the people directory."
-    },
-    {
-      "name": "Workspace",
-      "description": "The workspace itself: members, settings, invitations, and switching."
-    },
-    {
-      "name": "Domains",
-      "description": "Custom domains and vanity subdomains bound to artifacts."
-    },
-    {
-      "name": "Sync",
-      "description": "GitHub repository mirroring: connect a repo and keep its docs in sync."
-    },
-    {
-      "name": "Slack",
-      "description": "Slack connection status and integration toggles."
-    },
-    {
-      "name": "Webhooks",
-      "description": "Outgoing webhooks and their delivery log."
-    },
-    {
-      "name": "OAuth",
-      "description": "OAuth 2.1 authorization-server endpoints and sign-in capabilities."
-    },
-    {
-      "name": "Realtime",
-      "description": "Live presence and cursor sharing on an artifact."
-    },
-    {
-      "name": "Analytics",
-      "description": "Aggregate view statistics for an artifact."
-    },
-    {
-      "name": "Moderation",
-      "description": "Abuse reports and takedown / reinstate actions."
-    },
-    {
-      "name": "Vitals",
-      "description": "Client-reported web-vitals ingestion."
-    }
-  ],
   "components": {
     "schemas": {
       "PublicProfile": {
@@ -113,27 +18,22 @@
           },
           "image": {
             "type": "string",
-            "nullable": true,
-            "description": "Avatar URL; null if none is set."
+            "nullable": true
           },
           "profession": {
             "type": "string",
-            "nullable": true,
-            "description": "Self-set team role ('what you do'); null if unset."
+            "nullable": true
           },
           "about": {
             "type": "string",
-            "nullable": true,
-            "description": "One-line bio; on the full profile only, null if unset."
+            "nullable": true
           },
           "github_login": {
             "type": "string",
-            "nullable": true,
-            "description": "Linked GitHub login; full profile only, null if not linked."
+            "nullable": true
           },
           "teammate": {
-            "type": "boolean",
-            "description": "True when the viewer shares a workspace with this user."
+            "type": "boolean"
           },
           "stats": {
             "type": "object",
@@ -144,12 +44,10 @@
             },
             "required": [
               "works"
-            ],
-            "description": "Authored-works count; present only for teammates."
+            ]
           },
           "followed_by_me": {
-            "type": "boolean",
-            "description": "Whether the signed-in viewer follows this user."
+            "type": "boolean"
           }
         },
         "required": [
@@ -162,42 +60,35 @@
         "type": "object",
         "properties": {
           "short_id": {
-            "type": "string",
-            "description": "Stable public id — the /a/<short_id> URL slug."
+            "type": "string"
           },
           "url": {
-            "type": "string",
-            "description": "Canonical public URL of the artifact."
+            "type": "string"
           },
           "title": {
             "type": "string",
-            "nullable": true,
-            "description": "Display title; null when untitled or taken down."
+            "nullable": true
           },
           "kind": {
             "type": "string",
             "enum": [
               "file",
               "bundle"
-            ],
-            "description": "file = single file; bundle = multi-file archive (skill, site, or docs folder)."
+            ]
           },
           "current_content_type": {
             "type": "string",
-            "nullable": true,
-            "description": "MIME type of the current version's content."
+            "nullable": true
           },
           "locked": {
-            "type": "boolean",
-            "description": "When true, direct publishes are blocked — changes go through review."
+            "type": "boolean"
           },
           "workspace_access": {
             "type": "string",
             "enum": [
               "none",
               "member"
-            ],
-            "description": "v2 access: member = workspace seats reach it at their role; none = they don't."
+            ]
           },
           "link_role": {
             "type": "string",
@@ -206,8 +97,7 @@
               "viewer",
               "commenter",
               "editor"
-            ],
-            "description": "v2 access: what merely holding the world link confers (none = no link)."
+            ]
           },
           "listed": {
             "type": "string",
@@ -215,28 +105,22 @@
               "none",
               "workspace",
               "public"
-            ],
-            "description": "v2 access: where it surfaces for discovery — nowhere, the workspace, or public."
+            ]
           },
           "password_protected": {
-            "type": "boolean",
-            "description": "true when the world link is password-locked (the password is never returned)."
+            "type": "boolean"
           },
           "org_id": {
-            "type": "string",
-            "description": "The artifact's workspace id; drives move-to-workspace."
+            "type": "string"
           },
           "raw_token": {
-            "type": "string",
-            "description": "Signed, short-lived token for fetching raw content; detail responses only."
+            "type": "string"
           },
           "spa": {
-            "type": "boolean",
-            "description": "true when the bundle is a single-page app (all paths route to the entry)."
+            "type": "boolean"
           },
           "current_version": {
-            "type": "number",
-            "description": "Latest version number; 0 before any content is published."
+            "type": "number"
           },
           "versions": {
             "type": "array",
@@ -247,17 +131,14 @@
                   "type": "number"
                 },
                 "content_type": {
-                  "type": "string",
-                  "description": "MIME type of this version's content."
+                  "type": "string"
                 },
                 "author": {
-                  "type": "string",
-                  "description": "Display byline; heals to the author's current name."
+                  "type": "string"
                 },
                 "author_login": {
                   "type": "string",
-                  "nullable": true,
-                  "description": "Committer's GitHub login; null when not a GitHub commit."
+                  "nullable": true
                 },
                 "author_avatar": {
                   "type": "string",
@@ -265,23 +146,19 @@
                 },
                 "author_gh_id": {
                   "type": "string",
-                  "nullable": true,
-                  "description": "Committer's GitHub user id; null when not a GitHub commit."
+                  "nullable": true
                 },
                 "handle": {
                   "type": "string",
-                  "nullable": true,
-                  "description": "Committer's Derive @handle; null unless they signed in with GitHub."
+                  "nullable": true
                 },
                 "message": {
                   "type": "string",
-                  "nullable": true,
-                  "description": "Version (commit) message; null when none given."
+                  "nullable": true
                 },
                 "name": {
                   "type": "string",
-                  "nullable": true,
-                  "description": "Optional version label; null when unnamed."
+                  "nullable": true
                 },
                 "created_at": {
                   "type": "string"
@@ -300,12 +177,10 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/VersionSession"
-            },
-            "description": "Versions grouped into time-clustered sessions for the UI (newest-first)."
+            }
           },
           "views": {
-            "type": "number",
-            "description": "Total views; present only when analytics is enabled."
+            "type": "number"
           },
           "my_role": {
             "type": "string",
@@ -316,8 +191,7 @@
               "editor",
               "owner",
               null
-            ],
-            "description": "The caller's effective permission tier; null when they have none."
+            ]
           },
           "tags": {
             "type": "array",
@@ -326,68 +200,54 @@
             }
           },
           "favorite": {
-            "type": "boolean",
-            "description": "true when the caller has favorited this."
+            "type": "boolean"
           },
           "has_preview": {
-            "type": "boolean",
-            "description": "true when the current version has a ready screenshot preview."
+            "type": "boolean"
           },
           "open_proposals": {
-            "type": "number",
-            "description": "Count of open (pending-review) proposals."
+            "type": "number"
           },
           "proposals_total": {
-            "type": "number",
-            "description": "Count of all proposals except withdrawn ones."
+            "type": "number"
           },
           "open_threads": {
-            "type": "number",
-            "description": "Count of open (unresolved) comment threads."
+            "type": "number"
           },
           "mentions_me": {
-            "type": "boolean",
-            "description": "true when an open thread @mentions the calling user."
+            "type": "boolean"
           },
           "i_participated": {
-            "type": "boolean",
-            "description": "true when the caller authored or commented in a thread here."
+            "type": "boolean"
           },
           "collections": {
             "type": "array",
             "items": {
               "type": "string"
-            },
-            "description": "Ids of the collections that include this artifact."
+            }
           },
           "removed": {
-            "type": "boolean",
-            "description": "true when the artifact has been taken down (tombstone)."
+            "type": "boolean"
           },
           "managed": {
-            "type": "boolean",
-            "description": "true when mirrored from a GitHub sync — read-only in Derive."
+            "type": "boolean"
           },
           "bundle": {
             "type": "object",
             "properties": {
               "isSkill": {
-                "type": "boolean",
-                "description": "true when the bundle is a skill (entry SKILL.md)."
+                "type": "boolean"
               },
               "name": {
                 "type": "string",
-                "nullable": true,
-                "description": "Skill/bundle name; null when not declared."
+                "nullable": true
               },
               "description": {
                 "type": "string",
-                "nullable": true,
-                "description": "Skill/bundle description; null when not declared."
+                "nullable": true
               },
               "entry": {
-                "type": "string",
-                "description": "Path of the entry document rendered first."
+                "type": "string"
               },
               "files": {
                 "type": "array",
@@ -405,8 +265,7 @@
                     "path",
                     "type"
                   ]
-                },
-                "description": "The bundle's file tree (path + MIME type) for navigation."
+                }
               }
             },
             "required": [
@@ -415,41 +274,34 @@
               "description",
               "entry",
               "files"
-            ],
-            "description": "Present for a markdown bundle (skill or docs folder): entry, file tree, identity."
+            ]
           },
           "source_path": {
             "type": "string",
-            "nullable": true,
-            "description": "Source path (e.g. the repo path of a synced artifact); null when none."
+            "nullable": true
           },
           "created_at": {
             "type": "string"
           },
           "updated_at": {
             "type": "string",
-            "nullable": true,
-            "description": "Last-update timestamp; null when never updated since creation."
+            "nullable": true
           },
           "author_name": {
             "type": "string",
-            "nullable": true,
-            "description": "Raw current-author name; the resolved `author` object is preferred."
+            "nullable": true
           },
           "author_login": {
             "type": "string",
-            "nullable": true,
-            "description": "Raw current-author GitHub login; null when not from GitHub."
+            "nullable": true
           },
           "author_avatar": {
             "type": "string",
-            "nullable": true,
-            "description": "Raw current-author avatar URL; null when none."
+            "nullable": true
           },
           "author_gh_id": {
             "type": "string",
-            "nullable": true,
-            "description": "Raw current-author GitHub id; null when not from GitHub."
+            "nullable": true
           },
           "author": {
             "type": "object",
@@ -461,8 +313,7 @@
               },
               "login": {
                 "type": "string",
-                "nullable": true,
-                "description": "GitHub login; null if never signed in with GitHub."
+                "nullable": true
               },
               "avatar": {
                 "type": "string",
@@ -470,8 +321,7 @@
               },
               "handle": {
                 "type": "string",
-                "nullable": true,
-                "description": "Derive @handle; null when the author has none."
+                "nullable": true
               }
             },
             "required": [
@@ -479,8 +329,7 @@
               "login",
               "avatar",
               "handle"
-            ],
-            "description": "Resolved current-author profile; preferred over the raw author_* fields."
+            ]
           }
         },
         "required": [
@@ -496,28 +345,23 @@
         "type": "object",
         "properties": {
           "n": {
-            "type": "number",
-            "description": "Newest version number in this grouped session."
+            "type": "number"
           },
           "from_n": {
-            "type": "number",
-            "description": "Oldest version number in this grouped session."
+            "type": "number"
           },
           "count": {
-            "type": "number",
-            "description": "How many versions this session groups."
+            "type": "number"
           },
           "author": {
             "type": "string"
           },
           "name": {
             "type": "string",
-            "nullable": true,
-            "description": "Session label; null when unnamed."
+            "nullable": true
           },
           "created_at": {
-            "type": "string",
-            "description": "Timestamp of the newest version in the group."
+            "type": "string"
           }
         },
         "required": [
@@ -533,8 +377,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "description": "User id, or the agent id when kind is agent."
+            "type": "string"
           },
           "name": {
             "type": "string",
@@ -542,21 +385,18 @@
           },
           "handle": {
             "type": "string",
-            "nullable": true,
-            "description": "The @handle; null for agents (and users without one)."
+            "nullable": true
           },
           "kind": {
             "type": "string",
             "enum": [
               "user",
               "agent"
-            ],
-            "description": "Whether this entry is a person (user) or an agent."
+            ]
           },
           "profession": {
             "type": "string",
-            "nullable": true,
-            "description": "The person's role; null for agents."
+            "nullable": true
           }
         },
         "required": [
@@ -573,18 +413,15 @@
           },
           "handle": {
             "type": "string",
-            "nullable": true,
-            "description": "Public @handle; null when the user has none."
+            "nullable": true
           },
           "name": {
             "type": "string",
-            "nullable": true,
-            "description": "Display name; null when unset."
+            "nullable": true
           },
           "profession": {
             "type": "string",
-            "nullable": true,
-            "description": "Joined only on workspace-member payloads; absent on artifact/collection lists."
+            "nullable": true
           },
           "role": {
             "type": "string",
@@ -593,8 +430,7 @@
               "commenter",
               "editor",
               "owner"
-            ],
-            "description": "Permission tier, ascending: viewer < commenter < editor < owner."
+            ]
           }
         },
         "required": [
@@ -620,8 +456,7 @@
               "commenter",
               "editor",
               "owner"
-            ],
-            "description": "The caller's role in this workspace (owner = Admin)."
+            ]
           },
           "members": {
             "type": "array",
@@ -646,8 +481,7 @@
                 "type": "string",
                 "enum": [
                   "member"
-                ],
-                "description": "The invitee already had an account and was added directly."
+                ]
               },
               "member": {
                 "$ref": "#/components/schemas/ArtifactMember"
@@ -665,15 +499,13 @@
                 "type": "string",
                 "enum": [
                   "invite"
-                ],
-                "description": "No account yet — a pending invite was created instead."
+                ]
               },
               "invite": {
                 "$ref": "#/components/schemas/Invite"
               },
               "accept_url": {
-                "type": "string",
-                "description": "The link the invitee follows to accept."
+                "type": "string"
               }
             },
             "required": [
@@ -700,15 +532,13 @@
               "commenter",
               "editor",
               "owner"
-            ],
-            "description": "The role the invitee will receive (owner = Admin)."
+            ]
           },
           "created_at": {
             "type": "string"
           },
           "expires_at": {
-            "type": "string",
-            "description": "When the invite expires (7-day TTL)."
+            "type": "string"
           }
         },
         "required": [
@@ -723,8 +553,7 @@
         "type": "object",
         "properties": {
           "workspace": {
-            "type": "string",
-            "description": "Name of the workspace this invite joins."
+            "type": "string"
           },
           "role": {
             "type": "string",
@@ -733,17 +562,14 @@
               "commenter",
               "editor",
               "owner"
-            ],
-            "description": "The role this invite grants (owner = Admin)."
+            ]
           },
           "email": {
-            "type": "string",
-            "description": "The email address the invite was addressed to."
+            "type": "string"
           },
           "inviter": {
             "type": "string",
-            "nullable": true,
-            "description": "The inviter's display name; null if unknown."
+            "nullable": true
           }
         },
         "required": [
@@ -757,32 +583,32 @@
         "type": "object",
         "properties": {
           "emailNotifications": {
-            "type": "boolean",
-            "description": "When true, send workspace email notifications."
+            "type": "boolean"
           },
           "githubPostComments": {
-            "type": "boolean",
-            "description": "When true, post Derive comments onto the linked GitHub PR."
+            "type": "boolean"
           },
           "githubMirrorComments": {
-            "type": "boolean",
-            "description": "When true, mirror GitHub PR comments back into Derive."
+            "type": "boolean"
           },
           "githubPreviewLink": {
-            "type": "boolean",
-            "description": "When true, add a preview link to the linked GitHub PR."
+            "type": "boolean"
           },
           "slackPost": {
-            "type": "boolean",
-            "description": "When true, post events to Slack."
+            "type": "boolean"
+          },
+          "slackEvents": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "boolean"
+            }
           },
           "defaultWorkspaceAccess": {
             "type": "string",
             "enum": [
               "none",
               "member"
-            ],
-            "description": "Access a new publish lands with: none, or member (factory default)."
+            ]
           },
           "defaultLinkRole": {
             "type": "string",
@@ -791,8 +617,7 @@
               "viewer",
               "commenter",
               "editor"
-            ],
-            "description": "Share-link role a new publish lands with (factory default: none)."
+            ]
           },
           "defaultListed": {
             "type": "string",
@@ -800,8 +625,7 @@
               "none",
               "workspace",
               "public"
-            ],
-            "description": "Listing a new publish lands with: none (default), workspace, or public."
+            ]
           }
         },
         "required": [
@@ -819,12 +643,10 @@
         "type": "object",
         "properties": {
           "multi": {
-            "type": "boolean",
-            "description": "Whether multi-workspace mode is enabled."
+            "type": "boolean"
           },
           "active": {
-            "type": "string",
-            "description": "Id of the workspace this request resolved to."
+            "type": "string"
           },
           "account": {
             "$ref": "#/components/schemas/AccountSummary"
@@ -852,8 +674,7 @@
           },
           "handle": {
             "type": "string",
-            "nullable": true,
-            "description": "The account's @handle; null if unclaimed."
+            "nullable": true
           },
           "name": {
             "type": "string",
@@ -864,8 +685,7 @@
           "id",
           "handle",
           "name"
-        ],
-        "description": "The owner's identity (id + handle); null for anonymous callers."
+        ]
       },
       "WorkspaceSummary": {
         "type": "object",
@@ -883,12 +703,10 @@
               "commenter",
               "editor",
               "owner"
-            ],
-            "description": "The caller's role in this workspace (owner = Admin)."
+            ]
           },
           "personal": {
-            "type": "boolean",
-            "description": "True for the auto-provisioned personal workspace (id ws_p_<userId>)."
+            "type": "boolean"
           }
         },
         "required": [
@@ -914,8 +732,7 @@
               "commenter",
               "editor",
               "owner"
-            ],
-            "description": "Permission level; commenter proposes only, editor can write, owner never allowed"
+            ]
           },
           "created_at": {
             "type": "string"
@@ -932,8 +749,7 @@
         "type": "object",
         "properties": {
           "clientId": {
-            "type": "string",
-            "description": "OAuth client id of the authorized agent (e.g. an MCP client like Claude)"
+            "type": "string"
           },
           "clientName": {
             "type": "string"
@@ -942,8 +758,7 @@
             "type": "array",
             "items": {
               "type": "string"
-            },
-            "description": "The OAuth scopes this agent was granted"
+            }
           },
           "grantedAt": {
             "type": "string"
@@ -960,12 +775,10 @@
         "type": "object",
         "properties": {
           "key": {
-            "type": "string",
-            "description": "The blob hash (content-addressed storage key)"
+            "type": "string"
           },
           "ref": {
-            "type": "string",
-            "description": "The exact \"asset:<hash>\" string to drop into a publish files map"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -974,12 +787,10 @@
               "image/jpeg",
               "image/gif",
               "image/webp"
-            ],
-            "description": "The sniffed image MIME type (PNG, JPEG, GIF, or WebP)"
+            ]
           },
           "size": {
-            "type": "number",
-            "description": "The asset's size in bytes"
+            "type": "number"
           }
         },
         "required": [
@@ -996,12 +807,10 @@
             "type": "string"
           },
           "org_id": {
-            "type": "string",
-            "description": "The workspace this follow is scoped to; \"*\" (global) for people-follows"
+            "type": "string"
           },
           "user_id": {
-            "type": "string",
-            "description": "The follower (the signed-in user who owns this follow)"
+            "type": "string"
           },
           "kind": {
             "type": "string",
@@ -1009,30 +818,25 @@
               "author",
               "path",
               "user"
-            ],
-            "description": "What's followed: a GitHub author, a repo path prefix, or a person"
+            ]
           },
           "target": {
-            "type": "string",
-            "description": "The followed value: author login, path prefix, or (people) public @handle"
+            "type": "string"
           },
           "created_at": {
             "type": "string"
           },
           "handle": {
             "type": "string",
-            "nullable": true,
-            "description": "For people-follows, the followed person's public @handle; absent otherwise"
+            "nullable": true
           },
           "name": {
             "type": "string",
-            "nullable": true,
-            "description": "For people-follows, the followed person's display name; absent otherwise"
+            "nullable": true
           },
           "image": {
             "type": "string",
-            "nullable": true,
-            "description": "For people-follows, the followed person's avatar URL; absent otherwise"
+            "nullable": true
           }
         },
         "required": [
@@ -1054,23 +858,20 @@
             "type": "string"
           },
           "created_by": {
-            "type": "string",
-            "description": "Creator's user id (\"anon\" if created anonymously)."
+            "type": "string"
           },
           "created_at": {
             "type": "string"
           },
           "count": {
-            "type": "number",
-            "description": "Number of artifacts in the collection."
+            "type": "number"
           },
           "workspace_access": {
             "type": "string",
             "enum": [
               "none",
               "member"
-            ],
-            "description": "Workspace share scope: \"member\" (all members) or \"none\" (invite-only)."
+            ]
           },
           "my_role": {
             "type": "string",
@@ -1081,8 +882,7 @@
               "editor",
               "owner",
               null
-            ],
-            "description": "Caller's own role on the collection; drives the Share dialog. Null if none."
+            ]
           },
           "kind": {
             "type": "string",
@@ -1090,20 +890,16 @@
               "manual",
               "repo",
               "pr"
-            ],
-            "description": "Origin: \"manual\" (user-made), \"repo\" (GitHub mirror), or \"pr\" (PR preview)."
+            ]
           },
           "parentId": {
-            "type": "string",
-            "description": "For a PR preview: the repo collection it nests under, when connected."
+            "type": "string"
           },
           "prNumber": {
-            "type": "number",
-            "description": "For a PR preview: the pull-request number."
+            "type": "number"
           },
           "repo": {
-            "type": "string",
-            "description": "For repo/PR collections: the \"owner/name\" slug."
+            "type": "string"
           }
         },
         "required": [
@@ -1121,30 +917,25 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/RepoSource"
-            },
-            "description": "Branch mirrors, one per connected repo."
+            }
           },
           "prs": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/PrPreview"
-            },
-            "description": "PR previews, one per pull request being mirrored."
+            }
           },
           "app": {
             "type": "object",
             "properties": {
               "configured": {
-                "type": "boolean",
-                "description": "True when a live GitHub App is set up on this server."
+                "type": "boolean"
               },
               "slug": {
-                "type": "string",
-                "description": "The App's GitHub slug for install links; absent when unconfigured."
+                "type": "string"
               },
               "upToDate": {
-                "type": "boolean",
-                "description": "True when the App has every required permission and event."
+                "type": "boolean"
               },
               "missing": {
                 "type": "object",
@@ -1153,43 +944,36 @@
                     "type": "object",
                     "additionalProperties": {
                       "type": "string"
-                    },
-                    "description": "Scope → level still to grant (e.g. contents → read)."
+                    }
                   },
                   "events": {
                     "type": "array",
                     "items": {
                       "type": "string"
-                    },
-                    "description": "Webhook event names still to subscribe to."
+                    }
                   }
                 },
                 "required": [
                   "permissions",
                   "events"
-                ],
-                "description": "Permissions and events still to grant; absent when up to date."
+                ]
               },
               "permissionsUrl": {
-                "type": "string",
-                "description": "GitHub URL to adjust the App's permissions; absent when unconfigured."
+                "type": "string"
               },
               "approveUrl": {
-                "type": "string",
-                "description": "GitHub URL to install or approve the App; absent when unconfigured."
+                "type": "string"
               }
             },
             "required": [
               "configured"
-            ],
-            "description": "The instance GitHub App's setup and permission state."
+            ]
           },
           "installations": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/GithubInstallation"
-            },
-            "description": "This workspace's App installations (entry points to the repo picker)."
+            }
           }
         },
         "required": [
@@ -1206,40 +990,32 @@
             "type": "string"
           },
           "collection_id": {
-            "type": "string",
-            "description": "Collection the repo's docs are mirrored into."
+            "type": "string"
           },
           "repo": {
-            "type": "string",
-            "description": "The connected GitHub repo, as owner/name."
+            "type": "string"
           },
           "ref": {
-            "type": "string",
-            "description": "Branch or tag to mirror; \"HEAD\" tracks the default branch."
+            "type": "string"
           },
           "includes": {
-            "type": "string",
-            "description": "Comma-separated glob patterns selecting which files to mirror."
+            "type": "string"
           },
           "token": {
             "type": "string",
-            "nullable": true,
-            "description": "Redacted to \"•••\" when a PAT is stored; null for App-backed sources."
+            "nullable": true
           },
           "installation_id": {
             "type": "string",
-            "nullable": true,
-            "description": "GitHub App installation backing this source; null when using a PAT."
+            "nullable": true
           },
           "last_synced_at": {
             "type": "string",
-            "nullable": true,
-            "description": "When the last sync finished; null if it has never synced."
+            "nullable": true
           },
           "last_status": {
             "type": "string",
-            "nullable": true,
-            "description": "Outcome of the last sync run; null if it has never synced."
+            "nullable": true
           },
           "created_by": {
             "type": "string"
@@ -1248,13 +1024,11 @@
             "type": "string"
           },
           "file_count": {
-            "type": "number",
-            "description": "How many files are currently mirrored from the repo."
+            "type": "number"
           },
           "progress": {
             "type": "string",
-            "nullable": true,
-            "description": "Live sync progress as a JSON blob driving the bar; null when none recorded."
+            "nullable": true
           }
         },
         "required": [
@@ -1280,39 +1054,31 @@
             "type": "string"
           },
           "collection_id": {
-            "type": "string",
-            "description": "Collection holding this PR's previewed docs."
+            "type": "string"
           },
           "repo": {
-            "type": "string",
-            "description": "The connected GitHub repo, as owner/name."
+            "type": "string"
           },
           "pr_number": {
-            "type": "number",
-            "description": "The pull request number this preview mirrors."
+            "type": "number"
           },
           "title": {
-            "type": "string",
-            "description": "The PR's title, used as the preview's display name."
+            "type": "string"
           },
           "last_status": {
             "type": "string",
-            "nullable": true,
-            "description": "Outcome of the last sync run; null if it has never synced."
+            "nullable": true
           },
           "last_synced_at": {
             "type": "string",
-            "nullable": true,
-            "description": "When the last sync finished; null if it has never synced."
+            "nullable": true
           },
           "file_count": {
-            "type": "number",
-            "description": "How many of the PR's changed docs are mirrored."
+            "type": "number"
           },
           "progress": {
             "type": "string",
-            "nullable": true,
-            "description": "Live sync progress as a JSON blob driving the bar; null when none recorded."
+            "nullable": true
           }
         },
         "required": [
@@ -1331,13 +1097,11 @@
         "type": "object",
         "properties": {
           "installation_id": {
-            "type": "string",
-            "description": "GitHub's numeric App installation id, as a string."
+            "type": "string"
           },
           "account_login": {
             "type": "string",
-            "nullable": true,
-            "description": "The org/user the App is installed on; null until GitHub reports it."
+            "nullable": true
           }
         },
         "required": [
@@ -1349,21 +1113,17 @@
         "type": "object",
         "properties": {
           "full_name": {
-            "type": "string",
-            "description": "The repository's full name, as owner/name."
+            "type": "string"
           },
           "private": {
-            "type": "boolean",
-            "description": "True when the repo is private on GitHub."
+            "type": "boolean"
           },
           "default_branch": {
-            "type": "string",
-            "description": "The repo's default branch (e.g. main)."
+            "type": "string"
           },
           "pushed_at": {
             "type": "string",
-            "nullable": true,
-            "description": "When the repo was last pushed to; null if unknown. Drives sort order."
+            "nullable": true
           }
         },
         "required": [
@@ -1377,24 +1137,19 @@
         "type": "object",
         "properties": {
           "total": {
-            "type": "number",
-            "description": "Total files matching the include globs."
+            "type": "number"
           },
           "md": {
-            "type": "number",
-            "description": "How many matches are Markdown files."
+            "type": "number"
           },
           "html": {
-            "type": "number",
-            "description": "How many matches are HTML files."
+            "type": "number"
           },
           "other": {
-            "type": "number",
-            "description": "Matches that are neither Markdown nor HTML."
+            "type": "number"
           },
           "truncated": {
-            "type": "boolean",
-            "description": "True when GitHub capped the tree, so counts are a lower bound."
+            "type": "boolean"
           }
         },
         "required": [
@@ -1412,27 +1167,22 @@
             "type": "string"
           },
           "repo": {
-            "type": "string",
-            "description": "The connected GitHub repo, as owner/name."
+            "type": "string"
           },
           "progress": {
             "type": "string",
-            "nullable": true,
-            "description": "Live sync progress as a JSON blob driving the bar; null when none recorded."
+            "nullable": true
           },
           "last_status": {
             "type": "string",
-            "nullable": true,
-            "description": "Outcome of the last sync run; null if it has never synced."
+            "nullable": true
           },
           "last_synced_at": {
             "type": "string",
-            "nullable": true,
-            "description": "When the last sync finished; null if it has never synced."
+            "nullable": true
           },
           "file_count": {
-            "type": "number",
-            "description": "How many files are currently mirrored from the repo."
+            "type": "number"
           }
         },
         "required": [
@@ -1448,30 +1198,27 @@
         "type": "object",
         "properties": {
           "available": {
-            "type": "boolean",
-            "description": "True if this instance has Slack configured at all"
+            "type": "boolean"
           },
           "connected": {
-            "type": "boolean",
-            "description": "True if this workspace has connected a Slack team"
+            "type": "boolean"
           },
           "team_name": {
             "type": "string",
-            "nullable": true,
-            "description": "The connected Slack team's name, or null if not connected"
+            "nullable": true
           },
           "default_channel": {
             "type": "string",
-            "nullable": true,
-            "description": "The channel Derive posts to, or null if unset"
+            "nullable": true
           },
           "needs_reauth": {
-            "type": "boolean",
-            "description": "Whether the stored bot token needs a re-auth (an auth error since connecting)"
+            "type": "boolean"
           },
-          "slack_dm": {
-            "type": "boolean",
-            "description": "The caller's \"DM me for interrupts\" preference (mentions, review requests, shares)"
+          "linked": {
+            "type": "boolean"
+          },
+          "mention_dm": {
+            "type": "boolean"
           }
         },
         "required": [
@@ -1480,7 +1227,8 @@
           "team_name",
           "default_channel",
           "needs_reauth",
-          "slack_dm"
+          "linked",
+          "mention_dm"
         ]
       },
       "Report": {
@@ -1496,18 +1244,15 @@
             "type": "string"
           },
           "reason": {
-            "type": "string",
-            "description": "The reporter's stated reason for the report"
+            "type": "string"
           },
           "detail": {
             "type": "string",
-            "nullable": true,
-            "description": "Optional extra detail from the reporter, or null"
+            "nullable": true
           },
           "reporter": {
             "type": "string",
-            "nullable": true,
-            "description": "The reporter's IP (best-effort), or null; abuse reports are anonymous/public"
+            "nullable": true
           },
           "state": {
             "type": "string",
@@ -1515,8 +1260,7 @@
               "open",
               "actioned",
               "dismissed"
-            ],
-            "description": "open (awaiting review), actioned (taken down), or dismissed (no action)"
+            ]
           },
           "created_at": {
             "type": "string"
@@ -1549,22 +1293,18 @@
               "takedown",
               "reinstate",
               "dismiss"
-            ],
-            "description": "What happened: report filed, takedown, reinstate, or dismiss"
+            ]
           },
           "artifact_id": {
             "type": "string",
-            "nullable": true,
-            "description": "The artifact acted on, or null if not artifact-specific"
+            "nullable": true
           },
           "actor": {
-            "type": "string",
-            "description": "Who performed it: a user's name, or an IP/'anonymous' for public reports"
+            "type": "string"
           },
           "detail": {
             "type": "string",
-            "nullable": true,
-            "description": "Context such as the report reason or takedown note, or null"
+            "nullable": true
           },
           "created_at": {
             "type": "string"
@@ -1589,12 +1329,10 @@
               "ctx",
               "add",
               "del"
-            ],
-            "description": "Line op: ctx = unchanged context, add = added, del = removed."
+            ]
           },
           "line": {
-            "type": "string",
-            "description": "The line's text; the +/- marker lives in `t`, not here."
+            "type": "string"
           }
         },
         "required": [
@@ -1615,12 +1353,10 @@
               "approved",
               "changes_requested",
               "withdrawn"
-            ],
-            "description": "Review state: open, approved (went live), changes_requested, or withdrawn."
+            ]
           },
           "author": {
-            "type": "string",
-            "description": "Proposer's display name; \"anonymous\" if not signed in."
+            "type": "string"
           },
           "on_behalf_of": {
             "type": "object",
@@ -1638,52 +1374,43 @@
             "required": [
               "handle",
               "name"
-            ],
-            "description": "When an agent proposed, the human it acted on behalf of; null for a direct human proposal."
+            ]
           },
           "message": {
             "type": "string",
-            "nullable": true,
-            "description": "Proposer's cover message; null if none."
+            "nullable": true
           },
           "base_version": {
-            "type": "number",
-            "description": "Artifact version this proposal was authored against."
+            "type": "number"
           },
           "kind": {
             "type": "string",
             "enum": [
               "file",
               "bundle"
-            ],
-            "description": "Content shape: a single file or a multi-file bundle."
+            ]
           },
           "decided_by": {
             "type": "string",
-            "nullable": true,
-            "description": "Who approved/requested-changes/withdrew it; null while still open."
+            "nullable": true
           },
           "decided_version": {
             "type": "number",
-            "nullable": true,
-            "description": "The version it went live as when approved; null otherwise."
+            "nullable": true
           },
           "decision_note": {
             "type": "string",
-            "nullable": true,
-            "description": "Reviewer's note on the decision; null while open or if none."
+            "nullable": true
           },
           "decided_at": {
             "type": "string",
-            "nullable": true,
-            "description": "When it was decided; null while still open."
+            "nullable": true
           },
           "created_at": {
             "type": "string"
           },
           "preview_url": {
-            "type": "string",
-            "description": "URL that renders the proposed content like a live version."
+            "type": "string"
           },
           "diff": {
             "type": "object",
@@ -1701,8 +1428,7 @@
             "required": [
               "base_version",
               "ops"
-            ],
-            "description": "Line diff vs the base version; present only on the single-proposal fetch."
+            ]
           }
         },
         "required": [
@@ -1730,16 +1456,13 @@
             "type": "string"
           },
           "version": {
-            "type": "number",
-            "description": "The artifact version this round is reviewing."
+            "type": "number"
           },
           "requested_by": {
-            "type": "string",
-            "description": "Who asked for the review (usually the agent that published)."
+            "type": "string"
           },
           "requested_for": {
-            "type": "string",
-            "description": "The person asked to answer or approve this round."
+            "type": "string"
           },
           "state": {
             "type": "string",
@@ -1747,21 +1470,18 @@
               "pending",
               "sent_back",
               "approved"
-            ],
-            "description": "Round state: pending, sent_back (answers returned), or approved (the go-signal)."
+            ]
           },
           "note": {
             "type": "string",
-            "nullable": true,
-            "description": "Free-text note attached to the round; null if none."
+            "nullable": true
           },
           "created_at": {
             "type": "string"
           },
           "resolved_at": {
             "type": "string",
-            "nullable": true,
-            "description": "When it was sent back or approved; null while pending."
+            "nullable": true
           }
         },
         "required": [
@@ -1783,30 +1503,24 @@
             "type": "string"
           },
           "thread_id": {
-            "type": "string",
-            "description": "The thread this comment belongs to; equals id for the thread's root comment."
+            "type": "string"
           },
           "base_version": {
-            "type": "number",
-            "description": "Artifact version this comment was anchored against."
+            "type": "number"
           },
           "path": {
             "type": "string",
-            "nullable": true,
-            "description": "File within a bundle the comment targets; null if not file-scoped."
+            "nullable": true
           },
           "anchor": {
             "type": "string",
-            "nullable": true,
-            "description": "Serialized text-quote or element anchor locating the comment; null if unanchored."
+            "nullable": true
           },
           "body_md": {
-            "type": "string",
-            "description": "Comment body in Markdown; blanked when the comment is deleted."
+            "type": "string"
           },
           "author": {
-            "type": "string",
-            "description": "Author's display name; \"anonymous\" for an anonymous poster."
+            "type": "string"
           },
           "state": {
             "type": "string",
@@ -1815,15 +1529,13 @@
               "addressed",
               "resolved",
               "outdated"
-            ],
-            "description": "Thread state: open, addressed (a proposal in review claims to fix it), resolved, or outdated (the quoted text changed)."
+            ]
           },
           "created_at": {
             "type": "string"
           },
           "anchored": {
-            "type": "boolean",
-            "description": "Whether the anchor still resolves against the current version (list only)."
+            "type": "boolean"
           },
           "reactions": {
             "type": "object",
@@ -1832,28 +1544,23 @@
               "items": {
                 "type": "string"
               }
-            },
-            "description": "Emoji → list of reactor display names."
+            }
           },
           "edited": {
-            "type": "boolean",
-            "description": "True if the body was edited after posting."
+            "type": "boolean"
           },
           "edited_at": {
             "type": "string",
-            "nullable": true,
-            "description": "When the comment was last edited; null if never."
+            "nullable": true
           },
           "deleted": {
-            "type": "boolean",
-            "description": "True if soft-deleted; the row stays but the body is blanked."
+            "type": "boolean"
           },
           "mentions": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Mention"
-            },
-            "description": "Users or agents @mentioned in the comment body."
+            }
           }
         },
         "required": [
@@ -1872,8 +1579,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "description": "Id of the mentioned person or agent."
+            "type": "string"
           },
           "name": {
             "type": "string"
@@ -1894,13 +1600,11 @@
             "type": "string"
           },
           "agent_id": {
-            "type": "string",
-            "description": "The registered agent this context routes asks to."
+            "type": "string"
           },
           "manifest_short_id": {
             "type": "string",
-            "nullable": true,
-            "description": "Short id of the linked manifest artifact; null if it can't be resolved."
+            "nullable": true
           },
           "created_by": {
             "type": "string"
@@ -1910,8 +1614,14 @@
           },
           "runner_seen_at": {
             "type": "string",
-            "nullable": true,
-            "description": "When the runner last polled the queue (~minutely); null = never. Drives online/offline."
+            "nullable": true
+          },
+          "ask_policy": {
+            "type": "string",
+            "enum": [
+              "workspace",
+              "invited"
+            ]
           }
         },
         "required": [
@@ -1921,7 +1631,8 @@
           "manifest_short_id",
           "created_by",
           "created_at",
-          "runner_seen_at"
+          "runner_seen_at",
+          "ask_policy"
         ]
       },
       "Session": {
@@ -1937,8 +1648,7 @@
             "type": "string"
           },
           "context_version": {
-            "type": "number",
-            "description": "The manifest version this session was opened against."
+            "type": "number"
           },
           "state": {
             "type": "string",
@@ -1948,15 +1658,13 @@
               "escalated",
               "failed",
               "closed"
-            ],
-            "description": "open = awaiting the agent; answered; escalated = draft went to review; failed = run crashed; closed = ended by asker/owner."
+            ]
           },
           "created_at": {
             "type": "string"
           },
           "updated_at": {
-            "type": "string",
-            "description": "Last state/message change; equals created_at when never updated."
+            "type": "string"
           }
         },
         "required": [
@@ -1980,16 +1688,13 @@
             "enum": [
               "asker",
               "agent"
-            ],
-            "description": "Who wrote it: asker (the human) or agent (the context's runner)."
+            ]
           },
           "author_id": {
-            "type": "string",
-            "description": "The asker's user id, or the agent id when author_kind is agent."
+            "type": "string"
           },
           "body_md": {
-            "type": "string",
-            "description": "The message body as Markdown."
+            "type": "string"
           },
           "meta": {
             "$ref": "#/components/schemas/SessionMeta"
@@ -2013,25 +1718,21 @@
         "properties": {
           "query": {
             "type": "string",
-            "nullable": true,
-            "description": "The underlying query the agent ran to produce this answer."
+            "nullable": true
           },
           "confidence": {
             "type": "number",
-            "nullable": true,
-            "description": "The agent's confidence in the answer, 0-1 (shown as a percentage)."
+            "nullable": true
           },
           "caveats": {
             "type": "array",
             "items": {
               "type": "string"
-            },
-            "description": "Caveats or limitations the agent flagged on its answer."
+            }
           },
           "escalation_reason": {
             "type": "string",
-            "nullable": true,
-            "description": "Why the agent escalated to a human instead of answering."
+            "nullable": true
           },
           "artifacts": {
             "type": "array",
@@ -2049,27 +1750,22 @@
                 "short_id",
                 "title"
               ]
-            },
-            "description": "Artifacts the agent cited, each linkable by short_id."
+            }
           }
-        },
-        "description": "Structured answer payload on agent messages; null on asker messages."
+        }
       },
       "Viewer": {
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "description": "The viewer's id: a signed-in user's id, or a stable anonymous viewer id"
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "description": "Display name: a user's @handle, or a friendly handle for anonymous viewers"
+            "type": "string"
           },
           "role": {
             "type": "string",
-            "nullable": true,
-            "description": "The viewer's effective role on this artifact, or null if they have none"
+            "nullable": true
           }
         },
         "required": [
@@ -2082,16 +1778,13 @@
         "type": "object",
         "properties": {
           "total": {
-            "type": "number",
-            "description": "Total recorded views across all versions (de-duped opens)"
+            "type": "number"
           },
           "unique": {
-            "type": "number",
-            "description": "Distinct viewers; a signed-in person or anon cookie counts once"
+            "type": "number"
           },
           "anonViewers": {
-            "type": "number",
-            "description": "How many of the unique viewers are anonymous"
+            "type": "number"
           },
           "perVersion": {
             "type": "array",
@@ -2102,8 +1795,7 @@
                   "type": "number"
                 },
                 "count": {
-                  "type": "number",
-                  "description": "Views recorded for that version"
+                  "type": "number"
                 }
               },
               "required": [
@@ -2118,12 +1810,10 @@
               "type": "object",
               "properties": {
                 "day": {
-                  "type": "string",
-                  "description": "Calendar day bucket (YYYY-MM-DD)"
+                  "type": "string"
                 },
                 "count": {
-                  "type": "number",
-                  "description": "Views recorded on that day"
+                  "type": "number"
                 }
               },
               "required": [
@@ -2138,25 +1828,21 @@
               "type": "object",
               "properties": {
                 "viewer": {
-                  "type": "string",
-                  "description": "Display name (resolved @handle for users), or the anon viewer id"
+                  "type": "string"
                 },
                 "kind": {
                   "type": "string",
                   "enum": [
                     "user",
                     "anon"
-                  ],
-                  "description": "Whether the viewer is a signed-in user or anonymous"
+                  ]
                 },
                 "at": {
-                  "type": "string",
-                  "description": "When they last viewed (ISO timestamp)"
+                  "type": "string"
                 },
                 "avatar": {
                   "type": "string",
-                  "nullable": true,
-                  "description": "The user's avatar URL, or null/absent for anonymous viewers"
+                  "nullable": true
                 }
               },
               "required": [
@@ -2183,12 +1869,10 @@
             "type": "string"
           },
           "user_id": {
-            "type": "string",
-            "description": "The recipient this notification belongs to"
+            "type": "string"
           },
           "actor": {
-            "type": "string",
-            "description": "Who triggered it; for follow/publish this is the person's @handle"
+            "type": "string"
           },
           "kind": {
             "type": "string",
@@ -2199,32 +1883,26 @@
               "follow",
               "publish",
               "review"
-            ],
-            "description": "What happened: mention, comment, share, follow, publish, or review"
+            ]
           },
           "artifact_id": {
             "type": "string"
           },
           "artifact_short_id": {
-            "type": "string",
-            "description": "The artifact's public short id for links; empty for follows (no anchor)"
+            "type": "string"
           },
           "artifact_title": {
             "type": "string",
-            "nullable": true,
-            "description": "The artifact's title, or null if untitled or not artifact-anchored"
+            "nullable": true
           },
           "thread_id": {
-            "type": "string",
-            "description": "The comment thread anchor; empty when not comment-related"
+            "type": "string"
           },
           "comment_id": {
-            "type": "string",
-            "description": "The specific comment anchor; empty when not comment-related"
+            "type": "string"
           },
           "preview": {
-            "type": "string",
-            "description": "Short text preview shown in the notification bell"
+            "type": "string"
           },
           "read": {
             "anyOf": [
@@ -2240,8 +1918,7 @@
                   1
                 ]
               }
-            ],
-            "description": "Whether the user has read it: 0 unread, 1 read"
+            ]
           },
           "created_at": {
             "type": "string"
@@ -2270,29 +1947,24 @@
           },
           "artifact_id": {
             "type": "string",
-            "nullable": true,
-            "description": "The artifact this webhook is scoped to, or null to fire on all workspace events"
+            "nullable": true
           },
           "url": {
-            "type": "string",
-            "description": "The destination endpoint deliveries are POSTed to"
+            "type": "string"
           },
           "kind": {
             "type": "string",
             "enum": [
               "generic",
               "slack"
-            ],
-            "description": "Delivery format: generic posts signed JSON, slack posts a Block Kit message"
+            ]
           },
           "events": {
-            "type": "string",
-            "description": "Comma-separated event types to deliver, or \"*\" for all events"
+            "type": "string"
           },
           "label": {
             "type": "string",
-            "nullable": true,
-            "description": "Optional human-readable label, or null if unnamed"
+            "nullable": true
           },
           "active": {
             "anyOf": [
@@ -2308,8 +1980,7 @@
                   1
                 ]
               }
-            ],
-            "description": "Whether deliveries are enabled (1) or paused (0)"
+            ]
           },
           "created_at": {
             "type": "string"
@@ -2341,17 +2012,14 @@
               "pending",
               "delivered",
               "dead"
-            ],
-            "description": "Delivery state: pending (awaiting/retrying), delivered (succeeded), dead (gave up)"
+            ]
           },
           "attempts": {
-            "type": "number",
-            "description": "Number of delivery attempts made so far"
+            "type": "number"
           },
           "last_error": {
             "type": "string",
-            "nullable": true,
-            "description": "The most recent failure message, or null if none"
+            "nullable": true
           },
           "created_at": {
             "type": "string"
@@ -2370,20 +2038,17 @@
         "type": "object",
         "properties": {
           "host": {
-            "type": "string",
-            "description": "The hostname the artifact is served at."
+            "type": "string"
           },
           "url": {
-            "type": "string",
-            "description": "That host with scheme, ready to link to."
+            "type": "string"
           },
           "kind": {
             "type": "string",
             "enum": [
               "subdomain",
               "custom"
-            ],
-            "description": "\"subdomain\" = a vanity <label>.<base>; \"custom\" = a workspace custom domain."
+            ]
           },
           "status": {
             "type": "string",
@@ -2391,8 +2056,7 @@
               "active",
               "pending",
               "error"
-            ],
-            "description": "\"active\" = serving; \"pending\" = awaiting DNS/cert; \"error\" = validation failed."
+            ]
           },
           "created_at": {
             "type": "string"
@@ -2410,8 +2074,7 @@
         "type": "object",
         "properties": {
           "host": {
-            "type": "string",
-            "description": "The custom domain attached to the workspace."
+            "type": "string"
           },
           "status": {
             "type": "string",
@@ -2419,15 +2082,13 @@
               "active",
               "pending",
               "error"
-            ],
-            "description": "\"active\" = serving; \"pending\" = awaiting DNS/cert; \"error\" = validation failed."
+            ]
           },
           "records": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/DomainDnsRecord"
-            },
-            "description": "DNS records to add while pending; absent once the domain is active."
+            }
           },
           "created_at": {
             "type": "string"
@@ -2443,16 +2104,13 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": "string",
-            "description": "DNS record type to create (e.g. CNAME)."
+            "type": "string"
           },
           "name": {
-            "type": "string",
-            "description": "The name/host to create the DNS record at."
+            "type": "string"
           },
           "value": {
-            "type": "string",
-            "description": "The value the DNS record should point at."
+            "type": "string"
           }
         },
         "required": [
@@ -2465,47 +2123,38 @@
         "type": "object",
         "properties": {
           "password": {
-            "type": "boolean",
-            "description": "True if email + password sign-in is available (always on here)"
+            "type": "boolean"
           },
           "google": {
-            "type": "boolean",
-            "description": "True if Google sign-in is configured"
+            "type": "boolean"
           },
           "github": {
-            "type": "boolean",
-            "description": "True if GitHub sign-in is configured"
+            "type": "boolean"
           },
           "oidc": {
             "type": "object",
             "nullable": true,
             "properties": {
               "providerId": {
-                "type": "string",
-                "description": "The provider id used to initiate SSO"
+                "type": "string"
               },
               "label": {
-                "type": "string",
-                "description": "Human-readable label for the SSO button"
+                "type": "string"
               }
             },
             "required": [
               "providerId",
               "label"
-            ],
-            "description": "The enterprise OIDC/SSO provider, or null if none is configured"
+            ]
           },
           "emailVerification": {
-            "type": "boolean",
-            "description": "True if verification emails can be sent (a mail transport is configured)"
+            "type": "boolean"
           },
           "passwordReset": {
-            "type": "boolean",
-            "description": "True if password-reset emails can be sent"
+            "type": "boolean"
           },
           "passkey": {
-            "type": "boolean",
-            "description": "True if passkey (WebAuthn) sign-in works on this instance"
+            "type": "boolean"
           }
         },
         "required": [
@@ -2551,34 +2200,27 @@
                         },
                         "username": {
                           "type": "string",
-                          "nullable": true,
-                          "description": "The @handle; null until claimed at onboarding."
+                          "nullable": true
                         },
                         "discoverable": {
-                          "type": "boolean",
-                          "description": "Whether the user is findable in people search."
+                          "type": "boolean"
                         },
                         "profession": {
                           "type": "string",
-                          "nullable": true,
-                          "description": "Self-set team role; null if unset."
+                          "nullable": true
                         },
                         "about": {
                           "type": "string",
-                          "nullable": true,
-                          "description": "One-line bio; null if unset."
+                          "nullable": true
                         },
                         "onboarded": {
-                          "type": "boolean",
-                          "description": "Whether first-run onboarding is complete."
+                          "type": "boolean"
                         },
                         "emailVerified": {
-                          "type": "boolean",
-                          "description": "Whether the account email is verified."
+                          "type": "boolean"
                         },
                         "role": {
-                          "type": "string",
-                          "description": "The caller's role in the active workspace: viewer, commenter, editor, or owner (Admin)."
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -2595,8 +2237,7 @@
                       ]
                     },
                     "multi": {
-                      "type": "boolean",
-                      "description": "Whether multi-workspace mode is enabled."
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -2654,13 +2295,11 @@
                   "properties": {
                     "profession": {
                       "type": "string",
-                      "nullable": true,
-                      "description": "Saved team role; null when cleared."
+                      "nullable": true
                     },
                     "about": {
                       "type": "string",
-                      "nullable": true,
-                      "description": "Saved bio; null when cleared."
+                      "nullable": true
                     }
                   },
                   "required": [
@@ -2862,8 +2501,7 @@
                     },
                     "next_cursor": {
                       "type": "string",
-                      "nullable": true,
-                      "description": "Opaque cursor for the next page; null when there are no more."
+                      "nullable": true
                     }
                   },
                   "required": [
@@ -2892,8 +2530,7 @@
                   "type": "object",
                   "properties": {
                     "image": {
-                      "type": "string",
-                      "description": "The served (absolute) avatar URL."
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3547,8 +3184,7 @@
                     },
                     "next_cursor": {
                       "type": "string",
-                      "nullable": true,
-                      "description": "Opaque cursor for the next page; null on the last page."
+                      "nullable": true
                     },
                     "collection": {
                       "type": "object",
@@ -3563,8 +3199,7 @@
                       "required": [
                         "id",
                         "title"
-                      ],
-                      "description": "The scoped collection; present only when listing one (?collection=)."
+                      ]
                     }
                   },
                   "required": [
@@ -3593,20 +3228,16 @@
                   "type": "object",
                   "properties": {
                     "total": {
-                      "type": "number",
-                      "description": "Total artifacts in the workspace."
+                      "type": "number"
                     },
                     "favorites": {
-                      "type": "number",
-                      "description": "The caller's favorite count in this workspace."
+                      "type": "number"
                     },
                     "mine": {
-                      "type": "number",
-                      "description": "Count of artifacts the caller owns ('Created by me')."
+                      "type": "number"
                     },
                     "mine_private": {
-                      "type": "number",
-                      "description": "Owned artifacts not surfaced anywhere yet (listed=none)."
+                      "type": "number"
                     },
                     "tags": {
                       "type": "array",
@@ -3624,13 +3255,11 @@
                           "tag",
                           "count"
                         ]
-                      },
-                      "description": "Per-tag artifact counts for the workspace."
+                      }
                     },
                     "workspace": {
                       "type": "string",
-                      "nullable": true,
-                      "description": "Workspace display name; null for a non-member (empty summary)."
+                      "nullable": true
                     }
                   },
                   "required": [
@@ -3728,8 +3357,7 @@
                       "enum": [
                         "none",
                         "member"
-                      ],
-                      "description": "New workspace access: member = seats reach it; none = they don't."
+                      ]
                     },
                     "link_role": {
                       "type": "string",
@@ -3738,8 +3366,7 @@
                         "viewer",
                         "commenter",
                         "editor"
-                      ],
-                      "description": "New world-link role; none = no link."
+                      ]
                     },
                     "listed": {
                       "type": "string",
@@ -3747,12 +3374,10 @@
                         "none",
                         "workspace",
                         "public"
-                      ],
-                      "description": "New discovery listing: nowhere, the workspace, or public."
+                      ]
                     },
                     "locked": {
-                      "type": "boolean",
-                      "description": "true when the world link is now password-locked."
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -3912,8 +3537,7 @@
                       "type": "object",
                       "properties": {
                         "published": {
-                          "type": "number",
-                          "description": "The new version number created by the restore."
+                          "type": "number"
                         }
                       },
                       "required": [
@@ -4007,15 +3631,13 @@
                         "commenter",
                         "editor",
                         "owner"
-                      ],
-                      "description": "Workspace baseline role applied to anyone without an explicit share."
+                      ]
                     },
                     "members": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/ArtifactMember"
-                      },
-                      "description": "Collaborators with an explicit per-artifact role share."
+                      }
                     }
                   },
                   "required": [
@@ -4400,8 +4022,7 @@
                       "enum": [
                         "none",
                         "member"
-                      ],
-                      "description": "The collection's new workspace share scope."
+                      ]
                     }
                   },
                   "required": [
@@ -4514,8 +4135,7 @@
                   "type": "object",
                   "properties": {
                     "created_by": {
-                      "type": "string",
-                      "description": "User id of the collection's creator."
+                      "type": "string"
                     },
                     "members": {
                       "type": "array",
@@ -5223,8 +4843,7 @@
                           "type": "array",
                           "items": {
                             "type": "string"
-                          },
-                          "description": "Thread ids this proposal flipped to addressed (pending review)."
+                          }
                         }
                       },
                       "required": [
@@ -5368,8 +4987,7 @@
                       "type": "object",
                       "properties": {
                         "published": {
-                          "type": "number",
-                          "description": "The version number the approved proposal became live as."
+                          "type": "number"
                         }
                       },
                       "required": [
@@ -5564,8 +5182,7 @@
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/ReviewRound"
-                      },
-                      "description": "All review rounds, newest first."
+                      }
                     },
                     "pending": {
                       "allOf": [
@@ -5573,8 +5190,7 @@
                           "$ref": "#/components/schemas/ReviewRound"
                         },
                         {
-                          "nullable": true,
-                          "description": "The current unsettled round, or null if none is pending."
+                          "nullable": true
                         }
                       ]
                     }
@@ -5713,12 +5329,10 @@
                       "enum": [
                         "open",
                         "resolved"
-                      ],
-                      "description": "The thread's new state: resolved, or open when reopened."
+                      ]
                     },
                     "updated": {
-                      "type": "number",
-                      "description": "Number of comments in the thread whose state changed."
+                      "type": "number"
                     }
                   },
                   "required": [
@@ -5957,6 +5571,182 @@
         "responses": {
           "204": {
             "description": "The context was deleted."
+          }
+        }
+      }
+    },
+    "/v1/contexts/{id}/access": {
+      "post": {
+        "tags": [
+          "Contexts"
+        ],
+        "summary": "Set who may ask a context (workspace | invited). Never leaves the workspace.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The updated ask policy.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ask_policy": {
+                      "type": "string",
+                      "enum": [
+                        "workspace",
+                        "invited"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ask_policy"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/contexts/{id}/askers": {
+      "get": {
+        "tags": [
+          "Contexts"
+        ],
+        "summary": "The invited-asker roster (manager only).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The roster.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "askers": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "user_id": {
+                            "type": "string"
+                          },
+                          "username": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "added_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "user_id",
+                          "username",
+                          "added_at"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "askers"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Contexts"
+        ],
+        "summary": "Invite a WORKSPACE MEMBER to ask (by email). A non-member is rejected.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The added asker.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user_id": {
+                      "type": "string"
+                    },
+                    "username": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "added_at": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "user_id",
+                    "username",
+                    "added_at"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/contexts/{id}/askers/{userId}": {
+      "delete": {
+        "tags": [
+          "Contexts"
+        ],
+        "summary": "Remove someone from the asker roster (manager only).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "userId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Removed."
           }
         }
       }
@@ -6596,15 +6386,13 @@
                   "properties": {
                     "base": {
                       "type": "string",
-                      "nullable": true,
-                      "description": "Base host subdomains hang off (e.g. derive.to); null if disabled."
+                      "nullable": true
                     },
                     "domains": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/ArtifactDomain"
-                      },
-                      "description": "The artifact's own vanity subdomains, managed here."
+                      }
                     },
                     "workspace_domains": {
                       "type": "array",
@@ -6615,16 +6403,14 @@
                             "type": "string"
                           },
                           "url": {
-                            "type": "string",
-                            "description": "This artifact's URL on that domain, including its ref."
+                            "type": "string"
                           }
                         },
                         "required": [
                           "host",
                           "url"
                         ]
-                      },
-                      "description": "Workspace custom domains this artifact is served at (read-only)."
+                      }
                     }
                   },
                   "required": [
@@ -6738,20 +6524,17 @@
                   "type": "object",
                   "properties": {
                     "enabled": {
-                      "type": "boolean",
-                      "description": "True when this server supports custom domains."
+                      "type": "boolean"
                     },
                     "cname_target": {
                       "type": "string",
-                      "nullable": true,
-                      "description": "The CNAME target to point domains at; null when they're disabled."
+                      "nullable": true
                     },
                     "domains": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/WorkspaceDomain"
-                      },
-                      "description": "The workspace's attached custom domains."
+                      }
                     }
                   },
                   "required": [
@@ -6784,8 +6567,7 @@
                       "type": "object",
                       "properties": {
                         "cname_target": {
-                          "type": "string",
-                          "description": "The CNAME target to point your domain at."
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -6810,8 +6592,7 @@
                       "type": "object",
                       "properties": {
                         "cname_target": {
-                          "type": "string",
-                          "description": "The CNAME target to point your domain at."
+                          "type": "string"
                         }
                       },
                       "required": [

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -6,6 +6,7 @@ import {
   type BlobStore,
   type BundleManifest,
   type CollectionRecord,
+  type ContextRecord,
   can,
   capRole,
   DEFAULT_VERSION_WINDOW_MS,
@@ -802,6 +803,22 @@ export function buildContext(deps: AppDeps) {
     return !!me && !!(await meta.getMembership(orgId, me.id))
   }
 
+  // May THIS caller ask this context? A context is a workspace-scoped data-access
+  // grant, NOT a document — so this deliberately does not consult the manifest's
+  // artifact access (which can carry a world link or public listing). The hard
+  // floor is workspace membership: a non-member — however they hold a link — can
+  // never ask. Within the workspace, `workspace` policy admits every member;
+  // `invited` admits the creator and the asker roster. Askers are people (a
+  // session is on-behalf-of a human), so a bare agent/static token can't ask.
+  const canAskContext = async (c: Context, x: ContextRecord): Promise<boolean> => {
+    const me = await currentUser(c)
+    if (!me) return false
+    if (!(await meta.getMembership(x.org_id, me.id))) return false
+    if (x.created_by === me.id) return true
+    if (x.ask_policy === "workspace") return true
+    return !!(await meta.getContextAsker(x.id, me.id))
+  }
+
   return {
     deps,
     meta,
@@ -847,5 +864,6 @@ export function buildContext(deps: AppDeps) {
     requireUser,
     isToken,
     isMember,
+    canAskContext,
   }
 }

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -603,8 +603,16 @@ export const contextRoutes = (ctx: AppContext) => {
       if (me instanceof Response) return bail(me)
       const s = await meta.getSession(c.req.param("id"))
       const linked = s ? await contextOf(s) : null
-      if (!s || !linked || (s.asker_id !== me.id && linked.context.created_by !== me.id))
-        return bail(fail(c, 404, "not found"))
+      // The owner always sees their context's sessions; the asker sees their own
+      // ONLY while they can still ask — losing ask-access (removed from the
+      // workspace/roster, or a tightened policy) closes the window, so a former
+      // member can't keep reading the data answers a context delivered.
+      const allowed =
+        !!s &&
+        !!linked &&
+        (linked.context.created_by === me.id ||
+          (s.asker_id === me.id && (await canAskContext(c, linked.context))))
+      if (!s || !linked || !allowed) return bail(fail(c, 404, "not found"))
       const messages = await meta.listSessionMessages(s.id)
       return c.json({
         session: sessionJson(s),
@@ -689,7 +697,12 @@ export const contextRoutes = (ctx: AppContext) => {
 
       const me = await currentUser(c)
       if (!me) return bail(fail(c, 401, "unauthenticated"))
-      if (s.asker_id !== me.id) return bail(fail(c, 404, "not found"))
+      // Re-gate on ask-access, not just session ownership: a follow-up re-opens
+      // the session and the runner answers it (a fresh query against the data).
+      // A member removed from the workspace/roster after opening a session must
+      // not keep querying through it — canAskContext re-checks membership + policy.
+      if (s.asker_id !== me.id || !(await canAskContext(c, linked.context)))
+        return bail(fail(c, 404, "not found"))
       const gone = closed()
       if (gone) return bail(gone)
       const b = await readJson(c, z.object({ body_md: z.string().trim().min(1).max(20_000) }))

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -1,11 +1,14 @@
 import {
+  type ContextAskerRecord,
   type ContextRecord,
   newId,
   type SessionMessageRecord,
   type SessionRecord,
   type SessionState,
+  type UserDir,
 } from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import type { Context } from "hono"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
 import { bail, fail, readJson } from "../lib/http"
@@ -27,6 +30,7 @@ export const contextRoutes = (ctx: AppContext) => {
     activeWorkspace,
     agentFor,
     authorize,
+    canAskContext,
     currentUser,
     managementPrincipal,
     requireUser,
@@ -51,6 +55,11 @@ export const contextRoutes = (ctx: AppContext) => {
         .nullable()
         .describe(
           "When the runner last polled the queue (~minutely); null = never. Drives online/offline.",
+        ),
+      ask_policy: z
+        .enum(["workspace", "invited"])
+        .describe(
+          "Who in the workspace may ask: any member, or the invited roster. Never outside the workspace.",
         ),
     })
     .openapi("ContextInfo")
@@ -127,6 +136,7 @@ export const contextRoutes = (ctx: AppContext) => {
     created_by: x.created_by,
     created_at: x.created_at,
     runner_seen_at: x.runner_seen_at,
+    ask_policy: x.ask_policy,
   })
 
   const messageJson = (m: SessionMessageRecord) => {
@@ -281,18 +291,14 @@ export const contextRoutes = (ctx: AppContext) => {
     async (c) => {
       const x = await meta.getContext(c.req.param("id"))
       if (!x) return bail(fail(c, 404, "not found"))
-      // Visible to whoever can read the manifest (users) — or to the context's own
-      // agent, which needs its wiring (name, manifest) to run.
+      // The context's own agent gets its wiring to run; a human gets it only if
+      // they can ASK — workspace-scoped, never via the manifest's artifact access
+      // (see canAskContext). A context is a data grant, not a document: it must
+      // not be reachable outside its workspace, so 404 (not 403) to everyone else
+      // — its existence never leaks.
       const agent = await agentFor(c)
       const manifest = await meta.getArtifactById(x.manifest_artifact_id)
-      // Users need manifest read AND a session: a public manifest makes its
-      // CONTENT world-readable, but the context's wiring (agent id, creator)
-      // stays behind sign-in.
-      const allowed = agent
-        ? agent.id === x.agent_id
-        : manifest !== null &&
-          (await currentUser(c)) !== null &&
-          (await authorize(c, "read", manifest))
+      const allowed = agent ? agent.id === x.agent_id : await canAskContext(c, x)
       if (!allowed) return bail(fail(c, 404, "not found"))
       // The runner's one config fetch: its system prompt is the manifest's current
       // source, so a manifest edit reconfigures the runner with no deploy.
@@ -336,8 +342,159 @@ export const contextRoutes = (ctx: AppContext) => {
     },
   )
 
-  // Ask: open a session with the first question. The ask grant is read on the
-  // manifest, so sharing the manifest is sharing the context.
+  // ---- ask-access management (workspace-scoped only) ------------------------
+  // The context that this caller may MANAGE (set who can ask), or a Response to
+  // return. Management is the creator or a workspace manager — the same gate as
+  // delete, and NOT reachable by a runner's own agent token (managementPrincipal
+  // refuses those). Scoped to the caller's active workspace so a manager of B
+  // can't reach into A; cross-workspace callers get the same 404 as a missing id.
+  const manageableContext = async (c: Context): Promise<ContextRecord | Response> => {
+    const owner = await managementPrincipal(c)
+    if (!owner) return fail(c, 401, "unauthenticated")
+    // The generic hono Context (this helper is route-shared) types params as
+    // possibly-undefined; an empty id just resolves to no context → 404.
+    const x = await meta.getContext(c.req.param("id") ?? "")
+    if (!x || x.org_id !== (await activeWorkspace(c))) return fail(c, 404, "not found")
+    if (x.created_by !== owner && !(await workspaceCan(c, "manage")))
+      return fail(c, 403, "forbidden")
+    return x
+  }
+
+  const askerJson = (a: ContextAskerRecord, u: UserDir | undefined) => ({
+    user_id: a.user_id,
+    username: u?.username ?? null,
+    added_at: a.created_at,
+  })
+
+  app.openapi(
+    createRoute({
+      method: "post",
+      path: "/v1/contexts/{id}/access",
+      tags: ["Contexts"],
+      summary: "Set who may ask a context (workspace | invited). Never leaves the workspace.",
+      request: { params: z.object({ id: z.string() }) },
+      responses: {
+        200: {
+          description: "The updated ask policy.",
+          content: {
+            "application/json": {
+              schema: z.object({ ask_policy: z.enum(["workspace", "invited"]) }),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const x = await manageableContext(c)
+      if (x instanceof Response) return bail(x)
+      const b = await readJson(c, z.object({ ask_policy: z.enum(["workspace", "invited"]) }))
+      if (b instanceof Response) return bail(b)
+      await meta.setContextAskPolicy(x.id, b.ask_policy)
+      return c.json({ ask_policy: b.ask_policy })
+    },
+  )
+
+  app.openapi(
+    createRoute({
+      method: "get",
+      path: "/v1/contexts/{id}/askers",
+      tags: ["Contexts"],
+      summary: "The invited-asker roster (manager only).",
+      request: { params: z.object({ id: z.string() }) },
+      responses: {
+        200: {
+          description: "The roster.",
+          content: {
+            "application/json": {
+              schema: z.object({
+                askers: z.array(
+                  z.object({
+                    user_id: z.string(),
+                    username: z.string().nullable(),
+                    added_at: z.string(),
+                  }),
+                ),
+              }),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const x = await manageableContext(c)
+      if (x instanceof Response) return bail(x)
+      const roster = await meta.listContextAskers(x.id)
+      const users = new Map(
+        (await meta.getUsers(roster.map((a) => a.user_id))).map((u) => [u.id, u]),
+      )
+      return c.json({ askers: roster.map((a) => askerJson(a, users.get(a.user_id))) })
+    },
+  )
+
+  app.openapi(
+    createRoute({
+      method: "post",
+      path: "/v1/contexts/{id}/askers",
+      tags: ["Contexts"],
+      summary: "Invite a WORKSPACE MEMBER to ask (by email). A non-member is rejected.",
+      request: { params: z.object({ id: z.string() }) },
+      responses: {
+        201: {
+          description: "The added asker.",
+          content: {
+            "application/json": {
+              schema: z.object({
+                user_id: z.string(),
+                username: z.string().nullable(),
+                added_at: z.string(),
+              }),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const x = await manageableContext(c)
+      if (x instanceof Response) return bail(x)
+      const owner = (await managementPrincipal(c)) as string
+      const b = await readJson(c, z.object({ email: z.string().trim().email() }))
+      if (b instanceof Response) return bail(b)
+      const user = await meta.findUserByEmail(b.email)
+      if (!user) return bail(fail(c, 404, "no such user"))
+      // The invariant, enforced at the source: only a member of THIS context's
+      // workspace can be added to the roster. A non-member can never be an asker,
+      // so the roster can't reference outside the workspace.
+      if (!(await meta.getMembership(x.org_id, user.id)))
+        return bail(fail(c, 400, "that person isn't a member of this workspace"))
+      const added = await meta.addContextAsker({
+        id: newId("cask"),
+        context_id: x.id,
+        user_id: user.id,
+        added_by: owner,
+      })
+      return c.json(askerJson(added, user), 201)
+    },
+  )
+
+  app.openapi(
+    createRoute({
+      method: "delete",
+      path: "/v1/contexts/{id}/askers/{userId}",
+      tags: ["Contexts"],
+      summary: "Remove someone from the asker roster (manager only).",
+      request: { params: z.object({ id: z.string(), userId: z.string() }) },
+      responses: { 204: { description: "Removed." } },
+    }),
+    async (c) => {
+      const x = await manageableContext(c)
+      if (x instanceof Response) return bail(x)
+      await meta.removeContextAsker(x.id, c.req.param("userId"))
+      return c.body(null, 204)
+    },
+  )
+
+  // Ask: open a session with the first question. The ask grant is the context's
+  // own workspace-scoped policy (canAskContext) — NOT manifest read-access.
   app.openapi(
     createRoute({
       method: "post",
@@ -360,9 +517,11 @@ export const contextRoutes = (ctx: AppContext) => {
       const me = await requireUser(c)
       if (me instanceof Response) return bail(me)
       const x = await meta.getContext(c.req.param("id"))
-      const manifest = x ? await meta.getArtifactById(x.manifest_artifact_id) : null
-      if (!x || !manifest || !(await authorize(c, "read", manifest)))
-        return bail(fail(c, 404, "not found"))
+      // Asking is a workspace-scoped grant on the CONTEXT, not manifest read —
+      // so a manifest world link can never open a session (query the data).
+      if (!x || !(await canAskContext(c, x))) return bail(fail(c, 404, "not found"))
+      const manifest = await meta.getArtifactById(x.manifest_artifact_id)
+      if (!manifest) return bail(fail(c, 404, "not found"))
       const b = await readJson(c, z.object({ body_md: z.string().trim().min(1).max(20_000) }))
       if (b instanceof Response) return bail(b)
       const session = await meta.createSession({
@@ -406,9 +565,7 @@ export const contextRoutes = (ctx: AppContext) => {
       const me = await requireUser(c)
       if (me instanceof Response) return bail(me)
       const x = await meta.getContext(c.req.param("id"))
-      const manifest = x ? await meta.getArtifactById(x.manifest_artifact_id) : null
-      if (!x || !manifest || !(await authorize(c, "read", manifest)))
-        return bail(fail(c, 404, "not found"))
+      if (!x || !(await canAskContext(c, x))) return bail(fail(c, 404, "not found"))
       const limit = Math.min(100, Math.max(1, Number(c.req.query("limit")) || 50))
       const sessions = await meta.listSessions(x.id, {
         askerId: x.created_by === me.id ? undefined : me.id,

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -17,8 +17,10 @@ import { log } from "../log"
 /**
  * Contexts (askable agent setups) + sessions (ask-conversations with one).
  *
- * A context links a registered agent to its manifest artifact; the manifest's
- * share roster is the ask grant (v1: viewer on the manifest = can ask). Sessions
+ * A context links a registered agent to its manifest artifact. Ask-access is a
+ * WORKSPACE-SCOPED grant on the context itself (ask_policy + the asker roster) —
+ * NOT the manifest's artifact sharing: a context is a data grant, not a document,
+ * and must never be reachable outside its workspace (see canAskContext). Sessions
  * are private to the asker and the context owner — 404 to everyone else, so their
  * existence never leaks. The runner drains `open` sessions from the queue endpoint
  * with the agent's own bearer and answers through the messages endpoint. The
@@ -180,8 +182,9 @@ export const contextRoutes = (ctx: AppContext) => {
   }
 
   // Create a context: wire an agent to a manifest artifact. Editor+ in the
-  // workspace, and share-standing on the manifest — creating a context makes the
-  // manifest's roster govern who can ask, which is a sharing decision.
+  // workspace, and share-standing on the manifest (creating a context exposes the
+  // manifest's identity to askers, so it's a sharing decision). Who can ASK is a
+  // separate, workspace-scoped grant on the context — set via /access, not here.
   app.openapi(
     createRoute({
       method: "post",

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -603,15 +603,16 @@ export const contextRoutes = (ctx: AppContext) => {
       if (me instanceof Response) return bail(me)
       const s = await meta.getSession(c.req.param("id"))
       const linked = s ? await contextOf(s) : null
-      // The owner always sees their context's sessions; the asker sees their own
-      // ONLY while they can still ask — losing ask-access (removed from the
-      // workspace/roster, or a tightened policy) closes the window, so a former
-      // member can't keep reading the data answers a context delivered.
+      // Membership is the floor for BOTH parties: canAskContext requires it even
+      // for the creator, so a removed creator can't keep reading transcripts any
+      // more than a removed asker can (the invariant applies to owners too). The
+      // creator sees ANY session on their context; anyone else sees only their
+      // own — sessions stay private to asker + owner.
       const allowed =
         !!s &&
         !!linked &&
-        (linked.context.created_by === me.id ||
-          (s.asker_id === me.id && (await canAskContext(c, linked.context))))
+        (await canAskContext(c, linked.context)) &&
+        (linked.context.created_by === me.id || s.asker_id === me.id)
       if (!s || !linked || !allowed) return bail(fail(c, 404, "not found"))
       const messages = await meta.listSessionMessages(s.id)
       return c.json({
@@ -756,7 +757,12 @@ export const contextRoutes = (ctx: AppContext) => {
 
       const me = await currentUser(c)
       if (!me) return bail(fail(c, 401, "unauthenticated"))
-      if (s.asker_id !== me.id && linked.context.created_by !== me.id)
+      // Same membership floor as the session read: a removed asker/creator can't
+      // touch the session at all (close included) once they're out of the workspace.
+      if (
+        !(await canAskContext(c, linked.context)) ||
+        (s.asker_id !== me.id && linked.context.created_by !== me.id)
+      )
         return bail(fail(c, 404, "not found"))
       const b = await readJson(c, z.object({ state: z.literal("closed") }))
       if (b instanceof Response) return bail(b)

--- a/apps/api/test/contexts.test.ts
+++ b/apps/api/test/contexts.test.ts
@@ -426,6 +426,47 @@ describe("sessions: revoking ask-access cuts off an existing session", () => {
       200,
     )
   })
+
+  it("a removed CREATOR loses transcript access too — the floor applies to owners", async () => {
+    // The creator branch of the session read/patch must also require membership:
+    // offboarding doesn't reassign contexts, so created_by persists — a removed
+    // creator must not keep reading the data answers from outside the workspace.
+    const ag = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "A2", role: "editor" }))
+    ).json()
+    const manifest = (await (await publishAs(app, "# m2", {}, as(owner.email))).json()).short_id
+    const ctx = await (
+      await app.request(
+        "/v1/contexts",
+        jsonAs(as(owner.email), {
+          name: "Analytics2",
+          agent_id: ag.id,
+          manifest_short_id: manifest,
+        }),
+      )
+    ).json()
+    const asked = await (
+      await app.request(
+        `/v1/contexts/${ctx.id}/sessions`,
+        jsonAs(as(owner.email), { body_md: "self-ask" }),
+      )
+    ).json()
+    const sid = asked.session.id
+    expect((await app.request(`/v1/sessions/${sid}`, { headers: as(owner.email) })).status).toBe(
+      200,
+    )
+
+    await meta.removeMembership("default", owner.id)
+    expect((await app.request(`/v1/sessions/${sid}`, { headers: as(owner.email) })).status).toBe(
+      404,
+    )
+    const close = await app.request(`/v1/sessions/${sid}`, {
+      method: "PATCH",
+      headers: { ...as(owner.email), "content-type": "application/json" },
+      body: JSON.stringify({ state: "closed" }),
+    })
+    expect(close.status).toBe(404)
+  })
 })
 
 describe("runner liveness: the queue poll stamps runner_seen_at, throttled", () => {

--- a/apps/api/test/contexts.test.ts
+++ b/apps/api/test/contexts.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from "vitest"
 import { as, bearer, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 
 // Contexts + sessions: the ask → answer → follow-up loop, its permission edges,
-// and the runner's queue. The ask grant is "viewer on the manifest artifact", so
-// the sharing machinery is exercised here too (a private manifest gates asking).
+// and the runner's queue. Ask-access is WORKSPACE-SCOPED on the context itself
+// (never the manifest's artifact sharing) — a context is a data grant, not a
+// document, and must never be reachable outside its workspace.
 describe("contexts: create + wire an agent to a manifest", () => {
   const owner: TestUser = { id: "u_cx_own", email: "cxown@derive.test", name: "Owner" }
   const dev: TestUser = { id: "u_cx_dev", email: "cxdev@derive.test", name: "Dev" }
@@ -91,14 +92,14 @@ describe("sessions: the ask → answer → follow-up loop", () => {
   const owner: TestUser = { id: "u_ss_own", email: "ssown@derive.test", name: "Owner" }
   const daniel: TestUser = { id: "u_ss_dan", email: "ssdan@derive.test", name: "Daniel" }
   const stranger: TestUser = { id: "u_ss_str", email: "ssstr@derive.test", name: "Stranger" }
-  const { app } = makeAuthedApp("contexts-loop", [owner, daniel, stranger], "commenter")
+  const { app, meta } = makeAuthedApp("contexts-loop", [owner, daniel, stranger], "commenter")
 
   let contextId: string
   let sessionId: string
   let agentToken: string
   let manifestShortId: string
 
-  it("setup: agent + PRIVATE manifest + context; asking is gated on the manifest", async () => {
+  it("setup: ask-access is WORKSPACE-SCOPED on the context, never the manifest", async () => {
     await app.request("/v1/me", { headers: as(owner.email) })
     await app.request("/v1/me", { headers: as(daniel.email) })
     await app.request("/v1/me", { headers: as(stranger.email) })
@@ -106,9 +107,9 @@ describe("sessions: the ask → answer → follow-up loop", () => {
       await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Analyst", role: "editor" }))
     ).json()
     agentToken = ag.token
-    // link_role none = true invite-only: the round-4 workspace-default link would
-    // otherwise admit Daniel (a member) before the explicit share — this test is
-    // about the manifest GATE, so the link stays inert.
+    // The manifest is a PRIVATE artifact — and stays that way. Asking is granted by
+    // the CONTEXT's own policy, not manifest read, so the private manifest doesn't
+    // gate anything for members.
     manifestShortId = (
       await (
         await publishAs(
@@ -130,20 +131,27 @@ describe("sessions: the ask → answer → follow-up loop", () => {
       )
     ).json()
     contextId = x.id
+    // The default is `workspace`: every member can ask, no manifest share needed.
+    expect(x.ask_policy).toBe("workspace")
 
-    // Private manifest, no member row: Daniel can't ask (and can't tell it exists).
+    // Lock it to `invited` to exercise the roster gate — Daniel is a workspace
+    // member but not (yet) an invited asker, so he's denied and can't tell it exists.
+    await app.request(
+      `/v1/contexts/${contextId}/access`,
+      jsonAs(as(owner.email), { ask_policy: "invited" }),
+    )
     const denied = await app.request(
       `/v1/contexts/${contextId}/sessions`,
       jsonAs(as(daniel.email), { body_md: "churn for March?" }),
     )
     expect(denied.status).toBe(404)
 
-    // Share the manifest with Daniel → the context becomes askable.
-    await app.request(`/v1/artifacts/${manifestShortId}/members`, {
-      method: "PUT",
-      headers: { ...as(owner.email), "content-type": "application/json" },
-      body: JSON.stringify({ email: daniel.email, role: "viewer" }),
-    })
+    // Invite Daniel (a workspace member) to the asker roster → askable.
+    const invited = await app.request(
+      `/v1/contexts/${contextId}/askers`,
+      jsonAs(as(owner.email), { email: daniel.email }),
+    )
+    expect(invited.status).toBe(201)
     const asked = await app.request(
       `/v1/contexts/${contextId}/sessions`,
       jsonAs(as(daniel.email), { body_md: "churn for March?" }),
@@ -211,14 +219,13 @@ describe("sessions: the ask → answer → follow-up loop", () => {
     ).toBe(409)
   })
 
-  it("sessions are private: asker + context owner only; the roster viewer is not enough", async () => {
-    // The stranger holds no view at all; even sharing the manifest with them
-    // (roster viewer = may ASK) must not expose Daniel's session.
-    await app.request(`/v1/artifacts/${manifestShortId}/members`, {
-      method: "PUT",
-      headers: { ...as(owner.email), "content-type": "application/json" },
-      body: JSON.stringify({ email: stranger.email, role: "viewer" }),
-    })
+  it("sessions are private: asker + context owner only; another invited asker is not enough", async () => {
+    // The stranger is a workspace member; even inviting them to ASK must not
+    // expose Daniel's session — an asker sees only their own conversations.
+    await app.request(
+      `/v1/contexts/${contextId}/askers`,
+      jsonAs(as(owner.email), { email: stranger.email }),
+    )
     expect(
       (await app.request(`/v1/sessions/${sessionId}`, { headers: as(stranger.email) })).status,
     ).toBe(404)
@@ -235,6 +242,37 @@ describe("sessions: the ask → answer → follow-up loop", () => {
       await app.request(`/v1/contexts/${contextId}/sessions`, { headers: as(stranger.email) })
     ).json()
     expect(strangerList.sessions).toHaveLength(0)
+  })
+
+  it("SECURITY: a non-member can't ask — not even with the manifest world-linked + public", async () => {
+    // The exact leak this model closes: open the manifest to the world (viewer
+    // link + public listing) and drop the asker OUT of the workspace. Under the
+    // old "ask = manifest read" rule they could open a session (query the data);
+    // now the context's workspace-membership floor refuses them — 404, no leak.
+    await app.request(`/v1/artifacts/${manifestShortId}/access`, {
+      method: "PATCH",
+      headers: { ...as(owner.email), "content-type": "application/json" },
+      body: JSON.stringify({ linkRole: "viewer", listed: "public" }),
+    })
+    await meta.removeMembership("default", stranger.id)
+
+    // Switch the context back to `workspace` (any member) — the most permissive
+    // policy — to prove even THAT never reaches a non-member.
+    await app.request(
+      `/v1/contexts/${contextId}/access`,
+      jsonAs(as(owner.email), { ask_policy: "workspace" }),
+    )
+    expect(
+      (await app.request(`/v1/contexts/${contextId}`, { headers: as(stranger.email) })).status,
+    ).toBe(404)
+    expect(
+      (
+        await app.request(
+          `/v1/contexts/${contextId}/sessions`,
+          jsonAs(as(stranger.email), { body_md: "let me query your data" }),
+        )
+      ).status,
+    ).toBe(404)
   })
 
   it("a foreign agent can neither read the queue nor answer", async () => {

--- a/apps/api/test/contexts.test.ts
+++ b/apps/api/test/contexts.test.ts
@@ -131,15 +131,10 @@ describe("sessions: the ask → answer → follow-up loop", () => {
       )
     ).json()
     contextId = x.id
-    // The default is `workspace`: every member can ask, no manifest share needed.
-    expect(x.ask_policy).toBe("workspace")
-
-    // Lock it to `invited` to exercise the roster gate — Daniel is a workspace
-    // member but not (yet) an invited asker, so he's denied and can't tell it exists.
-    await app.request(
-      `/v1/contexts/${contextId}/access`,
-      jsonAs(as(owner.email), { ask_policy: "invited" }),
-    )
+    // Least-privilege default: `invited`, so a data grant opens to nobody but the
+    // creator until widened. Daniel is a workspace member but not an invited
+    // asker, so he's denied and can't even tell it exists.
+    expect(x.ask_policy).toBe("invited")
     const denied = await app.request(
       `/v1/contexts/${contextId}/sessions`,
       jsonAs(as(daniel.email), { body_md: "churn for March?" }),
@@ -399,7 +394,12 @@ describe("sessions: revoking ask-access cuts off an existing session", () => {
       )
     ).json()
 
-    // Daniel (a member, default workspace policy) opens a session.
+    // Open the context to the workspace so Daniel (a member) can ask, then he
+    // opens a session.
+    await app.request(
+      `/v1/contexts/${ctx.id}/access`,
+      jsonAs(as(owner.email), { ask_policy: "workspace" }),
+    )
     const asked = await app.request(
       `/v1/contexts/${ctx.id}/sessions`,
       jsonAs(as(daniel.email), { body_md: "churn?" }),

--- a/apps/api/test/contexts.test.ts
+++ b/apps/api/test/contexts.test.ts
@@ -372,6 +372,62 @@ describe("sessions: the ask → answer → follow-up loop", () => {
   })
 })
 
+// Revoking ask-access closes an IN-FLIGHT session too: a member who opened a
+// session and is then removed from the workspace can neither read it nor keep
+// asking — otherwise the session would be a standing query window that outlives
+// their membership (the exact "never outside the workspace" invariant).
+describe("sessions: revoking ask-access cuts off an existing session", () => {
+  const owner: TestUser = { id: "u_rv_own", email: "rvown@derive.test", name: "Owner" }
+  const daniel: TestUser = { id: "u_rv_dan", email: "rvdan@derive.test", name: "Daniel" }
+  const { app, meta } = makeAuthedApp("contexts-revoke", [owner, daniel], "commenter")
+
+  it("a removed member can't read or follow up on their own open session", async () => {
+    await app.request("/v1/me", { headers: as(owner.email) })
+    await app.request("/v1/me", { headers: as(daniel.email) })
+    const ag = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Analyst", role: "editor" }))
+    ).json()
+    const manifest = (await (await publishAs(app, "# m", {}, as(owner.email))).json()).short_id
+    const ctx = await (
+      await app.request(
+        "/v1/contexts",
+        jsonAs(as(owner.email), {
+          name: "Analytics",
+          agent_id: ag.id,
+          manifest_short_id: manifest,
+        }),
+      )
+    ).json()
+
+    // Daniel (a member, default workspace policy) opens a session.
+    const asked = await app.request(
+      `/v1/contexts/${ctx.id}/sessions`,
+      jsonAs(as(daniel.email), { body_md: "churn?" }),
+    )
+    expect(asked.status).toBe(201)
+    const sid = (await asked.json()).session.id
+    // He can read it while he's a member.
+    expect((await app.request(`/v1/sessions/${sid}`, { headers: as(daniel.email) })).status).toBe(
+      200,
+    )
+
+    // Remove Daniel from the workspace → his in-flight session goes dark.
+    await meta.removeMembership("default", daniel.id)
+    expect((await app.request(`/v1/sessions/${sid}`, { headers: as(daniel.email) })).status).toBe(
+      404,
+    )
+    const followUp = await app.request(
+      `/v1/sessions/${sid}/messages`,
+      jsonAs(as(daniel.email), { body_md: "one more query" }),
+    )
+    expect(followUp.status).toBe(404)
+    // The owner still sees it (they manage the context).
+    expect((await app.request(`/v1/sessions/${sid}`, { headers: as(owner.email) })).status).toBe(
+      200,
+    )
+  })
+})
+
 describe("runner liveness: the queue poll stamps runner_seen_at, throttled", () => {
   const owner: TestUser = { id: "u_rl_own", email: "rlown@derive.test", name: "Owner" }
   const { app, meta } = makeAuthedApp("contexts-liveness", [owner])

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -5387,7 +5387,10 @@ export interface components {
             created_at: string;
             /** @description When the runner last polled the queue (~minutely); null = never. Drives online/offline. */
             runner_seen_at: string | null;
-            /** @enum {string} */
+            /**
+             * @description Who in the workspace may ask: any member, or the invited roster. Never outside the workspace.
+             * @enum {string}
+             */
             ask_policy: "workspace" | "invited";
         };
         Session: {

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -3608,6 +3608,154 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/contexts/{id}/access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Set who may ask a context (workspace | invited). Never leaves the workspace. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The updated ask policy. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            ask_policy: "workspace" | "invited";
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/contexts/{id}/askers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** The invited-asker roster (manager only). */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The roster. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            askers: {
+                                user_id: string;
+                                username: string | null;
+                                added_at: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Invite a WORKSPACE MEMBER to ask (by email). A non-member is rejected. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The added asker. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            user_id: string;
+                            username: string | null;
+                            added_at: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/contexts/{id}/askers/{userId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Remove someone from the asker roster (manager only). */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                    userId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Removed. */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/contexts/{id}/sessions": {
         parameters: {
             query?: never;
@@ -5239,6 +5387,8 @@ export interface components {
             created_at: string;
             /** @description When the runner last polled the queue (~minutely); null = never. Drives online/offline. */
             runner_seen_at: string | null;
+            /** @enum {string} */
+            ask_policy: "workspace" | "invited";
         };
         Session: {
             id: string;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -590,6 +590,20 @@ export const api = {
     body_md: string,
   ): Promise<{ session: Session; messages: SessionMessage[] }> =>
     f(`/v1/contexts/${id}/sessions`, opts({ body_md })).then(j),
+  // Who may ask — workspace-scoped, never the manifest's artifact sharing.
+  setContextAskPolicy: (id: string, ask_policy: "workspace" | "invited"): Promise<void> =>
+    f(`/v1/contexts/${id}/access`, opts({ ask_policy })).then(() => undefined),
+  listContextAskers: (
+    id: string,
+  ): Promise<{ askers: { user_id: string; username: string | null; added_at: string }[] }> =>
+    f(`/v1/contexts/${id}/askers`, opts()).then(j),
+  addContextAsker: (
+    id: string,
+    email: string,
+  ): Promise<{ user_id: string; username: string | null; added_at: string }> =>
+    f(`/v1/contexts/${id}/askers`, opts({ email })).then(j),
+  removeContextAsker: (id: string, userId: string): Promise<void> =>
+    f(`/v1/contexts/${id}/askers/${userId}`, { ...opts(), method: "DELETE" }).then(() => undefined),
   listContextSessions: (id: string): Promise<{ sessions: Session[] }> =>
     f(`/v1/contexts/${id}/sessions`, opts()).then(j),
   getSession: (

--- a/apps/web/src/pages/context/console.tsx
+++ b/apps/web/src/pages/context/console.tsx
@@ -193,47 +193,40 @@ function Console({ id }: { id: string }) {
 // There is no "anyone"/public option here BY DESIGN: a context is a data-access
 // grant, not a document, and must never be reachable outside its workspace.
 function ContextAccess({ id, policy }: { id: string; policy: "workspace" | "invited" }) {
-  const qc = useQueryClient()
   const [open, setOpen] = useState(false)
   const [email, setEmail] = useState("")
-  const [busy, setBusy] = useState(false)
+  const rosterKey = ["context-askers", id] as const
   const { data: roster } = useQuery({
-    queryKey: ["context-askers", id] as const,
+    queryKey: rosterKey,
     queryFn: () => api.listContextAskers(id).then((r) => r.askers),
     enabled: open && policy === "invited",
   })
-  const refresh = () => qc.invalidateQueries({ queryKey: contextQuery(id).queryKey })
 
-  const setPolicy = async (next: "workspace" | "invited") => {
-    if (next === policy) return
-    setBusy(true)
-    try {
-      await api.setContextAskPolicy(id, next)
-      refresh()
-    } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Could not update access")
-    } finally {
-      setBusy(false)
-    }
+  // Mutations go through useApiMutation (#361): one place for the error toast +
+  // settle-time invalidation, so these can't drift from the app's write contract.
+  const policyMut = useApiMutation({
+    mutationFn: (next: "workspace" | "invited") => api.setContextAskPolicy(id, next),
+    invalidate: [contextQuery(id).queryKey],
+  })
+  const addMut = useApiMutation({
+    mutationFn: (v: string) => api.addContextAsker(id, v),
+    invalidate: [rosterKey],
+    onSuccess: () => setEmail(""),
+  })
+  const removeMut = useApiMutation({
+    mutationFn: (userId: string) => api.removeContextAsker(id, userId),
+    invalidate: [rosterKey],
+  })
+  const busy = policyMut.isPending || addMut.isPending || removeMut.isPending
+
+  const setPolicy = (next: "workspace" | "invited") => {
+    if (next !== policy) policyMut.mutate(next)
   }
-  const add = async () => {
+  const add = () => {
     const v = email.trim()
-    if (!v) return
-    setBusy(true)
-    try {
-      await api.addContextAsker(id, v)
-      setEmail("")
-      qc.invalidateQueries({ queryKey: ["context-askers", id] })
-    } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Could not add")
-    } finally {
-      setBusy(false)
-    }
+    if (v) addMut.mutate(v)
   }
-  const remove = async (userId: string) => {
-    await api.removeContextAsker(id, userId).catch(() => {})
-    qc.invalidateQueries({ queryKey: ["context-askers", id] })
-  }
+  const remove = (userId: string) => removeMut.mutate(userId)
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/apps/web/src/pages/context/console.tsx
+++ b/apps/web/src/pages/context/console.tsx
@@ -6,19 +6,27 @@ import { ApiError, api, type Session, type SessionMessage, type SessionMeta } fr
 import { Icon } from "@/components/icons"
 import { EmptyState } from "@/components/shared/empty-state"
 import { PageShell } from "@/components/shared/page-shell"
+import { PersonSearchInput } from "@/components/shared/person-search-input"
 import { Spinner } from "@/components/shared/spinner"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/components/ui/popover"
 import { toast } from "@/components/ui/sonner"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
 import { useAuth } from "@/ctx"
-import { artifactQuery, contextQuery, contextSessionsQuery, sessionQuery } from "@/lib/queries"
+import { contextQuery, contextSessionsQuery, sessionQuery } from "@/lib/queries"
 import { ago } from "@/lib/time"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { cn } from "@/lib/utils"
 import { mdToHtml } from "../artifact/lib/markdown"
-import { ShareButton } from "../artifact/share-dialog"
 import { answerMdToHtml } from "./lib/answer-md"
 
 // The context console: ask, read the answer (with the query/confidence/caveats the
@@ -43,10 +51,7 @@ function Console({ id }: { id: string }) {
     data: context,
     error,
     isLoading,
-  } = useQuery({
-    ...contextQuery(id),
-    refetchInterval: 60_000,
-  })
+  } = useQuery({ ...contextQuery(id), refetchInterval: 60_000 })
   const { data: sessions } = useQuery(contextSessionsQuery(id))
 
   // The session on screen: sticky once picked; defaults to the most recent.
@@ -58,12 +63,9 @@ function Console({ id }: { id: string }) {
   const active = picked === "new" ? null : (picked ?? mine[0]?.id ?? null)
   const isOwner = !!context && context.created_by === me?.id
 
-  // No standing on the context reads as 404 (its existence never leaks). Asking
-  // is granted by SHARING THE MANIFEST — the context has no access of its own —
-  // so a teammate who can't load it needs the owner to share the manifest, not
-  // a bug report. Say that plainly instead of spinning forever (the old
-  // behavior: the loader threw, `context` stayed undefined, the spinner never
-  // resolved — indistinguishable from "still loading").
+  // No ask-access reads as 404 (a context's existence never leaks outside its
+  // workspace). Say so instead of spinning forever — the loader prefetches (no
+  // rethrow), so this component owns the state.
   if (error) {
     const status = error instanceof ApiError ? error.status : undefined
     return (
@@ -73,7 +75,7 @@ function Console({ id }: { id: string }) {
           title={status === 404 || status === 403 ? "You don't have access" : "Couldn't load"}
           description={
             status === 404 || status === 403
-              ? "Ask the owner to share this context with you — access to ask is granted through the context's manifest."
+              ? "Ask this context's owner to give you access — only workspace members they invite can ask it."
               : "Something went wrong loading this context. Try again in a moment."
           }
         />
@@ -96,15 +98,8 @@ function Console({ id }: { id: string }) {
         </h1>
         <RunnerLiveness seenAt={context.runner_seen_at} />
         <div className="ml-auto flex items-center gap-3">
-          {/* Who can ASK is who can read the manifest — the context has no access
-              of its own. The owner sets it here so "share to let people ask" is
-              discoverable on the console, not buried on the manifest artifact
-              (its absence is why the pilot sat invite-only, unaskable by anyone
-              but its owner). */}
+          {isOwner && <ContextAccess id={id} policy={context.ask_policy} />}
           {isOwner && context.manifest_short_id && (
-            <ContextAccess shortId={context.manifest_short_id} />
-          )}
-          {context.manifest_short_id && (
             <Link
               to="/artifacts/$ref"
               params={{ ref: context.manifest_short_id }}
@@ -193,26 +188,129 @@ function Console({ id }: { id: string }) {
   )
 }
 
-// The context's ask-grant, surfaced and set on the console: it IS the manifest's
-// share state (read the manifest ⇒ can ask). Reuses the artifact ShareButton on
-// the manifest, plus a plain-language nudge when nobody but the owner can ask —
-// the state that reads as "the app is broken" when a teammate opens the console.
-function ContextAccess({ shortId }: { shortId: string }) {
-  const { data: manifest } = useQuery(artifactQuery(shortId))
-  if (!manifest) return null
-  const askable = manifest.workspace_access === "member" || manifest.link_role !== "none"
+// Who may ASK — the context's own workspace-scoped grant, deliberately NOT the
+// manifest's artifact sharing (which could carry a world link or public listing).
+// There is no "anyone"/public option here BY DESIGN: a context is a data-access
+// grant, not a document, and must never be reachable outside its workspace.
+function ContextAccess({ id, policy }: { id: string; policy: "workspace" | "invited" }) {
+  const qc = useQueryClient()
+  const [open, setOpen] = useState(false)
+  const [email, setEmail] = useState("")
+  const [busy, setBusy] = useState(false)
+  const { data: roster } = useQuery({
+    queryKey: ["context-askers", id] as const,
+    queryFn: () => api.listContextAskers(id).then((r) => r.askers),
+    enabled: open && policy === "invited",
+  })
+  const refresh = () => qc.invalidateQueries({ queryKey: contextQuery(id).queryKey })
+
+  const setPolicy = async (next: "workspace" | "invited") => {
+    if (next === policy) return
+    setBusy(true)
+    try {
+      await api.setContextAskPolicy(id, next)
+      refresh()
+    } catch (e) {
+      toast.error(e instanceof ApiError ? e.message : "Could not update access")
+    } finally {
+      setBusy(false)
+    }
+  }
+  const add = async () => {
+    const v = email.trim()
+    if (!v) return
+    setBusy(true)
+    try {
+      await api.addContextAsker(id, v)
+      setEmail("")
+      qc.invalidateQueries({ queryKey: ["context-askers", id] })
+    } catch (e) {
+      toast.error(e instanceof ApiError ? e.message : "Could not add")
+    } finally {
+      setBusy(false)
+    }
+  }
+  const remove = async (userId: string) => {
+    await api.removeContextAsker(id, userId).catch(() => {})
+    qc.invalidateQueries({ queryKey: ["context-askers", id] })
+  }
+
   return (
-    <div className="flex items-center gap-2" data-testid="context-access">
-      {!askable && <span className="text-xs text-muted-foreground">Only you can ask</span>}
-      <ShareButton
-        shortId={shortId}
-        myRole={manifest.my_role}
-        workspaceAccess={manifest.workspace_access}
-        linkRole={manifest.link_role}
-        listed={manifest.listed}
-        passwordProtected={manifest.password_protected}
-      />
-    </div>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="sm" data-testid="context-access" className="gap-1.5">
+          <Icon name="lock" className="text-muted-foreground" />
+          {policy === "workspace" ? "Workspace can ask" : "Invited only"}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80">
+        <PopoverHeader>
+          <PopoverTitle>Who can ask</PopoverTitle>
+          <PopoverDescription>
+            Only workspace members — a context is never reachable outside the workspace.
+          </PopoverDescription>
+        </PopoverHeader>
+        <div className="mt-3 grid grid-cols-2 gap-1.5">
+          {(["workspace", "invited"] as const).map((p) => (
+            <Button
+              key={p}
+              variant={policy === p ? "secondary" : "outline"}
+              size="sm"
+              disabled={busy}
+              data-testid={`context-access-${p}`}
+              onClick={() => setPolicy(p)}
+            >
+              {p === "workspace" ? "Any member" : "Invited only"}
+            </Button>
+          ))}
+        </div>
+        {policy === "invited" && (
+          <div className="mt-4 flex flex-col gap-2">
+            <div className="flex items-center gap-1.5">
+              <PersonSearchInput
+                value={email}
+                onChange={setEmail}
+                placeholder="Invite a member by email…"
+                testId="context-asker-add"
+                className="flex-1"
+              />
+              <Button
+                size="sm"
+                data-testid="context-asker-add-submit"
+                disabled={busy || !email.trim()}
+                onClick={add}
+              >
+                Add
+              </Button>
+            </div>
+            <div className="flex flex-col gap-1">
+              {(roster ?? []).map((a) => (
+                <div
+                  key={a.user_id}
+                  className="flex items-center justify-between rounded-md px-2 py-1 text-sm hover:bg-muted"
+                >
+                  <span className="text-foreground">{a.username ?? a.user_id}</span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    data-testid="context-asker-remove"
+                    onClick={() => remove(a.user_id)}
+                    className="text-muted-foreground"
+                  >
+                    Remove
+                  </Button>
+                </div>
+              ))}
+              {roster?.length === 0 && (
+                <p className="px-2 py-1 text-xs text-muted-foreground">
+                  No one invited yet — only you can ask.
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
   )
 }
 

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -388,7 +388,7 @@ CREATE TABLE IF NOT EXISTS context (
   created_by TEXT NOT NULL,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   runner_seen_at TEXT,
-  ask_policy TEXT NOT NULL DEFAULT 'workspace',
+  ask_policy TEXT NOT NULL DEFAULT 'invited',
   UNIQUE (org_id, name),
   FOREIGN KEY (manifest_artifact_id) REFERENCES artifact(id)
 );

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -388,8 +388,19 @@ CREATE TABLE IF NOT EXISTS context (
   created_by TEXT NOT NULL,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   runner_seen_at TEXT,
+  ask_policy TEXT NOT NULL DEFAULT 'workspace',
   UNIQUE (org_id, name),
   FOREIGN KEY (manifest_artifact_id) REFERENCES artifact(id)
+);
+
+CREATE TABLE IF NOT EXISTS context_asker (
+  id TEXT PRIMARY KEY,
+  context_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  added_by TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  UNIQUE (context_id, user_id),
+  FOREIGN KEY (context_id) REFERENCES context(id)
 );
 
 CREATE TABLE IF NOT EXISTS context_session (

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1191,7 +1191,7 @@ export interface NewContext {
   agent_id: string
   manifest_artifact_id: string
   created_by: string
-  /** Defaults to `workspace` when omitted (the store default). */
+  /** Defaults to `invited` (creator-only) when omitted (the store default). */
   ask_policy?: "workspace" | "invited"
 }
 export interface ContextAskerRecord {

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -625,6 +625,17 @@ export interface ContextStore {
   /** Stamp `runner_seen_at` (the queue route's liveness mark). The caller decides
    *  WHEN — the write throttle lives there, next to the poll cadence it paces. */
   touchContextSeen(id: string, at: string): Promise<void>
+  /** Set who may ask (workspace | invited). Does not touch the roster. */
+  setContextAskPolicy(id: string, policy: "workspace" | "invited"): Promise<void>
+  /** The invited-asker roster for a context (only consulted when ask_policy = invited). */
+  listContextAskers(contextId: string): Promise<ContextAskerRecord[]>
+  /** Is this user on the context's asker roster? (Membership is checked separately.) */
+  getContextAsker(contextId: string, userId: string): Promise<ContextAskerRecord | null>
+  /** Add a user to the roster (idempotent on the unique (context, user)). The
+   *  route validates workspace membership before calling — the store does not. */
+  addContextAsker(a: NewContextAsker): Promise<ContextAskerRecord>
+  /** Remove a user from the roster; a no-op if they weren't on it. */
+  removeContextAsker(contextId: string, userId: string): Promise<void>
   createSession(s: NewSession): Promise<SessionRecord>
   getSession(id: string): Promise<SessionRecord | null>
   /** Sessions on a context, newest first; `askerId` narrows to one person's. */
@@ -1167,6 +1178,11 @@ export interface ContextRecord {
   /** When the runner last polled the queue (ISO), throttle-stamped there — the
    *  console's liveness signal. Null = never polled (or a pre-column row). */
   runner_seen_at: string | null
+  /** Who in the workspace may ASK — `workspace` (any member) or `invited` (the
+   *  context_asker roster + the creator). NEVER the manifest's artifact access:
+   *  a context is workspace-scoped by construction, with no world-link/public
+   *  path. Workspace membership is the hard floor regardless (the ask gate). */
+  ask_policy: "workspace" | "invited"
 }
 export interface NewContext {
   id: string
@@ -1175,6 +1191,21 @@ export interface NewContext {
   agent_id: string
   manifest_artifact_id: string
   created_by: string
+  /** Defaults to `workspace` when omitted (the store default). */
+  ask_policy?: "workspace" | "invited"
+}
+export interface ContextAskerRecord {
+  id: string
+  context_id: string
+  user_id: string
+  added_by: string
+  created_at: string
+}
+export interface NewContextAsker {
+  id: string
+  context_id: string
+  user_id: string
+  added_by: string
 }
 
 /** A session's lifecycle. `state` also encodes whose turn it is: `open` means the

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -21,6 +21,7 @@ import type {
   CollectionMemberRecord,
   CollectionRecord,
   CommentRecord,
+  ContextAskerRecord,
   ContextRecord,
   DeliveryRecord,
   DomainRecord,
@@ -64,6 +65,7 @@ export interface TypedTables {
   agentMention: AgentMentionRecord
   invitation: InvitationRecord
   context: ContextRecord
+  contextAsker: ContextAskerRecord
   contextSession: SessionRecord
   sessionMessage: SessionMessageRecord
   collection: CollectionRecord

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -508,8 +508,26 @@ export const context = pgTable(
     created_at: text("created_at").notNull().$defaultFn(isoNow),
     // Last runner queue poll, throttle-stamped — see schema.ts for the contract.
     runner_seen_at: text("runner_seen_at"),
+    // Who may ASK — workspace-scoped only, never the manifest's artifact access.
+    // See schema.ts for the design notes (a context can't leak outside its org).
+    ask_policy: text("ask_policy").$type<"workspace" | "invited">().notNull().default("workspace"),
   },
   (t) => [uniqueIndex("context_org_name").on(t.org_id, t.name)],
+)
+
+// Per-context asker roster (ask_policy = 'invited'); mirror of the sqlite def.
+export const contextAsker = pgTable(
+  "context_asker",
+  {
+    id: text("id").primaryKey(),
+    context_id: text("context_id")
+      .notNull()
+      .references(() => context.id),
+    user_id: text("user_id").notNull(),
+    added_by: text("added_by").notNull(),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [uniqueIndex("context_asker_user").on(t.context_id, t.user_id)],
 )
 
 export const contextSession = pgTable(
@@ -614,6 +632,7 @@ const TABLES = [
   proposal,
   reviewRound,
   context,
+  contextAsker,
   contextSession,
   sessionMessage,
   report,

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -510,7 +510,7 @@ export const context = pgTable(
     runner_seen_at: text("runner_seen_at"),
     // Who may ASK — workspace-scoped only, never the manifest's artifact access.
     // See schema.ts for the design notes (a context can't leak outside its org).
-    ask_policy: text("ask_policy").$type<"workspace" | "invited">().notNull().default("workspace"),
+    ask_policy: text("ask_policy").$type<"workspace" | "invited">().notNull().default("invited"),
   },
   (t) => [uniqueIndex("context_org_name").on(t.org_id, t.name)],
 )

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -10,6 +10,7 @@ import type {
   CommentRecord,
   CommentSignals,
   CommentState,
+  ContextAskerRecord,
   ContextRecord,
   DeliveryRecord,
   DeliveryStatus,
@@ -36,6 +37,7 @@ import type {
   NewCollectionMember,
   NewComment,
   NewContext,
+  NewContextAsker,
   NewDelivery,
   NewDomain,
   NewFollow,
@@ -114,6 +116,7 @@ import {
   collectionMember,
   comment,
   context,
+  contextAsker,
   contextSession,
   domain,
   follow,
@@ -175,6 +178,7 @@ export const schema = {
   invitation,
   oauthClientWorkspace,
   context,
+  contextAsker,
   contextSession,
   sessionMessage,
   collection,
@@ -210,6 +214,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   agentMention: true,
   invitation: true,
   context: true,
+  contextAsker: true,
   contextSession: true,
   sessionMessage: true,
   collection: true,
@@ -1683,12 +1688,44 @@ export class PgMetaStore implements MetaStore {
         ),
       )
     await this.db.delete(contextSession).where(eq(contextSession.context_id, id))
+    // The asker roster FKs the context — clear it before the parent row.
+    await this.db.delete(contextAsker).where(eq(contextAsker.context_id, id))
     await this.db.delete(context).where(eq(context.id, id))
   }
   // A no-op on an unknown id, deliberately: the caller already 404'd before
   // stamping, and liveness is best-effort — never worth a throw.
   async touchContextSeen(id: string, at: string): Promise<void> {
     await this.db.update(context).set({ runner_seen_at: at }).where(eq(context.id, id))
+  }
+  async setContextAskPolicy(id: string, policy: "workspace" | "invited"): Promise<void> {
+    await this.db.update(context).set({ ask_policy: policy }).where(eq(context.id, id))
+  }
+  async listContextAskers(contextId: string): Promise<ContextAskerRecord[]> {
+    return this.db
+      .select()
+      .from(contextAsker)
+      .where(eq(contextAsker.context_id, contextId))
+      .orderBy(contextAsker.created_at) as Promise<ContextAskerRecord[]>
+  }
+  async getContextAsker(contextId: string, userId: string): Promise<ContextAskerRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(contextAsker)
+      .where(and(eq(contextAsker.context_id, contextId), eq(contextAsker.user_id, userId)))
+      .limit(1)
+    return (rows[0] as ContextAskerRecord) ?? null
+  }
+  async addContextAsker(a: NewContextAsker): Promise<ContextAskerRecord> {
+    await this.db
+      .insert(contextAsker)
+      .values(a)
+      .onConflictDoNothing({ target: [contextAsker.context_id, contextAsker.user_id] })
+    return (await this.getContextAsker(a.context_id, a.user_id)) as ContextAskerRecord
+  }
+  async removeContextAsker(contextId: string, userId: string): Promise<void> {
+    await this.db
+      .delete(contextAsker)
+      .where(and(eq(contextAsker.context_id, contextId), eq(contextAsker.user_id, userId)))
   }
   async createSession(s: NewSession): Promise<SessionRecord> {
     const rows = await this.db.insert(contextSession).values(s).returning()

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -10,6 +10,7 @@ import type {
   CommentRecord,
   CommentSignals,
   CommentState,
+  ContextAskerRecord,
   ContextRecord,
   DeliveryRecord,
   DeliveryStatus,
@@ -34,6 +35,7 @@ import type {
   NewCollectionMember,
   NewComment,
   NewContext,
+  NewContextAsker,
   NewDelivery,
   NewDomain,
   NewFollow,
@@ -112,6 +114,7 @@ import {
   collectionMember,
   comment,
   context,
+  contextAsker,
   contextSession,
   domain,
   follow,
@@ -200,6 +203,7 @@ export const schema = {
   invitation,
   oauthClientWorkspace,
   context,
+  contextAsker,
   contextSession,
   sessionMessage,
   collection,
@@ -235,6 +239,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   agentMention: true,
   invitation: true,
   context: true,
+  contextAsker: true,
   contextSession: true,
   sessionMessage: true,
   collection: true,
@@ -1820,12 +1825,50 @@ export function makeRepos(db: SqliteDb) {
       )
       .run()
     await db.delete(contextSession).where(eq(contextSession.context_id, id)).run()
+    // The asker roster FKs the context — clear it before the parent row.
+    await db.delete(contextAsker).where(eq(contextAsker.context_id, id)).run()
     await db.delete(context).where(eq(context.id, id)).run()
   }
   // A no-op on an unknown id, deliberately: the caller already 404'd before
   // stamping, and liveness is best-effort — never worth a throw.
   const touchContextSeen = async (id: string, at: string): Promise<void> => {
     await db.update(context).set({ runner_seen_at: at }).where(eq(context.id, id)).run()
+  }
+  const setContextAskPolicy = async (
+    id: string,
+    policy: "workspace" | "invited",
+  ): Promise<void> => {
+    await db.update(context).set({ ask_policy: policy }).where(eq(context.id, id)).run()
+  }
+  const listContextAskers = async (contextId: string): Promise<ContextAskerRecord[]> =>
+    db
+      .select()
+      .from(contextAsker)
+      .where(eq(contextAsker.context_id, contextId))
+      .orderBy(contextAsker.created_at)
+      .all() as Promise<ContextAskerRecord[]>
+  const getContextAsker = async (
+    contextId: string,
+    userId: string,
+  ): Promise<ContextAskerRecord | null> =>
+    (await db
+      .select()
+      .from(contextAsker)
+      .where(and(eq(contextAsker.context_id, contextId), eq(contextAsker.user_id, userId)))
+      .get()) ?? null
+  const addContextAsker = async (a: NewContextAsker): Promise<ContextAskerRecord> => (
+    await db
+      .insert(contextAsker)
+      .values(a)
+      .onConflictDoNothing({ target: [contextAsker.context_id, contextAsker.user_id] })
+      .run(),
+    (await getContextAsker(a.context_id, a.user_id)) as ContextAskerRecord
+  )
+  const removeContextAsker = async (contextId: string, userId: string): Promise<void> => {
+    await db
+      .delete(contextAsker)
+      .where(and(eq(contextAsker.context_id, contextId), eq(contextAsker.user_id, userId)))
+      .run()
   }
   const createSession = async (s: NewSession): Promise<SessionRecord> =>
     (await db.insert(contextSession).values(s).returning().get()) as SessionRecord
@@ -2480,6 +2523,11 @@ export function makeRepos(db: SqliteDb) {
     listContexts,
     deleteContext,
     touchContextSeen,
+    setContextAskPolicy,
+    listContextAskers,
+    getContextAsker,
+    addContextAsker,
+    removeContextAsker,
     createSession,
     getSession,
     listSessions,

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -1856,14 +1856,15 @@ export function makeRepos(db: SqliteDb) {
       .from(contextAsker)
       .where(and(eq(contextAsker.context_id, contextId), eq(contextAsker.user_id, userId)))
       .get()) ?? null
-  const addContextAsker = async (a: NewContextAsker): Promise<ContextAskerRecord> => (
+  const addContextAsker = async (a: NewContextAsker): Promise<ContextAskerRecord> => {
     await db
       .insert(contextAsker)
       .values(a)
       .onConflictDoNothing({ target: [contextAsker.context_id, contextAsker.user_id] })
-      .run(),
-    (await getContextAsker(a.context_id, a.user_id)) as ContextAskerRecord
-  )
+      .run()
+    // Read back so a re-add returns the EXISTING row (the insert was a no-op).
+    return (await getContextAsker(a.context_id, a.user_id)) as ContextAskerRecord
+  }
   const removeContextAsker = async (contextId: string, userId: string): Promise<void> => {
     await db
       .delete(contextAsker)

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -612,10 +612,12 @@ export const context = sqliteTable(
     // Who in the workspace may ASK this context — DELIBERATELY not the manifest's
     // artifact access. A context is a data-access grant, not a document: it must
     // never be reachable outside its workspace, so its access model has no
-    // world-link or public concept to leak one. `workspace` = any member;
-    // `invited` = the context_asker roster (+ the creator). Membership in org_id
-    // is the hard floor either way (enforced in the ask gate, not here).
-    ask_policy: text("ask_policy").$type<"workspace" | "invited">().notNull().default("workspace"),
+    // world-link or public concept to leak one. `invited` = the context_asker
+    // roster (+ the creator); `workspace` = any member. Membership in org_id is
+    // the hard floor either way (enforced in the ask gate, not here). Defaults to
+    // `invited` (least privilege): a data grant opens to nobody until the owner
+    // widens it — the migration keeps existing contexts closed, not opened.
+    ask_policy: text("ask_policy").$type<"workspace" | "invited">().notNull().default("invited"),
   },
   (t) => [uniqueIndex("context_org_name").on(t.org_id, t.name)],
 )

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -609,8 +609,34 @@ export const context = sqliteTable(
     // route throttles; the poll is ~5s) so the row isn't churned. Nullable (never
     // polled + clean ALTER ADD COLUMN); the console renders online/offline from it.
     runner_seen_at: text("runner_seen_at"),
+    // Who in the workspace may ASK this context — DELIBERATELY not the manifest's
+    // artifact access. A context is a data-access grant, not a document: it must
+    // never be reachable outside its workspace, so its access model has no
+    // world-link or public concept to leak one. `workspace` = any member;
+    // `invited` = the context_asker roster (+ the creator). Membership in org_id
+    // is the hard floor either way (enforced in the ask gate, not here).
+    ask_policy: text("ask_policy").$type<"workspace" | "invited">().notNull().default("workspace"),
   },
   (t) => [uniqueIndex("context_org_name").on(t.org_id, t.name)],
+)
+
+// The per-context asker roster (only consulted when ask_policy = 'invited'). A
+// row grants ONE workspace member the right to ask; workspace membership is
+// re-checked at ask time, so removing someone from the workspace revokes here
+// too. No non-member can be added (the add route validates membership) — the
+// table structurally can't reference outside the workspace.
+export const contextAsker = sqliteTable(
+  "context_asker",
+  {
+    id: text("id").primaryKey(),
+    context_id: text("context_id")
+      .notNull()
+      .references(() => context.id),
+    user_id: text("user_id").notNull(),
+    added_by: text("added_by").notNull(),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [uniqueIndex("context_asker_user").on(t.context_id, t.user_id)],
 )
 
 // One ask-conversation with a context. Named context_session because Better Auth
@@ -721,6 +747,7 @@ const TABLES = [
   proposal,
   reviewRound,
   context,
+  contextAsker,
   contextSession,
   sessionMessage,
   report,

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1379,11 +1379,11 @@ export function runStoreContract(
       await expect(store.touchContextSeen(uuid(), at)).resolves.toBeUndefined()
     })
 
-    it("ask_policy defaults to workspace and is settable; the asker roster is idempotent", async () => {
+    it("ask_policy defaults to invited and is settable; the asker roster is idempotent", async () => {
       const ctx = await newContext()
-      expect(ctx.ask_policy).toBe("workspace")
-      await store.setContextAskPolicy(ctx.id, "invited")
-      expect((await store.getContext(ctx.id))?.ask_policy).toBe("invited")
+      expect(ctx.ask_policy).toBe("invited")
+      await store.setContextAskPolicy(ctx.id, "workspace")
+      expect((await store.getContext(ctx.id))?.ask_policy).toBe("workspace")
 
       expect(await store.getContextAsker(ctx.id, "u_daniel")).toBeNull()
       await store.addContextAsker({

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1379,6 +1379,34 @@ export function runStoreContract(
       await expect(store.touchContextSeen(uuid(), at)).resolves.toBeUndefined()
     })
 
+    it("ask_policy defaults to workspace and is settable; the asker roster is idempotent", async () => {
+      const ctx = await newContext()
+      expect(ctx.ask_policy).toBe("workspace")
+      await store.setContextAskPolicy(ctx.id, "invited")
+      expect((await store.getContext(ctx.id))?.ask_policy).toBe("invited")
+
+      expect(await store.getContextAsker(ctx.id, "u_daniel")).toBeNull()
+      await store.addContextAsker({
+        id: uuid(),
+        context_id: ctx.id,
+        user_id: "u_daniel",
+        added_by: "rob",
+      })
+      // Idempotent on (context, user) — a re-add doesn't duplicate or throw.
+      await store.addContextAsker({
+        id: uuid(),
+        context_id: ctx.id,
+        user_id: "u_daniel",
+        added_by: "rob",
+      })
+      expect(await store.getContextAsker(ctx.id, "u_daniel")).toMatchObject({ user_id: "u_daniel" })
+      expect(await store.listContextAskers(ctx.id)).toHaveLength(1)
+
+      await store.removeContextAsker(ctx.id, "u_daniel")
+      expect(await store.getContextAsker(ctx.id, "u_daniel")).toBeNull()
+      await expect(store.removeContextAsker(ctx.id, "u_nobody")).resolves.toBeUndefined()
+    })
+
     it("rejects a duplicate context name within a workspace", async () => {
       const ctx = await newContext()
       await expect(


### PR DESCRIPTION
## The vulnerability

A context is a **data-access grant, not a document** — but ask-access was derived from the manifest artifact's sharing. Since a manifest is a normal artifact, it can carry a **world link** (`link_role: viewer`) or **public listing**. That meant **any signed-in Derive user, from any workspace**, holding the manifest's link could open a session and *query the context's data source*. Confirmed against the live gates: `POST /v1/contexts/:id/sessions` was `requireUser` + `authorize(read, manifest)`, with no membership check.

## The model (B — decoupled, per Rob)

Contexts get their own workspace-scoped ask-grant that **structurally cannot reach outside the workspace** — there is no world-link or public concept anywhere in a context's access.

- `context.ask_policy`: `workspace` (any member) | `invited` (the `context_asker` roster + creator). Default `workspace`.
- `canAskContext(c, x)` — the one gate: currentUser exists → **member of x.org_id (hard floor)** → creator | policy=workspace | on roster. A non-member can never ask, however they hold a manifest link. Keyed off the *context's* org, not the caller's active workspace.
- The three leaking gates (GET context, POST/GET sessions) now call it instead of `authorize(read, manifest)`. Asking no longer touches manifest access — the manifest is purely the runner's prompt source and can stay fully private.
- `POST /:id/access` sets policy; `GET/POST/DELETE /:id/askers` manage the roster — creator-or-manager (`managementPrincipal`, so a stolen runner token can't); the roster add **validates workspace membership** so it can only reference members.
- **Console:** an owner-only workspace-scoped control (Any member / Invited + roster) — no world-link/public option by construction. Plus the no-access error state + prefetch loader. **Supersedes #351** (whose manifest-ShareButton approach exposed the very "Anyone" segment this closes).

## Self-review caught a second leak

The adversarial-review subagent couldn't run (repeated API 529 overloads), so I ran its priority checks by hand — and found that the **session read + follow-up routes** gated only on "are you this session's asker", not "can you still ask". A member who opened a session and was then removed from the workspace could keep reading the data answers and posting fresh questions. Fixed: both re-check `canAskContext` for the asker (owner access unchanged), with a dedicated test.

## Tests

- **The exact attack**: a non-member holding the manifest **world-linked AND public** still 404s on view and ask.
- **Revocation**: a removed member 404s on both reading and following up an in-flight session; the owner still sees it.
- Invited-roster gate; workspace default; non-members can't be added to the roster; store contract across sqlite/d1/pg.
- 812 API + 114 web + 178 db tests; full `pnpm run ci` + typecheck green.

## Two things for review

1. **Default `ask_policy: workspace`** — every existing + new context becomes askable by all its workspace members on deploy (unblocks the pilot; never wider). The alternative is `invited` (creator-only until added). Flag if you'd rather ship `invited`.
2. This is a **schema migration on a security boundary** — worth your eyes on the final diff. And note: the adversarial review is the one automated check I couldn't complete (API overload), so this leaned on manual review + tests.

Migration: additive `ask_policy` (NOT NULL default `workspace`) + `context_asker` table across all three dialects; `lint:schema` clean.