### PR TITLE
fix(web): theme-aware SVG favicon that follows the browser color scheme

### DIFF
--- a/apps/web/public/brand/favicon.svg
+++ b/apps/web/public/brand/favicon.svg
@@ -1,0 +1,44 @@
+<svg width="855" height="1138" viewBox="0 0 855 1138" fill="none" xmlns="http://www.w3.org/2000/svg">
+<style>
+/* Dark glyph on light browser chrome, light glyph on dark — the tab strip
+   follows the browser/OS theme, not the in-app theme toggle. */
+stop { stop-color: #030712 }
+@media (prefers-color-scheme: dark) {
+  stop { stop-color: #F4F5F8 }
+}
+</style>
+<g clip-path="url(#clip0_165_323)">
+<path d="M633.41 555.59V643.55L816.82 537.71L740.95 493.9C738.38 495.73 735.75 497.48 732.97 499.05L633.41 555.58V555.59Z" fill="url(#paint0_linear_165_323)"/>
+<path d="M480.981 729.889V643.369L297.551 749.269L373.901 793.379C375.661 792.169 377.461 790.999 379.321 789.909L480.991 729.879L480.981 729.889Z" fill="url(#paint1_linear_165_323)"/>
+<path d="M557.2 0L259.43 171.85V471.69L0 621.44V965.16L297.56 1137.15L595.28 965.16C595.28 965.16 594.81 412.97 595.14 409.72C598.23 380.41 615.16 354.09 641.12 339.37L642.02 338.83C703.35 303.99 779.53 348.26 779.53 418.84V419.04C779.53 448.99 764.99 476.72 740.97 493.95L816.85 537.74L854.98 515.71V171.85L557.19 0H557.2ZM259.44 1027.06L76.16 921.17V709.45L259.44 815.41V1027.06ZM473.97 947.8L472.32 948.77C410.96 984.38 334.07 940.09 334.07 869.17C334.07 838.75 349.07 810.52 373.91 793.38L114.25 643.38L114.2 643.33L334.06 516.65L335.64 515.7V259.83L519.06 365.79L519.8 868.06C519.87 900.91 502.39 931.27 473.96 947.8H473.97ZM557.2 299.84L373.71 193.95L557.2 87.99L740.62 193.95L557.2 299.84Z" fill="url(#paint2_linear_165_323)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_165_323" x1="768.32" y1="531.92" x2="618.74" y2="599.79" gradientUnits="userSpaceOnUse">
+<stop/>
+<stop offset="0.09" stop-opacity="0.97"/>
+<stop offset="0.22" stop-opacity="0.88"/>
+<stop offset="0.38" stop-opacity="0.74"/>
+<stop offset="0.57" stop-opacity="0.55"/>
+<stop offset="0.78" stop-opacity="0.29"/>
+<stop offset="1" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint1_linear_165_323" x1="337.741" y1="776.319" x2="491.981" y2="666.349" gradientUnits="userSpaceOnUse">
+<stop/>
+<stop offset="0.09" stop-opacity="0.97"/>
+<stop offset="0.2" stop-opacity="0.91"/>
+<stop offset="0.34" stop-opacity="0.79"/>
+<stop offset="0.49" stop-opacity="0.63"/>
+<stop offset="0.65" stop-opacity="0.43"/>
+<stop offset="0.82" stop-opacity="0.18"/>
+<stop offset="0.93" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint2_linear_165_323" x1="-72" y1="708.87" x2="927.02" y2="428.2" gradientUnits="userSpaceOnUse">
+<stop/>
+<stop offset="0.2"/>
+<stop offset="1"/>
+</linearGradient>
+<clipPath id="clip0_165_323">
+<rect width="855" height="1138" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -62,7 +62,9 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
       { title: "Derive" },
     ],
     links: [
-      { rel: "icon", type: "image/svg+xml", href: "/brand/logo-light.svg" },
+      // Theme-aware: dark glyph on light browser chrome, light on dark
+      // (prefers-color-scheme media query inside the SVG).
+      { rel: "icon", type: "image/svg+xml", href: "/brand/favicon.svg" },
       { rel: "icon", type: "image/png", href: "/brand/favicon.png" },
       { rel: "apple-touch-icon", href: "/brand/favicon.png" },
       // Fonts are self-hosted via @fontsource-variable imports in globals.css —


### PR DESCRIPTION
## Summary
- The `rel=icon` SVG pointed at `logo-light.svg` — a light glyph (`#F4F5F8`) that is effectively invisible against a light browser tab strip.
- Adds `brand/favicon.svg`: same geometry (the light/dark logo SVGs share identical paths), with an embedded `prefers-color-scheme` media query — dark glyph (`#030712`) on light browser chrome, light (`#F4F5F8`) on dark. The `stop-opacity` gradient fades on the accent facets are preserved in both themes.
- Points the icon link in `__root.tsx` at the new file.

Notes:
- The media query tracks the **browser/OS theme**, which is the right signal — the tab strip follows the browser theme, not the in-app theme toggle.
- Safari doesn't support SVG favicons; it keeps falling through to the existing `favicon.png` line, unchanged.

## Test plan
- Run the web app, toggle OS appearance: Chrome/Firefox update the tab icon live (dark glyph on light theme, light glyph on dark).
- Safari still shows the PNG fallback.