### PR TITLE
perf(ci): shard the api test + pg suites (speed over minutes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   # Which areas a change touches — lets the peripheral build jobs (bundle,
   # runner-image) skip when a PR can't affect them. The core gates
-  # (check/pg/d1/security) always run. No branch protection on this repo,
+  # (lint/typecheck/test-*/pg/d1/security) always run. No branch protection here,
   # so a skipped job can't wedge a required check — it just reports success.
   changes:
     runs-on: ubuntu-24.04-arm
@@ -54,36 +54,96 @@ jobs:
   # vitest, tsgo) is arm-native. The org's Ubicloud integration vanished
   # 2026-07-02 and every ubicloud-* job queued forever; GitHub-hosted keeps
   # deploys vendor-independent.
-  check:
+  lint:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/setup
-
       - name: Lint + format + guardrails (biome + custom checks)
         run: pnpm run ci
 
-      - name: Typecheck
-        run: pnpm typecheck
-
-      # Runs every package's suite once WITH coverage. Thresholds live in each
-      # vitest.config.ts (ratchet floors) — a regression fails here, and since
-      # deploy needs `check`, it blocks the ship. Replaces the old separate,
-      # redundant `coverage` job (which re-ran the whole suite a third time).
-      - name: Test + coverage gate
-        run: pnpm test:coverage
-
-  # Runs the SAME apps/api suite against a real Postgres (ephemeral Docker
-  # container, via scripts/test-pg.sh) so the hosted-tier driver is covered by
-  # the full behavioral suite, not just typecheck + parity guards.
-  pg:
+  typecheck:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/setup
+      - name: Typecheck (tsgo)
+        run: pnpm typecheck
 
-      - name: Test against Postgres
-        run: pnpm test:pg
+  # The 6 non-api packages, each with its own coverage gate. Fast + unsharded.
+  test-rest:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./.github/actions/setup
+      - name: Test + coverage (non-api packages)
+        run: pnpm --filter='!@derive/api' -r test:coverage
+
+  # The api suite (~60% of all tests) sharded across runners. Each shard collects
+  # coverage into a blob with thresholds DISABLED (a partial shard can't meet them);
+  # test-api-merge combines the blobs and enforces the real thresholds on the MERGED
+  # coverage — exact gate, ~1/N wall-clock.
+  test-api:
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./.github/actions/setup
+      - name: Test api (shard ${{ matrix.shard }}/4)
+        run: >-
+          pnpm --filter @derive/api exec vitest run
+          --shard=${{ matrix.shard }}/4 --coverage --reporter=blob
+          --coverage.thresholds.statements=0 --coverage.thresholds.branches=0
+          --coverage.thresholds.functions=0 --coverage.thresholds.lines=0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: api-coverage-blob-${{ matrix.shard }}
+          path: apps/api/.vitest-reports
+          retention-days: 1
+
+  # Merge the shards' coverage blobs and enforce the api thresholds on the total.
+  # This is the api coverage GATE (deploy needs it).
+  test-api-merge:
+    needs: test-api
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./.github/actions/setup
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: apps/api/.vitest-reports
+          pattern: api-coverage-blob-*
+          merge-multiple: true
+      - name: Merge coverage + enforce thresholds
+        run: pnpm --filter @derive/api test:merge
+
+  # The api suite against a real Postgres (the hosted-tier driver), sharded across
+  # runners — each shard spins its own ephemeral container (test-pg.sh) and runs one
+  # --shard of the api files. No coverage here, so no merge; all shards must pass.
+  pg:
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./.github/actions/setup
+      - name: Test api vs Postgres (shard ${{ matrix.shard }}/3)
+        run: bash scripts/test-pg.sh --shard=${{ matrix.shard }}/3
+
+  # The @derive/db store contract vs Postgres (its own container) — the only place
+  # pg.ts, the hosted-tier driver, is gated by the db package's own suite.
+  pg-db:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./.github/actions/setup
+      - name: DB store contract vs Postgres
+        run: bash scripts/test-pg.sh --db-only
 
   # Runs the SAME @derive/db store contract against a real Cloudflare D1, inside
   # workerd via Miniflare (the `pnpm test:d1` lane). The default (Node) lane can't
@@ -150,7 +210,7 @@ jobs:
   # worker's data path).
   deploy:
     if: github.repository == 'derive-to/derive' && github.event_name == 'push' # never PRs, never forks
-    needs: [check, pg, d1, security]
+    needs: [lint, typecheck, test-rest, test-api-merge, pg, pg-db, d1, security]
     runs-on: ubuntu-latest
     # A running deploy is never cancelled — a schema applied for a worker that
     # then didn't ship is the state to avoid. Queued runs are NOT ordered:

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ apps/api/.e2e-data/
 .local-run-data/
 apps/api/.local-run-data/
 RUNNER.md
+
+# Vitest coverage + sharding blob reports (generated, never committed)
+**/coverage/
+**/.vitest-reports/

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,6 +25,7 @@
     "typecheck:tsc": "tsc --noEmit && tsc --noEmit -p tsconfig.worker.json",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:merge": "vitest run --merge-reports --coverage",
     "gen:env": "vitest run test/config-manifest.test.ts -u",
     "gen:openapi": "vitest run test/openapi.test.ts -u"
   },

--- a/scripts/test-pg.sh
+++ b/scripts/test-pg.sh
@@ -45,26 +45,36 @@ done
 export DERIVE_TEST_DB=pg
 export TEST_DATABASE_URL="$URL"
 
-echo "→ running apps/api suite against Postgres"
-cd "$ROOT/apps/api"
-# The first test in each file pays the Postgres schema bootstrap (DROP SCHEMA
-# CASCADE + full DDL replay via the helpers' deferred store) — on a CI runner
-# that alone can cross vitest's default 5s testTimeout as the schema grows.
-# Relax the timeout for this lane only; the SQLite lane keeps the 5s default.
-#
-# File parallelism is ON (previously --no-file-parallelism): helpers.ts keys each
-# schema on VITEST_POOL_ID, so concurrent files land in distinct schemas and can't
-# collide. --maxWorkers=4 bounds the live per-store pools (node-postgres default
-# max=10) so their connections stay well under max_connections. Note vitest does
-# NOT clamp an explicit maxWorkers to core count, so this runs 4 forks even on a
-# 2-vCPU box — fine here because pg tests are I/O-bound (waiting on Postgres).
-pnpm exec vitest run --maxWorkers=4 --testTimeout=15000 "$@"
-
-# Also run @derive/db's store contract against the same Postgres — the only place
-# pg.ts (the hosted-tier driver) is covered + gated by the db package's own suite.
-# Skipped when a specific api file was requested (debugging one spec).
-if [ "$#" -eq 0 ]; then
+# Modes:
+#   test-pg.sh              → api suite + @derive/db store contract (local, full run)
+#   test-pg.sh --shard=i/N  → one shard of the api suite (a CI matrix leg)
+#   test-pg.sh --db-only    → just the @derive/db store contract (its own CI leg)
+if [ "${1:-}" = "--db-only" ]; then
   echo "→ running @derive/db store contract against Postgres"
   cd "$ROOT"
   pnpm --filter @derive/db test:pg
+else
+  echo "→ running apps/api suite against Postgres"
+  cd "$ROOT/apps/api"
+  # The first test in each file pays the Postgres schema bootstrap (DROP SCHEMA
+  # CASCADE + full DDL replay via the helpers' deferred store) — on a CI runner
+  # that alone can cross vitest's default 5s testTimeout as the schema grows.
+  # Relax the timeout for this lane only; the SQLite lane keeps the 5s default.
+  #
+  # File parallelism is ON (previously --no-file-parallelism): helpers.ts keys each
+  # schema on VITEST_POOL_ID, so concurrent files land in distinct schemas and can't
+  # collide. --maxWorkers=4 bounds the live per-store pools (node-postgres default
+  # max=10) so their connections stay well under max_connections. Note vitest does
+  # NOT clamp an explicit maxWorkers to core count, so this runs 4 forks even on a
+  # 2-vCPU box — fine here because pg tests are I/O-bound (waiting on Postgres). A
+  # CI shard passes --shard=i/N through "$@".
+  pnpm exec vitest run --maxWorkers=4 --testTimeout=15000 "$@"
+
+  # Also run @derive/db's store contract when running the whole suite locally
+  # (skipped for a specific file or a CI shard, which pass args).
+  if [ "$#" -eq 0 ]; then
+    echo "→ running @derive/db store contract against Postgres"
+    cd "$ROOT"
+    pnpm --filter @derive/db test:pg
+  fi
 fi


### PR DESCRIPTION
Optimizing CI for **wall-clock over minutes** (per the shift to cost-no-object on the Free plan). Stacked on #358.

The two poles were the api SQLite suite in `check` (~189s) and the pg lane (~193s), both bound on a 2-vCPU runner. This shards both.

- **Split `check`** → `lint`, `typecheck`, `test-rest` (6 non-api packages), and a **4-way sharded `test-api`**. Each api shard collects coverage into a blob with per-shard thresholds disabled; **`test-api-merge`** downloads the blobs, merges, and enforces the **real thresholds on the merged coverage** — the gate stays exact, wall-clock drops ~4×.
- **Shard the pg lane 3 ways** — `test-pg.sh --shard=i/N` (own container per shard) + a `pg-db` leg (`--db-only`) for the store contract.
- `deploy` needs updated to the split gate set (coverage still hard-gates via `test-api-merge`).

**Verified locally:** api 4-shard + merge reproduces the full-run coverage (78.9/70.2/79.1/83.2) and passes the gate; a partial shard alone fails thresholds (hence the per-shard override); `pg --shard=1/3` = 37 files green; `pg --db-only` = 98-test contract; `test-rest` passes all 6 gates; actionlint clean.

**Expected:** ~246s → ~120s wall-clock (e2e-smoke ~122s becomes the co-pole). Trade: ~1.5× the billed minutes (per-shard install + a merge job) — the point of "speed over cost". The artifact upload/download between shards + merge is the one piece only this CI run can confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)