### PR TITLE
refactor(slack): de-hack the webhook handlers — dedupe, harden, escape

### DIFF
--- a/apps/api/src/lib/slack-comments.ts
+++ b/apps/api/src/lib/slack-comments.ts
@@ -84,6 +84,21 @@ export const SLACK_PROPOSAL_ACTION = {
 export const encodeProposalAction = (artifactId: string, proposalId: string): string =>
   JSON.stringify({ a: artifactId, p: proposalId })
 
+/** Decode a proposal button `value` back to its target ids — the inverse of
+ *  encodeProposalAction. Tolerant of a malformed/attacker-supplied value (returns null): the
+ *  ids only NAME the target, which the handler re-authorizes against the account link, so a
+ *  bad value can at worst pick a nonexistent proposal. */
+export const decodeProposalAction = (
+  value: string,
+): { artifactId: string; proposalId: string } | null => {
+  try {
+    const { a, p } = JSON.parse(value) as { a?: string; p?: string }
+    return a && p ? { artifactId: a, proposalId: p } : null
+  } catch {
+    return null
+  }
+}
+
 /** Artifact-lifecycle events that post a top-level card to the connected channel (comments
  *  mirror separately + threaded, so they're NOT here). Everything else `notify` fans out to
  *  webhooks only. */
@@ -180,6 +195,20 @@ export const SLACK_THREAD_ACTION = {
 export const encodeThreadAction = (artifactId: string, threadId: string): string =>
   JSON.stringify({ a: artifactId, t: threadId })
 
+/** Decode a thread button `value` back to its target ids — the inverse of encodeThreadAction.
+ *  Tolerant of a malformed value (returns null); the ids are re-checked against the thread
+ *  link before any state change, so they're only a target name, never authorization. */
+export const decodeThreadAction = (
+  value: string,
+): { artifactId: string; threadId: string } | null => {
+  try {
+    const { a, t } = JSON.parse(value) as { a?: string; t?: string }
+    return a && t ? { artifactId: a, threadId: t } : null
+  } catch {
+    return null
+  }
+}
+
 /** The action + context blocks under a comment card for a given thread state. Rebuilt by the
  *  interactivity handler after a resolve/reopen (with `who` = the Slack user who acted) and
  *  used for the first post (open, no `who`). `value` is the encoded thread target. */
@@ -187,25 +216,32 @@ export const threadStateBlocks = (
   state: "open" | "resolved",
   value: string,
   who?: string,
-): unknown[] =>
-  state === "resolved"
+): unknown[] => {
+  // `who` is the acting Slack user's display name (attacker-controllable) landing in a mrkdwn
+  // context block — escape it like every other untrusted field so a name can't inject markup.
+  const w = who ? escapeMrkdwn(who) : undefined
+  return state === "resolved"
     ? [
         actions([actionButton(SLACK_THREAD_ACTION.reopen, "Reopen thread", value)]),
-        context(`Derive · :white_check_mark: resolved${who ? ` by ${who}` : ""}`),
+        context(`Derive · :white_check_mark: resolved${w ? ` by ${w}` : ""}`),
       ]
     : [
         actions([actionButton(SLACK_THREAD_ACTION.resolve, "Resolve thread", value, "primary")]),
         context(
-          who
-            ? `Derive · reopened by ${who} · reply in this thread to post back`
+          w
+            ? `Derive · reopened by ${w} · reply in this thread to post back`
             : "Derive · reply in this thread to post back",
         ),
       ]
+}
 
-/** Slack Block Kit blocks for a comment post (open thread, with a Resolve button). */
+/** Slack Block Kit blocks for a comment post (open thread, with a Resolve button). Every
+ *  untrusted field (author, title, body) is escaped: they land in a mrkdwn section, so an
+ *  unescaped `<!channel>` would ping the channel and a `>` would break out of the link —
+ *  same treatment eventBlocks already gives its fields. */
 const blocksFor = (p: SlackCommentPayload): unknown[] => [
   section(
-    `:speech_balloon: *${p.author}* commented on <${p.link}|${p.title}>\n${truncate(p.text, 600)}`,
+    `:speech_balloon: *${escapeMrkdwn(p.author)}* commented on <${p.link}|${escapeMrkdwn(p.title)}>\n${escapeMrkdwn(truncate(p.text, 600))}`,
   ),
   ...threadStateBlocks("open", encodeThreadAction(p.artifactId, p.threadId)),
 ]
@@ -232,7 +268,10 @@ export const makeSlackSender =
         bot.token,
         {
           channel: bot.install.default_channel,
-          text: `${e.author}: ${e.event} · ${e.title}`,
+          // The fallback text is parsed as mrkdwn too (notifications, blocks-failed render), so
+          // untrusted author/title must be escaped here as well — else a name like `<!channel>`
+          // could ping the channel via the fallback even though the blocks escape it.
+          text: `${escapeMrkdwn(e.author)}: ${e.event} · ${escapeMrkdwn(e.title)}`,
           blocks: eventBlocks(e),
         },
         { autoJoin: true, textFallback: true },
@@ -250,7 +289,7 @@ export const makeSlackSender =
       bot.token,
       {
         channel,
-        text: `${p.author} commented on ${p.title}`,
+        text: `${escapeMrkdwn(p.author)} commented on ${escapeMrkdwn(p.title)}`,
         blocks: blocksFor(p),
         threadTs: existing?.message_ts,
       },

--- a/apps/api/src/lib/slack-comments.ts
+++ b/apps/api/src/lib/slack-comments.ts
@@ -43,6 +43,9 @@ export const enqueueSlackComment = async (
 ): Promise<void> => {
   const { meta, baseUrl } = deps
   if (parseMeta(cm.meta).slack) return // came from Slack — don't echo back
+  // Only mirror feed-visible artifacts (same gate as the event cards): a comment on a private
+  // draft must not post its title + body to the org-wide channel where non-collaborators see it.
+  if (artifact.listed === "none") return
   const install = await meta.getSlackInstall(artifact.org_id)
   if (!install?.default_channel) return
   const link = commentDeepLink(baseUrl, artifact, cm.thread_id)

--- a/apps/api/src/lib/slack-dm.ts
+++ b/apps/api/src/lib/slack-dm.ts
@@ -18,7 +18,7 @@ import type { ChannelSendResult } from "../webhooks"
 import { enqueueChannelDelivery } from "../webhooks"
 import { commentDeepLink, type Mention } from "./comments"
 import { openSlackDm, resolveSlackUserIdByEmail } from "./slack"
-import { actions, openButton, section } from "./slack-cards"
+import { actions, escapeMrkdwn, openButton, section } from "./slack-cards"
 import { postWithRecovery, resolveBotToken, slackFailure } from "./slack-delivery"
 import { truncate } from "./text"
 
@@ -67,14 +67,14 @@ export const enqueueSlackMentionDms = async (
     const pref = await meta.getUserNotificationPref(artifact.org_id, m.id)
     if (!wantsSlackDm(pref?.prefs)) continue
     const blocks = [
-      section(`:wave: *${cm.author}* mentioned you on <${link}|${t}>`),
-      section(`> ${truncate(cm.body_md, 600)}`),
+      section(`:wave: *${escapeMrkdwn(cm.author)}* mentioned you on <${link}|${escapeMrkdwn(t)}>`),
+      section(`> ${escapeMrkdwn(truncate(cm.body_md, 600))}`),
       actions([openButton(link)]),
     ]
     await enqueueChannelDelivery(meta, "slack_dm", "comment.mention", {
       orgId: artifact.org_id,
       userId: m.id,
-      text: `${cm.author} mentioned you on ${t}`,
+      text: `${escapeMrkdwn(cm.author)} mentioned you on ${escapeMrkdwn(t)}`,
       blocks,
     } satisfies SlackDmPayload)
   }
@@ -98,15 +98,15 @@ export const enqueueSlackReviewRequestedDm = async (
   const t = title(artifact)
   const blocks = [
     section(
-      `:mag: *${proposal.requestedBy}* requested your review of <${link}|${t}> (v${proposal.version}).`,
+      `:mag: *${escapeMrkdwn(proposal.requestedBy)}* requested your review of <${link}|${escapeMrkdwn(t)}> (v${proposal.version}).`,
     ),
-    ...(proposal.note ? [section(`> ${truncate(proposal.note, 600)}`)] : []),
+    ...(proposal.note ? [section(`> ${escapeMrkdwn(truncate(proposal.note, 600))}`)] : []),
     actions([openButton(link, "Review in Derive")]),
   ]
   await enqueueChannelDelivery(meta, "slack_dm", "review.requested", {
     orgId: artifact.org_id,
     userId: reviewerId,
-    text: `${proposal.requestedBy} requested your review of ${t} (v${proposal.version})`,
+    text: `${escapeMrkdwn(proposal.requestedBy)} requested your review of ${escapeMrkdwn(t)} (v${proposal.version})`,
     blocks,
   } satisfies SlackDmPayload)
 }
@@ -127,15 +127,18 @@ export const enqueueSlackShareDm = async (
   if (!wantsSlackDm(pref?.prefs)) return
   const link = artifactUrl(baseUrl, artifact)
   const t = title(artifact)
+  // input.role is a fixed vocabulary (never user text), so it needs no escaping.
   const roleSuffix = input.role === "viewer" ? "" : ` as ${input.role}`
   const blocks = [
-    section(`:open_file_folder: *${input.sharedBy}* shared <${link}|${t}> with you${roleSuffix}.`),
+    section(
+      `:open_file_folder: *${escapeMrkdwn(input.sharedBy)}* shared <${link}|${escapeMrkdwn(t)}> with you${roleSuffix}.`,
+    ),
     actions([openButton(link)]),
   ]
   await enqueueChannelDelivery(meta, "slack_dm", "artifact.shared", {
     orgId: artifact.org_id,
     userId: recipientId,
-    text: `${input.sharedBy} shared ${t} with you`,
+    text: `${escapeMrkdwn(input.sharedBy)} shared ${escapeMrkdwn(t)} with you`,
     blocks,
   } satisfies SlackDmPayload)
 }

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -1,5 +1,6 @@
 import { newId, type SlackInstallRecord } from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import type { Context } from "hono"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
 import { encryptSecret, signState, verifyState } from "../lib/crypto"
@@ -16,6 +17,8 @@ import {
 } from "../lib/slack"
 import { deriveRecentBlocks, deriveResultsBlocks, notLinkedBlocks } from "../lib/slack-commands"
 import {
+  decodeProposalAction,
+  decodeThreadAction,
   enqueueSlackReplyIngest,
   SLACK_PROPOSAL_ACTION,
   SLACK_THREAD_ACTION,
@@ -42,6 +45,42 @@ export const slackRoutes = (ctx: AppContext) => {
   const slack = deps.slack
   const redirectUri = new URL("/v1/slack/oauth/callback", deps.baseUrl).toString()
   const linkRedirectUri = new URL("/v1/slack/link/callback", deps.baseUrl).toString()
+
+  // Every Slack webhook (events, interactivity, commands) is authenticated the same way: Slack
+  // HMACs the raw request body with the signing secret. Factored into one guard so the three
+  // handlers can't drift — a subtly weaker check on any one endpoint would be a real auth hole.
+  // Returns the raw body to parse, or a Response the caller returns as-is (404 unconfigured /
+  // 401 bad signature) — mirrors the requireUser/readJson `X | Response` convention.
+  const verifiedSlackBody = async (c: Context): Promise<string | Response> => {
+    if (!slack) return fail(c, 404, "Slack is not configured")
+    const raw = await c.req.text()
+    if (
+      !verifySlackSignature(
+        slack.signingSecret,
+        c.req.header("x-slack-request-timestamp"),
+        raw,
+        c.req.header("x-slack-signature"),
+      )
+    )
+      return fail(c, 401, "bad signature")
+    return raw
+  }
+
+  // Run best-effort work AFTER we've acked Slack (which demands a reply within 3s). On Workers,
+  // executionCtx.waitUntil keeps the isolate alive until it settles; Node has no executionCtx, so
+  // the promise just runs in-process. Either way a terminal .catch() is attached FIRST: an
+  // unawaited reject (e.g. a lookup throwing inside a deferred proposal action) would otherwise
+  // surface as an unhandledRejection — and under Node's default that can take down the process.
+  const runAfterAck = (c: Context, work: Promise<unknown>): void => {
+    const guarded = Promise.resolve(work).catch((err) =>
+      log.warn("slack deferred work failed", { err: String(err) }),
+    )
+    try {
+      c.executionCtx.waitUntil(guarded)
+    } catch {
+      void guarded // Node has no executionCtx; the promise runs in-process
+    }
+  }
 
   interface ConnectState {
     org: string
@@ -215,17 +254,8 @@ export const slackRoutes = (ctx: AppContext) => {
   // Respond fast and do the work best-effort. Same model as the GitHub App webhook.
   // authz-exempt: Slack signs every request with the signing secret (verifySlackSignature); no session on a webhook.
   app.post("/v1/slack/events", async (c) => {
-    if (!slack) return fail(c, 404, "Slack is not configured")
-    const raw = await c.req.text()
-    if (
-      !verifySlackSignature(
-        slack.signingSecret,
-        c.req.header("x-slack-request-timestamp"),
-        raw,
-        c.req.header("x-slack-signature"),
-      )
-    )
-      return fail(c, 401, "bad signature")
+    const raw = await verifiedSlackBody(c)
+    if (raw instanceof Response) return raw
 
     let body: SlackEventEnvelope
     try {
@@ -280,17 +310,8 @@ export const slackRoutes = (ctx: AppContext) => {
   // card update is fired without awaiting, so a slow response_url can't push us past the 3s ack.
   // authz-exempt: Slack signs every request with the signing secret (verifySlackSignature).
   app.post("/v1/slack/interactivity", async (c) => {
-    if (!slack) return fail(c, 404, "Slack is not configured")
-    const raw = await c.req.text()
-    if (
-      !verifySlackSignature(
-        slack.signingSecret,
-        c.req.header("x-slack-request-timestamp"),
-        raw,
-        c.req.header("x-slack-signature"),
-      )
-    )
-      return fail(c, 401, "bad signature")
+    const raw = await verifiedSlackBody(c)
+    if (raw instanceof Response) return raw
 
     // Interactivity is form-encoded: a single `payload` field holding URL-encoded JSON.
     const payloadStr = new URLSearchParams(raw).get("payload")
@@ -312,30 +333,24 @@ export const slackRoutes = (ctx: AppContext) => {
       action.action_id === SLACK_PROPOSAL_ACTION.approve ||
       action.action_id === SLACK_PROPOSAL_ACTION.requestChanges
     ) {
-      let pt: { a?: string; p?: string }
-      try {
-        pt = JSON.parse(action.value) as { a?: string; p?: string }
-      } catch {
-        return c.json({ ok: true })
-      }
-      if (pt.a && pt.p && payload.team?.id && payload.user?.id) {
-        const work = runSlackProposalAction(
-          { meta, blobs, bus, notify, notifyRender, search },
-          {
-            teamId: payload.team.id,
-            slackUserId: payload.user.id,
-            proposalId: pt.p,
-            artifactId: pt.a,
-            op: action.action_id === SLACK_PROPOSAL_ACTION.approve ? "approve" : "request_changes",
-            responseUrl: payload.response_url,
-            sectionBlock: payload.message?.blocks?.[0],
-          },
+      const pt = decodeProposalAction(action.value)
+      if (pt && payload.team?.id && payload.user?.id) {
+        runAfterAck(
+          c,
+          runSlackProposalAction(
+            { meta, blobs, bus, notify, notifyRender, search },
+            {
+              teamId: payload.team.id,
+              slackUserId: payload.user.id,
+              proposalId: pt.proposalId,
+              artifactId: pt.artifactId,
+              op:
+                action.action_id === SLACK_PROPOSAL_ACTION.approve ? "approve" : "request_changes",
+              responseUrl: payload.response_url,
+              sectionBlock: payload.message?.blocks?.[0],
+            },
+          ),
         )
-        try {
-          c.executionCtx.waitUntil(work)
-        } catch {
-          void work
-        }
       }
       return c.json({ ok: true })
     }
@@ -348,14 +363,9 @@ export const slackRoutes = (ctx: AppContext) => {
           : undefined
     // Not a thread action we handle (or a malformed value) → ack and ignore.
     if (!op) return c.json({ ok: true })
-    let target: { a?: string; t?: string }
-    try {
-      target = JSON.parse(action.value) as { a?: string; t?: string }
-    } catch {
-      return c.json({ ok: true })
-    }
-    const { a: artifactId, t: threadId } = target
-    if (!artifactId || !threadId) return c.json({ ok: true })
+    const target = decodeThreadAction(action.value)
+    if (!target) return c.json({ ok: true })
+    const { artifactId, threadId } = target
 
     // Re-establish trust from data (never the button value alone): the thread link maps this
     // thread to this artifact + org, the acting Slack team owns that org's install, and the
@@ -375,16 +385,14 @@ export const slackRoutes = (ctx: AppContext) => {
           const section0 = payload.message?.blocks?.[0]
           const blocks = [section0, ...threadStateBlocks(op, action.value, who)].filter(Boolean)
           if (payload.response_url) {
-            const update = postSlackResponseUrl(payload.response_url, {
-              text: op === "resolved" ? "Thread resolved" : "Thread reopened",
-              blocks,
-              replace_original: true,
-            })
-            try {
-              c.executionCtx.waitUntil(update)
-            } catch {
-              void update // Node has no executionCtx; the promise runs in-process
-            }
+            runAfterAck(
+              c,
+              postSlackResponseUrl(payload.response_url, {
+                text: op === "resolved" ? "Thread resolved" : "Thread reopened",
+                blocks,
+                replace_original: true,
+              }),
+            )
           }
         }
       }
@@ -402,17 +410,8 @@ export const slackRoutes = (ctx: AppContext) => {
   // stay under Slack's 3s deadline.
   // authz-exempt: Slack signs every request with the signing secret (verifySlackSignature).
   app.post("/v1/slack/commands", async (c) => {
-    if (!slack) return fail(c, 404, "Slack is not configured")
-    const raw = await c.req.text()
-    if (
-      !verifySlackSignature(
-        slack.signingSecret,
-        c.req.header("x-slack-request-timestamp"),
-        raw,
-        c.req.header("x-slack-signature"),
-      )
-    )
-      return fail(c, 401, "bad signature")
+    const raw = await verifiedSlackBody(c)
+    if (raw instanceof Response) return raw
 
     const form = new URLSearchParams(raw)
     const teamId = form.get("team_id")
@@ -478,11 +477,7 @@ export const slackRoutes = (ctx: AppContext) => {
           replace_original: true,
         }),
       )
-    try {
-      c.executionCtx.waitUntil(deliver)
-    } catch {
-      void deliver
-    }
+    runAfterAck(c, deliver)
     return c.json({ response_type: "ephemeral", text: "Searching…" })
   })
 

--- a/apps/api/test/comment-fanout.test.ts
+++ b/apps/api/test/comment-fanout.test.ts
@@ -148,6 +148,24 @@ describe("comment channel fan-out", () => {
     const kinds = (await claim(meta)).map((d) => d.kind)
     expect(kinds).not.toContain("slack_app")
   })
+
+  it("does not mirror a comment on a PRIVATE artifact (no leak)", async () => {
+    const { app, meta } = makeAuthedApp("fanout-slack-private", [owner], "editor")
+    await meta.setSlackInstall({
+      org_id: "default",
+      team_id: "T1",
+      team_name: "Acme",
+      bot_token: "xoxb-stored",
+      bot_user_id: "UBOT",
+      default_channel: "C1",
+      created_at: new Date().toISOString(),
+    })
+    const r = await pub(app, "# Secret", { visibility: "private" }, undefined, as(owner.email))
+    const shortId = (await r.json()).short_id as string
+    await comment(app, shortId, owner.email)
+    // Private draft (listed "none") → its title + comment body never reach the org-wide channel.
+    expect((await claim(meta)).map((d) => d.kind)).not.toContain("slack_app")
+  })
 })
 
 describe("connected-channel event cards (publishes / proposals)", () => {

--- a/apps/api/test/comment-fanout.test.ts
+++ b/apps/api/test/comment-fanout.test.ts
@@ -276,6 +276,50 @@ describe("connected-channel event cards (publishes / proposals)", () => {
     expect(s).toContain("derive_proposal_approve")
     expect(s).toContain("derive_proposal_request_changes")
   })
+
+  it("escapes untrusted title/author/body in the comment card (no mrkdwn injection)", async () => {
+    const { meta } = authed("chan-comment-escape")
+    await connect(meta)
+    const d: DeliveryRecord = {
+      id: "wd-cmt",
+      webhook_id: "internal",
+      url: "",
+      secret: "",
+      kind: "slack_app",
+      event_type: "comment.created",
+      payload: JSON.stringify({
+        orgId: "default",
+        artifactId: "a1",
+        threadId: "th1",
+        text: "ping <!channel>",
+        link: "https://derive.test/artifacts/a1",
+        title: "<fake|link> & more",
+        author: "<@U999>",
+      }),
+      status: "pending",
+      attempts: 0,
+      last_error: null,
+      next_attempt_at: new Date().toISOString(),
+      created_at: new Date().toISOString(),
+    }
+    let sent: { blocks?: unknown; text?: string } = {}
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: { body?: string }) => {
+        sent = JSON.parse(init?.body ?? "{}")
+        return new Response(JSON.stringify({ ok: true, ts: "1.1", channel: "C1" }))
+      }),
+    )
+    await makeSlackSender(meta, "k")(d)
+    const s = JSON.stringify(sent.blocks)
+    // Untrusted control chars are escaped in both the block text and the plain-text fallback; the
+    // only raw `<`/`>` left are the `<url|title>` link delimiters the card itself builds.
+    expect(s).not.toContain("<@U999>")
+    expect(s).not.toContain("<!channel>")
+    expect(s).toContain("&lt;@U999&gt;")
+    expect(sent.text).not.toContain("<@U999>")
+    expect(sent.text).toContain("&lt;@U999&gt;")
+  })
 })
 
 describe("review-request + share emails", () => {

--- a/apps/api/test/slack-dm.test.ts
+++ b/apps/api/test/slack-dm.test.ts
@@ -110,6 +110,47 @@ describe("enqueueSlackMentionDms (gate)", () => {
     expect(dms).toHaveLength(1)
     expect(JSON.parse(dms[0]?.payload ?? "{}").userId).toBe(linked.id)
   })
+
+  it("escapes mrkdwn control chars in the card + fallback (no <!channel> injection)", async () => {
+    const meta = make("slack-dm-escape")
+    await connect(meta)
+    const artifact = (await meta.createArtifact({
+      id: newId("a"),
+      short_id: newId("s").slice(0, 8),
+      org_id: "default",
+      slug: null,
+      title: "<!channel> & <fake|link>",
+      link_role: "viewer",
+      kind: "file",
+      spa: 0,
+    })) as ArtifactRecord
+    const comment = (await meta.createComment({
+      id: newId("c"),
+      artifact_id: artifact.id,
+      thread_id: newId("th"),
+      base_version: 0,
+      path: null,
+      anchor: null,
+      body_md: "look <!here>",
+      author: "<@U999>",
+      author_id: "u-x",
+    })) as CommentRecord
+    await enqueueSlackMentionDms({ meta, baseUrl }, artifact, comment, [
+      { id: linked.id, name: "L" },
+    ])
+    const payload = JSON.parse(
+      (await claim(meta)).find((d) => d.kind === "slack_dm")?.payload ?? "{}",
+    )
+    const serialized = JSON.stringify(payload)
+    // The literal control chars from untrusted author/title/body must be escaped everywhere they
+    // land — both the block text and the plain-text fallback. `link` URLs are ours, so the only
+    // raw `<`/`>` allowed are the `<url|...>` link delimiters we build.
+    expect(payload.text).not.toContain("<!channel>")
+    expect(payload.text).toContain("&lt;!channel&gt;")
+    expect(serialized).not.toContain("<@U999>")
+    expect(serialized).not.toContain("<!here>")
+    expect(serialized).toContain("&lt;@U999&gt;")
+  })
 })
 
 describe("enqueueSlackReviewRequestedDm (gate)", () => {

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -771,6 +771,30 @@ describe("slack interactivity endpoint (resolve/reopen from a button)", () => {
     expect(JSON.stringify(sent.blocks)).toContain(SLACK_THREAD_ACTION.reopen)
   })
 
+  it("escapes the acting Slack username in the replaced card (no mrkdwn injection)", async () => {
+    const { app, meta } = make("slack-int-escape-who")
+    const artifact = await seedResolvable(meta, {
+      artifact: "a-int-w",
+      short: "intwho01",
+      thread: "c-int-w",
+    })
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("ok", { status: 200 })),
+    )
+    // A crafted Slack display name lands in the card footer's mrkdwn context block.
+    const payload = {
+      ...threadAction(artifact.id, "c-int-w", SLACK_THREAD_ACTION.resolve),
+      user: { username: "<!channel>" },
+    }
+    const r = await postInteract(app, payload)
+    expect(r.status).toBe(200)
+    const call = vi.mocked(fetch).mock.calls.find(([u]) => String(u).includes("hooks.slack.test"))
+    const sent = JSON.stringify(JSON.parse(String(call?.[1]?.body)).blocks)
+    expect(sent).not.toContain("<!channel>")
+    expect(sent).toContain("&lt;!channel&gt;")
+  })
+
   it("a Reopen click reopens a resolved thread", async () => {
     const { app, meta } = make("slack-int-reopen")
     const artifact = await seedResolvable(meta, {


### PR DESCRIPTION
## What

A self-critical de-hack pass over the Slack integration, closing the hacky bits the recent feature work left behind, **and absorbing the held #464** (its escaping was identical to this branch's; its unique comment-mirror visibility-gate fix is folded in here). No happy-path behavior change — the added tests pin the security-relevant edges.

## Why + changes

**1. One signature guard, not three.** The events / interactivity / commands endpoints each carried an identical copy of the HMAC-verify boilerplate. Three copies of an auth check drift; a weaker check on one endpoint is a real hole. Factored into `verifiedSlackBody(c) -> string | Response`, preserving the exact 404-unconfigured / 401-bad-sig codes and short-circuit order.

**2. A terminal `.catch()` on post-ack work.** `runSlackProposalAction` runs its early lookups (account link, artifact, proposal, membership) *outside* its own try/catch, so a store error rejected a fire-and-forget promise that had **no** `.catch()`. New `runAfterAck(c, work)` attaches one before `waitUntil`/`void`, and dedupes the `try{waitUntil}catch{void}` idiom that appeared three times.

> **Scope of this one, stated honestly:** this is *not* a crash fix. `node.ts` installs a log-only `unhandledRejection` handler, so the rejection was already non-fatal. What it was: a bare, contextless global log line — and that safety net exists only on the Node path. Catching at the call site attributes the failure to the Slack deferral on both runtimes instead of leaning on the global net.

**3. Escape all untrusted text in mrkdwn.** `escapeMrkdwn` was applied to `eventBlocks` / commands / proposal cards but **missed** the comment card (`blocksFor`), every DM card, the thread-state footer (`who` = the acting Slack display name), and the plain-text `text:` fields. A title or display name like `<!channel>` would be interpreted, or a `>` would break out of a `<url|text>` link. URLs we build are left raw so a query-string `&` isn't corrupted.

> On the `text:` field specifically: it is always sent and is what Slack shows as the push/desktop **notification** text, so escaping matters on every card. Additionally, for the *event* card only — the one sender that passes `textFallback: true` (`slack-comments.ts:280`) — it becomes the entire message body on an `invalid_blocks` retry (`slack-delivery.ts:96`). The comment card and DMs do not set that flag.

**4. Gate the comment mirror on visibility (from #464).** `enqueueSlackComment` did not gate on visibility, so a comment on a private draft posted its title + body to the org-wide channel where non-collaborators see it. Now gated `if (artifact.listed === "none") return`, the same feed-visibility gate the event cards already use.

**5. Encode/decode symmetry.** Added `decode{Thread,Proposal}Action` to pair the existing encoders and centralize the tolerant parse. This also fixes a real crash: the old inline code destructured the parse result *outside* its try, so a button `value` of `"null"` (valid JSON, parses to `null`) threw a `TypeError` -> 500. Now acks 200 (pinned by a regression test in the follow-up #501, not here). Reachability is low — it takes a validly-signed Slack request — but the endpoint should never 500 on input it already means to ignore.

## Tests

| Test | Pins |
|---|---|
| `slack-dm.test.ts` | mention DM escapes `<!channel>` / `<@U999>` in both block and fallback |
| `comment-fanout.test.ts` | comment card escapes untrusted title/author/body |
| `comment-fanout.test.ts` | private-artifact comment is **not** mirrored (no leak) |
| `slack-routes.test.ts` | a crafted acting-username is escaped in the replaced card |

## Verification

`typecheck`, `biome ci`, and the full lint battery (`lint:api` / `boundaries` / `api-types` / schema / env) green. Full `apps/api` suite green on sqlite (1075). The three changed specs green on the Postgres lane (60). An independent adversarial review pass found no introduced defects, and flagged one claim in this description as overstated — corrected in point 2 above. A later claim-fidelity pass (#501) fixed the same overstatement in the code comment and added the missing regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

