### PR TITLE
fix(collections): propagate workspace-open access to contents; protect the creator

### DIFF
--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -787,10 +787,11 @@ export function buildContext(deps: AppDeps) {
     // it's workspace-open; an invite-only collection (workspace_access=none)
     // grants nothing from mere membership, matching Invited. An explicit
     // collection share (which can cross workspaces) folds in alongside either
-    // way, higher wins. This governs who can view/manage the COLLECTION only;
-    // artifact access still propagates purely from explicit collection
-    // membership (collectionRolesForArtifact), so a seat here never hands out
-    // access to the artifacts inside.
+    // way, higher wins. This is the role on the COLLECTION itself; a workspace-open
+    // collection propagates that same seat role to every artifact inside it —
+    // collectionRolesForArtifact mirrors this exact rule (explicit membership OR a
+    // seat on a workspace-open collection), so visibility of the collection and of
+    // its contents stay in lockstep (no phantom-empty collections).
     const explicit = (await meta.getCollectionMember(col.id, me.id))?.role ?? null
     const seat =
       col.workspace_access === "member"

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -270,8 +270,14 @@ export const artifactRoutes = (ctx: AppContext) => {
         publicOnly: shared || following ? false : publicOnly,
         // Private artifacts appear only for their explicit members (the publisher's
         // owner row included, so agents and owners always find their own drafts);
-        // the operator token sees everything (viewerId omitted).
-        viewerId: isOperator ? undefined : (memberKey ?? undefined),
+        // the operator token sees everything (viewerId omitted). Collection access is
+        // access to the WHOLE collection — a member/creator/seat-on-a-workspace-open
+        // collection reaches every item in it (matching collectionRolesForArtifact's
+        // propagation), so within a collection scope we drop the per-artifact filter
+        // (the collectionId JOIN already bounds the results). Without this the count
+        // (all items) would outrun the list (only your explicitly-shared items).
+        viewerId:
+          isOperator || (collectionId && collectionAccess) ? undefined : (memberKey ?? undefined),
       })
       const hasMore = rows.length > limit
       const page = hasMore ? rows.slice(0, limit) : rows

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -402,6 +402,10 @@ export const collectionRoutes = (ctx: AppContext) => {
       const id = await resolveUserRef(meta, (b.user ?? b.email) as string)
       const [user] = id ? await meta.getUsers([id]) : []
       if (!user) return bail(fail(c, 404, "no Derive user with that username or email"))
+      // The creator is permanently owner (collectionRole checks created_by first), so
+      // their role isn't a member row anyone can rewrite — reject demoting them.
+      if (user.id === col.created_by)
+        return bail(fail(c, 409, "the collection owner's role can't be changed"))
       await meta.setCollectionMember({
         id: newId("cm"),
         collection_id: col.id,
@@ -425,6 +429,10 @@ export const collectionRoutes = (ctx: AppContext) => {
       const col = await meta.getCollection(c.req.param("id"))
       if (!col) return bail(fail(c, 404, "not found"))
       if (!(await canManageCollection(c, col, "manage"))) return bail(fail(c, 403, "forbidden"))
+      // The creator stays owner via created_by regardless of member rows; removing the
+      // row wouldn't revoke their access, it would just orphan the roster — refuse it.
+      if (c.req.param("userId") === col.created_by)
+        return bail(fail(c, 409, "can't remove the collection owner"))
       await meta.removeCollectionMember(col.id, c.req.param("userId"))
       return c.body(null, 204)
     },

--- a/apps/api/test/collection-access.test.ts
+++ b/apps/api/test/collection-access.test.ts
@@ -126,4 +126,75 @@ describe("a collection's own workspace access", () => {
     // The collection's title doesn't leak to a caller who no longer has a role on it.
     expect(invitedFeed.collection).toBeUndefined()
   })
+
+  // Regression: the phantom-empty collection. The list count is a raw item count, but a
+  // seat-only member (no explicit share) used to get NO role on a PRIVATE artifact inside
+  // a workspace-open collection — so "· 1" rendered an empty body and opening the item
+  // 404'd. Propagation (collectionRolesForArtifact folds the seat) + the feed's
+  // collection-access bypass now let the seat reach every item, so count === contents and
+  // the item actually opens.
+  it("a seat-only member sees and can open a private artifact in a workspace-open collection; count matches", async () => {
+    const col = await create("Eng docs", as(ana.email))
+    // A truly private artifact: no workspace seat on the artifact itself, unlisted, no
+    // link — the ONLY way to reach it is the collection.
+    const priv = await (
+      await publishAs(
+        app,
+        "<p>secret</p>",
+        { title: "Secret", workspace_access: "none", listed: "none", link_role: "none" },
+        as(ana.email),
+      )
+    ).json()
+    await app.request(`/v1/collections/${col.id}/items/${priv.short_id}`, {
+      method: "PUT",
+      headers: as(ana.email),
+    })
+
+    // Ben has an editor SEAT but no explicit collection share and no artifact share. The
+    // count he sees…
+    const listForBen = await (
+      await app.request("/v1/collections", { headers: as(ben.email) })
+    ).json()
+    expect(listForBen.collections.find((c: { id: string }) => c.id === col.id)?.count).toBe(1)
+    // …matches the contents the feed serves him (no phantom-empty)…
+    const feed = await (
+      await app.request(`/v1/artifacts?collection=${col.id}`, { headers: as(ben.email) })
+    ).json()
+    expect(feed.artifacts.map((a: { short_id: string }) => a.short_id)).toEqual([priv.short_id])
+    // …and he can actually OPEN the item, not just see it listed (propagation reaches the
+    // read path too, so no 404).
+    expect(
+      (await app.request(`/v1/artifacts/${priv.short_id}`, { headers: as(ben.email) })).status,
+    ).toBe(200)
+  })
+
+  // The creator is permanently owner via created_by — their roster row is immovable, and
+  // the backend refuses to demote or remove them regardless of who asks (a self-demote,
+  // or another manager trying to unseat them).
+  it("the collection creator's owner role can't be demoted or removed, by anyone", async () => {
+    const col = await create("Ana's collection", as(ana.email))
+    const putMember = (actor: Record<string, string>, user: string, role: string) =>
+      app.request(`/v1/collections/${col.id}/members`, {
+        ...jsonAs(actor, { user, role }),
+        method: "PUT",
+      })
+    const delMember = (actor: Record<string, string>, userId: string) =>
+      app.request(`/v1/collections/${col.id}/members/${userId}`, {
+        method: "DELETE",
+        headers: actor,
+      })
+
+    // The creator can't demote or remove herself.
+    expect((await putMember(as(ana.email), ana.email, "editor")).status).toBe(409)
+    expect((await delMember(as(ana.email), ana.id)).status).toBe(409)
+
+    // Another manager (cara, promoted to owner) can manage the roster but still can't
+    // touch the creator.
+    expect((await putMember(as(ana.email), cara.email, "owner")).status).toBe(201)
+    expect((await putMember(as(cara.email), ana.email, "viewer")).status).toBe(409)
+    expect((await delMember(as(cara.email), ana.id)).status).toBe(409)
+
+    // Ana is still owner throughout.
+    expect((await meta.getCollectionMember(col.id, ana.id))?.role).toBe("owner")
+  })
 })

--- a/apps/web/e2e/deep/collection-visibility.deep.spec.ts
+++ b/apps/web/e2e/deep/collection-visibility.deep.spec.ts
@@ -1,0 +1,163 @@
+import { Buffer } from "node:buffer"
+import { mkdirSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import type { Page } from "@playwright/test"
+import { expect, signUp, test } from "../fixtures"
+
+// End-to-end proof for the collection visibility + owner-protection fix, driven
+// through the real web UI (real API, real Better Auth). Reproduces the exact
+// scenarios from the bug reports and captures screenshots into
+// ~/Projects/screenshots/derive-collections. Companion to the API/store coverage
+// in apps/api/test/collection-access.test.ts + packages/db/test/store-contract.ts.
+//
+// Cast, all in ANA's workspace (multi-workspace mode gives each signup its own):
+//  • ana  — creator/owner of the collection.
+//  • ben  — a workspace EDITOR seat, NOT an explicit collection member. He is the
+//           whole point: seat-only reach used to render "· 1" over an empty body.
+//  • cara — a workspace member promoted to collection OWNER (a manager), used to
+//           show a non-creator manager still can't touch the creator's row.
+
+const SHOTS = join(homedir(), "Projects/screenshots/derive-collections")
+
+test("collection visibility + owner protection, end to end", async ({
+  owner: ana,
+  secondUser: ben,
+  browser,
+}) => {
+  mkdirSync(SHOTS, { recursive: true })
+  const shot = (page: Page, name: string) => page.screenshot({ path: join(SHOTS, `${name}.png`) })
+
+  // --- ana's workspace id (so teammates can switch into it) ---
+  const anaOrg = ((await (await ana.request.get("/v1/workspaces")).json()) as { active: string })
+    .active
+
+  // --- ana creates a workspace-open collection (the default) ---
+  const col = (await (
+    await ana.request.post("/v1/collections", { data: { title: "Product Training" } })
+  ).json()) as { id: string; workspace_access: string }
+  expect(col.workspace_access).toBe("member")
+
+  // --- ana publishes a PRIVATE artifact and folds it into the collection. Private
+  //     means the ONLY way a teammate reaches it is the collection itself. ---
+  const priv = (await (
+    await ana.request.post("/v1/artifacts", {
+      multipart: {
+        file: {
+          name: "onboarding.md",
+          mimeType: "text/markdown",
+          buffer: Buffer.from("# Q3 Onboarding Playbook\n\nInternal, private.\n"),
+        },
+        title: "Q3 Onboarding Playbook",
+        visibility: "private",
+      },
+    })
+  ).json()) as { short_id: string }
+  expect((await ana.request.put(`/v1/collections/${col.id}/items/${priv.short_id}`)).ok()).toBe(
+    true,
+  )
+
+  // --- ben joins ana's workspace as an EDITOR seat (no explicit collection share) ---
+  expect(
+    (
+      await ana.request.post("/v1/workspace/invites", {
+        data: { email: ben.email, role: "editor" },
+      })
+    ).ok(),
+  ).toBe(true)
+
+  // --- cara joins the workspace as an editor seat now; she's promoted to
+  //     collection OWNER later (just before S2), so S1 sees ana as the sole
+  //     member and the creator-row assertion stays unambiguous. ---
+  const caraCtx = await browser.newContext()
+  const caraPage = await caraCtx.newPage()
+  const caraEmail = await signUp(caraPage, "Cara")
+  expect(
+    (
+      await ana.request.post("/v1/workspace/invites", {
+        data: { email: caraEmail, role: "editor" },
+      })
+    ).ok(),
+  ).toBe(true)
+
+  // ============================================================================
+  // S1 — the CREATOR's Share dialog: their own row is a fixed "Owner", no role
+  //      dropdown and no remove control (fixes the self-downgrade screenshot).
+  // ============================================================================
+  await ana.goto(`/?collection=${col.id}`)
+  await expect(ana.getByTestId("collection-share")).toBeVisible()
+  await ana.getByTestId("collection-share").click()
+  const anaDialog = ana.getByRole("dialog")
+  await expect(anaDialog.getByText("Product Training", { exact: false })).toBeVisible()
+  // Ana is the only member and she is the creator → zero editable controls.
+  await expect(anaDialog.locator('[data-testid^="collection-share-member-role-"]')).toHaveCount(0)
+  await expect(anaDialog.locator('[data-testid^="collection-share-remove-"]')).toHaveCount(0)
+  await expect(anaDialog.getByText("Owner", { exact: true }).first()).toBeVisible()
+  await shot(ana, "01-creator-dialog-owner-immovable")
+  await ana.keyboard.press("Escape")
+
+  // ============================================================================
+  // S3 — a SEAT-ONLY member sees the private artifact (count matches the body),
+  //      instead of "· 1" over "This collection is empty."
+  // ============================================================================
+  await ben.page.request.post("/v1/workspace/switch", { data: { id: anaOrg } })
+  await ben.page.goto(`/?collection=${col.id}`)
+  await expect(ben.page.getByText("Q3 Onboarding Playbook").first()).toBeVisible()
+  await expect(ben.page.getByText("This collection is empty.")).toBeHidden()
+  await shot(ben.page, "03-seat-member-sees-contents")
+
+  // ============================================================================
+  // S4 — the seat-only member can OPEN the private item (no 404): propagation
+  //      reaches the read path, not just the listing.
+  // ============================================================================
+  await ben.page.goto(`/artifacts/${priv.short_id}`)
+  await expect(ben.page.getByText("Q3 Onboarding Playbook").first()).toBeVisible()
+  await shot(ben.page, "04-seat-member-opens-item")
+
+  // ============================================================================
+  // S2 — a MANAGER who is not the creator: the creator's row is a fixed "Owner"
+  //      (no dropdown / no remove), while their own non-creator row stays
+  //      editable — management still works, the creator is protected.
+  // ============================================================================
+  // Promote cara to collection owner so she can manage the roster.
+  expect(
+    (
+      await ana.request.put(`/v1/collections/${col.id}/members`, {
+        data: { email: caraEmail, role: "owner" },
+      })
+    ).ok(),
+  ).toBe(true)
+  await caraPage.request.post("/v1/workspace/switch", { data: { id: anaOrg } })
+  await caraPage.goto(`/?collection=${col.id}`)
+  await expect(caraPage.getByTestId("collection-share")).toBeVisible()
+  await caraPage.getByTestId("collection-share").click()
+  const caraDialog = caraPage.getByRole("dialog")
+  await expect(caraDialog.getByText("Ana", { exact: false })).toBeVisible()
+  // Exactly one editable row (cara's own); the creator (ana) row is fixed.
+  await expect(caraDialog.locator('[data-testid^="collection-share-member-role-"]')).toHaveCount(1)
+  await expect(caraDialog.locator('[data-testid^="collection-share-remove-"]')).toHaveCount(1)
+  await shot(caraPage, "02-manager-view-creator-protected")
+  await caraPage.keyboard.press("Escape")
+
+  // ============================================================================
+  // S5 — flipping the collection to Invited drops the seat member entirely:
+  //      the artifact vanishes for ben (visibility stays consistent).
+  // ============================================================================
+  expect(
+    (
+      await ana.request.patch(`/v1/collections/${col.id}/access`, {
+        data: { workspaceAccess: "none" },
+      })
+    ).ok(),
+  ).toBe(true)
+  await ben.page.goto(`/?collection=${col.id}`)
+  await expect(ben.page.getByText("Q3 Onboarding Playbook")).toBeHidden()
+  // And it's gone from his sidebar entirely — land on the library home (shell
+  // settled) so the screenshot shows a stable "no Product Training" state.
+  await ben.page.goto("/")
+  await expect(ben.page.getByTestId("library-menu")).toBeVisible()
+  await expect(ben.page.getByText("Product Training")).toBeHidden()
+  await shot(ben.page, "05-invite-only-hides-from-seat-member")
+
+  await caraCtx.close()
+})

--- a/apps/web/src/pages/library/share-collection-dialog.tsx
+++ b/apps/web/src/pages/library/share-collection-dialog.tsx
@@ -206,50 +206,53 @@ export function ShareCollectionDialog({
               <EmptyState className="mt-2 p-6">No one shared yet.</EmptyState>
             ) : (
               <div className="mt-2 flex flex-col gap-1.5">
-                {members.map((m) => (
-                  <div key={m.user_id} className="flex items-center gap-2">
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-sm font-medium text-foreground">
-                        {m.name ?? (m.handle ? `@${m.handle}` : m.user_id)}
-                      </div>
-                      {m.name && m.handle && (
-                        <div className="truncate font-mono text-2xs text-muted-foreground">
-                          @{m.handle}
+                {members.map((m) => {
+                  const who = m.name ?? (m.handle ? `@${m.handle}` : "member")
+                  return (
+                    <div key={m.user_id} className="flex items-center gap-2">
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-sm font-medium text-foreground">
+                          {m.name ?? (m.handle ? `@${m.handle}` : m.user_id)}
                         </div>
-                      )}
-                    </div>
-                    {/* The creator's row is fixed — a collection's creator is
+                        {m.name && m.handle && (
+                          <div className="truncate font-mono text-2xs text-muted-foreground">
+                            @{m.handle}
+                          </div>
+                        )}
+                      </div>
+                      {/* The creator's row is fixed — a collection's creator is
                         permanently owner via created_by regardless of member rows
                         (collectionRole checks it first), so their role can't be
                         changed and removing the row wouldn't revoke access, just
                         orphan the roster. Show it read-only even to a manager (the
                         backend rejects demote/remove of the creator too). */}
-                    {canManage && m.user_id !== collection.created_by ? (
-                      <>
-                        <RoleSelect
-                          value={m.role}
-                          onChange={(next) => change(m, next)}
-                          data-testid={`collection-share-member-role-${m.user_id}`}
-                          aria-label={`Role for ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
-                          className="w-28 shrink-0"
-                        />
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          data-testid={`collection-share-remove-${m.user_id}`}
-                          onClick={() => remove(m)}
-                          aria-label={`Remove ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
-                        >
-                          <Icon name="close" />
-                        </Button>
-                      </>
-                    ) : (
-                      <span className="shrink-0 text-sm text-muted-foreground">
-                        {ROLE_LABELS[m.role]}
-                      </span>
-                    )}
-                  </div>
-                ))}
+                      {canManage && m.user_id !== collection.created_by ? (
+                        <>
+                          <RoleSelect
+                            value={m.role}
+                            onChange={(next) => change(m, next)}
+                            data-testid={`collection-share-member-role-${m.user_id}`}
+                            aria-label={`Role for ${who}`}
+                            className="w-28 shrink-0"
+                          />
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            data-testid={`collection-share-remove-${m.user_id}`}
+                            onClick={() => remove(m)}
+                            aria-label={`Remove ${who}`}
+                          >
+                            <Icon name="close" />
+                          </Button>
+                        </>
+                      ) : (
+                        <span className="shrink-0 text-sm text-muted-foreground">
+                          {ROLE_LABELS[m.role]}
+                        </span>
+                      )}
+                    </div>
+                  )
+                })}
               </div>
             )}
           </div>

--- a/apps/web/src/pages/library/share-collection-dialog.tsx
+++ b/apps/web/src/pages/library/share-collection-dialog.tsx
@@ -218,7 +218,13 @@ export function ShareCollectionDialog({
                         </div>
                       )}
                     </div>
-                    {canManage ? (
+                    {/* The creator's row is fixed — a collection's creator is
+                        permanently owner via created_by regardless of member rows
+                        (collectionRole checks it first), so their role can't be
+                        changed and removing the row wouldn't revoke access, just
+                        orphan the roster. Show it read-only even to a manager (the
+                        backend rejects demote/remove of the creator too). */}
+                    {canManage && m.user_id !== collection.created_by ? (
                       <>
                         <RoleSelect
                           value={m.role}
@@ -227,23 +233,15 @@ export function ShareCollectionDialog({
                           aria-label={`Role for ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
                           className="w-28 shrink-0"
                         />
-                        {/* The creator's own row is fixed — unlike an artifact's
-                            "last owner" member row, a collection's creator is
-                            permanently owner via created_by regardless of member
-                            rows (collectionRole checks it first), so removing this
-                            row wouldn't revoke access — it would just make them
-                            vanish from their own roster. Nothing to offer. */}
-                        {m.user_id !== collection.created_by && (
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            data-testid={`collection-share-remove-${m.user_id}`}
-                            onClick={() => remove(m)}
-                            aria-label={`Remove ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
-                          >
-                            <Icon name="close" />
-                          </Button>
-                        )}
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          data-testid={`collection-share-remove-${m.user_id}`}
+                          onClick={() => remove(m)}
+                          aria-label={`Remove ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
+                        >
+                          <Icon name="close" />
+                        </Button>
                       </>
                     ) : (
                       <span className="shrink-0 text-sm text-muted-foreground">

--- a/docs/plans/access-model.md
+++ b/docs/plans/access-model.md
@@ -54,6 +54,28 @@ Consequences that fall out for free:
 - The **role dropdown only appears for "Anyone"** in the UI — Workspace uses seats,
   so it has no role, just a listing switch.
 
+### Collections propagate like a workspace-open artifact
+
+A collection's role reaches its **contents** by the same explicit-or-seat rule an
+artifact uses, so "who can open the collection" and "who can open what's inside"
+never diverge:
+
+- **Explicit** `collection_member` rows grant that role on every artifact in the
+  collection (can cross workspaces).
+- A **workspace-open** collection (`workspace_access = member`) additionally hands
+  every workspace member their **seat role** on every artifact inside — the Share
+  dialog's promise, "Everyone in the workspace opens this at their role." An
+  **invite-only** collection (`workspace_access = none`) grants nothing from a mere
+  seat; only its explicit members reach it.
+
+`collectionRolesForArtifact` (both stores) folds both sources into an artifact's
+effective role, and `collectionRole` gates collection visibility on the same rule —
+so a raw `COUNT(collection_item)` is always truthful for anyone who can see the
+collection (no "· 1 but empty"). The **creator** (`created_by`) is permanently
+owner and can never be demoted or removed; workspace admins may otherwise manage
+membership. Collections omit `listed`/`link_role` (a collection isn't individually
+link-servable — it's a grouping of artifacts, each with its own link).
+
 ## Listing preconditions (the only invariants)
 
 Discovery may not surface an artifact to an audience that cannot open it:

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1335,12 +1335,29 @@ export class PgMetaStore implements MetaStore {
       )
   }
   async collectionRolesForArtifact(artifactId: string, userId: string): Promise<Role[]> {
-    const rows = await this.db
+    // Explicit collectionMember rows on any collection holding this artifact.
+    const explicit = await this.db
       .select({ role: collectionMember.role })
       .from(collectionMember)
       .innerJoin(collectionItem, eq(collectionItem.collection_id, collectionMember.collection_id))
       .where(and(eq(collectionItem.artifact_id, artifactId), eq(collectionMember.user_id, userId)))
-    return rows.map((r) => r.role)
+    // A workspace-open collection propagates the viewer's SEAT role to every artifact
+    // inside it — "Everyone in the workspace opens this at their role" (the Share
+    // dialog's promise; see access-model.md). Join the artifact's collections to the
+    // viewer's membership in each collection's org, keeping only workspace-open ones.
+    const seat = await this.db
+      .select({ role: membership.role })
+      .from(collectionItem)
+      .innerJoin(collection, eq(collection.id, collectionItem.collection_id))
+      .innerJoin(membership, eq(membership.org_id, collection.org_id))
+      .where(
+        and(
+          eq(collectionItem.artifact_id, artifactId),
+          eq(collection.workspace_access, "member"),
+          eq(membership.user_id, userId),
+        ),
+      )
+    return [...explicit, ...seat].map((r) => r.role)
   }
 
   // ---- GitHub sync sources -----------------------------------------------

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -1472,17 +1472,36 @@ export function makeRepos(db: SqliteDb) {
       )
       .run()
   }
-  const collectionRolesForArtifact = async (artifactId: string, userId: string): Promise<Role[]> =>
-    (
-      await db
-        .select({ role: collectionMember.role })
-        .from(collectionMember)
-        .innerJoin(collectionItem, eq(collectionItem.collection_id, collectionMember.collection_id))
-        .where(
-          and(eq(collectionItem.artifact_id, artifactId), eq(collectionMember.user_id, userId)),
-        )
-        .all()
-    ).map((r) => r.role)
+  const collectionRolesForArtifact = async (
+    artifactId: string,
+    userId: string,
+  ): Promise<Role[]> => {
+    // Explicit collectionMember rows on any collection holding this artifact.
+    const explicit = await db
+      .select({ role: collectionMember.role })
+      .from(collectionMember)
+      .innerJoin(collectionItem, eq(collectionItem.collection_id, collectionMember.collection_id))
+      .where(and(eq(collectionItem.artifact_id, artifactId), eq(collectionMember.user_id, userId)))
+      .all()
+    // A workspace-open collection propagates the viewer's SEAT role to every artifact
+    // inside it — "Everyone in the workspace opens this at their role" (the Share
+    // dialog's promise; see access-model.md). Join the artifact's collections to the
+    // viewer's membership in each collection's org, keeping only workspace-open ones.
+    const seat = await db
+      .select({ role: membership.role })
+      .from(collectionItem)
+      .innerJoin(collection, eq(collection.id, collectionItem.collection_id))
+      .innerJoin(membership, eq(membership.org_id, collection.org_id))
+      .where(
+        and(
+          eq(collectionItem.artifact_id, artifactId),
+          eq(collection.workspace_access, "member"),
+          eq(membership.user_id, userId),
+        ),
+      )
+      .all()
+    return [...explicit, ...seat].map((r) => r.role)
+  }
 
   // ---- GitHub sync sources -----------------------------------------------
   const createRepoSource = async (s: NewRepoSource): Promise<RepoSourceRecord> =>

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -886,6 +886,42 @@ export function runStoreContract(
       await store.deleteCollection(col.id)
       expect(await store.getCollection(col.id)).toBeNull()
     })
+
+    it("propagates a workspace-open collection's seat role to its artifacts; invite-only does not", async () => {
+      // A private artifact (workspace_access=none) no one is an explicit member of.
+      const priv = await store.createArtifact(
+        newArtifact({ workspace_access: "none", link_role: "none", listed: "none" }),
+      )
+      // carol has a workspace SEAT (editor) but is NOT an explicit collection member.
+      await store.setMembership({ id: uuid(), org_id: ORG, user_id: "carol", role: "editor" })
+
+      // A workspace-open collection hands carol her seat role on every artifact inside
+      // it — even a private one — purely via her workspace membership.
+      const open = await store.createCollection({
+        id: uuid(),
+        org_id: ORG,
+        title: "Open",
+        created_by: "amy",
+        workspace_access: "member",
+      })
+      await store.addCollectionItem(open.id, priv.id)
+      expect(await store.collectionRolesForArtifact(priv.id, "carol")).toContain("editor")
+
+      // An invite-only collection (workspace_access=none) grants a bare seat nothing —
+      // only its explicit members reach it.
+      const invite = await store.createCollection({
+        id: uuid(),
+        org_id: ORG,
+        title: "Invite",
+        created_by: "amy",
+        workspace_access: "none",
+      })
+      const priv2 = await store.createArtifact(
+        newArtifact({ workspace_access: "none", link_role: "none", listed: "none" }),
+      )
+      await store.addCollectionItem(invite.id, priv2.id)
+      expect(await store.collectionRolesForArtifact(priv2.id, "carol")).toHaveLength(0)
+    })
   })
 
   describe(`${label}: github sync sources`, () => {


### PR DESCRIPTION
## What and why

Two reported bugs, one root cause. A workspace **seat** inflated your role *on* a collection (visibility + management) but never reached the artifacts *inside* it:

- `collectionRole` folds in your seat for a workspace-open collection, so you see and can manage it.
- `listCollections` count is a raw `COUNT(collection_item)`, blind to the viewer.
- `collectionRolesForArtifact` propagated to artifacts only from explicit `collection_member` rows, never the seat.

So a workspace-open collection you did not create rendered "· 1" over an empty body (count raw, but the private artifact inside was invisible), and the Share dialog handed you owner controls to remove or downgrade the real owner. The dialog copy already promised the opposite ("everyone in the workspace opens this at their role on every artifact").

## The fix (confirmed direction: propagate + protect the creator)

**Part A: propagate workspace-open access to contents.**
- `collectionRolesForArtifact` (pg + sqlite stores) now folds in the viewer's seat role for `workspace_access='member'` collections, so opening a propagated artifact works.
- The collection contents feed drops its per-artifact filter once collection access is granted, so the listing matches. The raw count is now truthful for anyone who can see the collection (no phantom-empty collections).

**Part B: the creator is permanently owner.**
- The member routes reject demoting (PUT) or removing (DELETE) `created_by` with HTTP 409.
- The Share dialog renders the creator row as a fixed "Owner", no dropdown and no remove, even for a managing admin. Non-creator rows stay editable, so workspace admins can still manage.

Updated `docs/plans/access-model.md` and the now-inverted `context.ts` comment.

## Verification

- **Automated:** 11/11 collections API tests (incl. new seat-propagation + creator-protection cases), a new store-contract propagation test, full typecheck, Biome, and all 12 precommit lint gates.
- **End to end:** a new Playwright spec (`apps/web/e2e/deep/collection-visibility.deep.spec.ts`) drives the real web + API + Better Auth across all scenarios and captures screenshots. Passing.
- Full matrix + screenshots: https://derive.to/artifacts/collections-visibility-owner-protection-verifica-8m1b55ql
- Not run locally: the Postgres-store contract (needs a PG container); its query is identical to the exercised sqlite path and schema parity is lint-enforced, so CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)