### PR TITLE
feat: org-shared folders — group collections in the sidebar (Phase 3)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1327,6 +1327,10 @@
           "repo": {
             "type": "string",
             "description": "For repo/PR collections: the \"owner/name\" slug."
+          },
+          "folderId": {
+            "type": "string",
+            "description": "The org-shared folder this collection is filed under, when any."
           }
         },
         "required": [
@@ -1335,6 +1339,30 @@
           "created_by",
           "created_at",
           "count"
+        ]
+      },
+      "Folder": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "created_by": {
+            "type": "string",
+            "description": "Creator's user id (\"anon\" if created anonymously)."
+          },
+          "created_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "created_by",
+          "created_at"
         ]
       },
       "GithubSyncStatus": {
@@ -5111,6 +5139,129 @@
         "responses": {
           "204": {
             "description": "The member was removed."
+          }
+        }
+      }
+    },
+    "/v1/folders": {
+      "get": {
+        "tags": [
+          "Folders"
+        ],
+        "summary": "List the active workspace's folders (members only).",
+        "responses": {
+          "200": {
+            "description": "The workspace's folders, in name order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "folders": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Folder"
+                      }
+                    }
+                  },
+                  "required": [
+                    "folders"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Folders"
+        ],
+        "summary": "Create a folder (workspace owners only).",
+        "responses": {
+          "201": {
+            "description": "The created folder.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Folder"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/folders/{id}": {
+      "patch": {
+        "tags": [
+          "Folders"
+        ],
+        "summary": "Rename a folder (workspace owners only).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The updated folder.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Folder"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Folders"
+        ],
+        "summary": "Delete a folder (workspace owners only); its collections become ungrouped.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted; member collections are un-filed, not removed."
+          }
+        }
+      }
+    },
+    "/v1/collections/{id}/folder": {
+      "put": {
+        "tags": [
+          "Folders"
+        ],
+        "summary": "File a collection under a folder, or ungroup it (workspace owners only).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Filed (or ungrouped when folderId is null)."
           }
         }
       }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -23,6 +23,7 @@ import { contextRoutes } from "./routes/contexts"
 import { domainRoutes } from "./routes/domains"
 import { embedRoutes } from "./routes/embeds"
 import { favoriteRoutes } from "./routes/favorites"
+import { folderRoutes } from "./routes/folders"
 import { followRoutes } from "./routes/follows"
 import { githubAppRoutes } from "./routes/github-app"
 import { moderationRoutes } from "./routes/moderation"
@@ -369,6 +370,7 @@ export function createApp(deps: AppDeps): Hono {
     favoriteRoutes,
     followRoutes,
     collectionRoutes,
+    folderRoutes,
     syncRoutes,
     slackRoutes,
     vitalsRoutes,

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -80,6 +80,10 @@ export const collectionRoutes = (ctx: AppContext) => {
         .describe("For a PR preview: the repo collection it nests under, when connected."),
       prNumber: z.number().optional().describe("For a PR preview: the pull-request number."),
       repo: z.string().optional().describe('For repo/PR collections: the "owner/name" slug.'),
+      folderId: z
+        .string()
+        .optional()
+        .describe("The org-shared folder this collection is filed under, when any."),
     })
     .openapi("Collection")
 
@@ -103,11 +107,14 @@ export const collectionRoutes = (ctx: AppContext) => {
     srcByCollection: Map<string, Src>,
     branchByRepo: Map<string, string>,
   ) => {
+    // Expose the stored folder_id under the client's camelCase `folderId` (like
+    // parentId/prNumber). Folders are pure organization — never an auth input.
+    const withFolder = { ...col, folderId: col.folder_id ?? undefined }
     const src = srcByCollection.get(col.id)
-    if (!src) return { ...col, kind: "manual" as const }
-    if (src.pr === null) return { ...col, kind: "repo" as const, repo: src.repo }
+    if (!src) return { ...withFolder, kind: "manual" as const }
+    if (src.pr === null) return { ...withFolder, kind: "repo" as const, repo: src.repo }
     return {
-      ...col,
+      ...withFolder,
       kind: "pr" as const,
       repo: src.repo,
       prNumber: src.pr,

--- a/apps/api/src/routes/folders.ts
+++ b/apps/api/src/routes/folders.ts
@@ -1,0 +1,176 @@
+import { newId } from "@derive/core"
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import type { Context } from "hono"
+import type { BlankEnv } from "hono/types"
+import type { AppContext } from "../context"
+import { bail, fail, readJson } from "../lib/http"
+
+/** Folders: an owner-editable, workspace-shared layer that groups collections in the
+ *  sidebar (Phase 3 of the sidebar rework). A folder grants NO access — it never appears
+ *  in any auth path; it only files collections (collection.folder_id). Reads are
+ *  member-scoped; every mutation is workspace-owner-only (requireWorkspace "manage"). The
+ *  Folder response schema is the single source for the web client's type. */
+export const folderRoutes = (ctx: AppContext) => {
+  const { meta, isMember, isToken, currentUser, activeWorkspace, requireWorkspace } = ctx
+  const app = new OpenAPIHono<BlankEnv>()
+
+  const Folder = z
+    .object({
+      id: z.string(),
+      name: z.string(),
+      created_by: z.string().describe('Creator\'s user id ("anon" if created anonymously).'),
+      created_at: z.string(),
+    })
+    .openapi("Folder")
+
+  const NAME_MAX = 80
+  const cleanName = (s: string) => s.trim().slice(0, NAME_MAX)
+
+  // Resolve the :id folder IN the caller's workspace (404 otherwise). Every mutation
+  // opens with this after the owner gate, so a folder from another workspace can't be
+  // touched even by its own owner.
+  const requireFolder = async (c: Context, org: string) => {
+    const id = c.req.param("id")
+    const f = id ? await meta.getFolder(id) : null
+    if (!f || f.org_id !== org) return fail(c, 404, "not found")
+    return f
+  }
+
+  app.openapi(
+    createRoute({
+      method: "get",
+      path: "/v1/folders",
+      tags: ["Folders"],
+      summary: "List the active workspace's folders (members only).",
+      responses: {
+        200: {
+          description: "The workspace's folders, in name order.",
+          content: { "application/json": { schema: z.object({ folders: z.array(Folder) }) } },
+        },
+      },
+    }),
+    async (c) => {
+      const me = await currentUser(c)
+      if (!me && !isToken(c)) return bail(fail(c, 401, "unauthenticated"))
+      const org = await activeWorkspace(c)
+      // Folders are shared workspace structure — members (or the operator token) see the
+      // tree; a non-member gets an empty list (they can't enumerate it).
+      if (!(await isMember(c, org))) return c.json({ folders: [] })
+      const folders = (await meta.listFolders(org)).sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+      )
+      return c.json({ folders })
+    },
+  )
+
+  app.openapi(
+    createRoute({
+      method: "post",
+      path: "/v1/folders",
+      tags: ["Folders"],
+      summary: "Create a folder (workspace owners only).",
+      responses: {
+        201: {
+          description: "The created folder.",
+          content: { "application/json": { schema: Folder } },
+        },
+      },
+    }),
+    async (c) => {
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
+      const body = await readJson(
+        c,
+        z.object({ name: z.string().refine((s) => s.trim() !== "", "name required") }),
+      )
+      if (body instanceof Response) return bail(body)
+      const me = await currentUser(c)
+      const created = await meta.createFolder({
+        id: newId("fld"),
+        org_id: org,
+        name: cleanName(body.name),
+        created_by: me?.id ?? "anon",
+      })
+      return c.json(created, 201)
+    },
+  )
+
+  app.openapi(
+    createRoute({
+      method: "patch",
+      path: "/v1/folders/{id}",
+      tags: ["Folders"],
+      summary: "Rename a folder (workspace owners only).",
+      request: { params: z.object({ id: z.string() }) },
+      responses: {
+        200: {
+          description: "The updated folder.",
+          content: { "application/json": { schema: Folder } },
+        },
+      },
+    }),
+    async (c) => {
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
+      const f = await requireFolder(c, org)
+      if (f instanceof Response) return bail(f)
+      const body = await readJson(c, z.object({ name: z.string().optional() }))
+      if (body instanceof Response) return bail(body)
+      const name = body.name !== undefined ? cleanName(body.name) : undefined
+      // A provided-but-blank name is rejected, matching create — don't persist an
+      // empty folder name (an invisible row in the rail).
+      if (name === "") return bail(fail(c, 400, "name required"))
+      const updated = await meta.updateFolder(f.id, { name })
+      if (!updated) return bail(fail(c, 404, "not found"))
+      return c.json(updated)
+    },
+  )
+
+  app.openapi(
+    createRoute({
+      method: "delete",
+      path: "/v1/folders/{id}",
+      tags: ["Folders"],
+      summary: "Delete a folder (workspace owners only); its collections become ungrouped.",
+      request: { params: z.object({ id: z.string() }) },
+      responses: { 204: { description: "Deleted; member collections are un-filed, not removed." } },
+    }),
+    async (c) => {
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
+      const f = await requireFolder(c, org)
+      if (f instanceof Response) return bail(f)
+      await meta.deleteFolder(f.id)
+      return c.body(null, 204)
+    },
+  )
+
+  app.openapi(
+    createRoute({
+      method: "put",
+      path: "/v1/collections/{id}/folder",
+      tags: ["Folders"],
+      summary: "File a collection under a folder, or ungroup it (workspace owners only).",
+      request: { params: z.object({ id: z.string() }) },
+      responses: { 204: { description: "Filed (or ungrouped when folderId is null)." } },
+    }),
+    async (c) => {
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
+      const col = await meta.getCollection(c.req.param("id"))
+      if (!col || col.org_id !== org) return bail(fail(c, 404, "not found"))
+      const body = await readJson(c, z.object({ folderId: z.string().nullable() }))
+      if (body instanceof Response) return bail(body)
+      // A non-null target must be a real folder in THIS workspace (folders never cross
+      // workspaces, and an unknown id must not silently orphan the pointer).
+      if (body.folderId !== null) {
+        const f = await meta.getFolder(body.folderId)
+        if (!f || f.org_id !== org) return bail(fail(c, 404, "folder not found"))
+      }
+      await meta.setCollectionFolder(col.id, body.folderId)
+      return c.body(null, 204)
+    },
+  )
+
+  return app
+}

--- a/apps/api/test/folders.test.ts
+++ b/apps/api/test/folders.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest"
+import { app, as, makeAuthedApp, meta, postJson, type TestUser } from "./helpers"
+
+describe("folders", () => {
+  const putJson = (path: string, body: unknown, headers: Record<string, string> = {}) =>
+    app.request(path, {
+      method: "PUT",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    })
+
+  it("owner creates + lists + renames folders; the list is case-insensitive alphabetical", async () => {
+    const beta = await (await postJson("/v1/folders", { name: "Beta" })).json()
+    const alpha = await (await postJson("/v1/folders", { name: "alpha" })).json()
+    expect(beta.name).toBe("Beta")
+    expect(alpha.name).toBe("alpha")
+
+    const list = await (await app.request("/v1/folders")).json()
+    const names = list.folders.map((f: { name: string }) => f.name)
+    expect(names).toEqual(["alpha", "Beta"]) // A–Z, case-insensitive
+
+    const renamed = await app.request(`/v1/folders/${beta.id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Bravo" }),
+    })
+    expect(renamed.status).toBe(200)
+    expect((await meta.getFolder(beta.id))?.name).toBe("Bravo")
+  })
+
+  it("files a collection under a folder (exposes folderId); deleting the folder un-files it, collection survives", async () => {
+    const folder = await (await postJson("/v1/folders", { name: "Rebrand" })).json()
+    const col = await (await postJson("/v1/collections", { title: "Homepage" })).json()
+    expect(
+      (await putJson(`/v1/collections/${col.id}/folder`, { folderId: folder.id })).status,
+    ).toBe(204)
+
+    const list = await (await app.request("/v1/collections")).json()
+    expect(list.collections.find((c: { id: string }) => c.id === col.id)?.folderId).toBe(folder.id)
+
+    expect((await app.request(`/v1/folders/${folder.id}`, { method: "DELETE" })).status).toBe(204)
+    expect(await meta.getFolder(folder.id)).toBeNull()
+    // The collection survives, un-filed.
+    expect((await meta.getCollection(col.id))?.folder_id ?? null).toBeNull()
+    const after = await (await app.request("/v1/collections")).json()
+    expect(after.collections.find((c: { id: string }) => c.id === col.id)?.folderId).toBeUndefined()
+  })
+
+  it("ungroups a collection when folderId is null", async () => {
+    const folder = await (await postJson("/v1/folders", { name: "Temp" })).json()
+    const col = await (await postJson("/v1/collections", { title: "C" })).json()
+    await putJson(`/v1/collections/${col.id}/folder`, { folderId: folder.id })
+    expect((await putJson(`/v1/collections/${col.id}/folder`, { folderId: null })).status).toBe(204)
+    expect((await meta.getCollection(col.id))?.folder_id ?? null).toBeNull()
+  })
+
+  it("rejects filing under an unknown folder (404)", async () => {
+    const col = await (await postJson("/v1/collections", { title: "C2" })).json()
+    expect(
+      (await putJson(`/v1/collections/${col.id}/folder`, { folderId: "fld_missing" })).status,
+    ).toBe(404)
+  })
+
+  it("rejects a blank rename (matches create)", async () => {
+    const folder = await (await postJson("/v1/folders", { name: "Keep" })).json()
+    const res = await app.request(`/v1/folders/${folder.id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "   " }),
+    })
+    expect(res.status).toBe(400)
+    expect((await meta.getFolder(folder.id))?.name).toBe("Keep")
+  })
+
+  it("won't file a collection under a folder from another workspace (404)", async () => {
+    // Folder lives in the default app's workspace…
+    const folder = await (await postJson("/v1/folders", { name: "Theirs" })).json()
+    // …a different, isolated workspace's owner has their own collection…
+    const solo: TestUser = {
+      id: "u_fld_solo",
+      email: "solo@fld.test",
+      name: "Solo",
+      username: "solof",
+    }
+    const { app: other } = makeAuthedApp("folders-xws", [solo], undefined, { isolated: true })
+    const col = await (
+      await other.request("/v1/collections", {
+        method: "POST",
+        headers: { "content-type": "application/json", ...as(solo.email) },
+        body: JSON.stringify({ title: "Mine" }),
+      })
+    ).json()
+    // …and cannot file it under the other workspace's folder (folder not in their org).
+    const res = await other.request(`/v1/collections/${col.id}/folder`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", ...as(solo.email) },
+      body: JSON.stringify({ folderId: folder.id }),
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it("folder mutations are workspace-owner-only; a member editor can read but not write", async () => {
+    const owner: TestUser = {
+      id: "u_fld_own",
+      email: "own@fld.test",
+      name: "Own",
+      username: "ownf",
+    }
+    const ed: TestUser = { id: "u_fld_ed", email: "ed@fld.test", name: "Ed", username: "edf" }
+    const { app: team } = makeAuthedApp("folders-roles", [owner, ed], "editor")
+
+    const created = await team.request("/v1/folders", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...as(owner.email) },
+      body: JSON.stringify({ name: "Team" }),
+    })
+    expect(created.status).toBe(201)
+    const folder = await created.json()
+
+    // The editor sees the shared folder tree…
+    const list = await (await team.request("/v1/folders", { headers: as(ed.email) })).json()
+    expect(list.folders.map((f: { id: string }) => f.id)).toContain(folder.id)
+
+    // …but can't create / rename / delete (owner-only).
+    const create = await team.request("/v1/folders", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...as(ed.email) },
+      body: JSON.stringify({ name: "Nope" }),
+    })
+    expect(create.status).toBe(403)
+    const rename = await team.request(`/v1/folders/${folder.id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json", ...as(ed.email) },
+      body: JSON.stringify({ name: "X" }),
+    })
+    expect(rename.status).toBe(403)
+    const del = await team.request(`/v1/folders/${folder.id}`, {
+      method: "DELETE",
+      headers: as(ed.email),
+    })
+    expect(del.status).toBe(403)
+  })
+})

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -2506,6 +2506,158 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/folders": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the active workspace's folders (members only). */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The workspace's folders, in name order. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            folders: components["schemas"]["Folder"][];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create a folder (workspace owners only). */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The created folder. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Folder"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/folders/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a folder (workspace owners only); its collections become ungrouped. */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Deleted; member collections are un-filed, not removed. */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** Rename a folder (workspace owners only). */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The updated folder. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Folder"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/v1/collections/{id}/folder": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** File a collection under a folder, or ungroup it (workspace owners only). */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Filed (or ungrouped when folderId is null). */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/sync/github/resync-installations": {
         parameters: {
             query?: never;
@@ -5592,6 +5744,15 @@ export interface components {
             prNumber?: number;
             /** @description For repo/PR collections: the "owner/name" slug. */
             repo?: string;
+            /** @description The org-shared folder this collection is filed under, when any. */
+            folderId?: string;
+        };
+        Folder: {
+            id: string;
+            name: string;
+            /** @description Creator's user id ("anon" if created anonymously). */
+            created_by: string;
+            created_at: string;
         };
         GithubSyncStatus: {
             /** @description Branch mirrors, one per connected repo. */

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -75,6 +75,7 @@ export type Report = components["schemas"]["Report"]
  *  (kind = manual / repo / pr). Generated from the OpenAPI spec (apps/api/openapi.json)
  *  — a backend shape change surfaces here at `tsc`. */
 export type Collection = components["schemas"]["Collection"]
+export type Folder = components["schemas"]["Folder"]
 /** The result of a /v1/bulk/* op: counts per artifact (skipped = not yours to touch). */
 export type BulkSummary = components["schemas"]["BulkSummary"]
 /** A collection whose sharing reaches an artifact (workspace-open, or invite-only with
@@ -843,6 +844,19 @@ export const api = {
     f(`/v1/collections/${id}/access`, { ...opts({ workspaceAccess }), method: "PATCH" }).then(j),
   addToCollection: (collectionId: string, shortId: string): Promise<void> =>
     f(`/v1/collections/${collectionId}/items/${shortId}`, { ...opts(), method: "PUT" }).then(
+      () => undefined,
+    ),
+  // Folders (owner-editable org grouping; grant no access). Mutations are workspace-
+  // owner-only server-side — the UI hides them for non-owners.
+  listFolders: (): Promise<{ folders: Folder[] }> => f("/v1/folders", opts()).then(j),
+  createFolder: (name: string): Promise<Folder> => f("/v1/folders", opts({ name })).then(j),
+  renameFolder: (id: string, name: string): Promise<Folder> =>
+    f(`/v1/folders/${id}`, { ...opts({ name }), method: "PATCH" }).then(j),
+  deleteFolder: (id: string): Promise<void> =>
+    f(`/v1/folders/${id}`, { method: "DELETE", credentials: "include" }).then(() => undefined),
+  // File a collection under a folder (or null to ungroup).
+  setCollectionFolder: (collectionId: string, folderId: string | null): Promise<void> =>
+    f(`/v1/collections/${collectionId}/folder`, { ...opts({ folderId }), method: "PUT" }).then(
       () => undefined,
     ),
   removeFromCollection: (collectionId: string, shortId: string): Promise<void> =>

--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -1,9 +1,20 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, useLocation, useNavigate } from "@tanstack/react-router"
-import { useState } from "react"
-import { api, type Collection } from "@/api"
+import { Fragment, type ReactNode, useState } from "react"
+import { api, type Collection, type Folder } from "@/api"
 import { Icon, type IconName } from "@/components/icons"
+import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { Logo } from "@/components/shared/logo"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
 import { Kbd } from "@/components/ui/kbd"
 import {
@@ -32,7 +43,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useAuth } from "@/ctx"
 import { getMonogram } from "@/lib/initials"
 import { prTitle } from "@/lib/pr"
-import { collectionsQuery, summaryQuery, workspacesQuery } from "@/lib/queries"
+import { collectionsQuery, foldersQuery, summaryQuery, workspacesQuery } from "@/lib/queries"
 import { useBrandprintCollectionIds } from "@/lib/use-brandprint-ids"
 import { cn } from "@/lib/utils"
 import type { LibrarySearch } from "@/pages/library/types"
@@ -172,20 +183,106 @@ function CollectionGlyph({ col }: { col: Collection }) {
 // bespoke branch inline in NavRail). Mirrors FilterItem, but the glyph is kind-aware
 // (CollectionGlyph) rather than a fixed IconName, and it carries a tooltip so the
 // collapsed icon rail still names it.
-function CollectionRow({ col, active }: { col: Collection; active: boolean }) {
+function CollectionRow({
+  col,
+  active,
+  menuAction,
+  indented,
+}: {
+  col: Collection
+  active: boolean
+  // An owner-only ⋯ action (the move-to-folder menu) rendered as a sibling of the row;
+  // when present the count badge shifts left to clear it (mirrors the repo row).
+  menuAction?: ReactNode
+  // Filed under a folder → a left border + inset, reusing the rail's PR-nesting grammar
+  // so a folder's contents read as nested (and the ungrouped block below reads as
+  // separate). Only in the expanded rail — the icon rail shows every collection flat.
+  indented?: boolean
+}) {
   const linkProps = useRowLinkProps(col.title, active, `sidebar-collection-${col.id}`, col.count)
   return (
-    <SidebarMenuItem>
+    <SidebarMenuItem className={cn(indented && "ml-3.5 border-sidebar-border border-l")}>
       <SidebarMenuButton asChild isActive={active} tooltip={col.title}>
-        <Link to="/" search={{ collection: col.id }} {...linkProps}>
+        <Link
+          to="/"
+          search={{ collection: col.id }}
+          {...linkProps}
+          className={cn(ROW_ICON, col.count > 0 && (menuAction ? "pr-12" : "pr-7"))}
+        >
           <CollectionGlyph col={col} />
           <span>{col.title}</span>
           {col.count > 0 && (
-            <SidebarMenuBadge className={COUNT_BADGE}>{col.count}</SidebarMenuBadge>
+            <SidebarMenuBadge className={cn(COUNT_BADGE, menuAction && "right-7")}>
+              {col.count}
+            </SidebarMenuBadge>
           )}
         </Link>
       </SidebarMenuButton>
+      {menuAction}
     </SidebarMenuItem>
+  )
+}
+
+// The owner-only ⋯ menu on a collection row: file it into a folder, move between
+// folders, or remove it from its folder. Rendered as a SidebarMenuAction so it sits in
+// the row's action slot (hidden in the collapsed icon rail by the primitive).
+function CollectionMoveMenu({
+  col,
+  folders,
+  onMove,
+}: {
+  col: Collection
+  folders: Folder[]
+  onMove: (collectionId: string, folderId: string | null) => void
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <SidebarMenuAction
+          aria-label={`Organize ${col.title}`}
+          data-testid={`sidebar-collection-${col.id}-menu`}
+          showOnHover
+          className="text-muted-foreground hover:text-foreground"
+        >
+          <Icon name="more" />
+        </SidebarMenuAction>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="right" align="start" className="w-52">
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <Icon name="collections" className="mr-2 size-4 text-muted-foreground" />
+            Move to folder
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="max-h-72 w-52 overflow-auto">
+            {folders.length === 0 && <DropdownMenuItem disabled>No folders yet</DropdownMenuItem>}
+            {folders.map((f) => (
+              <DropdownMenuItem
+                key={f.id}
+                data-testid={`move-to-folder-${f.id}`}
+                disabled={col.folderId === f.id}
+                onSelect={() => onMove(col.id, f.id)}
+              >
+                <span className="truncate">{f.name}</span>
+                {col.folderId === f.id && (
+                  <Icon name="check" className="ml-auto size-4 text-muted-foreground" />
+                )}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        {col.folderId && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              data-testid={`sidebar-collection-${col.id}-ungroup`}
+              onSelect={() => onMove(col.id, null)}
+            >
+              Remove from folder
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 
@@ -349,11 +446,17 @@ export function NavRail() {
     enabled: !!me,
   })
   const { data: workspaces } = useQuery({ ...workspacesQuery(), enabled: !!me })
+  // Org-shared folders (grouping only). Read for everyone; only owners see the
+  // management affordances below (the server also owner-gates every folder mutation).
+  const { data: folders = [] } = useQuery({ ...foldersQuery(), enabled: !!me })
   // The pod subtitle: "Personal" for the auto-provisioned workspace (its stored
   // name is provisioning plumbing), else the summary's workspace name.
   const activeWs = workspaces?.workspaces.find((w) => w.id === workspaces.active)
+  // Folder editing is workspace-owner-only (matches the API gate); non-owners just see
+  // the shared tree, no manage menus.
+  const isOwner = activeWs?.role === "owner"
   const workspaceLabel = activeWs?.personal ? "Personal" : (summary?.workspace ?? "")
-  const { setOpenMobile } = useSidebar()
+  const { state, setOpenMobile } = useSidebar()
   const nav = useNavigate()
   const loc = useLocation()
   const search = loc.search as LibrarySearch
@@ -420,293 +523,524 @@ export function NavRail() {
     }
   }
 
+  // ---- Folders (owner-managed org grouping) --------------------------------
+  const [collapsedFolders, setCollapsedFolders] = useState<Set<string>>(new Set())
+  const toggleFolder = (id: string) =>
+    setCollapsedFolders((prev) => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+  const [creatingFolder, setCreatingFolder] = useState(false)
+  const [newFolderName, setNewFolderName] = useState("")
+  const [renamingFolder, setRenamingFolder] = useState<string | null>(null)
+  const [renameName, setRenameName] = useState("")
+  const [deletingFolder, setDeletingFolder] = useState<Folder | null>(null)
+  const refetchFolders = () => qc.invalidateQueries({ queryKey: foldersQuery().queryKey })
+  const refetchCollections = () => qc.invalidateQueries({ queryKey: collectionsQuery().queryKey })
+
+  const submitFolder = async () => {
+    const name = newFolderName.trim()
+    setNewFolderName("")
+    setCreatingFolder(false)
+    if (!name) return
+    try {
+      await api.createFolder(name)
+      refetchFolders()
+    } catch {
+      /* surfaced on next action */
+    }
+  }
+  const submitRename = async (id: string) => {
+    const name = renameName.trim()
+    setRenamingFolder(null)
+    setRenameName("")
+    if (!name) return
+    try {
+      await api.renameFolder(id, name)
+      refetchFolders()
+    } catch {
+      /* surfaced on next action */
+    }
+  }
+  const confirmDelete = async () => {
+    if (!deletingFolder) return
+    // Let errors propagate: ConfirmDialog keeps itself open on a throw (and closes on
+    // resolve, clearing deletingFolder via onOpenChange) — a destructive action must not
+    // fail silently.
+    await api.deleteFolder(deletingFolder.id)
+    refetchFolders()
+    refetchCollections() // its collections are now ungrouped
+  }
+  const moveToFolder = async (collectionId: string, folderId: string | null) => {
+    try {
+      await api.setCollectionFolder(collectionId, folderId)
+      refetchCollections()
+    } catch {
+      /* surfaced on next action */
+    }
+  }
+
+  // Group the (already accessible-only) top collections by folder. A folder shows when it
+  // holds ≥1 visible collection, OR when the viewer is an owner (owners see empty folders
+  // as a management surface). Everything else stays flat below, exactly as before. Repo
+  // collections keep their own nesting and never carry a folder in v1.
+  const byFolder = new Map<string, typeof collections>()
+  const ungrouped: typeof collections = []
+  for (const col of topCollections) {
+    const fid = col.folderId
+    if (fid && folders.some((f) => f.id === fid)) {
+      const arr = byFolder.get(fid) ?? []
+      arr.push(col)
+      byFolder.set(fid, arr)
+    } else ungrouped.push(col)
+  }
+  // folders arrive name-sorted from the server.
+  const visibleFolders = folders.filter((f) => isOwner || (byFolder.get(f.id)?.length ?? 0) > 0)
+
+  // One collection row — the ungrouped/flat case and each folder's children share it.
+  // A repo with nested PRs keeps its bespoke collapsible row; everything else is a
+  // CollectionRow, with an owner-only move-to-folder menu on manual collections.
+  const renderCollection = (col: Collection, indented?: boolean) => {
+    const childPrs = childPrsByRepo.get(col.id)
+    const colActive = onLibrary && search.collection === col.id
+    if (!childPrs || childPrs.length === 0) {
+      const menuAction =
+        isOwner && col.kind !== "repo" && col.kind !== "pr" ? (
+          <CollectionMoveMenu col={col} folders={folders} onMove={moveToFolder} />
+        ) : undefined
+      return (
+        <CollectionRow
+          key={col.id}
+          col={col}
+          active={colActive}
+          menuAction={menuAction}
+          indented={indented}
+        />
+      )
+    }
+    const repoCollapsed = collapsedRepos.has(col.id)
+    return (
+      <SidebarMenuItem key={col.id}>
+        <SidebarMenuButton asChild isActive={colActive} tooltip={col.title}>
+          <Link
+            to="/"
+            search={{ collection: col.id }}
+            aria-label={col.title}
+            data-testid={`sidebar-collection-${col.id}`}
+            aria-current={colActive ? "page" : undefined}
+            onClick={closeMobile}
+            // pr-12 clears both the count and the fold action.
+            className={cn(ROW_ICON, col.count > 0 && "pr-12")}
+          >
+            <CollectionGlyph col={col} />
+            <span>{col.title}</span>
+            {col.count > 0 && (
+              <SidebarMenuBadge className={cn(COUNT_BADGE, "right-7")}>
+                {col.count}
+              </SidebarMenuBadge>
+            )}
+          </Link>
+        </SidebarMenuButton>
+        <SidebarMenuAction
+          onClick={() => toggleRepo(col.id)}
+          aria-expanded={!repoCollapsed}
+          aria-label={
+            repoCollapsed
+              ? `Show ${childPrs.length} pull request${childPrs.length === 1 ? "" : "s"}`
+              : "Hide pull requests"
+          }
+          data-testid={`sidebar-collection-${col.id}-toggle`}
+          className="text-muted-foreground hover:text-foreground"
+        >
+          <Icon
+            name="caret"
+            className={cn("transition-transform", repoCollapsed && "-rotate-90")}
+          />
+        </SidebarMenuAction>
+        {!repoCollapsed && (
+          <SidebarMenuSub>
+            {childPrs.slice(0, MAX_SIDEBAR_PRS).map((pr) => {
+              const prActive = onLibrary && search.collection === pr.id
+              return (
+                <SidebarMenuSubItem key={pr.id}>
+                  <SidebarMenuSubButton asChild isActive={prActive}>
+                    <Link
+                      to="/"
+                      search={{ collection: pr.id }}
+                      data-testid={`sidebar-collection-${pr.id}`}
+                      aria-current={prActive ? "page" : undefined}
+                      onClick={closeMobile}
+                      className={cn(ROW_ICON, pr.count > 0 && "pr-7")}
+                    >
+                      <Icon name="review" />
+                      <span className="min-w-0 flex-1 truncate">
+                        {pr.prNumber
+                          ? `#${pr.prNumber} ${prTitle(pr.title, pr.prNumber)}`
+                          : prTitle(pr.title)}
+                      </span>
+                      {pr.count > 0 && (
+                        <SidebarMenuBadge className={cn(COUNT_BADGE, "top-1")}>
+                          {pr.count}
+                        </SidebarMenuBadge>
+                      )}
+                    </Link>
+                  </SidebarMenuSubButton>
+                </SidebarMenuSubItem>
+              )
+            })}
+            {childPrs.length > MAX_SIDEBAR_PRS && (
+              <SidebarMenuSubItem>
+                <SidebarMenuSubButton
+                  asChild
+                  size="sm"
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  <Link
+                    to="/"
+                    search={{ collection: col.id }}
+                    data-testid={`sidebar-collection-${col.id}-more-prs`}
+                    onClick={closeMobile}
+                  >
+                    <span>
+                      +{childPrs.length - MAX_SIDEBAR_PRS} more pull request
+                      {childPrs.length - MAX_SIDEBAR_PRS === 1 ? "" : "s"}
+                    </span>
+                  </Link>
+                </SidebarMenuSubButton>
+              </SidebarMenuSubItem>
+            )}
+          </SidebarMenuSub>
+        )}
+      </SidebarMenuItem>
+    )
+  }
+
+  // A folder header (owner-only manage menu / inline rename) followed by its collections,
+  // which render flat beneath it — the header delineates the group, like the section
+  // eyebrows. Collapsing the folder hides its rows. Empty folders only reach here for an
+  // owner (their management surface).
+  const renderFolder = (f: Folder) => {
+    const kids = byFolder.get(f.id) ?? []
+    // Icon rail: folders are an expanded-rail concept. Show every collection as a flat,
+    // reachable tile — no header, no per-folder collapse — so a collapsed folder can't
+    // hide its collections behind an unlabeled icon.
+    if (state === "collapsed")
+      return <Fragment key={f.id}>{kids.map((col) => renderCollection(col))}</Fragment>
+
+    const folderCollapsed = collapsedFolders.has(f.id)
+    if (renamingFolder === f.id)
+      return (
+        <SidebarMenuItem key={f.id}>
+          <Input
+            autoFocus
+            value={renameName}
+            aria-label="Folder name"
+            data-testid={`sidebar-folder-${f.id}-rename-input`}
+            onChange={(e) => setRenameName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") submitRename(f.id)
+              if (e.key === "Escape") {
+                setRenamingFolder(null)
+                setRenameName("")
+              }
+            }}
+            onBlur={() => submitRename(f.id)}
+            className="mb-1"
+          />
+        </SidebarMenuItem>
+      )
+    return (
+      <Fragment key={f.id}>
+        <SidebarMenuItem>
+          {/* A folder header: click toggles its section; its children render indented
+              below so the group's extent is legible (the ungrouped block reads separate).
+              The manage ⋯ (owner-only) auto-pads the row via the primitive's menu-action
+              rule — no explicit pr needed. */}
+          <SidebarMenuButton
+            onClick={() => toggleFolder(f.id)}
+            aria-expanded={!folderCollapsed}
+            tooltip={f.name}
+            data-testid={`sidebar-folder-${f.id}`}
+            className="text-sidebar-foreground/80"
+          >
+            <Icon name="collections" className="text-muted-foreground" />
+            <span className="min-w-0 flex-1 truncate">{f.name}</span>
+          </SidebarMenuButton>
+          {isOwner && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <SidebarMenuAction
+                  aria-label={`Manage folder ${f.name}`}
+                  data-testid={`sidebar-folder-${f.id}-menu`}
+                  showOnHover
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  <Icon name="more" />
+                </SidebarMenuAction>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent side="right" align="start" className="w-44">
+                <DropdownMenuItem
+                  data-testid={`sidebar-folder-${f.id}-rename`}
+                  onSelect={() => {
+                    setRenameName(f.name)
+                    setRenamingFolder(f.id)
+                  }}
+                >
+                  <Icon name="pencil" className="mr-2 size-4 text-muted-foreground" />
+                  Rename
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  data-testid={`sidebar-folder-${f.id}-delete`}
+                  onSelect={() => setDeletingFolder(f)}
+                >
+                  <Icon name="delete" className="mr-2 size-4 text-muted-foreground" />
+                  Delete folder
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </SidebarMenuItem>
+        {!folderCollapsed && kids.map((col) => renderCollection(col, true))}
+      </Fragment>
+    )
+  }
+
   // Session still resolving → the neutral rail silhouette, so we never flash the
   // anon rail before an authed user's data lands (in-app navs have `me` cached).
   if (loading) return <RailSkeleton />
 
   return (
-    <Sidebar collapsible="icon" variant="inset">
-      <RailHeader showSearch />
-      <SidebarContent>
-        {/* TIER 1 — primary navigation: the whole library at a glance, plus the
+    <>
+      <Sidebar collapsible="icon" variant="inset">
+        <RailHeader showSearch />
+        <SidebarContent>
+          {/* TIER 1 — primary navigation: the whole library at a glance, plus the
             people directory. The rail's home base; it carries no section label
             because it IS the top of the rail. */}
-        <SidebarGroup>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <FilterItem
-                icon="all"
-                label="All artifacts"
-                count={summary?.total}
-                search={{}}
-                active={isAll}
-                testId="sidebar-all"
-              />
-              <NavItem
-                icon="favorites"
-                label="Favorites"
-                count={summary?.favorites}
-                to="/favorites"
-                active={isFav}
-                testId="sidebar-favorites"
-              />
-              {/* Shared with you — a durable named feed (things others gave you access to),
+          <SidebarGroup>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <FilterItem
+                  icon="all"
+                  label="All artifacts"
+                  count={summary?.total}
+                  search={{}}
+                  active={isAll}
+                  testId="sidebar-all"
+                />
+                <NavItem
+                  icon="favorites"
+                  label="Favorites"
+                  count={summary?.favorites}
+                  to="/favorites"
+                  active={isFav}
+                  testId="sidebar-favorites"
+                />
+                {/* Shared with you — a durable named feed (things others gave you access to),
                   a peer of the feeds above; not a home strip (that's the whole IA move). */}
-              <NavItem
-                icon="share"
-                label="Shared with you"
-                to="/shared"
-                active={onShared}
-                testId="nav-shared"
-              />
-              {/* People — who you follow, plus a way to find the people you work with.
+                <NavItem
+                  icon="share"
+                  label="Shared with you"
+                  to="/shared"
+                  active={onShared}
+                  testId="nav-shared"
+                />
+                {/* People — who you follow, plus a way to find the people you work with.
                   Folds the old /following feed in as this tab's default (people you
                   follow); the artifact activity feed lives on at /following, unlinked. */}
-              <NavItem
-                icon="user"
-                label="People"
-                to="/people"
-                active={onPeople}
-                testId="nav-people"
-              />
-              <NavItem
-                icon="context"
-                label="Contexts"
-                to="/contexts"
-                active={onContexts}
-                testId="nav-contexts"
-              />
-              <NavItem
-                icon="brandprint"
-                label="Brandprint"
-                to="/brandprint"
-                active={onBrandprint}
-                testId="nav-brandprint"
-              />
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
+                <NavItem
+                  icon="user"
+                  label="People"
+                  to="/people"
+                  active={onPeople}
+                  testId="nav-people"
+                />
+                <NavItem
+                  icon="context"
+                  label="Contexts"
+                  to="/contexts"
+                  active={onContexts}
+                  testId="nav-contexts"
+                />
+                <NavItem
+                  icon="brandprint"
+                  label="Brandprint"
+                  to="/brandprint"
+                  active={onBrandprint}
+                  testId="nav-brandprint"
+                />
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
 
-        {/* TIER 2 — your library: the things you've organized. Each list carries a
+          {/* TIER 2 — your library: the things you've organized. Each list carries a
             mono eyebrow, so the section labels do the tier-separating work (no
             divider needed between the eyebrowed groups). Collections stay in the
             collapsed icon rail (each row keeps its kind glyph + a tooltip), so you can
             still reach a collection with the rail collapsed — the primitive auto-hides
             the label, the + action, the counts, and any nested PR list in icon mode. */}
-        <SidebarGroup>
-          <SidebarGroupLabel>Collections</SidebarGroupLabel>
-          {/* The + stays neutral, not the accent: create-in-rail isn't a sanctioned
+          <SidebarGroup>
+            <SidebarGroupLabel>Collections</SidebarGroupLabel>
+            {/* The + stays neutral, not the accent: create-in-rail isn't a sanctioned
               ink moment. */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <SidebarGroupAction
-                aria-label="New collection"
-                data-testid="sidebar-new-collection"
-                onClick={() => setCreating((v) => !v)}
-                className="text-muted-foreground hover:text-foreground"
-              >
-                <Icon name="plus" />
-              </SidebarGroupAction>
-            </TooltipTrigger>
-            <TooltipContent side="right">New collection</TooltipContent>
-          </Tooltip>
-          <SidebarGroupContent>
-            {creating && (
-              <Input
-                autoFocus
-                value={newName}
-                placeholder="Collection name…"
-                aria-label="Collection name"
-                data-testid="sidebar-new-collection-input"
-                onChange={(e) => setNewName(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") submitCollection()
-                  if (e.key === "Escape") {
-                    setCreating(false)
-                    setNewName("")
-                  }
-                }}
-                onBlur={submitCollection}
-                // No text-size override: Input's base keeps 16px on touch (iOS
-                // no-zoom) and steps to 14px from sm up. Hidden in the collapsed icon
-                // rail (the + that opens it is hidden there too — no way to reach it).
-                className="mb-1 group-data-[collapsible=icon]:hidden"
-              />
-            )}
-            <SidebarMenu>
-              {/* First load only — a refetch keeps the current list (no data → no
-                  isPending), so switching views never flashes the collections. */}
-              {collectionsPending &&
-                RAIL_SKELETON_COLLECTIONS.map((r) => (
-                  <SidebarMenuSkeleton key={r.id} showIcon width={r.w} />
-                ))}
-              {topCollections.map((col) => {
-                const childPrs = childPrsByRepo.get(col.id)
-                const colActive = onLibrary && search.collection === col.id
-                if (!childPrs || childPrs.length === 0)
-                  return <CollectionRow key={col.id} col={col} active={colActive} />
-                const repoCollapsed = collapsedRepos.has(col.id)
-                return (
-                  <SidebarMenuItem key={col.id}>
-                    <SidebarMenuButton asChild isActive={colActive} tooltip={col.title}>
-                      <Link
-                        to="/"
-                        search={{ collection: col.id }}
-                        aria-label={col.title}
-                        data-testid={`sidebar-collection-${col.id}`}
-                        aria-current={colActive ? "page" : undefined}
-                        onClick={closeMobile}
-                        // pr-12 clears both the count and the fold action.
-                        className={cn(ROW_ICON, col.count > 0 && "pr-12")}
-                      >
-                        <CollectionGlyph col={col} />
-                        <span>{col.title}</span>
-                        {col.count > 0 && (
-                          <SidebarMenuBadge className={cn(COUNT_BADGE, "right-7")}>
-                            {col.count}
-                          </SidebarMenuBadge>
-                        )}
-                      </Link>
-                    </SidebarMenuButton>
-                    <SidebarMenuAction
-                      onClick={() => toggleRepo(col.id)}
-                      aria-expanded={!repoCollapsed}
-                      aria-label={
-                        repoCollapsed
-                          ? `Show ${childPrs.length} pull request${childPrs.length === 1 ? "" : "s"}`
-                          : "Hide pull requests"
-                      }
-                      data-testid={`sidebar-collection-${col.id}-toggle`}
-                      className="text-muted-foreground hover:text-foreground"
-                    >
-                      <Icon
-                        name="caret"
-                        className={cn("transition-transform", repoCollapsed && "-rotate-90")}
-                      />
-                    </SidebarMenuAction>
-                    {!repoCollapsed && (
-                      <SidebarMenuSub>
-                        {childPrs.slice(0, MAX_SIDEBAR_PRS).map((pr) => {
-                          const prActive = onLibrary && search.collection === pr.id
-                          return (
-                            <SidebarMenuSubItem key={pr.id}>
-                              <SidebarMenuSubButton asChild isActive={prActive}>
-                                <Link
-                                  to="/"
-                                  search={{ collection: pr.id }}
-                                  data-testid={`sidebar-collection-${pr.id}`}
-                                  aria-current={prActive ? "page" : undefined}
-                                  onClick={closeMobile}
-                                  className={cn(ROW_ICON, pr.count > 0 && "pr-7")}
-                                >
-                                  <Icon name="review" />
-                                  <span className="min-w-0 flex-1 truncate">
-                                    {pr.prNumber
-                                      ? `#${pr.prNumber} ${prTitle(pr.title, pr.prNumber)}`
-                                      : prTitle(pr.title)}
-                                  </span>
-                                  {pr.count > 0 && (
-                                    <SidebarMenuBadge className={cn(COUNT_BADGE, "top-1")}>
-                                      {pr.count}
-                                    </SidebarMenuBadge>
-                                  )}
-                                </Link>
-                              </SidebarMenuSubButton>
-                            </SidebarMenuSubItem>
-                          )
-                        })}
-                        {childPrs.length > MAX_SIDEBAR_PRS && (
-                          <SidebarMenuSubItem>
-                            {/* A de-emphasized meta row, not a full nav item. */}
-                            <SidebarMenuSubButton
-                              asChild
-                              size="sm"
-                              className="text-muted-foreground hover:text-foreground"
-                            >
-                              <Link
-                                to="/"
-                                search={{ collection: col.id }}
-                                data-testid={`sidebar-collection-${col.id}-more-prs`}
-                                onClick={closeMobile}
-                              >
-                                <span>
-                                  +{childPrs.length - MAX_SIDEBAR_PRS} more pull request
-                                  {childPrs.length - MAX_SIDEBAR_PRS === 1 ? "" : "s"}
-                                </span>
-                              </Link>
-                            </SidebarMenuSubButton>
-                          </SidebarMenuSubItem>
-                        )}
-                      </SidebarMenuSub>
-                    )}
-                  </SidebarMenuItem>
-                )
-              })}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-
-        {tags.length > 0 && (
-          <SidebarGroup className="group-data-[collapsible=icon]:hidden">
-            <SidebarGroupLabel>Tags</SidebarGroupLabel>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <SidebarGroupAction
+                  aria-label="New collection"
+                  data-testid="sidebar-new-collection"
+                  onClick={() => setCreating((v) => !v)}
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  <Icon name="plus" />
+                </SidebarGroupAction>
+              </TooltipTrigger>
+              <TooltipContent side="right">New collection</TooltipContent>
+            </Tooltip>
             <SidebarGroupContent>
+              {creating && (
+                <Input
+                  autoFocus
+                  value={newName}
+                  placeholder="Collection name…"
+                  aria-label="Collection name"
+                  data-testid="sidebar-new-collection-input"
+                  onChange={(e) => setNewName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") submitCollection()
+                    if (e.key === "Escape") {
+                      setCreating(false)
+                      setNewName("")
+                    }
+                  }}
+                  onBlur={submitCollection}
+                  // No text-size override: Input's base keeps 16px on touch (iOS
+                  // no-zoom) and steps to 14px from sm up. Hidden in the collapsed icon
+                  // rail (the + that opens it is hidden there too — no way to reach it).
+                  className="mb-1 group-data-[collapsible=icon]:hidden"
+                />
+              )}
               <SidebarMenu>
-                {tags.map(({ tag, count }) => (
-                  <FilterItem
-                    key={tag}
-                    icon="tag"
-                    label={tag}
-                    count={count}
-                    search={{ tag }}
-                    active={onLibrary && search.tag === tag}
-                    testId={`sidebar-tag-${tag}`}
-                  />
-                ))}
+                {/* First load only — a refetch keeps the current list (no data → no
+                  isPending), so switching views never flashes the collections. */}
+                {collectionsPending &&
+                  RAIL_SKELETON_COLLECTIONS.map((r) => (
+                    <SidebarMenuSkeleton key={r.id} showIcon width={r.w} />
+                  ))}
+                {/* Owner-only: create a folder to group collections. Folders are shared
+                  workspace structure, so only owners see this (and the manage menus). */}
+                {isOwner &&
+                  (creatingFolder ? (
+                    <SidebarMenuItem>
+                      <Input
+                        autoFocus
+                        value={newFolderName}
+                        placeholder="Folder name…"
+                        aria-label="Folder name"
+                        data-testid="sidebar-new-folder-input"
+                        onChange={(e) => setNewFolderName(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") submitFolder()
+                          if (e.key === "Escape") {
+                            setCreatingFolder(false)
+                            setNewFolderName("")
+                          }
+                        }}
+                        onBlur={submitFolder}
+                        className="mb-1 group-data-[collapsible=icon]:hidden"
+                      />
+                    </SidebarMenuItem>
+                  ) : (
+                    <SidebarMenuItem className="group-data-[collapsible=icon]:hidden">
+                      <SidebarMenuButton
+                        onClick={() => setCreatingFolder(true)}
+                        data-testid="sidebar-new-folder"
+                        className="text-muted-foreground hover:text-foreground"
+                      >
+                        <Icon name="plus" />
+                        <span>New folder</span>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  ))}
+                {visibleFolders.map((f) => renderFolder(f))}
+                {ungrouped.map((col) => renderCollection(col))}
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
-        )}
 
-        {/* Tools — a running sync, notifications, Settings. Pinned to the foot of
+          {tags.length > 0 && (
+            <SidebarGroup className="group-data-[collapsible=icon]:hidden">
+              <SidebarGroupLabel>Tags</SidebarGroupLabel>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  {tags.map(({ tag, count }) => (
+                    <FilterItem
+                      key={tag}
+                      icon="tag"
+                      label={tag}
+                      count={count}
+                      search={{ tag }}
+                      active={onLibrary && search.tag === tag}
+                      testId={`sidebar-tag-${tag}`}
+                    />
+                  ))}
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+          )}
+
+          {/* Tools — a running sync, notifications, Settings. Pinned to the foot of
             the scroll (mt-auto); the whitespace above sets them apart, no divider. */}
-        <SidebarGroup className="mt-auto">
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SyncChip />
-              <NotificationBell />
-              <SidebarMenuItem>
-                <SidebarMenuButton asChild isActive={onSettings} tooltip="Settings">
-                  <Link
-                    to="/settings"
-                    data-testid="menu-settings"
-                    aria-current={onSettings ? "page" : undefined}
-                    onClick={closeMobile}
-                    className={ROW_ICON}
-                  >
-                    <Icon name="settings" />
-                    <span>Settings</span>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-      </SidebarContent>
+          <SidebarGroup className="mt-auto">
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SyncChip />
+                <NotificationBell />
+                <SidebarMenuItem>
+                  <SidebarMenuButton asChild isActive={onSettings} tooltip="Settings">
+                    <Link
+                      to="/settings"
+                      data-testid="menu-settings"
+                      aria-current={onSettings ? "page" : undefined}
+                      onClick={closeMobile}
+                      className={ROW_ICON}
+                    >
+                      <Icon name="settings" />
+                      <span>Settings</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
 
-      {/* TIER 4 — account: the identity row, pinned below the scroll. It needs no
+        {/* TIER 4 — account: the identity row, pinned below the scroll. It needs no
           divider of its own — the avatar + taller row already set it apart from the
           tools directly above it. */}
-      <SidebarFooter>
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <UserPod
-              workspaceLabel={workspaceLabel}
-              workspaces={workspaces ?? null}
-              onSwitchWorkspace={switchWorkspace}
-            />
-          </SidebarMenuItem>
-        </SidebarMenu>
-      </SidebarFooter>
-    </Sidebar>
+        <SidebarFooter>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <UserPod
+                workspaceLabel={workspaceLabel}
+                workspaces={workspaces ?? null}
+                onSwitchWorkspace={switchWorkspace}
+              />
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarFooter>
+      </Sidebar>
+      {/* Deleting a folder only un-files its collections (they survive) — the confirm
+          says so, so an owner isn't scared it'll take the collections with it. */}
+      <ConfirmDialog
+        open={!!deletingFolder}
+        onOpenChange={(o) => !o && setDeletingFolder(null)}
+        title={`Delete folder “${deletingFolder?.name ?? ""}”?`}
+        description="The folder is removed and its collections become ungrouped. The collections and their artifacts are not deleted."
+        confirmLabel="Delete folder"
+        confirmTestId="folder-delete-confirm"
+        onConfirm={confirmDelete}
+      />
+    </>
   )
 }

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -34,6 +34,14 @@ export const collectionsQuery = () =>
     queryFn: () => api.listCollections().then((r) => r.collections),
   })
 
+// The workspace's org-shared folders (name order), for the rail's folder grouping and
+// the "Move to folder" picker. Small and warm like collectionsQuery.
+export const foldersQuery = () =>
+  queryOptions({
+    queryKey: ["folders"] as const,
+    queryFn: () => api.listFolders().then((r) => r.folders),
+  })
+
 // Workspaces only change via create/switch/delete — all of which hard-reload — so
 // this is effectively fetch-once per session.
 export const workspacesQuery = () =>

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -251,7 +251,8 @@ CREATE TABLE IF NOT EXISTS collection (
   title TEXT NOT NULL,
   created_by TEXT NOT NULL,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-  workspace_access TEXT NOT NULL DEFAULT 'member'
+  workspace_access TEXT NOT NULL DEFAULT 'member',
+  folder_id TEXT
 );
 
 CREATE TABLE IF NOT EXISTS collection_item (
@@ -272,6 +273,14 @@ CREATE TABLE IF NOT EXISTS collection_member (
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   UNIQUE (collection_id, user_id),
   FOREIGN KEY (collection_id) REFERENCES collection(id)
+);
+
+CREATE TABLE IF NOT EXISTS folder (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL DEFAULT 'local',
+  name TEXT NOT NULL,
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 
 CREATE TABLE IF NOT EXISTS repo_source (

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -624,6 +624,18 @@ export interface CollectionStore {
   /** This user's collection-member roles over collections containing the
    *  artifact — folded into their effective artifact role (collection sharing). */
   collectionRolesForArtifact(artifactId: string, userId: string): Promise<Role[]>
+
+  // ---- Folders (owner-editable org grouping for collections; grant no access) ---
+  createFolder(f: NewFolder): Promise<FolderRecord>
+  /** All folders in a workspace (scoped when orgId given). Name order is a view concern. */
+  listFolders(orgId?: string): Promise<FolderRecord[]>
+  getFolder(id: string): Promise<FolderRecord | null>
+  updateFolder(id: string, fields: { name?: string }): Promise<FolderRecord | null>
+  /** Delete a folder and un-file its collections (set their folder_id to null) — the
+   *  collections themselves are untouched. */
+  deleteFolder(id: string): Promise<void>
+  /** File a collection under a folder (or null to ungroup). */
+  setCollectionFolder(collectionId: string, folderId: string | null): Promise<void>
 }
 
 export interface IntegrationStore {
@@ -1607,6 +1619,9 @@ export interface CollectionRecord {
    *  link-servable content). `member` = every workspace member reaches it at
    *  their seat role; `none` = invite-only (collectionMember rows only). */
   workspace_access: WorkspaceAccess
+  /** The org-shared folder this collection is filed under (null = ungrouped). Pure
+   *  organization — never consulted by any auth path. See FolderRecord. */
+  folder_id: string | null
 }
 export interface NewCollection {
   id: string
@@ -1616,6 +1631,23 @@ export interface NewCollection {
   /** Omitted falls to the store's column default (`member`, unlike an artifact's
    *  fail-closed `none` — see CollectionRecord.workspace_access). */
   workspace_access?: WorkspaceAccess
+}
+
+/** A workspace-shared organizing folder for collections (owner-editable). Grouping
+ *  only — it grants no access and never appears in any auth path; a collection points
+ *  at one via CollectionRecord.folder_id. */
+export interface FolderRecord {
+  id: string
+  org_id: string
+  name: string
+  created_by: string
+  created_at: string
+}
+export interface NewFolder {
+  id: string
+  org_id: string
+  name: string
+  created_by: string
 }
 export interface DomainRecord {
   host: string

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -27,6 +27,7 @@ import type {
   ContextRecord,
   DeliveryRecord,
   DomainRecord,
+  FolderRecord,
   FollowRecord,
   GitHubAppRecord,
   GitHubInstallationRecord,
@@ -73,6 +74,7 @@ export interface TypedTables {
   sessionMessage: SessionMessageRecord
   collection: CollectionRecord
   collectionMember: CollectionMemberRecord
+  folder: FolderRecord
   repoSource: RepoSourceRecord
   githubApp: GitHubAppRecord
   githubInstallation: GitHubInstallationRecord

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -351,6 +351,18 @@ export const collection = pgTable("collection", {
   // See the sqlite dialect's schema.ts for the full comment. Defaults to `member`
   // (not artifact's fail-closed `none`) to match collections' existing behavior.
   workspace_access: text("workspace_access").$type<WorkspaceAccess>().notNull().default("member"),
+  // See schema.ts for the full comment: the org-shared folder this collection is filed
+  // under (null = ungrouped). Plain nullable pointer, NOT a FK — folders grant no access.
+  folder_id: text("folder_id"),
+})
+// A workspace-shared organizing folder for collections (see schema.ts). Grouping only —
+// grants no access, never in any auth path.
+export const folder = pgTable("folder", {
+  id: text("id").primaryKey(),
+  org_id: text("org_id").notNull().default("local"),
+  name: text("name").notNull(),
+  created_by: text("created_by").notNull(),
+  created_at: text("created_at").notNull().$defaultFn(isoNow),
 })
 export const collectionItem = pgTable(
   "collection_item",
@@ -677,6 +689,7 @@ const TABLES = [
   collection,
   collectionItem,
   collectionMember,
+  folder,
   repoSource,
   orgSettings,
   slackInstall,

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -18,6 +18,7 @@ import type {
   DeliveryStatus,
   DomainRecord,
   DomainStatus,
+  FolderRecord,
   FollowKind,
   FollowRecord,
   GitHubAppRecord,
@@ -44,6 +45,7 @@ import type {
   NewContextAsker,
   NewDelivery,
   NewDomain,
+  NewFolder,
   NewFollow,
   NewInvitation,
   NewMembership,
@@ -127,6 +129,7 @@ import {
   contextAsker,
   contextSession,
   domain,
+  folder,
   follow,
   githubApp,
   githubInstallation,
@@ -194,6 +197,7 @@ export const schema = {
   collection,
   collectionItem,
   collectionMember,
+  folder,
   repoSource,
   githubApp,
   githubInstallation,
@@ -231,6 +235,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   sessionMessage: true,
   collection: true,
   collectionMember: true,
+  folder: true,
   repoSource: true,
   githubApp: true,
   githubInstallation: true,
@@ -1391,6 +1396,41 @@ export class PgMetaStore implements MetaStore {
     const cmap = new Map(counts.map((r) => [r.id, Number(r.c)]))
     return rows.map((r) => ({ ...r, count: cmap.get(r.id) ?? 0 }))
   }
+  // ---- Folders (org grouping for collections) ----------------------------
+  async createFolder(f: NewFolder): Promise<FolderRecord> {
+    const rows = await this.db.insert(folder).values(f).returning()
+    return one(rows)
+  }
+  async listFolders(orgId?: string): Promise<FolderRecord[]> {
+    const base = this.db.select().from(folder)
+    return orgId ? base.where(eq(folder.org_id, orgId)) : base
+  }
+  async getFolder(id: string): Promise<FolderRecord | null> {
+    const rows = await this.db.select().from(folder).where(eq(folder.id, id))
+    return rows[0] ?? null
+  }
+  async updateFolder(id: string, fields: { name?: string }): Promise<FolderRecord | null> {
+    if (fields.name === undefined) return this.getFolder(id)
+    const rows = await this.db
+      .update(folder)
+      .set({ name: fields.name })
+      .where(eq(folder.id, id))
+      .returning()
+    return rows[0] ?? null
+  }
+  async deleteFolder(id: string): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      await tx.update(collection).set({ folder_id: null }).where(eq(collection.folder_id, id))
+      await tx.delete(folder).where(eq(folder.id, id))
+    })
+  }
+  async setCollectionFolder(collectionId: string, folderId: string | null): Promise<void> {
+    await this.db
+      .update(collection)
+      .set({ folder_id: folderId })
+      .where(eq(collection.id, collectionId))
+  }
+
   async collectionArtifactIds(collectionId: string): Promise<string[]> {
     const rows = await this.db
       .select({ id: collectionItem.artifact_id })

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -18,6 +18,7 @@ import type {
   DeliveryStatus,
   DomainRecord,
   DomainStatus,
+  FolderRecord,
   FollowKind,
   FollowRecord,
   GitHubAppRecord,
@@ -42,6 +43,7 @@ import type {
   NewContextAsker,
   NewDelivery,
   NewDomain,
+  NewFolder,
   NewFollow,
   NewInvitation,
   NewMembership,
@@ -125,6 +127,7 @@ import {
   contextAsker,
   contextSession,
   domain,
+  folder,
   follow,
   githubApp,
   githubInstallation,
@@ -230,6 +233,7 @@ export const schema = {
   collection,
   collectionItem,
   collectionMember,
+  folder,
   repoSource,
   githubApp,
   githubInstallation,
@@ -267,6 +271,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   sessionMessage: true,
   collection: true,
   collectionMember: true,
+  folder: true,
   repoSource: true,
   githubApp: true,
   githubInstallation: true,
@@ -1539,6 +1544,46 @@ export function makeRepos(db: SqliteDb) {
     const cmap = new Map(counts.map((r) => [r.id, Number(r.c)]))
     return rows.map((r) => ({ ...r, count: cmap.get(r.id) ?? 0 }))
   }
+  // ---- Folders (org grouping for collections) ----------------------------
+  const createFolder = async (f: NewFolder): Promise<FolderRecord> =>
+    (await db.insert(folder).values(f).returning().get()) as FolderRecord
+  const listFolders = async (orgId?: string): Promise<FolderRecord[]> => {
+    const base = db.select().from(folder)
+    return (orgId ? base.where(eq(folder.org_id, orgId)) : base).all()
+  }
+  const getFolder = async (id: string): Promise<FolderRecord | null> =>
+    (await db.select().from(folder).where(eq(folder.id, id)).get()) ?? null
+  const updateFolder = async (
+    id: string,
+    fields: { name?: string },
+  ): Promise<FolderRecord | null> => {
+    if (fields.name === undefined) return getFolder(id)
+    return (
+      (await db
+        .update(folder)
+        .set({ name: fields.name })
+        .where(eq(folder.id, id))
+        .returning()
+        .get()) ?? null
+    )
+  }
+  // Un-file the folder's collections (they survive), then drop the folder. Sequential
+  // (D1-safe), like deleteCollection.
+  const deleteFolder = async (id: string): Promise<void> => {
+    await db.update(collection).set({ folder_id: null }).where(eq(collection.folder_id, id)).run()
+    await db.delete(folder).where(eq(folder.id, id)).run()
+  }
+  const setCollectionFolder = async (
+    collectionId: string,
+    folderId: string | null,
+  ): Promise<void> => {
+    await db
+      .update(collection)
+      .set({ folder_id: folderId })
+      .where(eq(collection.id, collectionId))
+      .run()
+  }
+
   const collectionArtifactIds = async (collectionId: string): Promise<string[]> =>
     (
       await db
@@ -2767,6 +2812,12 @@ export function makeRepos(db: SqliteDb) {
     setCollectionAccess,
     deleteCollection,
     listCollections,
+    createFolder,
+    listFolders,
+    getFolder,
+    updateFolder,
+    deleteFolder,
+    setCollectionFolder,
     collectionArtifactIds,
     collectionIdsForArtifact,
     addCollectionItem,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -406,6 +406,23 @@ export const collection = sqliteTable("collection", {
   // already folds in the caller's seat unconditionally, so an ADD COLUMN migration
   // defaulting every existing row to `member` changes nothing for anyone.
   workspace_access: text("workspace_access").$type<WorkspaceAccess>().notNull().default("member"),
+  // The org-shared folder this collection is filed under (null = ungrouped). A plain
+  // pointer, NOT a FK — folders are pure organization and grant no access, and a
+  // constraint-free nullable column keeps the ADD COLUMN migration trivially additive
+  // across both dialects. Integrity (a real folder in the same workspace) is enforced
+  // by the owner-only assign endpoint; deleting a folder nulls this on its members.
+  folder_id: text("folder_id"),
+})
+
+// A workspace-shared organizing folder for collections — owner-editable, grouping only.
+// It grants NO access of its own (a collection keeps its own auth); it never appears in
+// any auth path. A collection points at one via collection.folder_id.
+export const folder = sqliteTable("folder", {
+  id: text("id").primaryKey(),
+  org_id: text("org_id").notNull().default("local"),
+  name: text("name").notNull(),
+  created_by: text("created_by").notNull(),
+  created_at: text("created_at").notNull().default(now),
 })
 
 export const collectionItem = sqliteTable(
@@ -808,6 +825,7 @@ const TABLES = [
   collection,
   collectionItem,
   collectionMember,
+  folder,
   repoSource,
   orgSettings,
   slackInstall,


### PR DESCRIPTION
## What & why

Phase 3 of the sidebar rework: **org-shared folders**. Workspace owners can create folders and file collections under them; the folder tree is *shared workspace structure* everyone sees — so one person's organizing benefits the whole team (Rob's framing). Folders are pure organization: they **grant no access**, and a collection keeps its own auth.

## Model (additive, zero-backfill migration)

- New `folder` table (workspace-scoped: `id, org_id, name, created_by, created_at`) + a nullable, **FK-free** `collection.folder_id` (sidesteps the SQLite `ADD COLUMN`-with-FK edge; integrity enforced at the owner-gated API).
- Wired across the dual-dialect schema (`schema.ts` + `pg-schema.ts`), core Records + `parity.ts`, both drivers (`repos.ts` sqlite/d1, `pg.ts`), and the regenerated `deploy/d1-schema.sql`.

## API (owner-gated via `requireWorkspace("manage")`)

- `GET /v1/folders` (member read, name-sorted) · `POST` / `PATCH` / `DELETE /v1/folders` (owner) · `PUT /v1/collections/{id}/folder` (owner; `null` ungroups; deleting a folder un-files its collections, which survive).
- `Collection` gains an optional `folderId`, derived in `enrich` alongside `kind`/`parentId`. Every folder route verifies workspace ownership **and** same-workspace resource ownership (no cross-workspace touch).

## Rail UI

- Collections group into collapsible **folder sections**; children indent under the header (reusing the PR-nesting left border) so the group's extent is legible.
- **Owner-only** inline management: create ("New folder"), rename, delete (with a confirm that says collections survive), and a "Move to folder" ⋯ menu on collections.
- **Collapsed icon rail**: every collection renders flat as a reachable tile (no folder headers, folder-collapse ignored) — a collapsed folder never hides its collections.
- A folder shows when it holds a visible collection, **or always for an owner** (management surface); a folder empty for a viewer hides. Alphabetical order (v1 — manual reorder is a deliberate follow-up).

## Testing

- [x] `pnpm typecheck` (core, db, web; api clean apart from a pre-existing local-only missing optional dep, `@huggingface/transformers`, in an untouched file — green in CI)
- [x] `pnpm exec biome ci .` — 0 errors on changed files
- [x] `pnpm test` — web 168, db 202, **api folders 7/7** (owner-gating, CRUD, file/unfile, ungroup, 404 unknown-folder, blank-rename 400, **cross-workspace 404**), collections + collection-access still green
- [x] Custom lints: tokens / frontend / testids / surfaces / deadcode / **schema** (additive-only) / **api-types** all green; D1 snapshot regenerated
- [x] **Real run** (screens harness, since deleted): grouped rail renders; inline create; move-to-folder menu files a collection; expanded shows indented nesting; collapsed icon rail keeps a filed collection reachable even with its folder collapsed

## Notes for reviewers

Two independent refute-reviewers ran. **Backend invariants confirmed clean**: folders appear in zero auth paths (grep of `collectionRole`/`collectionRolesForArtifact`/`permissions`), owner-only mutations, cross-workspace isolation, purely-additive migration across all three tiers, compile-checked parity. Frontend fixes applied from the review: the collapsed icon rail now shows collections flat (a collapsed folder no longer hid them); foldered collections are indented (were indistinguishable from ungrouped); blank folder rename rejected (matched create); destructive delete surfaces errors via the ConfirmDialog contract; dropped a misleading `following`/`size={12}` shared marker; removed a redundant `pr-8`.

Phase 3 of the rework (Phases 1 = #470, 2 = #471). Working doc: https://derive.to/artifacts/sidebar-rework-working-doc-901guwbe
