### PR TITLE
Release: @derive-to/cli 0.4.0 + @derive-to/mcp 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,17 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once it reache
   and structured logging introduced. No behavior change.
 
 ### Added
+- `@derive-to/mcp` 0.5.0 — `content_path` on `publish`: pass an absolute path and the
+  stdio server reads and uploads the file's raw bytes itself, so page content never
+  passes through the agent's context (no token cost, no transcription risk). The
+  local file's sha256 is verified against the server's `content_sha256` echo — a
+  corrupted upload is a hard error, and a clean one reports `content_verified`.
+  Works for proposals (`for_review`) too; the filename defaults to the file's
+  basename. Publish responses now also relay the server's `advisories`.
+- `@derive-to/cli` 0.4.0 — republish carrying the `./publish` export the workspace
+  gained in the unified cli/mcp publish refactor; npm's 0.3.0 predates it, which
+  would have made mcp 0.5.0 uninstallable (its client imports
+  `@derive-to/cli/publish`). Publish the CLI before the MCP server.
 - Binary asset uploads for bundles: `POST /v1/assets` stores raw image bytes
   content-addressed (dedup by hash) and returns an `asset:<hash>` handle; a `publish`
   `files` value may now be that handle instead of an inline base64 data URI. An agent

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@derive-to/cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "description": "CLI for Derive — init a project, publish versioned artifacts, and run the publish → review → revise loop from the terminal.",
   "keywords": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@derive-to/mcp",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "description": "Stdio MCP server for Derive — list, read, catch up on, comment on, and publish artifacts on a Derive instance.",
   "keywords": [


### PR DESCRIPTION
Version bumps + changelog for publishing the #400 stdio work to npm.

## Why the CLI is in here

Packing mcp 0.5.0 against npm's `@derive-to/cli@0.3.0` produced an uninstallable-in-practice package: the new client imports `@derive-to/cli/publish`, an export the workspace gained in the unified-publish refactor (#391) **without a version bump** — so workspace 0.3.0 and npm 0.3.0 quietly diverged. Caught by installing the packed tarball into a clean project (the smoke found `ERR_PACKAGE_PATH_NOT_EXPORTED` immediately). Same failure family as the 0.4.0 workspace-protocol incident the changelog already records.

## Verification

- Both tarballs packed with `pnpm pack` (workspace dep rewrites to `0.4.0` — asserted, not eyeballed).
- Installed both into a clean npm project and completed a real MCP `initialize` handshake over stdio against derive.to; clean stderr.

## Publish order (after merge, from main)

```bash
cd packages/cli && pnpm publish   # first — mcp 0.5.0 depends on it
cd ../mcp      && pnpm publish
```

`pnpm publish`, not `npm publish` — npm ships the raw `workspace:*` protocol (the 0.4.0 incident). Both packages carry `publishConfig.access: public`.

## Worth considering as a follow-up guardrail

The root cause — a package's public surface changing without a version bump — is machine-checkable: a `scripts/check-*` that diffs each publishable package's `exports`/`files` against its published version on npm and fails when they differ without a bump. Cheap, and this is the second incident in that family.