### PR TITLE
fix(web): stop persisting capability tokens; declarative meta.persist opt-out

### DIFF
--- a/apps/web/src/lib/persist.ts
+++ b/apps/web/src/lib/persist.ts
@@ -5,7 +5,7 @@ import {
   persistQueryClientSubscribe,
 } from "@tanstack/react-query-persist-client"
 import { del, get, set } from "idb-keyval"
-import { CACHE_MAX_AGE, queryClient } from "./query-client"
+import { CACHE_MAX_AGE, queryClient, shouldPersistQuery } from "./query-client"
 
 // Persist the query cache to IndexedDB so a refresh restores the last-known data and paints
 // instantly — the same warm cache an in-app navigation already runs against. This erases the
@@ -37,9 +37,11 @@ const persistOptions = {
   // build; the typeof guard keeps it defined in envs without the define (vitest, plain Node).
   buster: typeof __BUILD_ID__ !== "undefined" ? __BUILD_ID__ : "dev",
   dehydrateOptions: {
-    // Persist data, but NEVER the session: `me` must re-resolve fresh on every boot so an
-    // expired session can't restore as "logged in" (the route guards await a live one).
-    shouldDehydrateQuery: (q: Query) => q.queryKey[0] !== "me" && defaultShouldDehydrateQuery(q),
+    // Persist successful queries EXCEPT those that opted out with `meta.persist: false` — the
+    // session (auth re-resolves fresh) and anything keyed by a secret/capability token. The
+    // opt-out is declared at each query, not listed here (see AppQueryMeta in query-client.ts).
+    shouldDehydrateQuery: (q: Query) =>
+      shouldPersistQuery(q.meta) && defaultShouldDehydrateQuery(q),
   },
 }
 

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -12,6 +12,9 @@ export const meQuery = () =>
     queryKey: ["me"] as const,
     queryFn: () => api.session(),
     staleTime: Number.POSITIVE_INFINITY,
+    // Never persist the session — auth must re-resolve fresh on every boot so an expired
+    // session can't restore as "logged in" (the route guards await a live one).
+    meta: { persist: false },
   })
 
 // Nav-rail data (counts + tag list, collections, workspaces). Warmed

--- a/apps/web/src/lib/query-client.test.ts
+++ b/apps/web/src/lib/query-client.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest"
-import { isTransient, retryQuery, shouldToastError, toastMessageFor } from "./query-client"
+import {
+  isTransient,
+  retryQuery,
+  shouldPersistQuery,
+  shouldToastError,
+  toastMessageFor,
+} from "./query-client"
 
 // The resilience seam: transient failures self-heal, client errors fail fast.
 const apiErr = (status: number) => Object.assign(new Error(`HTTP ${status}`), { status })
@@ -37,6 +43,17 @@ describe("shouldToastError", () => {
   })
   it("stays silent only when a mutation explicitly opts out (errorToast:false)", () => {
     expect(shouldToastError({ errorToast: false })).toBe(false)
+  })
+})
+
+describe("shouldPersistQuery", () => {
+  it("persists a query's data to IndexedDB by default", () => {
+    expect(shouldPersistQuery(undefined)).toBe(true)
+    expect(shouldPersistQuery({})).toBe(true)
+    expect(shouldPersistQuery({ persist: true })).toBe(true)
+  })
+  it("skips only when a query explicitly opts out (persist:false — session, token-keyed)", () => {
+    expect(shouldPersistQuery({ persist: false })).toBe(false)
   })
 })
 

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -32,9 +32,17 @@ export const retryQuery = (failureCount: number, err: unknown): boolean =>
 // declared, so a typo like `errorTost` is a compile error, not a silent no-op.
 export type AppMutationMeta = { errorToast?: boolean }
 
+// Query meta the app understands. `persist: false` opts a query OUT of the IndexedDB cache
+// (lib/persist.ts) — for the session (auth must re-resolve fresh) and for anything keyed by a
+// secret/capability token (invite previews), which has no reason to sit on disk. Declarative +
+// colocated with the query, so a new sensitive query opts out at its definition, not in a
+// central list someone has to remember to update.
+export type AppQueryMeta = { persist?: boolean }
+
 declare module "@tanstack/react-query" {
   interface Register {
     mutationMeta: AppMutationMeta
+    queryMeta: AppQueryMeta
   }
 }
 
@@ -42,6 +50,11 @@ declare module "@tanstack/react-query" {
  *  it opted out to handle the failure inline. Pure + exported so it's unit-tested. */
 export const shouldToastError = (meta: AppMutationMeta | undefined): boolean =>
   meta?.errorToast !== false
+
+/** Whether a query's data may be persisted to IndexedDB: yes UNLESS it opted out via
+ *  `meta.persist: false`. Pure + exported so it's unit-tested. */
+export const shouldPersistQuery = (meta: AppQueryMeta | undefined): boolean =>
+  meta?.persist !== false
 
 /** The user-facing text for a mutation failure. A server error (ApiError) carries a numeric
  *  `status` and a human message worth showing; a network/unknown failure throws a raw browser

--- a/apps/web/src/pages/accept-invite.tsx
+++ b/apps/web/src/pages/accept-invite.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { getRouteApi, useNavigate } from "@tanstack/react-router"
-import { type ArtifactInvitePreview, api, type InvitePreview } from "@/api"
+import { api } from "@/api"
 import { Logo } from "@/components/shared/logo"
 import { ROLE_LABELS } from "@/components/shared/role-select"
 import { Spinner } from "@/components/shared/spinner"
@@ -47,6 +47,8 @@ export function AcceptInvite() {
     queryKey: ["invite", token],
     queryFn: () => api.previewInvite(token),
     retry: false,
+    // Keyed by the invite token (a capability secret) — never write it to IndexedDB.
+    meta: { persist: false },
   })
 
   // The invite named an email; the signed-in account has a different one. The
@@ -132,6 +134,8 @@ export function AcceptArtifactInvite() {
     queryKey: ["artifact-invite", token],
     queryFn: () => api.previewArtifactInvite(token),
     retry: false,
+    // Keyed by the invite token (a capability secret) — never write it to IndexedDB.
+    meta: { persist: false },
   })
 
   const mismatch = !!(


### PR DESCRIPTION
## What I found auditing our own persistence work

I pulled latest (a whole **brandprint** feature + comment/UI work landed from other sessions — all of it follows our loading/mutation contracts, guards green). Then I turned the audit on *our* cache-persistence: I'd made **every** successful query persist to IndexedDB, excluded only `me`.

The gap: the **invite-preview queries are keyed by the invite token** — a capability secret (the `/invite/a/$token` route literally comments "the token in the path is the secret"). So we were **writing capability tokens to disk**, for **zero benefit** (invites are one-shot). And the `me`-only exclusion was a magic-string list that would only grow.

## The fix — a declarative opt-out, not a magic-string

Mirror the existing `meta.errorToast` mutation opt-out with a query-side **`meta.persist: false`**. The "don't persist this" decision now lives *at each query* — a future sensitive/token-keyed query opts out at its own definition, not in a central list someone has to remember to update.

- `query-client.ts` — `AppQueryMeta` + a pure, unit-tested `shouldPersistQuery(meta)`.
- `persist.ts` — `shouldDehydrateQuery = shouldPersistQuery(q.meta) && defaultShouldDehydrateQuery(q)` (replaces `queryKey[0] !== "me"`).
- `meQuery` + both invite-preview queries → `meta.persist: false`.
- Drive-by: removed two dead type imports flagged in `accept-invite.tsx`.

## Honest severity

**Defense-in-depth, not a critical leak** — the API already redacts secrets from *read* responses (I checked: "webhook without its signing secret", "token redacted", "invite token never exposed"), and the invite token is also in the URL/history. But there's no reason to also write it to IndexedDB, and the cleaner opt-out pattern is worth having regardless.

## Verification

Driven: the persisted blob keeps data (`summary`/`artifacts`) but no longer contains the `["me"]` query — session excluded via the meta path, invite tokens ride the same exclusion. Unit +2 (`shouldPersistQuery`), smoke 11/11, typecheck 0, biome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
