### PR TITLE
feat(runner): pluggable providers + per-user plan credentials (no shared token)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -41,7 +41,7 @@
     "@huggingface/transformers": "^4.2.0",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@scalar/hono-api-reference": "^0.11.9",
-    "better-auth": "^1.6.19",
+    "better-auth": "^1.6.22",
     "better-sqlite3": "^12.11.1",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.6.0",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -30,6 +30,7 @@ import { folderRoutes } from "./routes/folders"
 import { followRoutes } from "./routes/follows"
 import { githubAppRoutes } from "./routes/github-app"
 import { marketingRoutes } from "./routes/marketing"
+import { modelCredentialRoutes } from "./routes/model-credentials"
 import { moderationRoutes } from "./routes/moderation"
 import { notificationRoutes } from "./routes/notifications"
 import { oauthRoutes } from "./routes/oauth"
@@ -386,6 +387,7 @@ export function createApp(deps: AppDeps): Hono {
     proposalRoutes,
     reviewRoutes,
     automationRoutes,
+    modelCredentialRoutes,
     conciergeRoutes,
     reworkRoutes,
     commentRoutes,

--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -180,6 +180,9 @@ export const automationRoutes = (ctx: AppContext) => {
       automation_id: a.id,
       agent_id: a.agent_id,
       reason: `manual:${me.id}`,
+      // First-class, not parsed out of `reason`: the clicker's plan bills this run
+      // (the wallet follows the initiator). Schedule/event enqueues leave it null.
+      initiated_by: me.id,
       scheduled_for: isoNow(),
     })
     return c.json({ id: rec.id, status: rec.status }, 201)
@@ -234,6 +237,10 @@ export const automationRoutes = (ctx: AppContext) => {
       runs: runnable.map(({ r, a }) => ({
         id: r.id,
         reason: r.reason,
+        // The wallet key: whose plan this run bills (null = clock/event → registrant
+        // today, the workspace pool once it lands). The executor passes it back on
+        // the model-credential fetch via ?run=.
+        initiated_by: r.initiated_by,
         automation_id: r.automation_id,
         instruction: a.instruction,
         // Canonical selectors: artifact = revise it, collection = file new work there,

--- a/apps/api/src/routes/model-credentials.ts
+++ b/apps/api/src/routes/model-credentials.ts
@@ -1,0 +1,101 @@
+import { newId } from "@derive/core"
+import { z } from "@hono/zod-openapi"
+import { Hono } from "hono"
+import type { AppContext } from "../context"
+import { decryptSecret, encryptSecret } from "../lib/crypto"
+import { bail, fail, readJson } from "../lib/http"
+
+// Per-user model-plan credentials. Every team member connects their OWN Claude/Codex plan
+// token (or an API key) here; it is encrypted at rest (lib/crypto, keyed by DERIVE_AUTH_SECRET)
+// and used ONLY for that user's own agent runs. Two surfaces:
+//   - personal (session): a user manages their own credential, one per provider.
+//   - agent (bearer): the executor fetches the calling agent's OWNER's credential to run on
+//     that user's plan. Scoped to the caller-agent's registrant — never another user's.
+
+const PROVIDERS = ["claude-code", "codex"] as const
+const isoNow = () => new Date().toISOString()
+
+export const modelCredentialRoutes = (ctx: AppContext) => {
+  const { meta, deps, agentFor, requireUser, requireWorkspace } = ctx
+  const app = new Hono()
+
+  // List the caller's own connected credentials — HINTS only, never the secret.
+  app.get("/v1/me/model-credentials", async (c) => {
+    const org = await requireWorkspace(c, "read")
+    if (org instanceof Response) return org
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    const creds = await meta.listModelCredentials(org, me.id)
+    return c.json({
+      credentials: creds.map((cr) => ({
+        provider: cr.provider,
+        kind: cr.kind,
+        hint: cr.hint,
+        updated_at: cr.updated_at,
+      })),
+    })
+  })
+
+  // Connect / replace the caller's own plan token for a provider (encrypt + upsert).
+  app.post("/v1/me/model-credentials", async (c) => {
+    const org = await requireWorkspace(c, "read")
+    if (org instanceof Response) return org
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    if (!deps.encryptionKey) return fail(c, 503, "secret encryption is not configured")
+    const b = await readJson(
+      c,
+      z.object({
+        provider: z.enum(PROVIDERS),
+        kind: z.enum(["oauth", "api_key"]),
+        token: z.string().min(1).max(4000),
+      }),
+    )
+    if (b instanceof Response) return bail(b)
+    const token = b.token.trim()
+    if (token === "") return fail(c, 400, "token is empty")
+    const now = isoNow()
+    const hint = token.slice(-4)
+    await meta.setModelCredential({
+      id: newId("mcr"),
+      org_id: org,
+      user_id: me.id,
+      provider: b.provider,
+      kind: b.kind,
+      secret: encryptSecret(token, deps.encryptionKey),
+      hint,
+      created_at: now,
+      updated_at: now,
+    })
+    return c.json({ ok: true, provider: b.provider, hint }, 201)
+  })
+
+  // Disconnect the caller's own credential for a provider.
+  app.delete("/v1/me/model-credentials/:provider", async (c) => {
+    const org = await requireWorkspace(c, "read")
+    if (org instanceof Response) return org
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    await meta.deleteModelCredential(org, me.id, c.req.param("provider"))
+    return c.body(null, 204)
+  })
+
+  // The executor fetches the calling agent's OWNER's credential for a provider, decrypted, so
+  // it can run on that user's plan. Returns `{ credential: null }` when the owner has none —
+  // the runner fails the run closed with a "connect your plan" message rather than falling back
+  // to a shared token. Isolation is structural: only the caller-agent's registrant's row is read.
+  app.get("/v1/agent/model-credential", async (c) => {
+    const agent = await agentFor(c)
+    if (!agent) return fail(c, 401, "agent token required")
+    const provider = c.req.query("provider") ?? "claude-code"
+    const owner = agent.created_by
+    if (!owner || !deps.encryptionKey) return c.json({ credential: null })
+    const cred = await meta.getModelCredential(agent.org_id, owner, provider)
+    if (!cred) return c.json({ credential: null })
+    return c.json({
+      credential: { kind: cred.kind, value: decryptSecret(cred.secret, deps.encryptionKey) },
+    })
+  })
+
+  return app
+}

--- a/apps/api/src/routes/model-credentials.ts
+++ b/apps/api/src/routes/model-credentials.ts
@@ -9,8 +9,9 @@ import { bail, fail, readJson } from "../lib/http"
 // token (or an API key) here; it is encrypted at rest (lib/crypto, keyed by DERIVE_AUTH_SECRET)
 // and used ONLY for that user's own agent runs. Two surfaces:
 //   - personal (session): a user manages their own credential, one per provider.
-//   - agent (bearer): the executor fetches the calling agent's OWNER's credential to run on
-//     that user's plan. Scoped to the caller-agent's registrant — never another user's.
+//   - agent (bearer): the executor fetches the credential the run BILLS — the initiator's
+//     (the session's asker) first, then the caller-agent's registrant. Never an unrelated
+//     user's: session lookups are bound to the calling agent's own context.
 
 const PROVIDERS = ["claude-code", "codex"] as const
 const isoNow = () => new Date().toISOString()
@@ -80,21 +81,43 @@ export const modelCredentialRoutes = (ctx: AppContext) => {
     return c.body(null, 204)
   })
 
-  // The executor fetches the calling agent's OWNER's credential for a provider, decrypted, so
-  // it can run on that user's plan. Returns `{ credential: null }` when the owner has none —
-  // the runner fails the run closed with a "connect your plan" message rather than falling back
-  // to a shared token. Isolation is structural: only the caller-agent's registrant's row is read.
+  // The executor fetches the credential a run bills against, decrypted. WHOSE plan is the
+  // run's INITIATOR's: pass `?session=` and the server resolves that session's ASKER first
+  // — their question, their tokens — falling back to the agent's registrant (the interim
+  // chain until the workspace pool lands; then the fallback becomes the pool). Without a
+  // session (boot preflight, scheduled runs) it is the registrant's. Returns
+  // `{ credential: null }` when nobody in the chain has one — the runner fails the run
+  // closed with a "connect your plan" message rather than falling back to a shared token.
+  // Isolation is structural twice over: a session id resolves only when that session
+  // belongs to THIS agent's own context (404 otherwise, so foreign ids don't leak), and
+  // only the resolved person's row is ever read.
   app.get("/v1/agent/model-credential", async (c) => {
     const agent = await agentFor(c)
     if (!agent) return fail(c, 401, "agent token required")
     const provider = c.req.query("provider") ?? "claude-code"
+    if (!deps.encryptionKey) return c.json({ credential: null })
+    const present = (cred: { kind: string; secret: string }, source: string) =>
+      c.json({
+        credential: {
+          kind: cred.kind,
+          value: decryptSecret(cred.secret, deps.encryptionKey as string),
+        },
+        source,
+      })
+    const sessionId = c.req.query("session")
+    if (sessionId) {
+      const s = await meta.getSession(sessionId)
+      const sctx = s ? await meta.getContext(s.context_id) : null
+      if (!s || !sctx || sctx.agent_id !== agent.id || s.org_id !== agent.org_id)
+        return fail(c, 404, "unknown session")
+      const asker = await meta.getModelCredential(agent.org_id, s.asker_id, provider)
+      if (asker) return present(asker, "asker")
+    }
     const owner = agent.created_by
-    if (!owner || !deps.encryptionKey) return c.json({ credential: null })
+    if (!owner) return c.json({ credential: null })
     const cred = await meta.getModelCredential(agent.org_id, owner, provider)
     if (!cred) return c.json({ credential: null })
-    return c.json({
-      credential: { kind: cred.kind, value: decryptSecret(cred.secret, deps.encryptionKey) },
-    })
+    return present(cred, "registrant")
   })
 
   return app

--- a/apps/api/src/routes/model-credentials.ts
+++ b/apps/api/src/routes/model-credentials.ts
@@ -82,14 +82,16 @@ export const modelCredentialRoutes = (ctx: AppContext) => {
   })
 
   // The executor fetches the credential a run bills against, decrypted. WHOSE plan is the
-  // run's INITIATOR's: pass `?session=` and the server resolves that session's ASKER first
-  // — their question, their tokens — falling back to the agent's registrant (the interim
-  // chain until the workspace pool lands; then the fallback becomes the pool). Without a
-  // session (boot preflight, scheduled runs) it is the registrant's. Returns
-  // `{ credential: null }` when nobody in the chain has one — the runner fails the run
-  // closed with a "connect your plan" message rather than falling back to a shared token.
-  // Isolation is structural twice over: a session id resolves only when that session
-  // belongs to THIS agent's own context (404 otherwise, so foreign ids don't leak), and
+  // run's INITIATOR's: pass `?session=` (the ask loop) or `?run=` (the automation lane)
+  // and the server resolves the initiator first — the session's asker, or the run's
+  // `initiated_by` (the person who clicked Run now) — falling back to the agent's
+  // registrant (the interim chain until the workspace pool lands; then the fallback
+  // becomes the pool). A clock/event run has no initiator (`initiated_by` null) and
+  // resolves straight to the fallback. Without either id (boot preflight) it is the
+  // registrant's. Returns `{ credential: null }` when nobody in the chain has one — the
+  // runner fails the run closed with a "connect your plan" message rather than falling
+  // back to a shared token. Isolation is structural twice over: a session/run id resolves
+  // only when it belongs to THIS agent (404 otherwise, so foreign ids don't leak), and
   // only the resolved person's row is ever read.
   app.get("/v1/agent/model-credential", async (c) => {
     const agent = await agentFor(c)
@@ -112,6 +114,16 @@ export const modelCredentialRoutes = (ctx: AppContext) => {
         return fail(c, 404, "unknown session")
       const asker = await meta.getModelCredential(agent.org_id, s.asker_id, provider)
       if (asker) return present(asker, "asker")
+    }
+    const runId = c.req.query("run")
+    if (runId) {
+      const r = await meta.getRun(runId)
+      if (!r || r.agent_id !== agent.id || r.org_id !== agent.org_id)
+        return fail(c, 404, "unknown run")
+      if (r.initiated_by) {
+        const initiator = await meta.getModelCredential(agent.org_id, r.initiated_by, provider)
+        if (initiator) return present(initiator, "initiator")
+      }
     }
     const owner = agent.created_by
     if (!owner) return c.json({ credential: null })

--- a/apps/api/test/automations.test.ts
+++ b/apps/api/test/automations.test.ts
@@ -122,6 +122,9 @@ describe("automations + runs", () => {
     // The claim hands the executor everything it needs: the instruction + resolved gate inputs.
     // Automation runs propose by default; write mode will ride per-target in refs.
     expect(mine.instruction).toBe("keep the roadmap current")
+    // The wallet key rides the claim: Run-now stamps the clicker as the initiator, so
+    // the executor bills THEIR plan (a schedule/event enqueue leaves it null).
+    expect(mine.initiated_by).toBe("u_auto_own")
     expect(mine.flags).toMatchObject({ agentKillswitch: expect.any(Boolean) })
     // Claimed once: a second poll gets nothing.
     const again = await (

--- a/apps/api/test/model-credentials.test.ts
+++ b/apps/api/test/model-credentials.test.ts
@@ -205,3 +205,97 @@ describe("model credentials: session-keyed initiator resolution", () => {
     expect(res.status).toBe(404)
   })
 })
+
+// The automation lane of the same chain: ?run= resolves the run's initiated_by (the person
+// who clicked Run now) before the registrant; a clock/event run (null initiator) falls
+// straight through. Run ids resolve only for the agent the run belongs to — 404 otherwise.
+describe("model credentials: run-keyed initiator resolution", () => {
+  const owner: TestUser = { id: "u_mcr_own", email: "mcrown@derive.test", name: "Owner" }
+  const clicker: TestUser = { id: "u_mcr_clk", email: "mcrclk@derive.test", name: "Clicker" }
+  const { app } = makeAuthedApp("model-creds-runs", [owner, clicker], "editor", {
+    deps: { encryptionKey: "test-enc-secret" },
+  })
+  const connect = (email: string, body: object) =>
+    app.request("/v1/me/model-credentials", jsonAs(as(email), body))
+
+  let agentToken: string
+  let runId: string
+
+  it("setup: automation + Run now by the clicker, both plans connected", async () => {
+    await app.request("/v1/me", { headers: as(owner.email) })
+    await app.request("/v1/me", { headers: as(clicker.email) })
+    const ag = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Automation Runner" }))
+    ).json()
+    agentToken = ag.token
+    const auto = await (
+      await app.request(
+        "/v1/automations",
+        jsonAs(as(owner.email), {
+          agentId: ag.id,
+          trigger: { kind: "manual" },
+          instruction: "whose plan pays for a run?",
+        }),
+      )
+    ).json()
+    const run = await (
+      await app.request(`/v1/automations/${auto.id}/run`, {
+        method: "POST",
+        headers: as(clicker.email),
+      })
+    ).json()
+    runId = run.id
+    expect(runId).toBeTruthy()
+    await connect(owner.email, {
+      provider: "claude-code",
+      kind: "api_key",
+      token: "sk-registrant-plan",
+    })
+    await connect(clicker.email, {
+      provider: "claude-code",
+      kind: "api_key",
+      token: "sk-clicker-plan",
+    })
+  })
+
+  it("a run-keyed fetch bills the CLICKER (initiated_by), not the registrant", async () => {
+    const got = await (
+      await app.request(`/v1/agent/model-credential?provider=claude-code&run=${runId}`, {
+        headers: bearer(agentToken),
+      })
+    ).json()
+    expect(got.credential).toEqual({ kind: "api_key", value: "sk-clicker-plan" })
+    expect(got.source).toBe("initiator")
+  })
+
+  it("an initiator with no plan falls back to the registrant", async () => {
+    await app.request("/v1/me/model-credentials/claude-code", {
+      method: "DELETE",
+      headers: as(clicker.email),
+    })
+    const got = await (
+      await app.request(`/v1/agent/model-credential?provider=claude-code&run=${runId}`, {
+        headers: bearer(agentToken),
+      })
+    ).json()
+    expect(got.credential).toEqual({ kind: "api_key", value: "sk-registrant-plan" })
+    expect(got.source).toBe("registrant")
+  })
+
+  it("ISOLATION: another agent's run id is a 404, not a bill", async () => {
+    const foreign = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Unrelated Runner" }))
+    ).json()
+    const res = await app.request(`/v1/agent/model-credential?provider=claude-code&run=${runId}`, {
+      headers: bearer(foreign.token),
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it("an unknown run id is a 404, never a silent registrant fallback", async () => {
+    const res = await app.request("/v1/agent/model-credential?provider=claude-code&run=run_nope", {
+      headers: bearer(agentToken),
+    })
+    expect(res.status).toBe(404)
+  })
+})

--- a/apps/api/test/model-credentials.test.ts
+++ b/apps/api/test/model-credentials.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { as, bearer, jsonAs, makeAuthedApp, type TestUser } from "./helpers"
+import { as, bearer, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 
 // Per-user model-plan credentials. A member connects their OWN plan token (encrypted at
 // rest); the executor fetches it via an agent bearer — scoped to the agent's registrant, so
@@ -100,5 +100,108 @@ describe("model credentials", () => {
   it("the agent surface requires an agent bearer", async () => {
     const anon = await app.request("/v1/agent/model-credential?provider=codex")
     expect([401, 403]).toContain(anon.status)
+  })
+})
+
+// The initiator chain: a session-keyed fetch bills the run's ASKER first — their question,
+// their tokens — and only falls back to the agent's registrant when the asker has no plan
+// (the interim chain until the workspace pool lands). Session ids resolve ONLY within the
+// calling agent's own context: anything else is a 404, so foreign ids neither leak nor bill.
+describe("model credentials: session-keyed initiator resolution", () => {
+  const owner: TestUser = { id: "u_mcs_own", email: "mcsown@derive.test", name: "Owner" }
+  const asker: TestUser = { id: "u_mcs_ask", email: "mcsask@derive.test", name: "Asker" }
+  const { app } = makeAuthedApp("model-creds-sessions", [owner, asker], "editor", {
+    deps: { encryptionKey: "test-enc-secret" },
+  })
+  const connect = (email: string, body: object) =>
+    app.request("/v1/me/model-credentials", jsonAs(as(email), body))
+
+  let agentToken: string
+  let sessionId: string
+
+  it("setup: wire a context, invite the asker, open a session, connect both plans", async () => {
+    await app.request("/v1/me", { headers: as(owner.email) })
+    await app.request("/v1/me", { headers: as(asker.email) })
+    const ag = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Shared Analyst" }))
+    ).json()
+    agentToken = ag.token
+    const manifest = await (await publishAs(app, "# Shared manifest", {}, as(owner.email))).json()
+    const ctx = await (
+      await app.request(
+        "/v1/contexts",
+        jsonAs(as(owner.email), {
+          name: "Shared",
+          agent_id: ag.id,
+          manifest_short_id: manifest.short_id,
+        }),
+      )
+    ).json()
+    await app.request(
+      `/v1/contexts/${ctx.id}/askers`,
+      jsonAs(as(owner.email), { email: asker.email }),
+    )
+    const asked = await (
+      await app.request(
+        `/v1/contexts/${ctx.id}/sessions`,
+        jsonAs(as(asker.email), { body_md: "whose plan pays?" }),
+      )
+    ).json()
+    sessionId = asked.session?.id
+    expect(sessionId).toBeTruthy()
+    await connect(owner.email, {
+      provider: "claude-code",
+      kind: "api_key",
+      token: "sk-registrant-plan",
+    })
+    await connect(asker.email, {
+      provider: "claude-code",
+      kind: "api_key",
+      token: "sk-asker-plan",
+    })
+  })
+
+  it("a session-keyed fetch returns the ASKER's plan, not the registrant's", async () => {
+    const got = await (
+      await app.request(`/v1/agent/model-credential?provider=claude-code&session=${sessionId}`, {
+        headers: bearer(agentToken),
+      })
+    ).json()
+    expect(got.credential).toEqual({ kind: "api_key", value: "sk-asker-plan" })
+    expect(got.source).toBe("asker")
+  })
+
+  it("an asker with no plan falls back to the registrant (interim, until the pool)", async () => {
+    await app.request("/v1/me/model-credentials/claude-code", {
+      method: "DELETE",
+      headers: as(asker.email),
+    })
+    const got = await (
+      await app.request(`/v1/agent/model-credential?provider=claude-code&session=${sessionId}`, {
+        headers: bearer(agentToken),
+      })
+    ).json()
+    expect(got.credential).toEqual({ kind: "api_key", value: "sk-registrant-plan" })
+    expect(got.source).toBe("registrant")
+  })
+
+  it("ISOLATION: a session outside the calling agent's context is a 404, not a bill", async () => {
+    // A second agent NOT wired to the context must not resolve the session at all.
+    const foreign = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Unwired Runner" }))
+    ).json()
+    const res = await app.request(
+      `/v1/agent/model-credential?provider=claude-code&session=${sessionId}`,
+      { headers: bearer(foreign.token) },
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it("an unknown session id is a 404, never a silent registrant fallback", async () => {
+    const res = await app.request(
+      "/v1/agent/model-credential?provider=claude-code&session=ses_nope",
+      { headers: bearer(agentToken) },
+    )
+    expect(res.status).toBe(404)
   })
 })

--- a/apps/api/test/model-credentials.test.ts
+++ b/apps/api/test/model-credentials.test.ts
@@ -38,7 +38,7 @@ describe("model credentials", () => {
     await connect(owner.email, {
       provider: "codex",
       kind: "api_key",
-      token: "sk-owner-plan-1234",
+      token: "owner-plan-fixture-value",
     })
     const agent = await mintAgent(owner.email, "Owner Runner")
     const got = await (
@@ -47,7 +47,7 @@ describe("model credentials", () => {
       })
     ).json()
     // Decrypted round-trip: the runner gets the real value to inject.
-    expect(got.credential).toEqual({ kind: "api_key", value: "sk-owner-plan-1234" })
+    expect(got.credential).toEqual({ kind: "api_key", value: "owner-plan-fixture-value" })
   })
 
   it("ISOLATION: the endpoint resolves ONLY the calling agent's registrant + provider", async () => {

--- a/apps/api/test/model-credentials.test.ts
+++ b/apps/api/test/model-credentials.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest"
+import { as, bearer, jsonAs, makeAuthedApp, type TestUser } from "./helpers"
+
+// Per-user model-plan credentials. A member connects their OWN plan token (encrypted at
+// rest); the executor fetches it via an agent bearer — scoped to the agent's registrant, so
+// one user's token never reaches another user's runs. Isolation is the point of these tests.
+describe("model credentials", () => {
+  const owner: TestUser = { id: "u_mc_own", email: "mcown@derive.test", name: "Owner" }
+  const other: TestUser = { id: "u_mc_oth", email: "mcoth@derive.test", name: "Other" }
+  // A configured encryption key is what makes the connect endpoint work at all.
+  const { app } = makeAuthedApp("model-creds", [owner, other], "editor", {
+    deps: { encryptionKey: "test-enc-secret" },
+  })
+
+  const mintAgent = async (email: string, name: string) => {
+    const res = await app.request("/v1/agents", jsonAs(as(email), { name }))
+    return (await res.json()) as { id: string; token: string }
+  }
+  const connect = (email: string, body: object) =>
+    app.request("/v1/me/model-credentials", jsonAs(as(email), body))
+
+  it("connect stores an encrypted secret; list returns hints only, never the token", async () => {
+    const token = "sk-ant-oat01-SUPERSECRETVALUE9999"
+    const res = await connect(owner.email, { provider: "codex", kind: "api_key", token })
+    expect(res.status).toBe(201)
+    expect((await res.json()).hint).toBe("9999")
+
+    const list = await (
+      await app.request("/v1/me/model-credentials", { headers: as(owner.email) })
+    ).json()
+    expect(list.credentials).toHaveLength(1)
+    expect(list.credentials[0]).toMatchObject({ provider: "codex", kind: "api_key", hint: "9999" })
+    // The raw token is NEVER in the list response.
+    expect(JSON.stringify(list)).not.toContain(token)
+  })
+
+  it("the agent surface returns the DECRYPTED credential of the agent's own registrant", async () => {
+    await connect(owner.email, {
+      provider: "codex",
+      kind: "api_key",
+      token: "sk-owner-plan-1234",
+    })
+    const agent = await mintAgent(owner.email, "Owner Runner")
+    const got = await (
+      await app.request("/v1/agent/model-credential?provider=codex", {
+        headers: bearer(agent.token),
+      })
+    ).json()
+    // Decrypted round-trip: the runner gets the real value to inject.
+    expect(got.credential).toEqual({ kind: "api_key", value: "sk-owner-plan-1234" })
+  })
+
+  it("ISOLATION: the endpoint resolves ONLY the calling agent's registrant + provider", async () => {
+    // Owner connects codex, but NOT claude-code. Their own agent gets the codex token and
+    // null for claude-code — the lookup is keyed (org, registrant, provider), so it can only
+    // ever return this agent-owner's own row. Cross-USER keying (one user's row is never
+    // another's) is proven exhaustively in the db store-contract (u1 vs u2).
+    await connect(owner.email, { provider: "codex", kind: "api_key", token: "sk-owner-only" })
+    const agent = await mintAgent(owner.email, "Owner Runner 2")
+    const codexGot = await (
+      await app.request("/v1/agent/model-credential?provider=codex", {
+        headers: bearer(agent.token),
+      })
+    ).json()
+    expect(codexGot.credential?.value).toBe("sk-owner-only")
+    const claudeGot = await (
+      await app.request("/v1/agent/model-credential?provider=claude-code", {
+        headers: bearer(agent.token),
+      })
+    ).json()
+    expect(claudeGot.credential).toBeNull()
+  })
+
+  it("a missing provider connection is null (fail-closed at the runner), not a leak", async () => {
+    const agent = await mintAgent(owner.email, "Runner 2")
+    const got = await (
+      await app.request("/v1/agent/model-credential?provider=claude-code", {
+        headers: bearer(agent.token),
+      })
+    ).json()
+    expect(got.credential).toBeNull()
+  })
+
+  it("disconnect removes it; the agent then gets null", async () => {
+    await connect(owner.email, { provider: "codex", kind: "oauth", token: "sk-to-delete" })
+    const del = await app.request("/v1/me/model-credentials/codex", {
+      method: "DELETE",
+      headers: as(owner.email),
+    })
+    expect(del.status).toBe(204)
+    const agent = await mintAgent(owner.email, "Runner 3")
+    const got = await (
+      await app.request("/v1/agent/model-credential?provider=codex", {
+        headers: bearer(agent.token),
+      })
+    ).json()
+    expect(got.credential).toBeNull()
+  })
+
+  it("the agent surface requires an agent bearer", async () => {
+    const anon = await app.request("/v1/agent/model-credential?provider=codex")
+    expect([401, 403]).toContain(anon.status)
+  })
+})

--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -23,9 +23,22 @@ this process ever needs a private API the public contract lacks, that is a bug.
 | `DISPATCHER_HOST_SECRET` | The shared secret the Derive API presents to the internal invoke surface. Unset ⇒ the hosted lane (HTTP server) is off; the owner-run drain lane still works. |
 | `DISPATCHER_HTTP_PORT` | Port for the internal invoke/health surface. Defaults `3040`. |
 
-Plus the runner's own env, passed through untouched: exactly one of
-`ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`, optional `RUNNER_*` knobs,
-`GH_TOKEN` for private repo pointers.
+Plus the runner's own env, passed through untouched: the model credential for
+the chosen provider, optional `RUNNER_*` knobs, `GH_TOKEN` for private repo
+pointers.
+
+**Providers.** The runner is agent-CLI-agnostic (`RUNNER_PROVIDER` / `--provider`,
+default `claude-code`; add one in `packages/cli/src/providers/`). Each provider's
+own CLI owns its auth from the inherited env — no token is ever reimplemented:
+
+| Provider | Binary | Credential (either) |
+| --- | --- | --- |
+| `claude-code` | `claude` | `ANTHROPIC_API_KEY`, or `CLAUDE_CODE_OAUTH_TOKEN` (a Pro/Max plan) |
+| `codex` (experimental) | `codex` | `OPENAI_API_KEY`, or a `codex login` (ChatGPT plan) |
+
+A subscription/plan token works because the runner drives the provider's real
+CLI, which consumes the token exactly as licensed — the sanctioned path, not a
+reimplemented client.
 
 ## Two lanes
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,7 +37,7 @@
     "@tanstack/react-router": "^1.170.15",
     "@tanstack/react-start": "^1.168.25",
     "@tanstack/react-virtual": "^3.14.2",
-    "better-auth": "1.6.19",
+    "better-auth": "1.6.22",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -166,6 +166,13 @@ export interface AutomationTrigger {
   tz?: string
   on?: string
 }
+/** A connected model-plan credential, as the settings UI sees it — never the secret. */
+export interface ModelCredentialHint {
+  provider: "claude-code" | "codex"
+  kind: "oauth" | "api_key"
+  hint: string
+  updated_at: string
+}
 /** A ref is a selector — one generic way to point at a set of artifacts: a specific
  *  doc (revise it), a collection (file new work into it), or a tag (stamped on every
  *  write the run makes). The API accepts a bare short-id string as artifact shorthand
@@ -757,6 +764,20 @@ export const api = {
   runAutomation: (id: string): Promise<{ id: string; status: string }> =>
     f(`/v1/automations/${id}/run`, opts({})).then(j),
   listRuns: (): Promise<{ runs: Run[] }> => f("/v1/workspace/runs", opts()).then(j),
+
+  // Per-user model-plan credentials (the caller's own; see routes/model-credentials.ts).
+  listModelCredentials: (): Promise<{ credentials: ModelCredentialHint[] }> =>
+    f("/v1/me/model-credentials", opts()).then(j),
+  connectModelCredential: (input: {
+    provider: "claude-code" | "codex"
+    kind: "oauth" | "api_key"
+    token: string
+  }): Promise<{ ok: true; provider: string; hint: string }> =>
+    f("/v1/me/model-credentials", opts(input)).then(j),
+  disconnectModelCredential: (provider: string): Promise<void> =>
+    f(`/v1/me/model-credentials/${provider}`, { method: "DELETE", credentials: "include" }).then(
+      () => undefined,
+    ),
 
   // Contexts + sessions (the ask loop; see routes/contexts.ts server-side).
   listContexts: (): Promise<{ contexts: ContextInfo[] }> => f("/v1/contexts", opts()).then(j),

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -363,6 +363,13 @@ export const automationsQuery = () =>
     queryFn: () => api.listAutomations().then((r) => r.automations),
   })
 
+// The caller's own connected model-plan credentials (hints only). Personal, so keyed plainly.
+export const modelCredentialsQuery = () =>
+  queryOptions({
+    queryKey: ["model-credentials"] as const,
+    queryFn: () => api.listModelCredentials().then((r) => r.credentials),
+  })
+
 export const runsQuery = () =>
   queryOptions({
     queryKey: ["runs"] as const,

--- a/apps/web/src/pages/settings/index.tsx
+++ b/apps/web/src/pages/settings/index.tsx
@@ -14,6 +14,7 @@ import { GeneralSection } from "./general-section"
 import { GithubSection } from "./github-section"
 import { IntegrationsSection } from "./integrations-section"
 import { MembersSection } from "./members-section"
+import { ModelPlansSection } from "./model-plans-section"
 import { ProfileSection } from "./profile-section"
 import { ReportsSection } from "./reports-section"
 import { SecuritySection } from "./security-section"
@@ -29,6 +30,7 @@ const route = getRouteApi("/settings/$section")
 const SECTION_TITLES: Record<string, string> = {
   profile: "Profile",
   security: "Security",
+  "model-plans": "Model plans",
   appearance: "Appearance",
   general: "General",
   members: "Members",
@@ -71,6 +73,7 @@ export function Settings() {
       items: [
         { id: "profile", label: "Profile", testId: "settings-tab-profile" },
         { id: "security", label: "Security", testId: "settings-tab-security" },
+        { id: "model-plans", label: "Model plans", testId: "settings-tab-model-plans" },
         { id: "appearance", label: "Appearance", testId: "settings-tab-appearance" },
       ],
     },
@@ -135,6 +138,7 @@ export function Settings() {
           <div className="min-w-0">
             {active === "profile" && <ProfileSection />}
             {active === "security" && <SecuritySection />}
+            {active === "model-plans" && <ModelPlansSection />}
             {active === "appearance" && <AppearanceSection />}
             {active === "general" && <GeneralSection />}
             {active === "members" && <MembersSection meId={me.id} />}

--- a/apps/web/src/pages/settings/model-plans-section.tsx
+++ b/apps/web/src/pages/settings/model-plans-section.tsx
@@ -1,0 +1,200 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useState } from "react"
+import { api, type ModelCredentialHint } from "@/api"
+import { ConfirmDialog } from "@/components/shared/confirm-dialog"
+import { EmptyState } from "@/components/shared/empty-state"
+import { SettingsGroup } from "@/components/shared/settings-group"
+import { StatusPanel } from "@/components/shared/status-panel"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { modelCredentialsQuery } from "@/lib/queries"
+import { useApiMutation } from "@/lib/use-api-mutation"
+import { SettingsListSkeleton } from "./settings-list-skeleton"
+import { SettingsSection } from "./settings-section"
+
+type Provider = "claude-code" | "codex"
+
+const PROVIDERS: { id: Provider; label: string; how: string }[] = [
+  {
+    id: "claude-code",
+    label: "Claude",
+    how: "Run `claude setup-token` on any machine (it opens a browser) and paste the token it prints.",
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    how: "Paste an OpenAI API key. (A ChatGPT-plan login is coming; API keys work today.)",
+  },
+]
+const providerLabel = (id: string) => PROVIDERS.find((p) => p.id === id)?.label ?? id
+
+// Personal "Model plans": connect your OWN Claude/Codex plan (or API key). It is encrypted
+// and used ONLY for your own agent runs — never shared. This is what lets your work run on
+// hosted Derive without a machine of your own.
+export function ModelPlansSection() {
+  const qc = useQueryClient()
+  const { data: creds, isPending, isError, refetch } = useQuery(modelCredentialsQuery())
+  const reload = () => qc.invalidateQueries({ queryKey: modelCredentialsQuery().queryKey })
+
+  return (
+    <SettingsSection
+      title="Model plans"
+      description={
+        <>
+          Connect your own model plan so your agents run on it. Your token is encrypted and used
+          only for your own runs, never shared with anyone else on the team.
+        </>
+      }
+    >
+      <div className="rounded-lg border bg-card p-4">
+        <ConnectForm onConnected={reload} />
+      </div>
+
+      {isPending ? (
+        <SettingsListSkeleton />
+      ) : isError ? (
+        <StatusPanel
+          tone="danger"
+          title="Couldn't load your plans"
+          description="This is usually temporary."
+          action={
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="model-plans-retry"
+              onClick={() => refetch()}
+            >
+              Try again
+            </Button>
+          }
+        />
+      ) : !creds || creds.length === 0 ? (
+        <EmptyState>No plan connected yet. Connect one above to run on your own plan.</EmptyState>
+      ) : (
+        <SettingsGroup>
+          {creds.map((c) => (
+            <CredentialRow key={c.provider} cred={c} onDone={reload} />
+          ))}
+        </SettingsGroup>
+      )}
+    </SettingsSection>
+  )
+}
+
+function ConnectForm({ onConnected }: { onConnected: () => void }) {
+  const [provider, setProvider] = useState<Provider>("claude-code")
+  const [kind, setKind] = useState<"oauth" | "api_key">("oauth")
+  const [token, setToken] = useState("")
+  const how = PROVIDERS.find((p) => p.id === provider)?.how ?? ""
+
+  const connect = useApiMutation({
+    mutationFn: () => api.connectModelCredential({ provider, kind, token: token.trim() }),
+    success: "Plan connected",
+    onSuccess: () => {
+      setToken("")
+      onConnected()
+    },
+  })
+  const ready = token.trim() !== ""
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap gap-2">
+        <Select value={provider} onValueChange={(v) => setProvider(v as Provider)}>
+          <SelectTrigger data-testid="model-plan-provider" aria-label="Provider" className="w-40">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {PROVIDERS.map((p) => (
+              <SelectItem key={p.id} value={p.id}>
+                {p.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={kind} onValueChange={(v) => setKind(v as "oauth" | "api_key")}>
+          <SelectTrigger
+            data-testid="model-plan-kind"
+            aria-label="Credential type"
+            className="w-44"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="oauth">Plan token</SelectItem>
+            <SelectItem value="api_key">API key</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <Input
+        data-testid="model-plan-token"
+        type="password"
+        aria-label="Plan token or API key"
+        placeholder="Paste your token"
+        value={token}
+        onChange={(e) => setToken(e.target.value)}
+        onKeyDown={(e) => e.key === "Enter" && ready && connect.mutate()}
+      />
+      <p className="text-2xs text-muted-foreground">{how}</p>
+      <div className="flex justify-end">
+        <Button
+          data-testid="model-plan-connect"
+          variant="secondary"
+          size="sm"
+          onClick={() => ready && connect.mutate()}
+          loading={connect.isPending}
+          disabled={connect.isPending || !ready}
+        >
+          {connect.isPending ? "Connecting…" : "Connect"}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function CredentialRow({ cred, onDone }: { cred: ModelCredentialHint; onDone: () => void }) {
+  const [confirming, setConfirming] = useState(false)
+  const remove = useApiMutation({
+    mutationFn: () => api.disconnectModelCredential(cred.provider),
+    success: "Plan disconnected",
+    onSuccess: () => onDone(),
+  })
+  return (
+    <div
+      data-testid={`model-plan-row-${cred.provider}`}
+      className="flex items-center gap-3 py-3 text-sm"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5 font-medium text-foreground">
+          {providerLabel(cred.provider)}
+          <Badge variant="outline">{cred.kind === "oauth" ? "Plan token" : "API key"}</Badge>
+        </div>
+        <div className="font-mono text-2xs text-muted-foreground">connected · ••••{cred.hint}</div>
+      </div>
+      <Button
+        data-testid={`model-plan-disconnect-${cred.provider}`}
+        variant="destructive-ghost"
+        size="sm"
+        onClick={() => setConfirming(true)}
+      >
+        Disconnect
+      </Button>
+      <ConfirmDialog
+        open={confirming}
+        onOpenChange={setConfirming}
+        title="Disconnect this plan?"
+        description="Your agents will stop running on it until you reconnect."
+        confirmLabel="Disconnect"
+        onConfirm={() => remove.mutate()}
+      />
+    </div>
+  )
+}

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -345,6 +345,19 @@ CREATE TABLE IF NOT EXISTS org_settings (
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 
+CREATE TABLE IF NOT EXISTS model_credential (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  secret TEXT NOT NULL,
+  hint TEXT NOT NULL DEFAULT '',
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  UNIQUE (org_id, user_id, provider)
+);
+
 CREATE TABLE IF NOT EXISTS slack_install (
   org_id TEXT PRIMARY KEY,
   team_id TEXT NOT NULL,

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -197,6 +197,7 @@ CREATE TABLE IF NOT EXISTS run (
   automation_id TEXT,
   agent_id TEXT NOT NULL,
   reason TEXT NOT NULL,
+  initiated_by TEXT,
   status TEXT NOT NULL,
   scheduled_for TEXT,
   started_at TEXT,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
       "sharp": ">=0.35.0",
       "shell-quote": ">=1.9.0",
       "undici": "^7.28.0",
-      "ws": "^8.21.0"
+      "ws": "^8.21.0",
+      "postcss": ">=8.5.18"
     },
     "patchedDependencies": {
       "@better-auth/oauth-provider@1.6.19": "patches/@better-auth__oauth-provider@1.6.19.patch",

--- a/packages/cli/src/providers/claude-code.js
+++ b/packages/cli/src/providers/claude-code.js
@@ -24,9 +24,13 @@ function logEvent(event) {
 
 /** Spawn `claude` once and normalize its stream-json output into the shared
  *  RunResult shape the runner's orchestrator consumes. */
-function spawnClaude({ bin, cwd, args, timeoutMs }) {
+function spawnClaude({ bin, cwd, args, timeoutMs, env }) {
   return new Promise((resolve) => {
-    const child = spawn(bin, args, { cwd, env: process.env, stdio: ["ignore", "pipe", "pipe"] })
+    const child = spawn(bin, args, {
+      cwd,
+      env: env ?? process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    })
     let buffer = ""
     let resultText = ""
     let sessionId = null
@@ -129,7 +133,7 @@ export const claudeCode = {
    *  no longer see. Headless: --dangerously-skip-permissions, because an
    *  interactive prompt would hang the subprocess; the real safety boundary is
    *  the read-only credentials the MCP config carries. */
-  async run({ bin, cwd, model, systemPrompt, prompt, timeoutMs, resumeSessionId }) {
+  async run({ bin, cwd, model, systemPrompt, prompt, timeoutMs, resumeSessionId, env }) {
     const systemArgs = [
       "--append-system-prompt",
       systemPrompt,
@@ -143,7 +147,7 @@ export const claudeCode = {
     const args = resumeSessionId
       ? ["-p", prompt, "--resume", resumeSessionId, ...systemArgs]
       : ["-p", prompt, ...systemArgs]
-    return spawnClaude({ bin, cwd, args, timeoutMs })
+    return spawnClaude({ bin, cwd, args, timeoutMs, env })
   },
 
   /** Is this run worth a second attempt? Only when the SERVICE failed, never

--- a/packages/cli/src/providers/claude-code.js
+++ b/packages/cli/src/providers/claude-code.js
@@ -1,0 +1,177 @@
+// The Claude Code provider: drives Anthropic's `claude` CLI. This is the default
+// provider and the reference implementation of the AgentProvider shape (see
+// ./index.js). Everything Claude-Code-specific lives here — the argv it wants,
+// how it streams (`stream-json`), how a failure surfaces (`api_error_status`) —
+// so the runner core stays agnostic. Auth is the CLI's own concern: it reads
+// ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN from the inherited env, so a plan
+// token "just works" through the sanctioned client, no reimplementation here.
+import { spawn } from "node:child_process"
+
+/** Log one stream event; returns the assistant text it carried (if any), which
+ *  the caller keeps as the run's last words for diagnostics. */
+function logEvent(event) {
+  if (event.type !== "assistant") return ""
+  let text = ""
+  for (const c of event.message?.content ?? []) {
+    if (c.type === "tool_use") console.log(`[claude] → ${String(c.name)}`)
+    else if (c.type === "text" && typeof c.text === "string" && c.text.trim()) {
+      text = c.text
+      console.log(`[claude] ${c.text.replace(/\s+/g, " ").slice(0, 200)}`)
+    }
+  }
+  return text
+}
+
+/** Spawn `claude` once and normalize its stream-json output into the shared
+ *  RunResult shape the runner's orchestrator consumes. */
+function spawnClaude({ bin, cwd, args, timeoutMs }) {
+  return new Promise((resolve) => {
+    const child = spawn(bin, args, { cwd, env: process.env, stdio: ["ignore", "pipe", "pipe"] })
+    let buffer = ""
+    let resultText = ""
+    let sessionId = null
+    let stderr = ""
+    // The model's last words, kept for the failure message: a crash mid-run
+    // exits nonzero with EMPTY stderr, so `exit 1: ` was all an owner ever saw.
+    // The reason ("API Error: 529 Overloaded") is in the assistant stream.
+    let lastText = ""
+    // The CLI's own verdict on the run. An API failure is NOT a silent exit: it
+    // emits a result event with is_error + api_error_status and a `result`
+    // string carrying the message ("API Error: 529 Overloaded"). Reading those
+    // is the difference between "retry, the service was busy" and "don't, the
+    // model name is wrong" — the exit code alone can't tell them apart.
+    let isError = false
+    let apiErrorStatus = null
+    let timedOut = false
+    let killTimer
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill("SIGTERM")
+      killTimer = setTimeout(() => child.kill("SIGKILL"), 5_000)
+    }, timeoutMs)
+    const take = (line) => {
+      try {
+        const event = JSON.parse(line)
+        lastText = logEvent(event) || lastText
+        if (!sessionId && typeof event.session_id === "string") sessionId = event.session_id
+        if (event.type === "result") {
+          if (typeof event.result === "string") resultText = event.result
+          if (event.is_error === true) isError = true
+          if (Number.isFinite(event.api_error_status)) apiErrorStatus = event.api_error_status
+        }
+      } catch {
+        // partial line / non-JSON noise
+      }
+    }
+    child.stdout.on("data", (b) => {
+      buffer += b.toString()
+      let nl = buffer.indexOf("\n")
+      while (nl >= 0) {
+        const line = buffer.slice(0, nl).trim()
+        buffer = buffer.slice(nl + 1)
+        nl = buffer.indexOf("\n")
+        if (line) take(line)
+      }
+    })
+    child.stderr.on("data", (b) => {
+      stderr += b.toString()
+    })
+    child.on("close", (code) => {
+      clearTimeout(timer)
+      clearTimeout(killTimer)
+      // The stream can end without a trailing newline; the unterminated line may
+      // be the `result` event itself.
+      if (buffer.trim()) take(buffer.trim())
+      resolve({ timedOut, code, resultText, sessionId, stderr, lastText, isError, apiErrorStatus })
+    })
+    child.on("error", (err) => {
+      clearTimeout(timer)
+      clearTimeout(killTimer)
+      resolve({
+        timedOut: false,
+        code: -1,
+        resultText: "",
+        sessionId: null,
+        stderr: String(err),
+        lastText: "",
+        isError: true,
+        // A spawn failure (missing binary, missing cwd) never reached the
+        // service — deterministic, so it must not look retryable.
+        apiErrorStatus: null,
+      })
+    })
+  })
+}
+
+export const claudeCode = {
+  name: "claude-code",
+  // Sonnet by default: an asker is sitting in the console waiting, and data Q&A
+  // is tool-call-bound — latency buys more than the top model's depth.
+  defaultModel: "sonnet",
+  defaultBin: "claude",
+
+  /** Resolve the binary from flags/env, honoring the historical CLAUDE_BIN /
+   *  --claude-bin names alongside the generic AGENT_BIN / --agent-bin. */
+  binFrom(flags, env) {
+    return (
+      flags["agent-bin"] ??
+      flags["claude-bin"] ??
+      env.AGENT_BIN ??
+      env.CLAUDE_BIN ??
+      this.defaultBin
+    )
+  },
+
+  /** Run one turn. `systemPrompt` already carries the runner's answer contract;
+   *  `resumeSessionId` continues an existing session. --resume does NOT carry the
+   *  original --append-system-prompt (verified against the CLI), so we re-send it
+   *  on every spawn or a resumed turn would be judged against a contract it can
+   *  no longer see. Headless: --dangerously-skip-permissions, because an
+   *  interactive prompt would hang the subprocess; the real safety boundary is
+   *  the read-only credentials the MCP config carries. */
+  async run({ bin, cwd, model, systemPrompt, prompt, timeoutMs, resumeSessionId }) {
+    const systemArgs = [
+      "--append-system-prompt",
+      systemPrompt,
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--dangerously-skip-permissions",
+      "--model",
+      model,
+    ]
+    const args = resumeSessionId
+      ? ["-p", prompt, "--resume", resumeSessionId, ...systemArgs]
+      : ["-p", prompt, ...systemArgs]
+    return spawnClaude({ bin, cwd, args, timeoutMs })
+  },
+
+  /** Is this run worth a second attempt? Only when the SERVICE failed, never
+   *  when the configuration did — a wrong model name or a missing binary fails
+   *  the same way twice, and paying a sleep plus a second spawn to learn that is
+   *  pure latency.
+   *    - 429 / 5xx from the API (the 529 that killed a review five minutes deep)
+   *    - an engine/turn error: nonzero exit, no api status, nothing to show
+   *  Excluded: timeouts (the owner's signal the work doesn't fit the budget),
+   *  spawn failures (code -1), and every 4xx (a 404 model_not_found or 401 never
+   *  comes good on its own). */
+  retryable(r) {
+    if (r.timedOut || r.code === 0 || r.code === -1) return false
+    if (r.apiErrorStatus != null) return r.apiErrorStatus === 429 || r.apiErrorStatus >= 500
+    return true
+  },
+
+  /** Version probe for `derive runner doctor`. Resolves the version string, or
+   *  null when the binary is missing / not spawnable. */
+  version(bin) {
+    return new Promise((resolve) => {
+      const p = spawn(bin, ["--version"], { stdio: ["ignore", "pipe", "ignore"], timeout: 15_000 })
+      let out = ""
+      p.stdout.on("data", (b) => {
+        out += b
+      })
+      p.on("close", (code) => resolve(code === 0 ? out.trim() : null))
+      p.on("error", () => resolve(null))
+    })
+  },
+}

--- a/packages/cli/src/providers/claude-code.js
+++ b/packages/cli/src/providers/claude-code.js
@@ -161,6 +161,13 @@ export const claudeCode = {
     return true
   },
 
+  /** Map an owner's fetched credential to the env the `claude` CLI reads. A plan/OAuth
+   *  token rides CLAUDE_CODE_OAUTH_TOKEN; an API key rides ANTHROPIC_API_KEY. Returns an
+   *  env map the runner sets for this (single-owner) run process. */
+  credentialEnv(kind, value) {
+    return kind === "oauth" ? { CLAUDE_CODE_OAUTH_TOKEN: value } : { ANTHROPIC_API_KEY: value }
+  },
+
   /** Version probe for `derive runner doctor`. Resolves the version string, or
    *  null when the binary is missing / not spawnable. */
   version(bin) {

--- a/packages/cli/src/providers/codex.js
+++ b/packages/cli/src/providers/codex.js
@@ -101,6 +101,14 @@ export const codex = {
     return true
   },
 
+  /** Map an owner's credential to Codex's env. An API key rides OPENAI_API_KEY. A
+   *  ChatGPT-plan login is file-based (~/.codex/auth.json), not an env var, so it can't
+   *  be injected this way yet — returns null (the runner then fails closed with a clear
+   *  message); wiring per-run file auth is a follow-up. */
+  credentialEnv(kind, value) {
+    return kind === "api_key" ? { OPENAI_API_KEY: value } : null
+  },
+
   version(bin) {
     return new Promise((resolve) => {
       const p = spawn(bin, ["--version"], { stdio: ["ignore", "pipe", "ignore"], timeout: 15_000 })

--- a/packages/cli/src/providers/codex.js
+++ b/packages/cli/src/providers/codex.js
@@ -15,9 +15,13 @@
 import { spawn } from "node:child_process"
 
 /** Spawn `codex exec` once and capture stdout as the reply text. */
-function spawnCodex({ bin, cwd, args, timeoutMs }) {
+function spawnCodex({ bin, cwd, args, timeoutMs, env }) {
   return new Promise((resolve) => {
-    const child = spawn(bin, args, { cwd, env: process.env, stdio: ["ignore", "pipe", "pipe"] })
+    const child = spawn(bin, args, {
+      cwd,
+      env: env ?? process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    })
     let out = ""
     let stderr = ""
     let timedOut = false
@@ -81,7 +85,7 @@ export const codex = {
   /** Run one turn. Codex takes a single prompt, so the system prompt (which
    *  carries the answer contract) is prepended to the task rather than passed as
    *  a separate flag. resumeSessionId is ignored (no resume). */
-  async run({ bin, cwd, model, systemPrompt, prompt, timeoutMs }) {
+  async run({ bin, cwd, model, systemPrompt, prompt, timeoutMs, env }) {
     const args = [
       "exec",
       "--model",
@@ -90,7 +94,7 @@ export const codex = {
       "--dangerously-bypass-approvals-and-sandbox",
       `${systemPrompt}\n\n---\n\n${prompt}`,
     ]
-    return spawnCodex({ bin, cwd, args, timeoutMs })
+    return spawnCodex({ bin, cwd, args, timeoutMs, env })
   },
 
   /** Without a structured api status, a nonzero exit that produced no output is

--- a/packages/cli/src/providers/codex.js
+++ b/packages/cli/src/providers/codex.js
@@ -1,0 +1,115 @@
+// The Codex provider: drives OpenAI's `codex` CLI (`codex exec`). Like Claude
+// Code, it authenticates itself from the inherited env — a ChatGPT-plan login
+// (`codex login`) or OPENAI_API_KEY — so a plan token flows through the official
+// client, never a reimplemented one.
+//
+// EXPERIMENTAL: the argv and I/O below follow Codex's documented `exec` shape but
+// have NOT been verified against a pinned binary in this tree; the flag names are
+// the one thing to confirm with `codex exec --help` before relying on it. It is
+// written conservatively on purpose:
+//   - plain stdout is the reply (no JSON-event schema to track); the runner's
+//     <answer> contract rides in the system prompt, so parsing is unchanged.
+//   - no session resume (Codex's resume semantics differ); a transient failure
+//     retries from scratch rather than resuming, which the orchestrator handles.
+// Both are safe degradations, not correctness gaps — see ./index.js for the shape.
+import { spawn } from "node:child_process"
+
+/** Spawn `codex exec` once and capture stdout as the reply text. */
+function spawnCodex({ bin, cwd, args, timeoutMs }) {
+  return new Promise((resolve) => {
+    const child = spawn(bin, args, { cwd, env: process.env, stdio: ["ignore", "pipe", "pipe"] })
+    let out = ""
+    let stderr = ""
+    let timedOut = false
+    let killTimer
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill("SIGTERM")
+      killTimer = setTimeout(() => child.kill("SIGKILL"), 5_000)
+    }, timeoutMs)
+    child.stdout.on("data", (b) => {
+      out += b.toString()
+    })
+    child.stderr.on("data", (b) => {
+      stderr += b.toString()
+    })
+    child.on("close", (code) => {
+      clearTimeout(timer)
+      clearTimeout(killTimer)
+      resolve({
+        timedOut,
+        code,
+        // The whole reply is the result text; the runner extracts the <answer>
+        // block from it exactly as it does for any provider.
+        resultText: out,
+        // No session model here — a retry restarts rather than resumes.
+        sessionId: null,
+        stderr,
+        lastText: out.replace(/\s+/g, " ").slice(-200),
+        isError: code !== 0,
+        // Codex plain-text mode surfaces no structured api status; the exit code
+        // is the only signal, so retryable() falls back to "engine error".
+        apiErrorStatus: null,
+      })
+    })
+    child.on("error", (err) => {
+      clearTimeout(timer)
+      clearTimeout(killTimer)
+      resolve({
+        timedOut: false,
+        code: -1,
+        resultText: "",
+        sessionId: null,
+        stderr: String(err),
+        lastText: "",
+        isError: true,
+        apiErrorStatus: null,
+      })
+    })
+  })
+}
+
+export const codex = {
+  name: "codex",
+  defaultModel: "gpt-5-codex",
+  defaultBin: "codex",
+
+  binFrom(flags, env) {
+    return flags["agent-bin"] ?? env.AGENT_BIN ?? env.CODEX_BIN ?? this.defaultBin
+  },
+
+  /** Run one turn. Codex takes a single prompt, so the system prompt (which
+   *  carries the answer contract) is prepended to the task rather than passed as
+   *  a separate flag. resumeSessionId is ignored (no resume). */
+  async run({ bin, cwd, model, systemPrompt, prompt, timeoutMs }) {
+    const args = [
+      "exec",
+      "--model",
+      model,
+      // Non-interactive: skip approvals, like the Claude provider's headless mode.
+      "--dangerously-bypass-approvals-and-sandbox",
+      `${systemPrompt}\n\n---\n\n${prompt}`,
+    ]
+    return spawnCodex({ bin, cwd, args, timeoutMs })
+  },
+
+  /** Without a structured api status, a nonzero exit that produced no output is
+   *  treated as an engine error worth one retry; a spawn failure (code -1) and a
+   *  timeout are not. Mirrors the claude-code policy on the signals Codex gives. */
+  retryable(r) {
+    if (r.timedOut || r.code === 0 || r.code === -1) return false
+    return true
+  },
+
+  version(bin) {
+    return new Promise((resolve) => {
+      const p = spawn(bin, ["--version"], { stdio: ["ignore", "pipe", "ignore"], timeout: 15_000 })
+      let out = ""
+      p.stdout.on("data", (b) => {
+        out += b
+      })
+      p.on("close", (code) => resolve(code === 0 ? out.trim() : null))
+      p.on("error", () => resolve(null))
+    })
+  },
+}

--- a/packages/cli/src/providers/index.js
+++ b/packages/cli/src/providers/index.js
@@ -1,0 +1,39 @@
+// The agent-provider registry. Each provider drives one agent CLI; the runner
+// core is agnostic and talks only to this shape, so adding a provider is one new
+// file plus one line here. Auth is always the provider CLI's own concern (a plan
+// OAuth token or an API key from the inherited env), never reimplemented.
+//
+// AgentProvider shape:
+//   name         string            — id used by --provider / RUNNER_PROVIDER
+//   defaultModel string            — used when neither --model nor RUNNER_MODEL is set
+//   defaultBin   string            — the binary name if none is configured
+//   binFrom(flags, env) -> string  — resolve the binary from flags/env
+//   run(opts)    -> Promise<RunResult>
+//     opts:      { bin, cwd, model, systemPrompt, prompt, timeoutMs, resumeSessionId }
+//                systemPrompt already includes the runner's <answer> contract.
+//     RunResult: { timedOut, code, resultText, sessionId, stderr, lastText, isError, apiErrorStatus }
+//                resultText is the reply the runner parses for the <answer> block;
+//                sessionId (or null) is what a resume/nudge continues.
+//   retryable(RunResult) -> boolean — service failure (retry) vs config failure (don't)
+//   version(bin) -> Promise<string|null> — for `runner doctor`
+import { claudeCode } from "./claude-code.js"
+import { codex } from "./codex.js"
+
+/** name → provider. claude-code is the default and the verified reference impl;
+ *  codex is experimental (see its header). */
+export const PROVIDERS = {
+  [claudeCode.name]: claudeCode,
+  [codex.name]: codex,
+}
+
+export const DEFAULT_PROVIDER = claudeCode.name
+
+/** Resolve a provider by name, failing loudly on an unknown one (a typo in
+ *  --provider should not silently fall back to a different agent). */
+export function selectProvider(name) {
+  const key = name || DEFAULT_PROVIDER
+  const provider = PROVIDERS[key]
+  if (!provider)
+    throw new Error(`unknown provider "${key}" — known: ${Object.keys(PROVIDERS).join(", ")}`)
+  return provider
+}

--- a/packages/cli/src/runner.js
+++ b/packages/cli/src/runner.js
@@ -184,8 +184,9 @@ export class DeriveClient {
   /** The owner's connected model credential for a provider (decrypted), or null. The
    *  server scopes it to THIS agent's registrant, so a runner only ever sees its own
    *  owner's plan token. */
-  async modelCredential(provider) {
-    const r = await this.call(`/v1/agent/model-credential?provider=${encodeURIComponent(provider)}`)
+  async modelCredential(provider, sessionId = null) {
+    const q = `provider=${encodeURIComponent(provider)}${sessionId ? `&session=${encodeURIComponent(sessionId)}` : ""}`
+    const r = await this.call(`/v1/agent/model-credential?${q}`)
     return r.credential ?? null
   }
 
@@ -597,6 +598,7 @@ export async function runAgent(provider, opts) {
     model: opts.model,
     systemPrompt,
     timeoutMs: opts.timeoutMs,
+    env: opts.env,
   }
   // An API failure's message arrives in the result text, a crash's in the last
   // assistant words, a spawn failure's on stderr. Try all three before reporting
@@ -694,6 +696,21 @@ const MOCK_ANSWER = {
 export async function serveSession(client, session, manifest, cfg, repoMeta = [], skillMeta = []) {
   const asked = session.messages.at(-1)?.body_md?.slice(0, 80) ?? "?"
   console.log(`[runner] session ${session.id}: "${asked}"`)
+  // Whose plan pays for THIS answer: the session's asker (the server resolves it,
+  // falling back to the registrant), composed as a per-spawn overlay so nothing
+  // sticks to process.env between sessions with different askers. A fail-closed
+  // resolve (no plan, no ambient) fails THIS session server-side like any other
+  // run failure — thrown, it would leave the claim dangling and retry-loop.
+  let modelEnv = null
+  if (!cfg.mock) {
+    try {
+      modelEnv = await resolveModelEnv(cfg, client, session.id)
+    } catch (err) {
+      console.error(`[runner] session ${session.id} failed: ${err.message}`)
+      await client.fail(session.id)
+      return
+    }
+  }
   const result = cfg.mock
     ? { ok: true, answer: MOCK_ANSWER }
     : await runAgent(selectProvider(cfg.providerName), {
@@ -703,6 +720,7 @@ export async function serveSession(client, session, manifest, cfg, repoMeta = []
         timeoutMs: cfg.timeoutMs,
         systemPrompt: manifest,
         prompt: buildPrompt(session.messages),
+        env: modelEnv ? { ...process.env, ...modelEnv } : undefined,
       })
   if (!result.ok || !result.answer) {
     console.error(`[runner] session ${session.id} failed: ${result.error}`)
@@ -781,23 +799,25 @@ export async function serveSession(client, session, manifest, cfg, repoMeta = []
 /** Boot the host state serve/once share: context info, repo corpus, skills,
  *  conventions. Everything here is per-boot truth on purpose (see the comments
  *  inline) — `once` inherits the same freshness contract as a serve restart. */
-/** Resolve the model credential this run authenticates with. The runner process serves
- *  exactly one context (one owner), so injecting the owner's connected plan token into this
- *  process's env is isolation by construction: it is used only for this owner's runs and
- *  overrides any ambient token. Precedence:
- *    1. the owner's connected per-user plan (fetched, decrypted, provider-mapped) — inject it;
- *    2. no connection but an ambient token is set (self-host's single global plan) — use it;
+/** Resolve the model credential a run authenticates with, as a per-spawn ENV OVERLAY —
+ *  never a process.env mutation, so one asker's plan token can't leak into the next
+ *  asker's session on a shared context. Pass a session id to bill the run's INITIATOR:
+ *  the server resolves the session's asker first and falls back to the agent's
+ *  registrant (interim until the workspace pool lands). Precedence:
+ *    1. the initiator's connected plan (fetched, decrypted, provider-mapped) — overlay it;
+ *    2. no connection but an ambient token is set (self-host's single global plan) — null
+ *       overlay, the spawn inherits process.env;
  *    3. neither — FAIL CLOSED with a connect-your-plan message (never a shared fallback).
  *  A lookup error (older/self-host server without the endpoint) degrades to the ambient path. */
-export async function applyModelCredential(cfg, client) {
-  if (cfg.mock) return
+export async function resolveModelEnv(cfg, client, sessionId = null) {
+  if (cfg.mock) return null
   const provider = selectProvider(cfg.providerName)
   let cred = null
   try {
-    cred = await client.modelCredential(cfg.providerName)
+    cred = await client.modelCredential(cfg.providerName, sessionId)
   } catch (e) {
     console.error(`[runner] model-credential lookup failed (${e.message}); using ambient env`)
-    return
+    return null
   }
   if (cred) {
     const env = provider.credentialEnv?.(cred.kind, cred.value)
@@ -805,22 +825,24 @@ export async function applyModelCredential(cfg, client) {
       throw new Error(
         `the connected ${cfg.providerName} credential (${cred.kind}) can't be injected — connect an API key, or use a provider that supports it`,
       )
-    for (const [k, v] of Object.entries(env)) process.env[k] = v
-    console.log(`[runner] running on the owner's connected ${cfg.providerName} plan`)
-    return
+    return env
   }
   const ambient = ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"].some(
     (k) => process.env[k],
   )
   if (!ambient)
     throw new Error(
-      `no model plan connected for this context's owner — connect one at ${cfg.server} (Settings → Model plans)`,
+      `no model plan connected for this run's initiator — connect one at ${cfg.server} (Settings → Model plans)`,
     )
+  return null
 }
 
 async function bootHost(cfg, modeLabel) {
   const client = new DeriveClient(cfg.server, cfg.token)
-  await applyModelCredential(cfg, client)
+  // Preflight only — verifies SOME credential path exists (registrant plan or ambient)
+  // so misconfiguration fails at boot with a clear message, not at the first answer.
+  // The overlay is discarded: each session resolves its own initiator's credential.
+  await resolveModelEnv(cfg, client)
   const info = await client.getContext(cfg.contextId)
   if (!info.manifest_md && !cfg.manifestFile) throw new Error("context has no readable manifest")
   const readManifest = () =>

--- a/packages/cli/src/runner.js
+++ b/packages/cli/src/runner.js
@@ -181,6 +181,14 @@ export class DeriveClient {
     return r.sessions
   }
 
+  /** The owner's connected model credential for a provider (decrypted), or null. The
+   *  server scopes it to THIS agent's registrant, so a runner only ever sees its own
+   *  owner's plan token. */
+  async modelCredential(provider) {
+    const r = await this.call(`/v1/agent/model-credential?provider=${encodeURIComponent(provider)}`)
+    return r.credential ?? null
+  }
+
   /** Post an answer. `answers` names the asker message it addresses — if a
    *  follow-up landed mid-run, the server keeps the session open for re-serve
    *  instead of settling it over the unseen follow-up. */
@@ -773,8 +781,46 @@ export async function serveSession(client, session, manifest, cfg, repoMeta = []
 /** Boot the host state serve/once share: context info, repo corpus, skills,
  *  conventions. Everything here is per-boot truth on purpose (see the comments
  *  inline) — `once` inherits the same freshness contract as a serve restart. */
+/** Resolve the model credential this run authenticates with. The runner process serves
+ *  exactly one context (one owner), so injecting the owner's connected plan token into this
+ *  process's env is isolation by construction: it is used only for this owner's runs and
+ *  overrides any ambient token. Precedence:
+ *    1. the owner's connected per-user plan (fetched, decrypted, provider-mapped) — inject it;
+ *    2. no connection but an ambient token is set (self-host's single global plan) — use it;
+ *    3. neither — FAIL CLOSED with a connect-your-plan message (never a shared fallback).
+ *  A lookup error (older/self-host server without the endpoint) degrades to the ambient path. */
+export async function applyModelCredential(cfg, client) {
+  if (cfg.mock) return
+  const provider = selectProvider(cfg.providerName)
+  let cred = null
+  try {
+    cred = await client.modelCredential(cfg.providerName)
+  } catch (e) {
+    console.error(`[runner] model-credential lookup failed (${e.message}); using ambient env`)
+    return
+  }
+  if (cred) {
+    const env = provider.credentialEnv?.(cred.kind, cred.value)
+    if (!env)
+      throw new Error(
+        `the connected ${cfg.providerName} credential (${cred.kind}) can't be injected — connect an API key, or use a provider that supports it`,
+      )
+    for (const [k, v] of Object.entries(env)) process.env[k] = v
+    console.log(`[runner] running on the owner's connected ${cfg.providerName} plan`)
+    return
+  }
+  const ambient = ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"].some(
+    (k) => process.env[k],
+  )
+  if (!ambient)
+    throw new Error(
+      `no model plan connected for this context's owner — connect one at ${cfg.server} (Settings → Model plans)`,
+    )
+}
+
 async function bootHost(cfg, modeLabel) {
   const client = new DeriveClient(cfg.server, cfg.token)
+  await applyModelCredential(cfg, client)
   const info = await client.getContext(cfg.contextId)
   if (!info.manifest_md && !cfg.manifestFile) throw new Error("context has no readable manifest")
   const readManifest = () =>

--- a/packages/cli/src/runner.js
+++ b/packages/cli/src/runner.js
@@ -20,7 +20,7 @@ import {
 } from "node:fs"
 import { dirname, join, resolve, sep } from "node:path"
 import { claudeCode } from "./providers/claude-code.js"
-import { DEFAULT_PROVIDER, selectProvider } from "./providers/index.js"
+import { DEFAULT_PROVIDER, PROVIDERS, selectProvider } from "./providers/index.js"
 import {
   conventionsBlock,
   materializeNotes,
@@ -86,9 +86,14 @@ export function loadRunnerConfig(env = process.env, flags = {}, { partial = fals
       "a context id and an agent token are required (positional/--context + --token|--token-file, or DERIVE_CONTEXT + DERIVE_TOKEN)",
     )
   // Which agent CLI drives the runs. Default claude-code; the provider owns its
-  // binary resolution and default model so this stays agnostic.
+  // binary resolution and default model so this stays agnostic. An unknown name
+  // is fatal for a real run, but in `partial` mode (doctor) it must degrade to a
+  // FINDING, not a crash — the same contract as a missing token/context — so we
+  // fall back to the default for the derived defaults and let doctor report it.
   const providerName = flags.provider ?? env.RUNNER_PROVIDER ?? DEFAULT_PROVIDER
-  const provider = selectProvider(providerName)
+  const provider = partial
+    ? (PROVIDERS[providerName] ?? PROVIDERS[DEFAULT_PROVIDER])
+    : selectProvider(providerName)
   return {
     server,
     token,
@@ -983,15 +988,20 @@ export async function doctor(cfg) {
   }
 
   // launchd/systemd PATHs don't include shell profile additions — the exact
-  // failure mode that produced `spawn claude ENOENT` in the field.
-  const provider = selectProvider(cfg.providerName)
-  const version = await provider.version(cfg.agentBin)
-  version
-    ? ok(cfg.providerName, `${cfg.agentBin} (${version.slice(0, 40)})`)
-    : bad(
-        cfg.providerName,
-        `${cfg.agentBin} not spawnable — pass --agent-bin with an absolute path`,
-      )
+  // failure mode that produced `spawn claude ENOENT` in the field. An unknown
+  // provider is a finding here, not a throw (doctor must survive a bad config).
+  const provider = PROVIDERS[cfg.providerName]
+  if (!provider)
+    bad("provider", `unknown "${cfg.providerName}" — known: ${Object.keys(PROVIDERS).join(", ")}`)
+  else {
+    const version = await provider.version(cfg.agentBin)
+    version
+      ? ok(cfg.providerName, `${cfg.agentBin} (${version.slice(0, 40)})`)
+      : bad(
+          cfg.providerName,
+          `${cfg.agentBin} not spawnable — pass --agent-bin with an absolute path`,
+        )
+  }
 
   for (const tool of ["gh", "python3"]) {
     ;(await spawnable(tool)) !== null

--- a/packages/cli/src/runner.js
+++ b/packages/cli/src/runner.js
@@ -19,6 +19,8 @@ import {
   statSync,
 } from "node:fs"
 import { dirname, join, resolve, sep } from "node:path"
+import { claudeCode } from "./providers/claude-code.js"
+import { DEFAULT_PROVIDER, selectProvider } from "./providers/index.js"
 import {
   conventionsBlock,
   materializeNotes,
@@ -83,15 +85,21 @@ export function loadRunnerConfig(env = process.env, flags = {}, { partial = fals
     throw new Error(
       "a context id and an agent token are required (positional/--context + --token|--token-file, or DERIVE_CONTEXT + DERIVE_TOKEN)",
     )
+  // Which agent CLI drives the runs. Default claude-code; the provider owns its
+  // binary resolution and default model so this stays agnostic.
+  const providerName = flags.provider ?? env.RUNNER_PROVIDER ?? DEFAULT_PROVIDER
+  const provider = selectProvider(providerName)
   return {
     server,
     token,
     contextId,
     cwd: flags.cwd ?? env.RUNNER_CWD ?? process.cwd(),
-    claudeBin: flags["claude-bin"] ?? env.CLAUDE_BIN ?? "claude",
-    // Sonnet by default: an asker is sitting in the console waiting, and data
-    // Q&A is tool-call-bound — latency buys more than the top model's depth.
-    model: flags.model ?? env.RUNNER_MODEL ?? "sonnet",
+    providerName,
+    agentBin: provider.binFrom(flags, env),
+    // The provider's default (claude-code → sonnet): an asker is sitting in the
+    // console waiting, and data Q&A is tool-call-bound, so latency buys more than
+    // the top model's depth. --model / RUNNER_MODEL override it.
+    model: flags.model ?? env.RUNNER_MODEL ?? provider.defaultModel,
     timeoutMs: positiveMs(flags.timeout ?? env.RUNNER_TIMEOUT_MS, 600_000, 10_000),
     pollMs: positiveMs(flags.poll ?? env.RUNNER_POLL_MS, 5_000, 500),
     mock: flags.mock === "true" || env.RUNNER_MOCK === "1",
@@ -549,201 +557,87 @@ const RESUME_PROMPT = `Your previous turn was cut short by a transient service e
 
 /** One `claude -p` run (or resume). Streams events (logged as they arrive),
  *  captures the session id (first system event) and the final `result` text. */
-function spawnClaude({ bin, cwd, args, timeoutMs }) {
-  return new Promise((resolve) => {
-    const child = spawn(bin, args, { cwd, env: process.env, stdio: ["ignore", "pipe", "pipe"] })
-    let buffer = ""
-    let resultText = ""
-    let sessionId = null
-    let stderr = ""
-    // The model's last words, kept for the failure message: a crash mid-run
-    // exits nonzero with EMPTY stderr, so `exit 1: ` was all an owner ever saw.
-    // The reason ("API Error: 529 Overloaded") is in the assistant stream.
-    let lastText = ""
-    // The CLI's own verdict on the run. An API failure is NOT a silent exit: it
-    // emits a result event with is_error + api_error_status and a `result`
-    // string carrying the message ("API Error: 529 Overloaded"). Reading those
-    // is the difference between "retry, the service was busy" and "don't, the
-    // model name is wrong" — the exit code alone can't tell them apart.
-    let isError = false
-    let apiErrorStatus = null
-    let timedOut = false
-    let killTimer
-    const timer = setTimeout(() => {
-      timedOut = true
-      child.kill("SIGTERM")
-      killTimer = setTimeout(() => child.kill("SIGKILL"), 5_000)
-    }, timeoutMs)
-    const take = (line) => {
-      try {
-        const event = JSON.parse(line)
-        lastText = logEvent(event) || lastText
-        if (!sessionId && typeof event.session_id === "string") sessionId = event.session_id
-        if (event.type === "result") {
-          if (typeof event.result === "string") resultText = event.result
-          if (event.is_error === true) isError = true
-          if (Number.isFinite(event.api_error_status)) apiErrorStatus = event.api_error_status
-        }
-      } catch {
-        // partial line / non-JSON noise
-      }
-    }
-    child.stdout.on("data", (b) => {
-      buffer += b.toString()
-      let nl = buffer.indexOf("\n")
-      while (nl >= 0) {
-        const line = buffer.slice(0, nl).trim()
-        buffer = buffer.slice(nl + 1)
-        nl = buffer.indexOf("\n")
-        if (line) take(line)
-      }
-    })
-    child.stderr.on("data", (b) => {
-      stderr += b.toString()
-    })
-    child.on("close", (code) => {
-      clearTimeout(timer)
-      clearTimeout(killTimer)
-      // The stream can end without a trailing newline; the unterminated line may
-      // be the `result` event itself.
-      if (buffer.trim()) take(buffer.trim())
-      resolve({ timedOut, code, resultText, sessionId, stderr, lastText, isError, apiErrorStatus })
-    })
-    child.on("error", (err) => {
-      clearTimeout(timer)
-      clearTimeout(killTimer)
-      resolve({
-        timedOut: false,
-        code: -1,
-        resultText: "",
-        sessionId: null,
-        stderr: String(err),
-        lastText: "",
-        isError: true,
-        // A spawn failure (missing binary, missing cwd) never reached the
-        // service — deterministic, so it must not look retryable.
-        apiErrorStatus: null,
-      })
-    })
-  })
-}
-
-// Long enough to be worth taking. The CLI does its OWN backoff first — a run
-// that surfaces `api_error_status` has already burned ~10 attempts over minutes
-// — so a 5s wait just re-enters the same overload window the CLI gave up on.
-// (`--fallback-model` is the CLI's other answer to overload; deliberately not
-// used: silently answering from a different model changes the answer without
-// telling the asker, and which model a context speaks with is the owner's call.)
+// Long enough to be worth taking. A provider whose CLI does its own backoff has
+// already burned attempts over minutes before it surfaces a retryable failure, so
+// a short wait would just re-enter the overload window it already gave up on.
 export const RETRY_DELAY_MS = 30_000
 
-/** Is this run worth a second attempt? Only when the SERVICE failed, never when
- *  the configuration did — a wrong model name or a missing binary fails exactly
- *  the same way twice, and paying a sleep plus a second spawn per session to
- *  learn that is pure latency.
- *    - 429 / 5xx from the API (the 529 that killed a review five minutes deep)
- *    - an engine/turn error: nonzero exit, no api status, nothing to show
- *  Excluded: timeouts (the owner's signal that the work doesn't fit the budget),
- *  spawn failures (code -1: missing claude, missing cwd), and every 4xx — a 404
- *  model_not_found or a 401 will never come good on its own. */
-function retryable(r) {
-  if (r.timedOut || r.code === 0 || r.code === -1) return false
-  if (r.apiErrorStatus != null) return r.apiErrorStatus === 429 || r.apiErrorStatus >= 500
-  return true
-}
-
-/** Produce a validated answer from a claude run, robustly:
- *   1. run → a parseable <answer> counts EVEN IF the CLI exited nonzero after
+/** Produce a validated answer from one agent run, robustly and provider-agnostically:
+ *   1. run -> a parseable <answer> counts EVEN IF the process exited nonzero after
  *      emitting it; the block is the contract, the exit code is a hint.
- *   2. the service failed (429/5xx/engine error)? retry ONCE, resuming the
- *      session when there is one so minutes of tool calls aren't paid for twice.
- *   3. still nothing, and the run is an ERROR run? fail — its `result` text is
- *      the API's error message, and posting "API Error: 529" as an answer would
- *      be worse than a failed session.
- *   4. a clean exit with no block? nudge-retry on the SAME session (--resume) —
- *      a model deep in a build often just forgets the block; reformatting is
- *      cheap and recovers a page it had only written to a file.
- *   5. still no block but there IS substantive output? SALVAGE it — post the raw
- *      reply with a caveat rather than hard-fail a run that did the work.
- *  Fresh process per run is unchanged — a resume is one follow-up turn within
- *  the same run, never across Derive sessions. Retries stay bounded at one, and
- *  the retry borrows the FIRST run's unspent budget rather than a fresh full
- *  one, so a wedged session can't stall the (strictly sequential) queue for
- *  double the timeout. */
-export async function runClaude(opts) {
-  const baseArgs = [
-    "--output-format",
-    "stream-json",
-    "--verbose",
-    // Headless: an interactive permission prompt would hang the subprocess.
-    // The safety boundary is the credentials the MCP config carries — read-only.
-    "--dangerously-skip-permissions",
-    "--model",
-    opts.model,
-  ]
-  // --resume does NOT carry the original --append-system-prompt (verified
-  // against the CLI): a resumed turn would run with neither the output contract
-  // nor the manifest, then be judged for not following a contract it could no
-  // longer see. Every spawn re-sends it.
-  const systemArgs = ["--append-system-prompt", opts.systemPrompt + OUTPUT_CONTRACT, ...baseArgs]
-  const firstArgs = ["-p", opts.prompt, ...systemArgs]
-  // An API failure's message arrives in the result STRING, a crash's in the
-  // assistant stream, a spawn failure's on stderr. Try all three before
-  // reporting the bare `exit 1: ` an owner used to get.
-  const why = (x) => (x.lastText || x.resultText || x.stderr || "").replace(/\s+/g, " ").trim()
-  const started = Date.now()
-  let r = await spawnClaude({
+ *   2. the service failed (provider.retryable)? retry ONCE, resuming the session
+ *      when the provider gave one so minutes of tool calls aren't paid for twice.
+ *   3. still nothing, and it's an ERROR run? fail -- its text is the API's error
+ *      message, and posting "API Error: 529" as an answer is worse than failing.
+ *   4. a clean exit with no block, and a session to resume? nudge-retry -- a model
+ *      deep in a build often just forgets the block; reformatting is cheap.
+ *   5. still no block but substantive output? SALVAGE it with a caveat.
+ *  The retry borrows the FIRST run's unspent budget rather than a fresh full one,
+ *  so a wedged session can't stall the (strictly sequential) queue for double the
+ *  timeout. The runner appends its <answer> contract to the system prompt here, so
+ *  every provider is judged against the same output shape. */
+export async function runAgent(provider, opts) {
+  const systemPrompt = opts.systemPrompt + OUTPUT_CONTRACT
+  const base = {
     bin: opts.bin,
     cwd: opts.cwd,
+    model: opts.model,
+    systemPrompt,
     timeoutMs: opts.timeoutMs,
-    args: firstArgs,
-  })
+  }
+  // An API failure's message arrives in the result text, a crash's in the last
+  // assistant words, a spawn failure's on stderr. Try all three before reporting
+  // the bare `exit 1: ` an owner used to get.
+  const why = (x) => (x.lastText || x.resultText || x.stderr || "").replace(/\s+/g, " ").trim()
+  const started = Date.now()
+  let r = await provider.run({ ...base, prompt: opts.prompt, resumeSessionId: null })
   let parsed = parseAnswer(r.resultText)
 
-  // The service failed and gave us nothing usable. One retry — resumed if the
-  // run got far enough to have a session id, otherwise from the top.
-  if (!parsed.answer && retryable(r)) {
+  // The service failed and gave us nothing usable. One retry -- resumed if the run
+  // got a session id, otherwise from the top.
+  if (!parsed.answer && provider.retryable(r)) {
     const sid = r.sessionId
     console.error(
-      `[runner] run exited ${r.code}${r.apiErrorStatus ? ` (api ${r.apiErrorStatus})` : ""}: ${why(r).slice(0, 160) || "no output"} — retrying once${sid ? ` (resume ${sid.slice(0, 8)})` : ""}`,
+      `[runner] run exited ${r.code}${r.apiErrorStatus ? ` (api ${r.apiErrorStatus})` : ""}: ${why(r).slice(0, 160) || "no output"} -- retrying once${sid ? ` (resume ${sid.slice(0, 8)})` : ""}`,
     )
     await new Promise((res) => setTimeout(res, opts.retryDelayMs ?? RETRY_DELAY_MS))
     // Whatever the first attempt didn't spend, floored so a late failure still
     // gets a usable window. The queue is sequential: an unbounded second run
     // would stall every other asker for double the timeout.
     const left = opts.timeoutMs - (Date.now() - started)
-    r = await spawnClaude({
-      bin: opts.bin,
-      cwd: opts.cwd,
+    r = await provider.run({
+      ...base,
       timeoutMs: Math.max(left, 120_000),
-      args: sid ? ["-p", RESUME_PROMPT, "--resume", sid, ...systemArgs] : firstArgs,
+      prompt: sid ? RESUME_PROMPT : opts.prompt,
+      resumeSessionId: sid,
     })
     parsed = parseAnswer(r.resultText)
   }
 
-  // A block is a valid answer however the process exited — the model did the
-  // work and said so in the contract's own words.
+  // A block is a valid answer however the process exited -- the model did the work
+  // and said so in the contract's own words.
   if (parsed.answer) return { ok: true, answer: parsed.answer }
   if (r.timedOut) return { ok: false, error: "timed out" }
-  // An error run's `result` text is the API's error message, not an answer:
-  // fail rather than let the salvage path post "API Error: 529" to the asker.
+  // An error run's text is the API's error message, not an answer: fail rather
+  // than let the salvage path post "API Error: 529" to the asker.
   if (r.code !== 0 || r.isError)
     return { ok: false, error: `exit ${r.code}: ${why(r).slice(0, 500)}` }
 
-  // Nudge-retry on the same session (bounded — this is a reformat, not new work).
+  // Nudge-retry on the same session (bounded -- this is a reformat, not new work).
   if (r.sessionId) {
     console.log(`[runner] no <answer> block; nudging (resume ${r.sessionId.slice(0, 8)})`)
-    const r2 = await spawnClaude({
-      bin: opts.bin,
-      cwd: opts.cwd,
+    const r2 = await provider.run({
+      ...base,
       timeoutMs: Math.min(opts.timeoutMs, 180_000),
-      args: ["-p", NUDGE_PROMPT, "--resume", r.sessionId, ...systemArgs],
+      prompt: NUDGE_PROMPT,
+      resumeSessionId: r.sessionId,
     })
     const p2 = parseAnswer(r2.resultText)
     if (p2.answer) return { ok: true, answer: p2.answer }
   }
 
-  // Salvage: the run produced real output but never the block. Post the raw reply
-  // rather than lose the work — flagged so the number/prose is read with care.
+  // Salvage: real output but never the block. Post the raw reply rather than lose
+  // the work -- flagged so the number/prose is read with care.
   const raw = r.resultText.trim()
   if (raw) {
     console.log("[runner] salvaging unstructured reply (no <answer> block after nudge)")
@@ -754,7 +648,7 @@ export async function runClaude(opts) {
         query: null,
         confidence: null,
         caveats: [
-          "The runner couldn't parse a structured answer, so this is the model's raw reply — treat any figures and confidence with extra care.",
+          "The runner couldn't parse a structured answer, so this is the model's raw reply -- treat any figures and confidence with extra care.",
         ],
         escalate: false,
         escalation_reason: null,
@@ -765,20 +659,9 @@ export async function runClaude(opts) {
   return { ok: false, error: parsed.error }
 }
 
-/** Log one stream event; returns the assistant text it carried (if any), which
- *  the caller keeps as the run's last words for diagnostics. */
-function logEvent(event) {
-  if (event.type !== "assistant") return ""
-  let text = ""
-  for (const c of event.message?.content ?? []) {
-    if (c.type === "tool_use") console.log(`[claude] → ${String(c.name)}`)
-    else if (c.type === "text" && typeof c.text === "string" && c.text.trim()) {
-      text = c.text
-      console.log(`[claude] ${c.text.replace(/\s+/g, " ").slice(0, 200)}`)
-    }
-  }
-  return text
-}
+/** Back-compat convenience for the default provider; the runClaude tests exercise
+ *  the full orchestration through it. New call sites pass a provider to runAgent. */
+export const runClaude = (opts) => runAgent(claudeCode, opts)
 
 // ---- serve --------------------------------------------------------------------
 
@@ -800,8 +683,8 @@ export async function serveSession(client, session, manifest, cfg, repoMeta = []
   console.log(`[runner] session ${session.id}: "${asked}"`)
   const result = cfg.mock
     ? { ok: true, answer: MOCK_ANSWER }
-    : await runClaude({
-        bin: cfg.claudeBin,
+    : await runAgent(selectProvider(cfg.providerName), {
+        bin: cfg.agentBin,
         cwd: cfg.cwd,
         model: cfg.model,
         timeoutMs: cfg.timeoutMs,
@@ -895,7 +778,7 @@ async function bootHost(cfg, modeLabel) {
   console.log(
     `[runner] serving "${info.name}" (${cfg.contextId}) on ${cfg.server} — ` +
       `${cfg.manifestFile ? `manifest LOCAL ${cfg.manifestFile}` : `manifest v${info.manifest_version}`}, ` +
-      `${cfg.mock ? "MOCK" : `${cfg.claudeBin} (${cfg.model})`}, ${modeLabel}`,
+      `${cfg.mock ? "MOCK" : `${cfg.providerName}:${cfg.agentBin} (${cfg.model})`}, ${modeLabel}`,
   )
   // Pointers sync at boot, like every other piece of host state — a manifest
   // edit that adds one applies on the next start (the catalog in the prompt is
@@ -1101,10 +984,14 @@ export async function doctor(cfg) {
 
   // launchd/systemd PATHs don't include shell profile additions — the exact
   // failure mode that produced `spawn claude ENOENT` in the field.
-  const version = await spawnable(cfg.claudeBin, 15_000)
+  const provider = selectProvider(cfg.providerName)
+  const version = await provider.version(cfg.agentBin)
   version
-    ? ok("claude", `${cfg.claudeBin} (${version.slice(0, 40)})`)
-    : bad("claude", `${cfg.claudeBin} not spawnable — pass --claude-bin with an absolute path`)
+    ? ok(cfg.providerName, `${cfg.agentBin} (${version.slice(0, 40)})`)
+    : bad(
+        cfg.providerName,
+        `${cfg.agentBin} not spawnable — pass --agent-bin with an absolute path`,
+      )
 
   for (const tool of ["gh", "python3"]) {
     ;(await spawnable(tool)) !== null
@@ -1140,8 +1027,10 @@ export function renderServiceUnit(cfg, binPath, platform = process.platform) {
     cfg.server,
     "--cwd",
     cfg.cwd,
-    "--claude-bin",
-    cfg.claudeBin,
+    "--provider",
+    cfg.providerName,
+    "--agent-bin",
+    cfg.agentBin,
     "--model",
     cfg.model,
     "--timeout",

--- a/packages/cli/test/providers.test.js
+++ b/packages/cli/test/providers.test.js
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest"
 import { claudeCode } from "../src/providers/claude-code.js"
 import { codex } from "../src/providers/codex.js"
 import { DEFAULT_PROVIDER, PROVIDERS, selectProvider } from "../src/providers/index.js"
-import { applyModelCredential, loadRunnerConfig, runAgent } from "../src/runner.js"
+import { loadRunnerConfig, resolveModelEnv, runAgent } from "../src/runner.js"
 
 describe("provider registry", () => {
   it("defaults to claude-code, resolves known names, and throws on an unknown one", () => {
@@ -108,53 +108,65 @@ describe("credentialEnv", () => {
   })
 })
 
-describe("applyModelCredential — per-user isolation + fail-closed", () => {
+describe("resolveModelEnv — per-initiator overlay + fail-closed", () => {
   const CRED_ENV = ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"]
   const clean = () => {
     for (const k of CRED_ENV) delete process.env[k]
   }
   const cfg = (over = {}) => ({ providerName: "claude-code", server: "https://derive.to", ...over })
   const client = (credential, throws = false) => ({
-    modelCredential: async () => {
+    calls: [],
+    async modelCredential(provider, sessionId = null) {
+      this.calls.push({ provider, sessionId })
       if (throws) throw new Error("404")
       return credential
     },
   })
 
-  it("injects the owner's connected plan into this run's env (and overrides any ambient)", async () => {
+  it("returns the initiator's plan as an OVERLAY — process.env is never mutated", async () => {
     clean()
-    process.env.CLAUDE_CODE_OAUTH_TOKEN = "GLOBAL-should-be-overridden"
-    await applyModelCredential(cfg(), client({ kind: "oauth", value: "OWNER-A" }))
-    expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("OWNER-A")
-    clean()
-  })
-
-  it("FAILS CLOSED when the owner has no plan and no ambient token is set", async () => {
-    clean()
-    await expect(applyModelCredential(cfg(), client(null))).rejects.toThrow(
-      /no model plan connected/,
-    )
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "ambient-should-survive"
+    const env = await resolveModelEnv(cfg(), client({ kind: "oauth", value: "ASKER-A" }))
+    expect(env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "ASKER-A" })
+    // The isolation property itself: the parent env still holds the ambient value,
+    // so the NEXT session (a different asker) starts from clean ground.
+    expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("ambient-should-survive")
     clean()
   })
 
-  it("falls back to an ambient token (self-host's single plan) when the owner has none", async () => {
+  it("passes the session id through, so the server can resolve the ASKER's plan", async () => {
+    clean()
+    process.env.ANTHROPIC_API_KEY = "ambient"
+    const c = client(null)
+    await resolveModelEnv(cfg(), c, "ses_123")
+    expect(c.calls).toEqual([{ provider: "claude-code", sessionId: "ses_123" }])
+    clean()
+  })
+
+  it("FAILS CLOSED when the initiator has no plan and no ambient token is set", async () => {
+    clean()
+    await expect(resolveModelEnv(cfg(), client(null))).rejects.toThrow(/no model plan connected/)
+    clean()
+  })
+
+  it("falls back to an ambient token (self-host's single plan) — null overlay", async () => {
     clean()
     process.env.ANTHROPIC_API_KEY = "self-host-key"
-    await expect(applyModelCredential(cfg(), client(null))).resolves.toBeUndefined()
+    await expect(resolveModelEnv(cfg(), client(null))).resolves.toBeNull()
     clean()
   })
 
   it("a lookup error degrades to the ambient path rather than crashing the run", async () => {
     clean()
     process.env.CLAUDE_CODE_OAUTH_TOKEN = "ambient"
-    await expect(applyModelCredential(cfg(), client(null, true))).resolves.toBeUndefined()
+    await expect(resolveModelEnv(cfg(), client(null, true))).resolves.toBeNull()
     clean()
   })
 
   it("rejects a credential kind the provider can't inject (codex plan/oauth)", async () => {
     clean()
     await expect(
-      applyModelCredential(cfg({ providerName: "codex" }), client({ kind: "oauth", value: "x" })),
+      resolveModelEnv(cfg({ providerName: "codex" }), client({ kind: "oauth", value: "x" })),
     ).rejects.toThrow(/can't be injected/)
     clean()
   })

--- a/packages/cli/test/providers.test.js
+++ b/packages/cli/test/providers.test.js
@@ -4,7 +4,7 @@ import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import { codex } from "../src/providers/codex.js"
 import { DEFAULT_PROVIDER, PROVIDERS, selectProvider } from "../src/providers/index.js"
-import { runAgent } from "../src/runner.js"
+import { loadRunnerConfig, runAgent } from "../src/runner.js"
 
 describe("provider registry", () => {
   it("defaults to claude-code, resolves known names, and throws on an unknown one", () => {
@@ -13,6 +13,19 @@ describe("provider registry", () => {
     expect(selectProvider("codex").name).toBe("codex")
     expect(Object.keys(PROVIDERS).sort()).toEqual(["claude-code", "codex"])
     expect(() => selectProvider("nope")).toThrow(/unknown provider "nope"/)
+  })
+
+  it("an unknown provider is fatal for a real run but degrades to a finding under partial (doctor)", () => {
+    // A real run must fail loudly rather than silently pick a different agent.
+    expect(() =>
+      loadRunnerConfig({ RUNNER_PROVIDER: "nope", DERIVE_TOKEN: "t", DERIVE_CONTEXT: "c" }, {}),
+    ).toThrow(/unknown provider "nope"/)
+    // doctor (partial) must survive a bad config and report it, not crash: the
+    // name is preserved so doctor can flag it, and defaults fall back sanely.
+    const cfg = loadRunnerConfig({ RUNNER_PROVIDER: "nope" }, {}, { partial: true })
+    expect(cfg.providerName).toBe("nope")
+    expect(cfg.model).toBe("sonnet")
+    expect(cfg.agentBin).toBe("claude")
   })
 })
 

--- a/packages/cli/test/providers.test.js
+++ b/packages/cli/test/providers.test.js
@@ -1,0 +1,114 @@
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import { codex } from "../src/providers/codex.js"
+import { DEFAULT_PROVIDER, PROVIDERS, selectProvider } from "../src/providers/index.js"
+import { runAgent } from "../src/runner.js"
+
+describe("provider registry", () => {
+  it("defaults to claude-code, resolves known names, and throws on an unknown one", () => {
+    expect(DEFAULT_PROVIDER).toBe("claude-code")
+    expect(selectProvider().name).toBe("claude-code")
+    expect(selectProvider("codex").name).toBe("codex")
+    expect(Object.keys(PROVIDERS).sort()).toEqual(["claude-code", "codex"])
+    expect(() => selectProvider("nope")).toThrow(/unknown provider "nope"/)
+  })
+})
+
+describe("runAgent is provider-agnostic", () => {
+  // A pure-JS provider: no subprocess, just canned results. If the orchestration
+  // is truly agnostic, the claude-only retry/salvage behavior works here too.
+  const fake = (script) => {
+    const calls = []
+    return {
+      calls,
+      name: "fake",
+      run: async (opts) => {
+        calls.push(opts)
+        return {
+          timedOut: false,
+          code: 0,
+          sessionId: null,
+          stderr: "",
+          lastText: "",
+          isError: false,
+          apiErrorStatus: null,
+          resultText: "",
+          ...script(calls.length),
+        }
+      },
+      retryable: (r) => r.code !== 0 && !r.timedOut,
+    }
+  }
+  const opts = (provider) => ({
+    provider,
+    bin: "x",
+    cwd: tmpdir(),
+    model: "m",
+    timeoutMs: 30_000,
+    systemPrompt: "sys",
+    prompt: "task",
+    retryDelayMs: 0,
+  })
+
+  it("returns the parsed answer and appends the <answer> contract to the system prompt", async () => {
+    const p = fake(() => ({ resultText: '<answer>{"body_md":"hi"}</answer>' }))
+    const out = await runAgent(p, opts())
+    expect(out).toEqual({ ok: true, answer: expect.objectContaining({ body_md: "hi" }) })
+    // The runner, not the provider, carries the output contract.
+    expect(p.calls[0].systemPrompt).toContain("sys")
+    expect(p.calls[0].systemPrompt).toContain("<answer>")
+    expect(p.calls[0].resumeSessionId).toBeNull()
+  })
+
+  it("retries a retryable failure, resuming the session the provider returned", async () => {
+    const p = fake((n) =>
+      n === 1
+        ? { code: 1, sessionId: "sess-9", resultText: "" }
+        : { resultText: '<answer>{"body_md":"ok"}</answer>' },
+    )
+    const out = await runAgent(p, opts())
+    expect(out.ok).toBe(true)
+    expect(p.calls).toHaveLength(2)
+    expect(p.calls[1].resumeSessionId).toBe("sess-9")
+  })
+
+  it("salvages substantive output that never produced a block", async () => {
+    const p = fake(() => ({ resultText: "prose, no block", sessionId: "s1" }))
+    const out = await runAgent(p, opts())
+    expect(out.ok).toBe(true)
+    expect(out.answer.body_md).toBe("prose, no block")
+    expect(out.answer.caveats[0]).toMatch(/couldn't parse/)
+  })
+})
+
+describe("codex provider", () => {
+  const fakeCodex = (reply) => {
+    const dir = mkdtempSync(join(tmpdir(), "fake-codex-"))
+    const bin = join(dir, "codex")
+    writeFileSync(bin, `#!/bin/sh\nprintf '%s\\n' "$@" > "${dir}/args"\n${reply}\n`)
+    chmodSync(bin, 0o755)
+    return { bin, args: () => readFileSync(join(dir, "args"), "utf8") }
+  }
+
+  it("runs `codex exec` with the model and the combined prompt, and parses the reply", async () => {
+    const fake = fakeCodex(`echo '<answer>{"body_md":"42"}</answer>'`)
+    const out = await runAgent(codex, {
+      bin: fake.bin,
+      cwd: tmpdir(),
+      model: "gpt-5-codex",
+      timeoutMs: 30_000,
+      systemPrompt: "you are a runner",
+      prompt: "how many?",
+    })
+    expect(out.ok).toBe(true)
+    expect(out.answer.body_md).toBe("42")
+    const args = fake.args()
+    expect(args).toContain("exec")
+    expect(args).toContain("gpt-5-codex")
+    // System prompt (with the appended contract) and the task travel in one prompt.
+    expect(args).toContain("you are a runner")
+    expect(args).toContain("how many?")
+  })
+})

--- a/packages/cli/test/providers.test.js
+++ b/packages/cli/test/providers.test.js
@@ -2,9 +2,10 @@ import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { describe, expect, it } from "vitest"
+import { claudeCode } from "../src/providers/claude-code.js"
 import { codex } from "../src/providers/codex.js"
 import { DEFAULT_PROVIDER, PROVIDERS, selectProvider } from "../src/providers/index.js"
-import { loadRunnerConfig, runAgent } from "../src/runner.js"
+import { applyModelCredential, loadRunnerConfig, runAgent } from "../src/runner.js"
 
 describe("provider registry", () => {
   it("defaults to claude-code, resolves known names, and throws on an unknown one", () => {
@@ -93,6 +94,69 @@ describe("runAgent is provider-agnostic", () => {
     expect(out.ok).toBe(true)
     expect(out.answer.body_md).toBe("prose, no block")
     expect(out.answer.caveats[0]).toMatch(/couldn't parse/)
+  })
+})
+
+describe("credentialEnv", () => {
+  it("claude-code maps oauth→CLAUDE_CODE_OAUTH_TOKEN and api_key→ANTHROPIC_API_KEY", () => {
+    expect(claudeCode.credentialEnv("oauth", "tok")).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "tok" })
+    expect(claudeCode.credentialEnv("api_key", "sk")).toEqual({ ANTHROPIC_API_KEY: "sk" })
+  })
+  it("codex maps api_key→OPENAI_API_KEY; a plan (oauth) login is file-based, so null for now", () => {
+    expect(codex.credentialEnv("api_key", "sk")).toEqual({ OPENAI_API_KEY: "sk" })
+    expect(codex.credentialEnv("oauth", "tok")).toBeNull()
+  })
+})
+
+describe("applyModelCredential — per-user isolation + fail-closed", () => {
+  const CRED_ENV = ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"]
+  const clean = () => {
+    for (const k of CRED_ENV) delete process.env[k]
+  }
+  const cfg = (over = {}) => ({ providerName: "claude-code", server: "https://derive.to", ...over })
+  const client = (credential, throws = false) => ({
+    modelCredential: async () => {
+      if (throws) throw new Error("404")
+      return credential
+    },
+  })
+
+  it("injects the owner's connected plan into this run's env (and overrides any ambient)", async () => {
+    clean()
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "GLOBAL-should-be-overridden"
+    await applyModelCredential(cfg(), client({ kind: "oauth", value: "OWNER-A" }))
+    expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("OWNER-A")
+    clean()
+  })
+
+  it("FAILS CLOSED when the owner has no plan and no ambient token is set", async () => {
+    clean()
+    await expect(applyModelCredential(cfg(), client(null))).rejects.toThrow(
+      /no model plan connected/,
+    )
+    clean()
+  })
+
+  it("falls back to an ambient token (self-host's single plan) when the owner has none", async () => {
+    clean()
+    process.env.ANTHROPIC_API_KEY = "self-host-key"
+    await expect(applyModelCredential(cfg(), client(null))).resolves.toBeUndefined()
+    clean()
+  })
+
+  it("a lookup error degrades to the ambient path rather than crashing the run", async () => {
+    clean()
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "ambient"
+    await expect(applyModelCredential(cfg(), client(null, true))).resolves.toBeUndefined()
+    clean()
+  })
+
+  it("rejects a credential kind the provider can't inject (codex plan/oauth)", async () => {
+    clean()
+    await expect(
+      applyModelCredential(cfg({ providerName: "codex" }), client({ kind: "oauth", value: "x" })),
+    ).rejects.toThrow(/can't be injected/)
+    clean()
   })
 })
 

--- a/packages/cli/test/runner.test.js
+++ b/packages/cli/test/runner.test.js
@@ -420,7 +420,7 @@ describe("artifact file channel", () => {
       "manifest",
       {
         ...base,
-        claudeBin: fake(
+        agentBin: fake(
           '{\\"body_md\\":\\"page built\\",\\"artifact\\":{\\"title\\":\\"Companion\\",\\"path\\":\\"page.html\\"}}',
         ),
       },
@@ -437,7 +437,7 @@ describe("artifact file channel", () => {
       "manifest",
       {
         ...base,
-        claudeBin: fake(
+        agentBin: fake(
           '{\\"body_md\\":\\"page built\\",\\"artifact\\":{\\"title\\":\\"Gone\\",\\"path\\":\\"nope.html\\"}}',
         ),
       },
@@ -638,7 +638,8 @@ describe("doctor", () => {
         server: "http://127.0.0.1:9",
         token: "",
         contextId: "",
-        claudeBin: "/nonexistent/claude",
+        agentBin: "/nonexistent/claude",
+        providerName: "claude-code",
         ...cfg,
       })
       return { failures, out: lines.join("\n") }

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1007,6 +1007,8 @@ export interface AgentStore {
   /** Enqueue or record a run. status defaults to "queued" (pending work); pass a terminal
    *  status to record an already-finished run straight into the ledger. */
   createRun(r: NewRun): Promise<RunRecord>
+  /** One run by id — the model-credential endpoint resolves a run's initiator through this. */
+  getRun(id: string): Promise<RunRecord | null>
   /** Atomically claim due queued runs for one agent: status "queued" with scheduled_for ≤
    *  now, flipped to "running" (started_at = now) under a row lock so concurrent executors
    *  never double-run one. Returns the claimed rows, oldest-scheduled first. */
@@ -1414,6 +1416,11 @@ export interface RunRecord {
   agent_id: string
   /** What fired it: "manual:<userId>", "schedule", "event:<name>" (free text). */
   reason: string
+  /** The person whose action fired it — the WALLET key (their plan bills the run).
+   *  Null = a clock or event started it (no person), which resolves to the
+   *  registrant today and the workspace pool once it lands. First-class on
+   *  purpose: `reason` is display text, never a resolution key. */
+  initiated_by: string | null
   status: RunStatus
   /** When it should run (queue time); claimed once this is <= now. Null = as soon as possible. */
   scheduled_for: string | null
@@ -1431,6 +1438,8 @@ export interface NewRun {
   automation_id?: string | null
   agent_id: string
   reason: string
+  /** The initiating person (wallet key); omit for clock/event runs. */
+  initiated_by?: string | null
   /** Defaults to "queued". */
   status?: RunStatus
   scheduled_for?: string | null

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -714,6 +714,19 @@ export interface IntegrationStore {
   setSlackInstall(s: SlackInstallRecord): Promise<void>
   /** Disconnect Slack for a workspace. */
   deleteSlackInstall(orgId: string): Promise<void>
+  // ---- Per-user model-plan credentials -----------------------------------
+  /** A user's own model credential for a provider (encrypted `secret`), or null. */
+  getModelCredential(
+    orgId: string,
+    userId: string,
+    provider: string,
+  ): Promise<ModelCredentialRecord | null>
+  /** Upsert a user's model credential (keyed org+user+provider). */
+  setModelCredential(c: ModelCredentialRecord): Promise<void>
+  /** Remove a user's model credential for a provider. */
+  deleteModelCredential(orgId: string, userId: string, provider: string): Promise<void>
+  /** A user's connected credentials (all providers) — for the settings hint list. */
+  listModelCredentials(orgId: string, userId: string): Promise<ModelCredentialRecord[]>
   /** The Slack message a Derive thread is mirrored to (for threading replies), or null. */
   getSlackThreadLinkByThread(threadId: string): Promise<SlackThreadLinkRecord | null>
   /** The Derive thread a Slack message maps to (for reply-back), or null. */
@@ -2084,6 +2097,21 @@ export const DEFAULT_ORG_SETTINGS: OrgSettings = {
 /** A connected Slack workspace (one per Derive workspace). `bot_token` is the OAuth bot
  *  token, AES-encrypted at rest. `default_channel` is where Derive posts when an artifact
  *  has no more specific channel. */
+/** A team member's own model-plan credential, encrypted at rest. `secret` is the AES-GCM
+ *  blob (lib/crypto); `provider` matches a runner provider ("claude-code" | "codex"); `kind`
+ *  distinguishes an OAuth/plan token from a plain API key. Scoped (org, user, provider). */
+export interface ModelCredentialRecord {
+  id: string
+  org_id: string
+  user_id: string
+  provider: string
+  kind: "oauth" | "api_key"
+  secret: string
+  hint: string
+  created_at: string
+  updated_at: string
+}
+
 export interface SlackInstallRecord {
   org_id: string
   team_id: string

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -490,6 +490,23 @@ export const userNotificationPref = pgTable(
   },
   (t) => [uniqueIndex("user_notification_pref_key").on(t.org_id, t.user_id)],
 )
+// Per-user model-plan credential (Claude/Codex plan token or API key), encrypted at rest
+// and scoped (org, user, provider). Used only for that user's own runs — see schema.ts.
+export const modelCredential = pgTable(
+  "model_credential",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    user_id: text("user_id").notNull(),
+    provider: text("provider").notNull(),
+    kind: text("kind").$type<"oauth" | "api_key">().notNull(),
+    secret: text("secret").notNull(),
+    hint: text("hint").notNull().default(""),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+    updated_at: text("updated_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [uniqueIndex("model_credential_key").on(t.org_id, t.user_id, t.provider)],
+)
 export const slackThreadLink = pgTable(
   "slack_thread_link",
   {

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -794,6 +794,7 @@ const TABLES = [
   report,
   auditLog,
   asset,
+  modelCredential,
 ]
 
 /** Build the Postgres boot DDL: generated table/index CREATEs + placeholder tables

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -190,6 +190,8 @@ export const run = pgTable("run", {
   automation_id: text("automation_id"),
   agent_id: text("agent_id").notNull(),
   reason: text("reason").notNull(),
+  // The initiating person (wallet key) — null for clock/event runs. See RunRecord.
+  initiated_by: text("initiated_by"),
   status: text("status").$type<RunStatus>().notNull(),
   scheduled_for: text("scheduled_for"),
   started_at: text("started_at"),

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -2509,6 +2509,10 @@ export class PgMetaStore implements MetaStore {
       .returning()
     return one(rows)
   }
+  async getRun(id: string): Promise<RunRecord | null> {
+    const rows = await this.db.select().from(run).where(eq(run.id, id)).limit(1)
+    return (rows[0] as RunRecord | undefined) ?? null
+  }
   claimDueRuns(agentId: string, now: string, limit = 20): Promise<RunRecord[]> {
     // The oldest queued runs due now for this agent, flipped to running under a row lock
     // (FOR UPDATE SKIP LOCKED) so two executors never claim the same run. A null

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -32,6 +32,7 @@ import type {
   Listed,
   MembershipRecord,
   MetaStore,
+  ModelCredentialRecord,
   NewAgent,
   NewAgentMention,
   NewArtifact,
@@ -143,6 +144,7 @@ import {
   githubInstallation,
   invitation,
   membership,
+  modelCredential,
   notification,
   oauthClientWorkspace,
   orgSettings,
@@ -1689,6 +1691,49 @@ export class PgMetaStore implements MetaStore {
   }
   async deleteSlackInstall(orgId: string): Promise<void> {
     await this.db.delete(slackInstall).where(eq(slackInstall.org_id, orgId))
+  }
+  async getModelCredential(
+    orgId: string,
+    userId: string,
+    provider: string,
+  ): Promise<ModelCredentialRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(modelCredential)
+      .where(
+        and(
+          eq(modelCredential.org_id, orgId),
+          eq(modelCredential.user_id, userId),
+          eq(modelCredential.provider, provider),
+        ),
+      )
+    return rows[0] ?? null
+  }
+  async setModelCredential(c: ModelCredentialRecord): Promise<void> {
+    await this.db
+      .insert(modelCredential)
+      .values(c)
+      .onConflictDoUpdate({
+        target: [modelCredential.org_id, modelCredential.user_id, modelCredential.provider],
+        set: { secret: c.secret, kind: c.kind, hint: c.hint, updated_at: c.updated_at },
+      })
+  }
+  async deleteModelCredential(orgId: string, userId: string, provider: string): Promise<void> {
+    await this.db
+      .delete(modelCredential)
+      .where(
+        and(
+          eq(modelCredential.org_id, orgId),
+          eq(modelCredential.user_id, userId),
+          eq(modelCredential.provider, provider),
+        ),
+      )
+  }
+  async listModelCredentials(orgId: string, userId: string): Promise<ModelCredentialRecord[]> {
+    return this.db
+      .select()
+      .from(modelCredential)
+      .where(and(eq(modelCredential.org_id, orgId), eq(modelCredential.user_id, userId)))
   }
   async getSlackThreadLinkByThread(threadId: string): Promise<SlackThreadLinkRecord | null> {
     const rows = await this.db

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -30,6 +30,7 @@ import type {
   ListArtifactsOpts,
   Listed,
   MembershipRecord,
+  ModelCredentialRecord,
   NewAgent,
   NewAgentMention,
   NewArtifact,
@@ -142,6 +143,7 @@ import {
   githubInstallation,
   invitation,
   membership,
+  modelCredential,
   notification,
   oauthClientWorkspace,
   orgSettings,
@@ -1890,6 +1892,53 @@ export function makeRepos(db: SqliteDb) {
   const deleteSlackInstall = async (orgId: string): Promise<void> => {
     await db.delete(slackInstall).where(eq(slackInstall.org_id, orgId)).run()
   }
+
+  // ---- Per-user model-plan credentials ------------------------------------
+  const modelCredWhere = (orgId: string, userId: string, provider: string) =>
+    and(
+      eq(modelCredential.org_id, orgId),
+      eq(modelCredential.user_id, userId),
+      eq(modelCredential.provider, provider),
+    )
+  const getModelCredential = async (
+    orgId: string,
+    userId: string,
+    provider: string,
+  ): Promise<ModelCredentialRecord | null> =>
+    (await db
+      .select()
+      .from(modelCredential)
+      .where(modelCredWhere(orgId, userId, provider))
+      .get()) ?? null
+  const setModelCredential = async (c: ModelCredentialRecord): Promise<void> => {
+    await db
+      .insert(modelCredential)
+      .values(c)
+      .onConflictDoUpdate({
+        target: [modelCredential.org_id, modelCredential.user_id, modelCredential.provider],
+        set: { secret: c.secret, kind: c.kind, hint: c.hint, updated_at: c.updated_at },
+      })
+      .run()
+  }
+  const deleteModelCredential = async (
+    orgId: string,
+    userId: string,
+    provider: string,
+  ): Promise<void> => {
+    await db
+      .delete(modelCredential)
+      .where(modelCredWhere(orgId, userId, provider))
+      .run()
+  }
+  const listModelCredentials = async (
+    orgId: string,
+    userId: string,
+  ): Promise<ModelCredentialRecord[]> =>
+    db
+      .select()
+      .from(modelCredential)
+      .where(and(eq(modelCredential.org_id, orgId), eq(modelCredential.user_id, userId)))
+      .all()
   const getSlackThreadLinkByThread = async (
     threadId: string,
   ): Promise<SlackThreadLinkRecord | null> =>
@@ -3217,6 +3266,10 @@ export function makeRepos(db: SqliteDb) {
     getSlackInstall,
     setSlackInstall,
     deleteSlackInstall,
+    getModelCredential,
+    setModelCredential,
+    deleteModelCredential,
+    listModelCredentials,
     getSlackThreadLinkByThread,
     getSlackThreadLinkByTs,
     setSlackThreadLink,

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -2545,6 +2545,8 @@ export function makeRepos(db: SqliteDb) {
       .values({ ...r, status: r.status ?? "queued" })
       .returning()
       .get()) as RunRecord
+  const getRun = async (id: string): Promise<RunRecord | null> =>
+    ((await db.select().from(run).where(eq(run.id, id)).get()) as RunRecord | undefined) ?? null
   const claimDueRuns = async (agentId: string, now: string, limit = 20): Promise<RunRecord[]> => {
     // The oldest queued runs due now for this agent, flipped to running under a row lock so
     // two executors never claim the same run. A null scheduled_for means "as soon as possible";
@@ -3336,6 +3338,7 @@ export function makeRepos(db: SqliteDb) {
     updateAutomation,
     deleteAutomation,
     createRun,
+    getRun,
     claimDueRuns,
     finishRun,
     listRuns,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -592,6 +592,27 @@ export const userNotificationPref = sqliteTable(
   (t) => [uniqueIndex("user_notification_pref_key").on(t.org_id, t.user_id)],
 )
 
+// A team member's OWN model-plan credential — their Claude/Codex plan token (or an API
+// key) — encrypted at rest (AES-GCM, lib/crypto, keyed by DERIVE_AUTH_SECRET), scoped
+// (org, user, provider) and used ONLY for that user's own agent runs. Never a shared
+// token: this is what replaces the single global model-credential env for hosted runs.
+// `secret` is the encrypted blob; `hint` is a safe label (e.g. last 4) for the UI.
+export const modelCredential = sqliteTable(
+  "model_credential",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    user_id: text("user_id").notNull(),
+    provider: text("provider").notNull(),
+    kind: text("kind").$type<"oauth" | "api_key">().notNull(),
+    secret: text("secret").notNull(),
+    hint: text("hint").notNull().default(""),
+    created_at: text("created_at").notNull().default(now),
+    updated_at: text("updated_at").notNull().default(now),
+  },
+  (t) => [uniqueIndex("model_credential_key").on(t.org_id, t.user_id, t.provider)],
+)
+
 // Derive comment thread ↔ the Slack message Derive posted for it (for two-way threading).
 export const slackThreadLink = sqliteTable(
   "slack_thread_link",
@@ -920,6 +941,7 @@ const TABLES = [
   folder,
   repoSource,
   orgSettings,
+  modelCredential,
   slackInstall,
   slackThreadLink,
   slackUserLink,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -229,6 +229,8 @@ export const run = sqliteTable("run", {
   automation_id: text("automation_id"),
   agent_id: text("agent_id").notNull(),
   reason: text("reason").notNull(),
+  // The initiating person (wallet key) — null for clock/event runs. See RunRecord.
+  initiated_by: text("initiated_by"),
   status: text("status").$type<RunStatus>().notNull(),
   scheduled_for: text("scheduled_for"),
   started_at: text("started_at"),

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -2301,7 +2301,9 @@ export function runStoreContract(
       // List returns only that user's rows.
       const u1 = await store.listModelCredentials(ORG, "u1")
       expect(u1.map((c) => c.provider).sort()).toEqual(["claude-code", "codex"])
-      expect((await store.listModelCredentials(ORG, "u2")).map((c) => c.provider)).toEqual(["codex"])
+      expect((await store.listModelCredentials(ORG, "u2")).map((c) => c.provider)).toEqual([
+        "codex",
+      ])
 
       // Delete is scoped: removing u1/codex leaves u1/claude-code and u2/codex.
       await store.deleteModelCredential(ORG, "u1", "codex")
@@ -2318,17 +2320,24 @@ export function runStoreContract(
         org_id: ORG,
         agent_id: agentId,
         reason: "manual:u1",
+        // First-class wallet key, round-tripped — never parsed out of `reason`.
+        initiated_by: "u1",
         scheduled_for: "2000-01-01T00:00:00.000Z",
       })
       expect(queued.status).toBe("queued")
-      // A future run is NOT due yet.
-      await store.createRun({
+      expect(queued.initiated_by).toBe("u1")
+      // getRun round-trips it; a clock run (no initiator) stays null; unknown id is null.
+      expect((await store.getRun(queued.id))?.initiated_by).toBe("u1")
+      expect(await store.getRun(uuid())).toBeNull()
+      // A future run is NOT due yet — and a clock run carries no initiator.
+      const clockRun = await store.createRun({
         id: uuid(),
         org_id: ORG,
         agent_id: agentId,
         reason: "schedule",
         scheduled_for: "2999-01-01T00:00:00.000Z",
       })
+      expect(clockRun.initiated_by).toBeNull()
 
       const now = "2100-01-01T00:00:00.000Z"
       const claimed = await store.claimDueRuns(agentId, now)

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -2272,6 +2272,44 @@ export function runStoreContract(
       expect(got.map((x) => x.id).sort()).toEqual([a.id, b.id].sort())
     })
 
+    it("model credentials: upsert, get, list per user, delete — all scoped (org, user, provider)", async () => {
+      const now = "2026-07-24T00:00:00.000Z"
+      const cred = (userId: string, provider: string, secret: string) => ({
+        id: uuid(),
+        org_id: ORG,
+        user_id: userId,
+        provider,
+        kind: "oauth" as const,
+        secret,
+        hint: secret.slice(-4),
+        created_at: now,
+        updated_at: now,
+      })
+      await store.setModelCredential(cred("u1", "codex", "enc-A"))
+      await store.setModelCredential(cred("u1", "claude-code", "enc-B"))
+      await store.setModelCredential(cred("u2", "codex", "enc-C"))
+
+      // Get is keyed (org, user, provider) — never leaks across users.
+      expect((await store.getModelCredential(ORG, "u1", "codex"))?.secret).toBe("enc-A")
+      expect((await store.getModelCredential(ORG, "u2", "codex"))?.secret).toBe("enc-C")
+      expect(await store.getModelCredential(ORG, "u1", "gemini")).toBeNull()
+
+      // Upsert replaces the secret for the same key, not a second row.
+      await store.setModelCredential(cred("u1", "codex", "enc-A2"))
+      expect((await store.getModelCredential(ORG, "u1", "codex"))?.secret).toBe("enc-A2")
+
+      // List returns only that user's rows.
+      const u1 = await store.listModelCredentials(ORG, "u1")
+      expect(u1.map((c) => c.provider).sort()).toEqual(["claude-code", "codex"])
+      expect((await store.listModelCredentials(ORG, "u2")).map((c) => c.provider)).toEqual(["codex"])
+
+      // Delete is scoped: removing u1/codex leaves u1/claude-code and u2/codex.
+      await store.deleteModelCredential(ORG, "u1", "codex")
+      expect(await store.getModelCredential(ORG, "u1", "codex")).toBeNull()
+      expect((await store.getModelCredential(ORG, "u1", "claude-code"))?.secret).toBe("enc-B")
+      expect((await store.getModelCredential(ORG, "u2", "codex"))?.secret).toBe("enc-C")
+    })
+
     it("queue + ledger: enqueue → claim (running) → finish; a second claim gets nothing", async () => {
       const agentId = uuid()
       // A queued run due in the past.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   shell-quote: '>=1.9.0'
   undici: ^7.28.0
   ws: ^8.21.0
+  postcss: '>=8.5.18'
 
 patchedDependencies:
   '@better-auth/oauth-provider@1.6.19':
@@ -54,10 +55,10 @@ importers:
     dependencies:
       '@better-auth/oauth-provider':
         specifier: 1.6.19
-        version: 1.6.19(patch_hash=da96def66da8f71821804f1d1e269964333ef0d4a0c4a703ee8c306f4f49e981)(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.6(zod@4.4.3))
+        version: 1.6.19(patch_hash=da96def66da8f71821804f1d1e269964333ef0d4a0c4a703ee8c306f4f49e981)(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.7(zod@4.4.3))
       '@better-auth/passkey':
         specifier: 1.6.19
-        version: 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.6(zod@4.4.3))(nanostores@1.3.0)
+        version: 1.6.19(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.7(zod@4.4.3))(nanostores@1.3.0)
       '@cloudflare/puppeteer':
         specifier: ^1.0.0
         version: 1.1.0
@@ -89,8 +90,8 @@ importers:
         specifier: ^0.11.9
         version: 0.11.9(hono@4.12.25)
       better-auth:
-        specifier: ^1.6.19
-        version: 1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
+        specifier: ^1.6.22
+        version: 1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
       better-sqlite3:
         specifier: ^12.11.1
         version: 12.11.1
@@ -185,7 +186,7 @@ importers:
     dependencies:
       '@better-auth/passkey':
         specifier: 1.6.19
-        version: 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.6(zod@3.25.76))(nanostores@1.3.0)
+        version: 1.6.19(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.7(zod@3.25.76))(nanostores@1.3.0)
       '@codemirror/commands':
         specifier: ^6.10.3
         version: 6.10.3
@@ -232,8 +233,8 @@ importers:
         specifier: ^3.14.2
         version: 3.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       better-auth:
-        specifier: 1.6.19
-        version: 1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
+        specifier: 1.6.22
+        version: 1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -330,7 +331,7 @@ importers:
         version: 7.13.0(typescript@6.0.3)
       react-scan:
         specifier: ^0.5.7
-        version: 0.5.7(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.1)
+        version: 0.5.7(@types/react@19.2.17)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.1)
       rollup-plugin-visualizer:
         specifier: ^7.0.1
         version: 7.0.1(rolldown@1.0.3)(rollup@4.61.1)
@@ -563,6 +564,10 @@ packages:
     peerDependencies:
       zod: ^3.23.8
 
+  '@alcalzone/ansi-tokenize@0.3.0':
+    resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
+    engines: {node: '>=18'}
+
   '@asteasolutions/zod-to-openapi@8.5.0':
     resolution: {integrity: sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==}
     peerDependencies:
@@ -705,14 +710,14 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@better-auth/core@1.6.19':
-    resolution: {integrity: sha512-ddE3Y9MoQ8t32QSO5Y8mV7pmnDAv5LdJjX1SPWUH6JUUmuOc7YEy3B5JfXZIJbRaXFdnAitN7pHPVa5u/dYAZA==}
+  '@better-auth/core@1.6.22':
+    resolution: {integrity: sha512-aFH/5nzmR501jAJPKjJfiVg4BrkcjVCqq9WS9JnhTruE/2PIWopv1QGMiRIRqxXaPbHczri7cqRdhep3Lg5PMw==}
     peerDependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@cloudflare/workers-types': '>=4'
       '@opentelemetry/api': ^1.9.0
-      better-call: 1.3.6
+      better-call: 1.3.7
       jose: ^6.1.0
       kysely: ^0.28.5 || ^0.29.0
       nanostores: ^1.0.1
@@ -722,36 +727,36 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@better-auth/drizzle-adapter@1.6.19':
-    resolution: {integrity: sha512-57C9ePorPmIEez6dHuQMz3hCTkYim0lfVRIoRtX7PiVfiRFB2bjXseQwrCJfQmkgMFlkp1s/c9nKgAjc2EvAIg==}
+  '@better-auth/drizzle-adapter@1.6.22':
+    resolution: {integrity: sha512-uNa9qH53CfxBmuKP8kbLWxY90oIRwUPn5BcHhO+szK05e2yh6EYwSNNivDSqV3YG5HPfjtPHulklInjq1wtm3w==}
     peerDependencies:
-      '@better-auth/core': ^1.6.19
+      '@better-auth/core': ^1.6.22
       '@better-auth/utils': 0.4.2
       drizzle-orm: 0.45.2
     peerDependenciesMeta:
       drizzle-orm:
         optional: true
 
-  '@better-auth/kysely-adapter@1.6.19':
-    resolution: {integrity: sha512-DlmvllEd0nv8JL+plX3JB3WTmqDFnGFOmjmIiUDHo8R3PTAvC0ZaJq3Jk+LQLN5PyVQSUzXZKtvTQYaqRHzBaw==}
+  '@better-auth/kysely-adapter@1.6.22':
+    resolution: {integrity: sha512-4k/07lPRizlQi+B+uOE5CwTfH3w+Lq8ZDX1nDN1+e+glRVKAIfHoLvC9cfAVcCbio3DDrl0RTbwjLwjEhG0LxA==}
     peerDependencies:
-      '@better-auth/core': ^1.6.19
+      '@better-auth/core': ^1.6.22
       '@better-auth/utils': 0.4.2
       kysely: ^0.28.17 || ^0.29.0
     peerDependenciesMeta:
       kysely:
         optional: true
 
-  '@better-auth/memory-adapter@1.6.19':
-    resolution: {integrity: sha512-cZ8iLRG/T8Oi/CqE9FTHj3z8pIOqRsINi50trWxPNwyY/Eyb7YCljrBi0PuqgIdyVs7BWfrrtEYTpO4ddfuwEw==}
+  '@better-auth/memory-adapter@1.6.22':
+    resolution: {integrity: sha512-rbepe/gHhWs0aF4fAu6+l+wNPJxT9XN4U+Hqa1Y/5HhjtT9y5evo3INrSWlkIOymsMaQ0cBPrSL5pm9Z195hcA==}
     peerDependencies:
-      '@better-auth/core': ^1.6.19
+      '@better-auth/core': ^1.6.22
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.19':
-    resolution: {integrity: sha512-8AReXqhMGiGQIPEpGbmAhh+R4g70TsAVvzwdd6Aj4q+LTSwd3tqC89TFJ4eX8KSplxm9PFBZ6g6gsRmDd7urQg==}
+  '@better-auth/mongo-adapter@1.6.22':
+    resolution: {integrity: sha512-OYnfySHlVkIx7y6XNBsCHjKhl6IYGprRkFwifc/TAuPBVjoRKhLKRAXuzMdWTQYFt4FYb6holbhjNUrXxPIWcw==}
     peerDependencies:
-      '@better-auth/core': ^1.6.19
+      '@better-auth/core': ^1.6.22
       '@better-auth/utils': 0.4.2
       mongodb: ^6.0.0 || ^7.0.0
     peerDependenciesMeta:
@@ -777,10 +782,10 @@ packages:
       better-call: 1.3.6
       nanostores: ^1.0.1
 
-  '@better-auth/prisma-adapter@1.6.19':
-    resolution: {integrity: sha512-pXZBhR7/bzJb48IUHlGMyz9SM9h1OCO5GIIuHEllJYt8MKgrjtsnXfUkwZh6pAUEIp3WxBEYMMK96bfkqHiWEg==}
+  '@better-auth/prisma-adapter@1.6.22':
+    resolution: {integrity: sha512-I6lWQwLva732V600u5dLM2kRcQ94pRZOVVfZ87+Ow9RBxMUnV+I+YQ5h2yggdN2tmsmITacZTy1DSZbDxGu0LQ==}
     peerDependencies:
-      '@better-auth/core': ^1.6.19
+      '@better-auth/core': ^1.6.22
       '@better-auth/utils': 0.4.2
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
       prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -790,10 +795,10 @@ packages:
       prisma:
         optional: true
 
-  '@better-auth/telemetry@1.6.19':
-    resolution: {integrity: sha512-bBaB6SMIsrD3WutDdm5YQ1bQyinANTimHD8RtpLWhNh/jIXvzgwVVCrDFqA256vcGC/ZRCydmtW8ZrUqNMW9Og==}
+  '@better-auth/telemetry@1.6.22':
+    resolution: {integrity: sha512-glq/oEk9qP+zGh9k/WUH5+pwvBCMolNNhaAVBCtYQrkADFee2gP3VoPs1YeO9coNuOmBhc+AYSIHs+fL9DoJnw==}
     peerDependencies:
-      '@better-auth/core': ^1.6.19
+      '@better-auth/core': ^1.6.22
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -964,14 +969,17 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/core@1.11.1':
-    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -1589,8 +1597,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@oxc-parser/binding-android-arm-eabi@0.138.0':
-    resolution: {integrity: sha512-hSYAD+F9W2Qh8SETMqBsQRx6YHvB4z+i/i36shlC7tfdZQauMs4vf3G/EQwKOkNlN7rkTiKINvsNmQb9q2MWcQ==}
+  '@oxc-parser/binding-android-arm-eabi@0.141.0':
+    resolution: {integrity: sha512-jk7086MFvR/T4DG9IY7MKBVt1PMxvSZoz/TvnifodvS0pjghVwJHRttnAExhlwdMOgHv1TmLdENnbNpYk2zjvA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
@@ -1601,8 +1609,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@oxc-parser/binding-android-arm64@0.138.0':
-    resolution: {integrity: sha512-Ns5LLTp8cVyP8DsYqD482h0HE84xiGYRgtm7g4LtTinq209NAiMF768e/8r2NHaa0UMirS5mrT1m1VwiVmBi4Q==}
+  '@oxc-parser/binding-android-arm64@0.141.0':
+    resolution: {integrity: sha512-a4XDQ27ZT7e7zwAlxJDTiCA7IBGWDuy2+MhFq85Of7XlBSmpkfcBFml11q0Zx6f7RMuI0B4xCtt2ytBS4yOptg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -1613,8 +1621,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-arm64@0.138.0':
-    resolution: {integrity: sha512-Yka0m4YhKUHBIZufafSLAeO+DUrfHPtNXBlZSj7DxshquIl41x/a+i/MbRnbOy8heuLiYU1STa6h0FAAzT7Pbw==}
+  '@oxc-parser/binding-darwin-arm64@0.141.0':
+    resolution: {integrity: sha512-m/kVk6rzYmBeHYnz+1Y5fod00AVTTxMbC71azFfm/zjx1j9XxwKtA0+VfkKuVMC8rbghb9TtfevnuWZa9OuPEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -1625,8 +1633,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-x64@0.138.0':
-    resolution: {integrity: sha512-MWLUZZzmNRUqTWueZF27ncreaZ1wZ0gboWL2QMPxRQA2xgOmBPlGg2H9pAKJSPBlwEHcWa9TdWRiehAS+yls8w==}
+  '@oxc-parser/binding-darwin-x64@0.141.0':
+    resolution: {integrity: sha512-o0X+6KZlfucWU/v5oKRQPwdFXsXAjW8jmpo/Gpw/qyKsbKtlfkHoeH9Bjp/m13TwjewvJnCkwF0DWzgpC4HjTQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -1637,8 +1645,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-parser/binding-freebsd-x64@0.138.0':
-    resolution: {integrity: sha512-Vae5tzsrzZ/lCDVCZUMi/vzSiiHEgcOEfsyIfWOHmjZ2ji+gT+n96T757yX5/f7/7JIJuiannAHJKV5ARaF6ng==}
+  '@oxc-parser/binding-freebsd-x64@0.141.0':
+    resolution: {integrity: sha512-W5KbTnNkTMMMylqj6dYqnsXvkmESVPodPKYLJ5zdzIPdl9fUJtolkpUeSzYEbGGYB4a4A4avl3EePnZ/wLIdJg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -1649,8 +1657,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.138.0':
-    resolution: {integrity: sha512-qkU8wv5mYexrCw0X4DHFgxGbRScwGLIIKUkHXU7xXEiLoMnQzELak2gujxfa9GFrlEgPjbyLUDFHWm67Zs38ng==}
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.141.0':
+    resolution: {integrity: sha512-g3dtbJa8zeOGK36Sr9cQavsdi5H/ie2hVjrSjIxsNAR1qZA40ZYVXnfdfoMAlq8CmB9qFL1yhsSCUHeNmdmt8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -1661,8 +1669,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.138.0':
-    resolution: {integrity: sha512-3HgULIvoDV7h2ZfVYzxQwOSOJnAjMwYmyUBzndNuLRGgBNI549ED0P6AGmN9y2TnSvrwJ+Q8zqdxqssMnGXitA==}
+  '@oxc-parser/binding-linux-arm-musleabihf@0.141.0':
+    resolution: {integrity: sha512-e6hwQqd+3lvP13G2jxvFpoA7dzHcFLN+Mq47JCVMtdNHbbyBRo756JCtbbJH6ca8inTfyqZoqBmS3vhQlzAK2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -1674,8 +1682,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.138.0':
-    resolution: {integrity: sha512-pIonbH2p0KLCwz4CNPCi0xGqci4numpMQDCLJwLfsrEky7NUuByKDFhCjzE0E7vR3aj/lBjyMoTskHBo/qSg8g==}
+  '@oxc-parser/binding-linux-arm64-gnu@0.141.0':
+    resolution: {integrity: sha512-vXz2BLAuypA+4MLyBg94pzEo6THVnzYnCtAjXoihIIQo0t2pnp/AmW+SH1EI+4VbuJnC//KplIJ5yyaCGua4jA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -1688,8 +1696,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-arm64-musl@0.138.0':
-    resolution: {integrity: sha512-cT5L1Xz/5m6Ga1hD3922gLc+fePOauJZJdApPTI/2Vu0EmYo62uHG9V5Dq65hhgU9TW10oDi2840y9cGdd7BIg==}
+  '@oxc-parser/binding-linux-arm64-musl@0.141.0':
+    resolution: {integrity: sha512-jMkS/EztNW34HKsXIaT/SoHcmtocq/vWhwFOVduF9kduuuRIVwfwQ6uxzIO+qPKSXdd2TXt54of0BJ2zFMXnmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -1702,8 +1710,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-ppc64-gnu@0.138.0':
-    resolution: {integrity: sha512-hKy/vvejKk3LNE/FsRbekWejLa046//TnLWtSo7ur29NIsNbSIvnOVYIirSVC7fsd6NO8UFzwDdcoZfCyBvSBA==}
+  '@oxc-parser/binding-linux-ppc64-gnu@0.141.0':
+    resolution: {integrity: sha512-vo+MR+n3zQJ6Mq92hiP084NZcgDv5iJlVR02gMf28neMvVT1tKVm7VeiW/DxhdqOi3QLeaXIk9cUcLL1qrkngw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -1716,8 +1724,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.138.0':
-    resolution: {integrity: sha512-bh6tjNGq0v0b9GAMu0pTv/YpTqepCFy0TIOtQHm8+41fZwLXTaB6xiEWVUSarNCXqc5kyzYcH6EOfwW1sJxJOw==}
+  '@oxc-parser/binding-linux-riscv64-gnu@0.141.0':
+    resolution: {integrity: sha512-oh80w+7RuiO5gBp9Jnoa/H8Qlt3JsHL2MkW+0dwEdlDMdslVZX/YsekSK6EeyEenY66/mhCfypsNATQ7Ph3qlQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -1730,8 +1738,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-riscv64-musl@0.138.0':
-    resolution: {integrity: sha512-HhOkddcClSTtTxY10f/mACblKcQdxWy4lYYwX12G23j+S5eiJ5y1kpo1r7kKng+2bdnCBO+lCDWOVVc9kVl9+g==}
+  '@oxc-parser/binding-linux-riscv64-musl@0.141.0':
+    resolution: {integrity: sha512-LOyEmFA8sCnYbEXP1+iQvCC/P1YXHMA/t6x1Ksp0Y9VwhLFsiBJFzV1zIxrOIE2LKaGGhDjQ29xq9cbq6omDXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -1744,8 +1752,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.138.0':
-    resolution: {integrity: sha512-5mi+wtbeJiEa4waGG88EcEGgJBBNJdDeIcayPPcrLNMXbCrgdtbb80q0Nrat7A8NglLUVzhuTAAp7K6PjmUO8Q==}
+  '@oxc-parser/binding-linux-s390x-gnu@0.141.0':
+    resolution: {integrity: sha512-3wnwk/l1CvszVE5TJR1wSl/zSEfydRqrNhn6s7Vr9IzSJpUQIroqVsIoPARHRFA+FQwkxAFDAHDAasa7v8OobQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
@@ -1758,8 +1766,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-x64-gnu@0.138.0':
-    resolution: {integrity: sha512-ckbq3AMI7lI8AhQtE8KdqYRmzmzwKfCU12QN/PBKXO72PfWdvvZQN0hFShDX/XRNsPqjddLmvXaQMT3zfYtNlw==}
+  '@oxc-parser/binding-linux-x64-gnu@0.141.0':
+    resolution: {integrity: sha512-qtyQVAAebFq57B2tifTlel3TgGqUtsYNI/e+p6aya9rN9lOZVTDvr215fGYSA9XWooxzMxDiVxkBLk2jQHbsOQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1772,8 +1780,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-x64-musl@0.138.0':
-    resolution: {integrity: sha512-JrCOzHO9BYEs5Xz5JHYBxSc/hYKxfXUj5QQb64sERSbkQot6+KEgMTOR2C9hLrhaqOui65OYcFyTTS+YxXDtnA==}
+  '@oxc-parser/binding-linux-x64-musl@0.141.0':
+    resolution: {integrity: sha512-SkGV1nKw40roEc94pv5EaaeH2ay14G6+roe8Q0wIUC1LcEKxzKW921h7+ZuZX0D3q2Mb/7aSFmxEVqnko3lPRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1785,8 +1793,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxc-parser/binding-openharmony-arm64@0.138.0':
-    resolution: {integrity: sha512-eASMMfOOIfLHkWJRPSu8llByvVRM+c1M/lh18KjsjELM3y10+7B5iBbbrht9LdtsJXQ+mRuP/lJ7UWe3Ok3ehw==}
+  '@oxc-parser/binding-openharmony-arm64@0.141.0':
+    resolution: {integrity: sha512-cVgDM7n8QziQqOaP5hNgUYfMG7S/ZeuPxFWXnnHRv7rh025COk0rfQ6eEdKG3j/GaUuyvNZN4ifF1J8KmuXLLA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -1796,8 +1804,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@oxc-parser/binding-wasm32-wasi@0.138.0':
-    resolution: {integrity: sha512-BnTCO87Iwc57NufXS7vcrkrmpN+daeCeYr1+/xgPT6HjwNs0lBmJYeFrcOs4WkNN8yscdd6Rc4FxWh3+59hAFw==}
+  '@oxc-parser/binding-wasm32-wasi@0.141.0':
+    resolution: {integrity: sha512-HggH++Fkn3OilBn+bs3jpgIFQa34oMAyUUHy0vpGum+gt1Eb5nyLc8dNU/RAPSw6lsLrx7ncKtHSZE+3Sp0l2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
@@ -1807,8 +1815,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.138.0':
-    resolution: {integrity: sha512-+Zi47boD2wKNL0hOA47Vkwk6njMZ8sOsr4Geu/56EUtlooDh9crNOU41U6bXGS0UjC4Y72HtRA1iuB6qx1ARUw==}
+  '@oxc-parser/binding-win32-arm64-msvc@0.141.0':
+    resolution: {integrity: sha512-KLSEH9GwgbrqbJOjtGHt9STw96s+78yDzp7IDN8Lno+7Ut9sNBfZ4jYZIz4mD50qmWUjoOI7i9I6UENbhNbMZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -1819,8 +1827,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@oxc-parser/binding-win32-ia32-msvc@0.138.0':
-    resolution: {integrity: sha512-SYcV674Wi2WuoBefUFgf0PBMNlZe5IF0YZ0TnP7DK+EusMVpEWq6iz+7r64svjAb7vjthzlas0FUCSlz8YkqYg==}
+  '@oxc-parser/binding-win32-ia32-msvc@0.141.0':
+    resolution: {integrity: sha512-9UVWUOOCI/1YkiSSNjg2zyBJYM9E/t1A/8GNobd48JDn/fQ6mzxcVO3H08jb3rAaW/B1VBf8eCORTvSsO9T08g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
@@ -1831,8 +1839,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-x64-msvc@0.138.0':
-    resolution: {integrity: sha512-QZplnCxS4vPe4StAVBtvD2bW3pELlidf0Ek6iQ/HHiCjbEtrs5pFZZfLAoPhKLJyDzyxoGAdic9bSIYrJYTZcg==}
+  '@oxc-parser/binding-win32-x64-msvc@0.141.0':
+    resolution: {integrity: sha512-HI/wsvbWT5RHHw5c37D0fEgeTd8/1Q4OJs5jUmEBc17VZFG6SsCIe4barq7NsAPPks/JW+3ayi3Rp+PQI5h4Kg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1840,16 +1848,16 @@ packages:
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
-  '@oxc-project/types@0.138.0':
-    resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
+  '@oxc-project/types@0.141.0':
+    resolution: {integrity: sha512-S4as7z0j0xQkXcJlyY5ehntwK8/wRkQb9Cyqw+J/N2rkWGQGK0SxD6X6DhQTc7qsxVTBxXbxZtBJh3mr3PtIzQ==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.20.0':
     resolution: {integrity: sha512-IjfWOXRgJFNdORDl+Uf1aibNgZY2guOD3zmOhx1BGVb/MIiqlFTdmjpQNplSN58lhWehnX4UNqC3QwpUo8pjJg==}
     cpu: [arm]
     os: [android]
 
-  '@oxc-resolver/binding-android-arm-eabi@11.23.0':
-    resolution: {integrity: sha512-8IJyWRLVAyhTfe9/TIEbQqSQnl5rUqYJrUOS6Dkr+Mq9FGHMxDGeiEmwkBqCvDP5KckpPh/GYSgbag66O6JsCw==}
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
+    resolution: {integrity: sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==}
     cpu: [arm]
     os: [android]
 
@@ -1858,8 +1866,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@oxc-resolver/binding-android-arm64@11.23.0':
-    resolution: {integrity: sha512-pprVojnNhHxupwTT2gdeUlkxll6XEvWWBk3oVicOSNVWQC99OBnDhMQDoirqnzrE1bScQSMS2JgPpqdlrhz/Fg==}
+  '@oxc-resolver/binding-android-arm64@11.24.2':
+    resolution: {integrity: sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==}
     cpu: [arm64]
     os: [android]
 
@@ -1868,8 +1876,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-resolver/binding-darwin-arm64@11.23.0':
-    resolution: {integrity: sha512-mbIrWIMAJeytyee36OyUP5XH92TP7FaKaQ2m5AjokKy7STgjrhRt7SMXqpqLjhGm6Xn721Xmsg6H3Rtd9YQETw==}
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
+    resolution: {integrity: sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==}
     cpu: [arm64]
     os: [darwin]
 
@@ -1878,8 +1886,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-resolver/binding-darwin-x64@11.23.0':
-    resolution: {integrity: sha512-UnIphmZ1LazUCr9DXWaKYWtKDefPMbgLsywaoYxRqVCNHhq4MM6d2q1Nz1i9Vzxt5i+cE2nRUYpAUHr/lijNYA==}
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
+    resolution: {integrity: sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==}
     cpu: [x64]
     os: [darwin]
 
@@ -1888,8 +1896,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-resolver/binding-freebsd-x64@11.23.0':
-    resolution: {integrity: sha512-aaZ/cSEYFkSxgS2hOrobT6RQcsWNviOX8dW6CEkVx2/UYkAf9MeHbjl3W0usWV53rVV//ndBdn2nb1y7jsu4lw==}
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
+    resolution: {integrity: sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==}
     cpu: [x64]
     os: [freebsd]
 
@@ -1898,8 +1906,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxc-resolver/binding-linux-arm-gnueabihf@11.23.0':
-    resolution: {integrity: sha512-IoJLvO5SjLSVMaq83BNTrPCb1FppvoJc1IhZ5CoUVl3PykUBku7D+LK1j0GSurhJcIc6zfjghsvaZNpq5ev6Mg==}
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
+    resolution: {integrity: sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==}
     cpu: [arm]
     os: [linux]
 
@@ -1908,8 +1916,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxc-resolver/binding-linux-arm-musleabihf@11.23.0':
-    resolution: {integrity: sha512-vskFpwg44T/LFsfjSCnVZ5ygcuqzPC1yUzVEiKa8BgHAQz0+QLQQW3EGWLPVi8EXFghzjR4EtgPBtOhCjU4jdw==}
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
+    resolution: {integrity: sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==}
     cpu: [arm]
     os: [linux]
 
@@ -1919,8 +1927,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-resolver/binding-linux-arm64-gnu@11.23.0':
-    resolution: {integrity: sha512-//TcHVhrChyw5RYtgts6WO7KcWq9387c1Z5Zvhqpk/ktAbyaRYgBZrpSY1GDCFq50ASt6B6jhh+JxB1rB45IAg==}
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
+    resolution: {integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -1931,8 +1939,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxc-resolver/binding-linux-arm64-musl@11.23.0':
-    resolution: {integrity: sha512-ZFqlwiTf7CXLLSGyAR9tYiO33LiaeIEXW+xm42d8mnUGpDgPltyrCGYtQezyMMEXvjhOgCz1X+i7sbDTJEx+bg==}
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
+    resolution: {integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
@@ -1943,8 +1951,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-resolver/binding-linux-ppc64-gnu@11.23.0':
-    resolution: {integrity: sha512-oZ5LeN5+H1R19dRjTAxKrxQguH+AsemHcnthEfFxf4OjmBSty2doHLeSmMunKy3zpTHJQ3lh3Af+dNS+W6dYeA==}
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
+    resolution: {integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -1955,8 +1963,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-resolver/binding-linux-riscv64-gnu@11.23.0':
-    resolution: {integrity: sha512-O4ciFDyX5ebQd0qkb1bjAIg8IEfiLT03GbSeylwlwlUMK9KwBWaALwrxSbc0Msaz4U6iPj+T9eRXpD5mxBfmvA==}
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
+    resolution: {integrity: sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -1967,8 +1975,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxc-resolver/binding-linux-riscv64-musl@11.23.0':
-    resolution: {integrity: sha512-P3o8Y9kISYjcxadmbO+94ThRwLhwGuDAbA7dcdd4+YLpfeF+mmobz8fXf4NmSdfSqjyRSkceJDBRZha9NVYkiQ==}
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
+    resolution: {integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
@@ -1979,8 +1987,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-resolver/binding-linux-s390x-gnu@11.23.0':
-    resolution: {integrity: sha512-oj03m1E3RmTFczKhcKJDzHaEDKJnPIsDcQFVxBJsSdXGSuIPdt5TvcM332FfMQgzI6yDJqyl4InrnFfXrmUTKQ==}
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
+    resolution: {integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -1991,8 +1999,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-resolver/binding-linux-x64-gnu@11.23.0':
-    resolution: {integrity: sha512-BqJxbSC8FdP7mSuSpRePTGHm0hXWV+dfz//f7SjsteZncLaBgWTBmi/OZNv7sX6CyG/Pt/eJkPorP+DkMOhMwQ==}
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
+    resolution: {integrity: sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -2003,8 +2011,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxc-resolver/binding-linux-x64-musl@11.23.0':
-    resolution: {integrity: sha512-utmw+VmUrW4K8LI5/6jhg4aGYKJHOIjQ9syYOOA6pF3w7haKu4r4enTe2U0C04/HbUvkq/Zif43xFsKW1Pnq9w==}
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
+    resolution: {integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -2014,8 +2022,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxc-resolver/binding-openharmony-arm64@11.23.0':
-    resolution: {integrity: sha512-V6lbRrthHa4TbvsLjPtg+EkXT1tRY+s4I8rYLXUfiHlZzGx3sLv1EH9CEOOevjvUYHLsbe/gqCIc73XnQfPb9A==}
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
+    resolution: {integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==}
     cpu: [arm64]
     os: [openharmony]
 
@@ -2024,8 +2032,8 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@oxc-resolver/binding-wasm32-wasi@11.23.0':
-    resolution: {integrity: sha512-gRoOxQPdnAmIAjxcuQNBxfihvx+wjTaQM/9/eP12xwnGNawOG/+Zz9RHN4WNSxT45b5CrscK4NB8aPh+oZQXAQ==}
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
+    resolution: {integrity: sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
@@ -2034,8 +2042,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-resolver/binding-win32-arm64-msvc@11.23.0':
-    resolution: {integrity: sha512-CgTGMYsJVe1eUiCdJTpGw21svXw79ITsemN1h0hcNkiswasDbN5MoibSLY+gRMWP5syfEz5iffrjZnwEP8xeUA==}
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
+    resolution: {integrity: sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==}
     cpu: [arm64]
     os: [win32]
 
@@ -2044,129 +2052,129 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxc-resolver/binding-win32-x64-msvc@11.23.0':
-    resolution: {integrity: sha512-gUGJpr+Rn6zMxm5juApV0K3U845i8t47o8k+rbO0BHbi4PoJIfSPeQmrE2dgohQm2g5k6iviNFyXCGqvmaYUpw==}
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    resolution: {integrity: sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==}
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.66.0':
-    resolution: {integrity: sha512-f7kq8N51T4phpzqfBpA2qaVTI/KrkCmNwaj3t/97I/WLTDI+UhlP5GL9eER+zVxBhtlx5rKXWByJU1/zDAvyaw==}
+  '@oxlint/binding-android-arm-eabi@1.74.0':
+    resolution: {integrity: sha512-+gHd12muVI9ZLBaWLPkHt3Fj7jihFjgQ1MGtBaRL8vWrWrI0P7dLUty/cHrHS0oqPYIRgQUJsPu2CExQuMcwNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.66.0':
-    resolution: {integrity: sha512-xu6QO71tdDS9mjmLZ3AqhtaVHBvdmsOKkYnReNNDgh+XiwnsipeQOIxbiYOOO0iAXycJ+GK0wdMSZP/2j/AmSg==}
+  '@oxlint/binding-android-arm64@1.74.0':
+    resolution: {integrity: sha512-xjKdoMB+H+RCOByv/7l7nfIGW9mlOisqYdcyC75UqYuQecLpReAeEYUf2CNeDEI3KtmUgxpRw/+c63y4AeF/Bw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.66.0':
-    resolution: {integrity: sha512-HZ24VimSOC7mxuEA99e0H2FS0C1yO3+iW13jPRAk+e2njsUs3QeAXsafCDyaIrV/MirdOVez+etQNQsJE43zNQ==}
+  '@oxlint/binding-darwin-arm64@1.74.0':
+    resolution: {integrity: sha512-iUK7wvc6sejMKsC+Pt67mntoF5weFcyEunhZfLJceU6gL419mexz5wBkSx/EnkFBExMLNtOi9fnDSc5xfK0IzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.66.0':
-    resolution: {integrity: sha512-awhj8ZvJrrRSnXj7V++rpZvTmnl99L6mi0B7gg7Cp7BN6cKpzuI481bHNLvXGA9GB1/oEgA3ponuyoAc6Md12A==}
+  '@oxlint/binding-darwin-x64@1.74.0':
+    resolution: {integrity: sha512-ggKc/tn5SJ1u2yG2izC6VKODfYKV8MQ2AicJlNzOjuyrC29udvOef6/JzK2r32xqCnBDLFouR1VCkjzEI0/N9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.66.0':
-    resolution: {integrity: sha512-KQF0oVV21/FjIqkRuL8Q1vh8ECsE5+ocdH5tcqTQ4ZnYuDVoYibQUNfqBjQaUsP6UIIda5Y75Wpm5p4RgQWiWw==}
+  '@oxlint/binding-freebsd-x64@1.74.0':
+    resolution: {integrity: sha512-u++dH/43jy9hTLbneaWlS0gla/Bp1JdwJ2zgevCl8nDFUh6qRCGMxcL0f0lb7By3A9p/LfFr+7cG4HU1hG856g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.66.0':
-    resolution: {integrity: sha512-9u1rgwZSEXWb30vbFZzQ78HVXBo0WCKNwJ3a2InRUTNMRng+PUDIoSFmA+m4HdUfBaIqftShq8J8qHc+eE/Vig==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.74.0':
+    resolution: {integrity: sha512-Sj1zmtFDVTPeIbIz4ZfcXAbFHqCmKCXdCUlAJzvTF7I20NTH1RDpoF2PhkqNODutJzVhJYmm3oz0GwgY+tvE2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.66.0':
-    resolution: {integrity: sha512-Ynot2HR1bHxUaNWoC280MVTDfZuaWuP3XfSMRDhyuZrVjhzoaBCVFlw8h8qeZjWKVUBhPWFIxB7AQTlK8Z2WWg==}
+  '@oxlint/binding-linux-arm-musleabihf@1.74.0':
+    resolution: {integrity: sha512-//PKyQb/tQXcHArx2f7z+oVI/eMS2Jpv+edNuAtOrgIhWdGcpHxogveAxzmF2rpH1AIHp4Hq04RF/rgJdiICnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.66.0':
-    resolution: {integrity: sha512-xCbgzciGgo+A4aQZEknsNrNiIwY7sU5SfRuMmRjPIvZAgdF34cIHiKvwOsS5XRLjlTVSFwitmq6YclTtHTfU+g==}
+  '@oxlint/binding-linux-arm64-gnu@1.74.0':
+    resolution: {integrity: sha512-/k1Me+aX2tjuH10K62mLS0y8cLkJBHX6Ce0xPK+eWeel4bSdEGZ8dv4+hYMzg0GrSmjwy4yAYsDPeEeKBft/2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-arm64-musl@1.66.0':
-    resolution: {integrity: sha512-hmo+ZB/lHkR1HdDmnziNpzSLmulnUSu10VEqX2Yex7OwvoBAbjJQLvy4gIBRV3AAwWnCvAxKp5Nv1GE6LU1QMg==}
+  '@oxlint/binding-linux-arm64-musl@1.74.0':
+    resolution: {integrity: sha512-3tFSjBxc5D8/zvjEuLvOqcA8ZXKD0+6NuaVO/edeamNc49MoAsbfaC9s1UiwODwgF6slGaF8yJA2TPkukd77tg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.66.0':
-    resolution: {integrity: sha512-2Invd4Uyy81mVooQC5FBtfxSNrvcX1OxbMlVQ6M2erRrNI2awFYF26YNW2yFxdVFZ4ffNOWKghtMjhnUPsXsVA==}
+  '@oxlint/binding-linux-ppc64-gnu@1.74.0':
+    resolution: {integrity: sha512-9QggtPkSPXOCTu8Szis7auOK/sC7KdQaN+/TujP7YVVhzCAOhgdRfgv8uEz0r2tk5xdgus5rLYUrCDoZNtiRUw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.66.0':
-    resolution: {integrity: sha512-s0iXPDQVdgayE3RGa/N2DZF7tjgg0TwEtD1sGoDxqPDGrIXgo45H0yHknT0f9A0yteASsweYZtDyTuVlM4aSag==}
+  '@oxlint/binding-linux-riscv64-gnu@1.74.0':
+    resolution: {integrity: sha512-VM5VPUJ4DJIWiK+AZn8FScUqMr6OFrCAYybMYjEEi7W13ParI64MByiXTkKMqZpBmvQ9zxl9Ebq2VUOiZRJYUg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.66.0':
-    resolution: {integrity: sha512-OekL4XFiu7RPK0JIZi8VeHgtIXPREf42t8Cy/rKEsC+P3gcqDgNAAGiyuUOpdbG4wwbfue1q4CHcCO7spSve6w==}
+  '@oxlint/binding-linux-riscv64-musl@1.74.0':
+    resolution: {integrity: sha512-SaDY1gh9rOA592J54g+gu5hkOFFQBZsMmIYHs+NRHG+Uq0OxtuuCXMWQ3vu1830Eugv5uMXyjG+bv2Z9y4IXjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.66.0':
-    resolution: {integrity: sha512-Ga1D0kj1SFslm34ThA/BdkUlyAYEnTsXyRC4pF0C5agZSwtGdHYWMTQWemUfBGp4RCG4QWXgdO+HmmmKqOtlBg==}
+  '@oxlint/binding-linux-s390x-gnu@1.74.0':
+    resolution: {integrity: sha512-ZATQeHZCyr6MbDveg0obD5sxLHFOghtOdC5jwVwYlvFWqtFOxctgFEG6Ef/64hYvZrWyhyCckB10AelqLopeDA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-gnu@1.66.0':
-    resolution: {integrity: sha512-p5jfP1wUZe/IC3qpQO84n9DRnf9g3lKRtLBlQq23ykyrDglHcVx7sWmVTlPuU6SBw8mNnPzyOn022G3XZHnlww==}
+  '@oxlint/binding-linux-x64-gnu@1.74.0':
+    resolution: {integrity: sha512-+aIvJyrdeD7LwCQ2WYLMUWNmnbeDRSPb40aBYtPjD9+PTqUwgJnk+HK5yLfSMeqXrMrDhE9uTmtt2y50tvjhHw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.66.0':
-    resolution: {integrity: sha512-vUB/sYlYZorDL1ZD+o9mRv7zbsykrrFRtmgS6R8musZqLtrPRQn1gc1eGpuX+sfdccz42STl/AqldY6XRb2upQ==}
+  '@oxlint/binding-linux-x64-musl@1.74.0':
+    resolution: {integrity: sha512-XyktaR8lhK2qWiCK0Tk8oYD+/cgn+oHA6ddRnxSSXUKkkojkV78CmShZUxQF+yrBFs0SuW+JBOPG6hecyc/iZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.66.0':
-    resolution: {integrity: sha512-yde+6p/F59xRkGR9H1HfngWRif1QRJjynZK349l+UI0H6w9hL3G8/AVaTHFyTtLVQ56qtNbX2/5Dc77n1ovnOg==}
+  '@oxlint/binding-openharmony-arm64@1.74.0':
+    resolution: {integrity: sha512-mzbjrPl4neaVUiJ1fUiEUxTGaSZBoiKtaoB6jmIpz9S+VOA2vDYmJpihQ82w6178V5jxziclTg8Cgj5yF6tTDg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.66.0':
-    resolution: {integrity: sha512-O9GLucgoTdmOrbBX+EjzNe7o/Ze5TFOvXcib6bzUOtBOmj6cV+zw18NgB+cGKAkDw1Pdqs8vGkfHbbsLuDtXWg==}
+  '@oxlint/binding-win32-arm64-msvc@1.74.0':
+    resolution: {integrity: sha512-vUAe9okpS2Oa5+lX67lqHMuNUvfkleRKwrUDJ/WJBsgmddvZ1mrsh2HVmuFDRzqFELhaJhFaCNOuR6a7L3rtIA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.66.0':
-    resolution: {integrity: sha512-m3Pjwc2MfTcom4E4gOv7DyuGyt7OfGNCbmqDHd+N7EzXmP+ppHuudm2NjcA3AjV5TSeGxaguVF4SbTKHe1USYA==}
+  '@oxlint/binding-win32-ia32-msvc@1.74.0':
+    resolution: {integrity: sha512-yyXXJyYYSXL4I8K8jAWjJs+J3fa9gH2JmEbo4f5adm+1tNC9itseicBNuwK7BDHvqQ5J534s+yDULu89vYL2ZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.66.0':
-    resolution: {integrity: sha512-/DbBvw8UFBhja6PqudUjV4UtfsJr0Oa7jUjWVKB0g86lj/VwnPrkngn0sFql3c9RDA0O16dh7ozsXb6GjNAzBQ==}
+  '@oxlint/binding-win32-x64-msvc@1.74.0':
+    resolution: {integrity: sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -3060,8 +3068,8 @@ packages:
   '@radix-ui/rect@1.1.2':
     resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
 
-  '@react-grab/cli@0.1.48':
-    resolution: {integrity: sha512-KXRZFN0b78BeVa4Tq1FC9kiXPpC5lS4pQp/mvQ1azy9dZUJ3zfc7Ei84+yvGh+WoYdceMCFxXfBp6qhU/G056g==}
+  '@react-grab/cli@0.1.50':
+    resolution: {integrity: sha512-Px/Hwhhyk2PubCA4ZaRFsfvwxhbxXsetJyvqC6aFFi8WhJhA+oVC33aTzuAeWmM3fhb4/8ce8YsHXI1d6ChcKg==}
     hasBin: true
 
   '@redocly/ajv@8.11.2':
@@ -3946,6 +3954,10 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -3998,6 +4010,10 @@ packages:
 
   atomically@2.1.1:
     resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
+
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
@@ -4072,8 +4088,8 @@ packages:
     resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
 
-  better-auth@1.6.19:
-    resolution: {integrity: sha512-68eXWKj0sxa0xW4+n4tENd6Co94UCynPKe1fncmO6kIB3XhSXWgwDEpiUouJV2dmLBrHM1FPkoI6Q5597zCGpQ==}
+  better-auth@1.6.22:
+    resolution: {integrity: sha512-B5s6+lPsDWp8rGLRnvNyr5h9tftG9zLRjNrlkEJdYRhcuhPhJiw9b8o6ibgxEFpSAdUqoDaP5/FLqfu8QsXIVg==}
     peerDependencies:
       '@lynx-js/react': '*'
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -4134,8 +4150,8 @@ packages:
       vue:
         optional: true
 
-  better-call@1.3.6:
-    resolution: {integrity: sha512-no1jI+h6Bkxs1NVBo4rONbVIzsPjZ8IUu7IHaJBiFwVX1XEQGN8KpHots5fSWmXe9nNyLuLIcgx6WEUcE6EDaA==}
+  better-call@1.3.7:
+    resolution: {integrity: sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==}
     peerDependencies:
       zod: ^4.0.0
     peerDependenciesMeta:
@@ -4154,8 +4170,8 @@ packages:
     peerDependencies:
       react: '>=17.0.1'
 
-  bippy@0.5.43:
-    resolution: {integrity: sha512-Tvu7b1M7+d8b9/YHaCeODEsi2CgbuoBql+dWSBrNnCuqJ1gMUeY3i0r+319hvjjl5GVBP6FFWxrKnq3fhZER0w==}
+  bippy@0.6.1:
+    resolution: {integrity: sha512-ky4m94Y/KfsddjGkKTsV4uFjZqkJjpOjQ2t5gKPdX6XH1MNxMNX5FrVefsxV4lpjemEmEdwe0e0YbzAMNs3oUQ==}
     peerDependencies:
       react: '>=17.0.1'
 
@@ -4270,6 +4286,14 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  cli-boxes@4.0.1:
+    resolution: {integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==}
+    engines: {node: '>=18.20 <19 || >=20.10'}
+
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
@@ -4281,6 +4305,10 @@ packages:
   cli-spinners@3.4.0:
     resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
     engines: {node: '>=18.20'}
+
+  cli-truncate@6.1.1:
+    resolution: {integrity: sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==}
+    engines: {node: '>=22'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -4302,6 +4330,10 @@ packages:
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -4353,6 +4385,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
@@ -4499,8 +4535,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  deslop-js@0.8.3:
-    resolution: {integrity: sha512-axNV/iX3Zq9xt0MYesmbBGxneeeY/HrYgXTsaM4+GOrdxXP9JyCfTdC4j8zx09bBML94oSIpFNyn9U1f0oEPqQ==}
+  deslop-js@0.9.1:
+    resolution: {integrity: sha512-eo3Tn37bqC1mMS3BwsdwRITYgQQQdT30g8SMY9C/zRbMu6ekNf9o7aGNUEkxWiKd1dTND58Sndi5fBlT9V6UvA==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -4673,6 +4709,10 @@ packages:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
@@ -4694,6 +4734,9 @@ packages:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
+
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
@@ -4708,6 +4751,10 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -5139,6 +5186,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
@@ -5152,6 +5203,26 @@ packages:
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  ink-spinner@5.0.0:
+    resolution: {integrity: sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==}
+    engines: {node: '>=14.16'}
+    peerDependencies:
+      ink: '>=4.0.0'
+      react: '>=18.0.0'
+
+  ink@7.1.1:
+    resolution: {integrity: sha512-Y43xxa1ZSPvpmfLHcN5o+OdP8Rf8ykkNJEuKYOUNZKT8wXVNLFTtEm1nSDMQkfBH+YANF4Xuu0hhZ4ejqAtN2w==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@types/react': '>=19.2.0'
+      react: '>=19.2.0'
+      react-devtools-core: '>=6.1.2'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
 
   input-otp@1.4.2:
     resolution: {integrity: sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==}
@@ -5200,9 +5271,18 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-in-ci@2.0.0:
+    resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   is-in-ssh@1.0.0:
     resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
@@ -5733,6 +5813,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanoid@5.1.11:
     resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
     engines: {node: ^18 || >=20}
@@ -5859,28 +5944,31 @@ packages:
     resolution: {integrity: sha512-661RSx+ZcjBmjBYid+Fpp/2F5EbtildpeoZh5HdgnGs+jZ03nqQEQW8yGkt4BGyOC3OMPDQQRl8M5kqD2/g6jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  oxc-parser@0.138.0:
-    resolution: {integrity: sha512-c25lvfpZ2+WY1yk6NkP0X0RTQg0ZxgSVaZHDa7lt6fEe1jwZjPWkRWvTyZ1xyaM7roVJMdtRCfbhUj/d4ims3Q==}
+  oxc-parser@0.141.0:
+    resolution: {integrity: sha512-uFkGGr1KMWd6aWv9UAqooYrN78trw8MWWmoPvgWokfBEUq1+eiIQ+qfj3wokhy0fxtZWZk+0dHoS7/yRTJtd6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxc-resolver@11.20.0:
     resolution: {integrity: sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==}
 
-  oxc-resolver@11.23.0:
-    resolution: {integrity: sha512-f0+l598CJMOLnYPXsXxttJALH0ljtivdRMKtvHhxRuWa5FYmw5+qODARl8oYjMC/brpzKcrpdORsOBrTqhBZ9A==}
+  oxc-resolver@11.24.2:
+    resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
 
-  oxlint-plugin-react-doctor@0.8.3:
-    resolution: {integrity: sha512-S1Gq1H9+BpziApWcZ/sWPNYYy1FMkFmtSEGiqIJ4/Aac76LfkeutPFtSRlkJF1JlcrbYFf7LXcfcxZCJgmVBBQ==}
+  oxlint-plugin-react-doctor@0.9.1:
+    resolution: {integrity: sha512-yCW8USbiuszbVsUMN4fL1iU7mRu3Ae3w96+k/xqCyWvW6bF6DzCMtLy5N/w6WLRX78iQsWxVqW/SEgzRBXLfsA==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
-  oxlint@1.66.0:
-    resolution: {integrity: sha512-N4LLxYLd94KEBqXDMDM5f+2PUpItTjDLreXe2Gn5KhjhCK4Qp2YUXaBi8Yu325ryOgKwt22m45fpD7nPOn69Yw==}
+  oxlint@1.74.0:
+    resolution: {integrity: sha512-odGl2s2x5IOJoj3A0v1k0PGBXVFBZeZ2+AK/+K2MJur7Ghi3bkyX5NuLUWHKqa4js1wjep3hJeuTQJOlr+4+dA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: '>=0.22.1'
+      oxlint-tsgolint: '>=0.24.0'
+      vite-plus: '*'
     peerDependenciesMeta:
       oxlint-tsgolint:
+        optional: true
+      vite-plus:
         optional: true
 
   p-limit@2.3.0:
@@ -5941,6 +6029,10 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -6054,8 +6146,8 @@ packages:
     resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
     engines: {node: '>=4'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.22:
+    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -6183,8 +6275,8 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-doctor@0.8.3:
-    resolution: {integrity: sha512-FfG7YQKb1yv1UNk2gknZzLAPx6L3RMOhYsYbslr4MSpVMNk5xBHlu9VxjtS0br0DEBWjkZovrf/C1MrchiIzAw==}
+  react-doctor@0.9.1:
+    resolution: {integrity: sha512-pKCWENXuYZK7UNBHpNLbEBlpy+oVWwPnOxTD2B//gmrQLm+UvIknArzP3IOjNP5Nk1NKCR9uavypFA1QMbYFyg==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -6193,14 +6285,20 @@ packages:
     peerDependencies:
       react: ^19.2.7
 
-  react-grab@0.1.48:
-    resolution: {integrity: sha512-p3WnmK9LLvXE/c4ITPLlXcP1fkXo2VFEQqK94tIfcHIWKNdqdhYYFyNVioO50HR+uyHIwT63Z4txZDqJlVcD/Q==}
+  react-grab@0.1.50:
+    resolution: {integrity: sha512-zRkHKq/8a1msCpEOp8BDROeQZT50m0OH2XPrP6jk5op+JAHrlsm3pj7eAQMOsct87EZDeGNnu4r+sGsJJzyw1Q==}
     hasBin: true
     peerDependencies:
       react: '>=17.0.0'
     peerDependenciesMeta:
       react:
         optional: true
+
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -6242,6 +6340,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
@@ -6305,6 +6407,10 @@ packages:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -6487,6 +6593,10 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  slice-ansi@9.0.0:
+    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
+    engines: {node: '>=22'}
+
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -6535,6 +6645,10 @@ packages:
     resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
     engines: {node: '>=20.16.0'}
     hasBin: true
+
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -6664,6 +6778,10 @@ packages:
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  terminal-size@4.0.1:
+    resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
+    engines: {node: '>=18'}
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -7030,6 +7148,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  widest-line@6.0.0:
+    resolution: {integrity: sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==}
+    engines: {node: '>=20'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -7048,6 +7170,10 @@ packages:
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
+
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -7137,6 +7263,9 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
@@ -7265,6 +7394,11 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
       zod: 4.4.3
       zod-to-json-schema: 3.25.2(zod@4.4.3)
+
+  '@alcalzone/ansi-tokenize@0.3.0':
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   '@asteasolutions/zod-to-openapi@8.5.0(zod@4.4.3)':
     dependencies:
@@ -7465,13 +7599,13 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)':
+  '@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)':
     dependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@opentelemetry/semantic-conventions': 1.41.1
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.6(zod@3.25.76)
+      better-call: 1.3.7(zod@3.25.76)
       jose: 6.2.3
       kysely: 0.29.2
       nanostores: 1.3.0
@@ -7480,13 +7614,13 @@ snapshots:
       '@cloudflare/workers-types': 4.20260615.1
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)':
+  '@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)':
     dependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@opentelemetry/semantic-conventions': 1.41.1
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.6(zod@4.4.3)
+      better-call: 1.3.7(zod@4.4.3)
       jose: 6.2.3
       kysely: 0.29.2
       nanostores: 1.3.0
@@ -7495,72 +7629,72 @@ snapshots:
       '@cloudflare/workers-types': 4.20260615.1
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))':
+  '@better-auth/drizzle-adapter@1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0)
 
-  '@better-auth/kysely-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
+  '@better-auth/kysely-adapter@1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.29.2
 
-  '@better-auth/memory-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/mongo-adapter@1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/oauth-provider@1.6.19(patch_hash=da96def66da8f71821804f1d1e269964333ef0d4a0c4a703ee8c306f4f49e981)(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.6(zod@4.4.3))':
+  '@better-auth/oauth-provider@1.6.19(patch_hash=da96def66da8f71821804f1d1e269964333ef0d4a0c4a703ee8c306f4f49e981)(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.7(zod@4.4.3))':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
-      better-call: 1.3.6(zod@4.4.3)
+      better-auth: 1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
+      better-call: 1.3.7(zod@4.4.3)
       jose: 6.2.3
       zod: 4.4.3
 
-  '@better-auth/passkey@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.6(zod@3.25.76))(nanostores@1.3.0)':
+  '@better-auth/passkey@1.6.19(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.7(zod@3.25.76))(nanostores@1.3.0)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@simplewebauthn/browser': 13.3.0
       '@simplewebauthn/server': 13.3.2
-      better-auth: 1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
-      better-call: 1.3.6(zod@3.25.76)
+      better-auth: 1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
+      better-call: 1.3.7(zod@3.25.76)
       nanostores: 1.3.0
       zod: 4.4.3
 
-  '@better-auth/passkey@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.6(zod@4.4.3))(nanostores@1.3.0)':
+  '@better-auth/passkey@1.6.19(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.7(zod@4.4.3))(nanostores@1.3.0)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@simplewebauthn/browser': 13.3.0
       '@simplewebauthn/server': 13.3.2
-      better-auth: 1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
-      better-call: 1.3.6(zod@4.4.3)
+      better-auth: 1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
+      better-call: 1.3.7(zod@4.4.3)
       nanostores: 1.3.0
       zod: 4.4.3
 
-  '@better-auth/prisma-adapter@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/telemetry@1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -7773,7 +7907,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.1':
+  '@emnapi/core@1.11.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
@@ -7785,6 +7919,11 @@ snapshots:
     optional: true
 
   '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -8335,10 +8474,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -8413,97 +8552,97 @@ snapshots:
   '@oxc-parser/binding-android-arm-eabi@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm-eabi@0.138.0':
+  '@oxc-parser/binding-android-arm-eabi@0.141.0':
     optional: true
 
   '@oxc-parser/binding-android-arm64@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm64@0.138.0':
+  '@oxc-parser/binding-android-arm64@0.141.0':
     optional: true
 
   '@oxc-parser/binding-darwin-arm64@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-arm64@0.138.0':
+  '@oxc-parser/binding-darwin-arm64@0.141.0':
     optional: true
 
   '@oxc-parser/binding-darwin-x64@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-x64@0.138.0':
+  '@oxc-parser/binding-darwin-x64@0.141.0':
     optional: true
 
   '@oxc-parser/binding-freebsd-x64@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-freebsd-x64@0.138.0':
+  '@oxc-parser/binding-freebsd-x64@0.141.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-gnueabihf@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.138.0':
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.141.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-musleabihf@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.138.0':
+  '@oxc-parser/binding-linux-arm-musleabihf@0.141.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-gnu@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.138.0':
+  '@oxc-parser/binding-linux-arm64-gnu@0.141.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-musl@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-musl@0.138.0':
+  '@oxc-parser/binding-linux-arm64-musl@0.141.0':
     optional: true
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-linux-ppc64-gnu@0.138.0':
+  '@oxc-parser/binding-linux-ppc64-gnu@0.141.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.138.0':
+  '@oxc-parser/binding-linux-riscv64-gnu@0.141.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-musl@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-linux-riscv64-musl@0.138.0':
+  '@oxc-parser/binding-linux-riscv64-musl@0.141.0':
     optional: true
 
   '@oxc-parser/binding-linux-s390x-gnu@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.138.0':
+  '@oxc-parser/binding-linux-s390x-gnu@0.141.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-gnu@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-linux-x64-gnu@0.138.0':
+  '@oxc-parser/binding-linux-x64-gnu@0.141.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-musl@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-linux-x64-musl@0.138.0':
+  '@oxc-parser/binding-linux-x64-musl@0.141.0':
     optional: true
 
   '@oxc-parser/binding-openharmony-arm64@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-openharmony-arm64@0.138.0':
+  '@oxc-parser/binding-openharmony-arm64@0.141.0':
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.133.0':
@@ -8513,129 +8652,129 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@oxc-parser/binding-wasm32-wasi@0.138.0':
+  '@oxc-parser/binding-wasm32-wasi@0.141.0':
     dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
   '@oxc-parser/binding-win32-arm64-msvc@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.138.0':
+  '@oxc-parser/binding-win32-arm64-msvc@0.141.0':
     optional: true
 
   '@oxc-parser/binding-win32-ia32-msvc@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-win32-ia32-msvc@0.138.0':
+  '@oxc-parser/binding-win32-ia32-msvc@0.141.0':
     optional: true
 
   '@oxc-parser/binding-win32-x64-msvc@0.133.0':
     optional: true
 
-  '@oxc-parser/binding-win32-x64-msvc@0.138.0':
+  '@oxc-parser/binding-win32-x64-msvc@0.141.0':
     optional: true
 
   '@oxc-project/types@0.133.0': {}
 
-  '@oxc-project/types@0.138.0': {}
+  '@oxc-project/types@0.141.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-android-arm-eabi@11.23.0':
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
     optional: true
 
   '@oxc-resolver/binding-android-arm64@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-android-arm64@11.23.0':
+  '@oxc-resolver/binding-android-arm64@11.24.2':
     optional: true
 
   '@oxc-resolver/binding-darwin-arm64@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-darwin-arm64@11.23.0':
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
     optional: true
 
   '@oxc-resolver/binding-darwin-x64@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-darwin-x64@11.23.0':
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
     optional: true
 
   '@oxc-resolver/binding-freebsd-x64@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-freebsd-x64@11.23.0':
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
     optional: true
 
   '@oxc-resolver/binding-linux-arm-gnueabihf@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-linux-arm-gnueabihf@11.23.0':
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
     optional: true
 
   '@oxc-resolver/binding-linux-arm-musleabihf@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-linux-arm-musleabihf@11.23.0':
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
     optional: true
 
   '@oxc-resolver/binding-linux-arm64-gnu@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-linux-arm64-gnu@11.23.0':
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
     optional: true
 
   '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-linux-arm64-musl@11.23.0':
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
     optional: true
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-linux-ppc64-gnu@11.23.0':
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
     optional: true
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-linux-riscv64-gnu@11.23.0':
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
     optional: true
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-linux-riscv64-musl@11.23.0':
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
     optional: true
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-linux-s390x-gnu@11.23.0':
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
     optional: true
 
   '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-linux-x64-gnu@11.23.0':
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
     optional: true
 
   '@oxc-resolver/binding-linux-x64-musl@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-linux-x64-musl@11.23.0':
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
     optional: true
 
   '@oxc-resolver/binding-openharmony-arm64@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-openharmony-arm64@11.23.0':
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
     optional: true
 
   '@oxc-resolver/binding-wasm32-wasi@11.20.0':
@@ -8645,80 +8784,80 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.23.0':
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
     dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
   '@oxc-resolver/binding-win32-arm64-msvc@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-win32-arm64-msvc@11.23.0':
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
     optional: true
 
   '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-win32-x64-msvc@11.23.0':
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.66.0':
+  '@oxlint/binding-android-arm-eabi@1.74.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.66.0':
+  '@oxlint/binding-android-arm64@1.74.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.66.0':
+  '@oxlint/binding-darwin-arm64@1.74.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.66.0':
+  '@oxlint/binding-darwin-x64@1.74.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.66.0':
+  '@oxlint/binding-freebsd-x64@1.74.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.66.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.74.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.66.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.74.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.66.0':
+  '@oxlint/binding-linux-arm64-gnu@1.74.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.66.0':
+  '@oxlint/binding-linux-arm64-musl@1.74.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.66.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.74.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.66.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.74.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.66.0':
+  '@oxlint/binding-linux-riscv64-musl@1.74.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.66.0':
+  '@oxlint/binding-linux-s390x-gnu@1.74.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.66.0':
+  '@oxlint/binding-linux-x64-gnu@1.74.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.66.0':
+  '@oxlint/binding-linux-x64-musl@1.74.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.66.0':
+  '@oxlint/binding-openharmony-arm64@1.74.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.66.0':
+  '@oxlint/binding-win32-arm64-msvc@1.74.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.66.0':
+  '@oxlint/binding-win32-ia32-msvc@1.74.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.66.0':
+  '@oxlint/binding-win32-x64-msvc@1.74.0':
     optional: true
 
   '@peculiar/asn1-android@2.8.0':
@@ -9721,7 +9860,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.2': {}
 
-  '@react-grab/cli@0.1.48':
+  '@react-grab/cli@0.1.50':
     dependencies:
       agent-install: 0.0.6
       commander: 14.0.3
@@ -10545,6 +10684,10 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -10591,6 +10734,8 @@ snapshots:
     dependencies:
       stubborn-fs: 2.0.0
       when-exit: 2.1.5
+
+  auto-bind@5.0.1: {}
 
   b4a@1.8.1: {}
 
@@ -10648,20 +10793,20 @@ snapshots:
 
   basic-ftp@5.3.1: {}
 
-  better-auth@1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9):
+  better-auth@1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9):
     dependencies:
-      '@better-auth/core': 1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))
-      '@better-auth/kysely-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
-      '@better-auth/memory-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.19(@better-auth/core@1.6.19(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))
+      '@better-auth/kysely-adapter': 1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
+      '@better-auth/memory-adapter': 1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
-      better-call: 1.3.6(zod@4.4.3)
+      better-call: 1.3.7(zod@4.4.3)
       defu: 6.1.7
       jose: 6.2.3
       kysely: 0.29.2
@@ -10680,7 +10825,7 @@ snapshots:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-call@1.3.6(zod@3.25.76):
+  better-call@1.3.7(zod@3.25.76):
     dependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
@@ -10689,7 +10834,7 @@ snapshots:
     optionalDependencies:
       zod: 3.25.76
 
-  better-call@1.3.6(zod@4.4.3):
+  better-call@1.3.7(zod@4.4.3):
     dependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
@@ -10711,7 +10856,7 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  bippy@0.5.43(react@19.2.7):
+  bippy@0.6.1(react@19.2.7):
     dependencies:
       react: 19.2.7
 
@@ -10845,6 +10990,12 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  cli-boxes@4.0.1: {}
+
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
+
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
@@ -10852,6 +11003,11 @@ snapshots:
   cli-spinners@2.9.2: {}
 
   cli-spinners@3.4.0: {}
+
+  cli-truncate@6.1.1:
+    dependencies:
+      slice-ansi: 9.0.0
+      string-width: 8.2.1
 
   cliui@8.0.1:
     dependencies:
@@ -10880,6 +11036,10 @@ snapshots:
       - '@types/react-dom'
 
   code-block-writer@13.0.3: {}
+
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
 
   color-convert@2.0.1:
     dependencies:
@@ -10931,6 +11091,8 @@ snapshots:
   content-type@2.0.0: {}
 
   convert-source-map@2.0.0: {}
+
+  convert-to-spaces@2.0.1: {}
 
   cookie-es@3.1.1: {}
 
@@ -11062,13 +11224,13 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  deslop-js@0.8.3:
+  deslop-js@0.9.1:
     dependencies:
-      '@oxc-project/types': 0.138.0
+      '@oxc-project/types': 0.141.0
       fast-glob: 3.3.3
       minimatch: 10.2.5
-      oxc-parser: 0.138.0
-      oxc-resolver: 11.23.0
+      oxc-parser: 0.141.0
+      oxc-resolver: 11.24.2
       typescript: 5.9.3
 
   detect-libc@2.1.2: {}
@@ -11152,6 +11314,8 @@ snapshots:
 
   env-paths@3.0.0: {}
 
+  environment@1.1.0: {}
+
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
@@ -11167,6 +11331,8 @@ snapshots:
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
+
+  es-toolkit@1.49.0: {}
 
   es6-error@4.1.1: {}
 
@@ -11202,6 +11368,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
+
+  escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -11695,6 +11863,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@5.0.0: {}
+
   index-to-position@1.2.0: {}
 
   inherits@2.0.4: {}
@@ -11702,6 +11872,46 @@ snapshots:
   ini@1.3.8: {}
 
   ini@4.1.1: {}
+
+  ink-spinner@5.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.5))(react@19.2.5):
+    dependencies:
+      cli-spinners: 2.9.2
+      ink: 7.1.1(@types/react@19.2.17)(react@19.2.5)
+      react: 19.2.5
+
+  ink@7.1.1(@types/react@19.2.17)(react@19.2.5):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.3.0
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 4.0.1
+      cli-cursor: 4.0.0
+      cli-truncate: 6.1.1
+      code-excerpt: 4.0.0
+      es-toolkit: 1.49.0
+      indent-string: 5.0.0
+      is-in-ci: 2.0.0
+      patch-console: 2.0.0
+      react: 19.2.5
+      react-reconciler: 0.33.0(react@19.2.5)
+      scheduler: 0.27.0
+      signal-exit: 3.0.7
+      slice-ansi: 9.0.0
+      stack-utils: 2.0.6
+      string-width: 8.2.1
+      terminal-size: 4.0.1
+      type-fest: 5.7.0
+      widest-line: 6.0.0
+      wrap-ansi: 10.0.0
+      ws: 8.21.0
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   input-otp@1.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -11730,9 +11940,15 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-in-ci@2.0.0: {}
 
   is-in-ssh@1.0.0: {}
 
@@ -12342,6 +12558,8 @@ snapshots:
 
   nanoid@3.3.12: {}
 
+  nanoid@3.3.16: {}
+
   nanoid@5.1.11: {}
 
   nanostores@1.3.0: {}
@@ -12505,30 +12723,30 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.133.0
       '@oxc-parser/binding-win32-x64-msvc': 0.133.0
 
-  oxc-parser@0.138.0:
+  oxc-parser@0.141.0:
     dependencies:
-      '@oxc-project/types': 0.138.0
+      '@oxc-project/types': 0.141.0
     optionalDependencies:
-      '@oxc-parser/binding-android-arm-eabi': 0.138.0
-      '@oxc-parser/binding-android-arm64': 0.138.0
-      '@oxc-parser/binding-darwin-arm64': 0.138.0
-      '@oxc-parser/binding-darwin-x64': 0.138.0
-      '@oxc-parser/binding-freebsd-x64': 0.138.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.138.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.138.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.138.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.138.0
-      '@oxc-parser/binding-linux-ppc64-gnu': 0.138.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.138.0
-      '@oxc-parser/binding-linux-riscv64-musl': 0.138.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.138.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.138.0
-      '@oxc-parser/binding-linux-x64-musl': 0.138.0
-      '@oxc-parser/binding-openharmony-arm64': 0.138.0
-      '@oxc-parser/binding-wasm32-wasi': 0.138.0
-      '@oxc-parser/binding-win32-arm64-msvc': 0.138.0
-      '@oxc-parser/binding-win32-ia32-msvc': 0.138.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.138.0
+      '@oxc-parser/binding-android-arm-eabi': 0.141.0
+      '@oxc-parser/binding-android-arm64': 0.141.0
+      '@oxc-parser/binding-darwin-arm64': 0.141.0
+      '@oxc-parser/binding-darwin-x64': 0.141.0
+      '@oxc-parser/binding-freebsd-x64': 0.141.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.141.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.141.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.141.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.141.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.141.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.141.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.141.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.141.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.141.0
+      '@oxc-parser/binding-linux-x64-musl': 0.141.0
+      '@oxc-parser/binding-openharmony-arm64': 0.141.0
+      '@oxc-parser/binding-wasm32-wasi': 0.141.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.141.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.141.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.141.0
 
   oxc-resolver@11.20.0:
     optionalDependencies:
@@ -12552,56 +12770,56 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.20.0
       '@oxc-resolver/binding-win32-x64-msvc': 11.20.0
 
-  oxc-resolver@11.23.0:
+  oxc-resolver@11.24.2:
     optionalDependencies:
-      '@oxc-resolver/binding-android-arm-eabi': 11.23.0
-      '@oxc-resolver/binding-android-arm64': 11.23.0
-      '@oxc-resolver/binding-darwin-arm64': 11.23.0
-      '@oxc-resolver/binding-darwin-x64': 11.23.0
-      '@oxc-resolver/binding-freebsd-x64': 11.23.0
-      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.23.0
-      '@oxc-resolver/binding-linux-arm-musleabihf': 11.23.0
-      '@oxc-resolver/binding-linux-arm64-gnu': 11.23.0
-      '@oxc-resolver/binding-linux-arm64-musl': 11.23.0
-      '@oxc-resolver/binding-linux-ppc64-gnu': 11.23.0
-      '@oxc-resolver/binding-linux-riscv64-gnu': 11.23.0
-      '@oxc-resolver/binding-linux-riscv64-musl': 11.23.0
-      '@oxc-resolver/binding-linux-s390x-gnu': 11.23.0
-      '@oxc-resolver/binding-linux-x64-gnu': 11.23.0
-      '@oxc-resolver/binding-linux-x64-musl': 11.23.0
-      '@oxc-resolver/binding-openharmony-arm64': 11.23.0
-      '@oxc-resolver/binding-wasm32-wasi': 11.23.0
-      '@oxc-resolver/binding-win32-arm64-msvc': 11.23.0
-      '@oxc-resolver/binding-win32-x64-msvc': 11.23.0
+      '@oxc-resolver/binding-android-arm-eabi': 11.24.2
+      '@oxc-resolver/binding-android-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-x64': 11.24.2
+      '@oxc-resolver/binding-freebsd-x64': 11.24.2
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-musl': 11.24.2
+      '@oxc-resolver/binding-openharmony-arm64': 11.24.2
+      '@oxc-resolver/binding-wasm32-wasi': 11.24.2
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
+      '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
 
-  oxlint-plugin-react-doctor@0.8.3:
+  oxlint-plugin-react-doctor@0.9.1:
     dependencies:
       '@typescript-eslint/types': 8.61.1
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
-      oxc-parser: 0.138.0
+      oxc-parser: 0.141.0
 
-  oxlint@1.66.0:
+  oxlint@1.74.0:
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.66.0
-      '@oxlint/binding-android-arm64': 1.66.0
-      '@oxlint/binding-darwin-arm64': 1.66.0
-      '@oxlint/binding-darwin-x64': 1.66.0
-      '@oxlint/binding-freebsd-x64': 1.66.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.66.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.66.0
-      '@oxlint/binding-linux-arm64-gnu': 1.66.0
-      '@oxlint/binding-linux-arm64-musl': 1.66.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.66.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.66.0
-      '@oxlint/binding-linux-riscv64-musl': 1.66.0
-      '@oxlint/binding-linux-s390x-gnu': 1.66.0
-      '@oxlint/binding-linux-x64-gnu': 1.66.0
-      '@oxlint/binding-linux-x64-musl': 1.66.0
-      '@oxlint/binding-openharmony-arm64': 1.66.0
-      '@oxlint/binding-win32-arm64-msvc': 1.66.0
-      '@oxlint/binding-win32-ia32-msvc': 1.66.0
-      '@oxlint/binding-win32-x64-msvc': 1.66.0
+      '@oxlint/binding-android-arm-eabi': 1.74.0
+      '@oxlint/binding-android-arm64': 1.74.0
+      '@oxlint/binding-darwin-arm64': 1.74.0
+      '@oxlint/binding-darwin-x64': 1.74.0
+      '@oxlint/binding-freebsd-x64': 1.74.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.74.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.74.0
+      '@oxlint/binding-linux-arm64-gnu': 1.74.0
+      '@oxlint/binding-linux-arm64-musl': 1.74.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.74.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.74.0
+      '@oxlint/binding-linux-riscv64-musl': 1.74.0
+      '@oxlint/binding-linux-s390x-gnu': 1.74.0
+      '@oxlint/binding-linux-x64-gnu': 1.74.0
+      '@oxlint/binding-linux-x64-musl': 1.74.0
+      '@oxlint/binding-openharmony-arm64': 1.74.0
+      '@oxlint/binding-win32-arm64-msvc': 1.74.0
+      '@oxlint/binding-win32-ia32-msvc': 1.74.0
+      '@oxlint/binding-win32-x64-msvc': 1.74.0
 
   p-limit@2.3.0:
     dependencies:
@@ -12667,6 +12885,8 @@ snapshots:
   parse-ms@4.0.0: {}
 
   parseurl@1.3.3: {}
+
+  patch-console@2.0.0: {}
 
   path-browserify@1.0.1: {}
 
@@ -12760,9 +12980,9 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.15:
+  postcss@8.5.22:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -12950,20 +13170,24 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-doctor@0.8.3(eslint@10.5.0(jiti@2.7.0)):
+  react-doctor@0.9.1(@types/react@19.2.17)(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@sentry/node': 10.58.0
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.8.3
+      deslop-js: 0.9.1
       eslint-plugin-react-hooks: 7.1.1(eslint@10.5.0(jiti@2.7.0))
+      figures: 6.1.0
+      ink: 7.1.1(@types/react@19.2.17)(react@19.2.5)
+      ink-spinner: 5.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.5))(react@19.2.5)
       jiti: 2.7.0
       magicast: 0.5.3
-      oxlint: 1.66.0
-      oxlint-plugin-react-doctor: 0.8.3
+      oxlint: 1.74.0
+      oxlint-plugin-react-doctor: 0.9.1
       prompts: 2.4.2
+      react: 19.2.5
       typescript: 5.9.3
       vscode-languageserver: 9.0.1
       vscode-languageserver-textdocument: 1.0.12
@@ -12971,21 +13195,31 @@ snapshots:
       yaml: 2.9.0
     transitivePeerDependencies:
       - '@opentelemetry/exporter-trace-otlp-http'
+      - '@types/react'
+      - bufferutil
       - eslint
       - oxlint-tsgolint
+      - react-devtools-core
       - supports-color
+      - utf-8-validate
+      - vite-plus
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
 
-  react-grab@0.1.48(react@19.2.7):
+  react-grab@0.1.50(react@19.2.7):
     dependencies:
-      '@react-grab/cli': 0.1.48
-      bippy: 0.5.43(react@19.2.7)
+      '@react-grab/cli': 0.1.50
+      bippy: 0.6.1(react@19.2.7)
     optionalDependencies:
       react: 19.2.7
+
+  react-reconciler@0.33.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
     dependencies:
@@ -13006,7 +13240,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  react-scan@0.5.7(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.1):
+  react-scan@0.5.7(@types/react@19.2.17)(esbuild@0.28.1)(eslint@10.5.0(jiti@2.7.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.1):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/types': 7.29.7
@@ -13018,18 +13252,23 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.8.3(eslint@10.5.0(jiti@2.7.0))
+      react-doctor: 0.9.1(@types/react@19.2.17)(eslint@10.5.0(jiti@2.7.0))
       react-dom: 19.2.7(react@19.2.7)
-      react-grab: 0.1.48(react@19.2.7)
+      react-grab: 0.1.50(react@19.2.7)
     optionalDependencies:
       esbuild: 0.28.1
       unplugin: 3.0.0
     transitivePeerDependencies:
       - '@opentelemetry/exporter-trace-otlp-http'
+      - '@types/react'
+      - bufferutil
       - eslint
       - oxlint-tsgolint
+      - react-devtools-core
       - rollup
       - supports-color
+      - utf-8-validate
+      - vite-plus
 
   react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
@@ -13038,6 +13277,8 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.17
+
+  react@19.2.5: {}
 
   react@19.2.7: {}
 
@@ -13114,6 +13355,11 @@ snapshots:
       is-core-module: 2.16.2
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
 
   restore-cursor@5.1.0:
     dependencies:
@@ -13304,7 +13550,7 @@ snapshots:
       kleur: 4.1.5
       open: 11.0.0
       ora: 8.2.0
-      postcss: 8.5.15
+      postcss: 8.5.22
       postcss-selector-parser: 7.1.4
       prompts: 2.4.2
       recast: 0.23.12
@@ -13408,6 +13654,11 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  slice-ansi@9.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   smart-buffer@4.2.0: {}
 
   smol-toml@1.6.1: {}
@@ -13446,6 +13697,10 @@ snapshots:
   sprintf-js@1.1.3: {}
 
   srvx@0.11.16: {}
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
 
@@ -13583,6 +13838,8 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  terminal-size@4.0.1: {}
 
   text-decoder@1.2.7:
     dependencies:
@@ -13790,7 +14047,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.22
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -13876,6 +14133,10 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  widest-line@6.0.0:
+    dependencies:
+      string-width: 8.2.1
+
   word-wrap@1.2.5: {}
 
   workerd@1.20260611.1:
@@ -13903,6 +14164,12 @@ snapshots:
       - '@types/node'
       - bufferutil
       - utf-8-validate
+
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.1
+      strip-ansi: 7.2.0
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -13984,6 +14251,8 @@ snapshots:
       yoctocolors: 2.1.2
 
   yoctocolors@2.1.2: {}
+
+  yoga-layout@3.2.1: {}
 
   youch-core@0.3.3:
     dependencies:


### PR DESCRIPTION
**Taken over from @an1va (he's on #518).** Four commits, one arc: the provider seam, per-user plans, and the initiator chain — WHO a run bills, resolved correctly on both lanes.

## The stack

1. **`12a141e1` + `21765739` — pluggable providers** (Anir): agnostic runner core, claude-code/codex split behind one `provider.run()` seam; doctor survives an unknown provider.
2. **`216741b5` — per-user model-plan credentials** (Anir, was #522): `model_credential` table (encrypted at rest, keyed org+user+provider), personal connect/list/delete surface, agent fetch endpoint, web Model-plans card, fails closed with no shared fallback.
3. **`839b5fc5` — bill the initiator, not the registrant** (Rob): `?session=` resolves the session's **asker's** plan first (registrant fallback until the pool); session ids only resolve inside the calling agent's own context (404 otherwise). Runner: per-spawn env **overlay** instead of `process.env` mutation — one asker's token can't leak into the next asker's session; fail-closed resolves fail that session server-side instead of dangling the claim.
4. **`ec383895` — `run.initiated_by`** (Rob): the automation lane of the same chain. First-class nullable column (all three dialects + d1 snapshot), stamped by Run-now, exposed in the claim payload, `?run=` on the credential endpoint (initiator → registrant, foreign ids 404). No in-repo consumer of `?run=` by design — the hosted run lane adopts it at #518's `resolvePlan` fold.
5. **`0a813434` — CI unblock**: `model_credential` was missing from the **pg** boot roster (sqlite-only — the pg job caught it, every credential query failed on the hosted tier); plus two fresh high advisories cleared (better-auth 1.6.19→1.6.22 — account-takeover advisory, hits main's audit too — and a postcss override).

## The resolution chain, after this PR

| Run | Bills |
| --- | --- |
| A session (someone asks) | **the asker's** plan → registrant fallback |
| Run now (someone clicks) | **the clicker's** plan → registrant fallback |
| Schedule / event (no person) | registrant → **the workspace pool once #518's `resolvePlan` folds in** |

## Hand-off points for #518 (agreed with Anir)

- `plan` absorbs `model_credential` (`kind:'model'`, carry `oauth|api_key` + hint); `/v1/agent/model-credential` becomes a thin read over `resolvePlan(org, initiator, 'model')` — keep the asker/initiator-first order and the 404 isolation.
- `connection.user_id` nullable (workspace-scoped org apps), per the review comment there.

## Verification

api **1181** (15 model-credential incl. asker-keyed / clicker-keyed / cross-agent 404s) · cli **152** (per-spawn overlay isolation property) · db **224** sqlite + the pg job green on the roster fix · web **188** · typecheck clean (scenarios.e2e pre-existing) · audit 0 high.