### PR TITLE
fix(deploy): skip the idle-D1 schema apply on the Postgres tier

### DIFF
--- a/apps/api/scripts/apply-d1-schema.mjs
+++ b/apps/api/scripts/apply-d1-schema.mjs
@@ -10,6 +10,10 @@
 //   2. Diff each table's columns against the live DB and ALTER ... ADD COLUMN only the
 //      missing ones (CREATE-IF-NOT-EXISTS never adds columns to a table that exists).
 //
+// No-op on the Postgres tier: with Hyperdrive → Neon bound, the worker reads Postgres
+// and this D1 sits idle, so its schema is irrelevant. DATABASE_URL set ⇒ skip (see the
+// guard below) — otherwise a drift in a database prod never reads could block deploys.
+//
 //   node scripts/apply-d1-schema.mjs           # --remote (production D1)
 //   node scripts/apply-d1-schema.mjs --local   # local/dev D1
 import { execFileSync } from "node:child_process"
@@ -20,6 +24,20 @@ import { parseExpectedColumns, planColumnAdds } from "./d1-schema-plan.mjs"
 
 const DB = process.env.DERIVE_D1_NAME ?? "derive"
 const TARGET = process.argv.includes("--local") ? "--local" : "--remote"
+
+// Postgres tier: skip. When Hyperdrive → Neon is bound, the worker reads Postgres and
+// the D1 database "sits idle" (see apps/api/wrangler.toml) — its schema never serves a
+// request. Applying it anyway lets a drift in a database prod never reads block every
+// deploy: e.g. a NOT NULL column added to an existing table, which fails the `CREATE
+// INDEX` in the declarative file AND can't be ALTER-added by the additive-only
+// reconciler below — wedging the pipeline over dead weight. DATABASE_URL set means the
+// Postgres tier (the deploy step asserts it before calling this), so bow out cleanly. A
+// D1-tier deploy (no DATABASE_URL) still applies, as does `--local` dev without one.
+if (process.env.DATABASE_URL) {
+  console.log("[d1] DATABASE_URL set (Postgres tier) — D1 is idle; skipping D1 schema apply")
+  process.exit(0)
+}
+
 const here = dirname(fileURLToPath(import.meta.url))
 const schemaPath = join(here, "../../../deploy/d1-schema.sql")
 


### PR DESCRIPTION
## The incident
Prod deploys have been **broken for ~4 hours** — five consecutive failures since #453 ("Sign in with Slack"), blocking four Slack PRs *and* #460 (`stage_publish`). Last green deploy was #452.

The deploy dies at its first step, "Apply schemas", with `no such column: team_id` while running `deploy/d1-schema.sql` against the **D1** database — which prod doesn't even use.

## Root cause
On the hosted tier the worker reads **Neon via Hyperdrive**; the D1 database "sits idle" (stated outright in `apps/api/wrangler.toml`). But the deploy still applies `d1-schema.sql` to it, first, and gates the whole deploy on it. #453 added `slack_user_link` with a `NOT NULL team_id` column to a table that already existed on remote D1 in an older shape, so:
- `CREATE TABLE IF NOT EXISTS` skips the redefinition (no `team_id` added),
- `CREATE INDEX … (team_id)` throws, and
- `apply-d1-schema.mjs`'s additive-only reconciler can't `ALTER ADD` a `NOT NULL`/no-default column either.

A drift in a database prod never reads wedged the pipeline for everyone. (Prod itself stayed up — schema applies *before* the worker flip, so the old worker kept serving.)

## The fix
`apply-d1-schema.mjs` bows out (exit 0, clear log) when `DATABASE_URL` is set — precisely the Postgres tier, which the deploy step already asserts. The D1 schema is irrelevant there, so skipping it can't affect what prod serves.

- **D1-tier deploys** (self-host, no `DATABASE_URL`) still apply the schema unchanged.
- **No test coverage lost**: the `d1` CI job runs `test:d1` (a Miniflare driver test); it never invoked this script. `apply-d1-schema.mjs` is called only in the deploy job.
- **Self-unblocking**: this PR's own post-merge deploy takes the skip and ships current main — the queued Slack PRs and `stage_publish` all go out in that deploy.

## Testing
Smoke-tested both branches locally: `DATABASE_URL=… node apply-d1-schema.mjs --remote` → prints the skip and exits 0 with no `wrangler` call; without `DATABASE_URL` it proceeds to apply as before. Full lint battery passes.

## Follow-ups (not in this PR)
- The remote idle-D1 `slack_user_link` table stays drifted — harmless (idle), but worth a one-line `DROP TABLE` cleanup with a D1-scoped token whenever convenient.
- The `CLOUDFLARE_API_TOKEN` in `.env` is stale (fails auth); the local `pnpm deploy` path is broken until it's rotated.
- Confirm the Slack sign-in feature is Postgres-backed on prod (via Drizzle) and the D1 `slack_user_link` was purely vestigial.