### PR TITLE
fix(search): gate locked-artifact content on the read grant, not publicOnly

### DIFF
--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -480,11 +480,22 @@ export const searchWorkspace = async (
     })
     visible.push(...rows)
   }
-  // A password lock gates the world-link CONTENT behind a password — read 401s without it.
-  // The publicOnly caller IS that anonymous/link visitor, so drop locked artifacts here,
-  // else their body would be grep-readable, bypassing the unlock. A member (viewerId)
-  // reaches content through membership, not the link, so the lock never applies to them.
-  const gated = opts.publicOnly ? visible.filter((a) => !a.password_hash) : visible
+  // A password lock suspends the WORLD LINK until unlocked — `effectiveRole` (permissions.ts)
+  // makes `locked && !unlocked` ⇒ the link grants nothing. So a locked artifact is readable
+  // ONLY through a non-link grant: a workspace SEAT (workspace_access:"member" opened by a
+  // member) or an explicit share. `listArtifacts` is the LISTING gate, not the read gate — a
+  // {listed:"public", workspace_access:"none", link_role:"viewer", password:…} doc lists to a
+  // member, yet they can open it only via the (locked) link, so its body must not be
+  // grep-readable to them (read would 401 "password required"). Keep a locked artifact only
+  // when the caller's SEAT grants read: a member (not publicOnly) on a workspace_access:"member"
+  // doc. Anonymous/link-only callers — and the rare member reachable solely by an explicit
+  // share on a workspace_access:"none" lock — are conservatively dropped: a safe recall loss,
+  // never a leak. (A per-candidate `authorize(c,"read",a)` would also honor explicit shares and
+  // unlock cookies, but the MCP entry point has no request Context to build that actor from, so
+  // this seat-only predicate is the uniform floor both callers share.)
+  const gated = visible.filter(
+    (a) => !a.password_hash || (!opts.publicOnly && a.workspace_access === "member"),
+  )
   // listArtifacts returns in its own (recency) order; restore relevance order.
   gated.sort((a, b) => (rankOf.get(a.id) ?? Infinity) - (rankOf.get(b.id) ?? Infinity))
 

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -56,9 +56,12 @@ export const systemRoutes = (ctx: AppContext) => {
   // Backfill the workspace search index over the EXISTING corpus. Publishing keeps the
   // index current going forward (emitVersionBump), but artifacts published before that
   // wiring — or created outside it — need a one-time sweep. Operator-only, idempotent,
-  // and bounded: it indexes one page (default 100, max 500) and returns `nextCursor`;
-  // the operator re-POSTs with that cursor until it comes back null. Keeping each call
-  // bounded is what fits the Workers CPU budget rather than one unbounded pass. Run it as
+  // and bounded: it indexes one page (default 100, max 200) and returns `nextCursor`;
+  // the operator re-POSTs with that cursor until it comes back null. The cap stays modest
+  // because a bundle indexes every page it holds — a bundle-dense page of 500 could breach
+  // the Worker's per-invocation subrequest ceiling, which the per-artifact try/catch would
+  // silently swallow as "skipped." Keeping each call bounded is what fits the Workers CPU +
+  // subrequest budget rather than one unbounded pass. Run it as
   // a one-time backfill: under a concurrent live publish it could momentarily write
   // older-version text for that artifact, but grep-confirm reads the live blob (so
   // precision holds) and the next publish re-indexes it — the staleness self-heals.
@@ -71,15 +74,18 @@ export const systemRoutes = (ctx: AppContext) => {
       c,
       z.object({
         orgId: z.string().optional(),
-        cursor: z.object({ created_at: z.string(), id: z.string() }).optional(),
+        // `.nullish()`: the natural resume loop echoes back the previous `nextCursor`, which is
+        // literally `null` on the final page — accept it as "start from the top" rather than 400.
+        cursor: z.object({ created_at: z.string(), id: z.string() }).nullish(),
         limit: z.number().int().optional(),
       }),
     )
     if (body instanceof Response) return body
-    const limit = Math.min(Math.max(body.limit ?? 100, 1), 500)
+    const limit = Math.min(Math.max(body.limit ?? 100, 1), 200)
     const result = await reindexSearchBatch(
       { meta, blobs },
-      { orgId: body.orgId, cursor: body.cursor, limit },
+      // Normalize null→undefined: reindexSearchBatch's keyset cursor is `{…} | undefined`.
+      { orgId: body.orgId, cursor: body.cursor ?? undefined, limit },
     )
     return c.json(result)
   })

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -1041,23 +1041,23 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(res).toContain("No matches")
   })
 
-  it("searchWorkspace hides a public-but-password-locked artifact's content from the anonymous (publicOnly) path, not from members", async () => {
+  it("searchWorkspace hides a password-locked artifact's content unless the caller reads it via a workspace SEAT (not the locked link)", async () => {
     const { app, token, meta, blobs } = appWithGrant("wslock", "openid derive:read derive:publish")
     const seed = (await (await publishRaw(app, token, "# Seed", "seed.md", "Seed")).json()).short_id
     const owner = await meta.getByShortId(seed)
     if (!owner) throw new Error("expected the seed artifact to exist")
     const org = owner.org_id
     const key = await blobs.put(new TextEncoder().encode("the gatedneedle lives inside"))
-    // Two PUBLIC-listed artifacts with the same content; one is password-locked (a lock on
-    // its world link). The content differs only in whether reading it needs the password.
-    const mk = async (id: string, locked: boolean) => {
+    // Three PUBLIC-listed artifacts with the same content. A password locks the WORLD LINK;
+    // whether the caller can still read the body turns on whether they hold a NON-link grant.
+    const mk = async (id: string, locked: boolean, workspace_access: "member" | "none") => {
       await meta.createArtifact({
         id,
         short_id: id,
         org_id: org,
         slug: null,
         title: `Doc ${id}`,
-        workspace_access: "member",
+        workspace_access,
         link_role: "viewer",
         listed: "public",
         password_hash: locked ? "a-real-hash" : null,
@@ -1073,8 +1073,11 @@ describe("remote MCP endpoint (/mcp)", () => {
       })
       await meta.indexArtifact(id, org, `Doc ${id}`, "the gatedneedle lives inside")
     }
-    await mk("aopen", false)
-    await mk("alock", true)
+    await mk("aopen", false, "member") // no lock
+    await mk("alock", true, "member") // locked, but a member's SEAT reads it (not the link)
+    // Locked AND workspace_access:"none": a member can reach it only through the (locked) link,
+    // so its body must stay hidden from them — reading it would 401 "password required".
+    await mk("alocknone", true, "none")
     const sourceText = async (v: { blob_key: string; content_type: string }) => {
       const b = await blobs.get(v.blob_key)
       return b ? new TextDecoder().decode(b) : null
@@ -1088,12 +1091,12 @@ describe("remote MCP endpoint (/mcp)", () => {
       ctxLines: 0,
       cap: 40,
     }
-    // Anonymous / non-member (publicOnly): the locked doc's body must NOT be grep-readable —
-    // reading it needs the password, and search must not bypass that.
+    // Anonymous / non-member (publicOnly): every locked doc's body must be non-grep-readable —
+    // reading needs the password, and search must not bypass that.
     const anon = await searchWorkspace(deps, { ...base, publicOnly: true })
     expect(anon.results.map((r) => r.short_id).sort()).toEqual(["aopen"])
-    // A member/trusted caller (no publicOnly) reaches content through membership, not the
-    // link, so the lock doesn't apply — both surface.
+    // A member (no publicOnly) surfaces the unlocked doc AND the seat-readable lock — but NOT
+    // the workspace_access:"none" lock, which they could only open via the locked link.
     const member = await searchWorkspace(deps, base)
     expect(member.results.map((r) => r.short_id).sort()).toEqual(["alock", "aopen"])
   })

--- a/apps/api/test/system-capabilities.test.ts
+++ b/apps/api/test/system-capabilities.test.ts
@@ -36,3 +36,29 @@ describe("GET /v1/system/capabilities", () => {
     expect(body.capabilities.find((c) => c.id === "email")?.status).toBe("on")
   })
 })
+
+describe("POST /v1/system/search-reindex", () => {
+  it("accepts cursor:null as 'start from the top' — the natural resume loop echoes the final nextCursor back", async () => {
+    // A resumable client re-POSTs the previous `nextCursor`, which is literally `null` on the
+    // last page. The endpoint's `cursor` is `.nullish()`, so that must be a 200 (start over),
+    // not a 400 — otherwise a curl loop that doesn't special-case null wedges on its own output.
+    const res = await app.request("/v1/system/search-reindex", {
+      method: "POST",
+      headers: { ...bearer(TEST_TOKEN), "content-type": "application/json" },
+      body: JSON.stringify({ cursor: null, limit: 1 }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { scanned: number; indexed: number; nextCursor: unknown }
+    expect(typeof body.scanned).toBe("number")
+    expect(typeof body.indexed).toBe("number")
+  })
+
+  it("forbids a non-operator", async () => {
+    const res = await anonApp.request("/v1/system/search-reindex", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ limit: 1 }),
+    })
+    expect(res.status).toBe(403)
+  })
+})


### PR DESCRIPTION
Post-deploy audit of the persisted workspace search index (the arc from #422–#426) surfaced one **HIGH** content leak and two reindex footguns. All three are fixed here with regression tests.

## 1. Password-leak (HIGH) — `apps/api/src/lib/search.ts`
`searchWorkspace` dropped password-locked artifacts **only on the `publicOnly` (anonymous) path**. A signed-in workspace **member** searching therefore got the grep-confirmed body of a
`{listed:"public", workspace_access:"none", link_role:"viewer", password:…}` artifact — a doc they can open *only* via the locked link, where the read route 401s `"password required"`.

A password suspends the **world link**, not membership: `effectiveRole` (permissions.ts) makes `locked && !unlocked ⇒ the link grants nothing`, so a locked doc is readable solely through a **non-link** grant — a workspace **seat** or an explicit share. The gate now keeps a locked artifact only when the caller's **seat** grants read (a member, not `publicOnly`, on a `workspace_access:"member"` doc). Anonymous/link-only callers — and the rare member reachable only by an explicit share on a `workspace_access:"none"` lock — are conservatively dropped: **a safe recall loss, never a leak.**

Uniform across both entry points. The exact fix would be a per-candidate `authorize(c,"read",a)`, but the **MCP** search tool has no request `Context` to build that actor from, so this seat-only predicate is the shared floor both callers use. (Documented inline.)

## 2. Reindex `cursor:null` → 400 — `apps/api/src/routes/system.ts`
The natural resume loop echoes the previous `nextCursor` back, which is **literally `null` on the final page**. `cursor` was `.optional()` (rejects `null`), so a curl loop that didn't special-case null 400'd on its own output. Now `.nullish()`, normalized `null→undefined` for the keyset.

## 3. Reindex `limit` ceiling 500 → 200 — `apps/api/src/routes/system.ts`
A bundle indexes every page it holds, so a bundle-dense page of 500 could breach the Worker's per-invocation **subrequest cap** — which the per-artifact `try/catch` would silently swallow as `"skipped"` (silent under-indexing). Ceiling lowered to 200 (default stays 100).

## Tests
- `workspace_access:"none"` lock stays hidden from a member; the seat-readable `workspace_access:"member"` lock still surfaces; anonymous sees neither lock.
- Reindex endpoint accepts `cursor:null` with 200; forbids a non-operator.

## Gates
Typecheck, biome, all 15 precommit lints (api/schema/api-types contract), and the full API suite green (the 2 `oauth-refresh-rotation` local failures are the known stale-patch-hash flake — pass in CI).

## Follow-up (deferred, not in this PR)
Library `?query=` URL-sync (`pages/library/index.tsx`) ships correctly but is one-way state→URL: a tag-click / clear-filters nav that drops `query` is silently re-asserted if the search box still holds text. The reviewer-recommended fix (clear the local draft on those navs) carries a product-judgment nuance — surfaced separately rather than bundled into a security hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)