### PR TITLE
feat(mcp): wake a long-polling agent the instant it's @mentioned

### DIFF
--- a/apps/api/src/events.ts
+++ b/apps/api/src/events.ts
@@ -28,6 +28,11 @@ const DOMAIN_EVENTS = [
   // channel so their open tabs can auto-open the artifact. Not webhook-eligible
   // (it is a per-user UI signal, like `notification`).
   "artifact.pushed",
+  // A request landed in an agent's pull inbox (an @mention of that agent) —
+  // emitted on the agent's `u:<id>` channel so a session long-polling
+  // check_requests({wait}) wakes at once instead of on its next reconnect. A
+  // wake signal only (the handler re-reads the inbox); not webhook-eligible.
+  "request.created",
 ] as const
 export type DomainEvent = (typeof DOMAIN_EVENTS)[number]
 

--- a/apps/api/src/lib/mentions.ts
+++ b/apps/api/src/lib/mentions.ts
@@ -70,6 +70,15 @@ export const notifyMentions = async (
         body: cm.body_md,
         author: cm.author,
       })
+      // Wake a session that's long-polling this agent's inbox (check_requests's
+      // `wait`). Signal-only, mirroring the human bell path above — no body on the
+      // bus; the handler re-reads the inbox from the store. Fire-and-forget: an
+      // offline agent simply picks the row up on its next connect.
+      bus.publish(`u:${m.id}`, {
+        type: "request.created",
+        artifact: a.short_id,
+        thread_id: cm.thread_id,
+      })
       notified.push(m.name)
     }
   }

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -594,7 +594,7 @@ async function buildServer(
     "check_requests",
     {
       description:
-        "Your work queue: pending requests teammates handed you by @mentioning you in a comment (the ask-agent and Rework buttons land here). Each entry names the artifact, the comment thread, and what to do. Handle a request on its artifact — usually read it, do the asked revision, and publish with the thread id in `addresses` — then call this again with ack:[id,…] to clear what you finished. Unacked requests stay queued for your next session.",
+        "Your work queue: pending requests teammates handed you by @mentioning you in a comment (the ask-agent and Rework buttons land here). Each entry names the artifact, the comment thread, and what to do. Handle a request on its artifact — usually read it, do the asked revision, and publish with the thread id in `addresses` — then call this again with ack:[id,…] to clear what you finished. Unacked requests stay queued for your next session. WAITING FOR WORK? Pass `wait` (seconds, max 50): when the queue is empty the call blocks until a new request lands (or the time runs out), then returns it — chain `wait` calls to react in seconds instead of polling on a cadence.",
       inputSchema: {
         ack: z
           .array(z.string())
@@ -602,9 +602,18 @@ async function buildServer(
           .describe(
             "Request ids you have HANDLED — acknowledges them off the queue. Ack after the work lands (a publish or a reply), not on read; an unknown or already-acked id is skipped, never an error.",
           ),
+        wait: z
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .optional()
+          .describe(
+            "Long-poll: when nothing is queued, block up to this many seconds for a new request to land before returning. Returns immediately when work is already waiting.",
+          ),
       },
     },
-    async ({ ack }) => {
+    async ({ ack, wait }) => {
       // The queue this request already read at connect (a fresh server per request, so
       // it is this call's snapshot — and empty without a re-read for a grant that has
       // no inbox at all).
@@ -616,7 +625,29 @@ async function buildServer(
       const handled = new Set((ack ?? []).filter((id) => queue.some((m) => m.id === id)))
       let acked = 0
       for (const id of handled) if (await ctx.meta.ackAgentMention(agent.id, id)) acked++
-      const pending = queue.filter((m) => !handled.has(m.id))
+      let pending = queue.filter((m) => !handled.has(m.id))
+
+      // Long-poll: only a registered agent has an inbox to wait on. When nothing is
+      // pending, subscribe to this agent's channel, then RE-READ fresh (a request may
+      // have landed since connect, or during the wait) — the same check-then-wait gap
+      // close catch_up uses. The event is only a wake signal; we always answer from a
+      // fresh store read, so a missed or raced wake is never a wrong answer.
+      if (registered && wait && pending.length === 0 && ctx.bus.waitFor) {
+        const release = new AbortController()
+        const woke = ctx.bus
+          .waitFor(`u:${agent.id}`, ["request.created"], wait * 1000, release.signal)
+          .catch(() => null)
+        const fresh = await ctx.meta.listPendingAgentMentions(agent.id, AGENT_INBOX_PAGE)
+        if (fresh.length) {
+          release.abort()
+          await woke
+        } else {
+          await woke
+        }
+        pending = fresh.length
+          ? fresh
+          : await ctx.meta.listPendingAgentMentions(agent.id, AGENT_INBOX_PAGE)
+      }
       return json({
         acked,
         pending: pending.map((m) => ({

--- a/apps/api/test/mcp-inbox-wait.test.ts
+++ b/apps/api/test/mcp-inbox-wait.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest"
+import { createInProcessBackplane, type DeriveEvent } from "../src/bus"
+import { as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// Phase 2 slice 1 — the cross-doc wake. An @mention lands a row in the agent's
+// pull inbox AND publishes `request.created` on the agent's `u:<id>` channel, so a
+// session long-polling `check_requests({wait})` wakes in ~a beat instead of only
+// on its next reconnect. Mirrors catch_up's `wait`: the event is a wake signal
+// only, so the handler always answers from a fresh store read.
+
+const owner: TestUser = { id: "u_iw_own", email: "iwown@derive.test", name: "Owner" }
+
+type App = ReturnType<typeof makeAuthedApp>["app"]
+
+// A direct tools/call over the stateless /mcp endpoint (same shape as mcp-loop.test.ts).
+const call = async (
+  app: App,
+  token: string,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<Record<string, unknown>> => {
+  const res = await app.request("/mcp", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+  })
+  const ct = res.headers.get("content-type") ?? ""
+  const txt = await res.text()
+  const out = ct.includes("application/json")
+    ? JSON.parse(txt)
+    : JSON.parse(
+        (txt.split("\n").find((l) => l.startsWith("data:")) ?? "data:null").slice(5).trim(),
+      )
+  const t = (out?.result as { content?: { text: string }[] } | undefined)?.content?.[0]?.text
+  if (t == null) throw new Error(`no tool text: ${JSON.stringify(out)}`)
+  return JSON.parse(t)
+}
+
+// Register an agent (owner-only) and return its raw token + id.
+const registerAgent = async (app: App) => {
+  await app.request("/v1/me", { headers: as(owner.email) }) // claims ownership
+  const a = await (
+    await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Claude" }))
+  ).json()
+  return { agentId: a.id as string, agentToken: a.token as string }
+}
+
+const mention = (app: App, shortId: string, agentId: string, body: string) =>
+  app.request(
+    `/v1/artifacts/${shortId}/comments`,
+    jsonAs(as(owner.email), { body_md: body, mentions: [{ id: agentId, name: "Claude" }] }),
+  )
+
+describe("check_requests({wait}) — the cross-doc wake", () => {
+  it("blocks, then wakes the instant an @mention lands, and answers from a fresh read", async () => {
+    const backplane = createInProcessBackplane()
+    const { app } = makeAuthedApp("inbox-wait", [owner], "commenter", { deps: { backplane } })
+    const { agentId, agentToken } = await registerAgent(app)
+    const shortId = (
+      await (await publishAs(app, "<h1>draft</h1>", { visibility: "org" }, as(owner.email))).json()
+    ).short_id
+
+    // Record the agent's channel so the wake publish is pinned explicitly.
+    const woke: DeriveEvent[] = []
+    backplane.subscribe(`u:${agentId}`, (e) => woke.push(e))
+
+    // Start the long-poll BEFORE the mention exists — its connect snapshot is empty,
+    // so it must block on the wake rather than return immediately.
+    const waiting = call(app, agentToken, "check_requests", { wait: 10 })
+    const cm = await mention(app, shortId, agentId, "@Claude tighten the headline")
+    expect(cm.status).toBe(201)
+
+    const res = await waiting
+    const pending = res.pending as { request: string }[]
+    expect(pending).toHaveLength(1)
+    expect(pending[0]?.request).toContain("tighten the headline")
+    expect(woke.map((e) => e.type)).toContain("request.created")
+  })
+
+  it("returns immediately when a request is already queued (no needless block)", async () => {
+    const { app } = makeAuthedApp("inbox-ready", [owner], "commenter")
+    const { agentId, agentToken } = await registerAgent(app)
+    const shortId = (
+      await (await publishAs(app, "<h1>draft</h1>", { visibility: "org" }, as(owner.email))).json()
+    ).short_id
+    expect((await mention(app, shortId, agentId, "@Claude do the thing")).status).toBe(201)
+
+    // A generous wait that must NOT be spent: the request is already pending, so the
+    // call returns at once. (If it blocked the full 30s the test would time out.)
+    const started = Date.now()
+    const res = await call(app, agentToken, "check_requests", { wait: 30 })
+    expect(Date.now() - started).toBeLessThan(5_000)
+    expect(res.pending).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## What

`check_requests` gains a **`wait` long-poll**: when an agent's pull inbox is empty it blocks (up to 50s) until a new request lands, then returns it. So an agent session reacts to cross-doc `@mentions` in **~a beat** instead of only on its next reconnect.

The wake: `notifyMentions` now publishes a `request.created` event on the mentioned agent's `u:<id>` channel, right after the inbox row is committed — **signal-only**, mirroring the existing human-bell path (no comment body on the bus; the handler re-reads the inbox from the store).

**Phase 2, slice 1** of the [*Ask an Agent → Comments, Sessions & Presence* RFC](https://derive.to/artifacts/rfc-ask-an-agent-comments-sessions-presence-w00q7g55). It closes the one gap the RFC named as Phase 2's first item: **cross-doc discovery for a connected session**. (I verified in Phase 1 that per-artifact `comment.created` is already published, so `catch_up({wait})` on a held doc already worked; the missing piece was the *agent-channel* wake — this.)

## Why this shape

- **Faithful to the proven `catch_up({wait})` pattern** in the same file: subscribe *before* the state check to close the check-then-wait gap, and **always answer from a fresh store read**, so a missed or raced wake is never a wrong answer — only added latency.
- **Every mention path wakes**: `createAgentMention` has one caller (`notifyMentions`), which both the comment `@mention` route and Rework route through.
- **Strictly more restricted than what already shipped**: gated on `registered`, so only a workspace agent (which actually has an inbox) can block; an OAuth grant or anonymous caller returns immediately, exactly as before. `catch_up({wait})` is already open to any grant.

## Changes

- `apps/api/src/events.ts` — add `request.created` domain event (not webhook-eligible, like `notification`/`artifact.pushed`).
- `apps/api/src/lib/mentions.ts` — publish the wake on `u:<agentId>` after the inbox row commits.
- `apps/api/src/mcp.ts` — add `wait` to `check_requests`; long-poll the agent's channel and return fresh work.
- `apps/api/test/mcp-inbox-wait.test.ts` — new: pins that `wait` blocks then wakes on a new `@mention` (fails before the change), and returns immediately when work is already queued.

## Verification

- ✅ Test written **failing-first**, then made to pass (watched it fail with empty `pending` before the change).
- ✅ `typecheck` clean (the only error locally is a pre-existing `@huggingface/transformers` module not installed in my sandbox — unrelated, present on `main`).
- ✅ Blast-radius suite green: `mcp`, `mcp-loop`, `mcp-workspace-switch`, `agents`, `comments`, `realtime`, `bus`, `webhooks`, `webhook-adapter` + the new file (156 tests).
- ✅ Full precommit hook (biome + all custom lints) passed on commit.
- ⚠️ `oauth-refresh-rotation.test.ts` is flaky on `main` (fails identically with my change stashed) — pre-existing, not from this change.

## Adversarial review

Two independent refute-reviewers (correctness/concurrency; security/abuse/portability) — both **could not break it**:
- No subscription/promise/timer leaks; cleanup is idempotent on all exit paths (event / abort / timeout) in both the in-process and Durable Object backplanes.
- No information disclosure: `u:<id>` is not client-subscribable with a supplied id; the wake reaches only the mentioned agent, and `request.created` is excluded from webhook events.
- DO rendezvous verified: publish and `waitFor` map to the same room by channel name across isolates; the `waitUntil`-deferred publish stays alive.
- Wake-vs-commit ordering safe: row is committed before the wake; a lost wake degrades to the timeout re-read.

**One latent fragility (not a current bug), noted for the future:** `check_requests`'s ack filter (matching acks against the per-connect snapshot) is correct *only because* the MCP transport is stateless (a fresh snapshot per HTTP call). If MCP sessions ever become stateful, a `wait`-delivered row could become un-ackable. Left as-is to keep this diff to one idea; flagging it here and in project memory.

## Follow-ups (later Phase 2/3 slices)
- The visible thread lifecycle (waiting → picked up → replied) from `agent_mention.state` + presence.
- Client "watch mode" (a session parked on `check_requests({wait})` in a loop) — Phase 3.