### PR TITLE
ci: CodeQL + Scorecard workflows, gated until public

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+# CodeQL SAST. GitHub Advanced Security is free on public repositories only, so
+# the job gates on repository visibility: this file lands while the repo is
+# private (the job skips) and starts analyzing the moment the repo flips public,
+# with nothing to remember on launch day. The visibility check is fail-safe: if
+# the payload ever lacks the repository object, the job skips rather than runs.
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "24 5 * * 1" # weekly re-scan against new query releases
+
+permissions: {}
+
+jobs:
+  analyze:
+    if: github.repository == 'derive-to/derive' && github.event.repository.private == false
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload analysis results
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: github/codeql-action/init@08d09a53f0f5d694f253bd25732e4429c9e9337f # v3
+        with:
+          languages: javascript-typescript
+          build-mode: none
+      - uses: github/codeql-action/analyze@08d09a53f0f5d694f253bd25732e4429c9e9337f # v3
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,40 @@
+# OpenSSF Scorecard: grades the repo's supply-chain posture (branch protection,
+# pinned deps, SAST, dependency updates, code review) and publishes the score for
+# the README badge. Publishing requires a public repo, so the job gates on
+# visibility the same fail-safe way codeql.yml does: it lands while private and
+# activates at the flip. Badge (add to README once public):
+#   https://api.scorecard.dev/projects/github.com/derive-to/derive/badge
+name: scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "30 4 * * 2" # weekly
+
+permissions: read-all
+
+jobs:
+  analysis:
+    if: github.repository == 'derive-to/derive' && github.event.repository.private == false
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF to code scanning
+      id-token: write # publish results to the OpenSSF REST API
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+      - uses: github/codeql-action/upload-sarif@08d09a53f0f5d694f253bd25732e4429c9e9337f # v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Stages the flip-day security items that can land while private:

- **codeql.yml**: JS/TS SAST on push/PR/weekly cron. GHAS is public-only, so the job gates on `github.event.repository.private == false` — it skips today and activates automatically when the repo flips public. The gate is fail-safe (missing payload field → skip, never a false run).
- **scorecard.yml**: OpenSSF Scorecard weekly + on push, SARIF into code scanning, `publish_results` for the badge (badge URL in the file header comment, to add to the README at flip).

Both SHA-pinned. This PR itself demonstrates the gate: the codeql job should appear as **skipped**, not failed, in this PR's checks.

Also done outside the tree (no PR needed): Discussions enabled, and draft release **Derive v0.1.0** staged (tag/publish happens at flip).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787259242&installation_model_id=428097&pr_number=505&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F505&signature=a55329de22a167e6926ab9ec46d9fb869bfb3eb248cbdd98cae22eecfa4c7a2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->