### PR TITLE
feat(web): a "reconnecting" cue when the live stream drops (real-time robustness)

### DIFF
--- a/apps/web/e2e/deep/artifact-live-reconnect.deep.spec.ts
+++ b/apps/web/e2e/deep/artifact-live-reconnect.deep.spec.ts
@@ -1,0 +1,31 @@
+import { expect, openArtifact, publishArtifact, shareArtifact, test } from "../fixtures"
+
+const NOTE = "A collaborator comment during your outage"
+
+// Real-time robustness: a dropped live stream must READ as "reconnecting" — not a silently
+// frozen collaborative view — and on reconnect the stream re-establishes, the updates missed
+// during the gap resync in, and the cue clears. Driven with a real network drop (setOffline)
+// and a second collaborator posting while we're down.
+test("SSE drop shows a reconnecting cue, then resyncs the gap and clears", async ({
+  owner,
+  secondUser,
+}) => {
+  test.setTimeout(90_000)
+  const id = await publishArtifact(owner)
+  await shareArtifact(owner.request, id, secondUser.email, "commenter")
+  await openArtifact(owner, id)
+
+  // Drop the live stream — the cue appears (offline is the fast, reliable signal).
+  await owner.context().setOffline(true)
+  await expect(owner.getByTestId("live-reconnecting")).toBeVisible()
+
+  // A collaborator comments while we're disconnected — we do NOT see it live.
+  await secondUser.page.request.post(`/v1/artifacts/${id}/comments`, { data: { body_md: NOTE } })
+  await owner.waitForTimeout(1000)
+  await expect(owner.getByText(NOTE)).toHaveCount(0)
+
+  // Back online: the stream re-establishes, resync pulls in the missed comment, the cue clears.
+  await owner.context().setOffline(false)
+  await expect(owner.getByText(NOTE)).toBeVisible({ timeout: 15_000 })
+  await expect(owner.getByTestId("live-reconnecting")).toBeHidden({ timeout: 15_000 })
+})

--- a/apps/web/src/lib/use-online.ts
+++ b/apps/web/src/lib/use-online.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react"
+
+// Tracks browser connectivity, reactively (mirrors usePageVisible). A dropped network takes SSE
+// streams + heartbeats down, and native EventSource is documented NOT to reliably auto-reconnect
+// after the browser returns online — so realtime hooks GATE their stream on this and re-establish
+// it the moment connectivity is back (the effect re-runs when `online` flips, no manual trigger).
+export function useOnline(): boolean {
+  const [online, setOnline] = useState(() => typeof navigator === "undefined" || navigator.onLine)
+  useEffect(() => {
+    const sync = () => setOnline(navigator.onLine)
+    window.addEventListener("online", sync)
+    window.addEventListener("offline", sync)
+    return () => {
+      window.removeEventListener("online", sync)
+      window.removeEventListener("offline", sync)
+    }
+  }, [])
+  return online
+}

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -648,6 +648,19 @@ export function Artifact() {
               phone header (compact) so multiplayer identity never vanishes on mobile;
               the cursor picker stays desktop-only (no hovering cursor to style on touch). */}
           <div className="flex items-center gap-0.5">
+            {/* Live-stream health: surfaced ONLY while disconnected, so a dropped connection
+                reads as "reconnecting" instead of a silently-frozen collaborative view.
+                Comments/presence self-heal on reconnect (use-artifact-live's onResync). */}
+            {!live.connected && (
+              <span
+                data-testid="live-reconnecting"
+                title="Reconnecting to live updates — comments and presence may be briefly out of date"
+                className="mr-1.5 flex items-center gap-1.5 text-2xs text-muted-foreground"
+              >
+                <span className="size-1.5 animate-pulse rounded-full bg-muted-foreground/70" />
+                <span className="hidden sm:inline">Reconnecting…</span>
+              </span>
+            )}
             <Presence viewers={live.viewers} selfId={me?.id} compact={isMobile} />
             {!isMobile && <CursorButton />}
           </div>

--- a/apps/web/src/pages/artifact/use-artifact-live.ts
+++ b/apps/web/src/pages/artifact/use-artifact-live.ts
@@ -31,6 +31,10 @@ export function useArtifactLive(opts: {
 }) {
   const { shortId, onComment, onVersion, onReview, onResync } = opts
   const [viewers, setViewers] = useState<Viewer[]>([])
+  // Whether the live stream is currently connected — so the UI can say "reconnecting"
+  // instead of silently showing a frozen collaborative view. Optimistic on mount (the data
+  // was just loaded); flips only on a real drop, and back on the next open.
+  const [connected, setConnected] = useState(true)
   // Whether ANY stream for this page has connected before — the first "ready" of
   // the first stream is the mount itself (the loader/query just fetched; nothing
   // to catch up on); every later "ready" means a gap just closed.
@@ -39,15 +43,39 @@ export function useArtifactLive(opts: {
   const { paintFrame } = cursors
   const visible = usePageVisible()
 
+  // Browser-level connectivity drives the "reconnecting" cue. `offline` is the fastest, most
+  // reliable drop signal (an EventSource `onerror` can lag a dead socket by seconds) → flip to
+  // disconnected. `online` bumps a nonce that RE-ESTABLISHES the stream below, because native
+  // EventSource auto-reconnect is unreliable across an offline→online cycle; a fresh stream
+  // guarantees a `ready` (which flips us back to connected + runs onResync). We never claim
+  // "live" on `online` alone — only when the stream's `ready` actually lands.
+  const [reconnectNonce, setReconnectNonce] = useState(0)
+  useEffect(() => {
+    const drop = () => setConnected(false)
+    const back = () => setReconnectNonce((n) => n + 1)
+    window.addEventListener("offline", drop)
+    window.addEventListener("online", back)
+    return () => {
+      window.removeEventListener("offline", drop)
+      window.removeEventListener("online", back)
+    }
+  }, [])
+
   // The live stream: comment churn + new versions refetch/reload; presence and
   // peer cursors paint directly. Closed while the tab is hidden (and reopened
   // on focus) so a backgrounded tab doesn't keep the artifact's room Durable
   // Object active.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reconnectNonce is a deliberate re-run trigger (bumped on `online`) to re-open a fresh stream; its value isn't read.
   useEffect(() => {
     if (!visible) return
     const ev = new EventSource(`${API_BASE}/v1/artifacts/${shortId}/events`, {
       withCredentials: true,
     })
+    // Connection health for the "reconnecting" cue: onerror flips us to disconnected when the
+    // socket drops. We flip back to connected on the server's `ready` hello (below), NOT on the
+    // raw `onopen` — `ready` is the definitive "the stream is live and the server acknowledged
+    // us" signal, and onopen proved unreliable at confirming a real reconnect.
+    ev.onerror = () => setConnected(false)
     ev.addEventListener("comment.created", onComment)
     ev.addEventListener("comment.resolved", onComment)
     ev.addEventListener("comment.outdated", onComment)
@@ -63,8 +91,10 @@ export function useArtifactLive(opts: {
       }
       onVersion(n)
     })
-    // "ready" is the server's hello on every (re)connect — see onResync.
+    // "ready" is the server's hello on every (re)connect — see onResync. It's also the live
+    // signal: reaching it means the stream is up and the server acknowledged us.
     ev.addEventListener("ready", () => {
+      setConnected(true)
       if (everConnected.current) onResync?.()
       everConnected.current = true
     })
@@ -88,7 +118,8 @@ export function useArtifactLive(opts: {
       }
     })
     return () => ev.close()
-  }, [shortId, onComment, onVersion, onReview, onResync, paintFrame, visible])
+    // reconnectNonce re-runs this to open a FRESH stream when the browser comes back online.
+  }, [shortId, onComment, onVersion, onReview, onResync, paintFrame, visible, reconnectNonce])
 
   // Announce we're viewing (anon shows up by their server handle — Google-Docs
   // style) and keep the heartbeat alive (TTL 45s). Paused while the tab is
@@ -116,6 +147,7 @@ export function useArtifactLive(opts: {
 
   return {
     viewers,
+    connected,
     onPointerMove: cursors.onPointerMove,
     onPointerLeave: cursors.onPointerLeave,
     onTap: cursors.onTap,

--- a/apps/web/src/pages/artifact/use-artifact-live.ts
+++ b/apps/web/src/pages/artifact/use-artifact-live.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import { API_BASE, api, type Viewer } from "@/api"
+import { useOnline } from "@/lib/use-online"
 import { usePageVisible } from "@/lib/use-page-visible"
 import { useLiveCursors } from "./cursors/use-live-cursors"
 
@@ -31,10 +32,16 @@ export function useArtifactLive(opts: {
 }) {
   const { shortId, onComment, onVersion, onReview, onResync } = opts
   const [viewers, setViewers] = useState<Viewer[]>([])
-  // Whether the live stream is currently connected — so the UI can say "reconnecting"
-  // instead of silently showing a frozen collaborative view. Optimistic on mount (the data
-  // was just loaded); flips only on a real drop, and back on the next open.
-  const [connected, setConnected] = useState(true)
+  // The live-stream "reconnecting" cue: `connected` is false whenever the browser is offline OR
+  // the stream isn't confirmed live — so a dropped connection reads as reconnecting instead of a
+  // silently-frozen collaborative view. `streamReady` is optimistic on mount (the data was just
+  // loaded) and flips on the server's `ready` (up) / the socket's `onerror` (down). `online`
+  // covers the browser-offline case instantly AND — being a real dependency of the stream effect
+  // below — re-establishes the stream the moment the network returns (which native EventSource is
+  // documented not to do reliably), so there's no bespoke reconnect trigger to hand-roll.
+  const online = useOnline()
+  const [streamReady, setStreamReady] = useState(true)
+  const connected = online && streamReady
   // Whether ANY stream for this page has connected before — the first "ready" of
   // the first stream is the mount itself (the loader/query just fetched; nothing
   // to catch up on); every later "ready" means a gap just closed.
@@ -43,39 +50,22 @@ export function useArtifactLive(opts: {
   const { paintFrame } = cursors
   const visible = usePageVisible()
 
-  // Browser-level connectivity drives the "reconnecting" cue. `offline` is the fastest, most
-  // reliable drop signal (an EventSource `onerror` can lag a dead socket by seconds) → flip to
-  // disconnected. `online` bumps a nonce that RE-ESTABLISHES the stream below, because native
-  // EventSource auto-reconnect is unreliable across an offline→online cycle; a fresh stream
-  // guarantees a `ready` (which flips us back to connected + runs onResync). We never claim
-  // "live" on `online` alone — only when the stream's `ready` actually lands.
-  const [reconnectNonce, setReconnectNonce] = useState(0)
+  // The live stream: comment churn + new versions refetch/reload; presence and peer cursors
+  // paint directly. Gated on `online` as well as `visible`, so it RE-ESTABLISHES the moment the
+  // browser returns online (the idiomatic reconnect — the effect just re-runs when its `online`
+  // dep flips; native EventSource is documented not to auto-reconnect reliably across that
+  // cycle). Also closed while the tab is hidden (reopened on focus) so a backgrounded tab
+  // doesn't keep the artifact's room Durable Object active — and a return-to-tab likewise
+  // re-establishes, which recovers the rarer server-error CLOSED case too.
   useEffect(() => {
-    const drop = () => setConnected(false)
-    const back = () => setReconnectNonce((n) => n + 1)
-    window.addEventListener("offline", drop)
-    window.addEventListener("online", back)
-    return () => {
-      window.removeEventListener("offline", drop)
-      window.removeEventListener("online", back)
-    }
-  }, [])
-
-  // The live stream: comment churn + new versions refetch/reload; presence and
-  // peer cursors paint directly. Closed while the tab is hidden (and reopened
-  // on focus) so a backgrounded tab doesn't keep the artifact's room Durable
-  // Object active.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: reconnectNonce is a deliberate re-run trigger (bumped on `online`) to re-open a fresh stream; its value isn't read.
-  useEffect(() => {
-    if (!visible) return
+    if (!visible || !online) return
     const ev = new EventSource(`${API_BASE}/v1/artifacts/${shortId}/events`, {
       withCredentials: true,
     })
-    // Connection health for the "reconnecting" cue: onerror flips us to disconnected when the
-    // socket drops. We flip back to connected on the server's `ready` hello (below), NOT on the
-    // raw `onopen` — `ready` is the definitive "the stream is live and the server acknowledged
-    // us" signal, and onopen proved unreliable at confirming a real reconnect.
-    ev.onerror = () => setConnected(false)
+    // Connection health for the cue: onerror flips to reconnecting; the server's `ready` hello
+    // (below) confirms we're live again — NOT the raw `onopen`, which proved unreliable at
+    // confirming a real reconnect.
+    ev.onerror = () => setStreamReady(false)
     ev.addEventListener("comment.created", onComment)
     ev.addEventListener("comment.resolved", onComment)
     ev.addEventListener("comment.outdated", onComment)
@@ -94,7 +84,7 @@ export function useArtifactLive(opts: {
     // "ready" is the server's hello on every (re)connect — see onResync. It's also the live
     // signal: reaching it means the stream is up and the server acknowledged us.
     ev.addEventListener("ready", () => {
-      setConnected(true)
+      setStreamReady(true)
       if (everConnected.current) onResync?.()
       everConnected.current = true
     })
@@ -118,8 +108,7 @@ export function useArtifactLive(opts: {
       }
     })
     return () => ev.close()
-    // reconnectNonce re-runs this to open a FRESH stream when the browser comes back online.
-  }, [shortId, onComment, onVersion, onReview, onResync, paintFrame, visible, reconnectNonce])
+  }, [shortId, onComment, onVersion, onReview, onResync, paintFrame, visible, online])
 
   // Announce we're viewing (anon shows up by their server handle — Google-Docs
   // style) and keep the heartbeat alive (TTL 45s). Paused while the tab is


### PR DESCRIPTION
## Real-time robustness — the visible layer

I drove an SSE drop (`context.setOffline` + a second collaborator commenting during the outage) to find the real gap. The result was reassuring on the *functional* side and clear on the *visible* side:

**Already solid (kept):** the artifact page's `onResync` refetches missed comments/versions/reviews on reconnect (via the server's `ready` hello + an `everConnected` latch), presence is heartbeated, hidden tabs release the stream. Recovery works end-to-end.

**The gap:** during a drop the page looked **completely normal** — a silently-frozen collaborative view was indistinguishable from a live one. A collaborator could be actively commenting and you'd have no reason to distrust what you're looking at. Figma/Docs/Linear all surface this ("Reconnecting…").

## The fix

A subtle, on-brand **"● Reconnecting…"** cue in the top bar's collaboration cluster (next to presence + Share), shown **only while disconnected** — surface the exceptional state, don't clutter the good one.

- **Detection:** the browser `offline` event flips to disconnected (fast + reliable — an EventSource `onerror` lags a dead socket by seconds); the server's `ready` event flips back to connected (the definitive "stream is live and acknowledged" signal, not the flaky raw `onopen`).
- **Reconnect:** on `online` we force a **fresh stream** (native EventSource auto-reconnect proved unreliable across an offline→online cycle) — which guarantees a `ready` → resync pulls in what was missed → cue clears.

## Verification

New deep regression test (`artifact-live-reconnect.deep.spec.ts`): drop → cue shows + the collaborator's comment is *not* shown live → reconnect → resync recovers it + cue clears. typecheck 0 · biome · smoke 11/11.

## Scope note

Scoped to the **artifact page** (where live collaboration is core). The per-user stream (notifications) already relies on server-side `Last-Event-ID` replay + dedup; a matching app-wide indicator is a possible follow-up, but the artifact page is the high-value surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
