### PR TITLE
CI audit follow-ups: paths-filter gap, soften small-pkg coverage floors, scope e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   # Which areas a change touches — lets the peripheral build jobs (bundle,
   # runner-image) skip when a PR can't affect them. The core gates
-  # (check/pg/d1/coverage/security) always run. No branch protection on this repo,
+  # (check/pg/d1/security) always run. No branch protection on this repo,
   # so a skipped job can't wedge a required check — it just reports success.
   changes:
     runs-on: ubuntu-24.04-arm
@@ -40,8 +40,11 @@ jobs:
             web:
               - 'apps/web/**'
               - 'packages/**'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
             docker:
               - 'packages/cli/**'
+              - 'pnpm-lock.yaml'
               - 'deploy/runner.Dockerfile'
               - 'deploy/runner.Dockerfile.dockerignore'
               - 'deploy/runner-entrypoint.sh'
@@ -224,10 +227,9 @@ jobs:
           echo "prod not healthy after deploy (last /v1/artifacts status: $db)" >&2
           exit 1
 
-      # e2e smoke's post-deploy auto-dispatch is disabled for now (still flaky
-      # under CI CPU contention — see e2e-smoke.yml). Run it manually with
-      # `gh workflow run e2e-smoke.yml --ref main` when a regression signal is
-      # actually wanted.
+      # e2e smoke now runs on PRs (see e2e-smoke.yml). Its post-DEPLOY auto-dispatch
+      # stays off — a post-ship prod check is separate from the PR gate; trigger it
+      # manually with `gh workflow run e2e-smoke.yml --ref main` if wanted.
 
   # Supply-chain: a known-vulnerable production dependency, or a committed secret,
   # fails the build. Reads the lockfile + working tree, so no install is needed.

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -11,7 +11,13 @@ name: e2e smoke
 # just bump workers.
 on:
   workflow_dispatch:
+  # Scope to changes that can affect a user flow — skip docs/CI-only PRs so the
+  # (uncached-browser + build + serial specs) minutes don't burn on every PR.
   pull_request:
+    paths:
+      - "apps/**"
+      - "packages/**"
+      - "pnpm-lock.yaml"
 
 permissions:
   contents: read

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -24,9 +24,10 @@ export default defineConfig({
         "src/pages/artifact/lib/layout.ts",
       ],
       reporter: ["text-summary"],
-      // Ratchet floors under current (95.5/83/100/97.2). Extra headroom: this gate
-      // is scoped to 7 small pure-logic files, so each function is worth several %.
-      thresholds: { statements: 90, branches: 76, functions: 90, lines: 92 },
+      // Ratchet floors. Only statements + lines gate — this is 7 small pure-logic
+      // files, so functions/branches (22 fns) swing several % per unit and would
+      // false-fail routine additions on a hard gate. (current 95.5/97.2)
+      thresholds: { statements: 90, lines: 92 },
     },
   },
 })

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "typecheck": "tsgo --noEmit",
     "typecheck:tsc": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage --passWithNoTests"
   },
   "dependencies": {
     "fflate": "^0.8.2",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -20,7 +20,7 @@
     "typecheck": "tsgo --noEmit",
     "typecheck:tsc": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
-    "test:coverage": "vitest run --coverage",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
     "test:pg": "vitest run --config vitest.pg.config.ts --coverage test/pg-store.test.ts test/pg-schema-conformance.test.ts",
     "test:d1": "vitest run --config vitest.d1.config.ts test/d1-store.test.ts",
     "gen:d1-schema": "vitest run test/d1-schema.test.ts -u"

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -10,9 +10,9 @@ export default defineConfig({
       provider: "v8",
       include: ["src/client.ts"],
       reporter: ["text-summary"],
-      // Ratchet floors under current (80.9/73.8/72.2/92.8), with headroom — client.ts
-      // is small (18 fns), so each unit is worth several %.
-      thresholds: { statements: 75, branches: 66, functions: 66, lines: 88 },
+      // Ratchet floors. Only statements + lines gate — client.ts is small (18 fns),
+      // so functions/branches are too jumpy for a hard gate. (current 80.9/92.8)
+      thresholds: { statements: 75, lines: 88 },
     },
   },
 })

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -19,7 +19,7 @@
     "typecheck": "tsgo --noEmit",
     "typecheck:tsc": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage --passWithNoTests"
   },
   "dependencies": {
     "@derive/core": "workspace:*"

--- a/packages/storage/vitest.config.ts
+++ b/packages/storage/vitest.config.ts
@@ -9,9 +9,9 @@ export default defineConfig({
       provider: "v8",
       include: ["src/**"],
       reporter: ["text-summary"],
-      // Ratchet floors under current (98.9/94.7/94.4/100), with headroom — small
-      // denominators (18 fns) swing several % per unit.
-      thresholds: { statements: 92, branches: 85, functions: 83, lines: 95 },
+      // Ratchet floors. Only statements + lines gate — 18 fns / 38 branches swing
+      // several % per unit, too jumpy for a hard gate. (current 98.9/100)
+      thresholds: { statements: 92, lines: 95 },
     },
   },
 })

--- a/scripts/test-pg.sh
+++ b/scripts/test-pg.sh
@@ -54,9 +54,10 @@ cd "$ROOT/apps/api"
 #
 # File parallelism is ON (previously --no-file-parallelism): helpers.ts keys each
 # schema on VITEST_POOL_ID, so concurrent files land in distinct schemas and can't
-# collide. Cap workers so the per-store pools (node-postgres default max=10) stay
-# well under max_connections; a 2-vCPU CI box uses ~2 anyway, so the cap only
-# bounds beefier local machines.
+# collide. --maxWorkers=4 bounds the live per-store pools (node-postgres default
+# max=10) so their connections stay well under max_connections. Note vitest does
+# NOT clamp an explicit maxWorkers to core count, so this runs 4 forks even on a
+# 2-vCPU box — fine here because pg tests are I/O-bound (waiting on Postgres).
 pnpm exec vitest run --maxWorkers=4 --testTimeout=15000 "$@"
 
 # Also run @derive/db's store contract against the same Postgres — the only place


### PR DESCRIPTION
Follow-ups from an adversarial audit of #356 (the CI/test overhaul, now merged). All core jobs were already green on that PR; these close the real gaps the audit surfaced.

- **paths-filter gap** — add `pnpm-lock.yaml` + root `package.json` to the `web`/`docker` filters. A dep-only bump (transitive weight regression) rewrites only the lockfile and silently SKIPPED the `bundle` budget job — the exact regression it exists to catch.
- **Soften small-package coverage floors** — drop the `functions`/`branches` thresholds on web/storage/mcp (~18 functions each), keep statements+lines. On a hard gate, one uncovered helper swings those metrics several % and would false-fail routine PRs; statements/lines still ratchet.
- **Scope e2e-smoke** — `pull_request: paths: [apps/**, packages/**, pnpm-lock.yaml]` so docs/CI-only PRs skip the (uncached-browser + build + serial-specs) minutes — the largest per-PR cost on the 2,000-min budget.
- **`--passWithNoTests`** symmetry on core/db/storage `test:coverage`.
- **Comment fixes** — the deleted `coverage` job, the "still flaky" e2e note, and the `maxWorkers` reasoning.

Verified: web/storage/mcp coverage still pass; actionlint clean.

**Open question (not in this PR):** the audit flagged that coverage-gating-deploy + no branch protection can silently stall main's deploy on a coverage regression — being decided separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)