### PR TITLE
stdio publish: infer .md/.html from content, never a blind index.html

### DIFF
--- a/packages/mcp/src/filename.ts
+++ b/packages/mcp/src/filename.ts
@@ -1,0 +1,19 @@
+// Choosing the upload filename for an inline `content` publish when the caller gave
+// none. The Derive server types an artifact by its filename FIRST, so a blind
+// `index.html` default silently stores Markdown as text/html — the page then renders
+// the raw Markdown as markup and swallows tag-like text (the 2026-07 retype incident).
+//
+// These mirror the server's own sniff, inlined here because the stdio shim keeps NO
+// @derive/core dependency at runtime (it is a thin HTTP client).
+
+/** A full HTML document starts with `<!doctype html>` or `<html>`. Everything else
+ *  (Markdown, plain text, an HTML fragment) is NOT one. */
+export const looksLikeHtmlDocument = (s: string): boolean =>
+  /^\s*<(!doctype\s+html|html)[\s>]/i.test(s.slice(0, 256))
+
+/** The fallback filename for inline content with none given: a full HTML document →
+ *  `index.html`, anything else → `index.md`. So Markdown is never stored as HTML.
+ *  Caveat: a fragment-HTML artifact (not starting with a doctype) republished with no
+ *  filename lands as `.md` — pass an explicit `filename` (or use `edits`) to keep it. */
+export const fallbackFilename = (content: string | undefined): string =>
+  looksLikeHtmlDocument(content ?? "") ? "index.html" : "index.md"

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -15,6 +15,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod"
 import { createClient } from "./client"
+import { fallbackFilename } from "./filename"
 
 // Stdio MCP server for self-hosters: `npx @derive-to/mcp` talks to a Derive instance over
 // the /v1 HTTP API (DERIVE_SERVER). It exposes the SAME tools as the remote /mcp
@@ -592,7 +593,9 @@ server.registerTool(
       filename: z
         .string()
         .optional()
-        .describe("Filename, e.g. report.html or notes.md. Defaults to index.html."),
+        .describe(
+          "Filename, e.g. report.html or notes.md — its extension sets the content type. Omit and it's inferred from the content (a full HTML document → HTML, otherwise Markdown); pass it explicitly to be sure, especially when republishing.",
+        ),
       short_id: z
         .string()
         .optional()
@@ -664,7 +667,13 @@ server.registerTool(
           content: pathBytes ?? content,
           edits,
           baseVersion: base_version,
-          filename: filename ?? (content_path !== undefined ? basename(content_path) : undefined),
+          filename:
+            filename ??
+            (content_path !== undefined
+              ? basename(content_path)
+              : edits
+                ? undefined
+                : fallbackFilename(content)),
           message: message ?? "Proposed revision",
           addresses,
         })
@@ -689,7 +698,11 @@ server.registerTool(
         baseVersion: base_version,
         filename:
           filename ??
-          (content_path !== undefined ? basename(content_path) : edits ? undefined : "index.html"),
+          (content_path !== undefined
+            ? basename(content_path)
+            : edits
+              ? undefined
+              : fallbackFilename(content)),
         title,
         workspaceAccess: workspace_access,
         linkRole: link_role,

--- a/packages/mcp/test/client.test.ts
+++ b/packages/mcp/test/client.test.ts
@@ -8,6 +8,7 @@ import { FsBlobStore } from "@derive/storage/fs"
 import { serve } from "@hono/node-server"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
 import { createClient, type DeriveClient } from "../src/client"
+import { fallbackFilename } from "../src/filename"
 
 let server: ReturnType<typeof serve>
 let meta: SqliteMetaStore
@@ -46,6 +47,28 @@ describe("derive client (the MCP server's backend) over real HTTP", () => {
     expect(a.current_version).toBe(1)
     expect(a.kind).toBe("file")
     expect((await client.getContent(shortId)).text).toBe("# Hello")
+  })
+
+  it("filenameless markdown stays markdown and keeps <angle> tokens (retype-incident fix)", async () => {
+    const content = "# Doc\n\nsee the <token> below"
+    // What the publish tool now sends when the caller gives no filename.
+    const good = await client.publish({
+      content,
+      filename: fallbackFilename(content),
+      title: "Good",
+    })
+    // Read as markdown: a markdown artifact passes through, so the <token> survives.
+    expect((await client.getContent(good.short_id, { format: "markdown" })).text).toContain(
+      "<token>",
+    )
+
+    // Contrast with the OLD blind `index.html` default: the same content typed as HTML,
+    // read back as markdown, converts — and the browser/converter drops the unknown
+    // <token> tag, exactly the content-swallowing the fix prevents.
+    const bad = await client.publish({ content, filename: "index.html", title: "Bad" })
+    expect((await client.getContent(bad.short_id, { format: "markdown" })).text).not.toContain(
+      "<token>",
+    )
   })
 
   it("publishes a new version and reads each version back", async () => {

--- a/packages/mcp/test/filename.test.ts
+++ b/packages/mcp/test/filename.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+import { fallbackFilename, looksLikeHtmlDocument } from "../src/filename"
+
+describe("fallbackFilename — inline publish with no filename never re-types markdown", () => {
+  it("markdown content lands as .md (the retype-incident fix)", () => {
+    expect(fallbackFilename("# Title\n\nSome **markdown** with a <short_id> token.")).toBe(
+      "index.md",
+    )
+    expect(fallbackFilename("- a list\n- of items")).toBe("index.md")
+    expect(fallbackFilename("plain prose")).toBe("index.md")
+    expect(fallbackFilename("")).toBe("index.md")
+    expect(fallbackFilename(undefined)).toBe("index.md")
+  })
+
+  it("a full HTML document lands as .html", () => {
+    expect(fallbackFilename("<!DOCTYPE html><html><body><h1>Hi</h1></body></html>")).toBe(
+      "index.html",
+    )
+    expect(fallbackFilename("<!doctype html>\n<html>")).toBe("index.html")
+    expect(fallbackFilename('  <html lang="en">…')).toBe("index.html")
+  })
+
+  it("an HTML fragment is NOT a document, so it defaults to .md (caveat: pass a filename)", () => {
+    // A styled page whose source starts with <div>/<style> rather than a doctype isn't
+    // detected as a document — the caller must pass filename:"x.html" to keep it HTML.
+    expect(fallbackFilename('<div class="card">hi</div>')).toBe("index.md")
+    expect(fallbackFilename("<style>body{color:red}</style><p>x</p>")).toBe("index.md")
+  })
+
+  it("looksLikeHtmlDocument only matches a leading doctype/html tag", () => {
+    expect(looksLikeHtmlDocument("<!DOCTYPE html>")).toBe(true)
+    expect(looksLikeHtmlDocument("<html>")).toBe(true)
+    expect(looksLikeHtmlDocument("# md then <html> later")).toBe(false)
+    expect(looksLikeHtmlDocument("<htmlish>")).toBe(false) // needs a tag boundary
+  })
+})


### PR DESCRIPTION
The stdio MCP shim (`@derive-to/mcp`) defaulted a filename-less inline `content` publish to `index.html`. The Derive server types an artifact by its filename **first**, so **markdown published with no filename was stored as `text/html`** — the page then renders the raw markdown as markup and swallows tag-like text (`<short_id>`, `<cwd>`). This is the #395 retype incident, which was only fixed on the remote `/mcp` server; the stdio path was still live.

## Fix

Mirror the server's own content sniff (`looksLikeHtmlDocument`), extracted into a small dependency-free `packages/mcp/src/filename.ts` (the shim intentionally keeps **no `@derive/core` at runtime** — it's a thin HTTP client): a full HTML document → `index.html`, anything else (markdown, plain text) → `index.md`. Applied to **both** the publish and propose paths, and the tool's `filename` description now says the type is inferred from content when omitted.

**Caveat (documented in code + description):** a fragment-HTML artifact (source that doesn't start with a doctype) republished with no filename lands as `.md` — pass an explicit `filename` or use `edits` to keep its type. Full correctness on that edge would need a metadata round-trip to read the stored type; not worth it for a rare case, and the dangerous direction (markdown → HTML, which swallows content) is fully closed.

## Tests

- Unit tests for the sniff (markdown / HTML-doc / fragment / empty / leading-tag boundary).
- An **end-to-end regression over a real server**: filenameless markdown containing a `<token>` keeps it (stored as markdown), where the old `index.html` default drops it (stored as HTML, then converted on read). That's the exact content-swallowing this prevents.

All gates green: typecheck, Biome, all 14 `lint:*` checks, dependency-boundaries (confirming no core dependency crept into the shim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)