### PR TITLE
site: light, dark, and system theme modes on the home page

### DIFF
--- a/apps/web/public/site/index.html
+++ b/apps/web/public/site/index.html
@@ -3,7 +3,17 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="color-scheme" content="dark">
+<meta name="color-scheme" content="light dark">
+<script>
+/* theme boot — set the class before first paint (the choice lives in localStorage) */
+(function(){
+  var m = null; try { m = localStorage.getItem('derive-theme'); } catch (e) {}
+  if (m !== 'light' && m !== 'system') m = 'dark';
+  var light = m === 'light' || (m === 'system' && matchMedia('(prefers-color-scheme: light)').matches);
+  var c = document.documentElement.classList;
+  c.toggle('light', light); c.toggle('dark', !light);
+})();
+</script>
 <title>Derive — The open source home for AI artifacts.</title>
 <meta name="description" content="You've never made more, and never kept less. Derive is where your team and its agents publish, review, and revise work. Open source and self-hostable.">
 <meta property="og:type" content="website">
@@ -31,15 +41,33 @@
 }
 
 :root{
+  color-scheme:dark;
   --bg:#0a0b0d; --fg:#f3f4f6; --card:#101216; --secondary:#16181d;
   --muted:#969aa2; --faint:#5c616b; --accent:#1b1d23; --border:#23252b; --border-soft:#191b1f;
-  --primary:#f3f4f6; --primary-fg:#0a0b0d;
+  --primary:#f3f4f6; --primary-fg:#0a0b0d; --primary-hover:#fff;
   --success:#74b085; --warning:#fb923c;
   --gold:#c2a15e; --share:#8781b0;
   --scrim:#030712; --scrim-fg:#f4f5f8;
+  --ink-top:#ffffff; --ink-bot:rgba(243,244,246,.60);
+  --wire:#c6cad1; --wire-dim:#41454d; --key-fill:#1b1d22; --ph-line:#3a3e45;
+  --halo:rgba(3,7,18,.9);
+  --wm-ink:rgba(243,244,246,.02); --wm-stroke:rgba(243,244,246,.11);
   --sans:"Geist",system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
   --mono:"Geist Mono",ui-monospace,Menlo,Consolas,monospace;
   --maxw:1260px;
+}
+/* light: the same ink, on paper */
+html.light{
+  color-scheme:light;
+  --bg:#f7f7f5; --fg:#16171b; --card:#fdfdfc; --secondary:#eeeeeb;
+  --muted:#5d626b; --faint:#9aa0a8; --accent:#e9e9e6; --border:#d9d9d4; --border-soft:#e7e7e2;
+  --primary:#16171b; --primary-fg:#f7f7f5; --primary-hover:#000;
+  --success:#2f7d4d; --warning:#b45309;
+  --gold:#8f6f2f; --share:#5f5a94;
+  --ink-top:#000000; --ink-bot:rgba(22,23,27,.62);
+  --wire:#3f444c; --wire-dim:#b9bdc3; --key-fill:#2b2d33; --ph-line:#c7cacf;
+  --halo:rgba(247,247,245,.92);
+  --wm-ink:rgba(22,23,27,.025); --wm-stroke:rgba(22,23,27,.10);
 }
 *,*::before,*::after{box-sizing:border-box}
 html{-webkit-text-size-adjust:100%;scroll-behavior:smooth}
@@ -49,7 +77,7 @@ body{
   -webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;
   overflow-x:hidden;
 }
-::selection{background:rgba(243,244,246,.18)}
+::selection{background:color-mix(in srgb,var(--fg) 18%,transparent)}
 a{color:inherit;text-decoration:none;cursor:default}
 button{cursor:default;font:inherit;background:none;border:0;color:inherit;padding:0}
 
@@ -59,6 +87,7 @@ body::after{
   background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
   mix-blend-mode:screen;opacity:.07;
 }
+html.light body::after{mix-blend-mode:multiply;opacity:.05}
 
 .wrap{max-width:var(--maxw);margin:0 auto;padding:0 28px}
 .eyebrow{font-family:var(--mono);font-size:11px;font-weight:500;letter-spacing:.1em;text-transform:uppercase;color:var(--muted)}
@@ -76,7 +105,7 @@ p{margin:0;text-wrap:pretty}
 }
 .btn:active{transform:translateY(1px)}
 .btn-primary{background:var(--primary);color:var(--primary-fg);box-shadow:inset 0 1px 0 rgba(255,255,255,.2)}
-.btn-primary:hover{background:#fff}
+.btn-primary:hover{background:var(--primary-hover)}
 .btn-ghost{border-color:var(--border);color:var(--fg)}
 .btn-ghost:hover{background:var(--secondary)}
 
@@ -88,6 +117,16 @@ nav.scrolled{border-bottom-color:var(--border-soft)}
 .nav-inner{max-width:var(--maxw);margin:0 auto;padding:0 28px;height:64px;display:flex;align-items:center;gap:26px}
 .wordmark{display:flex;align-items:center}
 .wordmark img{height:26px;width:auto;display:block}
+.wordmark .wm-light{display:none}
+html.light .wordmark .wm-dark{display:none}
+html.light .wordmark .wm-light{display:block}
+/* theme toggle — cycles system → light → dark */
+.theme-btn{display:inline-flex;align-items:center;justify-content:center;width:30px;height:30px;border-radius:7px;color:var(--muted)}
+.theme-btn:hover{color:var(--fg);background:var(--secondary)}
+.theme-btn svg{display:none}
+.theme-btn[data-mode="light"] .i-sun{display:block}
+.theme-btn[data-mode="dark"] .i-moon{display:block}
+.theme-btn[data-mode="system"] .i-sys{display:block}
 .nav-right{margin-left:auto;display:flex;align-items:center;gap:24px;font-size:14px}
 .nav-right a{color:var(--muted)}
 .nav-right a:hover{color:var(--fg)}
@@ -173,10 +212,10 @@ nav.scrolled{border-bottom-color:var(--border-soft)}
   margin-top:8px;font-family:var(--mono);font-size:10.5px;letter-spacing:.05em;color:var(--faint);
 }
 .wl-meta:empty{display:none}
-.hero-eyebrow{margin-bottom:0;color:var(--muted)}
+.hero-eyebrow{margin-bottom:0;color:var(--muted);font-size:14px;letter-spacing:.14em}
 /* the tagline in gradient ink: lit at the cap line, settling toward the baseline */
 .grad-ink{
-  background-image:linear-gradient(178deg,#ffffff 6%,var(--fg) 44%,rgba(243,244,246,.60) 100%);
+  background-image:linear-gradient(178deg,var(--ink-top) 6%,var(--fg) 44%,var(--ink-bot) 100%);
   -webkit-background-clip:text;background-clip:text;color:transparent;
 }
 /* presence — you show up, like opening any Derive artifact */
@@ -243,22 +282,29 @@ nav.scrolled{border-bottom-color:var(--border-soft)}
 .doc h3.lphead em{font-style:normal;position:relative}
 .doc h3.lphead em::after{content:"";position:absolute;left:0;right:0;bottom:1px;height:2px;background:var(--fg);border-radius:2px}
 .doc .lsub{margin-top:12px;font-size:13.5px;line-height:1.6;color:var(--muted);min-height:64px}
-.doc .lbtn{display:inline-block;margin-top:16px;background:var(--fg);color:#0d0e11;border-radius:7px;padding:8px 16px;font-size:12.5px;font-weight:600}
+.doc .lbtn{display:inline-block;margin-top:16px;background:var(--fg);color:var(--bg);border-radius:7px;padding:8px 16px;font-size:12.5px;font-weight:600}
 .doc .lprice{margin-top:11px;font-family:var(--mono);font-size:11px;color:var(--faint);min-height:16px}
 .doc .lprice b{color:var(--fg);font-weight:600}
 .doc .figslot{flex:1;min-width:0;position:relative}
-.doc .lph{height:248px;border:1px dashed #3a3e45;border-radius:8px;position:relative}
-.doc .lph::before,.doc .lph::after{content:"";position:absolute;inset:0;background:linear-gradient(to top right,transparent calc(50% - .5px),#3a3e45 50%,transparent calc(50% + .5px))}
+.doc .lph{height:248px;border:1px dashed var(--ph-line);border-radius:8px;position:relative}
+.doc .lph::before,.doc .lph::after{content:"";position:absolute;inset:0;background:linear-gradient(to top right,transparent calc(50% - .5px),var(--ph-line) 50%,transparent calc(50% + .5px))}
 .doc .lph::after{transform:scaleX(-1)}
-.doc .lph > span{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:10px;letter-spacing:.14em;color:#5c626b}
+.doc .lph > span{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:10px;letter-spacing:.14em;color:var(--faint)}
 .doc .lph > span.hlspan{position:absolute;inset:auto;left:50%;top:50%;transform:translate(-50%,-50%);padding:2px 6px}
 .doc .draw3d{position:relative;height:248px;display:none;cursor:crosshair}
 .doc .draw3d canvas{position:absolute;inset:0;width:100%;height:100%;display:block}
 .doc .draw3d svg.leads{position:absolute;inset:0;width:100%;height:100%;pointer-events:none}
-.doc .draw3d .g-lbl{position:absolute;font-family:var(--mono);font-size:9px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);white-space:nowrap;pointer-events:none;transform:translate(-50%,-50%);text-shadow:0 1px 8px rgba(16,18,22,.95)}
+.doc .draw3d .g-lbl{position:absolute;font-family:var(--mono);font-size:9px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);white-space:nowrap;pointer-events:none;transform:translate(-50%,-50%);text-shadow:0 1px 8px var(--card)}
 .doc .draw3d .g-lbl b{color:var(--fg);font-weight:500}
 .doc .lpsvg{display:none;height:248px}
 .doc .lpsvg svg{display:block;width:100%;height:100%}
+/* the filing's ink follows the theme (CSS wins over the SVG presentation attributes) */
+.doc .lpsvg [stroke="#c6cad1"]{stroke:var(--wire)}
+.doc .lpsvg [stroke="#f3f4f6"]{stroke:var(--fg)}
+.doc .lpsvg [stroke="#41454d"]{stroke:var(--wire-dim)}
+.doc .lpsvg [fill="#1b1d22"]{fill:var(--key-fill)}
+.doc .lpsvg [fill="#969aa2"]{fill:var(--muted)}
+.doc .lpsvg [fill="#5c616b"]{fill:var(--faint)}
 .doc .figcapline{display:flex;justify-content:space-between;gap:12px;font-family:var(--mono);font-size:9.5px;letter-spacing:.1em;color:var(--faint);margin-top:9px;text-transform:uppercase;min-height:13px}
 .doc .lspecs{margin-top:24px;border-top:1px solid var(--border-soft);padding-top:2px;display:none;flex-wrap:wrap}
 .doc .lspecs.show{display:flex;animation:replyIn .4s ease-out}
@@ -276,6 +322,13 @@ nav.scrolled{border-bottom-color:var(--border-soft)}
 .doc.v1 h3.lphead{font-size:23px;letter-spacing:-0.01em;color:#c6cad1;font-weight:600}
 .doc.v1 .lsub{color:#787f88}
 .doc.v1 .lbtn{background:none;border:1px solid #4a4f57;color:#c6cad1;font-weight:400}
+/* v1 stays washed-out and generic on paper too */
+html.light .doc.v1 .lnav{color:#9aa0a8}
+html.light .doc.v1 .lnav .wm{color:#7d838b}
+html.light .doc.v1 .lnav .lb{color:#7d838b;border-bottom-color:#c3c7cc}
+html.light .doc.v1 h3.lphead{color:#6f747c}
+html.light .doc.v1 .lsub{color:#9aa0a8}
+html.light .doc.v1 .lbtn{border-color:#c3c7cc;color:#6f747c}
 @media(max-width:840px){.doc .lhero{flex-wrap:wrap}.doc .lcol{width:100%}.doc h3.lphead,.doc .lsub{min-height:0}}
 .flash{animation:flash 1.1s ease-out}
 @keyframes flash{0%{background:color-mix(in srgb,var(--fg) 9%,transparent)}100%{background:transparent}}
@@ -336,6 +389,7 @@ nav.scrolled{border-bottom-color:var(--border-soft)}
   position:absolute;left:14px;top:16px;font-size:11px;font-weight:500;line-height:1;
   padding:4px 9px;border-radius:999px;color:var(--scrim);white-space:nowrap;
 }
+html.light .pcursor .flag{color:#fff}
 .pcursor.rob svg .arrow{fill:var(--gold)}
 .pcursor.rob .flag{background:var(--gold)}
 .pcursor.ada svg .arrow{fill:var(--share)}
@@ -422,7 +476,7 @@ nav.scrolled{border-bottom-color:var(--border-soft)}
 }
 .kept-card{
   background:var(--card);border:1px solid var(--border);border-radius:12px;padding:22px 26px;
-  box-shadow:0 0 0 1px rgba(243,244,246,.04),0 0 80px 30px rgba(3,7,18,.9);
+  box-shadow:0 0 0 1px color-mix(in srgb,var(--fg) 4%,transparent),0 0 80px 30px var(--halo);
   display:flex;flex-direction:column;gap:12px;min-width:min(430px,88vw);
 }
 .kept-card .kc-top{display:flex;align-items:center;gap:10px;font-family:var(--mono);font-size:12.5px;color:var(--fg)}
@@ -431,7 +485,7 @@ nav.scrolled{border-bottom-color:var(--border-soft)}
 .kept-card .kc-meta .ok{color:var(--success)}
 .kept-line{
   font-size:clamp(22px,3vw,32px);font-weight:500;letter-spacing:-0.02em;text-align:center;
-  text-shadow:0 0 24px rgba(10,11,13,.9);
+  text-shadow:0 0 24px var(--bg);
 }
 .kept-line em{font-style:normal;color:var(--muted)}
 
@@ -551,7 +605,7 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
 .watermark{
   position:absolute;left:50%;bottom:-.34em;transform:translateX(-50%);
   font-size:clamp(120px,24vw,340px);font-weight:500;letter-spacing:-0.04em;line-height:1;
-  color:rgba(243,244,246,.02);-webkit-text-stroke:1px rgba(243,244,246,.11);
+  color:var(--wm-ink);-webkit-text-stroke:1px var(--wm-stroke);
   pointer-events:none;user-select:none;white-space:nowrap;
 }
 .foot-inner{
@@ -645,11 +699,17 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
 <nav id="nav">
   <div class="nav-inner">
     <a class="wordmark" href="#">
-      <img src="/brand/wordmark-light.svg" alt="Derive">
+      <img class="wm-dark" src="/brand/wordmark-light.svg" alt="Derive">
+      <img class="wm-light" src="/brand/wordmark-dark.svg" alt="Derive">
     </a>
     <div class="nav-right">
       <a href="/pricing">Pricing</a>
       <a href="https://github.com/derive-to/derive">GitHub</a>
+      <button class="theme-btn" id="themeBtn" type="button" data-mode="dark" aria-label="Theme: dark" title="Theme: dark">
+        <svg class="i-sun" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="3" stroke="currentColor" stroke-width="1.3"/><path d="M7 .8v1.7M7 11.5v1.7M.8 7h1.7M11.5 7h1.7M2.6 2.6l1.2 1.2M10.2 10.2l1.2 1.2M11.4 2.6l-1.2 1.2M3.8 10.2l-1.2 1.2" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>
+        <svg class="i-moon" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><path d="M11.8 8.6A5.2 5.2 0 1 1 5.4 2.2a4.2 4.2 0 0 0 6.4 6.4Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
+        <svg class="i-sys" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="5.4" stroke="currentColor" stroke-width="1.3"/><path d="M7 1.6v10.8A5.4 5.4 0 0 0 7 1.6Z" fill="currentColor"/></svg>
+      </button>
       <a class="nav-signin" href="/login">Sign in to Beta <span class="arr">→</span></a>
     </div>
   </div>
@@ -1212,6 +1272,7 @@ let glSetVersion = (n) => {
   const svg = $('lpSvg'); if (svg) svg.style.display = n >= 2 ? 'block' : 'none';
 };
 let glSnap = () => {};
+let glSetTheme = () => {};
 if (glOk) (() => {
   const gl = glCtx;
   const M = {
@@ -1287,14 +1348,15 @@ if (glOk) (() => {
     'attribute vec3 p; uniform mat4 mvp; uniform vec3 off; varying float w;' +
     'void main(){ vec4 c = mvp * vec4(p + off, 1.0); w = c.w; gl_Position = c; }'));
   gl.attachShader(prog, sh(gl.FRAGMENT_SHADER,
-    'precision mediump float; uniform float ua; varying float w;' +
+    'precision mediump float; uniform float ua; uniform vec3 uc; varying float w;' +
     'void main(){ float d = clamp((w - 240.0) / 260.0, 0.0, 1.0);' +
-    'gl_FragColor = vec4(0.953, 0.957, 0.965, ua * mix(1.0, 0.22, d)); }'));
+    'gl_FragColor = vec4(uc, ua * mix(1.0, 0.22, d)); }'));
   gl.linkProgram(prog); gl.useProgram(prog);
   const aP = gl.getAttribLocation(prog, 'p');
   const uMVP = gl.getUniformLocation(prog, 'mvp');
   const uOff = gl.getUniformLocation(prog, 'off');
   const uA = gl.getUniformLocation(prog, 'ua');
+  const uC = gl.getUniformLocation(prog, 'uc');
   gl.enableVertexAttribArray(aP);
   gl.enable(gl.BLEND); gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
   for (const pp of parts) { pp.buf = gl.createBuffer(); gl.bindBuffer(gl.ARRAY_BUFFER, pp.buf); gl.bufferData(gl.ARRAY_BUFFER, pp.v, gl.STATIC_DRAW); }
@@ -1398,6 +1460,12 @@ if (glOk) (() => {
     eT = 0;
     setTimeout(() => { if (glVersion === 3) eT = 0.4; }, 950);
   };
+  /* line ink per theme: #f3f4f6 on the dark bg, #16171b on paper */
+  glSetTheme = (light) => {
+    gl.uniform3f(uC, light ? 0.086 : 0.953, light ? 0.090 : 0.957, light ? 0.106 : 0.965);
+    if (glVersion >= 2) glDraw(0);
+  };
+  glSetTheme(document.documentElement.classList.contains('light'));
   addEventListener('resize', () => { if (glVersion >= 2) { glResize(); glDraw(0); } });
 })();
 
@@ -1634,6 +1702,33 @@ function typeTerm(){
 }
 const tio = new IntersectionObserver(es => es.forEach(en => { if (en.isIntersecting) { typeTerm(); tio.disconnect(); } }), {threshold:.35});
 tio.observe(document.querySelector('.bigterm'));
+
+/* ══ theme: light / dark / system (the boot script in <head> painted the right one) ══ */
+const themeBtn = $('themeBtn');
+const sysLight = matchMedia('(prefers-color-scheme: light)');
+const THEME_KEY = 'derive-theme';
+function themeMode(){
+  let m = null; try { m = localStorage.getItem(THEME_KEY); } catch {}
+  return m === 'light' || m === 'system' ? m : 'dark';
+}
+function applyTheme(){
+  const mode = themeMode();
+  const light = mode === 'light' || (mode === 'system' && sysLight.matches);
+  const c = document.documentElement.classList;
+  c.toggle('light', light); c.toggle('dark', !light);
+  themeBtn.dataset.mode = mode;
+  themeBtn.setAttribute('aria-label', 'Theme: ' + mode);
+  themeBtn.title = 'Theme: ' + mode;
+  glSetTheme(light);
+}
+themeBtn.addEventListener('click', () => {
+  const order = ['dark', 'light', 'system'];
+  const next = order[(order.indexOf(themeMode()) + 1) % order.length];
+  try { localStorage.setItem(THEME_KEY, next); } catch {}
+  applyTheme();
+});
+sysLight.addEventListener('change', () => { if (themeMode() === 'system') applyTheme(); });
+applyTheme();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Adds light and dark mode, plus a system option, to the marketing home page. **Dark stays the default** — a fresh visitor gets the existing dark poster regardless of OS preference; light and system are opt-in via a new toggle in the nav.

Stacked on #510 (base is `site/hero-direct-category`), so this diff is theme work only.

## How it works

- **Nav toggle** cycles dark → light → system (moon / sun / half-circle icon). Choice persists in `localStorage['derive-theme']`.
- **No flash**: a tiny inline script in `<head>` sets the `light`/`dark` class on `<html>` before first paint. No-JS visitors get dark via the markup default.
- **System mode** tracks `prefers-color-scheme` live through a media-query listener.
- **Light palette** is the same monochrome ink system, on paper (`#f7f7f5` / `#16171b`), with gold/violet/success darkened to hold contrast as text on white.

## Colors that lived outside the tokens, now theme-aware

- The **WebGL exploded wireframe** had its line color baked into the fragment shader — it's now a `uniform` the toggle sets, so the 3D drawing re-inks with the page.
- The **patent-filing SVG** used literal hex stroke/fill attributes; CSS attribute selectors (`[stroke="#c6cad1"]{stroke:var(--wire)}`) override them per theme without touching the markup.
- The **film grain** flips from `screen` to `multiply` blend on light; gradient-ink H1, selection, watermark footer, ocean spotlight halo, v1 "generic template" grays, cursor flags, and the wordmark swap (`wordmark-light.svg` ↔ `wordmark-dark.svg`) all follow tokens or light overrides.

## Verified

Playwright against a static serve of `apps/web/public`:
- Fresh profile with OS in **light** mode still loads **dark**.
- Toggle cycles dark → light → system; selection survives reload.
- Screenshots of hero, live-artifact demo (WebGL wireframe re-inked), ocean, and finale in both themes; no console errors.

Not in scope: `pricing.html` is still dark-only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787411889&installation_model_id=428097&pr_number=512&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F512&signature=60172a55a44617a9ec7232b6294379dbbb98a23d74833f11b94cc0b3b3443b73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->