### PR TITLE
feat(search): a measured relevance floor on the dense arm + batched backfill

### DIFF
--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -382,6 +382,7 @@ export const reindexSearchBatch = async (
     excludeRemoved: true,
   })
   let indexed = 0
+  const denseItems: { id: string; orgId: string; title: string | null; text: string }[] = []
   for (const a of arts) {
     // Isolate each artifact: a single unreadable blob / transient store error must not
     // abort the whole batch and wedge the operator's cursor (unlike the publish path,
@@ -389,10 +390,25 @@ export const reindexSearchBatch = async (
     try {
       const v = await deps.meta.getVersion(a.id, a.current_version)
       if (!v) continue // no readable current version — skip rather than index empty
-      await indexArtifactVersion(deps.meta, deps.blobs, a, v, deps.search)
+      const text = await versionIndexText(deps.blobs, v)
+      await deps.meta.indexArtifact(a.id, a.org_id, a.title, text) // lexical arm (synchronous truth)
+      denseItems.push({ id: a.id, orgId: a.org_id, title: a.title, text })
       indexed++
     } catch (err) {
       log.error("search reindex skipped one artifact", { artifact: a.id, err: String(err) })
+    }
+  }
+  // Dense arm: batched embed+upsert (in sub-batches) instead of one-per-artifact — far fewer
+  // Workers-AI calls + Vectorize mutations, so a bundle-dense page is much less likely to breach the
+  // subrequest ceiling. Best-effort, like the publish path: a dense hiccup logs and moves on — the
+  // lexical arm already committed and the next publish/sweep re-adds. NOTE: `indexed` counts LEXICAL
+  // successes, so a dense-arm failure won't show as `indexed < scanned`; a full re-sweep is the
+  // dense safety net.
+  if (deps.search && denseItems.length) {
+    try {
+      await deps.search.indexArtifacts(denseItems)
+    } catch (err) {
+      log.error("search reindex: dense batch failed", { err: String(err) })
     }
   }
   // A full page implies there may be more; the last row is the keyset for the next call

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -58,14 +58,14 @@ export const systemRoutes = (ctx: AppContext) => {
   // wiring — or created outside it — need a one-time sweep. Operator-only, idempotent,
   // and bounded: it indexes one page (default 100, max 200) and returns `nextCursor`;
   // the operator re-POSTs with that cursor until it comes back null. The cap stays modest
-  // because a bundle indexes every page it holds — a bundle-dense page of 500 could breach
-  // the Worker's per-invocation subrequest ceiling, which the per-artifact try/catch would
-  // silently swallow as "skipped." NOTE: once that ceiling trips mid-page, every remaining
-  // artifact on the page also throws + skips, yet `nextCursor` still advances past them — so a
-  // page returning `indexed < scanned` left some un-embedded that the normal resume loop won't
-  // revisit. On a bundle-heavy corpus, use a smaller `limit`, and re-sweep from cursor 0 (it's
-  // idempotent) to catch skips. Keeping each call bounded is what fits the Workers CPU +
-  // subrequest budget rather than one unbounded pass. Run it as
+  // because it reads every page a bundle holds. The dense arm now embeds + upserts in BATCHES (few
+  // subrequests), so the per-invocation budget is dominated by the LEXICAL arm's per-artifact blob
+  // read + D1 write; keeping `limit` ≤ 200 holds that under the Worker's subrequest ceiling. Two
+  // failure modes to know: (1) one artifact's lexical index fails (e.g. an unreadable blob) — caught
+  // per-artifact, and `indexed < scanned` flags it, so re-sweep from cursor 0 (idempotent) to catch
+  // it; (2) the whole dense BATCH fails — best-effort, swallowed after the loop, so it does NOT lower
+  // `indexed`; if the dense arm was down for a page, re-sweep from cursor 0. Keeping each call
+  // bounded fits the Workers CPU + subrequest budget rather than one unbounded pass. Run it as
   // a one-time backfill: under a concurrent live publish it could momentarily write
   // older-version text for that artifact, but grep-confirm reads the live blob (so
   // precision holds) and the next publish re-indexes it — the staleness self-heals.

--- a/apps/api/src/search-vectorize.ts
+++ b/apps/api/src/search-vectorize.ts
@@ -47,6 +47,19 @@ export const EMBED_MODEL = "@cf/baai/bge-m3"
 export const EMBED_CHAR_BUDGET = 24_000
 // The stored semantic snippet (Vectorize metadata caps at 10 KiB/vector; this stays far under it).
 export const PREVIEW_CHARS = 480
+// Minimum cosine similarity for a dense candidate to count as relevant. Calibrated on the live
+// bge-m3 index from a SMALL sample (3 real + 3 gibberish queries): real-query top matches sat
+// ~0.53–0.60, off-target ones ~0.44–0.54. At 0.48 it removes the lowest slice of noise (a gibberish
+// query drops from ~6 weak hits to 0–1) while preserving every observed real match (lowest ~0.527)
+// — but the ranges OVERLAP, so it's a precision/recall trade point, not a free lunch: noise up to
+// ~0.54 still passes, and a genuinely-relevant-but-weak dense-ONLY match below 0.48 (a pure synonym
+// with zero lexical overlap) is also dropped. A discriminative reranker + chunk-level embeddings are
+// the real precision lever (they need a re-backfill — deliberate follow-up). Tunable; exported so it
+// can be adjusted or referenced in tests.
+export const DENSE_MIN_SCORE = 0.48
+// Embed at most this many texts per Workers-AI call — bge-m3's sync-embed batch ceiling is 100, so
+// 50 is conservative. Exported for the sub-batch test.
+export const EMBED_BATCH = 50
 
 export class VectorizeSearchIndex implements SearchIndex {
   constructor(
@@ -55,11 +68,11 @@ export class VectorizeSearchIndex implements SearchIndex {
     private readonly model: string = EMBED_MODEL,
   ) {}
 
+  // truncate_inputs:true so an over-8192-token body (long or CJK docs, where ~1 char ≈ 1 token)
+  // trims to the limit instead of throwing BadInput — otherwise those docs silently never embed.
   private async embed(text: string): Promise<number[]> {
-    // truncate_inputs:true so an over-8192-token body (long or CJK docs, where ~1 char ≈ 1 token)
-    // trims to the limit instead of throwing BadInput — otherwise those docs silently never embed.
     const { data } = await this.ai.run(this.model, { text: [text], truncate_inputs: true })
-    const vector = data[0]
+    const [vector] = data
     if (!vector) throw new Error("empty embedding from Workers AI")
     return vector
   }
@@ -77,6 +90,42 @@ export class VectorizeSearchIndex implements SearchIndex {
     await this.vectorize.upsert([
       { id, values, metadata: { org_id: orgId, preview: content.slice(0, PREVIEW_CHARS) } },
     ])
+  }
+
+  async indexArtifacts(
+    items: { id: string; orgId: string; title: string | null; text: string }[],
+  ): Promise<void> {
+    const prepared = items.map((it) => ({
+      id: it.id,
+      orgId: it.orgId,
+      content: it.title ? `${it.title}\n\n${it.text}` : it.text,
+    }))
+    // Empty-content artifacts (e.g. a bare image) carry no vector — drop any stale one, as the
+    // single path does.
+    const empty = prepared.filter((p) => !p.content.trim()).map((p) => p.id)
+    if (empty.length) await this.vectorize.deleteByIds(empty)
+    const embeddable = prepared.filter((p) => p.content.trim())
+    // Embed + upsert PER sub-batch (not one flatten over the whole page): a transient failure is
+    // bounded to one sub-batch instead of losing the page's dense arm, and vectors can never
+    // misalign to the wrong artifact across sub-batch seams. bge-m3 returns one vector per input in
+    // order; the length check turns a short/misordered response into a loud failure rather than
+    // silent cross-contamination.
+    for (let i = 0; i < embeddable.length; i += EMBED_BATCH) {
+      const slice = embeddable.slice(i, i + EMBED_BATCH)
+      const { data } = await this.ai.run(this.model, {
+        text: slice.map((p) => p.content.slice(0, EMBED_CHAR_BUDGET)),
+        truncate_inputs: true,
+      })
+      if (data.length !== slice.length)
+        throw new Error(`bge-m3 returned ${data.length} vectors for ${slice.length} inputs`)
+      await this.vectorize.upsert(
+        slice.map((p, j) => ({
+          id: p.id,
+          values: data[j] as number[],
+          metadata: { org_id: p.orgId, preview: p.content.slice(0, PREVIEW_CHARS) },
+        })),
+      )
+    }
   }
 
   async unindexArtifact(id: string): Promise<void> {
@@ -99,10 +148,16 @@ export class VectorizeSearchIndex implements SearchIndex {
       filter: { org_id: orgId },
       returnMetadata: "all",
     })
-    return matches.map((m) => ({
-      id: m.id,
-      score: m.score,
-      chunk: typeof m.metadata?.preview === "string" ? m.metadata.preview : "",
-    }))
+    // Relevance floor: Vectorize always returns its nearest topK however far away they are, so
+    // without this an off-target query surfaces weak noise. Drop sub-threshold matches (see
+    // DENSE_MIN_SCORE) — the grep-confirm/fusion downstream can't recover precision the vector
+    // query already lost.
+    return matches
+      .filter((m) => m.score >= DENSE_MIN_SCORE)
+      .map((m) => ({
+        id: m.id,
+        score: m.score,
+        chunk: typeof m.metadata?.preview === "string" ? m.metadata.preview : "",
+      }))
   }
 }

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -915,6 +915,7 @@ describe("remote MCP endpoint (/mcp)", () => {
       indexArtifact: async (id) => {
         indexed.push(id)
       },
+      indexArtifacts: async () => {},
       unindexArtifact: async () => {},
       search: async () => [],
     }

--- a/apps/api/test/search-hybrid.test.ts
+++ b/apps/api/test/search-hybrid.test.ts
@@ -12,6 +12,8 @@ import {
   workspaceSearchReport,
 } from "../src/lib/search"
 import {
+  DENSE_MIN_SCORE,
+  EMBED_BATCH,
   type VectorizeLike,
   VectorizeSearchIndex,
   type WorkersAiLike,
@@ -70,6 +72,7 @@ const denseIndex = (
   byQuery: Record<string, { id: string; score: number; chunk: string }[]>,
 ): SearchIndex => ({
   indexArtifact: async () => {},
+  indexArtifacts: async () => {},
   unindexArtifact: async () => {},
   search: async (_org, query, limit) => (byQuery[query] ?? []).slice(0, limit),
 })
@@ -223,6 +226,7 @@ describe("searchWorkspace — hybrid retrieval", () => {
     }
     const boom: SearchIndex = {
       indexArtifact: async () => {},
+      indexArtifacts: async () => {},
       unindexArtifact: async () => {},
       search: async () => {
         throw new Error("vectorize unavailable")
@@ -321,6 +325,76 @@ describe("VectorizeSearchIndex (Cloudflare adapter)", () => {
     expect(await new VectorizeSearchIndex(vectorize, ai).search("org1", "   ", 6)).toEqual([])
     expect(runs).toHaveLength(0)
   })
+
+  it("search applies the relevance floor at DENSE_MIN_SCORE (>= kept, just-below dropped)", async () => {
+    const { ai } = makeAi()
+    const vectorize: VectorizeLike = {
+      upsert: async () => {},
+      deleteByIds: async () => {},
+      query: async () => ({
+        matches: [
+          { id: "above", score: 0.6, metadata: { preview: "above" } },
+          { id: "at", score: DENSE_MIN_SCORE, metadata: { preview: "exactly at the floor" } },
+          { id: "below", score: DENSE_MIN_SCORE - 0.001, metadata: { preview: "just below" } },
+        ],
+      }),
+    }
+    const hits = await new VectorizeSearchIndex(vectorize, ai).search("org1", "q", 6)
+    expect(hits.map((h) => h.id)).toEqual(["above", "at"]) // >= floor kept; just-below dropped
+  })
+
+  it("indexArtifacts batches: one embed call for the page, empties dropped, org_id + preview stored", async () => {
+    const { vectorize, store } = makeVectorize()
+    const { ai, runs } = makeAi()
+    await new VectorizeSearchIndex(vectorize, ai).indexArtifacts([
+      { id: "a1", orgId: "org1", title: "T1", text: "body one" },
+      { id: "a2", orgId: "org1", title: null, text: "body two" },
+      { id: "a3", orgId: "org1", title: null, text: "   " }, // empty → no vector
+    ])
+    expect(store.has("a1")).toBe(true)
+    expect(store.has("a2")).toBe(true)
+    expect(store.has("a3")).toBe(false) // empty content: no upsert
+    expect(store.get("a1")?.metadata?.org_id).toBe("org1")
+    expect(store.get("a1")?.metadata?.preview).toContain("T1")
+    expect(runs).toHaveLength(1) // batched — one AI call for both embeddable texts, not two
+    expect(runs[0]?.text).toEqual(["T1\n\nbody one", "body two"])
+    expect(runs[0]?.truncate).toBe(true)
+  })
+
+  it("indexArtifacts sub-batches a large page (embed+upsert per EMBED_BATCH), preserving id↔text order", async () => {
+    const { vectorize, store } = makeVectorize()
+    const { ai, runs } = makeAi()
+    const n = EMBED_BATCH + 5
+    const items = Array.from({ length: n }, (_, i) => ({
+      id: `id${i}`,
+      orgId: "org1",
+      title: null,
+      text: `body ${i}`,
+    }))
+    await new VectorizeSearchIndex(vectorize, ai).indexArtifacts(items)
+    expect(runs.length).toBe(2) // ceil((EMBED_BATCH+5)/EMBED_BATCH) = 2 sub-batches
+    expect(runs[0]?.text).toHaveLength(EMBED_BATCH)
+    expect(runs[1]?.text).toEqual([
+      `body ${EMBED_BATCH}`,
+      `body ${EMBED_BATCH + 1}`,
+      `body ${EMBED_BATCH + 2}`,
+      `body ${EMBED_BATCH + 3}`,
+      `body ${EMBED_BATCH + 4}`,
+    ])
+    expect(store.size).toBe(n) // every artifact upserted, across the sub-batch seam
+    expect(store.has(`id${EMBED_BATCH}`)).toBe(true) // first of the 2nd sub-batch
+  })
+
+  it("indexArtifacts throws (not misaligns) if the model returns fewer vectors than inputs", async () => {
+    const { vectorize } = makeVectorize()
+    const ai: WorkersAiLike = { run: async () => ({ data: [[0.1, 0.2]] }) } // 1 vector for N inputs
+    await expect(
+      new VectorizeSearchIndex(vectorize, ai).indexArtifacts([
+        { id: "a", orgId: "o", title: null, text: "x" },
+        { id: "b", orgId: "o", title: null, text: "y" },
+      ]),
+    ).rejects.toThrow(/returned 1 vectors for 2/)
+  })
 })
 
 describe("workspaceSearchReport — semantic rendering", () => {
@@ -406,14 +480,19 @@ describe("write path — dense arm best-effort + backfill", () => {
       getVersion: async () => ({ blob_key: "k", content_type: "text/markdown" }) as VersionRecord,
     }
     const blobs = { get: async () => enc("body"), put: async () => "k" }
+    let denseCalls = 0
     const search: SearchIndex = {
-      indexArtifact: async (id) => {
-        dense.push(id)
+      indexArtifact: async () => {},
+      // backfill uses the BATCH path now — record the ids, and count the calls
+      indexArtifacts: async (items) => {
+        denseCalls++
+        dense.push(...items.map((i) => i.id))
       },
       unindexArtifact: async () => {},
       search: async () => [],
     }
     const res = await reindexSearchBatch({ meta, blobs, search }, { limit: 10 })
+    expect(denseCalls).toBe(1) // ONE batched dense call for the page, not one per artifact
     expect(dense).toEqual(["a", "b"])
     expect(res.indexed).toBe(2)
   })

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -30,6 +30,12 @@ export interface SearchIndex {
    *  chunk-level embedding for finer long-doc recall is a later enhancement), scoped by org.
    *  Driven by the same publish/restore/approve chokepoint as the FTS index. */
   indexArtifact(id: string, orgId: string, title: string | null, text: string): Promise<void>
+  /** Batch variant of {@link indexArtifact} for the backfill sweep: embed + upsert a page in
+   *  sub-batches — far fewer Workers-AI calls + Vectorize mutations than one call per artifact.
+   *  Single publishes still use indexArtifact. Best-effort like the rest. */
+  indexArtifacts(
+    items: { id: string; orgId: string; title: string | null; text: string }[],
+  ): Promise<void>
   /** Drop an artifact's vectors (hard delete). Best-effort; the gate covers a miss. Named to
    *  match its lexical sibling {@link MetaStore.unindexArtifact}. */
   unindexArtifact(id: string): Promise<void>


### PR DESCRIPTION
Two deploy-safe improvements to the live hybrid search (no re-backfill needed) — done via the ship-loop, with the design driven by **measurement, not instinct**.

## Why (measured, not guessed)
Querying the *live* index showed two things:
- **The dense arm returns noise for off-target queries.** Vectorize always returns its nearest topK however far away, and the score was discarded — so a gibberish query surfaced ~6 weak "hits." Measured cosines: real-query tops **~0.53–0.60**, off-target **~0.44–0.54**.
- **A naive threshold *and* a reranker both fail on the current whole-doc granularity** — `bge-m3`'s cosine distribution is narrow/overlapping, and `bge-reranker-base` scored near-zero on doc-head previews (it needs the actual passage). The real precision lever is **chunk-level embeddings** — which needs a re-backfill, so it's a deliberate follow-up, not an autonomous surprise on prod.

## What
1. **Relevance floor** (`DENSE_MIN_SCORE = 0.48`) in the Vectorize adapter — drops sub-threshold matches so an off-target query returns 0–1 instead of ~6. Calibrated below the lowest observed real match (~0.527) → **no *observed* recall loss**. Honest: the ranges overlap, so it's a precision/recall trade point (a pure-synonym match below 0.48 with zero lexical overlap is also dropped), not a free lunch. Tunable + exported.
2. **Batched backfill** — new `SearchIndex.indexArtifacts` embeds + upserts **per sub-batch** (`EMBED_BATCH=50`, under bge-m3's 100 ceiling) instead of one Workers-AI call + upsert per artifact. Far fewer subrequests (bundle-dense pages less likely to breach the ceiling). Per-sub-batch (not a page-wide flatten) **bounds a transient failure to 50 artifacts** and makes cross-artifact vector misalignment impossible; a short/misordered model response throws loudly rather than cross-contaminating.

## Verification & audit
- Measured the thresholds on the live index; verified a **50-text bge-m3 batch returns 50 ordered 1024-dim vectors** on real Cloudflare.
- **Two independent adversarial refuters:** runtime ceilings confirmed safe (embed 50≤100, upsert ≤200≤1000, topK 50); the lexical path proven byte-identical; self-host unchanged. Their findings — the "no recall loss" overstatement, the batch blast-radius + misalignment risk, and test gaps (>50-item sub-batch path, floor boundary) — are **all fixed** in this diff.
- Local gates green: `pnpm run ci` (incl. knip), typecheck (default + worker), full api suite **962**.

## Deferred (documented, need a re-backfill / bigger bets)
Chunk-level embeddings + a reranker (the real precision lever); a brute-force-cosine-in-DB adapter (kills eventual-consistency + edge-only, for current scale); a reconcile sweep for orphan vectors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)