### PR TITLE
feat(slack): resolve/reopen a thread from a Block Kit button

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -139,12 +139,14 @@ https://derive.example.com/api/auth/oauth2/callback/<OIDC_PROVIDER_ID>
 ### Slack app (optional)
 
 To connect Slack workspaces (Derive comments mirrored to a channel with two-way
-reply-back, plus DMs to a member for mentions, review requests and shares), create one
-Slack app for this instance:
+reply-back and a Resolve/Reopen button on each comment card, plus DMs to a member for
+mentions, review requests and shares), create one Slack app for this instance:
 
-1. Open **Settings → Integrations → Set up Slack app** (or go straight to `/settings/slack/app/new`). This renders the app manifest already filled in with this instance's URL, so the event subscriptions and bot scopes are configured for you — nothing to hand-edit. At [api.slack.com/apps](https://api.slack.com/apps) → **Create New App → From a manifest**, paste it, and create the app.
+1. Open **Settings → Integrations → Set up Slack app** (or go straight to `/settings/slack/app/new`). This renders the app manifest already filled in with this instance's URL, so the event subscriptions, interactivity, and bot scopes are configured for you — nothing to hand-edit. At [api.slack.com/apps](https://api.slack.com/apps) → **Create New App → From a manifest**, paste it, and create the app.
 2. From the app's **Basic Information** page, set `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, and `SLACK_SIGNING_SECRET` (all three required, or Slack stays off). On Workers these are secrets: `wrangler secret put SLACK_CLIENT_ID` (and the other two).
 3. Workspace admins connect from **Settings → Integrations → Add to Slack**, then set a default channel and invite the Derive bot to it. Both public and private channels work; a private channel must have the bot invited (it can't self-join). A workspace connected before private-channel support was added must **reconnect** (Add to Slack again) to grant the `groups:*` scopes — there's no automatic reconnect prompt for it.
+
+An app created from an older manifest (before the Resolve/Reopen buttons) won't have **interactivity** enabled, so those buttons do nothing. Re-apply the manifest to your app — Slack app config → **App Manifest** → paste the updated one from `/v1/slack/manifest.json` — to turn it on. This is an app-config change, not a scope change, so it needs no per-workspace reconnect.
 
 The manifest is served (filled) at `/v1/slack/manifest.json`; the setup page is the copy-paste
 front end for it. Bot tokens are stored per workspace, encrypted at rest with `DERIVE_AUTH_SECRET`.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -342,6 +342,7 @@ export function createApp(deps: AppDeps): Hono {
     /^\/v1\/vitals$/, // anonymous Core Web Vitals beacon (telemetry, no state)
     /^\/v1\/sync\/github\/webhook$/, // GitHub App webhook — HMAC signature is the gate
     /^\/v1\/slack\/events$/, // Slack Events API — signing-secret signature is the gate
+    /^\/v1\/slack\/interactivity$/, // Slack Block Kit actions — signing-secret signature is the gate
     /^\/v1\/assets\/t\/[^/]+$/, // MCP-minted upload URL — the signed expiring token is the gate
   ]
   app.use("/v1/*", async (c, next) => {

--- a/apps/api/src/lib/slack-cards.ts
+++ b/apps/api/src/lib/slack-cards.ts
@@ -34,3 +34,17 @@ export const openButton = (url: string, text = "Open in Derive") => ({
   text: { type: "plain_text", text },
   url,
 })
+/** An interactive button: clicking POSTs to the app's interactivity request URL with the
+ *  `action_id` + `value` (unlike openButton, which is a plain link). `value` ≤ 2000 chars. */
+export const actionButton = (
+  actionId: string,
+  text: string,
+  value: string,
+  style?: "primary" | "danger",
+) => ({
+  type: "button",
+  action_id: actionId,
+  text: { type: "plain_text", text },
+  value,
+  ...(style ? { style } : {}),
+})

--- a/apps/api/src/lib/slack-comments.ts
+++ b/apps/api/src/lib/slack-comments.ts
@@ -17,7 +17,7 @@ import type { EventBus } from "../bus"
 import { type ChannelSendResult, enqueueChannelDelivery } from "../webhooks"
 import { commentDeepLink, parseMeta } from "./comments"
 import { slackUserName } from "./slack"
-import { context, section } from "./slack-cards"
+import { actionButton, actions, context, section } from "./slack-cards"
 import { postWithRecovery, resolveBotToken } from "./slack-delivery"
 import { truncate } from "./text"
 
@@ -56,12 +56,47 @@ export const enqueueSlackComment = async (
   await enqueueChannelDelivery(meta, "slack_app", "comment.created", payload)
 }
 
-/** Slack Block Kit blocks for a comment post. */
+/** The interactivity `action_id`s a comment card's buttons carry. The handler in
+ *  routes/slack.ts dispatches on these; they double as the resolve/reopen intent. */
+export const SLACK_THREAD_ACTION = {
+  resolve: "derive_thread_resolve",
+  reopen: "derive_thread_reopen",
+} as const
+
+/** Encode a button's `value`: which thread to act on. Read back by the interactivity
+ *  handler (and re-checked against the thread link — the value is ours, but we don't
+ *  trust it for authorization, only to name the target). */
+export const encodeThreadAction = (artifactId: string, threadId: string): string =>
+  JSON.stringify({ a: artifactId, t: threadId })
+
+/** The action + context blocks under a comment card for a given thread state. Rebuilt by the
+ *  interactivity handler after a resolve/reopen (with `who` = the Slack user who acted) and
+ *  used for the first post (open, no `who`). `value` is the encoded thread target. */
+export const threadStateBlocks = (
+  state: "open" | "resolved",
+  value: string,
+  who?: string,
+): unknown[] =>
+  state === "resolved"
+    ? [
+        actions([actionButton(SLACK_THREAD_ACTION.reopen, "Reopen thread", value)]),
+        context(`Derive · :white_check_mark: resolved${who ? ` by ${who}` : ""}`),
+      ]
+    : [
+        actions([actionButton(SLACK_THREAD_ACTION.resolve, "Resolve thread", value, "primary")]),
+        context(
+          who
+            ? `Derive · reopened by ${who} · reply in this thread to post back`
+            : "Derive · reply in this thread to post back",
+        ),
+      ]
+
+/** Slack Block Kit blocks for a comment post (open thread, with a Resolve button). */
 const blocksFor = (p: SlackCommentPayload): unknown[] => [
   section(
     `:speech_balloon: *${p.author}* commented on <${p.link}|${p.title}>\n${truncate(p.text, 600)}`,
   ),
-  context("Derive · reply in this thread to post back"),
+  ...threadStateBlocks("open", encodeThreadAction(p.artifactId, p.threadId)),
 ]
 
 /** Build the slack_app delivery sender for a runtime. Resolves the channel + thread from

--- a/apps/api/src/lib/slack.ts
+++ b/apps/api/src/lib/slack.ts
@@ -135,6 +135,27 @@ export const postSlackMessage = async (
   return { ts: data.ts, channel: data.channel ?? args.channel }
 }
 
+/** Update the message an interaction came from, via its `response_url` (a signed URL valid
+ *  ~30 min, no token needed). `replace_original` swaps the whole message. Best-effort +
+ *  time-bounded: the interactivity ack must return well under Slack's 3s, and the action it
+ *  reflects has already been applied, so a slow/failed cosmetic update must not block. */
+export const postSlackResponseUrl = async (
+  responseUrl: string,
+  body: { text: string; blocks?: unknown; replace_original?: boolean },
+): Promise<boolean> => {
+  try {
+    const res = await fetch(responseUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(2500),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
 /** Join a public channel so the bot can post to it (best-effort; private channels must
  *  invite the bot manually). Returns true on success. */
 export const joinSlackChannel = async (token: string, channel: string): Promise<boolean> => {

--- a/apps/api/src/lib/thread-actions.ts
+++ b/apps/api/src/lib/thread-actions.ts
@@ -1,0 +1,29 @@
+// The resolve / reopen side-effect chain for a comment thread, extracted so both the HTTP
+// route (routes/comments.ts) and the Slack interactivity handler (routes/slack.ts) run the
+// EXACT same pipeline — flip every comment in the thread, announce it on the realtime bus,
+// fan the event out to webhooks. Callers own authorization; this just executes the action.
+// Mirrors lib/proposal-actions.ts.
+
+import type { ArtifactRecord, CommentState, MetaStore } from "@derive/core"
+import type { Backplane } from "../bus"
+import type { WebhookEvent } from "../events"
+
+export interface ThreadActionDeps {
+  meta: MetaStore
+  bus: Backplane
+  notify: (a: ArtifactRecord, event: WebhookEvent, data: Record<string, unknown>) => Promise<void>
+}
+
+/** Resolve (or reopen, with state "open") the thread; returns the number of comments changed. */
+export const resolveThreadAction = async (
+  deps: ThreadActionDeps,
+  artifact: ArtifactRecord,
+  threadId: string,
+  state: Extract<CommentState, "open" | "resolved">,
+): Promise<number> => {
+  const { meta, bus, notify } = deps
+  const updated = await meta.setThreadState(artifact.id, threadId, state)
+  bus.publish(artifact.id, { type: "comment.resolved", thread_id: threadId, state })
+  await notify(artifact, "comment.resolved", { state, thread_id: threadId })
+  return updated
+}

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -25,6 +25,7 @@ import { notifyCommentBells } from "../lib/notify-comment"
 import { enqueueCommentEmails } from "../lib/notify-email"
 import { enqueueSlackComment } from "../lib/slack-comments"
 import { enqueueSlackMentionDms } from "../lib/slack-dm"
+import { resolveThreadAction } from "../lib/thread-actions"
 import { Mention as MentionSchema } from "../schemas"
 
 /** Comments: threaded, anchored to text quotes, with reactions, edits, and soft
@@ -351,9 +352,12 @@ export const commentRoutes = (ctx: AppContext) => {
       const body = await readJson(c, z.object({ state: z.string().optional() }))
       if (body instanceof Response) return bail(body)
       const state: "open" | "resolved" = body.state === "open" ? "open" : "resolved"
-      const updated = await meta.setThreadState(artifact.id, cm.thread_id, state)
-      bus.publish(artifact.id, { type: "comment.resolved", thread_id: cm.thread_id, state })
-      await notify(artifact, "comment.resolved", { state, thread_id: cm.thread_id })
+      const updated = await resolveThreadAction(
+        { meta, bus, notify },
+        artifact,
+        cm.thread_id,
+        state,
+      )
       return c.json({ thread_id: cm.thread_id, state, updated })
     },
   )

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -4,9 +4,19 @@ import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
 import { encryptSecret, signState, verifyState } from "../lib/crypto"
 import { bail, fail, readJson } from "../lib/http"
-import { exchangeSlackOAuth, slackAuthorizeUrl, verifySlackSignature } from "../lib/slack"
-import { enqueueSlackReplyIngest } from "../lib/slack-comments"
+import {
+  exchangeSlackOAuth,
+  postSlackResponseUrl,
+  slackAuthorizeUrl,
+  verifySlackSignature,
+} from "../lib/slack"
+import {
+  enqueueSlackReplyIngest,
+  SLACK_THREAD_ACTION,
+  threadStateBlocks,
+} from "../lib/slack-comments"
 import { enqueueSlackDm, wantsSlackDm } from "../lib/slack-dm"
+import { resolveThreadAction } from "../lib/thread-actions"
 import { log } from "../log"
 import { buildSlackManifest, slackSetupHTML } from "../slack-app-setup"
 
@@ -18,7 +28,7 @@ import { buildSlackManifest, slackSetupHTML } from "../slack-app-setup"
  *  the web client's type; the OAuth redirects and the Slack Events webhook stay plain
  *  routes (not typed JSON). */
 export const slackRoutes = (ctx: AppContext) => {
-  const { meta, deps, requireUser } = ctx
+  const { meta, deps, bus, notify, requireUser } = ctx
   const { activeWorkspace, workspaceCan, requireWorkspace } = ctx
   const app = new OpenAPIHono<BlankEnv>()
   const slack = deps.slack
@@ -167,6 +177,94 @@ export const slackRoutes = (ctx: AppContext) => {
     return c.json({ ok: true })
   })
 
+  // Block Kit interactivity: a button on a comment card resolves / reopens that thread. Trust,
+  // like reply-back, is by data not a Derive principal — but the target here comes from the
+  // (attacker-influenceable) button value, so we bind it three ways: (1) the Slack signature
+  // authenticates the request; (2) a slack_thread_link maps threadId→artifact→org; (3) the
+  // ACTING Slack team must equal that org's connected install — so one signed workspace can't
+  // act on another org's thread by carrying its ids (the events path is immune to this because
+  // it keys on Slack-assigned channel+ts, not a value). Then the org's slackPost opt-in gates it.
+  // Deliberately NOT gated on a Derive role: any member of the connected channel can resolve, the
+  // same collaboration boundary reply-back already grants for posting — and resolve is reversible.
+  // The state flip is applied + fanned out inline (durable before we ack); the cosmetic Slack
+  // card update is fired without awaiting, so a slow response_url can't push us past the 3s ack.
+  // authz-exempt: Slack signs every request with the signing secret (verifySlackSignature).
+  app.post("/v1/slack/interactivity", async (c) => {
+    if (!slack) return fail(c, 404, "Slack is not configured")
+    const raw = await c.req.text()
+    if (
+      !verifySlackSignature(
+        slack.signingSecret,
+        c.req.header("x-slack-request-timestamp"),
+        raw,
+        c.req.header("x-slack-signature"),
+      )
+    )
+      return fail(c, 401, "bad signature")
+
+    // Interactivity is form-encoded: a single `payload` field holding URL-encoded JSON.
+    const payloadStr = new URLSearchParams(raw).get("payload")
+    if (!payloadStr) return c.json({ ok: true })
+    let payload: SlackInteractionPayload
+    try {
+      payload = JSON.parse(payloadStr) as SlackInteractionPayload
+    } catch {
+      return fail(c, 400, "invalid payload")
+    }
+
+    const action = payload.actions?.[0]
+    const op =
+      action?.action_id === SLACK_THREAD_ACTION.resolve
+        ? "resolved"
+        : action?.action_id === SLACK_THREAD_ACTION.reopen
+          ? "open"
+          : undefined
+    // Not a thread action we handle (or a malformed value) → ack and ignore.
+    if (payload.type !== "block_actions" || !op || !action?.value) return c.json({ ok: true })
+    let target: { a?: string; t?: string }
+    try {
+      target = JSON.parse(action.value) as { a?: string; t?: string }
+    } catch {
+      return c.json({ ok: true })
+    }
+    const { a: artifactId, t: threadId } = target
+    if (!artifactId || !threadId) return c.json({ ok: true })
+
+    // Re-establish trust from data (never the button value alone): the thread link maps this
+    // thread to this artifact + org, the acting Slack team owns that org's install, and the
+    // org's channel mirror is on. Any miss → ack and no-op (a click that changes nothing).
+    const link = await meta.getSlackThreadLinkByThread(threadId)
+    if (link && link.artifact_id === artifactId) {
+      const install = await meta.getSlackInstall(link.org_id)
+      const teamOwnsThread = !!install && !!payload.team?.id && install.team_id === payload.team.id
+      if (teamOwnsThread && (await meta.getOrgSettings(link.org_id)).slackPost) {
+        const artifact = await meta.getArtifactById(artifactId)
+        if (artifact) {
+          await resolveThreadAction({ meta, bus, notify }, artifact, threadId, op)
+          // Reflect the new state in Slack: keep the comment section, swap the button + footer.
+          // Fire-and-forget — the resolve above is already durable, so a slow/failed cosmetic
+          // update must not sit on the ack path (waitUntil on Workers; in-process on Node).
+          const who = payload.user?.username || payload.user?.name || undefined
+          const section0 = payload.message?.blocks?.[0]
+          const blocks = [section0, ...threadStateBlocks(op, action.value, who)].filter(Boolean)
+          if (payload.response_url) {
+            const update = postSlackResponseUrl(payload.response_url, {
+              text: op === "resolved" ? "Thread resolved" : "Thread reopened",
+              blocks,
+              replace_original: true,
+            })
+            try {
+              c.executionCtx.waitUntil(update)
+            } catch {
+              void update // Node has no executionCtx; the promise runs in-process
+            }
+          }
+        }
+      }
+    }
+    return c.json({ ok: true })
+  })
+
   // Connection status for the Settings UI: whether Slack is configured at all, whether
   // this workspace has connected one, and its team + default channel.
   app.openapi(
@@ -303,4 +401,17 @@ interface SlackEventEnvelope {
     ts?: string
     thread_ts?: string
   }
+}
+
+/** The Block Kit interactivity payload (the JSON inside the form's `payload` field). Only the
+ *  fields the thread-action handler reads; `message.blocks` is the original card, reused so
+ *  the resolved/reopened card keeps its comment section. */
+interface SlackInteractionPayload {
+  type?: string
+  response_url?: string
+  /** The workspace the click came from; bound to the thread's org install for authz. */
+  team?: { id?: string }
+  user?: { id?: string; username?: string; name?: string }
+  actions?: Array<{ action_id?: string; value?: string }>
+  message?: { blocks?: unknown[] }
 }

--- a/apps/api/src/slack-app-setup.ts
+++ b/apps/api/src/slack-app-setup.ts
@@ -34,6 +34,11 @@ export const buildSlackManifest = (baseUrl: string) => {
         request_url: u("/v1/slack/events"),
         bot_events: ["message.channels", "message.groups", "message.im"],
       },
+      // Buttons on comment cards (resolve / reopen a thread) POST here.
+      interactivity: {
+        is_enabled: true,
+        request_url: u("/v1/slack/interactivity"),
+      },
       org_deploy_enabled: false,
       socket_mode_enabled: false,
       token_rotation_enabled: false,

--- a/apps/api/test/slack-app-setup.test.ts
+++ b/apps/api/test/slack-app-setup.test.ts
@@ -35,6 +35,11 @@ describe("buildSlackManifest", () => {
     )
   })
 
+  it("enables interactivity pointed at this instance (comment-card buttons post here)", () => {
+    expect(m.settings.interactivity.is_enabled).toBe(true)
+    expect(m.settings.interactivity.request_url).toBe(`${BASE}/v1/slack/interactivity`)
+  })
+
   it("is named just Derive (Slack caps the app name at 35 chars)", () => {
     expect(m.display_information.name).toBe("Derive")
     expect(m.display_information.name.length).toBeLessThanOrEqual(35)

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -1,8 +1,18 @@
 import { createHmac } from "node:crypto"
-import type { CommentRecord, MetaStore, NewComment, SlackThreadLinkRecord } from "@derive/core"
+import {
+  type CommentRecord,
+  DEFAULT_ORG_SETTINGS,
+  type MetaStore,
+  type NewComment,
+  type SlackThreadLinkRecord,
+} from "@derive/core"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { encryptSecret } from "../src/lib/crypto"
-import { ingestSlackReply, makeSlackIngestSender } from "../src/lib/slack-comments"
+import {
+  ingestSlackReply,
+  makeSlackIngestSender,
+  SLACK_THREAD_ACTION,
+} from "../src/lib/slack-comments"
 import { runDeliveryTick } from "../src/webhooks"
 import { as, quotaApp, type TestUser } from "./helpers"
 
@@ -61,6 +71,31 @@ const postEvent = (app: TestApp, body: string) => {
     body,
   })
 }
+
+// A signed Block Kit interactivity POST (form-encoded: payload=<url-encoded JSON>).
+const postInteract = (app: TestApp, payload: unknown) => {
+  const raw = `payload=${encodeURIComponent(JSON.stringify(payload))}`
+  const ts = String(Math.floor(Date.now() / 1000))
+  return app.request("/v1/slack/interactivity", {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      "x-slack-request-timestamp": ts,
+      "x-slack-signature": sign(ts, raw),
+    },
+    body: raw,
+  })
+}
+
+// "T1" matches the team_id seedResolvable stores on the install (the acting-team authz bind).
+const threadAction = (artifactId: string, threadId: string, actionId: string, teamId = "T1") => ({
+  type: "block_actions",
+  response_url: "https://hooks.slack.test/response",
+  team: { id: teamId },
+  user: { username: "dana" },
+  actions: [{ action_id: actionId, value: JSON.stringify({ a: artifactId, t: threadId }) }],
+  message: { blocks: [{ type: "section", text: { type: "mrkdwn", text: "a comment" } }] },
+})
 
 afterEach(() => vi.unstubAllGlobals())
 
@@ -424,5 +459,214 @@ describe("slack events endpoint", () => {
       new Date(Date.now() + 120_000).toISOString(),
     )
     expect(rows.some((d) => d.kind === "slack_ingest")).toBe(false)
+  })
+})
+
+describe("slack interactivity endpoint (resolve/reopen from a button)", () => {
+  // Seed an artifact + connected install + a thread link + a root comment to act on.
+  const seedResolvable = async (
+    meta: MetaStore,
+    ids: { artifact: string; short: string; thread: string },
+  ) => {
+    const artifact = await meta.createArtifact({
+      id: ids.artifact,
+      short_id: ids.short,
+      org_id: "default",
+      slug: null,
+      title: "Doc",
+      workspace_access: "member",
+      link_role: "viewer",
+      listed: "public",
+      kind: "file",
+      spa: 0,
+    })
+    await meta.setSlackInstall({
+      org_id: "default",
+      team_id: "T1",
+      team_name: "Acme",
+      bot_token: encryptSecret("xoxb-1", KEY),
+      bot_user_id: "UBOT",
+      default_channel: "C1",
+      created_at: new Date().toISOString(),
+    })
+    await meta.setSlackThreadLink({
+      id: `stl-${ids.thread}`,
+      org_id: "default",
+      artifact_id: artifact.id,
+      thread_id: ids.thread,
+      channel: "C1",
+      message_ts: `${ids.thread}.1`,
+      created_at: new Date().toISOString(),
+    })
+    // A root comment (thread_id === id) so there's a thread to flip and assert on.
+    await meta.createComment({
+      id: ids.thread,
+      artifact_id: artifact.id,
+      thread_id: ids.thread,
+      base_version: 0,
+      path: null,
+      anchor: null,
+      body_md: "hi",
+      author: "A",
+      author_id: "u1",
+    })
+    return artifact
+  }
+
+  it("rejects an unsigned or wrongly-signed interactivity request", async () => {
+    const { app } = make("slack-int-badsig")
+    const unsigned = await app.request("/v1/slack/interactivity", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "payload=%7B%7D",
+    })
+    expect(unsigned.status).toBe(401)
+    // A present-but-wrong signature is also rejected (constant-time compare, not "any v0=").
+    const ts = String(Math.floor(Date.now() / 1000))
+    const wrong = await app.request("/v1/slack/interactivity", {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-slack-request-timestamp": ts,
+        "x-slack-signature": "v0=deadbeef",
+      },
+      body: "payload=%7B%7D",
+    })
+    expect(wrong.status).toBe(401)
+  })
+
+  it("ignores a click whose Slack team does not own the thread's org (cross-org guard)", async () => {
+    const { app, meta } = make("slack-int-xorg")
+    const artifact = await seedResolvable(meta, {
+      artifact: "a-int-x",
+      short: "intxor01",
+      thread: "c-int-x",
+    })
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("ok", { status: 200 })),
+    )
+    // Signed + valid ids, but the acting team ("T-EVIL") isn't the org's install team ("T1").
+    const r = await postInteract(
+      app,
+      threadAction(artifact.id, "c-int-x", SLACK_THREAD_ACTION.resolve, "T-EVIL"),
+    )
+    expect(r.status).toBe(200)
+    const cm = (await meta.listComments(artifact.id)).find((c) => c.id === "c-int-x")
+    expect(cm?.state).toBe("open") // not resolved — the team bind blocked it
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled()
+  })
+
+  it("a signed Resolve click resolves the thread and updates the message", async () => {
+    const { app, meta } = make("slack-int-resolve")
+    const artifact = await seedResolvable(meta, {
+      artifact: "a-int-r",
+      short: "intres01",
+      thread: "c-int-r",
+    })
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("ok", { status: 200 })),
+    )
+
+    const r = await postInteract(
+      app,
+      threadAction(artifact.id, "c-int-r", SLACK_THREAD_ACTION.resolve),
+    )
+    expect(r.status).toBe(200)
+    const cm = (await meta.listComments(artifact.id)).find((c) => c.id === "c-int-r")
+    expect(cm?.state).toBe("resolved")
+
+    // The card was replaced via response_url with a Reopen button.
+    const call = vi.mocked(fetch).mock.calls.find(([u]) => String(u).includes("hooks.slack.test"))
+    expect(call).toBeTruthy()
+    const sent = JSON.parse(String(call?.[1]?.body))
+    expect(sent.replace_original).toBe(true)
+    expect(JSON.stringify(sent.blocks)).toContain(SLACK_THREAD_ACTION.reopen)
+  })
+
+  it("a Reopen click reopens a resolved thread", async () => {
+    const { app, meta } = make("slack-int-reopen")
+    const artifact = await seedResolvable(meta, {
+      artifact: "a-int-o",
+      short: "intreo01",
+      thread: "c-int-o",
+    })
+    await meta.setThreadState(artifact.id, "c-int-o", "resolved")
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("ok", { status: 200 })),
+    )
+
+    const r = await postInteract(
+      app,
+      threadAction(artifact.id, "c-int-o", SLACK_THREAD_ACTION.reopen),
+    )
+    expect(r.status).toBe(200)
+    const cm = (await meta.listComments(artifact.id)).find((c) => c.id === "c-int-o")
+    expect(cm?.state).toBe("open")
+  })
+
+  it("ignores the click when the org's channel mirror (slackPost) is off", async () => {
+    const { app, meta } = make("slack-int-off")
+    const artifact = await seedResolvable(meta, {
+      artifact: "a-int-f",
+      short: "intoff01",
+      thread: "c-int-f",
+    })
+    await meta.setOrgSettings("default", { ...DEFAULT_ORG_SETTINGS, slackPost: false })
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("ok", { status: 200 })),
+    )
+
+    const r = await postInteract(
+      app,
+      threadAction(artifact.id, "c-int-f", SLACK_THREAD_ACTION.resolve),
+    )
+    expect(r.status).toBe(200)
+    // Trust gate closed → thread stays open, no message update sent.
+    const cm = (await meta.listComments(artifact.id)).find((c) => c.id === "c-int-f")
+    expect(cm?.state).toBe("open")
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled()
+  })
+
+  it("ignores a click whose thread has no link (no forged targets)", async () => {
+    const { app, meta } = make("slack-int-nolink")
+    // An artifact + comment, but NO slack_thread_link for the thread.
+    const artifact = await meta.createArtifact({
+      id: "a-int-n",
+      short_id: "intnol01",
+      org_id: "default",
+      slug: null,
+      title: "Doc",
+      workspace_access: "member",
+      link_role: "viewer",
+      listed: "public",
+      kind: "file",
+      spa: 0,
+    })
+    await meta.createComment({
+      id: "c-int-n",
+      artifact_id: artifact.id,
+      thread_id: "c-int-n",
+      base_version: 0,
+      path: null,
+      anchor: null,
+      body_md: "hi",
+      author: "A",
+      author_id: "u1",
+    })
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("ok", { status: 200 })),
+    )
+    const r = await postInteract(
+      app,
+      threadAction(artifact.id, "c-int-n", SLACK_THREAD_ACTION.resolve),
+    )
+    expect(r.status).toBe(200)
+    const cm = (await meta.listComments(artifact.id)).find((c) => c.id === "c-int-n")
+    expect(cm?.state).toBe("open")
   })
 })


### PR DESCRIPTION
## What

Increment 2 of the Slack improvement program: the connected app's **comment cards now carry a Resolve button** (and a Reopen button once resolved). Clicking it resolves/reopens the whole Derive thread and updates the card in place.

Builds on the ack-fast foundation from #450.

## How

- **New `POST /v1/slack/interactivity`** — signature-verified (same `verifySlackSignature`), added to the anon-write allow list like `/events`.
- **Trust model** (documented in-code): by data, not a Derive principal — the same collaboration boundary reply-back already grants. A `slack_thread_link` maps the thread→artifact→org, the org's `slackPost` opt-in gates it, and — because the target comes from the button *value* (unlike `/events`, which keys on Slack-assigned `channel`+`ts`) — the **acting Slack team must match that org's install**, so one signed workspace can't act on another org's thread by carrying its ids.
- **Ack budget**: the resolve is applied + fanned out inline (durable before the 200); the cosmetic `response_url` card update is **fire-and-forget** (`waitUntil` on Workers, in-process on Node) so a slow Slack can't push past the 3s deadline.
- **Lockstep**: extracted `resolveThreadAction` (`lib/thread-actions.ts`), now shared by the HTTP resolve route and the Slack handler — mirrors the existing `proposal-actions.ts`.
- Manifest gains `interactivity`; `DEPLOY.md` documents it + how to enable it on an app made from an older manifest.

## Scoped out (→ increment 3)

Approve / request-changes from Slack needs (a) proposal cards to actually reach the connected channel (only `comment.created` does today) and (b) account linking to authorize the **editor**-level action. `proposal-actions.ts` is already extracted for it.

## Audit

An adversarial review flagged, and this PR fixes: a missing team→org bind (the cross-org guard above; pinned by a test) and the `response_url` fetch sitting on the ack path (now fire-and-forget). Accepted + documented: no per-user Derive authz (consistent with reply-back; tighten when account linking lands) and stale sibling Resolve buttons (harmless/idempotent).

## Testing

- `pnpm run ci` ✅ · `pnpm typecheck` ✅ · full suite + `test:pg` green locally (42 Slack tests sqlite, 19 under real Postgres).
- New tests: resolve → thread resolved + card swapped, reopen, `slackPost`-off gate, no-thread-link no-op, **cross-org team guard**, unsigned + **wrong-signature** rejection, manifest interactivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)