### PR TITLE
fix(ci): use pnpm 11's audit — npm retired the legacy audit endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,12 +246,11 @@ jobs:
         with:
           install: "false"
 
-      # pnpm 10.x audits via npm's legacy audit endpoint, which npm is retiring.
-      # Verified working as of 2026-07; if it starts returning 410, switch to
-      # `pnpm dlx pnpm@11 audit --prod --audit-level=high` (pnpm 11 uses the
-      # bulk-advisories endpoint) or OSV-Scanner (no npm-endpoint dependency).
+      # pnpm 10.x audits via npm's legacy audit endpoint, which npm has now retired
+      # (it returns 410 as of 2026-07-15). pnpm 11's audit uses the bulk-advisories
+      # endpoint, so run it via dlx (the repo stays on pnpm 10 for everything else).
       - name: Audit production dependencies
-        run: pnpm audit --prod --audit-level=high
+        run: pnpm dlx pnpm@11 audit --prod --audit-level=high
 
       - name: Secret scan (gitleaks)
         run: |


### PR DESCRIPTION
## Problem

The `security` job's `pnpm audit --prod --audit-level=high` calls npm's **legacy** audit endpoint, which npm has now **retired** — as of 2026-07-15 it returns:

```
ERR_PNPM_AUDIT_BAD_RESPONSE  The audit endpoint … responded with 410:
{"error":"This endpoint is being retired. Use the bulk advisory endpoint instead."}
```

This fails the `security` job on **every PR** (reproduces on rerun; unrelated PRs like `feat/agent-tags` hit it today; everything on 2026-07-14 passed).

## Fix

Exactly the contingency the step's own comment documented: **pnpm 11's audit uses the bulk-advisories endpoint**, so run it via `pnpm dlx pnpm@11` (the repo stays on pnpm 10 for everything else). One line.

The gitleaks secret-scan step in the same job is unaffected.