### PR TITLE
feat(collections): folders inside a collection

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1327,10 +1327,6 @@
           "repo": {
             "type": "string",
             "description": "For repo/PR collections: the \"owner/name\" slug."
-          },
-          "folderId": {
-            "type": "string",
-            "description": "The org-shared folder this collection is filed under, when any."
           }
         },
         "required": [
@@ -1347,6 +1343,10 @@
           "id": {
             "type": "string"
           },
+          "collectionId": {
+            "type": "string",
+            "description": "The collection this folder organizes."
+          },
           "name": {
             "type": "string"
           },
@@ -1360,6 +1360,7 @@
         },
         "required": [
           "id",
+          "collectionId",
           "name",
           "created_by",
           "created_at"
@@ -5143,15 +5144,25 @@
         }
       }
     },
-    "/v1/folders": {
+    "/v1/collections/{id}/folders": {
       "get": {
         "tags": [
           "Folders"
         ],
-        "summary": "List the active workspace's folders (members only).",
+        "summary": "A collection's folders + its item→folder assignments (any collection role).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
         "responses": {
           "200": {
-            "description": "The workspace's folders, in name order.",
+            "description": "Folders (name order) and the artifact→folder map for grouping.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5162,10 +5173,18 @@
                       "items": {
                         "$ref": "#/components/schemas/Folder"
                       }
+                    },
+                    "assignments": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "artifact short_id → folder id (filed items only)."
                     }
                   },
                   "required": [
-                    "folders"
+                    "folders",
+                    "assignments"
                   ]
                 }
               }
@@ -5177,7 +5196,17 @@
         "tags": [
           "Folders"
         ],
-        "summary": "Create a folder (workspace owners only).",
+        "summary": "Create a folder in a collection (collection editors).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
         "responses": {
           "201": {
             "description": "The created folder.",
@@ -5197,7 +5226,7 @@
         "tags": [
           "Folders"
         ],
-        "summary": "Rename a folder (workspace owners only).",
+        "summary": "Rename a folder (collection editors).",
         "parameters": [
           {
             "schema": {
@@ -5225,7 +5254,7 @@
         "tags": [
           "Folders"
         ],
-        "summary": "Delete a folder (workspace owners only); its collections become ungrouped.",
+        "summary": "Delete a folder (collection editors); its items become unfiled, not removed.",
         "parameters": [
           {
             "schema": {
@@ -5238,17 +5267,17 @@
         ],
         "responses": {
           "204": {
-            "description": "Deleted; member collections are un-filed, not removed."
+            "description": "Deleted; the collection's artifacts are un-filed, not removed."
           }
         }
       }
     },
-    "/v1/collections/{id}/folder": {
+    "/v1/collections/{id}/items/{shortId}/folder": {
       "put": {
         "tags": [
           "Folders"
         ],
-        "summary": "File a collection under a folder, or ungroup it (workspace owners only).",
+        "summary": "File a collection's artifact under a folder, or unfile it (collection editors).",
         "parameters": [
           {
             "schema": {
@@ -5257,11 +5286,19 @@
             "required": true,
             "name": "id",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "shortId",
+            "in": "path"
           }
         ],
         "responses": {
           "204": {
-            "description": "Filed (or ungrouped when folderId is null)."
+            "description": "Filed (or unfiled when folderId is null)."
           }
         }
       }

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -80,10 +80,6 @@ export const collectionRoutes = (ctx: AppContext) => {
         .describe("For a PR preview: the repo collection it nests under, when connected."),
       prNumber: z.number().optional().describe("For a PR preview: the pull-request number."),
       repo: z.string().optional().describe('For repo/PR collections: the "owner/name" slug.'),
-      folderId: z
-        .string()
-        .optional()
-        .describe("The org-shared folder this collection is filed under, when any."),
     })
     .openapi("Collection")
 
@@ -107,14 +103,11 @@ export const collectionRoutes = (ctx: AppContext) => {
     srcByCollection: Map<string, Src>,
     branchByRepo: Map<string, string>,
   ) => {
-    // Expose the stored folder_id under the client's camelCase `folderId` (like
-    // parentId/prNumber). Folders are pure organization — never an auth input.
-    const withFolder = { ...col, folderId: col.folder_id ?? undefined }
     const src = srcByCollection.get(col.id)
-    if (!src) return { ...withFolder, kind: "manual" as const }
-    if (src.pr === null) return { ...withFolder, kind: "repo" as const, repo: src.repo }
+    if (!src) return { ...col, kind: "manual" as const }
+    if (src.pr === null) return { ...col, kind: "repo" as const, repo: src.repo }
     return {
-      ...withFolder,
+      ...col,
       kind: "pr" as const,
       repo: src.repo,
       prNumber: src.pr,

--- a/apps/api/src/routes/folders.ts
+++ b/apps/api/src/routes/folders.ts
@@ -1,74 +1,105 @@
-import { newId } from "@derive/core"
+import { type Action, type FolderRecord, newId, roleAllows } from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { Context } from "hono"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
 import { bail, fail, readJson } from "../lib/http"
 
-/** Folders: an owner-editable, workspace-shared layer that groups collections in the
- *  sidebar (Phase 3 of the sidebar rework). A folder grants NO access — it never appears
- *  in any auth path; it only files collections (collection.folder_id). Reads are
- *  member-scoped; every mutation is workspace-owner-only (requireWorkspace "manage"). The
- *  Folder response schema is the single source for the web client's type. */
+/** Folders organize the artifacts WITHIN a collection (Collection → Folder → artifacts).
+ *  A folder inherits its collection's access and grants nothing of its own — it never
+ *  appears in any auth path. Reading a collection's folders needs any role on it; managing
+ *  (create / rename / delete / file an item) needs the collection's editor role. Items are
+ *  filed per-membership (collection_item.folder_id), so the same artifact can sit in
+ *  different folders in different collections. The Folder schema is the web client's type. */
 export const folderRoutes = (ctx: AppContext) => {
-  const { meta, isMember, isToken, currentUser, activeWorkspace, requireWorkspace } = ctx
+  const { meta, currentUser, collectionRole } = ctx
   const app = new OpenAPIHono<BlankEnv>()
 
   const Folder = z
     .object({
       id: z.string(),
+      collectionId: z.string().describe("The collection this folder organizes."),
       name: z.string(),
       created_by: z.string().describe('Creator\'s user id ("anon" if created anonymously).'),
       created_at: z.string(),
     })
     .openapi("Folder")
+  const toFolder = (f: FolderRecord) => ({
+    id: f.id,
+    collectionId: f.collection_id ?? "",
+    name: f.name,
+    created_by: f.created_by,
+    created_at: f.created_at,
+  })
 
   const NAME_MAX = 80
   const cleanName = (s: string) => s.trim().slice(0, NAME_MAX)
+  const byName = (a: { name: string }, b: { name: string }) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
 
-  // Resolve the :id folder IN the caller's workspace (404 otherwise). Every mutation
-  // opens with this after the owner gate, so a folder from another workspace can't be
-  // touched even by its own owner.
-  const requireFolder = async (c: Context, org: string) => {
+  // Resolve the collection by id and require `action` on it (managing folders = "publish",
+  // the collection's editor role). 404 missing, 403 present-but-unauthorized.
+  const requireCollectionRole = async (c: Context, colId: string, action: Action) => {
+    const col = await meta.getCollection(colId)
+    if (!col) return fail(c, 404, "not found")
+    if (!roleAllows((await collectionRole(c, col)) ?? "viewer", action))
+      return fail(c, 403, "forbidden")
+    return col
+  }
+  // Resolve the :id folder and gate on ITS collection (editor). Used by rename/delete,
+  // whose path carries the folder id, not the collection id.
+  const requireFolderManage = async (c: Context) => {
     const id = c.req.param("id")
     const f = id ? await meta.getFolder(id) : null
-    if (!f || f.org_id !== org) return fail(c, 404, "not found")
+    if (!f || !f.collection_id) return fail(c, 404, "not found")
+    const col = await requireCollectionRole(c, f.collection_id, "publish")
+    if (col instanceof Response) return col
     return f
   }
 
   app.openapi(
     createRoute({
       method: "get",
-      path: "/v1/folders",
+      path: "/v1/collections/{id}/folders",
       tags: ["Folders"],
-      summary: "List the active workspace's folders (members only).",
+      summary: "A collection's folders + its item→folder assignments (any collection role).",
+      request: { params: z.object({ id: z.string() }) },
       responses: {
         200: {
-          description: "The workspace's folders, in name order.",
-          content: { "application/json": { schema: z.object({ folders: z.array(Folder) }) } },
+          description: "Folders (name order) and the artifact→folder map for grouping.",
+          content: {
+            "application/json": {
+              schema: z.object({
+                folders: z.array(Folder),
+                assignments: z
+                  .record(z.string(), z.string())
+                  .describe("artifact short_id → folder id (filed items only)."),
+              }),
+            },
+          },
         },
       },
     }),
     async (c) => {
-      const me = await currentUser(c)
-      if (!me && !isToken(c)) return bail(fail(c, 401, "unauthenticated"))
-      const org = await activeWorkspace(c)
-      // Folders are shared workspace structure — members (or the operator token) see the
-      // tree; a non-member gets an empty list (they can't enumerate it).
-      if (!(await isMember(c, org))) return c.json({ folders: [] })
-      const folders = (await meta.listFolders(org)).sort((a, b) =>
-        a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
-      )
-      return c.json({ folders })
+      const col = await meta.getCollection(c.req.param("id"))
+      if (!col) return bail(fail(c, 404, "not found"))
+      // Any role on the collection can see its folder structure (it's part of the view).
+      if ((await collectionRole(c, col)) === null) return bail(fail(c, 403, "forbidden"))
+      const [folders, assignments] = await Promise.all([
+        meta.listFolders(col.id),
+        meta.collectionItemFolders(col.id),
+      ])
+      return c.json({ folders: folders.map(toFolder).sort(byName), assignments })
     },
   )
 
   app.openapi(
     createRoute({
       method: "post",
-      path: "/v1/folders",
+      path: "/v1/collections/{id}/folders",
       tags: ["Folders"],
-      summary: "Create a folder (workspace owners only).",
+      summary: "Create a folder in a collection (collection editors).",
+      request: { params: z.object({ id: z.string() }) },
       responses: {
         201: {
           description: "The created folder.",
@@ -77,8 +108,8 @@ export const folderRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const org = await requireWorkspace(c, "manage")
-      if (org instanceof Response) return bail(org)
+      const col = await requireCollectionRole(c, c.req.param("id"), "publish")
+      if (col instanceof Response) return bail(col)
       const body = await readJson(
         c,
         z.object({ name: z.string().refine((s) => s.trim() !== "", "name required") }),
@@ -87,11 +118,12 @@ export const folderRoutes = (ctx: AppContext) => {
       const me = await currentUser(c)
       const created = await meta.createFolder({
         id: newId("fld"),
-        org_id: org,
+        org_id: col.org_id,
+        collection_id: col.id,
         name: cleanName(body.name),
         created_by: me?.id ?? "anon",
       })
-      return c.json(created, 201)
+      return c.json(toFolder(created), 201)
     },
   )
 
@@ -100,7 +132,7 @@ export const folderRoutes = (ctx: AppContext) => {
       method: "patch",
       path: "/v1/folders/{id}",
       tags: ["Folders"],
-      summary: "Rename a folder (workspace owners only).",
+      summary: "Rename a folder (collection editors).",
       request: { params: z.object({ id: z.string() }) },
       responses: {
         200: {
@@ -110,19 +142,15 @@ export const folderRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const org = await requireWorkspace(c, "manage")
-      if (org instanceof Response) return bail(org)
-      const f = await requireFolder(c, org)
+      const f = await requireFolderManage(c)
       if (f instanceof Response) return bail(f)
       const body = await readJson(c, z.object({ name: z.string().optional() }))
       if (body instanceof Response) return bail(body)
       const name = body.name !== undefined ? cleanName(body.name) : undefined
-      // A provided-but-blank name is rejected, matching create — don't persist an
-      // empty folder name (an invisible row in the rail).
       if (name === "") return bail(fail(c, 400, "name required"))
       const updated = await meta.updateFolder(f.id, { name })
       if (!updated) return bail(fail(c, 404, "not found"))
-      return c.json(updated)
+      return c.json(toFolder(updated))
     },
   )
 
@@ -131,14 +159,14 @@ export const folderRoutes = (ctx: AppContext) => {
       method: "delete",
       path: "/v1/folders/{id}",
       tags: ["Folders"],
-      summary: "Delete a folder (workspace owners only); its collections become ungrouped.",
+      summary: "Delete a folder (collection editors); its items become unfiled, not removed.",
       request: { params: z.object({ id: z.string() }) },
-      responses: { 204: { description: "Deleted; member collections are un-filed, not removed." } },
+      responses: {
+        204: { description: "Deleted; the collection's artifacts are un-filed, not removed." },
+      },
     }),
     async (c) => {
-      const org = await requireWorkspace(c, "manage")
-      if (org instanceof Response) return bail(org)
-      const f = await requireFolder(c, org)
+      const f = await requireFolderManage(c)
       if (f instanceof Response) return bail(f)
       await meta.deleteFolder(f.id)
       return c.body(null, 204)
@@ -148,26 +176,30 @@ export const folderRoutes = (ctx: AppContext) => {
   app.openapi(
     createRoute({
       method: "put",
-      path: "/v1/collections/{id}/folder",
+      path: "/v1/collections/{id}/items/{shortId}/folder",
       tags: ["Folders"],
-      summary: "File a collection under a folder, or ungroup it (workspace owners only).",
-      request: { params: z.object({ id: z.string() }) },
-      responses: { 204: { description: "Filed (or ungrouped when folderId is null)." } },
+      summary: "File a collection's artifact under a folder, or unfile it (collection editors).",
+      request: { params: z.object({ id: z.string(), shortId: z.string() }) },
+      responses: { 204: { description: "Filed (or unfiled when folderId is null)." } },
     }),
     async (c) => {
-      const org = await requireWorkspace(c, "manage")
-      if (org instanceof Response) return bail(org)
-      const col = await meta.getCollection(c.req.param("id"))
-      if (!col || col.org_id !== org) return bail(fail(c, 404, "not found"))
+      const col = await requireCollectionRole(c, c.req.param("id"), "publish")
+      if (col instanceof Response) return bail(col)
+      const art = await meta.getByShortId(c.req.param("shortId"))
+      if (!art || art.org_id !== col.org_id) return bail(fail(c, 404, "artifact not found"))
+      // The artifact must actually be IN this collection — filing a non-member would be a
+      // silent no-op (no collection_item row to update), so reject it as not-found.
+      if (!(await meta.collectionIdsForArtifact(art.id)).includes(col.id))
+        return bail(fail(c, 404, "artifact not in collection"))
       const body = await readJson(c, z.object({ folderId: z.string().nullable() }))
       if (body instanceof Response) return bail(body)
-      // A non-null target must be a real folder in THIS workspace (folders never cross
-      // workspaces, and an unknown id must not silently orphan the pointer).
+      // A non-null target must be a folder OF THIS collection — you can't file an item into
+      // another collection's folder (the cross-collection integrity the DB can't enforce).
       if (body.folderId !== null) {
         const f = await meta.getFolder(body.folderId)
-        if (!f || f.org_id !== org) return bail(fail(c, 404, "folder not found"))
+        if (!f || f.collection_id !== col.id) return bail(fail(c, 404, "folder not found"))
       }
-      await meta.setCollectionFolder(col.id, body.folderId)
+      await meta.setItemFolder(col.id, art.id, body.folderId)
       return c.body(null, 204)
     },
   )

--- a/apps/api/test/folders.test.ts
+++ b/apps/api/test/folders.test.ts
@@ -1,142 +1,198 @@
 import { describe, expect, it } from "vitest"
-import { app, as, makeAuthedApp, meta, postJson, type TestUser } from "./helpers"
+import { app, as, makeAuthedApp, meta, postJson, type TestUser, upload } from "./helpers"
 
-describe("folders", () => {
-  const putJson = (path: string, body: unknown, headers: Record<string, string> = {}) =>
+// Folders organize the artifacts WITHIN a collection. A folder belongs to one collection;
+// an item's folder is per-membership (collection_item.folder_id). Management needs the
+// collection's editor role; reading needs any role on it.
+describe("folders (inside a collection)", () => {
+  const jsonReq = (
+    path: string,
+    method: string,
+    body: unknown,
+    headers: Record<string, string> = {},
+  ) =>
     app.request(path, {
-      method: "PUT",
+      method,
       headers: { "content-type": "application/json", ...headers },
       body: JSON.stringify(body),
     })
-
-  it("owner creates + lists + renames folders; the list is case-insensitive alphabetical", async () => {
-    const beta = await (await postJson("/v1/folders", { name: "Beta" })).json()
-    const alpha = await (await postJson("/v1/folders", { name: "alpha" })).json()
-    expect(beta.name).toBe("Beta")
-    expect(alpha.name).toBe("alpha")
-
-    const list = await (await app.request("/v1/folders")).json()
-    const names = list.folders.map((f: { name: string }) => f.name)
-    expect(names).toEqual(["alpha", "Beta"]) // A–Z, case-insensitive
-
-    const renamed = await app.request(`/v1/folders/${beta.id}`, {
-      method: "PATCH",
+  const addItem = (colId: string, shortId: string) =>
+    app.request(`/v1/collections/${colId}/items/${shortId}`, {
+      method: "PUT",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ name: "Bravo" }),
     })
-    expect(renamed.status).toBe(200)
-    expect((await meta.getFolder(beta.id))?.name).toBe("Bravo")
-  })
+  const seedItem = async (colId: string, title: string) => {
+    const { short_id } = await (await upload(`${title}.md`, "x", { title })).json()
+    await addItem(colId, short_id)
+    const art = await meta.getByShortId(short_id)
+    if (!art) throw new Error("artifact missing")
+    return { short_id, id: art.id }
+  }
 
-  it("files a collection under a folder (exposes folderId); deleting the folder un-files it, collection survives", async () => {
-    const folder = await (await postJson("/v1/folders", { name: "Rebrand" })).json()
+  it("creates folders in a collection and lists them (name order) with an empty assignment map", async () => {
     const col = await (await postJson("/v1/collections", { title: "Homepage" })).json()
-    expect(
-      (await putJson(`/v1/collections/${col.id}/folder`, { folderId: folder.id })).status,
-    ).toBe(204)
-
-    const list = await (await app.request("/v1/collections")).json()
-    expect(list.collections.find((c: { id: string }) => c.id === col.id)?.folderId).toBe(folder.id)
-
-    expect((await app.request(`/v1/folders/${folder.id}`, { method: "DELETE" })).status).toBe(204)
-    expect(await meta.getFolder(folder.id)).toBeNull()
-    // The collection survives, un-filed.
-    expect((await meta.getCollection(col.id))?.folder_id ?? null).toBeNull()
-    const after = await (await app.request("/v1/collections")).json()
-    expect(after.collections.find((c: { id: string }) => c.id === col.id)?.folderId).toBeUndefined()
+    const a = await (
+      await jsonReq(`/v1/collections/${col.id}/folders`, "POST", { name: "alpha" })
+    ).json()
+    await jsonReq(`/v1/collections/${col.id}/folders`, "POST", { name: "Beta" })
+    expect(a.collectionId).toBe(col.id)
+    const list = await (await app.request(`/v1/collections/${col.id}/folders`)).json()
+    expect(list.folders.map((f: { name: string }) => f.name)).toEqual(["alpha", "Beta"])
+    expect(list.assignments).toEqual({})
   })
 
-  it("ungroups a collection when folderId is null", async () => {
-    const folder = await (await postJson("/v1/folders", { name: "Temp" })).json()
+  it("files an artifact into a folder (assignment map reflects it); null unfiles it", async () => {
     const col = await (await postJson("/v1/collections", { title: "C" })).json()
-    await putJson(`/v1/collections/${col.id}/folder`, { folderId: folder.id })
-    expect((await putJson(`/v1/collections/${col.id}/folder`, { folderId: null })).status).toBe(204)
-    expect((await meta.getCollection(col.id))?.folder_id ?? null).toBeNull()
+    const folder = await (
+      await jsonReq(`/v1/collections/${col.id}/folders`, "POST", { name: "Heroes" })
+    ).json()
+    const item = await seedItem(col.id, "Art")
+    expect(
+      (
+        await jsonReq(`/v1/collections/${col.id}/items/${item.short_id}/folder`, "PUT", {
+          folderId: folder.id,
+        })
+      ).status,
+    ).toBe(204)
+    let list = await (await app.request(`/v1/collections/${col.id}/folders`)).json()
+    expect(list.assignments[item.short_id]).toBe(folder.id)
+    expect(
+      (
+        await jsonReq(`/v1/collections/${col.id}/items/${item.short_id}/folder`, "PUT", {
+          folderId: null,
+        })
+      ).status,
+    ).toBe(204)
+    list = await (await app.request(`/v1/collections/${col.id}/folders`)).json()
+    expect(list.assignments[item.short_id]).toBeUndefined()
   })
 
-  it("rejects filing under an unknown folder (404)", async () => {
-    const col = await (await postJson("/v1/collections", { title: "C2" })).json()
+  it("the same artifact sits in different folders in different collections (per-membership)", async () => {
+    const x = await (await postJson("/v1/collections", { title: "X" })).json()
+    const y = await (await postJson("/v1/collections", { title: "Y" })).json()
+    const fx = await (
+      await jsonReq(`/v1/collections/${x.id}/folders`, "POST", { name: "FX" })
+    ).json()
+    const fy = await (
+      await jsonReq(`/v1/collections/${y.id}/folders`, "POST", { name: "FY" })
+    ).json()
+    const { short_id } = await (await upload("multi.md", "x", { title: "Multi" })).json()
+    await addItem(x.id, short_id)
+    await addItem(y.id, short_id)
+    await jsonReq(`/v1/collections/${x.id}/items/${short_id}/folder`, "PUT", { folderId: fx.id })
+    await jsonReq(`/v1/collections/${y.id}/items/${short_id}/folder`, "PUT", { folderId: fy.id })
+    const lx = await (await app.request(`/v1/collections/${x.id}/folders`)).json()
+    const ly = await (await app.request(`/v1/collections/${y.id}/folders`)).json()
+    expect(lx.assignments[short_id]).toBe(fx.id)
+    expect(ly.assignments[short_id]).toBe(fy.id)
+  })
+
+  it("won't file an item under a folder from another collection (404)", async () => {
+    const x = await (await postJson("/v1/collections", { title: "X2" })).json()
+    const y = await (await postJson("/v1/collections", { title: "Y2" })).json()
+    const fy = await (
+      await jsonReq(`/v1/collections/${y.id}/folders`, "POST", { name: "other" })
+    ).json()
+    const item = await seedItem(x.id, "Cross")
     expect(
-      (await putJson(`/v1/collections/${col.id}/folder`, { folderId: "fld_missing" })).status,
+      (
+        await jsonReq(`/v1/collections/${x.id}/items/${item.short_id}/folder`, "PUT", {
+          folderId: fy.id,
+        })
+      ).status,
     ).toBe(404)
   })
 
-  it("rejects a blank rename (matches create)", async () => {
-    const folder = await (await postJson("/v1/folders", { name: "Keep" })).json()
-    const res = await app.request(`/v1/folders/${folder.id}`, {
-      method: "PATCH",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ name: "   " }),
-    })
-    expect(res.status).toBe(400)
-    expect((await meta.getFolder(folder.id))?.name).toBe("Keep")
+  it("won't file an artifact that isn't in the collection (404, not a silent no-op)", async () => {
+    const col = await (await postJson("/v1/collections", { title: "Members" })).json()
+    const folder = await (
+      await jsonReq(`/v1/collections/${col.id}/folders`, "POST", { name: "F" })
+    ).json()
+    // An artifact that exists but was never added to this collection.
+    const { short_id } = await (await upload("stray.md", "x", { title: "Stray" })).json()
+    expect(
+      (
+        await jsonReq(`/v1/collections/${col.id}/items/${short_id}/folder`, "PUT", {
+          folderId: folder.id,
+        })
+      ).status,
+    ).toBe(404)
   })
 
-  it("won't file a collection under a folder from another workspace (404)", async () => {
-    // Folder lives in the default app's workspace…
-    const folder = await (await postJson("/v1/folders", { name: "Theirs" })).json()
-    // …a different, isolated workspace's owner has their own collection…
-    const solo: TestUser = {
-      id: "u_fld_solo",
-      email: "solo@fld.test",
-      name: "Solo",
-      username: "solof",
+  it("deleting a folder unfiles its items — the artifacts stay in the collection", async () => {
+    const col = await (await postJson("/v1/collections", { title: "D" })).json()
+    const folder = await (
+      await jsonReq(`/v1/collections/${col.id}/folders`, "POST", { name: "Temp" })
+    ).json()
+    const item = await seedItem(col.id, "Survivor")
+    await jsonReq(`/v1/collections/${col.id}/items/${item.short_id}/folder`, "PUT", {
+      folderId: folder.id,
+    })
+    expect((await app.request(`/v1/folders/${folder.id}`, { method: "DELETE" })).status).toBe(204)
+    expect(await meta.getFolder(folder.id)).toBeNull()
+    const list = await (await app.request(`/v1/collections/${col.id}/folders`)).json()
+    expect(list.folders).toHaveLength(0)
+    expect(list.assignments).toEqual({})
+    const arts = await (await app.request(`/v1/artifacts?collection=${col.id}`)).json()
+    expect(arts.artifacts.map((a: { short_id: string }) => a.short_id)).toContain(item.short_id)
+  })
+
+  it("rejects a blank folder name (create + rename)", async () => {
+    const col = await (await postJson("/v1/collections", { title: "N" })).json()
+    expect(
+      (await jsonReq(`/v1/collections/${col.id}/folders`, "POST", { name: "   " })).status,
+    ).toBe(400)
+    const f = await (
+      await jsonReq(`/v1/collections/${col.id}/folders`, "POST", { name: "Keep" })
+    ).json()
+    expect((await jsonReq(`/v1/folders/${f.id}`, "PATCH", { name: "   " })).status).toBe(400)
+    expect((await meta.getFolder(f.id))?.name).toBe("Keep")
+  })
+
+  it("management needs the collection's editor role; a viewer member can read but not write", async () => {
+    const owner: TestUser = { id: "u_f2_own", email: "own@f2.test", name: "Own", username: "ownf2" }
+    const viewer: TestUser = {
+      id: "u_f2_view",
+      email: "view@f2.test",
+      name: "View",
+      username: "viewf2",
     }
-    const { app: other } = makeAuthedApp("folders-xws", [solo], undefined, { isolated: true })
+    const { app: team } = makeAuthedApp("folders2-roles", [owner, viewer], "viewer")
     const col = await (
-      await other.request("/v1/collections", {
+      await team.request("/v1/collections", {
         method: "POST",
-        headers: { "content-type": "application/json", ...as(solo.email) },
-        body: JSON.stringify({ title: "Mine" }),
+        headers: { "content-type": "application/json", ...as(owner.email) },
+        body: JSON.stringify({ title: "Team" }),
       })
     ).json()
-    // …and cannot file it under the other workspace's folder (folder not in their org).
-    const res = await other.request(`/v1/collections/${col.id}/folder`, {
-      method: "PUT",
-      headers: { "content-type": "application/json", ...as(solo.email) },
-      body: JSON.stringify({ folderId: folder.id }),
-    })
-    expect(res.status).toBe(404)
-  })
-
-  it("folder mutations are workspace-owner-only; a member editor can read but not write", async () => {
-    const owner: TestUser = {
-      id: "u_fld_own",
-      email: "own@fld.test",
-      name: "Own",
-      username: "ownf",
-    }
-    const ed: TestUser = { id: "u_fld_ed", email: "ed@fld.test", name: "Ed", username: "edf" }
-    const { app: team } = makeAuthedApp("folders-roles", [owner, ed], "editor")
-
-    const created = await team.request("/v1/folders", {
-      method: "POST",
-      headers: { "content-type": "application/json", ...as(owner.email) },
-      body: JSON.stringify({ name: "Team" }),
-    })
-    expect(created.status).toBe(201)
-    const folder = await created.json()
-
-    // The editor sees the shared folder tree…
-    const list = await (await team.request("/v1/folders", { headers: as(ed.email) })).json()
+    const folder = await (
+      await team.request(`/v1/collections/${col.id}/folders`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...as(owner.email) },
+        body: JSON.stringify({ name: "Owned" }),
+      })
+    ).json()
+    // The viewer can READ the folder structure…
+    const list = await (
+      await team.request(`/v1/collections/${col.id}/folders`, { headers: as(viewer.email) })
+    ).json()
     expect(list.folders.map((f: { id: string }) => f.id)).toContain(folder.id)
-
-    // …but can't create / rename / delete (owner-only).
-    const create = await team.request("/v1/folders", {
+    // …but can't create / rename / delete.
+    const create = await team.request(`/v1/collections/${col.id}/folders`, {
       method: "POST",
-      headers: { "content-type": "application/json", ...as(ed.email) },
+      headers: { "content-type": "application/json", ...as(viewer.email) },
       body: JSON.stringify({ name: "Nope" }),
     })
     expect(create.status).toBe(403)
     const rename = await team.request(`/v1/folders/${folder.id}`, {
       method: "PATCH",
-      headers: { "content-type": "application/json", ...as(ed.email) },
+      headers: { "content-type": "application/json", ...as(viewer.email) },
       body: JSON.stringify({ name: "X" }),
     })
     expect(rename.status).toBe(403)
     const del = await team.request(`/v1/folders/${folder.id}`, {
       method: "DELETE",
-      headers: as(ed.email),
+      headers: as(viewer.email),
     })
     expect(del.status).toBe(403)
   })

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -2506,24 +2506,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/folders": {
+    "/v1/collections/{id}/folders": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** List the active workspace's folders (members only). */
+        /** A collection's folders + its item→folder assignments (any collection role). */
         get: {
             parameters: {
                 query?: never;
                 header?: never;
-                path?: never;
+                path: {
+                    id: string;
+                };
                 cookie?: never;
             };
             requestBody?: never;
             responses: {
-                /** @description The workspace's folders, in name order. */
+                /** @description Folders (name order) and the artifact→folder map for grouping. */
                 200: {
                     headers: {
                         [name: string]: unknown;
@@ -2531,18 +2533,24 @@ export interface paths {
                     content: {
                         "application/json": {
                             folders: components["schemas"]["Folder"][];
+                            /** @description artifact short_id → folder id (filed items only). */
+                            assignments: {
+                                [key: string]: string;
+                            };
                         };
                     };
                 };
             };
         };
         put?: never;
-        /** Create a folder (workspace owners only). */
+        /** Create a folder in a collection (collection editors). */
         post: {
             parameters: {
                 query?: never;
                 header?: never;
-                path?: never;
+                path: {
+                    id: string;
+                };
                 cookie?: never;
             };
             requestBody?: never;
@@ -2574,7 +2582,7 @@ export interface paths {
         get?: never;
         put?: never;
         post?: never;
-        /** Delete a folder (workspace owners only); its collections become ungrouped. */
+        /** Delete a folder (collection editors); its items become unfiled, not removed. */
         delete: {
             parameters: {
                 query?: never;
@@ -2586,7 +2594,7 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description Deleted; member collections are un-filed, not removed. */
+                /** @description Deleted; the collection's artifacts are un-filed, not removed. */
                 204: {
                     headers: {
                         [name: string]: unknown;
@@ -2597,7 +2605,7 @@ export interface paths {
         };
         options?: never;
         head?: never;
-        /** Rename a folder (workspace owners only). */
+        /** Rename a folder (collection editors). */
         patch: {
             parameters: {
                 query?: never;
@@ -2622,7 +2630,7 @@ export interface paths {
         };
         trace?: never;
     };
-    "/v1/collections/{id}/folder": {
+    "/v1/collections/{id}/items/{shortId}/folder": {
         parameters: {
             query?: never;
             header?: never;
@@ -2630,19 +2638,20 @@ export interface paths {
             cookie?: never;
         };
         get?: never;
-        /** File a collection under a folder, or ungroup it (workspace owners only). */
+        /** File a collection's artifact under a folder, or unfile it (collection editors). */
         put: {
             parameters: {
                 query?: never;
                 header?: never;
                 path: {
                     id: string;
+                    shortId: string;
                 };
                 cookie?: never;
             };
             requestBody?: never;
             responses: {
-                /** @description Filed (or ungrouped when folderId is null). */
+                /** @description Filed (or unfiled when folderId is null). */
                 204: {
                     headers: {
                         [name: string]: unknown;
@@ -5744,11 +5753,11 @@ export interface components {
             prNumber?: number;
             /** @description For repo/PR collections: the "owner/name" slug. */
             repo?: string;
-            /** @description The org-shared folder this collection is filed under, when any. */
-            folderId?: string;
         };
         Folder: {
             id: string;
+            /** @description The collection this folder organizes. */
+            collectionId: string;
             name: string;
             /** @description Creator's user id ("anon" if created anonymously). */
             created_by: string;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -850,19 +850,24 @@ export const api = {
     f(`/v1/collections/${collectionId}/items/${shortId}`, { ...opts(), method: "PUT" }).then(
       () => undefined,
     ),
-  // Folders (owner-editable org grouping; grant no access). Mutations are workspace-
-  // owner-only server-side — the UI hides them for non-owners.
-  listFolders: (): Promise<{ folders: Folder[] }> => f("/v1/folders", opts()).then(j),
-  createFolder: (name: string): Promise<Folder> => f("/v1/folders", opts({ name })).then(j),
+  // Folders organize a collection's artifacts (grant no access). Management is gated on
+  // the collection's editor role server-side — the UI hides it for non-editors.
+  collectionFolders: (
+    collectionId: string,
+  ): Promise<{ folders: Folder[]; assignments: Record<string, string> }> =>
+    f(`/v1/collections/${collectionId}/folders`, opts()).then(j),
+  createFolder: (collectionId: string, name: string): Promise<Folder> =>
+    f(`/v1/collections/${collectionId}/folders`, opts({ name })).then(j),
   renameFolder: (id: string, name: string): Promise<Folder> =>
     f(`/v1/folders/${id}`, { ...opts({ name }), method: "PATCH" }).then(j),
   deleteFolder: (id: string): Promise<void> =>
     f(`/v1/folders/${id}`, { method: "DELETE", credentials: "include" }).then(() => undefined),
-  // File a collection under a folder (or null to ungroup).
-  setCollectionFolder: (collectionId: string, folderId: string | null): Promise<void> =>
-    f(`/v1/collections/${collectionId}/folder`, { ...opts({ folderId }), method: "PUT" }).then(
-      () => undefined,
-    ),
+  // File an artifact (within a collection) under a folder, or null to unfile.
+  setItemFolder: (collectionId: string, shortId: string, folderId: string | null): Promise<void> =>
+    f(`/v1/collections/${collectionId}/items/${shortId}/folder`, {
+      ...opts({ folderId }),
+      method: "PUT",
+    }).then(() => undefined),
   removeFromCollection: (collectionId: string, shortId: string): Promise<void> =>
     f(`/v1/collections/${collectionId}/items/${shortId}`, {
       method: "DELETE",

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -35,12 +35,12 @@ export const collectionsQuery = () =>
     queryFn: () => api.listCollections().then((r) => r.collections),
   })
 
-// The workspace's org-shared folders (name order), for the rail's folder grouping and
-// the "Move to folder" picker. Small and warm like collectionsQuery.
-export const foldersQuery = () =>
+// A collection's folders (name order) + its artifact→folder assignment map — drives the
+// collection view's folder grouping and management. Keyed by collection.
+export const collectionFoldersQuery = (collectionId: string) =>
   queryOptions({
-    queryKey: ["folders"] as const,
-    queryFn: () => api.listFolders().then((r) => r.folders),
+    queryKey: ["collection-folders", collectionId] as const,
+    queryFn: () => api.collectionFolders(collectionId),
   })
 
 // Workspaces only change via create/switch/delete — all of which hard-reload — so

--- a/apps/web/src/pages/library/bulk-organize.tsx
+++ b/apps/web/src/pages/library/bulk-organize.tsx
@@ -1,7 +1,7 @@
 import type { QueryKey } from "@tanstack/react-query"
 import { useQuery } from "@tanstack/react-query"
 import { useState } from "react"
-import { type Artifact, api } from "@/api"
+import { type Artifact, api, type Folder } from "@/api"
 import { Icon } from "@/components/icons"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Badge } from "@/components/ui/badge"
@@ -15,7 +15,12 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
-import { artifactQuery, collectionsQuery, summaryQuery } from "@/lib/queries"
+import {
+  artifactQuery,
+  collectionFoldersQuery,
+  collectionsQuery,
+  summaryQuery,
+} from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { useBrandprintCollectionIds } from "@/lib/use-brandprint-ids"
 import { cn } from "@/lib/utils"
@@ -150,6 +155,117 @@ export function BulkTagsDialog({
             {apply.isPending
               ? "Tagging…"
               : `Tag ${items.length} ${items.length === 1 ? "artifact" : "artifacts"}`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// Move the selected artifacts INTO a folder of the current collection (or unfile them).
+// One target folder for the whole selection; applies per item (folder membership is
+// per-collection, so this only touches the current collection's memberships).
+export function BulkFolderDialog({
+  items,
+  collectionId,
+  folders,
+  listKey,
+  onDone,
+  open,
+  onOpenChange,
+}: {
+  items: Artifact[]
+  collectionId: string
+  folders: Folder[]
+  listKey: QueryKey
+  onDone: () => void
+  open: boolean
+  onOpenChange: (o: boolean) => void
+}) {
+  // undefined = nothing picked yet; null = "Unfiled"; string = a folder id.
+  const [target, setTarget] = useState<string | null | undefined>(undefined)
+  const sorted = [...folders].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+  )
+
+  const apply = useApiMutation({
+    // One PUT per item (no bulk endpoint yet). `allSettled` so a single rejection can't
+    // abort the rest and leave a silent partial move — count the failures and report them
+    // like the other bulk actions' `summarize`. All-failed throws so it surfaces as an
+    // error toast rather than a green "Moved 0".
+    mutationFn: async (folderId: string | null) => {
+      const results = await Promise.allSettled(
+        items.map((a) => api.setItemFolder(collectionId, a.short_id, folderId)),
+      )
+      const failed = results.filter((r) => r.status === "rejected").length
+      if (failed === items.length) throw new Error("Couldn’t move any of the selected artifacts.")
+      return failed
+    },
+    invalidate: [listKey, collectionFoldersQuery(collectionId).queryKey],
+    success: (failed) => {
+      const moved = items.length - failed
+      const base = `Moved ${moved} ${moved === 1 ? "artifact" : "artifacts"}`
+      return failed > 0 ? `${base} · ${failed} couldn’t be moved` : base
+    },
+    onSuccess: onDone,
+  })
+
+  const row = (id: string | null, label: string, testId: string) => (
+    <button
+      key={testId}
+      type="button"
+      data-testid={testId}
+      aria-pressed={target === id}
+      onClick={() => setTarget(id)}
+      className={cn(
+        "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm font-medium text-foreground outline-none hover:bg-accent focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring",
+        target === id && "bg-accent",
+      )}
+    >
+      <span className="grid w-3.5 shrink-0 place-items-center">
+        {target === id && <Icon name="check" size={16} />}
+      </span>
+      <span className="flex-1 truncate">{label}</span>
+    </button>
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Move to folder</DialogTitle>
+          <DialogDescription>
+            File the selected artifacts under a folder in this collection. Folders organize a
+            collection’s contents — they don’t change who can see them.
+          </DialogDescription>
+        </DialogHeader>
+        {folders.length === 0 && (
+          <div className="text-sm text-muted-foreground">
+            No folders yet — create one from “New folder” in the collection.
+          </div>
+        )}
+        <div className="flex max-h-64 flex-col gap-px overflow-auto">
+          {sorted.map((f) => row(f.id, f.name, `bulk-folder-${f.id}`))}
+          {row(null, "Unfiled (remove from folder)", "bulk-folder-unfile")}
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="bulk-folder-cancel"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            data-testid="bulk-folder-apply"
+            disabled={target === undefined || apply.isPending}
+            onClick={() => target !== undefined && apply.mutate(target)}
+          >
+            {apply.isPending
+              ? "Moving…"
+              : `Move ${items.length} ${items.length === 1 ? "artifact" : "artifacts"}`}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/pages/library/collection-folders.tsx
+++ b/apps/web/src/pages/library/collection-folders.tsx
@@ -1,0 +1,335 @@
+import { ChevronRight } from "lucide-react"
+import { useState } from "react"
+import { type Artifact, api, type Folder } from "@/api"
+import { Icon } from "@/components/icons"
+import { ConfirmDialog } from "@/components/shared/confirm-dialog"
+import { Count } from "@/components/shared/section-eyebrow"
+import { Spinner } from "@/components/shared/spinner"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Input } from "@/components/ui/input"
+import { collectionFoldersQuery } from "@/lib/queries"
+import { useApiMutation } from "@/lib/use-api-mutation"
+import { cn } from "@/lib/utils"
+import { ArtifactRow } from "./artifact-row"
+import type { LibrarySelection } from "./use-library-selection"
+
+interface RowHandlers {
+  onOpen: (a: Artifact) => void
+  onToggleFavorite: (a: Artifact) => void
+  onPickTag: (tag: string) => void
+  onPickAuthor: (login: string) => void
+  onEditTags: (a: Artifact) => void
+  onAddToCollection: (a: Artifact) => void
+  onDelete: (a: Artifact) => void
+  onPrefetch: (a: Artifact) => void
+  selection?: LibrarySelection
+}
+
+const UNFILED = "__unfiled__"
+
+// The "New folder" affordance (button → inline input). Shared by the grouped view below
+// and the flat (no-folders-yet) collection grid, so both create folders one way.
+export function NewFolderControl({
+  collectionId,
+  className,
+}: {
+  collectionId: string
+  className?: string
+}) {
+  const [creating, setCreating] = useState(false)
+  const [name, setName] = useState("")
+  const create = useApiMutation({
+    mutationFn: (n: string) => api.createFolder(collectionId, n),
+    invalidate: [collectionFoldersQuery(collectionId).queryKey],
+    onSuccess: () => {
+      setCreating(false)
+      setName("")
+    },
+  })
+  const submit = () => (name.trim() ? create.mutate(name.trim()) : setCreating(false))
+  if (creating)
+    return (
+      <Input
+        autoFocus
+        value={name}
+        placeholder="Folder name…"
+        aria-label="Folder name"
+        data-testid="collection-new-folder-input"
+        onChange={(e) => setName(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") submit()
+          if (e.key === "Escape") {
+            setCreating(false)
+            setName("")
+          }
+        }}
+        onBlur={submit}
+        className={cn("max-w-xs", className)}
+      />
+    )
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      data-testid="collection-new-folder"
+      onClick={() => setCreating(true)}
+      className={cn("self-start", className)}
+    >
+      <Icon name="plus" size={16} />
+      New folder
+    </Button>
+  )
+}
+
+/**
+ * A manual collection's artifacts, grouped into its user folders (Collection → Folder →
+ * artifacts). Folders come first (name order), then an "Unfiled" bucket; each section is
+ * collapsible. Collection editors get a "New folder" affordance and a per-folder rename /
+ * delete menu; filing artifacts is done from the multi-select bar's "Move to folder".
+ * Sibling of `folder-groups.tsx` (the repo path-folder view), one level, alphabetical.
+ */
+export function CollectionFolders({
+  collectionId,
+  items,
+  folders,
+  assignments,
+  canManage,
+  hasNextPage,
+  isFetchingNextPage,
+  ...handlers
+}: {
+  collectionId: string
+  items: Artifact[]
+  folders: Folder[]
+  /** artifact short_id → folder id (filed items only). */
+  assignments: Record<string, string>
+  canManage: boolean
+  // The parent loads the whole collection when this view is active (folders need every
+  // item to bucket + count), so there's no load-more button here — just a tail spinner
+  // while those pages arrive.
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+} & RowHandlers) {
+  const [renaming, setRenaming] = useState<string | null>(null)
+  const [renameName, setRenameName] = useState("")
+  const [deleting, setDeleting] = useState<Folder | null>(null)
+  const invalidate = [collectionFoldersQuery(collectionId).queryKey]
+
+  const renameFolder = useApiMutation({
+    mutationFn: ({ id, name }: { id: string; name: string }) => api.renameFolder(id, name),
+    invalidate,
+    onSuccess: () => {
+      setRenaming(null)
+      setRenameName("")
+    },
+  })
+  const removeFolder = useApiMutation({
+    mutationFn: (id: string) => api.deleteFolder(id),
+    invalidate,
+  })
+
+  // Bucket the loaded artifacts by their folder; unfiled last.
+  const byFolder = new Map<string, Artifact[]>()
+  for (const a of items) {
+    const key = assignments[a.short_id] ?? UNFILED
+    const arr = byFolder.get(key)
+    if (arr) arr.push(a)
+    else byFolder.set(key, [a])
+  }
+  const sortedFolders = [...folders].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+  )
+  const unfiled = byFolder.get(UNFILED) ?? []
+
+  return (
+    <div className="flex flex-col gap-3">
+      {canManage && <NewFolderControl collectionId={collectionId} />}
+
+      {sortedFolders.map((f) => (
+        <Section
+          key={f.id}
+          title={f.name}
+          testId={`collection-folder-${f.id}`}
+          items={byFolder.get(f.id) ?? []}
+          menu={
+            canManage ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    aria-label={`Manage folder ${f.name}`}
+                    data-testid={`collection-folder-${f.id}-menu`}
+                    className="shrink-0 opacity-0 group-hover/folder:opacity-100 focus-visible:opacity-100"
+                  >
+                    <Icon name="more" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-40">
+                  <DropdownMenuItem
+                    data-testid={`collection-folder-${f.id}-rename`}
+                    onSelect={() => {
+                      setRenameName(f.name)
+                      setRenaming(f.id)
+                    }}
+                  >
+                    <Icon name="pencil" className="mr-2 size-4 text-muted-foreground" />
+                    Rename
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    data-testid={`collection-folder-${f.id}-delete`}
+                    onSelect={() => setDeleting(f)}
+                  >
+                    <Icon name="delete" className="mr-2 size-4 text-muted-foreground" />
+                    Delete folder
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : undefined
+          }
+          renameInput={
+            renaming === f.id ? (
+              <Input
+                autoFocus
+                value={renameName}
+                aria-label="Folder name"
+                data-testid={`collection-folder-${f.id}-rename-input`}
+                onChange={(e) => setRenameName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && renameName.trim())
+                    renameFolder.mutate({ id: f.id, name: renameName.trim() })
+                  if (e.key === "Escape") {
+                    setRenaming(null)
+                    setRenameName("")
+                  }
+                }}
+                onBlur={() =>
+                  renameName.trim()
+                    ? renameFolder.mutate({ id: f.id, name: renameName.trim() })
+                    : setRenaming(null)
+                }
+                className="max-w-xs"
+              />
+            ) : undefined
+          }
+          {...handlers}
+        />
+      ))}
+
+      {unfiled.length > 0 && (
+        <Section
+          title="Unfiled"
+          testId="collection-folder-unfiled"
+          muted
+          items={unfiled}
+          {...handlers}
+        />
+      )}
+
+      {(hasNextPage || isFetchingNextPage) && (
+        <div className="flex justify-center py-2">
+          <Spinner />
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={!!deleting}
+        onOpenChange={(o) => !o && setDeleting(null)}
+        title={`Delete folder “${deleting?.name ?? ""}”?`}
+        description="The folder is removed and its artifacts become unfiled — they stay in the collection."
+        confirmLabel="Delete folder"
+        confirmTestId="collection-folder-delete-confirm"
+        onConfirm={async () => {
+          if (deleting) await removeFolder.mutateAsync(deleting.id)
+          setDeleting(null)
+        }}
+      />
+    </div>
+  )
+}
+
+function Section({
+  title,
+  testId,
+  items,
+  menu,
+  renameInput,
+  muted,
+  ...handlers
+}: {
+  title: string
+  testId: string
+  items: Artifact[]
+  menu?: React.ReactNode
+  renameInput?: React.ReactNode
+  muted?: boolean
+} & RowHandlers) {
+  const [open, setOpen] = useState(true)
+  if (renameInput) return <div>{renameInput}</div>
+  return (
+    <div className="group/folder">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          data-testid={`${testId}-toggle`}
+          aria-expanded={open}
+          onClick={() => setOpen((o) => !o)}
+          className="flex min-w-0 flex-1 items-center gap-2 rounded-md py-1.5 text-left outline-none hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+        >
+          <ChevronRight
+            className={cn(
+              "size-4 shrink-0 text-muted-foreground transition-transform",
+              open && "rotate-90",
+            )}
+            aria-hidden
+          />
+          {/* A folder — the single-folder glyph — for both a named folder and the Unfiled
+              bucket; `muted` carries the Unfiled distinction through color, not a different
+              icon (the plural stack reads as "many collections", wrong for one folder). */}
+          <Icon name="collection" className="text-muted-foreground" />
+          <span
+            className={cn(
+              "truncate text-sm font-medium",
+              muted ? "text-muted-foreground" : "text-foreground",
+            )}
+          >
+            {title}
+          </span>
+          <Count>{items.length}</Count>
+        </button>
+        {menu}
+      </div>
+      {open && (
+        <div className="mt-1.5 flex flex-col gap-2 pl-6">
+          {items.map((a) => (
+            <ArtifactRow
+              key={a.short_id}
+              artifact={a}
+              onOpen={() => handlers.onOpen(a)}
+              onToggleFavorite={() => handlers.onToggleFavorite(a)}
+              onPickTag={handlers.onPickTag}
+              onPickAuthor={handlers.onPickAuthor}
+              onEditTags={() => handlers.onEditTags(a)}
+              onAddToCollection={() => handlers.onAddToCollection(a)}
+              onDelete={() => handlers.onDelete(a)}
+              onPrefetch={() => handlers.onPrefetch(a)}
+              selected={handlers.selection?.selected.has(a.short_id)}
+              selectionActive={handlers.selection?.active}
+              onSelect={
+                handlers.selection
+                  ? (shift) => handlers.selection?.toggle(a.short_id, shift)
+                  : undefined
+              }
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, useNavigate, useSearch } from "@tanstack/react-router"
-import { FolderTree, List } from "lucide-react"
+import { FolderTree, LayoutGrid, List } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { type Artifact, api } from "@/api"
 import { Icon } from "@/components/icons"
@@ -18,6 +18,7 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { useAuth } from "@/ctx"
 import {
   artifactQuery,
+  collectionFoldersQuery,
   collectionsQuery,
   needsFeedbackArtifactsQuery,
   summaryQuery,
@@ -34,6 +35,7 @@ import { ArtifactGrid } from "./artifact-grid"
 import { ArtifactRow, byRecency } from "./artifact-row"
 import { BrandprintNudge } from "./brandprint-nudge"
 import { CollectionBar } from "./collection-bar"
+import { CollectionFolders, NewFolderControl } from "./collection-folders"
 import { FolderGroups } from "./folder-groups"
 import { FollowingStrip } from "./following-strip"
 import { HowItWorks } from "./how-it-works"
@@ -166,11 +168,19 @@ function LibraryBody({ view }: { view: LibraryView }) {
   const activeCollection =
     filter.kind === "collection" ? collections.find((c) => c.id === filter.id) : undefined
   const isSyncedCollection = activeCollection?.kind === "repo" || activeCollection?.kind === "pr"
-  // Pull the whole collection so the sort + grouping see every doc (collections are finite
-  // and scoping keeps them small).
-  useEffect(() => {
-    if (isSyncedCollection && hasNextPage && !isFetchingNextPage) fetchNextPage()
-  }, [isSyncedCollection, hasNextPage, isFetchingNextPage, fetchNextPage])
+  // In-collection folders (manual collections only; repos use the path-based FolderGroups).
+  // Fetch the folder list + artifact→folder assignment map so the view can group.
+  const isManualCollection = filter.kind === "collection" && !isSyncedCollection
+  const { data: colFolders } = useQuery({
+    ...collectionFoldersQuery(filter.kind === "collection" ? filter.id : ""),
+    enabled: !!me && isManualCollection,
+  })
+  const folders = colFolders?.folders ?? []
+  const folderAssignments = colFolders?.assignments ?? {}
+  // Managing a collection's folders needs the collection's editor role.
+  const canManageFolders =
+    isManualCollection &&
+    (activeCollection?.my_role === "editor" || activeCollection?.my_role === "owner")
   const recencyItems = isSyncedCollection ? [...items].sort(byRecency) : items
 
   // Folder-vs-flat is remembered PER COLLECTION (a JSON map under the one storage key),
@@ -189,6 +199,11 @@ function LibraryBody({ view }: { view: LibraryView }) {
   // feeds pass nothing — a direct/feed open has no single collection to page within.
   const openContext = filter.kind === "collection" ? { collection: filter.id } : {}
   const showFolders = filter.kind === "collection" ? !!folderPrefs[filter.id] : false
+  // A manual collection that HAS folders defaults to the grouped folder view; the
+  // List/Folders toggle (same per-collection pref as the synced one) flips it back to the
+  // card grid so thumbnails are never lost for good. Default true only when folders exist.
+  const showManualFolders = filter.kind === "collection" ? (folderPrefs[filter.id] ?? true) : true
+  const foldersView = isManualCollection && folders.length > 0 && showManualFolders
   const setShowFolders = (on: boolean) => {
     if (filter.kind !== "collection") return
     setFolderPrefs((prev) => {
@@ -201,6 +216,13 @@ function LibraryBody({ view }: { view: LibraryView }) {
       return next
     })
   }
+  // Pull the WHOLE collection when the sort + grouping need every doc: always for a synced
+  // repo/PR, and for a manual collection while its folder view is active (so buckets +
+  // counts reflect every item, not just the first page). Collections are finite and
+  // scoping keeps them small.
+  useEffect(() => {
+    if ((isSyncedCollection || foldersView) && hasNextPage && !isFetchingNextPage) fetchNextPage()
+  }, [isSyncedCollection, foldersView, hasNextPage, isFetchingNextPage, fetchNextPage])
 
   const renameCol = useApiMutation({
     mutationFn: ({ id, title }: { id: string; title: string }) => api.renameCollection(id, title),
@@ -551,8 +573,88 @@ function LibraryBody({ view }: { view: LibraryView }) {
           onPrefetch={(a) => prefetch(a.short_id, a.current_version)}
           selection={selection}
         />
+      ) : isManualCollection && folders.length > 0 ? (
+        // An organized manual collection. A Cards/Folders toggle (default Folders) rides
+        // above so thumbnails are one click away — the folder grouping never traps you in
+        // rows. Both views share the same items + multi-select.
+        <div className="flex flex-col gap-3">
+          <ToggleGroup
+            type="single"
+            variant="outline"
+            size="sm"
+            aria-label="View"
+            className="self-end"
+            value={foldersView ? "folders" : "list"}
+            onValueChange={(v) => v && setShowFolders(v === "folders")}
+          >
+            <ToggleGroupItem value="list" aria-label="Cards" data-testid="library-view-list">
+              <LayoutGrid aria-hidden />
+              Cards
+            </ToggleGroupItem>
+            <ToggleGroupItem
+              value="folders"
+              aria-label="Folders"
+              data-testid="library-view-folders"
+            >
+              <FolderTree aria-hidden />
+              Folders
+            </ToggleGroupItem>
+          </ToggleGroup>
+          {foldersView ? (
+            <CollectionFolders
+              collectionId={filter.id}
+              items={items}
+              folders={folders}
+              assignments={folderAssignments}
+              canManage={!!canManageFolders}
+              hasNextPage={!!hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+              onOpen={(a) =>
+                nav({ to: "/artifacts/$ref", params: { ref: refFor(a) }, search: openContext })
+              }
+              onToggleFavorite={toggleFavorite}
+              onPickTag={(tag) => nav({ to: "/", search: { tag } })}
+              onPickAuthor={pickAuthor}
+              onEditTags={setPendingTags}
+              onAddToCollection={setPendingCollections}
+              onDelete={setPendingDelete}
+              onPrefetch={(a) => prefetch(a.short_id, a.current_version)}
+              selection={selection}
+            />
+          ) : (
+            <>
+              <ArtifactGrid
+                items={items}
+                scrollRef={scrollRef}
+                hasNextPage={!!hasNextPage}
+                isFetchingNextPage={isFetchingNextPage}
+                onLoadMore={() => fetchNextPage()}
+                onOpen={(a) =>
+                  nav({ to: "/artifacts/$ref", params: { ref: refFor(a) }, search: openContext })
+                }
+                onToggleFavorite={toggleFavorite}
+                onPickTag={(tag) => nav({ to: "/", search: { tag } })}
+                onEditTags={setPendingTags}
+                onAddToCollection={setPendingCollections}
+                onDelete={setPendingDelete}
+                onPrefetch={(a) => prefetch(a.short_id, a.current_version)}
+                selection={selection}
+              />
+              {isFetchingNextPage && (
+                <div className="flex justify-center py-2" data-testid="library-loading-more">
+                  <Spinner />
+                </div>
+              )}
+            </>
+          )}
+        </div>
       ) : (
         <>
+          {/* No folders yet on a manual collection → keep the card grid; an editor gets a
+              "New folder" to start organizing (the view flips to folders once one exists). */}
+          {filter.kind === "collection" && canManageFolders && (
+            <NewFolderControl collectionId={filter.id} className="mb-3" />
+          )}
           <ArtifactGrid
             items={items}
             scrollRef={scrollRef}
@@ -586,6 +688,11 @@ function LibraryBody({ view }: { view: LibraryView }) {
           items={selection.selectedItems}
           listKey={listQuery.queryKey}
           onClear={selection.clear}
+          folderContext={
+            filter.kind === "collection" && canManageFolders
+              ? { collectionId: filter.id, folders }
+              : undefined
+          }
         />
       )}
 

--- a/apps/web/src/pages/library/selection-bar.tsx
+++ b/apps/web/src/pages/library/selection-bar.tsx
@@ -1,6 +1,6 @@
 import type { QueryKey } from "@tanstack/react-query"
 import { type ReactNode, useState } from "react"
-import { type Artifact, api } from "@/api"
+import { type Artifact, api, type Folder } from "@/api"
 import { Icon } from "@/components/icons"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { Button } from "@/components/ui/button"
@@ -8,7 +8,7 @@ import { collectionsQuery, summaryQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { cn } from "@/lib/utils"
 import { summarize } from "./bulk-apply"
-import { BulkCollectionsDialog, BulkTagsDialog } from "./bulk-organize"
+import { BulkCollectionsDialog, BulkFolderDialog, BulkTagsDialog } from "./bulk-organize"
 
 // One action in the bar. The label is the button's text on a roomy viewport and its
 // accessible name everywhere — below `sm` the text collapses and the icon carries it, so
@@ -62,6 +62,7 @@ export function SelectionBar({
   items,
   listKey,
   onClear,
+  folderContext,
 }: {
   // The selection, in feed order — already reconciled against the live feed, so every
   // artifact here is one the user can still see.
@@ -69,9 +70,13 @@ export function SelectionBar({
   // The active feed's list query, so a bulk write reconciles the grid it just changed.
   listKey: QueryKey
   onClear: () => void
+  // Present only in a collection view whose folders the caller can manage — enables the
+  // "Move to folder" action (folders are per-collection, so it needs that collection).
+  folderContext?: { collectionId: string; folders: Folder[] }
 }) {
   const [showTags, setShowTags] = useState(false)
   const [showCollections, setShowCollections] = useState(false)
+  const [showFolder, setShowFolder] = useState(false)
   const [showDelete, setShowDelete] = useState(false)
 
   const n = items.length
@@ -151,6 +156,17 @@ export function SelectionBar({
             onClick={() => setShowCollections(true)}
           />
 
+          {folderContext && (
+            <BarAction
+              testId="library-selection-folder"
+              icon={<Icon name="collection" size={16} />}
+              label="Move to folder"
+              disabled={busy}
+              title="File the selected artifacts under a folder in this collection"
+              onClick={() => setShowFolder(true)}
+            />
+          )}
+
           <BarAction
             testId="library-selection-favorite"
             icon={
@@ -219,6 +235,20 @@ export function SelectionBar({
           onOpenChange={setShowCollections}
           onDone={() => {
             setShowCollections(false)
+            onClear()
+          }}
+        />
+      )}
+      {showFolder && folderContext && (
+        <BulkFolderDialog
+          items={items}
+          collectionId={folderContext.collectionId}
+          folders={folderContext.folders}
+          listKey={listKey}
+          open={showFolder}
+          onOpenChange={setShowFolder}
+          onDone={() => {
+            setShowFolder(false)
             onClear()
           }}
         />

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -259,6 +259,7 @@ CREATE TABLE IF NOT EXISTS collection_item (
   id TEXT PRIMARY KEY,
   collection_id TEXT NOT NULL,
   artifact_id TEXT NOT NULL,
+  folder_id TEXT,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   UNIQUE (collection_id, artifact_id),
   FOREIGN KEY (collection_id) REFERENCES collection(id),
@@ -278,6 +279,7 @@ CREATE TABLE IF NOT EXISTS collection_member (
 CREATE TABLE IF NOT EXISTS folder (
   id TEXT PRIMARY KEY,
   org_id TEXT NOT NULL DEFAULT 'local',
+  collection_id TEXT,
   name TEXT NOT NULL,
   created_by TEXT NOT NULL,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -632,17 +632,21 @@ export interface CollectionStore {
    *  artifact — folded into their effective artifact role (collection sharing). */
   collectionRolesForArtifact(artifactId: string, userId: string): Promise<Role[]>
 
-  // ---- Folders (owner-editable org grouping for collections; grant no access) ---
+  // ---- Folders (organize a collection's artifacts; inherit its access, grant nothing) --
   createFolder(f: NewFolder): Promise<FolderRecord>
-  /** All folders in a workspace (scoped when orgId given). Name order is a view concern. */
-  listFolders(orgId?: string): Promise<FolderRecord[]>
+  /** The folders belonging to a collection. Name order is a view concern. */
+  listFolders(collectionId: string): Promise<FolderRecord[]>
   getFolder(id: string): Promise<FolderRecord | null>
   updateFolder(id: string, fields: { name?: string }): Promise<FolderRecord | null>
-  /** Delete a folder and un-file its collections (set their folder_id to null) — the
-   *  collections themselves are untouched. */
+  /** Delete a folder and un-file its items within the collection (collection_item.folder_id
+   *  → null) — the artifacts stay in the collection. */
   deleteFolder(id: string): Promise<void>
-  /** File a collection under a folder (or null to ungroup). */
-  setCollectionFolder(collectionId: string, folderId: string | null): Promise<void>
+  /** File an artifact (within a collection) under a folder, or null to unfile. Scoped to
+   *  the membership row, so the same artifact can sit in different folders per collection. */
+  setItemFolder(collectionId: string, artifactId: string, folderId: string | null): Promise<void>
+  /** Map of artifact SHORT-ID → folder_id for a collection's FILED items (unfiled ones
+   *  absent). Keyed by short_id so the web (which works in short_ids) can group directly. */
+  collectionItemFolders(collectionId: string): Promise<Record<string, string>>
 }
 
 export interface IntegrationStore {
@@ -1640,12 +1644,14 @@ export interface NewCollection {
   workspace_access?: WorkspaceAccess
 }
 
-/** A workspace-shared organizing folder for collections (owner-editable). Grouping
- *  only — it grants no access and never appears in any auth path; a collection points
- *  at one via CollectionRecord.folder_id. */
+/** A folder that organizes ONE collection's artifacts (Collection → Folder → artifacts).
+ *  It inherits the collection's access and grants nothing of its own — never in any auth
+ *  path. Items are filed via collection_item.folder_id. `collection_id` is app-required
+ *  (nullable at the DB only for an additive migration). */
 export interface FolderRecord {
   id: string
   org_id: string
+  collection_id: string | null
   name: string
   created_by: string
   created_at: string
@@ -1653,6 +1659,7 @@ export interface FolderRecord {
 export interface NewFolder {
   id: string
   org_id: string
+  collection_id: string
   name: string
   created_by: string
 }

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -360,6 +360,9 @@ export const collection = pgTable("collection", {
 export const folder = pgTable("folder", {
   id: text("id").primaryKey(),
   org_id: text("org_id").notNull().default("local"),
+  // The collection this folder organizes (see schema.ts). App-required, nullable at DB,
+  // FK-free.
+  collection_id: text("collection_id"),
   name: text("name").notNull(),
   created_by: text("created_by").notNull(),
   created_at: text("created_at").notNull().$defaultFn(isoNow),
@@ -374,6 +377,8 @@ export const collectionItem = pgTable(
     artifact_id: text("artifact_id")
       .notNull()
       .references(() => artifact.id),
+    // Folder within this collection (see schema.ts); null = unfiled. FK-free.
+    folder_id: text("folder_id"),
     created_at: text("created_at").notNull().$defaultFn(isoNow),
   },
   (t) => [uniqueIndex("collection_item_uniq").on(t.collection_id, t.artifact_id)],

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1382,6 +1382,7 @@ export class PgMetaStore implements MetaStore {
     await this.db.transaction(async (tx) => {
       await tx.delete(collectionItem).where(eq(collectionItem.collection_id, id))
       await tx.delete(collectionMember).where(eq(collectionMember.collection_id, id))
+      await tx.delete(folder).where(eq(folder.collection_id, id))
       await tx.delete(collection).where(eq(collection.id, id))
     })
   }
@@ -1397,14 +1398,13 @@ export class PgMetaStore implements MetaStore {
     const cmap = new Map(counts.map((r) => [r.id, Number(r.c)]))
     return rows.map((r) => ({ ...r, count: cmap.get(r.id) ?? 0 }))
   }
-  // ---- Folders (org grouping for collections) ----------------------------
+  // ---- Folders (organize a collection's artifacts) -----------------------
   async createFolder(f: NewFolder): Promise<FolderRecord> {
     const rows = await this.db.insert(folder).values(f).returning()
     return one(rows)
   }
-  async listFolders(orgId?: string): Promise<FolderRecord[]> {
-    const base = this.db.select().from(folder)
-    return orgId ? base.where(eq(folder.org_id, orgId)) : base
+  async listFolders(collectionId: string): Promise<FolderRecord[]> {
+    return this.db.select().from(folder).where(eq(folder.collection_id, collectionId))
   }
   async getFolder(id: string): Promise<FolderRecord | null> {
     const rows = await this.db.select().from(folder).where(eq(folder.id, id))
@@ -1421,15 +1421,39 @@ export class PgMetaStore implements MetaStore {
   }
   async deleteFolder(id: string): Promise<void> {
     await this.db.transaction(async (tx) => {
-      await tx.update(collection).set({ folder_id: null }).where(eq(collection.folder_id, id))
+      await tx
+        .update(collectionItem)
+        .set({ folder_id: null })
+        .where(eq(collectionItem.folder_id, id))
       await tx.delete(folder).where(eq(folder.id, id))
     })
   }
-  async setCollectionFolder(collectionId: string, folderId: string | null): Promise<void> {
+  async setItemFolder(
+    collectionId: string,
+    artifactId: string,
+    folderId: string | null,
+  ): Promise<void> {
     await this.db
-      .update(collection)
+      .update(collectionItem)
       .set({ folder_id: folderId })
-      .where(eq(collection.id, collectionId))
+      .where(
+        and(
+          eq(collectionItem.collection_id, collectionId),
+          eq(collectionItem.artifact_id, artifactId),
+        ),
+      )
+  }
+  async collectionItemFolders(collectionId: string): Promise<Record<string, string>> {
+    const rows = await this.db
+      .select({ s: artifact.short_id, f: collectionItem.folder_id })
+      .from(collectionItem)
+      .innerJoin(artifact, eq(artifact.id, collectionItem.artifact_id))
+      .where(
+        and(eq(collectionItem.collection_id, collectionId), isNotNull(collectionItem.folder_id)),
+      )
+    const map: Record<string, string> = {}
+    for (const r of rows) if (r.f) map[r.s] = r.f
+    return map
   }
 
   async collectionArtifactIds(collectionId: string): Promise<string[]> {

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -1555,6 +1555,7 @@ export function makeRepos(db: SqliteDb) {
   const deleteCollection = async (id: string): Promise<void> => {
     await db.delete(collectionItem).where(eq(collectionItem.collection_id, id)).run()
     await db.delete(collectionMember).where(eq(collectionMember.collection_id, id)).run()
+    await db.delete(folder).where(eq(folder.collection_id, id)).run()
     await db.delete(collection).where(eq(collection.id, id)).run()
   }
   const listCollections = async (
@@ -1572,13 +1573,11 @@ export function makeRepos(db: SqliteDb) {
     const cmap = new Map(counts.map((r) => [r.id, Number(r.c)]))
     return rows.map((r) => ({ ...r, count: cmap.get(r.id) ?? 0 }))
   }
-  // ---- Folders (org grouping for collections) ----------------------------
+  // ---- Folders (organize a collection's artifacts) -----------------------
   const createFolder = async (f: NewFolder): Promise<FolderRecord> =>
     (await db.insert(folder).values(f).returning().get()) as FolderRecord
-  const listFolders = async (orgId?: string): Promise<FolderRecord[]> => {
-    const base = db.select().from(folder)
-    return (orgId ? base.where(eq(folder.org_id, orgId)) : base).all()
-  }
+  const listFolders = async (collectionId: string): Promise<FolderRecord[]> =>
+    db.select().from(folder).where(eq(folder.collection_id, collectionId)).all()
   const getFolder = async (id: string): Promise<FolderRecord | null> =>
     (await db.select().from(folder).where(eq(folder.id, id)).get()) ?? null
   const updateFolder = async (
@@ -1595,21 +1594,44 @@ export function makeRepos(db: SqliteDb) {
         .get()) ?? null
     )
   }
-  // Un-file the folder's collections (they survive), then drop the folder. Sequential
-  // (D1-safe), like deleteCollection.
+  // Un-file this folder's items (they stay in the collection), then drop the folder.
+  // Sequential (D1-safe), like deleteCollection.
   const deleteFolder = async (id: string): Promise<void> => {
-    await db.update(collection).set({ folder_id: null }).where(eq(collection.folder_id, id)).run()
+    await db
+      .update(collectionItem)
+      .set({ folder_id: null })
+      .where(eq(collectionItem.folder_id, id))
+      .run()
     await db.delete(folder).where(eq(folder.id, id)).run()
   }
-  const setCollectionFolder = async (
+  const setItemFolder = async (
     collectionId: string,
+    artifactId: string,
     folderId: string | null,
   ): Promise<void> => {
     await db
-      .update(collection)
+      .update(collectionItem)
       .set({ folder_id: folderId })
-      .where(eq(collection.id, collectionId))
+      .where(
+        and(
+          eq(collectionItem.collection_id, collectionId),
+          eq(collectionItem.artifact_id, artifactId),
+        ),
+      )
       .run()
+  }
+  const collectionItemFolders = async (collectionId: string): Promise<Record<string, string>> => {
+    const rows = await db
+      .select({ s: artifact.short_id, f: collectionItem.folder_id })
+      .from(collectionItem)
+      .innerJoin(artifact, eq(artifact.id, collectionItem.artifact_id))
+      .where(
+        and(eq(collectionItem.collection_id, collectionId), isNotNull(collectionItem.folder_id)),
+      )
+      .all()
+    const map: Record<string, string> = {}
+    for (const r of rows) if (r.f) map[r.s] = r.f
+    return map
   }
 
   const collectionArtifactIds = async (collectionId: string): Promise<string[]> =>
@@ -2845,7 +2867,8 @@ export function makeRepos(db: SqliteDb) {
     getFolder,
     updateFolder,
     deleteFolder,
-    setCollectionFolder,
+    setItemFolder,
+    collectionItemFolders,
     collectionArtifactIds,
     collectionIdsForArtifact,
     addCollectionItem,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -420,6 +420,11 @@ export const collection = sqliteTable("collection", {
 export const folder = sqliteTable("folder", {
   id: text("id").primaryKey(),
   org_id: text("org_id").notNull().default("local"),
+  // The collection this folder organizes (a folder lives INSIDE a collection and groups
+  // its artifacts). App-required; nullable at the DB only so the ADD COLUMN migration
+  // stays additive. FK-free — folders grant no access; the API enforces that a filed
+  // item's folder belongs to the item's collection.
+  collection_id: text("collection_id"),
   name: text("name").notNull(),
   created_by: text("created_by").notNull(),
   created_at: text("created_at").notNull().default(now),
@@ -435,6 +440,10 @@ export const collectionItem = sqliteTable(
     artifact_id: text("artifact_id")
       .notNull()
       .references(() => artifact.id),
+    // Which folder (within THIS collection) the artifact is filed under; null = unfiled.
+    // Folder membership refines collection membership, so it rides the membership row.
+    // FK-free (see folder.collection_id).
+    folder_id: text("folder_id"),
     created_at: text("created_at").notNull().default(now),
   },
   (t) => [uniqueIndex("collection_item_uniq").on(t.collection_id, t.artifact_id)],


### PR DESCRIPTION
## Folders inside a collection

The rebuild after #476 undid the backwards model. Folders now live **inside** a collection and organize its artifacts — **Collection → Folder → artifacts** — instead of folders containing collections.

A folder belongs to one collection and **grants no access of its own** — it never appears in an auth path (it inherits the collection's access, full stop). An item's folder is **per-membership** (`collection_item.folder_id`), so the same artifact can sit in *different* folders in *different* collections — the same way it can already belong to multiple collections. One level, alphabetical.

### Backend
- **Schema (additive):** `folder.collection_id` + `collection_item.folder_id`, both nullable and FK-free (app-required, DB-lax — matches the boot-DDL / additive-only model). D1 snapshot + the pg twin kept in step; parity guards pass.
- **CollectionStore:** folder CRUD is collection-scoped; `setItemFolder` / `collectionItemFolders` (assignment map keyed by artifact **short_id**). `deleteFolder` unfiles its items (they stay in the collection); `deleteCollection` cascades its folders.
- **`routes/folders`:** reading the structure needs **any** role on the collection; create / rename / delete / file need the collection's **editor** role. Filing rejects a folder from another collection (404) and an artifact that isn't in the collection (404 — not a silent no-op).

### Web
- **`CollectionFolders`** — the grouped view: folders (name order), then an *Unfiled* bucket, each collapsible. Editors get **New folder** + a per-folder rename / delete menu.
- **Cards / Folders toggle** (defaults to Folders when folders exist) so thumbnails are always one click away — the grouping never traps you in rows. The folder view **auto-loads the whole collection** (the same load-all the synced repo/PR view uses) so buckets and counts reflect every item, not just the first page.
- **Multi-select "Move to folder"** in the selection bar → a folder or *Unfiled*, via `Promise.allSettled` with a moved / couldn't-move summary (never all-or-nothing).

### Tests / gates
- 8 API tests (create/list order, file/unfile, per-membership across collections, cross-collection 404, non-member 404, delete-unfiles, blank-name 400, editor gating).
- Full sweep green: web typecheck, biome, tokens / frontend / surfaces / testids / schema / api-types / deadcode / mutations / boundaries, web unit (170), db (208), web build. OpenAPI + api-types regenerated.

### Verification note
The grouped folder view was live-driven (screenshots) in the phase-3 session; this PR refines that path. The new >30-item auto-load is a faithful reuse of the synced-collection load-all that already ships in production. There is a pre-existing, unrelated failure in `oauth-refresh-rotation.test.ts` (time-window sensitive) that fails on `main` without these changes.
