### PR TITLE
Don't leak a password-locked artifact's content via workspace search

### DIFF
--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -480,15 +480,20 @@ export const searchWorkspace = async (
     })
     visible.push(...rows)
   }
+  // A password lock gates the world-link CONTENT behind a password — read 401s without it.
+  // The publicOnly caller IS that anonymous/link visitor, so drop locked artifacts here,
+  // else their body would be grep-readable, bypassing the unlock. A member (viewerId)
+  // reaches content through membership, not the link, so the lock never applies to them.
+  const gated = opts.publicOnly ? visible.filter((a) => !a.password_hash) : visible
   // listArtifacts returns in its own (recency) order; restore relevance order.
-  visible.sort((a, b) => (rankOf.get(a.id) ?? Infinity) - (rankOf.get(b.id) ?? Infinity))
+  gated.sort((a, b) => (rankOf.get(a.id) ?? Infinity) - (rankOf.get(b.id) ?? Infinity))
 
   // Grep-confirm only the top-N most-relevant survivors — the blob-read+scan is the
   // real cost, so it stays bounded. A candidate the index nominated on token overlap
   // but whose exact literal/scope isn't actually present yields no hunks and drops out
   // here: the index is RECALL, the grep is PRECISION.
   const grepCap = opts.limit ?? WORKSPACE_SEARCH_ARTIFACT_CAP
-  const toGrep = visible.slice(0, grepCap)
+  const toGrep = gated.slice(0, grepCap)
   // 4, not searchArtifactVersion's inner 8: the two fan-outs compose (a batch of
   // bundles each opens its own 8-wide page fan-out), so peak blob reads is the product
   // — 4×8=32 keeps that worst case reasonable without a cross-cutting semaphore.
@@ -525,9 +530,9 @@ export const searchWorkspace = async (
   // wording says "candidates", never "matches". `grepTruncated`: more visible candidates
   // than we confirmed. `moreCandidates`: the index had still more below the window
   // (detected by the over-fetched sentinel) — hence the `+`.
-  const grepTruncated = visible.length > grepCap
+  const grepTruncated = gated.length > grepCap
   const note = grepTruncated
-    ? `ranked by relevance — grep-confirmed the top ${grepCap} of ${visible.length}${
+    ? `ranked by relevance — grep-confirmed the top ${grepCap} of ${gated.length}${
         moreCandidates ? "+" : ""
       } candidate artifacts you can see; refine the query to reach the rest`
     : moreCandidates

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -10,7 +10,13 @@ import { exportJWK, generateKeyPair, SignJWT } from "jose"
 import { afterAll, describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
 import { sha256 } from "../src/lib/crypto"
-import { MAX_INDEX_TEXT, reindexSearchBatch, versionIndexText } from "../src/lib/search"
+import {
+  MAX_INDEX_TEXT,
+  reindexSearchBatch,
+  searchMatcher,
+  searchWorkspace,
+  versionIndexText,
+} from "../src/lib/search"
 
 // The remote MCP endpoint (/mcp) authenticated by an OAuth bearer. We seed a grant
 // straight into the oauth-provider tables (what the consent dance produces), publish
@@ -1033,6 +1039,63 @@ describe("remote MCP endpoint (/mcp)", () => {
     // contiguous literal finds nothing → honestly "No matches", never a false hit.
     const res = toolText(await call(app, token, "search", { query: "alpha omega" }))
     expect(res).toContain("No matches")
+  })
+
+  it("searchWorkspace hides a public-but-password-locked artifact's content from the anonymous (publicOnly) path, not from members", async () => {
+    const { app, token, meta, blobs } = appWithGrant("wslock", "openid derive:read derive:publish")
+    const seed = (await (await publishRaw(app, token, "# Seed", "seed.md", "Seed")).json()).short_id
+    const owner = await meta.getByShortId(seed)
+    if (!owner) throw new Error("expected the seed artifact to exist")
+    const org = owner.org_id
+    const key = await blobs.put(new TextEncoder().encode("the gatedneedle lives inside"))
+    // Two PUBLIC-listed artifacts with the same content; one is password-locked (a lock on
+    // its world link). The content differs only in whether reading it needs the password.
+    const mk = async (id: string, locked: boolean) => {
+      await meta.createArtifact({
+        id,
+        short_id: id,
+        org_id: org,
+        slug: null,
+        title: `Doc ${id}`,
+        workspace_access: "member",
+        link_role: "viewer",
+        listed: "public",
+        password_hash: locked ? "a-real-hash" : null,
+        kind: "file",
+        spa: 0,
+      })
+      await meta.addVersion(id, {
+        id: `v_${id}`,
+        blob_key: key,
+        content_type: "text/markdown",
+        author: "o",
+        message: null,
+      })
+      await meta.indexArtifact(id, org, `Doc ${id}`, "the gatedneedle lives inside")
+    }
+    await mk("aopen", false)
+    await mk("alock", true)
+    const sourceText = async (v: { blob_key: string; content_type: string }) => {
+      const b = await blobs.get(v.blob_key)
+      return b ? new TextDecoder().decode(b) : null
+    }
+    const deps = { blobs, sourceText, meta }
+    const base = {
+      orgId: org,
+      query: "gatedneedle",
+      re: searchMatcher("gatedneedle", false),
+      where: "text" as const,
+      ctxLines: 0,
+      cap: 40,
+    }
+    // Anonymous / non-member (publicOnly): the locked doc's body must NOT be grep-readable —
+    // reading it needs the password, and search must not bypass that.
+    const anon = await searchWorkspace(deps, { ...base, publicOnly: true })
+    expect(anon.results.map((r) => r.short_id).sort()).toEqual(["aopen"])
+    // A member/trusted caller (no publicOnly) reaches content through membership, not the
+    // link, so the lock doesn't apply — both surface.
+    const member = await searchWorkspace(deps, base)
+    expect(member.results.map((r) => r.short_id).sort()).toEqual(["alock", "aopen"])
   })
 
   it("versionIndexText degrades safely on the non-happy paths (never throws)", async () => {


### PR DESCRIPTION
Follow-up from the search-index audit (one of the items we flagged along the way).

A password lock gates an artifact's world-link **content** behind a password — the read path 401s without it. But workspace search greps the body, and the anonymous / non-member (`publicOnly`) path would return snippets of a public-but-locked artifact, **bypassing the unlock**.

- Scope: the `publicOnly` REST path only. Members reach content through membership (not the link), so the lock never applied to them — and the ⌘K palette is member-only, so it never hit this.
- Fix: in `searchWorkspace`, when `publicOnly`, drop artifacts with a `password_hash` before grep-confirm — the same shape as the `excludeRemoved` tombstone gate. Members / trusted operators are unaffected: a locked doc they can already read still surfaces for them.
- Test (direct `searchWorkspace`): a public+locked and a public+open artifact with the same body — `publicOnly` returns only the open one; a non-`publicOnly` caller gets both.

Stacked on #423 (touches `searchWorkspace`). No product decision needed — members should see it, anonymous shouldn't get locked content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)