### PR TITLE
fix(cursors): tint peers by stable id, not the collapsible name

### DIFF
--- a/apps/web/src/lib/cursors.ts
+++ b/apps/web/src/lib/cursors.ts
@@ -1,10 +1,11 @@
 // The live-cursor domain — one source of truth for the on-canvas overlay and the
 // one preference (hide). A peer's color is NOT here and NOT on the wire: it's
-// derived from their name via `colorForName` (the shared identity palette avatar
-// tints draw from), keyed on the SAME server-stamped handle that names them in the
-// presence roster — so each peer keeps one stable, distinct tint for the session,
-// with the name tag carrying identity. No per-cursor look to pick — the design
-// language rations color and forbids emoji.
+// derived from their stable `id` via `colorForName` (the shared identity palette
+// avatar tints draw from) — keyed on the id, not the display name, because the name
+// collapses (a handle-less account is "someone", a missing name is "Guest") and would
+// paint distinct people the same color; the id is always present and unique, so each
+// peer keeps one stable, distinct tint, with the name tag carrying the label. No
+// per-cursor look to pick — the design language rations color and forbids emoji.
 //
 // Nothing here touches React or the DOM: just the wire vocabulary, the one pref,
 // and the animation/lifecycle tuning.

--- a/apps/web/src/pages/artifact/cursors/use-cursor-paint.ts
+++ b/apps/web/src/pages/artifact/cursors/use-cursor-paint.ts
@@ -10,13 +10,15 @@ import { CURSOR_TUNING, type CursorFrame, effectiveDocH, placePeer } from "@/lib
 // viewport edge collapse into an edge indicator. React only re-renders when the roster
 // changes (a peer joins, leaves, or is renamed) or a ripple fires; every-frame motion is
 // written straight to the DOM via refs, never through React. A peer's color isn't sent —
-// it's derived from their name (`colorForName`, the shared identity palette), keyed on the
-// same server-stamped handle presence uses, so each peer keeps one stable, distinct tint.
-// The SENDING half (our own pointer → server) lives in use-cursor-send. `selfId` is shared
-// so we ignore our own echoed frames.
+// it's derived from their stable `id` via `colorForName` (the shared identity palette). We
+// key on the id, NOT the display name, on purpose: the name collapses (a handle-less account
+// stamps as "someone", a missing name as "Guest"), which would paint distinct people the same
+// color — the id is always present and unique per viewer, so every peer gets a distinct tint
+// that never flickers when their name resolves. The SENDING half (our own pointer → server)
+// lives in use-cursor-send. `selfId` is shared so we ignore our own echoed frames.
 
 /** A peer entry the overlay mounts/unmounts (no per-frame churn). Color is the peer's
- *  identity tint, derived once from their name so it matches their avatar. */
+ *  identity tint, derived once from their stable id (a distinct tint per viewer). */
 export interface PeerView {
   id: string
   color: string
@@ -50,7 +52,7 @@ interface PeerTarget {
   y: number
   cx: number // current eased position: cx in layer px (x), cy in document px (y)
   cy: number
-  color: string // identity tint, derived from name (recomputed only on rename)
+  color: string // identity tint, derived once from the stable id (never changes)
   name: string
   slide?: number // deck slide the peer is on (undefined on non-deck artifacts)
   gone: boolean
@@ -61,7 +63,8 @@ interface PeerTarget {
   labelEl: HTMLElement | null
 }
 
-// The roster only re-renders when a peer is renamed (their tint follows their name).
+// The roster re-renders when a peer is renamed (guest → resolved handle) to update the tag;
+// their tint is keyed on the stable id, so it does NOT change on rename.
 const nameChanged = (t: PeerTarget, f: CursorFrame) => t.name !== (f.name ?? t.name)
 
 export function useCursorPaint(selfId: string): {
@@ -180,10 +183,7 @@ export function useCursorPaint(selfId: string): {
         })
         if (place.onScreen) {
           const key = ++rippleKey.current
-          setRipples((rs) => [
-            ...rs,
-            { key, x: place.x, y: place.y, color: colorForName(f.name ?? "Guest") },
-          ])
+          setRipples((rs) => [...rs, { key, x: place.x, y: place.y, color: colorForName(f.id) }])
           setTimeout(
             () => setRipples((rs) => rs.filter((r) => r.key !== key)),
             CURSOR_TUNING.rippleMs,
@@ -201,14 +201,13 @@ export function useCursorPaint(selfId: string): {
         // y is document-normalized, so seed cy in document pixels (eased there).
         const r = layerRef.current?.getBoundingClientRect()
         const docH = effectiveDocH(geomRef.current.docH, r?.height ?? 0)
-        const name = f.name ?? "Guest"
         targets.current.set(f.id, {
           x: f.x,
           y: f.y,
           cx: f.x * (r?.width ?? 0),
           cy: f.y * docH,
-          color: colorForName(name),
-          name,
+          color: colorForName(f.id), // keyed on the stable id, not the collapsible name
+          name: f.name ?? "Guest",
           slide: f.slide,
           gone: false,
           fade: 1,
@@ -222,8 +221,8 @@ export function useCursorPaint(selfId: string): {
       }
 
       if (nameChanged(existing, f)) {
+        // Only the tag text changes; the tint stays (it's keyed on the stable id).
         existing.name = f.name ?? existing.name
-        existing.color = colorForName(existing.name)
         markRosterDirty()
       }
       existing.x = f.x

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -456,7 +456,9 @@ variants.
   lives behind the ⋯ — the render is the hero, the chrome recedes.
 - **Live cursors** — peers' cursors are a slim arrow tinted by their **identity**: a stable,
   distinct tint from the shared identity palette (`colorForName`, the same palette avatar
-  tints draw from), keyed on the server-stamped handle that also names them in presence.
+  tints draw from), keyed on the peer's stable **id** — not their display name, which
+  collapses (a handle-less account is "someone", a missing name "Guest") and would paint
+  distinct people one color; the id is always unique, so every peer gets a distinct tint.
   Color follows the person — one tint per peer for the session, never a per-cursor pick — with
   a `font-medium` name flag that fades on stillness. The identity tint stops at the cursor **on
   purpose**: a cursor *moves*, so color pre-attentively separates two arrows scrubbing at once


### PR DESCRIPTION
## Symptom
Peers with different identities all rendered the **same yellowish cursor** (reported: "a user with no avatar, and another incognito, all the same yellowish color").

## Root cause
#411 derived the cursor tint from the server-stamped **`name`** — but `name` *collapses*:
- a signed-in account **without a handle** stamps as `"someone"`
- a missing name stamps as `"Guest"`

So every distinct handle-less person shared one color — and `colorForName("someone") === #a04425`, a rust/brown that reads as yellowish. Freshly-created test accounts (no avatar → no username) all landed there.

## Fix
Key the tint on the peer's **`id`** instead of `name`. The `id` (`me.id`, or `anon_<token>`) is:
- **already on every frame** — it's the presence id used for the self-filter and the roster key (no new wire data, no privacy change)
- **always present and unique per viewer** → every peer gets a distinct, well-distributed tint (verified: ≈even across all 8 palette slots)
- **stable across a rename** → the tint no longer flickers when a guest's name resolves to a handle

The name tag still carries the label; only the color-keying changed. Client-only.

## Note
With 8 palette colors, exact collisions still become likely at ~4+ *simultaneous distinct* viewers (birthday bound) — acceptable for a review surface (2–3 typical), and the name tag disambiguates. Widening the shared `AUTHOR_TINTS` palette is a separate, avatar-affecting call if we ever need it.

Verified: web typecheck + all 150 web unit tests + token guard + full precommit guards green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)