### PR TITLE
fix(comments): make delete race-safe; clean the Slack link on artifact delete

### DIFF
--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -472,14 +472,23 @@ export const commentRoutes = (ctx: AppContext) => {
       if (acting && !ownsComment(cm, acting)) return bail(fail(c, 403, "forbidden"))
       const md = parseMeta(cm.meta)
       md.deleted = true
-      // Any OTHER comment in this thread still carrying content? (excludes cm and prior
-      // tombstones). Threads are small, so a single list + filter is cheaper than a new
-      // query path.
-      const survivors = (await meta.listComments(artifact.id)).filter(
-        (x) => x.thread_id === cm.thread_id && x.id !== cm.id && !parseMeta(x.meta).deleted,
+      // Tombstone FIRST, then re-read the thread. Writing before the survivor check is what
+      // makes this race-safe WITHOUT a cross-request transaction: if two authors delete the
+      // last two live comments at once, each re-reads only AFTER its own tombstone commits,
+      // so at least one of them observes the other's tombstone and sees a fully-dead thread.
+      // (A check-then-write order would let both see the other as "alive" and both tombstone,
+      // reviving the very "Comment deleted" ghost this removes.)
+      await meta.updateComment(cm.id, { meta: JSON.stringify(md) })
+      // Any comment in this thread still carrying content? cm is now tombstoned, so the
+      // `deleted` check already excludes it. Threads are small — one list + filter beats a
+      // dedicated query path.
+      const live = (await meta.listComments(artifact.id)).filter(
+        (x) => x.thread_id === cm.thread_id && !parseMeta(x.meta).deleted,
       )
-      if (survivors.length === 0) await meta.deleteThread(artifact.id, cm.thread_id)
-      else await meta.updateComment(cm.id, { meta: JSON.stringify(md) })
+      // Nothing anchors to the thread anymore → remove it whole (comments + notifications +
+      // agent mentions + Slack link) rather than leave a ghost pinned to the document. When
+      // two deletes race here, both may run this; deleteThread is idempotent.
+      if (live.length === 0) await meta.deleteThread(artifact.id, cm.thread_id)
       bus.publish(artifact.id, { type: "comment.updated", thread_id: cm.thread_id })
       return c.json(commentJson({ ...cm, meta: JSON.stringify(md) }))
     },

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -2500,6 +2500,7 @@ export class PgMetaStore implements MetaStore {
       await tx.delete(report).where(eq(report.artifact_id, id))
       await tx.delete(notification).where(eq(notification.artifact_id, id))
       await tx.delete(agentMention).where(eq(agentMention.artifact_id, id))
+      await tx.delete(slackThreadLink).where(eq(slackThreadLink.artifact_id, id))
       await tx.delete(artifact).where(eq(artifact.id, id))
     })
   }

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -2458,6 +2458,7 @@ export function makeRepos(db: SqliteDb) {
     await db.delete(report).where(eq(report.artifact_id, id)).run()
     await db.delete(notification).where(eq(notification.artifact_id, id)).run()
     await db.delete(agentMention).where(eq(agentMention.artifact_id, id)).run()
+    await db.delete(slackThreadLink).where(eq(slackThreadLink.artifact_id, id)).run()
     await db.delete(artifact).where(eq(artifact.id, id)).run()
   }
 

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -177,6 +177,7 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
         db.delete(report).where(eq(report.artifact_id, id)).run()
         db.delete(notification).where(eq(notification.artifact_id, id)).run()
         db.delete(agentMention).where(eq(agentMention.artifact_id, id)).run()
+        db.delete(slackThreadLink).where(eq(slackThreadLink.artifact_id, id)).run()
         db.delete(artifact).where(eq(artifact.id, id)).run()
       })()
     },

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1580,6 +1580,15 @@ export function runStoreContract(
       })
       await store.setFavorite(a.id, "amy")
       await store.setArtifactTags(a.id, ["del-tag"])
+      await store.setSlackThreadLink({
+        id: uuid(),
+        org_id: ORG,
+        artifact_id: a.id,
+        thread_id: thread,
+        channel: "C1",
+        message_ts: "1.1",
+        created_at: "2026-01-01T00:00:00.000Z",
+      })
 
       await store.deleteArtifact(a.id, ORG)
 
@@ -1590,6 +1599,63 @@ export function runStoreContract(
       expect(await store.getArtifactMember(a.id, "bob")).toBeNull()
       expect(await store.listUserFavoriteIds("amy")).not.toContain(a.id)
       expect(await store.artifactIdsByTag("del-tag")).not.toContain(a.id)
+      // The Slack thread link is thread-keyed, not artifact_id-obvious — regression guard
+      // that it's cleaned too (it was orphaned before).
+      expect(await store.getSlackThreadLinkByThread(thread)).toBeNull()
+    })
+  })
+
+  describe(`${label}: deleteThread`, () => {
+    it("hard-removes a thread's comments, notifications, and Slack link — scoped to the thread", async () => {
+      const a = await store.createArtifact(newArtifact())
+      const dead = uuid()
+      const kept = uuid()
+      const mkComment = (thread: string, body: string) =>
+        store.createComment({
+          id: uuid(),
+          artifact_id: a.id,
+          thread_id: thread,
+          base_version: 1,
+          body_md: body,
+          author: "amy",
+        })
+      // The doomed thread (root + reply) and a sibling thread that must survive.
+      await mkComment(dead, "root")
+      await mkComment(dead, "reply")
+      await mkComment(kept, "untouched")
+      const mkNotif = (thread: string, commentId: string) =>
+        store.createNotification({
+          id: uuid(),
+          user_id: "bob",
+          actor: "amy",
+          kind: "mention",
+          artifact_id: a.id,
+          artifact_short_id: a.short_id,
+          artifact_title: null,
+          thread_id: thread,
+          comment_id: commentId,
+          preview: "hi",
+        })
+      await mkNotif(dead, uuid())
+      await mkNotif(kept, uuid())
+      await store.setSlackThreadLink({
+        id: uuid(),
+        org_id: ORG,
+        artifact_id: a.id,
+        thread_id: dead,
+        channel: "C1",
+        message_ts: "1.1",
+        created_at: "2026-01-01T00:00:00.000Z",
+      })
+
+      await store.deleteThread(a.id, dead)
+
+      // The whole dead thread is gone — no ghost, no dangling notification or Slack link.
+      const comments = await store.listComments(a.id)
+      expect(comments.map((c) => c.thread_id)).toEqual([kept])
+      expect(await store.getSlackThreadLinkByThread(dead)).toBeNull()
+      const notifs = await store.listNotifications("bob", 50)
+      expect(notifs.map((n) => n.thread_id)).toEqual([kept]) // the sibling's survives
     })
   })
 


### PR DESCRIPTION
Audit follow-up to #419. An adversarial review of that change surfaced two real defects; this hardens both.

## 1. Concurrency race (the main fix)
The delete handler read the thread (`listComments`) and **then** decided tombstone-vs-remove — a non-atomic read-then-write. Two authors deleting the **last two live comments** in one thread at the same instant could each see the *other* as a survivor and both tombstone → reviving the exact "Comment deleted" ghost #419 removes (lingering card, inflated count, orphan document highlight, dangling notifications). On an agent-native surface where two agents may act at once, this isn't hypothetical.

**Fix — tombstone first, then re-read.** Because each request re-reads only *after its own tombstone commits*, of two concurrent last-comment deletes at least one observes the other's tombstone and sees a fully-dead thread, so it runs `deleteThread` (idempotent if both do). This is:
- **race-safe with no cross-request transaction** — provable (each re-read follows its own write, so both can't miss each other) and works on **every dialect incl. D1**;
- **more complete than a read-side filter** — it also clears the *notifications* in the raced case, which hiding the thread on read would leave dangling.

## 2. Pre-existing orphan (bonus, same bug-class)
The cross-check found `deleteArtifact` never deleted `slack_thread_link` rows — so removing an artifact orphaned them. Added `slackThreadLink` cleanup to `deleteArtifact` across all three impls (repos/pg/sqlite) — exactly the class of dangling-row bug #419 fixed for threads.

## Tests
- A **`deleteThread` store-contract test**: comments + notifications + Slack link removed, **scoped to the thread** (a sibling thread survives).
- A slack-link assertion added to the **`deleteArtifact` cascade test**.
- Both run against **sqlite locally and Postgres in CI**.

## Accepted & documented (not fixed)
The D1 `deleteThread`/`deleteArtifact` paths stay non-transactional — platform-inherent (D1 has no interactive multi-statement transaction), matches the existing cascade, and the dependents-first ordering is the safe failure mode. `pg` and `sqlite` are transactional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)