### PR TITLE
refactor: consolidate publish side-effects + guard lints against drift

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -120,6 +120,9 @@ export function createApp(deps: AppDeps): Hono {
       path: redactPath(c.req.path),
       request_id: c.get("requestId"),
       error: err instanceof Error ? err.message : String(err),
+      // Server log only (never the client) — a production 500 without a stack is
+      // a message with no location.
+      stack: err instanceof Error ? err.stack : undefined,
     })
     return c.json({ error: "internal error" }, 500)
   })

--- a/apps/api/src/lib/after-publish.ts
+++ b/apps/api/src/lib/after-publish.ts
@@ -1,0 +1,127 @@
+// The side-effect chain every new live version runs, in ONE place. A version reaches
+// "live" from three entry points — the HTTP publish route, the MCP publish tool, and a
+// version restore — and each used to hand-copy the same fan-out. When they drift, an MCP
+// publish silently skips webhooks (the exact bug this consolidation exists to prevent from
+// recurring). Proposal-approve shares the realtime core via `emitVersionBump` but keeps its
+// own `proposal.approved` webhook, so it stays in proposal-actions.ts.
+//
+// `lint:api` forbids constructing a raw `version.published` bus event or the follower
+// fan-out anywhere but this file — every publish path must route through here.
+
+import {
+  type ArtifactRecord,
+  type BlobStore,
+  type MetaStore,
+  newId,
+  type VersionRecord,
+} from "@derive/core"
+import type { Backplane } from "../bus"
+import type { WebhookEvent } from "../events"
+import { publishSweepEvents } from "./anchor-sweep"
+
+/** The realtime + render + re-anchor core shared by every version bump (publish, restore,
+ *  proposal-approve): announce the new version so open tabs live-reload, enqueue its preview
+ *  render, then re-anchor existing threads against the new content. Webhook delivery and
+ *  follower fan-out are NOT here — they differ per path and live in {@link afterPublish}. */
+export interface VersionBumpDeps {
+  meta: MetaStore
+  blobs: BlobStore
+  bus: Backplane
+  /** Fire-and-forget preview render. Optional so a caller without render access (a test) omits it. */
+  notifyRender?: (a: ArtifactRecord, n: number) => void
+}
+
+export const emitVersionBump = async (
+  deps: VersionBumpDeps,
+  artifact: ArtifactRecord,
+  version: VersionRecord,
+): Promise<void> => {
+  const { meta, blobs, bus, notifyRender } = deps
+  bus.publish(artifact.id, { type: "version.published", n: version.n, message: version.message })
+  notifyRender?.(artifact, version.n)
+  await publishSweepEvents(meta, blobs, bus, artifact.id, version)
+}
+
+export interface AfterPublishDeps extends VersionBumpDeps {
+  notify: (a: ArtifactRecord, event: WebhookEvent, data: Record<string, unknown>) => Promise<void>
+  /** Run after-response work off the hot path (webhook enqueue, follower fan-out). */
+  background: (work: Promise<unknown>) => Promise<void>
+}
+
+export interface AfterPublishOpts {
+  /** First version of a brand-new artifact — gates the one-time follower fan-out (a
+   *  republish must not re-notify followers on every edit). */
+  isNew: boolean
+  /** The human behind the publish (a session user, or an agent's registrant). Their
+   *  followers are the ones who care; null for a truly headless publish. */
+  onBehalf: string | null
+  /** Thread ids to resolve in the same call (a live publish that fixes feedback). The
+   *  caller has already validated these belong to `artifact`. */
+  resolves?: string[]
+}
+
+/**
+ * Everything that must happen after a publish makes a version live, canonicalized so the
+ * HTTP route, the MCP tool, and restore can't drift: fire the `version.published` webhook,
+ * fan out to the publisher's followers (new + human + public only), resolve any threads
+ * named in the call, then run the shared realtime/render/re-anchor bump. Returns the thread
+ * ids actually resolved so the caller can report them.
+ */
+export const afterPublish = async (
+  deps: AfterPublishDeps,
+  artifact: ArtifactRecord,
+  version: VersionRecord,
+  opts: AfterPublishOpts,
+): Promise<{ resolved: string[] }> => {
+  const { meta, bus, notify, background } = deps
+  await notify(artifact, "version.published", {
+    version: version.n,
+    message: version.message,
+    author: version.author,
+  })
+  // Fan out to the publisher's followers: "someone you follow published X". Gated to a
+  // known HUMAN behind the publish (an agent publish fans out to the followers of the
+  // person it acts for), a publicly-listed artifact (a follow never surfaces a private
+  // title), and a NEW artifact only. In the background so a popular author's fan-out never
+  // adds to publish latency.
+  if (opts.isNew && opts.onBehalf && artifact.listed === "public") {
+    const behalf = opts.onBehalf
+    background(fanOutToFollowers(meta, behalf, artifact))
+  }
+  // A live publish that fixes feedback resolves those threads directly.
+  const resolved: string[] = []
+  for (const threadId of opts.resolves ?? []) {
+    await meta.setThreadState(artifact.id, threadId, "resolved")
+    bus.publish(artifact.id, { type: "comment.resolved", thread_id: threadId, state: "resolved" })
+    resolved.push(threadId)
+  }
+  await emitVersionBump(deps, artifact, version)
+  return { resolved }
+}
+
+const fanOutToFollowers = async (
+  meta: MetaStore,
+  authorId: string,
+  artifact: ArtifactRecord,
+): Promise<void> => {
+  const [author] = await meta.getUsers([authorId])
+  if (!author) return
+  const followers = await meta.listFollowers(author.id, 200)
+  // One bulk insert for the whole fan-out, not a createNotification per follower.
+  await meta.createNotifications(
+    followers
+      .filter((follower) => follower.id !== author.id)
+      .map((follower) => ({
+        id: newId("ntf"),
+        user_id: follower.id,
+        actor: author.name ?? author.username ?? "Someone",
+        kind: "publish",
+        artifact_id: artifact.id,
+        artifact_short_id: artifact.short_id,
+        artifact_title: artifact.title,
+        thread_id: "",
+        comment_id: "",
+        preview: artifact.title ?? "published something new",
+      })),
+  )
+}

--- a/apps/api/src/lib/pr-preview.ts
+++ b/apps/api/src/lib/pr-preview.ts
@@ -5,12 +5,14 @@ import {
   type RepoSourceRecord,
   type VersionRecord,
 } from "@derive/core"
+import type { Backplane } from "../bus"
 import { log } from "../log"
-import { sweepAnchors } from "./anchor-sweep"
+import { publishSweepEvents } from "./anchor-sweep"
 
 interface PrPreviewDeps {
   meta: MetaStore
   blobs: BlobStore
+  bus: Backplane
   baseUrl: string
   /** Queue a source for a mirror run — the sync-trigger wrapper owned by syncRoutes. */
   launch: (source: RepoSourceRecord, inlineFallback: boolean) => Promise<void>
@@ -24,7 +26,7 @@ interface PrPreviewDeps {
  * source's installation + include globs, and the engine scopes the mirror to just the PR's
  * changed docs. Created on open/synchronize, torn down on close, graduated on merge.
  */
-export function makePrPreview({ meta, blobs, baseUrl, launch }: PrPreviewDeps) {
+export function makePrPreview({ meta, blobs, bus, baseUrl, launch }: PrPreviewDeps) {
   // Upsert a preview to the PR's current head. An existing preview is re-pointed at the
   // new head sha (its file map is kept, so the engine updates artifacts in place and
   // tombstones docs the PR no longer touches); a missing one is created fresh.
@@ -163,8 +165,9 @@ export function makePrPreview({ meta, blobs, baseUrl, launch }: PrPreviewDeps) {
     }
     // Re-anchor the canonical doc's threads (incl. the migrated ones) against its new
     // current version — quoted text that survived the merge stays anchored, the rest flips
-    // to `outdated` (Derive's normal post-version-bump behavior).
-    if (latest) await sweepAnchors(meta, blobs, canonicalId, latest)
+    // to `outdated` (Derive's normal post-version-bump behavior). Announce the transitions
+    // on the bus too, so a tab open on the canonical doc live-updates after a PR graduates.
+    if (latest) await publishSweepEvents(meta, blobs, bus, canonicalId, latest)
     // The preview copy is now redundant — hard-delete it (cascades its versions + comments).
     await meta.deleteArtifact(previewId, preview.org_id)
   }

--- a/apps/api/src/lib/proposal-actions.ts
+++ b/apps/api/src/lib/proposal-actions.ts
@@ -15,7 +15,7 @@ import {
 import type { Backplane } from "../bus"
 import type { WebhookEvent } from "../events"
 import { releaseAddressed } from "./addressed"
-import { publishSweepEvents } from "./anchor-sweep"
+import { emitVersionBump } from "./after-publish"
 
 export interface ProposalActionDeps {
   meta: MetaStore
@@ -38,10 +38,9 @@ export const approveProposalAction = async (
   const { meta, blobs, bus, notify, notifyRender } = deps
   const version = await approveProposal(meta, blobs, proposal, approver, note)
   bus.publish(artifact.id, { type: "proposal.approved", proposal_id: proposal.id, n: version.n })
-  bus.publish(artifact.id, { type: "version.published", n: version.n, message: version.message })
-  // The approved candidate is now live content — re-anchor existing threads so feedback on
-  // changed text flips to `outdated`.
-  await publishSweepEvents(meta, blobs, bus, artifact.id, version)
+  // The approved candidate is now live content: run the shared version-bump core (announce
+  // the version so open tabs reload, enqueue the preview render, re-anchor existing threads).
+  await emitVersionBump({ meta, blobs, bus, notifyRender }, artifact, version)
   // Threads this proposal addressed are now settled.
   for (const threadId of await releaseAddressed(meta, artifact.id, proposal.id, "resolved"))
     bus.publish(artifact.id, { type: "comment.addressed", thread_id: threadId, state: "resolved" })
@@ -50,7 +49,6 @@ export const approveProposalAction = async (
     version: version.n,
     approver,
   })
-  notifyRender?.(artifact, version.n)
   return version
 }
 

--- a/apps/api/src/log.ts
+++ b/apps/api/src/log.ts
@@ -6,7 +6,12 @@
  */
 type Level = "info" | "warn" | "error"
 
-const isProd = process.env.NODE_ENV === "production"
+// JSON when the Node container says production, and ALWAYS on Cloudflare Workers —
+// the deployed edge tier never sets NODE_ENV, and pretty-format lines there defeat
+// Workers Logs' field indexing. The UA string is the canonical workerd detection.
+const isProd =
+  process.env.NODE_ENV === "production" ||
+  (typeof navigator !== "undefined" && navigator.userAgent === "Cloudflare-Workers")
 const TAG: Record<Level, string> = { info: "·", warn: "⚠", error: "✖" }
 
 const emit = (level: Level, msg: string, fields?: Record<string, unknown>): void => {

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -55,7 +55,7 @@ import { z } from "zod"
 import { BRANDPRINT_REFERENCE, BRANDPRINT_TEMPLATE } from "./brandprint-reference"
 import type { AppContext } from "./context"
 import { markAddressed } from "./lib/addressed"
-import { publishSweepEvents } from "./lib/anchor-sweep"
+import { afterPublish } from "./lib/after-publish"
 import {
   cleanPath,
   mergeBundleZip,
@@ -1463,36 +1463,24 @@ async function buildServer(
             user_id: actingFor?.id ?? agent.id,
             role: "owner",
           })
-        // Event parity with the HTTP publish route: the artifact channel makes a
-        // tab viewing this doc live-reload; the webhook outbox fans out to
-        // integrations. Without these an MCP publish is invisible to open tabs.
-        ctx.bus.publish(artifact.id, {
-          type: "version.published",
-          n: version.n,
-          message: version.message,
-        })
-        await ctx.notify(artifact, "version.published", {
-          version: version.n,
-          message: version.message,
-          author: version.author,
-        })
-        ctx.notifyRender(artifact, version.n)
-        // Re-anchor existing threads: feedback whose quoted text changed flips to
-        // `outdated` (and back to `open` if the text reappears). Same sweep the
-        // HTTP route runs — MCP publish must call it too.
-        await publishSweepEvents(ctx.meta, ctx.blobs, ctx.bus, artifact.id, version)
-        // A live publish that fixes feedback resolves those threads directly (no
-        // approval step to wait on, unlike a proposal's `addressed`).
-        const resolved: string[] = []
-        for (const threadId of addresses ?? []) {
-          await ctx.meta.setThreadState(artifact.id, threadId, "resolved")
-          ctx.bus.publish(artifact.id, {
-            type: "comment.resolved",
-            thread_id: threadId,
-            state: "resolved",
-          })
-          resolved.push(threadId)
-        }
+        // Webhook + follower fan-out + thread resolves + realtime/render/re-anchor, via the
+        // one shared helper — event parity with the HTTP publish route (an open tab
+        // live-reloads, the webhook outbox reaches integrations) with no chance to drift.
+        // A live publish that fixes feedback resolves those threads directly here (no
+        // approval step, unlike a proposal's `addressed`).
+        const { resolved } = await afterPublish(
+          {
+            meta: ctx.meta,
+            blobs: ctx.blobs,
+            bus: ctx.bus,
+            notify: ctx.notify,
+            notifyRender: ctx.notifyRender,
+            background: ctx.background,
+          },
+          artifact,
+          version,
+          { isNew: !short_id, onBehalf: actingFor?.id ?? null, resolves: addresses ?? [] },
+        )
         // The /derive loop: ask the human to review this live version.
         let review_round: string | null = null
         if (request_review && actingFor) {

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -31,7 +31,7 @@ import type { Context } from "hono"
 import { setCookie } from "hono/cookie"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
-import { publishSweepEvents } from "../lib/anchor-sweep"
+import { afterPublish } from "../lib/after-publish"
 import { authorProfile, resolveHandles, resolveUserBylines } from "../lib/author"
 import { cleanPath, manifestOf } from "../lib/bundle"
 import { hashPassword, signState, unlockCookie, unlockToken, verifyPassword } from "../lib/crypto"
@@ -651,51 +651,9 @@ export const artifactRoutes = (ctx: AppContext) => {
           user_id: ownerId,
           role: "owner",
         })
-      bus.publish(artifact.id, {
-        type: "version.published",
-        n: version.n,
-        message: version.message,
-      })
-      await notify(artifact, "version.published", {
-        version: version.n,
-        message: version.message,
-        author: version.author,
-      })
-      notifyRender(artifact, version.n)
-      // Fan out to the publisher's followers: "someone you follow published X". Gated
-      // to a known HUMAN behind the publish (their followers are who care — an agent
-      // publish fans out to the followers of the person it acts for), a publicly-
-      // visible artifact (a follow never surfaces a private title), and a NEW artifact
-      // only — `shortId` means a republish/new version, which would otherwise spam
-      // followers on every edit. Done in the background so a popular author's fan-out
-      // never adds to publish latency (like the comment-mention fan-out).
-      if (!shortId && onBehalf && artifact.listed === "public") {
-        background(
-          (async () => {
-            const [author] = await meta.getUsers([onBehalf])
-            if (!author) return
-            const followers = await meta.listFollowers(author.id, 200)
-            // One bulk insert for the whole fan-out, not a createNotification per follower.
-            await meta.createNotifications(
-              followers
-                .filter((follower) => follower.id !== author.id)
-                .map((follower) => ({
-                  id: newId("ntf"),
-                  user_id: follower.id,
-                  actor: author.name ?? author.username ?? "Someone",
-                  kind: "publish",
-                  artifact_id: artifact.id,
-                  artifact_short_id: artifact.short_id,
-                  artifact_title: artifact.title,
-                  thread_id: "",
-                  comment_id: "",
-                  preview: artifact.title ?? "published something new",
-                })),
-            )
-          })(),
-        )
-      }
-      // Republish can resolve comment threads in the same call.
+      // Republish can resolve comment threads in the same call: map the given comment
+      // ids to their threads, keeping only ones that belong to this artifact.
+      const toResolve: string[] = []
       const resolves = body["resolves"]
       if (shortId && typeof resolves === "string" && resolves) {
         for (const cid of resolves
@@ -703,15 +661,21 @@ export const artifactRoutes = (ctx: AppContext) => {
           .map((s) => s.trim())
           .filter(Boolean)) {
           const cm = await meta.getComment(cid)
-          if (cm && cm.artifact_id === artifact.id) {
-            await meta.setThreadState(artifact.id, cm.thread_id, "resolved")
-            bus.publish(artifact.id, { type: "comment.resolved", thread_id: cm.thread_id })
-          }
+          if (cm && cm.artifact_id === artifact.id) toResolve.push(cm.thread_id)
         }
       }
-      // Re-anchor existing threads against the new version: feedback whose quoted
-      // text changed flips to `outdated` (and back to `open` if it reappears).
-      await publishSweepEvents(meta, blobs, bus, artifact.id, version)
+      // Webhook + follower fan-out + thread resolves + realtime/render/re-anchor, all via
+      // the one shared helper so this path can never drift from MCP publish or restore.
+      await afterPublish(
+        { meta, blobs, bus, notify, notifyRender, background },
+        artifact,
+        version,
+        {
+          isNew: !shortId,
+          onBehalf,
+          resolves: toResolve,
+        },
+      )
       // Open a review round if the publisher asked for one (the /derive loop). The
       // reviewer is the human behind the publish (onBehalf covers both a session
       // user and an agent's registrant); falls back to the workspace's first owner
@@ -1319,19 +1283,17 @@ export const artifactRoutes = (ctx: AppContext) => {
         message: `Restored v${src.n}`,
         name: null,
       })
-      await notify(artifact, "version.published", {
-        version: version.n,
-        message: version.message,
-        author: version.author,
-      })
-      notifyRender(artifact, version.n)
-      bus.publish(artifact.id, {
-        type: "version.published",
-        n: version.n,
-        message: version.message,
-      })
-      // Restoring an old blob is a content change too — re-anchor threads against it.
-      await publishSweepEvents(meta, blobs, bus, artifact.id, version)
+      // A restore is a version bump too: same webhook + realtime + re-anchor as a publish,
+      // but never a new artifact, so no follower fan-out and no thread resolves.
+      await afterPublish(
+        { meta, blobs, bus, notify, notifyRender, background },
+        artifact,
+        version,
+        {
+          isNew: false,
+          onBehalf: null,
+        },
+      )
       const fresh = (await meta.getByShortId(artifact.short_id)) as ArtifactRecord
       const versions = await meta.listVersions(artifact.id)
       return c.json(

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -334,6 +334,7 @@ export const syncRoutes = (ctx: AppContext) => {
   const { upsertPrPreview, previewCommentBody, removePrPreview, graduatePreview } = makePrPreview({
     meta,
     blobs: deps.blobs,
+    bus,
     baseUrl: deps.baseUrl,
     launch,
   })

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -337,6 +337,38 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(read).not.toContain("\\n")
   })
 
+  it("publish fires the version.published webhook — parity with the HTTP route", async () => {
+    // The bug this guards against: an MCP publish that skips the webhook outbox because its
+    // side-effect chain drifted from the HTTP route's. Both now share lib/after-publish.ts.
+    const { app, token, meta } = appWithGrant("mcpwebhook", "openid derive:read derive:publish")
+    await rpc(app, token, initBody)
+    // Publish once to discover the agent's workspace, subscribe a webhook there, then
+    // republish — the republish is the event we assert reaches the outbox.
+    const first = await call(app, token, "publish", { title: "Hook Me", content: "<h1>v1</h1>" })
+    const shortId = JSON.parse(toolText(first)).short_id as string
+    const art = await meta.getByShortId(shortId)
+    if (!art) throw new Error("published artifact not found")
+    await meta.createWebhook({
+      id: "wh_mcp",
+      org_id: art.org_id,
+      url: "http://example.com/hook",
+      secret: "s",
+      kind: "generic",
+      events: "version.published",
+    })
+    await call(app, token, "publish", { short_id: shortId, content: "<h1>v2</h1>", message: "v2" })
+
+    const due = await meta.claimDueDeliveries(
+      new Date(Date.now() + 1000).toISOString(),
+      10,
+      new Date(Date.now() + 60_000).toISOString(),
+    )
+    const forThis = due.filter((d) => JSON.parse(d.payload).artifact.short_id === shortId)
+    expect(forThis.length).toBe(1)
+    expect(forThis[0]?.event_type).toBe("version.published")
+    expect(forThis[0]?.url).toBe("http://example.com/hook")
+  })
+
   it("catch_up reports what changed, with the line diff folded in", async () => {
     const { app, token } = appWithGrant("catchup", "openid derive:read derive:publish")
     const shortId = (await (await publish(app, token, "V1 Title")).json()).short_id

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -7,6 +7,16 @@ compatibility_date = "2024-11-01"
 # (GOOGLE_*, GITHUB_LOGIN_*, OIDC_*) there, same as on Node.
 compatibility_flags = ["nodejs_compat", "nodejs_compat_populate_process_env"]
 
+# Workers Logs: persist + index every invocation's structured logs (queryable in the
+# dashboard; retention per plan). Without this block console output is live-tail-only
+# and "what happened yesterday" is unanswerable. log.ts emits JSON on workerd, so
+# request_id / duration_ms / actor index as fields. Sample everything — volume is
+# modest, and a sampled-away incident costs more than the log spend. Longer retention
+# → add a Logpush job to a dedicated R2 bucket (NOT derive-blobs).
+[observability]
+enabled = true
+head_sampling_rate = 1
+
 [[d1_databases]]
 binding = "DB"
 database_name = "derive"

--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -58,6 +58,7 @@ export function CommandPalette() {
       api
         .listArtifacts({ q: query.trim() || undefined, limit: 8 })
         .then((r) => alive && setResults(r.artifacts))
+        // frontend-ignore: debounced typeahead — clearing on an aborted/failed keystroke is intended, not a hidden load failure
         .catch(() => alive && setResults([]))
         .finally(() => alive && setLoading(false))
     }, 180)
@@ -83,6 +84,7 @@ export function CommandPalette() {
       api
         .searchPeople(term)
         .then((r) => alive && setPeople(r.users))
+        // frontend-ignore: debounced typeahead — clearing on an aborted/failed keystroke is intended, not a hidden load failure
         .catch(() => alive && setPeople([]))
         .finally(() => alive && setPeopleLoading(false))
     }, 180)

--- a/apps/web/src/components/shared/person-search-input.tsx
+++ b/apps/web/src/components/shared/person-search-input.tsx
@@ -50,6 +50,7 @@ export function PersonSearchInput({
             setActive(-1)
           }
         })
+        // frontend-ignore: debounced typeahead — clearing on an aborted/failed keystroke is intended, not a hidden load failure
         .catch(() => alive && setSuggest([]))
     }, 180)
     return () => {

--- a/apps/web/src/pages/artifact/insights-history.tsx
+++ b/apps/web/src/pages/artifact/insights-history.tsx
@@ -98,12 +98,14 @@ export function Insights({
   onOpenChange: (open: boolean) => void
 }) {
   const [data, setData] = useState<Analytics | null>(null)
+  const [failed, setFailed] = useState(false)
   useEffect(() => {
     if (open && !data)
       api
         .analytics(shortId)
         .then(setData)
-        .catch(() => {})
+        // Without this a failed load shows the loading skeleton forever — say it failed.
+        .catch(() => setFailed(true))
   }, [open, data, shortId])
 
   const max = data ? Math.max(1, ...data.daily.map((d) => d.count)) : 1
@@ -119,7 +121,13 @@ export function Insights({
           <DialogTitle>Insights{title ? ` · ${title}` : ""}</DialogTitle>
         </DialogHeader>
         {!data ? (
-          <InsightsSkeleton />
+          failed ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              Couldn't load insights. Close and reopen to try again.
+            </div>
+          ) : (
+            <InsightsSkeleton />
+          )
         ) : (
           <div className="flex flex-col gap-5">
             <div className="flex flex-wrap items-end gap-6">

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -334,7 +334,8 @@ export function ShareButton({
         setMembers(r.members)
         setInvites(r.invites)
       })
-      .catch(() => {})
+      // A failed load must not read as "no one has access" — say so instead of blanking.
+      .catch(() => toast.error("Couldn't load who has access"))
   // After a share change, refresh the local list AND the shared cache: the artifact
   // query holds `my_role` (drives the toolbar), and the library reflects access.
   const synced = async () => {

--- a/scripts/check-api.mjs
+++ b/scripts/check-api.mjs
@@ -1,14 +1,25 @@
 #!/usr/bin/env node
-// Backend convention guardrails. Today: route handlers return errors through the
-// shared `fail(c, status, message)` helper (apps/api/src/lib/http.ts), never a
-// bare `c.json({ error }, status)`, so the error contract lives in one place.
-// Runs in the CI gate. Escape hatch: an `api-ignore` comment on the line.
+// Backend convention guardrails, run in the CI gate. Escape hatch on any flagged line: an
+// `api-ignore` comment.
+//
+//  1. ROUTE error contract — handlers return errors through the shared `fail(c, status,
+//     message)` helper (apps/api/src/lib/http.ts), never a bare `c.json({ error }, status)`,
+//     and validate bodies with `readJson(c, schema)`, never a raw `c.req.json()` cast.
+//
+//  2. PUBLISH orchestration — the "a new version went live" side-effect chain (the
+//     `version.published` realtime event and the follower fan-out) is constructed in exactly
+//     ONE place, apps/api/src/lib/after-publish.ts. Every publish path (HTTP route, MCP tool,
+//     restore, proposal-approve) must route through `afterPublish` / `emitVersionBump`. This
+//     is here because it already went wrong once: an MCP publish silently skipped webhooks
+//     and the realtime event because the sequence was hand-copied and drifted.
 import { readdirSync, readFileSync, statSync } from "node:fs"
 import { join, relative } from "node:path"
 
-const ROUTES = join(process.cwd(), "apps/api/src/routes")
+const API_SRC = join(process.cwd(), "apps/api/src")
+const ROUTES = join(API_SRC, "routes")
 
-const RULES = [
+// Scoped to routes/: the error-response contract.
+const ROUTE_RULES = [
   {
     re: /c\.json\(\{\s*error/,
     msg: "return errors via fail(c, status, message) (lib/http.ts), not a bare c.json({ error })",
@@ -19,47 +30,70 @@ const RULES = [
   },
 ]
 
+// Scoped to all of apps/api/src EXCEPT the one sanctioned home: publish orchestration.
+// `\btype:` deliberately does not match `event_type:` (a webhook row column).
+const ORCHESTRATION_HOME = join(API_SRC, "lib/after-publish.ts")
+const ORCHESTRATION_RULES = [
+  {
+    re: /\btype:\s*["']version\.published["']/,
+    msg: "emit the version.published bus event via afterPublish/emitVersionBump (lib/after-publish.ts), not inline — every publish path must share the one side-effect chain",
+  },
+  {
+    re: /\bkind:\s*["']publish["']/,
+    msg: "the publisher→follower fan-out lives only in lib/after-publish.ts; call afterPublish instead of re-inlining the notification",
+  },
+]
+
 const stripIgnorable = (line) => line.replace(/\/\/.*$/, "").replace(/\/\*.*?\*\//g, "")
 
 const walk = (dir, out = []) => {
   for (const name of readdirSync(dir)) {
     const full = join(dir, name)
     if (statSync(full).isDirectory()) walk(full, out)
-    else if (name.endsWith(".ts")) out.push(full)
+    else if (name.endsWith(".ts") && !name.endsWith(".test.ts")) out.push(full)
   }
   return out
 }
 
-const violations = []
-for (const file of walk(ROUTES)) {
-  const rel = relative(ROUTES, file)
-  readFileSync(file, "utf8")
-    .split("\n")
-    .forEach((raw, i) => {
-      if (raw.includes("api-ignore")) return
-      const line = stripIgnorable(raw)
-      for (const rule of RULES) {
-        const m = rule.re.exec(line)
-        if (m)
-          violations.push({
-            rel,
-            line: i + 1,
-            col: m.index + 1,
-            snippet: m[0].trim(),
-            msg: rule.msg,
-          })
-      }
-    })
+const scan = (files, rules, skip = () => false) => {
+  const hits = []
+  for (const file of files) {
+    if (skip(file)) continue
+    readFileSync(file, "utf8")
+      .split("\n")
+      .forEach((raw, i) => {
+        if (raw.includes("api-ignore")) return
+        const line = stripIgnorable(raw)
+        for (const rule of rules) {
+          const m = rule.re.exec(line)
+          if (m)
+            hits.push({
+              rel: relative(API_SRC, file),
+              line: i + 1,
+              col: m.index + 1,
+              snippet: m[0].trim(),
+              msg: rule.msg,
+            })
+        }
+      })
+  }
+  return hits
 }
 
+const allFiles = walk(API_SRC)
+const violations = [
+  ...scan(walk(ROUTES), ROUTE_RULES),
+  ...scan(allFiles, ORCHESTRATION_RULES, (f) => f === ORCHESTRATION_HOME),
+]
+
 if (violations.length === 0) {
-  console.log("api: ok — every route error goes through fail()")
+  console.log("api: ok — error contract via fail(); publish side-effects via after-publish.ts")
   process.exit(0)
 }
 
-console.error(`api: ${violations.length} ad-hoc error response(s)\n`)
+console.error(`api: ${violations.length} convention violation(s)\n`)
 for (const v of violations) {
-  console.error(`  apps/api/src/routes/${v.rel}:${v.line}:${v.col}  ${v.snippet}`)
+  console.error(`  apps/api/src/${v.rel}:${v.line}:${v.col}  ${v.snippet}`)
   console.error(`    → ${v.msg}`)
 }
 process.exit(1)

--- a/scripts/check-frontend.mjs
+++ b/scripts/check-frontend.mjs
@@ -15,6 +15,15 @@ const RULES = [
     re: /\b(?:local|session)Storage\.(?:get|set|remove)Item\(\s*["'`]/,
     msg: "storage key must come from STORAGE_KEYS (lib/storage-keys.ts), not a string literal",
   },
+  {
+    // A load that catches its error into an empty array renders "request failed" as
+    // "zero items" — the blank-list-means-broken bug. Surface an error state (or use
+    // React Query's error state via lib/queries.ts) instead of swallowing to []. A
+    // debounced search that intentionally clears on an aborted keystroke is the one
+    // legitimate case: annotate it with `frontend-ignore` and a reason.
+    re: /\.catch\(\(\)\s*=>\s*(?:[\w.]+\s*&&\s*)?set\w*\(\s*\[\s*\]\s*\)/,
+    msg: "a failed load is not an empty result — surface an error state, don't .catch(() => setX([]))",
+  },
 ]
 
 const stripIgnorable = (line) => line.replace(/\/\/.*$/, "").replace(/\/\*.*?\*\//g, "")
@@ -35,23 +44,24 @@ const violations = []
 for (const file of walk(WEB_SRC)) {
   const rel = relative(WEB_SRC, file)
   if (rel === STORAGE_KEYS_FILE) continue
-  readFileSync(file, "utf8")
-    .split("\n")
-    .forEach((raw, i) => {
-      if (raw.includes("frontend-ignore")) return
-      const line = stripIgnorable(raw)
-      for (const rule of RULES) {
-        const m = rule.re.exec(line)
-        if (m)
-          violations.push({
-            rel,
-            line: i + 1,
-            col: m.index + 1,
-            snippet: m[0].trim(),
-            msg: rule.msg,
-          })
-      }
-    })
+  const lines = readFileSync(file, "utf8").split("\n")
+  lines.forEach((raw, i) => {
+    // A `frontend-ignore` on the flagged line OR the line just above suppresses it
+    // (biome-ignore style), so the reason can sit on its own comment line.
+    if (raw.includes("frontend-ignore") || lines[i - 1]?.includes("frontend-ignore")) return
+    const line = stripIgnorable(raw)
+    for (const rule of RULES) {
+      const m = rule.re.exec(line)
+      if (m)
+        violations.push({
+          rel,
+          line: i + 1,
+          col: m.index + 1,
+          snippet: m[0].trim(),
+          msg: rule.msg,
+        })
+    }
+  })
 }
 
 if (violations.length === 0) {


### PR DESCRIPTION
## What this is

A tech-debt paydown pass on the publish/side-effect layer, plus two custom guard lints so the debt can't silently recur. Grew out of a full-repo debt survey ([Derive doc](https://derive.to/artifacts/tech-debt-paydown-plan-july-2026-w8rjylx2)).

**Important:** the survey was taken against an older commit and much of the original plan was already merged on `main` (the MCP-publish webhook bug was already fixed; `isMember`, `makePrPreview`, `useApiMutation`, and the `lint:mutations`/`lint:surfaces` guards already exist). So this PR does **not** re-fix fixed things — it's the genuinely-remaining work: regression-prevention consolidation and a couple of real "load fails → renders blank" spots.

## Commits

1. **`refactor(api)` — one `afterPublish` helper for every publish path.** The "a new version went live" chain (`version.published` bus event, webhook, preview render, follower fan-out, thread re-anchor sweep) was consistent but hand-copied across HTTP publish, HTTP restore, MCP publish, and proposal-approve — the exact shape that drifted once before (an MCP publish silently skipping webhooks). Consolidated into `apps/api/src/lib/after-publish.ts` (`emitVersionBump` core + `afterPublish`). Side benefit: an MCP publish of a new *public* artifact now fans out to the acting human's followers, matching the HTTP route.

2. **`fix(web)` — surface failed loads instead of blanking.** The share dialog's member list and the insights popover swallowed load errors into a blank/skeleton view (looked like "no one has access" / stuck loading). Both now say the load failed.

3. **`fix(api)` — emit sweep events when a merged PR graduates.** `foldIntoCanonical` re-anchored the canonical doc's threads state-only (`sweepAnchors`), so a tab open on the canonical doc kept stale thread states after a PR merged. Now uses `publishSweepEvents` like every other version-bump path.

## Custom guard lints (the "protect from happening again" ask)

- **`lint:api`** now forbids constructing a raw `version.published` bus event or the follower fan-out anywhere but `after-publish.ts` — every publish path must share the one chain.
- **`lint:frontend`** now forbids `.catch(() => setX([]))` (a failed load is not an empty list). Debounced typeahead, where clearing on an aborted keystroke is intended, is annotated as the one legitimate exception.

Both were negative-tested (throwaway violation files confirmed they fire).

## Testing (local)

- `pnpm typecheck` (tsgo, incl. the Workers config): clean.
- `pnpm test`: **api 873, web 146, db 191, storage 16, mcp 19 — all pass**, including a new integration test that drives the real MCP JSON-RPC `publish` and asserts a `version.published` webhook delivery lands (parity with the HTTP route — the original bug class).
- Full lint gate (biome + all `lint:*` + knip + boundaries): green. The two `noUnusedImports` warnings in `workspace.ts` are pre-existing on `main`, non-blocking, and untouched here.

## Deliberately not in this PR

The store-dialect merge and `MetaStore` split (explicit non-goals). The share-dialog split (WP5) and CRUD-section generalization (WP4) are optional polish with real regression surface — deferred rather than rushed, since the mutation/error-surface guardrails they'd protect already exist on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)