### PR TITLE
fix(runner): survive a busy API, an unwritable /work, and a page too big to inline

### DIFF
--- a/packages/cli/src/runner.js
+++ b/packages/cli/src/runner.js
@@ -9,8 +9,16 @@
 // Ported from packages/runner (TS) into the published CLI so `derive runner
 // serve` works from a bare npx on any machine — one package, no build step.
 import { spawn } from "node:child_process"
-import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs"
-import { dirname, join } from "node:path"
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+} from "node:fs"
+import { dirname, join, resolve, sep } from "node:path"
 import {
   conventionsBlock,
   materializeNotes,
@@ -311,7 +319,17 @@ export async function syncRepos(repos, cwd) {
       res = await git(["-C", dir, "fetch", "--depth", "1", "origin", ...(r.ref ? [r.ref] : [])])
       if (res.code === 0) res = await git(["-C", dir, "checkout", "-q", "--detach", "FETCH_HEAD"])
     } else {
-      mkdirSync(dirname(dir), { recursive: true })
+      // Same "loud but non-fatal" contract as a failed clone. An unwritable cwd
+      // (bind-mount owner vs container uid) used to throw HERE, before the
+      // handling below — taking the whole daemon down at boot, on repeat, under
+      // restart:unless-stopped. A runner with no repos still answers.
+      try {
+        mkdirSync(dirname(dir), { recursive: true })
+      } catch (e) {
+        console.error(`[runner] repo ${r.url}: cannot create ${dirname(dir)} — ${e.message}`)
+        catalog.push({ ...r, dir, sha: null })
+        continue
+      }
       res = await git(["clone", "--depth", "1", ...(r.ref ? ["--branch", r.ref] : []), r.url, dir])
     }
     if (res.code !== 0) {
@@ -324,6 +342,26 @@ export async function syncRepos(repos, cwd) {
     console.log(`[runner] repo ${repoSlug(r.url)} @ ${sha.out} (${r.ref ?? "default branch"})`)
   }
   return catalog
+}
+
+/** Can the runner actually WRITE here? `statSync` proves the cwd exists, which
+ *  is not the same thing: the runner clones repos, materializes skills, and now
+ *  reads back artifact files under it. Returns null when writable, else the
+ *  reason — so doctor reports rather than throws. */
+export function checkWritable(dir) {
+  let probe
+  try {
+    // mkdtemp, not a pid-named dir: a probe leaked by a killed doctor (pid 1 in
+    // a fresh container, every time) would make the NEXT run report EEXIST on a
+    // perfectly writable directory — a health check that fails once and then
+    // fails forever.
+    probe = mkdtempSync(join(dir, ".derive-probe-"))
+    return null
+  } catch (e) {
+    return e.message
+  } finally {
+    if (probe) rmSync(probe, { recursive: true, force: true })
+  }
 }
 
 /** The prompt block that tells the model what's on disk and at which SHA. An
@@ -368,11 +406,17 @@ Do not end with prose like "this looks good" — end with the block.
 Escalate (escalate: true, with a short reason) when the manifest's escalation
 rules say so — still produce your best draft in body_md.
 
-When the asker wants a chart, visual, or report page, set "artifact" to
-{"title": "...", "html": "<!doctype html>..."} — ONE fully self-contained HTML
-document (inline CSS/JS/SVG, no external requests; it renders in a sandbox).
-Put the artifact's FULL HTML INLINE in that field — do NOT write it to a file
-and do NOT reference a path; a file on disk never reaches the asker. It is
+When the asker wants a chart, visual, or report page, set "artifact" to ONE
+fully self-contained HTML document (inline CSS/JS/SVG, no external requests; it
+renders in a sandbox), through either channel:
+  - small page — inline it: {"title": "...", "html": "<!doctype html>..."}
+  - large page, or one you built with a script — write the file inside your
+    WORKING DIRECTORY (not /tmp — a path outside it is refused) and send its
+    relative path instead: {"title": "...", "path": "companion.html"}
+The runner reads that file and publishes it for you, so a big page never has to
+survive being re-typed into JSON. The path must be a .html file that already
+exists inside your working directory when you send the block — it names the page
+you built, never some other file you happen to have read. It is
 published for you and linked under your answer; keep body_md as the prose
 summary. Otherwise leave artifact null.`
 
@@ -385,6 +429,66 @@ export function buildPrompt(messages) {
     .map((m) => `[${m.author_kind === "asker" ? "asker" : "you"}] ${m.body_md}`)
     .join("\n\n")
   return `Session transcript:\n\n${transcript}\n\nAnswer the asker's latest message (it may sit above your own last reply, if they followed up while you were answering).`
+}
+
+// 2MB cap: big enough for any inline-SVG/JS chart, small enough that a runaway
+// generation can't turn one answer into a storage-quota event.
+const MAX_ARTIFACT_CHARS = 2_000_000
+
+/** Resolve an artifact to the HTML to publish. Inline passes straight through;
+ *  a path is read from disk under three guards.
+ *
+ *  Be honest about what those guards are for. They are NOT a confidentiality
+ *  boundary against the model: it runs with permissions skipped in this very
+ *  directory, already holds the runner's credentials in its environment, and
+ *  can `cp` any file it can read into cwd. What they stop is a path STRING
+ *  that shouldn't be honored — one an asker's prompt injection, or a confused
+ *  model, points at something that was never meant for publication — and a
+ *  mis-aimed path taking the daemon down:
+ *    - inside cwd (both sides realpath'd, so a symlink out is an escape;
+ *      relative is what the contract asks for, absolute-inside-cwd is tolerated)
+ *    - a regular .html/.htm file, so a FIFO can't block the poll loop forever
+ *      and a directory/device isn't read at all
+ *    - sized BEFORE reading, so a mis-pointed 600MB dump can't OOM the daemon
+ *  Returns {html} or {error}; the caller demotes an error to a caveat, never a
+ *  failed session. */
+export function resolveArtifactHtml(artifact, cwd) {
+  if (typeof artifact.html === "string") {
+    // parseAnswer already enforces both, but this function is the guard layer
+    // its own callers trust — don't let the invariant live in one place only.
+    if (!artifact.html.trim()) return { error: "the inline artifact html is empty" }
+    if (artifact.html.length > MAX_ARTIFACT_CHARS)
+      return { error: "the inline artifact html is over the 2MB cap" }
+    return { html: artifact.html }
+  }
+  const rel = artifact.path
+  if (!/\.html?$/i.test(rel))
+    return { error: `${rel} is not a .html file — the artifact path must name the page you built` }
+  let root
+  let full
+  let st
+  try {
+    root = realpathSync(resolve(cwd))
+    full = realpathSync(resolve(root, rel))
+    st = statSync(full)
+  } catch (e) {
+    return { error: `cannot read ${rel} (${e.code ?? e.message})` }
+  }
+  if (full !== root && !full.startsWith(root + sep))
+    return { error: `${rel} resolves outside the working directory` }
+  if (!st.isFile()) return { error: `${rel} is not a regular file` }
+  if (st.size > MAX_ARTIFACT_CHARS)
+    return {
+      error: `${rel} is ${st.size} bytes — over the ${MAX_ARTIFACT_CHARS}-char artifact cap`,
+    }
+  let html
+  try {
+    html = readFileSync(full, "utf8")
+  } catch (e) {
+    return { error: `cannot read ${rel} (${e.code ?? e.message})` }
+  }
+  if (!html.trim()) return { error: `${rel} is empty` }
+  return { html }
 }
 
 /** Extract + validate the <answer> block from the assistant's final text. */
@@ -406,20 +510,18 @@ export function parseAnswer(text) {
   if (!raw || typeof raw !== "object") return { error: "answer is not an object" }
   if (typeof raw.body_md !== "string" || !raw.body_md.trim())
     return { error: "body_md must be a non-empty string" }
-  // 2MB cap: big enough for any inline-SVG/JS chart, small enough that a
-  // runaway generation can't turn one answer into a storage-quota event.
+  // Two channels, inline first: html when it fits, otherwise a file the runner
+  // reads (resolveArtifactHtml). Oversized inline WITH a path falls through to
+  // the file rather than dropping the artifact on the floor.
   const a = raw.artifact
-  const artifact =
-    a &&
-    typeof a === "object" &&
-    typeof a.title === "string" &&
-    a.title.trim() &&
-    typeof a.html === "string" &&
-    a.html.trim() &&
-    a.html.length <= 2_000_000
-      ? // Title is model-generated: clamp it to card width, not to trust it less.
-        { title: a.title.trim().slice(0, 120), html: a.html }
-      : null
+  let artifact = null
+  if (a && typeof a === "object" && typeof a.title === "string" && a.title.trim()) {
+    // Title is model-generated: clamp it to card width, not to trust it less.
+    const title = a.title.trim().slice(0, 120)
+    if (typeof a.html === "string" && a.html.trim() && a.html.length <= MAX_ARTIFACT_CHARS)
+      artifact = { title, html: a.html }
+    else if (typeof a.path === "string" && a.path.trim()) artifact = { title, path: a.path.trim() }
+  }
   return {
     answer: {
       artifact,
@@ -436,9 +538,14 @@ export function parseAnswer(text) {
 
 // The nudge for a run that ended without the <answer> block. Sent as a follow-up
 // turn on the SAME claude session (--resume), so the model still holds everything
-// it just built — cheap to reformat, and it can re-emit an inline artifact it had
-// only written to a file.
-const NUDGE_PROMPT = `Your previous reply was NOT accepted — it did not end with the required <answer> block, so it never reached the asker. Reply now with ONLY that block and nothing else: <answer>{"body_md":"…","query":…,"confidence":…,"caveats":[…],"escalate":false,"escalation_reason":null,"artifact":…}</answer>. If you built a chart or page, put its FULL HTML inline in "artifact".html — never a file path.`
+// it just built — cheap to reformat, and a page it had only written to a file is
+// now recovered by pointing at that file rather than re-typing it into JSON.
+const NUDGE_PROMPT = `Your previous reply was NOT accepted — it did not end with the required <answer> block, so it never reached the asker. Reply now with ONLY that block and nothing else: <answer>{"body_md":"…","query":…,"confidence":…,"caveats":[…],"escalate":false,"escalation_reason":null,"artifact":…}</answer>. If you built a chart or page, either inline its full HTML in "artifact".html or — if it is large or you already wrote it to a file — send {"title":"…","path":"<relative path inside your working directory>"} and the runner will publish that file — write it into your working directory first if it is currently somewhere else like /tmp. Do not re-type a large page into JSON.`
+
+// The follow-up for a run the API cut short. Resume, don't restart: the session
+// still holds everything the model built before the error, which on a long
+// review is minutes of tool calls that would otherwise be paid for twice.
+const RESUME_PROMPT = `Your previous turn was cut short by a transient service error before you could reply — everything you had already done is still here in this session. Pick up where you left off, finish the job, and end with the required <answer> block.`
 
 /** One `claude -p` run (or resume). Streams events (logged as they arrive),
  *  captures the session id (first system event) and the final `result` text. */
@@ -449,6 +556,17 @@ function spawnClaude({ bin, cwd, args, timeoutMs }) {
     let resultText = ""
     let sessionId = null
     let stderr = ""
+    // The model's last words, kept for the failure message: a crash mid-run
+    // exits nonzero with EMPTY stderr, so `exit 1: ` was all an owner ever saw.
+    // The reason ("API Error: 529 Overloaded") is in the assistant stream.
+    let lastText = ""
+    // The CLI's own verdict on the run. An API failure is NOT a silent exit: it
+    // emits a result event with is_error + api_error_status and a `result`
+    // string carrying the message ("API Error: 529 Overloaded"). Reading those
+    // is the difference between "retry, the service was busy" and "don't, the
+    // model name is wrong" — the exit code alone can't tell them apart.
+    let isError = false
+    let apiErrorStatus = null
     let timedOut = false
     let killTimer
     const timer = setTimeout(() => {
@@ -459,9 +577,13 @@ function spawnClaude({ bin, cwd, args, timeoutMs }) {
     const take = (line) => {
       try {
         const event = JSON.parse(line)
-        logEvent(event)
+        lastText = logEvent(event) || lastText
         if (!sessionId && typeof event.session_id === "string") sessionId = event.session_id
-        if (event.type === "result" && typeof event.result === "string") resultText = event.result
+        if (event.type === "result") {
+          if (typeof event.result === "string") resultText = event.result
+          if (event.is_error === true) isError = true
+          if (Number.isFinite(event.api_error_status)) apiErrorStatus = event.api_error_status
+        }
       } catch {
         // partial line / non-JSON noise
       }
@@ -485,26 +607,68 @@ function spawnClaude({ bin, cwd, args, timeoutMs }) {
       // The stream can end without a trailing newline; the unterminated line may
       // be the `result` event itself.
       if (buffer.trim()) take(buffer.trim())
-      resolve({ timedOut, code, resultText, sessionId, stderr })
+      resolve({ timedOut, code, resultText, sessionId, stderr, lastText, isError, apiErrorStatus })
     })
     child.on("error", (err) => {
       clearTimeout(timer)
       clearTimeout(killTimer)
-      resolve({ timedOut: false, code: -1, resultText: "", sessionId: null, stderr: String(err) })
+      resolve({
+        timedOut: false,
+        code: -1,
+        resultText: "",
+        sessionId: null,
+        stderr: String(err),
+        lastText: "",
+        isError: true,
+        // A spawn failure (missing binary, missing cwd) never reached the
+        // service — deterministic, so it must not look retryable.
+        apiErrorStatus: null,
+      })
     })
   })
 }
 
+// Long enough to be worth taking. The CLI does its OWN backoff first — a run
+// that surfaces `api_error_status` has already burned ~10 attempts over minutes
+// — so a 5s wait just re-enters the same overload window the CLI gave up on.
+// (`--fallback-model` is the CLI's other answer to overload; deliberately not
+// used: silently answering from a different model changes the answer without
+// telling the asker, and which model a context speaks with is the owner's call.)
+export const RETRY_DELAY_MS = 30_000
+
+/** Is this run worth a second attempt? Only when the SERVICE failed, never when
+ *  the configuration did — a wrong model name or a missing binary fails exactly
+ *  the same way twice, and paying a sleep plus a second spawn per session to
+ *  learn that is pure latency.
+ *    - 429 / 5xx from the API (the 529 that killed a review five minutes deep)
+ *    - an engine/turn error: nonzero exit, no api status, nothing to show
+ *  Excluded: timeouts (the owner's signal that the work doesn't fit the budget),
+ *  spawn failures (code -1: missing claude, missing cwd), and every 4xx — a 404
+ *  model_not_found or a 401 will never come good on its own. */
+function retryable(r) {
+  if (r.timedOut || r.code === 0 || r.code === -1) return false
+  if (r.apiErrorStatus != null) return r.apiErrorStatus === 429 || r.apiErrorStatus >= 500
+  return true
+}
+
 /** Produce a validated answer from a claude run, robustly:
- *   1. run → parse the <answer> block
- *   2. no block? nudge-retry on the SAME session (--resume) — a model deep in a
- *      build often just forgets the block; reformatting is cheap and recovers a
- *      built-but-file-only artifact.
- *   3. still no block, but there IS substantive output? SALVAGE it — post the raw
- *      reply as the answer with a caveat rather than hard-fail a run that did the
- *      work. A real crash (timeout / nonzero exit / empty output) still fails.
- *  Fresh process per run is unchanged — the resume is one follow-up turn within
- *  the same run, never across Derive sessions. */
+ *   1. run → a parseable <answer> counts EVEN IF the CLI exited nonzero after
+ *      emitting it; the block is the contract, the exit code is a hint.
+ *   2. the service failed (429/5xx/engine error)? retry ONCE, resuming the
+ *      session when there is one so minutes of tool calls aren't paid for twice.
+ *   3. still nothing, and the run is an ERROR run? fail — its `result` text is
+ *      the API's error message, and posting "API Error: 529" as an answer would
+ *      be worse than a failed session.
+ *   4. a clean exit with no block? nudge-retry on the SAME session (--resume) —
+ *      a model deep in a build often just forgets the block; reformatting is
+ *      cheap and recovers a page it had only written to a file.
+ *   5. still no block but there IS substantive output? SALVAGE it — post the raw
+ *      reply with a caveat rather than hard-fail a run that did the work.
+ *  Fresh process per run is unchanged — a resume is one follow-up turn within
+ *  the same run, never across Derive sessions. Retries stay bounded at one, and
+ *  the retry borrows the FIRST run's unspent budget rather than a fresh full
+ *  one, so a wedged session can't stall the (strictly sequential) queue for
+ *  double the timeout. */
 export async function runClaude(opts) {
   const baseArgs = [
     "--output-format",
@@ -516,23 +680,54 @@ export async function runClaude(opts) {
     "--model",
     opts.model,
   ]
-  const r = await spawnClaude({
+  // --resume does NOT carry the original --append-system-prompt (verified
+  // against the CLI): a resumed turn would run with neither the output contract
+  // nor the manifest, then be judged for not following a contract it could no
+  // longer see. Every spawn re-sends it.
+  const systemArgs = ["--append-system-prompt", opts.systemPrompt + OUTPUT_CONTRACT, ...baseArgs]
+  const firstArgs = ["-p", opts.prompt, ...systemArgs]
+  // An API failure's message arrives in the result STRING, a crash's in the
+  // assistant stream, a spawn failure's on stderr. Try all three before
+  // reporting the bare `exit 1: ` an owner used to get.
+  const why = (x) => (x.lastText || x.resultText || x.stderr || "").replace(/\s+/g, " ").trim()
+  const started = Date.now()
+  let r = await spawnClaude({
     bin: opts.bin,
     cwd: opts.cwd,
     timeoutMs: opts.timeoutMs,
-    args: [
-      "-p",
-      opts.prompt,
-      "--append-system-prompt",
-      opts.systemPrompt + OUTPUT_CONTRACT,
-      ...baseArgs,
-    ],
+    args: firstArgs,
   })
-  if (r.timedOut) return { ok: false, error: "timed out" }
-  if (r.code !== 0) return { ok: false, error: `exit ${r.code}: ${r.stderr.slice(0, 500)}` }
+  let parsed = parseAnswer(r.resultText)
 
-  const parsed = parseAnswer(r.resultText)
+  // The service failed and gave us nothing usable. One retry — resumed if the
+  // run got far enough to have a session id, otherwise from the top.
+  if (!parsed.answer && retryable(r)) {
+    const sid = r.sessionId
+    console.error(
+      `[runner] run exited ${r.code}${r.apiErrorStatus ? ` (api ${r.apiErrorStatus})` : ""}: ${why(r).slice(0, 160) || "no output"} — retrying once${sid ? ` (resume ${sid.slice(0, 8)})` : ""}`,
+    )
+    await new Promise((res) => setTimeout(res, opts.retryDelayMs ?? RETRY_DELAY_MS))
+    // Whatever the first attempt didn't spend, floored so a late failure still
+    // gets a usable window. The queue is sequential: an unbounded second run
+    // would stall every other asker for double the timeout.
+    const left = opts.timeoutMs - (Date.now() - started)
+    r = await spawnClaude({
+      bin: opts.bin,
+      cwd: opts.cwd,
+      timeoutMs: Math.max(left, 120_000),
+      args: sid ? ["-p", RESUME_PROMPT, "--resume", sid, ...systemArgs] : firstArgs,
+    })
+    parsed = parseAnswer(r.resultText)
+  }
+
+  // A block is a valid answer however the process exited — the model did the
+  // work and said so in the contract's own words.
   if (parsed.answer) return { ok: true, answer: parsed.answer }
+  if (r.timedOut) return { ok: false, error: "timed out" }
+  // An error run's `result` text is the API's error message, not an answer:
+  // fail rather than let the salvage path post "API Error: 529" to the asker.
+  if (r.code !== 0 || r.isError)
+    return { ok: false, error: `exit ${r.code}: ${why(r).slice(0, 500)}` }
 
   // Nudge-retry on the same session (bounded — this is a reformat, not new work).
   if (r.sessionId) {
@@ -541,7 +736,7 @@ export async function runClaude(opts) {
       bin: opts.bin,
       cwd: opts.cwd,
       timeoutMs: Math.min(opts.timeoutMs, 180_000),
-      args: ["-p", NUDGE_PROMPT, "--resume", r.sessionId, ...baseArgs],
+      args: ["-p", NUDGE_PROMPT, "--resume", r.sessionId, ...systemArgs],
     })
     const p2 = parseAnswer(r2.resultText)
     if (p2.answer) return { ok: true, answer: p2.answer }
@@ -570,13 +765,19 @@ export async function runClaude(opts) {
   return { ok: false, error: parsed.error }
 }
 
+/** Log one stream event; returns the assistant text it carried (if any), which
+ *  the caller keeps as the run's last words for diagnostics. */
 function logEvent(event) {
-  if (event.type !== "assistant") return
+  if (event.type !== "assistant") return ""
+  let text = ""
   for (const c of event.message?.content ?? []) {
     if (c.type === "tool_use") console.log(`[claude] → ${String(c.name)}`)
-    else if (c.type === "text" && typeof c.text === "string" && c.text.trim())
+    else if (c.type === "text" && typeof c.text === "string" && c.text.trim()) {
+      text = c.text
       console.log(`[claude] ${c.text.replace(/\s+/g, " ").slice(0, 200)}`)
+    }
   }
+  return text
 }
 
 // ---- serve --------------------------------------------------------------------
@@ -591,7 +792,10 @@ const MOCK_ANSWER = {
   artifact: null,
 }
 
-async function serveSession(client, session, manifest, cfg, repoMeta = [], skillMeta = []) {
+// Exported for tests: this is where a model's answer becomes a posted message —
+// artifact resolution, the publish-failure demotion, and the quota cap all live
+// here, and all three are things that must not take a session down with them.
+export async function serveSession(client, session, manifest, cfg, repoMeta = [], skillMeta = []) {
   const asked = session.messages.at(-1)?.body_md?.slice(0, 80) ?? "?"
   console.log(`[runner] session ${session.id}: "${asked}"`)
   const result = cfg.mock
@@ -636,9 +840,20 @@ async function serveSession(client, session, manifest, cfg, repoMeta = [], skill
     meta.caveats = [...a.caveats, "chart skipped — this session already published 10 artifacts"]
   } else if (a.artifact) {
     try {
-      const pub = await client.publishArtifact(a.artifact.title, a.artifact.html)
+      // Inline or a file under cwd — a bad path reads as a publish failure, so
+      // the prose answer still lands with the reason attached.
+      const src = resolveArtifactHtml(a.artifact, cfg.cwd)
+      if (src.error) throw new Error(src.error)
+      const pub = await client.publishArtifact(a.artifact.title, src.html)
       meta.artifacts = [{ short_id: pub.short_id, title: a.artifact.title }]
-      console.log(`[runner] published artifact ${pub.short_id} ("${a.artifact.title}")`)
+      // Name the FILE, not just the model's chosen title: bytes published from
+      // disk never pass through the event stream, so without this the host log
+      // records only a title the model wrote — no record of what was actually
+      // sent to the workspace.
+      console.log(
+        `[runner] published artifact ${pub.short_id} ("${a.artifact.title}"` +
+          `${a.artifact.path ? ` from ${a.artifact.path}` : ""})`,
+      )
     } catch (err) {
       const reason = err.message.slice(0, 120)
       meta.caveats = [...a.caveats, `a chart was produced but failed to publish (${reason})`]
@@ -787,6 +1002,7 @@ export async function doctor(cfg) {
   }
 
   let repos = []
+  let skills = []
   if (!cfg.token || !cfg.contextId) {
     // Partial config: still worth running the local checks below.
     bad(
@@ -799,7 +1015,9 @@ export async function doctor(cfg) {
       info.manifest_md
         ? ok("context + manifest", `"${info.name}" manifest v${info.manifest_version}`)
         : bad("manifest", "context resolves but its manifest is unreadable")
-      repos = parseManifest(info.manifest_md ?? "").repos
+      const parsedManifest = parseManifest(info.manifest_md ?? "")
+      repos = parsedManifest.repos
+      skills = parsedManifest.skills
     } catch (e) {
       bad("token/context", `cannot resolve ${cfg.contextId} (${e.message.slice(0, 120)})`)
     }
@@ -818,12 +1036,33 @@ export async function doctor(cfg) {
   }
 
   // A missing cwd makes spawn fail with the same ENOENT as a missing binary —
-  // check it separately so the error points at the actual problem.
+  // check it separately so the error points at the actual problem. And EXISTS
+  // is not ENOUGH: the runner clones repos, materializes skills, and reads back
+  // artifact files here. A read-only cwd passed doctor while serve crash-looped
+  // on it — the check has to be the same one serve makes.
+  let isDir = false
   try {
-    if (!statSync(cfg.cwd).isDirectory()) throw new Error("not a directory")
-    ok("cwd", cfg.cwd)
+    isDir = statSync(cfg.cwd).isDirectory()
   } catch {
-    bad("cwd", `${cfg.cwd} is not a directory — check --cwd / RUNNER_CWD`)
+    isDir = false
+  }
+  if (!isDir) bad("cwd", `${cfg.cwd} is not a directory — check --cwd / RUNNER_CWD`)
+  else {
+    const why = checkWritable(cfg.cwd)
+    // Fatal only when this context actually needs to write: repos and skills
+    // materialize into cwd, and their absence is a WRONG answer, not a missing
+    // one. Without either, an unwritable cwd is survivable (the model keeps its
+    // scratch in /tmp), so it's a warning — doctor must not refuse to start a
+    // deployment that serves correctly, now that a failed clone is non-fatal.
+    const needsWrite = repos.length > 0 || skills.length > 0
+    const detail =
+      `${cfg.cwd} — ${why}. A bind-mount owned by a different uid than the runner ` +
+      "process is the usual cause"
+    if (!why) ok("cwd", `${cfg.cwd} (writable)`)
+    else if (needsWrite)
+      bad("cwd writable", `${detail}; this context's repos/skills cannot materialize`)
+    else
+      warn("cwd writable", `${detail}; fine while this context clones no repos and pins no skills`)
   }
 
   // launchd/systemd PATHs don't include shell profile additions — the exact

--- a/packages/cli/test/runner.test.js
+++ b/packages/cli/test/runner.test.js
@@ -1,17 +1,31 @@
 import { execSync } from "node:child_process"
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { basename, join } from "node:path"
 import { describe, expect, it } from "vitest"
 import {
   buildPrompt,
+  checkWritable,
+  doctor,
   loadRunnerConfig,
   OUTPUT_CONTRACT,
   parseAnswer,
   parseManifest,
+  RETRY_DELAY_MS,
   renderServiceUnit,
   repoCatalogBlock,
   repoSlug,
+  resolveArtifactHtml,
+  runClaude,
+  serveSession,
   syncRepos,
 } from "../src/runner.js"
 
@@ -263,6 +277,402 @@ brandprint: off
     expect(out).toHaveLength(1)
     expect(out[0].sha).toBeNull()
   }, 30_000)
+
+  it("an unwritable cwd is non-fatal too — it must not crash-loop serve at boot", async () => {
+    // The field failure: a bind-mounted /work owned by the host uid, cloned into
+    // by a container running as a different one. The mkdir threw and, unlike a
+    // failed clone, took the whole daemon down under restart:unless-stopped.
+    const cwd = mkdtempSync(join(tmpdir(), "runner-ro-cwd-"))
+    chmodSync(cwd, 0o555)
+    try {
+      const out = await syncRepos([{ url: "file:///some/repo", ref: null, description: "" }], cwd)
+      expect(out).toHaveLength(1)
+      expect(out[0].sha).toBeNull()
+    } finally {
+      chmodSync(cwd, 0o755)
+    }
+  }, 30_000)
+
+  it("checkWritable tells a writable dir from one the runner only has read access to", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "runner-probe-"))
+    expect(checkWritable(cwd)).toBeNull()
+    chmodSync(cwd, 0o555)
+    try {
+      expect(checkWritable(cwd)).toMatch(/EACCES|permission/i)
+    } finally {
+      chmodSync(cwd, 0o755)
+    }
+    // A missing dir reports rather than throws — doctor prints, it doesn't crash.
+    expect(checkWritable(join(cwd, "nope"))).toBeTruthy()
+  })
+})
+
+describe("artifact file channel", () => {
+  it("parseAnswer accepts a path artifact, and inline html still wins", () => {
+    const byPath = parseAnswer(
+      '<answer>{"body_md":"page below","artifact":{"title":"Companion","path":"companion.html"}}</answer>',
+    )
+    expect(byPath.answer.artifact).toEqual({ title: "Companion", path: "companion.html" })
+    const inline = parseAnswer(
+      '<answer>{"body_md":"x","artifact":{"title":"t","html":"<p>hi</p>","path":"x.html"}}</answer>',
+    )
+    expect(inline.answer.artifact).toMatchObject({ html: "<p>hi</p>" })
+    // Neither channel filled is still nothing to publish.
+    expect(
+      parseAnswer('<answer>{"body_md":"x","artifact":{"title":"t","path":"  "}}</answer>').answer
+        .artifact,
+    ).toBeNull()
+    // Oversized inline WITH a path falls back to the file — the exact case that
+    // made a 107KB companion page unrecoverable.
+    const both = JSON.stringify({
+      body_md: "x",
+      artifact: { title: "t", html: "a".repeat(2_000_001), path: "big.html" },
+    })
+    expect(parseAnswer(`<answer>${both}</answer>`).answer.artifact).toEqual({
+      title: "t",
+      path: "big.html",
+    })
+  })
+
+  it("resolves a relative path under cwd and refuses to leave it", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "runner-art-"))
+    mkdirSync(join(cwd, "out"))
+    writeFileSync(join(cwd, "out", "page.html"), "<!doctype html><p>hi</p>")
+    expect(resolveArtifactHtml({ title: "t", path: "out/page.html" }, cwd).html).toContain(
+      "<p>hi</p>",
+    )
+    // Inline artifacts pass straight through — no filesystem involved.
+    expect(resolveArtifactHtml({ title: "t", html: "<b>x</b>" }, cwd).html).toBe("<b>x</b>")
+    // Escapes and misses report, never publish. Publishing an arbitrary host
+    // file into a workspace artifact would be a real leak.
+    const elsewhere = mkdtempSync(join(tmpdir(), "runner-elsewhere-"))
+    writeFileSync(join(elsewhere, "secret.html"), "<p>not yours</p>")
+    expect(
+      resolveArtifactHtml({ title: "t", path: join(elsewhere, "secret.html") }, cwd).error,
+    ).toMatch(/outside/)
+    expect(
+      resolveArtifactHtml({ title: "t", path: `../${basename(elsewhere)}/secret.html` }, cwd).error,
+    ).toMatch(/outside/)
+    // A symlink the model itself plants inside cwd is still an escape.
+    symlinkSync(join(elsewhere, "secret.html"), join(cwd, "link.html"))
+    expect(resolveArtifactHtml({ title: "t", path: "link.html" }, cwd).error).toMatch(/outside/)
+    expect(resolveArtifactHtml({ title: "t", path: "missing.html" }, cwd).error).toMatch(/read/i)
+    writeFileSync(join(cwd, "empty.html"), "   ")
+    expect(resolveArtifactHtml({ title: "t", path: "empty.html" }, cwd).error).toMatch(/empty/)
+    writeFileSync(join(cwd, "huge.html"), "a".repeat(2_000_001))
+    expect(resolveArtifactHtml({ title: "t", path: "huge.html" }, cwd).error).toMatch(/cap/)
+  })
+
+  it("only publishes a regular .html file — a FIFO would wedge the poll loop forever", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "runner-art-guard-"))
+    // The path names the PAGE the model built. This is not a confidentiality
+    // boundary — a model with shell in cwd can `cp .env page.html` — but it
+    // stops the zero-effort form, where one innocuous-looking field points
+    // straight at the runner's own credentials (cwd/.env on the prod host).
+    writeFileSync(join(cwd, ".env"), "DERIVE_TOKEN=dk_secret\nMONGO_URI=mongodb://x")
+    expect(resolveArtifactHtml({ title: "t", path: ".env" }, cwd).error).toMatch(/\.html/)
+    mkdirSync(join(cwd, "dir.html"))
+    expect(resolveArtifactHtml({ title: "t", path: "dir.html" }, cwd).error).toBeTruthy()
+    // readFileSync on a FIFO blocks the event loop with no timeout: the daemon
+    // stays "up" under restart:unless-stopped while answering nothing, ever.
+    execSync(`mkfifo ${join(cwd, "pipe.html")}`)
+    expect(resolveArtifactHtml({ title: "t", path: "pipe.html" }, cwd).error).toMatch(
+      /not a regular file/,
+    )
+  })
+
+  it("serveSession publishes the file's bytes, and a bad path is a caveat not a dead session", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "runner-serve-"))
+    writeFileSync(join(cwd, "page.html"), "<!doctype html><h1>companion</h1>")
+    const calls = { published: [], answered: [], failed: [] }
+    const client = {
+      publishArtifact: async (title, html) => {
+        calls.published.push({ title, html })
+        return { short_id: "art123" }
+      },
+      answer: async (id, body, meta, state) => calls.answered.push({ id, body, meta, state }),
+      fail: async (id) => calls.failed.push(id),
+    }
+    const session = () => ({
+      id: "ses_1",
+      messages: [{ id: "m1", author_kind: "asker", body_md: "build me a page" }],
+    })
+    const cfg = { cwd, mock: false }
+    // A fake `claude` that just emits the block, so the artifact channel runs
+    // end to end — parse → resolve from disk → publish → answer.
+    const fake = (answerJson) => {
+      const dir = mkdtempSync(join(tmpdir(), "runner-fake-"))
+      const bin = join(dir, "claude")
+      writeFileSync(
+        bin,
+        `#!/bin/sh\ncat <<'EOF'\n{"type":"result","result":"<answer>${answerJson}</answer>"}\nEOF\n`,
+      )
+      chmodSync(bin, 0o755)
+      return bin
+    }
+    const base = { ...cfg, model: "sonnet", timeoutMs: 30_000 }
+
+    await serveSession(
+      client,
+      session(),
+      "manifest",
+      {
+        ...base,
+        claudeBin: fake(
+          '{\\"body_md\\":\\"page built\\",\\"artifact\\":{\\"title\\":\\"Companion\\",\\"path\\":\\"page.html\\"}}',
+        ),
+      },
+      [],
+      [],
+    )
+    expect(calls.published[0]).toMatchObject({ title: "Companion" })
+    expect(calls.published[0].html).toContain("<h1>companion</h1>") // the FILE's bytes
+    expect(calls.answered[0].meta.artifacts).toEqual([{ short_id: "art123", title: "Companion" }])
+
+    await serveSession(
+      client,
+      session(),
+      "manifest",
+      {
+        ...base,
+        claudeBin: fake(
+          '{\\"body_md\\":\\"page built\\",\\"artifact\\":{\\"title\\":\\"Gone\\",\\"path\\":\\"nope.html\\"}}',
+        ),
+      },
+      [],
+      [],
+    )
+    expect(calls.published).toHaveLength(1) // nothing published for the missing file
+    expect(calls.failed).toHaveLength(0) // and the session still answered
+    expect(calls.answered[1].state).toBe("answered")
+    expect(calls.answered[1].meta.caveats.join(" ")).toMatch(/nope\.html/)
+  }, 30_000)
+})
+
+describe("runClaude transient-failure retry", () => {
+  /** A stub `claude` that records each invocation's argv and replays canned
+   *  stream-json. `script` is sh run per invocation with $n = attempt number. */
+  const fakeClaude = (body) => {
+    const dir = mkdtempSync(join(tmpdir(), "runner-fake-claude-"))
+    const bin = join(dir, "claude")
+    writeFileSync(
+      bin,
+      `#!/bin/sh
+d="${dir}"
+n=$(cat "$d/count" 2>/dev/null || echo 0)
+n=$((n+1))
+echo $n > "$d/count"
+printf '%s\\n' "$@" > "$d/args.$n"
+${body}
+`,
+    )
+    chmodSync(bin, 0o755)
+    return {
+      bin,
+      attempts: () => Number(readFileSync(join(dir, "count"), "utf8").trim()),
+      args: (n) => readFileSync(join(dir, `args.${n}`), "utf8"),
+    }
+  }
+  const opts = (bin) => ({
+    bin,
+    cwd: tmpdir(),
+    model: "sonnet",
+    timeoutMs: 30_000,
+    systemPrompt: "you are a runner",
+    prompt: "how many orgs?",
+    retryDelayMs: 0,
+  })
+
+  // The shape below is COPIED FROM THE REAL CLI (v2.1.216): an API failure is a
+  // `result` event with is_error + api_error_status and a POPULATED `result`
+  // string. Assuming it exited silently is exactly the mistake that made the
+  // first cut of this retry inert for the failure it was written for.
+  const apiError = (status, msg) =>
+    `echo '{"type":"result","subtype":"success","is_error":true,"api_error_status":${status},"result":"${msg}","session_id":"sess-abc"}'\nexit 1`
+
+  it("resumes the session after a transient API error instead of losing the run", async () => {
+    // The field failure: `API Error: 529 Overloaded` five minutes into a review.
+    const fake = fakeClaude(`
+if [ "$n" = 1 ]; then
+  echo '{"type":"system","session_id":"sess-abc"}'
+  ${apiError(529, "API Error: 529 Overloaded")}
+fi
+echo '{"type":"result","result":"<answer>{\\"body_md\\":\\"32%\\"}</answer>"}'
+`)
+    const out = await runClaude(opts(fake.bin))
+    expect(out.ok).toBe(true)
+    expect(out.answer.body_md).toBe("32%")
+    expect(fake.attempts()).toBe(2)
+    // Resumed, not restarted: the five minutes of work already done survives.
+    expect(fake.args(2)).toContain("--resume")
+    expect(fake.args(2)).toContain("sess-abc")
+  }, 30_000)
+
+  it("does NOT retry a 4xx — a wrong model name fails identically twice", async () => {
+    // Real capture: `--model bogus-model-xyz` → api_error_status 404, exit 1.
+    const fake = fakeClaude(
+      apiError(404, "There is an issue with the selected model (bogus-model-xyz)."),
+    )
+    const out = await runClaude(opts(fake.bin))
+    expect(out.ok).toBe(false)
+    expect(out.error).toMatch(/selected model/)
+    expect(fake.attempts()).toBe(1) // no sleep, no second spawn
+  }, 30_000)
+
+  it("does NOT retry a spawn failure — a missing binary is not a busy service", async () => {
+    const out = await runClaude(opts("/nonexistent/claude"))
+    expect(out.ok).toBe(false)
+    expect(out.error).toMatch(/ENOENT/)
+  }, 30_000)
+
+  it("an error run is never salvaged — the asker must not get 'API Error: 529' as an answer", async () => {
+    const fake = fakeClaude(apiError(529, "API Error: 529 Overloaded"))
+    const out = await runClaude(opts(fake.bin))
+    expect(out.ok).toBe(false)
+    expect(out.error).toContain("529")
+    expect(fake.attempts()).toBe(2) // bounded at one retry
+  }, 30_000)
+
+  it("takes a valid block even when the process exits nonzero after emitting it", async () => {
+    const fake = fakeClaude(`
+echo '{"type":"result","result":"<answer>{\\"body_md\\":\\"the work got done\\"}</answer>"}'
+exit 1
+`)
+    const out = await runClaude(opts(fake.bin))
+    expect(out.ok).toBe(true)
+    expect(out.answer.body_md).toBe("the work got done")
+  }, 30_000)
+
+  it("does NOT retry a timeout — that's the owner's signal, not a busy service", async () => {
+    const fake = fakeClaude(`sleep 10`)
+    const out = await runClaude({ ...opts(fake.bin), timeoutMs: 1_000 })
+    expect(out.ok).toBe(false)
+    expect(out.error).toBe("timed out")
+    expect(fake.attempts()).toBe(1)
+  }, 30_000)
+
+  it("re-sends the system prompt on every resume — --resume does not carry it", async () => {
+    // Verified against the real CLI: a turn started with --resume runs WITHOUT
+    // the original --append-system-prompt. Without this, the retry and the nudge
+    // both judge the model against a contract it can no longer see.
+    const fake = fakeClaude(`
+if [ "$n" = 1 ]; then
+  echo '{"type":"system","session_id":"sess-abc"}'
+  ${apiError(529, "API Error: 529 Overloaded")}
+fi
+echo '{"type":"result","result":"<answer>{\\"body_md\\":\\"ok\\"}</answer>"}'
+`)
+    await runClaude(opts(fake.bin))
+    expect(fake.args(2)).toContain("--resume")
+    expect(fake.args(2)).toContain("--append-system-prompt")
+    expect(fake.args(2)).toContain("you are a runner") // the manifest
+    expect(fake.args(2)).toContain("<answer>") // and the output contract
+  }, 30_000)
+
+  it("the nudge carries the system prompt too", async () => {
+    const fake = fakeClaude(`
+echo '{"type":"system","session_id":"sess-x"}'
+echo '{"type":"result","result":"prose, no block"}'
+`)
+    await runClaude(opts(fake.bin))
+    expect(fake.args(2)).toContain("--resume")
+    expect(fake.args(2)).toContain("--append-system-prompt")
+  }, 30_000)
+
+  it("waits before retrying, and the default wait clears the CLI's own backoff", async () => {
+    // Two halves, so neither costs 30s of CI: the delay is really awaited...
+    const fake = fakeClaude(apiError(503, "overloaded"))
+    const started = Date.now()
+    await runClaude({ ...opts(fake.bin), retryDelayMs: 1_000 })
+    expect(Date.now() - started).toBeGreaterThanOrEqual(1_000)
+    expect(fake.attempts()).toBe(2)
+    // ...and the production default (every other test overrides it to 0) is long
+    // enough not to land inside the overload window the CLI just gave up on.
+    expect(RETRY_DELAY_MS).toBeGreaterThanOrEqual(20_000)
+  }, 30_000)
+
+  it("retries from scratch when the run died before a session id existed", async () => {
+    const fake = fakeClaude(`
+if [ "$n" = 1 ]; then exit 1; fi
+echo '{"type":"result","result":"<answer>{\\"body_md\\":\\"ok\\"}</answer>"}'
+`)
+    const out = await runClaude(opts(fake.bin))
+    expect(out.ok).toBe(true)
+    expect(fake.args(2)).not.toContain("--resume")
+    expect(fake.args(2)).toContain("how many orgs?")
+  }, 30_000)
+
+  it("does NOT retry a run that produced output — that's the nudge/salvage path", async () => {
+    const fake = fakeClaude(`
+echo '{"type":"system","session_id":"sess-x"}'
+echo '{"type":"result","result":"here is prose but no block"}'
+`)
+    const out = await runClaude(opts(fake.bin))
+    expect(out.ok).toBe(true) // salvaged
+    expect(out.answer.body_md).toBe("here is prose but no block")
+    expect(fake.attempts()).toBe(2) // the original run + the nudge, not a retry
+    expect(fake.args(2)).toContain("--resume")
+  }, 30_000)
+})
+
+describe("doctor", () => {
+  // The point of the writability check is that DOCTOR reports it — testing
+  // checkWritable alone leaves the actual fix (and the field regression it
+  // exists for: doctor green while serve crash-looped) free to be reverted.
+  const runDoctor = async (cfg) => {
+    const lines = []
+    const spy =
+      (m) =>
+      (...a) => {
+        lines.push(a.join(" "))
+        return m
+      }
+    const orig = [console.log, console.error, console.warn]
+    console.log = spy()
+    console.error = spy()
+    console.warn = spy()
+    try {
+      const failures = await doctor({
+        server: "http://127.0.0.1:9",
+        token: "",
+        contextId: "",
+        claudeBin: "/nonexistent/claude",
+        ...cfg,
+      })
+      return { failures, out: lines.join("\n") }
+    } finally {
+      ;[console.log, console.error, console.warn] = orig
+    }
+  }
+
+  it.skipIf(process.getuid?.() === 0)(
+    "fails on a cwd it cannot write, and says why",
+    async () => {
+      const cwd = mkdtempSync(join(tmpdir(), "runner-doctor-"))
+      const before = await runDoctor({ cwd })
+      expect(before.out).toContain("(writable)")
+
+      chmodSync(cwd, 0o555)
+      try {
+        const after = await runDoctor({ cwd })
+        expect(after.out).toMatch(/cwd writable/)
+        expect(after.out).toMatch(/uid/) // names the bind-mount cause
+        // Without a manifest there are no repos or skills to materialize, so an
+        // unwritable cwd is survivable — a warning, not a refusal to start.
+        expect(after.failures).toBe(before.failures)
+      } finally {
+        chmodSync(cwd, 0o755)
+      }
+    },
+    60_000,
+  )
+
+  it("leaves no probe directory behind", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "runner-doctor-"))
+    await runDoctor({ cwd })
+    await runDoctor({ cwd })
+    expect(readdirSync(cwd)).toEqual([])
+  }, 60_000)
 })
 
 describe("output contract + service units", () => {
@@ -271,10 +681,17 @@ describe("output contract + service units", () => {
     expect(OUTPUT_CONTRACT).toContain("body_md")
   })
 
-  it("the contract hammers the two things that failed in the field", () => {
-    // A model deep in a build forgot the block and wrote the artifact to a file.
+  it("the contract still demands the block, and no longer forbids the file channel", () => {
+    // Weak by nature — it greps a prompt — so it asserts only the two things a
+    // future edit could silently invert. The block is still mandatory...
     expect(OUTPUT_CONTRACT).toMatch(/FINAL message MUST END/i)
-    expect(OUTPUT_CONTRACT).toMatch(/do NOT write it to a file/i)
+    // ...and the old "do NOT write it to a file" rule is GONE: it was what made
+    // a 107KB page unrecoverable, since re-emitting it inline never fit.
+    expect(OUTPUT_CONTRACT).not.toMatch(/do NOT write it to a file/i)
+    expect(
+      parseAnswer('<answer>{"body_md":"x","artifact":{"title":"t","path":"p.html"}}</answer>')
+        .answer.artifact,
+    ).toEqual({ title: "t", path: "p.html" })
   })
 
   it("renders units that reproduce the FULL running config (nothing silently dropped)", () => {


### PR DESCRIPTION
Four production failures from the last two weeks of running Analytics, PR Companion, and Customer Support on hedgehog. All in the runner's recovery paths — the code that decides whether a bad run costs an asker their answer.

## 1. A 529 threw away 5.5 minutes of review

`ses_0y1xqdpa2i5cffam` (PR Companion, 3-PR "Pulse" triad) died on `API Error: 529 Overloaded` right after fetching PR metadata. Exit 1, session `failed`, every tool call discarded. The #366 chain only recovers a *missing `<answer>` block*; a transient API error was the one path with no recovery.

`runClaude` now retries **once**, resuming the same claude session so the work already done survives.

The important part: **the signal is the CLI's own result event, not the exit code.** My first cut guarded on "exited nonzero with no output" — and a refute-reviewer proved it inert, because an API failure exits nonzero *with* a populated `result`:

```json
{"type":"result","is_error":true,"api_error_status":404,
 "result":"There's an issue with the selected model (bogus-model-xyz)..."}
```

So the runner reads `is_error` / `api_error_status`. Retries: 429, 5xx, engine errors. Does **not** retry: 4xx (a wrong model name fails identically twice), spawn ENOENT, or a timeout (that's the owner's signal the work doesn't fit the budget). The retry borrows the first run's *unspent* budget — the serve loop is sequential, so an unbounded second run would stall every queued asker for double the timeout.

Delay is 30s, not 5s: the CLI does its own backoff first (`api_retry attempt:10 max_retries:10`), so a 5s wait just re-enters the overload window it gave up on. `--fallback-model` is deliberately not used — silently answering from a different model changes the answer without telling the asker.

## 2. `--resume` was dropping the system prompt

Verified against the CLI: a turn started with `--resume` does **not** carry the original `--append-system-prompt`.

```
-p "…" --append-system-prompt "end every reply with ZZQQ9"  →  "2+2 = 4\n\nZZQQ9"
-p "…" --resume <same session>                             →  "3+3 = 6"
```

Both the new retry and the **pre-existing nudge** were resuming with neither the output contract nor the manifest in context — then judging the model for not following a contract it could no longer see. Every spawn re-sends it now. This one is a latent fix to #366, not just to this PR's new code.

## 3. A 107KB companion page, lost

The contract said *"put the FULL HTML INLINE — do NOT write it to a file"*. When the model ended without the block, the nudge asked it to re-emit the whole page as a JSON string; that never fit in one message, so salvage posted prose that still promised "the full companion page is attached as the artifact." #366 fixed the lost-file bug by trading it for a can't-inline bug.

An artifact may now be `{"title", "path"}` — a `.html` file inside the working directory that the runner reads and publishes. Three guards, each from a confirmed failure:

- **inside cwd**, both sides `realpath`'d (a symlink out is an escape)
- **regular file** — `readFileSync` on a FIFO blocks the event loop *forever*; the daemon stays "up" under `restart:unless-stopped` while answering nothing, ever
- **sized before the read** — the cap was checked after; a 600MB file spiked 537MB RSS

Being straight about what those guards are: they stop a bad path *string* (prompt injection, a confused model) and a bad path taking the daemon down. They are **not** a confidentiality boundary against the model — it has shell in cwd and can `cp` anything it can read into place, and it already holds the runner's credentials in its environment. The code comments say exactly that rather than claiming more. The `.html` requirement still kills the zero-effort form (`{"path": ".env"}`).

Separately worth doing, not in this PR: on the production host `/work/.env` sits *inside* the runner's cwd, and `bin/derive.js` defaults it there. Secrets belong outside the working directory.

## 4. An unwritable `/work` crash-looped the container

`EACCES: permission denied, mkdir '/work/repos'` — bind-mount owned by host uid 1000, container runner is uid 1001. Unlike a failed clone (loud but non-fatal), the `mkdir` threw and took the daemon down on repeat. Now non-fatal, matching the clone design.

`doctor` gained the matching check — it only proved the cwd *existed*, so it passed green while serve crash-looped. Fatal when the manifest has repos or skills to materialize (their absence is a *wrong* answer, not a missing one), a warning when there's nothing to write, so it can't refuse to start a deployment that serves correctly.

## Also

- a nonzero exit that **did** emit a valid `<answer>` is honored rather than discarded
- failures report what the model last said, instead of the bare `exit 1: ` the prod log actually showed
- an error run is never salvaged — no asker receives "API Error: 529" as their answer
- the published-artifact log names the source file (bytes read from disk never pass through the event stream, so the title was the only record)

## Verification

- 46 runner tests (135 across the CLI package), full workspace suite green (1704).
- Reviewed by three independent refute-agents; findings that survived are fixed above. Mutation-tested: reverting any individual fix fails its test — dropping the `isFile()` guard *hangs* the suite on the FIFO case. The pass also caught that `doctor` had zero coverage and three retry decisions were unpinned; both closed.
- Driven end to end against the real `claude` binary: asked for a page, the model wrote `drive-test.html` into cwd, returned it via the path channel, and the runner resolved 673 chars of real HTML.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787260937&installation_model_id=428097&pr_number=506&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F506&signature=fa73306270dd3bbecf1b4ceb601be6d93717a897063b5c9a877522d56d513f5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->