### PR TITLE
feat: mobile auto-reflow becomes opt-in per artifact ([Q2])

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -234,6 +234,10 @@
             "type": "boolean",
             "description": "true when the bundle is a single-page app (all paths route to the entry)."
           },
+          "reflow": {
+            "type": "boolean",
+            "description": "true = Derive may inject mobile-reflow CSS into viewport-less HTML at serve time; false/omitted = the page serves byte-faithful, exactly as authored."
+          },
           "current_version": {
             "type": "number",
             "description": "Latest version number; 0 before any content is published."

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -194,6 +194,10 @@ export function createApp(deps: AppDeps): Hono {
         prefix,
         rawPath,
         cacheControlFor(a.link_role, !!a.password_hash),
+        undefined,
+        undefined,
+        // Mobile auto-reflow is opt-in per artifact ([Q2]) — byte-faithful by default.
+        !!a.reflow,
       )
     }
     app.use("*", async (c, next) => {

--- a/apps/api/src/lib/serve-content.ts
+++ b/apps/api/src/lib/serve-content.ts
@@ -43,10 +43,11 @@ export const serveContent = async (
   transformHtml?: (html: string) => Promise<string>,
   /** Auto-reflow non-mobile-optimized HTML at serve time (inject a viewport tag + a
    *  conservative overflow reset, only when the document declares no viewport). Detection-
-   *  gated and non-destructive — the stored bytes are untouched. Default on; pass false to
-   *  serve the document exactly as authored. Never applied to markdown-rendered output,
-   *  which is already responsive. */
-  reflow = true,
+   *  gated and non-destructive — the stored bytes are untouched. OPT-IN as of [Q2]
+   *  (2026-07-13): default OFF — byte-faith wins; callers pass the artifact's own
+   *  `reflow` flag (set at publish) to enable it. Never applied to markdown-rendered
+   *  output, which is already responsive. */
+  reflow = false,
 ) => {
   const headers = { ...RAW_HEADERS, "Cache-Control": cacheControl }
   const tx = (doc: string) => (transformHtml ? transformHtml(doc) : Promise.resolve(doc))

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -626,6 +626,8 @@ export const artifactRoutes = (ctx: AppContext) => {
           title: str(body["title"]),
           slug: str(body["slug"]),
           spa: body["spa"] === "true" || body["spa"] === "1",
+          // Opt-IN mobile auto-reflow ([Q2]): omitted = byte-faithful serving.
+          reflow: body["reflow"] === "true" || body["reflow"] === "1",
           message: str(body["message"]),
           // Author is the authenticated identity, never a client-supplied field — a
           // logged-in publish must be attributed to that person. The human behind the

--- a/apps/api/src/routes/raw.ts
+++ b/apps/api/src/routes/raw.ts
@@ -57,6 +57,8 @@ export const rawRoutes = (ctx: AppContext) => {
       // so a tab like `walkthrough.html` navigates to the walkthrough artifact instead
       // of re-serving this page. No-op unless this artifact is GitHub-synced.
       crossDocTransform(meta, artifact),
+      // Mobile auto-reflow is opt-in per artifact ([Q2]) — byte-faithful by default.
+      !!artifact.reflow,
     )
   }
 
@@ -133,7 +135,20 @@ export const rawRoutes = (ctx: AppContext) => {
     const path = decodeURIComponent(c.req.path.slice(prefix.length))
     // A proposal is in-review, transient content (it can be withdrawn or change);
     // never let a shared cache hold it, regardless of the artifact's visibility.
-    return serveContent(c, blobs, proposal, artifact.title, prefix, path, "private, no-store")
+    // A proposal previews exactly as the live version would serve — including the
+    // artifact's own opt-in reflow flag ([Q2]).
+    return serveContent(
+      c,
+      blobs,
+      proposal,
+      artifact.title,
+      prefix,
+      path,
+      "private, no-store",
+      undefined,
+      undefined,
+      !!artifact.reflow,
+    )
   })
 
   return app

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -142,6 +142,12 @@ export const Artifact = z
       .boolean()
       .optional()
       .describe("true when the bundle is a single-page app (all paths route to the entry)."),
+    reflow: z
+      .boolean()
+      .optional()
+      .describe(
+        "true = Derive may inject mobile-reflow CSS into viewport-less HTML at serve time; false/omitted = the page serves byte-faithful, exactly as authored.",
+      ),
     current_version: z
       .number()
       .describe("Latest version number; 0 before any content is published."),

--- a/apps/api/test/reflow-serve.test.ts
+++ b/apps/api/test/reflow-serve.test.ts
@@ -1,32 +1,46 @@
 import { describe, expect, it } from "vitest"
 import { app, upload } from "./helpers"
 
-// End-to-end: a non-mobile-optimized HTML artifact gets the viewport tag + reflow CSS
-// injected at serve time, while already-responsive HTML and markdown are left alone.
+// End-to-end: mobile auto-reflow is OPT-IN per artifact ([Q2], 2026-07-13). By
+// default a viewport-less page serves byte-faithful — exactly as authored; a
+// publisher passes reflow=true to let Derive inject the viewport tag + reflow CSS
+// at serve time. Already-responsive HTML and markdown are never touched either way.
 const raw = async (shortId: string) => (await app.request(`/raw/${shortId}/v/1/index.html`)).text()
 
-const publish = async (name: string, content: string): Promise<string> =>
-  (await (await upload(name, content)).json()).short_id as string
+const publish = async (
+  name: string,
+  content: string,
+  fields: Record<string, string> = {},
+): Promise<string> => (await (await upload(name, content, fields)).json()).short_id as string
 
-describe("serve-time HTML auto-reflow", () => {
-  it("injects viewport + reflow CSS into a fixed-width page with no viewport", async () => {
-    const html =
-      "<!doctype html><html><head><title>Report</title></head>" +
-      '<body><div style="width:1200px">wide</div></body></html>'
-    const body = await raw(await publish("report.html", html))
-    expect(body).toContain('name="viewport"')
-    expect(body).toContain("width=device-width")
-    expect(body).toContain("data-derive-reflow")
-    // Original content is preserved; the anchor client is still appended.
+const FIXED_WIDTH_HTML =
+  "<!doctype html><html><head><title>Report</title></head>" +
+  '<body><div style="width:1200px">wide</div></body></html>'
+
+describe("serve-time HTML auto-reflow (opt-in)", () => {
+  it("BY DEFAULT serves a viewport-less page byte-faithful — no injection (the [Q2] flip)", async () => {
+    const body = await raw(await publish("report.html", FIXED_WIDTH_HTML))
+    expect(body).not.toContain("data-derive-reflow")
+    expect(body).not.toContain('name="viewport"')
+    // Content and the anchor client are untouched by the flip.
     expect(body).toContain("wide")
     expect(body).toContain("derive-client.js")
   })
 
-  it("leaves an already-responsive page alone (no reflow injected)", async () => {
+  it("publishing with reflow=true opts in: viewport + reflow CSS are injected", async () => {
+    const body = await raw(await publish("report.html", FIXED_WIDTH_HTML, { reflow: "true" }))
+    expect(body).toContain('name="viewport"')
+    expect(body).toContain("width=device-width")
+    expect(body).toContain("data-derive-reflow")
+    expect(body).toContain("wide")
+    expect(body).toContain("derive-client.js")
+  })
+
+  it("even opted-in, an already-responsive page is left alone (detection still gates)", async () => {
     const html =
       '<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1">' +
       "<title>Responsive</title></head><body>hi</body></html>"
-    const body = await raw(await publish("responsive.html", html))
+    const body = await raw(await publish("responsive.html", html, { reflow: "true" }))
     expect(body).not.toContain("data-derive-reflow")
     // Exactly the one viewport the author wrote — we didn't add a second.
     expect(body.match(/name="viewport"/g)).toHaveLength(1)

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -4917,6 +4917,8 @@ export interface components {
             raw_token?: string;
             /** @description true when the bundle is a single-page app (all paths route to the entry). */
             spa?: boolean;
+            /** @description true = Derive may inject mobile-reflow CSS into viewport-less HTML at serve time; false/omitted = the page serves byte-faithful, exactly as authored. */
+            reflow?: boolean;
             /** @description Latest version number; 0 before any content is published. */
             current_version: number;
             versions: {

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS artifact (
   password_hash TEXT,
   kind TEXT NOT NULL,
   spa INTEGER NOT NULL DEFAULT 0,
+  reflow INTEGER NOT NULL DEFAULT 0,
   locked INTEGER NOT NULL DEFAULT 0,
   current_version INTEGER NOT NULL DEFAULT 0,
   current_content_type TEXT,

--- a/packages/core/src/advisories.test.ts
+++ b/packages/core/src/advisories.test.ts
@@ -6,11 +6,14 @@ const HTML_WITH_VIEWPORT =
   '<!doctype html><html><head><meta name="viewport" content="width=device-width"></head><body>hi</body></html>'
 
 describe("publishAdvisories", () => {
-  it("flags a styled page publishing into the reflow injection (no viewport meta)", () => {
+  it("flags a viewport-less page as zoomed-out on phones, steering to a viewport meta or the reflow:true opt-in ([Q2])", () => {
     const out = publishAdvisories(HTML_NO_VIEWPORT, "text/html")
     expect(out).toHaveLength(1)
     expect(out[0]).toContain("viewport")
+    expect(out[0]).toContain("reflow:true")
     expect(out[0]).toContain("data-reflow-exempt")
+    // The old wording claimed Derive injects automatically — it no longer does.
+    expect(out[0]).not.toContain("Derive injects mobile-reflow CSS (")
   })
 
   it("says nothing when the author declared a viewport (they considered layout)", () => {
@@ -19,6 +22,19 @@ describe("publishAdvisories", () => {
 
   it("never gives the viewport advisory to markdown", () => {
     expect(publishAdvisories("# just a doc", "text/markdown")).toHaveLength(0)
+  })
+
+  it("flags a full HTML document stored as markdown (an explicit .md filename mistyped it) — it would render as escaped source", () => {
+    const out = publishAdvisories(HTML_NO_VIEWPORT, "text/markdown")
+    expect(out).toHaveLength(1)
+    expect(out[0]).toContain("full HTML document")
+    expect(out[0]).toContain(".html")
+  })
+
+  it("does NOT flag markdown that merely contains inline html fragments (no doctype/html shell)", () => {
+    expect(
+      publishAdvisories("# doc\n\nan <em>inline</em> tag and a <div>block</div>", "text/markdown"),
+    ).toHaveLength(0)
   })
 
   it("flags large inlined base64 (binaries that should be assets), with the size", () => {

--- a/packages/core/src/advisories.ts
+++ b/packages/core/src/advisories.ts
@@ -3,19 +3,32 @@
 // descriptions do). The REST route carries them as a field; both MCP servers fold
 // them into their notes. Plan: docs/plans/agent-artifact-learnings.md §4.
 
+import { looksLikeHtmlDocument } from "./publish"
 import { needsReflow } from "./reflow"
 
 /** Advisory strings for a just-published single file — empty when nothing to say. */
 export const publishAdvisories = (content: string, contentType: string): string[] => {
   const out: string[] = []
 
-  // A page with no viewport meta gets the mobile-reflow injection, whose media
-  // caps can fight an intentional layout (see reflow.ts).
+  // Reflow is opt-in as of [Q2] (2026-07-13): a viewport-less page now serves
+  // byte-faithful, which means phones render it zoomed-out. Nudge, don't mutate.
   if (contentType === "text/html" && needsReflow(content))
     out.push(
-      'This page has no <meta name="viewport">, so Derive injects mobile-reflow CSS ' +
-        "(its media caps can fight intentional layouts; data-reflow-exempt on an element " +
-        "opts a component out). Declare your own viewport meta to skip the injection.",
+      'This page has no <meta name="viewport">, so phones will render it zoomed-out. ' +
+        "Add your own viewport meta (best), or republish with reflow:true to let Derive " +
+        "inject conservative mobile-reflow CSS at serve time (data-reflow-exempt opts an " +
+        "element out).",
+    )
+
+  // Extension/content mismatch: a full HTML document stored under a markdown type
+  // (an explicit .md filename overrode the sniffer) renders as ESCAPED SOURCE, not
+  // a page — the second half of the retype-incident class the filename sniffer
+  // (#416) fixed for the filename-less path.
+  if (contentType === "text/markdown" && looksLikeHtmlDocument(content))
+    out.push(
+      "The content is a full HTML document but the filename typed it as markdown, so " +
+        "it will render as escaped source instead of a page. If it should render, " +
+        "republish with an .html filename.",
     )
 
   // Large inlined base64 usually means binaries were pasted through a tool call

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -40,6 +40,11 @@ export interface ArtifactRecord {
   password_hash: string | null
   kind: ArtifactKind
   spa: 0 | 1
+  /** Opt-IN mobile auto-reflow ([Q2], 2026-07-13): 1 = Derive may inject a viewport
+   *  tag + responsive CSS caps into viewport-less HTML at serve time; 0 (default) =
+   *  byte-faithful, the page serves exactly as authored. Set on create, like the
+   *  access triple. */
+  reflow: 0 | 1
   /** Locked: direct publishes are rejected; changes must go through a proposal. */
   locked: 0 | 1
   current_version: number
@@ -190,6 +195,8 @@ export interface NewArtifact {
   password_hash?: string | null
   kind: ArtifactKind
   spa: 0 | 1
+  /** Omitted ⇒ 0 (byte-faithful serving; see ArtifactRecord.reflow). */
+  reflow?: 0 | 1
 }
 
 export interface NewVersion {

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -34,6 +34,8 @@ export interface PublishInput {
   title?: string
   slug?: string
   spa?: boolean
+  /** Opt-IN mobile auto-reflow for viewport-less HTML ([Q2]); omitted = byte-faithful. */
+  reflow?: boolean
   message?: string
   author?: string
   /** The GitHub identity behind this publish (sync only): the commit author's login,
@@ -286,6 +288,7 @@ export async function publish(
     password_hash: input.passwordHash ?? null,
     kind,
     spa: input.spa ? 1 : 0,
+    reflow: input.reflow ? 1 : 0,
   })
   const version = await meta.addVersion(artifact.id, {
     id: newId("v"),
@@ -418,6 +421,7 @@ export const toJson = (baseUrl: string, a: ArtifactRecord, versions: VersionReco
   // `locked`, which is the publish lock (changes must go through proposals).
   password_protected: !!a.password_hash,
   spa: !!a.spa,
+  reflow: !!a.reflow,
   locked: !!a.locked,
   current_version: a.current_version,
   created_at: a.created_at,

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -45,6 +45,7 @@ export const artifact = pgTable("artifact", {
   password_hash: text("password_hash"),
   kind: text("kind").$type<ArtifactKind>().notNull(),
   spa: integer("spa").$type<0 | 1>().notNull().default(0),
+  reflow: integer("reflow").$type<0 | 1>().notNull().default(0),
   locked: integer("locked").$type<0 | 1>().notNull().default(0),
   current_version: integer("current_version").notNull().default(0),
   current_content_type: text("current_content_type"),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -61,6 +61,7 @@ export const artifact = sqliteTable("artifact", {
   // deploy/drop-v1-access.sql — new ones never create them.)
   kind: text("kind").$type<ArtifactKind>().notNull(),
   spa: integer("spa").$type<0 | 1>().notNull().default(0),
+  reflow: integer("reflow").$type<0 | 1>().notNull().default(0),
   // When locked, direct publishes are rejected — changes must go through the
   // proposal → approval flow (any editor can toggle it).
   locked: integer("locked").$type<0 | 1>().notNull().default(0),


### PR DESCRIPTION
Split out of #430 (3 of 3). DRAFT on purpose: this one is a product call and can be closed freely without affecting the other two.

Today every viewport-less HTML page is auto-reflowed at serve time (viewport injection + overflow reset). This flips it to opt-in:

- `reflow` column on artifact (0/1, default 0), set at publish (`reflow:true` in MCP/REST publish).
- Byte-faithful serving becomes the default for viewport-less pages; `reflow:true` restores today's mobile-friendly transform per artifact.
- Plus an extension-mismatch advisory at publish (bytes look like a full HTML document but the filename says otherwise).

The trade, stated plainly: this is RETROACTIVE for existing content. Already-published viewport-less pages render zoomed-out on phones after deploy (no backfill), and owners must republish with `reflow:true` to restore the old behavior. More faithful to the stored bytes, but a silent visible change for existing artifacts. If we ship it, it needs a release note; grandfathering (a one-time backfill setting `reflow=1` on pre-deploy artifacts) is the alternative if we want zero surprise.

Migration is safe on all three dialects (constant-default ADD COLUMN, schema-before-code on D1). 942 tests green including the rewritten reflow-serve suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)