### PR TITLE
feat(slack): link a Slack account to a Derive user (Sign in with Slack)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -140,13 +140,16 @@ https://derive.example.com/api/auth/oauth2/callback/<OIDC_PROVIDER_ID>
 
 To connect Slack workspaces (Derive comments mirrored to a channel with two-way
 reply-back and a Resolve/Reopen button on each comment card, plus DMs to a member for
-mentions, review requests and shares), create one Slack app for this instance:
+mentions, review requests and shares — reliable once a member links their Slack account),
+create one Slack app for this instance:
 
 1. Open **Settings → Integrations → Set up Slack app** (or go straight to `/settings/slack/app/new`). This renders the app manifest already filled in with this instance's URL, so the event subscriptions, interactivity, and bot scopes are configured for you — nothing to hand-edit. At [api.slack.com/apps](https://api.slack.com/apps) → **Create New App → From a manifest**, paste it, and create the app.
 2. From the app's **Basic Information** page, set `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, and `SLACK_SIGNING_SECRET` (all three required, or Slack stays off). On Workers these are secrets: `wrangler secret put SLACK_CLIENT_ID` (and the other two).
 3. Workspace admins connect from **Settings → Integrations → Add to Slack**, then set a default channel and invite the Derive bot to it. Both public and private channels work; a private channel must have the bot invited (it can't self-join). A workspace connected before private-channel support was added must **reconnect** (Add to Slack again) to grant the `groups:*` scopes — there's no automatic reconnect prompt for it.
 
-An app created from an older manifest (before the Resolve/Reopen buttons) won't have **interactivity** enabled, so those buttons do nothing. Re-apply the manifest to your app — Slack app config → **App Manifest** → paste the updated one from `/v1/slack/manifest.json` — to turn it on. This is an app-config change, not a scope change, so it needs no per-workspace reconnect.
+An app created from an older manifest won't have the newer features enabled — **interactivity** (the Resolve/Reopen buttons) and the **"Sign in with Slack" redirect URL** (so members can link their account from **Settings → Integrations → Link account**). Re-apply the manifest to your app — Slack app config → **App Manifest** → paste the updated one from `/v1/slack/manifest.json` — to turn them on. This is an app-config change, not a scope change, so it needs no per-workspace reconnect.
+
+Linking is per-user and optional: without it, DMs fall back to matching a member by their Derive account email; with it, DMs and Slack-reply attribution resolve to the member's exact Slack identity (so a Derive email that differs from the Slack email no longer drops the DM).
 
 The manifest is served (filled) at `/v1/slack/manifest.json`; the setup page is the copy-paste
 front end for it. Bot tokens are stored per workspace, encrypted at rest with `DERIVE_AUTH_SECRET`.

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1673,6 +1673,10 @@
           "slack_dm": {
             "type": "boolean",
             "description": "The caller's \"DM me for interrupts\" preference (mentions, review requests, shares)"
+          },
+          "linked": {
+            "type": "boolean",
+            "description": "Whether the caller has linked their Slack identity for the connected team"
           }
         },
         "required": [
@@ -1681,7 +1685,8 @@
           "team_name",
           "default_channel",
           "needs_reauth",
-          "slack_dm"
+          "slack_dm",
+          "linked"
         ]
       },
       "Report": {

--- a/apps/api/src/lib/slack-comments.ts
+++ b/apps/api/src/lib/slack-comments.ts
@@ -180,12 +180,17 @@ export const makeSlackIngestSender =
     const bot = await resolveBotToken(meta, link.org_id, encryptionKey)
     if (!bot) return { ok: true, status: "skipped: slack not connected" }
     const name = await slackUserName(bot.token, p.userId)
+    // If the Slack author has linked their account, attribute the comment to their real Derive
+    // user (and name) instead of an opaque slack:<id>; otherwise fall back to the Slack name.
+    const userLink = await meta.getSlackUserLinkBySlackId(bot.install.team_id, p.userId)
+    const deriveUser = userLink ? (await meta.getUsers([userLink.user_id]))[0] : undefined
     const created = await ingestSlackReply(meta, link, {
       ts: p.ts,
       userId: p.userId,
-      userName: name,
+      userName: deriveUser?.name ?? name,
       text: p.text,
       botUserId: bot.install.bot_user_id,
+      deriveUserId: userLink?.user_id ?? null,
     })
     if (created) bus?.publish(created.artifact_id, { type: "comment.created" })
     return { ok: true, status: created ? "ingested" : "skipped: own or duplicate" }
@@ -197,7 +202,16 @@ export const makeSlackIngestSender =
 export const ingestSlackReply = async (
   meta: MetaStore,
   link: SlackThreadLinkRecord,
-  args: { ts: string; userId: string; userName: string; text: string; botUserId: string | null },
+  args: {
+    ts: string
+    userId: string
+    userName: string
+    text: string
+    botUserId: string | null
+    /** The linked Derive user id, when the Slack author has linked their account — the comment
+     *  is then owned by that account; otherwise it's tagged with the opaque `slack:<id>`. */
+    deriveUserId?: string | null
+  },
 ): Promise<CommentRecord | null> => {
   if (args.botUserId && args.userId === args.botUserId) return null // our own post
   // Dedupe on the Slack message ts (re-deliveries / retries).
@@ -216,7 +230,7 @@ export const ingestSlackReply = async (
     anchor: null,
     body_md: args.text,
     author: args.userName,
-    author_id: `slack:${args.userId}`,
+    author_id: args.deriveUserId ?? `slack:${args.userId}`,
     meta: JSON.stringify({ slack: { ts: args.ts, channel: link.channel } }),
   })
 }

--- a/apps/api/src/lib/slack-dm.ts
+++ b/apps/api/src/lib/slack-dm.ts
@@ -166,14 +166,24 @@ export const makeSlackDmSender =
     const p = JSON.parse(d.payload) as SlackDmPayload
     const bot = await resolveBotToken(meta, p.orgId, encryptionKey)
     if (!bot) return { ok: true, status: "skipped: slack not connected" }
-    const [user] = await meta.getUsers([p.userId])
-    if (!user?.email) return { ok: true, status: "skipped: no email on file" }
 
-    let slackUserId: string | null
-    try {
-      slackUserId = await resolveSlackUserIdByEmail(bot.token, user.email)
-    } catch (err) {
-      return slackFailure(meta, p.orgId, err)
+    // Prefer the reliable account link (the user linked their Slack identity); fall back to
+    // guessing by account email only for users who haven't linked — so a Derive email that
+    // differs from the Slack email no longer silently drops the DM. (A linked user whose Slack
+    // account was later deactivated retries then dead-letters rather than falling back to email
+    // — rare, and re-linking or unlinking fixes it.)
+    let slackUserId: string | null = null
+    const link = await meta.getSlackUserLinkByUser(bot.install.team_id, p.userId)
+    if (link) {
+      slackUserId = link.slack_user_id
+    } else {
+      const [user] = await meta.getUsers([p.userId])
+      if (!user?.email) return { ok: true, status: "skipped: not linked, no email on file" }
+      try {
+        slackUserId = await resolveSlackUserIdByEmail(bot.token, user.email)
+      } catch (err) {
+        return slackFailure(meta, p.orgId, err)
+      }
     }
     if (!slackUserId) return { ok: true, status: "skipped: no matching Slack account" }
 

--- a/apps/api/src/lib/slack.ts
+++ b/apps/api/src/lib/slack.ts
@@ -67,6 +67,76 @@ export const exchangeSlackOAuth = async (
   }
 }
 
+/** The "Sign in with Slack" (OIDC) authorize URL for the per-user account-link flow. Distinct
+ *  from the bot install (`slackAuthorizeUrl`): Slack rejects mixing `openid` scopes with bot
+ *  scopes in one call, so linking a personal identity is its own lightweight flow. `nonce` is
+ *  required by OIDC; we read identity from the back-channel userinfo, so the signed `state`
+ *  (not the id_token) is what binds the callback to the Derive user who started it. */
+export const slackOidcAuthorizeUrl = (
+  clientId: string,
+  redirectUri: string,
+  state: string,
+  nonce: string,
+  team?: string,
+): string => {
+  const u = new URL("https://slack.com/openid/connect/authorize")
+  u.searchParams.set("response_type", "code")
+  u.searchParams.set("scope", "openid profile email")
+  u.searchParams.set("client_id", clientId)
+  u.searchParams.set("redirect_uri", redirectUri)
+  u.searchParams.set("state", state)
+  u.searchParams.set("nonce", nonce)
+  // Pre-select the connected workspace so the user links the identity for the right team.
+  if (team) u.searchParams.set("team", team)
+  return u.toString()
+}
+
+/** Exchange an OIDC `code` for an access token (openid.connect.token). Back-channel: we
+ *  authenticate with the client secret over TLS, so the token response is trusted. */
+export const exchangeSlackOidc = async (
+  clientId: string,
+  clientSecret: string,
+  code: string,
+  redirectUri: string,
+): Promise<{ accessToken: string }> => {
+  const res = await fetch(`${API}/openid.connect.token`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+      redirect_uri: redirectUri,
+      grant_type: "authorization_code",
+    }),
+  })
+  const data = (await res.json()) as { ok?: boolean; error?: string; access_token?: string }
+  if (!data.access_token) throw new Error(`slack oidc token failed: ${data.error ?? "unknown"}`)
+  return { accessToken: data.access_token }
+}
+
+/** The linked Slack identity (openid.connect.userinfo). The identifying claims are namespaced
+ *  URL keys (`https://slack.com/user_id`, `.../team_id`) — read them literally. These are the
+ *  same `U…`/`T…` ids the bot sees in events, which is what makes the link resolvable. */
+export const slackOidcUserinfo = async (
+  accessToken: string,
+): Promise<{ slackUserId: string; teamId: string; email: string | null }> => {
+  const res = await fetch(`${API}/openid.connect.userinfo`, {
+    headers: { authorization: `Bearer ${accessToken}` },
+  })
+  const data = (await res.json()) as {
+    error?: string
+    "https://slack.com/user_id"?: string
+    "https://slack.com/team_id"?: string
+    email?: string
+  }
+  const slackUserId = data["https://slack.com/user_id"]
+  const teamId = data["https://slack.com/team_id"]
+  if (!slackUserId || !teamId)
+    throw new Error(`slack oidc userinfo failed: ${data.error ?? "no identity"}`)
+  return { slackUserId, teamId, email: data.email ?? null }
+}
+
 export interface SlackPostResult {
   ts: string
   channel: string

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -6,8 +6,11 @@ import { encryptSecret, signState, verifyState } from "../lib/crypto"
 import { bail, fail, readJson } from "../lib/http"
 import {
   exchangeSlackOAuth,
+  exchangeSlackOidc,
   postSlackResponseUrl,
   slackAuthorizeUrl,
+  slackOidcAuthorizeUrl,
+  slackOidcUserinfo,
   verifySlackSignature,
 } from "../lib/slack"
 import {
@@ -33,6 +36,7 @@ export const slackRoutes = (ctx: AppContext) => {
   const app = new OpenAPIHono<BlankEnv>()
   const slack = deps.slack
   const redirectUri = new URL("/v1/slack/oauth/callback", deps.baseUrl).toString()
+  const linkRedirectUri = new URL("/v1/slack/link/callback", deps.baseUrl).toString()
 
   interface ConnectState {
     org: string
@@ -60,6 +64,9 @@ export const slackRoutes = (ctx: AppContext) => {
         .describe(
           'The caller\'s "DM me for interrupts" preference (mentions, review requests, shares)',
         ),
+      linked: z
+        .boolean()
+        .describe("Whether the caller has linked their Slack identity for the connected team"),
     })
     .openapi("SlackStatus")
 
@@ -119,6 +126,84 @@ export const slackRoutes = (ctx: AppContext) => {
       log.warn("slack oauth failed", { error: err instanceof Error ? err.message : String(err) })
       return c.redirect("/settings/integrations?error=oauth")
     }
+  })
+
+  // Per-user "Link Slack account" — a lightweight OIDC (Sign in with Slack) flow, separate
+  // from the admin bot install: it maps the signed-in Derive user to their Slack identity so
+  // DMs/attribution resolve to the real account instead of guessing by email. Any signed-in
+  // member (not just admins) may link their own account; the signed state binds the callback
+  // to them. Pre-selects the workspace's connected team so they link the right identity.
+  app.get("/v1/slack/link", async (c) => {
+    if (!slack || !deps.encryptionKey) return fail(c, 404, "Slack is not configured")
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    const org = await activeWorkspace(c)
+    const install = await meta.getSlackInstall(org)
+    if (!install) return c.redirect("/settings/integrations?error=not_connected")
+    const state = signState({ org, uid: me.id }, deps.encryptionKey)
+    return c.redirect(
+      slackOidcAuthorizeUrl(
+        slack.clientId,
+        linkRedirectUri,
+        state,
+        newId("nonce"),
+        install.team_id,
+      ),
+    )
+  })
+
+  // OIDC callback: recover the signed-in user from the signed state, resolve their Slack
+  // identity, and store the link — but only if that identity belongs to the workspace's
+  // connected team (else someone could link an identity from an unrelated workspace).
+  app.get("/v1/slack/link/callback", async (c) => {
+    if (!slack || !deps.encryptionKey) return fail(c, 404, "Slack is not configured")
+    const me = await requireUser(c)
+    const code = c.req.query("code")
+    const stateRaw = c.req.query("state")
+    const state = stateRaw ? verifyState<ConnectState>(stateRaw, deps.encryptionKey) : null
+    // Bind the completion to the SAME signed-in user who started the flow. The signed state
+    // proves who INITIATED it, but it rides the browser URL (leakable / replayable for its
+    // 15-min window), so a session is required and must match — otherwise someone who got a
+    // victim's state could complete the link and route the victim's DMs to their own Slack.
+    if (me instanceof Response || !code || !state || me.id !== state.uid)
+      return c.redirect("/settings/integrations?error=link")
+    try {
+      const { accessToken } = await exchangeSlackOidc(
+        slack.clientId,
+        slack.clientSecret,
+        code,
+        linkRedirectUri,
+      )
+      const identity = await slackOidcUserinfo(accessToken)
+      const install = await meta.getSlackInstall(state.org)
+      if (!install || install.team_id !== identity.teamId)
+        return c.redirect("/settings/integrations?error=link_team")
+      // One link per user per team: clear any prior link, then store the new one, bound to the
+      // Derive user from the signed state (never from the OAuth response).
+      await meta.deleteSlackUserLink(identity.teamId, state.uid)
+      await meta.setSlackUserLink({
+        id: newId("sul"),
+        org_id: state.org,
+        user_id: state.uid,
+        team_id: identity.teamId,
+        slack_user_id: identity.slackUserId,
+        created_at: new Date().toISOString(),
+      })
+      return c.redirect("/settings/integrations")
+    } catch (err) {
+      log.warn("slack link failed", { error: err instanceof Error ? err.message : String(err) })
+      return c.redirect("/settings/integrations?error=link")
+    }
+  })
+
+  // Unlink the caller's Slack identity for the active workspace's team.
+  app.delete("/v1/slack/link", async (c) => {
+    const me = await requireUser(c)
+    if (me instanceof Response) return bail(me)
+    const org = await activeWorkspace(c)
+    const install = await meta.getSlackInstall(org)
+    if (install) await meta.deleteSlackUserLink(install.team_id, me.id)
+    return c.body(null, 204)
   })
 
   // Inbound Events API: url_verification challenge + threaded message replies → Derive.
@@ -288,6 +373,8 @@ export const slackRoutes = (ctx: AppContext) => {
       // Read the DM preference regardless of connection state so the reported value always
       // reflects what's stored (the toggle can be set before/after connecting).
       const pref = await meta.getUserNotificationPref(org, me.id)
+      // Whether THIS user has linked their Slack identity for the connected team.
+      const linked = install ? !!(await meta.getSlackUserLinkByUser(install.team_id, me.id)) : false
       return c.json({
         available: !!slack,
         connected: !!install,
@@ -295,6 +382,7 @@ export const slackRoutes = (ctx: AppContext) => {
         default_channel: install?.default_channel ?? null,
         needs_reauth: install?.needs_reauth === 1,
         slack_dm: wantsSlackDm(pref?.prefs),
+        linked,
       })
     },
   )

--- a/apps/api/src/slack-app-setup.ts
+++ b/apps/api/src/slack-app-setup.ts
@@ -26,7 +26,8 @@ export const buildSlackManifest = (baseUrl: string) => {
       bot_user: { display_name: "Derive", always_online: true },
     },
     oauth_config: {
-      redirect_urls: [u("/v1/slack/oauth/callback")],
+      // The bot install callback + the per-user "Sign in with Slack" (OIDC) link callback.
+      redirect_urls: [u("/v1/slack/oauth/callback"), u("/v1/slack/link/callback")],
       scopes: { bot: SLACK_BOT_SCOPES },
     },
     settings: {

--- a/apps/api/test/slack-app-setup.test.ts
+++ b/apps/api/test/slack-app-setup.test.ts
@@ -10,7 +10,10 @@ describe("buildSlackManifest", () => {
     // The whole point: a self-hoster never hand-edits a placeholder (the gap that
     // left reply-back dead). Serialize and assert the token is gone entirely.
     expect(JSON.stringify(m)).not.toContain("<BASE_URL>")
-    expect(m.oauth_config.redirect_urls).toEqual([`${BASE}/v1/slack/oauth/callback`])
+    expect(m.oauth_config.redirect_urls).toEqual([
+      `${BASE}/v1/slack/oauth/callback`,
+      `${BASE}/v1/slack/link/callback`,
+    ])
     expect(m.settings.event_subscriptions.request_url).toBe(`${BASE}/v1/slack/events`)
   })
 

--- a/apps/api/test/slack-dm.test.ts
+++ b/apps/api/test/slack-dm.test.ts
@@ -201,6 +201,42 @@ describe("makeSlackDmSender (delivery)", () => {
     expect(calls.some((c) => c.url.endsWith("/conversations.open"))).toBe(true)
   })
 
+  it("prefers a linked Slack identity over the email lookup", async () => {
+    const meta = make("slack-dm-linked")
+    await connect(meta)
+    await meta.setSlackUserLink({
+      id: "sul-1",
+      org_id: "default",
+      user_id: linked.id,
+      team_id: "T1",
+      slack_user_id: "U-LINKED",
+      created_at: new Date().toISOString(),
+    })
+    const { artifact, comment } = await artifactAndComment(meta)
+    await enqueueSlackMentionDms({ meta, baseUrl }, artifact, comment, [
+      { id: linked.id, name: "Lin" },
+    ])
+
+    const calls: { url: string; body: Record<string, unknown> }[] = []
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: { body?: string }) => {
+        calls.push({ url, body: JSON.parse(init?.body ?? "{}") })
+        if (url.endsWith("/conversations.open"))
+          return new Response(JSON.stringify({ ok: true, channel: { id: "D-9" } }))
+        return new Response(JSON.stringify({ ok: true, ts: "1.1", channel: "D-9" }))
+      }),
+    )
+    const [row] = (await claim(meta)).filter((d) => d.kind === "slack_dm")
+    if (!row) throw new Error("no slack_dm row")
+    const res = await makeSlackDmSender(meta, KEY)(row)
+    expect(res.ok).toBe(true)
+    // The link resolved the Slack user directly — no email lookup at all.
+    expect(calls.some((c) => c.url.includes("/users.lookupByEmail"))).toBe(false)
+    const open = calls.find((c) => c.url.endsWith("/conversations.open"))
+    expect(JSON.stringify(open?.body)).toContain("U-LINKED")
+  })
+
   it("is a delivered no-op when the email has no matching Slack account", async () => {
     const meta = make("slack-dm-nomatch")
     await connect(meta)

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -7,7 +7,7 @@ import {
   type SlackThreadLinkRecord,
 } from "@derive/core"
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { encryptSecret } from "../src/lib/crypto"
+import { encryptSecret, signState } from "../src/lib/crypto"
 import {
   ingestSlackReply,
   makeSlackIngestSender,
@@ -211,6 +211,120 @@ describe("slack DM prefs (email-resolved, no linking)", () => {
       new Date(Date.now() + 120_000).toISOString(),
     )
     expect(rows.some((r) => r.kind === "slack_dm")).toBe(true)
+  })
+})
+
+describe("slack account linking (OIDC)", () => {
+  const connect = (meta: MetaStore, teamId = "T1") =>
+    meta.setSlackInstall({
+      org_id: "default",
+      team_id: teamId,
+      team_name: "Acme",
+      bot_token: encryptSecret("xoxb-1", KEY),
+      bot_user_id: "UBOT",
+      default_channel: "C1",
+      created_at: new Date().toISOString(),
+    })
+
+  // Stub the two OIDC back-channel calls (token exchange + userinfo).
+  const stubOidc = (userId: string, teamId: string, email = "o@x.com") =>
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request) => {
+        const u = String(url)
+        if (u.includes("openid.connect.token"))
+          return new Response(JSON.stringify({ ok: true, access_token: "xoxp-oidc" }), {
+            status: 200,
+          })
+        if (u.includes("openid.connect.userinfo"))
+          return new Response(
+            JSON.stringify({
+              "https://slack.com/user_id": userId,
+              "https://slack.com/team_id": teamId,
+              email,
+            }),
+            { status: 200 },
+          )
+        return new Response("{}", { status: 200 })
+      }),
+    )
+
+  it("starts the OIDC link flow for a signed-in user of a connected workspace", async () => {
+    const { app, meta } = make("slack-link-start")
+    await connect(meta)
+    const r = await app.request("/v1/slack/link", { headers: as(owner.email), redirect: "manual" })
+    expect(r.status).toBe(302)
+    const loc = r.headers.get("location") ?? ""
+    expect(loc).toContain("slack.com/openid/connect/authorize")
+    expect(loc).toContain("scope=openid")
+    expect(loc).toContain("team=T1") // pre-selects the connected workspace
+  })
+
+  it("stores a link on callback, bound to the user in the signed state", async () => {
+    const { app, meta } = make("slack-link-cb")
+    await connect(meta)
+    stubOidc("U777", "T1")
+    const state = signState({ org: "default", uid: owner.id }, KEY)
+    const r = await app.request(
+      `/v1/slack/link/callback?code=abc&state=${encodeURIComponent(state)}`,
+      { redirect: "manual", headers: as(owner.email) },
+    )
+    expect(r.status).toBe(302)
+    expect(r.headers.get("location")).toBe("/settings/integrations")
+    const link = await meta.getSlackUserLinkBySlackId("T1", "U777")
+    expect(link?.user_id).toBe(owner.id)
+    // Reverse + forward lookups both resolve.
+    expect((await meta.getSlackUserLinkByUser("T1", owner.id))?.slack_user_id).toBe("U777")
+    // Status now reports linked for that user.
+    const status = await (await app.request("/v1/slack", { headers: as(owner.email) })).json()
+    expect(status.linked).toBe(true)
+  })
+
+  it("rejects a linked identity from a different Slack team than the install", async () => {
+    const { app, meta } = make("slack-link-team")
+    await connect(meta, "T1")
+    stubOidc("U777", "T-OTHER") // userinfo says a different team
+    const state = signState({ org: "default", uid: owner.id }, KEY)
+    const r = await app.request(
+      `/v1/slack/link/callback?code=abc&state=${encodeURIComponent(state)}`,
+      { redirect: "manual", headers: as(owner.email) },
+    )
+    expect(r.status).toBe(302)
+    expect(r.headers.get("location")).toContain("error=link_team")
+    expect(await meta.getSlackUserLinkBySlackId("T-OTHER", "U777")).toBe(null)
+    expect(await meta.getSlackUserLinkByUser("T1", owner.id)).toBe(null)
+  })
+
+  it("rejects a callback whose session isn't the user in the signed state (link-CSRF guard)", async () => {
+    const { app, meta } = make("slack-link-csrf")
+    await connect(meta)
+    stubOidc("U777", "T1")
+    // State was minted for `owner`, but `editor` completes the callback — must not link.
+    const state = signState({ org: "default", uid: owner.id }, KEY)
+    const r = await app.request(
+      `/v1/slack/link/callback?code=abc&state=${encodeURIComponent(state)}`,
+      { redirect: "manual", headers: as(editor.email) },
+    )
+    expect(r.status).toBe(302)
+    expect(r.headers.get("location")).toContain("error=link")
+    expect(await meta.getSlackUserLinkBySlackId("T1", "U777")).toBe(null)
+    expect(await meta.getSlackUserLinkByUser("T1", owner.id)).toBe(null)
+  })
+
+  it("unlinks the caller's Slack identity", async () => {
+    const { app, meta } = make("slack-link-unlink")
+    await connect(meta)
+    await meta.setSlackUserLink({
+      id: "sul-1",
+      org_id: "default",
+      user_id: owner.id,
+      team_id: "T1",
+      slack_user_id: "U777",
+      created_at: new Date().toISOString(),
+    })
+    const r = await app.request("/v1/slack/link", { method: "DELETE", headers: as(owner.email) })
+    expect(r.status).toBe(204)
+    expect(await meta.getSlackUserLinkByUser("T1", owner.id)).toBe(null)
   })
 })
 
@@ -433,6 +547,53 @@ describe("slack events endpoint", () => {
     await drainIngest(meta)
     const mirrored = (await meta.listComments(artifact.id)).filter((c) => c.thread_id === "t-dup")
     expect(mirrored).toHaveLength(1)
+  })
+
+  it("attributes a reply from a linked Slack user to their Derive account", async () => {
+    const { app, meta } = make("slack-ev-linked")
+    const artifact = await seedThread(meta, {
+      artifact: "a-slk-lnk",
+      short: "slklnk01",
+      thread: "t-lnk",
+      ts: "888.1",
+    })
+    // U777 has linked their Slack identity to `owner` (display name "O").
+    await meta.setSlackUserLink({
+      id: "sul-x",
+      org_id: "default",
+      user_id: owner.id,
+      team_id: "T1",
+      slack_user_id: "U777",
+      created_at: new Date().toISOString(),
+    })
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({ ok: true, user: { profile: { display_name: "SlackName" } } }),
+            { status: 200 },
+          ),
+      ),
+    )
+    await postEvent(
+      app,
+      JSON.stringify({
+        type: "event_callback",
+        event: {
+          type: "message",
+          user: "U777",
+          text: "hi",
+          channel: "C1",
+          ts: "889.2",
+          thread_ts: "888.1",
+        },
+      }),
+    )
+    await drainIngest(meta)
+    const cm = (await meta.listComments(artifact.id)).find((c) => c.thread_id === "t-lnk")
+    expect(cm?.author_id).toBe(owner.id) // the Derive user, not "slack:U777"
+    expect(cm?.author).toBe("O") // the Derive display name, not the Slack one
   })
 
   it("enqueues nothing for a reply on a channel with no Derive thread link", async () => {

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -5521,6 +5521,8 @@ export interface components {
             needs_reauth: boolean;
             /** @description The caller's "DM me for interrupts" preference (mentions, review requests, shares) */
             slack_dm: boolean;
+            /** @description Whether the caller has linked their Slack identity for the connected team */
+            linked: boolean;
         };
         Report: {
             id: string;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -760,6 +760,9 @@ export const api = {
     f("/v1/slack/prefs", { ...opts({ slack_dm }), method: "PATCH" }).then(j),
   sendSlackTestDm: (): Promise<{ ok: boolean }> =>
     f("/v1/slack/test-dm", { ...opts({}), method: "POST" }).then(j),
+  // Link is a redirect to /v1/slack/link (full-page navigation); only unlink is a fetch.
+  unlinkSlack: (): Promise<void> =>
+    f("/v1/slack/link", { method: "DELETE", credentials: "include" }).then(() => undefined),
 
   // Workspace name + members (Admin / Creator / Viewer = owner / editor / commenter)
   getWorkspace: (): Promise<Workspace> => f("/v1/workspace", opts()).then(j),

--- a/apps/web/src/pages/settings/integrations-section.tsx
+++ b/apps/web/src/pages/settings/integrations-section.tsx
@@ -72,6 +72,12 @@ export function IntegrationsSection() {
     success: "Test DM sent",
   })
   const sendTestDm = () => testDm.mutate()
+  const unlink = useApiMutation({
+    mutationFn: () => api.unlinkSlack(),
+    success: "Slack account unlinked",
+    invalidate: [slackQuery().queryKey],
+  })
+  const unlinkSlack = () => unlink.mutate()
 
   return (
     <SettingsSection
@@ -195,7 +201,7 @@ export function IntegrationsSection() {
             <SettingRow
               htmlFor="toggle-slack-dm"
               label="DM me for interrupts"
-              description="A Slack direct message when someone @mentions you, requests your review, or shares a doc with you — the same events that email you. Resolved by your account email — no separate Slack sign-in needed."
+              description="A Slack direct message when someone @mentions you, requests your review, or shares a doc with you — the same events that email you. Link your Slack account below for reliable delivery; otherwise Derive matches you by account email."
             >
               <div className="flex items-center gap-2">
                 <Button
@@ -214,6 +220,30 @@ export function IntegrationsSection() {
                   onCheckedChange={toggleSlackDm}
                 />
               </div>
+            </SettingRow>
+            <SettingRow
+              label="Your Slack account"
+              description={
+                slack.linked
+                  ? "Linked. DMs and thread attribution resolve to your Slack identity directly."
+                  : "Link your Slack account so DMs reach you even if your Slack email differs, and Slack replies are attributed to you."
+              }
+            >
+              {slack.linked ? (
+                <Button
+                  data-testid="slack-unlink"
+                  variant="outline"
+                  size="sm"
+                  onClick={unlinkSlack}
+                  loading={unlink.isPending}
+                >
+                  Unlink
+                </Button>
+              ) : (
+                <Button data-testid="slack-link" variant="default" size="sm" asChild>
+                  <a href="/v1/slack/link">Link account</a>
+                </Button>
+              )}
             </SettingRow>
             <FormField label="Default channel ID" htmlFor="slack-channel" className="max-w-sm">
               <div className="flex gap-2">

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -322,6 +322,18 @@ CREATE TABLE IF NOT EXISTS slack_thread_link (
   UNIQUE (channel, message_ts)
 );
 
+CREATE TABLE IF NOT EXISTS slack_user_link (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  team_id TEXT NOT NULL,
+  slack_user_id TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  UNIQUE (team_id, slack_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS slack_user_link_user ON slack_user_link (team_id, user_id);
+
 CREATE TABLE IF NOT EXISTS user_notification_pref (
   id TEXT PRIMARY KEY,
   org_id TEXT NOT NULL,

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -688,6 +688,17 @@ export interface IntegrationStore {
   getSlackThreadLinkByTs(channel: string, ts: string): Promise<SlackThreadLinkRecord | null>
   /** Record the Slack message ↔ Derive thread mapping (idempotent on thread_id). */
   setSlackThreadLink(l: SlackThreadLinkRecord): Promise<void>
+  /** Resolve a Slack user (team + user id) to the Derive user who linked it, or null. */
+  getSlackUserLinkBySlackId(
+    teamId: string,
+    slackUserId: string,
+  ): Promise<SlackUserLinkRecord | null>
+  /** The Slack identity a Derive user linked for a team, or null. */
+  getSlackUserLinkByUser(teamId: string, userId: string): Promise<SlackUserLinkRecord | null>
+  /** Link a Derive user to a Slack identity (idempotent on (team_id, slack_user_id)). */
+  setSlackUserLink(l: SlackUserLinkRecord): Promise<void>
+  /** Remove a Derive user's Slack link for a team. */
+  deleteSlackUserLink(teamId: string, userId: string): Promise<void>
   /** A user's notification preferences in a workspace, or null (⇒ defaults). */
   getUserNotificationPref(orgId: string, userId: string): Promise<UserNotificationPrefRecord | null>
   /** Upsert a user's notification preferences (idempotent on workspace + user). */
@@ -1801,6 +1812,19 @@ export interface SlackThreadLinkRecord {
   thread_id: string
   channel: string
   message_ts: string
+  created_at: string
+}
+
+/** Links a Derive user to their Slack identity, so Slack events/DMs resolve to the real
+ *  account instead of guessing by email. Keyed on (team_id, slack_user_id): a Slack user id
+ *  is unique per workspace, and one Derive user can link across several workspaces. `org_id`
+ *  is the workspace the link was made from (context, not part of the identity key). */
+export interface SlackUserLinkRecord {
+  id: string
+  org_id: string
+  user_id: string
+  team_id: string
+  slack_user_id: string
   created_at: string
 }
 

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -442,6 +442,21 @@ export const slackThreadLink = pgTable(
     uniqueIndex("slack_thread_link_msg").on(t.channel, t.message_ts),
   ],
 )
+export const slackUserLink = pgTable(
+  "slack_user_link",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    user_id: text("user_id").notNull(),
+    team_id: text("team_id").notNull(),
+    slack_user_id: text("slack_user_id").notNull(),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [
+    uniqueIndex("slack_user_link_slack").on(t.team_id, t.slack_user_id),
+    index("slack_user_link_user").on(t.team_id, t.user_id),
+  ],
+)
 export const githubApp = pgTable("github_app", {
   id: text("id").primaryKey(),
   app_id: text("app_id").notNull(),
@@ -666,6 +681,7 @@ const TABLES = [
   orgSettings,
   slackInstall,
   slackThreadLink,
+  slackUserLink,
   userNotificationPref,
   githubApp,
   githubInstallation,

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -78,6 +78,7 @@ import type {
   SessionState,
   SlackInstallRecord,
   SlackThreadLinkRecord,
+  SlackUserLinkRecord,
   TakedownInput,
   UserDir,
   UserNotificationPrefRecord,
@@ -143,6 +144,7 @@ import {
   sessionMessage,
   slackInstall,
   slackThreadLink,
+  slackUserLink,
   userNotificationPref,
   version,
   webhook,
@@ -1628,6 +1630,38 @@ export class PgMetaStore implements MetaStore {
       .insert(slackThreadLink)
       .values(l)
       .onConflictDoUpdate({ target: slackThreadLink.thread_id, set })
+  }
+  async getSlackUserLinkBySlackId(
+    teamId: string,
+    slackUserId: string,
+  ): Promise<SlackUserLinkRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(slackUserLink)
+      .where(and(eq(slackUserLink.team_id, teamId), eq(slackUserLink.slack_user_id, slackUserId)))
+    return rows[0] ?? null
+  }
+  async getSlackUserLinkByUser(
+    teamId: string,
+    userId: string,
+  ): Promise<SlackUserLinkRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(slackUserLink)
+      .where(and(eq(slackUserLink.team_id, teamId), eq(slackUserLink.user_id, userId)))
+    return rows[0] ?? null
+  }
+  async setSlackUserLink(l: SlackUserLinkRecord): Promise<void> {
+    const { id: _i, created_at: _c, ...set } = l
+    await this.db
+      .insert(slackUserLink)
+      .values(l)
+      .onConflictDoUpdate({ target: [slackUserLink.team_id, slackUserLink.slack_user_id], set })
+  }
+  async deleteSlackUserLink(teamId: string, userId: string): Promise<void> {
+    await this.db
+      .delete(slackUserLink)
+      .where(and(eq(slackUserLink.team_id, teamId), eq(slackUserLink.user_id, userId)))
   }
   async getUserNotificationPref(
     orgId: string,

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -75,6 +75,7 @@ import type {
   SessionState,
   SlackInstallRecord,
   SlackThreadLinkRecord,
+  SlackUserLinkRecord,
   TakedownInput,
   UserNotificationPrefRecord,
   UserProfile,
@@ -140,6 +141,7 @@ import {
   sessionMessage,
   slackInstall,
   slackThreadLink,
+  slackUserLink,
   userNotificationPref,
   version,
   webhook,
@@ -1792,6 +1794,38 @@ export function makeRepos(db: SqliteDb) {
       .onConflictDoUpdate({ target: slackThreadLink.thread_id, set })
       .run()
   }
+  const getSlackUserLinkBySlackId = async (
+    teamId: string,
+    slackUserId: string,
+  ): Promise<SlackUserLinkRecord | null> =>
+    (await db
+      .select()
+      .from(slackUserLink)
+      .where(and(eq(slackUserLink.team_id, teamId), eq(slackUserLink.slack_user_id, slackUserId)))
+      .get()) ?? null
+  const getSlackUserLinkByUser = async (
+    teamId: string,
+    userId: string,
+  ): Promise<SlackUserLinkRecord | null> =>
+    (await db
+      .select()
+      .from(slackUserLink)
+      .where(and(eq(slackUserLink.team_id, teamId), eq(slackUserLink.user_id, userId)))
+      .get()) ?? null
+  const setSlackUserLink = async (l: SlackUserLinkRecord): Promise<void> => {
+    const { id: _i, created_at: _c, ...set } = l
+    await db
+      .insert(slackUserLink)
+      .values(l)
+      .onConflictDoUpdate({ target: [slackUserLink.team_id, slackUserLink.slack_user_id], set })
+      .run()
+  }
+  const deleteSlackUserLink = async (teamId: string, userId: string): Promise<void> => {
+    await db
+      .delete(slackUserLink)
+      .where(and(eq(slackUserLink.team_id, teamId), eq(slackUserLink.user_id, userId)))
+      .run()
+  }
   const getUserNotificationPref = async (
     orgId: string,
     userId: string,
@@ -2763,6 +2797,10 @@ export function makeRepos(db: SqliteDb) {
     getSlackThreadLinkByThread,
     getSlackThreadLinkByTs,
     setSlackThreadLink,
+    getSlackUserLinkBySlackId,
+    getSlackUserLinkByUser,
+    setSlackUserLink,
+    deleteSlackUserLink,
     getUserNotificationPref,
     setUserNotificationPref,
     upsertGithubInstallation,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -523,6 +523,25 @@ export const slackThreadLink = sqliteTable(
   ],
 )
 
+// Derive user ↔ their Slack identity in a workspace (from the "Link Slack account" OIDC
+// flow). Keyed on (team_id, slack_user_id) — a Slack user id is per-workspace — so a Slack
+// event/DM resolves to the real Derive account instead of an email guess.
+export const slackUserLink = sqliteTable(
+  "slack_user_link",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    user_id: text("user_id").notNull(),
+    team_id: text("team_id").notNull(),
+    slack_user_id: text("slack_user_id").notNull(),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [
+    uniqueIndex("slack_user_link_slack").on(t.team_id, t.slack_user_id),
+    index("slack_user_link_user").on(t.team_id, t.user_id),
+  ],
+)
+
 export const githubApp = sqliteTable("github_app", {
   id: text("id").primaryKey(),
   app_id: text("app_id").notNull(),
@@ -793,6 +812,7 @@ const TABLES = [
   orgSettings,
   slackInstall,
   slackThreadLink,
+  slackUserLink,
   userNotificationPref,
   githubApp,
   githubInstallation,


### PR DESCRIPTION
## What

Increment 3 (the keystone) of the Slack program: a member **links their Slack identity** to their Derive account, so Slack events and DMs resolve to the real account instead of guessing by email. This unblocks per-user scoping for the remaining UX (`/derive`, App Home) and per-user "Approve" authz.

## How

- **Hand-rolled OIDC "Sign in with Slack"** flow, separate from the admin bot install (Slack forbids mixing `openid` with bot scopes): `GET /v1/slack/link` signs `{org,uid}` and redirects to `openid/connect/authorize` (pre-selecting the connected team) → `GET /v1/slack/link/callback` exchanges the code, reads identity from the back-channel `openid.connect.userinfo` (the namespaced `https://slack.com/user_id`/`team_id` claims — the same ids the bot sees), verifies the identity's team matches the workspace's install, and stores the link → `DELETE /v1/slack/link` unlinks.
- **New `slack_user_link` table** across sqlite/pg/d1, keyed `UNIQUE(team_id, slack_user_id) → user_id` (a Slack user is per-workspace; one Derive user links across workspaces). `d1-schema.sql` regenerated via the generator, not hand-edited.
- **Consumers wired**: DM delivery prefers the link over the lossy `users.lookupByEmail`; inbound Slack replies are **attributed to the linked Derive user** (`author_id` = the user, not `slack:<id>`).
- `status.linked` + a Settings **Link account / Unlink** control; OpenAPI + web types regenerated.

## Security (from the adversarial audit)

- **Link-CSRF fixed**: the callback now requires a session **and** asserts it matches the signed state's `uid`. The state proves who *initiated* the link but rides the browser URL (leakable / replayable for 15 min); without the session match, a stolen state would let an attacker complete the link and route a **victim's DMs to their own Slack**. Pinned by a test.
- **No email auto-linking**: keyed purely on the OIDC `(team_id, slack_user_id)` + the authenticated user — the returned email is never used to link (avoids the classic takeover vector).
- Team-bind check rejects linking an identity from a different workspace than the install.
- Known, documented (low): a linked-but-deactivated Slack account's DM retries then dead-letters rather than falling back to email; re-link/unlink fixes it.

## Testing

- `pnpm run ci` ✅ · `pnpm typecheck` ✅ · full suite ✅ (apps/api 1023, web 156, db 199) · `test:pg` ✅ (33 Slack tests on real Postgres).
- New tests: link start (redirect + team pre-select), callback stores link + reverse/forward lookups + `status.linked`, **wrong-team reject**, **link-CSRF reject (session ≠ state)**, unlink, DM **prefers link over email**, reply **attributed to linked Derive user**, manifest link redirect URL.

## Follow-ups (unchanged plan)

With linking in place, the remaining increment-2 UX can be built per-user-safely: `/derive` search scoped to what you can see, a personalized App Home, and Slack "Approve" authorized as your Derive role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)