### PR TITLE
Fix/pricing page parity

### DIFF
--- a/apps/web/public/site/pricing.html
+++ b/apps/web/public/site/pricing.html
@@ -217,7 +217,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
     <div class="tier">
       <div class="tname">Team <span class="tag">MOST TEAMS</span></div>
       <p class="tfor">For teams whose agents ship work that needs review.</p>
-      <div class="price">$10 <small>per editor / month · $8 billed annually</small></div>
+      <div class="price">$15 <small>per editor / month · $12 billed annually</small></div>
       <a class="btn btn-primary" href="#join">Get beta access</a>
       <ul>
         <li>Everything in Free, plus</li>
@@ -225,17 +225,18 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
         <li>Custom domain</li>
         <li>Password-protected links</li>
         <li><strong>Brandprint</strong>: your house style, read by every agent</li>
-        <li>50 GB pooled storage</li>
+        <li>50 GB pooled storage, then ~$1 per extra 10 GB/month</li>
         <li>Full analytics history</li>
       </ul>
     </div>
     <div class="tier">
       <div class="tname">Business</div>
       <p class="tfor">For organizations that need control and accountability.</p>
-      <div class="price">$20 <small>per editor / month · $16 billed annually</small></div>
+      <div class="price">$30 <small>per editor / month · $25 billed annually</small></div>
       <a class="btn btn-ghost" href="#join">Get beta access</a>
       <ul>
         <li>Everything in Team, plus</li>
+        <li>250 GB pooled storage, then ~$1 per extra 10 GB/month</li>
         <li>SSO with your identity provider (OIDC)</li>
         <li>Audit log</li>
         <li>Multiple custom domains</li>
@@ -247,7 +248,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
     <div class="tier">
       <div class="tname">Enterprise</div>
       <p class="tfor">For isolation, residency, and procurement requirements.</p>
-      <div class="price">Custom <small>annual contract</small></div>
+      <div class="price">From ~$500/mo <small>custom annual contract</small></div>
       <a class="btn btn-ghost" href="mailto:hello@derive.to">Talk to us</a>
       <ul>
         <li>Everything in Business, plus</li>
@@ -255,6 +256,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
         <li>Data residency: your region, your cloud or ours</li>
         <li>Migration and onboarding help</li>
         <li>Support contract</li>
+        <li>Support contracts for self-hosted deployments: SLA, LTS releases, upgrade and migration help</li>
       </ul>
     </div>
   </div>
@@ -293,7 +295,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
   <div class="faq">
     <details>
       <summary>What counts as an editor?</summary>
-      <p class="a">Anyone who <strong>publishes or approves work</strong> during a billing period. Viewers and commenters are never counted, no matter how many.</p>
+      <p class="a">Anyone who <strong>publishes or approves work</strong> during a billing period. Viewers and commenters are never counted, no matter how many. <strong>Guests can propose changes for free</strong> — a guest only becomes a billable editor when a workspace owner explicitly grants them an editor seat. For example: 10 people read a workspace, 2 leave comments, and 1 approves and publishes — you pay for 1 editor.</p>
     </details>
     <details>
       <summary>What happens if we stop paying?</summary>

--- a/apps/web/public/site/pricing.html
+++ b/apps/web/public/site/pricing.html
@@ -295,7 +295,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
   <div class="faq">
     <details>
       <summary>What counts as an editor?</summary>
-      <p class="a">Anyone who <strong>publishes or approves work</strong> during a billing period. Viewers and commenters are never counted, no matter how many. <strong>Guests can propose changes for free</strong> — a guest only becomes a billable editor when a workspace owner explicitly grants them an editor seat. For example: 10 people read a workspace, 2 leave comments, and 1 approves and publishes — you pay for 1 editor.</p>
+      <p class="a">Anyone who <strong>publishes or approves work</strong> during a billing period. Viewers and commenters are never counted, no matter how many. <strong>Guests can propose changes for free</strong>: a guest only becomes a billable editor when a workspace owner explicitly grants them an editor seat. For example, 10 people read a workspace, 2 leave comments, and 1 approves and publishes: you pay for 1 editor.</p>
     </details>
     <details>
       <summary>What happens if we stop paying?</summary>


### PR DESCRIPTION
## Summary

Implements 7 of the recommendations from the internal pricing review doc ("Derive pricing: where it should land"), by team decision. Other recommendations from that doc (principles copy, "Unlimited editors" framing, SAML/SCIM naming, "open source" vs "fair source" wording, SOC 2 FAQ) are deliberately deferred to a future pass.

- Team price: $10/mo ($8 annual) → $15/mo ($12 annual), per editor
- Business price: $20/mo ($16 annual) → $30/mo ($25 annual), per editor
- Team storage overage published: "50 GB pooled storage" → "50 GB pooled storage, then ~$1 per extra 10 GB/month"
- Business storage line added: Business previously had no storage bullet at all; added "250 GB pooled storage, then ~$1 per extra 10 GB/month"
- Enterprise floor stated: "Custom" → "From ~$500/mo" (still "custom annual contract")
- Self-host support contract added: new Enterprise bullet for support contracts on self-hosted deployments (SLA, LTS, upgrade/migration help), additive to the existing hosted "Support contract" line
- Guest billing clarified in FAQ: "What counts as an editor?" now states guests can propose for free and only become billable when an owner explicitly grants a seat, plus a worked example (10 readers, 2 commenters, 1 approver = 1 billed editor)

Billing isn't live yet (this is a beta pricing-intent page), so there's no migration or enforcement work attached, copy and numbers only.

## Test plan

- [ ] Visually diff all four tier cards on the deployed preview against this diff
- [ ] Confirm the FAQ "What counts as an editor?" answer renders correctly with the added sentences
- [ ] Confirm Enterprise tier price line renders "From ~$500/mo" / "custom annual contract" without layout breakage
- [ ] Confirm Business tier's new storage bullet doesn't push the card height out of alignment with siblings on desktop/mobile

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787149968&installation_id=147805651&pr_number=499&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F499&signature=cf0435237858f003603f03c21334cd3f376a3c3cd2bde7b18ad953fcab94cde6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->