### PR TITLE
feat(slack): approve / request-changes a proposal from Slack

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -140,9 +140,10 @@ https://derive.example.com/api/auth/oauth2/callback/<OIDC_PROVIDER_ID>
 
 To connect Slack workspaces (Derive comments mirrored to a channel with two-way
 reply-back and a Resolve/Reopen button on each comment card, plus top-level cards for
-publishes and proposal updates, plus DMs to a member for mentions, review requests and
-shares — reliable once a member links their Slack account), create one Slack app for
-this instance:
+publishes and proposal updates — with Approve / Request-changes buttons on a proposal
+card, authorized as the clicker's linked Derive account — plus DMs to a member for
+mentions, review requests and shares (reliable once a member links their Slack account),
+create one Slack app for this instance:
 
 1. Open **Settings → Integrations → Set up Slack app** (or go straight to `/settings/slack/app/new`). This renders the app manifest already filled in with this instance's URL, so the event subscriptions, interactivity, and bot scopes are configured for you — nothing to hand-edit. At [api.slack.com/apps](https://api.slack.com/apps) → **Create New App → From a manifest**, paste it, and create the app.
 2. From the app's **Basic Information** page, set `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, and `SLACK_SIGNING_SECRET` (all three required, or Slack stays off). On Workers these are secrets: `wrangler secret put SLACK_CLIENT_ID` (and the other two).

--- a/apps/api/src/lib/slack-comments.ts
+++ b/apps/api/src/lib/slack-comments.ts
@@ -63,13 +63,26 @@ export const enqueueSlackComment = async (
  *  event cards and the comment mirror share the kind without a payload discriminator. */
 interface SlackEventPayload {
   orgId: string
+  artifactId: string
   event: WebhookEvent
   title: string
   link: string
   author: string
   version: number | null
   message: string | null
+  /** The proposal id, for a proposal.created card — carried on its Approve buttons. */
+  proposalId: string | null
 }
+
+/** The interactivity `action_id`s an in-channel proposal card's buttons carry. */
+export const SLACK_PROPOSAL_ACTION = {
+  approve: "derive_proposal_approve",
+  requestChanges: "derive_proposal_request_changes",
+} as const
+
+/** Encode a proposal button's `value`: which proposal on which artifact to act on. */
+export const encodeProposalAction = (artifactId: string, proposalId: string): string =>
+  JSON.stringify({ a: artifactId, p: proposalId })
 
 /** Artifact-lifecycle events that post a top-level card to the connected channel (comments
  *  mirror separately + threaded, so they're NOT here). Everything else `notify` fans out to
@@ -102,12 +115,14 @@ export const enqueueSlackChannelEvent = async (
   const actor = [data.author, data.approver, data.reviewer].find((v) => typeof v === "string")
   const payload: SlackEventPayload = {
     orgId: artifact.org_id,
+    artifactId: artifact.id,
     event,
     title: artifact.title ?? artifact.short_id,
     link: artifactUrl(baseUrl, artifact),
     author: typeof actor === "string" ? actor : "someone",
     version: typeof data.version === "number" ? data.version : null,
     message: typeof data.message === "string" ? data.message : null,
+    proposalId: typeof data.proposal_id === "string" ? data.proposal_id : null,
   }
   await enqueueChannelDelivery(meta, "slack_app", event, payload)
   return true
@@ -136,7 +151,20 @@ const eventBlocks = (p: SlackEventPayload): unknown[] => {
       head = `${link} — ${escapeMrkdwn(p.event)}`
   }
   const body = p.message ? `${head}\n> ${escapeMrkdwn(truncate(p.message, 280))}` : head
-  return [section(body), context(`Derive · ${p.event}`)]
+  const blocks: unknown[] = [section(body)]
+  // An open proposal gets Approve / Request-changes buttons (the clicker is authorized as
+  // their linked Derive user in the interactivity handler).
+  if (p.event === "proposal.created" && p.proposalId) {
+    const value = encodeProposalAction(p.artifactId, p.proposalId)
+    blocks.push(
+      actions([
+        actionButton(SLACK_PROPOSAL_ACTION.approve, "Approve", value, "primary"),
+        actionButton(SLACK_PROPOSAL_ACTION.requestChanges, "Request changes", value),
+      ]),
+    )
+  }
+  blocks.push(context(`Derive · ${p.event}`))
+  return blocks
 }
 
 /** The interactivity `action_id`s a comment card's buttons carry. The handler in

--- a/apps/api/src/lib/slack-proposal.ts
+++ b/apps/api/src/lib/slack-proposal.ts
@@ -1,0 +1,96 @@
+// Approve / request-changes a proposal from a Slack button. Unlike thread resolve (a low-stakes
+// action gated only by the channel connection), approving a proposal is editor-level, so it is
+// authorized AS the clicking user's linked Derive account — the whole reason account linking is a
+// prerequisite. Runs the same proposal-actions pipeline the HTTP route does.
+
+import { type Actor, can, maxRole } from "@derive/core"
+import {
+  approveProposalAction,
+  type ProposalActionDeps,
+  requestChangesAction,
+} from "./proposal-actions"
+import { postSlackResponseUrl } from "./slack"
+import { context, escapeMrkdwn } from "./slack-cards"
+
+export interface SlackProposalArgs {
+  teamId: string
+  slackUserId: string
+  proposalId: string
+  artifactId: string
+  op: "approve" | "request_changes"
+  /** Where to send the ephemeral outcome / card update (from the interaction payload). */
+  responseUrl?: string
+  /** The original card's first block, kept when we replace the card after a decision. */
+  sectionBlock?: unknown
+}
+
+/** Resolve the clicking Slack user to their Derive account, authorize (editor), run the action,
+ *  and update the Slack card / send an ephemeral error. All feedback rides `response_url` so this
+ *  can run off the interaction ack path (approving publishes a version — not sub-3s work). */
+export const runSlackProposalAction = async (
+  deps: ProposalActionDeps,
+  args: SlackProposalArgs,
+): Promise<void> => {
+  const eph = (text: string): Promise<boolean> =>
+    args.responseUrl
+      ? postSlackResponseUrl(args.responseUrl, { text, response_type: "ephemeral" })
+      : Promise.resolve(false)
+
+  // No link → no Derive principal to authorize against; prompt them to link (private msg).
+  const link = await deps.meta.getSlackUserLinkBySlackId(args.teamId, args.slackUserId)
+  if (!link) {
+    await eph("Link your Slack account (Settings → Integrations) to approve proposals from Slack.")
+    return
+  }
+  const artifact = await deps.meta.getArtifactById(args.artifactId)
+  const proposal = await deps.meta.getProposal(args.proposalId)
+  if (!artifact || !proposal || proposal.artifact_id !== artifact.id) {
+    await eph("That proposal is no longer available.")
+    return
+  }
+
+  // Authorize as the linked Derive user — mirrors context.actorFor's human branch, then can().
+  const orgRole = (await deps.meta.getMembership(artifact.org_id, link.user_id))?.role ?? null
+  const am = await deps.meta.getArtifactMember(artifact.id, link.user_id)
+  const cRoles = await deps.meta.collectionRolesForArtifact(artifact.id, link.user_id)
+  const actor: Actor = {
+    kind: "user",
+    userId: link.user_id,
+    artifactRole: maxRole(am?.role ?? null, ...cRoles),
+    orgRole,
+    locked: !!artifact.password_hash,
+    unlocked: false,
+  }
+  if (!can(actor, "approve", artifact.workspace_access, artifact.link_role)) {
+    await eph("You don't have permission to approve proposals on this artifact.")
+    return
+  }
+  // Fresh open-state check (the proposal was just re-read), so a click on a card whose proposal
+  // was already decided elsewhere no-ops with a message. NOTE: this is not a lock — two truly
+  // concurrent decisions can still both pass (a pre-existing race the HTTP approve route shares;
+  // the real fix is an atomic decide in core, out of scope here).
+  if (proposal.state !== "open") {
+    await eph(`This proposal is already ${proposal.state}.`)
+    return
+  }
+
+  const [du] = await deps.meta.getUsers([link.user_id])
+  const who = du?.name ?? link.user_id // raw name stored as the decider; escaped only for display
+  const display = escapeMrkdwn(who)
+  const replaceCard = (line: string): Promise<boolean> => {
+    if (!args.responseUrl) return Promise.resolve(false)
+    const blocks = [args.sectionBlock, context(`Derive · ${line}`)].filter(Boolean)
+    return postSlackResponseUrl(args.responseUrl, { text: line, blocks, replace_original: true })
+  }
+  try {
+    if (args.op === "approve") {
+      const version = await approveProposalAction(deps, artifact, proposal, who, null)
+      await replaceCard(`:white_check_mark: Approved by ${display} — now v${version.n}`)
+    } else {
+      await requestChangesAction(deps, artifact, proposal, who, null)
+      await replaceCard(`:leftwards_arrow_with_hook: Changes requested by ${display}`)
+    }
+  } catch {
+    await eph("Sorry — that didn't go through. Try approving in Derive.")
+  }
+}

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -17,10 +17,12 @@ import {
 import { deriveRecentBlocks, deriveResultsBlocks, notLinkedBlocks } from "../lib/slack-commands"
 import {
   enqueueSlackReplyIngest,
+  SLACK_PROPOSAL_ACTION,
   SLACK_THREAD_ACTION,
   threadStateBlocks,
 } from "../lib/slack-comments"
 import { enqueueSlackDm, wantsSlackDm } from "../lib/slack-dm"
+import { runSlackProposalAction } from "../lib/slack-proposal"
 import { resolveThreadAction } from "../lib/thread-actions"
 import { log } from "../log"
 import { buildSlackManifest, slackSetupHTML } from "../slack-app-setup"
@@ -35,7 +37,7 @@ import { buildSlackManifest, slackSetupHTML } from "../slack-app-setup"
 export const slackRoutes = (ctx: AppContext) => {
   const { meta, deps, bus, notify, requireUser } = ctx
   const { activeWorkspace, workspaceCan, requireWorkspace } = ctx
-  const { blobs, sourceText, search } = ctx
+  const { blobs, sourceText, search, notifyRender } = ctx
   const app = new OpenAPIHono<BlankEnv>()
   const slack = deps.slack
   const redirectUri = new URL("/v1/slack/oauth/callback", deps.baseUrl).toString()
@@ -301,14 +303,51 @@ export const slackRoutes = (ctx: AppContext) => {
     }
 
     const action = payload.actions?.[0]
+    if (payload.type !== "block_actions" || !action?.value) return c.json({ ok: true })
+
+    // Proposal Approve / Request-changes — editor-level, authorized AS the clicker's linked
+    // Derive account. The work (approving publishes a version) can exceed 3s, so ack now and
+    // run it off the ack path; all feedback rides response_url.
+    if (
+      action.action_id === SLACK_PROPOSAL_ACTION.approve ||
+      action.action_id === SLACK_PROPOSAL_ACTION.requestChanges
+    ) {
+      let pt: { a?: string; p?: string }
+      try {
+        pt = JSON.parse(action.value) as { a?: string; p?: string }
+      } catch {
+        return c.json({ ok: true })
+      }
+      if (pt.a && pt.p && payload.team?.id && payload.user?.id) {
+        const work = runSlackProposalAction(
+          { meta, blobs, bus, notify, notifyRender, search },
+          {
+            teamId: payload.team.id,
+            slackUserId: payload.user.id,
+            proposalId: pt.p,
+            artifactId: pt.a,
+            op: action.action_id === SLACK_PROPOSAL_ACTION.approve ? "approve" : "request_changes",
+            responseUrl: payload.response_url,
+            sectionBlock: payload.message?.blocks?.[0],
+          },
+        )
+        try {
+          c.executionCtx.waitUntil(work)
+        } catch {
+          void work
+        }
+      }
+      return c.json({ ok: true })
+    }
+
     const op =
-      action?.action_id === SLACK_THREAD_ACTION.resolve
+      action.action_id === SLACK_THREAD_ACTION.resolve
         ? "resolved"
-        : action?.action_id === SLACK_THREAD_ACTION.reopen
+        : action.action_id === SLACK_THREAD_ACTION.reopen
           ? "open"
           : undefined
     // Not a thread action we handle (or a malformed value) → ack and ignore.
-    if (payload.type !== "block_actions" || !op || !action?.value) return c.json({ ok: true })
+    if (!op) return c.json({ ok: true })
     let target: { a?: string; t?: string }
     try {
       target = JSON.parse(action.value) as { a?: string; t?: string }

--- a/apps/api/test/comment-fanout.test.ts
+++ b/apps/api/test/comment-fanout.test.ts
@@ -235,6 +235,47 @@ describe("connected-channel event cards (publishes / proposals)", () => {
     expect(sent.thread_ts).toBeUndefined() // top-level, not a threaded reply
     expect(JSON.stringify(sent.blocks)).toContain("published")
   })
+
+  it("a proposal card carries Approve / Request-changes buttons", async () => {
+    const { meta } = authed("chan-propcard")
+    await connect(meta)
+    const d: DeliveryRecord = {
+      id: "wd-prop",
+      webhook_id: "internal",
+      url: "",
+      secret: "",
+      kind: "slack_app",
+      event_type: "proposal.created",
+      payload: JSON.stringify({
+        orgId: "default",
+        artifactId: "a1",
+        event: "proposal.created",
+        title: "Doc",
+        link: "https://derive.test/artifacts/a1",
+        author: "Ann",
+        version: null,
+        message: "please review",
+        proposalId: "p9",
+      }),
+      status: "pending",
+      attempts: 0,
+      last_error: null,
+      next_attempt_at: new Date().toISOString(),
+      created_at: new Date().toISOString(),
+    }
+    let sent: { blocks?: unknown } = {}
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: { body?: string }) => {
+        sent = JSON.parse(init?.body ?? "{}")
+        return new Response(JSON.stringify({ ok: true, ts: "1.1", channel: "C1" }))
+      }),
+    )
+    await makeSlackSender(meta, "k")(d)
+    const s = JSON.stringify(sent.blocks)
+    expect(s).toContain("derive_proposal_approve")
+    expect(s).toContain("derive_proposal_request_changes")
+  })
 })
 
 describe("review-request + share emails", () => {

--- a/apps/api/test/slack-proposal.test.ts
+++ b/apps/api/test/slack-proposal.test.ts
@@ -1,0 +1,105 @@
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { newId } from "@derive/core"
+import { SqliteMetaStore } from "@derive/db/sqlite"
+import { FsBlobStore } from "@derive/storage/fs"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { createInProcessBackplane } from "../src/bus"
+import { runSlackProposalAction } from "../src/lib/slack-proposal"
+
+// Approving from Slack is editor-level, authorized AS the clicker's LINKED Derive account.
+// We use request_changes for the positive path — it decides the proposal without republishing
+// a version (no blob), so the test stays focused on the authorization gate.
+const setup = async () => {
+  const dir = mkdtempSync(join(tmpdir(), "slkprop-"))
+  const meta = new SqliteMetaStore(join(dir, "db.sqlite"))
+  const blobs = new FsBlobStore(join(dir, "blobs"))
+  await meta.setMembership({ id: newId("mem"), org_id: "default", user_id: "u-ed", role: "editor" })
+  await meta.createArtifact({
+    id: "a1",
+    short_id: "a1short",
+    org_id: "default",
+    slug: null,
+    title: "Doc",
+    workspace_access: "member",
+    link_role: "viewer",
+    listed: "workspace",
+    kind: "file",
+    spa: 0,
+  })
+  await meta.createProposal({
+    id: "p1",
+    artifact_id: "a1",
+    blob_key: "bk",
+    content_type: "text/markdown",
+    kind: "file",
+    author: "Ed",
+    base_version: 0,
+  })
+  await meta.setSlackInstall({
+    org_id: "default",
+    team_id: "T1",
+    team_name: "Acme",
+    bot_token: "xoxb",
+    bot_user_id: "UBOT",
+    default_channel: "C1",
+    created_at: new Date().toISOString(),
+  })
+  // U1 → editor member; U2 → a linked user who is NOT a member of the workspace.
+  await meta.setSlackUserLink({
+    id: newId("sul"),
+    org_id: "default",
+    user_id: "u-ed",
+    team_id: "T1",
+    slack_user_id: "U1",
+    created_at: new Date().toISOString(),
+  })
+  await meta.setSlackUserLink({
+    id: newId("sul"),
+    org_id: "default",
+    user_id: "u-nobody",
+    team_id: "T1",
+    slack_user_id: "U2",
+    created_at: new Date().toISOString(),
+  })
+  const deps = { meta, blobs, bus: createInProcessBackplane(), notify: async () => {} }
+  return { meta, deps }
+}
+
+const args = (op: "approve" | "request_changes", slackUserId: string) => ({
+  teamId: "T1",
+  slackUserId,
+  proposalId: "p1",
+  artifactId: "a1",
+  op,
+  responseUrl: "https://hooks.slack.test/r",
+})
+
+describe("runSlackProposalAction (approve/request-changes from Slack)", () => {
+  beforeEach(() =>
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("ok", { status: 200 })),
+    ),
+  )
+  afterEach(() => vi.unstubAllGlobals())
+
+  it("a linked editor's click decides the proposal", async () => {
+    const { meta, deps } = await setup()
+    await runSlackProposalAction(deps, args("request_changes", "U1"))
+    expect((await meta.getProposal("p1"))?.state).toBe("changes_requested")
+  })
+
+  it("a linked NON-member is denied (authz gate) — proposal stays open", async () => {
+    const { meta, deps } = await setup()
+    await runSlackProposalAction(deps, args("request_changes", "U2"))
+    expect((await meta.getProposal("p1"))?.state).toBe("open")
+  })
+
+  it("an UNLINKED Slack user cannot act — proposal stays open", async () => {
+    const { meta, deps } = await setup()
+    await runSlackProposalAction(deps, args("request_changes", "U-UNKNOWN"))
+    expect((await meta.getProposal("p1"))?.state).toBe("open")
+  })
+})

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -11,6 +11,7 @@ import { encryptSecret, signState } from "../src/lib/crypto"
 import {
   ingestSlackReply,
   makeSlackIngestSender,
+  SLACK_PROPOSAL_ACTION,
   SLACK_THREAD_ACTION,
 } from "../src/lib/slack-comments"
 import { runDeliveryTick } from "../src/webhooks"
@@ -101,6 +102,15 @@ const postCommand = (app: TestApp, fields: Record<string, string>) => {
     body: raw,
   })
 }
+
+const proposalAction = (artifactId: string, proposalId: string, actionId: string) => ({
+  type: "block_actions",
+  response_url: "https://hooks.slack.test/response",
+  team: { id: "T1" },
+  user: { id: "U777", username: "dana" },
+  actions: [{ action_id: actionId, value: JSON.stringify({ a: artifactId, p: proposalId }) }],
+  message: { blocks: [{ type: "section", text: { type: "mrkdwn", text: "a proposal" } }] },
+})
 
 // "T1" matches the team_id seedResolvable stores on the install (the acting-team authz bind).
 const threadAction = (artifactId: string, threadId: string, actionId: string, teamId = "T1") => ({
@@ -805,6 +815,18 @@ describe("slack interactivity endpoint (resolve/reopen from a button)", () => {
     const cm = (await meta.listComments(artifact.id)).find((c) => c.id === "c-int-f")
     expect(cm?.state).toBe("open")
     expect(vi.mocked(fetch)).not.toHaveBeenCalled()
+  })
+
+  it("acks a proposal Approve interaction (dispatched off the ack path)", async () => {
+    const { app } = make("slack-int-proposal")
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("ok", { status: 200 })),
+    )
+    // The approve work runs via response_url off the ack path; the endpoint just acks 200
+    // (authorization + execution are covered by slack-proposal.test.ts).
+    const r = await postInteract(app, proposalAction("a-x", "p-x", SLACK_PROPOSAL_ACTION.approve))
+    expect(r.status).toBe(200)
   })
 
   it("ignores a click whose thread has no link (no forged targets)", async () => {


### PR DESCRIPTION
## What

In-channel proposal cards (from #456) now carry **Approve / Request-changes** buttons. Clicking runs the same proposal decision the web app does — **authorized as the clicking user's linked Derive account**. This is the capstone that ties together proposal cards in-channel (#456), account linking (#453), and the interactivity endpoint (#452).

## How

- The interactivity handler dispatches proposal actions to `runSlackProposalAction` **off the ack path** (`waitUntil` / in-process; approving publishes a version, not sub-3s work), delivering the outcome + card update via `response_url`.
- **Authorization is faithful to the HTTP route**: resolve the Slack user → their Derive account, build the `Actor` **exactly as `context.actorFor`'s human branch does** (workspace + per-artifact + collection roles), gate on `can(actor, "approve")` — editor-level. A linked viewer/non-member is denied; an unlinked user is prompted to link.
- Runs the shared `proposal-actions` pipeline, so Slack and web approve **identically**.

## Audit (authorization-critical)

The adversarial review confirmed **the authorization gate is clean — no over-grant**: the Actor is field-identical to `actorFor`, cross-org is denied (membership keys on the *artifact's* org), and the approver is a server-side name (no spoofing). Fixes/notes:
- **Escaped** the approver's display name in the card footer (mrkdwn injection via a display name).
- **Noted, not fixed here**: the concurrent double-decision race is **pre-existing** — the HTTP approve route shares it (`decideProposal` is an unconditional UPDATE); the fix is an atomic decide in core, out of scope for this Slack feature. The handler's fresh open-state check already no-ops a click on an already-decided proposal.

## Testing

- `pnpm run ci` ✅ · `pnpm typecheck` ✅ · full suite ✅ (apps/api 1039) · `test:pg` ✅ (50) — verified locally before the escape fix; CI re-runs the full gate.
- New tests: **editor's click decides the proposal**, **non-member denied (authz gate)**, **unlinked denied**, proposal card **carries Approve/Request-changes buttons**, interactivity **dispatches the proposal action**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)