### PR TITLE
feat(web): disclose collection-propagated access in the share dialog

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -360,6 +360,13 @@
             },
             "description": "Ids of the collections that include this artifact."
           },
+          "collection_access": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CollectionGrant"
+            },
+            "description": "Collections whose sharing ADDS reach to this artifact — the share dialog's disclosure rows, renderable verbatim (the caller's own solo invite-only collection is already excluded). Detail responses only; scoped to collections the caller can see, except the artifact's managers (explicit or seat standing — never mere link-holders), who see every granting collection."
+          },
           "removed": {
             "type": "boolean",
             "description": "true when the artifact has been taken down (tombstone)."
@@ -527,6 +534,59 @@
           "author",
           "name",
           "created_at"
+        ]
+      },
+      "CollectionGrant": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "workspace_access": {
+            "type": "string",
+            "enum": [
+              "none",
+              "member"
+            ],
+            "description": "\"member\" = every workspace seat opens the artifact at their role."
+          },
+          "my_role": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "viewer",
+              "commenter",
+              "editor",
+              "owner",
+              null
+            ],
+            "description": "Caller's role on the COLLECTION (owner ⇒ can manage its sharing); null if none."
+          },
+          "member_count": {
+            "type": "number",
+            "description": "Explicit collection-member rows (the creator always holds one)."
+          },
+          "created_by": {
+            "type": "string",
+            "description": "Creator's user id — permanently owner of the collection."
+          },
+          "owner_name": {
+            "type": "string",
+            "nullable": true,
+            "description": "Creator's display name for attribution (\"Managed by …\"); null when unknown."
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "workspace_access",
+          "my_role",
+          "member_count",
+          "created_by",
+          "owner_name"
         ]
       },
       "DirUser": {

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -18,10 +18,12 @@ import {
   PublishError,
   pageText,
   publish,
+  type Role,
   renderMarkdown,
   sectionOf,
   toJson,
   toMarkdown,
+  type WorkspaceAccess,
 } from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { Context } from "hono"
@@ -880,6 +882,7 @@ export const artifactRoutes = (ctx: AppContext) => {
           tags: [],
           favorite: false,
           collections: [],
+          collection_access: [],
           open_proposals: 0,
           proposals_total: 0,
           removed: true,
@@ -890,6 +893,70 @@ export const artifactRoutes = (ctx: AppContext) => {
       const tags = (await meta.tagsForArtifacts([artifact.id]))[artifact.id] ?? []
       const favorite = me ? (await meta.listUserFavoriteIds(me)).includes(artifact.id) : false
       const collections = await meta.collectionIdsForArtifact(artifact.id)
+      const myRole = effectiveRole(actor, artifact.workspace_access, artifact.link_role)
+      // The share dialog's disclosure rows: which collections' sharing REACHES this
+      // artifact (a workspace-open collection propagates every seat; an invite-only
+      // one its members — see collectionRolesForArtifact). The artifact's own access
+      // fields never reflect that grant, so the detail response must carry it or the
+      // dialog lies ("Invited · 1 person" on a doc the whole workspace can open).
+      // Two independent gates shape the list:
+      //   VISIBLE — collections the caller has a role on (their explicit share, a
+      //     seat on a workspace-open one, created_by, or the operator token), plus
+      //     everything for the artifact's own managers. Manager standing is computed
+      //     WITHOUT the world link (linkRole "none") — a stranger holding an editor
+      //     URL must not unlock other people's private collections' titles/rosters,
+      //     the same class of caller the members-roster route 404s.
+      //   GRANTING — of those, only collections that actually ADD reach: any
+      //     workspace-open one; an invite-only one only when someone besides the
+      //     caller enters through it (another member row, or a creator who isn't
+      //     them). This is the response's contract — consumers render it verbatim.
+      const standing = effectiveRole(actor, artifact.workspace_access, "none")
+      const canManageArtifact = standing === "owner" || standing === "editor"
+      let collectionAccess: {
+        id: string
+        title: string
+        workspace_access: WorkspaceAccess
+        my_role: Role | null
+        member_count: number
+        created_by: string
+        owner_name: string | null
+      }[] = []
+      // Anonymous link readers can never see a row (no role, no standing) — skip the
+      // lookups entirely on that hot path.
+      if (collections.length > 0 && (me !== null || isToken(c) || canManageArtifact)) {
+        const [colRecords, rolesById] = await Promise.all([
+          meta.getCollections(collections),
+          me
+            ? meta.collectionRolesForUser(collections, me)
+            : Promise.resolve<Record<string, Role>>({}),
+        ])
+        // Fold in the two sources the batched query can't know (mirrors collectionRole).
+        const roleOf = (col: (typeof colRecords)[number]): Role | null =>
+          isToken(c) ? "owner" : col.created_by === me ? "owner" : (rolesById[col.id] ?? null)
+        const visible = colRecords
+          .map((col) => ({ col, role: roleOf(col) }))
+          .filter(({ role }) => role !== null || canManageArtifact)
+        const [memberCounts, creatorNames] = await Promise.all([
+          meta.collectionMemberCounts(visible.map(({ col }) => col.id)),
+          resolveUserBylines(meta, [...new Set(visible.map(({ col }) => col.created_by))]),
+        ])
+        collectionAccess = visible
+          .filter(
+            ({ col }) =>
+              col.workspace_access === "member" ||
+              col.created_by !== me ||
+              (memberCounts[col.id] ?? 0) >= 2,
+          )
+          .map(({ col, role }) => ({
+            id: col.id,
+            title: col.title,
+            workspace_access: col.workspace_access,
+            my_role: role,
+            member_count: memberCounts[col.id] ?? 0,
+            created_by: col.created_by,
+            owner_name: creatorNames[col.created_by]?.name ?? null,
+          }))
+      }
       const proposals = await meta.listProposals(artifact.id)
       // A markdown bundle (a skill — entry SKILL.md — or a docs folder) gets a `bundle`
       // block: the entry + file tree (so the client can render the doc and navigate
@@ -948,13 +1015,14 @@ export const artifactRoutes = (ctx: AppContext) => {
           }
         }),
         sessions: groupSessions(versions, versionWindowMs),
-        my_role: effectiveRole(actor, artifact.workspace_access, artifact.link_role),
+        my_role: myRole,
         // The artifact's current workspace — the move dialog needs this to exclude
         // it from the destination picker.
         org_id: artifact.org_id,
         tags,
         favorite,
         collections,
+        collection_access: collectionAccess,
         open_proposals: proposals.filter((p) => p.state === "open").length,
         proposals_total: proposals.filter((p) => p.state !== "withdrawn").length,
         // Present for a markdown bundle (skill or docs folder): { isSkill, name,

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -57,6 +57,32 @@ export const VersionSession = z
   })
   .openapi("VersionSession")
 
+/** A collection that grants access to an artifact, as the share dialog discloses it: a
+ *  workspace-open collection reaches every workspace seat at their role; an invite-only
+ *  one reaches its explicit members. The artifact's own access fields never see this
+ *  grant (it folds into the explicit slot — see access-model.md), so the dialog must. */
+export const CollectionGrant = z
+  .object({
+    id: z.string(),
+    title: z.string(),
+    workspace_access: z
+      .enum(["none", "member"])
+      .describe('"member" = every workspace seat opens the artifact at their role.'),
+    my_role: z
+      .enum(["viewer", "commenter", "editor", "owner"])
+      .nullable()
+      .describe("Caller's role on the COLLECTION (owner ⇒ can manage its sharing); null if none."),
+    member_count: z
+      .number()
+      .describe("Explicit collection-member rows (the creator always holds one)."),
+    created_by: z.string().describe("Creator's user id — permanently owner of the collection."),
+    owner_name: z
+      .string()
+      .nullable()
+      .describe('Creator\'s display name for attribution ("Managed by …"); null when unknown.'),
+  })
+  .openapi("CollectionGrant")
+
 /** The artifact view-model — the largest, most-composed shape in the client. Built by
  *  core's toJson() plus per-request enrichment (roles, counts, tags, threads). Returned
  *  by the artifacts router AND session's /users/:handle/artifacts, so it's shared here.
@@ -170,6 +196,16 @@ export const Artifact = z
       .array(z.string())
       .optional()
       .describe("Ids of the collections that include this artifact."),
+    collection_access: z
+      .array(CollectionGrant)
+      .optional()
+      .describe(
+        "Collections whose sharing ADDS reach to this artifact — the share dialog's " +
+          "disclosure rows, renderable verbatim (the caller's own solo invite-only " +
+          "collection is already excluded). Detail responses only; scoped to collections " +
+          "the caller can see, except the artifact's managers (explicit or seat standing " +
+          "— never mere link-holders), who see every granting collection.",
+      ),
     removed: z
       .boolean()
       .optional()

--- a/apps/api/test/collection-access.test.ts
+++ b/apps/api/test/collection-access.test.ts
@@ -198,3 +198,155 @@ describe("a collection's own workspace access", () => {
     expect((await meta.getCollectionMember(col.id, ana.id))?.role).toBe("owner")
   })
 })
+
+// The detail response's `collection_access` — the share dialog's disclosure rows. The
+// artifact's own fields can't express a collection grant (it folds into the explicit
+// slot), so the detail payload must carry which collections' sharing reaches the doc,
+// or the dialog renders "Invited · 1 person" on a doc the whole workspace can open.
+describe("collection_access disclosure on the artifact detail", () => {
+  const dana: TestUser = { id: "u_cad_ana", email: "ana@cad.test", name: "Ana" }
+  const dben: TestUser = { id: "u_cad_ben", email: "ben@cad.test", name: "Ben" }
+  const dcara: TestUser = { id: "u_cad_cara", email: "cara@cad.test", name: "Cara" }
+  const dave: TestUser = { id: "u_cad_dave", email: "dave@cad.test", name: "Dave" }
+  const { app, meta } = makeAuthedApp("cad", [dana, dben, dcara, dave], "editor")
+
+  const detail = async (shortId: string, headers?: Record<string, string>) =>
+    (await app.request(`/v1/artifacts/${shortId}`, headers ? { headers } : undefined)).json()
+  const create = async (title: string, actor: Record<string, string>) =>
+    (await app.request("/v1/collections", jsonAs(actor, { title }))).json()
+  const addItem = (colId: string, shortId: string, actor: Record<string, string>) =>
+    app.request(`/v1/collections/${colId}/items/${shortId}`, { method: "PUT", headers: actor })
+
+  it("discloses a workspace-open collection, with each viewer's own collection role", async () => {
+    const { short_id } = await (
+      await publishAs(
+        app,
+        "<p>enablement</p>",
+        { title: "Custom Offers", workspace_access: "none", listed: "none", link_role: "none" },
+        as(dana.email),
+      )
+    ).json()
+    // Outside any collection: nothing to disclose.
+    expect((await detail(short_id, as(dana.email))).collection_access).toEqual([])
+
+    const col = await create("Product Training", as(dana.email)) // workspace-open by default
+    await addItem(col.id, short_id, as(dana.email))
+
+    // The owner sees the grant with her role on the COLLECTION (owner ⇒ Manage).
+    const forAna = (await detail(short_id, as(dana.email))).collection_access
+    expect(forAna).toEqual([
+      {
+        id: col.id,
+        title: "Product Training",
+        workspace_access: "member",
+        my_role: "owner",
+        member_count: 1,
+        created_by: dana.id,
+        owner_name: "Ana",
+      },
+    ])
+
+    // A seat-only member reaches the doc THROUGH the collection and sees the same
+    // row at his seat role (editor — no Manage, just attribution).
+    const forBen = (await detail(short_id, as(dben.email))).collection_access
+    expect(forBen).toHaveLength(1)
+    expect(forBen[0]).toMatchObject({ id: col.id, my_role: "editor", owner_name: "Ana" })
+  })
+
+  it("someone else's invite-only collection is disclosed to the artifact's manager, but never to a roleless caller", async () => {
+    const { short_id } = await (
+      await publishAs(
+        app,
+        "<p>open</p>",
+        { title: "Open doc", workspace_access: "member", listed: "none", link_role: "viewer" },
+        as(dana.email),
+      )
+    ).json()
+    // Cara (workspace editor ⇒ share on the artifact) files it into her own
+    // invite-only collection — a grant Ana neither made nor can see as a collection.
+    const col = await create("Cara's picks", as(dcara.email))
+    await app.request(`/v1/collections/${col.id}/access`, {
+      ...jsonAs(as(dcara.email), { workspaceAccess: "none" }),
+      method: "PATCH",
+    })
+    await addItem(col.id, short_id, as(dcara.email))
+
+    // Ana manages the artifact, so she sees WHAT grants access to her doc even though
+    // she has no role on the collection itself (my_role null ⇒ "Managed by Cara").
+    const forAna = (await detail(short_id, as(dana.email))).collection_access
+    expect(forAna).toHaveLength(1)
+    expect(forAna[0]).toMatchObject({
+      id: col.id,
+      title: "Cara's picks",
+      workspace_access: "none",
+      my_role: null,
+      owner_name: "Cara",
+    })
+
+    // An anonymous link viewer can open the doc but has no role on the collection and
+    // doesn't manage the artifact — the private collection's existence (and title)
+    // doesn't leak to them.
+    expect((await detail(short_id)).collection_access).toEqual([])
+  })
+
+  // Manager standing is computed WITHOUT the world link: a signed-in stranger holding
+  // an editor URL gets editor on the DOC, but must not unlock other people's private
+  // collections' titles/rosters — the same class of caller the members-roster route
+  // refuses (sharing's cross-workspace gate).
+  it("an editor world link never unlocks other people's private collection metadata", async () => {
+    const { short_id } = await (
+      await publishAs(
+        app,
+        "<p>linked</p>",
+        { title: "Linked doc", workspace_access: "member", listed: "none", link_role: "editor" },
+        as(dana.email),
+      )
+    ).json()
+    const col = await create("Cara's private list", as(dcara.email))
+    await app.request(`/v1/collections/${col.id}/access`, {
+      ...jsonAs(as(dcara.email), { workspaceAccess: "none" }),
+      method: "PATCH",
+    })
+    await addItem(col.id, short_id, as(dcara.email))
+
+    // Dave is signed in but holds NO seat anywhere — pure link-holder.
+    await meta.removeMembership("default", dave.id)
+    const forDave = await detail(short_id, as(dave.email))
+    expect(forDave.my_role).toBe("editor") // the link grants him the doc…
+    expect(forDave.collection_access).toEqual([]) // …never Cara's private collection
+
+    // Ana (explicit owner — real standing) still sees what grants access to her doc.
+    const forAna = (await detail(short_id, as(dana.email))).collection_access
+    expect(forAna.map((g: { id: string }) => g.id)).toContain(col.id)
+  })
+
+  // The response contract: collection_access lists only collections that ADD reach.
+  // Your own invite-only collection with just you in it reaches nobody new — the
+  // server excludes it, so every consumer (MCP, CLI, web) can render the field verbatim.
+  it("your own solo invite-only collection adds no reach — excluded server-side", async () => {
+    const { short_id } = await (
+      await publishAs(
+        app,
+        "<p>solo</p>",
+        { title: "Solo doc", workspace_access: "none", listed: "none", link_role: "none" },
+        as(dana.email),
+      )
+    ).json()
+    const col = await create("Ana's own shelf", as(dana.email))
+    await app.request(`/v1/collections/${col.id}/access`, {
+      ...jsonAs(as(dana.email), { workspaceAccess: "none" }),
+      method: "PATCH",
+    })
+    await addItem(col.id, short_id, as(dana.email))
+    expect((await detail(short_id, as(dana.email))).collection_access).toEqual([])
+
+    // Inviting one person makes it a real grant — the row appears.
+    await app.request(`/v1/collections/${col.id}/members`, {
+      ...jsonAs(as(dana.email), { user: dben.email, role: "viewer" }),
+      method: "PUT",
+    })
+    const after = (await detail(short_id, as(dana.email))).collection_access
+    expect(after).toHaveLength(1)
+    expect(after[0]).toMatchObject({ id: col.id, member_count: 2 })
+  })
+})

--- a/apps/web/e2e/deep/share-collection-disclosure.deep.spec.ts
+++ b/apps/web/e2e/deep/share-collection-disclosure.deep.spec.ts
@@ -1,0 +1,141 @@
+import { Buffer } from "node:buffer"
+import { mkdirSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import type { Page } from "@playwright/test"
+import { expect, test } from "../fixtures"
+
+// End-to-end proof for the share dialog's collection-disclosure rows + the honest
+// trigger glyph, driven through the real web UI. The bug being fixed: a fully
+// private artifact inside a workspace-open collection is readable by every seat
+// (collectionRolesForArtifact folds the grant in), but the Share dialog said
+// "Invited" and the trigger wore a lock. Companion to the API coverage in
+// apps/api/test/collection-access.test.ts ("collection_access disclosure…") and
+// the UI-visibility coverage in collection-visibility.deep.spec.ts.
+//
+// Cast:
+//  • ana — publishes a PRIVATE artifact, then files it into her workspace-open
+//          "Product Training" collection (the Lucas scenario).
+//  • ben — an editor seat, no explicit share anywhere: reaches the doc only
+//          through the collection; his dialog must say who to ask ("Managed by").
+
+const SHOTS = join(homedir(), "Projects/screenshots/derive-share-disclosure")
+
+test("the share dialog discloses collection-propagated access, live", async ({
+  owner: ana,
+  secondUser: ben,
+}) => {
+  mkdirSync(SHOTS, { recursive: true })
+  const shot = (page: Page, name: string) => page.screenshot({ path: join(SHOTS, `${name}.png`) })
+
+  const anaOrg = ((await (await ana.request.get("/v1/workspaces")).json()) as { active: string })
+    .active
+
+  // --- ana publishes a PRIVATE artifact: no workspace seat, no link, unlisted. ---
+  const priv = (await (
+    await ana.request.post("/v1/artifacts", {
+      multipart: {
+        file: {
+          name: "custom-offers.md",
+          mimeType: "text/markdown",
+          buffer: Buffer.from("# Custom Offers — Internal Enablement\n\nPrivate.\n"),
+        },
+        title: "Custom Offers — Internal Enablement",
+        workspace_access: "none",
+        link_role: "none",
+        listed: "none",
+      },
+    })
+  ).json()) as { short_id: string }
+
+  // ============================================================================
+  // S1 — before any collection: the trigger wears the LOCK and the dialog shows
+  //      no disclosure section. The baseline the fix must not disturb.
+  // ============================================================================
+  await ana.goto(`/artifacts/${priv.short_id}`)
+  const trigger = ana.getByTestId("share-trigger")
+  await expect(trigger.locator("svg.lucide-lock")).toBeVisible()
+  await trigger.click()
+  const dialog = ana.getByRole("dialog")
+  await expect(dialog.getByText("Reachable through collections")).toBeHidden()
+  await expect(dialog.getByText("Only the people you add below can open this.")).toBeVisible()
+  await shot(ana, "01-private-no-collection-lock")
+  await ana.keyboard.press("Escape")
+
+  // --- ana files it into a workspace-open collection (the default). ---
+  const col = (await (
+    await ana.request.post("/v1/collections", { data: { title: "Product Training" } })
+  ).json()) as { id: string; workspace_access: string }
+  expect(col.workspace_access).toBe("member")
+  expect((await ana.request.put(`/v1/collections/${col.id}/items/${priv.short_id}`)).ok()).toBe(
+    true,
+  )
+
+  // ============================================================================
+  // S2 — the OWNER's dialog now tells the truth: share glyph on the trigger, a
+  //      "Reachable through collections" row naming the collection and its reach,
+  //      honest Invited copy, and a Manage affordance (she owns the collection).
+  // ============================================================================
+  await ana.goto(`/artifacts/${priv.short_id}`)
+  await expect(trigger.locator("svg.lucide-share2")).toBeVisible()
+  await trigger.click()
+  await expect(dialog.getByText("Reachable through collections")).toBeVisible()
+  const row = dialog.getByTestId(`share-collection-row-${col.id}`)
+  await expect(row.getByText("Product Training")).toBeVisible()
+  await expect(row.getByText("Everyone in the workspace opens this at their role")).toBeVisible()
+  await expect(
+    dialog.getByText("Only the people you add below — plus everyone reached through"),
+  ).toBeVisible()
+  await shot(ana, "02-owner-sees-disclosure-row")
+
+  // ============================================================================
+  // S3 — Manage opens the collection's own share dialog STACKED (no navigation);
+  //      flipping it to Invited and closing refreshes the artifact dialog live:
+  //      the row disappears (her solo invite-only collection adds no reach) and
+  //      the trigger's lock promise is true again.
+  // ============================================================================
+  await dialog.getByTestId(`share-collection-manage-${col.id}`).click()
+  const stacked = ana.getByRole("dialog").filter({ hasText: "every artifact" })
+  await expect(stacked.getByText("Product Training", { exact: false })).toBeVisible()
+  await ana.waitForTimeout(400) // let both fade-ins settle so the screenshot shows real layering
+  await shot(ana, "03-manage-stacks-collection-dialog")
+  await stacked.getByTestId("collection-share-access").getByText("Invited").click()
+  await ana.keyboard.press("Escape") // close the stacked dialog → invalidate + refetch
+  await expect(ana.getByText("Reachable through collections")).toBeHidden()
+  await shot(ana, "04-invited-collection-row-gone")
+  await ana.keyboard.press("Escape")
+  await expect(trigger.locator("svg.lucide-lock")).toBeVisible()
+
+  // Flip it back to workspace-open for ben's leg.
+  expect(
+    (
+      await ana.request.patch(`/v1/collections/${col.id}/access`, {
+        data: { workspaceAccess: "member" },
+      })
+    ).ok(),
+  ).toBe(true)
+
+  // ============================================================================
+  // S4 — a SEAT-ONLY member reaches the private doc through the collection; his
+  //      dialog shows the same row with ATTRIBUTION, not Manage — the lever
+  //      belongs to ana and the row says so.
+  // ============================================================================
+  expect(
+    (
+      await ana.request.post("/v1/workspace/invites", {
+        data: { email: ben.email, role: "editor" },
+      })
+    ).ok(),
+  ).toBe(true)
+  await ben.page.request.post("/v1/workspace/switch", { data: { id: anaOrg } })
+  await ben.page.goto(`/artifacts/${priv.short_id}`)
+  const benTrigger = ben.page.getByTestId("share-trigger")
+  await expect(benTrigger.locator("svg.lucide-share2")).toBeVisible()
+  await benTrigger.click()
+  const benDialog = ben.page.getByRole("dialog")
+  const benRow = benDialog.getByTestId(`share-collection-row-${col.id}`)
+  await expect(benRow.getByText("Product Training")).toBeVisible()
+  await expect(benRow.getByText(/Managed by/)).toBeVisible()
+  await expect(benDialog.getByTestId(`share-collection-manage-${col.id}`)).toHaveCount(0)
+  await shot(ben.page, "05-seat-member-attribution-no-manage")
+})

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -4834,6 +4834,8 @@ export interface components {
             i_participated?: boolean;
             /** @description Ids of the collections that include this artifact. */
             collections?: string[];
+            /** @description Collections whose sharing ADDS reach to this artifact — the share dialog's disclosure rows, renderable verbatim (the caller's own solo invite-only collection is already excluded). Detail responses only; scoped to collections the caller can see, except the artifact's managers (explicit or seat standing — never mere link-holders), who see every granting collection. */
+            collection_access?: components["schemas"]["CollectionGrant"][];
             /** @description true when the artifact has been taken down (tombstone). */
             removed?: boolean;
             /** @description true when mirrored from a GitHub sync — read-only in Derive. */
@@ -4889,6 +4891,26 @@ export interface components {
             name: string | null;
             /** @description Timestamp of the newest version in the group. */
             created_at: string;
+        };
+        CollectionGrant: {
+            id: string;
+            title: string;
+            /**
+             * @description "member" = every workspace seat opens the artifact at their role.
+             * @enum {string}
+             */
+            workspace_access: "none" | "member";
+            /**
+             * @description Caller's role on the COLLECTION (owner ⇒ can manage its sharing); null if none.
+             * @enum {string|null}
+             */
+            my_role: "viewer" | "commenter" | "editor" | "owner" | null;
+            /** @description Explicit collection-member rows (the creator always holds one). */
+            member_count: number;
+            /** @description Creator's user id — permanently owner of the collection. */
+            created_by: string;
+            /** @description Creator's display name for attribution ("Managed by …"); null when unknown. */
+            owner_name: string | null;
         };
         DirUser: {
             /** @description User id, or the agent id when kind is agent. */

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -52,6 +52,9 @@ export type Report = components["schemas"]["Report"]
  *  (kind = manual / repo / pr). Generated from the OpenAPI spec (apps/api/openapi.json)
  *  — a backend shape change surfaces here at `tsc`. */
 export type Collection = components["schemas"]["Collection"]
+/** A collection whose sharing reaches an artifact (workspace-open, or invite-only with
+ *  members) — the share dialog's disclosure rows. Generated from the OpenAPI spec. */
+export type CollectionGrant = components["schemas"]["CollectionGrant"]
 /** A per-user follow: a GitHub author (kind="author", target=login), a repo path
  *  prefix (kind="path", target=path prefix), or a person (kind="user", target=username
  *  on the wire). Drives the `scope=following` feed. Generated from the API's OpenAPI

--- a/apps/web/src/components/shared/organize-dialogs.tsx
+++ b/apps/web/src/components/shared/organize-dialogs.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
+import { artifactQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { cn } from "@/lib/utils"
 
@@ -45,7 +46,10 @@ export function CollectionsDialog({
   }, [open])
   const inSet = new Set(inCollections)
   // Toggle membership optimistically (via onChange); the primitive rolls it back and
-  // toasts if the write fails.
+  // toasts if the write fails. The settle-time invalidation reconciles the artifact
+  // detail (`collections` AND the server-computed `collection_access` disclosure rows)
+  // against the server once the write lands — never during the optimistic phase, where
+  // a refetch would race the in-flight PUT and repaint pre-mutation state.
   const toggleCol = useApiMutation({
     mutationFn: ({ col, isIn }: { col: Collection; isIn: boolean }) =>
       isIn ? api.removeFromCollection(col.id, shortId) : api.addToCollection(col.id, shortId),
@@ -54,6 +58,7 @@ export function CollectionsDialog({
       onChange(isIn ? inCollections.filter((id) => id !== col.id) : [...inCollections, col.id])
       return () => onChange(prev)
     },
+    invalidate: [artifactQuery(shortId).queryKey],
   })
   const toggle = (col: Collection) => toggleCol.mutate({ col, isIn: inSet.has(col.id) })
   // Create a collection and drop this artifact into it in one gesture.
@@ -67,6 +72,7 @@ export function CollectionsDialog({
       setAll((a) => [col, ...a])
       onChange([...inCollections, col.id])
     },
+    invalidate: [artifactQuery(shortId).queryKey],
   })
   const create = () => {
     const t = draft.trim()

--- a/apps/web/src/pages/artifact/artifact-top-bar.tsx
+++ b/apps/web/src/pages/artifact/artifact-top-bar.tsx
@@ -1,6 +1,6 @@
 import { Maximize2 } from "lucide-react"
 import { useState } from "react"
-import type { LinkRole, Listed, Role, WorkspaceAccess } from "@/api"
+import type { CollectionGrant, LinkRole, Listed, Role, WorkspaceAccess } from "@/api"
 import { Icon } from "@/components/icons"
 import { CollectionsDialog, TagsDialog } from "@/components/shared/organize-dialogs"
 import { Button } from "@/components/ui/button"
@@ -40,6 +40,8 @@ export function ArtifactTopBar(props: {
   favorite: boolean
   tags: string[]
   collections: string[]
+  /** Collections whose sharing reaches this artifact — the share dialog's disclosure rows. */
+  collectionAccess: CollectionGrant[]
   canEditTags: boolean
   openProposals: number
   proposalsTotal: number
@@ -92,6 +94,7 @@ export function ArtifactTopBar(props: {
           linkRole={props.linkRole}
           listed={props.listed}
           passwordProtected={props.passwordProtected}
+          collectionAccess={props.collectionAccess}
         />
         <StarButton shortId={shortId} favorite={props.favorite} onChange={props.onFavorite} />
         <DropdownMenu>

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -601,6 +601,7 @@ export function Artifact() {
               favorite={!!art.favorite}
               tags={art.tags ?? []}
               collections={art.collections ?? []}
+              collectionAccess={art.collection_access ?? []}
               canEditTags={art.my_role === "editor" || art.my_role === "owner"}
               openProposals={art.open_proposals ?? 0}
               proposalsTotal={art.proposals_total ?? 0}
@@ -634,6 +635,9 @@ export function Artifact() {
                 qc.setQueryData(artifactQuery(shortId).queryKey, (a) => (a ? { ...a, tags } : a))
               }
               onCollections={(collections) =>
+                // Pure cache write — CollectionsDialog calls this during its OPTIMISTIC
+                // phase, so no refetch here (it would race the in-flight write); the
+                // dialog itself reconciles collection_access on settle.
                 qc.setQueryData(artifactQuery(shortId).queryKey, (a) =>
                   a ? { ...a, collections } : a,
                 )

--- a/apps/web/src/pages/artifact/share-dialog.test.ts
+++ b/apps/web/src/pages/artifact/share-dialog.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+import { accessIcon, accessSummary } from "./share-dialog"
+
+// The share dialog's pure access projections. The invariant under test: a
+// workspace-open collection makes an artifact workspace-reachable regardless of the
+// artifact's own fields (see access-model.md), so the trigger glyph and the read-only
+// summary must both fold that grant in — the lock is a promise ("nobody but the
+// roster"), never shown when a collection breaks it. (Which collections count as
+// granting is the SERVER's contract — covered in collection-access.test.ts.)
+
+describe("accessIcon", () => {
+  it("world link wins: globe even when a collection is also open", () => {
+    expect(accessIcon("viewer", "none", true)).toBe("globe")
+  })
+  it("workspace seat access shows the share glyph", () => {
+    expect(accessIcon("none", "member", false)).toBe("share")
+  })
+  it("invite-only with NO collection grant keeps the lock", () => {
+    expect(accessIcon("none", "none", false)).toBe("lock")
+  })
+  it("a workspace-open collection breaks the lock's promise — share glyph instead", () => {
+    expect(accessIcon("none", "none", true)).toBe("share")
+  })
+})
+
+describe("accessSummary", () => {
+  it("folds a workspace-open collection into the workspace summary", () => {
+    expect(accessSummary("none", "none", true)).toBe("Everyone in the workspace can open this.")
+  })
+  it("stays invite-only without a collection grant", () => {
+    expect(accessSummary("none", "none", false)).toBe("Only invited people can open this.")
+  })
+  it("the world link outranks everything", () => {
+    expect(accessSummary("editor", "none", true)).toBe("Anyone with the link can edit.")
+  })
+})

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -6,6 +6,7 @@ import {
   type ArtifactDomain,
   type ArtifactMember,
   api,
+  type CollectionGrant,
   type LinkRole,
   type Listed,
   type Role,
@@ -40,6 +41,7 @@ import { useAuth } from "@/ctx"
 import { getInitials } from "@/lib/initials"
 import { artifactQuery, workspaceQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { ShareCollectionDialog } from "@/pages/library/share-collection-dialog"
 
 // Access is ONE primary question — who can open this — projected from the v2
 // triple (workspace_access, link_role, listed; see access-model.md). Each segment
@@ -55,22 +57,35 @@ const SEGMENTS: { value: Segment; label: string; icon: IconName }[] = [
 
 // The state glyph the Share trigger carries so exposure is legible without opening
 // the dialog: a globe when the URL alone reads, the share glyph for the workspace,
-// a lock for invite-only.
-const accessIcon = (linkRole: LinkRole, workspaceAccess: WorkspaceAccess): IconName =>
-  linkRole !== "none" ? "globe" : workspaceAccess === "member" ? "share" : "lock"
+// a lock for invite-only. A workspace-open collection makes the artifact workspace-
+// reachable even when its own fields say Invited (see access-model.md) — the lock is
+// a promise ("nobody but the roster"), so it must account for that grant too.
+export const accessIcon = (
+  linkRole: LinkRole,
+  workspaceAccess: WorkspaceAccess,
+  collectionOpen = false,
+): IconName =>
+  linkRole !== "none" ? "globe" : workspaceAccess === "member" || collectionOpen ? "share" : "lock"
 
 const LINK_ROLE_LABEL: Record<Exclude<LinkRole, "none">, string> = {
   viewer: "Can view",
   commenter: "Can comment",
   editor: "Can edit",
 }
-// The read-only one-liner for someone who can't manage access.
-const accessSummary = (linkRole: LinkRole, workspaceAccess: WorkspaceAccess): string => {
+// The read-only one-liner for someone who can't manage access. Mirrors accessIcon:
+// a workspace-open collection makes "everyone in the workspace" true regardless of
+// the artifact's own fields, so the summary must fold it in too.
+export const accessSummary = (
+  linkRole: LinkRole,
+  workspaceAccess: WorkspaceAccess,
+  collectionOpen = false,
+): string => {
   if (linkRole !== "none") {
     const what = linkRole === "viewer" ? "view" : linkRole === "editor" ? "edit" : "comment"
     return `Anyone with the link can ${what}.`
   }
-  if (workspaceAccess === "member") return "Everyone in the workspace can open this."
+  if (workspaceAccess === "member" || collectionOpen)
+    return "Everyone in the workspace can open this."
   return "Only invited people can open this."
 }
 
@@ -96,6 +111,7 @@ export function ShareButton({
   linkRole,
   listed,
   passwordProtected = false,
+  collectionAccess,
 }: {
   shortId: string
   myRole?: Role | null
@@ -105,6 +121,10 @@ export function ShareButton({
   listed?: Listed
   /** The world link carries a password (the lock). */
   passwordProtected?: boolean
+  /** Collections whose sharing reaches this artifact (detail response) — rendered as
+   *  disclosure rows so the dialog never claims "Invited" while a collection grants
+   *  the workspace access. */
+  collectionAccess?: CollectionGrant[]
 }) {
   const qc = useQueryClient()
   const { me } = useAuth()
@@ -146,6 +166,13 @@ export function ShareButton({
 
   // GDocs model: owners and editors manage access; everyone else gets view-only.
   const canManage = myRole === "owner" || myRole === "editor"
+
+  // The server sends only collections whose sharing ADDS reach, pre-scoped to what
+  // this caller may see (the collection_access contract) — render verbatim.
+  const grants = collectionAccess ?? []
+  const collectionOpen = grants.some((g) => g.workspace_access === "member")
+  // The collection being managed in the stacked ShareCollectionDialog (null = closed).
+  const [manageCol, setManageCol] = useState<CollectionGrant | null>(null)
 
   // The canonical share URL — the server-built artifact URL when the detail is
   // cached (it is, on the artifact page), else reconstructed from the short id.
@@ -403,7 +430,9 @@ export function ShareButton({
             eye lands). Everything else in the bar is ghost. The glyph carries the
             exposure state: globe = the URL alone reads, lock = invite-only. */}
         <Button data-testid="share-trigger" variant="default" size="sm">
-          <Icon name={accessIcon(linkRole ?? "none", workspaceAccess ?? "member")} />
+          <Icon
+            name={accessIcon(linkRole ?? "none", workspaceAccess ?? "member", collectionOpen)}
+          />
           Share
         </Button>
       </DialogTrigger>
@@ -438,7 +467,10 @@ export function ShareButton({
 
                 {segment === "invite" && (
                   <p className="mt-3 text-sm text-muted-foreground">
-                    Only the people you add below can open this.
+                    {grants.length > 0
+                      ? // Invited must not read as a promise the collections below break.
+                        "Only the people you add below — plus everyone reached through its collections."
+                      : "Only the people you add below can open this."}
                   </p>
                 )}
 
@@ -594,11 +626,68 @@ export function ShareButton({
               </div>
             ) : (
               <p className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
-                <Icon name={accessIcon(linkRole ?? "none", workspaceAccess ?? "member")} />
-                {accessSummary(linkRole ?? "none", workspaceAccess ?? "member")}
+                <Icon
+                  name={accessIcon(linkRole ?? "none", workspaceAccess ?? "member", collectionOpen)}
+                />
+                {accessSummary(linkRole ?? "none", workspaceAccess ?? "member", collectionOpen)}
               </p>
             )}
           </div>
+
+          {/* Disclosure, not control: each row is a collection whose sharing reaches
+              this artifact — the one access source the fields above can't express
+              (a collection grant folds into the explicit slot; see access-model.md).
+              Rendered for every viewer, managers or not — reach is never a secret
+              from someone who can already open the doc. The revocable unit is the
+              collection relationship, so the affordance is Manage (its share dialog),
+              not per-person rows. */}
+          {grants.length > 0 && (
+            <div>
+              <SectionEyebrow count={grants.length > 1 ? grants.length : undefined}>
+                Reachable through collections
+              </SectionEyebrow>
+              <div className="-mx-2 mt-1 flex flex-col">
+                {grants.map((g) => (
+                  <div
+                    key={g.id}
+                    data-testid={`share-collection-row-${g.id}`}
+                    className="flex items-center gap-3 rounded-lg px-2 py-2 hover:bg-secondary"
+                  >
+                    <span className="grid size-8 shrink-0 place-items-center rounded-lg bg-secondary">
+                      <Icon name="collections" size={16} className="text-muted-foreground" />
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium text-foreground">{g.title}</div>
+                      <div className="truncate text-xs text-muted-foreground">
+                        {g.workspace_access === "member"
+                          ? "Everyone in the workspace opens this at their role"
+                          : // member_count includes the creator's own row, so "members",
+                            // not "invited" — the creator wasn't invited, but reaches it.
+                            `${g.member_count} collection ${g.member_count === 1 ? "member opens" : "members open"} this at their role`}
+                      </div>
+                    </div>
+                    {/* Collection sharing is owner-managed (matches ShareCollectionDialog's
+                        bar); everyone else gets attribution — who to ask. */}
+                    {g.my_role === "owner" ? (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        data-testid={`share-collection-manage-${g.id}`}
+                        onClick={() => setManageCol(g)}
+                      >
+                        Manage
+                        <Icon name="chevron-right" />
+                      </Button>
+                    ) : (
+                      <span className="shrink-0 text-xs text-muted-foreground">
+                        {g.owner_name ? `Managed by ${g.owner_name}` : "Shared collection"}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
 
           <div>
             <SectionEyebrow count={members.length || undefined}>People with access</SectionEyebrow>
@@ -868,6 +957,18 @@ export function ShareButton({
           </div>
         )}
       </DialogContent>
+
+      {/* Manage a granting collection without leaving the share dialog — the stacked
+          collection dialog portals above this one. The refetch rides onChanged (fired
+          when each write LANDS), never onClose: an Escape mid-flight must not race the
+          PATCH and repaint the disclosure rows from the pre-change state. */}
+      {manageCol && (
+        <ShareCollectionDialog
+          collection={manageCol}
+          onChanged={() => qc.invalidateQueries({ queryKey: artifactQuery(shortId).queryKey })}
+          onClose={() => setManageCol(null)}
+        />
+      )}
     </Dialog>
   )
 }

--- a/apps/web/src/pages/library/share-collection-dialog.tsx
+++ b/apps/web/src/pages/library/share-collection-dialog.tsx
@@ -33,9 +33,17 @@ const SEGMENTS: { value: Segment; label: string; icon: IconName }[] = [
 export function ShareCollectionDialog({
   collection,
   onClose,
+  onChanged,
 }: {
-  collection: Collection
+  /** Narrowed to the fields this dialog reads, so both callers fit: the library
+   *  passes a full Collection; the artifact share dialog passes a CollectionGrant
+   *  (its disclosure row's Manage action — see share-dialog.tsx). */
+  collection: Pick<Collection, "id" | "title" | "created_by" | "workspace_access" | "my_role">
   onClose: () => void
+  /** Fired each time a write LANDS (access flip, member add/remove/re-role) — the
+   *  artifact share dialog refetches its disclosure rows from here, never from
+   *  onClose, so an Escape mid-flight can't race the write. */
+  onChanged?: () => void
 }) {
   const [members, setMembers] = useState<ArtifactMember[]>([])
   const [email, setEmail] = useState("")
@@ -46,6 +54,12 @@ export function ShareCollectionDialog({
   // first mutate re-renders. The ref flips synchronously, so only the first gets through.
   const adding = useRef(false)
   const [wsAccess, setWsAccess] = useState<WorkspaceAccess>(collection.workspace_access ?? "member")
+  // Re-seed when the caller hands us a different snapshot of the SAME dialog's
+  // subject — the artifact share dialog's grant refreshes after a write, and a
+  // stale seed here would re-create the exact lie this feature exists to fix.
+  useEffect(() => {
+    setWsAccess(collection.workspace_access ?? "member")
+  }, [collection.workspace_access])
 
   // Unlike an artifact (editors can share — GDocs model), a collection's access
   // and membership routes are owner-only on the backend (same bar as delete —
@@ -75,7 +89,10 @@ export function ShareCollectionDialog({
       setWsAccess(next)
       return () => setWsAccess(prev)
     },
-    onSuccess: (r) => setWsAccess(r.workspace_access),
+    onSuccess: (r) => {
+      setWsAccess(r.workspace_access)
+      onChanged?.()
+    },
   })
   const applyAccess = (next: WorkspaceAccess) => accessMut.mutate(next)
 
@@ -84,6 +101,7 @@ export function ShareCollectionDialog({
     onSuccess: () => {
       setEmail("")
       load()
+      onChanged?.()
     },
   })
   const add = (e: React.FormEvent) => {
@@ -101,7 +119,10 @@ export function ShareCollectionDialog({
 
   const removeMut = useApiMutation({
     mutationFn: (m: ArtifactMember) => api.removeCollectionMember(collection.id, m.user_id),
-    onSuccess: () => load(),
+    onSuccess: () => {
+      load()
+      onChanged?.()
+    },
   })
   const remove = (m: ArtifactMember) => removeMut.mutate(m)
 
@@ -110,7 +131,10 @@ export function ShareCollectionDialog({
     mutationFn: ({ handle, next }: { handle: string; next: Role }) =>
       api.setCollectionMember(collection.id, handle, next),
     success: "Role updated",
-    onSuccess: () => load(),
+    onSuccess: () => {
+      load()
+      onChanged?.()
+    },
   })
   const change = (m: ArtifactMember, next: Role) => {
     if (next === m.role || !m.handle) return

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -474,6 +474,16 @@ export interface CollectionStore {
   removeCollectionItem(collectionId: string, artifactId: string): Promise<void>
   getCollectionMember(collectionId: string, userId: string): Promise<CollectionMemberRecord | null>
   listCollectionMembers(collectionId: string): Promise<CollectionMemberRecord[]>
+  /** Explicit member-row counts for a set of collections in ONE query (id ∈ ids);
+   *  ids with no member rows are absent from the map. Empty ids ⇒ {}. Drives the
+   *  share dialog's collection-disclosure rows ("n collection members"). */
+  collectionMemberCounts(collectionIds: string[]): Promise<Record<string, number>>
+  /** One user's role per collection over a set of collections, in TWO queries
+   *  (explicit member rows + the workspace seat on workspace-open collections,
+   *  higher wins) — the batched face of context.ts's collectionRole for the
+   *  artifact detail's disclosure rows. The caller still folds in created_by
+   *  (permanent owner) and the static token. Ids with no role are absent. */
+  collectionRolesForUser(collectionIds: string[], userId: string): Promise<Record<string, Role>>
   setCollectionMember(m: NewCollectionMember): Promise<CollectionMemberRecord>
   removeCollectionMember(collectionId: string, userId: string): Promise<void>
   /** This user's collection-member roles over collections containing the

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -84,7 +84,7 @@ import type {
   WorkspaceAccess,
   WorkspaceRecord,
 } from "@derive/core"
-import { GLOBAL_FOLLOW_ORG } from "@derive/core"
+import { GLOBAL_FOLLOW_ORG, maxRole } from "@derive/core"
 import {
   and,
   asc,
@@ -1317,6 +1317,15 @@ export class PgMetaStore implements MetaStore {
       .from(collectionMember)
       .where(eq(collectionMember.collection_id, collectionId))
   }
+  async collectionMemberCounts(collectionIds: string[]): Promise<Record<string, number>> {
+    if (collectionIds.length === 0) return {}
+    const rows = await this.db
+      .select({ id: collectionMember.collection_id, c: count() })
+      .from(collectionMember)
+      .where(inArray(collectionMember.collection_id, collectionIds))
+      .groupBy(collectionMember.collection_id)
+    return Object.fromEntries(rows.map((r) => [r.id, Number(r.c)]))
+  }
   async setCollectionMember(m: NewCollectionMember): Promise<CollectionMemberRecord> {
     const rows = await this.db
       .insert(collectionMember)
@@ -1359,6 +1368,37 @@ export class PgMetaStore implements MetaStore {
         ),
       )
     return [...explicit, ...seat].map((r) => r.role)
+  }
+  async collectionRolesForUser(
+    collectionIds: string[],
+    userId: string,
+  ): Promise<Record<string, Role>> {
+    if (collectionIds.length === 0) return {}
+    // Same two sources as collectionRolesForArtifact, keyed per collection: the
+    // user's explicit member rows, and their SEAT on each workspace-open collection.
+    const explicit = await this.db
+      .select({ id: collectionMember.collection_id, role: collectionMember.role })
+      .from(collectionMember)
+      .where(
+        and(
+          inArray(collectionMember.collection_id, collectionIds),
+          eq(collectionMember.user_id, userId),
+        ),
+      )
+    const seat = await this.db
+      .select({ id: collection.id, role: membership.role })
+      .from(collection)
+      .innerJoin(membership, eq(membership.org_id, collection.org_id))
+      .where(
+        and(
+          inArray(collection.id, collectionIds),
+          eq(collection.workspace_access, "member"),
+          eq(membership.user_id, userId),
+        ),
+      )
+    const out: Record<string, Role> = {}
+    for (const r of [...explicit, ...seat]) out[r.id] = maxRole(out[r.id] ?? null, r.role) as Role
+    return out
   }
 
   // ---- GitHub sync sources -----------------------------------------------

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -79,7 +79,7 @@ import type {
   WorkspaceAccess,
   WorkspaceRecord,
 } from "@derive/core"
-import { DEFAULT_ORG_SETTINGS, GLOBAL_FOLLOW_ORG } from "@derive/core"
+import { DEFAULT_ORG_SETTINGS, GLOBAL_FOLLOW_ORG, maxRole } from "@derive/core"
 import {
   and,
   asc,
@@ -1436,6 +1436,18 @@ export function makeRepos(db: SqliteDb) {
       .get()) ?? null
   const listCollectionMembers = async (collectionId: string): Promise<CollectionMemberRecord[]> =>
     db.select().from(collectionMember).where(eq(collectionMember.collection_id, collectionId)).all()
+  const collectionMemberCounts = async (
+    collectionIds: string[],
+  ): Promise<Record<string, number>> => {
+    if (collectionIds.length === 0) return {}
+    const rows = await db
+      .select({ id: collectionMember.collection_id, c: count() })
+      .from(collectionMember)
+      .where(inArray(collectionMember.collection_id, collectionIds))
+      .groupBy(collectionMember.collection_id)
+      .all()
+    return Object.fromEntries(rows.map((r) => [r.id, Number(r.c)]))
+  }
   const setCollectionMember = async (m: NewCollectionMember): Promise<CollectionMemberRecord> =>
     (await db
       .insert(collectionMember)
@@ -1483,6 +1495,39 @@ export function makeRepos(db: SqliteDb) {
       )
       .all()
     return [...explicit, ...seat].map((r) => r.role)
+  }
+  const collectionRolesForUser = async (
+    collectionIds: string[],
+    userId: string,
+  ): Promise<Record<string, Role>> => {
+    if (collectionIds.length === 0) return {}
+    // Same two sources as collectionRolesForArtifact, keyed per collection: the
+    // user's explicit member rows, and their SEAT on each workspace-open collection.
+    const explicit = await db
+      .select({ id: collectionMember.collection_id, role: collectionMember.role })
+      .from(collectionMember)
+      .where(
+        and(
+          inArray(collectionMember.collection_id, collectionIds),
+          eq(collectionMember.user_id, userId),
+        ),
+      )
+      .all()
+    const seat = await db
+      .select({ id: collection.id, role: membership.role })
+      .from(collection)
+      .innerJoin(membership, eq(membership.org_id, collection.org_id))
+      .where(
+        and(
+          inArray(collection.id, collectionIds),
+          eq(collection.workspace_access, "member"),
+          eq(membership.user_id, userId),
+        ),
+      )
+      .all()
+    const out: Record<string, Role> = {}
+    for (const r of [...explicit, ...seat]) out[r.id] = maxRole(out[r.id] ?? null, r.role) as Role
+    return out
   }
 
   // ---- GitHub sync sources -----------------------------------------------
@@ -2463,6 +2508,8 @@ export function makeRepos(db: SqliteDb) {
     setCollectionMember,
     removeCollectionMember,
     collectionRolesForArtifact,
+    collectionRolesForUser,
+    collectionMemberCounts,
     createRepoSource,
     getRepoSource,
     listRepoSources,


### PR DESCRIPTION
## The lie

A fully private artifact inside a workspace-open collection is readable by every workspace seat — `collectionRolesForArtifact` folds the grant into the explicit slot, by design. But the share dialog rendered only the artifact's own three fields: **"Invited · 1 person" on a doc the whole team can open**, lock glyph on the trigger. Found live on a real doc; the backend was right, the UI was lying.

Design doc (reviewed, decisions recorded inline): https://derive.to/artifacts/share-dialog-surfacing-collection-propagated-acc-e1utobve

## What ships

| | |
|---|---|
| **API** | Detail response gains `collection_access` — the collections whose sharing *adds reach*, renderable verbatim. New batched `collectionRolesForUser` (2 queries, both stores); counts + bylines fetched in parallel; anonymous link readers skip the block entirely. |
| **Dialog** | "Reachable through collections" section between access and people: reach subtext per row, **Manage** (opens the existing `ShareCollectionDialog`, stacked) for the collection owner, "Managed by …" attribution for everyone else. Shown to all viewers — disclosure isn't a manager privilege. |
| **Trigger** | `accessIcon`/`accessSummary` fold the collection grant in — the lock only shows when nobody-but-the-roster is actually true. |
| **Freshness** | Refetches ride the writes, never the races: the stacked dialog reports each landed write via `onChanged`; the organize dialog reconciles on settle via `useApiMutation`'s `invalidate`; `onCollections` stays a pure optimistic cache write. The stacked dialog re-seeds from its prop so a refreshed grant can't show pre-change access. |

## Security note

Manager standing for the "owners see every granting collection" rule is computed **without the world link** — a signed-in stranger holding an editor URL gets the doc, never other people's private collections' titles/rosters (same class of caller the members-roster route refuses). Regression-tested.

## Verification

- API: 4 new tests in `collection-access.test.ts` (per-viewer roles, cross-owner disclosure, link-holder leak guard, solo-collection reach contract) — 838 total green
- Web: `accessIcon`/`accessSummary` unit tests; full suite green
- E2E: new `share-collection-disclosure.deep.spec.ts` drives the whole flow in a real browser — lock baseline, disclosure row + honest glyph, stacked Manage, live row removal on access flip, seat-only member attribution
- Multi-agent adversarial review at high effort: 8 findings, all fixed in this diff (privacy leak, server-side reach contract, 3 race/staleness bugs, count copy, 2 hot-path efficiency)