### PR TITLE
Onboarding front door: per-account welcome gate + connect card on the home library

### DIFF
--- a/apps/web/src/components/shared/example-asks.tsx
+++ b/apps/web/src/components/shared/example-asks.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react"
+import { Icon } from "@/components/icons"
+import { toast } from "@/components/ui/sonner"
+
+// The example first asks — the walkthrough IS these prompts: each teaches what
+// Derive is for in the user's own tool. Shared by /welcome's connected state and
+// the home library's connect nudge, so the suggested loop can't drift between them.
+export const EXAMPLE_ASKS = [
+  "Publish a one-page summary of what I'm working on to Derive.",
+  "Turn the README into a shareable page on Derive.",
+  "Draft our launch plan as a Derive doc I can get feedback on.",
+]
+
+// A copyable example ask — chip-shaped, mono-quoted, one tap to clipboard.
+export function AskChip({ text, testId }: { text: string; testId: string }) {
+  const [copied, setCopied] = useState(false)
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      toast.success("Copied — paste it into your agent")
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      toast.error("Couldn't copy; select the text and copy it manually")
+    }
+  }
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      onClick={copy}
+      className="flex items-center justify-between gap-3 rounded-lg border bg-secondary/40 px-4 py-2.5 text-left text-sm text-muted-foreground transition-colors hover:border-foreground/25 hover:text-foreground"
+    >
+      <span className="text-pretty">"{text}"</span>
+      <Icon
+        name={copied ? "check" : "copy"}
+        className={copied ? "shrink-0 text-success" : "shrink-0"}
+      />
+    </button>
+  )
+}

--- a/apps/web/src/lib/route-guards.test.ts
+++ b/apps/web/src/lib/route-guards.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { needsOnboarding } from "./route-guards"
+import { STORAGE_KEYS } from "./storage-keys"
+
+// The suite runs in the node environment — stub the one browser API the predicate reads.
+const store = new Map<string, string>()
+vi.stubGlobal("localStorage", {
+  getItem: (k: string) => store.get(k) ?? null,
+  setItem: (k: string, v: string) => void store.set(k, v),
+  removeItem: (k: string) => void store.delete(k),
+  clear: () => store.clear(),
+})
+
+// The first-run predicate. The critical pin: the localStorage fast-path cache is
+// PER-BROWSER, so it must only vouch for the account that wrote it — a brand-new
+// second account created in a browser where an earlier account finished onboarding
+// must still be routed to /welcome (the prod bug this fixed: the gate silently
+// skipped for any account after the first).
+describe("needsOnboarding", () => {
+  beforeEach(() => localStorage.clear())
+
+  it("gates a fresh account (no flag, no profession, no cache)", () => {
+    expect(needsOnboarding({ id: "u_new", onboarded: false, profession: null })).toBe(true)
+  })
+
+  it("never gates once the server flag is set", () => {
+    expect(needsOnboarding({ id: "u_a", onboarded: true, profession: null })).toBe(false)
+  })
+
+  it("legacy fallback: a claimed profession vouches for pre-flag accounts", () => {
+    expect(needsOnboarding({ id: "u_pre", onboarded: false, profession: "Engineer" })).toBe(false)
+  })
+
+  it("the cache only vouches for the account that wrote it", () => {
+    localStorage.setItem(STORAGE_KEYS.onboarded, "u_first")
+    expect(needsOnboarding({ id: "u_first", onboarded: false, profession: null })).toBe(false)
+    // The prod bug: a SECOND account in the same browser must still be gated.
+    expect(needsOnboarding({ id: "u_second", onboarded: false, profession: null })).toBe(true)
+  })
+
+  it("a legacy '1' cache value no longer bypasses the gate for anyone", () => {
+    localStorage.setItem(STORAGE_KEYS.onboarded, "1")
+    expect(needsOnboarding({ id: "u_any", onboarded: false, profession: null })).toBe(true)
+  })
+})

--- a/apps/web/src/lib/route-guards.ts
+++ b/apps/web/src/lib/route-guards.ts
@@ -24,16 +24,23 @@ export const requireAuth = async ({ context, location }: GuardArgs) => {
 
 // The ONE first-run predicate — the single source of truth for "does this signed-in
 // user still need /welcome". The server-authoritative flag (syncs across devices,
-// survives a cleared cache) wins; otherwise fall back to the legacy signals so accounts
-// from before the flag are never bounced back to /welcome — a claimed profession, or the
-// per-browser localStorage cache. Both the route gate and the post-login redirect route
-// off THIS, so they can't drift (a simpler onboarded-only check would send returning
-// pre-flag users to /welcome after sign-in).
-export const needsOnboarding = (me: { onboarded?: boolean; profession?: string | null }) => {
+// survives a cleared cache) wins; a claimed profession vouches for pre-flag accounts;
+// and the localStorage fast-path cache counts ONLY when it was written by THIS account
+// (it stores the user id). The cache is per-browser, so an account-agnostic value would
+// silently skip the gate for every account after the first one created in a browser —
+// the exact prod bug this scoping fixed. Legacy "1" values are deliberately no longer
+// honored: any account they'd exempt is un-onboarded and un-activated, which is exactly
+// who /welcome is for (and Skip re-writes the properly-scoped flag in one click).
+// Both the route gate and the post-login redirect route off THIS, so they can't drift.
+export const needsOnboarding = (me: {
+  id?: string
+  onboarded?: boolean
+  profession?: string | null
+}) => {
   if (me.onboarded) return false
   let cached = false
   try {
-    cached = localStorage.getItem(STORAGE_KEYS.onboarded) === "1"
+    cached = !!me.id && localStorage.getItem(STORAGE_KEYS.onboarded) === me.id
   } catch {
     /* private mode — the profession check still gates it */
   }

--- a/apps/web/src/lib/storage-keys.ts
+++ b/apps/web/src/lib/storage-keys.ts
@@ -23,7 +23,9 @@ export const STORAGE_KEYS = {
   // racing a server cookie into several phantom viewers (see lib/guest-id).
   guestId: "derive.guest",
   // Legacy literals (the colon convention predates the dot switch) — kept as-is so a
-  // saved onboarding flag / folder pref survives the rename.
+  // saved folder pref survives the rename. The onboarded value is the USER ID that
+  // finished onboarding (needsOnboarding only honors a match), so a second account in
+  // the same browser is still gated; old "1" values are deliberately not honored.
   onboarded: "derive:onboarded",
   libraryFolders: "derive:show-folders",
   // Dismissal of the home's one-time "set up your team's Brandprint" nudge (owners
@@ -35,4 +37,7 @@ export const STORAGE_KEYS = {
   // The checklist's "shared a link" step: set by the share dialog's copy-link
   // action (per-browser; the server signals cover connect + first publish).
   sharedLink: "derive.shared-link",
+  // Dismissal of the home library's connect-your-agent card (see
+  // pages/library/connect-nudge) — per-browser, one click, permanent.
+  connectNudge: "derive.connect-nudge",
 } as const

--- a/apps/web/src/pages/library/connect-nudge.tsx
+++ b/apps/web/src/pages/library/connect-nudge.tsx
@@ -1,0 +1,119 @@
+import { useQuery } from "@tanstack/react-query"
+import { useState } from "react"
+import { Icon } from "@/components/icons"
+import { ConnectAgent } from "@/components/shared/connect-agent"
+import { AskChip, EXAMPLE_ASKS } from "@/components/shared/example-asks"
+import { Button } from "@/components/ui/button"
+import { useAuth } from "@/ctx"
+import { connectedAgentsQuery, onboardingQuery } from "@/lib/queries"
+import { STORAGE_KEYS } from "@/lib/storage-keys"
+
+// Whether the home's connect-your-agent card should render for this user right now.
+// Shared with the library so the Brandprint nudge can yield (one onboarding surface
+// per screen): while the user hasn't activated, connecting comes first. Ambient by
+// design — errors and missing data just hide the card.
+export function useConnectNudge() {
+  const { me } = useAuth()
+  const [dismissed, setDismissed] = useState(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEYS.connectNudge) === "1"
+    } catch {
+      return true
+    }
+  })
+  // Same read the rail pill uses (react-query dedupes them). Focus refetch matters:
+  // the connect happens in the user's terminal — tabbing back is the moment to look.
+  const { data: ob } = useQuery({
+    ...onboardingQuery(),
+    enabled: !!me && !dismissed,
+    refetchOnWindowFocus: true,
+  })
+  const { data: agents } = useQuery({
+    ...connectedAgentsQuery(),
+    enabled: !!me && !dismissed,
+    refetchOnWindowFocus: true,
+  })
+  const dismiss = () => {
+    setDismissed(true)
+    try {
+      localStorage.setItem(STORAGE_KEYS.connectNudge, "1")
+    } catch {
+      /* private mode — the in-memory dismissal holds this session */
+    }
+  }
+  const agentName = agents?.[0]?.clientName ?? ob?.agent_name ?? null
+  const stage: "connect" | "publish" | null =
+    !me || dismissed || !ob
+      ? null
+      : !ob.agent_connected
+        ? "connect"
+        : ob.published_via_agent
+          ? null
+          : "publish"
+  return { stage, agentName, dismiss }
+}
+
+/**
+ * The home library's activation card — the core loop, on the page people actually
+ * land on. Two live stages, the same signals as /welcome and the rail pill:
+ * no agent yet → the per-agent connect tabs; connected but never published → the
+ * example first asks. Disappears on activation; "Not now" dismisses per-browser
+ * (the rail pill and ⌘K stay as the quiet paths back). Sits above the publish
+ * card and suppresses the Brandprint nudge while visible — one onboarding surface
+ * per screen. The How-Derive-Works guide below is untouched: this card is the
+ * door into the loop, that section explains it.
+ */
+export function ConnectNudge({ nudge }: { nudge: ReturnType<typeof useConnectNudge> }) {
+  const { stage, agentName, dismiss } = nudge
+  if (!stage) return null
+  return (
+    <section
+      data-testid="library-connect-nudge"
+      className="mb-6 flex flex-col gap-3 rounded-lg border bg-card px-5 py-4 shadow-xs"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="flex flex-col gap-1">
+          {stage === "connect" ? (
+            <>
+              <h2 className="font-serif text-lg font-medium tracking-tight text-foreground">
+                Connect your agent.
+              </h2>
+              <p className="text-sm text-pretty text-muted-foreground">
+                Derive works through the agent you already use — it publishes here, you share the
+                link.
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="flex items-center gap-2 text-sm font-medium text-foreground">
+                <Icon name="check" className="text-success" />
+                {agentName ?? "Agent"} connected
+              </p>
+              <h2 className="font-serif text-lg font-medium tracking-tight text-foreground">
+                Now ask it to publish something.
+              </h2>
+            </>
+          )}
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          data-testid="library-connect-nudge-dismiss"
+          className="text-muted-foreground"
+          onClick={dismiss}
+        >
+          Not now
+        </Button>
+      </div>
+      {stage === "connect" ? (
+        <ConnectAgent testidPrefix="home-connect" />
+      ) : (
+        <div className="flex flex-col gap-2">
+          {EXAMPLE_ASKS.map((ask, i) => (
+            <AskChip key={ask} text={ask} testId={`library-ask-${i}`} />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -36,6 +36,7 @@ import { ArtifactRow, byRecency } from "./artifact-row"
 import { BrandprintNudge } from "./brandprint-nudge"
 import { CollectionBar } from "./collection-bar"
 import { CollectionFolders, NewFolderControl } from "./collection-folders"
+import { ConnectNudge, useConnectNudge } from "./connect-nudge"
 import { DisplayMenu } from "./display-menu"
 import { FolderGroups } from "./folder-groups"
 import { FollowingStrip } from "./following-strip"
@@ -386,6 +387,10 @@ function LibraryBody({ view }: { view: LibraryView }) {
   // keeps its own empty state (the workspace may hold plenty you didn't create).
   const emptyHome = homeView && filter.kind === "all" && items.length === 0
 
+  // The activation card's state — read here so the Brandprint nudge can yield to it
+  // (one onboarding surface per screen; connecting an agent comes first).
+  const connectNudge = useConnectNudge()
+
   return (
     <PageShell scrollRef={scrollRef} width="wide">
       {/* The full "Activity" feed, reached from the People tab's Recent-activity peek
@@ -510,6 +515,11 @@ function LibraryBody({ view }: { view: LibraryView }) {
         <FollowingStrip follows={follows} onUnfollow={(kind, target) => unfollow(kind, target)} />
       )}
 
+      {/* The core loop's front door: connect your agent (or make the first ask),
+          live on the page people actually land on. Above the publish card — the
+          agent path leads; hand-publishing stays one row below. */}
+      {homeView && <ConnectNudge nudge={connectNudge} />}
+
       {showPublish && <PublishCard />}
 
       {/* The quiet triage line — one entry point to the /feedback feed, home only. */}
@@ -521,7 +531,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
 
       {/* One-time, dismissible: the owner of a Brandprint-less workspace gets the
           "first on the team" setup nudge here (spec: Onboarding / Timing). */}
-      {homeView && <BrandprintNudge />}
+      {homeView && connectNudge.stage === null && <BrandprintNudge />}
 
       {filter.kind === "collection" ? (
         <>

--- a/apps/web/src/pages/welcome.tsx
+++ b/apps/web/src/pages/welcome.tsx
@@ -4,23 +4,25 @@ import { useEffect, useState } from "react"
 import { api } from "@/api"
 import { Icon } from "@/components/icons"
 import { ConnectAgent } from "@/components/shared/connect-agent"
+import { AskChip, EXAMPLE_ASKS } from "@/components/shared/example-asks"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Button } from "@/components/ui/button"
-import { toast } from "@/components/ui/sonner"
 import { useAuth } from "@/ctx"
 import { connectedAgentsQuery, onboardingQuery } from "@/lib/queries"
 import { STORAGE_KEYS } from "@/lib/storage-keys"
 import { useDocumentTitle } from "@/lib/use-document-title"
 
 // Persist "onboarding finished" server-side (authoritative + cross-device) and cache
-// locally for an instant guard on the very next nav. Fire-and-forget: the flag is
-// one-way, so a dropped write just re-shows /welcome once. The in-memory `me` update
-// happens at the call site (setMe) — that's what keeps the redirect guard from
-// bouncing even when localStorage is unavailable (private mode).
-const persistOnboarded = () => {
+// locally for an instant guard on the very next nav. The cache stores the USER ID —
+// needsOnboarding only honors it for the account that wrote it, so a second account
+// created in this browser is still gated. Fire-and-forget: the flag is one-way, so a
+// dropped write just re-shows /welcome once. The in-memory `me` update happens at the
+// call site (setMe) — that's what keeps the redirect guard from bouncing even when
+// localStorage is unavailable (private mode).
+const persistOnboarded = (userId: string) => {
   api.setOnboarded().catch(() => {})
   try {
-    localStorage.setItem(STORAGE_KEYS.onboarded, "1")
+    localStorage.setItem(STORAGE_KEYS.onboarded, userId)
   } catch {
     /* private mode — setMe carries the in-session guard */
   }
@@ -30,14 +32,6 @@ const persistOnboarded = () => {
 // completing OAuth, the first artifact landing). 2s matches the sync-chip poll —
 // both are single indexed reads a user is actively watching.
 const WATCH_INTERVAL_MS = 2000
-
-// The example first asks — the walkthrough IS these prompts: each teaches what
-// Derive is for in the user's own tool. Copy-to-clipboard chips, not buttons.
-const EXAMPLE_ASKS = [
-  "Publish a one-page summary of what I'm working on to Derive.",
-  "Turn the README into a shareable page on Derive.",
-  "Draft our launch plan as a Derive doc I can get feedback on.",
-]
 
 /**
  * First-run onboarding, slimmed to the one activation moment: connect the agent
@@ -89,9 +83,10 @@ export function Welcome() {
   // Activation IS onboarding: the moment the first artifact exists, the gate is
   // done — even if the user closes the tab from here without clicking an exit.
   const activated = !!first
+  const meId = me?.id
   useEffect(() => {
-    if (activated) persistOnboarded()
-  }, [activated])
+    if (activated && meId) persistOnboarded(meId)
+  }, [activated, meId])
 
   if (!me) return null
   const firstName = (me.name ?? me.username ?? me.email).split(/[@\s]/)[0]
@@ -99,7 +94,7 @@ export function Welcome() {
   // Every exit marks onboarding done — server, storage, AND the in-memory session
   // (setMe), so the guard can't bounce back here even when storage writes fail.
   const leave = (to: "/" | "artifact") => {
-    persistOnboarded()
+    persistOnboarded(me.id)
     setMe({ ...me, onboarded: true })
     if (to === "artifact" && first) {
       nav({ to: "/artifacts/$ref", params: { ref: first.short_id } })
@@ -269,34 +264,5 @@ function WatchRow({ children, testId }: { children: React.ReactNode; testId: str
       </span>
       <span>{children}</span>
     </p>
-  )
-}
-
-// A copyable example ask — chip-shaped, mono-quoted, one tap to clipboard.
-function AskChip({ text, testId }: { text: string; testId: string }) {
-  const [copied, setCopied] = useState(false)
-  const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopied(true)
-      toast.success("Copied — paste it into your agent")
-      setTimeout(() => setCopied(false), 2000)
-    } catch {
-      toast.error("Couldn't copy; select the text and copy it manually")
-    }
-  }
-  return (
-    <button
-      type="button"
-      data-testid={testId}
-      onClick={copy}
-      className="flex items-center justify-between gap-3 rounded-lg border bg-secondary/40 px-4 py-2.5 text-left text-sm text-muted-foreground transition-colors hover:border-foreground/25 hover:text-foreground"
-    >
-      <span className="text-pretty">"{text}"</span>
-      <Icon
-        name={copied ? "check" : "copy"}
-        className={copied ? "shrink-0 text-success" : "shrink-0"}
-      />
-    </button>
   )
 }

--- a/scripts/check-surfaces.mjs
+++ b/scripts/check-surfaces.mjs
@@ -38,6 +38,7 @@ const QUERY_ALLOW = new Set([
   "components/chrome/command-palette.tsx", // renders whatever's cached
   "components/chrome/sync-chip.tsx", // ambient status indicator
   "components/chrome/getting-started.tsx", // ambient checklist pill; hides itself on any failure
+  "pages/library/connect-nudge.tsx", // ambient activation card; hides itself on any failure
   "pages/artifact/artifact-breadcrumb.tsx", // collections/siblings reads degrade to the title (no switcher)
   "pages/artifact/share-dialog.tsx", // reads the warm artifact cache (enabled:false)
   "pages/artifact/header-actions.tsx", // move-menu dropdown, warm read


### PR DESCRIPTION
Follow-up to #483, from signing up fresh on production: the new onboarding never appeared. Two causes, both fixed.

## The gate leak (why /welcome never showed)

`needsOnboarding`'s localStorage fast-path cache was per-browser and account-agnostic — any **second** account created in a browser where an earlier account finished onboarding silently skipped the `/welcome` redirect. Every e2e run uses a fresh browser, so this only reproduced on a real machine with history.

The cache now stores the **user id** and only vouches for the account that wrote it. Legacy `"1"` values are deliberately no longer honored: any account they'd exempt has `onboarded=false` and no claimed profession — un-activated, exactly who `/welcome` is for (and Skip re-writes the properly-scoped flag in one click). Pinned by `route-guards.test.ts`; the second-account case fails against the old logic.

## The front door (the loop, on the page people land on)

The activation loop lived only in `/welcome` and the quiet rail pill. The home library now leads with a **connect-your-agent card** — the same per-agent tabs, driven by the same server signals as the pill (focus-refetch):

- no agent → the connect tabs
- connected but never published → the example first asks
- activated → the card is gone

"Not now" dismisses per-browser; while visible the card suppresses the Brandprint nudge (one onboarding surface per screen). **How Derive works is untouched** — the card is the door into the loop, that section explains it. `AskChip` + the example asks moved to a shared module so `/welcome` and the card can't drift.

## Verification

- `route-guards.test.ts` (5 cases) written first and watched fail on the old cache logic; 178 web tests green.
- Full lint suite + typecheck green.
- Driven in the real app: fresh signup → gated to the new `/welcome` → skip → home leads with the connect card above the publish card, How-it-works below, pill in the rail.