### PR TITLE
docs(design-system): record the cursor-tint scope as a decision

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -458,11 +458,13 @@ variants.
   distinct tint from the shared identity palette (`colorForName`, the same palette avatar
   tints draw from), keyed on the server-stamped handle that also names them in presence.
   Color follows the person — one tint per peer for the session, never a per-cursor pick — with
-  a `font-medium` name flag that fades on stillness. (Today that palette is a cursor-only
-  accent in the artifact view; the presence facepile still reads you-vs-them in `primary`/
-  `accent`. Unifying the two on `colorForName` — so a cursor and its facepile row share a
-  color — is the obvious next coherence step, deferred as its own call.) There is no style
-  selector: a picker of colors + emoji would break both *color is rationed* and *never emojis*.
+  a `font-medium` name flag that fades on stillness. The identity tint stops at the cursor **on
+  purpose**: a cursor *moves*, so color pre-attentively separates two arrows scrubbing at once
+  (the name tag confirms). The presence facepile and comment avatars are static and already
+  name-labeled — they read you-vs-them in `primary`/`accent` and stay calm; painting them with
+  8 identity tints would add persistent color to the view's busiest surfaces for a match nobody
+  needs at 2–3 concurrent viewers. So the tint earns its keep here and nowhere else. There is no
+  style selector: a picker of colors + emoji would break both *color is rationed* and *never emojis*.
   The one real preference — **Hide live cursors** — is a checkbox item in the ⋯ menu's view-
   modes group beside Focus; it opts you out of the whole layer (peers vanish, yours stops
   broadcasting) and persists per-browser like the theme.


### PR DESCRIPTION
Follow-up to #412. The note there framed unifying the presence facepile + comment avatars onto `colorForName` as "the obvious next coherence step." The actual judgment is the opposite — record it as **decided**, not pending.

**The call:** the identity tint stops at the cursor on purpose.
- A cursor *moves*, so color pre-attentively separates two arrows scrubbing at once (the name tag confirms) — the tint earns its keep.
- The presence facepile and comment avatars are static and already name-labeled; they read you-vs-them in `primary`/`accent` and stay calm. Painting them with 8 identity tints would add persistent color to the view's busiest surfaces for a cursor↔face match nobody needs at 2–3 concurrent viewers — and it cuts against the lean/monochrome direction this whole artifact-view initiative has pursued.

Doc-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)