### PR TITLE
feat(library-sort): redefine the menu modes (Newest/Oldest + revised-…

### DIFF
--- a/apps/api/test/artifacts.test.ts
+++ b/apps/api/test/artifacts.test.ts
@@ -369,26 +369,29 @@ describe("server-side search + cursor pagination", () => {
     await upload("s3.md", "three")
 
     const desc = (
-      await (await app.request("/v1/artifacts?sort=created&limit=200")).json()
+      await (await app.request("/v1/artifacts?sort=updated&limit=200")).json()
     ).artifacts.map((a: { short_id: string }) => a.short_id)
     const asc = (
-      await (await app.request("/v1/artifacts?sort=created-asc&limit=200")).json()
+      await (await app.request("/v1/artifacts?sort=updated-asc&limit=200")).json()
     ).artifacts.map((a: { short_id: string }) => a.short_id)
     // asc is the exact reverse of desc — proves ?sort= is read and flips the ordering.
     expect(asc).toEqual([...desc].reverse())
 
     // No ?sort= must preserve the historical created-desc default (non-library callers).
+    const createdDesc = (
+      await (await app.request("/v1/artifacts?sort=created&limit=200")).json()
+    ).artifacts.map((a: { short_id: string }) => a.short_id)
     const noSort = (await (await app.request("/v1/artifacts?limit=200")).json()).artifacts.map(
       (a: { short_id: string }) => a.short_id,
     )
-    expect(noSort).toEqual(desc)
+    expect(noSort).toEqual(createdDesc)
 
     // Keyset cursor round-trip under asc: page 1 + page 2 is a contiguous, dup-free prefix.
-    const p1 = await (await app.request("/v1/artifacts?sort=created-asc&limit=2")).json()
+    const p1 = await (await app.request("/v1/artifacts?sort=updated-asc&limit=2")).json()
     expect(p1.next_cursor).toContain("|")
     const p2 = await (
       await app.request(
-        `/v1/artifacts?sort=created-asc&cursor=${encodeURIComponent(p1.next_cursor)}`,
+        `/v1/artifacts?sort=updated-asc&cursor=${encodeURIComponent(p1.next_cursor)}`,
       )
     ).json()
     const combined = [...p1.artifacts, ...p2.artifacts].map((a: { short_id: string }) => a.short_id)

--- a/apps/web/src/pages/library/sort.test.ts
+++ b/apps/web/src/pages/library/sort.test.ts
@@ -4,8 +4,10 @@ import { DEFAULT_SORT, LIBRARY_SORTS, parseLibrarySort, sortLabel } from "./sort
 describe("parseLibrarySort", () => {
   it("keeps a valid non-default mode and drops the default (stays out of the URL)", () => {
     expect(parseLibrarySort("az")).toBe("az")
-    expect(parseLibrarySort("created-asc")).toBe("created-asc")
+    expect(parseLibrarySort("revised")).toBe("revised")
     expect(parseLibrarySort(DEFAULT_SORT)).toBeUndefined()
+    // `created` is a valid core mode (the store default) but not a library menu option.
+    expect(parseLibrarySort("created")).toBeUndefined()
     expect(parseLibrarySort("bogus")).toBeUndefined()
     expect(parseLibrarySort(undefined)).toBeUndefined()
     expect(parseLibrarySort(123)).toBeUndefined()
@@ -15,13 +17,13 @@ describe("parseLibrarySort", () => {
     expect(LIBRARY_SORTS.map((s) => s.value)).toEqual([
       "updated",
       "updated-asc",
-      "created",
-      "created-asc",
+      "revised",
+      "revised-asc",
       "az",
       "za",
     ])
-    expect(LIBRARY_SORTS[0]).toEqual({ value: "updated", label: "Recently updated" })
+    expect(LIBRARY_SORTS[0]).toEqual({ value: "updated", label: "Newest" })
     expect(sortLabel("az")).toBe("Title A–Z")
-    expect(sortLabel(DEFAULT_SORT)).toBe("Recently updated")
+    expect(sortLabel(DEFAULT_SORT)).toBe("Newest")
   })
 })

--- a/apps/web/src/pages/library/sort.ts
+++ b/apps/web/src/pages/library/sort.ts
@@ -6,10 +6,10 @@ import type { SortMode } from "@derive/core"
 export const DEFAULT_SORT: SortMode = "updated"
 
 export const LIBRARY_SORTS: { value: SortMode; label: string }[] = [
-  { value: "updated", label: "Recently updated" },
-  { value: "updated-asc", label: "Least recently updated" },
-  { value: "created", label: "Recently created" },
-  { value: "created-asc", label: "Oldest created" },
+  { value: "updated", label: "Newest" },
+  { value: "updated-asc", label: "Oldest" },
+  { value: "revised", label: "Recently updated" },
+  { value: "revised-asc", label: "Least recently updated" },
   { value: "az", label: "Title A–Z" },
   { value: "za", label: "Title Z–A" },
 ]
@@ -21,6 +21,7 @@ const VALUES = new Set<string>(LIBRARY_SORTS.map((s) => s.value))
 export const parseLibrarySort = (raw: unknown): SortMode | undefined =>
   typeof raw === "string" && VALUES.has(raw) && raw !== DEFAULT_SORT ? (raw as SortMode) : undefined
 
-/** The menu label for a mode (falls back to the default's label for an unknown value). */
+/** The menu label for a mode (falls back to the default's label for an unknown value — e.g.
+ *  the `created` store default, which the menu doesn't list). */
 export const sortLabel = (mode: SortMode): string =>
-  LIBRARY_SORTS.find((s) => s.value === mode)?.label ?? "Recently updated"
+  LIBRARY_SORTS.find((s) => s.value === mode)?.label ?? "Newest"

--- a/apps/web/src/pages/library/types.ts
+++ b/apps/web/src/pages/library/types.ts
@@ -54,6 +54,6 @@ export type LibrarySearch = {
   // query param, not a route — a view of your own work is a filter on the home
   // library, not a separate feed (docs/decisions/0002).
   tab?: "mine"
-  // How the grid is ordered; absent = the default (Recently updated). See ./sort.
+  // How the grid is ordered; absent = the default ("Newest"). See ./sort.
   sort?: SortMode
 }

--- a/packages/core/src/sort.ts
+++ b/packages/core/src/sort.ts
@@ -6,19 +6,29 @@
  * imports only the `SortMode` type; see apps/web/src/pages/library/sort.ts.
  */
 
-export type SortMode = "updated" | "updated-asc" | "created" | "created-asc" | "az" | "za"
+export type SortMode =
+  | "updated"
+  | "updated-asc"
+  | "created"
+  | "revised"
+  | "revised-asc"
+  | "az"
+  | "za"
 
-/** The default the library opens in: newest first, where "newest" tracks a doc's LAST
- *  version — publishing a new version bumps it back to the top. Only the two `created` modes
- *  ignore versions. */
+/** The library's default ("Newest"): last activity, where an upload OR a new version both
+ *  count — publishing a new version bumps a doc back to the top so you never dig for a doc you
+ *  just revised. `created` is the store-side default for non-UI callers (created-desc); it is
+ *  not offered in the library menu. */
 export const DEFAULT_SORT: SortMode = "updated"
 
-/** Every mode, in the order the menu offers them. */
+/** Every valid mode. `created` is accepted (it is the store/route default) but the library
+ *  menu is a separate, smaller list (see apps/web/src/pages/library/sort.ts). */
 export const SORT_MODES: readonly SortMode[] = [
   "updated",
   "updated-asc",
   "created",
-  "created-asc",
+  "revised",
+  "revised-asc",
   "az",
   "za",
 ]
@@ -33,7 +43,7 @@ export const parseSortMode = (raw: string | null | undefined): SortMode =>
  *  ordering and its pagination can't disagree. */
 export const sortFields = (
   mode: SortMode,
-): { field: "updated" | "created" | "title"; dir: "asc" | "desc" } => {
+): { field: "updated" | "created" | "revised" | "title"; dir: "asc" | "desc" } => {
   switch (mode) {
     case "updated":
       return { field: "updated", dir: "desc" }
@@ -41,8 +51,10 @@ export const sortFields = (
       return { field: "updated", dir: "asc" }
     case "created":
       return { field: "created", dir: "desc" }
-    case "created-asc":
-      return { field: "created", dir: "asc" }
+    case "revised":
+      return { field: "revised", dir: "desc" }
+    case "revised-asc":
+      return { field: "revised", dir: "asc" }
     case "az":
       return { field: "title", dir: "asc" }
     case "za":
@@ -52,19 +64,28 @@ export const sortFields = (
 
 /** The value the keyset cursor carries for a row under `mode` — the JS twin of the store's
  *  ordering expression, for building the next-page cursor. `updated` coalesces to created_at
- *  (a row is versionless until its first publish); `title` is the RAW title (coalesced to '').
- *  The store lowers BOTH the column and the cursor key in SQL (`lower(coalesce(title,''))`),
- *  so the SAME engine owns case-folding for the comparison — JS `toLowerCase()` (full Unicode)
- *  and SQLite's `lower()` (ASCII-only on D1/SQLite) disagree on non-ASCII letters, which would
- *  corrupt a title-sort page boundary if JS lowered the key instead. */
+ *  (a row is versionless until its first publish). `revised` prefixes that coalesced time with
+ *  a group flag (`1:` for a doc with a genuine new version, current_version >= 2; `0:`
+ *  otherwise) so the revised docs sort as one block above the never-revised ones. `title` is
+ *  the RAW title (coalesced to ''); the store lowers BOTH the column and the cursor key in SQL
+ *  (`lower(coalesce(title,''))`), so the SAME engine owns case-folding — JS `toLowerCase()`
+ *  (full Unicode) and SQLite's `lower()` (ASCII-only on D1/SQLite) disagree on non-ASCII
+ *  letters, which would corrupt a title-sort page boundary if JS lowered the key instead. */
 export const sortKeyOf = (
-  row: { created_at: string; updated_at: string | null; title: string | null },
+  row: {
+    created_at: string
+    updated_at: string | null
+    title: string | null
+    current_version: number
+  },
   mode: SortMode,
 ): string => {
   const { field } = sortFields(mode)
   if (field === "updated") return row.updated_at ?? row.created_at
-  if (field === "title") return row.title ?? ""
-  return row.created_at
+  if (field === "created") return row.created_at
+  if (field === "revised")
+    return `${row.current_version >= 2 ? "1:" : "0:"}${row.updated_at ?? row.created_at}`
+  return row.title ?? ""
 }
 
 /** Keyset cursor codec: an opaque "<key>|<id>" string. An id is delimiter-free, so decode

--- a/packages/core/test/sort.test.ts
+++ b/packages/core/test/sort.test.ts
@@ -12,7 +12,7 @@ describe("parseSortMode", () => {
   it("accepts every known mode and falls back to the default otherwise", () => {
     expect(parseSortMode("updated")).toBe("updated")
     expect(parseSortMode("az")).toBe("az")
-    expect(parseSortMode("created-asc")).toBe("created-asc")
+    expect(parseSortMode("revised")).toBe("revised")
     expect(parseSortMode("bogus")).toBe(DEFAULT_SORT)
     expect(parseSortMode(undefined)).toBe(DEFAULT_SORT)
     expect(parseSortMode(null)).toBe(DEFAULT_SORT)
@@ -25,7 +25,8 @@ describe("sortFields", () => {
     expect(sortFields("updated")).toEqual({ field: "updated", dir: "desc" })
     expect(sortFields("updated-asc")).toEqual({ field: "updated", dir: "asc" })
     expect(sortFields("created")).toEqual({ field: "created", dir: "desc" })
-    expect(sortFields("created-asc")).toEqual({ field: "created", dir: "asc" })
+    expect(sortFields("revised")).toEqual({ field: "revised", dir: "desc" })
+    expect(sortFields("revised-asc")).toEqual({ field: "revised", dir: "asc" })
     expect(sortFields("az")).toEqual({ field: "title", dir: "asc" })
     expect(sortFields("za")).toEqual({ field: "title", dir: "desc" })
   })
@@ -36,6 +37,7 @@ describe("sortKeyOf", () => {
     created_at: "2026-01-01T00:00:00.000Z",
     updated_at: "2026-02-02T00:00:00.000Z",
     title: "Beta|Gamma",
+    current_version: 3,
   }
   it("uses coalesced updated_at, raw created_at, and the raw title per mode", () => {
     expect(sortKeyOf(row, "updated")).toBe("2026-02-02T00:00:00.000Z")
@@ -43,6 +45,16 @@ describe("sortKeyOf", () => {
     expect(sortKeyOf(row, "created")).toBe("2026-01-01T00:00:00.000Z")
     expect(sortKeyOf(row, "az")).toBe("Beta|Gamma")
     expect(sortKeyOf({ ...row, title: null }, "az")).toBe("")
+  })
+  it("prefixes the revised key with a group flag: 1: for a re-versioned doc, 0: otherwise", () => {
+    // v3 doc (genuinely revised) → "1:" + its last-version time.
+    expect(sortKeyOf(row, "revised")).toBe("1:2026-02-02T00:00:00.000Z")
+    // v1 doc (uploaded, never re-versioned) → "0:" group, below all revised docs.
+    expect(sortKeyOf({ ...row, current_version: 1 }, "revised")).toBe("0:2026-02-02T00:00:00.000Z")
+    // versionless stub → coalesces to created_at.
+    expect(sortKeyOf({ ...row, current_version: 0, updated_at: null }, "revised")).toBe(
+      "0:2026-01-01T00:00:00.000Z",
+    )
   })
 })
 

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -166,6 +166,7 @@ export function artifactListConditions(
     title: Column
     created_at: Column
     updated_at: Column
+    current_version: Column
     id: Column
     org_id: Column
     listed: Column
@@ -211,20 +212,31 @@ export function artifactListConditions(
   return conds
 }
 
-/** The keyset/ordering column for a sort field, as SQL valid on both SQLite and Postgres. */
+/** The keyset/ordering column for a sort field, as SQL valid on both SQLite and Postgres.
+ *  `revised` prefixes the coalesced activity time with a group flag so docs with a genuine new
+ *  version (current_version >= 2) sort as one block above the never-revised ones; the JS twin
+ *  is sortKeyOf. `||` and `case` are standard on both dialects. */
 export function artifactSortExpr(
-  art: { created_at: Column; updated_at: Column; title: Column },
-  field: "updated" | "created" | "title",
+  art: { created_at: Column; updated_at: Column; title: Column; current_version: Column },
+  field: "updated" | "created" | "revised" | "title",
 ): SQL {
   if (field === "updated") return sql`coalesce(${art.updated_at}, ${art.created_at})`
   if (field === "title") return sql`lower(coalesce(${art.title}, ''))`
+  if (field === "revised")
+    return sql`(case when ${art.current_version} >= 2 then '1:' else '0:' end) || coalesce(${art.updated_at}, ${art.created_at})`
   return sql`${art.created_at}`
 }
 
 /** The `ORDER BY` for a sort mode: the mode's column then the `id` tiebreak, same direction —
  *  the tuple the keyset cursor comparison mirrors. Shared by both drivers so they can't drift. */
 export function artifactListOrder(
-  art: { created_at: Column; updated_at: Column; title: Column; id: Column },
+  art: {
+    created_at: Column
+    updated_at: Column
+    title: Column
+    current_version: Column
+    id: Column
+  },
   mode: SortMode,
 ): SQL[] {
   const { field, dir } = sortFields(mode)

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -235,9 +235,8 @@ export function runStoreContract(
       // updated: banana(2030) > apple(2029) > cherry(2028) > nullish(its created_at, ~now < 2028).
       expect(await ids("updated")).toEqual([banana.id, apple.id, cherry.id, nullish.id])
       expect(await ids("updated-asc")).toEqual([nullish.id, cherry.id, apple.id, banana.id])
-      // created ignores versions: newest-created first (nullish created last).
+      // created (the store-side default) ignores versions: newest-created first.
       expect(await ids("created")).toEqual([nullish.id, cherry.id, apple.id, banana.id])
-      expect(await ids("created-asc")).toEqual([banana.id, apple.id, cherry.id, nullish.id])
       // az: lower(coalesce(title,'')) → "" (nullish), "apple", "banana", "cherry". A case-sensitive
       // sort would rank "Banana"(66) before "apple"(97); this order proves it does not.
       expect(await ids("az")).toEqual([nullish.id, apple.id, banana.id, cherry.id])
@@ -288,6 +287,48 @@ export function runStoreContract(
       const created = (await store.listArtifacts({ orgId: org, sort: "created" })).map((a) => a.id)
       expect(updated).toEqual([older.id, newer.id]) // version bump wins
       expect(created).toEqual([newer.id, older.id]) // created ignores the bump
+    })
+
+    it("revised: re-versioned docs sort as one block above never-revised uploads", async () => {
+      const org = `org_revised_${uuid()}`
+      // Two genuinely revised docs (current_version >= 2), with controlled revise times.
+      const reviseOld = await store.createArtifact(
+        newArtifact({ org_id: org, title: "revise-old" }),
+      )
+      await store.addVersion(reviseOld.id, newVersion())
+      await store.addVersion(reviseOld.id, newVersion())
+      const reviseNew = await store.createArtifact(
+        newArtifact({ org_id: org, title: "revise-new" }),
+      )
+      await store.addVersion(reviseNew.id, newVersion())
+      await store.addVersion(reviseNew.id, newVersion())
+      await store.setArtifactUpdatedAt(reviseOld.id, "2028-01-01T00:00:00.000Z")
+      await store.setArtifactUpdatedAt(reviseNew.id, "2029-01-01T00:00:00.000Z")
+      // A never-revised v1 upload with a DECEPTIVELY-new updated_at, and a versionless stub.
+      const freshUpload = await store.createArtifact(newArtifact({ org_id: org, title: "fresh" }))
+      await store.addVersion(freshUpload.id, newVersion()) // current_version = 1 (not revised)
+      await store.setArtifactUpdatedAt(freshUpload.id, "2030-01-01T00:00:00.000Z")
+      const stub = await store.createArtifact(newArtifact({ org_id: org, title: "stub" })) // v0
+
+      const revisedIds = (await store.listArtifacts({ orgId: org, sort: "revised" })).map(
+        (a) => a.id,
+      )
+      // Revised block first (newest revision first), then the never-revised uploads by activity.
+      // freshUpload's 2030 stamp does NOT float it above the revised docs — it was never revised.
+      expect(revisedIds).toEqual([reviseNew.id, reviseOld.id, freshUpload.id, stub.id])
+
+      // Keyset pagination under `revised` reassembles that order one row at a time, no drop/dup.
+      const walked: string[] = []
+      let cursor: { key: string; id: string } | undefined
+      for (let guard = 0; guard < 8; guard++) {
+        const page = await store.listArtifacts({ orgId: org, sort: "revised", limit: 1, cursor })
+        if (page.length === 0) break
+        walked.push(...page.map((a) => a.id))
+        const last = page[page.length - 1]
+        const flag = last.current_version >= 2 ? "1:" : "0:"
+        cursor = { key: `${flag}${last.updated_at ?? last.created_at}`, id: last.id }
+      }
+      expect(walked).toEqual(revisedIds)
     })
   })
 


### PR DESCRIPTION
## What

Follow-up to the library sort feature (#474): reworks the six menu modes to
match the intended definitions. The default now treats a re-versioned document
as fresh work, so a doc you upgraded last week doesn't stay buried under its
original date.

## The modes now

| Menu option | Sorts by |
| --- | --- |
| **Newest** (default) | Last activity: an upload OR a new version, whichever is most recent |
| **Oldest** | The reverse |
| **Recently updated** | Only docs given a genuine new version (version 2+), newest revision first |
| **Least recently updated** | The reverse |
| **A–Z / Z–A** | Title (unchanged) |

## Notes

- **Newest / Oldest** order by `coalesce(updated_at, created_at)`, so publishing
  a new version bumps a doc back to the top. This is behaviorally what the old
  default did; it's now correctly labeled "Newest."
- **Recently updated / Least recently updated** count only a *genuine* new
  version (`current_version >= 2`). A brand-new single-version upload is not
  treated as "updated" and sorts below the revised docs. This is done by
  encoding a group flag into the keyset sort key (`1:` for revised, `0:`
  otherwise), so the revised docs form one contiguous block and keyset
  pagination stays correct across a page boundary.
- Edge behavior worth a look: under **Least recently updated**, never-revised
  uploads surface at the top (they have "never been updated," so they are the
  least-recently-updated of all). Easy to flip to the bottom instead if that
  reads better in use.
- The two "created" menu options are dropped. `created` (created-desc) is kept
  as the store-side default for non-UI car and MCP
  `list_artifacts`), so nothing outside the library changes.

## Testing

- Core unit tests for the new field/direction mapping and the revised group-flag
  key.
- Store-contract tests (SQLite in every run, Postgres in CI) assert the revised
  block ordering and walk the full set onrsors to prove
  no drop or duplicate at a page boundary, including that a never-revised upload
  with a newer timestamp does not float a
- API test confirms the created-desc default for non-UI callers is preserved and
  that a garbage `?sort=` falls back safe

🤖 Generated with [Claude Code](https://c