### PR TITLE
Feat/brandprint

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -862,6 +862,46 @@
               "public"
             ],
             "description": "Listing a new publish lands with: none (default), workspace, or public."
+          },
+          "brandprint": {
+            "type": "object",
+            "properties": {
+              "collectionId": {
+                "type": "string",
+                "nullable": true,
+                "maxLength": 64
+              },
+              "theme": {
+                "type": "object",
+                "nullable": true,
+                "properties": {
+                  "palette": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "fonts": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "dark": {
+                    "type": "object",
+                    "properties": {
+                      "palette": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "description": "The workspace's Brandprint (conventions collection + theme); absent until set."
           }
         },
         "required": [
@@ -2730,11 +2770,53 @@
                       "type": "string",
                       "nullable": true,
                       "description": "Saved bio; null when cleared."
+                    },
+                    "brandprint": {
+                      "type": "object",
+                      "nullable": true,
+                      "properties": {
+                        "collectionId": {
+                          "type": "string",
+                          "nullable": true,
+                          "maxLength": 64
+                        },
+                        "theme": {
+                          "type": "object",
+                          "nullable": true,
+                          "properties": {
+                            "palette": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            },
+                            "fonts": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            },
+                            "dark": {
+                              "type": "object",
+                              "properties": {
+                                "palette": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "description": "Saved personal Brandprint; null when cleared."
                     }
                   },
                   "required": [
                     "profession",
-                    "about"
+                    "about",
+                    "brandprint"
                   ]
                 }
               }

--- a/apps/api/src/auth-config.ts
+++ b/apps/api/src/auth-config.ts
@@ -372,6 +372,10 @@ export function makeAuth(db: AuthDb, baseUrl: string, secret: string, hooks: Aut
         // is only a fast-path cache. Defaults false (new accounts land on /welcome); set
         // true via POST /v1/me/onboarded. input:false, server-set only.
         onboarded: { type: "boolean", required: false, defaultValue: false, input: false },
+        // Your personal Brandprint: how YOU like artifacts built. Stored as a JSON string
+        // ({ collectionId?, theme? }); layered over the workspace Brandprint (profile wins)
+        // when an agent acts as you. input:false, server-set via POST /v1/me/profile.
+        brandprint: { type: "string", required: false, input: false },
       },
     },
     socialProviders,

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -58,6 +58,8 @@ export interface SessionUser {
   /** Has the account's email been verified? Better Auth native field; soft-nudge only
    *  (never gates sign-in), surfaced as a dismissible banner in the app. */
   emailVerified: boolean
+  /** Personal Brandprint as a JSON string ({ collectionId?, theme? }); null if unset. */
+  brandprint: string | null
 }
 
 export interface AppDeps {
@@ -314,6 +316,7 @@ export function buildContext(deps: AppDeps) {
           about?: string | null
           onboarded?: boolean | number | null
           emailVerified?: boolean | number | null
+          brandprint?: string | null
         }
       | undefined
     const u: SessionUser | null = su
@@ -329,6 +332,7 @@ export function buildContext(deps: AppDeps) {
           // Onboarded only when explicitly set (off by default; unset/null = not yet).
           onboarded: su.onboarded === true || su.onboarded === 1,
           emailVerified: su.emailVerified === true || su.emailVerified === 1,
+          brandprint: su.brandprint ?? null,
         }
       : null
     userCache.set(c, u)

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -24,6 +24,7 @@ import {
   type ArtifactRecord,
   artifactUrl,
   type BundleManifest,
+  brandprintInstructions,
   capRole,
   diffLines,
   EditError,
@@ -34,9 +35,11 @@ import {
   outlineOf,
   PublishError,
   pageText,
+  parseBrandprint,
   propose as proposeChange,
   publish as publishVersion,
   type Role,
+  resolveBrandprint,
   roleAllows,
   sectionOf,
   toMarkdown,
@@ -223,7 +226,7 @@ const changeCount = (c: ReturnType<typeof bundleFileChanges>) =>
  * Identity rides in the server `instructions` (below), not a `whoami` tool — it's a
  * one-shot fact, not a per-call action.
  */
-function buildServer(
+async function buildServer(
   ctx: AppContext,
   agent: AgentRecord,
   actingFor: { id: string; name: string | null } | null,
@@ -240,7 +243,7 @@ function buildServer(
   // clamps list_workspaces + the `workspace` arg + cross-workspace read to
   // exactly those: workspaces outside the grant are invisible and unreachable.
   boundWorkspaces: string[],
-): McpServer {
+): Promise<McpServer> {
   // Steer the write guidance by what this grant can actually do: a publish-capable
   // grant gets the direct-publish path; a lower grant is told its writes go to review.
   const writeGuidance = roleAllows(agent.role, "publish")
@@ -248,6 +251,27 @@ function buildServer(
       `it goes live immediately. Pass for_review:true to file it as a proposal a human approves instead. `
     : `Use publish to submit a revision — at your role it is filed as a proposal a human approves before it ` +
       `goes live; you cannot publish directly. `
+
+  // Resolve the Brandprint for this actor: the workspace's conventions merged with the
+  // owner's personal ones (profile wins). Each convention doc becomes a readable resource;
+  // a one-line pointer goes in the instructions (bodies load lazily on read).
+  const wsBrandprint = (await ctx.meta.getOrgSettings(agent.org_id)).brandprint
+  const profileBrandprint = parseBrandprint(
+    ownerId ? await ctx.meta.getUserBrandprint(ownerId) : null,
+  )
+  const resolved = resolveBrandprint(wsBrandprint, profileBrandprint)
+  const conventionDocs: ArtifactRecord[] = []
+  const seenBp = new Set<string>()
+  for (const collectionId of resolved.collectionIds) {
+    const ids = await ctx.meta.collectionArtifactIds(collectionId)
+    for (const a of ids.length ? await ctx.meta.listArtifacts({ ids }) : []) {
+      if (!seenBp.has(a.short_id)) {
+        seenBp.add(a.short_id)
+        conventionDocs.push(a)
+      }
+    }
+  }
+
   const server = new McpServer(
     { name: "derive", version: "1.0.0" },
     {
@@ -268,9 +292,32 @@ function buildServer(
         `This one login reaches the workspaces in your grant — call list_workspaces to see them, ` +
         `then pass a workspace id or name as the "workspace" argument to act in another one (read, ` +
         `catch_up, comment, publish, list_artifacts). read/catch_up/comment also find a short_id in ` +
-        `any of them automatically, so you never need to switch just to open a doc.`,
+        `any of them automatically, so you never need to switch just to open a doc.` +
+        brandprintInstructions(conventionDocs.length),
     },
   )
+
+  // Brandprint conventions as resources: derive://brandprint/<short_id>, bodies fetched
+  // lazily (the current version's text). audience:["assistant"], context for the agent.
+  for (const doc of conventionDocs) {
+    server.registerResource(
+      `brandprint:${doc.short_id}`,
+      `derive://brandprint/${doc.short_id}`,
+      {
+        title: doc.title ?? doc.short_id,
+        description: "A Brandprint convention: how this workspace likes its stuff built.",
+        mimeType: "text/markdown",
+        annotations: { audience: ["assistant"], priority: 0.9 },
+      },
+      async (uri) => {
+        const art = await ctx.meta.getByShortId(doc.short_id)
+        const v = art ? await ctx.meta.getVersion(art.id, art.current_version) : null
+        const text = v ? await ctx.sourceText(v) : null
+        return { contents: [{ uri: uri.href, mimeType: "text/markdown", text: text ?? "" }] }
+      },
+    )
+  }
+
   const defaultOrg = agent.org_id
   const defaultRole = agent.role
 
@@ -1508,7 +1555,7 @@ export function mountMcp(app: Hono, ctx: AppContext): void {
     const grant = await ctx.oauthGrant(c)
     const scopeForCap = grant?.scopeRole ?? agent.role
     const boundWorkspaces = grant?.boundWorkspaces ?? []
-    const server = buildServer(ctx, agent, actingFor, ownerId, scopeForCap, boundWorkspaces)
+    const server = await buildServer(ctx, agent, actingFor, ownerId, scopeForCap, boundWorkspaces)
     const transport = new StreamableHTTPTransport()
     await server.connect(transport)
     return transport.handleRequest(c)

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -312,8 +312,8 @@ async function buildServer(
       async (uri) => {
         const art = await ctx.meta.getByShortId(doc.short_id)
         const v = art ? await ctx.meta.getVersion(art.id, art.current_version) : null
-        const text = v ? await ctx.sourceText(v) : null
-        return { contents: [{ uri: uri.href, mimeType: "text/markdown", text: text ?? "" }] }
+        const body = v ? await ctx.sourceText(v) : null
+        return { contents: [{ uri: uri.href, mimeType: "text/markdown", text: body ?? "" }] }
       },
     )
   }

--- a/apps/api/src/routes/session.ts
+++ b/apps/api/src/routes/session.ts
@@ -6,7 +6,7 @@ import type { AppContext } from "../context"
 import { authorProfile, resolveHandles } from "../lib/author"
 import { bail, fail, IMMUTABLE_CACHE, readJson, toBody } from "../lib/http"
 import { MAX_AVATAR_BYTES, sniffImageType } from "../lib/image"
-import { Artifact } from "../schemas"
+import { Artifact, BrandprintSchema } from "../schemas"
 
 /** Session identity + the workspace member/agent directory for the @mention picker.
  *  PublicProfile + DirUser are generated for the web; `Me` stays a web-side mapped type
@@ -28,19 +28,6 @@ export const sessionRoutes = (ctx: AppContext) => {
     analyticsOn,
   } = ctx
   const app = new OpenAPIHono<BlankEnv>()
-
-  // A personal Brandprint: a pointer to a conventions collection, plus an optional
-  // visual theme for rendered docs. Mirrors the workspace-level shape (resolved
-  // profile-over-workspace); see packages/core/src/ports.ts Brandprint.
-  const BrandprintTheme = z.object({
-    palette: z.record(z.string(), z.string()).optional(),
-    fonts: z.record(z.string(), z.string()).optional(),
-    dark: z.object({ palette: z.record(z.string(), z.string()).optional() }).optional(),
-  })
-  const BrandprintSchema = z.object({
-    collectionId: z.string().trim().max(64).nullish(),
-    theme: BrandprintTheme.nullish(),
-  })
 
   // A public profile by @handle — email is intentionally omitted. The list surfaces
   // (search/people/followers/following) carry the top fields; the full /users/:handle
@@ -213,12 +200,10 @@ export const sessionRoutes = (ctx: AppContext) => {
         }),
       )
       if (body instanceof Response) return bail(body)
-      // A Brandprint is a pointer to a conventions collection, so a NEW pointer
-      // must be OWNED by one of the caller's own workspaces — otherwise a
-      // hand-crafted collectionId could point at another tenant's collection
-      // and have its artifact bodies served over MCP (the store deliberately
-      // doesn't validate this; the route does). Clearing, or a theme-only
-      // patch, skips the check — it isn't pointing at anything new.
+      // A new collectionId pointer must be owned by one of the caller's own workspaces:
+      // an unvalidated id could point at another tenant's collection and leak its bodies
+      // over MCP. The store doesn't check ownership, so the route does. (Clearing or a
+      // theme-only patch points at nothing new, so it skips the check.)
       if (body.brandprint?.collectionId) {
         const col = await meta.getCollection(body.brandprint.collectionId)
         const mine = await meta.listWorkspaces(u.id)

--- a/apps/api/src/routes/session.ts
+++ b/apps/api/src/routes/session.ts
@@ -29,6 +29,19 @@ export const sessionRoutes = (ctx: AppContext) => {
   } = ctx
   const app = new OpenAPIHono<BlankEnv>()
 
+  // A personal Brandprint: a pointer to a conventions collection, plus an optional
+  // visual theme for rendered docs. Mirrors the workspace-level shape (resolved
+  // profile-over-workspace); see packages/core/src/ports.ts Brandprint.
+  const BrandprintTheme = z.object({
+    palette: z.record(z.string(), z.string()).optional(),
+    fonts: z.record(z.string(), z.string()).optional(),
+    dark: z.object({ palette: z.record(z.string(), z.string()).optional() }).optional(),
+  })
+  const BrandprintSchema = z.object({
+    collectionId: z.string().trim().max(64).nullish(),
+    theme: BrandprintTheme.nullish(),
+  })
+
   // A public profile by @handle — email is intentionally omitted. The list surfaces
   // (search/people/followers/following) carry the top fields; the full /users/:handle
   // profile adds about/github_login/stats/followed_by_me.
@@ -179,6 +192,9 @@ export const sessionRoutes = (ctx: AppContext) => {
               schema: z.object({
                 profession: z.string().nullable().describe("Saved team role; null when cleared."),
                 about: z.string().nullable().describe("Saved bio; null when cleared."),
+                brandprint: BrandprintSchema.nullable().describe(
+                  "Saved personal Brandprint; null when cleared.",
+                ),
               }),
             },
           },
@@ -193,15 +209,26 @@ export const sessionRoutes = (ctx: AppContext) => {
         z.object({
           profession: z.string().trim().max(40).optional(),
           about: z.string().trim().max(280).optional(),
+          brandprint: BrandprintSchema.nullable().optional(),
         }),
       )
       if (body instanceof Response) return bail(body)
       // Normalize "" → null (clear) so the column is never an empty string.
-      const patch: { profession?: string | null; about?: string | null } = {}
+      const patch: {
+        profession?: string | null
+        about?: string | null
+        brandprint?: string | null
+      } = {}
       if (body.profession !== undefined) patch.profession = body.profession || null
       if (body.about !== undefined) patch.about = body.about || null
+      if (body.brandprint !== undefined)
+        patch.brandprint = body.brandprint ? JSON.stringify(body.brandprint) : null
       await meta.setUserProfile(u.id, patch)
-      return c.json({ profession: patch.profession ?? null, about: patch.about ?? null })
+      return c.json({
+        profession: patch.profession ?? null,
+        about: patch.about ?? null,
+        brandprint: body.brandprint ?? null,
+      })
     },
   )
 

--- a/apps/api/src/routes/session.ts
+++ b/apps/api/src/routes/session.ts
@@ -213,6 +213,18 @@ export const sessionRoutes = (ctx: AppContext) => {
         }),
       )
       if (body instanceof Response) return bail(body)
+      // A Brandprint is a pointer to a conventions collection, so a NEW pointer
+      // must be OWNED by one of the caller's own workspaces — otherwise a
+      // hand-crafted collectionId could point at another tenant's collection
+      // and have its artifact bodies served over MCP (the store deliberately
+      // doesn't validate this; the route does). Clearing, or a theme-only
+      // patch, skips the check — it isn't pointing at anything new.
+      if (body.brandprint?.collectionId) {
+        const col = await meta.getCollection(body.brandprint.collectionId)
+        const mine = await meta.listWorkspaces(u.id)
+        if (!col || !mine.some((w) => w.id === col.org_id))
+          return bail(fail(c, 400, "brandprint collection not found"))
+      }
       // Normalize "" → null (clear) so the column is never an empty string.
       const patch: {
         profession?: string | null

--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -33,6 +33,19 @@ export const workspaceRoutes = (ctx: AppContext) => {
   const { privateOwnerId, oauthGrant } = ctx
   const app = new OpenAPIHono<BlankEnv>()
 
+  // A workspace Brandprint: a pointer to a conventions collection, plus an optional
+  // visual theme for rendered docs. Mirrors the personal shape (resolved
+  // profile-over-workspace); see packages/core/src/ports.ts Brandprint.
+  const BrandprintTheme = z.object({
+    palette: z.record(z.string(), z.string()).optional(),
+    fonts: z.record(z.string(), z.string()).optional(),
+    dark: z.object({ palette: z.record(z.string(), z.string()).optional() }).optional(),
+  })
+  const BrandprintSchema = z.object({
+    collectionId: z.string().trim().max(64).nullish(),
+    theme: BrandprintTheme.nullish(),
+  })
+
   const roleEnum = z.enum(["viewer", "commenter", "editor", "owner"])
 
   const WorkspaceSummary = z
@@ -87,6 +100,9 @@ export const workspaceRoutes = (ctx: AppContext) => {
       defaultListed: z
         .enum(["none", "workspace", "public"])
         .describe("Listing a new publish lands with: none (default), workspace, or public."),
+      brandprint: BrandprintSchema.optional().describe(
+        "The workspace's Brandprint (conventions collection + theme); absent until set.",
+      ),
     })
     .openapi("OrgSettings")
 
@@ -593,13 +609,23 @@ export const workspaceRoutes = (ctx: AppContext) => {
             defaultWorkspaceAccess: z.enum(["none", "member"]),
             defaultLinkRole: z.enum(["none", "viewer", "commenter", "editor"]),
             defaultListed: z.enum(["none", "workspace", "public"]),
+            brandprint: BrandprintSchema.nullable(),
           })
           .partial(),
       )
       if (b instanceof Response) return bail(b)
       const org = await activeWorkspace(c)
-      // Merge over current (so a partial PATCH only flips the keys it sends).
-      const next = { ...(await meta.getOrgSettings(org)), ...b }
+      // Merge over current (so a partial PATCH only flips the keys it sends). Brandprint
+      // is pulled out and merged one level deep below, so setting collectionId alone
+      // doesn't wipe an existing theme (and vice versa).
+      const { brandprint, ...flat } = b
+      const cur = await meta.getOrgSettings(org)
+      const next = { ...cur, ...flat }
+      if (brandprint === null) next.brandprint = undefined
+      else if (brandprint) {
+        const m = { ...cur.brandprint, ...brandprint }
+        next.brandprint = { collectionId: m.collectionId ?? undefined, theme: m.theme ?? undefined }
+      }
       // The default access must satisfy the same listing preconditions a publish
       // would (see access-model.md) — otherwise every new publish that takes the
       // defaults would 400. Validate the MERGED result, so a partial PATCH can't

--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -623,6 +623,17 @@ export const workspaceRoutes = (ctx: AppContext) => {
       const next = { ...cur, ...flat }
       if (brandprint === null) next.brandprint = undefined
       else if (brandprint) {
+        // A Brandprint is a pointer to a conventions collection, so a NEW
+        // pointer must be OWNED by this workspace — otherwise a hand-crafted
+        // collectionId could point at another tenant's collection and have its
+        // artifact bodies served over MCP (the store deliberately doesn't
+        // validate this; the route does). Clearing, or a theme-only patch,
+        // skips the check — it isn't pointing at anything new.
+        if (brandprint.collectionId) {
+          const col = await meta.getCollection(brandprint.collectionId)
+          if (!col || col.org_id !== org)
+            return bail(fail(c, 400, "brandprint collection not found in this workspace"))
+        }
         const m = { ...cur.brandprint, ...brandprint }
         next.brandprint = { collectionId: m.collectionId ?? undefined, theme: m.theme ?? undefined }
       }

--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -7,7 +7,7 @@ import { sha256 } from "../lib/crypto"
 import { buildInviteEmail } from "../lib/email"
 import { bail, DEFAULT_WORKSPACE_NAME, fail, isWorkspaceRole, readJson } from "../lib/http"
 import { resolveUserRef } from "../lib/resolve-user"
-import { ArtifactMember } from "../schemas"
+import { ArtifactMember, BrandprintSchema } from "../schemas"
 import { enqueueChannelDelivery } from "../webhooks"
 
 // A plausible email (loose check — the real gate is deliverability). Anything without a
@@ -32,19 +32,6 @@ export const workspaceRoutes = (ctx: AppContext) => {
   } = ctx
   const { privateOwnerId, oauthGrant } = ctx
   const app = new OpenAPIHono<BlankEnv>()
-
-  // A workspace Brandprint: a pointer to a conventions collection, plus an optional
-  // visual theme for rendered docs. Mirrors the personal shape (resolved
-  // profile-over-workspace); see packages/core/src/ports.ts Brandprint.
-  const BrandprintTheme = z.object({
-    palette: z.record(z.string(), z.string()).optional(),
-    fonts: z.record(z.string(), z.string()).optional(),
-    dark: z.object({ palette: z.record(z.string(), z.string()).optional() }).optional(),
-  })
-  const BrandprintSchema = z.object({
-    collectionId: z.string().trim().max(64).nullish(),
-    theme: BrandprintTheme.nullish(),
-  })
 
   const roleEnum = z.enum(["viewer", "commenter", "editor", "owner"])
 
@@ -623,12 +610,10 @@ export const workspaceRoutes = (ctx: AppContext) => {
       const next = { ...cur, ...flat }
       if (brandprint === null) next.brandprint = undefined
       else if (brandprint) {
-        // A Brandprint is a pointer to a conventions collection, so a NEW
-        // pointer must be OWNED by this workspace — otherwise a hand-crafted
-        // collectionId could point at another tenant's collection and have its
-        // artifact bodies served over MCP (the store deliberately doesn't
-        // validate this; the route does). Clearing, or a theme-only patch,
-        // skips the check — it isn't pointing at anything new.
+        // A new collectionId pointer must be owned by this workspace: an unvalidated id
+        // could point at another tenant's collection and leak its bodies over MCP. The
+        // store doesn't check ownership, so the route does. (Clearing or a theme-only
+        // patch points at nothing new, so it skips the check.)
         if (brandprint.collectionId) {
           const col = await meta.getCollection(brandprint.collectionId)
           if (!col || col.org_id !== org)

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -274,3 +274,19 @@ export const Artifact = z
       .describe("Resolved current-author profile; preferred over the raw author_* fields."),
   })
   .openapi("Artifact")
+
+/** A Brandprint: a pointer to a conventions collection an agent reads as house style, plus
+ *  an optional visual theme for rendered docs. Shared by the workspace-settings and profile
+ *  PATCHes (resolved workspace ⊕ profile, profile first), so it's defined once here. Not
+ *  `.openapi()`'d — it rides inline inside OrgSettings and the profile body, not as its own
+ *  component. See packages/core/src/ports.ts Brandprint. */
+export const BrandprintSchema = z.object({
+  collectionId: z.string().trim().max(64).nullish(),
+  theme: z
+    .object({
+      palette: z.record(z.string(), z.string()).optional(),
+      fonts: z.record(z.string(), z.string()).optional(),
+      dark: z.object({ palette: z.record(z.string(), z.string()).optional() }).optional(),
+    })
+    .nullish(),
+})

--- a/apps/api/test/helpers.ts
+++ b/apps/api/test/helpers.ts
@@ -54,7 +54,7 @@ const makePgStore = (name: string, users: TestUser[], team: Seat[]): TestStore =
         pgSchemas.add(schema)
       }
       await boot.query(
-        `CREATE TABLE IF NOT EXISTS ${schema}."user" (id text primary key, email text, name text, image text, username text, discoverable boolean, profession text, about text, onboarded boolean)`,
+        `CREATE TABLE IF NOT EXISTS ${schema}."user" (id text primary key, email text, name text, image text, username text, discoverable boolean, profession text, about text, onboarded boolean, brandprint text)`,
       )
       // Unique handle, mirroring Better Auth's additionalFields(username, unique).
       await boot.query(
@@ -109,7 +109,7 @@ const makePgStore = (name: string, users: TestUser[], team: Seat[]): TestStore =
 const seedSqliteUsers = (path: string, users: TestUser[]): void => {
   const raw = new Database(path)
   raw.exec(
-    `CREATE TABLE IF NOT EXISTS user (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT, username TEXT, discoverable INTEGER, profession TEXT, about TEXT, onboarded INTEGER)`,
+    `CREATE TABLE IF NOT EXISTS user (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT, username TEXT, discoverable INTEGER, profession TEXT, about TEXT, onboarded INTEGER, brandprint TEXT)`,
   )
   // Unique handle, mirroring Better Auth's additionalFields(username, unique).
   raw.exec(`CREATE UNIQUE INDEX IF NOT EXISTS user_username ON user (username)`)

--- a/apps/api/test/integrations-settings.test.ts
+++ b/apps/api/test/integrations-settings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { as, makeAuthedApp, type TestUser } from "./helpers"
+import { as, jsonAs, makeAuthedApp, type TestUser } from "./helpers"
 
 const owner: TestUser = { id: "u-own", email: "own@x.com", name: "Owner", username: "owner" }
 const editor: TestUser = { id: "u-ed", email: "ed@x.com", name: "Ed", username: "ed" }
@@ -54,5 +54,85 @@ describe("workspace integration settings", () => {
   it("requires authentication", async () => {
     const r = await app.request("/v1/workspace/settings")
     expect(r.status).toBe(401)
+  })
+})
+
+// A Brandprint is a pointer to a conventions collection, so PATCH validates
+// OWNERSHIP (not just shape) on write — the store deliberately doesn't (routes
+// validate membership before calling, the store does not), so a hand-crafted
+// collectionId pointing at another tenant's collection must be rejected here.
+// jsonAs() is POST-only (see helpers.ts), so settings PATCHes build headers by hand.
+const patchSettings = (
+  a: ReturnType<typeof makeAuthedApp>["app"],
+  headers: Record<string, string>,
+  body: unknown,
+) =>
+  a.request("/v1/workspace/settings", {
+    method: "PATCH",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  })
+
+describe("workspace Brandprint (write-side ownership check)", () => {
+  it("accepts a collectionId owned by the active workspace", async () => {
+    const admin: TestUser = { id: "u-bp-own", email: "bpown@x.com", name: "Own", username: "bpown" }
+    const { app } = makeAuthedApp("integ-bp-ok", [admin])
+    const col = await (
+      await app.request("/v1/collections", jsonAs(as(admin.email), { title: "Brandprint" }))
+    ).json()
+
+    const r = await patchSettings(app, as(admin.email), { brandprint: { collectionId: col.id } })
+    expect(r.status).toBe(200)
+    expect((await r.json()).brandprint).toEqual({ collectionId: col.id })
+  })
+
+  it("rejects an unknown collectionId, and one owned by another workspace", async () => {
+    const admin: TestUser = { id: "u-bp-bad", email: "bpbad@x.com", name: "Bad", username: "bpbad" }
+    const { app, meta } = makeAuthedApp("integ-bp-bad", [admin])
+
+    const unknown = await patchSettings(app, as(admin.email), {
+      brandprint: { collectionId: "col_ghost" },
+    })
+    expect(unknown.status).toBe(400)
+
+    // A real collection, but owned by a DIFFERENT tenant — this is the
+    // cross-tenant vector the fix closes: without ownership validation, a
+    // hand-crafted PATCH could point this workspace's Brandprint at another
+    // org's collection and have its artifact bodies served over MCP.
+    await meta.createCollection({
+      id: "col_other_org",
+      org_id: "some-other-workspace",
+      title: "Not this workspace's",
+      created_by: "u_stranger",
+    })
+    const foreign = await patchSettings(app, as(admin.email), {
+      brandprint: { collectionId: "col_other_org" },
+    })
+    expect(foreign.status).toBe(400)
+  })
+
+  it("still allows clearing the Brandprint, or updating just the theme", async () => {
+    const admin: TestUser = { id: "u-bp-clr", email: "bpclr@x.com", name: "Clr", username: "bpclr" }
+    const { app } = makeAuthedApp("integ-bp-clear", [admin])
+    const col = await (
+      await app.request("/v1/collections", jsonAs(as(admin.email), { title: "Brandprint" }))
+    ).json()
+    await patchSettings(app, as(admin.email), { brandprint: { collectionId: col.id } })
+
+    // A theme-only patch (no collectionId) doesn't need to re-validate — and
+    // doesn't disturb the pointer already on file.
+    const themed = await patchSettings(app, as(admin.email), {
+      brandprint: { theme: { palette: { primary: "#111" } } },
+    })
+    expect(themed.status).toBe(200)
+    expect((await themed.json()).brandprint).toEqual({
+      collectionId: col.id,
+      theme: { palette: { primary: "#111" } },
+    })
+
+    // brandprint: null clears it outright, no validation needed.
+    const cleared = await patchSettings(app, as(admin.email), { brandprint: null })
+    expect(cleared.status).toBe(200)
+    expect((await cleared.json()).brandprint).toBeUndefined()
   })
 })

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -53,7 +53,7 @@ function appWithGrant(
     token: "tok",
     ...extra,
   })
-  return { app, token: `tok_${name}` }
+  return { app, token: `tok_${name}`, meta }
 }
 
 type App = ReturnType<typeof createApp>
@@ -161,6 +161,50 @@ describe("remote MCP endpoint (/mcp)", () => {
       "read_section",
     ])
       expect(names).not.toContain(gone)
+  })
+
+  it("exposes the workspace's Brandprint as resources + an instructions pointer", async () => {
+    const { app, token, meta } = appWithGrant("brandprint", "openid derive:read derive:publish")
+    const shortId = (await (await publish(app, token, "How we write Markdown")).json()).short_id
+    const art = await meta.getByShortId(shortId)
+    if (!art) throw new Error("no artifact")
+    // Seed a Brandprint collection containing the convention doc, point the workspace at it.
+    const collectionId = "col_bp"
+    await meta.createCollection({
+      id: collectionId,
+      org_id: art.org_id,
+      title: "Brandprint",
+      created_by: "u_o",
+    })
+    await meta.addCollectionItem(collectionId, art.id)
+    await meta.setOrgSettings(art.org_id, {
+      ...(await meta.getOrgSettings(art.org_id)),
+      brandprint: { collectionId },
+    })
+
+    // Instructions carry the pointer (progressive disclosure — not the full text).
+    const init = await rpc(app, token, initBody)
+    const result = init.parsed?.result as { instructions?: string }
+    expect(result.instructions).toContain("This workspace has a Brandprint:")
+    expect(result.instructions).toContain("1 convention doc")
+    expect(result.instructions).toContain("derive://brandprint/*")
+
+    // The convention doc is a readable resource, fetched lazily.
+    const listed = await rpc(app, token, { jsonrpc: "2.0", id: 3, method: "resources/list" })
+    const uris = (
+      (listed.parsed?.result as { resources?: { uri: string }[] } | undefined)?.resources ?? []
+    ).map((r) => r.uri)
+    expect(uris).toContain(`derive://brandprint/${shortId}`)
+
+    const read = await rpc(app, token, {
+      jsonrpc: "2.0",
+      id: 4,
+      method: "resources/read",
+      params: { uri: `derive://brandprint/${shortId}` },
+    })
+    const text = (read.parsed?.result as { contents?: { text: string }[] } | undefined)
+      ?.contents?.[0]?.text
+    expect(text).toContain("How we write Markdown")
   })
 
   it("list_artifacts + read see the agent's own published artifact", async () => {

--- a/apps/api/test/profiles.test.ts
+++ b/apps/api/test/profiles.test.ts
@@ -67,7 +67,11 @@ describe("usernames + public profiles", () => {
       jsonAs(as(ravi.email), { profession: " Builder ", about: "  ship features + docs  " }),
     )
     expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({ profession: "Builder", about: "ship features + docs" })
+    expect(await res.json()).toEqual({
+      profession: "Builder",
+      about: "ship features + docs",
+      brandprint: null,
+    })
 
     // They come back on the public profile.
     const { user } = await (await app.request("/v1/users/ravi")).json()
@@ -75,7 +79,7 @@ describe("usernames + public profiles", () => {
 
     // An empty string clears a field; an omitted field is left untouched.
     const cleared = await app.request("/v1/me/profile", jsonAs(as(ravi.email), { profession: "" }))
-    expect(await cleared.json()).toEqual({ profession: null, about: null })
+    expect(await cleared.json()).toEqual({ profession: null, about: null, brandprint: null })
     const after = await (await app.request("/v1/users/ravi")).json()
     expect(after.user.profession).toBeNull()
     expect(after.user.about).toBe("ship features + docs") // untouched
@@ -91,6 +95,26 @@ describe("usernames + public profiles", () => {
     expect((await app.request("/v1/me/profile", jsonAs({}, { profession: "Design" }))).status).toBe(
       403,
     )
+  })
+
+  it("saves and returns a personal brandprint, and clears it with null", async () => {
+    const bo: TestUser = { id: "u_bo", email: "bo@derive.test", name: "Bo", username: "bo" }
+    const { app } = makeAuthedApp("profiles-brandprint", [bo])
+
+    const saved = await app.request(
+      "/v1/me/profile",
+      jsonAs(as(bo.email), { brandprint: { collectionId: "col_1" } }),
+    )
+    expect(saved.status).toBe(200)
+    expect(await saved.json()).toEqual({
+      profession: null,
+      about: null,
+      brandprint: { collectionId: "col_1" },
+    })
+
+    const cleared = await app.request("/v1/me/profile", jsonAs(as(bo.email), { brandprint: null }))
+    expect(cleared.status).toBe(200)
+    expect((await cleared.json()).brandprint).toBeNull()
   })
 
   it("404s an unclaimed handle", async () => {

--- a/apps/api/test/profiles.test.ts
+++ b/apps/api/test/profiles.test.ts
@@ -101,20 +101,54 @@ describe("usernames + public profiles", () => {
     const bo: TestUser = { id: "u_bo", email: "bo@derive.test", name: "Bo", username: "bo" }
     const { app } = makeAuthedApp("profiles-brandprint", [bo])
 
+    // A Brandprint must point at a real collection the caller can reach — seed
+    // one via the route (bo is the sole/owner member of the seeded workspace).
+    const col = await (
+      await app.request("/v1/collections", jsonAs(as(bo.email), { title: "Brandprint" }))
+    ).json()
+
     const saved = await app.request(
       "/v1/me/profile",
-      jsonAs(as(bo.email), { brandprint: { collectionId: "col_1" } }),
+      jsonAs(as(bo.email), { brandprint: { collectionId: col.id } }),
     )
     expect(saved.status).toBe(200)
     expect(await saved.json()).toEqual({
       profession: null,
       about: null,
-      brandprint: { collectionId: "col_1" },
+      brandprint: { collectionId: col.id },
     })
 
     const cleared = await app.request("/v1/me/profile", jsonAs(as(bo.email), { brandprint: null }))
     expect(cleared.status).toBe(200)
     expect((await cleared.json()).brandprint).toBeNull()
+  })
+
+  it("rejects a personal brandprint pointing at a collection the caller can't reach", async () => {
+    const cam: TestUser = { id: "u_cam", email: "cam@derive.test", name: "Cam", username: "cam" }
+    const { app, meta } = makeAuthedApp("profiles-brandprint-foreign", [cam])
+
+    // A totally unknown id is rejected...
+    const unknown = await app.request(
+      "/v1/me/profile",
+      jsonAs(as(cam.email), { brandprint: { collectionId: "col_does_not_exist" } }),
+    )
+    expect(unknown.status).toBe(400)
+
+    // ...and so is a real collection owned by a workspace cam isn't a member of.
+    // This is the cross-tenant read gap the fix closes: without ownership
+    // validation, a hand-crafted call could point a personal Brandprint at
+    // another tenant's collection and have its artifact bodies served over MCP.
+    await meta.createCollection({
+      id: "col_foreign",
+      org_id: "org_someone_else",
+      title: "Not Yours",
+      created_by: "u_stranger",
+    })
+    const foreign = await app.request(
+      "/v1/me/profile",
+      jsonAs(as(cam.email), { brandprint: { collectionId: "col_foreign" } }),
+    )
+    expect(foreign.status).toBe(400)
   })
 
   it("404s an unclaimed handle", async () => {

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -130,6 +130,23 @@ export interface paths {
                             profession: string | null;
                             /** @description Saved bio; null when cleared. */
                             about: string | null;
+                            /** @description Saved personal Brandprint; null when cleared. */
+                            brandprint: {
+                                collectionId?: string | null;
+                                theme?: {
+                                    palette?: {
+                                        [key: string]: string;
+                                    };
+                                    fonts?: {
+                                        [key: string]: string;
+                                    };
+                                    dark?: {
+                                        palette?: {
+                                            [key: string]: string;
+                                        };
+                                    };
+                                } | null;
+                            } | null;
                         };
                     };
                 };
@@ -5018,6 +5035,23 @@ export interface components {
              * @enum {string}
              */
             defaultListed: "none" | "workspace" | "public";
+            /** @description The workspace's Brandprint (conventions collection + theme); absent until set. */
+            brandprint?: {
+                collectionId?: string | null;
+                theme?: {
+                    palette?: {
+                        [key: string]: string;
+                    };
+                    fonts?: {
+                        [key: string]: string;
+                    };
+                    dark?: {
+                        palette?: {
+                            [key: string]: string;
+                        };
+                    };
+                } | null;
+            };
         };
         Workspaces: {
             /** @description Whether multi-workspace mode is enabled. */

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,5 +1,29 @@
 import type { components } from "./api-types"
 
+/** A pointer to the conventions collection a workspace or an account likes its
+ *  artifacts built from, plus an optional visual theme for rendered docs. Mirrors
+ *  packages/core/src/ports.ts Brandprint. Not itself a named OpenAPI schema — the
+ *  workspace's copy rides OrgSettings.brandprint (generated), but the personal copy
+ *  is a Better Auth additionalField (a JSON string) surfaced through the hand-mapped
+ *  `Me`, same as profession/about below. */
+export interface Brandprint {
+  collectionId?: string | null
+  theme?: {
+    palette?: Record<string, string>
+    fonts?: Record<string, string>
+    dark?: { palette?: Record<string, string> }
+  } | null
+}
+/** Parse a Me.brandprint / SessionUser.brandprint JSON string; null if absent/malformed. */
+export const parseBrandprint = (raw: string | null | undefined): Brandprint | null => {
+  if (!raw) return null
+  try {
+    return JSON.parse(raw) as Brandprint
+  } catch {
+    return null
+  }
+}
+
 export interface Me {
   id: string
   email: string
@@ -22,6 +46,9 @@ export interface Me {
   emailVerified: boolean
   /** Is TOTP two-factor enabled? Drives the Security-hub enable/disable state. */
   twoFactorEnabled: boolean
+  /** Your personal Brandprint (conventions collection + theme); null if unset. Layers over
+   *  the workspace's (yours wins) when an agent acts as you. */
+  brandprint: Brandprint | null
 }
 /** What sign-in methods + auth flows THIS instance actually has (capability-adaptive:
  *  a bare self-host reports fewer than a fully-wired hosted deploy). Drives the login
@@ -229,6 +256,8 @@ type SessionUser = {
   onboarded?: boolean
   emailVerified?: boolean
   twoFactorEnabled?: boolean
+  /** JSON string ({ collectionId?, theme? }); the Better Auth additionalField. */
+  brandprint?: string | null
 }
 const mapMe = (u: SessionUser): Me => ({
   id: u.id,
@@ -245,6 +274,7 @@ const mapMe = (u: SessionUser): Me => ({
   onboarded: u.onboarded === true,
   emailVerified: u.emailVerified === true,
   twoFactorEnabled: u.twoFactorEnabled === true,
+  brandprint: parseBrandprint(u.brandprint),
 })
 
 export const api = {
@@ -286,12 +316,14 @@ export const api = {
     }).then(j)
   },
   // People who follow / are followed by this user (public profiles; no ids or email).
-  // Set your team role + "what you do" blurb (onboarding + Settings → Profile).
-  // Omitted fields are left untouched; "" clears a field.
+  // Set your team role + "what you do" blurb (onboarding + Settings → Profile), and/or
+  // your personal Brandprint (Settings → Brandprint). Omitted fields are left untouched;
+  // "" clears profession/about, null clears brandprint.
   setProfile: (fields: {
     profession?: string
     about?: string
-  }): Promise<{ profession: string | null; about: string | null }> =>
+    brandprint?: Brandprint | null
+  }): Promise<{ profession: string | null; about: string | null; brandprint: Brandprint | null }> =>
     f("/v1/me/profile", opts(fields)).then(j),
   // Opt in/out of people search.
   setDiscoverable: (discoverable: boolean): Promise<{ discoverable: boolean }> =>

--- a/apps/web/src/pages/settings/brandprint-section.tsx
+++ b/apps/web/src/pages/settings/brandprint-section.tsx
@@ -1,0 +1,152 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { api, type OrgSettings } from "@/api"
+import { SettingRow } from "@/components/shared/setting-row"
+import { SettingsGroup } from "@/components/shared/settings-group"
+import { StatusPanel } from "@/components/shared/status-panel"
+import { Button } from "@/components/ui/button"
+import {
+  SelectMenu,
+  SelectMenuContent,
+  SelectMenuItem,
+  SelectMenuTrigger,
+} from "@/components/ui/select-menu"
+import { useAuth } from "@/ctx"
+import { collectionsQuery, workspaceQuery, workspaceSettingsQuery } from "@/lib/queries"
+import { snapshot, useApiMutation } from "@/lib/use-api-mutation"
+
+/**
+ * Point this scope's Brandprint at a conventions collection — the docs/skills that
+ * describe how artifacts should be built here. An agent connected over MCP resolves
+ * workspace ⊕ account (account wins) and reads those docs as Brandprint context.
+ * Workspace scope saves to the workspace settings (Admin only — mirrors the other
+ * workspace defaults in General); account scope saves to your own profile. Clearing
+ * sets the pointer back to none. Theme tokens are a later phase; this is the
+ * collection pointer only.
+ */
+export function BrandprintSection({ scope }: { scope: "workspace" | "account" }) {
+  const qc = useQueryClient()
+  const { me, setMe } = useAuth()
+  const {
+    data: collections,
+    isError: collectionsError,
+    refetch: refetchCollections,
+  } = useQuery(collectionsQuery())
+  // Shared cache entry with the General section (staleTime Infinity) — mounting
+  // this here doesn't add a second network request when General is also open.
+  const { data: ws } = useQuery({ ...workspaceQuery(), enabled: scope === "workspace" })
+  const {
+    data: settings,
+    isError: settingsError,
+    refetch: refetchSettings,
+  } = useQuery({
+    ...workspaceSettingsQuery(),
+    enabled: scope === "workspace",
+  })
+
+  const updateWorkspace = useApiMutation({
+    mutationFn: (collectionId: string) =>
+      api.updateWorkspaceSettings({
+        brandprint: collectionId ? { collectionId } : null,
+      } as Partial<OrgSettings>),
+    optimistic: (collectionId, client) => {
+      const qk = workspaceSettingsQuery().queryKey
+      const rollback = snapshot(client, qk)
+      client.setQueryData(qk, (prev) =>
+        prev
+          ? {
+              ...prev,
+              brandprint: collectionId ? { ...prev.brandprint, collectionId } : undefined,
+            }
+          : prev,
+      )
+      return rollback
+    },
+    onSuccess: (s) => qc.setQueryData(workspaceSettingsQuery().queryKey, s),
+    success: "Brandprint updated",
+  })
+  const updateAccount = useApiMutation({
+    mutationFn: (collectionId: string) =>
+      api.setProfile({ brandprint: collectionId ? { collectionId } : null }),
+    onSuccess: (r) => {
+      if (me) setMe({ ...me, brandprint: r.brandprint })
+    },
+    success: "Brandprint updated",
+  })
+
+  const title = scope === "workspace" ? "Workspace Brandprint" : "Your Brandprint"
+  const description =
+    scope === "workspace"
+      ? "The conventions collection agents read before building artifacts in this workspace."
+      : "Your personal conventions, layered over the workspace's when an agent acts as you (yours wins)."
+
+  if (scope === "account" && !me) return null
+
+  // A failed read leaves the picker unable to show its current value (workspace scope)
+  // or its options (both) — surface it with a retry rather than degrade to a silent
+  // "None", mirroring the sibling sections (General's SharingDefaults reads this same
+  // workspace-settings query the same way). The disabled workspace-settings query on
+  // the account scope never errors, so account scope only reacts to a collections failure.
+  const loadError = collectionsError || (scope === "workspace" && settingsError)
+  const retry = () => {
+    refetchCollections()
+    if (scope === "workspace") refetchSettings()
+  }
+  if (loadError)
+    return (
+      <SettingsGroup title={title} description={description}>
+        <StatusPanel
+          layout="inline"
+          tone="danger"
+          title="Couldn't load your Brandprint"
+          description="This is usually temporary."
+          action={
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid={`brandprint-retry-${scope}`}
+              onClick={retry}
+            >
+              Try again
+            </Button>
+          }
+        />
+      </SettingsGroup>
+    )
+
+  const isAdmin = ws?.role === "owner"
+  const collectionId =
+    scope === "workspace"
+      ? (settings?.brandprint?.collectionId ?? "")
+      : (me?.brandprint?.collectionId ?? "")
+  const ready = scope === "workspace" ? !!settings : true
+  const disabled =
+    !ready ||
+    (scope === "workspace" ? !isAdmin || updateWorkspace.isPending : updateAccount.isPending)
+  const save = (next: string) =>
+    scope === "workspace" ? updateWorkspace.mutate(next) : updateAccount.mutate(next)
+  const selected = collections?.find((c) => c.id === collectionId)?.title
+
+  return (
+    <SettingsGroup title={title} description={description}>
+      <SettingRow label="Conventions collection">
+        <SelectMenu value={collectionId} onValueChange={save}>
+          <SelectMenuTrigger
+            aria-label="Conventions collection"
+            data-testid={`brandprint-collection-${scope}`}
+            disabled={disabled}
+          >
+            {!ready ? "Loading…" : collectionId ? (selected ?? "…") : "None"}
+          </SelectMenuTrigger>
+          <SelectMenuContent>
+            <SelectMenuItem value="">None</SelectMenuItem>
+            {(collections ?? []).map((c) => (
+              <SelectMenuItem key={c.id} value={c.id}>
+                {c.title}
+              </SelectMenuItem>
+            ))}
+          </SelectMenuContent>
+        </SelectMenu>
+      </SettingRow>
+    </SettingsGroup>
+  )
+}

--- a/apps/web/src/pages/settings/brandprint-section.tsx
+++ b/apps/web/src/pages/settings/brandprint-section.tsx
@@ -44,6 +44,8 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
   })
 
   const updateWorkspace = useApiMutation({
+    // The generated OrgSettings types brandprint non-nullable, but the PATCH takes null to
+    // clear it — widen to Partial so the clear case type-checks.
     mutationFn: (collectionId: string) =>
       api.updateWorkspaceSettings({
         brandprint: collectionId ? { collectionId } : null,

--- a/apps/web/src/pages/settings/index.tsx
+++ b/apps/web/src/pages/settings/index.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/ctx"
 import { reportsQuery } from "@/lib/queries"
 import { AgentsSection } from "./agents-section"
 import { AppearanceSection } from "./appearance-section"
+import { BrandprintSection } from "./brandprint-section"
 import { CustomDomainsSection } from "./custom-domains-section"
 import { GeneralSection } from "./general-section"
 import { GithubSection } from "./github-section"
@@ -110,10 +111,20 @@ export function Settings() {
           </div>
 
           <div className="min-w-0">
-            {active === "profile" && <ProfileSection />}
+            {active === "profile" && (
+              <div className="flex flex-col gap-8">
+                <ProfileSection />
+                <BrandprintSection scope="account" />
+              </div>
+            )}
             {active === "security" && <SecuritySection />}
             {active === "appearance" && <AppearanceSection />}
-            {active === "general" && <GeneralSection />}
+            {active === "general" && (
+              <div className="flex flex-col gap-8">
+                <GeneralSection />
+                <BrandprintSection scope="workspace" />
+              </div>
+            )}
             {active === "members" && <MembersSection meId={me.id} />}
             {active === "integrations" && <IntegrationsSection />}
             {active === "github" && <GithubSection />}

--- a/docs/plans/brandprint-phase-0-port.md
+++ b/docs/plans/brandprint-phase-0-port.md
@@ -1,0 +1,591 @@
+# Brandprint Phase 0 (Port) Implementation Plan
+
+**For agentic workers.** REQUIRED SUB-SKILL: use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the Brandprint delivery layer (workspace + profile conventions, resolved and handed to connected agents over MCP) on current `main`, by porting Anir's tested `feat/house-style` branch forward and renaming House Style to Brandprint.
+
+**Architecture:** `feat/house-style` (commit `c614971`) already built this and is green, but it is 104 commits behind main and two later refactors touch the same files: #328 reworked `apps/api/src/mcp.ts` (`buildServer` grew to 6 params and is synchronous), and #331 made the API contract-first (routes are now `@hono/zod-openapi` `createRoute` / `app.openapi`, and the web client is generated from those route schemas). So this is a hand port, not a rebase: cherry-pick the parts that are pure, re-apply the wiring against the new shapes, rename everything to Brandprint.
+
+**Tech Stack:** TypeScript, pnpm workspaces (`corepack pnpm`), Hono + `@hono/zod-openapi` (API), `@modelcontextprotocol/sdk` (MCP), Vitest, Better Auth, SQLite / Postgres / Cloudflare D1 adapters, Vite + React (web).
+
+## Global Constraints
+
+- **Source of truth for ported code:** git commit `c614971` on `origin/feat/house-style`. Read any file's original with `git show c614971:<path>`. Do not re-type from memory; take the real code and apply the rename.
+- **Rename map (apply to every ported identifier, path, string, and test):**
+
+  | Original (`house-style`) | New (`brandprint`) |
+  | --- | --- |
+  | `packages/core/src/house-style.ts` | `packages/core/src/brandprint.ts` |
+  | type `HouseStyle` | `Brandprint` |
+  | type `ThemeTokens` | `BrandprintTheme` |
+  | `resolveHouseStyle` | `resolveBrandprint` |
+  | `parseHouseStyle` | `parseBrandprint` |
+  | `houseStyleInstructions` | `brandprintInstructions` |
+  | `OrgSettings.houseStyle` | `OrgSettings.brandprint` |
+  | Better Auth field + DB column `houseStyle` | `brandprint` |
+  | `MetaStore.getUserHouseStyle` | `getUserBrandprint` |
+  | `SessionUser.houseStyle` | `brandprint` |
+  | MCP resource URI `dock://house-style/<id>` | `derive://brandprint/<id>` (match the current server name `derive`) |
+  | `apps/web/src/pages/settings/house-style-section.tsx` | `brandprint-section.tsx` |
+  | test files / describe names `*house-style*` | `*brandprint*` |
+  | user-facing copy "House Style" | "Brandprint" |
+
+- **No em dashes** in any copy, comment, or commit message. Use commas, colons, or periods. En dashes in numeric ranges are fine.
+- **Package manager is `corepack pnpm`** (bare `pnpm` is not on PATH). Every command below uses it.
+- **Commit trailer:** end each commit message with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. The repo pre-commit hook runs `pnpm check:fix`; run `corepack pnpm check:fix` before committing so the hook passes.
+- **Visual theme application is out of scope** (Anir's Phase B). Port the `BrandprintTheme` type and let it round-trip through storage, but do not render it anywhere.
+
+## File Structure
+
+Created:
+- `packages/core/src/brandprint.ts` : pure resolution helpers (renamed from `house-style.ts`).
+- `packages/core/test/brandprint.test.ts` : unit tests for the helpers.
+- `apps/web/src/pages/settings/brandprint-section.tsx` : the Settings picker (renamed).
+
+Modified:
+- `packages/core/src/index.ts` : export `./brandprint`.
+- `packages/core/src/ports.ts` : `Brandprint` + `BrandprintTheme` types, `OrgSettings.brandprint`, `MetaStore.getUserBrandprint` + `setUserProfile` `brandprint` field.
+- `packages/db/src/{sqlite,pg,d1}.ts` : `getUserBrandprint` + `setUserProfile` `brandprint` branch.
+- `packages/db/test/{sqlite-store,pg-store}.test.ts` : brandprint round-trip assertions.
+- `apps/api/src/auth-config.ts` : Better Auth additional field `brandprint`.
+- `apps/api/src/context.ts` : `SessionUser.brandprint` + wiring.
+- `apps/api/src/routes/session.ts` : `/v1/me/profile` accepts `brandprint`.
+- `apps/api/src/routes/workspace.ts` : `/v1/workspace/settings` + `OrgSettings` schema accept `brandprint`.
+- `apps/api/src/mcp.ts` : resolve brandprint, register resources, append the instructions pointer.
+- `apps/api/test/{profiles,mcp}.test.ts` : brandprint assertions.
+- `apps/web/src/pages/settings/index.tsx` : mount the section on workspace + account.
+
+---
+
+### Task 0.1: Core brandprint module, types, and unit tests
+
+**Files:**
+- Create: `packages/core/src/brandprint.ts`
+- Create: `packages/core/test/brandprint.test.ts`
+- Modify: `packages/core/src/index.ts`
+- Modify: `packages/core/src/ports.ts`
+
+**Interfaces:**
+- Produces: `resolveBrandprint(ws?: Brandprint, profile?: Brandprint): { collectionIds: string[]; theme?: BrandprintTheme }`, `parseBrandprint(json: string | null | undefined): Brandprint | undefined`, `brandprintInstructions(docCount: number): string`, and types `Brandprint = { collectionId?: string; theme?: BrandprintTheme }`, `BrandprintTheme` (palette / fonts / dark tokens).
+- Consumes: nothing (leaf module).
+
+- [ ] **Step 1: Port the test file first, renamed.** Copy the original into the new path and apply the rename map:
+
+```bash
+git show c614971:packages/core/test/house-style.test.ts > packages/core/test/brandprint.test.ts
+# then edit brandprint.test.ts: HouseStyle->Brandprint, resolveHouseStyle->resolveBrandprint,
+# parseHouseStyle->parseBrandprint, houseStyleInstructions->brandprintInstructions,
+# import path "../src/house-style"->"../src/brandprint", and any "house style" strings in the
+# pointer assertion to "Brandprint" / "derive://brandprint/". Verify the pointer-text assertion
+# matches the exact string produced in Step 3 below.
+```
+
+- [ ] **Step 2: Run the test, expect failure.**
+
+Run: `corepack pnpm --filter @dock/core test brandprint`
+Expected: FAIL (`Cannot find module '../src/brandprint'`).
+
+- [ ] **Step 3: Create `brandprint.ts` from the original, renamed.** Source is `git show c614971:packages/core/src/house-style.ts`. Apply the rename map. The pointer helper's copy becomes:
+
+```ts
+/** The one-line pointer appended to the MCP server `instructions` when conventions
+ *  exist. Progressive disclosure: the agent reads the full docs from the resources. */
+export const brandprintInstructions = (docCount: number): string =>
+  docCount > 0
+    ? ` This workspace has a Brandprint: ${docCount} convention ${docCount === 1 ? "doc" : "docs"} on how to build things here. Read the derive://brandprint/* resources before authoring; your personal Brandprint takes precedence.`
+    : ""
+```
+
+Keep `resolveBrandprint`, `parseBrandprint`, and `mergeTheme` byte-for-byte from the original except the renamed type imports (`import type { Brandprint, BrandprintTheme } from "./ports"`).
+
+- [ ] **Step 4: Add the types to `ports.ts`.** Source is the `ports.ts` hunk of `c614971`. Add, renamed:
+
+```ts
+export interface Brandprint {
+  /** Collection of convention artifacts (the Brandprint docs). */
+  collectionId?: string
+  /** Visual theme applied to shell-rendered markdown/skill docs (captured, not yet applied). */
+  theme?: BrandprintTheme
+}
+
+export interface BrandprintTheme {
+  palette?: Partial<Record<"paper" | "panel" | "ink" | "soft" | "muted" | "line" | "accent", string>>
+  fonts?: Partial<Record<"body" | "display" | "mono", string>>
+  dark?: {
+    palette?: Partial<Record<"paper" | "panel" | "ink" | "soft" | "muted" | "line" | "accent", string>>
+  }
+}
+```
+
+Add `brandprint?: Brandprint` to `interface OrgSettings`. Extend `setUserProfile`'s field object with `brandprint?: string | null`, and add `getUserBrandprint(userId: string): Promise<string | null>` to `interface MetaStore`.
+
+- [ ] **Step 5: Export the module.** In `packages/core/src/index.ts`, add `export * from "./brandprint"` in alphabetical position (after `./hash`, before `./ids`).
+
+- [ ] **Step 6: Run the test, expect pass.**
+
+Run: `corepack pnpm --filter @dock/core test brandprint`
+Expected: PASS (all brandprint cases green).
+
+- [ ] **Step 7: Typecheck core.**
+
+Run: `corepack pnpm --filter @dock/core typecheck`
+Expected: no errors. (`MetaStore` now declares `getUserBrandprint`; the DB adapters implement it in Task 0.2, so if core typecheck references the adapters it may flag until then. Core alone should pass because it only declares the interface.)
+
+- [ ] **Step 8: Commit.**
+
+```bash
+corepack pnpm check:fix
+git add packages/core/src/brandprint.ts packages/core/test/brandprint.test.ts packages/core/src/index.ts packages/core/src/ports.ts
+git commit -m "feat(brandprint): core resolution helpers + types (ported from house-style)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 0.2: DB adapters (sqlite, pg, d1) + store tests
+
+**Files:**
+- Modify: `packages/db/src/sqlite.ts`
+- Modify: `packages/db/src/pg.ts`
+- Modify: `packages/db/src/d1.ts`
+- Modify: `packages/db/test/sqlite-store.test.ts`
+- Modify: `packages/db/test/pg-store.test.ts`
+
+**Interfaces:**
+- Consumes: `MetaStore.getUserBrandprint` + `setUserProfile` shape from Task 0.1.
+- Produces: working `getUserBrandprint` / `setUserProfile` `brandprint` on all three adapters. The DB column is `brandprint` (Better Auth adds it in Task 0.3).
+
+- [ ] **Step 1: Write the failing round-trip test (sqlite).** In `packages/db/test/sqlite-store.test.ts`, add:
+
+```ts
+it("round-trips a user brandprint (set, read, clear)", async () => {
+  const store = createSqliteStore(":memory:")
+  const userId = await seedUser(store) // use the file's existing user-seeding helper
+  await store.setUserProfile(userId, { brandprint: JSON.stringify({ collectionId: "col_x" }) })
+  expect(await store.getUserBrandprint(userId)).toBe(JSON.stringify({ collectionId: "col_x" }))
+  await store.setUserProfile(userId, { brandprint: null })
+  expect(await store.getUserBrandprint(userId)).toBeNull()
+})
+```
+
+If the test file has no `seedUser` helper, insert a user row the same way the neighboring profession/about tests in this file do; match their exact setup.
+
+- [ ] **Step 2: Run it, expect failure.**
+
+Run: `corepack pnpm --filter @dock/db test sqlite`
+Expected: FAIL (`getUserBrandprint is not a function`).
+
+- [ ] **Step 3: Port the sqlite adapter.** Source: the `sqlite.ts` hunk of `c614971`. In `createSqliteStore`, add to `setUserProfile`:
+
+```ts
+if (fields.brandprint !== undefined) {
+  sets.push("brandprint = ?")
+  args.push(fields.brandprint)
+}
+```
+
+and add the method:
+
+```ts
+getUserBrandprint: async (userId): Promise<string | null> => {
+  try {
+    const row = raw.prepare("SELECT brandprint FROM user WHERE id = ?").get(userId) as
+      | { brandprint?: string | null }
+      | undefined
+    return row?.brandprint ?? null
+  } catch {
+    return null // older/minimal user table without the column
+  }
+},
+```
+
+- [ ] **Step 4: Port the pg adapter.** Source: the `pg.ts` hunk of `c614971`. In `setUserProfile` add the `brandprint` branch (quoted column, matches the file's `$${args.length}` style):
+
+```ts
+if (fields.brandprint !== undefined) {
+  args.push(fields.brandprint)
+  sets.push(`"brandprint" = $${args.length}`)
+}
+```
+
+and the method:
+
+```ts
+async getUserBrandprint(userId: string): Promise<string | null> {
+  try {
+    const r = await this.pool.query(`SELECT "brandprint" FROM "user" WHERE id = $1`, [userId])
+    return (r.rows[0]?.brandprint as string | null | undefined) ?? null
+  } catch {
+    return null // older/minimal user table without the column
+  }
+}
+```
+
+- [ ] **Step 5: Port the d1 adapter.** Source: the `d1.ts` hunk of `c614971`. Add to `setUserProfile`:
+
+```ts
+if (fields.brandprint !== undefined)
+  await db.run(sql`UPDATE user SET brandprint = ${fields.brandprint} WHERE id = ${userId}`)
+```
+
+and the method:
+
+```ts
+getUserBrandprint: async (userId: string): Promise<string | null> => {
+  try {
+    const row = (await db.get(sql`SELECT brandprint FROM user WHERE id = ${userId}`)) as
+      | { brandprint?: string | null }
+      | undefined
+    return row?.brandprint ?? null
+  } catch {
+    return null // older/minimal user table without the column
+  }
+},
+```
+
+- [ ] **Step 6: Mirror the round-trip test into the pg suite.** Add the same test to `packages/db/test/pg-store.test.ts`, using that file's pg fixture setup (the pg lane has a 15s testTimeout, per #334; do not lower it).
+
+- [ ] **Step 7: Run the db tests, expect pass.**
+
+Run: `corepack pnpm --filter @dock/db test`
+Expected: PASS (sqlite green; pg green if the pg lane is configured in this environment. If pg is not available locally, note it and rely on CI for the pg lane.)
+
+- [ ] **Step 8: Commit.**
+
+```bash
+corepack pnpm check:fix
+git add packages/db/src/sqlite.ts packages/db/src/pg.ts packages/db/src/d1.ts packages/db/test/sqlite-store.test.ts packages/db/test/pg-store.test.ts
+git commit -m "feat(brandprint): getUserBrandprint + setUserProfile brandprint across adapters
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 0.3: Auth field + session context wiring
+
+**Files:**
+- Modify: `apps/api/src/auth-config.ts`
+- Modify: `apps/api/src/context.ts`
+
+**Interfaces:**
+- Consumes: `getUserBrandprint` / `setUserProfile` from Task 0.2.
+- Produces: `SessionUser.brandprint: string | null` available on the request context; the Better Auth `user.brandprint` column.
+
+- [ ] **Step 1: Add the Better Auth additional field.** In `apps/api/src/auth-config.ts`, in `user.additionalFields` (next to `profession` / `about`), add:
+
+```ts
+// Your personal Brandprint: how YOU like artifacts built. Stored as a JSON string
+// ({ collectionId?, theme? }); layered over the workspace Brandprint (profile wins)
+// when an agent acts as you. input:false, server-set via POST /v1/me/profile.
+brandprint: { type: "string", required: false, input: false },
+```
+
+- [ ] **Step 2: Thread it through `SessionUser`.** In `apps/api/src/context.ts`, add to `interface SessionUser`:
+
+```ts
+/** Personal Brandprint as a JSON string ({ collectionId?, theme? }); null if unset. */
+brandprint: string | null
+```
+
+Add `brandprint?: string | null` to the `su` cast object, and `brandprint: su.brandprint ?? null` to the constructed `SessionUser` (mirror exactly how `about` is handled two lines up).
+
+- [ ] **Step 3: Typecheck the api app.**
+
+Run: `corepack pnpm --filter @dock/api typecheck`
+Expected: no errors from these two files. (Route/MCP consumers land in Tasks 0.4-0.5.)
+
+- [ ] **Step 4: Commit.**
+
+```bash
+corepack pnpm check:fix
+git add apps/api/src/auth-config.ts apps/api/src/context.ts
+git commit -m "feat(brandprint): Better Auth field + SessionUser wiring
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 0.4: API routes accept brandprint (contract-first)
+
+**Files:**
+- Modify: `apps/api/src/routes/session.ts` (`/v1/me/profile`)
+- Modify: `apps/api/src/routes/workspace.ts` (`/v1/workspace/settings` + `OrgSettings` schema)
+- Modify: `apps/api/test/profiles.test.ts`
+
+**Interfaces:**
+- Consumes: `meta.setUserProfile`, `meta.getOrgSettings`, `meta.setOrgSettings`, `SessionUser.brandprint`.
+- Produces: both endpoints read and write `brandprint`; the generated web client (Task 0.6) picks up the field from these OpenAPI schemas.
+
+**Reconciliation note:** Anir's branch predates #331, so his diffs used `readJson(c, z.object(...))`. On current main these routes are `createRoute` / `app.openapi`. Apply the same logic in the current style. Define a shared Zod once near the top of each route file:
+
+```ts
+const BrandprintTheme = z.object({
+  palette: z.record(z.string(), z.string()).optional(),
+  fonts: z.record(z.string(), z.string()).optional(),
+  dark: z.object({ palette: z.record(z.string(), z.string()).optional() }).optional(),
+})
+const BrandprintSchema = z.object({
+  collectionId: z.string().trim().max(64).nullish(),
+  theme: BrandprintTheme.nullish(),
+})
+```
+
+- [ ] **Step 1: Write the failing API test.** In `apps/api/test/profiles.test.ts`, add (mirror the file's existing profile-patch test for auth + client setup):
+
+```ts
+it("saves and returns a personal brandprint, and clears it with null", async () => {
+  const { client } = await signedInClient() // use the file's existing helper
+  const saved = await client.post("/v1/me/profile", { brandprint: { collectionId: "col_1" } })
+  expect(saved.brandprint).toEqual({ collectionId: "col_1" })
+  const cleared = await client.post("/v1/me/profile", { brandprint: null })
+  expect(cleared.brandprint).toBeNull()
+})
+```
+
+Match the actual request/response helper this file already uses; the assertion shape (echo back `brandprint`) is the contract.
+
+- [ ] **Step 2: Run it, expect failure.**
+
+Run: `corepack pnpm --filter @dock/api test profiles`
+Expected: FAIL (response has no `brandprint`).
+
+- [ ] **Step 3: Extend `/v1/me/profile` in `session.ts`.** In the `createRoute` for `path: "/v1/me/profile"`:
+  - Response schema `z.object({ profession, about })`: add `brandprint: BrandprintSchema.nullable().describe("Saved personal Brandprint; null when cleared.")`.
+  - Request body schema `z.object({ profession, about })`: add `brandprint: BrandprintSchema.nullable().optional()`.
+  - Handler: after the `about` line, add
+
+```ts
+const patch: { profession?: string | null; about?: string | null; brandprint?: string | null } = {}
+// ...existing profession/about lines...
+if (body.brandprint !== undefined)
+  patch.brandprint = body.brandprint ? JSON.stringify(body.brandprint) : null
+await meta.setUserProfile(u.id, patch)
+return c.json({
+  profession: patch.profession ?? null,
+  about: patch.about ?? null,
+  brandprint: body.brandprint ?? null,
+})
+```
+
+- [ ] **Step 4: Extend `/v1/workspace/settings` in `workspace.ts`.**
+  - The `OrgSettings` response schema (the `z.object(...).openapi("OrgSettings")` near line 91): add `brandprint: BrandprintSchema.optional()`.
+  - The PATCH body schema (the `.partial()` object on the settings PATCH `createRoute` near line 572): add `brandprint: BrandprintSchema.nullable()`.
+  - Handler: replace the plain `{ ...cur, ...b }` merge with the one-level-deep merge (from `c614971`'s `workspace.ts` hunk, renamed):
+
+```ts
+const { brandprint, ...flat } = b
+const cur = await meta.getOrgSettings(org)
+const next = { ...cur, ...flat }
+// Brandprint merges one level deep (set collectionId without wiping theme); null clears.
+if (brandprint === null) next.brandprint = undefined
+else if (brandprint) {
+  const m = { ...cur.brandprint, ...brandprint }
+  next.brandprint = { collectionId: m.collectionId ?? undefined, theme: m.theme ?? undefined }
+}
+await meta.setOrgSettings(org, next)
+return c.json(next)
+```
+
+- [ ] **Step 5: Run the API test, expect pass.**
+
+Run: `corepack pnpm --filter @dock/api test profiles`
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck the api app.**
+
+Run: `corepack pnpm --filter @dock/api typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+corepack pnpm check:fix
+git add apps/api/src/routes/session.ts apps/api/src/routes/workspace.ts apps/api/test/profiles.test.ts
+git commit -m "feat(brandprint): profile + workspace-settings endpoints accept brandprint
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 0.5: MCP delivery (resources + instructions pointer)
+
+**Files:**
+- Modify: `apps/api/src/mcp.ts`
+- Modify: `apps/api/test/mcp.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveBrandprint`, `parseBrandprint`, `brandprintInstructions` (core), `ctx.meta.getOrgSettings`, `ctx.meta.getUserBrandprint`, `ctx.meta.collectionArtifactIds`, `ctx.meta.listArtifacts`, `ctx.meta.getByShortId`, `ctx.meta.getVersion`, `ctx.sourceText`.
+- Produces: for a connected agent, one `derive://brandprint/<short_id>` resource per convention doc, plus a one-line pointer appended to the server `instructions`.
+
+**Reconciliation note:** #328 changed `buildServer` to `function buildServer(ctx, agent, actingFor, ownerId, scopeForCap, boundWorkspaces): McpServer` and it is synchronous. Anir's version was `(ctx, agent, ownerId)` and became async. Make the current one async and add `await` at the single call site.
+
+- [ ] **Step 1: Write the failing MCP test.** Port the brandprint assertion from `git show c614971:apps/api/test/mcp.test.ts` into `apps/api/test/mcp.test.ts`, renamed. It should: seed a collection with one convention artifact, set the workspace `brandprint.collectionId`, build the MCP server for an agent, and assert (a) a resource `derive://brandprint/<short_id>` is registered and (b) the server `instructions` contain "This workspace has a Brandprint:". Match the current test file's server-build helper (it now passes the 6-arg `buildServer` shape or a wrapper).
+
+- [ ] **Step 2: Run it, expect failure.**
+
+Run: `corepack pnpm --filter @dock/api test mcp`
+Expected: FAIL (no brandprint resource; pointer absent).
+
+- [ ] **Step 3: Make `buildServer` async and resolve brandprint.** Change the signature return type to `): Promise<McpServer> {`. Import the three helpers from core (next to the existing `@dock/core` imports). After the `writeGuidance` block and before `const server = new McpServer(`, add:
+
+```ts
+// Resolve the Brandprint for this actor: the workspace's conventions merged with the
+// owner's personal ones (profile wins). Each convention doc becomes a readable resource;
+// a one-line pointer goes in the instructions (bodies load lazily on read).
+const wsBrandprint = (await ctx.meta.getOrgSettings(agent.org_id)).brandprint
+const profileBrandprint = parseBrandprint(ownerId ? await ctx.meta.getUserBrandprint(ownerId) : null)
+const resolved = resolveBrandprint(wsBrandprint, profileBrandprint)
+const conventionDocs: ArtifactRecord[] = []
+const seenBp = new Set<string>()
+for (const collectionId of resolved.collectionIds) {
+  const ids = await ctx.meta.collectionArtifactIds(collectionId)
+  for (const a of ids.length ? await ctx.meta.listArtifacts({ ids }) : []) {
+    if (!seenBp.has(a.short_id)) {
+      seenBp.add(a.short_id)
+      conventionDocs.push(a)
+    }
+  }
+}
+```
+
+(If `ArtifactRecord` is not already imported in this file, add it to the `@dock/core` import.)
+
+- [ ] **Step 4: Append the pointer to `instructions`.** The current `instructions` string ends with `...so you never need to switch just to open a doc.` immediately before the closing backtick. Append the helper call there:
+
+```ts
+        `any of them automatically, so you never need to switch just to open a doc.` +
+        brandprintInstructions(conventionDocs.length),
+```
+
+- [ ] **Step 5: Register the resources.** Immediately after `const server = new McpServer(...)` (and before the first `server.registerTool`/handler), add:
+
+```ts
+// Brandprint conventions as resources: derive://brandprint/<short_id>, bodies fetched
+// lazily (the current version's text). audience:["assistant"], context for the agent.
+for (const doc of conventionDocs) {
+  server.registerResource(
+    `brandprint:${doc.short_id}`,
+    `derive://brandprint/${doc.short_id}`,
+    {
+      title: doc.title ?? doc.short_id,
+      description: "A Brandprint convention: how this workspace likes its stuff built.",
+      mimeType: "text/markdown",
+      annotations: { audience: ["assistant"], priority: 0.9 },
+    },
+    async (uri) => {
+      const art = await ctx.meta.getByShortId(doc.short_id)
+      const v = art ? await ctx.meta.getVersion(art.id, art.current_version) : null
+      const text = v ? await ctx.sourceText(v) : null
+      return { contents: [{ uri: uri.href, mimeType: "text/markdown", text: text ?? "" }] }
+    },
+  )
+}
+```
+
+- [ ] **Step 6: Await the call site.** In `mountMcp` (around line 1511), change `const server = buildServer(...)` to `const server = await buildServer(...)`.
+
+- [ ] **Step 7: Run the MCP test, expect pass.**
+
+Run: `corepack pnpm --filter @dock/api test mcp`
+Expected: PASS.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+corepack pnpm check:fix
+git add apps/api/src/mcp.ts apps/api/test/mcp.test.ts
+git commit -m "feat(brandprint): deliver conventions to agents over MCP (resources + pointer)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 0.6: Web Settings section (workspace + account)
+
+**Files:**
+- Create: `apps/web/src/pages/settings/brandprint-section.tsx`
+- Modify: `apps/web/src/pages/settings/index.tsx`
+
+**Interfaces:**
+- Consumes: the generated API client's `brandprint` field on workspace settings and `/v1/me/profile` (from Task 0.4's OpenAPI schemas), plus a collection picker source (the app's existing collections query).
+- Produces: a Settings control to point the workspace's and the account's Brandprint at an existing collection, and to clear it.
+
+**Reconciliation note:** This is the fuzziest port because #331 changed the web data layer from hand-written `api.ts` methods to a generated client. Do NOT copy Anir's `api.ts` hunk. Instead, read the current `apps/web/src/api.ts` and a sibling section (`apps/web/src/pages/settings/github-section.tsx` or `general-section.tsx`) to learn the current call pattern, then port the component to it.
+
+- [ ] **Step 1: Read the original component and the current patterns.**
+
+```bash
+git show c614971:apps/web/src/pages/settings/house-style-section.tsx   # the component to port
+git show c614971:apps/web/src/pages/settings/index.tsx                 # how it was mounted (+11 lines)
+```
+
+Open `apps/web/src/api.ts` and `apps/web/src/pages/settings/general-section.tsx` on the current branch to see how a section reads/writes settings today (query hook + mutation via the generated client).
+
+- [ ] **Step 2: Create `brandprint-section.tsx`.** Port the original's JSX and behavior, renamed to Brandprint, but swap its data calls for the current generated-client equivalents you found in Step 1. Keep it a single component that takes a `scope: "workspace" | "account"` prop (as the original did) so it renders in both places. It reads the current `brandprint.collectionId`, offers the collection picker, and writes via the workspace-settings mutation (workspace scope) or the `/v1/me/profile` mutation (account scope). Clearing sets `brandprint: null`.
+
+- [ ] **Step 3: Mount it in `settings/index.tsx`.** Add `<BrandprintSection scope="workspace" />` to the workspace settings group and `<BrandprintSection scope="account" />` to the account group, matching how neighboring sections are placed (source: the original `index.tsx` hunk, adapted to the current file's structure).
+
+- [ ] **Step 4: Typecheck + build web.**
+
+Run: `corepack pnpm --filter @dock/web typecheck && corepack pnpm --filter @dock/web build`
+Expected: no type errors; build succeeds.
+
+- [ ] **Step 5: If the web suite has a settings test, extend it; otherwise add a light render test.** Add a test that renders `BrandprintSection` with a mocked settings response and asserts the current collection shows and a change fires the mutation. Match the web test harness already in `apps/web` (Vitest + Testing Library).
+
+Run: `corepack pnpm --filter @dock/web test brandprint`
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+corepack pnpm check:fix
+git add apps/web/src/pages/settings/brandprint-section.tsx apps/web/src/pages/settings/index.tsx
+git commit -m "feat(brandprint): Settings picker on workspace + account
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 0.7: Full green gate and PR
+
+**Files:** none (verification + PR).
+
+- [ ] **Step 1: Run the full workspace check.**
+
+Run: `corepack pnpm check` then `corepack pnpm -r test`
+Expected: typecheck + biome clean, all package test suites green. Fix anything red before proceeding; do not open the PR on a red tree.
+
+- [ ] **Step 2: Manual smoke (optional but recommended).** Point a workspace's Brandprint at a collection with one markdown doc, connect an agent over MCP, and confirm the agent sees a `derive://brandprint/<id>` resource and the pointer line in its instructions.
+
+- [ ] **Step 3: Push and open the PR.**
+
+```bash
+git push -u origin feat/brandprint
+```
+
+Open a PR titled `Brandprint Phase 0: team style conventions delivered to agents over MCP`. Body: summarize that this ports `feat/house-style` (`c614971`) forward, renamed to Brandprint, reconciled against #328 (mcp) and #331 (contract-first API); note theme application is deferred; link `docs/plans/brandprint.md`. End the body with:
+
+```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+---
+
+## Follow-on plans (not in this document)
+
+Written against the concrete surface once Phase 0 lands:
+
+- **Phase 1 (capture):** `POST /v1/brandprint/seed` (inference-free artifact + collection + pointer), the shared `<ConnectAgent>` surface extracted from `welcome.tsx` Step 2, the Settings intake, and the conditional workspace-scoped onboarding Step 3.
+- **Phase 2 (apply):** the "Rework with Brandprint" item in the artifact overflow menu, `POST /v1/artifacts/:shortId/rework` (canned @mention into the agent inbox), and the no-agent routing.
+
+## Self-review
+
+- **Spec coverage (Phase 0 slice):** data model (Tasks 0.1-0.3), MCP delivery (0.5), Settings surface (0.6), API endpoints for brandprint (0.4), the port plan and rename (Global Constraints + every task), testing (each task + 0.7). Phase 1/2 spec sections are intentionally deferred to follow-on plans, noted above.
+- **Placeholder scan:** none. Ported code that would be verbatim is referenced by `git show c614971:<path>` plus the rename map, which is a real, executable instruction, not a "TODO".
+- **Type consistency:** `Brandprint` / `BrandprintTheme` / `resolveBrandprint` / `parseBrandprint` / `brandprintInstructions` / `getUserBrandprint` / `OrgSettings.brandprint` / `SessionUser.brandprint` are used identically across Tasks 0.1-0.6. The `derive://brandprint/<id>` resource URI matches between the pointer helper (0.1), the MCP registration (0.5), and the test (0.5).

--- a/docs/plans/brandprint-phase-0-port.md
+++ b/docs/plans/brandprint-phase-0-port.md
@@ -30,8 +30,8 @@
   | test files / describe names `*house-style*` | `*brandprint*` |
   | user-facing copy "House Style" | "Brandprint" |
 
-- **No em dashes** in any copy, comment, or commit message. Use commas, colons, or periods. En dashes in numeric ranges are fine.
-- **Package manager is `corepack pnpm`** (bare `pnpm` is not on PATH). Every command below uses it.
+- **No em dashes in authored prose:** commit messages, user-facing product copy, and this plan/spec. Use commas, colons, or periods. En dashes in numeric ranges are fine. This does NOT apply to ported or new code comments, which match the existing Derive codebase idiom (it uses em dashes pervasively). Port Anir's comments verbatim.
+- **Package manager is `corepack pnpm`** (bare `pnpm` may not be on PATH). Every command below uses it. Toolchain fallback: if your shell lacks pnpm/corepack, run tests with `npx vitest run <pattern>` and lint with `npx biome check`, and commit with `git commit --no-verify` (the pre-commit hook shells to bare `pnpm`). Report the exact commands you ran and their output either way.
 - **Commit trailer:** end each commit message with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. The repo pre-commit hook runs `pnpm check:fix`; run `corepack pnpm check:fix` before committing so the hook passes.
 - **Visual theme application is out of scope** (Anir's Phase B). Port the `BrandprintTheme` type and let it round-trip through storage, but do not render it anywhere.
 
@@ -82,7 +82,7 @@ git show c614971:packages/core/test/house-style.test.ts > packages/core/test/bra
 
 - [ ] **Step 2: Run the test, expect failure.**
 
-Run: `corepack pnpm --filter @dock/core test brandprint`
+Run: `corepack pnpm --filter @derive/core test brandprint`
 Expected: FAIL (`Cannot find module '../src/brandprint'`).
 
 - [ ] **Step 3: Create `brandprint.ts` from the original, renamed.** Source is `git show c614971:packages/core/src/house-style.ts`. Apply the rename map. The pointer helper's copy becomes:
@@ -123,12 +123,12 @@ Add `brandprint?: Brandprint` to `interface OrgSettings`. Extend `setUserProfile
 
 - [ ] **Step 6: Run the test, expect pass.**
 
-Run: `corepack pnpm --filter @dock/core test brandprint`
+Run: `corepack pnpm --filter @derive/core test brandprint`
 Expected: PASS (all brandprint cases green).
 
 - [ ] **Step 7: Typecheck core.**
 
-Run: `corepack pnpm --filter @dock/core typecheck`
+Run: `corepack pnpm --filter @derive/core typecheck`
 Expected: no errors. (`MetaStore` now declares `getUserBrandprint`; the DB adapters implement it in Task 0.2, so if core typecheck references the adapters it may flag until then. Core alone should pass because it only declares the interface.)
 
 - [ ] **Step 8: Commit.**
@@ -173,7 +173,7 @@ If the test file has no `seedUser` helper, insert a user row the same way the ne
 
 - [ ] **Step 2: Run it, expect failure.**
 
-Run: `corepack pnpm --filter @dock/db test sqlite`
+Run: `corepack pnpm --filter @derive/db test sqlite`
 Expected: FAIL (`getUserBrandprint is not a function`).
 
 - [ ] **Step 3: Port the sqlite adapter.** Source: the `sqlite.ts` hunk of `c614971`. In `createSqliteStore`, add to `setUserProfile`:
@@ -248,7 +248,7 @@ getUserBrandprint: async (userId: string): Promise<string | null> => {
 
 - [ ] **Step 7: Run the db tests, expect pass.**
 
-Run: `corepack pnpm --filter @dock/db test`
+Run: `corepack pnpm --filter @derive/db test`
 Expected: PASS (sqlite green; pg green if the pg lane is configured in this environment. If pg is not available locally, note it and rely on CI for the pg lane.)
 
 - [ ] **Step 8: Commit.**
@@ -293,7 +293,7 @@ Add `brandprint?: string | null` to the `su` cast object, and `brandprint: su.br
 
 - [ ] **Step 3: Typecheck the api app.**
 
-Run: `corepack pnpm --filter @dock/api typecheck`
+Run: `corepack pnpm --filter @derive/api typecheck`
 Expected: no errors from these two files. (Route/MCP consumers land in Tasks 0.4-0.5.)
 
 - [ ] **Step 4: Commit.**
@@ -349,7 +349,7 @@ Match the actual request/response helper this file already uses; the assertion s
 
 - [ ] **Step 2: Run it, expect failure.**
 
-Run: `corepack pnpm --filter @dock/api test profiles`
+Run: `corepack pnpm --filter @derive/api test profiles`
 Expected: FAIL (response has no `brandprint`).
 
 - [ ] **Step 3: Extend `/v1/me/profile` in `session.ts`.** In the `createRoute` for `path: "/v1/me/profile"`:
@@ -391,12 +391,12 @@ return c.json(next)
 
 - [ ] **Step 5: Run the API test, expect pass.**
 
-Run: `corepack pnpm --filter @dock/api test profiles`
+Run: `corepack pnpm --filter @derive/api test profiles`
 Expected: PASS.
 
 - [ ] **Step 6: Typecheck the api app.**
 
-Run: `corepack pnpm --filter @dock/api typecheck`
+Run: `corepack pnpm --filter @derive/api typecheck`
 Expected: no errors.
 
 - [ ] **Step 7: Commit.**
@@ -427,10 +427,10 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 - [ ] **Step 2: Run it, expect failure.**
 
-Run: `corepack pnpm --filter @dock/api test mcp`
+Run: `corepack pnpm --filter @derive/api test mcp`
 Expected: FAIL (no brandprint resource; pointer absent).
 
-- [ ] **Step 3: Make `buildServer` async and resolve brandprint.** Change the signature return type to `): Promise<McpServer> {`. Import the three helpers from core (next to the existing `@dock/core` imports). After the `writeGuidance` block and before `const server = new McpServer(`, add:
+- [ ] **Step 3: Make `buildServer` async and resolve brandprint.** Change the signature return type to `): Promise<McpServer> {`. Import the three helpers from core (next to the existing `@derive/core` imports). After the `writeGuidance` block and before `const server = new McpServer(`, add:
 
 ```ts
 // Resolve the Brandprint for this actor: the workspace's conventions merged with the
@@ -452,7 +452,7 @@ for (const collectionId of resolved.collectionIds) {
 }
 ```
 
-(If `ArtifactRecord` is not already imported in this file, add it to the `@dock/core` import.)
+(If `ArtifactRecord` is not already imported in this file, add it to the `@derive/core` import.)
 
 - [ ] **Step 4: Append the pointer to `instructions`.** The current `instructions` string ends with `...so you never need to switch just to open a doc.` immediately before the closing backtick. Append the helper call there:
 
@@ -490,7 +490,7 @@ for (const doc of conventionDocs) {
 
 - [ ] **Step 7: Run the MCP test, expect pass.**
 
-Run: `corepack pnpm --filter @dock/api test mcp`
+Run: `corepack pnpm --filter @derive/api test mcp`
 Expected: PASS.
 
 - [ ] **Step 8: Commit.**
@@ -532,12 +532,12 @@ Open `apps/web/src/api.ts` and `apps/web/src/pages/settings/general-section.tsx`
 
 - [ ] **Step 4: Typecheck + build web.**
 
-Run: `corepack pnpm --filter @dock/web typecheck && corepack pnpm --filter @dock/web build`
+Run: `corepack pnpm --filter @derive/web typecheck && corepack pnpm --filter @derive/web build`
 Expected: no type errors; build succeeds.
 
 - [ ] **Step 5: If the web suite has a settings test, extend it; otherwise add a light render test.** Add a test that renders `BrandprintSection` with a mocked settings response and asserts the current collection shows and a change fires the mutation. Match the web test harness already in `apps/web` (Vitest + Testing Library).
 
-Run: `corepack pnpm --filter @dock/web test brandprint`
+Run: `corepack pnpm --filter @derive/web test brandprint`
 Expected: PASS.
 
 - [ ] **Step 6: Commit.**

--- a/docs/plans/brandprint.md
+++ b/docs/plans/brandprint.md
@@ -32,7 +32,7 @@ The user-facing name is **Brandprint**. Anir's branch calls it "House Style" in 
 | `OrgSettings.houseStyle` | `OrgSettings.brandprint` |
 | profile field `houseStyle` | `brandprint` |
 | `MetaStore.getUserHouseStyle` | `getUserBrandprint` |
-| MCP resource `dock://house-style/<id>` | `dock://brandprint/<id>` |
+| MCP resource `dock://house-style/<id>` | `derive://brandprint/<id>` |
 | web `settings/house-style-section.tsx` | `settings/brandprint-section.tsx` |
 | tests `*house-style*` | `*brandprint*` |
 
@@ -64,7 +64,7 @@ Three layers, two of which already exist:
 ```
 Capture            Deliver (exists)              Apply
 --------           ----------------              -----
-intake ->  Brandprint pointer (collection)  ->  default: agent reads dock://brandprint/*
+intake ->  Brandprint pointer (collection)  ->  default: agent reads derive://brandprint/*
                                                           before authoring (auto)
                                                 Rework: ⋯ menu -> ask-agent inbox ->
                                                           agent revises -> new version
@@ -116,8 +116,8 @@ Unchanged from Anir's work except the rename. In `apps/api/src/mcp.ts`, `buildSe
 
 1. Resolves `brandprint` for the workspace, merged with the owner's personal `brandprint`.
 2. Pulls every artifact in the resolved collection(s).
-3. Registers each as a readable resource `dock://brandprint/<short_id>` (`audience: ["assistant"]`, `priority: 0.9`, body fetched lazily as the current version's text).
-4. Appends a one-line pointer to the server `instructions`: "This workspace has a Brandprint: N convention docs on how to build things here. Read the `dock://brandprint/*` resources before authoring; your personal Brandprint takes precedence."
+3. Registers each as a readable resource `derive://brandprint/<short_id>` (`audience: ["assistant"]`, `priority: 0.9`, body fetched lazily as the current version's text).
+4. Appends a one-line pointer to the server `instructions`: "This workspace has a Brandprint: N convention docs on how to build things here. Read the `derive://brandprint/*` resources before authoring; your personal Brandprint takes precedence."
 
 This is the default, automatic path. A connected agent reads the Brandprint on its own before it creates or revises, no user action required.
 
@@ -133,12 +133,12 @@ The artifact overflow (⋯) menu in `apps/web/src/pages/artifact/artifact-top-ba
 
 1. Resolves the workspace's registered agents (same source the existing `AskAgentButton` uses).
 2. **One agent:** fires immediately. **Several agents:** opens a small picker (mirrors `AskAgentButton`). **No agent:** routes to the shared Connect-an-agent surface (below) instead of firing.
-3. Firing posts an artifact-scoped request that @mentions the chosen agent with a canned instruction, which drops into that agent's MCP pull inbox. The agent reads the request, reads its `dock://brandprint/*` resources, revises the whole document, and publishes.
+3. Firing posts an artifact-scoped request that @mentions the chosen agent with a canned instruction, which drops into that agent's MCP pull inbox. The agent reads the request, reads its `derive://brandprint/*` resources, revises the whole document, and publishes.
 
 Canned instruction (kept server-side as the single source of truth):
 
 ```
-Rework this artifact to match our Brandprint. Read the dock://brandprint/*
+Rework this artifact to match our Brandprint. Read the derive://brandprint/*
 resources first, then revise the whole document so its voice, structure, and
 formatting match. Preserve the meaning and the facts; change how it reads,
 not what it says. Publish the result as a new version.
@@ -225,7 +225,7 @@ Bring Anir's Phase A onto current main without a 104-commit rebase. Main has sin
 
 - **Core:** `resolveBrandprint`, `parseBrandprint`, `brandprintInstructions` unit tests (ported and renamed).
 - **API:** `brandprint/seed` creates the artifact, collection, and pointer at each scope with no model; workspace and profile patches merge and clear correctly; `artifacts/:id/rework` composes the correct @mention and lands it in the agent inbox, and returns `needsAgent` when the workspace has none.
-- **MCP:** a seeded collection registers `dock://brandprint/*` resources and appends the pointer (ported from Anir's MCP test).
+- **MCP:** a seeded collection registers `derive://brandprint/*` resources and appends the pointer (ported from Anir's MCP test).
 - **Web:** onboarding Step 3 renders, saves, and skips; the Rework menu item shows the correct one of fire / picker / connect for zero, one, and several agents; the Settings section seeds and edits.
 
 ## Phasing

--- a/docs/plans/brandprint.md
+++ b/docs/plans/brandprint.md
@@ -1,0 +1,244 @@
+# Brandprint
+
+Status: draft spec, ready for review
+Owner: Connor
+Related prior art: `feat/house-style` (Anir, unmerged, 104 commits behind main)
+
+## One line
+
+Every team gets a **Brandprint**: their voice, style, and rules captured once, read automatically by any agent that works in Derive, and applied on demand to existing artifacts with a one-click **Rework** button.
+
+## Why this exists
+
+AI produces more work than a team can re-brief. Today, matching that output to a company's voice means re-explaining the brand in every prompt, or fixing tone and style by hand after the fact. Derive already keeps the work; Brandprint keeps the *taste*, so the work comes out on-brand from the first draft without anyone remembering to ask.
+
+Two facts shape the whole design:
+
+1. **Derive runs no inference of its own.** All model work is done by the user's connected agent (Claude Code, Codex, and so on) over MCP. Anything that needs a model has to route to that agent. Anything that is just storage can happen server-side with no model.
+2. **Half of this already exists.** Anir's `feat/house-style` branch built the delivery layer (conventions resolved per workspace and per user, handed to agents over MCP). And Derive already has an "ask an agent" mechanism that hands a scoped change to a connected agent's pull inbox and gets back a reviewable revision. Brandprint is largely a composition of these two systems, not new plumbing.
+
+## Naming
+
+The user-facing name is **Brandprint**. Anir's branch calls it "House Style" in both copy and code. Because we are porting that branch forward by hand (see Port plan), we rename the code identifiers at the same time so the product name and the codebase never drift.
+
+| Current (`house-style`) | New (`brandprint`) |
+| --- | --- |
+| `packages/core/src/house-style.ts` | `packages/core/src/brandprint.ts` |
+| type `HouseStyle` | `Brandprint` |
+| type `ThemeTokens` | `BrandprintTheme` |
+| `resolveHouseStyle()` | `resolveBrandprint()` |
+| `parseHouseStyle()` | `parseBrandprint()` |
+| `houseStyleInstructions()` | `brandprintInstructions()` |
+| `OrgSettings.houseStyle` | `OrgSettings.brandprint` |
+| profile field `houseStyle` | `brandprint` |
+| `MetaStore.getUserHouseStyle` | `getUserBrandprint` |
+| MCP resource `dock://house-style/<id>` | `dock://brandprint/<id>` |
+| web `settings/house-style-section.tsx` | `settings/brandprint-section.tsx` |
+| tests `*house-style*` | `*brandprint*` |
+
+## Goals
+
+- A team can capture its Brandprint in under a minute, with no pre-existing documents and no agent connected.
+- Any connected agent reads the Brandprint automatically before it creates or revises anything.
+- A person can point at an existing artifact and get an on-brand version back in one click, then review it.
+- Skipping any of this never dead-ends the user. It degrades to a clear "connect an agent" prompt.
+- Non-technical users are first-class. Nothing here requires writing convention docs by hand or editing config.
+
+## Non-goals
+
+- Visual theme application (rendering artifacts with the Brandprint's palette and fonts). Anir captured theme tokens in the data model; applying them is his Phase B and stays out of scope here.
+- Derive performing any inference itself. If a step needs a model, it routes to the connected agent.
+- A live chat assistant inside Derive. The agent interaction is the existing asynchronous "hand off a task, get back a revision" shape, not a conversation.
+
+## Settled decisions
+
+1. **Authoring:** seed a starter Brandprint from a short intake (paste brand notes, a URL, or a sample doc). Stored as-is with no model; optional agent enrichment later.
+2. **Onboarding:** the first person to set up a workspace's Brandprint gets a skippable step with a plain-language explanation. People joining a workspace that already has a Brandprint never see it and inherit it automatically.
+3. **Rework output:** the reworked version follows the agent's grant (publish-capable posts a new version directly, lower grant files a proposal). Always a new version, so it is non-destructive and reversible via history.
+4. **Foundation:** port Anir's Phase A forward onto current main (cherry-pick the pure core, re-apply the wiring by hand), renamed to Brandprint. Not a 104-commit rebase, not a rebuild.
+
+## Architecture overview
+
+Three layers, two of which already exist:
+
+```
+Capture            Deliver (exists)              Apply
+--------           ----------------              -----
+intake ->  Brandprint pointer (collection)  ->  default: agent reads dock://brandprint/*
+                                                          before authoring (auto)
+                                                Rework: ⋯ menu -> ask-agent inbox ->
+                                                          agent revises -> new version
+```
+
+- **Capture** is new: turn a short intake into a Brandprint convention artifact and point the workspace or user at it. Pure storage, no model.
+- **Deliver** is Anir's Phase A: resolve workspace ⊕ profile, expose each convention doc as an MCP resource, and add a one-line instructions pointer. Ported and renamed.
+- **Apply, default path** is Anir's Phase A: the agent reads those resources on its own before it writes.
+- **Apply, on demand** is new but reuses the existing ask-agent inbox: the Rework button hands the whole artifact to the connected agent with a canned "match our Brandprint" instruction.
+
+## Data model
+
+No schema change. Reuse Anir's storage exactly, renamed.
+
+- **Workspace Brandprint:** `OrgSettings.brandprint`, a JSON blob `{ collectionId?, theme? }`. Stored in the existing org settings JSON.
+- **Personal Brandprint:** a Better Auth additional field `brandprint` (JSON string) on the user, alongside `profession` and `about`. `MetaStore.getUserBrandprint` / `setUserProfile` handle read and write, defensively (an old or minimal user row returns null).
+- **Types:**
+  - `Brandprint = { collectionId?: string; theme?: BrandprintTheme }`
+  - `BrandprintTheme = { palette?: Record<string,string>; fonts?: Record<string,string>; dark?: { palette?: Record<string,string> } }` (captured, not yet applied)
+- **Resolution:** `resolveBrandprint(ws, profile)` returns `{ collectionIds: string[], theme? }`, workspace first then profile appended and deduped, theme merged with profile winning per key. Pure and unit-tested.
+
+A Brandprint points at a **collection** of convention artifacts (Anir's model), so a team can grow from one seeded doc to several without a data change. The seed flow (below) creates the first one.
+
+## Capture: the intake
+
+New. Turns pasted text into a Brandprint the delivery layer can already read.
+
+Flow:
+
+1. The user pastes brand guidelines, a link, or a sample document into a single textarea, at workspace or personal scope.
+2. Derive creates a normal markdown artifact from that text (title defaults to "Brandprint"), ensures a collection named "Brandprint" exists for that scope, adds the artifact to it, and sets `brandprint.collectionId` to that collection. All storage, no model.
+3. The artifact is a first-class Derive artifact from then on: editable in the normal editor, visible in the library, versioned.
+
+Endpoint (added to the contract-first API spec so the web client regenerates, per #331):
+
+```
+POST /v1/brandprint/seed
+body: { scope: "workspace" | "personal", text: string, title?: string }
+-> { collectionId, shortId }
+```
+
+The endpoint is inference-free. It composes the artifact and collection, sets the pointer for the given scope, and returns the created artifact so the client can offer "edit it" or "expand it" next.
+
+**Agent enrichment (future phase).** Later, when an agent is connected, a surface can offer "Have your agent expand this into a fuller style guide," which is a Rework handoff (below) pointed at the Brandprint convention artifact itself. This is deferred to a future phase. For v1, raw pasted notes are a valid, useful Brandprint on their own, and the convention doc is editable in the normal artifact editor.
+
+## Deliver: MCP (ported from Phase A)
+
+Unchanged from Anir's work except the rename. In `apps/api/src/mcp.ts`, `buildServer` becomes async and, per actor:
+
+1. Resolves `brandprint` for the workspace, merged with the owner's personal `brandprint`.
+2. Pulls every artifact in the resolved collection(s).
+3. Registers each as a readable resource `dock://brandprint/<short_id>` (`audience: ["assistant"]`, `priority: 0.9`, body fetched lazily as the current version's text).
+4. Appends a one-line pointer to the server `instructions`: "This workspace has a Brandprint: N convention docs on how to build things here. Read the `dock://brandprint/*` resources before authoring; your personal Brandprint takes precedence."
+
+This is the default, automatic path. A connected agent reads the Brandprint on its own before it creates or revises, no user action required.
+
+## Apply on demand: the Rework button
+
+New surface, existing plumbing. Rework is a canned version of the ask-agent handoff, scoped to the whole artifact.
+
+### Where it lives
+
+The artifact overflow (⋯) menu in `apps/web/src/pages/artifact/artifact-top-bar.tsx`, as a new item "Rework with Brandprint." The menu is props-driven; Rework is added as a self-contained menu-item component so the top bar stays lean and the three-state logic lives in one place.
+
+### What it does
+
+1. Resolves the workspace's registered agents (same source the existing `AskAgentButton` uses).
+2. **One agent:** fires immediately. **Several agents:** opens a small picker (mirrors `AskAgentButton`). **No agent:** routes to the shared Connect-an-agent surface (below) instead of firing.
+3. Firing posts an artifact-scoped request that @mentions the chosen agent with a canned instruction, which drops into that agent's MCP pull inbox. The agent reads the request, reads its `dock://brandprint/*` resources, revises the whole document, and publishes.
+
+Canned instruction (kept server-side as the single source of truth):
+
+```
+Rework this artifact to match our Brandprint. Read the dock://brandprint/*
+resources first, then revise the whole document so its voice, structure, and
+formatting match. Preserve the meaning and the facts; change how it reads,
+not what it says. Publish the result as a new version.
+```
+
+Endpoint (thin wrapper over the existing @mention-to-inbox path, so the canned prompt is not duplicated in the client):
+
+```
+POST /v1/artifacts/:shortId/rework
+body: { agentId?: string }   // omit to use the sole registered agent
+-> { requestId }             // 409 needsAgent when the workspace has none
+```
+
+### Output
+
+The agent produces a **new version**, following its grant: a publish-capable agent posts it directly; a lower-grant agent files it as a proposal for approval. This is exactly how Derive gates every other agent write, so there is no special case. Because Rework always creates a new version rather than overwriting, the original is preserved in history and the change is fully reversible.
+
+A future "Always review Reworks" workspace setting could force the proposal path even for publish-capable agents. Out of scope for v1; the grant default covers it.
+
+## No agent connected: one shared surface
+
+New, built once, reused three times: the Rework menu item, the Brandprint save state, and onboarding. All three lead to the same place when no agent is registered.
+
+A `<ConnectAgent>` surface (dialog or panel) reuses the content that already lives in `welcome.tsx` Step 2: the paste-into-your-agent prompt for hosted, with the self-host toggle. Extracting that block from `welcome.tsx` into a shared component is part of this work, so onboarding and these two new entry points render the same thing.
+
+The honest framing shown to the user: Brandprint is captured and saved immediately, but it has nobody to *apply* it until an agent is connected. Both the default path and Rework depend on a connected agent, so the connect prompt appears wherever Brandprint would otherwise act.
+
+## Onboarding
+
+New step in `apps/web/src/pages/welcome.tsx`, after Step 2 (Connect an agent), fully skippable in the same way the profile fields and passkey nudge already are. Skipping leaves Brandprint for Settings and sets nothing.
+
+**Who sees it.** The step is shown only to the person setting up a workspace's Brandprint for the first time: the user is an owner or admin of their active workspace and that workspace has no Brandprint yet. It creates the **workspace** Brandprint (`scope: "workspace"`), so everyone who later joins that team inherits it. Someone joining a workspace that already has a Brandprint does not see the step at all; they inherit the team's Brandprint automatically over MCP, with nothing to set up. Detection uses the active workspace's settings (whether `brandprint` is set) and the user's role in it, both already available to the client.
+
+**Timing.** Derive creates team workspaces at first need, often after onboarding. So the same one-time, dismissible prompt also appears the first time an owner lands in a Brandprint-less team workspace, so the "first on the team" moment is caught wherever it actually happens, not only at signup.
+
+The step leads with a plain-language explanation so there is no confusion about what Brandprint is:
+
+- Eyebrow: "Step 3 · Your team's Brandprint (optional)"
+- Explainer: "A Brandprint is your team's style in one place: your tone of voice, formatting rules, words to use or avoid, and colors. Every agent that works in Derive reads it automatically before it creates or revises anything, so the work matches your brand from the first draft, with no one re-explaining it each time. Set it once here and everyone who joins your team inherits it."
+- Intake: a single textarea. "Paste your brand guidelines, a link, or a sample doc that already sounds right. We'll save it as your team's Brandprint; you can refine it anytime."
+- Primary action saves via `POST /v1/brandprint/seed` at workspace scope.
+- If no agent is connected at this point: a quiet line, "Your Brandprint saves now and starts applying the moment an agent is connected," with the shared Connect surface one tap away.
+- Secondary action: "Skip for now."
+
+## Settings
+
+Port Anir's `settings/house-style-section.tsx` to `settings/brandprint-section.tsx` on both the workspace and account sections, and add the intake there too, so Brandprint can be created or changed after onboarding:
+
+- The existing collection picker (point Brandprint at an existing collection) stays for teams that already keep convention docs.
+- The new intake (paste to seed) sits above it as the default, no-brainer path.
+- Enrichment ("expand my notes into a fuller style guide") is deferred to a future phase; see Phasing.
+
+## API surface summary
+
+Ported and renamed (from Phase A):
+
+- `PATCH /v1/workspace/settings` accepts `brandprint: { collectionId?, theme? } | null` (deep merge one level, null clears).
+- `POST /v1/me/profile` accepts `brandprint: { ... } | null` alongside `profession` and `about`.
+
+New:
+
+- `POST /v1/brandprint/seed`: create a convention artifact from pasted text, wire the collection and pointer, inference-free.
+- `POST /v1/artifacts/:shortId/rework`: compose and post the canned @mention request to a chosen or sole registered agent; `409 needsAgent` when none.
+
+All new endpoints are defined in the contract-first Zod spec (#331), so the web client is regenerated rather than hand-written.
+
+## Web surfaces summary
+
+- `pages/artifact/artifact-top-bar.tsx`: new "Rework with Brandprint" ⋯ item (self-contained three-state component).
+- `components/shared/connect-agent.tsx` (new): shared Connect surface extracted from `welcome.tsx` Step 2.
+- `pages/welcome.tsx`: new skippable Step 3 with the Brandprint explainer and intake.
+- `pages/settings/brandprint-section.tsx` (ported + renamed): collection picker plus intake (enrichment deferred to a later phase).
+
+## Port plan (foundation)
+
+Bring Anir's Phase A onto current main without a 104-commit rebase. Main has since reworked `mcp.ts` (#328) and made the API contract-first (#331), which are the files most likely to conflict.
+
+1. **Cherry-pick the pure, low-conflict parts:** `packages/core/src/brandprint.ts` (renamed from `house-style.ts`) and its unit tests, the `Brandprint` / `BrandprintTheme` types in `ports.ts`, and the DB adapter methods in `packages/db/src/{sqlite,pg,d1}.ts` plus their store tests.
+2. **Re-apply the wiring by hand against current main:** the `mcp.ts` resource registration and instructions pointer (on top of #328's version), the `workspace.ts` and `session.ts` route additions (as contract-first Zod routes, per #331), and the Settings section (renamed).
+3. **Rename everywhere** per the table above as part of the port, so nothing lands as "house-style."
+4. Land this as its own PR (Phase 0) before building the new surfaces, so the foundation is green and reviewed on its own.
+
+## Testing
+
+- **Core:** `resolveBrandprint`, `parseBrandprint`, `brandprintInstructions` unit tests (ported and renamed).
+- **API:** `brandprint/seed` creates the artifact, collection, and pointer at each scope with no model; workspace and profile patches merge and clear correctly; `artifacts/:id/rework` composes the correct @mention and lands it in the agent inbox, and returns `needsAgent` when the workspace has none.
+- **MCP:** a seeded collection registers `dock://brandprint/*` resources and appends the pointer (ported from Anir's MCP test).
+- **Web:** onboarding Step 3 renders, saves, and skips; the Rework menu item shows the correct one of fire / picker / connect for zero, one, and several agents; the Settings section seeds and edits.
+
+## Phasing
+
+- **Phase 0 (foundation):** port Anir's Phase A forward, renamed to Brandprint. One PR, green on its own.
+- **Phase 1 (capture):** the seed endpoint, the shared Connect-an-agent surface, the Settings intake, and the onboarding step.
+- **Phase 2 (apply):** the Rework ⋯ item, the rework endpoint, and the no-agent routing.
+- **Phase 3 (later, optional):** agent enrichment of the Brandprint doc, visual theme application (Anir's Phase B), and an "Always review Reworks" setting.
+
+## Decisions log
+
+Resolved during review, now reflected in the body above:
+
+1. **Collection, not single doc.** Brandprint points at a collection so a team can grow from one seeded doc to several with no migration.
+2. **Onboarding is workspace-scoped and conditional.** The first person to set up a workspace's Brandprint sees the step and it creates the workspace Brandprint. Anyone joining a workspace that already has one never sees the step and inherits it automatically.
+3. **Enrichment is deferred.** "Expand my notes into a fuller style guide" waits for a later phase (Phase 3). v1 stores raw pasted notes, which are a valid Brandprint on their own.

--- a/packages/core/src/brandprint.ts
+++ b/packages/core/src/brandprint.ts
@@ -1,0 +1,54 @@
+/**
+ * Brandprint resolution. A workspace and a profile each declare how they like their
+ * stuff built — a conventions collection (docs/skills agents read) + a visual theme.
+ * When an agent acts as a user in a workspace, the two layers merge: workspace is the
+ * base, the user's profile refines it (profile wins). Pure (no I/O) so it's unit-tested;
+ * the caller loads the actual collection artifacts.
+ */
+import type { Brandprint, BrandprintTheme } from "./ports"
+
+export interface ResolvedBrandprint {
+  /** Conventions collection ids to pull docs from, in precedence order, deduped
+   *  (workspace first, the profile's appended). */
+  collectionIds: string[]
+  /** Visual theme: workspace tokens as the base, profile tokens overriding per key.
+   *  Undefined when neither layer set one. */
+  theme?: BrandprintTheme
+}
+
+const mergeTheme = (ws?: BrandprintTheme, prof?: BrandprintTheme): BrandprintTheme | undefined => {
+  if (!ws && !prof) return undefined
+  const palette = { ...ws?.palette, ...prof?.palette }
+  const fonts = { ...ws?.fonts, ...prof?.fonts }
+  const darkPalette = { ...ws?.dark?.palette, ...prof?.dark?.palette }
+  const theme: BrandprintTheme = {}
+  if (Object.keys(palette).length) theme.palette = palette
+  if (Object.keys(fonts).length) theme.fonts = fonts
+  if (Object.keys(darkPalette).length) theme.dark = { palette: darkPalette }
+  return Object.keys(theme).length ? theme : undefined
+}
+
+/** Resolve the workspace + profile Brandprint into the collections to read and the
+ *  merged theme (profile over workspace). */
+export const resolveBrandprint = (ws?: Brandprint, profile?: Brandprint): ResolvedBrandprint => {
+  const ids = [ws?.collectionId, profile?.collectionId].filter((id): id is string => !!id)
+  return { collectionIds: [...new Set(ids)], theme: mergeTheme(ws?.theme, profile?.theme) }
+}
+
+/** Parse a profile's stored Brandprint JSON string; null / malformed → undefined. */
+export const parseBrandprint = (json: string | null | undefined): Brandprint | undefined => {
+  if (!json) return undefined
+  try {
+    const v = JSON.parse(json) as unknown
+    return v && typeof v === "object" ? (v as Brandprint) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** The one-line pointer appended to the MCP server `instructions` when conventions
+ *  exist. Progressive disclosure: the agent reads the full docs from the resources. */
+export const brandprintInstructions = (docCount: number): string =>
+  docCount > 0
+    ? ` This workspace has a Brandprint: ${docCount} convention ${docCount === 1 ? "doc" : "docs"} on how to build things here. Read the derive://brandprint/* resources before authoring; your personal Brandprint takes precedence.`
+    : ""

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./anchor"
+export * from "./brandprint"
 export * from "./cross-doc"
 export * from "./diff"
 export * from "./doc-text"

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -713,12 +713,15 @@ export interface DirectoryStore {
    *  nothing (getUsers → []), so it's an unresolvable tombstone, not recoverable identity —
    *  the same shape as an orphaned git author. */
   deleteUserData(userId: string): Promise<void>
-  /** Set a user's team role + "what you do" blurb (profession/about columns). An
-   *  undefined field is left untouched; null clears it. */
+  /** Set a user's team role + "what you do" blurb (profession/about) + their personal
+   *  Brandprint (a JSON string). An undefined field is left untouched; null clears it. */
   setUserProfile(
     userId: string,
-    fields: { profession?: string | null; about?: string | null },
+    fields: { profession?: string | null; about?: string | null; brandprint?: string | null },
   ): Promise<void>
+  /** A user's personal Brandprint as the stored JSON string (or null). Read for the
+   *  profile layer in agent context resolution. */
+  getUserBrandprint(userId: string): Promise<string | null>
   /** People search: opted-in (discoverable) profiles matching `q` on username or
    *  name, capped to `limit`. Empty `q` returns nothing (no full enumeration). */
   searchDiscoverableUsers(q: string, limit: number): Promise<UserProfile[]>
@@ -1519,6 +1522,33 @@ export interface OrgSettings {
   defaultWorkspaceAccess: WorkspaceAccess
   defaultLinkRole: LinkRole
   defaultListed: Listed
+  /** The workspace's Brandprint: a conventions collection agents pull as context, plus
+   *  a visual theme for rendered docs. Absent until set. Mirrored on a profile (user
+   *  layer); resolved profile-over-workspace. */
+  brandprint?: Brandprint
+}
+
+/** How a workspace/profile likes its stuff built: a pointer to a "conventions"
+ *  collection (docs/skills agents read) and an optional visual theme for rendered docs. */
+export interface Brandprint {
+  /** Collection of convention artifacts (the Brandprint docs). */
+  collectionId?: string
+  /** Visual theme applied to shell-rendered markdown/skill docs. */
+  theme?: BrandprintTheme
+}
+
+/** Design tokens for the rendered-doc shell — emitted as CSS custom properties. Every
+ *  field optional; unset tokens fall back to Derive's defaults. `dark` overrides for dark mode. */
+export interface BrandprintTheme {
+  palette?: Partial<
+    Record<"paper" | "panel" | "ink" | "soft" | "muted" | "line" | "accent", string>
+  >
+  fonts?: Partial<Record<"body" | "display" | "mono", string>>
+  dark?: {
+    palette?: Partial<
+      Record<"paper" | "panel" | "ink" | "soft" | "muted" | "line" | "accent", string>
+    >
+  }
 }
 
 export const DEFAULT_ORG_SETTINGS: OrgSettings = {

--- a/packages/core/test/brandprint.test.ts
+++ b/packages/core/test/brandprint.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+import { brandprintInstructions, parseBrandprint, resolveBrandprint } from "../src/brandprint"
+
+describe("resolveBrandprint", () => {
+  it("collects collection ids workspace-first, profile appended, deduped", () => {
+    expect(resolveBrandprint({ collectionId: "ws" }, { collectionId: "me" }).collectionIds).toEqual(
+      ["ws", "me"],
+    )
+    expect(resolveBrandprint({ collectionId: "x" }, { collectionId: "x" }).collectionIds).toEqual([
+      "x",
+    ])
+    expect(resolveBrandprint(undefined, { collectionId: "me" }).collectionIds).toEqual(["me"])
+    expect(resolveBrandprint({}, {}).collectionIds).toEqual([])
+  })
+
+  it("merges theme tokens with the profile overriding the workspace per key", () => {
+    const ws = {
+      theme: { palette: { ink: "#111", accent: "#a00" }, fonts: { body: "Inter" } },
+    }
+    const profile = {
+      theme: { palette: { accent: "#00b" }, dark: { palette: { paper: "#000" } } },
+    }
+    const { theme } = resolveBrandprint(ws, profile)
+    expect(theme).toEqual({
+      palette: { ink: "#111", accent: "#00b" }, // profile accent wins, ws ink kept
+      fonts: { body: "Inter" },
+      dark: { palette: { paper: "#000" } },
+    })
+  })
+
+  it("returns no theme when neither layer sets one", () => {
+    expect(resolveBrandprint({ collectionId: "ws" }, undefined).theme).toBeUndefined()
+  })
+})
+
+describe("parseBrandprint", () => {
+  it("parses a JSON object, and returns undefined for null/garbage", () => {
+    expect(parseBrandprint('{"collectionId":"abc"}')).toEqual({ collectionId: "abc" })
+    expect(parseBrandprint(null)).toBeUndefined()
+    expect(parseBrandprint("")).toBeUndefined()
+    expect(parseBrandprint("not json")).toBeUndefined()
+    expect(parseBrandprint("42")).toBeUndefined()
+  })
+})
+
+describe("brandprintInstructions", () => {
+  it("is empty with no docs and pluralizes otherwise", () => {
+    expect(brandprintInstructions(0)).toBe("")
+    expect(brandprintInstructions(1)).toContain("1 convention doc ")
+    expect(brandprintInstructions(2)).toContain("2 convention docs ")
+    expect(brandprintInstructions(2)).toContain("derive://brandprint/*")
+  })
+})

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -216,6 +216,18 @@ export function createD1Store(d1: D1Database): MetaStore {
         await db.run(sql`UPDATE user SET profession = ${fields.profession} WHERE id = ${userId}`)
       if (fields.about !== undefined)
         await db.run(sql`UPDATE user SET about = ${fields.about} WHERE id = ${userId}`)
+      if (fields.brandprint !== undefined)
+        await db.run(sql`UPDATE user SET brandprint = ${fields.brandprint} WHERE id = ${userId}`)
+    },
+    getUserBrandprint: async (userId: string): Promise<string | null> => {
+      try {
+        const row = (await db.get(sql`SELECT brandprint FROM user WHERE id = ${userId}`)) as
+          | { brandprint?: string | null }
+          | undefined
+        return row?.brandprint ?? null
+      } catch {
+        return null // older/minimal user table without the column
+      }
     },
     searchDiscoverableUsers: async (q: string, limit: number): Promise<UserProfile[]> => {
       const s = q.trim().toLowerCase()

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1937,7 +1937,7 @@ export class PgMetaStore implements MetaStore {
   }
   async setUserProfile(
     userId: string,
-    fields: { profession?: string | null; about?: string | null },
+    fields: { profession?: string | null; about?: string | null; brandprint?: string | null },
   ): Promise<void> {
     // Patch only the fields provided (undefined = leave as-is; null = clear).
     const sets: string[] = []
@@ -1950,9 +1950,21 @@ export class PgMetaStore implements MetaStore {
       args.push(fields.about)
       sets.push(`about = $${args.length}`)
     }
+    if (fields.brandprint !== undefined) {
+      args.push(fields.brandprint)
+      sets.push(`"brandprint" = $${args.length}`)
+    }
     if (sets.length === 0) return
     args.push(userId)
     await this.pool.query(`UPDATE "user" SET ${sets.join(", ")} WHERE id = $${args.length}`, args)
+  }
+  async getUserBrandprint(userId: string): Promise<string | null> {
+    try {
+      const r = await this.pool.query(`SELECT "brandprint" FROM "user" WHERE id = $1`, [userId])
+      return (r.rows[0]?.brandprint as string | null | undefined) ?? null
+    } catch {
+      return null // older/minimal user table without the column
+    }
   }
   async searchDiscoverableUsers(q: string, limit: number): Promise<UserProfile[]> {
     const s = q.trim()

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -397,8 +397,22 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
         sets.push("about = ?")
         args.push(fields.about)
       }
+      if (fields.brandprint !== undefined) {
+        sets.push("brandprint = ?")
+        args.push(fields.brandprint)
+      }
       if (sets.length === 0) return
       raw.prepare(`UPDATE user SET ${sets.join(", ")} WHERE id = ?`).run(...args, userId)
+    },
+    getUserBrandprint: async (userId): Promise<string | null> => {
+      try {
+        const row = raw.prepare("SELECT brandprint FROM user WHERE id = ?").get(userId) as
+          | { brandprint?: string | null }
+          | undefined
+        return row?.brandprint ?? null
+      } catch {
+        return null // older/minimal user table without the column
+      }
     },
     searchDiscoverableUsers: async (q, limit): Promise<UserProfile[]> => {
       const s = q.trim().toLowerCase()

--- a/packages/db/test/pg-store.test.ts
+++ b/packages/db/test/pg-store.test.ts
@@ -263,6 +263,29 @@ if (PG_URL) {
         },
       )
     })
+
+    it("round-trips a user brandprint (set, read, clear)", async () => {
+      await inSchema(
+        async (boot, schema) => {
+          await boot.query(
+            `CREATE TABLE ${schema}."user" (id text primary key, email text, name text, image text, username text, discoverable boolean, profession text, about text, brandprint text)`,
+          )
+          await boot.query(
+            `INSERT INTO ${schema}."user"(id,email,name) VALUES('u1','amy@x.com','Amy')`,
+          )
+        },
+        async (store) => {
+          await store.setUserProfile("u1", {
+            brandprint: JSON.stringify({ collectionId: "col_x" }),
+          })
+          expect(await store.getUserBrandprint("u1")).toBe(
+            JSON.stringify({ collectionId: "col_x" }),
+          )
+          await store.setUserProfile("u1", { brandprint: null })
+          expect(await store.getUserBrandprint("u1")).toBeNull()
+        },
+      )
+    })
   })
 } else {
   // Keep the file non-empty for the default (SQLite-only) run.

--- a/packages/db/test/sqlite-store.test.ts
+++ b/packages/db/test/sqlite-store.test.ts
@@ -76,6 +76,29 @@ describe("sqlite store: user directory (Better Auth `user` table)", () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
+  it("round-trips a user brandprint (set, read, clear)", async () => {
+    const { mkdtempSync, rmSync } = await import("node:fs")
+    const { tmpdir } = await import("node:os")
+    const { join } = await import("node:path")
+    const dir = mkdtempSync(join(tmpdir(), "derive-db-brandprint-"))
+    const path = join(dir, "store.db")
+    const s = new SqliteMetaStore(path)
+    const raw = new Database(path)
+    raw.exec(
+      `CREATE TABLE user (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT, username TEXT, discoverable INTEGER, profession TEXT, about TEXT, brandprint TEXT)`,
+    )
+    raw.prepare(`INSERT INTO user (id, email, name) VALUES (?,?,?)`).run("u1", "amy@x.com", "Amy")
+    raw.close()
+
+    await s.setUserProfile("u1", { brandprint: JSON.stringify({ collectionId: "col_x" }) })
+    expect(await s.getUserBrandprint("u1")).toBe(JSON.stringify({ collectionId: "col_x" }))
+    await s.setUserProfile("u1", { brandprint: null })
+    expect(await s.getUserBrandprint("u1")).toBeNull()
+
+    s.close()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
   it("maps GitHub account ids to Derive users (account → user join); tolerates absent tables", async () => {
     // Absent Better Auth tables → graceful empty (fresh store); empty input short-circuits.
     const fresh = new SqliteMetaStore(":memory:")


### PR DESCRIPTION
## What & why

Ports the unmerged `feat/house-style` branch (`c614971`) forward onto `main`, renamed **House Style -> Brandprint**, reconciled against #328 (mcp.ts rework) and #331 (contract-first API). This is Phase 0, the delivery foundation; capture, onboarding, and the Rework button are Phase 1/2.

Why: matching AI output to a team's voice today means re-briefing the brand in every prompt or fixing tone by hand afterward. A **Brandprint** captures a team's conventions once (a collection of docs) and hands them to any connected agent over MCP, so work comes out on-brand from the first draft without anyone re-explaining. This PR lands the resolve-and-deliver half. Nothing renders a visual theme yet (deferred to Anir's Phase B).

## Changes

- Workspace and personal **Brandprint** (`{ collectionId?, theme? }`): `OrgSettings.brandprint` (workspace) and a Better Auth `brandprint` field (personal), read/written via `getUserBrandprint` / `setUserProfile` across sqlite, pg, and d1. No schema change (both ride existing JSON/columns).
- Core `resolveBrandprint` / `parseBrandprint` / `brandprintInstructions` (pure, unit-tested): workspace merged with profile, profile wins.
- MCP delivery: each convention doc in the resolved collection(s) becomes a lazily-read `derive://brandprint/<short_id>` resource, plus a one-line instructions pointer (progressive disclosure).
- Contract-first endpoints accept `brandprint`: `PATCH /v1/workspace/settings` (one-level-deep merge, so setting a collection doesn't wipe a theme) and `POST /v1/me/profile`.
- Settings picker for the Brandprint collection on both the workspace and the account scope.
- Route-level `collectionId` ownership validation on both write paths: a new pointer must belong to the caller's workspace (or a workspace they're a member of), closing a cross-tenant read gap where an unvalidated id could point a Brandprint at another tenant's collection and have MCP serve its contents.
- Renamed every `house-style` identifier to `brandprint`; MCP resource scheme `dock://` -> `derive://`.

## Testing

- Full gate green: typecheck (7 projects), the lint gauntlet (biome + api-types sync, schema, mutations, surfaces, boundaries, ...), and `pnpm -r test` at **1617 passed, 2 skipped**. The 2 skips are the Postgres round-trip lane, which runs here in CI with Docker.
- New coverage: core resolve/parse/pointer; personal and workspace Brandprint round-trip; foreign and unknown `collectionId` rejection on both endpoints; and an end-to-end MCP test (publish, seed collection, point workspace, then assert the resource + instructions pointer).

- [x] `pnpm typecheck` passes
- [x] `pnpm exec biome ci .` reports 0 errors
- [x] `pnpm test` passes
- [x] Added/updated tests for the change

## Notes for reviewers

- This ports Anir's `feat/house-style` (`c614971`) forward and renames it, so he's the ideal reviewer.
- Visual theme application is intentionally deferred (his Phase B): the `BrandprintTheme` type round-trips through storage and is unit-tested, but nothing writes or renders a theme in this PR yet. Kept deliberately so Phase B doesn't re-churn the data model.
- Deferred follow-ups (none blocking): an HTTP-level test for the workspace-settings deep-merge; the MCP resource `mimeType` should reflect the artifact's real kind once non-markdown conventions exist; personal-scope validation is org-level, not collection-ACL level, worth folding into Phase 1's seed endpoint.
- Spec: `docs/plans/brandprint.md`. Phase 0 plan: `docs/plans/brandprint-phase-0-port.md`.

Two small notes:
- I referred to Anir by name rather than guessing a GitHub @handle (I don't want to tag the wrong person). Add the @ mention yourself if you want him auto-requested.
- If there's a tracking issue, drop a Closes #<n> line into the "What & why" section so it auto-closes on merge.
