### PR TITLE
fix(mcp): never re-type an artifact when publish omits the filename

### DIFF
--- a/apps/api/src/lib/edits.ts
+++ b/apps/api/src/lib/edits.ts
@@ -22,6 +22,13 @@ export interface MaterializedEdits {
   filename: string
 }
 
+/** A filename that round-trips `contentType` through the publish sniffer (which types
+ *  by filename first). Any revision of an existing single-file artifact that doesn't
+ *  carry an explicit filename must go through this — an `index.html` default silently
+ *  re-types a markdown doc as HTML, and the browser then swallows its text as markup. */
+export const preservingFilename = (contentType: string | null): string =>
+  (contentType ?? "").split(";")[0]?.trim() === "text/markdown" ? "index.md" : "index.html"
+
 /**
  * Turn an `edits` request into stored-revision bytes: validate the artifact can take
  * edits at all (single-file, `base_version` still fresh), load its current source,
@@ -57,11 +64,7 @@ export async function materializeEdits(
   const content = applyEdits(src, edits)
   // Keep the artifact's content type: the sniffer types by filename first, and the
   // default index.html would silently re-type an edited markdown doc as HTML.
-  const filename =
-    (cur.content_type.split(";")[0]?.trim() ?? cur.content_type) === "text/markdown"
-      ? "index.md"
-      : "index.html"
-  return { content, filename }
+  return { content, filename: preservingFilename(cur.content_type) }
 }
 
 /** Parse a `base_version` value from an untyped form field: `undefined` when absent,

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -31,6 +31,7 @@ import {
   elideDataUris,
   formatDiff,
   isHtmlLike,
+  looksLikeHtmlDocument,
   newId,
   type OutlineSection,
   outlineOf,
@@ -62,7 +63,7 @@ import {
   zipBundleFiles,
 } from "./lib/bundle"
 import { parseMeta, quoteOf, REACTIONS } from "./lib/comments"
-import { type MaterializedEdits, materializeEdits } from "./lib/edits"
+import { type MaterializedEdits, materializeEdits, preservingFilename } from "./lib/edits"
 import { buildReviewEmail } from "./lib/email"
 import { MAX_UPLOAD_BYTES } from "./lib/http"
 import { notifyCommentBells } from "./lib/notify-comment"
@@ -1337,7 +1338,9 @@ async function buildServer(
         try {
           const { proposal } = await proposeChange(ctx.meta, ctx.blobs, short_id as string, {
             bytes: new TextEncoder().encode(content as string),
-            filename: filename ?? "index.html",
+            // The sniffer types by filename first: a bare index.html default would
+            // re-type a markdown artifact as HTML when the proposal is approved.
+            filename: filename ?? preservingFilename(existing.current_content_type),
             isBundle: false,
             message: message ?? "Proposed revision",
             author: agent.name,
@@ -1414,12 +1417,25 @@ async function buildServer(
           return text("A workspace-listed artifact must grant workspace access.")
         if (!short_id && resolvedListed === "public" && resolvedLinkRole === "none")
           return text("A publicly-listed artifact must grant at least a viewer link.")
+        // No filename on a single-file publish must never blindly default to
+        // index.html: the sniffer types by filename first, so that default silently
+        // re-types an existing markdown doc as HTML — the browser then parses the
+        // raw markdown as markup and swallows tag-like text. A republish preserves
+        // the artifact's current type; a new artifact is sniffed, so markdown
+        // content without a filename hint lands as markdown.
+        const singleFileFallback = existing
+          ? preservingFilename(existing.current_content_type)
+          : looksLikeHtmlDocument((content as string | undefined) ?? "")
+            ? "index.html"
+            : "index.md"
         const { artifact, version } = await publishVersion(
           ctx.meta,
           ctx.blobs,
           {
             bytes,
-            filename: isBundle ? `${title?.trim() || "bundle"}.zip` : (filename ?? "index.html"),
+            filename: isBundle
+              ? `${title?.trim() || "bundle"}.zip`
+              : (filename ?? singleFileFallback),
             isBundle,
             spa: bundleSpa,
             title: title?.trim(),

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -867,6 +867,56 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(read).toContain("proposed body")
   })
 
+  // End-to-end through the RENDER pipeline (not just the stored-type label): publish
+  // markdown with no filename, then fetch the served /raw/ page and prove it is
+  // rendered markdown with tag-like tokens intact — the exact failure that flattened
+  // a real doc to raw-source soup and ate its `<...>` placeholders. Reproduces the
+  // production round-trip: fresh publish, then a full-content republish with no
+  // filename (the step that flipped the artifact to text/html and broke the render).
+  it("render e2e: a no-filename markdown publish renders as markdown, tokens intact, across a republish", async () => {
+    const { app, token } = appWithGrant("rendere2e", "openid derive:read derive:publish")
+    // A heading (proves it gets RENDERED, not served as source) and a tag-like token
+    // in a code span (proves it SURVIVES, escaped, instead of vanishing as a phantom tag).
+    const v1 =
+      "# Skills across Derive\n\n## The idea\n\nGet it as a `derive://brandprint/<short_id>` resource; put files in `<cwd>/.claude/skills/`.\n"
+    const created = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          title: "Skills across Derive",
+          content: v1,
+          link_role: "viewer", // world-link readable so the anonymous /raw/ GET renders it
+        }),
+      ),
+    )
+
+    // Anonymous fetch of the SERVED page — the real serveContent → renderMarkdown chain.
+    const page1 = await app.request(`/raw/${created.short_id}/v/1/`)
+    expect(page1.status).toBe(200)
+    expect(page1.headers.get("content-type")).toContain("text/html")
+    const html1 = await page1.text()
+    // Rendered, not dumped: the `##` became a real heading element.
+    expect(html1).toContain("<h1")
+    expect(html1).toContain("<h2")
+    expect(html1).toContain("The idea")
+    // The token survived as escaped text inside the code span…
+    expect(html1).toContain("&lt;short_id&gt;")
+    // …and the raw markdown source is NOT what got served (the soup failure mode).
+    expect(html1).not.toContain("## The idea")
+
+    // The production round-trip: a full-content republish with NO filename. This is the
+    // exact step that re-typed the artifact to text/html and broke it.
+    const v2 =
+      "# Skills across Derive\n\n## The idea\n\nRevised: `derive://brandprint/<short_id>` still resolves; skills land in `<cwd>/.claude/skills/`.\n"
+    await call(app, token, "publish", { short_id: created.short_id, content: v2 })
+    const page2 = await app.request(`/raw/${created.short_id}/v/2/`)
+    expect(page2.status).toBe(200)
+    const html2 = await page2.text()
+    expect(html2).toContain("<h2")
+    expect(html2).toContain("Revised")
+    expect(html2).toContain("&lt;short_id&gt;")
+    expect(html2).not.toContain("## The idea")
+  })
+
   it("surfaces outdated feedback after a republish drops the quoted text", async () => {
     const { app, token } = appWithGrant("stale", "openid derive:read derive:comment derive:publish")
     const shortId = (await (await publish(app, token, "alpha beta gamma")).json()).short_id

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -787,6 +787,86 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(read).not.toContain("Revised")
   })
 
+  // The sniffer types by filename first, so a bare index.html fallback silently
+  // re-types a markdown artifact as HTML on any revision that omits `filename` —
+  // the browser then parses the raw markdown as markup and swallows tag-like text.
+  // These three pin every no-filename path: full-content republish, new-artifact
+  // sniff, and the proposal route.
+  it("publish: a full-content republish without a filename keeps a markdown doc markdown", async () => {
+    const { app, token } = appWithGrant("retype", "openid derive:read derive:publish")
+    const created = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          title: "Doc",
+          content: "# Doc\n\nfirst body\n",
+          filename: "doc.md",
+        }),
+      ),
+    )
+    await call(app, token, "publish", {
+      short_id: created.short_id,
+      content: "# Doc\n\nrevised body\n",
+    })
+    const read = toolText(await call(app, token, "read", { short_id: created.short_id }))
+    expect(read).toContain("version: 2 (current)")
+    expect(read).toContain("format: markdown (source)")
+    expect(read).toContain("revised body")
+  })
+
+  it("publish: a new single-file artifact without a filename is sniffed, not defaulted to HTML", async () => {
+    const { app, token } = appWithGrant("sniff", "openid derive:read derive:publish")
+    const md = JSON.parse(
+      toolText(
+        await call(app, token, "publish", { title: "Plain", content: "# Plain\n\nno filename\n" }),
+      ),
+    )
+    const readMd = toolText(await call(app, token, "read", { short_id: md.short_id }))
+    expect(readMd).toContain("format: markdown (source)")
+    // A real HTML document still lands as HTML — the sniff is conservative, not a
+    // markdown default.
+    const html = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          title: "Page",
+          content: "<!doctype html><html><body><h1>Page</h1></body></html>",
+        }),
+      ),
+    )
+    const readHtml = toolText(await call(app, token, "read", { short_id: html.short_id }))
+    expect(readHtml).toContain("markdown (converted from text/html)")
+  })
+
+  it("publish: an approved no-filename proposal keeps a markdown doc markdown", async () => {
+    const { app, token } = appWithGrant("retypeprop", "openid derive:read derive:publish")
+    const created = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          title: "Spec",
+          content: "# Spec\n\ndraft\n",
+          filename: "spec.md",
+        }),
+      ),
+    )
+    const p = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          short_id: created.short_id,
+          content: "# Spec\n\nproposed body\n",
+          for_review: true,
+        }),
+      ),
+    )
+    const approved = await app.request(
+      `/v1/artifacts/${created.short_id}/proposals/${p.proposal_id}/approve`,
+      { method: "POST", headers: { authorization: `Bearer ${token}` } },
+    )
+    expect(approved.status).toBe(200)
+    const read = toolText(await call(app, token, "read", { short_id: created.short_id }))
+    expect(read).toContain("version: 2 (current)")
+    expect(read).toContain("format: markdown (source)")
+    expect(read).toContain("proposed body")
+  })
+
   it("surfaces outdated feedback after a republish drops the quoted text", async () => {
     const { app, token } = appWithGrant("stale", "openid derive:read derive:comment derive:publish")
     const shortId = (await (await publish(app, token, "alpha beta gamma")).json()).short_id


### PR DESCRIPTION
## The bug

A full-content republish (and a proposal) through the MCP `publish` tool fell back to filename `index.html` when the caller gave no `filename` hint. The publish sniffer types by filename first, so one no-filename revision silently re-typed a `text/markdown` artifact as `text/html`. From there the browser parses raw markdown as markup: tag-like tokens (`<short_id>`, `<cwd>`) vanish as phantom elements, structure flattens to soup, the MCP text/anchor view strips those tokens, and markdown sectioning stops working (`docOutline` finds no HTML headings).

The `edits` path already defended against exactly this — `materializeEdits` infers a content-type-preserving filename, with a comment naming the failure — but the full-content and proposal paths did not.

**Seen in production:** artifact `j8lfhpkg` was markdown for v1–v4 (v1 carried a filename; v2–v4 were edits), then flipped to `text/html` on its v5 full-content republish and rendered as raw-source soup. Healed by republishing with a `.md` filename.

## The fix

- Extract the inference as `preservingFilename()` in `lib/edits` and share it across all three surfaces.
- Republish + proposal without a filename now preserve the artifact's current content type.
- A NEW single-file artifact with no filename is sniffed with the existing `looksLikeHtmlDocument` (conservative: requires a doctype/`<html>` start), so markdown content lands as markdown instead of defaulting to HTML.

## Tests

Three regression tests pin every no-filename path: full-content republish keeps markdown, new-artifact sniff (markdown in, markdown stored; real HTML doc still lands as HTML), and an approved no-filename proposal keeps markdown. Each fails against the old default.

`pnpm --filter api test`: 114 files, 871 tests green. `pnpm check:fix` + `pnpm -w typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)