### PR TITLE
feat(search): move the edge dense arm from Vectorize to pgvector-over-Hyperdrive

### DIFF
--- a/apps/api/scripts/apply-pg-schema.ts
+++ b/apps/api/scripts/apply-pg-schema.ts
@@ -1,7 +1,9 @@
 import { join } from "node:path"
 import { PgMetaStore } from "@derive/db/pg"
+import { PgVectorStore } from "@derive/db/pgvector"
 import { Pool } from "pg"
 import { makeAuth, migrateAuth } from "../src/auth-config"
+import { EMBED_DIMENSIONS } from "../src/embedder"
 
 // Bring the hosted tier's Postgres fully current before a Worker deploy — the pg
 // twin of `apply-d1-schema.mjs` + `migrate-auth-d1.ts`. The Workers entry never
@@ -56,6 +58,24 @@ await migrateAuth(auth)
 // Node boot and this script apply the same backstop — see node.ts).
 await pool.query(`CREATE UNIQUE INDEX IF NOT EXISTS user_username ON "user" (username)`)
 console.log("auth schema applied")
+
+// Dense/semantic search: the pgvector table for the edge dense arm (the Worker never runs DDL at
+// runtime, so — like the app + auth schema — it's created here, out of band). bge-m3 = 1024-dim.
+// Idempotent; the dimension guard throws only on an incompatible embedder swap (⇒ drop + rebackfill).
+const vectorStore = new PgVectorStore(pool, EMBED_DIMENSIONS)
+await vectorStore.ensureSchema()
+// Widen HNSW candidate breadth DB-wide so Hyperdrive's pooled connections don't cap topK at the
+// default ef_search=40 (the edge can't set it per-connection the way the Node pool does). Best-
+// effort — a recall tuning knob, not required for correctness, so a failure here doesn't block the
+// deploy.
+try {
+  const { rows } = await pool.query<{ d: string }>("SELECT current_database() AS d")
+  const db = rows[0]?.d
+  if (db) await pool.query(`ALTER DATABASE "${db}" SET hnsw.ef_search = 100`)
+} catch (e) {
+  console.error("ef_search tuning skipped:", e instanceof Error ? e.message : String(e))
+}
+console.log("vector schema applied")
 
 await store.close()
 await pool.end()

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -11,6 +11,7 @@ import type {
 } from "@cloudflare/workers-types"
 import { createD1Store } from "@derive/db/d1"
 import { PgMetaStore } from "@derive/db/pg"
+import { PgVectorStore } from "@derive/db/pgvector"
 import { R2BlobStore } from "@derive/storage"
 import { drizzleAdapter } from "better-auth/adapters/drizzle"
 import { drizzle } from "drizzle-orm/d1"
@@ -20,6 +21,7 @@ import { type AuthDb, makeAuth } from "./auth-config"
 import { authSchema } from "./auth-schema"
 import { hyperdriveConn, livePgPool, requestPg } from "./edge-pg"
 import type { SendEmailBinding } from "./email-cf"
+import { bindingEmbedder, EMBED_DIMENSIONS, type WorkersAiLike } from "./embedder"
 import { workspacesBlockingDeletion } from "./lib/account"
 import { customDomainsFromEnv } from "./lib/cloudflare-saas"
 import { buildAuthEmail } from "./lib/email"
@@ -27,7 +29,8 @@ import { slackFromEnv, subdomainBaseFromEnv, superAdminsFromEnv } from "./lib/en
 import { nativeLimiter } from "./lib/rate-limit"
 import { liveD1, requestD1 } from "./lib/request-d1"
 import { createDoBackplane, edgeCtx, edgeWaitUntil } from "./realtime-do"
-import { type VectorizeLike, VectorizeSearchIndex, type WorkersAiLike } from "./search-vectorize"
+import { PgvectorSearchIndex } from "./search-pgvector"
+import { type VectorizeLike, VectorizeSearchIndex } from "./search-vectorize"
 import { enqueueChannelDelivery } from "./webhooks"
 
 export { PreviewRenderer } from "./preview-do"
@@ -211,11 +214,21 @@ const handle = (req: Request, env: Env, ctx: ExecutionContext): Response | Promi
         // was dead on prod. Undefined when unset ⇒ isToken stays false, as before.
         token: env.DERIVE_TOKEN,
         blobs: new R2BlobStore(env.BUCKET),
-        // Hybrid search's dense arm — only when BOTH the Vectorize index and Workers AI are bound
-        // (create the index + its org_id metadata index first; see wrangler.toml). Unbound ⇒
-        // undefined ⇒ searchWorkspace runs pure-lexical, identical to the Node/self-host path.
-        search:
-          env.VECTORIZE && env.AI ? new VectorizeSearchIndex(env.VECTORIZE, env.AI) : undefined,
+        // Hybrid search's dense arm, embeddings from Workers AI (env.AI). On the Postgres path
+        // (HYPERDRIVE) the vectors live in pgvector in that same Postgres — the table is created out
+        // of band by apply-pg-schema, and PgVectorStore rides the request-scoped livePgPool exactly
+        // as the metadata store does. Falls back to Vectorize on a D1 edge (no pgvector on D1). No
+        // AI binding, or neither store ⇒ undefined ⇒ pure-lexical, identical to self-host.
+        search: env.AI
+          ? env.HYPERDRIVE
+            ? new PgvectorSearchIndex(
+                bindingEmbedder(env.AI),
+                new PgVectorStore(livePgPool, EMBED_DIMENSIONS),
+              )
+            : env.VECTORIZE
+              ? new VectorizeSearchIndex(env.VECTORIZE, env.AI)
+              : undefined
+          : undefined,
         backplane: createDoBackplane(env.ROOMS),
         baseUrl,
         auth,


### PR DESCRIPTION
## Stage B of the pgvector migration — the edge

Stage A gave **self-host** a pgvector dense arm. This moves the **edge** (prod: Workers + Neon Postgres via Hyperdrive) from Vectorize → pgvector in that same Postgres. Embeddings still come from the Workers AI binding (`bge-m3`, 1024-dim) — only the **store** changes. One datastore, no per-query vector billing, and a committed vector is queryable on the next request (pgvector indexes synchronously) instead of Vectorize's async-indexing lag.

## How

- **`worker.ts`**: on the `HYPERDRIVE` path, `search` is a `PgvectorSearchIndex` over the *same* request-scoped `livePgPool` the metadata store rides — no new `Pool` (the Worker never opens sockets directly; `check-hyperdrive` enforces this). Vectorize stays as the fallback **only** for a D1 edge (D1 can't do pgvector). Safe switch: a pgvector query failure already degrades to lexical via `searchWorkspace`'s best-effort catch.
- **`apply-pg-schema.ts`**: creates the pgvector table out of band at deploy (the Worker runs no runtime DDL) via `PgVectorStore.ensureSchema` at the edge dimension (1024), and `ALTER DATABASE … SET hnsw.ef_search = 100` so Hyperdrive's pooled connections aren't capped at the default-40 (the edge can't set it per-connection).

## Why the text-cast approach is Hyperdrive-safe

Vectors go over the wire as `$n::vector` **text params** and are never selected back as the custom type — so there's no per-connection dynamic-OID registration, the one real footgun over Hyperdrive's pooled connections. Validated on node-postgres already; this deploy is the real-runtime confirmation.

## Rollout (staged for safety)

Vectorize (class + wrangler binding) is **intentionally kept this PR** so the switch is one revertible line while I validate pgvector-over-Hyperdrive on a real deploy + re-backfill. On merge: the deploy applies the vector schema to Neon and flips the Worker to pgvector; I then re-backfill prod (`/v1/system/search-reindex`, now writing pgvector) and confirm semantic hits. **Removing Vectorize is the follow-up PR**, once prod search is confirmed on pgvector.

## Verification

typecheck (app + worker) ✅ · biome + 15 custom gates ✅ · **983 tests** ✅ · worker bundle stays `pg.Pool`-free and node-free (PgVectorStore is pure SQL over the proxy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)