### PR TITLE
fix(mcp): make the image pipeline work end to end — path-segment preview tokens + stage_asset upload URLs

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -4243,6 +4243,36 @@
         }
       }
     },
+    "/v1/assets/t/{token}": {
+      "post": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Stage a binary asset with a short-lived upload token (minted over MCP).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "token",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The stored asset's public URL and content-addressed handle.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetRef"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/artifacts/{shortId}/members": {
       "get": {
         "tags": [

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -341,6 +341,7 @@ export function createApp(deps: AppDeps): Hono {
     /^\/v1\/vitals$/, // anonymous Core Web Vitals beacon (telemetry, no state)
     /^\/v1\/sync\/github\/webhook$/, // GitHub App webhook — HMAC signature is the gate
     /^\/v1\/slack\/events$/, // Slack Events API — signing-secret signature is the gate
+    /^\/v1\/assets\/t\/[^/]+$/, // MCP-minted upload URL — the signed expiring token is the gate
   ]
   app.use("/v1/*", async (c, next) => {
     const m = c.req.method

--- a/apps/api/src/lib/capability-token.ts
+++ b/apps/api/src/lib/capability-token.ts
@@ -1,0 +1,134 @@
+/**
+ * The shared core of the short-lived HMAC-SHA256 capability tokens: a signed,
+ * expiring proof that its holder may do ONE narrow thing, spendable without a
+ * session. Each token kind gets its own domain string, so a token of one kind
+ * can never be replayed as another — the domains are as much a part of the key
+ * as the secret. Current kinds:
+ *
+ *   - lib/preview-token.ts  ("derive-preview-token:") — read one artifact+version;
+ *     minted for the screenshot renderer.
+ *   - lib/upload-token.ts   ("derive-upload-token:") — stage assets into one
+ *     workspace; minted by the MCP stage_asset tool.
+ *
+ * (lib/crypto.ts's signState is the third, older signed-state format — node:crypto
+ * based, used for the OAuth install flow and raw_tokens. New capability tokens
+ * should be built on this file instead.)
+ *
+ * Format: `<payload>.<signature>`
+ *   payload  = base64url(`<field1>.<field2>...<expEpochMs>`) — expiry is ALWAYS
+ *              the last dot-separated field; earlier fields are the kind's own.
+ *   signature = base64url(HMAC-SHA256(key, payload))
+ *
+ * Edge-safe: Web Crypto (crypto.subtle) only — no node:crypto, no Buffer. Works
+ * on Node 24 and Cloudflare Workers without nodejs_compat. Both functions are
+ * async (crypto.subtle returns Promises).
+ */
+
+// One key-schedule per (domain, secret) per process: importKey re-derivation is
+// pure repeated work, and verify runs on hot unauthenticated paths (every nested
+// asset request of a preview render; every tokened upload POST).
+const keyCache = new Map<string, Promise<CryptoKey>>()
+
+const importKey = (domain: string, secret: string): Promise<CryptoKey> => {
+  const cacheKey = `${domain} ${secret}`
+  let key = keyCache.get(cacheKey)
+  if (!key) {
+    key = crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode(`${domain}${secret}`),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign", "verify"],
+    )
+    keyCache.set(cacheKey, key)
+  }
+  return key
+}
+
+/** Encode a Uint8Array to base64url (no padding). */
+const toBase64Url = (buf: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buf)
+  let bin = ""
+  for (const b of bytes) bin += String.fromCharCode(b)
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "")
+}
+
+/** Decode a base64url string to Uint8Array. Returns null on invalid input. */
+const fromBase64Url = (s: string): Uint8Array | null => {
+  try {
+    const b64 = s.replace(/-/g, "+").replace(/_/g, "/")
+    const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4)
+    const bin = atob(padded)
+    const out = new Uint8Array(bin.length)
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+    return out
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Sign a capability token: `fields` joined with dots, expiry appended as the
+ * final field, HMAC'd under the domain-separated key.
+ *
+ * The LAST field is the only one recovered structurally on verify — earlier
+ * fields are rejoined verbatim, so a kind with several fields splits them
+ * itself (and must pick separators its field values can't contain).
+ */
+export const signCapabilityToken = async (
+  domain: string,
+  secret: string,
+  fields: string[],
+  expEpochMs: number,
+): Promise<string> => {
+  const encoded = new TextEncoder().encode([...fields, expEpochMs].join("."))
+  const payload = toBase64Url(encoded.buffer as ArrayBuffer)
+  const key = await importKey(domain, secret)
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(payload))
+  return `${payload}.${toBase64Url(sig)}`
+}
+
+/**
+ * Verify a capability token. Returns the payload with expiry split back off —
+ * `rest` is everything before the final dot (the sign-time fields, still
+ * joined) — or null on any failure: bad encoding, bad signature, expired.
+ * Never throws; constant-time signature comparison via crypto.subtle.verify.
+ */
+export const verifyCapabilityToken = async (
+  domain: string,
+  secret: string,
+  token: string,
+  nowMs: number,
+): Promise<{ rest: string } | null> => {
+  const dot = token.lastIndexOf(".")
+  if (dot <= 0) return null
+  const payload = token.slice(0, dot)
+  const sigBytes = fromBase64Url(token.slice(dot + 1))
+  if (!sigBytes) return null
+
+  let key: CryptoKey
+  try {
+    key = await importKey(domain, secret)
+  } catch {
+    return null
+  }
+  const valid = await crypto.subtle.verify(
+    "HMAC",
+    key,
+    new Uint8Array(sigBytes),
+    new TextEncoder().encode(payload),
+  )
+  if (!valid) return null
+
+  const plainBytes = fromBase64Url(payload)
+  if (!plainBytes) return null
+  const plain = new TextDecoder().decode(plainBytes)
+
+  // Expiry is always the last dot-separated field; the rest is the kind's own.
+  const lastDot = plain.lastIndexOf(".")
+  if (lastDot <= 0) return null
+  const expEpochMs = Number(plain.slice(lastDot + 1))
+  if (!Number.isFinite(expEpochMs) || nowMs >= expEpochMs) return null
+
+  return { rest: plain.slice(0, lastDot) }
+}

--- a/apps/api/src/lib/preview-token.ts
+++ b/apps/api/src/lib/preview-token.ts
@@ -1,52 +1,16 @@
 /**
- * Short-lived HMAC-SHA256 preview-access tokens for the /raw/:shortId/v/:n/*
- * route. Used by the screenshot renderer to load private/gated artifacts
- * without embedding long-lived credentials.
+ * Short-lived preview-access tokens for the /raw/:shortId/v/:n/pv/:pv/* route.
+ * Used by the screenshot renderer to load private/gated artifacts without
+ * embedding long-lived credentials. Grants read of exactly one
+ * artifact+version; never widens anything else.
  *
- * Format: `<payload>.<signature>`
- *   payload  = base64url(`<artifactId>.<n>.<expEpochMs>`)
- *   signature = base64url(HMAC-SHA256(key, payload))
- *
- * Edge-safe: uses Web Crypto (crypto.subtle) only — no node:crypto. Works on
- * Node 24 and Cloudflare Workers without nodejs_compat.
- *
- * Both exported functions are async (crypto.subtle.sign returns a Promise).
- * Callers must await them; the minting task must also await signPreviewToken.
+ * A thin wrapper over lib/capability-token.ts (which owns the HMAC format,
+ * key caching, and the edge-safety notes) with this kind's domain and its
+ * `<artifactId>.<n>` payload.
  */
+import { signCapabilityToken, verifyCapabilityToken } from "./capability-token"
 
 const DOMAIN = "derive-preview-token:"
-
-/** Import a signing key from the raw secret string (domain-separated). */
-const importKey = async (secret: string): Promise<CryptoKey> =>
-  crypto.subtle.importKey(
-    "raw",
-    new TextEncoder().encode(`${DOMAIN}${secret}`),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign", "verify"],
-  )
-
-/** Encode a Uint8Array to base64url (no padding). */
-const toBase64Url = (buf: ArrayBuffer): string => {
-  const bytes = new Uint8Array(buf)
-  let bin = ""
-  for (const b of bytes) bin += String.fromCharCode(b)
-  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "")
-}
-
-/** Decode a base64url string to Uint8Array. Returns null on invalid input. */
-const fromBase64Url = (s: string): Uint8Array | null => {
-  try {
-    const b64 = s.replace(/-/g, "+").replace(/_/g, "/")
-    const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4)
-    const bin = atob(padded)
-    const out = new Uint8Array(bin.length)
-    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
-    return out
-  } catch {
-    return null
-  }
-}
 
 /**
  * Sign a preview token that authorizes read of exactly one artifact+version.
@@ -57,77 +21,33 @@ const fromBase64Url = (s: string): Uint8Array | null => {
  * @param expEpochMs  Expiry as ms since epoch (Date.now() + ttl)
  * @returns           A compact opaque token string (async — must be awaited)
  */
-export const signPreviewToken = async (
+export const signPreviewToken = (
   secret: string,
   artifactId: string,
   n: number,
   expEpochMs: number,
-): Promise<string> => {
-  const encoded = new TextEncoder().encode(`${artifactId}.${n}.${expEpochMs}`)
-  const payload = toBase64Url(encoded.buffer as ArrayBuffer)
-  const key = await importKey(secret)
-  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(payload))
-  return `${payload}.${toBase64Url(sig)}`
-}
+): Promise<string> => signCapabilityToken(DOMAIN, secret, [artifactId, String(n)], expEpochMs)
 
 /**
- * Verify a preview token. Returns the artifact id + version if valid, or null.
- *
- * Constant-time: uses crypto.subtle.verify so the HMAC comparison is timing-safe.
+ * Verify a preview token. Returns the artifact id + version if valid, or null
+ * (bad signature, malformed, expired). Never throws.
  *
  * @param secret  The DERIVE_AUTH_SECRET / encryptionKey
  * @param token   The token string produced by signPreviewToken
  * @param nowMs   Current time in ms (Date.now()); injectable for testing
- * @returns       { artifactId, n } if valid and not expired, else null (async)
  */
 export const verifyPreviewToken = async (
   secret: string,
   token: string,
   nowMs: number,
 ): Promise<{ artifactId: string; n: number } | null> => {
-  const dot = token.lastIndexOf(".")
-  if (dot <= 0) return null
-  const payload = token.slice(0, dot)
-  const sigB64 = token.slice(dot + 1)
-
-  const sigBytes = fromBase64Url(sigB64)
-  if (!sigBytes) return null
-
-  let key: CryptoKey
-  try {
-    key = await importKey(secret)
-  } catch {
-    return null
-  }
-
-  const valid = await crypto.subtle.verify(
-    "HMAC",
-    key,
-    new Uint8Array(sigBytes),
-    new TextEncoder().encode(payload),
-  )
-  if (!valid) return null
-
-  const plainBytes = fromBase64Url(payload)
-  if (!plainBytes) return null
-  const plain = new TextDecoder().decode(plainBytes)
-
-  // Format: `<artifactId>.<n>.<expEpochMs>`
-  // artifactId may contain hyphens but not dots; n and expEpochMs are integers.
-  // Split from the right so artifactId is allowed to contain dots (defensive).
-  const lastDot = plain.lastIndexOf(".")
-  if (lastDot <= 0) return null
-  const expStr = plain.slice(lastDot + 1)
-  const rest = plain.slice(0, lastDot)
-  const midDot = rest.lastIndexOf(".")
+  const claim = await verifyCapabilityToken(DOMAIN, secret, token, nowMs)
+  if (!claim) return null
+  // Payload: `<artifactId>.<n>` — split from the right so artifactId is
+  // allowed to contain dots (defensive).
+  const midDot = claim.rest.lastIndexOf(".")
   if (midDot <= 0) return null
-  const nStr = rest.slice(midDot + 1)
-  const artifactId = rest.slice(0, midDot)
-
-  const expEpochMs = Number(expStr)
-  const n = Number(nStr)
-  if (!Number.isFinite(expEpochMs) || !Number.isInteger(n)) return null
-  if (nowMs >= expEpochMs) return null
-
-  return { artifactId, n }
+  const n = Number(claim.rest.slice(midDot + 1))
+  if (!Number.isInteger(n)) return null
+  return { artifactId: claim.rest.slice(0, midDot), n }
 }

--- a/apps/api/src/lib/upload-token.ts
+++ b/apps/api/src/lib/upload-token.ts
@@ -1,0 +1,71 @@
+/**
+ * Short-lived upload-access tokens for POST /v1/assets/t/:token.
+ *
+ * Minted by the MCP `stage_asset` tool for agents whose only credential lives
+ * INSIDE the MCP transport (hosted OAuth): the model can call tools but its
+ * shell holds no bearer token, so the plain POST /v1/assets — the blessed
+ * images-without-base64 path — 403s on it. This token moves that capability
+ * out to the shell: mint it over MCP, spend it with curl --data-binary, and
+ * the bytes never ride through the model's context.
+ *
+ * Grants exactly one thing: staging assets into one workspace until expiry.
+ * It can't read anything, and what it writes is bounded the same as the authed
+ * route (sniffed non-executable formats, 25MB cap, the workspace storage quota).
+ * The token also names the USER whose grant minted it, so the spend side can
+ * re-check live membership — demoting or removing the person kills their
+ * outstanding upload URLs immediately, matching the per-request role check the
+ * authed route does. (An ownerless legacy agent mints with an empty principal;
+ * for those the mint-time role check is all there is, same as before.)
+ *
+ * A thin wrapper over lib/capability-token.ts (which owns the HMAC format,
+ * key caching, and the edge-safety notes) with this kind's domain and its
+ * `<orgId>.<userId>` payload.
+ */
+import { signCapabilityToken, verifyCapabilityToken } from "./capability-token"
+
+const DOMAIN = "derive-upload-token:"
+
+/** How long a minted upload URL stays spendable. Long enough for an agent to
+ *  stage a batch of screenshots in one working session, short enough that a
+ *  leaked URL (shell history, a pasted transcript) is a bounded liability. */
+export const UPLOAD_TOKEN_TTL_MS = 15 * 60 * 1000
+
+/**
+ * Sign an upload token that authorizes staging assets into one workspace.
+ *
+ * @param secret      The DERIVE_AUTH_SECRET / encryptionKey
+ * @param orgId       The workspace the staged assets belong to
+ * @param userId      The granting user, re-checked for live membership at spend
+ *                    time ("" for an ownerless legacy agent — no re-check)
+ * @param expEpochMs  Expiry as ms since epoch (Date.now() + UPLOAD_TOKEN_TTL_MS)
+ * @returns           A compact opaque token string (async — must be awaited)
+ */
+export const signUploadToken = (
+  secret: string,
+  orgId: string,
+  userId: string,
+  expEpochMs: number,
+): Promise<string> => signCapabilityToken(DOMAIN, secret, [orgId, userId], expEpochMs)
+
+/**
+ * Verify an upload token. Returns the workspace it stages into and the user
+ * whose membership must still allow publishing (empty string = no principal,
+ * skip the re-check), or null (bad signature, malformed, expired). Never throws.
+ *
+ * @param secret  The DERIVE_AUTH_SECRET / encryptionKey
+ * @param token   The token string produced by signUploadToken
+ * @param nowMs   Current time in ms (Date.now()); injectable for testing
+ */
+export const verifyUploadToken = async (
+  secret: string,
+  token: string,
+  nowMs: number,
+): Promise<{ orgId: string; userId: string } | null> => {
+  const claim = await verifyCapabilityToken(DOMAIN, secret, token, nowMs)
+  if (!claim) return null
+  // Payload: `<orgId>.<userId>` — split from the right so orgId is allowed to
+  // contain dots (defensive; user ids can't, ws_/u_ ids don't today).
+  const midDot = claim.rest.lastIndexOf(".")
+  if (midDot <= 0) return null
+  return { orgId: claim.rest.slice(0, midDot), userId: claim.rest.slice(midDot + 1) }
+}

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -75,6 +75,7 @@ import { parseMeta, quoteOf, REACTIONS } from "./lib/comments"
 import { type MaterializedEdits, materializeEdits, preservingFilename } from "./lib/edits"
 import { buildReviewEmail } from "./lib/email"
 import { MAX_UPLOAD_BYTES } from "./lib/http"
+import { MAX_ASSET_BYTES } from "./lib/image"
 import { notifyCommentBells } from "./lib/notify-comment"
 import {
   baseType,
@@ -88,6 +89,7 @@ import {
   workspaceSearchReport,
 } from "./lib/search"
 import { enqueueSlackReviewRequestedDm } from "./lib/slack-dm"
+import { signUploadToken, UPLOAD_TOKEN_TTL_MS } from "./lib/upload-token"
 import { enqueueChannelDelivery } from "./webhooks"
 
 const text = (s: string) => ({ content: [{ type: "text" as const, text: s }] })
@@ -336,7 +338,10 @@ async function buildServer(
         `short_id to grep across the workspace instead — same tool, that one parameter omitted. ` +
         `After publishing a styled page, call read with render:"top" (or ` +
         `"full"/"marked") to SEE what shipped — it catches visual breakage no text ` +
-        `read can. Use comment to leave or ` +
+        `read can. For images and web fonts, call stage_asset for a short-lived upload ` +
+        `URL, curl the file's raw bytes to it from your shell, and reference the ` +
+        `returned permanent url — never base64 binaries through a tool call (a pasted ` +
+        `image usually already sits on disk; upload that file). Use comment to leave or ` +
         `resolve feedback. ${writeGuidance}To change PART of an artifact, prefer publish's edits ` +
         `(exact-match search/replace against the stored source) over resending everything. When a ` +
         `revision fixes specific feedback, pass those thread ids as publish's "addresses" so the ` +
@@ -1472,24 +1477,65 @@ async function buildServer(
     },
   )
 
+  // STAGE ASSETS — a tokenless upload URL for binaries -------------------------
+  // The blessed images path is POST /v1/assets with raw bytes, but a hosted-OAuth
+  // connection's credential lives inside this transport — the agent's shell has no
+  // bearer to curl with, so that path 403s on exactly the agents told to use it.
+  // This tool moves the capability out to the shell: mint a short-lived signed
+  // upload URL over MCP, spend it with curl. The bytes never enter the context.
+  server.registerTool(
+    "stage_asset",
+    {
+      description:
+        "Mint a SHORT-LIVED upload URL for staging binary assets — raster images (PNG/JPEG/GIF/WebP) and web fonts (WOFF/WOFF2), max 25MB — into this workspace, no bearer token needed. POST a file's RAW bytes to the returned URL from your shell (`curl -sS --data-binary @shot.png <upload_url>`); the response carries a permanent public `url` to paste into any artifact's <img src>/CSS url()/markdown, and the `asset:<hash>` `ref` for a publish `files` map. The URL is reusable until it expires (~15 min), so stage a whole batch with one mint. An image PASTED into your conversation is usually ALREADY a file on disk (Claude Code caches pastes and shows the path alongside the image) — upload those bytes; NEVER transcribe an image to base64 through your context (~1 token/byte, and it can be silently corrupted). No shell? Fall back to a base64 data: URI entry in a bundle publish's `files` map — small images only.",
+      inputSchema: { workspace: wsArg },
+    },
+    async ({ workspace }) => {
+      const t = await resolveWs(workspace)
+      if ("error" in t) return err(t.error)
+      // Same bar as POST /v1/assets itself: staging is a publish-side capability.
+      if (!roleAllows(t.role, "publish"))
+        return err("Your role in this workspace can't stage assets (publishing required).")
+      const secret = ctx.deps.encryptionKey
+      if (!secret)
+        return err(
+          "This server has no signing secret configured, so it can't mint upload URLs. POST the bytes to /v1/assets with a bearer token instead (DERIVE_TOKEN, or `derive login`).",
+        )
+      // Bind the token to the granting user so the spend side can re-check live
+      // membership — revoking or demoting them kills outstanding URLs mid-TTL.
+      // An ownerless legacy agent has no user to bind; it mints an unbound token.
+      const expiresAt = Date.now() + UPLOAD_TOKEN_TTL_MS
+      const tok = await signUploadToken(secret, t.org, ownerId ?? "", expiresAt)
+      const uploadUrl = `${ctx.deps.baseUrl.replace(/\/$/, "")}/v1/assets/t/${tok}`
+      return json({
+        upload_url: uploadUrl,
+        workspace: t.org,
+        expires_in_minutes: Math.round(UPLOAD_TOKEN_TTL_MS / 60_000),
+        max_bytes: MAX_ASSET_BYTES,
+        accepts: ["image/png", "image/jpeg", "image/gif", "image/webp", "font/woff", "font/woff2"],
+        how: `curl -sS -X POST --data-binary @<file> "${uploadUrl}" → {url, ref, ...}. Paste \`url\` into content, or use \`ref\` ("asset:<hash>") as a bundle files value. Repeat for each file until expiry.`,
+      })
+    },
+  )
+
   // WRITE — publish live, or file a proposal for review -----------------------
   server.registerTool(
     "publish",
     {
       description:
-        "Save a revision of an artifact. It goes LIVE immediately if your role can publish (Creator/Admin); otherwise — or whenever you pass for_review:true — it is filed as a PROPOSAL a human approves before it goes live. To CHANGE PART of a single-file artifact, prefer `edits` (exact-match search/replace against the stored source — read format:'html' first) over resending everything. Otherwise provide the full `content` for a SINGLE-FILE artifact, or `files` (a map of page path → content) for a MULTI-PAGE BUNDLE (a whole site, images and any binary asset). OMIT short_id to create a NEW artifact (`title` required); PASS short_id to add a version to one you own, matching its kind. A bundle republish REPLACES the whole bundle, so include EVERY page and asset (or use `merge`). Pass `addresses` with the thread ids (from catch_up) this revision resolves. (Proposals are single-file only; bundles must be published directly.) FULLY-STYLED HTML renders as-authored (own <style>/scripts/fonts) in the sandboxed viewer — two rules: declare your own <meta name=\"viewport\"> (pages without one get a mobile-reflow injection whose media caps can fight intentional layouts; `data-reflow-exempt` on an element is the per-component escape hatch), and self-host binaries via POST /v1/assets (images AND woff2 fonts) instead of base64. The response echoes `content_sha256` of the stored bytes — verify it when the content passed through your context.",
+        "Save a revision of an artifact. It goes LIVE immediately if your role can publish (Creator/Admin); otherwise — or whenever you pass for_review:true — it is filed as a PROPOSAL a human approves before it goes live. To CHANGE PART of a single-file artifact, prefer `edits` (exact-match search/replace against the stored source — read format:'html' first) over resending everything. Otherwise provide the full `content` for a SINGLE-FILE artifact, or `files` (a map of page path → content) for a MULTI-PAGE BUNDLE (a whole site, images and any binary asset). OMIT short_id to create a NEW artifact (`title` required); PASS short_id to add a version to one you own, matching its kind. A bundle republish REPLACES the whole bundle, so include EVERY page and asset (or use `merge`). Pass `addresses` with the thread ids (from catch_up) this revision resolves. (Proposals are single-file only; bundles must be published directly.) FULLY-STYLED HTML renders as-authored (own <style>/scripts/fonts) in the sandboxed viewer — two rules: declare your own <meta name=\"viewport\"> (pages without one get a mobile-reflow injection whose media caps can fight intentional layouts; `data-reflow-exempt` on an element is the per-component escape hatch), and self-host binaries via a stage_asset upload URL (images AND woff2 fonts) instead of base64. The response echoes `content_sha256` of the stored bytes — verify it when the content passed through your context.",
       inputSchema: {
         content: z
           .string()
           .optional()
           .describe(
-            "The complete content for a SINGLE-FILE artifact (HTML or Markdown). Use this OR `files`, not both. To embed an image OR a web font CHEAPLY (no base64 in this call), upload the raw bytes to POST /v1/assets first (PNG/JPEG/GIF/WebP/WOFF/WOFF2) — the response's `url` is a permanent public link; paste it into an `<img src>`, a CSS `url()`, or markdown `![]()`. Never inline a base64 data: URI here — it tokenizes at roughly 1 token/char (one modest screenshot can cost 100k+ tokens), and content carried through your context can be silently mistranscribed; binaries should travel as bytes. If you have shell access and the file is large, you can also POST it directly to /v1/artifacts (raw body) with your bearer token — zero tokens through this call.",
+            "The complete content for a SINGLE-FILE artifact (HTML or Markdown). Use this OR `files`, not both. To embed an image OR a web font CHEAPLY (no base64 in this call), call stage_asset for a short-lived upload URL and curl the raw bytes to it (PNG/JPEG/GIF/WebP/WOFF/WOFF2) — the response's `url` is a permanent public link; paste it into an `<img src>`, a CSS `url()`, or markdown `![]()`. Never inline a base64 data: URI here — it tokenizes at roughly 1 token/char (one modest screenshot can cost 100k+ tokens), and content carried through your context can be silently mistranscribed; binaries should travel as bytes. If you have shell access and the file is large, you can also POST it directly to /v1/artifacts (raw body) with your bearer token — zero tokens through this call.",
           ),
         files: z
           .record(z.string(), z.string())
           .optional()
           .describe(
-            'A MULTI-PAGE bundle as a map of path → content — the whole site. Each value is one of: a text page (plain string); a base64 data: URI for a small inline binary ("shot.png":"data:image/png;base64,iVBORw0K…"); or — PREFERRED for real images — an "asset:<hash>" handle returned by uploading the raw bytes to POST /v1/assets first ("shot.png":"asset:9f86d0818…"). The asset handle keeps the call tiny: stream each screenshot up as raw binary (no base64 transcription), then reference the handles here. Example: {"index.html":"<img src=shot.png>","styles.css":"…","shot.png":"asset:9f86d0818…","logo.png":"data:image/png;base64,iVBORw0K…"}. The root index.html (else the shallowest .html) becomes the entry page; pages reference assets by relative path. Served content-type comes from the file extension, so give binary entries a real extension (.png/.jpg/.webp/.woff2). A plain republish REPLACES the bundle (include every page and asset). Keep each call to a few MB; for many/large images, upload them to /v1/assets and reference the handles (or publish pages first, then `merge` asset batches). Each published page is also readable directly at /raw/<short_id>/v/<n>/<path> once live.',
+            'A MULTI-PAGE bundle as a map of path → content — the whole site. Each value is one of: a text page (plain string); a base64 data: URI for a small inline binary ("shot.png":"data:image/png;base64,iVBORw0K…"); or — PREFERRED for real images — an "asset:<hash>" handle: call stage_asset for an upload URL, curl the raw bytes to it, and use the returned `ref` here ("shot.png":"asset:9f86d0818…"). The asset handle keeps the call tiny: stream each screenshot up as raw binary (no base64 transcription), then reference the handles here. Example: {"index.html":"<img src=shot.png>","styles.css":"…","shot.png":"asset:9f86d0818…","logo.png":"data:image/png;base64,iVBORw0K…"}. The root index.html (else the shallowest .html) becomes the entry page; pages reference assets by relative path. Served content-type comes from the file extension, so give binary entries a real extension (.png/.jpg/.webp/.woff2). A plain republish REPLACES the bundle (include every page and asset). Keep each call to a few MB; for many/large images, stage them as assets and reference the handles (or publish pages first, then `merge` asset batches). Each published page is also readable directly at /raw/<short_id>/v/<n>/<path> once live.',
           ),
         title: z
           .string()

--- a/apps/api/src/previews.ts
+++ b/apps/api/src/previews.ts
@@ -221,8 +221,10 @@ export const runRenderTick = async (
         Date.now() + CLAIM_LEASE_MS,
       )
 
+      // The token rides as a path segment (not `?pv=`) so a bundle's relative asset
+      // references inherit it — see the `/pv/:pv/` route in routes/raw.ts.
       const origin = deps.sandboxOrigin ?? deps.baseUrl
-      const url = `${origin}/raw/${artifact.short_id}/v/${job.version_n}/index.html?pv=${pv}`
+      const url = `${origin}/raw/${artifact.short_id}/v/${job.version_n}/pv/${pv}/index.html`
 
       // Screenshot with a timeout guard so a hung browser can't wedge the loop
       const png = await withTimeout(
@@ -269,7 +271,7 @@ export const runRenderTick = async (
         fullPage: true,
         timeoutMs: RENDER_TIMEOUT_MS,
       })
-      await renderPreviewVariant(deps, artifact.id, job.version_n, "marked", `${url}&marks=1`, {
+      await renderPreviewVariant(deps, artifact.id, job.version_n, "marked", `${url}?marks=1`, {
         width: OG_W,
         height: OG_H,
         fullPage: true,

--- a/apps/api/src/routes/assets.ts
+++ b/apps/api/src/routes/assets.ts
@@ -1,8 +1,11 @@
+import { roleAllows } from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import type { Context } from "hono"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
 import { bail, fail } from "../lib/http"
 import { MAX_ASSET_BYTES, sniffAssetType } from "../lib/image"
+import { verifyUploadToken } from "../lib/upload-token"
 
 const EXT_FOR_TYPE: Record<string, string> = {
   "image/png": "png",
@@ -55,6 +58,51 @@ export const assetRoutes = (ctx: AppContext) => {
     })
     .openapi("AssetRef")
 
+  // The storage half, shared by both entry points below once the caller has proven
+  // a workspace: read the body, sniff, quota-check, store. Returns the handle payload
+  // (each route c.json()s it under its own typed context) or an error Response.
+  const storeAsset = async (c: Context, org: string) => {
+    const declared = Number(c.req.header("content-length") ?? 0)
+    if (declared > MAX_ASSET_BYTES + 4096) return fail(c, 413, "asset too large (max 25MB)")
+
+    // Accept either a multipart `file` field (browsers, the CLI's FormData) or a raw
+    // binary body (curl --data-binary @shot.png), so an agent can stream bytes the
+    // simplest way it has.
+    const contentType = c.req.header("content-type") ?? ""
+    let bytes: Uint8Array
+    if (contentType.includes("multipart/form-data")) {
+      const file = (await c.req.parseBody()).file
+      if (!(file instanceof File)) return fail(c, 400, "multipart field 'file' required")
+      bytes = new Uint8Array(await file.arrayBuffer())
+    } else {
+      bytes = new Uint8Array(await c.req.arrayBuffer())
+    }
+
+    if (bytes.byteLength === 0) return fail(c, 400, "empty asset body")
+    if (bytes.byteLength > MAX_ASSET_BYTES) return fail(c, 413, "asset too large (max 25MB)")
+
+    // Trust the bytes, not the declared type — and only store non-executable formats:
+    // plain raster images and packaged web fonts (no SVG/HTML: served from our origin
+    // they could carry script).
+    const type = sniffAssetType(bytes)
+    if (!type) return fail(c, 400, "unsupported asset (use PNG, JPEG, GIF, WebP, or WOFF/WOFF2)")
+
+    if (await overStorage(org, bytes.byteLength)) return fail(c, 413, "storage quota exceeded")
+
+    const key = await blobs.put(bytes)
+    // Content-addressed row: this is the allowlist that makes GET /blob/:hash
+    // servable at all (the blob store also holds manifests/HTML the route must
+    // never serve) — see routes/blob.ts. A re-upload of the same bytes is a no-op.
+    await meta.createAsset({
+      hash: key,
+      org_id: org,
+      content_type: type,
+      size_bytes: bytes.byteLength,
+    })
+    const url = `${deps.baseUrl.replace(/\/$/, "")}/blob/${key}.${EXT_FOR_TYPE[type]}`
+    return { key, url, ref: `asset:${key}`, type, size: bytes.byteLength }
+  }
+
   app.openapi(
     createRoute({
       method: "post",
@@ -74,49 +122,50 @@ export const assetRoutes = (ctx: AppContext) => {
       // anonymous write-lockdown already blocks unauthenticated POSTs.)
       const org = await requireWorkspace(c, "publish")
       if (org instanceof Response) return bail(org)
+      const r = await storeAsset(c, org)
+      return r instanceof Response ? bail(r) : c.json(r)
+    },
+  )
 
-      const declared = Number(c.req.header("content-length") ?? 0)
-      if (declared > MAX_ASSET_BYTES + 4096) return bail(fail(c, 413, "asset too large (max 25MB)"))
-
-      // Accept either a multipart `file` field (browsers, the CLI's FormData) or a raw
-      // binary body (curl --data-binary @shot.png), so an agent can stream bytes the
-      // simplest way it has.
-      const contentType = c.req.header("content-type") ?? ""
-      let bytes: Uint8Array
-      if (contentType.includes("multipart/form-data")) {
-        const file = (await c.req.parseBody()).file
-        if (!(file instanceof File)) return bail(fail(c, 400, "multipart field 'file' required"))
-        bytes = new Uint8Array(await file.arrayBuffer())
-      } else {
-        bytes = new Uint8Array(await c.req.arrayBuffer())
+  // The tokened entry point: same upload, but the proof of workspace is a
+  // short-lived signed capability in the path instead of a session/bearer. Minted
+  // by the MCP `stage_asset` tool for agents whose only credential lives inside
+  // the MCP transport (hosted OAuth) — their shell can curl this URL with raw
+  // bytes, keeping binaries out of the model's context. The token is
+  // workspace-scoped and expiring; what it can write is bounded exactly like the
+  // authed route above (sniffed formats, size cap, storage quota).
+  app.openapi(
+    createRoute({
+      method: "post",
+      path: "/v1/assets/t/{token}",
+      tags: ["Assets"],
+      summary: "Stage a binary asset with a short-lived upload token (minted over MCP).",
+      request: { params: z.object({ token: z.string() }) },
+      responses: {
+        200: {
+          description: "The stored asset's public URL and content-addressed handle.",
+          content: { "application/json": { schema: AssetRef } },
+        },
+      },
+    }),
+    async (c) => {
+      const secret = deps.encryptionKey
+      const claim = secret
+        ? await verifyUploadToken(secret, c.req.param("token"), Date.now())
+        : null
+      if (!claim) return bail(fail(c, 403, "invalid or expired upload token"))
+      // The token names the user whose grant minted it; re-check their LIVE
+      // membership so revocation works mid-TTL — demote or remove the person and
+      // their outstanding upload URLs die with the next request, exactly like the
+      // per-request role check on the authed route above. (Empty = an ownerless
+      // legacy agent; the mint-time role check is all there is for those.)
+      if (claim.userId) {
+        const m = await meta.getMembership(claim.orgId, claim.userId)
+        if (!m || !roleAllows(m.role, "publish"))
+          return bail(fail(c, 403, "invalid or expired upload token"))
       }
-
-      if (bytes.byteLength === 0) return bail(fail(c, 400, "empty asset body"))
-      if (bytes.byteLength > MAX_ASSET_BYTES)
-        return bail(fail(c, 413, "asset too large (max 25MB)"))
-
-      // Trust the bytes, not the declared type — and only store non-executable formats:
-      // plain raster images and packaged web fonts (no SVG/HTML: served from our origin
-      // they could carry script).
-      const type = sniffAssetType(bytes)
-      if (!type)
-        return bail(fail(c, 400, "unsupported asset (use PNG, JPEG, GIF, WebP, or WOFF/WOFF2)"))
-
-      if (await overStorage(org, bytes.byteLength))
-        return bail(fail(c, 413, "storage quota exceeded"))
-
-      const key = await blobs.put(bytes)
-      // Content-addressed row: this is the allowlist that makes GET /blob/:hash
-      // servable at all (the blob store also holds manifests/HTML the route must
-      // never serve) — see routes/blob.ts. A re-upload of the same bytes is a no-op.
-      await meta.createAsset({
-        hash: key,
-        org_id: org,
-        content_type: type,
-        size_bytes: bytes.byteLength,
-      })
-      const url = `${deps.baseUrl.replace(/\/$/, "")}/blob/${key}.${EXT_FOR_TYPE[type]}`
-      return c.json({ key, url, ref: `asset:${key}`, type, size: bytes.byteLength })
+      const r = await storeAsset(c, claim.orgId)
+      return r instanceof Response ? bail(r) : c.json(r)
     },
   )
 

--- a/apps/api/src/routes/raw.ts
+++ b/apps/api/src/routes/raw.ts
@@ -92,30 +92,46 @@ export const rawRoutes = (ctx: AppContext) => {
     )
   })
 
+  // The screenshot renderer's entry point: the short-lived preview token minted in
+  // previews.ts (read of exactly one artifact+version, never anything wider) rides as
+  // a PATH segment for the same reason the viewer's `/t/:token/` above does. It used
+  // to arrive as `?pv=` on the plain route below — which authorized the page itself
+  // but not a bundle's own `<img src="picker.webp">` requests (a relative URL keeps
+  // its base's path, not its query string), so private bundles screenshotted with
+  // every image broken. In the path, the proof of access replays automatically on
+  // each nested asset request. Same registration-order constraint as `/t/:token/`.
+  //
+  // Verify BEFORE anything else, and fall through (next()) when the segment isn't a
+  // valid token: this route pattern would otherwise reserve the `pv/` name inside
+  // every artifact — a bundle's own literal `pv/chart.png` would match here, get its
+  // path sliced against the wrong prefix, and 404 for a fully authorized viewer.
+  // A segment that HMAC-verifies can't be a coincidental filename, so a valid token
+  // (even for the wrong artifact — someone replaying it) owns the request, and
+  // everything else is a real file path for the plain route below to serve under
+  // its normal cookie authorization.
+  app.get("/raw/:shortId/v/:n/pv/:pv/*", async (c, next) => {
+    const secret = deps.encryptionKey
+    const claim = secret ? await verifyPreviewToken(secret, c.req.param("pv"), Date.now()) : null
+    if (!claim) return next()
+    const shortId = c.req.param("shortId")
+    const n = Number(c.req.param("n"))
+    const artifact = await meta.getByShortId(shortId)
+    if (!artifact || !Number.isInteger(n)) return c.text("not found", 404)
+    if (claim.artifactId !== artifact.id || claim.n !== n) return c.text("not found", 404)
+    return serveVersion(
+      c,
+      artifact,
+      n,
+      `/raw/${shortId}/v/${c.req.param("n")}/pv/${c.req.param("pv")}/`,
+    )
+  })
+
   app.get("/raw/:shortId/v/:n/*", async (c) => {
     const shortId = c.req.param("shortId")
     const n = Number(c.req.param("n"))
     const artifact = await meta.getByShortId(shortId)
     if (!artifact || !Number.isInteger(n)) return c.text("not found", 404)
-
-    // Preview-access token: a short-lived HMAC token minted by the screenshot
-    // renderer so it can load private/gated artifacts without a session. Grants
-    // read of exactly one artifact+version; never widens anything else.
-    const pv = c.req.query("pv")
-    const secret = deps.encryptionKey
-    let pvAuthorized = false
-    if (pv && secret) {
-      try {
-        const claim = await verifyPreviewToken(secret, pv, Date.now())
-        if (claim && claim.artifactId === artifact.id && claim.n === n) {
-          pvAuthorized = true
-        }
-      } catch {
-        // Malformed token — fall through to normal authorize
-      }
-    }
-
-    if (!pvAuthorized && !(await authorize(c, "read", artifact))) return c.text("not found", 404)
+    if (!(await authorize(c, "read", artifact))) return c.text("not found", 404)
     return serveVersion(c, artifact, n, `/raw/${shortId}/v/${c.req.param("n")}/`)
   })
 

--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -1,5 +1,4 @@
-import { randomUUID } from "node:crypto"
-import { type InvitationRecord, newId, type Role } from "@derive/core"
+import { newId, type Role } from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"

--- a/apps/api/test/assets.test.ts
+++ b/apps/api/test/assets.test.ts
@@ -1,17 +1,17 @@
+import { randomUUID } from "node:crypto"
 import { join } from "node:path"
+import { SqliteMetaStore } from "@derive/db/sqlite"
 import { FsBlobStore } from "@derive/storage/fs"
-import { describe, expect, it } from "vitest"
+import { afterAll, describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { signUploadToken } from "../src/lib/upload-token"
+import { PNG_BYTES } from "./fixtures"
 import { anonApp, app, dir } from "./helpers"
 
 // POST /v1/assets is the "images without base64" path: an agent streams the raw bytes
 // of a screenshot up as binary (no transcription), gets back a content-addressed
 // `asset:<hash>` handle, and references that handle in a `publish` files map — where
 // decodeBundleFiles resolves it back to these exact bytes (see bundle-assets.test.ts).
-
-// A real 1x1 transparent PNG.
-const PNG_B64 =
-  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-const PNG_BYTES = new Uint8Array(Buffer.from(PNG_B64, "base64"))
 
 const postAsset = (body: BodyInit, contentType?: string) =>
   app.request("/v1/assets", {
@@ -83,6 +83,110 @@ describe("POST /v1/assets", () => {
 
   it("is closed to anonymous callers (the write-lockdown)", async () => {
     const res = await anonApp.request("/v1/assets", {
+      method: "POST",
+      headers: { "content-type": "image/png" },
+      body: PNG_BYTES,
+    })
+    expect(res.status).toBe(403)
+  })
+})
+
+// The tokened entry point: a short-lived signed capability (minted by the MCP
+// stage_asset tool) takes the place of the session/bearer, so an agent whose only
+// credential lives inside the MCP transport can still stream raw bytes from its
+// shell. Requests here are deliberately UNAUTHENTICATED — the token is the proof.
+describe("POST /v1/assets/t/:token (MCP-minted upload URL)", () => {
+  const UPLOAD_SECRET = "test-upload-secret-long-enough"
+  const tokMeta = new SqliteMetaStore(join(dir, "upload-token.db"))
+  const tokApp = createApp({
+    meta: tokMeta,
+    blobs: new FsBlobStore(join(dir, "upload-token-blobs")),
+    baseUrl: "http://derive.test",
+    token: "tok",
+    encryptionKey: UPLOAD_SECRET,
+  })
+  afterAll(() => tokMeta.close())
+
+  const postTokened = (token: string, body: BodyInit) =>
+    tokApp.request(`/v1/assets/t/${token}`, {
+      method: "POST",
+      headers: { "content-type": "image/png" },
+      body,
+    })
+
+  // An unbound token (empty principal — what an ownerless legacy agent mints):
+  // no membership re-check, the mint-time role check was all there is.
+  const unbound = (exp: number) => signUploadToken(UPLOAD_SECRET, "default", "", exp)
+
+  it("a valid token stages bytes with no auth header and returns the same handle shape", async () => {
+    const tok = await unbound(Date.now() + 60_000)
+    const res = await postTokened(tok, PNG_BYTES)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.type).toBe("image/png")
+    expect(body.ref).toBe(`asset:${body.key}`)
+    expect(body.url).toBe(`http://derive.test/blob/${body.key}.png`)
+
+    // The permanent URL serves the exact bytes back — same as the authed route.
+    const served = await tokApp.request(new URL(body.url).pathname)
+    expect(served.status).toBe(200)
+    expect(new Uint8Array(await served.arrayBuffer())).toEqual(PNG_BYTES)
+  })
+
+  it("the token is reusable until expiry (one mint stages a batch)", async () => {
+    const tok = await unbound(Date.now() + 60_000)
+    const woff2 = new Uint8Array([0x77, 0x4f, 0x46, 0x32, 0, 1, 2, 3, 4, 5])
+    expect((await postTokened(tok, PNG_BYTES)).status).toBe(200)
+    expect((await postTokened(tok, woff2)).status).toBe(200)
+  })
+
+  it("an expired token → 403", async () => {
+    const tok = await unbound(Date.now() - 1_000)
+    expect((await postTokened(tok, PNG_BYTES)).status).toBe(403)
+  })
+
+  it("a garbage token → 403", async () => {
+    expect((await postTokened("garbage", PNG_BYTES)).status).toBe(403)
+  })
+
+  it("a user-bound token dies with the user's publish rights (revocation mid-TTL)", async () => {
+    // Bind a token to a member who can publish; it works. Demote them to
+    // commenter and the SAME still-unexpired token is refused on the next
+    // request — capability URLs must not outlive the grant that minted them.
+    const uid = "u_upload"
+    await tokMeta.setMembership({
+      id: randomUUID(),
+      org_id: "default",
+      user_id: uid,
+      role: "editor",
+    })
+    const tok = await signUploadToken(UPLOAD_SECRET, "default", uid, Date.now() + 60_000)
+    expect((await postTokened(tok, PNG_BYTES)).status).toBe(200)
+
+    await tokMeta.setMembership({
+      id: randomUUID(),
+      org_id: "default",
+      user_id: uid,
+      role: "commenter",
+    })
+    expect((await postTokened(tok, PNG_BYTES)).status).toBe(403)
+  })
+
+  it("a token bound to a non-member → 403", async () => {
+    const tok = await signUploadToken(UPLOAD_SECRET, "default", "u_ghost", Date.now() + 60_000)
+    expect((await postTokened(tok, PNG_BYTES)).status).toBe(403)
+  })
+
+  it("still sniffs the bytes — a valid token can't stage a non-asset format", async () => {
+    const tok = await unbound(Date.now() + 60_000)
+    const res = await postTokened(tok, new TextEncoder().encode("<svg>not raster</svg>"))
+    expect(res.status).toBe(400)
+  })
+
+  it("fails closed on a server with no signing secret", async () => {
+    // The shared helper app has no encryptionKey; even a well-formed token is 403.
+    const tok = await unbound(Date.now() + 60_000)
+    const res = await anonApp.request(`/v1/assets/t/${tok}`, {
       method: "POST",
       headers: { "content-type": "image/png" },
       body: PNG_BYTES,

--- a/apps/api/test/bundle-assets.test.ts
+++ b/apps/api/test/bundle-assets.test.ts
@@ -7,6 +7,7 @@ import { FsBlobStore } from "@derive/storage/fs"
 import { unzipSync } from "fflate"
 import { afterAll, describe, expect, it } from "vitest"
 import { manifestOf, mergeBundleZip, zipBundleFiles } from "../src/lib/bundle"
+import { PNG_B64, PNG_BYTES, PNG_SIGNATURE } from "./fixtures"
 
 // MCP `publish` builds its bundle zip from a {path: content} map. Pages are text,
 // but a real site also has images, fonts, etc. — binary that UTF-8 encoding would
@@ -17,12 +18,6 @@ import { manifestOf, mergeBundleZip, zipBundleFiles } from "../src/lib/bundle"
 
 const dir = mkdtempSync(join(tmpdir(), "derive-bundle-assets-"))
 afterAll(() => rmSync(dir, { recursive: true, force: true }))
-
-// A real 1x1 transparent PNG (starts with the 8-byte PNG signature).
-const PNG_B64 =
-  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-const PNG_BYTES = new Uint8Array(Buffer.from(PNG_B64, "base64"))
-const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
 
 describe("zipBundleFiles carries binary assets, not just text", () => {
   it("decodes a base64 data: URI to raw bytes and keeps text pages as UTF-8", async () => {

--- a/apps/api/test/fixtures.ts
+++ b/apps/api/test/fixtures.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared binary test fixtures — import these instead of pasting base64 blobs, so
+ * every test provably exercises the SAME bytes (fixture drift between copies is
+ * invisible in a diff of base64 strings).
+ */
+
+/** A real 1x1 transparent PNG: small enough to inline, real enough to pass
+ *  sniffAssetType's magic-byte check and round-trip through the asset pipeline. */
+export const PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+export const PNG_BYTES = new Uint8Array(Buffer.from(PNG_B64, "base64"))
+
+/** The 8-byte PNG file signature, for asserting stored bytes are a real PNG. */
+export const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -17,6 +17,7 @@ import {
   searchWorkspace,
   versionIndexText,
 } from "../src/lib/search"
+import { PNG_BYTES } from "./fixtures"
 
 // The remote MCP endpoint (/mcp) authenticated by an OAuth bearer. We seed a grant
 // straight into the oauth-provider tables (what the consent dance produces), publish
@@ -172,6 +173,7 @@ describe("remote MCP endpoint (/mcp)", () => {
       "publish",
       "read",
       "search",
+      "stage_asset",
     ])
     // Consolidated away — folded into catch_up / comment / publish.
     for (const gone of [
@@ -185,6 +187,39 @@ describe("remote MCP endpoint (/mcp)", () => {
       "read_section",
     ])
       expect(names).not.toContain(gone)
+  })
+
+  it("stage_asset mints an upload URL an anonymous shell can spend (the pasted-screenshot path)", async () => {
+    // The whole point: the OAuth credential lives inside the MCP transport, so the
+    // agent's shell has no bearer — the minted URL must work with NO auth header.
+    const { app, token } = appWithGrant("stageasset", "openid derive:read derive:publish", {
+      encryptionKey: "mcp-upload-secret",
+    })
+    const staged = JSON.parse(toolText(await call(app, token, "stage_asset")))
+    expect(staged.upload_url).toContain("/v1/assets/t/")
+    expect(staged.max_bytes).toBeGreaterThan(0)
+
+    // A real 1x1 transparent PNG — what `curl --data-binary @shot.png` would send.
+    const png = PNG_BYTES
+    const up = await app.request(new URL(staged.upload_url).pathname, {
+      method: "POST",
+      headers: { "content-type": "image/png" },
+      body: png,
+    })
+    expect(up.status).toBe(200)
+    const asset = await up.json()
+    expect(asset.ref).toBe(`asset:${asset.key}`)
+
+    // The permanent public URL serves the exact bytes back.
+    const served = await app.request(new URL(asset.url).pathname)
+    expect(served.status).toBe(200)
+    expect(new Uint8Array(await served.arrayBuffer())).toEqual(png)
+  })
+
+  it("stage_asset fails actionably when no signing secret is configured", async () => {
+    const { app, token } = appWithGrant("stagenosecret", "openid derive:read derive:publish")
+    const r = await call(app, token, "stage_asset")
+    expect(toolText(r)).toContain("bearer token")
   })
 
   it("exposes the workspace's Brandprint as resources + an instructions pointer", async () => {

--- a/apps/api/test/preview-token.test.ts
+++ b/apps/api/test/preview-token.test.ts
@@ -1,12 +1,14 @@
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { newId } from "@derive/core"
+import { newId, publish } from "@derive/core"
 import { SqliteMetaStore } from "@derive/db/sqlite"
 import { FsBlobStore } from "@derive/storage/fs"
 import { afterAll, describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
+import { zipBundleFiles } from "../src/lib/bundle"
 import { signPreviewToken, verifyPreviewToken } from "../src/lib/preview-token"
+import { PNG_B64, PNG_SIGNATURE } from "./fixtures"
 
 // ---- Unit tests: token sign/verify -----------------------------------------
 
@@ -55,7 +57,7 @@ describe("preview token", () => {
   })
 })
 
-// ---- Route tests: /raw with ?pv= token -------------------------------------
+// ---- Route tests: /raw with a /pv/<token>/ path segment ---------------------
 
 const dir = mkdtempSync(join(tmpdir(), "derive-pvtest-"))
 const meta = new SqliteMetaStore(join(dir, "pv.db"))
@@ -78,7 +80,7 @@ afterAll(() => {
 
 const enc = (s: string) => new TextEncoder().encode(s)
 
-describe("raw route: preview-access token (?pv=)", () => {
+describe("raw route: preview-access token (/pv/<token>/ path segment)", () => {
   let shortId: string
   let artifactId: string
 
@@ -108,60 +110,147 @@ describe("raw route: preview-access token (?pv=)", () => {
     artifactId = a.id
   })
 
-  it("anonymous GET /raw without pv= → 404", async () => {
+  it("anonymous GET /raw without a token → 404", async () => {
     const res = await app.request(`/raw/${shortId}/v/1/index.html`)
     expect(res.status).toBe(404)
   })
 
-  it("anonymous GET /raw with a valid pv= → 200", async () => {
+  it("anonymous GET /raw with a valid /pv/ token → 200", async () => {
     const exp = Date.now() + 60_000
     const tok = await signPreviewToken(TEST_SECRET, artifactId, 1, exp)
-    const res = await app.request(`/raw/${shortId}/v/1/index.html?pv=${tok}`)
+    const res = await app.request(`/raw/${shortId}/v/1/pv/${tok}/index.html`)
     expect(res.status).toBe(200)
     const body = await res.text()
     expect(body).toContain("Private Content")
   })
 
-  it("anonymous GET /raw with an expired pv= → 404", async () => {
-    const exp = Date.now() - 1_000 // already expired
+  it("the legacy ?pv= query form no longer grants access → 404", async () => {
+    // The token moved into the path so a bundle's relative asset references
+    // inherit it; the query form is gone, not just deprecated.
+    const exp = Date.now() + 60_000
     const tok = await signPreviewToken(TEST_SECRET, artifactId, 1, exp)
     const res = await app.request(`/raw/${shortId}/v/1/index.html?pv=${tok}`)
     expect(res.status).toBe(404)
   })
 
-  it("anonymous GET /raw with garbage pv= → 404", async () => {
-    const res = await app.request(`/raw/${shortId}/v/1/index.html?pv=garbage`)
+  it("anonymous GET /raw with an expired /pv/ token → 404", async () => {
+    const exp = Date.now() - 1_000 // already expired
+    const tok = await signPreviewToken(TEST_SECRET, artifactId, 1, exp)
+    const res = await app.request(`/raw/${shortId}/v/1/pv/${tok}/index.html`)
     expect(res.status).toBe(404)
   })
 
-  it("pv= for the right artifact but wrong version → 404", async () => {
+  it("anonymous GET /raw with a garbage /pv/ token → 404", async () => {
+    const res = await app.request(`/raw/${shortId}/v/1/pv/garbage/index.html`)
+    expect(res.status).toBe(404)
+  })
+
+  it("/pv/ token for the right artifact but wrong version → 404", async () => {
     const exp = Date.now() + 60_000
     // Token for version 2 (which doesn't exist), but we're requesting version 1
     const tok = await signPreviewToken(TEST_SECRET, artifactId, 2, exp)
-    const res = await app.request(`/raw/${shortId}/v/1/index.html?pv=${tok}`)
+    const res = await app.request(`/raw/${shortId}/v/1/pv/${tok}/index.html`)
     // Version 2 doesn't exist in meta, so 404 is expected either way
     // But this also tests that version scoping is enforced
     expect(res.status).toBe(404)
   })
 
-  it("pv= for a different artifact → 404", async () => {
+  it("/pv/ token for a different artifact → 404", async () => {
     const exp = Date.now() + 60_000
     // Token signed for a different artifact id
     const tok = await signPreviewToken(TEST_SECRET, "different-artifact-id", 1, exp)
-    const res = await app.request(`/raw/${shortId}/v/1/index.html?pv=${tok}`)
+    const res = await app.request(`/raw/${shortId}/v/1/pv/${tok}/index.html`)
     expect(res.status).toBe(404)
   })
 
-  it("pv= does not apply to the proposal route (nonexistent proposal)", async () => {
+  it("a private bundle's sub-assets load through the /pv/ page URL (the renderer's broken-image regression)", async () => {
+    // The bug: the renderer used to load `index.html?pv=<token>` — the page
+    // authorized, but the browser resolves its `<img src="shot.png">` against the
+    // PATH only, dropping the query, so every sub-asset request arrived anonymous
+    // and 404'd. Private bundles screenshotted with broken images. With the token
+    // as a path segment, the asset URL a browser computes from the page URL
+    // carries the same proof of access automatically.
+    const { artifact } = await publish(meta, blobs, {
+      bytes: await zipBundleFiles({
+        "index.html": '<!doctype html><img src="shot.png">',
+        "shot.png": `data:image/png;base64,${PNG_B64}`,
+      }),
+      filename: "site.zip",
+      isBundle: true,
+      title: "Private Bundle",
+      author: "t",
+      orgId: "default",
+      workspaceAccess: "none",
+      linkRole: "none",
+      listed: "none",
+    })
+    const exp = Date.now() + 60_000
+    const tok = await signPreviewToken(TEST_SECRET, artifact.id, 1, exp)
+
+    // The bundle really is private: no token, no asset.
+    const anon = await app.request(`/raw/${artifact.short_id}/v/1/shot.png`)
+    expect(anon.status).toBe(404)
+
+    // The page loads at the /pv/ URL...
+    const page = await app.request(`/raw/${artifact.short_id}/v/1/pv/${tok}/index.html`)
+    expect(page.status).toBe(200)
+
+    // ...and the sub-asset URL a browser derives from it (relative resolution
+    // keeps the /pv/<token>/ path prefix) serves the actual PNG bytes.
+    const img = await app.request(`/raw/${artifact.short_id}/v/1/pv/${tok}/shot.png`)
+    expect(img.status).toBe(200)
+    const bytes = new Uint8Array(await img.arrayBuffer())
+    expect(Array.from(bytes.slice(0, 8))).toEqual(PNG_SIGNATURE)
+  })
+
+  it("a bundle's own literal pv/ directory still serves — an invalid segment falls through, it is not a reserved name", async () => {
+    // The route pattern /v/:n/pv/:pv/* would otherwise swallow a bundle's real
+    // pv/chart.png (segment consumed as a "token", remainder sliced against the
+    // wrong prefix → 404 for a fully authorized viewer). The handler verifies
+    // FIRST and next()s to the plain route when the segment isn't a real token.
+    const { artifact } = await publish(meta, blobs, {
+      bytes: await zipBundleFiles({
+        "index.html": '<!doctype html><img src="pv/chart.png">',
+        "pv/chart.png": `data:image/png;base64,${PNG_B64}`,
+        "pv/deep/nested.png": `data:image/png;base64,${PNG_B64}`,
+      }),
+      filename: "site.zip",
+      isBundle: true,
+      title: "Bundle With pv Dir",
+      author: "t",
+      orgId: "default",
+      workspaceAccess: "none",
+      linkRole: "none",
+      listed: "none",
+    })
+
+    // An authorized viewer (the owner token) gets the real files under pv/.
+    const authed = (p: string) =>
+      app.request(`/raw/${artifact.short_id}/v/1/${p}`, {
+        headers: { authorization: "Bearer tok" },
+      })
+    const img = await authed("pv/chart.png")
+    expect(img.status).toBe(200)
+    const bytes = new Uint8Array(await img.arrayBuffer())
+    expect(Array.from(bytes.slice(0, 8))).toEqual(PNG_SIGNATURE)
+    // Deeper nesting under pv/ (the "token" segment would have been a directory).
+    expect((await authed("pv/deep/nested.png")).status).toBe(200)
+
+    // The fallthrough grants nothing: anonymous still can't read the private file.
+    const anon = await app.request(`/raw/${artifact.short_id}/v/1/pv/chart.png`)
+    expect(anon.status).toBe(404)
+  })
+
+  it("the pv token does not apply to the proposal route (nonexistent proposal)", async () => {
     const exp = Date.now() + 60_000
     const tok = await signPreviewToken(TEST_SECRET, artifactId, 1, exp)
-    // The proposal route should not be affected by ?pv=
+    // There is no /pv/ segment on the proposal route; a stray query token is inert.
     const res = await app.request(`/raw/${shortId}/p/nonexistent-proposal/?pv=${tok}`)
-    // Should 404 because the proposal doesn't exist (not because pv= granted access)
+    // Should 404 because the proposal doesn't exist (not because pv granted access)
     expect(res.status).toBe(404)
   })
 
-  it("pv= does NOT bypass the proposal route for a real proposal on a private artifact", async () => {
+  it("the pv token does NOT bypass the proposal route for a real proposal on a private artifact", async () => {
     // Create a proposal on the private artifact (using the owner token)
     const propForm = new FormData()
     propForm.append("file", new Blob([new TextEncoder().encode("<h1>proposed</h1>")]), "f.html")
@@ -179,8 +268,8 @@ describe("raw route: preview-access token (?pv=)", () => {
 
     // Anonymous GET to the proposal raw route WITH the pv token — must NOT be authorized
     const res = await app.request(`/raw/${shortId}/p/${proposal.id}/index.html?pv=${tok}`)
-    // The pv bypass only applies to /v/:n/*, not /p/:proposalId/*; anonymous reads
-    // of a private artifact's proposals are rejected (404 — existence never leaks)
+    // The pv grant only exists on /v/:n/pv/:pv/*, not /p/:proposalId/*; anonymous
+    // reads of a private artifact's proposals are rejected (404 — existence never leaks)
     expect(res.status).toBe(404)
   })
 })

--- a/apps/api/test/previews.test.ts
+++ b/apps/api/test/previews.test.ts
@@ -337,8 +337,8 @@ describe("previews: enqueueRender + runRenderTick", () => {
     // URL contains the raw route with shortId
     expect(seen[0]).toContain("/raw/")
     expect(seen[0]).toContain("short1")
-    // URL contains the preview token query param
-    expect(seen[0]).toContain("?pv=")
+    // The preview token rides as a path segment so bundle sub-assets inherit it
+    expect(seen[0]).toContain("/pv/")
     // Version is now ready
     expect(fakes.versions.get("a1:1")?.preview_status).toBe("ready")
     expect(fakes.versions.get("a1:1")?.preview_key).toBeTruthy()
@@ -378,7 +378,7 @@ describe("previews: enqueueRender + runRenderTick", () => {
     expect(og?.opts?.fullPage).toBeFalsy()
     expect(full?.url).toBe(og?.url) // same page, just fullPage:true
     expect(full?.opts?.fullPage).toBe(true)
-    expect(marked?.url).toBe(`${og?.url}&marks=1`)
+    expect(marked?.url).toBe(`${og?.url}?marks=1`)
     expect(marked?.opts?.fullPage).toBe(true)
 
     const v = fakes.versions.get("a1v:1")

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -1595,6 +1595,44 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/assets/t/{token}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Stage a binary asset with a short-lived upload token (minted over MCP). */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    token: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The stored asset's public URL and content-addressed handle. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AssetRef"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/artifacts/{shortId}/members": {
         parameters: {
             query?: never;

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -226,179 +226,177 @@ export function MobileComments({
     if (head.anchor) tree.onJump(head.thread_id)
   }
   return (
-    <>
-      <aside
-        ref={sheetRef}
-        className={cn(
-          // The slide rides the `translate` property (translate-y-full/0), so the
-          // transition MUST target `translate` — not `transform` — or the sheet jumps
-          // in and out instead of sliding. Height changes snap (auto isn't
-          // animatable); the drag handlers suspend/restore this transition inline.
-          "fixed inset-x-0 bottom-0 z-61 flex flex-col rounded-t-2xl border-t border-border bg-card shadow-[var(--shadow-pop)] transition-[translate] duration-200 ease-out",
-          // Heights are CONTENT-WEIGHTED: composing is a compact bar above the
-          // keyboard; expanded hugs its comments up to half the screen (the doc
-          // strip above stays visible and live — no reading mode that owns the
-          // whole screen); peek is a slim bar, one line taller with a preview.
-          composer ? "max-h-[80vh]" : size === "full" ? "max-h-[50vh]" : latest ? "h-24" : "h-18.5",
-          open ? "translate-y-0" : "translate-y-full",
-        )}
-        // While the keyboard is up, lift the sheet's bottom to just above it and cap
-        // its height to the visible band — so the half-height composer sits in view
-        // (with a sliver of document above) instead of behind/under the keyboard.
-        style={kb ? { bottom: kb.inset, maxHeight: kb.height } : undefined}
-        // Non-modal by design: the document above stays visible and interactive in
-        // every state, so this is an aside, not a dialog (no focus trap, no scrim).
-        aria-label="Comments"
+    <aside
+      ref={sheetRef}
+      className={cn(
+        // The slide rides the `translate` property (translate-y-full/0), so the
+        // transition MUST target `translate` — not `transform` — or the sheet jumps
+        // in and out instead of sliding. Height changes snap (auto isn't
+        // animatable); the drag handlers suspend/restore this transition inline.
+        "fixed inset-x-0 bottom-0 z-61 flex flex-col rounded-t-2xl border-t border-border bg-card shadow-[var(--shadow-pop)] transition-[translate] duration-200 ease-out",
+        // Heights are CONTENT-WEIGHTED: composing is a compact bar above the
+        // keyboard; expanded hugs its comments up to half the screen (the doc
+        // strip above stays visible and live — no reading mode that owns the
+        // whole screen); peek is a slim bar, one line taller with a preview.
+        composer ? "max-h-[80vh]" : size === "full" ? "max-h-[50vh]" : latest ? "h-24" : "h-18.5",
+        open ? "translate-y-0" : "translate-y-full",
+      )}
+      // While the keyboard is up, lift the sheet's bottom to just above it and cap
+      // its height to the visible band — so the half-height composer sits in view
+      // (with a sliver of document above) instead of behind/under the keyboard.
+      style={kb ? { bottom: kb.inset, maxHeight: kb.height } : undefined}
+      // Non-modal by design: the document above stays visible and interactive in
+      // every state, so this is an aside, not a dialog (no focus trap, no scrim).
+      aria-label="Comments"
+    >
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: the grip/header strip is a drag handle (pointer events) with tap-to-toggle; the real controls inside are buttons. */}
+      <div
+        className="shrink-0 touch-none"
+        onPointerDown={dragStart}
+        onPointerMove={dragMove}
+        onPointerUp={dragEnd}
+        onPointerCancel={dragEnd}
       >
-        {/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: the grip/header strip is a drag handle (pointer events) with tap-to-toggle; the real controls inside are buttons. */}
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: grip toggles the sheet size; keyboard users have the labeled caret button below. */}
         <div
-          className="shrink-0 touch-none"
-          onPointerDown={dragStart}
-          onPointerMove={dragMove}
-          onPointerUp={dragEnd}
-          onPointerCancel={dragEnd}
+          data-testid="comments-sheet-grip"
+          className="flex cursor-grab justify-center pb-1 pt-2"
+          onClick={grip}
+          title="Resize"
         >
-          {/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: grip toggles the sheet size; keyboard users have the labeled caret button below. */}
-          <div
-            data-testid="comments-sheet-grip"
-            className="flex cursor-grab justify-center pb-1 pt-2"
-            onClick={grip}
-            title="Resize"
-          >
-            <div className="h-1 w-10 rounded-full bg-border" />
-          </div>
-          <div className="flex items-center gap-2 border-b border-border-soft pb-3 pl-3 pr-2.5 pt-2">
-            <CommentsHeading count={openThreads.length} />
-            {size === "full" && !composer && openThreads.length > 1 && (
-              // Step through the discussion one thread at a time: the card scrolls
-              // into view and an anchored thread scrolls the doc to its highlight.
-              <div className="flex items-center gap-0.5 font-mono text-xs tabular-nums text-muted-foreground">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  aria-label="Previous comment"
-                  data-testid="comments-step-prev"
-                  onClick={() => stepTo(stepIdx - 1)}
-                >
-                  <Icon name="caret" className="size-4 rotate-90" />
-                </Button>
-                {stepIdx + 1}/{openThreads.length}
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  aria-label="Next comment"
-                  data-testid="comments-step-next"
-                  onClick={() => stepTo(stepIdx + 1)}
-                >
-                  <Icon name="caret" className="size-4 -rotate-90" />
-                </Button>
-              </div>
-            )}
-            {canComment && (
-              <Button
-                variant="outline"
-                size="sm"
-                data-testid="comments-sheet-new"
-                onClick={() => {
-                  setSize("full")
-                  onNewGeneral()
-                }}
-              >
-                <Icon name="plus" size={16} />
-                New
-              </Button>
-            )}
-            <Button
-              variant="ghost"
-              size="icon"
-              aria-label={size === "peek" ? "Expand" : "Collapse"}
-              data-testid="comments-sheet-resize"
-              onClick={() => setSize(size === "peek" ? "full" : "peek")}
-            >
-              <Icon name="caret" className={cn("size-4", size === "peek" && "rotate-180")} />
-            </Button>
-          </div>
+          <div className="h-1 w-10 rounded-full bg-border" />
         </div>
-        {composer ? (
-          // Composing ("half open"): just the composer, so the sheet is a compact bar
-          // pinned above the keyboard with the document visible above. The list
-          // reappears once you send or cancel.
-          <div className="overflow-auto p-3 pb-[max(14px,env(safe-area-inset-bottom))]">
-            <Composer
-              quote={selLabel(composer.anchor)}
-              agent={composer.agent}
-              // After posting, open the full list so the new comment is visible (the
-              // sheet would otherwise drop back to the peek bar and hide it).
-              onSubmit={(text, mentions) => {
-                setSize("full")
-                onSubmitNew(text, mentions)
-              }}
-              onCancel={onCancelNew}
-            />
-          </div>
-        ) : size === "full" ? (
-          <CommentTreeProvider value={sheetTree}>
-            <div className="min-h-0 flex-1 overflow-auto p-3 pb-[max(14px,env(safe-area-inset-bottom))]">
-              {empty && (
-                <EmptyState
-                  className="p-8"
-                  icon={<Icon name="comments" strokeWidth={1.75} />}
-                  title="Start the conversation."
-                  description="Select text in the document, or add a general comment."
-                  action={
-                    canComment ? (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        data-testid="comments-sheet-empty-new"
-                        onClick={() => {
-                          setSize("full")
-                          onNewGeneral()
-                        }}
-                      >
-                        New comment
-                      </Button>
-                    ) : undefined
-                  }
-                />
-              )}
-              {openThreads.map((t) => {
-                const head = t[0]
-                if (!head) return null
-                return (
-                  <div key={head.thread_id} data-thread-id={head.thread_id} className="mb-2.5">
-                    <CommentCard thread={t} />
-                  </div>
-                )
-              })}
-              {resolved.length > 0 && (
-                <CollapsibleThreadSection
-                  label="Resolved"
-                  defaultOpen={false}
-                  testId="resolved-section-toggle"
-                  className="mt-1"
-                  threads={resolved}
-                />
-              )}
+        <div className="flex items-center gap-2 border-b border-border-soft pb-3 pl-3 pr-2.5 pt-2">
+          <CommentsHeading count={openThreads.length} />
+          {size === "full" && !composer && openThreads.length > 1 && (
+            // Step through the discussion one thread at a time: the card scrolls
+            // into view and an anchored thread scrolls the doc to its highlight.
+            <div className="flex items-center gap-0.5 font-mono text-xs tabular-nums text-muted-foreground">
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Previous comment"
+                data-testid="comments-step-prev"
+                onClick={() => stepTo(stepIdx - 1)}
+              >
+                <Icon name="caret" className="size-4 rotate-90" />
+              </Button>
+              {stepIdx + 1}/{openThreads.length}
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Next comment"
+                data-testid="comments-step-next"
+                onClick={() => stepTo(stepIdx + 1)}
+              >
+                <Icon name="caret" className="size-4 -rotate-90" />
+              </Button>
             </div>
-          </CommentTreeProvider>
-        ) : latest ? (
-          // Peek preview: a one-line teaser of the latest comment, so the resting
-          // sheet shows the live discussion. Tapping it expands to the full list.
-          <button
-            type="button"
-            data-testid="comments-peek-preview"
-            onClick={() => setSize("full")}
-            className="flex min-w-0 items-center gap-1.5 px-3 pt-0.5 pb-[max(12px,env(safe-area-inset-bottom))] text-left"
+          )}
+          {canComment && (
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="comments-sheet-new"
+              onClick={() => {
+                setSize("full")
+                onNewGeneral()
+              }}
+            >
+              <Icon name="plus" size={16} />
+              New
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={size === "peek" ? "Expand" : "Collapse"}
+            data-testid="comments-sheet-resize"
+            onClick={() => setSize(size === "peek" ? "full" : "peek")}
           >
-            <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
-              <span className="font-medium text-foreground">{latest.author}</span>{" "}
-              {teaser(latest.body_md)}
-            </span>
-          </button>
-        ) : null}
-      </aside>
-    </>
+            <Icon name="caret" className={cn("size-4", size === "peek" && "rotate-180")} />
+          </Button>
+        </div>
+      </div>
+      {composer ? (
+        // Composing ("half open"): just the composer, so the sheet is a compact bar
+        // pinned above the keyboard with the document visible above. The list
+        // reappears once you send or cancel.
+        <div className="overflow-auto p-3 pb-[max(14px,env(safe-area-inset-bottom))]">
+          <Composer
+            quote={selLabel(composer.anchor)}
+            agent={composer.agent}
+            // After posting, open the full list so the new comment is visible (the
+            // sheet would otherwise drop back to the peek bar and hide it).
+            onSubmit={(text, mentions) => {
+              setSize("full")
+              onSubmitNew(text, mentions)
+            }}
+            onCancel={onCancelNew}
+          />
+        </div>
+      ) : size === "full" ? (
+        <CommentTreeProvider value={sheetTree}>
+          <div className="min-h-0 flex-1 overflow-auto p-3 pb-[max(14px,env(safe-area-inset-bottom))]">
+            {empty && (
+              <EmptyState
+                className="p-8"
+                icon={<Icon name="comments" strokeWidth={1.75} />}
+                title="Start the conversation."
+                description="Select text in the document, or add a general comment."
+                action={
+                  canComment ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      data-testid="comments-sheet-empty-new"
+                      onClick={() => {
+                        setSize("full")
+                        onNewGeneral()
+                      }}
+                    >
+                      New comment
+                    </Button>
+                  ) : undefined
+                }
+              />
+            )}
+            {openThreads.map((t) => {
+              const head = t[0]
+              if (!head) return null
+              return (
+                <div key={head.thread_id} data-thread-id={head.thread_id} className="mb-2.5">
+                  <CommentCard thread={t} />
+                </div>
+              )
+            })}
+            {resolved.length > 0 && (
+              <CollapsibleThreadSection
+                label="Resolved"
+                defaultOpen={false}
+                testId="resolved-section-toggle"
+                className="mt-1"
+                threads={resolved}
+              />
+            )}
+          </div>
+        </CommentTreeProvider>
+      ) : latest ? (
+        // Peek preview: a one-line teaser of the latest comment, so the resting
+        // sheet shows the live discussion. Tapping it expands to the full list.
+        <button
+          type="button"
+          data-testid="comments-peek-preview"
+          onClick={() => setSize("full")}
+          className="flex min-w-0 items-center gap-1.5 px-3 pt-0.5 pb-[max(12px,env(safe-area-inset-bottom))] text-left"
+        >
+          <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">{latest.author}</span>{" "}
+            {teaser(latest.body_md)}
+          </span>
+        </button>
+      ) : null}
+    </aside>
   )
 }
 


### PR DESCRIPTION
Two fixes from the same support ping: a co-worker's agent spent 10+ minutes pushing a pasted screenshot into Derive through the MCP, and the artifact it produced screenshotted with a broken image.

## 1. Private-bundle screenshots rendered images broken

The screenshot renderer authenticated with `?pv=<token>`, but a bundle page's relative asset references resolve against the **path only** — browsers drop the query string — so every sub-asset request arrived anonymous and 404'd. The viewer's `/t/:token/` route documents this exact trap; the renderer just used the older entry point.

The token now rides as a path segment (`/raw/:shortId/v/:n/pv/:pv/*`), inherited by every nested asset request automatically. The handler **verifies first and falls through (`next()`)** when the segment isn't a real token, so `pv/` is not a reserved name — a bundle's own literal `pv/chart.png` still serves to authorized viewers (caught in review; regression-tested both ways).

## 2. `stage_asset`: the blessed images path was unreachable for hosted-MCP agents

Raw `POST /v1/assets` needs a bearer token in the shell, but a hosted-MCP agent's OAuth lives inside the transport — the exact agents the publish tool steers to that path got 403 and fell back to base64-through-context (~1 token/byte, transcription risk, bundles only). Meanwhile the pasted screenshot was on disk the whole time (Claude Code caches pastes and shows the path).

New `stage_asset` MCP tool mints a 15-minute HMAC capability URL (`POST /v1/assets/t/<token>`) the agent spends with `curl --data-binary` — zero bytes through the model's context. Allowlisted through the anonymous write-lockdown like the GitHub/Slack webhook routes (the signed token is the gate); byte-sniffing, size cap, and storage quota identical to the authed route.

**Revocation survives the indirection** (caught in review): the token binds the granting user and the spend side re-checks live membership, so demoting/removing someone kills their outstanding URLs on the next request — same semantics as the per-request role check on the authed route.

## Supporting changes

- Shared `lib/capability-token.ts`: HMAC format, per-process key caching, base64url plumbing. `preview-token.ts` / `upload-token.ts` are now thin domain-separated wrappers, so the two verifiers can't drift. Wire format unchanged — in-flight preview tokens stay valid across deploy.
- Publish tool descriptions + server instructions route image/font embedding through `stage_asset` and state plainly that a pasted image in Claude Code is already a file on disk — upload it, never transcribe it.
- Shared PNG fixture in `test/fixtures.ts` (was copied in 4 files); regenerated `openapi.json` + web `api-types.ts`.
- Lead-off commit fixes two pre-existing lint errors on main that were blocking the pre-commit hook.

## Testing

- New route tests: valid/expired/garbage/no-secret upload tokens, batch reuse, sniffing still enforced, revocation mid-TTL (demote → 403, non-member → 403).
- MCP e2e: mints via the tool, spends the URL with **no auth header**, serves the exact bytes back.
- Renderer regressions: private bundle sub-assets load through the tokened page URL; a bundle with a real `pv/` directory (incl. nested paths) serves normally; fallthrough grants nothing to anonymous.
- Full API suite: 1000+ tests green except two pre-existing `oauth-refresh-rotation` failures that also fail on a clean main checkout. Both typecheck configs and the full lint battery pass.

A multi-agent adversarial review ran over this diff before opening; both CONFIRMED correctness findings (the `pv/` namespace collision and the revocation gap) are fixed and regression-tested, and all five cleanup findings are applied.