### PR TITLE
Persisted workspace search index (BM25/FTS) — whole-corpus, relevance-ranked, visibility-safe

### DIFF
--- a/apps/api/src/lib/after-publish.ts
+++ b/apps/api/src/lib/after-publish.ts
@@ -17,7 +17,9 @@ import {
 } from "@derive/core"
 import type { Backplane } from "../bus"
 import type { WebhookEvent } from "../events"
+import { log } from "../log"
 import { publishSweepEvents } from "./anchor-sweep"
+import { indexArtifactVersion } from "./search"
 
 /** The realtime + render + re-anchor core shared by every version bump (publish, restore,
  *  proposal-approve): announce the new version so open tabs live-reload, enqueue its preview
@@ -40,6 +42,15 @@ export const emitVersionBump = async (
   bus.publish(artifact.id, { type: "version.published", n: version.n, message: version.message })
   notifyRender?.(artifact, version.n)
   await publishSweepEvents(meta, blobs, bus, artifact.id, version)
+  // Keep the workspace search index current for the new live version. Best-effort:
+  // a search-index hiccup must never fail a publish that already succeeded, so log
+  // and move on — the artifact re-indexes on its next publish (and the backfill
+  // sweep is the safety net for anything missed).
+  try {
+    await indexArtifactVersion(meta, blobs, artifact, version)
+  } catch (err) {
+    log.error("search index update failed", { artifact: artifact.id, err: String(err) })
+  }
 }
 
 export interface AfterPublishDeps extends VersionBumpDeps {

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -4,6 +4,7 @@ import {
   elideDataUris,
   enclosingMarker,
   isHtmlLike,
+  type MetaStore,
   pageText,
   type SectionMarker,
   sectionMarkers,
@@ -30,9 +31,15 @@ export interface WorkspaceSearchDeps extends SearchDeps {
       orgId?: string
       viewerId?: string
       publicOnly?: boolean
+      ids?: string[]
       limit?: number
     }): Promise<ArtifactRecord[]>
     getVersion(artifactId: string, n: number): Promise<VersionRecord | null>
+    searchArtifactIds(
+      orgId: string,
+      query: string,
+      limit: number,
+    ): Promise<{ id: string; rank: number }[]>
   }
 }
 
@@ -262,15 +269,127 @@ export const searchReport = (
 }
 
 // ---------------------------------------------------------------------------
-// Workspace-wide search — the same one-artifact engine fanned out across the
-// artifacts a viewer can see, grouped by artifact.
+// Index maintenance — the WRITE side of workspace search. The persisted FTS/
+// tsvector index behind searchArtifactIds needs the current version's text kept in
+// step: emitVersionBump calls indexArtifactVersion on every publish/restore/
+// proposal-approve, and the DB layer maintains it on deleteArtifact/moveArtifactOrg.
 // ---------------------------------------------------------------------------
 
-// Cap on how many of a workspace's artifacts a workspace-wide search scans (most
-// recently created first, same ordering list_artifacts uses) — a live grep with no
-// index behind it can't scan an unbounded workspace within one request. Mirrors
-// ARTIFACT_PAGE_SCAN_CAP's shape: a documented, honest cap with a truncation note,
-// not a silent one.
+// Postgres caps a single tsvector near 1MB, so a source far past this can't be one
+// tsvector at all. Bound the indexed text well under that (real artifacts are far
+// smaller) on BOTH dialects, so the index content stays identical across them. The
+// tail of a giant doc isn't FTS-findable, but once the index nominates the artifact
+// grep still reads the live blob in full — so a hit past the bound is still reported
+// on the one-artifact path, just not discovered workspace-wide.
+export const MAX_INDEX_TEXT = 256 * 1024
+
+// The text an artifact version contributes to the search index: its raw SOURCE — so
+// the default source-scope search finds tag/attribute content, not only visible text
+// — across every text page of a bundle, with data: URIs elided (megabytes of inlined
+// base64 are index bloat, never a real search target). This is a RECALL superset of
+// what search greps in either scope: the index only nominates candidates, and
+// searchArtifactVersion re-applies the exact scope + literal. A non-text single file
+// (a bare uploaded image) contributes nothing.
+export async function versionIndexText(blobs: BlobStore, v: VersionRecord): Promise<string> {
+  const clipText = (s: string) => (s.length > MAX_INDEX_TEXT ? s.slice(0, MAX_INDEX_TEXT) : s)
+  const manifest = await manifestOf(blobs, v)
+  if (!manifest) {
+    if (!isTextType(v.content_type)) return ""
+    const bytes = await blobs.get(v.blob_key)
+    return bytes ? clipText(elideDataUris(new TextDecoder().decode(bytes))) : ""
+  }
+  const pages = Object.keys(manifest.files).filter((p) => isTextType(manifest.files[p]?.type ?? ""))
+  const parts: string[] = []
+  let used = 0
+  for (const p of pages) {
+    if (used >= MAX_INDEX_TEXT) break // enough text collected; skip the rest
+    const key = manifest.files[p]?.key
+    if (!key) continue
+    const bytes = await blobs.get(key)
+    if (!bytes) continue
+    const t = elideDataUris(new TextDecoder().decode(bytes))
+    parts.push(t)
+    used += t.length
+  }
+  return clipText(parts.join("\n\n"))
+}
+
+// Upsert an artifact's current-version text into the search index. Called from
+// emitVersionBump so publish, restore, and proposal-approve all keep it current.
+export async function indexArtifactVersion(
+  meta: Pick<MetaStore, "indexArtifact">,
+  blobs: BlobStore,
+  artifact: Pick<ArtifactRecord, "id" | "org_id" | "title">,
+  v: VersionRecord,
+): Promise<void> {
+  await meta.indexArtifact(
+    artifact.id,
+    artifact.org_id,
+    artifact.title,
+    await versionIndexText(blobs, v),
+  )
+}
+
+// Backfill — index artifacts that predate the write-path (or were created outside it).
+// Publishing keeps the index current going forward; this one-time sweep covers the
+// existing corpus. Idempotent (indexArtifact upserts), operator-driven in bounded
+// batches (POST /v1/system/search-reindex), resumed by passing nextCursor back until
+// it's null. Runs at operator scope (no viewerId) so it walks EVERY live artifact;
+// removed/taken-down rows are excluded by listArtifacts and stay out of the index.
+export interface ReindexSearchDeps {
+  blobs: BlobStore
+  meta: Pick<MetaStore, "indexArtifact" | "getVersion" | "listArtifacts">
+}
+
+export interface ReindexBatchResult {
+  scanned: number
+  indexed: number
+  nextCursor: { created_at: string; id: string } | null
+}
+
+export const reindexSearchBatch = async (
+  deps: ReindexSearchDeps,
+  opts: { orgId?: string; cursor?: { created_at: string; id: string }; limit: number },
+): Promise<ReindexBatchResult> => {
+  const arts = await deps.meta.listArtifacts({
+    orgId: opts.orgId,
+    cursor: opts.cursor,
+    limit: opts.limit,
+  })
+  let indexed = 0
+  for (const a of arts) {
+    const v = await deps.meta.getVersion(a.id, a.current_version)
+    if (!v) continue // no readable current version — skip rather than index empty
+    await indexArtifactVersion(deps.meta, deps.blobs, a, v)
+    indexed++
+  }
+  // A full page implies there may be more; the last row is the keyset for the next call
+  // (listArtifacts is newest-first, keyset on created_at+id — the same cursor the list
+  // route uses). A short page means we've reached the end.
+  const last = arts[arts.length - 1]
+  const nextCursor =
+    arts.length >= opts.limit && last ? { created_at: last.created_at, id: last.id } : null
+  return { scanned: arts.length, indexed, nextCursor }
+}
+
+// ---------------------------------------------------------------------------
+// Workspace-wide search — two-tier retrieval over the WHOLE corpus: the persisted
+// index nominates the most relevant candidate artifacts (searchArtifactIds), those
+// ids are re-resolved through the one visibility gate (listArtifacts), and the same
+// one-artifact grep engine confirms the exact literal on the top-ranked survivors.
+// This replaced a live grep of only the 30 most-RECENT artifacts, which was
+// structurally blind to everything older.
+// ---------------------------------------------------------------------------
+
+// How many ranked candidates the index returns. Generous headroom over the
+// grep-confirm cap so the visibility filter (which drops candidates the viewer can't
+// see) still leaves plenty to confirm. Org-ranked, so the top of this window is the
+// most relevant across the whole corpus — not the most recent.
+export const WORKSPACE_SEARCH_CANDIDATE_CAP = 200
+
+// How many visible, relevance-ranked candidates get the expensive grep-confirm (blob
+// read + literal scan). The real cost bound — was the old "scan the 30 most recent",
+// now "grep-confirm the 30 most RELEVANT you can see".
 export const WORKSPACE_SEARCH_ARTIFACT_CAP = 30
 
 export interface WorkspaceSearchResult {
@@ -280,10 +399,6 @@ export interface WorkspaceSearchResult {
   total: number
 }
 
-// Fan out searchArtifactVersion across the artifacts a viewer can see, batched for
-// cost (same shape as the bundle-page batching above). listArtifacts is called with
-// the SAME viewerId/orgId list_artifacts uses — that's the one true source of what
-// an agent can see, so this can't accidentally widen visibility past it.
 export const searchWorkspace = async (
   deps: WorkspaceSearchDeps,
   opts: {
@@ -295,32 +410,47 @@ export const searchWorkspace = async (
     // route this also backs can be called anonymously.
     viewerId?: string
     publicOnly?: boolean
+    // The raw literal query drives the index lookup (`query`) AND the grep-confirm
+    // (`re`, the same literal compiled) — both derive from the one user string.
+    query: string
     re: RegExp
     where: "source" | "text"
     ctxLines: number
     cap: number
   },
 ): Promise<{ results: WorkspaceSearchResult[]; note: string | null }> => {
-  // Fetch one past the cap — the same over-fetch-by-one pagination idiom the
-  // GET /v1/artifacts list route already uses — so "exactly WORKSPACE_SEARCH_
-  // ARTIFACT_CAP accessible artifacts" and "more than that" are distinguishable.
-  // Without the +1, a workspace with EXACTLY the cap worth of artifacts always
-  // reports "there may be more" even though there isn't. The sentinel row itself
-  // is never scanned (sliced off below) — its only job is answering that question.
-  const arts = await deps.meta.listArtifacts({
+  // Tier 1 — the index nominates the most relevant candidate ids across the whole
+  // corpus. Org-scoped and ranked, but with NO visibility knowledge by design.
+  const candidates = await deps.meta.searchArtifactIds(
+    opts.orgId,
+    opts.query,
+    WORKSPACE_SEARCH_CANDIDATE_CAP,
+  )
+  if (candidates.length === 0) return { results: [], note: null }
+  const rankOf = new Map(candidates.map((c, i) => [c.id, i]))
+
+  // Tier 2 gate — THE visibility check. Re-resolve the nominated ids through
+  // listArtifacts with the SAME orgId/viewerId/publicOnly list_artifacts uses: an id
+  // the index nominated survives only if this call (the one true source of what a
+  // viewer can see) returns it. The index is a pure relevance oracle with no access
+  // knowledge, so it can never widen visibility past this gate.
+  const visible = await deps.meta.listArtifacts({
     orgId: opts.orgId,
     viewerId: opts.viewerId,
     publicOnly: opts.publicOnly,
-    limit: WORKSPACE_SEARCH_ARTIFACT_CAP + 1,
+    ids: candidates.map((c) => c.id),
   })
-  const hasMore = arts.length > WORKSPACE_SEARCH_ARTIFACT_CAP
-  const scanned = hasMore ? arts.slice(0, WORKSPACE_SEARCH_ARTIFACT_CAP) : arts
-  // Lower than searchArtifactVersion's own inner CONCURRENCY=8 (bundle-page
-  // batching) on purpose: this outer batch and that inner one aren't composed —
-  // if several of the artifacts landing in one outer batch are themselves bundles,
-  // each independently opens its own 8-wide inner fan-out, so peak concurrent blob
-  // reads is the PRODUCT of the two, not either alone. 4×8=32 keeps that worst case
-  // reasonable without adding a cross-cutting semaphore for a bound this small.
+  // listArtifacts returns in its own (recency) order; restore relevance order.
+  visible.sort((a, b) => (rankOf.get(a.id) ?? Infinity) - (rankOf.get(b.id) ?? Infinity))
+
+  // Grep-confirm only the top-N most-relevant survivors — the blob-read+scan is the
+  // real cost, so it stays bounded. A candidate the index nominated on token overlap
+  // but whose exact literal/scope isn't actually present yields no hunks and drops out
+  // here: the index is RECALL, the grep is PRECISION.
+  const toGrep = visible.slice(0, WORKSPACE_SEARCH_ARTIFACT_CAP)
+  // 4, not searchArtifactVersion's inner 8: the two fan-outs compose (a batch of
+  // bundles each opens its own 8-wide page fan-out), so peak blob reads is the product
+  // — 4×8=32 keeps that worst case reasonable without a cross-cutting semaphore.
   const CONCURRENCY = 4
   const scanArtifact = async (a: ArtifactRecord): Promise<WorkspaceSearchResult | null> => {
     const v = await deps.meta.getVersion(a.id, a.current_version)
@@ -336,13 +466,23 @@ export const searchWorkspace = async (
     return total ? { short_id: a.short_id, title: a.title ?? a.short_id, groups, total } : null
   }
   const results: WorkspaceSearchResult[] = []
-  for (let i = 0; i < scanned.length; i += CONCURRENCY) {
-    const batch = await Promise.all(scanned.slice(i, i + CONCURRENCY).map(scanArtifact))
+  for (let i = 0; i < toGrep.length; i += CONCURRENCY) {
+    const batch = await Promise.all(toGrep.slice(i, i + CONCURRENCY).map(scanArtifact))
     for (const r of batch) if (r) results.push(r)
   }
-  const note = hasMore
-    ? `scanned the ${WORKSPACE_SEARCH_ARTIFACT_CAP} most recently created artifacts you can see — there may be more`
-    : null
+
+  // Honest truncation. `grepTruncated`: more visible matches than we confirmed.
+  // `moreCandidates`: the index itself hit its candidate cap, so lower-ranked matches
+  // (some possibly visible) exist below the window — hence the `+`.
+  const grepTruncated = visible.length > WORKSPACE_SEARCH_ARTIFACT_CAP
+  const moreCandidates = candidates.length >= WORKSPACE_SEARCH_CANDIDATE_CAP
+  const note = grepTruncated
+    ? `ranked by relevance — showing the top ${WORKSPACE_SEARCH_ARTIFACT_CAP} of ${visible.length}${
+        moreCandidates ? "+" : ""
+      } matching artifacts you can see; refine the query for the rest`
+    : moreCandidates
+      ? "ranked by relevance — there may be more lower-ranked matches; refine the query to surface them"
+      : null
   return { results, note }
 }
 

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -416,6 +416,7 @@ const LIST_ID_CHUNK = 90
 export interface WorkspaceSearchResult {
   short_id: string
   title: string
+  current_version: number
   groups: { path: string | null; hunks: SearchHunk[] }[]
   total: number
 }
@@ -438,6 +439,10 @@ export const searchWorkspace = async (
     where: "source" | "text"
     ctxLines: number
     cap: number
+    // How many visible candidates to grep-confirm. Defaults to WORKSPACE_SEARCH_ARTIFACT_CAP
+    // (agents want depth); a typeahead surface passes a small value so a debounced keystroke
+    // reads only a handful of blobs.
+    limit?: number
   },
 ): Promise<{ results: WorkspaceSearchResult[]; note: string | null }> => {
   // Tier 1 — the index nominates the most relevant candidate ids across the whole
@@ -479,7 +484,8 @@ export const searchWorkspace = async (
   // real cost, so it stays bounded. A candidate the index nominated on token overlap
   // but whose exact literal/scope isn't actually present yields no hunks and drops out
   // here: the index is RECALL, the grep is PRECISION.
-  const toGrep = visible.slice(0, WORKSPACE_SEARCH_ARTIFACT_CAP)
+  const grepCap = opts.limit ?? WORKSPACE_SEARCH_ARTIFACT_CAP
+  const toGrep = visible.slice(0, grepCap)
   // 4, not searchArtifactVersion's inner 8: the two fan-outs compose (a batch of
   // bundles each opens its own 8-wide page fan-out), so peak blob reads is the product
   // — 4×8=32 keeps that worst case reasonable without a cross-cutting semaphore.
@@ -495,7 +501,15 @@ export const searchWorkspace = async (
       opts.ctxLines,
       opts.cap,
     )
-    return total ? { short_id: a.short_id, title: a.title ?? a.short_id, groups, total } : null
+    return total
+      ? {
+          short_id: a.short_id,
+          title: a.title ?? a.short_id,
+          current_version: a.current_version,
+          groups,
+          total,
+        }
+      : null
   }
   const results: WorkspaceSearchResult[] = []
   for (let i = 0; i < toGrep.length; i += CONCURRENCY) {
@@ -508,9 +522,9 @@ export const searchWorkspace = async (
   // wording says "candidates", never "matches". `grepTruncated`: more visible candidates
   // than we confirmed. `moreCandidates`: the index had still more below the window
   // (detected by the over-fetched sentinel) — hence the `+`.
-  const grepTruncated = visible.length > WORKSPACE_SEARCH_ARTIFACT_CAP
+  const grepTruncated = visible.length > grepCap
   const note = grepTruncated
-    ? `ranked by relevance — grep-confirmed the top ${WORKSPACE_SEARCH_ARTIFACT_CAP} of ${visible.length}${
+    ? `ranked by relevance — grep-confirmed the top ${grepCap} of ${visible.length}${
         moreCandidates ? "+" : ""
       } candidate artifacts you can see; refine the query to reach the rest`
     : moreCandidates
@@ -543,3 +557,45 @@ export const workspaceSearchReport = (
   const steer = `\n\nOpen one with search(short_id:"...", query:"${query}") for full context, or read(short_id:"...", lines:"from-to", format:"${fmt}").`
   return clip(`${head}\n\n${body}${steer}`)
 }
+
+// ---------------------------------------------------------------------------
+// JSON hits — the same workspace results shaped for a UI (the ⌘K palette) instead of
+// the agent text report: one artifact per hit, with a single-line snippet of WHERE it
+// matched so a human sees why it surfaced. The client highlights the term itself.
+// ---------------------------------------------------------------------------
+
+export interface SearchHit {
+  short_id: string
+  title: string
+  current_version: number
+  /** One line of the matching text, windowed around the first match (…elided ends). */
+  snippet: string
+}
+
+const SNIPPET_RADIUS = 90
+
+// Window a long line around the first occurrence of `query` so the match stays visible
+// instead of scrolling off a clipped line. Whitespace is collapsed (a source line can be
+// deeply indented). Falls back to the head of the line when the literal isn't found on it.
+export const snippetAround = (line: string, query: string): string => {
+  const flat = line.replace(/\s+/g, " ").trim()
+  const q = query.trim()
+  if (flat.length <= SNIPPET_RADIUS * 2) return flat
+  const at = flat.toLowerCase().indexOf(q.toLowerCase())
+  if (at < 0) return `${flat.slice(0, SNIPPET_RADIUS * 2)}…`
+  const start = Math.max(0, at - SNIPPET_RADIUS)
+  const end = Math.min(flat.length, at + q.length + SNIPPET_RADIUS)
+  return `${start > 0 ? "…" : ""}${flat.slice(start, end)}${end < flat.length ? "…" : ""}`
+}
+
+export const toSearchHits = (results: WorkspaceSearchResult[], query: string): SearchHit[] =>
+  results.map((r) => {
+    // The first HIT line across the artifact's groups is the most relevant snippet source.
+    const hit = r.groups.flatMap((g) => g.hunks.flatMap((h) => h.lines)).find((l) => l.hit)
+    return {
+      short_id: r.short_id,
+      title: r.title,
+      current_version: r.current_version,
+      snippet: hit ? snippetAround(hit.text, query) : "",
+    }
+  })

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -575,21 +575,25 @@ export interface SearchHit {
   snippet: string
 }
 
-const SNIPPET_RADIUS = 90
+// A short lead of context BEFORE the match, then the rest trailing. The window is biased
+// left on purpose: the palette renders the snippet in a single left-truncating line, so a
+// centered window would push the highlighted term off the right edge — the common case
+// here, where agent-authored markdown writes each paragraph as one long unwrapped line.
+const SNIPPET_LEAD = 16
+const SNIPPET_LEN = 160
 
-// Window a long line around the first occurrence of `query` so the match stays visible
-// instead of scrolling off a clipped line. Whitespace is collapsed (a source line can be
-// deeply indented). Falls back to the head of the line when the literal isn't found on it.
+// Window a line so the first occurrence of `query` sits near the visible LEFT edge and
+// survives truncation. Whitespace in both the line and the query is collapsed (a source
+// line can be deeply indented; a query may carry stray spaces) so the match stays
+// locatable. Falls back to the head of the line when the literal isn't on it (shouldn't
+// happen after grep-confirm, but stays safe).
 export const snippetAround = (line: string, query: string): string => {
   const flat = line.replace(/\s+/g, " ").trim()
-  // Collapse the query's whitespace too, so a multi-space/tab query still locates its
-  // match in the collapsed line (else it'd fall to the head-of-line branch).
   const q = query.replace(/\s+/g, " ").trim()
-  if (flat.length <= SNIPPET_RADIUS * 2) return flat
-  const at = flat.toLowerCase().indexOf(q.toLowerCase())
-  if (at < 0) return `${flat.slice(0, SNIPPET_RADIUS * 2)}…`
-  const start = Math.max(0, at - SNIPPET_RADIUS)
-  const end = Math.min(flat.length, at + q.length + SNIPPET_RADIUS)
+  const at = q ? flat.toLowerCase().indexOf(q.toLowerCase()) : -1
+  if (at < 0) return flat.length > SNIPPET_LEN ? `${flat.slice(0, SNIPPET_LEN)}…` : flat
+  const start = Math.max(0, at - SNIPPET_LEAD)
+  const end = Math.min(flat.length, start + SNIPPET_LEN)
   return `${start > 0 ? "…" : ""}${flat.slice(start, end)}${end < flat.length ? "…" : ""}`
 }
 

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -11,6 +11,7 @@ import {
   toMarkdown,
   type VersionRecord,
 } from "@derive/core"
+import { log } from "../log"
 import { cleanPath, manifestOf } from "./bundle"
 import { clip } from "./clip"
 
@@ -31,6 +32,7 @@ export interface WorkspaceSearchDeps extends SearchDeps {
       orgId?: string
       viewerId?: string
       publicOnly?: boolean
+      excludeRemoved?: boolean
       ids?: string[]
       limit?: number
     }): Promise<ArtifactRecord[]>
@@ -275,21 +277,25 @@ export const searchReport = (
 // proposal-approve, and the DB layer maintains it on deleteArtifact/moveArtifactOrg.
 // ---------------------------------------------------------------------------
 
-// Postgres caps a single tsvector near 1MB, so a source far past this can't be one
-// tsvector at all. Bound the indexed text well under that (real artifacts are far
-// smaller) on BOTH dialects, so the index content stays identical across them. The
-// tail of a giant doc isn't FTS-findable, but once the index nominates the artifact
-// grep still reads the live blob in full — so a hit past the bound is still reported
-// on the one-artifact path, just not discovered workspace-wide.
+// Bound the indexed text per artifact (in JS chars — real artifacts are far smaller).
+// This keeps the index lean and stays comfortably under Postgres's ~1MB-per-tsvector
+// ceiling: 256K UTF-16 code units is at most ~1MB of UTF-8, and a tsvector is no larger
+// than its input, so `to_tsvector` won't overflow on normal input. Applied on BOTH
+// dialects so the index content matches. The tail of a giant doc isn't FTS-findable,
+// but once the index nominates the artifact the one-artifact grep still reads the live
+// blob in full — so a past-the-bound hit is reported there, just not discovered
+// workspace-wide.
 export const MAX_INDEX_TEXT = 256 * 1024
 
 // The text an artifact version contributes to the search index: its raw SOURCE — so
-// the default source-scope search finds tag/attribute content, not only visible text
-// — across every text page of a bundle, with data: URIs elided (megabytes of inlined
-// base64 are index bloat, never a real search target). This is a RECALL superset of
-// what search greps in either scope: the index only nominates candidates, and
-// searchArtifactVersion re-applies the exact scope + literal. A non-text single file
-// (a bare uploaded image) contributes nothing.
+// the default source-scope search finds tag/attribute content, not only visible text —
+// across every text page of a bundle. The index is a RECALL-APPROXIMATE candidate
+// generator, not a strict superset of what grep-confirm reads: data: URIs are elided
+// (megabytes of inlined base64 are bloat, never a real target), text past MAX_INDEX_TEXT
+// is dropped, and — because the source is indexed, not the rendered text — an `in:'text'`
+// query for a word split across inline tags (foo<b>bar</b> → visible "foobar") may not
+// be nominated. All three are workspace-discovery gaps only: the one-artifact grep still
+// finds those hits directly. A non-text single file (a bare uploaded image) adds nothing.
 export async function versionIndexText(blobs: BlobStore, v: VersionRecord): Promise<string> {
   const clipText = (s: string) => (s.length > MAX_INDEX_TEXT ? s.slice(0, MAX_INDEX_TEXT) : s)
   const manifest = await manifestOf(blobs, v)
@@ -334,8 +340,8 @@ export async function indexArtifactVersion(
 // Publishing keeps the index current going forward; this one-time sweep covers the
 // existing corpus. Idempotent (indexArtifact upserts), operator-driven in bounded
 // batches (POST /v1/system/search-reindex), resumed by passing nextCursor back until
-// it's null. Runs at operator scope (no viewerId) so it walks EVERY live artifact;
-// removed/taken-down rows are excluded by listArtifacts and stay out of the index.
+// it's null. Runs at operator scope (no viewerId) but with `excludeRemoved` so it walks
+// every LIVE artifact and never indexes a taken-down one.
 export interface ReindexSearchDeps {
   blobs: BlobStore
   meta: Pick<MetaStore, "indexArtifact" | "getVersion" | "listArtifacts">
@@ -355,13 +361,21 @@ export const reindexSearchBatch = async (
     orgId: opts.orgId,
     cursor: opts.cursor,
     limit: opts.limit,
+    excludeRemoved: true,
   })
   let indexed = 0
   for (const a of arts) {
-    const v = await deps.meta.getVersion(a.id, a.current_version)
-    if (!v) continue // no readable current version — skip rather than index empty
-    await indexArtifactVersion(deps.meta, deps.blobs, a, v)
-    indexed++
+    // Isolate each artifact: a single unreadable blob / transient store error must not
+    // abort the whole batch and wedge the operator's cursor (unlike the publish path,
+    // this loop is the only driver). Log and move on — the row can be re-swept later.
+    try {
+      const v = await deps.meta.getVersion(a.id, a.current_version)
+      if (!v) continue // no readable current version — skip rather than index empty
+      await indexArtifactVersion(deps.meta, deps.blobs, a, v)
+      indexed++
+    } catch (err) {
+      log.error("search reindex skipped one artifact", { artifact: a.id, err: String(err) })
+    }
   }
   // A full page implies there may be more; the last row is the keyset for the next call
   // (listArtifacts is newest-first, keyset on created_at+id — the same cursor the list
@@ -392,6 +406,13 @@ export const WORKSPACE_SEARCH_CANDIDATE_CAP = 200
 // now "grep-confirm the 30 most RELEVANT you can see".
 export const WORKSPACE_SEARCH_ARTIFACT_CAP = 30
 
+// The candidate ids are resolved through listArtifacts in chunks this size: `ids`
+// compiles to `id IN (?…)`, one bound parameter each, and D1 rejects any statement
+// with >100 of them (a 500). 90 leaves room for the query's other bound params
+// (org, viewer, listed). Postgres could take all 200 at once but chunking is harmless
+// there. The chunks are independent visibility queries; their rows just concatenate.
+const LIST_ID_CHUNK = 90
+
 export interface WorkspaceSearchResult {
   short_id: string
   title: string
@@ -420,26 +441,37 @@ export const searchWorkspace = async (
   },
 ): Promise<{ results: WorkspaceSearchResult[]; note: string | null }> => {
   // Tier 1 — the index nominates the most relevant candidate ids across the whole
-  // corpus. Org-scoped and ranked, but with NO visibility knowledge by design.
-  const candidates = await deps.meta.searchArtifactIds(
+  // corpus. Org-scoped and ranked, but with NO visibility knowledge by design. Fetch one
+  // past the cap: the sentinel row (never resolved) just answers "were there more?".
+  const nominated = await deps.meta.searchArtifactIds(
     opts.orgId,
     opts.query,
-    WORKSPACE_SEARCH_CANDIDATE_CAP,
+    WORKSPACE_SEARCH_CANDIDATE_CAP + 1,
   )
-  if (candidates.length === 0) return { results: [], note: null }
+  if (nominated.length === 0) return { results: [], note: null }
+  const moreCandidates = nominated.length > WORKSPACE_SEARCH_CANDIDATE_CAP
+  const candidates = nominated.slice(0, WORKSPACE_SEARCH_CANDIDATE_CAP)
   const rankOf = new Map(candidates.map((c, i) => [c.id, i]))
 
   // Tier 2 gate — THE visibility check. Re-resolve the nominated ids through
-  // listArtifacts with the SAME orgId/viewerId/publicOnly list_artifacts uses: an id
-  // the index nominated survives only if this call (the one true source of what a
-  // viewer can see) returns it. The index is a pure relevance oracle with no access
-  // knowledge, so it can never widen visibility past this gate.
-  const visible = await deps.meta.listArtifacts({
-    orgId: opts.orgId,
-    viewerId: opts.viewerId,
-    publicOnly: opts.publicOnly,
-    ids: candidates.map((c) => c.id),
-  })
+  // listArtifacts with the SAME orgId/viewerId/publicOnly list_artifacts uses, PLUS
+  // excludeRemoved (the index can outlive a takedown, and listArtifacts keeps tombstones
+  // for the feed — so search must drop them explicitly, else a moderated artifact's text
+  // is grep-readable). An id the index nominated survives only if this call returns it,
+  // so the index — a pure relevance oracle with no access knowledge — can never widen
+  // visibility. Chunked to stay under D1's bound-parameter cap (see LIST_ID_CHUNK).
+  const visible: ArtifactRecord[] = []
+  const candidateIds = candidates.map((c) => c.id)
+  for (let i = 0; i < candidateIds.length; i += LIST_ID_CHUNK) {
+    const rows = await deps.meta.listArtifacts({
+      orgId: opts.orgId,
+      viewerId: opts.viewerId,
+      publicOnly: opts.publicOnly,
+      excludeRemoved: true,
+      ids: candidateIds.slice(i, i + LIST_ID_CHUNK),
+    })
+    visible.push(...rows)
+  }
   // listArtifacts returns in its own (recency) order; restore relevance order.
   visible.sort((a, b) => (rankOf.get(a.id) ?? Infinity) - (rankOf.get(b.id) ?? Infinity))
 
@@ -471,17 +503,18 @@ export const searchWorkspace = async (
     for (const r of batch) if (r) results.push(r)
   }
 
-  // Honest truncation. `grepTruncated`: more visible matches than we confirmed.
-  // `moreCandidates`: the index itself hit its candidate cap, so lower-ranked matches
-  // (some possibly visible) exist below the window — hence the `+`.
+  // Honest truncation. These are CANDIDATE counts (index nominations that passed
+  // visibility), not confirmed-hit counts: grep-confirm may still drop some, so the
+  // wording says "candidates", never "matches". `grepTruncated`: more visible candidates
+  // than we confirmed. `moreCandidates`: the index had still more below the window
+  // (detected by the over-fetched sentinel) — hence the `+`.
   const grepTruncated = visible.length > WORKSPACE_SEARCH_ARTIFACT_CAP
-  const moreCandidates = candidates.length >= WORKSPACE_SEARCH_CANDIDATE_CAP
   const note = grepTruncated
-    ? `ranked by relevance — showing the top ${WORKSPACE_SEARCH_ARTIFACT_CAP} of ${visible.length}${
+    ? `ranked by relevance — grep-confirmed the top ${WORKSPACE_SEARCH_ARTIFACT_CAP} of ${visible.length}${
         moreCandidates ? "+" : ""
-      } matching artifacts you can see; refine the query for the rest`
+      } candidate artifacts you can see; refine the query to reach the rest`
     : moreCandidates
-      ? "ranked by relevance — there may be more lower-ranked matches; refine the query to surface them"
+      ? `ranked by relevance — more than ${WORKSPACE_SEARCH_CANDIDATE_CAP} artifacts matched the index; refine the query to narrow`
       : null
   return { results, note }
 }

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -441,21 +441,24 @@ export const searchWorkspace = async (
     cap: number
     // How many visible candidates to grep-confirm. Defaults to WORKSPACE_SEARCH_ARTIFACT_CAP
     // (agents want depth); a typeahead surface passes a small value so a debounced keystroke
-    // reads only a handful of blobs.
+    // reads only a handful of blobs. NOTE: this bounds only the blob-read + grep stage, not
+    // the (indexed, cheap) candidate scan or the visibility resolve — cap those with
+    // `candidateCap` when the caller wants the whole request small.
     limit?: number
+    // How many ranked candidates to nominate + visibility-check. Defaults to
+    // WORKSPACE_SEARCH_CANDIDATE_CAP (deep recall for agents); a typeahead surface passes a
+    // small value (≤ LIST_ID_CHUNK) so the visibility resolve is a SINGLE query, not three.
+    candidateCap?: number
   },
 ): Promise<{ results: WorkspaceSearchResult[]; note: string | null }> => {
   // Tier 1 — the index nominates the most relevant candidate ids across the whole
   // corpus. Org-scoped and ranked, but with NO visibility knowledge by design. Fetch one
   // past the cap: the sentinel row (never resolved) just answers "were there more?".
-  const nominated = await deps.meta.searchArtifactIds(
-    opts.orgId,
-    opts.query,
-    WORKSPACE_SEARCH_CANDIDATE_CAP + 1,
-  )
+  const candidateCap = opts.candidateCap ?? WORKSPACE_SEARCH_CANDIDATE_CAP
+  const nominated = await deps.meta.searchArtifactIds(opts.orgId, opts.query, candidateCap + 1)
   if (nominated.length === 0) return { results: [], note: null }
-  const moreCandidates = nominated.length > WORKSPACE_SEARCH_CANDIDATE_CAP
-  const candidates = nominated.slice(0, WORKSPACE_SEARCH_CANDIDATE_CAP)
+  const moreCandidates = nominated.length > candidateCap
+  const candidates = nominated.slice(0, candidateCap)
   const rankOf = new Map(candidates.map((c, i) => [c.id, i]))
 
   // Tier 2 gate — THE visibility check. Re-resolve the nominated ids through
@@ -528,7 +531,7 @@ export const searchWorkspace = async (
         moreCandidates ? "+" : ""
       } candidate artifacts you can see; refine the query to reach the rest`
     : moreCandidates
-      ? `ranked by relevance — more than ${WORKSPACE_SEARCH_CANDIDATE_CAP} artifacts matched the index; refine the query to narrow`
+      ? `ranked by relevance — more than ${candidateCap} artifacts matched the index; refine the query to narrow`
       : null
   return { results, note }
 }
@@ -579,7 +582,9 @@ const SNIPPET_RADIUS = 90
 // deeply indented). Falls back to the head of the line when the literal isn't found on it.
 export const snippetAround = (line: string, query: string): string => {
   const flat = line.replace(/\s+/g, " ").trim()
-  const q = query.trim()
+  // Collapse the query's whitespace too, so a multi-space/tab query still locates its
+  // match in the collapsed line (else it'd fall to the head-of-line branch).
+  const q = query.replace(/\s+/g, " ").trim()
   if (flat.length <= SNIPPET_RADIUS * 2) return flat
   const at = flat.toLowerCase().indexOf(q.toLowerCase())
   if (at < 0) return `${flat.slice(0, SNIPPET_RADIUS * 2)}…`

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -480,15 +480,20 @@ export const searchWorkspace = async (
     })
     visible.push(...rows)
   }
+  // A password lock gates the world-link CONTENT behind a password — read 401s without it.
+  // The publicOnly caller IS that anonymous/link visitor, so drop locked artifacts here,
+  // else their body would be grep-readable, bypassing the unlock. A member (viewerId)
+  // reaches content through membership, not the link, so the lock never applies to them.
+  const gated = opts.publicOnly ? visible.filter((a) => !a.password_hash) : visible
   // listArtifacts returns in its own (recency) order; restore relevance order.
-  visible.sort((a, b) => (rankOf.get(a.id) ?? Infinity) - (rankOf.get(b.id) ?? Infinity))
+  gated.sort((a, b) => (rankOf.get(a.id) ?? Infinity) - (rankOf.get(b.id) ?? Infinity))
 
   // Grep-confirm only the top-N most-relevant survivors — the blob-read+scan is the
   // real cost, so it stays bounded. A candidate the index nominated on token overlap
   // but whose exact literal/scope isn't actually present yields no hunks and drops out
   // here: the index is RECALL, the grep is PRECISION.
   const grepCap = opts.limit ?? WORKSPACE_SEARCH_ARTIFACT_CAP
-  const toGrep = visible.slice(0, grepCap)
+  const toGrep = gated.slice(0, grepCap)
   // 4, not searchArtifactVersion's inner 8: the two fan-outs compose (a batch of
   // bundles each opens its own 8-wide page fan-out), so peak blob reads is the product
   // — 4×8=32 keeps that worst case reasonable without a cross-cutting semaphore.
@@ -525,9 +530,9 @@ export const searchWorkspace = async (
   // wording says "candidates", never "matches". `grepTruncated`: more visible candidates
   // than we confirmed. `moreCandidates`: the index had still more below the window
   // (detected by the over-fetched sentinel) — hence the `+`.
-  const grepTruncated = visible.length > grepCap
+  const grepTruncated = gated.length > grepCap
   const note = grepTruncated
-    ? `ranked by relevance — grep-confirmed the top ${grepCap} of ${visible.length}${
+    ? `ranked by relevance — grep-confirmed the top ${grepCap} of ${gated.length}${
         moreCandidates ? "+" : ""
       } candidate artifacts you can see; refine the query to reach the rest`
     : moreCandidates

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -1062,7 +1062,7 @@ async function buildServer(
     "search",
     {
       description:
-        "Find text within ONE artifact, or across a WORKSPACE. Pass short_id to grep one artifact (not a full read): matching lines with line numbers (and optional context), ripgrep-style, so you can then `read` a narrow `lines` range (in the format the result names) or `edit` that spot. A bundle is searched across all its text pages, grouped by page. Omit short_id to search the WHOLE workspace — every artifact you can see (same visibility rules as list_artifacts), ranked by relevance, grouped by artifact — so you can find WHICH doc has something before opening it. Searches the exact source by default (in:'text' searches the visible text instead). The query is matched literally (metacharacters are not special).",
+        "Find text within ONE artifact, or across a WORKSPACE. Pass short_id to grep one artifact (not a full read): matching lines with line numbers (and optional context), ripgrep-style, so you can then `read` a narrow `lines` range (in the format the result names) or `edit` that spot. A bundle is searched across all its text pages, grouped by page. Omit short_id to search across the workspace — the artifacts you can see (same visibility rules as list_artifacts), ranked by relevance and grouped by artifact — so you can find WHICH doc has something before opening it; a note tells you when more matched than were shown. Searches the exact source by default (in:'text' searches the visible text instead). The query is matched literally (metacharacters are not special).",
       inputSchema: {
         short_id: z
           .string()

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -547,6 +547,12 @@ async function buildServer(
         (await ctx.meta.getArtifactMember(a.id, agent.id))
       if (!ok) return null
     }
+    // A taken-down artifact serves NO content, mirroring the web /raw 410: read, search,
+    // comment, and publish all resolve through here, so gating it once covers every
+    // one-artifact tool. It stays visible as a tombstone in list_artifacts (metadata
+    // only). Checked AFTER the reach/membership gates so it never confirms a removed
+    // short_id to someone who couldn't have reached it anyway (they still get notFound).
+    if (a.removed_at) return { error: `"${shortId}" was taken down and is no longer available.` }
     return { a, org, role }
   }
   const notFound = (shortId: string) =>

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -1062,7 +1062,7 @@ async function buildServer(
     "search",
     {
       description:
-        "Find text within ONE artifact, or across a WORKSPACE. Pass short_id to grep one artifact (not a full read): matching lines with line numbers (and optional context), ripgrep-style, so you can then `read` a narrow `lines` range (in the format the result names) or `edit` that spot. A bundle is searched across all its text pages, grouped by page. Omit short_id to grep instead across the most recently created artifacts you can see in a workspace — same visibility rules as list_artifacts — grouped by artifact, so you can find WHICH doc has something before opening it. Searches the exact source by default (in:'text' searches the visible text instead). The query is matched literally (metacharacters are not special).",
+        "Find text within ONE artifact, or across a WORKSPACE. Pass short_id to grep one artifact (not a full read): matching lines with line numbers (and optional context), ripgrep-style, so you can then `read` a narrow `lines` range (in the format the result names) or `edit` that spot. A bundle is searched across all its text pages, grouped by page. Omit short_id to search the WHOLE workspace — every artifact you can see (same visibility rules as list_artifacts), ranked by relevance, grouped by artifact — so you can find WHICH doc has something before opening it. Searches the exact source by default (in:'text' searches the visible text instead). The query is matched literally (metacharacters are not special).",
       inputSchema: {
         short_id: z
           .string()
@@ -1117,6 +1117,7 @@ async function buildServer(
         const { results, note } = await searchWorkspace(ctx, {
           orgId: t.org,
           viewerId: actingFor?.id ?? agent.id,
+          query,
           re,
           where,
           ctxLines,

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -877,6 +877,10 @@ export const artifactRoutes = (ctx: AppContext) => {
     // reads only a few blobs; the text report keeps the full agent depth.
     const isJson = c.req.query("format") === "json"
     const limit = isJson ? Math.min(Math.max(Number(c.req.query("limit")) || 6, 1), 12) : undefined
+    // Keep the whole JSON request cheap, not just the blob reads: a small candidate cap
+    // means the visibility resolve is a SINGLE chunked query and the FTS scan is small —
+    // the palette only shows a handful, so deep recall would be wasted work on a hot path.
+    const candidateCap = isJson ? 60 : undefined
 
     const { results, note } = await searchWorkspace(
       { blobs, sourceText, meta },
@@ -890,9 +894,11 @@ export const artifactRoutes = (ctx: AppContext) => {
         ctxLines,
         cap,
         limit,
+        candidateCap,
       },
     )
     if (isJson) {
+      c.header("X-Content-Type-Options", "nosniff")
       c.header("Cache-Control", "no-store")
       return c.json({ hits: toSearchHits(results, query), truncated: note !== null })
     }

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -876,6 +876,7 @@ export const artifactRoutes = (ctx: AppContext) => {
         orgId: listOrg,
         viewerId: isOperator ? undefined : (memberKey ?? undefined),
         publicOnly,
+        query,
         re,
         where,
         ctxLines,

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -62,6 +62,7 @@ import {
   searchMatcher,
   searchReport,
   searchWorkspace,
+  toSearchHits,
   workspaceSearchReport,
 } from "../lib/search"
 import { enqueueSlackReviewRequestedDm } from "../lib/slack-dm"
@@ -870,6 +871,13 @@ export const artifactRoutes = (ctx: AppContext) => {
         : null
     const publicOnly = !(isOperator || baselineRole !== null)
 
+    // `?format=json` is the UI shape (the ⌘K palette): a small, ranked hit list with a
+    // snippet per artifact instead of the agent-facing ripgrep text report. A typeahead
+    // caller keeps the grep-confirm count tiny (bounded 1..12) so a debounced keystroke
+    // reads only a few blobs; the text report keeps the full agent depth.
+    const isJson = c.req.query("format") === "json"
+    const limit = isJson ? Math.min(Math.max(Number(c.req.query("limit")) || 6, 1), 12) : undefined
+
     const { results, note } = await searchWorkspace(
       { blobs, sourceText, meta },
       {
@@ -881,8 +889,13 @@ export const artifactRoutes = (ctx: AppContext) => {
         where,
         ctxLines,
         cap,
+        limit,
       },
     )
+    if (isJson) {
+      c.header("Cache-Control", "no-store")
+      return c.json({ hits: toSearchHits(results, query), truncated: note !== null })
+    }
     c.header("Access-Control-Allow-Origin", "*")
     c.header("X-Content-Type-Options", "nosniff")
     c.header("Content-Type", "text/plain; charset=utf-8")

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -1,7 +1,9 @@
+import { z } from "@hono/zod-openapi"
 import { Hono } from "hono"
 import { capabilityReport } from "../config-manifest"
 import type { AppContext } from "../context"
-import { fail } from "../lib/http"
+import { fail, readJson } from "../lib/http"
+import { reindexSearchBatch } from "../lib/search"
 import { log } from "../log"
 
 /** Operational endpoints: liveness (/healthz), readiness (/readyz — proves the datastore
@@ -49,6 +51,34 @@ export const systemRoutes = (ctx: AppContext) => {
         : cap,
     )
     return c.json({ capabilities })
+  })
+
+  // Backfill the workspace search index over the EXISTING corpus. Publishing keeps the
+  // index current going forward (emitVersionBump), but artifacts published before that
+  // wiring — or created outside it — need a one-time sweep. Operator-only, idempotent,
+  // and bounded: it indexes one page (default 100, max 500) and returns `nextCursor`;
+  // the operator re-POSTs with that cursor until it comes back null. Keeping each call
+  // bounded is what fits the Workers CPU budget rather than one unbounded pass.
+  //   curl -XPOST -H "authorization: Bearer $DERIVE_TOKEN" .../v1/system/search-reindex
+  //   # then repeat, passing {"cursor": <nextCursor>} until nextCursor is null
+  app.post("/v1/system/search-reindex", async (c) => {
+    if (!isToken(c) && !(await isSuperAdmin(c)))
+      return fail(c, 403, "operator access required (DERIVE_TOKEN or a super-admin account)")
+    const body = await readJson(
+      c,
+      z.object({
+        orgId: z.string().optional(),
+        cursor: z.object({ created_at: z.string(), id: z.string() }).optional(),
+        limit: z.number().int().optional(),
+      }),
+    )
+    if (body instanceof Response) return body
+    const limit = Math.min(Math.max(body.limit ?? 100, 1), 500)
+    const result = await reindexSearchBatch(
+      { meta, blobs },
+      { orgId: body.orgId, cursor: body.cursor, limit },
+    )
+    return c.json(result)
   })
 
   // A minimal API-origin landing. Skipped when the SPA is bundled in-process

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -58,7 +58,10 @@ export const systemRoutes = (ctx: AppContext) => {
   // wiring — or created outside it — need a one-time sweep. Operator-only, idempotent,
   // and bounded: it indexes one page (default 100, max 500) and returns `nextCursor`;
   // the operator re-POSTs with that cursor until it comes back null. Keeping each call
-  // bounded is what fits the Workers CPU budget rather than one unbounded pass.
+  // bounded is what fits the Workers CPU budget rather than one unbounded pass. Run it as
+  // a one-time backfill: under a concurrent live publish it could momentarily write
+  // older-version text for that artifact, but grep-confirm reads the live blob (so
+  // precision holds) and the next publish re-indexes it — the staleness self-heals.
   //   curl -XPOST -H "authorization: Bearer $DERIVE_TOKEN" .../v1/system/search-reindex
   //   # then repeat, passing {"cursor": <nextCursor>} until nextCursor is null
   app.post("/v1/system/search-reindex", async (c) => {

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -10,7 +10,13 @@ import { exportJWK, generateKeyPair, SignJWT } from "jose"
 import { afterAll, describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
 import { sha256 } from "../src/lib/crypto"
-import { MAX_INDEX_TEXT, reindexSearchBatch, versionIndexText } from "../src/lib/search"
+import {
+  MAX_INDEX_TEXT,
+  reindexSearchBatch,
+  searchMatcher,
+  searchWorkspace,
+  versionIndexText,
+} from "../src/lib/search"
 
 // The remote MCP endpoint (/mcp) authenticated by an OAuth bearer. We seed a grant
 // straight into the oauth-provider tables (what the consent dance produces), publish
@@ -1033,6 +1039,63 @@ describe("remote MCP endpoint (/mcp)", () => {
     // contiguous literal finds nothing → honestly "No matches", never a false hit.
     const res = toolText(await call(app, token, "search", { query: "alpha omega" }))
     expect(res).toContain("No matches")
+  })
+
+  it("searchWorkspace hides a public-but-password-locked artifact's content from the anonymous (publicOnly) path, not from members", async () => {
+    const { app, token, meta, blobs } = appWithGrant("wslock", "openid derive:read derive:publish")
+    const seed = (await (await publishRaw(app, token, "# Seed", "seed.md", "Seed")).json()).short_id
+    const owner = await meta.getByShortId(seed)
+    if (!owner) throw new Error("expected the seed artifact to exist")
+    const org = owner.org_id
+    const key = await blobs.put(new TextEncoder().encode("the gatedneedle lives inside"))
+    // Two PUBLIC-listed artifacts with the same content; one is password-locked (a lock on
+    // its world link). The content differs only in whether reading it needs the password.
+    const mk = async (id: string, locked: boolean) => {
+      await meta.createArtifact({
+        id,
+        short_id: id,
+        org_id: org,
+        slug: null,
+        title: `Doc ${id}`,
+        workspace_access: "member",
+        link_role: "viewer",
+        listed: "public",
+        password_hash: locked ? "a-real-hash" : null,
+        kind: "file",
+        spa: 0,
+      })
+      await meta.addVersion(id, {
+        id: `v_${id}`,
+        blob_key: key,
+        content_type: "text/markdown",
+        author: "o",
+        message: null,
+      })
+      await meta.indexArtifact(id, org, `Doc ${id}`, "the gatedneedle lives inside")
+    }
+    await mk("aopen", false)
+    await mk("alock", true)
+    const sourceText = async (v: { blob_key: string; content_type: string }) => {
+      const b = await blobs.get(v.blob_key)
+      return b ? new TextDecoder().decode(b) : null
+    }
+    const deps = { blobs, sourceText, meta }
+    const base = {
+      orgId: org,
+      query: "gatedneedle",
+      re: searchMatcher("gatedneedle", false),
+      where: "text" as const,
+      ctxLines: 0,
+      cap: 40,
+    }
+    // Anonymous / non-member (publicOnly): the locked doc's body must NOT be grep-readable —
+    // reading it needs the password, and search must not bypass that.
+    const anon = await searchWorkspace(deps, { ...base, publicOnly: true })
+    expect(anon.results.map((r) => r.short_id).sort()).toEqual(["aopen"])
+    // A member/trusted caller (no publicOnly) reaches content through membership, not the
+    // link, so the lock doesn't apply — both surface.
+    const member = await searchWorkspace(deps, base)
+    expect(member.results.map((r) => r.short_id).sort()).toEqual(["alock", "aopen"])
   })
 
   it("versionIndexText degrades safely on the non-happy paths (never throws)", async () => {

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -912,7 +912,7 @@ describe("remote MCP endpoint (/mcp)", () => {
     // grep-confirm cap engages and the truncation note must appear.
     await seedMatching(meta, blobs, owner.org_id, "bulk", 31)
     const res = toolText(await call(app, token, "search", { query: "widget" }))
-    expect(res).toContain("matching artifacts you can see") // the relevance-truncation note
+    expect(res).toContain("candidate artifacts you can see") // the relevance-truncation note
     expect(res).toContain("top 30 of 31")
   })
 
@@ -928,8 +928,75 @@ describe("remote MCP endpoint (/mcp)", () => {
     // boundary means no truncation note fires.
     await seedMatching(meta, blobs, owner.org_id, "exct", 30)
     const res = toolText(await call(app, token, "search", { query: "widget" }))
-    expect(res).not.toContain("matching artifacts you can see")
-    expect(res).not.toContain("there may be more")
+    expect(res).not.toContain("candidate artifacts you can see")
+    expect(res).not.toContain("matched the index")
+  })
+
+  it("search (workspace mode): a taken-down artifact's content is NOT grep-exfiltratable via search (tombstone hole)", async () => {
+    const { app, token, meta } = appWithGrant("wstomb", "openid derive:read derive:publish")
+    const sid = (
+      await (
+        await publishRaw(app, token, "# Secret\n\nthe tombstoneneedle lives here", "s.md", "Secret")
+      ).json()
+    ).short_id
+    // Findable while live — proves it's indexed (so the negative below is non-vacuous).
+    expect(toolText(await call(app, token, "search", { query: "tombstoneneedle" }))).toContain(
+      "tombstoneneedle",
+    )
+    // Take it down. Takedown deliberately does NOT unindex (a restore must stay cheap), so
+    // the index row survives and still nominates it — the ONLY thing keeping its content
+    // out of search is searchWorkspace's excludeRemoved gate. This pins that hole shut:
+    // the content must not be grep-readable even though the read endpoint 410s it.
+    const art = await meta.getByShortId(sid)
+    if (!art) throw new Error("expected the artifact to exist")
+    await meta.setArtifactRemoved(art.id, new Date().toISOString())
+    const after = toolText(await call(app, token, "search", { query: "tombstoneneedle" }))
+    expect(after).toContain("No matches")
+    expect(after).not.toContain("Secret")
+    expect(after).not.toContain(sid)
+  })
+
+  it("search (workspace mode): index nominations lacking the exact literal are not reported as matches (recall vs precision)", async () => {
+    const { app, token, meta, blobs } = appWithGrant("wsprec", "openid derive:read derive:publish")
+    const seed = (await (await publishRaw(app, token, "# Seed", "seed.md", "Seed")).json()).short_id
+    const owner = await meta.getByShortId(seed)
+    if (!owner) throw new Error("expected the seed artifact to exist")
+    // Both words are present but never the contiguous phrase "alpha omega".
+    const key = await blobs.put(
+      new TextEncoder().encode("alpha here and omega there, not adjacent"),
+    )
+    for (let i = 0; i < 3; i++) {
+      const id = `a_prec_${i}`
+      await meta.createArtifact({
+        id,
+        short_id: `prec${i.toString().padStart(5, "0")}`,
+        org_id: owner.org_id,
+        slug: null,
+        title: `Prec ${i}`,
+        workspace_access: "member",
+        link_role: "viewer",
+        listed: "workspace",
+        kind: "file",
+        spa: 0,
+      })
+      await meta.addVersion(id, {
+        id: `v_prec_${i}`,
+        blob_key: key,
+        content_type: "text/markdown",
+        author: "s",
+        message: null,
+      })
+      await meta.indexArtifact(
+        id,
+        owner.org_id,
+        `Prec ${i}`,
+        "alpha here and omega there, not adjacent",
+      )
+    }
+    // The index nominates all three (both prefix tokens present), but grep-confirm for the
+    // contiguous literal finds nothing → honestly "No matches", never a false hit.
+    const res = toolText(await call(app, token, "search", { query: "alpha omega" }))
+    expect(res).toContain("No matches")
   })
 
   it("search reindex (backfill): a bounded, resumable sweep makes pre-existing (never-indexed) artifacts findable", async () => {

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import type { BlobStore, MetaStore } from "@derive/core"
 import { SqliteMetaStore } from "@derive/db/sqlite"
 import { FsBlobStore } from "@derive/storage/fs"
 import Database from "better-sqlite3"
@@ -9,6 +10,7 @@ import { exportJWK, generateKeyPair, SignJWT } from "jose"
 import { afterAll, describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
 import { sha256 } from "../src/lib/crypto"
+import { reindexSearchBatch } from "../src/lib/search"
 
 // The remote MCP endpoint (/mcp) authenticated by an OAuth bearer. We seed a grant
 // straight into the oauth-provider tables (what the consent dance produces), publish
@@ -804,12 +806,15 @@ describe("remote MCP endpoint (/mcp)", () => {
     // surface, even though it lives in the same workspace. This mirrors exactly the
     // visibility rule list_artifacts already enforces (artifactListConditions: listed
     // != 'none' OR isMember); workspace search reuses listArtifacts with the same
-    // viewerId, so this pins that it didn't accidentally widen the scope.
+    // viewerId, so this pins that it didn't accidentally widen the scope. Crucially we
+    // ALSO index it below (indexArtifact) so the FTS layer genuinely NOMINATES it as a
+    // candidate — otherwise the negative below would pass vacuously (an unindexed doc
+    // is never a candidate). This proves the listArtifacts gate, not an empty index,
+    // is what drops it.
     const owner = await meta.getByShortId(r1)
     if (!owner) throw new Error("expected the visible artifact to exist")
-    const key = await blobs.put(
-      new TextEncoder().encode("# Secret\n\nthe private-needle-zulu lives here"),
-    )
+    const secret = "# Secret\n\nthe private-needle-zulu lives here"
+    const key = await blobs.put(new TextEncoder().encode(secret))
     await meta.createArtifact({
       id: "a_stranger_private",
       short_id: "strangr1",
@@ -829,6 +834,9 @@ describe("remote MCP endpoint (/mcp)", () => {
       author: "stranger",
       message: null,
     })
+    // The index HAS the private artifact + its needle (org-scoped, no visibility) — so
+    // searchArtifactIds will nominate it. The visibility gate must still drop it.
+    await meta.indexArtifact("a_stranger_private", owner.org_id, "Stranger's Private Doc", secret)
 
     const afterPrivate = toolText(
       await call(app, token, "search", { query: "private-needle-zulu" }),
@@ -841,21 +849,43 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(afterPrivate).not.toContain("Secret")
   })
 
-  it("search (workspace mode): caps the scan at the most recent artifacts, with an honest truncation note (not silent)", async () => {
-    const { app, token, meta, blobs } = appWithGrant("wscap", "openid derive:read derive:publish")
-    const seed = (await (await publishRaw(app, token, "# Seed", "seed.md", "Seed")).json()).short_id
-    const owner = await meta.getByShortId(seed)
-    if (!owner) throw new Error("expected the seed artifact to exist")
-    const key = await blobs.put(new TextEncoder().encode("filler content, nothing to find"))
-    // One more than WORKSPACE_SEARCH_ARTIFACT_CAP (30) so the cap must engage.
-    for (let i = 0; i < 31; i++) {
-      const id = `a_bulk_${i}`
+  it("search (workspace mode): a freshly published artifact is findable across the workspace (publish indexes it)", async () => {
+    // End-to-end proof of the write-path: publishing runs emitVersionBump →
+    // indexArtifactVersion, so the new content is in the index and workspace search
+    // (index → visibility → grep-confirm) surfaces it — no short_id needed.
+    const { app, token } = appWithGrant("wsidx", "openid derive:read derive:publish")
+    await publishRaw(
+      app,
+      token,
+      "# Onboarding\n\nThe kestrel protocol handles retries.",
+      "doc.md",
+      "Onboarding",
+    )
+    const res = toolText(await call(app, token, "search", { query: "kestrel" }))
+    expect(res).toContain("kestrel") // grep-confirmed hunk
+    expect(res).toContain("Onboarding") // grouped under its artifact
+  })
+
+  // Seed N indexed artifacts that all match one query, so the grep-confirm cap is
+  // exercised. Uses the direct meta path (fast) plus indexArtifact — the same row the
+  // publish write-path would write — rather than N slow tool publishes.
+  const seedMatching = async (
+    meta: MetaStore,
+    blobs: BlobStore,
+    orgId: string,
+    prefix: string,
+    n: number,
+  ): Promise<void> => {
+    const key = await blobs.put(new TextEncoder().encode("every doc mentions widget here"))
+    for (let i = 0; i < n; i++) {
+      const id = `a_${prefix}_${i}`
+      const title = `${prefix} ${i} widget`
       await meta.createArtifact({
         id,
-        short_id: `bulk${i.toString().padStart(4, "0")}`,
-        org_id: owner.org_id,
+        short_id: `${prefix}${i.toString().padStart(4, "0")}`,
+        org_id: orgId,
         slug: null,
-        title: `Bulk ${i}`,
+        title,
         workspace_access: "member",
         link_role: "viewer",
         listed: "workspace",
@@ -863,18 +893,30 @@ describe("remote MCP endpoint (/mcp)", () => {
         spa: 0,
       })
       await meta.addVersion(id, {
-        id: `v_bulk_${i}`,
+        id: `v_${prefix}_${i}`,
         blob_key: key,
         content_type: "text/markdown",
         author: "seeder",
         message: null,
       })
+      await meta.indexArtifact(id, orgId, title, "every doc mentions widget here")
     }
-    const res = toolText(await call(app, token, "search", { query: "zzz-nothing-matches-zzz" }))
-    expect(res).toContain("scanned the 30 most recently created artifacts you can see")
+  }
+
+  it("search (workspace mode): ranks the whole corpus and shows an honest truncation note past the grep-confirm cap", async () => {
+    const { app, token, meta, blobs } = appWithGrant("wscap", "openid derive:read derive:publish")
+    const seed = (await (await publishRaw(app, token, "# Seed", "seed.md", "Seed")).json()).short_id
+    const owner = await meta.getByShortId(seed)
+    if (!owner) throw new Error("expected the seed artifact to exist")
+    // 31 matching artifacts — one more than WORKSPACE_SEARCH_ARTIFACT_CAP (30), so the
+    // grep-confirm cap engages and the truncation note must appear.
+    await seedMatching(meta, blobs, owner.org_id, "bulk", 31)
+    const res = toolText(await call(app, token, "search", { query: "widget" }))
+    expect(res).toContain("matching artifacts you can see") // the relevance-truncation note
+    expect(res).toContain("top 30 of 31")
   })
 
-  it("search (workspace mode): EXACTLY WORKSPACE_SEARCH_ARTIFACT_CAP (30) artifacts must NOT show the truncation note (boundary regression — a naive `arts.length === cap` check false-positives here since a plain `limit:30` fetch always returns exactly 30 when there are 30+)", async () => {
+  it("search (workspace mode): EXACTLY the cap (30) matching artifacts shows NO truncation note", async () => {
     const { app, token, meta, blobs } = appWithGrant(
       "wscapexact",
       "openid derive:read derive:publish",
@@ -882,33 +924,65 @@ describe("remote MCP endpoint (/mcp)", () => {
     const seed = (await (await publishRaw(app, token, "# Seed", "seed.md", "Seed")).json()).short_id
     const owner = await meta.getByShortId(seed)
     if (!owner) throw new Error("expected the seed artifact to exist")
-    const key = await blobs.put(new TextEncoder().encode("filler content, nothing to find"))
-    // 29 here + the seed artifact published above = exactly 30
-    // (WORKSPACE_SEARCH_ARTIFACT_CAP), not one more.
-    for (let i = 0; i < 29; i++) {
-      const id = `a_exact_${i}`
+    // Exactly 30 matching artifacts (the seed doesn't match "widget"): the strict `>`
+    // boundary means no truncation note fires.
+    await seedMatching(meta, blobs, owner.org_id, "exct", 30)
+    const res = toolText(await call(app, token, "search", { query: "widget" }))
+    expect(res).not.toContain("matching artifacts you can see")
+    expect(res).not.toContain("there may be more")
+  })
+
+  it("search reindex (backfill): a bounded, resumable sweep makes pre-existing (never-indexed) artifacts findable", async () => {
+    const { app, token, meta, blobs } = appWithGrant("reidx", "openid derive:read derive:publish")
+    const seed = (await (await publishRaw(app, token, "# Seed", "seed.md", "Seed")).json()).short_id
+    const owner = await meta.getByShortId(seed)
+    if (!owner) throw new Error("expected the seed artifact to exist")
+    // 3 artifacts created via the DIRECT meta path (createArtifact + addVersion, no
+    // emitVersionBump) — exactly what a pre-feature / imported artifact looks like: it
+    // exists but was never indexed.
+    const key = await blobs.put(new TextEncoder().encode("the backfillneedle appears here"))
+    for (let i = 0; i < 3; i++) {
       await meta.createArtifact({
-        id,
-        short_id: `exct${i.toString().padStart(4, "0")}`,
+        id: `a_pre_${i}`,
+        short_id: `pre${i.toString().padStart(5, "0")}`,
         org_id: owner.org_id,
         slug: null,
-        title: `Exact ${i}`,
+        title: `Pre ${i}`,
         workspace_access: "member",
         link_role: "viewer",
         listed: "workspace",
         kind: "file",
         spa: 0,
       })
-      await meta.addVersion(id, {
-        id: `v_exact_${i}`,
+      await meta.addVersion(`a_pre_${i}`, {
+        id: `v_pre_${i}`,
         blob_key: key,
         content_type: "text/markdown",
-        author: "seeder",
+        author: "importer",
         message: null,
       })
     }
-    const res = toolText(await call(app, token, "search", { query: "zzz-nothing-matches-zzz" }))
-    expect(res).not.toContain("there may be more")
+    // Not findable before the backfill — the index has no row for them.
+    expect(toolText(await call(app, token, "search", { query: "backfillneedle" }))).toContain(
+      "No matches",
+    )
+    // Drive the bounded sweep to completion (limit:2 forces multiple pages across the
+    // seed + 3 artifacts, exercising the cursor).
+    let cursor: { created_at: string; id: string } | null | undefined
+    let pages = 0
+    let indexed = 0
+    do {
+      const r = await reindexSearchBatch({ meta, blobs }, { cursor: cursor ?? undefined, limit: 2 })
+      indexed += r.indexed
+      cursor = r.nextCursor
+      pages++
+    } while (cursor)
+    expect(pages).toBeGreaterThan(1) // actually paginated, not one big pass
+    expect(indexed).toBeGreaterThanOrEqual(3)
+    // Now findable — grouped under their artifacts.
+    const found = toolText(await call(app, token, "search", { query: "backfillneedle" }))
+    expect(found).toContain("backfillneedle")
+    expect(found).toContain("Pre 0")
   })
 
   it("read: a region ref (@N) reads that region directly, with actionable errors", async () => {

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import type { BlobStore, MetaStore } from "@derive/core"
+import type { BlobStore, MetaStore, VersionRecord } from "@derive/core"
 import { SqliteMetaStore } from "@derive/db/sqlite"
 import { FsBlobStore } from "@derive/storage/fs"
 import Database from "better-sqlite3"
@@ -10,7 +10,7 @@ import { exportJWK, generateKeyPair, SignJWT } from "jose"
 import { afterAll, describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
 import { sha256 } from "../src/lib/crypto"
-import { reindexSearchBatch } from "../src/lib/search"
+import { MAX_INDEX_TEXT, reindexSearchBatch, versionIndexText } from "../src/lib/search"
 
 // The remote MCP endpoint (/mcp) authenticated by an OAuth bearer. We seed a grant
 // straight into the oauth-provider tables (what the consent dance produces), publish
@@ -970,6 +970,28 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(after).not.toContain(sid)
   })
 
+  it("read/search (one-artifact): a taken-down artifact serves no content, mirroring the web 410", async () => {
+    const { app, token, meta } = appWithGrant("wsone", "openid derive:read derive:publish")
+    const sid = (
+      await (
+        await publishRaw(app, token, "# Secret\n\nthe onedocneedle lives here", "s.md", "Secret")
+      ).json()
+    ).short_id
+    // Readable by short_id while live.
+    expect(toolText(await call(app, token, "read", { short_id: sid }))).toContain("onedocneedle")
+    const art = await meta.getByShortId(sid)
+    if (!art) throw new Error("expected the artifact to exist")
+    await meta.setArtifactRemoved(art.id, new Date().toISOString())
+    // After takedown, the direct one-artifact paths (which resolve through reach, not the
+    // index) must ALSO refuse content — otherwise knowing the short_id bypasses the 410.
+    const read = toolText(await call(app, token, "read", { short_id: sid }))
+    expect(read).toContain("taken down")
+    expect(read).not.toContain("onedocneedle")
+    const one = toolText(await call(app, token, "search", { short_id: sid, query: "onedocneedle" }))
+    expect(one).toContain("taken down")
+    expect(one).not.toContain("onedocneedle")
+  })
+
   it("search (workspace mode): index nominations lacking the exact literal are not reported as matches (recall vs precision)", async () => {
     const { app, token, meta, blobs } = appWithGrant("wsprec", "openid derive:read derive:publish")
     const seed = (await (await publishRaw(app, token, "# Seed", "seed.md", "Seed")).json()).short_id
@@ -1011,6 +1033,31 @@ describe("remote MCP endpoint (/mcp)", () => {
     // contiguous literal finds nothing → honestly "No matches", never a false hit.
     const res = toolText(await call(app, token, "search", { query: "alpha omega" }))
     expect(res).toContain("No matches")
+  })
+
+  it("versionIndexText degrades safely on the non-happy paths (never throws)", async () => {
+    // These branches are load-bearing: they keep a publish from throwing, and a throw
+    // here would only be swallowed by emitVersionBump's best-effort catch (silently
+    // dropping the artifact from search). Pin them so a refactor can't regress them.
+    const dir = mkdtempSync(join(tmpdir(), "vit-"))
+    const blobs = new FsBlobStore(join(dir, "b"))
+    const v = (blobKey: string, ct: string) =>
+      ({ blob_key: blobKey, content_type: ct }) as VersionRecord
+    // Happy single-file: the source is indexed.
+    const md = await blobs.put(new TextEncoder().encode("# Title\n\nthe indexed body"))
+    expect(await versionIndexText(blobs, v(md, "text/markdown"))).toContain("indexed body")
+    // Oversized source is capped, not unbounded.
+    const big = await blobs.put(new TextEncoder().encode("x".repeat(MAX_INDEX_TEXT + 5000)))
+    expect((await versionIndexText(blobs, v(big, "text/markdown"))).length).toBeLessThanOrEqual(
+      MAX_INDEX_TEXT,
+    )
+    // Degrade branches → "" (never a throw):
+    const img = await blobs.put(new Uint8Array([1, 2, 3, 4]))
+    expect(await versionIndexText(blobs, v(img, "image/png"))).toBe("") // non-text single file
+    expect(await versionIndexText(blobs, v("0".repeat(64), "text/html"))).toBe("") // missing blob
+    const badBundle = await blobs.put(new TextEncoder().encode("not-a-json-manifest"))
+    expect(await versionIndexText(blobs, v(badBundle, "derive/bundle"))).toBe("") // unparseable manifest
+    rmSync(dir, { recursive: true, force: true })
   })
 
   it("search reindex (backfill): a bounded, resumable sweep makes pre-existing (never-indexed) artifacts findable", async () => {

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -932,6 +932,20 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(res).not.toContain("matched the index")
   })
 
+  it("search (workspace mode): resolves >90 candidates correctly across visibility chunks (D1 bound-param safety)", async () => {
+    const { app, token, meta, blobs } = appWithGrant("wschunk", "openid derive:read derive:publish")
+    const seed = (await (await publishRaw(app, token, "# Seed", "seed.md", "Seed")).json()).short_id
+    const owner = await meta.getByShortId(seed)
+    if (!owner) throw new Error("expected the seed artifact to exist")
+    // 120 matching artifacts exceed the 90-id visibility chunk, so candidate ids resolve
+    // over multiple listArtifacts calls (each stays under D1's 100 bound-parameter cap).
+    // The merged, re-ranked result must count all 120 — nothing dropped or duplicated at
+    // the chunk boundary.
+    await seedMatching(meta, blobs, owner.org_id, "chunk", 120)
+    const res = toolText(await call(app, token, "search", { query: "widget" }))
+    expect(res).toContain("top 30 of 120")
+  })
+
   it("search (workspace mode): a taken-down artifact's content is NOT grep-exfiltratable via search (tombstone hole)", async () => {
     const { app, token, meta } = appWithGrant("wstomb", "openid derive:read derive:publish")
     const sid = (

--- a/apps/api/test/search-rest.test.ts
+++ b/apps/api/test/search-rest.test.ts
@@ -123,4 +123,39 @@ describe("/v1/artifacts/:shortId/search and /v1/artifacts/search — REST search
     const res = await a.request("/v1/artifacts/search?query=x") // no headers at all
     expect(res.status).toBe(401)
   })
+
+  it("?format=json returns ranked hits with a match snippet (the ⌘K palette shape)", async () => {
+    const { app: a } = makeAuthedApp("rest-search-json", users, "editor")
+    await publishAs(
+      a,
+      "# Notes\n\nthe quarterly kestrel review is scheduled for friday",
+      { title: "Notes", listed: "workspace" },
+      as("search-owner@x.test"),
+    )
+    const res = await a.request("/v1/artifacts/search?format=json&in=text&query=kestrel", {
+      headers: as("search-owner@x.test"),
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toContain("application/json")
+    const body = (await res.json()) as {
+      hits: { short_id: string; title: string; current_version: number; snippet: string }[]
+      truncated: boolean
+    }
+    const hit = body.hits.find((h) => h.title === "Notes")
+    if (!hit) throw new Error("expected the Notes artifact in the hits")
+    expect(hit.short_id).toBeTruthy()
+    expect(hit.current_version).toBe(1)
+    // The snippet is the matching line — what the palette highlights.
+    expect(hit.snippet.toLowerCase()).toContain("kestrel")
+    expect(typeof body.truncated).toBe("boolean")
+    // Visibility is the SAME searchWorkspace gate the text path uses (results are
+    // filtered before toSearchHits), so a private artifact can't leak here either — a
+    // word absent from anything visible returns no hits.
+    const none = await (
+      await a.request("/v1/artifacts/search?format=json&query=zznomatchzz", {
+        headers: as("search-owner@x.test"),
+      })
+    ).json()
+    expect(none.hits).toEqual([])
+  })
 })

--- a/apps/api/test/snippet.test.ts
+++ b/apps/api/test/snippet.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import { snippetAround } from "../src/lib/search"
+
+// snippetAround windows a matching line so the highlighted term survives the palette's
+// single-line, LEFT-truncating render — the match must land near the left edge.
+describe("snippetAround", () => {
+  it("returns a short line whole, with the match intact", () => {
+    expect(snippetAround("the kestrel review is friday", "kestrel")).toBe(
+      "the kestrel review is friday",
+    )
+  })
+
+  it("windows a long line so the match sits near the LEFT edge (not centered off-screen)", () => {
+    const line = `${"x".repeat(120)}kestrel${"y".repeat(120)}`
+    const snip = snippetAround(line, "kestrel")
+    expect(snip.startsWith("…")).toBe(true) // leading context elided
+    expect(snip).toContain("kestrel")
+    // The match is near the start of the returned snippet, so left-truncation keeps it.
+    expect(snip.indexOf("kestrel")).toBeLessThan(20)
+    expect(snip.length).toBeLessThanOrEqual(161) // SNIPPET_LEN + the leading ellipsis
+  })
+
+  it("omits the leading ellipsis when the match is at the start", () => {
+    const snip = snippetAround(`kestrel${"y".repeat(300)}`, "kestrel")
+    expect(snip.startsWith("kestrel")).toBe(true)
+    expect(snip.endsWith("…")).toBe(true) // trailing context elided
+  })
+
+  it("omits the trailing ellipsis when the match is at the end", () => {
+    const snip = snippetAround(`${"x".repeat(300)}kestrel`, "kestrel")
+    expect(snip.startsWith("…")).toBe(true)
+    expect(snip.endsWith("kestrel")).toBe(true)
+  })
+
+  it("collapses whitespace in BOTH the line and a multi-space query so the match is found", () => {
+    // Deeply-indented / multi-spaced source line, and a query with stray spaces.
+    const line = `${"z".repeat(120)}the   alpha    beta${"z".repeat(120)}`
+    const snip = snippetAround(line, "alpha  beta")
+    expect(snip).toContain("alpha beta") // collapsed + located (not the not-found fallback)
+    expect(snip.indexOf("alpha beta")).toBeLessThan(30)
+  })
+
+  it("falls back to the head of the line when the literal isn't present", () => {
+    expect(snippetAround("a short line with no hit", "zzz")).toBe("a short line with no hit")
+    const long = snippetAround("q".repeat(300), "zzz")
+    expect(long.endsWith("…")).toBe(true)
+    expect(long.length).toBeLessThanOrEqual(161)
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -277,6 +277,16 @@ const mapMe = (u: SessionUser): Me => ({
   brandprint: parseBrandprint(u.brandprint),
 })
 
+// A workspace content-search hit. Hand-written (not generated): the search endpoint's
+// `?format=json` shape is a plain route, not part of the OpenAPI contract.
+export interface SearchHit {
+  short_id: string
+  title: string
+  current_version: number
+  /** One line of the matching text, windowed around the match (server-side). */
+  snippet: string
+}
+
 export const api = {
   // The ONE identity read — behind meQuery, and re-read after login/signup to seed the
   // auth cache. Prerender-safe (null at build — no document); a resolved null for an
@@ -343,6 +353,19 @@ export const api = {
   // Find opted-in people by @handle or name (signed-in; empty q → []).
   searchPeople: (q: string): Promise<{ users: PublicProfile[] }> =>
     f(`/v1/users/search?query=${encodeURIComponent(q)}`, opts()).then(j),
+  // Content search across the workspace via the persisted index: hits ranked by
+  // relevance, each with a one-line snippet of WHERE it matched (visible text, so the
+  // snippet reads as prose). Empty q → []. A small `limit` keeps the palette's debounced
+  // typeahead to a few blob reads. Same visibility rules as list_artifacts.
+  searchContent: (q: string, limit = 6): Promise<{ hits: SearchHit[]; truncated: boolean }> => {
+    const term = q.trim()
+    return term
+      ? f(
+          `/v1/artifacts/search?format=json&in=text&limit=${limit}&query=${encodeURIComponent(term)}`,
+          opts(),
+        ).then(j)
+      : Promise.resolve({ hits: [], truncated: false })
+  },
   // The People directory: browse opted-in people (empty q) or search them (signed-in).
   // Unlike searchPeople, an empty query BROWSES the discoverable set.
   people: (q?: string): Promise<{ users: PublicProfile[] }> =>

--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -23,18 +23,25 @@ import { cn } from "@/lib/utils"
 import { refFor } from "@/pages/artifact/parse-ref"
 import { useShell } from "./shell-context"
 
+// The content group's data, carried together so the snippet is always highlighted
+// against the query it was FETCHED for — not the live input, which races ahead of the
+// (heavier, more debounced) content call and would briefly mis-highlight stale hits.
+type ContentState = { hits: SearchHit[]; truncated: boolean; q: string }
+const EMPTY_CONTENT: ContentState = { hits: [], truncated: false, q: "" }
+
 // Emphasize the query where it appears in a content snippet — the surrounding text is
 // muted (the caller styles it), the match reads at full weight. Splitting is pure +
-// tested in lib/highlight; here we just render the marked segments.
+// tested in lib/highlight; here we just render the marked segments. Index keys are safe:
+// the segments are stateless text spans, so a shifted boundary only re-renders text.
 function highlight(text: string, query: string): React.ReactNode[] {
   return splitMatches(text, query).map((seg, i) =>
     seg.match ? (
-      // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional + stable per render
+      // biome-ignore lint/suspicious/noArrayIndexKey: stateless text segments
       <span key={i} className="font-semibold text-foreground">
         {seg.text}
       </span>
     ) : (
-      // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional + stable per render
+      // biome-ignore lint/suspicious/noArrayIndexKey: stateless text segments
       <span key={i}>{seg.text}</span>
     ),
   )
@@ -54,7 +61,7 @@ export function CommandPalette() {
   const prefetch = usePrefetchArtifact()
   const [query, setQuery] = useState("")
   const [results, setResults] = useState<Artifact[]>([])
-  const [contentHits, setContentHits] = useState<SearchHit[]>([])
+  const [content, setContent] = useState<ContentState>(EMPTY_CONTENT)
   const [people, setPeople] = useState<PublicProfile[]>([])
   const [loading, setLoading] = useState(false)
   const [contentLoading, setContentLoading] = useState(false)
@@ -65,7 +72,7 @@ export function CommandPalette() {
     if (paletteOpen) {
       setQuery("")
       setResults([])
-      setContentHits([])
+      setContent(EMPTY_CONTENT)
       setPeople([])
     }
   }, [paletteOpen])
@@ -123,7 +130,7 @@ export function CommandPalette() {
     if (!paletteOpen) return
     const term = query.trim()
     if (term.length < 2) {
-      setContentHits([])
+      setContent(EMPTY_CONTENT)
       setContentLoading(false)
       return
     }
@@ -132,9 +139,9 @@ export function CommandPalette() {
     const t = setTimeout(() => {
       api
         .searchContent(term, 6)
-        .then((r) => alive && setContentHits(r.hits))
+        .then((r) => alive && setContent({ hits: r.hits, truncated: r.truncated, q: term }))
         // frontend-ignore: debounced typeahead — clearing on an aborted/failed keystroke is intended, not a hidden load failure
-        .catch(() => alive && setContentHits([]))
+        .catch(() => alive && setContent(EMPTY_CONTENT))
         .finally(() => alive && setContentLoading(false))
     }, 220)
     return () => {
@@ -152,7 +159,7 @@ export function CommandPalette() {
   // An artifact whose TITLE matched already shows in "Artifacts" — don't repeat it as a
   // content hit; the content group is for docs found only by what's inside them.
   const titleIds = new Set(results.map((r) => r.short_id))
-  const contentOnly = contentHits.filter((h) => !titleIds.has(h.short_id))
+  const contentOnly = content.hits.filter((h) => !titleIds.has(h.short_id))
   // Brandprint-pointed collections are managed on /brandprint, not jumped to here.
   const brandprintIds = useBrandprintCollectionIds()
   const matchedCollections = collections.filter(
@@ -254,19 +261,28 @@ export function CommandPalette() {
                   }
                   onMouseEnter={() => prefetch(h.short_id, h.current_version)}
                   onFocus={() => prefetch(h.short_id, h.current_version)}
-                  className="flex-col items-start gap-0.5"
+                  // Top-align: this is a two-line row (title over snippet), so the icon
+                  // sits with the title, not centered against the whole block. Keeping the
+                  // item flex-ROW (a flex-col child holds the two lines) leaves cmdk's
+                  // trailing check glyph in the row instead of adding a phantom third line.
+                  className="items-start"
                 >
-                  <div className="flex w-full items-center gap-2">
-                    <Icon name="all" size={16} className="text-muted-foreground" />
-                    <span className="flex-1 truncate">{h.title}</span>
+                  <Icon name="all" size={16} className="mt-0.5 text-muted-foreground" />
+                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="truncate">{h.title}</span>
+                    {h.snippet && (
+                      <span className="truncate text-xs text-muted-foreground">
+                        {highlight(h.snippet, content.q)}
+                      </span>
+                    )}
                   </div>
-                  {h.snippet && (
-                    <span className="w-full truncate pl-6 text-xs text-muted-foreground">
-                      {highlight(h.snippet, query)}
-                    </span>
-                  )}
                 </CommandItem>
               ))}
+              {content.truncated && (
+                <div className="px-2 py-1.5 text-2xs text-muted-foreground">
+                  More matches — refine the query to narrow.
+                </div>
+              )}
             </CommandGroup>
           )}
 

--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
-import { type Artifact, api, type PublicProfile, workspaceDisplayName } from "@/api"
+import { type Artifact, api, type PublicProfile, type SearchHit, workspaceDisplayName } from "@/api"
 import { Icon } from "@/components/icons"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import {
@@ -14,6 +14,7 @@ import {
   CommandList,
 } from "@/components/ui/command"
 import { colorForName } from "@/lib/avatar-tints"
+import { splitMatches } from "@/lib/highlight"
 import { getInitials } from "@/lib/initials"
 import { collectionsQuery, workspacesQuery } from "@/lib/queries"
 import { useBrandprintCollectionIds } from "@/lib/use-brandprint-ids"
@@ -21,6 +22,23 @@ import { usePrefetchArtifact } from "@/lib/use-prefetch-artifact"
 import { cn } from "@/lib/utils"
 import { refFor } from "@/pages/artifact/parse-ref"
 import { useShell } from "./shell-context"
+
+// Emphasize the query where it appears in a content snippet — the surrounding text is
+// muted (the caller styles it), the match reads at full weight. Splitting is pure +
+// tested in lib/highlight; here we just render the marked segments.
+function highlight(text: string, query: string): React.ReactNode[] {
+  return splitMatches(text, query).map((seg, i) =>
+    seg.match ? (
+      // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional + stable per render
+      <span key={i} className="font-semibold text-foreground">
+        {seg.text}
+      </span>
+    ) : (
+      // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional + stable per render
+      <span key={i}>{seg.text}</span>
+    ),
+  )
+}
 
 // ⌘K palette: jump to any artifact (server search) or to a feed (All / Favorites /
 // Following), a collection, or another workspace — from anywhere, incl. inside an artifact.
@@ -36,8 +54,10 @@ export function CommandPalette() {
   const prefetch = usePrefetchArtifact()
   const [query, setQuery] = useState("")
   const [results, setResults] = useState<Artifact[]>([])
+  const [contentHits, setContentHits] = useState<SearchHit[]>([])
   const [people, setPeople] = useState<PublicProfile[]>([])
   const [loading, setLoading] = useState(false)
+  const [contentLoading, setContentLoading] = useState(false)
   const [peopleLoading, setPeopleLoading] = useState(false)
 
   // Fresh query each open.
@@ -45,6 +65,7 @@ export function CommandPalette() {
     if (paletteOpen) {
       setQuery("")
       setResults([])
+      setContentHits([])
       setPeople([])
     }
   }, [paletteOpen])
@@ -94,12 +115,44 @@ export function CommandPalette() {
     }
   }, [query, paletteOpen])
 
+  // Debounced CONTENT search (the persisted index) — finds artifacts by what's inside
+  // them, not just their title, with a snippet of the match. Gated to ≥2 chars and a
+  // small limit so a debounced keystroke reads only a few blobs. Slightly longer debounce
+  // than the title lookup: it's the heavier call.
+  useEffect(() => {
+    if (!paletteOpen) return
+    const term = query.trim()
+    if (term.length < 2) {
+      setContentHits([])
+      setContentLoading(false)
+      return
+    }
+    let alive = true
+    setContentLoading(true)
+    const t = setTimeout(() => {
+      api
+        .searchContent(term, 6)
+        .then((r) => alive && setContentHits(r.hits))
+        // frontend-ignore: debounced typeahead — clearing on an aborted/failed keystroke is intended, not a hidden load failure
+        .catch(() => alive && setContentHits([]))
+        .finally(() => alive && setContentLoading(false))
+    }, 220)
+    return () => {
+      alive = false
+      clearTimeout(t)
+    }
+  }, [query, paletteOpen])
+
   const go = (fn: () => void) => {
     setPaletteOpen(false)
     fn()
   }
 
   const q = query.trim().toLowerCase()
+  // An artifact whose TITLE matched already shows in "Artifacts" — don't repeat it as a
+  // content hit; the content group is for docs found only by what's inside them.
+  const titleIds = new Set(results.map((r) => r.short_id))
+  const contentOnly = contentHits.filter((h) => !titleIds.has(h.short_id))
   // Brandprint-pointed collections are managed on /brandprint, not jumped to here.
   const brandprintIds = useBrandprintCollectionIds()
   const matchedCollections = collections.filter(
@@ -128,7 +181,9 @@ export function CommandPalette() {
           placeholder="Search artifacts, people, collections…"
         />
         <CommandList>
-          <CommandEmpty>{loading ? "Searching…" : "No results."}</CommandEmpty>
+          <CommandEmpty>
+            {loading || contentLoading || peopleLoading ? "Searching…" : "No results."}
+          </CommandEmpty>
 
           {(showAll || showFav || showFollowing) && (
             <CommandGroup heading="Jump to">
@@ -180,6 +235,36 @@ export function CommandPalette() {
                   <span className="font-mono text-2xs text-muted-foreground tabular-nums">
                     v{a.current_version}
                   </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+
+          {contentOnly.length > 0 && (
+            <CommandGroup
+              heading="In content"
+              className={cn(contentLoading && "opacity-60 transition-opacity")}
+            >
+              {contentOnly.map((h) => (
+                <CommandItem
+                  key={`content-${h.short_id}`}
+                  value={`content-${h.short_id}`}
+                  onSelect={() =>
+                    go(() => nav({ to: "/artifacts/$ref", params: { ref: refFor(h) } }))
+                  }
+                  onMouseEnter={() => prefetch(h.short_id, h.current_version)}
+                  onFocus={() => prefetch(h.short_id, h.current_version)}
+                  className="flex-col items-start gap-0.5"
+                >
+                  <div className="flex w-full items-center gap-2">
+                    <Icon name="all" size={16} className="text-muted-foreground" />
+                    <span className="flex-1 truncate">{h.title}</span>
+                  </div>
+                  {h.snippet && (
+                    <span className="w-full truncate pl-6 text-xs text-muted-foreground">
+                      {highlight(h.snippet, query)}
+                    </span>
+                  )}
                 </CommandItem>
               ))}
             </CommandGroup>

--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -34,7 +34,9 @@ const EMPTY_CONTENT: ContentState = { hits: [], truncated: false, q: "" }
 // tested in lib/highlight; here we just render the marked segments. Index keys are safe:
 // the segments are stateless text spans, so a shifted boundary only re-renders text.
 function highlight(text: string, query: string): React.ReactNode[] {
-  return splitMatches(text, query).map((seg, i) =>
+  // Collapse the query's whitespace to match the server-collapsed snippet, so a multi-space
+  // query is still located (and highlighted) in the single-spaced snippet text.
+  return splitMatches(text, query.replace(/\s+/g, " ")).map((seg, i) =>
     seg.match ? (
       // biome-ignore lint/suspicious/noArrayIndexKey: stateless text segments
       <span key={i} className="font-semibold text-foreground">
@@ -280,7 +282,7 @@ export function CommandPalette() {
               ))}
               {content.truncated && (
                 <div className="px-2 py-1.5 text-2xs text-muted-foreground">
-                  More matches — refine the query to narrow.
+                  More may match — refine to narrow.
                 </div>
               )}
             </CommandGroup>

--- a/apps/web/src/lib/highlight.test.ts
+++ b/apps/web/src/lib/highlight.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+import { splitMatches } from "./highlight"
+
+describe("splitMatches", () => {
+  it("marks case-insensitive literal matches, preserving original casing + surrounding text", () => {
+    expect(splitMatches("the Kestrel and the kestrel", "kestrel")).toEqual([
+      { text: "the ", match: false },
+      { text: "Kestrel", match: true },
+      { text: " and the ", match: false },
+      { text: "kestrel", match: true },
+    ])
+  })
+
+  it("returns the whole text unmarked when the query is empty or unmatched", () => {
+    expect(splitMatches("hello world", "")).toEqual([{ text: "hello world", match: false }])
+    expect(splitMatches("hello world", "   ")).toEqual([{ text: "hello world", match: false }])
+    expect(splitMatches("hello world", "xyz")).toEqual([{ text: "hello world", match: false }])
+  })
+
+  it("handles a match at the very start and the very end", () => {
+    expect(splitMatches("foobar", "foo")).toEqual([
+      { text: "foo", match: true },
+      { text: "bar", match: false },
+    ])
+    expect(splitMatches("barfoo", "foo")).toEqual([
+      { text: "bar", match: false },
+      { text: "foo", match: true },
+    ])
+  })
+})

--- a/apps/web/src/lib/highlight.ts
+++ b/apps/web/src/lib/highlight.ts
@@ -1,0 +1,20 @@
+// Split `text` into segments, marking the ones that literally match `query`
+// (case-insensitive). The pure basis for highlighting a search snippet — no regex is
+// built from user input, and the original casing is preserved in the output.
+export function splitMatches(text: string, query: string): { text: string; match: boolean }[] {
+  const term = query.trim()
+  if (!term) return text ? [{ text, match: false }] : []
+  const lower = text.toLowerCase()
+  const needle = term.toLowerCase()
+  const out: { text: string; match: boolean }[] = []
+  let from = 0
+  let at = lower.indexOf(needle)
+  while (at !== -1) {
+    if (at > from) out.push({ text: text.slice(from, at), match: false })
+    out.push({ text: text.slice(at, at + term.length), match: true })
+    from = at + term.length
+    at = lower.indexOf(needle, from)
+  }
+  if (from < text.length) out.push({ text: text.slice(from), match: false })
+  return out
+}

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -533,3 +533,5 @@ CREATE INDEX IF NOT EXISTS comment_artifact_state ON comment (artifact_id, state
 CREATE INDEX IF NOT EXISTS report_state ON report (state, created_at);
 
 CREATE INDEX IF NOT EXISTS audit_artifact ON audit_log (artifact_id, created_at);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS artifact_search USING fts5(text, artifact_id UNINDEXED, org_id UNINDEXED, tokenize='unicode61');

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -534,4 +534,4 @@ CREATE INDEX IF NOT EXISTS report_state ON report (state, created_at);
 
 CREATE INDEX IF NOT EXISTS audit_artifact ON audit_log (artifact_id, created_at);
 
-CREATE VIRTUAL TABLE IF NOT EXISTS artifact_search USING fts5(text, artifact_id UNINDEXED, org_id UNINDEXED, tokenize='unicode61');
+CREATE VIRTUAL TABLE IF NOT EXISTS artifact_search USING fts5(text, artifact_id UNINDEXED, org_id UNINDEXED, tokenize='unicode61 remove_diacritics 0');

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -101,6 +101,13 @@ export interface ListArtifactsOpts {
    *  An empty/omitted set with a profile query ⇒ public-only. Used by `listUserWorks`
    *  so a person's profile never leaks non-public work the viewer can't open. */
   visibleOrgIds?: string[]
+  /** Drop taken-down (`removed_at` set) rows. OFF by default because a plain listing
+   *  (the feed) deliberately keeps them to render a tombstone card — it never exposes
+   *  their content. Search MUST set this: it reads the live blob, so a surviving index
+   *  row for a moderated artifact would otherwise let its text be grepped out, bypassing
+   *  the read path's 410 tombstone. `listArtifacts` alone is therefore NOT a complete
+   *  visibility gate for content — this flag closes the tombstone hole. */
+  excludeRemoved?: boolean
 }
 
 export type PreviewStatus = "pending" | "ready" | "failed"

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -332,6 +332,20 @@ export interface ArtifactQueryStore {
    * `ids` array matches nothing.
    */
   listArtifacts(opts?: ListArtifactsOpts): Promise<ArtifactRecord[]>
+  /** Full-text search index over an artifact's current visible text (+ title), keyed by
+   *  id and scoped by org — the substrate that lifts workspace search past a live-grep of
+   *  the N most-recent artifacts to the whole corpus. `indexArtifact` upserts (call on every
+   *  publish/move with the new current text); `unindexArtifact` drops it (on delete).
+   *  `searchArtifactIds` returns the best-matching ids in ONE org, ranked (higher = more
+   *  relevant, dialect-normalized), with NO visibility filter — the caller re-applies
+   *  visibility via `listArtifacts({ ids })` so that rule lives in exactly one place. */
+  indexArtifact(id: string, orgId: string, title: string | null, text: string): Promise<void>
+  unindexArtifact(id: string): Promise<void>
+  searchArtifactIds(
+    orgId: string,
+    query: string,
+    limit: number,
+  ): Promise<{ id: string; rank: number }[]>
   /** Artifact ids carrying a tag (server-side tag filtering). */
   artifactIdsByTag(tag: string): Promise<string[]>
   /** Artifact ids in a workspace whose current author_login matches `login`

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -684,12 +684,30 @@ const TABLES = [
 /** Build the Postgres boot DDL: generated table/index CREATEs + placeholder tables
  *  + perf indexes, then the idempotent ADD COLUMN IF NOT EXISTS migrations. Pure;
  *  exported for the conformance test. */
+// Full-text search index (workspace search substrate) — the Postgres twin of the SQLite
+// fts5 virtual table. A real table holding a precomputed `tsvector` per artifact, with a
+// GIN index for `@@` lookups; the query filters `org_id` to one workspace and ranks with
+// `ts_rank_cd`. Raw DDL (tsvector/GIN aren't in the drizzle defs), appended like the perf
+// indexes so both dialects gain the same capability from one schema pass.
+const ARTIFACT_SEARCH_PG = [
+  `CREATE TABLE IF NOT EXISTS artifact_search (` +
+    `artifact_id text PRIMARY KEY, org_id text NOT NULL, tsv tsvector NOT NULL)`,
+  `CREATE INDEX IF NOT EXISTS artifact_search_tsv ON artifact_search USING gin (tsv)`,
+  `CREATE INDEX IF NOT EXISTS artifact_search_org ON artifact_search (org_id)`,
+]
+
 export const buildPgSchemaStatements = (): string[] => {
   const { creates, alters } = generateDdl(TABLES, getTableConfig, {
     ifNotExists: true,
     timestampDefault: PG_TIMESTAMP_DEFAULT,
   })
-  return [...creates, ...placeholderTables(PG_TIMESTAMP_DEFAULT), ...PERF_INDEXES, ...alters]
+  return [
+    ...creates,
+    ...placeholderTables(PG_TIMESTAMP_DEFAULT),
+    ...PERF_INDEXES,
+    ...ARTIFACT_SEARCH_PG,
+    ...alters,
+  ]
 }
 
 export const PG_SCHEMA_STATEMENTS: string[] = buildPgSchemaStatements()

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -588,9 +588,19 @@ export class PgMetaStore implements MetaStore {
     return opts?.limit ? q.limit(opts.limit) : q
   }
   // ---- full-text search index (workspace search substrate) — the tsvector twin of the
-  // SQLite fts5 path. `plainto_tsquery` turns the raw user text into an AND of its words,
-  // safely (no query-syntax injection); `ts_rank_cd` ranks (higher = more relevant). `text`
-  // is title + body so a title hit ranks the artifact too.
+  // SQLite fts5 path. `ts_rank_cd` ranks (higher = more relevant). `text` is title + body
+  // so a title hit ranks the artifact too.
+  //
+  // Query building is the tsquery twin of repos.ts `fts5Match`: the raw user text is
+  // reduced to alnum tokens, then AND'd as `:*` PREFIX lexemes so a partial word finds its
+  // whole word ("auth" → "authentication"), matching the fts5 prefix behaviour. Because the
+  // tokens are alnum-only they can never carry tsquery operators (& | ! ( ) : *), so
+  // `to_tsquery` can't be injected — the prefix only widens candidate RECALL; the caller's
+  // grep-confirm still enforces the exact literal. No tokens → null → no query, no matches.
+  private tsPrefixQuery(query: string): string | null {
+    const tokens = query.match(/[\p{L}\p{N}]+/gu)
+    return tokens?.length ? tokens.map((t) => `${t}:*`).join(" & ") : null
+  }
   async indexArtifact(
     id: string,
     orgId: string,
@@ -612,12 +622,14 @@ export class PgMetaStore implements MetaStore {
     query: string,
     limit: number,
   ): Promise<{ id: string; rank: number }[]> {
+    const ts = this.tsPrefixQuery(query)
+    if (!ts) return []
     const r = await this.pool.query<{ artifact_id: string; rank: number }>(
-      `SELECT artifact_id, ts_rank_cd(tsv, plainto_tsquery('simple', $2)) AS rank
+      `SELECT artifact_id, ts_rank_cd(tsv, to_tsquery('simple', $2)) AS rank
        FROM artifact_search
-       WHERE org_id = $1 AND tsv @@ plainto_tsquery('simple', $2)
+       WHERE org_id = $1 AND tsv @@ to_tsquery('simple', $2)
        ORDER BY rank DESC LIMIT $3`,
-      [orgId, query, limit],
+      [orgId, ts, limit],
     )
     return r.rows.map((row) => ({ id: row.artifact_id, rank: Number(row.rank) }))
   }
@@ -2560,6 +2572,10 @@ export class PgMetaStore implements MetaStore {
       await tx.delete(agentMention).where(eq(agentMention.artifact_id, id))
       await tx.delete(artifact).where(eq(artifact.id, id))
     })
+    // Drop the search-index row after the delete commits (the tombstone table isn't a
+    // drizzle model, so it stays outside the tx). An orphaned row left by a crash here
+    // is harmless: listArtifacts filters the now-deleted artifact out of any result.
+    await this.unindexArtifact(id)
   }
 
   // Atomic move: org_id flips, collection membership and any artifact-targeted
@@ -2570,6 +2586,13 @@ export class PgMetaStore implements MetaStore {
       await tx.delete(collectionItem).where(eq(collectionItem.artifact_id, artifactId))
       await tx.update(webhook).set({ artifact_id: null }).where(eq(webhook.artifact_id, artifactId))
     })
+    // Re-scope the search-index row to match. Non-atomic with the move is fine: a stale
+    // org can't leak the artifact (listArtifacts re-checks org live) — it's only a
+    // findability fix, so it re-scopes on next publish/backfill even if this misses.
+    await this.pool.query(`UPDATE artifact_search SET org_id = $2 WHERE artifact_id = $1`, [
+      artifactId,
+      targetOrgId,
+    ])
   }
 
   // Atomic takedown: tombstone + bulk open-report resolution + audit entry in one

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -587,6 +587,40 @@ export class PgMetaStore implements MetaStore {
       .orderBy(desc(artifact.created_at), desc(artifact.id))
     return opts?.limit ? q.limit(opts.limit) : q
   }
+  // ---- full-text search index (workspace search substrate) — the tsvector twin of the
+  // SQLite fts5 path. `plainto_tsquery` turns the raw user text into an AND of its words,
+  // safely (no query-syntax injection); `ts_rank_cd` ranks (higher = more relevant). `text`
+  // is title + body so a title hit ranks the artifact too.
+  async indexArtifact(
+    id: string,
+    orgId: string,
+    title: string | null,
+    text: string,
+  ): Promise<void> {
+    const content = title ? `${title}\n\n${text}` : text
+    await this.pool.query(
+      `INSERT INTO artifact_search (artifact_id, org_id, tsv) VALUES ($1, $2, to_tsvector('simple', $3))
+       ON CONFLICT (artifact_id) DO UPDATE SET org_id = $2, tsv = to_tsvector('simple', $3)`,
+      [id, orgId, content],
+    )
+  }
+  async unindexArtifact(id: string): Promise<void> {
+    await this.pool.query(`DELETE FROM artifact_search WHERE artifact_id = $1`, [id])
+  }
+  async searchArtifactIds(
+    orgId: string,
+    query: string,
+    limit: number,
+  ): Promise<{ id: string; rank: number }[]> {
+    const r = await this.pool.query<{ artifact_id: string; rank: number }>(
+      `SELECT artifact_id, ts_rank_cd(tsv, plainto_tsquery('simple', $2)) AS rank
+       FROM artifact_search
+       WHERE org_id = $1 AND tsv @@ plainto_tsquery('simple', $2)
+       ORDER BY rank DESC LIMIT $3`,
+      [orgId, query, limit],
+    )
+    return r.rows.map((row) => ({ id: row.artifact_id, rank: Number(row.rank) }))
+  }
   async artifactIdsByTag(tag: string): Promise<string[]> {
     const rows = await this.db
       .select({ id: artifactTag.artifact_id })

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -558,11 +558,15 @@ export function makeRepos(db: SqliteDb) {
 
   // ---- full-text search index (workspace search substrate) ----
   // Translate a LITERAL user query into a safe FTS5 MATCH: alnum tokens AND'd as quoted
-  // phrases, so the user's text is never read as FTS5 syntax (AND/OR/NEAR/*/parens/quotes).
+  // PREFIX phrases (`"auth"*`), so the user's text is never read as FTS5 syntax
+  // (AND/OR/NEAR/*/parens/quotes) AND a partial word finds its whole word ("auth" →
+  // "authentication") — the grep-confirm pass the caller runs still enforces the exact
+  // literal, so the prefix only widens candidate RECALL, never final precision. Quoting
+  // before the star keeps it valid for every token shape (numeric-leading, unicode).
   // No tokens (all punctuation) → no query → no matches.
   const fts5Match = (query: string): string | null => {
     const tokens = query.match(/[\p{L}\p{N}]+/gu)
-    return tokens?.length ? tokens.map((t) => `"${t}"`).join(" ") : null
+    return tokens?.length ? tokens.map((t) => `"${t}"*`).join(" ") : null
   }
   // FTS5 has no UPSERT, so index = delete-then-insert the one row. `text` is title + body
   // so a title hit ranks the artifact too. Contentless: the source of truth stays the blob.
@@ -2526,11 +2530,21 @@ export function makeRepos(db: SqliteDb) {
     await db.delete(notification).where(eq(notification.artifact_id, id)).run()
     await db.delete(agentMention).where(eq(agentMention.artifact_id, id)).run()
     await db.delete(artifact).where(eq(artifact.id, id)).run()
+    // Drop the search-index row too. Contentless FTS/tsvector rows aren't drizzle
+    // tables, so they ride the same raw-SQL path unindexArtifact uses.
+    await unindexArtifact(id)
   }
 
   // Sequential move (used by D1). better-sqlite3 + pg override with a transaction.
   const moveArtifactOrg = async (artifactId: string, targetOrgId: string): Promise<void> => {
     await db.update(artifact).set({ org_id: targetOrgId }).where(eq(artifact.id, artifactId)).run()
+    // Keep the search-index row's org in step so the moved artifact is findable in its
+    // new workspace immediately (its text is unchanged by a move — only the scope is).
+    // A stale org here could never LEAK it: listArtifacts re-checks org against the live
+    // row, so this is a findability fix, not a visibility one.
+    await db.run(
+      sql`UPDATE artifact_search SET org_id = ${targetOrgId} WHERE artifact_id = ${artifactId}`,
+    )
     // Collections are org-scoped groupings; the artifact leaves all of them.
     await db.delete(collectionItem).where(eq(collectionItem.artifact_id, artifactId)).run()
     // An org-scoped webhook that targeted this one artifact falls back to org-wide

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -556,6 +556,48 @@ export function makeRepos(db: SqliteDb) {
     return opts?.limit ? rows.limit(opts.limit).all() : rows.all()
   }
 
+  // ---- full-text search index (workspace search substrate) ----
+  // Translate a LITERAL user query into a safe FTS5 MATCH: alnum tokens AND'd as quoted
+  // phrases, so the user's text is never read as FTS5 syntax (AND/OR/NEAR/*/parens/quotes).
+  // No tokens (all punctuation) → no query → no matches.
+  const fts5Match = (query: string): string | null => {
+    const tokens = query.match(/[\p{L}\p{N}]+/gu)
+    return tokens?.length ? tokens.map((t) => `"${t}"`).join(" ") : null
+  }
+  // FTS5 has no UPSERT, so index = delete-then-insert the one row. `text` is title + body
+  // so a title hit ranks the artifact too. Contentless: the source of truth stays the blob.
+  const indexArtifact = async (
+    id: string,
+    orgId: string,
+    title: string | null,
+    text: string,
+  ): Promise<void> => {
+    const content = title ? `${title}\n\n${text}` : text
+    await db.run(sql`DELETE FROM artifact_search WHERE artifact_id = ${id}`)
+    await db.run(
+      sql`INSERT INTO artifact_search (text, artifact_id, org_id) VALUES (${content}, ${id}, ${orgId})`,
+    )
+  }
+  const unindexArtifact = async (id: string): Promise<void> => {
+    await db.run(sql`DELETE FROM artifact_search WHERE artifact_id = ${id}`)
+  }
+  const searchArtifactIds = async (
+    orgId: string,
+    query: string,
+    limit: number,
+  ): Promise<{ id: string; rank: number }[]> => {
+    const match = fts5Match(query)
+    if (!match) return []
+    // bm25() is smaller-is-better; negate so the interface's "higher = more relevant" holds.
+    const rows = (await db.all(sql`
+      SELECT artifact_id, -bm25(artifact_search) AS rank
+      FROM artifact_search
+      WHERE org_id = ${orgId} AND artifact_search MATCH ${match}
+      ORDER BY rank DESC
+      LIMIT ${limit}`)) as { artifact_id: string; rank: number }[]
+    return rows.map((r) => ({ id: r.artifact_id, rank: r.rank }))
+  }
+
   const artifactIdsByTag = async (tag: string): Promise<string[]> =>
     (
       await db
@@ -2573,6 +2615,9 @@ export function makeRepos(db: SqliteDb) {
     setVersionPreview,
     setVersionPreviewVariant,
     listArtifacts,
+    indexArtifact,
+    unindexArtifact,
+    searchArtifactIds,
     artifactIdsByTag,
     artifactIdsByAuthor,
     artifactIdsOwnedBy,

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -155,10 +155,21 @@ import {
  * once, not in two places (the listArtifacts the review flagged as duplicated).
  */
 export function artifactListConditions(
-  art: { title: Column; created_at: Column; id: Column; org_id: Column; listed: Column },
+  art: {
+    title: Column
+    created_at: Column
+    id: Column
+    org_id: Column
+    listed: Column
+    removed_at: Column
+  },
   opts?: ListArtifactsOpts,
 ): SQL[] {
   const conds: SQL[] = []
+  // Tombstone filter — OFF by default (the feed shows removed rows as tombstone cards),
+  // ON for content-reading callers like search so a moderated artifact's text can't be
+  // grepped out of the index. See ListArtifactsOpts.excludeRemoved.
+  if (opts?.excludeRemoved) conds.push(isNull(art.removed_at))
   // Anonymous / non-member callers only ever see the public directory — a
   // workspace-listed title must not leak to someone outside the workspace.
   if (opts?.publicOnly) conds.push(eq(art.listed, "public"))
@@ -599,7 +610,17 @@ export function makeRepos(db: SqliteDb) {
       WHERE org_id = ${orgId} AND artifact_search MATCH ${match}
       ORDER BY rank DESC
       LIMIT ${limit}`)) as { artifact_id: string; rank: number }[]
-    return rows.map((r) => ({ id: r.artifact_id, rank: r.rank }))
+    // fts5 has no UNIQUE(artifact_id) and index = DELETE-then-INSERT (two statements), so a
+    // race between two same-artifact publishes can momentarily leave two rows. Dedup on read
+    // (keep the best-ranked) so a caller never sees an id twice. (Postgres can't: PK upsert.)
+    const seen = new Set<string>()
+    const out: { id: string; rank: number }[] = []
+    for (const r of rows) {
+      if (seen.has(r.artifact_id)) continue
+      seen.add(r.artifact_id)
+      out.push({ id: r.artifact_id, rank: r.rank })
+    }
+    return out
   }
 
   const artifactIdsByTag = async (tag: string): Promise<string[]> =>

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -824,9 +824,16 @@ const ddl = generateDdl(TABLES, getTableConfig, {
 // can filter to one workspace (`org_id = ?`) and return the id, ranked by `bm25()`. Not a
 // drizzle def (FTS5 is raw DDL only), so it lives here explicitly like the perf indexes.
 // D1 ships FTS5; better-sqlite3 ships it too.
+// `remove_diacritics 0` keeps fts5 accent-SENSITIVE, matching both Postgres
+// `to_tsvector('simple', …)` (which preserves diacritics) and the literal grep-confirm
+// pass — so "café" is found by "café", not by "cafe", identically on every tier.
+// unicode61's default folds accents, which would silently diverge the two dialects
+// AND nominate docs the literal grep then drops. Word/whitespace tokenization still
+// differs across dialects for scripts without spaces (CJK) and tokens >2047 bytes
+// (Postgres drops those) — a documented limit of a lexical index, not fixed here.
 const ARTIFACT_SEARCH_FTS5 =
   `CREATE VIRTUAL TABLE IF NOT EXISTS artifact_search USING fts5(` +
-  `text, artifact_id UNINDEXED, org_id UNINDEXED, tokenize='unicode61')`
+  `text, artifact_id UNINDEXED, org_id UNINDEXED, tokenize='unicode61 remove_diacritics 0')`
 
 export const SCHEMA_STATEMENTS: string[] = [
   ...ddl.creates,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -819,10 +819,20 @@ const ddl = generateDdl(TABLES, getTableConfig, {
  * the not-yet-queried placeholder tables (principal/view) and the perf indexes
  * have no drizzle def and stay explicit (see ./ddl).
  */
+// Full-text search index (workspace search substrate). A contentless FTS5 virtual table:
+// `text` is tokenized/searched; `artifact_id`/`org_id` are stored-but-UNINDEXED so a query
+// can filter to one workspace (`org_id = ?`) and return the id, ranked by `bm25()`. Not a
+// drizzle def (FTS5 is raw DDL only), so it lives here explicitly like the perf indexes.
+// D1 ships FTS5; better-sqlite3 ships it too.
+const ARTIFACT_SEARCH_FTS5 =
+  `CREATE VIRTUAL TABLE IF NOT EXISTS artifact_search USING fts5(` +
+  `text, artifact_id UNINDEXED, org_id UNINDEXED, tokenize='unicode61')`
+
 export const SCHEMA_STATEMENTS: string[] = [
   ...ddl.creates,
   ...placeholderTables(SQLITE_TIMESTAMP_DEFAULT),
   ...PERF_INDEXES,
+  ARTIFACT_SEARCH_FTS5,
 ]
 
 /**

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -179,6 +179,10 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
         db.delete(agentMention).where(eq(agentMention.artifact_id, id)).run()
         db.delete(artifact).where(eq(artifact.id, id)).run()
       })()
+      // The contentless fts5 row isn't a drizzle table, so it rides the inherited
+      // unindexArtifact (raw SQL) after the delete commits. An orphan left by a crash
+      // here is harmless: listArtifacts filters the deleted artifact out of any result.
+      await repos.unindexArtifact(id)
     },
 
     // Atomic move: org_id flips, collection membership and any artifact-targeted
@@ -192,6 +196,12 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
           .where(eq(webhook.artifact_id, artifactId))
           .run()
       })()
+      // Re-scope the fts5 row to match (raw, since it's not a drizzle model). A stale org
+      // can't leak the artifact — listArtifacts re-checks org against the live row — so
+      // this is only a findability fix, safe to run outside the move's transaction.
+      raw
+        .prepare(`UPDATE artifact_search SET org_id = ? WHERE artifact_id = ?`)
+        .run(targetOrgId, artifactId)
     },
 
     // Atomic takedown: the tombstone, the bulk open-report resolution, and the

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1678,6 +1678,18 @@ export function runStoreContract(
       expect(await store.searchArtifactIds(ORG, "migration", 10)).toHaveLength(0)
       expect(ids(await store.searchArtifactIds(target, "migration", 10))).toEqual([a.id])
     })
+
+    it("is accent-SENSITIVE identically on both dialects (fts5 remove_diacritics 0 == tsvector 'simple')", async () => {
+      const a = await store.createArtifact(newArtifact())
+      await store.indexArtifact(a.id, ORG, null, "the café résumé report")
+      // The exact accented form matches; the unaccented form does NOT — the same on
+      // fts5 and tsvector, and consistent with the byte-literal grep-confirm ("cafe"
+      // would not grep "café" either). unicode61's default would fold café→cafe and
+      // silently diverge from Postgres; remove_diacritics 0 pins the parity.
+      expect(ids(await store.searchArtifactIds(ORG, "café", 10))).toEqual([a.id])
+      expect(ids(await store.searchArtifactIds(ORG, "résumé", 10))).toEqual([a.id])
+      expect(await store.searchArtifactIds(ORG, "cafe", 10)).toHaveLength(0)
+    })
   })
 
   describe(`${label}: moderation (reports, takedown, audit)`, () => {

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1644,6 +1644,40 @@ export function runStoreContract(
       expect(ranked[0]?.rank).toBeGreaterThanOrEqual(ranked[1]?.rank ?? 0)
       expect(await store.searchArtifactIds(ORG, "kestrel", 1)).toHaveLength(1)
     })
+
+    it("prefix-matches a partial word onto its whole word (both dialects)", async () => {
+      const a = await store.createArtifact(newArtifact())
+      await store.indexArtifact(a.id, ORG, null, "the authentication flow uses rotating tokens")
+      // A partial word finds the whole word — candidate recall; the caller's grep pass
+      // still enforces the exact literal. Same behaviour on fts5 (`"auth"*`) and
+      // tsvector (`auth:*`).
+      expect(ids(await store.searchArtifactIds(ORG, "auth", 10))).toEqual([a.id])
+      expect(ids(await store.searchArtifactIds(ORG, "rotat", 10))).toEqual([a.id])
+      // Multiple prefix tokens AND together.
+      expect(ids(await store.searchArtifactIds(ORG, "auth token", 10))).toEqual([a.id])
+      // A word absent from the text still doesn't match.
+      expect(await store.searchArtifactIds(ORG, "invoice", 10)).toHaveLength(0)
+    })
+
+    it("deleteArtifact drops the artifact's index row", async () => {
+      const a = await store.createArtifact(newArtifact())
+      await store.indexArtifact(a.id, ORG, "Ledger", "reconciliation of the general ledger")
+      expect(ids(await store.searchArtifactIds(ORG, "reconciliation", 10))).toEqual([a.id])
+      await store.deleteArtifact(a.id)
+      expect(await store.searchArtifactIds(ORG, "reconciliation", 10)).toHaveLength(0)
+    })
+
+    it("moveArtifactOrg re-scopes the index row to the new workspace", async () => {
+      const target = `org_${uuid()}`
+      const a = await store.createArtifact(newArtifact())
+      await store.indexArtifact(a.id, ORG, null, "migration playbook for the platform team")
+      expect(ids(await store.searchArtifactIds(ORG, "migration", 10))).toEqual([a.id])
+      await store.moveArtifactOrg(a.id, target)
+      // Gone from the old workspace's search; present in the new one (its text is
+      // unchanged by the move — only the scope column moves).
+      expect(await store.searchArtifactIds(ORG, "migration", 10)).toHaveLength(0)
+      expect(ids(await store.searchArtifactIds(target, "migration", 10))).toEqual([a.id])
+    })
   })
 
   describe(`${label}: moderation (reports, takedown, audit)`, () => {

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1593,6 +1593,59 @@ export function runStoreContract(
     })
   })
 
+  describe(`${label}: full-text search index`, () => {
+    const ids = (hits: { id: string }[]) => hits.map((h) => h.id).sort()
+    it("indexes text, finds it ranked, scoped to one org; reindex/unindex mutate it", async () => {
+      const a = await store.createArtifact(newArtifact())
+      const b = await store.createArtifact(newArtifact())
+      const elsewhere = await store.createArtifact(newArtifact({ org_id: `org_${uuid()}` }))
+      await store.indexArtifact(
+        a.id,
+        ORG,
+        "Revenue report",
+        "quarterly revenue grew twenty percent",
+      )
+      await store.indexArtifact(b.id, ORG, "Costs", "operating costs held flat this period")
+      await store.indexArtifact(elsewhere.id, elsewhere.org_id, "Revenue", "revenue in another org")
+
+      // Relevance: "revenue" finds a, not b; "costs" finds b, not a.
+      expect(ids(await store.searchArtifactIds(ORG, "revenue", 10))).toEqual([a.id])
+      expect(ids(await store.searchArtifactIds(ORG, "costs", 10))).toEqual([b.id])
+      // Org isolation: the same-word artifact in another org never leaks into ORG.
+      expect(ids(await store.searchArtifactIds(ORG, "revenue", 10))).not.toContain(elsewhere.id)
+      expect(ids(await store.searchArtifactIds(elsewhere.org_id, "revenue", 10))).toEqual([
+        elsewhere.id,
+      ])
+      // Title is searchable too.
+      expect(ids(await store.searchArtifactIds(ORG, "report", 10))).toEqual([a.id])
+
+      // Reindex (a new version) REPLACES the prior text.
+      await store.indexArtifact(a.id, ORG, "Now", "entirely different subject matter here")
+      expect(await store.searchArtifactIds(ORG, "revenue", 10)).toHaveLength(0)
+      expect(ids(await store.searchArtifactIds(ORG, "subject", 10))).toEqual([a.id])
+
+      // Unindex drops it.
+      await store.unindexArtifact(a.id)
+      expect(await store.searchArtifactIds(ORG, "subject", 10)).toHaveLength(0)
+
+      // A punctuation-only query yields nothing — the literal text is never read as
+      // query syntax (no FTS injection / no error).
+      expect(await store.searchArtifactIds(ORG, "!!! (*)", 10)).toHaveLength(0)
+    })
+
+    it("ranks a more-relevant artifact first, and honours the limit", async () => {
+      const hi = await store.createArtifact(newArtifact())
+      const lo = await store.createArtifact(newArtifact())
+      await store.indexArtifact(hi.id, ORG, null, Array(12).fill("kestrel").join(" "))
+      await store.indexArtifact(lo.id, ORG, null, "kestrel among many unrelated other words here")
+      const ranked = await store.searchArtifactIds(ORG, "kestrel", 10)
+      expect(ranked).toHaveLength(2)
+      expect(ranked[0]?.id).toBe(hi.id) // far more occurrences → higher rank in both dialects
+      expect(ranked[0]?.rank).toBeGreaterThanOrEqual(ranked[1]?.rank ?? 0)
+      expect(await store.searchArtifactIds(ORG, "kestrel", 1)).toHaveLength(1)
+    })
+  })
+
   describe(`${label}: moderation (reports, takedown, audit)`, () => {
     it("files a report, transitions it, takes down an artifact, logs the action", async () => {
       const a = await store.createArtifact(newArtifact())

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1690,6 +1690,21 @@ export function runStoreContract(
       expect(ids(await store.searchArtifactIds(ORG, "résumé", 10))).toEqual([a.id])
       expect(await store.searchArtifactIds(ORG, "cafe", 10)).toHaveLength(0)
     })
+
+    it("excludeRemoved drops taken-down rows from listArtifacts (the search visibility gate)", async () => {
+      const a = await store.createArtifact(newArtifact({ listed: "workspace" }))
+      const seen = async (opts: Parameters<typeof store.listArtifacts>[0]) =>
+        (await store.listArtifacts(opts)).map((x) => x.id)
+      expect(await seen({ orgId: ORG, ids: [a.id] })).toEqual([a.id])
+      await store.setArtifactRemoved(a.id, new Date().toISOString())
+      // The default (feed) listing still returns the tombstone; the search gate,
+      // which reads the live blob, must exclude it — this is what keeps a moderated
+      // artifact's text out of workspace search.
+      expect(await seen({ orgId: ORG, ids: [a.id] })).toEqual([a.id])
+      expect(
+        await store.listArtifacts({ orgId: ORG, ids: [a.id], excludeRemoved: true }),
+      ).toHaveLength(0)
+    })
   })
 
   describe(`${label}: moderation (reports, takedown, audit)`, () => {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -205,7 +205,7 @@ server.registerTool(
   "search",
   {
     description:
-      "Find text within ONE artifact, or across a WORKSPACE — same tool, same behavior as the remote MCP server's `search`. Pass short_id to grep one artifact: matching lines with line numbers (and optional context), ripgrep-style, so you can then `read` a narrow `lines` range or `edit` that spot. Omit short_id to search the whole workspace — every artifact you can see, ranked by relevance, grouped by artifact — find WHICH doc has something before opening it. Searches the exact source by default (in:'text' searches the visible text instead). The query is matched literally (metacharacters are not special).",
+      "Find text within ONE artifact, or across a WORKSPACE — same tool, same behavior as the remote MCP server's `search`. Pass short_id to grep one artifact: matching lines with line numbers (and optional context), ripgrep-style, so you can then `read` a narrow `lines` range or `edit` that spot. Omit short_id to search across the workspace — the artifacts you can see, ranked by relevance and grouped by artifact — find WHICH doc has something before opening it. Searches the exact source by default (in:'text' searches the visible text instead). The query is matched literally (metacharacters are not special).",
     inputSchema: {
       short_id: z
         .string()

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -205,7 +205,7 @@ server.registerTool(
   "search",
   {
     description:
-      "Find text within ONE artifact, or across a WORKSPACE — same tool, same behavior as the remote MCP server's `search`. Pass short_id to grep one artifact: matching lines with line numbers (and optional context), ripgrep-style, so you can then `read` a narrow `lines` range or `edit` that spot. Omit short_id to grep instead across the most recently created artifacts you can see in a workspace, grouped by artifact — find WHICH doc has something before opening it. Searches the exact source by default (in:'text' searches the visible text instead). The query is matched literally (metacharacters are not special).",
+      "Find text within ONE artifact, or across a WORKSPACE — same tool, same behavior as the remote MCP server's `search`. Pass short_id to grep one artifact: matching lines with line numbers (and optional context), ripgrep-style, so you can then `read` a narrow `lines` range or `edit` that spot. Omit short_id to search the whole workspace — every artifact you can see, ranked by relevance, grouped by artifact — find WHICH doc has something before opening it. Searches the exact source by default (in:'text' searches the visible text instead). The query is matched literally (metacharacters are not special).",
     inputSchema: {
       short_id: z
         .string()


### PR DESCRIPTION
Stacked on #415. Closes the acknowledged structural gap where workspace `search` was a live grep of only the **30 most-recently-created** artifacts a viewer could see — blind to the rest of the corpus. It's now a persisted full-text index, retrieved over the whole workspace, relevance-ranked, with visibility unchanged.

## Design — two-tier retrieval (index nominates, `listArtifacts` gates, grep confirms)
1. **Tier 1** `searchArtifactIds(orgId, query, K)` — a dual-dialect FTS index (SQLite/D1 `fts5`+`bm25`, Postgres `tsvector`+GIN+`ts_rank_cd`) returns the most relevant candidate ids across the corpus. Org-scoped, ranked, **no visibility knowledge by design**.
2. **Tier 2 gate** — those ids are re-resolved through `listArtifacts({ids, viewerId, publicOnly, excludeRemoved})`, the *same* gate `list_artifacts` uses. The index is a pure relevance oracle, so it can never widen what a viewer sees.
3. **Grep-confirm** — the existing literal engine confirms the exact match on the top-ranked survivors (index = recall, grep = precision), with an honest truncation note.

## Write path (keeps the index current)
- `emitVersionBump` indexes on every publish / restore / proposal-approve (the one chokepoint all three route through), best-effort so a search-index hiccup never fails a publish.
- `deleteArtifact` drops the row, `moveArtifactOrg` re-scopes it — all three dialect impls.
- Indexes raw **source** (data:-URIs elided, size-capped) so the default source-scope search finds tag/attribute content.
- Prefix matching (`auth`→`authentication`) on both dialects; grep-confirm still enforces the exact literal.

## Backfill
`reindexSearchBatch` + operator-gated `POST /v1/system/search-reindex` sweep the existing corpus in bounded, resumable pages (publishing covers new work).

## Adversarial audit (four independent refuters) — findings fixed before this PR
- **SECURITY (fixed):** a taken-down artifact's content was grep-exfiltratable — `listArtifacts` never filtered `removed_at` (the feed keeps tombstones) and `takedownArtifact` didn't unindex. Fixed with an opt-in `excludeRemoved` gate that search + backfill set; regression-tested on both dialects.
- **D1 500 (fixed):** resolving up to 200 candidate ids via `id IN (?…)` exceeded D1's 100-bound-parameter cap → now chunked at 90.
- **Dialect parity (fixed):** accent folding diverged (SQLite folded `café`→`cafe`, Postgres didn't) → `fts5 remove_diacritics 0`, accent-sensitive on both and consistent with the literal grep; pinned by a store-contract test.
- **Robustness (fixed):** backfill made per-artifact-resilient; concurrent-publish duplicate fts5 rows deduped on read.
- **Claim fidelity (fixed):** truncation note reworded to "candidate artifacts" (grep-confirm can drop some) with a `+1` sentinel; index described as recall-*approximate*; tool descriptions no longer claim "every artifact".
- CJK / >2047-byte-token tokenizer differences are documented as a lexical-index limit.

## Tests / gates
Store-contract FTS block (index/rank/org-isolation/prefix/accent/delete/move/`excludeRemoved`) runs on sqlite **and** Postgres in CI. MCP/REST: E2E publish→findable, whole-corpus relevance + truncation, >90-candidate chunk-merge, recall-vs-precision, backfill+pagination, and the tombstone-hole + private-leak regressions (both non-vacuously index the hidden artifact so they prove the gate, not an empty index). Full local db + api suites green (the 2 `oauth-refresh-rotation` failures are a pre-existing local-only stale-patch-hash issue that passes in CI; my diff touches no oauth code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)