### PR TITLE
feat(api): signup attribution: stamp arrivals, record the source at s…

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,7 @@ import { compress } from "hono/compress"
 import type { BlankEnv } from "hono/types"
 import { OAUTH_ANON_CLIENT_TTL_MS } from "./auth-config"
 import { type AppDeps, buildContext } from "./context"
+import { captureSignupSource } from "./lib/attribution"
 import { cacheControlFor, corsFor, fail, TOMBSTONE } from "./lib/http"
 import { observability, redactPath } from "./lib/observability"
 import { inMemoryRateLimiters, ipRateLimit } from "./lib/rate-limit"
@@ -117,6 +118,11 @@ export function createApp(deps: AppDeps): Hono {
     const gzip = compress()
     app.use("*", (c, next) => (c.req.path.endsWith("/events") ? next() : gzip(c, next)))
   }
+
+  // Signup-source capture: external arrivals on the HTML entry points get a d_src
+  // cookie the auth layer reads back at signup (see lib/attribution.ts). The
+  // middleware scopes itself — API and raw paths never stamp.
+  app.use("*", captureSignupSource())
 
   // Uncaught errors become a consistent JSON 500 (never a stack trace to the
   // client) and a structured server log line.

--- a/apps/api/src/auth-config.ts
+++ b/apps/api/src/auth-config.ts
@@ -140,6 +140,11 @@ export interface AuthHooks {
   /** Purge the user's Derive-domain data AFTER Better Auth deletes the account (the
    *  deleteUserData cascade). Unset (tests) ⇒ no cascade. */
   purgeUserData?: (userId: string) => Promise<void>
+  /** Record where the signup came from: called once per created user with the raw
+   *  Cookie header, so the d_src stamp (see lib/attribution.ts) becomes the account's
+   *  signup_attribution row. Best-effort telemetry — failures never block creation.
+   *  Unset (tests, schema-gen) ⇒ signups are simply unattributed. */
+  recordSignupAttribution?: (userId: string, cookieHeader: string | null) => Promise<void>
 }
 
 export function makeAuth(db: AuthDb, baseUrl: string, secret: string, hooks: AuthHooks = {}) {
@@ -300,6 +305,19 @@ export function makeAuth(db: AuthDb, baseUrl: string, secret: string, hooks: Aut
               return { data: { ...user, username } }
             } catch {
               return { data: user }
+            }
+          },
+          // Signup attribution: hand the arriving Cookie header (the d_src stamp) to
+          // the app. Every provider — email, Google, OIDC — creates users through
+          // this one path, and OAuth callbacks are top-level GETs, so the Lax cookie
+          // rides along.
+          after: async (user, ctx) => {
+            try {
+              const cookie =
+                ctx?.headers?.get("cookie") ?? ctx?.request?.headers.get("cookie") ?? null
+              await hooks.recordSignupAttribution?.(user.id, cookie)
+            } catch {
+              // Best-effort telemetry: the account always wins.
             }
           },
         },

--- a/apps/api/src/lib/attribution.ts
+++ b/apps/api/src/lib/attribution.ts
@@ -1,0 +1,145 @@
+import { type MetaStore, newId, parseRef } from "@derive/core"
+import type { Context, MiddlewareHandler } from "hono"
+import { getCookie, setCookie } from "hono/cookie"
+import { SESSION_COOKIE_NAMES } from "./http"
+
+/**
+ * Signup-source capture. An external GET on an HTML entry point — an
+ * `/artifacts/:ref` share link, or `/` / `/pricing` carrying a `?src=` campaign
+ * tag — stamps an httpOnly `d_src` cookie: the surface (`badge`, `comment_wall`,
+ * a campaign token, or bare `artifact_visit`), the artifact, the landing path,
+ * and the external referrer host. Last touch wins.
+ *
+ * The other half runs at signup: Better Auth's user-create hook feeds the Cookie
+ * header to `signupAttributionHook`, which parses the stamp and writes the
+ * account's `signup_attribution` row (unique per user, so first write wins).
+ * No stamp — or a garbage one — is an organic signup, never an error.
+ */
+
+/** Cookie name for the signup-source stamp. */
+export const SRC_COOKIE = "d_src"
+
+/** 30 days: long enough to span seeing a shared artifact and signing up later. */
+const MAX_AGE_S = 30 * 24 * 3600
+
+// A campaign/surface token (`badge`, `comment_wall`, `hn-launch`) — never markup.
+const KIND = /^[a-z0-9][a-z0-9_-]{0,39}$/i
+// An artifact short id (the shape core's parseRef extracts).
+const SHORT_ID = /^[0-9a-z]{6,12}$/
+
+/** What the capture middleware stamped, decoded for the signup hook. */
+export interface ParsedSrc {
+  source_kind: string
+  source_artifact: string | null
+  landing_path: string | null
+  referrer: string | null
+}
+
+// A hand-typed or truncated share link can carry broken percent-encoding;
+// decodeURIComponent would throw and 500 the page over a tracking cookie.
+const safeDecode = (s: string): string => {
+  try {
+    return decodeURIComponent(s)
+  } catch {
+    return s
+  }
+}
+
+/** The external referrer's host — null when missing, unparsable, or same-host
+ *  (internal navigation is not a source). */
+const referrerHost = (referer: string | undefined, ownHost: string): string | null => {
+  if (!referer) return null
+  try {
+    const host = new URL(referer).host
+    return host && host !== ownHost ? host.slice(0, 100) : null
+  } catch {
+    return null
+  }
+}
+
+const stamp = (c: Context): void => {
+  if (c.req.method !== "GET") return
+  const path = c.req.path
+  // Only the HTML entry points stamp — never API, raw-viewer, or asset paths.
+  const ref = path.startsWith("/artifacts/") ? path.slice("/artifacts/".length) : null
+  if (ref === null && path !== "/" && path !== "/pricing") return
+  // A signed-in visitor can't sign up again; skip the write (presence-only check,
+  // a stale cookie just skips the stamp).
+  if (SESSION_COOKIE_NAMES.some((n) => getCookie(c, n))) return
+
+  const srcParam = c.req.query("src")
+  const kind =
+    srcParam && KIND.test(srcParam)
+      ? srcParam.toLowerCase()
+      : ref !== null
+        ? "artifact_visit"
+        : null
+  // A bare marketing view is not a source — organic stays unattributed.
+  if (!kind) return
+
+  // `?art=` lets a campaign link name the artifact; a share link carries it in the ref.
+  const artParam = c.req.query("art")
+  const fromRef = ref !== null ? parseRef(safeDecode(ref)).shortId : null
+  const artifact =
+    artParam && SHORT_ID.test(artParam)
+      ? artParam
+      : fromRef && SHORT_ID.test(fromRef)
+        ? fromRef
+        : null
+  // Host is the origin the visitor actually hit; a same-host referer is internal
+  // navigation, not a source.
+  const referrer = referrerHost(c.req.header("referer"), c.req.header("host") ?? "")
+
+  const value = JSON.stringify({
+    k: kind,
+    ...(artifact ? { a: artifact } : {}),
+    p: path.slice(0, 200),
+    ...(referrer ? { r: referrer } : {}),
+  })
+  setCookie(c, SRC_COOKIE, value, {
+    path: "/",
+    httpOnly: true,
+    sameSite: "Lax",
+    maxAge: MAX_AGE_S,
+    secure: c.req.url.startsWith("https://"),
+  })
+}
+
+/** Mount once with `app.use("*", …)`; `stamp` itself scopes to the entry points. */
+export const captureSignupSource = (): MiddlewareHandler => async (c, next) => {
+  stamp(c)
+  await next()
+}
+
+/** The signup half: parse the arriving Cookie header, record the row. Wired into
+ *  AuthHooks by both the Node and Worker entries. */
+export const signupAttributionHook =
+  (meta: MetaStore) =>
+  async (userId: string, cookieHeader: string | null): Promise<void> => {
+    const src = parseSrcCookie(cookieHeader)
+    if (!src) return
+    await meta.recordSignupAttribution({ id: newId("src"), user_id: userId, ...src })
+  }
+
+/** Decode the `d_src` stamp from a raw Cookie header; null for absent or invalid. */
+export const parseSrcCookie = (cookieHeader: string | null): ParsedSrc | null => {
+  if (!cookieHeader) return null
+  const pair = cookieHeader.split(/;\s*/).find((p) => p.startsWith(`${SRC_COOKIE}=`))
+  if (!pair) return null
+  try {
+    const v = JSON.parse(decodeURIComponent(pair.slice(SRC_COOKIE.length + 1))) as Record<
+      string,
+      unknown
+    >
+    const kind = typeof v.k === "string" && KIND.test(v.k) ? v.k.toLowerCase() : null
+    if (!kind) return null
+    return {
+      source_kind: kind,
+      source_artifact: typeof v.a === "string" && SHORT_ID.test(v.a) ? v.a : null,
+      landing_path: typeof v.p === "string" ? v.p.slice(0, 200) : null,
+      referrer: typeof v.r === "string" ? v.r.slice(0, 100) : null,
+    }
+  } catch {
+    return null
+  }
+}

--- a/apps/api/src/lib/http.ts
+++ b/apps/api/src/lib/http.ts
@@ -55,6 +55,13 @@ export const WS_COOKIE = "derive_ws"
 /** Long-lived cookie that gives an anonymous browser one stable identity — used
  *  for unique-view counts and a stable presence name across opens. */
 export const VIEWER_COOKIE = "derive_vid"
+/** Better Auth's session cookie, both spellings (useSecureCookies adds the
+ *  __Secure- prefix on https origins). For presence-only checks; never validate
+ *  a session by cookie name alone. */
+export const SESSION_COOKIE_NAMES = [
+  "__Secure-better-auth.session_token",
+  "better-auth.session_token",
+]
 
 // Friendly, anonymous presence handles — `helpful-kitty-95` style. An anonymous
 // viewer never picks their own name (no impersonation/spam); the server derives a

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -17,6 +17,7 @@ import { configWarnings } from "./config-manifest"
 import { restEmbedder } from "./embedder"
 import { loadLocalEmbedder } from "./embedder-local"
 import { workspacesBlockingDeletion } from "./lib/account"
+import { signupAttributionHook } from "./lib/attribution"
 import { customDomainsFromEnv } from "./lib/cloudflare-saas"
 import { buildAuthEmail, emailDeliverySender, logEmailSender, resendEmailSender } from "./lib/email"
 import { makeGithubCommentSender } from "./lib/github-comments"
@@ -205,6 +206,8 @@ const auth = makeAuth(authDb, cfg.baseUrl, authSecret, {
       : null
   },
   purgeUserData: (userId) => meta.deleteUserData(userId),
+  // The d_src stamp (lib/attribution.ts) becomes the account's signup_attribution row.
+  recordSignupAttribution: signupAttributionHook(meta),
 })
 await migrateAuth(auth)
 

--- a/apps/api/src/routes/marketing.ts
+++ b/apps/api/src/routes/marketing.ts
@@ -1,6 +1,7 @@
 import { type Context, Hono } from "hono"
 import { getCookie } from "hono/cookie"
 import type { AppContext } from "../context"
+import { SESSION_COOKIE_NAMES } from "../lib/http"
 
 /**
  * The marketing site (the hosted front door). Two self-contained HTML pages that
@@ -39,10 +40,9 @@ export const marketingRoutes = (ctx: AppContext) => {
     }
     return app
   }
-  // Better Auth's session cookie, both spellings (useSecureCookies adds the
-  // __Secure- prefix on https origins). Presence only — never validated here.
-  const SESSION_COOKIES = ["__Secure-better-auth.session_token", "better-auth.session_token"]
-  const hasSession = (c: Context): boolean => SESSION_COOKIES.some((n) => !!getCookie(c, n))
+  // Presence only — never validated here; a stale cookie serves the shell and the
+  // SPA's own guard bounces to /login.
+  const hasSession = (c: Context): boolean => SESSION_COOKIE_NAMES.some((n) => !!getCookie(c, n))
 
   app.get("/", async (c) => {
     // app.* is the app alias: its visitors chose the app, never the brochure.

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -23,6 +23,7 @@ import { hyperdriveConn, livePgPool, requestPg } from "./edge-pg"
 import type { SendEmailBinding } from "./email-cf"
 import { bindingEmbedder, EMBED_DIMENSIONS, type WorkersAiLike } from "./embedder"
 import { workspacesBlockingDeletion } from "./lib/account"
+import { signupAttributionHook } from "./lib/attribution"
 import { customDomainsFromEnv } from "./lib/cloudflare-saas"
 import { buildAuthEmail } from "./lib/email"
 import { slackFromEnv, subdomainBaseFromEnv, superAdminsFromEnv } from "./lib/env"
@@ -225,6 +226,8 @@ const handle = (req: Request, env: Env, ctx: ExecutionContext): Response | Promi
             : null
         },
         purgeUserData: (userId) => meta.deleteUserData(userId),
+        // The d_src stamp (lib/attribution.ts) becomes the account's signup_attribution row.
+        recordSignupAttribution: signupAttributionHook(meta),
       })
       app = createApp({
         meta,

--- a/apps/api/test/attribution-signup.test.ts
+++ b/apps/api/test/attribution-signup.test.ts
@@ -1,0 +1,106 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { SqliteMetaStore } from "@derive/db/sqlite"
+import { FsBlobStore } from "@derive/storage/fs"
+import Database from "better-sqlite3"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { makeAuth, migrateAuth } from "../src/auth-config"
+import { SRC_COOKIE, signupAttributionHook } from "../src/lib/attribution"
+
+// The signup half of attribution: a REAL Better Auth sign-up (the same harness as
+// auth-origin.test.ts) carrying the d_src cookie the capture middleware stamped —
+// the user-create hook must record it, and must never be able to block the signup.
+const dir = mkdtempSync(join(tmpdir(), "derive-attr-signup-"))
+
+const dbPath = join(dir, "auth.db")
+const db = new Database(dbPath)
+const meta = new SqliteMetaStore(dbPath)
+const auth = makeAuth(db, "http://localhost:8080", "test-secret-0123456789abcd", {
+  recordSignupAttribution: signupAttributionHook(meta),
+})
+const app = createApp({
+  meta,
+  blobs: new FsBlobStore(join(dir, "blobs")),
+  baseUrl: "http://localhost:8080",
+  auth,
+})
+
+// A second auth stack whose hook always throws — attribution is best-effort
+// telemetry and must never cost an account.
+const db2 = new Database(join(dir, "auth2.db"))
+const auth2 = makeAuth(db2, "http://localhost:8080", "test-secret-0123456789abcd", {
+  recordSignupAttribution: async () => {
+    throw new Error("attribution store down")
+  },
+})
+const app2 = createApp({
+  meta: new SqliteMetaStore(join(dir, "auth2.db")),
+  blobs: new FsBlobStore(join(dir, "blobs2")),
+  baseUrl: "http://localhost:8080",
+  auth: auth2,
+})
+
+beforeAll(async () => {
+  await migrateAuth(auth)
+  await migrateAuth(auth2)
+})
+afterAll(() => {
+  db.close()
+  db2.close()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+const stamp = (v: object) => `${SRC_COOKIE}=${encodeURIComponent(JSON.stringify(v))}`
+
+const signUp = (a: typeof app, email: string, cookie?: string) =>
+  a.request("/api/auth/sign-up/email", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      // A cookie arms Better Auth's CSRF/origin check; real browser signups always
+      // carry a same-origin Origin header, so send one (auth-origin.test.ts pattern).
+      origin: "http://localhost:8080",
+      ...(cookie ? { cookie } : {}),
+    },
+    body: JSON.stringify({ email, password: "password12345", name: "Tester" }),
+  })
+
+describe("signup attribution (the user-create hook)", () => {
+  it("records the d_src stamp onto the new account", async () => {
+    const res = await signUp(
+      app,
+      "badge@example.com",
+      stamp({ k: "badge", a: "ab12cd34", p: "/artifacts/doc-ab12cd34", r: "news.ycombinator.com" }),
+    )
+    expect(res.status).toBe(200)
+    const userId = (await res.json()).user.id as string
+    expect(await meta.getSignupAttribution(userId)).toMatchObject({
+      user_id: userId,
+      source_kind: "badge",
+      source_artifact: "ab12cd34",
+      landing_path: "/artifacts/doc-ab12cd34",
+      referrer: "news.ycombinator.com",
+    })
+  })
+
+  it("records nothing for an organic signup (no cookie)", async () => {
+    const res = await signUp(app, "organic@example.com")
+    expect(res.status).toBe(200)
+    const userId = (await res.json()).user.id as string
+    expect(await meta.getSignupAttribution(userId)).toBeNull()
+  })
+
+  it("treats a garbage stamp as organic — signup still succeeds", async () => {
+    const res = await signUp(app, "garbage@example.com", `${SRC_COOKIE}=%7Bnope`)
+    expect(res.status).toBe(200)
+    const userId = (await res.json()).user.id as string
+    expect(await meta.getSignupAttribution(userId)).toBeNull()
+  })
+
+  it("a throwing attribution hook never blocks account creation", async () => {
+    const res = await signUp(app2, "resilient@example.com", stamp({ k: "badge", p: "/" }))
+    expect(res.status).toBe(200)
+  })
+})

--- a/apps/api/test/attribution.test.ts
+++ b/apps/api/test/attribution.test.ts
@@ -1,0 +1,179 @@
+import { join } from "node:path"
+import { FsBlobStore } from "@derive/storage/fs"
+import { describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { parseSrcCookie, SRC_COOKIE } from "../src/lib/attribution"
+import { dir, meta, TEST_TOKEN } from "./helpers"
+
+const SHELL =
+  "<!doctype html><html><head><title>Derive</title></head><body><div id=root></div></body></html>"
+const HOME = "<!doctype html><html><body>MARKETING HOME</body></html>"
+
+// Worker-shaped app (shellFetch, marketing) — the paths the capture middleware
+// stamps are exactly the worker-first HTML entry points (/artifacts/:ref, /, /pricing).
+const a = createApp({
+  meta,
+  blobs: new FsBlobStore(join(dir, "blobs-attribution")),
+  baseUrl: "http://derive.test",
+  token: TEST_TOKEN,
+  shellFetch: async () => SHELL,
+  marketing: { home: async () => HOME, pricing: async () => HOME },
+})
+
+const BEARER = { authorization: `Bearer ${TEST_TOKEN}` }
+
+// One published artifact for the share-link tests; the middleware stamps by path,
+// independent of readability (an arrival is an arrival).
+const publish = async (): Promise<string> => {
+  const form = new FormData()
+  form.append("file", new Blob([new TextEncoder().encode("<h1>hi</h1>")]), "f.html")
+  form.append("title", "Attribution Doc")
+  const res = await a.request("/v1/artifacts", { method: "POST", body: form, headers: BEARER })
+  expect(res.status).toBe(201)
+  return (await res.json()).short_id as string
+}
+
+const setCookies = (res: Response): string[] =>
+  // getSetCookie keeps multiple Set-Cookie headers apart (get() would comma-join them).
+  res.headers.getSetCookie?.() ?? []
+
+const srcCookie = (res: Response): string | null => {
+  const raw = setCookies(res).find((c) => c.startsWith(`${SRC_COOKIE}=`))
+  return raw ?? null
+}
+
+// Decode the stamped value the way the signup hook will see it: as a Cookie header.
+const decodeStamp = (setCookie: string) => {
+  const pair = setCookie.split(";")[0] ?? ""
+  return parseSrcCookie(pair)
+}
+
+describe("d_src capture middleware", () => {
+  it("stamps artifact_visit on an anonymous artifact-page load, httpOnly + Lax + 30d", async () => {
+    const shortId = await publish()
+    const res = await a.request(`/artifacts/${shortId}`)
+    const cookie = srcCookie(res)
+    expect(cookie).toBeTruthy()
+    expect(cookie).toContain("HttpOnly")
+    expect(cookie).toContain("SameSite=Lax")
+    expect(cookie).toContain("Max-Age=2592000")
+    expect(cookie).toContain("Path=/")
+    const parsed = decodeStamp(cookie ?? "")
+    expect(parsed).toMatchObject({
+      source_kind: "artifact_visit",
+      source_artifact: shortId,
+      landing_path: `/artifacts/${shortId}`,
+    })
+  })
+
+  it("honors a ?src= override on the artifact page (the badge link)", async () => {
+    const shortId = await publish()
+    const res = await a.request(`/artifacts/${shortId}?src=badge`)
+    const parsed = decodeStamp(srcCookie(res) ?? "")
+    expect(parsed).toMatchObject({ source_kind: "badge", source_artifact: shortId })
+  })
+
+  it("stamps a campaign kind on / with ?src= (launch links), no artifact", async () => {
+    const res = await a.request("/?src=hn-launch")
+    const parsed = decodeStamp(srcCookie(res) ?? "")
+    expect(parsed).toMatchObject({
+      source_kind: "hn-launch",
+      source_artifact: null,
+      landing_path: "/",
+    })
+  })
+
+  it("does not stamp a bare / load (an organic homepage view is not a source)", async () => {
+    const res = await a.request("/")
+    expect(srcCookie(res)).toBeNull()
+  })
+
+  it("does not stamp visitors who already have a session", async () => {
+    const shortId = await publish()
+    const res = await a.request(`/artifacts/${shortId}`, {
+      headers: { cookie: "better-auth.session_token=abc" },
+    })
+    expect(srcCookie(res)).toBeNull()
+  })
+
+  it("falls back to artifact_visit when ?src= is malformed", async () => {
+    const shortId = await publish()
+    const res = await a.request(`/artifacts/${shortId}?src=${encodeURIComponent("<script>")}`)
+    const parsed = decodeStamp(srcCookie(res) ?? "")
+    expect(parsed).toMatchObject({ source_kind: "artifact_visit", source_artifact: shortId })
+  })
+
+  it("survives a ref with broken percent-encoding (no 500, stamp without artifact)", async () => {
+    const res = await a.request("/artifacts/%E0%A4%A")
+    expect(res.status).toBeLessThan(500)
+    const parsed = decodeStamp(srcCookie(res) ?? "")
+    expect(parsed).toMatchObject({ source_kind: "artifact_visit", source_artifact: null })
+  })
+
+  it("records the external referrer host, but never a same-host one", async () => {
+    const shortId = await publish()
+    const external = await a.request(`/artifacts/${shortId}`, {
+      headers: { referer: "https://news.ycombinator.com/item?id=1" },
+    })
+    expect(decodeStamp(srcCookie(external) ?? "")?.referrer).toBe("news.ycombinator.com")
+
+    const internal = await a.request(`/artifacts/${shortId}`, {
+      headers: { host: "derive.test", referer: "http://derive.test/somewhere" },
+    })
+    expect(decodeStamp(srcCookie(internal) ?? "")?.referrer).toBeNull()
+  })
+
+  it("last touch wins: a later arrival overwrites the cookie", async () => {
+    const first = await publish()
+    const second = await publish()
+    const res1 = await a.request(`/artifacts/${first}?src=badge`)
+    expect(decodeStamp(srcCookie(res1) ?? "")?.source_artifact).toBe(first)
+    // The browser re-sends the first cookie; the middleware still restamps.
+    const pair = (srcCookie(res1) ?? "").split(";")[0] ?? ""
+    const res2 = await a.request(`/artifacts/${second}`, { headers: { cookie: pair } })
+    expect(decodeStamp(srcCookie(res2) ?? "")).toMatchObject({
+      source_kind: "artifact_visit",
+      source_artifact: second,
+    })
+  })
+
+  it("never stamps API paths", async () => {
+    const res = await a.request("/v1/artifacts", { headers: BEARER })
+    expect(res.status).toBe(200)
+    expect(srcCookie(res)).toBeNull()
+  })
+})
+
+describe("parseSrcCookie", () => {
+  it("returns null for an absent, foreign, or malformed cookie", () => {
+    expect(parseSrcCookie(null)).toBeNull()
+    expect(parseSrcCookie("")).toBeNull()
+    expect(parseSrcCookie("other=1; theme=dark")).toBeNull()
+    expect(parseSrcCookie(`${SRC_COOKIE}=%7Bnot-json`)).toBeNull()
+    expect(parseSrcCookie(`${SRC_COOKIE}=${encodeURIComponent('{"x":1}')}`)).toBeNull()
+  })
+
+  it("rejects a stamp whose kind fails validation", () => {
+    const bad = encodeURIComponent(JSON.stringify({ k: "<script>", p: "/" }))
+    expect(parseSrcCookie(`${SRC_COOKIE}=${bad}`)).toBeNull()
+  })
+
+  it("drops an invalid artifact id but keeps the stamp", () => {
+    const v = encodeURIComponent(JSON.stringify({ k: "badge", a: "NOT AN ID!!", p: "/" }))
+    const parsed = parseSrcCookie(`${SRC_COOKIE}=${v}`)
+    expect(parsed).toMatchObject({ source_kind: "badge", source_artifact: null })
+  })
+
+  it("finds the stamp among other cookies", () => {
+    const v = encodeURIComponent(
+      JSON.stringify({ k: "badge", a: "ab12cd34", p: "/x", r: "hn.com" }),
+    )
+    const parsed = parseSrcCookie(`theme=dark; ${SRC_COOKIE}=${v}; other=1`)
+    expect(parsed).toMatchObject({
+      source_kind: "badge",
+      source_artifact: "ab12cd34",
+      landing_path: "/x",
+      referrer: "hn.com",
+    })
+  })
+})

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -243,6 +243,17 @@ CREATE TABLE IF NOT EXISTS beta_signup (
   UNIQUE (email)
 );
 
+CREATE TABLE IF NOT EXISTS signup_attribution (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  source_kind TEXT NOT NULL,
+  source_artifact TEXT,
+  landing_path TEXT,
+  referrer TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  UNIQUE (user_id)
+);
+
 CREATE TABLE IF NOT EXISTS oauth_client_workspace (
   id TEXT PRIMARY KEY,
   user_id TEXT NOT NULL,

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1065,6 +1065,13 @@ export interface AgentStore {
    *  email either way, so "sign up again" doubles as "resend my link". */
   recordBetaSignup(id: string, email: string): Promise<boolean>
 
+  // ---- Signup attribution (which surface sourced a signup) -----------------
+  /** Record where a signup came from, once per user — a duplicate hook fire is a
+   *  no-op (first write wins; the attribution of record is the one at signup). */
+  recordSignupAttribution(a: NewSignupAttribution): Promise<void>
+  /** The recorded source for a user, or null for an organic signup. */
+  getSignupAttribution(userId: string): Promise<SignupAttributionRecord | null>
+
   /** Queue a mention into an agent's pull inbox. */
   createAgentMention(m: NewAgentMention): Promise<void>
   /** Pending (unhandled) mentions for an agent, oldest first. */
@@ -1483,6 +1490,29 @@ export interface BetaSignupRecord {
   email: string
   created_at: string
 }
+
+/**
+ * Where a signup came from. One row per user, recorded by the
+ * auth layer's user-create hook from the `d_src` cookie the capture middleware
+ * stamped on the way in; first write wins. Organic signups have no row.
+ */
+export interface SignupAttributionRecord {
+  id: string
+  /** The Better Auth user this attribution belongs to (no FK; auth owns its tables). */
+  user_id: string
+  /** The sourcing surface: an artifact surface (badge, comment_wall, duplicate,
+   *  share_chrome, artifact_visit) or a campaign token (hn-launch, …). */
+  source_kind: string
+  /** The artifact (short id) the sourcing surface lived on, when known. */
+  source_artifact: string | null
+  /** Path of the page that stamped the cookie. */
+  landing_path: string | null
+  /** Referrer host at stamp time. */
+  referrer: string | null
+  created_at: string
+}
+
+export type NewSignupAttribution = Omit<SignupAttributionRecord, "created_at">
 
 /**
  * A pending per-artifact share invitation: an email invited to one artifact at a

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -44,6 +44,7 @@ import type {
   RunRecord,
   SessionMessageRecord,
   SessionRecord,
+  SignupAttributionRecord,
   VersionRecord,
   WebhookRecord,
   WorkspaceRecord,
@@ -74,6 +75,7 @@ export interface TypedTables {
   artifactInvite: ArtifactInviteRecord
   invitation: InvitationRecord
   betaSignup: BetaSignupRecord
+  signupAttribution: SignupAttributionRecord
   context: ContextRecord
   contextAsker: ContextAskerRecord
   contextSession: SessionRecord

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -318,6 +318,21 @@ export const betaSignup = pgTable(
   (t) => [uniqueIndex("beta_signup_email").on(t.email)],
 )
 
+// Where a signup came from (see schema.ts for the full note).
+export const signupAttribution = pgTable(
+  "signup_attribution",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    source_kind: text("source_kind").notNull(),
+    source_artifact: text("source_artifact"),
+    landing_path: text("landing_path"),
+    referrer: text("referrer"),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [uniqueIndex("signup_attribution_user").on(t.user_id)],
+)
+
 export const agentMention = pgTable("agent_mention", {
   id: text("id").primaryKey(),
   agent_id: text("agent_id").notNull(),
@@ -749,6 +764,7 @@ const TABLES = [
   invitation,
   artifactInvite,
   betaSignup,
+  signupAttribution,
   oauthClientWorkspace,
   artifactFavorite,
   follow,

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -60,6 +60,7 @@ import type {
   NewRun,
   NewSession,
   NewSessionMessage,
+  NewSignupAttribution,
   NewVersion,
   NewView,
   NewWebhook,
@@ -83,6 +84,7 @@ import type {
   SessionMessageRecord,
   SessionRecord,
   SessionState,
+  SignupAttributionRecord,
   SlackInstallRecord,
   SlackThreadLinkRecord,
   SlackUserLinkRecord,
@@ -154,6 +156,7 @@ import {
   reviewRound,
   run,
   sessionMessage,
+  signupAttribution,
   slackInstall,
   slackThreadLink,
   slackUserLink,
@@ -202,6 +205,7 @@ export const schema = {
   artifactInvite,
   invitation,
   betaSignup,
+  signupAttribution,
   oauthClientWorkspace,
   context,
   contextAsker,
@@ -245,6 +249,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   invitation: true,
   artifactInvite: true,
   betaSignup: true,
+  signupAttribution: true,
   context: true,
   contextAsker: true,
   contextSession: true,
@@ -2752,6 +2757,22 @@ export class PgMetaStore implements MetaStore {
       .onConflictDoNothing()
       .returning()
     return rows.length > 0
+  }
+
+  // ---- Signup attribution ----------------------------------------------------
+  async recordSignupAttribution(a: NewSignupAttribution): Promise<void> {
+    // The unique user_id index makes a duplicate hook fire a no-op — first write
+    // wins, so the attribution of record stays the one captured at signup time.
+    await this.db.insert(signupAttribution).values(a).onConflictDoNothing()
+  }
+
+  async getSignupAttribution(userId: string): Promise<SignupAttributionRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(signupAttribution)
+      .where(eq(signupAttribution.user_id, userId))
+      .limit(1)
+    return rows[0] ?? null
   }
 
   // ---- Artifact invitations ------------------------------------------------

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -58,6 +58,7 @@ import type {
   NewRun,
   NewSession,
   NewSessionMessage,
+  NewSignupAttribution,
   NewVersion,
   NewWebhook,
   NotificationRecord,
@@ -80,6 +81,7 @@ import type {
   SessionMessageRecord,
   SessionRecord,
   SessionState,
+  SignupAttributionRecord,
   SlackInstallRecord,
   SlackThreadLinkRecord,
   SlackUserLinkRecord,
@@ -152,6 +154,7 @@ import {
   reviewRound,
   run,
   sessionMessage,
+  signupAttribution,
   slackInstall,
   slackThreadLink,
   slackUserLink,
@@ -276,6 +279,7 @@ export const schema = {
   artifactInvite,
   invitation,
   betaSignup,
+  signupAttribution,
   oauthClientWorkspace,
   context,
   contextAsker,
@@ -319,6 +323,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   invitation: true,
   artifactInvite: true,
   betaSignup: true,
+  signupAttribution: true,
   context: true,
   contextAsker: true,
   contextSession: true,
@@ -2798,6 +2803,22 @@ export function makeRepos(db: SqliteDb) {
     return row !== undefined
   }
 
+  // ---- Signup attribution ---------------------------------------------------
+  const recordSignupAttribution = async (a: NewSignupAttribution): Promise<void> => {
+    // The unique user_id index makes a duplicate hook fire a no-op — first write
+    // wins, so the attribution of record stays the one captured at signup time.
+    await db.insert(signupAttribution).values(a).onConflictDoNothing().run()
+  }
+
+  const getSignupAttribution = async (userId: string): Promise<SignupAttributionRecord | null> => {
+    const row = await db
+      .select()
+      .from(signupAttribution)
+      .where(eq(signupAttribution.user_id, userId))
+      .get()
+    return row ?? null
+  }
+
   // ---- Artifact invitations ------------------------------------------------
   const createArtifactInvite = async (i: NewArtifactInvite): Promise<ArtifactInviteRecord> =>
     (await db.insert(artifactInvite).values(i).returning().get()) as ArtifactInviteRecord
@@ -3279,6 +3300,8 @@ export function makeRepos(db: SqliteDb) {
     deleteInvitation,
     markInvitationAccepted,
     recordBetaSignup,
+    recordSignupAttribution,
+    getSignupAttribution,
     createArtifactInvite,
     getArtifactInviteByToken,
     listPendingArtifactInvites,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -372,6 +372,28 @@ export const betaSignup = sqliteTable(
   (t) => [uniqueIndex("beta_signup_email").on(t.email)],
 )
 
+// Where a signup came from. One row per user, written by the auth
+// layer's user-create hook from the `d_src` cookie the capture middleware stamped;
+// first write wins — the attribution of record is the one at signup time. No FK to
+// Better Auth's user table: auth owns its tables out-of-band, like beta_signup.
+export const signupAttribution = sqliteTable(
+  "signup_attribution",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id").notNull(),
+    // The surface that sourced the signup: an artifact surface (badge, comment_wall,
+    // duplicate, share_chrome, artifact_visit) or a campaign token (hn-launch, …).
+    source_kind: text("source_kind").notNull(),
+    // The artifact (short id) the sourcing surface lived on, when known.
+    source_artifact: text("source_artifact"),
+    // Path of the page that stamped the cookie, and the referrer host at stamp time.
+    landing_path: text("landing_path"),
+    referrer: text("referrer"),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [uniqueIndex("signup_attribution_user").on(t.user_id)],
+)
+
 // An agent's pull inbox: one row per mention directed at the agent.
 export const agentMention = sqliteTable("agent_mention", {
   id: text("id").primaryKey(),
@@ -910,6 +932,7 @@ const TABLES = [
   invitation,
   artifactInvite,
   betaSignup,
+  signupAttribution,
   oauthClientWorkspace,
   artifactFavorite,
   follow,

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -2432,4 +2432,58 @@ export function runStoreContract(
       expect(otherTotal).toBe(999)
     })
   })
+
+  describe(`${label}: signup attribution`, () => {
+    it("records the signup source once per user (first write wins) and reads it back", async () => {
+      const userId = `u_${uuid()}`
+      await store.recordSignupAttribution({
+        id: uuid(),
+        user_id: userId,
+        source_kind: "badge",
+        source_artifact: "ab12cd34",
+        landing_path: "/artifacts/doc-ab12cd34",
+        referrer: "news.ycombinator.com",
+      })
+      // A duplicate hook fire (retry, double submit) must not add a second row or
+      // overwrite the first — the attribution of record is the one at signup time.
+      await store.recordSignupAttribution({
+        id: uuid(),
+        user_id: userId,
+        source_kind: "comment_wall",
+        source_artifact: null,
+        landing_path: null,
+        referrer: null,
+      })
+
+      const rec = await store.getSignupAttribution(userId)
+      expect(rec).toMatchObject({
+        user_id: userId,
+        source_kind: "badge",
+        source_artifact: "ab12cd34",
+        landing_path: "/artifacts/doc-ab12cd34",
+        referrer: "news.ycombinator.com",
+      })
+      expect(rec?.created_at).toBeTruthy()
+    })
+
+    it("returns null for a user with no recorded source (organic signup)", async () => {
+      expect(await store.getSignupAttribution(`u_${uuid()}`)).toBeNull()
+    })
+
+    it("stores nullable fields as null (a campaign link with no artifact)", async () => {
+      const userId = `u_${uuid()}`
+      await store.recordSignupAttribution({
+        id: uuid(),
+        user_id: userId,
+        source_kind: "hn-launch",
+        source_artifact: null,
+        landing_path: "/",
+        referrer: null,
+      })
+      const rec = await store.getSignupAttribution(userId)
+      expect(rec?.source_kind).toBe("hn-launch")
+      expect(rec?.source_artifact).toBeNull()
+      expect(rec?.referrer).toBeNull()
+    })
+  })
 }


### PR DESCRIPTION
## What

Answers one question the funnel dashboard needs and nothing else: **which artifact (or campaign link) brought each new account.**

Three pieces:

1. **Capture middleware** (`apps/api/src/lib/attribution.ts`, mounted in `app.ts`). External `GET` arrivals on the HTML entry points — `/artifacts/:ref` share links, or `/` and `/pricing` carrying `?src=` — get an httpOnly `d_src` cookie stamped: the surface (`badge`, `comment_wall`, a campaign token like `hn-launch`, or the bare `artifact_visit`), the artifact short id (parsed from the ref via core's `parseRef`, or a validated `?art=` override), the landing path, and the external referrer host. **Last touch wins.** Signed-in visitors (presence-only session check, the marketing.ts pattern) and all API/raw/asset paths never stamp.

2. **Signup hook.** Better Auth's `user.create` after-hook hands the raw Cookie header to the app via a new `AuthHooks.recordSignupAttribution`; the shared `signupAttributionHook(meta)` parses the stamp and writes the row. Runs for **every provider** (email, Google, OIDC) since they all create users through this one path. Best-effort by construction: a throwing hook can never cost an account (tested).

3. **`signup_attribution` table.** One row per user, unique on `user_id`, so a duplicate hook fire is a no-op — **first write wins**; the attribution onup time. Organic signups simply have norow. Schema lands across all three dialects (drizzle defs feed the generated DDL; the `deploy/d1-schema.sqblock matches — the conformance suites vettribution`/`getSignupAttribution` on theMetaStore port and the parity classification.                                                             
## Design decisions worth review                                                                          
- **Last-touch** (each qualifying arrival overwrites the cookie) — deliberate; it answers "what converted them," which is what the badge/CTA tuning
- **Stamping is authz-independent.** The middleware records the arrival without a DB hit; whether the visitor
could read the artifact is irrelevant to
- **httpOnly** — the client never needs to read the stamp, so no script surface.
- **Self-host posture:** attribution rowsn database like any other table. Nothingphones home, ever.
- Garbage cookies parse to `null` (organind short-id formats are strictly validated on both write and read.

## Tests (written first, watched fail)

- **Store contract** (all dialects: sqlite / d1 / pg lanes): record + read-back, first-write-wins
idempotency, nullable fields.
- **Middleware:** cookie attributes (HttpOnly / SameSite=Lax / Max-Age 30d), `?src=` override, campaign
stamps on `/`, no stamp on bare `/` or wic fallback, external-vs-same-hostreferrer, last-touch overwrite, API paths never stamp.
- **End to end:** a real Better Auth `POS carrying the cookie produces the row;organic and garbage-cookie signups produce none; a throwing hook still returns 200.

Gates: `pnpm run ci`, `pnpm typecheck`, `pnpm test` (full workspace) all green.

## What this unblocks

- The funnel dashboard's "viewer-sourced signup share" metric (its query is pre-written against exactly this
table).
- The viewer badge / comment-wall / duplicate CTAs can now carry `?src=` from their first day, with
measurement live before they ship.

## Out of scope (deliberate)

- No UI. No badge yet — this is the measunto.
- SPA-internal navigations don't stamp (client-side route changes never hit the server); external arrivals —
the thing attribution is for — always do.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787457787&installation_model_id=428097&pr_number=517&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F517&signature=148d21cc4b3892f15adc4a90ea5b652c7743ec612fe534061c3ab98031684aa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->