### PR TITLE
fix(slack): correct an overstated comment; pin the null-value regression

### DIFF
--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -69,8 +69,11 @@ export const slackRoutes = (ctx: AppContext) => {
   // Run best-effort work AFTER we've acked Slack (which demands a reply within 3s). On Workers,
   // executionCtx.waitUntil keeps the isolate alive until it settles; Node has no executionCtx, so
   // the promise just runs in-process. Either way a terminal .catch() is attached FIRST: an
-  // unawaited reject (e.g. a lookup throwing inside a deferred proposal action) would otherwise
-  // surface as an unhandledRejection — and under Node's default that can take down the process.
+  // unawaited reject (e.g. a lookup throwing inside a deferred proposal action, which runs its
+  // early lookups outside its own try/catch) would otherwise escape as an unhandledRejection.
+  // Not fatal here — node.ts installs a log-only last-resort handler — but that logs a bare,
+  // contextless line and only exists on the Node path; catching at the call site attributes the
+  // failure to the Slack deferral on both runtimes instead of leaning on the global net.
   const runAfterAck = (c: Context, work: Promise<unknown>): void => {
     const guarded = Promise.resolve(work).catch((err) =>
       log.warn("slack deferred work failed", { err: String(err) }),

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -795,6 +795,23 @@ describe("slack interactivity endpoint (resolve/reopen from a button)", () => {
     expect(sent).toContain("&lt;!channel&gt;")
   })
 
+  it('acks (not 500s) a button value of "null" — JSON.parse succeeds but yields null', async () => {
+    const { app } = make("slack-int-null-value")
+    // Regression: the old inline decode destructured the parse result OUTSIDE its try, so a
+    // literal "null" (valid JSON, parses to null) threw a TypeError → 500 instead of acking.
+    for (const actionId of [SLACK_THREAD_ACTION.resolve, SLACK_PROPOSAL_ACTION.approve]) {
+      const r = await postInteract(app, {
+        type: "block_actions",
+        response_url: "https://hooks.slack.test/response",
+        team: { id: "T1" },
+        user: { id: "U777", username: "dana" },
+        actions: [{ action_id: actionId, value: "null" }],
+        message: { blocks: [] },
+      })
+      expect(r.status).toBe(200)
+    }
+  })
+
   it("a Reopen click reopens a resolved thread", async () => {
     const { app, meta } = make("slack-int-reopen")
     const artifact = await seedResolvable(meta, {


### PR DESCRIPTION
Follow-up to #467 — a claim-fidelity pass over the assertions that PR shipped with. Two things it asserted that the code didn't fully support:

### 1. An overstated comment (corrected)

`runAfterAck`'s comment claimed an unhandled rejection "can take down the process" under Node's default. **That's wrong for this app** — `node.ts` installs a log-only `unhandledRejection` handler (`log.error`, no `exit`), so the rejection was already non-fatal.

The `.catch()` is still worth having, just for a different reason, which the comment now states: the global net logs a bare, contextless line and exists **only on the Node path**, so catching at the call site attributes the failure to the Slack deferral on both runtimes rather than leaning on a last-resort handler.

### 2. A claim that was reasoned, not proven (now pinned)

#467 claimed it fixed "a latent 500" from a button `value` of `"null"`. That was reasoning, with no test behind it. Verified the old shape really did throw:

```
"null"            -> THREW TypeError: Cannot destructure property 'a' of 'target' as it is null.
"{}"              -> ack-and-ignore
"bad json"        -> ack-and-ignore
{"a":1,"t":2}     -> handled
```

Now pinned end-to-end against the real endpoint: a `value` of `"null"` acks 200 on **both** the thread and proposal branches. Reachability is low (it takes a validly-signed Slack request), but the endpoint should never 500 on input it already means to ignore.

## Verification

`typecheck` green; `slack-routes.test.ts` green (34). Full suite + pg lane were green for this change on the pre-merge branch; CI covers them here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787215449&installation_model_id=428097&pr_number=501&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F501&signature=1ef0180edf62baaac47cdf0989f15065de0cc3be2fd8846fc3b2506c710ba509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->