### PR TITLE
feat(web): a global progress bar makes the SPA's background fetching legible

### DIFF
--- a/apps/web/src/components/chrome/global-progress.tsx
+++ b/apps/web/src/components/chrome/global-progress.tsx
@@ -1,0 +1,34 @@
+import { useIsFetching } from "@tanstack/react-query"
+import { useRouterState } from "@tanstack/react-router"
+import { useDelayedPending } from "@/lib/use-delayed-pending"
+import { cn } from "@/lib/utils"
+
+// The ONE global "something is loading" cue. The app serves cached data instantly and
+// refetches in the background (router.tsx: "React Query owns staleness"), so a refresh or a
+// stale-tab switch shows old data with NO skeleton — which reads as "nothing's happening"
+// even while the truth is in flight. This thin top bar makes every background fetch AND cold
+// nav legible app-wide, in one mount, so cached-and-refreshing never looks identical to
+// settled. Gated by the shared PENDING timing (useDelayedPending): a cache-warm resolve under
+// ~150ms flashes nothing, and once shown it holds long enough not to strobe.
+export function GlobalProgress() {
+  // Any query in flight (background refetch, prefetch, first load) OR a route transition
+  // whose loader hasn't resolved. Either one means "the view you see may not be settled".
+  const fetching = useIsFetching()
+  const navigating = useRouterState({ select: (s) => s.status === "pending" })
+  const busy = useDelayedPending(fetching > 0 || navigating)
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "pointer-events-none fixed inset-x-0 top-0 z-100 h-0.5 overflow-hidden transition-opacity duration-300",
+        busy ? "opacity-100" : "opacity-0",
+      )}
+    >
+      {/* Faint full-width track — the static fallback that stays legible under reduced motion,
+          where the sweep segment below freezes off-screen. */}
+      <div className="h-full w-full bg-primary/20" />
+      {/* The bright sweep segment riding over the track. */}
+      <div className="absolute inset-y-0 left-0 w-1/3 animate-progress bg-primary" />
+    </div>
+  )
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -11,6 +11,7 @@ import { type ReactNode, useEffect, useState } from "react"
 import { AgentPushListener } from "../components/chrome/agent-push"
 import { AppShell } from "../components/chrome/app-shell"
 import { BootShell } from "../components/chrome/boot-shell"
+import { GlobalProgress } from "../components/chrome/global-progress"
 import { Toaster } from "../components/ui/sonner"
 import { AuthProvider, CursorPrefProvider, ThemeProvider } from "../ctx"
 import { CHROMELESS_EXACT, CHROMELESS_PREFIX, isChromelessPath } from "../lib/chrome-routes"
@@ -91,6 +92,10 @@ function RootComponent() {
                 inside the router tree for navigation. */}
             <AgentPushListener />
           </AuthProvider>
+          {/* One app-wide loading cue for the SPA's stale-while-revalidate model: makes
+              every background refetch + cold nav legible, so cached data being refreshed
+              never looks identical to settled data. */}
+          <GlobalProgress />
           {/* Inside ThemeProvider so sonner's useTheme() tracks the app's forced
               theme rather than falling back to the OS preference. */}
           <Toaster />

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -391,6 +391,22 @@
   animation: derive-skeleton-breath 1.6s ease-in-out infinite;
 }
 
+/* Indeterminate top-progress sweep — the global "something is loading" cue (GlobalProgress).
+   A 1/3-width segment sweeps across a faint full-width track. Under prefers-reduced-motion the
+   sweep freezes off-screen (the global reduce block below), leaving just the static faint track
+   — still a legible, non-animated "busy" line. */
+@keyframes derive-progress-sweep {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(300%);
+  }
+}
+@utility animate-progress {
+  animation: derive-progress-sweep 1.1s ease-in-out infinite;
+}
+
 /* Honor prefers-reduced-motion (unlayered → wins over utilities without !important). */
 @media (prefers-reduced-motion: reduce) {
   *,


### PR DESCRIPTION
## The decision behind this

The "weird rendering on refresh vs nav" is **not Vite** — it's that the app is **TanStack Start in SPA mode** (`spa: { enabled: true }`, "No SSR, no server runtime — static bundle for any CDN"). `router.tsx` hands loading to React Query: *"React Query owns staleness."* Cached data paints instantly and refetches in the background, so a refresh or a stale-tab switch shows old data with **no skeleton** — which reads as "nothing's happening."

The evidence: **27 surfaces gate on `isPending`** (false whenever there's cached/placeholder data); only ~2 surface the refetching state. So background refreshes were **invisible**.

Full Next.js-parity (a refresh returning a rendered page) needs SSR — a server runtime, server-side auth, SSR-through-the-Hono-API. For an **auth-walled, self-hostable, static-CDN** app, that's the wrong trade (no SEO payoff behind login; it undoes the "self-host as static files" strength; permanent tax on a small team). So the direction is **a consistent loading contract in the SPA**, not an SSR migration.

## This PR — piece 1 of the contract

One global cue that makes background fetching legible **app-wide, in one mount**: a thin top progress bar driven by `useIsFetching()` + the router's nav-pending status, gated through the shared `PENDING` timing (`useDelayedPending`) so a cache-warm resolve under ~150ms flashes nothing and it never strobes. Indeterminate ink sweep; degrades to a static faint bar under `prefers-reduced-motion`.

3 files, additive, zero per-page changes.

## Verification

Driven: the bar shows on a slowed feed fetch and clears when settled (screenshots in-thread). **smoke 11/11** · typecheck 0 · biome.

## Status: holding merge for design sign-off

It's an app-wide visual change on a design-conscious product — I don't want to merge it without you seeing the look/behavior first. Tune-ables: thickness (currently 2px), whether to fire on intent-prefetch, the sweep speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
