### PR TITLE
feat(web): the tab titles every view, not just artifacts

### DIFF
--- a/apps/web/e2e/deep/chrome.deep.spec.ts
+++ b/apps/web/e2e/deep/chrome.deep.spec.ts
@@ -56,3 +56,16 @@ test("icon-only chrome controls expose accessible names", async ({ owner }) => {
   await expect(owner.getByRole("button", { name: "Search (⌘K)" })).toBeVisible()
   await expect(owner.getByRole("searchbox", { name: "Filter artifacts by title" })).toBeVisible()
 })
+
+test("the tab title follows the view", async ({ owner }) => {
+  await expect(owner).toHaveTitle("Derive")
+  await owner.getByTestId("library-tab-mine").click()
+  await expect(owner).toHaveTitle("Created by me · Derive")
+  await owner.goto("/people")
+  await expect(owner).toHaveTitle("People · Derive")
+  await owner.goto("/settings/members")
+  await expect(owner).toHaveTitle("Members · Settings · Derive")
+  // Back home restores the base title (the hook's unmount contract).
+  await owner.goto("/")
+  await expect(owner).toHaveTitle("Derive")
+})

--- a/apps/web/src/pages/accept-invite.tsx
+++ b/apps/web/src/pages/accept-invite.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button"
 import { useAuth } from "@/ctx"
 import { workspaceQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { useDocumentTitle } from "@/lib/use-document-title"
 import { roleLabel } from "./settings/roles"
 
 const route = getRouteApi("/invite/$token")
@@ -31,6 +32,7 @@ function Shell({ children }: { children: React.ReactNode }) {
 }
 
 export function AcceptInvite() {
+  useDocumentTitle("Invitation")
   const { token } = route.useParams()
   const { me, loading } = useAuth()
   const nav = useNavigate()

--- a/apps/web/src/pages/context/console.tsx
+++ b/apps/web/src/pages/context/console.tsx
@@ -27,6 +27,7 @@ import { useAuth } from "@/ctx"
 import { contextQuery, contextSessionsQuery, sessionQuery } from "@/lib/queries"
 import { ago } from "@/lib/time"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { useDocumentTitle } from "@/lib/use-document-title"
 import { cn } from "@/lib/utils"
 import { mdToHtml } from "../artifact/lib/markdown"
 import { ConsolePending } from "./context-skeleton"
@@ -63,6 +64,8 @@ function Console({ id }: { id: string }) {
     isError: sessionsFailed,
     refetch: refetchSessions,
   } = useQuery(contextSessionsQuery(id))
+  // The tab names the context; base title while it loads (or on no-access).
+  useDocumentTitle(context?.name ?? null)
 
   // The session on screen: sticky once picked; defaults to the most recent.
   const [picked, setPicked] = useState<string | null>(null)

--- a/apps/web/src/pages/context/index.tsx
+++ b/apps/web/src/pages/context/index.tsx
@@ -17,12 +17,14 @@ import {
 } from "@/components/ui/select"
 import { agentsQuery, contextsQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { useDocumentTitle } from "@/lib/use-document-title"
 import { ContextRowsSkeleton } from "./context-skeleton"
 
 // The contexts directory: the workspace's askable agent setups. Creation wires an
 // existing agent (Settings → Agents) to a manifest artifact by its short id — the
 // two halves already exist as first-class objects; a context is just the joint.
 export function Contexts() {
+  useDocumentTitle("Contexts")
   const qc = useQueryClient()
   const { data: contexts, isPending, isError, refetch } = useQuery(contextsQuery())
   // Agents load lazily for the create form; a 403 (non-admin) just hides it —

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -24,6 +24,7 @@ import {
 import { STORAGE_KEYS } from "@/lib/storage-keys"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { useDelayedPending } from "@/lib/use-delayed-pending"
+import { useDocumentTitle } from "@/lib/use-document-title"
 import { useFollows } from "@/lib/use-follows"
 import { usePrefetchArtifact } from "@/lib/use-prefetch-artifact"
 import { cn } from "@/lib/utils"
@@ -287,6 +288,9 @@ function LibraryBody({ view }: { view: LibraryView }) {
                 : filter.kind === "tag"
                   ? `#${filter.tag}`
                   : collectionTitle
+  // The tab names the view — a tag, a collection, Favorites, Created by me… —
+  // while the unfiltered home stays plain "Derive".
+  useDocumentTitle(filter.kind === "all" ? null : heading)
   // Only the counts the server can state authoritatively (preloaded summary / the
   // collection's own count) get a number; the follow/shared/feedback feeds show none
   // rather than a misleading "loaded-so-far" count that grows as you scroll.

--- a/apps/web/src/pages/login.tsx
+++ b/apps/web/src/pages/login.tsx
@@ -17,10 +17,12 @@ import {
 import { useAuth } from "@/ctx"
 import { authClient } from "@/lib/auth-client"
 import { needsOnboarding } from "@/lib/route-guards"
+import { useDocumentTitle } from "@/lib/use-document-title"
 
 const loginRoute = getRouteApi("/login")
 
 export function Login() {
+  useDocumentTitle("Sign in")
   const { me, loading, setMe } = useAuth()
   const { signup: wantSignup, return_to: returnTo, reset: didReset } = loginRoute.useSearch()
   const [mode, setMode] = useState<"login" | "signup">(wantSignup ? "signup" : "login")

--- a/apps/web/src/pages/new.tsx
+++ b/apps/web/src/pages/new.tsx
@@ -5,6 +5,7 @@ import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { toast } from "@/components/ui/sonner"
 import { collectionsQuery, summaryQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { useDocumentTitle } from "@/lib/use-document-title"
 import { refFor } from "./artifact/parse-ref"
 import { SourceEditor } from "./artifact/source-editor"
 
@@ -29,6 +30,7 @@ const detectFormat = (t: string): "md" | "html" => {
 // title. Publishing creates the artifact (private by default; widen
 // access from its Share menu) and opens it.
 export function NewArtifact() {
+  useDocumentTitle("New artifact")
   const nav = useNavigate()
   const [src, setSrc] = useState("")
   const [title, setTitle] = useState("")

--- a/apps/web/src/pages/people.tsx
+++ b/apps/web/src/pages/people.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/lib/queries"
 import { ago } from "@/lib/time"
 import { useDelayedPending } from "@/lib/use-delayed-pending"
+import { useDocumentTitle } from "@/lib/use-document-title"
 import { cn } from "@/lib/utils"
 import { refFor } from "@/pages/artifact/parse-ref"
 
@@ -34,6 +35,7 @@ import { refFor } from "@/pages/artifact/parse-ref"
 // to your workspaces — there is deliberately no global directory at launch);
 // results stay put (dimmed) while the next set loads — never a flash.
 export function People() {
+  useDocumentTitle("People")
   const [q, setQ] = useState("")
   const [debounced, setDebounced] = useState("")
   useEffect(() => {

--- a/apps/web/src/pages/profile/index.tsx
+++ b/apps/web/src/pages/profile/index.tsx
@@ -20,6 +20,7 @@ import { useAuth } from "@/ctx"
 import { colorForName } from "@/lib/avatar-tints"
 import { getInitials } from "@/lib/initials"
 import { profileArtifactsQuery, profileQuery } from "@/lib/queries"
+import { useDocumentTitle } from "@/lib/use-document-title"
 import { ProfilePending, ProfileWorkSkeleton } from "./skeleton"
 import { ProfileWorkCard, ProfileWorkRow } from "./work-card"
 
@@ -52,6 +53,9 @@ function ProfileInner({ handle }: { handle: string }) {
   const scrollRef = useRef<HTMLDivElement>(null)
 
   const { data, isPending, isError, error, refetch } = useQuery(profileQuery(handle))
+  // The tab names the person (display name, else handle); before the early
+  // returns — hooks. Base title while loading or on a 404.
+  useDocumentTitle(data ? (data.name ?? `@${data.username}`) : null)
 
   // The identity is preloaded, so isPending here is only ever a genuine cold load; the
   // route's ProfilePending (same skeleton) already covers that window, so a null here

--- a/apps/web/src/pages/reset-password.tsx
+++ b/apps/web/src/pages/reset-password.tsx
@@ -7,6 +7,7 @@ import { StatusPanel } from "@/components/shared/status-panel"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { useDocumentTitle } from "@/lib/use-document-title"
 
 const route = getRouteApi("/reset-password")
 
@@ -61,6 +62,7 @@ function BackToSignIn() {
 }
 
 export function ResetPassword() {
+  useDocumentTitle("Reset password")
   const { token, error } = route.useSearch()
   // The emailed link lands here with a token; without one this is the request form.
   return token ? <Complete token={token} /> : <Request expired={error === "INVALID_TOKEN"} />

--- a/apps/web/src/pages/settings/index.tsx
+++ b/apps/web/src/pages/settings/index.tsx
@@ -5,6 +5,7 @@ import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { Badge } from "@/components/ui/badge"
 import { useAuth } from "@/ctx"
 import { reportsQuery } from "@/lib/queries"
+import { useDocumentTitle } from "@/lib/use-document-title"
 import { AgentsSection } from "./agents-section"
 import { AppearanceSection } from "./appearance-section"
 import { CustomDomainsSection } from "./custom-domains-section"
@@ -23,6 +24,21 @@ import { WebhooksSection } from "./webhooks-section"
 // useParams/useNavigate.
 const route = getRouteApi("/settings/$section")
 
+// Tab titles per section — keep in step with the nav `groups` in Settings below.
+const SECTION_TITLES: Record<string, string> = {
+  profile: "Profile",
+  security: "Security",
+  appearance: "Appearance",
+  general: "General",
+  members: "Members",
+  integrations: "Integrations",
+  github: "GitHub",
+  webhooks: "Webhooks",
+  agents: "Agents",
+  domains: "Domains",
+  reports: "Reports",
+}
+
 // Settings, reconceived as a scope-grouped two-pane: a sticky category rail
 // (Account · Workspace · Developer · Moderation) beside a readable detail column,
 // reflowing to a horizontal strip on a narrow pane. The active section is a path
@@ -36,6 +52,10 @@ export function Settings() {
   const { data: reports } = useQuery({ ...reportsQuery(), enabled: !!me })
   const { section } = route.useParams()
   const nav = route.useNavigate()
+
+  // Before the early return (hooks). Labels mirror the groups below — a static
+  // map because the groups themselves are gated on data (`reports`).
+  useDocumentTitle(SECTION_TITLES[section] ? `${SECTION_TITLES[section]} · Settings` : "Settings")
 
   if (!me) return null
 

--- a/apps/web/src/pages/welcome.tsx
+++ b/apps/web/src/pages/welcome.tsx
@@ -32,6 +32,7 @@ import { getInitials } from "@/lib/initials"
 import { OTHER, PROFESSIONS, presetFor } from "@/lib/professions"
 import { STORAGE_KEYS } from "@/lib/storage-keys"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { useDocumentTitle } from "@/lib/use-document-title"
 import { normalizeUsername, usernameError } from "@/lib/username"
 
 // A present account — the stateful onboarding body only mounts once `me` resolves
@@ -100,6 +101,7 @@ Then you can publish, read review comments, and run the propose -> review -> rev
 // Gate on the session BEFORE the stateful body so the profile fields initialize from
 // a resolved account (a direct visit to /welcome renders once with me=null first).
 export function Welcome() {
+  useDocumentTitle("Welcome")
   const { me } = useAuth()
   if (!me) return null
   return <Onboarding me={me} />


### PR DESCRIPTION
## What & why

Follow-up to #374, which gave artifact pages a browser-tab title. This rolls the same hook out across the app so the tab always says where you are: a collection or tag view titles the tab with its name, and every other screen names itself.

## Changes

- Library views: a tag titles `#tag · Derive`, a collection its title, plus Favorites, Following, Shared with you, Needs your feedback, and Created by me. The unfiltered home stays plain `Derive`.
- Settings: `<Section> · Settings · Derive` (static label map, kept in step with the nav groups).
- People, Contexts, and each context console (the context's name, live off the query).
- Profiles: display name, else `@handle`.
- One-off screens: Sign in, Reset password, Welcome, New artifact, Invitation.

## Testing

- [x] `pnpm typecheck` passes
- [x] `pnpm exec biome ci .` reports 0 errors (full `pnpm run ci` green)
- [x] `pnpm test` passes
- [x] Added/updated tests for the change

New e2e in chrome.deep drives home tab, People, and a settings section asserting each title, and that returning home restores the base title (the hook's unmount contract). Library, settings, chrome, and contexts-console deep suites run green locally (the pre-existing ask-loop spec failure noted on #374 remains, untouched here).

## Notes for reviewers

Pure additions (58 insertions, no deletions): one `useDocumentTitle` call per page plus imports.