### PR TITLE
fix(edits): bound the whitespace miss-diagnostic scan on large docs

### DIFF
--- a/packages/core/src/doc-text.test.ts
+++ b/packages/core/src/doc-text.test.ts
@@ -460,6 +460,31 @@ describe("applyEdits", () => {
     )
   })
 
+  it("skips the whitespace-normalized scan on a very large source, and stays fast (bounds O(n·m) wall time)", () => {
+    // The Tier-1 scan re-normalized each haystack line per window; on a multi-MB doc with
+    // long lines a single failed edit took seconds (found via adversarial testing on a
+    // ~50MB doc). Above the source cap the scan is skipped entirely — the miss still gets
+    // a diagnostic, just not the whitespace one — so it can't block the request budget.
+    const line = "x".repeat(2_000)
+    const src = Array.from({ length: 600 }, () => line).join("\n") // ~1.2 MB, over the cap
+    expect(src.length).toBeGreaterThan(1_000_000)
+    const start = performance.now()
+    // old_str is a whitespace-variant of every line: without the size guard this is the
+    // exact pathological scan; with it, the guard short-circuits before any O(n·m) work.
+    expect(() => applyEdits(src, [{ old_str: `${line} `, new_str: "y" }])).toThrow(
+      /not found in the current source/,
+    )
+    expect(performance.now() - start).toBeLessThan(200)
+    // The whitespace hint (the skipped scan) must NOT appear — proof the guard fired.
+    let msg = ""
+    try {
+      applyEdits(src, [{ old_str: `${line} `, new_str: "y" }])
+    } catch (e) {
+      msg = e instanceof EditError ? e.message : ""
+    }
+    expect(msg).not.toMatch(/whitespace differs/)
+  })
+
   it("a zero-match miss falls back to showing what's actually at a similar line (doc changed since read)", () => {
     const src = "alpha\nbeta original\ngamma"
     expect(() => applyEdits(src, [{ old_str: "beta stale text here", new_str: "x" }])).toThrow(

--- a/packages/core/src/doc-text.ts
+++ b/packages/core/src/doc-text.ts
@@ -829,6 +829,15 @@ const normalizeLine = (s: string): string => s.trim().replace(/\s+/g, " ")
 // 500K comparisons is ~12ms by extrapolation from a measured 36M-comparison/~900ms case.
 const TIER1_MAX_COMPARISONS = 500_000
 
+// The comparison COUNT above doesn't bound wall time on its own: a doc with a few very
+// long lines re-normalizes tens of thousands of chars per window, so the same "budget" of
+// comparisons measured seconds on a ~50MB doc (found via adversarial testing). Skip the
+// whitespace scan entirely past this source size — a live O(n·m) scan can't run within a
+// request budget on a multi-MB doc (mirrors edits.ts's CONFLICT_DIFF_MAX_SRC_CHARS guard).
+// Above it, a miss just gets the generic re-read steer. Well above any real artifact, far
+// below the upload ceiling. (Within it, normalizing each line ONCE keeps the scan cheap.)
+const WS_HINT_MAX_SRC = 1_000_000
+
 // Same cap search results already apply per line (see LINE_CLIP in
 // apps/api/src/lib/search.ts) — this file can't import that (packages/core has
 // zero external deps), so it's a local constant, not a shared one.
@@ -854,11 +863,16 @@ const nearestMissHint = (haystack: string, needle: string): string => {
 
   // Tier 1: the exact same lines exist, just with different whitespace — a sliding
   // window match on normalized lines, reported at its real (unnormalized) line no.
-  if (hLines.length * normN.length <= TIER1_MAX_COMPARISONS) {
+  // Two guards bound the cost: skip huge sources (WS_HINT_MAX_SRC) so the scan can't
+  // blow the request budget, and normalize each haystack line ONCE up front rather than
+  // re-normalizing it for every window it appears in (the per-window re-normalization,
+  // not the comparison count, is what made a large doc's failed edit take seconds).
+  if (haystack.length <= WS_HINT_MAX_SRC && hLines.length * normN.length <= TIER1_MAX_COMPARISONS) {
+    const normH = hLines.map(normalizeLine)
     for (let i = 0; i + normN.length <= hLines.length; i++) {
       let allMatch = true
       for (let j = 0; j < normN.length; j++) {
-        if (normalizeLine(hLines[i + j] as string) !== normN[j]) {
+        if (normH[i + j] !== normN[j]) {
           allMatch = false
           break
         }


### PR DESCRIPTION
Stacks onto **#415** (base = `feat/agent-read-tools`).

## Context
I set out to implement the highest-leverage edit-ergonomics win the SOTA review surfaced — promoting `nearestMissHint`'s whitespace-normalized match from a *diagnostic* into an *auto-apply* (aider's "whitespace-insensitive" rung). An adversarial pass **killed that feature**: on Derive's *byte-faithful, goes-live* artifacts it silently rewrites significant whitespace (a de-indented `new_str` promotes a nested list item to top-level) and can retarget a stale `old_str` onto a coincidental whitespace-variant elsewhere — defeating the safety + fidelity that make exact-match correct here. That's an IDE-source-code pattern that doesn't fit a published-document product, so it's not shipping.

## What this PR is
The one **safe** improvement that pass surfaced: a real **pre-existing** O(n·m) wall-time issue in the miss diagnostic.

`nearestMissHint`'s Tier-1 scan re-normalized each haystack line *for every window it appears in*. `TIER1_MAX_COMPARISONS` bounds the comparison **count** but not wall time — a doc with a few very long lines normalizes tens of thousands of chars per window, so the same "budget" measured **~7.8s on a ~50MB doc**. And it runs on **every** failed edit, so any miss on such a doc pays it. Same O(n·m) class this branch already hardened for the shown-line length and the conflict diff.

**Fix (two guards):**
- Skip the scan past `WS_HINT_MAX_SRC` (1MB) — a miss above it gets the generic re-read steer, mirroring `edits.ts`'s `CONFLICT_DIFF_MAX_SRC_CHARS`.
- Normalize each haystack line **once** up front instead of per window.

Behavior is unchanged for any real-sized doc (the whitespace hint still fires identically); a regression test pins a **1.2MB long-lined source returning in <200ms**.

Diagnostic-path only — it never touches `applyEdits`' matching or the stored bytes.

## Verify
core 356 ✓ · api edit/mcp/proposals/content-params ✓ · typecheck core+api ✓ · biome + all 15 precommit guards ✓ (no contract drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)