### PR TITLE
DRY pass: shared route guards, type-only role vocab, unified cli/mcp publish

### DIFF
--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -789,17 +789,30 @@ export function buildContext(deps: AppDeps) {
 
   // ---- Route guard helpers: the return-or-Response idiom (mirrors `limited`), so a
   // route opens with `const x = await require*(c); if (x instanceof Response) return x`.
-  // Resolve the :shortId artifact and gate it — 404 for BOTH missing and unauthorized,
-  // so a gated artifact you can't read is indistinguishable from one that isn't there
-  // (existence never leaks). Returns the artifact, or the Response to return.
+  // Resolve the :shortId artifact and gate it. Default: 404 for BOTH missing and
+  // unauthorized, so a gated artifact you can't read is indistinguishable from one
+  // that isn't there (existence never leaks) — right for `read`. Pass
+  // `{ split: true }` for actions where the caller SHOULD learn "it exists but you
+  // can't <action> it" (comment/propose/share/approve/manage) — 404 missing, 403
+  // unauthorized. Returns the artifact, or the Response to return.
   const requireArtifact = async (
     c: Context,
     action: Action,
+    opts?: { split?: boolean },
   ): Promise<ArtifactRecord | Response> => {
     const shortId = c.req.param("shortId")
     const a = shortId ? await meta.getByShortId(shortId) : null
-    if (!a || !(await authorize(c, action, a))) return fail(c, 404, "not found")
+    if (!a) return fail(c, 404, "not found")
+    if (!(await authorize(c, action, a))) {
+      return opts?.split ? fail(c, 403, "forbidden") : fail(c, 404, "not found")
+    }
     return a
+  }
+  // The caller's active-workspace org id, or the 403 to return — collapses the
+  // `workspaceCan` + `activeWorkspace` pair every workspace-scoped route opens with.
+  const requireWorkspace = async (c: Context, action: Action): Promise<string | Response> => {
+    if (!(await workspaceCan(c, action))) return fail(c, 403, "forbidden")
+    return activeWorkspace(c)
   }
   // The signed-in user, or the 401 to return — the guard every authed route opens with.
   const requireUser = async (c: Context): Promise<SessionUser | Response> =>
@@ -873,6 +886,7 @@ export function buildContext(deps: AppDeps) {
     collectionRole,
     sourceText,
     requireArtifact,
+    requireWorkspace,
     requireUser,
     isToken,
     isMember,

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -11,7 +11,7 @@ import { bail, fail, readJson } from "../lib/http"
  *  (generated from the OpenAPI spec). The agent inbox endpoints (bearer-authed, consumed
  *  by agents not the web UI) stay plain routes. */
 export const agentRoutes = (ctx: AppContext) => {
-  const { meta, activeWorkspace, agentFor, privateOwnerId, requireUser, workspaceCan } = ctx
+  const { meta, agentFor, privateOwnerId, requireUser, requireWorkspace } = ctx
   const app = new OpenAPIHono<BlankEnv>()
 
   const agentJson = (a: AgentRecord) => ({
@@ -61,8 +61,9 @@ export const agentRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
-      const agents = await meta.listAgents(await activeWorkspace(c))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
+      const agents = await meta.listAgents(org)
       return c.json({ agents: agents.map(agentJson) })
     },
   )
@@ -86,7 +87,8 @@ export const agentRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
       const b = await readJson(
         c,
         z.object({
@@ -102,7 +104,7 @@ export const agentRoutes = (ctx: AppContext) => {
       try {
         const agent = await meta.createAgent({
           id: newId("ag"),
-          org_id: await activeWorkspace(c),
+          org_id: org,
           name,
           token: sha256(token),
           role,
@@ -130,10 +132,11 @@ export const agentRoutes = (ctx: AppContext) => {
       responses: { 204: { description: "The agent was deleted." } },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
       // Scope the delete to the caller's workspace: deleteAgent is keyed by
       // (id, org) so an Admin can't delete another workspace's agent by id.
-      await meta.deleteAgent(c.req.param("id"), await activeWorkspace(c))
+      await meta.deleteAgent(c.req.param("id"), org)
       return c.body(null, 204)
     },
   )

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -106,6 +106,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     agentFor,
     authorize,
     authorizeStanding,
+    requireArtifact,
     workspaceCan,
     collectionRole,
     limited,
@@ -1182,9 +1183,8 @@ export const artifactRoutes = (ctx: AppContext) => {
       responses: { 204: { description: "The artifact was deleted." } },
     }),
     async (c) => {
-      const artifact = await meta.getByShortId(c.req.param("shortId"))
-      if (!artifact) return bail(fail(c, 404, "not found"))
-      if (!(await authorize(c, "manage", artifact))) return bail(fail(c, 403, "forbidden"))
+      const artifact = await requireArtifact(c, "manage", { split: true })
+      if (artifact instanceof Response) return bail(artifact)
       await meta.deleteArtifact(artifact.id, artifact.org_id)
       return c.body(null, 204)
     },
@@ -1209,9 +1209,8 @@ export const artifactRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const artifact = await meta.getByShortId(c.req.param("shortId"))
-      if (!artifact) return bail(fail(c, 404, "not found"))
-      if (!(await authorize(c, "manage", artifact))) return bail(fail(c, 403, "forbidden"))
+      const artifact = await requireArtifact(c, "manage", { split: true })
+      if (artifact instanceof Response) return bail(artifact)
       const b = await readJson(c, z.object({ targetOrgId: z.string().min(1) }))
       if (b instanceof Response) return bail(b)
       if (b.targetOrgId === artifact.org_id) return bail(fail(c, 400, "already in that workspace"))
@@ -1295,9 +1294,8 @@ export const artifactRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const artifact = await meta.getByShortId(c.req.param("shortId"))
-      if (!artifact) return bail(fail(c, 404, "not found"))
-      if (!(await authorize(c, "publish", artifact))) return bail(fail(c, 403, "forbidden"))
+      const artifact = await requireArtifact(c, "publish", { split: true })
+      if (artifact instanceof Response) return bail(artifact)
       const body = await readJson(c, z.object({ version: z.number().int("version required") }))
       if (body instanceof Response) return bail(body)
       const src = await meta.getVersion(artifact.id, body.version)

--- a/apps/api/src/routes/assets.ts
+++ b/apps/api/src/routes/assets.ts
@@ -29,7 +29,7 @@ const EXT_FOR_TYPE: Record<string, string> = {
  * own visibility. That trade-off is deliberate — see docs/decisions on asset URLs.
  */
 export const assetRoutes = (ctx: AppContext) => {
-  const { meta, blobs, workspaceCan, activeWorkspace, overStorage, deps } = ctx
+  const { meta, blobs, requireWorkspace, overStorage, deps } = ctx
   // Contract-first: the *request* is a raw/multipart binary upload (read by hand
   // below, no JSON body schema), but the *response* is a typed handle that agents /
   // the CLI / MCP consume — so it gets a schema like every other JSON response.
@@ -68,7 +68,8 @@ export const assetRoutes = (ctx: AppContext) => {
     async (c) => {
       // Anyone who can publish to their workspace can stage an asset for it. (The
       // anonymous write-lockdown already blocks unauthenticated POSTs.)
-      if (!(await workspaceCan(c, "publish"))) return bail(fail(c, 403, "forbidden"))
+      const org = await requireWorkspace(c, "publish")
+      if (org instanceof Response) return bail(org)
 
       const declared = Number(c.req.header("content-length") ?? 0)
       if (declared > MAX_ASSET_BYTES + 4096) return bail(fail(c, 413, "asset too large (max 25MB)"))
@@ -95,7 +96,6 @@ export const assetRoutes = (ctx: AppContext) => {
       const type = sniffImageType(bytes)
       if (!type) return bail(fail(c, 400, "unsupported asset (use PNG, JPEG, GIF, or WebP)"))
 
-      const org = await activeWorkspace(c)
       if (await overStorage(org, bytes.byteLength))
         return bail(fail(c, 413, "storage quota exceeded"))
 

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -35,6 +35,21 @@ export const collectionRoutes = (ctx: AppContext) => {
   const canManageCollection = async (c: Context, col: CollectionRecord, action: Action) =>
     roleAllows((await collectionRole(c, col)) ?? "viewer", action)
 
+  // Resolve the :id collection and gate it — 404 missing, 403 present-but-
+  // unauthorized (unlike an artifact's read gate, a collection you can't manage is
+  // still worth knowing exists, so this doesn't hide it behind a 404). The
+  // getCollection + canManageCollection pair every mutating route below opens with.
+  const requireCollection = async (
+    c: Context,
+    action: Action,
+  ): Promise<CollectionRecord | Response> => {
+    const id = c.req.param("id")
+    const col = id ? await meta.getCollection(id) : null
+    if (!col) return fail(c, 404, "not found")
+    if (!(await canManageCollection(c, col, action))) return fail(c, 403, "forbidden")
+    return col
+  }
+
   // A collection as it goes out: the stored row + its item `count` + where it came from
   // (`kind` = manual/repo/pr, with the repo/PR details). Origin is DERIVED here, not
   // stored. Every collection-returning endpoint emits this one shape.
@@ -204,9 +219,8 @@ export const collectionRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const col = await meta.getCollection(c.req.param("id"))
-      if (!col) return bail(fail(c, 404, "not found"))
-      if (!(await canManageCollection(c, col, "publish"))) return bail(fail(c, 403, "forbidden"))
+      const col = await requireCollection(c, "publish")
+      if (col instanceof Response) return bail(col)
       const body = await readJson(c, z.object({ title: z.string().optional() }))
       if (body instanceof Response) return bail(body)
       const updated = await meta.updateCollection(col.id, {
@@ -255,9 +269,8 @@ export const collectionRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const col = await meta.getCollection(c.req.param("id"))
-      if (!col) return bail(fail(c, 404, "not found"))
-      if (!(await canManageCollection(c, col, "manage"))) return bail(fail(c, 403, "forbidden"))
+      const col = await requireCollection(c, "manage")
+      if (col instanceof Response) return bail(col)
       const b = await readJson(c, z.object({ workspaceAccess: z.enum(["none", "member"]) }))
       if (b instanceof Response) return bail(b)
       await meta.setCollectionAccess(col.id, b.workspaceAccess)
@@ -275,9 +288,8 @@ export const collectionRoutes = (ctx: AppContext) => {
       responses: { 204: { description: "The collection was deleted." } },
     }),
     async (c) => {
-      const col = await meta.getCollection(c.req.param("id"))
-      if (!col) return bail(fail(c, 404, "not found"))
-      if (!(await canManageCollection(c, col, "manage"))) return bail(fail(c, 403, "forbidden"))
+      const col = await requireCollection(c, "manage")
+      if (col instanceof Response) return bail(col)
       await meta.deleteCollection(col.id)
       return c.body(null, 204)
     },
@@ -298,9 +310,8 @@ export const collectionRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const col = await meta.getCollection(c.req.param("id"))
-      if (!col) return bail(fail(c, 404, "not found"))
-      if (!(await canManageCollection(c, col, "publish"))) return bail(fail(c, 403, "forbidden"))
+      const col = await requireCollection(c, "publish")
+      if (col instanceof Response) return bail(col)
       const art = await meta.getByShortId(c.req.param("shortId"))
       // Adding to a collection re-shares the artifact (the collection's members inherit
       // a role on it), so the caller must be able to SHARE the artifact — not merely
@@ -326,9 +337,8 @@ export const collectionRoutes = (ctx: AppContext) => {
       responses: { 204: { description: "The artifact was removed." } },
     }),
     async (c) => {
-      const col = await meta.getCollection(c.req.param("id"))
-      if (!col) return bail(fail(c, 404, "not found"))
-      if (!(await canManageCollection(c, col, "publish"))) return bail(fail(c, 403, "forbidden"))
+      const col = await requireCollection(c, "publish")
+      if (col instanceof Response) return bail(col)
       const art = await meta.getByShortId(c.req.param("shortId"))
       // Curation of your own collection; same-workspace guard mirrors the add path.
       if (!art || art.org_id !== col.org_id) return bail(fail(c, 404, "artifact not found"))
@@ -393,9 +403,8 @@ export const collectionRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const col = await meta.getCollection(c.req.param("id"))
-      if (!col) return bail(fail(c, 404, "not found"))
-      if (!(await canManageCollection(c, col, "manage"))) return bail(fail(c, 403, "forbidden"))
+      const col = await requireCollection(c, "manage")
+      if (col instanceof Response) return bail(col)
       const b = await readJson(
         c,
         z
@@ -434,9 +443,8 @@ export const collectionRoutes = (ctx: AppContext) => {
       responses: { 204: { description: "The member was removed." } },
     }),
     async (c) => {
-      const col = await meta.getCollection(c.req.param("id"))
-      if (!col) return bail(fail(c, 404, "not found"))
-      if (!(await canManageCollection(c, col, "manage"))) return bail(fail(c, 403, "forbidden"))
+      const col = await requireCollection(c, "manage")
+      if (col instanceof Response) return bail(col)
       // The creator stays owner via created_by regardless of member rows; removing the
       // row wouldn't revoke their access, it would just orphan the roster — refuse it.
       if (c.req.param("userId") === col.created_by)

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -344,9 +344,8 @@ export const commentRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const artifact = await meta.getByShortId(c.req.param("shortId"))
-      if (!artifact) return bail(fail(c, 404, "not found"))
-      if (!(await authorize(c, "comment", artifact))) return bail(fail(c, 403, "forbidden"))
+      const artifact = await requireArtifact(c, "comment", { split: true })
+      if (artifact instanceof Response) return bail(artifact)
       const cm = await meta.getComment(c.req.param("commentId"))
       if (!cm || cm.artifact_id !== artifact.id) return bail(fail(c, 404, "not found"))
       const body = await readJson(c, z.object({ state: z.string().optional() }))

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -36,6 +36,7 @@ export const contextRoutes = (ctx: AppContext) => {
     currentUser,
     managementPrincipal,
     requireUser,
+    requireWorkspace,
     sourceText,
     workspaceCan,
   } = ctx
@@ -207,7 +208,8 @@ export const contextRoutes = (ctx: AppContext) => {
       // still applies on top with the grant's membership-capped role.
       const owner = await managementPrincipal(c)
       if (!owner) return bail(fail(c, 401, "unauthenticated"))
-      if (!(await workspaceCan(c, "publish"))) return bail(fail(c, 403, "forbidden"))
+      const org = await requireWorkspace(c, "publish")
+      if (org instanceof Response) return bail(org)
       const b = await readJson(
         c,
         z.object({
@@ -217,7 +219,6 @@ export const contextRoutes = (ctx: AppContext) => {
         }),
       )
       if (b instanceof Response) return bail(b)
-      const org = await activeWorkspace(c)
       const agents = await meta.listAgents(org)
       if (!agents.some((a) => a.id === b.agent_id)) return bail(fail(c, 404, "no such agent"))
       const manifest = await meta.getByShortId(b.manifest_short_id)
@@ -257,8 +258,9 @@ export const contextRoutes = (ctx: AppContext) => {
       // wiring (agent ids, creators), which GET /:id deliberately hides from
       // agents that aren't the context's own.
       if (!(await managementPrincipal(c))) return bail(fail(c, 401, "unauthenticated"))
-      if (!(await workspaceCan(c, "read"))) return bail(fail(c, 403, "forbidden"))
-      const rows = await meta.listContexts(await activeWorkspace(c))
+      const org = await requireWorkspace(c, "read")
+      if (org instanceof Response) return bail(org)
+      const rows = await meta.listContexts(org)
       // Resolve every context's manifest artifact in ONE query, then map id → short_id —
       // not a getArtifactById per row.
       const manifests = await meta.getArtifactsByIds(rows.map((x) => x.manifest_artifact_id))

--- a/apps/api/src/routes/moderation.ts
+++ b/apps/api/src/routes/moderation.ts
@@ -9,7 +9,7 @@ import { clientIp } from "../lib/rate-limit"
  *  artifact keeps its record but serves no content (410). The Report response schema
  *  is the single source for the web client's type. */
 export const moderationRoutes = (ctx: AppContext) => {
-  const { meta, actingUser, workspaceCan, activeWorkspace, isSuperAdmin } = ctx
+  const { meta, actingUser, workspaceCan, activeWorkspace, requireWorkspace, isSuperAdmin } = ctx
   const app = new OpenAPIHono<BlankEnv>()
 
   const Report = z
@@ -171,11 +171,12 @@ export const moderationRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
       const artifact = await meta.getByShortId(c.req.param("shortId"))
       // A super-admin (operator) takes down any artifact globally; a workspace
       // Admin only within their own workspace.
-      if (!artifact || (!(await isSuperAdmin(c)) && artifact.org_id !== (await activeWorkspace(c))))
+      if (!artifact || (!(await isSuperAdmin(c)) && artifact.org_id !== org))
         return bail(fail(c, 404, "not found"))
       const who = (await actingUser(c))?.name ?? "owner"
       const b = await readJson(c, z.object({ note: z.unknown().optional() }))
@@ -218,9 +219,10 @@ export const moderationRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
       const artifact = await meta.getByShortId(c.req.param("shortId"))
-      if (!artifact || (!(await isSuperAdmin(c)) && artifact.org_id !== (await activeWorkspace(c))))
+      if (!artifact || (!(await isSuperAdmin(c)) && artifact.org_id !== org))
         return bail(fail(c, 404, "not found"))
       const who = (await actingUser(c))?.name ?? "owner"
       await meta.setArtifactRemoved(artifact.id, null)

--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -5,7 +5,7 @@ import { streamSSE } from "hono/streaming"
 import type { BlankEnv } from "hono/types"
 import type { Viewer } from "../bus"
 import type { AppContext } from "../context"
-import { anonName, bail, fail, readJson } from "../lib/http"
+import { anonName, bail, readJson } from "../lib/http"
 
 /** Live updates per artifact (SSE) + ephemeral presence (who's viewing now). The
  *  Viewer response schema is the single source for the web client's type; the SSE
@@ -21,6 +21,7 @@ export const realtimeRoutes = (ctx: AppContext) => {
     currentUser,
     actorFor,
     anonViewerId,
+    requireArtifact,
   } = ctx
   const app = new OpenAPIHono<BlankEnv>()
 
@@ -121,9 +122,8 @@ export const realtimeRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const artifact = await meta.getByShortId(c.req.param("shortId"))
-      if (!artifact || !(await authorize(c, "read", artifact)))
-        return bail(fail(c, 404, "not found"))
+      const artifact = await requireArtifact(c, "read")
+      if (artifact instanceof Response) return bail(artifact)
       const viewer = await deriveViewer(c, artifact)
       const viewers = await presence.heartbeat(artifact.id, viewer, Date.now())
       bus.publish(artifact.id, { type: "presence", viewers })
@@ -143,9 +143,8 @@ export const realtimeRoutes = (ctx: AppContext) => {
       responses: { 204: { description: "Fanned out (ephemeral; nothing stored)." } },
     }),
     async (c) => {
-      const artifact = await meta.getByShortId(c.req.param("shortId"))
-      if (!artifact || !(await authorize(c, "read", artifact)))
-        return bail(fail(c, 404, "not found"))
+      const artifact = await requireArtifact(c, "read")
+      if (artifact instanceof Response) return bail(artifact)
       const body = await readJson(
         c,
         z.object({

--- a/apps/api/src/routes/review.ts
+++ b/apps/api/src/routes/review.ts
@@ -10,7 +10,7 @@ import { bail, fail, readJson, str } from "../lib/http"
  *  routes; a terminal "go" records the same call. Humans never resolve threads.
  *  The ReviewRound response schema is the single source for the web client's type. */
 export const reviewRoutes = (ctx: AppContext) => {
-  const { meta, bus, authorize, currentUser } = ctx
+  const { meta, bus, currentUser, requireArtifact } = ctx
   const app = new OpenAPIHono<BlankEnv>()
 
   const ReviewRound = z
@@ -60,9 +60,8 @@ export const reviewRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const artifact = await meta.getByShortId(c.req.param("shortId"))
-      if (!artifact) return bail(fail(c, 404, "not found"))
-      if (!(await authorize(c, "comment", artifact))) return bail(fail(c, 403, "forbidden"))
+      const artifact = await requireArtifact(c, "comment", { split: true })
+      if (artifact instanceof Response) return bail(artifact)
       const body = await readJson(c, z.object({ note: z.unknown().optional() }))
       if (body instanceof Response) return bail(body)
       const me = await currentUser(c)
@@ -94,9 +93,8 @@ export const reviewRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const artifact = await meta.getByShortId(c.req.param("shortId"))
-      if (!artifact) return bail(fail(c, 404, "not found"))
-      if (!(await authorize(c, "approve", artifact))) return bail(fail(c, 403, "forbidden"))
+      const artifact = await requireArtifact(c, "approve", { split: true })
+      if (artifact instanceof Response) return bail(artifact)
       const body = await readJson(c, z.object({ note: z.unknown().optional() }))
       if (body instanceof Response) return bail(body)
       const me = await currentUser(c)
@@ -138,9 +136,8 @@ export const reviewRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const artifact = await meta.getByShortId(c.req.param("shortId"))
-      if (!artifact) return bail(fail(c, 404, "not found"))
-      if (!(await authorize(c, "read", artifact))) return bail(fail(c, 404, "not found"))
+      const artifact = await requireArtifact(c, "read")
+      if (artifact instanceof Response) return bail(artifact)
       const me = await currentUser(c)
       const [rounds, pending] = await Promise.all([
         meta.listReviewRounds(artifact.id),

--- a/apps/api/src/routes/sharing.ts
+++ b/apps/api/src/routes/sharing.ts
@@ -35,10 +35,10 @@ export const sharingRoutes = (ctx: AppContext) => {
     meta,
     deps,
     defaultRole,
-    authorize,
     actorFor,
     actingUser,
     requireUser,
+    requireArtifact,
     bus,
     inviteLimiter,
     limited,
@@ -130,9 +130,8 @@ export const sharingRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const artifact = await meta.getByShortId(c.req.param("shortId"))
-      if (!artifact || !(await authorize(c, "read", artifact)))
-        return bail(fail(c, 404, "not found"))
+      const artifact = await requireArtifact(c, "read")
+      if (artifact instanceof Response) return bail(artifact)
       // The member roster is for collaborators, not the public. A caller who only has
       // read access via the artifact's visibility (no membership and no share) gets
       // nothing — mirrors the collection-members gate, and stops a stranger reading a
@@ -182,9 +181,8 @@ export const sharingRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const artifact = await meta.getByShortId(c.req.param("shortId"))
-      if (!artifact) return bail(fail(c, 404, "not found"))
-      if (!(await authorize(c, "share", artifact))) return bail(fail(c, 403, "forbidden"))
+      const artifact = await requireArtifact(c, "share", { split: true })
+      if (artifact instanceof Response) return bail(artifact)
       const b = await readJson(
         c,
         z
@@ -330,9 +328,8 @@ export const sharingRoutes = (ctx: AppContext) => {
       responses: { 204: { description: "The collaborator was removed." } },
     }),
     async (c) => {
-      const artifact = await meta.getByShortId(c.req.param("shortId"))
-      if (!artifact) return bail(fail(c, 404, "not found"))
-      if (!(await authorize(c, "share", artifact))) return bail(fail(c, 403, "forbidden"))
+      const artifact = await requireArtifact(c, "share", { split: true })
+      if (artifact instanceof Response) return bail(artifact)
       const members = await meta.listArtifactMembers(artifact.id)
       const target = members.find((m) => m.user_id === c.req.param("userId"))
       if (target && rank(target.role) > (await callerRank(c, artifact)))
@@ -357,9 +354,8 @@ export const sharingRoutes = (ctx: AppContext) => {
       responses: { 204: { description: "The invite was revoked." } },
     }),
     async (c) => {
-      const artifact = await meta.getByShortId(c.req.param("shortId"))
-      if (!artifact) return bail(fail(c, 404, "not found"))
-      if (!(await authorize(c, "share", artifact))) return bail(fail(c, 403, "forbidden"))
+      const artifact = await requireArtifact(c, "share", { split: true })
+      if (artifact instanceof Response) return bail(artifact)
       const target = (await meta.listPendingArtifactInvites(artifact.id)).find(
         (i) => i.id === c.req.param("id"),
       )

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -24,7 +24,7 @@ import { buildSlackManifest, slackSetupHTML } from "../slack-app-setup"
  *  routes (not typed JSON). */
 export const slackRoutes = (ctx: AppContext) => {
   const { meta, deps, bus, requireUser } = ctx
-  const { activeWorkspace, workspaceCan } = ctx
+  const { activeWorkspace, workspaceCan, requireWorkspace } = ctx
   const app = new OpenAPIHono<BlankEnv>()
   const slack = deps.slack
   const redirectUri = new URL("/v1/slack/oauth/callback", deps.baseUrl).toString()
@@ -62,10 +62,11 @@ export const slackRoutes = (ctx: AppContext) => {
   // install to this workspace + user via signed state (same pattern as GitHub install).
   app.get("/v1/slack/install", async (c) => {
     if (!slack || !deps.encryptionKey) return fail(c, 404, "Slack is not configured")
-    if (!(await workspaceCan(c, "manage"))) return fail(c, 403, "forbidden")
+    const org = await requireWorkspace(c, "manage")
+    if (org instanceof Response) return org
     const me = await requireUser(c)
     if (me instanceof Response) return me
-    const state = signState({ org: await activeWorkspace(c), uid: me.id }, deps.encryptionKey)
+    const state = signState({ org, uid: me.id }, deps.encryptionKey)
     return c.redirect(slackAuthorizeUrl(slack.clientId, redirectUri, state))
   })
 
@@ -262,8 +263,8 @@ export const slackRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
-      const org = await activeWorkspace(c)
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
       const install = await meta.getSlackInstall(org)
       if (!install) return bail(fail(c, 404, "Slack is not connected"))
       const b = await readJson(c, z.object({ default_channel: z.string().nullable() }))
@@ -284,8 +285,9 @@ export const slackRoutes = (ctx: AppContext) => {
       responses: { 204: { description: "Slack was disconnected." } },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
-      await meta.deleteSlackInstall(await activeWorkspace(c))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
+      await meta.deleteSlackInstall(org)
       return c.body(null, 204)
     },
   )

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -86,7 +86,7 @@ interface GitHubWebhookPayload {
  * (a GitHub server-to-server callback) stay plain routes.
  */
 export const syncRoutes = (ctx: AppContext) => {
-  const { meta, deps, bus, currentUser, activeWorkspace, workspaceCan, background } = ctx
+  const { meta, deps, bus, currentUser, activeWorkspace, requireWorkspace, background } = ctx
   const app = new OpenAPIHono<BlankEnv>()
 
   const RepoSource = z
@@ -356,10 +356,10 @@ export const syncRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "publish"))) return bail(fail(c, 403, "forbidden"))
+      const org = await requireWorkspace(c, "publish")
+      if (org instanceof Response) return bail(org)
       const loaded = await loadApp()
       if (!loaded) return bail(fail(c, 409, "GitHub App is not set up yet"))
-      const org = await activeWorkspace(c)
       const uid = (await currentUser(c))?.id ?? "anon"
       try {
         const installs = await listAppInstallations(loaded.app.app_id, loaded.pem)
@@ -394,8 +394,8 @@ export const syncRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "comment"))) return bail(fail(c, 403, "forbidden"))
-      const org = await activeWorkspace(c)
+      const org = await requireWorkspace(c, "comment")
+      if (org instanceof Response) return bail(org)
       const [sources, installs, loaded] = await Promise.all([
         meta.listRepoSources(org),
         meta.listGithubInstallations(org),
@@ -469,10 +469,10 @@ export const syncRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "publish"))) return bail(fail(c, 403, "forbidden"))
+      const org = await requireWorkspace(c, "publish")
+      if (org instanceof Response) return bail(org)
       const loaded = await loadApp()
       if (!loaded) return bail(fail(c, 409, "GitHub App is not set up yet"))
-      const org = await activeWorkspace(c)
       const uid = (await currentUser(c))?.id ?? "anon"
       const state = signState({ org, uid }, deps.encryptionKey as string)
       const url = `https://github.com/apps/${encodeURIComponent(
@@ -543,8 +543,8 @@ export const syncRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "publish"))) return bail(fail(c, 403, "forbidden"))
-      const org = await activeWorkspace(c)
+      const org = await requireWorkspace(c, "publish")
+      if (org instanceof Response) return bail(org)
       const installationId = c.req.param("id")
       const inst = await meta.getGithubInstallation(installationId)
       // Scope: only an installation owned by the caller's workspace is listable.
@@ -582,8 +582,8 @@ export const syncRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "publish"))) return bail(fail(c, 403, "forbidden"))
-      const org = await activeWorkspace(c)
+      const org = await requireWorkspace(c, "publish")
+      if (org instanceof Response) return bail(org)
       const installationId = c.req.param("id")
       const inst = await meta.getGithubInstallation(installationId)
       if (!inst || inst.org_id !== org) return bail(fail(c, 404, "not found"))
@@ -640,7 +640,8 @@ export const syncRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "publish"))) return bail(fail(c, 403, "forbidden"))
+      const org = await requireWorkspace(c, "publish")
+      if (org instanceof Response) return bail(org)
       const body = await readJson(
         c,
         z.object({
@@ -655,7 +656,6 @@ export const syncRoutes = (ctx: AppContext) => {
       const parsed = parseRepo(body.repo)
       if (!parsed) return bail(fail(c, 400, "repo must be owner/name"))
       const repo = `${parsed.owner}/${parsed.name}`
-      const org = await activeWorkspace(c)
       const createdBy = (await currentUser(c))?.id ?? "anon"
 
       // Dedup: one BRANCH source (and one collection) per repo in a workspace.
@@ -739,8 +739,8 @@ export const syncRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "publish"))) return bail(fail(c, 403, "forbidden"))
-      const org = await activeWorkspace(c)
+      const org = await requireWorkspace(c, "publish")
+      if (org instanceof Response) return bail(org)
       const source = await meta.getRepoSource(c.req.param("id"), org)
       if (!source) return bail(fail(c, 404, "not found"))
       if (deps.maxArtifacts && (await meta.countArtifacts(org)) >= deps.maxArtifacts)
@@ -784,8 +784,8 @@ export const syncRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "comment"))) return bail(fail(c, 403, "forbidden"))
-      const org = await activeWorkspace(c)
+      const org = await requireWorkspace(c, "comment")
+      if (org instanceof Response) return bail(org)
       const source = await meta.getRepoSource(c.req.param("id"), org)
       if (!source) return bail(fail(c, 404, "not found"))
       const view = toJson(source)
@@ -818,8 +818,8 @@ export const syncRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "comment"))) return bail(fail(c, 403, "forbidden"))
-      const org = await activeWorkspace(c)
+      const org = await requireWorkspace(c, "comment")
+      if (org instanceof Response) return bail(org)
       const active = (await meta.listRepoSources(org)).filter(isSyncing).map(toJson)
       return c.json({ active })
     },
@@ -836,8 +836,8 @@ export const syncRoutes = (ctx: AppContext) => {
       responses: { 204: { description: "The source was disconnected." } },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "publish"))) return bail(fail(c, 403, "forbidden"))
-      const org = await activeWorkspace(c)
+      const org = await requireWorkspace(c, "publish")
+      if (org instanceof Response) return bail(org)
       const source = await meta.getRepoSource(c.req.param("id"), org)
       if (!source) return bail(fail(c, 404, "not found"))
       if (c.req.query("wipe") === "true") {

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -11,7 +11,7 @@ import { WEBHOOK_EVENTS, type WebhookEvent } from "../webhooks"
  *  Webhook + Delivery response schemas are the single source for the web client's
  *  types (generated from the OpenAPI spec). */
 export const webhookRoutes = (ctx: AppContext) => {
-  const { meta, deps, workspaceCan, activeWorkspace } = ctx
+  const { meta, deps, requireWorkspace } = ctx
   const app = new OpenAPIHono<BlankEnv>()
 
   // Strip the signing secret on the way out, preserving every other field's type (so the
@@ -78,8 +78,9 @@ export const webhookRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
-      const hooks = await meta.listWebhooks(await activeWorkspace(c))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
+      const hooks = await meta.listWebhooks(org)
       return c.json({ webhooks: hooks.map(publicWebhook) })
     },
   )
@@ -98,8 +99,8 @@ export const webhookRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
-      const org = await activeWorkspace(c)
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
       const b = await readJson(
         c,
         z.object({
@@ -151,8 +152,9 @@ export const webhookRoutes = (ctx: AppContext) => {
       responses: { 204: { description: "The webhook was deleted." } },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
-      await meta.deleteWebhook(c.req.param("id"), await activeWorkspace(c))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
+      await meta.deleteWebhook(c.req.param("id"), org)
       return c.body(null, 204)
     },
   )
@@ -172,8 +174,9 @@ export const webhookRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
-      const w = await meta.getWebhook(c.req.param("id"), await activeWorkspace(c))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
+      const w = await meta.getWebhook(c.req.param("id"), org)
       if (!w) return bail(fail(c, 404, "not found"))
       const rows = await meta.recentDeliveries(w.id, 20)
       return c.json({
@@ -204,8 +207,9 @@ export const webhookRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
-      const w = await meta.getWebhook(c.req.param("id"), await activeWorkspace(c))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
+      const w = await meta.getWebhook(c.req.param("id"), org)
       if (!w) return bail(fail(c, 404, "not found"))
       const sample = JSON.stringify({
         event: "version.published",

--- a/apps/api/src/routes/workspace-domains.ts
+++ b/apps/api/src/routes/workspace-domains.ts
@@ -28,7 +28,7 @@ const parseRecords = (v: string | null): DnsRecord[] | undefined => {
  * web client's types.
  */
 export const workspaceDomainRoutes = (ctx: AppContext) => {
-  const { meta, activeWorkspace, workspaceCan } = ctx
+  const { meta, activeWorkspace, requireWorkspace } = ctx
   const cd = ctx.deps.customDomains
   const app = new OpenAPIHono<BlankEnv>()
 
@@ -133,8 +133,8 @@ export const workspaceDomainRoutes = (ctx: AppContext) => {
     }),
     async (c) => {
       if (!cd) return bail(fail(c, 501, "custom domains are not enabled on this server"))
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
-      const org = await activeWorkspace(c)
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
       const body = await readJson(c, z.object({ host: z.string() }))
       if (body instanceof Response) return bail(body)
       const host = body.host
@@ -190,8 +190,8 @@ export const workspaceDomainRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
-      const org = await activeWorkspace(c)
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
       const existing = await meta.getDomain(c.req.param("host").toLowerCase())
       if (!existing || existing.org_id !== org || existing.artifact_id)
         return bail(fail(c, 404, "not found"))
@@ -225,8 +225,8 @@ export const workspaceDomainRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
-      const org = await activeWorkspace(c)
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
       const host = c.req.param("host").toLowerCase()
       const existing = await meta.getDomain(host)
       if (!existing || existing.org_id !== org || existing.artifact_id)

--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -28,9 +28,9 @@ export const workspaceRoutes = (ctx: AppContext) => {
     requireUser,
     currentUser,
     activeWorkspace,
+    requireWorkspace,
     setWsCookie,
     workspaceRole,
-    workspaceCan,
   } = ctx
   const { privateOwnerId, oauthGrant, inviteLimiter, limited } = ctx
   const app = new OpenAPIHono<BlankEnv>()
@@ -205,14 +205,15 @@ export const workspaceRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
       const b = await readJson(
         c,
         z.object({ name: z.string().refine((s) => s.trim() !== "", "name required") }),
       )
       if (b instanceof Response) return bail(b)
       const name = b.name.trim().slice(0, 80)
-      const ws = await meta.setWorkspace(await activeWorkspace(c), name)
+      const ws = await meta.setWorkspace(org, name)
       return c.json({ name: ws.name })
     },
   )
@@ -232,7 +233,8 @@ export const workspaceRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
       const b = await readJson(
         c,
         z
@@ -247,7 +249,6 @@ export const workspaceRoutes = (ctx: AppContext) => {
       const id = await resolveUserRef(meta, (b.user ?? b.email) as string)
       const [user] = id ? await meta.getUsers([id]) : []
       if (!user) return bail(fail(c, 404, "no Derive user with that username or email"))
-      const org = await activeWorkspace(c)
       // This route both adds and re-roles, so it must honor the same last-Admin
       // guard as PATCH — otherwise an Admin could demote the sole Admin via PUT.
       const existing = await meta.getMembership(org, user.id)
@@ -290,14 +291,14 @@ export const workspaceRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
       const userId = c.req.param("userId")
       const b = await readJson(
         c,
         z.object({ role: z.custom<Role>(isWorkspaceRole, "a valid role is required") }),
       )
       if (b instanceof Response) return bail(b)
-      const org = await activeWorkspace(c)
       const existing = await meta.getMembership(org, userId)
       if (!existing) return bail(fail(c, 404, "not a member"))
       if (existing.role === "owner" && b.role !== "owner" && (await isLastOwner(org, userId)))
@@ -318,9 +319,9 @@ export const workspaceRoutes = (ctx: AppContext) => {
       responses: { 204: { description: "The member was removed (idempotent)." } },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
       const userId = c.req.param("userId")
-      const org = await activeWorkspace(c)
       const existing = await meta.getMembership(org, userId)
       if (!existing) return c.body(null, 204)
       if (existing.role === "owner" && (await isLastOwner(org, userId)))
@@ -345,7 +346,8 @@ export const workspaceRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
       const b = await readJson(
         c,
         z.object({
@@ -354,7 +356,6 @@ export const workspaceRoutes = (ctx: AppContext) => {
         }),
       )
       if (b instanceof Response) return bail(b)
-      const org = await activeWorkspace(c)
       const ref = b.email.trim()
 
       // Existing account → add directly (and clear any stale pending invite for them).
@@ -441,8 +442,9 @@ export const workspaceRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
-      const invites = await meta.listPendingInvitations(await activeWorkspace(c))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
+      const invites = await meta.listPendingInvitations(org)
       return c.json({ invites: invites.map(inviteJson) })
     },
   )
@@ -458,8 +460,9 @@ export const workspaceRoutes = (ctx: AppContext) => {
       responses: { 204: { description: "The invitation was revoked." } },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
-      await meta.deleteInvitation(c.req.param("id"), await activeWorkspace(c))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
+      await meta.deleteInvitation(c.req.param("id"), org)
       return c.body(null, 204)
     },
   )
@@ -567,7 +570,8 @@ export const workspaceRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      if (!(await workspaceCan(c, "manage"))) return bail(fail(c, 403, "forbidden"))
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
       const b = await readJson(
         c,
         z
@@ -585,7 +589,6 @@ export const workspaceRoutes = (ctx: AppContext) => {
           .partial(),
       )
       if (b instanceof Response) return bail(b)
-      const org = await activeWorkspace(c)
       // Merge over current (so a partial PATCH only flips the keys it sends). Brandprint
       // is pulled out and merged one level deep below, so setting collectionId alone
       // doesn't wipe an existing theme (and vice versa).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",
+    "@derive/core": "workspace:*",
     "@playwright/test": "^1.61.0",
     "@rolldown/plugin-babel": "^0.2.3",
     "@tailwindcss/vite": "^4.3.1",

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,4 +1,11 @@
+import type { LinkRole, Listed, Role, WorkspaceAccess } from "@derive/core"
 import type { components } from "./api-types"
+
+/** The role vocabulary and the v2 access model's three single-purpose fields are
+ *  canonical in @derive/core (roles.ts); imported here as type-only (clients never
+ *  import core at runtime — see .dependency-cruiser.mjs) and re-exported so this
+ *  stays the one place other web modules name them from. */
+export type { LinkRole, Listed, Role, WorkspaceAccess }
 
 /** A pointer to the conventions collection a workspace or an account likes its
  *  artifacts built from, plus an optional visual theme for rendered docs. Mirrors
@@ -62,13 +69,6 @@ export type ConnectedAgent = components["schemas"]["ConnectedAgent"]
 export type PublicProfile = components["schemas"]["PublicProfile"]
 /** Time-grouped view of an artifact's versions. Generated from the OpenAPI spec. */
 export type VersionSession = components["schemas"]["VersionSession"]
-export type Role = "viewer" | "commenter" | "editor" | "owner"
-/** The v2 access model's three single-purpose fields (see access-model.md), as
- *  standalone aliases for the share controls — they match the generated Artifact's
- *  inline enums. */
-export type LinkRole = "none" | "viewer" | "commenter" | "editor"
-export type WorkspaceAccess = "none" | "member"
-export type Listed = "none" | "workspace" | "public"
 /** The artifact view-model — the largest, most-composed shape in the client. Generated
  *  from the OpenAPI spec (apps/api/openapi.json). `my_role` is `Role | null`;
  *  workspace_access/link_role/listed are the v2 access enums (see access-model.md). */

--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -56,8 +56,37 @@ const ROW_ICON =
 // SidebarMenuBadge itself; only the muted tint is a call-site choice.
 const COUNT_BADGE = "top-1.5 text-muted-foreground"
 
-// One filter-nav row: sets the library filter via URL search. A zero count is
-// noise — the badge earns its ink only once it's nonzero.
+// The row's inner glyph — icon, label, and the ink-earning count badge — shared by
+// FilterItem and NavItem below (a zero count is noise, so the badge only renders
+// once it's nonzero).
+function RowGlyph({ icon, label, count }: { icon: IconName; label: string; count?: number }) {
+  return (
+    <>
+      <Icon name={icon} />
+      <span>{label}</span>
+      {(count ?? 0) > 0 && <SidebarMenuBadge className={COUNT_BADGE}>{count}</SidebarMenuBadge>}
+    </>
+  )
+}
+
+// The attributes every rail row's <Link> shares, regardless of where it points.
+function useRowLinkProps(
+  label: string,
+  active: boolean,
+  testId: string | undefined,
+  count: number | undefined,
+) {
+  const { setOpenMobile } = useSidebar()
+  return {
+    "aria-label": label,
+    "data-testid": testId,
+    "aria-current": active ? ("page" as const) : undefined,
+    onClick: () => setOpenMobile(false),
+    className: cn(ROW_ICON, (count ?? 0) > 0 && "pr-7"),
+  }
+}
+
+// One filter-nav row: sets the library filter via URL search.
 function FilterItem({
   icon,
   label,
@@ -73,22 +102,12 @@ function FilterItem({
   active: boolean
   testId?: string
 }) {
-  const { setOpenMobile } = useSidebar()
+  const linkProps = useRowLinkProps(label, active, testId, count)
   return (
     <SidebarMenuItem>
       <SidebarMenuButton asChild isActive={active} tooltip={label}>
-        <Link
-          to="/"
-          search={search}
-          aria-label={label}
-          data-testid={testId}
-          aria-current={active ? "page" : undefined}
-          onClick={() => setOpenMobile(false)}
-          className={cn(ROW_ICON, (count ?? 0) > 0 && "pr-7")}
-        >
-          <Icon name={icon} />
-          <span>{label}</span>
-          {(count ?? 0) > 0 && <SidebarMenuBadge className={COUNT_BADGE}>{count}</SidebarMenuBadge>}
+        <Link to="/" search={search} {...linkProps}>
+          <RowGlyph icon={icon} label={label} count={count} />
         </Link>
       </SidebarMenuButton>
     </SidebarMenuItem>
@@ -98,7 +117,7 @@ function FilterItem({
 // A fixed-feed nav row: navigates to a top-level ROUTE (a named feed like /favorites
 // or /following, or the /people directory) rather than a library filter. The path IS
 // the destination — the FilterItem counterpart for feeds that earned their own route
-// (docs/decisions/0002). The optional count badge only inks once nonzero (a zero is noise).
+// (docs/decisions/0002).
 function NavItem({
   icon,
   label,
@@ -114,21 +133,12 @@ function NavItem({
   active: boolean
   testId?: string
 }) {
-  const { setOpenMobile } = useSidebar()
+  const linkProps = useRowLinkProps(label, active, testId, count)
   return (
     <SidebarMenuItem>
       <SidebarMenuButton asChild isActive={active} tooltip={label}>
-        <Link
-          to={to}
-          aria-label={label}
-          data-testid={testId}
-          aria-current={active ? "page" : undefined}
-          onClick={() => setOpenMobile(false)}
-          className={cn(ROW_ICON, (count ?? 0) > 0 && "pr-7")}
-        >
-          <Icon name={icon} />
-          <span>{label}</span>
-          {(count ?? 0) > 0 && <SidebarMenuBadge className={COUNT_BADGE}>{count}</SidebarMenuBadge>}
+        <Link to={to} {...linkProps}>
+          <RowGlyph icon={icon} label={label} count={count} />
         </Link>
       </SidebarMenuButton>
     </SidebarMenuItem>

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -300,16 +300,22 @@ export function ShareButton({
         listed: on ? "public" : "none",
       })
   }
+  // The current triple, untouched, with the world-link password set to the given
+  // value — shared by the two calls below that change only the password.
+  const currentTripleWithPassword = (password: string): AccessDraft => ({
+    workspaceAccess: wsAccess,
+    linkRole: lRole,
+    listed: lst,
+    password,
+  })
   // The lock checkbox: checking reveals the password input (applies on Set);
   // unchecking clears the lock immediately (an explicit empty password).
   const toggleLock = (on: boolean) => {
     if (on) setLockDraft(true)
-    else if (hasLock)
-      void applyAccess({ workspaceAccess: wsAccess, linkRole: lRole, listed: lst, password: "" })
+    else if (hasLock) void applyAccess(currentTripleWithPassword(""))
     else setLockDraft(false)
   }
-  const setPassword = (password: string) =>
-    void applyAccess({ workspaceAccess: wsAccess, linkRole: lRole, listed: lst, password })
+  const setPassword = (password: string) => void applyAccess(currentTripleWithPassword(password))
   const copyLink = async () => {
     try {
       await navigator.clipboard.writeText(shareUrl)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,10 @@
     "./config": {
       "types": "./src/config.d.ts",
       "default": "./src/config.js"
+    },
+    "./publish": {
+      "types": "./src/publish.d.ts",
+      "default": "./src/publish.js"
     }
   },
   "files": [

--- a/packages/cli/src/publish.d.ts
+++ b/packages/cli/src/publish.d.ts
@@ -1,0 +1,69 @@
+// Hand-written declarations for publish.js (plain JS by convention — this package
+// doesn't typecheck). Kept in lockstep with the exports below; this is what
+// @derive-to/mcp imports for a typed view of the shared publish-request builder.
+
+export interface DocEdit {
+  old_str: string
+  new_str: string
+}
+
+export interface PublishFormFields {
+  bytes?: Uint8Array
+  filename?: string
+  /** Surgical revision, no file upload — mutually exclusive with `bytes`. */
+  edits?: DocEdit[]
+  baseVersion?: number
+  title?: string
+  slug?: string
+  spa?: boolean
+  message?: string
+  name?: string
+  workspaceAccess?: "none" | "member"
+  linkRole?: "none" | "viewer" | "commenter" | "editor"
+  listed?: "none" | "workspace" | "public"
+  /** Legacy pre-v2 alias; an explicit access field above wins server-side. */
+  visibility?: "public" | "link" | "org" | "password" | "private"
+  password?: string
+  resolves?: string[]
+  requestReview?: boolean
+  /** Escape hatch for one-off form fields without a dedicated parameter. */
+  extra?: Record<string, string>
+}
+
+export declare function buildPublishForm(fields: PublishFormFields): FormData
+
+export interface UploadTarget {
+  server: string
+  token?: string
+  workspaceId?: string
+  id?: string
+  title?: string
+  slug?: string
+  spa?: boolean
+  message?: string
+  name?: string
+  workspaceAccess?: PublishFormFields["workspaceAccess"]
+  linkRole?: PublishFormFields["linkRole"]
+  listed?: PublishFormFields["listed"]
+  visibility?: PublishFormFields["visibility"]
+  password?: string
+}
+
+export declare function uploadArtifact(
+  p: UploadTarget,
+  bytes: Uint8Array,
+  filename: string,
+  extra?: Record<string, string>,
+): Promise<{ res: Response; json: unknown }>
+
+export declare function collectDir(
+  dir: string,
+  base?: string,
+  out?: { files: Record<string, Uint8Array>; skipped: string[] },
+  skipTopDirs?: string[],
+): { files: Record<string, Uint8Array>; skipped: string[] }
+
+export declare function readTarget(
+  target: string,
+  skipTopDirs?: string[],
+): { bytes: Uint8Array; filename: string; skipped: string[] }

--- a/packages/cli/src/publish.js
+++ b/packages/cli/src/publish.js
@@ -51,28 +51,79 @@ export function readTarget(target, skipTopDirs = []) {
   return { bytes: readFileSync(target), filename: basename(target), skipped: [] }
 }
 
-/** POST the upload: a new artifact, or a new version when `id` is set.
- *  Returns { res, json } — HTTP-level failures are the caller's to present. */
-export async function uploadArtifact(p, bytes, filename, extra = {}) {
+/** Build the FormData body for a publish (new artifact or new version) request.
+ *  Shared by the CLI's upload path and the MCP client's publish tool, so the two
+ *  independently-grown field sets can't drift apart. `edits` (surgical search/
+ *  replace, no file upload) is mutually exclusive with `bytes`; `extra` is an
+ *  escape hatch for one-off fields (e.g. the CLI's `--review` flag) without a
+ *  dedicated parameter. */
+export function buildPublishForm({
+  bytes,
+  filename,
+  edits,
+  baseVersion,
+  title,
+  slug,
+  spa,
+  message,
+  name,
+  workspaceAccess,
+  linkRole,
+  listed,
+  visibility,
+  password,
+  resolves,
+  requestReview,
+  extra = {},
+}) {
   const form = new FormData()
-  form.append("file", new Blob([bytes]), filename)
-  if (p.title) form.append("title", p.title)
-  if (p.slug) form.append("slug", p.slug)
-  if (p.spa) form.append("spa", "true")
-  if (p.message) form.append("message", p.message)
-  if (p.name) form.append("name", p.name)
+  if (edits) {
+    form.append("edits", JSON.stringify(edits))
+    if (baseVersion != null) form.append("base_version", String(baseVersion))
+    if (filename) form.append("filename", filename)
+  } else {
+    form.append("file", new Blob([bytes]), filename ?? "index.html")
+  }
+  if (title) form.append("title", title)
+  if (slug) form.append("slug", slug)
+  if (spa) form.append("spa", "true")
+  if (message) form.append("message", message)
+  if (name) form.append("name", name)
   // The canonical v2 access fields; an explicit field wins over the legacy
   // `visibility` alias server-side. Send only what's set (all-absent = the
   // workspace default).
-  if (p.workspaceAccess) form.append("workspace_access", p.workspaceAccess)
-  if (p.linkRole) form.append("link_role", p.linkRole)
-  if (p.listed) form.append("listed", p.listed)
-  if (p.visibility) form.append("visibility", p.visibility)
+  if (workspaceAccess) form.append("workspace_access", workspaceAccess)
+  if (linkRole) form.append("link_role", linkRole)
+  if (listed) form.append("listed", listed)
+  if (visibility) form.append("visibility", visibility)
   // --password gates a world-linked publish behind a passphrase (the server hashes
   // it; the legacy `--visibility password` spelling still maps). Never put it in
   // derive.json (it isn't a config field), only pass it on the command line.
-  if (p.password) form.append("password", p.password)
+  if (password) form.append("password", password)
+  if (resolves?.length) form.append("resolves", resolves.join(","))
+  if (requestReview) form.append("request_review", "true")
   for (const [k, v] of Object.entries(extra)) form.append(k, v)
+  return form
+}
+
+/** POST the upload: a new artifact, or a new version when `id` is set.
+ *  Returns { res, json } — HTTP-level failures are the caller's to present. */
+export async function uploadArtifact(p, bytes, filename, extra = {}) {
+  const form = buildPublishForm({
+    bytes,
+    filename,
+    title: p.title,
+    slug: p.slug,
+    spa: p.spa,
+    message: p.message,
+    name: p.name,
+    workspaceAccess: p.workspaceAccess,
+    linkRole: p.linkRole,
+    listed: p.listed,
+    visibility: p.visibility,
+    password: p.password,
+    extra,
+  })
   const url = p.id ? `${p.server}/v1/artifacts/${p.id}/versions` : `${p.server}/v1/artifacts`
   const headers = {
     ...(p.token ? { authorization: `Bearer ${p.token}` } : {}),

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@derive/api": "workspace:*",
+    "@derive/core": "workspace:*",
     "@derive/db": "workspace:*",
     "@derive/storage": "workspace:*",
     "@hono/node-server": "^2.0.5",

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -1,5 +1,8 @@
 /** HTTP client for a Derive server. Shared by the MCP server and any tooling. */
 
+import type { LinkRole, Listed, WorkspaceAccess } from "@derive/core"
+import { buildPublishForm } from "@derive-to/cli/publish"
+
 /** One exact-match search/replace edit (the Edit-tool contract). */
 export interface DocEdit {
   old_str: string
@@ -16,9 +19,9 @@ export interface PublishArgs {
   message?: string
   /** The v2 access triple for a NEW artifact (see access-model.md); ignored on a
    *  republish. */
-  workspaceAccess?: "none" | "member"
-  linkRole?: "none" | "viewer" | "commenter" | "editor"
-  listed?: "none" | "workspace" | "public"
+  workspaceAccess?: WorkspaceAccess
+  linkRole?: LinkRole
+  listed?: Listed
   /** A lock on the world link (optional). */
   password?: string
   /** When set, publishes a new version of this artifact instead of a new one. */
@@ -245,28 +248,29 @@ export function createClient(opts: ClientOptions): DeriveClient {
     },
 
     async publish(args) {
-      const form = new FormData()
-      if (args.edits) {
-        // Surgical revision: no file upload, the server materializes it from the
-        // current stored source. Requires an existing artifact (args.id).
-        form.append("edits", JSON.stringify(args.edits))
-        if (args.baseVersion != null) form.append("base_version", String(args.baseVersion))
-        if (args.filename) form.append("filename", args.filename)
-      } else {
-        const bytes =
-          typeof args.content === "string" ? new TextEncoder().encode(args.content) : args.content
-        form.append("file", new Blob([bytes as BlobPart]), args.filename ?? "index.html")
-      }
-      if (args.title) form.append("title", args.title)
-      if (args.slug) form.append("slug", args.slug)
-      if (args.message) form.append("message", args.message)
-      if (args.workspaceAccess) form.append("workspace_access", args.workspaceAccess)
-      if (args.linkRole) form.append("link_role", args.linkRole)
-      if (args.listed) form.append("listed", args.listed)
-      if (args.password) form.append("password", args.password)
-      if (args.spa) form.append("spa", "true")
-      if (args.resolves?.length) form.append("resolves", args.resolves.join(","))
-      if (args.requestReview) form.append("request_review", "true")
+      // Surgical revision (args.edits) needs no file upload — the server materializes
+      // it from the current stored source (requires an existing artifact, args.id).
+      const bytes = args.edits
+        ? undefined
+        : typeof args.content === "string"
+          ? new TextEncoder().encode(args.content)
+          : args.content
+      const form = buildPublishForm({
+        bytes: bytes as Uint8Array | undefined,
+        filename: args.filename,
+        edits: args.edits,
+        baseVersion: args.baseVersion,
+        title: args.title,
+        slug: args.slug,
+        spa: args.spa,
+        message: args.message,
+        workspaceAccess: args.workspaceAccess,
+        linkRole: args.linkRole,
+        listed: args.listed,
+        password: args.password,
+        resolves: args.resolves,
+        requestReview: args.requestReview,
+      })
       const url = args.id ? `${base}/v1/artifacts/${args.id}/versions` : `${base}/v1/artifacts`
       return ok(
         await f(url, { method: "POST", body: form, headers: authHeaders }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,9 @@ importers:
       '@babel/core':
         specifier: ^7.29.7
         version: 7.29.7
+      '@derive/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@playwright/test':
         specifier: ^1.61.0
         version: 1.61.0
@@ -388,6 +391,9 @@ importers:
       '@derive/api':
         specifier: workspace:*
         version: link:../../apps/api
+      '@derive/core':
+        specifier: workspace:*
+        version: link:../core
       '@derive/db':
         specifier: workspace:*
         version: link:../db
@@ -4225,8 +4231,8 @@ packages:
     engines: {node: ^22||^24||>=26}
     hasBin: true
 
-  deslop-js@0.7.2:
-    resolution: {integrity: sha512-mLqCC+L0bnTOK8m7Adw5IR+xVrXey9zJsyUiwrPyTAc4m9fhNChoW1tZ0LPljTNUG2YSC8wJt6+WaMlx/Fb9GQ==}
+  deslop-js@0.7.3:
+    resolution: {integrity: sha512-SsrIu4ud41rSn7PnU8IjHlcd9cAfSeJWcRxKB0yPw7Q224XokD+fDbLf58LCCmckiVnnM8SVZEdBvbRE/4bRTg==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -5375,8 +5381,8 @@ packages:
   oxc-resolver@11.20.0:
     resolution: {integrity: sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==}
 
-  oxlint-plugin-react-doctor@0.7.2:
-    resolution: {integrity: sha512-5euEAWYWwA/q9DIfazvFCmuu7x3N075P0AiRyXCvsuInRzFL6xswF91s12NWQEmSuPRiA+ofmz8ZC5Xxd3we6Q==}
+  oxlint-plugin-react-doctor@0.7.3:
+    resolution: {integrity: sha512-efbhWdD/FCsRnaEPKbf356B8ek5oqHjUXBRax0QJZoi/zT6UqlU9EL+o3r8J48qp9s/xKPVmW7wr5bKVpQu9pA==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint@1.66.0:
@@ -5661,8 +5667,8 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-doctor@0.7.2:
-    resolution: {integrity: sha512-SdZFSBOGJXOPbbW5lAMGM98DdjEyQarKR/UYLPKjdQsroCWFbb7ctqXspnFGVtLM0m8UnXNEM31R/LkimF1gtQ==}
+  react-doctor@0.7.3:
+    resolution: {integrity: sha512-N/aeVyOaMXe4MNCdQ8IQZUbpI23Z2fPSpDRhCLL1bvYEFD2MIco6CslJWMtOlkA9RVSKPhWCbPT4wf2AA+BWVg==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -6782,28 +6788,28 @@ snapshots:
       '@cloudflare/workers-types': 4.20260615.1
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))':
+  '@better-auth/drizzle-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0)
 
-  '@better-auth/kysely-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
+  '@better-auth/kysely-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.29.2
 
-  '@better-auth/memory-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/mongo-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
   '@better-auth/oauth-provider@1.6.19(patch_hash=18c0372b3b8e3f9edd7aff2cab60145f40713d067145a42a0c561297d0202928)(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.6(zod@4.4.3))':
@@ -6840,14 +6846,14 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
 
-  '@better-auth/prisma-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/telemetry@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -9723,13 +9729,13 @@ snapshots:
 
   better-auth@1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9):
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))
-      '@better-auth/kysely-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
-      '@better-auth/memory-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))
+      '@better-auth/kysely-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
+      '@better-auth/memory-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.2.0
@@ -10077,7 +10083,7 @@ snapshots:
       tsconfig-paths-webpack-plugin: 4.2.0
       watskeburt: 6.0.0
 
-  deslop-js@0.7.2:
+  deslop-js@0.7.3:
     dependencies:
       '@oxc-project/types': 0.132.0
       fast-glob: 3.3.3
@@ -11204,7 +11210,7 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.20.0
       '@oxc-resolver/binding-win32-x64-msvc': 11.20.0
 
-  oxlint-plugin-react-doctor@0.7.2:
+  oxlint-plugin-react-doctor@0.7.3:
     dependencies:
       '@typescript-eslint/types': 8.61.1
       eslint-scope: 9.1.2
@@ -11546,19 +11552,19 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-doctor@0.7.2(eslint@10.5.0(jiti@2.7.0)):
+  react-doctor@0.7.3(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@sentry/node': 10.58.0
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.7.2
+      deslop-js: 0.7.3
       eslint-plugin-react-hooks: 7.1.1(eslint@10.5.0(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.66.0
-      oxlint-plugin-react-doctor: 0.7.2
+      oxlint-plugin-react-doctor: 0.7.3
       prompts: 2.4.2
       typescript: 5.9.3
       vscode-languageserver: 9.0.1
@@ -11614,7 +11620,7 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.7.2(eslint@10.5.0(jiti@2.7.0))
+      react-doctor: 0.7.3(eslint@10.5.0(jiti@2.7.0))
       react-dom: 19.2.7(react@19.2.7)
       react-grab: 0.1.48(react@19.2.7)
     optionalDependencies:


### PR DESCRIPTION
## Summary

Implements items 2, 3 (corrected), 4, and 5 from the [DRY pass plan](https://derive.to/artifacts/dry-pass-the-five-things-worth-fixing-nv2f6ak7). **Item 1 (folding `packages/db`'s two dialect implementations together) is intentionally excluded** — it's the largest, riskiest change (backs every real customer's data across SQLite/D1/Postgres) and deserves its own reviewed pass with real dual-driver test coverage, not a bundled drive-by.

Three commits, each independently reviewable:

1. **Type-only role-vocab imports + small web dedups.** `Role`/`LinkRole`/`WorkspaceAccess`/`Listed` were declared three times (core, web, mcp); now web and mcp import them as types from `@derive/core` (barrel already re-exports them via `permissions.ts`). Also collapses `nav-rail`'s `FilterItem`/`NavItem` into a shared body, and `share-dialog`'s `toggleLock`/`setPassword` into one helper.

   **Correction to the original plan:** the `username.ts` mirror and the `SKILL_CONTENT_TYPE` string mirror are **not** fixable the way the plan proposed. `.dependency-cruiser.mjs` enforces a hard, CI-gated rule that `apps/web`/`packages/cli`/`packages/mcp`/`packages/runner` may never import `@derive/core` at runtime — only type-only imports are exempt. Those two mirrors carry runtime logic, so importing them from core would fail `pnpm lint:boundaries`. They're architecturally mandated duplication, not a bug, and are left untouched.

2. **Shared route guards.** `requireArtifact` gets a `{ split: true }` option (404 missing / 403 forbidden, for actions where existence shouldn't hide behind a blanket 404), plus a new `requireWorkspace(c, action)` collapsing the `workspaceCan` + `activeWorkspace` pair, plus a `requireCollection` local to `collections.ts` for its own 7x-repeated gate. Migrated ~30 call sites across 14 route files.

   Deliberately **not** touched: `authorizeStanding` sites (a stricter mode — swapping it for `requireArtifact` would silently widen access), anon-exempt/redirect/SSE-text routes, and sites with an extra `current_version === 0` draft-hiding check that doesn't fit the shared helper without a redundant query.

3. **Shared cli/mcp publish builder.** `cli`'s `uploadArtifact` and `mcp`'s `client.publish()` each built the FormData independently, with drifted field sets (cli: `name`/`visibility`; mcp: `edits`/`resolves`/`request_review`). Extracted `buildPublishForm` into a new `@derive-to/cli/publish` subpath export (hand-typed `.d.ts`, matching this package's existing plain-JS convention), consumed by both.

## Verification

- `pnpm run ci` — green (biome + all lint gates: tokens, frontend, mutations, surfaces, testids, api, schema, hyperdrive, filesize, anchor-client, deadcode, boundaries, env, api-types).
- `pnpm -w typecheck` — green across all 7 packages.
- `pnpm test` — **1,650 tests green** (apps/api 857, apps/web 144, packages/core 323, packages/cli 102, packages/db 189, packages/storage 16, packages/mcp 19). mcp's 19 tests are real end-to-end HTTP round trips against a live API server and exercise plain publish, versioned publish, `edits`, and `resolves` — they pass unchanged against the shared builder, which is strong evidence the request shape didn't move.
- Rebased onto latest `origin/main` (through #389); resolved one small conflict in `assets.ts` (upstream added public blob URLs to the same route this PR's `requireWorkspace` touches).

## Test plan

- [x] CI green (typecheck, lint, full test suite)
- [ ] Reviewer spot-check: pick 2-3 migrated route files and confirm status codes are unchanged for both the happy path and the 403/404 paths
- [ ] Confirm `packages/cli`'s `derive publish` and `derive context push` commands still work end-to-end (no automated coverage for `uploadArtifact` itself, only its helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)