### PR TITLE
feat(search): hybrid semantic + lexical workspace search (Cloudflare Vectorize + Workers AI)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -281,6 +281,36 @@ while every other path serves a static file or the SPA shell. `pnpm build:web` b
 apps/web and preps the output (writes `index.html`, drops the Pages-only `_redirects`
 catch-all that otherwise hijacks `/assets/*`); see `scripts/prep-edge-assets.mjs`.
 
+### Semantic search (optional)
+
+Workspace search is lexical (SQLite/D1 FTS + Postgres tsvector) everywhere by default. On the
+Cloudflare edge you can add a **hybrid dense arm** — embeddings via Workers AI, nearest-neighbour
+over Vectorize — fused with the lexical arm (reciprocal-rank fusion). It finds documents by meaning,
+not just literal tokens (e.g. "getting started" matches an *onboarding* doc), and the multilingual
+`bge-m3` model also covers CJK, which the lexical tokenizer handles poorly. Visibility is unchanged:
+the vector index only *nominates* candidates — the same `listArtifacts` gate re-checks every one, so
+it can never widen what a viewer sees.
+
+It activates only when **both** the `VECTORIZE` and `AI` bindings are present (see the commented
+block in `wrangler.toml`); omit either and search stays lexical, exactly as self-host. The Vectorize
+metadata index **must exist before any vector is inserted**, so provision it first, then deploy, then
+backfill the existing corpus:
+
+```bash
+# 1. Create the index (bge-m3 is 1024-dim) and its org-scoping metadata index — BEFORE any insert:
+wrangler vectorize create derive-search --dimensions=1024 --metric=cosine
+wrangler vectorize create-metadata-index derive-search --property-name=org_id --type=string
+# 2. Uncomment the [[vectorize]] + [ai] blocks in wrangler.toml, then deploy.
+# 3. Backfill: new publishes index automatically; sweep the existing corpus with the operator token,
+#    re-POSTing with the returned nextCursor until it comes back null (bundle-dense? lower `limit`):
+curl -XPOST -H "authorization: Bearer $DERIVE_TOKEN" https://<host>/v1/system/search-reindex
+```
+
+Vectorize is eventually consistent (a just-upserted vector is queryable within seconds–minutes), but
+the synchronous lexical arm answers read-your-writes for a fresh publish, so this never shows to a
+user. Costs are modest (Workers AI embeddings + Vectorize stored/queried dimensions); see the
+Cloudflare pricing pages. Left off by default so a deploy without the index provisioned never fails.
+
 ---
 
 ## Cloudflare Scale: Workers + Postgres + Durable Objects

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -20,6 +20,7 @@ import {
   principalOwnerId,
   type Role,
   roleAllows,
+  type SearchIndex,
 } from "@derive/core"
 import type { Context } from "hono"
 import { getCookie, setCookie } from "hono/cookie"
@@ -65,6 +66,9 @@ export interface SessionUser {
 export interface AppDeps {
   meta: MetaStore
   blobs: BlobStore
+  /** Optional dense/semantic search index. Unbound ⇒ workspace search stays lexical-only
+   *  (self-host, unchanged). The Cloudflare edge entry injects a Vectorize + Workers AI adapter. */
+  search?: SearchIndex
   /** Realtime relay + presence. In-process when unset (self-host); the Cloudflare
    *  edge entry injects a Durable Object backplane. */
   backplane?: Backplane
@@ -866,6 +870,7 @@ export function buildContext(deps: AppDeps) {
     deps,
     meta,
     blobs,
+    search: deps.search,
     bus,
     presence,
     backplane,

--- a/apps/api/src/lib/after-publish.ts
+++ b/apps/api/src/lib/after-publish.ts
@@ -13,6 +13,7 @@ import {
   type BlobStore,
   type MetaStore,
   newId,
+  type SearchIndex,
   type VersionRecord,
 } from "@derive/core"
 import type { Backplane } from "../bus"
@@ -31,6 +32,9 @@ export interface VersionBumpDeps {
   bus: Backplane
   /** Fire-and-forget preview render. Optional so a caller without render access (a test) omits it. */
   notifyRender?: (a: ArtifactRecord, n: number) => void
+  /** The optional dense/semantic search index (Cloudflare edge). When bound, every version
+   *  bump keeps it current alongside the lexical FTS — best-effort, in indexArtifactVersion. */
+  search?: SearchIndex
 }
 
 export const emitVersionBump = async (
@@ -47,7 +51,7 @@ export const emitVersionBump = async (
   // and move on — the artifact re-indexes on its next publish (and the backfill
   // sweep is the safety net for anything missed).
   try {
-    await indexArtifactVersion(meta, blobs, artifact, version)
+    await indexArtifactVersion(meta, blobs, artifact, version, deps.search)
   } catch (err) {
     log.error("search index update failed", { artifact: artifact.id, err: String(err) })
   }

--- a/apps/api/src/lib/proposal-actions.ts
+++ b/apps/api/src/lib/proposal-actions.ts
@@ -10,6 +10,7 @@ import {
   type BlobStore,
   type MetaStore,
   type ProposalRecord,
+  type SearchIndex,
   type VersionRecord,
 } from "@derive/core"
 import type { Backplane } from "../bus"
@@ -25,6 +26,9 @@ export interface ProposalActionDeps {
   /** Enqueue a screenshot render for the newly-published version. Fire-and-forget; optional
    *  so a caller without render access (e.g. a test) can omit it. */
   notifyRender?: (a: ArtifactRecord, n: number) => void
+  /** The optional dense/semantic index — an approved proposal is a version bump, so it keeps
+   *  the index current too (best-effort, via emitVersionBump). Absent on self-host. */
+  search?: SearchIndex
 }
 
 /** Approve: the proposed content becomes the new live version. Mirrors the approve route. */
@@ -35,12 +39,12 @@ export const approveProposalAction = async (
   approver: string | null,
   note: string | null,
 ): Promise<VersionRecord> => {
-  const { meta, blobs, bus, notify, notifyRender } = deps
+  const { meta, blobs, bus, notify, notifyRender, search } = deps
   const version = await approveProposal(meta, blobs, proposal, approver, note)
   bus.publish(artifact.id, { type: "proposal.approved", proposal_id: proposal.id, n: version.n })
   // The approved candidate is now live content: run the shared version-bump core (announce
   // the version so open tabs reload, enqueue the preview render, re-anchor existing threads).
-  await emitVersionBump({ meta, blobs, bus, notifyRender }, artifact, version)
+  await emitVersionBump({ meta, blobs, bus, notifyRender, search }, artifact, version)
   // Threads this proposal addressed are now settled.
   for (const threadId of await releaseAddressed(meta, artifact.id, proposal.id, "resolved"))
     bus.publish(artifact.id, { type: "comment.addressed", thread_id: threadId, state: "resolved" })

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -275,10 +275,14 @@ export const searchReport = (
 }
 
 // ---------------------------------------------------------------------------
-// Index maintenance — the WRITE side of workspace search. The persisted FTS/
-// tsvector index behind searchArtifactIds needs the current version's text kept in
-// step: emitVersionBump calls indexArtifactVersion on every publish/restore/
-// proposal-approve, and the DB layer maintains it on deleteArtifact/moveArtifactOrg.
+// Index maintenance — the WRITE side of workspace search, for BOTH arms: the lexical
+// FTS/tsvector index behind searchArtifactIds, and (when bound) the dense SearchIndex.
+// emitVersionBump calls indexArtifactVersion on every publish/restore/proposal-approve,
+// keeping both current. On delete/move the two diverge by necessity: the FTS lives IN the
+// MetaStore, so deleteArtifact/moveArtifactOrg maintain it transactionally; the dense arm
+// lives outside the DB, so the delete/move ROUTES unindex/re-scope it best-effort — and any
+// orphan left by another path (sync/preview churn, a crash) is reclaimed by the backfill/
+// reconcile sweep. Never a leak: the Tier-2 gate drops a stale vector regardless.
 // ---------------------------------------------------------------------------
 
 // Bound the indexed text per artifact (in JS chars — real artifacts are far smaller).
@@ -494,15 +498,14 @@ export const searchWorkspace = async (
     candidateCap?: number
   },
 ): Promise<{ results: WorkspaceSearchResult[]; note: string | null }> => {
-  // Tier 1 — the index nominates the most relevant candidate ids across the whole
-  // corpus. Org-scoped and ranked, but with NO visibility knowledge by design. Fetch one
-  // past the cap: the sentinel row (never resolved) just answers "were there more?".
   const candidateCap = opts.candidateCap ?? WORKSPACE_SEARCH_CANDIDATE_CAP
-  // Tier 1 — hybrid nomination. The lexical FTS runs always (and answers read-your-writes for a
-  // just-published doc); the dense/semantic arm runs in parallel WHEN a SearchIndex is bound, and
-  // the two are fused by reciprocal-rank fusion. Neither arm knows visibility — the Tier-2 gate
-  // below is still the single authority, so hybrid can't widen what a viewer sees. With no
-  // SearchIndex (self-host), `nominated` is byte-for-byte the old pure-lexical candidate list.
+  // Tier 1 — hybrid nomination across the whole corpus. The lexical FTS runs always (and answers
+  // read-your-writes for a just-published doc); the dense/semantic arm runs in parallel WHEN a
+  // SearchIndex is bound, and the two are fused by reciprocal-rank fusion. Both are org-scoped and
+  // ranked but carry NO visibility knowledge — the Tier-2 gate below is the single authority, so
+  // hybrid can't widen what a viewer sees. Over-fetch one past the cap so the fused list keeps a
+  // sentinel (never resolved) that answers "were there more?". With no SearchIndex (self-host),
+  // `nominated` is byte-for-byte the old pure-lexical candidate list.
   const [lexical, dense] = await Promise.all([
     deps.meta.searchArtifactIds(opts.orgId, opts.query, candidateCap + 1),
     deps.search
@@ -587,6 +590,8 @@ export const searchWorkspace = async (
     // Literal hunks are the lexical arm's precision. A dense-nominated artifact the literal grep
     // can't confirm (total === 0) is still a real semantic match — keep it, carrying its best
     // chunk as evidence. A pure-lexical miss (no hunks and no chunk) drops out exactly as before.
+    // (snippetAround centers on the literal when present; a semantic chunk has none, so it returns
+    // the chunk head — which is exactly the evidence we want here.)
     const chunk = chunkOf.get(a.id)
     if (total === 0 && !chunk) return null
     return {

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -6,6 +6,7 @@ import {
   isHtmlLike,
   type MetaStore,
   pageText,
+  type SearchIndex,
   type SectionMarker,
   sectionMarkers,
   toMarkdown,
@@ -43,6 +44,9 @@ export interface WorkspaceSearchDeps extends SearchDeps {
       limit: number,
     ): Promise<{ id: string; rank: number }[]>
   }
+  /** The optional dense/semantic arm (Cloudflare Vectorize + Workers AI). Absent on
+   *  self-host ⇒ nomination stays pure-lexical, byte-identical to before. */
+  search?: SearchIndex
 }
 
 // ---------------------------------------------------------------------------
@@ -327,13 +331,21 @@ export async function indexArtifactVersion(
   blobs: BlobStore,
   artifact: Pick<ArtifactRecord, "id" | "org_id" | "title">,
   v: VersionRecord,
+  search?: Pick<SearchIndex, "indexArtifact">,
 ): Promise<void> {
-  await meta.indexArtifact(
-    artifact.id,
-    artifact.org_id,
-    artifact.title,
-    await versionIndexText(blobs, v),
-  )
+  const text = await versionIndexText(blobs, v)
+  await meta.indexArtifact(artifact.id, artifact.org_id, artifact.title, text)
+  // The dense arm is independently best-effort: a Vectorize/Workers-AI hiccup must never undo
+  // the lexical upsert that already committed, nor fail the publish. Log and move on — the next
+  // publish re-embeds and the backfill sweep is the safety net. (emitVersionBump's own catch
+  // covers the lexical arm; this inner catch keeps a dense failure from ever reaching it.)
+  if (search) {
+    try {
+      await search.indexArtifact(artifact.id, artifact.org_id, artifact.title, text)
+    } catch (err) {
+      log.error("semantic index update failed", { artifact: artifact.id, err: String(err) })
+    }
+  }
 }
 
 // Backfill — index artifacts that predate the write-path (or were created outside it).
@@ -345,6 +357,8 @@ export async function indexArtifactVersion(
 export interface ReindexSearchDeps {
   blobs: BlobStore
   meta: Pick<MetaStore, "indexArtifact" | "getVersion" | "listArtifacts">
+  /** The optional dense arm — backfill embeds into it too when a SearchIndex is bound. */
+  search?: SearchIndex
 }
 
 export interface ReindexBatchResult {
@@ -371,7 +385,7 @@ export const reindexSearchBatch = async (
     try {
       const v = await deps.meta.getVersion(a.id, a.current_version)
       if (!v) continue // no readable current version — skip rather than index empty
-      await indexArtifactVersion(deps.meta, deps.blobs, a, v)
+      await indexArtifactVersion(deps.meta, deps.blobs, a, v, deps.search)
       indexed++
     } catch (err) {
       log.error("search reindex skipped one artifact", { artifact: a.id, err: String(err) })
@@ -413,12 +427,41 @@ export const WORKSPACE_SEARCH_ARTIFACT_CAP = 30
 // there. The chunks are independent visibility queries; their rows just concatenate.
 const LIST_ID_CHUNK = 90
 
+// Reciprocal-rank fusion: merge the lexical and dense candidate lists by summing 1/(k+rank)
+// across the lists an id appears in (k=60, the standard constant). Rank-based, so it needs no
+// score normalization between BM25 and cosine — an id near the top of EITHER arm ranks well, and
+// one near the top of BOTH ranks best. Carries the dense arm's `chunk` (the semantic snippet
+// source) for the ids the lexical arm didn't also surface. V8's Map preserves insertion order
+// and its sort is stable, so ties resolve lexical-first, deterministically. Pure — unit-tested.
+export const RRF_K = 60
+export const rrfFuse = (
+  lexical: { id: string }[],
+  dense: { id: string; chunk: string }[],
+  limit: number,
+): { id: string; chunk?: string }[] => {
+  const score = new Map<string, number>()
+  const chunkOf = new Map<string, string>()
+  for (const [i, r] of lexical.entries())
+    score.set(r.id, (score.get(r.id) ?? 0) + 1 / (RRF_K + i + 1))
+  for (const [i, r] of dense.entries()) {
+    score.set(r.id, (score.get(r.id) ?? 0) + 1 / (RRF_K + i + 1))
+    chunkOf.set(r.id, r.chunk)
+  }
+  return [...score.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([id]) => ({ id, chunk: chunkOf.get(id) }))
+}
+
 export interface WorkspaceSearchResult {
   short_id: string
   title: string
   current_version: number
   groups: { path: string | null; hunks: SearchHunk[] }[]
   total: number
+  /** Set only for a dense-nominated hit the literal grep-confirm couldn't reproduce
+   *  (total === 0): the best-matching passage, shown as the match evidence. */
+  semantic?: { snippet: string }
 }
 
 export const searchWorkspace = async (
@@ -455,11 +498,32 @@ export const searchWorkspace = async (
   // corpus. Org-scoped and ranked, but with NO visibility knowledge by design. Fetch one
   // past the cap: the sentinel row (never resolved) just answers "were there more?".
   const candidateCap = opts.candidateCap ?? WORKSPACE_SEARCH_CANDIDATE_CAP
-  const nominated = await deps.meta.searchArtifactIds(opts.orgId, opts.query, candidateCap + 1)
+  // Tier 1 — hybrid nomination. The lexical FTS runs always (and answers read-your-writes for a
+  // just-published doc); the dense/semantic arm runs in parallel WHEN a SearchIndex is bound, and
+  // the two are fused by reciprocal-rank fusion. Neither arm knows visibility — the Tier-2 gate
+  // below is still the single authority, so hybrid can't widen what a viewer sees. With no
+  // SearchIndex (self-host), `nominated` is byte-for-byte the old pure-lexical candidate list.
+  const [lexical, dense] = await Promise.all([
+    deps.meta.searchArtifactIds(opts.orgId, opts.query, candidateCap + 1),
+    deps.search
+      ? deps.search.search(opts.orgId, opts.query, candidateCap).catch((err) => {
+          // The dense arm is best-effort on READ too: a Vectorize/Workers-AI hiccup degrades this
+          // query to lexical-only rather than 500-ing a search the lexical arm could still serve.
+          log.error("semantic search arm failed; falling back to lexical", { err: String(err) })
+          return [] as { id: string; score: number; chunk: string }[]
+        })
+      : Promise.resolve([] as { id: string; score: number; chunk: string }[]),
+  ])
+  const nominated: { id: string; chunk?: string }[] = deps.search
+    ? rrfFuse(lexical, dense, candidateCap + 1)
+    : lexical.map((r) => ({ id: r.id }))
   if (nominated.length === 0) return { results: [], note: null }
   const moreCandidates = nominated.length > candidateCap
   const candidates = nominated.slice(0, candidateCap)
   const rankOf = new Map(candidates.map((c, i) => [c.id, i]))
+  // The best dense passage per candidate — the evidence a semantic-only hit shows when the
+  // literal grep-confirm below finds nothing to quote.
+  const chunkOf = new Map(candidates.flatMap((c) => (c.chunk ? [[c.id, c.chunk] as const] : [])))
 
   // Tier 2 gate — THE visibility check. Re-resolve the nominated ids through
   // listArtifacts with the SAME orgId/viewerId/publicOnly list_artifacts uses, PLUS
@@ -520,15 +584,19 @@ export const searchWorkspace = async (
       opts.ctxLines,
       opts.cap,
     )
-    return total
-      ? {
-          short_id: a.short_id,
-          title: a.title ?? a.short_id,
-          current_version: a.current_version,
-          groups,
-          total,
-        }
-      : null
+    // Literal hunks are the lexical arm's precision. A dense-nominated artifact the literal grep
+    // can't confirm (total === 0) is still a real semantic match — keep it, carrying its best
+    // chunk as evidence. A pure-lexical miss (no hunks and no chunk) drops out exactly as before.
+    const chunk = chunkOf.get(a.id)
+    if (total === 0 && !chunk) return null
+    return {
+      short_id: a.short_id,
+      title: a.title ?? a.short_id,
+      current_version: a.current_version,
+      groups,
+      total,
+      semantic: total === 0 && chunk ? { snippet: snippetAround(chunk, opts.query) } : undefined,
+    }
   }
   const results: WorkspaceSearchResult[] = []
   for (let i = 0; i < toGrep.length; i += CONCURRENCY) {
@@ -562,15 +630,29 @@ export const workspaceSearchReport = (
   note: string | null,
 ): string => {
   const grandTotal = results.reduce((sum, r) => sum + r.total, 0)
-  if (grandTotal === 0)
+  // A result with no literal hunks (total 0) but a semantic snippet is a dense-arm match.
+  const hasSemantic = results.some((r) => r.total === 0 && r.semantic)
+  if (grandTotal === 0 && !hasSemantic)
     return `No matches for "${query}" in ${where} across the workspace${note ? ` (${note})` : ""}.${
       where === "source" ? " Try in:'text' to search the visible text." : ""
     }`
-  const head = `${grandTotal} match${grandTotal === 1 ? "" : "es"} for "${query}" in ${where} across ${
-    results.length
-  } artifact${results.length === 1 ? "" : "s"}${note ? ` (${note})` : ""}`
+  // Header keeps the exact literal-match wording when there are any (so the lexical-only path —
+  // every self-host deploy — is unchanged); an all-dense result set reports a semantic-match
+  // count instead of reading as "0 matches".
+  const head =
+    grandTotal > 0
+      ? `${grandTotal} match${grandTotal === 1 ? "" : "es"} for "${query}" in ${where} across ${
+          results.length
+        } artifact${results.length === 1 ? "" : "s"}${note ? ` (${note})` : ""}`
+      : `${results.length} semantic match${results.length === 1 ? "" : "es"} for "${query}" in ${where}${
+          note ? ` (${note})` : ""
+        }`
   const body = results
-    .map((r) => `## ${r.short_id} — ${r.title}\n${renderGroups(r.groups)}`)
+    .map((r) =>
+      r.total > 0
+        ? `## ${r.short_id} — ${r.title}\n${renderGroups(r.groups)}`
+        : `## ${r.short_id} — ${r.title}  (semantic match)\n  ~ ${r.semantic?.snippet ?? ""}`,
+    )
     .join("\n\n")
   const fmt = where === "text" ? "text" : "html"
   const steer = `\n\nOpen one with search(short_id:"...", query:"${query}") for full context, or read(short_id:"...", lines:"from-to", format:"${fmt}").`
@@ -621,6 +703,7 @@ export const toSearchHits = (results: WorkspaceSearchResult[], query: string): S
       short_id: r.short_id,
       title: r.title,
       current_version: r.current_version,
-      snippet: hit ? snippetAround(hit.text, query) : "",
+      // A literal hit line is the best snippet; a dense-only hit falls back to its chunk snippet.
+      snippet: hit ? snippetAround(hit.text, query) : (r.semantic?.snippet ?? ""),
     }
   })

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -1831,6 +1831,9 @@ async function buildServer(
             notify: ctx.notify,
             notifyRender: ctx.notifyRender,
             background: ctx.background,
+            // Thread the dense arm too — agents publish primarily through this tool, so omitting
+            // `search` here would leave the bulk of new content lexically-indexed but never embedded.
+            search: ctx.search,
           },
           artifact,
           version,

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -58,6 +58,7 @@ import {
   workspaceAccessOf,
 } from "../lib/http"
 import {
+  indexArtifactVersion,
   searchArtifactVersion,
   searchMatcher,
   searchReport,
@@ -66,6 +67,7 @@ import {
   workspaceSearchReport,
 } from "../lib/search"
 import { enqueueSlackReviewRequestedDm } from "../lib/slack-dm"
+import { log } from "../log"
 import { Artifact } from "../schemas"
 import { enqueueChannelDelivery } from "../webhooks"
 
@@ -1288,6 +1290,14 @@ export const artifactRoutes = (ctx: AppContext) => {
       const artifact = await requireArtifact(c, "manage", { split: true })
       if (artifact instanceof Response) return bail(artifact)
       await meta.deleteArtifact(artifact.id, artifact.org_id)
+      // The FTS row is dropped inside deleteArtifact; the dense index lives outside the DB, so
+      // drop its vector here too. Best-effort — an orphan the Tier-2 gate already filters out,
+      // otherwise reclaimed by the reconcile/backfill sweep.
+      await search
+        ?.unindexArtifact(artifact.id)
+        .catch((err) =>
+          log.error("dense unindex failed", { artifact: artifact.id, err: String(err) }),
+        )
       return c.body(null, 204)
     },
   )
@@ -1325,6 +1335,24 @@ export const artifactRoutes = (ctx: AppContext) => {
       if ((await meta.getArtifactDomains(artifact.id)).length > 0)
         return bail(fail(c, 409, "remove the custom domain before moving this artifact"))
       await meta.moveArtifactOrg(artifact.id, b.targetOrgId)
+      // moveArtifactOrg re-scopes the FTS row in the DB; the dense vector lives outside it, so
+      // re-embed under the new org here — otherwise it keeps its old org_id metadata and vanishes
+      // from the new workspace's semantic search until the next publish. Best-effort.
+      if (search) {
+        try {
+          const v = await meta.getVersion(artifact.id, artifact.current_version)
+          if (v)
+            await indexArtifactVersion(
+              meta,
+              blobs,
+              { ...artifact, org_id: b.targetOrgId },
+              v,
+              search,
+            )
+        } catch (err) {
+          log.error("dense re-index after move failed", { artifact: artifact.id, err: String(err) })
+        }
+      }
       return c.json({ org_id: b.targetOrgId })
     },
   )

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -97,6 +97,7 @@ export const artifactRoutes = (ctx: AppContext) => {
   const {
     meta,
     blobs,
+    search,
     deps,
     analyticsOn,
     versionWindowMs,
@@ -676,7 +677,7 @@ export const artifactRoutes = (ctx: AppContext) => {
       // Webhook + follower fan-out + thread resolves + realtime/render/re-anchor, all via
       // the one shared helper so this path can never drift from MCP publish or restore.
       await afterPublish(
-        { meta, blobs, bus, notify, notifyRender, background },
+        { meta, blobs, bus, notify, notifyRender, background, search },
         artifact,
         version,
         {
@@ -883,7 +884,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     const candidateCap = isJson ? 60 : undefined
 
     const { results, note } = await searchWorkspace(
-      { blobs, sourceText, meta },
+      { blobs, sourceText, meta, search },
       {
         orgId: listOrg,
         viewerId: isOperator ? undefined : (memberKey ?? undefined),
@@ -1417,7 +1418,7 @@ export const artifactRoutes = (ctx: AppContext) => {
       // A restore is a version bump too: same webhook + realtime + re-anchor as a publish,
       // but never a new artifact, so no follower fan-out and no thread resolves.
       await afterPublish(
-        { meta, blobs, bus, notify, notifyRender, background },
+        { meta, blobs, bus, notify, notifyRender, background, search },
         artifact,
         version,
         {

--- a/apps/api/src/routes/proposals.ts
+++ b/apps/api/src/routes/proposals.ts
@@ -35,6 +35,7 @@ export const proposalRoutes = (ctx: AppContext) => {
   const {
     meta,
     blobs,
+    search,
     deps,
     bus,
     notify,
@@ -384,7 +385,7 @@ export const proposalRoutes = (ctx: AppContext) => {
       if (body instanceof Response) return bail(body)
       try {
         const version = await approveProposalAction(
-          { meta, blobs, bus, notify, notifyRender },
+          { meta, blobs, bus, notify, notifyRender, search },
           artifact,
           proposal,
           approver,

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -9,7 +9,7 @@ import { log } from "../log"
 /** Operational endpoints: liveness (/healthz), readiness (/readyz — proves the datastore
  *  and blob store are reachable), and the minimal API-origin landing page. */
 export const systemRoutes = (ctx: AppContext) => {
-  const { deps, meta, blobs, isToken, isSuperAdmin } = ctx
+  const { deps, meta, blobs, search, isToken, isSuperAdmin } = ctx
   const app = new Hono()
 
   app.get("/healthz", (c) => c.json({ ok: true }))
@@ -83,7 +83,7 @@ export const systemRoutes = (ctx: AppContext) => {
     if (body instanceof Response) return body
     const limit = Math.min(Math.max(body.limit ?? 100, 1), 200)
     const result = await reindexSearchBatch(
-      { meta, blobs },
+      { meta, blobs, search },
       // Normalize null→undefined: reindexSearchBatch's keyset cursor is `{…} | undefined`.
       { orgId: body.orgId, cursor: body.cursor ?? undefined, limit },
     )

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -60,7 +60,11 @@ export const systemRoutes = (ctx: AppContext) => {
   // the operator re-POSTs with that cursor until it comes back null. The cap stays modest
   // because a bundle indexes every page it holds — a bundle-dense page of 500 could breach
   // the Worker's per-invocation subrequest ceiling, which the per-artifact try/catch would
-  // silently swallow as "skipped." Keeping each call bounded is what fits the Workers CPU +
+  // silently swallow as "skipped." NOTE: once that ceiling trips mid-page, every remaining
+  // artifact on the page also throws + skips, yet `nextCursor` still advances past them — so a
+  // page returning `indexed < scanned` left some un-embedded that the normal resume loop won't
+  // revisit. On a bundle-heavy corpus, use a smaller `limit`, and re-sweep from cursor 0 (it's
+  // idempotent) to catch skips. Keeping each call bounded is what fits the Workers CPU +
   // subrequest budget rather than one unbounded pass. Run it as
   // a one-time backfill: under a concurrent live publish it could momentarily write
   // older-version text for that artifact, but grep-confirm reads the live blob (so

--- a/apps/api/src/search-vectorize.ts
+++ b/apps/api/src/search-vectorize.ts
@@ -1,0 +1,108 @@
+import type { SearchIndex } from "@derive/core"
+
+// The Cloudflare-edge adapter for the SearchIndex port: dense/semantic workspace search over
+// Vectorize, embeddings from Workers AI. Model is bge-m3 (1024-dim — under Vectorize's 1536 cap —
+// 8K-token, 100+ languages, which also lifts the CJK weakness of the lexical FTS). ONE vector per
+// artifact (whole-doc embed) in this first cut: re-index is an upsert by artifact id and unindex a
+// single delete, so lifecycle stays trivial; chunk-level embedding (finer recall on long docs) is a
+// later enhancement. `org_id` is a pre-declared Vectorize metadata index so a query filters to one
+// workspace — per-viewer visibility stays in the caller's Tier-2 gate, so this adapter, like the
+// FTS, never widens what a viewer sees. Structural binding interfaces (rather than
+// @cloudflare/workers-types) keep it unit-testable with a fake and robust to type-package churn;
+// the real `env.VECTORIZE` / `env.AI` bindings satisfy them structurally.
+
+/** The slice of a Vectorize binding this adapter uses. */
+export interface VectorizeLike {
+  upsert(
+    vectors: { id: string; values: number[]; metadata?: Record<string, string> }[],
+  ): Promise<unknown>
+  query(
+    vector: number[],
+    opts: {
+      topK?: number
+      filter?: Record<string, unknown>
+      returnMetadata?: "none" | "indexed" | "all"
+    },
+  ): Promise<{ matches: { id: string; score: number; metadata?: Record<string, unknown> }[] }>
+  deleteByIds(ids: string[]): Promise<unknown>
+}
+
+/** The slice of a Workers AI binding this adapter uses (text embeddings). `truncate_inputs`
+ *  makes the model trim an over-long input to its token limit instead of erroring (see embed). */
+export interface WorkersAiLike {
+  run(
+    model: string,
+    inputs: { text: string[]; truncate_inputs?: boolean },
+  ): Promise<{ data: number[][] }>
+}
+
+export const EMBED_MODEL = "@cf/baai/bge-m3"
+// A payload guard on the text handed to the model, NOT the real token bound. bge-m3 accepts 8192
+// tokens and we pass `truncate_inputs: true`, so the MODEL trims anything longer to its first 8192
+// tokens — the tail drops (the lexical arm and the one-artifact grep still reach a past-the-bound
+// hit, same shape as the FTS MAX_INDEX_TEXT bound). This char cap just avoids shipping a multi-MB
+// body: ~24k chars is roughly a whole Latin doc (~6k tokens); for dense scripts (≈1 token/char) the
+// model's token truncation is what bounds it. WITHOUT truncate_inputs an over-limit input is a
+// BadInput error, not a silent trim — which would drop long (esp. CJK) docs from the dense index.
+export const EMBED_CHAR_BUDGET = 24_000
+// The stored semantic snippet (Vectorize metadata caps at 10 KiB/vector; this stays far under it).
+export const PREVIEW_CHARS = 480
+
+export class VectorizeSearchIndex implements SearchIndex {
+  constructor(
+    private readonly vectorize: VectorizeLike,
+    private readonly ai: WorkersAiLike,
+    private readonly model: string = EMBED_MODEL,
+  ) {}
+
+  private async embed(text: string): Promise<number[]> {
+    // truncate_inputs:true so an over-8192-token body (long or CJK docs, where ~1 char ≈ 1 token)
+    // trims to the limit instead of throwing BadInput — otherwise those docs silently never embed.
+    const { data } = await this.ai.run(this.model, { text: [text], truncate_inputs: true })
+    const vector = data[0]
+    if (!vector) throw new Error("empty embedding from Workers AI")
+    return vector
+  }
+
+  async indexArtifact(
+    id: string,
+    orgId: string,
+    title: string | null,
+    text: string,
+  ): Promise<void> {
+    const content = title ? `${title}\n\n${text}` : text
+    // Nothing embeddable (e.g. a bare uploaded image) — ensure a prior vector doesn't linger.
+    if (!content.trim()) return this.unindex(id)
+    const values = await this.embed(content.slice(0, EMBED_CHAR_BUDGET))
+    await this.vectorize.upsert([
+      { id, values, metadata: { org_id: orgId, preview: content.slice(0, PREVIEW_CHARS) } },
+    ])
+  }
+
+  async unindex(id: string): Promise<void> {
+    await this.vectorize.deleteByIds([id])
+  }
+
+  async search(
+    orgId: string,
+    query: string,
+    limit: number,
+  ): Promise<{ id: string; score: number; chunk: string }[]> {
+    const q = query.trim()
+    if (!q) return []
+    const vector = await this.embed(q)
+    // topK is capped at 50 (Vectorize's ceiling when metadata is returned). The `org_id` filter
+    // needs a pre-declared metadata index (see wrangler.toml / DEPLOY.md); `preview` is unindexed
+    // metadata, so "all" is required to read it back for the snippet.
+    const { matches } = await this.vectorize.query(vector, {
+      topK: Math.min(Math.max(limit, 1), 50),
+      filter: { org_id: orgId },
+      returnMetadata: "all",
+    })
+    return matches.map((m) => ({
+      id: m.id,
+      score: m.score,
+      chunk: typeof m.metadata?.preview === "string" ? m.metadata.preview : "",
+    }))
+  }
+}

--- a/apps/api/src/search-vectorize.ts
+++ b/apps/api/src/search-vectorize.ts
@@ -72,14 +72,14 @@ export class VectorizeSearchIndex implements SearchIndex {
   ): Promise<void> {
     const content = title ? `${title}\n\n${text}` : text
     // Nothing embeddable (e.g. a bare uploaded image) — ensure a prior vector doesn't linger.
-    if (!content.trim()) return this.unindex(id)
+    if (!content.trim()) return this.unindexArtifact(id)
     const values = await this.embed(content.slice(0, EMBED_CHAR_BUDGET))
     await this.vectorize.upsert([
       { id, values, metadata: { org_id: orgId, preview: content.slice(0, PREVIEW_CHARS) } },
     ])
   }
 
-  async unindex(id: string): Promise<void> {
+  async unindexArtifact(id: string): Promise<void> {
     await this.vectorize.deleteByIds([id])
   }
 

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -27,6 +27,7 @@ import { slackFromEnv, subdomainBaseFromEnv, superAdminsFromEnv } from "./lib/en
 import { nativeLimiter } from "./lib/rate-limit"
 import { liveD1, requestD1 } from "./lib/request-d1"
 import { createDoBackplane, edgeCtx, edgeWaitUntil } from "./realtime-do"
+import { type VectorizeLike, VectorizeSearchIndex, type WorkersAiLike } from "./search-vectorize"
 import { enqueueChannelDelivery } from "./webhooks"
 
 export { PreviewRenderer } from "./preview-do"
@@ -76,6 +77,11 @@ export interface Env {
   // every declared binding to resolve). Unbound ⇒ D1 is the store (the default).
   HYPERDRIVE?: Hyperdrive
   BUCKET: R2Bucket
+  // Optional semantic search: a Vectorize index + Workers AI (embeddings). Bind BOTH to add the
+  // dense/hybrid arm to workspace search; omit either ⇒ search stays lexical-only, exactly as
+  // self-host. Structurally typed (see search-vectorize.ts) — the real bindings satisfy them.
+  VECTORIZE?: VectorizeLike
+  AI?: WorkersAiLike
   ROOMS: DurableObjectNamespace
   // The webhook outbox drainer DO (a single named instance). Declared in wrangler.toml.
   WEBHOOK_OUTBOX: DurableObjectNamespace
@@ -205,6 +211,11 @@ const handle = (req: Request, env: Env, ctx: ExecutionContext): Response | Promi
         // was dead on prod. Undefined when unset ⇒ isToken stays false, as before.
         token: env.DERIVE_TOKEN,
         blobs: new R2BlobStore(env.BUCKET),
+        // Hybrid search's dense arm — only when BOTH the Vectorize index and Workers AI are bound
+        // (create the index + its org_id metadata index first; see wrangler.toml). Unbound ⇒
+        // undefined ⇒ searchWorkspace runs pure-lexical, identical to the Node/self-host path.
+        search:
+          env.VECTORIZE && env.AI ? new VectorizeSearchIndex(env.VECTORIZE, env.AI) : undefined,
         backplane: createDoBackplane(env.ROOMS),
         baseUrl,
         auth,

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import type { BlobStore, MetaStore, VersionRecord } from "@derive/core"
+import type { BlobStore, MetaStore, SearchIndex, VersionRecord } from "@derive/core"
 import { SqliteMetaStore } from "@derive/db/sqlite"
 import { FsBlobStore } from "@derive/storage/fs"
 import Database from "better-sqlite3"
@@ -908,6 +908,29 @@ describe("remote MCP endpoint (/mcp)", () => {
       await meta.indexArtifact(id, orgId, title, "every doc mentions widget here")
     }
   }
+
+  it("search (workspace mode): a doc published via the MCP publish tool is indexed into the DENSE arm, not just the FTS (regression)", async () => {
+    const indexed: string[] = []
+    const fakeSearch: SearchIndex = {
+      indexArtifact: async (id) => {
+        indexed.push(id)
+      },
+      unindexArtifact: async () => {},
+      search: async () => [],
+    }
+    const { app, token, meta } = appWithGrant("densepub", "openid derive:read derive:publish", {
+      search: fakeSearch,
+    })
+    const created = JSON.parse(
+      toolText(
+        await call(app, token, "publish", { title: "Doc", content: "# Doc\n\nsemantic body" }),
+      ),
+    )
+    const art = await meta.getByShortId(created.short_id)
+    expect(art).toBeTruthy()
+    // Before the fix, MCP publish's afterPublish deps omitted `search`, so this was [].
+    expect(indexed).toContain(art?.id)
+  })
 
   it("search (workspace mode): ranks the whole corpus and shows an honest truncation note past the grep-confirm cap", async () => {
     const { app, token, meta, blobs } = appWithGrant("wscap", "openid derive:read derive:publish")

--- a/apps/api/test/search-hybrid.test.ts
+++ b/apps/api/test/search-hybrid.test.ts
@@ -1,11 +1,15 @@
 import type { ArtifactRecord, SearchIndex, VersionRecord } from "@derive/core"
 import { describe, expect, it } from "vitest"
 import {
+  indexArtifactVersion,
+  reindexSearchBatch,
   rrfFuse,
   searchMatcher,
   searchWorkspace,
   toSearchHits,
   type WorkspaceSearchDeps,
+  type WorkspaceSearchResult,
+  workspaceSearchReport,
 } from "../src/lib/search"
 import {
   type VectorizeLike,
@@ -66,7 +70,7 @@ const denseIndex = (
   byQuery: Record<string, { id: string; score: number; chunk: string }[]>,
 ): SearchIndex => ({
   indexArtifact: async () => {},
-  unindex: async () => {},
+  unindexArtifact: async () => {},
   search: async (_org, query, limit) => (byQuery[query] ?? []).slice(0, limit),
 })
 
@@ -219,7 +223,7 @@ describe("searchWorkspace — hybrid retrieval", () => {
     }
     const boom: SearchIndex = {
       indexArtifact: async () => {},
-      unindex: async () => {},
+      unindexArtifact: async () => {},
       search: async () => {
         throw new Error("vectorize unavailable")
       },
@@ -303,7 +307,7 @@ describe("VectorizeSearchIndex (Cloudflare adapter)", () => {
     const idx = new VectorizeSearchIndex(vectorize, ai)
     await idx.indexArtifact("a1", "org1", "T", "body")
     expect(store.has("a1")).toBe(true)
-    await idx.unindex("a1")
+    await idx.unindexArtifact("a1")
     expect(store.has("a1")).toBe(false)
     // A non-text artifact (empty indexable content) must not upsert — and drops any prior vector.
     await idx.indexArtifact("a2", "org1", null, "   ")
@@ -316,5 +320,101 @@ describe("VectorizeSearchIndex (Cloudflare adapter)", () => {
     const { ai, runs } = makeAi()
     expect(await new VectorizeSearchIndex(vectorize, ai).search("org1", "   ", 6)).toEqual([])
     expect(runs).toHaveLength(0)
+  })
+})
+
+describe("workspaceSearchReport — semantic rendering", () => {
+  const lit = (short_id: string, title: string, total: number): WorkspaceSearchResult => ({
+    short_id,
+    title,
+    current_version: 1,
+    total,
+    groups: [
+      { path: null, hunks: [{ from: 1, lines: [{ n: 1, text: `hit for ${title}`, hit: true }] }] },
+    ],
+  })
+  const sem = (short_id: string, title: string, snippet: string): WorkspaceSearchResult => ({
+    short_id,
+    title,
+    current_version: 1,
+    total: 0,
+    groups: [],
+    semantic: { snippet },
+  })
+
+  it("all-semantic result set reports a semantic-match count (not '0 matches') and renders the chunk", () => {
+    const out = workspaceSearchReport(
+      "getting started",
+      "text",
+      [sem("onb1", "Onboarding", "the golden path")],
+      null,
+    )
+    expect(out).toContain("1 semantic match")
+    expect(out).not.toMatch(/\b0 match/)
+    expect(out).toContain("## onb1 — Onboarding  (semantic match)")
+    expect(out).toContain("the golden path")
+  })
+
+  it("mixed literal + semantic keeps the literal-count header and renders both shapes", () => {
+    const out = workspaceSearchReport(
+      "x",
+      "text",
+      [lit("a1", "A", 2), sem("b1", "B", "chunk B")],
+      null,
+    )
+    expect(out).toContain("2 matches for")
+    expect(out).toContain("## a1 — A\n")
+    expect(out).toContain("## b1 — B  (semantic match)")
+    expect(out).toContain("chunk B")
+  })
+
+  it("empty results → the no-matches line", () => {
+    expect(workspaceSearchReport("q", "text", [], null)).toContain("No matches")
+  })
+})
+
+describe("write path — dense arm best-effort + backfill", () => {
+  it("indexArtifactVersion: a throwing dense arm neither blocks the lexical upsert nor throws", async () => {
+    const lexed: string[] = []
+    const meta = {
+      indexArtifact: async (id: string) => {
+        lexed.push(id)
+      },
+    }
+    const blobs = { get: async () => enc("# T\n\nbody"), put: async () => "k" }
+    const v = { blob_key: "k", content_type: "text/markdown" } as VersionRecord
+    const boom = {
+      indexArtifact: async () => {
+        throw new Error("vectorize down")
+      },
+    }
+    await expect(
+      indexArtifactVersion(meta, blobs, { id: "a", org_id: ORG, title: "T" }, v, boom),
+    ).resolves.toBeUndefined()
+    expect(lexed).toEqual(["a"]) // lexical committed despite the dense failure
+  })
+
+  it("reindexSearchBatch: backfill embeds each artifact into the dense arm too", async () => {
+    const dense: string[] = []
+    const arts = [
+      { id: "a", current_version: 1, org_id: ORG, title: "A", created_at: "t1" },
+      { id: "b", current_version: 1, org_id: ORG, title: "B", created_at: "t2" },
+    ] as ArtifactRecord[]
+    const meta = {
+      indexArtifact: async () => {},
+      listArtifacts: async () => arts,
+      getVersion: async () => ({ blob_key: "k", content_type: "text/markdown" }) as VersionRecord,
+    }
+    const blobs = { get: async () => enc("body"), put: async () => "k" }
+    const search: SearchIndex = {
+      indexArtifact: async (id) => {
+        dense.push(id)
+      },
+      unindexArtifact: async () => {},
+      search: async () => [],
+    }
+    const res = await reindexSearchBatch({ meta, blobs, search }, { limit: 10 })
+    expect(dense).toEqual(["a", "b"])
+    expect(res.indexed).toBe(2)
   })
 })

--- a/apps/api/test/search-hybrid.test.ts
+++ b/apps/api/test/search-hybrid.test.ts
@@ -1,0 +1,320 @@
+import type { ArtifactRecord, SearchIndex, VersionRecord } from "@derive/core"
+import { describe, expect, it } from "vitest"
+import {
+  rrfFuse,
+  searchMatcher,
+  searchWorkspace,
+  toSearchHits,
+  type WorkspaceSearchDeps,
+} from "../src/lib/search"
+import {
+  type VectorizeLike,
+  VectorizeSearchIndex,
+  type WorkersAiLike,
+} from "../src/search-vectorize"
+
+// Hybrid (lexical FTS + dense/semantic) workspace search. These are pure-logic tests over the
+// fusion + orchestration and the Cloudflare adapter — with in-memory fakes for both the FTS arm
+// and the dense arm, so the Vectorize/Workers-AI wiring itself is what's deployment-verified, but
+// the RRF fusion, the recall-gap fix, the visibility gate over the new arm, and the adapter's
+// embed/filter/preview contract are all pinned here. The existing lexical-only behavior is proven
+// unchanged (no SearchIndex bound ⇒ byte-for-byte the old path) in mcp/search-rest.
+
+const ORG = "org_test"
+const enc = (s: string) => new TextEncoder().encode(s)
+
+interface Doc {
+  id: string
+  short_id: string
+  title: string
+  body: string
+  org_id?: string
+  workspace_access?: "member" | "none"
+}
+
+// A partial ArtifactRecord is castable because ArtifactRecord is assignable to it (same trick the
+// existing tests use for VersionRecord): only real fields the search path reads are set.
+const artifact = (d: Doc): ArtifactRecord =>
+  ({
+    id: d.id,
+    short_id: d.short_id,
+    title: d.title,
+    current_version: 1,
+    org_id: d.org_id ?? ORG,
+    workspace_access: d.workspace_access ?? "member",
+    password_hash: null,
+  }) as ArtifactRecord
+
+// A stand-in FTS arm: AND'd case-insensitive substring match over title+body (looser than real
+// fts5 prefix, but the same "nominate, then the caller grep-confirms the literal" contract).
+const lexical = (docs: Doc[], orgId: string, query: string, limit: number) => {
+  const toks = query.toLowerCase().match(/[a-z0-9]+/g) ?? []
+  if (!toks.length) return []
+  return docs
+    .filter((d) => (d.org_id ?? ORG) === orgId)
+    .filter((d) => {
+      const hay = `${d.title}\n${d.body}`.toLowerCase()
+      return toks.every((t) => hay.includes(t))
+    })
+    .slice(0, limit)
+    .map((d, i) => ({ id: d.id, rank: -i }))
+}
+
+// A stand-in dense arm: a fixed query→hits table, with NO visibility knowledge (by design) — the
+// Tier-2 gate is what enforces visibility over whatever this nominates.
+const denseIndex = (
+  byQuery: Record<string, { id: string; score: number; chunk: string }[]>,
+): SearchIndex => ({
+  indexArtifact: async () => {},
+  unindex: async () => {},
+  search: async (_org, query, limit) => (byQuery[query] ?? []).slice(0, limit),
+})
+
+const makeDeps = (docs: Doc[], search?: SearchIndex): WorkspaceSearchDeps => {
+  const keyOf = (d: Doc) => `blob_${d.id}`
+  const bodyForKey = (key: string) => docs.find((d) => keyOf(d) === key)?.body ?? null
+  const version = (d: Doc) =>
+    ({ blob_key: keyOf(d), content_type: "text/markdown" }) as VersionRecord
+  return {
+    blobs: {
+      get: async (key: string) => {
+        const b = bodyForKey(key)
+        return b === null ? null : enc(b)
+      },
+      put: async () => "unused",
+    },
+    sourceText: async (v) => bodyForKey(v.blob_key),
+    meta: {
+      listArtifacts: async (opts) => {
+        const ids = new Set(opts.ids ?? [])
+        return (
+          docs
+            .filter((d) => ids.has(d.id))
+            .filter((d) => (d.org_id ?? ORG) === opts.orgId)
+            // Minimal visibility: a workspace_access:"none" doc is hidden from a publicOnly (anon)
+            // caller — enough to prove the gate governs the dense arm's nominations too.
+            .filter((d) => !(opts.publicOnly && (d.workspace_access ?? "member") === "none"))
+            .map(artifact)
+        )
+      },
+      getVersion: async (id: string) => {
+        const d = docs.find((x) => x.id === id)
+        return d ? version(d) : null
+      },
+      searchArtifactIds: async (orgId, query, limit) => lexical(docs, orgId, query, limit),
+    },
+    search,
+  }
+}
+
+const run = (
+  deps: WorkspaceSearchDeps,
+  query: string,
+  extra: { publicOnly?: boolean; viewerId?: string } = {},
+) =>
+  searchWorkspace(deps, {
+    orgId: ORG,
+    query,
+    re: searchMatcher(query, false),
+    where: "text",
+    ctxLines: 0,
+    cap: 40,
+    ...extra,
+  })
+
+describe("rrfFuse", () => {
+  it("ranks an id present in BOTH arms above one in either alone, and carries the dense chunk", () => {
+    const fused = rrfFuse(
+      [{ id: "b" }, { id: "a" }],
+      [
+        { id: "a", chunk: "A-chunk" },
+        { id: "c", chunk: "C-chunk" },
+      ],
+      10,
+    )
+    expect(fused.map((f) => f.id)).toEqual(["a", "b", "c"]) // a in both ⇒ top; then b, c by rank
+    expect(fused.find((f) => f.id === "a")?.chunk).toBe("A-chunk")
+    expect(fused.find((f) => f.id === "b")?.chunk).toBeUndefined() // lexical-only ⇒ no chunk
+  })
+
+  it("honours the limit", () => {
+    expect(rrfFuse([{ id: "a" }, { id: "b" }], [], 1)).toHaveLength(1)
+  })
+})
+
+describe("searchWorkspace — hybrid retrieval", () => {
+  const onboarding: Doc = {
+    id: "onb",
+    short_id: "onb1",
+    title: "Onboarding",
+    body: "# Onboarding\n\nthe golden path for new users to reach the aha moment",
+  }
+
+  it("dense arm surfaces a paraphrase the lexical arm MISSES (the recall gap) — lexical-only returns nothing", async () => {
+    const q = "getting started" // a synonym for onboarding; absent from the text literally
+    // Lexical-only (no SearchIndex): the paraphrase finds nothing — the gap seen live on prod.
+    const lexOnly = await run(makeDeps([onboarding]), q)
+    expect(lexOnly.results).toHaveLength(0)
+    // Hybrid: the dense arm nominates the doc; it survives with a semantic snippet from its chunk.
+    const dense = denseIndex({
+      "getting started": [{ id: "onb", score: 0.9, chunk: "the golden path for new users" }],
+    })
+    const hybrid = await run(makeDeps([onboarding], dense), q)
+    expect(hybrid.results.map((r) => r.short_id)).toEqual(["onb1"])
+    expect(hybrid.results[0]?.total).toBe(0) // no literal hunks — it's a semantic match
+    expect(hybrid.results[0]?.semantic?.snippet).toContain("golden path")
+  })
+
+  it("a literal match renders identically whether or not a dense arm is bound (lexical path unchanged)", async () => {
+    const doc: Doc = {
+      id: "onb",
+      short_id: "onb1",
+      title: "Onboarding",
+      body: "onboarding is the golden path",
+    }
+    const withDense = await run(makeDeps([doc], denseIndex({})), "onboarding")
+    const without = await run(makeDeps([doc]), "onboarding")
+    for (const r of [withDense, without]) {
+      expect(r.results.map((x) => x.short_id)).toEqual(["onb1"])
+      expect(r.results[0]?.total).toBeGreaterThan(0) // literal grep hunks
+      expect(r.results[0]?.semantic).toBeUndefined()
+    }
+  })
+
+  it("the Tier-2 visibility gate drops a dense-nominated artifact the viewer can't see (no leak via the new arm)", async () => {
+    const secret: Doc = {
+      id: "priv",
+      short_id: "priv1",
+      title: "Secret",
+      body: "the roadmap internals nobody outside should read",
+      workspace_access: "none",
+    }
+    const dense = denseIndex({
+      "future plans": [{ id: "priv", score: 0.95, chunk: "the roadmap internals" }],
+    })
+    // Anonymous (publicOnly): the dense arm nominates it, the gate drops it — nothing leaks.
+    const anon = await run(makeDeps([secret], dense), "future plans", { publicOnly: true })
+    expect(anon.results).toHaveLength(0)
+    // A member (not publicOnly) can see it, so the semantic hit surfaces for them.
+    const member = await run(makeDeps([secret], dense), "future plans", { viewerId: "u1" })
+    expect(member.results.map((r) => r.short_id)).toEqual(["priv1"])
+  })
+
+  it("toSearchHits (⌘K palette) uses the chunk as the snippet for a semantic-only hit", async () => {
+    const dense = denseIndex({
+      "getting started": [{ id: "onb", score: 0.9, chunk: "the golden path for new users" }],
+    })
+    const { results } = await run(makeDeps([onboarding], dense), "getting started")
+    const hits = toSearchHits(results, "getting started")
+    expect(hits).toHaveLength(1)
+    expect(hits[0]?.snippet).toContain("golden path")
+  })
+
+  it("a throwing dense arm degrades to lexical-only rather than failing the whole search", async () => {
+    const doc: Doc = {
+      id: "onb",
+      short_id: "onb1",
+      title: "Onboarding",
+      body: "onboarding is the golden path",
+    }
+    const boom: SearchIndex = {
+      indexArtifact: async () => {},
+      unindex: async () => {},
+      search: async () => {
+        throw new Error("vectorize unavailable")
+      },
+    }
+    const { results } = await run(makeDeps([doc], boom), "onboarding")
+    expect(results.map((r) => r.short_id)).toEqual(["onb1"]) // the lexical hit still comes back
+  })
+})
+
+// --- The Cloudflare adapter, over fake Vectorize + Workers AI bindings ------------------------
+
+const makeAi = () => {
+  const runs: { model: string; text: string[]; truncate?: boolean }[] = []
+  const ai: WorkersAiLike = {
+    run: async (model, inputs) => {
+      runs.push({ model, text: inputs.text, truncate: inputs.truncate_inputs })
+      return { data: inputs.text.map(() => [0.1, 0.2, 0.3]) }
+    },
+  }
+  return { ai, runs }
+}
+
+const makeVectorize = () => {
+  const store = new Map<string, { values: number[]; metadata?: Record<string, string> }>()
+  const seen = { deletes: [] as string[][], queries: [] as Parameters<VectorizeLike["query"]>[1][] }
+  const vectorize: VectorizeLike = {
+    upsert: async (vectors) => {
+      for (const v of vectors) store.set(v.id, { values: v.values, metadata: v.metadata })
+    },
+    deleteByIds: async (ids) => {
+      seen.deletes.push(ids)
+      for (const id of ids) store.delete(id)
+    },
+    query: async (_vector, opts) => {
+      seen.queries.push(opts)
+      const org = opts.filter?.org_id
+      const matches = [...store.entries()]
+        .filter(([, v]) => org === undefined || v.metadata?.org_id === org)
+        .slice(0, opts.topK ?? 10)
+        .map(([id, v]) => ({ id, score: 0.5, metadata: v.metadata as Record<string, unknown> }))
+      return { matches }
+    },
+  }
+  return { vectorize, store, seen }
+}
+
+describe("VectorizeSearchIndex (Cloudflare adapter)", () => {
+  it("indexArtifact embeds title+body and upserts one vector with org_id + preview metadata", async () => {
+    const { vectorize, store } = makeVectorize()
+    const { ai, runs } = makeAi()
+    await new VectorizeSearchIndex(vectorize, ai).indexArtifact(
+      "a1",
+      "org1",
+      "Onboarding",
+      "the golden path",
+    )
+    expect(runs[0]?.model).toBe("@cf/baai/bge-m3")
+    expect(runs[0]?.text).toEqual(["Onboarding\n\nthe golden path"]) // title prepended for the embed
+    expect(runs[0]?.truncate).toBe(true) // over-limit (long/CJK) inputs trim instead of throwing
+    expect(store.get("a1")?.metadata?.org_id).toBe("org1")
+    expect(store.get("a1")?.metadata?.preview).toContain("Onboarding")
+  })
+
+  it("search embeds the query, filters by org_id, requests metadata, and maps preview → chunk", async () => {
+    const { vectorize, seen } = makeVectorize()
+    const { ai } = makeAi()
+    const idx = new VectorizeSearchIndex(vectorize, ai)
+    await idx.indexArtifact("a1", "org1", "Onboarding", "the golden path")
+    await idx.indexArtifact("a2", "org2", "Other", "a different workspace")
+    const hits = await idx.search("org1", "getting started", 6)
+    expect(hits.map((h) => h.id)).toEqual(["a1"]) // org filter excludes the other workspace
+    expect(hits[0]?.chunk).toContain("Onboarding")
+    expect(seen.queries[0]?.filter).toEqual({ org_id: "org1" })
+    expect(seen.queries[0]?.returnMetadata).toBe("all")
+    expect(seen.queries[0]?.topK).toBe(6)
+  })
+
+  it("unindex deletes the vector; empty content unindexes instead of upserting", async () => {
+    const { vectorize, store, seen } = makeVectorize()
+    const { ai } = makeAi()
+    const idx = new VectorizeSearchIndex(vectorize, ai)
+    await idx.indexArtifact("a1", "org1", "T", "body")
+    expect(store.has("a1")).toBe(true)
+    await idx.unindex("a1")
+    expect(store.has("a1")).toBe(false)
+    // A non-text artifact (empty indexable content) must not upsert — and drops any prior vector.
+    await idx.indexArtifact("a2", "org1", null, "   ")
+    expect(store.has("a2")).toBe(false)
+    expect(seen.deletes).toContainEqual(["a2"])
+  })
+
+  it("search with a blank query short-circuits without calling the model", async () => {
+    const { vectorize } = makeVectorize()
+    const { ai, runs } = makeAi()
+    expect(await new VectorizeSearchIndex(vectorize, ai).search("org1", "   ", 6)).toEqual([])
+    expect(runs).toHaveLength(0)
+  })
+})

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -45,6 +45,21 @@ id = "10b9d78afcdb46ad8f8db7ad449fb2b3"
 binding = "BUCKET"
 bucket_name = "derive-blobs"
 
+# Optional semantic search (the dense/hybrid arm of workspace search): Cloudflare Vectorize
+# (vector index) + Workers AI (bge-m3 embeddings). Bind BOTH to enable it; omit to stay
+# lexical-only (self-host parity — the worker gates on `env.VECTORIZE && env.AI`). The metadata
+# index MUST exist before any vector is inserted, so create both up front, then backfill:
+#   wrangler vectorize create derive-search --dimensions=1024 --metric=cosine
+#   wrangler vectorize create-metadata-index derive-search --property-name=org_id --type=string
+#   # then, per workspace corpus: POST /v1/system/search-reindex with the operator token
+# See DEPLOY.md. Left commented so a deploy without the index provisioned doesn't fail.
+# [[vectorize]]
+# binding = "VECTORIZE"
+# index_name = "derive-search"
+#
+# [ai]
+# binding = "AI"
+
 [[durable_objects.bindings]]
 name = "ROOMS"
 class_name = "ArtifactRoom"

--- a/knip.json
+++ b/knip.json
@@ -2,12 +2,10 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
     "apps/api": {
-      "entry": ["gen-auth-schema.ts"],
-      "ignoreDependencies": ["cloudflare"]
+      "entry": ["gen-auth-schema.ts"]
     },
     "apps/web": {
-      "entry": ["src/components/ui/**", "e2e/**/*.screens.ts"],
-      "ignoreDependencies": ["openapi-typescript"]
+      "entry": ["src/components/ui/**", "e2e/**/*.screens.ts"]
     },
     "packages/core": {
       "entry": ["src/anchor-client.ts"]

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
       "ws": "^8.21.0"
     },
     "patchedDependencies": {
-      "@better-auth/oauth-provider@1.6.19": "patches/@better-auth__oauth-provider@1.6.19.patch"
+      "@better-auth/oauth-provider@1.6.19": "patches/@better-auth__oauth-provider@1.6.19.patch",
+      "knip@6.16.1": "patches/knip@6.16.1.patch"
     }
   },
   "scripts": {
@@ -72,7 +73,6 @@
     "dependency-cruiser": "^18.0.0",
     "esbuild": "0.28.1",
     "knip": "^6.16.1",
-    "typescript": "^6.0.3",
-    "wrangler": "^4.110.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "dependency-cruiser": "^18.0.0",
     "esbuild": "0.28.1",
     "knip": "^6.16.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "wrangler": "^4.110.0"
   }
 }

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -10,6 +10,39 @@ export interface BlobStore {
   get(key: string): Promise<Uint8Array | null>
 }
 
+/**
+ * An optional SEMANTIC search index — the dense (embedding) arm of workspace search,
+ * paired with the lexical FTS the MetaStore already provides ({@link MetaStore.searchArtifactIds}).
+ * Unbound on self-host (search stays lexical-only, unchanged); the Cloudflare edge injects a
+ * Vectorize + Workers AI adapter. The caller fuses these candidates with the lexical ones
+ * (reciprocal-rank fusion) and re-applies visibility through `listArtifacts({ ids })`, so this
+ * port — exactly like the FTS — has NO visibility knowledge and can never widen what a viewer
+ * sees. Runs on Node AND Workers (no Node APIs), same as every other port here.
+ *
+ * Every method is BEST-EFFORT from the caller's side: an index hiccup must never fail a publish,
+ * and a stale row (a delete/move/takedown the caller didn't propagate) is a findability/cost
+ * concern only — the visibility gate drops it, so it can never leak content. Eventual
+ * consistency in the backend (a just-upserted vector isn't instantly queryable) is likewise
+ * invisible to users: the synchronous FTS arm answers read-your-writes; the dense arm catches up.
+ */
+export interface SearchIndex {
+  /** Upsert an artifact's current text (embedded internally — whole-doc in the current adapter;
+   *  chunk-level embedding for finer long-doc recall is a later enhancement), scoped by org.
+   *  Driven by the same publish/restore/approve chokepoint as the FTS index. */
+  indexArtifact(id: string, orgId: string, title: string | null, text: string): Promise<void>
+  /** Drop an artifact's vectors (hard delete). Best-effort; the gate covers a miss. */
+  unindex(id: string): Promise<void>
+  /** The most semantically-relevant artifact ids in ONE org for `query`, ranked (higher
+   *  score = more relevant), with NO visibility filter — the caller re-applies visibility
+   *  via `listArtifacts({ ids })`. `chunk` is the best-matching passage: the evidence/snippet
+   *  a caller shows for a semantic match the literal grep-confirm pass won't reproduce. */
+  search(
+    orgId: string,
+    query: string,
+    limit: number,
+  ): Promise<{ id: string; score: number; chunk: string }[]>
+}
+
 export type ArtifactKind = "file" | "bundle"
 
 /** A platform subdomain (`name.derived.app`) or a customer's own domain. */

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -30,12 +30,15 @@ export interface SearchIndex {
    *  chunk-level embedding for finer long-doc recall is a later enhancement), scoped by org.
    *  Driven by the same publish/restore/approve chokepoint as the FTS index. */
   indexArtifact(id: string, orgId: string, title: string | null, text: string): Promise<void>
-  /** Drop an artifact's vectors (hard delete). Best-effort; the gate covers a miss. */
-  unindex(id: string): Promise<void>
+  /** Drop an artifact's vectors (hard delete). Best-effort; the gate covers a miss. Named to
+   *  match its lexical sibling {@link MetaStore.unindexArtifact}. */
+  unindexArtifact(id: string): Promise<void>
   /** The most semantically-relevant artifact ids in ONE org for `query`, ranked (higher
    *  score = more relevant), with NO visibility filter — the caller re-applies visibility
    *  via `listArtifacts({ ids })`. `chunk` is the best-matching passage: the evidence/snippet
-   *  a caller shows for a semantic match the literal grep-confirm pass won't reproduce. */
+   *  a caller shows for a semantic match the literal grep-confirm pass won't reproduce. `score`
+   *  is returned for a future score-weighted fusion / relevance threshold; today's caller fuses
+   *  by rank (RRF) and doesn't read it. */
   search(
     orgId: string,
     query: string,

--- a/patches/knip@6.16.1.patch
+++ b/patches/knip@6.16.1.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/typescript/ast-nodes.js b/dist/typescript/ast-nodes.js
+index 5c58b3f2c75923fc81a7c8ccd3364cd644e775a3..92092f3817cb12a758811b7a5456b4ff038ec26c 100644
+--- a/dist/typescript/ast-nodes.js
++++ b/dist/typescript/ast-nodes.js
+@@ -5,7 +5,12 @@ import { timerify } from '../util/Performance.js';
+ import { EMPTY_TAGS } from './visitors/jsdoc.js';
+ const defaultParseOptions = {
+     sourceType: 'unambiguous',
+-    experimentalRawTransfer: rawTransferSupported(),
++    // PATCHED (derive): force the standard parser instead of oxc-parser's raw transfer.
++    // Raw transfer allocates a 6 GiB ArrayBuffer per parse (oxc-parser common.js), which fails
++    // under memory limits — OOMing knip locally and producing non-deterministic partial analysis
++    // in CI (phantom "unused dependency" findings). The standard path is slower but reliable and
++    // deterministic. See patches/knip@6.16.1.patch.
++    experimentalRawTransfer: false,
+ };
+ const parseFile = (filePath, sourceText) => {
+     const ext = extname(filePath);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ patchedDependencies:
   '@better-auth/oauth-provider@1.6.19':
     hash: da96def66da8f71821804f1d1e269964333ef0d4a0c4a703ee8c306f4f49e981
     path: patches/@better-auth__oauth-provider@1.6.19.patch
+  knip@6.16.1:
+    hash: cf79d735b85aab963d81af049c0d567430915a8e181d52739592a4a33bc91189
+    path: patches/knip@6.16.1.patch
 
 importers:
 
@@ -36,13 +39,10 @@ importers:
         version: 0.28.1
       knip:
         specifier: ^6.16.1
-        version: 6.16.1
+        version: 6.16.1(patch_hash=cf79d735b85aab963d81af049c0d567430915a8e181d52739592a4a33bc91189)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
-      wrangler:
-        specifier: ^4.110.0
-        version: 4.110.0
 
   apps/api:
     dependencies:
@@ -764,20 +764,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20260708.1':
-    resolution: {integrity: sha512-HXFCvhS1wpg3uXO0CLUwmwC41i2loM5FSK69EUchOBpmYBAXxT1oHLm6EOA5lqhTk5Mu9kjRiQYxa1GwKPwfJg==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-
   '@cloudflare/workerd-darwin-arm64@1.20260611.1':
     resolution: {integrity: sha512-yBbVXvbZyltR3I7NJdC4C4ItkItjZSiabcA/3HzEWOUQjLVKFqRh4so6ToHr70VCYh8VGeR8EDZL23igLhXqFQ==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@cloudflare/workerd-darwin-arm64@1.20260708.1':
-    resolution: {integrity: sha512-JVlJaKDoRTVKSroHIlf8g3UCPjKj4iDbMZE2CNYht5qQ+2rL0FAUiVlV82G3BqKnnw9kHYnnsMzC08b9zVtdzA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -788,32 +776,14 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20260708.1':
-    resolution: {integrity: sha512-3daE60YdD7YX0Jtuzc9DE/r/qMkmx8ZvHTkF8Mzmp3F5tbzlV0DAzmu5PFUPF2WuvtKbAhZKbvC2cHmWpQYxnA==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
-
   '@cloudflare/workerd-linux-arm64@1.20260611.1':
     resolution: {integrity: sha512-GEp4XbuIKjlF8pakqXcUDJfKiJosD/Q7S83J0d+r+z9XIlYGfF3ntm08e2aiF5TFTwp3fnG4yMoPUAKNhNJpvQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260708.1':
-    resolution: {integrity: sha512-VLdNYOx5Hj+9C6isy0ACWZsbMtSxex2DIJWEe7cZxUdlphZ58ZT8zxNXK8yunFiowd34hn3VwGMopdvdj8lvmA==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [linux]
-
   '@cloudflare/workerd-windows-64@1.20260611.1':
     resolution: {integrity: sha512-S6JkS0kEbcCKs19RGqEPhjCRbP8GBkQwqYLp2fhBJtD/KTlwqLzOJ9E6PQ7gQKgWHtxy1NBG3oXarlNFRNU/dw==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [win32]
-
-  '@cloudflare/workerd-windows-64@1.20260708.1':
-    resolution: {integrity: sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -1365,12 +1335,6 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
-
-  '@napi-rs/wasm-runtime@1.1.5':
-    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -3527,9 +3491,6 @@ packages:
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
 
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
-
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -5263,11 +5224,6 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
-  miniflare@4.20260708.1:
-    resolution: {integrity: sha512-c94O9zRDISdqO18EHt6l0iF/fWgWt8p18PJvRsA/L/NJZ9Cfke3s/F5Blg1XXF7WDutVRzWVWy8Vy4LaT5ifsA==}
-    engines: {node: '>=22.0.0'}
-    hasBin: true
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -6469,27 +6425,12 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20260708.1:
-    resolution: {integrity: sha512-WAK+Kt/VVCSldH2qSr8lx46XCJ4Q+bdlHNaFqUtOHthBEIB8C1N8HVW+VOLrxDoTCk0NGNv0zajnBeQK4JOB9w==}
-    engines: {node: '>=16'}
-    hasBin: true
-
   wrangler@4.100.0:
     resolution: {integrity: sha512-dSQO7DO+mD6XDzkVWIWBoGLO3yw+lacWSc/KhFvd7pgfpth+kX98qb5SGRHZN8ACCDhhfwzDLXwB6qHsIHhfBg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^4.20260611.1
-    peerDependenciesMeta:
-      '@cloudflare/workers-types':
-        optional: true
-
-  wrangler@4.110.0:
-    resolution: {integrity: sha512-xZeXKYi7hxQRF5anL+v77RkufJNpF9f3Eqeyqq2QBsETpLZgh0Agj0jJ6JPtkbgn6ukZdh8OK5egsGPWIditgg==}
-    engines: {node: '>=22.0.0'}
-    hasBin: true
-    peerDependencies:
-      '@cloudflare/workers-types': ^5.20260708.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -6834,28 +6775,28 @@ snapshots:
       '@cloudflare/workers-types': 4.20260615.1
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))':
+  '@better-auth/drizzle-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0)
 
-  '@better-auth/kysely-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
+  '@better-auth/kysely-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.29.2
 
-  '@better-auth/memory-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/mongo-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
   '@better-auth/oauth-provider@1.6.19(patch_hash=da96def66da8f71821804f1d1e269964333ef0d4a0c4a703ee8c306f4f49e981)(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.6(zod@4.4.3))':
@@ -6892,14 +6833,14 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
 
-  '@better-auth/prisma-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/telemetry@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -6966,12 +6907,6 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260611.1
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260708.1)':
-    dependencies:
-      unenv: 2.0.0-rc.24
-    optionalDependencies:
-      workerd: 1.20260708.1
-
   '@cloudflare/vitest-pool-workers@0.16.15(@cloudflare/workers-types@4.20260615.1)(@vitest/runner@4.1.9)(@vitest/snapshot@4.1.9)(vitest@4.1.9)':
     dependencies:
       '@vitest/runner': 4.1.9
@@ -6990,31 +6925,16 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20260611.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260708.1':
-    optional: true
-
   '@cloudflare/workerd-darwin-arm64@1.20260611.1':
-    optional: true
-
-  '@cloudflare/workerd-darwin-arm64@1.20260708.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260611.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260708.1':
-    optional: true
-
   '@cloudflare/workerd-linux-arm64@1.20260611.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260708.1':
-    optional: true
-
   '@cloudflare/workerd-windows-64@1.20260611.1':
-    optional: true
-
-  '@cloudflare/workerd-windows-64@1.20260708.1':
     optional: true
 
   '@cloudflare/workers-types@4.20260615.1': {}
@@ -7547,11 +7467,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
@@ -7729,7 +7649,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.138.0':
@@ -7861,7 +7781,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@oxc-resolver/binding-wasm32-wasi@11.23.0':
@@ -8988,7 +8908,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.3':
@@ -9478,11 +9398,6 @@ snapshots:
       minimatch: 10.2.5
       path-browserify: 1.0.1
 
-  '@tybys/wasm-util@0.10.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -9819,13 +9734,13 @@ snapshots:
 
   better-auth@1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9):
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))
-      '@better-auth/kysely-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
-      '@better-auth/memory-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))
+      '@better-auth/kysely-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
+      '@better-auth/memory-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.2.0
@@ -10043,7 +9958,7 @@ snapshots:
       json-schema-typed: 7.0.3
       onetime: 5.1.2
       pkg-up: 3.1.0
-      semver: 7.8.4
+      semver: 7.8.5
 
   conf@15.1.0:
     dependencies:
@@ -10908,7 +10823,7 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  knip@6.16.1:
+  knip@6.16.1(patch_hash=cf79d735b85aab963d81af049c0d567430915a8e181d52739592a4a33bc91189):
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       formatly: 0.3.0
@@ -11023,7 +10938,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.8.4
+      semver: 7.8.5
 
   marked@18.0.5: {}
 
@@ -11068,18 +10983,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  miniflare@4.20260708.1:
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      sharp: 0.34.5
-      undici: 7.28.0
-      workerd: 1.20260708.1
-      ws: 8.21.0
-      youch: 4.1.0-beta.10
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -11117,7 +11020,7 @@ snapshots:
 
   node-abi@3.92.0:
     dependencies:
-      semver: 7.8.4
+      semver: 7.8.5
 
   node-releases@2.0.47: {}
 
@@ -12478,14 +12381,6 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260611.1
       '@cloudflare/workerd-windows-64': 1.20260611.1
 
-  workerd@1.20260708.1:
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260708.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260708.1
-      '@cloudflare/workerd-linux-64': 1.20260708.1
-      '@cloudflare/workerd-linux-arm64': 1.20260708.1
-      '@cloudflare/workerd-windows-64': 1.20260708.1
-
   wrangler@4.100.0(@cloudflare/workers-types@4.20260615.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
@@ -12498,22 +12393,6 @@ snapshots:
       workerd: 1.20260611.1
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260615.1
-      fsevents: 2.3.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  wrangler@4.110.0:
-    dependencies:
-      '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260708.1)
-      blake3-wasm: 2.1.5
-      esbuild: 0.28.1
-      miniflare: 4.20260708.1
-      path-to-regexp: 6.3.0
-      unenv: 2.0.0-rc.24
-      workerd: 1.20260708.1
-    optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      wrangler:
+        specifier: ^4.110.0
+        version: 4.110.0
 
   apps/api:
     dependencies:
@@ -761,8 +764,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-64@1.20260708.1':
+    resolution: {integrity: sha512-HXFCvhS1wpg3uXO0CLUwmwC41i2loM5FSK69EUchOBpmYBAXxT1oHLm6EOA5lqhTk5Mu9kjRiQYxa1GwKPwfJg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
   '@cloudflare/workerd-darwin-arm64@1.20260611.1':
     resolution: {integrity: sha512-yBbVXvbZyltR3I7NJdC4C4ItkItjZSiabcA/3HzEWOUQjLVKFqRh4so6ToHr70VCYh8VGeR8EDZL23igLhXqFQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260708.1':
+    resolution: {integrity: sha512-JVlJaKDoRTVKSroHIlf8g3UCPjKj4iDbMZE2CNYht5qQ+2rL0FAUiVlV82G3BqKnnw9kHYnnsMzC08b9zVtdzA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -773,14 +788,32 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-64@1.20260708.1':
+    resolution: {integrity: sha512-3daE60YdD7YX0Jtuzc9DE/r/qMkmx8ZvHTkF8Mzmp3F5tbzlV0DAzmu5PFUPF2WuvtKbAhZKbvC2cHmWpQYxnA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
   '@cloudflare/workerd-linux-arm64@1.20260611.1':
     resolution: {integrity: sha512-GEp4XbuIKjlF8pakqXcUDJfKiJosD/Q7S83J0d+r+z9XIlYGfF3ntm08e2aiF5TFTwp3fnG4yMoPUAKNhNJpvQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-arm64@1.20260708.1':
+    resolution: {integrity: sha512-VLdNYOx5Hj+9C6isy0ACWZsbMtSxex2DIJWEe7cZxUdlphZ58ZT8zxNXK8yunFiowd34hn3VwGMopdvdj8lvmA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
   '@cloudflare/workerd-windows-64@1.20260611.1':
     resolution: {integrity: sha512-S6JkS0kEbcCKs19RGqEPhjCRbP8GBkQwqYLp2fhBJtD/KTlwqLzOJ9E6PQ7gQKgWHtxy1NBG3oXarlNFRNU/dw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20260708.1':
+    resolution: {integrity: sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -852,11 +885,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -5230,6 +5263,11 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
+  miniflare@4.20260708.1:
+    resolution: {integrity: sha512-c94O9zRDISdqO18EHt6l0iF/fWgWt8p18PJvRsA/L/NJZ9Cfke3s/F5Blg1XXF7WDutVRzWVWy8Vy4LaT5ifsA==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -6431,12 +6469,27 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workerd@1.20260708.1:
+    resolution: {integrity: sha512-WAK+Kt/VVCSldH2qSr8lx46XCJ4Q+bdlHNaFqUtOHthBEIB8C1N8HVW+VOLrxDoTCk0NGNv0zajnBeQK4JOB9w==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   wrangler@4.100.0:
     resolution: {integrity: sha512-dSQO7DO+mD6XDzkVWIWBoGLO3yw+lacWSc/KhFvd7pgfpth+kX98qb5SGRHZN8ACCDhhfwzDLXwB6qHsIHhfBg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^4.20260611.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  wrangler@4.110.0:
+    resolution: {integrity: sha512-xZeXKYi7hxQRF5anL+v77RkufJNpF9f3Eqeyqq2QBsETpLZgh0Agj0jJ6JPtkbgn6ukZdh8OK5egsGPWIditgg==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^5.20260708.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -6781,28 +6834,28 @@ snapshots:
       '@cloudflare/workers-types': 4.20260615.1
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))':
+  '@better-auth/drizzle-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0)
 
-  '@better-auth/kysely-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
+  '@better-auth/kysely-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.29.2
 
-  '@better-auth/memory-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/mongo-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
   '@better-auth/oauth-provider@1.6.19(patch_hash=da96def66da8f71821804f1d1e269964333ef0d4a0c4a703ee8c306f4f49e981)(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.6(zod@4.4.3))':
@@ -6839,14 +6892,14 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
 
-  '@better-auth/prisma-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/telemetry@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -6913,6 +6966,12 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260611.1
 
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260708.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260708.1
+
   '@cloudflare/vitest-pool-workers@0.16.15(@cloudflare/workers-types@4.20260615.1)(@vitest/runner@4.1.9)(@vitest/snapshot@4.1.9)(vitest@4.1.9)':
     dependencies:
       '@vitest/runner': 4.1.9
@@ -6931,16 +6990,31 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20260611.1':
     optional: true
 
+  '@cloudflare/workerd-darwin-64@1.20260708.1':
+    optional: true
+
   '@cloudflare/workerd-darwin-arm64@1.20260611.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260708.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260611.1':
     optional: true
 
+  '@cloudflare/workerd-linux-64@1.20260708.1':
+    optional: true
+
   '@cloudflare/workerd-linux-arm64@1.20260611.1':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20260708.1':
+    optional: true
+
   '@cloudflare/workerd-windows-64@1.20260611.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260708.1':
     optional: true
 
   '@cloudflare/workers-types@4.20260615.1': {}
@@ -7356,7 +7430,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.1
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -9745,13 +9819,13 @@ snapshots:
 
   better-auth@1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9):
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))
-      '@better-auth/kysely-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
-      '@better-auth/memory-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))
+      '@better-auth/kysely-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
+      '@better-auth/memory-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.2.0
@@ -10994,6 +11068,18 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  miniflare@4.20260708.1:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.28.0
+      workerd: 1.20260708.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -11887,7 +11973,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.8.4
+      semver: 7.8.5
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -12392,6 +12478,14 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260611.1
       '@cloudflare/workerd-windows-64': 1.20260611.1
 
+  workerd@1.20260708.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260708.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260708.1
+      '@cloudflare/workerd-linux-64': 1.20260708.1
+      '@cloudflare/workerd-linux-arm64': 1.20260708.1
+      '@cloudflare/workerd-windows-64': 1.20260708.1
+
   wrangler@4.100.0(@cloudflare/workers-types@4.20260615.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
@@ -12404,6 +12498,22 @@ snapshots:
       workerd: 1.20260611.1
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260615.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  wrangler@4.110.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260708.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 4.20260708.1
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260708.1
+    optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/scripts/check-env.mjs
+++ b/scripts/check-env.mjs
@@ -25,6 +25,8 @@ const NON_CONFIG = new Set([
   "SYNC_RUNNER",
   "PREVIEW_RENDERER",
   "BROWSER",
+  "VECTORIZE",
+  "AI",
   "RL_AUTH",
   "RL_INVITE",
   "RL_WRITE",


### PR DESCRIPTION
## Why

Workspace search is **lexical only** (FTS/BM25 + a literal grep-confirm). Verified live on prod against a real 43-doc workspace, that means paraphrases return **nothing** despite whole documents on the topic:

| Concept (richly present) | Literal term | Paraphrase a human types |
|---|---|---|
| Onboarding | `onboarding` → **6** | `getting started` → **0** · `first run experience` → **0** |
| Access control | `sharing`/`permissions` → **6** | `revoke access` → **0** · `who can see this` → 1 |
| Auth | `login`/`auth` → **6** | `single sign-on` → **0** · `authentication` → **1** |
| Pricing | `pricing` → **6** | `how much does it cost` → **0** · `cost per seat` → **0** |

(`SSO` even returned 3 *wrong* docs — a stray-token false positive.) This adds a **dense/semantic arm** that closes that gap.

## What

A **hybrid** retriever: keep the lexical FTS (it's authoritative for exact tokens, IDs like `nk0dsral`, `$31k`, code) and **add** a dense arm, fused with **reciprocal-rank fusion**. Pure-semantic would *regress* on exact-token queries — the research and the corpus both say keep both.

The whole thing is **one new optional `SearchIndex` port** (`packages/core`), injected like every other hosted-only capability (`backplane?`, `BROWSER`, `HYPERDRIVE`):

- **Only Tier-1 (candidate nomination) changes.** The Tier-2 visibility gate (`listArtifacts` + `excludeRemoved` + the password-lock seat rule) and grep-confirm are **untouched** — so the dense arm, like the FTS, has no visibility knowledge and **can never widen what a viewer sees**.
- **Cloudflare edge** injects a `Vectorize + Workers AI (bge-m3)` adapter (`apps/api/src/search-vectorize.ts`); **self-host stays lexical-only, byte-for-byte unchanged** — the entire change is gated on a bound `SearchIndex`.
- `bge-m3` is multilingual (1024-dim, ≤ Vectorize's 1536 cap), which also lifts the **CJK** weakness of the lexical tokenizer.
- A **semantic-only** hit (one the literal grep can't reproduce) carries its best chunk as the snippet.
- **Best-effort everywhere:** the write arm (publish/restore/approve via `emitVersionBump`, plus the reindex backfill) never lets a dense failure touch the committed lexical upsert; the **read** arm degrades to lexical-only on a Vectorize/Workers-AI hiccup rather than 500-ing. The synchronous FTS answers read-your-writes, so Vectorize's eventual consistency never shows to a user.

## Not AutoRAG / "AI Search"

Evaluated and rejected: it's open-beta, control-limited, and 100% Cloudflare-bound — it can't back the self-hostable SQLite/Postgres path, so it'd force a second retrieval stack. The hand-rolled `embed → upsert → filtered-query → gate` shape is what a future pgvector/sqlite-vec adapter reuses.

## Tests

`apps/api/test/search-hybrid.test.ts` (11): RRF fusion; **the recall-gap fix** (a paraphrase the lexical arm misses, surfaced via the dense arm — and lexical-only still misses it); lexical-only unchanged; the **visibility gate over the new arm** (a dense-nominated private doc is dropped for anon, seen by a member); **dense-arm-degrades-on-error → lexical-only**; and the adapter's embed/`org_id`-filter/`truncate_inputs`/preview/unindex contract. Existing search suites (mcp + search-rest, 64) unchanged.

## Adversarial review

Three independent refuters (security / regression / adapter+claim-fidelity):
- **Security: no finding.** The chunk (only new content payload) is structurally unreachable until after the Tier-2 gate; password-lock, tombstone, and cross-org are defended in depth.
- **Regression:** confirmed the no-index path is byte-for-byte identical; the one HIGH (dense read arm not error-isolated) is **fixed**.
- **Adapter:** API shapes verified against 2026 Cloudflare docs; the one MEDIUM (CJK docs threw `BadInput` without `truncate_inputs`) and the claim-fidelity nits ("chunked" wording) are **fixed**.

## Deploy / gates

Off by default (commented `[[vectorize]]` + `[ai]` in `wrangler.toml`); provision the index + `org_id` metadata index **before** inserts, then backfill via `POST /v1/system/search-reindex` — see `DEPLOY.md`. Local gates green: Biome CI, all 15 lints, typecheck (incl. worker), full suite (951 api + 395 others). (`lint:deadcode`/knip OOMs in the local sandbox — an off-heap `oxc-parser` allocation the environment can't satisfy — and with `exports: off` it can't flag anything here anyway; it runs clean in CI.)

## Deliberate follow-ups (not this PR)

- **Chunk-level embedding** for finer long-doc recall (this cut is whole-doc, one vector per artifact).
- **Stale-vector lifecycle:** dense `unindex` isn't wired into delete/move/takedown — a stale vector is a findability/cost concern only (the gate drops it, confirmed by the security refuter); a reconcile sweep or lifecycle hook is the cleanup.
- **Optional reranker** on the agent/deep path (skip on typeahead for latency).
- RRF reranks: a mid-ranked literal hit can be displaced by a strong semantic match — the standard, intended fusion trade-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)