### PR TITLE
Wire DERIVE_TOKEN into the edge worker (operator-token auth was dead on prod)

### DIFF
--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -104,6 +104,7 @@ export interface Env {
   ASSETS: Fetcher
   BASE_URL?: string
   DERIVE_AUTH_SECRET?: string
+  DERIVE_TOKEN?: string
   DERIVE_SANDBOX_URL?: string
   DERIVE_SUPERADMIN_EMAILS?: string
   // Base domain for vanity subdomains (domain mode); unset = off.
@@ -198,6 +199,11 @@ const handle = (req: Request, env: Env, ctx: ExecutionContext): Response | Promi
       })
       app = createApp({
         meta,
+        // The static operator/CI bearer (isToken). The Node entry wires this via
+        // loadConfig(process.env); the edge builds deps by hand from the CF binding and
+        // had omitted it, so operator-token auth (reindex, and any DERIVE_TOKEN automation)
+        // was dead on prod. Undefined when unset ⇒ isToken stays false, as before.
+        token: env.DERIVE_TOKEN,
         blobs: new R2BlobStore(env.BUCKET),
         backplane: createDoBackplane(env.ROOMS),
         baseUrl,


### PR DESCRIPTION
**Bug:** `worker.ts` (the CF/edge entry) builds `createApp` deps by hand from the `env` binding and never passed `token: env.DERIVE_TOKEN`. So `isToken()` is always false on the edge — the operator-token path (the new `/v1/system/search-reindex`, and any `DERIVE_TOKEN`-based CI/automation) is **dead on prod**. It worked on the Node/self-host entry (which reads `process.env.DERIVE_TOKEN` via `loadConfig`). Latent because nothing had used operator-token auth on the edge before the reindex endpoint.

**Fix:** wire `token: env.DERIVE_TOKEN` in the edge `createApp` deps, and declare `DERIVE_TOKEN?: string` on the `Env` type. Undefined when the secret is unset ⇒ `isToken` stays false, so there's no behavior change unless `DERIVE_TOKEN` is configured.

**Verification:** typecheck (incl. `tsconfig.worker`) + biome clean; `isToken` behavior is already covered on the Node path (`search-rest` / `mcp` tests pass a `token`); the edge wiring is confirmed end-to-end post-deploy by an operator curl against `/v1/system/search-reindex` (a 1-line env-binding fix has no clean miniflare unit surface — the live check is the proof).

Hotfix to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)