### PR TITLE
fix(previews): enqueue renders on MCP publish + self-heal missed versions

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,19 @@
+# verify (local runtime for apps/api)
+
+Run the real Node server against a throwaway SQLite to observe API behavior end-to-end
+(no Docker needed — faster than `deploy/compose.yml` for a verification loop):
+
+```bash
+DATA_DIR=<scratch-dir> PORT=8791 DERIVE_TOKEN=devtok BASE_URL=http://localhost:8791 \
+  pnpm --filter @derive/api exec tsx src/node.ts
+```
+
+- Health: `curl localhost:8791/healthz` → `{"ok":true}`. The boot log's `meta:` line names
+  the exact SQLite path — always confirm it's your scratch dir, never a remote DB.
+- Publish via HTTP: `curl -X POST localhost:8791/v1/artifacts -H "authorization: Bearer devtok" -F 'file=@-;filename=index.html;type=text/html' -F 'title=T' <<< '<h1>x</h1>'`
+- Preview screenshots: add `DERIVE_PREVIEWS=true` (needs Playwright Chromium — usually
+  already in `~/Library/Caches/ms-playwright`; else `pnpm --filter @derive/api exec playwright install chromium`).
+  The worker ticks every 1.5s; `/v1/og/<short_id>` flips from SVG fallback to PNG when the
+  render lands. `version.preview_status` / `render_job` in the scratch `derive.db` show pipeline state.
+- The bundled SPA serves at `/` but needs a signup; API-level checks (`/v1/artifacts`,
+  `/v1/og/:id`) cover most verification without a browser session.

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -1460,6 +1460,7 @@ async function buildServer(
           message: version.message,
           author: version.author,
         })
+        ctx.notifyRender(artifact, version.n)
         // Re-anchor existing threads: feedback whose quoted text changed flips to
         // `outdated` (and back to `open` if the text reappears). Same sweep the
         // HTTP route runs — MCP publish must call it too.

--- a/apps/api/src/preview-do.ts
+++ b/apps/api/src/preview-do.ts
@@ -9,7 +9,7 @@ import { R2BlobStore } from "@derive/storage"
 import { tickStore } from "./edge-pg"
 import { log } from "./log"
 import { cfBrowserRenderer } from "./preview-cf"
-import { runRenderTick } from "./previews"
+import { runRenderTick, sweepMissingRenders } from "./previews"
 
 // While the render queue has work, re-tick on this cadence so a burst drains
 // promptly and near-term retries fire on time — mirroring the webhook outbox.
@@ -78,6 +78,9 @@ export class PreviewRenderer {
           "preview renderer: BASE_URL unset, defaulting to https://derive.to — set BASE_URL for non-prod deploys",
         )
       const baseUrl = this.env.BASE_URL ?? "https://derive.to"
+      // Sweep first so a never-rendered version (pre-pipeline publish, or a path
+      // that missed the enqueue) is claimed by the very tick that finds it.
+      await sweepMissingRenders(opened.store)
       const claimed = await runRenderTick({
         meta: opened.store,
         blobs,

--- a/apps/api/src/previews.ts
+++ b/apps/api/src/previews.ts
@@ -40,6 +40,9 @@ export const RENDER_TIMEOUT_MS = 20_000
 /** Maximum jobs to claim per tick (concurrency budget: jobs are sequential). */
 export const RENDER_CLAIM_LIMIT = 3
 
+/** Maximum missing-preview versions the self-heal sweep enqueues per tick. */
+export const SWEEP_LIMIT = 50
+
 // ---------------------------------------------------------------------------
 // Interfaces
 // ---------------------------------------------------------------------------
@@ -117,6 +120,24 @@ export const enqueueRender = async (
  * On failure: marks the version failed with a short error, then either retries
  * with exponential backoff or dead-letters after MAX_ATTEMPTS.
  */
+/**
+ * Self-heal sweep: enqueue a render job for every live artifact whose current
+ * version was never rendered (it predates the pipeline, or its publish path
+ * missed the enqueue) and has no pending job. Versions that rendered and FAILED
+ * keep their own job's retry/dead-letter state — the sweep never resurrects
+ * them, so it converges instead of hammering a broken render. Runs ahead of the
+ * claim in both workers (the Node interval and the edge DO alarm), so a swept
+ * version renders on the same tick that found it. Returns the number enqueued.
+ */
+export const sweepMissingRenders = async (
+  meta: MetaStore,
+  limit = SWEEP_LIMIT,
+): Promise<number> => {
+  const missing = await meta.versionsMissingPreview(limit)
+  for (const m of missing) await enqueueRender(meta, m.artifact_id, m.n)
+  return missing.length
+}
+
 export const runRenderTick = async (
   deps: RenderTickDeps,
   limit = RENDER_CLAIM_LIMIT,
@@ -220,6 +241,9 @@ export const startPreviewWorker = (deps: RenderTickDeps, intervalMs = 1500): Pre
     if (stopped || running) return
     running = true
     try {
+      // Sweep first so a never-rendered version found now is claimed this tick.
+      // Cheap when there's nothing missing (one bounded SELECT on a local DB).
+      await sweepMissingRenders(deps.meta)
       await runRenderTick(deps)
     } catch (err) {
       // A bad tick must not kill the loop, but it must not vanish either —

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -1264,4 +1264,49 @@ describe("remote MCP endpoint (/mcp)", () => {
     })
     expect(toolText(asFile)).toContain("bundle")
   })
+
+  it("publish enqueues a preview render job (parity with the HTTP route)", async () => {
+    const { app, token, meta } = appWithGrant("pubrender", "openid derive:read derive:publish", {
+      renderPreviews: true,
+    })
+    const created = JSON.parse(
+      toolText(await call(app, token, "publish", { title: "Card", content: "<h1>v1</h1>" })),
+    )
+    expect(created.published).toBe(true)
+    // notifyRender is fire-and-forget — give the enqueue promise a tick to settle.
+    await new Promise((r) => setTimeout(r, 20))
+    const lease = new Date(Date.now() + 60_000).toISOString()
+    const due = await meta.claimDueRenderJobs(new Date().toISOString(), 10, lease)
+    expect(due).toHaveLength(1)
+    expect(due[0]?.version_n).toBe(1)
+
+    // A republish enqueues for the NEW version.
+    await call(app, token, "publish", { short_id: created.short_id, content: "<h1>v2</h1>" })
+    await new Promise((r) => setTimeout(r, 20))
+    const due2 = await meta.claimDueRenderJobs(new Date().toISOString(), 10, lease)
+    expect(due2).toHaveLength(1)
+    expect(due2[0]?.version_n).toBe(2)
+  })
+
+  it("publish with for_review (a proposal) does NOT enqueue a render job", async () => {
+    const { app, token, meta } = appWithGrant("proprender", "openid derive:read derive:publish", {
+      renderPreviews: true,
+    })
+    const created = JSON.parse(
+      toolText(await call(app, token, "publish", { title: "Base", content: "<h1>v1</h1>" })),
+    )
+    await new Promise((r) => setTimeout(r, 20))
+    // Drain the publish's own job so the assertion below isolates the proposal.
+    const lease = new Date(Date.now() + 60_000).toISOString()
+    await meta.claimDueRenderJobs(new Date().toISOString(), 10, lease)
+
+    const proposed = await call(app, token, "publish", {
+      short_id: created.short_id,
+      content: "<h1>proposed</h1>",
+      for_review: true,
+    })
+    expect(JSON.parse(toolText(proposed)).proposed).toBe(true)
+    await new Promise((r) => setTimeout(r, 20))
+    expect(await meta.claimDueRenderJobs(new Date().toISOString(), 10, lease)).toHaveLength(0)
+  })
 })

--- a/apps/api/test/previews.test.ts
+++ b/apps/api/test/previews.test.ts
@@ -11,7 +11,13 @@ import type {
 } from "@derive/core"
 import { sha256Hex } from "@derive/core"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { enqueueRender, MAX_ATTEMPTS, runRenderTick, startPreviewWorker } from "../src/previews"
+import {
+  enqueueRender,
+  MAX_ATTEMPTS,
+  runRenderTick,
+  startPreviewWorker,
+  sweepMissingRenders,
+} from "../src/previews"
 
 // ---------------------------------------------------------------------------
 // Fake BlobStore (content-addressed, Map-backed)
@@ -138,6 +144,22 @@ const makeFakes = (): FakeMeta => {
         created_at: new Date().toISOString(),
       }
       jobs.set(j.id, rec)
+    },
+    versionsMissingPreview: async (
+      limit: number,
+    ): Promise<Array<{ artifact_id: string; n: number }>> => {
+      const out: Array<{ artifact_id: string; n: number }> = []
+      for (const a of artifacts.values()) {
+        if (out.length >= limit) break
+        if (a.removed_at !== null) continue
+        const v = versions.get(`${a.id}:${a.current_version}`)
+        if (!v || v.preview_status !== null) continue
+        const pending = [...jobs.values()].some(
+          (j) => j.artifact_id === a.id && j.status === "pending",
+        )
+        if (!pending) out.push({ artifact_id: a.id, n: a.current_version })
+      }
+      return out
     },
     claimDueRenderJobs: async (
       _now: string,
@@ -443,6 +465,59 @@ describe("previews: enqueueRender + runRenderTick", () => {
       secret: "s",
     })
     expect(n).toBe(0)
+  })
+})
+
+describe("sweepMissingRenders", () => {
+  it("enqueues a job for a never-rendered current version, and the next tick renders it", async () => {
+    const fakes = makeFakes()
+    // Published without ever enqueuing a render (e.g. an MCP publish before the fix).
+    await seedArtifact(fakes, { id: "s1", shortId: "sshort1", versionN: 1 })
+    expect(fakes.jobs.size).toBe(0)
+
+    const swept = await sweepMissingRenders(fakes.meta)
+    expect(swept).toBe(1)
+    expect(fakes.jobs.size).toBe(1)
+
+    const renderer = { screenshot: async () => new Uint8Array([9]) }
+    await runRenderTick({
+      meta: fakes.meta,
+      blobs: makeBlobs(),
+      renderer,
+      baseUrl: "https://d.to",
+      secret: "s",
+    })
+    expect(fakes.versions.get("s1:1")?.preview_status).toBe("ready")
+  })
+
+  it("does not duplicate a version that already has a pending job", async () => {
+    const fakes = makeFakes()
+    await seedArtifact(fakes, { id: "s2", shortId: "sshort2", versionN: 1 })
+    await enqueueRender(fakes.meta, "s2", 1)
+
+    expect(await sweepMissingRenders(fakes.meta)).toBe(0)
+    expect(fakes.jobs.size).toBe(1)
+  })
+
+  it("never resurrects a version that rendered and failed", async () => {
+    const fakes = makeFakes()
+    await seedArtifact(fakes, { id: "s3", shortId: "sshort3", versionN: 1 })
+    await fakes.meta.setVersionPreview("s3", 1, {
+      preview_status: "failed",
+      preview_error: "boom",
+    })
+
+    expect(await sweepMissingRenders(fakes.meta)).toBe(0)
+    expect(fakes.jobs.size).toBe(0)
+  })
+
+  it("respects the limit", async () => {
+    const fakes = makeFakes()
+    await seedArtifact(fakes, { id: "s4", shortId: "sshort4", versionN: 1 })
+    await seedArtifact(fakes, { id: "s5", shortId: "sshort5", versionN: 1 })
+
+    expect(await sweepMissingRenders(fakes.meta, 1)).toBe(1)
+    expect(fakes.jobs.size).toBe(1)
   })
 })
 

--- a/apps/web/src/components/shared/thumb.tsx
+++ b/apps/web/src/components/shared/thumb.tsx
@@ -49,7 +49,9 @@ export function Thumb({
     >
       {thumbMedia(hasPreview, imgFailed) === "img" ? (
         <img
-          src={`${API_BASE}/v1/og/${id}`}
+          // Keyed by version so a republish busts the browser's cached screenshot
+          // of the previous one (the og route serves long max-age per URL).
+          src={`${API_BASE}/v1/og/${id}?v=${v}`}
           alt=""
           aria-hidden
           loading="lazy"

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -245,6 +245,15 @@ export interface ArtifactStore {
    * to `leaseUntil`), then returns the claimed rows.
    */
   claimDueRenderJobs(now: string, limit: number, leaseUntil: string): Promise<RenderJobRecord[]>
+  /**
+   * Up to `limit` live artifacts whose CURRENT version has never been rendered
+   * (preview_status is null) and has no pending render job. Feeds the self-heal
+   * sweep: publishes that predate the render pipeline — or that slipped past the
+   * enqueue (a crashed request, a code path that missed notifyRender) — get their
+   * screenshot on the next tick instead of never. Versions that already ran and
+   * failed ("failed"/dead-lettered) are excluded: they had their retries.
+   */
+  versionsMissingPreview(limit: number): Promise<Array<{ artifact_id: string; n: number }>>
   updateRenderJob(
     id: string,
     fields: {

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -101,6 +101,7 @@ import {
   isNull,
   lte,
   ne,
+  notExists,
   or,
   sql,
 } from "drizzle-orm"
@@ -786,6 +787,28 @@ export class PgMetaStore implements MetaStore {
   // ---- Render-job queue --------------------------------------------------
   async enqueueRenderJob(j: NewRenderJob): Promise<void> {
     await this.db.insert(renderJob).values(j)
+  }
+  versionsMissingPreview(limit: number): Promise<Array<{ artifact_id: string; n: number }>> {
+    return this.db
+      .select({ artifact_id: version.artifact_id, n: version.n })
+      .from(artifact)
+      .innerJoin(
+        version,
+        and(eq(version.artifact_id, artifact.id), eq(version.n, artifact.current_version)),
+      )
+      .where(
+        and(
+          isNull(artifact.removed_at),
+          isNull(version.preview_status),
+          notExists(
+            this.db
+              .select({ one: sql`1` })
+              .from(renderJob)
+              .where(and(eq(renderJob.artifact_id, artifact.id), eq(renderJob.status, "pending"))),
+          ),
+        ),
+      )
+      .limit(limit)
   }
   claimDueRenderJobs(now: string, limit: number, leaseUntil: string): Promise<RenderJobRecord[]> {
     const due = this.db

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -99,6 +99,7 @@ import {
   lt,
   lte,
   ne,
+  notExists,
   or,
   type SQL,
   sql,
@@ -860,6 +861,30 @@ export function makeRepos(db: SqliteDb) {
   const enqueueRenderJob = async (j: NewRenderJob): Promise<void> => {
     await db.insert(renderJob).values(j).run()
   }
+  const versionsMissingPreview = async (
+    limit: number,
+  ): Promise<Array<{ artifact_id: string; n: number }>> =>
+    db
+      .select({ artifact_id: version.artifact_id, n: version.n })
+      .from(artifact)
+      .innerJoin(
+        version,
+        and(eq(version.artifact_id, artifact.id), eq(version.n, artifact.current_version)),
+      )
+      .where(
+        and(
+          isNull(artifact.removed_at),
+          isNull(version.preview_status),
+          notExists(
+            db
+              .select({ one: sql`1` })
+              .from(renderJob)
+              .where(and(eq(renderJob.artifact_id, artifact.id), eq(renderJob.status, "pending"))),
+          ),
+        ),
+      )
+      .limit(limit)
+      .all()
   const claimDueRenderJobs = async (
     now: string,
     limit: number,
@@ -2534,6 +2559,7 @@ export function makeRepos(db: SqliteDb) {
     updateDelivery,
     recentDeliveries,
     enqueueRenderJob,
+    versionsMissingPreview,
     claimDueRenderJobs,
     updateRenderJob,
     getMembership,

--- a/packages/db/test/preview.test.ts
+++ b/packages/db/test/preview.test.ts
@@ -31,3 +31,49 @@ describe("version preview fields", () => {
     expect(after?.preview_error).toBeNull()
   })
 })
+
+describe("versionsMissingPreview", () => {
+  const seed = async (meta: SqliteMetaStore, id: string) => {
+    const a = await meta.createArtifact({
+      id,
+      short_id: `s_${id}`,
+      org_id: "o1",
+      slug: null,
+      title: "t",
+      kind: "file",
+      spa: 0,
+    })
+    await meta.addVersion(a.id, {
+      id: `v_${id}`,
+      blob_key: "k",
+      content_type: "text/html",
+      author: "me",
+      message: null,
+    })
+    return a
+  }
+
+  it("finds only never-rendered current versions of live artifacts", async () => {
+    const meta = new SqliteMetaStore(":memory:")
+    await seed(meta, "a1") // never rendered → in
+    const ready = await seed(meta, "a2")
+    await meta.setVersionPreview(ready.id, 1, { preview_key: "k", preview_status: "ready" })
+    const failed = await seed(meta, "a3")
+    await meta.setVersionPreview(failed.id, 1, { preview_status: "failed", preview_error: "x" })
+    const removed = await seed(meta, "a4")
+    await meta.setArtifactRemoved(removed.id, new Date().toISOString())
+    const queued = await seed(meta, "a5") // pending job already → out
+    await meta.enqueueRenderJob({ id: "rj_a5", artifact_id: queued.id, version_n: 1 })
+
+    const missing = await meta.versionsMissingPreview(10)
+    expect(missing).toEqual([{ artifact_id: "a1", n: 1 }])
+  })
+
+  it("respects the limit", async () => {
+    const meta = new SqliteMetaStore(":memory:")
+    await seed(meta, "b1")
+    await seed(meta, "b2")
+    expect(await meta.versionsMissingPreview(1)).toHaveLength(1)
+    expect(await meta.versionsMissingPreview(10)).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## Why

Library cards already prefer the static screenshot (`/v1/og/:id`, shipped in #332) and only fall back to the live iframe when `has_preview` is false. But screenshot renders were only enqueued on the **HTTP** publish route — an MCP publish (the primary path in practice) never enqueued one, so those artifacts never get a preview. In prod, 137 of 176 live artifacts have none.

## What

- **`mcp.ts`**: a live MCP publish now calls `notifyRender`, same as the HTTP route and proposal approval. (Proposals still don't render until approved.)
- **Self-heal sweep**: new `versionsMissingPreview` store method (sqlite/D1/pg) lists live artifacts whose *current* version was never rendered and has no pending job; `sweepMissingRenders` enqueues them ahead of each render tick, in both the Node worker and the edge DO. On deploy, the cron tick backfills all existing preview-less artifacts automatically (50/sweep), and any future publish path that forgets the enqueue heals instead of silently iframing forever. Versions that rendered and **failed** keep their dead-letter state — the sweep never resurrects them, so it converges.
- **`thumb.tsx`**: the card's og image URL is keyed by version (`?v=<n>`) so a republish busts the browser's long-max-age cache of the previous version's screenshot.

## Verification

Ran the real Node server (scratch SQLite, `DERIVE_PREVIEWS=true`):
- HTTP publish → PNG at `/v1/og/:id?v=1` in ~6s.
- Erased an artifact's preview state + jobs (simulating a pre-fix MCP publish), restarted → the sweep re-rendered it ~2s after boot with no publish event; `has_preview: true` in the list API.
- Probes: 10s of idle ticks after healing left exactly 1 render job (no duplicate enqueues); a version marked `failed` with its job deleted stayed untouched (never resurrected).

New tests: MCP publish enqueues for v1 + republish, proposal doesn't; sweep unit tests (enqueue/dedupe/failed-exclusion/limit) against the fake store and `versionsMissingPreview` against real sqlite. Full suites green (db 191, api 868, web 146), typecheck + biome clean.