### PR TITLE
feat(library): multi-select bar + tags/collections for agents

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1032,6 +1032,28 @@
           "grantedAt"
         ]
       },
+      "BulkSummary": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "number",
+            "description": "Artifacts the operation applied to."
+          },
+          "skipped": {
+            "type": "number",
+            "description": "Not found, or the caller may not do this to it — not an error."
+          },
+          "failed": {
+            "type": "number",
+            "description": "The write was attempted but threw."
+          }
+        },
+        "required": [
+          "ok",
+          "skipped",
+          "failed"
+        ]
+      },
       "AssetRef": {
         "type": "object",
         "properties": {
@@ -4078,6 +4100,26 @@
         }
       }
     },
+    "/v1/bulk/delete": {
+      "post": {
+        "tags": [
+          "Artifacts"
+        ],
+        "summary": "Permanently delete many artifacts (owner-only per artifact).",
+        "responses": {
+          "200": {
+            "description": "How many were deleted / skipped / failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkSummary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/artifacts/{shortId}/move": {
       "post": {
         "tags": [
@@ -4622,6 +4664,46 @@
         }
       }
     },
+    "/v1/bulk/tags": {
+      "post": {
+        "tags": [
+          "Favorites"
+        ],
+        "summary": "Add browse tags to many artifacts (per-artifact editor-gated).",
+        "responses": {
+          "200": {
+            "description": "How many were tagged / skipped / failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkSummary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/bulk/favorite": {
+      "post": {
+        "tags": [
+          "Favorites"
+        ],
+        "summary": "Star or unstar many artifacts (any reader).",
+        "responses": {
+          "200": {
+            "description": "How many were starred / skipped / failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkSummary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/follows": {
       "get": {
         "tags": [
@@ -4904,6 +4986,26 @@
         "responses": {
           "204": {
             "description": "The artifact was removed."
+          }
+        }
+      }
+    },
+    "/v1/bulk/collections": {
+      "post": {
+        "tags": [
+          "Collections"
+        ],
+        "summary": "Add many artifacts to one or more collections (per-artifact share-gated).",
+        "responses": {
+          "200": {
+            "description": "How many artifacts were added / skipped / failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkSummary"
+                }
+              }
+            }
           }
         }
       }

--- a/apps/api/src/lib/bulk.ts
+++ b/apps/api/src/lib/bulk.ts
@@ -1,0 +1,74 @@
+import { z } from "@hono/zod-openapi"
+
+// The server side of the library's multi-select bar. There is deliberately no "bulk"
+// concept in the data model: a bulk route resolves each artifact and runs the SAME
+// per-artifact authorization the single-artifact route does, just over a set. That is the
+// honest shape, because a library selection routinely mixes artifacts you own with ones
+// you only read — one all-or-nothing call would either over-reach or fail the whole batch
+// on the first artifact you can't touch.
+
+/** What a bulk mutation did, counted per artifact. `skipped` is not an error — the
+ *  artifact wasn't found, or the caller may not perform THIS action on it (tagging a doc
+ *  you only read, deleting one you don't own). `failed` is a write that was attempted and
+ *  threw. Every /v1/bulk/* route returns this one shape so the client renders a single
+ *  consistent "N done · M skipped" line. */
+export interface BulkSummary {
+  ok: number
+  skipped: number
+  failed: number
+}
+
+export const BulkSummarySchema = z
+  .object({
+    ok: z.number().describe("Artifacts the operation applied to."),
+    skipped: z.number().describe("Not found, or the caller may not do this to it — not an error."),
+    failed: z.number().describe("The write was attempted but threw."),
+  })
+  .openapi("BulkSummary")
+
+/** A hard ceiling on one bulk request. A library selection is human-sized (you check
+ *  cards), so this guards against a scripted or pathological call, not a normal limit. */
+export const BULK_MAX = 500
+
+// Enough to keep a 50-item set from serializing a few hundred DB round-trips, without
+// opening a connection per artifact.
+const CONCURRENCY = 8
+
+/**
+ * The one bulk primitive: for each (deduped) shortId, resolve it, authorize it, and apply
+ * to the ones that pass — bounded-concurrent — returning the {ok, skipped, failed} tally.
+ * Not-found or authz-refused counts as `skipped`; a thrown `apply` counts as `failed` and
+ * never sinks the rest of the batch. The `allow`/`apply` split is what lets every caller
+ * reuse the existing per-artifact authz (`authorize(c, action, a)`) unchanged.
+ */
+export async function bulkArtifactOp<A>(
+  shortIds: string[],
+  resolve: (shortId: string) => Promise<A | null>,
+  allow: (a: A) => Promise<boolean>,
+  apply: (a: A) => Promise<void>,
+): Promise<BulkSummary> {
+  const uniq = [...new Set(shortIds)]
+  const summary: BulkSummary = { ok: 0, skipped: 0, failed: 0 }
+  let next = 0
+  const worker = async () => {
+    while (next < uniq.length) {
+      const shortId = uniq[next++]
+      if (shortId === undefined) break
+      const a = await resolve(shortId)
+      if (!a || !(await allow(a))) {
+        summary.skipped++
+        continue
+      }
+      try {
+        await apply(a)
+        summary.ok++
+      } catch {
+        // A per-artifact failure is data, not an exception — it lands in the tally and the
+        // remaining artifacts still run.
+        summary.failed++
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, uniq.length) }, worker))
+  return summary
+}

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -35,6 +35,7 @@ import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
 import { afterPublish } from "../lib/after-publish"
 import { authorProfile, resolveHandles, resolveUserBylines } from "../lib/author"
+import { BULK_MAX, BulkSummarySchema, bulkArtifactOp } from "../lib/bulk"
 import { cleanPath, manifestOf } from "../lib/bundle"
 import { hashPassword, signState, unlockCookie, unlockToken, verifyPassword } from "../lib/crypto"
 import {
@@ -1372,6 +1373,38 @@ export const artifactRoutes = (ctx: AppContext) => {
       // helper so a hard-delete path can't clean one arm and forget the other.
       await deleteArtifactAndUnindex(meta, search, artifact.id, artifact.org_id)
       return c.body(null, 204)
+    },
+  )
+
+  // Bulk delete — the library multi-select bar. Owner-only per artifact (the same `manage`
+  // gate as the single delete); anything you don't own comes back as `skipped` rather than
+  // failing the batch, so a mixed selection deletes what's yours and leaves the rest.
+  app.openapi(
+    createRoute({
+      method: "post",
+      path: "/v1/bulk/delete",
+      tags: ["Artifacts"],
+      summary: "Permanently delete many artifacts (owner-only per artifact).",
+      responses: {
+        200: {
+          description: "How many were deleted / skipped / failed.",
+          content: { "application/json": { schema: BulkSummarySchema } },
+        },
+      },
+    }),
+    async (c) => {
+      const body = await readJson(
+        c,
+        z.object({ shortIds: z.array(z.string()).min(1).max(BULK_MAX) }),
+      )
+      if (body instanceof Response) return bail(body)
+      const summary = await bulkArtifactOp(
+        body.shortIds,
+        (shortId) => meta.getByShortId(shortId),
+        (a) => authorize(c, "manage", a),
+        (a) => deleteArtifactAndUnindex(meta, search, a.id, a.org_id),
+      )
+      return c.json(summary)
     },
   )
 

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -10,6 +10,7 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { Context } from "hono"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
+import { BULK_MAX, BulkSummarySchema, bulkArtifactOp } from "../lib/bulk"
 import { bail, fail, readJson } from "../lib/http"
 import { resolveUserRef } from "../lib/resolve-user"
 import { ArtifactMember } from "../schemas"
@@ -344,6 +345,58 @@ export const collectionRoutes = (ctx: AppContext) => {
       if (!art || art.org_id !== col.org_id) return bail(fail(c, 404, "artifact not found"))
       await meta.removeCollectionItem(col.id, art.id)
       return c.body(null, 204)
+    },
+  )
+
+  // Bulk add — the library multi-select bar drops many artifacts into one or more
+  // collections in a single call. The collections are authorized once each (you must be
+  // able to publish to a collection to fold artifacts into it); every artifact is then
+  // authorized on its own for "share" exactly like the single add-item route, since adding
+  // to a shared collection re-shares the artifact. Per-artifact refusals come back as
+  // `skipped`, so a mixed selection lands what it can without failing the batch.
+  app.openapi(
+    createRoute({
+      method: "post",
+      path: "/v1/bulk/collections",
+      tags: ["Collections"],
+      summary: "Add many artifacts to one or more collections (per-artifact share-gated).",
+      responses: {
+        200: {
+          description: "How many artifacts were added / skipped / failed.",
+          content: { "application/json": { schema: BulkSummarySchema } },
+        },
+      },
+    }),
+    async (c) => {
+      const body = await readJson(
+        c,
+        z.object({
+          shortIds: z.array(z.string()).min(1).max(BULK_MAX),
+          collectionIds: z.array(z.string()).min(1),
+        }),
+      )
+      if (body instanceof Response) return bail(body)
+      // Resolve the target collections and keep only those the caller can publish to. If
+      // they can manage NONE, that's a flat 403 — nothing to add into.
+      const resolved = await Promise.all(body.collectionIds.map((id) => meta.getCollection(id)))
+      const allowedCols: CollectionRecord[] = []
+      for (const col of resolved) {
+        if (col && (await canManageCollection(c, col, "publish"))) allowedCols.push(col)
+      }
+      if (allowedCols.length === 0) return bail(fail(c, 403, "forbidden"))
+      const summary = await bulkArtifactOp(
+        body.shortIds,
+        (shortId) => meta.getByShortId(shortId),
+        (a) => authorize(c, "share", a),
+        async (a) => {
+          // Same-workspace guard mirrors the single add-item route: a foreign-workspace
+          // artifact (by short_id) is not folded into this workspace's collection.
+          for (const col of allowedCols) {
+            if (col.org_id === a.org_id) await meta.addCollectionItem(col.id, a.id)
+          }
+        },
+      )
+      return c.json(summary)
     },
   )
 

--- a/apps/api/src/routes/favorites.ts
+++ b/apps/api/src/routes/favorites.ts
@@ -1,6 +1,7 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
+import { BULK_MAX, BulkSummarySchema, bulkArtifactOp } from "../lib/bulk"
 import { bail, fail, readJson } from "../lib/http"
 
 /** Favorites (personal stars) + tags (workspace browse metadata). */
@@ -97,6 +98,85 @@ export const favoriteRoutes = (ctx: AppContext) => {
       const tags = normalizeTags(body.tags)
       await meta.setArtifactTags(artifact.id, tags)
       return c.json({ tags })
+    },
+  )
+
+  // Bulk tags — the library multi-select bar. ADDS a set of tags to many artifacts at
+  // once; it never replaces, so tagging a selection can't wipe the tags its other members
+  // already carry. The union is computed per artifact server-side (the client sends only
+  // the tags to add), and each artifact is authorized on its own like the single route.
+  app.openapi(
+    createRoute({
+      method: "post",
+      path: "/v1/bulk/tags",
+      tags: ["Favorites"],
+      summary: "Add browse tags to many artifacts (per-artifact editor-gated).",
+      responses: {
+        200: {
+          description: "How many were tagged / skipped / failed.",
+          content: { "application/json": { schema: BulkSummarySchema } },
+        },
+      },
+    }),
+    async (c) => {
+      const me = await requireUser(c)
+      if (me instanceof Response) return bail(me)
+      const body = await readJson(
+        c,
+        z.object({
+          shortIds: z.array(z.string()).min(1).max(BULK_MAX),
+          add: z.array(z.string()),
+        }),
+      )
+      if (body instanceof Response) return bail(body)
+      const add = normalizeTags(body.add)
+      if (add.length === 0) return c.json({ ok: 0, skipped: 0, failed: 0 })
+      const summary = await bulkArtifactOp(
+        body.shortIds,
+        (shortId) => meta.getByShortId(shortId),
+        (a) => authorize(c, "publish", a),
+        async (a) => {
+          const current = (await meta.tagsForArtifacts([a.id]))[a.id] ?? []
+          await meta.setArtifactTags(a.id, normalizeTags([...current, ...add]))
+        },
+      )
+      return c.json(summary)
+    },
+  )
+
+  // Bulk favorite — star or unstar many artifacts at once. Personal, like the single
+  // route: any user who can READ an artifact may star it.
+  app.openapi(
+    createRoute({
+      method: "post",
+      path: "/v1/bulk/favorite",
+      tags: ["Favorites"],
+      summary: "Star or unstar many artifacts (any reader).",
+      responses: {
+        200: {
+          description: "How many were starred / skipped / failed.",
+          content: { "application/json": { schema: BulkSummarySchema } },
+        },
+      },
+    }),
+    async (c) => {
+      const me = await requireUser(c)
+      if (me instanceof Response) return bail(me)
+      const body = await readJson(
+        c,
+        z.object({
+          shortIds: z.array(z.string()).min(1).max(BULK_MAX),
+          favorite: z.boolean(),
+        }),
+      )
+      if (body instanceof Response) return bail(body)
+      const summary = await bulkArtifactOp(
+        body.shortIds,
+        (shortId) => meta.getByShortId(shortId),
+        (a) => authorize(c, "read", a),
+        (a) => (body.favorite ? meta.setFavorite(a.id, me.id) : meta.removeFavorite(a.id, me.id)),
+      )
+      return c.json(summary)
     },
   )
 

--- a/apps/api/test/bulk.test.ts
+++ b/apps/api/test/bulk.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest"
+import { as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// The /v1/bulk/* routes behind the library multi-select bar. The point of these routes is
+// that each artifact is authorized on its own — a selection legitimately mixes what you own
+// with what you only read — so the tests that matter most are the MIXED ones: the batch
+// applies to what the caller may touch and reports the rest as `skipped`, never failing the
+// whole call or silently dropping the artifacts it couldn't act on.
+
+const amy: TestUser = { id: "u_bulk_amy", email: "amy@bulk.test", name: "Amy", username: "amyb" }
+const ben: TestUser = { id: "u_bulk_ben", email: "ben@bulk.test", name: "Ben", username: "benb" }
+
+// amy owns the workspace (users[0]); ben is a plain editor seat. Team-draft artifacts
+// (the default) are workspace-readable, so ben can read/edit them but not manage (delete).
+const { app, meta } = makeAuthedApp("bulk", [amy, ben], "editor")
+
+const publish = async (title: string): Promise<string> => {
+  const res = await publishAs(app, `# ${title}`, { title }, as(amy.email))
+  return (await res.json()).short_id
+}
+
+const bulk = (path: string, body: unknown, who: TestUser = amy) =>
+  app.request(path, jsonAs(as(who.email), body))
+
+describe("bulk tags", () => {
+  it("ADDS to each artifact's set (never replaces) and skips nothing you own", async () => {
+    const [a, b, c] = [await publish("tag-a"), await publish("tag-b"), await publish("tag-c")]
+    // b already carries a tag — the bulk add must not wipe it.
+    await app.request(`/v1/artifacts/${b}/tags`, {
+      ...jsonAs(as(amy.email), { tags: ["keep"] }),
+      method: "PUT",
+    })
+
+    const res = await bulk("/v1/bulk/tags", { shortIds: [a, b], add: ["q3"] })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: 2, skipped: 0, failed: 0 })
+
+    const idA = (await meta.getByShortId(a))?.id as string
+    const idB = (await meta.getByShortId(b))?.id as string
+    const idC = (await meta.getByShortId(c))?.id as string
+    const tags = await meta.tagsForArtifacts([idA, idB, idC])
+    expect(tags[idA]).toEqual(["q3"])
+    expect(tags[idB]?.sort()).toEqual(["keep", "q3"]) // merged, not replaced
+    expect(tags[idC] ?? []).toEqual([]) // untouched — never in the set
+  })
+
+  it("a short id that resolves to nothing is skipped, not a failure", async () => {
+    const a = await publish("mixed-a")
+    // An unknown id resolves to null → skipped; the real, owned artifact still gets tagged.
+    // (The authz-refused skip path — a caller without standing — is covered by bulk delete.)
+    const res = await bulk("/v1/bulk/tags", { shortIds: [a, "does_not_exist"], add: ["x"] })
+    expect(await res.json()).toEqual({ ok: 1, skipped: 1, failed: 0 })
+  })
+
+  it("a no-op tag set is a clean 0/0/0, not an error", async () => {
+    const a = await publish("noop")
+    const res = await bulk("/v1/bulk/tags", { shortIds: [a], add: ["   "] })
+    expect(await res.json()).toEqual({ ok: 0, skipped: 0, failed: 0 })
+  })
+})
+
+describe("bulk favorite", () => {
+  it("stars a set, then unstars it", async () => {
+    const [a, b] = [await publish("fav-a"), await publish("fav-b")]
+
+    const star = await bulk("/v1/bulk/favorite", { shortIds: [a, b], favorite: true })
+    expect(await star.json()).toEqual({ ok: 2, skipped: 0, failed: 0 })
+    const starred = await (
+      await app.request("/v1/artifacts?favorite=true", { headers: as(amy.email) })
+    ).json()
+    expect(starred.artifacts.map((x: { short_id: string }) => x.short_id).sort()).toEqual(
+      [a, b].sort(),
+    )
+
+    const unstar = await bulk("/v1/bulk/favorite", { shortIds: [a, b], favorite: false })
+    expect(await unstar.json()).toEqual({ ok: 2, skipped: 0, failed: 0 })
+    const after = await (
+      await app.request("/v1/artifacts?favorite=true", { headers: as(amy.email) })
+    ).json()
+    expect(after.artifacts).toHaveLength(0)
+  })
+})
+
+describe("bulk collections", () => {
+  it("adds a set to a collection in one call", async () => {
+    const [a, b, c] = [await publish("col-a"), await publish("col-b"), await publish("col-c")]
+    const col = await (await bulk("/v1/collections", { title: "Q3" })).json()
+
+    const res = await bulk("/v1/bulk/collections", {
+      shortIds: [a, b],
+      collectionIds: [col.id],
+    })
+    expect(await res.json()).toEqual({ ok: 2, skipped: 0, failed: 0 })
+
+    const listed = await (
+      await app.request(`/v1/artifacts?collection=${col.id}`, { headers: as(amy.email) })
+    ).json()
+    expect(listed.artifacts.map((x: { short_id: string }) => x.short_id).sort()).toEqual(
+      [a, b].sort(),
+    )
+    // c was never in the selection.
+    expect(listed.artifacts.map((x: { short_id: string }) => x.short_id)).not.toContain(c)
+  })
+
+  it("403s when the caller can manage none of the target collections", async () => {
+    const a = await publish("col-orphan")
+    const res = await bulk("/v1/bulk/collections", {
+      shortIds: [a],
+      collectionIds: ["col_does_not_exist"],
+    })
+    expect(res.status).toBe(403)
+  })
+})
+
+describe("bulk delete", () => {
+  it("deletes an owned set and leaves the unselected one", async () => {
+    const [a, b, c] = [await publish("del-a"), await publish("del-b"), await publish("del-c")]
+    const res = await bulk("/v1/bulk/delete", { shortIds: [a, b] })
+    expect(await res.json()).toEqual({ ok: 2, skipped: 0, failed: 0 })
+    expect(await meta.getByShortId(a)).toBeNull()
+    expect(await meta.getByShortId(b)).toBeNull()
+    expect(await meta.getByShortId(c)).not.toBeNull()
+  })
+
+  it("skips artifacts the caller doesn't own — an editor can't bulk-delete", async () => {
+    const [a, b] = [await publish("guard-a"), await publish("guard-b")]
+    // ben is an editor: he can read these team drafts but delete is owner-only (manage), so
+    // both are skipped and neither is removed. The batch does not error.
+    const res = await bulk("/v1/bulk/delete", { shortIds: [a, b] }, ben)
+    expect(await res.json()).toEqual({ ok: 0, skipped: 2, failed: 0 })
+    expect(await meta.getByShortId(a)).not.toBeNull()
+    expect(await meta.getByShortId(b)).not.toBeNull()
+  })
+})
+
+describe("bulk validation", () => {
+  it("rejects an empty selection", async () => {
+    const res = await bulk("/v1/bulk/delete", { shortIds: [] })
+    expect(res.status).toBe(400)
+  })
+})

--- a/apps/web/e2e/library-multi-select.smoke.spec.ts
+++ b/apps/web/e2e/library-multi-select.smoke.spec.ts
@@ -147,16 +147,24 @@ test("star a set from the bar, then unstar it", async ({ owner }) => {
   await expect(owner.getByTestId(`artifact-card-open-${a}`)).toBeHidden()
 })
 
-test("deleting a set asks first, then removes them", async ({ owner }) => {
+test("deleting a set requires typing 'delete', then removes them", async ({ owner }) => {
   const [a, b, c] = await seedLibrary(owner, 3)
 
   await owner.getByTestId(`artifact-card-select-${a}`).click()
   await owner.getByTestId(`artifact-card-select-${b}`).click()
   await owner.getByTestId("library-selection-delete").click()
 
-  // Destructive, so it goes through the shared confirm — never a bare bulk button.
+  // Destructive AND bulk, so it goes through the shared confirm with a type-to-confirm
+  // gate — the button is inert until the word is typed, so a reflex click can't delete.
   await expect(owner.getByText("Delete 2 artifacts?")).toBeVisible()
-  await owner.getByTestId("library-selection-delete-confirm").click()
+  const confirm = owner.getByTestId("library-selection-delete-confirm")
+  await expect(confirm).toBeDisabled()
+  await confirm.click({ force: true }) // even forced, an inert button does nothing
+  await expect(owner.getByText("Deleted 2 artifacts")).toBeHidden()
+
+  await owner.getByTestId("confirm-dialog-phrase").fill("delete")
+  await expect(confirm).toBeEnabled()
+  await confirm.click()
   await expect(owner.getByText("Deleted 2 artifacts")).toBeVisible()
 
   await expect(owner.getByTestId(`artifact-card-open-${a}`)).toBeHidden()

--- a/apps/web/e2e/library-multi-select.smoke.spec.ts
+++ b/apps/web/e2e/library-multi-select.smoke.spec.ts
@@ -1,0 +1,233 @@
+import { expect, publishArtifact, test } from "./fixtures"
+
+/**
+ * Library multi-select: check some cards, act on the set from the floating bar.
+ *
+ * The bar writes through the SAME per-artifact endpoints the ⋯ menu uses, so the
+ * assertions here deliberately end at the API, not at the toast — a green toast only
+ * proves the client thinks it worked. Each bulk test reads the state back over HTTP and
+ * checks the write actually landed on every artifact in the set.
+ *
+ * The mobile block is not a duplicate of the desktop one: it pins the two things that a
+ * hover-built selection UI gets wrong on a phone — a checkbox that only appears on hover
+ * (there is no hover), and a four-action bar that silently overflows a 375px viewport.
+ */
+
+// Publish n artifacts and land on the library with all of them on screen.
+async function seedLibrary(page: Parameters<typeof publishArtifact>[0], n: number) {
+  const ids: string[] = []
+  for (let i = 1; i <= n; i++) {
+    ids.push(await publishArtifact(page, `doc-${i}.md`, `# Doc ${i}\n\nbody`))
+  }
+  await page.goto("/")
+  for (const id of ids) {
+    await expect(page.getByTestId(`artifact-card-open-${id}`)).toBeVisible()
+  }
+  return ids
+}
+
+test("select cards, tag the set, and the tags land on every artifact", async ({ owner }) => {
+  const [a, b, c] = await seedLibrary(owner, 3)
+
+  // No selection, no bar — the library is a gallery until you say otherwise.
+  await expect(owner.getByTestId("library-selection-bar")).toBeHidden()
+
+  await owner.getByTestId(`artifact-card-select-${a}`).click()
+  await owner.getByTestId(`artifact-card-select-${b}`).click()
+
+  await expect(owner.getByTestId("library-selection-bar")).toBeVisible()
+  await expect(owner.getByTestId("library-selection-count")).toHaveText("2")
+
+  await owner.getByTestId("library-selection-tags").click()
+  await owner.getByTestId("bulk-tag-input").fill("q3")
+  await owner.getByTestId("bulk-tag-stage").click()
+  await owner.getByTestId("bulk-tag-apply").click()
+
+  await expect(owner.getByText("Tagged 2 artifacts")).toBeVisible()
+  // The write cleared the selection, so the bar retires on its own.
+  await expect(owner.getByTestId("library-selection-bar")).toBeHidden()
+
+  // The real assertion: the server says both artifacts carry the tag, and the third —
+  // never selected — was not touched.
+  for (const id of [a, b]) {
+    const res = await owner.request.get(`/v1/artifacts/${id}`)
+    expect(res.ok()).toBeTruthy()
+    expect(((await res.json()) as { tags: string[] }).tags).toContain("q3")
+  }
+  const untouched = await owner.request.get(`/v1/artifacts/${c}`)
+  expect(((await untouched.json()) as { tags: string[] }).tags).not.toContain("q3")
+})
+
+test("tagging a set MERGES — it never replaces the tags an artifact already has", async ({
+  owner,
+}) => {
+  const [a] = await seedLibrary(owner, 2)
+  // Pre-existing tag, set the way the single-artifact dialog would.
+  await owner.request.put(`/v1/artifacts/${a}/tags`, { data: { tags: ["keepme"] } })
+  await owner.reload()
+
+  await owner.getByTestId(`artifact-card-select-${a}`).click()
+  await owner.getByTestId("library-selection-tags").click()
+  await owner.getByTestId("bulk-tag-input").fill("added")
+  await owner.getByTestId("bulk-tag-stage").click()
+  await owner.getByTestId("bulk-tag-apply").click()
+  await expect(owner.getByText("Tagged 1 artifact")).toBeVisible()
+
+  // Both, not just the new one — the bulk path unions against each artifact's own set.
+  const tags = (await (await owner.request.get(`/v1/artifacts/${a}`)).json()) as { tags: string[] }
+  expect(tags.tags.sort()).toEqual(["added", "keepme"])
+})
+
+test("shift-click selects the range between two cards", async ({ owner }) => {
+  const [a, , c] = await seedLibrary(owner, 3)
+
+  await owner.getByTestId(`artifact-card-select-${a}`).click()
+  await owner.getByTestId(`artifact-card-select-${c}`).click({ modifiers: ["Shift"] })
+
+  // a through c inclusive — the card in the middle came along without being clicked.
+  await expect(owner.getByTestId("library-selection-count")).toHaveText("3")
+})
+
+test("Escape clears the selection", async ({ owner }) => {
+  const [a] = await seedLibrary(owner, 2)
+  await owner.getByTestId(`artifact-card-select-${a}`).click()
+  await expect(owner.getByTestId("library-selection-bar")).toBeVisible()
+
+  await owner.keyboard.press("Escape")
+  await expect(owner.getByTestId("library-selection-bar")).toBeHidden()
+})
+
+test("add a set to a new collection, created from the bar", async ({ owner }) => {
+  const [a, b] = await seedLibrary(owner, 3)
+
+  await owner.getByTestId(`artifact-card-select-${a}`).click()
+  await owner.getByTestId(`artifact-card-select-${b}`).click()
+  await owner.getByTestId("library-selection-collections").click()
+
+  await owner.getByTestId("bulk-collection-new-input").fill("Q3 Research")
+  await owner.getByTestId("bulk-collection-create").click()
+  await owner.getByTestId("bulk-collection-apply").click()
+  await expect(owner.getByText("Added 2 artifacts")).toBeVisible()
+
+  // Read the membership back off the server: the collection holds exactly the two.
+  const cols = (await (await owner.request.get("/v1/collections")).json()) as {
+    collections: { id: string; title: string }[]
+  }
+  const col = cols.collections.find((x) => x.title === "Q3 Research")
+  expect(col, "the collection was created").toBeTruthy()
+  const listed = (await (
+    await owner.request.get(`/v1/artifacts?collection=${col?.id}`)
+  ).json()) as { artifacts: { short_id: string }[] }
+  expect(listed.artifacts.map((x) => x.short_id).sort()).toEqual([a, b].sort())
+})
+
+test("star a set from the bar, then unstar it", async ({ owner }) => {
+  const [a, b] = await seedLibrary(owner, 2)
+
+  await owner.getByTestId(`artifact-card-select-${a}`).click()
+  await owner.getByTestId(`artifact-card-select-${b}`).click()
+  await owner.getByTestId("library-selection-favorite").click()
+  await expect(owner.getByText("Starred 2 artifacts")).toBeVisible()
+
+  // Favorites is its own feed — both land there.
+  await owner.goto("/favorites")
+  await expect(owner.getByTestId(`artifact-card-open-${a}`)).toBeVisible()
+  await expect(owner.getByTestId(`artifact-card-open-${b}`)).toBeVisible()
+
+  // Re-select in the favorites feed: every card is already starred, so the action
+  // inverts to Unstar.
+  await owner.getByTestId(`artifact-card-select-${a}`).click()
+  await owner.getByTestId(`artifact-card-select-${b}`).click()
+  await expect(owner.getByTestId("library-selection-favorite")).toHaveAttribute(
+    "aria-label",
+    "Unstar",
+  )
+  await owner.getByTestId("library-selection-favorite").click()
+  await expect(owner.getByText("Unstarred 2 artifacts")).toBeVisible()
+  await expect(owner.getByTestId(`artifact-card-open-${a}`)).toBeHidden()
+})
+
+test("deleting a set asks first, then removes them", async ({ owner }) => {
+  const [a, b, c] = await seedLibrary(owner, 3)
+
+  await owner.getByTestId(`artifact-card-select-${a}`).click()
+  await owner.getByTestId(`artifact-card-select-${b}`).click()
+  await owner.getByTestId("library-selection-delete").click()
+
+  // Destructive, so it goes through the shared confirm — never a bare bulk button.
+  await expect(owner.getByText("Delete 2 artifacts?")).toBeVisible()
+  await owner.getByTestId("library-selection-delete-confirm").click()
+  await expect(owner.getByText("Deleted 2 artifacts")).toBeVisible()
+
+  await expect(owner.getByTestId(`artifact-card-open-${a}`)).toBeHidden()
+  await expect(owner.getByTestId(`artifact-card-open-${b}`)).toBeHidden()
+  // The one we never checked survives.
+  await expect(owner.getByTestId(`artifact-card-open-${c}`)).toBeVisible()
+})
+
+test("changing the feed drops the selection instead of carrying it off-screen", async ({
+  owner,
+}) => {
+  const [a] = await seedLibrary(owner, 2)
+  await owner.getByTestId(`artifact-card-select-${a}`).click()
+  await expect(owner.getByTestId("library-selection-bar")).toBeVisible()
+
+  // Switch to the "Created by me" tab — a different feed, so the set resets rather than
+  // leaving the bar counting artifacts the new feed may not even contain.
+  await owner.getByTestId("library-tab-mine").click()
+  await expect(owner.getByTestId("library-selection-bar")).toBeHidden()
+})
+
+// The phone. A selection UI built around hover and a four-action bar are exactly the two
+// things that break here, so both are asserted directly rather than inferred from a click
+// that would have "passed" against an invisible control (Playwright clicks opacity-0
+// elements happily — hence the explicit computed-opacity check).
+test.describe("mobile", () => {
+  test.use({ viewport: { width: 375, height: 812 }, hasTouch: true, isMobile: true })
+
+  test("checkboxes are visible without hover, and the bar fits the viewport", async ({ owner }) => {
+    const [a, b] = await seedLibrary(owner, 3)
+
+    // On a touch pointer the checkbox is pinned visible: there is no hover to reveal it.
+    const box = owner.getByTestId(`artifact-card-select-${a}`)
+    await expect(box).toHaveCSS("opacity", "1")
+
+    await box.tap()
+    await owner.getByTestId(`artifact-card-select-${b}`).tap()
+    const bar = owner.getByTestId("library-selection-bar")
+    await expect(bar).toBeVisible()
+    await expect(owner.getByTestId("library-selection-count")).toHaveText("2")
+
+    // The bar fits inside the phone, and the page never gains a horizontal scrollbar.
+    const width = (await bar.boundingBox())?.width ?? 0
+    expect(width).toBeGreaterThan(0)
+    expect(width).toBeLessThanOrEqual(375)
+    const overflows = await owner.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    )
+    expect(overflows, "the library must not scroll horizontally").toBe(false)
+
+    // All four actions are reachable — they collapse to icons, they don't disappear into
+    // an overflow menu.
+    for (const id of ["tags", "collections", "favorite", "delete"]) {
+      await expect(owner.getByTestId(`library-selection-${id}`)).toBeVisible()
+    }
+  })
+
+  test("the full tag flow works on a phone", async ({ owner }) => {
+    const [a, b] = await seedLibrary(owner, 2)
+
+    await owner.getByTestId(`artifact-card-select-${a}`).tap()
+    await owner.getByTestId(`artifact-card-select-${b}`).tap()
+    await owner.getByTestId("library-selection-tags").tap()
+    await owner.getByTestId("bulk-tag-input").fill("mobile")
+    await owner.getByTestId("bulk-tag-stage").tap()
+    await owner.getByTestId("bulk-tag-apply").tap()
+
+    await expect(owner.getByText("Tagged 2 artifacts")).toBeVisible()
+    for (const id of [a, b]) {
+      const res = await owner.request.get(`/v1/artifacts/${id}`)
+      expect(((await res.json()) as { tags: string[] }).tags).toContain("mobile")
+    }
+  })
+})

--- a/apps/web/e2e/screens/multiselect.screens.ts
+++ b/apps/web/e2e/screens/multiselect.screens.ts
@@ -1,0 +1,59 @@
+import { test } from "../fixtures"
+import { publishArtifact } from "../helpers"
+
+// Capture-only, not a gate: seeds a library, drives the multi-select bar into a few
+// states, and screenshots them for the walkthrough. Gated on SHOTS=1 like the other
+// screens specs so a bare `playwright test` skips it. Output lands in ~/Projects/screenshots.
+const OUT = `${process.env.HOME}/Projects/screenshots/library-multiselect`
+const run = process.env.SHOTS === "1"
+
+async function seed(page: Parameters<typeof publishArtifact>[0], titles: string[]) {
+  const ids: string[] = []
+  for (const t of titles) ids.push(await publishArtifact(page, `${t}.md`, `# ${t}\n\nbody`))
+  await page.goto("/")
+  for (const id of ids) await page.getByTestId(`artifact-card-open-${id}`).waitFor()
+  return ids
+}
+
+test.describe("multiselect screens", () => {
+  test.skip(!run, "SHOTS=1 to capture")
+
+  test("desktop — bar over a selection (light + dark)", async ({ owner }) => {
+    await owner.setViewportSize({ width: 1280, height: 900 })
+    const ids = await seed(owner, ["Q3 Roadmap", "Launch Brief", "Retro Notes", "API Spec"])
+    await owner.getByTestId(`artifact-card-select-${ids[0]}`).click()
+    await owner.getByTestId(`artifact-card-select-${ids[1]}`).click()
+    await owner.getByTestId(`artifact-card-select-${ids[2]}`).click()
+    await owner.getByTestId("library-selection-bar").waitFor()
+    await owner.screenshot({ path: `${OUT}/desktop-light.png` })
+
+    await owner.getByTestId("user-menu-trigger").click()
+    await owner.getByTestId("theme-option-dark").click()
+    await owner.locator("html.dark").waitFor()
+    await owner.keyboard.press("Escape")
+    await owner.screenshot({ path: `${OUT}/desktop-dark.png` })
+  })
+
+  test("desktop — the add-tags dialog", async ({ owner }) => {
+    await owner.setViewportSize({ width: 1280, height: 900 })
+    const ids = await seed(owner, ["Q3 Roadmap", "Launch Brief", "Retro Notes"])
+    await owner.getByTestId(`artifact-card-select-${ids[0]}`).click()
+    await owner.getByTestId(`artifact-card-select-${ids[1]}`).click()
+    await owner.getByTestId("library-selection-tags").click()
+    await owner.getByTestId("bulk-tag-input").fill("q3")
+    await owner.getByTestId("bulk-tag-stage").click()
+    await owner.getByTestId("bulk-tag-input").fill("planning")
+    await owner.getByTestId("bulk-tag-stage").click()
+    await owner.getByTestId("bulk-tag-apply").waitFor()
+    await owner.screenshot({ path: `${OUT}/desktop-tags-dialog.png` })
+  })
+
+  test("mobile — checkboxes + collapsed bar", async ({ owner }) => {
+    await owner.setViewportSize({ width: 390, height: 844 })
+    const ids = await seed(owner, ["Q3 Roadmap", "Launch Brief", "Retro Notes"])
+    await owner.getByTestId(`artifact-card-select-${ids[0]}`).click()
+    await owner.getByTestId(`artifact-card-select-${ids[1]}`).click()
+    await owner.getByTestId("library-selection-bar").waitFor()
+    await owner.screenshot({ path: `${OUT}/mobile-light.png` })
+  })
+})

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -1400,6 +1400,42 @@ export interface paths {
         };
         trace?: never;
     };
+    "/v1/bulk/delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Permanently delete many artifacts (owner-only per artifact). */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description How many were deleted / skipped / failed. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BulkSummary"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/artifacts/{shortId}/move": {
         parameters: {
             query?: never;
@@ -1961,6 +1997,78 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/bulk/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Add browse tags to many artifacts (per-artifact editor-gated). */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description How many were tagged / skipped / failed. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BulkSummary"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/bulk/favorite": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Star or unstar many artifacts (any reader). */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description How many were starred / skipped / failed. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BulkSummary"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/follows": {
         parameters: {
             query?: never;
@@ -2256,6 +2364,42 @@ export interface paths {
                 };
             };
         };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/bulk/collections": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Add many artifacts to one or more collections (per-artifact share-gated). */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description How many artifacts were added / skipped / failed. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["BulkSummary"];
+                    };
+                };
+            };
+        };
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -5283,6 +5427,14 @@ export interface components {
             /** @description The OAuth scopes this agent was granted */
             scopes: string[];
             grantedAt: string;
+        };
+        BulkSummary: {
+            /** @description Artifacts the operation applied to. */
+            ok: number;
+            /** @description Not found, or the caller may not do this to it — not an error. */
+            skipped: number;
+            /** @description The write was attempted but threw. */
+            failed: number;
         };
         AssetRef: {
             /** @description The blob hash (content-addressed storage key) */

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -75,6 +75,8 @@ export type Report = components["schemas"]["Report"]
  *  (kind = manual / repo / pr). Generated from the OpenAPI spec (apps/api/openapi.json)
  *  — a backend shape change surfaces here at `tsc`. */
 export type Collection = components["schemas"]["Collection"]
+/** The result of a /v1/bulk/* op: counts per artifact (skipped = not yours to touch). */
+export type BulkSummary = components["schemas"]["BulkSummary"]
 /** A collection whose sharing reaches an artifact (workspace-open, or invite-only with
  *  members) — the share dialog's disclosure rows. Generated from the OpenAPI spec. */
 export type CollectionGrant = components["schemas"]["CollectionGrant"]
@@ -627,6 +629,20 @@ export const api = {
     f(`/v1/artifacts/${id}/favorite`, { ...opts(), method: on ? "PUT" : "DELETE" }).then(j),
   setTags: (id: string, tags: string[]): Promise<{ tags: string[] }> =>
     f(`/v1/artifacts/${id}/tags`, { ...opts({ tags }), method: "PUT" }).then(j),
+
+  // Bulk organize — the library multi-select bar. Each is ONE call over a set of
+  // short_ids; the server authorizes every artifact on its own and returns a
+  // {ok, skipped, failed} tally (skipped = not yours to touch), so the client sends the
+  // whole selection and shows what actually landed. Tags ADD (never replace); the server
+  // computes the per-artifact union, so the client sends only the tags to add.
+  bulkTags: (shortIds: string[], add: string[]): Promise<BulkSummary> =>
+    f("/v1/bulk/tags", opts({ shortIds, add })).then(j),
+  bulkFavorite: (shortIds: string[], favorite: boolean): Promise<BulkSummary> =>
+    f("/v1/bulk/favorite", opts({ shortIds, favorite })).then(j),
+  bulkAddToCollections: (shortIds: string[], collectionIds: string[]): Promise<BulkSummary> =>
+    f("/v1/bulk/collections", opts({ shortIds, collectionIds })).then(j),
+  bulkDelete: (shortIds: string[]): Promise<BulkSummary> =>
+    f("/v1/bulk/delete", opts({ shortIds })).then(j),
 
   // Follows (track GitHub authors + repo path prefixes) — the activity feed is
   // listArtifacts({ scope: "following" }). All scoped to the active workspace.

--- a/apps/web/src/components/shared/confirm-dialog.tsx
+++ b/apps/web/src/components/shared/confirm-dialog.tsx
@@ -8,6 +8,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 
 // The one destructive-confirm surface: every Remove/Delete/Take down goes
 // through this dialog — never window.confirm(). The confirm button keeps the
@@ -23,6 +25,7 @@ export function ConfirmDialog({
   tone = "destructive",
   onConfirm,
   confirmTestId = "confirm-dialog-confirm",
+  confirmPhrase,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -33,11 +36,22 @@ export function ConfirmDialog({
   tone?: "destructive" | "default"
   onConfirm: () => void | Promise<void>
   confirmTestId?: string
+  /** Require the user to TYPE this word before the confirm button enables — the
+   *  extra friction reserved for the highest-stakes destructions (a bulk delete of
+   *  many artifacts at once). Matched case-insensitively, trimmed. Omit for the
+   *  ordinary one-click confirm. */
+  confirmPhrase?: string
 }) {
   const [pending, setPending] = useState(false)
+  const [typed, setTyped] = useState("")
   const cancelRef = useRef<HTMLButtonElement>(null)
 
+  // With a phrase, the confirm button stays inert until it's typed — so Enter can't
+  // destroy anything by reflex, and a pre-focused button can't be mis-clicked into it.
+  const phraseMet = !confirmPhrase || typed.trim().toLowerCase() === confirmPhrase.toLowerCase()
+
   async function handleConfirm() {
+    if (!phraseMet) return
     setPending(true)
     try {
       await onConfirm()
@@ -48,12 +62,24 @@ export function ConfirmDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={(next) => !pending && onOpenChange(next)}>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (pending) return
+        // Reset the typed guard whenever the dialog closes, so re-opening it always
+        // starts locked — a stale match can't carry over into the next deletion.
+        if (!next) setTyped("")
+        onOpenChange(next)
+      }}
+    >
       <DialogContent
         showCloseButton={false}
-        // Initial focus lands on the LEAST destructive action — Enter can't
-        // destroy anything by reflex (the alertdialog convention).
+        // Initial focus: the type-to-confirm input when there is one (so you can type
+        // straight away), otherwise the LEAST destructive action — Enter can't destroy
+        // anything by reflex (the alertdialog convention). The typed button is disabled
+        // until matched, so focusing the input doesn't reintroduce a reflex confirm.
         onOpenAutoFocus={(e) => {
+          if (confirmPhrase) return
           e.preventDefault()
           cancelRef.current?.focus()
         }}
@@ -65,6 +91,27 @@ export function ConfirmDialog({
           <DialogTitle>{title}</DialogTitle>
           {description && <DialogDescription>{description}</DialogDescription>}
         </DialogHeader>
+        {confirmPhrase && (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="confirm-phrase">
+              Type <span className="font-mono font-semibold text-foreground">{confirmPhrase}</span>{" "}
+              to confirm.
+            </Label>
+            <Input
+              id="confirm-phrase"
+              value={typed}
+              autoComplete="off"
+              spellCheck={false}
+              placeholder={confirmPhrase}
+              data-testid="confirm-dialog-phrase"
+              onChange={(e) => setTyped(e.target.value)}
+              // Enter submits only once the phrase matches — the same gate the button has.
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && phraseMet && !pending) handleConfirm()
+              }}
+            />
+          </div>
+        )}
         <DialogFooter>
           <Button
             ref={cancelRef}
@@ -80,6 +127,7 @@ export function ConfirmDialog({
             type="button"
             variant={tone === "destructive" ? "destructive" : "default"}
             loading={pending}
+            disabled={!phraseMet}
             onClick={handleConfirm}
             data-testid={confirmTestId}
           >

--- a/apps/web/src/pages/library/artifact-card.tsx
+++ b/apps/web/src/pages/library/artifact-card.tsx
@@ -5,6 +5,7 @@ import { Thumb } from "@/components/shared/thumb"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -37,6 +38,9 @@ export function ArtifactCard({
   onAddToCollection,
   onDelete,
   onPrefetch,
+  selected = false,
+  selectionActive = false,
+  onSelect,
 }: {
   artifact: Artifact
   onOpen: () => void
@@ -51,6 +55,14 @@ export function ArtifactCard({
   // Warm the artifact (metadata + comments + rendered HTML) when the card is
   // hovered or focused, so the click that follows opens instantly.
   onPrefetch?: () => void
+  // Multi-select. The checkbox is the ONLY selection affordance: a plain click on
+  // the card still opens the artifact, even mid-selection, so the library's one
+  // lifelong gesture never changes meaning underneath you.
+  selected?: boolean
+  // Any selection in progress — every checkbox is pinned visible, not just the
+  // hovered card's, so the set you've built is legible at a glance.
+  selectionActive?: boolean
+  onSelect?: (shift: boolean) => void
 }) {
   const isOwner = a.my_role === "owner"
   const showTags = !!onEditTags && (a.my_role === "owner" || a.my_role === "editor")
@@ -80,16 +92,21 @@ export function ArtifactCard({
 
   return (
     <Card
+      data-selected={selected || undefined}
       className={cn(
         "group relative isolate flex flex-col gap-0 overflow-hidden p-0 shadow-(--shadow-sm)",
-        // A direct @mention gets the full accent + ring; a thread you're in — or
-        // proposals waiting on your review — gets a softer accent border. The ink
-        // accent is the sanctioned attention signal, shown at rest.
-        a.mentions_me
-          ? "border-primary ring-1 ring-primary/30"
-          : a.i_participated || awaitingReview
-            ? "border-primary/60"
-            : "border-border hover:border-foreground/25",
+        // Selection outranks every ambient signal: while you're building a set, the one
+        // thing the card must answer is "am I in it?".
+        selected
+          ? "border-primary ring-2 ring-primary/40"
+          : // A direct @mention gets the full accent + ring; a thread you're in — or
+            // proposals waiting on your review — gets a softer accent border. The ink
+            // accent is the sanctioned attention signal, shown at rest.
+            a.mentions_me
+            ? "border-primary ring-1 ring-primary/30"
+            : a.i_participated || awaitingReview
+              ? "border-primary/60"
+              : "border-border hover:border-foreground/25",
       )}
     >
       <div className="relative">
@@ -99,6 +116,33 @@ export function ArtifactCard({
           typeLabel={artifactTypeLabel(a)}
           hasPreview={a.has_preview}
         />
+        {/* The select box, opposite the actions cluster. Hidden at rest on a mouse (the
+            grid stays a gallery), pinned visible once ANY card is selected, and always
+            visible on touch — where there is no hover to reveal it. The ring keeps it
+            legible over a busy render. */}
+        {onSelect && (
+          <div className="absolute top-2 left-2 z-20">
+            <Checkbox
+              data-testid={`artifact-card-select-${a.short_id}`}
+              aria-label={`Select ${a.title ?? a.short_id}`}
+              checked={selected}
+              // Read the modifier off the CLICK: Radix's onCheckedChange can't see the
+              // shift key, and shift-click (extend the range) is the gesture that makes
+              // selecting twenty cards bearable. The parent owns the set, so letting the
+              // click drive it — not onCheckedChange — keeps one source of truth.
+              onClick={(e) => {
+                e.stopPropagation()
+                onSelect(e.shiftKey)
+              }}
+              className={cn(
+                "size-5 shadow-(--shadow-sm) ring-1 ring-foreground/10 transition-opacity",
+                !selected &&
+                  !selectionActive &&
+                  "opacity-0 group-hover:opacity-100 focus-visible:opacity-100 pointer-coarse:opacity-100",
+              )}
+            />
+          </div>
+        )}
         {/* Actions — top-right over the render, revealed on hover/focus (always shown
             on touch; a favourited star persists). Translucent pills read over any
             render, both themes. */}

--- a/apps/web/src/pages/library/artifact-grid.tsx
+++ b/apps/web/src/pages/library/artifact-grid.tsx
@@ -4,6 +4,7 @@ import type { Artifact } from "@/api"
 import { CARD_GRID_COLS, MIN_CARD_PX } from "@/components/shared/card-grid"
 import { cn } from "@/lib/utils"
 import { ArtifactCard } from "./artifact-card"
+import type { LibrarySelection } from "./use-library-selection"
 
 // Grid geometry comes from card-grid.tsx (one source with the live grid and the
 // skeleton). We virtualize ROWS (each row = `columns` cards), so we derive the
@@ -31,6 +32,7 @@ export function ArtifactGrid({
   onAddToCollection,
   onDelete,
   onPrefetch,
+  selection,
 }: {
   items: Artifact[]
   // The scrolling ancestor (the library's overflow-y-auto container).
@@ -45,6 +47,9 @@ export function ArtifactGrid({
   onAddToCollection: (a: Artifact) => void
   onDelete: (a: Artifact) => void
   onPrefetch: (a: Artifact) => void
+  // Multi-select. The grid only threads it through: the set lives in the library body,
+  // so it survives the virtualizer recycling a card out of the DOM on scroll.
+  selection?: LibrarySelection
 }) {
   const gridRef = useRef<HTMLDivElement>(null)
   const [columns, setColumns] = useState(1)
@@ -127,6 +132,9 @@ export function ArtifactGrid({
                 onAddToCollection={() => onAddToCollection(a)}
                 onDelete={() => onDelete(a)}
                 onPrefetch={() => onPrefetch(a)}
+                selected={selection?.selected.has(a.short_id)}
+                selectionActive={selection?.active}
+                onSelect={selection ? (shift) => selection.toggle(a.short_id, shift) : undefined}
               />
             ))}
           </div>

--- a/apps/web/src/pages/library/artifact-row.tsx
+++ b/apps/web/src/pages/library/artifact-row.tsx
@@ -4,6 +4,7 @@ import { AuthorChip } from "@/components/shared/author-chip"
 import { FollowButton } from "@/components/shared/follow-button"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -33,6 +34,9 @@ export function ArtifactRow({
   onAddToCollection,
   onDelete,
   onPrefetch,
+  selected = false,
+  selectionActive = false,
+  onSelect,
 }: {
   artifact: Artifact
   onOpen: () => void
@@ -48,6 +52,11 @@ export function ArtifactRow({
   onAddToCollection?: () => void
   onDelete?: () => void
   onPrefetch?: () => void
+  // Multi-select — the row's twin of the card's checkbox, same rules: the box is the
+  // only selection gesture, so a click on the row still opens the artifact.
+  selected?: boolean
+  selectionActive?: boolean
+  onSelect?: (shift: boolean) => void
 }) {
   const isOwner = a.my_role === "owner"
   const showTags = !!onEditTags && (a.my_role === "owner" || a.my_role === "editor")
@@ -68,16 +77,39 @@ export function ArtifactRow({
 
   return (
     <div
+      data-selected={selected || undefined}
       className={cn(
         "group relative flex items-center gap-3 rounded-lg border bg-card px-3.5 py-2.5 hover:bg-secondary",
-        // Needs-your-feedback accents — the ink accent is the sanctioned attention signal.
-        a.mentions_me
-          ? "border-primary ring-1 ring-primary/30"
-          : a.i_participated || awaitingReview
-            ? "border-primary/60"
-            : "border-border",
+        // Selection outranks the ambient accents — see ArtifactCard.
+        selected
+          ? "border-primary ring-2 ring-primary/40"
+          : // Needs-your-feedback accents — the ink accent is the sanctioned attention signal.
+            a.mentions_me
+            ? "border-primary ring-1 ring-primary/30"
+            : a.i_participated || awaitingReview
+              ? "border-primary/60"
+              : "border-border",
       )}
     >
+      {/* Leading edge, ahead of the title. It holds its column at rest (opacity, not
+          display) so revealing it on hover never reflows the row. */}
+      {onSelect && (
+        <Checkbox
+          data-testid={`artifact-row-select-${a.short_id}`}
+          aria-label={`Select ${a.title ?? a.short_id}`}
+          checked={selected}
+          onClick={(e) => {
+            e.stopPropagation()
+            onSelect(e.shiftKey)
+          }}
+          className={cn(
+            "relative z-20 shrink-0 transition-opacity",
+            !selected &&
+              !selectionActive &&
+              "opacity-0 group-hover:opacity-100 focus-visible:opacity-100 pointer-coarse:opacity-100",
+          )}
+        />
+      )}
       <button
         type="button"
         data-testid={`artifact-row-open-${a.short_id}`}

--- a/apps/web/src/pages/library/bulk-apply.ts
+++ b/apps/web/src/pages/library/bulk-apply.ts
@@ -1,0 +1,57 @@
+import type { Artifact } from "@/api"
+
+// Applying one organize action to many artifacts.
+//
+// There is no bulk ROUTE by design. Every artifact in a selection carries its own
+// authorization — a library view routinely mixes docs you own with docs you can only
+// read — and the existing per-artifact endpoints already gate exactly right. So the
+// honest primitive is N gated writes plus a summary of what landed, not one
+// all-or-nothing call that a single 403 in the middle would sink. Six at a time keeps
+// a 50-card selection quick without opening a connection per card.
+const CONCURRENCY = 6
+
+export interface BulkResult {
+  ok: number
+  failed: number
+  // Filtered out BEFORE the call because the caller can't perform it on that artifact
+  // (tagging a doc you only read, deleting one you don't own). Named separately from
+  // `failed` so the toast can say "skipped" — nothing went wrong, it just wasn't yours.
+  skipped: number
+}
+
+export async function bulkApply(
+  items: Artifact[],
+  write: (a: Artifact) => Promise<unknown>,
+  skipped = 0,
+): Promise<BulkResult> {
+  let ok = 0
+  let failed = 0
+  let next = 0
+  const worker = async () => {
+    while (next < items.length) {
+      const a = items[next++]
+      if (!a) break
+      try {
+        await write(a)
+        ok++
+      } catch {
+        // A per-artifact rejection (a 403 the client couldn't predict, a network blip)
+        // is data, not an exception: it lands in the summary and the rest still run.
+        failed++
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, items.length) }, worker))
+  // Nothing at all landed and it wasn't for lack of trying — surface it as a failure so
+  // the mutation primitive's error toast fires and the selection survives for a retry.
+  if (ok === 0 && failed > 0) throw new Error(`Couldn’t update ${failed} artifacts.`)
+  return { ok, failed, skipped }
+}
+
+// One line for the toast: what landed, then anything that didn't.
+export function summarize(verb: string, r: BulkResult): string {
+  const parts = [`${verb} ${r.ok} ${r.ok === 1 ? "artifact" : "artifacts"}`]
+  if (r.skipped > 0) parts.push(`${r.skipped} skipped`)
+  if (r.failed > 0) parts.push(`${r.failed} failed`)
+  return parts.join(" · ")
+}

--- a/apps/web/src/pages/library/bulk-apply.ts
+++ b/apps/web/src/pages/library/bulk-apply.ts
@@ -1,55 +1,10 @@
-import type { Artifact } from "@/api"
+import type { BulkSummary } from "@/api"
 
-// Applying one organize action to many artifacts.
-//
-// There is no bulk ROUTE by design. Every artifact in a selection carries its own
-// authorization — a library view routinely mixes docs you own with docs you can only
-// read — and the existing per-artifact endpoints already gate exactly right. So the
-// honest primitive is N gated writes plus a summary of what landed, not one
-// all-or-nothing call that a single 403 in the middle would sink. Six at a time keeps
-// a 50-card selection quick without opening a connection per card.
-const CONCURRENCY = 6
-
-export interface BulkResult {
-  ok: number
-  failed: number
-  // Filtered out BEFORE the call because the caller can't perform it on that artifact
-  // (tagging a doc you only read, deleting one you don't own). Named separately from
-  // `failed` so the toast can say "skipped" — nothing went wrong, it just wasn't yours.
-  skipped: number
-}
-
-export async function bulkApply(
-  items: Artifact[],
-  write: (a: Artifact) => Promise<unknown>,
-  skipped = 0,
-): Promise<BulkResult> {
-  let ok = 0
-  let failed = 0
-  let next = 0
-  const worker = async () => {
-    while (next < items.length) {
-      const a = items[next++]
-      if (!a) break
-      try {
-        await write(a)
-        ok++
-      } catch {
-        // A per-artifact rejection (a 403 the client couldn't predict, a network blip)
-        // is data, not an exception: it lands in the summary and the rest still run.
-        failed++
-      }
-    }
-  }
-  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, items.length) }, worker))
-  // Nothing at all landed and it wasn't for lack of trying — surface it as a failure so
-  // the mutation primitive's error toast fires and the selection survives for a retry.
-  if (ok === 0 && failed > 0) throw new Error(`Couldn’t update ${failed} artifacts.`)
-  return { ok, failed, skipped }
-}
-
-// One line for the toast: what landed, then anything that didn't.
-export function summarize(verb: string, r: BulkResult): string {
+// One line for the toast, from the summary a /v1/bulk/* route returns: what landed, then
+// anything that didn't. `skipped` is not a failure — the server passed over artifacts the
+// caller can't perform this action on (tagging a doc you only read, deleting one you don't
+// own), which a mixed library selection routinely includes.
+export function summarize(verb: string, r: BulkSummary): string {
   const parts = [`${verb} ${r.ok} ${r.ok === 1 ? "artifact" : "artifacts"}`]
   if (r.skipped > 0) parts.push(`${r.skipped} skipped`)
   if (r.failed > 0) parts.push(`${r.failed} failed`)

--- a/apps/web/src/pages/library/bulk-organize.tsx
+++ b/apps/web/src/pages/library/bulk-organize.tsx
@@ -1,0 +1,312 @@
+import type { QueryKey } from "@tanstack/react-query"
+import { useQuery } from "@tanstack/react-query"
+import { useState } from "react"
+import { type Artifact, api } from "@/api"
+import { Icon } from "@/components/icons"
+import { StatusPanel } from "@/components/shared/status-panel"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { artifactQuery, collectionsQuery, summaryQuery } from "@/lib/queries"
+import { useApiMutation } from "@/lib/use-api-mutation"
+import { useBrandprintCollectionIds } from "@/lib/use-brandprint-ids"
+import { cn } from "@/lib/utils"
+import { bulkApply, summarize } from "./bulk-apply"
+
+// The two organize dialogs in their MANY-artifact form, opened from the selection bar.
+// They mirror the single-artifact dialogs in components/shared/organize-dialogs (same
+// grammar, same API calls) with one deliberate difference: they ADD, never replace.
+// Applying "#q3" to eight artifacts must not flatten the tags the other seven already
+// carry — so tags are merged per artifact, and collections are only ever added to.
+
+// The artifacts a bulk write will touch, and the ones it will pass over. Every dialog
+// states this up front: a bulk write should never be a surprise.
+function ScopeLine({ count, skipped }: { count: number; skipped: number }) {
+  if (skipped === 0) return null
+  return (
+    <p className="text-sm text-muted-foreground">
+      {count} of {count + skipped} selected — {skipped} you can’t edit will be skipped.
+    </p>
+  )
+}
+
+export function BulkTagsDialog({
+  items,
+  skipped,
+  listKey,
+  onDone,
+  open,
+  onOpenChange,
+}: {
+  // Already narrowed to what the caller can tag (owner/editor).
+  items: Artifact[]
+  skipped: number
+  listKey: QueryKey
+  onDone: () => void
+  open: boolean
+  onOpenChange: (o: boolean) => void
+}) {
+  const [draft, setDraft] = useState("")
+  const [adding, setAdding] = useState<string[]>([])
+
+  const apply = useApiMutation({
+    // setTags REPLACES an artifact's set, so the union is computed per artifact from the
+    // tags already on its card. The server then normalizes (lowercase, dedupe, cap 20).
+    mutationFn: (tags: string[]) =>
+      bulkApply(
+        items,
+        (a) => api.setTags(a.short_id, [...new Set([...(a.tags ?? []), ...tags])]),
+        skipped,
+      ),
+    invalidate: [
+      listKey,
+      summaryQuery().queryKey,
+      ...items.map((a) => artifactQuery(a.short_id).queryKey),
+    ],
+    success: (r) => summarize("Tagged", r),
+    onSuccess: onDone,
+  })
+
+  const stage = () => {
+    const v = draft.trim().toLowerCase()
+    setDraft("")
+    if (v && !adding.includes(v)) setAdding((prev) => [...prev, v])
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add tags</DialogTitle>
+          <DialogDescription>
+            Tags are added to each artifact’s existing set — nothing is replaced.
+          </DialogDescription>
+        </DialogHeader>
+        <ScopeLine count={items.length} skipped={skipped} />
+        {adding.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {adding.map((t) => (
+              <Badge key={t} variant="outline" className="gap-1">
+                #{t}
+                <button
+                  type="button"
+                  data-icon="inline-end"
+                  data-testid={`bulk-tag-remove-${t}`}
+                  onClick={() => setAdding((prev) => prev.filter((x) => x !== t))}
+                  aria-label={`Remove ${t}`}
+                  className="rounded-sm outline-none hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                >
+                  <Icon name="close" size={12} />
+                </button>
+              </Badge>
+            ))}
+          </div>
+        )}
+        <div className="flex gap-1.5">
+          <Input
+            value={draft}
+            placeholder="Add a tag…"
+            data-testid="bulk-tag-input"
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") stage()
+            }}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={stage}
+            disabled={!draft.trim()}
+            data-testid="bulk-tag-stage"
+          >
+            Add
+          </Button>
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="bulk-tag-cancel"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            data-testid="bulk-tag-apply"
+            disabled={adding.length === 0 || apply.isPending}
+            onClick={() => apply.mutate(adding)}
+          >
+            {apply.isPending
+              ? "Tagging…"
+              : `Tag ${items.length} ${items.length === 1 ? "artifact" : "artifacts"}`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function BulkCollectionsDialog({
+  items,
+  listKey,
+  onDone,
+  open,
+  onOpenChange,
+}: {
+  items: Artifact[]
+  listKey: QueryKey
+  onDone: () => void
+  open: boolean
+  onOpenChange: (o: boolean) => void
+}) {
+  const { data: all = [], isError, refetch } = useQuery({ ...collectionsQuery(), enabled: open })
+  const [draft, setDraft] = useState("")
+  const [picked, setPicked] = useState<string[]>([])
+  // Brandprint-pointed collections take docs through /brandprint only — same exclusion
+  // the single-artifact dialog makes.
+  const brandprintIds = useBrandprintCollectionIds()
+  const pickable = all.filter((col) => !brandprintIds.has(col.id))
+
+  const apply = useApiMutation({
+    // One unit of work per ARTIFACT (its collection adds run together), so the summary
+    // counts artifacts moved, not requests made.
+    mutationFn: (ids: string[]) =>
+      bulkApply(items, (a) =>
+        Promise.all(ids.map((colId) => api.addToCollection(colId, a.short_id))),
+      ),
+    invalidate: [
+      listKey,
+      collectionsQuery().queryKey,
+      ...items.map((a) => artifactQuery(a.short_id).queryKey),
+    ],
+    success: (r) => summarize("Added", r),
+    onSuccess: onDone,
+  })
+
+  // Create and pick in one gesture — the artifacts land when you hit Add.
+  const createCol = useApiMutation({
+    mutationFn: (title: string) => api.createCollection(title),
+    invalidate: [collectionsQuery().queryKey],
+    onSuccess: (col) => setPicked((prev) => [...prev, col.id]),
+  })
+  const create = () => {
+    const t = draft.trim()
+    setDraft("")
+    if (t) createCol.mutate(t)
+  }
+
+  const busy = apply.isPending || createCol.isPending
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add to collection</DialogTitle>
+          <DialogDescription>
+            Collections group related artifacts; sharing a collection shares its artifacts with its
+            members.
+          </DialogDescription>
+        </DialogHeader>
+        {/* A failed load is NOT "no collections yet" — saying so would invite you to
+            create a duplicate of one you already have. */}
+        {isError && (
+          <StatusPanel
+            tone="danger"
+            title="Couldn’t load your collections"
+            description="This is usually temporary."
+            action={
+              <Button
+                variant="outline"
+                size="sm"
+                data-testid="bulk-collection-retry"
+                onClick={() => refetch()}
+              >
+                Try again
+              </Button>
+            }
+          />
+        )}
+        {!isError && pickable.length === 0 && (
+          <div className="text-sm text-muted-foreground">
+            No collections yet — create one below.
+          </div>
+        )}
+        {pickable.length > 0 && (
+          <div className="flex max-h-64 flex-col gap-px overflow-auto">
+            {pickable.map((col) => (
+              <button
+                key={col.id}
+                type="button"
+                data-testid={`bulk-collection-${col.id}`}
+                aria-pressed={picked.includes(col.id)}
+                onClick={() =>
+                  setPicked((prev) =>
+                    prev.includes(col.id) ? prev.filter((id) => id !== col.id) : [...prev, col.id],
+                  )
+                }
+                className={cn(
+                  // The menu-row recipe, shared with the single-artifact dialog.
+                  "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm font-medium text-foreground outline-none hover:bg-accent focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring",
+                  picked.includes(col.id) && "bg-accent",
+                )}
+              >
+                <span className="grid w-3.5 shrink-0 place-items-center">
+                  {picked.includes(col.id) && <Icon name="check" size={16} />}
+                </span>
+                <span className="flex-1 truncate">{col.title}</span>
+              </button>
+            ))}
+          </div>
+        )}
+        <div className="flex gap-1.5">
+          <Input
+            value={draft}
+            placeholder="New collection…"
+            data-testid="bulk-collection-new-input"
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") create()
+            }}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={create}
+            disabled={!draft.trim() || busy}
+            data-testid="bulk-collection-create"
+          >
+            Create
+          </Button>
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="bulk-collection-cancel"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            data-testid="bulk-collection-apply"
+            disabled={picked.length === 0 || busy}
+            onClick={() => apply.mutate(picked)}
+          >
+            {apply.isPending
+              ? "Adding…"
+              : `Add ${items.length} ${items.length === 1 ? "artifact" : "artifacts"}`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/pages/library/bulk-organize.tsx
+++ b/apps/web/src/pages/library/bulk-organize.tsx
@@ -19,7 +19,7 @@ import { artifactQuery, collectionsQuery, summaryQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { useBrandprintCollectionIds } from "@/lib/use-brandprint-ids"
 import { cn } from "@/lib/utils"
-import { bulkApply, summarize } from "./bulk-apply"
+import { summarize } from "./bulk-apply"
 
 // The two organize dialogs in their MANY-artifact form, opened from the selection bar.
 // They mirror the single-artifact dialogs in components/shared/organize-dialogs (same
@@ -46,7 +46,8 @@ export function BulkTagsDialog({
   open,
   onOpenChange,
 }: {
-  // Already narrowed to what the caller can tag (owner/editor).
+  // The full selection — the server authorizes each artifact and skips what the caller
+  // can't edit. `skipped` is the caller's own pre-action estimate for the preview line.
   items: Artifact[]
   skipped: number
   listKey: QueryKey
@@ -58,13 +59,14 @@ export function BulkTagsDialog({
   const [adding, setAdding] = useState<string[]>([])
 
   const apply = useApiMutation({
-    // setTags REPLACES an artifact's set, so the union is computed per artifact from the
-    // tags already on its card. The server then normalizes (lowercase, dedupe, cap 20).
+    // One call over the whole selection: the server ADDS the tags to each artifact's
+    // existing set (computing the union itself, so the client sends only the tags to add)
+    // and authorizes every artifact on its own — anything the caller can't edit comes back
+    // in `skipped`. Normalization (lowercase, dedupe, cap 20) is the server's too.
     mutationFn: (tags: string[]) =>
-      bulkApply(
-        items,
-        (a) => api.setTags(a.short_id, [...new Set([...(a.tags ?? []), ...tags])]),
-        skipped,
+      api.bulkTags(
+        items.map((a) => a.short_id),
+        tags,
       ),
     invalidate: [
       listKey,
@@ -177,11 +179,13 @@ export function BulkCollectionsDialog({
   const pickable = all.filter((col) => !brandprintIds.has(col.id))
 
   const apply = useApiMutation({
-    // One unit of work per ARTIFACT (its collection adds run together), so the summary
-    // counts artifacts moved, not requests made.
+    // One call: the server folds the whole selection into every picked collection,
+    // authorizing each artifact for "share" (adding to a shared collection re-shares it),
+    // so the summary counts artifacts added and reports the rest as skipped.
     mutationFn: (ids: string[]) =>
-      bulkApply(items, (a) =>
-        Promise.all(ids.map((colId) => api.addToCollection(colId, a.short_id))),
+      api.bulkAddToCollections(
+        items.map((a) => a.short_id),
+        ids,
       ),
     invalidate: [
       listKey,

--- a/apps/web/src/pages/library/folder-groups.tsx
+++ b/apps/web/src/pages/library/folder-groups.tsx
@@ -9,6 +9,7 @@ import { dirOf } from "@/lib/artifact"
 import { useFollows } from "@/lib/use-follows"
 import { cn } from "@/lib/utils"
 import { ArtifactRow } from "./artifact-row"
+import type { LibrarySelection } from "./use-library-selection"
 
 interface Handlers {
   onOpen: (a: Artifact) => void
@@ -19,6 +20,9 @@ interface Handlers {
   onAddToCollection: (a: Artifact) => void
   onDelete: (a: Artifact) => void
   onPrefetch: (a: Artifact) => void
+  // Multi-select, threaded to every row — a folder view is exactly where selecting a
+  // dozen docs at once earns its keep.
+  selection?: LibrarySelection
 }
 
 /**
@@ -151,6 +155,13 @@ function FolderSection({
               onAddToCollection={() => handlers.onAddToCollection(a)}
               onDelete={() => handlers.onDelete(a)}
               onPrefetch={() => handlers.onPrefetch(a)}
+              selected={handlers.selection?.selected.has(a.short_id)}
+              selectionActive={handlers.selection?.active}
+              onSelect={
+                handlers.selection
+                  ? (shift) => handlers.selection?.toggle(a.short_id, shift)
+                  : undefined
+              }
             />
           ))}
         </div>

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -41,10 +41,12 @@ import { LibrarySkeleton } from "./library-skeleton"
 import { PublishCard } from "./publish-card"
 import { LibraryCollectionsDialog, LibraryTagsDialog } from "./quick-organize"
 import { RepoPullRequests } from "./repo-pull-requests"
+import { SelectionBar } from "./selection-bar"
 import { ShareCollectionDialog } from "./share-collection-dialog"
 import { TriageBar } from "./triage-bar"
 import type { Filter, LibrarySearch, LibraryView } from "./types"
 import { useLibraryFeed } from "./use-library-feed"
+import { type LibrarySelection, useLibrarySelection } from "./use-library-selection"
 
 // The library surface, shared by five routes: "/" (your work), "/favorites",
 // "/following", "/shared", and "/feedback". The base feed comes from the route (the
@@ -144,6 +146,10 @@ function LibraryBody({ view }: { view: LibraryView }) {
   }
   const { query: feed, items, listQuery, toggleFavorite, deleteArtifact } = useLibraryFeed(params)
   const { isPending, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } = feed
+  // Multi-select, scoped to THIS feed: the params are the feed's identity, so changing
+  // the tab, filter, or search drops the selection rather than carrying ids off-screen
+  // into a bulk write.
+  const selection = useLibrarySelection(items, JSON.stringify(params))
   // keepPreviousData holds the OLD grid while a new filter/tab/search loads. With the cache
   // persisted to IndexedDB (lib/persist.ts), a switch to a view you've already seen resolves
   // from cache instantly — the previous grid is simply replaced with no flash, no ceremony.
@@ -524,6 +530,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
           onAddToCollection={setPendingCollections}
           onDelete={setPendingDelete}
           onPrefetch={(a) => prefetch(a.short_id, a.current_version)}
+          selection={selection}
         />
       ) : (
         <>
@@ -540,6 +547,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
             onAddToCollection={setPendingCollections}
             onDelete={setPendingDelete}
             onPrefetch={(a) => prefetch(a.short_id, a.current_version)}
+            selection={selection}
           />
           {isFetchingNextPage && (
             <div className="flex justify-center py-2" data-testid="library-loading-more">
@@ -547,6 +555,17 @@ function LibraryBody({ view }: { view: LibraryView }) {
             </div>
           )}
         </>
+      )}
+
+      {/* The bulk-action bar — the only surface multi-select adds. It rides at the end of
+          the page content (sticky), so it pins above the fold while you scroll and never
+          overlaps the rail. */}
+      {selection.selectedItems.length > 0 && (
+        <SelectionBar
+          items={selection.selectedItems}
+          listKey={listQuery.queryKey}
+          onClear={selection.clear}
+        />
       )}
 
       {shareCol && (
@@ -600,6 +619,7 @@ function SyncedCollection({
   onAddToCollection,
   onDelete,
   onPrefetch,
+  selection,
 }: {
   items: Artifact[]
   showFolders: boolean
@@ -615,6 +635,7 @@ function SyncedCollection({
   onAddToCollection: (a: Artifact) => void
   onDelete: (a: Artifact) => void
   onPrefetch: (a: Artifact) => void
+  selection?: LibrarySelection
 }) {
   return (
     <div className="flex flex-col gap-3">
@@ -650,6 +671,7 @@ function SyncedCollection({
           onAddToCollection={onAddToCollection}
           onDelete={onDelete}
           onPrefetch={onPrefetch}
+          selection={selection}
         />
       ) : (
         <div className="flex flex-col gap-2" data-testid="library-flat-list">
@@ -665,6 +687,9 @@ function SyncedCollection({
               onAddToCollection={() => onAddToCollection(a)}
               onDelete={() => onDelete(a)}
               onPrefetch={() => onPrefetch(a)}
+              selected={selection?.selected.has(a.short_id)}
+              selectionActive={selection?.active}
+              onSelect={selection ? (shift) => selection.toggle(a.short_id, shift) : undefined}
             />
           ))}
           {(hasNextPage || isFetchingNextPage) && (

--- a/apps/web/src/pages/library/selection-bar.tsx
+++ b/apps/web/src/pages/library/selection-bar.tsx
@@ -234,6 +234,10 @@ export function SelectionBar({
         }
         confirmLabel="Delete"
         confirmTestId="library-selection-delete-confirm"
+        // A bulk delete is the highest-stakes action the bar can take — many artifacts and
+        // their whole version history, at once, unrecoverable — so it asks you to type the
+        // word, not just click. (The card's own ⋯ menu keeps the one-click confirm.)
+        confirmPhrase="delete"
         onConfirm={async () => {
           await remove.mutateAsync()
         }}

--- a/apps/web/src/pages/library/selection-bar.tsx
+++ b/apps/web/src/pages/library/selection-bar.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button"
 import { collectionsQuery, summaryQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { cn } from "@/lib/utils"
-import { bulkApply, summarize } from "./bulk-apply"
+import { summarize } from "./bulk-apply"
 import { BulkCollectionsDialog, BulkTagsDialog } from "./bulk-organize"
 
 // One action in the bar. The label is the button's text on a roomy viewport and its
@@ -75,21 +75,25 @@ export function SelectionBar({
   const [showDelete, setShowDelete] = useState(false)
 
   const n = items.length
+  const shortIds = items.map((a) => a.short_id)
+  // Client-side role counts drive the button-enable + the pre-action preview text ONLY.
+  // The server is the source of truth for what actually happens: each bulk call sends the
+  // whole selection and reports back what it could and couldn't touch.
   const taggable = items.filter((a) => a.my_role === "owner" || a.my_role === "editor")
   const deletable = items.filter((a) => a.my_role === "owner")
   // All-starred → the star becomes the un-star (the card's own toggle, at scale).
   const allFavorite = n > 0 && items.every((a) => a.favorite)
 
   const favorite = useApiMutation({
-    mutationFn: (on: boolean) => bulkApply(items, (a) => api.favorite(a.short_id, on)),
+    mutationFn: (on: boolean) => api.bulkFavorite(shortIds, on),
     invalidate: [listKey, summaryQuery().queryKey],
     success: (r) => summarize(allFavorite ? "Unstarred" : "Starred", r),
     onSuccess: onClear,
   })
 
   const remove = useApiMutation({
-    mutationFn: () =>
-      bulkApply(deletable, (a) => api.deleteArtifact(a.short_id), n - deletable.length),
+    // Send the whole selection; the server deletes what the caller owns and skips the rest.
+    mutationFn: () => api.bulkDelete(shortIds),
     invalidate: [listKey, summaryQuery().queryKey, collectionsQuery().queryKey],
     success: (r) => summarize("Deleted", r),
     onSuccess: onClear,
@@ -193,8 +197,10 @@ export function SelectionBar({
       </div>
 
       {showTags && (
+        // The FULL selection goes to the dialog; the server tags what the caller can edit
+        // and reports the rest as skipped. `skipped` here is only the pre-action preview.
         <BulkTagsDialog
-          items={taggable}
+          items={items}
           skipped={n - taggable.length}
           listKey={listKey}
           open={showTags}

--- a/apps/web/src/pages/library/selection-bar.tsx
+++ b/apps/web/src/pages/library/selection-bar.tsx
@@ -1,0 +1,237 @@
+import type { QueryKey } from "@tanstack/react-query"
+import { type ReactNode, useState } from "react"
+import { type Artifact, api } from "@/api"
+import { Icon } from "@/components/icons"
+import { ConfirmDialog } from "@/components/shared/confirm-dialog"
+import { Button } from "@/components/ui/button"
+import { collectionsQuery, summaryQuery } from "@/lib/queries"
+import { useApiMutation } from "@/lib/use-api-mutation"
+import { cn } from "@/lib/utils"
+import { bulkApply, summarize } from "./bulk-apply"
+import { BulkCollectionsDialog, BulkTagsDialog } from "./bulk-organize"
+
+// One action in the bar. The label is the button's text on a roomy viewport and its
+// accessible name everywhere — below `sm` the text collapses and the icon carries it, so
+// four actions still fit a phone without a scroll or an overflow menu.
+function BarAction({
+  testId,
+  icon,
+  label,
+  title,
+  disabled,
+  onClick,
+  className,
+}: {
+  testId: string
+  icon: ReactNode
+  label: string
+  title: string
+  disabled: boolean
+  onClick: () => void
+  className?: string
+}) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      data-testid={testId}
+      aria-label={label}
+      title={title}
+      disabled={disabled}
+      onClick={onClick}
+      className={cn("shrink-0", className)}
+    >
+      {icon}
+      <span className="hidden sm:inline">{label}</span>
+    </Button>
+  )
+}
+
+// The bulk-action bar: it rises from the bottom of the library the moment a card is
+// checked, and it is the ONLY new surface multi-select introduces. Everything it can do,
+// a card's ⋯ menu can already do to one artifact — this just does it to the set, through
+// the very same endpoints.
+//
+// Every action states its own scope before it runs. A library selection mixes what you
+// own with what you can merely read, so each action narrows the set to the artifacts it
+// may legally touch (tags: owner/editor; delete: owner) and reports the rest as
+// "skipped" rather than failing the batch or, worse, half-silently dropping them.
+// Collections are the exception: adding is an act of curation on YOUR collection, so the
+// server decides per artifact and anything it refuses comes back as skipped too.
+export function SelectionBar({
+  items,
+  listKey,
+  onClear,
+}: {
+  // The selection, in feed order — already reconciled against the live feed, so every
+  // artifact here is one the user can still see.
+  items: Artifact[]
+  // The active feed's list query, so a bulk write reconciles the grid it just changed.
+  listKey: QueryKey
+  onClear: () => void
+}) {
+  const [showTags, setShowTags] = useState(false)
+  const [showCollections, setShowCollections] = useState(false)
+  const [showDelete, setShowDelete] = useState(false)
+
+  const n = items.length
+  const taggable = items.filter((a) => a.my_role === "owner" || a.my_role === "editor")
+  const deletable = items.filter((a) => a.my_role === "owner")
+  // All-starred → the star becomes the un-star (the card's own toggle, at scale).
+  const allFavorite = n > 0 && items.every((a) => a.favorite)
+
+  const favorite = useApiMutation({
+    mutationFn: (on: boolean) => bulkApply(items, (a) => api.favorite(a.short_id, on)),
+    invalidate: [listKey, summaryQuery().queryKey],
+    success: (r) => summarize(allFavorite ? "Unstarred" : "Starred", r),
+    onSuccess: onClear,
+  })
+
+  const remove = useApiMutation({
+    mutationFn: () =>
+      bulkApply(deletable, (a) => api.deleteArtifact(a.short_id), n - deletable.length),
+    invalidate: [listKey, summaryQuery().queryKey, collectionsQuery().queryKey],
+    success: (r) => summarize("Deleted", r),
+    onSuccess: onClear,
+  })
+
+  const busy = favorite.isPending || remove.isPending
+
+  return (
+    <>
+      {/* Sticky, not fixed: the bar centers on the CONTENT column with no rail-width
+          arithmetic, so it lands right on a phone (no rail) and on a desktop with the nav
+          open. The bottom offset clears the iOS home indicator — the same
+          safe-area floor the mobile comment composer uses. */}
+      <div className="pointer-events-none sticky bottom-[max(0.75rem,env(safe-area-inset-bottom))] z-30 mt-4 flex justify-center sm:bottom-6">
+        <div
+          data-testid="library-selection-bar"
+          // The floating-surface recipe (popover step + hairline ring), same as every
+          // other surface that lifts off the page. Labels collapse to icons below `sm`
+          // so all four actions + the count fit a 320px phone without wrapping or
+          // horizontal scroll; each keeps its aria-label, so the icon-only form stays
+          // announced.
+          className="pointer-events-auto flex max-w-[calc(100vw-1.5rem)] items-center gap-0.5 rounded-2xl bg-popover px-2 py-2 text-popover-foreground shadow-[var(--shadow-pop)] ring-1 ring-foreground/10 duration-200 ease-out animate-in fade-in-0 slide-in-from-bottom-2 sm:gap-1 sm:px-3"
+        >
+          <div className="flex items-center gap-2 border-r border-border-soft pr-2 pl-1 sm:pr-3">
+            <span
+              data-testid="library-selection-count"
+              className="grid size-6 shrink-0 place-items-center rounded-full bg-foreground font-mono text-2xs font-semibold text-background tabular-nums"
+            >
+              {n}
+            </span>
+            <span className="hidden text-sm font-medium whitespace-nowrap text-muted-foreground sm:inline">
+              selected
+            </span>
+          </div>
+
+          <BarAction
+            testId="library-selection-tags"
+            icon={<Icon name="tag" size={16} />}
+            label="Tags"
+            disabled={busy || taggable.length === 0}
+            title={
+              taggable.length === 0
+                ? "You can only tag artifacts you own or can edit"
+                : "Add tags to the selected artifacts"
+            }
+            onClick={() => setShowTags(true)}
+          />
+
+          <BarAction
+            testId="library-selection-collections"
+            icon={<Icon name="collections" size={16} />}
+            label="Add to collection"
+            disabled={busy}
+            title="Add the selected artifacts to a collection"
+            onClick={() => setShowCollections(true)}
+          />
+
+          <BarAction
+            testId="library-selection-favorite"
+            icon={
+              <Icon
+                name="star"
+                size={16}
+                weight={allFavorite ? "fill" : "regular"}
+                className={allFavorite ? "text-primary" : undefined}
+              />
+            }
+            label={allFavorite ? "Unstar" : "Star"}
+            disabled={busy}
+            title={allFavorite ? "Remove the star from all" : "Star the selected artifacts"}
+            onClick={() => favorite.mutate(!allFavorite)}
+          />
+
+          <BarAction
+            testId="library-selection-delete"
+            icon={<Icon name="delete" size={16} />}
+            label="Delete"
+            disabled={busy || deletable.length === 0}
+            title={
+              deletable.length === 0
+                ? "You can only delete artifacts you own"
+                : "Delete the selected artifacts"
+            }
+            onClick={() => setShowDelete(true)}
+            className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+          />
+
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            data-testid="library-selection-clear"
+            aria-label="Clear selection"
+            title="Clear selection (Esc)"
+            disabled={busy}
+            onClick={onClear}
+            className="ml-0.5 shrink-0"
+          >
+            <Icon name="close" size={16} />
+          </Button>
+        </div>
+      </div>
+
+      {showTags && (
+        <BulkTagsDialog
+          items={taggable}
+          skipped={n - taggable.length}
+          listKey={listKey}
+          open={showTags}
+          onOpenChange={setShowTags}
+          onDone={() => {
+            setShowTags(false)
+            onClear()
+          }}
+        />
+      )}
+      {showCollections && (
+        <BulkCollectionsDialog
+          items={items}
+          listKey={listKey}
+          open={showCollections}
+          onOpenChange={setShowCollections}
+          onDone={() => {
+            setShowCollections(false)
+            onClear()
+          }}
+        />
+      )}
+      <ConfirmDialog
+        open={showDelete}
+        onOpenChange={setShowDelete}
+        title={`Delete ${deletable.length} ${deletable.length === 1 ? "artifact" : "artifacts"}?`}
+        description={
+          deletable.length < n
+            ? `This permanently deletes them and their versions. ${n - deletable.length} you don’t own will be skipped. This cannot be undone.`
+            : "This permanently deletes them and their versions. This cannot be undone."
+        }
+        confirmLabel="Delete"
+        confirmTestId="library-selection-delete-confirm"
+        onConfirm={async () => {
+          await remove.mutateAsync()
+        }}
+      />
+    </>
+  )
+}

--- a/apps/web/src/pages/library/use-library-selection.ts
+++ b/apps/web/src/pages/library/use-library-selection.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { Artifact } from "@/api"
+
+// Multi-select for the library. The set holds short_ids — the identity every library
+// surface already keys on (cards, rows, caches) — and the anchor drives shift-click
+// range selection against the CURRENT feed order, so "everything between these two"
+// means what you can see, not what the server happened to return.
+//
+// A selection belongs to ONE feed: switch the tab, filter, or search and it clears.
+// Carrying ids across a filter change would leave the bar counting artifacts that are
+// no longer on screen, and a bulk write is the last place to be vague about its scope.
+export function useLibrarySelection(items: Artifact[], feedKey: string) {
+  const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set())
+  // The last card clicked WITHOUT shift — the fixed end of a shift-click range.
+  const anchor = useRef<string | null>(null)
+
+  const clear = useCallback(() => {
+    anchor.current = null
+    setSelected((prev) => (prev.size === 0 ? prev : new Set()))
+  }, [])
+
+  // Reset DURING render, not in an effect ("You Might Not Need an Effect" → adjusting
+  // state when a prop changes). An effect would paint one frame of the old selection
+  // over the new feed — the bar briefly claiming artifacts that aren't on screen — and
+  // that frame is exactly the confusion this reset exists to prevent.
+  const [feedAtSelection, setFeedAtSelection] = useState(feedKey)
+  if (feedKey !== feedAtSelection) {
+    setFeedAtSelection(feedKey)
+    anchor.current = null
+    if (selected.size > 0) setSelected(new Set())
+  }
+
+  // Escape is the universal "never mind" — the keyboard twin of the bar's ×. Bound
+  // only while a selection exists, so it can't shadow a dialog's own Escape at rest.
+  useEffect(() => {
+    if (selected.size === 0) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") clear()
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [selected.size, clear])
+
+  const toggle = useCallback(
+    (shortId: string, shift = false) => {
+      setSelected((prev) => {
+        const next = new Set(prev)
+        const from = anchor.current
+        // Shift extends from the anchor through this card (inclusive), additive — the
+        // grid/list order IS the range, so a range never picks up an off-screen id.
+        if (shift && from && from !== shortId) {
+          const order = items.map((a) => a.short_id)
+          const i = order.indexOf(from)
+          const j = order.indexOf(shortId)
+          if (i !== -1 && j !== -1) {
+            for (const id of order.slice(Math.min(i, j), Math.max(i, j) + 1)) next.add(id)
+            anchor.current = shortId
+            return next
+          }
+        }
+        if (next.has(shortId)) next.delete(shortId)
+        else next.add(shortId)
+        anchor.current = shortId
+        return next
+      })
+    },
+    [items],
+  )
+
+  // The selection as ARTIFACTS, in feed order. Deriving from `items` (rather than
+  // stashing the objects at click time) is what keeps a bulk write honest: an id whose
+  // card has since left the feed — deleted, filtered out by a refetch — simply drops
+  // out here, so the bar can never act on a row that isn't there any more.
+  const selectedItems = useMemo(
+    () => items.filter((a) => selected.has(a.short_id)),
+    [items, selected],
+  )
+
+  return { selected, selectedItems, active: selected.size > 0, toggle, clear }
+}
+
+// What a card/row needs to render its checkbox, threaded through the grid + list views.
+export interface LibrarySelection {
+  selected: ReadonlySet<string>
+  // Any selection in progress — every checkbox shows, not just the hovered card's.
+  active: boolean
+  toggle: (shortId: string, shift?: boolean) => void
+}


### PR DESCRIPTION
Two threads of the same "make the library findable and actionable" story: a **multi-select bar** in the web library, and **tags + collections exposed to the agentic layer** (MCP + CLI) so agents can discover, suggest, and apply tags.

## Walkthrough (multi-select UI, screenshots + tests)

📄 **https://derive.to/artifacts/library-multi-select-build-test-walkthrough-vcpkfkp9**

---

## 1 · Library multi-select bar

Check any set of artifacts and a floating bar rises — **Tags · Add to collection · Star · Delete**. Writes go through four `/v1/bulk/*` routes that authorize **per artifact** (a shared `bulkArtifactOp` helper) and report `{ok, skipped, failed}`, so a mixed selection lands what it can. Tags **merge**; bulk delete is guarded by **type-to-confirm** ("delete"). Mobile: checkboxes pin on touch, the bar collapses to icons for a 375px viewport, safe-area aware. Selection is re-derived from the live feed each render and clears on feed change. Shift-click ranges; Escape clears.

## 2 · Tags + collections for the agentic layer

Neither MCP server nor the CLI could see tags before. Now:

**New tools (local stdio `derive` + remote `/mcp`):**
- `list_tags` — the workspace tag vocabulary (tag → count). **Discover**, so agents reuse tags instead of fragmenting them.
- `suggest_tags` — an artifact's current tags + tags from its **semantically-similar neighbors** (queries the dense/embedding arm) + the vocabulary. **Suggest**.
- `tag` — add / remove / replace tags on one or many artifacts. **Apply**; per-artifact authorized, skips what it can't edit.
- `list_collections` / `collect` — see + route into collections (create-by-name). **Light**, by design.

**Extended:** `list_artifacts` gains a `tag` filter and returns each artifact's tags; `publish` gains a `tags` param (**auto-tag on create**).

**CLI:** `derive tags`, `derive tag <tag…> [--rm] [--set]`, `derive suggest-tags`, `derive publish --tags a,b`.

Agents are nudged to tag-as-you-go via the MCP server instructions + `SKILL.md` (reuse the vocabulary, be generous; collections for real units). **Tools + guidance, not a server-side LLM** — the agent decides.

**Server internals:**
- `lib/tags.ts` — one shared `normalizeTags` (trim/lowercase/dedupe/cap) across the single route, bulk route, publish, and MCP tools, so the vocabulary can't fragment.
- `lib/tag-suggestions.ts` — `computeTagSuggestions`, shared by `GET /v1/artifacts/{shortId}/tag-suggestions` and `suggest_tags`; embeds the doc's own text to find neighbors, re-applies visibility, falls back to vocabulary-only with no embedder.

## Verification

- `pnpm typecheck` ✓ · `pnpm run ci` (biome + 16 guardrails, incl. `check-api-types`, `authz-coverage`) ✓ · `pnpm test` — **full suite green (api 1076, mcp 27, web 156)**.
- API tests: bulk routes (9), tags — publish normalize/merge/clear, `?tag=` filter, vocabulary, suggestions fallback (5). MCP smoke: publish-tags → list_tags → tag → filter → suggest_tags, and collect-by-name.
- 10 Playwright cases (multi-select, desktop + mobile), delete gated on type-to-confirm.

Merge left to Anir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)