### PR TITLE
fix(web): profile work grid uses the same delayed-pending as the other feeds

### DIFF
--- a/apps/web/src/pages/profile/index.tsx
+++ b/apps/web/src/pages/profile/index.tsx
@@ -20,6 +20,7 @@ import { useAuth } from "@/ctx"
 import { colorForName } from "@/lib/avatar-tints"
 import { getInitials } from "@/lib/initials"
 import { profileArtifactsQuery, profileQuery } from "@/lib/queries"
+import { useDelayedPending } from "@/lib/use-delayed-pending"
 import { useDocumentTitle } from "@/lib/use-document-title"
 import { ProfilePending, ProfileWorkSkeleton } from "./skeleton"
 import { ProfileWorkCard, ProfileWorkRow } from "./work-card"
@@ -248,6 +249,9 @@ function ProfileWork({
   const { data, isPending, isError, fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
     useInfiniteQuery(profileArtifactsQuery(handle))
   const items = data?.pages.flatMap((p) => p.artifacts) ?? []
+  // Same delayed-pending discipline as the library + people feeds: a cache-warm/fast load
+  // flashes nothing rather than strobing the grid skeleton.
+  const showWork = useDelayedPending(isPending)
   const sentinel = useRef<HTMLDivElement>(null)
   const [view, setView] = useState<"grid" | "list">("grid")
 
@@ -291,10 +295,13 @@ function ProfileWork({
         )}
       </div>
       {isPending ? (
-        <div role="status">
-          <span className="sr-only">Loading work…</span>
-          <ProfileWorkSkeleton />
-        </div>
+        // Hold blank for the show-delay so a fast load doesn't flash the skeleton.
+        showWork ? (
+          <div role="status">
+            <span className="sr-only">Loading work…</span>
+            <ProfileWorkSkeleton />
+          </div>
+        ) : null
       ) : isError ? (
         <StatusPanel
           tone="danger"


### PR DESCRIPTION
## Loading-contract follow-up to #373 — and a scope correction

I investigated pieces 2–4 before writing anything, and the honest result is that **most of it was already handled or would be overcomplication** — exactly what you predicted. So this PR is the *one* genuinely-warranted change.

**Piece 2 (consistent stale-dim) — already done.** `keepPreviousData` is used in exactly two places (`libraryArtifactsQuery`, `peopleQuery`), and **both already dim** on `isPlaceholderData` (library via #367, People at `people.tsx:156`). Nothing to build.

**Piece 3 (delayed skeletons) — this PR, one surface.** The library and People feeds gate their skeleton through `useDelayedPending` (flash nothing on a fast/warm load); the **profile work grid gated on bare `isPending`**, so it could strobe. Routed through the same delay — now all three feeds behave identically. `profileArtifactsQuery` has no `keepPreviousData`, so no dim is needed. The other ~24 `isPending` sites are settings sections / sub-lists where a cold-load skeleton is correct and already covered by route pending components — routing all of them through the delay would be churn for a sub-150ms flash the global bar (#373) already accompanies. **Not built.**

**Piece 4 (per-feed staleTime) — not warranted.** The library feed already `refetchOnMount: "always"` (revalidates every nav, now visible via the bar); volatile data (syncs, sessions) already polls; settings data invalidates on mutation. Shortening staleTime would add background traffic for no felt gain. **Not built.**

## Change

Two-line alignment: `const showWork = useDelayedPending(isPending)`, and gate the grid skeleton on `showWork` (blank during the ~150ms show-delay).

## Verification

typecheck 0 · biome · smoke 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)