### PR TITLE
feat(web): public /roadmap page framing the living roadmap

### DIFF
--- a/apps/web/src/lib/chrome-routes.ts
+++ b/apps/web/src/lib/chrome-routes.ts
@@ -5,7 +5,13 @@
 // get a rail. The boot script additionally treats a public artifact permalink
 // (/artifacts/*) as "bare": AppShell renders it chrome-light until a session
 // resolves, so a rail silhouette there would only flash away.
-export const CHROMELESS_EXACT: string[] = ["/login", "/reset-password", "/welcome", "/showcase"]
+export const CHROMELESS_EXACT: string[] = [
+  "/login",
+  "/reset-password",
+  "/welcome",
+  "/showcase",
+  "/roadmap",
+]
 export const CHROMELESS_PREFIX: string[] = ["/invite/"]
 
 export const isChromelessPath = (p: string): boolean =>

--- a/apps/web/src/pages/roadmap.tsx
+++ b/apps/web/src/pages/roadmap.tsx
@@ -1,0 +1,62 @@
+import { Link } from "@tanstack/react-router"
+import { Logo } from "@/components/shared/logo"
+import { useDocumentTitle } from "@/lib/use-document-title"
+
+// The public roadmap page. Its body is a Derive artifact (short id 9gqu98hd)
+// embedded chrome-less: the page draws its own frame, the artifact stays the
+// single source of truth, and every republish shows here with no redeploy. The
+// URLs are absolute to derive.to on purpose — this markets the hosted product's
+// own roadmap, not a per-instance page. Rendered chrome-less (see chrome-routes)
+// and forced dark to match the dark-designed artifact regardless of app theme.
+const ROADMAP_ARTIFACT = "https://derive.to/artifacts/derive-roadmap-9gqu98hd"
+const ROADMAP_EMBED = "https://derive.to/v1/embed/derive-roadmap-9gqu98hd?chrome=none"
+
+export function Roadmap() {
+  useDocumentTitle("Roadmap")
+  return (
+    <div className="dark min-h-dvh bg-background text-foreground">
+      <div className="mx-auto max-w-5xl px-6 py-5">
+        <header className="flex items-center gap-2.5 border-b border-border/70 pb-5">
+          <Link to="/" className="flex items-center gap-2.5">
+            <Logo size={19} />
+            <span className="text-sm font-semibold tracking-tight">Derive</span>
+          </Link>
+          <a
+            href={ROADMAP_ARTIFACT}
+            target="_blank"
+            rel="noopener"
+            className="ml-auto text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Open on Derive ↗
+          </a>
+        </header>
+
+        <div className="pt-10 pb-7">
+          <p className="font-mono text-2xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+            Living document
+          </p>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl">
+            Where Derive is going
+          </h1>
+          <p className="mt-3 max-w-prose text-muted-foreground">
+            This roadmap is a Derive artifact, maintained by an agent through review rounds. It
+            updates here the moment a new version is published, so the page never goes stale.
+          </p>
+        </div>
+
+        {/* A definite height (not flex-1) so the iframe's height resolves cleanly through
+            the embed's nested frame; the living roadmap scrolls inside its frame. */}
+        <div className="h-[82vh] min-h-[34rem] overflow-hidden rounded-xl border border-border">
+          <iframe src={ROADMAP_EMBED} title="Derive Roadmap" className="size-full" />
+        </div>
+
+        <footer className="flex flex-wrap items-center justify-between gap-2 pt-5 font-mono text-2xs uppercase tracking-wider text-muted-foreground">
+          <span>Derive · publish, review, and own your AI artifacts</span>
+          <a href="https://derive.to" className="transition-colors hover:text-foreground">
+            derive.to
+          </a>
+        </footer>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as ShowcaseRouteImport } from './routes/showcase'
 import { Route as SharedRouteImport } from './routes/shared'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as SearchRouteImport } from './routes/search'
+import { Route as RoadmapRouteImport } from './routes/roadmap'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as PeopleRouteImport } from './routes/people'
 import { Route as NewRouteImport } from './routes/new'
@@ -61,6 +62,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const SearchRoute = SearchRouteImport.update({
   id: '/search',
   path: '/search',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const RoadmapRoute = RoadmapRouteImport.update({
+  id: '/roadmap',
+  path: '/roadmap',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ResetPasswordRoute = ResetPasswordRouteImport.update({
@@ -159,6 +165,7 @@ export interface FileRoutesByFullPath {
   '/new': typeof NewRoute
   '/people': typeof PeopleRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/roadmap': typeof RoadmapRoute
   '/search': typeof SearchRoute
   '/settings': typeof SettingsRouteWithChildren
   '/shared': typeof SharedRoute
@@ -184,6 +191,7 @@ export interface FileRoutesByTo {
   '/new': typeof NewRoute
   '/people': typeof PeopleRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/roadmap': typeof RoadmapRoute
   '/search': typeof SearchRoute
   '/shared': typeof SharedRoute
   '/showcase': typeof ShowcaseRoute
@@ -209,6 +217,7 @@ export interface FileRoutesById {
   '/new': typeof NewRoute
   '/people': typeof PeopleRoute
   '/reset-password': typeof ResetPasswordRoute
+  '/roadmap': typeof RoadmapRoute
   '/search': typeof SearchRoute
   '/settings': typeof SettingsRouteWithChildren
   '/shared': typeof SharedRoute
@@ -236,6 +245,7 @@ export interface FileRouteTypes {
     | '/new'
     | '/people'
     | '/reset-password'
+    | '/roadmap'
     | '/search'
     | '/settings'
     | '/shared'
@@ -261,6 +271,7 @@ export interface FileRouteTypes {
     | '/new'
     | '/people'
     | '/reset-password'
+    | '/roadmap'
     | '/search'
     | '/shared'
     | '/showcase'
@@ -285,6 +296,7 @@ export interface FileRouteTypes {
     | '/new'
     | '/people'
     | '/reset-password'
+    | '/roadmap'
     | '/search'
     | '/settings'
     | '/shared'
@@ -311,6 +323,7 @@ export interface RootRouteChildren {
   NewRoute: typeof NewRoute
   PeopleRoute: typeof PeopleRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
+  RoadmapRoute: typeof RoadmapRoute
   SearchRoute: typeof SearchRoute
   SettingsRoute: typeof SettingsRouteWithChildren
   SharedRoute: typeof SharedRoute
@@ -367,6 +380,13 @@ declare module '@tanstack/react-router' {
       path: '/search'
       fullPath: '/search'
       preLoaderRoute: typeof SearchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/roadmap': {
+      id: '/roadmap'
+      path: '/roadmap'
+      fullPath: '/roadmap'
+      preLoaderRoute: typeof RoadmapRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/reset-password': {
@@ -515,6 +535,7 @@ const rootRouteChildren: RootRouteChildren = {
   NewRoute: NewRoute,
   PeopleRoute: PeopleRoute,
   ResetPasswordRoute: ResetPasswordRoute,
+  RoadmapRoute: RoadmapRoute,
   SearchRoute: SearchRoute,
   SettingsRoute: SettingsRouteWithChildren,
   SharedRoute: SharedRoute,

--- a/apps/web/src/routes/roadmap.tsx
+++ b/apps/web/src/routes/roadmap.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Roadmap } from "../pages/roadmap"
+
+// /roadmap — the public living-roadmap page. No auth guard (anyone can read it),
+// and chrome-less (no nav rail; see lib/chrome-routes). Deliberately not linked
+// from the nav or login yet — reachable directly at /roadmap.
+export const Route = createFileRoute("/roadmap")({
+  component: Roadmap,
+})


### PR DESCRIPTION
## What

A public, chrome-less **/roadmap** page that frames the Derive roadmap artifact (`9gqu98hd`) as a live embed. It's the first real proof of the embed-as-distribution idea, on Derive's own surface.

- **Framed embed, always current.** The page iframes `/v1/embed/9gqu98hd?chrome=none` (the bare variant from #490), so it draws its own frame and the artifact stays the single source of truth. Every republish of the roadmap shows here with **no redeploy** — that's the living-document story, demonstrated.
- **Public + chrome-less.** No auth guard (anyone can read it) and no nav rail (`/roadmap` joins `CHROMELESS_EXACT`). Forced-dark to match the dark-designed artifact regardless of app theme; real Derive mark, an Open-on-Derive link, and a definite-height frame the roadmap scrolls inside.
- **Tokens only.** No hardcoded colors or font sizes (passes `lint:tokens`); no new interactive controls needing testids.

## Deliberately not linked yet

Per the ask, **/roadmap is not linked from the nav or login** — it's reachable directly at the path. Wiring an entry point is a follow-up.

## Verification

Real browser, desktop + mobile (the artifact's own responsive layout kicks in inside the frame). Typecheck (tsgo), biome, and all 14 precommit lints clean. Two gotchas found and fixed while building: a `flex-1` container gave the iframe an indefinite height (percentage-height couldn't resolve through the embed's nested frame) → switched to a definite height; and `loading="lazy"` was deferring the nested iframe → removed.

## Files

- `apps/web/src/pages/roadmap.tsx` — the page
- `apps/web/src/routes/roadmap.tsx` — the public route
- `apps/web/src/lib/chrome-routes.ts` — `/roadmap` → chrome-less
- `apps/web/src/routeTree.gen.ts` — regenerated by the TanStack plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)