### PR TITLE
feat(agent): one `organize` tool for tags + collections (findability)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1212,6 +1212,61 @@
           "inviter"
         ]
       },
+      "TagSuggestions": {
+        "type": "object",
+        "properties": {
+          "current": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Tags already on the artifact."
+          },
+          "suggested": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tag": {
+                  "type": "string"
+                },
+                "count": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "tag",
+                "count"
+              ]
+            },
+            "description": "Tags from similar artifacts, most-shared first; excludes current tags."
+          },
+          "vocabulary": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tag": {
+                  "type": "string"
+                },
+                "count": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "tag",
+                "count"
+              ]
+            },
+            "description": "Every tag in the workspace with its usage count, most-used first."
+          }
+        },
+        "required": [
+          "current",
+          "suggested",
+          "vocabulary"
+        ]
+      },
       "Follow": {
         "type": "object",
         "properties": {
@@ -4785,6 +4840,36 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/BulkSummary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/artifacts/{shortId}/tag-suggestions": {
+      "get": {
+        "tags": [
+          "Favorites"
+        ],
+        "summary": "Suggest browse tags from similar artifacts + the workspace vocabulary.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "shortId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current tags, suggestions from similar artifacts, and the vocabulary.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagSuggestions"
                 }
               }
             }

--- a/apps/api/src/lib/tag-suggestions.ts
+++ b/apps/api/src/lib/tag-suggestions.ts
@@ -1,7 +1,7 @@
 import type { ArtifactRecord, MetaStore, SearchIndex, VersionRecord } from "@derive/core"
 
 // Tag suggestions for an artifact — the discover half of "auto-tag", shared by the HTTP
-// route (GET /v1/artifacts/{shortId}/tag-suggestions) and the MCP `suggest_tags` tool so
+// route (GET /v1/artifacts/{shortId}/tag-suggestions) and the MCP `organize` tool so
 // the two never drift. It answers "what should this be tagged?" the way a librarian would:
 // look at what similar things are already tagged, and reuse that vocabulary.
 

--- a/apps/api/src/lib/tag-suggestions.ts
+++ b/apps/api/src/lib/tag-suggestions.ts
@@ -1,0 +1,94 @@
+import type { ArtifactRecord, MetaStore, SearchIndex, VersionRecord } from "@derive/core"
+
+// Tag suggestions for an artifact — the discover half of "auto-tag", shared by the HTTP
+// route (GET /v1/artifacts/{shortId}/tag-suggestions) and the MCP `suggest_tags` tool so
+// the two never drift. It answers "what should this be tagged?" the way a librarian would:
+// look at what similar things are already tagged, and reuse that vocabulary.
+
+export interface TagSuggestions {
+  /** Tags already on the artifact. */
+  current: string[]
+  /** Tags carried by the most semantically-similar artifacts, most-shared first, with the
+   *  artifact's current tags removed. Empty when no dense arm is configured. */
+  suggested: { tag: string; count: number }[]
+  /** Every tag in the workspace with its usage count, most-used first (capped). Lets a
+   *  caller reuse an existing tag instead of minting a near-duplicate. */
+  vocabulary: { tag: string; count: number }[]
+}
+
+// How many neighbors to pull, how many suggestions/vocabulary entries to return, and how
+// much of the doc to embed as the neighbor query.
+const NEIGHBORS = 20
+const MAX_SUGGESTED = 12
+const MAX_VOCAB = 100
+const QUERY_CHARS = 4000
+
+type SuggestDeps = {
+  meta: Pick<MetaStore, "tagCounts" | "tagsForArtifacts" | "getVersion" | "listArtifacts">
+  /** The optional dense/semantic arm; absent ⇒ vocabulary-only suggestions. */
+  search?: SearchIndex
+  sourceText: (content: { blob_key: string; content_type: string }) => Promise<string | null>
+}
+
+export async function computeTagSuggestions(
+  deps: SuggestDeps,
+  artifact: ArtifactRecord,
+  viewerId: string | undefined,
+): Promise<TagSuggestions> {
+  const { meta, search, sourceText } = deps
+  const org = artifact.org_id
+  const [vocab, currentMap] = await Promise.all([
+    meta.tagCounts(org),
+    meta.tagsForArtifacts([artifact.id]),
+  ])
+  const current = currentMap[artifact.id] ?? []
+  const currentSet = new Set(current)
+
+  let suggested: { tag: string; count: number }[] = []
+  // The dense store already holds this artifact, so querying it with the doc's own title +
+  // text returns its nearest neighbors. Best-effort: a slow/absent embedder must never
+  // fail the call — it just yields no neighbor suggestions.
+  if (search) {
+    try {
+      const ver: VersionRecord | null = await meta.getVersion(artifact.id, artifact.current_version)
+      const body = ver ? ((await sourceText(ver)) ?? "") : ""
+      const query = `${artifact.title ?? ""}\n${body}`.slice(0, QUERY_CHARS).trim()
+      if (query) {
+        const hits = await search.search(org, query, NEIGHBORS)
+        const neighborIds = hits.map((h) => h.id).filter((id) => id !== artifact.id)
+        if (neighborIds.length) {
+          // search.search applies NO visibility filter (per SearchIndex), so re-apply it
+          // through listArtifacts({ ids, viewerId }) before reading anyone's tags.
+          const visible = await meta.listArtifacts({
+            orgId: org,
+            viewerId,
+            ids: neighborIds,
+            excludeRemoved: true,
+          })
+          const tagMap = await meta.tagsForArtifacts(visible.map((a) => a.id))
+          const counts = new Map<string, number>()
+          for (const a of visible) {
+            for (const t of tagMap[a.id] ?? []) {
+              if (currentSet.has(t) || t.startsWith("sift-")) continue
+              counts.set(t, (counts.get(t) ?? 0) + 1)
+            }
+          }
+          suggested = [...counts.entries()]
+            .map(([tag, count]) => ({ tag, count }))
+            .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
+            .slice(0, MAX_SUGGESTED)
+        }
+      }
+    } catch {
+      // Dense-arm hiccup — vocabulary-only is still a useful answer.
+    }
+  }
+
+  return {
+    current,
+    suggested,
+    vocabulary: vocab
+      .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
+      .slice(0, MAX_VOCAB),
+  }
+}

--- a/apps/api/src/lib/tags.ts
+++ b/apps/api/src/lib/tags.ts
@@ -1,0 +1,45 @@
+// Browse tags are workspace-wide labels for finding artifacts later. One normalizer,
+// shared by every write path (the single tag route, the bulk route, publish, and the MCP
+// tools), so the stored vocabulary can never fragment on casing or whitespace: a tag typed
+// "Q3 Planning", "q3 planning", and " Q3  Planning " must all land as the same "q3
+// planning". Trimmed, lowercased, inner whitespace collapsed, deduped, capped per artifact,
+// and sorted so every read returns them in one order.
+export const MAX_TAGS_PER_ARTIFACT = 20
+const MAX_TAG_LEN = 40
+
+export function normalizeTags(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return []
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const t of raw) {
+    if (typeof t !== "string") continue
+    const v = t.trim().toLowerCase().replace(/\s+/g, " ").slice(0, MAX_TAG_LEN)
+    if (!v || seen.has(v)) continue
+    seen.add(v)
+    out.push(v)
+    if (out.length >= MAX_TAGS_PER_ARTIFACT) break
+  }
+  // Sorted so the PUT response matches the list/detail order (tagsForArtifacts also
+  // sorts), and browse chips read alphabetically everywhere.
+  return out.sort()
+}
+
+// Parse a `tags` field off a multipart/form body (the publish path): either a JSON array
+// string (["a","b"]) or a comma/space-separated list ("a, b c"). Returns raw strings for
+// normalizeTags to finish. Undefined field → null (leave tags untouched), an EMPTY string
+// → [] (an explicit "clear the tags"), so a caller can distinguish "don't touch" from
+// "remove all".
+export function parseTagsField(field: unknown): string[] | null {
+  if (typeof field !== "string") return null
+  const s = field.trim()
+  if (s === "") return []
+  if (s.startsWith("[")) {
+    try {
+      const arr = JSON.parse(s)
+      return Array.isArray(arr) ? arr.map(String) : []
+    } catch {
+      // fall through to the delimiter split — a malformed JSON array is treated as text
+    }
+  }
+  return s.split(/[,\n]/).flatMap((part) => part.trim().split(/\s+/))
+}

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -106,6 +106,8 @@ import {
   workspaceSearchReport,
 } from "./lib/search"
 import { enqueueSlackReviewRequestedDm } from "./lib/slack-dm"
+import { computeTagSuggestions } from "./lib/tag-suggestions"
+import { normalizeTags } from "./lib/tags"
 import { signUploadToken, UPLOAD_TOKEN_TTL_MS } from "./lib/upload-token"
 import { enqueueChannelDelivery } from "./webhooks"
 
@@ -373,11 +375,16 @@ async function buildServer(
         `This one login reaches the workspaces in your grant — call list_workspaces to see them, ` +
         `then pass a workspace id or name as the "workspace" argument to act in another one (read, ` +
         `catch_up, comment, publish, list_artifacts). read/catch_up/comment also find a short_id in ` +
-        `any of them automatically, so you never need to switch just to open a doc.` +
-        ` Workspaces can also host contexts — askable live data agents. list_contexts shows the ` +
+        `any of them automatically, so you never need to switch just to open a doc. ` +
+        `Workspaces can also host contexts — askable live data agents. list_contexts shows the ` +
         `ones your user may ask (and whether each runner is online); ask opens a question session ` +
         `on your user's behalf and returns the answer, or a session id to resume when the runner ` +
-        `needs longer.` +
+        `needs longer. ` +
+        `Keep the library findable: browse tags are how work is discovered later, so tag as you ` +
+        `go — set \`tags\` when you publish, or run suggest_tags on an artifact and apply them with ` +
+        `tag. Reuse the existing vocabulary (list_tags) over near-duplicates; tagging is cheap, so ` +
+        `be generous. Collections group work that genuinely belongs together (list_collections / ` +
+        `collect) — reach for a tag first, a collection when a set is a real unit.` +
         brandprintInstructions(bpSources.length, bpProfile) +
         pendingRequestsPointer(pendingRequests.length),
     },
@@ -705,9 +712,13 @@ async function buildServer(
     "list_artifacts",
     {
       description:
-        "List the artifacts (docs, plans, sites, skills) in a workspace — short id, title, kind, is_skill, current version, access (workspace_access/link_role/listed). Defaults to your current workspace; pass `workspace` (id or name from list_workspaces) to list another one. Pass skills:true to list only skills (reusable agent procedure). Includes your own unlisted publishes — out of the shared library, but you always find your work. Start here to find what to work on, then catch_up or read it.",
+        "List the artifacts (docs, plans, sites, skills) in a workspace — short id, title, kind, is_skill, current version, access, and its browse `tags`. Defaults to your current workspace; pass `workspace` (id or name from list_workspaces) to list another one. Pass `tag` to list only artifacts carrying that tag (findability — list_tags shows the vocabulary). Pass skills:true to list only skills (reusable agent procedure). Includes your own unlisted publishes — out of the shared library, but you always find your work. Start here to find what to work on, then catch_up or read it.",
       inputSchema: {
         query: z.string().optional().describe("Optional title search filter."),
+        tag: z
+          .string()
+          .optional()
+          .describe("Only artifacts carrying this browse tag (case-insensitive)."),
         skills: z
           .boolean()
           .optional()
@@ -715,21 +726,31 @@ async function buildServer(
         workspace: wsArg,
       },
     },
-    async ({ query, skills, workspace }) => {
+    async ({ query, tag, skills, workspace }) => {
       const t = await resolveWs(workspace)
       if ("error" in t) return err(t.error)
+      // A tag filter resolves to an id set first (mirrors the HTTP ?tag= path), which
+      // listArtifacts then scopes to the workspace + re-applies visibility over.
+      const ids = tag ? await ctx.meta.artifactIdsByTag(tag.trim().toLowerCase()) : undefined
+      if (ids && ids.length === 0) return json({ workspace: t.org, count: 0, artifacts: [] })
       // viewerId keeps private rows scoped to the agent's human (mirrors `reach`) —
       // the owner row written at publish is what lets the agent always find its
       // own drafts while a teammate's private work stays invisible.
       const arts = await ctx.meta.listArtifacts({
         orgId: t.org,
         q: query,
+        ids,
         viewerId: actingFor?.id ?? agent.id,
       })
       // Skill-ness isn't a store-level filter (it's the denormalized content type), so
       // narrow here — a title `query` still composes with it.
       const rows = skills ? arts.filter((a) => a.current_content_type === SKILL_CONTENT_TYPE) : arts
-      return json({ workspace: t.org, count: rows.length, artifacts: rows.map(summarizeArtifact) })
+      const tagMap = await ctx.meta.tagsForArtifacts(rows.map((a) => a.id))
+      return json({
+        workspace: t.org,
+        count: rows.length,
+        artifacts: rows.map((a) => ({ ...summarizeArtifact(a), tags: tagMap[a.id] ?? [] })),
+      })
     },
   )
 
@@ -1296,6 +1317,199 @@ async function buildServer(
     },
   )
 
+  // TAGS — discover the vocabulary, suggest from similar docs, apply ------------
+  server.registerTool(
+    "list_tags",
+    {
+      description:
+        'The workspace\'s browse-tag vocabulary — every tag with how many artifacts carry it, most-used first. Call this BEFORE tagging so you reuse an existing tag instead of minting a near-duplicate ("planning" vs "plan"); it\'s how the library stays findable. Then list_artifacts(tag:…) to see what\'s under a tag.',
+      inputSchema: { workspace: wsArg },
+    },
+    async ({ workspace }) => {
+      const t = await resolveWs(workspace)
+      if ("error" in t) return err(t.error)
+      const tags = (await ctx.meta.tagCounts(t.org)).sort(
+        (a, b) => b.count - a.count || a.tag.localeCompare(b.tag),
+      )
+      return json({ workspace: t.org, count: tags.length, tags })
+    },
+  )
+
+  server.registerTool(
+    "suggest_tags",
+    {
+      description:
+        "Suggest browse tags for an artifact. Returns its current tags, `suggested` tags drawn from the most semantically-similar artifacts in the workspace (so you reuse how similar things are already tagged), and the full `vocabulary`. Read this, pick the ones that fit — reuse a suggestion or vocabulary entry over a new coinage — then apply them with `tag` (or set them on `publish`). Be generous: tagging is cheap and makes the library findable.",
+      inputSchema: {
+        short_id: z.string().describe("The artifact to suggest tags for."),
+        workspace: wsArg,
+      },
+    },
+    async ({ short_id, workspace }) => {
+      const reached = await reach(short_id, workspace)
+      if (!reached) return notFound(short_id)
+      if ("error" in reached) return err(reached.error)
+      const suggestions = await computeTagSuggestions(
+        { meta: ctx.meta, search: ctx.search, sourceText: ctx.sourceText },
+        reached.a,
+        actingFor?.id ?? agent.id,
+      )
+      return json({ short_id, ...suggestions })
+    },
+  )
+
+  server.registerTool(
+    "tag",
+    {
+      description:
+        "Add, remove, or replace an artifact's browse tags — one artifact or many at once. Pass `add` and/or `remove` to adjust the set (add is the default gesture — it never drops the tags a doc already has), or `set` to replace it wholesale. Tags are normalized (trimmed, lowercased, deduped, capped 20). Each artifact is authorized on its own; ones you can't edit come back in `skipped`, so a mixed list still tags what it can. Tag freely — reuse the vocabulary (list_tags / suggest_tags) so the library stays findable.",
+      inputSchema: {
+        short_ids: z.array(z.string()).min(1).describe("One or more artifact short ids to tag."),
+        add: z.array(z.string()).optional().describe("Tags to add (union with the existing set)."),
+        remove: z.array(z.string()).optional().describe("Tags to remove."),
+        set: z
+          .array(z.string())
+          .optional()
+          .describe("Replace the WHOLE set with exactly these (overrides add/remove)."),
+        workspace: wsArg,
+      },
+    },
+    async ({ short_ids, add, remove, set, workspace }) => {
+      if (!add && !remove && !set) return err("Pass at least one of `add`, `remove`, or `set`.")
+      const removeSet = new Set(normalizeTags(remove ?? []))
+      let updated = 0
+      let skipped = 0
+      let failed = 0
+      const results: { short_id: string; tags: string[] }[] = []
+      // Per-artifact, sequential: the set is human-sized (a selection), and each write
+      // reads-then-sets, which mustn't interleave on the same artifact.
+      for (const shortId of [...new Set(short_ids)]) {
+        const reached = await reach(shortId, workspace)
+        // Not found or not editable → skipped, never fails the batch.
+        if (!reached || "error" in reached || !roleAllows(reached.role, "publish")) {
+          skipped++
+          continue
+        }
+        try {
+          const next = set
+            ? normalizeTags(set)
+            : normalizeTags([
+                ...((await ctx.meta.tagsForArtifacts([reached.a.id]))[reached.a.id] ?? []),
+                ...(add ?? []),
+              ]).filter((t) => !removeSet.has(t))
+          await ctx.meta.setArtifactTags(reached.a.id, next)
+          updated++
+          results.push({ short_id: shortId, tags: next })
+        } catch {
+          failed++
+        }
+      }
+      return json({ updated, skipped, failed, results })
+    },
+  )
+
+  // COLLECTIONS (light) — see and route into them -------------------------------
+  server.registerTool(
+    "list_collections",
+    {
+      description:
+        "The workspace's collections — shareable groups of artifacts — with each one's item count. Read-only overview so you can route work into an existing collection with `collect` instead of scattering it. Lists the team-visible collections (invite-only ones you don't belong to stay hidden).",
+      inputSchema: { workspace: wsArg },
+    },
+    async ({ workspace }) => {
+      const t = await resolveWs(workspace)
+      if ("error" in t) return err(t.error)
+      const actorId = actingFor?.id ?? agent.id
+      const cols = await ctx.meta.listCollections(t.org)
+      // Light visibility: team-visible collections, plus any the acting user created (their
+      // own invite-only ones). Mirrors the web rail without the full per-collection role
+      // resolve — enough for an agent to pick a routing target.
+      const visible = cols
+        .filter((col) => col.workspace_access === "member" || col.created_by === actorId)
+        .map((col) => ({ id: col.id, title: col.title, count: col.count }))
+      return json({ workspace: t.org, count: visible.length, collections: visible })
+    },
+  )
+
+  server.registerTool(
+    "collect",
+    {
+      description:
+        "Add one or more artifacts to a collection — by `collection_id` (from list_collections) or by `collection` name, creating that collection if no team-visible one matches. Adding to a SHARED collection re-shares the artifacts to its members, so each artifact is authorized for sharing; ones you can't share come back in `skipped`. Collections are heavier than tags — reach for a tag first for plain findability, a collection when a set genuinely belongs together.",
+      inputSchema: {
+        short_ids: z.array(z.string()).min(1).describe("Artifact short ids to add."),
+        collection_id: z.string().optional().describe("An existing collection's id."),
+        collection: z
+          .string()
+          .optional()
+          .describe("A collection name — matched against team-visible collections, else created."),
+        workspace: wsArg,
+      },
+    },
+    async ({ short_ids, collection_id, collection, workspace }) => {
+      if (!collection_id && !collection?.trim())
+        return err("Pass a `collection_id` or a `collection` name.")
+      const t = await resolveWs(workspace)
+      if ("error" in t) return err(t.error)
+      const actorId = actingFor?.id ?? agent.id
+      // Resolve the target collection: by id, then by name, else create it.
+      let col = collection_id ? await ctx.meta.getCollection(collection_id) : null
+      if (col && col.org_id !== t.org) return err("That collection is in another workspace.")
+      if (!col && collection?.trim()) {
+        const name = collection.trim()
+        const existing = (await ctx.meta.listCollections(t.org)).find(
+          (x) =>
+            x.title.toLowerCase() === name.toLowerCase() &&
+            (x.workspace_access === "member" || x.created_by === actorId),
+        )
+        col =
+          existing ??
+          (await (async () => {
+            const created = await ctx.meta.createCollection({
+              id: newId("col"),
+              org_id: t.org,
+              title: name.slice(0, 120),
+              created_by: actorId,
+              workspace_access: "member",
+            })
+            await ctx.meta.setCollectionMember({
+              id: newId("cm"),
+              collection_id: created.id,
+              user_id: actorId,
+              role: "owner",
+            })
+            return created
+          })())
+      }
+      if (!col) return err("Collection not found.")
+      // The caller must be able to MANAGE the collection to fold artifacts in: a
+      // team-visible one at their workspace seat, an invite-only one via an explicit
+      // member row. Mirrors the HTTP route's canManageCollection.
+      const canManage =
+        col.workspace_access === "member"
+          ? roleAllows(t.role, "publish")
+          : roleAllows(
+              (await ctx.meta.getCollectionMember(col.id, actorId))?.role ?? "viewer",
+              "publish",
+            )
+      if (!canManage) return err("You can't add to that collection.")
+
+      let added = 0
+      let skipped = 0
+      for (const shortId of [...new Set(short_ids)]) {
+        const reached = await reach(shortId, workspace)
+        // Adding to a shared collection re-shares the artifact, so it needs share standing.
+        if (!reached || "error" in reached || !roleAllows(reached.role, "share")) {
+          skipped++
+          continue
+        }
+        await ctx.meta.addCollectionItem(col.id, reached.a.id)
+        added++
+      }
+      return json({ collection: { id: col.id, title: col.title }, added, skipped })
+    },
+  )
+
   // CATCH UP — state, feedback, history, and diffs all in one ------------------
   server.registerTool(
     "catch_up",
@@ -1797,6 +2011,12 @@ async function buildServer(
             "Add/overwrite the given `files` INTO the existing bundle instead of replacing it (default false). Build a large site across several calls without re-sending it: publish the pages first, then merge in batches of assets — each call carries only the new files. Requires `short_id` of a bundle; same-path files overwrite, the rest are kept.",
           ),
         message: z.string().optional().describe("What changed — recorded as the version message."),
+        tags: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Browse tags to set on the artifact — workspace-wide labels that make it findable (list_tags shows the vocabulary; suggest_tags proposes from similar docs). Reuse an existing tag over a near-duplicate. Given ⇒ REPLACES the set (normalized: trimmed, lowercased, deduped, capped 20); [] clears; omitted leaves existing tags untouched on a republish.",
+          ),
         filename: z
           .string()
           .optional()
@@ -1862,6 +2082,7 @@ async function buildServer(
       spa,
       merge,
       message,
+      tags,
       filename,
       for_review,
       addresses,
@@ -2105,6 +2326,10 @@ async function buildServer(
           version,
           { isNew: !short_id, onBehalf: actingFor?.id ?? null, resolves: addresses ?? [] },
         )
+        // Tag at publish time — the one-step "auto-tag on create". `tags` given ⇒ set them
+        // (normalized, deduped, capped); an empty array clears; omitted leaves them be, so
+        // a republish that doesn't mention tags keeps the artifact's existing set.
+        if (tags !== undefined) await ctx.meta.setArtifactTags(artifact.id, normalizeTags(tags))
         // The /derive loop: ask the human to review this live version.
         let review_round: string | null = null
         if (request_review && actingFor) {

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -381,10 +381,10 @@ async function buildServer(
         `on your user's behalf and returns the answer, or a session id to resume when the runner ` +
         `needs longer. ` +
         `Keep the library findable: browse tags are how work is discovered later, so tag as you ` +
-        `go — set \`tags\` when you publish, or run suggest_tags on an artifact and apply them with ` +
-        `tag. Reuse the existing vocabulary (list_tags) over near-duplicates; tagging is cheap, so ` +
-        `be generous. Collections group work that genuinely belongs together (list_collections / ` +
-        `collect) — reach for a tag first, a collection when a set is a real unit.` +
+        `go — set \`tags\` when you publish, or use the one \`organize\` tool: call it on an ` +
+        `artifact to see its tags + suggestions, then again with \`add\` to apply (or \`collection\` ` +
+        `to group). Call organize with no arguments for the workspace's tag vocabulary — reuse an ` +
+        `existing tag over a near-duplicate; tagging is cheap, so be generous.` +
         brandprintInstructions(bpSources.length, bpProfile) +
         pendingRequestsPointer(pendingRequests.length),
     },
@@ -1317,196 +1317,184 @@ async function buildServer(
     },
   )
 
-  // TAGS — discover the vocabulary, suggest from similar docs, apply ------------
+  // ORGANIZE — ONE tool for the library's findability metadata: tags + collections,
+  // read + write. No short_ids ⇒ the workspace overview (vocabulary + collections).
+  // short_ids alone ⇒ inspect them (current tags/collections + tag suggestions). Any of
+  // add/remove/set/collection ⇒ write. Replaces the old list_tags/suggest_tags/tag/
+  // list_collections/collect point-tools.
   server.registerTool(
-    "list_tags",
+    "organize",
     {
       description:
-        'The workspace\'s browse-tag vocabulary — every tag with how many artifacts carry it, most-used first. Call this BEFORE tagging so you reuse an existing tag instead of minting a near-duplicate ("planning" vs "plan"); it\'s how the library stays findable. Then list_artifacts(tag:…) to see what\'s under a tag.',
-      inputSchema: { workspace: wsArg },
-    },
-    async ({ workspace }) => {
-      const t = await resolveWs(workspace)
-      if ("error" in t) return err(t.error)
-      const tags = (await ctx.meta.tagCounts(t.org)).sort(
-        (a, b) => b.count - a.count || a.tag.localeCompare(b.tag),
-      )
-      return json({ workspace: t.org, count: tags.length, tags })
-    },
-  )
-
-  server.registerTool(
-    "suggest_tags",
-    {
-      description:
-        "Suggest browse tags for an artifact. Returns its current tags, `suggested` tags drawn from the most semantically-similar artifacts in the workspace (so you reuse how similar things are already tagged), and the full `vocabulary`. Read this, pick the ones that fit — reuse a suggestion or vocabulary entry over a new coinage — then apply them with `tag` (or set them on `publish`). Be generous: tagging is cheap and makes the library findable.",
+        "Tags and collections in one tool — the library's findability layer.\n" +
+        "• READ (no `short_ids`): the workspace's tag vocabulary (tag → count) and its collections. Call this before tagging to reuse an existing tag over a near-duplicate.\n" +
+        "• READ (with `short_ids`): those artifacts' current tags + collections, plus `suggested` tags drawn from the most semantically-similar docs (when one id is given).\n" +
+        "• WRITE: pass `add`/`remove`/`set` to change tags (add never drops existing; set replaces the whole set), and/or `collection` (an id, or a name — created if new) to fold the artifacts into a collection. Each artifact is authorized on its own; ones you can't touch come back as skipped.\n" +
+        "Tag freely and reuse the vocabulary — a well-tagged library is findable. Collections are heavier: a tag for plain findability, a collection when a set is a real unit.",
       inputSchema: {
-        short_id: z.string().describe("The artifact to suggest tags for."),
-        workspace: wsArg,
-      },
-    },
-    async ({ short_id, workspace }) => {
-      const reached = await reach(short_id, workspace)
-      if (!reached) return notFound(short_id)
-      if ("error" in reached) return err(reached.error)
-      const suggestions = await computeTagSuggestions(
-        { meta: ctx.meta, search: ctx.search, sourceText: ctx.sourceText },
-        reached.a,
-        actingFor?.id ?? agent.id,
-      )
-      return json({ short_id, ...suggestions })
-    },
-  )
-
-  server.registerTool(
-    "tag",
-    {
-      description:
-        "Add, remove, or replace an artifact's browse tags — one artifact or many at once. Pass `add` and/or `remove` to adjust the set (add is the default gesture — it never drops the tags a doc already has), or `set` to replace it wholesale. Tags are normalized (trimmed, lowercased, deduped, capped 20). Each artifact is authorized on its own; ones you can't edit come back in `skipped`, so a mixed list still tags what it can. Tag freely — reuse the vocabulary (list_tags / suggest_tags) so the library stays findable.",
-      inputSchema: {
-        short_ids: z.array(z.string()).min(1).describe("One or more artifact short ids to tag."),
-        add: z.array(z.string()).optional().describe("Tags to add (union with the existing set)."),
+        short_ids: z
+          .array(z.string())
+          .optional()
+          .describe("Artifacts to inspect or organize. Omit for the workspace overview."),
+        add: z.array(z.string()).optional().describe("Tags to add (union; never drops existing)."),
         remove: z.array(z.string()).optional().describe("Tags to remove."),
         set: z
           .array(z.string())
           .optional()
-          .describe("Replace the WHOLE set with exactly these (overrides add/remove)."),
-        workspace: wsArg,
-      },
-    },
-    async ({ short_ids, add, remove, set, workspace }) => {
-      if (!add && !remove && !set) return err("Pass at least one of `add`, `remove`, or `set`.")
-      const removeSet = new Set(normalizeTags(remove ?? []))
-      let updated = 0
-      let skipped = 0
-      let failed = 0
-      const results: { short_id: string; tags: string[] }[] = []
-      // Per-artifact, sequential: the set is human-sized (a selection), and each write
-      // reads-then-sets, which mustn't interleave on the same artifact.
-      for (const shortId of [...new Set(short_ids)]) {
-        const reached = await reach(shortId, workspace)
-        // Not found or not editable → skipped, never fails the batch.
-        if (!reached || "error" in reached || !roleAllows(reached.role, "publish")) {
-          skipped++
-          continue
-        }
-        try {
-          const next = set
-            ? normalizeTags(set)
-            : normalizeTags([
-                ...((await ctx.meta.tagsForArtifacts([reached.a.id]))[reached.a.id] ?? []),
-                ...(add ?? []),
-              ]).filter((t) => !removeSet.has(t))
-          await ctx.meta.setArtifactTags(reached.a.id, next)
-          updated++
-          results.push({ short_id: shortId, tags: next })
-        } catch {
-          failed++
-        }
-      }
-      return json({ updated, skipped, failed, results })
-    },
-  )
-
-  // COLLECTIONS (light) — see and route into them -------------------------------
-  server.registerTool(
-    "list_collections",
-    {
-      description:
-        "The workspace's collections — shareable groups of artifacts — with each one's item count. Read-only overview so you can route work into an existing collection with `collect` instead of scattering it. Lists the team-visible collections (invite-only ones you don't belong to stay hidden).",
-      inputSchema: { workspace: wsArg },
-    },
-    async ({ workspace }) => {
-      const t = await resolveWs(workspace)
-      if ("error" in t) return err(t.error)
-      const actorId = actingFor?.id ?? agent.id
-      const cols = await ctx.meta.listCollections(t.org)
-      // Light visibility: team-visible collections, plus any the acting user created (their
-      // own invite-only ones). Mirrors the web rail without the full per-collection role
-      // resolve — enough for an agent to pick a routing target.
-      const visible = cols
-        .filter((col) => col.workspace_access === "member" || col.created_by === actorId)
-        .map((col) => ({ id: col.id, title: col.title, count: col.count }))
-      return json({ workspace: t.org, count: visible.length, collections: visible })
-    },
-  )
-
-  server.registerTool(
-    "collect",
-    {
-      description:
-        "Add one or more artifacts to a collection — by `collection_id` (from list_collections) or by `collection` name, creating that collection if no team-visible one matches. Adding to a SHARED collection re-shares the artifacts to its members, so each artifact is authorized for sharing; ones you can't share come back in `skipped`. Collections are heavier than tags — reach for a tag first for plain findability, a collection when a set genuinely belongs together.",
-      inputSchema: {
-        short_ids: z.array(z.string()).min(1).describe("Artifact short ids to add."),
-        collection_id: z.string().optional().describe("An existing collection's id."),
+          .describe("Replace the whole tag set (overrides add/remove)."),
         collection: z
           .string()
           .optional()
-          .describe("A collection name — matched against team-visible collections, else created."),
+          .describe("Fold `short_ids` into this collection — an id, or a name (created if new)."),
         workspace: wsArg,
       },
     },
-    async ({ short_ids, collection_id, collection, workspace }) => {
-      if (!collection_id && !collection?.trim())
-        return err("Pass a `collection_id` or a `collection` name.")
+    async ({ short_ids, add, remove, set, collection, workspace }) => {
       const t = await resolveWs(workspace)
       if ("error" in t) return err(t.error)
       const actorId = actingFor?.id ?? agent.id
-      // Resolve the target collection: by id, then by name, else create it.
-      let col = collection_id ? await ctx.meta.getCollection(collection_id) : null
-      if (col && col.org_id !== t.org) return err("That collection is in another workspace.")
-      if (!col && collection?.trim()) {
-        const name = collection.trim()
-        const existing = (await ctx.meta.listCollections(t.org)).find(
-          (x) =>
-            x.title.toLowerCase() === name.toLowerCase() &&
-            (x.workspace_access === "member" || x.created_by === actorId),
-        )
-        col =
-          existing ??
-          (await (async () => {
-            const created = await ctx.meta.createCollection({
-              id: newId("col"),
-              org_id: t.org,
-              title: name.slice(0, 120),
-              created_by: actorId,
-              workspace_access: "member",
-            })
-            await ctx.meta.setCollectionMember({
-              id: newId("cm"),
-              collection_id: created.id,
-              user_id: actorId,
-              role: "owner",
-            })
-            return created
-          })())
-      }
-      if (!col) return err("Collection not found.")
-      // The caller must be able to MANAGE the collection to fold artifacts in: a
-      // team-visible one at their workspace seat, an invite-only one via an explicit
-      // member row. Mirrors the HTTP route's canManageCollection.
-      const canManage =
-        col.workspace_access === "member"
-          ? roleAllows(t.role, "publish")
-          : roleAllows(
-              (await ctx.meta.getCollectionMember(col.id, actorId))?.role ?? "viewer",
-              "publish",
-            )
-      if (!canManage) return err("You can't add to that collection.")
+      const sortVocab = (v: { tag: string; count: number }[]) =>
+        v.sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
 
-      let added = 0
-      let skipped = 0
-      for (const shortId of [...new Set(short_ids)]) {
-        const reached = await reach(shortId, workspace)
-        // Adding to a shared collection re-shares the artifact, so it needs share standing.
-        if (!reached || "error" in reached || !roleAllows(reached.role, "share")) {
-          skipped++
-          continue
+      // ---- WRITE: add/remove/set tags and/or fold into a collection ----
+      if (add || remove || set || collection) {
+        if (!short_ids?.length)
+          return err("Pass `short_ids` to organize (with add/remove/set and/or collection).")
+        const out: Record<string, unknown> = {}
+        if (add || remove || set) {
+          const removeSet = new Set(normalizeTags(remove ?? []))
+          let updated = 0
+          let skipped = 0
+          const results: { short_id: string; tags: string[] }[] = []
+          for (const shortId of [...new Set(short_ids)]) {
+            const reached = await reach(shortId, workspace)
+            // Not found or not editable → skipped, never fails the batch.
+            if (!reached || "error" in reached || !roleAllows(reached.role, "publish")) {
+              skipped++
+              continue
+            }
+            const next = set
+              ? normalizeTags(set)
+              : normalizeTags([
+                  ...((await ctx.meta.tagsForArtifacts([reached.a.id]))[reached.a.id] ?? []),
+                  ...(add ?? []),
+                ]).filter((x) => !removeSet.has(x))
+            await ctx.meta.setArtifactTags(reached.a.id, next)
+            updated++
+            results.push({ short_id: shortId, tags: next })
+          }
+          out.tagged = { updated, skipped, results }
         }
-        await ctx.meta.addCollectionItem(col.id, reached.a.id)
-        added++
+        if (collection) {
+          // Resolve the target collection: an id, else a name (matched team-visible, else
+          // created). Then the caller must be able to MANAGE it (mirrors the HTTP route).
+          const ref = collection.trim()
+          let col = await ctx.meta.getCollection(ref)
+          if (col && col.org_id !== t.org) return err("That collection is in another workspace.")
+          if (!col) {
+            const existing = (await ctx.meta.listCollections(t.org)).find(
+              (x) =>
+                x.title.toLowerCase() === ref.toLowerCase() &&
+                (x.workspace_access === "member" || x.created_by === actorId),
+            )
+            if (existing) col = existing
+            else {
+              col = await ctx.meta.createCollection({
+                id: newId("col"),
+                org_id: t.org,
+                title: ref.slice(0, 120),
+                created_by: actorId,
+                workspace_access: "member",
+              })
+              await ctx.meta.setCollectionMember({
+                id: newId("cm"),
+                collection_id: col.id,
+                user_id: actorId,
+                role: "owner",
+              })
+            }
+          }
+          const canManage =
+            col.workspace_access === "member"
+              ? roleAllows(t.role, "publish")
+              : roleAllows(
+                  (await ctx.meta.getCollectionMember(col.id, actorId))?.role ?? "viewer",
+                  "publish",
+                )
+          if (!canManage) return err("You can't add to that collection.")
+          let added = 0
+          let skipped = 0
+          for (const shortId of [...new Set(short_ids)]) {
+            const reached = await reach(shortId, workspace)
+            // Adding to a shared collection re-shares the artifact → needs share standing.
+            if (!reached || "error" in reached || !roleAllows(reached.role, "share")) {
+              skipped++
+              continue
+            }
+            await ctx.meta.addCollectionItem(col.id, reached.a.id)
+            added++
+          }
+          out.collected = { collection: { id: col.id, title: col.title }, added, skipped }
+        }
+        return json(out)
       }
-      return json({ collection: { id: col.id, title: col.title }, added, skipped })
+
+      // ---- READ: inspect specific artifacts (current tags + collections + suggestions) --
+      if (short_ids?.length) {
+        const artifacts: {
+          short_id: string
+          tags?: string[]
+          collections?: string[]
+          error?: string
+        }[] = []
+        let firstReached: ArtifactRecord | null = null
+        for (const shortId of short_ids) {
+          const reached = await reach(shortId, workspace)
+          if (!reached || "error" in reached) {
+            artifacts.push({ short_id: shortId, error: "not reachable" })
+            continue
+          }
+          if (!firstReached) firstReached = reached.a
+          const [tagMap, colIds] = await Promise.all([
+            ctx.meta.tagsForArtifacts([reached.a.id]),
+            ctx.meta.collectionIdsForArtifact(reached.a.id),
+          ])
+          artifacts.push({
+            short_id: shortId,
+            tags: tagMap[reached.a.id] ?? [],
+            collections: colIds,
+          })
+        }
+        // Suggestions only for a SINGLE artifact — aggregating across many is ambiguous.
+        const suggested =
+          short_ids.length === 1 && firstReached
+            ? (
+                await computeTagSuggestions(
+                  { meta: ctx.meta, search: ctx.search, sourceText: ctx.sourceText },
+                  firstReached,
+                  actorId,
+                )
+              ).suggested
+            : undefined
+        return json({
+          artifacts,
+          ...(suggested ? { suggested } : {}),
+          vocabulary: sortVocab(await ctx.meta.tagCounts(t.org)).slice(0, 50),
+        })
+      }
+
+      // ---- READ: workspace overview (vocabulary + collections) ----
+      const [tags, cols] = await Promise.all([
+        ctx.meta.tagCounts(t.org),
+        ctx.meta.listCollections(t.org),
+      ])
+      return json({
+        workspace: t.org,
+        vocabulary: sortVocab(tags),
+        collections: cols
+          .filter((col) => col.workspace_access === "member" || col.created_by === actorId)
+          .map((col) => ({ id: col.id, title: col.title, count: col.count })),
+      })
     },
   )
 

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -1389,14 +1389,23 @@ async function buildServer(
           // Resolve the target collection: an id, else a name (matched team-visible, else
           // created). Then the caller must be able to MANAGE it (mirrors the HTTP route).
           const ref = collection.trim()
+          if (!ref) return err("Pass a non-empty collection name or id.")
           let col = await ctx.meta.getCollection(ref)
           if (col && col.org_id !== t.org) return err("That collection is in another workspace.")
           if (!col) {
-            const existing = (await ctx.meta.listCollections(t.org)).find(
-              (x) =>
-                x.title.toLowerCase() === ref.toLowerCase() &&
-                (x.workspace_access === "member" || x.created_by === actorId),
-            )
+            const existing = (
+              await Promise.all(
+                (
+                  await ctx.meta.listCollections(t.org)
+                ).map(async (x) => ({
+                  x,
+                  visible:
+                    x.workspace_access === "member" ||
+                    x.created_by === actorId ||
+                    !!(await ctx.meta.getCollectionMember(x.id, actorId)),
+                })),
+              )
+            ).find(({ x, visible }) => x.title.toLowerCase() === ref.toLowerCase() && visible)?.x
             if (existing) col = existing
             else {
               col = await ctx.meta.createCollection({
@@ -1427,7 +1436,16 @@ async function buildServer(
           for (const shortId of [...new Set(short_ids)]) {
             const reached = await reach(shortId, workspace)
             // Adding to a shared collection re-shares the artifact → needs share standing.
-            if (!reached || "error" in reached || !roleAllows(reached.role, "share")) {
+            // `reach` may roam across the grant when `workspace` is omitted, but a collection
+            // can contain only artifacts from its own workspace (the HTTP bulk route has the
+            // same guard). Without this check, a default-workspace collection could reference
+            // an artifact from another workspace the grant can reach.
+            if (
+              !reached ||
+              "error" in reached ||
+              reached.org !== t.org ||
+              !roleAllows(reached.role, "share")
+            ) {
               skipped++
               continue
             }
@@ -1488,12 +1506,21 @@ async function buildServer(
         ctx.meta.tagCounts(t.org),
         ctx.meta.listCollections(t.org),
       ])
+      const visibleCols = await Promise.all(
+        cols.map(async (col) => ({
+          col,
+          visible:
+            col.workspace_access === "member" ||
+            col.created_by === actorId ||
+            !!(await ctx.meta.getCollectionMember(col.id, actorId)),
+        })),
+      )
       return json({
         workspace: t.org,
         vocabulary: sortVocab(tags),
-        collections: cols
-          .filter((col) => col.workspace_access === "member" || col.created_by === actorId)
-          .map((col) => ({ id: col.id, title: col.title, count: col.count })),
+        collections: visibleCols
+          .filter(({ visible }) => visible)
+          .map(({ col }) => ({ id: col.id, title: col.title, count: col.count })),
       })
     },
   )

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -712,7 +712,7 @@ async function buildServer(
     "list_artifacts",
     {
       description:
-        "List the artifacts (docs, plans, sites, skills) in a workspace — short id, title, kind, is_skill, current version, access, and its browse `tags`. Defaults to your current workspace; pass `workspace` (id or name from list_workspaces) to list another one. Pass `tag` to list only artifacts carrying that tag (findability — list_tags shows the vocabulary). Pass skills:true to list only skills (reusable agent procedure). Includes your own unlisted publishes — out of the shared library, but you always find your work. Start here to find what to work on, then catch_up or read it.",
+        "List the artifacts (docs, plans, sites, skills) in a workspace — short id, title, kind, is_skill, current version, access, and its browse `tags`. Defaults to your current workspace; pass `workspace` (id or name from list_workspaces) to list another one. Pass `tag` to list only artifacts carrying that tag (findability — organize shows the vocabulary). Pass skills:true to list only skills (reusable agent procedure). Includes your own unlisted publishes — out of the shared library, but you always find your work. Start here to find what to work on, then catch_up or read it.",
       inputSchema: {
         query: z.string().optional().describe("Optional title search filter."),
         tag: z
@@ -2003,7 +2003,7 @@ async function buildServer(
           .array(z.string())
           .optional()
           .describe(
-            "Browse tags to set on the artifact — workspace-wide labels that make it findable (list_tags shows the vocabulary; suggest_tags proposes from similar docs). Reuse an existing tag over a near-duplicate. Given ⇒ REPLACES the set (normalized: trimmed, lowercased, deduped, capped 20); [] clears; omitted leaves existing tags untouched on a republish.",
+            "Browse tags to set on the artifact — workspace-wide labels that make it findable (organize shows the vocabulary and proposes tags from similar docs). Reuse an existing tag over a near-duplicate. Given ⇒ REPLACES the set (normalized: trimmed, lowercased, deduped, capped 20); [] clears; omitted leaves existing tags untouched on a republish.",
           ),
         filename: z
           .string()

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -75,6 +75,7 @@ import {
   workspaceSearchReport,
 } from "../lib/search"
 import { enqueueSlackReviewRequestedDm } from "../lib/slack-dm"
+import { normalizeTags, parseTagsField } from "../lib/tags"
 import { log } from "../log"
 import { Artifact } from "../schemas"
 import { enqueueChannelDelivery } from "../webhooks"
@@ -738,6 +739,13 @@ export const artifactRoutes = (ctx: AppContext) => {
           resolves: toResolve,
         },
       )
+      // Tag at publish time — the one-step "auto-tag on create/version" hook. `tags` is a
+      // JSON array or a comma/space list on the multipart body; an editor can set it (the
+      // publisher already holds publish standing on this artifact by having written the
+      // version). An empty string clears; an absent field leaves tags untouched, so a
+      // republish that doesn't mention tags keeps them.
+      const parsedTags = parseTagsField(body["tags"])
+      if (parsedTags !== null) await meta.setArtifactTags(artifact.id, normalizeTags(parsedTags))
       // Open a review round if the publisher asked for one (the /derive loop). The
       // reviewer is the human behind the publish (onBehalf covers both a session
       // user and an agent's registrant); falls back to the workspace's first owner

--- a/apps/api/src/routes/favorites.ts
+++ b/apps/api/src/routes/favorites.ts
@@ -3,11 +3,28 @@ import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
 import { BULK_MAX, BulkSummarySchema, bulkArtifactOp } from "../lib/bulk"
 import { bail, fail, readJson } from "../lib/http"
+import { computeTagSuggestions } from "../lib/tag-suggestions"
+import { normalizeTags } from "../lib/tags"
 
-/** Favorites (personal stars) + tags (workspace browse metadata). */
+/** Favorites (personal stars) + tags (workspace browse metadata + suggestions). */
 export const favoriteRoutes = (ctx: AppContext) => {
-  const { meta, requireUser, requireArtifact, authorize } = ctx
+  const { meta, search, sourceText, currentUser, requireUser, requireArtifact, authorize } = ctx
   const app = new OpenAPIHono<BlankEnv>()
+
+  // What comes back from tag-suggestions: the artifact's current tags, tags to consider
+  // (aggregated from semantically-similar artifacts), and the workspace vocabulary so a
+  // caller reuses an existing tag instead of minting a near-duplicate.
+  const TagSuggestionsSchema = z
+    .object({
+      current: z.array(z.string()).describe("Tags already on the artifact."),
+      suggested: z
+        .array(z.object({ tag: z.string(), count: z.number() }))
+        .describe("Tags from similar artifacts, most-shared first; excludes current tags."),
+      vocabulary: z
+        .array(z.object({ tag: z.string(), count: z.number() }))
+        .describe("Every tag in the workspace with its usage count, most-used first."),
+    })
+    .openapi("TagSuggestions")
 
   // Favorites are personal: any user who can read the artifact can star it.
   app.openapi(
@@ -57,24 +74,9 @@ export const favoriteRoutes = (ctx: AppContext) => {
     },
   )
 
-  // Tags are workspace metadata: editors set them. Normalized (trimmed,
-  // lowercased, deduped, capped) so browse stays tidy.
-  const normalizeTags = (raw: unknown): string[] => {
-    if (!Array.isArray(raw)) return []
-    const seen = new Set<string>()
-    const out: string[] = []
-    for (const t of raw) {
-      if (typeof t !== "string") continue
-      const v = t.trim().toLowerCase().replace(/\s+/g, " ").slice(0, 40)
-      if (!v || seen.has(v)) continue
-      seen.add(v)
-      out.push(v)
-      if (out.length >= 20) break
-    }
-    // Sorted so the PUT response matches the list/detail order (tagsForArtifacts
-    // also sorts), and browse chips read alphabetically everywhere.
-    return out.sort()
-  }
+  // Tags are workspace metadata: editors set them. normalizeTags (shared with the bulk
+  // route + publish + the MCP tools) trims, lowercases, dedupes, and caps, so the stored
+  // vocabulary never fragments on casing or whitespace.
   app.openapi(
     createRoute({
       method: "put",
@@ -177,6 +179,41 @@ export const favoriteRoutes = (ctx: AppContext) => {
         (a) => (body.favorite ? meta.setFavorite(a.id, me.id) : meta.removeFavorite(a.id, me.id)),
       )
       return c.json(summary)
+    },
+  )
+
+  // Tag suggestions — the discover half of "auto-tag". For an artifact it returns the tags
+  // that its most semantically-similar neighbors carry (so an agent reuses the vocabulary
+  // instead of inventing near-duplicates), plus the full workspace vocabulary and the
+  // artifact's own current tags. Read-gated: suggesting reads, applying (the tag routes)
+  // still needs publish. Falls back to vocabulary-only where the dense arm is absent
+  // (SQLite / no embedder), so it always answers.
+  app.openapi(
+    createRoute({
+      method: "get",
+      path: "/v1/artifacts/{shortId}/tag-suggestions",
+      tags: ["Favorites"],
+      summary: "Suggest browse tags from similar artifacts + the workspace vocabulary.",
+      request: { params: z.object({ shortId: z.string() }) },
+      responses: {
+        200: {
+          description: "Current tags, suggestions from similar artifacts, and the vocabulary.",
+          content: { "application/json": { schema: TagSuggestionsSchema } },
+        },
+      },
+    }),
+    async (c) => {
+      const artifact = await requireArtifact(c, "read")
+      if (artifact instanceof Response) return bail(artifact)
+      const me = await currentUser(c)
+      // Shared with the MCP `suggest_tags` tool — one implementation of "what should this
+      // be tagged?" so the route and the agent tool never disagree.
+      const suggestions = await computeTagSuggestions(
+        { meta, search, sourceText },
+        artifact,
+        me?.id,
+      )
+      return c.json(suggestions)
     },
   )
 

--- a/apps/api/src/routes/favorites.ts
+++ b/apps/api/src/routes/favorites.ts
@@ -208,7 +208,7 @@ export const favoriteRoutes = (ctx: AppContext) => {
       const artifact = await requireArtifact(c, "read")
       if (artifact instanceof Response) return bail(artifact)
       const me = await currentUser(c)
-      // Shared with the MCP `suggest_tags` tool — one implementation of "what should this
+      // Shared with the MCP `organize` tool — one implementation of "what should this
       // be tagged?" so the route and the agent tool never disagree.
       const suggestions = await computeTagSuggestions(
         { meta, search, sourceText },

--- a/apps/api/src/routes/favorites.ts
+++ b/apps/api/src/routes/favorites.ts
@@ -106,7 +106,11 @@ export const favoriteRoutes = (ctx: AppContext) => {
   // Bulk tags — the library multi-select bar. ADDS a set of tags to many artifacts at
   // once; it never replaces, so tagging a selection can't wipe the tags its other members
   // already carry. The union is computed per artifact server-side (the client sends only
-  // the tags to add), and each artifact is authorized on its own like the single route.
+  // the tags to add), and each artifact is authorized on its own — the SAME per-artifact
+  // `authorize(publish)` the single PUT /tags route uses, no `requireUser`: tags aren't
+  // user-scoped, so a static-token principal (a CI/agent integration, and the local MCP
+  // server) must be able to tag just like the single route lets it. The hard anonymous
+  // lockdown (app.ts) already refuses tokenless callers at the door.
   app.openapi(
     createRoute({
       method: "post",
@@ -121,8 +125,6 @@ export const favoriteRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const me = await requireUser(c)
-      if (me instanceof Response) return bail(me)
       const body = await readJson(
         c,
         z.object({

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -170,25 +170,19 @@ describe("remote MCP endpoint (/mcp)", () => {
       "catch_up",
       "check_requests",
       "checkpoint",
-      "collect",
       "comment",
       "list_artifacts",
       "list_contexts",
-      "list_collections",
-      "list_tags",
       "list_workspaces",
+      "organize",
       "publish",
       "read",
       "search",
       "setup_brandprint",
       "stage_asset",
       "stage_publish",
-      "suggest_tags",
-      "tag",
-      "suggest_tags",
-      "tag",
     ])
-    // Consolidated away — folded into catch_up / comment / publish.
+    // Consolidated away — folded into catch_up / comment / publish / organize.
     for (const gone of [
       "whoami",
       "catch_me_up",
@@ -198,6 +192,12 @@ describe("remote MCP endpoint (/mcp)", () => {
       "propose",
       "read_artifact",
       "read_section",
+      // Tags/collections now live under the one `organize` tool.
+      "list_tags",
+      "suggest_tags",
+      "tag",
+      "list_collections",
+      "collect",
     ])
       expect(names).not.toContain(gone)
   })
@@ -645,8 +645,8 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(read).not.toContain("\\n")
   })
 
-  it("tags: publish tags, list_tags vocabulary, tag apply, list_artifacts(tag) filter, suggest_tags", async () => {
-    const { app, token } = appWithGrant("tags", "openid derive:read derive:publish")
+  it("organize: publish tags, overview vocabulary, apply, list_artifacts filter, inspect+suggest", async () => {
+    const { app, token } = appWithGrant("organize", "openid derive:read derive:publish")
     // Auto-tag on publish.
     const a = JSON.parse(
       toolText(
@@ -661,29 +661,31 @@ describe("remote MCP endpoint (/mcp)", () => {
       toolText(await call(app, token, "publish", { title: "Notes", content: "# Notes\n\nbody" })),
     ).short_id
 
-    // list_tags shows the vocabulary with counts.
-    const vocab = JSON.parse(toolText(await call(app, token, "list_tags")))
-    expect(vocab.tags.find((t: { tag: string }) => t.tag === "planning")?.count).toBe(1)
+    // organize() with no args → the workspace overview: vocabulary + collections.
+    const overview = JSON.parse(toolText(await call(app, token, "organize")))
+    expect(overview.vocabulary.find((t: { tag: string }) => t.tag === "planning")?.count).toBe(1)
+    expect(Array.isArray(overview.collections)).toBe(true)
 
     // list_artifacts carries tags, and tag: filters to the tagged doc.
     const filtered = JSON.parse(toolText(await call(app, token, "list_artifacts", { tag: "q3" })))
     expect(filtered.artifacts.map((x: { short_id: string }) => x.short_id)).toEqual([a])
     expect(filtered.artifacts[0].tags.sort()).toEqual(["planning", "q3"])
 
-    // tag adds to b (union) and reports it updated.
+    // organize({short_ids, add}) applies (union) and reports it tagged.
     const tagged = JSON.parse(
-      toolText(await call(app, token, "tag", { short_ids: [b], add: ["planning", "notes"] })),
+      toolText(await call(app, token, "organize", { short_ids: [b], add: ["planning", "notes"] })),
     )
-    expect(tagged.updated).toBe(1)
-    expect(tagged.results[0].tags.sort()).toEqual(["notes", "planning"])
+    expect(tagged.tagged.updated).toBe(1)
+    expect(tagged.tagged.results[0].tags.sort()).toEqual(["notes", "planning"])
 
-    // suggest_tags returns the doc's current tags + the workspace vocabulary (no dense arm here).
-    const sugg = JSON.parse(toolText(await call(app, token, "suggest_tags", { short_id: a })))
-    expect(sugg.current.sort()).toEqual(["planning", "q3"])
-    expect(sugg.vocabulary.map((t: { tag: string }) => t.tag)).toContain("notes")
+    // organize({short_ids:[a]}) inspects: current tags + collections + vocabulary (+ suggestions).
+    const inspect = JSON.parse(toolText(await call(app, token, "organize", { short_ids: [a] })))
+    expect(inspect.artifacts[0].tags.sort()).toEqual(["planning", "q3"])
+    expect(inspect.artifacts[0].collections).toEqual([])
+    expect(inspect.vocabulary.map((t: { tag: string }) => t.tag)).toContain("notes")
   })
 
-  it("collect: creates a collection by name and folds artifacts in", async () => {
+  it("organize: folds artifacts into a collection by name, then lists membership", async () => {
     const { app, token } = appWithGrant("collect", "openid derive:read derive:publish")
     const a = JSON.parse(
       toolText(await call(app, token, "publish", { title: "One", content: "# One\n\nbody" })),
@@ -693,15 +695,19 @@ describe("remote MCP endpoint (/mcp)", () => {
     ).short_id
 
     const res = JSON.parse(
-      toolText(await call(app, token, "collect", { short_ids: [a, b], collection: "Q3 Work" })),
+      toolText(await call(app, token, "organize", { short_ids: [a, b], collection: "Q3 Work" })),
     )
-    expect(res.added).toBe(2)
-    expect(res.collection.title).toBe("Q3 Work")
+    expect(res.collected.added).toBe(2)
+    expect(res.collected.collection.title).toBe("Q3 Work")
 
-    const cols = JSON.parse(toolText(await call(app, token, "list_collections")))
-    expect(
-      cols.collections.find((c: { title: string; count: number }) => c.title === "Q3 Work")?.count,
-    ).toBe(2)
+    // The overview lists the collection with its count; inspecting an artifact shows membership.
+    const overview = JSON.parse(toolText(await call(app, token, "organize")))
+    const col = overview.collections.find(
+      (c: { title: string; count: number }) => c.title === "Q3 Work",
+    )
+    expect(col?.count).toBe(2)
+    const inspect = JSON.parse(toolText(await call(app, token, "organize", { short_ids: [a] })))
+    expect(inspect.artifacts[0].collections).toContain(col.id)
   })
 
   it("list_artifacts marks skills and filters to them with skills:true", async () => {

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -170,9 +170,12 @@ describe("remote MCP endpoint (/mcp)", () => {
       "catch_up",
       "check_requests",
       "checkpoint",
+      "collect",
       "comment",
       "list_artifacts",
       "list_contexts",
+      "list_collections",
+      "list_tags",
       "list_workspaces",
       "publish",
       "read",
@@ -180,6 +183,10 @@ describe("remote MCP endpoint (/mcp)", () => {
       "setup_brandprint",
       "stage_asset",
       "stage_publish",
+      "suggest_tags",
+      "tag",
+      "suggest_tags",
+      "tag",
     ])
     // Consolidated away — folded into catch_up / comment / publish.
     for (const gone of [
@@ -636,6 +643,65 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(read).toContain("title: My Plan")
     expect(read).toContain("# My Plan")
     expect(read).not.toContain("\\n")
+  })
+
+  it("tags: publish tags, list_tags vocabulary, tag apply, list_artifacts(tag) filter, suggest_tags", async () => {
+    const { app, token } = appWithGrant("tags", "openid derive:read derive:publish")
+    // Auto-tag on publish.
+    const a = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          title: "Roadmap",
+          content: "# Roadmap\n\nbody",
+          tags: ["planning", "q3"],
+        }),
+      ),
+    ).short_id
+    const b = JSON.parse(
+      toolText(await call(app, token, "publish", { title: "Notes", content: "# Notes\n\nbody" })),
+    ).short_id
+
+    // list_tags shows the vocabulary with counts.
+    const vocab = JSON.parse(toolText(await call(app, token, "list_tags")))
+    expect(vocab.tags.find((t: { tag: string }) => t.tag === "planning")?.count).toBe(1)
+
+    // list_artifacts carries tags, and tag: filters to the tagged doc.
+    const filtered = JSON.parse(toolText(await call(app, token, "list_artifacts", { tag: "q3" })))
+    expect(filtered.artifacts.map((x: { short_id: string }) => x.short_id)).toEqual([a])
+    expect(filtered.artifacts[0].tags.sort()).toEqual(["planning", "q3"])
+
+    // tag adds to b (union) and reports it updated.
+    const tagged = JSON.parse(
+      toolText(await call(app, token, "tag", { short_ids: [b], add: ["planning", "notes"] })),
+    )
+    expect(tagged.updated).toBe(1)
+    expect(tagged.results[0].tags.sort()).toEqual(["notes", "planning"])
+
+    // suggest_tags returns the doc's current tags + the workspace vocabulary (no dense arm here).
+    const sugg = JSON.parse(toolText(await call(app, token, "suggest_tags", { short_id: a })))
+    expect(sugg.current.sort()).toEqual(["planning", "q3"])
+    expect(sugg.vocabulary.map((t: { tag: string }) => t.tag)).toContain("notes")
+  })
+
+  it("collect: creates a collection by name and folds artifacts in", async () => {
+    const { app, token } = appWithGrant("collect", "openid derive:read derive:publish")
+    const a = JSON.parse(
+      toolText(await call(app, token, "publish", { title: "One", content: "# One\n\nbody" })),
+    ).short_id
+    const b = JSON.parse(
+      toolText(await call(app, token, "publish", { title: "Two", content: "# Two\n\nbody" })),
+    ).short_id
+
+    const res = JSON.parse(
+      toolText(await call(app, token, "collect", { short_ids: [a, b], collection: "Q3 Work" })),
+    )
+    expect(res.added).toBe(2)
+    expect(res.collection.title).toBe("Q3 Work")
+
+    const cols = JSON.parse(toolText(await call(app, token, "list_collections")))
+    expect(
+      cols.collections.find((c: { title: string; count: number }) => c.title === "Q3 Work")?.count,
+    ).toBe(2)
   })
 
   it("list_artifacts marks skills and filters to them with skills:true", async () => {

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -710,6 +710,36 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(inspect.artifacts[0].collections).toContain(col.id)
   })
 
+  it("organize never folds a roaming artifact into the default workspace's collection", async () => {
+    const { app, token, meta } = appWithGrant(
+      "collect-cross-workspace",
+      "openid derive:read derive:publish",
+    )
+    // Establish the OAuth grant's default before adding a second workspace.
+    await call(app, token, "list_workspaces")
+    await meta.setWorkspace("ws_other", "Other workspace")
+    await meta.setMembership({ id: "m_other", org_id: "ws_other", user_id: "u_o", role: "owner" })
+
+    // Publish outside the default workspace, then omit `workspace` on organize so reach()
+    // takes its intentional cross-workspace lookup path.
+    const other = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          title: "Elsewhere",
+          content: "# Elsewhere\n\nbody",
+          workspace: "ws_other",
+        }),
+      ),
+    ).short_id
+    const res = JSON.parse(
+      toolText(await call(app, token, "organize", { short_ids: [other], collection: "Default" })),
+    )
+    expect(res.collected).toMatchObject({ added: 0, skipped: 1 })
+    const artifact = await meta.getByShortId(other)
+    if (!artifact) throw new Error("published artifact disappeared")
+    expect(await meta.collectionIdsForArtifact(artifact.id)).toEqual([])
+  })
+
   it("list_artifacts marks skills and filters to them with skills:true", async () => {
     const { app, token } = appWithGrant("listskills", "openid derive:read derive:publish")
     const doc = (await (await publish(app, token, "A plain doc")).json()).short_id

--- a/apps/api/test/tags.test.ts
+++ b/apps/api/test/tags.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest"
+import { app, upload } from "./helpers"
+
+// Tags as the findability layer: set them at publish time, filter the library by them, and
+// ask for suggestions. The embedded SQLite test backend has NO dense arm, so suggestions
+// here exercise the vocabulary-only fallback (current + vocabulary, empty neighbor list) —
+// the semantic-neighbor path is covered by the shared computeTagSuggestions logic against a
+// real embedder in deployed envs.
+
+const detail = async (shortId: string) =>
+  (await (await app.request(`/v1/artifacts/${shortId}`)).json()) as { tags: string[] }
+
+describe("tags on publish", () => {
+  it("sets browse tags from a JSON-array `tags` field, normalized", async () => {
+    const { short_id } = await (
+      await upload("p1.md", "x", { title: "Tagged", tags: JSON.stringify(["Q3 Plan", "planning"]) })
+    ).json()
+    // Lowercased, inner whitespace collapsed, sorted.
+    expect((await detail(short_id)).tags).toEqual(["planning", "q3 plan"])
+  })
+
+  it("accepts a comma/space list too, and an empty field leaves a republish's tags intact", async () => {
+    const { short_id } = await (
+      await upload("p2.md", "x", { title: "T", tags: "alpha, beta" })
+    ).json()
+    expect((await detail(short_id)).tags).toEqual(["alpha", "beta"])
+    // Republish WITHOUT a tags field — tags must survive (absent ≠ clear).
+    await upload("p2.md", "y", {}, short_id)
+    expect((await detail(short_id)).tags).toEqual(["alpha", "beta"])
+    // Republish with an EMPTY tags field clears them (explicit "remove all").
+    await upload("p2.md", "z", { tags: "" }, short_id)
+    expect((await detail(short_id)).tags).toEqual([])
+  })
+})
+
+describe("filtering + vocabulary", () => {
+  it("?tag= narrows the listing, and the summary counts each tag", async () => {
+    const a = await (await upload("f1.md", "x", { title: "A", tags: "shared,only-a" })).json()
+    await (await upload("f2.md", "x", { title: "B", tags: "shared" })).json()
+
+    const listed = (await (await app.request("/v1/artifacts?tag=shared")).json()) as {
+      artifacts: { short_id: string }[]
+    }
+    expect(listed.artifacts.length).toBeGreaterThanOrEqual(2)
+
+    const onlyA = (await (await app.request("/v1/artifacts?tag=only-a")).json()) as {
+      artifacts: { short_id: string }[]
+    }
+    expect(onlyA.artifacts.map((x) => x.short_id)).toEqual([a.short_id])
+
+    const summary = (await (await app.request("/v1/tags")).json()) as {
+      tags: { tag: string; count: number }[]
+    }
+    expect(summary.tags.find((t) => t.tag === "shared")?.count).toBeGreaterThanOrEqual(2)
+  })
+})
+
+describe("tag-suggestions", () => {
+  it("returns current tags + the workspace vocabulary (neighbor path is a no-op without a dense arm)", async () => {
+    await (await upload("s1.md", "x", { title: "Neighbor", tags: "roadmap" })).json()
+    const { short_id } = await (
+      await upload("s2.md", "x", { title: "Subject", tags: "draft" })
+    ).json()
+
+    const res = await app.request(`/v1/artifacts/${short_id}/tag-suggestions`)
+    expect(res.status).toBe(200)
+    const s = (await res.json()) as {
+      current: string[]
+      suggested: { tag: string }[]
+      vocabulary: { tag: string; count: number }[]
+    }
+    expect(s.current).toEqual(["draft"])
+    // No dense arm in the SQLite test backend → no neighbor suggestions, but the vocabulary
+    // (which includes tags from the whole workspace) still answers.
+    expect(s.suggested).toEqual([])
+    expect(s.vocabulary.map((t) => t.tag)).toContain("roadmap")
+  })
+})

--- a/apps/api/test/tags.test.ts
+++ b/apps/api/test/tags.test.ts
@@ -1,5 +1,7 @@
+import type { SearchIndex } from "@derive/core"
 import { describe, expect, it } from "vitest"
-import { app, upload } from "./helpers"
+import { computeTagSuggestions } from "../src/lib/tag-suggestions"
+import { app, meta, upload } from "./helpers"
 
 // Tags as the findability layer: set them at publish time, filter the library by them, and
 // ask for suggestions. The embedded SQLite test backend has NO dense arm, so suggestions
@@ -74,5 +76,42 @@ describe("tag-suggestions", () => {
     // (which includes tags from the whole workspace) still answers.
     expect(s.suggested).toEqual([])
     expect(s.vocabulary.map((t) => t.tag)).toContain("roadmap")
+  })
+
+  it("aggregates neighbor tags via the dense arm — ranked by frequency, current tags excluded", async () => {
+    // The semantic path the SQLite endpoint can't reach: seed a subject + neighbors, then
+    // drive computeTagSuggestions with a STUB SearchIndex that returns those neighbors, so
+    // the real aggregation (frequency count, current-tag + sift- exclusion, ranking) runs.
+    const subject = await (
+      await upload("dense-subj.md", "x", { title: "Subject", tags: "draft" })
+    ).json()
+    const n1 = await (await upload("dense-n1.md", "x", { title: "N1", tags: "roadmap, q4" })).json()
+    const n2 = await (await upload("dense-n2.md", "x", { title: "N2", tags: "roadmap" })).json()
+    // "draft" here is already on the subject → must be excluded from suggestions.
+    const n3 = await (await upload("dense-n3.md", "x", { title: "N3", tags: "misc, draft" })).json()
+
+    const subjRec = await meta.getByShortId(subject.short_id)
+    if (!subjRec) throw new Error("subject missing")
+    const neighborIds = await Promise.all(
+      [n1, n2, n3].map(async (x) => (await meta.getByShortId(x.short_id))?.id ?? ""),
+    )
+    // Stub the dense arm: return the neighbors (ranked), ignore the query text. Only
+    // `search` is called by computeTagSuggestions; the rest are no-op to satisfy the type.
+    const search: SearchIndex = {
+      search: async () => neighborIds.map((id, i) => ({ id, score: 1 - i * 0.1, chunk: "" })),
+      indexArtifact: async () => {},
+      indexArtifacts: async () => {},
+      unindexArtifact: async () => {},
+    }
+    const suggestions = await computeTagSuggestions(
+      { meta, search, sourceText: async () => "subject body text" },
+      subjRec,
+      undefined,
+    )
+    // roadmap on 2 neighbors → first; misc on 1; q4 on 1; draft excluded (already current).
+    expect(suggestions.suggested.find((t) => t.tag === "roadmap")?.count).toBe(2)
+    expect(suggestions.suggested[0]?.tag).toBe("roadmap")
+    expect(suggestions.suggested.map((t) => t.tag).sort()).toEqual(["misc", "q4", "roadmap"])
+    expect(suggestions.suggested.some((t) => t.tag === "draft")).toBe(false)
   })
 })

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -2117,6 +2117,44 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/artifacts/{shortId}/tag-suggestions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Suggest browse tags from similar artifacts + the workspace vocabulary. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    shortId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Current tags, suggestions from similar artifacts, and the vocabulary. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TagSuggestions"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/follows": {
         parameters: {
             query?: never;
@@ -5750,6 +5788,20 @@ export interface components {
             email: string;
             /** @description The inviter's display name; null if unknown. */
             inviter: string | null;
+        };
+        TagSuggestions: {
+            /** @description Tags already on the artifact. */
+            current: string[];
+            /** @description Tags from similar artifacts, most-shared first; excludes current tags. */
+            suggested: {
+                tag: string;
+                count: number;
+            }[];
+            /** @description Every tag in the workspace with its usage count, most-used first. */
+            vocabulary: {
+                tag: string;
+                count: number;
+            }[];
         };
         Follow: {
             id: string;

--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -14,7 +14,10 @@
 //                                           set/show/clear what a workspace is FOR
 //   derive account use <ref>               set the default account
 //   derive logout [--account a] [--all]    sign out
-//   derive publish [file|dir] [--id --title --slug --spa --message --name --workspace-access --link-role --listed --password --server --token --workspace --account]  (--visibility is a deprecated shorthand)
+//   derive publish [file|dir] [--id --title --slug --spa --message --tags a,b --name --workspace-access --link-role --listed --password --server --token --workspace --account]  (--visibility is a deprecated shorthand)
+//   derive tags [--json]                   the workspace tag vocabulary (tag → count)
+//   derive tag <tag…> [--rm a,b] [--set a,b] [--id]  add/remove/replace an artifact's tags
+//   derive suggest-tags [short_id] [--id --json]  suggest tags from similar artifacts
 //   derive comments [--id]                 list the artifact's comment threads
 //   derive pull [short_id] [--v N] [--out f]  print an artifact's source (bundles: entry file)
 //   derive open [short_id] [--id]          open the artifact in a browser
@@ -929,6 +932,10 @@ const LOOP = [
   "status",
   "send-back",
   "approve",
+  // Findability: the workspace tag vocabulary + per-artifact tag apply / suggest.
+  "tags",
+  "tag",
+  "suggest-tags",
 ]
 if (LOOP.includes(cmd)) {
   let cfg = null
@@ -945,8 +952,11 @@ if (LOOP.includes(cmd)) {
   // <short_id>`: a positional id overrides the repo pin — the fallback an agent
   // runs when a publish reports opened_in_tab:false. (reply/resolve keep their
   // positional for the thread/comment id.)
-  if (positional[0] && ["open", "status", "comments", "pull"].includes(cmd)) r.id = positional[0]
-  if (!r.id) {
+  if (positional[0] && ["open", "status", "comments", "pull", "suggest-tags"].includes(cmd))
+    r.id = positional[0]
+  // `tags` is workspace-scoped (the vocabulary), so it needs no artifact id; every other
+  // loop verb does.
+  if (!r.id && cmd !== "tags") {
     console.error(`error: no artifact id. Set "id" in ${CONFIG_FILE} (publish once), or pass --id.`)
     process.exit(1)
   }
@@ -959,6 +969,95 @@ if (LOOP.includes(cmd)) {
     const j = await res.json().catch(() => ({}))
     console.error(`error (${res.status}): ${j.error ?? res.statusText}`)
     process.exit(1)
+  }
+
+  // ---- Findability: tags vocabulary, per-artifact apply, suggestions --------
+  const splitTags = (v) =>
+    String(v ?? "")
+      .split(/[,\s]+/)
+      .map((t) => t.trim())
+      .filter(Boolean)
+
+  if (cmd === "tags") {
+    const res = await fetch(`${r.server}/v1/tags`, { headers: auth })
+    if (!res.ok) await die(res)
+    const tags = ((await res.json()).tags ?? []).sort(
+      (a, b) => b.count - a.count || a.tag.localeCompare(b.tag),
+    )
+    if (flags.json) {
+      console.log(JSON.stringify(tags))
+    } else if (tags.length === 0) {
+      console.log("(no tags yet)")
+    } else {
+      const w = Math.max(...tags.map((t) => t.tag.length))
+      for (const t of tags) console.log(`  ${t.tag.padEnd(w)}  ${t.count}`)
+    }
+    process.exit(0)
+  }
+
+  if (cmd === "suggest-tags") {
+    const res = await fetch(`${base}/tag-suggestions`, { headers: auth })
+    if (!res.ok) await die(res)
+    const s = await res.json()
+    if (flags.json) {
+      console.log(JSON.stringify(s))
+    } else {
+      console.log(`current:    ${s.current.length ? s.current.join(", ") : "(none)"}`)
+      console.log(
+        `suggested:  ${s.suggested.length ? s.suggested.map((x) => x.tag).join(", ") : "(none — no similar docs)"}`,
+      )
+      console.log(
+        `vocabulary: ${
+          s.vocabulary.length
+            ? s.vocabulary
+                .slice(0, 20)
+                .map((x) => x.tag)
+                .join(", ")
+            : "(empty)"
+        }`,
+      )
+      if (s.suggested.length)
+        console.error(`\n  apply:  derive tag ${s.suggested.map((x) => x.tag).join(" ")}`)
+    }
+    process.exit(0)
+  }
+
+  if (cmd === "tag") {
+    // `derive tag foo bar` adds; `--rm x,y` removes; `--set a,b` replaces the whole set.
+    // Operates on the repo-pinned artifact (or --id). Positional tokens are tags to add.
+    const add = positional
+    const remove = splitTags(flags.rm)
+    const set = flags.set !== undefined ? splitTags(flags.set) : null
+    if (!add.length && !remove.length && set === null) {
+      console.error(
+        "usage: derive tag <tag…> [--rm a,b] [--set a,b] [--id short_id]\n" +
+          "  add tags (positional), remove (--rm), or replace the set (--set).",
+      )
+      process.exit(1)
+    }
+    const put = async (tags) => {
+      const res = await fetch(`${base}/tags`, {
+        method: "PUT",
+        headers: { ...auth, "content-type": "application/json" },
+        body: JSON.stringify({ tags }),
+      })
+      if (!res.ok) await die(res)
+      return (await res.json()).tags
+    }
+    let tags
+    if (set !== null) {
+      tags = await put(set)
+    } else {
+      // Read-modify-write the single artifact: union in `add`, drop `remove`.
+      const cur = await fetch(base, { headers: auth })
+      if (!cur.ok) await die(cur)
+      const existing = (await cur.json()).tags ?? []
+      const removeSet = new Set(remove.map((t) => t.toLowerCase()))
+      tags = await put([...existing, ...add].filter((t) => !removeSet.has(t.toLowerCase())))
+    }
+    if (flags.json) console.log(JSON.stringify({ id: r.id, tags }))
+    else console.log(`✓ ${r.id} tags: ${tags.length ? tags.join(", ") : "(none)"}`)
+    process.exit(0)
   }
 
   if (cmd === "open") {
@@ -1256,12 +1355,21 @@ try {
   console.error(`error: ${e.message}`)
   process.exit(1)
 }
-const { res, json } = await uploadArtifact(
-  p,
-  up.bytes,
-  up.filename,
-  flags.review ? { request_review: "true" } : {},
-)
+const { res, json } = await uploadArtifact(p, up.bytes, up.filename, {
+  ...(flags.review ? { request_review: "true" } : {}),
+  // --tags a,b sets the artifact's browse tags at publish time (JSON array; the server
+  // normalizes). Passed through the form escape hatch so no new UploadTarget field is needed.
+  ...(flags.tags
+    ? {
+        tags: JSON.stringify(
+          String(flags.tags)
+            .split(/[,\s]+/)
+            .map((t) => t.trim())
+            .filter(Boolean),
+        ),
+      }
+    : {}),
+})
 if (!res.ok) {
   console.error(`error (${res.status}): ${json.error ?? res.statusText}`)
   process.exit(1)

--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -15,9 +15,9 @@
 //   derive account use <ref>               set the default account
 //   derive logout [--account a] [--all]    sign out
 //   derive publish [file|dir] [--id --title --slug --spa --message --tags a,b --name --workspace-access --link-role --listed --password --server --token --workspace --account]  (--visibility is a deprecated shorthand)
-//   derive tags [--json]                   the workspace tag vocabulary (tag → count)
+//   derive tag                             the workspace tag vocabulary (tag → count)
+//   derive tag --suggest [--id]            suggest tags for the artifact (from similar docs)
 //   derive tag <tag…> [--rm a,b] [--set a,b] [--id]  add/remove/replace an artifact's tags
-//   derive suggest-tags [short_id] [--id --json]  suggest tags from similar artifacts
 //   derive comments [--id]                 list the artifact's comment threads
 //   derive pull [short_id] [--v N] [--out f]  print an artifact's source (bundles: entry file)
 //   derive open [short_id] [--id]          open the artifact in a browser
@@ -86,6 +86,7 @@ for (let i = 0; i < args.length; i++) {
   else if (a === "--clear") flags.clear = "true"
   else if (a === "--mock") flags.mock = "true"
   else if (a === "--manage") flags.manage = "true"
+  else if (a === "--suggest") flags.suggest = "true"
   // Repeatable: `--env-file a --env-file b` stacks (equivalent to --env-file a,b).
   else if (a === "--env-file")
     flags["env-file"] = flags["env-file"] ? `${flags["env-file"]},${args[++i]}` : args[++i]
@@ -932,10 +933,8 @@ const LOOP = [
   "status",
   "send-back",
   "approve",
-  // Findability: the workspace tag vocabulary + per-artifact tag apply / suggest.
-  "tags",
+  // Findability: one `tag` verb — vocabulary (no args), suggest (--suggest), or apply.
   "tag",
-  "suggest-tags",
 ]
 if (LOOP.includes(cmd)) {
   let cfg = null
@@ -952,11 +951,16 @@ if (LOOP.includes(cmd)) {
   // <short_id>`: a positional id overrides the repo pin — the fallback an agent
   // runs when a publish reports opened_in_tab:false. (reply/resolve keep their
   // positional for the thread/comment id.)
-  if (positional[0] && ["open", "status", "comments", "pull", "suggest-tags"].includes(cmd))
-    r.id = positional[0]
-  // `tags` is workspace-scoped (the vocabulary), so it needs no artifact id; every other
-  // loop verb does.
-  if (!r.id && cmd !== "tags") {
+  if (positional[0] && ["open", "status", "comments", "pull"].includes(cmd)) r.id = positional[0]
+  // `derive tag` with NO tags + NO --suggest is the workspace vocabulary — needs no artifact
+  // id; every other loop verb (and the apply/suggest forms of `tag`) does.
+  const tagVocab =
+    cmd === "tag" &&
+    positional.length === 0 &&
+    !flags.rm &&
+    flags.set === undefined &&
+    !flags.suggest
+  if (!r.id && !tagVocab) {
     console.error(`error: no artifact id. Set "id" in ${CONFIG_FILE} (publish once), or pass --id.`)
     process.exit(1)
   }
@@ -971,70 +975,64 @@ if (LOOP.includes(cmd)) {
     process.exit(1)
   }
 
-  // ---- Findability: tags vocabulary, per-artifact apply, suggestions --------
-  const splitTags = (v) =>
-    String(v ?? "")
-      .split(/[,\s]+/)
-      .map((t) => t.trim())
-      .filter(Boolean)
-
-  if (cmd === "tags") {
-    const res = await fetch(`${r.server}/v1/tags`, { headers: auth })
-    if (!res.ok) await die(res)
-    const tags = ((await res.json()).tags ?? []).sort(
-      (a, b) => b.count - a.count || a.tag.localeCompare(b.tag),
-    )
-    if (flags.json) {
-      console.log(JSON.stringify(tags))
-    } else if (tags.length === 0) {
-      console.log("(no tags yet)")
-    } else {
-      const w = Math.max(...tags.map((t) => t.tag.length))
-      for (const t of tags) console.log(`  ${t.tag.padEnd(w)}  ${t.count}`)
-    }
-    process.exit(0)
-  }
-
-  if (cmd === "suggest-tags") {
-    const res = await fetch(`${base}/tag-suggestions`, { headers: auth })
-    if (!res.ok) await die(res)
-    const s = await res.json()
-    if (flags.json) {
-      console.log(JSON.stringify(s))
-    } else {
-      console.log(`current:    ${s.current.length ? s.current.join(", ") : "(none)"}`)
-      console.log(
-        `suggested:  ${s.suggested.length ? s.suggested.map((x) => x.tag).join(", ") : "(none — no similar docs)"}`,
-      )
-      console.log(
-        `vocabulary: ${
-          s.vocabulary.length
-            ? s.vocabulary
-                .slice(0, 20)
-                .map((x) => x.tag)
-                .join(", ")
-            : "(empty)"
-        }`,
-      )
-      if (s.suggested.length)
-        console.error(`\n  apply:  derive tag ${s.suggested.map((x) => x.tag).join(" ")}`)
-    }
-    process.exit(0)
-  }
-
+  // ---- Findability: one `derive tag` verb, mirroring the MCP `organize` tool -----
+  //   derive tag                       → the workspace tag vocabulary
+  //   derive tag --suggest [--id]      → tag suggestions for the artifact
+  //   derive tag <tag…> [--rm a,b] [--set a,b] [--id]  → add / remove / replace
   if (cmd === "tag") {
-    // `derive tag foo bar` adds; `--rm x,y` removes; `--set a,b` replaces the whole set.
-    // Operates on the repo-pinned artifact (or --id). Positional tokens are tags to add.
+    const splitTags = (v) =>
+      String(v ?? "")
+        .split(/[,\s]+/)
+        .map((t) => t.trim())
+        .filter(Boolean)
+
+    // No tags + no --suggest → the workspace vocabulary (no artifact id needed).
+    if (tagVocab) {
+      const res = await fetch(`${r.server}/v1/tags`, { headers: auth })
+      if (!res.ok) await die(res)
+      const tags = ((await res.json()).tags ?? []).sort(
+        (a, b) => b.count - a.count || a.tag.localeCompare(b.tag),
+      )
+      if (flags.json) console.log(JSON.stringify(tags))
+      else if (tags.length === 0) console.log("(no tags yet)")
+      else {
+        const w = Math.max(...tags.map((t) => t.tag.length))
+        for (const t of tags) console.log(`  ${t.tag.padEnd(w)}  ${t.count}`)
+      }
+      process.exit(0)
+    }
+
+    if (flags.suggest) {
+      const res = await fetch(`${base}/tag-suggestions`, { headers: auth })
+      if (!res.ok) await die(res)
+      const s = await res.json()
+      if (flags.json) {
+        console.log(JSON.stringify(s))
+      } else {
+        console.log(`current:    ${s.current.length ? s.current.join(", ") : "(none)"}`)
+        console.log(
+          `suggested:  ${s.suggested.length ? s.suggested.map((x) => x.tag).join(", ") : "(none — no similar docs)"}`,
+        )
+        console.log(
+          `vocabulary: ${
+            s.vocabulary.length
+              ? s.vocabulary
+                  .slice(0, 20)
+                  .map((x) => x.tag)
+                  .join(", ")
+              : "(empty)"
+          }`,
+        )
+        if (s.suggested.length)
+          console.error(`\n  apply:  derive tag ${s.suggested.map((x) => x.tag).join(" ")}`)
+      }
+      process.exit(0)
+    }
+
+    // Apply: positional tokens add; `--rm` removes; `--set` replaces the whole set.
     const add = positional
     const remove = splitTags(flags.rm)
     const set = flags.set !== undefined ? splitTags(flags.set) : null
-    if (!add.length && !remove.length && set === null) {
-      console.error(
-        "usage: derive tag <tag…> [--rm a,b] [--set a,b] [--id short_id]\n" +
-          "  add tags (positional), remove (--rm), or replace the set (--set).",
-      )
-      process.exit(1)
-    }
     const put = async (tags) => {
       const res = await fetch(`${base}/tags`, {
         method: "PUT",

--- a/packages/cli/src/publish.d.ts
+++ b/packages/cli/src/publish.d.ts
@@ -17,6 +17,8 @@ export interface PublishFormFields {
   slug?: string
   spa?: boolean
   message?: string
+  /** Browse tags to set at publish time (JSON-encoded; server normalizes). */
+  tags?: string[]
   name?: string
   workspaceAccess?: "none" | "member"
   linkRole?: "none" | "viewer" | "commenter" | "editor"

--- a/packages/cli/src/publish.js
+++ b/packages/cli/src/publish.js
@@ -66,6 +66,7 @@ export function buildPublishForm({
   slug,
   spa,
   message,
+  tags,
   name,
   workspaceAccess,
   linkRole,
@@ -88,6 +89,9 @@ export function buildPublishForm({
   if (slug) form.append("slug", slug)
   if (spa) form.append("spa", "true")
   if (message) form.append("message", message)
+  // Browse tags: a JSON array the server normalizes (trim/lowercase/dedupe/cap). An empty
+  // array clears; omitted leaves existing tags untouched on a republish.
+  if (tags) form.append("tags", JSON.stringify(tags))
   if (name) form.append("name", name)
   // The canonical v2 access fields; an explicit field wins over the legacy
   // `visibility` alias server-side. Send only what's set (all-absent = the

--- a/packages/mcp/SKILL.md
+++ b/packages/mcp/SKILL.md
@@ -21,12 +21,16 @@ Your identity (agent name, workspace, role) is in the server instructions — th
 
 | Tool | Use |
 |---|---|
-| `list_artifacts` | Find: the artifacts in your workspace (short id, title, kind, version, visibility). Optional `query` filters by title. |
+| `list_artifacts` | Find: the artifacts in your workspace (short id, title, kind, version, visibility, and their browse `tags`). Optional `query` filters by title; `tag` filters to one browse tag. |
+| `list_tags` | The workspace tag vocabulary — every tag with how many artifacts carry it. Read it before tagging so you reuse an existing tag over a near-duplicate. |
+| `suggest_tags` | For an artifact: its current tags, `suggested` tags drawn from the most semantically-similar docs, and the full `vocabulary`. Pick the ones that fit, then apply with `tag`. |
+| `tag` | Add / remove / replace an artifact's browse tags — one artifact or many (`short_ids`). `add` (the default gesture) never drops existing tags; `set` replaces the whole set. |
+| `list_collections` / `collect` | Collections group work that belongs together. `list_collections` shows them with counts; `collect` adds artifacts to one (by id or name, creating by name). Lighter-touch than tags — reach for a tag first. |
 | `search` | Grep. Pass `short_id` to find text WITHIN one artifact — matching lines with line numbers (and optional `context`), ripgrep-style, so you can `read` a narrow `lines` range or `edit` that spot next. Omit `short_id` to grep instead ACROSS the workspace's most recently created artifacts, grouped by artifact — find WHICH doc has something before opening it. `in:'text'` searches the visible text instead of raw source; the query is matched literally (no regex metacharacters). |
 | `read` | Read an artifact's content by short id, as **Markdown by default** (HTML is converted — headings, lists, tables, code fences; a styled page still renders fully to viewers, only this reading view flattens it). Omit `section` and a small doc/bundle returns whole; a **large one returns its outline first** (heading slugs for a single-file doc, page paths for a bundle) — call again with a `section` (a slug, a bundle page, `page.html#slug`, or `"*"` for the full clipped document). Pass `format:'html'` for the exact stored source (needed before publish `edits`) or `format:'text'` for flat visible text (what comment `quote`s anchor against). Pass `version` to read history. An image page in a bundle comes back as a real image, not garbage text. |
 | `catch_up` | Start here on an artifact: its state in one call — what changed since `since_version`, the open/outdated comment threads, the `review` round state, and version history. Pass `comments` (open/addressed/resolved/outdated) for that filtered feedback queue, or `response_format='detailed'` (with optional `since_version`/`to_version`) to fold in a line diff — of the **readable Markdown form**, not raw HTML, so it shows what changed instead of tag noise. Waiting on a review? Pass `wait` (seconds, max 50) to long-poll: the call blocks until the human sends back / approves / comments — chain these instead of sleeping. |
 | `comment` | Leave feedback, reply (`reply_to` a thread id), anchor to a `quote`, react (`react: "👍"` with `reply_to` — the loop's lightweight ack, landing on the thread's latest human comment), and/or resolve/reopen (`set_state`). |
-| `publish` | Save a revision. `content` for a single file, `files` (path→content map) for a multi-page bundle, or **`edits`** (`[{old_str, new_str}]`) to revise part of a single-file artifact without resending it. Omit `short_id` to create new (title required); pass it to add a version. `addresses` lists thread ids this revision resolves; `request_review:true` opens a review round for your human. New artifacts land **private** by default (the human you act for owns the draft) — they promote via the share dialog, so don't pass a wider `visibility` unasked. The result's `opened_in_tab` says whether an open Derive tab caught the push; when false, open the `url` for the user if they should see it now. Fully-styled HTML renders as-authored in the sandboxed viewer: declare your own `<meta name="viewport">` (skips the mobile-reflow injection; `data-reflow-exempt` exempts a single element), upload images/woff2 fonts to `POST /v1/assets` instead of inlining base64, and check the echoed `content_sha256` against your local bytes. |
+| `publish` | Save a revision. `content` for a single file, `files` (path→content map) for a multi-page bundle, or **`edits`** (`[{old_str, new_str}]`) to revise part of a single-file artifact without resending it. Omit `short_id` to create new (title required); pass it to add a version. Pass **`tags`** to tag it at publish time — the one-step auto-tag. `addresses` lists thread ids this revision resolves; `request_review:true` opens a review round for your human. New artifacts land **private** by default (the human you act for owns the draft) — they promote via the share dialog, so don't pass a wider `visibility` unasked. The result's `opened_in_tab` says whether an open Derive tab caught the push; when false, open the `url` for the user if they should see it now. Fully-styled HTML renders as-authored in the sandboxed viewer: declare your own `<meta name="viewport">` (skips the mobile-reflow injection; `data-reflow-exempt` exempts a single element), upload images/woff2 fonts to `POST /v1/assets` instead of inlining base64, and check the echoed `content_sha256` against your local bytes. |
 
 ## Role decides: live publish vs proposal
 
@@ -54,6 +58,21 @@ human approves rather than live content.
    (`comment(reply_to, react:"👍")` at minimum), then revise and publish with
    `addresses` + `request_review:true` for the next round. The human never
    resolves threads — you settle thread state.
+
+## Keep the library findable — tag as you go
+
+Browse tags are how work is discovered later, so tag whenever you publish. The cheap,
+high-reuse loop:
+
+1. `list_tags` (or `suggest_tags <short_id>`) → see the vocabulary and what similar docs
+   are tagged, so you reuse an existing tag instead of minting `plan` next to `planning`.
+2. Set `tags` right on `publish` (auto-tag), or apply them after with `tag`.
+3. Find later with `list_artifacts(tag: …)`.
+
+Be generous — tagging is cheap and low-risk, and a well-tagged library is the difference
+between findable and lost. Collections (`list_collections` / `collect`) are heavier: use
+one when a set of artifacts is a real unit (a project, a release), a tag for plain
+findability.
 
 ## Reading big documents
 

--- a/packages/mcp/SKILL.md
+++ b/packages/mcp/SKILL.md
@@ -22,10 +22,7 @@ Your identity (agent name, workspace, role) is in the server instructions — th
 | Tool | Use |
 |---|---|
 | `list_artifacts` | Find: the artifacts in your workspace (short id, title, kind, version, visibility, and their browse `tags`). Optional `query` filters by title; `tag` filters to one browse tag. |
-| `list_tags` | The workspace tag vocabulary — every tag with how many artifacts carry it. Read it before tagging so you reuse an existing tag over a near-duplicate. |
-| `suggest_tags` | For an artifact: its current tags, `suggested` tags drawn from the most semantically-similar docs, and the full `vocabulary`. Pick the ones that fit, then apply with `tag`. |
-| `tag` | Add / remove / replace an artifact's browse tags — one artifact or many (`short_ids`). `add` (the default gesture) never drops existing tags; `set` replaces the whole set. |
-| `list_collections` / `collect` | Collections group work that belongs together. `list_collections` shows them with counts; `collect` adds artifacts to one (by id or name, creating by name). Lighter-touch than tags — reach for a tag first. |
+| `organize` | Tags + collections in one tool. **No `short_ids`** → the workspace's tag vocabulary + collections (read this before tagging to reuse a tag). **With `short_ids`** → those artifacts' tags + collections + `suggested` tags from similar docs. **`add`/`remove`/`set`** change tags; **`collection`** (id or name, created if new) folds them into a collection. Ones you can't touch are skipped. |
 | `search` | Grep. Pass `short_id` to find text WITHIN one artifact — matching lines with line numbers (and optional `context`), ripgrep-style, so you can `read` a narrow `lines` range or `edit` that spot next. Omit `short_id` to grep instead ACROSS the workspace's most recently created artifacts, grouped by artifact — find WHICH doc has something before opening it. `in:'text'` searches the visible text instead of raw source; the query is matched literally (no regex metacharacters). |
 | `read` | Read an artifact's content by short id, as **Markdown by default** (HTML is converted — headings, lists, tables, code fences; a styled page still renders fully to viewers, only this reading view flattens it). Omit `section` and a small doc/bundle returns whole; a **large one returns its outline first** (heading slugs for a single-file doc, page paths for a bundle) — call again with a `section` (a slug, a bundle page, `page.html#slug`, or `"*"` for the full clipped document). Pass `format:'html'` for the exact stored source (needed before publish `edits`) or `format:'text'` for flat visible text (what comment `quote`s anchor against). Pass `version` to read history. An image page in a bundle comes back as a real image, not garbage text. |
 | `catch_up` | Start here on an artifact: its state in one call — what changed since `since_version`, the open/outdated comment threads, the `review` round state, and version history. Pass `comments` (open/addressed/resolved/outdated) for that filtered feedback queue, or `response_format='detailed'` (with optional `since_version`/`to_version`) to fold in a line diff — of the **readable Markdown form**, not raw HTML, so it shows what changed instead of tag noise. Waiting on a review? Pass `wait` (seconds, max 50) to long-poll: the call blocks until the human sends back / approves / comments — chain these instead of sleeping. |
@@ -62,17 +59,18 @@ human approves rather than live content.
 ## Keep the library findable — tag as you go
 
 Browse tags are how work is discovered later, so tag whenever you publish. The cheap,
-high-reuse loop:
+high-reuse loop, all through the one `organize` tool:
 
-1. `list_tags` (or `suggest_tags <short_id>`) → see the vocabulary and what similar docs
-   are tagged, so you reuse an existing tag instead of minting `plan` next to `planning`.
-2. Set `tags` right on `publish` (auto-tag), or apply them after with `tag`.
+1. `organize()` (no args) or `organize({short_ids: ["x"]})` → see the vocabulary and what
+   similar docs are tagged, so you reuse an existing tag instead of minting `plan` next to
+   `planning`.
+2. Set `tags` right on `publish` (auto-tag), or apply after with
+   `organize({short_ids, add: […]})`.
 3. Find later with `list_artifacts(tag: …)`.
 
 Be generous — tagging is cheap and low-risk, and a well-tagged library is the difference
-between findable and lost. Collections (`list_collections` / `collect`) are heavier: use
-one when a set of artifacts is a real unit (a project, a release), a tag for plain
-findability.
+between findable and lost. Collections are heavier: `organize({short_ids, collection})`
+when a set of artifacts is a real unit (a project, a release), a tag for plain findability.
 
 ## Reading big documents
 

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -147,6 +147,8 @@ export interface ArtifactJson {
   versions: VersionJson[]
   /** Browse tags — present on the detail endpoint (newer servers). */
   tags?: string[]
+  /** Collection ids this artifact belongs to — present on the detail endpoint. */
+  collections?: string[]
   /** Time-grouped version view (newest-first); present on the detail endpoint. */
   sessions?: SessionJson[]
   /** Publish-response extras (agent-credentialed publishes only). */
@@ -235,10 +237,10 @@ export interface DeriveClient {
   ): Promise<TagResultJson>
   /** The workspace's team-visible collections with item counts. */
   listCollections(): Promise<CollectionSummaryJson[]>
-  /** Add artifacts to a collection by id or name (creating the collection by name). */
+  /** Add artifacts to a collection identified by id OR name (created if a new name). */
   collect(
     shortIds: string[],
-    target: { collectionId?: string; collection?: string },
+    ref: string,
   ): Promise<{ collection: { id: string; title: string }; added: number; skipped: number }>
   publish(args: PublishArgs): Promise<ArtifactJson>
   /** Submit a single-file revision for human review (does not go live). */
@@ -403,36 +405,28 @@ export function createClient(opts: ClientOptions): DeriveClient {
       return r.collections.map((c) => ({ id: c.id, title: c.title, count: c.count }))
     },
 
-    async collect(shortIds, target) {
-      // Resolve the collection: an explicit id, else match/create by name.
-      let collectionId = target.collectionId
-      let title = ""
+    async collect(shortIds, ref) {
+      // Resolve `ref` against the workspace's collections by id OR title, else create it.
+      const name = ref.trim()
       const cols = (
         (await ok(await f(`${base}/v1/collections`, { headers: authHeaders }))) as {
           collections: { id: string; title: string }[]
         }
       ).collections
-      if (collectionId) {
-        title = cols.find((c) => c.id === collectionId)?.title ?? ""
-      } else if (target.collection?.trim()) {
-        const name = target.collection.trim()
-        const existing = cols.find((c) => c.title.toLowerCase() === name.toLowerCase())
-        if (existing) {
-          collectionId = existing.id
-          title = existing.title
-        } else {
-          const created = (await ok(
-            await f(`${base}/v1/collections`, {
-              method: "POST",
-              headers: { ...authHeaders, "content-type": "application/json" },
-              body: JSON.stringify({ title: name }),
-            }),
-          )) as { id: string; title: string }
-          collectionId = created.id
-          title = created.title
-        }
+      const match = cols.find((c) => c.id === name || c.title.toLowerCase() === name.toLowerCase())
+      let collectionId = match?.id
+      let title = match?.title ?? ""
+      if (!collectionId) {
+        const created = (await ok(
+          await f(`${base}/v1/collections`, {
+            method: "POST",
+            headers: { ...authHeaders, "content-type": "application/json" },
+            body: JSON.stringify({ title: name }),
+          }),
+        )) as { id: string; title: string }
+        collectionId = created.id
+        title = created.title
       }
-      if (!collectionId) throw new Error("collect: pass a collectionId or a collection name")
       const r = (await ok(
         await f(`${base}/v1/bulk/collections`, {
           method: "POST",

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -17,6 +17,9 @@ export interface PublishArgs {
   slug?: string
   spa?: boolean
   message?: string
+  /** Browse tags to set on the artifact at publish time. Given ⇒ replaces the set;
+   *  omitted ⇒ leaves existing tags untouched on a republish. */
+  tags?: string[]
   /** The v2 access triple for a NEW artifact (see access-model.md); ignored on a
    *  republish. */
   workspaceAccess?: WorkspaceAccess
@@ -61,6 +64,30 @@ export interface ArtifactSummaryJson {
   workspace_access?: string
   link_role?: string
   listed?: string
+  /** Browse tags on the artifact — present when the server returns them (newer servers). */
+  tags?: string[]
+}
+
+export interface TagCountJson {
+  tag: string
+  count: number
+}
+export interface TagSuggestionsJson {
+  current: string[]
+  suggested: TagCountJson[]
+  vocabulary: TagCountJson[]
+}
+/** The result of adding/removing/replacing tags across one or many artifacts. */
+export interface TagResultJson {
+  updated: number
+  skipped: number
+  failed: number
+  results: { short_id: string; tags: string[] }[]
+}
+export interface CollectionSummaryJson {
+  id: string
+  title: string
+  count: number
 }
 
 /** A revision submitted for human review instead of published live. */
@@ -118,6 +145,8 @@ export interface ArtifactJson {
   listed?: string
   current_version: number
   versions: VersionJson[]
+  /** Browse tags — present on the detail endpoint (newer servers). */
+  tags?: string[]
   /** Time-grouped version view (newest-first); present on the detail endpoint. */
   sessions?: SessionJson[]
   /** Publish-response extras (agent-credentialed publishes only). */
@@ -192,8 +221,25 @@ export interface SearchOpts {
 }
 
 export interface DeriveClient {
-  /** List the workspace's artifacts (optionally filtered by a title query). */
-  list(query?: string): Promise<ArtifactSummaryJson[]>
+  /** List the workspace's artifacts (optionally filtered by a title query and/or a browse tag). */
+  list(query?: string, tag?: string): Promise<ArtifactSummaryJson[]>
+  /** The workspace tag vocabulary (tag → count, most-used first). */
+  listTags(): Promise<TagCountJson[]>
+  /** Suggest tags for an artifact: its current tags, neighbors' tags, and the vocabulary. */
+  suggestTags(shortId: string): Promise<TagSuggestionsJson>
+  /** Add/remove/replace browse tags across one or more artifacts. `set` replaces the
+   *  whole set (overriding add/remove); otherwise add then remove. */
+  tag(
+    shortIds: string[],
+    ops: { add?: string[]; remove?: string[]; set?: string[] },
+  ): Promise<TagResultJson>
+  /** The workspace's team-visible collections with item counts. */
+  listCollections(): Promise<CollectionSummaryJson[]>
+  /** Add artifacts to a collection by id or name (creating the collection by name). */
+  collect(
+    shortIds: string[],
+    target: { collectionId?: string; collection?: string },
+  ): Promise<{ collection: { id: string; title: string }; added: number; skipped: number }>
   publish(args: PublishArgs): Promise<ArtifactJson>
   /** Submit a single-file revision for human review (does not go live). */
   propose(shortId: string, args: ProposeArgs): Promise<ProposalJson>
@@ -255,12 +301,146 @@ export function createClient(opts: ClientOptions): DeriveClient {
   }
 
   return {
-    async list(query) {
-      const q = query ? `?query=${encodeURIComponent(query)}` : ""
+    async list(query, tag) {
+      const qs = new URLSearchParams()
+      if (query) qs.set("query", query)
+      if (tag) qs.set("tag", tag.trim().toLowerCase())
+      const q = qs.toString() ? `?${qs}` : ""
       const r = (await ok(await f(`${base}/v1/artifacts${q}`, { headers: authHeaders }))) as {
         artifacts: ArtifactSummaryJson[]
       }
       return r.artifacts
+    },
+
+    async listTags() {
+      const r = (await ok(await f(`${base}/v1/tags`, { headers: authHeaders }))) as {
+        tags: TagCountJson[]
+      }
+      return (r.tags ?? []).slice().sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
+    },
+
+    async suggestTags(shortId) {
+      return ok(
+        await f(`${base}/v1/artifacts/${shortId}/tag-suggestions`, { headers: authHeaders }),
+      ) as Promise<TagSuggestionsJson>
+    },
+
+    async tag(shortIds, ops) {
+      // `set` replaces the whole set in one bulk call. Otherwise apply the additive `add`
+      // (the bulk-add route merges per artifact) and/or `remove` — each a bulk call over
+      // the same id set, so the server does the per-artifact authorization + skip counting.
+      const post = (path: string, body: unknown) =>
+        f(`${base}${path}`, {
+          method: "POST",
+          headers: { ...authHeaders, "content-type": "application/json" },
+          body: JSON.stringify(body),
+        })
+      if (ops.set) {
+        // No bulk "set" route; set each artifact's tags directly (the union with nothing).
+        const results: { short_id: string; tags: string[] }[] = []
+        let updated = 0
+        let failed = 0
+        for (const id of shortIds) {
+          try {
+            const r = (await ok(
+              await f(`${base}/v1/artifacts/${id}/tags`, {
+                method: "PUT",
+                headers: { ...authHeaders, "content-type": "application/json" },
+                body: JSON.stringify({ tags: ops.set }),
+              }),
+            )) as { tags: string[] }
+            results.push({ short_id: id, tags: r.tags })
+            updated++
+          } catch {
+            failed++
+          }
+        }
+        return { updated, skipped: 0, failed, results }
+      }
+      let updated = 0
+      let skipped = 0
+      let failed = 0
+      if (ops.add?.length) {
+        const r = (await ok(await post("/v1/bulk/tags", { shortIds, add: ops.add }))) as {
+          ok: number
+          skipped: number
+          failed: number
+        }
+        updated = r.ok
+        skipped = r.skipped
+        failed = r.failed
+      }
+      if (ops.remove?.length) {
+        // No bulk-remove route: read-modify-write each artifact via the single tag route.
+        const removeSet = new Set(ops.remove.map((t) => t.trim().toLowerCase()))
+        for (const id of shortIds) {
+          try {
+            const a = await (ok(
+              await f(`${base}/v1/artifacts/${id}`, { headers: authHeaders }),
+            ) as Promise<{
+              tags?: string[]
+            }>)
+            const next = (a.tags ?? []).filter((t) => !removeSet.has(t))
+            await ok(
+              await f(`${base}/v1/artifacts/${id}/tags`, {
+                method: "PUT",
+                headers: { ...authHeaders, "content-type": "application/json" },
+                body: JSON.stringify({ tags: next }),
+              }),
+            )
+          } catch {
+            /* a remove miss (not editable) is reflected by the add pass's skipped, or ignored */
+          }
+        }
+      }
+      return { updated, skipped, failed, results: [] }
+    },
+
+    async listCollections() {
+      const r = (await ok(await f(`${base}/v1/collections`, { headers: authHeaders }))) as {
+        collections: { id: string; title: string; count: number }[]
+      }
+      return r.collections.map((c) => ({ id: c.id, title: c.title, count: c.count }))
+    },
+
+    async collect(shortIds, target) {
+      // Resolve the collection: an explicit id, else match/create by name.
+      let collectionId = target.collectionId
+      let title = ""
+      const cols = (
+        (await ok(await f(`${base}/v1/collections`, { headers: authHeaders }))) as {
+          collections: { id: string; title: string }[]
+        }
+      ).collections
+      if (collectionId) {
+        title = cols.find((c) => c.id === collectionId)?.title ?? ""
+      } else if (target.collection?.trim()) {
+        const name = target.collection.trim()
+        const existing = cols.find((c) => c.title.toLowerCase() === name.toLowerCase())
+        if (existing) {
+          collectionId = existing.id
+          title = existing.title
+        } else {
+          const created = (await ok(
+            await f(`${base}/v1/collections`, {
+              method: "POST",
+              headers: { ...authHeaders, "content-type": "application/json" },
+              body: JSON.stringify({ title: name }),
+            }),
+          )) as { id: string; title: string }
+          collectionId = created.id
+          title = created.title
+        }
+      }
+      if (!collectionId) throw new Error("collect: pass a collectionId or a collection name")
+      const r = (await ok(
+        await f(`${base}/v1/bulk/collections`, {
+          method: "POST",
+          headers: { ...authHeaders, "content-type": "application/json" },
+          body: JSON.stringify({ shortIds, collectionIds: [collectionId] }),
+        }),
+      )) as { ok: number; skipped: number }
+      return { collection: { id: collectionId, title }, added: r.ok, skipped: r.skipped }
     },
 
     async publish(args) {
@@ -280,6 +460,7 @@ export function createClient(opts: ClientOptions): DeriveClient {
         slug: args.slug,
         spa: args.spa,
         message: args.message,
+        tags: args.tags,
         workspaceAccess: args.workspaceAccess,
         linkRole: args.linkRole,
         listed: args.listed,

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -617,100 +617,72 @@ server.registerTool(
   },
 )
 
-// TAGS — discover the vocabulary, suggest from similar docs, apply ------------
+// ORGANIZE — ONE tool for the library's findability metadata: tags + collections,
+// read + write. Replaces the old list_tags/suggest_tags/tag/list_collections/collect.
 server.registerTool(
-  "list_tags",
+  "organize",
   {
     description:
-      "The workspace's browse-tag vocabulary — every tag with how many artifacts carry it, most-used first. Call this BEFORE tagging so you reuse an existing tag instead of minting a near-duplicate; it's how the library stays findable. Then list_artifacts(tag:…) to see what's under a tag.",
-    inputSchema: { workspace: wsArg },
-  },
-  async ({ workspace: ws }) => {
-    const tags = await clientFor(ws).listTags()
-    return json({ count: tags.length, tags })
-  },
-)
-
-server.registerTool(
-  "suggest_tags",
-  {
-    description:
-      "Suggest browse tags for an artifact: its current tags, `suggested` tags drawn from the most semantically-similar artifacts (so you reuse how similar things are already tagged), and the full `vocabulary`. Pick the ones that fit — reuse a suggestion or vocabulary entry over a new coinage — then apply them with `tag` (or set them on `publish`). Tagging is cheap; be generous.",
+      "Tags and collections in one tool — the library's findability layer.\n" +
+      "• READ (no `short_ids`): the workspace's tag vocabulary (tag → count) and its collections. Call this before tagging to reuse an existing tag over a near-duplicate.\n" +
+      "• READ (with `short_ids`): those artifacts' current tags + collections, plus `suggested` tags drawn from the most semantically-similar docs (when one id is given).\n" +
+      "• WRITE: pass `add`/`remove`/`set` to change tags (add never drops existing; set replaces the whole set), and/or `collection` (an id, or a name — created if new) to fold the artifacts into a collection. Each artifact is authorized on its own; ones you can't touch are skipped.\n" +
+      "Tag freely and reuse the vocabulary — a well-tagged library is findable. Collections are heavier: a tag for plain findability, a collection when a set is a real unit.",
     inputSchema: {
-      short_id: z.string().describe("The artifact to suggest tags for."),
-      workspace: wsArg,
-    },
-  },
-  async ({ short_id, workspace: ws }) => {
-    try {
-      return json({ short_id, ...(await clientFor(ws).suggestTags(short_id)) })
-    } catch (e) {
-      return err(e instanceof Error ? e.message : "suggest_tags failed")
-    }
-  },
-)
-
-server.registerTool(
-  "tag",
-  {
-    description:
-      "Add, remove, or replace an artifact's browse tags — one artifact or many. Pass `add` and/or `remove` to adjust the set (add never drops existing tags), or `set` to replace it wholesale. Tags are normalized (trimmed, lowercased, deduped, capped 20); artifacts you can't edit are skipped. Tag freely and reuse the vocabulary (list_tags / suggest_tags) so the library stays findable.",
-    inputSchema: {
-      short_ids: z.array(z.string()).min(1).describe("One or more artifact short ids to tag."),
-      add: z.array(z.string()).optional().describe("Tags to add (union with the existing set)."),
+      short_ids: z
+        .array(z.string())
+        .optional()
+        .describe("Artifacts to inspect or organize. Omit for the workspace overview."),
+      add: z.array(z.string()).optional().describe("Tags to add (union; never drops existing)."),
       remove: z.array(z.string()).optional().describe("Tags to remove."),
       set: z
         .array(z.string())
         .optional()
-        .describe("Replace the WHOLE set with exactly these (overrides add/remove)."),
+        .describe("Replace the whole tag set (overrides add/remove)."),
+      collection: z
+        .string()
+        .optional()
+        .describe("Fold `short_ids` into this collection — an id, or a name (created if new)."),
       workspace: wsArg,
     },
   },
-  async ({ short_ids, add, remove, set, workspace: ws }) => {
-    if (!add && !remove && !set) return text("Pass at least one of `add`, `remove`, or `set`.")
+  async ({ short_ids, add, remove, set, collection, workspace: ws }) => {
+    const client = clientFor(ws)
     try {
-      return json(await clientFor(ws).tag(short_ids, { add, remove, set }))
+      // WRITE
+      if (add || remove || set || collection) {
+        if (!short_ids?.length)
+          return text("Pass `short_ids` to organize (with add/remove/set and/or collection).")
+        const out: Record<string, unknown> = {}
+        if (add || remove || set) out.tagged = await client.tag(short_ids, { add, remove, set })
+        if (collection) out.collected = await client.collect(short_ids, collection)
+        return json(out)
+      }
+      // READ: inspect specific artifacts
+      if (short_ids?.length) {
+        const artifacts = await Promise.all(
+          short_ids.map(async (id) => {
+            const a = await client.get(id)
+            return { short_id: id, tags: a.tags ?? [], collections: a.collections ?? [] }
+          }),
+        )
+        // Suggestions only for a single artifact (aggregating across many is ambiguous).
+        const only = short_ids.length === 1 ? short_ids[0] : undefined
+        const suggested = only ? (await client.suggestTags(only)).suggested : undefined
+        return json({
+          artifacts,
+          ...(suggested ? { suggested } : {}),
+          vocabulary: (await client.listTags()).slice(0, 50),
+        })
+      }
+      // READ: workspace overview
+      const [vocabulary, collections] = await Promise.all([
+        client.listTags(),
+        client.listCollections(),
+      ])
+      return json({ vocabulary, collections })
     } catch (e) {
-      return err(e instanceof Error ? e.message : "tag failed")
-    }
-  },
-)
-
-// COLLECTIONS (light) — see and route into them -------------------------------
-server.registerTool(
-  "list_collections",
-  {
-    description:
-      "The workspace's collections — shareable groups of artifacts — with each one's item count. A read-only overview so you can route work into an existing collection with `collect` instead of scattering it.",
-    inputSchema: { workspace: wsArg },
-  },
-  async ({ workspace: ws }) => {
-    const collections = await clientFor(ws).listCollections()
-    return json({ count: collections.length, collections })
-  },
-)
-
-server.registerTool(
-  "collect",
-  {
-    description:
-      "Add one or more artifacts to a collection — by `collection_id` (from list_collections) or by `collection` name, creating that collection if none matches. Adding to a shared collection re-shares the artifacts to its members. Collections are heavier than tags — reach for a tag first for plain findability, a collection when a set genuinely belongs together.",
-    inputSchema: {
-      short_ids: z.array(z.string()).min(1).describe("Artifact short ids to add."),
-      collection_id: z.string().optional().describe("An existing collection's id."),
-      collection: z.string().optional().describe("A collection name — matched, else created."),
-      workspace: wsArg,
-    },
-  },
-  async ({ short_ids, collection_id, collection, workspace: ws }) => {
-    if (!collection_id && !collection?.trim())
-      return text("Pass a `collection_id` or a `collection` name.")
-    try {
-      return json(
-        await clientFor(ws).collect(short_ids, { collectionId: collection_id, collection }),
-      )
-    } catch (e) {
-      return err(e instanceof Error ? e.message : "collect failed")
+      return err(e instanceof Error ? e.message : "organize failed")
     }
   },
 )

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -188,7 +188,7 @@ server.registerTool(
   "list_artifacts",
   {
     description:
-      "List the artifacts in your workspace — short id, title, kind, current version, access, and browse `tags`. Defaults to this session's workspace; pass `workspace` (id or name from list_workspaces) to list another. Pass `tag` to list only artifacts carrying that tag (list_tags shows the vocabulary). Start here to find what to work on, then catch_up or read it.",
+      "List the artifacts in your workspace — short id, title, kind, current version, access, and browse `tags`. Defaults to this session's workspace; pass `workspace` (id or name from list_workspaces) to list another. Pass `tag` to list only artifacts carrying that tag (organize shows the vocabulary). Start here to find what to work on, then catch_up or read it.",
     inputSchema: {
       query: z.string().optional().describe("Optional title search filter."),
       tag: z
@@ -742,7 +742,7 @@ server.registerTool(
         .array(z.string())
         .optional()
         .describe(
-          "Browse tags to set on the artifact — labels that make it findable (list_tags shows the vocabulary; suggest_tags proposes from similar docs). Reuse an existing tag over a near-duplicate. Given ⇒ replaces the set; omitted ⇒ leaves existing tags untouched on a republish.",
+          "Browse tags to set on the artifact — labels that make it findable (organize shows the vocabulary and proposes tags from similar docs). Reuse an existing tag over a near-duplicate. Given ⇒ replaces the set; omitted ⇒ leaves existing tags untouched on a republish.",
         ),
       // The v2 access triple for a NEW artifact (see access-model.md); omit any to
       // take the workspace default (the team draft — the human you act for owns it

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -188,14 +188,18 @@ server.registerTool(
   "list_artifacts",
   {
     description:
-      "List the artifacts in your workspace — short id, title, kind, current version, access. Defaults to this session's workspace; pass `workspace` (id or name from list_workspaces) to list another. Start here to find what to work on, then catch_up or read it.",
+      "List the artifacts in your workspace — short id, title, kind, current version, access, and browse `tags`. Defaults to this session's workspace; pass `workspace` (id or name from list_workspaces) to list another. Pass `tag` to list only artifacts carrying that tag (list_tags shows the vocabulary). Start here to find what to work on, then catch_up or read it.",
     inputSchema: {
       query: z.string().optional().describe("Optional title search filter."),
+      tag: z
+        .string()
+        .optional()
+        .describe("Only artifacts carrying this browse tag (case-insensitive)."),
       workspace: wsArg,
     },
   },
-  async ({ query, workspace: ws }) => {
-    const arts = await clientFor(ws).list(query)
+  async ({ query, tag, workspace: ws }) => {
+    const arts = await clientFor(ws).list(query, tag)
     return json({ count: arts.length, artifacts: arts })
   },
 )
@@ -613,6 +617,104 @@ server.registerTool(
   },
 )
 
+// TAGS — discover the vocabulary, suggest from similar docs, apply ------------
+server.registerTool(
+  "list_tags",
+  {
+    description:
+      "The workspace's browse-tag vocabulary — every tag with how many artifacts carry it, most-used first. Call this BEFORE tagging so you reuse an existing tag instead of minting a near-duplicate; it's how the library stays findable. Then list_artifacts(tag:…) to see what's under a tag.",
+    inputSchema: { workspace: wsArg },
+  },
+  async ({ workspace: ws }) => {
+    const tags = await clientFor(ws).listTags()
+    return json({ count: tags.length, tags })
+  },
+)
+
+server.registerTool(
+  "suggest_tags",
+  {
+    description:
+      "Suggest browse tags for an artifact: its current tags, `suggested` tags drawn from the most semantically-similar artifacts (so you reuse how similar things are already tagged), and the full `vocabulary`. Pick the ones that fit — reuse a suggestion or vocabulary entry over a new coinage — then apply them with `tag` (or set them on `publish`). Tagging is cheap; be generous.",
+    inputSchema: {
+      short_id: z.string().describe("The artifact to suggest tags for."),
+      workspace: wsArg,
+    },
+  },
+  async ({ short_id, workspace: ws }) => {
+    try {
+      return json({ short_id, ...(await clientFor(ws).suggestTags(short_id)) })
+    } catch (e) {
+      return err(e instanceof Error ? e.message : "suggest_tags failed")
+    }
+  },
+)
+
+server.registerTool(
+  "tag",
+  {
+    description:
+      "Add, remove, or replace an artifact's browse tags — one artifact or many. Pass `add` and/or `remove` to adjust the set (add never drops existing tags), or `set` to replace it wholesale. Tags are normalized (trimmed, lowercased, deduped, capped 20); artifacts you can't edit are skipped. Tag freely and reuse the vocabulary (list_tags / suggest_tags) so the library stays findable.",
+    inputSchema: {
+      short_ids: z.array(z.string()).min(1).describe("One or more artifact short ids to tag."),
+      add: z.array(z.string()).optional().describe("Tags to add (union with the existing set)."),
+      remove: z.array(z.string()).optional().describe("Tags to remove."),
+      set: z
+        .array(z.string())
+        .optional()
+        .describe("Replace the WHOLE set with exactly these (overrides add/remove)."),
+      workspace: wsArg,
+    },
+  },
+  async ({ short_ids, add, remove, set, workspace: ws }) => {
+    if (!add && !remove && !set) return text("Pass at least one of `add`, `remove`, or `set`.")
+    try {
+      return json(await clientFor(ws).tag(short_ids, { add, remove, set }))
+    } catch (e) {
+      return err(e instanceof Error ? e.message : "tag failed")
+    }
+  },
+)
+
+// COLLECTIONS (light) — see and route into them -------------------------------
+server.registerTool(
+  "list_collections",
+  {
+    description:
+      "The workspace's collections — shareable groups of artifacts — with each one's item count. A read-only overview so you can route work into an existing collection with `collect` instead of scattering it.",
+    inputSchema: { workspace: wsArg },
+  },
+  async ({ workspace: ws }) => {
+    const collections = await clientFor(ws).listCollections()
+    return json({ count: collections.length, collections })
+  },
+)
+
+server.registerTool(
+  "collect",
+  {
+    description:
+      "Add one or more artifacts to a collection — by `collection_id` (from list_collections) or by `collection` name, creating that collection if none matches. Adding to a shared collection re-shares the artifacts to its members. Collections are heavier than tags — reach for a tag first for plain findability, a collection when a set genuinely belongs together.",
+    inputSchema: {
+      short_ids: z.array(z.string()).min(1).describe("Artifact short ids to add."),
+      collection_id: z.string().optional().describe("An existing collection's id."),
+      collection: z.string().optional().describe("A collection name — matched, else created."),
+      workspace: wsArg,
+    },
+  },
+  async ({ short_ids, collection_id, collection, workspace: ws }) => {
+    if (!collection_id && !collection?.trim())
+      return text("Pass a `collection_id` or a `collection` name.")
+    try {
+      return json(
+        await clientFor(ws).collect(short_ids, { collectionId: collection_id, collection }),
+      )
+    } catch (e) {
+      return err(e instanceof Error ? e.message : "collect failed")
+    }
+  },
+)
+
 // WRITE — publish live, or file a proposal for review -------------------------
 server.registerTool(
   "publish",
@@ -664,6 +766,12 @@ server.registerTool(
         .optional()
         .describe("Omit to create a new artifact; pass it to add a version."),
       title: z.string().optional(),
+      tags: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Browse tags to set on the artifact — labels that make it findable (list_tags shows the vocabulary; suggest_tags proposes from similar docs). Reuse an existing tag over a near-duplicate. Given ⇒ replaces the set; omitted ⇒ leaves existing tags untouched on a republish.",
+        ),
       // The v2 access triple for a NEW artifact (see access-model.md); omit any to
       // take the workspace default (the team draft — the human you act for owns it
       // and promotes it when ready). Ignored on a republish.
@@ -696,6 +804,7 @@ server.registerTool(
     filename,
     short_id,
     title,
+    tags,
     workspace_access,
     link_role,
     listed,
@@ -767,6 +876,7 @@ server.registerTool(
               ? undefined
               : fallbackFilename(content)),
         title,
+        tags,
         workspaceAccess: workspace_access,
         linkRole: link_role,
         listed,

--- a/packages/mcp/test/client.test.ts
+++ b/packages/mcp/test/client.test.ts
@@ -385,3 +385,64 @@ describe("createClient — workspace targeting", () => {
     expect(headers["X-Derive-Workspace"]).toBeUndefined()
   })
 })
+
+// The tag/collection client methods that back the local MCP `organize` tool, exercised
+// over the same real in-process HTTP server. (The dense-arm suggestion path has no embedder
+// here, so suggestTags returns the vocabulary-only fallback — the semantic aggregation is
+// covered by a computeTagSuggestions unit test in apps/api.)
+describe("organize backend: tags + collections client methods over real HTTP", () => {
+  it("publish sets tags; list(tag) filters; get + list carry them", async () => {
+    const a = await client.publish({
+      content: "# A",
+      title: "Alpha",
+      tags: ["Q3 Plan", "planning"],
+    })
+    await client.publish({ content: "# B", title: "Beta", tags: ["planning"] })
+    // Normalized (lowercase, whitespace-collapsed, sorted) on the detail read.
+    expect((await client.get(a.short_id)).tags).toEqual(["planning", "q3 plan"])
+    // Tag filter narrows the listing; each row carries its tags.
+    const listed = await client.list(undefined, "q3 plan")
+    expect(listed.map((x) => x.short_id)).toEqual([a.short_id])
+    expect(listed[0]?.tags).toEqual(["planning", "q3 plan"])
+  })
+
+  it("listTags returns the vocabulary with counts, most-used first", async () => {
+    const vocab = await client.listTags()
+    expect(vocab.find((t) => t.tag === "planning")?.count).toBe(2)
+    // Sorted by count desc — the most-used tag leads.
+    expect(vocab[0]?.count).toBeGreaterThanOrEqual(vocab[vocab.length - 1]?.count ?? 0)
+  })
+
+  it("tag add unions, remove drops, set replaces", async () => {
+    const { short_id } = await client.publish({ content: "# T", title: "Tagme", tags: ["keep"] })
+    const added = await client.tag([short_id], { add: ["extra"] })
+    expect(added.updated).toBe(1)
+    expect((await client.get(short_id)).tags).toEqual(["extra", "keep"])
+    await client.tag([short_id], { remove: ["keep"] })
+    expect((await client.get(short_id)).tags).toEqual(["extra"])
+    await client.tag([short_id], { set: ["only"] })
+    expect((await client.get(short_id)).tags).toEqual(["only"])
+  })
+
+  it("suggestTags returns current tags + vocabulary (no dense arm ⇒ empty suggestions)", async () => {
+    const { short_id } = await client.publish({ content: "# S", title: "Subj", tags: ["draft"] })
+    const s = await client.suggestTags(short_id)
+    expect(s.current).toEqual(["draft"])
+    expect(s.suggested).toEqual([])
+    expect(s.vocabulary.map((t) => t.tag)).toContain("planning")
+  })
+
+  it("collect creates a collection by name and folds artifacts in; get shows membership", async () => {
+    const a = await client.publish({ content: "# 1", title: "One" })
+    const b = await client.publish({ content: "# 2", title: "Two" })
+    const res = await client.collect([a.short_id, b.short_id], "Q3 Work")
+    expect(res.added).toBe(2)
+    expect(res.collection.title).toBe("Q3 Work")
+    expect((await client.get(a.short_id)).collections).toContain(res.collection.id)
+    // Same name again resolves to the SAME collection (matched, not duplicated).
+    const c = await client.publish({ content: "# 3", title: "Three" })
+    const again = await client.collect([c.short_id], "Q3 Work")
+    expect(again.collection.id).toBe(res.collection.id)
+    expect((await client.listCollections()).find((x) => x.id === res.collection.id)?.count).toBe(3)
+  })
+})


### PR DESCRIPTION
Follow-on to #462 (multi-select bar + bulk routes, merged): make the library **findable and taggable by agents** — through a **single tool**.

## `organize` — one tool, both MCP servers

Tags and collections, read and write, dispatched by which params are present (Derive's `catch_up`/`comment` pattern — no action enum):

| Call | Does |
|---|---|
| `organize()` | Workspace overview — the tag **vocabulary** (tag → count) + collections. Read this before tagging to reuse a tag over a near-duplicate. |
| `organize({short_ids})` | Those artifacts' current tags + collections, plus **`suggested`** tags from their semantically-similar neighbors (single id). |
| `organize({short_ids, add / remove / set})` | Change tags — `add` never drops existing, `set` replaces. |
| `organize({short_ids, collection})` | Fold into a collection (id or name — created if new). |

Each artifact is authorized on its own (publish to tag, share to collect); what you can't touch is skipped. Replaces the five point-tools from the first draft (`list_tags` / `suggest_tags` / `tag` / `list_collections` / `collect`) — **tool count on each MCP server drops from 14 back to 10.**

**Also:** `list_artifacts` gains a `tag` filter + returns tags; `publish` gains a `tags` param (auto-tag on create). **CLI:** one `derive tag` verb — bare = vocabulary, `--suggest` = suggestions, positional/`--rm`/`--set` = apply. Plus `derive publish --tags a,b`.

## How aggressive

Tools + guidance, **no server-side LLM**. The agent decides; the MCP server instructions + `SKILL.md` nudge tag-as-you-go (reuse the vocabulary, be generous; collections for real units). More aggressive on tags, lighter on collections.

## Server internals (unchanged by the consolidation)

- `lib/tags.ts` — one shared `normalizeTags` across the single route, bulk route, publish, and the tool.
- `lib/tag-suggestions.ts` — `computeTagSuggestions`, shared by `GET /v1/artifacts/{shortId}/tag-suggestions` and the tool; embeds the doc's own text to find neighbors, re-applies visibility, falls back to vocabulary-only with no embedder.

## Verification

- `pnpm typecheck` ✓ · `pnpm run ci` (biome + 16 guardrails, incl. `check-api-types`, `authz-coverage`) ✓ · `pnpm test` — full suite green (api 1076, mcp 27).
- MCP smoke drives the whole `organize` surface (overview → filter → apply → inspect+suggest, and collection-by-name → membership); API tests cover publish-tags normalize/merge/clear, `?tag=` filter, and the suggestions fallback.

Rebased cleanly onto merged main. Merge left to Anir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)