### PR TITLE
fix(search): post-audit cleanup — stale docs/comments + warn on misconfig

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -298,9 +298,12 @@ request (pgvector indexes synchronously). Only the embedder differs by tier:
   Activates when both `AI` and `HYPERDRIVE` are bound. The pgvector table (`artifact_vec`) + its
   HNSW index are created out of band by `deploy:pg-schema` (part of `pnpm deploy`), which also sets
   `hnsw.ef_search` DB-wide — nothing to provision by hand.
-- **Node self-host** (Postgres): set `DERIVE_EMBED_CF_ACCOUNT_ID` + `DERIVE_EMBED_CF_API_TOKEN` to
-  embed via Workers AI over REST (a local-model embedder is a planned follow-up). The table is
-  created at boot. With the embedded-SQLite default there's no pgvector, so search stays lexical.
+- **Node self-host** (Postgres): set `DERIVE_EMBED_PROVIDER` to pick the embedder. `local` (the
+  zero-config, no-Cloudflare choice) runs an in-process ONNX model (bge-small, ~30 MB, downloaded on
+  first boot and cached) — nothing else to set. `workersai` embeds via Cloudflare Workers AI over
+  REST and additionally needs `DERIVE_EMBED_CF_ACCOUNT_ID` + `DERIVE_EMBED_CF_API_TOKEN`. Either way
+  the `artifact_vec` table is created at boot. With the embedded-SQLite default there's no pgvector,
+  so `DERIVE_EMBED_PROVIDER` is ignored and search stays lexical (a warning is logged).
 
 After enabling + deploying, backfill the existing corpus (new publishes index automatically):
 

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -94,13 +94,24 @@ export interface Config {
  *  capability report). Any other value (incl. unset) ⇒ undefined ⇒ lexical-only. */
 function denseSearchFromEnv(env: NodeJS.ProcessEnv): Config["denseSearch"] {
   const provider = env.DERIVE_EMBED_PROVIDER
+  if (!provider) return undefined // unset = lexical-only (the default), no warning
   if (provider === "local") return { provider: "local" }
-  if (provider === "workersai" && env.DERIVE_EMBED_CF_ACCOUNT_ID && env.DERIVE_EMBED_CF_API_TOKEN)
-    return {
-      provider: "workersai",
-      accountId: env.DERIVE_EMBED_CF_ACCOUNT_ID,
-      apiToken: env.DERIVE_EMBED_CF_API_TOKEN,
-    }
+  if (provider === "workersai") {
+    if (env.DERIVE_EMBED_CF_ACCOUNT_ID && env.DERIVE_EMBED_CF_API_TOKEN)
+      return {
+        provider: "workersai",
+        accountId: env.DERIVE_EMBED_CF_ACCOUNT_ID,
+        apiToken: env.DERIVE_EMBED_CF_API_TOKEN,
+      }
+    // Set-but-incomplete is a likely misconfiguration — warn instead of silently staying lexical.
+    log.warn(
+      "DERIVE_EMBED_PROVIDER=workersai but DERIVE_EMBED_CF_ACCOUNT_ID / DERIVE_EMBED_CF_API_TOKEN is missing — semantic search stays OFF (lexical-only)",
+    )
+    return undefined
+  }
+  log.warn(
+    `ignoring DERIVE_EMBED_PROVIDER=${provider} (expected "local" or "workersai") — semantic search stays OFF`,
+  )
   return undefined
 }
 

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -66,8 +66,9 @@ export interface SessionUser {
 export interface AppDeps {
   meta: MetaStore
   blobs: BlobStore
-  /** Optional dense/semantic search index. Unbound ⇒ workspace search stays lexical-only
-   *  (self-host, unchanged). The Cloudflare edge entry injects a Vectorize + Workers AI adapter. */
+  /** Optional dense/semantic search index. Unset ⇒ workspace search stays lexical-only. Both the
+   *  edge and a Postgres self-host inject a pgvector adapter (embeddings from Workers AI or, on
+   *  self-host, a local ONNX model); it's absent on SQLite / when no embedder is configured. */
   search?: SearchIndex
   /** Realtime relay + presence. In-process when unset (self-host); the Cloudflare
    *  edge entry injects a Durable Object backplane. */

--- a/apps/api/src/embedder.ts
+++ b/apps/api/src/embedder.ts
@@ -4,8 +4,9 @@ import { DENSE_MIN_SCORE } from "./search-chunk"
 // Embedder implementations (the generation half of the dense arm). Workers AI bge-m3 is reachable
 // two ways with an identical model + 1024-dim output, so the edge and a self-host box can share ONE
 // vector space (a corpus embedded on either is queryable by the other): the `env.AI` BINDING on
-// Cloudflare, or the REST endpoint from any Node process holding an account id + token. A future
-// local-ONNX embedder implements the same `Embedder` port and drops in with no store/wiring change.
+// Cloudflare, or the REST endpoint from any Node process holding an account id + token. The
+// local-ONNX embedder (embedder-local.ts) implements the same `Embedder` port — a self-host box can
+// use it instead of these to need no Cloudflare at all.
 
 export const EMBED_MODEL = "@cf/baai/bge-m3"
 export const EMBED_DIMENSIONS = 1024
@@ -55,8 +56,9 @@ export const bindingEmbedder = (ai: WorkersAiLike): WorkersAiEmbedder =>
   })
 
 /** Self-host embedder: Workers AI over REST, for a Node box with an account id + API token. Same
- *  model/dimension as the binding, so it shares the edge's vector space. (A local-ONNX embedder is
- *  the eventual zero-Cloudflare default; this is the first, dependency-free Node embedder.) */
+ *  model/dimension as the binding, so it shares the edge's vector space. (For a zero-Cloudflare
+ *  self-host, use the local-ONNX embedder in embedder-local.ts instead — this is the dependency-free
+ *  option that keeps the same 1024-dim bge-m3 space as the edge.) */
 export const restEmbedder = (
   accountId: string,
   apiToken: string,

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -44,8 +44,8 @@ export interface WorkspaceSearchDeps extends SearchDeps {
       limit: number,
     ): Promise<{ id: string; rank: number }[]>
   }
-  /** The optional dense/semantic arm (Cloudflare Vectorize + Workers AI). Absent on
-   *  self-host ⇒ nomination stays pure-lexical, byte-identical to before. */
+  /** The optional dense/semantic arm (pgvector + an embedder). Absent when no embedder is
+   *  configured (or on SQLite) ⇒ nomination stays pure-lexical, byte-identical to before. */
   search?: SearchIndex
 }
 
@@ -339,7 +339,7 @@ export async function indexArtifactVersion(
 ): Promise<void> {
   const text = await versionIndexText(blobs, v)
   await meta.indexArtifact(artifact.id, artifact.org_id, artifact.title, text)
-  // The dense arm is independently best-effort: a Vectorize/Workers-AI hiccup must never undo
+  // The dense arm is independently best-effort: a dense-arm (embed or store) hiccup must never undo
   // the lexical upsert that already committed, nor fail the publish. Log and move on — the next
   // publish re-embeds and the backfill sweep is the safety net. (emitVersionBump's own catch
   // covers the lexical arm; this inner catch keeps a dense failure from ever reaching it.)
@@ -399,7 +399,7 @@ export const reindexSearchBatch = async (
     }
   }
   // Dense arm: batched embed+upsert (in sub-batches) instead of one-per-artifact — far fewer
-  // Workers-AI calls + Vectorize mutations, so a bundle-dense page is much less likely to breach the
+  // embed calls + vector-store writes, so a bundle-dense page is much less likely to breach the
   // subrequest ceiling. Best-effort, like the publish path: a dense hiccup logs and moves on — the
   // lexical arm already committed and the next publish/sweep re-adds. NOTE: `indexed` counts LEXICAL
   // successes, so a dense-arm failure won't show as `indexed < scanned`; a full re-sweep is the
@@ -526,7 +526,7 @@ export const searchWorkspace = async (
     deps.meta.searchArtifactIds(opts.orgId, opts.query, candidateCap + 1),
     deps.search
       ? deps.search.search(opts.orgId, opts.query, candidateCap).catch((err) => {
-          // The dense arm is best-effort on READ too: a Vectorize/Workers-AI hiccup degrades this
+          // The dense arm is best-effort on READ too: a dense-arm (embed or store) hiccup degrades this
           // query to lexical-only rather than 500-ing a search the lexical arm could still serve.
           log.error("semantic search arm failed; falling back to lexical", { err: String(err) })
           return [] as { id: string; score: number; chunk: string }[]

--- a/apps/api/src/search-chunk.ts
+++ b/apps/api/src/search-chunk.ts
@@ -1,8 +1,8 @@
-// Backend-agnostic chunk-level dense-search logic, shared by every SearchIndex adapter (the
-// Cloudflare Vectorize edge adapter and the pgvector self-host adapter). Keeping the chunker,
-// the per-chunk unit shape, the stale-id math, and the best-chunk rollup in ONE place is what
-// stops the edge and self-host corpora from silently diverging — a change to chunk size or the
-// relevance floor lands in both at once. Pure + unit-tested; no store or embedder dependency.
+// Backend-agnostic chunk-level dense-search logic, shared by the SearchIndex adapter across both
+// tiers (edge and self-host both run PgvectorSearchIndex). Keeping the chunker, the per-chunk unit
+// shape, the stale-id math, and the best-chunk rollup in ONE place is what stops the edge and self-
+// host corpora from silently diverging — a change to chunk size or the relevance floor lands in
+// both at once. Pure + unit-tested; no store or embedder dependency.
 
 // Target chunk size in chars (~450 bge-m3 tokens at ~4 chars/token for Latin text) with ~15%
 // overlap so a match spanning a boundary still lands wholly in a chunk.

--- a/apps/api/src/search-pgvector.ts
+++ b/apps/api/src/search-pgvector.ts
@@ -3,10 +3,10 @@ import type { VectorStore } from "@derive/db/pgvector"
 import { EMBED_BATCH } from "./embedder"
 import { type ChunkUnit, rollupBestChunk, staleIds, unitsFor } from "./search-chunk"
 
-// The self-host dense-search adapter: chunk-level semantic search backed by pgvector in the SAME
-// Postgres as the artifacts. It's the storage-agnostic counterpart to the Cloudflare Vectorize
-// adapter — same SearchIndex port, same chunking + best-chunk rollup (shared via search-chunk),
-// same visibility contract (none: the caller's Tier-2 gate owns it). It composes an Embedder (the
+// The dense-search adapter (used by BOTH tiers — edge and Postgres self-host): chunk-level semantic
+// search backed by pgvector in the SAME Postgres as the artifacts. Same SearchIndex port, same
+// chunking + best-chunk rollup (shared via search-chunk), same visibility contract (none: the
+// caller's Tier-2 gate owns it). It composes an Embedder (the
 // generation half) with a PgVectorStore (the storage half); the two must agree on dimensions, which
 // PgVectorStore.ensureSchema enforces against the table. The caller runs this best-effort after the
 // lexical index (its own try/catch in lib/search.ts) — NOT in the metadata transaction — but a
@@ -16,8 +16,8 @@ import { type ChunkUnit, rollupBestChunk, staleIds, unitsFor } from "./search-ch
 // Over-fetch this many chunk hits, then roll up to the best chunk per artifact. Several top chunks
 // can belong to one doc, so this yields fewer DISTINCT artifacts than raw hits — fine: the dense
 // arm fuses with lexical (which dominates recall on the wide agent path) and precision is the win.
-// Matches the Vectorize adapter's topK so both arms behave alike (the vector pool sets
-// hnsw.ef_search ≥ this so pgvector doesn't cap the fetch — see node.ts / pgvector.ts).
+// The vector pool sets hnsw.ef_search ≥ this so pgvector's ANN scan doesn't cap the fetch below it
+// (see node.ts / apply-pg-schema.ts).
 const SEARCH_TOPK = 50
 
 export class PgvectorSearchIndex implements SearchIndex {
@@ -27,9 +27,9 @@ export class PgvectorSearchIndex implements SearchIndex {
   ) {}
 
   // Embed + upsert a flat unit list in EMBED_BATCH groups, interleaved (not embed-all-then-write) —
-  // bounds peak memory to one batch of vectors and, like the Vectorize adapter, lands earlier
-  // groups before a later embed can fail. A count mismatch throws rather than misaligning vector↔
-  // chunk (bge-m3 returns one vector per input, in order).
+  // bounds peak memory to one batch of vectors and lands earlier groups before a later embed can
+  // fail. A count mismatch throws rather than misaligning vector↔chunk (the embedder returns one
+  // vector per input, in order).
   private async embedAndStore(units: ChunkUnit[]): Promise<void> {
     for (let i = 0; i < units.length; i += EMBED_BATCH) {
       const group = units.slice(i, i + EMBED_BATCH)
@@ -59,7 +59,7 @@ export class PgvectorSearchIndex implements SearchIndex {
     // Upsert the fresh chunks first, then clear any chunk slots beyond the new count (a shrunk doc)
     // plus the bare legacy id. Empty content ⇒ no units ⇒ this clears everything for the artifact.
     // (upsert-then-delete, two statements: a delete failure leaves orphan chunks that self-heal on
-    // the next index — best-effort, matching the Vectorize adapter and the port's contract.)
+    // the next index — best-effort, per the port's contract.)
     if (units.length) await this.embedAndStore(units)
     await this.store.deleteByIds(staleIds(id, units.length))
   }

--- a/apps/api/test/config.test.ts
+++ b/apps/api/test/config.test.ts
@@ -46,6 +46,47 @@ describe("config: fail-fast env validation", () => {
   })
 })
 
+// The dense-search embedder is selected by DERIVE_EMBED_PROVIDER; `workersai` additionally needs
+// the CF creds. A set-but-incomplete/typo'd provider must resolve to OFF (lexical), not a crash.
+describe("config: denseSearch provider resolution", () => {
+  const base = { PORT: "8080", BASE_URL: "http://derive.test" }
+
+  it("unset ⇒ off (lexical-only, the default)", () => {
+    expect(loadConfig({ ...base }).denseSearch).toBeUndefined()
+  })
+
+  it("provider=local ⇒ local, no credentials required", () => {
+    expect(loadConfig({ ...base, DERIVE_EMBED_PROVIDER: "local" }).denseSearch).toEqual({
+      provider: "local",
+    })
+  })
+
+  it("provider=workersai WITH both CF vars ⇒ workersai", () => {
+    expect(
+      loadConfig({
+        ...base,
+        DERIVE_EMBED_PROVIDER: "workersai",
+        DERIVE_EMBED_CF_ACCOUNT_ID: "acct",
+        DERIVE_EMBED_CF_API_TOKEN: "tok",
+      }).denseSearch,
+    ).toEqual({ provider: "workersai", accountId: "acct", apiToken: "tok" })
+  })
+
+  it("provider=workersai but missing a CF var ⇒ off (not a broken half-config)", () => {
+    expect(
+      loadConfig({
+        ...base,
+        DERIVE_EMBED_PROVIDER: "workersai",
+        DERIVE_EMBED_CF_ACCOUNT_ID: "acct",
+      }).denseSearch,
+    ).toBeUndefined()
+  })
+
+  it("an unknown provider value ⇒ off (not a crash)", () => {
+    expect(loadConfig({ ...base, DERIVE_EMBED_PROVIDER: "openai" }).denseSearch).toBeUndefined()
+  })
+})
+
 // The public origin drives auth cookies + share links. An explicit BASE_URL always
 // wins; otherwise infer the URL a managed host assigned us, so a one-click deploy
 // gets working auth without anyone hand-typing the domain.

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -13,8 +13,9 @@ export interface BlobStore {
 /**
  * An optional SEMANTIC search index — the dense (embedding) arm of workspace search,
  * paired with the lexical FTS the MetaStore already provides ({@link MetaStore.searchArtifactIds}).
- * Unbound on self-host (search stays lexical-only, unchanged); the Cloudflare edge injects a
- * Vectorize + Workers AI adapter. The caller fuses these candidates with the lexical ones
+ * Unset ⇒ search stays lexical-only; otherwise the edge and a Postgres self-host both inject a
+ * pgvector adapter (embeddings from Workers AI or a local model). The caller fuses these with the
+ * lexical ones
  * (reciprocal-rank fusion) and re-applies visibility through `listArtifacts({ ids })`, so this
  * port — exactly like the FTS — has NO visibility knowledge and can never widen what a viewer
  * sees. Runs on Node AND Workers (no Node APIs), same as every other port here.
@@ -30,7 +31,7 @@ export interface SearchIndex {
    *  scoped by org. Driven by the same publish/restore/approve chokepoint as the FTS index. */
   indexArtifact(id: string, orgId: string, title: string | null, text: string): Promise<void>
   /** Batch variant of {@link indexArtifact} for the backfill sweep: embed + upsert a page in
-   *  sub-batches — far fewer Workers-AI calls + Vectorize mutations than one call per artifact.
+   *  sub-batches — far fewer embed calls + vector-store writes than one call per artifact.
    *  Single publishes still use indexArtifact. Best-effort like the rest. */
   indexArtifacts(
     items: { id: string; orgId: string; title: string | null; text: string }[],
@@ -54,18 +55,19 @@ export interface SearchIndex {
 /**
  * Turns text into embedding vectors — the generation half of the dense arm, split from the
  * storage half ({@link SearchIndex}) so the two vary independently: a deployment pairs whatever
- * embedder it can run (Cloudflare Workers AI on the edge, a local ONNX model or a hosted API on
- * a self-host box) with whatever vector store it has (Vectorize, pgvector). A `SearchIndex`
- * adapter that needs to embed composes an `Embedder`; the two MUST agree on `dimensions`.
+ * embedder it can run (Cloudflare Workers AI on the edge, a local ONNX model or the Workers AI REST
+ * API on a self-host box) with the pgvector store. A `SearchIndex` adapter that needs to embed
+ * composes an `Embedder`; the two MUST agree on `dimensions`.
  *
  * `model` + `dimensions` identify the vector space: a corpus embedded with one model can't be
- * queried with another (the geometry differs), so a store tags its vectors with the model and
- * treats an embedder change as a full re-backfill, never an in-place mix. Runs on Node AND
- * Workers (no Node APIs in the interface itself).
+ * queried with another (the geometry differs), so an embedder change is a full re-backfill, never an
+ * in-place mix. The pgvector store guards this by DIMENSION (its column is `vector(dimensions)`, and
+ * ensureSchema refuses a differently-sized swap) — enough today because the embedders differ in
+ * dimension (bge-m3 1024, bge-small 384); a same-dimension swap would need the old vectors dropped
+ * manually. Runs on Node AND Workers (no Node APIs in the interface itself).
  */
 export interface Embedder {
-  /** Stable model id, e.g. `@cf/baai/bge-m3`. Pinned — never "latest" — and stored alongside
-   *  vectors so a mismatch on read is detectable rather than silently wrong. */
+  /** Stable model id, e.g. `@cf/baai/bge-m3`. Pinned — never "latest". */
   readonly model: string
   /** Output vector length (e.g. 1024 for bge-m3, 384 for bge-small). The vector store's column
    *  type / index is sized to this; a change forces a new index + re-backfill. */


### PR DESCRIPTION
Fixes the doc-fidelity findings from a comprehensive audit of the pgvector migration (backend + frontend). The audit found **no correctness or security bugs** — the issues were stale docs/comments left by the 5-PR migration plus one silent-degradation gap.

- **DEPLOY.md was broken post-#445**: the Node self-host instructions said to set the two CF vars (missing `DERIVE_EMBED_PROVIDER`, so it silently stayed lexical) and called the local embedder "a planned follow-up" (it shipped). Rewritten around `DERIVE_EMBED_PROVIDER=local | workersai`.
- **`config.ts`**: `denseSearchFromEnv` now **warns** instead of silently degrading to lexical when `workersai` is missing a CF var or the provider is a typo. `config.test.ts` pins every resolution branch.
- **Stale "Vectorize" narration** corrected across `context.ts`, `ports.ts`, `search-chunk.ts`, `search-pgvector.ts`, `lib/search.ts`, `embedder.ts` — both tiers run `PgvectorSearchIndex`; the local embedder shipped.
- **`ports.ts`** no longer claims vectors are "tagged with the model" (they're guarded by *dimension*); documents that a same-dimension embedder swap needs a manual drop.

Doc/comment-only plus the warn + its tests — no behavior change to the search path. typecheck + lint + 76 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)