### PR TITLE
Make a filtered library shareable (write the search back to the URL)

### DIFF
--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -113,6 +113,18 @@ function LibraryBody({ view }: { view: LibraryView }) {
     const t = setTimeout(() => setDebouncedQ(query.trim()), 280)
     return () => clearTimeout(t)
   }, [query])
+  // Reflect the SETTLED search in the URL so a filtered library is shareable/deep-linkable —
+  // the field seeds FROM ?query= above but must also write back. `replace` so keystrokes
+  // don't stack history; the guard skips a no-op nav (and its re-render loop). Keeps the
+  // current route (one of five feeds) and the other params (tag/collection/author).
+  useEffect(() => {
+    if (debouncedQ === (search.query ?? "").trim()) return
+    nav({
+      to: ".",
+      search: (prev) => ({ ...prev, query: debouncedQ || undefined }),
+      replace: true,
+    })
+  }, [debouncedQ, search.query, nav])
   // "Searching" tracks the LIVE input, not the debounced value — so the greeting/publish/
   // triage collapse the instant you type, not 280 ms later (the old whole-header jump).
   // Results still key off the debounced value (network), so requests stay throttled.


### PR DESCRIPTION
A small follow-up we spotted while mapping the frontend search surface.

The library filter field seeds **from** `?query=` but never wrote **back**: typing updated local state + the feed, but the URL stayed put — so a "searched library" wasn't actually deep-linkable/shareable, despite the field placeholder and the route intent implying it is.

Fix: an effect reflects the **settled** (debounced) search in the URL, preserving the current feed (one of five routes) and the other params (tag/collection/author), with `replace` so keystrokes don't stack history and a guard so a no-op can't loop. Opening a shared `?query=` link still seeds the field as before, so both directions now work.

Independent of the search-index / palette PRs (touches only the library route) — based on `main`, so it can merge on its own.

Note: this is a router-sync effect (typecheck-clean, logic traced) — it has no unit-testable surface without an e2e; the smoke suite exercises the app broadly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)