### PR TITLE
feat: derived-view cache for large-doc agent reads (8-40x)

### DIFF
--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -869,7 +869,7 @@ export function buildContext(deps: AppDeps) {
     // The derived-view cache's narrow deps (lib/derived-cache.ts) — pre-bundled so
     // any consumer holding an AppContext (the MCP tools pass ctx straight in as
     // SearchDeps) gets the cache without threading meta/blobs separately.
-    derived: { meta, blobs },
+    derived: { meta, blobs, background },
     bus,
     presence,
     backplane,

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -866,6 +866,10 @@ export function buildContext(deps: AppDeps) {
     deps,
     meta,
     blobs,
+    // The derived-view cache's narrow deps (lib/derived-cache.ts) — pre-bundled so
+    // any consumer holding an AppContext (the MCP tools pass ctx straight in as
+    // SearchDeps) gets the cache without threading meta/blobs separately.
+    derived: { meta, blobs },
     bus,
     presence,
     backplane,

--- a/apps/api/src/lib/derived-cache.ts
+++ b/apps/api/src/lib/derived-cache.ts
@@ -20,15 +20,19 @@ import { log } from "../log"
  * inline — caching them would only make a small view fetch the whole multi-MB blob.
  * Below ~150K chars nothing is cached: the whole ladder is 1-12ms/session there, so
  * the cache would only add I/O — small docs stay byte-for-byte on the direct path.
- * Above ~8M chars nothing is cached either: a miss would compute + serialize a
+ * Above ~5MB (bytes) nothing is cached either: a miss would compute + serialize a
  * multi-MB payload (peak memory a few times the source), and workspace search runs
  * several concurrently — an upper bound keeps a handful of huge docs from exhausting
  * an edge isolate. Giant docs take the direct single-view path, exactly as before.
  *
- * Content addressing IS the invalidation: the key is the sha of the source, so a
- * new version is a new key and rows can never go stale. No TTL, no write-path
- * hook, no eviction logic (rows for content nothing references are inert; the
- * blob store is content-addressed too, so identical republish reuses everything).
+ * Content addressing IS the invalidation: the key is a generation tag + the sha of
+ * the source, so a new version is a new key and rows can never go stale. Content
+ * addressing only covers CONTENT change, though — a change to the view code itself
+ * (toMarkdown, sectionMarkers, elideDataUris, or the cached shape) must bump
+ * DERIVED_CACHE_GEN, or old rows would silently serve the old algorithm's output
+ * forever. No TTL, no write-path hook, no eviction logic (rows for content nothing
+ * references are inert; the blob store is content-addressed too, so identical
+ * republish reuses everything).
  * Every cache interaction is best-effort — a store hiccup falls back to computing
  * exactly what today's path computes, and only the WRITE failure is logged (a
  * read fallback needs no alarm; losing writes silently would).
@@ -58,15 +62,24 @@ export interface DerivedCacheDeps {
  *  ~150K chars is where per-read costs start to matter. */
 export const DERIVED_CACHE_MIN_CHARS = 150_000
 
-/** ABOVE this source size the cache is skipped and the caller takes the direct
- *  single-view path (exactly the pre-cache behavior). A miss computes BOTH views
- *  and JSON-serializes them — a ~3-4x peak-memory multiple of the source — and
- *  workspace search runs up to 4 of these concurrently in one isolate. Uploads can
- *  reach MAX_UPLOAD_BYTES (100MB), so without a ceiling a handful of huge HTML docs
- *  could exhaust a 128MB edge isolate. 8M chars keeps 4 concurrent misses well under
- *  budget while still caching every realistically-large dashboard/deck. Giant docs
- *  are rare and read directly — a single view, no serialized copy, no blob. */
-export const DERIVED_CACHE_MAX_CHARS = 8_000_000
+/** ABOVE this source size (in UTF-8 BYTES — the unit the isolate's memory budget is
+ *  actually spent in; a chars gate undercounts CJK 3x) the cache is skipped and the
+ *  caller takes the direct single-view path, exactly the pre-cache behavior. A miss
+ *  holds the source, both views, the JSON string, and its encoded bytes at once —
+ *  roughly a 3-4x multiple of the source — and workspace search runs up to 4 misses
+ *  concurrently in one isolate, so at 5MB the cache's worst-case concurrent delta is
+ *  ~60-80MB against a 128MB budget. Uploads can reach MAX_UPLOAD_BYTES (100MB);
+ *  without this ceiling a handful of huge HTML docs could exhaust the isolate. Docs
+ *  over the ceiling are rare and read directly — one view, no copies, no blob. */
+export const DERIVED_CACHE_MAX_BYTES = 5_000_000
+
+/** Cache GENERATION, part of every row key. Content addressing invalidates on
+ *  content change; this invalidates on CODE change. Bump it whenever computeViews'
+ *  output could differ for the same source — a semantic change to toMarkdown,
+ *  sectionMarkers, or elideDataUris, or a change to the DerivedViews shape —
+ *  otherwise existing rows keep serving the previous algorithm's output (there is
+ *  no TTL to age them out). Old-generation rows are simply never read again. */
+export const DERIVED_CACHE_GEN = "dv1"
 
 const computeViews = (src: string, contentType: string): DerivedViews => ({
   // Byte-identical to what the direct paths produce: markdown elides data: URIs
@@ -92,20 +105,26 @@ export const derivedViewsFor = async (
   src: string,
   contentType: string,
 ): Promise<DerivedViews | null> => {
-  if (
-    !isHtmlLike(contentType) ||
-    src.length < DERIVED_CACHE_MIN_CHARS ||
-    src.length > DERIVED_CACHE_MAX_CHARS
-  ) {
-    return null
-  }
+  if (!isHtmlLike(contentType) || src.length < DERIVED_CACHE_MIN_CHARS) return null
+  // The upper gate measures BYTES (chars undercount multi-byte text), on the encode
+  // the sha needs anyway — over the ceiling costs one encode, no hash, no I/O.
+  const encoded = new TextEncoder().encode(src)
+  if (encoded.byteLength > DERIVED_CACHE_MAX_BYTES) return null
 
-  const sha = await sha256Hex(new TextEncoder().encode(src))
+  const key = `${DERIVED_CACHE_GEN}:${await sha256Hex(encoded)}`
   try {
-    const rec = await deps.meta.getDerivedView(sha)
+    const rec = await deps.meta.getDerivedView(key)
     if (rec) {
       const bytes = await deps.blobs.get(rec.blob_key)
-      if (bytes) return JSON.parse(new TextDecoder().decode(bytes)) as DerivedViews
+      if (bytes) {
+        // Validate the shape, don't just cast: the generation key already fences
+        // off other generations, so this only catches a corrupt-but-valid-JSON
+        // blob — which must read as a MISS (recompute + overwrite), never flow a
+        // number into a .split() or a non-array into annotateSections.
+        const parsed = JSON.parse(new TextDecoder().decode(bytes)) as Partial<DerivedViews>
+        if (typeof parsed?.markdown === "string" && Array.isArray(parsed.markers))
+          return parsed as DerivedViews
+      }
     }
   } catch {
     // A failed cache READ is a plain fallback to compute — no alarm needed.
@@ -120,10 +139,10 @@ export const derivedViewsFor = async (
   const persist = (async () => {
     try {
       const blobKey = await deps.blobs.put(new TextEncoder().encode(JSON.stringify(views)))
-      await deps.meta.putDerivedView({ source_sha: sha, blob_key: blobKey })
+      await deps.meta.putDerivedView({ source_sha: key, blob_key: blobKey })
     } catch (err) {
       log.warn("derived-view cache write failed", {
-        sourceSha: sha,
+        sourceSha: key,
         error: err instanceof Error ? err.message : String(err),
       })
     }

--- a/apps/api/src/lib/derived-cache.ts
+++ b/apps/api/src/lib/derived-cache.ts
@@ -2,11 +2,6 @@ import {
   type BlobStore,
   elideDataUris,
   isHtmlLike,
-  type LandmarkRegion,
-  landmarksOf,
-  type OutlineSection,
-  outlineOf,
-  pageText,
   type SectionMarker,
   sectionMarkers,
   sha256Hex,
@@ -15,17 +10,20 @@ import {
 import { log } from "../log"
 
 /**
- * Lazy, content-addressed cache for the derived views of one exact source: the
- * markdown conversion, visible text, heading outline, landmark map, and search
- * section markers — everything the read/search ladder recomputes per call today.
+ * Lazy, content-addressed cache for the two EXPENSIVE derived views of one exact
+ * source: the markdown conversion and the search section markers.
  *
- * Design (benchmarked 2026-07-13 on real content): below ~150K chars the whole
- * ladder costs 1-12ms per agent session, so caching would only add I/O — the gate
- * keeps small docs on the direct path, byte-for-byte unchanged. Above it, the
- * per-call cost climbs to 42-215ms/session (sectionMarkers alone is ~83ms per
- * search on a 4MB doc) while a cache hit is 0.3-5ms — an 8-40x win exactly where
- * agents feel it, because they search/read the same big doc repeatedly in a
- * session.
+ * Only these two are cached, on purpose (benchmarked 2026-07-13 on real content):
+ * at 4MB, toMarkdown is ~41ms and sectionMarkers ~83ms — the costs agents feel,
+ * repeatedly, on the same big doc. The other derived views (visible text, heading
+ * outline, landmark map) are ALL cheap (~6ms even at 4MB), so callers compute those
+ * inline — caching them would only make a small view fetch the whole multi-MB blob.
+ * Below ~150K chars nothing is cached: the whole ladder is 1-12ms/session there, so
+ * the cache would only add I/O — small docs stay byte-for-byte on the direct path.
+ * Above ~8M chars nothing is cached either: a miss would compute + serialize a
+ * multi-MB payload (peak memory a few times the source), and workspace search runs
+ * several concurrently — an upper bound keeps a handful of huge docs from exhausting
+ * an edge isolate. Giant docs take the direct single-view path, exactly as before.
  *
  * Content addressing IS the invalidation: the key is the sha of the source, so a
  * new version is a new key and rows can never go stale. No TTL, no write-path
@@ -37,9 +35,6 @@ import { log } from "../log"
  */
 export interface DerivedViews {
   markdown: string
-  text: string
-  outline: OutlineSection[]
-  landmarks: LandmarkRegion[]
   markers: SectionMarker[]
 }
 
@@ -49,6 +44,12 @@ export interface DerivedCacheDeps {
     putDerivedView(rec: { source_sha: string; blob_key: string }): Promise<void>
   }
   blobs: BlobStore
+  /** Run the miss-path PERSIST (blob put + row write) off the read response. On the
+   *  Workers edge this is waitUntil, so a GET isn't held open for a D1 write; on Node
+   *  it awaits inline. Omit ⇒ the persist awaits inline (unit tests, and any caller
+   *  that doesn't hold a request context). Either way the read returns the same
+   *  views — persistence is best-effort and never blocks correctness. */
+  background?: (work: Promise<unknown>) => Promise<void>
 }
 
 /** Below this source size, computing views directly is already ~free (1-12ms per
@@ -57,34 +58,47 @@ export interface DerivedCacheDeps {
  *  ~150K chars is where per-read costs start to matter. */
 export const DERIVED_CACHE_MIN_CHARS = 150_000
 
+/** ABOVE this source size the cache is skipped and the caller takes the direct
+ *  single-view path (exactly the pre-cache behavior). A miss computes BOTH views
+ *  and JSON-serializes them — a ~3-4x peak-memory multiple of the source — and
+ *  workspace search runs up to 4 of these concurrently in one isolate. Uploads can
+ *  reach MAX_UPLOAD_BYTES (100MB), so without a ceiling a handful of huge HTML docs
+ *  could exhaust a 128MB edge isolate. 8M chars keeps 4 concurrent misses well under
+ *  budget while still caching every realistically-large dashboard/deck. Giant docs
+ *  are rare and read directly — a single view, no serialized copy, no blob. */
+export const DERIVED_CACHE_MAX_CHARS = 8_000_000
+
 const computeViews = (src: string, contentType: string): DerivedViews => ({
-  // Matches lib/search.ts's present() for each format EXACTLY (markdown elides
-  // data: URIs there, text is pageText for HTML) — the cache must be substitution-
-  // transparent: same bytes out whether a call hit the cache or computed directly.
+  // Byte-identical to what the direct paths produce: markdown elides data: URIs
+  // exactly as present() does; markers are the source-scope sectionMarkers search
+  // uses. Substitution transparency — a hit == a miss, byte for byte.
   markdown: elideDataUris(toMarkdown(src, contentType)),
-  text: pageText(src),
-  outline: outlineOf(src, contentType),
-  landmarks: landmarksOf(src, contentType),
   markers: sectionMarkers(src, contentType),
 })
 
 /**
- * The derived views for `src`, through the cache when the doc is big enough to
- * benefit. Small docs and non-HTML sources return null — the caller computes the
- * one view it needs directly, exactly as before this cache existed (markdown and
- * plain text are near-passthrough conversions, so only HTML earns the round trip).
+ * The two expensive derived views for `src`, through the cache when the doc is big
+ * enough to benefit. Small docs and non-HTML sources return null — the caller
+ * computes the view it needs directly, exactly as before this cache existed (only
+ * HTML earns the round trip).
  *
- * On a miss this computes ALL views even if the caller wants one — a deliberate
- * trade: the marginal cost of the other four is bounded (~240ms total worst case
- * on a 4MB doc, one time per unique content), and every subsequent call for ANY
- * view on this content becomes a single blob read.
+ * On a miss this computes BOTH cached views even if the caller wants one — a
+ * deliberate trade: their combined cost is bounded (~124ms worst case on a 4MB doc,
+ * one time per unique content), and every subsequent read/search on this content
+ * becomes a single blob read instead.
  */
 export const derivedViewsFor = async (
   deps: DerivedCacheDeps,
   src: string,
   contentType: string,
 ): Promise<DerivedViews | null> => {
-  if (!isHtmlLike(contentType) || src.length < DERIVED_CACHE_MIN_CHARS) return null
+  if (
+    !isHtmlLike(contentType) ||
+    src.length < DERIVED_CACHE_MIN_CHARS ||
+    src.length > DERIVED_CACHE_MAX_CHARS
+  ) {
+    return null
+  }
 
   const sha = await sha256Hex(new TextEncoder().encode(src))
   try {
@@ -98,16 +112,23 @@ export const derivedViewsFor = async (
   }
 
   const views = computeViews(src, contentType)
-  try {
-    const blobKey = await deps.blobs.put(new TextEncoder().encode(JSON.stringify(views)))
-    await deps.meta.putDerivedView({ source_sha: sha, blob_key: blobKey })
-  } catch (err) {
-    // A failed WRITE means every future read of this content pays full compute
-    // again — worth knowing about, never worth failing the read that found it.
-    log.warn("derived-view cache write failed", {
-      sourceSha: sha,
-      error: err instanceof Error ? err.message : String(err),
-    })
-  }
+  // Persist off the read response (edge: waitUntil; Node: inline). A never-rejecting
+  // promise so it's safe whether awaited inline or handed to waitUntil: a failed write
+  // just means the next read of this content recomputes (best-effort), never an alarm
+  // beyond a log. A racing concurrent miss recomputes + rewrites the SAME content-
+  // addressed blob/row — idempotent, no corruption.
+  const persist = (async () => {
+    try {
+      const blobKey = await deps.blobs.put(new TextEncoder().encode(JSON.stringify(views)))
+      await deps.meta.putDerivedView({ source_sha: sha, blob_key: blobKey })
+    } catch (err) {
+      log.warn("derived-view cache write failed", {
+        sourceSha: sha,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  })()
+  if (deps.background) await deps.background(persist)
+  else await persist
   return views
 }

--- a/apps/api/src/lib/derived-cache.ts
+++ b/apps/api/src/lib/derived-cache.ts
@@ -1,0 +1,113 @@
+import {
+  type BlobStore,
+  elideDataUris,
+  isHtmlLike,
+  type LandmarkRegion,
+  landmarksOf,
+  type OutlineSection,
+  outlineOf,
+  pageText,
+  type SectionMarker,
+  sectionMarkers,
+  sha256Hex,
+  toMarkdown,
+} from "@derive/core"
+import { log } from "../log"
+
+/**
+ * Lazy, content-addressed cache for the derived views of one exact source: the
+ * markdown conversion, visible text, heading outline, landmark map, and search
+ * section markers — everything the read/search ladder recomputes per call today.
+ *
+ * Design (benchmarked 2026-07-13 on real content): below ~150K chars the whole
+ * ladder costs 1-12ms per agent session, so caching would only add I/O — the gate
+ * keeps small docs on the direct path, byte-for-byte unchanged. Above it, the
+ * per-call cost climbs to 42-215ms/session (sectionMarkers alone is ~83ms per
+ * search on a 4MB doc) while a cache hit is 0.3-5ms — an 8-40x win exactly where
+ * agents feel it, because they search/read the same big doc repeatedly in a
+ * session.
+ *
+ * Content addressing IS the invalidation: the key is the sha of the source, so a
+ * new version is a new key and rows can never go stale. No TTL, no write-path
+ * hook, no eviction logic (rows for content nothing references are inert; the
+ * blob store is content-addressed too, so identical republish reuses everything).
+ * Every cache interaction is best-effort — a store hiccup falls back to computing
+ * exactly what today's path computes, and only the WRITE failure is logged (a
+ * read fallback needs no alarm; losing writes silently would).
+ */
+export interface DerivedViews {
+  markdown: string
+  text: string
+  outline: OutlineSection[]
+  landmarks: LandmarkRegion[]
+  markers: SectionMarker[]
+}
+
+export interface DerivedCacheDeps {
+  meta: {
+    getDerivedView(sourceSha: string): Promise<{ blob_key: string } | null>
+    putDerivedView(rec: { source_sha: string; blob_key: string }): Promise<void>
+  }
+  blobs: BlobStore
+}
+
+/** Below this source size, computing views directly is already ~free (1-12ms per
+ *  whole session, measured) — the cache would only add blob I/O. Matches the same
+ *  order of magnitude as the conflict-diff guard in edits.ts, for the same reason:
+ *  ~150K chars is where per-read costs start to matter. */
+export const DERIVED_CACHE_MIN_CHARS = 150_000
+
+const computeViews = (src: string, contentType: string): DerivedViews => ({
+  // Matches lib/search.ts's present() for each format EXACTLY (markdown elides
+  // data: URIs there, text is pageText for HTML) — the cache must be substitution-
+  // transparent: same bytes out whether a call hit the cache or computed directly.
+  markdown: elideDataUris(toMarkdown(src, contentType)),
+  text: pageText(src),
+  outline: outlineOf(src, contentType),
+  landmarks: landmarksOf(src, contentType),
+  markers: sectionMarkers(src, contentType),
+})
+
+/**
+ * The derived views for `src`, through the cache when the doc is big enough to
+ * benefit. Small docs and non-HTML sources return null — the caller computes the
+ * one view it needs directly, exactly as before this cache existed (markdown and
+ * plain text are near-passthrough conversions, so only HTML earns the round trip).
+ *
+ * On a miss this computes ALL views even if the caller wants one — a deliberate
+ * trade: the marginal cost of the other four is bounded (~240ms total worst case
+ * on a 4MB doc, one time per unique content), and every subsequent call for ANY
+ * view on this content becomes a single blob read.
+ */
+export const derivedViewsFor = async (
+  deps: DerivedCacheDeps,
+  src: string,
+  contentType: string,
+): Promise<DerivedViews | null> => {
+  if (!isHtmlLike(contentType) || src.length < DERIVED_CACHE_MIN_CHARS) return null
+
+  const sha = await sha256Hex(new TextEncoder().encode(src))
+  try {
+    const rec = await deps.meta.getDerivedView(sha)
+    if (rec) {
+      const bytes = await deps.blobs.get(rec.blob_key)
+      if (bytes) return JSON.parse(new TextDecoder().decode(bytes)) as DerivedViews
+    }
+  } catch {
+    // A failed cache READ is a plain fallback to compute — no alarm needed.
+  }
+
+  const views = computeViews(src, contentType)
+  try {
+    const blobKey = await deps.blobs.put(new TextEncoder().encode(JSON.stringify(views)))
+    await deps.meta.putDerivedView({ source_sha: sha, blob_key: blobKey })
+  } catch (err) {
+    // A failed WRITE means every future read of this content pays full compute
+    // again — worth knowing about, never worth failing the read that found it.
+    log.warn("derived-view cache write failed", {
+      sourceSha: sha,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+  return views
+}

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -209,19 +209,17 @@ export const searchArtifactVersion = async (
 
   if (!manifest) {
     const src = (await deps.sourceText(v)) ?? ""
-    // A large HTML doc's markers (and text-scope conversion) come through the
-    // derived-view cache when one is wired — sectionMarkers alone is ~83ms per
-    // search on a 4MB doc, and agents search the same doc repeatedly. Small docs
-    // return null here and take the identical direct path as before. The cached
-    // markers are SOURCE-line markers, so they substitute only where the direct
-    // path would have computed source markers (source scope) — an HTML text-scope
-    // search keeps its empty marker list, exactly like markersFor.
-    const views = deps.derived ? await derivedViewsFor(deps.derived, src, v.content_type) : null
-    const content = where === "text" ? (views?.text ?? contentFor(src, v.content_type)) : src
-    const markers =
-      where === "source"
-        ? (views?.markers ?? markersFor(src, v.content_type))
-        : markersFor(src, v.content_type)
+    const content = contentFor(src, v.content_type)
+    // A large HTML doc's SOURCE-scope section markers come through the derived-view
+    // cache when one is wired — sectionMarkers is ~83ms on a 4MB doc, and agents
+    // search the same doc repeatedly. Only the source-scope, large-HTML case fetches
+    // the cache; a text-scope search's markers are empty (markersFor), and small docs
+    // return null from the cache and take the identical direct path as before.
+    const cached =
+      where === "source" && deps.derived
+        ? await derivedViewsFor(deps.derived, src, v.content_type)
+        : null
+    const markers = cached?.markers ?? markersFor(src, v.content_type)
     const { hunks, total } = scanLines(content, re, ctxLines, cap)
     annotateSections(hunks, markers)
     return { groups: [{ path: null, hunks }], total, note: null }

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -14,6 +14,7 @@ import {
 import { log } from "../log"
 import { cleanPath, manifestOf } from "./bundle"
 import { clip } from "./clip"
+import { type DerivedCacheDeps, derivedViewsFor } from "./derived-cache"
 
 // The minimal store surface search needs — a BlobStore, a version→text resolver
 // (works for a version OR a proposal, same as the rest of the app), and (only for
@@ -24,6 +25,10 @@ import { clip } from "./clip"
 export interface SearchDeps {
   blobs: BlobStore
   sourceText: (v: Pick<VersionRecord, "blob_key" | "content_type">) => Promise<string | null>
+  /** Optional derived-view cache (lib/derived-cache.ts) — when present, a large
+   *  HTML doc's section markers and text conversion come from the cache instead
+   *  of being recomputed per search. Absent ⇒ the identical direct path. */
+  derived?: DerivedCacheDeps
 }
 
 export interface WorkspaceSearchDeps extends SearchDeps {
@@ -204,8 +209,21 @@ export const searchArtifactVersion = async (
 
   if (!manifest) {
     const src = (await deps.sourceText(v)) ?? ""
-    const { hunks, total } = scanLines(contentFor(src, v.content_type), re, ctxLines, cap)
-    annotateSections(hunks, markersFor(src, v.content_type))
+    // A large HTML doc's markers (and text-scope conversion) come through the
+    // derived-view cache when one is wired — sectionMarkers alone is ~83ms per
+    // search on a 4MB doc, and agents search the same doc repeatedly. Small docs
+    // return null here and take the identical direct path as before. The cached
+    // markers are SOURCE-line markers, so they substitute only where the direct
+    // path would have computed source markers (source scope) — an HTML text-scope
+    // search keeps its empty marker list, exactly like markersFor.
+    const views = deps.derived ? await derivedViewsFor(deps.derived, src, v.content_type) : null
+    const content = where === "text" ? (views?.text ?? contentFor(src, v.content_type)) : src
+    const markers =
+      where === "source"
+        ? (views?.markers ?? markersFor(src, v.content_type))
+        : markersFor(src, v.content_type)
+    const { hunks, total } = scanLines(content, re, ctxLines, cap)
+    annotateSections(hunks, markers)
     return { groups: [{ path: null, hunks }], total, note: null }
   }
 

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -213,8 +213,9 @@ export const searchArtifactVersion = async (
     // A large HTML doc's SOURCE-scope section markers come through the derived-view
     // cache when one is wired — sectionMarkers is ~83ms on a 4MB doc, and agents
     // search the same doc repeatedly. Only the source-scope, large-HTML case fetches
-    // the cache; a text-scope search's markers are empty (markersFor), and small docs
-    // return null from the cache and take the identical direct path as before.
+    // the cache: an HTML text-scope search's markers are empty, a non-HTML doc's are
+    // cheap line scans (both via markersFor), and small docs return null from the
+    // cache — every one of those takes the identical direct path as before.
     const cached =
       where === "source" && deps.derived
         ? await derivedViewsFor(deps.derived, src, v.content_type)

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -786,7 +786,7 @@ async function buildServer(
           const idx = Number(regionRef[1])
           const slice = landmarkSlice(src, idx)
           if (slice === null) {
-            const count = (await landmarksDoc()).length
+            const count = landmarksDoc().length
             return err(
               count
                 ? `No region @${idx} in "${short_id}" — it has ${count} region(s), @1..@${count}. Read with no \`section\` for the map.`
@@ -794,7 +794,7 @@ async function buildServer(
             )
           }
           const body = present(slice, ct, fmt)
-          const count = (await landmarksDoc()).length
+          const count = landmarksDoc().length
           return doc(
             { ...meta, section: `@${idx} of ${count} regions`, chars: body.length },
             clip(body),
@@ -803,7 +803,7 @@ async function buildServer(
         if (section && section !== "*") {
           const slice = sectionOf(src, ct, section)
           if (slice === null) {
-            const slugs = (await outlineDoc()).map((s) => s.slug)
+            const slugs = outlineDoc().map((s) => s.slug)
             return err(
               slugs.length
                 ? `No section "${section}" in "${short_id}" v${n} — sections: ${slugs.join(", ")}.`
@@ -813,7 +813,7 @@ async function buildServer(
           // Also feeds clipDoc's steer below — a single section can itself be huge
           // (e.g. the last one, which runs to </body>), so it needs the same
           // MAX_CHARS ceiling the whole-doc path gets, not an unbounded return.
-          const outline = await outlineDoc()
+          const outline = outlineDoc()
           const i = outline.findIndex((s) => s.slug === section)
           const body = present(slice, ct, fmt)
           return doc(
@@ -827,7 +827,7 @@ async function buildServer(
         }
         const body = await presentDoc(fmt)
         if (!section && body.length > FULL_DOC_MAX) {
-          const outline = await outlineDoc()
+          const outline = outlineDoc()
           if (outline.length)
             return json({
               short_id,
@@ -844,7 +844,7 @@ async function buildServer(
           // No headings — a designed, headless HTML page (dashboard, card grid) still
           // has landmark structure. Return that map so the agent can search/window in
           // rather than blindly dumping a clipped wall of text.
-          const regions = await landmarksDoc()
+          const regions = landmarksDoc()
           if (regions.length)
             return json({
               short_id,
@@ -869,7 +869,7 @@ async function buildServer(
         }
         // Under FULL_DOC_MAX: clipDoc's MAX_CHARS ceiling is far above this body's
         // size, so it can never truncate — skip computing an outline it won't use.
-        const outline = body.length > MAX_CHARS ? await outlineDoc() : []
+        const outline = body.length > MAX_CHARS ? outlineDoc() : []
         return doc({ ...meta, chars: body.length }, clipDoc(body, outline))
       }
 

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -735,24 +735,22 @@ async function buildServer(
         // Single-file artifact.
         const src = (await ctx.sourceText(v)) ?? ""
         const ct = v.content_type
-        // Derived-view cache, fetched LAZILY and once: paths that never need a
-        // derived view (format:"html" windows, region slices) stay zero-cost, and
-        // a cache MISS computes the views exactly once per request, not per site.
-        // Small docs / non-HTML resolve to null and every site below falls back to
-        // the identical direct computation this code always did.
-        let viewsPromise: Promise<DerivedViews | null> | undefined
-        const views = (): Promise<DerivedViews | null> =>
-          (viewsPromise ??= derivedViewsFor(ctx.derived, src, ct))
+        // Only MARKDOWN is served from the derived-view cache (the one expensive view
+        // a read produces — ~41ms on a 4MB doc), fetched lazily and once so a
+        // format:"html" window, a region slice, or a text/outline read never pays a
+        // cache fetch at all. A miss / small doc / non-HTML falls back to the identical
+        // direct computation. text, outline and landmarks are cheap (~6ms) — always
+        // computed inline, so a cheap view never drags in the whole multi-MB blob.
+        let mdPromise: Promise<DerivedViews | null> | undefined
+        const cachedMd = (): Promise<DerivedViews | null> =>
+          (mdPromise ??= derivedViewsFor(ctx.derived, src, ct))
         const presentDoc = async (f: ReadFormat): Promise<string> => {
           if (f === "html") return src
-          const cached = await views()
-          if (cached) return f === "markdown" ? cached.markdown : cached.text
+          if (f === "markdown") return (await cachedMd())?.markdown ?? present(src, ct, "markdown")
           return present(src, ct, f)
         }
-        const outlineDoc = async (): Promise<OutlineSection[]> =>
-          (await views())?.outline ?? outlineOf(src, ct)
-        const landmarksDoc = async (): Promise<LandmarkRegion[]> =>
-          (await views())?.landmarks ?? landmarksOf(src, ct)
+        const outlineDoc = (): OutlineSection[] => outlineOf(src, ct)
+        const landmarksDoc = (): LandmarkRegion[] => landmarksOf(src, ct)
         const meta = {
           short_id,
           title: a.title,

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -35,6 +35,7 @@ import {
   EditError,
   formatDiff,
   isHtmlLike,
+  type LandmarkRegion,
   landmarkSlice,
   landmarksOf,
   looksLikeHtmlDocument,
@@ -72,6 +73,7 @@ import {
 } from "./lib/bundle"
 import { clip, MAX_CHARS } from "./lib/clip"
 import { parseMeta, quoteOf, REACTIONS } from "./lib/comments"
+import { type DerivedViews, derivedViewsFor } from "./lib/derived-cache"
 import { type MaterializedEdits, materializeEdits, preservingFilename } from "./lib/edits"
 import { buildReviewEmail } from "./lib/email"
 import { MAX_UPLOAD_BYTES } from "./lib/http"
@@ -733,6 +735,24 @@ async function buildServer(
         // Single-file artifact.
         const src = (await ctx.sourceText(v)) ?? ""
         const ct = v.content_type
+        // Derived-view cache, fetched LAZILY and once: paths that never need a
+        // derived view (format:"html" windows, region slices) stay zero-cost, and
+        // a cache MISS computes the views exactly once per request, not per site.
+        // Small docs / non-HTML resolve to null and every site below falls back to
+        // the identical direct computation this code always did.
+        let viewsPromise: Promise<DerivedViews | null> | undefined
+        const views = (): Promise<DerivedViews | null> =>
+          (viewsPromise ??= derivedViewsFor(ctx.derived, src, ct))
+        const presentDoc = async (f: ReadFormat): Promise<string> => {
+          if (f === "html") return src
+          const cached = await views()
+          if (cached) return f === "markdown" ? cached.markdown : cached.text
+          return present(src, ct, f)
+        }
+        const outlineDoc = async (): Promise<OutlineSection[]> =>
+          (await views())?.outline ?? outlineOf(src, ct)
+        const landmarksDoc = async (): Promise<LandmarkRegion[]> =>
+          (await views())?.landmarks ?? landmarksOf(src, ct)
         const meta = {
           short_id,
           title: a.title,
@@ -744,7 +764,7 @@ async function buildServer(
         if (lines) {
           if (section && section !== "*")
             return err("Pass `lines` OR `section`, not both — windowing applies to the whole doc.")
-          const body = present(src, ct, fmt)
+          const body = await presentDoc(fmt)
           const all = body.split("\n")
           const range = parseLineRange(lines, all.length)
           if (!range)
@@ -768,7 +788,7 @@ async function buildServer(
           const idx = Number(regionRef[1])
           const slice = landmarkSlice(src, idx)
           if (slice === null) {
-            const count = landmarksOf(src, ct).length
+            const count = (await landmarksDoc()).length
             return err(
               count
                 ? `No region @${idx} in "${short_id}" — it has ${count} region(s), @1..@${count}. Read with no \`section\` for the map.`
@@ -776,7 +796,7 @@ async function buildServer(
             )
           }
           const body = present(slice, ct, fmt)
-          const count = landmarksOf(src, ct).length
+          const count = (await landmarksDoc()).length
           return doc(
             { ...meta, section: `@${idx} of ${count} regions`, chars: body.length },
             clip(body),
@@ -785,7 +805,7 @@ async function buildServer(
         if (section && section !== "*") {
           const slice = sectionOf(src, ct, section)
           if (slice === null) {
-            const slugs = outlineOf(src, ct).map((s) => s.slug)
+            const slugs = (await outlineDoc()).map((s) => s.slug)
             return err(
               slugs.length
                 ? `No section "${section}" in "${short_id}" v${n} — sections: ${slugs.join(", ")}.`
@@ -795,7 +815,7 @@ async function buildServer(
           // Also feeds clipDoc's steer below — a single section can itself be huge
           // (e.g. the last one, which runs to </body>), so it needs the same
           // MAX_CHARS ceiling the whole-doc path gets, not an unbounded return.
-          const outline = outlineOf(src, ct)
+          const outline = await outlineDoc()
           const i = outline.findIndex((s) => s.slug === section)
           const body = present(slice, ct, fmt)
           return doc(
@@ -807,9 +827,9 @@ async function buildServer(
             clipDoc(body, outline),
           )
         }
-        const body = present(src, ct, fmt)
+        const body = await presentDoc(fmt)
         if (!section && body.length > FULL_DOC_MAX) {
-          const outline = outlineOf(src, ct)
+          const outline = await outlineDoc()
           if (outline.length)
             return json({
               short_id,
@@ -826,7 +846,7 @@ async function buildServer(
           // No headings — a designed, headless HTML page (dashboard, card grid) still
           // has landmark structure. Return that map so the agent can search/window in
           // rather than blindly dumping a clipped wall of text.
-          const regions = landmarksOf(src, ct)
+          const regions = await landmarksDoc()
           if (regions.length)
             return json({
               short_id,
@@ -851,7 +871,7 @@ async function buildServer(
         }
         // Under FULL_DOC_MAX: clipDoc's MAX_CHARS ceiling is far above this body's
         // size, so it can never truncate — skip computing an outline it won't use.
-        const outline = body.length > MAX_CHARS ? outlineOf(src, ct) : []
+        const outline = body.length > MAX_CHARS ? await outlineDoc() : []
         return doc({ ...meta, chars: body.length }, clipDoc(body, outline))
       }
 

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -36,6 +36,7 @@ import { afterPublish } from "../lib/after-publish"
 import { authorProfile, resolveHandles, resolveUserBylines } from "../lib/author"
 import { cleanPath, manifestOf } from "../lib/bundle"
 import { hashPassword, signState, unlockCookie, unlockToken, verifyPassword } from "../lib/crypto"
+import { type DerivedViews, derivedViewsFor } from "../lib/derived-cache"
 import {
   EditConflictError,
   type MaterializedEdits,
@@ -883,7 +884,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     const candidateCap = isJson ? 60 : undefined
 
     const { results, note } = await searchWorkspace(
-      { blobs, sourceText, meta },
+      { blobs, sourceText, meta, derived: { meta, blobs } },
       {
         orgId: listOrg,
         viewerId: isOperator ? undefined : (memberKey ?? undefined),
@@ -928,7 +929,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     if (!version) return fail(c, 404, `no version ${v}`)
 
     const { groups, total, note } = await searchArtifactVersion(
-      { blobs, sourceText },
+      { blobs, sourceText, derived: { meta, blobs } },
       version,
       re,
       where,
@@ -1476,25 +1477,41 @@ export const artifactRoutes = (ctx: AppContext) => {
 
     const manifest = await manifestOf(blobs, version)
     if (!manifest) {
-      // Single-file artifact.
+      // Single-file artifact. Full-doc derived views (outline, markdown/text
+      // conversion) come through the derived-view cache for large HTML docs —
+      // the same substitution-transparent cache the MCP read tool uses; small
+      // docs resolve null and take the identical direct path. Section slices
+      // stay direct (a slice is its own content, small by construction).
       const src = await sourceText(version)
       if (src === null) return fail(c, 500, "blob missing")
+      const ct = version.content_type
+      let viewsPromise: Promise<DerivedViews | null> | undefined
+      const views = (): Promise<DerivedViews | null> =>
+        (viewsPromise ??= derivedViewsFor({ meta, blobs }, src, ct))
       if (outline) {
         c.header("X-Derive-Format", "outline")
-        return c.json({ sections: outlineOf(src, version.content_type) })
+        return c.json({ sections: (await views())?.outline ?? outlineOf(src, ct) })
       }
       if (section) {
-        const slice = sectionOf(src, version.content_type, section)
+        const slice = sectionOf(src, ct, section)
         if (slice === null) return fail(c, 404, `no section "${section}"`)
-        const body = present(slice, version.content_type)
+        const body = present(slice, ct)
         c.header("X-Derive-Format", format ?? "raw")
         c.header("X-Derive-Section", section)
         c.header("Content-Type", "text/plain; charset=utf-8")
         return c.body(body)
       }
-      const body = present(src, version.content_type)
+      const cached = format ? await views() : null
+      const body = cached
+        ? format === "markdown"
+          ? cached.markdown
+          : cached.text
+        : present(src, ct)
       c.header("X-Derive-Format", format ?? "raw")
-      c.header("X-Derive-Sections", String(outlineOf(src, version.content_type).length))
+      // Only consult the cache for the outline count when a format read already
+      // fetched it — a RAW read is the byte-exact fast path and must not pay a
+      // first-touch cache fill just for a response header.
+      c.header("X-Derive-Sections", String((cached?.outline ?? outlineOf(src, ct)).length))
       c.header("Content-Type", "text/plain; charset=utf-8")
       return c.body(body)
     }

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -884,7 +884,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     const candidateCap = isJson ? 60 : undefined
 
     const { results, note } = await searchWorkspace(
-      { blobs, sourceText, meta, derived: { meta, blobs } },
+      { blobs, sourceText, meta, derived: { meta, blobs, background } },
       {
         orgId: listOrg,
         viewerId: isOperator ? undefined : (memberKey ?? undefined),
@@ -929,7 +929,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     if (!version) return fail(c, 404, `no version ${v}`)
 
     const { groups, total, note } = await searchArtifactVersion(
-      { blobs, sourceText, derived: { meta, blobs } },
+      { blobs, sourceText, derived: { meta, blobs, background } },
       version,
       re,
       where,
@@ -1477,20 +1477,23 @@ export const artifactRoutes = (ctx: AppContext) => {
 
     const manifest = await manifestOf(blobs, version)
     if (!manifest) {
-      // Single-file artifact. Full-doc derived views (outline, markdown/text
-      // conversion) come through the derived-view cache for large HTML docs —
-      // the same substitution-transparent cache the MCP read tool uses; small
-      // docs resolve null and take the identical direct path. Section slices
-      // stay direct (a slice is its own content, small by construction).
+      // Single-file artifact. Only the MARKDOWN conversion of a large HTML doc
+      // comes through the derived-view cache (the one expensive full-doc view,
+      // ~41ms on a 4MB doc) — the same substitution-transparent cache the MCP
+      // read tool uses. It's fetched lazily and once, so an outline read, a text
+      // read, or a raw byte read never pays a cache fetch. Outline and text are
+      // cheap (~6ms) and computed inline; small docs / non-HTML resolve null and
+      // take the identical direct path. Section slices stay direct (a slice is
+      // its own content, small by construction).
       const src = await sourceText(version)
       if (src === null) return fail(c, 500, "blob missing")
       const ct = version.content_type
-      let viewsPromise: Promise<DerivedViews | null> | undefined
-      const views = (): Promise<DerivedViews | null> =>
-        (viewsPromise ??= derivedViewsFor({ meta, blobs }, src, ct))
+      let mdPromise: Promise<DerivedViews | null> | undefined
+      const cachedMd = (): Promise<DerivedViews | null> =>
+        (mdPromise ??= derivedViewsFor({ meta, blobs, background }, src, ct))
       if (outline) {
         c.header("X-Derive-Format", "outline")
-        return c.json({ sections: (await views())?.outline ?? outlineOf(src, ct) })
+        return c.json({ sections: outlineOf(src, ct) })
       }
       if (section) {
         const slice = sectionOf(src, ct, section)
@@ -1501,17 +1504,12 @@ export const artifactRoutes = (ctx: AppContext) => {
         c.header("Content-Type", "text/plain; charset=utf-8")
         return c.body(body)
       }
-      const cached = format ? await views() : null
-      const body = cached
-        ? format === "markdown"
-          ? cached.markdown
-          : cached.text
-        : present(src, ct)
+      const body =
+        format === "markdown"
+          ? ((await cachedMd())?.markdown ?? present(src, ct))
+          : present(src, ct)
       c.header("X-Derive-Format", format ?? "raw")
-      // Only consult the cache for the outline count when a format read already
-      // fetched it — a RAW read is the byte-exact fast path and must not pay a
-      // first-touch cache fill just for a response header.
-      c.header("X-Derive-Sections", String((cached?.outline ?? outlineOf(src, ct)).length))
+      c.header("X-Derive-Sections", String(outlineOf(src, ct).length))
       c.header("Content-Type", "text/plain; charset=utf-8")
       return c.body(body)
     }

--- a/apps/api/test/content-params.test.ts
+++ b/apps/api/test/content-params.test.ts
@@ -1,8 +1,21 @@
+import { join } from "node:path"
+import Database from "better-sqlite3"
 import { zipSync } from "fflate"
 import { describe, expect, it } from "vitest"
-import { app, TEST_TOKEN, upload } from "./helpers"
+import { app, dir, TEST_TOKEN, upload } from "./helpers"
 
 const bearer = { authorization: `Bearer ${TEST_TOKEN}` }
+
+// Derived-view cache rows in the shared REST app's db — raw SQL against the same
+// sqlite file makeStore("default") created, mirroring mcp.test.ts's counter.
+const countDerivedViews = (): number => {
+  const db = new Database(join(dir, "default.db"))
+  try {
+    return (db.prepare(`SELECT count(*) AS n FROM derived_view`).get() as { n: number }).n
+  } finally {
+    db.close()
+  }
+}
 
 describe("/v1/artifacts/:shortId/content — format, section, outline params", () => {
   it("defaults to raw source; format=markdown converts; format=text is flat text", async () => {
@@ -39,6 +52,41 @@ describe("/v1/artifacts/:shortId/content — format, section, outline params", (
 
     const missing = await app.request(`/v1/artifacts/${short_id}/content?section=nope`)
     expect(missing.status).toBe(404)
+  })
+
+  it("format=markdown on a LARGE doc rides the derived-view cache: first read persists a row, the cached read is byte-identical, and raw/outline reads never add rows", async () => {
+    // Big enough to cross DERIVED_CACHE_MIN_CHARS (150K), with a needle to assert on.
+    const html =
+      `<!doctype html><html><body><h1>Big</h1>\n` +
+      Array.from(
+        { length: 1400 },
+        (_, i) =>
+          `<section><h2>Part ${i}</h2><p>body of part ${i}${i === 42 ? " rest-dcache-needle" : ""}, padded for size padded for size padded for size.</p></section>`,
+      ).join("\n") +
+      `\n</body></html>`
+    expect(html.length).toBeGreaterThan(150_000)
+    const { short_id } = await (await upload("big.html", html)).json()
+
+    const before = countDerivedViews()
+    const mdRes = await app.request(`/v1/artifacts/${short_id}/content?format=markdown`)
+    expect(mdRes.headers.get("x-derive-format")).toBe("markdown")
+    const first = await mdRes.text()
+    expect(first).toContain("rest-dcache-needle")
+    expect(countDerivedViews()).toBe(before + 1) // the miss persisted a row
+
+    // Cache hit: byte-identical body (substitution transparency), no new row.
+    const second = await (
+      await app.request(`/v1/artifacts/${short_id}/content?format=markdown`)
+    ).text()
+    expect(second).toBe(first)
+    expect(countDerivedViews()).toBe(before + 1)
+
+    // Raw and outline reads take the direct path — no cache fetch, no new rows.
+    const raw = await (await app.request(`/v1/artifacts/${short_id}/content`)).text()
+    expect(raw).toBe(html)
+    const outline = await (await app.request(`/v1/artifacts/${short_id}/content?outline=1`)).json()
+    expect(outline.sections.length).toBeGreaterThan(1000)
+    expect(countDerivedViews()).toBe(before + 1)
   })
 
   it("bundle pages: outline, a page, and page#slug", async () => {

--- a/apps/api/test/content-params.test.ts
+++ b/apps/api/test/content-params.test.ts
@@ -1,21 +1,10 @@
-import { join } from "node:path"
-import Database from "better-sqlite3"
+import { sha256Hex } from "@derive/core"
 import { zipSync } from "fflate"
 import { describe, expect, it } from "vitest"
-import { app, dir, TEST_TOKEN, upload } from "./helpers"
+import { DERIVED_CACHE_GEN } from "../src/lib/derived-cache"
+import { app, meta, TEST_TOKEN, upload } from "./helpers"
 
 const bearer = { authorization: `Bearer ${TEST_TOKEN}` }
-
-// Derived-view cache rows in the shared REST app's db — raw SQL against the same
-// sqlite file makeStore("default") created, mirroring mcp.test.ts's counter.
-const countDerivedViews = (): number => {
-  const db = new Database(join(dir, "default.db"))
-  try {
-    return (db.prepare(`SELECT count(*) AS n FROM derived_view`).get() as { n: number }).n
-  } finally {
-    db.close()
-  }
-}
 
 describe("/v1/artifacts/:shortId/content — format, section, outline params", () => {
   it("defaults to raw source; format=markdown converts; format=text is flat text", async () => {
@@ -54,7 +43,7 @@ describe("/v1/artifacts/:shortId/content — format, section, outline params", (
     expect(missing.status).toBe(404)
   })
 
-  it("format=markdown on a LARGE doc rides the derived-view cache: first read persists a row, the cached read is byte-identical, and raw/outline reads never add rows", async () => {
+  it("format=markdown on a LARGE doc rides the derived-view cache: cheap reads never fill it, the first markdown read persists the row, and the cached read is byte-identical", async () => {
     // Big enough to cross DERIVED_CACHE_MIN_CHARS (150K), with a needle to assert on.
     const html =
       `<!doctype html><html><body><h1>Big</h1>\n` +
@@ -67,26 +56,31 @@ describe("/v1/artifacts/:shortId/content — format, section, outline params", (
     expect(html.length).toBeGreaterThan(150_000)
     const { short_id } = await (await upload("big.html", html)).json()
 
-    const before = countDerivedViews()
-    const mdRes = await app.request(`/v1/artifacts/${short_id}/content?format=markdown`)
-    expect(mdRes.headers.get("x-derive-format")).toBe("markdown")
-    const first = await mdRes.text()
-    expect(first).toContain("rest-dcache-needle")
-    expect(countDerivedViews()).toBe(before + 1) // the miss persisted a row
+    // The exact key this content caches under (generation + sha) — asserted through
+    // the shared meta store itself, so this test runs on BOTH dialects (the pg CI
+    // job has no sqlite file to count rows in).
+    const key = `${DERIVED_CACHE_GEN}:${await sha256Hex(new TextEncoder().encode(html))}`
+    expect(await meta.getDerivedView(key)).toBeNull()
 
-    // Cache hit: byte-identical body (substitution transparency), no new row.
-    const second = await (
-      await app.request(`/v1/artifacts/${short_id}/content?format=markdown`)
-    ).text()
-    expect(second).toBe(first)
-    expect(countDerivedViews()).toBe(before + 1)
-
-    // Raw and outline reads take the direct path — no cache fetch, no new rows.
+    // Raw and outline reads take the direct path — they must NOT fill the cache.
     const raw = await (await app.request(`/v1/artifacts/${short_id}/content`)).text()
     expect(raw).toBe(html)
     const outline = await (await app.request(`/v1/artifacts/${short_id}/content?outline=1`)).json()
     expect(outline.sections.length).toBeGreaterThan(1000)
-    expect(countDerivedViews()).toBe(before + 1)
+    expect(await meta.getDerivedView(key)).toBeNull()
+
+    // The first markdown read is the miss that persists the row...
+    const mdRes = await app.request(`/v1/artifacts/${short_id}/content?format=markdown`)
+    expect(mdRes.headers.get("x-derive-format")).toBe("markdown")
+    const first = await mdRes.text()
+    expect(first).toContain("rest-dcache-needle")
+    expect(await meta.getDerivedView(key)).not.toBeNull()
+
+    // ...and the hit is byte-identical (substitution transparency).
+    const second = await (
+      await app.request(`/v1/artifacts/${short_id}/content?format=markdown`)
+    ).text()
+    expect(second).toBe(first)
   })
 
   it("bundle pages: outline, a page, and page#slug", async () => {

--- a/apps/api/test/derived-cache.test.ts
+++ b/apps/api/test/derived-cache.test.ts
@@ -1,10 +1,11 @@
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { elideDataUris, outlineOf, pageText, sectionMarkers, toMarkdown } from "@derive/core"
+import { elideDataUris, sectionMarkers, toMarkdown } from "@derive/core"
 import { FsBlobStore } from "@derive/storage/fs"
 import { afterAll, describe, expect, it } from "vitest"
 import {
+  DERIVED_CACHE_MAX_CHARS,
   DERIVED_CACHE_MIN_CHARS,
   type DerivedViews,
   derivedViewsFor,
@@ -45,12 +46,19 @@ const bigHtml = (marker = "alpha") =>
   `</body></html>`
 
 describe("derivedViewsFor — the lazy content-addressed cache", () => {
-  it("gates: small docs and non-HTML return null and never touch the store", async () => {
+  it("gates: too-small, too-large, and non-HTML sources return null and never touch the store", async () => {
     const { meta, rows } = makeMeta()
     const blobs = new FsBlobStore(join(dir, "gate"))
+    // Too small — the direct path is already ~free.
     expect(await derivedViewsFor({ meta, blobs }, "<h1>tiny</h1>", "text/html")).toBeNull()
+    // Non-HTML — markdown/text are near-passthrough, no round trip earned.
     const bigMd = "# md\n\n".padEnd(DERIVED_CACHE_MIN_CHARS + 10, "x")
     expect(await derivedViewsFor({ meta, blobs }, bigMd, "text/markdown")).toBeNull()
+    // Too large — computing + serializing a multi-MB payload would risk the isolate;
+    // giant docs fall back to the direct single-view path (no cache, no blob).
+    const huge = `<h1>Huge</h1>${"<p>x</p>".repeat(DERIVED_CACHE_MAX_CHARS / 7 + 100)}`
+    expect(huge.length).toBeGreaterThan(DERIVED_CACHE_MAX_CHARS)
+    expect(await derivedViewsFor({ meta, blobs }, huge, "text/html")).toBeNull()
     expect(rows.size).toBe(0)
   })
 
@@ -64,9 +72,9 @@ describe("derivedViewsFor — the lazy content-addressed cache", () => {
     if (!views) throw new Error("expected views for a big HTML doc")
     // Byte-identical to what the read/search paths would compute directly — the
     // whole contract: a cache hit and a direct computation are indistinguishable.
+    // Only the two EXPENSIVE views are cached (markdown + source markers); the
+    // cheap views (text/outline/landmarks) are computed inline by the callers.
     expect(views.markdown).toBe(elideDataUris(toMarkdown(src, "text/html")))
-    expect(views.text).toBe(pageText(src))
-    expect(views.outline).toEqual(outlineOf(src, "text/html"))
     expect(views.markers).toEqual(sectionMarkers(src, "text/html"))
     expect(rows.size).toBe(1)
   })
@@ -81,9 +89,6 @@ describe("derivedViewsFor — the lazy content-addressed cache", () => {
     // second call recomputed instead of reading the cache, it would NOT see this.
     const poisoned: DerivedViews = {
       markdown: "POISONED-MARKDOWN",
-      text: "poisoned",
-      outline: [],
-      landmarks: [],
       markers: [],
     }
     const poisonKey = await blobs.put(new TextEncoder().encode(JSON.stringify(poisoned)))
@@ -107,7 +112,7 @@ describe("derivedViewsFor — the lazy content-addressed cache", () => {
       src,
       "text/html",
     )
-    expect(v1?.text).toBe(pageText(src))
+    expect(v1?.markdown).toBe(elideDataUris(toMarkdown(src, "text/html")))
 
     const putFail = makeMeta({ failPut: true })
     const v2 = await derivedViewsFor(
@@ -115,7 +120,7 @@ describe("derivedViewsFor — the lazy content-addressed cache", () => {
       src,
       "text/html",
     )
-    expect(v2?.text).toBe(pageText(src))
+    expect(v2?.markdown).toBe(elideDataUris(toMarkdown(src, "text/html")))
     expect(putFail.rows.size).toBe(0) // nothing persisted, nothing thrown
   })
 
@@ -128,6 +133,43 @@ describe("derivedViewsFor — the lazy content-addressed cache", () => {
     rows.set([...rows.keys()][0] as string, junkKey)
 
     const views = await derivedViewsFor({ meta, blobs }, src, "text/html")
-    expect(views?.text).toBe(pageText(src))
+    expect(views?.markdown).toBe(elideDataUris(toMarkdown(src, "text/html")))
+  })
+
+  it("routes the miss-path persist through `background` when given (edge waitUntil) and still persists (Node inline-await)", async () => {
+    const { meta, rows } = makeMeta()
+    const blobs = new FsBlobStore(join(dir, "bg"))
+    const src = bigHtml()
+    // A background that awaits inline — exactly what ctx.background does on Node, so
+    // the row is written before the call returns (deterministic for tests + Node).
+    const backgrounded: Promise<unknown>[] = []
+    const background = async (work: Promise<unknown>) => {
+      backgrounded.push(work)
+      await work
+    }
+    const views = await derivedViewsFor({ meta, blobs, background }, src, "text/html")
+    expect(views?.markdown).toBe(elideDataUris(toMarkdown(src, "text/html")))
+    expect(backgrounded).toHaveLength(1) // the persist was routed through background
+    expect(rows.size).toBe(1) // and it completed (Node inline-await)
+    // The persist promise never rejects (safe for edge waitUntil to fire-and-forget).
+    await expect(backgrounded[0]).resolves.toBeUndefined()
+  })
+
+  it("the persist promise NEVER rejects even when the write fails — safe to hand to waitUntil without a catch", async () => {
+    const { meta } = makeMeta({ failPut: true })
+    const src = bigHtml()
+    let handed: Promise<unknown> | undefined
+    const background = async (work: Promise<unknown>) => {
+      handed = work
+      // Deliberately do NOT await here — mimics edge waitUntil registering it to run
+      // after the response; the read must not depend on it, and it must not reject.
+    }
+    const views = await derivedViewsFor(
+      { meta, blobs: new FsBlobStore(join(dir, "bgfail")), background },
+      src,
+      "text/html",
+    )
+    expect(views?.markdown).toBe(elideDataUris(toMarkdown(src, "text/html"))) // read returns regardless
+    await expect(handed).resolves.toBeUndefined() // the write failure was swallowed, not thrown
   })
 })

--- a/apps/api/test/derived-cache.test.ts
+++ b/apps/api/test/derived-cache.test.ts
@@ -5,7 +5,8 @@ import { elideDataUris, sectionMarkers, toMarkdown } from "@derive/core"
 import { FsBlobStore } from "@derive/storage/fs"
 import { afterAll, describe, expect, it } from "vitest"
 import {
-  DERIVED_CACHE_MAX_CHARS,
+  DERIVED_CACHE_GEN,
+  DERIVED_CACHE_MAX_BYTES,
   DERIVED_CACHE_MIN_CHARS,
   type DerivedViews,
   derivedViewsFor,
@@ -56,10 +57,59 @@ describe("derivedViewsFor — the lazy content-addressed cache", () => {
     expect(await derivedViewsFor({ meta, blobs }, bigMd, "text/markdown")).toBeNull()
     // Too large — computing + serializing a multi-MB payload would risk the isolate;
     // giant docs fall back to the direct single-view path (no cache, no blob).
-    const huge = `<h1>Huge</h1>${"<p>x</p>".repeat(DERIVED_CACHE_MAX_CHARS / 7 + 100)}`
-    expect(huge.length).toBeGreaterThan(DERIVED_CACHE_MAX_CHARS)
+    const huge = `<h1>Huge</h1>${"<p>x</p>".repeat(DERIVED_CACHE_MAX_BYTES / 7 + 100)}`
+    expect(huge.length).toBeGreaterThan(DERIVED_CACHE_MAX_BYTES)
     expect(await derivedViewsFor({ meta, blobs }, huge, "text/html")).toBeNull()
     expect(rows.size).toBe(0)
+  })
+
+  it("the upper gate measures BYTES, not chars — multi-byte text under the char count but over the byte budget is skipped", async () => {
+    const { meta, rows } = makeMeta()
+    const blobs = new FsBlobStore(join(dir, "gate-bytes"))
+    // ~2M CJK chars ≈ 6MB UTF-8: comfortably over MAX_BYTES while the same
+    // NUMBER of ASCII chars would have sailed under it. The memory the gate
+    // protects is spent in bytes, so the gate must count bytes.
+    const cjk = `<h1>大</h1><p>${"漢".repeat(2_000_000)}</p>`
+    expect(cjk.length).toBeLessThan(DERIVED_CACHE_MAX_BYTES)
+    expect(new TextEncoder().encode(cjk).byteLength).toBeGreaterThan(DERIVED_CACHE_MAX_BYTES)
+    expect(await derivedViewsFor({ meta, blobs }, cjk, "text/html")).toBeNull()
+    expect(rows.size).toBe(0)
+  })
+
+  it("rows are keyed by GENERATION + sha, so a view-code change (gen bump) orphans old rows instead of serving them", async () => {
+    const { meta, rows } = makeMeta()
+    const blobs = new FsBlobStore(join(dir, "gen"))
+    const src = bigHtml()
+    await derivedViewsFor({ meta, blobs }, src, "text/html")
+    const key = [...rows.keys()][0] as string
+    expect(key.startsWith(`${DERIVED_CACHE_GEN}:`)).toBe(true)
+    // A row written under a DIFFERENT generation (an older algorithm's output)
+    // is invisible: this read misses, recomputes, and writes its own gen row.
+    const staleKey = `dv0:${key.split(":")[1]}`
+    rows.set(staleKey, rows.get(key) as string)
+    rows.delete(key)
+    const views = await derivedViewsFor({ meta, blobs }, src, "text/html")
+    expect(views?.markdown).toBe(elideDataUris(toMarkdown(src, "text/html")))
+    expect(rows.has(key)).toBe(true) // repopulated under the current generation
+  })
+
+  it("a wrong-shape but VALID-JSON blob reads as a miss (recompute + self-repair), never flows bad types to callers", async () => {
+    const { meta, rows } = makeMeta()
+    const blobs = new FsBlobStore(join(dir, "shape"))
+    const src = bigHtml()
+    await derivedViewsFor({ meta, blobs }, src, "text/html")
+    const key = [...rows.keys()][0] as string
+    // markdown is a number, markers is not an array — JSON.parse succeeds, so only
+    // the shape check stands between this and a `.split()` crash in a caller.
+    const badKey = await blobs.put(new TextEncoder().encode(`{"markdown":42,"markers":{}}`))
+    rows.set(key, badKey)
+
+    const views = await derivedViewsFor({ meta, blobs }, src, "text/html")
+    expect(views?.markdown).toBe(elideDataUris(toMarkdown(src, "text/html")))
+    expect(views?.markers).toEqual(sectionMarkers(src, "text/html"))
+    // And the bad row was overwritten by the recompute's persist (self-repair):
+    // the NEXT read hits the cache and gets the good payload.
+    expect(rows.get(key)).not.toBe(badKey)
   })
 
   it("miss computes views that are SUBSTITUTION-TRANSPARENT with the direct path, and persists them", async () => {

--- a/apps/api/test/derived-cache.test.ts
+++ b/apps/api/test/derived-cache.test.ts
@@ -1,0 +1,133 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { elideDataUris, outlineOf, pageText, sectionMarkers, toMarkdown } from "@derive/core"
+import { FsBlobStore } from "@derive/storage/fs"
+import { afterAll, describe, expect, it } from "vitest"
+import {
+  DERIVED_CACHE_MIN_CHARS,
+  type DerivedViews,
+  derivedViewsFor,
+} from "../src/lib/derived-cache"
+
+const dir = mkdtempSync(join(tmpdir(), "derive-dcache-"))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+// A minimal in-memory meta for the two cache methods — plus knobs to fail either
+// direction, for the best-effort guarantees.
+const makeMeta = (opts?: { failGet?: boolean; failPut?: boolean }) => {
+  const rows = new Map<string, string>()
+  return {
+    rows,
+    meta: {
+      getDerivedView: async (sha: string) => {
+        if (opts?.failGet) throw new Error("simulated get failure")
+        const blob_key = rows.get(sha)
+        return blob_key ? { blob_key } : null
+      },
+      putDerivedView: async (rec: { source_sha: string; blob_key: string }) => {
+        if (opts?.failPut) throw new Error("simulated put failure")
+        rows.set(rec.source_sha, rec.blob_key)
+      },
+    },
+  }
+}
+
+// A real HTML doc big enough to cross the gate, with structure worth deriving.
+const bigHtml = (marker = "alpha") =>
+  `<!doctype html><html><head><title>Big</title><style>body{color:red}</style></head><body>` +
+  `<h1>Big Doc</h1>` +
+  Array.from(
+    { length: 1100 },
+    (_, i) =>
+      `<section aria-label="Part ${i}"><h2>Part ${i}</h2><p>the ${marker} content of part ${i}, long enough to matter and then some padding padding padding.</p></section>`,
+  ).join("") +
+  `</body></html>`
+
+describe("derivedViewsFor — the lazy content-addressed cache", () => {
+  it("gates: small docs and non-HTML return null and never touch the store", async () => {
+    const { meta, rows } = makeMeta()
+    const blobs = new FsBlobStore(join(dir, "gate"))
+    expect(await derivedViewsFor({ meta, blobs }, "<h1>tiny</h1>", "text/html")).toBeNull()
+    const bigMd = "# md\n\n".padEnd(DERIVED_CACHE_MIN_CHARS + 10, "x")
+    expect(await derivedViewsFor({ meta, blobs }, bigMd, "text/markdown")).toBeNull()
+    expect(rows.size).toBe(0)
+  })
+
+  it("miss computes views that are SUBSTITUTION-TRANSPARENT with the direct path, and persists them", async () => {
+    const { meta, rows } = makeMeta()
+    const blobs = new FsBlobStore(join(dir, "miss"))
+    const src = bigHtml()
+    expect(src.length).toBeGreaterThan(DERIVED_CACHE_MIN_CHARS)
+
+    const views = await derivedViewsFor({ meta, blobs }, src, "text/html")
+    if (!views) throw new Error("expected views for a big HTML doc")
+    // Byte-identical to what the read/search paths would compute directly — the
+    // whole contract: a cache hit and a direct computation are indistinguishable.
+    expect(views.markdown).toBe(elideDataUris(toMarkdown(src, "text/html")))
+    expect(views.text).toBe(pageText(src))
+    expect(views.outline).toEqual(outlineOf(src, "text/html"))
+    expect(views.markers).toEqual(sectionMarkers(src, "text/html"))
+    expect(rows.size).toBe(1)
+  })
+
+  it("hit is REALLY served from the cache (poisoned-blob proof), and distinct content gets distinct rows", async () => {
+    const { meta, rows } = makeMeta()
+    const blobs = new FsBlobStore(join(dir, "hit"))
+    const src = bigHtml()
+    await derivedViewsFor({ meta, blobs }, src, "text/html")
+
+    // Poison the cached blob: overwrite the row to point at a marker payload. If a
+    // second call recomputed instead of reading the cache, it would NOT see this.
+    const poisoned: DerivedViews = {
+      markdown: "POISONED-MARKDOWN",
+      text: "poisoned",
+      outline: [],
+      landmarks: [],
+      markers: [],
+    }
+    const poisonKey = await blobs.put(new TextEncoder().encode(JSON.stringify(poisoned)))
+    const sha = [...rows.keys()][0] as string
+    rows.set(sha, poisonKey)
+
+    const second = await derivedViewsFor({ meta, blobs }, src, "text/html")
+    expect(second?.markdown).toBe("POISONED-MARKDOWN")
+
+    // Different content — different sha — misses the poisoned row entirely.
+    const other = await derivedViewsFor({ meta, blobs }, bigHtml("beta"), "text/html")
+    expect(other?.markdown).not.toBe("POISONED-MARKDOWN")
+    expect(rows.size).toBe(2)
+  })
+
+  it("best-effort both directions: a failing store read falls back to compute; a failing write still returns views", async () => {
+    const src = bigHtml()
+    const getFail = makeMeta({ failGet: true })
+    const v1 = await derivedViewsFor(
+      { meta: getFail.meta, blobs: new FsBlobStore(join(dir, "gf")) },
+      src,
+      "text/html",
+    )
+    expect(v1?.text).toBe(pageText(src))
+
+    const putFail = makeMeta({ failPut: true })
+    const v2 = await derivedViewsFor(
+      { meta: putFail.meta, blobs: new FsBlobStore(join(dir, "pf")) },
+      src,
+      "text/html",
+    )
+    expect(v2?.text).toBe(pageText(src))
+    expect(putFail.rows.size).toBe(0) // nothing persisted, nothing thrown
+  })
+
+  it("a corrupt cached blob (bad JSON) falls back to compute instead of throwing", async () => {
+    const { meta, rows } = makeMeta()
+    const blobs = new FsBlobStore(join(dir, "corrupt"))
+    const src = bigHtml()
+    await derivedViewsFor({ meta, blobs }, src, "text/html")
+    const junkKey = await blobs.put(new TextEncoder().encode("{not json"))
+    rows.set([...rows.keys()][0] as string, junkKey)
+
+    const views = await derivedViewsFor({ meta, blobs }, src, "text/html")
+    expect(views?.text).toBe(pageText(src))
+  })
+})

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -143,6 +143,17 @@ const call = (app: App, token: string, name: string, args: Record<string, unknow
     params: { name, arguments: args },
   })
 
+// How many derived-view cache rows exist in a test's db — raw SQL against the
+// same per-test file appWithGrant created, exactly like the grant seeding above.
+const countDerivedViews = (name: string): number => {
+  const db = new Database(join(dir, `${name}.db`))
+  try {
+    return (db.prepare(`SELECT count(*) AS n FROM derived_view`).get() as { n: number }).n
+  } finally {
+    db.close()
+  }
+}
+
 describe("remote MCP endpoint (/mcp)", () => {
   it("rejects an unauthenticated connect with 401 + WWW-Authenticate", async () => {
     const { app } = appWithGrant("noauth", "openid derive:read")
@@ -777,6 +788,54 @@ describe("remote MCP endpoint (/mcp)", () => {
     const hid = (await (await publishRaw(app, token, html, "d.html", "D")).json()).short_id
     const s = toolText(await call(app, token, "search", { short_id: hid, query: "pricing" }))
     expect(s).toContain("§ Revenue")
+  })
+
+  it("search + read on a LARGE html doc go through the derived-view cache: the first call persists a derived_view row, and cached calls return byte-identical results (substitution transparency, end to end)", async () => {
+    const { app, token } = appWithGrant("dcache", "openid derive:read derive:publish")
+    // Big enough to cross DERIVED_CACHE_MIN_CHARS (150K); real section structure.
+    const html =
+      `<!doctype html><html><head><title>Big</title></head><body><h1>Big Doc</h1>\n` +
+      Array.from(
+        { length: 1400 },
+        (_, i) =>
+          `<section aria-label="Part ${i}"><h2>Part ${i}</h2><p>content of part ${i}${i === 777 ? " with the dcache-needle-x" : ""}, padded out for size padded out for size and then some more.</p></section>`,
+      ).join("\n") +
+      `\n</body></html>`
+    const id = (await (await publishRaw(app, token, html, "big.html", "Big")).json()).short_id
+
+    // No cached views yet — the first search is the miss that fills the cache.
+    const before = countDerivedViews("dcache")
+    const first = toolText(
+      await call(app, token, "search", { short_id: id, query: "dcache-needle-x" }),
+    )
+    expect(first).toContain("1 match")
+    expect(first).toContain("§ Part 777") // markers work on the miss path
+    const after = countDerivedViews("dcache")
+    expect(after).toBe(before + 1)
+
+    // Second search hits the cache — result must be byte-identical (the whole
+    // substitution-transparency contract), and no new row appears.
+    const second = toolText(
+      await call(app, token, "search", { short_id: id, query: "dcache-needle-x" }),
+    )
+    expect(second).toBe(first)
+    expect(countDerivedViews("dcache")).toBe(after)
+
+    // The outline-first read comes from the same cached views.
+    const outlineRead = toolText(await call(app, token, "read", { short_id: id }))
+    expect(outlineRead).toContain("part-777")
+    expect(countDerivedViews("dcache")).toBe(after)
+
+    // Republishing CHANGED content is a new sha — a fresh row, no stale reuse.
+    await call(app, token, "publish", {
+      short_id: id,
+      edits: [{ old_str: "dcache-needle-x", new_str: "dcache-needle-y" }],
+    })
+    const changed = toolText(
+      await call(app, token, "search", { short_id: id, query: "dcache-needle-y" }),
+    )
+    expect(changed).toContain("1 match")
+    expect(countDerivedViews("dcache")).toBe(after + 1)
   })
 
   it("search (workspace mode, short_id omitted): greps across accessible artifacts, grouped by artifact, and NEVER leaks a private artifact's content to a viewer who isn't its member (regression)", async () => {

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -821,7 +821,8 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(second).toBe(first)
     expect(countDerivedViews("dcache")).toBe(after)
 
-    // The outline-first read comes from the same cached views.
+    // An outline-first read computes its outline INLINE (only markdown + markers
+    // are cached) — cheap path, and it must not add a cache row of its own.
     const outlineRead = toolText(await call(app, token, "read", { short_id: id }))
     expect(outlineRead).toContain("part-777")
     expect(countDerivedViews("dcache")).toBe(after)

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -113,6 +113,12 @@ CREATE TABLE IF NOT EXISTS render_job (
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 
+CREATE TABLE IF NOT EXISTS derived_view (
+  source_sha TEXT PRIMARY KEY,
+  blob_key TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
 CREATE TABLE IF NOT EXISTS membership (
   id TEXT PRIMARY KEY,
   org_id TEXT NOT NULL,

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -129,6 +129,16 @@ export interface NewRenderJob {
   version_n: number
 }
 
+/** A cached bundle of derived views (markdown, text, outline, landmarks, section
+ *  markers) for one exact source, keyed by the source's content sha. Content
+ *  addressing IS the invalidation: new content is a new sha, so rows never go
+ *  stale — an orphaned row for content nothing references anymore is inert. */
+export interface DerivedViewRecord {
+  source_sha: string
+  blob_key: string
+  created_at: string
+}
+
 export interface VersionRecord {
   id: string
   artifact_id: string
@@ -297,6 +307,15 @@ export interface ArtifactStore {
       next_attempt_at: string
     },
   ): Promise<void>
+
+  // ---- Derived-view cache (read-through, content-addressed) ----------------
+  /** The cached derived-views blob for this exact source content, if one exists. */
+  getDerivedView(sourceSha: string): Promise<DerivedViewRecord | null>
+  /** Record where a source's derived views live. Idempotent per sha (last write
+   *  wins is fine — two racing writers derived the same content, so either blob
+   *  is correct). Callers treat failures as best-effort: a cache-write hiccup
+   *  must never fail the read that triggered it. */
+  putDerivedView(rec: { source_sha: string; blob_key: string }): Promise<void>
 }
 
 export interface CommentStore {

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -129,10 +129,11 @@ export interface NewRenderJob {
   version_n: number
 }
 
-/** A cached bundle of derived views (markdown, text, outline, landmarks, section
- *  markers) for one exact source, keyed by the source's content sha. Content
- *  addressing IS the invalidation: new content is a new sha, so rows never go
- *  stale — an orphaned row for content nothing references anymore is inert. */
+/** A cached bundle of the two EXPENSIVE derived views (markdown conversion +
+ *  section markers) for one exact source, keyed by a generation tag + the
+ *  source's content sha (see DERIVED_CACHE_GEN in the api's derived-cache.ts).
+ *  Content addressing IS the invalidation: new content is a new sha, so rows
+ *  never go stale — an orphaned row for content nothing references is inert. */
 export interface DerivedViewRecord {
   source_sha: string
   blob_key: string

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -26,6 +26,7 @@ import type {
   ContextAskerRecord,
   ContextRecord,
   DeliveryRecord,
+  DerivedViewRecord,
   DomainRecord,
   FollowRecord,
   GitHubAppRecord,
@@ -56,6 +57,7 @@ export interface TypedTables {
   webhook: WebhookRecord
   webhookDelivery: DeliveryRecord
   renderJob: RenderJobRecord
+  derivedView: DerivedViewRecord
   membership: MembershipRecord
   workspace: WorkspaceRecord
   artifactMember: ArtifactMemberRecord

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -165,6 +165,14 @@ export const renderJob = pgTable("render_job", {
   created_at: text("created_at").notNull().$defaultFn(isoNow),
 })
 
+// Derived-view cache — see schema.ts's derivedView for the design notes (content
+// addressing is the invalidation; lazy write on first large-doc read).
+export const derivedView = pgTable("derived_view", {
+  source_sha: text("source_sha").primaryKey(),
+  blob_key: text("blob_key").notNull(),
+  created_at: text("created_at").notNull().$defaultFn(isoNow),
+})
+
 export const membership = pgTable(
   "membership",
   {
@@ -647,6 +655,7 @@ const TABLES = [
   webhook,
   webhookDelivery,
   renderJob,
+  derivedView,
   membership,
   workspace,
   artifactMember,

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -16,6 +16,7 @@ import type {
   ContextRecord,
   DeliveryRecord,
   DeliveryStatus,
+  DerivedViewRecord,
   DomainRecord,
   DomainStatus,
   FollowKind,
@@ -125,6 +126,7 @@ import {
   context,
   contextAsker,
   contextSession,
+  derivedView,
   domain,
   follow,
   githubApp,
@@ -171,6 +173,7 @@ export const schema = {
   webhook,
   webhookDelivery,
   renderJob,
+  derivedView,
   membership,
   workspace,
   artifactMember,
@@ -212,6 +215,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   webhook: true,
   webhookDelivery: true,
   renderJob: true,
+  derivedView: true,
   membership: true,
   workspace: true,
   artifactMember: true,
@@ -921,6 +925,23 @@ export class PgMetaStore implements MetaStore {
     },
   ): Promise<void> {
     await this.db.update(renderJob).set(fields).where(eq(renderJob.id, id))
+  }
+
+  // ---- Derived-view cache -------------------------------------------------
+  async getDerivedView(sourceSha: string): Promise<DerivedViewRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(derivedView)
+      .where(eq(derivedView.source_sha, sourceSha))
+    return rows[0] ?? null
+  }
+  async putDerivedView(rec: { source_sha: string; blob_key: string }): Promise<void> {
+    // Last write wins on a sha collision: two racing writers derived the SAME
+    // content, so either blob is correct — no need to preserve the first.
+    await this.db
+      .insert(derivedView)
+      .values(rec)
+      .onConflictDoUpdate({ target: derivedView.source_sha, set: { blob_key: rec.blob_key } })
   }
 
   // ---- Permissions: membership + per-artifact shares ---------------------

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -16,6 +16,7 @@ import type {
   ContextRecord,
   DeliveryRecord,
   DeliveryStatus,
+  DerivedViewRecord,
   DomainRecord,
   DomainStatus,
   FollowKind,
@@ -123,6 +124,7 @@ import {
   context,
   contextAsker,
   contextSession,
+  derivedView,
   domain,
   follow,
   githubApp,
@@ -207,6 +209,7 @@ export const schema = {
   webhook,
   webhookDelivery,
   renderJob,
+  derivedView,
   membership,
   workspace,
   artifactMember,
@@ -248,6 +251,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   webhook: true,
   webhookDelivery: true,
   renderJob: true,
+  derivedView: true,
   membership: true,
   workspace: true,
   artifactMember: true,
@@ -1025,6 +1029,19 @@ export function makeRepos(db: SqliteDb) {
     },
   ): Promise<void> => {
     await db.update(renderJob).set(fields).where(eq(renderJob.id, id)).run()
+  }
+
+  // ---- Derived-view cache ---------------------------------------------------
+  const getDerivedView = async (sourceSha: string): Promise<DerivedViewRecord | null> =>
+    (await db.select().from(derivedView).where(eq(derivedView.source_sha, sourceSha)).get()) ?? null
+  const putDerivedView = async (rec: { source_sha: string; blob_key: string }): Promise<void> => {
+    // Last write wins on a sha collision: two racing writers derived the SAME
+    // content, so either blob is correct — no need to preserve the first.
+    await db
+      .insert(derivedView)
+      .values(rec)
+      .onConflictDoUpdate({ target: derivedView.source_sha, set: { blob_key: rec.blob_key } })
+      .run()
   }
 
   // ---- Workspace membership ----------------------------------------------
@@ -2691,6 +2708,8 @@ export function makeRepos(db: SqliteDb) {
     versionsMissingPreview,
     claimDueRenderJobs,
     updateRenderJob,
+    getDerivedView,
+    putDerivedView,
     getMembership,
     listMemberships,
     listMembershipsForOrgs,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -193,6 +193,17 @@ export const renderJob = sqliteTable("render_job", {
   created_at: text("created_at").notNull().default(now),
 })
 
+// Derived-view cache: where the precomputed views (markdown/text/outline/landmarks/
+// section markers) for one exact source live, keyed by the source's content sha.
+// Content addressing IS the invalidation — new content is a new sha — so there is
+// no staleness state, no TTL, and no write-path hook: rows are written lazily on
+// first read of a large doc and never touched again.
+export const derivedView = sqliteTable("derived_view", {
+  source_sha: text("source_sha").primaryKey(),
+  blob_key: text("blob_key").notNull(),
+  created_at: text("created_at").notNull().default(now),
+})
+
 export const membership = sqliteTable(
   "membership",
   {
@@ -774,6 +785,7 @@ const TABLES = [
   webhook,
   webhookDelivery,
   renderJob,
+  derivedView,
   membership,
   workspace,
   artifactMember,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -193,11 +193,13 @@ export const renderJob = sqliteTable("render_job", {
   created_at: text("created_at").notNull().default(now),
 })
 
-// Derived-view cache: where the precomputed views (markdown/text/outline/landmarks/
-// section markers) for one exact source live, keyed by the source's content sha.
-// Content addressing IS the invalidation — new content is a new sha — so there is
-// no staleness state, no TTL, and no write-path hook: rows are written lazily on
-// first read of a large doc and never touched again.
+// Derived-view cache: where the two precomputed EXPENSIVE views (markdown
+// conversion + section markers) for one exact source live, keyed by a generation
+// tag + the source's content sha (DERIVED_CACHE_GEN in the api's derived-cache.ts;
+// a code change to the view functions bumps the tag). Content addressing IS the
+// invalidation — new content is a new sha — so there is no staleness state, no
+// TTL, and no write-path hook: rows are written lazily on first read of a large
+// doc and never touched again.
 export const derivedView = sqliteTable("derived_view", {
   source_sha: text("source_sha").primaryKey(),
   blob_key: text("blob_key").notNull(),

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1773,6 +1773,29 @@ export function runStoreContract(
     })
   })
 
+  describe(`${label}: derived-view cache`, () => {
+    it("get/put round-trips by source sha; a sha rewrite (last write wins) replaces the blob key; an unknown sha is null", async () => {
+      const sha = `sha_${uuid()}`
+      expect(await store.getDerivedView(sha)).toBeNull()
+
+      await store.putDerivedView({ source_sha: sha, blob_key: "blob-one" })
+      const first = await store.getDerivedView(sha)
+      expect(first?.blob_key).toBe("blob-one")
+      expect(first?.created_at).toBeTruthy()
+
+      // Two racing writers derived the SAME content — either blob is correct, so
+      // the second write simply wins instead of erroring on the primary key.
+      await store.putDerivedView({ source_sha: sha, blob_key: "blob-two" })
+      expect((await store.getDerivedView(sha))?.blob_key).toBe("blob-two")
+
+      // Distinct content is a distinct row — content addressing, no cross-talk.
+      const other = `sha_${uuid()}`
+      await store.putDerivedView({ source_sha: other, blob_key: "blob-three" })
+      expect((await store.getDerivedView(sha))?.blob_key).toBe("blob-two")
+      expect((await store.getDerivedView(other))?.blob_key).toBe("blob-three")
+    })
+  })
+
   describe(`${label}: moderation (reports, takedown, audit)`, () => {
     it("files a report, transitions it, takes down an artifact, logs the action", async () => {
       const a = await store.createArtifact(newArtifact())


### PR DESCRIPTION
Split out of #430 (1 of 3), carrying all its review hardenings.

Content-addressed, lazy cache for the two expensive derived views of large HTML docs (markdown conversion + search section markers). Agents re-reading the same big artifact via MCP/REST get ~16x faster reads (4.9ms vs 80ms on a 4MB doc, measured); small docs and misses take the identical direct path, byte for byte.

- Keys are generation-versioned (`dv1:<sha>`): bump `DERIVED_CACHE_GEN` when view code changes so rows can never silently serve a stale algorithm.
- Gate is [150K chars, 5MB bytes] — bytes, because that's the unit isolate memory is spent in; over-ceiling docs take the pre-cache direct path.
- Miss-path persist rides `waitUntil` on the edge (inline on Node); the persist promise never rejects.
- Shape-validated reads: a corrupt-but-valid-JSON blob reads as a miss and self-repairs.
- Best-effort everywhere: any store failure degrades to exactly today's behavior.

Two adversarial reviews passed over this (one on the initial shape, one on the final); all findings addressed. Tests pin substitution transparency, both gates, generation keys, wrong-shape repair, background routing, and the REST cache branch, on both sqlite and Postgres (`pnpm test:pg`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)