### PR TITLE
Real wordmark in the nav; Sign in to Beta text button

### DIFF
--- a/apps/api/src/lib/serve-web.ts
+++ b/apps/api/src/lib/serve-web.ts
@@ -98,6 +98,11 @@ export const mountWeb = (app: Hono, { webRoot, shellHtml }: ServeWebOpts): void 
   )
   // Root-level static files Vite emits (favicon, manifest, …).
   app.get("/:file{[^/]+\\.[^/]+}", serveStatic({ root: webRoot }))
+  // Nested public/ directories the marketing pages reference (/site fonts + og
+  // image, /brand wordmark). Without these the shell fallback swallows them —
+  // the Worker's Static Assets serve them natively, so only Node needs the routes.
+  app.get("/site/*", serveStatic({ root: webRoot }))
+  app.get("/brand/*", serveStatic({ root: webRoot }))
   app.notFound((c) =>
     isApiPath(c.req.path) ? c.json({ error: "not found" }, 404) : c.html(shellHtml),
   )

--- a/apps/web/public/site/index.html
+++ b/apps/web/public/site/index.html
@@ -86,12 +86,15 @@ nav{position:fixed;inset:0 0 auto;z-index:100;border-bottom:1px solid transparen
   -webkit-backdrop-filter:blur(14px);backdrop-filter:blur(14px)}
 nav.scrolled{border-bottom-color:var(--border-soft)}
 .nav-inner{max-width:var(--maxw);margin:0 auto;padding:0 28px;height:64px;display:flex;align-items:center;gap:26px}
-.wordmark{display:flex;align-items:center;gap:10px;font-size:18px;font-weight:500;letter-spacing:-0.02em}
+.wordmark{display:flex;align-items:center}
+.wordmark img{height:26px;width:auto;display:block}
 .nav-right{margin-left:auto;display:flex;align-items:center;gap:24px;font-size:14px}
 .nav-right a{color:var(--muted)}
 .nav-right a:hover{color:var(--fg)}
-.nav-right .btn{height:34px;padding:0 16px;font-size:13px;border-radius:6px;color:var(--primary-fg)}
-@media(max-width:480px){.nav-right a:not(.btn){display:none}}
+.nav-right .nav-signin{color:var(--fg)}
+.nav-right .nav-signin .arr{display:inline-block;transition:transform .18s ease}
+.nav-right .nav-signin:hover .arr{transform:translateX(3px)}
+@media(max-width:480px){.nav-right a:not(.nav-signin){display:none}}
 
 /* ══════════ HERO — the tagline, then the artifact ══════════ */
 .hero{position:relative;padding:150px 0 0}
@@ -572,17 +575,12 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
 <nav id="nav">
   <div class="nav-inner">
     <a class="wordmark" href="#">
-      <svg width="19" height="19" viewBox="0 0 18 18" fill="none" aria-hidden="true">
-        <path d="M3 15V3h5.2a6 6 0 0 1 0 12H3Z" stroke="currentColor" stroke-width="1.6"/>
-        <path d="M11.5 15 15 3" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
-      </svg>
-      Derive
+      <img src="/brand/wordmark-light.svg" alt="Derive">
     </a>
     <div class="nav-right">
       <a href="/pricing">Pricing</a>
       <a href="https://github.com/derive-to/derive">GitHub</a>
-      <a href="/login">Log in</a>
-      <a class="btn btn-primary" href="#join">Get beta access</a>
+      <a class="nav-signin" href="/login">Sign in to Beta <span class="arr">→</span></a>
     </div>
   </div>
 </nav>

--- a/apps/web/public/site/pricing.html
+++ b/apps/web/public/site/pricing.html
@@ -73,13 +73,15 @@ nav{
 }
 nav.scrolled{border-bottom-color:var(--border-soft)}
 .nav-inner{max-width:var(--maxw);margin:0 auto;padding:0 24px;height:60px;display:flex;align-items:center;gap:28px}
-.wordmark{display:flex;align-items:center;gap:9px;font-size:17px;font-weight:500;letter-spacing:-0.02em}
+.wordmark{display:flex;align-items:center}
+.wordmark img{height:24px;width:auto;display:block}
 .nav-links{display:flex;gap:22px;font-size:14px;color:var(--muted-fg);margin-left:8px}
 .nav-links a:hover{color:var(--fg)}
 .nav-links a.on{color:var(--fg)}
-.nav-cta{margin-left:auto;display:flex;align-items:center;gap:22px}
-.nav-cta .nav-login{font-size:14px;color:var(--muted-fg)}
-.nav-cta .nav-login:hover{color:var(--fg)}
+.nav-cta{margin-left:auto;display:flex;align-items:center}
+.nav-cta .nav-signin{font-size:14px;color:var(--fg)}
+.nav-cta .nav-signin .arr{display:inline-block;transition:transform .18s ease}
+.nav-cta .nav-signin:hover .arr{transform:translateX(3px)}
 .nav-cta .btn{height:32px;padding:0 14px;border-radius:6px;font-size:13px}
 @media(max-width:720px){.nav-links{display:none}}
 
@@ -161,19 +163,14 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
 <nav id="nav">
   <div class="nav-inner">
     <a class="wordmark" href="/">
-      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
-        <path d="M3 15V3h5.2a6 6 0 0 1 0 12H3Z" stroke="currentColor" stroke-width="1.6"/>
-        <path d="M11.5 15 15 3" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
-      </svg>
-      Derive
+      <img src="/brand/wordmark-light.svg" alt="Derive">
     </a>
     <div class="nav-links">
       <a class="on" href="/pricing">Pricing</a>
       <a href="https://github.com/derive-to/derive">GitHub</a>
     </div>
     <div class="nav-cta">
-      <a class="nav-login" href="/login">Log in</a>
-      <a class="btn btn-primary" href="#join">Get beta access</a>
+      <a class="nav-signin" href="/login">Sign in to Beta <span class="arr">→</span></a>
     </div>
   </div>
 </nav>


### PR DESCRIPTION
Two nav changes per Rob, plus a Node static-serving fix they surfaced.

- **The real logo**: the nav's hand-drawn placeholder glyph is now `/brand/wordmark-light.svg` (the actual brand wordmark — same asset the app ships; single #F4F5F8 fill matches the site's ink).
- **Sign in to Beta →**: the filled Get-beta-access nav button becomes a quiet text link to /login and replaces the separate Log in link. Hero and footer signup forms keep their submit buttons. On narrow screens the sign-in link survives the nav cull (previously the .btn did).
- **fix(serve-web)**: `mountWeb` only routed `/assets/*` and root-level files, so nested public dirs fell through to the SPA-shell fallback on the Node tier — the marketing pages' fonts, og.png, and now the wordmark were all silently broken on self-host. Added `/site/*` and `/brand/*` static routes (the Worker serves these natively via Static Assets; prod was unaffected).

Verified locally on the Node tier: wordmark renders, fonts/og serve with correct content-types, mobile nav keeps logo + sign-in. Typecheck green, marketing + serve-web tests pass.