### PR TITLE
fix(web): a failed comment offers a Retry that recovers the text, never eats it

### DIFF
--- a/apps/web/e2e/smoke/artifact.smoke.spec.ts
+++ b/apps/web/e2e/smoke/artifact.smoke.spec.ts
@@ -19,3 +19,38 @@ test("publish, open, comment, and resolve", async ({ owner }) => {
   await owner.getByTestId("comment-resolve").click()
   await expect(owner.getByText(/Resolved \(\d+\)/)).toBeVisible()
 })
+
+// A failed comment post must be RECOVERABLE, not silently lost. The optimistic row rolls
+// back, but a Retry toast re-sends the exact text — the rejected mutation still holds it.
+// (Regression guard for the text-loss this replaced, found by driving the loop under an
+// injected 500: submitNew closes the composer optimistically, so a blip used to eat the draft.)
+test("a failed comment offers a Retry that recovers the text", async ({ owner }) => {
+  const shortId = await publishArtifact(owner)
+  await openArtifact(owner, shortId)
+
+  // Fail only the FIRST create-POST; let the Retry through.
+  let failNext = true
+  await owner.route(
+    (url) => url.pathname === `/v1/artifacts/${shortId}/comments`,
+    (route) => {
+      if (route.request().method() === "POST" && failNext) {
+        failNext = false
+        return route.fulfill({ status: 500, contentType: "application/json", body: "{}" })
+      }
+      return route.continue()
+    },
+  )
+
+  const body = "Don't lose this to a blip."
+  await owner.getByTestId("comment-new").click()
+  await owner.getByTestId("composer-input").fill(body)
+  await owner.getByTestId("composer-submit").click()
+
+  // The optimistic row rolled back; the Retry toast is the recovery path.
+  const retry = owner.getByRole("button", { name: "Retry" })
+  await expect(retry).toBeVisible()
+  await retry.click()
+
+  // One tap re-sends the exact comment — it lands for real.
+  await expect(owner.getByText(body)).toBeVisible()
+})

--- a/apps/web/src/lib/use-api-mutation.ts
+++ b/apps/web/src/lib/use-api-mutation.ts
@@ -34,6 +34,10 @@ export function useApiMutation<TData = unknown, TVars = void>(config: {
   pendingKey?: (vars: TVars) => string
   /** Extra success side-effect (navigate, close a dialog) once the write lands. */
   onSuccess?: (data: TData, vars: TVars) => void
+  /** Extra failure side-effect (offer a retry, restore a draft) once the write rejects —
+   *  runs AFTER the optimistic rollback. The symmetric counterpart to onSuccess; the error
+   *  toast stays the MutationCache's job (honoring meta.errorToast), so don't toast here. */
+  onError?: (err: Error, vars: TVars) => void
 }) {
   const qc = useQueryClient()
   // Keys with an in-flight mutation — per-call so one row's toggle doesn't disable
@@ -57,10 +61,12 @@ export function useApiMutation<TData = unknown, TVars = void>(config: {
       const rollback = config.optimistic?.(vars, qc)
       return { rollback, pendingKey }
     },
-    onError: (_err, _vars, ctx) => {
-      // Undo the optimistic edit. The TOAST is the MutationCache's job (it honors
-      // meta.errorToast), so toasting here too would double up.
+    onError: (err, vars, ctx) => {
+      // Undo the optimistic edit first, then run any caller failure side-effect. The TOAST
+      // is the MutationCache's job (it honors meta.errorToast), so toasting here too would
+      // double up.
       ctx?.rollback?.()
+      config.onError?.(err, vars)
     },
     onSuccess: (data, vars) => {
       const msg = typeof config.success === "function" ? config.success(data, vars) : config.success

--- a/apps/web/src/pages/artifact/artifact-actions.ts
+++ b/apps/web/src/pages/artifact/artifact-actions.ts
@@ -146,6 +146,16 @@ export function useArtifactActions(p: {
       )
       refetchComments()
     },
+    // A failed post rolls the optimistic row back — and the just-typed text would vanish with
+    // it, leaving only a generic toast and a retype. Opt out of that toast and raise one that
+    // carries a Retry: the rejected vars still hold the exact text, mentions, and anchor, so a
+    // single tap re-sends it. (submitNew closes the composer optimistically, so the draft only
+    // lives here now.)
+    errorToast: false,
+    onError: (_err, vars) =>
+      toast.error("Couldn't post your comment. Check your connection and try again.", {
+        action: { label: "Retry", onClick: () => comment.mutate(vars) },
+      }),
   })
   const addComment = (
     text: string,


### PR DESCRIPTION
## What

Drove the **core artifact loop** (open → comment → resolve → publish) under a hostile network — injected latency and failure with `route()` and *watched* each frame. One clear defect surfaced; two other paths I drove and cleared as sound.

## The defect: a failed comment silently eats your text

`submitNew` closes the composer optimistically (the send feels instant — deliberate, and good). But when the create-POST fails, the optimistic row rolls back and **the just-typed text is gone** — the user gets a generic toast and has to retype from scratch. Invisible to typecheck/guards; it only shows when you actually make the post fail.

**Before → after** (comment POST returns 500):

| | Before | After |
|---|---|---|
| Signal | generic toast (`"boom"` / raw server msg) | `"Couldn't post your comment. Check your connection and try again."` |
| Recovery | none — retype it | **Retry** button → one tap re-sends the exact text |

The rejected mutation's `vars` still hold the exact **text, mentions, and anchor**, so the Retry re-sends losslessly.

## The fix (2 files + a test)

- **`use-api-mutation.ts`** — add the symmetric **`onError`** seam the primitive was missing (the failure-side counterpart to the existing `onSuccess`). Runs *after* the optimistic rollback; the error toast stays the MutationCache's job.
- **`artifact-actions.ts`** — the create-comment mutation opts out of the generic toast (`errorToast: false`) and raises one carrying a Retry that re-sends the failed `vars`.
- **`artifact.smoke.spec.ts`** — regression guard: fail the first POST, assert the Retry recovers the exact text.

Deliberately *not* the reopen-the-composer approach (would spread `draft`/`mentions`/anchor state across 3 render sites with anchored-position edge cases — disproportionate for a rare transient failure). One-tap Retry recovers the work with far less surface.

## Drove and cleared as sound

- **Slow send** — the optimistic row appears instantly and *dims* (`opacity-60`) as a "sending" cue, then solidifies. Good.
- **Artifact load error** — a clean `"Couldn't load this artifact … Try again"` that fully recovers on retry. It takes ~15s of retry-backoff (3 retries, exp) to appear — the deliberate resilience tradeoff, left as is.

## Verification

Driven and *watched* (before/after screenshots of the toast + recovery). **smoke 10/10** (incl. the new guard) · typecheck 0 · biome · mutation guard ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
