### PR TITLE
feat(web): a /search results page — surface the semantic search arm

### DIFF
--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -711,6 +711,11 @@ export interface SearchHit {
   current_version: number
   /** One line of the matching text, windowed around the first match (…elided ends). */
   snippet: string
+  /** True when this is a SEMANTIC-only match — the query matched by meaning, with no literal
+   *  occurrence in the text (so the snippet is the dense passage, not a highlightable line). Lets
+   *  the UI badge it as a meaning match. A hit found literally (with or without also matching
+   *  semantically) is false. */
+  semantic: boolean
 }
 
 // A short lead of context BEFORE the match, then the rest trailing. The window is biased
@@ -745,5 +750,7 @@ export const toSearchHits = (results: WorkspaceSearchResult[], query: string): S
       current_version: r.current_version,
       // A literal hit line is the best snippet; a dense-only hit falls back to its chunk snippet.
       snippet: hit ? snippetAround(hit.text, query) : (r.semantic?.snippet ?? ""),
+      // Semantic-only when there's no literal hit line but a dense passage carried it here.
+      semantic: !hit && !!r.semantic?.snippet,
     }
   })

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -875,16 +875,17 @@ export const artifactRoutes = (ctx: AppContext) => {
         : null
     const publicOnly = !(isOperator || baselineRole !== null)
 
-    // `?format=json` is the UI shape (the ⌘K palette): a small, ranked hit list with a
-    // snippet per artifact instead of the agent-facing ripgrep text report. A typeahead
-    // caller keeps the grep-confirm count tiny (bounded 1..12) so a debounced keystroke
-    // reads only a few blobs; the text report keeps the full agent depth.
+    // `?format=json` is the UI shape: a ranked hit list with a snippet per artifact instead of the
+    // agent-facing ripgrep text report. Two callers, one shape: the ⌘K palette typeahead requests a
+    // tiny `limit` (≤~6) so a debounced keystroke reads only a few blobs; the /search results page
+    // requests a deeper page (up to 50). Bounded 1..50 either way — a page reads up to `limit` blobs
+    // for grep-confirm, acceptable off the hot typeahead path but still capped.
     const isJson = c.req.query("format") === "json"
-    const limit = isJson ? Math.min(Math.max(Number(c.req.query("limit")) || 6, 1), 12) : undefined
-    // Keep the whole JSON request cheap, not just the blob reads: a small candidate cap
-    // means the visibility resolve is a SINGLE chunked query and the FTS scan is small —
-    // the palette only shows a handful, so deep recall would be wasted work on a hot path.
-    const candidateCap = isJson ? 60 : undefined
+    const limit = isJson ? Math.min(Math.max(Number(c.req.query("limit")) || 6, 1), 50) : undefined
+    // Nomination breadth scales with the requested depth: the palette (limit ~6) stays at the cheap
+    // 60-candidate single-chunked visibility resolve; the results page (limit ~30) nominates deeper
+    // so the ranked list is fuller. Capped at the workspace default (200) so it can't run away.
+    const candidateCap = isJson ? Math.min(Math.max((limit ?? 6) * 4, 60), 200) : undefined
 
     const { results, note } = await searchWorkspace(
       { blobs, sourceText, meta, search },

--- a/apps/api/test/search-hybrid.test.ts
+++ b/apps/api/test/search-hybrid.test.ts
@@ -210,6 +210,20 @@ describe("searchWorkspace — hybrid retrieval", () => {
     const hits = toSearchHits(results, "getting started")
     expect(hits).toHaveLength(1)
     expect(hits[0]?.snippet).toContain("golden path")
+    expect(hits[0]?.semantic).toBe(true) // no literal hit line ⇒ flagged as a meaning match
+  })
+
+  it("toSearchHits flags a LITERAL hit as semantic:false (it matched the text directly)", async () => {
+    const doc: Doc = {
+      id: "onb",
+      short_id: "onb1",
+      title: "Onboarding",
+      body: "the onboarding path",
+    }
+    const { results } = await run(makeDeps([doc], denseIndex({})), "onboarding")
+    const hits = toSearchHits(results, "onboarding")
+    expect(hits[0]?.semantic).toBe(false) // a real grep hit isn't a meaning-only match
+    expect(hits[0]?.snippet.toLowerCase()).toContain("onboarding")
   })
 
   it("a throwing dense arm degrades to lexical-only rather than failing the whole search", async () => {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -285,6 +285,8 @@ export interface SearchHit {
   current_version: number
   /** One line of the matching text, windowed around the match (server-side). */
   snippet: string
+  /** True when this matched by MEANING only (no literal occurrence) — the UI badges it. */
+  semantic: boolean
 }
 
 export const api = {

--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -280,11 +280,18 @@ export function CommandPalette() {
                   </div>
                 </CommandItem>
               ))}
-              {content.truncated && (
-                <div className="px-2 py-1.5 text-2xs text-muted-foreground">
-                  More may match — refine to narrow.
-                </div>
-              )}
+              {/* Escape the 6-row peek: jump to the full, browsable results page. */}
+              <CommandItem
+                value="see-all-results"
+                data-testid="palette-see-all-results"
+                onSelect={() => go(() => nav({ to: "/search", search: { q: query.trim() } }))}
+                className="text-muted-foreground"
+              >
+                <Icon name="search" size={16} />
+                <span>
+                  {content.truncated ? "See all results (more match)" : "See all results"}
+                </span>
+              </CommandItem>
             </CommandGroup>
           )}
 

--- a/apps/web/src/components/shared/search-field.tsx
+++ b/apps/web/src/components/shared/search-field.tsx
@@ -32,6 +32,7 @@ export function SearchField({
   autoFocus = false,
   className,
   testId,
+  onEnter,
   "aria-label": ariaLabel,
 }: {
   value: string
@@ -44,6 +45,8 @@ export function SearchField({
   autoFocus?: boolean
   className?: string
   testId: string
+  /** Fired on Enter with the current value trimmed non-empty — e.g. to submit to a results page. */
+  onEnter?: (value: string) => void
   "aria-label": string
 }) {
   const inputRef = useRef<HTMLInputElement>(null)
@@ -59,6 +62,11 @@ export function SearchField({
         value={value}
         onChange={(e) => onValueChange(e.target.value)}
         onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            const v = value.trim()
+            if (onEnter && v) onEnter(v)
+            return
+          }
           if (e.key !== "Escape") return
           if (value) {
             // First Esc clears; inside a dialog, closing stays the second Esc.

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -170,6 +170,18 @@ export const peopleQuery = (query: string) =>
     placeholderData: keepPreviousData,
   })
 
+// Full workspace search for the /search results page — the same hybrid (lexical + dense/semantic)
+// endpoint the ⌘K palette uses, but a deeper page (default 30 vs the palette's 6). Gated to ≥2
+// chars (the server also requires a query); keepPreviousData holds the list across refinements so
+// it never flashes empty mid-type.
+export const searchQuery = (query: string, limit = 30) =>
+  queryOptions({
+    queryKey: ["search", query, limit] as const,
+    queryFn: () => api.searchContent(query, limit),
+    enabled: query.trim().length >= 2,
+    placeholderData: keepPreviousData,
+  })
+
 // The directory's "your workspaces" section — people you already work with,
 // listed ahead of the global browse (and regardless of their discoverability).
 export const workspacePeopleQuery = () =>

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -372,8 +372,11 @@ function LibraryBody({ view }: { view: LibraryView }) {
         <SearchField
           value={query}
           onValueChange={setQuery}
-          placeholder="Filter by title…"
-          aria-label="Filter artifacts by title"
+          // The box filters the list by TITLE; Enter escalates to full-text + semantic search
+          // over the whole workspace on the /search page (the reach titles alone can't).
+          onEnter={(v) => nav({ to: "/search", search: { q: v } })}
+          placeholder="Filter by title, or ↵ to search everything…"
+          aria-label="Filter artifacts by title, or press Enter to search all content"
           testId="library-search"
           hotkey
           className="min-w-50 flex-1"

--- a/apps/web/src/pages/search.tsx
+++ b/apps/web/src/pages/search.tsx
@@ -1,0 +1,202 @@
+import { useQuery } from "@tanstack/react-query"
+import { Link, useNavigate, useSearch } from "@tanstack/react-router"
+import { useEffect, useState } from "react"
+import type { SearchHit } from "@/api"
+import { Icon } from "@/components/icons"
+import { EmptyState } from "@/components/shared/empty-state"
+import { PageHeader } from "@/components/shared/page-header"
+import { PageShell } from "@/components/shared/page-shell"
+import { SearchField } from "@/components/shared/search-field"
+import { StatusPanel } from "@/components/shared/status-panel"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { splitMatches } from "@/lib/highlight"
+import { searchQuery } from "@/lib/queries"
+import { useDelayedPending } from "@/lib/use-delayed-pending"
+import { useDocumentTitle } from "@/lib/use-document-title"
+import { refFor } from "@/pages/artifact/parse-ref"
+
+const MIN_CHARS = 2
+
+// The full workspace search results page (/search?q=). The ⌘K palette is a quick 6-row peek; this
+// is the deep, browsable view over the SAME hybrid (lexical + dense/semantic) endpoint — a ranked
+// list with a snippet per artifact, semantic-only matches badged as meaning matches. Reached from
+// the palette's "See all results" and by pressing Enter in a page's search field.
+export function SearchResults() {
+  const urlQ = (useSearch({ strict: false }) as { q?: string }).q ?? ""
+  const nav = useNavigate()
+  const [input, setInput] = useState(urlQ)
+  const [debounced, setDebounced] = useState(urlQ.trim())
+  useDocumentTitle(urlQ.trim() ? `Search: ${urlQ.trim()}` : "Search")
+
+  // Debounce keystrokes, and mirror the settled query into the URL so a search is shareable and the
+  // back button works — `replace` so typing doesn't stack history entries.
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(input.trim()), 250)
+    return () => clearTimeout(t)
+  }, [input])
+  useEffect(() => {
+    if (debounced === urlQ.trim()) return
+    nav({ to: "/search", search: debounced ? { q: debounced } : {}, replace: true })
+  }, [debounced, urlQ, nav])
+
+  const q = debounced
+  const active = q.length >= MIN_CHARS
+  const { data, isError, isFetching, refetch } = useQuery(searchQuery(q))
+  const hits = data?.hits ?? []
+
+  // First-load only (keepPreviousData holds the list across refinements); gated so a warm cache
+  // flashes nothing.
+  const loading = active && isFetching && hits.length === 0
+  const showSkeleton = useDelayedPending(loading)
+  const nothing = active && !isFetching && hits.length === 0
+
+  return (
+    <PageShell width="wide" className="flex flex-col gap-5">
+      <div className="flex flex-col gap-4">
+        <PageHeader
+          title="Search"
+          subtitle="Find artifacts by keyword or meaning across this workspace."
+        />
+        <SearchField
+          value={input}
+          onValueChange={setInput}
+          onEnter={(v) => setDebounced(v)}
+          placeholder="Search all artifacts…"
+          aria-label="Search all artifacts by keyword or meaning"
+          testId="search-field"
+          hotkey
+          autoFocus
+          loading={active && isFetching}
+        />
+      </div>
+
+      {!active ? (
+        <EmptyState
+          icon={<Icon name="search" strokeWidth={1.75} />}
+          title="Search your workspace"
+          description={`Find artifacts by keyword or by meaning — type at least ${MIN_CHARS} characters.`}
+        />
+      ) : loading ? (
+        showSkeleton ? (
+          <SearchResultsSkeleton />
+        ) : null
+      ) : isError ? (
+        <StatusPanel
+          tone="danger"
+          title="Couldn’t run that search"
+          description="This is usually temporary."
+          action={
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="search-retry"
+              onClick={() => refetch()}
+            >
+              Try again
+            </Button>
+          }
+        />
+      ) : nothing ? (
+        <div data-testid="search-empty">
+          <EmptyState
+            icon={<Icon name="search" strokeWidth={1.75} />}
+            title={`No artifacts match “${q}”.`}
+            description="Try different words, or fewer of them."
+          />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          <ul role="list" data-testid="search-results" className="flex flex-col gap-1">
+            {hits.map((h) => (
+              <HitRow key={h.short_id} hit={h} query={q} />
+            ))}
+          </ul>
+          {data?.truncated && (
+            <p className="px-1 text-xs text-muted-foreground">
+              Showing the top matches — refine your search to narrow it.
+            </p>
+          )}
+        </div>
+      )}
+    </PageShell>
+  )
+}
+
+// One result row: the artifact title over its snippet. A semantic-only hit is badged and its
+// snippet is the matching passage (no literal term to highlight); a literal hit highlights the
+// matched term. The whole row links to the artifact.
+function HitRow({ hit, query }: { hit: SearchHit; query: string }) {
+  return (
+    <li>
+      <Link
+        to="/artifacts/$ref"
+        params={{ ref: refFor(hit) }}
+        data-testid={`search-hit-${hit.short_id}`}
+        className="flex items-start gap-3 rounded-lg px-3 py-2.5 outline-none hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+      >
+        <Icon name="all" size={16} className="mt-0.5 shrink-0 text-muted-foreground" />
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate font-medium text-foreground">{hit.title}</span>
+            {hit.semantic && (
+              <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-2xs text-muted-foreground">
+                meaning match
+              </span>
+            )}
+          </div>
+          {hit.snippet && (
+            <span className="line-clamp-2 text-xs text-muted-foreground">
+              {splitMatches(hit.snippet, query).map((seg, i) =>
+                seg.match ? (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional + static
+                  <span key={i} className="font-semibold text-foreground">
+                    {seg.text}
+                  </span>
+                ) : (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: segments are positional + static
+                  <span key={i}>{seg.text}</span>
+                ),
+              )}
+            </span>
+          )}
+        </div>
+      </Link>
+    </li>
+  )
+}
+
+function SearchResultsSkeleton() {
+  return (
+    <ul role="list" className="flex flex-col gap-1" aria-hidden>
+      {Array.from({ length: 6 }, (_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length static skeleton
+        <li key={i} className="flex items-start gap-3 px-3 py-2.5">
+          <Skeleton className="mt-0.5 size-4 rounded" />
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <Skeleton className="h-4 w-48 rounded" />
+            <Skeleton className="h-3 w-full max-w-xl rounded" />
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+// Route-level pending frame (the /search pendingComponent): the static chrome + results skeleton,
+// shown on a cold nav while the auth guard resolves. The in-component skeleton carries the data
+// load, so the two are seamless.
+export function SearchPending() {
+  return (
+    <PageShell width="wide" className="flex flex-col gap-5">
+      <div className="flex flex-col gap-4">
+        <PageHeader
+          title="Search"
+          subtitle="Find artifacts by keyword or meaning across this workspace."
+        />
+        <Skeleton className="h-8 w-full rounded-lg" />
+      </div>
+      <SearchResultsSkeleton />
+    </PageShell>
+  )
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as UnlistedRouteImport } from './routes/unlisted'
 import { Route as ShowcaseRouteImport } from './routes/showcase'
 import { Route as SharedRouteImport } from './routes/shared'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as SearchRouteImport } from './routes/search'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as PeopleRouteImport } from './routes/people'
 import { Route as NewRouteImport } from './routes/new'
@@ -55,6 +56,11 @@ const SharedRoute = SharedRouteImport.update({
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SearchRoute = SearchRouteImport.update({
+  id: '/search',
+  path: '/search',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ResetPasswordRoute = ResetPasswordRouteImport.update({
@@ -153,6 +159,7 @@ export interface FileRoutesByFullPath {
   '/new': typeof NewRoute
   '/people': typeof PeopleRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/search': typeof SearchRoute
   '/settings': typeof SettingsRouteWithChildren
   '/shared': typeof SharedRoute
   '/showcase': typeof ShowcaseRoute
@@ -177,6 +184,7 @@ export interface FileRoutesByTo {
   '/new': typeof NewRoute
   '/people': typeof PeopleRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/search': typeof SearchRoute
   '/shared': typeof SharedRoute
   '/showcase': typeof ShowcaseRoute
   '/unlisted': typeof UnlistedRoute
@@ -201,6 +209,7 @@ export interface FileRoutesById {
   '/new': typeof NewRoute
   '/people': typeof PeopleRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/search': typeof SearchRoute
   '/settings': typeof SettingsRouteWithChildren
   '/shared': typeof SharedRoute
   '/showcase': typeof ShowcaseRoute
@@ -227,6 +236,7 @@ export interface FileRouteTypes {
     | '/new'
     | '/people'
     | '/reset-password'
+    | '/search'
     | '/settings'
     | '/shared'
     | '/showcase'
@@ -251,6 +261,7 @@ export interface FileRouteTypes {
     | '/new'
     | '/people'
     | '/reset-password'
+    | '/search'
     | '/shared'
     | '/showcase'
     | '/unlisted'
@@ -274,6 +285,7 @@ export interface FileRouteTypes {
     | '/new'
     | '/people'
     | '/reset-password'
+    | '/search'
     | '/settings'
     | '/shared'
     | '/showcase'
@@ -299,6 +311,7 @@ export interface RootRouteChildren {
   NewRoute: typeof NewRoute
   PeopleRoute: typeof PeopleRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
+  SearchRoute: typeof SearchRoute
   SettingsRoute: typeof SettingsRouteWithChildren
   SharedRoute: typeof SharedRoute
   ShowcaseRoute: typeof ShowcaseRoute
@@ -347,6 +360,13 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/settings'
       preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/search': {
+      id: '/search'
+      path: '/search'
+      fullPath: '/search'
+      preLoaderRoute: typeof SearchRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/reset-password': {
@@ -495,6 +515,7 @@ const rootRouteChildren: RootRouteChildren = {
   NewRoute: NewRoute,
   PeopleRoute: PeopleRoute,
   ResetPasswordRoute: ResetPasswordRoute,
+  SearchRoute: SearchRoute,
   SettingsRoute: SettingsRouteWithChildren,
   SharedRoute: SharedRoute,
   ShowcaseRoute: ShowcaseRoute,

--- a/apps/web/src/routes/search.tsx
+++ b/apps/web/src/routes/search.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { requireOnboarded } from "../lib/route-guards"
+import { SearchPending, SearchResults } from "../pages/search"
+
+// Full workspace search results: /search?q= — the deep, browsable view over the same hybrid
+// (lexical + dense/semantic) endpoint the ⌘K palette peeks at. In-app; requires a signed-in user.
+export const Route = createFileRoute("/search")({
+  beforeLoad: requireOnboarded,
+  pendingComponent: SearchPending,
+  // `q` is the search term; anything else is ignored so a shared link stays clean.
+  validateSearch: (s: Record<string, unknown>): { q?: string } => ({
+    q: typeof s.q === "string" && s.q.trim() ? s.q : undefined,
+  }),
+  component: SearchResults,
+})


### PR DESCRIPTION
Addresses the audit's top user-facing gap: the hybrid (lexical + dense/semantic) backend was reachable only through the ⌘K palette's **6-row "In content" peek** — unlabeled, no way to see the full list — while the always-visible library box searched **titles only**. This ships a real results page and wires the entry points to it.

## Frontend
- **New `/search?q=` route + page** — the deep, browsable view over the *same* search endpoint: a ranked list with a per-artifact snippet, the loading/error/empty ladder, the query mirrored to the URL (shareable + back-button), reusing the palette's `splitMatches` highlight. Clones the `people.tsx` conventions (PageShell, tokens, testids, pendingComponent).
- **Semantic matches are now badged** ("meaning match") — a new `SearchHit.semantic` flag (set server-side when a hit matched by meaning with no literal occurrence) makes the dense arm *visible* instead of indistinguishable from lexical.
- **Entry points**: the palette gains a "See all results" item → `/search`; the library search box gains **Enter → `/search`** (title filter escalates to full content+semantic search); `SearchField` grew an `onEnter` hook.

## Backend
- The JSON search route was hard-capped at `limit≤12` / `candidateCap 60` (right for the palette typeahead, too shallow for a page). Raised to `limit≤50` with `candidateCap` scaling to the requested depth — **the palette still requests 6, so its hot path is unchanged**.
- `toSearchHits` sets `semantic` per hit.

## Verification
typecheck + biome + 15 lint gates (tokens/testids/surfaces/frontend) + **web production build** + **985 api tests** green. New route confirmed registered in `routeTree.gen.ts` and bundled.

Remaining audit item after this: true cursor pagination on the results page (currently one deep page of up to 50 + a "refine" note) — a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)