### PR TITLE
Feat/brandprint rework

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -5974,6 +5974,61 @@
         }
       }
     },
+    "/v1/artifacts/{shortId}/rework": {
+      "post": {
+        "tags": [
+          "Artifacts"
+        ],
+        "summary": "Ask a registered agent to rework this artifact to match the Brandprint.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "shortId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "agentId": {
+                    "type": "string",
+                    "description": "Which agent to ask; omit to use the sole registered agent."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The rework request was posted and landed in the agent's pull inbox. 409 needsAgent when no agent is registered; 409 needsBrandprint when no Brandprint resolves.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "requestId": {
+                      "type": "string",
+                      "description": "The request comment's thread id."
+                    }
+                  },
+                  "required": [
+                    "requestId"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/artifacts/{shortId}/comments": {
       "post": {
         "tags": [

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -32,6 +32,7 @@ import { proposalRoutes } from "./routes/proposals"
 import { rawRoutes } from "./routes/raw"
 import { realtimeRoutes } from "./routes/realtime"
 import { reviewRoutes } from "./routes/review"
+import { reworkRoutes } from "./routes/rework"
 import { sessionRoutes } from "./routes/session"
 import { sharingRoutes } from "./routes/sharing"
 import { slackRoutes } from "./routes/slack"
@@ -369,6 +370,7 @@ export function createApp(deps: AppDeps): Hono {
     moderationRoutes,
     proposalRoutes,
     reviewRoutes,
+    reworkRoutes,
     commentRoutes,
     contextRoutes,
     realtimeRoutes,

--- a/apps/api/src/lib/brandprint.ts
+++ b/apps/api/src/lib/brandprint.ts
@@ -1,0 +1,26 @@
+import {
+  type MetaStore,
+  parseBrandprint,
+  type ResolvedBrandprint,
+  resolveBrandprint,
+} from "@derive/core"
+
+/**
+ * Resolve the effective Brandprint for an actor in a workspace: the workspace's
+ * conventions merged with the actor's personal layer (profile wins). One home for
+ * the two-read + merge sequence the MCP connection, the context runner, and the
+ * rework endpoint all need — keyed on a different user id at each site, which is
+ * exactly the axis the hand-rolled copies had started to drift on. The reads are
+ * independent, so they run concurrently. `userId` null ⇒ workspace layer only.
+ */
+export const resolveActorBrandprint = async (
+  meta: MetaStore,
+  orgId: string,
+  userId: string | null,
+): Promise<ResolvedBrandprint> => {
+  const [settings, personal] = await Promise.all([
+    meta.getOrgSettings(orgId),
+    userId ? meta.getUserBrandprint(userId) : null,
+  ])
+  return resolveBrandprint(settings.brandprint, parseBrandprint(personal))
+}

--- a/apps/api/src/lib/brandprint.ts
+++ b/apps/api/src/lib/brandprint.ts
@@ -9,8 +9,7 @@ import {
  * Resolve the effective Brandprint for an actor in a workspace: the workspace's
  * conventions merged with the actor's personal layer (profile wins). One home for
  * the two-read + merge sequence the MCP connection, the context runner, and the
- * rework endpoint all need — keyed on a different user id at each site, which is
- * exactly the axis the hand-rolled copies had started to drift on. The reads are
+ * rework endpoint all need, each keyed on a different user id. The reads are
  * independent, so they run concurrently. `userId` null ⇒ workspace layer only.
  */
 export const resolveActorBrandprint = async (

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -42,14 +42,12 @@ import {
   type OutlineSection,
   outlineOf,
   PublishError,
-  parseBrandprint,
   parseFrontmatter,
   profileState,
   propose as proposeChange,
   publishAdvisories,
   publish as publishVersion,
   type Role,
-  resolveBrandprint,
   roleAllows,
   SKILL_CONTENT_TYPE,
   sectionOf,
@@ -64,6 +62,7 @@ import { BRANDPRINT_REFERENCE, BRANDPRINT_TEMPLATE } from "./brandprint-referenc
 import type { AppContext } from "./context"
 import { markAddressed } from "./lib/addressed"
 import { afterPublish } from "./lib/after-publish"
+import { resolveActorBrandprint } from "./lib/brandprint"
 import {
   cleanPath,
   mergeBundleZip,
@@ -283,11 +282,7 @@ async function buildServer(
   // Resolve the Brandprint for this actor: the workspace's conventions merged with the
   // owner's personal ones (profile wins). Each convention doc becomes a readable resource;
   // a one-line pointer goes in the instructions (bodies load lazily on read).
-  const wsBrandprint = (await ctx.meta.getOrgSettings(agent.org_id)).brandprint
-  const profileBrandprint = parseBrandprint(
-    ownerId ? await ctx.meta.getUserBrandprint(ownerId) : null,
-  )
-  const resolved = resolveBrandprint(wsBrandprint, profileBrandprint)
+  const resolved = await resolveActorBrandprint(ctx.meta, agent.org_id, ownerId)
   const conventionDocs: ArtifactRecord[] = []
   const seenBp = new Set<string>()
   for (const collectionId of resolved.collectionIds) {

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -2,8 +2,6 @@ import {
   type ContextAskerRecord,
   type ContextRecord,
   newId,
-  parseBrandprint,
-  resolveBrandprint,
   type SessionMessageRecord,
   type SessionRecord,
   type SessionState,
@@ -14,6 +12,7 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { Context } from "hono"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
+import { resolveActorBrandprint } from "../lib/brandprint"
 import { bail, fail, readJson } from "../lib/http"
 import { log } from "../log"
 
@@ -223,9 +222,7 @@ export const contextRoutes = (ctx: AppContext) => {
   // simply omitted. A member the runner can't read still appears (it discovers the
   // 404 at materialize time and reports it, mirroring a failed repo clone).
   const resolveContextBrandprint = async (x: ContextRecord) => {
-    const wsBrandprint = (await meta.getOrgSettings(x.org_id)).brandprint
-    const profileBrandprint = parseBrandprint(await meta.getUserBrandprint(x.created_by))
-    const resolved = resolveBrandprint(wsBrandprint, profileBrandprint)
+    const resolved = await resolveActorBrandprint(meta, x.org_id, x.created_by)
     if (resolved.collectionIds.length === 0) return undefined
     const seen = new Set<string>()
     const members: {

--- a/apps/api/src/routes/rework.ts
+++ b/apps/api/src/routes/rework.ts
@@ -1,13 +1,8 @@
-import {
-  newId,
-  parseBrandprint,
-  profileState,
-  resolveBrandprint,
-  reworkInstruction,
-} from "@derive/core"
+import { newId, profileState, reworkInstruction } from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
+import { resolveActorBrandprint } from "../lib/brandprint"
 import { parseMeta, quoteOf } from "../lib/comments"
 import { bail, fail, readJson } from "../lib/http"
 import { notifyMentions } from "../lib/mentions"
@@ -75,7 +70,11 @@ export const reworkRoutes = (ctx: AppContext) => {
       const body = await readJson(c, z.object({ agentId: z.string().optional() }))
       if (body instanceof Response) return bail(body)
 
-      const agents = await meta.listAgents(artifact.org_id)
+      // The agent list and the Brandprint resolution are independent reads; batch them.
+      const [agents, resolved] = await Promise.all([
+        meta.listAgents(artifact.org_id),
+        resolveActorBrandprint(meta, artifact.org_id, acting.id),
+      ])
       if (agents.length === 0)
         return bail(
           fail(c, 409, "no agent is registered in this workspace", { code: "needsAgent" }),
@@ -86,21 +85,18 @@ export const reworkRoutes = (ctx: AppContext) => {
         if (!found) return bail(fail(c, 404, "no such agent in this workspace"))
         agent = found
       } else {
+        // `!sole` can't fire — the empty case 409'd above; it narrows the
+        // destructured element so no unchecked index escapes.
         const [sole, ...rest] = agents
         if (!sole || rest.length > 0)
           return bail(fail(c, 400, "agentId required when several agents are registered"))
         agent = sole
       }
 
-      // Resolve the Brandprint the agent will read (workspace ⊕ requester's profile) —
-      // needed for the profile-first line, and as a guard: firing the canned
-      // instruction with zero derive://brandprint/* resources behind it would hand
-      // the agent an empty brief.
-      const [orgSettings, personalRaw] = await Promise.all([
-        meta.getOrgSettings(artifact.org_id),
-        meta.getUserBrandprint(acting.id),
-      ])
-      const resolved = resolveBrandprint(orgSettings.brandprint, parseBrandprint(personalRaw))
+      // The resolved Brandprint (workspace ⊕ requester's profile) drives the
+      // profile-first line and guards the empty brief: firing the canned instruction
+      // with zero derive://brandprint/* resources behind it would hand the agent
+      // nothing to read.
       if (resolved.collectionIds.length === 0 && !resolved.profileId)
         return bail(
           fail(c, 409, "no Brandprint is set on this workspace or your profile", {

--- a/apps/api/src/routes/rework.ts
+++ b/apps/api/src/routes/rework.ts
@@ -107,7 +107,11 @@ export const reworkRoutes = (ctx: AppContext) => {
       }
 
       // The canned request: a whole-document comment (no anchor) @mentioning the
-      // agent — the same row and fan-out the ask-agent composer produces.
+      // agent — the same ROW the ask-agent composer writes, but a deliberately
+      // narrower fan-out: comment.created + mention/bell notify only, skipping the
+      // comment.mention webhook, comment emails, Slack, and the GitHub PR echo. This
+      // is a canned, bot-directed note, not a human conversation — mirroring it into
+      // those channels would just be noise for people who didn't ask for it.
       const id = newId("c")
       const mentions = [{ id: agent.id, name: agent.name }]
       const created = await meta.createComment({

--- a/apps/api/src/routes/rework.ts
+++ b/apps/api/src/routes/rework.ts
@@ -1,0 +1,145 @@
+import {
+  newId,
+  parseBrandprint,
+  profileState,
+  resolveBrandprint,
+  reworkInstruction,
+} from "@derive/core"
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import type { BlankEnv } from "hono/types"
+import type { AppContext } from "../context"
+import { quoteOf } from "../lib/comments"
+import { bail, fail, readJson } from "../lib/http"
+import { notifyMentions } from "../lib/mentions"
+import { notifyCommentBells } from "../lib/notify-comment"
+
+/** Phase 3 (apply): the Rework button's endpoint. A thin wrapper over the existing
+ *  @mention-to-inbox path — composes the canned Brandprint instruction server-side
+ *  (the single source of truth; the client never carries the prompt) and posts it as
+ *  a whole-document comment @mentioning the chosen agent, which drops into that
+ *  agent's MCP pull inbox. The agent revises and publishes per its grant: a
+ *  publish-capable agent posts the new version directly, a lower grant files a
+ *  proposal — no special case here. */
+export const reworkRoutes = (ctx: AppContext) => {
+  const { meta, bus, background, notify, actingUser, authorize, limited, commentLimiter } = ctx
+  const app = new OpenAPIHono<BlankEnv>()
+
+  app.openapi(
+    createRoute({
+      method: "post",
+      path: "/v1/artifacts/{shortId}/rework",
+      tags: ["Artifacts"],
+      summary: "Ask a registered agent to rework this artifact to match the Brandprint.",
+      request: {
+        params: z.object({ shortId: z.string() }),
+        body: {
+          required: false,
+          content: {
+            "application/json": {
+              schema: z.object({
+                agentId: z
+                  .string()
+                  .optional()
+                  .describe("Which agent to ask; omit to use the sole registered agent."),
+              }),
+            },
+          },
+        },
+      },
+      responses: {
+        201: {
+          description:
+            "The rework request was posted and landed in the agent's pull inbox. 409 needsAgent when no agent is registered; 409 needsBrandprint when no Brandprint resolves.",
+          content: {
+            "application/json": {
+              schema: z.object({
+                requestId: z.string().describe("The request comment's thread id."),
+              }),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const artifact = await meta.getByShortId(c.req.param("shortId"))
+      if (!artifact || artifact.current_version === 0) return bail(fail(c, 404, "not found"))
+      if (!(await authorize(c, "comment", artifact))) return bail(fail(c, 403, "forbidden"))
+      // Rework acts as a named collaborator (the request is authored and attributed,
+      // and the personal Brandprint layer is theirs) — no anonymous firing.
+      const acting = await actingUser(c)
+      if (!acting) return bail(fail(c, 401, "sign in to request a rework"))
+      const rl = await limited(c, commentLimiter)
+      if (rl) return bail(rl)
+      let agentId: string | undefined
+      if (c.req.header("content-type")?.includes("application/json")) {
+        const body = await readJson(c, z.object({ agentId: z.string().optional() }))
+        if (body instanceof Response) return bail(body)
+        agentId = body.agentId
+      }
+
+      const agents = await meta.listAgents(artifact.org_id)
+      if (agents.length === 0) return bail(fail(c, 409, "needsAgent"))
+      const agent = agentId
+        ? agents.find((a) => a.id === agentId)
+        : agents.length === 1
+          ? agents[0]
+          : undefined
+      if (!agent)
+        return bail(
+          agentId
+            ? fail(c, 404, "no such agent in this workspace")
+            : fail(c, 400, "agentId required when several agents are registered"),
+        )
+
+      // Resolve the Brandprint the agent will read (workspace ⊕ requester's profile) —
+      // needed for the profile-first line, and as a guard: firing the canned
+      // instruction with zero derive://brandprint/* resources behind it would hand
+      // the agent an empty brief.
+      const ws = (await meta.getOrgSettings(artifact.org_id)).brandprint
+      const personal = parseBrandprint(await meta.getUserBrandprint(acting.id))
+      const resolved = resolveBrandprint(ws, personal)
+      if (resolved.collectionIds.length === 0 && !resolved.profileId)
+        return bail(fail(c, 409, "needsBrandprint"))
+      let profileLive = false
+      if (resolved.profileId) {
+        const prof = await meta.getByShortId(resolved.profileId)
+        profileLive = !!prof && profileState(prof.current_version) === "live"
+      }
+
+      // The canned request: a whole-document comment (no anchor) @mentioning the
+      // agent — the same row and fan-out the ask-agent composer produces.
+      const id = newId("c")
+      const mentions = [{ id: agent.id, name: agent.name }]
+      const created = await meta.createComment({
+        id,
+        artifact_id: artifact.id,
+        thread_id: id,
+        base_version: artifact.current_version,
+        path: null,
+        anchor: null,
+        body_md: `@${agent.name} ${reworkInstruction(profileLive)}`,
+        author: acting.name,
+        author_id: acting.id,
+      })
+      await meta.updateComment(created.id, { meta: JSON.stringify({ mentions }) })
+      bus.publish(artifact.id, { type: "comment.created" })
+      await background(
+        (async () => {
+          await notify(artifact, "comment.created", {
+            author: created.author,
+            body: created.body_md,
+            quote: quoteOf(created.anchor),
+            thread_id: created.thread_id,
+          })
+          await notifyMentions({ meta, bus }, artifact, created, mentions, acting.id)
+          await notifyCommentBells({ meta, bus }, artifact, created, {
+            mentionIds: new Set(mentions.map((m) => m.id)),
+            actorId: acting.id,
+          })
+        })(),
+      )
+      return c.json({ requestId: created.thread_id }, 201)
+    },
+  )
+  return app
+}

--- a/apps/api/src/routes/rework.ts
+++ b/apps/api/src/routes/rework.ts
@@ -8,12 +8,12 @@ import {
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
-import { quoteOf } from "../lib/comments"
+import { parseMeta, quoteOf } from "../lib/comments"
 import { bail, fail, readJson } from "../lib/http"
 import { notifyMentions } from "../lib/mentions"
 import { notifyCommentBells } from "../lib/notify-comment"
 
-/** Phase 3 (apply): the Rework button's endpoint. A thin wrapper over the existing
+/** The Rework button's endpoint. A thin wrapper over the existing
  *  @mention-to-inbox path — composes the canned Brandprint instruction server-side
  *  (the single source of truth; the client never carries the prompt) and posts it as
  *  a whole-document comment @mentioning the chosen agent, which drops into that
@@ -70,36 +70,43 @@ export const reworkRoutes = (ctx: AppContext) => {
       if (!acting) return bail(fail(c, 401, "sign in to request a rework"))
       const rl = await limited(c, commentLimiter)
       if (rl) return bail(rl)
-      let agentId: string | undefined
-      if (c.req.header("content-type")?.includes("application/json")) {
-        const body = await readJson(c, z.object({ agentId: z.string().optional() }))
-        if (body instanceof Response) return bail(body)
-        agentId = body.agentId
-      }
+      // readJson tolerates a missing body (it parses to {}), so a bare POST means
+      // "use the sole registered agent".
+      const body = await readJson(c, z.object({ agentId: z.string().optional() }))
+      if (body instanceof Response) return bail(body)
 
       const agents = await meta.listAgents(artifact.org_id)
-      if (agents.length === 0) return bail(fail(c, 409, "needsAgent"))
-      const agent = agentId
-        ? agents.find((a) => a.id === agentId)
-        : agents.length === 1
-          ? agents[0]
-          : undefined
-      if (!agent)
+      if (agents.length === 0)
         return bail(
-          agentId
-            ? fail(c, 404, "no such agent in this workspace")
-            : fail(c, 400, "agentId required when several agents are registered"),
+          fail(c, 409, "no agent is registered in this workspace", { code: "needsAgent" }),
         )
+      let agent: (typeof agents)[number]
+      if (body.agentId) {
+        const found = agents.find((a) => a.id === body.agentId)
+        if (!found) return bail(fail(c, 404, "no such agent in this workspace"))
+        agent = found
+      } else {
+        const [sole, ...rest] = agents
+        if (!sole || rest.length > 0)
+          return bail(fail(c, 400, "agentId required when several agents are registered"))
+        agent = sole
+      }
 
       // Resolve the Brandprint the agent will read (workspace ⊕ requester's profile) —
       // needed for the profile-first line, and as a guard: firing the canned
       // instruction with zero derive://brandprint/* resources behind it would hand
       // the agent an empty brief.
-      const ws = (await meta.getOrgSettings(artifact.org_id)).brandprint
-      const personal = parseBrandprint(await meta.getUserBrandprint(acting.id))
-      const resolved = resolveBrandprint(ws, personal)
+      const [orgSettings, personalRaw] = await Promise.all([
+        meta.getOrgSettings(artifact.org_id),
+        meta.getUserBrandprint(acting.id),
+      ])
+      const resolved = resolveBrandprint(orgSettings.brandprint, parseBrandprint(personalRaw))
       if (resolved.collectionIds.length === 0 && !resolved.profileId)
-        return bail(fail(c, 409, "needsBrandprint"))
+        return bail(
+          fail(c, 409, "no Brandprint is set on this workspace or your profile", {
+            code: "needsBrandprint",
+          }),
+        )
       let profileLive = false
       if (resolved.profileId) {
         const prof = await meta.getByShortId(resolved.profileId)
@@ -125,7 +132,9 @@ export const reworkRoutes = (ctx: AppContext) => {
         author: acting.name,
         author_id: acting.id,
       })
-      await meta.updateComment(created.id, { meta: JSON.stringify({ mentions }) })
+      await meta.updateComment(created.id, {
+        meta: JSON.stringify({ ...parseMeta(created.meta), mentions }),
+      })
       bus.publish(artifact.id, { type: "comment.created" })
       await background(
         (async () => {

--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -1,5 +1,4 @@
-import { randomUUID } from "node:crypto"
-import { type InvitationRecord, newId, type Role } from "@derive/core"
+import { newId, type Role } from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"

--- a/apps/api/test/rework.test.ts
+++ b/apps/api/test/rework.test.ts
@@ -115,6 +115,28 @@ describe("rework: firing", () => {
     expect(mentions[0]?.body).not.toContain("derive://brandprint/profile")
   })
 
+  it("workspace Brandprint unset, requester's personal profile carries one: still fires", async () => {
+    const { app } = makeAuthedApp("rework-personal", [owner, editor], "editor")
+    const shortId = await newArtifact(app)
+    const ag = await addAgent(app, "Reviser")
+    // No seedBrandprint call — the workspace layer stays unset. Seed the requester's
+    // PERSONAL layer through the real route the web uses (POST /v1/me/profile), same
+    // as profiles.test.ts, pointed at a collection the requester can reach.
+    const col = await (
+      await app.request("/v1/collections", jsonAs(as(editor.email), { title: "My Brandprint" }))
+    ).json()
+    const saved = await app.request(
+      "/v1/me/profile",
+      jsonAs(as(editor.email), { brandprint: { collectionId: col.id } }),
+    )
+    expect(saved.status).toBe(200)
+    const res = await rework(app, shortId)
+    expect(res.status).toBe(201)
+    const mentions = await inboxBodies(app, ag.token)
+    expect(mentions).toHaveLength(1)
+    expect(mentions[0]?.body).toContain("@Reviser")
+  })
+
   it("several agents: omitted agentId 400s; a chosen agentId fires that agent only", async () => {
     const { app, meta } = makeAuthedApp("rework-many", [owner, editor], "editor")
     const shortId = await newArtifact(app)

--- a/apps/api/test/rework.test.ts
+++ b/apps/api/test/rework.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest"
 import { as, bearer, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 
-// Phase 3 (apply): POST /v1/artifacts/:shortId/rework composes the canned Brandprint
-// instruction server-side and lands it in the chosen agent's pull inbox as an @mention
+// POST /v1/artifacts/:shortId/rework composes the canned Brandprint instruction
+// server-side and lands it in the chosen agent's pull inbox as an @mention
 // comment — the same path the ask-agent composer uses, minus the human typing it.
 
 const owner: TestUser = {
@@ -73,7 +73,7 @@ describe("rework: gating", () => {
     await seedBrandprint(meta, shortId)
     const res = await rework(app, shortId)
     expect(res.status).toBe(409)
-    expect(((await res.json()) as { error: string }).error).toBe("needsAgent")
+    expect(((await res.json()) as { code: string }).code).toBe("needsAgent")
   })
 
   it("409 needsBrandprint when no Brandprint resolves — an empty brief never fires", async () => {
@@ -82,7 +82,7 @@ describe("rework: gating", () => {
     await addAgent(app, "Reviser")
     const res = await rework(app, shortId)
     expect(res.status).toBe(409)
-    expect(((await res.json()) as { error: string }).error).toBe("needsBrandprint")
+    expect(((await res.json()) as { code: string }).code).toBe("needsBrandprint")
   })
 
   it("404 for an unknown artifact; 404 for an agentId from another workspace", async () => {

--- a/apps/api/test/rework.test.ts
+++ b/apps/api/test/rework.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest"
+import { as, bearer, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// Phase 3 (apply): POST /v1/artifacts/:shortId/rework composes the canned Brandprint
+// instruction server-side and lands it in the chosen agent's pull inbox as an @mention
+// comment — the same path the ask-agent composer uses, minus the human typing it.
+
+const owner: TestUser = {
+  id: "u_rw_own",
+  email: "rwown@derive.test",
+  name: "Owner",
+  username: "rwown",
+}
+const editor: TestUser = { id: "u_rw_ed", email: "rwed@derive.test", name: "Ed", username: "rwed" }
+
+type App = ReturnType<typeof makeAuthedApp>["app"]
+type Meta = ReturnType<typeof makeAuthedApp>["meta"]
+
+const newArtifact = async (app: App) => {
+  const r = await publishAs(app, "# Doc", {}, as(owner.email))
+  return (await r.json()).short_id as string
+}
+
+// Register an agent (owner-only route); the token is returned once, here.
+const addAgent = async (app: App, name: string) =>
+  (await (
+    await app.request("/v1/agents", jsonAs(as(owner.email), { name, role: "editor" }))
+  ).json()) as {
+    id: string
+    name: string
+    token: string
+  }
+
+// Seed a Brandprint: a collection holding the given doc, pointed at by the workspace
+// (the same store-level seeding mcp.test.ts uses).
+const seedBrandprint = async (meta: Meta, artShortId: string, extra?: { profileId?: string }) => {
+  const art = await meta.getByShortId(artShortId)
+  if (!art) throw new Error("no artifact")
+  const collectionId = `col_${artShortId}`
+  await meta.createCollection({
+    id: collectionId,
+    org_id: art.org_id,
+    title: "Brandprint",
+    created_by: owner.id,
+  })
+  await meta.addCollectionItem(collectionId, art.id)
+  await meta.setOrgSettings(art.org_id, {
+    ...(await meta.getOrgSettings(art.org_id)),
+    brandprint: { collectionId, ...extra },
+  })
+}
+
+const rework = (
+  app: App,
+  shortId: string,
+  body: Record<string, unknown> = {},
+  who = editor.email,
+) => app.request(`/v1/artifacts/${shortId}/rework`, jsonAs(as(who), body))
+
+const inboxBodies = async (app: App, token: string) => {
+  const inbox = (await (
+    await app.request("/v1/agent/inbox", { headers: bearer(token) })
+  ).json()) as {
+    mentions: { body: string; artifact: string; thread_id: string }[]
+  }
+  return inbox.mentions
+}
+
+describe("rework: gating", () => {
+  it("409 needsAgent when the workspace has no registered agent", async () => {
+    const { app, meta } = makeAuthedApp("rework-noagent", [owner, editor], "editor")
+    const shortId = await newArtifact(app)
+    await seedBrandprint(meta, shortId)
+    const res = await rework(app, shortId)
+    expect(res.status).toBe(409)
+    expect(((await res.json()) as { error: string }).error).toBe("needsAgent")
+  })
+
+  it("409 needsBrandprint when no Brandprint resolves — an empty brief never fires", async () => {
+    const { app } = makeAuthedApp("rework-nobp", [owner, editor], "editor")
+    const shortId = await newArtifact(app)
+    await addAgent(app, "Reviser")
+    const res = await rework(app, shortId)
+    expect(res.status).toBe(409)
+    expect(((await res.json()) as { error: string }).error).toBe("needsBrandprint")
+  })
+
+  it("404 for an unknown artifact; 404 for an agentId from another workspace", async () => {
+    const { app, meta } = makeAuthedApp("rework-404", [owner, editor], "editor")
+    expect((await rework(app, "nope")).status).toBe(404)
+    const shortId = await newArtifact(app)
+    await seedBrandprint(meta, shortId)
+    await addAgent(app, "Reviser")
+    expect((await rework(app, shortId, { agentId: "agt_elsewhere" })).status).toBe(404)
+  })
+})
+
+describe("rework: firing", () => {
+  it("sole agent, agentId omitted: the canned request lands in the agent's inbox", async () => {
+    const { app, meta } = makeAuthedApp("rework-sole", [owner, editor], "editor")
+    const shortId = await newArtifact(app)
+    await seedBrandprint(meta, shortId)
+    const ag = await addAgent(app, "Reviser")
+    const res = await rework(app, shortId)
+    expect(res.status).toBe(201)
+    const { requestId } = (await res.json()) as { requestId: string }
+    expect(requestId).toBeTruthy()
+    const mentions = await inboxBodies(app, ag.token)
+    expect(mentions).toHaveLength(1)
+    expect(mentions[0]?.artifact).toBe(shortId)
+    expect(mentions[0]?.thread_id).toBe(requestId)
+    expect(mentions[0]?.body).toContain("@Reviser")
+    expect(mentions[0]?.body).toContain("derive://brandprint/*")
+    expect(mentions[0]?.body).toContain("Publish the result as a new version.")
+    expect(mentions[0]?.body).not.toContain("derive://brandprint/profile")
+  })
+
+  it("several agents: omitted agentId 400s; a chosen agentId fires that agent only", async () => {
+    const { app, meta } = makeAuthedApp("rework-many", [owner, editor], "editor")
+    const shortId = await newArtifact(app)
+    await seedBrandprint(meta, shortId)
+    const a = await addAgent(app, "Reviser")
+    const b = await addAgent(app, "Stylist")
+    expect((await rework(app, shortId)).status).toBe(400)
+    const res = await rework(app, shortId, { agentId: b.id })
+    expect(res.status).toBe(201)
+    expect(await inboxBodies(app, a.token)).toHaveLength(0)
+    const got = await inboxBodies(app, b.token)
+    expect(got).toHaveLength(1)
+    expect(got[0]?.body).toContain("@Stylist")
+  })
+
+  it("a LIVE brand profile is named as the first read; a pending one is not", async () => {
+    const { app, meta } = makeAuthedApp("rework-profile", [owner, editor], "editor")
+    const shortId = await newArtifact(app)
+    const ag = await addAgent(app, "Reviser")
+    // The profile stub is v1 (pending); publishing a second version makes it live.
+    const profId = (await (await publishAs(app, "profile v1", {}, as(owner.email))).json())
+      .short_id as string
+    await seedBrandprint(meta, shortId, { profileId: profId })
+    const pending = await rework(app, shortId)
+    expect(pending.status).toBe(201)
+    await publishAs(app, "profile v2", {}, as(owner.email), profId)
+    const live = await rework(app, shortId)
+    expect(live.status).toBe(201)
+    const bodies = (await inboxBodies(app, ag.token)).map((m) => m.body)
+    expect(bodies).toHaveLength(2)
+    expect(bodies.filter((b) => b.includes("Read derive://brandprint/profile first"))).toHaveLength(
+      1,
+    )
+  })
+})

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -3399,6 +3399,54 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/artifacts/{shortId}/rework": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Ask a registered agent to rework this artifact to match the Brandprint. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    shortId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @description Which agent to ask; omit to use the sole registered agent. */
+                        agentId?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description The rework request was posted and landed in the agent's pull inbox. 409 needsAgent when no agent is registered; 409 needsBrandprint when no Brandprint resolves. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @description The request comment's thread id. */
+                            requestId: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/artifacts/{shortId}/comments": {
         parameters: {
             query?: never;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -884,6 +884,11 @@ export const api = {
       headers: { accept: "application/json" },
     }).then(j),
 
+  // Ask a registered agent to rework the artifact to match the Brandprint. The canned
+  // instruction lives server-side; omit agentId when exactly one agent is registered.
+  reworkArtifact: (shortId: string, agentId?: string): Promise<{ requestId: string }> =>
+    f(`/v1/artifacts/${shortId}/rework`, opts(agentId ? { agentId } : {})).then(j),
+
   // ---- Mention directory + in-app notifications -------------------------
   // `artifact` (a short_id) scopes the directory to that thread's people —
   // workspace members + collaborators + everyone who has commented — so you can

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -215,18 +215,23 @@ const u = (path: string) => API_BASE + path
 const f = (path: string, init?: RequestInit) => fetch(u(path), init)
 
 // Thrown error carries the HTTP status so callers can branch (e.g. a 401 on a
-// password artifact means "prompt for the password", not "not found").
+// password artifact means "prompt for the password", not "not found"), plus the
+// server's machine-readable `code` when fail() attached one — branch on that,
+// never on the human-readable message, which is free to be reworded.
 export class ApiError extends Error {
   constructor(
     message: string,
     readonly status: number,
+    readonly code?: string,
   ) {
     super(message)
   }
 }
 const j = async (r: Response) => {
-  if (!r.ok)
-    throw new ApiError((await r.json().catch(() => ({}))).error ?? `HTTP ${r.status}`, r.status)
+  if (!r.ok) {
+    const body = await r.json().catch(() => ({}))
+    throw new ApiError(body.error ?? `HTTP ${r.status}`, r.status, body.code)
+  }
   return r.json()
 }
 const opts = (body?: unknown): RequestInit => ({

--- a/apps/web/src/components/shared/connect-agent.tsx
+++ b/apps/web/src/components/shared/connect-agent.tsx
@@ -15,9 +15,8 @@ import { Switch } from "@/components/ui/switch"
 
 // The one Connect-an-agent surface: the paste-into-your-agent prompt (hosted, with a
 // self-host toggle), shared by onboarding Step 2, the library's connect empty state,
-// and the Brandprint page's saved-but-inert nudge — extracted from welcome.tsx so
-// every entry point renders the same thing. Rework's no-agent state (Phase 2) lands
-// here too.
+// the Brandprint page's saved-but-inert nudge, and the Rework ⋯ item's no-agent
+// state — extracted from welcome.tsx so every entry point renders the same thing.
 
 // The public origin to hand an agent. A deployed Derive instance's own origin IS its
 // public URL, so that's what we embed — except in local dev (localhost), where we
@@ -122,17 +121,28 @@ export function ConnectAgentButton({
           {children ?? "Connect an agent"}
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>Connect an agent</DialogTitle>
-          <DialogDescription>
-            One paste connects any MCP agent to Derive — it can then publish, review, and revise for
-            you.
-          </DialogDescription>
-        </DialogHeader>
-        <ConnectAgent testidPrefix={`${testId}-dialog`} />
-      </DialogContent>
+      <ConnectAgentDialogContent testidPrefix={`${testId}-dialog`} />
     </Dialog>
+  )
+}
+
+/**
+ * The dialog body every Connect-an-agent opening shares — one home for the header
+ * copy, so the button-triggered and externally-controlled (Rework ⋯ menu) dialogs
+ * can't drift apart. Render inside a `Dialog`.
+ */
+export function ConnectAgentDialogContent({ testidPrefix }: { testidPrefix: string }) {
+  return (
+    <DialogContent className="sm:max-w-lg">
+      <DialogHeader>
+        <DialogTitle>Connect an agent</DialogTitle>
+        <DialogDescription>
+          One paste connects any MCP agent to Derive — it can then publish, review, and revise for
+          you.
+        </DialogDescription>
+      </DialogHeader>
+      <ConnectAgent testidPrefix={testidPrefix} />
+    </DialogContent>
   )
 }
 

--- a/apps/web/src/pages/artifact/artifact-top-bar.tsx
+++ b/apps/web/src/pages/artifact/artifact-top-bar.tsx
@@ -15,6 +15,7 @@ import {
 import { useCursorPref } from "@/ctx"
 import { cn } from "@/lib/utils"
 import { MoveToWorkspaceDialog, ReportDialog, StarButton } from "./header-actions"
+import { ReworkConnectDialog, ReworkMenuItem } from "./rework-menu-item"
 import { ShareButton } from "./share-dialog"
 
 /**
@@ -79,6 +80,7 @@ export function ArtifactTopBar(props: {
   const [tagsOpen, setTagsOpen] = useState(false)
   const [collectionsOpen, setCollectionsOpen] = useState(false)
   const [moveOpen, setMoveOpen] = useState(false)
+  const [reworkConnectOpen, setReworkConnectOpen] = useState(false)
   return (
     <>
       {/* Actions cluster — the filled Share leads (the one primary), then the favorited
@@ -156,6 +158,10 @@ export function ArtifactTopBar(props: {
                 </span>
               )}
             </DropdownMenuItem>
+
+            {/* Apply the Brandprint — the ask-agent handoff scoped to the whole artifact. */}
+            <DropdownMenuSeparator />
+            <ReworkMenuItem shortId={shortId} onConnect={() => setReworkConnectOpen(true)} />
 
             {/* Activity. */}
             <DropdownMenuSeparator />
@@ -243,6 +249,7 @@ export function ArtifactTopBar(props: {
         open={moveOpen}
         onOpenChange={setMoveOpen}
       />
+      <ReworkConnectDialog open={reworkConnectOpen} onOpenChange={setReworkConnectOpen} />
     </>
   )
 }

--- a/apps/web/src/pages/artifact/artifact-top-bar.tsx
+++ b/apps/web/src/pages/artifact/artifact-top-bar.tsx
@@ -159,8 +159,9 @@ export function ArtifactTopBar(props: {
               )}
             </DropdownMenuItem>
 
-            {/* Apply the Brandprint — the ask-agent handoff scoped to the whole artifact. */}
-            <DropdownMenuSeparator />
+            {/* Apply the Brandprint — the ask-agent handoff scoped to the whole artifact.
+                The item brings its own leading separator, so both vanish together when it
+                renders nothing (anonymous viewer, pending or failed reads). */}
             <ReworkMenuItem shortId={shortId} onConnect={() => setReworkConnectOpen(true)} />
 
             {/* Activity. */}

--- a/apps/web/src/pages/artifact/ask-agent.tsx
+++ b/apps/web/src/pages/artifact/ask-agent.tsx
@@ -12,6 +12,12 @@ import { getInitials } from "@/lib/initials"
 import { cn } from "@/lib/utils"
 import type { AgentTarget } from "./types"
 
+/** Directory rows an ask-an-agent affordance can actually address: named agents
+ *  only. The directory query already drops nameless rows; the type predicate is what
+ *  narrows `name` to non-null for TS. Shared with the Rework ⋯ item. */
+export const usableAgents = (agents: DirUser[]) =>
+  agents.filter((a): a is DirUser & { name: string } => !!a.name)
+
 // The "ask an agent to revise this selection" affordance, shared by the desktop
 // selection pill and the mobile selection bar. This is Derive's agent-native moat: a
 // human hands a scoped change to a registered agent, whose MCP inbox the request lands
@@ -29,7 +35,7 @@ export function AskAgentButton({
   size?: "default" | "bar"
   className?: string
 }) {
-  const usable = agents.filter((a): a is DirUser & { name: string } => !!a.name)
+  const usable = usableAgents(agents)
   const single = usable.length === 1 ? usable[0] : null
   if (usable.length === 0 || (usable.length === 1 && !single)) return null
 

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -226,179 +226,177 @@ export function MobileComments({
     if (head.anchor) tree.onJump(head.thread_id)
   }
   return (
-    <>
-      <aside
-        ref={sheetRef}
-        className={cn(
-          // The slide rides the `translate` property (translate-y-full/0), so the
-          // transition MUST target `translate` — not `transform` — or the sheet jumps
-          // in and out instead of sliding. Height changes snap (auto isn't
-          // animatable); the drag handlers suspend/restore this transition inline.
-          "fixed inset-x-0 bottom-0 z-61 flex flex-col rounded-t-2xl border-t border-border bg-card shadow-[var(--shadow-pop)] transition-[translate] duration-200 ease-out",
-          // Heights are CONTENT-WEIGHTED: composing is a compact bar above the
-          // keyboard; expanded hugs its comments up to half the screen (the doc
-          // strip above stays visible and live — no reading mode that owns the
-          // whole screen); peek is a slim bar, one line taller with a preview.
-          composer ? "max-h-[80vh]" : size === "full" ? "max-h-[50vh]" : latest ? "h-24" : "h-18.5",
-          open ? "translate-y-0" : "translate-y-full",
-        )}
-        // While the keyboard is up, lift the sheet's bottom to just above it and cap
-        // its height to the visible band — so the half-height composer sits in view
-        // (with a sliver of document above) instead of behind/under the keyboard.
-        style={kb ? { bottom: kb.inset, maxHeight: kb.height } : undefined}
-        // Non-modal by design: the document above stays visible and interactive in
-        // every state, so this is an aside, not a dialog (no focus trap, no scrim).
-        aria-label="Comments"
+    <aside
+      ref={sheetRef}
+      className={cn(
+        // The slide rides the `translate` property (translate-y-full/0), so the
+        // transition MUST target `translate` — not `transform` — or the sheet jumps
+        // in and out instead of sliding. Height changes snap (auto isn't
+        // animatable); the drag handlers suspend/restore this transition inline.
+        "fixed inset-x-0 bottom-0 z-61 flex flex-col rounded-t-2xl border-t border-border bg-card shadow-[var(--shadow-pop)] transition-[translate] duration-200 ease-out",
+        // Heights are CONTENT-WEIGHTED: composing is a compact bar above the
+        // keyboard; expanded hugs its comments up to half the screen (the doc
+        // strip above stays visible and live — no reading mode that owns the
+        // whole screen); peek is a slim bar, one line taller with a preview.
+        composer ? "max-h-[80vh]" : size === "full" ? "max-h-[50vh]" : latest ? "h-24" : "h-18.5",
+        open ? "translate-y-0" : "translate-y-full",
+      )}
+      // While the keyboard is up, lift the sheet's bottom to just above it and cap
+      // its height to the visible band — so the half-height composer sits in view
+      // (with a sliver of document above) instead of behind/under the keyboard.
+      style={kb ? { bottom: kb.inset, maxHeight: kb.height } : undefined}
+      // Non-modal by design: the document above stays visible and interactive in
+      // every state, so this is an aside, not a dialog (no focus trap, no scrim).
+      aria-label="Comments"
+    >
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: the grip/header strip is a drag handle (pointer events) with tap-to-toggle; the real controls inside are buttons. */}
+      <div
+        className="shrink-0 touch-none"
+        onPointerDown={dragStart}
+        onPointerMove={dragMove}
+        onPointerUp={dragEnd}
+        onPointerCancel={dragEnd}
       >
-        {/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: the grip/header strip is a drag handle (pointer events) with tap-to-toggle; the real controls inside are buttons. */}
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: grip toggles the sheet size; keyboard users have the labeled caret button below. */}
         <div
-          className="shrink-0 touch-none"
-          onPointerDown={dragStart}
-          onPointerMove={dragMove}
-          onPointerUp={dragEnd}
-          onPointerCancel={dragEnd}
+          data-testid="comments-sheet-grip"
+          className="flex cursor-grab justify-center pb-1 pt-2"
+          onClick={grip}
+          title="Resize"
         >
-          {/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: grip toggles the sheet size; keyboard users have the labeled caret button below. */}
-          <div
-            data-testid="comments-sheet-grip"
-            className="flex cursor-grab justify-center pb-1 pt-2"
-            onClick={grip}
-            title="Resize"
-          >
-            <div className="h-1 w-10 rounded-full bg-border" />
-          </div>
-          <div className="flex items-center gap-2 border-b border-border-soft pb-3 pl-3 pr-2.5 pt-2">
-            <CommentsHeading count={openThreads.length} />
-            {size === "full" && !composer && openThreads.length > 1 && (
-              // Step through the discussion one thread at a time: the card scrolls
-              // into view and an anchored thread scrolls the doc to its highlight.
-              <div className="flex items-center gap-0.5 font-mono text-xs tabular-nums text-muted-foreground">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  aria-label="Previous comment"
-                  data-testid="comments-step-prev"
-                  onClick={() => stepTo(stepIdx - 1)}
-                >
-                  <Icon name="caret" className="size-4 rotate-90" />
-                </Button>
-                {stepIdx + 1}/{openThreads.length}
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  aria-label="Next comment"
-                  data-testid="comments-step-next"
-                  onClick={() => stepTo(stepIdx + 1)}
-                >
-                  <Icon name="caret" className="size-4 -rotate-90" />
-                </Button>
-              </div>
-            )}
-            {canComment && (
-              <Button
-                variant="outline"
-                size="sm"
-                data-testid="comments-sheet-new"
-                onClick={() => {
-                  setSize("full")
-                  onNewGeneral()
-                }}
-              >
-                <Icon name="plus" size={16} />
-                New
-              </Button>
-            )}
-            <Button
-              variant="ghost"
-              size="icon"
-              aria-label={size === "peek" ? "Expand" : "Collapse"}
-              data-testid="comments-sheet-resize"
-              onClick={() => setSize(size === "peek" ? "full" : "peek")}
-            >
-              <Icon name="caret" className={cn("size-4", size === "peek" && "rotate-180")} />
-            </Button>
-          </div>
+          <div className="h-1 w-10 rounded-full bg-border" />
         </div>
-        {composer ? (
-          // Composing ("half open"): just the composer, so the sheet is a compact bar
-          // pinned above the keyboard with the document visible above. The list
-          // reappears once you send or cancel.
-          <div className="overflow-auto p-3 pb-[max(14px,env(safe-area-inset-bottom))]">
-            <Composer
-              quote={selLabel(composer.anchor)}
-              agent={composer.agent}
-              // After posting, open the full list so the new comment is visible (the
-              // sheet would otherwise drop back to the peek bar and hide it).
-              onSubmit={(text, mentions) => {
-                setSize("full")
-                onSubmitNew(text, mentions)
-              }}
-              onCancel={onCancelNew}
-            />
-          </div>
-        ) : size === "full" ? (
-          <CommentTreeProvider value={sheetTree}>
-            <div className="min-h-0 flex-1 overflow-auto p-3 pb-[max(14px,env(safe-area-inset-bottom))]">
-              {empty && (
-                <EmptyState
-                  className="p-8"
-                  icon={<Icon name="comments" strokeWidth={1.75} />}
-                  title="Start the conversation."
-                  description="Select text in the document, or add a general comment."
-                  action={
-                    canComment ? (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        data-testid="comments-sheet-empty-new"
-                        onClick={() => {
-                          setSize("full")
-                          onNewGeneral()
-                        }}
-                      >
-                        New comment
-                      </Button>
-                    ) : undefined
-                  }
-                />
-              )}
-              {openThreads.map((t) => {
-                const head = t[0]
-                if (!head) return null
-                return (
-                  <div key={head.thread_id} data-thread-id={head.thread_id} className="mb-2.5">
-                    <CommentCard thread={t} />
-                  </div>
-                )
-              })}
-              {resolved.length > 0 && (
-                <CollapsibleThreadSection
-                  label="Resolved"
-                  defaultOpen={false}
-                  testId="resolved-section-toggle"
-                  className="mt-1"
-                  threads={resolved}
-                />
-              )}
+        <div className="flex items-center gap-2 border-b border-border-soft pb-3 pl-3 pr-2.5 pt-2">
+          <CommentsHeading count={openThreads.length} />
+          {size === "full" && !composer && openThreads.length > 1 && (
+            // Step through the discussion one thread at a time: the card scrolls
+            // into view and an anchored thread scrolls the doc to its highlight.
+            <div className="flex items-center gap-0.5 font-mono text-xs tabular-nums text-muted-foreground">
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Previous comment"
+                data-testid="comments-step-prev"
+                onClick={() => stepTo(stepIdx - 1)}
+              >
+                <Icon name="caret" className="size-4 rotate-90" />
+              </Button>
+              {stepIdx + 1}/{openThreads.length}
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Next comment"
+                data-testid="comments-step-next"
+                onClick={() => stepTo(stepIdx + 1)}
+              >
+                <Icon name="caret" className="size-4 -rotate-90" />
+              </Button>
             </div>
-          </CommentTreeProvider>
-        ) : latest ? (
-          // Peek preview: a one-line teaser of the latest comment, so the resting
-          // sheet shows the live discussion. Tapping it expands to the full list.
-          <button
-            type="button"
-            data-testid="comments-peek-preview"
-            onClick={() => setSize("full")}
-            className="flex min-w-0 items-center gap-1.5 px-3 pt-0.5 pb-[max(12px,env(safe-area-inset-bottom))] text-left"
+          )}
+          {canComment && (
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="comments-sheet-new"
+              onClick={() => {
+                setSize("full")
+                onNewGeneral()
+              }}
+            >
+              <Icon name="plus" size={16} />
+              New
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={size === "peek" ? "Expand" : "Collapse"}
+            data-testid="comments-sheet-resize"
+            onClick={() => setSize(size === "peek" ? "full" : "peek")}
           >
-            <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
-              <span className="font-medium text-foreground">{latest.author}</span>{" "}
-              {teaser(latest.body_md)}
-            </span>
-          </button>
-        ) : null}
-      </aside>
-    </>
+            <Icon name="caret" className={cn("size-4", size === "peek" && "rotate-180")} />
+          </Button>
+        </div>
+      </div>
+      {composer ? (
+        // Composing ("half open"): just the composer, so the sheet is a compact bar
+        // pinned above the keyboard with the document visible above. The list
+        // reappears once you send or cancel.
+        <div className="overflow-auto p-3 pb-[max(14px,env(safe-area-inset-bottom))]">
+          <Composer
+            quote={selLabel(composer.anchor)}
+            agent={composer.agent}
+            // After posting, open the full list so the new comment is visible (the
+            // sheet would otherwise drop back to the peek bar and hide it).
+            onSubmit={(text, mentions) => {
+              setSize("full")
+              onSubmitNew(text, mentions)
+            }}
+            onCancel={onCancelNew}
+          />
+        </div>
+      ) : size === "full" ? (
+        <CommentTreeProvider value={sheetTree}>
+          <div className="min-h-0 flex-1 overflow-auto p-3 pb-[max(14px,env(safe-area-inset-bottom))]">
+            {empty && (
+              <EmptyState
+                className="p-8"
+                icon={<Icon name="comments" strokeWidth={1.75} />}
+                title="Start the conversation."
+                description="Select text in the document, or add a general comment."
+                action={
+                  canComment ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      data-testid="comments-sheet-empty-new"
+                      onClick={() => {
+                        setSize("full")
+                        onNewGeneral()
+                      }}
+                    >
+                      New comment
+                    </Button>
+                  ) : undefined
+                }
+              />
+            )}
+            {openThreads.map((t) => {
+              const head = t[0]
+              if (!head) return null
+              return (
+                <div key={head.thread_id} data-thread-id={head.thread_id} className="mb-2.5">
+                  <CommentCard thread={t} />
+                </div>
+              )
+            })}
+            {resolved.length > 0 && (
+              <CollapsibleThreadSection
+                label="Resolved"
+                defaultOpen={false}
+                testId="resolved-section-toggle"
+                className="mt-1"
+                threads={resolved}
+              />
+            )}
+          </div>
+        </CommentTreeProvider>
+      ) : latest ? (
+        // Peek preview: a one-line teaser of the latest comment, so the resting
+        // sheet shows the live discussion. Tapping it expands to the full list.
+        <button
+          type="button"
+          data-testid="comments-peek-preview"
+          onClick={() => setSize("full")}
+          className="flex min-w-0 items-center gap-1.5 px-3 pt-0.5 pb-[max(12px,env(safe-area-inset-bottom))] text-left"
+        >
+          <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">{latest.author}</span>{" "}
+            {teaser(latest.body_md)}
+          </span>
+        </button>
+      ) : null}
+    </aside>
   )
 }
 

--- a/apps/web/src/pages/artifact/rework-menu-item.tsx
+++ b/apps/web/src/pages/artifact/rework-menu-item.tsx
@@ -1,0 +1,132 @@
+import { useQuery } from "@tanstack/react-query"
+import { useNavigate } from "@tanstack/react-router"
+import { api } from "@/api"
+import { Icon } from "@/components/icons"
+import { ConnectAgent } from "@/components/shared/connect-agent"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+} from "@/components/ui/dropdown-menu"
+import { useAuth } from "@/ctx"
+import { artifactAgentsQuery, workspaceSettingsQuery } from "@/lib/queries"
+import { useApiMutation } from "@/lib/use-api-mutation"
+import { reworkState } from "./rework-state"
+import type { AgentTarget } from "./types"
+
+// "Rework with Brandprint" — the ⋯ menu's apply-on-demand entry (Brandprint Phase 3):
+// a canned version of the ask-agent handoff, scoped to the whole artifact. One
+// self-contained component owns the four-state logic (set-up / connect / fire /
+// picker) so the top bar stays lean. The canned instruction lives server-side; this
+// only chooses the agent and fires.
+export function ReworkMenuItem({
+  shortId,
+  onConnect,
+}: {
+  shortId: string
+  /** Open the shared Connect-an-agent dialog (portaled by the top bar — a dialog
+   *  inside DropdownMenuContent would unmount when the menu closes on select). */
+  onConnect: () => void
+}) {
+  const { me } = useAuth()
+  const nav = useNavigate()
+  const { data: settings, isError: settingsError } = useQuery({
+    ...workspaceSettingsQuery(),
+    enabled: !!me,
+  })
+  const { data: agents = [], isError: agentsError } = useQuery({
+    ...artifactAgentsQuery(shortId),
+    enabled: !!me,
+  })
+  const fire = useApiMutation<{ requestId: string }, AgentTarget>({
+    mutationFn: (agent) => api.reworkArtifact(shortId, agent.id),
+    success: (_r, agent) => `Rework request sent to ${agent.name}.`,
+  })
+  // Anonymous viewers can't fire an agent or own a Brandprint — no item at all. Same
+  // for a failed ambient read: rather than guess at a state from partial data, hide
+  // the affordance (the ApplyNudge convention on the Brandprint page itself).
+  if (!me || settingsError || agentsError) return null
+
+  const hasBrandprint = !!settings?.brandprint?.collectionId || !!me.brandprint?.collectionId
+  const usable = agents.filter((a): a is typeof a & { name: string } => !!a.name)
+  const state = reworkState(hasBrandprint, usable.length)
+
+  if (state === "setup")
+    return (
+      <DropdownMenuItem data-testid="rework-setup" onSelect={() => nav({ to: "/brandprint" })}>
+        <Icon name="sparkles" size={16} /> Set up your Brandprint
+      </DropdownMenuItem>
+    )
+  if (state === "connect")
+    return (
+      <DropdownMenuItem data-testid="rework-connect" onSelect={onConnect}>
+        <Icon name="sparkles" size={16} /> Rework with Brandprint
+      </DropdownMenuItem>
+    )
+  if (state === "fire") {
+    const sole = usable[0]
+    // reworkState guarantees exactly one usable agent in this branch; the guard is
+    // just to satisfy noUncheckedIndexedAccess, not a real runtime path.
+    if (!sole) return null
+    return (
+      <DropdownMenuItem
+        data-testid="rework-fire"
+        disabled={fire.isPending}
+        onSelect={() => fire.mutate({ id: sole.id, name: sole.name })}
+      >
+        <Icon name="sparkles" size={16} /> Rework with Brandprint
+      </DropdownMenuItem>
+    )
+  }
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger data-testid="rework-pick">
+        <Icon name="sparkles" size={16} /> Rework with Brandprint
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent>
+        {usable.map((a) => (
+          <DropdownMenuItem
+            key={a.id}
+            data-testid={`rework-pick-${a.id}`}
+            onSelect={() => fire.mutate({ id: a.id, name: a.name })}
+          >
+            {a.name}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  )
+}
+
+// The shared Connect-an-agent surface, dialog-wrapped — Rework's no-agent state is
+// its fifth entry point (see docs/plans/brandprint.md, "one shared surface").
+export function ReworkConnectDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Connect an agent</DialogTitle>
+          <DialogDescription>
+            One paste connects any MCP agent to Derive — it can then publish, review, and revise for
+            you.
+          </DialogDescription>
+        </DialogHeader>
+        <ConnectAgent testidPrefix="rework-connect" />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/pages/artifact/rework-menu-item.tsx
+++ b/apps/web/src/pages/artifact/rework-menu-item.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dialog"
 import {
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -38,45 +39,58 @@ export function ReworkMenuItem({
 }) {
   const { me } = useAuth()
   const nav = useNavigate()
-  const { data: settings, isError: settingsError } = useQuery({
-    ...workspaceSettingsQuery(),
-    enabled: !!me,
-  })
-  const { data: agents = [], isError: agentsError } = useQuery({
-    ...artifactAgentsQuery(shortId),
-    enabled: !!me,
-  })
+  const {
+    data: settings,
+    isPending: settingsPending,
+    isError: settingsError,
+  } = useQuery({ ...workspaceSettingsQuery(), enabled: !!me })
+  const {
+    data: agents = [],
+    isPending: agentsPending,
+    isError: agentsError,
+  } = useQuery({ ...artifactAgentsQuery(shortId), enabled: !!me })
   const fire = useApiMutation<{ requestId: string }, AgentTarget>({
     mutationFn: (agent) => api.reworkArtifact(shortId, agent.id),
     success: (_r, agent) => `Rework request sent to ${agent.name}.`,
   })
-  // Anonymous viewers can't fire an agent or own a Brandprint — no item at all. Same
-  // for a failed ambient read: rather than guess at a state from partial data, hide
-  // the affordance (the ApplyNudge convention on the Brandprint page itself).
-  if (!me || settingsError || agentsError) return null
+  // Anonymous viewers can't fire an agent or own a Brandprint — no item at all. This
+  // check must stay FIRST: the queries are gated on `me`, and a disabled query reports
+  // pending forever, so the pending guard below would otherwise hide the item for good.
+  if (!me) return null
+  // While either read is in flight the state is unknowable — computing it off
+  // undefined data would flash "Set up your Brandprint" at a member whose workspace
+  // Brandprint just hasn't loaded (and a fast click would misroute to /brandprint).
+  // Render nothing until the data settles; the item then appears in its true state.
+  if (settingsPending || agentsPending) return null
+  // A failed ambient read: rather than guess at a state from partial data, hide the
+  // affordance (the ApplyNudge convention on the Brandprint page itself).
+  if (settingsError || agentsError) return null
 
   const hasBrandprint = !!settings?.brandprint?.collectionId || !!me.brandprint?.collectionId
+  // artifactAgentsQuery already drops nameless agents; this re-asserts it with a type
+  // predicate because a plain filter doesn't narrow `name` to non-null for TS.
   const usable = agents.filter((a): a is typeof a & { name: string } => !!a.name)
   const state = reworkState(hasBrandprint, usable.length)
 
+  let item: React.ReactNode
   if (state === "setup")
-    return (
+    item = (
       <DropdownMenuItem data-testid="rework-setup" onSelect={() => nav({ to: "/brandprint" })}>
         <Icon name="sparkles" size={16} /> Set up your Brandprint
       </DropdownMenuItem>
     )
-  if (state === "connect")
-    return (
+  else if (state === "connect")
+    item = (
       <DropdownMenuItem data-testid="rework-connect" onSelect={onConnect}>
         <Icon name="sparkles" size={16} /> Rework with Brandprint
       </DropdownMenuItem>
     )
-  if (state === "fire") {
+  else if (state === "fire") {
     const sole = usable[0]
     // reworkState guarantees exactly one usable agent in this branch; the guard is
     // just to satisfy noUncheckedIndexedAccess, not a real runtime path.
     if (!sole) return null
-    return (
+    item = (
       <DropdownMenuItem
         data-testid="rework-fire"
         disabled={fire.isPending}
@@ -85,24 +99,34 @@ export function ReworkMenuItem({
         <Icon name="sparkles" size={16} /> Rework with Brandprint
       </DropdownMenuItem>
     )
-  }
+  } else
+    item = (
+      <DropdownMenuSub>
+        <DropdownMenuSubTrigger data-testid="rework-pick" disabled={fire.isPending}>
+          <Icon name="sparkles" size={16} /> Rework with Brandprint
+        </DropdownMenuSubTrigger>
+        <DropdownMenuSubContent>
+          {usable.map((a) => (
+            <DropdownMenuItem
+              key={a.id}
+              data-testid={`rework-pick-${a.id}`}
+              disabled={fire.isPending}
+              onSelect={() => fire.mutate({ id: a.id, name: a.name })}
+            >
+              {a.name}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuSubContent>
+      </DropdownMenuSub>
+    )
+
+  // The leading separator rides WITH the item, so when every guard above bails the
+  // menu doesn't keep an orphaned rule next to the Activity group's own separator.
   return (
-    <DropdownMenuSub>
-      <DropdownMenuSubTrigger data-testid="rework-pick">
-        <Icon name="sparkles" size={16} /> Rework with Brandprint
-      </DropdownMenuSubTrigger>
-      <DropdownMenuSubContent>
-        {usable.map((a) => (
-          <DropdownMenuItem
-            key={a.id}
-            data-testid={`rework-pick-${a.id}`}
-            onSelect={() => fire.mutate({ id: a.id, name: a.name })}
-          >
-            {a.name}
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuSubContent>
-    </DropdownMenuSub>
+    <>
+      <DropdownMenuSeparator />
+      {item}
+    </>
   )
 }
 

--- a/apps/web/src/pages/artifact/rework-menu-item.tsx
+++ b/apps/web/src/pages/artifact/rework-menu-item.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
 } from "@/components/ui/dropdown-menu"
+import { toast } from "@/components/ui/sonner"
 import { useAuth } from "@/ctx"
 import { artifactAgentsQuery, workspaceSettingsQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
@@ -39,6 +40,12 @@ export function ReworkMenuItem({
 }) {
   const { me } = useAuth()
   const nav = useNavigate()
+  // workspaceSettingsQuery reads the VIEWER'S ACTIVE workspace, not necessarily the
+  // artifact's — a share recipient or a multi-workspace member looking at another
+  // workspace's artifact can see a stale/wrong approximation here. That's fine: the
+  // server resolves the real workspace and 409s (needsAgent/needsBrandprint) when this
+  // client-side guess disagrees, and the fire mutation's onError below routes those
+  // 409s back to the correct state instead of surfacing the raw mismatch.
   const {
     data: settings,
     isPending: settingsPending,
@@ -52,6 +59,17 @@ export function ReworkMenuItem({
   const fire = useApiMutation<{ requestId: string }, AgentTarget>({
     mutationFn: (agent) => api.reworkArtifact(shortId, agent.id),
     success: (_r, agent) => `Rework request sent to ${agent.name}.`,
+    // The state computed below is a client-side approximation (see the comment on
+    // workspaceSettingsQuery above) — a stale cache can 409 with a raw machine token
+    // ("needsAgent"/"needsBrandprint") the server never meant for display. Opt out of
+    // the global toast and route to the state the client SHOULD have shown instead of
+    // flashing the token at the user.
+    errorToast: false,
+    onError: (err) => {
+      if (err.message === "needsAgent") onConnect()
+      else if (err.message === "needsBrandprint") nav({ to: "/brandprint" })
+      else toast.error("Rework request failed — try again.")
+    },
   })
   // Anonymous viewers can't fire an agent or own a Brandprint — no item at all. This
   // check must stay FIRST: the queries are gated on `me`, and a disabled query reports
@@ -66,7 +84,13 @@ export function ReworkMenuItem({
   // affordance (the ApplyNudge convention on the Brandprint page itself).
   if (settingsError || agentsError) return null
 
-  const hasBrandprint = !!settings?.brandprint?.collectionId || !!me.brandprint?.collectionId
+  // A workspace Brandprint of just { profileId } (no conventions collection, only the
+  // generated brand profile) still counts — both fields are nullish/optional in the
+  // schema, so collectionId alone would wrongly read as "not set up".
+  const hasBrandprint =
+    !!settings?.brandprint?.collectionId ||
+    !!settings?.brandprint?.profileId ||
+    !!me.brandprint?.collectionId
   // artifactAgentsQuery already drops nameless agents; this re-asserts it with a type
   // predicate because a plain filter doesn't narrow `name` to non-null for TS.
   const usable = agents.filter((a): a is typeof a & { name: string } => !!a.name)

--- a/apps/web/src/pages/artifact/rework-menu-item.tsx
+++ b/apps/web/src/pages/artifact/rework-menu-item.tsx
@@ -1,15 +1,9 @@
 import { useQuery } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
-import { api } from "@/api"
+import { ApiError, api } from "@/api"
 import { Icon } from "@/components/icons"
-import { ConnectAgent } from "@/components/shared/connect-agent"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
+import { ConnectAgentDialogContent } from "@/components/shared/connect-agent"
+import { Dialog } from "@/components/ui/dialog"
 import {
   DropdownMenuItem,
   DropdownMenuSeparator,
@@ -21,14 +15,15 @@ import { toast } from "@/components/ui/sonner"
 import { useAuth } from "@/ctx"
 import { artifactAgentsQuery, workspaceSettingsQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
-import { reworkState } from "./rework-state"
+import { usableAgents } from "./ask-agent"
+import { resolveRework } from "./rework-state"
 import type { AgentTarget } from "./types"
 
-// "Rework with Brandprint" — the ⋯ menu's apply-on-demand entry (Brandprint Phase 3):
-// a canned version of the ask-agent handoff, scoped to the whole artifact. One
-// self-contained component owns the four-state logic (set-up / connect / fire /
-// picker) so the top bar stays lean. The canned instruction lives server-side; this
-// only chooses the agent and fires.
+// "Rework with Brandprint" — the ⋯ menu's apply-on-demand entry: a canned version of
+// the ask-agent handoff, scoped to the whole artifact. One self-contained component
+// owns the four-state logic (set-up / connect / fire / picker) so the top bar stays
+// lean. The canned instruction lives server-side; this only chooses the agent and
+// fires.
 export function ReworkMenuItem({
   shortId,
   onConnect,
@@ -60,14 +55,13 @@ export function ReworkMenuItem({
     mutationFn: (agent) => api.reworkArtifact(shortId, agent.id),
     success: (_r, agent) => `Rework request sent to ${agent.name}.`,
     // The state computed below is a client-side approximation (see the comment on
-    // workspaceSettingsQuery above) — a stale cache can 409 with a raw machine token
-    // ("needsAgent"/"needsBrandprint") the server never meant for display. Opt out of
-    // the global toast and route to the state the client SHOULD have shown instead of
-    // flashing the token at the user.
+    // workspaceSettingsQuery above), so a stale cache can draw a 409. Instead of
+    // toasting that, route to the state the client should have shown.
     errorToast: false,
     onError: (err) => {
-      if (err.message === "needsAgent") onConnect()
-      else if (err.message === "needsBrandprint") nav({ to: "/brandprint" })
+      const code = err instanceof ApiError ? err.code : undefined
+      if (code === "needsAgent") onConnect()
+      else if (code === "needsBrandprint") nav({ to: "/brandprint" })
       else toast.error("Rework request failed — try again.")
     },
   })
@@ -91,46 +85,39 @@ export function ReworkMenuItem({
     !!settings?.brandprint?.collectionId ||
     !!settings?.brandprint?.profileId ||
     !!me.brandprint?.collectionId
-  // artifactAgentsQuery already drops nameless agents; this re-asserts it with a type
-  // predicate because a plain filter doesn't narrow `name` to non-null for TS.
-  const usable = agents.filter((a): a is typeof a & { name: string } => !!a.name)
-  const state = reworkState(hasBrandprint, usable.length)
+  const rework = resolveRework(hasBrandprint, usableAgents(agents))
 
   let item: React.ReactNode
-  if (state === "setup")
+  if (rework.state === "setup")
     item = (
       <DropdownMenuItem data-testid="rework-setup" onSelect={() => nav({ to: "/brandprint" })}>
         <Icon name="sparkles" size={16} /> Set up your Brandprint
       </DropdownMenuItem>
     )
-  else if (state === "connect")
+  else if (rework.state === "connect")
     item = (
       <DropdownMenuItem data-testid="rework-connect" onSelect={onConnect}>
         <Icon name="sparkles" size={16} /> Rework with Brandprint
       </DropdownMenuItem>
     )
-  else if (state === "fire") {
-    const sole = usable[0]
-    // reworkState guarantees exactly one usable agent in this branch; the guard is
-    // just to satisfy noUncheckedIndexedAccess, not a real runtime path.
-    if (!sole) return null
+  else if (rework.state === "fire")
     item = (
       <DropdownMenuItem
         data-testid="rework-fire"
         disabled={fire.isPending}
-        onSelect={() => fire.mutate({ id: sole.id, name: sole.name })}
+        onSelect={() => fire.mutate({ id: rework.agent.id, name: rework.agent.name })}
       >
         <Icon name="sparkles" size={16} /> Rework with Brandprint
       </DropdownMenuItem>
     )
-  } else
+  else
     item = (
       <DropdownMenuSub>
         <DropdownMenuSubTrigger data-testid="rework-pick" disabled={fire.isPending}>
           <Icon name="sparkles" size={16} /> Rework with Brandprint
         </DropdownMenuSubTrigger>
         <DropdownMenuSubContent>
-          {usable.map((a) => (
+          {rework.agents.map((a) => (
             <DropdownMenuItem
               key={a.id}
               data-testid={`rework-pick-${a.id}`}
@@ -155,7 +142,7 @@ export function ReworkMenuItem({
 }
 
 // The shared Connect-an-agent surface, dialog-wrapped — Rework's no-agent state is
-// its fifth entry point (see docs/plans/brandprint.md, "one shared surface").
+// one of its entry points (see docs/plans/brandprint.md, "one shared surface").
 export function ReworkConnectDialog({
   open,
   onOpenChange,
@@ -165,16 +152,7 @@ export function ReworkConnectDialog({
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>Connect an agent</DialogTitle>
-          <DialogDescription>
-            One paste connects any MCP agent to Derive — it can then publish, review, and revise for
-            you.
-          </DialogDescription>
-        </DialogHeader>
-        <ConnectAgent testidPrefix="rework-connect" />
-      </DialogContent>
+      <ConnectAgentDialogContent testidPrefix="rework-connect" />
     </Dialog>
   )
 }

--- a/apps/web/src/pages/artifact/rework-state.test.ts
+++ b/apps/web/src/pages/artifact/rework-state.test.ts
@@ -1,19 +1,22 @@
 import { describe, expect, it } from "vitest"
-import { reworkState } from "./rework-state"
+import { resolveRework } from "./rework-state"
 
-// The Rework ⋯ item's four states (spec: set-up / connect / fire / picker).
-describe("reworkState", () => {
+// The Rework ⋯ item's four states (set-up / connect / fire / picker).
+describe("resolveRework", () => {
+  const a = { id: "ag_1", name: "Reviser" }
+  const b = { id: "ag_2", name: "Stylist" }
+
   it("routes to setup when no Brandprint exists, regardless of agents", () => {
-    expect(reworkState(false, 0)).toBe("setup")
-    expect(reworkState(false, 3)).toBe("setup")
+    expect(resolveRework(false, [])).toEqual({ state: "setup" })
+    expect(resolveRework(false, [a, b])).toEqual({ state: "setup" })
   })
 
   it("routes to connect when a Brandprint exists but no agent is registered", () => {
-    expect(reworkState(true, 0)).toBe("connect")
+    expect(resolveRework(true, [])).toEqual({ state: "connect" })
   })
 
-  it("fires with a sole agent; picks among several", () => {
-    expect(reworkState(true, 1)).toBe("fire")
-    expect(reworkState(true, 2)).toBe("picker")
+  it("fires with a sole agent, carrying it; picks among several", () => {
+    expect(resolveRework(true, [a])).toEqual({ state: "fire", agent: a })
+    expect(resolveRework(true, [a, b])).toEqual({ state: "picker", agents: [a, b] })
   })
 })

--- a/apps/web/src/pages/artifact/rework-state.test.ts
+++ b/apps/web/src/pages/artifact/rework-state.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+import { reworkState } from "./rework-state"
+
+// The Rework ⋯ item's four states (spec: set-up / connect / fire / picker).
+describe("reworkState", () => {
+  it("routes to setup when no Brandprint exists, regardless of agents", () => {
+    expect(reworkState(false, 0)).toBe("setup")
+    expect(reworkState(false, 3)).toBe("setup")
+  })
+
+  it("routes to connect when a Brandprint exists but no agent is registered", () => {
+    expect(reworkState(true, 0)).toBe("connect")
+  })
+
+  it("fires with a sole agent; picks among several", () => {
+    expect(reworkState(true, 1)).toBe("fire")
+    expect(reworkState(true, 2)).toBe("picker")
+  })
+})

--- a/apps/web/src/pages/artifact/rework-state.ts
+++ b/apps/web/src/pages/artifact/rework-state.ts
@@ -1,0 +1,14 @@
+// The Rework ⋯ item's four states, resolved from what the signed-in viewer can see
+// (workspace settings + their profile + the artifact's addressable agents). Pure so
+// the mapping is unit-tested; the component supplies the live query data.
+//  - setup:   no Brandprint anywhere — the item routes to /brandprint instead of firing
+//  - connect: a Brandprint but no agent — the item opens the Connect-an-agent surface
+//  - fire:    exactly one agent — fire immediately
+//  - picker:  several agents — open a picker
+export type ReworkState = "setup" | "connect" | "fire" | "picker"
+
+export const reworkState = (hasBrandprint: boolean, agentCount: number): ReworkState => {
+  if (!hasBrandprint) return "setup"
+  if (agentCount === 0) return "connect"
+  return agentCount === 1 ? "fire" : "picker"
+}

--- a/apps/web/src/pages/artifact/rework-state.ts
+++ b/apps/web/src/pages/artifact/rework-state.ts
@@ -7,7 +7,7 @@
 //  - connect: a Brandprint but no agent — the item opens the Connect-an-agent surface
 //  - fire:    exactly one agent — fire immediately
 //  - picker:  several agents — open a picker
-export type ReworkResolution<A> =
+type ReworkResolution<A> =
   | { state: "setup" }
   | { state: "connect" }
   | { state: "fire"; agent: A }

--- a/apps/web/src/pages/artifact/rework-state.ts
+++ b/apps/web/src/pages/artifact/rework-state.ts
@@ -1,14 +1,21 @@
 // The Rework ⋯ item's four states, resolved from what the signed-in viewer can see
 // (workspace settings + their profile + the artifact's addressable agents). Pure so
-// the mapping is unit-tested; the component supplies the live query data.
+// the mapping is unit-tested; the component supplies the live query data. The fire
+// state carries its agent (and picker its list) so consumers never re-index the
+// array a state was derived from.
 //  - setup:   no Brandprint anywhere — the item routes to /brandprint instead of firing
 //  - connect: a Brandprint but no agent — the item opens the Connect-an-agent surface
 //  - fire:    exactly one agent — fire immediately
 //  - picker:  several agents — open a picker
-export type ReworkState = "setup" | "connect" | "fire" | "picker"
+export type ReworkResolution<A> =
+  | { state: "setup" }
+  | { state: "connect" }
+  | { state: "fire"; agent: A }
+  | { state: "picker"; agents: A[] }
 
-export const reworkState = (hasBrandprint: boolean, agentCount: number): ReworkState => {
-  if (!hasBrandprint) return "setup"
-  if (agentCount === 0) return "connect"
-  return agentCount === 1 ? "fire" : "picker"
+export const resolveRework = <A>(hasBrandprint: boolean, agents: A[]): ReworkResolution<A> => {
+  if (!hasBrandprint) return { state: "setup" }
+  const [sole, ...rest] = agents
+  if (!sole) return { state: "connect" }
+  return rest.length === 0 ? { state: "fire", agent: sole } : { state: "picker", agents }
 }

--- a/docs/plans/brandprint.md
+++ b/docs/plans/brandprint.md
@@ -1,6 +1,6 @@
 # Brandprint
 
-Status: living spec. Phases 0 and 1 have shipped end to end. Phase 2, the brand profile (our take on tasteprofile.io), is built and in review (#392); Rework (Phase 3) is the next build.
+Status: living spec. Phases 0–2 have shipped end to end (#392 merged the brand profile). Phase 3, Rework, is built (this PR); Phase 4 remains directional.
 Owner: Connor
 Related prior art: `feat/house-style` (Anir, unmerged; ported forward as Phase 0)
 
@@ -18,8 +18,8 @@ Every team gets a **Brandprint**: their voice, style, and rules captured once, d
 | Phase 1: docs managed on `/brandprint` only (collection hidden from Collections) + team-scope dialog copy | Shipped (#386) |
 | Phase 1: shared Connect-an-agent surface | Shipped (#388) |
 | Phase 1: onboarding step + owner home nudge | Shipped (#388) |
-| Phase 2: the brand profile (agent-generated, tasteprofile take) | Built, in review (#392) |
-| Phase 3: Rework button + endpoint + no-agent routing | **Next up** |
+| Phase 2: the brand profile (agent-generated, tasteprofile take) | Shipped (#392) |
+| Phase 3: Rework button + endpoint + no-agent routing | Built (this PR) |
 | Phase 4: enrichment, visual theming from profile tokens, "Always review Reworks" | Later |
 
 Sections below marked **(shipped)** describe behavior now on main; sections marked **(built, in review #392)** are built and awaiting merge. Everything else is still spec, and it is what we build next.
@@ -272,11 +272,11 @@ Shipped (#378):
 
 - `PATCH /v1/workspace/settings` accepts `brandprint: { collectionId?, theme? } | null` (deep merge one level, null clears; collection ownership validated).
 - `POST /v1/me/profile` accepts `brandprint: { ... } | null` alongside `profession` and `about` (membership validated).
+- `POST /v1/artifacts/:shortId/rework` (Phase 3): composes the canned @mention request server-side and posts it to the chosen or sole registered agent's inbox; `409 needsAgent` / `409 needsBrandprint`.
 
 Not built, still specced:
 
 - Phase 2 (brand profile) adds **no endpoints**, held in #392: the placeholder rides the existing publish path, `profileId` rides the existing settings/profile PATCH routes (with the same tenancy validation), and approval is the existing proposals route. The reference resources are MCP-only.
-- `POST /v1/artifacts/:shortId/rework` (Phase 3): compose and post the canned @mention request to a chosen or sole registered agent; `409 needsAgent` when none.
 - `POST /v1/brandprint/seed`: superseded by the shipped client-side composition. The onboarding step (#388) shipped without it, settling the open question (Decisions log #6); dead unless a future caller needs a single atomic round-trip.
 
 Any new endpoint is defined in the contract-first Zod spec (#331), so the web client is regenerated rather than hand-written.
@@ -321,7 +321,7 @@ To write with the remaining phases:
 - **Phase 0 (foundation): shipped** (#378). Anir's Phase A ported forward, renamed, with the cross-tenant ownership validation added in review.
 - **Phase 1 (capture): shipped** (#383, #384, #386, #388). The create dialog on the `/brandprint` page, the docs' one home, the shared ConnectAgent surface, onboarding Step 3, and both nudges. No seed endpoint, settled.
 - **Phase 2 (the brand profile): built, in review** (#392). The hand-off flow, the placeholder-proposal mechanics, the two reference resources, the page states, profile-first delivery, and the `BrandprintTheme` removal.
-- **Phase 3 (apply): next up.** The Rework ⋯ item (gated on a Brandprint existing), the rework endpoint, and the no-agent routing.
+- **Phase 3 (apply): built (this PR).** The Rework ⋯ item (gated on a Brandprint existing), the rework endpoint, and the no-agent routing.
 - **Phase 4 (later, optional):** agent enrichment of the Brandprint doc, visual theme application fed by the profile's embedded tokens, and an "Always review Reworks" setting.
 
 ## Decisions log

--- a/docs/plans/brandprint.md
+++ b/docs/plans/brandprint.md
@@ -273,9 +273,12 @@ Shipped (#378):
 
 - `PATCH /v1/workspace/settings` accepts `brandprint: { collectionId?, theme? } | null` (deep merge one level, null clears; collection ownership validated).
 - `POST /v1/me/profile` accepts `brandprint: { ... } | null` alongside `profession` and `about` (membership validated).
-- `POST /v1/artifacts/:shortId/rework` (Phase 3): composes the canned @mention request server-side and posts it to the chosen or sole registered agent's inbox; `409 needsAgent` / `409 needsBrandprint`.
 
-Not built, still specced:
+Shipped (this PR, Phase 3):
+
+- `POST /v1/artifacts/:shortId/rework`: composes the canned @mention request server-side and posts it to the chosen or sole registered agent's inbox; `409 needsAgent` / `409 needsBrandprint`.
+
+Not built — by design or superseded:
 
 - Phase 2 (brand profile) added **no endpoints**, by design (#392): the placeholder rides the existing publish path, `profileId` rides the existing settings/profile PATCH routes (with the same tenancy validation), and approval is the existing proposals route. The reference resources are MCP-only.
 - `POST /v1/brandprint/seed`: superseded by the shipped client-side composition. The onboarding step (#388) shipped without it, settling the open question (Decisions log #6); dead unless a future caller needs a single atomic round-trip.

--- a/docs/plans/brandprint.md
+++ b/docs/plans/brandprint.md
@@ -22,7 +22,7 @@ Every team gets a **Brandprint**: their voice, style, and rules captured once, d
 | Phase 3: Rework button + endpoint + no-agent routing | Built (this PR) |
 | Phase 4: enrichment, visual theming from profile tokens, "Always review Reworks" | Later |
 
-Sections below marked **(shipped)** describe behavior now on main; sections marked **(built, in review #392)** are built and awaiting merge. Everything else is still spec, and it is what we build next.
+Sections below marked **(shipped)** describe behavior now on main; the Rework section (Phase 3) is built on this PR and lands when it merges. Only Phase 4 is still spec.
 
 ## Why this exists
 
@@ -68,11 +68,11 @@ The user-facing name is **Brandprint**. Anir's branch called it "House Style" in
 
 ## Architecture overview
 
-Three layers; capture and delivery have shipped, the generated profile (Phase 2) and on-demand apply (Phase 3) are next.
+Three layers; capture, delivery, and the generated profile (Phase 2, #392) have shipped; on-demand apply (Phase 3, Rework) is built on this PR.
 
 ```
-Capture (shipped)         Deliver (shipped)             Apply
------------------         -----------------             -----
+Capture (shipped)         Deliver (shipped)             Apply (built)
+-----------------         -----------------             -------------
 create dialog ->  Brandprint pointer (collection)  ->  default (shipped): agent reads
 (upload look/read,   + brand profile (Phase 2):          derive://brandprint/* before
  write, or pick)     their agent reads sources +         authoring (auto)
@@ -140,7 +140,7 @@ This is the default, automatic path. A connected agent reads the Brandprint on i
 
 Built once, reused everywhere the feature would otherwise dead-end. `components/shared/connect-agent.tsx` holds the paste-into-your-agent block extracted from `welcome.tsx` Step 2 (hosted prompt, self-host toggle, copy button), plus a one-line `ConnectAgentButton` that opens it in a dialog from anywhere. Welcome's e2e testids were preserved via a prefix parameter.
 
-Four entry points render the same surface: onboarding Step 2, the library's "Connect an agent" empty state (which previously dead-ended on the workspace-bot token form in Settings → Agents, the known IA gap, now fixed), the owner home nudge (below), and the `/brandprint` saved-but-inert band. The profile hand-off card (Phase 2) and the Rework menu item (Phase 3) become the fifth and sixth.
+Four entry points render the same surface: onboarding Step 2, the library's "Connect an agent" empty state (which previously dead-ended on the workspace-bot token form in Settings → Agents, the known IA gap, now fixed), the owner home nudge (below), and the `/brandprint` saved-but-inert band. The profile hand-off card (Phase 2) and the Rework menu item (Phase 3) became the fifth and sixth.
 
 The honest framing shown to the user: Brandprint is captured and saved immediately, but it has nobody to *apply* it until an agent is connected. When a Brandprint exists but the caller has never authorized an MCP agent, the `/brandprint` page says so plainly, with the Connect surface one tap away. The signal is the OAuth connected-agents list, a query now shared with Security's revocation section rather than duplicated there.
 
@@ -156,9 +156,9 @@ Step 3 in `apps/web/src/pages/welcome.tsx`, after Step 2 (Connect an agent), ful
 
 ---
 
-Everything below this line is **not yet on main**. The brand profile is built and awaiting merge (#392); the rest is the roadmap, in build order.
+Below this line are the later phases: the brand profile, shipped (#392); Rework (Phase 3), built on this PR; and Phase 4, still directional roadmap.
 
-## The brand profile (built, in review #392)
+## The brand profile (shipped, #392)
 
 Our take on tasteprofile.io ("Brand guides are PDFs. AI tools need data."): every Brandprint culminates in one generated, beautiful, machine-readable HTML page, the **brand profile**, assembled by the user's own agent. Derive ships reference material and plumbing only; it never runs inference and never owns an agent.
 
@@ -224,7 +224,7 @@ Brand is a team property; the profile treatment is workspace-only. Personal Bran
 - **API**: placeholder creation in the intake path; `profileId` tenancy validation; the MCP serving matrix (no profile / pending / approved) asserting resource sets and instructions copy for both states.
 - **Web**: the five page states, testid'd like the rest of Brandprint; e2e remains the standing follow-up.
 
-## Apply on demand: the Rework button (Phase 3)
+## Apply on demand: the Rework button (Phase 3, built on this PR)
 
 New surface, existing plumbing. Rework is a canned version of the ask-agent handoff, scoped to the whole artifact.
 
@@ -257,7 +257,8 @@ Endpoint (thin wrapper over the existing @mention-to-inbox path, so the canned p
 ```
 POST /v1/artifacts/:shortId/rework
 body: { agentId?: string }   // omit to use the sole registered agent
--> { requestId }             // 409 needsAgent when the workspace has none
+-> { requestId }             // 409 needsAgent when the workspace has none;
+                             // 409 needsBrandprint guards an empty brief
 ```
 
 ### Output
@@ -276,7 +277,7 @@ Shipped (#378):
 
 Not built, still specced:
 
-- Phase 2 (brand profile) adds **no endpoints**, held in #392: the placeholder rides the existing publish path, `profileId` rides the existing settings/profile PATCH routes (with the same tenancy validation), and approval is the existing proposals route. The reference resources are MCP-only.
+- Phase 2 (brand profile) added **no endpoints**, by design (#392): the placeholder rides the existing publish path, `profileId` rides the existing settings/profile PATCH routes (with the same tenancy validation), and approval is the existing proposals route. The reference resources are MCP-only.
 - `POST /v1/brandprint/seed`: superseded by the shipped client-side composition. The onboarding step (#388) shipped without it, settling the open question (Decisions log #6); dead unless a future caller needs a single atomic round-trip.
 
 Any new endpoint is defined in the contract-first Zod spec (#331), so the web client is regenerated rather than hand-written.
@@ -291,15 +292,15 @@ Shipped:
 - `pages/welcome.tsx` (#388): skippable Step 3 with the Brandprint explainer and notes intake via the shared `useBrandprintImport` hook.
 - `pages/library/brandprint-nudge.tsx` (#388): one-time dismissible owner nudge on the home library.
 
-In review (#392):
+Shipped (#392):
 
 - `pages/brandprint/profile-panel.tsx`: the hand-off card (three-line brief through the shared PromptBlock, ConnectAgent one tap away), the polled reveal (full-width proposal preview, Approve, Review & comment), and the live profile with Regenerate. The page mounts it instead of the inert nudge whenever `profileId` is set.
 - `pages/brandprint/profile-placeholder.ts` + `use-brandprint-import.ts`: every workspace pointer-write (intake, picker, or the dialog's collection tab) seeds the placeholder and stores `profileId`; the docs list hides the profile artifact, since the panel is its home.
 - Onboarding Step 3: closing copy points at the Brandprint page to finish (one string).
 
-Next (Phase 3):
+Built (this PR, Phase 3):
 
-- `pages/artifact/artifact-top-bar.tsx`: "Rework with Brandprint" ⋯ item, four-state per the gate above.
+- `pages/artifact/rework-menu-item.tsx` + `rework-state.ts`: the "Rework with Brandprint" ⋯ item, four-state per the gate above, mounted from `artifact-top-bar.tsx`.
 
 ## Testing
 
@@ -310,17 +311,17 @@ Shipped coverage (#378, #383):
 - **MCP:** an end-to-end test seeds a collection, points the workspace at it, and asserts the `derive://brandprint/*` resources and instructions pointer.
 - **Web:** none yet; the create dialog and page carry testids (`brandprint-create-*`, `brandprint-upload-look/read-*`, `brandprint-notes-*`, `brandprint-pick-collection-*`, `nav-brandprint`) for an e2e follow-up.
 
-To write with the remaining phases:
+Coverage added with the later phases:
 
 - **Phase 2: written in #392** — `profileId` tenancy on both routes, the MCP serving matrix (pending and live states, reference resources), and `profileState`. Still standing: the page states carry testids for the e2e follow-up, and the agent-in-the-loop run (brief → proposal → approve → next session reads the profile) is a manual pre-merge pass.
-- **API (Phase 3):** `artifacts/:id/rework` composes the correct @mention, lands it in the agent inbox, and returns `needsAgent` when the workspace has none.
-- **Web:** onboarding Step 3 renders, saves, and skips; the Rework item shows the correct one of set-up / connect / fire / picker for its four states; an e2e over the create dialog.
+- **API (Phase 3): written (this PR)** — `rework.test.ts` covers the gates (`needsAgent`, `needsBrandprint`, cross-workspace 404s) and the firing (sole-agent default, chosen agent among several, a live profile named as the first read), asserting the canned @mention lands in the agent inbox.
+- **Web (Phase 3): written (this PR)** — the four-state resolver test (`rework-state.test.ts`) covers set-up / connect / fire / picker. Still standing: onboarding Step 3 renders, saves, and skips; an e2e over the create dialog.
 
 ## Phasing
 
 - **Phase 0 (foundation): shipped** (#378). Anir's Phase A ported forward, renamed, with the cross-tenant ownership validation added in review.
 - **Phase 1 (capture): shipped** (#383, #384, #386, #388). The create dialog on the `/brandprint` page, the docs' one home, the shared ConnectAgent surface, onboarding Step 3, and both nudges. No seed endpoint, settled.
-- **Phase 2 (the brand profile): built, in review** (#392). The hand-off flow, the placeholder-proposal mechanics, the two reference resources, the page states, profile-first delivery, and the `BrandprintTheme` removal.
+- **Phase 2 (the brand profile): shipped** (#392). The hand-off flow, the placeholder-proposal mechanics, the two reference resources, the page states, profile-first delivery, and the `BrandprintTheme` removal.
 - **Phase 3 (apply): built (this PR).** The Rework ⋯ item (gated on a Brandprint existing), the rework endpoint, and the no-agent routing.
 - **Phase 4 (later, optional):** agent enrichment of the Brandprint doc, visual theme application fed by the profile's embedded tokens, and an "Always review Reworks" setting.
 

--- a/packages/core/src/brandprint.ts
+++ b/packages/core/src/brandprint.ts
@@ -76,9 +76,9 @@ export const brandprintInstructions = (
 }
 
 /**
- * The canned Rework instruction (Phase 3) — kept server-side as the single source of
- * truth (the client fires the endpoint; it never carries the prompt). With a live
- * brand profile, the profile is named as the first read.
+ * The canned Rework instruction — kept server-side as the single source of truth
+ * (the client fires the endpoint; it never carries the prompt). With a live brand
+ * profile, the profile is named as the first read.
  */
 export const reworkInstruction = (profileLive: boolean): string =>
   (profileLive

--- a/packages/core/src/brandprint.ts
+++ b/packages/core/src/brandprint.ts
@@ -74,3 +74,16 @@ export const brandprintInstructions = (
     )
   return docs
 }
+
+/**
+ * The canned Rework instruction (Phase 3) — kept server-side as the single source of
+ * truth (the client fires the endpoint; it never carries the prompt). With a live
+ * brand profile, the profile is named as the first read.
+ */
+export const reworkInstruction = (profileLive: boolean): string =>
+  (profileLive
+    ? "Rework this artifact to match our Brandprint. Read derive://brandprint/profile first, then the rest of the derive://brandprint/* resources, "
+    : "Rework this artifact to match our Brandprint. Read the derive://brandprint/* resources first, ") +
+  "then revise the whole document so its voice, structure, and formatting match. " +
+  "Preserve the meaning and the facts; change how it reads, not what it says. " +
+  "Publish the result as a new version."

--- a/packages/core/test/brandprint.test.ts
+++ b/packages/core/test/brandprint.test.ts
@@ -4,6 +4,7 @@ import {
   parseBrandprint,
   profileState,
   resolveBrandprint,
+  reworkInstruction,
 } from "../src/brandprint"
 
 describe("profileState", () => {
@@ -71,5 +72,21 @@ describe("brandprintInstructions", () => {
     expect(s).toContain("abc123")
     expect(s).toContain("derive://brandprint/reference")
     expect(s.toLowerCase()).not.toContain("offer")
+  })
+})
+
+describe("reworkInstruction", () => {
+  it("points at the brandprint resources and asks for a new version", () => {
+    const s = reworkInstruction(false)
+    expect(s).toContain("derive://brandprint/*")
+    expect(s).toContain("Preserve the meaning and the facts")
+    expect(s).toContain("Publish the result as a new version.")
+    expect(s).not.toContain("derive://brandprint/profile")
+  })
+
+  it("names the live profile as the first read", () => {
+    const s = reworkInstruction(true)
+    expect(s).toContain("Read derive://brandprint/profile first")
+    expect(s).toContain("derive://brandprint/*")
   })
 })


### PR DESCRIPTION
Brandprint Phase 3: Rework — the ⋯ item + POST /v1/artifacts/:shortId/rework

Description:

## Brandprint Phase 3: Rework

Apply-on-demand for the Brandprint, per `docs/plans/brandprint.md` § "Apply on demand: the Rework button (Phase 3)". A canned version of the ask-agent handoff, scoped to the whole artifact.

### What ships

- **`reworkInstruction(profileLive)` in `@derive/core`**: the canned prompt, server-side single source of truth. When a live brand profile exists, `derive://brandprint/profile` is named as the first read.
- **`POST /v1/artifacts/:shortId/rework`**: a thin wrapper over the existing @mention-to-inbox path. Creates a whole-document comment @mentioning the chosen agent (sole agent by default, `agentId` to pick), which lands in that agent's MCP pull inbox. `409 needsAgent` when none registered. Contract-first route; openapi.json and api-types regenerated.
- **"Rework with Brandprint" in the artifact ⋯ menu**: one self-contained component resolving four states: no Brandprint routes to `/brandprint` ("Set up your Brandprint"), Brandprint-but-no-agent opens the shared Connect-an-agent surface (its fifth entry point, as the spec anticipated), one agent fires immediately, several agents get a submenu picker. Stale-state 409s route back to the correct surface instead of toasting raw tokens.
- **Spec reconciliation**: `docs/plans/brandprint.md` now reads Phases 0–2 shipped, Phase 3 built (this PR), Phase 4 later.
                                                                                                         ### Deliberate calls to review
                                                                                                         1. **`409 needsBrandprint` extends the spedsAgent`): the server refuses to hand anagent an empty brief when neither the workspace nor the requester's profile resolves a Brandprint. The clnever calls in that state; this guards AP
2. **Narrower fan-out than the composer, on purpose**: the request fires `comment.created`, the mention irow, and owner bells, but skips Slack cha, the `comment.mention` webhook, and theGitHub PR echo. A canned bot-directed note in those channels is noise. The route docstring documents the skip.
3. **Active-workspace approximation in the client**: the menu item reads the viewer's active-workspace settings for Brandprint presence, so a cree "Set up your Brandprint" where firingwould have worked. The server is authoritative in all cases and the 409 routing absorbs the fire-side
mismatch. Fast-follow: an artifact-scopedl.

### Testing

- `packages/core/test/brandprint.test.ts`file-first variant.
- `apps/api/test/rework.test.ts` (7 tests, real routes end to end): needsAgent, needsBrandprint, 404s,
sole-agent fire with inbox delivery, mult inbox assertion, pending-vs-live profilevia real version publishing, personal-profile-only resolution.
- `apps/web/src/pages/artifact/rework-sta-state resolver.
- Full gates green: 1,796 tests across the workspace, typecheck, `pnpm run ci`.
- Verified live in a dev instance: all fohe browser; the canned instructionconfirmed arriving in the agent's `/v1/agent/inbox`.

### Follow-ups (not in this PR)

- Artifact-scoped Brandprint-presence signal for the menu item (closes the cross-workspace "setup" misroute).
- 401/403 tests on the rework route (logiomments route's guards).
- Guard against a Brandprint pointing at a deleted collection (pre-existing pointer staleness).
- Warm `workspaceSettingsQuery` from the rase the item's first-open pop-in.

Note: `chore: clean up pre-existing lint e-commit hook` (57d3660) fixes twopre-existing lint failures on main that blocked any commit; behavior-neutral, reviewed.