### PR TITLE
feat(brandprint): the Brandprint collection lives on /brandprint only

### DIFF
--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -16,6 +16,7 @@ import {
 import { colorForName } from "@/lib/avatar-tints"
 import { getInitials } from "@/lib/initials"
 import { collectionsQuery, workspacesQuery } from "@/lib/queries"
+import { useBrandprintCollectionIds } from "@/lib/use-brandprint-ids"
 import { usePrefetchArtifact } from "@/lib/use-prefetch-artifact"
 import { cn } from "@/lib/utils"
 import { refFor } from "@/pages/artifact/parse-ref"
@@ -97,7 +98,11 @@ export function CommandPalette() {
   }
 
   const q = query.trim().toLowerCase()
-  const matchedCollections = collections.filter((c) => c.title.toLowerCase().includes(q))
+  // Brandprint-pointed collections are managed on /brandprint, not jumped to here.
+  const brandprintIds = useBrandprintCollectionIds()
+  const matchedCollections = collections.filter(
+    (c) => !brandprintIds.has(c.id) && c.title.toLowerCase().includes(q),
+  )
   // Personal shows (and searches) under its display name, same as the user pod.
   const otherWorkspaces = (workspaces?.workspaces ?? [])
     .map((w) => ({ ...w, display: workspaceDisplayName(w) }))

--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -32,6 +32,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useAuth } from "@/ctx"
 import { prTitle } from "@/lib/pr"
 import { collectionsQuery, summaryQuery, workspacesQuery } from "@/lib/queries"
+import { useBrandprintCollectionIds } from "@/lib/use-brandprint-ids"
 import { cn } from "@/lib/utils"
 import type { LibrarySearch } from "@/pages/library/types"
 import { NotificationBell } from "./notification-bell"
@@ -330,11 +331,16 @@ export function NavRail() {
       return next
     })
 
+  // Brandprint-pointed collections are managed on /brandprint, not here — hiding
+  // them keeps the docs and their options in one place (see use-brandprint-ids).
+  const brandprintIds = useBrandprintCollectionIds()
+  const visibleCollections = collections.filter((col) => !brandprintIds.has(col.id))
+
   // Nest PR-preview collections under their repo. A "pr" collection with a known
   // parentId becomes a child; everything else (repos, manual, orphaned PRs) stays
   // top-level. Children sort newest-PR-first.
   const childPrsByRepo = new Map<string, typeof collections>()
-  const topCollections = collections.filter((col) => {
+  const topCollections = visibleCollections.filter((col) => {
     if (col.kind === "pr" && col.parentId && collections.some((p) => p.id === col.parentId)) {
       const arr = childPrsByRepo.get(col.parentId) ?? []
       arr.push(col)

--- a/apps/web/src/components/shared/organize-dialogs.tsx
+++ b/apps/web/src/components/shared/organize-dialogs.tsx
@@ -13,6 +13,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { artifactQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { useBrandprintCollectionIds } from "@/lib/use-brandprint-ids"
 import { cn } from "@/lib/utils"
 
 // The two "organize" dialogs, shared by the artifact workbench's ⋯ menu and the
@@ -44,6 +45,10 @@ export function CollectionsDialog({
         .then((r) => setAll(r.collections))
         .catch(() => {})
   }, [open])
+  // Brandprint-pointed collections take docs through /brandprint only, not from
+  // an artifact's organize menu.
+  const brandprintIds = useBrandprintCollectionIds()
+  const pickable = all.filter((col) => !brandprintIds.has(col.id))
   const inSet = new Set(inCollections)
   // Toggle membership optimistically (via onChange); the primitive rolls it back and
   // toasts if the write fails. The settle-time invalidation reconciles the artifact
@@ -89,14 +94,14 @@ export function CollectionsDialog({
             members.
           </DialogDescription>
         </DialogHeader>
-        {all.length === 0 && (
+        {pickable.length === 0 && (
           <div className="text-sm text-muted-foreground">
             No collections yet — create one below.
           </div>
         )}
-        {all.length > 0 && (
+        {pickable.length > 0 && (
           <div className="flex max-h-64 flex-col gap-px overflow-auto">
-            {all.map((col) => (
+            {pickable.map((col) => (
               <button
                 key={col.id}
                 type="button"

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -85,6 +85,17 @@ export const needsFeedbackArtifactsQuery = () =>
       api.listArtifacts({ scope: "needs_feedback", limit: 12 }).then((r) => r.artifacts),
   })
 
+// The docs a Brandprint's collection holds, for the /brandprint page's managed list.
+// Keyed under the ["artifacts"] prefix so the intake's settle-time invalidation
+// refreshes this list the moment an upload lands. Flat and capped — a conventions
+// collection is a handful of docs, not a feed.
+export const brandprintDocsQuery = (collectionId: string) =>
+  queryOptions({
+    queryKey: ["artifacts", "brandprint-docs", collectionId] as const,
+    queryFn: () =>
+      api.listArtifacts({ collection: collectionId, limit: 100 }).then((r) => r.artifacts),
+  })
+
 // A small, flat slice of the Following feed — recent work from the people you follow —
 // for the "Recent activity" preview on the People tab. The full feed lives at /following
 // (the infinite libraryArtifactsQuery({ scope: "following" })); this is the peek.

--- a/apps/web/src/lib/use-brandprint-ids.ts
+++ b/apps/web/src/lib/use-brandprint-ids.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query"
+import { useAuth } from "@/ctx"
+import { workspaceSettingsQuery } from "@/lib/queries"
+
+/**
+ * The collection ids the caller's Brandprints point at. Those collections are
+ * managed on /brandprint, so the general collection surfaces (rail, command
+ * palette, organize dialogs) hide them — one home for the docs and their options,
+ * not two. The client can always name every one it could otherwise see: your own
+ * personal pointer rides the session, the workspace pointer is member-readable
+ * settings, and a teammate's personal Brandprint collection is invite-only, so it
+ * never lists for you in the first place.
+ */
+export function useBrandprintCollectionIds(): Set<string> {
+  const { me } = useAuth()
+  // staleTime Infinity — shared with the Brandprint page and Settings, so this
+  // costs one fetch per session, not one per surface.
+  const { data: settings } = useQuery({ ...workspaceSettingsQuery(), enabled: !!me })
+  const ids = new Set<string>()
+  const ws = settings?.brandprint?.collectionId
+  const mine = me?.brandprint?.collectionId
+  if (ws) ids.add(ws)
+  if (mine) ids.add(mine)
+  return ids
+}

--- a/apps/web/src/pages/brandprint/brandprint-section.tsx
+++ b/apps/web/src/pages/brandprint/brandprint-section.tsx
@@ -1,4 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
 import { Upload } from "lucide-react"
 import { useRef, useState } from "react"
 import { api, type OrgSettings } from "@/api"
@@ -22,17 +23,20 @@ import {
   SelectMenuItem,
   SelectMenuTrigger,
 } from "@/components/ui/select-menu"
+import { Skeleton } from "@/components/ui/skeleton"
 import { toast } from "@/components/ui/sonner"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
 import { useAuth } from "@/ctx"
 import {
+  brandprintDocsQuery,
   collectionsQuery,
   summaryQuery,
   workspaceQuery,
   workspaceSettingsQuery,
 } from "@/lib/queries"
 import { snapshot, useApiMutation } from "@/lib/use-api-mutation"
+import { refFor } from "../artifact/parse-ref"
 
 // What the one-click intake reports back: how many docs made it in, which files
 // didn't, and (when it created the collection and set the pointer itself) the fresh
@@ -45,18 +49,17 @@ type ImportResult = {
   profile?: Awaited<ReturnType<typeof api.setProfile>>
 }
 
-// The two halves of a brand the upload tab asks for; `cat` labels each staged file.
+// The two halves of a brand the upload tab asks for; `cat` labels each staged file
+// and doubles as the verb in the well's heading ("How … artifacts should look/read").
 type DocCategory = "look" | "read"
-const UPLOAD_CATEGORIES: { cat: DocCategory; heading: string; blurb: string }[] = [
+const UPLOAD_CATEGORIES: { cat: DocCategory; blurb: string }[] = [
   {
     cat: "look",
-    heading: "How your artifacts should look",
     blurb:
       "Visual theming: brand and style guides, palettes, font specs, CSS tokens, or example HTML that carries the look.",
   },
   {
     cat: "read",
-    heading: "How your artifacts should read",
     blurb: "Voice and tone: grammar, warmth, structure, wording do’s and don’ts.",
   },
 ]
@@ -374,6 +377,9 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
               <Upload /> {importDocs.isPending ? "Uploading…" : "Upload docs"}
             </Button>
           </SettingRow>
+          {collectionId && (
+            <BrandprintDocs collectionId={collectionId} scope={scope} disabled={disabled} />
+          )}
         </>
       ) : (
         <SettingRow
@@ -414,7 +420,10 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
                       className="flex flex-wrap items-center justify-between gap-3 rounded-lg border bg-secondary/40 px-4 py-3"
                     >
                       <div className="min-w-0 flex-1">
-                        <p className="text-sm font-medium text-foreground">{c.heading}</p>
+                        <p className="text-sm font-medium text-foreground">
+                          How {scope === "workspace" ? "your team's" : "your"} artifacts should{" "}
+                          {c.cat}
+                        </p>
                         <p className="text-sm text-pretty text-muted-foreground">{c.blurb}</p>
                       </div>
                       <Button
@@ -535,5 +544,78 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
         </SettingRow>
       )}
     </SettingsGroup>
+  )
+}
+
+// The docs the Brandprint points at, managed here — the collection is hidden from
+// the general collection surfaces (rail, palette, organize; see use-brandprint-ids),
+// so this list is its one home. Removing drops the doc from the collection; the
+// artifact itself lives on in the library.
+function BrandprintDocs({
+  collectionId,
+  scope,
+  disabled,
+}: {
+  collectionId: string
+  scope: "workspace" | "account"
+  disabled: boolean
+}) {
+  const { data: docs, isError, refetch } = useQuery(brandprintDocsQuery(collectionId))
+  const removeDoc = useApiMutation({
+    mutationFn: (shortId: string) => api.removeFromCollection(collectionId, shortId),
+    pendingKey: (shortId) => shortId,
+    invalidate: [brandprintDocsQuery(collectionId).queryKey, collectionsQuery().queryKey],
+  })
+  return (
+    <div className="flex flex-col gap-2 py-3.5">
+      <p className="text-sm font-medium text-foreground">Documents</p>
+      {isError ? (
+        <p className="text-sm text-muted-foreground">
+          Couldn't load the docs.{" "}
+          <Button
+            variant="link"
+            size="xs"
+            className="px-0"
+            data-testid={`brandprint-docs-retry-${scope}`}
+            onClick={() => refetch()}
+          >
+            Try again
+          </Button>
+        </p>
+      ) : !docs ? (
+        <div className="flex flex-col gap-1.5">
+          <Skeleton className="h-4 w-56" />
+          <Skeleton className="h-4 w-40" />
+        </div>
+      ) : docs.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No docs yet. Upload some above.</p>
+      ) : (
+        <ul className="flex flex-col gap-1">
+          {docs.map((a) => (
+            <li key={a.short_id} className="flex items-center gap-2 text-sm">
+              <Link
+                to="/artifacts/$ref"
+                params={{ ref: refFor(a) }}
+                data-testid={`brandprint-doc-${a.short_id}`}
+                className="min-w-0 flex-1 truncate text-foreground underline-offset-4 hover:underline"
+              >
+                {a.title ?? a.short_id}
+              </Link>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                aria-label={`Remove ${a.title ?? a.short_id} from the Brandprint`}
+                data-testid={`brandprint-doc-remove-${a.short_id}`}
+                disabled={disabled || removeDoc.isPendingFor(a.short_id)}
+                onClick={() => removeDoc.mutate(a.short_id)}
+                className="text-muted-foreground"
+              >
+                <Icon name="close" size={14} />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   )
 }


### PR DESCRIPTION
## What & why

The intake (#383) stores Brandprint docs in a collection, which then showed up in the rail, the command palette, and the organize dialogs like any other collection — so the feature's files and its options lived in two places. The collection stays a collection in the data model (the MCP delivery layer reads it unchanged), but it no longer surfaces as one: `/brandprint` is its single home.

Also a small copy fix: the create dialog's workspace-scope category headings now read "How your team's artifacts should look/read" ("your artifacts" on the personal scope).

## Changes

- **`lib/use-brandprint-ids.ts`** (new): the collection ids the caller's Brandprints point at. Hiding is fully client-side with no API change — your personal pointer rides the session, the workspace pointer is member-readable settings, and a teammate's personal Brandprint collection is invite-only so it never listed for you anyway (verified against the list route's `collectionRole` gate).
- **Hidden from**: the nav rail's Collections group, the ⌘K palette's collection results, and the CollectionsDialog (organize menu) — so docs can't be added to a Brandprint from an artifact's ⋯ menu either.
- **`/brandprint` gains a managed Documents list** (`BrandprintDocs`): every doc in the pointed collection, open-in-workbench links, and per-row remove (drops it from the collection; the artifact lives on in the library). Keyed under the `["artifacts"]` prefix, so the intake's settle-time invalidation refreshes the list the moment an upload lands. Admin-gated on the workspace scope like the rest of the section.
- Category headings are scope-aware; the `cat` value doubles as the heading verb, so the copy can't drift from the category.

## Testing

- Full gate green: `pnpm typecheck` (7 projects), `pnpm run ci` (biome + lint gauntlet incl. lint:surfaces and lint:mutations), web tests (133 passed).
- New testids for e2e follow-up: `brandprint-doc-*`, `brandprint-doc-remove-*`, `brandprint-docs-retry-*`.

- [x] `pnpm typecheck` passes
- [x] `pnpm exec biome ci .` reports 0 errors
- [x] `pnpm test` passes
- [ ] Added/updated tests for the change — UI-only; testids in place.

## Notes for reviewers

- Deliberately NOT hidden: direct URLs (`/?collection=<id>` still renders — nothing links there anymore), and the Brandprint page's own pickers ("Use a collection", the pointer select), which need the full list to render the pointed collection's title and to let a scope point at any collection.
- Considered a stored `kind: "brandprint"` on collections instead; rejected for now — `kind` is derived from repo sources, not stored, so that path means a schema change for something the client can already determine. If a server-side marker becomes necessary (e.g. hiding from a future API consumer), that's the upgrade path.
- Spec addendum rides the open `docs/brandprint-status` branch (Decisions log #8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
