### PR TITLE
derive://design/reference: the authoring method for styled artifacts

### DIFF
--- a/apps/api/src/design-reference.ts
+++ b/apps/api/src/design-reference.ts
@@ -1,0 +1,101 @@
+/**
+ * The design reference — the static MCP resource behind styled-artifact authoring
+ * (`derive://design/reference`). The Brandprint profile carries a workspace's values
+ * (colors, type, radii — the tokens island); this carries the method: how to turn
+ * values into a page that reads as designed rather than generated. Derive never runs
+ * inference; the guidance is versioned like code and the user's own agent applies it.
+ * A pure leaf: no imports, safe in every build (worker + node).
+ *
+ * Plan: docs/plans/agent-artifact-learnings.md §5. Teams that want to tune these
+ * rules fork them as a workspace skill (a bundle with a SKILL.md), which surfaces at
+ * connect like any Brandprint convention and takes precedence per the usual chain.
+ */
+
+export const DESIGN_REFERENCE = `# Designing a styled artifact
+
+You are about to publish a fully-styled HTML page. It will render exactly as you
+author it, in a sandboxed viewer, to humans who will judge it the way they judge any
+page: in the first second, by its composition. This is the method. If this workspace
+has a Brandprint profile (\`derive://brandprint/profile\`), that is the palette,
+type, and voice — read it first and use its tokens island; your personal Brandprint
+outranks the workspace's, and both outrank the defaults below.
+
+## Calibrate the treatment before writing a line
+
+Most pages are **working documents** — a plan, a review, a report, a dashboard. They
+deserve real craft: a type scale, considered spacing, a chosen palette. They do not
+deserve a hero section, a scroll animation, or a visual identity. Over-designing a
+memo reads as not knowing what a memo is.
+
+Some pages are **editorial** — a landing page, a launch page, a mock the team will
+judge as a product surface. There, open with the most characteristic thing in the
+subject's world and take one deliberate aesthetic risk in one place, keeping
+everything around it quiet.
+
+When unsure, err utilitarian: a well-composed document is never wrong; an
+over-designed one often is.
+
+## Type carries the page
+
+- Two roles, chosen deliberately: a display face with character for headings, a
+  complementary body face for reading. Naming the same one or two "safe" sans faces
+  every time is how generated pages get spotted.
+- Set a scale and stay on it. Running text near 65 characters per line. Headings get
+  \`text-wrap: balance\`; uppercase labels get letter-spacing; columns of digits get
+  \`font-variant-numeric: tabular-nums\`.
+- Fonts are binaries: upload woff2 to \`POST /v1/assets\` and reference the URL in
+  \`@font-face\` — never base64 through a tool call (one mistranscribed character
+  breaks a font silently).
+
+## Color is a token system, not a decoration
+
+- Define the palette as custom properties on \`:root\` and style components through
+  the tokens. With a live Brandprint profile, the tokens ARE the profile's — apply
+  its stated usage ratio rather than sprinkling the accent everywhere.
+- Style both color schemes via \`@media (prefers-color-scheme: dark)\` redefining the
+  tokens — viewers arrive in either. A page may commit to a single visual world (a
+  terminal, a printed ticket) as a choice, never as an omission.
+- Choose neutrals; don't inherit them. A grey with a slight hue bias toward the
+  page's accent reads as designed; pure \`#808080\` reads as unfinished.
+- Semantic color (good / warning / critical) is its own small set, separate from the
+  accent. Spend boldness in exactly one place.
+
+## Structure is information
+
+- Lay out sibling groups with flex/grid and \`gap\`, not per-element margins that
+  collapse unpredictably. Wide content (tables, code, diagrams) scrolls inside its
+  own \`overflow-x: auto\` container; the page body never scrolls sideways.
+- Structural devices must encode something true: number sections only when order
+  carries meaning; use eyebrows and dividers to mark real boundaries, not rhythm.
+- Build with the real content. Never lorem, never placeholder rows — a reviewer
+  can only judge a page holding the actual material.
+
+## The tells of a generated page (avoid unless asked)
+
+Warm cream + serif display + terracotta accent; near-black with a single neon
+accent; a purple-to-blue gradient hero on white; emoji as section markers;
+everything centered; identical rounded cards with colored left rails; hairline
+newspaper rules over dense columns. When the user asks for one of these, their words
+win. When nothing was specified, spend the freedom elsewhere.
+
+## Rules of this platform
+
+- Declare \`<meta name="viewport" content="width=device-width, initial-scale=1">\`.
+  Pages without one get a mobile-reflow injection whose media caps can fight
+  intentional layouts (\`data-reflow-exempt\` opts an element out; the viewport meta
+  opts the page out).
+- Keep meaningful text as real DOM text, not pixels: review comments anchor on text
+  quotes, so words baked into images can't take feedback — and feedback is what
+  this platform is for.
+- Binaries (images and fonts) go to \`POST /v1/assets\`; reference the returned
+  URLs. Self-contained pages with self-hosted assets are the dependable path.
+- Read the publish response: it echoes \`content_sha256\` (verify it when the
+  content passed through your context) and may carry \`advisories\` — fix what they
+  flag before reporting done.
+
+## Before you call it done
+
+Viewport declared · both schemes styled · no sideways body scroll · real content
+throughout · binaries as assets · the response's advisories are clean. If you can
+render what you shipped, look at it once — composition bugs are invisible in source.
+`

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -1683,12 +1683,11 @@ async function buildServer(
             (actingFor && !openedInTab
               ? " No open Derive tab caught this push — open the url for the user (e.g. run `open <url>`) if they should see it now."
               : "") +
-            // Detection-driven advisories: a rule delivered at the moment of the
-            // mistake (missing viewport → reflow injected; base64 blobs → use assets)
-            // beats one buried in the tool description. Content-provided single files
-            // only — an edits revision didn't carry the whole document through here.
-            (typeof contentIn === "string" && artifact.kind === "file"
-              ? publishAdvisories(contentIn, version.content_type)
+            // Advisories over what was just stored (missing viewport meta, oversized
+            // inline base64). `content` holds the full document for both direct and
+            // edits publishes — materializeEdits assigned into it above.
+            (typeof content === "string" && artifact.kind === "file"
+              ? publishAdvisories(content, version.content_type)
                   .map((advisory) => ` ${advisory}`)
                   .join("")
               : ""),

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -58,6 +58,7 @@ import type { Hono } from "hono"
 import { z } from "zod"
 import { BRANDPRINT_REFERENCE, BRANDPRINT_TEMPLATE } from "./brandprint-reference"
 import type { AppContext } from "./context"
+import { DESIGN_REFERENCE } from "./design-reference"
 import { markAddressed } from "./lib/addressed"
 import { afterPublish } from "./lib/after-publish"
 import {
@@ -312,7 +313,7 @@ async function buildServer(
         `history, text-anchored review comments, and a publish → review → revise loop. Fully-styled ` +
         `HTML pages are first-class too: a single-file artifact with its own <style>, scripts, fonts ` +
         `and images renders as-authored in a sandboxed viewer — publish real designed pages, not just ` +
-        `prose. ` +
+        `prose, and read derive://design/reference (the method) before authoring one. ` +
         `Start a session with catch_up to re-sync on what changed and what feedback is open; use ` +
         `read to view content — it returns Markdown by default (HTML is converted) and an outline ` +
         `first for large documents or bundles, so pull sections by heading slug or page path once ` +
@@ -396,6 +397,24 @@ async function buildServer(
       },
     )
   }
+  // The design reference: how to author a styled artifact page, served to every
+  // workspace. It carries the method; the Brandprint profile, when live, carries the
+  // values (its tokens island), and the reference tells the agent to read it first.
+  // Static and versioned like code, same as the Brandprint pair below.
+  server.registerResource(
+    "design:reference",
+    "derive://design/reference",
+    {
+      title: "Designing a styled artifact",
+      description:
+        "The authoring method for fully-styled HTML pages: treatment calibration, type/color/structure rules, the tells of a generated page, and this platform's own rules. Read before authoring; the Brandprint profile supplies the values.",
+      mimeType: "text/markdown",
+      annotations: { audience: ["assistant"], priority: 0.7 },
+    },
+    async (uri) => ({
+      contents: [{ uri: uri.href, mimeType: "text/markdown", text: DESIGN_REFERENCE }],
+    }),
+  )
   // The generation reference: the build guide + the neutral benchmark page, served
   // whenever a Brandprint exists. Derive runs no inference, so these two static files
   // are its entire side of profile generation; the user's agent does the assembling.

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -42,6 +42,7 @@ import {
   parseFrontmatter,
   profileState,
   propose as proposeChange,
+  publishAdvisories,
   publish as publishVersion,
   type Role,
   resolveBrandprint,
@@ -1681,6 +1682,15 @@ async function buildServer(
                 : "Live now — created a new artifact in your workspace.") +
             (actingFor && !openedInTab
               ? " No open Derive tab caught this push — open the url for the user (e.g. run `open <url>`) if they should see it now."
+              : "") +
+            // Detection-driven advisories: a rule delivered at the moment of the
+            // mistake (missing viewport → reflow injected; base64 blobs → use assets)
+            // beats one buried in the tool description. Content-provided single files
+            // only — an edits revision didn't carry the whole document through here.
+            (typeof contentIn === "string" && artifact.kind === "file"
+              ? publishAdvisories(contentIn, version.content_type)
+                  .map((advisory) => ` ${advisory}`)
+                  .join("")
               : ""),
         })
       } catch (e) {

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -19,6 +19,7 @@ import {
   PublishError,
   pageText,
   publish,
+  publishAdvisories,
   type Role,
   renderMarkdown,
   sectionOf,
@@ -792,6 +793,15 @@ export const artifactRoutes = (ctx: AppContext) => {
         }
       }
       const versions = await meta.listVersions(artifact.id)
+      // Detection-driven advisories over what was just stored (no viewport meta →
+      // the reflow injection applies; base64 blobs → they belong in /v1/assets).
+      // Computed HERE so every client — the stdio MCP shim, the CLI, a raw curl —
+      // relays the same guidance without importing server logic.
+      const advisories =
+        artifact.kind === "file" &&
+        (version.content_type === "text/html" || version.content_type === "text/markdown")
+          ? publishAdvisories(new TextDecoder().decode(bytes), version.content_type)
+          : []
       return c.json(
         {
           ...toJson(deps.baseUrl, artifact, versions),
@@ -801,6 +811,7 @@ export const artifactRoutes = (ctx: AppContext) => {
           // to catch content corrupted on the way in. Bundles store a manifest
           // blob, so there is no single-file hash to report.
           ...(artifact.kind === "file" ? { content_sha256: version.blob_key } : {}),
+          ...(advisories.length ? { advisories } : {}),
           ...(roundCreated ? { review_requested: true } : {}),
           ...(openedInTab !== null ? { opened_in_tab: openedInTab } : {}),
         },

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -793,10 +793,9 @@ export const artifactRoutes = (ctx: AppContext) => {
         }
       }
       const versions = await meta.listVersions(artifact.id)
-      // Detection-driven advisories over what was just stored (no viewport meta →
-      // the reflow injection applies; base64 blobs → they belong in /v1/assets).
-      // Computed HERE so every client — the stdio MCP shim, the CLI, a raw curl —
-      // relays the same guidance without importing server logic.
+      // Advisories over what was just stored (missing viewport meta, oversized
+      // inline base64) — computed server-side so every client relays the same
+      // guidance; the boundary rules keep @derive/core out of the clients.
       const advisories =
         artifact.kind === "file" &&
         (version.content_type === "text/html" || version.content_type === "text/markdown")

--- a/apps/api/test/artifacts.test.ts
+++ b/apps/api/test/artifacts.test.ts
@@ -134,6 +134,27 @@ describe("publish html file", () => {
     expect(json.current_version).toBe(1)
   })
 
+  it("returns detection-driven advisories (here: styled page publishing into the reflow injection)", async () => {
+    const res = await upload(
+      "noviewport.html",
+      "<html><head></head><body><h1>x</h1></body></html>",
+      {
+        title: "No viewport",
+      },
+    )
+    const json = await res.json()
+    expect(json.advisories).toHaveLength(1)
+    expect(json.advisories[0]).toContain("viewport")
+
+    // A page that declared its viewport hears nothing — the field is absent entirely.
+    const quiet = await upload(
+      "viewport.html",
+      '<html><head><meta name="viewport" content="width=device-width"></head><body>x</body></html>',
+      { title: "Viewport" },
+    )
+    expect((await quiet.json()).advisories).toBeUndefined()
+  })
+
   it("echoes the stored content's sha256 so a caller can verify byte integrity", async () => {
     const content = "<h1>Checksum me</h1>"
     const res = await upload("sum.html", content, { title: "Sum" })

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -321,6 +321,35 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(refText).toContain("brandprint-tokens")
   })
 
+  it("serves the design reference to every workspace (no Brandprint required)", async () => {
+    const { app, token } = appWithGrant("design-ref", "openid derive:read")
+    await rpc(app, token, initBody)
+    const listed = await rpc(app, token, { jsonrpc: "2.0", id: 3, method: "resources/list" })
+    const uris = (
+      (listed.parsed?.result as { resources?: { uri: string }[] } | undefined)?.resources ?? []
+    ).map((r) => r.uri)
+    expect(uris).toContain("derive://design/reference")
+
+    const ref = await rpc(app, token, {
+      jsonrpc: "2.0",
+      id: 4,
+      method: "resources/read",
+      params: { uri: "derive://design/reference" },
+    })
+    const refText =
+      (ref.parsed?.result as { contents?: { text: string }[] } | undefined)?.contents?.[0]?.text ??
+      ""
+    // The method composes with Brandprint (values) and names the platform rules.
+    expect(refText).toContain("derive://brandprint/profile")
+    expect(refText).toContain("viewport")
+    expect(refText).toContain("/v1/assets")
+
+    // The instructions point at it so an agent authoring a styled page finds it.
+    const init = await rpc(app, token, { ...initBody, id: 5 })
+    const inst = (init.parsed?.result as { instructions?: string }).instructions ?? ""
+    expect(inst).toContain("derive://design/reference")
+  })
+
   it("serves the live profile as the headline resource once it has a real version", async () => {
     const { app, token, meta } = appWithGrant(
       "brandprint-live",

--- a/docs/plans/agent-artifact-learnings.md
+++ b/docs/plans/agent-artifact-learnings.md
@@ -1,0 +1,98 @@
+# What Claude's artifact tooling teaches Derive
+
+Source: a dogfooding session (2026-07-11) where Claude Code published a fully-styled
+HTML artifact to Derive via the remote MCP, followed by a comparison against the same
+agent's *native* artifact tooling — its Artifact tool description, the `artifact-design`
+skill it is required to load before authoring, and the harness behavior around
+publishing. PR #399 shipped the first round of fixes (fonts as assets, reflow escape
+hatch, `content_sha256`, honest tool copy). This doc holds the rest, ranked by leverage.
+
+## 1. Take content by file path, not by string (stdio MCP) — SHIPPED with this doc
+
+Claude's Artifact tool takes a **file path**; the harness reads the bytes itself, so
+page content never travels through the model's token stream. Derive's `publish` takes
+`content` as a string — which is how an 18KB font ended up transcribed by a language
+model and silently corrupted by one wrong character.
+
+The remote `/mcp` can't read files, but `packages/mcp` (the stdio shim) runs on the
+user's machine with fs access. `content_path` there reads the file and POSTs the bytes:
+zero tokens for the page, no transcription surface, and it nudges agents into the
+healthy loop (build locally → verify → publish). Pairs with `content_sha256`: the shim
+can verify the echo against the local file automatically.
+
+## 2. Close the visual verification loop server-side (issue)
+
+The dogfooding bug (a font that failed to parse and silently fell back) was only caught
+because the agent had Playwright to screenshot what Derive actually served. Most agents
+won't — they publish a broken page and report success. Derive already runs a
+preview-render pipeline (#394 enqueues renders on MCP publish); surfacing it to agents —
+a `preview_png` URL in the publish response, or a `get_render` tool — makes
+"publish, then look at what you shipped" the default agent loop. Claude's ecosystem has
+no equivalent; this is a place Derive can lead.
+
+## 3. A theme contract for artifact pages (issue)
+
+Claude artifacts render in the viewer's light/dark theme: the harness stamps
+`data-theme` on the artifact's root element when the viewer toggles, and the tool
+description prescribes the CSS pattern (tokens on `:root`, `prefers-color-scheme` as
+the default signal, `:root[data-theme]` overrides that must win in both directions).
+Derive deliberately doesn't touch iframe content — but it already injects a script into
+every served HTML page (the anchor client) and runs a postMessage protocol with the
+host. Stamping the app theme onto the frame's `<html>` plus documenting the token
+pattern is small, and it fixes dark-mode users getting a blinding white page. Pages
+that ignore the contract behave exactly as today.
+
+## 4. Detection-driven nudges in the publish response — SHIPPED with this doc
+
+The best teaching in Claude's tooling happens in tool *results*, not descriptions.
+Derive already does this (the `note` field) and already sniffs published HTML
+server-side (viewport detection, content-type self-heal). Combining them: when a
+publish will get the mobile-reflow injection (no viewport meta), or embeds large
+base64 data URIs that should be assets, say so in the response note — a rule delivered
+at the moment of the mistake beats one buried in a 200-word description.
+
+## 5. Craft guidance as a reference resource, composed with Brandprint
+
+Before authoring an artifact, Claude is required to load a design skill: treatment
+calibration (a memo is not a landing page), a typography/palette method, and an
+explicit list of AI-default aesthetics to avoid. That skill is a large part of why its
+artifacts stopped looking samey. Derive's SKILL.md covers mechanics; nothing teaches
+craft.
+
+The Brandprint-of-skills architecture (#397) already defines the right slot:
+
+- Ship the method as a **static reference resource** (`derive://design/reference`),
+  a sibling of `brandprint-reference.ts` — versioned like code, zero setup, no
+  inference run by Derive. It teaches the brand-agnostic method: calibrate treatment,
+  pair typefaces deliberately, structure-as-information, the anti-slop list.
+- **Brandprint supplies the values; the design reference supplies the method.**
+  Claude's skill is brand-neutral with a placeholder palette to swap — Derive's version
+  says "swap in the tokens island from `derive://brandprint/profile`." The profile's
+  machine-readable tokens island is exactly the swap target, and the existing
+  precedence chain extends naturally: method defaults < workspace Brandprint <
+  personal Brandprint.
+- Teams that want to tune the aesthetic rules themselves fork it as a workspace
+  **skill** (the #397 machinery makes those discoverable at connect with their own
+  frontmatter identity) — same pattern as customizing a scout.
+- Wire-up is one pointer: the publish description (and the server instructions, next
+  to the Brandprint line) says "authoring a styled page? read `derive://design/reference`
+  first."
+
+## 6. Identity discipline (small, later)
+
+Claude's tool copy is obsessive about artifact identity: same path → same URL, stable
+title, stable per-artifact emoji favicon ("users find their tab by its icon"), new URL
+only on a hard pivot. The failure it guards — an agent minting a new artifact when the
+user meant "update the existing one" — applies to Derive verbatim, and copy is weak
+protection. Stronger: `publish` without `short_id` where a similar-titled artifact
+exists in the workspace returns a soft `did_you_mean: <short_id>` alongside the create.
+The per-artifact emoji favicon is a small, charming tab-navigation feature.
+
+## Already at parity or ahead — don't touch
+
+Private-by-default with human promotion (identical philosophy); version messages and
+named checkpoints (≈ Claude's version labels); teaching-in-results; `edits` (Claude has
+no surgical publish — full rewrites only); the asset store + sandboxed-but-networked
+serving (strictly more capable than Claude's everything-inline CSP, which forces
+base64-ing every image into the page). The gap was never capability — Claude's tooling
+*narrates* its capabilities and constraints relentlessly, and Derive's now does too.

--- a/packages/core/src/advisories.test.ts
+++ b/packages/core/src/advisories.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+import { publishAdvisories } from "./advisories"
+
+const HTML_NO_VIEWPORT = "<!doctype html><html><head><title>x</title></head><body>hi</body></html>"
+const HTML_WITH_VIEWPORT =
+  '<!doctype html><html><head><meta name="viewport" content="width=device-width"></head><body>hi</body></html>'
+
+describe("publishAdvisories", () => {
+  it("flags a styled page publishing into the reflow injection (no viewport meta)", () => {
+    const out = publishAdvisories(HTML_NO_VIEWPORT, "text/html")
+    expect(out).toHaveLength(1)
+    expect(out[0]).toContain("viewport")
+    expect(out[0]).toContain("data-reflow-exempt")
+  })
+
+  it("says nothing when the author declared a viewport (they considered layout)", () => {
+    expect(publishAdvisories(HTML_WITH_VIEWPORT, "text/html")).toHaveLength(0)
+  })
+
+  it("never gives the viewport advisory to markdown", () => {
+    expect(publishAdvisories("# just a doc", "text/markdown")).toHaveLength(0)
+  })
+
+  it("flags large inlined base64 (binaries that should be assets), with the size", () => {
+    const blob = "A".repeat(20 * 1024)
+    const out = publishAdvisories(
+      `${HTML_WITH_VIEWPORT}<img src="data:image/png;base64,${blob}">`,
+      "text/html",
+    )
+    expect(out).toHaveLength(1)
+    expect(out[0]).toContain("/v1/assets")
+    expect(out[0]).toMatch(/~20KB/)
+  })
+
+  it("stays quiet for icon-sized data URIs (under the threshold)", () => {
+    const out = publishAdvisories(
+      `${HTML_WITH_VIEWPORT}<img src="data:image/png;base64,${"A".repeat(2048)}">`,
+      "text/html",
+    )
+    expect(out).toHaveLength(0)
+  })
+
+  it("sums base64 across many small URIs — death by a thousand icons still flags", () => {
+    const imgs = Array.from(
+      { length: 20 },
+      (_, i) => `<img src="data:image/png;base64,${"B".repeat(1024)}${i}">`,
+    ).join("")
+    const out = publishAdvisories(HTML_WITH_VIEWPORT + imgs, "text/html")
+    expect(out).toHaveLength(1)
+  })
+})

--- a/packages/core/src/advisories.ts
+++ b/packages/core/src/advisories.ts
@@ -1,8 +1,7 @@
-// Detection-driven publish advisories. A rule delivered in the publish RESPONSE, at
-// the moment of the mistake, lands where a rule buried in a 200-word tool description
-// doesn't — the agent reads results, then acts. Pure string checks over the content
-// that was just published; both MCP servers append these to their response notes.
-// (Plan: docs/plans/agent-artifact-learnings.md §4.)
+// Publish advisories: pure string checks over just-published content, returned with
+// the publish response (response text reaches agents far more reliably than tool
+// descriptions do). The REST route carries them as a field; both MCP servers fold
+// them into their notes. Plan: docs/plans/agent-artifact-learnings.md §4.
 
 import { needsReflow } from "./reflow"
 
@@ -10,9 +9,8 @@ import { needsReflow } from "./reflow"
 export const publishAdvisories = (content: string, contentType: string): string[] => {
   const out: string[] = []
 
-  // A styled page with no viewport meta gets the mobile-reflow injection, whose
-  // media caps can silently fight an intentional layout (see reflow.ts). Authors who
-  // declared a viewport hear nothing.
+  // A page with no viewport meta gets the mobile-reflow injection, whose media
+  // caps can fight an intentional layout (see reflow.ts).
   if (contentType === "text/html" && needsReflow(content))
     out.push(
       'This page has no <meta name="viewport">, so Derive injects mobile-reflow CSS ' +
@@ -20,9 +18,8 @@ export const publishAdvisories = (content: string, contentType: string): string[
         "opts a component out). Declare your own viewport meta to skip the injection.",
     )
 
-  // Inlined base64 at scale means binaries rode through a tool call — the token-cost
-  // and silent-mistranscription path the asset store exists to replace. Threshold set
-  // well above icon-sized payloads so small data URIs stay quiet.
+  // Large inlined base64 usually means binaries were pasted through a tool call
+  // instead of staged via /v1/assets. The threshold keeps icon-sized data URIs quiet.
   let base64Chars = 0
   for (const m of content.matchAll(/data:[\w/+.-]+;base64,([A-Za-z0-9+/=]+)/g))
     base64Chars += (m[1] ?? "").length

--- a/packages/core/src/advisories.ts
+++ b/packages/core/src/advisories.ts
@@ -1,0 +1,37 @@
+// Detection-driven publish advisories. A rule delivered in the publish RESPONSE, at
+// the moment of the mistake, lands where a rule buried in a 200-word tool description
+// doesn't — the agent reads results, then acts. Pure string checks over the content
+// that was just published; both MCP servers append these to their response notes.
+// (Plan: docs/plans/agent-artifact-learnings.md §4.)
+
+import { needsReflow } from "./reflow"
+
+/** Advisory strings for a just-published single file — empty when nothing to say. */
+export const publishAdvisories = (content: string, contentType: string): string[] => {
+  const out: string[] = []
+
+  // A styled page with no viewport meta gets the mobile-reflow injection, whose
+  // media caps can silently fight an intentional layout (see reflow.ts). Authors who
+  // declared a viewport hear nothing.
+  if (contentType === "text/html" && needsReflow(content))
+    out.push(
+      'This page has no <meta name="viewport">, so Derive injects mobile-reflow CSS ' +
+        "(its media caps can fight intentional layouts; data-reflow-exempt on an element " +
+        "opts a component out). Declare your own viewport meta to skip the injection.",
+    )
+
+  // Inlined base64 at scale means binaries rode through a tool call — the token-cost
+  // and silent-mistranscription path the asset store exists to replace. Threshold set
+  // well above icon-sized payloads so small data URIs stay quiet.
+  let base64Chars = 0
+  for (const m of content.matchAll(/data:[\w/+.-]+;base64,([A-Za-z0-9+/=]+)/g))
+    base64Chars += (m[1] ?? "").length
+  if (base64Chars > 16 * 1024)
+    out.push(
+      `~${Math.round(base64Chars / 1024)}KB of inline base64 data URIs — upload binaries ` +
+        "(images, woff2 fonts) to POST /v1/assets and reference the returned URLs instead: " +
+        "base64 carried through a tool call costs tokens and can be silently mistranscribed.",
+    )
+
+  return out
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./advisories"
 export * from "./anchor"
 export * from "./brandprint"
 export * from "./cross-doc"

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -66,7 +66,7 @@ export interface ArtifactSummaryJson {
 /** A revision submitted for human review instead of published live. */
 export interface ProposeArgs {
   /** Full content for the proposal. Omit when using `edits` instead. */
-  content?: string
+  content?: string | Uint8Array
   filename?: string
   message: string
   /** Thread ids this revision addresses (flip to `addressed`, resolve on approval). */
@@ -283,11 +283,11 @@ export function createClient(opts: ClientOptions): DeriveClient {
         form.append("edits", JSON.stringify(args.edits))
         if (args.baseVersion != null) form.append("base_version", String(args.baseVersion))
       } else {
-        form.append(
-          "file",
-          new Blob([new TextEncoder().encode(args.content ?? "")]),
-          args.filename ?? "index.html",
-        )
+        const bytes =
+          typeof args.content === "string" || args.content === undefined
+            ? new TextEncoder().encode(args.content ?? "")
+            : args.content
+        form.append("file", new Blob([bytes as BlobPart]), args.filename ?? "index.html")
       }
       form.append("message", args.message)
       if (args.addresses?.length) form.append("addresses", args.addresses.join(","))

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,4 +1,6 @@
+import { createHash } from "node:crypto"
 import { readFileSync } from "node:fs"
+import { basename } from "node:path"
 import { fileURLToPath } from "node:url"
 import {
   findAccountWorkspace,
@@ -550,13 +552,19 @@ server.registerTool(
   "publish",
   {
     description:
-      "Publish a single-file artifact and get a permanent URL. OMIT short_id to create a NEW artifact (title recommended); PASS short_id to publish a new version (same URL). To CHANGE PART of an existing artifact, prefer `edits` (exact-match search/replace against the stored source — read format:'html' first) over resending everything via `content`. Pass for_review:true to file it as a PROPOSAL a human approves instead of going live. Pass `addresses` with the thread ids this revision resolves. (Multi-page bundles are published via the web app or the remote /mcp server.) FULLY-STYLED HTML renders as-authored (own <style>/scripts/fonts) in the sandboxed viewer — declare your own <meta name=\"viewport\"> to skip the mobile-reflow injection, and self-host binaries via POST /v1/assets (images and woff2 fonts) instead of inlining base64. The response echoes content_sha256 of the stored bytes — verify it when the content passed through your context.",
+      "Publish a single-file artifact and get a permanent URL. OMIT short_id to create a NEW artifact (title recommended); PASS short_id to publish a new version (same URL). Provide the body as `content_path` (a local file this server reads and uploads — preferred, zero tokens) or `content` (inline text). To CHANGE PART of an existing artifact, prefer `edits` (exact-match search/replace against the stored source — read format:'html' first) over resending everything. Pass for_review:true to file it as a PROPOSAL a human approves instead of going live. Pass `addresses` with the thread ids this revision resolves. (Multi-page bundles are published via the web app or the remote /mcp server.) FULLY-STYLED HTML renders as-authored (own <style>/scripts/fonts) in the sandboxed viewer — declare your own <meta name=\"viewport\"> to skip the mobile-reflow injection, and self-host binaries via POST /v1/assets (images and woff2 fonts) instead of inlining base64.",
     inputSchema: {
       content: z
         .string()
         .optional()
         .describe(
-          "The artifact's full text content (HTML or Markdown). Use this OR `edits`. For images or web fonts, upload the raw bytes to POST /v1/assets (no base64 — binaries carried through a tool call can be silently mistranscribed) and reference the returned URL.",
+          "The artifact's full text content (HTML or Markdown). Use this OR `content_path` OR `edits`. For images or web fonts, upload the raw bytes to POST /v1/assets (no base64 — binaries carried through a tool call can be silently mistranscribed) and reference the returned URL.",
+        ),
+      content_path: z
+        .string()
+        .optional()
+        .describe(
+          "PREFERRED over `content` when the artifact exists as a local file: an absolute path this server reads and uploads as raw bytes — the content never rides through your context (no token cost, no transcription risk), and the stored bytes are verified against the file's sha256 automatically. Build and iterate on the file locally, then publish it by path. Filename defaults to the file's basename.",
         ),
       edits: z
         .array(
@@ -614,6 +622,7 @@ server.registerTool(
   },
   async ({
     content,
+    content_path,
     edits,
     base_version,
     filename,
@@ -629,7 +638,24 @@ server.registerTool(
     workspace: ws,
   }) => {
     const client = clientFor(ws)
-    if (content !== undefined && edits) return text("Provide `content` OR `edits`, not both.")
+    if ([content, content_path, edits].filter((v) => v !== undefined).length > 1)
+      return text("Provide exactly one of `content`, `content_path`, or `edits`.")
+    // The by-path lane: read the bytes HERE (this server runs on the caller's machine)
+    // so the artifact never rides through the agent's context. The sha256 computed off
+    // the local file is checked against the publish response's content_sha256 echo —
+    // any mismatch means the bytes were mangled in transit and the agent must know.
+    let pathBytes: Uint8Array | undefined
+    let pathSha: string | undefined
+    if (content_path !== undefined) {
+      try {
+        pathBytes = new Uint8Array(readFileSync(content_path))
+      } catch (e) {
+        return err(
+          `could not read content_path "${content_path}": ${e instanceof Error ? e.message : "unknown error"}`,
+        )
+      }
+      pathSha = createHash("sha256").update(pathBytes).digest("hex")
+    }
     if (for_review) {
       if (!short_id) return text("A proposal revises an EXISTING artifact — pass its short_id.")
       try {
@@ -657,10 +683,12 @@ server.registerTool(
     try {
       a = await client.publish({
         id: short_id,
-        content,
+        content: pathBytes ?? content,
         edits,
         baseVersion: base_version,
-        filename: filename ?? (edits ? undefined : "index.html"),
+        filename:
+          filename ??
+          (content_path !== undefined ? basename(content_path) : edits ? undefined : "index.html"),
         title,
         workspaceAccess: workspace_access,
         linkRole: link_role,
@@ -672,15 +700,30 @@ server.registerTool(
     } catch (e) {
       return err(e instanceof Error ? e.message : "publish failed")
     }
+    // Integrity check for the by-path lane: the server echoes the sha256 of what it
+    // stored (single-file artifacts); it must be the local file's hash, byte for byte.
+    const echoedSha = (a as { content_sha256?: string }).content_sha256
+    if (pathSha && echoedSha && echoedSha !== pathSha)
+      return err(
+        `content integrity mismatch: local file sha256 ${pathSha} but the server stored ${echoedSha} — the upload was corrupted; retry the publish.`,
+      )
     const note = addresses?.length ? ` · resolved ${addresses.length} thread(s)` : ""
     const openNote =
       a.opened_in_tab === false
         ? " No open Derive tab caught this push — open the url for the user if they should see it now."
         : ""
+    // Detection-driven advisories (missing viewport → reflow injected; base64 blobs
+    // → use assets) are computed SERVER-side and ride the REST response — this shim
+    // is an HTTP client (no @derive/core at runtime), so it only relays them.
+    const advisories = (a as { advisories?: string[] }).advisories
+    const advisoryNote = advisories?.length
+      ? advisories.map((advisory) => ` ${advisory}`).join("")
+      : ""
     return json({
       published: true,
       short_id: a.short_id,
       ...(a.review_requested ? { review_requested: true } : {}),
+      ...(pathSha && echoedSha ? { content_verified: true } : {}),
       version: a.current_version,
       url: a.url,
       title: a.title,
@@ -689,7 +732,8 @@ server.registerTool(
       ...(a.opened_in_tab !== undefined ? { opened_in_tab: a.opened_in_tab } : {}),
       note:
         (short_id ? `Live — new version${note}.` : `Live — created "${a.title}"${note}.`) +
-        openNote,
+        openNote +
+        advisoryNote,
     })
   },
 )

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -640,10 +640,9 @@ server.registerTool(
     const client = clientFor(ws)
     if ([content, content_path, edits].filter((v) => v !== undefined).length > 1)
       return text("Provide exactly one of `content`, `content_path`, or `edits`.")
-    // The by-path lane: read the bytes HERE (this server runs on the caller's machine)
-    // so the artifact never rides through the agent's context. The sha256 computed off
-    // the local file is checked against the publish response's content_sha256 echo —
-    // any mismatch means the bytes were mangled in transit and the agent must know.
+    // content_path: this server runs on the caller's machine, so it reads the file
+    // itself and uploads the bytes — the content never passes through the model. The
+    // local file's sha256 is checked against the response's content_sha256 echo below.
     let pathBytes: Uint8Array | undefined
     let pathSha: string | undefined
     if (content_path !== undefined) {
@@ -660,10 +659,10 @@ server.registerTool(
       if (!short_id) return text("A proposal revises an EXISTING artifact — pass its short_id.")
       try {
         const p = await client.propose(short_id, {
-          content,
+          content: pathBytes ?? content,
           edits,
           baseVersion: base_version,
-          filename,
+          filename: filename ?? (content_path !== undefined ? basename(content_path) : undefined),
           message: message ?? "Proposed revision",
           addresses,
         })
@@ -700,8 +699,8 @@ server.registerTool(
     } catch (e) {
       return err(e instanceof Error ? e.message : "publish failed")
     }
-    // Integrity check for the by-path lane: the server echoes the sha256 of what it
-    // stored (single-file artifacts); it must be the local file's hash, byte for byte.
+    // The server echoes the sha256 of the stored bytes; for a by-path publish it
+    // must match the local file exactly.
     const echoedSha = (a as { content_sha256?: string }).content_sha256
     if (pathSha && echoedSha && echoedSha !== pathSha)
       return err(
@@ -712,9 +711,9 @@ server.registerTool(
       a.opened_in_tab === false
         ? " No open Derive tab caught this push — open the url for the user if they should see it now."
         : ""
-    // Detection-driven advisories (missing viewport → reflow injected; base64 blobs
-    // → use assets) are computed SERVER-side and ride the REST response — this shim
-    // is an HTTP client (no @derive/core at runtime), so it only relays them.
+    // Advisories (missing viewport, oversized inline base64) are computed server-side
+    // and carried on the REST response; this shim is an HTTP client with no @derive/core
+    // at runtime, so it only relays them.
     const advisories = (a as { advisories?: string[] }).advisories
     const advisoryNote = advisories?.length
       ? advisories.map((advisory) => ` ${advisory}`).join("")

--- a/packages/mcp/test/client.test.ts
+++ b/packages/mcp/test/client.test.ts
@@ -170,6 +170,13 @@ describe("derive client (the MCP server's backend) over real HTTP", () => {
     // No `addresses` (default filename) covers the other branch.
     const p2 = await client.propose(a.short_id, { content: "# again", message: "another pass" })
     expect(p2.id).toBeTruthy()
+
+    // Bytes content (the content_path lane) proposes the same as a string.
+    const p3 = await client.propose(a.short_id, {
+      content: new TextEncoder().encode("# from a file"),
+      message: "by path",
+    })
+    expect(p3.id).toBeTruthy()
   })
 
   it("surfaces server errors as thrown messages", async () => {


### PR DESCRIPTION
Stacked on #400 (which stacks on #399). Implements `docs/plans/agent-artifact-learnings.md` §5 — the craft-guidance analog of the skill Claude Code requires its agents to load before authoring an artifact, composed with the Brandprint architecture from #397.

## Shape

- **`apps/api/src/design-reference.ts`** — a static reference resource, sibling of `brandprint-reference.ts`: pure leaf, versioned like code, Derive runs no inference.
- Registered unconditionally as **`derive://design/reference`** (unlike the Brandprint pair it isn't gated on a collection — the method is universal; the profile, when live, supplies the values).
- One pointer added to the server instructions, next to the styled-HTML capability line.

## The content, briefly

Treatment calibration first (a memo is not a landing page — over-designing one reads as not knowing what a memo is), then type/color/structure as deliberate token systems, the named tells of a generated page (deployed only when the user specified nothing — their words always win), and the platform's own rules: viewport meta (reflow opt-out), binaries via `/v1/assets`, and *text stays text* — words baked into images can't take text-anchored review comments, and feedback is what this platform is for. Closes with a pre-publish checklist that leans on #400's advisories.

Precedence is stated in the resource itself: method defaults < workspace Brandprint < personal Brandprint. Teams that want different aesthetics fork this as a workspace skill (the #397 machinery) rather than editing code.

## Editorial note

The content is a draft for your voice pass — it's product copy as much as code. The structure (what sections exist, how it composes with Brandprint) is the load-bearing part; every sentence is fair game.

## Testing

`pnpm run ci` / `typecheck` / `test` green (885 api tests). New test: the resource lists and reads for a workspace with no Brandprint, the body names the profile/viewport/assets rules, and the instructions point at it.