### PR TITLE
chore(db): drop the dead v1 access schema — visibility, general_role, acl

### DIFF
--- a/apps/api/scripts/apply-pg-schema.ts
+++ b/apps/api/scripts/apply-pg-schema.ts
@@ -40,17 +40,10 @@ const url = u.toString()
 const store = await PgMetaStore.create(url, (e) => console.error("pool error:", e.message))
 console.log("app schema applied")
 
-// The one-time data migration the Node tier runs on boot but the Workers entry never
-// gets a chance to (it applies no schema at runtime — see PgMetaStore.fromPool), so
-// migrations run wherever schema does. backfillAccess maps the pre-v2 `visibility`
-// onto workspace_access/link_role/listed — without it every org/public artifact would
-// sit at the fail-closed `none` default (invite-only) after the ADD COLUMN. It's
-// idempotent (consumes `visibility`, so re-runs no-op) and self-contained (folds in
-// the pre-collapse vocabulary itself). Must run AFTER the DDL above (it touches the new
-// columns); deploy:pg runs this step just before the Worker deploy, which keeps the
-// brief "visibility consumed, old Worker still live" window to the deploy duration.
-await store.backfillAccess()
-console.log("access backfill applied")
+// (The one-time pre-v2 access backfill used to run here, after the DDL. Retired
+// with the v1 `visibility`/`general_role` columns — an instance upgrading straight
+// from a pre-v2 build runs deploy/drop-v1-access.sql instead, which folds the old
+// values into the access fields before dropping them.)
 
 // Better Auth schema: derived from the live auth config (the single source of
 // truth), reconciled by Better Auth's own migrator. baseUrl/secret are dummies —

--- a/apps/api/src/lib/http.ts
+++ b/apps/api/src/lib/http.ts
@@ -1,4 +1,4 @@
-import type { LinkRole, Listed, Role, Visibility, WorkspaceAccess } from "@derive/core"
+import type { LinkRole, Listed, Role, WorkspaceAccess } from "@derive/core"
 import type { Context } from "hono"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
 import type { z } from "zod"
@@ -127,6 +127,11 @@ export const anonName = (seed: string): string => {
 }
 
 export const VISIBILITIES = ["public", "org", "private"] as const
+
+/** Pre-v2 wire vocabulary, still accepted on the publish/access params below
+ *  (legacyAccessOf) so old clients keep working. Purely a request-body dialect —
+ *  the v1 DB columns it once named are gone. */
+type Visibility = (typeof VISIBILITIES)[number]
 
 /** Pre-collapse visibility vocabulary, mapped so old clients (a pinned CLI, a
  *  self-hosted stdio MCP, saved derive.json files) keep publishing without an

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -181,16 +181,10 @@ if (defaultOrg !== "local") {
   }
 }
 
-// One-time backfill of the v2 access model (see docs/plans/access-model.md): maps
-// the pre-v2 `visibility` onto the three single-purpose fields — org/public gain
-// workspace_access=member + their listing, a public row's live link is restored at
-// its legacy general_role. Self-contained: it folds the pre-3-value vocabulary
-// (link/password → public, unlisted → private) into its own CASE, so there's no
-// separate collapse pass to sequence. It CONSUMES visibility (resets it to 'private')
-// so the `WHERE visibility != 'private'` guard makes re-runs a no-op and setAccess
-// (which never writes visibility) is never re-clobbered. The hosted deploy applies
-// the same call after DDL (apply-pg-schema.ts) — migrations run wherever schema does.
-await meta.backfillAccess()
+// (The one-time pre-v2 → v2 access backfill used to run here. Retired with the
+// v1 `visibility`/`general_role` columns — a database upgrading straight from a
+// pre-v2 build runs deploy/drop-v1-access.sql, which folds the old values into
+// the access fields before dropping them.)
 
 // Blobs: S3/R2 when OBJECT_STORE_URL is set, else local disk (zero-config).
 const blobs: BlobStore = cfg.objectStoreUrl

--- a/apps/api/test/previews.test.ts
+++ b/apps/api/test/previews.test.ts
@@ -46,7 +46,6 @@ type FakeArtifact = NewArtifact & {
   author_gh_id: string | null
   author_id: string | null
   password_hash: string | null
-  general_role: "viewer"
 }
 
 type FakeVersion = {
@@ -101,7 +100,6 @@ const makeFakes = (): FakeMeta => {
         author_gh_id: null,
         author_id: null,
         password_hash: null,
-        general_role: "viewer" as const,
       }
       artifacts.set(a.id, rec)
       return rec
@@ -214,7 +212,6 @@ const seedArtifact = async (
     author_gh_id: null,
     author_id: null,
     password_hash: null,
-    general_role: "viewer",
   }
   fakes.artifacts.set(id, art)
 

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -13,8 +13,6 @@ CREATE TABLE IF NOT EXISTS artifact (
   link_role TEXT NOT NULL DEFAULT 'none',
   listed TEXT NOT NULL DEFAULT 'none',
   password_hash TEXT,
-  visibility TEXT NOT NULL DEFAULT 'private',
-  general_role TEXT NOT NULL DEFAULT 'viewer',
   kind TEXT NOT NULL,
   spa INTEGER NOT NULL DEFAULT 0,
   locked INTEGER NOT NULL DEFAULT 0,
@@ -460,13 +458,6 @@ CREATE TABLE IF NOT EXISTS principal (
     email TEXT,
     kind TEXT NOT NULL DEFAULT 'human',
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-  );
-
-CREATE TABLE IF NOT EXISTS acl (
-    artifact_id TEXT PRIMARY KEY REFERENCES artifact(id),
-    visibility TEXT NOT NULL,
-    password_hash TEXT,
-    org_gate TEXT
   );
 
 CREATE TABLE IF NOT EXISTS view (

--- a/deploy/drop-v1-access.sql
+++ b/deploy/drop-v1-access.sql
@@ -1,0 +1,26 @@
+-- One-shot removal of the retired v1 access schema. Run ONCE per existing
+-- database (new databases never create these). The boot DDL is additive-only
+-- (see scripts/check-schema.mjs), so this deliberate, separately-reviewed drop
+-- lives here instead of the schema sources.
+--
+--   self-host SQLite:  sqlite3 <data-dir>/derive.db < deploy/drop-v1-access.sql
+--   D1 (edge):         wrangler d1 execute <db> --remote --file=deploy/drop-v1-access.sql
+--   Postgres (hosted): psql "$DATABASE_URL" -f deploy/drop-v1-access.sql
+--
+-- Step 1 — safety net for an instance jumping straight from a pre-v2 build to a
+-- post-cleanup one: fold any never-backfilled v1 values into the v2 fields (the
+-- exact mapping the retired boot backfill applied; every instance that booted a
+-- v2 build has already run it, making this a no-op). Includes the pre-collapse
+-- vocabulary (link/password → public, unlisted → private).
+UPDATE artifact SET
+  workspace_access = CASE WHEN visibility IN ('org','public','link','password') THEN 'member' ELSE 'none' END,
+  listed = CASE WHEN visibility IN ('public','link','password') THEN 'public' WHEN visibility = 'org' THEN 'workspace' ELSE 'none' END,
+  link_role = CASE WHEN visibility IN ('public','link','password') THEN general_role ELSE 'none' END
+  WHERE visibility != 'private';
+
+-- Step 2 — drop the dead weight: the acl placeholder (zero query sites; its
+-- password_hash was never the live one — that's artifact.password_hash, untouched)
+-- and the two backfilled columns (read by nothing since the v2 access model).
+DROP TABLE IF EXISTS acl;
+ALTER TABLE artifact DROP COLUMN visibility;
+ALTER TABLE artifact DROP COLUMN general_role;

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -3,7 +3,7 @@ import type { LinkRole, Role, WorkspaceAccess } from "./roles"
 // The access vocabulary lives in ./roles (a leaf) so ./ports and this module can
 // both use it without forming an import cycle. Re-exported here so the long-standing
 // `@derive/core` surface stays unchanged (roles is not itself in the index barrel).
-export type { GeneralRole, LinkRole, Listed, Role, WorkspaceAccess } from "./roles"
+export type { LinkRole, Listed, Role, WorkspaceAccess } from "./roles"
 
 /** What an actor wants to do. Kept coarse on purpose; `can()` is the only gate. */
 export type Action = "read" | "comment" | "propose" | "publish" | "approve" | "share" | "manage"

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -2,12 +2,7 @@
  * Core owns the ports; packages/db and packages/storage provide the adapters.
  * Everything here must run on Node AND Cloudflare Workers — no Node APIs.
  */
-import type { GeneralRole, LinkRole, Listed, Role, WorkspaceAccess } from "./roles"
-
-/** @deprecated orphaned column vocabulary — the access model is `workspace_access`
- *  × `link_role` × `listed` (see access-model.md). Kept only to type the `visibility`
- *  DB column (backfilled once, read by nothing). */
-export type Visibility = "public" | "org" | "private"
+import type { LinkRole, Listed, Role, WorkspaceAccess } from "./roles"
 
 export interface BlobStore {
   /** Content-addressed put; returns the sha256 hex key. Idempotent. */
@@ -43,11 +38,6 @@ export interface ArtifactRecord {
   listed: Listed
   /** Salted hash of the unlock password locking the world link; null otherwise. */
   password_hash: string | null
-  /** @deprecated orphaned column, backfilled once into `workspace_access`+`listed`.
-   *  Kept only so this Record matches the drizzle table (parity.ts). Read by nothing. */
-  visibility: Visibility
-  /** @deprecated orphaned column, backfilled once into `link_role`. Read by nothing. */
-  general_role: GeneralRole
   kind: ArtifactKind
   spa: 0 | 1
   /** Locked: direct publishes are rejected; changes must go through a proposal. */
@@ -849,11 +839,6 @@ export interface ModerationStore {
    *  tables are absent). Pre-feature hand-published work without a GitHub identity has no
    *  recoverable author and is left null. */
   backfillAuthorIds(): Promise<number>
-  /** One-time boot backfill of the access model from the pre-v2 shape (`visibility`
-   *  + `general_role`) into `workspace_access` / `link_role` / `listed`. Idempotent:
-   *  it consumes `visibility` (resets it to the orphaned default), so a second run —
-   *  and every row created after — is a no-op. See docs/plans/access-model.md. */
-  backfillAccess(): Promise<void>
   createAuditLog(a: NewAuditLog): Promise<void>
   /** Moderation history, newest first. One workspace's, or — super-admin, orgId
    *  undefined — the whole instance's. Optionally narrowed to one artifact. */

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -33,8 +33,3 @@ export type WorkspaceAccess = "none" | "member"
  *  (nowhere), `workspace` (the workspace library), `public` (the public directory).
  *  Listing preconditions live at the write path, not here. */
 export type Listed = "none" | "workspace" | "public"
-
-/** @deprecated retired by the v2 access model; kept only to type the orphaned
- *  `general_role` DB column (expand/contract — the column stays, backfilled once
- *  into `link_role`, read by nothing). */
-export type GeneralRole = "viewer" | "commenter"

--- a/packages/db/src/ddl.ts
+++ b/packages/db/src/ddl.ts
@@ -113,12 +113,6 @@ export const placeholderTables = (iso: string): string[] => [
     kind TEXT NOT NULL DEFAULT 'human',
     created_at TEXT NOT NULL DEFAULT ${iso}
   )`,
-  `CREATE TABLE IF NOT EXISTS acl (
-    artifact_id TEXT PRIMARY KEY REFERENCES artifact(id),
-    visibility TEXT NOT NULL,
-    password_hash TEXT,
-    org_gate TEXT
-  )`,
   `CREATE TABLE IF NOT EXISTS view (
     id TEXT PRIMARY KEY,
     artifact_id TEXT NOT NULL REFERENCES artifact(id),

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -8,7 +8,6 @@ import type {
   DomainKind,
   DomainStatus,
   FollowKind,
-  GeneralRole,
   LinkRole,
   Listed,
   NotificationKind,
@@ -20,7 +19,6 @@ import type {
   Role,
   SessionMessageAuthor,
   SessionState,
-  Visibility,
   WebhookKind,
   WorkspaceAccess,
 } from "@derive/core"
@@ -45,9 +43,6 @@ export const artifact = pgTable("artifact", {
   link_role: text("link_role").$type<LinkRole>().notNull().default("none"),
   listed: text("listed").$type<Listed>().notNull().default("none"),
   password_hash: text("password_hash"),
-  // Orphaned, backfilled once into the fields above; read by nothing (mirrors schema.ts).
-  visibility: text("visibility").$type<Visibility>().notNull().default("private"),
-  general_role: text("general_role").$type<GeneralRole>().notNull().default("viewer"),
   kind: text("kind").$type<ArtifactKind>().notNull(),
   spa: integer("spa").$type<0 | 1>().notNull().default(0),
   locked: integer("locked").$type<0 | 1>().notNull().default(0),

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1842,24 +1842,6 @@ export class PgMetaStore implements MetaStore {
       return []
     }
   }
-  // One-time access backfill from the pre-v2 shape (see repos.ts backfillAccess for
-  // the idempotency argument — it consumes `visibility`, so it re-runs to a no-op).
-  // Self-sufficient: folds in the pre-collapse vocabulary (`link`/`password` → public,
-  // `unlisted` → private) so the hosted deploy path (apply-pg-schema.ts) maps correctly
-  // without node.ts's separate collapse. Errors propagate — the DDL runs first (the
-  // columns always exist), so a failure here is real and must fail the deploy loudly,
-  // not silently ship the Worker against un-backfilled data.
-  async backfillAccess(): Promise<void> {
-    await this.pool.query(
-      `UPDATE "artifact" SET
-         workspace_access = CASE WHEN visibility IN ('org','public','link','password') THEN 'member' ELSE 'none' END,
-         listed = CASE WHEN visibility IN ('public','link','password') THEN 'public' WHEN visibility = 'org' THEN 'workspace' ELSE 'none' END,
-         link_role = CASE WHEN visibility IN ('public','link','password') THEN general_role ELSE 'none' END,
-         visibility = 'private',
-         general_role = 'viewer'
-       WHERE visibility != 'private'`,
-    )
-  }
   // Idempotent backfill (see sqlite.ts) — stamp author_id from a known author_gh_id→user mapping.
   async backfillAuthorIds(): Promise<number> {
     try {

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -408,25 +408,6 @@ export function makeRepos(db: SqliteDb) {
       .run()
   }
 
-  // One-time boot backfill from the pre-v2 shape (visibility + general_role) into
-  // the access fields. Idempotent: it CONSUMES `visibility` (resets it to the
-  // orphaned default 'private'), and only touches rows where it's still non-default
-  // — so a second boot, and every row created after (born visibility='private'),
-  // is a no-op. setAccess never writes visibility, so a later access change is
-  // never re-clobbered. See docs/plans/access-model.md.
-  // Self-sufficient: it also folds in the pre-collapse vocabulary (`link`/`password`
-  // → public, `unlisted` → private) so it maps correctly on ANY caller — the hosted
-  // deploy path (apply-pg-schema.ts) runs it without node.ts's separate collapse.
-  const backfillAccess = async (): Promise<void> => {
-    await db.run(sql`UPDATE artifact SET
-      workspace_access = CASE WHEN visibility IN ('org','public','link','password') THEN 'member' ELSE 'none' END,
-      listed = CASE WHEN visibility IN ('public','link','password') THEN 'public' WHEN visibility = 'org' THEN 'workspace' ELSE 'none' END,
-      link_role = CASE WHEN visibility IN ('public','link','password') THEN general_role ELSE 'none' END,
-      visibility = 'private',
-      general_role = 'viewer'
-      WHERE visibility != 'private'`)
-  }
-
   const setLocked = async (artifactId: string, locked: 0 | 1): Promise<void> => {
     await db.update(artifact).set({ locked }).where(eq(artifact.id, artifactId)).run()
   }
@@ -2385,7 +2366,6 @@ export function makeRepos(db: SqliteDb) {
   return {
     createArtifact,
     setAccess,
-    backfillAccess,
     setLocked,
     getByShortId,
     getArtifactById,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -8,7 +8,6 @@ import type {
   DomainKind,
   DomainStatus,
   FollowKind,
-  GeneralRole,
   LinkRole,
   Listed,
   NotificationKind,
@@ -20,7 +19,6 @@ import type {
   Role,
   SessionMessageAuthor,
   SessionState,
-  Visibility,
   WebhookKind,
   WorkspaceAccess,
 } from "@derive/core"
@@ -58,12 +56,9 @@ export const artifact = sqliteTable("artifact", {
   // Locks the world link on a public-directory doc until unlocked; members and
   // explicit shares never need it.
   password_hash: text("password_hash"),
-  // ── Orphaned columns (expand/contract — CONTRIBUTING.md). Backfilled ONCE at
-  // boot into the access fields above (backfillAccess consumes `visibility`, so
-  // it re-runs to a no-op), then read by nothing. Kept so existing rows + the DDL
-  // stay consistent and ArtifactRecord's shape matches this table (see ./parity).
-  visibility: text("visibility").$type<Visibility>().notNull().default("private"),
-  general_role: text("general_role").$type<GeneralRole>().notNull().default("viewer"),
+  // (The v1 `visibility`/`general_role` columns were backfilled into the fields
+  // above and removed from this definition; existing databases drop them with
+  // deploy/drop-v1-access.sql — new ones never create them.)
   kind: text("kind").$type<ArtifactKind>().notNull(),
   spa: integer("spa").$type<0 | 1>().notNull().default(0),
   // When locked, direct publishes are rejected — changes must go through the
@@ -764,7 +759,7 @@ const ddl = generateDdl(TABLES, getTableConfig, {
 /**
  * Raw DDL run at boot for the self-host SQLite default (zero-config), and used to
  * seed D1 (deploy/d1-schema.sql). Table/index CREATEs come from the drizzle defs;
- * the not-yet-queried placeholder tables (principal/acl/view) and the perf indexes
+ * the not-yet-queried placeholder tables (principal/view) and the perf indexes
  * have no drizzle def and stay explicit (see ./ddl).
  */
 export const SCHEMA_STATEMENTS: string[] = [

--- a/packages/db/test/pg-store.test.ts
+++ b/packages/db/test/pg-store.test.ts
@@ -205,7 +205,6 @@ if (PG_URL) {
             org_id: "o",
             slug: null,
             title: "T",
-            visibility: "public",
             kind: "file",
             spa: 0,
           })

--- a/packages/db/test/preview-ready.test.ts
+++ b/packages/db/test/preview-ready.test.ts
@@ -16,7 +16,6 @@ describe("previewReady", () => {
       org_id: "o1",
       slug: null,
       title: "t",
-      visibility: "public",
       kind: "file",
       spa: 0,
     })
@@ -40,7 +39,6 @@ describe("previewReady", () => {
       org_id: "o1",
       slug: null,
       title: "t",
-      visibility: "public",
       kind: "file",
       spa: 0,
     })
@@ -64,7 +62,6 @@ describe("previewReady", () => {
       org_id: "o1",
       slug: null,
       title: "t",
-      visibility: "public",
       kind: "file",
       spa: 0,
     })
@@ -98,7 +95,6 @@ describe("previewReady", () => {
       org_id: "o1",
       slug: null,
       title: "t",
-      visibility: "public",
       kind: "file",
       spa: 0,
     })
@@ -108,7 +104,6 @@ describe("previewReady", () => {
       org_id: "o1",
       slug: null,
       title: "t",
-      visibility: "public",
       kind: "file",
       spa: 0,
     })

--- a/packages/db/test/preview.test.ts
+++ b/packages/db/test/preview.test.ts
@@ -10,7 +10,6 @@ describe("version preview fields", () => {
       org_id: "o1",
       slug: null,
       title: "t",
-      visibility: "public",
       kind: "file",
       spa: 0,
     })

--- a/packages/db/test/sqlite-store.test.ts
+++ b/packages/db/test/sqlite-store.test.ts
@@ -214,7 +214,6 @@ describe("sqlite store: people directory + follower lists + author backfill", ()
       org_id: "o",
       slug: null,
       title: "T",
-      visibility: "public",
       kind: "file",
       spa: 0,
     })


### PR DESCRIPTION
## What

The v2 access refactor left three orphans in prod, and they actively mislead: a debugging session reads `visibility='private'` as meaningful when the live gate is `workspace_access`/`link_role`/`listed`. This removes them:

- `artifact.visibility` + `artifact.general_role` — backfilled once at boot, then read by nothing
- the `acl` placeholder table — zero query sites, ever (its `password_hash` was never the live one; that's `artifact.password_hash`, untouched)
- the boot backfill (`backfillAccess`) retires with the columns it consumed

## How the drop actually lands

The boot DDL is additive-only by design (`check-schema` gate), so removing the drizzle defs only stops *new* databases from creating the columns. Existing databases run **`deploy/drop-v1-access.sql`** once per environment (SQLite / D1 / Postgres invocations documented in the file). The script first re-applies the v1→v2 fold — a no-op everywhere that ever booted a v2 build, a safety net for an instance jumping straight from pre-v2 — then drops.

## What is deliberately untouched

The legacy **wire** vocabulary: `--visibility` on the CLI and the `visibility`/`general_role` request-body params still map through `legacyAccessOf` (old pinned clients keep publishing). Its `Visibility` type moved into `http.ts`, where that dialect actually lives.

## Verification

- `parity.ts` compile guard forces the column/type/schema removals to land together — full `pnpm -r typecheck` green
- db 179 ✓ / api 834 ✓ / full precommit lint suite ✓
- drop script exercised against a synthetic pre-v2 SQLite DB: `org/commenter` folds to workspace-open + workspace-listed, pre-collapse `link` vocab restores its live link, `private` untouched, both columns + `acl` gone

Companion to the share-dialog collection-disclosure work (same investigation surfaced both; that lands separately).