### PR TITLE
fix(comments): remove a thread when its last comment is deleted

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -6196,7 +6196,7 @@
         "tags": [
           "Comments"
         ],
-        "summary": "Soft-delete a comment (author only); the row stays, body tombstoned.",
+        "summary": "Delete a comment (author only); tombstoned if replies remain, else removed.",
         "parameters": [
           {
             "schema": {
@@ -6217,7 +6217,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The tombstoned comment.",
+            "description": "The comment's final deleted state.",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -442,18 +442,23 @@ export const commentRoutes = (ctx: AppContext) => {
     },
   )
 
-  // Soft-delete a comment (author only when signed in); the row stays so replies
-  // keep their thread, and the body is tombstoned.
+  // Delete a comment (author only when signed in). A tombstone only earns its keep
+  // when there are replies to hold the thread together, so we keep it conditional: if
+  // another live comment survives in the thread, tombstone this one (row stays, body
+  // blanked); if it was the thread's LAST living comment, remove the whole thread
+  // instead — otherwise a solo delete leaves a "Comment deleted" ghost pinned to the
+  // document with an orphaned highlight and a dangling notification. Either way the
+  // response describes the comment's final (deleted) state.
   app.openapi(
     createRoute({
       method: "delete",
       path: "/v1/artifacts/{shortId}/comments/{commentId}",
       tags: ["Comments"],
-      summary: "Soft-delete a comment (author only); the row stays, body tombstoned.",
+      summary: "Delete a comment (author only); tombstoned if replies remain, else removed.",
       request: { params: z.object({ shortId: z.string(), commentId: z.string() }) },
       responses: {
         200: {
-          description: "The tombstoned comment.",
+          description: "The comment's final deleted state.",
           content: { "application/json": { schema: Comment } },
         },
       },
@@ -467,9 +472,16 @@ export const commentRoutes = (ctx: AppContext) => {
       if (acting && !ownsComment(cm, acting)) return bail(fail(c, 403, "forbidden"))
       const md = parseMeta(cm.meta)
       md.deleted = true
-      const updated = await meta.updateComment(cm.id, { meta: JSON.stringify(md) })
+      // Any OTHER comment in this thread still carrying content? (excludes cm and prior
+      // tombstones). Threads are small, so a single list + filter is cheaper than a new
+      // query path.
+      const survivors = (await meta.listComments(artifact.id)).filter(
+        (x) => x.thread_id === cm.thread_id && x.id !== cm.id && !parseMeta(x.meta).deleted,
+      )
+      if (survivors.length === 0) await meta.deleteThread(artifact.id, cm.thread_id)
+      else await meta.updateComment(cm.id, { meta: JSON.stringify(md) })
       bus.publish(artifact.id, { type: "comment.updated", thread_id: cm.thread_id })
-      return c.json(commentJson(updated ?? cm))
+      return c.json(commentJson({ ...cm, meta: JSON.stringify(md) }))
     },
   )
 

--- a/apps/api/test/comments.test.ts
+++ b/apps/api/test/comments.test.ts
@@ -109,6 +109,83 @@ describe("comments + the loop", () => {
   })
 })
 
+describe("deleting comments — tombstone only when it earns its keep", () => {
+  const list = async (sid: string) =>
+    (await (await app.request(`/v1/artifacts/${sid}/comments`)).json()).comments as {
+      id: string
+      deleted: boolean
+      body_md: string
+    }[]
+  const add = async (sid: string, body: Record<string, unknown>) =>
+    (await app.request(`/v1/artifacts/${sid}/comments`, json(body))).json()
+  const del = (sid: string, id: string) =>
+    app.request(`/v1/artifacts/${sid}/comments/${id}`, { method: "delete" })
+
+  it("removes the whole thread when the last living comment goes (no ghost, no orphan anchor)", async () => {
+    const sid = (await (await upload("d1.md", "# solo doc", {})).json()).short_id
+    const cm = await add(sid, {
+      body_md: "just me",
+      anchor: { type: "TextQuoteSelector", exact: "solo" },
+    })
+    expect((await del(sid, cm.id)).status).toBe(200)
+    // Gone entirely — not a "Comment deleted" tombstone left pinned to the document.
+    expect(await list(sid)).toHaveLength(0)
+  })
+
+  it("tombstones instead when a reply survives, and blanks the body (no content leak)", async () => {
+    const sid = (await (await upload("d2.md", "# doc", {})).json()).short_id
+    const root = await add(sid, { body_md: "root here" })
+    await add(sid, { body_md: "a reply", thread_id: root.thread_id })
+    await del(sid, root.id)
+    const after = await list(sid)
+    expect(after).toHaveLength(2) // thread intact so the reply keeps its context
+    const tomb = after.find((c) => c.id === root.id)
+    expect(tomb?.deleted).toBe(true)
+    expect(tomb?.body_md).toBe("")
+  })
+
+  it("cleans up the tombstoned root once its last reply is also deleted", async () => {
+    const sid = (await (await upload("d3.md", "# doc", {})).json()).short_id
+    const root = await add(sid, { body_md: "root" })
+    const reply = await add(sid, { body_md: "reply", thread_id: root.thread_id })
+    await del(sid, root.id) // reply survives → root tombstoned
+    expect(await list(sid)).toHaveLength(2)
+    await del(sid, reply.id) // last living comment gone → whole thread removed
+    expect(await list(sid)).toHaveLength(0)
+  })
+})
+
+describe("deleting a solo comment clears its dangling notification", () => {
+  const alice: TestUser = { id: "u_del_alice", email: "dela@derive.test", name: "Alice" }
+  const bob: TestUser = { id: "u_del_bob", email: "delb@derive.test", name: "Bob" }
+  const { app: aApp } = makeAuthedApp("del-notif", [alice, bob], "editor")
+
+  it("removes the mentioned user's notification when the thread is removed", async () => {
+    const shortId = (await (await publishAs(aApp, "<h1>doc</h1>", {}, as(alice.email))).json())
+      .short_id
+    await aApp.request("/v1/me", { headers: as(bob.email) }) // provision Bob as a member
+    const cm = await (
+      await aApp.request(
+        `/v1/artifacts/${shortId}/comments`,
+        jsonAs(as(alice.email), { body_md: "look @bob", mentions: [{ id: bob.id, name: "Bob" }] }),
+      )
+    ).json()
+    // Bob has the mention notification…
+    expect(
+      (await (await aApp.request("/v1/notifications", { headers: as(bob.email) })).json()).unread,
+    ).toBe(1)
+    // …and deleting the solo comment removes the thread AND the notification with it (no
+    // click-through to a comment that no longer exists).
+    await aApp.request(`/v1/artifacts/${shortId}/comments/${cm.id}`, {
+      method: "delete",
+      headers: as(alice.email),
+    })
+    const bobN = await (await aApp.request("/v1/notifications", { headers: as(bob.email) })).json()
+    expect(bobN.unread).toBe(0)
+    expect(bobN.notifications).toHaveLength(0)
+  })
+})
+
 describe("anchored comments", () => {
   it("flags comments anchored vs orphaned against the current version", async () => {
     const sid = (await (await upload("a.md", "alpha beta gamma", { title: "A" })).json()).short_id

--- a/apps/web/e2e/deep/artifact.deep.spec.ts
+++ b/apps/web/e2e/deep/artifact.deep.spec.ts
@@ -72,7 +72,11 @@ test("edit and delete an own comment", async ({ page }) => {
   await page.getByTestId("comment-delete").click()
   // Destructive actions confirm via the shared dialog, never immediately.
   await page.getByTestId("comment-delete-confirm").click()
-  await expect(page.getByText("Comment deleted")).toBeVisible()
+  // A solo comment (no replies) is removed outright — no "Comment deleted" ghost left
+  // pinned to the document. The tombstone path (when replies remain) is covered in the
+  // API tests (comments.test.ts).
+  await expect(page.getByText("Fixed now.")).toHaveCount(0)
+  await expect(page.getByText("Comment deleted")).toHaveCount(0)
 })
 
 test("the insights panel opens and reports viewers", async ({ page }) => {

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -3560,7 +3560,7 @@ export interface paths {
         get?: never;
         put?: never;
         post?: never;
-        /** Soft-delete a comment (author only); the row stays, body tombstoned. */
+        /** Delete a comment (author only); tombstoned if replies remain, else removed. */
         delete: {
             parameters: {
                 query?: never;
@@ -3573,7 +3573,7 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description The tombstoned comment. */
+                /** @description The comment's final deleted state. */
                 200: {
                     headers: {
                         [name: string]: unknown;

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -279,6 +279,11 @@ export interface CommentStore {
   ): Promise<CommentRecord | null>
   /** Flips every comment in a thread to a state; returns the count updated. */
   setThreadState(artifactId: string, threadId: string, state: CommentState): Promise<number>
+  /** Hard-remove an entire comment thread and everything keyed to it — its comments,
+   *  notifications, agent mentions, and Slack link. Called when a delete leaves the
+   *  thread with no surviving comment, so no "Comment deleted" ghost (nor its orphaned
+   *  document highlight or dangling notification) is left behind. */
+  deleteThread(artifactId: string, threadId: string): Promise<void>
   /** Per-artifact comment signals for `userId` over a set of artifact ids, in one
    *  query: open-thread count plus whether the viewer is tagged in or has authored an
    *  open thread (drives the "needs your feedback" featuring). A null userId gets

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -454,6 +454,23 @@ export class PgMetaStore implements MetaStore {
     return rows.length
   }
 
+  // Atomic: the thread's comments and everything keyed to it (notifications, agent
+  // mentions, Slack link) go together, so a removed thread leaves nothing dangling.
+  async deleteThread(artifactId: string, threadId: string): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      await tx
+        .delete(notification)
+        .where(and(eq(notification.artifact_id, artifactId), eq(notification.thread_id, threadId)))
+      await tx
+        .delete(agentMention)
+        .where(and(eq(agentMention.artifact_id, artifactId), eq(agentMention.thread_id, threadId)))
+      await tx.delete(slackThreadLink).where(eq(slackThreadLink.thread_id, threadId))
+      await tx
+        .delete(comment)
+        .where(and(eq(comment.artifact_id, artifactId), eq(comment.thread_id, threadId)))
+    })
+  }
+
   // Mirrors the sqlite path: mentions live in meta.mentions (JSON), matched in code.
   private commentMentionsUser(metaJson: string | null, userId: string): boolean {
     if (!metaJson) return false

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -696,6 +696,27 @@ export function makeRepos(db: SqliteDb) {
     return res.changes ?? res.meta?.changes ?? 0
   }
 
+  // Hard-remove an entire thread and everything keyed to it. Sequential deletes (no
+  // cross-statement transaction on D1; the sqlite path wraps these in one) — order is
+  // immaterial since nothing here references another of these rows. Everything keyed on
+  // thread_id goes, so a removed thread leaves no dangling notification / agent mention /
+  // Slack link behind. Mirrors deleteArtifact's cascade, scoped to one thread.
+  const deleteThread = async (artifactId: string, threadId: string): Promise<void> => {
+    await db
+      .delete(notification)
+      .where(and(eq(notification.artifact_id, artifactId), eq(notification.thread_id, threadId)))
+      .run()
+    await db
+      .delete(agentMention)
+      .where(and(eq(agentMention.artifact_id, artifactId), eq(agentMention.thread_id, threadId)))
+      .run()
+    await db.delete(slackThreadLink).where(eq(slackThreadLink.thread_id, threadId)).run()
+    await db
+      .delete(comment)
+      .where(and(eq(comment.artifact_id, artifactId), eq(comment.thread_id, threadId)))
+      .run()
+  }
+
   // Does this comment's meta JSON tag `userId`? Mentions live in meta.mentions
   // (a {id,name}[]), so they can't be filtered in SQL cheaply — matched in code.
   const commentMentionsUser = (metaJson: string | null, userId: string): boolean => {
@@ -2546,6 +2567,7 @@ export function makeRepos(db: SqliteDb) {
     updateComment,
     listComments,
     setThreadState,
+    deleteThread,
     commentSignals,
     artifactIdsNeedingFeedback,
     createWebhook,

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -32,6 +32,7 @@ import {
   reviewRound,
   SCHEMA_STATEMENTS,
   sessionMessage,
+  slackThreadLink,
   version,
   webhook,
 } from "./schema"
@@ -117,6 +118,27 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
         db.delete(collectionItem).where(eq(collectionItem.collection_id, id)).run()
         db.delete(collectionMember).where(eq(collectionMember.collection_id, id)).run()
         db.delete(collection).where(eq(collection.id, id)).run()
+      })()
+    },
+
+    // Atomic: the thread's comments and everything keyed to it commit together, so a
+    // removed thread never leaves a dangling notification / agent mention / Slack link.
+    deleteThread: async (artifactId: string, threadId: string): Promise<void> => {
+      raw.transaction(() => {
+        db.delete(notification)
+          .where(
+            and(eq(notification.artifact_id, artifactId), eq(notification.thread_id, threadId)),
+          )
+          .run()
+        db.delete(agentMention)
+          .where(
+            and(eq(agentMention.artifact_id, artifactId), eq(agentMention.thread_id, threadId)),
+          )
+          .run()
+        db.delete(slackThreadLink).where(eq(slackThreadLink.thread_id, threadId)).run()
+        db.delete(comment)
+          .where(and(eq(comment.artifact_id, artifactId), eq(comment.thread_id, threadId)))
+          .run()
       })()
     },
 


### PR DESCRIPTION
## What happens today
Deleting a comment always soft-tombstones the row (`meta.deleted = true`, "Comment deleted"), even when it's the **only** comment in its thread. The tombstone was applied unconditionally and nothing downstream keys on `deleted`, so a solo delete leaves a trail of ghosts:

- a **"Comment deleted" card** stays pinned in the margin (`bucketThreads` filters on `state`, never `deleted`),
- its **document highlight stays painted** (`sendAnchors` also keys on `state` only),
- it still **counts** toward the open-comments badge,
- and any **@mention notification** it fired **dangles** — clicking through to a comment that no longer says anything.

## The fix
A tombstone only earns its keep when replies depend on it. Make deletion conditional **at the source** so every consumer (web render, count, highlight, notifications, API, webhooks) sees the truth — with **zero client changes**:

- **Survivor exists** → tombstone this comment (row stays, body blanked); the remaining replies keep their context. *(unchanged path)*
- **Last living comment** → remove the whole thread via a new `deleteThread(artifactId, threadId)`, cascading everything keyed to it: **comments, notifications, agent mentions, and the Slack thread link.** Nothing dangles; the highlight and count clear on the client's existing post-delete refetch.

The rule is a single invariant: **a thread exists iff it has ≥1 non-deleted comment.** It handles every case uniformly — solo delete, delete-root-with-replies (tombstone), and delete-the-last-reply-of-a-tombstoned-root (whole thread goes).

## Why server-side, not a client filter
A client filter would only hide the card/highlight — it still leaves the DB tombstone and, worse, the **dangling notification**. Fixing it at the delete handler means the data reflects reality and no consumer needs special-casing. `deleteThread` mirrors `deleteArtifact`'s cascade, scoped to one thread, across all three `MetaStore` impls (repos / pg / sqlite, transactional where the dialect supports it). The client is untouched: `removeComment` already refetches, so a removed thread simply isn't in the list.

## Tests
API: solo→removed, reply-survives→tombstoned, tombstoned-root cleaned once its last reply goes, and notification cleanup. Updated the delete **e2e** (it deleted a solo comment and asserted the tombstone) to the new behavior. Full guard suite + core/db/api typecheck + comment/db/related suites green locally (pg path runs in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)