### PR TITLE
The arrow everywhere — no pointer cursor in app chrome

### DIFF
--- a/apps/api/src/brand-page.ts
+++ b/apps/api/src/brand-page.ts
@@ -25,7 +25,8 @@ const STYLE = `<style>
   h1{font-family:var(--display);font-weight:600;font-size:23px;line-height:1.2;letter-spacing:-.02em;margin:0 0 7px}
   .sub{color:var(--ink-soft);font-size:14px;margin:0 0 20px}
   .row{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
-  .btn{display:inline-block;padding:10px 17px;border-radius:10px;font:600 14px var(--sans);cursor:pointer;
+  a{cursor:default} /* the arrow everywhere, Linear-style — same rule as the app's globals.css */
+  .btn{display:inline-block;padding:10px 17px;border-radius:10px;font:600 14px var(--sans);
     border:1px solid var(--accent);background:var(--accent);color:var(--accent-fg);text-decoration:none}
   .btn:hover{filter:brightness(1.07)}
   .btn.ghost{background:transparent;color:var(--ink);border-color:var(--line)}
@@ -38,7 +39,7 @@ const STYLE = `<style>
   .code pre{margin:0;max-height:240px;overflow:auto;background:var(--paper);border:1px solid var(--line);
     border-radius:12px;padding:14px 15px;font-family:var(--mono);font-size:11.5px;line-height:1.5;color:var(--ink)}
   .code .copy{position:absolute;top:9px;right:9px;padding:5px 11px;border-radius:8px;font:600 12px var(--sans);
-    cursor:pointer;border:1px solid var(--line);background:var(--panel);color:var(--ink)}
+    border:1px solid var(--line);background:var(--panel);color:var(--ink)}
   .code .copy:hover{border-color:var(--accent)}
 </style>`
 

--- a/apps/api/src/oauth-cli-callback.ts
+++ b/apps/api/src/oauth-cli-callback.ts
@@ -41,7 +41,7 @@ const SHELL = (title: string, inner: { badge: string; body: string }): string =>
   .code{display:flex;gap:10px;align-items:center;border:1px solid var(--line);border-radius:13px;
     background:var(--panel-2);padding:13px 15px}
   .code code{flex:1;font:13px/1.45 var(--mono);word-break:break-all;color:var(--ink);letter-spacing:.01em}
-  .btn{padding:9px 15px;border-radius:10px;font:600 13px var(--sans);cursor:pointer;border:1px solid var(--accent);
+  .btn{padding:9px 15px;border-radius:10px;font:600 13px var(--sans);border:1px solid var(--accent);
     background:var(--accent);color:var(--accent-fg);flex:none;transition:transform .05s,filter .15s}
   .btn:active{transform:translateY(1px)} .btn:hover{filter:brightness(1.07)}
   .foot{color:var(--muted);font-size:12.5px;line-height:1.5;margin:20px 0 0}

--- a/apps/api/src/oauth-consent.ts
+++ b/apps/api/src/oauth-consent.ts
@@ -120,18 +120,19 @@ export function consentHTML(props: {
   .sub{color:var(--ink-soft);font-size:13.5px;margin:0 0 18px}
   .ws-label{display:block;font-family:var(--mono);font-size:10.5px;font-weight:600;letter-spacing:.05em;
     text-transform:uppercase;color:var(--muted);margin:0 0 6px}
+  a{cursor:default} /* the arrow everywhere, Linear-style — same rule as the app's globals.css */
   select.ws{width:100%;margin:0 0 16px;padding:10px 12px;border:1px solid var(--line);border-radius:11px;
-    background:var(--panel-2);color:var(--ink);font:500 14px var(--sans);cursor:pointer}
+    background:var(--panel-2);color:var(--ink);font:500 14px var(--sans)}
   select.ws:focus{outline:2px solid var(--accent-soft);border-color:var(--accent)}
   .ws-access{margin:0 0 18px;padding:10px 14px;border:1px solid var(--line);border-radius:14px;background:var(--panel-2)}
   .ws-access .ws-label{margin:2px 0 4px}
-  .ws-opt{display:flex;gap:10px;align-items:flex-start;padding:7px 0;cursor:pointer}
+  .ws-opt{display:flex;gap:10px;align-items:flex-start;padding:7px 0}
   .ws-opt input{margin-top:2px;accent-color:var(--accent);flex:none;width:15px;height:15px}
   .ws-opt-t{display:flex;flex-direction:column;font-size:13.5px;font-weight:600;color:var(--ink)}
   .ws-opt-t small{font-weight:400;font-size:12px;color:var(--muted);margin-top:1px}
   .ws-list{margin:2px 0 4px 25px;padding-left:12px;border-left:1px solid var(--line);display:flex;flex-direction:column}
   .ws-list[hidden]{display:none}
-  .ws-check{display:flex;gap:9px;align-items:center;padding:6px 0;font-size:13.5px;color:var(--ink-soft);cursor:pointer}
+  .ws-check{display:flex;gap:9px;align-items:center;padding:6px 0;font-size:13.5px;color:var(--ink-soft)}
   .ws-check input{accent-color:var(--accent);flex:none;width:15px;height:15px}
   ul.scopes{list-style:none;margin:0 0 22px;padding:8px 16px;border:1px solid var(--line);border-radius:14px;background:var(--panel-2)}
   ul.scopes li{display:flex;gap:11px;align-items:flex-start;padding:9px 0;font-size:13.5px;color:var(--ink-soft)}
@@ -139,14 +140,14 @@ export function consentHTML(props: {
   .tick{color:var(--good);font-weight:700;flex:none;font-size:13px;line-height:1.5}
   .tick.w{color:var(--accent)}
   .row{display:flex;gap:10px}
-  .btn{flex:1;padding:12px 16px;border-radius:11px;font:600 14px var(--sans);cursor:pointer;border:1px solid var(--line);
+  .btn{flex:1;padding:12px 16px;border-radius:11px;font:600 14px var(--sans);border:1px solid var(--line);
     transition:transform .05s,background .15s,filter .15s}
   .btn:active{transform:translateY(1px)}
   .btn.ghost{background:transparent;color:var(--muted)}
   .btn.ghost:hover{background:var(--panel-2);color:var(--ink-soft)}
   .btn.primary{background:var(--accent);color:var(--accent-fg);border-color:var(--accent)}
   .btn.primary:hover{filter:brightness(1.07)}
-  .btn[disabled]{opacity:.55;cursor:default}
+  .btn[disabled]{opacity:.55}
   .foot{color:var(--muted);font-size:12px;text-align:center;margin:16px 0 0}
   .err{color:var(--bad);font-size:12.5px;text-align:center;margin:12px 0 0;min-height:0}
   .badge.ok{background:var(--good-soft);color:var(--good)}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -278,8 +278,12 @@
   a {
     color: var(--primary);
     text-decoration: none;
-    /* Links carry the pointer affordance on hover. */
-    cursor: pointer;
+    /* The arrow everywhere, Linear-style: links keep the default cursor instead
+       of the hand. Overrides the UA's a[href] pointer; buttons are already
+       arrow-by-default, and nothing else in the app opts into `cursor-pointer`.
+       Authored artifact content lives in its own iframe and keeps web-native
+       cursors. */
+    cursor: default;
   }
   /* Tighten heading tracking a hair — the "this was designed" tell. */
   h1,

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -193,6 +193,15 @@ padding.
   focus-visible:ring-2 focus-visible:ring-ring/40` — an **ink** border + soft glow, no
   offset (never `outline-offset` on inputs).
 
+## Cursor
+
+The arrow everywhere, Linear-style. Links and buttons keep the default cursor — no
+`cursor-pointer` in app chrome; hover states, not the hand, signal clickability
+(globals.css sets `a { cursor: default }` to override the browser's link pointer).
+Functional cursors stay: text fields keep the I-beam, resize handles keep resize
+cursors, drag surfaces keep grab. Authored artifact content renders in its own
+iframe and keeps web-native cursors — we're a guest in the author's document.
+
 ## Motion
 
 Fast and quiet. No hover color/background transitions — color changes are instant


### PR DESCRIPTION
## What

Adopts Linear's cursor convention: links and buttons keep the default arrow cursor. Hover states, not the hand, signal clickability — the hand is a web-page affordance, and dropping it makes the app feel a touch snappier.

## How

The audit found only two pointer sources in the whole product: our own `a { cursor: pointer }` rule in `globals.css`, and the browser's built-in pointer on `a[href]`. Tailwind v4's preflight adds none, shadcn's base CSS is clean, nothing uses the `cursor-pointer` utility, and buttons are arrow-by-default in modern browsers. So the app-wide fix is one rule:

- **`apps/web/src/styles/globals.css`** — the base `a` rule now sets `cursor: default`, overriding the UA link pointer everywhere (nav, sidebar, cards, every link).
- **`apps/api/src/{oauth-consent,oauth-cli-callback,brand-page}.ts`** — the server-rendered pages hand-set `cursor:pointer` on buttons/labels/select; removed, with the same `a { cursor: default }` rule where those shells render anchors.
- **`docs/design-system.md`** — new **Cursor** section codifying the policy so it doesn't creep back.

## Deliberately untouched

- Functional cursors: I-beam in text fields, resize on the sidebar handle, grab on drag surfaces.
- Authored artifact content renders in its own sandboxed iframe and keeps web-native cursors — we're a guest in the author's document. Same for the anchor-client's comment-badge overlay injected into those documents.