### PR TITLE
feat(artifact): drop "Ask an agent" from the selection popup

### DIFF
--- a/apps/web/src/pages/artifact/artifact-actions.ts
+++ b/apps/web/src/pages/artifact/artifact-actions.ts
@@ -6,7 +6,7 @@ import { commentsQuery } from "@/lib/queries"
 import { snapshot, useApiMutation } from "@/lib/use-api-mutation"
 import type { CommentActions } from "./comment-actions"
 import { toggleReaction } from "./lib/reactions"
-import type { AgentTarget, ComposerState, Sel, Selection } from "./types"
+import type { ComposerState, Sel, Selection } from "./types"
 
 type Me = { name?: string | null; email?: string | null } | null
 
@@ -218,14 +218,6 @@ export function useArtifactActions(p: {
     p.setComposer({ anchor: p.sel.selector, docTop: p.sel.docTop })
     p.setActiveThread(null)
   }
-  // Open the composer as a revision REQUEST addressed to `agent` (the "ask an agent to
-  // revise this selection" flow) — same anchored composer, pre-seeded with the mention so
-  // the posted note lands in the agent's MCP pull inbox.
-  const startSelAgent = (agent: AgentTarget) => {
-    if (!p.sel) return
-    p.setComposer({ anchor: p.sel.selector, docTop: p.sel.docTop, agent })
-    p.setActiveThread(null)
-  }
 
   // Reaction: optimistic toggle, rolled back on failure, then reconciled on settle. Edit is
   // likewise optimistic (below); delete refetches on success. All surface a failure via the
@@ -296,7 +288,6 @@ export function useArtifactActions(p: {
     toggleResolve,
     activate,
     startSelComment,
-    startSelAgent,
     actions,
     restore: (n: number) => restore.mutate(n),
     // Pending flags the page threads into the editor toolbar + version rail, replacing the

--- a/apps/web/src/pages/artifact/artifact-comments.tsx
+++ b/apps/web/src/pages/artifact/artifact-comments.tsx
@@ -3,14 +3,12 @@ import type { Comment, DirUser, Mention } from "@/api"
 import { Icon } from "@/components/icons"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
-import { AskAgentButton } from "./ask-agent"
 import { MobileComments, OpenPanel } from "./comment-panels"
 import { CommentScopeProvider } from "./lib/comment-scope"
 import { type CommentTree, CommentTreeProvider } from "./lib/comment-tree"
 import { quoteChipClass } from "./quote-chip"
 import { SelectionMenu } from "./selection-menu"
 import {
-  type AgentTarget,
   type AnchorConf,
   type ComposerState,
   type FrameGeom,
@@ -67,9 +65,8 @@ export function ArtifactComments(p: {
   submitNew: (text: string, mentions?: Mention[]) => void
   jumpTo: (threadId: string) => void
   startSelComment: () => void
-  /** Open the composer as a revision request addressed to `agent`. */
-  startSelAgent: (agent: AgentTarget) => void
-  /** Agents this viewer can hand a revision to (empty ⇒ the affordance is hidden). */
+  /** The artifact's registered agents — used only to tag agent-authored comments
+   *  (agentIds below); the selection composer no longer hands revisions to them. */
   agents: DirUser[]
   /** Deck artifacts: the slide being viewed, and where each thread's text resolved.
    *  Used by comment cards to show a "Slide N" / "moved" badge. */
@@ -190,14 +187,9 @@ export function ArtifactComments(p: {
             frameRef={p.frameRef}
             subscribeGeom={p.subscribeGeom}
             asideWidth={p.asideWidth}
-            agents={p.agents}
             onComment={() => {
               if (panel !== "open") p.setPanel("open")
               p.startSelComment()
-            }}
-            onAgent={(agent) => {
-              if (panel !== "open") p.setPanel("open")
-              p.startSelAgent(agent)
             }}
           />
         )}
@@ -215,15 +207,6 @@ export function ArtifactComments(p: {
                 ? selLabel(sel.selector)
                 : `“${selLabel(sel.selector) ?? ""}”`}
             </span>
-            <AskAgentButton
-              agents={p.agents}
-              size="bar"
-              onPick={(agent) => {
-                primer.current?.focus()
-                p.setPanel("open")
-                p.startSelAgent(agent)
-              }}
-            />
             <Button
               data-testid="mobile-comment-start"
               onClick={() => {

--- a/apps/web/src/pages/artifact/ask-agent.tsx
+++ b/apps/web/src/pages/artifact/ask-agent.tsx
@@ -1,6 +1,4 @@
 import type { DirUser } from "@/api"
-import { Icon } from "@/components/icons"
-import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -9,7 +7,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { getInitials } from "@/lib/initials"
-import { cn } from "@/lib/utils"
 import type { AgentTarget } from "./types"
 
 /** What "we handed this to your agent" means: the inbox is a PULL queue, so the work
@@ -75,55 +72,5 @@ export function AgentMenu({
         ))}
       </DropdownMenuContent>
     </DropdownMenu>
-  )
-}
-
-// The "ask an agent to revise this selection" affordance, shared by the desktop
-// selection pill and the mobile selection bar. This is Derive's agent-native moat: a
-// human hands a scoped change to a registered agent, whose MCP inbox the request lands
-// in; the agent revises + proposes, and the human reviews. With ONE agent it fires
-// immediately; with several it opens a small picker. `agents` empty ⇒ render nothing.
-export function AskAgentButton({
-  agents,
-  onPick,
-  size = "default",
-  className,
-}: {
-  agents: DirUser[]
-  onPick: (agent: AgentTarget) => void
-  /** "default" desktop pill · "bar" the fuller mobile bar button. */
-  size?: "default" | "bar"
-  className?: string
-}) {
-  // One Button recipe, whether it fires directly (a lone agent) or triggers the picker —
-  // so the affordance's look can't drift between the two paths. Desktop sits inside the
-  // selection bar's popover surface, so it takes the same flat ghost item as Comment; the
-  // mobile bar keeps its standalone rounded pill. onMouseDown preventDefault keeps it from
-  // stealing the document selection it acts on. The desktop pill names a lone agent ("Ask
-  // Reviser"); the mobile bar and the picker use the generic verb.
-  return (
-    <AgentMenu
-      agents={agents}
-      menuLabel="Ask an agent to revise"
-      testidPrefix="ask-agent"
-      onPick={onPick}
-      trigger={({ sole, onClick }) => (
-        <Button
-          variant={size === "bar" ? "outline" : "ghost"}
-          size="sm"
-          data-testid="ask-agent"
-          title={sole ? `Ask ${sole.name} to revise the selection` : undefined}
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={onClick}
-          className={cn(
-            size === "bar" && "shrink-0 rounded-full border-primary/30 hover:border-primary/50",
-            className,
-          )}
-        >
-          <Icon name="sparkles" size={size === "bar" ? 16 : 15} className="text-primary" />
-          {sole && size === "default" ? `Ask ${sole.name.split(/\s+/)[0]}` : "Ask an agent"}
-        </Button>
-      )}
-    />
   )
 }

--- a/apps/web/src/pages/artifact/comment-composer.tsx
+++ b/apps/web/src/pages/artifact/comment-composer.tsx
@@ -17,7 +17,6 @@ import { useIsMobile } from "@/lib/use-is-mobile"
 import { cn } from "@/lib/utils"
 import { useCommentScope } from "./lib/comment-scope"
 import { quoteChipClass } from "./quote-chip"
-import type { AgentTarget } from "./types"
 
 // Split the composer text into plain / mention runs for the highlight backdrop.
 // React renders each run (escaping text itself, so no innerHTML), and the inline
@@ -448,42 +447,24 @@ export function Composer({
   quote,
   onSubmit,
   onCancel,
-  agent,
 }: {
   quote: string | null
   onSubmit: (t: string, mentions: Mention[]) => void
   onCancel: () => void
-  /** Set when this is a revision REQUEST addressed to an agent — seeds the mention,
-   *  reframes the copy, and posts so the request drops into the agent's MCP inbox. */
-  agent?: AgentTarget
 }) {
-  // A request seeds `@Agent ` + the mention up front, so the note is addressed the
-  // moment it opens; a plain comment starts empty. The composer unmounts between opens
-  // (it only renders for a live composer), so this initial state re-seeds each time.
-  // MentionField's autofocus drops the caret after the seed (see its setSelectionRange).
-  const [text, setText] = useState(agent ? `@${agent.name} ` : "")
-  const [mentions, setMentions] = useState<Mention[]>(
-    agent ? [{ id: agent.id, name: agent.name }] : [],
-  )
+  // Starts empty; @mention anyone (including an agent) by typing. The composer unmounts
+  // between opens (it only renders for a live composer), so this initial state resets
+  // each time.
+  const [text, setText] = useState("")
+  const [mentions, setMentions] = useState<Mention[]>([])
   const submit = (resolved: Mention[]) => {
     if (text.trim()) onSubmit(text, resolved)
   }
   return (
     <div
-      data-testid={agent ? "agent-request-composer" : "comment-composer"}
-      className={cn(
-        "overflow-hidden rounded-lg border bg-card shadow-[var(--shadow)]",
-        // A request reads as a distinct, ink-tinted moment (the one place the accent
-        // carries a "hand this to an agent" action), not a plain neutral comment box.
-        agent ? "border-primary/40 ring-1 ring-primary/15" : "border-border",
-      )}
+      data-testid="comment-composer"
+      className="overflow-hidden rounded-lg border border-border bg-card shadow-[var(--shadow)]"
     >
-      {agent && (
-        <div className="flex items-center gap-1.5 border-b border-primary/20 bg-primary/5 px-2.5 py-1.5 text-sm font-medium text-foreground">
-          <Icon name="sparkles" size={14} className="text-primary" />
-          Ask {agent.name} to revise
-        </div>
-      )}
       {quote && (
         // Inset with the card's padding (the reference is context, not a banner).
         // Phones get a longer multi-line preview of what you're commenting on; the
@@ -514,11 +495,7 @@ export function Composer({
           onSubmit={submit}
           onCancel={onCancel}
           placeholder={
-            agent
-              ? "Describe the change… e.g. tighten this paragraph"
-              : quote
-                ? "Comment on the selection… (@ to mention)"
-                : "Add a comment… (@ to mention)"
+            quote ? "Comment on the selection… (@ to mention)" : "Add a comment… (@ to mention)"
           }
         />
         {/* The send is right-aligned and compact (a full-width filled bar made the
@@ -539,7 +516,7 @@ export function Composer({
             data-testid="composer-submit"
             onClick={() => submit(mentions.filter((m) => text.includes(`@${m.name}`)))}
           >
-            {agent ? "Send request" : "Comment"}
+            Comment
           </Button>
         </div>
       </div>

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -325,7 +325,6 @@ export function MobileComments({
         <div className="overflow-auto p-3 pb-[max(14px,env(safe-area-inset-bottom))]">
           <Composer
             quote={selLabel(composer.anchor)}
-            agent={composer.agent}
             // After posting, open the full list so the new comment is visible (the
             // sheet would otherwise drop back to the peek bar and hide it).
             onSubmit={(text, mentions) => {

--- a/apps/web/src/pages/artifact/comment-thread.tsx
+++ b/apps/web/src/pages/artifact/comment-thread.tsx
@@ -108,7 +108,7 @@ export function PinnedZone({
   // exactly when there's an anchored composer with a resolved position.
   const activeComposer =
     composer?.anchor && composer.docTop != null
-      ? { docTop: composer.docTop, quote: selLabel(composer.anchor), agent: composer.agent }
+      ? { docTop: composer.docTop, quote: selLabel(composer.anchor) }
       : null
   // Everything here is DOC-ABSOLUTE. The pin layer translates the whole stack by
   // `datum − scrollY − offset` imperatively (see use-pin-layer), so a scroll never
@@ -195,12 +195,7 @@ export function PinnedZone({
               transform: `translateY(${Math.round(pos[COMPOSER_ID] ?? activeComposer.docTop)}px)`,
             }}
           >
-            <Composer
-              quote={activeComposer.quote}
-              agent={activeComposer.agent}
-              onSubmit={onSubmitNew}
-              onCancel={onCancelNew}
-            />
+            <Composer quote={activeComposer.quote} onSubmit={onSubmitNew} onCancel={onCancelNew} />
           </div>
         )}
       </div>

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -355,7 +355,6 @@ export function Artifact() {
     toggleResolve,
     activate,
     startSelComment,
-    startSelAgent,
     actions,
     restore,
     publishing,
@@ -852,7 +851,6 @@ export function Artifact() {
               submitNew={submitNew}
               jumpTo={jumpTo}
               startSelComment={startSelComment}
-              startSelAgent={startSelAgent}
               agents={agents}
               currentSlide={deck?.i ?? null}
               landedSlides={landedSlides}

--- a/apps/web/src/pages/artifact/selection-menu.tsx
+++ b/apps/web/src/pages/artifact/selection-menu.tsx
@@ -1,17 +1,16 @@
 import { type RefObject, useLayoutEffect, useRef } from "react"
-import type { DirUser } from "@/api"
 import { Icon } from "@/components/icons"
 import { Button } from "@/components/ui/button"
-import { AskAgentButton } from "./ask-agent"
 import { clamp } from "./lib/layout"
-import type { AgentTarget, FrameGeom, Selection } from "./types"
+import type { FrameGeom, Selection } from "./types"
 
 /**
- * The action bar on a text selection — the SAME interaction as the original pill
- * (a compact horizontal bar above the selection, shown instantly; multiple agents
- * open the picker), restyled onto the popover grammar: surface + ring + pop
- * shadow, one flat item recipe for both verbs, and an arrow tethering it to the
- * highlighted text. No entrance animation — it appears in place, like before.
+ * The action bar on a text selection — a compact horizontal bar above the
+ * selection, shown instantly, restyled onto the popover grammar: surface + ring +
+ * pop shadow and an arrow tethering it to the highlighted text. No entrance
+ * animation — it appears in place. One verb: Comment. Addressing an agent is just
+ * an @mention typed into the composer (see the "Comments, Sessions & Presence"
+ * RFC) — not a parallel action here.
  *
  * The selection lives in the sandboxed iframe, so this positions against the
  * frame-reported rect: doc-absolute top (live against scroll, via the geometry
@@ -30,17 +29,13 @@ export function SelectionMenu({
   frameRef,
   subscribeGeom,
   asideWidth,
-  agents,
   onComment,
-  onAgent,
 }: {
   sel: NonNullable<Selection>
   frameRef: RefObject<HTMLIFrameElement | null>
   subscribeGeom: (cb: (g: FrameGeom) => void) => () => void
   asideWidth: number
-  agents: DirUser[]
   onComment: () => void
-  onAgent: (agent: AgentTarget) => void
 }) {
   const ref = useRef<HTMLDivElement>(null)
   const { docTop } = sel
@@ -96,10 +91,6 @@ export function SelectionMenu({
         <Icon name="comments" size={15} className="text-muted-foreground" />
         Comment
       </Button>
-      {agents.length > 0 && <span aria-hidden className="h-4 w-px bg-border-soft" />}
-      {/* The agent-native moat: hand the selected span to an agent to revise.
-          Single agent fires directly; several open the picker — as before. */}
-      <AskAgentButton agents={agents} onPick={onAgent} />
       {/* The tether: a rotated square riding the edge nearest the selection,
           its two exposed sides picking up the same hairline as the surface ring. */}
       <span

--- a/apps/web/src/pages/artifact/types.ts
+++ b/apps/web/src/pages/artifact/types.ts
@@ -78,20 +78,19 @@ export type Selection = {
   vRight: number
 } | null
 
-// An agent the composer is pre-addressed to (the "ask an agent to revise" flow): its
-// id + display name, so the request opens with `@Name ` seeded and posts a mention that
-// drops into the agent's MCP pull inbox.
+// A registered agent a canned request can be handed to (the Rework ⋯ item and the
+// Brandprint build request): its id + display name for the mention posted to the
+// agent's MCP inbox. (The selection composer no longer pre-addresses agents — you
+// @mention them by typing, like any collaborator.)
 export type AgentTarget = { id: string; name: string }
 
 // A pending new-comment composer: the anchor it pins to (null = a general, unanchored
 // comment) and the DOC-ABSOLUTE Y of that anchor (null for a general comment). Doc
 // coordinates, same as every pin, so the composer glides with its highlight when the
 // document scrolls — a viewport Y here was the "composer parks while cards glide" bug.
-// `agent` is set when this is a revision REQUEST addressed to an agent.
 export type ComposerState = {
   anchor: Sel | null
   docTop: number | null
-  agent?: AgentTarget
 } | null
 
 // A parsed anchor — text (a quote) or element (a non-text selector), read back from a


### PR DESCRIPTION
## What

Removes the **"Ask an agent"** button and agent picker from the text-selection popup. The selection popup is now a single **Comment** action; you address an agent the same way you address a teammate — by typing an `@mention` in the composer.

This is **Phase 1** of the [*Ask an Agent → Comments, Sessions & Presence* RFC](https://derive.to/artifacts/rfc-ask-an-agent-comments-sessions-presence-w00q7g55).

## Why

"Ask an agent" was presented as a parallel action to Comment, routed through a picker of registered agent grants ("Claude (Connor's)", "Pavel's claude", …). At the implementation level it was just a comment that `@mentions` an agent, writing to a pull inbox that **nothing services** — and in the dominant MCP flow there is **no standing agent to route to**: the "agent" is the Claude Code session the user is already driving. The picker mis-modeled that and reliably confused people (it's what kicked off the RFC).

Verified while scoping this: `catch_up(short_id)` already returns *every* open thread on a doc (no mention filter — `listComments(a.id, {state:"open"})`), so a session that holds a doc's id already sees your comments without any routing. The real gap is cross-doc discovery + wake + presence, which later phases address.

## Changes

- **selection-menu.tsx** — remove the agent button, divider, and `agents`/`onAgent` props. One verb: Comment.
- **artifact-comments.tsx** — drop the desktop `onAgent` wiring and the mobile bar's agent button. The `agents` prop **stays** — it still tags agent-authored comments (`agentIds`).
- **ask-agent.tsx** — delete the now-dead `AskAgentButton`. `AgentMenu` + helpers stay (still used by **Rework** and **Brandprint**, which are out of scope here).
- **comment-composer.tsx** — remove the agent-seeding path (pre-filled `@Agent`, ink-tint styling, "Send request" label). Typed `@mention` is unchanged, so you can still address an agent.
- **artifact-actions.ts / types.ts / comment-panels.tsx / comment-thread.tsx / index.tsx** — remove the now-unused `startSelAgent` and `ComposerState.agent` plumbing.

## Out of scope / follow-ups

- Rework (⋯ menu) and Brandprint build-request still use `AgentMenu` — untouched.
- Presence indicator, honest thread lifecycle (waiting → picked up → replied), and the wake-on-comment signal are later RFC phases.

## Verification

- ✅ `typecheck` (web)
- ✅ full `precommit` suite (biome, testids, frontend, deadcode/knip, boundaries, api-types, …)
- ✅ web unit tests — 156/156
- The 2 biome warnings are a **pre-existing** unrelated suppression in `comment-panels.tsx` (confirmed present on `main`).
- e2e `comments.screens.ts` uses `selection-menu` + `comment-on-selection`, both retained.