### PR TITLE
feat(mcp): agent-native Brandprint setup + reliable derive:// reads

### DIFF
--- a/apps/api/src/brandprint-reference.ts
+++ b/apps/api/src/brandprint-reference.ts
@@ -350,3 +350,40 @@ export const BRANDPRINT_TEMPLATE = `<!doctype html>
 </body>
 </html>
 `
+
+/**
+ * The brand-profile placeholder: version 1 of a workspace's "Brand profile" artifact,
+ * created when the Brandprint is scaffolded so the agent has a fixed short_id to file its
+ * proposal against (spec: the placeholder is the recognition contract). The profile counts
+ * as live from version 2, so this stub is what renders until then. Server home for the
+ * setup_brandprint tool; the web mirrors it at
+ * apps/web/src/pages/brandprint/profile-placeholder.ts (the SPA can't import this module).
+ */
+export const PROFILE_PLACEHOLDER_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Brand profile</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    margin: 0; min-height: 100vh; display: grid; place-items: center;
+    font: 16px/1.6 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+    background: #faf9f7; color: #1c1b1a;
+  }
+  @media (prefers-color-scheme: dark) { body { background: #171614; color: #f0eee9; } }
+  main { max-width: 420px; text-align: center; padding: 24px; }
+  h1 { font-size: 20px; margin: 0 0 8px; }
+  p { margin: 0; opacity: .7; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Brand profile</h1>
+  <p>This brand profile hasn't been generated yet. Your agent builds it from the source
+  documents in this Brandprint.</p>
+</main>
+</body>
+</html>
+`

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -13,12 +13,15 @@
 // shaped to the agent's workflow (not the API surface), high-signal responses with
 // truncate-and-steer, semantic ids (short_id / vN / page path — never UUIDs),
 // actionable errors, and identity carried in the server `instructions` rather than a
-// tool slot. Eight tools, one per intent — WORKSPACES (list_workspaces), FIND
+// tool slot. Nine tools, one per intent — WORKSPACES (list_workspaces), FIND
 // (list_artifacts), READ content (read), GREP (search), CATCH UP on state/feedback/
-// history (catch_up), COMMENT (comment), WRITE (publish), and the WORK QUEUE
+// history (catch_up), COMMENT (comment), WRITE (publish), the WORK QUEUE
 // (check_requests: what teammates asked THIS agent to do — the one intent that is
 // about the agent rather than a document, which is why it earns a slot instead of a
-// parameter on catch_up). Variation lives in parameters, never a new tool: `since_version`/`to_version` turn catch_up into a
+// parameter on catch_up), and SET UP the Brandprint (setup_brandprint: scaffold the
+// workspace's brand-profile slot so it can be authored over MCP — workspace
+// configuration, not a document write, so like check_requests it's a distinct intent
+// that doesn't reduce to a parameter on another tool). Variation lives in parameters, never a new tool: `since_version`/`to_version` turn catch_up into a
 // diff, `reply_to`/`set_state` fold reply+resolve into comment, `for_review`/role
 // turn publish into a human-reviewed proposal, and omitting `short_id` turns
 // `search` from grep-one-artifact into grep-the-workspace. A new capability is a
@@ -62,7 +65,11 @@ import { StreamableHTTPTransport } from "@hono/mcp"
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import type { Hono } from "hono"
 import { z } from "zod"
-import { BRANDPRINT_REFERENCE, BRANDPRINT_TEMPLATE } from "./brandprint-reference"
+import {
+  BRANDPRINT_REFERENCE,
+  BRANDPRINT_TEMPLATE,
+  PROFILE_PLACEHOLDER_HTML,
+} from "./brandprint-reference"
 import type { AppContext } from "./context"
 import { markAddressed } from "./lib/addressed"
 import { afterPublish } from "./lib/after-publish"
@@ -433,38 +440,43 @@ async function buildServer(
       },
     )
   }
-  // The generation reference: the build guide + the neutral benchmark page, served
-  // whenever a Brandprint exists. Derive runs no inference, so these two static files
-  // are its entire side of profile generation; the user's agent does the assembling.
-  if (resolved.collectionIds.length > 0) {
-    server.registerResource(
-      "brandprint:reference",
-      "derive://brandprint/reference",
-      {
-        title: "How to build this workspace's brand profile",
-        description: "The build guide: required sections, extraction rules, output contract.",
-        mimeType: "text/markdown",
-        annotations: { audience: ["assistant"], priority: 0.8 },
-      },
-      async (uri) => ({
-        contents: [{ uri: uri.href, mimeType: "text/markdown", text: BRANDPRINT_REFERENCE }],
-      }),
-    )
-    server.registerResource(
-      "brandprint:template",
-      "derive://brandprint/template",
-      {
-        title: "Brand profile template (neutral benchmark)",
-        description:
-          "A complete brand-neutral profile page — the structural and quality benchmark; restyle everything.",
-        mimeType: "text/html",
-        annotations: { audience: ["assistant"], priority: 0.8 },
-      },
-      async (uri) => ({
-        contents: [{ uri: uri.href, mimeType: "text/html", text: BRANDPRINT_TEMPLATE }],
-      }),
-    )
-  }
+  // The generation reference: the build guide + the neutral benchmark page. Registered
+  // UNCONDITIONALLY (not gated on an existing Brandprint) for two reasons: (1) they're
+  // the static guide an agent needs precisely BEFORE a Brandprint exists, to build one;
+  // (2) registering at least one resource is what makes the SDK advertise the `resources`
+  // capability at `initialize` — gating them meant a session that connected to a
+  // Brandprint-less workspace cached "no resources" for its whole life (capability is
+  // negotiated once), so a later `set up my Brandprint` couldn't read them. They're also
+  // reachable through the `read` tool (read("derive://brandprint/reference")), which every
+  // client supports even when MCP resources aren't. Derive runs no inference; these two
+  // static files are its entire side of profile generation, the user's agent assembles it.
+  server.registerResource(
+    "brandprint:reference",
+    "derive://brandprint/reference",
+    {
+      title: "How to build this workspace's brand profile",
+      description: "The build guide: required sections, extraction rules, output contract.",
+      mimeType: "text/markdown",
+      annotations: { audience: ["assistant"], priority: 0.8 },
+    },
+    async (uri) => ({
+      contents: [{ uri: uri.href, mimeType: "text/markdown", text: BRANDPRINT_REFERENCE }],
+    }),
+  )
+  server.registerResource(
+    "brandprint:template",
+    "derive://brandprint/template",
+    {
+      title: "Brand profile template (neutral benchmark)",
+      description:
+        "A complete brand-neutral profile page — the structural and quality benchmark; restyle everything.",
+      mimeType: "text/html",
+      annotations: { audience: ["assistant"], priority: 0.8 },
+    },
+    async (uri) => ({
+      contents: [{ uri: uri.href, mimeType: "text/html", text: BRANDPRINT_TEMPLATE }],
+    }),
+  )
   // The live brand profile is the headline read — one page that carries the whole
   // brand, humans and machines alike (tokens ride in it as CSS variables + JSON island).
   // The server is per-request, so the record fetched above is fresh enough to reuse.
@@ -718,7 +730,11 @@ async function buildServer(
       description:
         "Read an artifact's CONTENT by short id, as Markdown by default (HTML is converted to its readable text — note a styled page renders fully to VIEWERS; only this reading view flattens it). Small docs return whole; a LARGE doc returns its heading OUTLINE first — call again with a `section` slug for just that part. Multi-page bundle: omit `section` for the page outline, then pass a page path (optionally `page.html#slug`). Pass format:'html' for the exact source (required before publish `edits`), or a past `version` for history. (For what CHANGED, or the comment threads, use catch_up.)",
       inputSchema: {
-        short_id: z.string().describe("The artifact's short id, e.g. nk0dsral."),
+        short_id: z
+          .string()
+          .describe(
+            "The artifact's short id, e.g. nk0dsral. Also accepts a Brandprint URI — derive://brandprint/reference or /template (the static build guide), /profile (this workspace's live brand profile), or /<short_id> (a source doc) — so the strings the instructions name are readable here even where MCP resources aren't.",
+          ),
         section: z
           .string()
           .optional()
@@ -749,9 +765,40 @@ async function buildServer(
     },
     async ({ short_id, section, format, version, lines, render, workspace }) => {
       const fmt: ReadFormat = format ?? "markdown"
-      const r = await reach(short_id, workspace)
+      // `derive://brandprint/*` URIs are readable through `read`, not only as MCP
+      // resources — the exact strings the server instructions name, reachable by every
+      // client even where resource support is weak or was never negotiated (the failure
+      // this fixes: a session that connected before the Brandprint existed caches "no
+      // resources" for its whole life). `reference`/`template` are the static build guide;
+      // `profile` is the live brand profile; any other segment is a source-doc short_id
+      // that falls through to the normal read path (so `section`/`lines`/`version` work).
+      const BP = "derive://brandprint/"
+      let docId = short_id
+      if (short_id.startsWith(BP)) {
+        const seg = short_id.slice(BP.length)
+        if (seg === "reference")
+          return json({ uri: short_id, mimeType: "text/markdown", content: BRANDPRINT_REFERENCE })
+        if (seg === "template")
+          return json({ uri: short_id, mimeType: "text/html", content: BRANDPRINT_TEMPLATE })
+        if (seg === "profile") {
+          if (!(bpProfile?.state === "live" && profileArt))
+            return err(
+              "This workspace has no live brand profile yet. Read derive://brandprint/reference and derive://brandprint/template, then run setup_brandprint and publish the profile with for_review:true.",
+            )
+          const pv = await ctx.meta.getVersion(profileArt.id, profileArt.current_version)
+          const body = pv ? await ctx.sourceText(pv) : null
+          return json({
+            uri: short_id,
+            mimeType: "text/html",
+            version: profileArt.current_version,
+            content: body ?? "",
+          })
+        }
+        docId = seg
+      }
+      const r = await reach(docId, workspace)
       if (r && "error" in r) return err(r.error)
-      if (!r) return notFound(short_id)
+      if (!r) return notFound(docId)
       const a = r.a
       const n = version ?? a.current_version
       if (n < 1 || n > a.current_version)
@@ -2199,6 +2246,130 @@ async function buildServer(
       } catch (e) {
         const msg = e instanceof PublishError ? e.message : "could not publish"
         return text(`Publish failed: ${msg}`)
+      }
+    },
+  )
+
+  // SET UP THE BRANDPRINT ------------------------------------------------------
+  // The agent-native counterpart to the web create dialog: scaffold (or return) the
+  // workspace's Brandprint so "set up our Brandprint" typed into a connected agent works
+  // end to end, no context-switch to the app. Idempotent — it ensures the conventions
+  // collection + the "Brand profile" placeholder exist and the org pointer names them,
+  // then hands back the placeholder's short_id. The agent then reads
+  // derive://brandprint/reference + /template, builds the profile, and publishes it
+  // for_review against that short_id (the placeholder is the recognition contract — a
+  // human still approves the reveal, which flips it live at derive://brandprint/profile).
+  // It never generates or approves the profile itself. Owner/Admin only, like the web
+  // PATCH /v1/workspace/settings it mirrors.
+  server.registerTool(
+    "setup_brandprint",
+    {
+      description:
+        "Set up (or return) this workspace's Brandprint so its brand profile can be authored over MCP — the agent-native version of the web create dialog. Idempotent: it ensures a conventions collection and a 'Brand profile' placeholder artifact exist and points the workspace's settings at them, then returns the placeholder's short_id. NEXT: read derive://brandprint/reference and derive://brandprint/template, build ONE self-contained HTML brand profile, and publish it with for_review:true to that short_id — it lands as a proposal a human approves (never publish the profile live). This tool does NOT generate or approve the profile. Owner/Admin only. Call it when the user asks to set up, build, or finish their Brandprint.",
+      inputSchema: { workspace: wsArg },
+    },
+    async ({ workspace }) => {
+      const t = await resolveWs(workspace)
+      if ("error" in t) return err(t.error)
+      if (!roleAllows(t.role, "manage"))
+        return err("Setting up a Brandprint needs an Admin/Owner role in this workspace.")
+      // Collection ownership + the placeholder's author must be a real user; an OAuth
+      // grant carries the granting human (actingFor/ownerId), a static agent token may not.
+      const uid = actingFor?.id ?? ownerId
+      if (!uid)
+        return err(
+          "setup_brandprint needs a signed-in user to attribute the setup to. Connect with an OAuth agent grant rather than a static agent token.",
+        )
+      const targetOrg = t.org
+      try {
+        const settings = await ctx.meta.getOrgSettings(targetOrg)
+        const bp = settings.brandprint
+
+        // Reuse an in-tenant collection pointer; otherwise create the conventions
+        // collection (workspace-open so teammates read the docs + the reveal).
+        let collectionId = bp?.collectionId
+        let createdCollection = false
+        if (collectionId) {
+          const col = await ctx.meta.getCollection(collectionId)
+          if (!col || col.org_id !== targetOrg) collectionId = undefined
+        }
+        if (!collectionId) {
+          const col = await ctx.meta.createCollection({
+            id: newId("col"),
+            org_id: targetOrg,
+            title: "Brandprint",
+            created_by: uid,
+            workspace_access: "member",
+          })
+          await ctx.meta.setCollectionMember({
+            id: newId("cm"),
+            collection_id: col.id,
+            user_id: uid,
+            role: "owner",
+          })
+          collectionId = col.id
+          createdCollection = true
+        }
+
+        // Reuse an in-tenant profile pointer; otherwise publish the placeholder (v1 stub)
+        // into the collection. profileState reads live from v2, so a reused profile may
+        // already be live — report that rather than clobbering it.
+        let profileShortId = bp?.profileId
+        let state: "pending" | "live" = "pending"
+        let createdProfile = false
+        if (profileShortId) {
+          const art = await ctx.meta.getByShortId(profileShortId)
+          if (art && art.org_id === targetOrg) state = profileState(art.current_version)
+          else profileShortId = undefined
+        }
+        if (!profileShortId) {
+          const { artifact } = await publishVersion(ctx.meta, ctx.blobs, {
+            bytes: new TextEncoder().encode(PROFILE_PLACEHOLDER_HTML),
+            filename: "Brand profile.html",
+            isBundle: false,
+            title: "Brand profile",
+            message: "Brand profile placeholder — your agent fills this in.",
+            author: agent.name,
+            authorId: uid,
+            orgId: targetOrg,
+            workspaceAccess: "member",
+            linkRole: "none",
+            listed: "none",
+          })
+          await ctx.meta.addCollectionItem(collectionId, artifact.id)
+          profileShortId = artifact.short_id
+          state = "pending"
+          createdProfile = true
+        }
+
+        // Persist the pointer only when something actually changed (a fully-set-up
+        // Brandprint is a no-op read).
+        const pointerChanged =
+          createdCollection ||
+          createdProfile ||
+          bp?.collectionId !== collectionId ||
+          bp?.profileId !== profileShortId
+        if (pointerChanged)
+          await ctx.meta.setOrgSettings(targetOrg, {
+            ...settings,
+            brandprint: { collectionId, profileId: profileShortId },
+          })
+
+        const already = !createdCollection && !createdProfile
+        return json({
+          workspace: targetOrg,
+          collection_id: collectionId,
+          profile_short_id: profileShortId,
+          state,
+          created: !already,
+          message:
+            state === "live"
+              ? `This workspace already has a live brand profile (${profileShortId}). To revise it, build a new version and publish it with for_review:true to that short_id.`
+              : `Brandprint ${already ? "is ready" : "scaffolded"}. NEXT: read derive://brandprint/reference and derive://brandprint/template, build ONE self-contained HTML brand profile from the source docs, then publish it with for_review:true to ${profileShortId}. A human approves it to go live.`,
+        })
+      } catch (e) {
+        const msg = e instanceof PublishError ? e.message : String(e)
+        return text(`Couldn't set up the Brandprint: ${msg}`)
       }
     },
   )

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -174,6 +174,7 @@ describe("remote MCP endpoint (/mcp)", () => {
       "publish",
       "read",
       "search",
+      "setup_brandprint",
       "stage_asset",
       "stage_publish",
     ])
@@ -514,6 +515,94 @@ describe("remote MCP endpoint (/mcp)", () => {
     const text = (read.parsed?.result as { contents?: { text: string }[] } | undefined)
       ?.contents?.[0]?.text
     expect(text).toContain("Acme brand profile")
+  })
+
+  it("advertises resources + serves the build guide via `read` even with no Brandprint", async () => {
+    // The bug this covers: reference/template were gated on an existing Brandprint, so a
+    // session that connected first cached "no resources" for life. They now register
+    // unconditionally, and `read` resolves the derive:// URIs directly (every client can).
+    const { app, token } = appWithGrant("bp-static", "openid derive:read")
+
+    const init = await rpc(app, token, initBody)
+    const caps = (init.parsed?.result as { capabilities?: { resources?: unknown } }).capabilities
+    expect(caps?.resources).toBeDefined()
+
+    const listed = await rpc(app, token, { jsonrpc: "2.0", id: 3, method: "resources/list" })
+    const uris = (
+      (listed.parsed?.result as { resources?: { uri: string }[] } | undefined)?.resources ?? []
+    ).map((r) => r.uri)
+    expect(uris).toContain("derive://brandprint/reference")
+    expect(uris).toContain("derive://brandprint/template")
+
+    // The same strings the instructions name are readable through the `read` tool.
+    const ref = JSON.parse(
+      toolText(await call(app, token, "read", { short_id: "derive://brandprint/reference" })),
+    )
+    expect(ref.content).toContain("for_review")
+    expect(ref.content).toContain("brandprint-tokens")
+    const tpl = JSON.parse(
+      toolText(await call(app, token, "read", { short_id: "derive://brandprint/template" })),
+    )
+    expect(tpl.content).toContain("brandprint-tokens")
+    // No live profile yet ⇒ the profile URI is an actionable error, not an empty read.
+    expect(
+      toolText(await call(app, token, "read", { short_id: "derive://brandprint/profile" })),
+    ).toContain("no live brand profile")
+  })
+
+  it("setup_brandprint scaffolds the profile slot, is idempotent, and the loop goes live", async () => {
+    const { app, token, meta } = appWithGrant(
+      "bp-setup",
+      "openid derive:read derive:publish derive:manage",
+    )
+    // No web dialog: the agent scaffolds the whole Brandprint over MCP.
+    const out = JSON.parse(toolText(await call(app, token, "setup_brandprint")))
+    expect(out.created).toBe(true)
+    expect(out.state).toBe("pending")
+    expect(out.collection_id).toBeTruthy()
+    expect(out.profile_short_id).toBeTruthy()
+    const profId = out.profile_short_id as string
+
+    // The pointer is persisted and the placeholder sits in the collection.
+    const prof = await meta.getByShortId(profId)
+    if (!prof) throw new Error("no profile artifact")
+    const settings = await meta.getOrgSettings(prof.org_id)
+    expect(settings.brandprint?.profileId).toBe(profId)
+    expect(settings.brandprint?.collectionId).toBe(out.collection_id)
+    expect(await meta.collectionArtifactIds(out.collection_id)).toContain(prof.id)
+
+    // Idempotent: a second call returns the same slot, nothing re-created.
+    const again = JSON.parse(toolText(await call(app, token, "setup_brandprint")))
+    expect(again.created).toBe(false)
+    expect(again.profile_short_id).toBe(profId)
+    expect(again.collection_id).toBe(out.collection_id)
+
+    // The agent builds the profile: a v2 against the placeholder flips it live.
+    const form = new FormData()
+    form.append(
+      "file",
+      new Blob([new TextEncoder().encode("<h1>Derive brand profile</h1>")]),
+      "index.html",
+    )
+    const rep = await app.request(`/v1/artifacts/${profId}/versions`, {
+      method: "POST",
+      body: form,
+      headers: { authorization: `Bearer ${token}` },
+    })
+    expect(rep.status).toBe(201)
+
+    // read derive://brandprint/profile now returns the live content; setup reports live.
+    const live = JSON.parse(
+      toolText(await call(app, token, "read", { short_id: "derive://brandprint/profile" })),
+    )
+    expect(live.content).toContain("Derive brand profile")
+    const post = JSON.parse(toolText(await call(app, token, "setup_brandprint")))
+    expect(post.state).toBe("live")
+  })
+
+  it("setup_brandprint requires an Admin/Owner role", async () => {
+    const { app, token } = appWithGrant("bp-setup-denied", "openid derive:read")
+    expect(toolText(await call(app, token, "setup_brandprint"))).toContain("Admin/Owner role")
   })
 
   it("list_artifacts + read see the agent's own published artifact", async () => {


### PR DESCRIPTION
## Why

Setting up a workspace Brandprint end to end **from a connected agent** hit two structural gaps (found while dogfooding the flow):

1. **`derive://brandprint/*` was unreadable in the golden onboarding order.** Resources registered only when a Brandprint already existed, and the MCP `resources` capability is negotiated **once at `initialize`** — so an agent that connected *before* setup (exactly the shipped onboarding: connect agent → set up Brandprint later) cached "no resources" for its whole session, with no fallback (`read` only accepted a `short_id`). The whole generation flow ("read `derive://brandprint/reference`") dead-ended.
2. **Linking was web-Admin-only.** No MCP tool could create the conventions collection + "Brand profile" placeholder or set the `org_settings.brandprint` pointer. So "set up our Brandprint" typed into an agent had nowhere to land — the human had to use the web dialog first.

## What changed (`apps/api/src/mcp.ts`, `brandprint-reference.ts`)

**Reliability**
- `read` now resolves the Brandprint URIs directly: `read("derive://brandprint/reference" | "/template" | "/profile" | "/<short_id>")`. The exact strings the instructions name are readable through the one primitive every client supports, even where MCP resources aren't. `/<short_id>` falls through to the normal read path (so `section`/`lines`/`version` still work).
- `reference` + `template` register **unconditionally**, so the `resources` capability is always advertised — killing the "connected-before-setup" trap for resource-capable clients too.

**Agent-native setup**
- New `setup_brandprint` tool (Owner/Admin only): idempotently ensures the collection + placeholder exist and points `org_settings.brandprint` at them, then returns the placeholder `short_id` — the server-side mirror of the web `useBrandprintImport` composition. Works with zero source docs.
- "The placeholder is the contract" preserved: the agent then `publish`es `for_review` against the returned short_id.

**Unchanged by design:** the human still approves the profile reveal to flip it live (`setup_brandprint` never generates or approves).

## Tests
- `apps/api/test/mcp.test.ts` (+): capability advertised + guide readable via `read` with **no** Brandprint; `setup_brandprint` scaffolds → idempotent → full setup→propose→live loop; role-gate denial. Existing tool-list assertion updated for the new tool.
- All related suites green (`mcp` 71/71, rework/profiles/contexts/publish-token/integrations, core brandprint). Typecheck + biome + all `lint:*` gates pass.

## UX result
"set up our Brandprint" → agent calls `setup_brandprint` → reads reference/template reliably → builds → files the proposal → human approves in the web reveal. No context-switch, nothing silently broken.