### PR TITLE
feat(mcp): stage_publish — tokened byte-upload for files too large to inline over MCP

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -345,6 +345,8 @@ export function createApp(deps: AppDeps): Hono {
     /^\/v1\/slack\/interactivity$/, // Slack Block Kit actions — signing-secret signature is the gate
     /^\/v1\/slack\/commands$/, // Slack slash command (/derive) — signing-secret signature is the gate
     /^\/v1\/assets\/t\/[^/]+$/, // MCP-minted upload URL — the signed expiring token is the gate
+    /^\/v1\/artifacts\/t\/[^/]+$/, // MCP-minted publish URL (create) — signed token is the gate
+    /^\/v1\/artifacts\/[^/]+\/versions\/t\/[^/]+$/, // MCP-minted publish URL (revise) — signed token is the gate
   ]
   app.use("/v1/*", async (c, next) => {
     const m = c.req.method

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -747,6 +747,26 @@ export function buildContext(deps: AppDeps) {
   const authorizeStanding = (c: Context, action: Action, a: ArtifactRecord): Promise<boolean> =>
     actorFor(c, a).then((actor) => can(actor, action, a.workspace_access, "none"))
 
+  /** Authorize an EXPLICIT user (not the request's principal) against an artifact,
+   *  on STANDING only — their explicit share + collection shares + workspace seat,
+   *  never the world link. The tokened publish path needs this: the request carries
+   *  no session (a capability token authorized it out of band), so we re-check the
+   *  BOUND user's real rights on the target — live, at spend time, so a revoked share
+   *  or lost seat kills the token. Mirrors actorFor's human branch; standing (not the
+   *  link) is what a publisher must hold, so a private artifact's viewer-share can't
+   *  publish even when its holder is a workspace editor. */
+  const authorizeUserStanding = async (
+    userId: string,
+    action: Action,
+    a: ArtifactRecord,
+  ): Promise<boolean> => {
+    const orgRole = (await meta.getMembership(a.org_id, userId))?.role ?? null
+    const am = await meta.getArtifactMember(a.id, userId)
+    const cRoles = await meta.collectionRolesForArtifact(a.id, userId)
+    const artifactRole = maxRole(am?.role ?? null, ...cRoles)
+    return can({ kind: "user", userId, artifactRole, orgRole }, action, a.workspace_access, "none")
+  }
+
   /**
    * True when the caller is an anonymous visitor — they may view public content
    * but nothing collaborative (comments, member list, proposals, analytics).
@@ -925,6 +945,7 @@ export function buildContext(deps: AppDeps) {
     actorFor,
     authorize,
     authorizeStanding,
+    authorizeUserStanding,
     anonLocked,
     isPrincipal,
     isSuperAdmin,

--- a/apps/api/src/lib/publish-token.ts
+++ b/apps/api/src/lib/publish-token.ts
@@ -1,0 +1,81 @@
+/**
+ * Short-lived publish-access tokens for POST /v1/artifacts/t/:token and
+ * .../versions/t/:token.
+ *
+ * Minted by the MCP `stage_publish` tool for the same reason `stage_asset`
+ * exists: a hosted-OAuth agent's credential lives INSIDE the MCP transport, so
+ * its shell has no bearer to publish with — and a large file (a designed HTML
+ * page, a bundle with big assets) can't ride the `publish` tool's inline
+ * `content`/`files` because that content is generated as model output, capped
+ * by the per-response token ceiling and forced into slow multi-turn chunking.
+ * This token moves the publish capability out to the shell: mint it over MCP,
+ * `curl -F file=@…` the bytes to the tokened route. The file never passes
+ * through the model's context.
+ *
+ * A publish token is a BIGGER capability than an upload token (it writes
+ * artifacts, not inert blobs), so it is scoped tightly:
+ *   - bound to the granting USER, whose live membership is re-checked at spend
+ *     time — demoting or removing them kills outstanding URLs (like the authed
+ *     route's per-request role check), and the publish is attributed to them.
+ *   - bound to a TARGET: "*" authorizes creating ONE-OR-MORE new artifacts in
+ *     the workspace; a specific short_id authorizes revising ONLY that artifact.
+ *     A leaked create-token can't overwrite existing work; a leaked
+ *     revise-token can't touch anything but its one artifact.
+ *
+ * A thin wrapper over lib/capability-token.ts (which owns the HMAC format, key
+ * caching, and edge-safety notes) with this kind's domain and its
+ * `<orgId>.<userId>.<target>` payload.
+ */
+import { signCapabilityToken, verifyCapabilityToken } from "./capability-token"
+
+const DOMAIN = "derive-publish-token:"
+
+/** How long a minted publish URL stays spendable — long enough to zip and push
+ *  a prototype, short enough that a leaked URL is a bounded liability. */
+export const PUBLISH_TOKEN_TTL_MS = 15 * 60 * 1000
+
+/** Sentinel `target` for a token that authorizes creating new artifacts. */
+export const PUBLISH_TARGET_CREATE = "*"
+
+/**
+ * Sign a publish token.
+ *
+ * @param secret      The DERIVE_AUTH_SECRET / encryptionKey
+ * @param orgId       The workspace the publish lands in
+ * @param userId      The granting user — re-checked for live publish rights at
+ *                    spend time, and attributed as the author/owner
+ * @param target      PUBLISH_TARGET_CREATE to create new artifacts, or a
+ *                    short_id to revise exactly that one
+ * @param expEpochMs  Expiry as ms since epoch (Date.now() + PUBLISH_TOKEN_TTL_MS)
+ */
+export const signPublishToken = (
+  secret: string,
+  orgId: string,
+  userId: string,
+  target: string,
+  expEpochMs: number,
+): Promise<string> => signCapabilityToken(DOMAIN, secret, [orgId, userId, target], expEpochMs)
+
+/**
+ * Verify a publish token. Returns the workspace, the granting user, and the
+ * target ("*" or a short_id), or null (bad signature, malformed, expired).
+ * Never throws.
+ */
+export const verifyPublishToken = async (
+  secret: string,
+  token: string,
+  nowMs: number,
+): Promise<{ orgId: string; userId: string; target: string } | null> => {
+  const claim = await verifyCapabilityToken(DOMAIN, secret, token, nowMs)
+  if (!claim) return null
+  // Payload: `<orgId>.<userId>.<target>`. target and userId are dot-free (a
+  // short_id / "*" and a u_ id); split them off the right, orgId keeps the rest
+  // (defensive — ws_ ids are dot-free too, but this never truncates one).
+  const parts = claim.rest.split(".")
+  if (parts.length < 3) return null
+  const target = parts[parts.length - 1]
+  const userId = parts[parts.length - 2]
+  const orgId = parts.slice(0, -2).join(".")
+  if (!orgId || !userId || !target) return null
+  return { orgId, userId, target }
+}

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -76,6 +76,7 @@ import { buildReviewEmail } from "./lib/email"
 import { MAX_UPLOAD_BYTES } from "./lib/http"
 import { MAX_ASSET_BYTES } from "./lib/image"
 import { notifyCommentBells } from "./lib/notify-comment"
+import { PUBLISH_TARGET_CREATE, PUBLISH_TOKEN_TTL_MS, signPublishToken } from "./lib/publish-token"
 import {
   baseType,
   isTextType,
@@ -336,7 +337,9 @@ async function buildServer(
         `read can. For images and web fonts, call stage_asset for a short-lived upload ` +
         `URL, curl the file's raw bytes to it from your shell, and reference the ` +
         `returned permanent url — never base64 binaries through a tool call (a pasted ` +
-        `image usually already sits on disk; upload that file). Use comment to leave or ` +
+        `image usually already sits on disk; upload that file). For a document too large to ` +
+        `inline (a big designed HTML page or a multi-file bundle), call stage_publish and curl ` +
+        `the file/zip to the returned URL instead of chunking it through content/files. Use comment to leave or ` +
         `resolve feedback. ${writeGuidance}To change PART of an artifact, prefer publish's edits ` +
         `(exact-match search/replace against the stored source) over resending everything. When a ` +
         `revision fixes specific feedback, pass those thread ids as publish's "addresses" so the ` +
@@ -1513,6 +1516,80 @@ async function buildServer(
     },
   )
 
+  // STAGE PUBLISH — a tokenless publish URL for large content ------------------
+  // The publish tool carries content INLINE (`content`/`files`), which is model
+  // output — capped by the per-response token ceiling and forced into slow,
+  // expensive multi-turn chunking once a file is bigger than a page or two. This
+  // mints a short-lived signed URL the shell curls the file's bytes to, so a big
+  // designed HTML page or a whole bundle publishes in one shot, zero bytes
+  // through the model's context. Same shell-out shape as stage_asset; scoped
+  // tighter because publishing writes artifacts (see lib/publish-token.ts).
+  server.registerTool(
+    "stage_publish",
+    {
+      description:
+        "Mint a SHORT-LIVED publish URL for pushing a file (or a whole bundle) too large to inline through the publish tool — a big designed HTML page, a multi-file prototype — with NO bearer token. Inline `content`/`files` is model output, so a file past ~a page forces slow, costly multi-turn chunking; this uploads the raw bytes from your shell instead, zero tokens through context. Omit short_id to CREATE a new artifact; pass a short_id to REVISE that one (the token is scoped to exactly that target). Then from your shell: a single file → `curl -sS -F file=@page.html -F title='My Page' <upload_url>`; a bundle → zip the dir first (`cd site && zip -r /tmp/site.zip .`) then `curl -sS -F file=@/tmp/site.zip <upload_url>` (a .zip publishes as a multi-page bundle). The URL is reusable until it expires (~15 min). Prefer the plain publish tool for small docs and for surgical `edits`; reach for this only when inlining would chunk.",
+      inputSchema: {
+        workspace: wsArg,
+        short_id: z
+          .string()
+          .optional()
+          .describe("Revise THIS artifact; omit to create a new one. The token is scoped to it."),
+      },
+    },
+    async ({ workspace, short_id }) => {
+      const t = await resolveWs(workspace)
+      if ("error" in t) return err(t.error)
+      // A publish is attributed to a person and its URL is re-checked against
+      // their live rights — so it needs a known granting user. A static agent
+      // token (dk_agt_/DERIVE_TOKEN) has none, but it also isn't trapped in this
+      // transport: it can POST to /v1/artifacts with that bearer directly.
+      if (!ownerId)
+        return err(
+          "stage_publish needs a signed-in user to attribute the publish to. With a static agent token, POST to /v1/artifacts with that token in the Authorization header instead.",
+        )
+      const secret = ctx.deps.encryptionKey
+      if (!secret)
+        return err(
+          "This server has no signing secret configured, so it can't mint publish URLs. POST to /v1/artifacts with a bearer token instead (DERIVE_TOKEN, or `derive login`).",
+        )
+      // The workspace the token is minted for. For a REVISE it must be the
+      // artifact's ACTUAL workspace — reach() may auto-roam a bare short_id to
+      // another workspace in the grant, and the spend-side org guard would 403 a
+      // token minted against the default one.
+      let org = t.org
+      if (short_id) {
+        const reached = await reach(short_id, workspace)
+        if (reached && "error" in reached) return err(reached.error)
+        if (!reached) return notFound(short_id)
+        org = reached.org
+        // Revising needs artifact-level publish STANDING (share + seat), the same
+        // right the spend-side re-checks — not the workspace seat role, which on a
+        // private artifact grants nothing. Fail at mint for a clear message.
+        if (!(await ctx.authorizeUserStanding(ownerId, "publish", reached.a)))
+          return err("You don't have permission to publish a new version of that artifact.")
+      } else if (!roleAllows(t.role, "publish")) {
+        // Creating is a workspace-level right.
+        return err("Your role in this workspace can't publish (publishing required).")
+      }
+      const expiresAt = Date.now() + PUBLISH_TOKEN_TTL_MS
+      const target = short_id ?? PUBLISH_TARGET_CREATE
+      const tok = await signPublishToken(secret, org, ownerId, target, expiresAt)
+      const base = ctx.deps.baseUrl.replace(/\/$/, "")
+      const uploadUrl = short_id
+        ? `${base}/v1/artifacts/${short_id}/versions/t/${tok}`
+        : `${base}/v1/artifacts/t/${tok}`
+      return json({
+        upload_url: uploadUrl,
+        workspace: org,
+        mode: short_id ? `revise ${short_id}` : "create",
+        expires_in_minutes: Math.round(PUBLISH_TOKEN_TTL_MS / 60_000),
+        max_bytes: MAX_UPLOAD_BYTES,
+        how: `Single file: curl -sS -F file=@<path> ${short_id ? "" : "-F title='<title>' "}"${uploadUrl}". Bundle: zip the dir (zip -r /tmp/b.zip .) then curl -sS -F file=@/tmp/b.zip "${uploadUrl}" — a .zip becomes a multi-page bundle. Returns the artifact {short_id, url, ...}.`,
+      })
+    },
+  )
+
   // WRITE — publish live, or file a proposal for review -----------------------
   server.registerTool(
     "publish",
@@ -1524,7 +1601,7 @@ async function buildServer(
           .string()
           .optional()
           .describe(
-            "The complete content for a SINGLE-FILE artifact (HTML or Markdown). Use this OR `files`, not both. To embed an image OR a web font CHEAPLY (no base64 in this call), call stage_asset for a short-lived upload URL and curl the raw bytes to it (PNG/JPEG/GIF/WebP/WOFF/WOFF2) — the response's `url` is a permanent public link; paste it into an `<img src>`, a CSS `url()`, or markdown `![]()`. Never inline a base64 data: URI here — it tokenizes at roughly 1 token/char (one modest screenshot can cost 100k+ tokens), and content carried through your context can be silently mistranscribed; binaries should travel as bytes. If you have shell access and the file is large, you can also POST it directly to /v1/artifacts (raw body) with your bearer token — zero tokens through this call.",
+            "The complete content for a SINGLE-FILE artifact (HTML or Markdown). Use this OR `files`, not both. To embed an image OR a web font CHEAPLY (no base64 in this call), call stage_asset for a short-lived upload URL and curl the raw bytes to it (PNG/JPEG/GIF/WebP/WOFF/WOFF2) — the response's `url` is a permanent public link; paste it into an `<img src>`, a CSS `url()`, or markdown `![]()`. Never inline a base64 data: URI here — it tokenizes at roughly 1 token/char (one modest screenshot can cost 100k+ tokens), and content carried through your context can be silently mistranscribed; binaries should travel as bytes. If the DOCUMENT ITSELF is large (a big designed HTML page), don't inline it here either — call stage_publish for an upload URL and curl the file's bytes, zero tokens through context.",
           ),
         files: z
           .record(z.string(), z.string())

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -22,6 +22,7 @@ import {
   publishAdvisories,
   type Role,
   renderMarkdown,
+  roleAllows,
   sectionOf,
   toJson,
   toMarkdown,
@@ -57,6 +58,7 @@ import {
   toBody,
   workspaceAccessOf,
 } from "../lib/http"
+import { PUBLISH_TARGET_CREATE, verifyPublishToken } from "../lib/publish-token"
 import {
   deleteArtifactAndUnindex,
   indexArtifactVersion,
@@ -119,6 +121,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     agentFor,
     authorize,
     authorizeStanding,
+    authorizeUserStanding,
     requireArtifact,
     workspaceCan,
     collectionRole,
@@ -455,14 +458,39 @@ export const artifactRoutes = (ctx: AppContext) => {
 
   // ---- Publish ----------------------------------------------------------
 
-  const handlePublish = async (c: Context, shortId?: string) => {
+  // `tokenAuth`, when present, is a caller the MCP stage_publish tool authorized
+  // out-of-band with a short-lived capability token (see lib/publish-token.ts):
+  // the route already verified the token, re-checked the user's live membership,
+  // and confirmed the target scope, so this skips the per-request auth and acts
+  // AS the bound user for attribution + ownership. Everything downstream —
+  // quota, body handling, access resolution, the publish itself — is shared with
+  // the session/bearer path, so a tokened publish behaves identically.
+  const handlePublish = async (
+    c: Context,
+    shortId?: string,
+    tokenAuth?: { org: string; user: { id: string; name: string | null } },
+  ) => {
     // Republishing a version needs publish rights on that artifact; creating a
     // new one needs publish rights at the workspace level.
     let existing: ArtifactRecord | null = null
     if (shortId) {
       existing = await meta.getByShortId(shortId)
       if (!existing) return fail(c, 404, "not found")
-      if (!(await authorize(c, "publish", existing))) return fail(c, 403, "forbidden")
+      // A tokened caller is scoped to this artifact's workspace by the token's
+      // own org; refuse if the artifact lives elsewhere, so a token minted for
+      // one workspace can never revise another's artifact via a shared short_id.
+      if (tokenAuth && existing.org_id !== tokenAuth.org) return fail(c, 403, "forbidden")
+      // Publish rights on an EXISTING artifact are artifact-level standing (an
+      // explicit/collection share + workspace seat), NOT the workspace seat alone
+      // — on a private artifact the seat grants nothing, only the share counts. The
+      // session path resolves that from the request; the tokened path resolves the
+      // SAME standing for the bound user, live (revocation-safe). Checking only the
+      // seat here would let a workspace editor with a mere viewer share overwrite a
+      // private doc — an escalation the authed API forbids.
+      const publishOk = tokenAuth
+        ? await authorizeUserStanding(tokenAuth.user.id, "publish", existing)
+        : await authorize(c, "publish", existing)
+      if (!publishOk) return fail(c, 403, "forbidden")
       // A GitHub-synced artifact is read-only in Derive: GitHub is the source of
       // truth, so a republish would be silently overwritten on the next sync.
       // Edit it in the repo instead.
@@ -472,12 +500,13 @@ export const artifactRoutes = (ctx: AppContext) => {
       // The web client routes editors to "propose" when locked, so this is the
       // backstop (and the answer for API/CLI callers).
       if (existing.locked) return fail(c, 409, "artifact is locked — propose a change for review")
-    } else if (!(await workspaceCan(c, "publish"))) {
+    } else if (!tokenAuth && !(await workspaceCan(c, "publish"))) {
       return fail(c, 403, "forbidden")
     }
     // Quotas are per-workspace: a republish counts against the artifact's own
-    // org, a new artifact against the caller's active workspace.
-    const org = existing ? existing.org_id : await activeWorkspace(c)
+    // org, a new artifact against the caller's active workspace (or, for a
+    // tokened create, the workspace the token was minted for).
+    const org = existing ? existing.org_id : tokenAuth ? tokenAuth.org : await activeWorkspace(c)
     const rl = await limited(c, publishLimiter)
     if (rl) return rl
     // A new artifact counts against the artifact cap; republishes don't.
@@ -586,12 +615,17 @@ export const artifactRoutes = (ctx: AppContext) => {
       // as the agent's own name ("Derive CLI", "Claude", or whatever client/model drove it;
       // authored work is the person's, and which tool typed it is an implementation detail).
       // `actor` is only the fallback for an ownerless principal (a pre-column agent).
-      const actor = await actingUser(c)
-      const human = await actingHuman(c)
-      const onBehalf = await privateOwnerId(c)
-      // The agent behind an agent-credentialed publish (registered token / OAuth
-      // bearer) — its name is the actor on the human's notification fan-out below.
-      const agentPrincipal = await agentFor(c)
+      // A tokened publish acts AS the bound user: they are the author byline, the
+      // author_id (their profile/feed), and the private owner — the same identity
+      // the session/bearer path resolves from the request, just supplied by the
+      // token instead. A tokened publish behaves like that user's OWN publish (they
+      // drove it and get the artifact URL back in the curl response), so — like a
+      // session publish, and unlike the agent `publish` tool — it has no agent
+      // principal and fires no "your agent published X" bell to onBehalf.
+      const actor = tokenAuth ? tokenAuth.user : await actingUser(c)
+      const human = tokenAuth ? tokenAuth.user : await actingHuman(c)
+      const onBehalf = tokenAuth ? tokenAuth.user.id : await privateOwnerId(c)
+      const agentPrincipal = tokenAuth ? null : await agentFor(c)
       // Access is set-on-create: a republish never re-stamps it (publish() only adds a
       // version). On a NEW artifact each field resolves independently — explicit request
       // field > legacy `visibility` mapping > the workspace default (factory default is
@@ -637,8 +671,12 @@ export const artifactRoutes = (ctx: AppContext) => {
           // publish reads as the person; a registered agent falls back to its own name.
           // Anonymous callers can't reach this route at all, so a publish is always
           // attributed to a real principal (the token's optional `author` label is the
-          // one headless exception).
-          author: human?.name ?? actor?.name ?? str(body["author"]),
+          // one headless exception). A TOKENED publish is bound to a known user, so it
+          // uses their name and never the client `author` field — otherwise a caller
+          // could stamp an arbitrary byline whenever that user's stored name is null.
+          author: tokenAuth
+            ? (tokenAuth.user.name ?? undefined)
+            : (human?.name ?? actor?.name ?? str(body["author"])),
           authorId: onBehalf,
           name: str(body["name"]),
           orgId: org,
@@ -836,6 +874,45 @@ export const artifactRoutes = (ctx: AppContext) => {
 
   app.post("/v1/artifacts", (c) => handlePublish(c))
   app.post("/v1/artifacts/:shortId/versions", (c) => handlePublish(c, c.req.param("shortId")))
+
+  // Tokened publish: the same handlePublish, but authorized by a short-lived
+  // capability token (minted by the MCP stage_publish tool) instead of a session
+  // or bearer — so a hosted-OAuth agent, whose credential is trapped inside the
+  // MCP transport, can `curl -F file=@…` a file too large to inline through the
+  // publish tool. See lib/publish-token.ts. Verify the token, re-check the bound
+  // user's LIVE membership (revocation kills the URL mid-TTL), enforce the target
+  // scope, then hand off to handlePublish acting as that user. Distinct segment
+  // counts from the routes above, so no registration-order collision.
+  const tokenPublish = async (c: Context, shortId?: string) => {
+    const secret = deps.encryptionKey
+    const token = c.req.param("token") ?? ""
+    const claim = secret ? await verifyPublishToken(secret, token, Date.now()) : null
+    if (!claim) return fail(c, 403, "invalid or expired publish token")
+    // Target scope: a "*" token only creates; a short_id token only revises that
+    // exact artifact. Mismatch is a hard refusal, so a leaked token can't be
+    // repurposed (create → overwrite, or revise-X → touch-Y).
+    if (claim.target === PUBLISH_TARGET_CREATE) {
+      if (shortId) return fail(c, 403, "this token can only create a new artifact")
+      // CREATE is a workspace-level right, and handlePublish skips workspaceCan for
+      // a tokened caller — so re-check the bound user's LIVE workspace publish role
+      // here (revocation-safe). REVISE is an artifact-level right that handlePublish
+      // re-checks itself (authorizeUserStanding), so it needs nothing extra here.
+      const m = await meta.getMembership(claim.orgId, claim.userId)
+      if (!m || !roleAllows(m.role, "publish"))
+        return fail(c, 403, "invalid or expired publish token")
+    } else if (claim.target !== shortId) {
+      return fail(c, 403, "this token cannot publish to that artifact")
+    }
+    const [dir] = await meta.getUsers([claim.userId])
+    return handlePublish(c, shortId, {
+      org: claim.orgId,
+      user: { id: claim.userId, name: dir?.name ?? null },
+    })
+  }
+  app.post("/v1/artifacts/t/:token", (c) => tokenPublish(c))
+  app.post("/v1/artifacts/:shortId/versions/t/:token", (c) =>
+    tokenPublish(c, c.req.param("shortId")),
+  )
 
   // Registered BEFORE GET /v1/artifacts/{shortId} below: Hono's router matches
   // routes in REGISTRATION order, not by static-vs-param specificity, so

--- a/apps/api/test/authz-coverage.test.ts
+++ b/apps/api/test/authz-coverage.test.ts
@@ -31,6 +31,10 @@ const AUTHZ = new Set([
   "isLastOwner",
   "agentFor",
   "isToken",
+  // A short-lived signed capability token IS the authorization for its route
+  // (the tokened publish endpoints re-check live membership on top). Same role
+  // as `isToken` — the credential is the gate.
+  "verifyPublishToken",
 ])
 
 const EXEMPT = "authz-exempt"

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -174,6 +174,7 @@ describe("remote MCP endpoint (/mcp)", () => {
       "read",
       "search",
       "stage_asset",
+      "stage_publish",
     ])
     // Consolidated away — folded into catch_up / comment / publish.
     for (const gone of [
@@ -220,6 +221,82 @@ describe("remote MCP endpoint (/mcp)", () => {
     const { app, token } = appWithGrant("stagenosecret", "openid derive:read derive:publish")
     const r = await call(app, token, "stage_asset")
     expect(toolText(r)).toContain("bearer token")
+  })
+
+  it("stage_publish mints a URL an anonymous shell can publish a whole file through", async () => {
+    const { app, token, meta } = appWithGrant("stagepub", "openid derive:read derive:publish", {
+      encryptionKey: "mcp-publish-secret",
+    })
+    const staged = JSON.parse(toolText(await call(app, token, "stage_publish")))
+    expect(staged.upload_url).toContain("/v1/artifacts/t/")
+    expect(staged.mode).toBe("create")
+
+    // In prod the OAuth grantor is a workspace member; the harness doesn't seed
+    // that, and the tokened route re-checks it — so add the membership the grant
+    // implies before spending the URL.
+    await meta.setMembership({
+      id: "m_stagepub",
+      org_id: staged.workspace,
+      user_id: "u_o",
+      role: "editor",
+    })
+
+    // Publish a file with NO auth header — the minted token is the only credential.
+    const fd = new FormData()
+    fd.append(
+      "file",
+      new File([new TextEncoder().encode("<h1>Staged</h1>") as BlobPart], "page.html", {
+        type: "text/html",
+      }),
+      "page.html",
+    )
+    fd.append("title", "Staged via MCP")
+    const up = await app.request(new URL(staged.upload_url).pathname, { method: "POST", body: fd })
+    expect(up.status).toBe(201)
+    const art = await up.json()
+    expect(art.short_id).toBeTruthy()
+
+    // Owned by + attributed to the grantor, exactly like a session publish.
+    const rec = await meta.getByShortId(art.short_id)
+    if (!rec) throw new Error("expected the published artifact")
+    expect(await meta.getArtifactMember(rec.id, "u_o")).toBeTruthy()
+  })
+
+  it("stage_publish fails actionably when no signing secret is configured", async () => {
+    const { app, token } = appWithGrant("stagepubnosecret", "openid derive:read derive:publish")
+    expect(toolText(await call(app, token, "stage_publish"))).toContain("bearer token")
+  })
+
+  it("stage_publish revise mints a versions URL that publishes a new version", async () => {
+    const { app, token, meta } = appWithGrant("stagepubrev", "openid derive:read derive:publish", {
+      encryptionKey: "mcp-publish-secret",
+    })
+    // Create v1 through the normal publish tool, then stage a revise.
+    const created = await (await publish(app, token, "Revisable")).json()
+    const shortId = created.short_id
+    await meta.setMembership({
+      id: "m_stagepubrev",
+      org_id: (await meta.getByShortId(shortId))?.org_id ?? "",
+      user_id: "u_o",
+      role: "editor",
+    })
+    const staged = JSON.parse(
+      toolText(await call(app, token, "stage_publish", { short_id: shortId })),
+    )
+    expect(staged.upload_url).toContain(`/v1/artifacts/${shortId}/versions/t/`)
+    expect(staged.mode).toBe(`revise ${shortId}`)
+
+    const fd = new FormData()
+    fd.append(
+      "file",
+      new File([new TextEncoder().encode("<h1>v2</h1>") as BlobPart], "x.html", {
+        type: "text/html",
+      }),
+      "x.html",
+    )
+    const up = await app.request(new URL(staged.upload_url).pathname, { method: "POST", body: fd })
+    expect(up.status).toBe(201)
+    expect((await up.json()).published).toBe(2)
   })
 
   it("exposes the workspace's Brandprint as resources + an instructions pointer", async () => {

--- a/apps/api/test/publish-token.test.ts
+++ b/apps/api/test/publish-token.test.ts
@@ -1,0 +1,473 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { newId } from "@derive/core"
+import { SqliteMetaStore } from "@derive/db/sqlite"
+import { FsBlobStore } from "@derive/storage/fs"
+import Database from "better-sqlite3"
+import { afterAll, describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { zipBundleFiles } from "../src/lib/bundle"
+import { signCapabilityToken } from "../src/lib/capability-token"
+import {
+  PUBLISH_TARGET_CREATE,
+  signPublishToken,
+  verifyPublishToken,
+} from "../src/lib/publish-token"
+
+// ---- Unit tests: token sign/verify -----------------------------------------
+
+describe("publish token", () => {
+  const secret = "s3cr3t-long-enough" // gitleaks:allow
+
+  it("round-trips a create token", async () => {
+    const tok = await signPublishToken(secret, "ws_a", "u_1", PUBLISH_TARGET_CREATE, 10_000)
+    expect(await verifyPublishToken(secret, tok, 5_000)).toEqual({
+      orgId: "ws_a",
+      userId: "u_1",
+      target: "*",
+    })
+  })
+
+  it("round-trips a revise token (target = short_id)", async () => {
+    const tok = await signPublishToken(secret, "ws_a", "u_1", "lp5e8s04", 10_000)
+    expect(await verifyPublishToken(secret, tok, 5_000)).toEqual({
+      orgId: "ws_a",
+      userId: "u_1",
+      target: "lp5e8s04",
+    })
+  })
+
+  it("returns null after expiry", async () => {
+    const tok = await signPublishToken(secret, "ws_a", "u_1", "*", 10_000)
+    expect(await verifyPublishToken(secret, tok, 20_000)).toBeNull()
+  })
+
+  it("returns null when tampered or signed with another secret", async () => {
+    const tok = await signPublishToken(secret, "ws_a", "u_1", "*", 10_000)
+    expect(await verifyPublishToken(secret, `${tok}x`, 5_000)).toBeNull()
+    expect(await verifyPublishToken("other", tok, 5_000)).toBeNull()
+  })
+
+  it("is domain-separated: a token from another kind won't verify here", async () => {
+    // Same secret, same payload bytes, different DOMAIN — the domain is part of
+    // the key, so an upload-domain token must be rejected by the publish verifier
+    // (and vice versa). This is what stops one capability being replayed as another.
+    const foreign = await signCapabilityToken(
+      "derive-upload-token:",
+      secret,
+      ["ws_a", "u_1", "*"],
+      10_000,
+    )
+    expect(await verifyPublishToken(secret, foreign, 5_000)).toBeNull()
+  })
+})
+
+// ---- Route tests: /v1/artifacts/t/:token (MCP-minted publish URL) ----------
+
+const dir = mkdtempSync(join(tmpdir(), "derive-pubtoken-"))
+const SECRET = "test-publish-secret-long-enough"
+const path = join(dir, "pub.db")
+const meta = new SqliteMetaStore(path)
+const blobs = new FsBlobStore(join(dir, "blobs"))
+
+// Seed the granting user (Better Auth `user` table) + an editor membership so the
+// spend-time recheck passes and getUsers resolves a byline.
+const raw = new Database(path)
+raw.exec(
+  `CREATE TABLE IF NOT EXISTS user (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT, username TEXT, discoverable INTEGER, profession TEXT, about TEXT, onboarded INTEGER, brandprint TEXT)`,
+)
+const insUser = raw.prepare(`INSERT OR IGNORE INTO user (id,email,name) VALUES (?,?,?)`)
+insUser.run("u_pub", "pub@x.test", "Pub User")
+insUser.run("u_viewer", "viewer@x.test", "Viewer User")
+insUser.run("u_noname", "noname@x.test", null) // null byline — spoofing regression
+raw.close()
+
+const app = createApp({
+  meta,
+  blobs,
+  baseUrl: "http://derive.test",
+  token: "tok",
+  encryptionKey: SECRET,
+})
+
+afterAll(() => {
+  meta.close()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+const seatUser = async (role: "editor" | "commenter", org = "default") =>
+  meta.setMembership({ id: newId("m"), org_id: org, user_id: "u_pub", role })
+
+// Multipart publish with NO auth header — the token in the URL is the only proof.
+const postFile = (
+  url: string,
+  bytes: Uint8Array,
+  name: string,
+  type: string,
+  fields: Record<string, string> = {},
+) => {
+  const fd = new FormData()
+  fd.append("file", new File([bytes as BlobPart], name, { type }), name)
+  for (const [k, v] of Object.entries(fields)) fd.append(k, v)
+  return app.request(url, { method: "POST", body: fd })
+}
+
+const html = (s: string) => new TextEncoder().encode(s)
+const createTok = (exp = Date.now() + 60_000, org = "default") =>
+  signPublishToken(SECRET, org, "u_pub", PUBLISH_TARGET_CREATE, exp)
+
+describe("POST /v1/artifacts/t/:token (create)", () => {
+  it("setup: seat the granting user as an editor", async () => {
+    await seatUser("editor")
+  })
+
+  it("publishes a single file with no auth header, owned + attributed to the bound user", async () => {
+    const tok = await createTok()
+    const res = await postFile(
+      `/v1/artifacts/t/${tok}`,
+      html("<h1>Big Page</h1>"),
+      "page.html",
+      "text/html",
+      { title: "Big Page" },
+    )
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.short_id).toBeTruthy()
+    expect(body.published).toBe(1)
+
+    // Attribution: the artifact is owned by the bound user (this is what makes
+    // `private` work + lets them find their own work), and the version byline is
+    // their name — not anonymous, even though the request carried no session.
+    const art = await meta.getByShortId(body.short_id)
+    if (!art) throw new Error("expected the created artifact")
+    expect(await meta.getArtifactMember(art.id, "u_pub")).toBeTruthy()
+    const v = await meta.getVersion(art.id, 1)
+    expect(v?.author).toBe("Pub User")
+    expect(art.org_id).toBe("default")
+  })
+
+  it("publishes a zip as a multi-page bundle", async () => {
+    const tok = await createTok()
+    const zip = await zipBundleFiles({
+      "index.html": "<!doctype html><h1>Site</h1><a href=about.html>about</a>",
+      "about.html": "<!doctype html><h1>About</h1>",
+    })
+    const res = await postFile(`/v1/artifacts/t/${tok}`, zip, "site.zip", "application/zip", {
+      title: "Prototype",
+    })
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.kind).toBe("bundle")
+  })
+
+  it("a create token cannot be used on the revise route (target mismatch)", async () => {
+    const tok = await createTok()
+    // First make an artifact to aim at.
+    const made = await (
+      await postFile(
+        `/v1/artifacts/t/${await createTok()}`,
+        html("<h1>x</h1>"),
+        "x.html",
+        "text/html",
+      )
+    ).json()
+    const res = await postFile(
+      `/v1/artifacts/${made.short_id}/versions/t/${tok}`,
+      html("<h1>y</h1>"),
+      "y.html",
+      "text/html",
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it("expired / garbage tokens → 403", async () => {
+    const expired = await createTok(Date.now() - 1_000)
+    expect(
+      (await postFile(`/v1/artifacts/t/${expired}`, html("<h1>x</h1>"), "x.html", "text/html"))
+        .status,
+    ).toBe(403)
+    expect(
+      (await postFile(`/v1/artifacts/t/garbage`, html("<h1>x</h1>"), "x.html", "text/html")).status,
+    ).toBe(403)
+  })
+
+  it("a server with no signing secret refuses the tokened route", async () => {
+    const noSecret = createApp({
+      meta: new SqliteMetaStore(join(dir, "nosecret.db")),
+      blobs: new FsBlobStore(join(dir, "nosecret-blobs")),
+      baseUrl: "http://derive.test",
+      token: "tok",
+    })
+    const tok = await createTok()
+    const res = await noSecret.request(`/v1/artifacts/t/${tok}`, {
+      method: "POST",
+      body: (() => {
+        const fd = new FormData()
+        fd.append(
+          "file",
+          new File([html("<h1>x</h1>") as BlobPart], "x.html", { type: "text/html" }),
+          "x.html",
+        )
+        return fd
+      })(),
+    })
+    expect(res.status).toBe(403)
+  })
+})
+
+describe("POST /v1/artifacts/:shortId/versions/t/:token (revise)", () => {
+  let shortId: string
+
+  it("setup: create an artifact to revise", async () => {
+    await seatUser("editor")
+    const made = await (
+      await postFile(
+        `/v1/artifacts/t/${await createTok()}`,
+        html("<h1>v1</h1>"),
+        "a.html",
+        "text/html",
+      )
+    ).json()
+    shortId = made.short_id
+  })
+
+  it("a revise token publishes a new version of exactly its target", async () => {
+    const tok = await signPublishToken(SECRET, "default", "u_pub", shortId, Date.now() + 60_000)
+    const res = await postFile(
+      `/v1/artifacts/${shortId}/versions/t/${tok}`,
+      html("<h1>v2</h1>"),
+      "a.html",
+      "text/html",
+    )
+    expect(res.status).toBe(201)
+    expect((await res.json()).published).toBe(2)
+  })
+
+  it("a revise token for artifact X cannot publish to artifact Y", async () => {
+    const other = await (
+      await postFile(
+        `/v1/artifacts/t/${await createTok()}`,
+        html("<h1>other</h1>"),
+        "b.html",
+        "text/html",
+      )
+    ).json()
+    const tokForShortId = await signPublishToken(
+      SECRET,
+      "default",
+      "u_pub",
+      shortId,
+      Date.now() + 60_000,
+    )
+    const res = await postFile(
+      `/v1/artifacts/${other.short_id}/versions/t/${tokForShortId}`,
+      html("<h1>hijack</h1>"),
+      "b.html",
+      "text/html",
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it("a revise token cannot reach an artifact in a different workspace than the token's org", async () => {
+    // Artifact lives in orgB; the token is scoped to "default". Membership
+    // re-check passes (u_pub IS a default editor), but the cross-org guard in
+    // handlePublish refuses — a token for one workspace can't touch another's.
+    const foreign = await meta.createArtifact({
+      id: newId("a"),
+      short_id: "foreign1",
+      org_id: "orgB",
+      slug: null,
+      title: "Foreign",
+      workspace_access: "member",
+      link_role: "none",
+      listed: "none",
+      kind: "file",
+      spa: 0,
+    })
+    await meta.addVersion(foreign.id, {
+      id: newId("v"),
+      blob_key: await blobs.put(html("<h1>foreign</h1>")),
+      content_type: "text/html",
+      size_bytes: 10,
+      author: "t",
+      message: null,
+    })
+    const tok = await signPublishToken(SECRET, "default", "u_pub", "foreign1", Date.now() + 60_000)
+    const res = await postFile(
+      `/v1/artifacts/foreign1/versions/t/${tok}`,
+      html("<h1>x</h1>"),
+      "x.html",
+      "text/html",
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it("revocation mid-TTL: losing the seat that granted publish kills an outstanding token", async () => {
+    await seatUser("editor")
+    // An artifact u_pub does NOT own (created directly, no owner share) that is
+    // workspace-accessible — so u_pub's publish right comes purely from the editor
+    // SEAT. Demoting the seat must kill an outstanding revise token, live. (On an
+    // artifact they own, the owner share persists past a seat change — correct, and
+    // why this uses a seat-only artifact.)
+    const seatArt = await meta.createArtifact({
+      id: newId("a"),
+      short_id: "seatart1",
+      org_id: "default",
+      slug: null,
+      title: "Seat-only",
+      workspace_access: "member",
+      link_role: "none",
+      listed: "none",
+      kind: "file",
+      spa: 0,
+    })
+    await meta.addVersion(seatArt.id, {
+      id: newId("v"),
+      blob_key: await blobs.put(html("<h1>v1</h1>")),
+      content_type: "text/html",
+      size_bytes: 10,
+      author: "t",
+      message: null,
+    })
+    const tok = await signPublishToken(SECRET, "default", "u_pub", "seatart1", Date.now() + 60_000)
+    // Editor seat → works.
+    expect(
+      (
+        await postFile(
+          `/v1/artifacts/seatart1/versions/t/${tok}`,
+          html("<h1>v2</h1>"),
+          "a.html",
+          "text/html",
+        )
+      ).status,
+    ).toBe(201)
+    // Demote to commenter → the SAME unexpired token is now refused.
+    await seatUser("commenter")
+    expect(
+      (
+        await postFile(
+          `/v1/artifacts/seatart1/versions/t/${tok}`,
+          html("<h1>v3</h1>"),
+          "a.html",
+          "text/html",
+        )
+      ).status,
+    ).toBe(403)
+    await seatUser("editor") // restore for any later test
+  })
+
+  it("a token whose user isn't a member → 403", async () => {
+    const tok = await signPublishToken(SECRET, "default", "u_ghost", shortId, Date.now() + 60_000)
+    const res = await postFile(
+      `/v1/artifacts/${shortId}/versions/t/${tok}`,
+      html("<h1>x</h1>"),
+      "a.html",
+      "text/html",
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it("no escalation: a workspace editor with only a viewer share can't revise a PRIVATE artifact", async () => {
+    // The token path must re-check ARTIFACT-level standing, not the workspace seat.
+    // On a private artifact (workspace_access="none") the seat grants nothing — only
+    // the share counts — so a workspace editor holding a mere viewer share is refused,
+    // exactly as the authed API refuses them.
+    await seatUser("editor") // u_pub, the creator/owner
+    await meta.setMembership({
+      id: newId("m"),
+      org_id: "default",
+      user_id: "u_viewer",
+      role: "editor",
+    })
+    const priv = await (
+      await postFile(
+        `/v1/artifacts/t/${await createTok()}`,
+        html("<h1>secret</h1>"),
+        "s.html",
+        "text/html",
+        {
+          workspace_access: "none",
+        },
+      )
+    ).json()
+    const art = await meta.getByShortId(priv.short_id)
+    if (!art) throw new Error("expected the private artifact")
+    await meta.setArtifactMember({
+      id: newId("am"),
+      artifact_id: art.id,
+      user_id: "u_viewer",
+      role: "viewer",
+    })
+
+    // Workspace editor + viewer share → refused.
+    const viewerTok = await signPublishToken(
+      SECRET,
+      "default",
+      "u_viewer",
+      priv.short_id,
+      Date.now() + 60_000,
+    )
+    expect(
+      (
+        await postFile(
+          `/v1/artifacts/${priv.short_id}/versions/t/${viewerTok}`,
+          html("<h1>hijack</h1>"),
+          "s.html",
+          "text/html",
+        )
+      ).status,
+    ).toBe(403)
+
+    // The owner (real publish standing on the private artifact) still can.
+    const ownerTok = await signPublishToken(
+      SECRET,
+      "default",
+      "u_pub",
+      priv.short_id,
+      Date.now() + 60_000,
+    )
+    expect(
+      (
+        await postFile(
+          `/v1/artifacts/${priv.short_id}/versions/t/${ownerTok}`,
+          html("<h1>v2</h1>"),
+          "s.html",
+          "text/html",
+        )
+      ).status,
+    ).toBe(201)
+  })
+
+  it("never takes the client-supplied author byline (bound to the real user)", async () => {
+    // A user whose stored name is null must not let the curl caller stamp an
+    // arbitrary `author` field as the version byline.
+    await meta.setMembership({
+      id: newId("m"),
+      org_id: "default",
+      user_id: "u_noname",
+      role: "editor",
+    })
+    const tok = await signPublishToken(
+      SECRET,
+      "default",
+      "u_noname",
+      PUBLISH_TARGET_CREATE,
+      Date.now() + 60_000,
+    )
+    const res = await postFile(
+      `/v1/artifacts/t/${tok}`,
+      html("<h1>x</h1>"),
+      "x.html",
+      "text/html",
+      {
+        author: "Impersonated",
+      },
+    )
+    expect(res.status).toBe(201)
+    const art = await meta.getByShortId((await res.json()).short_id)
+    if (!art) throw new Error("expected the artifact")
+    const v = await meta.getVersion(art.id, 1)
+    expect(v?.author).not.toBe("Impersonated")
+  })
+})


### PR DESCRIPTION
## Why

The `publish` tool carries content **inline** (`content`/`files`), which is model output — capped by the per-response token ceiling. Once a file is bigger than a page or two, an agent can't emit it in one tool call and is forced into slow, expensive multi-turn chunking (`edits`/`merge`). A hosted-OAuth agent can't fall back to the raw-body publish route either: its credential lives inside the MCP transport, so its shell has no bearer. The reported symptom: an agent grinding **34 minutes / ~105k tokens** to push a 107KB prototype in 11 chunks.

This is the text/code counterpart to `stage_asset` (which is image/font-only by design). Chosen over the "code-capable bundle staging" alternative for simplicity and completeness: it reuses the existing publish + sandboxed-serving pipeline, touches no schema and no `/blob/` route, and covers both single-file artifacts and bundles.

## What

`stage_publish` mints a short-lived signed capability URL the shell curls the file (or a zipped bundle) to — `POST /v1/artifacts/t/<token>` (create) or `/:shortId/versions/t/<token>` (revise) — reusing the whole existing `handlePublish` path. Zero bytes through the model's context.

`handlePublish` gains an optional `tokenAuth` override; the session/bearer path is unchanged. Routes are allowlisted through the anonymous write-lockdown like the asset/webhook routes (the signed token is the gate). The token lib is a thin wrapper over the shared `capability-token.ts`.

## Security scoping (publishing writes artifacts, so tighter than the asset token)

- **Bound to the granting user**, attributed as author + owner.
- **Live re-check at spend time** (revocation-safe): create re-checks the user's workspace publish seat; **revise re-checks artifact-level standing** (share + collection + seat), so losing the relevant grant kills the outstanding URL.
- **Target-scoped**: `*` only creates, a short_id only revises *that* artifact, and a tokened revise is refused if the artifact lives in another workspace — a leaked token can't be repurposed to overwrite arbitrary work.

## Review

A high-effort multi-agent adversarial review ran against this diff before opening; **all five confirmed findings are fixed and regression-tested**:

1. **Privilege escalation (critical):** the first cut re-checked only the workspace seat on revise, letting a workspace-editor with a mere viewer share overwrite a private artifact. Fixed with a new `authorizeUserStanding` helper that authorizes the bound user's artifact-level standing (never the world link), applied at both mint and spend. Regression test included.
2. **Cross-workspace revise always 403'd:** `stage_publish` minted against the default workspace instead of the one `reach()` roamed to. Now mints against the artifact's actual org.
3. **Author byline spoofing:** a null-named user's byline fell through to the client `author` field. A tokened publish now always uses the bound user's real name.
4. **Wrong-workspace mint role gate:** revise now gates on artifact standing, not the default-workspace seat role.
5. **(behavior, documented)** A tokened publish behaves like the user's own publish — no "your agent published X" bell, unlike the `publish` tool. Called out below as a possible follow-up.

## Testing

- Token unit: round-trip, target scoping, expiry, tamper, **domain separation** (an upload-domain token won't verify as a publish token).
- Route: create (single file + bundle), revise, all three scope refusals, cross-workspace refusal, **no-escalation on a private artifact**, **byline not client-spoofable**, revocation mid-TTL (seat-only artifact), non-member, expired/garbage/no-secret.
- MCP e2e: `stage_publish` create + revise → anonymous `curl` → published, owned, attributed.
- Full API suite green except two pre-existing `oauth-refresh-rotation` failures (also red on clean main). Both typecheck configs + the full lint battery pass. No OpenAPI change (tokened routes are plain `app.post`).

## Possible follow-up

If a headless/cron agent should still notify the human on a tokened publish (parity with the `publish` tool's bell), carry the agent identity in the token and reconstruct `agentPrincipal` at spend. Deferred deliberately to keep the token payload and spend-path minimal.