### PR TITLE
fix(web): show a loading cue on filter/tab transitions, not stale data

### DIFF
--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -37,11 +37,13 @@ export function CommandPalette() {
   const [results, setResults] = useState<Artifact[]>([])
   const [people, setPeople] = useState<PublicProfile[]>([])
   const [loading, setLoading] = useState(false)
+  const [peopleLoading, setPeopleLoading] = useState(false)
 
   // Fresh query each open.
   useEffect(() => {
     if (paletteOpen) {
       setQuery("")
+      setResults([])
       setPeople([])
     }
   }, [paletteOpen])
@@ -71,14 +73,17 @@ export function CommandPalette() {
     const term = query.trim()
     if (!term) {
       setPeople([])
+      setPeopleLoading(false)
       return
     }
     let alive = true
+    setPeopleLoading(true)
     const t = setTimeout(() => {
       api
         .searchPeople(term)
         .then((r) => alive && setPeople(r.users))
         .catch(() => alive && setPeople([]))
+        .finally(() => alive && setPeopleLoading(false))
     }, 180)
     return () => {
       alive = false
@@ -176,7 +181,7 @@ export function CommandPalette() {
           {people.length > 0 && (
             <CommandGroup
               heading="People"
-              className={cn(loading && "opacity-60 transition-opacity")}
+              className={cn(peopleLoading && "opacity-60 transition-opacity")}
             >
               {people.map((u) => (
                 <CommandItem

--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -17,6 +17,7 @@ import { colorForName } from "@/lib/avatar-tints"
 import { getInitials } from "@/lib/initials"
 import { collectionsQuery, workspacesQuery } from "@/lib/queries"
 import { usePrefetchArtifact } from "@/lib/use-prefetch-artifact"
+import { cn } from "@/lib/utils"
 import { refFor } from "@/pages/artifact/parse-ref"
 import { useShell } from "./shell-context"
 
@@ -147,7 +148,11 @@ export function CommandPalette() {
           )}
 
           {results.length > 0 && (
-            <CommandGroup heading="Artifacts">
+            // Dim while a new search is in flight — the prior matches are stale, not the answer.
+            <CommandGroup
+              heading="Artifacts"
+              className={cn(loading && "opacity-60 transition-opacity")}
+            >
               {results.map((a) => (
                 <CommandItem
                   key={a.short_id}
@@ -169,7 +174,10 @@ export function CommandPalette() {
           )}
 
           {people.length > 0 && (
-            <CommandGroup heading="People">
+            <CommandGroup
+              heading="People"
+              className={cn(loading && "opacity-60 transition-opacity")}
+            >
               {people.map((u) => (
                 <CommandItem
                   key={u.username}

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -129,6 +129,10 @@ function LibraryBody({ view }: { view: LibraryView }) {
   }
   const { query: feed, items, listQuery, toggleFavorite, deleteArtifact } = useLibraryFeed(params)
   const { isPending, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } = feed
+  // keepPreviousData holds the OLD grid while a new filter/tab/search loads, and `isPending`
+  // is false then — so without this the previous (wrong) grid shows with no cue. Dim it during
+  // the transition (mirrors people.tsx), so switching to e.g. "Created by me" reads as loading.
+  const transitioning = feed.isPlaceholderData
   // Hold the skeleton back ~150 ms so a cache-warm / fast first load flashes nothing
   // (keepPreviousData already keeps the current grid across filter changes).
   const showSkeleton = useDelayedPending(isPending)
@@ -470,24 +474,26 @@ function LibraryBody({ view }: { view: LibraryView }) {
           <EmptyState {...emptyProps} />
         )
       ) : isSyncedCollection ? (
-        <SyncedCollection
-          items={recencyItems}
-          showFolders={showFolders}
-          onToggle={setShowFolders}
-          hasNextPage={!!hasNextPage}
-          isFetchingNextPage={isFetchingNextPage}
-          onLoadMore={() => fetchNextPage()}
-          onOpen={(a) => nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })}
-          onToggleFavorite={toggleFavorite}
-          onPickTag={(tag) => nav({ to: "/", search: { tag } })}
-          onPickAuthor={pickAuthor}
-          onEditTags={setPendingTags}
-          onAddToCollection={setPendingCollections}
-          onDelete={setPendingDelete}
-          onPrefetch={(a) => prefetch(a.short_id, a.current_version)}
-        />
+        <div className={cn(transitioning && "opacity-60 transition-opacity")}>
+          <SyncedCollection
+            items={recencyItems}
+            showFolders={showFolders}
+            onToggle={setShowFolders}
+            hasNextPage={!!hasNextPage}
+            isFetchingNextPage={isFetchingNextPage}
+            onLoadMore={() => fetchNextPage()}
+            onOpen={(a) => nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })}
+            onToggleFavorite={toggleFavorite}
+            onPickTag={(tag) => nav({ to: "/", search: { tag } })}
+            onPickAuthor={pickAuthor}
+            onEditTags={setPendingTags}
+            onAddToCollection={setPendingCollections}
+            onDelete={setPendingDelete}
+            onPrefetch={(a) => prefetch(a.short_id, a.current_version)}
+          />
+        </div>
       ) : (
-        <>
+        <div className={cn(transitioning && "opacity-60 transition-opacity")}>
           <ArtifactGrid
             items={items}
             scrollRef={scrollRef}
@@ -507,7 +513,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
               <Spinner />
             </div>
           )}
-        </>
+        </div>
       )}
 
       {shareCol && (


### PR DESCRIPTION
## What

Loading states that showed **stale data instead of a loading cue** on an in-place transition.

**Reported bug:** clicking the library's "Created by me" tab shows *all* artifacts until the filtered query resolves. The feed uses `placeholderData: keepPreviousData`, so `isPending` is `false` on a filter/tab/search change; the render gated the skeleton on `isPending` alone and fell through to the previous (wrong) grid — under a heading + active tab that had already flipped to "Created by me". A guard could verify the loading state *exists*; only driving it shows it renders at the wrong *time*.

## Fix

Mirror the pattern `people.tsx` already uses: read `isPlaceholderData` and **dim** the content (`opacity-60 transition-opacity`) while the new query loads, so a transition reads as loading rather than as the result.

- **Library** (`pages/library/index.tsx`) — dim both grid branches (main grid + synced-collection) during a transition. Chose dim over a skeleton because this surface also has search-as-you-type, where a skeleton would strobe.
- **Command palette** (`components/chrome/command-palette.tsx`) — dim the artifact/people result groups while a search is in flight (they previously held the prior matches with a loading cue only in the empty state).

## Audit (checked all)

A one-reviewer app-wide loading-behaviour sweep confirmed the library was the standout; **most surfaces are already correct** (people / profile — its loader `await`s the prefetch / artifact page / context console / nav-rail / diff). Deliberately deferred as minor:

- Context `SessionThread` shows a bare centered spinner (honest, just not shape-matched) on a session switch.
- The webhook delivery-log first-open spinner (tiny lazy panel).
- Several settings sections gate on bare `isError` rather than `isError && !data`; **mitigated** — those queries don't poll, so the only nuke window is a failed post-mutation refetch.

Happy to fold any of those in if you'd like — flagging rather than gold-plating.

## Verification

typecheck 0 · biome · 126 unit tests · guards green (surfaces / mutations / testids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
