### PR TITLE
fix(slack): close two cross-increment leaks from a consolidation review

### DIFF
--- a/apps/api/src/lib/slack-comments.ts
+++ b/apps/api/src/lib/slack-comments.ts
@@ -43,6 +43,9 @@ export const enqueueSlackComment = async (
 ): Promise<void> => {
   const { meta, baseUrl } = deps
   if (parseMeta(cm.meta).slack) return // came from Slack — don't echo back
+  // Only mirror feed-visible artifacts (same gate as the event cards): a comment on a private
+  // draft must not post its title + body to the org-wide channel where non-collaborators see it.
+  if (artifact.listed === "none") return
   const install = await meta.getSlackInstall(artifact.org_id)
   if (!install?.default_channel) return
   const link = commentDeepLink(baseUrl, artifact, cm.thread_id)
@@ -187,25 +190,28 @@ export const threadStateBlocks = (
   state: "open" | "resolved",
   value: string,
   who?: string,
-): unknown[] =>
-  state === "resolved"
+): unknown[] => {
+  const w = who ? escapeMrkdwn(who) : undefined // `who` is a Slack-supplied display name
+  return state === "resolved"
     ? [
         actions([actionButton(SLACK_THREAD_ACTION.reopen, "Reopen thread", value)]),
-        context(`Derive · :white_check_mark: resolved${who ? ` by ${who}` : ""}`),
+        context(`Derive · :white_check_mark: resolved${w ? ` by ${w}` : ""}`),
       ]
     : [
         actions([actionButton(SLACK_THREAD_ACTION.resolve, "Resolve thread", value, "primary")]),
         context(
-          who
-            ? `Derive · reopened by ${who} · reply in this thread to post back`
+          w
+            ? `Derive · reopened by ${w} · reply in this thread to post back`
             : "Derive · reply in this thread to post back",
         ),
       ]
+}
 
-/** Slack Block Kit blocks for a comment post (open thread, with a Resolve button). */
+/** Slack Block Kit blocks for a comment post (open thread, with a Resolve button). Untrusted
+ *  text (author, title, body) is escaped so it can't break out of the `<url|text>` link. */
 const blocksFor = (p: SlackCommentPayload): unknown[] => [
   section(
-    `:speech_balloon: *${p.author}* commented on <${p.link}|${p.title}>\n${truncate(p.text, 600)}`,
+    `:speech_balloon: *${escapeMrkdwn(p.author)}* commented on <${p.link}|${escapeMrkdwn(p.title)}>\n${escapeMrkdwn(truncate(p.text, 600))}`,
   ),
   ...threadStateBlocks("open", encodeThreadAction(p.artifactId, p.threadId)),
 ]

--- a/apps/api/src/lib/slack-dm.ts
+++ b/apps/api/src/lib/slack-dm.ts
@@ -18,7 +18,7 @@ import type { ChannelSendResult } from "../webhooks"
 import { enqueueChannelDelivery } from "../webhooks"
 import { commentDeepLink, type Mention } from "./comments"
 import { openSlackDm, resolveSlackUserIdByEmail } from "./slack"
-import { actions, openButton, section } from "./slack-cards"
+import { actions, escapeMrkdwn, openButton, section } from "./slack-cards"
 import { postWithRecovery, resolveBotToken, slackFailure } from "./slack-delivery"
 import { truncate } from "./text"
 
@@ -67,8 +67,8 @@ export const enqueueSlackMentionDms = async (
     const pref = await meta.getUserNotificationPref(artifact.org_id, m.id)
     if (!wantsSlackDm(pref?.prefs)) continue
     const blocks = [
-      section(`:wave: *${cm.author}* mentioned you on <${link}|${t}>`),
-      section(`> ${truncate(cm.body_md, 600)}`),
+      section(`:wave: *${escapeMrkdwn(cm.author)}* mentioned you on <${link}|${escapeMrkdwn(t)}>`),
+      section(`> ${escapeMrkdwn(truncate(cm.body_md, 600))}`),
       actions([openButton(link)]),
     ]
     await enqueueChannelDelivery(meta, "slack_dm", "comment.mention", {
@@ -98,9 +98,9 @@ export const enqueueSlackReviewRequestedDm = async (
   const t = title(artifact)
   const blocks = [
     section(
-      `:mag: *${proposal.requestedBy}* requested your review of <${link}|${t}> (v${proposal.version}).`,
+      `:mag: *${escapeMrkdwn(proposal.requestedBy)}* requested your review of <${link}|${escapeMrkdwn(t)}> (v${proposal.version}).`,
     ),
-    ...(proposal.note ? [section(`> ${truncate(proposal.note, 600)}`)] : []),
+    ...(proposal.note ? [section(`> ${escapeMrkdwn(truncate(proposal.note, 600))}`)] : []),
     actions([openButton(link, "Review in Derive")]),
   ]
   await enqueueChannelDelivery(meta, "slack_dm", "review.requested", {
@@ -129,7 +129,9 @@ export const enqueueSlackShareDm = async (
   const t = title(artifact)
   const roleSuffix = input.role === "viewer" ? "" : ` as ${input.role}`
   const blocks = [
-    section(`:open_file_folder: *${input.sharedBy}* shared <${link}|${t}> with you${roleSuffix}.`),
+    section(
+      `:open_file_folder: *${escapeMrkdwn(input.sharedBy)}* shared <${link}|${escapeMrkdwn(t)}> with you${roleSuffix}.`,
+    ),
     actions([openButton(link)]),
   ]
   await enqueueChannelDelivery(meta, "slack_dm", "artifact.shared", {

--- a/apps/api/test/comment-fanout.test.ts
+++ b/apps/api/test/comment-fanout.test.ts
@@ -148,6 +148,24 @@ describe("comment channel fan-out", () => {
     const kinds = (await claim(meta)).map((d) => d.kind)
     expect(kinds).not.toContain("slack_app")
   })
+
+  it("does not mirror a comment on a PRIVATE artifact (no leak)", async () => {
+    const { app, meta } = makeAuthedApp("fanout-slack-private", [owner], "editor")
+    await meta.setSlackInstall({
+      org_id: "default",
+      team_id: "T1",
+      team_name: "Acme",
+      bot_token: "xoxb-stored",
+      bot_user_id: "UBOT",
+      default_channel: "C1",
+      created_at: new Date().toISOString(),
+    })
+    const r = await pub(app, "# Secret", { visibility: "private" }, undefined, as(owner.email))
+    const shortId = (await r.json()).short_id as string
+    await comment(app, shortId, owner.email)
+    // Private draft (listed "none") → its title + comment body never reach the org-wide channel.
+    expect((await claim(meta)).map((d) => d.kind)).not.toContain("slack_app")
+  })
 })
 
 describe("connected-channel event cards (publishes / proposals)", () => {
@@ -275,6 +293,45 @@ describe("connected-channel event cards (publishes / proposals)", () => {
     const s = JSON.stringify(sent.blocks)
     expect(s).toContain("derive_proposal_approve")
     expect(s).toContain("derive_proposal_request_changes")
+  })
+
+  it("escapes untrusted text (title/author) in the comment-mirror card", async () => {
+    const { meta } = authed("chan-comment-esc")
+    await connect(meta)
+    const d: DeliveryRecord = {
+      id: "wd-cmt",
+      webhook_id: "internal",
+      url: "",
+      secret: "",
+      kind: "slack_app",
+      event_type: "comment.created",
+      payload: JSON.stringify({
+        orgId: "default",
+        artifactId: "a1",
+        threadId: "t1",
+        text: "hi",
+        link: "https://derive.test/artifacts/a1",
+        title: "Doc> <https://phish|x",
+        author: "Ann",
+      }),
+      status: "pending",
+      attempts: 0,
+      last_error: null,
+      next_attempt_at: new Date().toISOString(),
+      created_at: new Date().toISOString(),
+    }
+    let sent: { blocks?: unknown } = {}
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: { body?: string }) => {
+        sent = JSON.parse(init?.body ?? "{}")
+        return new Response(JSON.stringify({ ok: true, ts: "1.1", channel: "C1" }))
+      }),
+    )
+    await makeSlackSender(meta, "k")(d)
+    const s = JSON.stringify(sent.blocks)
+    expect(s).toContain("Doc&gt;") // the title's > was escaped
+    expect(s).not.toContain("<https://phish") // the injected link's < was neutralized
   })
 })
 


### PR DESCRIPTION
## Context

After the six Slack increments (#450, #452, #453, #454, #456, #459) merged, I ran a **consolidation review of the whole integration together** — two independent adversarial reviewers over the cumulative surface. They converged on **exactly two real cross-increment inconsistencies the series itself created**, both where new code was careful but the older sibling path was not. Everything else was confirmed clean (inbound gates, authz consistency, secrets, dual-runtime parity, outbox semantics).

## Fixes

- **Visibility (MEDIUM)** — the connected-channel **comment mirror** didn't gate on artifact visibility, so a comment on a **private draft** posted its title + body to the org-wide channel. This is *worse* than the event-card leak the series already closed, because it exposes the comment text, not just the title. Now gated on `listed !== "none"`, matching the event cards one function away. Pinned by a test.
- **mrkdwn injection (MEDIUM/LOW, phishing)** — `escapeMrkdwn` was applied on every new path (slash command, event cards, approve footer) but **not** the older comment-mirror card, the thread-resolve footer's Slack-supplied name, or the DM cards. A crafted artifact title / display name could inject a second, attacker-controlled `<url|text>` link into a message the bot posts. Now escaped on all of them. Pinned by a test.

## Accepted + documented (low / theoretical — disproportionate to fix here)

- The `slack_ingest` ts-dedup is a scan, not a DB constraint — safe on the single-drainer edge DO and single-process Node; a horizontally-scaled Node self-host could theoretically double-ingest under concurrent drainers.
- `slack_user_link`'s one-per-`(team,user)` is app-enforced (delete-then-insert), not a DB `UNIQUE` — only at risk if one person with two Slack identities races two link flows.

## Testing

- `pnpm run ci` ✅ · `pnpm typecheck` ✅ · full suite ✅ (apps/api 1041) · `test:pg` ✅ (25).
- New tests: **private artifact's comment is NOT mirrored** (no leak), **comment-mirror card escapes** an injected title. (Rebased onto current main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)