### PR TITLE
feat(brandprint): promote Brandprint to its own page in the rail

### DIFF
--- a/apps/web/src/components/chrome/app-shell.tsx
+++ b/apps/web/src/components/chrome/app-shell.tsx
@@ -292,6 +292,7 @@ function PageLabel({ pathname }: { pathname: string }) {
   if (pathname === "/following") return "Following"
   if (pathname === "/people") return "People"
   if (pathname === "/new") return "New artifact"
+  if (pathname === "/brandprint") return "Brandprint"
   if (pathname.startsWith("/settings")) return "Settings"
   if (pathname.startsWith("/artifacts/")) return "Artifact"
   if (pathname.startsWith("/users/")) return "Profile"

--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -109,7 +109,7 @@ function NavItem({
   icon: IconName
   label: string
   count?: number
-  to: "/favorites" | "/following" | "/shared" | "/people" | "/contexts"
+  to: "/favorites" | "/following" | "/shared" | "/people" | "/contexts" | "/brandprint"
   active: boolean
   testId?: string
 }) {
@@ -311,6 +311,7 @@ export function NavRail() {
   // People + its Activity sub-view (the /following feed) are one tab; the row lights for both.
   const onPeople = loc.pathname === "/people" || loc.pathname === "/following"
   const onContexts = loc.pathname.startsWith("/contexts")
+  const onBrandprint = loc.pathname === "/brandprint"
   const onSettings = loc.pathname.startsWith("/settings")
   const tags = summary?.tags ?? []
 
@@ -414,6 +415,13 @@ export function NavRail() {
                 to="/contexts"
                 active={onContexts}
                 testId="nav-contexts"
+              />
+              <NavItem
+                icon="brandprint"
+                label="Brandprint"
+                to="/brandprint"
+                active={onBrandprint}
+                testId="nav-brandprint"
               />
             </SidebarMenu>
           </SidebarGroupContent>

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -68,7 +68,7 @@ const REG = {
   collections: Folders,
   collection: Folder,
   context: Bot,
-  // The team's conventions destination (a print of the brand — hence the mark).
+  // Brandprint — the brand's fingerprint.
   brandprint: Fingerprint,
   tag: Tag,
   search: Search,

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -22,6 +22,7 @@ import {
   Code,
   Ellipsis,
   Eye,
+  Fingerprint,
   Flag,
   Folder,
   Folders,
@@ -67,6 +68,8 @@ const REG = {
   collections: Folders,
   collection: Folder,
   context: Bot,
+  // The team's conventions destination (a print of the brand — hence the mark).
+  brandprint: Fingerprint,
   tag: Tag,
   search: Search,
   settings: Settings,

--- a/apps/web/src/pages/brandprint/brandprint-section.tsx
+++ b/apps/web/src/pages/brandprint/brandprint-section.tsx
@@ -95,8 +95,8 @@ function DocFileInput({
  * Point this scope's Brandprint at a conventions collection — the docs/skills that
  * describe how artifacts should be built here. An agent connected over MCP resolves
  * workspace ⊕ account (account wins) and reads those docs as Brandprint context.
- * Workspace scope saves to the workspace settings (Admin only — mirrors the other
- * workspace defaults in General); account scope saves to your own profile. Clearing
+ * Workspace scope saves to the workspace settings (Admin only, like the workspace
+ * defaults in Settings → General); account scope saves to your own profile. Clearing
  * sets the pointer back to none. Theme tokens are a later phase; this is the
  * collection pointer only.
  *
@@ -114,8 +114,8 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
     isError: collectionsError,
     refetch: refetchCollections,
   } = useQuery(collectionsQuery())
-  // Shared cache entry with the General section (staleTime Infinity) — mounting
-  // this here doesn't add a second network request when General is also open.
+  // Shared cache entry with Settings → General (staleTime Infinity), so this page
+  // and that section never double-fetch the same workspace record.
   const { data: ws } = useQuery({ ...workspaceQuery(), enabled: scope === "workspace" })
   const {
     data: settings,

--- a/apps/web/src/pages/brandprint/index.tsx
+++ b/apps/web/src/pages/brandprint/index.tsx
@@ -1,0 +1,51 @@
+import { PageHeader } from "@/components/shared/page-header"
+import { PageShell } from "@/components/shared/page-shell"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useDocumentTitle } from "@/lib/use-document-title"
+import { BrandprintSection } from "./brandprint-section"
+
+// The Brandprint page: /brandprint — the workspace's conventions and your personal
+// layer, one destination in the rail (a peer of Contexts). Promoted out of Settings:
+// a Brandprint is something a team sets up and returns to, not a preference. The two
+// sections own their data, states, and writes; this page is composition only.
+export function Brandprint() {
+  useDocumentTitle("Brandprint")
+  return (
+    <PageShell className="flex flex-col gap-8">
+      <PageHeader
+        title="Brandprint"
+        subtitle="The conventions your artifacts follow — how they look and how they read. Any agent connected to this workspace picks them up automatically."
+      />
+      <BrandprintSection scope="workspace" />
+      <BrandprintSection scope="account" />
+    </PageShell>
+  )
+}
+
+// Deterministic silhouette: the header band, then two group-shaped blocks (title
+// line, description line, a row) matching the sections above.
+const PENDING_GROUPS = ["workspace", "account"]
+
+export function BrandprintPending() {
+  return (
+    <PageShell className="flex flex-col gap-8" aria-busy>
+      <span role="status" className="sr-only">
+        Loading Brandprint…
+      </span>
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-8 w-44" />
+        <Skeleton className="h-4 w-3/4" />
+      </div>
+      {PENDING_GROUPS.map((k) => (
+        <div key={k} className="flex flex-col gap-3">
+          <Skeleton className="h-5 w-52" />
+          <Skeleton className="h-4 w-2/3" />
+          <div className="flex items-center justify-between py-3.5">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-8 w-36" />
+          </div>
+        </div>
+      ))}
+    </PageShell>
+  )
+}

--- a/apps/web/src/pages/brandprint/index.tsx
+++ b/apps/web/src/pages/brandprint/index.tsx
@@ -14,7 +14,7 @@ export function Brandprint() {
     <PageShell className="flex flex-col gap-8">
       <PageHeader
         title="Brandprint"
-        subtitle="The conventions your artifacts follow — how they look and how they read. Any agent connected to this workspace picks them up automatically."
+        subtitle="The conventions your artifacts follow: how they look and how they read. Any agent connected to this workspace picks them up automatically."
       />
       <BrandprintSection scope="workspace" />
       <BrandprintSection scope="account" />
@@ -23,12 +23,13 @@ export function Brandprint() {
 }
 
 // Deterministic silhouette: the header band, then two group-shaped blocks (title
-// line, description line, a row) matching the sections above.
+// line, description line, a row) matching the sections above. Announced by the
+// sr-only status line, the RailSkeleton idiom.
 const PENDING_GROUPS = ["workspace", "account"]
 
 export function BrandprintPending() {
   return (
-    <PageShell className="flex flex-col gap-8" aria-busy>
+    <PageShell className="flex flex-col gap-8">
       <span role="status" className="sr-only">
         Loading Brandprint…
       </span>

--- a/apps/web/src/pages/settings/index.tsx
+++ b/apps/web/src/pages/settings/index.tsx
@@ -8,7 +8,6 @@ import { reportsQuery } from "@/lib/queries"
 import { useDocumentTitle } from "@/lib/use-document-title"
 import { AgentsSection } from "./agents-section"
 import { AppearanceSection } from "./appearance-section"
-import { BrandprintSection } from "./brandprint-section"
 import { CustomDomainsSection } from "./custom-domains-section"
 import { GeneralSection } from "./general-section"
 import { GithubSection } from "./github-section"
@@ -131,20 +130,10 @@ export function Settings() {
           </div>
 
           <div className="min-w-0">
-            {active === "profile" && (
-              <div className="flex flex-col gap-8">
-                <ProfileSection />
-                <BrandprintSection scope="account" />
-              </div>
-            )}
+            {active === "profile" && <ProfileSection />}
             {active === "security" && <SecuritySection />}
             {active === "appearance" && <AppearanceSection />}
-            {active === "general" && (
-              <div className="flex flex-col gap-8">
-                <GeneralSection />
-                <BrandprintSection scope="workspace" />
-              </div>
-            )}
+            {active === "general" && <GeneralSection />}
             {active === "members" && <MembersSection meId={me.id} />}
             {active === "integrations" && <IntegrationsSection />}
             {active === "github" && <GithubSection />}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as FollowingRouteImport } from './routes/following'
 import { Route as FeedbackRouteImport } from './routes/feedback'
 import { Route as FavoritesRouteImport } from './routes/favorites'
+import { Route as BrandprintRouteImport } from './routes/brandprint'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings.index'
 import { Route as ContextsIndexRouteImport } from './routes/contexts.index'
@@ -91,6 +92,11 @@ const FavoritesRoute = FavoritesRouteImport.update({
   path: '/favorites',
   getParentRoute: () => rootRouteImport,
 } as any)
+const BrandprintRoute = BrandprintRouteImport.update({
+  id: '/brandprint',
+  path: '/brandprint',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -139,6 +145,7 @@ const InviteATokenRoute = InviteATokenRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/brandprint': typeof BrandprintRoute
   '/favorites': typeof FavoritesRoute
   '/feedback': typeof FeedbackRoute
   '/following': typeof FollowingRoute
@@ -162,6 +169,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/brandprint': typeof BrandprintRoute
   '/favorites': typeof FavoritesRoute
   '/feedback': typeof FeedbackRoute
   '/following': typeof FollowingRoute
@@ -185,6 +193,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/brandprint': typeof BrandprintRoute
   '/favorites': typeof FavoritesRoute
   '/feedback': typeof FeedbackRoute
   '/following': typeof FollowingRoute
@@ -210,6 +219,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/brandprint'
     | '/favorites'
     | '/feedback'
     | '/following'
@@ -233,6 +243,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/brandprint'
     | '/favorites'
     | '/feedback'
     | '/following'
@@ -255,6 +266,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/brandprint'
     | '/favorites'
     | '/feedback'
     | '/following'
@@ -279,6 +291,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  BrandprintRoute: typeof BrandprintRoute
   FavoritesRoute: typeof FavoritesRoute
   FeedbackRoute: typeof FeedbackRoute
   FollowingRoute: typeof FollowingRoute
@@ -385,6 +398,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof FavoritesRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/brandprint': {
+      id: '/brandprint'
+      path: '/brandprint'
+      fullPath: '/brandprint'
+      preLoaderRoute: typeof BrandprintRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -467,6 +487,7 @@ const SettingsRouteWithChildren = SettingsRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  BrandprintRoute: BrandprintRoute,
   FavoritesRoute: FavoritesRoute,
   FeedbackRoute: FeedbackRoute,
   FollowingRoute: FollowingRoute,

--- a/apps/web/src/routes/brandprint.tsx
+++ b/apps/web/src/routes/brandprint.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { collectionsQuery, workspaceSettingsQuery } from "../lib/queries"
+import { requireOnboarded } from "../lib/route-guards"
+import { Brandprint, BrandprintPending } from "../pages/brandprint"
+
+// Brandprint: /brandprint — the team's conventions destination (see pages/brandprint).
+export const Route = createFileRoute("/brandprint")({
+  beforeLoad: requireOnboarded,
+  // Best-effort warm of what both sections read (collections for the pickers, the
+  // workspace settings for the pointer); a failed preload must NOT blank the page
+  // behind the route error boundary — the sections own their error states.
+  loader: ({ context }) =>
+    Promise.all([
+      context.queryClient.ensureQueryData(collectionsQuery()),
+      context.queryClient.ensureQueryData(workspaceSettingsQuery()),
+    ]).catch(() => {}),
+  pendingComponent: BrandprintPending,
+  component: Brandprint,
+})


### PR DESCRIPTION
## What & why

Brandprint graduates from Settings to its own destination: `/brandprint`, a rail item under Contexts. Setting it up (#383) made it a thing teams actively build and return to, which is a page, not a preference. It also fixes the split-brain placement: the workspace half lived under Settings → General and the personal half under Settings → Profile, so the feature never appeared whole anywhere.

## Changes

- New `/brandprint` route + `pages/brandprint/index.tsx`: composes the workspace and personal sections on one page. Route warms `collectionsQuery` + `workspaceSettingsQuery` (best-effort, per the contexts pattern) behind a shape-matched pending frame.
- `BrandprintSection` moves `pages/settings/` → `pages/brandprint/` unchanged (one file, both scopes), with two stale location references in comments updated.
- Settings: the two embeds removed; Profile and General return to their pre-#378 shape.
- Nav rail: "Brandprint" item under Contexts (`nav-brandprint`), new `brandprint: Fingerprint` icon in the registry, `/brandprint` added to the NavItem path union.
- Mobile top bar labels the page; `routeTree.gen.ts` regenerated.

## Testing

- Full gate green locally: `pnpm typecheck` (7 projects), `pnpm run ci` (biome + the lint gauntlet incl. lint:surfaces, which checks the new route's pending frame), web tests (133 passed), and a production `vite build` (route tree regeneration + prerender).

- [x] `pnpm typecheck` passes
- [x] `pnpm exec biome ci .` reports 0 errors
- [x] `pnpm test` passes
- [ ] Added/updated tests for the change — none added; testids in place (`nav-brandprint`, plus the section's existing ones) for an e2e follow-up.

## Notes for reviewers

- Deep links to the old Settings placement don't break: the sections were embedded in `/settings/profile` and `/settings/general`, which still render (minus the Brandprint groups), so there's no dangling `$section` value to guard.
- The Fingerprint mark is a play on the name; happy to swap glyphs if there's a stronger opinion.
- Builds on #378 (Phase 0) and #383 (in-place setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
