### PR TITLE
docs(cursors): correct the identity-tint claims (no behavior change)

### DIFF
--- a/apps/web/src/lib/cursors.ts
+++ b/apps/web/src/lib/cursors.ts
@@ -1,8 +1,10 @@
 // The live-cursor domain — one source of truth for the on-canvas overlay and the
-// one preference (hide). A peer's identity color is NOT here and NOT on the wire:
-// it's derived from their name via the app's shared avatar tint (`colorForName`),
-// so a person is the same color on their cursor, avatar, and presence row. No
-// per-cursor look to pick — the design language rations color and forbids emoji.
+// one preference (hide). A peer's color is NOT here and NOT on the wire: it's
+// derived from their name via `colorForName` (the shared identity palette avatar
+// tints draw from), keyed on the SAME server-stamped handle that names them in the
+// presence roster — so each peer keeps one stable, distinct tint for the session,
+// with the name tag carrying identity. No per-cursor look to pick — the design
+// language rations color and forbids emoji.
 //
 // Nothing here touches React or the DOM: just the wire vocabulary, the one pref,
 // and the animation/lifecycle tuning.

--- a/apps/web/src/pages/artifact/cursors/use-cursor-paint.ts
+++ b/apps/web/src/pages/artifact/cursors/use-cursor-paint.ts
@@ -10,9 +10,10 @@ import { CURSOR_TUNING, type CursorFrame, effectiveDocH, placePeer } from "@/lib
 // viewport edge collapse into an edge indicator. React only re-renders when the roster
 // changes (a peer joins, leaves, or is renamed) or a ripple fires; every-frame motion is
 // written straight to the DOM via refs, never through React. A peer's color isn't sent —
-// it's their identity tint, derived from their name (`colorForName`) so their cursor
-// matches their avatar. The SENDING half (our own pointer → server) lives in
-// use-cursor-send. `selfId` is shared so we ignore our own echoed frames.
+// it's derived from their name (`colorForName`, the shared identity palette), keyed on the
+// same server-stamped handle presence uses, so each peer keeps one stable, distinct tint.
+// The SENDING half (our own pointer → server) lives in use-cursor-send. `selfId` is shared
+// so we ignore our own echoed frames.
 
 /** A peer entry the overlay mounts/unmounts (no per-frame churn). Color is the peer's
  *  identity tint, derived once from their name so it matches their avatar. */

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -454,9 +454,14 @@ variants.
   **Comments** toggle hugging the panel it opens. Everything that used to crowd the row
   (Present / Insights / History / Proposals / Edit / Lock / Report / Tags / Collections) now
   lives behind the ⋯ — the render is the hero, the chrome recedes.
-- **Live cursors** — peers' cursors are a slim arrow tinted by their **identity** (the same
-  `colorForName` tint as their avatar and presence dot — color follows the person, never a
-  per-cursor pick), with a `font-medium` name flag that fades on stillness. There is no style
+- **Live cursors** — peers' cursors are a slim arrow tinted by their **identity**: a stable,
+  distinct tint from the shared identity palette (`colorForName`, the same palette avatar
+  tints draw from), keyed on the server-stamped handle that also names them in presence.
+  Color follows the person — one tint per peer for the session, never a per-cursor pick — with
+  a `font-medium` name flag that fades on stillness. (Today that palette is a cursor-only
+  accent in the artifact view; the presence facepile still reads you-vs-them in `primary`/
+  `accent`. Unifying the two on `colorForName` — so a cursor and its facepile row share a
+  color — is the obvious next coherence step, deferred as its own call.) There is no style
   selector: a picker of colors + emoji would break both *color is rationed* and *never emojis*.
   The one real preference — **Hide live cursors** — is a checkbox item in the ⋯ menu's view-
   modes group beside Focus; it opts you out of the whole layer (peers vanish, yours stops


### PR DESCRIPTION
Follow-up to #411 — a self-audit found no runtime bug, but my own comments/docs overstated the cursor's color coherence. Comment/doc-only corrections, zero behavior change.

## The overclaim
#411 described a peer's cursor as "the same `colorForName()` tint as their **avatar and presence dot**." Neither holds:

- **Presence facepile** reads you-vs-them in `primary`/`accent` (`rail-deck.tsx` `presenceTint`), *not* `colorForName` — so the cursor matches nothing shown next to it in the header.
- **Feed/comment avatars** key on the display name (`name ?? username`), while the cursor keys on the server-stamped **handle** (deliberately — that's the presence identity, and the only name that crosses the wildcard-CORS SSE privacy boundary). Different colors whenever a display name exists.

## What's accurate
The tint is still well-chosen: a **stable, distinct per-peer color from the shared identity palette, keyed on the same handle presence uses**, with the name tag carrying identity. It does its job (tell simultaneous cursors apart). It's just *cursor-only* in the artifact view today — not a facepile match.

## Fixes
- Correct the header comments in `cursors.ts` and `use-cursor-paint.ts`.
- Rewrite the **Live cursors** note in `design-system.md` to state the truth, and record the obvious next coherence step (tint the presence facepile — and comment avatars — by `colorForName` too, so a cursor and its facepile row share a color) as a **deferred, separate design call** (it adds identity color to the facepile).

## Also corrected (in #411's description, not code)
My "anon viewers lost the hide toggle" caveat was wrong: anonymous viewers render through `PublicViewer`, which never had live cursors at all — the old `CursorButton` sat *after* the `if (isAnon) return <PublicViewer>` early return. No anon regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)