### PR TITLE
feat(web): artifact breadcrumb + sibling switcher within a collection

### DIFF
--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -99,6 +99,17 @@ export const brandprintDocsQuery = (collectionId: string) =>
       api.listArtifacts({ collection: collectionId, limit: 100 }).then((r) => r.artifacts),
   })
 
+// The artifacts in a collection, for the artifact header's sibling switcher (jump
+// between explorations in the same collection). Flat and capped at 100 in the
+// collection's own (recency) order — the switcher pages within that window; a rarely
+// larger collection just isn't fully reachable via prev/next (the library is).
+export const collectionSiblingsQuery = (collectionId: string) =>
+  queryOptions({
+    queryKey: ["artifacts", "siblings", collectionId] as const,
+    queryFn: () =>
+      api.listArtifacts({ collection: collectionId, limit: 100 }).then((r) => r.artifacts),
+  })
+
 // The active workspace's skills (bundles with a SKILL.md) — the shelf the Brandprint
 // "Add a skill" picker chooses from. Skill-ness rides the denormalized content type,
 // so this is a client-side narrow of the ordinary library listing.

--- a/apps/web/src/pages/artifact/artifact-breadcrumb.tsx
+++ b/apps/web/src/pages/artifact/artifact-breadcrumb.tsx
@@ -1,0 +1,197 @@
+import { useQuery } from "@tanstack/react-query"
+import { Link, useNavigate, useSearch } from "@tanstack/react-router"
+import { useCallback, useEffect } from "react"
+import type { Artifact } from "@/api"
+import { Icon } from "@/components/icons"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Kbd } from "@/components/ui/kbd"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { collectionSiblingsQuery, collectionsQuery } from "@/lib/queries"
+import { cn } from "@/lib/utils"
+import { resolveContextCollection, siblingNav } from "./lib/siblings"
+import { refFor } from "./parse-ref"
+
+// Shared title styling so the plain-title and switcher-trigger forms are pixel-identical
+// (the reframe's document header: serif, base, tight).
+const TITLE_CLASS = "truncate font-serif text-base font-medium leading-tight tracking-tight"
+
+// The document-title line in the artifact header. When the artifact was opened from a
+// collection (the `?collection=` context) — or belongs to exactly one — the title
+// becomes a breadcrumb: `Collection / Title`, where the collection links to its home and
+// the title is a switcher that pages between sibling artifacts in that collection.
+// `[` / `]` do the same from the keyboard. With no such context it's just the title,
+// exactly as before. The title is always the page's <h1>, in every branch. Hidden in
+// focus mode by the header wrapper (it stays mounted; keyboard paging is gated off then).
+export function ArtifactBreadcrumb({ art, focusMode }: { art: Artifact; focusMode: boolean }) {
+  const nav = useNavigate()
+  const { collection: paramCollection } = useSearch({ from: "/artifacts/$ref" })
+  const { data: collections = [] } = useQuery(collectionsQuery())
+  const contextId = resolveContextCollection(paramCollection, art.collections)
+  const { data: siblings = [] } = useQuery({
+    ...collectionSiblingsQuery(contextId ?? ""),
+    enabled: !!contextId,
+  })
+  const collectionTitle = contextId ? collections.find((c) => c.id === contextId)?.title : undefined
+
+  const { index, total, prev, next } = siblingNav(
+    siblings.map((s) => s.short_id),
+    art.short_id,
+  )
+
+  const goto = useCallback(
+    (target: string | null) => {
+      if (!target) return
+      const sib = siblings.find((s) => s.short_id === target)
+      if (!sib) return
+      nav({
+        to: "/artifacts/$ref",
+        params: { ref: refFor(sib) },
+        // Carry the context forward so the switcher persists across the jump.
+        search: contextId ? { collection: contextId } : {},
+      })
+    },
+    [siblings, nav, contextId],
+  )
+
+  // `[` / `]` page prev/next — free keys (arrows are taken for slide decks). Off in focus
+  // mode (the header is hidden — silent paging would eject you from a presented deck).
+  // Ignore while typing or with a dialog / menu / listbox open, and don't fight modified
+  // chords.
+  useEffect(() => {
+    if (focusMode || !contextId || (!prev && !next)) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return
+      if (e.key !== "[" && e.key !== "]") return
+      const t = e.target as HTMLElement | null
+      if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.isContentEditable)) return
+      if (document.querySelector('[role="dialog"],[role="menu"],[role="listbox"]')) return
+      e.preventDefault()
+      goto(e.key === "[" ? prev : next)
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [focusMode, contextId, prev, next, goto])
+
+  // No resolvable collection context (0 or ambiguously-many memberships, or its title
+  // isn't in reach) → the title alone, unchanged.
+  if (!contextId || !collectionTitle) {
+    return (
+      <h1 className={TITLE_CLASS} title={art.title ?? art.short_id}>
+        {art.title ?? art.short_id}
+      </h1>
+    )
+  }
+
+  const hasSwitcher = index >= 0 && total > 1
+
+  return (
+    <div className="flex min-w-0 items-center gap-1.5">
+      <Link
+        to="/"
+        search={{ collection: contextId }}
+        data-testid="breadcrumb-collection"
+        className="max-w-[11rem] shrink-0 truncate text-sm text-muted-foreground hover:text-foreground"
+        title={`Open ${collectionTitle}`}
+      >
+        {collectionTitle}
+      </Link>
+      <span aria-hidden="true" className="shrink-0 text-muted-foreground/50">
+        /
+      </span>
+      {hasSwitcher ? (
+        // The title stays the page's <h1>; the switcher control lives inside it.
+        <h1 className="flex min-w-0">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                data-testid="artifact-sibling-switcher"
+                title={art.title ?? art.short_id}
+                className={cn(
+                  TITLE_CLASS,
+                  "flex min-w-0 items-center gap-1 rounded-md text-left outline-none hover:text-foreground/70 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring",
+                )}
+              >
+                <span className="truncate">{art.title ?? art.short_id}</span>
+                <Icon name="caret" size={16} className="shrink-0 text-muted-foreground" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="max-h-80 w-72 overflow-auto">
+              {siblings.map((s) => (
+                <DropdownMenuItem
+                  key={s.short_id}
+                  data-testid={`sibling-option-${s.short_id}`}
+                  onSelect={() => goto(s.short_id)}
+                  className="gap-2"
+                >
+                  <span
+                    className={cn(
+                      "min-w-0 flex-1 truncate",
+                      s.short_id === art.short_id && "font-medium",
+                    )}
+                  >
+                    {s.title ?? s.short_id}
+                  </span>
+                  {s.short_id === art.short_id && (
+                    <Icon name="check" size={16} className="shrink-0 text-muted-foreground" />
+                  )}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </h1>
+      ) : (
+        <h1 className={TITLE_CLASS} title={art.title ?? art.short_id}>
+          {art.title ?? art.short_id}
+        </h1>
+      )}
+      {hasSwitcher && (
+        <div className="flex shrink-0 items-center gap-0.5 pl-1">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                aria-label="Previous artifact in collection"
+                data-testid="sibling-prev"
+                disabled={!prev}
+                onClick={() => goto(prev)}
+              >
+                <Icon name="chevron-left" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Previous <Kbd>[</Kbd>
+            </TooltipContent>
+          </Tooltip>
+          <span className="px-0.5 font-mono text-2xs tabular-nums text-muted-foreground">
+            {index + 1} / {total}
+          </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                aria-label="Next artifact in collection"
+                data-testid="sibling-next"
+                disabled={!next}
+                onClick={() => goto(next)}
+              >
+                <Icon name="chevron-right" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Next <Kbd>]</Kbd>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -17,6 +17,7 @@ import { useDocumentTitle } from "@/lib/use-document-title"
 import { useIsMobile } from "@/lib/use-is-mobile"
 import { cn } from "@/lib/utils"
 import { useArtifactActions } from "./artifact-actions"
+import { ArtifactBreadcrumb } from "./artifact-breadcrumb"
 import { ArtifactComments } from "./artifact-comments"
 import { ArtifactDocument } from "./artifact-document"
 import { ArtifactLoadError, ArtifactNotFound, ArtifactRemoved } from "./artifact-states"
@@ -376,6 +377,8 @@ export function Artifact() {
       nav({
         to: "/artifacts/$ref",
         params: { ref: refFor({ short_id: shortId, title: art?.title }) },
+        // Same artifact — keep the search (the ?collection switcher context, deep links).
+        search: (s) => s,
       }),
     onOpenReview: () => setReviewing({}),
     setEditing,
@@ -609,6 +612,8 @@ export function Artifact() {
               nav({
                 to: "/artifacts/$ref",
                 params: { ref: n === art.current_version ? base : `${base}@v${n}` },
+                // Same artifact, different version — preserve the ?collection context.
+                search: (s) => s,
               })
             }}
             open
@@ -639,12 +644,7 @@ export function Artifact() {
               bar's job is to say WHAT you're viewing and its state, not to be a run
               of icons — the actions collapse to the right. */}
           <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-            <h1
-              className="truncate font-serif text-base font-medium leading-tight tracking-tight"
-              title={art.title ?? shortId}
-            >
-              {art.title ?? shortId}
-            </h1>
+            <ArtifactBreadcrumb art={art} focusMode={focus} />
             <span className="truncate font-mono text-2xs tabular-nums text-muted-foreground">
               {artifactTypeLabel(art)} · v{art.current_version}
               {art.updated_at ? ` · updated ${ago(art.updated_at)}` : ""}

--- a/apps/web/src/pages/artifact/lib/siblings.test.ts
+++ b/apps/web/src/pages/artifact/lib/siblings.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { resolveContextCollection, siblingNav } from "./siblings"
+
+describe("resolveContextCollection", () => {
+  it("uses the ?collection param when the artifact is actually in it", () => {
+    expect(resolveContextCollection("c1", ["c1", "c2"])).toBe("c1")
+  })
+  it("ignores a stale param the artifact is NOT in, falling through", () => {
+    // param points at a collection the artifact left → fall back to its sole collection
+    expect(resolveContextCollection("gone", ["c2"])).toBe("c2")
+    // …or to nothing when it's ambiguous
+    expect(resolveContextCollection("gone", ["c2", "c3"])).toBeNull()
+  })
+  it("falls back to the sole collection when there's no valid param", () => {
+    expect(resolveContextCollection(undefined, ["only"])).toBe("only")
+  })
+  it("returns null when the artifact is in zero or many collections and no param picks one", () => {
+    expect(resolveContextCollection(undefined, [])).toBeNull()
+    expect(resolveContextCollection(undefined, ["a", "b"])).toBeNull()
+    expect(resolveContextCollection(undefined, undefined)).toBeNull()
+  })
+})
+
+describe("siblingNav", () => {
+  const ids = ["a", "b", "c"]
+  it("reports position and clamps prev/next at the ends (no wrap)", () => {
+    expect(siblingNav(ids, "a")).toEqual({ index: 0, total: 3, prev: null, next: "b" })
+    expect(siblingNav(ids, "b")).toEqual({ index: 1, total: 3, prev: "a", next: "c" })
+    expect(siblingNav(ids, "c")).toEqual({ index: 2, total: 3, prev: "b", next: null })
+  })
+  it("handles a current id missing from the list (no prev/next)", () => {
+    expect(siblingNav(ids, "x")).toEqual({ index: -1, total: 3, prev: null, next: null })
+  })
+  it("handles a single-item list", () => {
+    expect(siblingNav(["solo"], "solo")).toEqual({ index: 0, total: 1, prev: null, next: null })
+  })
+})

--- a/apps/web/src/pages/artifact/lib/siblings.ts
+++ b/apps/web/src/pages/artifact/lib/siblings.ts
@@ -1,0 +1,35 @@
+// Which collection provides the "sibling" context for the artifact view's breadcrumb
+// switcher, and where prev/next point within it. Pure so the resolution rules are
+// pinned by a test rather than tangled into the component.
+
+/** Resolve the collection whose artifacts the switcher pages through. Deterministic:
+ *  the `?collection=` param wins — but only if the artifact is actually a member (a
+ *  stale link that points at a collection it left must not lie); otherwise the sole
+ *  collection it belongs to; otherwise null (a 0- or ambiguously-multi-collection
+ *  artifact shows just its title, no switcher). */
+export function resolveContextCollection(
+  paramCollection: string | undefined,
+  artifactCollections: string[] | undefined,
+): string | null {
+  const cols = artifactCollections ?? []
+  if (paramCollection && cols.includes(paramCollection)) return paramCollection
+  if (cols.length === 1) return cols[0] ?? null
+  return null
+}
+
+/** The current artifact's position among its ordered siblings, plus the clamped
+ *  prev/next targets — null at the ends, so the switcher disables rather than wraps.
+ *  `index` is -1 when the current id isn't in the list (siblings still loading, or the
+ *  artifact dropped out of the collection), in which case there's no prev/next. */
+export function siblingNav(
+  siblingIds: string[],
+  currentId: string,
+): { index: number; total: number; prev: string | null; next: string | null } {
+  const index = siblingIds.indexOf(currentId)
+  return {
+    index,
+    total: siblingIds.length,
+    prev: index > 0 ? (siblingIds[index - 1] ?? null) : null,
+    next: index >= 0 && index < siblingIds.length - 1 ? (siblingIds[index + 1] ?? null) : null,
+  }
+}

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -181,6 +181,10 @@ function LibraryBody({ view }: { view: LibraryView }) {
       return {}
     }
   })
+  // Opening an artifact from a collection carries that collection as list context, so
+  // the artifact header can page between its siblings (the sibling switcher). Other
+  // feeds pass nothing — a direct/feed open has no single collection to page within.
+  const openContext = filter.kind === "collection" ? { collection: filter.id } : {}
   const showFolders = filter.kind === "collection" ? !!folderPrefs[filter.id] : false
   const setShowFolders = (on: boolean) => {
     if (filter.kind !== "collection") return
@@ -522,7 +526,9 @@ function LibraryBody({ view }: { view: LibraryView }) {
           hasNextPage={!!hasNextPage}
           isFetchingNextPage={isFetchingNextPage}
           onLoadMore={() => fetchNextPage()}
-          onOpen={(a) => nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })}
+          onOpen={(a) =>
+            nav({ to: "/artifacts/$ref", params: { ref: refFor(a) }, search: openContext })
+          }
           onToggleFavorite={toggleFavorite}
           onPickTag={(tag) => nav({ to: "/", search: { tag } })}
           onPickAuthor={pickAuthor}
@@ -540,7 +546,9 @@ function LibraryBody({ view }: { view: LibraryView }) {
             hasNextPage={!!hasNextPage}
             isFetchingNextPage={isFetchingNextPage}
             onLoadMore={() => fetchNextPage()}
-            onOpen={(a) => nav({ to: "/artifacts/$ref", params: { ref: refFor(a) } })}
+            onOpen={(a) =>
+              nav({ to: "/artifacts/$ref", params: { ref: refFor(a) }, search: openContext })
+            }
             onToggleFavorite={toggleFavorite}
             onPickTag={(tag) => nav({ to: "/", search: { tag } })}
             onEditTags={setPendingTags}

--- a/apps/web/src/routes/artifacts.$ref.tsx
+++ b/apps/web/src/routes/artifacts.$ref.tsx
@@ -10,9 +10,15 @@ export const Route = createFileRoute("/artifacts/$ref")({
   // human at a pending proposal (the Brandprint profile panel's "Review & comment") use
   // it — landing on the live version would show them the wrong thing, and with several
   // proposals open the overlay must not have to guess which one they meant.
-  validateSearch: (s: Record<string, unknown>): { comment?: string; review?: string } => ({
+  // `collection` carries the list context you opened FROM, so the header breadcrumb can
+  // page between siblings in that collection (dropped otherwise — a direct link has no
+  // context and falls back to the artifact's sole collection, if any).
+  validateSearch: (
+    s: Record<string, unknown>,
+  ): { comment?: string; review?: string; collection?: string } => ({
     ...(typeof s.comment === "string" && s.comment ? { comment: s.comment } : {}),
     ...(typeof s.review === "string" && s.review ? { review: s.review } : {}),
+    ...(typeof s.collection === "string" && s.collection ? { collection: s.collection } : {}),
   }),
   // Warm the artifact + its comments (and the rendered HTML the iframe loads) so
   // an intent-preloaded link opens instantly. Best-effort: the page owns the

--- a/scripts/check-surfaces.mjs
+++ b/scripts/check-surfaces.mjs
@@ -37,6 +37,7 @@ const QUERY_ALLOW = new Set([
   "components/chrome/app-shell.tsx", // workspace switcher, ambient
   "components/chrome/command-palette.tsx", // renders whatever's cached
   "components/chrome/sync-chip.tsx", // ambient status indicator
+  "pages/artifact/artifact-breadcrumb.tsx", // collections/siblings reads degrade to the title (no switcher)
   "pages/artifact/share-dialog.tsx", // reads the warm artifact cache (enabled:false)
   "pages/artifact/header-actions.tsx", // move-menu dropdown, warm read
   "pages/library/quick-organize.tsx", // reads the cached artifact row


### PR DESCRIPTION
## What & why

Phase 2 of the sidebar rework. When you're heads-down on an artifact you often want to hop to a sibling in the same collection without going back to the library (a user asked for exactly this: "switch quickly between assets within a collection"). Today there's no in-context navigation at all.

This adds a **breadcrumb in the artifact header** — `Collection / Title` — where the **title is a switcher** between sibling artifacts in the collection, **`[` / `]`** page prev/next, and the **collection name links to its home**. With no resolvable collection context the title renders exactly as before.

## Changes

- **Collection context threading:** open-from-collection now carries a validated `?collection=` param (it was dropped at navigation — the root fix). Resolution (pure, tested `resolveContextCollection`): the param if the artifact is actually in it, else its sole collection, else no switcher. Same-artifact navs (version history, reinstate) preserve the param.
- **`ArtifactBreadcrumb`:** the title is always the page's `<h1>` (the switcher control lives inside it); prev/next use the `Button` `icon-xs` primitive + `Tooltip` (which surfaces the `[` / `]` shortcut to keyboard/touch, not just a `title`); an `n / m` position sits between them and clamps at the ends (no wrap).
- **Keyboard:** `[` / `]` only (arrows stay reserved for slide decks). Gated off in focus/present mode and while a dialog/menu/listbox is open; ignores modified chords and typing targets.
- **Sibling list:** reuses `listArtifacts({collection})` (recency order, capped 100). Caveat: order reshuffles as items are edited, and a >100-item collection isn't fully reachable via prev/next (the library is) — acceptable for a switcher.

## Testing

- [x] `pnpm typecheck` passes
- [x] `pnpm exec biome ci .` — 0 errors on changed files
- [x] `pnpm test` — 168 web unit tests incl. new `resolveContextCollection` / `siblingNav` cases
- [x] Custom lints: `tokens`, `frontend`, `testids`, `surfaces`, `deadcode` all green
- [x] **Real run** (screens harness, since deleted): opened an artifact from a 4-item collection and verified breadcrumb + position `3 / 4`, next advances, `[` back, `]` forward, switcher-dropdown jump, and collection-name → home.
- [x] Adversarial review by two independent refuters; findings fixed (see below).

## Notes for reviewers

Two refute-reviewers ran against the diff. Fixed: a real a11y regression (the workbench lost its only `<h1>` when a switcher showed — now `<h1>` in every branch); `[` / `]` firing while a dropdown/menu was open (guard now covers `role=menu/listbox`); `[` / `]` ejecting you from a deck in focus mode (gated off); hand-rolled prev/next buttons + `title` attrs + 14px icons (now `Button` `icon-xs` + `Tooltip` + 16px). Accepted with reason: `collectionSiblingsQuery` duplicates `brandprintDocsQuery` — deduping means editing brandprint files another agent is actively working on, so I stayed out.

Frontend-only; no backend/schema change. Adds `collection?: string` to the `/artifacts/$ref` route's `validateSearch`. Phase 2 of the rework (Phase 1 = #470). Working doc: https://derive.to/artifacts/sidebar-rework-working-doc-901guwbe
