### PR TITLE
feat(web): kind-aware collection glyphs; keep collections in the collapsed rail

### DIFF
--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, useLocation, useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
-import { api } from "@/api"
+import { api, type Collection } from "@/api"
 import { Icon, type IconName } from "@/components/icons"
 import { Logo } from "@/components/shared/logo"
 import { Input } from "@/components/ui/input"
@@ -30,6 +30,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useAuth } from "@/ctx"
+import { getMonogram } from "@/lib/initials"
 import { prTitle } from "@/lib/pr"
 import { collectionsQuery, summaryQuery, workspacesQuery } from "@/lib/queries"
 import { useBrandprintCollectionIds } from "@/lib/use-brandprint-ids"
@@ -139,6 +140,49 @@ function NavItem({
       <SidebarMenuButton asChild isActive={active} tooltip={label}>
         <Link to={to} {...linkProps}>
           <RowGlyph icon={icon} label={label} count={count} />
+        </Link>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  )
+}
+
+// A collection's leading glyph, chosen by kind: a repo mirror gets the folder-git
+// glyph, a PR preview the pull-request glyph, and an ordinary (manual) collection a
+// monochrome monogram tile — its initial in a neutral chip. The uniform folder icon
+// is gone from manual collections: identical on every row, it differentiated nothing;
+// the monogram gives each collection a leading letter that also survives the collapsed
+// icon rail. Monochrome by design (see icons.tsx) — the chrome stays out of the way of
+// the user's own coloured artifacts. The letter follows the same ink register as the
+// sibling svg glyphs (ROW_ICON): muted at rest, re-inked on hover and on the active
+// row, so a manual row's glyph doesn't read louder or dimmer than a repo/PR row's.
+function CollectionGlyph({ col }: { col: Collection }) {
+  if (col.kind === "repo") return <Icon name="repo" />
+  if (col.kind === "pr") return <Icon name="review" />
+  return (
+    <span
+      aria-hidden="true"
+      className="flex size-4 shrink-0 items-center justify-center rounded-sm bg-sidebar-foreground/10 font-mono text-2xs font-medium text-muted-foreground group-hover/menu-button:text-foreground group-data-[active=true]/menu-button:text-foreground"
+    >
+      {getMonogram(col.title)}
+    </span>
+  )
+}
+
+// One collection row — the common case (a repo with nested PR previews takes the
+// bespoke branch inline in NavRail). Mirrors FilterItem, but the glyph is kind-aware
+// (CollectionGlyph) rather than a fixed IconName, and it carries a tooltip so the
+// collapsed icon rail still names it.
+function CollectionRow({ col, active }: { col: Collection; active: boolean }) {
+  const linkProps = useRowLinkProps(col.title, active, `sidebar-collection-${col.id}`, col.count)
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton asChild isActive={active} tooltip={col.title}>
+        <Link to="/" search={{ collection: col.id }} {...linkProps}>
+          <CollectionGlyph col={col} />
+          <span>{col.title}</span>
+          {col.count > 0 && (
+            <SidebarMenuBadge className={COUNT_BADGE}>{col.count}</SidebarMenuBadge>
+          )}
         </Link>
       </SidebarMenuButton>
     </SidebarMenuItem>
@@ -445,8 +489,11 @@ export function NavRail() {
 
         {/* TIER 2 — your library: the things you've organized. Each list carries a
             mono eyebrow, so the section labels do the tier-separating work (no
-            divider needed between the eyebrowed groups). */}
-        <SidebarGroup className="group-data-[collapsible=icon]:hidden">
+            divider needed between the eyebrowed groups). Collections stay in the
+            collapsed icon rail (each row keeps its kind glyph + a tooltip), so you can
+            still reach a collection with the rail collapsed — the primitive auto-hides
+            the label, the + action, the counts, and any nested PR list in icon mode. */}
+        <SidebarGroup>
           <SidebarGroupLabel>Collections</SidebarGroupLabel>
           {/* The + stays neutral, not the accent: create-in-rail isn't a sanctioned
               ink moment. */}
@@ -481,8 +528,9 @@ export function NavRail() {
                 }}
                 onBlur={submitCollection}
                 // No text-size override: Input's base keeps 16px on touch (iOS
-                // no-zoom) and steps to 14px from sm up.
-                className="mb-1"
+                // no-zoom) and steps to 14px from sm up. Hidden in the collapsed icon
+                // rail (the + that opens it is hidden there too — no way to reach it).
+                className="mb-1 group-data-[collapsible=icon]:hidden"
               />
             )}
             <SidebarMenu>
@@ -496,21 +544,11 @@ export function NavRail() {
                 const childPrs = childPrsByRepo.get(col.id)
                 const colActive = onLibrary && search.collection === col.id
                 if (!childPrs || childPrs.length === 0)
-                  return (
-                    <FilterItem
-                      key={col.id}
-                      icon="collection"
-                      label={col.title}
-                      count={col.count}
-                      search={{ collection: col.id }}
-                      active={colActive}
-                      testId={`sidebar-collection-${col.id}`}
-                    />
-                  )
+                  return <CollectionRow key={col.id} col={col} active={colActive} />
                 const repoCollapsed = collapsedRepos.has(col.id)
                 return (
                   <SidebarMenuItem key={col.id}>
-                    <SidebarMenuButton asChild isActive={colActive}>
+                    <SidebarMenuButton asChild isActive={colActive} tooltip={col.title}>
                       <Link
                         to="/"
                         search={{ collection: col.id }}
@@ -521,7 +559,7 @@ export function NavRail() {
                         // pr-12 clears both the count and the fold action.
                         className={cn(ROW_ICON, col.count > 0 && "pr-12")}
                       >
-                        <Icon name="collection" />
+                        <CollectionGlyph col={col} />
                         <span>{col.title}</span>
                         {col.count > 0 && (
                           <SidebarMenuBadge className={cn(COUNT_BADGE, "right-7")}>

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -24,6 +24,7 @@ import {
   Fingerprint,
   Flag,
   Folder,
+  FolderGit2,
   Folders,
   GitPullRequest,
   Globe,
@@ -66,6 +67,9 @@ const REG = {
   following: Users,
   collections: Folders,
   collection: Folder,
+  // A mirrored GitHub repo collection — a folder-with-git glyph, distinct from the
+  // plain `collection` folder so a repo reads as code-backed at a glance.
+  repo: FolderGit2,
   context: Bot,
   // Brandprint — the brand's fingerprint.
   brandprint: Fingerprint,

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -371,7 +371,12 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        "no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        // Collapsed (icon) rail scrolls vertically when its content is taller than
+        // the viewport — the rail can now hold a data-driven collections list, so a
+        // long one must reach the pinned tools/footer instead of clipping. X stays
+        // hidden (no sideways scroll during the width transition); no-scrollbar hides
+        // the bar, matching the expanded rail.
+        "no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-x-hidden group-data-[collapsible=icon]:overflow-y-auto",
         className,
       )}
       {...props}

--- a/apps/web/src/lib/initials.test.ts
+++ b/apps/web/src/lib/initials.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { getInitials } from "./initials"
+import { getInitials, getMonogram } from "./initials"
 
 describe("getInitials", () => {
   it("takes the first two characters, uppercased", () => {
@@ -19,5 +19,26 @@ describe("getInitials", () => {
   })
   it("uses a caller-supplied fallback", () => {
     expect(getInitials("", "??")).toBe("??")
+  })
+})
+
+describe("getMonogram", () => {
+  it("takes the first character only, uppercased (a chrome-sized tile fits one glyph)", () => {
+    expect(getMonogram("Homepage")).toBe("H")
+    expect(getMonogram("brandprint")).toBe("B")
+  })
+  it("trims surrounding whitespace first", () => {
+    expect(getMonogram("  pricing")).toBe("P")
+  })
+  it("keeps a leading digit or symbol as-is", () => {
+    expect(getMonogram("2024 launch")).toBe("2")
+  })
+  it("keeps a leading emoji whole (no split surrogate pair)", () => {
+    expect(getMonogram("🚀 Launch")).toBe("🚀")
+  })
+  it("falls back for empty / null / undefined", () => {
+    expect(getMonogram("")).toBe("?")
+    expect(getMonogram(null)).toBe("?")
+    expect(getMonogram(undefined)).toBe("?")
   })
 })

--- a/apps/web/src/lib/initials.ts
+++ b/apps/web/src/lib/initials.ts
@@ -6,3 +6,14 @@ export const getInitials = (label: string | null | undefined, fallback = "?"): s
   const s = (label ?? "").trim()
   return s ? s.slice(0, 2).toUpperCase() : fallback
 }
+
+/** A single-letter monogram for a small chrome tile (e.g. a collection glyph in
+ *  the nav rail, sized to the icon slot where two letters wouldn't fit). First
+ *  character of the trimmed label, uppercased; an empty label yields the fallback.
+ *  Kept beside getInitials so the app derives leading glyphs one way. */
+export const getMonogram = (label: string | null | undefined, fallback = "?"): string => {
+  const s = (label ?? "").trim()
+  // First code POINT (Array.from splits by code point), so an emoji or astral-plane
+  // leading char stays whole instead of rendering half a surrogate pair.
+  return s ? (Array.from(s)[0] ?? fallback).toUpperCase() : fallback
+}


### PR DESCRIPTION
## What & why

Phase 1 of the Linear-style sidebar rework. Two problems in the nav rail:

1. **Every collection showed an identical folder icon** — visual noise that differentiated nothing (Linear/Apple would never put the same glyph on every row).
2. **Collections vanished entirely when the rail was collapsed**, so working with the rail collapsed (common when focused on an artifact) meant losing your way back to a sibling collection.

## Changes

- **Kind-aware collection glyphs** (`nav-rail.tsx`): manual collections get a monochrome monogram tile (leading letter via new `getMonogram`); repo collections get a distinct folder-git glyph — they *wrongly shared* the plain folder icon before; PR previews keep the pull-request glyph. New `CollectionGlyph` / `CollectionRow`; `FilterItem`/`NavItem` (fixed nav + tags) untouched.
- **Collections stay in the collapsed icon rail** (glyph + tooltip). The shadcn primitive already auto-hides the group label, `+`, counts, and nested PR list in icon mode; the create-input is hidden there too.
- **Collapsed rail now scrolls vertically** (`ui/sidebar.tsx`) so a long collections list still reaches the pinned tools/footer instead of clipping (the rail can now hold a data-driven list; `overflow-hidden` → explicit `overflow-x-hidden overflow-y-auto` for icon mode).
- Monogram follows the rail's documented ink register (muted at rest, re-inked on hover/active) so a manual row's glyph doesn't read louder/dimmer than a repo/PR row's. Monochrome by design — honors the `icons.tsx` chrome-stays-monochrome principle (decided with the design lead; color remains a future opt-in).
- `getMonogram` takes the first **code point** (not UTF-16 unit) so an emoji-led title isn't split into a broken surrogate half.

## Testing

- [x] `pnpm typecheck` passes
- [x] `pnpm exec biome ci .` reports 0 errors (on changed files; 2 pre-existing warnings in an unrelated file)
- [x] `pnpm test` passes (161 web unit tests, incl. new `getMonogram` cases)
- [x] Custom lints: `tokens`, `frontend`, `testids`, `surfaces`, `deadcode` all green
- [x] Added `getMonogram` unit tests (first-char, whitespace, digit, emoji, empty/null fallback)
- [x] **Drove the real app** (screens harness): verified monograms replace the folder icons in both themes; verified collections appear in the collapsed rail; verified Settings stays reachable with 14 collections collapsed (the scroll fix); asserted the active-row monogram re-inks (`rgb(20,22,26)` foreground vs `rgb(92,97,107)` muted).

<details><summary>Rail before/after — expanded + collapsed</summary>

Expanded: four collections now read as `H / B / P / Q` monogram tiles instead of four identical folders. Collapsed: the monograms persist as icon-rail tiles beneath the primary nav, and the rail scrolls to keep the footer reachable.

</details>

## Notes for reviewers

- Touches the shared `ui/sidebar.tsx` primitive (one line: collapsed overflow), needed so the now-populated collapsed rail can scroll. Only affects the desktop collapsed icon rail; the mobile Sheet isn't `collapsible=icon`.
- Frontend-only; no backend/schema/API change.
- This is Phase 1 of a larger rework — Phase 2 (breadcrumb artifact switcher) and Phase 3 (org-shared folders) are planned separately. Working doc: https://derive.to/artifacts/sidebar-rework-working-doc-901guwbe
