### PR TITLE
fix(mcp): stdio read accepts format:'html' — release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,11 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once it reache
   `CODE_OF_CONDUCT.md`, issue + PR templates, `.editorconfig`.
 
 ### Fixed
+- `@derive-to/mcp` 0.5.1 — the stdio `read` tool now accepts `format:'html'`. Its
+  schema only allowed markdown/text while the publish description said "read
+  format:'html' first" before `edits` — following the server's own guidance was a
+  validation error (remote `/mcp` always accepted html). Found dogfooding 0.5.0.
+  Publish responses also surface `content_sha256` now, matching REST and remote.
 - `@derive-to/mcp` 0.4.1 — republish with the `@derive-to/cli` dependency resolved to
   a real version. 0.4.0 shipped it as the raw `workspace:*` protocol (published with
   `npm` instead of `pnpm`), which is uninstallable; 0.4.0 is deprecated.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@derive-to/mcp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "description": "Stdio MCP server for Derive — list, read, catch up on, comment on, and publish artifacts on a Derive instance.",
   "keywords": [

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -157,7 +157,7 @@ export interface ContentOpts {
   version?: number
   /** A heading slug (single-file) or page path (bundle, optionally page#slug). */
   section?: string
-  format?: "markdown" | "text"
+  format?: "markdown" | "text" | "html"
 }
 
 /** A content read: the body plus the server's X-Derive-* capability headers, so a

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -214,9 +214,11 @@ server.registerTool(
           'A heading slug (single-file) or page path (bundle, optionally page#slug). Pass "*" for the full document.',
         ),
       format: z
-        .enum(["markdown", "text"])
+        .enum(["markdown", "text", "html"])
         .optional()
-        .describe("markdown (default, HTML converted) or text (flat visible text)."),
+        .describe(
+          "markdown (default, HTML converted), text (flat visible text), or html (the exact stored source — read it before revising with publish `edits`).",
+        ),
       version: z.number().int().optional().describe("Defaults to the current version."),
       workspace: wsArg,
     },
@@ -722,6 +724,7 @@ server.registerTool(
       published: true,
       short_id: a.short_id,
       ...(a.review_requested ? { review_requested: true } : {}),
+      ...(echoedSha ? { content_sha256: echoedSha } : {}),
       ...(pathSha && echoedSha ? { content_verified: true } : {}),
       version: a.current_version,
       url: a.url,

--- a/packages/mcp/test/client.test.ts
+++ b/packages/mcp/test/client.test.ts
@@ -179,6 +179,13 @@ describe("derive client (the MCP server's backend) over real HTTP", () => {
     expect(p3.id).toBeTruthy()
   })
 
+  it("getContent format:'html' returns the exact stored source (the edits precondition)", async () => {
+    const src = "<html><head><title>t</title></head><body><h1>H</h1><p>body</p></body></html>"
+    const a = await client.publish({ content: src, filename: "h.html", title: "Html read" })
+    const r = await client.getContent(a.short_id, { format: "html" })
+    expect(r.text).toBe(src)
+  })
+
   it("surfaces server errors as thrown messages", async () => {
     await expect(client.get("nope0000")).rejects.toThrow(/derive 404/)
   })


### PR DESCRIPTION
Dogfooding the published 0.5.0 over real stdio JSON-RPC (initialize → tools/list → the full publish matrix) found two gaps, both stdio-only:

1. **`read` rejected `format:'html'`** — the zod enum only allowed `markdown|text`, while the publish description in the same server says "read format:'html' first" before `edits`. Following the tool's own guidance produced a validation error. The REST content route and remote `/mcp` both support html; the client passes format through verbatim, so the fix is the enum + `ContentOpts` type, plus a regression test that `getContent(format:'html')` round-trips the exact stored source.
2. **Publish responses didn't surface `content_sha256`** — the shim used the echo internally for the `content_path` verify but dropped it from the response, so string-`content` publishers couldn't verify. Now passed through, matching REST and remote.

Version bumped to 0.5.1 (same publish procedure as #413: after merge, `cd packages/mcp && pnpm publish` — no CLI change this time).

Dogfood scoreboard against production, for the record: handshake, schema advertising, `content_path` publish with `content_verified`, clean-note on a well-formed page, `edits`, both error paths (missing file, exclusivity), advisory relay on a viewport-less page, and proposal-from-file (verified server-side: the proposal diff carries the whole file) — all pass. The two failures in the matrix were this bug and the missing hash pass-through.