### PR TITLE
feat(brandprint): Phase 1 remainder — shared ConnectAgent + onboardin…

### DIFF
--- a/apps/web/src/components/shared/connect-agent.tsx
+++ b/apps/web/src/components/shared/connect-agent.tsx
@@ -1,0 +1,171 @@
+import { Copy } from "lucide-react"
+import { type ComponentProps, useState } from "react"
+import { Icon } from "@/components/icons"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { toast } from "@/components/ui/sonner"
+import { Switch } from "@/components/ui/switch"
+
+// The one Connect-an-agent surface: the paste-into-your-agent prompt (hosted, with a
+// self-host toggle), shared by onboarding Step 2, the library's connect empty state,
+// and the Brandprint page's saved-but-inert nudge — extracted from welcome.tsx so
+// every entry point renders the same thing. Rework's no-agent state (Phase 2) lands
+// here too.
+
+// The public origin to hand an agent. A deployed Derive instance's own origin IS its
+// public URL, so that's what we embed — except in local dev (localhost), where we
+// fall back to a clearly-editable placeholder so nobody copies an unreachable URL.
+const PLACEHOLDER_URL = "https://your-derive-server.com"
+const publicUrlOf = (origin: string) =>
+  /localhost|127\.0\.0\.1|\[::1\]/.test(origin) ? PLACEHOLDER_URL : origin
+
+// Hosted: Derive is already running (this instance, or any you point at). The fastest
+// on-ramp — Derive is itself a remote MCP server, so one line connects an agent and it
+// gets every Derive tool. No CLI needed for the publish/review loop.
+const hostedPrompt = (url: string) =>
+  `Connect me to Derive, a living-docs tool that hosts pages/docs at permanent, versioned URLs with inline review comments. Derive is a remote MCP server.
+
+Derive is running at: ${url}
+
+Please:
+1. Add it over MCP. In Claude Code run:
+     claude mcp add --transport http derive ${url}/mcp
+   In another harness, add an HTTP/streamable MCP server named "derive" at ${url}/mcp.
+   The first call opens a browser consent (OAuth); the scope I grant maps to my Derive role.
+2. Confirm it's connected by calling the "whoami" MCP tool, then "list_artifacts".
+
+Once connected you can publish a page, read its review comments, and run the propose -> review -> revise loop — all over MCP.`
+
+// Self-host: run Derive yourself first, then connect. Mirrors DEPLOY.md's single-
+// container quickstart; the MCP endpoint is always <your BASE_URL>/mcp.
+const selfHostPrompt = () =>
+  `Set up a self-hosted Derive for me, then connect this agent to it. Derive is an open-source living-docs tool (permanent versioned URLs + inline review comments) that is itself a remote MCP server.
+
+Please:
+1. From a Derive checkout (the directory with deploy/Dockerfile), run the single-container image (state lives in the derive_data volume):
+     docker build -f deploy/Dockerfile -t derive .
+     docker run -d -p 8080:8080 -v derive_data:/data \\
+       -e DERIVE_AUTH_SECRET="$(openssl rand -hex 32)" \\
+       -e BASE_URL="https://derive.example.com" \\
+       derive
+   Set BASE_URL to the public https URL I'll actually reach it at (behind a TLS proxy — not localhost). For a quick local-only trial, BASE_URL=http://localhost:8080 works.
+2. Connect over MCP, using that same BASE_URL:
+     claude mcp add --transport http derive <BASE_URL>/mcp
+   The first call opens a browser consent (OAuth).
+3. Confirm by calling the "whoami" MCP tool, then "list_artifacts".
+
+Then you can publish, read review comments, and run the propose -> review -> revise loop over MCP.`
+
+/**
+ * The paste-into-your-agent block: a one-line description, the quiet self-host
+ * toggle, and the copyable prompt. `testidPrefix` keys the block's testids
+ * (`<prefix>-prompt`, `<prefix>-prompt-copy`, `<prefix>-dev-toggle`) so each entry
+ * point stays individually addressable in e2e.
+ */
+export function ConnectAgent({ testidPrefix = "connect-agent" }: { testidPrefix?: string }) {
+  // Self-host mode swaps the connect snippet for run-it-yourself instructions.
+  const [devMode, setDevMode] = useState(false)
+  const publicUrl =
+    typeof window !== "undefined" ? publicUrlOf(window.location.origin) : PLACEHOLDER_URL
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-sm text-pretty text-muted-foreground">
+        {devMode
+          ? "Spin up your own Derive, then connect your agent to it. Paste this into Claude Code, Codex, or any agent."
+          : "Paste this into Claude Code, Codex, ChatGPT, or any agent — it connects Derive so the agent can publish, review, and revise for you."}
+      </p>
+      {/* The self-host switch rides just above the snippet it swaps — a rarely-
+          touched option, so it sits quiet and right-aligned, not in the header. */}
+      <label className="flex items-center gap-1.5 self-end text-sm font-medium text-muted-foreground">
+        <span>Self-host mode</span>
+        <Switch
+          checked={devMode}
+          aria-label="Self-host mode"
+          data-testid={`${testidPrefix}-dev-toggle`}
+          onCheckedChange={setDevMode}
+        />
+      </label>
+      <PromptBlock
+        key={devMode ? "dev" : "hosted"}
+        text={devMode ? selfHostPrompt() : hostedPrompt(publicUrl)}
+        testid={`${testidPrefix}-prompt`}
+      />
+    </div>
+  )
+}
+
+/**
+ * A button that opens ConnectAgent in a dialog — for entry points that live far
+ * from onboarding (the library's connect empty state, the Brandprint nudge).
+ * Owns its open state so call sites stay one line.
+ */
+export function ConnectAgentButton({
+  testId,
+  children,
+  ...props
+}: ComponentProps<typeof Button> & { testId: string }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button data-testid={testId} {...props}>
+          {children ?? "Connect an agent"}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Connect an agent</DialogTitle>
+          <DialogDescription>
+            One paste connects any MCP agent to Derive — it can then publish, review, and revise for
+            you.
+          </DialogDescription>
+        </DialogHeader>
+        <ConnectAgent testidPrefix={`${testId}-dialog`} />
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// A copyable prompt block: the scrollable text + a copy button that owns its own
+// "copied" tick, so each block has independent state.
+function PromptBlock({ text, testid }: { text: string; testid: string }) {
+  const [copied, setCopied] = useState(false)
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      toast.success("Copied — paste it into your agent")
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      toast.error("Couldn't copy; select the text and copy it manually")
+    }
+  }
+  return (
+    <div className="relative">
+      {/* The machine register on a quiet well: mono text, bg-secondary, hairline edge. */}
+      <pre
+        data-testid={testid}
+        className="max-h-64 overflow-auto whitespace-pre-wrap rounded-lg border bg-secondary p-3 pr-12 font-mono text-sm text-foreground"
+      >
+        {text}
+      </pre>
+      <Button
+        variant="outline"
+        size="icon-sm"
+        data-testid={`${testid}-copy`}
+        aria-label="Copy setup prompt"
+        className="absolute right-2 top-2"
+        onClick={copy}
+      >
+        {copied ? <Icon name="check" className="text-success" /> : <Copy className="size-4" />}
+      </Button>
+    </div>
+  )
+}

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -105,6 +105,15 @@ export const followingPreviewQuery = () =>
     queryFn: () => api.listArtifacts({ scope: "following", limit: 6 }).then((r) => r.artifacts),
   })
 
+// The OAuth clients (MCP agents) the CALLER has authorized to act as them — the
+// honest "have I connected an agent yet" signal. Read by Security's revocation list
+// and the connect-an-agent nudges (Brandprint, library empty state).
+export const connectedAgentsQuery = () =>
+  queryOptions({
+    queryKey: ["connected-agents"] as const,
+    queryFn: () => api.connectedAgents().then((r) => r.agents),
+  })
+
 // The caller's follows (GitHub authors + repo path prefixes) for the active
 // workspace. Drives the Following-feed empty state, the manage strip, and the
 // isFollowing* sets that toggle the Follow buttons. One source of truth: every

--- a/apps/web/src/lib/storage-keys.ts
+++ b/apps/web/src/lib/storage-keys.ts
@@ -18,4 +18,7 @@ export const STORAGE_KEYS = {
   // saved onboarding flag / folder pref survives the rename.
   onboarded: "derive:onboarded",
   libraryFolders: "derive:show-folders",
+  // Dismissal of the home's one-time "set up your team's Brandprint" nudge (owners
+  // of a Brandprint-less workspace; see pages/library/brandprint-nudge).
+  brandprintNudge: "derive:brandprint-nudge",
 } as const

--- a/apps/web/src/pages/brandprint/brandprint-section.tsx
+++ b/apps/web/src/pages/brandprint/brandprint-section.tsx
@@ -24,30 +24,18 @@ import {
   SelectMenuTrigger,
 } from "@/components/ui/select-menu"
 import { Skeleton } from "@/components/ui/skeleton"
-import { toast } from "@/components/ui/sonner"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
 import { useAuth } from "@/ctx"
 import {
   brandprintDocsQuery,
   collectionsQuery,
-  summaryQuery,
   workspaceQuery,
   workspaceSettingsQuery,
 } from "@/lib/queries"
 import { snapshot, useApiMutation } from "@/lib/use-api-mutation"
 import { refFor } from "../artifact/parse-ref"
-
-// What the one-click intake reports back: how many docs made it in, which files
-// didn't, and (when it created the collection and set the pointer itself) the fresh
-// server state to sync the caches from.
-type ImportResult = {
-  created: boolean
-  ok: number
-  failed: string[]
-  settings?: Awaited<ReturnType<typeof api.updateWorkspaceSettings>>
-  profile?: Awaited<ReturnType<typeof api.setProfile>>
-}
+import { type ImportResult, notesAsDoc, useBrandprintImport } from "./use-brandprint-import"
 
 // The two halves of a brand the upload tab asks for; `cat` labels each staged file
 // and doubles as the verb in the well's heading ("How … artifacts should look/read").
@@ -166,74 +154,10 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
     success: "Brandprint updated",
   })
 
-  // The one-click intake: publish each picked file, gather them into the pointed
-  // collection (creating one when the Brandprint is empty), and set the pointer.
-  // Composed from existing endpoints inside one governed mutation (the welcome.tsx
-  // save pattern). Per-file failures don't abort the batch; the pointer is only set
-  // once at least one doc made it in, so a total failure leaves nothing half-set.
+  // The one-click intake, shared with onboarding's Brandprint step — see
+  // use-brandprint-import for the composition and its failure semantics.
   const fileRef = useRef<HTMLInputElement>(null)
-  const importDocs = useApiMutation({
-    mutationFn: async (files: File[]): Promise<ImportResult> => {
-      let target = collectionId
-      let created = false
-      if (!target) {
-        const col = await api.createCollection(
-          scope === "workspace" ? "Brandprint" : "Personal Brandprint",
-        )
-        target = col.id
-        created = true
-      }
-      let ok = 0
-      const failed: string[] = []
-      for (const f of files) {
-        try {
-          // No title field — the server derives one from the doc's heading or filename.
-          const a = await api.publish(f)
-          await api.addToCollection(target, a.short_id)
-          ok++
-        } catch {
-          failed.push(f.name)
-        }
-      }
-      if (created && ok === 0) {
-        // Nothing made it in — drop the empty collection so a retry starts clean.
-        await api.deleteCollection(target).catch(() => {})
-        return { created: false, ok, failed }
-      }
-      if (!created) return { created, ok, failed }
-      if (scope === "workspace") {
-        // Conventions are for the whole team: open the collection to the workspace so
-        // members can read the docs (collection access propagates to its contents).
-        // Best-effort — MCP delivery reads under the workspace grant either way.
-        await api.setCollectionAccess(target, "member").catch(() => {})
-        const settings = await api.updateWorkspaceSettings({
-          brandprint: { collectionId: target },
-        })
-        return { created, ok, failed, settings }
-      }
-      const profile = await api.setProfile({ brandprint: { collectionId: target } })
-      return { created, ok, failed, profile }
-    },
-    success: (r) =>
-      r.ok === 0
-        ? undefined
-        : r.created
-          ? `Brandprint created with ${r.ok} doc${r.ok === 1 ? "" : "s"}`
-          : `${r.ok} doc${r.ok === 1 ? "" : "s"} added to your Brandprint`,
-    onSuccess: (r) => {
-      if (r.settings) qc.setQueryData(workspaceSettingsQuery().queryKey, r.settings)
-      if (r.profile && me) setMe({ ...me, brandprint: r.profile.brandprint })
-      if (r.failed.length > 0) {
-        // The mutation itself settled fine, so the global safety net stays quiet —
-        // name the files that fell out of the batch here.
-        const msg = `Couldn't publish ${r.failed.join(", ")}`
-        if (r.ok === 0)
-          toast.error(msg) // mutation-ignore: per-file outcome, not a rejected mutation
-        else toast.warning(msg)
-      }
-    },
-    invalidate: [collectionsQuery().queryKey, summaryQuery().queryKey, ["artifacts"]],
-  })
+  const importDocs = useBrandprintImport(scope, collectionId)
   const pickFiles = (list: FileList | null) => {
     const files = list ? [...list] : []
     if (files.length > 0) importDocs.mutate(files)
@@ -280,12 +204,7 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
   const createFromNotes = () => {
     const text = notes.trim()
     if (!text) return
-    // The notes become a markdown doc through the same intake as a picked file; the
-    // filename carries the title (slashes would read as a path, so swap them out).
-    const name = (noteTitle.trim() || "Brand notes").replace(/[\\/]/g, "-")
-    importDocs.mutate([new File([text], `${name}.md`, { type: "text/markdown" })], {
-      onSuccess: closeOnSuccess,
-    })
+    importDocs.mutate([notesAsDoc(text, noteTitle)], { onSuccess: closeOnSuccess })
   }
 
   const title = scope === "workspace" ? "Workspace Brandprint" : "Your Brandprint"

--- a/apps/web/src/pages/brandprint/index.tsx
+++ b/apps/web/src/pages/brandprint/index.tsx
@@ -1,6 +1,10 @@
+import { useQuery } from "@tanstack/react-query"
+import { ConnectAgentButton } from "@/components/shared/connect-agent"
 import { PageHeader } from "@/components/shared/page-header"
 import { PageShell } from "@/components/shared/page-shell"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useAuth } from "@/ctx"
+import { connectedAgentsQuery, workspaceSettingsQuery } from "@/lib/queries"
 import { useDocumentTitle } from "@/lib/use-document-title"
 import { BrandprintSection } from "./brandprint-section"
 
@@ -16,9 +20,31 @@ export function Brandprint() {
         title="Brandprint"
         subtitle="The conventions your artifacts follow: how they look and how they read. Any agent connected to this workspace picks them up automatically."
       />
+      <ApplyNudge />
       <BrandprintSection scope="workspace" />
       <BrandprintSection scope="account" />
     </PageShell>
+  )
+}
+
+// The saved-but-inert state: a Brandprint exists but the caller has never authorized
+// an agent, so nothing is reading it. The honest framing from the spec — captured and
+// saved now, applied the moment an agent connects — with the shared Connect surface
+// one tap away. Ambient: any load failure just keeps the band hidden.
+function ApplyNudge() {
+  const { me } = useAuth()
+  const { data: settings } = useQuery({ ...workspaceSettingsQuery(), enabled: !!me })
+  const { data: agents, isError } = useQuery({ ...connectedAgentsQuery(), enabled: !!me })
+  const hasBrandprint = !!settings?.brandprint?.collectionId || !!me?.brandprint?.collectionId
+  if (isError || !hasBrandprint || !agents || agents.length > 0) return null
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border bg-secondary/40 px-4 py-3">
+      <p className="text-sm text-pretty text-muted-foreground">
+        <span className="font-medium text-foreground">Your Brandprint is saved</span>, but nothing
+        is reading it yet. Connect an agent and it applies from the very next thing it builds.
+      </p>
+      <ConnectAgentButton variant="secondary" size="sm" testId="brandprint-connect-agent" />
+    </div>
   )
 }
 

--- a/apps/web/src/pages/brandprint/use-brandprint-import.ts
+++ b/apps/web/src/pages/brandprint/use-brandprint-import.ts
@@ -1,0 +1,100 @@
+import { useQueryClient } from "@tanstack/react-query"
+import { api } from "@/api"
+import { toast } from "@/components/ui/sonner"
+import { useAuth } from "@/ctx"
+import { collectionsQuery, summaryQuery, workspaceSettingsQuery } from "@/lib/queries"
+import { useApiMutation } from "@/lib/use-api-mutation"
+
+// What the intake reports back: how many docs made it in, which files didn't, and
+// (when it created the collection and set the pointer itself) the fresh server
+// state to sync the caches from.
+export type ImportResult = {
+  created: boolean
+  ok: number
+  failed: string[]
+  settings?: Awaited<ReturnType<typeof api.updateWorkspaceSettings>>
+  profile?: Awaited<ReturnType<typeof api.setProfile>>
+}
+
+/**
+ * The Brandprint intake: publish each given file, gather them into the pointed
+ * collection (creating one when `collectionId` is empty), and set the scope's
+ * pointer. Composed from existing endpoints inside one governed mutation (the
+ * welcome.tsx save pattern); shared by the Brandprint section's create dialog and
+ * onboarding's Brandprint step. Per-file failures don't abort the batch; the
+ * pointer is only set once at least one doc made it in, so a total failure leaves
+ * nothing half-set.
+ */
+export function useBrandprintImport(scope: "workspace" | "account", collectionId: string) {
+  const qc = useQueryClient()
+  const { me, setMe } = useAuth()
+  return useApiMutation({
+    mutationFn: async (files: File[]): Promise<ImportResult> => {
+      let target = collectionId
+      let created = false
+      if (!target) {
+        const col = await api.createCollection(
+          scope === "workspace" ? "Brandprint" : "Personal Brandprint",
+        )
+        target = col.id
+        created = true
+      }
+      let ok = 0
+      const failed: string[] = []
+      for (const f of files) {
+        try {
+          // No title field — the server derives one from the doc's heading or filename.
+          const a = await api.publish(f)
+          await api.addToCollection(target, a.short_id)
+          ok++
+        } catch {
+          failed.push(f.name)
+        }
+      }
+      if (created && ok === 0) {
+        // Nothing made it in — drop the empty collection so a retry starts clean.
+        await api.deleteCollection(target).catch(() => {})
+        return { created: false, ok, failed }
+      }
+      if (!created) return { created, ok, failed }
+      if (scope === "workspace") {
+        // Conventions are for the whole team: open the collection to the workspace so
+        // members can read the docs (collection access propagates to its contents).
+        // Best-effort — MCP delivery reads under the workspace grant either way.
+        await api.setCollectionAccess(target, "member").catch(() => {})
+        const settings = await api.updateWorkspaceSettings({
+          brandprint: { collectionId: target },
+        })
+        return { created, ok, failed, settings }
+      }
+      const profile = await api.setProfile({ brandprint: { collectionId: target } })
+      return { created, ok, failed, profile }
+    },
+    success: (r) =>
+      r.ok === 0
+        ? undefined
+        : r.created
+          ? `Brandprint created with ${r.ok} doc${r.ok === 1 ? "" : "s"}`
+          : `${r.ok} doc${r.ok === 1 ? "" : "s"} added to your Brandprint`,
+    onSuccess: (r) => {
+      if (r.settings) qc.setQueryData(workspaceSettingsQuery().queryKey, r.settings)
+      if (r.profile && me) setMe({ ...me, brandprint: r.profile.brandprint })
+      if (r.failed.length > 0) {
+        // The mutation itself settled fine, so the global safety net stays quiet —
+        // name the files that fell out of the batch here.
+        const msg = `Couldn't publish ${r.failed.join(", ")}`
+        if (r.ok === 0)
+          toast.error(msg) // mutation-ignore: per-file outcome, not a rejected mutation
+        else toast.warning(msg)
+      }
+    },
+    invalidate: [collectionsQuery().queryKey, summaryQuery().queryKey, ["artifacts"]],
+  })
+}
+
+/** Wrap pasted notes as the markdown doc the intake publishes; the filename carries
+ *  the title (slashes would read as a path, so swap them out). */
+export const notesAsDoc = (notes: string, title?: string) =>
+  new File([notes], `${(title?.trim() || "Brand notes").replace(/[\\/]/g, "-")}.md`, {
+    type: "text/markdown",
+  })

--- a/apps/web/src/pages/library/brandprint-nudge.tsx
+++ b/apps/web/src/pages/library/brandprint-nudge.tsx
@@ -1,0 +1,72 @@
+import { useQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
+import { useState } from "react"
+import { Icon } from "@/components/icons"
+import { Button } from "@/components/ui/button"
+import { useAuth } from "@/ctx"
+import { workspaceQuery, workspaceSettingsQuery } from "@/lib/queries"
+import { STORAGE_KEYS } from "@/lib/storage-keys"
+
+// The spec's "first on the team" catch-all: Derive creates team workspaces at first
+// need, often after onboarding, so the owner of a Brandprint-less workspace gets one
+// quiet, dismissible nudge on the home — wherever that moment actually happens, not
+// only at signup. Dismissal is per browser (localStorage); setting a Brandprint
+// hides it everywhere for good. Ambient: a failed read just keeps it hidden.
+export function BrandprintNudge() {
+  const { me } = useAuth()
+  const [dismissed, setDismissed] = useState(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEYS.brandprintNudge) === "1"
+    } catch {
+      return true
+    }
+  })
+  const { data: ws, isError: wsError } = useQuery({ ...workspaceQuery(), enabled: !!me })
+  const { data: settings, isError: settingsError } = useQuery({
+    ...workspaceSettingsQuery(),
+    enabled: !!me,
+  })
+  const dismiss = () => {
+    setDismissed(true)
+    try {
+      localStorage.setItem(STORAGE_KEYS.brandprintNudge, "1")
+    } catch {
+      /* private mode — the in-memory dismissal holds this session */
+    }
+  }
+  const show =
+    !dismissed &&
+    !wsError &&
+    !settingsError &&
+    ws?.role === "owner" &&
+    !!settings &&
+    !settings.brandprint?.collectionId
+  if (!show) return null
+  return (
+    <div className="mb-6 flex items-center gap-2.5 rounded-lg bg-secondary px-3.5 py-2.5 text-sm">
+      <Icon name="brandprint" size={16} className="shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1 text-pretty text-foreground">
+        <Link
+          to="/brandprint"
+          data-testid="library-brandprint-nudge"
+          className="font-medium underline-offset-4 hover:underline"
+        >
+          Set up your team&rsquo;s Brandprint
+        </Link>
+        <span className="text-muted-foreground">
+          : your voice and visual style, read automatically by every agent that works here.
+        </span>
+      </span>
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        aria-label="Dismiss"
+        data-testid="library-brandprint-nudge-dismiss"
+        onClick={dismiss}
+        className="shrink-0 text-muted-foreground"
+      >
+        <Icon name="close" size={14} />
+      </Button>
+    </div>
+  )
+}

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "react"
 import { type Artifact, api } from "@/api"
 import { Icon } from "@/components/icons"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
+import { ConnectAgentButton } from "@/components/shared/connect-agent"
 import { EmptyState } from "@/components/shared/empty-state"
 import { PageHeader } from "@/components/shared/page-header"
 import { PageShell } from "@/components/shared/page-shell"
@@ -31,6 +32,7 @@ import { cn } from "@/lib/utils"
 import { refFor } from "../artifact/parse-ref"
 import { ArtifactGrid } from "./artifact-grid"
 import { ArtifactRow, byRecency } from "./artifact-row"
+import { BrandprintNudge } from "./brandprint-nudge"
 import { CollectionBar } from "./collection-bar"
 import { FolderGroups } from "./folder-groups"
 import { FollowingStrip } from "./following-strip"
@@ -433,6 +435,10 @@ function LibraryBody({ view }: { view: LibraryView }) {
         </div>
       )}
 
+      {/* One-time, dismissible: the owner of a Brandprint-less workspace gets the
+          "first on the team" setup nudge here (spec: Onboarding / Timing). */}
+      {homeView && <BrandprintNudge />}
+
       {filter.kind === "collection" ? (
         <>
           <CollectionBar
@@ -752,14 +758,10 @@ function emptyStateFor(
         description:
           "Publish something, or connect an agent — everything you or your agents create shows up here, whatever its audience.",
         action: (
-          <Button
-            variant="outline"
-            size="sm"
-            data-testid="library-empty-connect-agent"
-            onClick={() => nav({ to: "/settings/$section", params: { section: "agents" } })}
-          >
-            Connect an agent
-          </Button>
+          // The shared ConnectAgent surface, right here in a dialog — this used to
+          // land on Settings -> Agents (the workspace-bot token form), a different
+          // concept that dead-ended the one activation moment.
+          <ConnectAgentButton variant="outline" size="sm" testId="library-empty-connect-agent" />
         ),
       }
     case "feedback":

--- a/apps/web/src/pages/settings/security-section.tsx
+++ b/apps/web/src/pages/settings/security-section.tsx
@@ -30,6 +30,7 @@ import {
 import { toast } from "@/components/ui/sonner"
 import { useAuth } from "@/ctx"
 import { authClient } from "@/lib/auth-client"
+import { connectedAgentsQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { SettingsListSkeleton } from "./settings-list-skeleton"
 import { SettingsSection } from "./settings-section"
@@ -86,25 +87,17 @@ const SCOPE_LABEL: Record<string, string> = {
 // always see what may act as you, and cut it off. The moat's human-facing trust surface.
 function ConnectedAgents() {
   const qc = useQueryClient()
-  const {
-    data: agents,
-    isPending,
-    isError,
-    refetch,
-  } = useQuery({
-    queryKey: ["connected-agents"],
-    queryFn: () => api.connectedAgents().then((r) => r.agents),
-  })
+  const { data: agents, isPending, isError, refetch } = useQuery(connectedAgentsQuery())
   const [confirming, setConfirming] = useState<string | null>(null)
 
   const revokeMut = useApiMutation({
     mutationFn: (clientId: string) => api.revokeConnectedAgent(clientId),
     onSuccess: (_data, clientId) =>
-      qc.setQueryData(["connected-agents"], (list: { clientId: string }[] | undefined) =>
+      qc.setQueryData(connectedAgentsQuery().queryKey, (list) =>
         list?.filter((a) => a.clientId !== clientId),
       ),
     success: "Access revoked — the agent must be re-authorized to act again",
-    invalidate: [["connected-agents"]],
+    invalidate: [connectedAgentsQuery().queryKey],
   })
   const revoke = (clientId: string) => revokeMut.mutate(clientId)
 

--- a/apps/web/src/pages/welcome.tsx
+++ b/apps/web/src/pages/welcome.tsx
@@ -1,9 +1,10 @@
+import { useQuery } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
-import { Copy } from "lucide-react"
 import { useEffect, useState } from "react"
 import { ApiError, api } from "@/api"
 import { Icon } from "@/components/icons"
 import { AvatarPicker } from "@/components/shared/avatar-picker"
+import { ConnectAgent } from "@/components/shared/connect-agent"
 import { fieldError } from "@/components/shared/field-error"
 import { FormField } from "@/components/shared/form-field"
 import { SectionEyebrow } from "@/components/shared/section-eyebrow"
@@ -24,16 +25,17 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { toast } from "@/components/ui/sonner"
-import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { useAuth } from "@/ctx"
 import { authClient } from "@/lib/auth-client"
 import { getInitials } from "@/lib/initials"
 import { OTHER, PROFESSIONS, presetFor } from "@/lib/professions"
+import { workspaceQuery, workspaceSettingsQuery } from "@/lib/queries"
 import { STORAGE_KEYS } from "@/lib/storage-keys"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { useDocumentTitle } from "@/lib/use-document-title"
 import { normalizeUsername, usernameError } from "@/lib/username"
+import { notesAsDoc, useBrandprintImport } from "@/pages/brandprint/use-brandprint-import"
 
 // A present account — the stateful onboarding body only mounts once `me` resolves
 // (see Welcome's guard), so the profile fields can safely initialize from it.
@@ -54,49 +56,9 @@ export const markOnboarded = () => {
   }
 }
 
-// The public origin to hand an agent. A deployed Derive instance's own origin IS its
-// public URL, so that's what we embed — except in local dev (localhost), where we
-// fall back to a clearly-editable placeholder so nobody copies an unreachable URL.
-const PLACEHOLDER_URL = "https://your-derive-server.com"
-const publicUrlOf = (origin: string) =>
-  /localhost|127\.0\.0\.1|\[::1\]/.test(origin) ? PLACEHOLDER_URL : origin
-
-// Hosted: Derive is already running (this instance, or any you point at). The fastest
-// on-ramp — Derive is itself a remote MCP server, so one line connects an agent and it
-// gets every Derive tool. No CLI needed for the publish/review loop.
-const hostedPrompt = (url: string) =>
-  `Connect me to Derive, a living-docs tool that hosts pages/docs at permanent, versioned URLs with inline review comments. Derive is a remote MCP server.
-
-Derive is running at: ${url}
-
-Please:
-1. Add it over MCP. In Claude Code run:
-     claude mcp add --transport http derive ${url}/mcp
-   In another harness, add an HTTP/streamable MCP server named "derive" at ${url}/mcp.
-   The first call opens a browser consent (OAuth); the scope I grant maps to my Derive role.
-2. Confirm it's connected by calling the "whoami" MCP tool, then "list_artifacts".
-
-Once connected you can publish a page, read its review comments, and run the propose -> review -> revise loop — all over MCP.`
-
-// Self-host: run Derive yourself first, then connect. Mirrors DEPLOY.md's single-
-// container quickstart; the MCP endpoint is always <your BASE_URL>/mcp.
-const selfHostPrompt = () =>
-  `Set up a self-hosted Derive for me, then connect this agent to it. Derive is an open-source living-docs tool (permanent versioned URLs + inline review comments) that is itself a remote MCP server.
-
-Please:
-1. From a Derive checkout (the directory with deploy/Dockerfile), run the single-container image (state lives in the derive_data volume):
-     docker build -f deploy/Dockerfile -t derive .
-     docker run -d -p 8080:8080 -v derive_data:/data \\
-       -e DERIVE_AUTH_SECRET="$(openssl rand -hex 32)" \\
-       -e BASE_URL="https://derive.example.com" \\
-       derive
-   Set BASE_URL to the public https URL I'll actually reach it at (behind a TLS proxy — not localhost). For a quick local-only trial, BASE_URL=http://localhost:8080 works.
-2. Connect over MCP, using that same BASE_URL:
-     claude mcp add --transport http derive <BASE_URL>/mcp
-   The first call opens a browser consent (OAuth).
-3. Confirm by calling the "whoami" MCP tool, then "list_artifacts".
-
-Then you can publish, read review comments, and run the propose -> review -> revise loop over MCP.`
+// Distinguishes a failed Brandprint seed from a failed profile save in the one
+// Continue action, so the inline error says which half to retry.
+const BRANDPRINT_FAILED = "brandprint-seed-failed"
 
 // Gate on the session BEFORE the stateful body so the profile fields initialize from
 // a resolved account (a direct visit to /welcome renders once with me=null first).
@@ -110,8 +72,6 @@ export function Welcome() {
 function Onboarding({ me }: { me: Account }) {
   const { setMe } = useAuth()
   const nav = useNavigate()
-  // Self-host mode swaps the connect snippet for run-it-yourself instructions.
-  const [devMode, setDevMode] = useState(false)
 
   // Profile state lives on the page (not a child) so the single primary action —
   // "Continue to Derive" — persists it and advances in one step. The old flow had a
@@ -123,11 +83,22 @@ function Onboarding({ me }: { me: Account }) {
     me.profession && presetFor(me.profession) === OTHER ? me.profession : "",
   )
   const [about, setAbout] = useState(me.about ?? "")
+  const [brandNotes, setBrandNotes] = useState("")
 
-  const publicUrl =
-    typeof window !== "undefined" ? publicUrlOf(window.location.origin) : PLACEHOLDER_URL
-  const hostedText = hostedPrompt(publicUrl)
-  const devText = selfHostPrompt()
+  // Step 3 shows only to the person who'd be setting up this workspace's Brandprint
+  // for the first time: an owner of a workspace that has none (the spec's "first on
+  // the team" rule — everyone else inherits it over MCP with nothing to set up).
+  // Degrade-by-design: the step is optional, so a failed read hides it rather than
+  // blocking onboarding behind a retry.
+  const { data: ws, isError: wsError } = useQuery(workspaceQuery())
+  const { data: wsSettings, isError: settingsError } = useQuery(workspaceSettingsQuery())
+  const showBrandprint =
+    !wsError &&
+    !settingsError &&
+    ws?.role === "owner" &&
+    !!wsSettings &&
+    !wsSettings.brandprint?.collectionId
+  const seedBrandprint = useBrandprintImport("workspace", "")
 
   const firstName = (me.name ?? me.username ?? me.email).split(/[@\s]/)[0]
   const initials = getInitials(me.name ?? me.email)
@@ -156,6 +127,16 @@ function Onboarding({ me }: { me: Account }) {
 
   const save = useApiMutation({
     mutationFn: async () => {
+      // The Brandprint seeds FIRST: a failure keeps the user here with their notes
+      // intact (nothing else has saved yet). On retry the settings cache already
+      // shows the pointer, so a seeded Brandprint is never doubled.
+      if (showBrandprint && brandNotes.trim()) {
+        try {
+          await seedBrandprint.mutateAsync([notesAsDoc(brandNotes)])
+        } catch {
+          throw new Error(BRANDPRINT_FAILED)
+        }
+      }
       let username = me.username
       // Only claim when it actually changed (claiming your own handle is a no-op, but
       // skipping avoids a needless round-trip).
@@ -176,9 +157,11 @@ function Onboarding({ me }: { me: Account }) {
   // Preserve the original message logic: the server's message for a known ApiError, a
   // friendly fallback for anything else.
   const saveErr = save.error
-    ? save.error instanceof ApiError
-      ? save.error.message
-      : "Could not save your profile."
+    ? save.error.message === BRANDPRINT_FAILED
+      ? "Couldn't save your Brandprint. Try again, or clear the box to skip it for now."
+      : save.error instanceof ApiError
+        ? save.error.message
+        : "Could not save your profile."
     : ""
   const continueToApp = () => {
     if (!handleErr) save.mutate()
@@ -315,33 +298,15 @@ function Onboarding({ me }: { me: Account }) {
             phishing-resistant one-tap sign-in now, or skip and do it later in Settings. */}
         <PasskeyNudge />
 
-        {/* Step 2 — Connect an agent: the activation moment (paste-into-an-agent). */}
+        {/* Step 2 — Connect an agent: the activation moment. The block itself is the
+            shared ConnectAgent surface (also behind the library's connect empty state
+            and the Brandprint nudge), so every entry point renders the same thing. */}
         <section className="flex flex-col gap-4">
           <SectionEyebrow as="h2">Step 2 · Connect an agent</SectionEyebrow>
-          <p className="text-sm text-pretty text-muted-foreground">
-            {devMode
-              ? "Spin up your own Derive, then connect your agent to it. Paste this into Claude Code, Codex, or any agent."
-              : "Paste this into Claude Code, Codex, ChatGPT, or any agent — it connects Derive so the agent can publish, review, and revise for you."}
-          </p>
-          <div className="flex flex-col gap-2">
-            {/* The self-host switch rides just above the snippet it swaps — a rarely-
-                touched option, so it sits quiet and right-aligned, not in the header. */}
-            <label className="flex items-center gap-1.5 self-end text-sm font-medium text-muted-foreground">
-              <span>Self-host mode</span>
-              <Switch
-                checked={devMode}
-                aria-label="Self-host mode"
-                data-testid="welcome-dev-toggle"
-                onCheckedChange={setDevMode}
-              />
-            </label>
-            <PromptBlock
-              key={devMode ? "dev" : "hosted"}
-              text={devMode ? devText : hostedText}
-              testid="welcome-prompt"
-            />
-          </div>
+          <ConnectAgent testidPrefix="welcome" />
         </section>
+
+        {showBrandprint && <BrandprintStep notes={brandNotes} onNotes={setBrandNotes} />}
 
         {/* Finish — one primary action that saves the profile and enters; skip leaves
             now without saving. */}
@@ -372,6 +337,38 @@ function Onboarding({ me }: { me: Account }) {
         </p>
       </div>
     </div>
+  )
+}
+
+// Step 3 — the workspace Brandprint, seeded from pasted notes (spec: onboarding is
+// workspace-scoped and conditional; the caller gates rendering). Deliberately one
+// textarea: files, look/read categories, and the collection picker live on the
+// /brandprint page — this step is the lightest useful capture, saved by the page's
+// single Continue action so nothing needs its own save button.
+function BrandprintStep({ notes, onNotes }: { notes: string; onNotes: (v: string) => void }) {
+  return (
+    <section className="flex flex-col gap-4">
+      <SectionEyebrow as="h2">Step 3 · Your team's Brandprint (optional)</SectionEyebrow>
+      <p className="text-sm text-pretty text-muted-foreground">
+        A Brandprint is your team's style in one place: your tone of voice, formatting rules, words
+        to use or avoid, and colors. Every agent that works in Derive reads it automatically before
+        it creates or revises anything, so the work matches your brand from the first draft, with no
+        one re-explaining it each time. Set it once here and everyone who joins your team inherits
+        it.
+      </p>
+      <Textarea
+        value={notes}
+        rows={5}
+        placeholder="Paste your brand guidelines, or a sample doc that already sounds right…"
+        aria-label="Your team's brand notes"
+        data-testid="welcome-brandprint"
+        onChange={(e) => onNotes(e.target.value)}
+      />
+      <p className="text-sm text-muted-foreground">
+        Saves when you continue, and starts applying the moment an agent is connected. Refine it
+        anytime on the Brandprint page.
+      </p>
+    </section>
   )
 }
 
@@ -426,43 +423,6 @@ function PasskeyNudge() {
         data-testid="welcome-add-passkey"
       >
         {busy ? "Waiting…" : "Add passkey"}
-      </Button>
-    </div>
-  )
-}
-
-// A copyable prompt block: the scrollable text + a copy button that owns its own
-// "copied" tick, so each tab's block has independent state.
-function PromptBlock({ text, testid }: { text: string; testid: string }) {
-  const [copied, setCopied] = useState(false)
-  const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopied(true)
-      toast.success("Copied — paste it into your agent")
-      setTimeout(() => setCopied(false), 2000)
-    } catch {
-      toast.error("Couldn't copy; select the text and copy it manually")
-    }
-  }
-  return (
-    <div className="relative">
-      {/* The machine register on a quiet well: mono text, bg-secondary, hairline edge. */}
-      <pre
-        data-testid={testid}
-        className="max-h-64 overflow-auto whitespace-pre-wrap rounded-lg border bg-secondary p-3 pr-12 font-mono text-sm text-foreground"
-      >
-        {text}
-      </pre>
-      <Button
-        variant="outline"
-        size="icon-sm"
-        data-testid={`${testid}-copy`}
-        aria-label="Copy setup prompt"
-        className="absolute right-2 top-2"
-        onClick={copy}
-      >
-        {copied ? <Icon name="check" className="text-success" /> : <Copy className="size-4" />}
       </Button>
     </div>
   )


### PR DESCRIPTION
## What & why

The Phase 1 remainder from `docs/plans/brandprint.md`: the shared Connect-an-agent surface and the onboarding Brandprint step. A Brandprint only matters once an agent reads it, and connecting an agent was a single-shot moment buried in onboarding — miss it and the app never offered it again (worse, the library's "Connect an agent" empty state landed on Settings → Agents, the workspace-bot token form, a different concept entirely).

Stacked on #<docs-home PR> (`feat/brandprint-docs-home`); merge that first.

## Changes

- **`components/shared/connect-agent.tsx`** (new): the paste-into-your-agent block (hosted prompt + self-host toggle + copy) extracted verbatim from `welcome.tsx`, plus a one-line `<ConnectAgentButton>` that opens it in a dialog. `testidPrefix` keeps every entry point e2e-addressable; welcome keeps its existing `welcome-prompt` ids (e2e untouched).
- **Welcome Step 2** renders the shared surface; the moved prompt builders and PromptBlock are deleted from `welcome.tsx`.
- **Welcome Step 3 (spec: Onboarding)**: owners of a Brandprint-less workspace get the plain-language explainer and one optional textarea. Notes seed the workspace Brandprint through the same intake as the create dialog (`useBrandprintImport`, extracted from the section into `pages/brandprint/use-brandprint-import.ts`), riding the page's single Continue action. Seeding runs before the profile writes, so a failure keeps the user on the page with notes intact and its own inline error; the settings cache flips the step off after success, so retries never double-seed. Degrade-by-design: if the workspace reads fail, the optional step hides rather than blocking onboarding.
- **Owner home nudge (spec: Onboarding / Timing)**: a quiet, dismissible line on the home library for owners of a Brandprint-less workspace — catches the "first on the team" moment for workspaces created after onboarding. Dismissal in localStorage (`STORAGE_KEYS.brandprintNudge`); setting a Brandprint hides it for good.
- **/brandprint saved-but-inert nudge**: when a Brandprint exists but the caller has never authorized an MCP agent, a band says so with the Connect surface one tap away. Signal is `connectedAgents` (OAuth clients), now a shared `connectedAgentsQuery` also consumed by Security's revocation list (was an inline key there).
- **Library empty state** ("Created by me"): the Connect button opens the shared dialog instead of navigating to the token form.

## Testing

- Full gate green: `pnpm typecheck` (7 projects), `pnpm run ci` (biome + lint gauntlet; lint:surfaces drove the degrade-by-design error handling on the new reads), web tests (133 passed).
- New testids for e2e: `welcome-brandprint`, `library-brandprint-nudge(-dismiss)`, `brandprint-connect-agent`, `library-empty-connect-agent` (now a dialog trigger), `connect-agent`-prefixed dialog internals.

- [x] `pnpm typecheck` passes
- [x] `pnpm exec biome ci .` reports 0 errors
- [x] `pnpm test` passes
- [ ] Added/updated tests for the change — UI composition over the tested intake; e2e over onboarding Step 3 is the natural follow-up.

## Notes for reviewers

- The seed endpoint stayed unnecessary: onboarding seeds through the same client-side composition as the create dialog, and its failure/retry semantics (seed-first, cache-driven idempotency) cover the atomicity concern that would have justified `POST /v1/brandprint/seed`.
- Step 3 shows for every fresh signup (owner of their auto-provisioned personal workspace with no Brandprint) — intended per spec: it's the plain-language introduction, fully skippable, and the workspace it seeds is inherited by anyone who joins later.
- `connectedAgents` is per-user, so the /brandprint nudge speaks to the caller ("nothing is reading it yet" means "you haven't connected an agent"), which is the honest scope for a connect prompt.
- Spec status updated on the open `docs/brandprint-status` branch. Next up: Phase 2 (Rework).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

