### PR TITLE
feat(comments): mobile-first comment sheet — always-docked peek, content-weighted height, drag, stepper

### DIFF
--- a/apps/web/src/pages/artifact/artifact-comments.tsx
+++ b/apps/web/src/pages/artifact/artifact-comments.tsx
@@ -173,10 +173,6 @@ export function ArtifactComments(p: {
             openThreads={p.openThreads}
             resolved={p.resolved}
             composer={p.composer}
-            onClose={() => {
-              p.setPanel("hidden")
-              cancelNew()
-            }}
             onNewGeneral={newGeneral}
             onSubmitNew={p.submitNew}
             onCancelNew={cancelNew}

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -6,7 +6,6 @@ import { Count } from "@/components/shared/section-eyebrow"
 import { Button } from "@/components/ui/button"
 import { Kbd } from "@/components/ui/kbd"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
-import { useFocusTrap } from "@/lib/use-focus-trap"
 import { cn } from "@/lib/utils"
 import { Composer } from "./comment-composer"
 import { CollapsibleThreadSection, CommentCard, PinnedZone } from "./comment-thread"
@@ -37,7 +36,6 @@ export function MobileComments({
   openThreads,
   resolved,
   composer,
-  onClose,
   onNewGeneral,
   onSubmitNew,
   onCancelNew,
@@ -47,7 +45,6 @@ export function MobileComments({
   openThreads: Comment[][]
   resolved: Comment[][]
   composer: ComposerState
-  onClose: () => void
   onNewGeneral: () => void
   onSubmitNew: (text: string, mentions?: Mention[]) => void
   onCancelNew: () => void
@@ -57,15 +54,16 @@ export function MobileComments({
    *  is left below it. */
   onHeightChange?: (px: number) => void
 }) {
-  // Two states only: peek (a slim "Comments (N)" bar — the default) and full (the
-  // list). Composing overrides both with a compact composer bar pinned above the
-  // keyboard (see the height + `kb` style below), so the box sits flush above the
-  // keyboard with the document visible above — no awkward half-height middle state.
+  // The sheet is ALWAYS docked on a phone (peek is the floor — there is no hidden
+  // state and no scrim; the doc above stays live). Two resting sizes: peek (the slim
+  // bar, one line taller when it can preview the latest comment) and full (the list,
+  // content-weighted up to half the screen). Composing overrides both with a compact
+  // composer bar pinned above the keyboard (see the height + `kb` style below), so
+  // the box sits flush above the keyboard with the document visible above.
   const { canComment } = useCommentScope()
   const tree = useCommentTree()
   const [size, setSize] = useState<"peek" | "full">("peek")
   const sheetRef = useRef<HTMLDivElement>(null)
-  useFocusTrap(sheetRef, open)
   useEffect(() => {
     if (open) setSize("peek")
   }, [open])
@@ -147,96 +145,179 @@ export function MobileComments({
       for (const c of t) if (c.body_md && (!best || c.created_at > best.created_at)) best = c
     return best
   }, [openThreads])
-  // The grip toggles peek <-> full.
-  const grip = () => setSize((s) => (s === "peek" ? "full" : "peek"))
-  // Jumping to text: drop to the peek bar so the highlight is visible in the doc.
-  const jumpToText = (id: string) => {
-    setSize("peek")
-    tree.onJump(id)
+  // The grip (tap) toggles peek <-> expanded.
+  const grip = () => {
+    if (moved.current) {
+      // A drag just ended on this element — the trailing click isn't a tap.
+      moved.current = false
+      return
+    }
+    setSize((s) => (s === "peek" ? "full" : "peek"))
   }
-  // The sheet's cards read this overridden tree: jumping also collapses the sheet, and
-  // touch has no hover (so no emphasis state) — everything else is the page's tree.
+  // Jumping to text keeps the sheet where it is: expanded is capped at half the
+  // screen, so the highlight always lands visible in the doc strip above. (The old
+  // collapse-to-peek was a workaround for the full-screen sheet covering the doc.)
+  const jumpToText = (id: string) => tree.onJump(id)
+  // The sheet's cards read this overridden tree: touch has no hover (so no emphasis
+  // state) — everything else is the page's tree.
   const sheetTree = { ...tree, hoverThread: null, onHover: NO_HOVER, onJump: jumpToText }
+
+  // --- drag: the grip/header drags between the two resting sizes -----------------
+  // Feedback is a direct `translate` style write per move (no re-render, transition
+  // suspended); release restores the class transition so the settle animates, and
+  // only a past-threshold drag (or a fling) flips the size. Peek is the FLOOR —
+  // dragging down from peek rubber-bands instead of dismissing (the docked bar is
+  // the comments entry point) — and expanded rubber-bands upward past its cap.
+  // Disabled while the keyboard owns the sheet's position (kb) or while composing.
+  const drag = useRef<{ y0: number; t0: number; dy: number } | null>(null)
+  const moved = useRef(false)
+  const dragStart = (e: React.PointerEvent) => {
+    if (kb || composer) return
+    if ((e.target as HTMLElement).closest("button")) return // buttons keep their taps
+    drag.current = { y0: e.clientY, t0: e.timeStamp, dy: 0 }
+    ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+    const el = sheetRef.current
+    if (el) el.style.transition = "none"
+  }
+  const dragMove = (e: React.PointerEvent) => {
+    const d = drag.current
+    const el = sheetRef.current
+    if (!d || !el) return
+    d.dy = e.clientY - d.y0
+    const resisted =
+      size === "peek"
+        ? d.dy > 0
+          ? d.dy / 4 // floor: resist downward
+          : Math.max(d.dy, -96) // follow upward a bit, then the flip takes over
+        : d.dy < 0
+          ? d.dy / 4 // cap: resist upward
+          : d.dy
+    el.style.translate = `0 ${resisted}px`
+  }
+  const dragEnd = (e: React.PointerEvent) => {
+    const d = drag.current
+    const el = sheetRef.current
+    drag.current = null
+    if (!d || !el) return
+    moved.current = Math.abs(d.dy) > 5
+    el.style.transition = ""
+    el.style.translate = ""
+    const fling = Math.abs(d.dy) / Math.max(1, e.timeStamp - d.t0) > 0.5
+    if (size === "peek" && (d.dy < -60 || (fling && d.dy < 0))) setSize("full")
+    else if (size === "full" && (d.dy > 60 || (fling && d.dy > 0))) setSize("peek")
+  }
+
+  // --- stepper: walk the open threads one at a time ------------------------------
+  // Each step scrolls the thread's card into view in the list AND, for an anchored
+  // thread, scrolls the document to its highlight — which stays visible because the
+  // sheet never exceeds half the screen.
+  const [step, setStep] = useState(0)
+  const stepIdx = Math.min(step, Math.max(0, openThreads.length - 1))
+  const stepTo = (i: number) => {
+    const n = openThreads.length
+    if (n === 0) return
+    const idx = (i + n) % n
+    setStep(idx)
+    const head = openThreads[idx]?.[0]
+    if (!head) return
+    sheetRef.current
+      ?.querySelector(`[data-thread-id="${head.thread_id}"]`)
+      ?.scrollIntoView({ block: "nearest", behavior: "smooth" })
+    if (head.anchor) tree.onJump(head.thread_id)
+  }
   return (
     <>
-      {/* Backdrop only at full height (reading mode). At half the document above
-          stays tappable/scrollable, so no dimming layer intercepts it. */}
-      <button
-        type="button"
-        data-testid="comments-sheet-backdrop"
-        aria-label="Collapse comments"
-        tabIndex={open && !composer && size === "full" ? 0 : -1}
-        onClick={() => setSize("peek")}
-        className={cn(
-          "fixed inset-0 z-60 bg-scrim/50 transition-opacity",
-          open && !composer && size === "full" ? "opacity-100" : "pointer-events-none opacity-0",
-        )}
-      />
-      <div
+      <aside
         ref={sheetRef}
         className={cn(
-          "fixed inset-x-0 bottom-0 z-61 flex flex-col rounded-t-2xl border-t border-border bg-card shadow-[var(--shadow-pop)] duration-200 ease-out",
           // The slide rides the `translate` property (translate-y-full/0), so the
           // transition MUST target `translate` — not `transform` — or the sheet jumps
-          // in and out instead of sliding. Don't animate height while the keyboard
-          // repositions the sheet.
-          kb ? "transition-[translate]" : "transition-[translate,height]",
-          // Composing: a compact bar sized to its content (capped), so the box sits
-          // flush above the keyboard rather than high up in a tall sheet.
-          // Peek grows a little to preview the latest comment; a bare header when empty.
-          composer ? "max-h-[80vh]" : size === "full" ? "h-[88vh]" : latest ? "h-24" : "h-18.5",
+          // in and out instead of sliding. Height changes snap (auto isn't
+          // animatable); the drag handlers suspend/restore this transition inline.
+          "fixed inset-x-0 bottom-0 z-61 flex flex-col rounded-t-2xl border-t border-border bg-card shadow-[var(--shadow-pop)] transition-[translate] duration-200 ease-out",
+          // Heights are CONTENT-WEIGHTED: composing is a compact bar above the
+          // keyboard; expanded hugs its comments up to half the screen (the doc
+          // strip above stays visible and live — no reading mode that owns the
+          // whole screen); peek is a slim bar, one line taller with a preview.
+          composer ? "max-h-[80vh]" : size === "full" ? "max-h-[50vh]" : latest ? "h-24" : "h-18.5",
           open ? "translate-y-0" : "translate-y-full",
         )}
         // While the keyboard is up, lift the sheet's bottom to just above it and cap
         // its height to the visible band — so the half-height composer sits in view
         // (with a sliver of document above) instead of behind/under the keyboard.
         style={kb ? { bottom: kb.inset, maxHeight: kb.height } : undefined}
-        role="dialog"
+        // Non-modal by design: the document above stays visible and interactive in
+        // every state, so this is an aside, not a dialog (no focus trap, no scrim).
         aria-label="Comments"
       >
-        {/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: grip resizes the sheet; ✕ closes. */}
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: the grip/header strip is a drag handle (pointer events) with tap-to-toggle; the real controls inside are buttons. */}
         <div
-          data-testid="comments-sheet-grip"
-          className="flex shrink-0 cursor-grab justify-center pb-1 pt-2"
-          onClick={grip}
-          title="Resize"
+          className="shrink-0 touch-none"
+          onPointerDown={dragStart}
+          onPointerMove={dragMove}
+          onPointerUp={dragEnd}
+          onPointerCancel={dragEnd}
         >
-          <div className="h-1 w-10 rounded-full bg-border" />
-        </div>
-        <div className="flex items-center gap-2 border-b border-border-soft pb-3 pl-3 pr-2.5 pt-2">
-          <CommentsHeading count={openThreads.length} />
-          {canComment && (
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: grip toggles the sheet size; keyboard users have the labeled caret button below. */}
+          <div
+            data-testid="comments-sheet-grip"
+            className="flex cursor-grab justify-center pb-1 pt-2"
+            onClick={grip}
+            title="Resize"
+          >
+            <div className="h-1 w-10 rounded-full bg-border" />
+          </div>
+          <div className="flex items-center gap-2 border-b border-border-soft pb-3 pl-3 pr-2.5 pt-2">
+            <CommentsHeading count={openThreads.length} />
+            {size === "full" && openThreads.length > 1 && (
+              // Step through the discussion one thread at a time: the card scrolls
+              // into view and an anchored thread scrolls the doc to its highlight.
+              <div className="flex items-center gap-0.5 font-mono text-xs tabular-nums text-muted-foreground">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Previous comment"
+                  data-testid="comments-step-prev"
+                  onClick={() => stepTo(stepIdx - 1)}
+                >
+                  <Icon name="caret" className="size-4 rotate-90" />
+                </Button>
+                {stepIdx + 1}/{openThreads.length}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Next comment"
+                  data-testid="comments-step-next"
+                  onClick={() => stepTo(stepIdx + 1)}
+                >
+                  <Icon name="caret" className="size-4 -rotate-90" />
+                </Button>
+              </div>
+            )}
+            {canComment && (
+              <Button
+                variant="outline"
+                size="sm"
+                data-testid="comments-sheet-new"
+                onClick={() => {
+                  setSize("full")
+                  onNewGeneral()
+                }}
+              >
+                <Icon name="plus" size={16} />
+                New
+              </Button>
+            )}
             <Button
-              variant="outline"
-              size="sm"
-              data-testid="comments-sheet-new"
-              onClick={() => {
-                setSize("full")
-                onNewGeneral()
-              }}
+              variant="ghost"
+              size="icon"
+              aria-label={size === "peek" ? "Expand" : "Collapse"}
+              data-testid="comments-sheet-resize"
+              onClick={() => setSize(size === "peek" ? "full" : "peek")}
             >
-              <Icon name="plus" size={16} />
-              New
+              <Icon name="caret" className={cn("size-4", size === "peek" && "rotate-180")} />
             </Button>
-          )}
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label={size === "peek" ? "Expand" : "Collapse"}
-            data-testid="comments-sheet-resize"
-            onClick={() => setSize(size === "peek" ? "full" : "peek")}
-          >
-            <Icon name="caret" className={cn("size-4", size === "peek" && "rotate-180")} />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Close comments"
-            data-testid="comments-sheet-close"
-            onClick={onClose}
-          >
-            <Icon name="close" className="size-4" />
-          </Button>
+          </div>
         </div>
         {composer ? (
           // Composing ("half open"): just the composer, so the sheet is a compact bar
@@ -285,7 +366,7 @@ export function MobileComments({
                 const head = t[0]
                 if (!head) return null
                 return (
-                  <div key={head.thread_id} className="mb-2.5">
+                  <div key={head.thread_id} data-thread-id={head.thread_id} className="mb-2.5">
                     <CommentCard thread={t} />
                   </div>
                 )
@@ -316,7 +397,7 @@ export function MobileComments({
             </span>
           </button>
         ) : null}
-      </div>
+      </aside>
     </>
   )
 }

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type RefObject, useEffect, useRef, useState } from "react"
+import { type ReactNode, type RefObject, useEffect, useMemo, useRef, useState } from "react"
 import type { Comment, Mention } from "@/api"
 import { Icon } from "@/components/icons"
 import { EmptyState } from "@/components/shared/empty-state"
@@ -16,6 +16,10 @@ import { type ComposerState, type FrameGeom, type PinItem, selLabel } from "./ty
 
 // Touch has no hover, so the mobile sheet overrides the tree's onHover with this.
 const NO_HOVER = () => {}
+
+// A one-line plain-text teaser of a comment body for the peek preview (CSS truncates
+// the length; this just flattens whitespace so a multi-line body reads as one line).
+const teaser = (md: string) => md.replace(/\s+/g, " ").trim()
 
 // The comments panel header: the label + the open-thread count in the machine
 // count register ("Comments · 3") — quieter than a pill blob beside the title.
@@ -135,6 +139,14 @@ export function MobileComments({
     return () => cancelAnimationFrame(raf)
   }, [open, onHeightChange])
   const empty = openThreads.length === 0 && resolved.length === 0 && !composer
+  // The most recent open comment — the peek bar previews it so the resting state
+  // teases the live discussion instead of showing a bare "Comments" header.
+  const latest = useMemo(() => {
+    let best: Comment | null = null
+    for (const t of openThreads)
+      for (const c of t) if (c.body_md && (!best || c.created_at > best.created_at)) best = c
+    return best
+  }, [openThreads])
   // The grip toggles peek <-> full.
   const grip = () => setSize((s) => (s === "peek" ? "full" : "peek"))
   // Jumping to text: drop to the peek bar so the highlight is visible in the doc.
@@ -163,12 +175,16 @@ export function MobileComments({
       <div
         ref={sheetRef}
         className={cn(
-          "fixed inset-x-0 bottom-0 z-61 flex flex-col rounded-t-2xl border-t border-border bg-card shadow-[var(--shadow-pop)] duration-200",
-          // Don't animate height while the keyboard repositions the sheet.
-          kb ? "transition-transform" : "transition-[transform,height]",
+          "fixed inset-x-0 bottom-0 z-61 flex flex-col rounded-t-2xl border-t border-border bg-card shadow-[var(--shadow-pop)] duration-200 ease-out",
+          // The slide rides the `translate` property (translate-y-full/0), so the
+          // transition MUST target `translate` — not `transform` — or the sheet jumps
+          // in and out instead of sliding. Don't animate height while the keyboard
+          // repositions the sheet.
+          kb ? "transition-[translate]" : "transition-[translate,height]",
           // Composing: a compact bar sized to its content (capped), so the box sits
           // flush above the keyboard rather than high up in a tall sheet.
-          composer ? "max-h-[80vh]" : size === "full" ? "h-[88vh]" : "h-18.5",
+          // Peek grows a little to preview the latest comment; a bare header when empty.
+          composer ? "max-h-[80vh]" : size === "full" ? "h-[88vh]" : latest ? "h-24" : "h-18.5",
           open ? "translate-y-0" : "translate-y-full",
         )}
         // While the keyboard is up, lift the sheet's bottom to just above it and cap
@@ -285,6 +301,20 @@ export function MobileComments({
               )}
             </div>
           </CommentTreeProvider>
+        ) : latest ? (
+          // Peek preview: a one-line teaser of the latest comment, so the resting
+          // sheet shows the live discussion. Tapping it expands to the full list.
+          <button
+            type="button"
+            data-testid="comments-peek-preview"
+            onClick={() => setSize("full")}
+            className="flex min-w-0 items-center gap-1.5 px-3 pt-0.5 pb-[max(12px,env(safe-area-inset-bottom))] text-left"
+          >
+            <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
+              <span className="font-medium text-foreground">{latest.author}</span>{" "}
+              {teaser(latest.body_md)}
+            </span>
+          </button>
         ) : null}
       </div>
     </>

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -269,7 +269,7 @@ export function MobileComments({
           </div>
           <div className="flex items-center gap-2 border-b border-border-soft pb-3 pl-3 pr-2.5 pt-2">
             <CommentsHeading count={openThreads.length} />
-            {size === "full" && openThreads.length > 1 && (
+            {size === "full" && !composer && openThreads.length > 1 && (
               // Step through the discussion one thread at a time: the card scrolls
               // into view and an anchored thread scrolls the doc to its highlight.
               <div className="flex items-center gap-0.5 font-mono text-xs tabular-nums text-muted-foreground">

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -517,6 +517,12 @@ export function Artifact() {
   // no width and the document gets the full screen.
   const asideWidth = isMobile ? 0 : panel === "open" ? 340 : 0
 
+  // Mobile has no hidden state: the sheet's peek bar is always docked (it IS the
+  // entry point — there's no top-bar toggle or `c` key on a phone, and a hidden
+  // panel made comments unreachable). Computed here rather than in the panel hook
+  // so a desktop→mobile resize with a persisted "hidden" can't strand a phone.
+  const effectivePanel = isMobile && !isAnon ? "open" : panel
+
   // The rendered artifact frame — identical for the anon public viewer and the authed
   // workbench, so build it once and place it in both branches (no prop drift).
   const documentEl = (
@@ -736,7 +742,9 @@ export function Artifact() {
             // bar, full list, or keyboard-pinned composer), so this never over- or
             // under-reserves the way a fixed `pb-[50vh]` did.
             style={
-              isMobile && !focus && panel === "open" ? { paddingBottom: sheetInset } : undefined
+              isMobile && !focus && effectivePanel === "open"
+                ? { paddingBottom: sheetInset }
+                : undefined
             }
           >
             {art.bundle && !editing && (
@@ -767,7 +775,7 @@ export function Artifact() {
                 the empty panel. On mobile NEITHER exists (the toggle is desktop-only,
                 there's no keyboard), so the FAB is the sole entry point and must show
                 even at zero — otherwise a comment-less doc has no way into comments. */}
-            {!isAnon && !focus && panel === "hidden" && (openCount > 0 || isMobile) && (
+            {!isAnon && !focus && !isMobile && panel === "hidden" && openCount > 0 && (
               <DocFab
                 title="Show comments (c)"
                 testId="artifact-comments-fab"
@@ -824,7 +832,7 @@ export function Artifact() {
               }
               onSheetHeight={setSheetInset}
               docLive={docLive}
-              panel={panel}
+              panel={effectivePanel}
               asideWidth={asideWidth}
               openCount={openCount}
               frameRef={frame}

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -762,16 +762,20 @@ export function Artifact() {
             ) : (
               documentEl
             )}
-            {/* Only when there ARE open comments — a zero-count "Show comments" pill
-                is noise over the render. The top-bar Comments toggle (and `c`)
-                still opens the empty panel to start the first thread. */}
-            {!isAnon && !focus && panel === "hidden" && openCount > 0 && (
+            {/* On desktop, only when there ARE open comments — a zero-count pill is
+                noise there, since the top-bar Comments toggle (and `c`) already opens
+                the empty panel. On mobile NEITHER exists (the toggle is desktop-only,
+                there's no keyboard), so the FAB is the sole entry point and must show
+                even at zero — otherwise a comment-less doc has no way into comments. */}
+            {!isAnon && !focus && panel === "hidden" && (openCount > 0 || isMobile) && (
               <DocFab
                 title="Show comments (c)"
                 testId="artifact-comments-fab"
                 onClick={() => setPanel("open")}
               >
-                {`${openCount} comment${openCount === 1 ? "" : "s"}`}
+                {openCount > 0
+                  ? `${openCount} comment${openCount === 1 ? "" : "s"}`
+                  : "Show comments"}
               </DocFab>
             )}
             {/* Anonymous visitor on a comment-enabled link: commenting forces auth (anon

--- a/apps/web/src/pages/artifact/use-comments-panel.ts
+++ b/apps/web/src/pages/artifact/use-comments-panel.ts
@@ -17,18 +17,24 @@ const loadPanel = (): Panel => {
  * The comments panel's open/hidden state and its two side effects: it's persisted
  * per device across visits, and the `c` hotkey toggles it. Escape is wired through
  * the same keydown listener (it routes to the page's composer cancel via
- * `onEscape`) so the page keeps one listener, not two. Phones start hidden
- * (document-first); desktop restores the saved state.
+ * `onEscape`) so the page keeps one listener, not two. Phones are ALWAYS open:
+ * the sheet's docked peek bar is the sole comments entry point on a phone (no
+ * top-bar toggle, no `c` key), so hidden is not a reachable state there — they
+ * start open, and the page clamps with `effectivePanel` against a persisted
+ * desktop "hidden" leaking across a resize. Desktop restores the saved state.
  */
 export function useCommentsPanel(onEscape: () => void) {
   const [panel, setPanel] = useState<Panel>(() =>
     typeof window !== "undefined" && window.matchMedia("(max-width:640px)").matches
-      ? "hidden"
+      ? "open"
       : loadPanel(),
   )
 
-  // Persist the collapse state.
+  // Persist the collapse state — desktop only. On a phone-width viewport the panel
+  // is forced open (above), and writing that would clobber a desktop "hidden"
+  // preference the moment a desktop window got narrowed below the breakpoint.
   useEffect(() => {
+    if (window.matchMedia("(max-width:640px)").matches) return
     try {
       localStorage.setItem(PANEL_KEY, panel)
     } catch {


### PR DESCRIPTION
Started as an access-regression fix, grew into making mobile comments **first-class**: designed for touch, not adapted from desktop. All states verified live in a 390px viewport.

## The original bug

#374 gated the "Show comments" FAB on `openCount > 0`, reasoning the top-bar toggle covers the empty case — but that toggle is desktop-only and phones have no `c` key, so a comment-less doc had **no way into comments on mobile**.

## The design (per review discussion)

**Peek is the floor.** The sheet's peek bar is permanently docked on phones — it *is* the entry point. No hidden state, no mobile FAB (reverts to desktop-only). This makes the #374 bug class structurally impossible: there is no state where comments are unreachable.

**Content-weighted expansion, max half the screen.** Expanded hugs its comments — one short comment gives a short sheet — up to `max-h-[50vh]`; past the cap the list scrolls. The 88vh full-screen mode + backdrop scrim are gone: the document stays visible and interactive in every state (the sheet is a semantic `<aside>` now, not a focus-trapped dialog).

**Drag.** Grip/header drags between peek ↔ expanded: direct `translate` writes per move, threshold-or-fling to flip, rubber-band at both ends (no dismiss — peek is the floor). Tap still toggles. Disabled while the keyboard owns the sheet or while composing.

**Stepper.** Expanded header gains `‹ i/N ›`: step threads one at a time — the card scrolls into view and an anchored thread scrolls the **document** to its highlight, which stays visible precisely because the sheet never exceeds half the screen. Jump-to-text keeps the sheet open (the old collapse-to-peek was a workaround for the full-screen sheet).

**Peek preview.** At rest with comments, the bar previews the latest comment (author + one-line teaser), tap to expand.

**Keyboard (explicit requirement).** The `visualViewport` pinning stays authoritative: its inline `bottom`/`maxHeight` override every size class, so an open keyboard caps the sheet to the visible band in all states; drag defers to it; the composer focus chain (primer → composer) verified live.

Also fixed en route: the sheet's slide transition targeted `transform` while the slide rides the `translate` property — it jumped instead of sliding.

## Verified live (390×844)

Docked peek on load — empty doc (slim bar + New) and commented doc (preview) · expand hugs content (399px < 422px cap) · stepper 1/3 → 2/3 with doc scroll · drag down 422→96px and up 96→399px · composer docked + focused · jump keeps sheet open. Desktop behavior unchanged throughout (FAB, side panel, persistence).

`apps/web` typecheck clean · biome clean · frontend/testids/tokens gates pass · 146 web tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)