### PR TITLE
feat(web): a round of UI polish (theme, focus, live updates, push hygiene)

### DIFF
--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -1429,6 +1429,11 @@ function buildServer(
         let openedInTab = false
         if (actingFor) {
           const channel = `u:${actingFor.id}`
+          // Same service flag as the /v1 publish path: a context-bound agent's
+          // push is routinely someone ELSE's ask — the client toasts instead of
+          // auto-opening the owner's tab.
+          const contexts = await ctx.meta.listContexts(artifact.org_id)
+          const service = contexts.some((x) => x.agent_id === agent.id)
           const pushed = {
             type: "artifact.pushed" as const,
             event_id: newId("ev"),
@@ -1440,6 +1445,7 @@ function buildServer(
             url,
             agent: agent.name,
             review_requested: !!review_round,
+            service,
           }
           if (ctx.bus.publishWithReceipt) {
             openedInTab =

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -790,6 +790,12 @@ export const artifactRoutes = (ctx: AppContext) => {
             notification: { ...row, read: 0, created_at: new Date().toISOString() },
           })
         }
+        // A context-bound agent is an askable service: its publishes are routinely
+        // OTHER people's asks riding this owner's grant, so the push must not
+        // commandeer the owner's browser. Flag it — the client downgrades
+        // auto-open to a toast (the bell row above still lands).
+        const contexts = await meta.listContexts(artifact.org_id)
+        const service = contexts.some((x) => x.agent_id === agentPrincipal.id)
         const pushed = {
           type: "artifact.pushed" as const,
           event_id: newId("ev"),
@@ -801,6 +807,7 @@ export const artifactRoutes = (ctx: AppContext) => {
           url: artifactUrl(deps.baseUrl, artifact),
           agent: agentPrincipal.name,
           review_requested: roundCreated,
+          service,
         }
         if (bus.publishWithReceipt) {
           openedInTab = await Promise.race([

--- a/apps/web/e2e/deep/artifact.deep.spec.ts
+++ b/apps/web/e2e/deep/artifact.deep.spec.ts
@@ -105,3 +105,34 @@ test("add a tag from the header", async ({ page }) => {
   await page.getByTestId("tag-add").click()
   await expect(page.getByText("#design")).toBeVisible()
 })
+
+test("focus mode removes the shell entirely and restores it on exit", async ({ page }) => {
+  const rail = page.locator('[data-slot="sidebar"]').first()
+  await expect(rail).toBeVisible()
+
+  // Enter via the ⋯ menu: the nav rail unmounts (fully gone, not the icon strip)
+  // and the workbench header hides — the render is the whole viewport.
+  await page.getByTestId("artifact-more").click()
+  await page.getByTestId("artifact-focus").click()
+  await expect(rail).toHaveCount(0)
+  await expect(page.getByTestId("artifact-more")).not.toBeVisible()
+
+  // Esc exits; the rail and header come back.
+  await page.keyboard.press("Escape")
+  await expect(page.locator('[data-slot="sidebar"]').first()).toBeVisible()
+  await expect(page.getByTestId("artifact-more")).toBeVisible()
+})
+
+test("typing c in the source editor never toggles the comments panel", async ({ page }) => {
+  // The desktop panel starts open (its empty state shows on a fresh doc).
+  const panelEmpty = page.getByText("Start the conversation.")
+  await expect(panelEmpty).toBeVisible()
+
+  // The source editor is contentEditable (CodeMirror) — the regression was a
+  // mid-sentence "c" collapsing the panel out from under the typist.
+  await page.getByTestId("artifact-more").click()
+  await page.getByTestId("artifact-edit").click()
+  await page.locator(".cm-content").click()
+  await page.keyboard.type("once section c")
+  await expect(panelEmpty).toBeVisible()
+})

--- a/apps/web/e2e/deep/auth.deep.spec.ts
+++ b/apps/web/e2e/deep/auth.deep.spec.ts
@@ -27,3 +27,14 @@ test("creating an account signs in and leaves the login page", async ({ page }) 
   await signUp(page) // drives login-toggle / login-name / login-email / login-password / login-submit
   await expect(page).not.toHaveURL(/\/login/)
 })
+
+test("password managers are invited on credentials and suppressed elsewhere", async ({ page }) => {
+  // Credential fields declare autocomplete/type and must NOT carry the ignore
+  // attr — 1Password filling your login is the point.
+  await page.goto("/login")
+  await expect(page.getByTestId("login-email")).not.toHaveAttribute("data-1p-ignore")
+
+  // Any other field (here: the library filter) suppresses the manager popup.
+  await signUp(page)
+  await expect(page.getByTestId("library-search")).toHaveAttribute("data-1p-ignore", "true")
+})

--- a/apps/web/e2e/deep/chrome.deep.spec.ts
+++ b/apps/web/e2e/deep/chrome.deep.spec.ts
@@ -18,6 +18,21 @@ test("the user menu switches between themes and the choice persists", async ({ o
   await expect(html).toHaveClass(/dark/)
 })
 
+test("the System theme follows the OS preference, live", async ({ owner }) => {
+  const html = owner.locator("html")
+  await owner.emulateMedia({ colorScheme: "dark" })
+  await owner.getByTestId("user-menu-trigger").click()
+  await owner.getByTestId("theme-option-system").click()
+  await expect(html).toHaveClass(/dark/)
+  // Flipping the OS preference retints the app without a reload (next-themes'
+  // media-query listener) — and the resolved theme survives one, via the
+  // pre-paint boot script's matchMedia fallback.
+  await owner.emulateMedia({ colorScheme: "light" })
+  await expect(html).toHaveClass(/light/)
+  await owner.reload()
+  await expect(html).toHaveClass(/light/)
+})
+
 test("the notification bell opens an empty panel", async ({ owner }) => {
   await owner.getByTestId("notif-bell").click()
   // Scoped to the popover: the bell row on the rail also carries a "Notifications"

--- a/apps/web/e2e/deep/mcp-loop.deep.spec.ts
+++ b/apps/web/e2e/deep/mcp-loop.deep.spec.ts
@@ -1,7 +1,7 @@
 import { Buffer } from "node:buffer"
 import type { APIRequestContext } from "@playwright/test"
 import { STORAGE_KEYS } from "../../src/lib/storage-keys"
-import { expect, test } from "../fixtures"
+import { expect, publishArtifact, test } from "../fixtures"
 
 // The strong MCP loop, browser side: an agent-credentialed publish auto-opens the
 // owner's tab (a created artifact navigates; a revision live-reloads with the review
@@ -131,4 +131,51 @@ test.describe("the MCP loop — auto-open, live rounds, private drafts", () => {
     await owner.getByTestId("library-tab-mine").click()
     await expect(owner.getByText("Hidden Draft").first()).toBeVisible()
   })
+})
+
+test("a live version bump repaints in place and announces itself", async ({ owner }) => {
+  const agent = await createAgent(owner.request, "Bump Bot")
+  const created = await agentPublish(owner.request, agent.token, {
+    title: "Live Doc",
+    content: "<h1>one</h1>",
+  })
+  await owner.goto(`/artifacts/${created.short_id}`)
+  await expect(owner.frameLocator("iframe").locator("h1")).toHaveText("one")
+
+  // A revision published elsewhere lands live: the quiet toast names the version
+  // (the cue that the repaint is an update, not a glitch) and the render swaps.
+  await agentPublish(owner.request, agent.token, {
+    content: "<h1>two</h1>",
+    shortId: created.short_id,
+  })
+  await expect(owner.getByText("Updated to v2.")).toBeVisible({ timeout: 10_000 })
+  await expect(owner.frameLocator("iframe").locator("h1")).toHaveText("two", { timeout: 10_000 })
+})
+
+test("a context-bound agent's publish toasts instead of commandeering the tab", async ({
+  owner,
+}) => {
+  // Bind the agent to a context — it's now an askable service, and its publishes
+  // may be answering someone ELSE's ask on the owner's grant.
+  const agent = await createAgent(owner.request, "Service Bot")
+  const manifestShortId = await publishArtifact(owner, "Service manifest", "# m")
+  const ctxRes = await owner.request.post("/v1/contexts", {
+    data: { name: "Service Desk", agent_id: agent.id, manifest_short_id: manifestShortId },
+  })
+  expect(ctxRes.ok(), `create context failed: ${ctxRes.status()}`).toBeTruthy()
+
+  await owner.goto("/")
+  // Give the per-user stream a beat to attach (mirrors the auto-open spec above) —
+  // the toast only rides the live event.
+  await owner.waitForTimeout(1000)
+  await agentPublish(owner.request, agent.token, {
+    title: "Someone Else's Answer",
+    content: "<h1>answer</h1>",
+  })
+
+  // The cue arrives as a toast with an Open action — the tab stays put.
+  await expect(owner.getByText(/published “Someone Else's Answer”/)).toBeVisible({
+    timeout: 10_000,
+  })
+  await expect(owner).toHaveURL(/\/$/)
 })

--- a/apps/web/src/components/chrome/agent-push.tsx
+++ b/apps/web/src/components/chrome/agent-push.tsx
@@ -13,7 +13,9 @@ import { parseRef, refFor } from "@/pages/artifact/parse-ref"
 // publishes (the server emits `artifact.pushed` on your user channel, only ever
 // to the granting owner), a newly created artifact opens right here; a revision
 // you're already viewing live-reloads via the artifact channel, and anything
-// else offers a toast. Renders nothing; mounted once in the root.
+// else offers a toast. A `service` push (a context-bound agent — often answering
+// someone ELSE's ask on your grant) never navigates, only toasts. Renders
+// nothing; mounted once in the root.
 //
 // The live path only reaches a VISIBLE tab (the stream closes while hidden, on
 // purpose — an idle tab shouldn't keep the per-user room billed active). So a
@@ -31,6 +33,10 @@ interface PushedEvent {
   version: number
   kind: "created" | "revised"
   agent: string
+  /** The agent is bound to a context (an askable service) — its publishes are
+   *  routinely OTHER people's asks riding this owner's grant, so they must
+   *  never commandeer the browser. Downgraded to a toast. */
+  service?: boolean
 }
 
 // Never act twice on one push: SSE reconnect replay, StrictMode double-fires,
@@ -82,6 +88,10 @@ export function AgentPushListener() {
       kind: "created" | "revised",
       agent: string,
       version?: number,
+      // Whether this push may navigate at all. False for a service (context-bound)
+      // agent — its publishes are often someone ELSE's ask — and for the refocus
+      // catch-up below, whose notification rows can't prove the push was yours.
+      mayNavigate = true,
     ) => {
       if (seen.has(id)) return
       remember(id)
@@ -97,7 +107,7 @@ export function AgentPushListener() {
       const open = () => nav({ to: "/artifacts/$ref", params: { ref } })
       const autoOpen = localStorage.getItem(STORAGE_KEYS.autoOpen) !== "off"
       const blocked = !!document.querySelector('[role="dialog"][data-state="open"]')
-      if (kind === "created" && autoOpen && !blocked && !inputHeld()) {
+      if (mayNavigate && kind === "created" && autoOpen && !blocked && !inputHeld()) {
         open()
         return
       }
@@ -127,6 +137,7 @@ export function AgentPushListener() {
         p.kind,
         p.agent,
         p.version,
+        !p.service,
       )
     },
     !!me && visible,
@@ -135,15 +146,12 @@ export function AgentPushListener() {
   // Regaining visibility: fetch the notification feed and catch up on the
   // single newest thing we missed while hidden — bounded to the last few
   // minutes and to unread rows, so reopening a tab from yesterday doesn't
-  // dredge up old pushes. Treated as "created" (always eligible to navigate)
-  // regardless of whether the underlying push was actually a create or a
-  // revision: the live path only withholds navigation to avoid interrupting
-  // active reading, which doesn't apply here — nothing was on screen to
-  // interrupt while the tab was hidden. Only the newest missed one navigates —
-  // several unread rows in the window would otherwise each fire their own
-  // `nav()`, and the LAST one processed wins the final URL, landing you on the
-  // oldest of the batch instead of the most recent. The bell still lists the
-  // rest for you to catch up on manually.
+  // dredge up old pushes. NEVER navigates, only toasts: publish/review rows in
+  // the feed also cover follower fan-outs, teammates' review asks, and a
+  // context agent answering someone else's ask — a feed row can't prove the
+  // push was yours, and commandeering a tab the user just returned to (they
+  // came back to do something) is exactly the wrong moment. The toast's Open
+  // action is the one-click recovery; the bell lists the rest.
   useEffect(() => {
     if (!me || !visible || wasVisible.current) {
       wasVisible.current = visible
@@ -167,6 +175,8 @@ export function AgentPushListener() {
             missed.artifact_title,
             "created",
             missed.actor,
+            undefined,
+            false,
           )
       })
       .catch(() => {})

--- a/apps/web/src/components/chrome/app-shell.tsx
+++ b/apps/web/src/components/chrome/app-shell.tsx
@@ -59,6 +59,9 @@ export function AppShell({ children }: { children: ReactNode }) {
   }
 
   const [paletteOpen, setPaletteOpen] = useState(false)
+  // Immersive (the artifact's focus mode): the rail + mobile top bar unmount and
+  // the inset mat drops (see ShellValue.immersive). Ephemeral — never persisted.
+  const [immersive, setImmersive] = useState(false)
   const qc = useQueryClient()
   // Workspaces power the switcher's no-op check below; the rail + command palette
   // read their own copies of the nav queries (deduped by key). enabled on a
@@ -162,6 +165,8 @@ export function AppShell({ children }: { children: ReactNode }) {
   const value: ShellValue = {
     paletteOpen,
     setPaletteOpen,
+    immersive,
+    setImmersive,
     switchWorkspace,
     createWorkspace,
     deleteWorkspace,
@@ -214,7 +219,11 @@ export function AppShell({ children }: { children: ReactNode }) {
           >
             Skip to content
           </a>
-          <NavRail />
+          {/* Immersive (focus mode) unmounts the rail rather than collapsing it —
+              with no sidebar peer, SidebarInset's mat (margins/rounding/ring) drops
+              too, so the page runs edge-to-edge. The rail's open state lives above
+              in this component, so it survives and restores untouched on exit. */}
+          {!immersive && <NavRail />}
           {/* The page region. Viewport-locked scroll model: the inset never
               scrolls itself (overflow-hidden); pages own their scroll areas
               (library virtualizer, artifact iframe). */}
@@ -227,7 +236,7 @@ export function AppShell({ children }: { children: ReactNode }) {
                 sticky bar answers "where am I" (current-page label) and keeps
                 navigation + search reachable mid-scroll. Desktop has no top bar
                 at all — the sidebar is the only persistent chrome. */}
-            {isMobile && (
+            {isMobile && !immersive && (
               <MobileTopBar pathname={pathname} onOpenPalette={() => setPaletteOpen(true)} />
             )}
             {children}

--- a/apps/web/src/components/chrome/boot-shell.tsx
+++ b/apps/web/src/components/chrome/boot-shell.tsx
@@ -9,6 +9,8 @@ import { ShellCtx, type ShellValue } from "./shell-context"
 const NOOP_SHELL: ShellValue = {
   paletteOpen: false,
   setPaletteOpen: () => {},
+  immersive: false,
+  setImmersive: () => {},
   switchWorkspace: () => {},
   createWorkspace: () => Promise.resolve(),
   deleteWorkspace: () => {},

--- a/apps/web/src/components/chrome/shell-context.ts
+++ b/apps/web/src/components/chrome/shell-context.ts
@@ -10,6 +10,13 @@ import { createContext, useContext } from "react"
 export interface ShellValue {
   paletteOpen: boolean
   setPaletteOpen: (open: boolean) => void
+  /** Immersive page state (the artifact's focus mode): the shell unmounts the nav
+   *  rail and mobile top bar entirely — not the icon-strip collapse — and, with no
+   *  sidebar peer, the inset mat drops so the page runs edge-to-edge. Page-scoped:
+   *  the setter is called on enter/exit and cleaned up on unmount, and the rail's
+   *  own open/collapsed preference is never touched. */
+  immersive: boolean
+  setImmersive: (on: boolean) => void
   switchWorkspace: (id: string) => void
   /** Create + switch; optional invite emails go out before the reload (one flow —
    *  naming a workspace and bringing the team are the same gesture). */

--- a/apps/web/src/components/chrome/theme-switch.tsx
+++ b/apps/web/src/components/chrome/theme-switch.tsx
@@ -2,7 +2,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { THEMES, useTheme } from "@/ctx"
 import { cn } from "@/lib/utils"
 
-// Segmented theme control: Light | Dark. Built on the shadcn Tabs primitive
+// Segmented theme control: Light | Dark | System. Built on the shadcn Tabs primitive
 // (radix-backed, so roles + keyboard nav come for free) at the compact `sm`
 // list size — no per-call-site size surgery. Lives in the account pod.
 // Keeps the `theme-option-<id>` test-ids the e2e net expects.

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -2,11 +2,32 @@ import type * as React from "react"
 
 import { cn } from "@/lib/utils"
 
+// Password managers (1Password, LastPass, Bitwarden, Dashlane) decorate any field
+// that smells like a login — email-shaped inputs, name fields, the invite box —
+// with their fill popup, which is noise everywhere except real credential fields.
+// So every Input opts OUT by default via the vendor ignore attributes, EXCEPT
+// fields that declare themselves credential-shaped: a password input, or an
+// autocomplete token managers legitimately fill (login identifiers, OTP,
+// passkeys, identity). Declare `autoComplete` to invite the manager in; the
+// ignore attrs also stay overridable per call site (they spread before props).
+const FILLABLE_AUTOCOMPLETE =
+  /(?:^|\s)(username|email|name|current-password|new-password|one-time-code|webauthn)(?:\s|$)/
+const pwManagerIgnore = (type?: string, autoComplete?: string) =>
+  type === "password" || (autoComplete && FILLABLE_AUTOCOMPLETE.test(autoComplete))
+    ? undefined
+    : ({
+        "data-1p-ignore": "true",
+        "data-lpignore": "true",
+        "data-bwignore": "true",
+        "data-form-type": "other",
+      } as const)
+
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
     <input
       type={type}
       data-slot="input"
+      {...pwManagerIgnore(type, props.autoComplete)}
       className={cn(
         // Quiet well: hairline border-input; transparent on light (the themed shadow
         // var adds depth there and zeroes in dark, where the well fill does the work).

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -6,6 +6,12 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (
     <textarea
       data-slot="textarea"
+      // No textarea hosts credentials — password managers stay out unconditionally
+      // (the same vendor ignore set as ui/input; see the rationale there).
+      data-1p-ignore="true"
+      data-lpignore="true"
+      data-bwignore="true"
+      data-form-type="other"
       className={cn(
         // Quiet well: hairline border-input; transparent on light (the themed shadow
         // var adds depth there and zeroes in dark, where the well fill does the work).

--- a/apps/web/src/ctx.tsx
+++ b/apps/web/src/ctx.tsx
@@ -49,15 +49,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 export const THEMES = [
   { id: "light", label: "Light" },
   { id: "dark", label: "Dark" },
+  { id: "system", label: "System" },
 ] as const
 
 // next-themes owns the theme: it toggles the `.dark`/`.light` class the shadcn tokens
 // key off, persists to STORAGE_KEYS.theme, and — with the head boot script in
-// __root — paints the right theme before hydration. Stock <Toaster/> (sonner) reads
-// this same next-themes context, so it follows the app with zero derive glue.
+// __root — paints the right theme before hydration. "system" (the default) follows
+// the OS preference live via next-themes' media-query listener. Stock <Toaster/>
+// (sonner) reads this same next-themes context, so it follows the app with zero
+// derive glue.
 export function useTheme() {
   const { theme, setTheme } = useNextTheme()
-  return { theme: theme ?? "dark", setTheme }
+  return { theme: theme ?? "system", setTheme }
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
@@ -65,8 +68,8 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     <NextThemesProvider
       attribute="class"
       themes={["light", "dark"]}
-      defaultTheme="dark"
-      enableSystem={false}
+      defaultTheme="system"
+      enableSystem
       storageKey={STORAGE_KEYS.theme}
       disableTransitionOnChange
     >

--- a/apps/web/src/lib/use-document-title.ts
+++ b/apps/web/src/lib/use-document-title.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react"
+
+// The prerendered shell and the root route's head both title the tab "Derive".
+const BASE_TITLE = "Derive"
+
+/**
+ * Title the browser tab "<name> · Derive" while mounted; pass a falsy name
+ * (still loading, not found) to leave the base title in place.
+ *
+ * Set imperatively rather than via a route head() because the data lives in the
+ * query cache, not loader data — the tab tracks client-side loads the best-effort
+ * loader missed, and renames. The unmount restore is load-bearing: HeadContent
+ * only rewrites <title> when its own vdom changes, so a manual document.title
+ * would otherwise outlive the page it named.
+ */
+export function useDocumentTitle(name: string | null | undefined) {
+  useEffect(() => {
+    if (!name) return
+    document.title = `${name} · Derive`
+    return () => {
+      document.title = BASE_TITLE
+    }
+  }, [name])
+}

--- a/apps/web/src/pages/artifact/comment-composer.tsx
+++ b/apps/web/src/pages/artifact/comment-composer.tsx
@@ -264,10 +264,23 @@ export function MentionField({
             ),
           )}
         </div>
+        {/* Raw elements (the mention backdrop needs them), so they carry the
+            password-manager ignore set themselves — see ui/input for why. */}
         {multiline ? (
-          <textarea {...handlers} className={fieldClass} />
+          <textarea
+            {...handlers}
+            data-1p-ignore="true"
+            data-lpignore="true"
+            className={fieldClass}
+          />
         ) : (
-          <input {...handlers} className={fieldClass} onClick={(e) => e.stopPropagation()} />
+          <input
+            {...handlers}
+            data-1p-ignore="true"
+            data-lpignore="true"
+            className={fieldClass}
+            onClick={(e) => e.stopPropagation()}
+          />
         )}
       </div>
 

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -3,14 +3,16 @@ import { useNavigate, useParams } from "@tanstack/react-router"
 import { Minimize2 } from "lucide-react"
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react"
 import { API_BASE, ApiError, api } from "@/api"
+import { useShell } from "@/components/chrome/shell-context"
 import { Icon } from "@/components/icons"
 import { Kbd } from "@/components/ui/kbd"
-import { useSidebar } from "@/components/ui/sidebar"
+import { toast } from "@/components/ui/sonner"
 import { useAuth } from "@/ctx"
 import { artifactTypeLabel } from "@/lib/artifact"
 import { artifactAgentsQuery, artifactQuery, commentsQuery } from "@/lib/queries"
 import { ago } from "@/lib/time"
 import { snapshot, useApiMutation } from "@/lib/use-api-mutation"
+import { useDocumentTitle } from "@/lib/use-document-title"
 import { useIsMobile } from "@/lib/use-is-mobile"
 import { cn } from "@/lib/utils"
 import { useArtifactActions } from "./artifact-actions"
@@ -73,21 +75,18 @@ function DocFab({
   )
 }
 
-// Focus mode also collapses the app nav rail (the render is the hero — the rail is
-// the shell's, not the page's, so this authed-only helper drives it through the
-// sidebar context). Restores the viewer's prior rail state on exit.
-function FocusRailSync({ focus }: { focus: boolean }) {
-  const { open, setOpen } = useSidebar()
-  const prior = useRef(open)
-  // biome-ignore lint/correctness/useExhaustiveDependencies: react to focus flips only, not rail toggles.
+// Focus mode is immersive: the shell unmounts the nav rail (and mobile top bar)
+// entirely and the inset mat drops, so the render runs edge-to-edge — not the old
+// icon-strip collapse that left a 3rem rail beside "focus". The rail is the
+// shell's, not the page's, so this authed-only helper drives it through the shell
+// context; the cleanup restores the chrome if the page unmounts mid-focus, and the
+// rail's own open/collapsed preference is never touched.
+function FocusShellSync({ focus }: { focus: boolean }) {
+  const { setImmersive } = useShell()
   useEffect(() => {
-    if (focus) {
-      prior.current = open
-      setOpen(false)
-    } else if (prior.current) {
-      setOpen(true)
-    }
-  }, [focus])
+    setImmersive(focus)
+    return () => setImmersive(false)
+  }, [focus, setImmersive])
   return null
 }
 
@@ -104,6 +103,8 @@ export function Artifact() {
   // the SSE live updates below write through the same client.
   const qc = useQueryClient()
   const { data: art, isError: failed, error, refetch } = useQuery(artifactQuery(shortId))
+  // The tab is named after the document, like the workbench header (title, else id).
+  useDocumentTitle(art ? (art.title ?? shortId) : null)
   const { data: comments = [] } = useQuery(commentsQuery(shortId))
   // Agents this viewer can hand a revision to (the "ask an agent" flow). Empty for
   // an anon viewer (the query is authed) or a workspace with no agents — then the
@@ -162,10 +163,47 @@ export function Artifact() {
   const [reviewTick, setReviewTick] = useState(0)
   const onReview = useCallback(() => setReviewTick((t) => t + 1), [])
 
+  // A version published while we're LOOKING refetches (the unpinned render swaps
+  // in place) and gets a cue, so the repaint reads as an update, not a glitch:
+  // a quiet toast normally, a WARNING while editing (this edit started from the
+  // old version — publishing it replaces the newer one). Pinned views (@vN) get
+  // neither: their version bar already carries "you're on an old version", and the
+  // refetch keeps it truthful. Read through refs so the SSE stream doesn't
+  // resubscribe every time the user opens the editor.
+  const editingRef = useRef(editing)
+  editingRef.current = editing
+  const pinnedRef = useRef(version)
+  pinnedRef.current = version
+  const onVersionLive = useCallback(
+    (n?: number) => {
+      load()
+      if (pinnedRef.current !== undefined) return
+      const v = n !== undefined ? `v${n}` : "A new version"
+      if (editingRef.current) {
+        toast.warning(`${v} was just published — publishing this edit will replace it.`, {
+          id: `stale-edit-${shortId}`,
+          duration: 8000,
+        })
+      } else {
+        toast(`Updated to ${v === "A new version" ? "the newest version" : v}.`, {
+          id: `live-version-${shortId}`,
+        })
+      }
+    },
+    [load, shortId],
+  )
+
   // Presence, live multiplayer cursors, the SSE stream, and view recording — see
   // use-artifact-live. The page feeds pointer moves in (from the iframe bridge
   // below) and reads `viewers` + the `cursorLayer` overlay ref back out.
-  const live = useArtifactLive({ shortId, onComment: refetchComments, onVersion: load, onReview })
+  // onResync closes coverage gaps (hidden tab return, SSE reconnect) silently.
+  const live = useArtifactLive({
+    shortId,
+    onComment: refetchComments,
+    onVersion: onVersionLive,
+    onReview,
+    onResync: load,
+  })
 
   // The whole postMessage channel with the sandboxed iframe: text selection,
   // anchor geometry, scroll, deck position, and peer cursors in; highlight
@@ -551,7 +589,7 @@ export function Artifact() {
       {/* data-artifact-view: while the workbench is mounted, globals.css drops the
           film-grain overlay so Derive's material steps back inside the author's document. */}
       <div data-artifact-view className="flex min-h-0 flex-1 flex-col">
-        <FocusRailSync focus={focus} />
+        <FocusShellSync focus={focus} />
         {/* The workbench bar — full-width now (sidebar-first shell), so the
               comments panel docks BELOW it instead of squeezing it into the
               remaining width. The page owns its toolbar: the artifact title (the
@@ -690,15 +728,16 @@ export function Artifact() {
             ) : (
               documentEl
             )}
-            {!isAnon && !focus && panel === "hidden" && (
+            {/* Only when there ARE open comments — a zero-count "Show comments" pill
+                is noise over the render. The top-bar Comments toggle (and `c`)
+                still opens the empty panel to start the first thread. */}
+            {!isAnon && !focus && panel === "hidden" && openCount > 0 && (
               <DocFab
                 title="Show comments (c)"
                 testId="artifact-comments-fab"
                 onClick={() => setPanel("open")}
               >
-                {openCount > 0
-                  ? `${openCount} comment${openCount === 1 ? "" : "s"}`
-                  : "Show comments"}
+                {`${openCount} comment${openCount === 1 ? "" : "s"}`}
               </DocFab>
             )}
             {/* Anonymous visitor on a comment-enabled link: commenting forces auth (anon

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -667,11 +667,14 @@ export function ShareButton({
                       </div>
                     </div>
                     {/* Collection sharing is owner-managed (matches ShareCollectionDialog's
-                        bar); everyone else gets attribution — who to ask. */}
+                        bar); everyone else gets attribution — who to ask. Muted at rest
+                        (this section is disclosure, not control — the row's content
+                        carries the weight); hover re-inks. */}
                     {g.my_role === "owner" ? (
                       <Button
                         variant="ghost"
-                        size="sm"
+                        size="xs"
+                        className="text-muted-foreground hover:text-foreground"
                         data-testid={`share-collection-manage-${g.id}`}
                         onClick={() => setManageCol(g)}
                       >

--- a/apps/web/src/pages/artifact/use-artifact-live.ts
+++ b/apps/web/src/pages/artifact/use-artifact-live.ts
@@ -18,13 +18,23 @@ import { useLiveCursors } from "./cursors/use-live-cursors"
 export function useArtifactLive(opts: {
   shortId: string
   onComment: () => void
-  onVersion: () => void
+  /** A new version landed live, with its number when the event carried one — the
+   *  page refetches AND may cue the user (toast / mid-edit warning). */
+  onVersion: (n?: number) => void
   /** A review round changed (requested / sent back / approved) — the review card
    *  refetches, so an agent's re-request appears live instead of on reload. */
   onReview?: () => void
+  /** The stream (re)connected after a coverage gap — a hidden tab returning (its
+   *  stream was closed) or an EventSource auto-reconnect. Events during the gap
+   *  were never replayed, so refetch silently instead of trusting the cache. */
+  onResync?: () => void
 }) {
-  const { shortId, onComment, onVersion, onReview } = opts
+  const { shortId, onComment, onVersion, onReview, onResync } = opts
   const [viewers, setViewers] = useState<Viewer[]>([])
+  // Whether ANY stream for this page has connected before — the first "ready" of
+  // the first stream is the mount itself (the loader/query just fetched; nothing
+  // to catch up on); every later "ready" means a gap just closed.
+  const everConnected = useRef(false)
   const cursors = useLiveCursors(shortId)
   const { paintFrame } = cursors
   const visible = usePageVisible()
@@ -44,7 +54,20 @@ export function useArtifactLive(opts: {
     ev.addEventListener("comment.addressed", onComment)
     ev.addEventListener("comment.reacted", onComment)
     ev.addEventListener("comment.updated", onComment)
-    ev.addEventListener("version.published", onVersion)
+    ev.addEventListener("version.published", (e) => {
+      let n: number | undefined
+      try {
+        n = JSON.parse((e as MessageEvent).data).n
+      } catch {
+        /* the refetch doesn't need the number */
+      }
+      onVersion(n)
+    })
+    // "ready" is the server's hello on every (re)connect — see onResync.
+    ev.addEventListener("ready", () => {
+      if (everConnected.current) onResync?.()
+      everConnected.current = true
+    })
     if (onReview) {
       ev.addEventListener("review.requested", onReview)
       ev.addEventListener("review.sent_back", onReview)
@@ -65,7 +88,7 @@ export function useArtifactLive(opts: {
       }
     })
     return () => ev.close()
-  }, [shortId, onComment, onVersion, onReview, paintFrame, visible])
+  }, [shortId, onComment, onVersion, onReview, onResync, paintFrame, visible])
 
   // Announce we're viewing (anon shows up by their server handle — Google-Docs
   // style) and keep the heartbeat alive (TTL 45s). Paused while the tab is

--- a/apps/web/src/pages/artifact/use-comments-panel.ts
+++ b/apps/web/src/pages/artifact/use-comments-panel.ts
@@ -48,7 +48,12 @@ export function useCommentsPanel(onEscape: () => void) {
         return
       }
       if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.altKey) return
-      if (el && /^(input|textarea|select)$/i.test(el.tagName)) return
+      // Never fire while typing: form fields AND contentEditable surfaces — the
+      // comment composer and the CodeMirror source editor are contentEditable, so
+      // the tag test alone let "c" toggle the panel mid-sentence. Dialogs opt out
+      // too (same set the app-shell "/" handler guards).
+      if (el && (/^(input|textarea|select)$/i.test(el.tagName) || el.isContentEditable)) return
+      if (document.querySelector('[role="dialog"]')) return
       if (e.key === "c" || e.key === "C") setPanel((p) => (p === "open" ? "hidden" : "open"))
     }
     window.addEventListener("keydown", onKey)

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { useNavigate, useSearch } from "@tanstack/react-router"
+import { Link, useNavigate, useSearch } from "@tanstack/react-router"
 import { FolderTree, List } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { type Artifact, api } from "@/api"
@@ -249,8 +249,10 @@ function LibraryBody({ view }: { view: LibraryView }) {
   const collectionTitle =
     activeCollection?.title ?? feed.data?.pages?.[0]?.collection?.title ?? "Collection"
 
-  // The home greeting + the quiet triage line only exist on the unfiltered "/" view.
-  const homeView = filter.kind === "all" && !isSearching
+  // The home greeting + publish launcher + the quiet triage line span BOTH home tabs
+  // ("All artifacts" / "Created by me") — the tab only filters the grid, it doesn't
+  // leave home. Searching or a tag/collection filter drops the home chrome.
+  const homeView = (filter.kind === "all" || filter.kind === "mine") && !isSearching
   const { data: feedbackData } = useQuery({ ...needsFeedbackArtifactsQuery(), enabled: homeView })
   const feedbackCount = feedbackData?.length ?? 0
 
@@ -303,13 +305,17 @@ function LibraryBody({ view }: { view: LibraryView }) {
               : undefined
 
   const showPublish =
-    !isSearching && (filter.kind === "all" || filter.kind === "tag" || filter.kind === "favorites")
+    !isSearching &&
+    (filter.kind === "all" ||
+      filter.kind === "mine" ||
+      filter.kind === "tag" ||
+      filter.kind === "favorites")
 
   const emptyProps = emptyStateFor(filter, isSearching, debouncedQ, nav)
   // The first-run guide is for a genuinely blank home (your work is empty and you're not
-  // mid-search). With the promoted strips gone from home, "all + empty" simply means
-  // first-run — no more racing three queries to decide.
-  const emptyHome = homeView && items.length === 0
+  // mid-search). Keyed to the "All artifacts" tab only — an empty "Created by me" tab
+  // keeps its own empty state (the workspace may hold plenty you didn't create).
+  const emptyHome = homeView && filter.kind === "all" && items.length === 0
 
   return (
     <PageShell scrollRef={scrollRef} width="wide">
@@ -330,9 +336,16 @@ function LibraryBody({ view }: { view: LibraryView }) {
           subtitle={
             <>
               Your artifacts live here — most recently updated first. Publish one below, or run{" "}
-              <code className="inline-flex h-5 items-center rounded-sm bg-muted px-1 font-mono text-2xs font-medium text-foreground/70">
+              {/* Links to /welcome — reachable any time; its "Connect an agent" step
+                  is the in-app guide to publishing over the CLI/MCP. */}
+              <Link
+                to="/welcome"
+                data-testid="library-cli-guide"
+                title="How to publish from the CLI or an agent (MCP)"
+                className="inline-flex h-5 items-center rounded-sm bg-muted px-1 font-mono text-2xs font-medium text-foreground/70 hover:text-foreground hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+              >
                 derive publish
-              </code>
+              </Link>
               .
             </>
           }
@@ -436,7 +449,6 @@ function LibraryBody({ view }: { view: LibraryView }) {
           active={filter.kind === "mine" ? "mine" : "all"}
           total={summary?.total}
           mine={summary?.mine}
-          pending={summary?.mine_private}
         />
       ) : (
         // Hide the heading on a brand-new empty home — the visual guide carries it.
@@ -653,15 +665,13 @@ function LibraryTabs({
   active,
   total,
   mine,
-  pending,
 }: {
   active: "all" | "mine"
   total?: number
   mine?: number
-  pending?: number
 }) {
   const nav = useNavigate()
-  const tab = (id: "all" | "mine", label: string, count?: number, accent?: number) => (
+  const tab = (id: "all" | "mine", label: string, count?: number) => (
     <button
       type="button"
       data-testid={`library-tab-${id}`}
@@ -680,20 +690,12 @@ function LibraryTabs({
       {count != null && (
         <span className="font-mono text-2xs tabular-nums text-muted-foreground">{count}</span>
       )}
-      {accent != null && accent > 0 && (
-        <span
-          title={`${accent} link-only — hidden from the shared library until shared wider`}
-          className="rounded-full bg-primary/10 px-1.5 font-mono text-2xs tabular-nums text-primary"
-        >
-          {accent}
-        </span>
-      )}
     </button>
   )
   return (
     <div className="mb-3.5 flex items-center gap-5 border-b border-border-soft">
       {tab("all", "All artifacts", total)}
-      {tab("mine", "Created by me", mine, pending)}
+      {tab("mine", "Created by me", mine)}
     </div>
   )
 }

--- a/apps/web/src/pages/library/share-collection-dialog.tsx
+++ b/apps/web/src/pages/library/share-collection-dialog.tsx
@@ -208,9 +208,11 @@ export function ShareCollectionDialog({
                   data-testid="collection-share-role"
                   className="w-28 shrink-0"
                 />
-                {/* Add is this dialog's one filled primary. */}
+                {/* Add is this dialog's one filled primary — sm to sit flush with
+                    the h-8 row chassis, matching ShareDialog's add row. */}
                 <Button
                   variant="default"
+                  size="sm"
                   type="submit"
                   data-testid="collection-share-add"
                   loading={addMut.isPending}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -20,14 +20,14 @@ import { reportWebVitals } from "../lib/vitals"
 import "@/styles/globals.css"
 
 // Resolve the theme before first paint so there's no flash: a stored light/dark
-// choice wins, otherwise follow the OS preference. Mirrors resolveTheme() in ctx
-// so the pre-paint attribute matches what ThemeProvider settles on post-hydration.
-// Runs synchronously in <head>, ahead of body render. Keyed off STORAGE_KEYS.theme
-// (not a literal) so it tracks the one key definition and stays out of the
-// storage-key linter's way.
+// choice wins; "system" (or nothing stored) follows the OS preference. Mirrors the
+// ThemeProvider config in ctx (defaultTheme system + enableSystem) so the pre-paint
+// class matches what next-themes settles on post-hydration. Runs synchronously in
+// <head>, ahead of body render. Keyed off STORAGE_KEYS.theme (not a literal) so it
+// tracks the one key definition and stays out of the storage-key linter's way.
 const THEME_BOOT = `(function(){try{var t=localStorage.getItem(${JSON.stringify(
   STORAGE_KEYS.theme,
-)});if(t!=="light"&&t!=="dark")t="dark";var e=document.documentElement;e.classList.remove("light","dark");e.classList.add(t)}catch(e){}})()`
+)});if(t!=="light"&&t!=="dark")t=matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";var e=document.documentElement;e.classList.remove("light","dark");e.classList.add(t)}catch(e){}})()`
 
 // Pre-paint sibling to THEME_BOOT: tag <html> with which boot frame to reserve —
 // before the shell paints — from the persisted auth hint AND the entry path. A


### PR DESCRIPTION
## What & why

A batch of UI fixes from a review pass of the app: several small paper cuts (tab titles, tab counts, button weights), two behavioral bugs (the comments hotkey firing mid-typing, the browser auto-opening artifacts the user never asked for), and two capability gaps (no System theme, no cue when a new version lands under you).

## Changes

- **Tab title**: artifact pages title the browser tab (`name · Derive`) off the live query, so it tracks client-side loads and renames; restores on unmount. New `useDocumentTitle` hook, one line to adopt per page.
- **System theme**: third option in the theme control, and the default when nothing is stored. `next-themes` `enableSystem` tracks OS changes live; the pre-paint boot script now falls back to `prefers-color-scheme` instead of hard-coding dark (matching its own comment, which had drifted from the code).
- **Home tabs**: the greeting, publish launcher, and triage line persist across All artifacts / Created by me (the tab now only filters the grid). The first-run guide stays keyed to an empty All artifacts tab. The unexplained private-count pill on Created by me is removed. The `derive publish` chip links to /welcome (the CLI/MCP connect guide).
- **Focus mode is immersive**: the shell unmounts the nav rail and mobile top bar via a new `immersive` shell flag, and with no sidebar peer the inset mat drops, so the render runs edge-to-edge (previously focus left a 3rem icon rail plus the floating-card mat). The rail returns in its prior open/collapsed state on exit.
- **Comments hotkey**: `c` no longer fires in contentEditable surfaces (the CodeMirror source editor was the hole; form fields were already guarded) or while a dialog is open. The bottom-right FAB renders only when open comments exist.
- **Live version awareness**: the artifact SSE stream resyncs on reconnect and tab return (events during coverage gaps were never replayed, so a backgrounded tab came back stale forever). A live bump shows a quiet "Updated to vN" toast (coalesced by id); a bump during a source edit shows a warning that publishing will replace it. Pinned `@vN` views keep their existing version bar, no toast.
- **Push hygiene** (the "my browser randomly navigates" bug, two causes):
  - A context-bound agent is an askable service, so its publishes may be answering someone else's ask on the owner's grant. The server now flags those pushes `service` (both the /v1 and MCP publish paths) and the client toasts instead of navigating.
  - The tab-refocus catch-up scanned the notification feed for recent publish/review rows and navigated to the newest, but that feed also holds follower fan-outs and teammates' review asks. It now only toasts (with an Open action).
  - The real MCP loop is unchanged: your own agent's created artifact still auto-opens live; revisions still live-reload.
- **Password managers**: every Input/Textarea (and the comment composer's raw fields) carries the vendor ignore attributes by default, except fields that declare themselves credential-shaped (`type=password` or a fillable autocomplete token: username, email, name, current/new-password, one-time-code, webauthn). Login, password change, and 2FA keep autofill; the invite box, searches, and titles stop attracting popups.
- **Share dialog polish**: the collection row's Manage action reads muted at rest (that section is disclosure, not control), re-inking on hover; the collection dialog's Add button gets the missing `size="sm"` so it sits on the h-8 row chassis like ShareDialog's.

## Testing

- [x] `pnpm typecheck` passes
- [x] `pnpm exec biome ci .` reports 0 errors (full `pnpm run ci` green)
- [x] `pnpm test` passes
- [x] Added/updated tests for the change

New e2e: System theme follows the OS preference live and across reload; focus mode removes the rail from the DOM and restores it; typing `c` in the source editor leaves the panel alone; a live version bump repaints in place with the toast; a context-bound agent's publish toasts without navigating; password managers invited on credentials and suppressed elsewhere. Full smoke project (11) plus the touched deep suites (artifact, chrome, library, mcp-loop, share, auth, settings, contexts console, responsive) run green locally.

## Notes for reviewers

- `opened_in_tab` semantics are unchanged: it still reports "reached a live tab", though a service push now toasts rather than navigates there.
- Pre-existing, not addressed here: the contexts deep spec (`ask → stub-runner answer`) is red on clean main. It still grants ask-access by sharing the manifest, but since #353 the grant is workspace-scoped on the context and the spec's users are not co-members. Wants its own PR.
- Known dev-only flake: an intermittent React "state update on a component that hasn't mounted yet" console warning appears under parallel e2e load with system theme enabled. next-themes' own updates are all effect-based (verified against its source), it never fails a test, and it is stripped from prod builds. Likely a latent render-phase race elsewhere whose timing shifts; left as a watch item.