### PR TITLE
site: direct category headline on the hero

### DIFF
--- a/apps/web/public/site/index.html
+++ b/apps/web/public/site/index.html
@@ -658,7 +658,7 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
 <!-- ══════════ HERO ══════════ -->
 <header class="hero" id="hero">
   <div class="stage">
-    <div class="eyebrow hero-eyebrow">Open source · Self-hostable · Model-agnostic</div>
+    <div class="eyebrow hero-eyebrow">Make things worth keeping</div>
     <h1 class="derivation grad-ink">The open source home for&nbsp;AI&nbsp;artifacts.</h1>
     <p class="sub"><strong>You've never made more, and never kept less.</strong> Derive is your team's library for the work you and your agents make: publish it, share it anywhere with a link, and revise it together until it's right. One URL, every version, yours.</p>
     <div class="cta-row">

--- a/apps/web/public/site/index.html
+++ b/apps/web/public/site/index.html
@@ -4,10 +4,10 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="color-scheme" content="dark">
-<title>Derive — Make things worth keeping.</title>
+<title>Derive — The open source home for AI artifacts.</title>
 <meta name="description" content="You've never made more, and never kept less. Derive is where your team and its agents publish, review, and revise work. Open source and self-hostable.">
 <meta property="og:type" content="website">
-<meta property="og:title" content="Derive — Make things worth keeping.">
+<meta property="og:title" content="Derive — The open source home for AI artifacts.">
 <meta property="og:description" content="You've never made more, and never kept less. Derive is where your team and its agents publish, review, and revise work.">
 <meta property="og:url" content="https://derive.to/">
 <meta property="og:image" content="https://derive.to/site/og.png">
@@ -659,7 +659,7 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
 <header class="hero" id="hero">
   <div class="stage">
     <div class="eyebrow hero-eyebrow">Open source · Self-hostable · Model-agnostic</div>
-    <h1 class="derivation grad-ink">Make things<br>worth keeping.</h1>
+    <h1 class="derivation grad-ink">The open source home for&nbsp;AI&nbsp;artifacts.</h1>
     <p class="sub"><strong>You've never made more, and never kept less.</strong> Derive is your team's library for the work you and your agents make: publish it, share it anywhere with a link, and revise it together until it's right. One URL, every version, yours.</p>
     <div class="cta-row">
       <div class="wl-theatre" id="wlTheatre">

--- a/apps/web/public/site/index.html
+++ b/apps/web/public/site/index.html
@@ -173,7 +173,7 @@ nav.scrolled{border-bottom-color:var(--border-soft)}
   margin-top:8px;font-family:var(--mono);font-size:10.5px;letter-spacing:.05em;color:var(--faint);
 }
 .wl-meta:empty{display:none}
-.hero-eyebrow{margin-bottom:28px;color:var(--muted)}
+.hero-eyebrow{margin-bottom:0;color:var(--muted)}
 /* the tagline in gradient ink: lit at the cap line, settling toward the baseline */
 .grad-ink{
   background-image:linear-gradient(178deg,#ffffff 6%,var(--fg) 44%,rgba(243,244,246,.60) 100%);
@@ -571,7 +571,7 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
 
   .hero{padding-top:112px}
   .hero .stage{padding:0 20px}
-  .hero-eyebrow{margin-bottom:20px}
+  .hero-eyebrow{margin-bottom:0}
   .derivation{margin-top:20px}
   .hero .sub{margin-top:26px}
   .hero .cta-row{margin-top:26px;align-self:stretch}


### PR DESCRIPTION
The hero H1 becomes **"The open source home for AI artifacts."** — a direct category claim in place of "Make things worth keeping." The tagline told visitors how to feel before they knew what Derive is; the subline ("You've never made more, and never kept less…") keeps the emotional load, one line later.

- `<title>` and `og:title` updated to match.
- Dropped the hard `<br>`: at phone widths it stranded "home" alone on a line. Natural wrap + `&nbsp;` produces clean two-line breaks at both 1440 and 390 (screenshots verified at both).

| Desktop | Mobile |
|---|---|
| "The open source home / for AI artifacts." | "The open source / home for AI artifacts." |
