### PR TITLE
Skills across Derive: Brandprint made of skills, end to end

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2132,6 +2132,50 @@
           "ask_policy"
         ]
       },
+      "BrandprintConfig": {
+        "type": "object",
+        "properties": {
+          "profile_short_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "The workspace brand-profile artifact (an HTML page carrying theme tokens), when set; null otherwise. Not in `members` — it is the headline read, not a note."
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "short_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "version": {
+                  "type": "number",
+                  "description": "The member's current version at fetch time (provenance)."
+                },
+                "is_skill": {
+                  "type": "boolean",
+                  "description": "A skill bundle (materialize into skills/) vs a prose note."
+                }
+              },
+              "required": [
+                "short_id",
+                "title",
+                "version",
+                "is_skill"
+              ]
+            },
+            "description": "Convention artifacts: skills to materialize, notes to read. Excludes the profile."
+          }
+        },
+        "required": [
+          "profile_short_id",
+          "members"
+        ]
+      },
       "Session": {
         "type": "object",
         "properties": {
@@ -6267,6 +6311,9 @@
                         "manifest_md": {
                           "type": "string",
                           "nullable": true
+                        },
+                        "brandprint": {
+                          "$ref": "#/components/schemas/BrandprintConfig"
                         }
                       }
                     }

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -343,21 +343,28 @@ async function buildServer(
       mimeType: "text/markdown" as const,
     }
     if (doc.current_content_type !== SKILL_CONTENT_TYPE) return generic
-    const v = await ctx.meta.getVersion(doc.id, doc.current_version)
-    const manifest = v ? await manifestOf(ctx, v) : null
-    const entry = v ? await ctx.sourceText(v) : null // the SKILL.md, frontmatter intact
-    if (!manifest || entry === null) return generic // never throw during connect
-    const info = bundleDoc(manifest, entry)
-    const others = info.files.map((f) => f.path).filter((p) => p !== info.entry)
-    const footer = others.length
-      ? `\n\n---\nOther files in this skill — read them with the read tool ` +
-        `(read short_id:"${doc.short_id}" section:"${others[0]}"): ${others.join(", ")}`
-      : ""
-    return {
-      title: info.name ?? doc.title ?? doc.short_id,
-      description: info.description ?? GENERIC_CONVENTION,
-      mimeType: "text/markdown",
-      body: parseFrontmatter(entry).body + footer,
+    // This runs at CONNECT (to surface the skill's frontmatter identity), so a read
+    // failure here must NEVER break the whole connection — fall back to the generic
+    // descriptor + the lazy body path, exactly as a non-skill member behaves.
+    try {
+      const v = await ctx.meta.getVersion(doc.id, doc.current_version)
+      const manifest = v ? await manifestOf(ctx, v) : null
+      const entry = v ? await ctx.sourceText(v) : null // the SKILL.md, frontmatter intact
+      if (!manifest || entry === null) return generic
+      const info = bundleDoc(manifest, entry)
+      const others = info.files.map((f) => f.path).filter((p) => p !== info.entry)
+      const footer = others.length
+        ? `\n\n---\nOther files in this skill — read them with the read tool ` +
+          `(read short_id:"${doc.short_id}" section:"${others[0]}"): ${others.join(", ")}`
+        : ""
+      return {
+        title: info.name ?? doc.title ?? doc.short_id,
+        description: info.description ?? GENERIC_CONVENTION,
+        mimeType: "text/markdown",
+        body: parseFrontmatter(entry).body + footer,
+      }
+    } catch {
+      return generic
     }
   }
 

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -25,6 +25,7 @@ import {
   artifactUrl,
   type BundleManifest,
   brandprintInstructions,
+  bundleDoc,
   capRole,
   diffLines,
   EditError,
@@ -38,12 +39,14 @@ import {
   PublishError,
   pageText,
   parseBrandprint,
+  parseFrontmatter,
   profileState,
   propose as proposeChange,
   publish as publishVersion,
   type Role,
   resolveBrandprint,
   roleAllows,
+  SKILL_CONTENT_TYPE,
   sectionOf,
   toMarkdown,
   type VersionRecord,
@@ -165,6 +168,10 @@ const summarizeArtifact = (a: ArtifactRecord) => ({
   short_id: a.short_id,
   title: a.title,
   kind: a.kind,
+  // Skill-ness rides the denormalized content type — a skill is a bundle, so `kind`
+  // alone can't distinguish it from a docs/site bundle. Surfaced so an agent can spot
+  // reusable procedure without opening each bundle.
+  is_skill: a.current_content_type === SKILL_CONTENT_TYPE,
   version: a.current_version,
   workspace_access: a.workspace_access,
   link_role: a.link_role,
@@ -318,19 +325,59 @@ async function buildServer(
     },
   )
 
-  // Brandprint conventions as resources: derive://brandprint/<short_id>, bodies fetched
-  // lazily (the current version's text). audience:["assistant"], context for the agent.
+  const GENERIC_CONVENTION = "A Brandprint convention: how this workspace likes its stuff built."
+
+  // A Brandprint member's resource shape. A SKILL bundle carries its own identity in
+  // SKILL.md frontmatter — name + description ARE progressive disclosure, so they must
+  // reach the resource list (not a generic label), and its auxiliary files (scripts/,
+  // references/) are announced so the agent knows to `read` them. Reading the skill's
+  // entry at connect is what surfaces that identity; a plain doc reads nothing here and
+  // keeps loading its body lazily on read. `body` set ⇒ prepared at connect (skill:
+  // frontmatter stripped, file footer appended); undefined ⇒ fetched lazily below.
+  const brandprintMember = async (
+    doc: ArtifactRecord,
+  ): Promise<{ title: string; description: string; mimeType: "text/markdown"; body?: string }> => {
+    const generic = {
+      title: doc.title ?? doc.short_id,
+      description: GENERIC_CONVENTION,
+      mimeType: "text/markdown" as const,
+    }
+    if (doc.current_content_type !== SKILL_CONTENT_TYPE) return generic
+    const v = await ctx.meta.getVersion(doc.id, doc.current_version)
+    const manifest = v ? await manifestOf(ctx, v) : null
+    const entry = v ? await ctx.sourceText(v) : null // the SKILL.md, frontmatter intact
+    if (!manifest || entry === null) return generic // never throw during connect
+    const info = bundleDoc(manifest, entry)
+    const others = info.files.map((f) => f.path).filter((p) => p !== info.entry)
+    const footer = others.length
+      ? `\n\n---\nOther files in this skill — read them with the read tool ` +
+        `(read short_id:"${doc.short_id}" section:"${others[0]}"): ${others.join(", ")}`
+      : ""
+    return {
+      title: info.name ?? doc.title ?? doc.short_id,
+      description: info.description ?? GENERIC_CONVENTION,
+      mimeType: "text/markdown",
+      body: parseFrontmatter(entry).body + footer,
+    }
+  }
+
+  // Brandprint conventions as resources: derive://brandprint/<short_id>. A plain doc's
+  // body is fetched lazily (the current version's text); a skill's is prepared at connect
+  // (we read its entry anyway to surface the frontmatter identity). audience:["assistant"].
   for (const doc of bpSources) {
+    const m = await brandprintMember(doc)
     server.registerResource(
       `brandprint:${doc.short_id}`,
       `derive://brandprint/${doc.short_id}`,
       {
-        title: doc.title ?? doc.short_id,
-        description: "A Brandprint convention: how this workspace likes its stuff built.",
-        mimeType: "text/markdown",
+        title: m.title,
+        description: m.description,
+        mimeType: m.mimeType,
         annotations: { audience: ["assistant"], priority: 0.9 },
       },
       async (uri) => {
+        if (m.body !== undefined)
+          return { contents: [{ uri: uri.href, mimeType: m.mimeType, text: m.body }] }
         const art = await ctx.meta.getByShortId(doc.short_id)
         const v = art ? await ctx.meta.getVersion(art.id, art.current_version) : null
         const body = v ? await ctx.sourceText(v) : null
@@ -506,13 +553,17 @@ async function buildServer(
     "list_artifacts",
     {
       description:
-        "List the artifacts (docs, plans, sites) in a workspace — short id, title, kind, current version, access (workspace_access/link_role/listed). Defaults to your current workspace; pass `workspace` (id or name from list_workspaces) to list another one. Includes your own unlisted publishes — out of the shared library, but you always find your work. Start here to find what to work on, then catch_up or read it.",
+        "List the artifacts (docs, plans, sites, skills) in a workspace — short id, title, kind, is_skill, current version, access (workspace_access/link_role/listed). Defaults to your current workspace; pass `workspace` (id or name from list_workspaces) to list another one. Pass skills:true to list only skills (reusable agent procedure). Includes your own unlisted publishes — out of the shared library, but you always find your work. Start here to find what to work on, then catch_up or read it.",
       inputSchema: {
         query: z.string().optional().describe("Optional title search filter."),
+        skills: z
+          .boolean()
+          .optional()
+          .describe("Only list skills (bundles with a SKILL.md — reusable agent procedure)."),
         workspace: wsArg,
       },
     },
-    async ({ query, workspace }) => {
+    async ({ query, skills, workspace }) => {
       const t = await resolveWs(workspace)
       if ("error" in t) return err(t.error)
       // viewerId keeps private rows scoped to the agent's human (mirrors `reach`) —
@@ -523,7 +574,10 @@ async function buildServer(
         q: query,
         viewerId: actingFor?.id ?? agent.id,
       })
-      return json({ workspace: t.org, count: arts.length, artifacts: arts.map(summarizeArtifact) })
+      // Skill-ness isn't a store-level filter (it's the denormalized content type), so
+      // narrow here — a title `query` still composes with it.
+      const rows = skills ? arts.filter((a) => a.current_content_type === SKILL_CONTENT_TYPE) : arts
+      return json({ workspace: t.org, count: rows.length, artifacts: rows.map(summarizeArtifact) })
     },
   )
 

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -2,9 +2,12 @@ import {
   type ContextAskerRecord,
   type ContextRecord,
   newId,
+  parseBrandprint,
+  resolveBrandprint,
   type SessionMessageRecord,
   type SessionRecord,
   type SessionState,
+  SKILL_CONTENT_TYPE,
   type UserDir,
 } from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
@@ -66,6 +69,37 @@ export const contextRoutes = (ctx: AppContext) => {
         ),
     })
     .openapi("ContextInfo")
+
+  // The resolved Brandprint handed to the context's runner (agent branch of GET only).
+  // The runner materializes skill members into its skills dir and reads notes + theme;
+  // it is the runner's ONLY window into workspace conventions — a context has no other
+  // config channel. Members are the workspace + owner-profile collection artifacts, deduped.
+  const BrandprintConfig = z
+    .object({
+      profile_short_id: z
+        .string()
+        .nullable()
+        .describe(
+          "The workspace brand-profile artifact (an HTML page carrying theme tokens), when set; null otherwise. Not in `members` — it is the headline read, not a note.",
+        ),
+      members: z
+        .array(
+          z.object({
+            short_id: z.string(),
+            title: z.string().nullable(),
+            version: z
+              .number()
+              .describe("The member's current version at fetch time (provenance)."),
+            is_skill: z
+              .boolean()
+              .describe("A skill bundle (materialize into skills/) vs a prose note."),
+          }),
+        )
+        .describe(
+          "Convention artifacts: skills to materialize, notes to read. Excludes the profile.",
+        ),
+    })
+    .openapi("BrandprintConfig")
 
   // The runner's structured payload on an agent message (parsed server-side).
   const SessionMeta = z
@@ -182,6 +216,43 @@ export const contextRoutes = (ctx: AppContext) => {
     return manifest ? { context: x, manifest } : null
   }
 
+  // Resolve the context's Brandprint: the workspace conventions merged with the
+  // context CREATOR's personal ones (profile wins) — the same resolution mcp.ts does
+  // for a connected agent, but keyed to the runner owner (created_by) rather than a
+  // live session user. Returns undefined when no Brandprint is set, so the field is
+  // simply omitted. A member the runner can't read still appears (it discovers the
+  // 404 at materialize time and reports it, mirroring a failed repo clone).
+  const resolveContextBrandprint = async (x: ContextRecord) => {
+    const wsBrandprint = (await meta.getOrgSettings(x.org_id)).brandprint
+    const profileBrandprint = parseBrandprint(await meta.getUserBrandprint(x.created_by))
+    const resolved = resolveBrandprint(wsBrandprint, profileBrandprint)
+    if (resolved.collectionIds.length === 0) return undefined
+    const seen = new Set<string>()
+    const members: {
+      short_id: string
+      title: string | null
+      version: number
+      is_skill: boolean
+    }[] = []
+    for (const collectionId of resolved.collectionIds) {
+      const ids = await meta.collectionArtifactIds(collectionId)
+      for (const a of ids.length ? await meta.listArtifacts({ ids }) : []) {
+        if (seen.has(a.short_id)) continue
+        seen.add(a.short_id)
+        // The brand profile rides in the collection but is not a note to materialize —
+        // it's the headline read, surfaced separately (mirrors mcp.ts's bpSources filter).
+        if (a.short_id === resolved.profileId) continue
+        members.push({
+          short_id: a.short_id,
+          title: a.title,
+          version: a.current_version,
+          is_skill: a.current_content_type === SKILL_CONTENT_TYPE,
+        })
+      }
+    }
+    return { profile_short_id: resolved.profileId ?? null, members }
+  }
+
   // Create a context: wire an agent to a manifest artifact. Editor+ in the
   // workspace, and share-standing on the manifest (creating a context exposes the
   // manifest's identity to askers, so it's a sharing decision). Who can ASK is a
@@ -287,6 +358,7 @@ export const contextRoutes = (ctx: AppContext) => {
               schema: ContextInfo.extend({
                 manifest_version: z.number().optional(),
                 manifest_md: z.string().nullable().optional(),
+                brandprint: BrandprintConfig.optional(),
               }),
             },
           },
@@ -306,13 +378,16 @@ export const contextRoutes = (ctx: AppContext) => {
       const allowed = agent ? agent.id === x.agent_id : await canAskContext(c, x)
       if (!allowed) return bail(fail(c, 404, "not found"))
       // The runner's one config fetch: its system prompt is the manifest's current
-      // source, so a manifest edit reconfigures the runner with no deploy.
+      // source, so a manifest edit reconfigures the runner with no deploy. The resolved
+      // Brandprint rides along here too — the runner's only window into workspace
+      // conventions (a context has no other config channel).
       if (agent && manifest) {
         const v = await meta.getVersion(manifest.id, manifest.current_version)
         return c.json({
           ...contextJson(x, manifest.short_id),
           manifest_version: manifest.current_version,
           manifest_md: v ? await sourceText(v) : null,
+          brandprint: await resolveContextBrandprint(x),
         })
       }
       return c.json(contextJson(x, manifest?.short_id ?? null))

--- a/apps/api/test/contexts.test.ts
+++ b/apps/api/test/contexts.test.ts
@@ -1,3 +1,4 @@
+import { zipSync } from "fflate"
 import { describe, expect, it } from "vitest"
 import { as, bearer, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 
@@ -514,5 +515,100 @@ describe("runner liveness: the queue poll stamps runner_seen_at, throttled", () 
     // Both user-facing reads carry the stamp (the console + directory render it).
     const list = await (await app.request("/v1/contexts", { headers: as(owner.email) })).json()
     expect(list.contexts[0].runner_seen_at).toBe(await seenAt())
+  })
+})
+
+// WP3: the runner's config fetch carries the resolved Brandprint — its only window
+// into workspace conventions. Agent-branch only; a human never sees runner config.
+describe("contexts: the config fetch carries the resolved Brandprint", () => {
+  const owner: TestUser = { id: "u_bp_own", email: "bpown@derive.test", name: "Owner" }
+  const { app, meta } = makeAuthedApp("contexts-brandprint", [owner], "editor")
+
+  const uploadZip = (files: Record<string, string>, headers: Record<string, string>) => {
+    const zipped = zipSync(
+      Object.fromEntries(
+        Object.entries(files).map(([k, v]) => [k, new TextEncoder().encode(v)] as const),
+      ),
+    )
+    const form = new FormData()
+    form.append("file", new Blob([zipped]), "skill.zip")
+    return app.request("/v1/artifacts", { method: "POST", body: form, headers })
+  }
+
+  it("agent GET carries skills + notes; human GET does not; unset omits it", async () => {
+    await app.request("/v1/me", { headers: as(owner.email) })
+    const ag = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Analyst", role: "editor" }))
+    ).json()
+    const manifestShortId = (await (await publishAs(app, "# Manifest", {}, as(owner.email))).json())
+      .short_id
+    const x = await (
+      await app.request(
+        "/v1/contexts",
+        jsonAs(as(owner.email), {
+          name: "Analytics",
+          agent_id: ag.id,
+          manifest_short_id: manifestShortId,
+        }),
+      )
+    ).json()
+
+    // Before any Brandprint is set, the agent config fetch omits the block entirely.
+    const bare = await (
+      await app.request(`/v1/contexts/${x.id}`, { headers: bearer(ag.token) })
+    ).json()
+    expect(bare.manifest_md).toContain("# Manifest")
+    expect(bare.brandprint).toBeUndefined()
+
+    // Seed a Brandprint: a prose note + a real skill bundle in one collection.
+    const noteId = (await (await publishAs(app, "# Voice\n\nBe warm.", {}, as(owner.email))).json())
+      .short_id
+    const skillId = (
+      await (
+        await uploadZip(
+          {
+            "SKILL.md":
+              "---\nname: chart-style\ndescription: House charts.\n---\n\n# Chart style\n",
+            "scripts/x.sh": "echo hi\n",
+          },
+          as(owner.email),
+        )
+      ).json()
+    ).short_id
+    const noteArt = await meta.getByShortId(noteId)
+    const skillArt = await meta.getByShortId(skillId)
+    if (!noteArt || !skillArt) throw new Error("no artifacts")
+    expect(skillArt.current_content_type).toBe("derive/skill")
+
+    const collectionId = "col_ctx_bp"
+    await meta.createCollection({
+      id: collectionId,
+      org_id: noteArt.org_id,
+      title: "Brandprint",
+      created_by: owner.id,
+    })
+    await meta.addCollectionItem(collectionId, noteArt.id)
+    await meta.addCollectionItem(collectionId, skillArt.id)
+    await meta.setOrgSettings(noteArt.org_id, {
+      ...(await meta.getOrgSettings(noteArt.org_id)),
+      brandprint: { collectionId },
+    })
+
+    // The agent config fetch now carries both members, the skill flagged, with versions.
+    const cfg = await (
+      await app.request(`/v1/contexts/${x.id}`, { headers: bearer(ag.token) })
+    ).json()
+    expect(cfg.brandprint.profile_short_id).toBeNull()
+    const member = (id: string) =>
+      cfg.brandprint.members.find((m: { short_id: string }) => m.short_id === id)
+    expect(member(noteId)).toMatchObject({ is_skill: false, version: 1 })
+    expect(member(skillId)).toMatchObject({ is_skill: true, version: 1 })
+
+    // The human branch (the creator can read it) never carries runner config.
+    const human = await (
+      await app.request(`/v1/contexts/${x.id}`, { headers: as(owner.email) })
+    ).json()
+    expect(human.brandprint).toBeUndefined()
+    expect(human.manifest_md).toBeUndefined()
   })
 })

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -207,6 +207,65 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(text).toContain("How we write Markdown")
   })
 
+  it("delivers a Brandprint SKILL member with its own name/description, stripped body, and file footer", async () => {
+    const { app, token, meta } = appWithGrant("bpskill", "openid derive:read derive:publish")
+    // A real skill bundle: SKILL.md entry (no html ⇒ derive/skill) plus an aux script.
+    const created = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          title: "ignored — frontmatter name wins",
+          files: {
+            "SKILL.md":
+              "---\nname: chart-style\ndescription: How this workspace builds charts.\n---\n\n# Chart style\n\nUse the house palette and Space Grotesk.\n",
+            "scripts/build.sh": "#!/usr/bin/env bash\necho chart\n",
+          },
+        }),
+      ),
+    )
+    const art = await meta.getByShortId(created.short_id)
+    if (!art) throw new Error("no artifact")
+    expect(art.current_content_type).toBe("derive/skill")
+
+    const collectionId = "col_bp_skill"
+    await meta.createCollection({
+      id: collectionId,
+      org_id: art.org_id,
+      title: "Brandprint",
+      created_by: "u_o",
+    })
+    await meta.addCollectionItem(collectionId, art.id)
+    await meta.setOrgSettings(art.org_id, {
+      ...(await meta.getOrgSettings(art.org_id)),
+      brandprint: { collectionId },
+    })
+
+    // The resource descriptor carries the skill's OWN identity, not a generic label.
+    const listed = await rpc(app, token, { jsonrpc: "2.0", id: 3, method: "resources/list" })
+    const resource = (
+      (
+        listed.parsed?.result as {
+          resources?: { uri: string; title?: string; description?: string }[]
+        }
+      )?.resources ?? []
+    ).find((r) => r.uri === `derive://brandprint/${created.short_id}`)
+    expect(resource?.title).toBe("chart-style")
+    expect(resource?.description).toBe("How this workspace builds charts.")
+
+    // The body is the SKILL.md sans frontmatter, plus a footer pointing at the aux files.
+    const read = await rpc(app, token, {
+      jsonrpc: "2.0",
+      id: 4,
+      method: "resources/read",
+      params: { uri: `derive://brandprint/${created.short_id}` },
+    })
+    const body = (read.parsed?.result as { contents?: { text: string }[] } | undefined)
+      ?.contents?.[0]?.text
+    expect(body).toContain("# Chart style")
+    expect(body).toContain("Use the house palette")
+    expect(body).not.toContain("name: chart-style") // frontmatter stripped
+    expect(body).toContain("scripts/build.sh") // aux files announced
+  })
+
   it("serves the build reference and a pending note while the profile is a stub", async () => {
     const { app, token, meta } = appWithGrant(
       "brandprint-pending",
@@ -335,6 +394,38 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(read).toContain("title: My Plan")
     expect(read).toContain("# My Plan")
     expect(read).not.toContain("\\n")
+  })
+
+  it("list_artifacts marks skills and filters to them with skills:true", async () => {
+    const { app, token } = appWithGrant("listskills", "openid derive:read derive:publish")
+    const doc = (await (await publish(app, token, "A plain doc")).json()).short_id
+    const skill = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          title: "A skill",
+          files: {
+            "SKILL.md": "---\nname: my-skill\ndescription: does a thing.\n---\n\n# My skill\n",
+          },
+        }),
+      ),
+    ).short_id
+
+    // Unfiltered: both present; is_skill distinguishes them.
+    const all = JSON.parse(toolText(await call(app, token, "list_artifacts")))
+    const rowOf = (id: string) =>
+      all.artifacts.find((a: { short_id: string }) => a.short_id === id) as
+        | { is_skill: boolean }
+        | undefined
+    expect(rowOf(skill)?.is_skill).toBe(true)
+    expect(rowOf(doc)?.is_skill).toBe(false)
+
+    // Filtered: only the skill.
+    const onlySkills = JSON.parse(
+      toolText(await call(app, token, "list_artifacts", { skills: true })),
+    )
+    const ids = onlySkills.artifacts.map((a: { short_id: string }) => a.short_id)
+    expect(ids).toContain(skill)
+    expect(ids).not.toContain(doc)
   })
 
   it("catch_up reports what changed, with the line diff folded in", async () => {

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -3698,6 +3698,7 @@ export interface paths {
                         "application/json": components["schemas"]["ContextInfo"] & {
                             manifest_version?: number;
                             manifest_md?: string | null;
+                            brandprint?: components["schemas"]["BrandprintConfig"];
                         };
                     };
                 };
@@ -5587,6 +5588,19 @@ export interface components {
              * @enum {string}
              */
             ask_policy: "workspace" | "invited";
+        };
+        BrandprintConfig: {
+            /** @description The workspace brand-profile artifact (an HTML page carrying theme tokens), when set; null otherwise. Not in `members` — it is the headline read, not a note. */
+            profile_short_id: string | null;
+            /** @description Convention artifacts: skills to materialize, notes to read. Excludes the profile. */
+            members: {
+                short_id: string;
+                title: string | null;
+                /** @description The member's current version at fetch time (provenance). */
+                version: number;
+                /** @description A skill bundle (materialize into skills/) vs a prose note. */
+                is_skill: boolean;
+            }[];
         };
         Session: {
             id: string;

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -99,6 +99,18 @@ export const brandprintDocsQuery = (collectionId: string) =>
       api.listArtifacts({ collection: collectionId, limit: 100 }).then((r) => r.artifacts),
   })
 
+// The active workspace's skills (bundles with a SKILL.md) — the shelf the Brandprint
+// "Add a skill" picker chooses from. Skill-ness rides the denormalized content type,
+// so this is a client-side narrow of the ordinary library listing.
+export const workspaceSkillsQuery = () =>
+  queryOptions({
+    queryKey: ["artifacts", "workspace-skills"] as const,
+    queryFn: () =>
+      api
+        .listArtifacts({ limit: 100 })
+        .then((r) => r.artifacts.filter((a) => a.current_content_type === "derive/skill")),
+  })
+
 // A small, flat slice of the Following feed — recent work from the people you follow —
 // for the "Recent activity" preview on the People tab. The full feed lives at /following
 // (the infinite libraryArtifactsQuery({ scope: "following" })); this is the peek.

--- a/apps/web/src/pages/brandprint/brandprint-section.tsx
+++ b/apps/web/src/pages/brandprint/brandprint-section.tsx
@@ -32,6 +32,7 @@ import {
   collectionsQuery,
   workspaceQuery,
   workspaceSettingsQuery,
+  workspaceSkillsQuery,
 } from "@/lib/queries"
 import { snapshot, useApiMutation } from "@/lib/use-api-mutation"
 import { refFor } from "../artifact/parse-ref"
@@ -315,6 +316,14 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
             </Button>
           </SettingRow>
           {collectionId && (
+            <SettingRow
+              label="Add a skill"
+              description="Put a published skill (how agents build things) into this Brandprint."
+            >
+              <AddSkill collectionId={collectionId} scope={scope} disabled={disabled} />
+            </SettingRow>
+          )}
+          {collectionId && (
             <BrandprintDocs
               collectionId={collectionId}
               scope={scope}
@@ -494,6 +503,65 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
 // so this list is its one home. Removing drops the doc from the collection; the
 // artifact itself lives on in the library. The brand-profile artifact rides in the
 // collection too but has its own home (the panel above), so it's not listed here.
+// The "Add a skill" picker: pick one of the workspace's skills into the Brandprint's
+// collection. Skills are ordinary artifacts, so this is add-to-collection — the same
+// endpoint the upload path uses — over the skill-filtered library listing.
+function AddSkill({
+  collectionId,
+  scope,
+  disabled,
+}: {
+  collectionId: string
+  scope: "workspace" | "account"
+  disabled: boolean
+}) {
+  const { data: skills, isError, refetch } = useQuery(workspaceSkillsQuery())
+  const addSkill = useApiMutation({
+    mutationFn: (shortId: string) => api.addToCollection(collectionId, shortId),
+    invalidate: [brandprintDocsQuery(collectionId).queryKey, collectionsQuery().queryKey],
+  })
+  if (isError)
+    return (
+      <p className="text-sm text-muted-foreground">
+        Couldn't load skills.{" "}
+        <Button
+          variant="link"
+          size="xs"
+          className="px-0"
+          data-testid={`brandprint-skills-retry-${scope}`}
+          onClick={() => refetch()}
+        >
+          Try again
+        </Button>
+      </p>
+    )
+  const available = skills ?? []
+  return (
+    <SelectMenu value="" onValueChange={(v) => v && addSkill.mutate(v)}>
+      <SelectMenuTrigger
+        aria-label="Add a skill"
+        data-testid={`brandprint-add-skill-${scope}`}
+        disabled={disabled || !skills || addSkill.isPending}
+      >
+        {!skills ? "Loading…" : addSkill.isPending ? "Adding…" : "Pick a skill"}
+      </SelectMenuTrigger>
+      <SelectMenuContent>
+        {available.length === 0 ? (
+          <SelectMenuItem value="" disabled>
+            No skills yet — publish one with `derive init --template skill`
+          </SelectMenuItem>
+        ) : (
+          available.map((s) => (
+            <SelectMenuItem key={s.short_id} value={s.short_id}>
+              {s.title ?? s.short_id}
+            </SelectMenuItem>
+          ))
+        )}
+      </SelectMenuContent>
+    </SelectMenu>
+  )
+}
+
 function BrandprintDocs({
   collectionId,
   scope,
@@ -547,6 +615,11 @@ function BrandprintDocs({
               >
                 {a.title ?? a.short_id}
               </Link>
+              {a.current_content_type === "derive/skill" && (
+                <Badge variant="secondary" shape="pill">
+                  Skill
+                </Badge>
+              )}
               <Button
                 variant="ghost"
                 size="icon-xs"

--- a/apps/web/src/pages/library/artifact-card.tsx
+++ b/apps/web/src/pages/library/artifact-card.tsx
@@ -235,6 +235,13 @@ export function ArtifactCard({
                 <Icon name="lock" size={12} /> Private
               </Badge>
             )}
+            {/* A skill is reusable agent procedure (a bundle with a SKILL.md) — call it
+                out wherever it surfaces so the shelf is spottable in the grid. */}
+            {a.current_content_type === "derive/skill" && (
+              <Badge shape="pill" variant="secondary" title="A skill: reusable agent procedure">
+                Skill
+              </Badge>
+            )}
             {/* Review queue, then discussion, then passive views — most-actionable first. */}
             <ProposalSignal artifact={a} size={12} />
             <CommentSignal artifact={a} size={12} compact />

--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -1171,7 +1171,9 @@ if (cmd === "brandprint") {
   const skills = []
   const notes = []
   for (const id of collectionIds) {
-    const page = await getJson(`/v1/artifacts?collection=${id}`)
+    // limit=100 is the endpoint's max; a curated Brandprint is far smaller, but cap
+    // explicitly rather than inherit the default 30 and silently drop members.
+    const page = await getJson(`/v1/artifacts?collection=${id}&limit=100`)
     for (const a of page?.artifacts ?? []) {
       if (seen.has(a.short_id)) continue
       seen.add(a.short_id)

--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -28,7 +28,7 @@
 //   derive context push|dev                ship a context dir as its manifest / tune it live
 import { spawn } from "node:child_process"
 import { createHash, randomBytes } from "node:crypto"
-import { existsSync, writeFileSync } from "node:fs"
+import { existsSync, readFileSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { createInterface } from "node:readline"
 import { fileURLToPath } from "node:url"
@@ -58,9 +58,12 @@ import {
   TEMPLATES,
   writeContextConfig,
   writeId,
+  writeSkillPin,
 } from "../src/config.js"
 import { createAgent, createContext, saveAgentToken } from "../src/context.js"
 import { readTarget, uploadArtifact } from "../src/publish.js"
+import { DeriveClient, parseManifest } from "../src/runner.js"
+import { materializeNotes, materializeSkills, pinManifestSkills } from "../src/skills.js"
 
 const args = process.argv.slice(2)
 const cmd = args.shift()
@@ -801,6 +804,35 @@ if (cmd === "context") {
       console.error("error: not signed in — run `derive login` first")
       process.exit(1)
     }
+    // Lockfile step: pin any unpinned `skills:` entry to its current version before the
+    // manifest ships, so the pushed config is deterministic and an upgrade is a visible,
+    // deliberate manifest edit (never a silent drift under a permission-skipping runner).
+    const manifestPath = join(target, "MANIFEST.md")
+    if (existsSync(manifestPath)) {
+      const text = readFileSync(manifestPath, "utf8")
+      const unpinned = parseManifest(text).skills.filter((s) => s.version == null)
+      if (unpinned.length) {
+        const versions = new Map()
+        for (const s of unpinned) {
+          try {
+            const detail = await (
+              await fetch(`${p.server}/v1/artifacts/${s.id}`, {
+                headers: { authorization: `Bearer ${p.token}` },
+              })
+            ).json()
+            if (Number.isFinite(detail?.current_version)) versions.set(s.id, detail.current_version)
+          } catch {
+            /* leave unpinned — the runner fetches current and logs it unpinned */
+          }
+        }
+        const { text: pinnedText, pinned } = pinManifestSkills(text, versions)
+        if (pinned.length) {
+          writeFileSync(manifestPath, pinnedText)
+          for (const pn of pinned) console.log(`  · pinned skill ${pn.id} → v${pn.version}`)
+        }
+      }
+    }
+
     let up
     try {
       // repos/ is the runner's clone workspace — pointer state, never source.
@@ -1037,6 +1069,129 @@ if (LOOP.includes(cmd)) {
   process.exit(0)
 }
 
+// ---- derive skill (add) -----------------------------------------------------
+// The consumption half of the skill loop: author with `init --template skill` +
+// `publish`, then INSTALL a published skill into ./.claude/skills/<name>/ where
+// this project's agent auto-discovers it. Pinned in derive.json so an update is a
+// deliberate `derive skill add` re-run, never silent drift.
+if (cmd === "skill") {
+  const sub = positional.shift()
+  const shortId = positional[0]
+  if (sub !== "add" || !shortId) {
+    console.error("usage: derive skill add <short_id>   materialize a skill into ./.claude/skills/")
+    process.exit(cmd ? 1 : 0)
+  }
+  let cfg = null
+  try {
+    cfg = loadConfig(".")
+  } catch {
+    /* no derive.json yet — the pin creates one */
+  }
+  const r = resolvePublish(flags, cfg)
+  r.token = flags.token ?? process.env.DERIVE_TOKEN ?? (await freshToken(r.server, r.accountId))
+  if (!r.token) {
+    console.error("error: not signed in — run `derive login` first")
+    process.exit(1)
+  }
+  const auth = {
+    authorization: `Bearer ${r.token}`,
+    ...(r.workspaceId ? { "x-derive-workspace": r.workspaceId } : {}),
+  }
+  const detail = await (await fetch(`${r.server}/v1/artifacts/${shortId}`, { headers: auth }))
+    .json()
+    .catch(() => null)
+  if (!detail?.current_version) {
+    console.error(`error: no such artifact ${shortId}`)
+    process.exit(1)
+  }
+  if (!detail.bundle?.isSkill) {
+    console.error(`error: ${shortId} is not a skill (a bundle with a SKILL.md)`)
+    process.exit(1)
+  }
+  const version = detail.current_version
+  const api = new DeriveClient(r.server, r.token).skillApi()
+  const cat = await materializeSkills(
+    api,
+    [{ id: shortId, version }],
+    join(".", ".claude", "skills"),
+  )
+  const done = cat.find((s) => s.ok)
+  if (!done) {
+    console.error("error: could not materialize the skill")
+    process.exit(1)
+  }
+  writeSkillPin(".", { id: shortId, version, name: done.name })
+  console.log(`✓ .claude/skills/${done.dir} — ${done.name} @v${version} (pinned in ${CONFIG_FILE})`)
+  process.exit(0)
+}
+
+// ---- derive brandprint (pull) -----------------------------------------------
+// Take the team's whole Brandprint into THIS repo in one command: skills into
+// .claude/skills/, prose notes into ./brandprint/. The workspace layer plus the
+// signed-in user's personal layer (profile wins), resolved the same way the server
+// does for a connected agent — but landed on disk for any repo, not just a runner.
+if (cmd === "brandprint") {
+  const sub = positional.shift()
+  if (sub !== "pull") {
+    console.error(
+      "usage: derive brandprint pull   materialize the workspace + your Brandprint here",
+    )
+    process.exit(cmd ? 1 : 0)
+  }
+  let cfg = null
+  try {
+    cfg = loadConfig(".")
+  } catch {
+    /* no derive.json — fine, we only read */
+  }
+  const r = resolvePublish(flags, cfg)
+  r.token = flags.token ?? process.env.DERIVE_TOKEN ?? (await freshToken(r.server, r.accountId))
+  if (!r.token) {
+    console.error("error: not signed in — run `derive login` first")
+    process.exit(1)
+  }
+  const auth = {
+    authorization: `Bearer ${r.token}`,
+    ...(r.workspaceId ? { "x-derive-workspace": r.workspaceId } : {}),
+  }
+  const getJson = async (path) =>
+    (await fetch(`${r.server}${path}`, { headers: auth })).json().catch(() => null)
+  // Resolve both layers' collection ids (workspace base, personal on top).
+  const ws = await getJson("/v1/workspace/settings")
+  const me = await getJson("/v1/me")
+  const collectionIds = [
+    ...new Set([ws?.brandprint?.collectionId, me?.brandprint?.collectionId].filter(Boolean)),
+  ]
+  if (collectionIds.length === 0) {
+    console.error("no Brandprint set on this workspace or your profile — nothing to pull")
+    process.exit(0)
+  }
+  // Gather members across the collections, deduped, split skills vs notes.
+  const seen = new Set()
+  const skills = []
+  const notes = []
+  for (const id of collectionIds) {
+    const page = await getJson(`/v1/artifacts?collection=${id}`)
+    for (const a of page?.artifacts ?? []) {
+      if (seen.has(a.short_id)) continue
+      seen.add(a.short_id)
+      if (a.current_content_type === "derive/skill")
+        skills.push({ id: a.short_id, version: a.current_version })
+      else notes.push({ short_id: a.short_id, title: a.title, version: a.current_version })
+    }
+  }
+  const api = new DeriveClient(r.server, r.token).skillApi()
+  const skillCat = await materializeSkills(api, skills, join(".", ".claude", "skills"))
+  const noteCat = await materializeNotes(api, notes, join(".", "brandprint"))
+  const okSkills = skillCat.filter((s) => s.ok).length
+  const okNotes = noteCat.filter((n) => n.ok).length
+  console.log(
+    `✓ pulled ${okSkills} skill${okSkills === 1 ? "" : "s"} into .claude/skills/ and ` +
+      `${okNotes} note${okNotes === 1 ? "" : "s"} into brandprint/`,
+  )
+  process.exit(0)
+}
+
 if (cmd !== "publish") {
   console.error(`usage:
   derive init [dir] [--template md|html|slides|site|skill|context] [--title t]
@@ -1066,7 +1221,9 @@ if (cmd !== "publish") {
   derive send-back [--id X] [--note m]     (human) return your answers to the waiting agent
   derive approve [--id X] [--note m]       (human) approve — the build go-signal
   derive runner serve|doctor|install       run a context's answer daemon (\`derive runner\` for flags)
-  derive context push|dev                  ship a context dir as its manifest / tune it on the working tree`)
+  derive context push|dev                  ship a context dir as its manifest / tune it on the working tree
+  derive skill add <short_id>              materialize a published skill into ./.claude/skills/ (pinned)
+  derive brandprint pull                   materialize the workspace + your Brandprint into this repo`)
   process.exit(cmd ? 1 : 0)
 }
 

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -582,6 +582,18 @@ export function writeContextConfig(dir, patch) {
   return config
 }
 
+/** Record (or replace) a skill pin in derive.json's top-level `skills` array — the
+ *  lockfile `derive skill add` maintains, so a later `update` is an explicit, diffable
+ *  act rather than silent drift. Same id ⇒ overwrite (a re-add repins). */
+export function writeSkillPin(dir, { id, version, name }) {
+  const path = join(dir, CONFIG_FILE)
+  const config = loadConfig(dir) ?? defaultConfig()
+  const kept = Array.isArray(config.skills) ? config.skills.filter((s) => s.id !== id) : []
+  config.skills = [...kept, { id, version, ...(name ? { name } : {}) }]
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`)
+  return config
+}
+
 // Each template's entry (what `derive publish` targets) + the starter file(s) it
 // writes. `site` is a multi-file bundle (entry is a directory). derive.json,
 // derive.schema.json, and AGENTS.md are added to every template.

--- a/packages/cli/src/runner.js
+++ b/packages/cli/src/runner.js
@@ -11,7 +11,12 @@
 import { spawn } from "node:child_process"
 import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs"
 import { dirname, join } from "node:path"
-import { conventionsBlock, materializeNotes, materializeSkills } from "./skills.js"
+import {
+  conventionsBlock,
+  materializeNotes,
+  materializeSkills,
+  mergeSkillLayers,
+} from "./skills.js"
 
 // ---- config -----------------------------------------------------------------
 
@@ -694,9 +699,12 @@ export async function serve(cfg) {
   const bpNotes = (bp?.members ?? [])
     .filter((mbr) => !mbr.is_skill)
     .map((mbr) => ({ short_id: mbr.short_id, title: mbr.title, version: mbr.version }))
+  // Dedup across the two layers: a skill named in BOTH the ambient Brandprint and the
+  // manifest's own `skills:` materializes ONCE (manifest pin wins), never twice under a
+  // collided dir.
   const skillCatalog = await materializeSkills(
     api,
-    [...bpSkills, ...boot.skills],
+    mergeSkillLayers(bpSkills, boot.skills),
     join(cfg.cwd, ".claude", "skills"),
   )
   const noteCatalog = await materializeNotes(api, bpNotes, join(cfg.cwd, "brandprint"))

--- a/packages/cli/src/runner.js
+++ b/packages/cli/src/runner.js
@@ -11,6 +11,7 @@
 import { spawn } from "node:child_process"
 import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs"
 import { dirname, join } from "node:path"
+import { conventionsBlock, materializeNotes, materializeSkills } from "./skills.js"
 
 // ---- config -----------------------------------------------------------------
 
@@ -117,6 +118,34 @@ export class DeriveClient {
     return res.json()
   }
 
+  // A raw GET (not JSON-parsed) — the content API returns file bytes/text, not JSON.
+  async callRaw(path) {
+    const res = await fetch(`${this.server}${path}`, {
+      signal: AbortSignal.timeout(30_000),
+      headers: { authorization: `Bearer ${this.token}` },
+    })
+    if (!res.ok) throw new Error(`${path} → ${res.status}`)
+    return res
+  }
+
+  /** The skills.js `api`: enumerate a bundle version, fetch one file (bytes, so binary
+   *  assets survive), and read a single-file doc's source — all pinned by version. */
+  skillApi() {
+    return {
+      outline: (id, version) => this.call(`/v1/artifacts/${id}/content?outline=1&v=${version}`),
+      file: async (id, path, version) =>
+        Buffer.from(
+          await (
+            await this.callRaw(
+              `/v1/artifacts/${id}/content?section=${encodeURIComponent(path)}&v=${version}`,
+            )
+          ).arrayBuffer(),
+        ),
+      content: async (id, version) =>
+        (await this.callRaw(`/v1/artifacts/${id}/content?v=${version}`)).text(),
+    }
+  }
+
   getContext(contextId) {
     return this.call(`/v1/contexts/${contextId}`)
   }
@@ -176,27 +205,41 @@ export class DeriveClient {
  *  manifest without frontmatter passes through untouched. */
 export function parseManifest(md) {
   const m = md.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/)
-  if (!m) return { body: md, repos: [] }
+  if (!m) return { body: md, repos: [], skills: [], brandprint: "live" }
   const unquote = (v) => {
     const t = v.trim()
     const q = t[0]
     return t.length >= 2 && (q === '"' || q === "'") && t.at(-1) === q ? t.slice(1, -1) : t
   }
   const repos = []
-  let inRepos = false
+  const skills = []
+  // Which list a `- item:` line belongs to; a top-level key line closes both.
+  let into = null // "repos" | "skills" | null
   let cur = null
+  let brandprint = "live" // ambient workspace conventions on by default
   for (const line of (m[1] ?? "").split(/\r?\n/)) {
     if (/^repos:\s*$/.test(line)) {
-      inRepos = true
+      into = "repos"
       continue
     }
-    if (inRepos && /^\S/.test(line)) inRepos = false // next top-level key
-    if (!inRepos) continue
+    if (/^skills:\s*$/.test(line)) {
+      into = "skills"
+      continue
+    }
+    // A top-level scalar: `brandprint: off` opts a context out of the ambient layer.
+    const bp = line.match(/^brandprint:\s*(\S+)/)
+    if (bp) {
+      into = null
+      brandprint = unquote(bp[1]) === "off" ? "off" : "live"
+      continue
+    }
+    if (into && /^\S/.test(line)) into = null // next top-level key
+    if (!into) continue
     const item = line.match(/^\s*-\s+(\w+):\s*(.+)$/)
     const kv = line.match(/^\s+(\w+):\s*(.+)$/)
     if (item) {
       cur = { [item[1]]: unquote(item[2]) }
-      repos.push(cur)
+      ;(into === "repos" ? repos : skills).push(cur)
     } else if (kv && cur) cur[kv[1]] = unquote(kv[2])
   }
   return {
@@ -206,6 +249,15 @@ export function parseManifest(md) {
         (r) => typeof r.url === "string" && /^(https:\/\/|ssh:\/\/|git@|file:\/\/)/.test(r.url),
       )
       .map((r) => ({ url: r.url, ref: r.ref ?? null, description: r.description ?? "" })),
+    // A skill needs an id; version is pinned by `derive context push`, but tolerate a
+    // hand-written manifest with none (current is fetched, logged unpinned).
+    skills: skills
+      .filter((s) => typeof s.id === "string" && s.id)
+      .map((s) => ({
+        id: s.id,
+        version: Number.isFinite(Number(s.version)) ? Number(s.version) : null,
+      })),
+    brandprint,
   }
 }
 
@@ -534,7 +586,7 @@ const MOCK_ANSWER = {
   artifact: null,
 }
 
-async function serveSession(client, session, manifest, cfg, repoMeta = []) {
+async function serveSession(client, session, manifest, cfg, repoMeta = [], skillMeta = []) {
   const asked = session.messages.at(-1)?.body_md?.slice(0, 80) ?? "?"
   console.log(`[runner] session ${session.id}: "${asked}"`)
   const result = cfg.mock
@@ -560,6 +612,9 @@ async function serveSession(client, session, manifest, cfg, repoMeta = []) {
     // Provenance: which corpus tips this answer was computed against — the
     // difference between "the data says X" and "the data as of ab12cd3 says X".
     ...(repoMeta.length ? { repos: repoMeta } : {}),
+    // And which skill versions were on disk for this run (the ambient Brandprint
+    // layer is live-at-boot, so its versions are only knowable per-run).
+    ...(skillMeta.length ? { skills: skillMeta } : {}),
     ...(a.escalate ? { escalation_reason: a.escalation_reason ?? "escalated" } : {}),
   }
   // Publish the answer's visual, if it produced one. A publish failure demotes
@@ -626,6 +681,29 @@ export async function serve(cfg) {
   const catalog = await syncRepos(boot.repos, cfg.cwd)
   const repoMeta = catalog.filter((r) => r.sha).map((r) => ({ url: r.url, sha: r.sha }))
 
+  // Conventions materialize at boot, like repos: the workspace Brandprint (ambient,
+  // unless `brandprint: off`) plus the manifest's own pinned skills. Skills land in
+  // .claude/skills/ (the spawned claude auto-discovers them); notes land in brandprint/.
+  // The Brandprint rides on the same config fetch as the manifest (info.brandprint) —
+  // the runner's only window into workspace settings.
+  const api = client.skillApi()
+  const bp = boot.brandprint !== "off" ? (info.brandprint ?? null) : null
+  const bpSkills = (bp?.members ?? [])
+    .filter((mbr) => mbr.is_skill)
+    .map((mbr) => ({ id: mbr.short_id, version: mbr.version }))
+  const bpNotes = (bp?.members ?? [])
+    .filter((mbr) => !mbr.is_skill)
+    .map((mbr) => ({ short_id: mbr.short_id, title: mbr.title, version: mbr.version }))
+  const skillCatalog = await materializeSkills(
+    api,
+    [...bpSkills, ...boot.skills],
+    join(cfg.cwd, ".claude", "skills"),
+  )
+  const noteCatalog = await materializeNotes(api, bpNotes, join(cfg.cwd, "brandprint"))
+  const conventions = conventionsBlock(skillCatalog, noteCatalog)
+  // Provenance, alongside the repo SHAs: which skill versions this run had on disk.
+  const skillMeta = skillCatalog.filter((s) => s.ok).map((s) => ({ id: s.id, version: s.version }))
+
   for (;;) {
     try {
       // An open session ending on an agent turn is one of two things: a settle
@@ -647,13 +725,13 @@ export async function serve(cfg) {
         const md = cfg.manifestFile
           ? readFileSync(cfg.manifestFile, "utf8")
           : ((await client.getContext(cfg.contextId)).manifest_md ?? info.manifest_md ?? "")
-        const manifest = parseManifest(md).body + repoCatalogBlock(catalog)
+        const manifest = parseManifest(md).body + repoCatalogBlock(catalog) + conventions
         // Sequential on purpose: one runner, one model, no fan-out — fairness
         // comes from the queue's oldest-first order. One session's failure must
         // not starve the rest of the batch.
         for (const s of sessions) {
           try {
-            await serveSession(client, s, manifest, cfg, repoMeta)
+            await serveSession(client, s, manifest, cfg, repoMeta, skillMeta)
           } catch (err) {
             console.error(`[runner] session ${s.id}: ${err.message}`)
           }

--- a/packages/cli/src/skills.js
+++ b/packages/cli/src/skills.js
@@ -1,0 +1,156 @@
+// Materializing Derive skill bundles (and Brandprint notes) onto disk. Shared by the
+// context runner (boot: pull the workspace Brandprint + the manifest's pinned skills
+// into .claude/skills/, where the spawned claude auto-discovers them) and the CLI
+// (`derive skill add` / `derive brandprint pull` into a repo). Pure of any Derive
+// client: callers pass a small `api` of three fetchers, so this module is unit-testable
+// against a mock and stays free of the @derive/core dependency (the CLI is standalone).
+//
+// The `api` contract (all keyed by short id + version):
+//   outline(id, version)  → { entry, pages: [{ path, type }] }   (bundle file tree)
+//   file(id, path, version) → bytes | string                     (one bundle file, raw)
+//   content(id, version)  → string                               (a single-file doc's source)
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+
+/** Read the frontmatter `name:` from a SKILL.md. Dependency-free (the CLI can't import
+ *  @derive/core's parseFrontmatter) and deliberately minimal: the leading `--- … ---`
+ *  block, first top-level `name:` scalar, quotes trimmed. null when absent. */
+export function skillNameFrom(skillMd) {
+  const s = String(skillMd ?? "")
+  const m = s.match(/^﻿?---[ \t]*\r?\n([\s\S]*?)\r?\n---/)
+  if (!m) return null
+  for (const line of m[1].split(/\r?\n/)) {
+    if (/^\s/.test(line)) continue // nested/indented — top-level scalars only
+    const kv = line.match(/^name:\s*(.+)$/)
+    if (kv) return kv[1].trim().replace(/^["']|["']$/g, "") || null
+  }
+  return null
+}
+
+/** A filesystem-safe directory/file stem. null when nothing usable survives. */
+export function skillSlug(name) {
+  const s = String(name ?? "")
+    .replace(/[^A-Za-z0-9._-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  return s || null
+}
+
+/** Fetch one pinned skill version's files WITHOUT writing them (so a caller can resolve
+ *  a collision-free directory name across the whole set before touching disk). Returns
+ *  { name, entry, files: Map<path, bytes> }; throws if the version has no readable tree. */
+export async function fetchSkill(api, { id, version }) {
+  const outline = await api.outline(id, version)
+  const pages = outline?.pages ?? []
+  if (pages.length === 0) throw new Error("no files in this version")
+  const entry = String(outline.entry ?? "SKILL.md").replace(/^\//, "")
+  const files = new Map()
+  for (const p of pages) {
+    const path = String(p.path).replace(/^\//, "")
+    files.set(path, await api.file(id, path, version))
+  }
+  return { name: skillNameFrom(files.get(entry)), entry, files }
+}
+
+/** Write a fetched skill under destRoot/<dir>/. A skills dir is DERIVED state (like the
+ *  runner's repos/), so it's replaced wholesale, never merged — a removed file at the
+ *  source must not linger on disk. */
+export function writeSkill(destRoot, dir, files) {
+  const root = join(destRoot, dir)
+  rmSync(root, { recursive: true, force: true })
+  for (const [path, bytes] of files) {
+    const dest = join(root, path)
+    mkdirSync(dirname(dest), { recursive: true })
+    writeFileSync(dest, bytes)
+  }
+}
+
+/** Materialize a set of pinned skills into destRoot, deduping directory names by short
+ *  id (two skills whose frontmatter name collides get `<name>-<id>`). A failed skill is
+ *  loud but NON-fatal — the runner still answers and the catalog marks it unavailable,
+ *  exactly the syncRepos posture. Returns the catalog. */
+export async function materializeSkills(api, skills, destRoot) {
+  const used = new Set()
+  const out = []
+  for (const s of skills) {
+    try {
+      const { name, files } = await fetchSkill(api, s)
+      const base = skillSlug(name) ?? s.id
+      const dir = used.has(base) ? `${base}-${s.id}` : base
+      used.add(dir)
+      writeSkill(destRoot, dir, files)
+      out.push({ id: s.id, version: s.version, dir, name: name ?? dir, ok: true })
+      console.log(`[skills] ${dir} @v${s.version}`)
+    } catch (e) {
+      console.error(`[skills] ${s.id}: ${e?.message ?? e}`)
+      out.push({ id: s.id, version: s.version, ok: false })
+    }
+  }
+  return out
+}
+
+/** Materialize Brandprint prose notes (single-file convention docs — not skills) into
+ *  destRoot as <slug>.md, so the runner can point the model at them. Non-fatal per note. */
+export async function materializeNotes(api, notes, destRoot) {
+  const out = []
+  for (const n of notes) {
+    try {
+      const body = await api.content(n.short_id, n.version)
+      const slug = skillSlug(n.title) ?? n.short_id
+      const dest = join(destRoot, `${slug}.md`)
+      mkdirSync(dirname(dest), { recursive: true })
+      writeFileSync(dest, body)
+      out.push({
+        short_id: n.short_id,
+        title: n.title,
+        file: `${destRoot.split("/").at(-1)}/${slug}.md`,
+        ok: true,
+      })
+    } catch (e) {
+      console.error(`[notes] ${n.short_id}: ${e?.message ?? e}`)
+      out.push({ short_id: n.short_id, ok: false })
+    }
+  }
+  return out
+}
+
+/** Pin unpinned `skills:` entries in a manifest's frontmatter by inserting a concrete
+ *  `version:` line after each `- id:` — lockfile semantics, so the pushed manifest is
+ *  deterministic and the diff IS the upgrade record. `versions` is a Map<id, number> of
+ *  the pins to apply (an already-pinned entry isn't in it, so it's left untouched). Pure
+ *  string surgery on the frontmatter block: it never reflows the author's manifest, only
+ *  splices a line under each named id. Returns { text, pinned:[{id, version}] }. */
+export function pinManifestSkills(text, versions) {
+  if (!versions || versions.size === 0) return { text, pinned: [] }
+  const fm = text.match(/^(---\r?\n)([\s\S]*?)(\r?\n---)/)
+  if (!fm) return { text, pinned: [] }
+  const pinned = []
+  const out = []
+  for (const line of fm[2].split(/\r?\n/)) {
+    out.push(line)
+    const m = line.match(/^(\s*)-\s+id:\s*(["']?)([A-Za-z0-9_-]+)\2\s*$/)
+    if (m && versions.has(m[3])) {
+      const version = versions.get(m[3])
+      out.push(`${m[1]}  version: ${version}`)
+      pinned.push({ id: m[3], version })
+    }
+  }
+  return { text: fm[1] + out.join("\n") + fm[3] + text.slice(fm[0].length), pinned }
+}
+
+/** The prompt block naming the conventions on disk (mirrors repoCatalogBlock). Skills in
+ *  .claude/skills/ are auto-discovered by the spawned claude, but naming them — and the
+ *  notes, which are NOT auto-discovered — is the honest "what's on disk" the model reads,
+ *  and an unavailable one is stated outright rather than silently missing. */
+export function conventionsBlock(skills, notes) {
+  const lines = []
+  for (const s of skills)
+    lines.push(
+      s.ok
+        ? `- .claude/skills/${s.dir} — skill "${s.name}" @v${s.version}`
+        : `- skill ${s.id} — UNAVAILABLE this run (fetch failed); say so if an answer would need it`,
+    )
+  for (const n of notes) if (n.ok) lines.push(`- ${n.file} — ${n.title ?? "convention note"}`)
+  if (lines.length === 0) return ""
+  return `\n\n## Conventions (materialized into your working directory)\n\n${lines.join("\n")}`
+}

--- a/packages/cli/src/skills.js
+++ b/packages/cli/src/skills.js
@@ -65,6 +65,16 @@ export function writeSkill(destRoot, dir, files) {
   }
 }
 
+/** Merge the ambient Brandprint skill layer with the manifest's own `skills:` into one
+ *  deduped list. A skill named in BOTH must materialize ONCE (not twice under a collided
+ *  dir); the manifest pin wins — it's the deliberate, context-specific choice over the
+ *  ambient default. Order follows first appearance (Brandprint, then new manifest ids). */
+export function mergeSkillLayers(brandprintSkills, manifestSkills) {
+  const byId = new Map()
+  for (const s of [...brandprintSkills, ...manifestSkills]) byId.set(s.id, s)
+  return [...byId.values()]
+}
+
 /** Materialize a set of pinned skills into destRoot, deduping directory names by short
  *  id (two skills whose frontmatter name collides get `<name>-<id>`). A failed skill is
  *  loud but NON-fatal — the runner still answers and the catalog marks it unavailable,

--- a/packages/cli/test/config.test.js
+++ b/packages/cli/test/config.test.js
@@ -31,6 +31,7 @@ import {
   TEMPLATES,
   writeContextConfig,
   writeId,
+  writeSkillPin,
 } from "../src/config.js"
 
 const dirs = []
@@ -176,6 +177,24 @@ describe("writeContextConfig", () => {
       id: "abc",
       context: { id: "ctx_1", agent_id: "ag_1", name: "T" },
     })
+  })
+})
+
+describe("writeSkillPin", () => {
+  it("appends a pin, and a re-add for the same id repins instead of duplicating", () => {
+    const d = tmp()
+    writeFileSync(join(d, CONFIG_FILE), JSON.stringify({ title: "T", entry: "context" }))
+    writeSkillPin(d, { id: "sk1", version: 3, name: "chart-style" })
+    let cfg = writeSkillPin(d, { id: "sk2", version: 1 })
+    expect(cfg.skills).toEqual([
+      { id: "sk1", version: 3, name: "chart-style" },
+      { id: "sk2", version: 1 },
+    ])
+    // Re-adding sk1 at a new version replaces it in place (still 2 entries).
+    cfg = writeSkillPin(d, { id: "sk1", version: 4, name: "chart-style" })
+    expect(cfg.skills).toHaveLength(2)
+    expect(cfg.skills.find((s) => s.id === "sk1").version).toBe(4)
+    expect(cfg.title).toBe("T") // untouched
   })
 })
 

--- a/packages/cli/test/runner.test.js
+++ b/packages/cli/test/runner.test.js
@@ -160,8 +160,10 @@ other_key: ignored
 ---
 
 # The manifest body`
-    const { body, repos } = parseManifest(md)
+    const { body, repos, skills, brandprint } = parseManifest(md)
     expect(body).toBe("\n# The manifest body")
+    expect(skills).toEqual([])
+    expect(brandprint).toBe("live")
     expect(repos).toEqual([
       {
         url: "https://github.com/churnkey/churnkey-labs",
@@ -173,7 +175,12 @@ other_key: ignored
   })
 
   it("passes a manifest without frontmatter through untouched", () => {
-    expect(parseManifest("# Plain")).toEqual({ body: "# Plain", repos: [] })
+    expect(parseManifest("# Plain")).toEqual({
+      body: "# Plain",
+      repos: [],
+      skills: [],
+      brandprint: "live",
+    })
   })
 
   it("the scaffolded example stays inert (commented) and junk urls are dropped", () => {
@@ -181,6 +188,33 @@ other_key: ignored
     expect(parseManifest(commented).repos).toEqual([])
     const junk = "---\nrepos:\n  - url: not-a-url\n---\nbody"
     expect(parseManifest(junk).repos).toEqual([])
+  })
+
+  it("parses a pinned skills list and the brandprint opt-out alongside repos", () => {
+    const md = `---
+repos:
+  - url: https://github.com/acme/warehouse
+skills:
+  - id: x7km2p4q
+    version: 3
+  - id: j9rw8n2v
+brandprint: off
+---
+
+# Body`
+    const { skills, brandprint, repos } = parseManifest(md)
+    expect(repos).toHaveLength(1)
+    expect(skills).toEqual([
+      { id: "x7km2p4q", version: 3 },
+      { id: "j9rw8n2v", version: null }, // unpinned until push resolves it
+    ])
+    expect(brandprint).toBe("off")
+  })
+
+  it("brandprint defaults to live when the scalar is absent", () => {
+    expect(parseManifest("---\nskills:\n  - id: a1b2c3d4\n    version: 1\n---\nx").brandprint).toBe(
+      "live",
+    )
   })
 
   it("slugs are owner-repo so same-named repos from different owners don't collide", () => {

--- a/packages/cli/test/skills.test.js
+++ b/packages/cli/test/skills.test.js
@@ -1,0 +1,158 @@
+import { mkdtempSync, readFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import {
+  conventionsBlock,
+  materializeNotes,
+  materializeSkills,
+  pinManifestSkills,
+  skillNameFrom,
+  skillSlug,
+} from "../src/skills.js"
+
+// A mock of the three-fetcher `api` contract, backed by an in-memory catalog of
+// { [id]: { [version]: { entry, files: {path: bytes} } } } for bundles and
+// { [id]: { [version]: "source" } } for single-file notes.
+const mockApi = (bundles = {}, notes = {}) => ({
+  outline: async (id, version) => {
+    const v = bundles[id]?.[version]
+    if (!v) throw new Error("no version")
+    return {
+      entry: v.entry,
+      pages: Object.keys(v.files).map((path) => ({ path, type: "text/plain" })),
+    }
+  },
+  file: async (id, path, version) => bundles[id][version].files[path],
+  content: async (id, version) => {
+    const s = notes[id]?.[version]
+    if (s == null) throw new Error("no note")
+    return s
+  },
+})
+
+describe("skillNameFrom + skillSlug", () => {
+  it("reads the frontmatter name; null when absent or nested", () => {
+    expect(skillNameFrom("---\nname: chart-style\ndescription: x\n---\n# hi")).toBe("chart-style")
+    expect(skillNameFrom('---\nname: "My Skill"\n---\n')).toBe("My Skill")
+    expect(skillNameFrom("no frontmatter here")).toBeNull()
+    expect(skillNameFrom("---\nmeta:\n  name: nested\n---\n")).toBeNull()
+  })
+
+  it("slugs to a filesystem-safe stem, null when nothing survives", () => {
+    expect(skillSlug("Chart Style!")).toBe("Chart-Style")
+    expect(skillSlug("a/../b")).toBe("a-..-b")
+    expect(skillSlug("***")).toBeNull()
+  })
+})
+
+describe("materializeSkills", () => {
+  it("writes each pinned skill's files under a name-derived dir and reports the catalog", async () => {
+    const api = mockApi({
+      sk1: {
+        3: {
+          entry: "SKILL.md",
+          files: {
+            "SKILL.md": "---\nname: chart-style\n---\n# Chart",
+            "scripts/build.sh": "echo hi",
+          },
+        },
+      },
+    })
+    const root = mkdtempSync(join(tmpdir(), "skills-"))
+    const cat = await materializeSkills(api, [{ id: "sk1", version: 3 }], root)
+    expect(cat).toEqual([
+      { id: "sk1", version: 3, dir: "chart-style", name: "chart-style", ok: true },
+    ])
+    expect(readFileSync(join(root, "chart-style", "SKILL.md"), "utf8")).toContain("# Chart")
+    expect(readFileSync(join(root, "chart-style", "scripts", "build.sh"), "utf8")).toBe("echo hi")
+  })
+
+  it("dedupes colliding names by short id", async () => {
+    const skillFiles = (name) => ({
+      entry: "SKILL.md",
+      files: { "SKILL.md": `---\nname: ${name}\n---\n` },
+    })
+    const api = mockApi({ a1: { 1: skillFiles("dup") }, b2: { 1: skillFiles("dup") } })
+    const root = mkdtempSync(join(tmpdir(), "skills-"))
+    const cat = await materializeSkills(
+      api,
+      [
+        { id: "a1", version: 1 },
+        { id: "b2", version: 1 },
+      ],
+      root,
+    )
+    expect(cat.map((c) => c.dir)).toEqual(["dup", "dup-b2"])
+  })
+
+  it("a failed skill is non-fatal: ok:false, the rest still materialize", async () => {
+    const api = mockApi({
+      ok1: { 1: { entry: "SKILL.md", files: { "SKILL.md": "---\nname: good\n---\n" } } },
+    })
+    const root = mkdtempSync(join(tmpdir(), "skills-"))
+    const cat = await materializeSkills(
+      api,
+      [
+        { id: "missing", version: 9 },
+        { id: "ok1", version: 1 },
+      ],
+      root,
+    )
+    expect(cat[0]).toMatchObject({ id: "missing", ok: false })
+    expect(cat[1]).toMatchObject({ id: "ok1", dir: "good", ok: true })
+  })
+})
+
+describe("materializeNotes", () => {
+  it("writes a note to <slug>.md and catalogs it", async () => {
+    const api = mockApi({}, { note1: { 2: "# Voice\n\nBe warm." } })
+    const root = mkdtempSync(join(tmpdir(), "brandprint-"))
+    const cat = await materializeNotes(
+      api,
+      [{ short_id: "note1", title: "Voice & Tone", version: 2 }],
+      root,
+    )
+    expect(cat[0]).toMatchObject({ short_id: "note1", ok: true })
+    expect(readFileSync(join(root, "Voice-Tone.md"), "utf8")).toContain("Be warm.")
+  })
+})
+
+describe("conventionsBlock", () => {
+  it("names skills + notes on disk, states an unavailable one, empty when nothing", () => {
+    expect(conventionsBlock([], [])).toBe("")
+    const block = conventionsBlock(
+      [
+        { ok: true, dir: "chart-style", name: "chart-style", version: 3 },
+        { ok: false, id: "gone" },
+      ],
+      [{ ok: true, file: "brandprint/voice.md", title: "Voice" }],
+    )
+    expect(block).toContain('.claude/skills/chart-style — skill "chart-style" @v3')
+    expect(block).toContain("skill gone — UNAVAILABLE")
+    expect(block).toContain("brandprint/voice.md — Voice")
+  })
+})
+
+describe("pinManifestSkills", () => {
+  it("inserts a version line under each unpinned id, leaving pinned ones untouched", () => {
+    const text = `---
+skills:
+  - id: aaaa1111
+    version: 5
+  - id: bbbb2222
+---
+
+# Body`
+    const { text: out, pinned } = pinManifestSkills(text, new Map([["bbbb2222", 7]]))
+    expect(pinned).toEqual([{ id: "bbbb2222", version: 7 }])
+    expect(out).toContain("  - id: bbbb2222\n    version: 7")
+    expect(out).toContain("  - id: aaaa1111\n    version: 5") // untouched
+    expect(out).toContain("# Body") // body preserved
+  })
+
+  it("is a no-op with an empty pin set or no frontmatter", () => {
+    expect(pinManifestSkills("# Plain", new Map([["x", 1]])).text).toBe("# Plain")
+    expect(pinManifestSkills("---\nskills:\n  - id: x\n---\n", new Map()).pinned).toEqual([])
+  })
+})

--- a/packages/cli/test/skills.test.js
+++ b/packages/cli/test/skills.test.js
@@ -6,6 +6,7 @@ import {
   conventionsBlock,
   materializeNotes,
   materializeSkills,
+  mergeSkillLayers,
   pinManifestSkills,
   skillNameFrom,
   skillSlug,
@@ -43,6 +44,26 @@ describe("skillNameFrom + skillSlug", () => {
     expect(skillSlug("Chart Style!")).toBe("Chart-Style")
     expect(skillSlug("a/../b")).toBe("a-..-b")
     expect(skillSlug("***")).toBeNull()
+  })
+})
+
+describe("mergeSkillLayers", () => {
+  it("dedupes a shared id once, with the manifest pin winning over the Brandprint", () => {
+    const merged = mergeSkillLayers(
+      [
+        { id: "shared", version: 3 },
+        { id: "bp-only", version: 1 },
+      ],
+      [
+        { id: "shared", version: 5 }, // manifest pins a newer version
+        { id: "manifest-only", version: 2 },
+      ],
+    )
+    expect(merged).toEqual([
+      { id: "shared", version: 5 }, // once, manifest's version
+      { id: "bp-only", version: 1 },
+      { id: "manifest-only", version: 2 },
+    ])
   })
 })
 

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -98,9 +98,13 @@ export const pickBundleEntry = (paths: string[]): string | null => {
   const shallowest = (pred: (p: string) => boolean): string | undefined =>
     paths.filter(pred).sort((a, b) => a.split("/").length - b.split("/").length)[0]
   if (paths.includes("/index.html")) return "/index.html"
+  // A root SKILL.md wins over any NON-root HTML: a skill folder is a skill even when it
+  // ships an HTML reference (references/example.html is exactly what a chart-style skill
+  // carries) — otherwise that reference would steal the entry and the bundle would lose
+  // its skill identity. An html site is still picked below when there's no root SKILL.md.
+  if (paths.includes("/SKILL.md")) return "/SKILL.md"
   const html = shallowest((p) => p.endsWith(".html"))
   if (html) return html
-  if (paths.includes("/SKILL.md")) return "/SKILL.md"
   if (paths.includes("/MANIFEST.md")) return "/MANIFEST.md"
   if (paths.includes("/README.md")) return "/README.md"
   return shallowest((p) => /\.(md|markdown)$/i.test(p)) ?? null

--- a/packages/core/test/publish.test.ts
+++ b/packages/core/test/publish.test.ts
@@ -248,8 +248,23 @@ describe("publish: bundles (zip)", () => {
       "/references/notes.md",
       "/scripts/run.sh",
     ])
-    // Title comes from the skill's frontmatter name, not the zip filename.
-    expect(artifact.title).toBe("my-skill")
+  })
+
+  it("a root SKILL.md wins the entry over a nested HTML reference (still a skill)", async () => {
+    const blobs = makeBlobs()
+    const { version } = await publish(
+      makeMeta(),
+      blobs,
+      bundle({
+        "SKILL.md": "---\nname: chart-style\ndescription: how we chart\n---\n\n# Chart style",
+        "references/example.html": "<!doctype html><h1>example</h1>",
+      }),
+    )
+    const manifest = JSON.parse(
+      new TextDecoder().decode((await blobs.get(version.blob_key)) ?? undefined),
+    )
+    // Not references/example.html — the skill keeps its identity despite shipping HTML.
+    expect(manifest.entry).toBe("/SKILL.md")
     // A skill carries the distinct content type so the library can badge it for free.
     expect(version.content_type).toBe("derive/skill")
   })


### PR DESCRIPTION
Implements the [Skills across Derive](https://derive.to/artifacts/skills-across-derive-j8lfhpkg) plan. A skill (a bundle with a `SKILL.md`) becomes a first-class Brandprint member, and every agent surface consumes it: MCP resources for hosted agents, materialized `.claude/skills/` folders for filesystem agents. One thing to curate (`/brandprint`), reaching every place an agent shows up.

## What ships (7 work packages)

**WP1 — Faithful skill delivery over MCP** (`apps/api/src/mcp.ts`). A skill in a Brandprint collection now reaches connected agents with its OWN identity: resource title/description from `SKILL.md` frontmatter, body delivered frontmatter-stripped, and a footer announcing `scripts/`/`references/` so the agent knows to `read` them. Plain convention docs are unchanged (generic label, lazy body).

**WP6 — Skill discovery over MCP** (`apps/api/src/mcp.ts`). `list_artifacts` marks each row `is_skill` (from the denormalized `derive/skill` content type) and takes `skills:true` to list only skills. No new tools — skill-ness is an argument, not a call.

**WP3 — Context config carries the resolved Brandprint** (`apps/api/src/routes/contexts.ts`). The runner's one config fetch (`GET /v1/contexts/{id}`, agent branch) now returns the resolved Brandprint: a `members` list (skills + notes, each with `version` provenance and an `is_skill` flag) plus `profile_short_id`. Agent-branch only — a human GET never carries runner config. This is the runner's only window into workspace settings.

**WP4 — Runner materialization** (`packages/cli/src/{runner,skills}.js`, `context.js`). At boot, after `syncRepos`, the runner materializes the workspace Brandprint (ambient; opt out with `brandprint: off` in the manifest) plus the manifest's own pinned `skills:` — skills into `.claude/skills/` (auto-discovered by the spawned claude), notes into `brandprint/`. Failed fetches are loud but non-fatal (the `syncRepos` posture). Resolved skill versions join repo SHAs in answer provenance. `derive context push` pins any unpinned skill to its current version (lockfile semantics: the manifest diff is the upgrade record). New shared `skills.js` is pure, unit-tested against a mock.

**WP5 — CLI verbs** (`packages/cli/bin/derive.js`). `derive skill add <short_id>` installs a published skill into `.claude/skills/` and pins it in `derive.json`; `derive brandprint pull` materializes the whole resolved Brandprint (workspace + personal) into any repo.

**WP2 — Brandprint UI** (`apps/web/src/pages/brandprint/brandprint-section.tsx`). An "Add a skill" picker beside "Upload docs", and a "Skill" badge on skill members in the docs list.

**WP7 — Library badge** (`apps/web/src/pages/library/artifact-card.tsx`). Skills are badged in the library grid so the shelf is spottable. (A server-side "Skills" feed filter is a follow-up — the feed is keyset-paginated with server scopes, so a correct filter is backend, not a client-side narrow.)

## Design notes

- **Two trust postures.** Manifest `skills:` are pinned (executable, context-specific; push resolves floating refs). The Brandprint layer is live-at-boot (ambient auto-update is the feature's contract), with resolved versions logged and a per-context opt-out.
- **No new artifact kind, no new API objects.** Skills are ordinary artifacts; the Brandprint collection already had no kind gate. This is affordances + faithful delivery over existing plumbing.
- **Materialization needs no new endpoint** — enumerate (`content?outline=1&v=`) + per-file fetch (`content?section=&v=`), which an agent bearer already authorizes.

## Verification

- Full suite green: **api 875, cli 114, core 325, web 146, db 191, mcp 19, storage 16**. Typecheck clean across all packages; `pnpm run ci` (all ~14 lint gates) exits 0; OpenAPI + web types regenerated.
- New tests: WP1 skill-resource delivery, WP6 `is_skill`/filter, WP3 agent-vs-human config branch, WP4 `skills.js` materializer + pin logic + `parseManifest` additions, WP5 `writeSkillPin`.
- **Live end-to-end** against a local node server: published a skill over MCP, ran `derive skill add` over the socket — all three files materialized with correct structure and byte-exact content, pin written to `derive.json`. This validates the content-API adapter that both the runner and CLI share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)