### PR TITLE
feat(web): seamless cold boot + remove the anonymous nav rail

### DIFF
--- a/apps/web/e2e/deep/anon-profile.deep.spec.ts
+++ b/apps/web/e2e/deep/anon-profile.deep.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "../fixtures"
+
+// The anon nav rail (the old "Create your own" conversion sidebar) was removed. An
+// anonymous visitor on a public profile now gets the chrome-light PublicFrame (brand
+// + the growth verbs), never the app rail — the same shareable-without-a-session
+// treatment as a public artifact.
+test("an anonymous visitor sees a public profile chrome-light, without the app rail", async ({
+  owner,
+  browser,
+}) => {
+  const me = (await (await owner.request.get("/v1/me")).json()) as {
+    user: { username: string }
+  }
+
+  // A truly anonymous visitor — a fresh context with no session.
+  const anon = await browser.newContext()
+  const page = await anon.newPage()
+  try {
+    await page.goto(`/users/${me.user.username}`)
+
+    // The profile renders for the anonymous visitor…
+    await expect(page.getByTestId("profile-username")).toBeVisible()
+    // …inside the public frame (brand + the growth verb)…
+    await expect(page.getByTestId("public-make-your-own")).toBeVisible()
+    // …and the app nav rail is absent (its rows never render for an anon).
+    await expect(page.getByTestId("sidebar-all")).toHaveCount(0)
+  } finally {
+    await anon.close()
+  }
+})

--- a/apps/web/src/components/chrome/app-shell.tsx
+++ b/apps/web/src/components/chrome/app-shell.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { SidebarInset, SidebarProvider, useSidebar } from "@/components/ui/sidebar"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { useAuth } from "@/ctx"
+import { readAuthHint } from "@/lib/auth-hint"
 import { collectionsQuery, summaryQuery, workspacesQuery } from "@/lib/queries"
 import { STORAGE_KEYS } from "@/lib/storage-keys"
 import { useIsMobile } from "@/lib/use-is-mobile"
@@ -31,8 +32,11 @@ const COLLAPSE_KEY = STORAGE_KEYS.navCollapsed
 // navbar's hamburger. Fetches the nav data (summary, collections, workspaces)
 // once, so the rail + pod behave identically on every page.
 export function AppShell({ children }: { children: ReactNode }) {
-  const { me } = useAuth()
+  const { me, loading } = useAuth()
   const isMobile = useIsMobile()
+  // Read once — steers only the me()-loading window (the `bare` calc below), so a
+  // returning user's cold load matches the rail the boot frame already reserved.
+  const [authedHint] = useState(readAuthHint)
 
   // The provider is controlled so the state round-trips through the app's
   // storage contract ("1" = collapsed, "0" = expanded; expanded by default)
@@ -61,13 +65,15 @@ export function AppShell({ children }: { children: ReactNode }) {
   // session so an anon visitor never fires the authed endpoints.
   const { data: workspaces } = useQuery({ ...workspacesQuery(), enabled: !!me })
 
-  // An anonymous visitor on a shared artifact gets the chrome-light PublicViewer
-  // (its own slim public header) — drop the app nav rail entirely so the render is
-  // the whole page (the viral view; research: the render is the hero). Auth +
-  // onboarding redirects for every other route now live in the routes' beforeLoad
-  // guards (lib/route-guards), so an anon never renders authed chrome.
+  // An anonymous visitor in the shell is always on a public view — a shared artifact
+  // (its own PublicViewer) or a public profile (PublicFrame) — so drop the app rail
+  // entirely and let the page's own chrome-light frame be the whole render (the viral
+  // view; the render is the hero). Every non-public route redirects an anon to /login
+  // via the routes' beforeLoad guards, so `me` is the signal. During the session's load
+  // window defer to the boot hint, so a returning user keeps the rail (and an anon keeps
+  // chrome-light) instead of popping when me() resolves.
   const pathname = useRouterState({ select: (s) => s.location.pathname })
-  const bareArtifact = !me && pathname.startsWith("/artifacts/")
+  const bare = !me && !(loading && authedHint)
 
   // ⌘K / Ctrl+K opens the command palette from anywhere. "/" (outside inputs)
   // focuses the page's primary SearchField when one is registered
@@ -162,21 +168,22 @@ export function AppShell({ children }: { children: ReactNode }) {
   }
 
   // No full-screen hold: the known chrome renders immediately (the __root
-  // AppFrame hydration gate covers the pre-hydration frame with AppBoot). The
+  // AppFrame hydration gate covers the pre-hydration frame with BootShell). The
   // rail's identity/nav atoms skeleton in during the me()/summary latency (see
   // NavRail's 3-state); a signed-out user on an auth-only route is bounced by the
-  // route beforeLoad guards before this renders. `bareArtifact` keeps a
-  // pending/anon `me` on the chrome-light artifact view — the rail enhances in
-  // only once `me` resolves truthy (in-app navs have it cached, so no shift).
+  // route beforeLoad guards before this renders. During the load window `bare` (above)
+  // defers to the boot hint, so a returning user keeps the rail rather than flashing
+  // the anon chrome-light view (in-app navs have `me` cached, so no shift either way).
 
   // Note: profile setup isn't gated *inside* the shell — the onboarding effect
   // above redirects a new user to the dedicated /welcome step (handle + role +
   // connect-your-tools) instead, so the shell only ever renders for onboarded or
   // skipped users.
 
-  // Chrome-light shell for an anon shared artifact: no rail, no mobile top bar —
-  // the PublicViewer owns its own header/footer and the render fills the frame.
-  if (bareArtifact)
+  // Chrome-light shell for any anon public view: no rail, no mobile top bar — the
+  // page's own frame (PublicViewer for an artifact, PublicFrame for a profile) owns
+  // the header/footer and the render fills the frame.
+  if (bare)
     return (
       <ShellCtx.Provider value={value}>
         <TooltipProvider>

--- a/apps/web/src/components/chrome/boot-shell.tsx
+++ b/apps/web/src/components/chrome/boot-shell.tsx
@@ -1,0 +1,49 @@
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { AppBoot } from "../shared/app-boot"
+import { RailSkeleton } from "./nav-rail"
+import { ShellCtx, type ShellValue } from "./shell-context"
+
+// The chrome actions a static silhouette never fires — a no-op ShellValue so
+// RailSkeleton's RailHeader can call useShell() without mounting the real AppShell.
+const NOOP_SHELL: ShellValue = {
+  paletteOpen: false,
+  setPaletteOpen: () => {},
+  switchWorkspace: () => {},
+  createWorkspace: () => Promise.resolve(),
+  deleteWorkspace: () => {},
+}
+
+// The pre-hydration boot frame: what the SPA prerender bakes into the static shell
+// and what __root's hydration gate shows on the first client paint. It renders the
+// SAME sidebar frame (RailSkeleton inside the real SidebarProvider + inset) that
+// AppShell settles into a tick later, so the rail silhouette is continuous across
+// hydration — no centered-logo → app-layout jump. Pure by construction: the providers
+// read no browser state (SidebarProvider's cookie write is removed; useIsMobile is
+// SSR-safe), so it prerenders and hydrates identically. RailSkeleton is already in the
+// eager bundle (AppShell → NavRail), so reusing it here adds nothing and can't drift.
+//
+// Both frames sit in the DOM; the pre-paint boot script (see __root) sets data-boot on
+// <html> from the entry path and CSS (globals.css) reveals exactly one — the rail for
+// app routes, the neutral mark for chromeless / bare-artifact entries, where AppShell's
+// own first paint is chrome-light. Rendering the same DOM regardless of path is what
+// keeps hydration clean; the attribute only drives which one is visible.
+export function BootShell() {
+  return (
+    <>
+      <div data-slot="boot-rail" className="contents">
+        <ShellCtx.Provider value={NOOP_SHELL}>
+          <TooltipProvider>
+            <SidebarProvider className="isolate h-full min-h-0">
+              <RailSkeleton />
+              <SidebarInset className="min-h-0 min-w-0 overflow-hidden" />
+            </SidebarProvider>
+          </TooltipProvider>
+        </ShellCtx.Provider>
+      </div>
+      <div data-slot="boot-mark" className="h-full">
+        <AppBoot />
+      </div>
+    </>
+  )
+}

--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -4,7 +4,6 @@ import { useState } from "react"
 import { api } from "@/api"
 import { Icon, type IconName } from "@/components/icons"
 import { Logo } from "@/components/shared/logo"
-import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Kbd } from "@/components/ui/kbd"
 import {
@@ -26,7 +25,6 @@ import {
   SidebarMenuSubButton,
   SidebarMenuSubItem,
   SidebarTrigger,
-  useIconRail,
   useSidebar,
 } from "@/components/ui/sidebar"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -149,6 +147,11 @@ function RailHeader({ showSearch }: { showSearch: boolean }) {
       <div className="flex items-center gap-1 group-data-[collapsible=icon]:flex-col">
         <Link
           to="/"
+          // The prerendered SPA shell bakes this rail (via BootShell) at "/", so the
+          // brand link is baked active; a cold load at any other route hydrates it
+          // inactive. The diff is visually inert (the brand carries no active styling),
+          // so suppress it — the route-agnostic boot frame hydrates without a warning.
+          suppressHydrationWarning
           onClick={() => setOpenMobile(false)}
           aria-label="Derive — home"
           className="flex h-8 min-w-0 flex-1 items-center gap-2.5 rounded-md px-1.5 text-foreground outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring group-data-[collapsible=icon]:w-8 group-data-[collapsible=icon]:flex-none group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0"
@@ -223,8 +226,9 @@ const RAIL_SKELETON_COLLECTIONS = [
 // never guesses anon-vs-authed and flashes the wrong one. The real Sidebar +
 // RailHeader (both data-free) render exactly, with silhouette rows for the nav +
 // collections and a skeleton pod at the foot. In-app navs have `me` cached, so
-// this only ever appears on a genuine cold load.
-function RailSkeleton() {
+// this only ever appears on a genuine cold load. Exported so BootShell can render
+// the identical silhouette in the pre-hydration frame (see chrome/boot-shell).
+export function RailSkeleton() {
   return (
     <Sidebar collapsible="icon" variant="inset">
       <RailHeader showSearch />
@@ -309,9 +313,6 @@ export function NavRail() {
   const onContexts = loc.pathname.startsWith("/contexts")
   const onSettings = loc.pathname.startsWith("/settings")
   const tags = summary?.tags ?? []
-  // The icon strip shows only glyph rows; content that has no icon form (the
-  // collections/tags lists, the anon conversion card) hides behind this.
-  const iconMode = useIconRail()
 
   // Picking a destination on mobile closes the drawer (no-op on desktop).
   const closeMobile = () => setOpenMobile(false)
@@ -361,84 +362,6 @@ export function NavRail() {
   // Session still resolving → the neutral rail silhouette, so we never flash the
   // anon rail before an authed user's data lands (in-app navs have `me` cached).
   if (loading) return <RailSkeleton />
-
-  // Anonymous visitor on a shared public artifact. There's no workspace to
-  // navigate, so the rail becomes the conversion surface — a single path to
-  // making their own (Figma/Notion-style viral loop). The artifact itself stays
-  // fully view-only; this is the only nav an anon ever sees.
-  if (!me)
-    return (
-      <Sidebar collapsible="icon" variant="inset">
-        <RailHeader showSearch={false} />
-        <SidebarContent>
-          {iconMode ? (
-            <SidebarGroup>
-              <SidebarGroupContent>
-                <SidebarMenu>
-                  <SidebarMenuItem>
-                    <SidebarMenuButton asChild tooltip="Sign up for Derive">
-                      {/* The rail's rows mute their icons; this one is the
-                          conversion moment, so it keeps the brand ink. */}
-                      <Link
-                        to="/login"
-                        search={{ signup: true }}
-                        aria-label="Sign up for Derive"
-                        data-testid="anon-signup"
-                        className="text-primary [&_svg]:text-primary"
-                      >
-                        <Icon name="plus" />
-                        <span>Sign up free</span>
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                </SidebarMenu>
-              </SidebarGroupContent>
-            </SidebarGroup>
-          ) : (
-            <SidebarGroup>
-              <SidebarGroupContent className="flex flex-col gap-3">
-                {/* The one card in the rail — a conversion moment that must lift off
-                    the flush canvas; its headline is a voice moment (Geist). */}
-                <div className="rounded-xl border border-border bg-card p-3.5">
-                  <div className="flex items-center gap-2">
-                    <Logo size={22} />
-                    <span className="font-serif text-base font-medium tracking-tight text-foreground">
-                      Create your own
-                    </span>
-                  </div>
-                  <p className="mt-2 text-pretty text-sm text-muted-foreground">
-                    Give your AI artifacts a permanent home: versions, comments, and one link to
-                    share.
-                  </p>
-                  <Button
-                    asChild
-                    variant="default"
-                    size="sm"
-                    className="mt-3 w-full"
-                    data-testid="anon-signup"
-                  >
-                    <Link to="/login" search={{ signup: true }} onClick={closeMobile}>
-                      Sign up free
-                    </Link>
-                  </Button>
-                </div>
-                <p className="px-1 text-sm text-muted-foreground">
-                  Already have an account?{" "}
-                  <Link
-                    to="/login"
-                    onClick={closeMobile}
-                    data-testid="anon-login"
-                    className="font-medium text-primary hover:underline"
-                  >
-                    Log in
-                  </Link>
-                </p>
-              </SidebarGroupContent>
-            </SidebarGroup>
-          )}
-        </SidebarContent>
-      </Sidebar>
-    )
 
   return (
     <Sidebar collapsible="icon" variant="inset">

--- a/apps/web/src/components/shared/public-frame.tsx
+++ b/apps/web/src/components/shared/public-frame.tsx
@@ -1,0 +1,59 @@
+import { Link } from "@tanstack/react-router"
+import type { ReactNode } from "react"
+import { Logo } from "@/components/shared/logo"
+import { Button } from "@/components/ui/button"
+
+// The chrome-light frame for a public surface an anonymous visitor lands on — a
+// shared profile today (the artifact viewer has its own richer PublicViewer). A slim
+// brand header (→ home) + the growth verbs, the content as the hero, and a quiet
+// "Made with Derive" footer: the same public-shell language as PublicViewer, minus the
+// artifact-specific identity/presence. Replaces the old anon nav rail — an anon never
+// sees app chrome now, just this frame around the render. `returnTo` sends Sign in
+// back here afterward.
+export function PublicFrame({ returnTo, children }: { returnTo: string; children: ReactNode }) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col bg-background">
+      {/* The slim public header — brand · the verbs. */}
+      <header className="flex shrink-0 items-center gap-3 border-b border-border px-4 py-2.5 max-sm:px-3">
+        <Link
+          to="/"
+          aria-label="Derive home"
+          className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md text-foreground outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+        >
+          <Logo size={20} />
+          <span className="font-serif text-base font-medium tracking-tight">Derive</span>
+        </Link>
+
+        {/* The growth verb (the page's one filled primary) + a quiet sign-in. */}
+        <Button asChild variant="default" size="sm" data-testid="public-make-your-own">
+          <Link to="/login" search={{ signup: true, return_to: "/new" }}>
+            Make your own
+          </Link>
+        </Button>
+        <Button
+          asChild
+          variant="ghost"
+          size="sm"
+          data-testid="public-sign-in"
+          className="max-sm:sr-only"
+        >
+          <Link to="/login" search={{ return_to: returnTo }}>
+            Sign in
+          </Link>
+        </Button>
+      </header>
+
+      {/* The render is the hero — it owns the rest of the height. overflow-hidden here
+          mirrors the shell's SidebarInset contract, so the page's own scroll container
+          (PageShell) behaves identically to when it renders inside the app rail. */}
+      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">{children}</div>
+
+      {/* A quiet, permanent brand mark (the "Made in Framer" idiom — attribution + a
+          soft nudge, never a wall). */}
+      <footer className="flex shrink-0 items-center justify-center gap-1.5 border-t border-border-soft py-1.5 font-mono text-2xs text-muted-foreground">
+        <Logo size={12} />
+        Made with Derive
+      </footer>
+    </div>
+  )
+}

--- a/apps/web/src/ctx.tsx
+++ b/apps/web/src/ctx.tsx
@@ -2,6 +2,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { ThemeProvider as NextThemesProvider, useTheme as useNextTheme } from "next-themes"
 import { createContext, type ReactNode, useContext, useEffect, useState } from "react"
 import type { Me } from "./api"
+import { writeAuthHint } from "./lib/auth-hint"
 import { type CursorPref, defaultPrefFor, normalizePref } from "./lib/cursors"
 import { meQuery } from "./lib/queries"
 import { STORAGE_KEYS } from "./lib/storage-keys"
@@ -34,6 +35,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     qc.cancelQueries({ queryKey: meQuery().queryKey })
     qc.setQueryData(meQuery().queryKey, m)
   }
+  // Mirror the resolved session into the per-browser boot hint — but never during the
+  // loading window (so a mid-load reload keeps the last known state). The pre-paint
+  // boot frame reads it to reserve the rail for a returning user and chrome-light for
+  // an anon, so neither pops on a cold load. UI-only; me() stays the authority.
+  useEffect(() => {
+    if (!loading) writeAuthHint(!!me)
+  }, [loading, me])
   return <AuthCtx.Provider value={{ me, loading, setMe }}>{children}</AuthCtx.Provider>
 }
 

--- a/apps/web/src/lib/auth-hint.ts
+++ b/apps/web/src/lib/auth-hint.ts
@@ -1,0 +1,23 @@
+import { STORAGE_KEYS } from "./storage-keys"
+
+// A per-browser, NON-authoritative hint of whether the last resolved session was
+// signed in. The server + the me() query are the only real authority; this steers
+// ONLY the pre-paint boot frame (rail vs chrome-light) so a returning user's cold
+// load reserves the right shape and doesn't pop when me() resolves. Stale at worst
+// (a since-expired session) → one self-correcting frame, never an access decision.
+export const readAuthHint = (): boolean => {
+  try {
+    return localStorage.getItem(STORAGE_KEYS.authed) === "1"
+  } catch {
+    return false
+  }
+}
+
+export const writeAuthHint = (authed: boolean): void => {
+  try {
+    if (authed) localStorage.setItem(STORAGE_KEYS.authed, "1")
+    else localStorage.removeItem(STORAGE_KEYS.authed)
+  } catch {
+    /* private mode / storage full — the hint just won't persist; boot falls back to bare */
+  }
+}

--- a/apps/web/src/lib/chrome-routes.ts
+++ b/apps/web/src/lib/chrome-routes.ts
@@ -1,0 +1,12 @@
+// The routes that render without the app chrome (no nav rail): the auth /
+// onboarding flows and the design canvas. One source of truth, read by AppFrame
+// (post-hydration, to pick Outlet vs AppShell) AND inlined by __root's pre-paint
+// boot script — so the static boot frame and the real frame agree on which entries
+// get a rail. The boot script additionally treats a public artifact permalink
+// (/artifacts/*) as "bare": AppShell renders it chrome-light until a session
+// resolves, so a rail silhouette there would only flash away.
+export const CHROMELESS_EXACT: string[] = ["/login", "/reset-password", "/welcome", "/showcase"]
+export const CHROMELESS_PREFIX: string[] = ["/invite/"]
+
+export const isChromelessPath = (p: string): boolean =>
+  CHROMELESS_EXACT.includes(p) || CHROMELESS_PREFIX.some((prefix) => p.startsWith(prefix))

--- a/apps/web/src/lib/storage-keys.ts
+++ b/apps/web/src/lib/storage-keys.ts
@@ -7,6 +7,10 @@ export const STORAGE_KEYS = {
   cursorPref: "derive.cursor.pref",
   commentsPanel: "derive.comments.panel",
   navCollapsed: "derive.nav.collapsed",
+  // A per-browser, NON-authoritative hint of the last resolved session's signed-in
+  // state — steers only the pre-paint boot frame (rail vs chrome-light) so a returning
+  // user's cold load doesn't pop. Never an access decision (see lib/auth-hint).
+  authed: "derive.authed",
   // Agent pushes auto-open in this tab (absent = on). Per-device on purpose:
   // yanking navigation is fine on your own laptop, hostile on a shared screen.
   autoOpen: "derive.autoopen",

--- a/apps/web/src/pages/profile/index.tsx
+++ b/apps/web/src/pages/profile/index.tsx
@@ -8,6 +8,7 @@ import { CardGrid } from "@/components/shared/card-grid"
 import { EmptyState } from "@/components/shared/empty-state"
 import { FollowButton } from "@/components/shared/follow-button"
 import { PageShell } from "@/components/shared/page-shell"
+import { PublicFrame } from "@/components/shared/public-frame"
 import { SectionEyebrow } from "@/components/shared/section-eyebrow"
 import { Spinner } from "@/components/shared/spinner"
 import { StatusPanel } from "@/components/shared/status-panel"
@@ -24,6 +25,16 @@ import { ProfileWorkCard, ProfileWorkRow } from "./work-card"
 
 const route = getRouteApi("/users/$handle")
 
+// A signed-in viewer sees the profile inside the app shell (rail); an anonymous visitor
+// gets it chrome-light in the public frame — shareable without a session, the same
+// treatment as a public artifact, minus the app rail (which an anon no longer sees).
+export function Profile() {
+  const { handle } = route.useParams()
+  const { me } = useAuth()
+  const inner = <ProfileInner handle={handle} />
+  return me ? inner : <PublicFrame returnTo={`/users/${handle}`}>{inner}</PublicFrame>
+}
+
 // A profile. For a teammate (shared workspace) or yourself: the identity header
 // (avatar, name, @handle, role, bio, GitHub link), a work count, Follow, and the
 // person's work the viewer can see. For anyone else it's the identity card alone —
@@ -31,8 +42,7 @@ const route = getRouteApi("/users/$handle")
 // launch. Header-first: the identity is preloaded in the route loader, so it
 // paints with real data on the first frame; only the work grid carries its own
 // load state.
-export function Profile() {
-  const { handle } = route.useParams()
+function ProfileInner({ handle }: { handle: string }) {
   const { me, setMe } = useAuth()
   const nav = useNavigate()
   const [editing, setEditing] = useState(false)

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -19,10 +19,11 @@ export function getRouter() {
     // Debounce intent so a pointer brushing past a link doesn't fire the loader;
     // ~65ms is below the time it takes to settle on a target you actually want.
     defaultPreloadDelay: 65,
-    // Cross-fade route changes. The rail/top bar are mounted once above the
-    // Outlet, so only the content visibly morphs. No-ops where the View
-    // Transitions API is unavailable.
-    defaultViewTransition: true,
+    // View transitions are deliberately OFF. With intent-preloading + shape-matched
+    // skeletons most navs already swap cleanly, but a global cross-fade dissolves the
+    // outgoing page THROUGH the pending skeleton on any cold nav — which reads as a
+    // flash. Opt a specific navigation in per-link (viewTransition) if it ever earns
+    // a deliberate transition.
     // Perceived-perf: hold the current page for delayMs before showing the pending
     // frame (most cache-warm navs resolve first, so nothing flashes), and once shown
     // keep it at least minShownMs so a just-too-slow load doesn't strobe. The same

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -10,9 +10,10 @@ import {
 import { type ReactNode, useEffect, useState } from "react"
 import { AgentPushListener } from "../components/chrome/agent-push"
 import { AppShell } from "../components/chrome/app-shell"
-import { AppBoot } from "../components/shared/app-boot"
+import { BootShell } from "../components/chrome/boot-shell"
 import { Toaster } from "../components/ui/sonner"
 import { AuthProvider, CursorPrefProvider, ThemeProvider } from "../ctx"
+import { CHROMELESS_EXACT, CHROMELESS_PREFIX, isChromelessPath } from "../lib/chrome-routes"
 import { queryClient } from "../lib/query-client"
 import { STORAGE_KEYS } from "../lib/storage-keys"
 import { reportWebVitals } from "../lib/vitals"
@@ -27,6 +28,19 @@ import "@/styles/globals.css"
 const THEME_BOOT = `(function(){try{var t=localStorage.getItem(${JSON.stringify(
   STORAGE_KEYS.theme,
 )});if(t!=="light"&&t!=="dark")t="dark";var e=document.documentElement;e.classList.remove("light","dark");e.classList.add(t)}catch(e){}})()`
+
+// Pre-paint sibling to THEME_BOOT: tag <html> with which boot frame to reserve —
+// before the shell paints — from the persisted auth hint AND the entry path. A
+// returning signed-in user (hint set) on an app route gets the rail silhouette;
+// everyone else (an anon, or a chromeless auth/onboarding route) gets the neutral
+// mark. globals.css keys the two off data-boot; BootShell renders both. Inlined as a
+// string so it runs before any module loads — kept in lockstep via the shared route
+// lists + STORAGE_KEYS. A stale hint (since-expired session) self-corrects next load.
+const BOOT_FRAME = `(function(){try{var p=location.pathname;var authed=localStorage.getItem(${JSON.stringify(
+  STORAGE_KEYS.authed,
+)})==="1";var e=${JSON.stringify(CHROMELESS_EXACT)};var f=${JSON.stringify(
+  CHROMELESS_PREFIX,
+)};var b=!authed||e.indexOf(p)>=0||f.some(function(x){return p.indexOf(x)===0});document.documentElement.setAttribute("data-boot",b?"bare":"rail")}catch(_){}})()`
 
 export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()({
   head: () => ({
@@ -90,27 +104,21 @@ function RootComponent() {
 // mounted once here, so navigating between pages morphs only the content — the
 // rail never remounts. /login is the one chrome-less route.
 function AppFrame() {
-  // Hydration gate. Until the client has mounted, render the neutral AppBoot — the
-  // SAME thing the SPA prerender bakes into the static shell — so the first client
-  // paint matches the prerendered HTML exactly (clean hydration, no flash). One
-  // tick later the route-correct chrome renders, INSTANTLY, not gated on the me()
-  // query (identity atoms skeleton in during its latency). This is a one-time
-  // cold-boot frame: in-app navs keep the chrome mounted and never see it again.
+  // Hydration gate. AppShell reads browser-only state (matchMedia, the persisted rail
+  // width), so it can't render identically on the prerendered static shell; until the
+  // client mounts we show BootShell — the SAME shell silhouette the SPA prerender bakes
+  // in — so the first client paint matches the static HTML (clean hydration) AND the
+  // rail is already in place, so the swap to real chrome a tick later is seamless (no
+  // centered-logo → app-layout jump). One-time: in-app navs keep the chrome mounted and
+  // never see it again.
   const [hydrated, setHydrated] = useState(false)
   useEffect(() => setHydrated(true), [])
 
-  // /login, /reset-password, and /welcome (first-run onboarding) render chrome-less — no
-  // rail/top bar. /showcase is the design canvas and renders chrome-less too.
-  const chromeless = useRouterState({
-    select: (s) =>
-      s.location.pathname === "/login" ||
-      s.location.pathname === "/reset-password" ||
-      s.location.pathname === "/welcome" ||
-      s.location.pathname === "/showcase" ||
-      s.location.pathname.startsWith("/invite/"),
-  })
+  // /login, /reset-password, /welcome (onboarding), /showcase, /invite/* render
+  // chrome-less — no rail. The one list, shared with the boot script (lib/chrome-routes).
+  const chromeless = useRouterState({ select: (s) => isChromelessPath(s.location.pathname) })
 
-  if (!hydrated) return <AppBoot />
+  if (!hydrated) return <BootShell />
   return chromeless ? (
     <Outlet />
   ) : (
@@ -128,6 +136,10 @@ function RootDocument({ children }: { children: ReactNode }) {
         <script
           // biome-ignore lint/security/noDangerouslySetInnerHtml: static boot string built from a constant storage key, no user input.
           dangerouslySetInnerHTML={{ __html: THEME_BOOT }}
+        />
+        <script
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: static boot string built from constant route lists, no user input.
+          dangerouslySetInnerHTML={{ __html: BOOT_FRAME }}
         />
         <HeadContent />
       </head>

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -340,6 +340,25 @@
   }
 }
 
+/* ── Boot frame ─────────────────────────────────────────────────────────────
+   __root's pre-paint BOOT_FRAME script sets data-boot on <html> from the entry path
+   so the static shell reserves the frame AppShell settles into — before hydration, no
+   layout jump. BootShell renders both frames; these rules reveal one. Rail silhouette
+   for app routes (default); the neutral brand mark for chromeless / bare-artifact
+   entries, where AppShell's own first paint is chrome-light. In @layer utilities so
+   the toggle outranks the boot-rail wrapper's `contents` utility. */
+@layer utilities {
+  [data-slot="boot-mark"] {
+    display: none;
+  }
+  [data-boot="bare"] [data-slot="boot-rail"] {
+    display: none;
+  }
+  [data-boot="bare"] [data-slot="boot-mark"] {
+    display: block;
+  }
+}
+
 /* A peer's click ripple on the live-cursor overlay (see cursor-layer.tsx RippleDot). */
 @keyframes derive-cursor-ripple {
   from {


### PR DESCRIPTION
## What & why

The app had visible "flashes" on cold load. Diagnosed as four stacked mechanisms; this fixes the two pervasive ones at the source and removes the anonymous conversion sidebar.

## Changes

**Boot frame (the big one).** The hydration gate painted a centered-logo `AppBoot`, then swapped to a completely different rail+content layout — a hard jump on every cold load. `BootShell` now bakes the *real* shell silhouette (reusing the existing `RailSkeleton`) into the SPA prerender, so boot → chrome is continuous. A pre-paint script + a persisted, UI-only **auth hint** reserve the right frame — the rail for a returning user, chrome-light for an anon — so the frame never pops when `me()` resolves.

**View transitions.** Dropped the global `defaultViewTransition` — it cross-faded every navigation *through* the pending skeleton, which reads as a flash. Shape-matched skeletons swap cleanly instead.

**Anon chrome.** Removed the "Create your own" nav rail. An anonymous visitor now gets the chrome-light `PublicFrame` (brand + growth verbs) on a public profile — matching the artifact `PublicViewer` — with no app rail. `app-shell`'s `bareArtifact` generalizes to a `bare` (any anon) check, hint-guarded during the session's load window.

## Verification

- typecheck, biome, all custom lints (tokens / frontend / testids / boundaries / deadcode) ✅
- build + SPA prerender ✅ (confirmed the rail silhouette bakes into `_shell.html`)
- e2e: smoke **10/10**, anon deep (visibility / collection-visibility / presence) **6/6**, plus a new `anon-profile.deep.spec.ts` **1/1**

## Measured (prod build, median of 3, cold cache)

| Surface | Network | LCP | FCP | CLS |
|---|---|---|---|---|
| anon artifact share | local | 360ms | 32ms | **0** |
| anon artifact share | Slow-4G +4×CPU | 2996ms | 884ms | **0** |
| anon profile share | local | 360ms | 28ms | **0** |
| anon profile share | Slow-4G +4×CPU | 2472ms | 728ms | **0** |
| returning authed `/` | local | 364ms | 32ms | **0** |
| returning authed `/` | Slow-4G +4×CPU | 2856ms | 744ms | **0** |

**CLS = 0 everywhere** — the jank this change targets is measured at zero. FCP is fast (static prerendered shell); LCP is instant locally and 2.5–3.0s only on a deliberately punishing Slow-4G profile.

## Notes

- Deliberately left as-is: the 150/300 ms pending floor (anti-strobe) and shape-matched skeletons — already well-tuned.
- SSR/streaming was evaluated and judged a poor trade for this architecture (self-hostable single-container + separate Hono API + SEO already server-solved). The `CLS = 0` / fast-FCP numbers confirm it would be solving a problem that's already solved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
