### PR TITLE
MCP: thin tools, thick skills + consolidate 15 tools to 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The agent acts at the role you grant: publish access publishes directly; a lower
 
 Derive is built for the loop where an agent publishes and a human (or another agent) reviews. `derive init` scaffolds the on-ramp straight into your project: a Claude Code skill (`.claude/skills/derive`) plus a project MCP config (`.mcp.json`), so an agent can publish, read comments, revise, and resolve with no extra wiring.
 
-The five MCP tools: `list_artifacts` (find), `read` (content), `catch_up` (what changed, plus open feedback and version history), `comment` (leave, reply, resolve), and `publish` (save a revision). `publish` goes live if your role can publish; otherwise, or with `for_review: true`, it files a proposal a human approves.
+The core MCP tools: `find` (search + browse artifacts and contexts), `read` (content), `catch_up` (what changed, open feedback, version history, and — with no id — your work queue), `comment` (leave, reply, resolve), `publish` (save a revision), and `stage` (upload a big document or an image/font out-of-band). `publish` goes live if your role can publish; otherwise, or with `for_review: true`, it files a proposal a human approves.
 
 ## How it works
 

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -25,23 +25,25 @@
 // instructions carry only a one-line index of them. The mcp-surface-budget test guards
 // the thinness.
 //
-// One tool per intent — WORKSPACES (list_workspaces), FIND
-// (list_artifacts), READ content (read), GREP (search), CATCH UP on state/feedback/
-// history (catch_up), COMMENT (comment), WRITE (publish), the WORK QUEUE
-// (check_requests: what teammates asked THIS agent to do — the one intent that is
-// about the agent rather than a document, which is why it earns a slot instead of a
-// parameter on catch_up), SET UP the Brandprint (setup_brandprint: scaffold the
-// workspace's brand-profile slot so it can be authored over MCP — workspace
-// configuration, not a document write, so like check_requests it's a distinct intent
-// that doesn't reduce to a parameter on another tool), and ASK a workspace context
-// (list_contexts + ask: query the live data agents a workspace hosts, acting for the
-// connection's human — the one intent where Derive routes a question to a runner).
-// Variation lives in parameters, never a new tool: `since_version`/`to_version` turn catch_up into a
-// diff, `reply_to`/`set_state` fold reply+resolve into comment, `for_review`/role
-// turn publish into a human-reviewed proposal, and omitting `short_id` turns
-// `search` from grep-one-artifact into grep-the-workspace. A new capability is a
-// parameter on an existing tool, not a new tool — every extra tool costs the agent
-// a slot to understand and choose between.
+// TEN tools, one per intent — WORKSPACES (list_workspaces), FIND (find: BROWSE the
+// library, GREP one artifact, or SEARCH the workspace — plus the askable contexts,
+// all discriminated by argument), READ content (read), CATCH UP on state/feedback/
+// history AND pull the WORK QUEUE (catch_up: with a short_id it's one artifact's
+// delta; with none it's the @mention inbox teammates handed this agent — the ask-agent
+// and Rework buttons — so the queue is a mode of catch_up, not its own slot), COMMENT
+// (comment), WRITE (publish: also the home for the Brandprint profile — publishing to
+// derive://brandprint/profile scaffolds the slot on first write, so brand setup is a
+// publish target, not a separate tool), STAGE out-of-band uploads (stage: target:'doc'
+// for a whole big document/bundle, target:'asset' for an image/font — one tool, two
+// upload URLs), SAVE working state (checkpoint), and USE a workspace context (use:
+// query the live data agents a workspace hosts, acting for the connection's human — the
+// one intent where Derive routes a question to a runner).
+// Variation lives in parameters, never a new tool: `since_version`/`to_version` turn
+// catch_up into a diff and omitting `short_id` turns it into the work queue,
+// `reply_to`/`set_state` fold reply+resolve into comment, `for_review`/role turn publish
+// into a human-reviewed proposal, and `find` collapses browse/grep/search/contexts onto
+// `query`/`short_id`/`tag`. A new capability is a parameter on an existing tool, not a
+// new tool — every extra tool costs the agent a slot to understand and choose between.
 
 import {
   AGENT_INBOX_PAGE,
@@ -115,7 +117,7 @@ import {
   searchMatcher,
   searchReport,
   searchWorkspace,
-  workspaceSearchReport,
+  toSearchHits,
 } from "./lib/search"
 import { enqueueSlackReviewRequestedDm } from "./lib/slack-dm"
 import { computeTagSuggestions } from "./lib/tag-suggestions"
@@ -129,6 +131,7 @@ const text = (s: string) => ({ content: [{ type: "text" as const, text: s }] })
 // publish: past `ms`, resolve with the fallback and move on.
 const withTimeout = <T>(p: Promise<T>, ms: number, fallback: T): Promise<T> =>
   Promise.race([p, new Promise<T>((resolve) => setTimeout(() => resolve(fallback), ms))])
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 const json = (v: unknown) => text(JSON.stringify(v, null, 2))
 // An actionable error the model can recover from (per the MCP spec, isError text is
 // fed back to the agent so it self-corrects), rather than an opaque failure.
@@ -141,6 +144,24 @@ const err = (s: string) => ({
 // a blind dump: ~9k tokens leaves room to read on, small enough that most docs still
 // arrive whole. Measured on the formatted body, not the raw source.
 const FULL_DOC_MAX = 30_000
+
+// publish guardrails — reject inline payloads that belong out-of-band, BEFORE writing,
+// with an error naming the `stage` mode to use. A single base64 data: URI past this is a
+// binary pasted through the tool call — it should be an asset (stage target:'asset').
+const MAX_INLINE_DATA_URI_BYTES = 32 * 1024
+// Total inline `content` (or summed `files`) past this is a whole big document that
+// should be curled out-of-band (stage target:'doc') instead of chunked through context.
+const MAX_INLINE_CONTENT_BYTES = 64 * 1024
+// The decoded byte size of the LARGEST single base64 data: URI in a string (0 if none) —
+// base64 encodes 3 bytes per 4 chars, so decoded ≈ payload_chars * 3/4.
+const largestInlineDataUriBytes = (s: string): number => {
+  let max = 0
+  for (const m of s.matchAll(/data:[\w/+.-]+;base64,([A-Za-z0-9+/=]+)/g)) {
+    const bytes = Math.floor(((m[1] ?? "").length * 3) / 4)
+    if (bytes > max) max = bytes
+  }
+  return max
+}
 
 // Cap on landmark regions in a headless-page map: a card grid can have thousands of
 // top-level sections/articles, and the map (built to AVOID a wall of text) must not
@@ -204,7 +225,14 @@ const toBase64 = (bytes: Uint8Array): string => {
 // out-of-range start (a `from` past the end has no valid window — the caller errors
 // with the real line count rather than returning an empty "999-5" window).
 const parseLineRange = (spec: string, total: number): { from: number; to: number } | null => {
-  const m = spec.trim().match(/^(\d+)(?:-(\d*))?$/)
+  // Forgiving: agents sometimes wrap the range in stray quotes (lines:'"40-120"') or
+  // whitespace — strip surrounding quotes/space before matching, so "40-120" and
+  // '"40-120"' parse identically.
+  const cleaned = spec
+    .trim()
+    .replace(/^['"]+|['"]+$/g, "")
+    .trim()
+  const m = cleaned.match(/^(\d+)(?:-(\d*))?$/)
   if (!m) return null
   const from = Number(m[1])
   if (from < 1 || from > total) return null
@@ -375,11 +403,11 @@ async function buildServer(
         `act — comment to give or resolve feedback, publish a revision, respond to review. This one ` +
         `login reaches every workspace in your grant: call list_workspaces to see them, then pass a ` +
         `workspace id or name as the "workspace" argument to act in another (read, catch_up, comment, ` +
-        `publish, list_artifacts); read/catch_up/comment also find a short_id in any of them ` +
+        `publish, find); read/catch_up/comment also find a short_id in any of them ` +
         `automatically.\n\n` +
         `CORE SKILLS carry the working procedure for each intent — read the matching one (a resource, ` +
         `or read("derive://skills/<name>")) before you act:\n${skillsIndex}\n\n` +
-        `Workspace skills (team procedures) exist too: list_artifacts skills:true, then read.` +
+        `Workspace skills (team procedures) exist too: find skills:true, then read.` +
         brandprintInstructions(bpSources.length, bpProfile) +
         pendingRequestsPointer(pendingRequests.length),
     },
@@ -609,9 +637,9 @@ async function buildServer(
         (await ctx.meta.getArtifactMember(a.id, agent.id))
       if (!ok) return null
     }
-    // A taken-down artifact serves NO content, mirroring the web /raw 410: read, search,
+    // A taken-down artifact serves NO content, mirroring the web /raw 410: read, find,
     // comment, and publish all resolve through here, so gating it once covers every
-    // one-artifact tool. It stays visible as a tombstone in list_artifacts (metadata
+    // one-artifact tool. It stays visible as a tombstone in find's browse rows (metadata
     // only). Checked AFTER the reach/membership gates so it never confirms a removed
     // short_id to someone who couldn't have reached it anyway (they still get notFound).
     if (a.removed_at) return { error: `"${shortId}" was taken down and is no longer available.` }
@@ -619,7 +647,7 @@ async function buildServer(
   }
   const notFound = (shortId: string) =>
     err(
-      `No artifact "${shortId}" you can reach in any of your workspaces. Call list_artifacts (optionally with a workspace) to see what's there.`,
+      `No artifact "${shortId}" you can reach in any of your workspaces. Call find (optionally with a workspace) to see what's there.`,
     )
 
   // The `workspace` argument shared by every workspace-scoped tool.
@@ -630,88 +658,68 @@ async function buildServer(
       "Workspace to act in — its id or name from list_workspaces. Omit for your default workspace; read/catch_up/comment also find a short_id in ANY of your workspaces automatically.",
     )
 
-  // WORK QUEUE — what teammates asked this agent to do -------------------------
+  // WORK QUEUE — what teammates asked this agent to do (a MODE of catch_up: no short_id).
   // The pull inbox behind the ask-agent and Rework buttons: a teammate @mentions this
   // agent in a comment and the request waits here until some session of the agent reads
-  // and acks it. Registered on every connection — a human grant simply has an empty
-  // queue — so the tool surface never differs by auth kind.
-  server.registerTool(
-    "check_requests",
-    {
-      description:
-        "Your work queue: pending requests teammates handed you by @mentioning you in a comment (the ask-agent and Rework buttons land here) — each names the artifact, the comment thread, and what to do. Handle a request on its artifact, then call this again with ack:[id,…] to clear what you finished; an unknown or already-acked id is skipped, never an error, and unacked requests stay queued for your next session. Pass `wait` (seconds, max 50) to long-poll for new work when the queue is empty, chaining calls to react in seconds instead of polling on a cadence. For how to work and ack a request, read derive://skills/loop.",
-      inputSchema: {
-        ack: z
-          .array(z.string())
-          .optional()
-          .describe(
-            "Request ids you have HANDLED — acknowledges them off the queue. Ack after the work lands (a publish or a reply), not on read; an unknown or already-acked id is skipped, never an error.",
-          ),
-        wait: z
-          .number()
-          .int()
-          .min(1)
-          .max(50)
-          .optional()
-          .describe(
-            "Long-poll: when nothing is queued, block up to this many seconds for a new request to land before returning. Returns immediately when work is already waiting.",
-          ),
-      },
-    },
-    async ({ ack, wait }) => {
-      // The queue this request already read at connect (a fresh server per request, so
-      // it is this call's snapshot — and empty without a re-read for a grant that has
-      // no inbox at all).
-      const queue = pendingRequests
-      // `acked` counts what actually LEFT the queue, so acking is idempotent: the store
-      // matches a row whether or not it was already acknowledged, so an unknown or
-      // repeated id would otherwise inflate the count. Ack against the snapshot, and
-      // answer from it.
-      const handled = new Set((ack ?? []).filter((id) => queue.some((m) => m.id === id)))
-      let acked = 0
-      for (const id of handled) if (await ctx.meta.ackAgentMention(agent.id, id)) acked++
-      let pending = queue.filter((m) => !handled.has(m.id))
-
-      // Long-poll: only a registered agent has an inbox to wait on. When nothing is
-      // pending, subscribe to this agent's channel, then RE-READ fresh (a request may
-      // have landed since connect, or during the wait) — the same check-then-wait gap
-      // close catch_up uses. The event is only a wake signal; we always answer from a
-      // fresh store read, so a missed or raced wake is never a wrong answer.
-      if (registered && wait && pending.length === 0 && ctx.bus.waitFor) {
-        const release = new AbortController()
-        const woke = ctx.bus
-          .waitFor(`u:${agent.id}`, ["request.created"], wait * 1000, release.signal)
-          .catch(() => null)
-        const fresh = await ctx.meta.listPendingAgentMentions(agent.id, AGENT_INBOX_PAGE)
-        if (fresh.length) {
-          release.abort()
-          await woke
-        } else {
-          await woke
-        }
-        pending = fresh.length
-          ? fresh
-          : await ctx.meta.listPendingAgentMentions(agent.id, AGENT_INBOX_PAGE)
-      }
+  // and acks it. catch_up with no short_id returns it; only a REGISTERED workspace agent
+  // has an inbox (an OAuth grant's id is oauth:<client>, which no @mention can name), so a
+  // connection without one gets an explicit note instead of a bare empty list.
+  const workQueue = async (ack?: string[], wait?: number) => {
+    // No inbox at all: say so, rather than returning [] the agent might read as "no work".
+    if (!registered)
       return json({
-        acked,
-        pending: pending.map((m) => ({
-          id: m.id,
-          artifact: m.artifact_short_id,
-          thread: m.thread_id,
-          author: m.author,
-          request: m.body,
-          created_at: m.created_at,
-        })),
+        acked: 0,
+        pending: [],
+        note: "This connection has no inbox — @mentions can't name an OAuth grant, so there's no work queue here (a registered workspace agent has one). Pass a short_id to catch up on an artifact instead.",
       })
-    },
-  )
+    // The queue this request already read at connect (a fresh server per request, so it
+    // is this call's snapshot). `acked` counts what actually LEFT the queue, so acking is
+    // idempotent: the store matches a row whether or not it was already acknowledged, so
+    // an unknown or repeated id would otherwise inflate the count.
+    const queue = pendingRequests
+    const handled = new Set((ack ?? []).filter((id) => queue.some((m) => m.id === id)))
+    let acked = 0
+    for (const id of handled) if (await ctx.meta.ackAgentMention(agent.id, id)) acked++
+    let pending = queue.filter((m) => !handled.has(m.id))
+
+    // Long-poll: when nothing is pending, subscribe to this agent's channel, then RE-READ
+    // fresh (a request may have landed since connect, or during the wait) — the same
+    // check-then-wait gap close catch_up uses. The event is only a wake signal; we always
+    // answer from a fresh store read, so a missed or raced wake is never a wrong answer.
+    if (wait && pending.length === 0 && ctx.bus.waitFor) {
+      const release = new AbortController()
+      const woke = ctx.bus
+        .waitFor(`u:${agent.id}`, ["request.created"], wait * 1000, release.signal)
+        .catch(() => null)
+      const fresh = await ctx.meta.listPendingAgentMentions(agent.id, AGENT_INBOX_PAGE)
+      if (fresh.length) {
+        release.abort()
+        await woke
+      } else {
+        await woke
+      }
+      pending = fresh.length
+        ? fresh
+        : await ctx.meta.listPendingAgentMentions(agent.id, AGENT_INBOX_PAGE)
+    }
+    return json({
+      acked,
+      pending: pending.map((m) => ({
+        id: m.id,
+        artifact: m.artifact_short_id,
+        thread: m.thread_id,
+        author: m.author,
+        request: m.body,
+        created_at: m.created_at,
+      })),
+    })
+  }
 
   server.registerTool(
     "list_workspaces",
     {
       description:
-        "List every workspace THIS grant can act in — id, name, your role there, and which is your default (the set you chose when you connected: all your workspaces, or a subset). Pass a workspace's id or name as the `workspace` argument to list_artifacts / read / catch_up / comment / publish to act there. No reconnect — read/catch_up/comment even find a short_id across these workspaces automatically.",
+        "List every workspace THIS grant can act in — id, name, your role there, and which is your default (the set you chose when you connected: all your workspaces, or a subset). Pass a workspace's id or name as the `workspace` argument to find / read / catch_up / comment / publish to act there. No reconnect — read/catch_up/comment even find a short_id across these workspaces automatically.",
       inputSchema: {},
     },
     async () => {
@@ -723,49 +731,190 @@ async function buildServer(
     },
   )
 
-  // FIND ----------------------------------------------------------------------
+  // FIND — one tool over BROWSE (list_artifacts) + GREP/SEARCH (search) + the askable
+  // CONTEXTS (list_contexts), discriminated by argument. The mode is decided by what's
+  // passed: `short_id` ⇒ grep within it; `query` alone ⇒ search the workspace; neither ⇒
+  // browse. Result rows are typed (artifact | match | context) so a mixed listing is
+  // unambiguous. -----------------------------------------------------------------------
+  const CONTEXTS_NEED_HUMAN =
+    "Contexts (askable live data agents) are hidden here: this connection has no signed-in user. Reconnect with an OAuth login to see and use them."
+  // Askable contexts as typed `find` rows — INVARIANT (A): sourced ONLY from
+  // askableContexts (the per-human canUserAskContext gate), so a roster-gated context this
+  // user may not ask never appears; (B): with no acting human this returns [] and the
+  // caller adds an explicit note rather than erroring. Each row carries its own open
+  // sessions and the steer to reach it with `use`. (askableContexts/runnerOnline are
+  // defined further down; referenced here from a handler that runs at call-time.)
+  const contextFindRows = async (org: string, matches?: (name: string) => boolean) => {
+    if (!actingFor) return []
+    const human = actingFor
+    const rows = await askableContexts(org, human.id)
+    const picked = matches ? rows.filter(({ x }) => matches(x.name)) : rows
+    return Promise.all(
+      picked.map(async ({ x, manifest }) => {
+        const open = (await ctx.meta.listSessions(x.id, { askerId: human.id, limit: 10 }))
+          .filter((s) => s.state !== "closed")
+          .map((s) => ({ id: s.id, state: s.state, updated_at: s.updated_at ?? s.created_at }))
+        return {
+          type: "context" as const,
+          id: x.id,
+          name: x.name,
+          online: runnerOnline(x),
+          manifest: manifest ? { short_id: manifest.short_id, title: manifest.title } : null,
+          your_open_sessions: open,
+          note: "Ask it on your user's behalf with `use` (a question or a commission).",
+        }
+      }),
+    )
+  }
   server.registerTool(
-    "list_artifacts",
+    "find",
     {
       description:
-        "List the artifacts (docs, plans, sites, skills) in a workspace — short id, title, kind, is_skill, current version, access (workspace_access/link_role/listed). Defaults to your current workspace; pass `workspace` (id or name from list_workspaces) to list another one. Pass skills:true to list only skills (reusable agent procedure). Pass `tag` to filter to one browse tag. Includes your own unlisted publishes — out of the shared library, but you always find your work. Start here to find what to work on, then catch_up or read it.",
+        "Find things in Derive — the MODE is decided by what you pass. Pass `short_id` + `query` to GREP within one artifact: matching lines with line numbers (in:'source'|'text', context lines, a past `version`), so you can then read a `lines` range or edit that spot. Pass `query` ALONE to SEARCH the whole workspace — artifacts ranked by relevance with a snippet each, so you find WHICH doc has something before opening it; this ALSO surfaces any askable context whose name matches. Pass NEITHER to BROWSE the library: every artifact (short id, title, kind, is_skill, version, access, tags — skills:true or a `tag` narrows it) PLUS the askable contexts. Rows are typed (artifact | match | context); a context row is reached with `use`, never read/opened. Includes your own unlisted work. For the browse→work rhythm, read derive://skills/loop.",
       inputSchema: {
-        query: z.string().optional().describe("Optional title search filter."),
+        query: z
+          .string()
+          .optional()
+          .describe(
+            "With `short_id`: the literal text to grep within it (metacharacters are not special). Alone (no short_id): the workspace content search. Omit both to browse.",
+          ),
+        short_id: z
+          .string()
+          .optional()
+          .describe("Grep WITHIN this one artifact (needs `query`). Omit to browse or search."),
         tag: z
           .string()
           .optional()
-          .describe("Only artifacts carrying this browse tag (case-insensitive)."),
+          .describe("Browse only: artifacts carrying this browse tag (case-insensitive)."),
         skills: z
           .boolean()
           .optional()
-          .describe("Only list skills (bundles with a SKILL.md — reusable agent procedure)."),
+          .describe(
+            "Browse only: list only skills (bundles with a SKILL.md — reusable agent procedure).",
+          ),
+        case_sensitive: z.boolean().optional().describe("Grep/search: default false."),
+        in: z
+          .enum(["source", "text"])
+          .optional()
+          .describe(
+            "Grep/search: source (default) the exact stored bytes (the positions you'd edit); text the visible text a reader sees (HTML tags stripped).",
+          ),
+        context: z
+          .number()
+          .optional()
+          .describe(
+            "Grep/search: lines of surrounding context around each match (default 0, max 5).",
+          ),
+        max_matches: z
+          .number()
+          .optional()
+          .describe("Grep/search: cap on matches per artifact (default 40, max 200)."),
+        version: z
+          .number()
+          .optional()
+          .describe("Grep within a past version (short_id mode). Defaults to the current one."),
         workspace: wsArg,
       },
     },
-    async ({ query, tag, skills, workspace }) => {
+    async ({
+      query,
+      short_id,
+      tag,
+      skills,
+      case_sensitive,
+      in: scope,
+      context,
+      max_matches,
+      version,
+      workspace,
+    }) => {
+      // MODE 1 — GREP WITHIN ONE ARTIFACT. Byte-for-byte the former search(short_id):
+      // matching lines, line numbers, in:'source'|'text', context lines, a chosen version.
+      if (short_id) {
+        if (!query) return err("`query` is required to grep within an artifact (short_id).")
+        const re = searchMatcher(query, case_sensitive ?? false)
+        const ctxLines = Math.min(Math.max(context ?? 0, 0), 5)
+        const cap = Math.min(Math.max(max_matches ?? 40, 1), 200)
+        const where = scope ?? "source"
+        const r = await reach(short_id, workspace)
+        if (r && "error" in r) return err(r.error)
+        if (!r) return notFound(short_id)
+        const a = r.a
+        const n = version ?? a.current_version
+        if (n < 1 || n > a.current_version)
+          return err(`No version ${n} for "${short_id}" — it has versions 1..${a.current_version}.`)
+        const v = await ctx.meta.getVersion(a.id, n)
+        if (!v) return err(`Version ${n} of "${short_id}" is unavailable.`)
+        const { groups, total, note } = await searchArtifactVersion(
+          ctx,
+          v,
+          re,
+          where,
+          ctxLines,
+          cap,
+        )
+        return text(searchReport(short_id, query, where, total, cap, groups, note))
+      }
+
+      // MODE 2 — SEARCH THE WORKSPACE (ranked artifacts + a snippet each), plus any askable
+      // context whose NAME matches the query. Typed rows: {type:"match"} + {type:"context"}.
+      if (query) {
+        const t = await resolveWs(workspace)
+        if ("error" in t) return err(t.error)
+        const re = searchMatcher(query, case_sensitive ?? false)
+        const ctxLines = Math.min(Math.max(context ?? 0, 0), 5)
+        const cap = Math.min(Math.max(max_matches ?? 40, 1), 200)
+        const where = scope ?? "source"
+        const { results, note } = await searchWorkspace(ctx, {
+          orgId: t.org,
+          viewerId: actingFor?.id ?? agent.id,
+          query,
+          re,
+          where,
+          ctxLines,
+          cap,
+        })
+        const matchRows = toSearchHits(results, query).map((h) => ({
+          type: "match" as const,
+          ...h,
+        }))
+        const q = query.toLowerCase()
+        const contextRows = await contextFindRows(t.org, (name) => name.toLowerCase().includes(q))
+        return json({
+          workspace: t.org,
+          query,
+          where,
+          count: matchRows.length + contextRows.length,
+          results: [...matchRows, ...contextRows],
+          ...(note ? { note } : {}),
+          ...(actingFor ? {} : { contexts_note: CONTEXTS_NEED_HUMAN }),
+        })
+      }
+
+      // MODE 3 — BROWSE the library: list_artifacts rows (skills:/tag facets), plus every
+      // askable context. A tag filter resolves to an id set first (mirrors the HTTP ?tag=
+      // path); viewerId keeps private rows scoped to the agent's human (mirrors `reach`).
       const t = await resolveWs(workspace)
       if ("error" in t) return err(t.error)
-      // A tag filter resolves to an id set first (mirrors the HTTP ?tag= path), which
-      // listArtifacts then scopes to the workspace + re-applies visibility over.
       const ids = tag ? await ctx.meta.artifactIdsByTag(tag.trim().toLowerCase()) : undefined
-      if (ids && ids.length === 0) return json({ workspace: t.org, count: 0, artifacts: [] })
-      // viewerId keeps private rows scoped to the agent's human (mirrors `reach`) —
-      // the owner row written at publish is what lets the agent always find its
-      // own drafts while a teammate's private work stays invisible.
-      const arts = await ctx.meta.listArtifacts({
-        orgId: t.org,
-        q: query,
-        ids,
-        viewerId: actingFor?.id ?? agent.id,
-      })
-      // Skill-ness isn't a store-level filter (it's the denormalized content type), so
-      // narrow here — a title `query` still composes with it.
+      const arts =
+        ids && ids.length === 0
+          ? []
+          : await ctx.meta.listArtifacts({ orgId: t.org, ids, viewerId: actingFor?.id ?? agent.id })
+      // Skill-ness isn't a store-level filter (it's the denormalized content type).
       const rows = skills ? arts.filter((a) => a.current_content_type === SKILL_CONTENT_TYPE) : arts
       const tagMap = await ctx.meta.tagsForArtifacts(rows.map((a) => a.id))
+      const artifactRows = rows.map((a) => ({
+        type: "artifact" as const,
+        ...summarizeArtifact(a),
+        tags: tagMap[a.id] ?? [],
+      }))
+      const contextRows = await contextFindRows(t.org)
       return json({
         workspace: t.org,
-        count: rows.length,
-        artifacts: rows.map((a) => ({ ...summarizeArtifact(a), tags: tagMap[a.id] ?? [] })),
+        count: artifactRows.length + contextRows.length,
+        results: [...artifactRows, ...contextRows],
+        ...(actingFor ? {} : { contexts_note: CONTEXTS_NEED_HUMAN }),
       })
     },
   )
@@ -806,11 +955,20 @@ async function buildServer(
           .describe(
             'SEE the published page instead of reading its text — what a viewer actually sees, catching visual breakage (a failed font, a broken layout) no text read can. "top": the 1200x630 crop (fastest, what an og:image unfurl shows). "full": the whole page, fullPage screenshot — catches below-the-fold breakage "top" misses. "marked": "full" again with the region map\'s @N refs drawn on it — pairs with a no-heading page\'s region map so what you SEE lines up with what you READ. All three computed a few seconds after each publish; pass alone (optionally with `version`).',
           ),
+        wait: z
+          .number()
+          .int()
+          .min(1)
+          .max(30)
+          .optional()
+          .describe(
+            "With `render`: when the screenshot isn't computed yet (a publish is seconds old), block up to this many seconds (max 30) for it to land instead of returning the not-ready message. Returns at once when it's already ready or has failed.",
+          ),
         version: z.number().optional().describe("Defaults to the current version."),
         workspace: wsArg,
       },
     },
-    async ({ short_id, section, format, version, lines, render, workspace }) => {
+    async ({ short_id, section, format, version, lines, render, wait, workspace }) => {
       const fmt: ReadFormat = format ?? "markdown"
       // `derive://brandprint/*` URIs are readable through `read`, not only as MCP
       // resources — the exact strings the server instructions name, reachable by every
@@ -843,7 +1001,7 @@ async function buildServer(
         if (seg === "profile") {
           if (!(bpProfile?.state === "live" && profileArt))
             return err(
-              "This workspace has no live brand profile yet. Read derive://brandprint/reference and derive://brandprint/template, then run setup_brandprint and publish the profile with for_review:true.",
+              "This workspace has no live brand profile yet. Read derive://brandprint/reference and derive://brandprint/template, build the profile, then publish it to derive://brandprint/profile (an Admin's first publish there scaffolds the slot; it lands as a proposal a human approves).",
             )
           const pv = await ctx.meta.getVersion(profileArt.id, profileArt.current_version)
           const body = pv ? await ctx.sourceText(pv) : null
@@ -877,19 +1035,19 @@ async function buildServer(
           return err(
             "`render` is a view of the whole version — pass it alone (with `version` for history).",
           )
-        const variant =
+        const pick = (ver: VersionRecord) =>
           render === "top"
-            ? { key: v.preview_key, status: v.preview_status, error: v.preview_error }
+            ? { key: ver.preview_key, status: ver.preview_status, error: ver.preview_error }
             : render === "full"
               ? {
-                  key: v.preview_full_key,
-                  status: v.preview_full_status,
-                  error: v.preview_full_error,
+                  key: ver.preview_full_key,
+                  status: ver.preview_full_status,
+                  error: ver.preview_full_error,
                 }
               : {
-                  key: v.preview_marked_key,
-                  status: v.preview_marked_status,
-                  error: v.preview_marked_error,
+                  key: ver.preview_marked_key,
+                  status: ver.preview_marked_status,
+                  error: ver.preview_marked_error,
                 }
         const label =
           render === "top"
@@ -897,6 +1055,23 @@ async function buildServer(
             : render === "full"
               ? "the whole page"
               : "the whole page, with the region map's @N refs drawn on it"
+        let variant = pick(v)
+        // Long-poll: the screenshot lands a few seconds after a publish. When it's neither
+        // ready nor failed and the caller passed `wait`, block up to that many seconds
+        // (max 30), re-reading the version, before returning the not-ready message — a
+        // bounded retry loop so the agent gets the render in one call after a fresh push.
+        if (wait && !(variant.status === "ready" && variant.key) && variant.status !== "failed") {
+          const deadline = Date.now() + Math.min(Math.max(wait, 0), 30) * 1000
+          while (
+            Date.now() < deadline &&
+            !(variant.status === "ready" && variant.key) &&
+            variant.status !== "failed"
+          ) {
+            await sleep(Math.min(1500, Math.max(0, deadline - Date.now())))
+            const refreshed = await ctx.meta.getVersion(a.id, n)
+            if (refreshed) variant = pick(refreshed)
+          }
+        }
         if (variant.status === "ready" && variant.key) {
           const png = await ctx.blobs.get(variant.key)
           if (png) {
@@ -924,7 +1099,7 @@ async function buildServer(
             `The render:${render} of "${short_id}" v${n} failed${variant.error ? ` (${variant.error})` : ""} — the page may still be fine; open ${url} to check, or republish to retry.`,
           )
         return err(
-          `The render:${render} of "${short_id}" v${n} isn't ready yet — screenshots are computed a few seconds after publish. Try again shortly.`,
+          `The render:${render} of "${short_id}" v${n} isn't ready yet — screenshots are computed a few seconds after publish. Try again shortly, or pass \`wait\` (seconds, max 30) to block for it.`,
         )
       }
       const manifest = await manifestOf(ctx, v)
@@ -1263,88 +1438,7 @@ async function buildServer(
     },
   )
 
-  // SEARCH — grep within one artifact, so an agent finds a spot without a full read
-  server.registerTool(
-    "search",
-    {
-      description:
-        "Find text within ONE artifact (pass short_id) or across a WORKSPACE (omit short_id) — ripgrep-style matching lines with line numbers, so you can then `read` a narrow `lines` range (in the format the result names) or `edit` that spot. A bundle is searched across all its text pages, grouped by page; a workspace search returns the artifacts you can see, ranked by relevance and grouped by artifact, so you find WHICH doc has something before opening it. Searches the exact source by default (in:'text' searches the visible text instead). The query is matched literally (metacharacters are not special).",
-      inputSchema: {
-        short_id: z
-          .string()
-          .optional()
-          .describe(
-            "The artifact's short id, e.g. nk0dsral. Omit to search across the workspace instead of one artifact.",
-          ),
-        query: z.string().describe("The literal text to find (metacharacters are not special)."),
-        case_sensitive: z.boolean().optional().describe("Default false."),
-        in: z
-          .enum(["source", "text"])
-          .optional()
-          .describe(
-            "source (default): the exact stored bytes — the positions you'd `edit`. text: the visible text a reader sees (HTML tags stripped).",
-          ),
-        context: z
-          .number()
-          .optional()
-          .describe("Lines of surrounding context to show around each match (default 0, max 5)."),
-        max_matches: z
-          .number()
-          .optional()
-          .describe(
-            "Cap on matches returned per artifact (default 40, max 200). Applies to each artifact scanned in workspace mode too.",
-          ),
-        version: z
-          .number()
-          .optional()
-          .describe("Defaults to the current version. Ignored in workspace mode (always current)."),
-        workspace: wsArg,
-      },
-    },
-    async ({
-      short_id,
-      query,
-      case_sensitive,
-      in: scope,
-      context,
-      max_matches,
-      version,
-      workspace,
-    }) => {
-      if (!query) return err("`query` is required.")
-      const re = searchMatcher(query, case_sensitive ?? false)
-      const ctxLines = Math.min(Math.max(context ?? 0, 0), 5)
-      const cap = Math.min(Math.max(max_matches ?? 40, 1), 200)
-      const where = scope ?? "source"
-
-      if (!short_id) {
-        const t = await resolveWs(workspace)
-        if ("error" in t) return err(t.error)
-        const { results, note } = await searchWorkspace(ctx, {
-          orgId: t.org,
-          viewerId: actingFor?.id ?? agent.id,
-          query,
-          re,
-          where,
-          ctxLines,
-          cap,
-        })
-        return text(workspaceSearchReport(query, where, results, note))
-      }
-
-      const r = await reach(short_id, workspace)
-      if (r && "error" in r) return err(r.error)
-      if (!r) return notFound(short_id)
-      const a = r.a
-      const n = version ?? a.current_version
-      if (n < 1 || n > a.current_version)
-        return err(`No version ${n} for "${short_id}" — it has versions 1..${a.current_version}.`)
-      const v = await ctx.meta.getVersion(a.id, n)
-      if (!v) return err(`Version ${n} of "${short_id}" is unavailable.`)
-      const { groups, total, note } = await searchArtifactVersion(ctx, v, re, where, ctxLines, cap)
-      return text(searchReport(short_id, query, where, total, cap, groups, note))
-    },
-  )
+  // (GREP + workspace SEARCH now live in `find` — same engine, discriminated by short_id.)
 
   // ORGANIZE — ONE tool for the library's findability metadata: tags + collections,
   // read + write. No short_ids ⇒ the workspace overview (vocabulary + collections).
@@ -1555,9 +1649,18 @@ async function buildServer(
     "catch_up",
     {
       description:
-        "START HERE on an artifact: its state in one call — a one-line summary, the versions that landed since `since_version`, which pages changed, the open (and outdated) comment threads, the review round you're waiting on, and the full version history. Pass `comments` (open/addressed/resolved/outdated) for that filtered thread list instead — your feedback to-do queue. Pass `response_format='detailed'` (optionally with `since_version`/`to_version`) for a line-by-line diff of the two versions' readable Markdown form. WAITING ON SOMETHING? Pass `wait` (seconds, max 50) to block until the human sends back / approves / comments / publishes a new version, then return the fresh state — chain waits instead of sleeping between polls. For the diff, review states, and the wait loop, read derive://skills/loop.",
+        "With a `short_id`: START HERE on an artifact — its state in one call: a one-line summary, the versions that landed since `since_version`, which pages changed, the open (and outdated) comment threads, the review round you're waiting on, and the full version history. Pass `comments` (open/addressed/resolved/outdated) for that filtered thread list instead — your feedback to-do queue. Pass `response_format='detailed'` (optionally with `since_version`/`to_version`) for a line-by-line diff of the two versions' readable Markdown form. WITHOUT a short_id: your WORK QUEUE — pending requests teammates handed you by @mentioning you in a comment (the ask-agent and Rework buttons); pass `ack:[id,…]` to clear the ones you finished. WAITING ON SOMETHING? Pass `wait` (seconds, max 50) to block until the human acts (or, in queue mode, until new work lands), then return the fresh state — chain waits instead of sleeping between polls. For the diff, review states, working a request, and the wait loop, read derive://skills/loop.",
       inputSchema: {
-        short_id: z.string(),
+        short_id: z
+          .string()
+          .optional()
+          .describe("The artifact to catch up on. Omit it to pull your work queue instead."),
+        ack: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Work-queue mode (no short_id): request ids you have HANDLED — acknowledges them off the queue. Ack after the work lands (a publish or a reply), not on read; an unknown or already-acked id is skipped, never an error.",
+          ),
         since_version: z
           .number()
           .optional()
@@ -1590,7 +1693,19 @@ async function buildServer(
         workspace: wsArg,
       },
     },
-    async ({ short_id, since_version, to_version, comments, response_format, wait, workspace }) => {
+    async ({
+      short_id,
+      ack,
+      since_version,
+      to_version,
+      comments,
+      response_format,
+      wait,
+      workspace,
+    }) => {
+      // No short_id ⇒ the WORK QUEUE mode (absorbs the former check_requests): the
+      // @mention inbox, its ack, and its own request.created long-poll.
+      if (!short_id) return workQueue(ack, wait)
       const r = await reach(short_id, workspace)
       if (r && "error" in r) return err(r.error)
       if (!r) return notFound(short_id)
@@ -1873,97 +1988,99 @@ async function buildServer(
     },
   )
 
-  // STAGE ASSETS — a tokenless upload URL for binaries -------------------------
-  // The blessed images path is POST /v1/assets with raw bytes, but a hosted-OAuth
-  // connection's credential lives inside this transport — the agent's shell has no
-  // bearer to curl with, so that path 403s on exactly the agents told to use it.
-  // This tool moves the capability out to the shell: mint a short-lived signed
-  // upload URL over MCP, spend it with curl. The bytes never enter the context.
-  server.registerTool(
-    "stage_asset",
-    {
-      description:
-        "Upload an image or font to embed in a document — do this BEFORE publish whenever a doc references a binary. Mint a SHORT-LIVED, no-bearer upload URL for raster images (PNG/JPEG/GIF/WebP) and web fonts (WOFF/WOFF2, max 25MB), curl the file's RAW bytes to it from your shell (`curl -sS --data-binary @shot.png <upload_url>`), and reference the returned permanent `url` (in an <img src>, CSS url(), or markdown) — or its `asset:<hash>` `ref` in a publish `files` map. The URL is reusable ~15 min, so stage a batch with one mint. NEVER base64 an image through a tool call — a pasted image is already a file on disk, so upload that. For the whole document (not a binary it embeds), use publish or stage_publish. Read derive://skills/publishing.",
-      inputSchema: { workspace: wsArg },
-    },
-    async ({ workspace }) => {
-      const t = await resolveWs(workspace)
-      if ("error" in t) return err(t.error)
-      // Same bar as POST /v1/assets itself: staging is a publish-side capability.
-      if (!roleAllows(t.role, "publish"))
-        return err("Your role in this workspace can't stage assets (publishing required).")
-      const secret = ctx.deps.encryptionKey
-      if (!secret)
-        return err(
-          "This server has no signing secret configured, so it can't mint upload URLs. POST the bytes to /v1/assets with a bearer token instead (DERIVE_TOKEN, or `derive login`).",
-        )
-      // Bind the token to the granting user so the spend side can re-check live
-      // membership — revoking or demoting them kills outstanding URLs mid-TTL.
-      // An ownerless legacy agent has no user to bind; it mints an unbound token.
-      const expiresAt = Date.now() + UPLOAD_TOKEN_TTL_MS
-      const tok = await signUploadToken(secret, t.org, ownerId ?? "", expiresAt)
-      const uploadUrl = `${ctx.deps.baseUrl.replace(/\/$/, "")}/v1/assets/t/${tok}`
-      return json({
-        upload_url: uploadUrl,
-        workspace: t.org,
-        expires_in_minutes: Math.round(UPLOAD_TOKEN_TTL_MS / 60_000),
-        max_bytes: MAX_ASSET_BYTES,
-        accepts: ["image/png", "image/jpeg", "image/gif", "image/webp", "font/woff", "font/woff2"],
-        how: `curl -sS -X POST --data-binary @<file> "${uploadUrl}" → {url, ref, ...}. Paste \`url\` into content, or use \`ref\` ("asset:<hash>") as a bundle files value. Repeat for each file until expiry.`,
-      })
-    },
-  )
-
-  // STAGE PUBLISH — a tokenless publish URL for large content ------------------
-  // The publish tool carries content INLINE (`content`/`files`), which is model
-  // output — capped by the per-response token ceiling and forced into slow,
-  // expensive multi-turn chunking once a file is bigger than a page or two. This
-  // mints a short-lived signed URL the shell curls the file's bytes to, so a big
-  // designed HTML page or a whole bundle publishes in one shot, zero bytes
-  // through the model's context. Same shell-out shape as stage_asset; scoped
+  // STAGE — one tool, two out-of-band upload URLs, each spent with curl so bytes never
+  // enter the model's context. target:'asset' = the former stage_asset (a binary a doc
+  // embeds); target:'doc' = the former stage_publish (a whole big document/bundle). The
+  // blessed paths are POST /v1/assets and POST /v1/artifacts, but a hosted-OAuth
+  // connection's credential lives inside this transport — the shell has no bearer to curl
+  // with — so these mint short-lived signed URLs that need none. The doc path is scoped
   // tighter because publishing writes artifacts (see lib/publish-token.ts).
   server.registerTool(
-    "stage_publish",
+    "stage",
     {
       description:
-        "Upload a whole document that is too big to inline — use this INSTEAD of publish when a designed HTML page or bundle is more than ~a page (inlining it through publish is slow, costly, and can fail). Mint a SHORT-LIVED, no-bearer upload URL, then curl the file (or a zipped dir, which publishes as a bundle) to it from your shell — zero tokens through context. Omit short_id to CREATE, pass short_id to REVISE that exact target. For a small doc or a partial change use publish (with `edits`) instead; for an image or font the doc embeds, use stage_asset. Read derive://skills/publishing for the curl recipes.",
+        "Upload out-of-band — mint a SHORT-LIVED, no-bearer upload URL, then curl the file's bytes to it from your shell (zero tokens through context). target:'doc' for a whole big document or bundle more than ~a page (returns a publish URL — curl the file, or a zipped dir which becomes a bundle; omit short_id to CREATE, pass it to REVISE that exact target). target:'asset' for an image or font a document EMBEDS (returns a permanent url + an asset:<hash> ref for an <img src>/CSS url()/markdown or a publish `files` map; raster images and WOFF/WOFF2 only, max 25MB). Use publish for inline content and surgical edits. NEVER base64 a binary through a tool call — a pasted image is already a file on disk. Read derive://skills/publishing.",
       inputSchema: {
-        workspace: wsArg,
+        target: z
+          .enum(["doc", "asset"])
+          .describe(
+            "doc: a whole document/bundle too big to inline (returns a publish URL). asset: an image or font a doc embeds (returns a permanent asset url + ref).",
+          ),
         short_id: z
           .string()
           .optional()
-          .describe("Revise THIS artifact; omit to create a new one. The token is scoped to it."),
+          .describe(
+            "target:'doc' ONLY — revise THIS artifact; omit to create a new one (the token is scoped to it). Rejected with target:'asset' (an asset isn't versioned).",
+          ),
+        workspace: wsArg,
       },
     },
-    async ({ workspace, short_id }) => {
+    async ({ target, short_id, workspace }) => {
       const t = await resolveWs(workspace)
       if ("error" in t) return err(t.error)
-      // A publish is attributed to a person and its URL is re-checked against
-      // their live rights — so it needs a known granting user. A static agent
-      // token (dk_agt_/DERIVE_TOKEN) has none, but it also isn't trapped in this
-      // transport: it can POST to /v1/artifacts with that bearer directly.
+
+      if (target === "asset") {
+        // A binary an embedding doc references — the former stage_asset path, verbatim.
+        if (short_id)
+          return err("`short_id` applies only to target:'doc'. An asset isn't versioned — omit it.")
+        // Same bar as POST /v1/assets itself: staging is a publish-side capability.
+        if (!roleAllows(t.role, "publish"))
+          return err("Your role in this workspace can't stage assets (publishing required).")
+        const secret = ctx.deps.encryptionKey
+        if (!secret)
+          return err(
+            "This server has no signing secret configured, so it can't mint upload URLs. POST the bytes to /v1/assets with a bearer token instead (DERIVE_TOKEN, or `derive login`).",
+          )
+        // Bind the token to the granting user so the spend side can re-check live
+        // membership — revoking or demoting them kills outstanding URLs mid-TTL.
+        // An ownerless legacy agent has no user to bind; it mints an unbound token.
+        const expiresAt = Date.now() + UPLOAD_TOKEN_TTL_MS
+        const tok = await signUploadToken(secret, t.org, ownerId ?? "", expiresAt)
+        const uploadUrl = `${ctx.deps.baseUrl.replace(/\/$/, "")}/v1/assets/t/${tok}`
+        return json({
+          target: "asset",
+          upload_url: uploadUrl,
+          workspace: t.org,
+          expires_in_minutes: Math.round(UPLOAD_TOKEN_TTL_MS / 60_000),
+          max_bytes: MAX_ASSET_BYTES,
+          accepts: [
+            "image/png",
+            "image/jpeg",
+            "image/gif",
+            "image/webp",
+            "font/woff",
+            "font/woff2",
+          ],
+          how: `curl -sS -X POST --data-binary @<file> "${uploadUrl}" → {url, ref, ...}. Paste \`url\` into content, or use \`ref\` ("asset:<hash>") as a bundle files value. Repeat for each file until expiry.`,
+        })
+      }
+
+      // target === "doc" — a whole document/bundle, the former stage_publish path, verbatim.
+      // A publish is attributed to a person and its URL is re-checked against their live
+      // rights — so it needs a known granting user. A static agent token (dk_agt_/
+      // DERIVE_TOKEN) has none, but it also isn't trapped in this transport: it can POST
+      // to /v1/artifacts with that bearer directly.
       if (!ownerId)
         return err(
-          "stage_publish needs a signed-in user to attribute the publish to. With a static agent token, POST to /v1/artifacts with that token in the Authorization header instead.",
+          "stage target:'doc' needs a signed-in user to attribute the publish to. With a static agent token, POST to /v1/artifacts with that token in the Authorization header instead.",
         )
       const secret = ctx.deps.encryptionKey
       if (!secret)
         return err(
           "This server has no signing secret configured, so it can't mint publish URLs. POST to /v1/artifacts with a bearer token instead (DERIVE_TOKEN, or `derive login`).",
         )
-      // The workspace the token is minted for. For a REVISE it must be the
-      // artifact's ACTUAL workspace — reach() may auto-roam a bare short_id to
-      // another workspace in the grant, and the spend-side org guard would 403 a
-      // token minted against the default one.
+      // The workspace the token is minted for. For a REVISE it must be the artifact's
+      // ACTUAL workspace — reach() may auto-roam a bare short_id to another workspace in
+      // the grant, and the spend-side org guard would 403 a token minted against default.
       let org = t.org
       if (short_id) {
         const reached = await reach(short_id, workspace)
         if (reached && "error" in reached) return err(reached.error)
         if (!reached) return notFound(short_id)
         org = reached.org
-        // Revising needs artifact-level publish STANDING (share + seat), the same
-        // right the spend-side re-checks — not the workspace seat role, which on a
-        // private artifact grants nothing. Fail at mint for a clear message.
+        // Revising needs artifact-level publish STANDING (share + seat), the same right
+        // the spend-side re-checks — not the workspace seat role, which on a private
+        // artifact grants nothing. Fail at mint for a clear message.
         if (!(await ctx.authorizeUserStanding(ownerId, "publish", reached.a)))
           return err("You don't have permission to publish a new version of that artifact.")
       } else if (!roleAllows(t.role, "publish")) {
@@ -1971,13 +2088,14 @@ async function buildServer(
         return err("Your role in this workspace can't publish (publishing required).")
       }
       const expiresAt = Date.now() + PUBLISH_TOKEN_TTL_MS
-      const target = short_id ?? PUBLISH_TARGET_CREATE
-      const tok = await signPublishToken(secret, org, ownerId, target, expiresAt)
+      const targetName = short_id ?? PUBLISH_TARGET_CREATE
+      const tok = await signPublishToken(secret, org, ownerId, targetName, expiresAt)
       const base = ctx.deps.baseUrl.replace(/\/$/, "")
       const uploadUrl = short_id
         ? `${base}/v1/artifacts/${short_id}/versions/t/${tok}`
         : `${base}/v1/artifacts/t/${tok}`
       return json({
+        target: "doc",
         upload_url: uploadUrl,
         workspace: org,
         mode: short_id ? `revise ${short_id}` : "create",
@@ -1988,24 +2106,101 @@ async function buildServer(
     },
   )
 
+  // Resolve derive://brandprint/profile to the workspace's brand-profile artifact,
+  // scaffolding it (conventions collection + "Brand profile" placeholder + settings
+  // pointer) on first use. This is the former setup_brandprint, folded in so the brand
+  // profile is a publish TARGET rather than a separate tool. INVARIANT (critical safety):
+  // the scaffold's WRITES fire ONLY when the caller holds `manage` (Owner/Admin); a
+  // non-manage caller for whom nothing is set up yet gets an actionable error naming an
+  // Admin, and NO write happens. Reusing an already-set-up profile needs no manage (a
+  // normal for_review revision). Body copied verbatim from setup_brandprint.
+  const resolveBrandprintProfileTarget = async (
+    targetOrg: string,
+    role: Role,
+    uid: string,
+  ): Promise<{ profileShortId: string } | { error: string }> => {
+    const settings = await ctx.meta.getOrgSettings(targetOrg)
+    const bp = settings.brandprint
+    // Reuse an in-tenant profile pointer if one exists — no scaffold, so no manage gate.
+    let profileShortId = bp?.profileId
+    if (profileShortId) {
+      const art = await ctx.meta.getByShortId(profileShortId)
+      if (!(art && art.org_id === targetOrg)) profileShortId = undefined
+    }
+    if (profileShortId) return { profileShortId }
+
+    // Nothing set up yet ⇒ SCAFFOLD, which writes. Owner/Admin only — the gate is BEFORE
+    // any create/publish, so a non-manage caller leaves the workspace untouched.
+    if (!roleAllows(role, "manage"))
+      return {
+        error:
+          "This workspace has no Brandprint profile yet, and only an Admin/Owner can set one up. Ask an Admin to publish to derive://brandprint/profile once (that scaffolds it); after that anyone with publish rights can propose revisions.",
+      }
+    // Reuse an in-tenant collection pointer; otherwise create the conventions collection
+    // (workspace-open so teammates read the docs + the reveal).
+    let collectionId = bp?.collectionId
+    if (collectionId) {
+      const col = await ctx.meta.getCollection(collectionId)
+      if (!col || col.org_id !== targetOrg) collectionId = undefined
+    }
+    if (!collectionId) {
+      const col = await ctx.meta.createCollection({
+        id: newId("col"),
+        org_id: targetOrg,
+        title: "Brandprint",
+        created_by: uid,
+        workspace_access: "member",
+      })
+      await ctx.meta.setCollectionMember({
+        id: newId("cm"),
+        collection_id: col.id,
+        user_id: uid,
+        role: "owner",
+      })
+      collectionId = col.id
+    }
+    // Publish the placeholder (v1 stub) into the collection. Deliberately UNstamped: this
+    // auto-scaffolded placeholder is not the user's "first agent publish" — stamping 'mcp'
+    // here would flip the onboarding signal (and welcome celebration) on an empty stub.
+    const { artifact } = await publishVersion(ctx.meta, ctx.blobs, {
+      bytes: new TextEncoder().encode(PROFILE_PLACEHOLDER_HTML),
+      filename: "Brand profile.html",
+      isBundle: false,
+      title: "Brand profile",
+      message: "Brand profile placeholder — your agent fills this in.",
+      author: agent.name,
+      authorId: uid,
+      orgId: targetOrg,
+      workspaceAccess: "member",
+      linkRole: "none",
+      listed: "none",
+    })
+    await ctx.meta.addCollectionItem(collectionId, artifact.id)
+    await ctx.meta.setOrgSettings(targetOrg, {
+      ...settings,
+      brandprint: { collectionId, profileId: artifact.short_id },
+    })
+    return { profileShortId: artifact.short_id }
+  }
+
   // WRITE — publish live, or file a proposal for review -----------------------
   server.registerTool(
     "publish",
     {
       description:
-        "Publish a document: pass `short_id` to UPDATE an existing one, omit it to CREATE a new one (`title` required). Choose ONE payload by what you're changing. DEFAULT to `edits` for any change to an existing doc — it is the safe, precise option: exact find/replace against the stored source, so read format:'html' FIRST or it won't match, and it fails unless each search string hits exactly once (add surrounding text to make it unique). Use `content` to write or fully replace a single file, or `files` for a multi-page bundle. Do NOT inline anything past ~a page or any image/font — use stage_publish (a whole big doc/bundle) or stage_asset (an image/font) instead. Publishes go LIVE at your role; pass for_review:true to file a PROPOSAL a human approves instead (nothing changes until they do). Pass `addresses` (thread ids from catch_up) to resolve the feedback this revision answers. Read derive://skills/publishing before bundles, edits, or assets.",
+        "Publish a document: pass `short_id` to UPDATE an existing one, omit it to CREATE a new one (`title` required). Choose ONE payload by what you're changing. DEFAULT to `edits` for any change to an existing doc — it is the safe, precise option: exact find/replace against the stored source, so read format:'html' FIRST or it won't match, and it fails unless each search string hits exactly once (add surrounding text to make it unique). Use `content` to write or fully replace a single file, or `files` for a multi-page bundle. Do NOT inline anything past ~a page or any image/font — use stage (target:'doc' for a whole big doc/bundle, target:'asset' for an image/font) instead; oversized inline payloads are rejected. Publishes go LIVE at your role; pass for_review:true to file a PROPOSAL a human approves instead (nothing changes until they do). Pass `addresses` (thread ids from catch_up) to resolve the feedback this revision answers. As a short_id you may pass derive://brandprint/profile to file this workspace's brand profile (an Admin's first publish there scaffolds the slot). Read derive://skills/publishing before bundles, edits, or assets.",
       inputSchema: {
         content: z
           .string()
           .optional()
           .describe(
-            "The complete content for a SINGLE-FILE artifact (HTML or Markdown). Use this OR `files`, not both. Embed images and fonts via a stage_asset upload URL (never a base64 data: URI here), and push a large document via stage_publish rather than inlining it — see derive://skills/publishing.",
+            "The complete content for a SINGLE-FILE artifact (HTML or Markdown). Use this OR `files`, not both. Embed images and fonts via a stage target:'asset' upload URL (never a base64 data: URI here), and push a large document via stage target:'doc' rather than inlining it — see derive://skills/publishing.",
           ),
         files: z
           .record(z.string(), z.string())
           .optional()
           .describe(
-            'A MULTI-PAGE bundle as a map of path → content — the whole site. Each value is a text page (plain string), a base64 data: URI for a small inline binary, or — PREFERRED for real images — an "asset:<hash>" handle from stage_asset. The root index.html (else the shallowest .html) becomes the entry page; a plain republish REPLACES the bundle, so include every page and asset (or use `merge`). See derive://skills/publishing.',
+            "A MULTI-PAGE bundle as a map of path → content — the whole site. Each value is a text page (plain string), a base64 data: URI for a small inline binary, or — PREFERRED for real images — an \"asset:<hash>\" handle from stage target:'asset'. The root index.html (else the shallowest .html) becomes the entry page; a plain republish REPLACES the bundle, so include every page and asset (or use `merge`). See derive://skills/publishing.",
           ),
         title: z
           .string()
@@ -2129,6 +2324,71 @@ async function buildServer(
       base_version,
     }) => {
       let content = contentIn
+      const BP = "derive://brandprint/"
+      // The brand profile is never published LIVE — its reveal/revision is always a
+      // human-approved proposal. Also its exemption from the total-inline cap below (it has
+      // no out-of-band path to its URI). Computed from the RAW target, before resolution.
+      const isProfileTarget = short_id === `${BP}profile`
+
+      // GUARDRAILS — reject inline payloads that belong out-of-band, BEFORE any write or
+      // scaffold, naming the `stage` mode to use. (a) A single base64 data: URI past ~32KB
+      // is a binary pasted through the call — stage it as an asset. (b) Total inline
+      // content/files past ~64KB is a whole big document — curl it via stage target:'doc'.
+      // `edits` publishes carry neither content nor files, so they never trip these; the
+      // brand profile is exempt from the total-size cap but still may not smuggle an
+      // oversized binary inline.
+      const inlineStrings: string[] = []
+      if (typeof contentIn === "string") inlineStrings.push(contentIn)
+      if (files) inlineStrings.push(...Object.values(files))
+      if (inlineStrings.length) {
+        const biggestDataUri = Math.max(0, ...inlineStrings.map(largestInlineDataUriBytes))
+        if (biggestDataUri > MAX_INLINE_DATA_URI_BYTES)
+          return err(
+            `An inline base64 data: URI is ~${Math.round(biggestDataUri / 1024)}KB — too big to carry through a tool call. Upload the binary with stage target:'asset' and reference the returned url/ref instead (a pasted image is already a file on disk).`,
+          )
+        const totalBytes = inlineStrings.reduce((n, s) => n + new TextEncoder().encode(s).length, 0)
+        if (!isProfileTarget && totalBytes > MAX_INLINE_CONTENT_BYTES)
+          return err(
+            `This inline payload is ~${Math.round(totalBytes / 1024)}KB — past the ~${Math.round(
+              MAX_INLINE_CONTENT_BYTES / 1024,
+            )}KB inline ceiling. Push the whole document/bundle with stage target:'doc' (curl the file, or a zipped dir for a bundle) instead of inlining it.`,
+          )
+      }
+
+      // Resolve a derive:// target — publish accepts the same URI strings `read` does. The
+      // only WRITEABLE one is the brand profile; the static build guide and core skills are
+      // read-only, and any other derive:// string is rejected rather than silently treated
+      // as a short_id. The profile's reveal is always a proposal (profileForReview).
+      let profileForReview = false
+      if (short_id?.startsWith("derive://")) {
+        if (isProfileTarget) {
+          const t = await resolveWs(workspace)
+          if ("error" in t) return text(t.error)
+          const uid = actingFor?.id ?? ownerId
+          if (!uid)
+            return err(
+              "Publishing the brand profile needs a signed-in user to attribute it to. Connect with an OAuth agent grant rather than a static agent token.",
+            )
+          const resolved = await resolveBrandprintProfileTarget(t.org, t.role, uid)
+          if ("error" in resolved) return err(resolved.error)
+          short_id = resolved.profileShortId
+          profileForReview = true
+        } else if (short_id.startsWith(BP)) {
+          const seg = short_id.slice(BP.length)
+          if (seg === "reference" || seg === "template")
+            return err(
+              `${short_id} is a read-only build guide — you can't publish to it. Build the profile and publish it to derive://brandprint/profile instead.`,
+            )
+          // derive://brandprint/<short_id> — a source doc; strip to the bare short_id.
+          short_id = seg
+        } else if (short_id.startsWith("derive://skills/")) {
+          return err("Core skills are read-only — you can't publish to a derive://skills/ URI.")
+        } else {
+          return err(
+            `Can't publish to "${short_id}" — the only writeable derive:// target is derive://brandprint/profile.`,
+          )
+        }
+      }
       // Revise an existing artifact wherever it lives (reach roams to its
       // workspace, within the grant); create a new one in the targeted (or
       // default) workspace. The acting role is re-capped to that workspace, so
@@ -2197,9 +2457,10 @@ async function buildServer(
       }
 
       // Direct publish is gated on the agent's role (Creator/Admin). A commenter-level
-      // grant — or anyone asking for_review — is routed to a human-reviewed proposal,
-      // so a low-privilege agent still can't push live content.
-      const review = for_review === true || !roleAllows(actRole, "publish")
+      // grant — or anyone asking for_review, or a publish to the brand profile (whose
+      // reveal is always human-approved) — is routed to a human-reviewed proposal, so a
+      // low-privilege agent still can't push live content.
+      const review = for_review === true || profileForReview || !roleAllows(actRole, "publish")
       if (review) {
         if (!roleAllows(actRole, "propose"))
           return text(
@@ -2709,23 +2970,22 @@ async function buildServer(
     },
   )
 
-  // ASK A CONTEXT — query a workspace's live data agents ------------------------
-  // Contexts are askable agent setups (a registered agent wired to a manifest,
-  // answering through an owner-run runner). These two tools are the agent-side
-  // ask surface, acting FOR the connection's on-behalf human: the human's own
-  // ask-grant (membership + ask_policy/roster, re-checked per call via
-  // canUserAskContext) is the ONLY gate, so an agent can ask exactly what its
-  // human can ask, and nothing more. Registered on every connection like
-  // check_requests (the tool surface never differs by auth kind); a connection
-  // with no known human is refused at call time instead. Management (create/
-  // rewire/delete) deliberately has no MCP path.
+  // USE A CONTEXT — query a workspace's live data agents ------------------------
+  // Contexts are askable agent setups (a registered agent wired to a manifest, answering
+  // through an owner-run runner). `use` is the agent-side surface, acting FOR the
+  // connection's on-behalf human: the human's own ask-grant (membership + ask_policy/
+  // roster, re-checked per call via canUserAskContext) is the ONLY gate, so an agent can
+  // reach exactly what its human can, and nothing more. Discovery is `find` (contexts ride
+  // the browse/search results); a connection with no known human is refused at call time.
+  // Management (create/rewire/delete) deliberately has no MCP path. (askableContexts /
+  // runnerOnline defined here are ALSO used by find's context rows above.)
 
   // The console's liveness window: a runner is "online" while its last queue
   // poll (stamped at most once a minute) is within this.
   const RUNNER_ONLINE_MS = 90_000
   const NO_HUMAN =
-    "Asking opens a session on a human's behalf, and this connection has no acting human. " +
-    "Reconnect with an OAuth login (or a token registered by a user) to ask."
+    "Using a context opens a session on a human's behalf, and this connection has no acting human. " +
+    "Reconnect with an OAuth login (or a token registered by a user) to use one."
 
   // The contexts `userId` may ask in `org`, each with its manifest (identity +
   // the current version a new session pins). One listContexts + one batched
@@ -2754,68 +3014,24 @@ async function buildServer(
       ? `${s.slice(0, max)}\n\n…[truncated ${s.length - max} of ${s.length} chars — full transcript in the console: ${consoleUrl}]`
       : s
 
-  server.registerTool(
-    "list_contexts",
-    {
-      description:
-        "List the CONTEXTS you may ask in a workspace — live data agents a workspace owner wired " +
-        "up, each answering against its own data and tools. Returns id, name, whether the runner " +
-        "is online, its manifest doc, and your own still-open sessions to resume with ask. Asking " +
-        "happens on your user's behalf and is granted per context, so this is exactly what your " +
-        "user may ask. Then call ask with a context's id or name; see derive://skills/contexts.",
-      inputSchema: { workspace: wsArg },
-    },
-    async ({ workspace }) => {
-      if (!actingFor) return err(NO_HUMAN)
-      const t = await resolveWs(workspace)
-      if ("error" in t) return err(t.error)
-      const rows = await askableContexts(t.org, actingFor.id)
-      // The caller's own open sessions — the resume points ask can pick up. One
-      // small read per context (a workspace holds a handful), not worth a batch
-      // port; closed sessions dropped (nothing to resume), newest 10 overall.
-      const sessions: { id: string; context: string; state: string; updated_at: string }[] = []
-      for (const { x } of rows) {
-        for (const s of await ctx.meta.listSessions(x.id, { askerId: actingFor.id, limit: 10 })) {
-          if (s.state === "closed") continue
-          sessions.push({
-            id: s.id,
-            context: x.name,
-            state: s.state,
-            updated_at: s.updated_at ?? s.created_at,
-          })
-        }
-      }
-      sessions.sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1))
-      return json({
-        workspace: t.org,
-        count: rows.length,
-        contexts: rows.map(({ x, manifest }) => ({
-          id: x.id,
-          name: x.name,
-          online: runnerOnline(x),
-          manifest: manifest ? { short_id: manifest.short_id, title: manifest.title } : null,
-        })),
-        your_open_sessions: sessions.slice(0, 10),
-      })
-    },
-  )
+  // (Listing the askable contexts now lives in `find` — they ride the browse/search rows.)
 
   server.registerTool(
-    "ask",
+    "use",
     {
       description:
-        "Ask a context (a live data agent from list_contexts) a question ON YOUR USER'S BEHALF " +
-        "(rate-limited), or resume/follow up an existing session. OPEN: `context` (id or name) + " +
-        "`question`. FOLLOW UP: `session_id` + `question`. CHECK/RESUME: `session_id` alone. The " +
-        "call waits up to `wait` seconds (default 25) for the answer; real runs often take " +
-        "minutes, so a still-open response is NORMAL, not an error — re-call with the returned " +
+        "Use a context (a live data agent — discover them with find) ON YOUR USER'S BEHALF " +
+        "(rate-limited): ask it a question or hand it a commission — one session. OPEN: `context` " +
+        "(id or name) + `question`. FOLLOW UP: `session_id` + `question`. CHECK/RESUME: `session_id` " +
+        "alone. The call waits up to `wait` seconds (default 25) for the answer; real runs often " +
+        "take minutes, so a still-open response is NORMAL, not an error — re-call with the returned " +
         "session_id until it settles. For the modes and wait semantics, read derive://skills/contexts.",
       inputSchema: {
         context: z
           .string()
           .optional()
           .describe(
-            "The context to ask — its id or name from list_contexts. Opens a NEW session; omit when passing session_id.",
+            "The context to use — its id or name from a find context row. Opens a NEW session; omit when passing session_id.",
           ),
         question: z
           .string()
@@ -2830,7 +3046,7 @@ async function buildServer(
           .string()
           .optional()
           .describe(
-            "An existing session of yours (from an earlier ask, or list_contexts) to follow up on or check.",
+            "An existing session of yours (from an earlier use, or a find context row) to follow up on or check.",
           ),
         wait: z
           .number()
@@ -2902,8 +3118,8 @@ async function buildServer(
         const note =
           s.state === "open"
             ? runnerOnline(x)
-              ? "Still thinking — real runs take minutes. Re-call ask with this session_id (+ wait) to collect the answer."
-              : "Queued, but the context's runner looks OFFLINE — it answers when it comes back. Re-call ask with this session_id later."
+              ? "Still thinking — real runs take minutes. Re-call use with this session_id (+ wait) to collect the answer."
+              : "Queued, but the context's runner looks OFFLINE — it answers when it comes back. Re-call use with this session_id later."
             : s.state === "escalated"
               ? "The runner escalated this to a human — a draft went to review. Check back later."
               : s.state === "failed"
@@ -2958,7 +3174,7 @@ async function buildServer(
           (await ctx.canUserAskContext(actingFor.id, linked))
         if (!found || !linked || !allowed)
           return err(
-            `No session "${session_id}" you can reach. list_contexts shows your open sessions.`,
+            `No session "${session_id}" you can reach. find (a context row) shows your open sessions.`,
           )
         if (!question) return reply(found, linked, true)
         if (found.state === "closed")
@@ -2982,7 +3198,7 @@ async function buildServer(
       // OPEN a new session.
       if (!context)
         return err(
-          "Pass `context` (+ `question`) to ask, or `session_id` to check/resume. list_contexts shows both.",
+          "Pass `context` (+ `question`) to open a session, or `session_id` to check/resume. find surfaces the contexts you can use and your open sessions.",
         )
       if (!question) return err("Opening a session needs a `question`.")
       const t = await resolveWs(workspace)
@@ -3025,132 +3241,9 @@ async function buildServer(
     },
   )
 
-  // SET UP THE BRANDPRINT ------------------------------------------------------
-  // The agent-native counterpart to the web create dialog: scaffold (or return) the
-  // workspace's Brandprint so "set up our Brandprint" typed into a connected agent works
-  // end to end, no context-switch to the app. Idempotent — it ensures the conventions
-  // collection + the "Brand profile" placeholder exist and the org pointer names them,
-  // then hands back the placeholder's short_id. The agent then reads
-  // derive://brandprint/reference + /template, builds the profile, and publishes it
-  // for_review against that short_id (the placeholder is the recognition contract — a
-  // human still approves the reveal, which flips it live at derive://brandprint/profile).
-  // It never generates or approves the profile itself. Owner/Admin only, like the web
-  // PATCH /v1/workspace/settings it mirrors.
-  server.registerTool(
-    "setup_brandprint",
-    {
-      description:
-        "Set up (or return) this workspace's Brandprint so its brand profile can be authored over MCP. Idempotent: it ensures a conventions collection and a 'Brand profile' placeholder artifact exist, points the workspace's settings at them, and returns the placeholder's short_id. NEXT: read derive://brandprint/reference and derive://brandprint/template, build ONE self-contained HTML brand profile, and publish it with for_review:true to that short_id — it lands as a proposal a human approves (never publish the profile live). This tool does NOT generate or approve the profile. Owner/Admin only.",
-      inputSchema: { workspace: wsArg },
-    },
-    async ({ workspace }) => {
-      const t = await resolveWs(workspace)
-      if ("error" in t) return err(t.error)
-      if (!roleAllows(t.role, "manage"))
-        return err("Setting up a Brandprint needs an Admin/Owner role in this workspace.")
-      // Collection ownership + the placeholder's author must be a real user; an OAuth
-      // grant carries the granting human (actingFor/ownerId), a static agent token may not.
-      const uid = actingFor?.id ?? ownerId
-      if (!uid)
-        return err(
-          "setup_brandprint needs a signed-in user to attribute the setup to. Connect with an OAuth agent grant rather than a static agent token.",
-        )
-      const targetOrg = t.org
-      try {
-        const settings = await ctx.meta.getOrgSettings(targetOrg)
-        const bp = settings.brandprint
-
-        // Reuse an in-tenant collection pointer; otherwise create the conventions
-        // collection (workspace-open so teammates read the docs + the reveal).
-        let collectionId = bp?.collectionId
-        let createdCollection = false
-        if (collectionId) {
-          const col = await ctx.meta.getCollection(collectionId)
-          if (!col || col.org_id !== targetOrg) collectionId = undefined
-        }
-        if (!collectionId) {
-          const col = await ctx.meta.createCollection({
-            id: newId("col"),
-            org_id: targetOrg,
-            title: "Brandprint",
-            created_by: uid,
-            workspace_access: "member",
-          })
-          await ctx.meta.setCollectionMember({
-            id: newId("cm"),
-            collection_id: col.id,
-            user_id: uid,
-            role: "owner",
-          })
-          collectionId = col.id
-          createdCollection = true
-        }
-
-        // Reuse an in-tenant profile pointer; otherwise publish the placeholder (v1 stub)
-        // into the collection. profileState reads live from v2, so a reused profile may
-        // already be live — report that rather than clobbering it.
-        let profileShortId = bp?.profileId
-        let state: "pending" | "live" = "pending"
-        let createdProfile = false
-        if (profileShortId) {
-          const art = await ctx.meta.getByShortId(profileShortId)
-          if (art && art.org_id === targetOrg) state = profileState(art.current_version)
-          else profileShortId = undefined
-        }
-        if (!profileShortId) {
-          const { artifact } = await publishVersion(ctx.meta, ctx.blobs, {
-            bytes: new TextEncoder().encode(PROFILE_PLACEHOLDER_HTML),
-            filename: "Brand profile.html",
-            isBundle: false,
-            title: "Brand profile",
-            message: "Brand profile placeholder — your agent fills this in.",
-            author: agent.name,
-            authorId: uid,
-            // Deliberately UNstamped: this auto-scaffolded placeholder is not the
-            // user's "first agent publish" — stamping 'mcp' here would flip the
-            // onboarding signal (and the welcome celebration) on an empty stub.
-            orgId: targetOrg,
-            workspaceAccess: "member",
-            linkRole: "none",
-            listed: "none",
-          })
-          await ctx.meta.addCollectionItem(collectionId, artifact.id)
-          profileShortId = artifact.short_id
-          state = "pending"
-          createdProfile = true
-        }
-
-        // Persist the pointer only when something actually changed (a fully-set-up
-        // Brandprint is a no-op read).
-        const pointerChanged =
-          createdCollection ||
-          createdProfile ||
-          bp?.collectionId !== collectionId ||
-          bp?.profileId !== profileShortId
-        if (pointerChanged)
-          await ctx.meta.setOrgSettings(targetOrg, {
-            ...settings,
-            brandprint: { collectionId, profileId: profileShortId },
-          })
-
-        const already = !createdCollection && !createdProfile
-        return json({
-          workspace: targetOrg,
-          collection_id: collectionId,
-          profile_short_id: profileShortId,
-          state,
-          created: !already,
-          message:
-            state === "live"
-              ? `This workspace already has a live brand profile (${profileShortId}). To revise it, build a new version and publish it with for_review:true to that short_id.`
-              : `Brandprint ${already ? "is ready" : "scaffolded"}. NEXT: read derive://brandprint/reference and derive://brandprint/template, build ONE self-contained HTML brand profile from the source docs, then publish it with for_review:true to ${profileShortId}. A human approves it to go live.`,
-        })
-      } catch (e) {
-        const msg = e instanceof PublishError ? e.message : String(e)
-        return text(`Couldn't set up the Brandprint: ${msg}`)
-      }
-    },
-  )
+  // (SET UP THE BRANDPRINT is dissolved into `publish`: publishing to
+  // derive://brandprint/profile scaffolds the slot on first write — see
+  // resolveBrandprintProfileTarget above.)
 
   return server
 }

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -19,7 +19,7 @@
 // — every tool description plus the server `instructions` — is context every connected
 // agent pays for before it does anything, so it stays THIN: each description states
 // intent, keeps its safety/consequence lines, and steers to a skill at the decision
-// point. The actual working procedure lives in three lazily-read CORE SKILLS
+// point. The actual working procedure lives in five lazily-read CORE SKILLS
 // (src/skills-reference.ts), served as derive://skills/<name> resources AND readable via
 // read("derive://skills/<name>") — exactly how derive://brandprint/* works. The
 // instructions carry only a one-line index of them. The mcp-surface-budget test guards
@@ -780,7 +780,7 @@ async function buildServer(
         short_id: z
           .string()
           .describe(
-            "The artifact's short id, e.g. nk0dsral. Also accepts a Brandprint URI — derive://brandprint/reference or /template (the static build guide), /profile (this workspace's live brand profile), or /<short_id> (a source doc) — or a CORE SKILL URI (derive://skills/loop, /publishing, /contexts), so the strings the instructions name are readable here even where MCP resources aren't.",
+            "The artifact's short id, e.g. nk0dsral. Also accepts a Brandprint URI — derive://brandprint/reference or /template (the static build guide), /profile (this workspace's live brand profile), or /<short_id> (a source doc) — or a CORE SKILL URI (derive://skills/loop, /publishing, /contexts, /checkpoint, /organize), so the strings the instructions name are readable here even where MCP resources aren't.",
           ),
         section: z
           .string()

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -775,7 +775,7 @@ async function buildServer(
     "read",
     {
       description:
-        "Read an artifact's CONTENT by short id, as Markdown by default (HTML is converted to its readable text — note a styled page renders fully to VIEWERS; only this reading view flattens it). Small docs return whole; a LARGE doc returns its heading OUTLINE first — call again with a `section` slug for just that part. Multi-page bundle: omit `section` for the page outline, then pass a page path (optionally `page.html#slug`). Pass format:'html' for the exact source (required before publish `edits`), or a past `version` for history. (For what CHANGED, or the comment threads, use catch_up.)",
+        "Read an artifact's CONTENT by short_id. A small doc returns whole; a LARGE doc returns its heading OUTLINE first — call again with a `section` slug (or a `lines` range) for just that part. Markdown by default; a styled HTML page is FLATTENED to text here, so pass render:'top' or 'full' to SEE it as a viewer does (do this after publishing a designed page to catch visual breakage). Bundle: omit `section` for the page list, then pass a page path (optionally `page.html#slug`). Pass format:'html' for the exact source (required BEFORE publish `edits`), or a past `version` for history. For what CHANGED or the comment threads, use catch_up instead.",
       inputSchema: {
         short_id: z
           .string()
@@ -1883,7 +1883,7 @@ async function buildServer(
     "stage_asset",
     {
       description:
-        "Mint a SHORT-LIVED, no-bearer upload URL for staging binary assets — raster images (PNG/JPEG/GIF/WebP) and web fonts (WOFF/WOFF2), max 25MB — into this workspace. POST a file's RAW bytes to the returned URL from your shell (`curl -sS --data-binary @shot.png <upload_url>`); the response gives a permanent public `url` (paste into an <img src>, a CSS url(), or markdown) and an `asset:<hash>` `ref` for a publish `files` map. The URL is reusable until it expires (~15 min), so stage a whole batch with one mint. NEVER transcribe an image to base64 through your context — a pasted image is usually already a file on disk, so upload those bytes. Before embedding images or fonts, read derive://skills/publishing.",
+        "Upload an image or font to embed in a document — do this BEFORE publish whenever a doc references a binary. Mint a SHORT-LIVED, no-bearer upload URL for raster images (PNG/JPEG/GIF/WebP) and web fonts (WOFF/WOFF2, max 25MB), curl the file's RAW bytes to it from your shell (`curl -sS --data-binary @shot.png <upload_url>`), and reference the returned permanent `url` (in an <img src>, CSS url(), or markdown) — or its `asset:<hash>` `ref` in a publish `files` map. The URL is reusable ~15 min, so stage a batch with one mint. NEVER base64 an image through a tool call — a pasted image is already a file on disk, so upload that. For the whole document (not a binary it embeds), use publish or stage_publish. Read derive://skills/publishing.",
       inputSchema: { workspace: wsArg },
     },
     async ({ workspace }) => {
@@ -1926,7 +1926,7 @@ async function buildServer(
     "stage_publish",
     {
       description:
-        "Mint a SHORT-LIVED, NO-bearer upload URL for pushing a file (or a whole bundle) too large to inline through publish — a big designed HTML page, a multi-file prototype. Inline `content`/`files` is model output, so a file past ~a page forces slow, costly multi-turn chunking; this uploads the raw bytes from your shell instead, zero tokens through context. Omit short_id to CREATE a new artifact; pass a short_id to REVISE that one (the token is scoped to exactly that target). Prefer the plain publish tool for small docs and for surgical `edits`; reach for this only when inlining would chunk. For the curl recipes (a single file, or a zipped dir that publishes as a bundle), read derive://skills/publishing.",
+        "Upload a whole document that is too big to inline — use this INSTEAD of publish when a designed HTML page or bundle is more than ~a page (inlining it through publish is slow, costly, and can fail). Mint a SHORT-LIVED, no-bearer upload URL, then curl the file (or a zipped dir, which publishes as a bundle) to it from your shell — zero tokens through context. Omit short_id to CREATE, pass short_id to REVISE that exact target. For a small doc or a partial change use publish (with `edits`) instead; for an image or font the doc embeds, use stage_asset. Read derive://skills/publishing for the curl recipes.",
       inputSchema: {
         workspace: wsArg,
         short_id: z
@@ -1993,7 +1993,7 @@ async function buildServer(
     "publish",
     {
       description:
-        "Save a revision of an artifact. It goes LIVE immediately if your role can publish (Creator/Admin); otherwise — or whenever you pass for_review:true — it is filed as a PROPOSAL a human approves before it goes live. OMIT short_id to create a NEW artifact (`title` required); PASS short_id to add a version to one you own, matching its kind. Provide `content` (a single file), `files` (a multi-page bundle), or `edits` (surgical search/replace against the stored source — read format:'html' first); pass `addresses` with the thread ids (from catch_up) this revision resolves. Before bundles, surgical edits, embedding assets, or shipping fully-styled HTML, read derive://skills/publishing. The response echoes content_sha256 of the stored bytes; verify it when the content passed through your context.",
+        "Publish a document: pass `short_id` to UPDATE an existing one, omit it to CREATE a new one (`title` required). Choose ONE payload by what you're changing. DEFAULT to `edits` for any change to an existing doc — it is the safe, precise option: exact find/replace against the stored source, so read format:'html' FIRST or it won't match, and it fails unless each search string hits exactly once (add surrounding text to make it unique). Use `content` to write or fully replace a single file, or `files` for a multi-page bundle. Do NOT inline anything past ~a page or any image/font — use stage_publish (a whole big doc/bundle) or stage_asset (an image/font) instead. Publishes go LIVE at your role; pass for_review:true to file a PROPOSAL a human approves instead (nothing changes until they do). Pass `addresses` (thread ids from catch_up) to resolve the feedback this revision answers. Read derive://skills/publishing before bundles, edits, or assets.",
       inputSchema: {
         content: z
           .string()

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -13,7 +13,19 @@
 // shaped to the agent's workflow (not the API surface), high-signal responses with
 // truncate-and-steer, semantic ids (short_id / vN / page path — never UUIDs),
 // actionable errors, and identity carried in the server `instructions` rather than a
-// tool slot. One tool per intent — WORKSPACES (list_workspaces), FIND
+// tool slot.
+//
+// THIN TOOLS, THICK SKILLS (spec: the "Thin tools, thick skills" plan on Derive). The always-loaded surface
+// — every tool description plus the server `instructions` — is context every connected
+// agent pays for before it does anything, so it stays THIN: each description states
+// intent, keeps its safety/consequence lines, and steers to a skill at the decision
+// point. The actual working procedure lives in three lazily-read CORE SKILLS
+// (src/skills-reference.ts), served as derive://skills/<name> resources AND readable via
+// read("derive://skills/<name>") — exactly how derive://brandprint/* works. The
+// instructions carry only a one-line index of them. The mcp-surface-budget test guards
+// the thinness.
+//
+// One tool per intent — WORKSPACES (list_workspaces), FIND
 // (list_artifacts), READ content (read), GREP (search), CATCH UP on state/feedback/
 // history (catch_up), COMMENT (comment), WRITE (publish), the WORK QUEUE
 // (check_requests: what teammates asked THIS agent to do — the one intent that is
@@ -109,6 +121,7 @@ import { enqueueSlackReviewRequestedDm } from "./lib/slack-dm"
 import { computeTagSuggestions } from "./lib/tag-suggestions"
 import { normalizeTags } from "./lib/tags"
 import { signUploadToken, UPLOAD_TOKEN_TTL_MS } from "./lib/upload-token"
+import { CORE_SKILLS } from "./skills-reference"
 import { enqueueChannelDelivery } from "./webhooks"
 
 const text = (s: string) => ({ content: [{ type: "text" as const, text: s }] })
@@ -296,13 +309,13 @@ async function buildServer(
   // exactly those: workspaces outside the grant are invisible and unreachable.
   boundWorkspaces: string[],
 ): Promise<McpServer> {
-  // Steer the write guidance by what this grant can actually do: a publish-capable
-  // grant gets the direct-publish path; a lower grant is told its writes go to review.
-  const writeGuidance = roleAllows(agent.role, "publish")
-    ? `Use publish to create a new artifact (omit short_id) or push a new version of one (pass short_id) — ` +
-      `it goes live immediately. Pass for_review:true to file it as a proposal a human approves instead. `
-    : `Use publish to submit a revision — at your role it is filed as a proposal a human approves before it ` +
-      `goes live; you cannot publish directly. `
+  // The always-loaded CORE SKILLS index: one line per skill (name — summary — read
+  // derive://skills/<name>), kept in lockstep with the skill bodies by iterating the
+  // same array the resources register from. The workflow/protocol prose lives in those
+  // lazily-read skills, not here.
+  const skillsIndex = CORE_SKILLS.map(
+    (s) => `- ${s.name} — ${s.summary} — read derive://skills/${s.name}`,
+  ).join("\n")
 
   // Resolve the Brandprint for this actor: the workspace's conventions merged with the
   // owner's personal ones (profile wins). Each convention doc becomes a readable resource;
@@ -344,47 +357,29 @@ async function buildServer(
   const server = new McpServer(
     { name: "derive", version: "1.0.0" },
     {
+      // High-level ORIENTATION, not a manual (SOTA per the MCP spec's "hint" framing and
+      // GitHub/Goose/Cline/Codex: identity first, capability pointers second, procedure
+      // deferred). Carries only what no single tool description conveys — identity, the loop
+      // at altitude, where durable context lives (Brandprint), that work is queued, and the
+      // core-skills index. The detailed workflow lives in the derive://skills/* bodies, and
+      // actionable errors steer the rest at runtime.
       instructions:
         `You are connected to Derive as "${agent.name}"${
           actingFor ? ` on behalf of ${actingFor.name ?? "your user"}` : ""
         }, acting in workspace ${agent.org_id} ` +
-        `with ${agent.role} permissions. Derive hosts living documents and plans with versioned ` +
-        `history, text-anchored review comments, and a publish → review → revise loop. Fully-styled ` +
-        `HTML pages are first-class too: a single-file artifact with its own <style>, scripts, fonts ` +
-        `and images renders as-authored in a sandboxed viewer — publish real designed pages, not just ` +
-        `prose. ` +
-        `Start a session with catch_up to re-sync on what changed and what feedback is open; use ` +
-        `read to view content — it returns Markdown by default (HTML is converted) and an outline ` +
-        `first for large documents or bundles, so pull sections by heading slug or page path once ` +
-        `you know what you want; pass format:'html' for the exact source. On a large artifact, use ` +
-        `search to grep for a spot and read's \`lines\` to window just that range, instead of ` +
-        `pulling the whole thing. Not sure WHICH artifact has something? Call search without ` +
-        `short_id to grep across the workspace instead — same tool, that one parameter omitted. ` +
-        `After publishing a styled page, call read with render:"top" (or ` +
-        `"full"/"marked") to SEE what shipped — it catches visual breakage no text ` +
-        `read can. For images and web fonts, call stage_asset for a short-lived upload ` +
-        `URL, curl the file's raw bytes to it from your shell, and reference the ` +
-        `returned permanent url — never base64 binaries through a tool call (a pasted ` +
-        `image usually already sits on disk; upload that file). For a document too large to ` +
-        `inline (a big designed HTML page or a multi-file bundle), call stage_publish and curl ` +
-        `the file/zip to the returned URL instead of chunking it through content/files. Use comment to leave or ` +
-        `resolve feedback. ${writeGuidance}To change PART of an artifact, prefer publish's edits ` +
-        `(exact-match search/replace against the stored source) over resending everything. When a ` +
-        `revision fixes specific feedback, pass those thread ids as publish's "addresses" so the ` +
-        `threads resolve (or show pending on a proposal). ` +
-        `This one login reaches the workspaces in your grant — call list_workspaces to see them, ` +
-        `then pass a workspace id or name as the "workspace" argument to act in another one (read, ` +
-        `catch_up, comment, publish, list_artifacts). read/catch_up/comment also find a short_id in ` +
-        `any of them automatically, so you never need to switch just to open a doc. ` +
-        `Workspaces can also host contexts — askable live data agents. list_contexts shows the ` +
-        `ones your user may ask (and whether each runner is online); ask opens a question session ` +
-        `on your user's behalf and returns the answer, or a session id to resume when the runner ` +
-        `needs longer. ` +
-        `Keep the library findable: browse tags are how work is discovered later, so tag as you ` +
-        `go — set \`tags\` when you publish, or use the one \`organize\` tool: call it on an ` +
-        `artifact to see its tags + suggestions, then again with \`add\` to apply (or \`collection\` ` +
-        `to group). Call organize with no arguments for the workspace's tag vocabulary — reuse an ` +
-        `existing tag over a near-duplicate; tagging is cheap, so be generous.` +
+        `with ${agent.role} permissions. Derive hosts living documents, plans, and skills with ` +
+        `versioned history, text-anchored review comments, and a publish → review → revise loop; ` +
+        `fully-styled HTML pages are first-class artifacts that render as-authored in a sandboxed ` +
+        `viewer, so publish real designed pages, not just prose. Work the loop: start with catch_up ` +
+        `to see what changed and what feedback is open, read to pull only the sections you need, then ` +
+        `act — comment to give or resolve feedback, publish a revision, respond to review. This one ` +
+        `login reaches every workspace in your grant: call list_workspaces to see them, then pass a ` +
+        `workspace id or name as the "workspace" argument to act in another (read, catch_up, comment, ` +
+        `publish, list_artifacts); read/catch_up/comment also find a short_id in any of them ` +
+        `automatically.\n\n` +
+        `CORE SKILLS carry the working procedure for each intent — read the matching one (a resource, ` +
+        `or read("derive://skills/<name>")) before you act:\n${skillsIndex}\n\n` +
+        `Workspace skills (team procedures) exist too: list_artifacts skills:true, then read.` +
         brandprintInstructions(bpSources.length, bpProfile) +
         pendingRequestsPointer(pendingRequests.length),
     },
@@ -515,6 +510,27 @@ async function buildServer(
     )
   }
 
+  // The CORE SKILLS as resources: derive://skills/<name>. Registered UNCONDITIONALLY,
+  // exactly like the Brandprint reference/template — they're the always-available
+  // protocol the instructions index points at, their bodies loading lazily on read. Each
+  // is also reachable through the `read` tool (read("derive://skills/<name>")), which
+  // every client supports even where MCP resources aren't. audience:["assistant"].
+  for (const skill of CORE_SKILLS) {
+    server.registerResource(
+      `skill:${skill.name}`,
+      `derive://skills/${skill.name}`,
+      {
+        title: `Core skill — ${skill.name}`,
+        description: skill.summary,
+        mimeType: "text/markdown",
+        annotations: { audience: ["assistant"], priority: 0.8 },
+      },
+      async (uri) => ({
+        contents: [{ uri: uri.href, mimeType: "text/markdown", text: skill.body }],
+      }),
+    )
+  }
+
   const defaultOrg = agent.org_id
   const defaultRole = agent.role
 
@@ -623,7 +639,7 @@ async function buildServer(
     "check_requests",
     {
       description:
-        "Your work queue: pending requests teammates handed you by @mentioning you in a comment (the ask-agent and Rework buttons land here). Each entry names the artifact, the comment thread, and what to do. Handle a request on its artifact — usually read it, do the asked revision, and publish with the thread id in `addresses` — then call this again with ack:[id,…] to clear what you finished. Unacked requests stay queued for your next session. WAITING FOR WORK? Pass `wait` (seconds, max 50): when the queue is empty the call blocks until a new request lands (or the time runs out), then returns it — chain `wait` calls to react in seconds instead of polling on a cadence.",
+        "Your work queue: pending requests teammates handed you by @mentioning you in a comment (the ask-agent and Rework buttons land here) — each names the artifact, the comment thread, and what to do. Handle a request on its artifact, then call this again with ack:[id,…] to clear what you finished; an unknown or already-acked id is skipped, never an error, and unacked requests stay queued for your next session. Pass `wait` (seconds, max 50) to long-poll for new work when the queue is empty, chaining calls to react in seconds instead of polling on a cadence. For how to work and ack a request, read derive://skills/loop.",
       inputSchema: {
         ack: z
           .array(z.string())
@@ -695,7 +711,7 @@ async function buildServer(
     "list_workspaces",
     {
       description:
-        "List every workspace THIS grant can act in — id, name, your role there, and which is your default. This is the set you chose when you connected (all your workspaces, or a subset). Pass a workspace's id or name as the `workspace` argument to list_artifacts / read / catch_up / comment / publish to act there. No reconnect — read/catch_up/comment even find a short_id across these workspaces automatically.",
+        "List every workspace THIS grant can act in — id, name, your role there, and which is your default (the set you chose when you connected: all your workspaces, or a subset). Pass a workspace's id or name as the `workspace` argument to list_artifacts / read / catch_up / comment / publish to act there. No reconnect — read/catch_up/comment even find a short_id across these workspaces automatically.",
       inputSchema: {},
     },
     async () => {
@@ -712,7 +728,7 @@ async function buildServer(
     "list_artifacts",
     {
       description:
-        "List the artifacts (docs, plans, sites, skills) in a workspace — short id, title, kind, is_skill, current version, access, and its browse `tags`. Defaults to your current workspace; pass `workspace` (id or name from list_workspaces) to list another one. Pass `tag` to list only artifacts carrying that tag (findability — organize shows the vocabulary). Pass skills:true to list only skills (reusable agent procedure). Includes your own unlisted publishes — out of the shared library, but you always find your work. Start here to find what to work on, then catch_up or read it.",
+        "List the artifacts (docs, plans, sites, skills) in a workspace — short id, title, kind, is_skill, current version, access (workspace_access/link_role/listed). Defaults to your current workspace; pass `workspace` (id or name from list_workspaces) to list another one. Pass skills:true to list only skills (reusable agent procedure). Pass `tag` to filter to one browse tag. Includes your own unlisted publishes — out of the shared library, but you always find your work. Start here to find what to work on, then catch_up or read it.",
       inputSchema: {
         query: z.string().optional().describe("Optional title search filter."),
         tag: z
@@ -764,7 +780,7 @@ async function buildServer(
         short_id: z
           .string()
           .describe(
-            "The artifact's short id, e.g. nk0dsral. Also accepts a Brandprint URI — derive://brandprint/reference or /template (the static build guide), /profile (this workspace's live brand profile), or /<short_id> (a source doc) — so the strings the instructions name are readable here even where MCP resources aren't.",
+            "The artifact's short id, e.g. nk0dsral. Also accepts a Brandprint URI — derive://brandprint/reference or /template (the static build guide), /profile (this workspace's live brand profile), or /<short_id> (a source doc) — or a CORE SKILL URI (derive://skills/loop, /publishing, /contexts), so the strings the instructions name are readable here even where MCP resources aren't.",
           ),
         section: z
           .string()
@@ -803,6 +819,19 @@ async function buildServer(
       // resources" for its whole life). `reference`/`template` are the static build guide;
       // `profile` is the live brand profile; any other segment is a source-doc short_id
       // that falls through to the normal read path (so `section`/`lines`/`version` work).
+      // `derive://skills/<name>` resolves the same way, so the core-skill strings the
+      // instructions index names are readable through `read` even where MCP resources
+      // aren't — same response shape as the Brandprint reference below.
+      const SK = "derive://skills/"
+      if (short_id.startsWith(SK)) {
+        const name = short_id.slice(SK.length)
+        const skill = CORE_SKILLS.find((s) => s.name === name)
+        if (!skill)
+          return err(
+            `No core skill "${name}". Available: ${CORE_SKILLS.map((s) => s.name).join(", ")}.`,
+          )
+        return json({ uri: short_id, mimeType: "text/markdown", content: skill.body })
+      }
       const BP = "derive://brandprint/"
       let docId = short_id
       if (short_id.startsWith(BP)) {
@@ -1239,7 +1268,7 @@ async function buildServer(
     "search",
     {
       description:
-        "Find text within ONE artifact, or across a WORKSPACE. Pass short_id to grep one artifact (not a full read): matching lines with line numbers (and optional context), ripgrep-style, so you can then `read` a narrow `lines` range (in the format the result names) or `edit` that spot. A bundle is searched across all its text pages, grouped by page. Omit short_id to search across the workspace — the artifacts you can see (same visibility rules as list_artifacts), ranked by relevance and grouped by artifact — so you can find WHICH doc has something before opening it; a note tells you when more matched than were shown. Searches the exact source by default (in:'text' searches the visible text instead). The query is matched literally (metacharacters are not special).",
+        "Find text within ONE artifact (pass short_id) or across a WORKSPACE (omit short_id) — ripgrep-style matching lines with line numbers, so you can then `read` a narrow `lines` range (in the format the result names) or `edit` that spot. A bundle is searched across all its text pages, grouped by page; a workspace search returns the artifacts you can see, ranked by relevance and grouped by artifact, so you find WHICH doc has something before opening it. Searches the exact source by default (in:'text' searches the visible text instead). The query is matched literally (metacharacters are not special).",
       inputSchema: {
         short_id: z
           .string()
@@ -1326,11 +1355,7 @@ async function buildServer(
     "organize",
     {
       description:
-        "Tags and collections in one tool — the library's findability layer.\n" +
-        "• READ (no `short_ids`): the workspace's tag vocabulary (tag → count) and its collections. Call this before tagging to reuse an existing tag over a near-duplicate.\n" +
-        "• READ (with `short_ids`): those artifacts' current tags + collections, plus `suggested` tags drawn from the most semantically-similar docs (when one id is given).\n" +
-        "• WRITE: pass `add`/`remove`/`set` to change tags (add never drops existing; set replaces the whole set), and/or `collection` (an id, or a name — created if new) to fold the artifacts into a collection. Each artifact is authorized on its own; ones you can't touch come back as skipped.\n" +
-        "Tag freely and reuse the vocabulary — a well-tagged library is findable. Collections are heavier: a tag for plain findability, a collection when a set is a real unit.",
+        "Tags and collections in one tool — the library's findability layer. READ (no `short_ids`) returns the workspace's tag vocabulary + collections; READ with `short_ids` returns their tags/collections plus suggested tags. WRITE (`add`/`remove`/`set` tags, and/or `collection`) changes them — each artifact is authorized on its own, so ones you can't touch come back skipped, never failing the batch. Tag freely and reuse the vocabulary; a collection is for when a set is a real unit. For the read-vs-write modes and the tags-vs-collections call, read derive://skills/organize.",
       inputSchema: {
         short_ids: z
           .array(z.string())
@@ -1530,10 +1555,7 @@ async function buildServer(
     "catch_up",
     {
       description:
-        "START HERE on an artifact. The state of it in one call: a one-line summary, the versions that landed since `since_version`, which pages changed, the open (and outdated) comment threads, and the full version history. " +
-        "Pass `comments` (open / addressed / resolved / outdated) to instead get that filtered thread list — your feedback to-do queue. " +
-        "Pass `response_format='detailed'` (optionally with `since_version`/`to_version`) to include a line-by-line diff between two versions — of their READABLE Markdown form, not raw HTML, so it shows what changed rather than tag noise. " +
-        "WAITING ON SOMETHING? Pass `wait` (seconds, max 50): the call blocks until the human sends back / approves / comments / publishes a new version (or the time runs out), then returns the fresh state — including anything new since `since_version`. Works with no pending review too: co-editing live with a human, `wait` blocks until THEIR next save lands. Chain wait calls instead of sleeping between polls — feedback reaches you in seconds.",
+        "START HERE on an artifact: its state in one call — a one-line summary, the versions that landed since `since_version`, which pages changed, the open (and outdated) comment threads, the review round you're waiting on, and the full version history. Pass `comments` (open/addressed/resolved/outdated) for that filtered thread list instead — your feedback to-do queue. Pass `response_format='detailed'` (optionally with `since_version`/`to_version`) for a line-by-line diff of the two versions' readable Markdown form. WAITING ON SOMETHING? Pass `wait` (seconds, max 50) to block until the human sends back / approves / comments / publishes a new version, then return the fresh state — chain waits instead of sleeping between polls. For the diff, review states, and the wait loop, read derive://skills/loop.",
       inputSchema: {
         short_id: z.string(),
         since_version: z
@@ -1733,7 +1755,7 @@ async function buildServer(
     "comment",
     {
       description:
-        "Leave feedback on an artifact, reply in a thread, react, and/or resolve or reopen a thread — all in one tool. Anchor a NEW comment to a quoted span of the rendered text with `quote`. Reply by passing the thread id as `reply_to`. Pass `react` (with `reply_to`) to acknowledge the latest human comment in a thread without the noise of a reply — the minimum ack the loop requires. Resolve or reopen by passing `set_state` along with the thread's id in `reply_to`. Thread ids come from catch_up.",
+        "Leave feedback on an artifact, reply in a thread, react, and/or resolve or reopen a thread — all in one tool. Anchor a NEW comment to a quoted span of the rendered text with `quote`; reply by passing the thread id as `reply_to`; `react` (with `reply_to`) is the lightweight ack. Pass `set_state` (with the thread's id in `reply_to`) to RESOLVE that thread, or reopen it. Thread ids come from catch_up. For quoting, the ack, and review-round etiquette, read derive://skills/loop.",
       inputSchema: {
         short_id: z.string(),
         body: z
@@ -1861,7 +1883,7 @@ async function buildServer(
     "stage_asset",
     {
       description:
-        "Mint a SHORT-LIVED upload URL for staging binary assets — raster images (PNG/JPEG/GIF/WebP) and web fonts (WOFF/WOFF2), max 25MB — into this workspace, no bearer token needed. POST a file's RAW bytes to the returned URL from your shell (`curl -sS --data-binary @shot.png <upload_url>`); the response carries a permanent public `url` to paste into any artifact's <img src>/CSS url()/markdown, and the `asset:<hash>` `ref` for a publish `files` map. The URL is reusable until it expires (~15 min), so stage a whole batch with one mint. An image PASTED into your conversation is usually ALREADY a file on disk (Claude Code caches pastes and shows the path alongside the image) — upload those bytes; NEVER transcribe an image to base64 through your context (~1 token/byte, and it can be silently corrupted). No shell? Fall back to a base64 data: URI entry in a bundle publish's `files` map — small images only.",
+        "Mint a SHORT-LIVED, no-bearer upload URL for staging binary assets — raster images (PNG/JPEG/GIF/WebP) and web fonts (WOFF/WOFF2), max 25MB — into this workspace. POST a file's RAW bytes to the returned URL from your shell (`curl -sS --data-binary @shot.png <upload_url>`); the response gives a permanent public `url` (paste into an <img src>, a CSS url(), or markdown) and an `asset:<hash>` `ref` for a publish `files` map. The URL is reusable until it expires (~15 min), so stage a whole batch with one mint. NEVER transcribe an image to base64 through your context — a pasted image is usually already a file on disk, so upload those bytes. Before embedding images or fonts, read derive://skills/publishing.",
       inputSchema: { workspace: wsArg },
     },
     async ({ workspace }) => {
@@ -1904,7 +1926,7 @@ async function buildServer(
     "stage_publish",
     {
       description:
-        "Mint a SHORT-LIVED publish URL for pushing a file (or a whole bundle) too large to inline through the publish tool — a big designed HTML page, a multi-file prototype — with NO bearer token. Inline `content`/`files` is model output, so a file past ~a page forces slow, costly multi-turn chunking; this uploads the raw bytes from your shell instead, zero tokens through context. Omit short_id to CREATE a new artifact; pass a short_id to REVISE that one (the token is scoped to exactly that target). Then from your shell: a single file → `curl -sS -F file=@page.html -F title='My Page' <upload_url>`; a bundle → zip the dir first (`cd site && zip -r /tmp/site.zip .`) then `curl -sS -F file=@/tmp/site.zip <upload_url>` (a .zip publishes as a multi-page bundle). The URL is reusable until it expires (~15 min). Prefer the plain publish tool for small docs and for surgical `edits`; reach for this only when inlining would chunk.",
+        "Mint a SHORT-LIVED, NO-bearer upload URL for pushing a file (or a whole bundle) too large to inline through publish — a big designed HTML page, a multi-file prototype. Inline `content`/`files` is model output, so a file past ~a page forces slow, costly multi-turn chunking; this uploads the raw bytes from your shell instead, zero tokens through context. Omit short_id to CREATE a new artifact; pass a short_id to REVISE that one (the token is scoped to exactly that target). Prefer the plain publish tool for small docs and for surgical `edits`; reach for this only when inlining would chunk. For the curl recipes (a single file, or a zipped dir that publishes as a bundle), read derive://skills/publishing.",
       inputSchema: {
         workspace: wsArg,
         short_id: z
@@ -1971,19 +1993,19 @@ async function buildServer(
     "publish",
     {
       description:
-        "Save a revision of an artifact. It goes LIVE immediately if your role can publish (Creator/Admin); otherwise — or whenever you pass for_review:true — it is filed as a PROPOSAL a human approves before it goes live. To CHANGE PART of a single-file artifact, prefer `edits` (exact-match search/replace against the stored source — read format:'html' first) over resending everything. Otherwise provide the full `content` for a SINGLE-FILE artifact, or `files` (a map of page path → content) for a MULTI-PAGE BUNDLE (a whole site, images and any binary asset). OMIT short_id to create a NEW artifact (`title` required); PASS short_id to add a version to one you own, matching its kind. A bundle republish REPLACES the whole bundle, so include EVERY page and asset (or use `merge`). Pass `addresses` with the thread ids (from catch_up) this revision resolves. (Proposals are single-file only; bundles must be published directly.) FULLY-STYLED HTML renders as-authored (own <style>/scripts/fonts) in the sandboxed viewer — two rules: declare your own <meta name=\"viewport\"> (pages without one get a mobile-reflow injection whose media caps can fight intentional layouts; `data-reflow-exempt` on an element is the per-component escape hatch), and self-host binaries via a stage_asset upload URL (images AND woff2 fonts) instead of base64. The response echoes `content_sha256` of the stored bytes — verify it when the content passed through your context.",
+        "Save a revision of an artifact. It goes LIVE immediately if your role can publish (Creator/Admin); otherwise — or whenever you pass for_review:true — it is filed as a PROPOSAL a human approves before it goes live. OMIT short_id to create a NEW artifact (`title` required); PASS short_id to add a version to one you own, matching its kind. Provide `content` (a single file), `files` (a multi-page bundle), or `edits` (surgical search/replace against the stored source — read format:'html' first); pass `addresses` with the thread ids (from catch_up) this revision resolves. Before bundles, surgical edits, embedding assets, or shipping fully-styled HTML, read derive://skills/publishing. The response echoes content_sha256 of the stored bytes; verify it when the content passed through your context.",
       inputSchema: {
         content: z
           .string()
           .optional()
           .describe(
-            "The complete content for a SINGLE-FILE artifact (HTML or Markdown). Use this OR `files`, not both. To embed an image OR a web font CHEAPLY (no base64 in this call), call stage_asset for a short-lived upload URL and curl the raw bytes to it (PNG/JPEG/GIF/WebP/WOFF/WOFF2) — the response's `url` is a permanent public link; paste it into an `<img src>`, a CSS `url()`, or markdown `![]()`. Never inline a base64 data: URI here — it tokenizes at roughly 1 token/char (one modest screenshot can cost 100k+ tokens), and content carried through your context can be silently mistranscribed; binaries should travel as bytes. If the DOCUMENT ITSELF is large (a big designed HTML page), don't inline it here either — call stage_publish for an upload URL and curl the file's bytes, zero tokens through context.",
+            "The complete content for a SINGLE-FILE artifact (HTML or Markdown). Use this OR `files`, not both. Embed images and fonts via a stage_asset upload URL (never a base64 data: URI here), and push a large document via stage_publish rather than inlining it — see derive://skills/publishing.",
           ),
         files: z
           .record(z.string(), z.string())
           .optional()
           .describe(
-            'A MULTI-PAGE bundle as a map of path → content — the whole site. Each value is one of: a text page (plain string); a base64 data: URI for a small inline binary ("shot.png":"data:image/png;base64,iVBORw0K…"); or — PREFERRED for real images — an "asset:<hash>" handle: call stage_asset for an upload URL, curl the raw bytes to it, and use the returned `ref` here ("shot.png":"asset:9f86d0818…"). The asset handle keeps the call tiny: stream each screenshot up as raw binary (no base64 transcription), then reference the handles here. Example: {"index.html":"<img src=shot.png>","styles.css":"…","shot.png":"asset:9f86d0818…","logo.png":"data:image/png;base64,iVBORw0K…"}. The root index.html (else the shallowest .html) becomes the entry page; pages reference assets by relative path. Served content-type comes from the file extension, so give binary entries a real extension (.png/.jpg/.webp/.woff2). A plain republish REPLACES the bundle (include every page and asset). Keep each call to a few MB; for many/large images, stage them as assets and reference the handles (or publish pages first, then `merge` asset batches). Each published page is also readable directly at /raw/<short_id>/v/<n>/<path> once live.',
+            'A MULTI-PAGE bundle as a map of path → content — the whole site. Each value is a text page (plain string), a base64 data: URI for a small inline binary, or — PREFERRED for real images — an "asset:<hash>" handle from stage_asset. The root index.html (else the shallowest .html) becomes the entry page; a plain republish REPLACES the bundle, so include every page and asset (or use `merge`). See derive://skills/publishing.',
           ),
         title: z
           .string()
@@ -2023,7 +2045,7 @@ async function buildServer(
           .boolean()
           .optional()
           .describe(
-            "Add/overwrite the given `files` INTO the existing bundle instead of replacing it (default false). Build a large site across several calls without re-sending it: publish the pages first, then merge in batches of assets — each call carries only the new files. Requires `short_id` of a bundle; same-path files overwrite, the rest are kept.",
+            "Add/overwrite the given `files` INTO the existing bundle instead of replacing it (default false). Requires `short_id` of a bundle; same-path files overwrite, the rest are kept. See derive://skills/publishing.",
           ),
         message: z.string().optional().describe("What changed — recorded as the version message."),
         tags: z
@@ -2076,7 +2098,7 @@ async function buildServer(
           )
           .optional()
           .describe(
-            "Surgical revision of a SINGLE-FILE artifact without resending it: exact-match search/replace against the current stored source, applied in order (each edit sees the previous one's result). Errors — applying nothing — if any old_str matches zero times, or matches more than once without `occurrence`; a miss's error explains why (whitespace difference, or the doc changed) so you can fix it in one round. Requires `short_id`; use INSTEAD of `content`. Composes with for_review, addresses, message, request_review.",
+            "Surgical revision of a SINGLE-FILE artifact without resending it: exact-match search/replace against the current stored source, applied in order (each edit sees the previous one's result). Requires `short_id`; use INSTEAD of `content`, and read format:'html' first so old_str matches the raw source. See derive://skills/publishing. A miss applies nothing and returns why.",
           ),
         base_version: z
           .number()
@@ -2531,7 +2553,7 @@ async function buildServer(
     "checkpoint",
     {
       description:
-        "Commit a compact LAYER of working state to this work's lineage — a one-page, human-readable checkpoint (state / decisions / open threads / next steps / refs) that lets ANY later session continue the work cold, on any machine. Call it at task boundaries: a task just completed, before a risky step, when wrapping up a session. FIRST call for a piece of work: pass `work` (a short name); the lineage is created and the result names its short_id — record it (e.g. in a .derive/lineage file at the repo root) and pass it as `short_id` on every checkpoint after. Each checkpoint REPLACES the page (versions keep the history; each layer is a pinned named version), so restate what still matters and drop what doesn't — the tool rejects more than a page. Prefer refs (artifact ids, PR URLs, file paths) over restated detail: the layer is an index a cold session follows, not a container.",
+        "Commit a compact LAYER of working state to this work's lineage — a one-page, human-readable checkpoint (state / decisions / open threads / next steps / refs) that lets ANY later session continue the work cold, on any machine. Call it at task boundaries: a task just completed, before a risky step, when wrapping up a session. FIRST call for a piece of work: pass `work` (a short name); the result names a short_id — record it (e.g. in a .derive/lineage file) and pass it as `short_id` on every checkpoint after. Each checkpoint REPLACES the page (versions keep the history), so restate what still matters and prefer refs over restated detail — the tool rejects more than a page. See derive://skills/checkpoint.",
       inputSchema: {
         work: z
           .string()
@@ -2737,11 +2759,10 @@ async function buildServer(
     {
       description:
         "List the CONTEXTS you may ask in a workspace — live data agents a workspace owner wired " +
-        "up, each answering questions against its own data and tools. Returns id, name, whether " +
-        "the runner is online, the manifest doc that defines it, and your own still-open sessions " +
-        "so you can resume one with ask. Asking happens on your user's behalf and is granted per " +
-        "context, so this list is exactly what your user may ask. Defaults to your current " +
-        "workspace; pass `workspace` to look in another. Then call ask with a context's id or name.",
+        "up, each answering against its own data and tools. Returns id, name, whether the runner " +
+        "is online, its manifest doc, and your own still-open sessions to resume with ask. Asking " +
+        "happens on your user's behalf and is granted per context, so this is exactly what your " +
+        "user may ask. Then call ask with a context's id or name; see derive://skills/contexts.",
       inputSchema: { workspace: wsArg },
     },
     async ({ workspace }) => {
@@ -2783,13 +2804,12 @@ async function buildServer(
     "ask",
     {
       description:
-        "Ask a context (a live data agent from list_contexts) a question on your user's behalf, " +
-        "or resume/follow up an existing session. OPEN: pass `context` (id or name) + `question`. " +
-        "FOLLOW UP: pass `session_id` + `question`. CHECK/RESUME: pass `session_id` alone. The " +
-        "call waits up to `wait` seconds (default 25) for the runner's answer and returns it " +
-        "inline when it lands — real runs often take minutes, so a still-open response is normal, " +
-        "not an error: re-call with the returned session_id (+ wait) until it settles. Answers " +
-        "cite artifact short_ids you can then read.",
+        "Ask a context (a live data agent from list_contexts) a question ON YOUR USER'S BEHALF " +
+        "(rate-limited), or resume/follow up an existing session. OPEN: `context` (id or name) + " +
+        "`question`. FOLLOW UP: `session_id` + `question`. CHECK/RESUME: `session_id` alone. The " +
+        "call waits up to `wait` seconds (default 25) for the answer; real runs often take " +
+        "minutes, so a still-open response is NORMAL, not an error — re-call with the returned " +
+        "session_id until it settles. For the modes and wait semantics, read derive://skills/contexts.",
       inputSchema: {
         context: z
           .string()
@@ -3020,7 +3040,7 @@ async function buildServer(
     "setup_brandprint",
     {
       description:
-        "Set up (or return) this workspace's Brandprint so its brand profile can be authored over MCP — the agent-native version of the web create dialog. Idempotent: it ensures a conventions collection and a 'Brand profile' placeholder artifact exist and points the workspace's settings at them, then returns the placeholder's short_id. NEXT: read derive://brandprint/reference and derive://brandprint/template, build ONE self-contained HTML brand profile, and publish it with for_review:true to that short_id — it lands as a proposal a human approves (never publish the profile live). This tool does NOT generate or approve the profile. Owner/Admin only. Call it when the user asks to set up, build, or finish their Brandprint.",
+        "Set up (or return) this workspace's Brandprint so its brand profile can be authored over MCP. Idempotent: it ensures a conventions collection and a 'Brand profile' placeholder artifact exist, points the workspace's settings at them, and returns the placeholder's short_id. NEXT: read derive://brandprint/reference and derive://brandprint/template, build ONE self-contained HTML brand profile, and publish it with for_review:true to that short_id — it lands as a proposal a human approves (never publish the profile live). This tool does NOT generate or approve the profile. Owner/Admin only.",
       inputSchema: { workspace: wsArg },
     },
     async ({ workspace }) => {

--- a/apps/api/src/skills-reference.ts
+++ b/apps/api/src/skills-reference.ts
@@ -7,7 +7,7 @@
  *
  * - `publishing` — create + revise artifacts, stage assets and large content, propose for review.
  * - `loop` — catch up on an artifact, respond to feedback, and pull queued work.
- * - `contexts` — ask a workspace's live data agents.
+ * - `contexts` — use a workspace's live data agents.
  * - `checkpoint` — save working state to a resumable lineage so a later session continues cold.
  * - `organize` — tag + collect artifacts for library findability.
  */
@@ -15,16 +15,16 @@
 const PUBLISHING = `# Publishing to Derive
 
 How to WRITE to Derive: create and revise artifacts with \`publish\`, and stage large
-content or binary assets with \`stage_publish\` and \`stage_asset\`. Derive hosts living
-documents and plans with versioned history; a fully-styled HTML page is a first-class
-artifact that renders as-authored in a sandboxed viewer, so publish real designed pages,
-not just prose.
+content or binary assets with \`stage\` (target:'doc' for a whole big document/bundle,
+target:'asset' for an image/font). Derive hosts living documents and plans with versioned
+history; a fully-styled HTML page is a first-class artifact that renders as-authored in a
+sandboxed viewer, so publish real designed pages, not just prose.
 
 ## Key rules (read these first)
 
-- NEVER base64 a binary through a tool call. Every image/font: stage_asset -> curl the raw bytes -> paste the returned url (or its asset:<hash> ref). A pasted image is already a file on disk; upload that file, don't transcribe it.
+- NEVER base64 a binary through a tool call. Every image/font: stage target:'asset' -> curl the raw bytes -> paste the returned url (or its asset:<hash> ref). A pasted image is already a file on disk; upload that file, don't transcribe it. publish REJECTS a single inline data: URI past ~32KB (stage the asset) and any inline content/files summing past ~64KB (stage target:'doc').
 - Assets are raster images and web fonts ONLY: PNG/JPEG/GIF/WebP/WOFF/WOFF2, <=25MB each. Inline SVG, CSS, and JS in the page itself (SVG is rejected as an asset).
-- Anything bigger than ~a page: stage_publish (curl the file/zip), never inline content/files.
+- Anything bigger than ~a page: stage target:'doc' (curl the file/zip), never inline content/files.
 - On a styled HTML page, declare your own <meta name="viewport">, or it gets a mobile-reflow injection that can fight your layout (data-reflow-exempt is the per-element escape hatch).
 - After publishing a styled page, read with render:"top" (or "full") to SEE it before you trust it; a text read can't catch a failed font or a broken layout.
 - To change part of a doc, read format:'html' FIRST, then edits with base_version. A bad match applies NOTHING and tells you why; fix and retry.
@@ -73,13 +73,13 @@ not just prose.
 
 ## Staging assets — never base64 binaries
 
-For images and web fonts, call \`stage_asset\` for a short-lived upload URL, curl the file's
-raw bytes to it from your shell, and reference the returned permanent url — NEVER base64
-binaries through a tool call.
+For images and web fonts, call \`stage\` with target:'asset' for a short-lived upload URL,
+curl the file's raw bytes to it from your shell, and reference the returned permanent url —
+NEVER base64 binaries through a tool call.
 
-\`stage_asset\` mints a SHORT-LIVED upload URL for raster images (PNG/JPEG/GIF/WebP) and web
-fonts (WOFF/WOFF2), max 25MB, into this workspace, no bearer token needed. POST a file's
-RAW bytes to the returned URL from your shell (\`curl -sS --data-binary @shot.png
+\`stage target:'asset'\` mints a SHORT-LIVED upload URL for raster images (PNG/JPEG/GIF/WebP)
+and web fonts (WOFF/WOFF2), max 25MB, into this workspace, no bearer token needed. POST a
+file's RAW bytes to the returned URL from your shell (\`curl -sS --data-binary @shot.png
 <upload_url>\`); the response carries a permanent public \`url\` to paste into any artifact's
 \`<img src>\`/CSS \`url()\`/markdown \`![]()\`, and the \`asset:<hash>\` \`ref\` for a publish
 \`files\` map. The URL is reusable until it expires (~15 min), so stage a whole batch with
@@ -94,8 +94,8 @@ bundle publish's \`files\` map — small images only.
 
 Inside a bundle's \`files\` map, each value is one of: a text page (plain string); a base64
 \`data:\` URI for a small inline binary (\`"shot.png":"data:image/png;base64,iVBORw0K…"\`); or —
-PREFERRED for real images — an \`asset:<hash>\` handle: call stage_asset for an upload URL,
-curl the raw bytes to it, and use the returned \`ref\` here
+PREFERRED for real images — an \`asset:<hash>\` handle: call stage target:'asset' for an
+upload URL, curl the raw bytes to it, and use the returned \`ref\` here
 (\`"shot.png":"asset:9f86d0818…"\`). Keep each call to a few MB; for many/large images, stage
 them as assets and reference the handles (or publish pages first, then \`merge\` asset
 batches).
@@ -109,28 +109,29 @@ reading view is not what a viewer sees). Two rules:
 - Declare your own \`<meta name="viewport">\`. Pages without one get a mobile-reflow
   injection whose media caps can fight intentional layouts; \`data-reflow-exempt\` on an
   element is the per-component escape hatch.
-- Self-host binaries via a stage_asset upload URL (images AND woff2 fonts) instead of
-  base64.
+- Self-host binaries via a stage target:'asset' upload URL (images AND woff2 fonts) instead
+  of base64.
 
 After publishing a styled page, call \`read\` with \`render:"top"\` (or \`"full"\`/\`"marked"\`)
 to SEE what shipped — a screenshot of the served page catches visual breakage (a failed
 font, a broken layout) that no text read can. The screenshots are computed a few seconds
 after each publish.
 
-## stage_publish for large docs and bundles
+## stage target:'doc' for large docs and bundles
 
 Inline \`content\`/\`files\` is model output — capped by the per-response token ceiling and
-forced into slow, costly multi-turn chunking once a file is bigger than a page or two. For
-a document too large to inline (a big designed HTML page or a multi-file bundle), call
-\`stage_publish\` and curl the file/zip to the returned URL instead of chunking it through
-content/files — zero bytes through the model's context.
+forced into slow, costly multi-turn chunking once a file is bigger than a page or two (and
+publish REJECTS an inline payload past ~64KB). For a document too large to inline (a big
+designed HTML page or a multi-file bundle), call \`stage\` with target:'doc' and curl the
+file/zip to the returned URL instead of chunking it through content/files — zero bytes
+through the model's context.
 
 Omit \`short_id\` to CREATE a new artifact; pass a \`short_id\` to REVISE that one (the token is
 scoped to exactly that target). Then from your shell: a single file → \`curl -sS -F
 file=@page.html -F title='My Page' <upload_url>\`; a bundle → zip the dir first (\`cd site &&
 zip -r /tmp/site.zip .\`) then \`curl -sS -F file=@/tmp/site.zip <upload_url>\` (a .zip
 publishes as a multi-page bundle). The URL is reusable until it expires (~15 min). Prefer
-the plain publish tool for small docs and for surgical \`edits\`; reach for stage_publish
+the plain publish tool for small docs and for surgical \`edits\`; reach for stage target:'doc'
 only when inlining would chunk.
 
 ## content_sha256 verification
@@ -164,11 +165,11 @@ those params' own descriptions for the exact meanings.
 const LOOP = `# The Derive working loop
 
 Start a session with \`catch_up\`, respond to feedback with \`comment\`, and pull queued work
-with \`check_requests\`. This is the read → respond → revise (revise via publish) rhythm around a Derive artifact.
+with \`catch_up\` (no short_id). This is the read → respond → revise (revise via publish) rhythm around a Derive artifact.
 
 ## catch_up: state, feedback, history, diffs
 
-START HERE on an artifact. Its state in one call: a one-line summary, the versions that
+START HERE on an artifact (pass its \`short_id\`). Its state in one call: a one-line summary, the versions that
 landed since \`since_version\`, which pages changed, the open (and outdated) comment threads,
 the review round you're waiting on, and the full version history.
 
@@ -204,16 +205,17 @@ Leave feedback on an artifact, reply in a thread, react, and/or resolve or reope
 - **Resolve / reopen.** Pass \`set_state\` (\`resolved\` or \`open\`) along with the thread's id
   in \`reply_to\`.
 
-## check_requests: your work queue
+## catch_up (no short_id): your work queue
 
-Pending requests teammates handed you by @mentioning you in a comment (the ask-agent and
-Rework buttons land here). Each entry names the artifact, the comment thread, and what to
-do.
+Call \`catch_up\` with NO short_id for your work queue: pending requests teammates handed you
+by @mentioning you in a comment (the ask-agent and Rework buttons land here). Each entry
+names the artifact, the comment thread, and what to do. (A connection with no @mentionable
+inbox — an OAuth grant — gets an explicit note instead of a queue.)
 
 - **Handle then ack.** Work a request on its artifact — usually read it, do the asked
-  revision, and publish with the thread id in \`addresses\` — then call check_requests again
-  with \`ack:[id,…]\` to clear what you finished. Ack AFTER the work lands (a publish or a
-  reply), not on read; an unknown or already-acked id is skipped, never an error. Unacked
+  revision, and publish with the thread id in \`addresses\` — then call catch_up (no short_id)
+  again with \`ack:[id,…]\` to clear what you finished. Ack AFTER the work lands (a publish or
+  a reply), not on read; an unknown or already-acked id is skipped, never an error. Unacked
   requests stay queued for your next session.
 - **Wait (long-poll).** WAITING FOR WORK? Pass \`wait\` (seconds, max 50): when the queue is
   empty the call blocks until a new request lands (or the time runs out), then returns it —
@@ -229,24 +231,25 @@ publish that resolves them, so they resolve (on a live publish) or flip to \`add
 proposal) rather than being closed in a separate step.
 `
 
-const CONTEXTS = `# Asking workspace contexts
+const CONTEXTS = `# Using workspace contexts
 
 Workspaces can host CONTEXTS — askable live data agents a workspace owner wired up, each
-answering questions against its own data and tools. \`list_contexts\` shows the ones your
-user may ask; \`ask\` opens a question session on your user's behalf and returns the answer.
+answering questions against its own data and tools. \`find\` surfaces the ones your user may
+use (as typed context rows in browse/search); \`use\` opens a session on your user's behalf —
+a question or a commission — and returns the answer.
 
-## list_contexts
+## Discovering contexts with find
 
-List the contexts you may ask in a workspace — id, name, whether the runner is online (its
-last queue poll is recent), the manifest doc that defines it, and your own still-open
-sessions so you can resume one with \`ask\`. Asking happens on your user's behalf and is
-granted per context, so this list is EXACTLY what your user may ask, nothing more. Defaults
-to your current workspace; pass \`workspace\` to look in another. Then call \`ask\` with a
-context's id or name.
+\`find\` (browse, or a query whose text matches a context name) lists the contexts you may
+use in a workspace — id, name, whether the runner is online (its last queue poll is recent),
+the manifest doc that defines it, and your own still-open sessions so you can resume one with
+\`use\`. Using happens on your user's behalf and is granted per context, so what \`find\`
+surfaces is EXACTLY what your user may use, nothing more. Then call \`use\` with a context's id
+or name.
 
-## ask: open, follow up, or check
+## use: open, follow up, or check
 
-Ask a context a question on your user's behalf, or resume/follow up an existing session:
+Use a context on your user's behalf, or resume/follow up an existing session:
 
 - **OPEN** a new session: pass \`context\` (id or name) + \`question\`.
 - **FOLLOW UP** an existing session: pass \`session_id\` + \`question\` (it already knows its
@@ -256,13 +259,13 @@ Ask a context a question on your user's behalf, or resume/follow up an existing 
 
 The call waits up to \`wait\` seconds (default 25, max 50; 0 = return at once) for the runner's
 answer and returns it inline when it lands. Real runs often take MINUTES, so a still-open
-response is NORMAL, not an error: an expired wait leaves the session open — re-call \`ask\`
+response is NORMAL, not an error: an expired wait leaves the session open — re-call \`use\`
 with the returned \`session_id\` (+ \`wait\`) until it settles. Sessions resume across calls
-and across your own sessions; \`list_contexts\` surfaces your still-open ones. If the runner
-looks offline, the session is queued and answers when it comes back. Answers cite artifact
-short_ids you can then \`read\`.
+and across your own sessions; a context row in \`find\` surfaces your still-open ones. If the
+runner looks offline, the session is queued and answers when it comes back. Answers cite
+artifact short_ids you can then \`read\`.
 
-A settled session is normally \`answered\`; it can instead come back \`escalated\` (the runner handed a draft to a human reviewer, check back later) or \`failed\` (the run crashed, just ask again). Re-calling \`ask\` always returns the current \`state\` and a one-line \`note\`.
+A settled session is normally \`answered\`; it can instead come back \`escalated\` (the runner handed a draft to a human reviewer, check back later) or \`failed\` (the run crashed, just ask again). Re-calling \`use\` always returns the current \`state\` and a one-line \`note\`.
 `
 
 const CHECKPOINT = `# Checkpointing working state
@@ -309,18 +312,18 @@ export const CORE_SKILLS: readonly { name: string; summary: string; body: string
   {
     name: "loop",
     summary:
-      "catch up on an artifact, work a review round, respond to feedback, and pull queued work (catch_up, comment, check_requests)",
+      "catch up on an artifact, work a review round, respond to feedback, and pull queued work (catch_up, comment)",
     body: LOOP,
   },
   {
     name: "publishing",
     summary:
-      "create and revise artifacts (incl. fully-styled HTML pages), stage assets and large content, and file proposals for review (publish, stage_asset, stage_publish)",
+      "create and revise artifacts (incl. fully-styled HTML pages), stage assets and large content, and file proposals for review (publish, stage)",
     body: PUBLISHING,
   },
   {
     name: "contexts",
-    summary: "ask a workspace's live data agents (list_contexts, ask)",
+    summary: "use a workspace's live data agents (find, use)",
     body: CONTEXTS,
   },
   {

--- a/apps/api/src/skills-reference.ts
+++ b/apps/api/src/skills-reference.ts
@@ -1,0 +1,338 @@
+/**
+ * The MCP CORE SKILLS — the workflow/protocol prose that used to live inline in every
+ * tool description and the server `instructions`, moved out to lazily-read skills so the
+ * always-loaded surface stays thin (spec: the "Thin tools, thick skills" plan on Derive). Each skill is served
+ * as a resource AND readable via read("derive://skills/<name>"), mirroring exactly how
+ * derive://brandprint/* works. A pure leaf: no imports, safe in every build (worker + node).
+ *
+ * - `publishing` — create + revise artifacts, stage assets and large content, propose for review.
+ * - `loop` — catch up on an artifact, respond to feedback, and pull queued work.
+ * - `contexts` — ask a workspace's live data agents.
+ * - `checkpoint` — save working state to a resumable lineage so a later session continues cold.
+ * - `organize` — tag + collect artifacts for library findability.
+ */
+
+const PUBLISHING = `# Publishing to Derive
+
+How to WRITE to Derive: create and revise artifacts with \`publish\`, and stage large
+content or binary assets with \`stage_publish\` and \`stage_asset\`. Derive hosts living
+documents and plans with versioned history; a fully-styled HTML page is a first-class
+artifact that renders as-authored in a sandboxed viewer, so publish real designed pages,
+not just prose.
+
+## Key rules (read these first)
+
+- NEVER base64 a binary through a tool call. Every image/font: stage_asset -> curl the raw bytes -> paste the returned url (or its asset:<hash> ref). A pasted image is already a file on disk; upload that file, don't transcribe it.
+- Assets are raster images and web fonts ONLY: PNG/JPEG/GIF/WebP/WOFF/WOFF2, <=25MB each. Inline SVG, CSS, and JS in the page itself (SVG is rejected as an asset).
+- Anything bigger than ~a page: stage_publish (curl the file/zip), never inline content/files.
+- On a styled HTML page, declare your own <meta name="viewport">, or it gets a mobile-reflow injection that can fight your layout (data-reflow-exempt is the per-element escape hatch).
+- After publishing a styled page, read with render:"top" (or "full") to SEE it before you trust it; a text read can't catch a failed font or a broken layout.
+- To change part of a doc, read format:'html' FIRST, then edits with base_version. A bad match applies NOTHING and tells you why; fix and retry.
+- Republishing a bundle REPLACES it: include every page and asset, or use merge to add only the new files.
+- Verify content_sha256 in the response whenever the content passed through your context.
+
+## publish: edits vs content vs files
+
+\`publish\` saves a revision of an artifact.
+
+- **Create vs revise.** OMIT \`short_id\` to create a NEW artifact (\`title\` required); PASS
+  \`short_id\` to add a version to one you own, matching its kind. Kind can't change on
+  republish — a bundle stays a bundle, a single file stays a single file.
+- **Surgical edits (preferred for partial changes).** To change PART of a single-file
+  artifact, prefer \`edits\` — exact-match search/replace against the stored source — over
+  resending everything. Read \`format:'html'\` FIRST on an HTML artifact: edits match the
+  raw stored source, and the markdown reading view will not match. Each edit is
+  \`{ old_str, new_str, occurrence? }\`, applied in order (each edit sees the previous
+  one's result). \`old_str\` must occur exactly once, unless \`occurrence\` (a 1-based index)
+  picks one of several. \`new_str\` empty deletes. The batch errors — applying NOTHING — if
+  any \`old_str\` matches zero times, or matches more than once without \`occurrence\`; the
+  error explains why (a whitespace difference, or the doc changed) so you can fix it in
+  one round. Requires \`short_id\`; use INSTEAD of \`content\`. Composes with \`for_review\`,
+  \`addresses\`, \`message\`, \`request_review\`.
+- **base_version safety.** With \`edits\`, pass the version you read as \`base_version\`; the
+  publish errors instead of applying when the artifact has moved past it.
+- **Full single file.** Provide the complete \`content\` (HTML or Markdown) for a
+  single-file artifact.
+- **Bundle.** Provide \`files\` (a map of page path → content) for a MULTI-PAGE bundle — a
+  whole site, images and any binary asset. The root \`index.html\` (else the shallowest
+  \`.html\`) becomes the entry page; pages reference assets by relative path. Served
+  content-type comes from the file extension, so give binary entries a real extension
+  (.png/.jpg/.webp/.woff2). Each published page is also readable directly at
+  \`/raw/<short_id>/v/<n>/<path>\` once live.
+
+## Bundles: merge and spa
+
+- A plain bundle republish REPLACES the whole bundle, so include EVERY page and asset — or
+  use \`merge\`.
+- **merge**: add/overwrite the given \`files\` INTO the existing bundle instead of replacing
+  it (default false). Build a large site across several calls without re-sending it:
+  publish the pages first, then merge in batches of assets — each call carries only the new
+  files. Requires the \`short_id\` of a bundle; same-path files overwrite, the rest are kept.
+- **spa** (a NEW bundle only): serve unknown paths from the entry page (single-page-app
+  routing). Default false.
+
+## Staging assets — never base64 binaries
+
+For images and web fonts, call \`stage_asset\` for a short-lived upload URL, curl the file's
+raw bytes to it from your shell, and reference the returned permanent url — NEVER base64
+binaries through a tool call.
+
+\`stage_asset\` mints a SHORT-LIVED upload URL for raster images (PNG/JPEG/GIF/WebP) and web
+fonts (WOFF/WOFF2), max 25MB, into this workspace, no bearer token needed. POST a file's
+RAW bytes to the returned URL from your shell (\`curl -sS --data-binary @shot.png
+<upload_url>\`); the response carries a permanent public \`url\` to paste into any artifact's
+\`<img src>\`/CSS \`url()\`/markdown \`![]()\`, and the \`asset:<hash>\` \`ref\` for a publish
+\`files\` map. The URL is reusable until it expires (~15 min), so stage a whole batch with
+one mint.
+
+An image PASTED into your conversation is usually ALREADY a file on disk (Claude Code
+caches pastes and shows the path alongside the image) — upload those bytes; NEVER transcribe
+an image to base64 through your context (~1 token/byte — one modest screenshot can cost
+100k+ tokens — and content carried through your context can be silently mistranscribed;
+binaries should travel as bytes). No shell? Fall back to a base64 \`data:\` URI entry in a
+bundle publish's \`files\` map — small images only.
+
+Inside a bundle's \`files\` map, each value is one of: a text page (plain string); a base64
+\`data:\` URI for a small inline binary (\`"shot.png":"data:image/png;base64,iVBORw0K…"\`); or —
+PREFERRED for real images — an \`asset:<hash>\` handle: call stage_asset for an upload URL,
+curl the raw bytes to it, and use the returned \`ref\` here
+(\`"shot.png":"asset:9f86d0818…"\`). Keep each call to a few MB; for many/large images, stage
+them as assets and reference the handles (or publish pages first, then \`merge\` asset
+batches).
+
+## Fully-styled HTML
+
+A single-file artifact with its own \`<style>\`, scripts, fonts and images renders
+as-authored in the sandboxed viewer (note: the \`read\` tool FLATTENS HTML to text — that
+reading view is not what a viewer sees). Two rules:
+
+- Declare your own \`<meta name="viewport">\`. Pages without one get a mobile-reflow
+  injection whose media caps can fight intentional layouts; \`data-reflow-exempt\` on an
+  element is the per-component escape hatch.
+- Self-host binaries via a stage_asset upload URL (images AND woff2 fonts) instead of
+  base64.
+
+After publishing a styled page, call \`read\` with \`render:"top"\` (or \`"full"\`/\`"marked"\`)
+to SEE what shipped — a screenshot of the served page catches visual breakage (a failed
+font, a broken layout) that no text read can. The screenshots are computed a few seconds
+after each publish.
+
+## stage_publish for large docs and bundles
+
+Inline \`content\`/\`files\` is model output — capped by the per-response token ceiling and
+forced into slow, costly multi-turn chunking once a file is bigger than a page or two. For
+a document too large to inline (a big designed HTML page or a multi-file bundle), call
+\`stage_publish\` and curl the file/zip to the returned URL instead of chunking it through
+content/files — zero bytes through the model's context.
+
+Omit \`short_id\` to CREATE a new artifact; pass a \`short_id\` to REVISE that one (the token is
+scoped to exactly that target). Then from your shell: a single file → \`curl -sS -F
+file=@page.html -F title='My Page' <upload_url>\`; a bundle → zip the dir first (\`cd site &&
+zip -r /tmp/site.zip .\`) then \`curl -sS -F file=@/tmp/site.zip <upload_url>\` (a .zip
+publishes as a multi-page bundle). The URL is reusable until it expires (~15 min). Prefer
+the plain publish tool for small docs and for surgical \`edits\`; reach for stage_publish
+only when inlining would chunk.
+
+## content_sha256 verification
+
+A single-file publish's response echoes \`content_sha256\` of the stored bytes (the
+content-addressed blob key) — verify it when the content passed through your context, so
+you know what landed matches what you sent.
+
+## Proposals and review (the /derive loop)
+
+\`publish\` goes LIVE immediately if your role can publish (Creator/Admin); otherwise — or
+whenever you pass \`for_review:true\` — it is filed as a PROPOSAL a human approves before it
+goes live. (Proposals are single-file only; bundles must be published directly.)
+
+- **addresses**: pass the thread ids (from catch_up) this revision resolves. On a live
+  publish they resolve; on a proposal they flip to \`addressed\` and resolve on approval.
+- **request_review**: after a LIVE publish, open a review round asking your human to review
+  this version — the /derive loop. They answer inline and hit Send back (or Approve); poll
+  catch_up's \`review\` field for the state. No effect on a proposal (that already IS a
+  review).
+
+## Access on a NEW artifact
+
+Access is set on create; a republish never re-stamps it. The factory default is the "team
+draft" — \`workspace_access=member\`, \`link_role=none\`, \`listed=none\`: a teammate can open
+the pasted link, the world can't, and it stays out of feeds until a human promotes it.
+Sharing wider (\`workspace_access\`, \`link_role\`, \`listed\`) stays a deliberate act — see
+those params' own descriptions for the exact meanings.
+`
+
+const LOOP = `# The Derive working loop
+
+Start a session with \`catch_up\`, respond to feedback with \`comment\`, and pull queued work
+with \`check_requests\`. This is the read → respond → revise (revise via publish) rhythm around a Derive artifact.
+
+## catch_up: state, feedback, history, diffs
+
+START HERE on an artifact. Its state in one call: a one-line summary, the versions that
+landed since \`since_version\`, which pages changed, the open (and outdated) comment threads,
+the review round you're waiting on, and the full version history.
+
+- **Feedback queue.** Pass \`comments\` (open / addressed / resolved / outdated) to instead
+  get that filtered thread list — your feedback to-do queue. \`outdated\` means the quoted
+  text changed in a landed version, so the feedback may no longer apply; \`addressed\` means a
+  proposal is already pending for it (don't re-address).
+- **Diffs.** Pass \`response_format='detailed'\` (optionally with \`since_version\`/\`to_version\`)
+  to include a line-by-line diff between two versions — of their READABLE Markdown form,
+  not raw HTML, so it shows what changed rather than tag noise. \`since_version\` defaults to
+  \`to_version − 1\`.
+- **Review state.** The \`review\` field tracks the round this agent is waiting on:
+  \`pending\` = still waiting for the human; \`sent_back\` = the human returned answers, read
+  the open threads and revise; \`approved\` = the go-signal to proceed. (A round is opened or re-opened with publish's \`request_review\` — see the publishing skill.)
+- **Wait (long-poll).** WAITING ON SOMETHING? Pass \`wait\` (seconds, max 50): the call blocks
+  until the human sends back / approves / comments / publishes a new version (or the time
+  runs out), then returns the fresh state — including anything new since \`since_version\`.
+  Works with no pending review too: co-editing live with a human, \`wait\` blocks until THEIR
+  next save lands. Chain \`wait\` calls instead of sleeping between polls — feedback reaches
+  you in seconds.
+
+## comment: leave, reply, react, resolve
+
+Leave feedback on an artifact, reply in a thread, react, and/or resolve or reopen a thread
+— all in one tool. Thread ids come from catch_up.
+
+- **New comment.** Anchor it to a quoted span of the rendered text with \`quote\` (the exact
+  text a reader sees — the same visible text the \`text\` read format shows).
+- **Reply.** Pass the thread id as \`reply_to\`.
+- **React (the lightweight ack).** Pass \`react\` (with \`reply_to\`) to acknowledge the latest
+  human comment in a thread without the noise of a reply — the minimum ack the loop
+  requires. 👍 is the conventional ack; pass it explicitly.
+- **Resolve / reopen.** Pass \`set_state\` (\`resolved\` or \`open\`) along with the thread's id
+  in \`reply_to\`.
+
+## check_requests: your work queue
+
+Pending requests teammates handed you by @mentioning you in a comment (the ask-agent and
+Rework buttons land here). Each entry names the artifact, the comment thread, and what to
+do.
+
+- **Handle then ack.** Work a request on its artifact — usually read it, do the asked
+  revision, and publish with the thread id in \`addresses\` — then call check_requests again
+  with \`ack:[id,…]\` to clear what you finished. Ack AFTER the work lands (a publish or a
+  reply), not on read; an unknown or already-acked id is skipped, never an error. Unacked
+  requests stay queued for your next session.
+- **Wait (long-poll).** WAITING FOR WORK? Pass \`wait\` (seconds, max 50): when the queue is
+  empty the call blocks until a new request lands (or the time runs out), then returns it —
+  chain \`wait\` calls to react in seconds instead of polling on a cadence.
+
+## Review-round etiquette
+
+When the human sends a review back (\`review.state === 'sent_back'\` in catch_up), sweep the
+open threads and acknowledge each as you address it — a \`react\` is the minimum the loop
+requires (👍 by default), or a reply where a threaded answer helps. Then revise and
+re-request review (publish with \`request_review:true\`). Cite the threads a revision fixes as publish's \`addresses\` on the SAME
+publish that resolves them, so they resolve (on a live publish) or flip to \`addressed\` (on a
+proposal) rather than being closed in a separate step.
+`
+
+const CONTEXTS = `# Asking workspace contexts
+
+Workspaces can host CONTEXTS — askable live data agents a workspace owner wired up, each
+answering questions against its own data and tools. \`list_contexts\` shows the ones your
+user may ask; \`ask\` opens a question session on your user's behalf and returns the answer.
+
+## list_contexts
+
+List the contexts you may ask in a workspace — id, name, whether the runner is online (its
+last queue poll is recent), the manifest doc that defines it, and your own still-open
+sessions so you can resume one with \`ask\`. Asking happens on your user's behalf and is
+granted per context, so this list is EXACTLY what your user may ask, nothing more. Defaults
+to your current workspace; pass \`workspace\` to look in another. Then call \`ask\` with a
+context's id or name.
+
+## ask: open, follow up, or check
+
+Ask a context a question on your user's behalf, or resume/follow up an existing session:
+
+- **OPEN** a new session: pass \`context\` (id or name) + \`question\`.
+- **FOLLOW UP** an existing session: pass \`session_id\` + \`question\` (it already knows its
+  context, so don't also pass \`context\`).
+- **CHECK / RESUME**: pass \`session_id\` alone (no question) to read the latest state and
+  transcript.
+
+The call waits up to \`wait\` seconds (default 25, max 50; 0 = return at once) for the runner's
+answer and returns it inline when it lands. Real runs often take MINUTES, so a still-open
+response is NORMAL, not an error: an expired wait leaves the session open — re-call \`ask\`
+with the returned \`session_id\` (+ \`wait\`) until it settles. Sessions resume across calls
+and across your own sessions; \`list_contexts\` surfaces your still-open ones. If the runner
+looks offline, the session is queued and answers when it comes back. Answers cite artifact
+short_ids you can then \`read\`.
+
+A settled session is normally \`answered\`; it can instead come back \`escalated\` (the runner handed a draft to a human reviewer, check back later) or \`failed\` (the run crashed, just ask again). Re-calling \`ask\` always returns the current \`state\` and a one-line \`note\`.
+`
+
+const CHECKPOINT = `# Checkpointing working state
+
+Commit a compact, resumable snapshot of your working state so any later session (on any machine) continues cold.
+
+- **First call for a piece of work:** pass \`work\` (a short name); the lineage is created and
+  the result names its \`short_id\` — record it (e.g. in a \`.derive/lineage\` file at the repo
+  root) and pass it as \`short_id\` on every checkpoint after.
+- **Each checkpoint REPLACES the page** (versions keep the history; each layer is a pinned
+  named version), so restate what still matters and drop what doesn't — the tool rejects
+  more than a page.
+- **Prefer refs over restated detail.** Cite artifact short_ids, PR/issue URLs, and key file
+  paths in \`refs\`: the layer is an index a cold session follows, not a container. A
+  continuing session reads those refs (artifact short_ids via the \`read\` tool) to rehydrate.
+`
+
+const ORGANIZE = `# Organizing the library (tags + collections)
+
+\`organize\` is the library's findability layer: browse TAGS (lightweight labels) and
+COLLECTIONS (a set treated as a unit), in one tool. Tag freely and reuse the vocabulary — a
+well-tagged library is findable. Reach for a collection only when a set is a real unit, not
+for plain findability. Tags can also be set at publish time via publish's \`tags\` param.
+
+## Read mode
+
+- **No \`short_ids\`:** returns the workspace's tag vocabulary (tag → count) and its
+  collections. Call this BEFORE tagging so you reuse an existing tag over a near-duplicate.
+- **With \`short_ids\`:** returns those artifacts' current tags + collections, plus
+  \`suggested\` tags drawn from the most semantically-similar docs (when a single id is given).
+
+## Write mode (pass \`short_ids\` plus any of these)
+
+- **\`add\`** — union onto existing tags (never drops what's there).
+- **\`remove\`** — drop these tags.
+- **\`set\`** — replace the whole tag set (overrides add/remove).
+- **\`collection\`** — fold the artifacts into a collection, by id or by name (created if new).
+
+Tags are normalized (trimmed, lowercased, deduped, capped 20). Each artifact is authorized on
+its own; ones you can't edit come back as \`skipped\`, never failing the batch.
+`
+
+export const CORE_SKILLS: readonly { name: string; summary: string; body: string }[] = [
+  {
+    name: "loop",
+    summary:
+      "catch up on an artifact, work a review round, respond to feedback, and pull queued work (catch_up, comment, check_requests)",
+    body: LOOP,
+  },
+  {
+    name: "publishing",
+    summary:
+      "create and revise artifacts (incl. fully-styled HTML pages), stage assets and large content, and file proposals for review (publish, stage_asset, stage_publish)",
+    body: PUBLISHING,
+  },
+  {
+    name: "contexts",
+    summary: "ask a workspace's live data agents (list_contexts, ask)",
+    body: CONTEXTS,
+  },
+  {
+    name: "checkpoint",
+    summary:
+      "save your working state to a resumable lineage so a later session continues cold, on any machine (checkpoint)",
+    body: CHECKPOINT,
+  },
+  {
+    name: "organize",
+    summary:
+      "make the library findable: browse the tag vocabulary + collections, and tag or collect artifacts (organize)",
+    body: ORGANIZE,
+  },
+]

--- a/apps/api/test/e2e/mcp-local-e2e.mts
+++ b/apps/api/test/e2e/mcp-local-e2e.mts
@@ -1,0 +1,216 @@
+/**
+ * Local E2E: a REAL HTTP Derive (createApp + @hono/node-server serve) driven over
+ * the /mcp Streamable-HTTP endpoint, exercising the consolidated tool surface end to
+ * end — including a genuine out-of-band content upload (stage -> curl bytes -> read
+ * back). Not a vitest test (it binds a socket); run manually:
+ *   cd apps/api && pnpm exec tsx test/e2e/mcp-local-e2e.mts
+ * Exits 0 on success, 1 on the first failed assertion. Self-seeds an OAuth grant
+ * (auto-provisions a personal workspace at owner grade), so no external state.
+ */
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { serve } from "@hono/node-server"
+import Database from "better-sqlite3"
+import { SqliteMetaStore } from "@derive/db/sqlite"
+import { FsBlobStore } from "@derive/storage/fs"
+import { createApp } from "../../src/app"
+import { createInProcessBackplane } from "../../src/bus"
+import { sha256 } from "../../src/lib/crypto"
+
+const PORT = 8199
+const BASE = `http://localhost:${PORT}`
+const BEARER = "tok_e2e"
+
+let pass = 0
+const fails: string[] = []
+const ok = (cond: unknown, msg: string) => {
+  if (cond) {
+    pass++
+    console.log(`  ✓ ${msg}`)
+  } else {
+    fails.push(msg)
+    console.log(`  ✗ ${msg}`)
+  }
+}
+
+const dir = mkdtempSync(join(tmpdir(), "derive-e2e-"))
+const dbPath = join(dir, "derive.db")
+
+// --- seed the OAuth grant (budget-test pattern: manual Better-Auth-ish tables the
+// getOAuthGrant path reads by hashed token; manage scope => owner grade) ---
+const seed = new Database(dbPath)
+seed.exec(`
+  CREATE TABLE IF NOT EXISTS "user" (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT, username TEXT, discoverable INTEGER, profession TEXT, about TEXT);
+  CREATE TABLE IF NOT EXISTS "oauthClient" (clientId TEXT PRIMARY KEY, name TEXT);
+  CREATE TABLE IF NOT EXISTS "oauthAccessToken" (token TEXT PRIMARY KEY, clientId TEXT, userId TEXT, scopes TEXT, expiresAt TEXT);
+`)
+seed.prepare(`INSERT OR IGNORE INTO "user"(id,email,name,username) VALUES('u_e2e','e2e@x.test','E2E User','e2e')`).run()
+seed.prepare(`INSERT OR IGNORE INTO "oauthClient"(clientId,name) VALUES('cli','Claude Code')`).run()
+seed
+  .prepare(`INSERT INTO "oauthAccessToken"(token,clientId,userId,scopes,expiresAt) VALUES(?,?,?,?,?)`)
+  .run(
+    sha256(BEARER),
+    "cli",
+    "u_e2e",
+    JSON.stringify(["openid", "derive:read", "derive:publish", "derive:manage"]),
+    new Date(Date.now() + 3_600_000).toISOString(),
+  )
+seed.close()
+
+const meta = new SqliteMetaStore(dbPath)
+const blobs = new FsBlobStore(join(dir, "blobs"))
+const app = createApp({
+  meta,
+  blobs,
+  baseUrl: BASE,
+  token: "dev-operator",
+  encryptionKey: "e2e-signing-secret-passphrase-0123456789",
+  backplane: createInProcessBackplane(),
+})
+const server = serve({ fetch: app.fetch, port: PORT })
+
+let id = 0
+const rpc = async (method: string, params: Record<string, unknown> = {}) => {
+  const res = await fetch(`${BASE}/mcp`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${BEARER}`,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: ++id, method, params }),
+  })
+  const txt = await res.text()
+  const ct = res.headers.get("content-type") ?? ""
+  const body = ct.includes("application/json")
+    ? JSON.parse(txt)
+    : JSON.parse((txt.split("\n").find((l) => l.startsWith("data:")) ?? "data:null").slice(5).trim())
+  return { status: res.status, body }
+}
+// A tools/call, returning the parsed text content (tools return a JSON text block).
+const call = async (name: string, args: Record<string, unknown> = {}) => {
+  const { body } = await rpc("tools/call", { name, arguments: args })
+  const text: string | undefined = body?.result?.content?.[0]?.text
+  const isError = !!body?.result?.isError
+  let json: unknown = null
+  try {
+    json = text ? JSON.parse(text) : null
+  } catch {
+    json = null
+  }
+  return { text, json: json as Record<string, unknown> | null, isError, raw: body }
+}
+
+const main = async () => {
+  // 1. initialize + tools/list — the surface is the consolidated ten, no retired names.
+  await rpc("initialize", {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "e2e", version: "1.0.0" },
+  })
+  const list = await rpc("tools/list")
+  const names: string[] = (list.body?.result?.tools ?? []).map((t: { name: string }) => t.name).sort()
+  console.log(`\n[surface] ${names.length} tools: ${names.join(", ")}`)
+  const RETIRED = ["search", "list_artifacts", "list_contexts", "check_requests", "stage_asset", "stage_publish", "setup_brandprint", "ask"]
+  ok(names.length <= 11, `tool count is small (${names.length}, target 10-11)`)
+  for (const r of RETIRED) ok(!names.includes(r), `retired tool '${r}' is gone`)
+  for (const keep of ["find", "read", "catch_up", "comment", "publish", "stage", "use", "checkpoint", "list_workspaces"])
+    ok(names.includes(keep), `tool '${keep}' present`)
+
+  // 2. find (browse) on an empty workspace — should not error, returns a structured result.
+  console.log("\n[find] browse empty workspace")
+  const f0 = await call("find")
+  ok(!f0.isError, "find (browse) does not error with no acting-human problems")
+
+  // 3. publish CREATE a small doc inline.
+  console.log("\n[publish] create inline")
+  const p1 = await call("publish", { title: "E2E Doc", content: "# Hello\n\nFirst version." })
+  ok(!p1.isError, "publish create did not error")
+  const shortId = (p1.json?.short_id as string) || (p1.json?.artifact as { short_id?: string })?.short_id
+  ok(!!shortId, `publish create returned a short_id (${shortId})`)
+
+  // 4. read it back.
+  console.log("\n[read] verify content landed")
+  const r1 = await call("read", { short_id: shortId })
+  ok(!r1.isError && (r1.text ?? "").includes("First version"), "read returns the published content")
+
+  // 5. publish EDITS (surgical) — the safe default path.
+  console.log("\n[publish] surgical edits")
+  const p2 = await call("publish", {
+    short_id: shortId,
+    edits: [{ old_str: "First version.", new_str: "Edited version." }],
+  })
+  ok(!p2.isError, "publish edits did not error")
+  const r2 = await call("read", { short_id: shortId })
+  ok((r2.text ?? "").includes("Edited version"), "edit applied and is readable")
+
+  // 6. publish GUARDRAILS: oversized base64 -> stage target:asset; oversized total -> stage target:doc.
+  console.log("\n[publish] guardrails (base64 + total size)")
+  const bigB64 = `data:image/png;base64,${"A".repeat(50_000)}` // ~37.5KB decoded, over the 32KB cap
+  const pgB = await call("publish", { title: "Bad Img", content: `<img src="${bigB64}">` })
+  ok(pgB.isError && /stage target:.?asset/i.test(pgB.text ?? ""), "oversized inline base64 rejected -> stage target:asset")
+  const pgS = await call("publish", { title: "Big Doc", content: "x".repeat(70_000) }) // over the 64KB cap
+  ok(pgS.isError && /stage target:.?doc/i.test(pgS.text ?? ""), "oversized inline content rejected -> stage target:doc")
+
+  // 7. find (query) finds the doc by content.
+  console.log("\n[find] content query")
+  const fq = await call("find", { query: "Edited" })
+  ok(!fq.isError && /Edited|E2E Doc/i.test(fq.text ?? ""), "find query surfaces the edited doc")
+
+  // 8. STAGE target:doc — the content-upload path. Mint URL, curl real bytes, read back.
+  console.log("\n[stage] doc upload (out-of-band content)")
+  const st = await call("stage", { target: "doc" })
+  ok(!st.isError, "stage target:doc minted a URL without error")
+  const uploadUrl = st.json?.upload_url as string
+  ok(!!uploadUrl && uploadUrl.startsWith(BASE), `stage returned a local upload_url (${uploadUrl?.slice(0, 48)}…)`)
+  if (uploadUrl) {
+    const htmlPath = join(dir, "big.html")
+    writeFileSync(htmlPath, `<!doctype html><meta name=viewport content="width=device-width"><h1>Staged Upload</h1><p>${"x".repeat(3000)}</p>`)
+    const fd = new FormData()
+    fd.append("file", new Blob([readFileSync(htmlPath)], { type: "text/html" }), "big.html")
+    fd.append("title", "Staged E2E Page")
+    const up = await fetch(uploadUrl, { method: "POST", body: fd })
+    const upBody = (await up.json().catch(() => ({}))) as { short_id?: string }
+    ok(up.ok, `curl-equivalent upload to stage URL succeeded (HTTP ${up.status})`)
+    ok(!!upBody.short_id, `upload created an artifact (${upBody.short_id})`)
+    if (upBody.short_id) {
+      const rs = await call("read", { short_id: upBody.short_id, render: undefined })
+      ok(/Staged Upload/.test(rs.text ?? ""), "the out-of-band uploaded content is readable via read")
+    }
+  }
+
+  // 9. STAGE target:asset — mint an asset URL (the image/font path).
+  console.log("\n[stage] asset upload")
+  const sa = await call("stage", { target: "asset" })
+  ok(!sa.isError && typeof sa.json?.upload_url === "string", "stage target:asset minted an asset upload URL")
+  ok(/asset/i.test((sa.json?.target as string) ?? "asset"), "stage asset response is typed for asset")
+
+  // 10. catch_up no-id = the work queue; an OAuth grant has no inbox -> explicit note.
+  console.log("\n[catch_up] no-id queue mode (OAuth grant)")
+  const q = await call("catch_up")
+  ok(!q.isError, "catch_up with no short_id does not error")
+  ok(/inbox|queue|mention|no .*request/i.test(q.text ?? ""), "queue mode returns an explicit note (not a bare empty list)")
+
+  // 11. use / list_workspaces sanity.
+  console.log("\n[use + list_workspaces]")
+  const lw = await call("list_workspaces")
+  ok(!lw.isError && Array.isArray(lw.json?.workspaces), "list_workspaces returns the grant's workspaces")
+}
+
+main()
+  .catch((e) => {
+    fails.push(`UNCAUGHT: ${e instanceof Error ? e.stack : String(e)}`)
+  })
+  .finally(async () => {
+    server.close()
+    try {
+      rmSync(dir, { recursive: true, force: true })
+    } catch {}
+    console.log(`\n${"=".repeat(50)}\nE2E: ${pass} passed, ${fails.length} failed`)
+    if (fails.length) {
+      console.log("FAILURES:")
+      for (const f of fails) console.log(`  - ${f}`)
+    }
+    process.exit(fails.length ? 1 : 0)
+  })

--- a/apps/api/test/e2e/mcp-local-e2e.mts
+++ b/apps/api/test/e2e/mcp-local-e2e.mts
@@ -76,7 +76,7 @@ const app = createApp({
   blobs,
   baseUrl: BASE,
   token: "dev-operator",
-  encryptionKey: "e2e-signing-secret-passphrase-0123456789",
+  encryptionKey: "e2e-secret",
   backplane: createInProcessBackplane(),
 })
 const server = serve({ fetch: app.fetch, port: PORT })

--- a/apps/api/test/e2e/mcp-local-e2e.mts
+++ b/apps/api/test/e2e/mcp-local-e2e.mts
@@ -21,6 +21,7 @@ import { sha256 } from "../../src/lib/crypto"
 const PORT = 8199
 const BASE = `http://localhost:${PORT}`
 const BEARER = "tok_e2e"
+const BEARER_PUB = "tok_pub" // a publish-but-not-manage grant, for the Brandprint manage-gate proof
 
 let pass = 0
 const fails: string[] = []
@@ -56,6 +57,16 @@ seed
     JSON.stringify(["openid", "derive:read", "derive:publish", "derive:manage"]),
     new Date(Date.now() + 3_600_000).toISOString(),
   )
+seed.prepare(`INSERT OR IGNORE INTO "user"(id,email,name,username) VALUES('u_pub','pub@x.test','Publish Only','pub')`).run()
+seed
+  .prepare(`INSERT INTO "oauthAccessToken"(token,clientId,userId,scopes,expiresAt) VALUES(?,?,?,?,?)`)
+  .run(
+    sha256(BEARER_PUB),
+    "cli",
+    "u_pub",
+    JSON.stringify(["openid", "derive:read", "derive:publish"]),
+    new Date(Date.now() + 3_600_000).toISOString(),
+  )
 seed.close()
 
 const meta = new SqliteMetaStore(dbPath)
@@ -71,13 +82,13 @@ const app = createApp({
 const server = serve({ fetch: app.fetch, port: PORT })
 
 let id = 0
-const rpc = async (method: string, params: Record<string, unknown> = {}) => {
+const rpc = async (method: string, params: Record<string, unknown> = {}, bearer = BEARER) => {
   const res = await fetch(`${BASE}/mcp`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
       accept: "application/json, text/event-stream",
-      authorization: `Bearer ${BEARER}`,
+      authorization: `Bearer ${bearer}`,
     },
     body: JSON.stringify({ jsonrpc: "2.0", id: ++id, method, params }),
   })
@@ -89,8 +100,8 @@ const rpc = async (method: string, params: Record<string, unknown> = {}) => {
   return { status: res.status, body }
 }
 // A tools/call, returning the parsed text content (tools return a JSON text block).
-const call = async (name: string, args: Record<string, unknown> = {}) => {
-  const { body } = await rpc("tools/call", { name, arguments: args })
+const call = async (name: string, args: Record<string, unknown> = {}, bearer = BEARER) => {
+  const { body } = await rpc("tools/call", { name, arguments: args }, bearer)
   const text: string | undefined = body?.result?.content?.[0]?.text
   const isError = !!body?.result?.isError
   let json: unknown = null
@@ -129,6 +140,7 @@ const main = async () => {
   ok(!p1.isError, "publish create did not error")
   const shortId = (p1.json?.short_id as string) || (p1.json?.artifact as { short_id?: string })?.short_id
   ok(!!shortId, `publish create returned a short_id (${shortId})`)
+  if (!shortId) throw new Error("create returned no short_id — cannot continue")
 
   // 4. read it back.
   console.log("\n[read] verify content landed")
@@ -192,8 +204,88 @@ const main = async () => {
   ok(!q.isError, "catch_up with no short_id does not error")
   ok(/inbox|queue|mention|no .*request/i.test(q.text ?? ""), "queue mode returns an explicit note (not a bare empty list)")
 
-  // 11. use / list_workspaces sanity.
-  console.log("\n[use + list_workspaces]")
+  // 11. comment: anchor to a quote, see it in catch_up, resolve it.
+  console.log("\n[comment] anchor + catch_up + resolve")
+  const c1 = await call("comment", { short_id: shortId, quote: "Edited version.", body: "E2E note." })
+  ok(!c1.isError, "comment (new, anchored) did not error")
+  const threadId =
+    (c1.json?.thread as string) ??
+    (c1.json?.thread_id as string) ??
+    (c1.json?.comment as { thread?: string; thread_id?: string })?.thread ??
+    (c1.json?.comment as { thread_id?: string })?.thread_id
+  const cu = await call("catch_up", { short_id: shortId, comments: "open" })
+  ok(!cu.isError && /E2E note/.test(cu.text ?? ""), "catch_up surfaces the open comment thread")
+  if (typeof threadId === "string") {
+    const c2 = await call("comment", { short_id: shortId, reply_to: threadId, set_state: "resolved" })
+    ok(!c2.isError, "comment resolve did not error")
+  }
+
+  // 12. organize: tag the doc, find it by tag.
+  console.log("\n[organize] tag + find by tag")
+  const o1 = await call("organize", { short_ids: [shortId], add: ["e2e-tag"] })
+  ok(!o1.isError, "organize add-tag did not error")
+  const ft = await call("find", { tag: "e2e-tag" })
+  ok(!ft.isError && (ft.text ?? "").includes(shortId), "find({tag}) surfaces the tagged doc")
+
+  // 13. checkpoint: create a lineage, then replace it on the same short_id.
+  console.log("\n[checkpoint] create + replace")
+  const k1 = await call("checkpoint", { work: "e2e-run", state: "testing the surface", next: ["verify the surface"] })
+  ok(!k1.isError, "checkpoint create did not error")
+  const kId = k1.json?.short_id as string
+  ok(!!kId, `checkpoint returned a lineage short_id (${kId})`)
+  if (kId) {
+    const k2 = await call("checkpoint", { short_id: kId, state: "verified" })
+    ok(!k2.isError, "checkpoint replace (same lineage) did not error")
+  }
+
+  // 14. stage target:asset -> curl a real PNG -> reference the returned url in a published doc.
+  console.log("\n[stage] asset upload + embed")
+  const png = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC",
+    "base64",
+  )
+  const saM = await call("stage", { target: "asset" })
+  const assetUrl = saM.json?.upload_url as string | undefined
+  if (assetUrl) {
+    const upA = await fetch(assetUrl, { method: "POST", body: png, headers: { "content-type": "image/png" } })
+    const upAB = (await upA.json().catch(() => ({}))) as { url?: string }
+    ok(upA.ok && !!upAB.url, `asset bytes uploaded, got a permanent url (HTTP ${upA.status})`)
+    if (upAB.url) {
+      const pe = await call("publish", { title: "Has Image", content: `<img src="${upAB.url}">` })
+      ok(!pe.isError, "publish a doc referencing the staged asset url did not error")
+    }
+  }
+
+  // 15. Brandprint dissolve: a MANAGE grant scaffolds the profile + files a proposal on the URI.
+  console.log("\n[brandprint] manage grant scaffolds + proposes")
+  const bp = await call("publish", { short_id: "derive://brandprint/profile", content: "<h1>Brand</h1>" })
+  ok(!bp.isError, "publish to derive://brandprint/profile (manage grant) did not error")
+
+  // 16. CRITICAL SAFETY: a publish-only (non-manage) grant is REFUSED on the same URI in its OWN
+  //     fresh workspace (no profile yet) — the manage-gate must hold, with no writes.
+  console.log("\n[brandprint] non-manage grant is refused (manage-gate)")
+  const bpN = await call(
+    "publish",
+    { short_id: "derive://brandprint/profile", content: "<h1>Nope</h1>" },
+    BEARER_PUB,
+  )
+  ok(
+    bpN.isError && /admin|owner|manage/i.test(bpN.text ?? ""),
+    "non-manage caller refused with an Admin/Owner error (manage-gate holds)",
+  )
+
+  // 17. use: an unknown context fails with an actionable error, not a crash.
+  console.log("\n[use] graceful with no wired context")
+  const u = await call("use", { context: "nonexistent-ctx", question: "hi" })
+  ok(u.isError && /context|no /i.test(u.text ?? ""), "use with an unknown context returns an actionable error")
+
+  // 18. read render:wait — no renderer configured here, so it must RETURN gracefully, never hang.
+  console.log("\n[read] render:wait returns gracefully")
+  const rr = await call("read", { short_id: shortId, render: "top", wait: 3 })
+  ok(!!rr.text || rr.isError, "read render:wait returned a response (did not hang)")
+
+  // 19. list_workspaces sanity.
+  console.log("\n[list_workspaces]")
   const lw = await call("list_workspaces")
   ok(!lw.isError && Array.isArray(lw.json?.workspaces), "list_workspaces returns the grant's workspaces")
 }

--- a/apps/api/test/mcp-contexts.test.ts
+++ b/apps/api/test/mcp-contexts.test.ts
@@ -4,11 +4,14 @@ import { sha256 } from "../src/lib/crypto"
 import { inMemoryRateLimiters } from "../src/lib/rate-limit"
 import { as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 
-// The MCP ask surface: list_contexts + ask act for the connection's on-behalf
-// human (the token's registrant / the OAuth grantor), gated per call by that
-// human's OWN ask-grant — canUserAskContext, the same rule the console enforces.
-// The tools are registered on every connection (the surface never differs by
-// auth kind); a connection with no known human is refused at call time.
+// The MCP ask surface after the 15→10 consolidation: `find` surfaces the askable
+// contexts as typed {type:"context"} rows (the former list_contexts), and `use`
+// acts on them (the former ask). Both act for the connection's on-behalf human
+// (the token's registrant / the OAuth grantor), gated per call by that human's OWN
+// ask-grant — canUserAskContext, the same rule the console enforces. `use` is
+// registered on every connection and refuses a no-human connection at call time;
+// `find` does NOT refuse it — it returns artifact rows plus a `contexts_note`
+// explaining the contexts are hidden without a signed-in user.
 //
 // Cast: owner (Admin) registers the agents — the answering one and "OwnerBot",
 // the MCP connection under test, whose acting human is therefore OWNER. dev
@@ -63,6 +66,14 @@ const call = async (
   // biome-ignore lint/suspicious/noExplicitAny: test convenience over a JSON payload
 ): Promise<any> => JSON.parse((await callRaw(app, token, name, args)).text)
 
+// find's browse/search rows are typed; the askable contexts come back as
+// {type:"context"} rows — the former list_contexts payload, one per context, each
+// carrying its own your_open_sessions. Pull just those out of a find result.
+const contextsOf = (
+  r: { results?: { type?: string }[] },
+  // biome-ignore lint/suspicious/noExplicitAny: test convenience over a JSON payload
+): any[] => (r.results ?? []).filter((x) => x.type === "context")
+
 const setup = async (name: string, deps?: Record<string, unknown>) => {
   const made = makeAuthedApp(name, [owner, dev], "editor", deps ? { deps } : undefined)
   const { app, meta } = made
@@ -100,15 +111,15 @@ const setup = async (name: string, deps?: Record<string, unknown>) => {
   }
 }
 
-describe("list_contexts — ask-scoped discovery", () => {
+describe("find — ask-scoped context discovery", () => {
   it("shows only what the acting human may ask; invited admits via the roster", async () => {
     const { app, cx, manifestShortId, ownerToken } = await setup("mcx-list")
     // Default ask_policy is `invited` (creator + roster): owner is a plain
-    // member, so OwnerBot sees nothing — and learns nothing exists.
-    const before = await call(app, ownerToken, "list_contexts", {})
-    expect(before.count).toBe(0)
-    // The creator invites owner; the same call now shows the context, offline
-    // (its runner has never polled), with the manifest identity attached.
+    // member, so OwnerBot sees no context rows — and learns nothing exists.
+    const before = await call(app, ownerToken, "find", {})
+    expect(contextsOf(before)).toHaveLength(0)
+    // The creator invites owner; the same call now surfaces the context row,
+    // offline (its runner has never polled), with the manifest identity attached.
     expect(
       (
         await app.request(
@@ -117,17 +128,18 @@ describe("list_contexts — ask-scoped discovery", () => {
         )
       ).status,
     ).toBe(201)
-    const after = await call(app, ownerToken, "list_contexts", {})
-    expect(after.count).toBe(1)
-    expect(after.contexts).toMatchObject([
+    const after = await call(app, ownerToken, "find", {})
+    const ctxs = contextsOf(after)
+    expect(ctxs).toMatchObject([
       {
+        type: "context",
         id: cx.id,
         name: "Analytics",
         online: false,
         manifest: { short_id: manifestShortId, title: "Analytics manifest" },
       },
     ])
-    expect(after.your_open_sessions).toEqual([])
+    expect(ctxs[0].your_open_sessions).toEqual([])
   })
 
   it("workspace policy admits every member; a web-opened session shows as resumable", async () => {
@@ -141,21 +153,21 @@ describe("list_contexts — ask-scoped discovery", () => {
       ).status,
     ).toBe(200)
     // A session the human opened in the CONSOLE is the same session the agent
-    // may resume — the MCP surface is the human's own seat.
+    // may resume — the MCP surface is the human's own seat. On a find context
+    // row, that open session rides in the row's own your_open_sessions.
     const opened = await (
       await app.request(
         `/v1/contexts/${cx.id}/sessions`,
         jsonAs(as(owner.email), { body_md: "Q?" }),
       )
     ).json()
-    const res = await call(app, ownerToken, "list_contexts", {})
-    expect(res.count).toBe(1)
-    expect(res.your_open_sessions).toMatchObject([
-      { id: opened.session.id, context: "Analytics", state: "open" },
-    ])
+    const res = await call(app, ownerToken, "find", {})
+    const ctxs = contextsOf(res)
+    expect(ctxs).toHaveLength(1)
+    expect(ctxs[0].your_open_sessions).toMatchObject([{ id: opened.session.id, state: "open" }])
   })
 
-  it("a connection with no acting human is refused at call time, not hidden", async () => {
+  it("a connection with no acting human returns a note, not context rows (find never refuses)", async () => {
     const { app, meta } = await setup("mcx-list-nohuman")
     // A pre-column legacy token: a registered agent with no created_by. Only
     // reachable by seeding the store directly — the API always stamps a creator.
@@ -169,9 +181,13 @@ describe("list_contexts — ask-scoped discovery", () => {
       role: "editor",
       created_by: null,
     })
-    const r = await callRaw(app, raw, "list_contexts", {})
-    expect(r.isError).toBe(true)
-    expect(r.text).toContain("no acting human")
+    // INTENTIONAL behavior change from the retired list_contexts (which errored):
+    // find does NOT refuse a no-human connection. It returns artifact rows and
+    // adds a contexts_note saying the askable contexts are hidden without a
+    // signed-in user — so no context row appears, but the browse itself succeeds.
+    const r = await call(app, raw, "find", {})
+    expect(r.contexts_note).toContain("no signed-in user")
+    expect(contextsOf(r)).toHaveLength(0)
   })
 })
 
@@ -183,7 +199,7 @@ const answerAs = (app: App, token: string, sessionId: string, body: Record<strin
     body: JSON.stringify(body),
   })
 
-describe("ask — open, check, and the grant edges", () => {
+describe("use — open, check, and the grant edges", () => {
   it("opens a session as the acting human; the console sees it as theirs", async () => {
     const { app, cx, ownerToken } = await setup("mcx-ask-open")
     expect(
@@ -194,7 +210,7 @@ describe("ask — open, check, and the grant edges", () => {
         )
       ).status,
     ).toBe(200)
-    const res = await call(app, ownerToken, "ask", {
+    const res = await call(app, ownerToken, "use", {
       context: "Analytics",
       question: "What changed this week?",
       wait: 0,
@@ -222,7 +238,7 @@ describe("ask — open, check, and the grant edges", () => {
         )
       ).status,
     ).toBe(200)
-    const opened = await call(app, ownerToken, "ask", { context: cx.id, question: "Q?", wait: 0 })
+    const opened = await call(app, ownerToken, "use", { context: cx.id, question: "Q?", wait: 0 })
     expect(
       (
         await answerAs(app, answeringToken, opened.session_id, {
@@ -232,7 +248,7 @@ describe("ask — open, check, and the grant edges", () => {
         })
       ).status,
     ).toBe(201)
-    const res = await call(app, ownerToken, "ask", { session_id: opened.session_id, wait: 0 })
+    const res = await call(app, ownerToken, "use", { session_id: opened.session_id, wait: 0 })
     expect(res.state).toBe("answered")
     expect(res.answer).toMatchObject({ body_md: "42.", meta: { confidence: 0.9 } })
     // Check-only mode re-grounds a resumed caller: asker turn + agent turn.
@@ -253,7 +269,7 @@ describe("ask — open, check, and the grant edges", () => {
       ).status,
     ).toBe(200)
     // A 5k question and a 50k answer — both over their caps (1.5k/entry, 40k answer).
-    const opened = await call(app, ownerToken, "ask", {
+    const opened = await call(app, ownerToken, "use", {
       context: cx.id,
       question: "q".repeat(5_000),
       wait: 0,
@@ -266,7 +282,7 @@ describe("ask — open, check, and the grant edges", () => {
         })
       ).status,
     ).toBe(201)
-    const res = await call(app, ownerToken, "ask", { session_id: opened.session_id, wait: 0 })
+    const res = await call(app, ownerToken, "use", { session_id: opened.session_id, wait: 0 })
     // The answer keeps a generous prefix; the steer names the console.
     expect(res.answer.body_md.length).toBeLessThan(45_000)
     expect(res.answer.body_md).toContain("truncated")
@@ -282,7 +298,7 @@ describe("ask — open, check, and the grant edges", () => {
   it("names the askable contexts when the ref misses — and stays silent when none are", async () => {
     const { app, cx, ownerToken } = await setup("mcx-ask-miss")
     // No grant at all: the miss must not enumerate what exists.
-    const dark = await callRaw(app, ownerToken, "ask", {
+    const dark = await callRaw(app, ownerToken, "use", {
       context: "Analytics",
       question: "Q?",
       wait: 0,
@@ -298,7 +314,7 @@ describe("ask — open, check, and the grant edges", () => {
         )
       ).status,
     ).toBe(200)
-    const miss = await callRaw(app, ownerToken, "ask", {
+    const miss = await callRaw(app, ownerToken, "use", {
       context: "Analytcs",
       question: "Q?",
       wait: 0,
@@ -316,14 +332,14 @@ describe("ask — open, check, and the grant edges", () => {
         jsonAs(as(dev.email), { body_md: "mine" }),
       )
     ).json()
-    const r = await callRaw(app, ownerToken, "ask", { session_id: opened.session.id })
+    const r = await callRaw(app, ownerToken, "use", { session_id: opened.session.id })
     expect(r.isError).toBe(true)
     expect(r.text).toContain("No session")
     expect(r.text).not.toContain("forbidden")
   })
 })
 
-describe("ask({wait}) — the settle wake and the session loop", () => {
+describe("use({wait}) — the settle wake and the session loop", () => {
   // The workspace-policy flip every case here needs (dev is creator; the MCP
   // caller acts for owner, a plain member).
   const openPolicy = async (app: App, cxId: string) =>
@@ -340,13 +356,13 @@ describe("ask({wait}) — the settle wake and the session loop", () => {
     const backplane = createInProcessBackplane()
     const { app, cx, ownerToken, answeringToken } = await setup("mcx-wake", { backplane })
     await openPolicy(app, cx.id)
-    const opened = await call(app, ownerToken, "ask", {
+    const opened = await call(app, ownerToken, "use", {
       context: "Analytics",
       question: "Q?",
       wait: 0,
     })
     const started = Date.now()
-    const waiting = call(app, ownerToken, "ask", { session_id: opened.session_id, wait: 20 })
+    const waiting = call(app, ownerToken, "use", { session_id: opened.session_id, wait: 20 })
     // A beat for the waiter to subscribe, then the runner settles over REST.
     await new Promise((r) => setTimeout(r, 150))
     expect(
@@ -368,7 +384,7 @@ describe("ask({wait}) — the settle wake and the session loop", () => {
   it("a follow-up rides the same session and re-opens it; closed refuses with a pointer", async () => {
     const { app, cx, ownerToken, answeringToken } = await setup("mcx-follow")
     await openPolicy(app, cx.id)
-    const opened = await call(app, ownerToken, "ask", {
+    const opened = await call(app, ownerToken, "use", {
       context: "Analytics",
       question: "Q?",
       wait: 0,
@@ -381,7 +397,7 @@ describe("ask({wait}) — the settle wake and the session loop", () => {
         })
       ).status,
     ).toBe(201)
-    const follow = await call(app, ownerToken, "ask", {
+    const follow = await call(app, ownerToken, "use", {
       session_id: opened.session_id,
       question: "And why?",
       wait: 0,
@@ -397,7 +413,7 @@ describe("ask({wait}) — the settle wake and the session loop", () => {
         })
       ).status,
     ).toBe(200)
-    const refused = await callRaw(app, ownerToken, "ask", {
+    const refused = await callRaw(app, ownerToken, "use", {
       session_id: opened.session_id,
       question: "still there?",
       wait: 0,
@@ -412,13 +428,13 @@ describe("ask({wait}) — the settle wake and the session loop", () => {
       rateLimiters: inMemoryRateLimiters({ askRate: 2 }),
     })
     await openPolicy(app, cx.id)
-    const first = await call(app, ownerToken, "ask", {
+    const first = await call(app, ownerToken, "use", {
       context: "Analytics",
       question: "1",
       wait: 0,
     })
-    await call(app, ownerToken, "ask", { context: "Analytics", question: "2", wait: 0 })
-    const third = await callRaw(app, ownerToken, "ask", {
+    await call(app, ownerToken, "use", { context: "Analytics", question: "2", wait: 0 })
+    const third = await callRaw(app, ownerToken, "use", {
       context: "Analytics",
       question: "3",
       wait: 0,
@@ -426,7 +442,7 @@ describe("ask({wait}) — the settle wake and the session loop", () => {
     expect(third.isError).toBe(true)
     expect(third.text).toContain("Rate limit")
     // Reads don't spend the budget: checking a session still works while capped.
-    const check = await call(app, ownerToken, "ask", { session_id: first.session_id, wait: 0 })
+    const check = await call(app, ownerToken, "use", { session_id: first.session_id, wait: 0 })
     expect(check.state).toBe("open")
   })
 })

--- a/apps/api/test/mcp-inbox-wait.test.ts
+++ b/apps/api/test/mcp-inbox-wait.test.ts
@@ -4,9 +4,10 @@ import { as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 
 // Phase 2 slice 1 — the cross-doc wake. An @mention lands a row in the agent's
 // pull inbox AND publishes `request.created` on the agent's `u:<id>` channel, so a
-// session long-polling `check_requests({wait})` wakes in ~a beat instead of only
-// on its next reconnect. Mirrors catch_up's `wait`: the event is a wake signal
-// only, so the handler always answers from a fresh store read.
+// session long-polling `catch_up({wait})` (no short_id = the work queue, formerly
+// check_requests) wakes in ~a beat instead of only on its next reconnect. Mirrors
+// catch_up's artifact `wait`: the event is a wake signal only, so the handler
+// always answers from a fresh store read.
 
 const owner: TestUser = { id: "u_iw_own", email: "iwown@derive.test", name: "Owner" }
 
@@ -60,7 +61,7 @@ const mention = (app: App, shortId: string, agentId: string, body: string) =>
     jsonAs(as(owner.email), { body_md: body, mentions: [{ id: agentId, name: "Claude" }] }),
   )
 
-describe("check_requests({wait}) — the cross-doc wake", () => {
+describe("catch_up({wait}) work queue — the cross-doc wake", () => {
   it("blocks, then wakes the instant an @mention lands, and answers from a fresh read", async () => {
     const backplane = createInProcessBackplane()
     const { app } = makeAuthedApp("inbox-wait", [owner], "commenter", { deps: { backplane } })
@@ -75,7 +76,7 @@ describe("check_requests({wait}) — the cross-doc wake", () => {
 
     // Start the long-poll BEFORE the mention exists — its connect snapshot is empty,
     // so it must block on the wake rather than return immediately.
-    const waiting = call(app, agentToken, "check_requests", { wait: 10 })
+    const waiting = call(app, agentToken, "catch_up", { wait: 10 })
     const cm = await mention(app, shortId, agentId, "@Claude tighten the headline")
     expect(cm.status).toBe(201)
 
@@ -97,7 +98,7 @@ describe("check_requests({wait}) — the cross-doc wake", () => {
     // A generous wait that must NOT be spent: the request is already pending, so the
     // call returns at once. (If it blocked the full 30s the test would time out.)
     const started = Date.now()
-    const res = await call(app, agentToken, "check_requests", { wait: 30 })
+    const res = await call(app, agentToken, "catch_up", { wait: 30 })
     expect(Date.now() - started).toBeLessThan(5_000)
     expect(res.pending).toHaveLength(1)
   })

--- a/apps/api/test/mcp-loop.test.ts
+++ b/apps/api/test/mcp-loop.test.ts
@@ -250,10 +250,10 @@ describe("the team-draft default", () => {
     expect(a?.workspace_access).toBe("member")
     expect(a?.link_role).toBe("none")
 
-    // The agent's list_artifacts finds it through the acting user's owner row —
+    // The agent's find (browse) surfaces it through the acting user's owner row —
     // it can always find its own work; a teammate's invite-only draft stays invisible.
-    const list = await call(app, token, "list_artifacts", {})
-    const shortIds = (list.artifacts as { short_id: string }[]).map((x) => x.short_id)
+    const list = await call(app, token, "find", {})
+    const shortIds = (list.results as { short_id?: string }[]).map((x) => x.short_id)
     expect(shortIds).toContain(created.short_id)
 
     // An explicit listing still wins over the workspace default.

--- a/apps/api/test/mcp-surface-budget.test.ts
+++ b/apps/api/test/mcp-surface-budget.test.ts
@@ -1,0 +1,141 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { SqliteMetaStore } from "@derive/db/sqlite"
+import { FsBlobStore } from "@derive/storage/fs"
+import Database from "better-sqlite3"
+import { afterAll, describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { sha256 } from "../src/lib/crypto"
+import { CORE_SKILLS } from "../src/skills-reference"
+
+// The always-loaded MCP surface — every tool description plus the server
+// `instructions` — is context every connected agent pays for on every session,
+// before it has done anything. The thin-tools/thick-skills reorg (spec: the
+// "Thin tools, thick skills" plan on Derive) moved the workflow/protocol prose OUT of
+// that surface and into lazily-read core skills (derive://skills/*, src/skills-reference.ts),
+// so each description now states intent, keeps its safety/consequence lines, and steers
+// to a skill at the decision point. These budgets keep the surface thin: they sit a
+// bit above the measured slimmed result, so blowing one means new prose crept back
+// into a description or the instructions — move it into a skill body instead, or raise
+// the budget here deliberately, in the same change that explains why.
+// Measured after the thin-tools reorg (all 15 tools slimmed, 5 core skills): summed tool
+// descriptions ~9063 chars, representative instructions ~1917 chars. The description cap
+// sits ~12% above the measured slim result; the instructions cap is deliberately generous
+// (the high-level block is finalized by hand in review) yet still below the old fat prose
+// so a regression to it fails here.
+const TOOL_DESCRIPTIONS_BUDGET = 10200
+const INSTRUCTIONS_BUDGET = 2400
+
+const dir = mkdtempSync(join(tmpdir(), "derive-mcp-budget-"))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+// A representative connection: an OAuth grant with read+publish (the common
+// claude.ai / Claude Code hookup), no Brandprint, no pending requests.
+function appWithGrant(name: string, scopes: string) {
+  const path = join(dir, `${name}.db`)
+  const meta = new SqliteMetaStore(path)
+  const db = new Database(path)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS "user" (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT, username TEXT, discoverable INTEGER, profession TEXT, about TEXT);
+    CREATE TABLE IF NOT EXISTS "oauthClient" (clientId TEXT PRIMARY KEY, name TEXT);
+    CREATE TABLE IF NOT EXISTS "oauthAccessToken" (token TEXT PRIMARY KEY, clientId TEXT, userId TEXT, scopes TEXT, expiresAt TEXT);
+  `)
+  db.prepare(
+    `INSERT OR IGNORE INTO "user"(id,email,name) VALUES('u_o','owner@x.test','Owner')`,
+  ).run()
+  db.prepare(`INSERT OR IGNORE INTO "oauthClient"(clientId,name) VALUES('cli','Claude')`).run()
+  db.prepare(
+    `INSERT INTO "oauthAccessToken"(token,clientId,userId,scopes,expiresAt) VALUES(?,?,?,?,?)`,
+  ).run(
+    sha256(`tok_${name}`),
+    "cli",
+    "u_o",
+    JSON.stringify(scopes.split(/\s+/).filter(Boolean)),
+    new Date(Date.now() + 3_600_000).toISOString(),
+  )
+  db.close()
+  const blobs = new FsBlobStore(join(dir, `${name}-blobs`))
+  const app = createApp({ meta, blobs, baseUrl: "http://derive.test", token: "tok" })
+  return { app, token: `tok_${name}` }
+}
+
+type App = ReturnType<typeof createApp>
+
+async function rpc(app: App, token: string, body: unknown) {
+  const res = await app.request("/mcp", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  })
+  const txt = await res.text()
+  const ct = res.headers.get("content-type") ?? ""
+  if (ct.includes("application/json")) return JSON.parse(txt)
+  const dataLine = txt.split("\n").find((l) => l.startsWith("data:"))
+  return dataLine ? JSON.parse(dataLine.slice(5).trim()) : null
+}
+
+const initBody = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "vitest", version: "1.0.0" },
+  },
+}
+
+describe("MCP surface budget (thin tools, thick skills)", () => {
+  it("keeps the summed tool descriptions and the instructions under budget", async () => {
+    const { app, token } = appWithGrant("budget", "openid derive:read derive:publish")
+
+    const init = await rpc(app, token, initBody)
+    const instructions: string = init?.result?.instructions ?? ""
+    expect(instructions.length).toBeGreaterThan(0)
+    // The core-skills index is still ADVERTISED in the always-loaded instructions —
+    // thinning must not drop the pointer that makes the lazy skills discoverable.
+    for (const skill of CORE_SKILLS) expect(instructions).toContain(`derive://skills/${skill.name}`)
+
+    const list = await rpc(app, token, { jsonrpc: "2.0", id: 2, method: "tools/list" })
+    const tools: { name: string; description?: string }[] = list?.result?.tools ?? []
+    expect(tools.length).toBeGreaterThan(0)
+
+    // Every tool keeps a description (thin, not absent).
+    for (const t of tools) expect(t.description, `tool ${t.name} has no description`).toBeTruthy()
+
+    const summed = tools.reduce((n, t) => n + (t.description?.length ?? 0), 0)
+    console.log(
+      `MCP surface: ${tools.length} tools, descriptions ${summed} chars, instructions ${instructions.length} chars`,
+    )
+    expect(summed).toBeLessThan(TOOL_DESCRIPTIONS_BUDGET)
+    expect(instructions.length).toBeLessThan(INSTRUCTIONS_BUDGET)
+  })
+
+  it("resolves every core skill through read('derive://skills/<name>')", async () => {
+    // The lazy path the thin surface leans on: each skill body must round-trip through
+    // the read tool (every client supports it, even where MCP resources don't), so the
+    // steer "read derive://skills/<name>" in a description can never be a dead link.
+    const { app, token } = appWithGrant("skills", "openid derive:read derive:publish")
+    await rpc(app, token, initBody)
+
+    for (const skill of CORE_SKILLS) {
+      const res = await rpc(app, token, {
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "read", arguments: { short_id: `derive://skills/${skill.name}` } },
+      })
+      const raw: string | undefined = res?.result?.content?.[0]?.text
+      expect(raw, `read derive://skills/${skill.name} returned no text`).toBeTruthy()
+      const payload = JSON.parse(raw as string) as { uri: string; content: string }
+      expect(payload.uri).toBe(`derive://skills/${skill.name}`)
+      expect(payload.content.length).toBeGreaterThan(0)
+      expect(payload.content).toBe(skill.body)
+    }
+  })
+})

--- a/apps/api/test/mcp-surface-budget.test.ts
+++ b/apps/api/test/mcp-surface-budget.test.ts
@@ -19,12 +19,14 @@ import { CORE_SKILLS } from "../src/skills-reference"
 // bit above the measured slimmed result, so blowing one means new prose crept back
 // into a description or the instructions — move it into a skill body instead, or raise
 // the budget here deliberately, in the same change that explains why.
-// Measured after the thin-tools reorg (all 15 tools slimmed, 5 core skills): summed tool
-// descriptions ~9063 chars, representative instructions ~1917 chars. The description cap
-// sits ~12% above the measured slim result; the instructions cap is deliberately generous
-// (the high-level block is finalized by hand in review) yet still below the old fat prose
-// so a regression to it fails here.
-const TOOL_DESCRIPTIONS_BUDGET = 10200
+// Measured after the 15→10 tool consolidation (find merges search/list_artifacts/
+// list_contexts; stage merges the two stage_* tools; catch_up absorbs check_requests as
+// its no-short_id queue; ask→use; setup_brandprint folded into publish; 5 core skills):
+// summed tool descriptions ~7077 chars, representative instructions ~1851 chars. The
+// description cap sits ~13% above the measured result; the instructions cap is deliberately
+// generous (the high-level block is finalized by hand in review) yet still below the old fat
+// prose so a regression to it fails here.
+const TOOL_DESCRIPTIONS_BUDGET = 8000
 const INSTRUCTIONS_BUDGET = 2400
 
 const dir = mkdtempSync(join(tmpdir(), "derive-mcp-budget-"))

--- a/apps/api/test/mcp-workspace-switch.test.ts
+++ b/apps/api/test/mcp-workspace-switch.test.ts
@@ -150,22 +150,22 @@ describe.skipIf(process.env.DERIVE_TEST_DB === "pg")("remote MCP workspace switc
     )
   })
 
-  it("list_artifacts scopes to the targeted workspace", async () => {
+  it("find (browse) scopes to the targeted workspace", async () => {
     const { app } = twoWorkspaceApp("switch-listarts")
     const created = await callJson(app, "publish", {
       title: "Only In Two",
       content: "<h1>x</h1>",
       workspace: "ws_two",
     })
-    const inTwo = (id: string) => (a: { short_id: string }) => a.short_id === id
+    const inTwo = (id: string) => (a: { short_id?: string }) => a.short_id === id
 
     // Default workspace (ws_one) doesn't see the ws_two artifact...
-    const def = await callJson(app, "list_artifacts")
-    expect(def.artifacts.some(inTwo(created.short_id))).toBe(false)
-    // ...but targeting ws_two (by name) does.
-    const two = await callJson(app, "list_artifacts", { workspace: "Derive" })
+    const def = await callJson(app, "find")
+    expect(def.results.some(inTwo(created.short_id))).toBe(false)
+    // ...but targeting ws_two (by name) does. find browse returns typed `results`.
+    const two = await callJson(app, "find", { workspace: "Derive" })
     expect(two.workspace).toBe("ws_two")
-    expect(two.artifacts.some(inTwo(created.short_id))).toBe(true)
+    expect(two.results.some(inTwo(created.short_id))).toBe(true)
   })
 
   it("fails closed on a workspace the owner can't reach", async () => {
@@ -175,9 +175,7 @@ describe.skipIf(process.env.DERIVE_TEST_DB === "pg")("remote MCP workspace switc
       content: "<h1>x</h1>",
       workspace: "ws_two",
     })
-    expect(toolText(await call(app, "list_artifacts", { workspace: "ws_nope" }))).toContain(
-      "No workspace",
-    )
+    expect(toolText(await call(app, "find", { workspace: "ws_nope" }))).toContain("No workspace")
     expect(
       toolText(await call(app, "read", { short_id: created.short_id, workspace: "ws_nope" })),
     ).toContain("No workspace")
@@ -202,9 +200,7 @@ describe.skipIf(process.env.DERIVE_TEST_DB === "pg")("remote MCP workspace switc
 
     // Targeting ws_one — a real workspace the owner belongs to, but OUTSIDE the
     // grant — is refused, not silently honored.
-    expect(toolText(await call(app, "list_artifacts", { workspace: "ws_one" }))).toContain(
-      "in this grant",
-    )
+    expect(toolText(await call(app, "find", { workspace: "ws_one" }))).toContain("in this grant")
     expect(
       toolText(await call(app, "read", { short_id: doc.short_id, workspace: "ws_one" })),
     ).toContain("in this grant")
@@ -231,8 +227,6 @@ describe.skipIf(process.env.DERIVE_TEST_DB === "pg")("remote MCP workspace switc
     expect(ws.count).toBe(2)
     expect(ws.workspaces.map((w: { id: string }) => w.id).sort()).toEqual(["ws_one", "ws_three"])
     // ws_two is a real workspace of the owner's but outside the grant → unreachable.
-    expect(toolText(await call(app, "list_artifacts", { workspace: "Derive" }))).toContain(
-      "in this grant",
-    )
+    expect(toolText(await call(app, "find", { workspace: "Derive" }))).toContain("in this grant")
   })
 })

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -23,7 +23,8 @@ import { PNG_BYTES } from "./fixtures"
 // straight into the oauth-provider tables (what the consent dance produces), publish
 // an artifact as that scoped agent, then drive the MCP JSON-RPC handshake + tools
 // over Streamable HTTP and assert the agent sees its own workspace. The tool surface
-// is the consolidated five: list_artifacts, read, catch_up, comment, publish.
+// is the consolidated ten (15→10, commit 65eb4e9): list_workspaces, find, read,
+// organize, catch_up, comment, stage, publish, checkpoint, use.
 
 const dir = mkdtempSync(join(tmpdir(), "derive-mcp-"))
 afterAll(() => rmSync(dir, { recursive: true, force: true }))
@@ -99,6 +100,19 @@ const toolText = (r: RpcOut): string => {
 const toolNames = (r: RpcOut): string[] =>
   ((r.parsed?.result as { tools?: { name: string }[] } | undefined)?.tools ?? []).map((t) => t.name)
 
+// find's workspace-search (query, no short_id) returns JSON with typed `results`; the
+// literal/semantic hits come back as {type:"match"} rows (contexts, when any, ride as
+// separate {type:"context"} rows). Pull just the match rows out.
+type FindMatch = {
+  type: string
+  short_id: string
+  title: string
+  snippet: string
+  semantic: boolean
+}
+const matchRows = (payload: { results?: { type?: string }[] }): FindMatch[] =>
+  (payload.results ?? []).filter((r): r is FindMatch => r.type === "match")
+
 const initBody = {
   jsonrpc: "2.0",
   id: 1,
@@ -165,24 +179,23 @@ describe("remote MCP endpoint (/mcp)", () => {
 
     const list = await rpc(app, token, { jsonrpc: "2.0", id: 2, method: "tools/list" })
     const names = toolNames(list)
+    // The consolidated ten (15→10, commit 65eb4e9): find merges search/
+    // list_artifacts/list_contexts; stage merges stage_asset/stage_publish;
+    // catch_up absorbs check_requests as its no-short_id queue; use replaces ask;
+    // setup_brandprint folds into publish (derive://brandprint/profile).
     expect(names.sort()).toEqual([
-      "ask",
       "catch_up",
-      "check_requests",
       "checkpoint",
       "comment",
-      "list_artifacts",
-      "list_contexts",
+      "find",
       "list_workspaces",
       "organize",
       "publish",
       "read",
-      "search",
-      "setup_brandprint",
-      "stage_asset",
-      "stage_publish",
+      "stage",
+      "use",
     ])
-    // Consolidated away — folded into catch_up / comment / publish / organize.
+    // Consolidated away — folded into find / catch_up / comment / publish / stage / use.
     for (const gone of [
       "whoami",
       "catch_me_up",
@@ -198,17 +211,27 @@ describe("remote MCP endpoint (/mcp)", () => {
       "tag",
       "list_collections",
       "collect",
+      // The 15→10 consolidation retired these by name.
+      "search",
+      "list_artifacts",
+      "list_contexts",
+      "check_requests",
+      "stage_asset",
+      "stage_publish",
+      "setup_brandprint",
+      "ask",
     ])
       expect(names).not.toContain(gone)
   })
 
-  it("stage_asset mints an upload URL an anonymous shell can spend (the pasted-screenshot path)", async () => {
+  it("stage target:'asset' mints an upload URL an anonymous shell can spend (the pasted-screenshot path)", async () => {
     // The whole point: the OAuth credential lives inside the MCP transport, so the
     // agent's shell has no bearer — the minted URL must work with NO auth header.
     const { app, token } = appWithGrant("stageasset", "openid derive:read derive:publish", {
       encryptionKey: "mcp-upload-secret",
     })
-    const staged = JSON.parse(toolText(await call(app, token, "stage_asset")))
+    const staged = JSON.parse(toolText(await call(app, token, "stage", { target: "asset" })))
+    expect(staged.target).toBe("asset")
     expect(staged.upload_url).toContain("/v1/assets/t/")
     expect(staged.max_bytes).toBeGreaterThan(0)
 
@@ -229,17 +252,18 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(new Uint8Array(await served.arrayBuffer())).toEqual(png)
   })
 
-  it("stage_asset fails actionably when no signing secret is configured", async () => {
+  it("stage target:'asset' fails actionably when no signing secret is configured", async () => {
     const { app, token } = appWithGrant("stagenosecret", "openid derive:read derive:publish")
-    const r = await call(app, token, "stage_asset")
+    const r = await call(app, token, "stage", { target: "asset" })
     expect(toolText(r)).toContain("bearer token")
   })
 
-  it("stage_publish mints a URL an anonymous shell can publish a whole file through", async () => {
+  it("stage target:'doc' mints a URL an anonymous shell can publish a whole file through", async () => {
     const { app, token, meta } = appWithGrant("stagepub", "openid derive:read derive:publish", {
       encryptionKey: "mcp-publish-secret",
     })
-    const staged = JSON.parse(toolText(await call(app, token, "stage_publish")))
+    const staged = JSON.parse(toolText(await call(app, token, "stage", { target: "doc" })))
+    expect(staged.target).toBe("doc")
     expect(staged.upload_url).toContain("/v1/artifacts/t/")
     expect(staged.mode).toBe("create")
 
@@ -287,12 +311,12 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect((await meta.getVersion(rec.id, 1))?.source).toBe("mcp")
   })
 
-  it("stage_publish fails actionably when no signing secret is configured", async () => {
+  it("stage target:'doc' fails actionably when no signing secret is configured", async () => {
     const { app, token } = appWithGrant("stagepubnosecret", "openid derive:read derive:publish")
-    expect(toolText(await call(app, token, "stage_publish"))).toContain("bearer token")
+    expect(toolText(await call(app, token, "stage", { target: "doc" }))).toContain("bearer token")
   })
 
-  it("stage_publish revise mints a versions URL that publishes a new version", async () => {
+  it("stage target:'doc' revise mints a versions URL that publishes a new version", async () => {
     const { app, token, meta } = appWithGrant("stagepubrev", "openid derive:read derive:publish", {
       encryptionKey: "mcp-publish-secret",
     })
@@ -306,7 +330,7 @@ describe("remote MCP endpoint (/mcp)", () => {
       role: "editor",
     })
     const staged = JSON.parse(
-      toolText(await call(app, token, "stage_publish", { short_id: shortId })),
+      toolText(await call(app, token, "stage", { target: "doc", short_id: shortId })),
     )
     expect(staged.upload_url).toContain(`/v1/artifacts/${shortId}/versions/t/`)
     expect(staged.mode).toBe(`revise ${shortId}`)
@@ -322,6 +346,44 @@ describe("remote MCP endpoint (/mcp)", () => {
     const up = await app.request(new URL(staged.upload_url).pathname, { method: "POST", body: fd })
     expect(up.status).toBe(201)
     expect((await up.json()).published).toBe(2)
+  })
+
+  it("stage requires a target (doc or asset) — never a silent default", async () => {
+    const { app, token } = appWithGrant("stagenotarget", "openid derive:read derive:publish", {
+      encryptionKey: "mcp-secret",
+    })
+    // `target` is a required enum on stage — omitting it is rejected at the schema, not
+    // silently defaulted to doc or asset.
+    const r = await call(app, token, "stage", {})
+    const result = r.parsed?.result as
+      | { isError?: boolean; content?: { text: string }[] }
+      | undefined
+    const errText = result?.content?.[0]?.text ?? JSON.stringify(r.parsed?.error ?? "")
+    expect(result?.isError === true || r.parsed?.error != null).toBe(true)
+    expect(errText.toLowerCase()).toContain("target")
+  })
+
+  it("publish rejects an oversized inline base64 data: URI, steering to stage target:'asset'", async () => {
+    const { app, token } = appWithGrant("pubbigb64", "openid derive:read derive:publish")
+    // A single base64 data: URI whose DECODED size clears the 32KB cap (base64 decodes
+    // ~3 bytes per 4 chars, so ~50k chars ≈ 37.5KB) is a binary pasted through the call.
+    const bigB64 = `data:image/png;base64,${"A".repeat(50_000)}`
+    const r = await call(app, token, "publish", {
+      title: "Bad Img",
+      content: `<img src="${bigB64}">`,
+    })
+    const out = r.parsed?.result as { isError?: boolean; content?: { text: string }[] } | undefined
+    expect(out?.isError).toBe(true)
+    expect(out?.content?.[0]?.text ?? "").toMatch(/stage target:.?asset/i)
+  })
+
+  it("publish rejects oversized inline content, steering to stage target:'doc'", async () => {
+    const { app, token } = appWithGrant("pubbigdoc", "openid derive:read derive:publish")
+    // Total inline content past the ~64KB ceiling is a whole big document — curl it out.
+    const r = await call(app, token, "publish", { title: "Big Doc", content: "x".repeat(70_000) })
+    const out = r.parsed?.result as { isError?: boolean; content?: { text: string }[] } | undefined
+    expect(out?.isError).toBe(true)
+    expect(out?.content?.[0]?.text ?? "").toMatch(/stage target:.?doc/i)
   })
 
   it("exposes the workspace's Brandprint as resources + an instructions pointer", async () => {
@@ -573,32 +635,56 @@ describe("remote MCP endpoint (/mcp)", () => {
     ).toContain("no live brand profile")
   })
 
-  it("setup_brandprint scaffolds the profile slot, is idempotent, and the loop goes live", async () => {
+  it("publish to derive://brandprint/profile scaffolds the slot, is idempotent, and the loop goes live", async () => {
     const { app, token, meta } = appWithGrant(
       "bp-setup",
       "openid derive:read derive:publish derive:manage",
     )
-    // No web dialog: the agent scaffolds the whole Brandprint over MCP.
-    const out = JSON.parse(toolText(await call(app, token, "setup_brandprint")))
-    expect(out.created).toBe(true)
-    expect(out.state).toBe("pending")
-    expect(out.collection_id).toBeTruthy()
-    expect(out.profile_short_id).toBeTruthy()
-    const profId = out.profile_short_id as string
+    // setup_brandprint is folded into publish: an Admin's first publish to the
+    // profile URI scaffolds the slot. The profile is always filed for_review (its
+    // reveal is human-approved), so the response is a PROPOSAL, never a live publish.
+    const out = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          short_id: "derive://brandprint/profile",
+          content: "<h1>Derive brand profile</h1>",
+        }),
+      ),
+    )
+    expect(out.proposed).toBe(true)
+    expect(out.published).toBe(false)
+    expect(out.proposal_id).toBeTruthy()
 
-    // The pointer is persisted and the placeholder sits in the collection.
+    // The scaffold persisted the pointer + placeholder into a Brandprint collection.
+    const ws = JSON.parse(toolText(await call(app, token, "list_workspaces")))
+    const org = ws.workspaces.find((w: { default: boolean }) => w.default).id as string
+    const settings = await meta.getOrgSettings(org)
+    expect(settings.brandprint?.profileId).toBeTruthy()
+    expect(settings.brandprint?.collectionId).toBeTruthy()
+    const profId = settings.brandprint?.profileId as string
+    const collectionId = settings.brandprint?.collectionId as string
     const prof = await meta.getByShortId(profId)
     if (!prof) throw new Error("no profile artifact")
-    const settings = await meta.getOrgSettings(prof.org_id)
-    expect(settings.brandprint?.profileId).toBe(profId)
-    expect(settings.brandprint?.collectionId).toBe(out.collection_id)
-    expect(await meta.collectionArtifactIds(out.collection_id)).toContain(prof.id)
+    expect(await meta.collectionArtifactIds(collectionId)).toContain(prof.id)
 
-    // Idempotent: a second call returns the same slot, nothing re-created.
-    const again = JSON.parse(toolText(await call(app, token, "setup_brandprint")))
-    expect(again.created).toBe(false)
-    expect(again.profile_short_id).toBe(profId)
-    expect(again.collection_id).toBe(out.collection_id)
+    // Idempotent: a second publish to the URI reuses the same slot, nothing re-created.
+    const again = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          short_id: "derive://brandprint/profile",
+          content: "<h1>revised proposal</h1>",
+        }),
+      ),
+    )
+    expect(again.proposed).toBe(true)
+    const settings2 = await meta.getOrgSettings(org)
+    expect(settings2.brandprint?.profileId).toBe(profId)
+    expect(settings2.brandprint?.collectionId).toBe(collectionId)
+
+    // While it's only a placeholder (v1), reading the profile URI reports no live profile.
+    expect(
+      toolText(await call(app, token, "read", { short_id: "derive://brandprint/profile" })),
+    ).toContain("no live brand profile")
 
     // The agent builds the profile: a v2 against the placeholder flips it live.
     const form = new FormData()
@@ -614,29 +700,34 @@ describe("remote MCP endpoint (/mcp)", () => {
     })
     expect(rep.status).toBe(201)
 
-    // read derive://brandprint/profile now returns the live content; setup reports live.
+    // read derive://brandprint/profile now returns the live content.
     const live = JSON.parse(
       toolText(await call(app, token, "read", { short_id: "derive://brandprint/profile" })),
     )
     expect(live.content).toContain("Derive brand profile")
-    const post = JSON.parse(toolText(await call(app, token, "setup_brandprint")))
-    expect(post.state).toBe("live")
   })
 
-  it("setup_brandprint requires an Admin/Owner role", async () => {
-    const { app, token } = appWithGrant("bp-setup-denied", "openid derive:read")
-    expect(toolText(await call(app, token, "setup_brandprint"))).toContain("Admin/Owner role")
+  it("publish to derive://brandprint/profile requires an Admin/Owner role to scaffold", async () => {
+    const { app, token } = appWithGrant("bp-setup-denied", "openid derive:read derive:propose")
+    expect(
+      toolText(
+        await call(app, token, "publish", {
+          short_id: "derive://brandprint/profile",
+          content: "<h1>x</h1>",
+        }),
+      ),
+    ).toContain("Admin/Owner")
   })
 
-  it("list_artifacts + read see the agent's own published artifact", async () => {
+  it("find (browse) + read see the agent's own published artifact", async () => {
     const { app, token } = appWithGrant("read", "openid derive:read derive:publish")
     const pub = await publish(app, token, "My Plan")
     expect(pub.status).toBe(201)
     const shortId = (await pub.json()).short_id
 
-    const list = await call(app, token, "list_artifacts")
+    const list = await call(app, token, "find")
     const listOut = JSON.parse(toolText(list))
-    expect(listOut.artifacts.some((a: { short_id: string }) => a.short_id === shortId)).toBe(true)
+    expect(listOut.results.some((a: { short_id?: string }) => a.short_id === shortId)).toBe(true)
 
     // Content reads are a frontmatter header + the markdown body — NOT a JSON envelope.
     const read = toolText(await call(app, token, "read", { short_id: shortId }))
@@ -645,7 +736,7 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(read).not.toContain("\\n")
   })
 
-  it("organize: publish tags, overview vocabulary, apply, list_artifacts filter, inspect+suggest", async () => {
+  it("organize: publish tags, overview vocabulary, apply, find tag filter, inspect+suggest", async () => {
     const { app, token } = appWithGrant("organize", "openid derive:read derive:publish")
     // Auto-tag on publish.
     const a = JSON.parse(
@@ -666,10 +757,10 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(overview.vocabulary.find((t: { tag: string }) => t.tag === "planning")?.count).toBe(1)
     expect(Array.isArray(overview.collections)).toBe(true)
 
-    // list_artifacts carries tags, and tag: filters to the tagged doc.
-    const filtered = JSON.parse(toolText(await call(app, token, "list_artifacts", { tag: "q3" })))
-    expect(filtered.artifacts.map((x: { short_id: string }) => x.short_id)).toEqual([a])
-    expect(filtered.artifacts[0].tags.sort()).toEqual(["planning", "q3"])
+    // find (browse) carries tags, and tag: filters to the tagged doc.
+    const filtered = JSON.parse(toolText(await call(app, token, "find", { tag: "q3" })))
+    expect(filtered.results.map((x: { short_id?: string }) => x.short_id)).toEqual([a])
+    expect(filtered.results[0].tags.sort()).toEqual(["planning", "q3"])
 
     // organize({short_ids, add}) applies (union) and reports it tagged.
     const tagged = JSON.parse(
@@ -740,7 +831,7 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(await meta.collectionIdsForArtifact(artifact.id)).toEqual([])
   })
 
-  it("list_artifacts marks skills and filters to them with skills:true", async () => {
+  it("find (browse) marks skills and filters to them with skills:true", async () => {
     const { app, token } = appWithGrant("listskills", "openid derive:read derive:publish")
     const doc = (await (await publish(app, token, "A plain doc")).json()).short_id
     const skill = JSON.parse(
@@ -755,19 +846,17 @@ describe("remote MCP endpoint (/mcp)", () => {
     ).short_id
 
     // Unfiltered: both present; is_skill distinguishes them.
-    const all = JSON.parse(toolText(await call(app, token, "list_artifacts")))
+    const all = JSON.parse(toolText(await call(app, token, "find")))
     const rowOf = (id: string) =>
-      all.artifacts.find((a: { short_id: string }) => a.short_id === id) as
+      all.results.find((a: { short_id?: string }) => a.short_id === id) as
         | { is_skill: boolean }
         | undefined
     expect(rowOf(skill)?.is_skill).toBe(true)
     expect(rowOf(doc)?.is_skill).toBe(false)
 
     // Filtered: only the skill.
-    const onlySkills = JSON.parse(
-      toolText(await call(app, token, "list_artifacts", { skills: true })),
-    )
-    const ids = onlySkills.artifacts.map((a: { short_id: string }) => a.short_id)
+    const onlySkills = JSON.parse(toolText(await call(app, token, "find", { skills: true })))
+    const ids = onlySkills.results.map((a: { short_id?: string }) => a.short_id)
     expect(ids).toContain(skill)
     expect(ids).not.toContain(doc)
   })
@@ -968,7 +1057,7 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(cu.pages_changed.added).toContain("new.html")
   })
 
-  it("search: literal matches with line numbers, context, case, and regex", async () => {
+  it("find (grep one artifact): literal matches with line numbers, context, case, and regex", async () => {
     const { app, token } = appWithGrant("search", "openid derive:read derive:publish")
     const md = [
       "# Plan",
@@ -981,14 +1070,14 @@ describe("remote MCP endpoint (/mcp)", () => {
     const id = (await (await publishRaw(app, token, md, "plan.md", "Plan")).json()).short_id
 
     // Literal, case-insensitive by default: both "Pricing" and "pricing" lines match.
-    const hit = toolText(await call(app, token, "search", { short_id: id, query: "pricing" }))
+    const hit = toolText(await call(app, token, "find", { short_id: id, query: "pricing" }))
     expect(hit).toContain("2 matches")
     expect(hit).toContain("4: beta line with Pricing")
     expect(hit).toContain("6: more pricing here")
 
     // Case-sensitive narrows to the capital-P line only.
     const cs = toolText(
-      await call(app, token, "search", { short_id: id, query: "Pricing", case_sensitive: true }),
+      await call(app, token, "find", { short_id: id, query: "Pricing", case_sensitive: true }),
     )
     expect(cs).toContain("1 match")
     expect(cs).toContain("4: beta line with Pricing")
@@ -996,7 +1085,7 @@ describe("remote MCP endpoint (/mcp)", () => {
 
     // Context shows neighbouring lines with a dash marker, matches with a colon.
     const withCtx = toolText(
-      await call(app, token, "search", { short_id: id, query: "beta", context: 1 }),
+      await call(app, token, "find", { short_id: id, query: "beta", context: 1 }),
     )
     expect(withCtx).toContain("3- alpha line")
     expect(withCtx).toContain("4: beta line with Pricing")
@@ -1004,33 +1093,31 @@ describe("remote MCP endpoint (/mcp)", () => {
 
     // The query is matched LITERALLY: regex metacharacters are not special, so a
     // pattern-shaped query only matches that verbatim text (and can't backtrack).
-    const literalMeta = toolText(
-      await call(app, token, "search", { short_id: id, query: "^gamma" }),
-    )
+    const literalMeta = toolText(await call(app, token, "find", { short_id: id, query: "^gamma" }))
     expect(literalMeta).toContain("no matches") // there is no literal "^gamma" in the doc
-    const literal = toolText(await call(app, token, "search", { short_id: id, query: "line with" }))
+    const literal = toolText(await call(app, token, "find", { short_id: id, query: "line with" }))
     expect(literal).toContain("4: beta line with Pricing")
 
     // No matches steers toward the text scope.
-    const none = toolText(await call(app, token, "search", { short_id: id, query: "zzznothere" }))
+    const none = toolText(await call(app, token, "find", { short_id: id, query: "zzznothere" }))
     expect(none).toContain("no matches")
   })
 
-  it("search: source vs text scope on HTML, and bundles grouped by page", async () => {
+  it("find (grep one artifact): source vs text scope on HTML, and bundles grouped by page", async () => {
     const { app, token } = appWithGrant("search2", "openid derive:read derive:publish")
     const html = "<h1>Heading</h1>\n<p>visible pricing text</p>"
     const id = (await (await publishRaw(app, token, html, "page.html", "Page")).json()).short_id
 
     // Source search sees the tags; text search sees only the visible words.
-    const inSource = toolText(await call(app, token, "search", { short_id: id, query: "h1" }))
+    const inSource = toolText(await call(app, token, "find", { short_id: id, query: "h1" }))
     expect(inSource).toContain("in source")
     expect(inSource).toContain("<h1>Heading</h1>")
     const inText = toolText(
-      await call(app, token, "search", { short_id: id, query: "h1", in: "text" }),
+      await call(app, token, "find", { short_id: id, query: "h1", in: "text" }),
     )
     expect(inText).toContain("no matches")
     const wordInText = toolText(
-      await call(app, token, "search", { short_id: id, query: "pricing", in: "text" }),
+      await call(app, token, "find", { short_id: id, query: "pricing", in: "text" }),
     )
     expect(wordInText).toContain("in text")
     expect(wordInText).toContain("pricing")
@@ -1064,15 +1151,13 @@ describe("remote MCP endpoint (/mcp)", () => {
         })
       ).json()
     ).short_id
-    const across = toolText(
-      await call(app, token, "search", { short_id: bundleId, query: "needle" }),
-    )
+    const across = toolText(await call(app, token, "find", { short_id: bundleId, query: "needle" }))
     expect(across).toContain("index.html")
     expect(across).toContain("about.html")
     expect(across).toContain("2 matches")
   })
 
-  it("search: matches are self-locating (§ section labels)", async () => {
+  it("find (grep one artifact): matches are self-locating (§ section labels)", async () => {
     const { app, token } = appWithGrant("srchsec", "openid derive:read derive:publish")
     const md = [
       "# Doc",
@@ -1086,20 +1171,20 @@ describe("remote MCP endpoint (/mcp)", () => {
     const id = (await (await publishRaw(app, token, md, "plan.md", "Plan")).json()).short_id
 
     // A term in each section is labelled with the heading it falls under.
-    const budget = toolText(await call(app, token, "search", { short_id: id, query: "spend" }))
+    const budget = toolText(await call(app, token, "find", { short_id: id, query: "spend" }))
     expect(budget).toContain("§ Budget")
-    const risk = toolText(await call(app, token, "search", { short_id: id, query: "churn" }))
+    const risk = toolText(await call(app, token, "find", { short_id: id, query: "churn" }))
     expect(risk).toContain("§ Risks")
 
     // On HTML, a nested labelled landmark is the section (not just top-level).
     const html =
       "<body>\n<main>\n<section aria-label='Revenue'>the pricing tier</section>\n</main>\n</body>"
     const hid = (await (await publishRaw(app, token, html, "d.html", "D")).json()).short_id
-    const s = toolText(await call(app, token, "search", { short_id: hid, query: "pricing" }))
+    const s = toolText(await call(app, token, "find", { short_id: hid, query: "pricing" }))
     expect(s).toContain("§ Revenue")
   })
 
-  it("search (workspace mode, short_id omitted): greps across accessible artifacts, grouped by artifact, and NEVER leaks a private artifact's content to a viewer who isn't its member (regression)", async () => {
+  it("find (workspace mode, short_id omitted): greps across accessible artifacts, grouped by artifact, and NEVER leaks a private artifact's content to a viewer who isn't its member (regression)", async () => {
     const { app, token, meta, blobs } = appWithGrant(
       "wssearch",
       "openid derive:read derive:publish",
@@ -1122,11 +1207,13 @@ describe("remote MCP endpoint (/mcp)", () => {
     ).short_id
 
     // Finds the hit and names which artifact it's in — the whole point of the mode.
-    const found = toolText(await call(app, token, "search", { query: "visible-needle-alpha" }))
-    expect(found).toContain(r1)
-    expect(found).toContain("Report One")
-    expect(found).toContain("1 match")
-    expect(found).not.toContain(r2) // no hit there — must not appear as an empty section
+    const found = JSON.parse(
+      toolText(await call(app, token, "find", { query: "visible-needle-alpha" })),
+    )
+    const foundHits = matchRows(found)
+    expect(foundHits.map((h) => h.short_id)).toEqual([r1]) // exactly one match row, in r1
+    expect(foundHits[0]?.title).toBe("Report One")
+    expect(foundHits.map((h) => h.short_id)).not.toContain(r2) // no hit there — never surfaced
 
     // A DIFFERENT artifact — listed:"none" (private) and NOT a member — must never
     // surface, even though it lives in the same workspace. This mirrors exactly the
@@ -1164,18 +1251,19 @@ describe("remote MCP endpoint (/mcp)", () => {
     // searchArtifactIds will nominate it. The visibility gate must still drop it.
     await meta.indexArtifact("a_stranger_private", owner.org_id, "Stranger's Private Doc", secret)
 
-    const afterPrivate = toolText(
-      await call(app, token, "search", { query: "private-needle-zulu" }),
+    const afterPrivateText = toolText(
+      await call(app, token, "find", { query: "private-needle-zulu" }),
     )
-    // "No matches for ... private-needle-zulu" legitimately echoes the searched
-    // query — the leak to guard against is the private artifact's short_id or its
-    // OWN content surfacing anywhere in the report, neither of which it should.
-    expect(afterPrivate).toContain("No matches")
-    expect(afterPrivate).not.toContain("strangr1")
-    expect(afterPrivate).not.toContain("Secret")
+    const afterPrivate = JSON.parse(afterPrivateText)
+    // No confirmed hits — and, crucially, the leak to guard against is the private
+    // artifact's short_id or its OWN content surfacing anywhere in the payload, neither
+    // of which it should (the echoed query itself is harmless).
+    expect(matchRows(afterPrivate)).toHaveLength(0)
+    expect(afterPrivateText).not.toContain("strangr1")
+    expect(afterPrivateText).not.toContain("Secret")
   })
 
-  it("search (workspace mode): a freshly published artifact is findable across the workspace (publish indexes it)", async () => {
+  it("find (workspace mode): a freshly published artifact is findable across the workspace (publish indexes it)", async () => {
     // End-to-end proof of the write-path: publishing runs emitVersionBump →
     // indexArtifactVersion, so the new content is in the index and workspace search
     // (index → visibility → grep-confirm) surfaces it — no short_id needed.
@@ -1187,9 +1275,10 @@ describe("remote MCP endpoint (/mcp)", () => {
       "doc.md",
       "Onboarding",
     )
-    const res = toolText(await call(app, token, "search", { query: "kestrel" }))
-    expect(res).toContain("kestrel") // grep-confirmed hunk
-    expect(res).toContain("Onboarding") // grouped under its artifact
+    const res = JSON.parse(toolText(await call(app, token, "find", { query: "kestrel" })))
+    const hits = matchRows(res)
+    expect(hits.some((h) => h.snippet.includes("kestrel"))).toBe(true) // grep-confirmed snippet
+    expect(hits.some((h) => h.title === "Onboarding")).toBe(true) // named by its artifact
   })
 
   // Seed N indexed artifacts that all match one query, so the grep-confirm cap is
@@ -1229,7 +1318,7 @@ describe("remote MCP endpoint (/mcp)", () => {
     }
   }
 
-  it("search (workspace mode): a doc published via the MCP publish tool is indexed into the DENSE arm, not just the FTS (regression)", async () => {
+  it("find (workspace mode): a doc published via the MCP publish tool is indexed into the DENSE arm, not just the FTS (regression)", async () => {
     const indexed: string[] = []
     const fakeSearch: SearchIndex = {
       indexArtifact: async (id) => {
@@ -1253,7 +1342,7 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(indexed).toContain(art?.id)
   })
 
-  it("search (workspace mode): ranks the whole corpus and shows an honest truncation note past the grep-confirm cap", async () => {
+  it("find (workspace mode): ranks the whole corpus and shows an honest truncation note past the grep-confirm cap", async () => {
     const { app, token, meta, blobs } = appWithGrant("wscap", "openid derive:read derive:publish")
     const seed = (await (await publishRaw(app, token, "# Seed", "seed.md", "Seed")).json()).short_id
     const owner = await meta.getByShortId(seed)
@@ -1261,12 +1350,13 @@ describe("remote MCP endpoint (/mcp)", () => {
     // 31 matching artifacts — one more than WORKSPACE_SEARCH_ARTIFACT_CAP (30), so the
     // grep-confirm cap engages and the truncation note must appear.
     await seedMatching(meta, blobs, owner.org_id, "bulk", 31)
-    const res = toolText(await call(app, token, "search", { query: "widget" }))
-    expect(res).toContain("candidate artifacts you can see") // the relevance-truncation note
-    expect(res).toContain("top 30 of 31")
+    const res = JSON.parse(toolText(await call(app, token, "find", { query: "widget" })))
+    // The relevance-truncation note rides in the JSON `note` field.
+    expect(res.note).toContain("candidate artifacts you can see")
+    expect(res.note).toContain("top 30 of 31")
   })
 
-  it("search (workspace mode): EXACTLY the cap (30) matching artifacts shows NO truncation note", async () => {
+  it("find (workspace mode): EXACTLY the cap (30) matching artifacts shows NO truncation note", async () => {
     const { app, token, meta, blobs } = appWithGrant(
       "wscapexact",
       "openid derive:read derive:publish",
@@ -1277,12 +1367,13 @@ describe("remote MCP endpoint (/mcp)", () => {
     // Exactly 30 matching artifacts (the seed doesn't match "widget"): the strict `>`
     // boundary means no truncation note fires.
     await seedMatching(meta, blobs, owner.org_id, "exct", 30)
-    const res = toolText(await call(app, token, "search", { query: "widget" }))
-    expect(res).not.toContain("candidate artifacts you can see")
-    expect(res).not.toContain("matched the index")
+    const res = JSON.parse(toolText(await call(app, token, "find", { query: "widget" })))
+    // Exactly at the grep-confirm cap → no truncation note is attached at all.
+    expect(matchRows(res)).toHaveLength(30)
+    expect(res.note).toBeUndefined()
   })
 
-  it("search (workspace mode): resolves >90 candidates correctly across visibility chunks (D1 bound-param safety)", async () => {
+  it("find (workspace mode): resolves >90 candidates correctly across visibility chunks (D1 bound-param safety)", async () => {
     const { app, token, meta, blobs } = appWithGrant("wschunk", "openid derive:read derive:publish")
     const seed = (await (await publishRaw(app, token, "# Seed", "seed.md", "Seed")).json()).short_id
     const owner = await meta.getByShortId(seed)
@@ -1292,11 +1383,11 @@ describe("remote MCP endpoint (/mcp)", () => {
     // The merged, re-ranked result must count all 120 — nothing dropped or duplicated at
     // the chunk boundary.
     await seedMatching(meta, blobs, owner.org_id, "chunk", 120)
-    const res = toolText(await call(app, token, "search", { query: "widget" }))
-    expect(res).toContain("top 30 of 120")
+    const res = JSON.parse(toolText(await call(app, token, "find", { query: "widget" })))
+    expect(res.note).toContain("top 30 of 120")
   })
 
-  it("search (workspace mode): a taken-down artifact's content is NOT grep-exfiltratable via search (tombstone hole)", async () => {
+  it("find (workspace mode): a taken-down artifact's content is NOT grep-exfiltratable via search (tombstone hole)", async () => {
     const { app, token, meta } = appWithGrant("wstomb", "openid derive:read derive:publish")
     const sid = (
       await (
@@ -1304,9 +1395,8 @@ describe("remote MCP endpoint (/mcp)", () => {
       ).json()
     ).short_id
     // Findable while live — proves it's indexed (so the negative below is non-vacuous).
-    expect(toolText(await call(app, token, "search", { query: "tombstoneneedle" }))).toContain(
-      "tombstoneneedle",
-    )
+    const live = JSON.parse(toolText(await call(app, token, "find", { query: "tombstoneneedle" })))
+    expect(matchRows(live).length).toBeGreaterThan(0)
     // Take it down. Takedown deliberately does NOT unindex (a restore must stay cheap), so
     // the index row survives and still nominates it — the ONLY thing keeping its content
     // out of search is searchWorkspace's excludeRemoved gate. This pins that hole shut:
@@ -1314,13 +1404,14 @@ describe("remote MCP endpoint (/mcp)", () => {
     const art = await meta.getByShortId(sid)
     if (!art) throw new Error("expected the artifact to exist")
     await meta.setArtifactRemoved(art.id, new Date().toISOString())
-    const after = toolText(await call(app, token, "search", { query: "tombstoneneedle" }))
-    expect(after).toContain("No matches")
-    expect(after).not.toContain("Secret")
-    expect(after).not.toContain(sid)
+    const afterText = toolText(await call(app, token, "find", { query: "tombstoneneedle" }))
+    const after = JSON.parse(afterText)
+    expect(matchRows(after)).toHaveLength(0)
+    expect(afterText).not.toContain("Secret")
+    expect(afterText).not.toContain(sid)
   })
 
-  it("read/search (one-artifact): a taken-down artifact serves no content, mirroring the web 410", async () => {
+  it("read/find (one-artifact): a taken-down artifact serves no content, mirroring the web 410", async () => {
     const { app, token, meta } = appWithGrant("wsone", "openid derive:read derive:publish")
     const sid = (
       await (
@@ -1337,12 +1428,12 @@ describe("remote MCP endpoint (/mcp)", () => {
     const read = toolText(await call(app, token, "read", { short_id: sid }))
     expect(read).toContain("taken down")
     expect(read).not.toContain("onedocneedle")
-    const one = toolText(await call(app, token, "search", { short_id: sid, query: "onedocneedle" }))
+    const one = toolText(await call(app, token, "find", { short_id: sid, query: "onedocneedle" }))
     expect(one).toContain("taken down")
     expect(one).not.toContain("onedocneedle")
   })
 
-  it("search (workspace mode): index nominations lacking the exact literal are not reported as matches (recall vs precision)", async () => {
+  it("find (workspace mode): index nominations lacking the exact literal are not reported as matches (recall vs precision)", async () => {
     const { app, token, meta, blobs } = appWithGrant("wsprec", "openid derive:read derive:publish")
     const seed = (await (await publishRaw(app, token, "# Seed", "seed.md", "Seed")).json()).short_id
     const owner = await meta.getByShortId(seed)
@@ -1380,9 +1471,9 @@ describe("remote MCP endpoint (/mcp)", () => {
       )
     }
     // The index nominates all three (both prefix tokens present), but grep-confirm for the
-    // contiguous literal finds nothing → honestly "No matches", never a false hit.
-    const res = toolText(await call(app, token, "search", { query: "alpha omega" }))
-    expect(res).toContain("No matches")
+    // contiguous literal finds nothing → honestly zero confirmed hits, never a false one.
+    const res = JSON.parse(toolText(await call(app, token, "find", { query: "alpha omega" })))
+    expect(matchRows(res)).toHaveLength(0)
   })
 
   it("searchWorkspace hides a password-locked artifact's content unless the caller reads it via a workspace SEAT (not the locked link)", async () => {
@@ -1501,9 +1592,9 @@ describe("remote MCP endpoint (/mcp)", () => {
       })
     }
     // Not findable before the backfill — the index has no row for them.
-    expect(toolText(await call(app, token, "search", { query: "backfillneedle" }))).toContain(
-      "No matches",
-    )
+    expect(
+      matchRows(JSON.parse(toolText(await call(app, token, "find", { query: "backfillneedle" })))),
+    ).toHaveLength(0)
     // Drive the bounded sweep to completion (limit:2 forces multiple pages across the
     // seed + 3 artifacts, exercising the cursor).
     let cursor: { key: string; id: string } | null | undefined
@@ -1517,10 +1608,12 @@ describe("remote MCP endpoint (/mcp)", () => {
     } while (cursor)
     expect(pages).toBeGreaterThan(1) // actually paginated, not one big pass
     expect(indexed).toBeGreaterThanOrEqual(3)
-    // Now findable — grouped under their artifacts.
-    const found = toolText(await call(app, token, "search", { query: "backfillneedle" }))
-    expect(found).toContain("backfillneedle")
-    expect(found).toContain("Pre 0")
+    // Now findable — named by their artifacts.
+    const found = matchRows(
+      JSON.parse(toolText(await call(app, token, "find", { query: "backfillneedle" }))),
+    )
+    expect(found.some((h) => h.snippet.includes("backfillneedle"))).toBe(true)
+    expect(found.some((h) => h.title === "Pre 0")).toBe(true)
   })
 
   it("read: a region ref (@N) reads that region directly, with actionable errors", async () => {
@@ -2370,9 +2463,9 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(created.url).toContain(created.short_id)
     expect(created.listed).toBe("none") // the team-draft default: out of every feed until promoted
 
-    // It's really there: list_artifacts + read see it live.
-    const list = JSON.parse(toolText(await call(app, token, "list_artifacts")))
-    expect(list.artifacts.some((a: { short_id: string }) => a.short_id === created.short_id)).toBe(
+    // It's really there: find (browse) + read see it live.
+    const list = JSON.parse(toolText(await call(app, token, "find")))
+    expect(list.results.some((a: { short_id?: string }) => a.short_id === created.short_id)).toBe(
       true,
     )
     const read = toolText(await call(app, token, "read", { short_id: created.short_id }))
@@ -2686,7 +2779,7 @@ describe("remote MCP endpoint (/mcp)", () => {
   })
 })
 
-describe("the agent inbox over MCP (check_requests)", () => {
+describe("the agent inbox over MCP (catch_up work queue)", () => {
   // A registered agent's bearer resolves through the same agentFor bridge as HTTP —
   // seed the agent store-level (token stored hashed, exactly what POST /v1/agents
   // writes) and hand it a pending request row (what the comment @mention fan-out
@@ -2724,16 +2817,17 @@ describe("the agent inbox over MCP (check_requests)", () => {
     const init = await rpc(app, agentToken, initBody)
     const inst = (init.parsed?.result as { instructions?: string }).instructions ?? ""
     expect(inst).toContain("1 pending request")
-    expect(inst).toContain("check_requests")
+    // The pointer now steers to catch_up (no short_id = the work queue), not check_requests.
+    expect(inst).toContain("catch_up")
     // The OAuth surface (a human's grant, no inbox of its own) stays quiet.
     const oinit = await rpc(app, oauthToken, initBody)
     const oinst = (oinit.parsed?.result as { instructions?: string }).instructions ?? ""
     expect(oinst).not.toContain("pending request")
   })
 
-  it("check_requests lists the queue; ack clears exactly what was handled", async () => {
+  it("catch_up (no short_id) lists the work queue; ack clears exactly what was handled", async () => {
     const { app, agentToken, shortId } = await seedInbox("inboxack")
-    const listed = await call(app, agentToken, "check_requests")
+    const listed = await call(app, agentToken, "catch_up")
     const first = JSON.parse(toolText(listed))
     expect(first.pending).toHaveLength(1)
     expect(first.pending[0]).toMatchObject({
@@ -2744,24 +2838,27 @@ describe("the agent inbox over MCP (check_requests)", () => {
     })
     expect(first.pending[0].request).toContain("Rework this artifact")
 
-    const acked = await call(app, agentToken, "check_requests", { ack: ["amn_inboxack"] })
+    const acked = await call(app, agentToken, "catch_up", { ack: ["amn_inboxack"] })
     const after = JSON.parse(toolText(acked))
     expect(after.acked).toBe(1)
     expect(after.pending).toHaveLength(0)
 
     // Repeated or unknown ids are a no-op, never an error — an agent can retry safely.
-    const again = await call(app, agentToken, "check_requests", {
+    const again = await call(app, agentToken, "catch_up", {
       ack: ["amn_inboxack", "amn_nope"],
     })
     expect(JSON.parse(toolText(again)).acked).toBe(0)
   })
 
-  it("a human-grant connection has an empty queue, not an error", async () => {
+  it("a human-grant connection has an empty queue with a no-inbox note, not an error", async () => {
     const { app, token } = appWithGrant("inboxoauth", "openid derive:read")
     const tools = await rpc(app, token, { jsonrpc: "2.0", id: 5, method: "tools/list" })
-    expect(toolNames(tools)).toContain("check_requests")
-    const r = await call(app, token, "check_requests")
-    expect(JSON.parse(toolText(r)).pending).toEqual([])
+    // The queue is now a MODE of catch_up (no check_requests tool of its own).
+    expect(toolNames(tools)).toContain("catch_up")
+    const out = JSON.parse(toolText(await call(app, token, "catch_up")))
+    expect(out.pending).toEqual([])
+    // An OAuth grant's id can't be @mentioned, so it has no inbox — said explicitly.
+    expect(out.note).toContain("no inbox")
   })
 })
 

--- a/apps/web/src/components/shared/connect-agent.tsx
+++ b/apps/web/src/components/shared/connect-agent.tsx
@@ -43,7 +43,7 @@ Please:
      claude mcp add --transport http derive ${url}/mcp
    In another harness, add an HTTP/streamable MCP server named "derive" at ${url}/mcp.
    The first call opens a browser consent (OAuth); the scope I grant maps to my Derive role.
-2. Confirm it's connected by calling the "whoami" MCP tool, then "list_artifacts".
+2. Confirm it's connected by calling the "find" MCP tool to list what's there (your identity, workspace, and role are already in the server instructions).
 
 Once connected you can publish a page, read its review comments, and run the propose -> review -> revise loop — all over MCP.`
 
@@ -63,7 +63,7 @@ Please:
 2. Connect over MCP, using that same BASE_URL:
      claude mcp add --transport http derive <BASE_URL>/mcp
    The first call opens a browser consent (OAuth).
-3. Confirm by calling the "whoami" MCP tool, then "list_artifacts".
+3. Confirm by calling the "find" MCP tool to list what's there.
 
 Then you can publish, read review comments, and run the propose -> review -> revise loop over MCP.`
 

--- a/biome.json
+++ b/biome.json
@@ -12,6 +12,7 @@
       "!**/routeTree.gen.ts",
       "!**/*.gen.ts",
       "!**/openapi.json",
+      "!apps/api/test/e2e/**",
       "!**/api-types.ts",
       "!**/dist",
       "!**/.output",

--- a/biome.json
+++ b/biome.json
@@ -12,7 +12,7 @@
       "!**/routeTree.gen.ts",
       "!**/*.gen.ts",
       "!**/openapi.json",
-      "!apps/api/test/e2e/**",
+      "!apps/api/test/e2e",
       "!**/api-types.ts",
       "!**/dist",
       "!**/.output",

--- a/knip.json
+++ b/knip.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
     "apps/api": {
-      "entry": ["gen-auth-schema.ts"]
+      "entry": ["gen-auth-schema.ts", "test/e2e/*.mts"]
     },
     "apps/web": {
       "entry": ["src/components/ui/**", "e2e/**/*.screens.ts"]

--- a/packages/core/src/brandprint.ts
+++ b/packages/core/src/brandprint.ts
@@ -121,6 +121,6 @@ export const pendingRequestsPointer = (count: number): string =>
   count === 0
     ? ""
     : ` You have ${count} pending request${count === 1 ? "" : "s"}: teammates @mentioned you` +
-      ` with work to do. Call check_requests FIRST — read each request, do what it asks on the` +
-      ` named artifact, then pass the handled ids back via check_requests({ack:[…]}) so they` +
-      ` leave the queue.`
+      ` with work to do. Call catch_up with NO short_id FIRST — that returns your work queue;` +
+      ` read each request, do what it asks on the named artifact, then pass the handled ids back` +
+      ` via catch_up({ack:[…]}) so they leave the queue.`

--- a/packages/core/test/brandprint.test.ts
+++ b/packages/core/test/brandprint.test.ts
@@ -105,10 +105,10 @@ describe("buildProfileInstruction", () => {
 })
 
 describe("pendingRequestsPointer", () => {
-  it("is empty with nothing queued, and steers to check_requests when work waits", () => {
+  it("is empty with nothing queued, and steers to catch_up when work waits", () => {
     expect(pendingRequestsPointer(0)).toBe("")
     expect(pendingRequestsPointer(1)).toContain("1 pending request:")
     expect(pendingRequestsPointer(2)).toContain("2 pending requests:")
-    expect(pendingRequestsPointer(1)).toContain("check_requests")
+    expect(pendingRequestsPointer(1)).toContain("catch_up")
   })
 })


### PR DESCRIPTION
Two levers on the Derive remote MCP surface, in one change.

## Lever 1: weight (thin tools, thick skills)
Move the workflow/protocol prose out of the always-loaded surface (tool descriptions + server instructions) into five lazily-read core skills served as `derive://skills/<name>` (resources AND `read()` URIs, mirroring `derive://brandprint/*`). Each description now states intent, keeps its safety/consequence lines, and steers to a skill at the decision point. The server instructions become high-level orientation (identity, the loop, pointers, the skills index), following the patterns the strongest open-source harnesses ship (GitHub MCP server, Goose, Cline, Codex `AGENTS.md`). A CI budget test keeps the surface thin.

Then the write-family descriptions were made **decidable**: `publish` leads with create-vs-update and a "default to `edits`, here is when to leave it" payload choice (modeled on GitHub `create_or_update_file` + Cline `replace_in_file` + Claude Code `edit`), and `publish`/`stage` name when to jump to a sibling so an LLM routes in one read.

## Lever 2: count (15 tools to 10)
Hard cutover to ten flexible tools behind a hard admission bar:

| Tool | Absorbs |
|---|---|
| **find** | search + list_artifacts + list_contexts (typed rows; askable-only contexts; a note, not an error, with no signed-in user) |
| **catch_up** | check_requests (no-id = the work queue + `ack`; an explicit no-inbox note for OAuth grants) |
| **stage** | stage_publish + stage_asset (required `target: doc | asset`) |
| **publish** | setup_brandprint dissolved in as a **manage-gated** `derive://brandprint/profile` target; plus base64 + oversized-inline **guardrails** that reject and route to `stage` |
| **use** | ask (renamed; archetype-neutral) |
| read, comment, organize, checkpoint, list_workspaces | unchanged |

The Brandprint scaffold writes only when the caller holds `manage`; a non-manage caller gets an actionable error and no writes occur.

## Publishing is now unmistakable, including uploads
- The decidable `publish` description + the `stage` decision triangle (inline text -> publish; whole big doc -> `stage target:doc`; image/font -> `stage target:asset`).
- Server-enforced guardrails: an oversized inline base64 data: URI or an oversized inline payload is rejected with a steer to `stage`, so "never base64 a binary through a tool call" is a guardrail, not a plea.

## Tested end to end against a real local Derive
`apps/api/test/e2e/mcp-local-e2e.mts` stands up an actual HTTP Derive (`createApp` + `serve`), seeds an OAuth grant, and drives the full loop over `/mcp`: tools/list (the ten, retired names gone) -> publish create/edits -> both guardrails -> find -> **`stage target:doc` -> upload real bytes to the minted URL -> read the content back** -> `stage target:asset` -> catch_up queue note -> use/list_workspaces. **37 checks, all green.**

## Surface
Always-loaded descriptions 9,204 -> 7,067 chars; instructions ~1,900; ~13k chars of deep procedure now lazy across five skills. Full gate green: `pnpm run ci` + `pnpm typecheck` + 1,847 tests.

Follow-ups (out of scope here): the separate local-CLI shim (`packages/mcp`) still has its own tool set; a handful of code comments still name retired tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)