### PR TITLE
Onboarding: activation-centered welcome, live connect detection, getting-started checklist

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3053,6 +3053,65 @@
         }
       }
     },
+    "/v1/me/onboarding": {
+      "get": {
+        "tags": [
+          "Session"
+        ],
+        "summary": "The signed-in user's activation signals (agent connected, first agent publish).",
+        "responses": {
+          "200": {
+            "description": "Whether an agent is connected and what it first published.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "agent_connected": {
+                      "type": "boolean",
+                      "description": "Whether an OAuth agent grant currently exists (revoking clears it)."
+                    },
+                    "agent_name": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Display name of the most recently authorized agent; null if none."
+                    },
+                    "published_via_agent": {
+                      "type": "boolean",
+                      "description": "Whether an agent has published an artifact for this user over MCP."
+                    },
+                    "first_artifact": {
+                      "type": "object",
+                      "nullable": true,
+                      "properties": {
+                        "short_id": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "short_id",
+                        "title"
+                      ],
+                      "description": "The first artifact an agent published for this user; null until then."
+                    }
+                  },
+                  "required": [
+                    "agent_connected",
+                    "agent_name",
+                    "published_via_agent",
+                    "first_artifact"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/users/search": {
       "get": {
         "tags": [

--- a/apps/api/src/lib/pr-preview.ts
+++ b/apps/api/src/lib/pr-preview.ts
@@ -132,6 +132,8 @@ export function makePrPreview({ meta, blobs, bus, baseUrl, launch }: PrPreviewDe
         author_login: v.author_login,
         author_avatar: v.author_avatar,
         author_gh_id: v.author_gh_id,
+        // Folding copies the version faithfully — keep its surface stamp too.
+        source: v.source,
         message: v.message ? `${prefix}: ${v.message}` : prefix,
         name: v.name,
       })

--- a/apps/api/src/lib/sync.ts
+++ b/apps/api/src/lib/sync.ts
@@ -460,6 +460,7 @@ export async function runSync(
         authorAvatar: gh?.avatar ?? null,
         authorGhId: gh?.ghId ?? null,
         message: `sync ${source.ref}@${sha.slice(0, 7)}`,
+        source: "sync" as const,
         orgId: source.org_id,
         // A mirrored repo is a workspace resource, not someone's draft: explicitly
         // listed in the workspace library (the publish default is unlisted, which

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -2054,6 +2054,7 @@ async function buildServer(
             // Attributed to the human the agent acts for — their profile, their
             // followers' feed (same as the HTTP publish route).
             authorId: actingFor?.id ?? null,
+            source: "mcp",
             // New artifacts land in the TARGETED workspace (the default unless a
             // `workspace` was named), never wider than asked (the workspace's
             // default access when unspecified).
@@ -2331,6 +2332,9 @@ async function buildServer(
             message: "Brand profile placeholder — your agent fills this in.",
             author: agent.name,
             authorId: uid,
+            // Deliberately UNstamped: this auto-scaffolded placeholder is not the
+            // user's "first agent publish" — stamping 'mcp' here would flip the
+            // onboarding signal (and the welcome celebration) on an empty stub.
             orgId: targetOrg,
             workspaceAccess: "member",
             linkRole: "none",

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -685,6 +685,10 @@ export const artifactRoutes = (ctx: AppContext) => {
             ? (tokenAuth.user.name ?? undefined)
             : (human?.name ?? actor?.name ?? str(body["author"])),
           authorId: onBehalf,
+          // The surface stamp: a stage_publish token IS the MCP flow's upload leg, an
+          // agent principal (OAuth bearer / dk_agt_ token, incl. the CLI) is the API,
+          // and a plain session publish is the web app.
+          source: tokenAuth ? "mcp" : agentPrincipal ? "api" : "web",
           name: str(body["name"]),
           orgId: org,
           workspaceAccess: resolvedWorkspaceAccess,
@@ -1552,6 +1556,8 @@ export const artifactRoutes = (ctx: AppContext) => {
         size_bytes: src.size_bytes,
         author: me ? (me.name ?? me.username ?? me.email) : "anonymous",
         author_id: me?.id ?? null,
+        // A restore is a web-surface action, whatever surface made the original.
+        source: "web",
         message: `Restored v${src.n}`,
         name: null,
       })

--- a/apps/api/src/routes/session.ts
+++ b/apps/api/src/routes/session.ts
@@ -284,6 +284,62 @@ export const sessionRoutes = (ctx: AppContext) => {
     },
   )
 
+  // The activation signals first-run onboarding reads: has this user ever authorized
+  // an agent (an oauthConsent row exists), and has an agent published for them over
+  // MCP yet (version.source='mcp' attributed to them). The welcome screen polls this
+  // while visible so connect + first-publish check themselves off live; the
+  // getting-started checklist reads it lazily.
+  app.openapi(
+    createRoute({
+      method: "get",
+      path: "/v1/me/onboarding",
+      tags: ["Session"],
+      summary: "The signed-in user's activation signals (agent connected, first agent publish).",
+      responses: {
+        200: {
+          description: "Whether an agent is connected and what it first published.",
+          content: {
+            "application/json": {
+              schema: z.object({
+                agent_connected: z
+                  .boolean()
+                  .describe("Whether an OAuth agent grant currently exists (revoking clears it)."),
+                agent_name: z
+                  .string()
+                  .nullable()
+                  .describe("Display name of the most recently authorized agent; null if none."),
+                published_via_agent: z
+                  .boolean()
+                  .describe("Whether an agent has published an artifact for this user over MCP."),
+                first_artifact: z
+                  .object({
+                    short_id: z.string(),
+                    title: z.string().nullable(),
+                  })
+                  .nullable()
+                  .describe(
+                    "The first artifact an agent published for this user; null until then.",
+                  ),
+              }),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const u = await requireUser(c)
+      if (u instanceof Response) return bail(u)
+      const grants = await meta.listUserGrants(u.id)
+      const first = await meta.firstAgentPublish(u.id)
+      return c.json({
+        agent_connected: grants.length > 0,
+        agent_name: grants[0]?.clientName ?? null,
+        published_via_agent: first !== null,
+        first_artifact: first,
+      })
+    },
+  )
+
   // People search: find OPTED-IN accounts by handle or name. Registered before
   // /v1/users/:handle so "search" isn't read as a handle.
   app.openapi(

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -262,6 +262,19 @@ describe("remote MCP endpoint (/mcp)", () => {
     const rec = await meta.getByShortId(art.short_id)
     if (!rec) throw new Error("expected the published artifact")
     expect(await meta.getArtifactMember(rec.id, "u_o")).toBeTruthy()
+    // The staged leg is the MCP flow's upload — it carries the 'mcp' surface stamp
+    // (the onboarding "published via agent" signal).
+    expect((await meta.getVersion(rec.id, 1))?.source).toBe("mcp")
+  })
+
+  it("stamps version.source='mcp' on tool publishes (the onboarding signal)", async () => {
+    const { app, token, meta } = appWithGrant("srcstamp", "openid derive:read derive:publish")
+    const created = JSON.parse(
+      toolText(await call(app, token, "publish", { title: "Stamped", content: "<h1>s</h1>" })),
+    )
+    const rec = await meta.getByShortId(created.short_id)
+    if (!rec) throw new Error("expected the published artifact")
+    expect((await meta.getVersion(rec.id, 1))?.source).toBe("mcp")
   })
 
   it("stage_publish fails actionably when no signing secret is configured", async () => {

--- a/apps/api/test/onboarding.test.ts
+++ b/apps/api/test/onboarding.test.ts
@@ -1,0 +1,139 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { SqliteMetaStore } from "@derive/db/sqlite"
+import Database from "better-sqlite3"
+import { afterAll, describe, expect, it } from "vitest"
+import { as, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// The activation signals behind /v1/me/onboarding (the live welcome screen + the
+// getting-started checklist): agent_connected comes from the user's OAuth grants,
+// published_via_agent from the first version an agent published FOR them over MCP
+// (version.source = 'mcp', attributed to them). The pin here is the source stamp —
+// a web publish must never count as agent activation.
+
+describe("onboarding activation signals", () => {
+  const u: TestUser = { id: "u_onb", email: "onb@derive.test", name: "Robin" }
+  // A second user whose ONLY agent activity is the propose → approve loop, so the
+  // proposal path is pinned on its own (not shadowed by u's direct MCP version).
+  const u2: TestUser = { id: "u_onb2", email: "onb2@derive.test", name: "Sam" }
+  const { app, meta } = makeAuthedApp("onboarding", [u, u2])
+
+  let firstShortId: string
+  const status = async (who: TestUser = u) =>
+    (await app.request("/v1/me/onboarding", { headers: as(who.email) })).json()
+
+  it("starts all-false for a fresh user", async () => {
+    await app.request("/v1/me", { headers: as(u.email) }) // provisions the workspace
+    expect(await status()).toEqual({
+      agent_connected: false,
+      agent_name: null,
+      published_via_agent: false,
+      first_artifact: null,
+    })
+  })
+
+  it("a session publish stamps version.source='web' and does not count as agent activation", async () => {
+    const res = await publishAs(app, "<h1>hand-made</h1>", { title: "By hand" }, as(u.email))
+    expect(res.status).toBe(201)
+    const { short_id } = await res.json()
+    const artifact = await meta.getByShortId(short_id)
+    if (!artifact) throw new Error("expected the artifact")
+    const v1 = await meta.getVersion(artifact.id, 1)
+    expect(v1?.source).toBe("web")
+    expect(v1?.author_id).toBe(u.id)
+    const s = await status()
+    expect(s.published_via_agent).toBe(false)
+    expect(s.first_artifact).toBeNull()
+  })
+
+  it("an MCP-stamped version flips published_via_agent and names the first artifact", async () => {
+    // The MCP publish tool runs the same core publish() with source:'mcp' and
+    // author_id = the human the agent acts for; addVersion is that path's write.
+    const res = await publishAs(app, "<h1>draft</h1>", { title: "Agent draft" }, as(u.email))
+    const { short_id } = await res.json()
+    const artifact = await meta.getByShortId(short_id)
+    if (!artifact) throw new Error("expected the artifact")
+    const v1 = await meta.getVersion(artifact.id, 1)
+    if (!v1) throw new Error("expected v1")
+    await meta.addVersion(artifact.id, {
+      id: "v_onb_mcp",
+      blob_key: v1.blob_key,
+      content_type: v1.content_type,
+      author: "Claude Code",
+      author_id: u.id,
+      source: "mcp",
+      message: "agent publish",
+    })
+    const s = await status()
+    expect(s.published_via_agent).toBe(true)
+    expect(s.first_artifact).toEqual({ short_id, title: "Agent draft" })
+    // agent_connected stays false — no OAuth consent exists in this app.
+    expect(s.agent_connected).toBe(false)
+    firstShortId = short_id
+  })
+
+  it("an approved agent proposal on the user's behalf also counts (the propose → approve loop)", async () => {
+    // A propose-scoped agent never creates an 'mcp'-stamped version itself; the
+    // delegation record (on_behalf_of) + the human's approval is the signal. u2's
+    // ONLY agent activity is this loop, so the assertion pins the proposal branch.
+    expect((await status(u2)).published_via_agent).toBe(false)
+    const res = await publishAs(app, "<h1>base</h1>", { title: "Proposal target" }, as(u2.email))
+    const { short_id } = await res.json()
+    const artifact = await meta.getByShortId(short_id)
+    if (!artifact) throw new Error("expected the artifact")
+    const v1 = await meta.getVersion(artifact.id, 1)
+    if (!v1) throw new Error("expected v1")
+    await meta.createProposal({
+      id: "p_onb",
+      artifact_id: artifact.id,
+      blob_key: v1.blob_key,
+      content_type: v1.content_type,
+      kind: artifact.kind,
+      author: "Claude Code",
+      author_id: "oauth:claude",
+      on_behalf_of: u2.id,
+      base_version: 1,
+      message: "agent proposal",
+    })
+    // An OPEN proposal is not activation — only the human's approval is.
+    expect((await status(u2)).published_via_agent).toBe(false)
+    await meta.decideProposal("p_onb", {
+      state: "approved",
+      decided_by: u2.id,
+      decided_version: 2,
+    })
+    const s = await status(u2)
+    expect(s.published_via_agent).toBe(true)
+    expect(s.first_artifact).toEqual({ short_id, title: "Proposal target" })
+    // And u's earlier direct MCP publish stays THEIR first artifact, undisturbed.
+    expect((await status()).first_artifact?.short_id).toBe(firstShortId)
+  })
+})
+
+// agent_connected's data source: listUserGrants reads the oauth-provider tables.
+// SQLite-direct like oauth.test.ts — the tables are Better Auth's, injected raw.
+describe("listUserGrants → agent_connected", () => {
+  const dir = mkdtempSync(join(tmpdir(), "derive-onb-"))
+  afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+  it("a consent row surfaces as a named grant", async () => {
+    const path = join(dir, "grants.db")
+    const meta = new SqliteMetaStore(path)
+    const db = new Database(path)
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS "oauthClient" (clientId TEXT PRIMARY KEY, name TEXT);
+      CREATE TABLE IF NOT EXISTS "oauthConsent" (userId TEXT, clientId TEXT, scopes TEXT, updatedAt TEXT);
+    `)
+    db.prepare(`INSERT INTO "oauthClient"(clientId, name) VALUES('cl_1', 'Claude Code')`).run()
+    db.prepare(
+      `INSERT INTO "oauthConsent"(userId, clientId, scopes, updatedAt) VALUES('u_1', 'cl_1', '["derive:publish"]', '2026-07-17T00:00:00.000Z')`,
+    ).run()
+    db.close()
+    const grants = await meta.listUserGrants("u_1")
+    expect(grants).toHaveLength(1)
+    expect(grants[0]?.clientName).toBe("Claude Code")
+    expect(await meta.listUserGrants("someone-else")).toEqual([])
+    meta.close()
+  })
+})

--- a/apps/web/e2e/screens/extra.screens.ts
+++ b/apps/web/e2e/screens/extra.screens.ts
@@ -60,11 +60,15 @@ test("capture the remaining surfaces", async ({ page: p }) => {
   await p.getByTestId("login-submit").click()
   await expect(p).not.toHaveURL(/\/login/, { timeout: 15_000 })
   await expect(p.getByTestId("welcome-skip")).toBeVisible()
-  // Wait for real content (the pasteable prompt block), not just the route skeleton,
-  // so the capture isn't a blank shimmer.
-  await expect(p.getByTestId("welcome-prompt")).toBeVisible()
+  // Wait for real content (the default tab's command block), not just the route
+  // skeleton, so the capture isn't a blank shimmer.
+  await expect(p.getByTestId("welcome-cmd-claude-code")).toBeVisible()
   await settle(p)
   await shot("welcome-dark-desktop")
+  // The full paste prompt lives on the "Any agent" tab now — flip to it so the
+  // fallback path stays covered.
+  await p.getByTestId("welcome-tab-any").click()
+  await expect(p.getByTestId("welcome-prompt")).toBeVisible()
   await p.getByTestId("welcome-skip").click()
   await expect(p.getByTestId("library-menu")).toBeVisible()
 

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -221,6 +221,54 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/me/onboarding": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** The signed-in user's activation signals (agent connected, first agent publish). */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Whether an agent is connected and what it first published. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @description Whether an OAuth agent grant currently exists (revoking clears it). */
+                            agent_connected: boolean;
+                            /** @description Display name of the most recently authorized agent; null if none. */
+                            agent_name: string | null;
+                            /** @description Whether an agent has published an artifact for this user over MCP. */
+                            published_via_agent: boolean;
+                            /** @description The first artifact an agent published for this user; null until then. */
+                            first_artifact: {
+                                short_id: string;
+                                title: string | null;
+                            } | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/users/search": {
         parameters: {
             query?: never;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,5 +1,5 @@
 import type { LinkRole, Listed, Role, SortMode, WorkspaceAccess } from "@derive/core"
-import type { components } from "./api-types"
+import type { components, paths } from "./api-types"
 import { guestQuery } from "./lib/guest-id"
 
 /** The role vocabulary and the v2 access model's three single-purpose fields are
@@ -60,6 +60,10 @@ export type AuthCapabilities = components["schemas"]["AuthCapabilities"]
 /** An OAuth agent the user authorized to act on their behalf (the "Connected agents"
  *  list). Generated from the OpenAPI spec. */
 export type ConnectedAgent = components["schemas"]["ConnectedAgent"]
+/** The activation signals for first-run onboarding: whether an agent is connected and
+ *  what it first published for this user. Generated from the OpenAPI spec. */
+export type OnboardingStatus =
+  paths["/v1/me/onboarding"]["get"]["responses"][200]["content"]["application/json"]
 /** A public profile, by handle. Email is private and never returned here.
  *  Generated from the OpenAPI spec. */
 export type PublicProfile = components["schemas"]["PublicProfile"]
@@ -355,6 +359,9 @@ export const api = {
   // your behalf, and one-tap revocation — delegation made legible + reversible.
   connectedAgents: (): Promise<{ agents: ConnectedAgent[] }> =>
     f("/v1/me/connected-agents", opts()).then(j),
+  // The activation signals first-run onboarding reads: agent connected + what it first
+  // published for you. Polled by /welcome; read lazily by the getting-started checklist.
+  onboarding: (): Promise<OnboardingStatus> => f("/v1/me/onboarding", opts()).then(j),
   revokeConnectedAgent: (clientId: string): Promise<void> =>
     f(`/v1/me/connected-agents/${encodeURIComponent(clientId)}`, {
       method: "DELETE",

--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -174,6 +174,10 @@ export function CommandPalette() {
   const showAll = "all artifacts".includes(q) || "library".includes(q)
   const showFav = "favorites".includes(q)
   const showFollowing = "following".includes(q)
+  // The way back to the connect instructions after onboarding — /welcome stays the
+  // app's connect-an-agent surface (see pages/welcome).
+  const showConnect =
+    "connect an agent".includes(q) || "getting started".includes(q) || "mcp setup".includes(q)
 
   return (
     <CommandDialog
@@ -194,7 +198,7 @@ export function CommandPalette() {
             {loading || contentLoading || peopleLoading ? "Searching…" : "No results."}
           </CommandEmpty>
 
-          {(showAll || showFav || showFollowing) && (
+          {(showAll || showFav || showFollowing || showConnect) && (
             <CommandGroup heading="Jump to">
               {showAll && (
                 <CommandItem
@@ -218,6 +222,15 @@ export function CommandPalette() {
                   onSelect={() => go(() => nav({ to: "/following" }))}
                 >
                   <Icon name="following" size={16} /> Following
+                </CommandItem>
+              )}
+              {showConnect && (
+                <CommandItem
+                  value="connect-an-agent"
+                  data-testid="palette-connect-agent"
+                  onSelect={() => go(() => nav({ to: "/welcome" }))}
+                >
+                  <Icon name="context" size={16} /> Connect an agent
                 </CommandItem>
               )}
             </CommandGroup>

--- a/apps/web/src/components/chrome/getting-started.tsx
+++ b/apps/web/src/components/chrome/getting-started.tsx
@@ -1,0 +1,208 @@
+import { useQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
+import { useEffect, useState } from "react"
+import { Icon } from "@/components/icons"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { SidebarMenuItem } from "@/components/ui/sidebar"
+import { useAuth } from "@/ctx"
+import { onboardingQuery } from "@/lib/queries"
+import { STORAGE_KEYS } from "@/lib/storage-keys"
+import { cn } from "@/lib/utils"
+
+// Reads a per-browser checklist flag; storage failures (private mode) read as unset.
+const flag = (key: string): boolean => {
+  try {
+    return localStorage.getItem(key) === "1"
+  } catch {
+    return false
+  }
+}
+
+/**
+ * The getting-started pill: onboarding as a STATE the app is in, not a page that
+ * vanished. Sits above the account pod until the user has activated — connected an
+ * agent, had it publish, shared a link — then retires itself for good. Each row
+ * completes from a real signal (the server's onboarding endpoint, or the share
+ * dialog's copy-link flag), never from clicks. Dismiss is one click and permanent
+ * (per-browser); the instructions stay reachable via ⌘K → "Connect an agent".
+ * Rendered for EVERY signed-in user who hasn't finished or dismissed it — including
+ * accounts onboarded before this shipped: they are the unactivated cohort this
+ * exists for.
+ */
+export function GettingStarted() {
+  const { me } = useAuth()
+  // One dismissal state for the session; reading localStorage once per mount is
+  // fine — the pill is chrome, not data.
+  const [dismissed, setDismissed] = useState(() => flag(STORAGE_KEYS.gettingStartedDismissed))
+  // Re-read the share flag whenever the popover opens, so a copy-link in another
+  // tab is picked up without any event plumbing.
+  const [open, setOpen] = useState(false)
+
+  // refetchOnWindowFocus: the journey happens in the user's TERMINAL — they connect
+  // an agent, it publishes, they tab back. The app default (no focus refetch) would
+  // freeze this checklist for the whole session; focus is exactly the moment to look.
+  const { data: ob } = useQuery({
+    ...onboardingQuery(),
+    enabled: !!me && !dismissed,
+    refetchOnWindowFocus: true,
+  })
+
+  // Both server-side steps done → this browser never needs the pill again. Persisted
+  // in an effect (never during render); the mounted pill keeps rendering this session
+  // so the user watching their journey sees completion — and the share row — before
+  // it retires on the next visit.
+  const serverDone = !!ob && ob.agent_connected && ob.published_via_agent
+  useEffect(() => {
+    if (serverDone) {
+      try {
+        localStorage.setItem(STORAGE_KEYS.gettingStartedDismissed, "1")
+      } catch {
+        /* private mode — it just re-checks next session */
+      }
+    }
+  }, [serverDone])
+  // An activated account on a NEW device sees serverDone on its very first data —
+  // that user finished long ago; hide without a nag. Mid-journey users saw an
+  // incomplete first read, so they keep the pill for this session.
+  const [initiallyDone, setInitiallyDone] = useState<boolean | null>(null)
+  useEffect(() => {
+    if (ob && initiallyDone === null) setInitiallyDone(serverDone)
+  }, [ob, serverDone, initiallyDone])
+
+  if (!me || dismissed || !ob || initiallyDone !== false) return null
+
+  const shared = flag(STORAGE_KEYS.sharedLink)
+  const steps = [
+    {
+      key: "connect",
+      label: "Connect an agent",
+      detail: "One command links the agent you already use.",
+      done: ob.agent_connected,
+      doneNote: ob.agent_name,
+    },
+    {
+      key: "publish",
+      label: "Publish through your agent",
+      detail: "Ask it to publish anything — you get a permanent, versioned link.",
+      done: ob.published_via_agent,
+      doneNote: null,
+    },
+    {
+      key: "share",
+      label: "Share a link",
+      detail: "Send an artifact to a teammate — comments pin to the text.",
+      done: shared,
+      doneNote: null,
+    },
+  ]
+  const doneCount = steps.filter((s) => s.done).length
+
+  const dismiss = () => {
+    setDismissed(true)
+    setOpen(false)
+    try {
+      localStorage.setItem(STORAGE_KEYS.gettingStartedDismissed, "1")
+    } catch {
+      /* private mode */
+    }
+  }
+
+  return (
+    <SidebarMenuItem className="group-data-[collapsible=icon]:hidden">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            data-testid="getting-started-pill"
+            className="flex h-8 w-full items-center gap-2 rounded-full border border-sidebar-border bg-sidebar px-3 text-xs font-medium text-sidebar-foreground outline-none hover:bg-sidebar-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+          >
+            <ProgressRing done={doneCount} total={steps.length} />
+            <span className="truncate">Getting started</span>
+            <span className="ml-auto font-mono text-2xs text-muted-foreground">
+              {doneCount}/{steps.length}
+            </span>
+          </button>
+        </PopoverTrigger>
+        <PopoverContent side="top" align="start" className="w-80 p-0">
+          <div className="flex flex-col gap-0.5 px-4 pt-4 pb-1">
+            <p className="font-serif text-base font-medium text-foreground">Getting started.</p>
+            <p className="text-xs text-muted-foreground">
+              Derive works through the agent you already use.
+            </p>
+          </div>
+          <div className="flex flex-col px-2 py-2">
+            {steps.map((s) => (
+              <div
+                key={s.key}
+                data-testid={`getting-started-${s.key}`}
+                className="flex items-start gap-2.5 rounded-md px-2 py-2"
+              >
+                <span
+                  className={cn(
+                    "mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full",
+                    s.done ? "bg-success/15 text-success" : "border border-border text-transparent",
+                  )}
+                >
+                  <Icon name="check" size={11} />
+                </span>
+                <span className="flex min-w-0 flex-col">
+                  <span
+                    className={cn(
+                      "text-sm",
+                      s.done ? "text-muted-foreground line-through" : "font-medium text-foreground",
+                    )}
+                  >
+                    {s.label}
+                    {s.done && s.doneNote ? (
+                      <span className="ml-1.5 font-mono text-2xs no-underline">{s.doneNote}</span>
+                    ) : null}
+                  </span>
+                  {!s.done && (
+                    <span className="text-xs text-pretty text-muted-foreground">{s.detail}</span>
+                  )}
+                </span>
+              </div>
+            ))}
+          </div>
+          <div className="flex items-center justify-between border-t px-4 py-2.5">
+            {/* Every row's instructions live on /welcome — the connect surface. */}
+            <Link
+              to="/welcome"
+              data-testid="getting-started-open"
+              onClick={() => setOpen(false)}
+              className="text-xs font-medium text-foreground underline-offset-3 hover:underline"
+            >
+              Show me how
+            </Link>
+            <button
+              type="button"
+              data-testid="getting-started-dismiss"
+              onClick={dismiss}
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
+              Dismiss
+            </button>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </SidebarMenuItem>
+  )
+}
+
+// A tiny conic progress ring — the pill's only ornament. Ink on the done arc,
+// hairline on the rest; no color, per the chrome's monochrome register.
+function ProgressRing({ done, total }: { done: number; total: number }) {
+  const pct = (done / total) * 100
+  return (
+    <span
+      aria-hidden="true"
+      className="size-3.5 shrink-0 rounded-full"
+      style={{
+        background: `conic-gradient(var(--sidebar-foreground) ${pct}%, var(--sidebar-border) ${pct}% 100%)`,
+        // Punch the middle out so it reads as a ring, not a pie.
+        WebkitMask: "radial-gradient(circle at center, transparent 42%, black 46%)",
+        mask: "radial-gradient(circle at center, transparent 42%, black 46%)",
+      }}
+    />
+  )
+}

--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -42,6 +42,7 @@ import { collectionsQuery, summaryQuery, workspacesQuery } from "@/lib/queries"
 import { useBrandprintCollectionIds } from "@/lib/use-brandprint-ids"
 import { cn } from "@/lib/utils"
 import type { LibrarySearch } from "@/pages/library/types"
+import { GettingStarted } from "./getting-started"
 import { NotificationBell } from "./notification-bell"
 import { useShell } from "./shell-context"
 import { SyncChip } from "./sync-chip"
@@ -754,6 +755,9 @@ export function NavRail() {
           tools directly above it. */}
       <SidebarFooter>
         <SidebarMenu>
+          {/* Onboarding as a state, not a memory: the pill rides above the account
+              pod until the user has activated, then retires itself (getting-started). */}
+          <GettingStarted />
           <SidebarMenuItem>
             <UserPod
               workspaceLabel={workspaceLabel}

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -19,6 +19,7 @@ import {
   ChevronRight,
   ChevronUp,
   Code,
+  Copy,
   Ellipsis,
   Eye,
   Fingerprint,
@@ -80,6 +81,7 @@ const REG = {
   user: User,
   workspace: Building2,
   check: Check,
+  copy: Copy,
   plus: Plus,
   signout: LogOut,
   // chrome

--- a/apps/web/src/components/shared/connect-agent.tsx
+++ b/apps/web/src/components/shared/connect-agent.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dialog"
 import { toast } from "@/components/ui/sonner"
 import { Switch } from "@/components/ui/switch"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 // The one Connect-an-agent surface: the paste-into-your-agent prompt (hosted, with a
 // self-host toggle), shared by onboarding Step 2, the library's connect empty state,
@@ -67,21 +68,110 @@ Please:
 Then you can publish, read review comments, and run the propose -> review -> revise loop over MCP.`
 
 /**
- * The paste-into-your-agent block: a one-line description, the quiet self-host
- * toggle, and the copyable prompt. `testidPrefix` keys the block's testids
- * (`<prefix>-prompt`, `<prefix>-prompt-copy`, `<prefix>-dev-toggle`) so each entry
- * point stays individually addressable in e2e.
+ * The connect surface: one tab per agent, each showing the lightest possible setup
+ * for that harness — a single command where one exists, two short steps where it
+ * doesn't. The full agent-native paste prompt (and the self-host variant) lives on
+ * the "Any agent" tab so nobody is stranded. `testidPrefix` keys the block's
+ * testids (`<prefix>-tab-<agent>`, `<prefix>-cmd-<agent>`, `<prefix>-prompt`,
+ * `<prefix>-dev-toggle`) so each entry point stays individually addressable in e2e.
  */
 export function ConnectAgent({ testidPrefix = "connect-agent" }: { testidPrefix?: string }) {
+  const url = publicUrl()
+  const mcp = `${url}/mcp`
+  // Verified per-harness setup lines. Cursor reads .cursor/mcp.json; the others
+  // register over their own CLI/UI. Kept inline (not a table) so each tab can
+  // carry its own hint copy.
+  const cursorJson = `{ "mcpServers": { "derive": { "url": "${mcp}" } } }`
+  const consentHint = (
+    <p className="text-sm text-pretty text-muted-foreground">
+      The first call opens your browser once to approve — then it can publish, review, and revise
+      for you.
+    </p>
+  )
+  // Radix unmounts inactive TabsContent, so this is layout-only.
+  const tabContent = "flex flex-col gap-2"
+  return (
+    <Tabs defaultValue="claude-code" className="gap-3">
+      <TabsList size="sm" className="max-w-full overflow-x-auto">
+        <TabsTrigger value="claude-code" data-testid={`${testidPrefix}-tab-claude-code`}>
+          Claude Code
+        </TabsTrigger>
+        <TabsTrigger value="claude" data-testid={`${testidPrefix}-tab-claude`}>
+          Claude
+        </TabsTrigger>
+        <TabsTrigger value="codex" data-testid={`${testidPrefix}-tab-codex`}>
+          Codex
+        </TabsTrigger>
+        <TabsTrigger value="cursor" data-testid={`${testidPrefix}-tab-cursor`}>
+          Cursor
+        </TabsTrigger>
+        <TabsTrigger value="any" data-testid={`${testidPrefix}-tab-any`}>
+          Any agent
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="claude-code" className={tabContent}>
+        <p className="text-sm text-pretty text-muted-foreground">
+          One command, run anywhere — then tell it{" "}
+          <span className="font-medium text-foreground">“connect to Derive.”</span>
+        </p>
+        <PromptBlock
+          text={`claude mcp add --transport http derive ${mcp}`}
+          testid={`${testidPrefix}-cmd-claude-code`}
+          copyLabel="Copy command"
+        />
+        {consentHint}
+      </TabsContent>
+      <TabsContent value="claude" className={tabContent}>
+        <p className="text-sm text-pretty text-muted-foreground">
+          In claude.ai or Claude Desktop:{" "}
+          <span className="font-medium text-foreground">
+            Settings → Connectors → Add custom connector
+          </span>
+          , then paste this URL.
+        </p>
+        <PromptBlock text={mcp} testid={`${testidPrefix}-cmd-claude`} copyLabel="Copy URL" />
+        {consentHint}
+      </TabsContent>
+      <TabsContent value="codex" className={tabContent}>
+        <p className="text-sm text-pretty text-muted-foreground">One command connects Codex.</p>
+        <PromptBlock
+          text={`codex mcp add derive --url ${mcp}`}
+          testid={`${testidPrefix}-cmd-codex`}
+          copyLabel="Copy command"
+        />
+        {consentHint}
+      </TabsContent>
+      <TabsContent value="cursor" className={tabContent}>
+        <p className="text-sm text-pretty text-muted-foreground">
+          Add Derive to <span className="font-medium text-foreground">.cursor/mcp.json</span> (or
+          Settings → MCP → Add server).
+        </p>
+        <PromptBlock
+          text={cursorJson}
+          testid={`${testidPrefix}-cmd-cursor`}
+          copyLabel="Copy config"
+        />
+        {consentHint}
+      </TabsContent>
+      <TabsContent value="any" className={tabContent}>
+        <AnyAgentPrompt testidPrefix={testidPrefix} url={url} />
+      </TabsContent>
+    </Tabs>
+  )
+}
+
+// The pre-tabs connect block, now the "Any agent" fallback: the agent-native paste
+// prompt with the quiet self-host toggle. Testids unchanged so every existing e2e
+// entry point still resolves.
+function AnyAgentPrompt({ testidPrefix, url }: { testidPrefix: string; url: string }) {
   // Self-host mode swaps the connect snippet for run-it-yourself instructions.
   const [devMode, setDevMode] = useState(false)
-  const url = publicUrl()
   return (
-    <div className="flex flex-col gap-2">
+    <>
       <p className="text-sm text-pretty text-muted-foreground">
         {devMode
-          ? "Spin up your own Derive, then connect your agent to it. Paste this into Claude Code, Codex, or any agent."
-          : "Paste this into Claude Code, Codex, ChatGPT, or any agent — it connects Derive so the agent can publish, review, and revise for you."}
+          ? "Spin up your own Derive, then connect your agent to it. Paste this into any agent."
+          : "Paste this into any MCP-capable agent — it connects Derive so the agent can publish, review, and revise for you."}
       </p>
       {/* The self-host switch rides just above the snippet it swaps — a rarely-
           touched option, so it sits quiet and right-aligned, not in the header. */}
@@ -99,7 +189,7 @@ export function ConnectAgent({ testidPrefix = "connect-agent" }: { testidPrefix?
         text={devMode ? selfHostPrompt() : hostedPrompt(url)}
         testid={`${testidPrefix}-prompt`}
       />
-    </div>
+    </>
   )
 }
 
@@ -137,8 +227,8 @@ export function ConnectAgentDialogContent({ testidPrefix }: { testidPrefix: stri
       <DialogHeader>
         <DialogTitle>Connect an agent</DialogTitle>
         <DialogDescription>
-          One paste connects any MCP agent to Derive — it can then publish, review, and revise for
-          you.
+          Pick your agent — one command connects it to Derive, and it can then publish, review, and
+          revise for you.
         </DialogDescription>
       </DialogHeader>
       <ConnectAgent testidPrefix={testidPrefix} />

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -152,6 +152,16 @@ export const connectedAgentsQuery = () =>
     queryFn: () => api.connectedAgents().then((r) => r.agents),
   })
 
+// The activation signals for first-run onboarding + the getting-started checklist:
+// whether an agent is connected and what it first published for you. The welcome
+// screen polls this (refetchInterval at the call site) so connect + first-publish
+// check themselves off live; the rail checklist reads it at normal staleness.
+export const onboardingQuery = () =>
+  queryOptions({
+    queryKey: ["onboarding"] as const,
+    queryFn: () => api.onboarding(),
+  })
+
 // The caller's follows (GitHub authors + repo path prefixes) for the active
 // workspace. Drives the Following-feed empty state, the manage strip, and the
 // isFollowing* sets that toggle the Follow buttons. One source of truth: every

--- a/apps/web/src/lib/storage-keys.ts
+++ b/apps/web/src/lib/storage-keys.ts
@@ -29,4 +29,10 @@ export const STORAGE_KEYS = {
   // Dismissal of the home's one-time "set up your team's Brandprint" nudge (owners
   // of a Brandprint-less workspace; see pages/library/brandprint-nudge).
   brandprintNudge: "derive:brandprint-nudge",
+  // Dismissal of the rail's getting-started checklist — one click, permanent,
+  // per-browser (see chrome/getting-started).
+  gettingStartedDismissed: "derive.getting-started.dismissed",
+  // The checklist's "shared a link" step: set by the share dialog's copy-link
+  // action (per-browser; the server signals cover connect + first publish).
+  sharedLink: "derive.shared-link",
 } as const

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -41,6 +41,7 @@ import { Switch } from "@/components/ui/switch"
 import { useAuth } from "@/ctx"
 import { getInitials } from "@/lib/initials"
 import { artifactQuery, workspaceQuery } from "@/lib/queries"
+import { STORAGE_KEYS } from "@/lib/storage-keys"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { ShareCollectionDialog } from "@/pages/library/share-collection-dialog"
 
@@ -322,6 +323,13 @@ export function ShareButton({
       setCopiedLink(true)
       toast.success("Link copied")
       window.setTimeout(() => setCopiedLink(false), 1500)
+      // The getting-started checklist's "share a link" step completes here — the
+      // one gesture that means "I sent this to someone" (see chrome/getting-started).
+      try {
+        localStorage.setItem(STORAGE_KEYS.sharedLink, "1")
+      } catch {
+        /* private mode — the checklist row just stays open */
+      }
     } catch {
       toast.error("Couldn't copy to clipboard")
     }

--- a/apps/web/src/pages/welcome.tsx
+++ b/apps/web/src/pages/welcome.tsx
@@ -1,429 +1,302 @@
 import { useQuery } from "@tanstack/react-query"
-import { useNavigate } from "@tanstack/react-router"
+import { Link, useNavigate } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
-import { ApiError, api } from "@/api"
+import { api } from "@/api"
 import { Icon } from "@/components/icons"
-import { AvatarPicker } from "@/components/shared/avatar-picker"
 import { ConnectAgent } from "@/components/shared/connect-agent"
-import { fieldError } from "@/components/shared/field-error"
-import { FormField } from "@/components/shared/form-field"
-import { SectionEyebrow } from "@/components/shared/section-eyebrow"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupInput,
-  InputGroupText,
-} from "@/components/ui/input-group"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 import { toast } from "@/components/ui/sonner"
-import { Textarea } from "@/components/ui/textarea"
 import { useAuth } from "@/ctx"
-import { authClient } from "@/lib/auth-client"
-import { getInitials } from "@/lib/initials"
-import { OTHER, PROFESSIONS, presetFor } from "@/lib/professions"
-import { workspaceQuery, workspaceSettingsQuery } from "@/lib/queries"
+import { connectedAgentsQuery, onboardingQuery } from "@/lib/queries"
 import { STORAGE_KEYS } from "@/lib/storage-keys"
-import { useApiMutation } from "@/lib/use-api-mutation"
 import { useDocumentTitle } from "@/lib/use-document-title"
-import { normalizeUsername, usernameError } from "@/lib/username"
-import { notesAsDoc, useBrandprintImport } from "@/pages/brandprint/use-brandprint-import"
 
-// A present account — the stateful onboarding body only mounts once `me` resolves
-// (see Welcome's guard), so the profile fields can safely initialize from it.
-type Account = NonNullable<ReturnType<typeof useAuth>["me"]>
-
-// Set once the user finishes (or skips) onboarding, so the post-signup redirect
-// (app-shell.tsx) doesn't bounce them back here on every visit.
-export const markOnboarded = () => {
-  // Persist server-side (authoritative + cross-device) and cache locally for an instant
-  // guard on the very next nav. Fire-and-forget: the localStorage cache covers the gap
-  // while the request is in flight, and the flag is one-way, so a dropped write just
-  // re-shows /welcome once rather than corrupting anything.
+// Persist "onboarding finished" server-side (authoritative + cross-device) and cache
+// locally for an instant guard on the very next nav. Fire-and-forget: the flag is
+// one-way, so a dropped write just re-shows /welcome once. The in-memory `me` update
+// happens at the call site (setMe) — that's what keeps the redirect guard from
+// bouncing even when localStorage is unavailable (private mode).
+const persistOnboarded = () => {
   api.setOnboarded().catch(() => {})
   try {
     localStorage.setItem(STORAGE_KEYS.onboarded, "1")
   } catch {
-    /* private mode — the in-session redirect guard still won't loop */
+    /* private mode — setMe carries the in-session guard */
   }
 }
 
-// Distinguishes a failed Brandprint seed from a failed profile save in the one
-// Continue action, so the inline error says which half to retry.
-const BRANDPRINT_FAILED = "brandprint-seed-failed"
+// How fast the screen notices the user acting in their OTHER window (the agent
+// completing OAuth, the first artifact landing). 2s matches the sync-chip poll —
+// both are single indexed reads a user is actively watching.
+const WATCH_INTERVAL_MS = 2000
 
-// Gate on the session BEFORE the stateful body so the profile fields initialize from
-// a resolved account (a direct visit to /welcome renders once with me=null first).
+// The example first asks — the walkthrough IS these prompts: each teaches what
+// Derive is for in the user's own tool. Copy-to-clipboard chips, not buttons.
+const EXAMPLE_ASKS = [
+  "Publish a one-page summary of what I'm working on to Derive.",
+  "Turn the README into a shareable page on Derive.",
+  "Draft our launch plan as a Derive doc I can get feedback on.",
+]
+
+/**
+ * First-run onboarding, slimmed to the one activation moment: connect the agent
+ * you already use, watch it publish. Three live states — the page polls the
+ * consent + first-publish signals and advances itself, no "next" button:
+ *   1. waiting to connect (the per-agent tabs)
+ *   2. connected → suggest first asks
+ *   3. first artifact live → open it / continue
+ * Profile, passkey, and Brandprint setup live in Settings and the home nudges now;
+ * activation pays for everything else. Reachable any time at /welcome — it stays
+ * the app's connect-an-agent surface after onboarding (⌘K → "Connect an agent"),
+ * so the connected state keeps the tabs one click away for adding a second agent.
+ */
 export function Welcome() {
   useDocumentTitle("Welcome")
-  const { me } = useAuth()
-  if (!me) return null
-  return <Onboarding me={me} />
-}
-
-function Onboarding({ me }: { me: Account }) {
-  const { setMe } = useAuth()
+  const { me, setMe } = useAuth()
   const nav = useNavigate()
+  // The connected state collapses the tabs; this reopens them (add a second agent).
+  const [showConnect, setShowConnect] = useState(false)
 
-  // Profile state lives on the page (not a child) so the single primary action —
-  // "Continue to Derive" — persists it and advances in one step. The old flow had a
-  // separate "Save profile" button, so filled fields were silently lost if you hit
-  // Continue without saving first.
-  const [handle, setHandle] = useState(me.username ?? "")
-  const [preset, setPreset] = useState(presetFor(me.profession ?? null))
-  const [custom, setCustom] = useState(
-    me.profession && presetFor(me.profession) === OTHER ? me.profession : "",
-  )
-  const [about, setAbout] = useState(me.about ?? "")
-  const [brandNotes, setBrandNotes] = useState("")
+  // Live signal 1: has an agent been authorized? Poll until one appears; stop on
+  // error too (the StatusPanel's Try again restarts the loop) so a down API isn't
+  // hammered every 2s behind a manual-retry affordance.
+  const agentsQ = useQuery({
+    ...connectedAgentsQuery(),
+    enabled: !!me,
+    refetchInterval: (q) =>
+      q.state.status === "error" || (q.state.data?.length ?? 0) > 0 ? false : WATCH_INTERVAL_MS,
+  })
+  const agent = agentsQ.data?.[0] ?? null
 
-  // Step 3 shows only to the person who'd be setting up this workspace's Brandprint
-  // for the first time: an owner of a workspace that has none (the spec's "first on
-  // the team" rule — everyone else inherits it over MCP with nothing to set up).
-  // Degrade-by-design: the step is optional, so a failed read hides it rather than
-  // blocking onboarding behind a retry.
-  const { data: ws, isError: wsError } = useQuery(workspaceQuery())
-  const { data: wsSettings, isError: settingsError } = useQuery(workspaceSettingsQuery())
-  const showBrandprint =
-    !wsError &&
-    !settingsError &&
-    ws?.role === "owner" &&
-    !!wsSettings &&
-    !wsSettings.brandprint?.collectionId
-  const seedBrandprint = useBrandprintImport("workspace", "")
+  // Live signal 2: has it published yet? Only asked once an agent is connected,
+  // and stops polling the moment the first artifact lands (or on error).
+  const obQ = useQuery({
+    ...onboardingQuery(),
+    enabled: !!me && !!agent,
+    refetchInterval: (q) =>
+      q.state.status === "error" || q.state.data?.published_via_agent ? false : WATCH_INTERVAL_MS,
+  })
+  const first = obQ.data?.first_artifact ?? null
+  // The polls are the page's live half; the instructions above them keep working
+  // regardless, so an error surfaces inline without replacing the surface.
+  const watchFailed = agentsQ.isError || obQ.isError
+  const retryWatch = () => {
+    if (agentsQ.isError) void agentsQ.refetch()
+    if (obQ.isError) void obQ.refetch()
+  }
 
+  // Activation IS onboarding: the moment the first artifact exists, the gate is
+  // done — even if the user closes the tab from here without clicking an exit.
+  const activated = !!first
+  useEffect(() => {
+    if (activated) persistOnboarded()
+  }, [activated])
+
+  if (!me) return null
   const firstName = (me.name ?? me.username ?? me.email).split(/[@\s]/)[0]
-  const initials = getInitials(me.name ?? me.email)
-  const normalized = normalizeUsername(handle)
-  const handleErr = normalized ? usernameError(normalized) : null
-  const usernameField = fieldError("welcome-username-error", handleErr)
-  const profession = preset === OTHER ? custom.trim() : preset
 
-  // Non-blocking (onboarding proceeds regardless) but NOT silent: a failed upload toasts, so
-  // the user isn't left believing a photo saved when it didn't.
-  const upload = useApiMutation({
-    mutationFn: (f: File) => api.uploadAvatar(f),
-    onSuccess: ({ image }) => setMe({ ...me, image }),
-  })
-  const pickPhoto = (f: File | null) => {
-    if (f) upload.mutate(f)
-  }
-
-  // Skip = leave now, persist nothing. Continue = save the profile (handle + role +
-  // bio) and THEN enter — the one action that finishes onboarding without dropping
-  // input. Both set the onboarded flag so the app-shell gate won't bounce back here.
-  const skip = () => {
-    markOnboarded()
-    nav({ to: "/" })
-  }
-
-  const save = useApiMutation({
-    mutationFn: async () => {
-      // The Brandprint seeds FIRST: a failure keeps the user here with their notes
-      // intact (nothing else has saved yet). On retry the settings cache already
-      // shows the pointer, so a seeded Brandprint is never doubled.
-      if (showBrandprint && brandNotes.trim()) {
-        try {
-          await seedBrandprint.mutateAsync([notesAsDoc(brandNotes)])
-        } catch {
-          throw new Error(BRANDPRINT_FAILED)
-        }
-      }
-      let username = me.username
-      // Only claim when it actually changed (claiming your own handle is a no-op, but
-      // skipping avoids a needless round-trip).
-      if (normalized && normalized !== me.username) {
-        const r = await api.setUsername(normalized)
-        username = r.username
-      }
-      const res = await api.setProfile({ profession, about: about.trim() })
-      return { username, profession: res.profession, about: res.about }
-    },
-    errorToast: false,
-    onSuccess: ({ username, profession: prof, about: bio }) => {
-      setMe({ ...me, username, profession: prof, about: bio, onboarded: true })
-      markOnboarded()
+  // Every exit marks onboarding done — server, storage, AND the in-memory session
+  // (setMe), so the guard can't bounce back here even when storage writes fail.
+  const leave = (to: "/" | "artifact") => {
+    persistOnboarded()
+    setMe({ ...me, onboarded: true })
+    if (to === "artifact" && first) {
+      nav({ to: "/artifacts/$ref", params: { ref: first.short_id } })
+    } else {
       nav({ to: "/" })
-    },
-  })
-  // Preserve the original message logic: the server's message for a known ApiError, a
-  // friendly fallback for anything else.
-  const saveErr = save.error
-    ? save.error.message === BRANDPRINT_FAILED
-      ? "Couldn't save your Brandprint. Try again, or clear the box to skip it for now."
-      : save.error instanceof ApiError
-        ? save.error.message
-        : "Could not save your profile."
-    : ""
-  const continueToApp = () => {
-    if (!handleErr) save.mutate()
+    }
   }
 
   return (
     <div className="min-h-dvh bg-background">
       <div className="mx-auto flex w-full max-w-2xl flex-col gap-8 px-5 py-10 sm:px-8 sm:py-14">
         <div className="flex flex-col gap-1.5">
-          {/* First-run greeting — a voice moment, so it renders in Geist display. */}
+          {/* First-run greeting — a voice moment, so it renders in the serif display. */}
           <h1 className="font-serif text-2xl font-medium tracking-tight text-balance text-foreground sm:text-3xl">
             Welcome to Derive, {firstName}.
           </h1>
           <p className="text-sm text-pretty text-muted-foreground">
-            A minute of setup — tell us who you are, then connect an agent to publish your first
-            artifact. You can change any of this later in Settings.
+            Connect the agent you already work with. It publishes; you share the link. Two minutes,
+            start to first artifact.
           </p>
         </div>
 
-        {/* Step 1 — Your profile. No per-section save: Continue persists it. */}
-        <section className="flex flex-col gap-4">
-          <SectionEyebrow as="h2">Step 1 · Your profile</SectionEyebrow>
-          <div className="flex flex-wrap items-start gap-4">
-            {/* Your own initials take the soft brand tint (the user-pod idiom). */}
-            <AvatarPicker
-              image={me.image}
-              initials={me.name ? initials : null}
-              uploading={upload.isPending}
-              onPick={pickPhoto}
-              ariaLabel="Add a profile photo"
-              testId="welcome-avatar"
-              fallbackClassName={me.name ? "bg-primary/10 text-primary" : undefined}
-            />
-
-            <div className="flex min-w-65 flex-1 flex-col gap-3">
-              <div className="flex flex-wrap gap-2">
-                <FormField
-                  label="Username"
-                  htmlFor="welcome-username"
-                  className="min-w-37.5 flex-1"
-                >
-                  <InputGroup>
-                    <InputGroupAddon>
-                      <InputGroupText>@</InputGroupText>
-                    </InputGroupAddon>
-                    <InputGroupInput
-                      id="welcome-username"
-                      data-testid="welcome-username"
-                      {...usernameField.aria}
-                      name="username"
-                      autoCapitalize="none"
-                      autoCorrect="off"
-                      spellCheck={false}
-                      value={handle}
-                      onChange={(e) => {
-                        setHandle(e.target.value)
-                        save.reset()
-                      }}
-                      placeholder="yourname"
-                    />
-                  </InputGroup>
-                </FormField>
-                <FormField label="Role" className="w-37.5">
-                  <Select value={preset || undefined} onValueChange={setPreset}>
-                    <SelectTrigger
-                      data-testid="welcome-role"
-                      aria-label="Your role"
-                      className="w-full"
-                    >
-                      <SelectValue placeholder="Who are you?" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {PROFESSIONS.map((p) => (
-                        <SelectItem key={p.value} value={p.value}>
-                          {p.value}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </FormField>
-              </div>
-              {usernameField.node ?? (
-                <p className="text-sm text-muted-foreground">
-                  Letters, numbers, and single - or _.
-                </p>
-              )}
-
-              {preset === OTHER && (
-                <Input
-                  data-testid="welcome-role-other"
-                  aria-label="Custom role"
-                  name="custom-role"
-                  value={custom}
-                  maxLength={40}
-                  placeholder="e.g. Data, Sales, Ops…"
-                  onChange={(e) => setCustom(e.target.value)}
-                />
-              )}
-
-              <FormField
-                label="What you do"
-                htmlFor="welcome-about"
-                count={about.length}
-                maxLength={280}
+        {/* Step 1 — connect. Collapses to a done-row once the OAuth consent lands,
+            with the tabs one click away (this page stays THE connect surface). */}
+        {agent ? (
+          <section className="flex flex-col gap-4">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <DoneRow testId="welcome-connected">{agent.clientName} connected</DoneRow>
+              <Button
+                variant="ghost"
+                size="sm"
+                data-testid="welcome-connect-another"
+                className="text-muted-foreground"
+                onClick={() => setShowConnect((v) => !v)}
               >
-                <Textarea
-                  id="welcome-about"
-                  data-testid="welcome-about"
-                  name="about"
-                  value={about}
-                  maxLength={280}
-                  rows={2}
-                  placeholder="A line about what you work on, so teammates and agents know who you are."
-                  onChange={(e) => setAbout(e.target.value)}
-                />
-              </FormField>
-
-              {saveErr && (
-                // The house form-error surface (matches Login): StatusPanel inline
-                // danger announces via role="alert"; the wrapper only carries the id.
-                <div data-testid="welcome-profile-error">
-                  <StatusPanel tone="danger" layout="inline" title={saveErr} />
-                </div>
-              )}
-
-              <p className="text-sm text-muted-foreground">
-                <span className="font-medium text-foreground">{me.email}</span> stays private.
-              </p>
+                {showConnect ? "Hide setup" : "Connect another agent"}
+              </Button>
             </div>
-          </div>
-        </section>
+            {showConnect && <ConnectAgent testidPrefix="welcome" />}
+          </section>
+        ) : (
+          <section className="flex flex-col gap-4">
+            <ConnectAgent testidPrefix="welcome" />
+            <WatchRow testId="welcome-watch-connect">Waiting for your agent to connect…</WatchRow>
+          </section>
+        )}
 
-        {/* An optional, quiet passkey nudge between the two steps — set up the
-            phishing-resistant one-tap sign-in now, or skip and do it later in Settings. */}
-        <PasskeyNudge />
+        {/* Step 2 — the first publish, suggested in the user's own words. Appears the
+            moment the agent connects; collapses to the artifact card once it lands. */}
+        {agent && !first && (
+          <section className="flex flex-col gap-3">
+            <h2 className="font-serif text-xl font-medium tracking-tight text-foreground">
+              Now ask it to publish something.
+            </h2>
+            <p className="text-sm text-pretty text-muted-foreground">
+              Anything becomes a living page with a permanent link. Try one of these, or ask in your
+              own words.
+            </p>
+            <div className="flex flex-col gap-2">
+              {EXAMPLE_ASKS.map((ask, i) => (
+                <AskChip key={ask} text={ask} testId={`welcome-ask-${i}`} />
+              ))}
+            </div>
+            <WatchRow testId="welcome-watch-publish">Watching for your first artifact…</WatchRow>
+          </section>
+        )}
 
-        {/* Step 2 — Connect an agent: the activation moment. The block itself is the
-            shared ConnectAgent surface (also behind the library's connect empty state
-            and the Brandprint nudge), so every entry point renders the same thing. */}
-        <section className="flex flex-col gap-4">
-          <SectionEyebrow as="h2">Step 2 · Connect an agent</SectionEyebrow>
-          <ConnectAgent testidPrefix="welcome" />
-        </section>
+        {/* Step 3 — the aha moment, witnessed: the thing the agent made appears on the
+            page that told you to ask for it (or greets a returning visitor). */}
+        {first && (
+          <section className="flex flex-col gap-4" data-testid="welcome-first-artifact">
+            <DoneRow testId="welcome-published">First artifact published</DoneRow>
+            <Link
+              to="/artifacts/$ref"
+              params={{ ref: first.short_id }}
+              className="flex flex-col gap-1 rounded-lg border bg-card px-4 py-3 shadow-xs transition-colors hover:border-foreground/25"
+            >
+              <span className="font-serif text-lg font-medium text-foreground">
+                {first.title ?? "Untitled"}
+              </span>
+              <span className="font-mono text-xs text-muted-foreground">
+                by {agent?.clientName ?? "your agent"}, for you
+              </span>
+            </Link>
+            <p className="text-sm text-pretty text-muted-foreground">
+              It's live at a permanent link. Share it with a teammate — comments pin to the text,
+              and your agent picks them up from here.
+            </p>
+          </section>
+        )}
 
-        {showBrandprint && <BrandprintStep notes={brandNotes} onNotes={setBrandNotes} />}
+        {watchFailed && (
+          <StatusPanel
+            tone="danger"
+            layout="inline"
+            title="Can't check your setup status right now."
+            action={
+              <Button variant="outline" size="sm" data-testid="welcome-retry" onClick={retryWatch}>
+                Try again
+              </Button>
+            }
+          />
+        )}
 
-        {/* Finish — one primary action that saves the profile and enters; skip leaves
-            now without saving. */}
+        {/* Exit row: before the first artifact, a quiet skip; after it, the real doors. */}
         <div className="flex items-center justify-between gap-3">
-          <Button
-            variant="ghost"
-            data-testid="welcome-skip"
-            className="text-muted-foreground"
-            onClick={skip}
-          >
-            Skip for now
-          </Button>
-          <Button
-            variant="default"
-            data-testid="welcome-continue"
-            onClick={continueToApp}
-            loading={save.isPending}
-            disabled={!!handleErr}
-          >
-            {save.isPending ? "Finishing…" : "Continue to Derive"}
-          </Button>
+          {first ? (
+            <>
+              <Button
+                variant="ghost"
+                data-testid="welcome-skip"
+                className="text-muted-foreground"
+                onClick={() => leave("/")}
+              >
+                Continue to Derive
+              </Button>
+              <Button
+                variant="default"
+                data-testid="welcome-open"
+                onClick={() => leave("artifact")}
+              >
+                Open your artifact
+              </Button>
+            </>
+          ) : (
+            <Button
+              variant="ghost"
+              data-testid="welcome-skip"
+              className="text-muted-foreground"
+              onClick={() => leave("/")}
+            >
+              Skip for now
+            </Button>
+          )}
         </div>
 
-        {/* Deliberately a line, not a step: teams are created at first need
-            (Settings, or the share dialog's hint), never chosen at signup. */}
         <p className="text-center text-sm text-muted-foreground">
-          Working with a team? Create a workspace and invite them anytime from Settings.
+          You can reopen this any time — search "Connect an agent" in ⌘K, or visit /welcome.
         </p>
       </div>
     </div>
   )
 }
 
-// Step 3 — the workspace Brandprint, seeded from pasted notes (spec: onboarding is
-// workspace-scoped and conditional; the caller gates rendering). Deliberately one
-// textarea: files, look/read categories, and the collection picker live on the
-// /brandprint page — this step is the lightest useful capture, saved by the page's
-// single Continue action so nothing needs its own save button.
-function BrandprintStep({ notes, onNotes }: { notes: string; onNotes: (v: string) => void }) {
+// A completed step: the quiet green tick + a line. The check is the whole reward —
+// no confetti, no card.
+function DoneRow({ children, testId }: { children: React.ReactNode; testId: string }) {
   return (
-    <section className="flex flex-col gap-4">
-      <SectionEyebrow as="h2">Step 3 · Your team's Brandprint (optional)</SectionEyebrow>
-      <p className="text-sm text-pretty text-muted-foreground">
-        A Brandprint is your team's style in one place: your tone of voice, formatting rules, words
-        to use or avoid, and colors. Every agent that works in Derive reads it automatically before
-        it creates or revises anything, so the work matches your brand from the first draft, with no
-        one re-explaining it each time. Set it once here and everyone who joins your team inherits
-        it.
-      </p>
-      <Textarea
-        value={notes}
-        rows={5}
-        placeholder="Paste your brand guidelines, or a sample doc that already sounds right…"
-        aria-label="Your team's brand notes"
-        data-testid="welcome-brandprint"
-        onChange={(e) => onNotes(e.target.value)}
-      />
-      <p className="text-sm text-muted-foreground">
-        Saves when you continue, and starts guiding agents the moment one is connected. Your agent
-        then assembles your team's brand profile from it — finish on the Brandprint page.
-      </p>
-    </section>
+    <p data-testid={testId} className="flex items-center gap-2 text-sm font-medium text-foreground">
+      <Icon name="check" className="text-success" />
+      <span>{children}</span>
+    </p>
   )
 }
 
-// A quiet, skippable passkey affordance — shown only where passkeys are supported and only
-// until one is added. Runs the browser create-credential ceremony via the auth client; a
-// cancel is silent, a success swaps to a "you're set" line.
-function PasskeyNudge() {
-  const [supported, setSupported] = useState(false)
-  const [added, setAdded] = useState(false)
-  const [busy, setBusy] = useState(false)
-  useEffect(() => {
-    api
-      .capabilities()
-      .then((c) => setSupported(c.passkey))
-      .catch(() => setSupported(false))
-  }, [])
-  if (!supported || added) {
-    if (!added) return null
-    return (
-      <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
-        <Icon name="check" className="text-success" /> Passkey added — you can sign in with one tap.
-      </p>
-    )
-  }
-  const add = async () => {
-    setBusy(true)
+// The honest pulse: the page really is polling the signal it names, so the moment
+// the user acts in their other window, this row is replaced by a DoneRow.
+function WatchRow({ children, testId }: { children: React.ReactNode; testId: string }) {
+  return (
+    <p
+      data-testid={testId}
+      className="flex items-center gap-2.5 border-t pt-4 text-sm text-muted-foreground"
+    >
+      <span className="relative flex size-2">
+        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-muted-foreground opacity-50" />
+        <span className="relative inline-flex size-2 rounded-full bg-muted-foreground" />
+      </span>
+      <span>{children}</span>
+    </p>
+  )
+}
+
+// A copyable example ask — chip-shaped, mono-quoted, one tap to clipboard.
+function AskChip({ text, testId }: { text: string; testId: string }) {
+  const [copied, setCopied] = useState(false)
+  const copy = async () => {
     try {
-      const res = await authClient.passkey.addPasskey()
-      if (res?.error) throw new Error(res.error.message ?? "")
-      setAdded(true)
-      toast.success("Passkey added")
-    } catch (e) {
-      const msg = (e as Error).message
-      // mutation-ignore: WebAuthn cancel/abort must stay silent; the primitive has no
-      // per-error suppression, so this passkey add is deliberately hand-rolled.
-      if (msg && !/cancel|abort|NotAllowed/i.test(msg)) toast.error(msg) // mutation-ignore
-    } finally {
-      setBusy(false)
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      toast.success("Copied — paste it into your agent")
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      toast.error("Couldn't copy; select the text and copy it manually")
     }
   }
   return (
-    <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border bg-secondary/40 px-4 py-3">
-      <p className="text-sm text-pretty text-muted-foreground">
-        <span className="font-medium text-foreground">Add a passkey</span> for a phishing-resistant,
-        one-tap sign-in. Optional — you can also do this later in Settings.
-      </p>
-      <Button
-        variant="secondary"
-        size="sm"
-        onClick={add}
-        loading={busy}
-        data-testid="welcome-add-passkey"
-      >
-        {busy ? "Waiting…" : "Add passkey"}
-      </Button>
-    </div>
+    <button
+      type="button"
+      data-testid={testId}
+      onClick={copy}
+      className="flex items-center justify-between gap-3 rounded-lg border bg-secondary/40 px-4 py-2.5 text-left text-sm text-muted-foreground transition-colors hover:border-foreground/25 hover:text-foreground"
+    >
+      <span className="text-pretty">"{text}"</span>
+      <Icon
+        name={copied ? "check" : "copy"}
+        className={copied ? "shrink-0 text-success" : "shrink-0"}
+      />
+    </button>
   )
 }

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS version (
   author_avatar TEXT,
   author_gh_id TEXT,
   author_id TEXT,
+  source TEXT,
   message TEXT,
   name TEXT,
   preview_key TEXT,

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -226,6 +226,9 @@ export interface VersionRecord {
   author_gh_id: string | null
   /** The Derive user who published this version by hand; null for sync/anon/legacy. */
   author_id: string | null
+  /** Which surface created this version — the onboarding/analytics stamp. Null for
+   *  versions predating the column and for paths that don't stamp (restore, PR preview). */
+  source: VersionSource | null
   message: string | null
   /** A named checkpoint (Docs-style). Null = an ordinary auto-saved revision. */
   name: string | null
@@ -272,6 +275,10 @@ export interface NewArtifact {
   spa: 0 | 1
 }
 
+/** Which surface created a version: the web app, the MCP publish tool, the HTTP API
+ *  (agent tokens / OAuth bearers, incl. the CLI), or a GitHub sync. */
+export type VersionSource = "web" | "mcp" | "api" | "sync"
+
 export interface NewVersion {
   id: string
   blob_key: string
@@ -284,6 +291,8 @@ export interface NewVersion {
   author_gh_id?: string | null
   /** The Derive user who published this version by hand; null/omitted for sync/anon. */
   author_id?: string | null
+  /** Which surface created this version; omitted for paths that don't stamp. */
+  source?: VersionSource | null
   message: string | null
   name?: string | null
 }
@@ -933,6 +942,10 @@ export interface AgentStore {
    *  review + revoke what may act on their behalf. Reads Better Auth's oauth-provider tables;
    *  empty when they aren't present. */
   listUserGrants(userId: string): Promise<OAuthGrantSummary[]>
+  /** The first artifact an agent produced for this user — a direct MCP publish
+   *  (version.source='mcp', attributed to them) or an approved agent proposal on their
+   *  behalf (proposal.on_behalf_of). The onboarding "published via agent" signal. */
+  firstAgentPublish(userId: string): Promise<{ short_id: string; title: string | null } | null>
   /** Revoke a user's grant to one OAuth client: drop the consent + every live access/refresh
    *  token, so the agent loses access immediately and must re-consent. */
   revokeUserGrant(userId: string, clientId: string): Promise<void>

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -12,6 +12,7 @@ import {
   type ProposalRecord,
   SKILL_CONTENT_TYPE,
   type VersionRecord,
+  type VersionSource,
 } from "./ports"
 import { isSkillBundle, parseFrontmatter } from "./skill"
 
@@ -48,6 +49,9 @@ export interface PublishInput {
    *  people-follow surface their hand-published work. Omitted/null for sync and bare
    *  static-token publishes. */
   authorId?: string | null
+  /** Which surface created this version ('web' | 'mcp' | 'api' | 'sync'); stored on the
+   *  version row. Omitted for paths that don't stamp. */
+  source?: VersionSource | null
   /** The workspace the new artifact belongs to (multi-workspace). */
   orgId?: string
   /** Salted unlock-password hash, set by the route when the world link is locked. */
@@ -259,6 +263,7 @@ export async function publish(
       author_avatar: input.authorAvatar ?? null,
       author_gh_id: input.authorGhId ?? null,
       author_id: input.authorId ?? null,
+      source: input.source ?? null,
       message: input.message ?? null,
       name: input.name ?? null,
     })
@@ -297,6 +302,7 @@ export async function publish(
     author_avatar: input.authorAvatar ?? null,
     author_gh_id: input.authorGhId ?? null,
     author_id: input.authorId ?? null,
+    source: input.source ?? null,
     message: input.message ?? "first publish",
     name: input.name ?? null,
   })

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -19,6 +19,7 @@ import type {
   Role,
   SessionMessageAuthor,
   SessionState,
+  VersionSource,
   WebhookKind,
   WorkspaceAccess,
 } from "@derive/core"
@@ -85,6 +86,9 @@ export const version = pgTable(
     author_gh_id: text("author_gh_id"),
     // The Derive user who published this version by hand; null for sync/anon/legacy.
     author_id: text("author_id"),
+    // Which surface created this version ('web' | 'mcp' | 'api' | 'sync') — the
+    // onboarding/analytics stamp. Mirrors schema.ts.
+    source: text("source").$type<VersionSource>(),
     message: text("message"),
     name: text("name"),
     preview_key: text("preview_key"),

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -2398,6 +2398,50 @@ export class PgMetaStore implements MetaStore {
       return 0
     }
   }
+  async firstAgentPublish(
+    userId: string,
+  ): Promise<{ short_id: string; title: string | null } | null> {
+    // The first artifact an agent produced FOR this user: a direct MCP publish, or an
+    // approved agent proposal on their behalf. Earliest wins. Mirrors repos.ts.
+    const direct = (
+      await this.db
+        .select({ short_id: artifact.short_id, title: artifact.title, at: version.created_at })
+        .from(version)
+        .innerJoin(artifact, eq(artifact.id, version.artifact_id))
+        .where(
+          and(
+            eq(version.author_id, userId),
+            eq(version.source, "mcp"),
+            isNull(artifact.removed_at),
+          ),
+        )
+        .orderBy(asc(version.created_at), asc(version.id))
+        .limit(1)
+    )[0]
+    const approved = (
+      await this.db
+        .select({ short_id: artifact.short_id, title: artifact.title, at: proposal.decided_at })
+        .from(proposal)
+        .innerJoin(artifact, eq(artifact.id, proposal.artifact_id))
+        .where(
+          and(
+            eq(proposal.on_behalf_of, userId),
+            eq(proposal.state, "approved"),
+            isNull(artifact.removed_at),
+          ),
+        )
+        .orderBy(asc(proposal.decided_at), asc(proposal.id))
+        .limit(1)
+    )[0]
+    // A null decided_at (defensive; decide always stamps it) sorts LAST, never first.
+    const winner =
+      direct && approved
+        ? approved.at && approved.at < direct.at
+          ? approved
+          : direct
+        : (direct ?? approved)
+    return winner ? { short_id: winner.short_id, title: winner.title } : null
+  }
   async listUserGrants(userId: string): Promise<OAuthGrantSummary[]> {
     try {
       const { rows } = await this.pool.query(

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -2458,6 +2458,48 @@ export function makeRepos(db: SqliteDb) {
       return []
     }
   }
+  // The first artifact an agent produced FOR this user — the onboarding "published
+  // via agent" signal. Two paths count: a direct MCP publish (version.source='mcp',
+  // attributed to the human the agent acted for) and the propose → approve loop
+  // (an agent proposal on_behalf_of this user that a human approved — the
+  // recommended flow for propose-scoped grants, which never creates an
+  // 'mcp'-stamped version itself). Earliest of the two wins.
+  const firstAgentPublish = async (
+    userId: string,
+  ): Promise<{ short_id: string; title: string | null } | null> => {
+    const direct = await db
+      .select({ short_id: artifact.short_id, title: artifact.title, at: version.created_at })
+      .from(version)
+      .innerJoin(artifact, eq(artifact.id, version.artifact_id))
+      .where(
+        and(eq(version.author_id, userId), eq(version.source, "mcp"), isNull(artifact.removed_at)),
+      )
+      .orderBy(asc(version.created_at), asc(version.id))
+      .limit(1)
+      .get()
+    const approved = await db
+      .select({ short_id: artifact.short_id, title: artifact.title, at: proposal.decided_at })
+      .from(proposal)
+      .innerJoin(artifact, eq(artifact.id, proposal.artifact_id))
+      .where(
+        and(
+          eq(proposal.on_behalf_of, userId),
+          eq(proposal.state, "approved"),
+          isNull(artifact.removed_at),
+        ),
+      )
+      .orderBy(asc(proposal.decided_at), asc(proposal.id))
+      .limit(1)
+      .get()
+    // A null decided_at (defensive; decide always stamps it) sorts LAST, never first.
+    const winner =
+      direct && approved
+        ? approved.at && approved.at < direct.at
+          ? approved
+          : direct
+        : (direct ?? approved)
+    return winner ? { short_id: winner.short_id, title: winner.title } : null
+  }
   // Revoke a user's grant to a client: drop the consent + every live token so access ends
   // now and a fresh consent is required. Best-effort per table (a table may not exist).
   const revokeUserGrant = async (userId: string, clientId: string): Promise<void> => {
@@ -2981,6 +3023,7 @@ export function makeRepos(db: SqliteDb) {
     getOAuthClientName,
     oauthClientExists,
     listUserGrants,
+    firstAgentPublish,
     revokeUserGrant,
     setOAuthClientWorkspaces,
     getOAuthClientWorkspaces,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -19,6 +19,7 @@ import type {
   Role,
   SessionMessageAuthor,
   SessionState,
+  VersionSource,
   WebhookKind,
   WorkspaceAccess,
 } from "@derive/core"
@@ -110,6 +111,9 @@ export const version = sqliteTable(
     author_gh_id: text("author_gh_id"),
     // The Derive user who published this version by hand; null for sync/anon/legacy.
     author_id: text("author_id"),
+    // Which surface created this version ('web' | 'mcp' | 'api' | 'sync') — the
+    // onboarding/analytics stamp. Null for pre-column versions and non-stamping paths.
+    source: text("source").$type<VersionSource>(),
     message: text("message"),
     name: text("name"),
     preview_key: text("preview_key"),

--- a/scripts/check-surfaces.mjs
+++ b/scripts/check-surfaces.mjs
@@ -37,6 +37,7 @@ const QUERY_ALLOW = new Set([
   "components/chrome/app-shell.tsx", // workspace switcher, ambient
   "components/chrome/command-palette.tsx", // renders whatever's cached
   "components/chrome/sync-chip.tsx", // ambient status indicator
+  "components/chrome/getting-started.tsx", // ambient checklist pill; hides itself on any failure
   "pages/artifact/artifact-breadcrumb.tsx", // collections/siblings reads degrade to the title (no switcher)
   "pages/artifact/share-dialog.tsx", // reads the warm artifact cache (enabled:false)
   "pages/artifact/header-actions.tsx", // move-menu dropdown, warm read


### PR DESCRIPTION
Implements the approved onboarding redesign ([design proposal](https://derive.to/artifacts/onboarding-the-shortest-path-to-a-connected-agen-3qreki7f)): onboarding becomes a state the app is in until your agent has published — not a page you pass through once.

## Welcome, slimmed to the activation moment

- **Per-agent connect tabs** (Claude Code / Claude / Codex / Cursor / Any agent) replace the 15-line paste prompt. One command or URL per harness; the full agent-native prompt + self-host toggle live on the Any-agent tab so nobody is stranded.
- **Three live states.** The page polls the OAuth-consent signal every 2s until an agent connects, then the onboarding signal until the first artifact lands. Steps check themselves off; the first artifact appears on the page with an Open door. Polling stops on completion and on error (inline retry).
- **Re-homed, not deleted:** profile → Settings → Profile, passkey nudge → Security hub, Brandprint → the existing home nudge. `/welcome` stays the app's connect surface afterward — the connected state keeps the tabs one click away ("Connect another agent"), and ⌘K gains a "Connect an agent" action.
- Activation auto-marks onboarding done; every exit also updates the in-memory session so the redirect guard can't loop even when localStorage is unavailable.

## Detection plumbing

- **`version.source`** ('web' | 'mcp' | 'api' | 'sync'), nullable, boot-DDL across all three backends. Stamped at every publish surface: the MCP tool and its staged-upload leg → `mcp`; the HTTP route by principal (session → `web`, agent bearer → `api`); GitHub sync → `sync`; restore → `web`; PR-preview folds carry the stamp through. The auto-scaffolded Brandprint placeholder is deliberately unstamped so it can't count as a first publish.
- **`GET /v1/me/onboarding`** → `{ agent_connected, agent_name, published_via_agent, first_artifact }`. `published_via_agent` counts the earliest of a direct MCP publish attributed to the user **or an approved agent proposal on their behalf** (`proposal.on_behalf_of`) — so propose-scoped grants activate through the propose → approve loop too.

## Getting-started pill

A checklist pill above the account pod: connect → publish through your agent → share a link. Fed by the onboarding endpoint (refetches on window focus — the journey happens in the user's terminal) plus a share flag set by the share dialog's copy-link action. It retires permanently once the server-side steps are done, never nags an already-activated account on a new device, and dismiss is one permanent click. Shown to existing never-connected users too — they're the unactivated cohort this is for.

## Verification

- New `apps/api/test/onboarding.test.ts` pins the endpoint transitions, the `web` stamp, the MCP path, and the propose → approve path — each verified to fail when its stamp/branch is removed. `mcp.test.ts` pins the `mcp` stamp on both the tool and staged legs.
- Full workspace suite green (1105 API / 173 web / 209 db), all repo lint gates pass, e2e screens flow driven against the real app (signup → new welcome → tabs → skip → library).
- Two independent adversarial reviews (data-model + web halves); all real findings fixed: proposal-path blindness, placeholder false-positive, dead-end welcome, mid-session checklist staleness, private-mode redirect loop, render-phase storage write, error-state poll leak.

## Known scope edges

- "Published via agent" counts MCP + approved proposals; a registered-token agent publishing over plain REST (`source='api'`) doesn't activate the signal — the onboarding path being pushed is the hosted MCP.
- The share-a-link step is per-browser (localStorage) and completes on the share dialog's copy-link; a server-side share signal is the phase-3 follow-up in the proposal.