### PR TITLE
fix(realtime): pin anonymous presence identity to a client-carried guest token

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -6814,6 +6814,16 @@
             "required": true,
             "name": "shortId",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "An anonymous viewer's stable guest token; fixes presence to one row per browser."
+            },
+            "required": false,
+            "description": "An anonymous viewer's stable guest token; fixes presence to one row per browser.",
+            "name": "g",
+            "in": "query"
           }
         ],
         "responses": {
@@ -6855,6 +6865,16 @@
             "required": true,
             "name": "shortId",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "An anonymous viewer's stable guest token; fixes presence to one row per browser."
+            },
+            "required": false,
+            "description": "An anonymous viewer's stable guest token; fixes presence to one row per browser.",
+            "name": "g",
+            "in": "query"
           }
         ],
         "responses": {

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -635,6 +635,25 @@ export function buildContext(deps: AppDeps) {
     return vid
   }
 
+  // The PRESENCE identity for an anonymous viewer, taken from a stable token the CLIENT
+  // carries (localStorage) and echoes on every realtime call — the SSE stream (`?g=`), the
+  // heartbeat, and cursor frames. Fixing identity client-side (the PartyKit/Liveblocks
+  // model) is what keeps one browser to ONE presence row: all of a page's concurrent
+  // realtime requests carry the same token, so there is no cookie set-and-read race to fan
+  // a single tab out into several phantom viewers. NON-authoritative and used only for the
+  // display handle/roster key — the caller's role always comes from real auth (see
+  // deriveViewer), never this. The `anon_` namespace + charset strip mean a client value
+  // can't collide with a real `usr_`/session id (no impersonating a signed-in user); it CAN
+  // collide with another anonymous viewer's handle, which is cosmetic and accepted. The
+  // web mirror `guestPresenceId()` (lib/guest-id.ts) must reproduce this exact transform so
+  // an anon viewer recognises its own row. Falls back to the cookie-minted id for a caller
+  // that sends no token (an older client, or curl). The `derive_vid` cookie now serves
+  // unique-view analytics only (see analytics.ts).
+  const guestViewerId = (c: Context): string => {
+    const clean = (c.req.query("g") ?? "").replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 40)
+    return clean ? `anon_${clean}` : anonViewerId(c)
+  }
+
   const actorFor = async (c: Context, a: ArtifactRecord): Promise<Actor> => {
     // A password on the artifact is a lock on its public link. Has this visitor
     // entered it? The unlock cookie's value is derived from the server-only
@@ -875,6 +894,7 @@ export function buildContext(deps: AppDeps) {
     activeWorkspace,
     setWsCookie,
     anonViewerId,
+    guestViewerId,
     actorFor,
     authorize,
     authorizeStanding,

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -1,6 +1,5 @@
 import { can, newId } from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
-import { getCookie, setCookie } from "hono/cookie"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
 import { bail, fail, readJson, VIEW_DEDUP_MS } from "../lib/http"
@@ -8,7 +7,7 @@ import { bail, fail, readJson, VIEW_DEDUP_MS } from "../lib/http"
 /** View recording (de-duped, owner self-views excluded) + per-artifact stats. The
  *  Analytics response schema is the single source for the web client's type. */
 export const analyticsRoutes = (ctx: AppContext) => {
-  const { meta, deps, analyticsOn, currentUser, actorFor, requireArtifact, authorize } = ctx
+  const { meta, analyticsOn, currentUser, actorFor, anonViewerId, requireArtifact, authorize } = ctx
   const app = new OpenAPIHono<BlankEnv>()
 
   const Analytics = z
@@ -77,31 +76,12 @@ export const analyticsRoutes = (ctx: AppContext) => {
       )
         return c.body(null, 204)
       const me = await currentUser(c)
-      let viewer: string
-      let kind: "user" | "anon"
-      if (me) {
-        // Stable identity = the account. The same signed-in person is one viewer,
-        // shown by name — never "anonymous".
-        viewer = me.id
-        kind = "user"
-      } else {
-        // A long-lived first-party cookie keeps the same browser as one anonymous
-        // viewer across opens. SameSite=None;Secure when the SPA is cross-site, so
-        // it actually sticks there (Lax would be dropped on the cross-site fetch).
-        let vid = getCookie(c, "derive_vid")
-        if (!vid) {
-          vid = newId("anon")
-          setCookie(c, "derive_vid", vid, {
-            path: "/",
-            maxAge: 60 * 60 * 24 * 365,
-            httpOnly: true,
-            sameSite: deps.crossSite ? "None" : "Lax",
-            secure: deps.crossSite || new URL(deps.baseUrl).protocol === "https:",
-          })
-        }
-        viewer = vid
-        kind = "anon"
-      }
+      // Stable identity per viewer: a signed-in account counts once by id; an anonymous
+      // opener by their long-lived `derive_vid` cookie (minted on first sight), so unique
+      // counts hold across opens. This cookie is the view-count anchor ONLY — presence
+      // identity is the client-carried guest token (see context.ts guestViewerId).
+      const viewer = me ? me.id : anonViewerId(c)
+      const kind: "user" | "anon" = me ? "user" : "anon"
       const body = await readJson(c, z.object({ version: z.number().int().optional() }))
       if (body instanceof Response) return bail(body)
       const version = body.version ?? artifact.current_version

--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -20,7 +20,7 @@ export const realtimeRoutes = (ctx: AppContext) => {
     actingUser,
     currentUser,
     actorFor,
-    anonViewerId,
+    guestViewerId,
     requireArtifact,
   } = ctx
   const app = new OpenAPIHono<BlankEnv>()
@@ -40,11 +40,27 @@ export const realtimeRoutes = (ctx: AppContext) => {
     })
     .openapi("Viewer")
 
-  // Server-derived presence identity (never client-supplied): a signed-in user by
-  // their public @handle, an anonymous viewer by a stable friendly handle keyed to
-  // their viewer cookie (no PII, no impersonation). `role` is their effective role on
-  // this artifact, so name/role can't be forged either. Shared by the SSE-lifecycle
-  // presence (join/leave) and the heartbeat backstop.
+  // The anonymous viewer's stable guest token (see guestViewerId). Declared on the
+  // contract routes below so it's visible in the OpenAPI spec + generated types; the SSE
+  // `/events` route reads the same param but is a plain route (streams can't be contract
+  // JSON). Signed-in callers are resolved from their session and ignore it.
+  const GuestQuery = z.object({
+    g: z
+      .string()
+      .optional()
+      .describe("An anonymous viewer's stable guest token; fixes presence to one row per browser."),
+  })
+
+  // Presence identity: a signed-in user by their public @handle + id; an anonymous viewer
+  // by a stable friendly handle derived from the guest token their browser carries (see
+  // guestViewerId). Derived ONCE per call (id and name from the same token, never two mints).
+  // `role` is the caller's EFFECTIVE role from real auth (session / link access / password
+  // unlock) — never from the token — so no capability can be forged, and a signed-in user
+  // can't be impersonated (anon ids are `anon_`-namespaced). The anonymous *display handle*
+  // IS a function of the client token, so it's chosen/collidable between anonymous viewers —
+  // an accepted, cosmetic trade-off (same as PartyKit/Liveblocks client-set ids); it names
+  // nobody real. Shared by the SSE-lifecycle presence and the heartbeat, so both agree on
+  // one identity per browser.
   const deriveViewer = async (
     c: Context,
     artifact: Parameters<typeof actorFor>[1],
@@ -55,9 +71,9 @@ export const realtimeRoutes = (ctx: AppContext) => {
       artifact.workspace_access,
       artifact.link_role,
     )
-    return me
-      ? { id: me.id, name: me.username ?? "someone", role }
-      : { id: anonViewerId(c), name: anonName(anonViewerId(c)), role }
+    if (me) return { id: me.id, name: me.username ?? "someone", role }
+    const gid = guestViewerId(c)
+    return { id: gid, name: anonName(gid), role }
   }
   // Per-connection key so a viewer's multiple tabs ref-count correctly on the
   // in-process backplane (the DO keys presence on the stream object itself).
@@ -113,7 +129,7 @@ export const realtimeRoutes = (ctx: AppContext) => {
       path: "/v1/artifacts/{shortId}/presence",
       tags: ["Realtime"],
       summary: "Presence heartbeat — keep this viewer on the artifact's roster.",
-      request: { params: z.object({ shortId: z.string() }) },
+      request: { params: z.object({ shortId: z.string() }), query: GuestQuery },
       responses: {
         200: {
           description: "The current viewers on this artifact.",
@@ -139,7 +155,7 @@ export const realtimeRoutes = (ctx: AppContext) => {
       path: "/v1/artifacts/{shortId}/cursor",
       tags: ["Realtime"],
       summary: "Broadcast a live cursor frame to the artifact's other viewers.",
-      request: { params: z.object({ shortId: z.string() }) },
+      request: { params: z.object({ shortId: z.string() }), query: GuestQuery },
       responses: { 204: { description: "Fanned out (ephemeral; nothing stored)." } },
     }),
     async (c) => {
@@ -162,10 +178,10 @@ export const realtimeRoutes = (ctx: AppContext) => {
       )
       if (body instanceof Response) return bail(body)
       const clamp = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n)
-      // Same server-derived identity as presence: a signed-in user/agent by their
-      // account name, an anonymous viewer by their stable rando handle — never a
+      // Same identity as presence: a signed-in user/agent by their account name, an
+      // anonymous viewer by the stable handle derived from their guest token — never a
       // client-supplied label. So a cursor and its presence row share one identity.
-      const name = (await actingUser(c))?.name ?? anonName(anonViewerId(c))
+      const name = (await actingUser(c))?.name ?? anonName(guestViewerId(c))
       const kind = body.kind ?? "arrow"
       bus.publish(artifact.id, {
         type: "cursor",

--- a/apps/api/test/realtime.test.ts
+++ b/apps/api/test/realtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { type Backplane, createInProcessBackplane, type DeriveEvent } from "../src/bus"
+import { anonName } from "../src/lib/http"
 import { bearer, json, publishAs, quotaApp, TEST_TOKEN } from "./helpers"
 
 // The live-cursor frame is the wire contract between viewers: it carries a chosen
@@ -78,5 +79,56 @@ describe("live cursor frame", () => {
     const { cursor } = await seed()
     expect((await cursor({ id: "d", emoji: "x".repeat(64), x: 0, y: 0 })).status).toBe(400)
     expect((await cursor({ id: "d", kind: "rainbow", x: 0, y: 0 })).status).toBe(400)
+  })
+})
+
+// Presence identity is pinned to the guest token the browser carries (`?g=`), so one
+// browser is one "viewing now" row — never several phantoms from a cookie raced across a
+// page's concurrent mount requests (the bug this replaced). The token is opaque: the
+// server derives the handle from it and never trusts it for anything else.
+describe("presence identity (one browser = one viewer)", () => {
+  const seed = async () => {
+    const { app } = quotaApp("realtime-presence", {})
+    const { short_id } = await (
+      await publishAs(app, "<h1>doc</h1>", { visibility: "public" }, bearer(TEST_TOKEN))
+    ).json()
+    const roster = async (token?: string) =>
+      (
+        (await (
+          await app.request(
+            `/v1/artifacts/${short_id}/presence${token ? `?g=${encodeURIComponent(token)}` : ""}`,
+            json({}),
+          )
+        ).json()) as { viewers: { id: string; name: string }[] }
+      ).viewers
+    return { roster }
+  }
+
+  it("collapses repeated heartbeats from one guest token to a single viewer", async () => {
+    const { roster } = await seed()
+    const first = await roster("alpha")
+    expect(first).toHaveLength(1)
+    // Identity + display handle both come from the one token — no id/name split.
+    expect(first[0]?.id).toBe("anon_alpha")
+    expect(first[0]?.name).toBe(anonName("anon_alpha"))
+    // A second beat with the SAME token is the SAME viewer, not a phantom second row.
+    const again = await roster("alpha")
+    expect(again).toHaveLength(1)
+    expect(again[0]?.id).toBe("anon_alpha")
+  })
+
+  it("keeps distinct guest tokens (e.g. a private tab) as distinct viewers", async () => {
+    const { roster } = await seed()
+    await roster("alpha")
+    const both = await roster("beta")
+    expect(both.map((v) => v.id).sort()).toEqual(["anon_alpha", "anon_beta"])
+  })
+
+  it("sanitizes + namespaces the token so a client can't forge a real user id", async () => {
+    const { roster } = await seed()
+    const one = await roster("usr_boss!! drop")
+    expect(one).toHaveLength(1)
+    // Punctuation/whitespace stripped, then namespaced under anon_ — can never equal usr_boss.
+    expect(one[0]?.id).toBe("anon_usr_bossdrop")
   })
 })

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -4108,7 +4108,10 @@ export interface paths {
         /** Presence heartbeat — keep this viewer on the artifact's roster. */
         post: {
             parameters: {
-                query?: never;
+                query?: {
+                    /** @description An anonymous viewer's stable guest token; fixes presence to one row per browser. */
+                    g?: string;
+                };
                 header?: never;
                 path: {
                     shortId: string;
@@ -4148,7 +4151,10 @@ export interface paths {
         /** Broadcast a live cursor frame to the artifact's other viewers. */
         post: {
             parameters: {
-                query?: never;
+                query?: {
+                    /** @description An anonymous viewer's stable guest token; fixes presence to one row per browser. */
+                    g?: string;
+                };
                 header?: never;
                 path: {
                     shortId: string;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,5 +1,6 @@
 import type { LinkRole, Listed, Role, WorkspaceAccess } from "@derive/core"
 import type { components } from "./api-types"
+import { guestQuery } from "./lib/guest-id"
 
 /** The role vocabulary and the v2 access model's three single-purpose fields are
  *  canonical in @derive/core (roles.ts); imported here as type-only (clients never
@@ -586,9 +587,11 @@ export const api = {
     f(`/v1/workspace/domains/${host}`, { method: "DELETE", credentials: "include" }).then(
       () => undefined,
     ),
-  // Identity is derived server-side from the session/cookie, so we send nothing.
+  // Presence identity: a signed-in caller is resolved from their session server-side; an
+  // anonymous caller carries their stable guest token (`?g=`) so the heartbeat and the SSE
+  // stream agree on ONE viewer per browser (see lib/guest-id).
   heartbeat: (id: string): Promise<{ viewers: Viewer[] }> =>
-    f(`/v1/artifacts/${id}/presence`, opts({})).then(j),
+    f(`/v1/artifacts/${id}/presence${guestQuery()}`, opts({})).then(j),
 
   favorite: (id: string, on: boolean): Promise<{ favorite: boolean }> =>
     f(`/v1/artifacts/${id}/favorite`, { ...opts(), method: on ? "PUT" : "DELETE" }).then(j),

--- a/apps/web/src/lib/guest-id.test.ts
+++ b/apps/web/src/lib/guest-id.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest"
+import { guestQuery, namespaceGuest } from "./guest-id"
+
+// `namespaceGuest` MUST reproduce the server's `guestViewerId` transform (apps/api
+// context.ts) byte-for-byte, so an anonymous viewer recognises its own presence row. These
+// cases mirror the server's own test (apps/api/test/realtime.test.ts "sanitizes + namespaces")
+// — if one side's transform changes, one of the two suites goes red.
+describe("namespaceGuest (client mirror of server guestViewerId)", () => {
+  it("prefixes a clean token unchanged", () => {
+    expect(namespaceGuest("550e8400-e29b-41d4-a716-446655440000")).toBe(
+      "anon_550e8400-e29b-41d4-a716-446655440000",
+    )
+  })
+  it("strips chars outside [A-Za-z0-9_-]", () => {
+    expect(namespaceGuest("usr_boss!! drop")).toBe("anon_usr_bossdrop")
+  })
+  it("caps the token at 40 chars", () => {
+    expect(namespaceGuest("x".repeat(50))).toBe(`anon_${"x".repeat(40)}`)
+  })
+})
+
+// Off a browser (SSR/prerender) there's no identity and no realtime connection, so the query
+// fragment is empty and the server falls back to the view cookie.
+describe("guestQuery", () => {
+  it("is empty when there's no browser identity", () => {
+    expect(guestQuery()).toBe("")
+  })
+})

--- a/apps/web/src/lib/guest-id.ts
+++ b/apps/web/src/lib/guest-id.ts
@@ -1,0 +1,59 @@
+import { STORAGE_KEYS } from "./storage-keys"
+
+// A stable, per-browser anonymous identity for realtime presence — generated once, kept in
+// localStorage, and sent EXPLICITLY on every realtime call (the SSE connect `?g=`, the
+// presence heartbeat, and cursor frames). This is the SOTA model (PartyKit/Liveblocks: the
+// client fixes its own connection identity): because one browser carries ONE token across
+// all of a page's concurrent requests, an anonymous viewer can never fan out into several
+// phantom "viewing now" rows — which a server-minted cookie, set on one request but not yet
+// echoed on the sibling requests it races, cannot guarantee. The token is opaque and
+// non-authoritative: the server derives the display handle from it and the viewer's role
+// from real auth, so choosing a token grants nothing. Signed-in viewers still show up by
+// their account, so this only ever names an anonymous one.
+let cached = ""
+
+export function getGuestId(): string {
+  if (cached) return cached
+  // Prerender/SSR has no browser identity and never opens a realtime connection.
+  if (typeof window === "undefined") return ""
+  const fresh = () =>
+    typeof crypto !== "undefined" && crypto.randomUUID
+      ? crypto.randomUUID()
+      : `g_${Math.random().toString(36).slice(2)}${Math.random().toString(36).slice(2)}`
+  try {
+    // `||` not `??`: a stored empty string is corrupt, not an identity — regenerate it,
+    // else we'd send `?g=` empty forever and fall back into the very cookie race this fixes.
+    cached = localStorage.getItem(STORAGE_KEYS.guestId) || fresh()
+    localStorage.setItem(STORAGE_KEYS.guestId, cached)
+  } catch {
+    // Storage blocked (private mode / hardened settings): fall back to an in-memory id.
+    // Still ONE identity for this tab's lifetime, so it stays a single presence row.
+    cached = fresh()
+  }
+  return cached
+}
+
+// The `?g=` fragment carrying this browser's guest token to a realtime endpoint. Empty
+// when there's no browser identity (SSR) — the server then falls back to the view cookie.
+export function guestQuery(): string {
+  const id = getGuestId()
+  return id ? `?g=${encodeURIComponent(id)}` : ""
+}
+
+// The server's `guestViewerId` transform (apps/api context.ts), mirrored byte-for-byte:
+// strip everything outside [A-Za-z0-9_-], cap at 40, prefix `anon_`. Kept as a mirror rather
+// than a shared import because the client bundle must not pull in server/core code at runtime
+// (same convention as parse-ref.ts mirroring core's parseRef). Exported pure so a unit test
+// can pin it against the server's own test without needing a DOM.
+export function namespaceGuest(token: string): string {
+  return `anon_${token.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 40)}`
+}
+
+// This browser's OWN row in the presence roster, so an anonymous viewer can recognise itself
+// ("(you)") and be filtered out of "others viewing" — a signed-in viewer uses their user id
+// instead. MUST byte-match what the server broadcasts (hence namespaceGuest above). Only
+// possible at all because the client now owns the token — an httpOnly cookie id could never
+// be read here, which is why anon self-recognition wasn't possible before.
+export function guestPresenceId(): string {
+  return namespaceGuest(getGuestId())
+}

--- a/apps/web/src/lib/storage-keys.ts
+++ b/apps/web/src/lib/storage-keys.ts
@@ -18,6 +18,10 @@ export const STORAGE_KEYS = {
   // of restoring it — set by reloadAfterWorkspaceChange (lib/persist) when the active
   // workspace changes, so another workspace's cache can't be rehydrated.
   cacheReset: "derive.cache.reset",
+  // A stable, per-browser anonymous identity for realtime PRESENCE — generated once and
+  // echoed on every realtime call, so one browser stays one "viewing now" row instead of
+  // racing a server cookie into several phantom viewers (see lib/guest-id).
+  guestId: "derive.guest",
   // Legacy literals (the colon convention predates the dot switch) — kept as-is so a
   // saved onboarding flag / folder pref survives the rename.
   onboarded: "derive:onboarded",

--- a/apps/web/src/pages/artifact/cursors/use-cursor-send.ts
+++ b/apps/web/src/pages/artifact/cursors/use-cursor-send.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from "react"
 import { API_BASE } from "@/api"
 import { useCursorPref } from "@/ctx"
 import { CURSOR_TUNING } from "@/lib/cursors"
+import { guestQuery } from "@/lib/guest-id"
 
 // The SENDING half of the live-cursor engine: our own pointer → the server (throttled),
 // our chosen look, and explicit leave / tap signals — plus a focus/idle state machine so
@@ -33,7 +34,8 @@ export function useCursorSend(
   const send = useCallback(
     (extra: Record<string, unknown>) => {
       const pt = xy.current ?? [0, 0]
-      fetch(`${API_BASE}/v1/artifacts/${shortId}/cursor`, {
+      // `?g=` so the cursor's server-derived handle matches this browser's presence row.
+      fetch(`${API_BASE}/v1/artifacts/${shortId}/cursor${guestQuery()}`, {
         method: "POST",
         headers: { "content-type": "application/json" },
         credentials: "include",

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -9,6 +9,7 @@ import { Kbd } from "@/components/ui/kbd"
 import { toast } from "@/components/ui/sonner"
 import { useAuth } from "@/ctx"
 import { artifactTypeLabel } from "@/lib/artifact"
+import { guestPresenceId } from "@/lib/guest-id"
 import { artifactAgentsQuery, artifactQuery, commentsQuery } from "@/lib/queries"
 import { ago } from "@/lib/time"
 import { snapshot, useApiMutation } from "@/lib/use-api-mutation"
@@ -566,6 +567,7 @@ export function Artifact() {
         art={art}
         returnTo={`/artifacts/${ref}`}
         viewers={live.viewers}
+        selfId={guestPresenceId()}
         isMobile={isMobile}
       >
         {documentEl}

--- a/apps/web/src/pages/artifact/use-artifact-live.ts
+++ b/apps/web/src/pages/artifact/use-artifact-live.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import { API_BASE, api, type Viewer } from "@/api"
+import { guestQuery } from "@/lib/guest-id"
 import { useOnline } from "@/lib/use-online"
 import { usePageVisible } from "@/lib/use-page-visible"
 import { useLiveCursors } from "./cursors/use-live-cursors"
@@ -59,7 +60,10 @@ export function useArtifactLive(opts: {
   // re-establishes, which recovers the rarer server-error CLOSED case too.
   useEffect(() => {
     if (!visible || !online) return
-    const ev = new EventSource(`${API_BASE}/v1/artifacts/${shortId}/events`, {
+    // `?g=` carries this browser's stable guest identity to the presence roster, so an
+    // anonymous viewer is ONE row here and on the heartbeat below — not a cookie raced
+    // across concurrent requests into several phantoms (see lib/guest-id).
+    const ev = new EventSource(`${API_BASE}/v1/artifacts/${shortId}/events${guestQuery()}`, {
       withCredentials: true,
     })
     // Connection health for the cue: onerror flips to reconnecting; the server's `ready` hello


### PR DESCRIPTION
## The bug

Opening an artifact in a private/incognito tab while the owner was viewing showed **more viewers than there were people** — e.g. the owner saw "3 viewing now" (themselves + two phantom anonymous viewers) for a single incognito tab.

## Root cause (verified against Hono 4.12.25 source + SOTA research)

Anonymous presence identity was derived **per HTTP request** from a lazily-minted `derive_vid` cookie. On mount, three requests fire near-simultaneously — the SSE `/events` stream, the `/presence` heartbeat, and `recordView` — each before any cookie has landed, so **each minted a different `anon_*` id and registered its own roster row**. The open SSE stream then pins its orphaned id for the whole session (never pruned). Compounding it:

- On the **Cloudflare/DO path**, the SSE route returns the DO's raw `Response` (`return direct`), which **drops the `Set-Cookie`** — Hono never merges its prepared headers onto an externally-produced Response — so the stream's id could *never* be the persisted one, making the phantom reliably reproducible on prod.
- `deriveViewer` minted the anon id **twice on one line** (`getCookie` reads the request, `setCookie` writes the response, so the second call minted again).

These are the exact anti-patterns every SOTA presence system (Liveblocks, Cloudflare DO/PartyKit, Yjs awareness, Phoenix, Google Docs) is built to avoid: *per-request-derived identity*, a *guest cookie raced across concurrent requests*, and *heartbeats on a different channel than the stream*.

## The fix — connection-scoped identity (the SOTA model)

The browser fixes its **own stable token** (localStorage) and carries it on every realtime call via `?g=` — the SSE stream, the heartbeat, and cursor frames — so **one browser is one roster row** regardless of request timing or the cookie. The token is opaque and non-authoritative: the display handle is derived from it, but **role/capabilities still come from real auth**, and it's namespaced `anon_` so it can't collide with a real user id. The `derive_vid` cookie now serves unique-view analytics only.

Also enables anon **self-recognition** ("(you)" + self-filtering), which was impossible while the id lived in an httpOnly cookie the client couldn't read.

## Changes

- **server**: `ctx.guestViewerId` reads/sanitizes/namespaces `?g=`; `deriveViewer` single-mints; cursor name matches presence
- **web**: `lib/guest-id` (`getGuestId`/`guestQuery`/`guestPresenceId`/`namespaceGuest`) threaded through the SSE URL, `api.heartbeat`, and the cursor POST; `PublicViewer` passes `selfId`
- `?g=` declared on the presence + cursor OpenAPI routes (contract + web types regenerated)
- `analytics.ts` de-duped onto `ctx.anonViewerId` (cookie = view-count only)
- **tests**: server roster contract (`realtime.test.ts`) + client mirror of the namespacing (`guest-id.test.ts`)

## Verification

- API typecheck + web typecheck ✅
- Full API suite **865** ✅ · full web suite **150** (+4 new) ✅
- biome + all CI guards (contract, api-types, mutations, frontend, boundaries, …) ✅
- Adversarial code review (8 finder angles); every surfaced issue fixed — self-heal on a corrupt token (`||` not `??`), contract-first declaration of `?g=`, client/server mirror hardening, and comment accuracy on the (accepted, cosmetic) anon-handle collision surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)