### PR TITLE
fix(slack): ack inbound events fast — defer ingest to the durable outbox

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -138,16 +138,16 @@ https://derive.example.com/api/auth/oauth2/callback/<OIDC_PROVIDER_ID>
 
 ### Slack app (optional)
 
-To connect Slack workspaces (comments, publishes, proposals and reviews in a channel,
-plus reply-back and interactive buttons), create one Slack app for this instance:
+To connect Slack workspaces (Derive comments mirrored to a channel with two-way
+reply-back, plus DMs to a member for mentions, review requests and shares), create one
+Slack app for this instance:
 
-1. Open **Settings → Integrations → Set up Slack app** (or go straight to `/settings/slack/app/new`). This renders the app manifest already filled in with this instance's URL, so event subscriptions, interactivity, the `/derive` command and the App Home are configured for you — nothing to hand-edit. At [api.slack.com/apps](https://api.slack.com/apps) → **Create New App → From a manifest**, paste it, and create the app.
+1. Open **Settings → Integrations → Set up Slack app** (or go straight to `/settings/slack/app/new`). This renders the app manifest already filled in with this instance's URL, so the event subscriptions and bot scopes are configured for you — nothing to hand-edit. At [api.slack.com/apps](https://api.slack.com/apps) → **Create New App → From a manifest**, paste it, and create the app.
 2. From the app's **Basic Information** page, set `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, and `SLACK_SIGNING_SECRET` (all three required, or Slack stays off). On Workers these are secrets: `wrangler secret put SLACK_CLIENT_ID` (and the other two).
-3. Workspace admins connect from **Settings → Integrations → Add to Slack**, then set a default channel and invite the Derive bot to it.
+3. Workspace admins connect from **Settings → Integrations → Add to Slack**, then set a default channel and invite the Derive bot to it. Both public and private channels work; a private channel must have the bot invited (it can't self-join). A workspace connected before private-channel support was added must **reconnect** (Add to Slack again) to grant the `groups:*` scopes — there's no automatic reconnect prompt for it.
 
 The manifest is served (filled) at `/v1/slack/manifest.json`; the setup page is the copy-paste
 front end for it. Bot tokens are stored per workspace, encrypted at rest with `DERIVE_AUTH_SECRET`.
-The assistant feature is forward-declared but needs Agents & AI Apps enabled when it ships.
 
 ---
 

--- a/apps/api/src/lib/slack-comments.ts
+++ b/apps/api/src/lib/slack-comments.ts
@@ -13,8 +13,10 @@ import {
   newId,
   type SlackThreadLinkRecord,
 } from "@derive/core"
+import type { EventBus } from "../bus"
 import { type ChannelSendResult, enqueueChannelDelivery } from "../webhooks"
 import { commentDeepLink, parseMeta } from "./comments"
+import { slackUserName } from "./slack"
 import { context, section } from "./slack-cards"
 import { postWithRecovery, resolveBotToken } from "./slack-delivery"
 import { truncate } from "./text"
@@ -103,6 +105,56 @@ export const makeSlackSender =
     return res
   }
 
+/** The inbound Slack thread reply an enqueued slack_ingest delivery carries. Self-contained:
+ *  the sender re-resolves the org + thread from the channel + thread ts on the worker. */
+interface SlackIngestPayload {
+  channel: string
+  threadTs: string
+  userId: string
+  text: string
+  ts: string
+}
+
+/** Defer a Slack thread reply for ingestion into Derive via the outbox. The events endpoint
+ *  calls this after a cheap thread-link check, so the slow part (users.info + the comment
+ *  write) runs on the worker: the endpoint acks Slack under its 3s deadline, and a transient
+ *  failure is retried by the outbox instead of silently dropping the reply. */
+export const enqueueSlackReplyIngest = async (
+  meta: MetaStore,
+  p: SlackIngestPayload,
+): Promise<void> => {
+  await enqueueChannelDelivery(meta, "slack_ingest", "slack.reply", p)
+}
+
+/** Build the slack_ingest sender: mirror a deferred Slack thread reply into a Derive comment.
+ *  Resolves the thread link + install from the payload, fetches the author's display name,
+ *  and writes the comment via ingestSlackReply (idempotent on the Slack message ts, so a
+ *  redelivery is a no-op). Publishes comment.created on the bus when given one, so a live
+ *  viewer sees it (Node runs the worker in-process; the edge has no cross-isolate bus here).
+ *  No-ops (delivered) when the thread link/install is gone or the channel mirror is off, so
+ *  a stale event never dead-letters. */
+export const makeSlackIngestSender =
+  (meta: MetaStore, encryptionKey: string | undefined, bus?: Pick<EventBus, "publish">) =>
+  async (d: DeliveryRecord): Promise<ChannelSendResult> => {
+    const p = JSON.parse(d.payload) as SlackIngestPayload
+    const link = await meta.getSlackThreadLinkByTs(p.channel, p.threadTs)
+    if (!link) return { ok: true, status: "skipped: no thread link" }
+    if (!(await meta.getOrgSettings(link.org_id)).slackPost)
+      return { ok: true, status: "skipped: channel mirror off" }
+    const bot = await resolveBotToken(meta, link.org_id, encryptionKey)
+    if (!bot) return { ok: true, status: "skipped: slack not connected" }
+    const name = await slackUserName(bot.token, p.userId)
+    const created = await ingestSlackReply(meta, link, {
+      ts: p.ts,
+      userId: p.userId,
+      userName: name,
+      text: p.text,
+      botUserId: bot.install.bot_user_id,
+    })
+    if (created) bus?.publish(created.artifact_id, { type: "comment.created" })
+    return { ok: true, status: created ? "ingested" : "skipped: own or duplicate" }
+  }
+
 /** Mirror a Slack thread reply into Derive as a comment on the linked thread. Returns the
  *  created comment, or null when it should be skipped (our own bot, or no thread link).
  *  `botUserId` is the connected app's bot so we never re-ingest our own posts. */
@@ -116,9 +168,11 @@ export const ingestSlackReply = async (
   const existing = await meta.listComments(link.artifact_id)
   if (existing.some((c) => parseMeta(c.meta).slack?.ts === args.ts)) return null
 
-  const id = newId("c")
-  const created = await meta.createComment({
-    id,
+  // Write the Slack origin marker atomically WITH the row (not a second updateComment): the
+  // outbox can re-claim a leased slack_ingest delivery after a crash, and a marker written
+  // in a follow-up write would be invisible to that retry's dedupe scan → a duplicate comment.
+  return meta.createComment({
+    id: newId("c"),
     artifact_id: link.artifact_id,
     thread_id: link.thread_id,
     base_version: 0, // a reply inherits the thread; base_version isn't meaningful here
@@ -127,9 +181,6 @@ export const ingestSlackReply = async (
     body_md: args.text,
     author: args.userName,
     author_id: `slack:${args.userId}`,
-  })
-  const patched = await meta.updateComment(created.id, {
     meta: JSON.stringify({ slack: { ts: args.ts, channel: link.channel } }),
   })
-  return patched ?? created
 }

--- a/apps/api/src/lib/slack-comments.ts
+++ b/apps/api/src/lib/slack-comments.ts
@@ -128,8 +128,9 @@ export const enqueueSlackReplyIngest = async (
 
 /** Build the slack_ingest sender: mirror a deferred Slack thread reply into a Derive comment.
  *  Resolves the thread link + install from the payload, fetches the author's display name,
- *  and writes the comment via ingestSlackReply (idempotent on the Slack message ts, so a
- *  redelivery is a no-op). Publishes comment.created on the bus when given one, so a live
+ *  and writes the comment via ingestSlackReply, which dedupes a redelivery on the Slack
+ *  message ts (a scan, not a DB uniqueness constraint — safe because the outbox drains one
+ *  delivery at a time per deployment). Publishes comment.created on the bus when given one, so a live
  *  viewer sees it (Node runs the worker in-process; the edge has no cross-isolate bus here).
  *  No-ops (delivered) when the thread link/install is gone or the channel mirror is off, so
  *  a stale event never dead-letters. */

--- a/apps/api/src/lib/slack.ts
+++ b/apps/api/src/lib/slack.ts
@@ -206,14 +206,24 @@ export const openSlackDm = async (token: string, userId: string): Promise<string
 
 /** Bot scopes requested at install — the single source of truth, also what the manifest
  *  declares (see slack-app-setup buildSlackManifest). Covers posting the comment mirror +
- *  event cards (chat/channels), reading channel history so a thread reply can flow back in,
- *  and DMing a mentioned user resolved by email (users:read.email, im:write) — no per-user
- *  OAuth. Adding a scope here means existing installs see the re-auth banner until reconnect. */
+ *  event cards (chat/channels), reading channel history so a thread reply can flow back in
+ *  (channels:* for public, groups:* for private channels the bot is invited to — matching
+ *  the message.channels + message.groups event subscriptions), and DMing a mentioned user
+ *  resolved by email (users:read.email, im:write) — no per-user OAuth.
+ *
+ *  Re-auth on scope drift is only automatic for scopes an OUTBOUND call needs: a stale
+ *  install hits `missing_scope`, which flags needs_reauth and shows the reconnect banner.
+ *  Event-delivery scopes (groups:*) are different — Slack simply stops delivering the events
+ *  to a token that lacks them, so Derive makes no failing call and nothing flags the drift.
+ *  Existing installs must reconnect by hand to get private-channel reply-back; there is no
+ *  automatic prompt (a real scope-drift detector is future work). */
 export const SLACK_BOT_SCOPES = [
   "chat:write",
   "channels:read",
   "channels:join",
   "channels:history",
+  "groups:read",
+  "groups:history",
   "users:read",
   "users:read.email",
   "im:write",

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -11,6 +11,7 @@ import Database from "better-sqlite3"
 import { Pool } from "pg"
 import { createApp } from "./app"
 import { type AuthDb, makeAuth, migrateAuth, OAUTH_ANON_CLIENT_TTL_MS } from "./auth-config"
+import { createInProcessBackplane } from "./bus"
 import { loadConfig, resolveAuthSecret, resolveDefaultOrg } from "./config"
 import { configWarnings } from "./config-manifest"
 import { restEmbedder } from "./embedder"
@@ -20,7 +21,7 @@ import { customDomainsFromEnv } from "./lib/cloudflare-saas"
 import { buildAuthEmail, emailDeliverySender, logEmailSender, resendEmailSender } from "./lib/email"
 import { makeGithubCommentSender } from "./lib/github-comments"
 import { mountWeb } from "./lib/serve-web"
-import { makeSlackSender } from "./lib/slack-comments"
+import { makeSlackIngestSender, makeSlackSender } from "./lib/slack-comments"
 import { makeSlackDmSender } from "./lib/slack-dm"
 import { makeShutdown } from "./lifecycle"
 import { log } from "./log"
@@ -274,6 +275,10 @@ const shellHtml = cfg.serveWeb ? readFileSync(cfg.webShell, "utf8") : undefined
 // First-party channel senders for the Node tier. Email uses Resend (over fetch) when
 // RESEND_API_KEY is set, else the log sender (visible in dev, no transport needed).
 // The edge tier wires the Cloudflare Email Service binding instead (see webhook-do.ts).
+// The realtime relay, created here so the inbound Slack-ingest sender (which runs on the
+// worker, outside a request) can publish comment.created to live viewers over the same
+// in-process bus the request handlers use. Passed into createApp below so both share it.
+const backplane = createInProcessBackplane()
 const channelSenders: ChannelSenders = {
   email: emailDeliverySender(
     cfg.resendApiKey && cfg.emailFrom
@@ -288,6 +293,9 @@ const channelSenders: ChannelSenders = {
   // comment thread mirror and per-user DMs (mentions, review requests, shares).
   slack_app: makeSlackSender(meta, authSecret),
   slack_dm: makeSlackDmSender(meta, authSecret),
+  // Inbound: a Slack thread reply the events endpoint deferred — resolve the author and
+  // write the Derive comment here, off the ack path, publishing to the shared bus.
+  slack_ingest: makeSlackIngestSender(meta, authSecret, backplane),
 }
 const webhookWorker = startWebhookWorker(meta, nodeDnsGuard, channelSenders)
 
@@ -313,6 +321,9 @@ const syncRunner = createNodeSyncRunner(meta, blobs, authSecret)
 const app = createApp({
   meta,
   blobs,
+  // Share the realtime relay with the webhook worker so a deferred Slack reply publishes
+  // comment.created to the same in-process subscribers a request would.
+  backplane,
   // Dense/semantic arm (pgvector) when configured on Postgres; undefined ⇒ lexical-only.
   search,
   baseUrl: cfg.baseUrl,

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -2,15 +2,10 @@ import { newId, type SlackInstallRecord } from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
-import { decryptSecret, encryptSecret, signState, verifyState } from "../lib/crypto"
+import { encryptSecret, signState, verifyState } from "../lib/crypto"
 import { bail, fail, readJson } from "../lib/http"
-import {
-  exchangeSlackOAuth,
-  slackAuthorizeUrl,
-  slackUserName,
-  verifySlackSignature,
-} from "../lib/slack"
-import { ingestSlackReply } from "../lib/slack-comments"
+import { exchangeSlackOAuth, slackAuthorizeUrl, verifySlackSignature } from "../lib/slack"
+import { enqueueSlackReplyIngest } from "../lib/slack-comments"
 import { enqueueSlackDm, wantsSlackDm } from "../lib/slack-dm"
 import { log } from "../log"
 import { buildSlackManifest, slackSetupHTML } from "../slack-app-setup"
@@ -23,7 +18,7 @@ import { buildSlackManifest, slackSetupHTML } from "../slack-app-setup"
  *  the web client's type; the OAuth redirects and the Slack Events webhook stay plain
  *  routes (not typed JSON). */
 export const slackRoutes = (ctx: AppContext) => {
-  const { meta, deps, bus, requireUser } = ctx
+  const { meta, deps, requireUser } = ctx
   const { activeWorkspace, workspaceCan, requireWorkspace } = ctx
   const app = new OpenAPIHono<BlankEnv>()
   const slack = deps.slack
@@ -152,21 +147,21 @@ export const slackRoutes = (ctx: AppContext) => {
       ev.user &&
       ev.text
     ) {
+      // Gate on a cheap indexed lookup (only replies under a message we posted map to a
+      // Derive thread) so channel chatter never floods the outbox, then defer the slow work
+      // — users.info + the comment write — to the worker. That keeps this handler well under
+      // Slack's 3s ack deadline, and the outbox retries a transient failure instead of
+      // dropping the reply (the old inline path did all of it before acking).
       const link = await meta.getSlackThreadLinkByTs(ev.channel, ev.thread_ts)
-      if (link && deps.encryptionKey && (await meta.getOrgSettings(link.org_id)).slackPost) {
-        const install = await meta.getSlackInstall(link.org_id)
-        if (install) {
-          const token = decryptSecret(install.bot_token, deps.encryptionKey)
-          const name = await slackUserName(token, ev.user)
-          const created = await ingestSlackReply(meta, link, {
-            ts: ev.ts ?? "",
-            userId: ev.user,
-            userName: name,
-            text: ev.text,
-            botUserId: install.bot_user_id,
-          })
-          if (created) bus.publish(created.artifact_id, { type: "comment.created" })
-        }
+      if (link) {
+        await enqueueSlackReplyIngest(meta, {
+          channel: ev.channel,
+          threadTs: ev.thread_ts,
+          userId: ev.user,
+          text: ev.text,
+          ts: ev.ts ?? "",
+        })
+        deps.pokeWebhooks?.()
       }
     }
     return c.json({ ok: true })

--- a/apps/api/src/slack-app-setup.ts
+++ b/apps/api/src/slack-app-setup.ts
@@ -19,7 +19,7 @@ export const buildSlackManifest = (baseUrl: string) => {
     display_information: {
       name: "Derive",
       description:
-        "Get Derive comments, publishes, proposals and reviews in Slack, and reply back from a thread.",
+        "Get Derive comments in a Slack channel, reply back from the thread, and DM members for mentions, review requests and shares.",
       background_color: "#1a1a2e",
     },
     features: {

--- a/apps/api/src/webhook-do.ts
+++ b/apps/api/src/webhook-do.ts
@@ -4,7 +4,7 @@ import { tickStore } from "./edge-pg"
 import { cloudflareEmailSender, type SendEmailBinding } from "./email-cf"
 import { emailDeliverySender } from "./lib/email"
 import { makeGithubCommentSender } from "./lib/github-comments"
-import { makeSlackSender } from "./lib/slack-comments"
+import { makeSlackIngestSender, makeSlackSender } from "./lib/slack-comments"
 import { makeSlackDmSender } from "./lib/slack-dm"
 import { type ChannelSenders, edgeGuard, runDeliveryTick } from "./webhooks"
 
@@ -64,6 +64,10 @@ export class WebhookOutbox {
       github_issue_comment: makeGithubCommentSender(store, env.DERIVE_AUTH_SECRET),
       slack_app: makeSlackSender(store, env.DERIVE_AUTH_SECRET),
       slack_dm: makeSlackDmSender(store, env.DERIVE_AUTH_SECRET),
+      // Inbound Slack thread reply deferred by the events endpoint. No bus here: the DO
+      // is a separate isolate from the SSE request handlers, so the comment lands and
+      // shows on the viewer's next read rather than a live push.
+      slack_ingest: makeSlackIngestSender(store, env.DERIVE_AUTH_SECRET),
     }
   }
 

--- a/apps/api/test/slack-app-setup.test.ts
+++ b/apps/api/test/slack-app-setup.test.ts
@@ -27,6 +27,14 @@ describe("buildSlackManifest", () => {
     )
   })
 
+  it("declares private-channel history scopes to match the message.groups subscription", () => {
+    // groups:* is what makes reply-back work in a private channel the bot is invited to;
+    // subscribing to message.groups without it (the old gap) silently dropped those replies.
+    expect(m.oauth_config.scopes.bot).toEqual(
+      expect.arrayContaining(["groups:read", "groups:history"]),
+    )
+  })
+
   it("is named just Derive (Slack caps the app name at 35 chars)", () => {
     expect(m.display_information.name).toBe("Derive")
     expect(m.display_information.name.length).toBeLessThanOrEqual(35)

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -1,8 +1,8 @@
 import { createHmac } from "node:crypto"
-import type { MetaStore } from "@derive/core"
+import type { CommentRecord, MetaStore, NewComment, SlackThreadLinkRecord } from "@derive/core"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { encryptSecret } from "../src/lib/crypto"
-import { makeSlackIngestSender } from "../src/lib/slack-comments"
+import { ingestSlackReply, makeSlackIngestSender } from "../src/lib/slack-comments"
 import { runDeliveryTick } from "../src/webhooks"
 import { as, quotaApp, type TestUser } from "./helpers"
 
@@ -283,17 +283,51 @@ describe("slack events endpoint", () => {
     expect(await meta.listComments(artifact.id)).toHaveLength(0)
 
     // The worker drains the enqueued slack_ingest delivery and mirrors the reply.
-    const createSpy = vi.spyOn(meta, "createComment")
     await drainIngest(meta)
     const mirrored = (await meta.listComments(artifact.id)).find((c) => c.thread_id === "t-root")
     expect(mirrored?.author).toBe("Dana")
     expect(mirrored?.author_id).toBe("slack:U777")
     expect(mirrored?.body_md).toBe("from slack")
-    // The dedupe marker is written IN the insert (atomic), not a follow-up updateComment —
-    // so an outbox re-claim after a crash can't create a second comment. The old two-write
-    // path called createComment with no meta, so this assertion pins the atomicity fix.
-    expect(createSpy).toHaveBeenCalledTimes(1)
-    expect(JSON.parse(createSpy.mock.calls[0]?.[0].meta ?? "{}")).toMatchObject({
+  })
+
+  it("ingestSlackReply writes the Slack dedupe marker IN the comment insert (atomic)", async () => {
+    // A focused unit test with a hand-built store (not the real adapter): the atomicity is
+    // that the {slack.ts} marker rides the createComment INSERT, not a follow-up write a
+    // crash-retry could skip. The old two-write path called createComment with no meta and
+    // then updateComment — the fake has no updateComment, so that path throws here. Both the
+    // "marker present" and "no second write" facts are pinned, on any adapter.
+    const inserts: NewComment[] = []
+    const link: SlackThreadLinkRecord = {
+      id: "l",
+      org_id: "o",
+      artifact_id: "a",
+      thread_id: "t",
+      channel: "C1",
+      message_ts: "111.1",
+      created_at: "",
+    }
+    const fakeMeta = {
+      listComments: async () => [],
+      createComment: async (c: NewComment) => {
+        inserts.push(c)
+        return {
+          ...c,
+          state: "open",
+          created_at: "",
+          meta: c.meta ?? null,
+        } as unknown as CommentRecord
+      },
+    } as unknown as MetaStore
+    const created = await ingestSlackReply(fakeMeta, link, {
+      ts: "222.2",
+      userId: "U1",
+      userName: "Dana",
+      text: "hi",
+      botUserId: "UBOT",
+    })
+    expect(created).not.toBeNull()
+    expect(inserts).toHaveLength(1)
+    expect(JSON.parse(inserts[0]?.meta ?? "{}")).toMatchObject({
       slack: { ts: "222.2", channel: "C1" },
     })
   })

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -1,6 +1,9 @@
 import { createHmac } from "node:crypto"
+import type { MetaStore } from "@derive/core"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { encryptSecret } from "../src/lib/crypto"
+import { makeSlackIngestSender } from "../src/lib/slack-comments"
+import { runDeliveryTick } from "../src/webhooks"
 import { as, quotaApp, type TestUser } from "./helpers"
 
 const KEY = "enc-key-slack-routes-123456"
@@ -33,6 +36,31 @@ const make = (name: string) => {
 
 const sign = (ts: string, body: string) =>
   `v0=${createHmac("sha256", SIGNING).update(`v0:${ts}:${body}`).digest("hex")}`
+
+// The events endpoint acks fast and defers ingestion to the outbox; tests drain it by
+// hand (no worker runs under quotaApp). A no-op address guard: ingestion isn't an HTTP
+// delivery, so there's no URL to SSRF-check.
+const drainIngest = (meta: MetaStore) =>
+  runDeliveryTick(
+    meta,
+    { precheck: async () => null },
+    { slack_ingest: makeSlackIngestSender(meta, KEY) },
+  )
+
+// A signed Slack events POST.
+type TestApp = { request: (path: string, init?: RequestInit) => Response | Promise<Response> }
+const postEvent = (app: TestApp, body: string) => {
+  const ts = String(Math.floor(Date.now() / 1000))
+  return app.request("/v1/slack/events", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-slack-request-timestamp": ts,
+      "x-slack-signature": sign(ts, body),
+    },
+    body,
+  })
+}
 
 afterEach(() => vi.unstubAllGlobals())
 
@@ -179,12 +207,13 @@ describe("slack events endpoint", () => {
     expect(r.status).toBe(401)
   })
 
-  it("mirrors a signed thread reply into a Derive comment on the linked thread", async () => {
-    const { app, meta } = make("slack-ev-reply")
-    // Seed an artifact + a thread link for an existing Derive thread.
+  const seedThread = async (
+    meta: MetaStore,
+    ids: { artifact: string; short: string; thread: string; ts: string },
+  ) => {
     const artifact = await meta.createArtifact({
-      id: "a-slack-reply",
-      short_id: "slkreply",
+      id: ids.artifact,
+      short_id: ids.short,
       org_id: "default",
       slug: null,
       title: "Doc",
@@ -204,15 +233,26 @@ describe("slack events endpoint", () => {
       created_at: new Date().toISOString(),
     })
     await meta.setSlackThreadLink({
-      id: "stl-1",
+      id: `stl-${ids.thread}`,
       org_id: "default",
       artifact_id: artifact.id,
-      thread_id: "t-root",
+      thread_id: ids.thread,
       channel: "C1",
-      message_ts: "111.1",
+      message_ts: ids.ts,
       created_at: new Date().toISOString(),
     })
-    // Slack users.info lookup → display name.
+    return artifact
+  }
+
+  it("acks fast and defers a linked thread reply to the outbox, which then mirrors it", async () => {
+    const { app, meta } = make("slack-ev-reply")
+    const artifact = await seedThread(meta, {
+      artifact: "a-slack-reply",
+      short: "slkreply",
+      thread: "t-root",
+      ts: "111.1",
+    })
+    // Slack users.info lookup → display name (only hit on drain, never in the request).
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -223,89 +263,124 @@ describe("slack events endpoint", () => {
       ),
     )
 
-    const ts = String(Math.floor(Date.now() / 1000))
-    const body = JSON.stringify({
-      type: "event_callback",
-      event: {
-        type: "message",
-        user: "U777",
-        text: "from slack",
-        channel: "C1",
-        ts: "222.2",
-        thread_ts: "111.1",
-      },
-    })
-    const r = await app.request("/v1/slack/events", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-slack-request-timestamp": ts,
-        "x-slack-signature": sign(ts, body),
-      },
-      body,
-    })
+    const r = await postEvent(
+      app,
+      JSON.stringify({
+        type: "event_callback",
+        event: {
+          type: "message",
+          user: "U777",
+          text: "from slack",
+          channel: "C1",
+          ts: "222.2",
+          thread_ts: "111.1",
+        },
+      }),
+    )
     expect(r.status).toBe(200)
-    const comments = await meta.listComments(artifact.id)
-    const mirrored = comments.find((c) => c.thread_id === "t-root")
+    // The endpoint acked without doing the ingest work (no users.info fetch, no comment yet).
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled()
+    expect(await meta.listComments(artifact.id)).toHaveLength(0)
+
+    // The worker drains the enqueued slack_ingest delivery and mirrors the reply.
+    await drainIngest(meta)
+    const mirrored = (await meta.listComments(artifact.id)).find((c) => c.thread_id === "t-root")
     expect(mirrored?.author).toBe("Dana")
     expect(mirrored?.author_id).toBe("slack:U777")
     expect(mirrored?.body_md).toBe("from slack")
   })
 
-  it("ignores our own bot's messages (loop prevention)", async () => {
+  it("the deferred ingest ignores our own bot's messages (loop prevention)", async () => {
     const { app, meta } = make("slack-ev-bot")
-    const artifact = await meta.createArtifact({
-      id: "a-slack-bot",
-      short_id: "slkbot01",
-      org_id: "default",
-      slug: null,
-      title: "Doc",
-      workspace_access: "member",
-      link_role: "viewer",
-      listed: "public",
-      kind: "file",
-      spa: 0,
+    const artifact = await seedThread(meta, {
+      artifact: "a-slack-bot",
+      short: "slkbot01",
+      thread: "t-bot",
+      ts: "333.3",
     })
-    await meta.setSlackInstall({
-      org_id: "default",
-      team_id: "T1",
-      team_name: "Acme",
-      bot_token: encryptSecret("xoxb-1", KEY),
-      bot_user_id: "UBOT",
-      default_channel: "C1",
-      created_at: new Date().toISOString(),
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 })),
+    )
+    const r = await postEvent(
+      app,
+      JSON.stringify({
+        type: "event_callback",
+        event: {
+          type: "message",
+          user: "UBOT",
+          text: "echo",
+          channel: "C1",
+          ts: "444.4",
+          thread_ts: "333.3",
+        },
+      }),
+    )
+    expect(r.status).toBe(200)
+    await drainIngest(meta)
+    expect(await meta.listComments(artifact.id)).toHaveLength(0)
+  })
+
+  it("a redelivered reply (at-least-once) still yields exactly one comment", async () => {
+    const { app, meta } = make("slack-ev-dedupe")
+    const artifact = await seedThread(meta, {
+      artifact: "a-slack-dup",
+      short: "slkdup01",
+      thread: "t-dup",
+      ts: "555.5",
     })
-    await meta.setSlackThreadLink({
-      id: "stl-2",
-      org_id: "default",
-      artifact_id: artifact.id,
-      thread_id: "t-bot",
-      channel: "C1",
-      message_ts: "333.3",
-      created_at: new Date().toISOString(),
-    })
-    const ts = String(Math.floor(Date.now() / 1000))
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ ok: true, user: { profile: { display_name: "Dana" } } }), {
+            status: 200,
+          }),
+      ),
+    )
     const body = JSON.stringify({
       type: "event_callback",
       event: {
         type: "message",
-        user: "UBOT",
-        text: "echo",
+        user: "U9",
+        text: "hi",
         channel: "C1",
-        ts: "444.4",
-        thread_ts: "333.3",
+        ts: "666.6",
+        thread_ts: "555.5",
       },
     })
-    const r = await app.request("/v1/slack/events", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-slack-request-timestamp": ts,
-        "x-slack-signature": sign(ts, body),
-      },
-      body,
-    })
+    // Slack redelivers the same event → two enqueued deliveries, drained together.
+    expect((await postEvent(app, body)).status).toBe(200)
+    expect((await postEvent(app, body)).status).toBe(200)
+    await drainIngest(meta)
+    await drainIngest(meta)
+    const mirrored = (await meta.listComments(artifact.id)).filter((c) => c.thread_id === "t-dup")
+    expect(mirrored).toHaveLength(1)
+  })
+
+  it("enqueues nothing for a reply on a channel with no Derive thread link", async () => {
+    const { app, meta } = make("slack-ev-nolink")
+    const r = await postEvent(
+      app,
+      JSON.stringify({
+        type: "event_callback",
+        event: {
+          type: "message",
+          user: "U1",
+          text: "hi",
+          channel: "CZZZ",
+          ts: "9.9",
+          thread_ts: "8.8",
+        },
+      }),
+    )
     expect(r.status).toBe(200)
-    expect(await meta.listComments(artifact.id)).toHaveLength(0)
+    // No thread link ⇒ no delivery enqueued (we don't flood the outbox with channel chatter).
+    const rows = await meta.claimDueDeliveries(
+      new Date(Date.now() + 60_000).toISOString(),
+      100,
+      new Date(Date.now() + 120_000).toISOString(),
+    )
+    expect(rows.some((d) => d.kind === "slack_ingest")).toBe(false)
   })
 })

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -283,11 +283,19 @@ describe("slack events endpoint", () => {
     expect(await meta.listComments(artifact.id)).toHaveLength(0)
 
     // The worker drains the enqueued slack_ingest delivery and mirrors the reply.
+    const createSpy = vi.spyOn(meta, "createComment")
     await drainIngest(meta)
     const mirrored = (await meta.listComments(artifact.id)).find((c) => c.thread_id === "t-root")
     expect(mirrored?.author).toBe("Dana")
     expect(mirrored?.author_id).toBe("slack:U777")
     expect(mirrored?.body_md).toBe("from slack")
+    // The dedupe marker is written IN the insert (atomic), not a follow-up updateComment —
+    // so an outbox re-claim after a crash can't create a second comment. The old two-write
+    // path called createComment with no meta, so this assertion pins the atomicity fix.
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(createSpy.mock.calls[0]?.[0].meta ?? "{}")).toMatchObject({
+      slack: { ts: "222.2", channel: "C1" },
+    })
   })
 
   it("the deferred ingest ignores our own bot's messages (loop prevention)", async () => {

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1854,11 +1854,17 @@ export type DeliveryStatus = "pending" | "delivered" | "dead"
  * GitHub PR comments (inline review or top-level issue comment). Internal-channel
  * rows carry `webhook_id = "internal"` (no backing `webhook` row); the per-kind
  * sender knows how to build credentials + destination from the payload.
+ *
+ * `slack_ingest` runs the seam the other way: an *inbound* Slack thread reply the events
+ * endpoint enqueues so the slow work (users.info + the comment write) happens on the
+ * worker — the endpoint acks Slack under its 3s deadline and the outbox retries a
+ * transient failure instead of dropping the reply.
  */
 export type DeliveryKind =
   | WebhookKind
   | "slack_app"
   | "slack_dm"
+  | "slack_ingest"
   | "github_review_comment"
   | "github_issue_comment"
   | "email"
@@ -1988,6 +1994,9 @@ export interface NewComment {
   body_md: string
   author: string
   author_id?: string | null
+  /** Opaque JSON sidecar (e.g. the Slack `{ts,channel}` origin marker). Set at insert so a
+   *  dedupe key is written atomically with the row, not in a second write a retry can skip. */
+  meta?: string | null
 }
 
 /** Options for {@link MetaStore.listComments}. */


### PR DESCRIPTION
## What

The Slack Events endpoint (`POST /v1/slack/events`) did all its work **inline before acking** — a thread-link lookup, a `users.info` round-trip, and a comment write — so a slow Slack API call could blow past Slack's **3-second deadline** and trigger retry storms.

It now: verifies the signature → does **one cheap indexed thread-link lookup** (to filter out non-Derive channel chatter) → enqueues a `slack_ingest` delivery into the **existing durable outbox** → acks immediately. A new `makeSlackIngestSender` does the slow work on the worker, inheriting retry + dead-lettering — the same model the outbound Slack senders already use.

This is increment 1 ("harden what exists") of a planned Slack improvement program.

## Why the outbox, not fire-and-forget

Fire-and-forget (`waitUntil`) would lose the reply if the process dies after the 200 (Slack won't retry a 200). The outbox gives durability + retry for a transient `users.info`/DB failure, and reuses infrastructure rather than inventing a new async path.

## Also in this change

- **Idempotency hardened at the root.** `ingestSlackReply` now writes the Slack origin marker **atomically in the comment insert** (new optional `NewComment.meta`) instead of a second write — so an outbox lease-lapse re-claim after a crash can't create a duplicate comment. Pinned by a redelivery test. (Found by adversarial self-review.)
- **Private channels.** Added `groups:read` / `groups:history` bot scopes to match the long-standing `message.groups` event subscription — reply-back in private channels was silently dead. Existing installs must **reconnect** (documented; scope drift on event-delivery scopes raises no automatic re-auth prompt — also surfaced by self-review).
- **Docs → reality.** `DEPLOY.md` and the app manifest description dropped claims of interactive buttons, a `/derive` command, App Home, and an assistant — none exist yet. They'll be re-added as later increments actually ship them.

## Known trade-off

On the Cloudflare Workers tier, the ingest sender runs in the outbox Durable Object with no cross-isolate bus, so a Slack reply no longer live-pushes `comment.created` over SSE there (it persists and appears on next read). Node — the primary container — is unaffected (shared in-process backplane). Wiring the `ROOMS` binding into the outbox DO is deferred as disproportionate for this increment.

## Testing

- `pnpm run ci` ✅ · `pnpm typecheck` ✅ · `pnpm test` ✅ (apps/api 988, core 355, db 199, web 153, cli 115, mcp 27, storage 16)
- New/updated tests: async-defer + no-inline-work, deferred loop-prevention, redelivery-yields-one-comment, no-thread-link-enqueues-nothing, private-channel scope assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)