### PR TITLE
fix(web): route post-login onboarding off the shared gate predicate, not a copy

### DIFF
--- a/apps/web/src/lib/route-guards.ts
+++ b/apps/web/src/lib/route-guards.ts
@@ -22,20 +22,28 @@ export const requireAuth = async ({ context, location }: GuardArgs) => {
   return { me }
 }
 
-// requireAuth + the first-run onboarding gate: a signed-in user who hasn't set a
-// profession (and hasn't finished/skipped onboarding) goes to /welcome. /welcome
-// itself uses requireAuth ONLY, so it never redirects to itself — no loop.
-export const requireOnboarded = async (args: GuardArgs) => {
-  const { me } = await requireAuth(args)
-  // Server-authoritative flag (syncs across devices, survives a cleared cache) wins.
-  if (me.onboarded) return
-  // Fall back to the legacy signals so accounts from before the flag are never bounced
-  // back to /welcome: a claimed profession, or the per-browser localStorage cache.
+// The ONE first-run predicate — the single source of truth for "does this signed-in
+// user still need /welcome". The server-authoritative flag (syncs across devices,
+// survives a cleared cache) wins; otherwise fall back to the legacy signals so accounts
+// from before the flag are never bounced back to /welcome — a claimed profession, or the
+// per-browser localStorage cache. Both the route gate and the post-login redirect route
+// off THIS, so they can't drift (a simpler onboarded-only check would send returning
+// pre-flag users to /welcome after sign-in).
+export const needsOnboarding = (me: { onboarded?: boolean; profession?: string | null }) => {
+  if (me.onboarded) return false
   let cached = false
   try {
     cached = localStorage.getItem(STORAGE_KEYS.onboarded) === "1"
   } catch {
     /* private mode — the profession check still gates it */
   }
-  if (!me.profession && !cached) throw redirect({ to: "/welcome" })
+  return !me.profession && !cached
+}
+
+// requireAuth + the first-run onboarding gate: a signed-in user who still needs
+// onboarding goes to /welcome. /welcome itself uses requireAuth ONLY, so it never
+// redirects to itself — no loop.
+export const requireOnboarded = async (args: GuardArgs) => {
+  const { me } = await requireAuth(args)
+  if (needsOnboarding(me)) throw redirect({ to: "/welcome" })
 }

--- a/apps/web/src/pages/login.tsx
+++ b/apps/web/src/pages/login.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/input-otp"
 import { useAuth } from "@/ctx"
 import { authClient } from "@/lib/auth-client"
+import { needsOnboarding } from "@/lib/route-guards"
 
 const loginRoute = getRouteApi("/login")
 
@@ -74,7 +75,7 @@ export function Login() {
   // user) with no /login left to re-trigger it. The one-shot latch guards the brief
   // pre-navigation window where the effect below can fire more than once.
   const redirected = useRef(false)
-  const afterAuth = (who?: { onboarded?: boolean } | null) => {
+  const afterAuth = (who?: Parameters<typeof needsOnboarding>[0] | null) => {
     if (redirected.current) return
     redirected.current = true
     const search = typeof window !== "undefined" ? window.location.search : ""
@@ -84,11 +85,13 @@ export function Login() {
       // Back to where sign-in was prompted (e.g. a shared artifact's "sign in to
       // comment"). Validated same-origin relative by the route, so this is safe.
       window.location.href = returnTo
-    } else if (who && who.onboarded === false) {
-      // A brand-new account goes straight to onboarding. Routing to "/" first boots the
-      // whole app shell (rail skeleton + a blank pane) only to redirect here — so the user's
-      // very first post-signup frame is a loading flash. Skip the detour. (The app-shell
-      // onboarding gate still covers any path that doesn't come through here.)
+    } else if (who && needsOnboarding(who)) {
+      // A user who still needs onboarding goes straight to /welcome. Routing to "/" first
+      // boots the whole app shell (rail skeleton + a blank pane) only for the same gate to
+      // redirect here — so the user's very first post-signup frame is a loading flash. Skip
+      // the detour by reusing the app-shell gate's exact predicate (needsOnboarding), so a
+      // returning pre-flag user is never wrongly sent to /welcome. The gate still covers any
+      // path that doesn't come through here.
       window.location.href = "/welcome"
     } else {
       window.location.href = "/"


### PR DESCRIPTION
## What

Self-audit follow-up to #369. Auditing that fix for hacky shortcuts surfaced one: it encoded a **simplified copy** of the onboarding predicate.

## The bug

`afterAuth()` in `login.tsx` used `who.onboarded === false` to decide "send to `/welcome`". But the authoritative gate — `requireOnboarded` — is:

```
needs onboarding  ⟺  !onboarded && !profession && !localStorageCache
```

Those two fallbacks are **deliberate**: the guard's own comment says they exist so *accounts from before the `onboarded` flag are never bounced back to `/welcome`*. My copy dropped them, so a **returning pre-flag user** (profession set, server flag off) who signed in was routed to `/welcome` — re-shown the onboarding form — instead of landing on home. `/welcome` uses `requireAuth` only and doesn't self-correct, so it wasn't masked.

Classic divergent-copy-of-the-truth: right for the case I built it for (fresh signup), wrong for the case I didn't test (returning legacy sign-in).

## The fix

Extract the predicate **once** — `needsOnboarding(me)` in `route-guards.ts` — and route **both** the app-shell gate and the post-login redirect off it. They can no longer drift.

- Fresh signup → `needsOnboarding` true → straight to `/welcome`. #369's no-flash win is **kept**.
- Returning user with a profession (or the browser cache) → false → home. Regression **gone**.
- Modern onboarded user → false → home. Unchanged.

## Verification

typecheck 0 · biome clean · **smoke 10/10**, including `auth.smoke` "sign up … lands in the app" (the helper clicks `welcome-skip`, which only exists on `/welcome` — so a broken signup→welcome route would fail it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
