### PR TITLE
⌘K finds artifacts by content, not just title

### DIFF
--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -416,6 +416,7 @@ const LIST_ID_CHUNK = 90
 export interface WorkspaceSearchResult {
   short_id: string
   title: string
+  current_version: number
   groups: { path: string | null; hunks: SearchHunk[] }[]
   total: number
 }
@@ -438,6 +439,10 @@ export const searchWorkspace = async (
     where: "source" | "text"
     ctxLines: number
     cap: number
+    // How many visible candidates to grep-confirm. Defaults to WORKSPACE_SEARCH_ARTIFACT_CAP
+    // (agents want depth); a typeahead surface passes a small value so a debounced keystroke
+    // reads only a handful of blobs.
+    limit?: number
   },
 ): Promise<{ results: WorkspaceSearchResult[]; note: string | null }> => {
   // Tier 1 — the index nominates the most relevant candidate ids across the whole
@@ -479,7 +484,8 @@ export const searchWorkspace = async (
   // real cost, so it stays bounded. A candidate the index nominated on token overlap
   // but whose exact literal/scope isn't actually present yields no hunks and drops out
   // here: the index is RECALL, the grep is PRECISION.
-  const toGrep = visible.slice(0, WORKSPACE_SEARCH_ARTIFACT_CAP)
+  const grepCap = opts.limit ?? WORKSPACE_SEARCH_ARTIFACT_CAP
+  const toGrep = visible.slice(0, grepCap)
   // 4, not searchArtifactVersion's inner 8: the two fan-outs compose (a batch of
   // bundles each opens its own 8-wide page fan-out), so peak blob reads is the product
   // — 4×8=32 keeps that worst case reasonable without a cross-cutting semaphore.
@@ -495,7 +501,15 @@ export const searchWorkspace = async (
       opts.ctxLines,
       opts.cap,
     )
-    return total ? { short_id: a.short_id, title: a.title ?? a.short_id, groups, total } : null
+    return total
+      ? {
+          short_id: a.short_id,
+          title: a.title ?? a.short_id,
+          current_version: a.current_version,
+          groups,
+          total,
+        }
+      : null
   }
   const results: WorkspaceSearchResult[] = []
   for (let i = 0; i < toGrep.length; i += CONCURRENCY) {
@@ -508,9 +522,9 @@ export const searchWorkspace = async (
   // wording says "candidates", never "matches". `grepTruncated`: more visible candidates
   // than we confirmed. `moreCandidates`: the index had still more below the window
   // (detected by the over-fetched sentinel) — hence the `+`.
-  const grepTruncated = visible.length > WORKSPACE_SEARCH_ARTIFACT_CAP
+  const grepTruncated = visible.length > grepCap
   const note = grepTruncated
-    ? `ranked by relevance — grep-confirmed the top ${WORKSPACE_SEARCH_ARTIFACT_CAP} of ${visible.length}${
+    ? `ranked by relevance — grep-confirmed the top ${grepCap} of ${visible.length}${
         moreCandidates ? "+" : ""
       } candidate artifacts you can see; refine the query to reach the rest`
     : moreCandidates
@@ -543,3 +557,45 @@ export const workspaceSearchReport = (
   const steer = `\n\nOpen one with search(short_id:"...", query:"${query}") for full context, or read(short_id:"...", lines:"from-to", format:"${fmt}").`
   return clip(`${head}\n\n${body}${steer}`)
 }
+
+// ---------------------------------------------------------------------------
+// JSON hits — the same workspace results shaped for a UI (the ⌘K palette) instead of
+// the agent text report: one artifact per hit, with a single-line snippet of WHERE it
+// matched so a human sees why it surfaced. The client highlights the term itself.
+// ---------------------------------------------------------------------------
+
+export interface SearchHit {
+  short_id: string
+  title: string
+  current_version: number
+  /** One line of the matching text, windowed around the first match (…elided ends). */
+  snippet: string
+}
+
+const SNIPPET_RADIUS = 90
+
+// Window a long line around the first occurrence of `query` so the match stays visible
+// instead of scrolling off a clipped line. Whitespace is collapsed (a source line can be
+// deeply indented). Falls back to the head of the line when the literal isn't found on it.
+export const snippetAround = (line: string, query: string): string => {
+  const flat = line.replace(/\s+/g, " ").trim()
+  const q = query.trim()
+  if (flat.length <= SNIPPET_RADIUS * 2) return flat
+  const at = flat.toLowerCase().indexOf(q.toLowerCase())
+  if (at < 0) return `${flat.slice(0, SNIPPET_RADIUS * 2)}…`
+  const start = Math.max(0, at - SNIPPET_RADIUS)
+  const end = Math.min(flat.length, at + q.length + SNIPPET_RADIUS)
+  return `${start > 0 ? "…" : ""}${flat.slice(start, end)}${end < flat.length ? "…" : ""}`
+}
+
+export const toSearchHits = (results: WorkspaceSearchResult[], query: string): SearchHit[] =>
+  results.map((r) => {
+    // The first HIT line across the artifact's groups is the most relevant snippet source.
+    const hit = r.groups.flatMap((g) => g.hunks.flatMap((h) => h.lines)).find((l) => l.hit)
+    return {
+      short_id: r.short_id,
+      title: r.title,
+      current_version: r.current_version,
+      snippet: hit ? snippetAround(hit.text, query) : "",
+    }
+  })

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -575,21 +575,25 @@ export interface SearchHit {
   snippet: string
 }
 
-const SNIPPET_RADIUS = 90
+// A short lead of context BEFORE the match, then the rest trailing. The window is biased
+// left on purpose: the palette renders the snippet in a single left-truncating line, so a
+// centered window would push the highlighted term off the right edge — the common case
+// here, where agent-authored markdown writes each paragraph as one long unwrapped line.
+const SNIPPET_LEAD = 16
+const SNIPPET_LEN = 160
 
-// Window a long line around the first occurrence of `query` so the match stays visible
-// instead of scrolling off a clipped line. Whitespace is collapsed (a source line can be
-// deeply indented). Falls back to the head of the line when the literal isn't found on it.
+// Window a line so the first occurrence of `query` sits near the visible LEFT edge and
+// survives truncation. Whitespace in both the line and the query is collapsed (a source
+// line can be deeply indented; a query may carry stray spaces) so the match stays
+// locatable. Falls back to the head of the line when the literal isn't on it (shouldn't
+// happen after grep-confirm, but stays safe).
 export const snippetAround = (line: string, query: string): string => {
   const flat = line.replace(/\s+/g, " ").trim()
-  // Collapse the query's whitespace too, so a multi-space/tab query still locates its
-  // match in the collapsed line (else it'd fall to the head-of-line branch).
   const q = query.replace(/\s+/g, " ").trim()
-  if (flat.length <= SNIPPET_RADIUS * 2) return flat
-  const at = flat.toLowerCase().indexOf(q.toLowerCase())
-  if (at < 0) return `${flat.slice(0, SNIPPET_RADIUS * 2)}…`
-  const start = Math.max(0, at - SNIPPET_RADIUS)
-  const end = Math.min(flat.length, at + q.length + SNIPPET_RADIUS)
+  const at = q ? flat.toLowerCase().indexOf(q.toLowerCase()) : -1
+  if (at < 0) return flat.length > SNIPPET_LEN ? `${flat.slice(0, SNIPPET_LEN)}…` : flat
+  const start = Math.max(0, at - SNIPPET_LEAD)
+  const end = Math.min(flat.length, start + SNIPPET_LEN)
   return `${start > 0 ? "…" : ""}${flat.slice(start, end)}${end < flat.length ? "…" : ""}`
 }
 

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -441,21 +441,24 @@ export const searchWorkspace = async (
     cap: number
     // How many visible candidates to grep-confirm. Defaults to WORKSPACE_SEARCH_ARTIFACT_CAP
     // (agents want depth); a typeahead surface passes a small value so a debounced keystroke
-    // reads only a handful of blobs.
+    // reads only a handful of blobs. NOTE: this bounds only the blob-read + grep stage, not
+    // the (indexed, cheap) candidate scan or the visibility resolve — cap those with
+    // `candidateCap` when the caller wants the whole request small.
     limit?: number
+    // How many ranked candidates to nominate + visibility-check. Defaults to
+    // WORKSPACE_SEARCH_CANDIDATE_CAP (deep recall for agents); a typeahead surface passes a
+    // small value (≤ LIST_ID_CHUNK) so the visibility resolve is a SINGLE query, not three.
+    candidateCap?: number
   },
 ): Promise<{ results: WorkspaceSearchResult[]; note: string | null }> => {
   // Tier 1 — the index nominates the most relevant candidate ids across the whole
   // corpus. Org-scoped and ranked, but with NO visibility knowledge by design. Fetch one
   // past the cap: the sentinel row (never resolved) just answers "were there more?".
-  const nominated = await deps.meta.searchArtifactIds(
-    opts.orgId,
-    opts.query,
-    WORKSPACE_SEARCH_CANDIDATE_CAP + 1,
-  )
+  const candidateCap = opts.candidateCap ?? WORKSPACE_SEARCH_CANDIDATE_CAP
+  const nominated = await deps.meta.searchArtifactIds(opts.orgId, opts.query, candidateCap + 1)
   if (nominated.length === 0) return { results: [], note: null }
-  const moreCandidates = nominated.length > WORKSPACE_SEARCH_CANDIDATE_CAP
-  const candidates = nominated.slice(0, WORKSPACE_SEARCH_CANDIDATE_CAP)
+  const moreCandidates = nominated.length > candidateCap
+  const candidates = nominated.slice(0, candidateCap)
   const rankOf = new Map(candidates.map((c, i) => [c.id, i]))
 
   // Tier 2 gate — THE visibility check. Re-resolve the nominated ids through
@@ -528,7 +531,7 @@ export const searchWorkspace = async (
         moreCandidates ? "+" : ""
       } candidate artifacts you can see; refine the query to reach the rest`
     : moreCandidates
-      ? `ranked by relevance — more than ${WORKSPACE_SEARCH_CANDIDATE_CAP} artifacts matched the index; refine the query to narrow`
+      ? `ranked by relevance — more than ${candidateCap} artifacts matched the index; refine the query to narrow`
       : null
   return { results, note }
 }
@@ -579,7 +582,9 @@ const SNIPPET_RADIUS = 90
 // deeply indented). Falls back to the head of the line when the literal isn't found on it.
 export const snippetAround = (line: string, query: string): string => {
   const flat = line.replace(/\s+/g, " ").trim()
-  const q = query.trim()
+  // Collapse the query's whitespace too, so a multi-space/tab query still locates its
+  // match in the collapsed line (else it'd fall to the head-of-line branch).
+  const q = query.replace(/\s+/g, " ").trim()
   if (flat.length <= SNIPPET_RADIUS * 2) return flat
   const at = flat.toLowerCase().indexOf(q.toLowerCase())
   if (at < 0) return `${flat.slice(0, SNIPPET_RADIUS * 2)}…`

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -480,15 +480,20 @@ export const searchWorkspace = async (
     })
     visible.push(...rows)
   }
+  // A password lock gates the world-link CONTENT behind a password — read 401s without it.
+  // The publicOnly caller IS that anonymous/link visitor, so drop locked artifacts here,
+  // else their body would be grep-readable, bypassing the unlock. A member (viewerId)
+  // reaches content through membership, not the link, so the lock never applies to them.
+  const gated = opts.publicOnly ? visible.filter((a) => !a.password_hash) : visible
   // listArtifacts returns in its own (recency) order; restore relevance order.
-  visible.sort((a, b) => (rankOf.get(a.id) ?? Infinity) - (rankOf.get(b.id) ?? Infinity))
+  gated.sort((a, b) => (rankOf.get(a.id) ?? Infinity) - (rankOf.get(b.id) ?? Infinity))
 
   // Grep-confirm only the top-N most-relevant survivors — the blob-read+scan is the
   // real cost, so it stays bounded. A candidate the index nominated on token overlap
   // but whose exact literal/scope isn't actually present yields no hunks and drops out
   // here: the index is RECALL, the grep is PRECISION.
   const grepCap = opts.limit ?? WORKSPACE_SEARCH_ARTIFACT_CAP
-  const toGrep = visible.slice(0, grepCap)
+  const toGrep = gated.slice(0, grepCap)
   // 4, not searchArtifactVersion's inner 8: the two fan-outs compose (a batch of
   // bundles each opens its own 8-wide page fan-out), so peak blob reads is the product
   // — 4×8=32 keeps that worst case reasonable without a cross-cutting semaphore.
@@ -525,9 +530,9 @@ export const searchWorkspace = async (
   // wording says "candidates", never "matches". `grepTruncated`: more visible candidates
   // than we confirmed. `moreCandidates`: the index had still more below the window
   // (detected by the over-fetched sentinel) — hence the `+`.
-  const grepTruncated = visible.length > grepCap
+  const grepTruncated = gated.length > grepCap
   const note = grepTruncated
-    ? `ranked by relevance — grep-confirmed the top ${grepCap} of ${visible.length}${
+    ? `ranked by relevance — grep-confirmed the top ${grepCap} of ${gated.length}${
         moreCandidates ? "+" : ""
       } candidate artifacts you can see; refine the query to reach the rest`
     : moreCandidates

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -877,6 +877,10 @@ export const artifactRoutes = (ctx: AppContext) => {
     // reads only a few blobs; the text report keeps the full agent depth.
     const isJson = c.req.query("format") === "json"
     const limit = isJson ? Math.min(Math.max(Number(c.req.query("limit")) || 6, 1), 12) : undefined
+    // Keep the whole JSON request cheap, not just the blob reads: a small candidate cap
+    // means the visibility resolve is a SINGLE chunked query and the FTS scan is small —
+    // the palette only shows a handful, so deep recall would be wasted work on a hot path.
+    const candidateCap = isJson ? 60 : undefined
 
     const { results, note } = await searchWorkspace(
       { blobs, sourceText, meta },
@@ -890,9 +894,11 @@ export const artifactRoutes = (ctx: AppContext) => {
         ctxLines,
         cap,
         limit,
+        candidateCap,
       },
     )
     if (isJson) {
+      c.header("X-Content-Type-Options", "nosniff")
       c.header("Cache-Control", "no-store")
       return c.json({ hits: toSearchHits(results, query), truncated: note !== null })
     }

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -62,6 +62,7 @@ import {
   searchMatcher,
   searchReport,
   searchWorkspace,
+  toSearchHits,
   workspaceSearchReport,
 } from "../lib/search"
 import { enqueueSlackReviewRequestedDm } from "../lib/slack-dm"
@@ -870,6 +871,13 @@ export const artifactRoutes = (ctx: AppContext) => {
         : null
     const publicOnly = !(isOperator || baselineRole !== null)
 
+    // `?format=json` is the UI shape (the ⌘K palette): a small, ranked hit list with a
+    // snippet per artifact instead of the agent-facing ripgrep text report. A typeahead
+    // caller keeps the grep-confirm count tiny (bounded 1..12) so a debounced keystroke
+    // reads only a few blobs; the text report keeps the full agent depth.
+    const isJson = c.req.query("format") === "json"
+    const limit = isJson ? Math.min(Math.max(Number(c.req.query("limit")) || 6, 1), 12) : undefined
+
     const { results, note } = await searchWorkspace(
       { blobs, sourceText, meta },
       {
@@ -881,8 +889,13 @@ export const artifactRoutes = (ctx: AppContext) => {
         where,
         ctxLines,
         cap,
+        limit,
       },
     )
+    if (isJson) {
+      c.header("Cache-Control", "no-store")
+      return c.json({ hits: toSearchHits(results, query), truncated: note !== null })
+    }
     c.header("Access-Control-Allow-Origin", "*")
     c.header("X-Content-Type-Options", "nosniff")
     c.header("Content-Type", "text/plain; charset=utf-8")

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -10,7 +10,13 @@ import { exportJWK, generateKeyPair, SignJWT } from "jose"
 import { afterAll, describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
 import { sha256 } from "../src/lib/crypto"
-import { MAX_INDEX_TEXT, reindexSearchBatch, versionIndexText } from "../src/lib/search"
+import {
+  MAX_INDEX_TEXT,
+  reindexSearchBatch,
+  searchMatcher,
+  searchWorkspace,
+  versionIndexText,
+} from "../src/lib/search"
 
 // The remote MCP endpoint (/mcp) authenticated by an OAuth bearer. We seed a grant
 // straight into the oauth-provider tables (what the consent dance produces), publish
@@ -1033,6 +1039,63 @@ describe("remote MCP endpoint (/mcp)", () => {
     // contiguous literal finds nothing → honestly "No matches", never a false hit.
     const res = toolText(await call(app, token, "search", { query: "alpha omega" }))
     expect(res).toContain("No matches")
+  })
+
+  it("searchWorkspace hides a public-but-password-locked artifact's content from the anonymous (publicOnly) path, not from members", async () => {
+    const { app, token, meta, blobs } = appWithGrant("wslock", "openid derive:read derive:publish")
+    const seed = (await (await publishRaw(app, token, "# Seed", "seed.md", "Seed")).json()).short_id
+    const owner = await meta.getByShortId(seed)
+    if (!owner) throw new Error("expected the seed artifact to exist")
+    const org = owner.org_id
+    const key = await blobs.put(new TextEncoder().encode("the gatedneedle lives inside"))
+    // Two PUBLIC-listed artifacts with the same content; one is password-locked (a lock on
+    // its world link). The content differs only in whether reading it needs the password.
+    const mk = async (id: string, locked: boolean) => {
+      await meta.createArtifact({
+        id,
+        short_id: id,
+        org_id: org,
+        slug: null,
+        title: `Doc ${id}`,
+        workspace_access: "member",
+        link_role: "viewer",
+        listed: "public",
+        password_hash: locked ? "a-real-hash" : null,
+        kind: "file",
+        spa: 0,
+      })
+      await meta.addVersion(id, {
+        id: `v_${id}`,
+        blob_key: key,
+        content_type: "text/markdown",
+        author: "o",
+        message: null,
+      })
+      await meta.indexArtifact(id, org, `Doc ${id}`, "the gatedneedle lives inside")
+    }
+    await mk("aopen", false)
+    await mk("alock", true)
+    const sourceText = async (v: { blob_key: string; content_type: string }) => {
+      const b = await blobs.get(v.blob_key)
+      return b ? new TextDecoder().decode(b) : null
+    }
+    const deps = { blobs, sourceText, meta }
+    const base = {
+      orgId: org,
+      query: "gatedneedle",
+      re: searchMatcher("gatedneedle", false),
+      where: "text" as const,
+      ctxLines: 0,
+      cap: 40,
+    }
+    // Anonymous / non-member (publicOnly): the locked doc's body must NOT be grep-readable —
+    // reading it needs the password, and search must not bypass that.
+    const anon = await searchWorkspace(deps, { ...base, publicOnly: true })
+    expect(anon.results.map((r) => r.short_id).sort()).toEqual(["aopen"])
+    // A member/trusted caller (no publicOnly) reaches content through membership, not the
+    // link, so the lock doesn't apply — both surface.
+    const member = await searchWorkspace(deps, base)
+    expect(member.results.map((r) => r.short_id).sort()).toEqual(["alock", "aopen"])
   })
 
   it("versionIndexText degrades safely on the non-happy paths (never throws)", async () => {

--- a/apps/api/test/search-rest.test.ts
+++ b/apps/api/test/search-rest.test.ts
@@ -123,4 +123,39 @@ describe("/v1/artifacts/:shortId/search and /v1/artifacts/search — REST search
     const res = await a.request("/v1/artifacts/search?query=x") // no headers at all
     expect(res.status).toBe(401)
   })
+
+  it("?format=json returns ranked hits with a match snippet (the ⌘K palette shape)", async () => {
+    const { app: a } = makeAuthedApp("rest-search-json", users, "editor")
+    await publishAs(
+      a,
+      "# Notes\n\nthe quarterly kestrel review is scheduled for friday",
+      { title: "Notes", listed: "workspace" },
+      as("search-owner@x.test"),
+    )
+    const res = await a.request("/v1/artifacts/search?format=json&in=text&query=kestrel", {
+      headers: as("search-owner@x.test"),
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toContain("application/json")
+    const body = (await res.json()) as {
+      hits: { short_id: string; title: string; current_version: number; snippet: string }[]
+      truncated: boolean
+    }
+    const hit = body.hits.find((h) => h.title === "Notes")
+    if (!hit) throw new Error("expected the Notes artifact in the hits")
+    expect(hit.short_id).toBeTruthy()
+    expect(hit.current_version).toBe(1)
+    // The snippet is the matching line — what the palette highlights.
+    expect(hit.snippet.toLowerCase()).toContain("kestrel")
+    expect(typeof body.truncated).toBe("boolean")
+    // Visibility is the SAME searchWorkspace gate the text path uses (results are
+    // filtered before toSearchHits), so a private artifact can't leak here either — a
+    // word absent from anything visible returns no hits.
+    const none = await (
+      await a.request("/v1/artifacts/search?format=json&query=zznomatchzz", {
+        headers: as("search-owner@x.test"),
+      })
+    ).json()
+    expect(none.hits).toEqual([])
+  })
 })

--- a/apps/api/test/snippet.test.ts
+++ b/apps/api/test/snippet.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import { snippetAround } from "../src/lib/search"
+
+// snippetAround windows a matching line so the highlighted term survives the palette's
+// single-line, LEFT-truncating render — the match must land near the left edge.
+describe("snippetAround", () => {
+  it("returns a short line whole, with the match intact", () => {
+    expect(snippetAround("the kestrel review is friday", "kestrel")).toBe(
+      "the kestrel review is friday",
+    )
+  })
+
+  it("windows a long line so the match sits near the LEFT edge (not centered off-screen)", () => {
+    const line = `${"x".repeat(120)}kestrel${"y".repeat(120)}`
+    const snip = snippetAround(line, "kestrel")
+    expect(snip.startsWith("…")).toBe(true) // leading context elided
+    expect(snip).toContain("kestrel")
+    // The match is near the start of the returned snippet, so left-truncation keeps it.
+    expect(snip.indexOf("kestrel")).toBeLessThan(20)
+    expect(snip.length).toBeLessThanOrEqual(161) // SNIPPET_LEN + the leading ellipsis
+  })
+
+  it("omits the leading ellipsis when the match is at the start", () => {
+    const snip = snippetAround(`kestrel${"y".repeat(300)}`, "kestrel")
+    expect(snip.startsWith("kestrel")).toBe(true)
+    expect(snip.endsWith("…")).toBe(true) // trailing context elided
+  })
+
+  it("omits the trailing ellipsis when the match is at the end", () => {
+    const snip = snippetAround(`${"x".repeat(300)}kestrel`, "kestrel")
+    expect(snip.startsWith("…")).toBe(true)
+    expect(snip.endsWith("kestrel")).toBe(true)
+  })
+
+  it("collapses whitespace in BOTH the line and a multi-space query so the match is found", () => {
+    // Deeply-indented / multi-spaced source line, and a query with stray spaces.
+    const line = `${"z".repeat(120)}the   alpha    beta${"z".repeat(120)}`
+    const snip = snippetAround(line, "alpha  beta")
+    expect(snip).toContain("alpha beta") // collapsed + located (not the not-found fallback)
+    expect(snip.indexOf("alpha beta")).toBeLessThan(30)
+  })
+
+  it("falls back to the head of the line when the literal isn't present", () => {
+    expect(snippetAround("a short line with no hit", "zzz")).toBe("a short line with no hit")
+    const long = snippetAround("q".repeat(300), "zzz")
+    expect(long.endsWith("…")).toBe(true)
+    expect(long.length).toBeLessThanOrEqual(161)
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -277,6 +277,16 @@ const mapMe = (u: SessionUser): Me => ({
   brandprint: parseBrandprint(u.brandprint),
 })
 
+// A workspace content-search hit. Hand-written (not generated): the search endpoint's
+// `?format=json` shape is a plain route, not part of the OpenAPI contract.
+export interface SearchHit {
+  short_id: string
+  title: string
+  current_version: number
+  /** One line of the matching text, windowed around the match (server-side). */
+  snippet: string
+}
+
 export const api = {
   // The ONE identity read — behind meQuery, and re-read after login/signup to seed the
   // auth cache. Prerender-safe (null at build — no document); a resolved null for an
@@ -343,6 +353,19 @@ export const api = {
   // Find opted-in people by @handle or name (signed-in; empty q → []).
   searchPeople: (q: string): Promise<{ users: PublicProfile[] }> =>
     f(`/v1/users/search?query=${encodeURIComponent(q)}`, opts()).then(j),
+  // Content search across the workspace via the persisted index: hits ranked by
+  // relevance, each with a one-line snippet of WHERE it matched (visible text, so the
+  // snippet reads as prose). Empty q → []. A small `limit` keeps the palette's debounced
+  // typeahead to a few blob reads. Same visibility rules as list_artifacts.
+  searchContent: (q: string, limit = 6): Promise<{ hits: SearchHit[]; truncated: boolean }> => {
+    const term = q.trim()
+    return term
+      ? f(
+          `/v1/artifacts/search?format=json&in=text&limit=${limit}&query=${encodeURIComponent(term)}`,
+          opts(),
+        ).then(j)
+      : Promise.resolve({ hits: [], truncated: false })
+  },
   // The People directory: browse opted-in people (empty q) or search them (signed-in).
   // Unlike searchPeople, an empty query BROWSES the discoverable set.
   people: (q?: string): Promise<{ users: PublicProfile[] }> =>

--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -23,18 +23,25 @@ import { cn } from "@/lib/utils"
 import { refFor } from "@/pages/artifact/parse-ref"
 import { useShell } from "./shell-context"
 
+// The content group's data, carried together so the snippet is always highlighted
+// against the query it was FETCHED for — not the live input, which races ahead of the
+// (heavier, more debounced) content call and would briefly mis-highlight stale hits.
+type ContentState = { hits: SearchHit[]; truncated: boolean; q: string }
+const EMPTY_CONTENT: ContentState = { hits: [], truncated: false, q: "" }
+
 // Emphasize the query where it appears in a content snippet — the surrounding text is
 // muted (the caller styles it), the match reads at full weight. Splitting is pure +
-// tested in lib/highlight; here we just render the marked segments.
+// tested in lib/highlight; here we just render the marked segments. Index keys are safe:
+// the segments are stateless text spans, so a shifted boundary only re-renders text.
 function highlight(text: string, query: string): React.ReactNode[] {
   return splitMatches(text, query).map((seg, i) =>
     seg.match ? (
-      // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional + stable per render
+      // biome-ignore lint/suspicious/noArrayIndexKey: stateless text segments
       <span key={i} className="font-semibold text-foreground">
         {seg.text}
       </span>
     ) : (
-      // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional + stable per render
+      // biome-ignore lint/suspicious/noArrayIndexKey: stateless text segments
       <span key={i}>{seg.text}</span>
     ),
   )
@@ -54,7 +61,7 @@ export function CommandPalette() {
   const prefetch = usePrefetchArtifact()
   const [query, setQuery] = useState("")
   const [results, setResults] = useState<Artifact[]>([])
-  const [contentHits, setContentHits] = useState<SearchHit[]>([])
+  const [content, setContent] = useState<ContentState>(EMPTY_CONTENT)
   const [people, setPeople] = useState<PublicProfile[]>([])
   const [loading, setLoading] = useState(false)
   const [contentLoading, setContentLoading] = useState(false)
@@ -65,7 +72,7 @@ export function CommandPalette() {
     if (paletteOpen) {
       setQuery("")
       setResults([])
-      setContentHits([])
+      setContent(EMPTY_CONTENT)
       setPeople([])
     }
   }, [paletteOpen])
@@ -123,7 +130,7 @@ export function CommandPalette() {
     if (!paletteOpen) return
     const term = query.trim()
     if (term.length < 2) {
-      setContentHits([])
+      setContent(EMPTY_CONTENT)
       setContentLoading(false)
       return
     }
@@ -132,9 +139,9 @@ export function CommandPalette() {
     const t = setTimeout(() => {
       api
         .searchContent(term, 6)
-        .then((r) => alive && setContentHits(r.hits))
+        .then((r) => alive && setContent({ hits: r.hits, truncated: r.truncated, q: term }))
         // frontend-ignore: debounced typeahead — clearing on an aborted/failed keystroke is intended, not a hidden load failure
-        .catch(() => alive && setContentHits([]))
+        .catch(() => alive && setContent(EMPTY_CONTENT))
         .finally(() => alive && setContentLoading(false))
     }, 220)
     return () => {
@@ -152,7 +159,7 @@ export function CommandPalette() {
   // An artifact whose TITLE matched already shows in "Artifacts" — don't repeat it as a
   // content hit; the content group is for docs found only by what's inside them.
   const titleIds = new Set(results.map((r) => r.short_id))
-  const contentOnly = contentHits.filter((h) => !titleIds.has(h.short_id))
+  const contentOnly = content.hits.filter((h) => !titleIds.has(h.short_id))
   // Brandprint-pointed collections are managed on /brandprint, not jumped to here.
   const brandprintIds = useBrandprintCollectionIds()
   const matchedCollections = collections.filter(
@@ -254,19 +261,28 @@ export function CommandPalette() {
                   }
                   onMouseEnter={() => prefetch(h.short_id, h.current_version)}
                   onFocus={() => prefetch(h.short_id, h.current_version)}
-                  className="flex-col items-start gap-0.5"
+                  // Top-align: this is a two-line row (title over snippet), so the icon
+                  // sits with the title, not centered against the whole block. Keeping the
+                  // item flex-ROW (a flex-col child holds the two lines) leaves cmdk's
+                  // trailing check glyph in the row instead of adding a phantom third line.
+                  className="items-start"
                 >
-                  <div className="flex w-full items-center gap-2">
-                    <Icon name="all" size={16} className="text-muted-foreground" />
-                    <span className="flex-1 truncate">{h.title}</span>
+                  <Icon name="all" size={16} className="mt-0.5 text-muted-foreground" />
+                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="truncate">{h.title}</span>
+                    {h.snippet && (
+                      <span className="truncate text-xs text-muted-foreground">
+                        {highlight(h.snippet, content.q)}
+                      </span>
+                    )}
                   </div>
-                  {h.snippet && (
-                    <span className="w-full truncate pl-6 text-xs text-muted-foreground">
-                      {highlight(h.snippet, query)}
-                    </span>
-                  )}
                 </CommandItem>
               ))}
+              {content.truncated && (
+                <div className="px-2 py-1.5 text-2xs text-muted-foreground">
+                  More matches — refine the query to narrow.
+                </div>
+              )}
             </CommandGroup>
           )}
 

--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
-import { type Artifact, api, type PublicProfile, workspaceDisplayName } from "@/api"
+import { type Artifact, api, type PublicProfile, type SearchHit, workspaceDisplayName } from "@/api"
 import { Icon } from "@/components/icons"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import {
@@ -14,6 +14,7 @@ import {
   CommandList,
 } from "@/components/ui/command"
 import { colorForName } from "@/lib/avatar-tints"
+import { splitMatches } from "@/lib/highlight"
 import { getInitials } from "@/lib/initials"
 import { collectionsQuery, workspacesQuery } from "@/lib/queries"
 import { useBrandprintCollectionIds } from "@/lib/use-brandprint-ids"
@@ -21,6 +22,23 @@ import { usePrefetchArtifact } from "@/lib/use-prefetch-artifact"
 import { cn } from "@/lib/utils"
 import { refFor } from "@/pages/artifact/parse-ref"
 import { useShell } from "./shell-context"
+
+// Emphasize the query where it appears in a content snippet — the surrounding text is
+// muted (the caller styles it), the match reads at full weight. Splitting is pure +
+// tested in lib/highlight; here we just render the marked segments.
+function highlight(text: string, query: string): React.ReactNode[] {
+  return splitMatches(text, query).map((seg, i) =>
+    seg.match ? (
+      // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional + stable per render
+      <span key={i} className="font-semibold text-foreground">
+        {seg.text}
+      </span>
+    ) : (
+      // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional + stable per render
+      <span key={i}>{seg.text}</span>
+    ),
+  )
+}
 
 // ⌘K palette: jump to any artifact (server search) or to a feed (All / Favorites /
 // Following), a collection, or another workspace — from anywhere, incl. inside an artifact.
@@ -36,8 +54,10 @@ export function CommandPalette() {
   const prefetch = usePrefetchArtifact()
   const [query, setQuery] = useState("")
   const [results, setResults] = useState<Artifact[]>([])
+  const [contentHits, setContentHits] = useState<SearchHit[]>([])
   const [people, setPeople] = useState<PublicProfile[]>([])
   const [loading, setLoading] = useState(false)
+  const [contentLoading, setContentLoading] = useState(false)
   const [peopleLoading, setPeopleLoading] = useState(false)
 
   // Fresh query each open.
@@ -45,6 +65,7 @@ export function CommandPalette() {
     if (paletteOpen) {
       setQuery("")
       setResults([])
+      setContentHits([])
       setPeople([])
     }
   }, [paletteOpen])
@@ -94,12 +115,44 @@ export function CommandPalette() {
     }
   }, [query, paletteOpen])
 
+  // Debounced CONTENT search (the persisted index) — finds artifacts by what's inside
+  // them, not just their title, with a snippet of the match. Gated to ≥2 chars and a
+  // small limit so a debounced keystroke reads only a few blobs. Slightly longer debounce
+  // than the title lookup: it's the heavier call.
+  useEffect(() => {
+    if (!paletteOpen) return
+    const term = query.trim()
+    if (term.length < 2) {
+      setContentHits([])
+      setContentLoading(false)
+      return
+    }
+    let alive = true
+    setContentLoading(true)
+    const t = setTimeout(() => {
+      api
+        .searchContent(term, 6)
+        .then((r) => alive && setContentHits(r.hits))
+        // frontend-ignore: debounced typeahead — clearing on an aborted/failed keystroke is intended, not a hidden load failure
+        .catch(() => alive && setContentHits([]))
+        .finally(() => alive && setContentLoading(false))
+    }, 220)
+    return () => {
+      alive = false
+      clearTimeout(t)
+    }
+  }, [query, paletteOpen])
+
   const go = (fn: () => void) => {
     setPaletteOpen(false)
     fn()
   }
 
   const q = query.trim().toLowerCase()
+  // An artifact whose TITLE matched already shows in "Artifacts" — don't repeat it as a
+  // content hit; the content group is for docs found only by what's inside them.
+  const titleIds = new Set(results.map((r) => r.short_id))
+  const contentOnly = contentHits.filter((h) => !titleIds.has(h.short_id))
   // Brandprint-pointed collections are managed on /brandprint, not jumped to here.
   const brandprintIds = useBrandprintCollectionIds()
   const matchedCollections = collections.filter(
@@ -128,7 +181,9 @@ export function CommandPalette() {
           placeholder="Search artifacts, people, collections…"
         />
         <CommandList>
-          <CommandEmpty>{loading ? "Searching…" : "No results."}</CommandEmpty>
+          <CommandEmpty>
+            {loading || contentLoading || peopleLoading ? "Searching…" : "No results."}
+          </CommandEmpty>
 
           {(showAll || showFav || showFollowing) && (
             <CommandGroup heading="Jump to">
@@ -180,6 +235,36 @@ export function CommandPalette() {
                   <span className="font-mono text-2xs text-muted-foreground tabular-nums">
                     v{a.current_version}
                   </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+
+          {contentOnly.length > 0 && (
+            <CommandGroup
+              heading="In content"
+              className={cn(contentLoading && "opacity-60 transition-opacity")}
+            >
+              {contentOnly.map((h) => (
+                <CommandItem
+                  key={`content-${h.short_id}`}
+                  value={`content-${h.short_id}`}
+                  onSelect={() =>
+                    go(() => nav({ to: "/artifacts/$ref", params: { ref: refFor(h) } }))
+                  }
+                  onMouseEnter={() => prefetch(h.short_id, h.current_version)}
+                  onFocus={() => prefetch(h.short_id, h.current_version)}
+                  className="flex-col items-start gap-0.5"
+                >
+                  <div className="flex w-full items-center gap-2">
+                    <Icon name="all" size={16} className="text-muted-foreground" />
+                    <span className="flex-1 truncate">{h.title}</span>
+                  </div>
+                  {h.snippet && (
+                    <span className="w-full truncate pl-6 text-xs text-muted-foreground">
+                      {highlight(h.snippet, query)}
+                    </span>
+                  )}
                 </CommandItem>
               ))}
             </CommandGroup>

--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -34,7 +34,9 @@ const EMPTY_CONTENT: ContentState = { hits: [], truncated: false, q: "" }
 // tested in lib/highlight; here we just render the marked segments. Index keys are safe:
 // the segments are stateless text spans, so a shifted boundary only re-renders text.
 function highlight(text: string, query: string): React.ReactNode[] {
-  return splitMatches(text, query).map((seg, i) =>
+  // Collapse the query's whitespace to match the server-collapsed snippet, so a multi-space
+  // query is still located (and highlighted) in the single-spaced snippet text.
+  return splitMatches(text, query.replace(/\s+/g, " ")).map((seg, i) =>
     seg.match ? (
       // biome-ignore lint/suspicious/noArrayIndexKey: stateless text segments
       <span key={i} className="font-semibold text-foreground">
@@ -280,7 +282,7 @@ export function CommandPalette() {
               ))}
               {content.truncated && (
                 <div className="px-2 py-1.5 text-2xs text-muted-foreground">
-                  More matches — refine the query to narrow.
+                  More may match — refine to narrow.
                 </div>
               )}
             </CommandGroup>

--- a/apps/web/src/lib/highlight.test.ts
+++ b/apps/web/src/lib/highlight.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+import { splitMatches } from "./highlight"
+
+describe("splitMatches", () => {
+  it("marks case-insensitive literal matches, preserving original casing + surrounding text", () => {
+    expect(splitMatches("the Kestrel and the kestrel", "kestrel")).toEqual([
+      { text: "the ", match: false },
+      { text: "Kestrel", match: true },
+      { text: " and the ", match: false },
+      { text: "kestrel", match: true },
+    ])
+  })
+
+  it("returns the whole text unmarked when the query is empty or unmatched", () => {
+    expect(splitMatches("hello world", "")).toEqual([{ text: "hello world", match: false }])
+    expect(splitMatches("hello world", "   ")).toEqual([{ text: "hello world", match: false }])
+    expect(splitMatches("hello world", "xyz")).toEqual([{ text: "hello world", match: false }])
+  })
+
+  it("handles a match at the very start and the very end", () => {
+    expect(splitMatches("foobar", "foo")).toEqual([
+      { text: "foo", match: true },
+      { text: "bar", match: false },
+    ])
+    expect(splitMatches("barfoo", "foo")).toEqual([
+      { text: "bar", match: false },
+      { text: "foo", match: true },
+    ])
+  })
+})

--- a/apps/web/src/lib/highlight.ts
+++ b/apps/web/src/lib/highlight.ts
@@ -1,0 +1,20 @@
+// Split `text` into segments, marking the ones that literally match `query`
+// (case-insensitive). The pure basis for highlighting a search snippet — no regex is
+// built from user input, and the original casing is preserved in the output.
+export function splitMatches(text: string, query: string): { text: string; match: boolean }[] {
+  const term = query.trim()
+  if (!term) return text ? [{ text, match: false }] : []
+  const lower = text.toLowerCase()
+  const needle = term.toLowerCase()
+  const out: { text: string; match: boolean }[] = []
+  let from = 0
+  let at = lower.indexOf(needle)
+  while (at !== -1) {
+    if (at > from) out.push({ text: text.slice(from, at), match: false })
+    out.push({ text: text.slice(at, at + term.length), match: true })
+    from = at + term.length
+    at = lower.indexOf(needle, from)
+  }
+  if (from < text.length) out.push({ text: text.slice(from), match: false })
+  return out
+}


### PR DESCRIPTION
Stacked on #422. Cashes in the persisted search index for **humans**: the ⌘K palette (and the library filter) matched **titles only** (`listArtifacts({q})` = `title LIKE %q%`), while agents could already search the whole corpus by content. So a person who remembered a phrase *inside* a doc but not its title got nothing. This wires the palette to the index — Notion-Quick-Find style.

## Backend
- `GET /v1/artifacts/search?format=json` → a small, ranked hit list `{short_id, title, current_version, snippet}` instead of the agent-facing ripgrep text report. **Same `searchWorkspace`, same visibility gate** — results are visibility-filtered *before* `toSearchHits`, so it can't leak more than the text path (a private/removed artifact still can't surface).
- A bounded `limit` (1..12) caps grep-confirm so a debounced keystroke reads only a few blobs; the `snippet` is the matching line windowed around the match.

## Frontend
- The palette gains an **"In content"** group: debounced (≥2 chars), relevance-ranked, each row a title + a one-line snippet with the query **highlighted**, and deduped against the title matches so an artifact found both ways shows once.
- Snippet highlighting split into a pure, **unit-tested** `lib/highlight` (`splitMatches`).

## Tests / gates
`search-rest`: `?format=json` returns ranked hits with a match snippet, and a no-match query returns `[]` (visibility is the shared `searchWorkspace` gate). `lib/highlight` unit test covers case-insensitive literal matches, start/end boundaries, empty/absent query. Full local `api` (930) + `web` (153) suites green (the 2 `oauth-refresh-rotation` failures are the known local-only flake). All 15 precommit guards pass.

## Deliberate follow-ups (own concerns, not this PR)
- Content search in the **library filter** + fixing its URL-share bug (a "searched library" isn't currently deep-linkable).
- A dedicated **/search results page** with filters for deep search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)