### PR TITLE
feat(web): surface the review loop on artifact cards

### DIFF
--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -312,6 +312,10 @@ export const artifactRoutes = (ctx: AppContext) => {
       // Per-artifact comment signals for the viewer (open-thread count + tagged/authored
       // flags) — drives the inline comment badge and the "needs your feedback" featuring.
       const feedback = me ? await meta.commentSignals(pageIds, me.id) : {}
+      // Open-proposal counts per artifact — the review queue. Same batched, no-N+1
+      // enrichment as the comment signals above (viewer-independent, so no `me` gate),
+      // so a card can badge "N proposals" on the feed the way the detail view does.
+      const proposalCounts = await meta.openProposalCounts(pageIds)
       // The viewer's per-artifact shares across the page, one query — folded into
       // my_role below so shared and private rows gate their quick actions correctly.
       // For a linked agent these are the registrant's rows, so the cap applies.
@@ -349,6 +353,8 @@ export const artifactRoutes = (ctx: AppContext) => {
           author: authorProfile(a, handleByGhId, bylineByUserId),
           // open_threads + mentions_me + i_participated (defaults for anon / no signals).
           ...(feedback[a.id] ?? { open_threads: 0, mentions_me: false, i_participated: false }),
+          // The review queue — proposals awaiting a decision (owner/editor acts on them).
+          open_proposals: proposalCounts[a.id] ?? 0,
         })),
         next_cursor,
         ...(collectionInfo ? { collection: collectionInfo } : {}),

--- a/apps/web/e2e/deep/library-review-signal.deep.spec.ts
+++ b/apps/web/e2e/deep/library-review-signal.deep.spec.ts
@@ -1,0 +1,26 @@
+import { expect, proposeEdit, publishArtifact, shareArtifact, test } from "../fixtures"
+
+// The library card surfaces an artifact's review queue: open proposals show as a count
+// in the activity row, inked when they're yours to decide. This drives the whole chain —
+// the list endpoint's `open_proposals` enrichment and the ProposalSignal render — so a
+// card that silently dropped the review loop can't ship. Setup mirrors review.deep: the
+// owner owns, a shared editor authors the proposals (owner ≠ author, so owner can decide).
+test("library card badges open proposals, featured when they're yours to review", async ({
+  owner,
+  secondUser,
+}) => {
+  const id = await publishArtifact(owner)
+  await shareArtifact(owner.request, id, secondUser.email, "editor")
+  await proposeEdit(secondUser.page.request, id, "Tighten the intro", "# Doc\n\ntighter intro")
+  await proposeEdit(secondUser.page.request, id, "Fix the footer", "# Doc\n\nbody\n\nfixed footer")
+
+  await owner.goto("/")
+  await expect(owner.getByTestId(`artifact-card-open-${id}`)).toBeVisible()
+
+  // The review signal reads the two open proposals, featured because the owner can act
+  // on them (the sanctioned "needs you" ink, same grammar as an @mention).
+  const signal = owner.getByTestId("proposal-signal")
+  await expect(signal).toBeVisible()
+  await expect(signal).toHaveText("2")
+  await expect(signal).toHaveAttribute("data-featured", "awaiting")
+})

--- a/apps/web/src/components/shared/thumb.tsx
+++ b/apps/web/src/components/shared/thumb.tsx
@@ -15,21 +15,19 @@ import { thumbMedia } from "./thumb-media"
 // visibly flashes, which is why cards never lift.
 //
 // One machine-register placard rides the bottom-left over a fixed scrim (legible
-// over any screenshot, both themes): the type, and the version when there's
-// history — `HTML · v3`. One chip, not a badge per fact.
+// over any screenshot, both themes): the artifact's type — `HTML`. The version and
+// freshness live in the card's caption state line, so the placard stays a single
+// category tag over the render.
 export function Thumb({
   id,
   v,
   typeLabel,
-  version,
   hasPreview,
   className,
 }: {
   id: string
   v: number
   typeLabel?: string
-  /** The current version ordinal — shown only when there's history (chain > 1). */
-  version?: number
   /** When true, render the static PNG from /v1/og/:id instead of the live iframe. */
   hasPreview?: boolean
   className?: string
@@ -81,11 +79,8 @@ export function Thumb({
         />
       )}
       {typeLabel && (
-        <span className="pointer-events-none absolute bottom-2 left-2 z-10 inline-flex items-center gap-1 rounded-md bg-scrim/85 px-1.5 py-0.5 font-mono text-2xs text-scrim-foreground ring-1 ring-scrim-foreground/15">
-          <span className="uppercase tracking-wide">{typeLabel}</span>
-          {version !== undefined && (
-            <span className="tabular-nums text-scrim-foreground/70">· v{version}</span>
-          )}
+        <span className="pointer-events-none absolute bottom-2 left-2 z-10 rounded-md bg-scrim/85 px-1.5 py-0.5 font-mono text-2xs uppercase tracking-wide text-scrim-foreground ring-1 ring-scrim-foreground/15">
+          {typeLabel}
         </span>
       )}
     </div>

--- a/apps/web/src/pages/library/artifact-card.tsx
+++ b/apps/web/src/pages/library/artifact-card.tsx
@@ -16,19 +16,18 @@ import { artifactTypeLabel, dirOf } from "@/lib/artifact"
 import { ago } from "@/lib/time"
 import { cn } from "@/lib/utils"
 import { CommentSignal } from "./comment-signal"
+import { ProposalSignal } from "./proposal-signal"
 
-// One card in the library grid, rebuilt preview-first: the live render bleeds to
-// the card's top edge as the hero, carrying a single machine-register `TYPE · vN`
-// chip; a hairline-divided caption below holds the title and one split meta row —
-// identity (who · when) on the left, signals (feedback · views) on the right.
-// The card is clean at rest and reveals its actions (star, ⋯ menu) on hover.
+// One card in the library grid, preview-first. The live render is the hero (bleeds to
+// the top edge, carrying a single machine-register TYPE placard); a hairline-divided
+// caption below holds the title in voice, a mono state line (version · freshness), and
+// one split meta row — who made it on the left, activity (review · comments · views)
+// on the right. Clean at rest; the actions (star, ⋯) reveal on hover, and the ink edge
+// accent (a persistent "needs you" state) shows at rest.
 //
-// Stretched-link pattern: the open button's ::after covers the whole card, so a
-// click anywhere (preview included) opens it, while the star / menu / author / tag
-// chips sit above (z-20) and stay independently clickable. Hover is an instant
-// hairline-strengthen + the preview waking — no transitioned shadow (a paint prop,
-// not a sanctioned move/scale/fade) and no transform (either would repaint the
-// iframe); the resting soft shadow carries the card's lift.
+// Stretched-link pattern: the open button's ::after covers the whole card (preview
+// included), while the actions / author / tag chips sit above it (z-20) and stay
+// independently clickable.
 export function ArtifactCard({
   artifact: a,
   onOpen,
@@ -60,25 +59,35 @@ export function ArtifactCard({
   const author = a.author ?? null
   const hasAuthor = !!(author?.name || author?.login || a.author_login || a.author_name)
   const updated = a.updated_at ?? a.created_at ?? a.versions[0]?.created_at
-  // The list endpoint sends `versions: []`, so history reads off `current_version`
-  // (the stable head ordinal). > 1 means "there is history here" → show the vN.
   const versionDepth = Math.max(a.current_version, a.versions.length)
+  const sourceDir = a.source_path ? dirOf(a.source_path) : ""
   const tags = a.tags ?? []
+  const isPrivate = a.workspace_access === "none" && (a.link_role ?? "none") === "none"
+  // Proposals you can act on (owner/editor) are a "needs you" signal — they soft-ink
+  // the card edge (the `i_participated` tier) and the review count.
+  const awaitingReview =
+    (a.my_role === "owner" || a.my_role === "editor") && (a.open_proposals ?? 0) > 0
+
+  // Machine-register state line under the title (house " · " join, matching the
+  // workbench header): a synced file's folder, else its version when there's history,
+  // then how fresh it is. The TYPE rides the placard, so it isn't repeated here.
+  const stateLine = [
+    sourceDir ? `${sourceDir}/` : versionDepth > 1 ? `v${a.current_version}` : "",
+    updated ? `updated ${ago(updated)}` : "",
+  ]
+    .filter(Boolean)
+    .join(" · ")
 
   return (
     <Card
       className={cn(
-        // Full-bleed preview: no mat, no inner padding — the caption owns its own.
-        // A resting soft shadow (zeroed in dark by the theme token) gives the card
-        // its lift; hover is the instant hairline-strengthen + preview wake, with no
-        // transitioned shadow and no transform (either repaints the iframe).
         "group relative isolate flex flex-col gap-0 overflow-hidden p-0 shadow-(--shadow-sm)",
-        // Needs-your-feedback items stand out: a tagged item gets the full accent +
-        // ring; one you're just in the thread on gets a softer accent border (the
-        // ink accent = "this matters", the sanctioned attention signal, like unread).
+        // A direct @mention gets the full accent + ring; a thread you're in — or
+        // proposals waiting on your review — gets a softer accent border. The ink
+        // accent is the sanctioned attention signal, shown at rest.
         a.mentions_me
           ? "border-primary ring-1 ring-primary/30"
-          : a.i_participated
+          : a.i_participated || awaitingReview
             ? "border-primary/60"
             : "border-border hover:border-foreground/25",
       )}
@@ -88,14 +97,12 @@ export function ArtifactCard({
           id={a.short_id}
           v={a.current_version}
           typeLabel={artifactTypeLabel(a)}
-          version={versionDepth > 1 ? a.current_version : undefined}
           hasPreview={a.has_preview}
         />
-        {/* Action cluster — one top-right corner above the stretched link (z-20).
-            Revealed on hover/focus for fine pointers, ALWAYS shown on coarse (touch)
-            pointers (no hover to reveal them). A favourited star also persists at
-            rest. Adaptive translucent pills read over any render, both themes. */}
-        <div className="absolute right-2 top-2 z-20 flex items-center gap-1.5">
+        {/* Actions — top-right over the render, revealed on hover/focus (always shown
+            on touch; a favourited star persists). Translucent pills read over any
+            render, both themes. */}
+        <div className="absolute top-2 right-2 z-20 flex items-center gap-1.5">
           {showMenu && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -163,13 +170,9 @@ export function ArtifactCard({
             }}
             className={cn(
               "relative border-border-soft bg-card transition-opacity focus-visible:opacity-100 pointer-coarse:opacity-100",
-              // A favourited star always shows; an unfavourited one reveals on
-              // hover/focus so the resting wall of previews stays calm.
               !a.favorite && "opacity-0 group-hover:opacity-100",
             )}
           >
-            {/* A favorited star keeps the brand ink — pinned/favorited is a
-                sanctioned ink moment. */}
             <Icon
               name="star"
               size={16}
@@ -194,61 +197,46 @@ export function ArtifactCard({
           aria-label={`Open ${a.title ?? a.short_id}`}
           className="flex w-full min-w-0 flex-col gap-0.5 text-left outline-none after:absolute after:inset-0 after:z-1 after:rounded-xl after:content-[''] focus-visible:after:outline-2 focus-visible:after:-outline-offset-2 focus-visible:after:outline-ring"
         >
-          {/* The title is the work, not the tool — Geist voice, sized to caption so
-              the preview stays the hero. */}
+          {/* The title is the work — Geist voice, sized to the caption so the preview
+              stays the hero. */}
           <span className="truncate font-serif text-base font-medium tracking-tight text-foreground">
             {a.title ?? a.short_id}
           </span>
-          {/* For a synced file: its folder location (the path lives in source_path). */}
-          {a.source_path && dirOf(a.source_path) && (
+          {stateLine && (
             <span
-              className="truncate font-mono text-2xs text-muted-foreground"
-              title={a.source_path}
+              className="truncate font-mono text-2xs tabular-nums text-muted-foreground"
+              title={sourceDir ? (a.source_path ?? undefined) : undefined}
             >
-              {dirOf(a.source_path)}/
+              {stateLine}
             </span>
           )}
         </button>
 
-        {/* Meta row, two glanceable clusters: provenance (who · when) left, activity
-            (feedback · views) right. The author is avatar-only — a repeated name on
-            a wall of your own work is noise, but the tint still says "who" for
-            shared/synced items (name in its tooltip). It's the one interactive
-            island here (z-20); the rest clicks through to open. Mono throughout.
-            mt-auto pins it (and any tags) to the card's bottom edge, so equal-height
-            grid rows anchor their meta rather than float empty space below it. */}
-        <div className="mt-auto flex min-w-0 items-center gap-2 font-mono text-2xs tabular-nums text-muted-foreground">
-          <span className="flex min-w-0 items-center gap-1.5">
-            {hasAuthor && (
-              <AuthorChip
-                name={author?.name ?? a.author_name ?? null}
-                login={author?.login ?? a.author_login ?? null}
-                avatar={author?.avatar ?? a.author_avatar ?? null}
-                handle={author?.handle ?? null}
-                size="xs"
-                showName={false}
-                className="relative z-20 shrink-0"
-                data-testid={`artifact-card-author-${a.short_id}`}
-              />
-            )}
-            {updated && (
-              <time
-                dateTime={new Date(updated).toISOString()}
-                title={new Date(updated).toLocaleString()}
-                className="truncate"
-              >
-                {ago(updated)}
-              </time>
-            )}
-          </span>
-          <span className="ml-auto inline-flex shrink-0 items-center gap-2.5">
+        {/* People + activity: who made it on the left (avatar + name), the activity
+            cluster on the right. The author is the one interactive island here (z-20);
+            the rest clicks through to open. */}
+        <div className="flex min-w-0 items-center gap-2 font-mono text-2xs tabular-nums text-muted-foreground">
+          {hasAuthor && (
+            <AuthorChip
+              name={author?.name ?? a.author_name ?? null}
+              login={author?.login ?? a.author_login ?? null}
+              avatar={author?.avatar ?? a.author_avatar ?? null}
+              handle={author?.handle ?? null}
+              size="xs"
+              className="relative z-20 min-w-0"
+              data-testid={`artifact-card-author-${a.short_id}`}
+            />
+          )}
+          <span className={cn("inline-flex shrink-0 items-center gap-2.5", hasAuthor && "ml-auto")}>
             {/* Invite-only work is invisible to everyone but its members — the chip
                 says so wherever the doc DOES surface (your library, Created by me). */}
-            {a.workspace_access === "none" && (a.link_role ?? "none") === "none" && (
+            {isPrivate && (
               <Badge shape="pill" variant="outline" title="Only you and people you add">
                 <Icon name="lock" size={12} /> Private
               </Badge>
             )}
+            {/* Review queue, then discussion, then passive views — most-actionable first. */}
+            <ProposalSignal artifact={a} size={12} />
             <CommentSignal artifact={a} size={12} compact />
             {a.views !== undefined && a.views > 0 && (
               <span className="inline-flex items-center gap-1" title={`${a.views} viewers`}>
@@ -262,8 +250,8 @@ export function ArtifactCard({
 
         {tags.length > 0 && (
           // One row only — chips are `nowrap` + clipped so a heavily-tagged artifact
-          // can't grow the card taller than its siblings (steady grid rhythm). The
-          // first three are interactive filter chips; a trailing "+N" counts the rest.
+          // can't grow the card taller than its siblings. First three are interactive
+          // filter chips; a trailing "+N" counts the rest.
           <div className="relative z-20 flex min-w-0 items-center gap-1.5 overflow-hidden">
             {tags.slice(0, 3).map((t) => (
               <Badge

--- a/apps/web/src/pages/library/artifact-row.tsx
+++ b/apps/web/src/pages/library/artifact-row.tsx
@@ -15,6 +15,7 @@ import { artifactTypeLabel, dirOf } from "@/lib/artifact"
 import { ago } from "@/lib/time"
 import { cn } from "@/lib/utils"
 import { CommentSignal } from "./comment-signal"
+import { ProposalSignal } from "./proposal-signal"
 
 /**
  * A compact list row for the library (the default for collections / synced repos,
@@ -60,6 +61,10 @@ export function ArtifactRow({
   const author = a.author ?? null
   const authorLogin = author?.login ?? a.author_login ?? null
   const hasAuthor = !!(author?.name || authorLogin || a.author_name)
+  // Proposals you can act on (owner/editor) soft-ink the row edge — the same
+  // "needs you" accent as a thread you're in (see ProposalSignal + ArtifactCard).
+  const awaitingReview =
+    (a.my_role === "owner" || a.my_role === "editor") && (a.open_proposals ?? 0) > 0
 
   return (
     <div
@@ -68,7 +73,7 @@ export function ArtifactRow({
         // Needs-your-feedback accents — the ink accent is the sanctioned attention signal.
         a.mentions_me
           ? "border-primary ring-1 ring-primary/30"
-          : a.i_participated
+          : a.i_participated || awaitingReview
             ? "border-primary/60"
             : "border-border",
       )}
@@ -105,13 +110,14 @@ export function ArtifactRow({
               {dir}/
             </span>
           )}
+          <ProposalSignal artifact={a} size={12} className="relative z-20" />
+          <CommentSignal artifact={a} size={12} className="relative z-20" />
           {a.views !== undefined && a.views > 0 && (
             <span className="inline-flex items-center gap-1" title={`${a.views} viewers`}>
               <Icon name="views" size={12} />
               {a.views > 999 ? `${(a.views / 1000).toFixed(1)}k` : a.views}
             </span>
           )}
-          <CommentSignal artifact={a} size={12} className="relative z-20" />
         </span>
       </button>
 

--- a/apps/web/src/pages/library/proposal-signal.tsx
+++ b/apps/web/src/pages/library/proposal-signal.tsx
@@ -1,0 +1,50 @@
+import type { Artifact } from "@/api"
+import { Icon } from "@/components/icons"
+import { cn } from "@/lib/utils"
+
+type Signals = Pick<Artifact, "open_proposals" | "my_role">
+
+/** Inline review indicator: how many proposals are open on an artifact — its review
+ *  queue, the thing that makes a Derive artifact a *living* document and not just a
+ *  file. Reads quietly as a muted count (like views) until the proposals are YOURS to
+ *  decide (owner/editor), when it takes the sanctioned "this needs you" ink — the same
+ *  tint CommentSignal uses for an @mention, one notch below a direct tag. Renders
+ *  nothing when there are no open proposals.
+ *
+ *  A count-only sibling to CommentSignal, sized to the 12px mono meta row; the `review`
+ *  glyph (a pull-request mark) reads as "a change is waiting on a decision". */
+export function ProposalSignal({
+  artifact: a,
+  size = 12,
+  className,
+}: {
+  artifact: Signals
+  size?: number
+  className?: string
+}) {
+  const open = a.open_proposals ?? 0
+  if (open === 0) return null
+  // Owner/editor can approve or request changes → the queue is waiting on YOU; a
+  // viewer/commenter just sees that a review is in flight (a muted count).
+  const yours = a.my_role === "owner" || a.my_role === "editor"
+  return (
+    <span
+      data-testid="proposal-signal"
+      data-featured={yours ? "awaiting" : undefined}
+      title={
+        yours
+          ? `${open} proposal${open === 1 ? "" : "s"} to review`
+          : `${open} open proposal${open === 1 ? "" : "s"}`
+      }
+      className={cn(
+        "inline-flex items-center gap-1 tabular-nums",
+        // The ink here IS the signal — "this review is waiting on you".
+        yours ? "text-primary" : "text-muted-foreground",
+        className,
+      )}
+    >
+      <Icon name="review" size={size} />
+      <span className="font-mono">{open}</span>
+    </span>
+  )
+}

--- a/apps/web/src/pages/profile/work-card.tsx
+++ b/apps/web/src/pages/profile/work-card.tsx
@@ -25,6 +25,16 @@ function Views({ n }: { n: number }) {
 // artifact. Mirrors the library card's look so the two read as one design.
 export function ProfileWorkCard({ artifact: a }: { artifact: Artifact }) {
   const updated = a.updated_at ?? a.created_at ?? a.versions[0]?.created_at
+  const dir = a.source_path ? dirOf(a.source_path) : ""
+  const versionDepth = Math.max(a.current_version, a.versions.length)
+  // Machine-register state line, house " · " join — a synced file's folder, else its
+  // version when there's history, then freshness. The TYPE rides the placard.
+  const stateLine = [
+    dir ? `${dir}/` : versionDepth > 1 ? `v${a.current_version}` : "",
+    updated ? `updated ${ago(updated)}` : "",
+  ]
+    .filter(Boolean)
+    .join(" · ")
   return (
     <Link
       to="/artifacts/$ref"
@@ -40,34 +50,26 @@ export function ProfileWorkCard({ artifact: a }: { artifact: Artifact }) {
         id={a.short_id}
         v={a.current_version}
         typeLabel={artifactTypeLabel(a)}
-        // Match the library card's gating: the list endpoint sends versions: [], so
-        // history reads off current_version (versions.length alone never fires here).
-        version={Math.max(a.current_version, a.versions.length) > 1 ? a.current_version : undefined}
         hasPreview={a.has_preview}
       />
       <div className="flex min-w-0 flex-col gap-2 border-t border-border-soft p-3.5">
-        {/* The artifact title is the work — Geist voice, sized to the card caption. */}
+        {/* The artifact title is the work — Geist voice, sized to the caption. */}
         <span className="truncate font-serif text-base font-medium tracking-tight text-foreground">
           {a.title ?? a.short_id}
         </span>
-        {a.source_path && dirOf(a.source_path) && (
-          <span className="truncate font-mono text-2xs text-muted-foreground" title={a.source_path}>
-            {dirOf(a.source_path)}/
-          </span>
-        )}
-        <span className="flex items-center gap-2 font-mono text-2xs text-muted-foreground">
-          {updated && (
-            <span>
-              updated{" "}
-              <time
-                dateTime={new Date(updated).toISOString()}
-                title={new Date(updated).toLocaleString()}
-              >
-                {ago(updated)}
-              </time>
+        {/* Machine-register state line, mirroring ArtifactCard (minus the library-only
+            author/review chrome), with any view count trailing right. */}
+        <span className="flex min-w-0 items-center gap-2 font-mono text-2xs tabular-nums text-muted-foreground">
+          {stateLine && (
+            <span className="truncate" title={dir ? (a.source_path ?? undefined) : undefined}>
+              {stateLine}
             </span>
           )}
-          {a.views !== undefined && a.views > 0 && <Views n={a.views} />}
+          {a.views !== undefined && a.views > 0 && (
+            <span className="ml-auto shrink-0">
+              <Views n={a.views} />
+            </span>
+          )}
         </span>
       </div>
     </Link>


### PR DESCRIPTION
## What

The library artifact card now surfaces an artifact's **open-proposal count** — inked when it's yours to review, with a soft "needs you" edge — so the agent+human review loop the card never showed reads at a glance. The caption is cleaned up alongside.

- **Review signal** — new `ProposalSignal` (a sibling to `CommentSignal`): the `⑂ N` review chip, muted for a viewer, inked (`text-primary`) + `data-featured="awaiting"` when the proposals are yours to decide (owner/editor). The card edge also soft-inks (the `i_participated` tier).
- **Feed enrichment** — `GET /v1/artifacts` now enriches `open_proposals` via the existing batched `meta.openProposalCounts` (no N+1). `open_proposals` was already optional on the `Artifact` schema, so **no OpenAPI/type regeneration**.
- **Caption cleanup** — one machine-register state line (the house `·` idiom, matching the workbench header), a **type-only** render placard (dropped `Thumb`'s now-dead `version` prop), and the author's name on every card.
- **Coherence** — the same review signal + state line propagate to `ProfileWorkCard` and `ArtifactRow`.

## Testing

- All-package typecheck, biome, and the full lint suite (tokens / testids / surfaces / frontend / api / schema / api-types / boundaries / …) green.
- API tests (36) + DB store-contract (189) green.
- **8/8 library e2e** green, including a new durable spec — `library-review-signal.deep.spec.ts` (owner owns → a shared editor proposes 2 → the card badges "2", featured).
- Verified visually in light + dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)