### PR TITLE
feat(search): chunk-level dense embedding — one vector per passage, best-chunk rollup

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -308,8 +308,15 @@ curl -XPOST -H "authorization: Bearer $DERIVE_TOKEN" https://<host>/v1/system/se
 
 Vectorize is eventually consistent (a just-upserted vector is queryable within seconds–minutes), but
 the synchronous lexical arm answers read-your-writes for a fresh publish, so this never shows to a
-user. Costs are modest (Workers AI embeddings + Vectorize stored/queried dimensions); see the
-Cloudflare pricing pages. Left off by default so a deploy without the index provisioned never fails.
+user. Left off by default so a deploy without the index provisioned never fails.
+
+**Cost note.** Each artifact is chunk-embedded (one vector per ~1800-char passage, ≤20/doc), so the
+index holds ~5–20× more vectors than one-vector-per-doc would. Vectorize bills queried dimensions on
+*stored-vector count* (not `topK`), so that multiplier scales both stored **and** per-search cost:
+e.g. a ~240-doc corpus grows to ≤~4.8k vectors, which can exhaust the free queried-dimension tier in
+a handful of searches/month. This is the deliberate price of chunk-level precision; Workers-AI
+embedding tokens rise only ~1.2–1.5×. See the Cloudflare Vectorize + Workers AI pricing pages, and
+re-run the backfill after changing chunking so stored vectors match the new scheme.
 
 ---
 

--- a/apps/api/src/search-vectorize.ts
+++ b/apps/api/src/search-vectorize.ts
@@ -2,14 +2,19 @@ import type { SearchIndex } from "@derive/core"
 
 // The Cloudflare-edge adapter for the SearchIndex port: dense/semantic workspace search over
 // Vectorize, embeddings from Workers AI. Model is bge-m3 (1024-dim — under Vectorize's 1536 cap —
-// 8K-token, 100+ languages, which also lifts the CJK weakness of the lexical FTS). ONE vector per
-// artifact (whole-doc embed) in this first cut: re-index is an upsert by artifact id and unindex a
-// single delete, so lifecycle stays trivial; chunk-level embedding (finer recall on long docs) is a
-// later enhancement. `org_id` is a pre-declared Vectorize metadata index so a query filters to one
-// workspace — per-viewer visibility stays in the caller's Tier-2 gate, so this adapter, like the
-// FTS, never widens what a viewer sees. Structural binding interfaces (rather than
-// @cloudflare/workers-types) keep it unit-testable with a fake and robust to type-package churn;
-// the real `env.VECTORIZE` / `env.AI` bindings satisfy them structurally.
+// 8K-token, 100+ languages, which also lifts the CJK weakness of the lexical FTS). CHUNK-LEVEL: each
+// artifact is split into ~450-token passages, one vector per chunk (id `${artifactId}#i`), so a
+// query matching a specific passage scores against THAT passage instead of the whole-doc average —
+// sharper relevance, and the stored snippet is drawn from the matching chunk (its head, not
+// necessarily the exact matched sentence). `search` rolls chunk hits up to the best chunk per
+// artifact. Chunking multiplies the vector count ~5–20×, which scales Vectorize's stored- AND
+// queried-dimension billing the same (query cost bills on stored-vector count, not topK): a ~240-doc
+// corpus goes from ~240 to ≤~4.8k vectors, enough to exhaust the free queried-dim tier in a handful
+// of searches/month — the deliberate cost of the precision win. `org_id` is a pre-declared metadata
+// index so a query filters to one workspace — per-viewer visibility stays in the caller's Tier-2
+// gate, so this adapter, like the FTS, never widens what a viewer sees. Structural binding
+// interfaces (rather than @cloudflare/workers-types) keep it unit-testable with a fake and robust to
+// type-package churn; the real `env.VECTORIZE` / `env.AI` bindings satisfy them structurally.
 
 /** The slice of a Vectorize binding this adapter uses. */
 export interface VectorizeLike {
@@ -37,29 +42,72 @@ export interface WorkersAiLike {
 }
 
 export const EMBED_MODEL = "@cf/baai/bge-m3"
-// A payload guard on the text handed to the model, NOT the real token bound. bge-m3 accepts 8192
-// tokens and we pass `truncate_inputs: true`, so the MODEL trims anything longer to its first 8192
-// tokens — the tail drops (the lexical arm and the one-artifact grep still reach a past-the-bound
-// hit, same shape as the FTS MAX_INDEX_TEXT bound). This char cap just avoids shipping a multi-MB
-// body: ~24k chars is roughly a whole Latin doc (~6k tokens); for dense scripts (≈1 token/char) the
-// model's token truncation is what bounds it. WITHOUT truncate_inputs an over-limit input is a
-// BadInput error, not a silent trim — which would drop long (esp. CJK) docs from the dense index.
-export const EMBED_CHAR_BUDGET = 24_000
-// The stored semantic snippet (Vectorize metadata caps at 10 KiB/vector; this stays far under it).
+// Target chunk size in chars (~450 bge-m3 tokens at ~4 chars/token for Latin text) with ~15% overlap
+// so a match spanning a boundary still lands wholly in a chunk. truncate_inputs:true guarantees a
+// chunk never exceeds the model's 8192-token limit even for dense scripts (~1 token/char).
+export const CHUNK_CHARS = 1800
+export const CHUNK_OVERLAP = 270
+// Bound the vectors per artifact: a fixed max makes the delete deterministic (drop `id#0..MAX-1`)
+// with no need to track the prior chunk count, and caps index growth. 20 chunks span ≈31k unique
+// chars (~1800 + 19×1530 after overlap) ≈ 7–8k tokens, covering a whole normal doc; a longer doc's
+// tail isn't chunk-indexed (the lexical arm + the one-artifact grep still reach it — same shape as
+// the FTS MAX_INDEX_TEXT bound). At ≤20 vectors/doc this is the ~5–20× vector-count (and thus
+// per-search query-billing) multiplier over whole-doc indexing noted in the header — deliberate.
+export const MAX_CHUNKS = 20
+// Cap on the text handed to the chunker (data: URIs are already elided upstream). CHUNK_CHARS×MAX.
+export const EMBED_CHAR_BUDGET = CHUNK_CHARS * MAX_CHUNKS
+// The stored per-chunk snippet (Vectorize metadata caps at 10 KiB/vector; a chunk stays well under).
 export const PREVIEW_CHARS = 480
-// Minimum cosine similarity for a dense candidate to count as relevant. Calibrated on the live
-// bge-m3 index from a SMALL sample (3 real + 3 gibberish queries): real-query top matches sat
-// ~0.53–0.60, off-target ones ~0.44–0.54. At 0.48 it removes the lowest slice of noise (a gibberish
-// query drops from ~6 weak hits to 0–1) while preserving every observed real match (lowest ~0.527)
-// — but the ranges OVERLAP, so it's a precision/recall trade point, not a free lunch: noise up to
-// ~0.54 still passes, and a genuinely-relevant-but-weak dense-ONLY match below 0.48 (a pure synonym
-// with zero lexical overlap) is also dropped. A discriminative reranker + chunk-level embeddings are
-// the real precision lever (they need a re-backfill — deliberate follow-up). Tunable; exported so it
-// can be adjusted or referenced in tests.
+// Minimum cosine similarity for a dense candidate to count as relevant. Calibrated on the live index
+// (3 real + 3 gibberish queries): whole-doc real-query tops sat ~0.53–0.60, off-target ~0.44–0.54,
+// so 0.48 removed the lowest noise slice with no observed recall loss. CHUNK vectors score SHARPER
+// (a query hits the matching passage, not a doc average), so the same floor is EXPECTED to behave at
+// least as well on chunks — but that's an untested inference, so re-measure on the live chunk index
+// before trusting it. Tunable; exported so it can be referenced in tests.
 export const DENSE_MIN_SCORE = 0.48
 // Embed at most this many texts per Workers-AI call — bge-m3's sync-embed batch ceiling is 100, so
 // 50 is conservative. Exported for the sub-batch test.
 export const EMBED_BATCH = 50
+// Vectorize documents a 1000-item/call upsert cap; we bound deletes the same way (mutations share
+// that batch limit) so chunk deletes stay safely under it.
+const MUTATE_BATCH = 500
+
+// Split `text` into overlapping ~CHUNK_CHARS chunks, breaking at a whitespace boundary near the end
+// (to avoid mid-word cuts), capped at MAX_CHUNKS. Pure — unit-tested. The `minBreak` guard also
+// guarantees forward progress (each chunk advances by ≥ 0.6·CHUNK_CHARS − OVERLAP > 0).
+export const chunkText = (text: string): string[] => {
+  const t = text.trimEnd()
+  if (!t.trim()) return []
+  if (t.length <= CHUNK_CHARS) return [t.trim()]
+  const chunks: string[] = []
+  const minBreak = Math.floor(CHUNK_CHARS * 0.6)
+  let start = 0
+  while (start < t.length && chunks.length < MAX_CHUNKS) {
+    let end = Math.min(start + CHUNK_CHARS, t.length)
+    if (end < t.length) {
+      const window = t.slice(start, end)
+      const nl = window.lastIndexOf("\n")
+      const sp = window.lastIndexOf(" ")
+      const brk = nl >= minBreak ? nl : sp >= minBreak ? sp : -1
+      if (brk > 0) end = start + brk
+    }
+    const chunk = t.slice(start, end).trim()
+    if (chunk) chunks.push(chunk)
+    if (end >= t.length) break
+    start = end - CHUNK_OVERLAP
+  }
+  return chunks
+}
+
+// One embed unit = one chunk's vector-to-be: its target id, the text to embed (title prepended for
+// cheap contextual retrieval), the snippet to store, and the artifact it rolls up to.
+interface Unit {
+  vectorId: string
+  orgId: string
+  artifactId: string
+  embedText: string
+  snippet: string
+}
 
 export class VectorizeSearchIndex implements SearchIndex {
   constructor(
@@ -68,13 +116,61 @@ export class VectorizeSearchIndex implements SearchIndex {
     private readonly model: string = EMBED_MODEL,
   ) {}
 
-  // truncate_inputs:true so an over-8192-token body (long or CJK docs, where ~1 char ≈ 1 token)
-  // trims to the limit instead of throwing BadInput — otherwise those docs silently never embed.
   private async embed(text: string): Promise<number[]> {
     const { data } = await this.ai.run(this.model, { text: [text], truncate_inputs: true })
     const [vector] = data
     if (!vector) throw new Error("empty embedding from Workers AI")
     return vector
+  }
+
+  // The chunk units an artifact contributes (no embedding). A title-only artifact still indexes its
+  // title as a single unit so title-only docs stay findable.
+  private unitsFor(id: string, orgId: string, title: string | null, text: string): Unit[] {
+    const body = chunkText(text.slice(0, EMBED_CHAR_BUDGET))
+    const chunks = body.length ? body : title?.trim() ? [""] : []
+    return chunks.map((c, i) => ({
+      vectorId: `${id}#${i}`,
+      orgId,
+      artifactId: id,
+      embedText: [title, c].filter(Boolean).join("\n\n"),
+      snippet: (c || title || "").slice(0, PREVIEW_CHARS),
+    }))
+  }
+
+  // Every vector id an artifact could hold from chunk `count` onward, plus the bare legacy id (a
+  // whole-doc vector from before chunking). Deleting these is the deterministic "clear the stale
+  // remainder": no prior-count tracking, and it migrates a legacy vector on the artifact's next index.
+  private staleIds(id: string, keptChunks: number): string[] {
+    const ids = [id]
+    for (let i = keptChunks; i < MAX_CHUNKS; i++) ids.push(`${id}#${i}`)
+    return ids
+  }
+
+  // Embed a flat unit list in EMBED_BATCH groups and upsert per group — bounded failure + no
+  // cross-group misalignment; a short/misordered model response throws loudly, not silent
+  // cross-contamination (bge-m3 returns one vector per input in order).
+  private async embedAndUpsert(units: Unit[]): Promise<void> {
+    for (let i = 0; i < units.length; i += EMBED_BATCH) {
+      const slice = units.slice(i, i + EMBED_BATCH)
+      const { data } = await this.ai.run(this.model, {
+        text: slice.map((u) => u.embedText),
+        truncate_inputs: true,
+      })
+      if (data.length !== slice.length)
+        throw new Error(`bge-m3 returned ${data.length} vectors for ${slice.length} inputs`)
+      await this.vectorize.upsert(
+        slice.map((u, j) => ({
+          id: u.vectorId,
+          values: data[j] as number[],
+          metadata: { org_id: u.orgId, artifact_id: u.artifactId, chunk: u.snippet },
+        })),
+      )
+    }
+  }
+
+  private async deleteInBatches(ids: string[]): Promise<void> {
+    for (let i = 0; i < ids.length; i += MUTATE_BATCH)
+      await this.vectorize.deleteByIds(ids.slice(i, i + MUTATE_BATCH))
   }
 
   async indexArtifact(
@@ -83,53 +179,32 @@ export class VectorizeSearchIndex implements SearchIndex {
     title: string | null,
     text: string,
   ): Promise<void> {
-    const content = title ? `${title}\n\n${text}` : text
-    // Nothing embeddable (e.g. a bare uploaded image) — ensure a prior vector doesn't linger.
-    if (!content.trim()) return this.unindexArtifact(id)
-    const values = await this.embed(content.slice(0, EMBED_CHAR_BUDGET))
-    await this.vectorize.upsert([
-      { id, values, metadata: { org_id: orgId, preview: content.slice(0, PREVIEW_CHARS) } },
-    ])
+    const units = this.unitsFor(id, orgId, title, text)
+    // Upsert the fresh chunks first (no empty window), then clear the legacy vector + any chunk
+    // slots beyond the new count (a shrunk doc). Empty content ⇒ no units ⇒ this clears everything.
+    await this.embedAndUpsert(units)
+    await this.vectorize.deleteByIds(this.staleIds(id, units.length))
   }
 
   async indexArtifacts(
     items: { id: string; orgId: string; title: string | null; text: string }[],
   ): Promise<void> {
-    const prepared = items.map((it) => ({
-      id: it.id,
-      orgId: it.orgId,
-      content: it.title ? `${it.title}\n\n${it.text}` : it.text,
-    }))
-    // Empty-content artifacts (e.g. a bare image) carry no vector — drop any stale one, as the
-    // single path does.
-    const empty = prepared.filter((p) => !p.content.trim()).map((p) => p.id)
-    if (empty.length) await this.vectorize.deleteByIds(empty)
-    const embeddable = prepared.filter((p) => p.content.trim())
-    // Embed + upsert PER sub-batch (not one flatten over the whole page): a transient failure is
-    // bounded to one sub-batch instead of losing the page's dense arm, and vectors can never
-    // misalign to the wrong artifact across sub-batch seams. bge-m3 returns one vector per input in
-    // order; the length check turns a short/misordered response into a loud failure rather than
-    // silent cross-contamination.
-    for (let i = 0; i < embeddable.length; i += EMBED_BATCH) {
-      const slice = embeddable.slice(i, i + EMBED_BATCH)
-      const { data } = await this.ai.run(this.model, {
-        text: slice.map((p) => p.content.slice(0, EMBED_CHAR_BUDGET)),
-        truncate_inputs: true,
-      })
-      if (data.length !== slice.length)
-        throw new Error(`bge-m3 returned ${data.length} vectors for ${slice.length} inputs`)
-      await this.vectorize.upsert(
-        slice.map((p, j) => ({
-          id: p.id,
-          values: data[j] as number[],
-          metadata: { org_id: p.orgId, preview: p.content.slice(0, PREVIEW_CHARS) },
-        })),
-      )
+    const all: Unit[] = []
+    const stale: string[] = []
+    for (const it of items) {
+      const units = this.unitsFor(it.id, it.orgId, it.title, it.text)
+      all.push(...units)
+      stale.push(...this.staleIds(it.id, units.length))
     }
+    // Chunks from all artifacts embed together in EMBED_BATCH groups (far fewer AI calls than
+    // per-artifact); stale ids clear after the fresh chunks land.
+    await this.embedAndUpsert(all)
+    await this.deleteInBatches(stale)
   }
 
   async unindexArtifact(id: string): Promise<void> {
-    await this.vectorize.deleteByIds([id])
+    // Drop every possible vector for the artifact: all chunk slots + the bare legacy id.
+    await this.vectorize.deleteByIds(this.staleIds(id, 0))
   }
 
   async search(
@@ -140,24 +215,35 @@ export class VectorizeSearchIndex implements SearchIndex {
     const q = query.trim()
     if (!q) return []
     const vector = await this.embed(q)
-    // topK is capped at 50 (Vectorize's ceiling when metadata is returned). The `org_id` filter
-    // needs a pre-declared metadata index (see wrangler.toml / DEPLOY.md); `preview` is unindexed
-    // metadata, so "all" is required to read it back for the snippet.
+    // topK 50 (Vectorize's ceiling with metadata, raised from 20 in 2026-03). Over-fetch chunk hits,
+    // then roll up to the best chunk per artifact — several top chunks can belong to one doc, so 50
+    // chunks yields FEWER distinct artifacts than the old 50-whole-doc-vectors did. On the small
+    // typeahead limit that's invisible; on the agent/deep path (large candidateCap) it narrows the
+    // dense arm's breadth — an accepted trade, since that arm fuses with the lexical one (which
+    // dominates recall there) and precision is the win. Worth re-measuring distinct-artifact recall
+    // on the live chunk index post-deploy. The `org_id` filter needs a pre-declared metadata index;
+    // `artifact_id`/`chunk` are unindexed, so "all" is required to read them back for rollup + snippet.
     const { matches } = await this.vectorize.query(vector, {
-      topK: Math.min(Math.max(limit, 1), 50),
+      topK: 50,
       filter: { org_id: orgId },
       returnMetadata: "all",
     })
-    // Relevance floor: Vectorize always returns its nearest topK however far away they are, so
-    // without this an off-target query surfaces weak noise. Drop sub-threshold matches (see
-    // DENSE_MIN_SCORE) — the grep-confirm/fusion downstream can't recover precision the vector
-    // query already lost.
-    return matches
-      .filter((m) => m.score >= DENSE_MIN_SCORE)
-      .map((m) => ({
-        id: m.id,
-        score: m.score,
-        chunk: typeof m.metadata?.preview === "string" ? m.metadata.preview : "",
-      }))
+    // Best chunk per artifact, above the relevance floor. Robust to legacy whole-doc vectors from
+    // before chunking (no `artifact_id` → fall back to the id before `#`; `chunk` → `preview`).
+    const best = new Map<string, { score: number; chunk: string }>()
+    for (const m of matches) {
+      if (m.score < DENSE_MIN_SCORE) continue
+      const md = m.metadata ?? {}
+      const artId =
+        typeof md.artifact_id === "string" ? md.artifact_id : (m.id.split("#")[0] ?? m.id)
+      const chunk =
+        typeof md.chunk === "string" ? md.chunk : typeof md.preview === "string" ? md.preview : ""
+      const prev = best.get(artId)
+      if (!prev || m.score > prev.score) best.set(artId, { score: m.score, chunk })
+    }
+    return [...best.entries()]
+      .map(([id, v]) => ({ id, score: v.score, chunk: v.chunk }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, Math.max(limit, 1))
   }
 }

--- a/apps/api/test/search-hybrid.test.ts
+++ b/apps/api/test/search-hybrid.test.ts
@@ -12,8 +12,12 @@ import {
   workspaceSearchReport,
 } from "../src/lib/search"
 import {
+  CHUNK_CHARS,
+  CHUNK_OVERLAP,
+  chunkText,
   DENSE_MIN_SCORE,
   EMBED_BATCH,
+  MAX_CHUNKS,
   type VectorizeLike,
   VectorizeSearchIndex,
   type WorkersAiLike,
@@ -274,8 +278,35 @@ const makeVectorize = () => {
   return { vectorize, store, seen }
 }
 
+describe("chunkText", () => {
+  it("returns one trimmed chunk for short text, [] for blank", () => {
+    expect(chunkText("  hello world  ")).toEqual(["hello world"])
+    expect(chunkText("   ")).toEqual([])
+  })
+  it("splits long text into multiple chunks, each within CHUNK_CHARS, capped at MAX_CHUNKS", () => {
+    const chunks = chunkText("lorem ipsum ".repeat(2000)) // ~24k chars
+    expect(chunks.length).toBeGreaterThan(1)
+    expect(chunks.length).toBeLessThanOrEqual(MAX_CHUNKS)
+    for (const c of chunks) {
+      expect(c.length).toBeGreaterThan(0)
+      expect(c.length).toBeLessThanOrEqual(CHUNK_CHARS)
+    }
+  })
+  it("caps a very long doc at MAX_CHUNKS (tail dropped)", () => {
+    expect(chunkText("word ".repeat(200_000)).length).toBe(MAX_CHUNKS)
+  })
+  it("overlaps consecutive chunks by CHUNK_OVERLAP so a boundary-spanning match is never split", () => {
+    // No-whitespace text: no break adjustment/trim, so the overlap is exact and assertable.
+    const t = "abcdefghij".repeat(500) // 5000 chars, no spaces → deterministic windows
+    const chunks = chunkText(t)
+    expect(chunks.length).toBeGreaterThan(2)
+    for (let i = 0; i < chunks.length - 1; i++)
+      expect(chunks[i]?.slice(-CHUNK_OVERLAP)).toBe(chunks[i + 1]?.slice(0, CHUNK_OVERLAP))
+  })
+})
+
 describe("VectorizeSearchIndex (Cloudflare adapter)", () => {
-  it("indexArtifact embeds title+body and upserts one vector with org_id + preview metadata", async () => {
+  it("indexArtifact chunks the body, embeds title+chunk, upserts id#i with artifact_id + chunk metadata", async () => {
     const { vectorize, store } = makeVectorize()
     const { ai, runs } = makeAi()
     await new VectorizeSearchIndex(vectorize, ai).indexArtifact(
@@ -285,38 +316,90 @@ describe("VectorizeSearchIndex (Cloudflare adapter)", () => {
       "the golden path",
     )
     expect(runs[0]?.model).toBe("@cf/baai/bge-m3")
-    expect(runs[0]?.text).toEqual(["Onboarding\n\nthe golden path"]) // title prepended for the embed
-    expect(runs[0]?.truncate).toBe(true) // over-limit (long/CJK) inputs trim instead of throwing
-    expect(store.get("a1")?.metadata?.org_id).toBe("org1")
-    expect(store.get("a1")?.metadata?.preview).toContain("Onboarding")
+    expect(runs[0]?.text).toEqual(["Onboarding\n\nthe golden path"]) // title prepended for context
+    expect(runs[0]?.truncate).toBe(true)
+    expect(store.has("a1#0")).toBe(true) // keyed by chunk id, not the bare artifact id
+    expect(store.has("a1")).toBe(false) // the bare/legacy id is cleared
+    expect(store.get("a1#0")?.metadata?.org_id).toBe("org1")
+    expect(store.get("a1#0")?.metadata?.artifact_id).toBe("a1")
+    expect(store.get("a1#0")?.metadata?.chunk).toBe("the golden path")
   })
 
-  it("search embeds the query, filters by org_id, requests metadata, and maps preview → chunk", async () => {
+  it("indexArtifact of a long doc writes multiple chunk vectors, and re-index clears stale slots", async () => {
+    const { vectorize, store } = makeVectorize()
+    const { ai } = makeAi()
+    const idx = new VectorizeSearchIndex(vectorize, ai)
+    await idx.indexArtifact("a1", "org1", null, "para ".repeat(1500)) // ~7.5k chars → several chunks
+    expect([...store.keys()].filter((k) => k.startsWith("a1#")).length).toBeGreaterThan(1)
+    // Re-index SHORTER → one chunk; the old extra chunk slots must be gone.
+    await idx.indexArtifact("a1", "org1", null, "short")
+    expect([...store.keys()].filter((k) => k.startsWith("a1#"))).toEqual(["a1#0"])
+  })
+
+  it("search rolls chunk hits up to the best chunk per artifact", async () => {
+    const meta = (artifact_id: string, chunk: string) => ({ org_id: "o", artifact_id, chunk })
+    const vectorize: VectorizeLike = {
+      upsert: async () => {},
+      deleteByIds: async () => {},
+      query: async () => ({
+        matches: [
+          { id: "a1#1", score: 0.7, metadata: meta("a1", "the best chunk") },
+          { id: "a1#0", score: 0.6, metadata: meta("a1", "weaker chunk") },
+          { id: "a2#0", score: 0.55, metadata: meta("a2", "other doc") },
+        ],
+      }),
+    }
+    const { ai } = makeAi()
+    const hits = await new VectorizeSearchIndex(vectorize, ai).search("o", "q", 6)
+    expect(hits.map((h) => h.id)).toEqual(["a1", "a2"]) // one hit per artifact, best-score order
+    expect(hits[0]?.chunk).toBe("the best chunk") // the higher-scoring chunk wins the snippet
+    expect(hits[0]?.score).toBe(0.7)
+  })
+
+  it("search over-fetches topK 50, filters by org_id, rolls the chunk up to its artifact id", async () => {
     const { vectorize, seen } = makeVectorize()
     const { ai } = makeAi()
     const idx = new VectorizeSearchIndex(vectorize, ai)
     await idx.indexArtifact("a1", "org1", "Onboarding", "the golden path")
-    await idx.indexArtifact("a2", "org2", "Other", "a different workspace")
+    await idx.indexArtifact("a2", "org2", "Other", "different workspace")
     const hits = await idx.search("org1", "getting started", 6)
-    expect(hits.map((h) => h.id)).toEqual(["a1"]) // org filter excludes the other workspace
-    expect(hits[0]?.chunk).toContain("Onboarding")
+    expect(hits.map((h) => h.id)).toEqual(["a1"]) // org filter excludes a2; rolled up to the artifact id
+    expect(hits[0]?.chunk).toBe("the golden path")
     expect(seen.queries[0]?.filter).toEqual({ org_id: "org1" })
     expect(seen.queries[0]?.returnMetadata).toBe("all")
-    expect(seen.queries[0]?.topK).toBe(6)
+    expect(seen.queries[0]?.topK).toBe(50) // over-fetch chunks; rollup reduces to distinct artifacts
   })
 
-  it("unindex deletes the vector; empty content unindexes instead of upserting", async () => {
+  it("search stays robust to a LEGACY whole-doc vector (no artifact_id, `preview` snippet)", async () => {
+    const vectorize: VectorizeLike = {
+      upsert: async () => {},
+      deleteByIds: async () => {},
+      query: async () => ({
+        matches: [
+          { id: "legacyArt", score: 0.6, metadata: { org_id: "o", preview: "legacy snippet" } },
+        ],
+      }),
+    }
+    const { ai } = makeAi()
+    const hits = await new VectorizeSearchIndex(vectorize, ai).search("o", "q", 6)
+    expect(hits).toEqual([{ id: "legacyArt", score: 0.6, chunk: "legacy snippet" }]) // id + preview fallback
+  })
+
+  it("unindexArtifact deletes every chunk slot + the bare id; empty content upserts nothing", async () => {
     const { vectorize, store, seen } = makeVectorize()
     const { ai } = makeAi()
     const idx = new VectorizeSearchIndex(vectorize, ai)
     await idx.indexArtifact("a1", "org1", "T", "body")
-    expect(store.has("a1")).toBe(true)
+    expect(store.has("a1#0")).toBe(true)
     await idx.unindexArtifact("a1")
-    expect(store.has("a1")).toBe(false)
-    // A non-text artifact (empty indexable content) must not upsert — and drops any prior vector.
+    expect(store.has("a1#0")).toBe(false)
+    const deleted = seen.deletes.flat()
+    expect(deleted).toContain("a1") // the bare legacy id
+    expect(deleted).toContain("a1#0")
+    expect(deleted).toContain(`a1#${MAX_CHUNKS - 1}`) // all chunk slots
+    // empty content → no vector upserted
     await idx.indexArtifact("a2", "org1", null, "   ")
-    expect(store.has("a2")).toBe(false)
-    expect(seen.deletes).toContainEqual(["a2"])
+    expect(store.has("a2#0")).toBe(false)
   })
 
   it("search with a blank query short-circuits without calling the model", async () => {
@@ -343,7 +426,7 @@ describe("VectorizeSearchIndex (Cloudflare adapter)", () => {
     expect(hits.map((h) => h.id)).toEqual(["above", "at"]) // >= floor kept; just-below dropped
   })
 
-  it("indexArtifacts batches: one embed call for the page, empties dropped, org_id + preview stored", async () => {
+  it("indexArtifacts batches chunks across artifacts, drops empties, stores artifact_id + chunk", async () => {
     const { vectorize, store } = makeVectorize()
     const { ai, runs } = makeAi()
     await new VectorizeSearchIndex(vectorize, ai).indexArtifacts([
@@ -351,12 +434,13 @@ describe("VectorizeSearchIndex (Cloudflare adapter)", () => {
       { id: "a2", orgId: "org1", title: null, text: "body two" },
       { id: "a3", orgId: "org1", title: null, text: "   " }, // empty → no vector
     ])
-    expect(store.has("a1")).toBe(true)
-    expect(store.has("a2")).toBe(true)
-    expect(store.has("a3")).toBe(false) // empty content: no upsert
-    expect(store.get("a1")?.metadata?.org_id).toBe("org1")
-    expect(store.get("a1")?.metadata?.preview).toContain("T1")
-    expect(runs).toHaveLength(1) // batched — one AI call for both embeddable texts, not two
+    expect(store.has("a1#0")).toBe(true)
+    expect(store.has("a2#0")).toBe(true)
+    expect(store.has("a3#0")).toBe(false) // empty content: no upsert
+    expect(store.get("a1#0")?.metadata?.org_id).toBe("org1")
+    expect(store.get("a1#0")?.metadata?.artifact_id).toBe("a1")
+    expect(store.get("a1#0")?.metadata?.chunk).toBe("body one")
+    expect(runs).toHaveLength(1) // both chunks embedded in one call
     expect(runs[0]?.text).toEqual(["T1\n\nbody one", "body two"])
     expect(runs[0]?.truncate).toBe(true)
   })
@@ -381,8 +465,8 @@ describe("VectorizeSearchIndex (Cloudflare adapter)", () => {
       `body ${EMBED_BATCH + 3}`,
       `body ${EMBED_BATCH + 4}`,
     ])
-    expect(store.size).toBe(n) // every artifact upserted, across the sub-batch seam
-    expect(store.has(`id${EMBED_BATCH}`)).toBe(true) // first of the 2nd sub-batch
+    expect([...store.keys()].filter((k) => k.endsWith("#0")).length).toBe(n) // one chunk vector each
+    expect(store.has(`id${EMBED_BATCH}#0`)).toBe(true) // first of the 2nd sub-batch
   })
 
   it("indexArtifacts throws (not misaligns) if the model returns fewer vectors than inputs", async () => {
@@ -394,6 +478,23 @@ describe("VectorizeSearchIndex (Cloudflare adapter)", () => {
         { id: "b", orgId: "o", title: null, text: "y" },
       ]),
     ).rejects.toThrow(/returned 1 vectors for 2/)
+  })
+
+  it("indexArtifacts batches stale deletes under the Vectorize 1000/call cap", async () => {
+    const { vectorize, seen } = makeVectorize()
+    const { ai } = makeAi()
+    // 30 single-chunk artifacts → 30 × (1 legacy + 19 empty slots) = 600 stale ids > MUTATE_BATCH(500).
+    const items = Array.from({ length: 30 }, (_, i) => ({
+      id: `id${i}`,
+      orgId: "org1",
+      title: null,
+      text: `body ${i}`,
+    }))
+    await new VectorizeSearchIndex(vectorize, ai).indexArtifacts(items)
+    const total = seen.deletes.reduce((n, b) => n + b.length, 0)
+    expect(total).toBe(30 * MAX_CHUNKS) // 1 legacy id + (MAX_CHUNKS-1) empty slots per artifact
+    expect(seen.deletes.length).toBeGreaterThan(1) // split across calls
+    for (const batch of seen.deletes) expect(batch.length).toBeLessThanOrEqual(500)
   })
 })
 


### PR DESCRIPTION
## What & why

The dense arm embedded each artifact as a **single whole-doc vector**, so a query matching one passage scored against the doc's *averaged* embedding — diluted relevance. This was the precision ceiling measured in #439: a reranker over whole-doc previews scored ~0 because it needs the *actual matching passage*, not a doc average.

This ships **chunk-level embedding**: each artifact is split into ~1800-char overlapping passages (≤20/doc), one vector per chunk (`${artifactId}#i`). At query time, chunk hits roll up to the **best chunk per artifact**. A query now scores against the passage it actually matches — the real precision lever from #439.

## How

- **`chunkText`** — pure, unit-tested chunker; overlap (270 chars) + forward-progress guaranteed (each step advances ≥810 chars), capped at `MAX_CHUNKS`.
- **Lifecycle** — deterministic stale-slot deletion (`id#kept..MAX` + the bare legacy id) that needs no prior-count tracking and **migrates** pre-chunk whole-doc vectors on an artifact's next index. Upsert-fresh-then-delete-stale ordering.
- **Batch path** — embed+upsert per `EMBED_BATCH` (50) sub-batch with a length assert, so a short/misordered model response throws loudly instead of silently misaligning vectors↔ids. Deletes batch under the Vectorize 1000/call cap.
- **`search`** — topK 50 (Vectorize's metadata ceiling), relevance floor at `DENSE_MIN_SCORE`, roll up to best chunk per artifact; robust to legacy whole-doc vectors (no `artifact_id` → id before `#`; `chunk` → `preview`).

## Honest trade-offs (documented in-code + DEPLOY.md)

- **Cost:** chunking multiplies the vector count ~5–20×. Vectorize bills queried dimensions on *stored-vector count* (not `topK`), so this scales both stored **and** per-search cost — a ~240-doc corpus → ≤~4.8k vectors can exhaust the free queried-dim tier in a handful of searches/month. Deliberate price of precision. Workers-AI embedding tokens rise only ~1.2–1.5×.
- **Recall:** the best-chunk rollup yields fewer *distinct* artifacts on the high-`candidateCap` agent path (invisible on typeahead). Accepted — that arm fuses with the lexical one, which dominates recall there.
- **Floor:** `DENSE_MIN_SCORE=0.48` was calibrated on the *whole-doc* index; expected to behave at least as well on sharper chunk scores, but flagged in-code to **re-measure on the live chunk index**.

## Verification

- typecheck ✅ · all 15 lint gates ✅ · **970 API tests pass** (+2: chunk-overlap invariant, delete-batch-under-cap)
- Two adversarial audit passes (correctness/lifecycle + CF-runtime/claim-fidelity): all Cloudflare per-op limits verified against current docs (upsert 1000, topK 50 rides the 2026-03-16 metadata-ceiling bump, 10 KiB metadata, org_id index model); migration proven collision-free (artifact ids never contain `#`); no blocking findings.

## ⚠️ Requires a prod re-backfill

Deploy migrates the code; a re-backfill (`POST /v1/system/search-reindex`) migrates the **data** — replacing legacy whole-doc vectors with chunk vectors. Legacy and chunk vectors for the same doc roll up to the same key, so search stays correct *during* the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)