### PR TITLE
feat(slack): post publishes + proposal updates to the connected channel

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -139,9 +139,10 @@ https://derive.example.com/api/auth/oauth2/callback/<OIDC_PROVIDER_ID>
 ### Slack app (optional)
 
 To connect Slack workspaces (Derive comments mirrored to a channel with two-way
-reply-back and a Resolve/Reopen button on each comment card, plus DMs to a member for
-mentions, review requests and shares — reliable once a member links their Slack account),
-create one Slack app for this instance:
+reply-back and a Resolve/Reopen button on each comment card, plus top-level cards for
+publishes and proposal updates, plus DMs to a member for mentions, review requests and
+shares — reliable once a member links their Slack account), create one Slack app for
+this instance:
 
 1. Open **Settings → Integrations → Set up Slack app** (or go straight to `/settings/slack/app/new`). This renders the app manifest already filled in with this instance's URL, so the event subscriptions, interactivity, and bot scopes are configured for you — nothing to hand-edit. At [api.slack.com/apps](https://api.slack.com/apps) → **Create New App → From a manifest**, paste it, and create the app.
 2. From the app's **Basic Information** page, set `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, and `SLACK_SIGNING_SECRET` (all three required, or Slack stays off). On Workers these are secrets: `wrangler secret put SLACK_CLIENT_ID` (and the other two).

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -37,6 +37,7 @@ import {
   type RateLimiters,
   rateLimited,
 } from "./lib/rate-limit"
+import { enqueueSlackChannelEvent } from "./lib/slack-comments"
 import { log } from "./log"
 import { enqueueRender } from "./previews"
 import { edgeCtx } from "./realtime-do"
@@ -250,20 +251,40 @@ export function buildContext(deps: AppDeps) {
   // delivers). Awaited so the row is durable before we respond, but never fatal.
   // When something was enqueued, poke the drainer so it goes out now instead of on
   // the next interval/alarm tick.
-  const notify = (a: ArtifactRecord, event: WebhookEvent, data: Record<string, unknown>) =>
-    enqueueForEvent(meta, deps.baseUrl, a, event, data)
+  const logEnqueueError =
+    (what: string, a: ArtifactRecord, event: WebhookEvent) => (err: unknown) =>
+      // Non-fatal (the request still succeeds), but a dropped enqueue means the delivery
+      // silently never fires — log it rather than swallow.
+      log.error(`${what} enqueue failed`, {
+        event,
+        artifact: a.short_id,
+        error: err instanceof Error ? err.message : String(err),
+      })
+
+  const notify = (
+    a: ArtifactRecord,
+    event: WebhookEvent,
+    data: Record<string, unknown>,
+  ): Promise<void> => {
+    // The two fan-outs are independent: one's failure must not skip the other's drain poke.
+    // User-configured webhooks (generic + Slack incoming-webhook rows).
+    const webhooks = enqueueForEvent(meta, deps.baseUrl, a, event, data)
       .then((queued) => {
         if (queued > 0) deps.pokeWebhooks?.()
       })
-      .catch((err) =>
-        // Non-fatal (the request still succeeds), but a dropped enqueue means the
-        // webhook silently never fires — log it rather than swallow.
-        log.error("webhook enqueue failed", {
-          event,
-          artifact: a.short_id,
-          error: err instanceof Error ? err.message : String(err),
-        }),
-      )
+      .catch(logEnqueueError("webhook", a, event))
+    // The connected Slack App's channel — a top-level card for artifact-lifecycle events
+    // (publish / proposal), gated inside the helper on visibility + connected channel + slackPost.
+    // Skipped entirely when no Slack app is configured on this instance (no wasted lookup).
+    const channel = deps.slack
+      ? enqueueSlackChannelEvent(meta, deps.baseUrl, a, event, data)
+          .then((posted) => {
+            if (posted) deps.pokeWebhooks?.()
+          })
+          .catch(logEnqueueError("slack channel", a, event))
+      : Promise.resolve()
+    return Promise.all([webhooks, channel]).then(() => {})
+  }
 
   // Enqueue a screenshot render for a newly-published version. Fire-and-forget,
   // mirroring `notify` above: non-fatal (logged on error), never awaited in the

--- a/apps/api/src/lib/slack-comments.ts
+++ b/apps/api/src/lib/slack-comments.ts
@@ -8,16 +8,18 @@
 import type { DeliveryRecord } from "@derive/core"
 import {
   type ArtifactRecord,
+  artifactUrl,
   type CommentRecord,
   type MetaStore,
   newId,
   type SlackThreadLinkRecord,
 } from "@derive/core"
 import type { EventBus } from "../bus"
+import type { WebhookEvent } from "../events"
 import { type ChannelSendResult, enqueueChannelDelivery } from "../webhooks"
 import { commentDeepLink, parseMeta } from "./comments"
 import { slackUserName } from "./slack"
-import { actionButton, actions, context, section } from "./slack-cards"
+import { actionButton, actions, context, escapeMrkdwn, section } from "./slack-cards"
 import { postWithRecovery, resolveBotToken } from "./slack-delivery"
 import { truncate } from "./text"
 
@@ -54,6 +56,87 @@ export const enqueueSlackComment = async (
     author: cm.author,
   }
   await enqueueChannelDelivery(meta, "slack_app", "comment.created", payload)
+}
+
+/** The self-contained payload for a channel EVENT card (publish / proposal lifecycle). Carried
+ *  on a `slack_app` delivery whose `event_type` is the event — the sender routes on that, so
+ *  event cards and the comment mirror share the kind without a payload discriminator. */
+interface SlackEventPayload {
+  orgId: string
+  event: WebhookEvent
+  title: string
+  link: string
+  author: string
+  version: number | null
+  message: string | null
+}
+
+/** Artifact-lifecycle events that post a top-level card to the connected channel (comments
+ *  mirror separately + threaded, so they're NOT here). Everything else `notify` fans out to
+ *  webhooks only. */
+const CHANNEL_EVENTS = new Set<WebhookEvent>([
+  "version.published",
+  "proposal.created",
+  "proposal.approved",
+  "proposal.changes_requested",
+])
+
+/** Enqueue a top-level channel card for an artifact-lifecycle event, when the org has a
+ *  connected channel and the mirror (slackPost) is on. Returns whether it enqueued (so the
+ *  caller can poke the drainer). Cheap no-op for the common case — the event whitelist is
+ *  checked before any DB lookup. */
+export const enqueueSlackChannelEvent = async (
+  meta: MetaStore,
+  baseUrl: string,
+  artifact: ArtifactRecord,
+  event: WebhookEvent,
+  data: Record<string, unknown>,
+): Promise<boolean> => {
+  if (!CHANNEL_EVENTS.has(event)) return false
+  // Only broadcast feed-visible artifacts. A private draft (listed "none") is visible to its
+  // owner + explicit shares — its publish/proposal title must not leak to the org-wide channel.
+  if (artifact.listed === "none") return false
+  const install = await meta.getSlackInstall(artifact.org_id)
+  if (!install?.default_channel) return false
+  if (!(await meta.getOrgSettings(artifact.org_id)).slackPost) return false
+  const actor = [data.author, data.approver, data.reviewer].find((v) => typeof v === "string")
+  const payload: SlackEventPayload = {
+    orgId: artifact.org_id,
+    event,
+    title: artifact.title ?? artifact.short_id,
+    link: artifactUrl(baseUrl, artifact),
+    author: typeof actor === "string" ? actor : "someone",
+    version: typeof data.version === "number" ? data.version : null,
+    message: typeof data.message === "string" ? data.message : null,
+  }
+  await enqueueChannelDelivery(meta, "slack_app", event, payload)
+  return true
+}
+
+/** Block Kit for a channel event card. Untrusted text (title, author, message) is escaped so
+ *  it can't break out of a `<url|text>` link or inject markup. */
+const eventBlocks = (p: SlackEventPayload): unknown[] => {
+  const link = `<${p.link}|${escapeMrkdwn(p.title)}>`
+  const who = escapeMrkdwn(p.author)
+  let head: string
+  switch (p.event) {
+    case "version.published":
+      head = `:package: *${link}* — v${p.version ?? "?"} published by ${who}`
+      break
+    case "proposal.created":
+      head = `:pencil2: *${who}* proposed a change to ${link}`
+      break
+    case "proposal.approved":
+      head = `:white_check_mark: A proposal for ${link} was approved${p.version ? ` — now v${p.version}` : ""}`
+      break
+    case "proposal.changes_requested":
+      head = `:leftwards_arrow_with_hook: Changes were requested on a proposal for ${link}`
+      break
+    default:
+      head = `${link} — ${escapeMrkdwn(p.event)}`
+  }
+  const body = p.message ? `${head}\n> ${escapeMrkdwn(truncate(p.message, 280))}` : head
+  return [section(body), context(`Derive · ${p.event}`)]
 }
 
 /** The interactivity `action_id`s a comment card's buttons carry. The handler in
@@ -106,6 +189,27 @@ const blocksFor = (p: SlackCommentPayload): unknown[] => [
 export const makeSlackSender =
   (meta: MetaStore, encryptionKey: string | undefined) =>
   async (d: DeliveryRecord): Promise<ChannelSendResult> => {
+    // Event cards (publish / proposal lifecycle) ride the same kind but a different event_type,
+    // and post top-level (not threaded under an artifact's comment message).
+    if (d.event_type !== "comment.created") {
+      const e = JSON.parse(d.payload) as SlackEventPayload
+      // Defensive: only enqueueSlackChannelEvent produces non-comment slack_app rows today, but
+      // guard against a future comment-shaped payload mis-routing here (no `event` → skip).
+      if (typeof e.event !== "string") return { ok: true, status: "skipped: not an event payload" }
+      const bot = await resolveBotToken(meta, e.orgId, encryptionKey)
+      if (!bot?.install.default_channel) return { ok: true, status: "skipped: slack not connected" }
+      return postWithRecovery(
+        meta,
+        e.orgId,
+        bot.token,
+        {
+          channel: bot.install.default_channel,
+          text: `${e.author}: ${e.event} · ${e.title}`,
+          blocks: eventBlocks(e),
+        },
+        { autoJoin: true, textFallback: true },
+      )
+    }
     const p = JSON.parse(d.payload) as SlackCommentPayload
     const bot = await resolveBotToken(meta, p.orgId, encryptionKey)
     if (!bot?.install.default_channel) return { ok: true, status: "skipped: slack not connected" }

--- a/apps/api/src/slack-app-setup.ts
+++ b/apps/api/src/slack-app-setup.ts
@@ -19,7 +19,7 @@ export const buildSlackManifest = (baseUrl: string) => {
     display_information: {
       name: "Derive",
       description:
-        "Get Derive comments in a Slack channel, reply back from the thread, and DM members for mentions, review requests and shares.",
+        "Get Derive comments, publishes and proposal updates in a Slack channel, reply back from the thread, and DM members for mentions, review requests and shares.",
       background_color: "#1a1a2e",
     },
     features: {

--- a/apps/api/test/comment-fanout.test.ts
+++ b/apps/api/test/comment-fanout.test.ts
@@ -1,6 +1,7 @@
 import type { DeliveryRecord } from "@derive/core"
 import { DEFAULT_ORG_SETTINGS } from "@derive/core"
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { makeSlackSender } from "../src/lib/slack-comments"
 import { as, jsonAs, makeAuthedApp, pub, type TestUser } from "./helpers"
 
 // The other interrupt-worthy emails ride the same outbox: a review request (the
@@ -146,6 +147,93 @@ describe("comment channel fan-out", () => {
     await comment(app, shortId, owner.email)
     const kinds = (await claim(meta)).map((d) => d.kind)
     expect(kinds).not.toContain("slack_app")
+  })
+})
+
+describe("connected-channel event cards (publishes / proposals)", () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  // An install can't exist without the instance having Slack creds, so the app is built with
+  // them (notify only fans to the channel when `deps.slack` is set).
+  const authed = (name: string) =>
+    makeAuthedApp(name, [owner], "editor", {
+      deps: { slack: { clientId: "c", clientSecret: "s", signingSecret: "sig" } },
+    })
+
+  const connect = (meta: Awaited<ReturnType<typeof makeAuthedApp>>["meta"]) =>
+    meta.setSlackInstall({
+      org_id: "default",
+      team_id: "T1",
+      team_name: "Acme",
+      bot_token: "xoxb-plain",
+      bot_user_id: "UBOT",
+      default_channel: "C1",
+      created_at: new Date().toISOString(),
+    })
+
+  it("a publish posts a version.published card to the connected channel", async () => {
+    const { app, meta } = authed("chan-publish")
+    await connect(meta)
+    await newArtifact(app) // publishes v1 → version.published
+    const card = (await claim(meta)).find(
+      (d) => d.kind === "slack_app" && d.event_type === "version.published",
+    )
+    expect(card).toBeTruthy()
+  })
+
+  it("does not post a channel card for a PRIVATE artifact's publish (no leak)", async () => {
+    const { app, meta } = authed("chan-private")
+    await connect(meta)
+    await pub(app, "# Secret", { visibility: "private" }, undefined, as(owner.email))
+    expect((await claim(meta)).map((d) => d.kind)).not.toContain("slack_app")
+  })
+
+  it("posts no channel card when the mirror (slackPost) is off", async () => {
+    const { app, meta } = authed("chan-off")
+    await connect(meta)
+    await meta.setOrgSettings("default", { ...DEFAULT_ORG_SETTINGS, slackPost: false })
+    await newArtifact(app)
+    expect((await claim(meta)).map((d) => d.kind)).not.toContain("slack_app")
+  })
+
+  it("the sender posts an event card top-level (not threaded under a comment)", async () => {
+    const { meta } = authed("chan-sender")
+    await connect(meta)
+    const d: DeliveryRecord = {
+      id: "wd-evt",
+      webhook_id: "internal",
+      url: "",
+      secret: "",
+      kind: "slack_app",
+      event_type: "version.published",
+      payload: JSON.stringify({
+        orgId: "default",
+        event: "version.published",
+        title: "Doc",
+        link: "https://derive.test/artifacts/abc",
+        author: "Ann",
+        version: 2,
+        message: null,
+      }),
+      status: "pending",
+      attempts: 0,
+      last_error: null,
+      next_attempt_at: new Date().toISOString(),
+      created_at: new Date().toISOString(),
+    }
+    let sent: { channel?: string; thread_ts?: string; blocks?: unknown } = {}
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: { body?: string }) => {
+        sent = JSON.parse(init?.body ?? "{}")
+        return new Response(JSON.stringify({ ok: true, ts: "1.1", channel: "C1" }))
+      }),
+    )
+    const res = await makeSlackSender(meta, "k")(d)
+    expect(res.ok).toBe(true)
+    expect(sent.channel).toBe("C1")
+    expect(sent.thread_ts).toBeUndefined() // top-level, not a threaded reply
+    expect(JSON.stringify(sent.blocks)).toContain("published")
   })
 })
 


### PR DESCRIPTION
## What

The connected Slack app posted only **comment** cards to the channel. Now it also posts **top-level cards for the artifact lifecycle** — version published, proposal created, proposal approved, changes requested. This also puts **proposal cards in the channel**, the prerequisite for approving a proposal from Slack.

## How

- Wired at the **`notify` fan-out chokepoint** (`context.ts`), so all four emit sites (after-publish, proposals, proposal-actions) are covered by one change. A whitelist `Set` short-circuits before any DB read, so the common comment/mention path pays nothing.
- Shares the `slack_app` sender, discriminated by the delivery's `event_type`: `comment.created` stays the threaded mirror; everything else posts a **top-level** event card (no thread).
- Gated like the comment mirror (connected `default_channel` + `slackPost`).

## From the adversarial audit

- **Visibility (MEDIUM)**: channel cards are gated on `listed != none`, so a **private draft's** publish or proposal title never broadcasts to the org-wide channel — a new exposure the naive version would have introduced. *(The pre-existing comment mirror doesn't gate on visibility — a separate, older issue, noted for follow-up.)*
- `notify`'s two fan-outs (webhooks + Slack channel) are **decoupled** so one failing can't skip the other's drain poke.
- The Slack fan-out is skipped when no Slack app is configured on the instance (no wasted lookup per publish).
- Sender guards against a mis-routed payload; untrusted title/author/message are escaped (no link injection).

## Testing

- `pnpm run ci` ✅ · `pnpm typecheck` ✅ · full suite ✅ (apps/api 1034) · `test:pg` ✅ (14).
- New tests: publish → `version.published` channel card, **private-artifact publish → NO card (no leak)**, `slackPost` off → no card, sender posts **top-level (no thread_ts)**.

## Next

Proposal cards are now in-channel, so **Slack "Approve"** (approve/request-changes from a button, authorized as your Derive editor role via the account link) is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)