### PR TITLE
Fix the broken front door: worker-first / was shadowed; marketing always on; nav Log in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,11 +125,6 @@ DATA_DIR=./data
 # The CNAME target customers point their custom domain at.
 # CF_SAAS_FALLBACK_ORIGIN=derive-saas.example.com
 
-# Serve the marketing site (the web build's site/ pages) at `/` for signed-out visitors
-# and at `/pricing` — the hosted front door (derive.to). Unset/false (the self-host
-# default), the app owns `/` and both paths fall back to the SPA as before.
-# DERIVE_MARKETING=true
-
 # --- Email (verification, password reset, invites) ------------------------
 
 # Transactional email via Resend (over fetch, no SDK). BOTH RESEND_API_KEY and EMAIL_FROM

--- a/apps/api/src/config-manifest.ts
+++ b/apps/api/src/config-manifest.ts
@@ -222,12 +222,6 @@ const CONFIG_VARS: ConfigVar[] = [
     doc: "The CNAME target customers point their custom domain at.",
     example: "derive-saas.example.com",
   },
-  {
-    name: "DERIVE_MARKETING",
-    group: "hosting",
-    doc: "Serve the marketing site (the web build's site/ pages) at `/` for signed-out visitors\nand at `/pricing` — the hosted front door (derive.to). Unset/false (the self-host\ndefault), the app owns `/` and both paths fall back to the SPA as before.",
-    example: "true",
-  },
 
   // -- email --
   {

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -66,10 +66,6 @@ export interface Config {
   webDir: string
   webShell: string
   serveWeb: boolean
-  /** Serve the marketing site (the web build's site/ pages) at `/` for signed-out
-   *  visitors and at `/pricing`. The hosted-tier front door; self-host default is
-   *  off, so the app keeps owning `/`. */
-  marketing: boolean
   /** Opt-in Node/Playwright preview rendering. When true, startPreviewWorker is
    *  started in node.ts and render jobs are enqueued on publish. Requires a
    *  locally-installed Playwright Chromium (bundled in the Docker image; bare Node
@@ -199,7 +195,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     webDir,
     webShell,
     serveWeb: existsSync(webShell),
-    marketing: env.DERIVE_MARKETING === "true",
   }
 }
 

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -209,12 +209,12 @@ export interface AppDeps {
   /** Wake the preview worker after enqueuing (Workers: poke the PreviewRenderer DO). */
   pokePreviews?: () => void
   /**
-   * The marketing site (the hosted front door, DERIVE_MARKETING). When set, `/`
-   * serves the marketing page to signed-out visitors (signed-in ones keep the SPA)
-   * and `/pricing` serves the pricing page. Each provider returns the page HTML —
-   * read from the web build's `site/` directory on Node, fetched from the ASSETS
-   * binding on the edge — or null when the page is missing (falls back to the
-   * shell). Unset (the default; self-host, tests) ⇒ the SPA owns `/` as before.
+   * The marketing site (the front door). When set, `/` serves the marketing page
+   * to signed-out visitors (signed-in ones keep the SPA) and `/pricing` serves the
+   * pricing page. Each provider returns the page HTML — read from the web build's
+   * `site/` directory on Node, fetched from the ASSETS binding on the edge — or
+   * null when the page is missing (falls back to the shell). Set whenever the web
+   * build ships the pages; unset (a page-less build, tests) ⇒ the SPA owns `/`.
    */
   marketing?: {
     home: () => Promise<string | null>

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -267,9 +267,10 @@ const blobs: BlobStore = cfg.objectStoreUrl
 // meta) and to mountWeb (the client-router fallback). Only when serving the web.
 const shellHtml = cfg.serveWeb ? readFileSync(cfg.webShell, "utf8") : undefined
 
-// The marketing pages (DERIVE_MARKETING), read once from the web build's site/
-// directory like the shell above. A missing page resolves null and the routes fall
-// back to the shell, so a stale build can't 404 the front door.
+// The marketing pages, read once from the web build's site/ directory like the
+// shell above. Always on when the web build ships the pages — a build without
+// them (or a missing page) resolves null and the routes fall back to the shell,
+// so the front door can never 404.
 const readSitePage = (name: string): string | null => {
   try {
     return readFileSync(join(cfg.webDir, "site", name), "utf8")
@@ -277,10 +278,10 @@ const readSitePage = (name: string): string | null => {
     return null
   }
 }
-const marketingHome = cfg.marketing && cfg.serveWeb ? readSitePage("index.html") : null
-const marketingPricing = cfg.marketing && cfg.serveWeb ? readSitePage("pricing.html") : null
+const marketingHome = cfg.serveWeb ? readSitePage("index.html") : null
+const marketingPricing = cfg.serveWeb ? readSitePage("pricing.html") : null
 const marketing =
-  cfg.marketing && cfg.serveWeb
+  marketingHome || marketingPricing
     ? { home: async () => marketingHome, pricing: async () => marketingPricing }
     : undefined
 
@@ -346,7 +347,7 @@ const app = createApp({
   baseUrl: cfg.baseUrl,
   shell: shellHtml,
   // The marketing front door (`/` for signed-out visitors + `/pricing`); unset
-  // (the self-host default) leaves the SPA owning both paths.
+  // only when the web build ships no site/ pages, leaving the SPA both paths.
   marketing,
   token: cfg.token,
   // Encrypt stored third-party secrets (GitHub PATs) at rest with the auth secret.

--- a/apps/api/src/routes/marketing.ts
+++ b/apps/api/src/routes/marketing.ts
@@ -12,8 +12,8 @@ import type { AppContext } from "../context"
  *                  so the app keeps owning `/` for its users.
  *   GET /pricing   the pricing page, for everyone.
  *
- * Mounted only when deps.marketing is configured (DERIVE_MARKETING): self-host and
- * dev keep today's behavior, where the SPA fallback owns both paths. The session
+ * Always on when the web build ships the pages (deps.marketing); a build without
+ * them keeps today's behavior, where the SPA fallback owns both paths. The session
  * check is presence-only — no DB hit on a landing view; a stale cookie serves the
  * shell and the SPA's own guard bounces to /login, exactly as it does today.
  */

--- a/apps/api/src/routes/marketing.ts
+++ b/apps/api/src/routes/marketing.ts
@@ -20,13 +20,24 @@ import type { AppContext } from "../context"
 export const marketingRoutes = (ctx: AppContext) => {
   const app = new Hono()
   const m = ctx.deps.marketing
-  if (!m) return app
 
   const getShell = async (): Promise<string | null> =>
     ctx.deps.shell ?? (ctx.deps.shellFetch ? await ctx.deps.shellFetch() : null)
   const shellOr404 = async (c: Context) => {
     const shell = await getShell()
     return shell ? c.html(shell) : c.notFound()
+  }
+
+  if (!m) {
+    // Marketing off, but wrangler.toml's run_worker_first is static config: on the
+    // edge these paths still reach the Worker, and nothing else serves them (there is
+    // no catch-all asset fallback). Hand back the SPA shell so `/` never 404s. On the
+    // Node tier (serveWeb) the in-process static middleware owns them — mount nothing.
+    if (!ctx.deps.serveWeb && (ctx.deps.shell || ctx.deps.shellFetch)) {
+      app.get("/", shellOr404)
+      app.get("/pricing", shellOr404)
+    }
+    return app
   }
   // Better Auth's session cookie, both spellings (useSecureCookies adds the
   // __Secure- prefix on https origins). Presence only — never validated here.

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -102,9 +102,11 @@ export const systemRoutes = (ctx: AppContext) => {
     return c.json(result)
   })
 
-  // A minimal API-origin landing. Skipped when the SPA is bundled in-process
-  // (serveWeb) so the app's own home page owns `/`.
-  if (!deps.serveWeb)
+  // A minimal API-origin landing, ONLY for deployments with no SPA at all. Skipped
+  // when the SPA is bundled in-process (serveWeb, the Node tier) AND when a shell
+  // provider exists (the edge Worker, where `/` is routed worker-first and
+  // routes/marketing.ts owns it — this placeholder would shadow the real home page).
+  if (!deps.serveWeb && !deps.shell && !deps.shellFetch)
     app.get("/", (c) =>
       c.html(
         `<!doctype html><meta charset="utf-8"><title>Derive</title>

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -110,9 +110,6 @@ export interface Env {
   // meta into /artifacts/:ref (the share URL). Declared in wrangler.toml `[assets] binding`.
   ASSETS: Fetcher
   BASE_URL?: string
-  // "true" ⇒ serve the marketing site: `/` for signed-out visitors + `/pricing`,
-  // read from the web build's site/ pages via ASSETS (see routes/marketing.ts).
-  DERIVE_MARKETING?: string
   DERIVE_AUTH_SECRET?: string
   DERIVE_TOKEN?: string
   DERIVE_SANDBOX_URL?: string
@@ -308,18 +305,16 @@ const handle = (req: Request, env: Env, ctx: ExecutionContext): Response | Promi
           }
           return shellCache
         },
-        // The marketing front door (DERIVE_MARKETING): `/` for signed-out visitors +
+        // The marketing front door, always on: `/` for signed-out visitors +
         // `/pricing`, from the web build's site/ pages. Fetched at the CANONICAL asset
         // URLs — html_handling serves site/index.html at /site/ and site/pricing.html
         // at /site/pricing, and redirects the literal filenames, which ASSETS.fetch
-        // would surface as a non-2xx.
-        marketing:
-          env.DERIVE_MARKETING === "true"
-            ? {
-                home: siteFetch(env, baseUrl, "/site/"),
-                pricing: siteFetch(env, baseUrl, "/site/pricing"),
-              }
-            : undefined,
+        // would surface as a non-2xx. A build without the pages resolves null and
+        // the routes fall back to the SPA shell.
+        marketing: {
+          home: siteFetch(env, baseUrl, "/site/"),
+          pricing: siteFetch(env, baseUrl, "/site/pricing"),
+        },
       })
     }
     // Run within the per-request context so the DO backplane's publish can waitUntil.

--- a/apps/api/test/marketing.test.ts
+++ b/apps/api/test/marketing.test.ts
@@ -1,0 +1,105 @@
+import { join } from "node:path"
+import { FsBlobStore } from "@derive/storage/fs"
+import { describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { dir, meta } from "./helpers"
+
+const SHELL =
+  "<!doctype html><html><head><title>Derive</title></head><body><div id=root></div></body></html>"
+const HOME = "<!doctype html><html><body>MARKETING HOME</body></html>"
+const PRICING = "<!doctype html><html><body>MARKETING PRICING</body></html>"
+
+// Worker-shaped deps: no serveWeb (assets come from the platform binding), the shell
+// arrives via the async provider. `/` and `/pricing` are routed worker-first there
+// (wrangler.toml run_worker_first), so the app itself MUST answer them.
+const workerApp = (marketing?: {
+  home: () => Promise<string | null>
+  pricing: () => Promise<string | null>
+}) =>
+  createApp({
+    meta,
+    blobs: new FsBlobStore(join(dir, "blobs-marketing")),
+    baseUrl: "http://derive.test",
+    token: "tok",
+    shellFetch: async () => SHELL,
+    marketing,
+  })
+
+const MARKETING = { home: async () => HOME, pricing: async () => PRICING }
+
+describe("marketing front door (worker-first `/` and `/pricing`)", () => {
+  it("serves the marketing page to anonymous visitors, never shared-cacheable", async () => {
+    const a = workerApp(MARKETING)
+    const res = await a.request("/")
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain("MARKETING HOME")
+    expect(res.headers.get("cache-control")).toContain("private")
+  })
+
+  it("serves the SPA shell to visitors with a session cookie", async () => {
+    const a = workerApp(MARKETING)
+    for (const name of ["better-auth.session_token", "__Secure-better-auth.session_token"]) {
+      const res = await a.request("/", { headers: { cookie: `${name}=abc` } })
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain("id=root")
+    }
+  })
+
+  it("serves the SPA shell on the app.* alias host", async () => {
+    const a = workerApp(MARKETING)
+    const res = await a.request("/", { headers: { host: "app.derive.test" } })
+    expect(await res.text()).toContain("id=root")
+  })
+
+  it("serves the pricing page to everyone, shared-cacheable", async () => {
+    const a = workerApp(MARKETING)
+    const res = await a.request("/pricing", {
+      headers: { cookie: "better-auth.session_token=abc" },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain("MARKETING PRICING")
+    expect(res.headers.get("cache-control")).toContain("public")
+  })
+
+  it("never serves the API-origin placeholder when a shell exists (the launch-day bug)", async () => {
+    // Regression: system.ts's placeholder `/` used to register whenever serveWeb was
+    // off — which is the Worker's shape — and, mounted first, shadowed both the
+    // marketing page and the signed-in shell once `/` went worker-first.
+    const a = workerApp(MARKETING)
+    for (const headers of [{}, { cookie: "better-auth.session_token=abc" }] as Record<
+      string,
+      string
+    >[]) {
+      const html = await (await a.request("/", { headers })).text()
+      expect(html).not.toContain("An open home for AI-generated artifacts")
+    }
+  })
+
+  it("falls back to the SPA shell when marketing is off (worker-first paths must not 404)", async () => {
+    const a = workerApp(undefined)
+    for (const path of ["/", "/pricing"]) {
+      const res = await a.request(path)
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain("id=root")
+    }
+  })
+
+  it("keeps the API-origin placeholder for deployments with no SPA at all", async () => {
+    const a = createApp({
+      meta,
+      blobs: new FsBlobStore(join(dir, "blobs-marketing-bare")),
+      baseUrl: "http://derive.test",
+      token: "tok",
+    })
+    const res = await a.request("/")
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain("An open home for AI-generated artifacts")
+  })
+
+  it("falls back to the shell when a marketing page is missing from the build", async () => {
+    const a = workerApp({ home: async () => null, pricing: async () => null })
+    const res = await a.request("/")
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain("id=root")
+  })
+})

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -221,8 +221,3 @@ custom_domain = true
 # extracts the bare address; the display-name form is kept for parity with the Resend (Node)
 # transport, which reads the same EMAIL_FROM. Pairs with the [[send_email]] binding above.
 EMAIL_FROM = "Derive <notifications@send.derive.to>"
-# The marketing front door: `/` serves the marketing page to signed-out visitors
-# (signed-in ones keep the SPA; app.derive.to always does) and `/pricing` serves
-# pricing. The pages ship inside the web build at site/ (apps/web/public/site).
-# Requires "/" + "/pricing" in run_worker_first above (serve-web.test asserts it).
-DERIVE_MARKETING = "true"

--- a/apps/web/public/site/index.html
+++ b/apps/web/public/site/index.html
@@ -581,6 +581,7 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
     <div class="nav-right">
       <a href="/pricing">Pricing</a>
       <a href="https://github.com/derive-to/derive">GitHub</a>
+      <a href="/login">Log in</a>
       <a class="btn btn-primary" href="#join">Get beta access</a>
     </div>
   </div>
@@ -605,11 +606,11 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
         </div>
         <div class="wl-presence" id="wlPresence" aria-hidden="true">
           <span class="pd you"></span>you
-          <span class="pd rob"></span>Rob
+          <span class="pd rob"></span>Maeva
           <span>· here now</span>
         </div>
         <div class="wl-story">
-          <span class="chip" aria-hidden="true">R</span>
+          <span class="chip" aria-hidden="true">M</span>
           <span class="q">"Add a beta signup right here?"</span>
           <span class="res" id="wlRes"><span class="vdot2" aria-hidden="true"></span><span id="wlResText">RESOLVED IN V12</span></span>
         </div>
@@ -634,7 +635,7 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
           </span>
           <span class="spacer"></span>
           <span class="face" aria-label="Who's here">
-            <span class="fc g">R</span><span class="fc v">P</span><span class="fc n">C</span><span class="fc y" id="youChip">Y</span>
+            <span class="fc g">M</span><span class="fc v">A</span><span class="fc n">C</span><span class="fc y" id="youChip">Y</span>
           </span>
           <span class="face-label" id="faceLabel">3 here</span>
           <span class="abadge" id="approvedBadge">
@@ -699,22 +700,22 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
             <div class="pane-label">Comments</div>
             <div class="comments-empty" id="cEmpty">No comments yet.</div>
             <div class="dcomment" id="cm1">
-              <div class="mini" aria-hidden="true"><span class="tk">✓</span>Rob · <span class="mq">"PRODUCT IMAGE"</span> · v2</div>
-              <div class="who"><span class="chip rob">R</span>Rob</div>
+              <div class="mini" aria-hidden="true"><span class="tk">✓</span>Maeva · <span class="mq">"PRODUCT IMAGE"</span> · v2</div>
+              <div class="who"><span class="chip rob">M</span>Maeva</div>
               <div class="quote">"PRODUCT IMAGE"</div>
               <div class="text">No glamour shot exists yet, so draw it: a patent filing, dimension lines, real materials.</div>
               <div class="state" id="cm1s">OPEN</div>
             </div>
             <div class="dcomment" id="cm2">
-              <div class="mini" aria-hidden="true"><span class="tk">✓</span>Rob · <span class="mq">"OSC-8 Synthesizer"</span> · v2</div>
-              <div class="who"><span class="chip rob">R</span>Rob</div>
+              <div class="mini" aria-hidden="true"><span class="tk">✓</span>Maeva · <span class="mq">"OSC-8 Synthesizer"</span> · v2</div>
+              <div class="who"><span class="chip rob">M</span>Maeva</div>
               <div class="quote">"OSC-8 Synthesizer"</div>
               <div class="text">This headline could sell any store template. It's a synth. Make the type the loudest thing on the page.</div>
               <div class="state" id="cm2s">OPEN</div>
             </div>
             <div class="dcomment" id="cm3">
-              <div class="mini" aria-hidden="true"><span class="tk">✓</span>Priya · <span class="mq">"€249"</span> · v3 · 1 reply</div>
-              <div class="who"><span class="chip ada">P</span>Priya<span class="ext">CLIENT</span></div>
+              <div class="mini" aria-hidden="true"><span class="tk">✓</span>Anya · <span class="mq">"€249"</span> · v3 · 1 reply</div>
+              <div class="who"><span class="chip ada">A</span>Anya<span class="ext">CLIENT</span></div>
               <div class="quote">"€249"</div>
               <div class="text">€249 with no context reads expensive. Anchor it with facts, not adjectives.</div>
               <div class="reply" id="cm3r">
@@ -729,13 +730,13 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
             <svg width="17" height="19" viewBox="0 0 17 19" fill="none">
               <path class="arrow" d="M1 1l5.2 15.6 2.6-6.2 6.6-1.8L1 1Z" stroke="rgba(3,7,18,.5)" stroke-width="1"/>
             </svg>
-            <span class="flag">Rob</span>
+            <span class="flag">Maeva</span>
           </div>
           <div class="pcursor ada" id="curAda" aria-hidden="true">
             <svg width="17" height="19" viewBox="0 0 17 19" fill="none">
               <path class="arrow" d="M1 1l5.2 15.6 2.6-6.2 6.6-1.8L1 1Z" stroke="rgba(3,7,18,.5)" stroke-width="1"/>
             </svg>
-            <span class="flag">Priya</span>
+            <span class="flag">Anya</span>
           </div>
           <div class="pcursor you" id="curYou" aria-hidden="true">
             <svg width="17" height="19" viewBox="0 0 17 19" fill="none">
@@ -912,7 +913,7 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
             <div class="t-text">Which nine teams? Name them or nobody plans around it.</div>
           </div>
           <div class="t-item">
-            <div class="t-who"><span class="chip">R</span>Rob</div>
+            <div class="t-who"><span class="chip">M</span>Maeva</div>
             <div class="t-text">Seconding. Owners too, @claude-code.</div>
           </div>
           <div class="t-item">
@@ -1098,13 +1099,13 @@ function editPlay(){
   at(150,  () => w1.classList.add('on'));
   at(900,  () => {
     w1.classList.add('struck');
-    note.textContent = 'v2 · "good takes more than one pass." — Rob';
+    note.textContent = 'v2 · "good takes more than one pass." — Maeva';
   });
   at(1080, () => w2.classList.add('on'));
   at(1650, () => {
     w1.classList.add('settle');
     w2.classList.add('struck');
-    note.textContent = 'v3 · "a prompt isn\'t craft." — Rob';
+    note.textContent = 'v3 · "a prompt isn\'t craft." — Maeva';
   });
   at(1830, () => w3.classList.add('on'));
   at(2350, () => {
@@ -1428,14 +1429,14 @@ function sceneFinal(){
   resolved('cm3','cm3s','RESOLVED IN V3');
   $('cm1').classList.add('collapsed'); $('cm2').classList.add('collapsed');
   $('approvedBadge').classList.add('show');
-  setLine('v3','Priya · approval','approved · preorders open Monday');
+  setLine('v3','Anya · approval','approved · preorders open Monday');
   sceneDone = true;
 }
 
 function scenePlay(){
   clearScene();
   sceneReset();
-  /* Rob arrives, highlights, comments twice */
+  /* Maeva arrives, highlights, comments twice */
   s(700,  () => { cursorShow(curRob, true); cursorTo(curRob, 't1'); });
   s(1700, () => { lit('t1'); });
   s(2250, () => { $('cEmpty').style.display='none'; thread('cm1', true); });
@@ -1465,7 +1466,7 @@ function scenePlay(){
   /* approval */
   s(11900,() => {
     $('approvedBadge').classList.add('show');
-    setLine('v3','Priya · approval','approved · preorders open Monday');
+    setLine('v3','Anya · approval','approved · preorders open Monday');
     cursorShow(curAda, false);
     glSnap();
     sceneDone = true;
@@ -1523,11 +1524,11 @@ const LINES = [
   ['p','› publish "August growth report"'],
   ['dim','→ derive.to/artifacts/august-growth-report · v1 live'],
   ['p','› catch_up'],
-  ['dim','← 1 comment · Rob on "+18% MoM": "the pricing change'],
+  ['dim','← 1 comment · Maeva on "+18% MoM": "the pricing change'],
   ['dim','  spiked signups for a week. Annotate it or the number lies."'],
   ['p','› publish --addresses c_41x'],
   ['ok','✓ v2 live · spike annotated · thread resolved'],
-  ['ok','✓ v3 approved by Rob · shipped'],
+  ['ok','✓ v3 approved by Maeva · shipped'],
 ];
 const termBody = $('termBody'), cursor = $('termCursor');
 let termStarted = false;

--- a/apps/web/public/site/pricing.html
+++ b/apps/web/public/site/pricing.html
@@ -77,7 +77,9 @@ nav.scrolled{border-bottom-color:var(--border-soft)}
 .nav-links{display:flex;gap:22px;font-size:14px;color:var(--muted-fg);margin-left:8px}
 .nav-links a:hover{color:var(--fg)}
 .nav-links a.on{color:var(--fg)}
-.nav-cta{margin-left:auto}
+.nav-cta{margin-left:auto;display:flex;align-items:center;gap:22px}
+.nav-cta .nav-login{font-size:14px;color:var(--muted-fg)}
+.nav-cta .nav-login:hover{color:var(--fg)}
 .nav-cta .btn{height:32px;padding:0 14px;border-radius:6px;font-size:13px}
 @media(max-width:720px){.nav-links{display:none}}
 
@@ -170,6 +172,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
       <a href="https://github.com/derive-to/derive">GitHub</a>
     </div>
     <div class="nav-cta">
+      <a class="nav-login" href="/login">Log in</a>
       <a class="btn btn-primary" href="#join">Get beta access</a>
     </div>
   </div>


### PR DESCRIPTION
## What broke on deploy

Merging #480 sent `/` and `/pricing` to the Worker (`run_worker_first`), where `system.ts`'s minimal API-origin landing ("An open home for AI-generated artifacts") matched first — it registers whenever in-process web serving is off, which is exactly the Worker's shape, and it was dead code until `/` became worker-first. Everyone got the placeholder: anonymous visitors never saw the marketing page, and signed-in users bounced from /login straight back into it.

## Fixes

- The placeholder now registers only when there is **no SPA at all** (no `serveWeb`, no shell provider) — API-only origins keep it.
- With no marketing pages in the build, the marketing routes hand worker-first paths the SPA shell instead of falling through to a 404 (`run_worker_first` is static config; the Worker has no asset fallback).
- Adds the marketing route tests this shipped without, including a regression test pinning the exact failure (worker-shaped deps, `/` must never serve the placeholder).

## Also in here (Rob's follow-ups)

- **Marketing is always on** — `DERIVE_MARKETING` is gone from config/manifest/wrangler/.env.example. The front door serves whenever the web build ships `site/` pages; a page-less build behaves exactly as before.
- **Log in** in the top nav on both pages (existing users keep a first-class door; signed-in visitors never see the brochure anyway).

Verified: 1096 API tests (8 new), typecheck both tsconfigs, local boot with no env var serves marketing at `/` + shell with a session cookie.