### PR TITLE
feat(api): permanent public blob URLs for uploaded image assets

### DIFF
--- a/.agents/skills/using/derive-publish.md
+++ b/.agents/skills/using/derive-publish.md
@@ -106,39 +106,57 @@ The `filename` parameter is a hint for content type detection:
 
 ---
 
+## Images in ANY artifact (the cheap way)
+
+Never inline a base64 `data:` URI to embed a screenshot — it tokenizes at roughly 1
+token/char, so one modest PNG can cost 100k+ tokens to pass through a tool call or
+read back. Instead, upload the raw bytes once and get a permanent public URL:
+
+```
+# 1. Stream the bytes up as binary — no base64, nothing to transcribe.
+curl -s -X POST "$DERIVE_URL/v1/assets" \
+  -H "authorization: Bearer $DERIVE_TOKEN" \
+  -H "content-type: image/png" \
+  --data-binary @shot.png
+# → { "key": "9f86d081…", "url": "https://derive.to/blob/9f86d081….png",
+#     "ref": "asset:9f86d081…", "type": "image/png", "size": 20531 }
+
+# 2. Paste the url straight into the content — works in a SINGLE-FILE artifact,
+#    a bundle page, or markdown — it's just a normal <img src> / ![]() target:
+publish(content = '<img src="https://derive.to/blob/9f86d081….png">')
+```
+
+`url` is a permanent, content-addressed capability link (the hash is unguessable, so
+it's effectively private, but it's not gated by the artifact's own visibility the way
+`/raw/...` bytes are — don't use it for anything that must stay strictly access-controlled).
+It never expires and never changes for the same bytes (re-uploading identical bytes is a
+free no-op). `POST /v1/assets` accepts a raw binary body (as above) or a multipart `file`
+field. Supported: PNG, JPEG, GIF, WebP (max 25 MB each; SVG is rejected).
+
 ## Images & binary assets in a bundle
 
 A bundle's `files` map carries binary assets (screenshots, images, fonts) alongside the
 HTML/CSS/JS pages. Each `files` value is one of:
 
 - **text** — a plain string (a page).
-- **base64 data URI** — `"shot.png": "data:image/png;base64,iVBORw0K…"`. Fine for a small
-  icon, but a real screenshot balloons the tool call and you have to transcribe the
-  base64 exactly.
-- **asset handle (preferred for real images)** — upload the raw bytes first, then
-  reference the returned handle:
+- **base64 data URI** — `"shot.png": "data:image/png;base64,iVBORw0K…"`. Avoid for real
+  screenshots (see above) — fine only for a tiny inline icon.
+- **the same `url` from above**, used as any page's `<img src>` — works in a bundle too.
+- **asset handle** — `"shot.png": "asset:9f86d081…"` (the same upload's `ref`), baked
+  into the bundle as its own file at that path instead of linked externally:
 
   ```
-  # 1. Stream the bytes up as binary — no base64, nothing to transcribe.
-  curl -s -X POST "$DERIVE_URL/v1/assets" \
-    -H "authorization: Bearer $DERIVE_TOKEN" \
-    -H "content-type: image/png" \
-    --data-binary @shot.png
-  # → { "key": "9f86d081…", "ref": "asset:9f86d081…", "type": "image/png", "size": 20531 }
-
-  # 2. Reference the handle in publish (the map stays tiny):
   publish(files = {
     "index.html": "<img src=shot.png>",
     "shot.png":   "asset:9f86d081…"
   })
   ```
 
-  `POST /v1/assets` accepts a raw binary body (as above) or a multipart `file` field, and
-  stores the bytes content-addressed (identical bytes dedup to one blob; re-uploading is
-  free). Supported: PNG, JPEG, GIF, WebP (max 25 MB each; SVG is rejected). The asset is
-  served with the doc's own visibility once published — it is not a public URL on its own.
+  Once published, that page serves at `https://derive.to/raw/<short_id>/v/<n>/shot.png`
+  (gated by the doc's own visibility, unlike the public `/blob/...` url above).
 
-  Mix and match: base64 for a tiny inline icon, `asset:` handles for the screenshots.
+  Mix and match as needed: the public `url` for the simple case, `asset:` handles when
+  the image must inherit the doc's own access control.
 
 ---
 

--- a/.claude/skills/using/derive-publish.md
+++ b/.claude/skills/using/derive-publish.md
@@ -111,39 +111,57 @@ The `filename` parameter is a hint for content type detection:
 
 ---
 
+## Images in ANY artifact (the cheap way)
+
+Never inline a base64 `data:` URI to embed a screenshot — it tokenizes at roughly 1
+token/char, so one modest PNG can cost 100k+ tokens to pass through a tool call or
+read back. Instead, upload the raw bytes once and get a permanent public URL:
+
+```
+# 1. Stream the bytes up as binary — no base64, nothing to transcribe.
+curl -s -X POST "$DERIVE_URL/v1/assets" \
+  -H "authorization: Bearer $DERIVE_TOKEN" \
+  -H "content-type: image/png" \
+  --data-binary @shot.png
+# → { "key": "9f86d081…", "url": "https://derive.to/blob/9f86d081….png",
+#     "ref": "asset:9f86d081…", "type": "image/png", "size": 20531 }
+
+# 2. Paste the url straight into the content — works in a SINGLE-FILE artifact,
+#    a bundle page, or markdown — it's just a normal <img src> / ![]() target:
+publish(content = '<img src="https://derive.to/blob/9f86d081….png">')
+```
+
+`url` is a permanent, content-addressed capability link (the hash is unguessable, so
+it's effectively private, but it's not gated by the artifact's own visibility the way
+`/raw/...` bytes are — don't use it for anything that must stay strictly access-controlled).
+It never expires and never changes for the same bytes (re-uploading identical bytes is a
+free no-op). `POST /v1/assets` accepts a raw binary body (as above) or a multipart `file`
+field. Supported: PNG, JPEG, GIF, WebP (max 25 MB each; SVG is rejected).
+
 ## Images & binary assets in a bundle
 
 A bundle's `files` map carries binary assets (screenshots, images, fonts) alongside the
 HTML/CSS/JS pages. Each `files` value is one of:
 
 - **text** — a plain string (a page).
-- **base64 data URI** — `"shot.png": "data:image/png;base64,iVBORw0K…"`. Fine for a small
-  icon, but a real screenshot balloons the tool call and you have to transcribe the
-  base64 exactly.
-- **asset handle (preferred for real images)** — upload the raw bytes first, then
-  reference the returned handle:
+- **base64 data URI** — `"shot.png": "data:image/png;base64,iVBORw0K…"`. Avoid for real
+  screenshots (see above) — fine only for a tiny inline icon.
+- **the same `url` from above**, used as any page's `<img src>` — works in a bundle too.
+- **asset handle** — `"shot.png": "asset:9f86d081…"` (the same upload's `ref`), baked
+  into the bundle as its own file at that path instead of linked externally:
 
   ```
-  # 1. Stream the bytes up as binary — no base64, nothing to transcribe.
-  curl -s -X POST "$DERIVE_URL/v1/assets" \
-    -H "authorization: Bearer $DERIVE_TOKEN" \
-    -H "content-type: image/png" \
-    --data-binary @shot.png
-  # → { "key": "9f86d081…", "ref": "asset:9f86d081…", "type": "image/png", "size": 20531 }
-
-  # 2. Reference the handle in publish (the map stays tiny):
   publish(files = {
     "index.html": "<img src=shot.png>",
     "shot.png":   "asset:9f86d081…"
   })
   ```
 
-  `POST /v1/assets` accepts a raw binary body (as above) or a multipart `file` field, and
-  stores the bytes content-addressed (identical bytes dedup to one blob; re-uploading is
-  free). Supported: PNG, JPEG, GIF, WebP (max 25 MB each; SVG is rejected). The asset is
-  served with the doc's own visibility once published — it is not a public URL on its own.
+  Once published, that page serves at `https://derive.to/raw/<short_id>/v/<n>/shot.png`
+  (gated by the doc's own visibility, unlike the public `/blob/...` url above).
 
-  Mix and match: base64 for a tiny inline icon, `asset:` handles for the screenshots.
+  Mix and match as needed: the public `url` for the simple case, `asset:` handles when
+  the image must inherit the doc's own access control.
 
 ---
 

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1063,6 +1063,10 @@
             "type": "string",
             "description": "The blob hash (content-addressed storage key)"
           },
+          "url": {
+            "type": "string",
+            "description": "A permanent public URL for these bytes — embed it in any artifact's content"
+          },
           "ref": {
             "type": "string",
             "description": "The exact \"asset:<hash>\" string to drop into a publish files map"
@@ -1084,6 +1088,7 @@
         },
         "required": [
           "key",
+          "url",
           "ref",
           "type",
           "size"
@@ -4230,10 +4235,10 @@
         "tags": [
           "Assets"
         ],
-        "summary": "Stage a binary image asset (raw or multipart) and get its asset:<hash> handle.",
+        "summary": "Stage a binary image asset and get a permanent URL + its asset:<hash> handle.",
         "responses": {
           "200": {
-            "description": "The stored asset's content-addressed handle.",
+            "description": "The stored asset's public URL and content-addressed handle.",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -16,6 +16,7 @@ import { agentRoutes } from "./routes/agents"
 import { analyticsRoutes } from "./routes/analytics"
 import { artifactRoutes } from "./routes/artifacts"
 import { assetRoutes } from "./routes/assets"
+import { blobRoutes } from "./routes/blob"
 import { collectionRoutes } from "./routes/collections"
 import { commentRoutes } from "./routes/comments"
 import { contextRoutes } from "./routes/contexts"
@@ -354,6 +355,7 @@ export function createApp(deps: AppDeps): Hono {
     agentRoutes,
     artifactRoutes,
     assetRoutes,
+    blobRoutes,
     sharingRoutes,
     favoriteRoutes,
     followRoutes,

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -527,8 +527,14 @@ export function buildContext(deps: AppDeps) {
     return rateLimited(c, r.retryAfter)
   }
   // Would storing `incoming` more bytes push THIS workspace over its storage cap?
+  // Sums published content (storageBytes) and staged /v1/assets uploads
+  // (assetStorageBytes) separately — an asset baked into a bundle can double-count
+  // against its staged row, a deliberate over-count: a permanent public /blob/:hash
+  // URL must count from the moment it exists, not just once some doc embeds it.
   const overStorage = async (orgId: string, incoming: number): Promise<boolean> =>
-    !!deps.maxBytes && (await meta.storageBytes(orgId)) + incoming > deps.maxBytes
+    !!deps.maxBytes &&
+    (await meta.storageBytes(orgId)) + (await meta.assetStorageBytes(orgId)) + incoming >
+      deps.maxBytes
 
   // Lazy provisioning: the first member of a workspace is its owner; everyone
   // else joins at the default role. Returns the caller's role in that workspace.

--- a/apps/api/src/lib/serve-web.ts
+++ b/apps/api/src/lib/serve-web.ts
@@ -15,7 +15,7 @@ import type { Hono } from "hono"
  *  · prefixes match the path and any subpath (`/v1`, `/v1/artifacts`, …)
  *  · exact paths match only themselves (`/healthz`)
  */
-const API_PREFIXES = ["/v1", "/api", "/raw", "/oauth"] as const
+const API_PREFIXES = ["/v1", "/api", "/raw", "/blob", "/oauth"] as const
 // Exact server-owned paths. The OAuth 2.0 discovery docs (RFC 8414 / RFC 9728) the
 // Worker must answer with JSON, else SPA not_found_handling shadows them. `/mcp` is
 // EXACT, not a prefix: the MCP Streamable-HTTP endpoint is hit at exactly /mcp with

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -28,6 +28,7 @@ import {
   capRole,
   diffLines,
   EditError,
+  elideDataUris,
   formatDiff,
   isHtmlLike,
   newId,
@@ -122,10 +123,12 @@ const doc = (meta: Record<string, string | number | null | undefined>, body: str
 type ReadFormat = "markdown" | "html" | "text"
 const baseType = (t: string) => t.split(";")[0]?.trim() ?? t
 const isTextType = (t: string) => baseType(t) === "text/html" || baseType(t) === "text/markdown"
+// Only the `markdown` format elides data: URIs (never `html`, which `edits` matches
+// byte-for-byte against, or `text`, the comment-anchor source) — see elideDataUris.
 const present = (source: string, contentType: string, format: ReadFormat): string => {
   if (format === "html") return source
   if (format === "text") return isHtmlLike(contentType) ? pageText(source) : source
-  return toMarkdown(source, contentType)
+  return elideDataUris(toMarkdown(source, contentType))
 }
 const formatLabel = (contentType: string, format: ReadFormat): string => {
   if (format === "markdown")
@@ -1061,13 +1064,13 @@ async function buildServer(
           .string()
           .optional()
           .describe(
-            "The complete content for a SINGLE-FILE artifact (HTML or Markdown). Use this OR `files`, not both.",
+            "The complete content for a SINGLE-FILE artifact (HTML or Markdown). Use this OR `files`, not both. To embed an image CHEAPLY (no base64 in this call), upload the raw bytes to POST /v1/assets first — the response's `url` is a permanent public link; paste it straight into an `<img src>` or markdown `![]()`. Never inline a base64 data: URI here — it tokenizes at roughly 1 token/char, so one modest screenshot can cost 100k+ tokens to pass through this call.",
           ),
         files: z
           .record(z.string(), z.string())
           .optional()
           .describe(
-            'A MULTI-PAGE bundle as a map of path → content — the whole site. Each value is one of: a text page (plain string); a base64 data: URI for a small inline binary ("shot.png":"data:image/png;base64,iVBORw0K…"); or — PREFERRED for real images — an "asset:<hash>" handle returned by uploading the raw bytes to POST /v1/assets first ("shot.png":"asset:9f86d0818…"). The asset handle keeps the call tiny: stream each screenshot up as raw binary (no base64 transcription), then reference the handles here. Example: {"index.html":"<img src=shot.png>","styles.css":"…","shot.png":"asset:9f86d0818…","logo.png":"data:image/png;base64,iVBORw0K…"}. The root index.html (else the shallowest .html) becomes the entry page; pages reference assets by relative path. Served content-type comes from the file extension, so give binary entries a real extension (.png/.jpg/.webp/.woff2). A plain republish REPLACES the bundle (include every page and asset). Keep each call to a few MB; for many/large images, upload them to /v1/assets and reference the handles (or publish pages first, then `merge` asset batches).',
+            'A MULTI-PAGE bundle as a map of path → content — the whole site. Each value is one of: a text page (plain string); a base64 data: URI for a small inline binary ("shot.png":"data:image/png;base64,iVBORw0K…"); or — PREFERRED for real images — an "asset:<hash>" handle returned by uploading the raw bytes to POST /v1/assets first ("shot.png":"asset:9f86d0818…"). The asset handle keeps the call tiny: stream each screenshot up as raw binary (no base64 transcription), then reference the handles here. Example: {"index.html":"<img src=shot.png>","styles.css":"…","shot.png":"asset:9f86d0818…","logo.png":"data:image/png;base64,iVBORw0K…"}. The root index.html (else the shallowest .html) becomes the entry page; pages reference assets by relative path. Served content-type comes from the file extension, so give binary entries a real extension (.png/.jpg/.webp/.woff2). A plain republish REPLACES the bundle (include every page and asset). Keep each call to a few MB; for many/large images, upload them to /v1/assets and reference the handles (or publish pages first, then `merge` asset batches). Each published page is also readable directly at /raw/<short_id>/v/<n>/<path> once live.',
           ),
         title: z
           .string()
@@ -1501,6 +1504,18 @@ async function buildServer(
             ctx.bus.publish(channel, pushed)
           }
         }
+        // Each bundle page (including any bound images) is directly fetchable once
+        // live — surfacing the URLs here is the fix for an agent that can't find
+        // them otherwise and falls back to inlining base64 (see the "cheap image
+        // embedding" handoff): no separate call needed to learn where a page serves.
+        const pageUrls = isBundle
+          ? Object.fromEntries(
+              Object.keys(files as Record<string, string>).map((p) => [
+                cleanPath(p),
+                `${ctx.deps.baseUrl}/raw/${artifact.short_id}/v/${version.n}/${cleanPath(p)}`,
+              ]),
+            )
+          : null
         return json({
           published: true,
           short_id: artifact.short_id,
@@ -1508,6 +1523,7 @@ async function buildServer(
           kind: artifact.kind,
           version: version.n,
           url,
+          ...(pageUrls ? { page_urls: pageUrls } : {}),
           title: artifact.title,
           workspace_access: artifact.workspace_access,
           link_role: artifact.link_role,

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -9,6 +9,7 @@ import {
   diffLines,
   EditError,
   effectiveRole,
+  elideDataUris,
   formatDiff,
   groupSessions,
   isHtmlLike,
@@ -1368,7 +1369,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     const present = (source: string, contentType: string): string => {
       if (!format) return source
       if (format === "text") return isHtmlLike(contentType) ? pageText(source) : source
-      return toMarkdown(source, contentType)
+      return elideDataUris(toMarkdown(source, contentType))
     }
 
     c.header("Access-Control-Allow-Origin", "*")

--- a/apps/api/src/routes/assets.ts
+++ b/apps/api/src/routes/assets.ts
@@ -4,31 +4,46 @@ import type { AppContext } from "../context"
 import { bail, fail } from "../lib/http"
 import { MAX_ASSET_BYTES, sniffImageType } from "../lib/image"
 
+const EXT_FOR_TYPE: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+}
+
 /**
- * Standalone binary assets for bundles. An agent uploads the raw bytes of a
- * screenshot here (a plain binary POST — no base64 transcription), gets back a
- * content-addressed `asset:<hash>` handle, and references that handle in a `publish`
- * `files` map (resolved by decodeBundleFiles). This is the images-without-base64 path:
- * the transport that can't carry megabytes of binary in a JSON tool call streams them
- * as bytes instead, and the tiny handle rides the publish.
+ * Standalone binary image assets. An agent uploads the raw bytes of a screenshot
+ * here (a plain binary POST — no base64 transcription) and gets back:
  *
- * Bytes are stored content-addressed (identical bytes dedup to one blob) but not yet
- * attached to any version — the storage quota only counts them once a publish
- * references them, so an unused upload costs nothing.
+ *  - `url`: a permanent, unguessable public link (GET /blob/<hash>.<ext>) — paste it
+ *    into ANY artifact's content (single-file HTML, markdown, a bundle page) or
+ *    anywhere else (Slack, GitHub). This is the images-without-base64 path: the
+ *    transport that can't carry megabytes of binary in a JSON tool call streams
+ *    them as bytes instead, and the ~70-char URL rides in the doc's own text.
+ *  - `ref` (`asset:<hash>`): the older handle for a bundle `publish` `files` map
+ *    (resolved by decodeBundleFiles), kept for that existing path.
+ *
+ * Both point at the same content-addressed bytes — `url`'s hash IS `ref`'s hash.
+ * `url` is a capability URL, not access-gated: the hash is unguessable (sha256 of
+ * the bytes), but anyone who has it can fetch it, independent of the artifact's
+ * own visibility. That trade-off is deliberate — see docs/decisions on asset URLs.
  */
 export const assetRoutes = (ctx: AppContext) => {
-  const { blobs, workspaceCan, activeWorkspace, overStorage } = ctx
+  const { meta, blobs, workspaceCan, activeWorkspace, overStorage, deps } = ctx
   // Contract-first: the *request* is a raw/multipart binary upload (read by hand
   // below, no JSON body schema), but the *response* is a typed handle that agents /
   // the CLI / MCP consume — so it gets a schema like every other JSON response.
   const app = new OpenAPIHono<BlankEnv>()
 
-  // The content-addressed handle: `key` is the blob hash, `ref` is the exact
-  // `asset:<hash>` string to drop into a publish `files` value, `type` is the sniffed
-  // image MIME (the closed ImageType set), `size` the byte length.
+  // The content-addressed handle: `key` is the blob hash, `url` a permanent public
+  // link to the same bytes, `ref` the exact `asset:<hash>` string for a bundle
+  // `files` value, `type` the sniffed image MIME, `size` the byte length.
   const AssetRef = z
     .object({
       key: z.string().describe("The blob hash (content-addressed storage key)"),
+      url: z
+        .string()
+        .describe("A permanent public URL for these bytes — embed it in any artifact's content"),
       ref: z.string().describe('The exact "asset:<hash>" string to drop into a publish files map'),
       type: z
         .enum(["image/png", "image/jpeg", "image/gif", "image/webp"])
@@ -42,10 +57,10 @@ export const assetRoutes = (ctx: AppContext) => {
       method: "post",
       path: "/v1/assets",
       tags: ["Assets"],
-      summary: "Stage a binary image asset (raw or multipart) and get its asset:<hash> handle.",
+      summary: "Stage a binary image asset and get a permanent URL + its asset:<hash> handle.",
       responses: {
         200: {
-          description: "The stored asset's content-addressed handle.",
+          description: "The stored asset's public URL and content-addressed handle.",
           content: { "application/json": { schema: AssetRef } },
         },
       },
@@ -85,8 +100,17 @@ export const assetRoutes = (ctx: AppContext) => {
         return bail(fail(c, 413, "storage quota exceeded"))
 
       const key = await blobs.put(bytes)
-      // `ref` is the exact string to drop into a publish `files` value.
-      return c.json({ key, ref: `asset:${key}`, type, size: bytes.byteLength })
+      // Content-addressed row: this is the allowlist that makes GET /blob/:hash
+      // servable at all (the blob store also holds manifests/HTML the route must
+      // never serve) — see routes/blob.ts. A re-upload of the same bytes is a no-op.
+      await meta.createAsset({
+        hash: key,
+        org_id: org,
+        content_type: type,
+        size_bytes: bytes.byteLength,
+      })
+      const url = `${deps.baseUrl.replace(/\/$/, "")}/blob/${key}.${EXT_FOR_TYPE[type]}`
+      return c.json({ key, url, ref: `asset:${key}`, type, size: bytes.byteLength })
     },
   )
 

--- a/apps/api/src/routes/blob.ts
+++ b/apps/api/src/routes/blob.ts
@@ -1,0 +1,35 @@
+import { Hono } from "hono"
+import type { AppContext } from "../context"
+import { RAW_HEADERS, toBody } from "../lib/http"
+
+const HASH_RE = /^([0-9a-f]{64})(?:\.[a-zA-Z0-9]+)?$/
+
+/**
+ * Public capability URLs for staged image assets (POST /v1/assets): the Slack/
+ * Notion file-link model. `:file` is a sha256 hash with an optional cosmetic
+ * extension (ignored — Content-Type always comes from the `asset` row, never the
+ * client-supplied extension, so a mismatched one can't spoof the served type).
+ *
+ * Deliberately unauthenticated: unguessable (you'd need the bytes to know the
+ * hash) but not access-gated, unlike an artifact's own visibility. Only hashes
+ * with an `asset` row are servable — the blob store also holds bundle manifests
+ * and page HTML, and that row is the allowlist keeping this route from ever
+ * serving those (see routes/assets.ts, where the row is written at upload).
+ */
+export const blobRoutes = (ctx: AppContext) => {
+  const { meta, blobs } = ctx
+  const app = new Hono()
+
+  app.get("/blob/:file", async (c) => {
+    const m = HASH_RE.exec(c.req.param("file"))
+    if (!m) return c.text("not found", 404, RAW_HEADERS)
+    const hash = m[1] as string
+    const row = await meta.getAsset(hash)
+    if (!row) return c.text("not found", 404, RAW_HEADERS)
+    const data = await blobs.get(hash)
+    if (!data) return c.text("blob missing", 500)
+    return c.body(toBody(data), 200, { ...RAW_HEADERS, "Content-Type": row.content_type })
+  })
+
+  return app
+}

--- a/apps/api/test/assets.test.ts
+++ b/apps/api/test/assets.test.ts
@@ -21,7 +21,7 @@ const postAsset = (body: BodyInit, contentType?: string) =>
   })
 
 describe("POST /v1/assets", () => {
-  it("stores raw-binary image bytes and returns a content-addressed asset handle", async () => {
+  it("stores raw-binary image bytes and returns a content-addressed asset handle + public url", async () => {
     const res = await postAsset(PNG_BYTES, "image/png")
     expect(res.status).toBe(200)
     const body = await res.json()
@@ -29,12 +29,19 @@ describe("POST /v1/assets", () => {
     expect(body.size).toBe(PNG_BYTES.byteLength)
     expect(body.key).toMatch(/^[0-9a-f]{64}$/)
     expect(body.ref).toBe(`asset:${body.key}`)
+    expect(body.url).toBe(`http://derive.test/blob/${body.key}.png`)
 
     // The exact bytes are stored at that key, ready for a publish to reference.
     const blobs = new FsBlobStore(join(dir, "blobs"))
     const stored = await blobs.get(body.key)
     expect(stored).toBeTruthy()
     expect(new Uint8Array(stored as Uint8Array)).toEqual(PNG_BYTES)
+
+    // And the returned `url` actually serves those bytes back.
+    const served = await app.request(new URL(body.url).pathname)
+    expect(served.status).toBe(200)
+    expect(served.headers.get("content-type")).toBe("image/png")
+    expect(new Uint8Array(await served.arrayBuffer())).toEqual(PNG_BYTES)
   })
 
   it("accepts a multipart file field and dedups identical bytes to the same key", async () => {
@@ -44,7 +51,9 @@ describe("POST /v1/assets", () => {
     const res = await postAsset(fd)
     expect(res.status).toBe(200)
     // Content-addressed: the same bytes hash to the same key regardless of transport.
-    expect((await res.json()).key).toBe(raw.key)
+    const body = await res.json()
+    expect(body.key).toBe(raw.key)
+    expect(body.url).toBe(raw.url)
   })
 
   it("trusts the bytes, not the type — rejects a non-image with a 400", async () => {

--- a/apps/api/test/blob.test.ts
+++ b/apps/api/test/blob.test.ts
@@ -1,0 +1,67 @@
+import { join } from "node:path"
+import { FsBlobStore } from "@derive/storage/fs"
+import { describe, expect, it } from "vitest"
+import { app, dir } from "./helpers"
+
+// GET /blob/:hash is the public capability URL side of POST /v1/assets (see
+// assets.test.ts): a permanent, unauthenticated link to a staged image's bytes.
+// The one thing this route must never do is serve a hash it only knows about
+// because SOME OTHER blob (a bundle manifest, an HTML page) happens to live at
+// that key in the shared content-addressed store — only a hash with its own
+// `asset` row (written at upload) is fair game. That's the security boundary
+// under test here, not just the happy path.
+
+const PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+const PNG_BYTES = new Uint8Array(Buffer.from(PNG_B64, "base64"))
+
+const postAsset = async () => {
+  const res = await app.request("/v1/assets", {
+    method: "POST",
+    headers: { "content-type": "image/png" },
+    body: PNG_BYTES,
+  })
+  return res.json()
+}
+
+describe("GET /blob/:file", () => {
+  it("serves a staged asset's bytes, unauthenticated, with an immutable cache header", async () => {
+    const { key } = await postAsset()
+    const res = await app.request(`/blob/${key}.png`, { headers: {} }) // no auth header at all
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toBe("image/png")
+    expect(res.headers.get("cache-control")).toContain("immutable")
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(PNG_BYTES)
+  })
+
+  it("ignores the file extension — serves the persisted content-type regardless", async () => {
+    const { key } = await postAsset()
+    for (const suffix of ["", ".png", ".jpg", ".anything"]) {
+      const res = await app.request(`/blob/${key}${suffix}`)
+      expect(res.status).toBe(200)
+      expect(res.headers.get("content-type")).toBe("image/png")
+    }
+  })
+
+  it("404s a well-formed hash that was never uploaded", async () => {
+    const res = await app.request(`/blob/${"0".repeat(64)}.png`)
+    expect(res.status).toBe(404)
+  })
+
+  it("404s malformed file params (not a 64-hex hash)", async () => {
+    for (const bad of ["not-a-hash", "abc.png", `${"g".repeat(64)}.png`, `${"a".repeat(63)}.png`]) {
+      expect((await app.request(`/blob/${bad}`)).status).toBe(404)
+    }
+  })
+
+  it("SECURITY: never serves a blob-store hash that has no asset row (a bundle manifest, an HTML page)", async () => {
+    // Simulate a real bytes-in-the-store-but-not-a-staged-asset case: a private
+    // bundle's manifest JSON or an HTML page blob, which lives in the exact same
+    // content-addressed store /blob reads from. Without the asset-row gate this
+    // would leak arbitrary artifact content by hash, unauthenticated.
+    const blobs = new FsBlobStore(join(dir, "blobs"))
+    const hash = await blobs.put(new TextEncoder().encode('{"entry":"/index.html","files":{}}'))
+    const res = await app.request(`/blob/${hash}`)
+    expect(res.status).toBe(404)
+  })
+})

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -167,7 +167,7 @@ crons = ["* * * * *"]
 [assets]
 directory = "../web/dist/client"
 binding = "ASSETS"
-run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/oauth/*", "/settings/github/*", "/settings/slack/*", "/artifacts/*", "/users/*", "/healthz", "/mcp", "/openapi.json", "/docs", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource", "/.well-known/openid-configuration"]
+run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/blob/*", "/oauth/*", "/settings/github/*", "/settings/slack/*", "/artifacts/*", "/users/*", "/healthz", "/mcp", "/openapi.json", "/docs", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource", "/.well-known/openid-configuration"]
 not_found_handling = "single-page-application"
 
 # Public hosts: the derive.to apex is canonical, app.derive.to an alias. Cloudflare

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -1581,7 +1581,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Stage a binary image asset (raw or multipart) and get its asset:<hash> handle. */
+        /** Stage a binary image asset and get a permanent URL + its asset:<hash> handle. */
         post: {
             parameters: {
                 query?: never;
@@ -1591,7 +1591,7 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description The stored asset's content-addressed handle. */
+                /** @description The stored asset's public URL and content-addressed handle. */
                 200: {
                     headers: {
                         [name: string]: unknown;
@@ -5219,6 +5219,8 @@ export interface components {
         AssetRef: {
             /** @description The blob hash (content-addressed storage key) */
             key: string;
+            /** @description A permanent public URL for these bytes — embed it in any artifact's content */
+            url: string;
             /** @description The exact "asset:<hash>" string to drop into a publish files map */
             ref: string;
             /**

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
         "/v1",
         "/api",
         "/raw",
+        "/blob",
         "/healthz",
         "/oauth",
         "/mcp",

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -467,6 +467,16 @@ CREATE TABLE IF NOT EXISTS audit_log (
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 
+CREATE TABLE IF NOT EXISTS asset (
+  hash TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  content_type TEXT NOT NULL,
+  size_bytes INTEGER NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS asset_org ON asset (org_id);
+
 CREATE TABLE IF NOT EXISTS principal (
     id TEXT PRIMARY KEY,
     org_id TEXT NOT NULL,

--- a/packages/core/src/doc-text.ts
+++ b/packages/core/src/doc-text.ts
@@ -599,6 +599,19 @@ export const isHtmlLike = (contentType: string): boolean => {
 export const toMarkdown = (source: string, contentType: string): string =>
   isHtmlLike(contentType) ? htmlToMarkdown(source) : source
 
+// A base64 data: URI tokenizes at roughly 1 token/char — a single modest screenshot
+// can cost 100k+ tokens to read back through an agent-facing surface. Only ever
+// applied to the markdown/agent-readable form (never the exact HTML source, which
+// `edits` matches byte-for-byte against); anything over ~200 base64 chars (~150
+// bytes) is worth collapsing.
+const DATA_URI_RE = /data:([a-zA-Z0-9.+-]+\/[a-zA-Z0-9.+-]+);base64,([A-Za-z0-9+/=]+)/g
+export const elideDataUris = (s: string): string =>
+  s.replace(DATA_URI_RE, (m, mime: string, b64: string) =>
+    b64.length > 200
+      ? `data:${mime};base64,[elided — ${Math.round((b64.length * 3) / 4 / 1024)}KB inline image. Re-upload via POST /v1/assets and swap in its url to make this doc cheap to read]`
+      : m,
+  )
+
 /** Outline for any text source (h1–h3 for HTML, ATX `#`–`###` for markdown). */
 export const outlineOf = (source: string, contentType: string): OutlineSection[] => {
   if (isHtmlLike(contentType)) return docOutline(source)

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -883,6 +883,36 @@ export interface ModerationStore {
  * area can depend on the narrower sub-store instead. Splitting the definition keeps a
  * change to one feature from visually touching the others.
  */
+export interface AssetRecord {
+  /** The blob's sha256 hex — same key as BlobStore.put/get, and the exact
+   *  `asset:<hash>` handle the client already has. */
+  hash: string
+  org_id: string
+  content_type: string
+  size_bytes: number
+  created_at: string
+}
+export interface NewAsset {
+  hash: string
+  org_id: string
+  content_type: string
+  size_bytes: number
+}
+
+export interface AssetStore {
+  // ---- Standalone image assets (POST /v1/assets), servable at GET /blob/:hash ----
+  /** Record a staged upload's metadata. Content-addressed: re-uploading the same
+   *  bytes is a no-op (ON CONFLICT DO NOTHING) — the row already describes them. */
+  createAsset(a: NewAsset): Promise<AssetRecord>
+  /** One asset by hash, org-unscoped — `/blob/:hash` is a public capability URL
+   *  (unguessable, not access-gated), so serving it never needs the caller's org. */
+  getAsset(hash: string): Promise<AssetRecord | null>
+  /** Distinct bytes staged by an org's uploads (whether or not they've been
+   *  embedded anywhere yet) — folded into storageBytes so a permanent public
+   *  URL counts against quota from the moment it exists, not just once referenced. */
+  assetStorageBytes(orgId: string): Promise<number>
+}
+
 export interface MetaStore
   extends ArtifactStore,
     CommentStore,
@@ -896,7 +926,8 @@ export interface MetaStore
     ContextStore,
     DirectoryStore,
     AgentStore,
-    ModerationStore {}
+    ModerationStore,
+    AssetStore {}
 
 /** What a user follows: a GitHub author (`target` = the login), a repo path prefix
  *  (`target` = a path prefix, e.g. "docs/plans"), or a Derive person (`target` = their

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -18,6 +18,7 @@ import type {
   ArtifactInviteRecord,
   ArtifactMemberRecord,
   ArtifactRecord,
+  AssetRecord,
   AuditLogRecord,
   CollectionMemberRecord,
   CollectionRecord,
@@ -78,6 +79,7 @@ export interface TypedTables {
   domain: DomainRecord
   report: ReportRecord
   auditLog: AuditLogRecord
+  asset: AssetRecord
 }
 
 /**

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -603,6 +603,22 @@ export const auditLog = pgTable("audit_log", {
   created_at: text("created_at").notNull().$defaultFn(isoNow),
 })
 
+// A staged binary image asset (POST /v1/assets): content-addressed by `hash`, so
+// re-uploading identical bytes is a no-op. This row is what makes GET /blob/:hash
+// servable at all — the blob store also holds bundle manifests and page HTML, and
+// this table is the allowlist keeping the public route from ever serving those.
+export const asset = pgTable(
+  "asset",
+  {
+    hash: text("hash").primaryKey(),
+    org_id: text("org_id").notNull(),
+    content_type: text("content_type").notNull(),
+    size_bytes: integer("size_bytes").notNull(),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [index("asset_org").on(t.org_id)],
+)
+
 // Schema parity is enforced in pg.ts, where the pg `schema` object lives — it
 // checks these table defs (via `Exhaustive`/`Shapes` in ./parity) against the
 // same core Record types the sqlite dialect uses, so the two dialects can't
@@ -653,6 +669,7 @@ const TABLES = [
   sessionMessage,
   report,
   auditLog,
+  asset,
 ]
 
 /** Build the Postgres boot DDL: generated table/index CREATEs + placeholder tables

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -4,6 +4,7 @@ import type {
   ArtifactInviteRecord,
   ArtifactMemberRecord,
   ArtifactRecord,
+  AssetRecord,
   AuditLogRecord,
   CollectionMemberRecord,
   CollectionRecord,
@@ -34,6 +35,7 @@ import type {
   NewArtifact,
   NewArtifactInvite,
   NewArtifactMember,
+  NewAsset,
   NewAuditLog,
   NewCollection,
   NewCollectionMember,
@@ -113,6 +115,7 @@ import {
   artifactInvite,
   artifactMember,
   artifactTag,
+  asset,
   auditLog,
   collection,
   collectionItem,
@@ -194,6 +197,7 @@ export const schema = {
   domain,
   report,
   auditLog,
+  asset,
 }
 
 // Compile-time schema parity (see ./parity), same classification as the sqlite
@@ -230,6 +234,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   domain: true,
   report: true,
   auditLog: true,
+  asset: true,
 }
 void _schemaExhaustive
 void _schemaShapes
@@ -2506,6 +2511,26 @@ export class PgMetaStore implements MetaStore {
       )
       .orderBy(desc(auditLog.created_at))
     return opts?.limit ? q.limit(opts.limit) : q
+  }
+
+  // ---- Standalone image assets (POST /v1/assets -> GET /blob/:hash) ------
+  async createAsset(a: NewAsset): Promise<AssetRecord> {
+    const rows = await this.db.insert(asset).values(a).onConflictDoNothing().returning()
+    // Content-addressed: a conflict means these exact bytes are already staged.
+    return rows[0] ?? ((await this.getAsset(a.hash)) as AssetRecord)
+  }
+  async getAsset(hash: string): Promise<AssetRecord | null> {
+    const rows = await this.db.select().from(asset).where(eq(asset.hash, hash))
+    return rows[0] ?? null
+  }
+  async assetStorageBytes(orgId: string): Promise<number> {
+    // `hash` is the primary key, so unlike storageBytes there's no per-org
+    // dedup to do — each row is already one distinct blob.
+    const rows = await this.db
+      .select({ s: sql<number>`coalesce(sum(${asset.size_bytes}), 0)` })
+      .from(asset)
+      .where(eq(asset.org_id, orgId))
+    return Number(rows[0]?.s ?? 0)
   }
 
   async close(): Promise<void> {

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -4,6 +4,7 @@ import type {
   ArtifactInviteRecord,
   ArtifactMemberRecord,
   ArtifactRecord,
+  AssetRecord,
   AuditLogRecord,
   CollectionMemberRecord,
   CollectionRecord,
@@ -32,6 +33,7 @@ import type {
   NewArtifact,
   NewArtifactInvite,
   NewArtifactMember,
+  NewAsset,
   NewAuditLog,
   NewCollection,
   NewCollectionMember,
@@ -111,6 +113,7 @@ import {
   artifactInvite,
   artifactMember,
   artifactTag,
+  asset,
   auditLog,
   collection,
   collectionItem,
@@ -219,6 +222,7 @@ export const schema = {
   domain,
   report,
   auditLog,
+  asset,
 }
 
 // Compile-time schema parity (see ./parity): every table must be classified, and
@@ -255,6 +259,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   domain: true,
   report: true,
   auditLog: true,
+  asset: true,
 }
 void _schemaExhaustive
 void _schemaShapes
@@ -2463,6 +2468,25 @@ export function makeRepos(db: SqliteDb) {
     return (opts?.limit ? q.limit(opts.limit) : q).all()
   }
 
+  // ---- Standalone image assets (POST /v1/assets -> GET /blob/:hash) ------
+  const createAsset = async (a: NewAsset): Promise<AssetRecord> => {
+    const inserted = await db.insert(asset).values(a).onConflictDoNothing().returning().get()
+    // Content-addressed: a conflict means these exact bytes are already staged.
+    return (inserted ?? (await getAsset(a.hash))) as AssetRecord
+  }
+  const getAsset = async (hash: string): Promise<AssetRecord | null> =>
+    (await db.select().from(asset).where(eq(asset.hash, hash)).get()) ?? null
+  const assetStorageBytes = async (orgId: string): Promise<number> => {
+    // `hash` is the primary key, so unlike storageBytes there's no per-org
+    // dedup to do — each row is already one distinct blob.
+    const row = await db
+      .select({ s: sql<number>`coalesce(sum(${asset.size_bytes}), 0)` })
+      .from(asset)
+      .where(eq(asset.org_id, orgId))
+      .get()
+    return Number(row?.s ?? 0)
+  }
+
   return {
     createArtifact,
     setAccess,
@@ -2663,6 +2687,9 @@ export function makeRepos(db: SqliteDb) {
     createAuditLog,
     takedownArtifact,
     listAuditLog,
+    createAsset,
+    getAsset,
+    assetStorageBytes,
   }
 }
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -727,6 +727,22 @@ export const auditLog = sqliteTable("audit_log", {
   created_at: text("created_at").notNull().default(now),
 })
 
+// A staged binary image asset (POST /v1/assets): content-addressed by `hash`, so
+// re-uploading identical bytes is a no-op. This row is what makes GET /blob/:hash
+// servable at all — the blob store also holds bundle manifests and page HTML, and
+// this table is the allowlist keeping the public route from ever serving those.
+export const asset = sqliteTable(
+  "asset",
+  {
+    hash: text("hash").primaryKey(),
+    org_id: text("org_id").notNull(),
+    content_type: text("content_type").notNull(),
+    size_bytes: integer("size_bytes").notNull(),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [index("asset_org").on(t.org_id)],
+)
+
 // user/session/account/verification tables are owned and migrated by Better Auth
 // (see apps/api/src/auth-config.ts) — not declared here.
 
@@ -775,6 +791,7 @@ const TABLES = [
   sessionMessage,
   report,
   auditLog,
+  asset,
 ]
 
 const ddl = generateDdl(TABLES, getTableConfig, {

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1810,4 +1810,61 @@ export function runStoreContract(
       expect((await store.getArtifactById(theirs.id))?.author_id).toBe(other)
     })
   })
+
+  describe(`${label}: standalone image assets (POST /v1/assets -> GET /blob/:hash)`, () => {
+    it("stages an asset, reads it back by hash, and is idempotent on re-upload", async () => {
+      const hash = uuid().replace(/-/g, "").padEnd(64, "0")
+      const created = await store.createAsset({
+        hash,
+        org_id: ORG,
+        content_type: "image/png",
+        size_bytes: 1234,
+      })
+      expect(created).toMatchObject({
+        hash,
+        org_id: ORG,
+        content_type: "image/png",
+        size_bytes: 1234,
+      })
+      expect(await store.getAsset(hash)).toMatchObject({ hash, content_type: "image/png" })
+
+      // Re-uploading the exact same bytes (same hash) is a no-op, not a duplicate
+      // or an error — it just returns the existing row unchanged.
+      const again = await store.createAsset({
+        hash,
+        org_id: ORG,
+        content_type: "image/png",
+        size_bytes: 1234,
+      })
+      expect(again).toMatchObject({ hash, org_id: ORG, size_bytes: 1234 })
+    })
+
+    it("returns null for a hash that was never staged", async () => {
+      expect(await store.getAsset(uuid().replace(/-/g, "").padEnd(64, "0"))).toBeNull()
+    })
+
+    it("sums an org's staged assets, scoped away from another org's", async () => {
+      const otherOrg = `org_${uuid()}`
+      const h1 = uuid().replace(/-/g, "").padEnd(64, "1")
+      const h2 = uuid().replace(/-/g, "").padEnd(64, "2")
+      const hOther = uuid().replace(/-/g, "").padEnd(64, "3")
+      await store.createAsset({ hash: h1, org_id: ORG, content_type: "image/png", size_bytes: 100 })
+      await store.createAsset({
+        hash: h2,
+        org_id: ORG,
+        content_type: "image/jpeg",
+        size_bytes: 250,
+      })
+      await store.createAsset({
+        hash: hOther,
+        org_id: otherOrg,
+        content_type: "image/png",
+        size_bytes: 999,
+      })
+
+      expect(await store.assetStorageBytes(ORG)).toBeGreaterThanOrEqual(350)
+      const otherTotal = await store.assetStorageBytes(otherOrg)
+      expect(otherTotal).toBe(999)
+    })
+  })
 }


### PR DESCRIPTION
## Summary

- Fixes the "cheap image embedding" problem reported in the [handoff doc](https://derive.to/artifacts/cheap-image-embedding-for-artifacts-handoff-x29qarzd): an agent had no cheap way to put a real screenshot in a **single-file** artifact (the reliable kind — `edits`, proposals, clean reads). The only working path (bundles + `asset:<hash>`) never had a standalone URL, and there was zero discoverability of the actual serving route (`/raw/<id>/v/<n>/<path>`), so agents fell back to base64 — ~1 token/char, 100k+ tokens for one modest PNG.
- `POST /v1/assets` now persists an `asset` row (org, sniffed content-type, size — previously discarded) and returns a permanent `url` alongside the existing `ref`.
- New `GET /blob/:hash` route serves those bytes unauthenticated — a Slack/Notion-style capability link (content-addressed, unguessable, immutable). Gated *only* by the presence of an `asset` row, so it can never leak an unrelated blob-store hash (a private bundle's manifest JSON, an HTML page) — verified with a dedicated security test.
- Bundle `asset:<hash>` (existing pattern) is untouched; both mechanisms point at the same underlying bytes.
- Folds staged-asset bytes into the storage quota (previously free forever until referenced by a publish — a quota bypass now that the bytes are permanently servable).
- Bundle `publish` results now surface each file's `/raw/...` URL directly (the discoverability fix).
- `read` (markdown format only) elides giant base64 `data:` URIs so an old base64-laden doc doesn't cost ~175k tokens to read back; `format:'html'` stays byte-exact for `edits`.
- Updates the `derive-publish` skill docs (both copies) with the new flow.

## Why this design (not the doc-gated alternative)

Considered making `asset:` refs resolve to a URL that inherits the artifact's own visibility (signed token, gated by doc access). Went with public capability URLs instead: far simpler (no publish-time scanning, no sanitizer-pipeline concerns, no rewrite machinery), covers the common case (handoffs, walkthroughs, screenshots), and the hash is unguessable — same trust model as an S3 presigned-forever link or a Slack file share.

## Test plan

- [x] `packages/db` store-contract suite (shared across sqlite/D1/pg dialects): stage/read/idempotent-reupload, org-scoped quota sum — passing on sqlite and D1 locally
- [x] New `apps/api/test/blob.test.ts`: happy path, extension-ignored, unknown-hash 404, malformed-hash 404, and the security case (a blob-store hash with no `asset` row 404s even though the bytes exist)
- [x] Extended `apps/api/test/assets.test.ts`: upload response includes `url`; the url actually serves the uploaded bytes back
- [x] `serve-web.test.ts` (the `/blob` worker-first lockstep across wrangler.toml / serve-web.ts / vite proxy)
- [x] Full monorepo `pnpm typecheck` — clean
- [x] Full `apps/api` suite on sqlite backend — clean (1 unrelated pre-existing flaky timeout in `sync-runner.test.ts`, reproduces identically on unmodified main)
- [x] OpenAPI snapshot + `apps/web/src/api-types.ts` regenerated
- [ ] Full suite against real Postgres (`scripts/test-pg.sh`) — running; will report back if anything fails that isn't resource-contention noise
- [ ] Live E2E on prod after deploy (upload → embed → render → verify existing bundle images still serve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)