### PR TITLE
Feat/anon commenting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,12 +21,15 @@ release; please run a recent build.
 
 Derive ships safe defaults, but a few choices matter for an internet-facing deploy:
 
-- **Anonymous callers are always read-only.** This is the load-bearing access
-  invariant: an anonymous (no-account) caller is never more than a viewer. Anything past
-  view (comment, propose, publish, share, manage) requires an authenticated identity, so
-  there is no "open" mode that elevates an anonymous caller. To write, a caller signs in
-  (Better Auth is always available, even zero-config) or presents a static `DERIVE_TOKEN`
-  (set it for headless CI/agent automation).
+- **Anonymous callers are capped at commenter.** This is the load-bearing access
+  invariant: an anonymous (no-account) caller reaches commenter only by holding a
+  commenter-or-better world link, capped there even on an editor link; a viewer link
+  (or no link) still clamps them to view (or no access). Publish, approve, share, and
+  manage always require an authenticated identity, so there is no "open" mode that
+  elevates an anonymous caller past commenter. Guests must self-provide a display name
+  to comment. To do more than comment, a caller signs in (Better Auth is always
+  available, even zero-config) or presents a static `DERIVE_TOKEN` (set it for headless
+  CI/agent automation).
 
   Access is three independent, single-purpose fields (docs/access-model.md).
   **`workspace_access`** (`none` / `member`): do the artifact's workspace members
@@ -36,7 +39,8 @@ Derive ships safe defaults, but a few choices matter for an internet-facing depl
   link). **`listed`** (`none` / workspace / public): pure discoverability — the
   workspace library or the public directory — with no access meaning of its own.
   The effective role is `max(explicit share, workspace seat if a member, world
-  link)`; an anonymous holder of a live link is always clamped to view. The
+  link)`; an anonymous holder of a live link resolves to viewer on a viewer link, and
+  to commenter (capped there even on an editor link) on a commenter-or-better link. The
   effective capability by who's asking:
 
   | Field state                    | Anonymous (no account) | Signed in outside the workspace | Workspace member          | Explicit share          |
@@ -44,8 +48,8 @@ Derive ships safe defaults, but a few choices matter for an internet-facing depl
   | workspace_access none, link none | No access            | No access                       | Their share role only¹    | Their share role        |
   | workspace_access member          | No access            | No access                       | max(seat, share)          | max(seat², share)       |
   | link_role viewer                 | View                 | View                            | max(seat/share, view)     | max(share, view)        |
-  | link_role commenter              | View (sign in to comment) | View + comment             | max(seat/share, comment)  | max(share, comment)     |
-  | link_role editor                 | View (sign in to edit) | Editor                        | max(seat/share, edit)     | max(share, edit)        |
+  | link_role commenter              | Comment (as a named guest) | View + comment             | max(seat/share, comment)  | max(share, comment)     |
+  | link_role editor                 | Comment (as a named guest, capped below edit) | Editor  | max(seat/share, edit)     | max(share, edit)        |
 
   ¹ workspace_access=none withholds the seat grant, so a workspace owner cannot
   open a teammate's invite-only draft by role alone — only an explicit share does.

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2184,6 +2184,10 @@
             "type": "boolean",
             "description": "True if soft-deleted; the row stays but the body is blanked."
           },
+          "guest": {
+            "type": "boolean",
+            "description": "True when the author was an anonymous guest (self-named, no account)."
+          },
           "mentions": {
             "type": "array",
             "items": {
@@ -6639,7 +6643,7 @@
         "tags": [
           "Comments"
         ],
-        "summary": "List an artifact's comments (authenticated readers only).",
+        "summary": "List an artifact's comments (authenticated readers, or anon guests on a commenter+ link).",
         "parameters": [
           {
             "schema": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -347,6 +347,7 @@ export function createApp(deps: AppDeps): Hono {
     /^\/v1\/artifacts\/[^/]+\/cursor$/, // ephemeral live cursor (viral viewing)
     /^\/v1\/artifacts\/[^/]+\/view$/, // de-duped, anonymous-safe view counter
     /^\/v1\/artifacts\/[^/]+\/unlock$/, // password unlock — the password is the gate
+    /^\/v1\/artifacts\/[^/]+\/comments$/, // guest comment create — role-gated in the route (commenter+ link required); create only, never edit/delete/resolve
     /^\/v1\/vitals$/, // anonymous Core Web Vitals beacon (telemetry, no state)
     /^\/v1\/beta\/signup$/, // marketing-site beta signup — anonymous is the point; IP-capped
     /^\/v1\/sync\/github\/webhook$/, // GitHub App webhook — HMAC signature is the gate

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -256,6 +256,7 @@ export function buildContext(deps: AppDeps) {
   const limiters = deps.rateLimiters ?? inMemoryRateLimiters(deps)
   const publishLimiter = deps.rateLimit ? limiters.publish : null
   const commentLimiter = deps.rateLimit ? limiters.comment : null
+  const anonCommentLimiter = deps.rateLimit ? limiters.anonComment : null
   const unlockLimiter = deps.rateLimit ? limiters.unlock : null
   const inviteLimiter = deps.rateLimit ? limiters.invite : null
   const askLimiter = deps.rateLimit ? limiters.ask : null
@@ -939,6 +940,7 @@ export function buildContext(deps: AppDeps) {
     defaultRole,
     publishLimiter,
     commentLimiter,
+    anonCommentLimiter,
     unlockLimiter,
     inviteLimiter,
     askLimiter,

--- a/apps/api/src/lib/comments.ts
+++ b/apps/api/src/lib/comments.ts
@@ -43,6 +43,10 @@ export type CommentMeta = {
   edited_at?: string
   deleted?: boolean
   mentions?: Mention[]
+  // Stamped true at write time for a genuinely anonymous (guest) author — see
+  // the guest stamp in routes/comments.ts. Never set for a signed-in or
+  // token-authenticated author.
+  guest?: boolean
   // The id of the open proposal whose revision claims to address this thread.
   // Set when the thread flips to `addressed`; cleared when that proposal is
   // approved (→ resolved) or withdrawn / sent back for changes (→ open).
@@ -96,6 +100,7 @@ export function commentJson(cm: CommentRecord, anchored?: boolean) {
     edited_at: md.edited_at ?? null,
     deleted,
     mentions: deleted ? [] : (md.mentions ?? []),
+    ...(md.guest ? { guest: true } : {}),
     ...(anchored !== undefined ? { anchored } : {}),
   }
 }

--- a/apps/api/src/lib/mentions.ts
+++ b/apps/api/src/lib/mentions.ts
@@ -14,6 +14,18 @@ import {
 import type { Backplane } from "../bus"
 import { type Mention, previewOf } from "./comments"
 
+/** The collaborator set for an artifact: workspace members ∪ explicit artifact-share
+ *  recipients. This is the gate for who a comment may notify — a mention (bell OR email)
+ *  only reaches someone who can actually SEE the artifact, never an arbitrary registered
+ *  user id a caller supplied. Shared by the mention fan-out here and the email fan-out
+ *  (lib/notify-email) so both apply the identical rule; "could view a public artifact" is
+ *  intentionally NOT enough. */
+export const collaboratorIds = async (meta: MetaStore, a: ArtifactRecord): Promise<Set<string>> =>
+  new Set<string>([
+    ...(await meta.listMemberships(a.org_id)).map((m) => m.user_id),
+    ...(await meta.listArtifactMembers(a.id)).map((r) => r.user_id),
+  ])
+
 export const notifyMentions = async (
   deps: { meta: MetaStore; bus: Backplane },
   a: ArtifactRecord,
@@ -32,12 +44,8 @@ export const notifyMentions = async (
   // workspace or an explicit share recipient. The `mentions[]` array is caller-supplied,
   // so without this gate any caller could push a notification carrying attacker-controlled
   // title/preview to ANY other user — cross-workspace spam/phishing into the bell + SSE.
-  // "Could view a public artifact" is intentionally NOT enough; a real collaboration
-  // mention means a member/share, not a stranger.
-  const collaborators = new Set<string>([
-    ...(await meta.listMemberships(a.org_id)).map((m) => m.user_id),
-    ...(await meta.listArtifactMembers(a.id)).map((r) => r.user_id),
-  ])
+  // Same collaborator set the email fan-out gates on (see lib/notify-email).
+  const collaborators = await collaboratorIds(meta, a)
   const preview = previewOf(cm.body_md)
   // Collect the human-mention bell rows so the whole fan-out is ONE bulk insert; agent
   // mentions land in their own table (a pull inbox), still one row each.

--- a/apps/api/src/lib/notify-email.ts
+++ b/apps/api/src/lib/notify-email.ts
@@ -13,6 +13,7 @@ import type { ArtifactRecord, CommentRecord, MetaStore } from "@derive/core"
 import { enqueueChannelDelivery } from "../webhooks"
 import { quoteOf } from "./comments"
 import { buildCommentEmail } from "./email"
+import { collaboratorIds } from "./mentions"
 
 export interface EmailFanoutDeps {
   meta: MetaStore
@@ -32,6 +33,15 @@ export const enqueueCommentEmails = async (
   const recipientIds = new Set<string>(opts.mentionIds)
   recipientIds.delete("") // guard
   if (opts.actorId) recipientIds.delete(opts.actorId)
+  if (recipientIds.size === 0) return
+
+  // Gate the recipients to the artifact's collaborators (workspace members ∪ share
+  // recipients), the SAME set the bell/Slack-DM fan-out filters on (lib/mentions).
+  // getUsers resolves ANY registered user id, so without this a caller-supplied mention
+  // (e.g. an anonymous guest comment) could email an attacker-chosen author+body to any
+  // account. Email has no second re-filter downstream; this is it.
+  const collaborators = await collaboratorIds(meta, artifact)
+  for (const id of [...recipientIds]) if (!collaborators.has(id)) recipientIds.delete(id)
   if (recipientIds.size === 0) return
 
   const users = await meta.getUsers([...recipientIds])

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -54,6 +54,9 @@ export interface RateLimiters {
   write: Limiter
   publish: Limiter
   comment: Limiter
+  /** Anonymous guest comment creation, keyed by IP: far tighter than the
+   *  signed-in rate — a guest thread is a conversation, not a firehose. */
+  anonComment: Limiter
   unlock: Limiter
   /** Invite creation (workspace + artifact). Each request emails an arbitrary,
    *  possibly unwilling address with caller-influenced content (the artifact
@@ -71,7 +74,12 @@ export interface RateLimiters {
  * rates.
  */
 export function inMemoryRateLimiters(
-  opts: { publishRate?: number; commentRate?: number; askRate?: number } = {},
+  opts: {
+    publishRate?: number
+    commentRate?: number
+    anonCommentRate?: number
+    askRate?: number
+  } = {},
 ): RateLimiters {
   return {
     auth: inMemoryLimiter(60_000, 20),
@@ -82,6 +90,7 @@ export function inMemoryRateLimiters(
     write: inMemoryLimiter(60_000, 120),
     publish: inMemoryLimiter(60_000, opts.publishRate ?? 30),
     comment: inMemoryLimiter(60_000, opts.commentRate ?? 60),
+    anonComment: inMemoryLimiter(60_000, opts.anonCommentRate ?? 5),
     unlock: inMemoryLimiter(5 * 60_000, 5),
     // 10 invite emails per minute per actor: a whole team invited in one sitting
     // clears it; a spam cannon doesn't.

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -41,6 +41,7 @@ export const commentRoutes = (ctx: AppContext) => {
     background,
     actingUser,
     anonLocked,
+    isPrincipal,
     requireArtifact,
     authorize,
     limited,
@@ -189,11 +190,21 @@ export const commentRoutes = (ctx: AppContext) => {
         return bail(fail(c, 400, "anchor is too large (max 16000 characters)"))
 
       const acting = await actingUser(c)
-      const author = acting
-        ? acting.name
-        : typeof body.author === "string" && body.author
-          ? body.author
-          : "anonymous"
+      // A signed-in author is always the session identity; a guest MUST name
+      // themself (the UI requires it; the API enforces it). Names are display-
+      // only — authorization never keys on them.
+      //
+      // "Guest" means genuinely anonymous (no session, agent, or static
+      // token) — actingUser is ALSO null for the static-token principal (it
+      // authors no byline), so the name requirement keys on isPrincipal
+      // (true anonymous) rather than `!acting`, preserving the pre-existing
+      // token-authenticated body.author/"anonymous" fallback automation relies on.
+      const anon = !(await isPrincipal(c))
+      const guestName = typeof body.author === "string" ? body.author.trim() : ""
+      if (anon && !guestName) return bail(fail(c, 400, "name required"))
+      if (anon && guestName.length > 80)
+        return bail(fail(c, 400, "name is too long (max 80 characters)"))
+      const author = acting ? acting.name : guestName || "anonymous"
       const mentions = parseMentions(body.mentions)
 
       let created = await meta.createComment({
@@ -209,9 +220,15 @@ export const commentRoutes = (ctx: AppContext) => {
       })
       // Mentions live in the comment's meta JSON (the picker supplies user ids, so
       // there's no fragile server-side @name parsing); persist them with the row.
-      if (mentions.length) {
+      const metaPatch: Record<string, unknown> = {}
+      if (mentions.length) metaPatch.mentions = mentions
+      // Stamp guest authorship at write time: author_id is null for legacy
+      // signed-in rows AND token-authenticated automation too, so rendering
+      // keys on this explicit flag instead.
+      if (anon) metaPatch.guest = true
+      if (Object.keys(metaPatch).length) {
         const patched = await meta.updateComment(created.id, {
-          meta: JSON.stringify({ ...parseMeta(created.meta), mentions }),
+          meta: JSON.stringify({ ...parseMeta(created.meta), ...metaPatch }),
         })
         if (patched) created = patched
       }

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -295,7 +295,8 @@ export const commentRoutes = (ctx: AppContext) => {
       method: "get",
       path: "/v1/artifacts/{shortId}/comments",
       tags: ["Comments"],
-      summary: "List an artifact's comments (authenticated readers only).",
+      summary:
+        "List an artifact's comments (authenticated readers, or anon guests on a commenter+ link).",
       request: {
         params: z.object({ shortId: z.string() }),
         query: z.object({
@@ -312,10 +313,12 @@ export const commentRoutes = (ctx: AppContext) => {
     async (c) => {
       const artifact = await requireArtifact(c, "read")
       if (artifact instanceof Response) return bail(artifact)
-      // Comments are collaboration, not content: anonymous visitors (no account) never
-      // see them, even on a public link. Authenticated readers — including a plain
-      // viewer — do, the Google-Docs way. So the gate is "has an account", not the role.
-      if (await anonLocked(c, artifact)) return bail(fail(c, 404, "not found"))
+      // Comments are collaboration, not content: anonymous visitors on a
+      // viewer/none link never see them. A commenter+ link admits guests to
+      // the conversation they can write into, so the gate is "can comment",
+      // not "has an account".
+      if ((await anonLocked(c, artifact)) && !(await authorize(c, "comment", artifact)))
+        return bail(fail(c, 404, "not found"))
       // state is validated by the route's query contract (the enum above): an
       // out-of-enum ?state= is rejected with a 400 before we reach here, so consume
       // the typed value directly rather than re-coercing. Absent ⇒ undefined ⇒ all.

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -96,6 +96,10 @@ export const commentRoutes = (ctx: AppContext) => {
         .boolean()
         .optional()
         .describe("True if soft-deleted; the row stays but the body is blanked."),
+      guest: z
+        .boolean()
+        .optional()
+        .describe("True when the author was an anonymous guest (self-named, no account)."),
       mentions: z
         .array(MentionSchema)
         .optional()

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -46,6 +46,7 @@ export const commentRoutes = (ctx: AppContext) => {
     authorize,
     limited,
     commentLimiter,
+    anonCommentLimiter,
     sourceText,
   } = ctx
   const app = new OpenAPIHono<BlankEnv>()
@@ -157,7 +158,17 @@ export const commentRoutes = (ctx: AppContext) => {
       const artifact = await meta.getByShortId(c.req.param("shortId"))
       if (!artifact || artifact.current_version === 0) return bail(fail(c, 404, "not found"))
       if (!(await authorize(c, "comment", artifact))) return bail(fail(c, 403, "forbidden"))
-      const rl = await limited(c, commentLimiter)
+      // "Guest" means genuinely anonymous (no session, agent, or static
+      // token) — actingUser is ALSO null for the static-token principal (it
+      // authors no byline), so this keys on isPrincipal (true anonymous)
+      // rather than `!acting`, preserving the pre-existing token-authenticated
+      // body.author/"anonymous" fallback automation relies on. Computed once,
+      // up front (isPrincipal is memoized), and reused below both to pick the
+      // rate limiter and to gate the name requirement.
+      const anon = !(await isPrincipal(c))
+      // Guests get a much tighter cap than the signed-in comment rate; keyed
+      // by IP via actorKey — a guest thread is a conversation, not a firehose.
+      const rl = await limited(c, anon ? anonCommentLimiter : commentLimiter)
       if (rl) return bail(rl)
       const body = await readJson(
         c,
@@ -192,14 +203,8 @@ export const commentRoutes = (ctx: AppContext) => {
       const acting = await actingUser(c)
       // A signed-in author is always the session identity; a guest MUST name
       // themself (the UI requires it; the API enforces it). Names are display-
-      // only — authorization never keys on them.
-      //
-      // "Guest" means genuinely anonymous (no session, agent, or static
-      // token) — actingUser is ALSO null for the static-token principal (it
-      // authors no byline), so the name requirement keys on isPrincipal
-      // (true anonymous) rather than `!acting`, preserving the pre-existing
-      // token-authenticated body.author/"anonymous" fallback automation relies on.
-      const anon = !(await isPrincipal(c))
+      // only — authorization never keys on them. `anon` was resolved above
+      // (before the rate-limit check).
       const guestName = typeof body.author === "string" ? body.author.trim() : ""
       if (anon && !guestName) return bail(fail(c, 400, "name required"))
       if (anon && guestName.length > 80)

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -138,10 +138,15 @@ export const commentRoutes = (ctx: AppContext) => {
 
   // Authorship is keyed on the stable actor id, never the mutable display name:
   // renaming your profile to a victim's name must not grant edit/delete rights.
-  // Legacy rows (author_id null, written before this column) fall back to the
-  // name match so their authors don't lose access.
+  // Legacy rows (author_id null, written before this column) fall back to the name
+  // match so their authors don't lose access. GUEST rows also have a null author_id,
+  // but a self-attested guest name is unauthenticated, so they're excluded from the
+  // fallback: a member who renames their profile to a guest's display name must not be
+  // able to PATCH/DELETE that guest's comment.
   const ownsComment = (cm: CommentRecord, acting: { id: string; name: string }): boolean =>
-    cm.author_id ? cm.author_id === acting.id : cm.author === acting.name
+    cm.author_id
+      ? cm.author_id === acting.id
+      : !parseMeta(cm.meta).guest && cm.author === acting.name
 
   // Create a comment (new thread) or a reply (pass thread_id).
   app.openapi(
@@ -242,8 +247,9 @@ export const commentRoutes = (ctx: AppContext) => {
         if (patched) created = patched
       }
       // Signal-only: never put the comment body on the realtime bus. Clients refetch
-      // /comments (which is account-gated), so the content can't leak to an anonymous
-      // SSE subscriber. Webhooks carry their own payload via notify() below.
+      // /comments, readable only by callers who can comment (members, or guests on a
+      // commenter+ link) and never a viewer/none visitor, so the content can't leak to
+      // an unentitled SSE subscriber. Webhooks carry their own payload via notify() below.
       // The realtime signal goes out now (cheap, in-process); everyone watching
       // refetches. The webhook enqueues and mention notifications are best-effort
       // fan-out, so they run after the response instead of stacking sequential D1
@@ -376,6 +382,10 @@ export const commentRoutes = (ctx: AppContext) => {
     async (c) => {
       const artifact = await requireArtifact(c, "comment", { split: true })
       if (artifact instanceof Response) return bail(artifact)
+      // Route-level defense in depth: authorize("comment") now passes for anon guests
+      // (create is their one allowed mutation, gated at the door). Resolve/react/edit/
+      // delete are principal-only; never rely on the door regex alone to block them.
+      if (!(await isPrincipal(c))) return bail(fail(c, 403, "forbidden"))
       const cm = await meta.getComment(c.req.param("commentId"))
       if (!cm || cm.artifact_id !== artifact.id) return bail(fail(c, 404, "not found"))
       const body = await readJson(c, z.object({ state: z.string().optional() }))
@@ -411,6 +421,8 @@ export const commentRoutes = (ctx: AppContext) => {
       if (!r.ok) return bail(r.error)
       const { artifact, cm } = r
       if (!(await authorize(c, "comment", artifact))) return bail(fail(c, 403, "forbidden"))
+      // Principal-only (see resolve): a guest never reacts, edits, or deletes.
+      if (!(await isPrincipal(c))) return bail(fail(c, 403, "forbidden"))
       const body = await readJson(
         c,
         z.object({ emoji: z.string().refine((e) => REACTIONS.includes(e), "unknown reaction") }),
@@ -452,6 +464,8 @@ export const commentRoutes = (ctx: AppContext) => {
       if (!r.ok) return bail(r.error)
       const { artifact, cm } = r
       if (!(await authorize(c, "comment", artifact))) return bail(fail(c, 403, "forbidden"))
+      // Principal-only (see resolve): a guest never edits.
+      if (!(await isPrincipal(c))) return bail(fail(c, 403, "forbidden"))
       const acting = await actingUser(c)
       if (acting && !ownsComment(cm, acting)) return bail(fail(c, 403, "forbidden"))
       const body = await readJson(
@@ -501,6 +515,8 @@ export const commentRoutes = (ctx: AppContext) => {
       if (!r.ok) return bail(r.error)
       const { artifact, cm } = r
       if (!(await authorize(c, "comment", artifact))) return bail(fail(c, 403, "forbidden"))
+      // Principal-only (see resolve): a guest never deletes.
+      if (!(await isPrincipal(c))) return bail(fail(c, 403, "forbidden"))
       const acting = await actingUser(c)
       if (acting && !ownsComment(cm, acting)) return bail(fail(c, 403, "forbidden"))
       const md = parseMeta(cm.meta)

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -272,6 +272,10 @@ const handle = (req: Request, env: Env, ctx: ExecutionContext): Response | Promi
           write: nativeLimiter(env.RL_WRITE, 60),
           publish: nativeLimiter(env.RL_PUBLISH, 60),
           comment: nativeLimiter(env.RL_COMMENT, 60),
+          // Rides RL_STRICT (3/60), namespaced — tighter than the in-process default
+          // (5/60) since the native window can't go narrower than 60s, but same
+          // "far below the signed-in rate" intent as unlock/oauth-register below.
+          anonComment: nativeLimiter(env.RL_STRICT, 60, "anon-comment"),
           // Both ride RL_STRICT (3/60); the prefix keeps their counts separate.
           unlock: nativeLimiter(env.RL_STRICT, 60, "unlock"),
           oauthRegister: nativeLimiter(env.RL_STRICT, 60, "oauth-register"),

--- a/apps/api/test/anon-comments.test.ts
+++ b/apps/api/test/anon-comments.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest"
+import {
+  anonApp,
+  app,
+  as,
+  json,
+  jsonAs,
+  makeAuthedApp,
+  publishAs,
+  type TestUser,
+  upload,
+} from "./helpers"
+
+// Create an artifact and set its world link role; returns short_id.
+const artifactWithLink = async (linkRole: "none" | "viewer" | "commenter" | "editor") => {
+  const shortId = (
+    await (await upload("doc.md", "# feedback me", { title: "Anon commenting" })).json()
+  ).short_id as string
+  const res = await app.request(`/v1/artifacts/${shortId}/access`, {
+    ...json({ linkRole }),
+    method: "PATCH",
+  })
+  expect(res.status).toBe(200)
+  return shortId
+}
+
+describe("anonymous commenting", () => {
+  it("anon can comment on a commenter link with a name", async () => {
+    const shortId = await artifactWithLink("commenter")
+    const res = await anonApp.request(
+      `/v1/artifacts/${shortId}/comments`,
+      json({ body_md: "love this section", author: "Glen from Customer.io" }),
+    )
+    expect(res.status).toBe(201)
+    const cm = await res.json()
+    expect(cm.author).toBe("Glen from Customer.io")
+  })
+
+  it("anon without a name is rejected", async () => {
+    const shortId = await artifactWithLink("commenter")
+    for (const body of [
+      { body_md: "hi" },
+      { body_md: "hi", author: "" },
+      { body_md: "hi", author: "   " },
+    ]) {
+      const res = await anonApp.request(`/v1/artifacts/${shortId}/comments`, json(body))
+      expect(res.status).toBe(400)
+    }
+  })
+
+  it("anon with an overlong name is rejected", async () => {
+    const shortId = await artifactWithLink("commenter")
+    const res = await anonApp.request(
+      `/v1/artifacts/${shortId}/comments`,
+      json({ body_md: "hi", author: "x".repeat(81) }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it("anon cannot comment on a viewer link", async () => {
+    const shortId = await artifactWithLink("viewer")
+    const res = await anonApp.request(
+      `/v1/artifacts/${shortId}/comments`,
+      json({ body_md: "hi", author: "Guest" }),
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it("anon cannot comment on a private artifact", async () => {
+    const shortId = await artifactWithLink("none")
+    const res = await anonApp.request(
+      `/v1/artifacts/${shortId}/comments`,
+      json({ body_md: "hi", author: "Guest" }),
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it("anon can comment on an editor link but never edit or delete", async () => {
+    const shortId = await artifactWithLink("editor")
+    const created = await (
+      await anonApp.request(
+        `/v1/artifacts/${shortId}/comments`,
+        json({ body_md: "guest note", author: "Guest" }),
+      )
+    ).json()
+    // Edit: PATCH is not on the anon allow-list -> 403 at the door.
+    const edit = await anonApp.request(`/v1/artifacts/${shortId}/comments/${created.id}`, {
+      ...json({ body_md: "hijacked" }),
+      method: "PATCH",
+    })
+    expect(edit.status).toBe(403)
+    const del = await anonApp.request(`/v1/artifacts/${shortId}/comments/${created.id}`, {
+      ...json({}),
+      method: "DELETE",
+    })
+    expect(del.status).toBe(403)
+    const resolve = await anonApp.request(
+      `/v1/artifacts/${shortId}/comments/${created.id}/resolve`,
+      json({ state: "resolved" }),
+    )
+    expect(resolve.status).toBe(403)
+  })
+
+  it("signed-in callers ignore a body author (session name wins)", async () => {
+    // A real signed-in session is cheap here via makeAuthedApp/as/jsonAs (same
+    // pattern as comment-access.test.ts), so exercise the actual route code
+    // rather than asserting it in review.
+    const alice: TestUser = { id: "u_ac_alice", email: "alice@anon-comments.test", name: "Alice" }
+    const { app: app2 } = makeAuthedApp("anon-comments-signedin", [alice])
+    const shortId = (await (await publishAs(app2, "<h1>doc</h1>", {}, as(alice.email))).json())
+      .short_id as string
+    const res = await app2.request(
+      `/v1/artifacts/${shortId}/comments`,
+      jsonAs(as(alice.email), { body_md: "hi", author: "Spoof" }),
+    )
+    expect(res.status).toBe(201)
+    const cm = await res.json()
+    expect(cm.author).toBe("Alice")
+    expect(cm.author).not.toBe("Spoof")
+  })
+})

--- a/apps/api/test/anon-comments.test.ts
+++ b/apps/api/test/anon-comments.test.ts
@@ -3,13 +3,37 @@ import {
   anonApp,
   app,
   as,
+  bearer,
   json,
   jsonAs,
   makeAuthedApp,
+  pub,
   publishAs,
+  quotaApp,
+  TEST_TOKEN,
   type TestUser,
   upload,
 } from "./helpers"
+
+// Create an artifact (as the token/owner) on a given app instance and set its
+// world link role; returns short_id. Like `artifactWithLink` above but parameterized
+// on the app, for the dedicated rate-limit-enabled instance below (quotaApp's app
+// is NOT auto-authed, so setup calls must carry the token explicitly).
+const artifactWithLinkOn = async (
+  targetApp: ReturnType<typeof quotaApp>["app"],
+  linkRole: "none" | "viewer" | "commenter" | "editor",
+) => {
+  const shortId = (
+    await (await pub(targetApp, "# feedback me", { title: "Anon rate limit" })).json()
+  ).short_id as string
+  const res = await targetApp.request(`/v1/artifacts/${shortId}/access`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json", ...bearer(TEST_TOKEN) },
+    body: JSON.stringify({ linkRole }),
+  })
+  expect(res.status).toBe(200)
+  return shortId
+}
 
 // Create an artifact and set its world link role; returns short_id.
 const artifactWithLink = async (linkRole: "none" | "viewer" | "commenter" | "editor") => {
@@ -136,5 +160,23 @@ describe("anonymous commenting", () => {
     const cm = await res.json()
     expect(cm.author).toBe("Alice")
     expect(cm.author).not.toBe("Spoof")
+  })
+
+  it("anon comment creation is capped at 5/min per IP", async () => {
+    // A fresh app + store (own in-memory limiter instance) so this test's budget
+    // can never be consumed by another test in the file — quotaApp isolates both.
+    const { app: rlApp } = quotaApp("rl-anon-comment", { rateLimit: true })
+    const shortId = await artifactWithLinkOn(rlApp, "commenter")
+    let last = 0
+    for (let i = 0; i < 6; i++) {
+      // No Authorization header: rlApp (from quotaApp) is not auto-authed, so this
+      // is a genuinely anonymous caller, same as anonApp above.
+      const res = await rlApp.request(
+        `/v1/artifacts/${shortId}/comments`,
+        json({ body_md: `spam ${i}`, author: "Flood" }),
+      )
+      last = res.status
+    }
+    expect(last).toBe(429)
   })
 })

--- a/apps/api/test/anon-comments.test.ts
+++ b/apps/api/test/anon-comments.test.ts
@@ -101,6 +101,25 @@ describe("anonymous commenting", () => {
     expect(resolve.status).toBe(403)
   })
 
+  it("anon can read comments on a commenter link", async () => {
+    const shortId = await artifactWithLink("commenter")
+    await anonApp.request(
+      `/v1/artifacts/${shortId}/comments`,
+      json({ body_md: "first!", author: "Guest" }),
+    )
+    const res = await anonApp.request(`/v1/artifacts/${shortId}/comments`)
+    expect(res.status).toBe(200)
+    const list = await res.json()
+    expect(list.comments).toHaveLength(1)
+    expect(list.comments[0].author).toBe("Guest")
+  })
+
+  it("anon still cannot read comments on a viewer link", async () => {
+    const shortId = await artifactWithLink("viewer")
+    const res = await anonApp.request(`/v1/artifacts/${shortId}/comments`)
+    expect(res.status).toBe(404)
+  })
+
   it("signed-in callers ignore a body author (session name wins)", async () => {
     // A real signed-in session is cheap here via makeAuthedApp/as/jsonAs (same
     // pattern as comment-access.test.ts), so exercise the actual route code

--- a/apps/api/test/anon-comments.test.ts
+++ b/apps/api/test/anon-comments.test.ts
@@ -179,4 +179,19 @@ describe("anonymous commenting", () => {
     }
     expect(last).toBe(429)
   })
+
+  it("guest comments carry guest:true on the wire; signed rows do not", async () => {
+    const shortId = await artifactWithLink("commenter")
+    const guest = await (
+      await anonApp.request(
+        `/v1/artifacts/${shortId}/comments`,
+        json({ body_md: "guest here", author: "Guest" }),
+      )
+    ).json()
+    expect(guest.guest).toBe(true)
+    const owner = await (
+      await app.request(`/v1/artifacts/${shortId}/comments`, json({ body_md: "owner here" }))
+    ).json()
+    expect(owner.guest).toBeUndefined()
+  })
 })

--- a/apps/api/test/anon-comments.test.ts
+++ b/apps/api/test/anon-comments.test.ts
@@ -195,3 +195,102 @@ describe("anonymous commenting", () => {
     expect(owner.guest).toBeUndefined()
   })
 })
+
+// The mention[] array on a guest comment is caller-supplied and unauthenticated. Email
+// has no downstream re-filter (bells + Slack DMs do), so the route must gate the email
+// fan-out to the artifact's collaborators. Otherwise a guest could email any registered
+// user an attacker-chosen author + body. We drive the real route and inspect the outbox.
+describe("guest comment mention-email is collaborator-gated", () => {
+  const claim = (m: ReturnType<typeof quotaApp>["meta"]) =>
+    m.claimDueDeliveries(
+      new Date(Date.now() + 60_000).toISOString(),
+      100,
+      new Date(Date.now() + 120_000).toISOString(),
+    )
+
+  it("mentioning a NON-collaborator enqueues no email", async () => {
+    const collab: TestUser = { id: "u_gm_collab", email: "collab@gm.test", name: "Collab" }
+    // Registered (getUsers resolves them, they have an email) but NOT a workspace member
+    // and NOT an artifact share — a non-collaborator, the exact relay target.
+    const outsider: TestUser = { id: "u_gm_out", email: "outsider@gm.test", name: "Outsider" }
+    const { app: gmApp, meta } = quotaApp(
+      "gm-noncollab",
+      {},
+      [collab, outsider],
+      [{ user_id: collab.id, role: "editor" }],
+    )
+    const shortId = await artifactWithLinkOn(gmApp, "commenter")
+    const res = await gmApp.request(
+      `/v1/artifacts/${shortId}/comments`,
+      json({
+        body_md: "look here",
+        author: "Guest",
+        mentions: [{ id: outsider.id, name: "Outsider" }],
+      }),
+    )
+    expect(res.status).toBe(201)
+    const emails = (await claim(meta)).filter((d) => d.kind === "email")
+    expect(emails).toHaveLength(0)
+  })
+
+  it("mentioning a collaborator enqueues an email to them", async () => {
+    const collab: TestUser = { id: "u_gm_collab2", email: "collab2@gm.test", name: "Collab" }
+    const { app: gmApp, meta } = quotaApp(
+      "gm-collab",
+      {},
+      [collab],
+      [{ user_id: collab.id, role: "editor" }],
+    )
+    const shortId = await artifactWithLinkOn(gmApp, "commenter")
+    const res = await gmApp.request(
+      `/v1/artifacts/${shortId}/comments`,
+      json({
+        body_md: "look here",
+        author: "Guest",
+        mentions: [{ id: collab.id, name: "Collab" }],
+      }),
+    )
+    expect(res.status).toBe(201)
+    const emails = (await claim(meta)).filter((d) => d.kind === "email")
+    expect(emails).toHaveLength(1)
+    expect(emails[0]?.payload).toContain(collab.email)
+  })
+})
+
+// A guest row has a null author_id, and its author byline is a self-attested, unverified
+// name. So authorship must NOT fall back to a display-name match for guest rows: a member
+// who renames their profile to a guest's name must never edit or delete that guest's comment.
+describe("guest comment cannot be hijacked by a name-colliding member", () => {
+  it("a member whose name equals the guest's gets 403 on PATCH and DELETE", async () => {
+    const owner: TestUser = { id: "u_hj_owner", email: "owner@hj.test", name: "Owner" }
+    // The attacker: a signed-in member who renamed their profile to the guest's byline.
+    const evil: TestUser = { id: "u_hj_evil", email: "evil@hj.test", name: "Collision" }
+    const { app: hjApp } = makeAuthedApp("guest-hijack", [owner, evil], "editor")
+    const shortId = (await (await publishAs(hjApp, "<h1>doc</h1>", {}, as(owner.email))).json())
+      .short_id as string
+    const acc = await hjApp.request(`/v1/artifacts/${shortId}/access`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json", ...as(owner.email) },
+      body: JSON.stringify({ linkRole: "commenter" }),
+    })
+    expect(acc.status).toBe(200)
+    // A guest posts, self-naming "Collision" (the same display name the evil member wears).
+    const guest = await (
+      await hjApp.request(
+        `/v1/artifacts/${shortId}/comments`,
+        json({ body_md: "guest note", author: "Collision" }),
+      )
+    ).json()
+    expect(guest.guest).toBe(true)
+    const edit = await hjApp.request(`/v1/artifacts/${shortId}/comments/${guest.id}`, {
+      ...jsonAs(as(evil.email), { body_md: "hijacked" }),
+      method: "PATCH",
+    })
+    expect(edit.status).toBe(403)
+    const del = await hjApp.request(`/v1/artifacts/${shortId}/comments/${guest.id}`, {
+      ...jsonAs(as(evil.email), {}),
+      method: "DELETE",
+    })
+    expect(del.status).toBe(403)
+  })
+})

--- a/apps/api/test/comment-access.test.ts
+++ b/apps/api/test/comment-access.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from "vitest"
 import { as, json, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 
 // The general-access comment grant, enforced end to end at the route layer (the
-// companion to packages/core's effectiveRole matrix). The invariant under test: an
-// anonymous caller can never comment, no matter the grant — auth is the gate — while a
-// signed-in caller reaching purely via the link rises to commenter when the link allows
-// it. Mirrors the access matrix in SECURITY.md.
+// companion to packages/core's effectiveRole matrix). The invariant under test: a
+// signed-in caller reaching purely via the link rises to commenter when the link
+// allows it; an anonymous caller reaches that same cap ONLY on a commenter-or-better
+// link, and only as a self-named guest — no name, no comment (never silently
+// "anonymous"). Mirrors the access matrix in SECURITY.md.
 describe("comment access via the general-access link", () => {
   const alice: TestUser = { id: "u_ca_alice", email: "alice@ca.test", name: "Alice" }
   // Bob is signed in but reaches Alice's artifact purely via the link (his own isolated
@@ -40,7 +41,7 @@ describe("comment access via the general-access link", () => {
     ).toBe(403)
   })
 
-  it("comment link: a signed-in reacher comments; an anonymous one is forced to auth", async () => {
+  it("comment link: a signed-in reacher comments; an anonymous one must name themself", async () => {
     await app.request("/v1/me", { headers: as(alice.email) })
     const shortId = (await (await publishAs(app, "<h1>doc2</h1>", {}, as(alice.email))).json())
       .short_id
@@ -48,17 +49,24 @@ describe("comment access via the general-access link", () => {
 
     // Signed in via the link → commenter → may comment.
     expect((await comment(shortId, as(bob.email))).ok).toBe(true)
-    // Anonymous → still viewer → 403 even on a comment link (the invariant).
+    // Anonymous, no name → 400 (the guest-naming requirement), never a silent
+    // "anonymous" author.
     expect(
       (await app.request(`/v1/artifacts/${shortId}/comments`, json({ body_md: "no" }))).status,
-    ).toBe(403)
+    ).toBe(400)
+    // Anonymous, named → commenter reach applies: the guest comments too.
+    const guest = await app.request(
+      `/v1/artifacts/${shortId}/comments`,
+      json({ body_md: "guest note", author: "Guest" }),
+    )
+    expect(guest.status).toBe(201)
 
     // my_role reflects the grant per caller; the GET returns the persisted link role.
     const bobView = await (await view(shortId, as(bob.email))).json()
     expect(bobView.my_role).toBe("commenter")
     expect(bobView.link_role).toBe("commenter")
     const anonView = await (await view(shortId)).json()
-    expect(anonView.my_role).toBe("viewer")
+    expect(anonView.my_role).toBe("commenter")
   })
 
   it("revoking the comment grant locks commenting again", async () => {

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -148,8 +148,8 @@ namespace_id = "1004"
   limit = 60
   period = 60
 
-# Shared by the two tight 3/60 surfaces (unlock + oauth registration); the worker
-# namespaces the key per surface so their counts stay separate.
+# Shared by the four tight 3/60 surfaces (auth-email, anon-comment, unlock, oauth
+# registration); the worker namespaces the key per surface so their counts stay separate.
 [[ratelimits]]
 name = "RL_STRICT"
 namespace_id = "1005"

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -3953,7 +3953,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List an artifact's comments (authenticated readers only). */
+        /** List an artifact's comments (authenticated readers, or anon guests on a commenter+ link). */
         get: {
             parameters: {
                 query?: {
@@ -6160,6 +6160,8 @@ export interface components {
             edited_at?: string | null;
             /** @description True if soft-deleted; the row stays but the body is blanked. */
             deleted?: boolean;
+            /** @description True when the author was an anonymous guest (self-named, no account). */
+            guest?: boolean;
             /** @description Users or agents @mentioned in the comment body. */
             mentions?: components["schemas"]["Mention"][];
         };

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -972,6 +972,7 @@ export const api = {
       thread_id?: string
       anchor?: unknown
       mentions?: Mention[]
+      author?: string
     },
   ): Promise<Comment> => f(`/v1/artifacts/${id}/comments`, opts(body)).then(j),
   // Review rounds (the /derive loop). getReview → the pending round + history;

--- a/apps/web/src/lib/guest-name.test.ts
+++ b/apps/web/src/lib/guest-name.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { getGuestName, setGuestName } from "./guest-name"
+
+// This suite runs in vitest's "node" environment (vitest.config.ts), not jsdom — there's no
+// global `localStorage`. guest-id.test.ts never needed a stub because its cases exercise the
+// SSR guard / pure transforms, not storage itself; this helper always touches `localStorage`
+// directly, so give it a minimal in-memory Storage stand-in via vitest's own global-stubbing.
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>()
+  get length() {
+    return this.store.size
+  }
+  clear = () => this.store.clear()
+  getItem = (key: string) => this.store.get(key) ?? null
+  key = (index: number) => [...this.store.keys()][index] ?? null
+  removeItem = (key: string) => void this.store.delete(key)
+  setItem = (key: string, value: string) => void this.store.set(key, value)
+}
+vi.stubGlobal("localStorage", new MemoryStorage())
+
+describe("guest name storage", () => {
+  beforeEach(() => localStorage.clear())
+
+  it("round-trips a trimmed name", () => {
+    setGuestName("  Glen  ")
+    expect(getGuestName()).toBe("Glen")
+  })
+
+  it("returns empty when unset", () => {
+    expect(getGuestName()).toBe("")
+  })
+
+  it("caps at 80 characters", () => {
+    setGuestName("x".repeat(120))
+    expect(getGuestName()).toHaveLength(80)
+  })
+})

--- a/apps/web/src/lib/guest-name.ts
+++ b/apps/web/src/lib/guest-name.ts
@@ -1,0 +1,20 @@
+const KEY = "derive:guest-name"
+const MAX = 80
+
+/** The guest's self-provided display name, persisted per browser so external
+ *  reviewers name themselves once. Display-only — never an identity. */
+export const getGuestName = (): string => {
+  try {
+    return (localStorage.getItem(KEY) ?? "").trim().slice(0, MAX)
+  } catch {
+    return ""
+  }
+}
+
+export const setGuestName = (name: string): void => {
+  try {
+    localStorage.setItem(KEY, name.trim().slice(0, MAX))
+  } catch {
+    // Storage unavailable (private mode): the field still works per-pageload.
+  }
+}

--- a/apps/web/src/pages/artifact/artifact-actions.ts
+++ b/apps/web/src/pages/artifact/artifact-actions.ts
@@ -65,8 +65,13 @@ export function useArtifactActions(p: {
   // re-renders the composer/reply line immediately, mirrored to storage on every change.
   const [guestName, setGuestNameState] = useState(getGuestName)
   const setGuestName = (v: string) => {
+    // Persist trims (the lib), but the LIVE mirror must keep interior + trailing
+    // spaces so a name can be typed word by word — trimming here on every keystroke
+    // ate the space between "Jane" and "Doe" ("Jane Doe" collapsed to "JaneDoe").
+    // Trimming happens where it matters: at persist, at the submit-gate checks
+    // (`guestName.trim()`), and on the author sent with the comment (below).
     persistGuestName(v)
-    setGuestNameState(v.trim().slice(0, 80))
+    setGuestNameState(v.slice(0, 80))
   }
 
   const startEdit = async () => {
@@ -177,7 +182,10 @@ export function useArtifactActions(p: {
     const tempId = `temp-${crypto.randomUUID()}`
     // An anonymous poster sends their self-named `guestName` as the author (the server
     // requires it for anon on a commenter+ link); a signed-in `me` never carries one.
-    const guestAuthor = !me ? guestName : undefined
+    // Trim here: the live state mirror now keeps trailing spaces (so typing works), so
+    // the value that ships must be trimmed like the persisted one — the submit gate has
+    // already guaranteed it's non-empty.
+    const guestAuthor = !me ? guestName.trim() : undefined
     const optimistic: Comment = {
       id: tempId,
       thread_id: opts?.threadId ?? tempId,

--- a/apps/web/src/pages/artifact/artifact-actions.ts
+++ b/apps/web/src/pages/artifact/artifact-actions.ts
@@ -1,7 +1,8 @@
 import { useQueryClient } from "@tanstack/react-query"
-import type { Dispatch, SetStateAction } from "react"
+import { type Dispatch, type SetStateAction, useState } from "react"
 import { type Artifact, api, type Comment, type Mention } from "@/api"
 import { toast } from "@/components/ui/sonner"
+import { getGuestName, setGuestName as persistGuestName } from "@/lib/guest-name"
 import { commentsQuery } from "@/lib/queries"
 import { snapshot, useApiMutation } from "@/lib/use-api-mutation"
 import type { CommentActions } from "./comment-actions"
@@ -59,6 +60,14 @@ export function useArtifactActions(p: {
   const { shortId, me, post, load, refetchComments } = p
   const qc = useQueryClient()
   const commentsKey = commentsQuery(shortId).queryKey
+
+  // The guest's self-named display name (localStorage-persisted): local state so an edit
+  // re-renders the composer/reply line immediately, mirrored to storage on every change.
+  const [guestName, setGuestNameState] = useState(getGuestName)
+  const setGuestName = (v: string) => {
+    persistGuestName(v)
+    setGuestNameState(v.trim().slice(0, 80))
+  }
 
   const startEdit = async () => {
     // Load the source BEFORE opening the editor: if the fetch fails, opening an empty editor
@@ -122,16 +131,19 @@ export function useArtifactActions(p: {
     mutationFn: ({
       text,
       opts,
+      author,
     }: {
       text: string
       opts?: { threadId?: string; anchor?: Sel | null; mentions?: Mention[] }
       optimistic: Comment
+      author?: string
     }) =>
       api.comment(shortId, {
         body_md: text,
         thread_id: opts?.threadId,
         anchor: opts?.threadId ? undefined : (opts?.anchor ?? undefined),
         mentions: opts?.mentions?.length ? opts.mentions : undefined,
+        author,
       }),
     optimistic: ({ optimistic }, client) => {
       client.setQueryData<Comment[]>(commentsKey, (old) => [...(old ?? []), optimistic])
@@ -163,6 +175,9 @@ export function useArtifactActions(p: {
   ) => {
     if (!text.trim() || !p.art) return
     const tempId = `temp-${crypto.randomUUID()}`
+    // An anonymous poster sends their self-named `guestName` as the author (the server
+    // requires it for anon on a commenter+ link); a signed-in `me` never carries one.
+    const guestAuthor = !me ? guestName : undefined
     const optimistic: Comment = {
       id: tempId,
       thread_id: opts?.threadId ?? tempId,
@@ -170,13 +185,14 @@ export function useArtifactActions(p: {
       path: null,
       anchor: opts?.anchor ? JSON.stringify(opts.anchor) : null,
       body_md: text,
-      author: me?.name ?? me?.email ?? "You",
+      author: me?.name ?? me?.email ?? (guestAuthor || "You"),
       state: "open",
       created_at: new Date().toISOString(),
       reactions: {},
       mentions: opts?.mentions,
+      ...(guestAuthor ? { guest: true } : {}),
     }
-    comment.mutate({ text, opts, optimistic })
+    comment.mutate({ text, opts, optimistic, author: guestAuthor })
   }
   const reply = (text: string, threadId: string, mentions: Mention[] = []) =>
     addComment(text, { threadId, mentions })
@@ -257,6 +273,9 @@ export function useArtifactActions(p: {
   })
   const actions: CommentActions = {
     meName: me?.name ?? me?.email ?? "",
+    isGuest: !me,
+    guestName,
+    setGuestName,
     react: (commentId, emoji) => react.mutate({ commentId, emoji }),
     edit: (commentId, body) => editComment.mutate({ commentId, body }),
     remove: (commentId) => removeComment.mutate(commentId),

--- a/apps/web/src/pages/artifact/artifact-comments.tsx
+++ b/apps/web/src/pages/artifact/artifact-comments.tsx
@@ -21,8 +21,11 @@ import {
 /**
  * All the comment surfaces for an artifact, in one place: the desktop margin aside,
  * the phone slide-up sheet, and the floating "comment on the selection" affordance.
- * Hidden entirely for an anonymous visitor (read-only). The page owns the state +
- * mutations and threads them in.
+ * Shown to any viewer who can SEE comments here — a signed-in viewer (read, incl.
+ * view-only), or an anonymous commenter on a commenter+ link (`canComment`); an
+ * anonymous view-only visitor never reaches this (they get PublicViewer). Write
+ * affordances inside stay gated on `canComment`. The page owns the state + mutations
+ * and threads them in.
  */
 export function ArtifactComments(p: {
   shortId: string
@@ -132,7 +135,7 @@ export function ArtifactComments(p: {
             className="pointer-events-none fixed bottom-0 left-0 -z-10 size-px resize-none border-0 bg-transparent p-0 text-base opacity-0"
           />
         )}
-        {!isMobile && !isAnon && (
+        {!isMobile && (!isAnon || canComment) && (
           <aside
             className={cn(
               // overflow-clip: focus scrolling must never shift this box — the pin
@@ -164,7 +167,7 @@ export function ArtifactComments(p: {
         {/* Phones: comments live in a slide-up sheet that takes the bottom half, so
           the document stays visible above it. Tapping a quote scrolls the visible
           document to the highlight without closing the sheet. */}
-        {isMobile && !isAnon && (
+        {isMobile && (!isAnon || canComment) && (
           <MobileComments
             open={panel === "open"}
             openThreads={p.openThreads}

--- a/apps/web/src/pages/artifact/comment-actions.ts
+++ b/apps/web/src/pages/artifact/comment-actions.ts
@@ -4,6 +4,12 @@ import { createContext, useContext } from "react"
 // context so the deep card tree doesn't re-pass them at every level.
 export type CommentActions = {
   meName: string
+  /** True for an anonymous visitor (no `me`) — gates the guest-name field and the
+   *  optimistic author fallback. */
+  isGuest: boolean
+  /** The guest's self-provided display name (localStorage-persisted, `lib/guest-name.ts`). */
+  guestName: string
+  setGuestName: (v: string) => void
   react: (commentId: string, emoji: string) => void
   edit: (commentId: string, body: string) => Promise<void> | void
   remove: (commentId: string) => void
@@ -15,6 +21,9 @@ export type CommentActions = {
 
 const NOOP_ACTIONS: CommentActions = {
   meName: "",
+  isGuest: false,
+  guestName: "",
+  setGuestName: () => {},
   react: () => {},
   edit: () => {},
   remove: () => {},

--- a/apps/web/src/pages/artifact/comment-composer.tsx
+++ b/apps/web/src/pages/artifact/comment-composer.tsx
@@ -10,11 +10,13 @@ import {
 import { api, type DirUser, type Mention } from "@/api"
 import { Icon } from "@/components/icons"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import { Kbd } from "@/components/ui/kbd"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { PICKER_EMOJI } from "@/lib/emoji"
 import { useIsMobile } from "@/lib/use-is-mobile"
 import { cn } from "@/lib/utils"
+import { useActions } from "./comment-actions"
 import { useCommentScope } from "./lib/comment-scope"
 import { quoteChipClass } from "./quote-chip"
 
@@ -457,14 +459,26 @@ export function Composer({
   // each time.
   const [text, setText] = useState("")
   const [mentions, setMentions] = useState<Mention[]>([])
+  const { isGuest, guestName, setGuestName } = useActions()
   const submit = (resolved: Mention[]) => {
-    if (text.trim()) onSubmit(text, resolved)
+    if (text.trim() && (!isGuest || guestName.trim())) onSubmit(text, resolved)
   }
   return (
     <div
       data-testid="comment-composer"
       className="overflow-hidden rounded-lg border border-border bg-card shadow-[var(--shadow)]"
     >
+      {isGuest && (
+        <div className="px-2.5 pt-2.5">
+          <Input
+            data-testid="guest-name-input"
+            placeholder="Your name (required)"
+            value={guestName}
+            maxLength={80}
+            onChange={(e) => setGuestName(e.target.value)}
+          />
+        </div>
+      )}
       {quote && (
         // Inset with the card's padding (the reference is context, not a banner).
         // Phones get a longer multi-line preview of what you're commenting on; the
@@ -512,7 +526,7 @@ export function Composer({
           <Button
             variant="default"
             size="sm"
-            disabled={!text.trim()}
+            disabled={!text.trim() || (isGuest && !guestName.trim())}
             data-testid="composer-submit"
             onClick={() => submit(mentions.filter((m) => text.includes(`@${m.name}`)))}
           >

--- a/apps/web/src/pages/artifact/comment-composer.tsx
+++ b/apps/web/src/pages/artifact/comment-composer.tsx
@@ -69,6 +69,7 @@ export function MentionField({
   style,
   testId,
   sendTestId,
+  canSend,
   bare,
 }: {
   value: string
@@ -89,6 +90,11 @@ export function MentionField({
    *  Replaces the emoji trigger — the two share the right rail, and :shortcodes:
    *  still cover emoji here. */
   sendTestId?: string
+  /** Gate for the send affordance (Enter + the in-well ↑ button), matching the
+   *  composer's `disabled` gate. `false` disables sending even with text — the reply
+   *  line passes this so a guest with no name can't silently no-op a send. Undefined
+   *  (the default) keeps sending open once there's text. */
+  canSend?: boolean
   /** No border/ring of its own — for a field living inside a container that
    *  already draws the edge (the thread card's reply line). A bordered well
    *  inside a bordered card stacked three edges in twenty pixels. Focus shows
@@ -185,7 +191,7 @@ export function MentionField({
   // Mentions whose "@Name" survived edits are the real ones.
   const resolve = () => mentions.filter((m) => value.includes(`@${m.name}`))
   const submit = () => {
-    if (value.trim()) onSubmit(resolve())
+    if (value.trim() && canSend !== false) onSubmit(resolve())
   }
 
   const onKeyDown = (e: ReactKeyboardEvent) => {
@@ -347,6 +353,9 @@ export function MentionField({
           size="icon-xs"
           data-testid={sendTestId}
           aria-label="Send"
+          // Disabled the same way the composer's Comment button is (see canSend) —
+          // so a guest with no name sees an inert send, not one that silently no-ops.
+          disabled={canSend === false}
           // mousedown-preventDefault keeps the field focused through the click.
           onMouseDown={(e) => e.preventDefault()}
           onClick={submit}

--- a/apps/web/src/pages/artifact/comment-row.tsx
+++ b/apps/web/src/pages/artifact/comment-row.tsx
@@ -116,6 +116,15 @@ export function CommentRow({
             <AvatarFallback className="text-2xs">{getInitials(c.author)}</AvatarFallback>
           </Avatar>
           <span className="min-w-0 truncate text-sm font-medium text-foreground">{c.author}</span>
+          {c.guest && (
+            <span
+              data-testid="guest-badge"
+              className="rounded border border-border px-1 text-2xs text-muted-foreground"
+              title="Self-provided name, no account"
+            >
+              guest
+            </span>
+          )}
           {/* Terse: "1h", not "1h ago" — repeated per row, the word is noise; the
               precise date is a hover away. */}
           <span

--- a/apps/web/src/pages/artifact/comment-row.tsx
+++ b/apps/web/src/pages/artifact/comment-row.tsx
@@ -212,6 +212,10 @@ export function CommentRow({
                 <button
                   type="button"
                   data-testid={`reaction-pill-${emoji}`}
+                  // Guests can SEE reactions but can't toggle one (react is a door-blocked
+                  // mutation for them) — render the pill non-interactive rather than let an
+                  // optimistic toggle flip and roll back with an error toast.
+                  disabled={A.isGuest}
                   // title shows on mouse hover; aria-label carries the same reactor list to
                   // keyboard + touch (where title never appears), and aria-pressed exposes
                   // the toggle state.
@@ -220,7 +224,7 @@ export function CommentRow({
                   aria-pressed={reacted}
                   onClick={(e) => {
                     e.stopPropagation()
-                    A.react(c.id, emoji)
+                    if (!A.isGuest) A.react(c.id, emoji)
                   }}
                 >
                   {/* The emoji keeps its original glyph size; the count takes the pill's register. */}
@@ -253,37 +257,42 @@ export function CommentRow({
           )}
           onClick={(e) => e.stopPropagation()}
         >
-          <Popover open={open === "react"} onOpenChange={(o) => setOpen(o ? "react" : null)}>
-            <PopoverTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                aria-label="Add reaction"
-                data-testid="comment-react"
-              >
-                <Icon name="react" className="size-4" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent align="end" className="w-auto p-1">
-              <div className="grid grid-cols-4 gap-px">
-                {REACTION_EMOJI.map((em) => (
-                  <button
-                    key={em}
-                    type="button"
-                    aria-label={`React with ${em}`}
-                    data-testid={`react-emoji-${em}`}
-                    onClick={() => {
-                      A.react(c.id, em)
-                      setOpen(null)
-                    }}
-                    className="grid size-7 place-items-center rounded-md text-lg outline-none hover:bg-accent focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring"
-                  >
-                    {em}
-                  </button>
-                ))}
-              </div>
-            </PopoverContent>
-          </Popover>
+          {/* Adding a reaction is a mutation a guest can't perform (door-blocked), so the
+              trigger is hidden for guests — no dead affordance that flips optimistically
+              and rolls back. The ⋯ menu below stays (Copy link works for everyone). */}
+          {!A.isGuest && (
+            <Popover open={open === "react"} onOpenChange={(o) => setOpen(o ? "react" : null)}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label="Add reaction"
+                  data-testid="comment-react"
+                >
+                  <Icon name="react" className="size-4" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-auto p-1">
+                <div className="grid grid-cols-4 gap-px">
+                  {REACTION_EMOJI.map((em) => (
+                    <button
+                      key={em}
+                      type="button"
+                      aria-label={`React with ${em}`}
+                      data-testid={`react-emoji-${em}`}
+                      onClick={() => {
+                        A.react(c.id, em)
+                        setOpen(null)
+                      }}
+                      className="grid size-7 place-items-center rounded-md text-lg outline-none hover:bg-accent focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring"
+                    >
+                      {em}
+                    </button>
+                  ))}
+                </div>
+              </PopoverContent>
+            </Popover>
+          )}
           <DropdownMenu open={open === "menu"} onOpenChange={(o) => setOpen(o ? "menu" : null)}>
             <DropdownMenuTrigger asChild>
               <Button

--- a/apps/web/src/pages/artifact/comment-thread.tsx
+++ b/apps/web/src/pages/artifact/comment-thread.tsx
@@ -483,8 +483,11 @@ export function CommentCard({ thread, inLayer }: { thread: Comment[]; inLayer?: 
                 : "Revision applied"}
           </span>
           {/* Ready → the one click from "the agent proposed" to the review overlay that
-              lets you approve it, closing the loop without hunting through the ⋯ menu. */}
-          {requestStage === "ready" && canComment && (
+              lets you approve it, closing the loop without hunting through the ⋯ menu.
+              The review/approve loop is account-gated (a member surface), so an anonymous
+              commenter — who reaches this card via a commenter+ link — never gets the
+              trigger: it's the one comment-adjacent affordance that opens Review. */}
+          {requestStage === "ready" && canComment && !isGuest && (
             <Button
               variant="default"
               size="xs"
@@ -690,6 +693,10 @@ export function CommentCard({ thread, inLayer }: { thread: Comment[]; inLayer?: 
                   bare
                   testId="comment-reply-input"
                   sendTestId="comment-reply-send"
+                  // A guest with no name yet can't send — disable the send affordance
+                  // instead of letting it look live and silently no-op (sendReply's
+                  // guard), matching the composer's own disabled gate.
+                  canSend={!isGuest || !!guestName.trim()}
                   className="field-sizing-content max-h-32 min-h-8 resize-none px-1.5"
                   value={reply}
                   onChange={setReply}

--- a/apps/web/src/pages/artifact/comment-thread.tsx
+++ b/apps/web/src/pages/artifact/comment-thread.tsx
@@ -19,6 +19,7 @@ import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import { getInitials } from "@/lib/initials"
 import { cn } from "@/lib/utils"
 import { useActions } from "./comment-actions"
@@ -361,7 +362,7 @@ export function CommentCard({ thread, inLayer }: { thread: Comment[]; inLayer?: 
   const { canComment, currentSlide, landedSlides, anchorConf, agentIds } = useCommentScope()
   const { activeThread, hoverThread, inDoc, onActivate, onHover, onResolve, onReply, onJump } =
     useCommentTree()
-  const { openReview, meName } = useActions()
+  const { openReview, meName, isGuest, guestName, setGuestName } = useActions()
   const [reply, setReply] = useState("")
   const [replyMentions, setReplyMentions] = useState<Mention[]>([])
   const root = thread[0]
@@ -384,7 +385,7 @@ export function CommentCard({ thread, inLayer }: { thread: Comment[]; inLayer?: 
   const hovered = hoverThread === root.thread_id
   const present = inDoc[root.thread_id]
   const sendReply = (resolved: Mention[]) => {
-    if (!reply.trim()) return
+    if (!reply.trim() || (isGuest && !guestName.trim())) return
     onReply(reply, root.thread_id, resolved)
     setReply("")
     setReplyMentions([])
@@ -674,6 +675,16 @@ export function CommentCard({ thread, inLayer }: { thread: Comment[]; inLayer?: 
                 <AvatarFallback className="text-2xs">{getInitials(meName)}</AvatarFallback>
               </Avatar>
               <div className="min-w-0 flex-1">
+                {isGuest && (
+                  <Input
+                    data-testid="guest-name-reply-input"
+                    placeholder="Your name (required)"
+                    value={guestName}
+                    maxLength={80}
+                    onChange={(e) => setGuestName(e.target.value)}
+                    className="mb-1.5 h-7"
+                  />
+                )}
                 <MentionField
                   multiline
                   bare

--- a/apps/web/src/pages/artifact/comment-thread.tsx
+++ b/apps/web/src/pages/artifact/comment-thread.tsx
@@ -567,10 +567,11 @@ export function CommentCard({ thread, inLayer }: { thread: Comment[]; inLayer?: 
                 </div>
               ))}
           </div>
-          {active && (
+          {active && !isGuest && (
             // Labeled, not icon-only: at launch, "Resolve" has to teach itself.
             // Still quiet in the title bar (ghost, muted → success on hover) —
-            // the verb carries the meaning, no tooltip needed.
+            // the verb carries the meaning, no tooltip needed. Hidden for guests:
+            // resolve is a door-blocked mutation, so no dead affordance for them.
             <Button
               variant="ghost"
               size="xs"

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -1,10 +1,11 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { Link, useNavigate, useParams } from "@tanstack/react-router"
 import { Minimize2 } from "lucide-react"
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react"
 import { API_BASE, ApiError, api } from "@/api"
 import { useShell } from "@/components/chrome/shell-context"
 import { Icon } from "@/components/icons"
+import { Button } from "@/components/ui/button"
 import { Kbd } from "@/components/ui/kbd"
 import { toast } from "@/components/ui/sonner"
 import { useAuth } from "@/ctx"
@@ -689,7 +690,30 @@ export function Artifact() {
               which the API gates for anon (anonLocked). So it stays gated on `!isAnon`
               even now an anon commenter falls through: showing it would be a row of dead,
               forbidden affordances. Their comment surfaces come from the rail/sheet below
-              (which the panel opens by default), not from this bar's comments toggle. */}
+              (which the panel opens by default), not from this bar's comments toggle.
+              A commenting guest instead gets the PublicViewer growth verbs in this slot:
+              the signup CTA and a sign-in that returns to this artifact (the seam the
+              future track-this-artifact flow grows into). */}
+          {isAnon && (
+            <div className="flex items-center gap-0.5">
+              <Button asChild variant="default" size="sm" data-testid="guest-make-your-own">
+                <Link to="/login" search={{ signup: true, return_to: "/new" }}>
+                  {isMobile ? "Make yours" : "Make your own"}
+                </Link>
+              </Button>
+              <Button
+                asChild
+                variant="ghost"
+                size="sm"
+                data-testid="guest-sign-in"
+                className="max-sm:sr-only"
+              >
+                <Link to="/login" search={{ return_to: `/artifacts/${ref}` }}>
+                  Sign in
+                </Link>
+              </Button>
+            </div>
+          )}
           {!isAnon && (
             <ArtifactTopBar
               shortId={shortId}

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -25,7 +25,7 @@ import { ArtifactTopBar } from "./artifact-top-bar"
 import { BundleBar } from "./bundle-bar"
 import { ActionsCtx } from "./comment-actions"
 import { FloatingControl } from "./floating-control"
-import { canCommentWithRole, shouldPromptSignInToComment } from "./lib/comment-access"
+import { canCommentWithRole } from "./lib/comment-access"
 import { bucketThreads } from "./lib/layout"
 import { parseRef, refFor } from "./parse-ref"
 import { PasswordGate } from "./password-gate"
@@ -491,10 +491,10 @@ export function Artifact() {
   const isAnon = !me
   // Commenting needs commenter+ (matches the API's `comment` gate). A signed-in viewer
   // reading via a view-only link sees comments but gets no write affordance. An
-  // anonymous visitor never qualifies — on a comment-enabled link they get a "sign in
-  // to comment" prompt instead (auth is the gate; see the access matrix).
+  // anonymous visitor on a commenter+ link now qualifies too — their `my_role` arrives
+  // as "commenter" (see the access matrix), and the composer's guest-name field covers
+  // the rest of the gate.
   const canComment = canCommentWithRole(art.my_role)
-  const promptSignInToComment = shouldPromptSignInToComment(isAnon, art.link_role, !!art.removed)
 
   // Sort threads into pinned (anchored & present in this live doc), general
   // (unanchored / orphaned / off-slide), and resolved — pure, from the frame's
@@ -777,24 +777,6 @@ export function Artifact() {
                 {openCount > 0
                   ? `${openCount} comment${openCount === 1 ? "" : "s"}`
                   : "Show comments"}
-              </DocFab>
-            )}
-            {/* Anonymous visitor on a comment-enabled link: commenting forces auth (anon
-                stays view-only). Offer sign-in, returning here afterward. */}
-            {promptSignInToComment && (
-              <DocFab
-                title="Sign in to comment"
-                testId="sign-in-to-comment"
-                onClick={() =>
-                  nav({
-                    to: "/login",
-                    search: {
-                      return_to: `/artifacts/${refFor({ short_id: shortId, title: art.title })}`,
-                    },
-                  })
-                }
-              >
-                Sign in to comment
               </DocFab>
             )}
             {/* Focus mode: the one way back (the header is hidden). Esc also exits. */}

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -483,11 +483,13 @@ export function Artifact() {
   const canMove = art.my_role === "owner"
   const isLocked = !!art.locked
   const effectiveCanPublish = canPublish && !isLocked
-  // A logged-out visitor on a public/link artifact: strictly view-only. They get
-  // the document + live presence/cursors (Google-Docs style) and nothing else —
-  // no favorite, tags, collections, share, report, comments, or version tools.
-  // The API gates every one of those for anon (anonLocked); hiding them here keeps
-  // the chrome honest so there's no dead/forbidden affordance to bump into.
+  // A logged-out visitor on a public/link artifact. On a view-only link they're
+  // strictly view-only — the document + live presence/cursors (Google-Docs style) and
+  // nothing else — and drop into PublicViewer below. On a commenter+ link they ALSO get
+  // the comment surface (canComment below), but never the member tools: no favorite,
+  // tags, collections, share, report, or version tools. The API gates every one of
+  // those for anon (anonLocked); hiding them here keeps the chrome honest so there's no
+  // dead/forbidden affordance to bump into.
   const isAnon = !me
   // Commenting needs commenter+ (matches the API's `comment` gate). A signed-in viewer
   // reading via a view-only link sees comments but gets no write affordance. An
@@ -525,7 +527,10 @@ export function Artifact() {
   // entry point — there's no top-bar toggle or `c` key on a phone, and a hidden
   // panel made comments unreachable). Computed here rather than in the panel hook
   // so a desktop→mobile resize with a persisted "hidden" can't strand a phone.
-  const effectivePanel = isMobile && !isAnon ? "open" : panel
+  // Keyed on "can this viewer see comments here" (any signed-in viewer, or an anon
+  // commenter on a commenter+ link) — an anon view-only visitor never reaches here
+  // (PublicViewer below), so this only forces the sheet open for someone with a sheet.
+  const effectivePanel = isMobile && (!isAnon || canComment) ? "open" : panel
 
   // The rendered artifact frame — identical for the anon public viewer and the authed
   // workbench, so build it once and place it in both branches (no prop drift).
@@ -560,11 +565,14 @@ export function Artifact() {
     />
   )
 
-  // Anonymous visitor → the chrome-light public/viral viewer (the app shell has
-  // dropped the rail). The render is the hero; a slim public header carries the
-  // brand, the creator byline, presence, and the growth verbs. The comment/editor
-  // chrome is absent — the API gates every write for anon anyway.
-  if (isAnon)
+  // Anonymous view-only visitor → the chrome-light public/viral viewer (the app shell
+  // has dropped the rail). The render is the hero; a slim public header carries the
+  // brand, the creator byline, presence, and the growth verbs. The comment/editor chrome
+  // is absent — the API gates every write for a view-only anon anyway. An anon visitor
+  // who CAN comment (a commenter+ link — canComment true) falls through to the full
+  // workbench below instead, so the comment surfaces (rail, selection composer, mobile
+  // sheet) mount for them; the member-only chrome there stays gated on `!isAnon`.
+  if (isAnon && !canComment)
     return (
       <PublicViewer
         art={art}
@@ -668,8 +676,20 @@ export function Artifact() {
                 <span className="hidden sm:inline">Reconnecting…</span>
               </span>
             )}
-            <Presence viewers={live.viewers} selfId={me?.id} compact={isMobile} />
+            {/* Self id matches the live hook's (me, else the stable guest id) so an anon
+                commenter — who now reaches this facepile — filters out their own dot. */}
+            <Presence
+              viewers={live.viewers}
+              selfId={me?.id ?? guestPresenceId()}
+              compact={isMobile}
+            />
           </div>
+          {/* The workbench action bar is a signed-in workspace member's toolbar — Share,
+              favorite, tags/collections, insights, review, edit, report — every one of
+              which the API gates for anon (anonLocked). So it stays gated on `!isAnon`
+              even now an anon commenter falls through: showing it would be a row of dead,
+              forbidden affordances. Their comment surfaces come from the rail/sheet below
+              (which the panel opens by default), not from this bar's comments toggle. */}
           {!isAnon && (
             <ArtifactTopBar
               shortId={shortId}
@@ -768,17 +788,21 @@ export function Artifact() {
                 the empty panel. On mobile NEITHER exists (the toggle is desktop-only,
                 there's no keyboard), so the FAB is the sole entry point and must show
                 even at zero — otherwise a comment-less doc has no way into comments. */}
-            {!isAnon && !focus && !isMobile && panel === "hidden" && openCount > 0 && (
-              <DocFab
-                title="Show comments (c)"
-                testId="artifact-comments-fab"
-                onClick={() => setPanel("open")}
-              >
-                {openCount > 0
-                  ? `${openCount} comment${openCount === 1 ? "" : "s"}`
-                  : "Show comments"}
-              </DocFab>
-            )}
+            {(!isAnon || canComment) &&
+              !focus &&
+              !isMobile &&
+              panel === "hidden" &&
+              openCount > 0 && (
+                <DocFab
+                  title="Show comments (c)"
+                  testId="artifact-comments-fab"
+                  onClick={() => setPanel("open")}
+                >
+                  {openCount > 0
+                    ? `${openCount} comment${openCount === 1 ? "" : "s"}`
+                    : "Show comments"}
+                </DocFab>
+              )}
             {/* Focus mode: the one way back (the header is hidden). Esc also exits. */}
             {focus && (
               <FloatingControl
@@ -802,8 +826,12 @@ export function Artifact() {
               isAnon={isAnon}
               canComment={canComment}
               reviewCard={
-                // Top of the comments rail, not its own pane; members who can act only.
-                canComment ? <ReviewCard shortId={shortId} refreshKey={reviewTick} /> : undefined
+                // Top of the comments rail, not its own pane; signed-in members who can
+                // act only — never an anon commenter (the review/approve loop, incl. the
+                // card's send-back, is account-gated), so keep it off the anon path.
+                canComment && !isAnon ? (
+                  <ReviewCard shortId={shortId} refreshKey={reviewTick} />
+                ) : undefined
               }
               onSheetHeight={setSheetInset}
               docLive={docLive}

--- a/apps/web/src/pages/artifact/lib/comment-access.test.ts
+++ b/apps/web/src/pages/artifact/lib/comment-access.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { canCommentWithRole, shouldPromptSignInToComment } from "./comment-access"
+import { canCommentWithRole } from "./comment-access"
 
 // The UI side of the access matrix (the API is the hard gate; these decide which
 // affordances render). Mirrors SECURITY.md and the core permissions matrix.
@@ -11,17 +11,5 @@ describe("canCommentWithRole (write-affordance gate)", () => {
     expect(canCommentWithRole("viewer")).toBe(false)
     expect(canCommentWithRole(null)).toBe(false)
     expect(canCommentWithRole(undefined)).toBe(false)
-  })
-})
-
-describe("shouldPromptSignInToComment (anonymous CTA)", () => {
-  it("offers sign-in only to an anon visitor on a live comment-enabled link", () => {
-    expect(shouldPromptSignInToComment(true, "commenter", false)).toBe(true)
-  })
-  it("stays hidden when signing in wouldn't help, when signed in, or when removed", () => {
-    expect(shouldPromptSignInToComment(true, "viewer", false)).toBe(false) // view-only link
-    expect(shouldPromptSignInToComment(true, undefined, false)).toBe(false) // no general access
-    expect(shouldPromptSignInToComment(false, "commenter", false)).toBe(false) // already signed in
-    expect(shouldPromptSignInToComment(true, "commenter", true)).toBe(false) // tombstoned
   })
 })

--- a/apps/web/src/pages/artifact/lib/comment-access.ts
+++ b/apps/web/src/pages/artifact/lib/comment-access.ts
@@ -1,4 +1,4 @@
-import type { LinkRole, Role } from "@/api"
+import type { Role } from "@/api"
 
 /**
  * The UI side of the access matrix (the API is the hard gate; these keep the UI from
@@ -7,17 +7,8 @@ import type { LinkRole, Role } from "@/api"
  */
 
 /** May a caller with this effective role create comments/replies? Mirrors the API's
- *  `comment` gate: commenter or above. Drives every write affordance in the comment UI. */
+ *  `comment` gate: commenter or above. Drives every write affordance in the comment UI —
+ *  including an anonymous visitor, whose `my_role` now arrives as "commenter" on a
+ *  commenter+ link (the guest-name field in the composer covers the rest of the gate). */
 export const canCommentWithRole = (role: Role | null | undefined): boolean =>
   role === "commenter" || role === "editor" || role === "owner"
-
-/** Should an anonymous visitor be offered "sign in to comment"? Only when the link
- *  actually grants comment or more (so signing in would lift them past viewer) and
- *  the artifact is live. If an anonymous visitor can SEE the doc at all, the link's
- *  audience already admitted them, so only the role matters here. Anonymous never
- *  comments directly: auth is the gate. */
-export const shouldPromptSignInToComment = (
-  isAnon: boolean,
-  linkRole: LinkRole | undefined,
-  removed: boolean,
-): boolean => isAnon && (linkRole === "commenter" || linkRole === "editor") && !removed

--- a/docs/access-model.md
+++ b/docs/access-model.md
@@ -40,7 +40,8 @@ effectiveRole(actor, workspaceAccess, linkRole):
   world    = linkRole === "none"        ? null     // link off
            : locked && !unlocked        ? null     // password gate
            : actor is a signed-in user  ? linkRole // any holder, member or not
-           : "viewer"                              // anonymous clamps to viewer
+           : linkRole === "viewer"      ? "viewer" // anon: viewer link stays viewer
+           : "commenter"                           // anon: commenter/editor link caps at commenter
   return max(explicit, seat, world)
 ```
 

--- a/docs/superpowers/plans/2026-07-23-anonymous-commenting.md
+++ b/docs/superpowers/plans/2026-07-23-anonymous-commenting.md
@@ -1,0 +1,820 @@
+# Anonymous Commenting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A logged-out visitor on an artifact whose link is set to "Can comment" (or better) can read comment threads and post comments/replies under a required self-provided display name, capped at commenter, rate-limited by IP, with anonymous comments visibly badged "guest".
+
+**Architecture:** Open the two existing authorization gates narrowly (the `effectiveRole` anon clamp in `@derive/core` and the API's anonymous-write allow-list) rather than adding any new endpoint. The comment create handler already supports name-only authorship (`author` notNull, `author_id` nullable); we make that path reachable, require the name for anon, and stamp `meta.guest = true` at write time so guest rendering never misfires on legacy rows. The web composer gains a localStorage-backed name field driven through the existing actions context.
+
+**Tech Stack:** TypeScript monorepo (pnpm), Hono + @hono/zod-openapi (API), Drizzle (SQLite + Postgres), Vitest, React + TanStack Query (web), Biome.
+
+**Spec:** `docs/superpowers/specs/2026-07-23-anonymous-commenting-design.md`
+
+## Global Constraints
+
+- Branch: `feat/anon-commenting` (already created; spec committed).
+- Anonymous NEVER exceeds `commenter` — even on an `editor` link.
+- Anonymous can never edit/delete/resolve/react — only create.
+- Private (`link_role="none"`) and viewer links: zero behavior change for anon.
+- Password-locked artifacts: unlock still required before any link role applies (existing behavior, must not regress).
+- No em dashes in any user-facing copy.
+- Every new interactive control in `apps/web/src/pages/` needs a `data-testid` (`pnpm lint:testids` enforces).
+- Run all test commands from the repo root `/Users/connor/Downloads/Claude/Derive/derive`.
+- Commit format: conventional commits, ending with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Core permissions — anon holder of a commenter+ link resolves to commenter
+
+**Files:**
+- Modify: `packages/core/src/permissions.ts` (the `effectiveRole` function and the doc comment above it)
+- Test: `packages/core/test/permissions.test.ts`
+
+**Interfaces:**
+- Produces: `effectiveRole(actor, workspaceAccess, linkRole)` — unchanged signature; NEW behavior: for `actor.kind === "anon"`, `linkRole "commenter" | "editor"` yields `"commenter"` (was `"viewer"`). Every API `authorize()` call inherits this automatically.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/core/test/permissions.test.ts` (match the file's existing describe/it style — read the file first and place these in the existing `effectiveRole` describe block if one exists, else add one):
+
+```ts
+describe("anonymous commenter links", () => {
+  const anon = { kind: "anon" as const, locked: false, unlocked: false }
+
+  it("anon on a commenter link gets commenter", () => {
+    expect(effectiveRole(anon, "none", "commenter")).toBe("commenter")
+  })
+
+  it("anon on an editor link is capped at commenter", () => {
+    expect(effectiveRole(anon, "none", "editor")).toBe("commenter")
+  })
+
+  it("anon on a viewer link stays viewer", () => {
+    expect(effectiveRole(anon, "none", "viewer")).toBe("viewer")
+  })
+
+  it("anon with no link gets nothing", () => {
+    expect(effectiveRole(anon, "none", "none")).toBeNull()
+  })
+
+  it("anon on a locked commenter link gets nothing until unlocked", () => {
+    const lockedAnon = { kind: "anon" as const, locked: true, unlocked: false }
+    expect(effectiveRole(lockedAnon, "none", "commenter")).toBeNull()
+    const unlockedAnon = { kind: "anon" as const, locked: true, unlocked: true }
+    expect(effectiveRole(unlockedAnon, "none", "commenter")).toBe("commenter")
+  })
+
+  it("anon can comment but never edit/publish on an editor link", () => {
+    expect(can(anon, "comment", "none", "editor")).toBe(true)
+    expect(can(anon, "publish", "none", "editor")).toBe(false)
+    expect(can(anon, "propose", "none", "editor")).toBe(true)
+    expect(can(anon, "share", "none", "editor")).toBe(false)
+  })
+
+  it("signed-in holder still gets the link's full role", () => {
+    const user = { kind: "user" as const, locked: false, unlocked: false }
+    expect(effectiveRole(user, "none", "editor")).toBe("editor")
+  })
+})
+```
+
+Note: check the actual `Actor` type shape and `can()` signature in `permissions.ts` before writing — if `can()` takes `(actor, action, workspaceAccess, linkRole)` in a different order or `Actor` requires more fields (e.g. `artifactRole`), adapt the test calls to the real signatures. The behavioral assertions stay exactly as above.
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `pnpm --filter @derive/core test -- permissions`
+Expected: the three NEW-behavior tests fail (`commenter` expected, got `viewer`); the unchanged-behavior tests pass.
+
+- [ ] **Step 3: Implement**
+
+In `packages/core/src/permissions.ts`, `effectiveRole`, replace the `world` computation:
+
+```ts
+  // The world link: anyone with the URL. A password suspends it until unlocked.
+  // A signed-in holder gets the link's role. An anonymous holder is capped at
+  // commenter: a "can comment" (or better) link admits named guest comments,
+  // but no anonymous caller ever holds a writing role past commenter.
+  const world: Role | null =
+    linkRole === "none"
+      ? null
+      : actor.locked && !actor.unlocked
+        ? null
+        : actor.kind === "user"
+          ? linkRole
+          : linkRole === "viewer"
+            ? "viewer"
+            : "commenter"
+```
+
+Also rewrite the invariant paragraph in the doc comment above the function (the block starting "Invariant: an anonymous caller is never more than `viewer`"):
+
+```
+ * Invariant: an anonymous caller is never more than `commenter`, and reaches
+ * commenter only through an explicit commenter-or-better world link. Publish,
+ * approve, share, and manage always need an authenticated identity. The old
+ * rule ("anon is never more than viewer") was relaxed 2026-07 so external
+ * reviewers can leave named guest comments on a "can comment" link.
+```
+
+And update the WORLD LINK bullet ("an anonymous holder is always clamped to `viewer`") to match: "a signed-in holder gets `linkRole`; an anonymous holder is capped at `commenter`."
+
+- [ ] **Step 4: Run the full core suite**
+
+Run: `pnpm --filter @derive/core test`
+Expected: all pass. If an existing test asserts the old viewer clamp, update that assertion to the new rule (it is a deliberate behavior change, note it in the commit body).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/permissions.ts packages/core/test/permissions.test.ts
+git commit -m "feat(core): anonymous holders of commenter+ links resolve to commenter
+
+Relaxes the anon-is-never-more-than-viewer invariant to anon-is-never-
+more-than-commenter, and only via an explicit commenter-or-better world
+link. Editor links cap anonymous at commenter. Viewer/none links and
+locked artifacts are unchanged.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: API — anonymous comment create with a required name + guest stamp
+
+**Files:**
+- Modify: `apps/api/src/app.ts` (ANON_WRITE_ALLOW)
+- Modify: `apps/api/src/routes/comments.ts` (create handler)
+- Test: `apps/api/test/anon-comments.test.ts` (new file)
+
+**Interfaces:**
+- Consumes: Task 1's `effectiveRole` change (route `authorize(c, "comment", artifact)` now passes for anon on commenter links).
+- Produces: `POST /v1/artifacts/{shortId}/comments` reachable anonymously; anon requests require non-empty `body.author` (≤80 chars) → else 400 `"name required"`; created row has `author_id = null` and comment `meta` JSON containing `guest: true`. Task 5 exposes `guest` on the wire; Task 3 opens reads.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/api/test/anon-comments.test.ts`. Use the existing helpers: `app` (token-authed proxy), `anonApp` (the same app with NO auth — the anonymous caller), `json` (POST opts), `upload` (creates an artifact as the token owner). Look at `apps/api/test/helpers.ts` and `apps/api/test/comments.test.ts` first to confirm the exact call shapes.
+
+```ts
+import { describe, expect, it } from "vitest"
+import { anonApp, app, json, upload } from "./helpers"
+
+// Create an artifact and set its world link role; returns short_id.
+const artifactWithLink = async (linkRole: "none" | "viewer" | "commenter" | "editor") => {
+  const shortId = (
+    await (await upload("doc.md", "# feedback me", { title: "Anon commenting" })).json()
+  ).short_id as string
+  const res = await app.request(`/v1/artifacts/${shortId}/access`, {
+    ...json({ linkRole }),
+    method: "PATCH",
+  })
+  expect(res.status).toBe(200)
+  return shortId
+}
+
+describe("anonymous commenting", () => {
+  it("anon can comment on a commenter link with a name", async () => {
+    const shortId = await artifactWithLink("commenter")
+    const res = await anonApp.request(
+      `/v1/artifacts/${shortId}/comments`,
+      json({ body_md: "love this section", author: "Glen from Customer.io" }),
+    )
+    expect(res.status).toBe(201)
+    const cm = await res.json()
+    expect(cm.author).toBe("Glen from Customer.io")
+  })
+
+  it("anon without a name is rejected", async () => {
+    const shortId = await artifactWithLink("commenter")
+    for (const body of [{ body_md: "hi" }, { body_md: "hi", author: "" }, { body_md: "hi", author: "   " }]) {
+      const res = await anonApp.request(`/v1/artifacts/${shortId}/comments`, json(body))
+      expect(res.status).toBe(400)
+    }
+  })
+
+  it("anon with an overlong name is rejected", async () => {
+    const shortId = await artifactWithLink("commenter")
+    const res = await anonApp.request(
+      `/v1/artifacts/${shortId}/comments`,
+      json({ body_md: "hi", author: "x".repeat(81) }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it("anon cannot comment on a viewer link", async () => {
+    const shortId = await artifactWithLink("viewer")
+    const res = await anonApp.request(
+      `/v1/artifacts/${shortId}/comments`,
+      json({ body_md: "hi", author: "Guest" }),
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it("anon cannot comment on a private artifact", async () => {
+    const shortId = await artifactWithLink("none")
+    const res = await anonApp.request(
+      `/v1/artifacts/${shortId}/comments`,
+      json({ body_md: "hi", author: "Guest" }),
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it("anon can comment on an editor link but never edit or delete", async () => {
+    const shortId = await artifactWithLink("editor")
+    const created = await (
+      await anonApp.request(
+        `/v1/artifacts/${shortId}/comments`,
+        json({ body_md: "guest note", author: "Guest" }),
+      )
+    ).json()
+    // Edit: PATCH is not on the anon allow-list -> 403 at the door.
+    const edit = await anonApp.request(`/v1/artifacts/${shortId}/comments/${created.id}`, {
+      ...json({ body_md: "hijacked" }),
+      method: "PATCH",
+    })
+    expect(edit.status).toBe(403)
+    const del = await anonApp.request(`/v1/artifacts/${shortId}/comments/${created.id}`, {
+      ...json({}),
+      method: "DELETE",
+    })
+    expect(del.status).toBe(403)
+    const resolve = await anonApp.request(
+      `/v1/artifacts/${shortId}/comments/${created.id}/resolve`,
+      json({ state: "resolved" }),
+    )
+    expect(resolve.status).toBe(403)
+  })
+
+  it("signed-in callers ignore a body author (session name wins)", async () => {
+    const shortId = await artifactWithLink("commenter")
+    // `app` authenticates as the static-token owner; actingUser is null for a
+    // token principal, so use the token path's documented behavior instead:
+    // this guards the USER path via makeAuthedApp if available. Read
+    // helpers.ts; if makeAuthedApp + as() provide a real user session, use:
+    //   const res = await app2.request(..., jsonAs(as("u@x.co"), { body_md: "hi", author: "Spoof" }))
+    //   expect((await res.json()).author).not.toBe("Spoof")
+    // If that harness costs more than it earns here, assert the route code
+    // directly in review instead and drop this case.
+  })
+})
+```
+
+The last test is a judgment call: implement it with `makeAuthedApp`/`as`/`jsonAs` if those helpers give a real signed-in user cheaply (they do in other suites — see `apps/api/test/comment-access.test.ts` for usage patterns); otherwise delete the stub before committing. Do not leave a commented-out test in the final diff.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @derive/api test -- anon-comments`
+Expected: FAIL — the create cases return 403 (the anon lockdown), not 201/400.
+
+- [ ] **Step 3: Implement — allow-list the create path**
+
+In `apps/api/src/app.ts`, add to `ANON_WRITE_ALLOW` (keep the comment style of the neighboring entries):
+
+```ts
+    /^\/v1\/artifacts\/[^/]+\/comments$/, // guest comment create — role-gated in the route (commenter+ link required); create only, never edit/delete/resolve
+```
+
+The regex matches only the create path. `/comments/{id}` (PATCH/DELETE), `/comments/{id}/resolve`, and `/comments/{id}/react` do NOT match, so every other comment mutation still 403s at the door.
+
+- [ ] **Step 4: Implement — require the name and stamp guest meta**
+
+In `apps/api/src/routes/comments.ts` create handler, after `const acting = await actingUser(c)` and the existing `author` computation, replace the author block:
+
+```ts
+      const acting = await actingUser(c)
+      // A signed-in author is always the session identity; a guest MUST name
+      // themself (the UI requires it; the API enforces it). Names are display-
+      // only — authorization never keys on them.
+      const guestName = typeof body.author === "string" ? body.author.trim() : ""
+      if (!acting && !guestName) return bail(fail(c, 400, "name required"))
+      if (!acting && guestName.length > 80)
+        return bail(fail(c, 400, "name is too long (max 80 characters)"))
+      const author = acting ? acting.name : guestName
+```
+
+Then stamp the guest flag in meta at creation. The existing code persists mentions into meta after create; extend that block so a guest row always carries `guest: true` (find the `if (mentions.length)` block after `meta.createComment` and rework it):
+
+```ts
+      const metaPatch: Record<string, unknown> = {}
+      if (mentions.length) metaPatch.mentions = mentions
+      // Stamp guest authorship at write time: author_id is null for legacy
+      // signed-in rows too, so rendering keys on this explicit flag instead.
+      if (!acting) metaPatch.guest = true
+      if (Object.keys(metaPatch).length) {
+        const patched = await meta.updateComment(created.id, {
+          meta: JSON.stringify({ ...parseMeta(created.meta), ...metaPatch }),
+        })
+        if (patched) created = patched
+      }
+```
+
+Keep the existing surrounding logic (thread id, anchor cap, fan-out) untouched. `author_id: acting?.id ?? null` already does the right thing.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `pnpm --filter @derive/api test -- anon-comments`
+Expected: PASS (all cases).
+Also run: `pnpm --filter @derive/api test -- comments` and `pnpm --filter @derive/api test -- authz`
+Expected: PASS. The authz-coverage suite asserts every mutating route is protected — if it flags the comments create path as newly anon-reachable, read its failure message and extend its expected-exceptions list the same way presence/unlock are listed, preserving the suite's intent.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/app.ts apps/api/src/routes/comments.ts apps/api/test/anon-comments.test.ts
+git commit -m "feat(api): anonymous guest comments on commenter links, named + stamped
+
+Adds the comment-create path to the anonymous allow-list (create only;
+edit/delete/resolve/react still refused at the door). Guests must send a
+non-empty display name (max 80 chars); rows stamp meta.guest=true so
+guest rendering never misfires on legacy null-author_id rows.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: API — anonymous commenters can read the threads they write into
+
+**Files:**
+- Modify: `apps/api/src/routes/comments.ts` (list route gate; check the single-thread/read routes for the same `anonLocked` pattern)
+- Test: `apps/api/test/anon-comments.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: Task 1 (anon `authorize(c, "comment", artifact)` is true on commenter+ links).
+- Produces: `GET /v1/artifacts/{shortId}/comments` returns 200 + comments for anon on commenter+ links; still 404 for anon on viewer/none links.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/api/test/anon-comments.test.ts`:
+
+```ts
+  it("anon can read comments on a commenter link", async () => {
+    const shortId = await artifactWithLink("commenter")
+    await anonApp.request(
+      `/v1/artifacts/${shortId}/comments`,
+      json({ body_md: "first!", author: "Guest" }),
+    )
+    const res = await anonApp.request(`/v1/artifacts/${shortId}/comments`)
+    expect(res.status).toBe(200)
+    const list = await res.json()
+    expect(list.comments).toHaveLength(1)
+    expect(list.comments[0].author).toBe("Guest")
+  })
+
+  it("anon still cannot read comments on a viewer link", async () => {
+    const shortId = await artifactWithLink("viewer")
+    const res = await anonApp.request(`/v1/artifacts/${shortId}/comments`)
+    expect(res.status).toBe(404)
+  })
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @derive/api test -- anon-comments`
+Expected: the commenter-link read test FAILS with 404 (the `anonLocked` gate).
+
+- [ ] **Step 3: Implement**
+
+In the comments list route, the gate currently reads:
+
+```ts
+      if (await anonLocked(c, artifact)) return bail(fail(c, 404, "not found"))
+```
+
+Change to: anonymous readers are admitted exactly when they hold comment rights (i.e. the link is commenter+); otherwise the existing account gate stands:
+
+```ts
+      // Comments are collaboration, not content: anonymous visitors on a
+      // viewer/none link never see them. A commenter+ link admits guests to
+      // the conversation they can write into, so the gate is "can comment",
+      // not "has an account".
+      if ((await anonLocked(c, artifact)) && !(await authorize(c, "comment", artifact)))
+        return bail(fail(c, 404, "not found"))
+```
+
+Grep `comments.ts` for every other `anonLocked` use (single-comment GET, thread endpoints, reactions listing if present) and apply the same compound gate ONLY to pure read endpoints. Leave any mutation gate untouched.
+
+- [ ] **Step 4: Run the API suite**
+
+Run: `pnpm --filter @derive/api test -- anon-comments` then `pnpm --filter @derive/api test -- comment`
+Expected: PASS everywhere (comment-access.test.ts is the suite most likely to assert the old 404; update any case that asserted anon-404 on a commenter link, keeping the viewer-link 404 assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/comments.ts apps/api/test/anon-comments.test.ts apps/api/test/comment-access.test.ts
+git commit -m "feat(api): guests on commenter links can read the comment thread
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+(Include `comment-access.test.ts` only if it needed updating.)
+
+---
+
+### Task 4: API — stricter per-IP rate limit for anonymous comment creation
+
+**Files:**
+- Modify: `apps/api/src/lib/rate-limit.ts` (Limiters interface + builder)
+- Modify: `apps/api/src/context.ts` (expose the limiter)
+- Modify: `apps/api/src/routes/comments.ts` (pick the anon limiter for anon callers)
+- Test: `apps/api/test/anon-comments.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: existing `limited(c, limiter)` helper (keys anon callers by `ip:<clientIp>` via `actorKey` — already correct for this).
+- Produces: `limiters.anonComment` — `inMemoryLimiter(60_000, 5)` (5 creates/min/IP); context exposes `anonCommentLimiter`; the create route uses it for anon callers and keeps `commentLimiter` for signed-in.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/api/test/anon-comments.test.ts`. First check how existing rate-limit tests construct an app with limits enabled — grep `apps/api/test` for `rateLimit` (e.g. a `quotaApp` or deps override in helpers). Follow that pattern; the shared `anonApp` may have limits off. If the harness builds apps via `createApp(deps)`, construct one with `rateLimit: true` and its own store, then:
+
+```ts
+  it("anon comment creation is capped at 5/min per IP", async () => {
+    // rlApp: an app instance with rateLimit enabled, built per the existing
+    // rate-limit test pattern in this suite (see helpers/quotaApp usage).
+    const shortId = await artifactWithLinkOn(rlApp, "commenter")
+    let last = 0
+    for (let i = 0; i < 6; i++) {
+      const res = await rlAnon.request(
+        `/v1/artifacts/${shortId}/comments`,
+        json({ body_md: `spam ${i}`, author: "Flood" }),
+      )
+      last = res.status
+    }
+    expect(last).toBe(429)
+  })
+```
+
+Adapt `artifactWithLinkOn`/`rlAnon` to the actual harness shapes you find; the assertion (6th anon create in a minute → 429) is the requirement. If enabling rate limits requires a differently-authed app for the setup steps, mirror how `quotaApp` tests do setup.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @derive/api test -- anon-comments`
+Expected: FAIL — 6th request returns 201 (only the generous 60/min shared limiter applies).
+
+- [ ] **Step 3: Implement**
+
+`apps/api/src/lib/rate-limit.ts` — add to the `Limiters` interface, next to `comment`:
+
+```ts
+  /** Anonymous guest comment creation, keyed by IP: far tighter than the
+   *  signed-in rate — a guest thread is a conversation, not a firehose. */
+  anonComment: Limiter
+```
+
+and in the builder next to `comment: inMemoryLimiter(...)`:
+
+```ts
+    anonComment: inMemoryLimiter(60_000, opts.anonCommentRate ?? 5),
+```
+
+(add `anonCommentRate?: number` to the opts type alongside `commentRate`).
+
+`apps/api/src/context.ts` — next to `const commentLimiter = ...`:
+
+```ts
+  const anonCommentLimiter = deps.rateLimit ? limiters.anonComment : null
+```
+
+and add `anonCommentLimiter,` to the returned context object (next to `commentLimiter,`).
+
+`apps/api/src/routes/comments.ts` — destructure `anonCommentLimiter` alongside `commentLimiter` from the ctx, and in the create handler replace:
+
+```ts
+      const rl = await limited(c, commentLimiter)
+```
+
+with:
+
+```ts
+      // Guests get a much tighter cap than the signed-in comment rate; keyed
+      // by IP via actorKey. The acting lookup is memoized, so this is cheap.
+      const rl = await limited(c, (await actingUser(c)) ? commentLimiter : anonCommentLimiter)
+```
+
+(If `actingUser` is not already in scope at that point, hoist the existing `const acting = await actingUser(c)` above the limiter call and reuse it for both the limiter choice and the author block — do not call it twice for style points; once hoisted, use `acting ? commentLimiter : anonCommentLimiter`.)
+
+- [ ] **Step 4: Run the tests**
+
+Run: `pnpm --filter @derive/api test -- anon-comments` and `pnpm --filter @derive/api test`
+Expected: PASS; no unrelated failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/lib/rate-limit.ts apps/api/src/context.ts apps/api/src/routes/comments.ts apps/api/test/anon-comments.test.ts
+git commit -m "feat(api): tight per-IP rate limit on guest comment creation
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: API wire + types — expose `guest` on the Comment schema, regen types
+
+**Files:**
+- Modify: `apps/api/src/lib/comments.ts` (`commentJson`)
+- Modify: `apps/api/src/routes/comments.ts` (Comment zod schema)
+- Regen: `apps/api/openapi.json` (via `pnpm --filter @derive/api gen:openapi`)
+- Regen: `apps/web/src/api-types.ts` (via `pnpm --filter @derive/web gen:api-types`)
+- Test: `apps/api/test/anon-comments.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: Task 2's `meta.guest === true` stamp.
+- Produces: wire field `guest?: boolean` on every comment payload (true only for guest-authored rows); regenerated `components["schemas"]["Comment"]` so the web `Comment` type carries `guest?: boolean`. Task 7 renders the badge from it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/api/test/anon-comments.test.ts`:
+
+```ts
+  it("guest comments carry guest:true on the wire; signed rows do not", async () => {
+    const shortId = await artifactWithLink("commenter")
+    const guest = await (
+      await anonApp.request(
+        `/v1/artifacts/${shortId}/comments`,
+        json({ body_md: "guest here", author: "Guest" }),
+      )
+    ).json()
+    expect(guest.guest).toBe(true)
+    const owner = await (
+      await app.request(`/v1/artifacts/${shortId}/comments`, json({ body_md: "owner here" }))
+    ).json()
+    expect(owner.guest).toBeUndefined()
+  })
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @derive/api test -- anon-comments`
+Expected: FAIL — `guest` is undefined on the guest row (meta is stored but not unpacked to the wire).
+
+- [ ] **Step 3: Implement**
+
+`apps/api/src/lib/comments.ts`, in `commentJson`, add to the returned object (next to `deleted`):
+
+```ts
+    ...(md.guest ? { guest: true } : {}),
+```
+
+`apps/api/src/routes/comments.ts`, in the Comment zod schema (next to `deleted`):
+
+```ts
+      guest: z
+        .boolean()
+        .optional()
+        .describe("True when the author was an anonymous guest (self-named, no account)."),
+```
+
+- [ ] **Step 4: Run tests, then regenerate the spec and web types**
+
+Run: `pnpm --filter @derive/api test -- anon-comments` → PASS
+Run: `pnpm --filter @derive/api gen:openapi` (updates `apps/api/openapi.json`)
+Run: `pnpm --filter @derive/web gen:api-types` (updates `apps/web/src/api-types.ts`)
+Run: `pnpm lint:api-types` → ok
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/lib/comments.ts apps/api/src/routes/comments.ts apps/api/openapi.json apps/web/src/api-types.ts apps/api/test/anon-comments.test.ts
+git commit -m "feat(api): expose guest flag on the comment wire shape
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Web — guest name field, guest-aware create, retire "Sign in to comment"
+
+**Files:**
+- Create: `apps/web/src/lib/guest-name.ts` + `apps/web/src/lib/guest-name.test.ts`
+- Modify: `apps/web/src/api.ts` (comment body type gains `author?: string`)
+- Modify: `apps/web/src/pages/artifact/artifact-actions.ts` (send author when anon; optimistic author; expose `isGuest`, `guestName`, `setGuestName` on the actions context)
+- Modify: `apps/web/src/pages/artifact/comment-composer.tsx` (name field in `Composer`)
+- Modify: `apps/web/src/pages/artifact/comment-thread.tsx` (name field on the reply line)
+- Modify: `apps/web/src/pages/artifact/lib/comment-access.ts` + its test (retire `shouldPromptSignInToComment`)
+- Modify: `apps/web/src/pages/artifact/index.tsx` (remove the sign-in-to-comment floating button + its import)
+
+**Interfaces:**
+- Consumes: `my_role === "commenter"` now arrives for anon on commenter+ links (Task 1), so `canCommentWithRole` already shows the composer; `api.comment` passes `author` through (server requires it for anon, Task 2).
+- Produces: `getGuestName(): string` / `setGuestName(name: string): void` (localStorage key `"derive:guest-name"`, trimmed, 80-char cap) in `apps/web/src/lib/guest-name.ts`; actions context gains `isGuest: boolean`, `guestName: string`, `setGuestName(v: string): void`.
+
+- [ ] **Step 1: Write the failing unit test for the storage helper**
+
+`apps/web/src/lib/guest-name.test.ts` (mirror the style of `guest-id.test.ts` in the same directory — jsdom localStorage):
+
+```ts
+import { beforeEach, describe, expect, it } from "vitest"
+import { getGuestName, setGuestName } from "./guest-name"
+
+describe("guest name storage", () => {
+  beforeEach(() => localStorage.clear())
+
+  it("round-trips a trimmed name", () => {
+    setGuestName("  Glen  ")
+    expect(getGuestName()).toBe("Glen")
+  })
+
+  it("returns empty when unset", () => {
+    expect(getGuestName()).toBe("")
+  })
+
+  it("caps at 80 characters", () => {
+    setGuestName("x".repeat(120))
+    expect(getGuestName()).toHaveLength(80)
+  })
+
+  it("survives storage being unavailable", () => {
+    // guest-id.test.ts has the established pattern for simulating a throwing
+    // localStorage in this suite; reuse it. Both fns must no-op, not throw.
+  })
+})
+```
+
+Fill the last test body using the exact pattern found in `guest-id.test.ts` (do not invent a new mocking approach; if that file has no such case, drop this test and match whatever defensive pattern `guest-id.ts` itself uses).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @derive/web test -- guest-name`
+Expected: FAIL (module does not exist).
+
+- [ ] **Step 3: Implement the helper**
+
+`apps/web/src/lib/guest-name.ts` (mirror `guest-id.ts`'s defensive try/catch style):
+
+```ts
+const KEY = "derive:guest-name"
+const MAX = 80
+
+/** The guest's self-provided display name, persisted per browser so external
+ *  reviewers name themselves once. Display-only — never an identity. */
+export const getGuestName = (): string => {
+  try {
+    return (localStorage.getItem(KEY) ?? "").trim().slice(0, MAX)
+  } catch {
+    return ""
+  }
+}
+
+export const setGuestName = (name: string): void => {
+  try {
+    localStorage.setItem(KEY, name.trim().slice(0, MAX))
+  } catch {
+    // Storage unavailable (private mode): the field still works per-pageload.
+  }
+}
+```
+
+Run: `pnpm --filter @derive/web test -- guest-name` → PASS.
+
+- [ ] **Step 4: Thread the guest name through create**
+
+`apps/web/src/api.ts` — the `comment` method's body type gains `author?: string`:
+
+```ts
+  comment: (
+    id: string,
+    body: {
+      body_md: string
+      thread_id?: string
+      anchor?: unknown
+      mentions?: Mention[]
+      author?: string
+    },
+  ): Promise<Comment> => f(`/v1/artifacts/${id}/comments`, opts(body)).then(j),
+```
+
+`apps/web/src/pages/artifact/artifact-actions.ts`:
+1. Import the lib with an alias to avoid a name collision with the exposed setter: `import { getGuestName, setGuestName as persistGuestName } from "@/lib/guest-name"`. Add local state so edits re-render: `const [guestName, setGuestNameState] = useState(getGuestName)` and expose `const setGuestName = (v: string) => { persistGuestName(v); setGuestNameState(v.trim().slice(0, 80)) }` (persist first, then mirror to state; read the file's structure and place state where `me` lives).
+2. In `addComment`, when there is no `me`, include the author and use it optimistically:
+
+```ts
+    const guestAuthor = !me ? guestName : undefined
+    const optimistic: Comment = {
+      // ...existing fields...
+      author: me?.name ?? me?.email ?? (guestAuthor || "You"),
+      ...(guestAuthor ? { guest: true } : {}),
+    }
+```
+
+and pass `author: guestAuthor` through the mutation into `api.comment` (follow the existing `{ text, opts, optimistic }` shape — add `author` to the mutation variables and spread it into the request body).
+3. Expose on the returned actions value (next to `meName`): `isGuest: !me`, `guestName`, `setGuestName`.
+
+- [ ] **Step 5: The name field UI**
+
+`apps/web/src/pages/artifact/comment-composer.tsx` — inside `Composer`, above the `MentionField`, render for guests (get `isGuest`, `guestName`, `setGuestName` from `useActions()` — check the import used by `comment-thread.tsx` line ~364 for the exact hook name/path):
+
+```tsx
+      {isGuest && (
+        <div className="px-2.5 pt-2.5">
+          <input
+            data-testid="guest-name-input"
+            className="w-full rounded-md border border-border bg-transparent px-2 py-1 text-sm outline-none focus:border-ring"
+            placeholder="Your name (required)"
+            value={guestName}
+            maxLength={80}
+            onChange={(e) => setGuestName(e.target.value)}
+          />
+        </div>
+      )}
+```
+
+Gate submit: in `Composer`'s `submit`, require the name for guests: `if (text.trim() && (!isGuest || guestName.trim())) onSubmit(text, resolved)`. Use the design-token classes above only if they exist in this codebase's patterns — copy the exact input styling from an existing small input in `pages/` (e.g. the share dialog) rather than inventing classes, and keep `data-testid` (lint:testids requires it). NOTE: `pnpm lint:tokens` forbids hardcoded colors/text sizes — reuse existing utility classes verbatim from a neighboring input.
+
+`apps/web/src/pages/artifact/comment-thread.tsx` — the reply line (the `canComment &&` block around line 665): add the same guarded input above the reply `MentionField` when `isGuest` (pull `isGuest`, `guestName`, `setGuestName` from the same `useActions()` already destructured at line ~364), with `data-testid="guest-name-reply-input"`, and gate `sendReply` the same way.
+
+- [ ] **Step 6: Retire the sign-in prompt**
+
+- `apps/web/src/pages/artifact/lib/comment-access.ts`: delete `shouldPromptSignInToComment`.
+- `apps/web/src/pages/artifact/lib/comment-access.test.ts`: delete its cases; keep/extend `canCommentWithRole` cases.
+- `apps/web/src/pages/artifact/index.tsx`: remove the `promptSignInToComment` computation, the floating "Sign in to comment" button JSX it renders, and the now-unused import. `pnpm lint:deadcode` (knip) will catch leftovers.
+
+- [ ] **Step 7: Verify**
+
+Run: `pnpm --filter @derive/web test` → PASS
+Run: `pnpm --filter @derive/web typecheck` → clean
+Run: `pnpm lint:testids && pnpm lint:tokens && pnpm lint:frontend` → ok
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/lib/guest-name.ts apps/web/src/lib/guest-name.test.ts apps/web/src/api.ts apps/web/src/pages/artifact/artifact-actions.ts apps/web/src/pages/artifact/comment-composer.tsx apps/web/src/pages/artifact/comment-thread.tsx apps/web/src/pages/artifact/lib/comment-access.ts apps/web/src/pages/artifact/lib/comment-access.test.ts apps/web/src/pages/artifact/index.tsx
+git commit -m "feat(web): guest commenting — required name field, no more sign-in wall
+
+Anonymous visitors on commenter links now get the composer (their
+my_role arrives as commenter) with a required, localStorage-persisted
+name field on both the composer and the reply line. The floating
+'Sign in to comment' prompt is retired — the composer replaces it.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Web — guest badge on comment rows
+
+**Files:**
+- Modify: `apps/web/src/pages/artifact/comment-thread.tsx` (`CommentRow` author line)
+
+**Interfaces:**
+- Consumes: `Comment.guest?: boolean` from Task 5's regenerated types.
+- Produces: a small "guest" chip after the author name on any comment with `guest === true`.
+
+- [ ] **Step 1: Locate the author render**
+
+In `comment-thread.tsx`, find `CommentRow` and the element rendering `c.author`. Read the surrounding JSX for the exact classes used by small metadata chips in this file (the quote chip / state chips are nearby patterns).
+
+- [ ] **Step 2: Implement**
+
+Next to the author name, add (copying chip classes from an existing neighboring chip rather than these placeholders, and honoring lint:tokens):
+
+```tsx
+              {c.guest && (
+                <span
+                  data-testid="guest-badge"
+                  className="rounded border border-border px-1 text-2xs text-muted-foreground"
+                  title="Self-provided name, no account"
+                >
+                  guest
+                </span>
+              )}
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `pnpm --filter @derive/web typecheck && pnpm --filter @derive/web test` → clean/PASS
+Run: `pnpm lint:testids && pnpm lint:tokens` → ok
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/pages/artifact/comment-thread.tsx
+git commit -m "feat(web): guest badge on anonymous comments
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Full verification + PR
+
+**Files:** none new.
+
+- [ ] **Step 1: Full suite**
+
+Run from repo root:
+```bash
+pnpm -r test && pnpm -r typecheck && pnpm precommit
+```
+Expected: all green (precommit runs biome + every lint:* gate). Fix anything that fails before proceeding; do not skip gates.
+
+- [ ] **Step 2: End-to-end sanity (manual, dev server)**
+
+Run: `pnpm dev` + `pnpm dev:web`, then in a browser: publish an artifact, set link to "Can comment", open the link in a private window (logged out) and verify: composer visible with name field; posting without a name is blocked; posting with a name lands with a guest badge; the thread is readable; a viewer-link artifact still hides comments when logged out. This is the spec's acceptance walk — do it, don't assume it.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin feat/anon-commenting
+```
+
+`gh` is NOT installed on this machine — do not try it. Emit the PR-create URL (`https://github.com/derive-to/derive/pull/new/feat/anon-commenting`) plus a ready-to-paste title and body. Title: `Guest comments: anyone with a commenter link can comment, named`. Body: summarize the permission relaxation (anon capped at commenter, only via commenter+ links), the required name + guest stamp + badge, the per-IP rate limit, reads opened on commenter links, the retired sign-in wall, and the test coverage; note the deliberate invariant change in `permissions.ts` for the reviewer, and end with the standard Claude Code attribution line.

--- a/docs/superpowers/specs/2026-07-23-anonymous-commenting-design.md
+++ b/docs/superpowers/specs/2026-07-23-anonymous-commenting-design.md
@@ -1,0 +1,68 @@
+# Anonymous commenting with a required name
+
+**Date:** 2026-07-23 · **Status:** approved · **Driver:** Customer.io feedback (external-share feedback loops are blocked)
+
+## Problem
+
+An artifact shared with "Anyone with the link · Can comment" (`link_role = "commenter"`) does not actually let a logged-out visitor comment. Two deliberate gates block it:
+
+1. The anonymous-write lockdown middleware 403s every non-GET from a non-principal before routing (`apps/api/src/app.ts:360-366`; comment paths are not in `ANON_WRITE_ALLOW`).
+2. `effectiveRole` clamps any anonymous link-holder to `viewer` regardless of the link's role (`packages/core/src/permissions.ts:112-119`, "there is deliberately no 'trusted anonymous' path").
+
+The UI mirrors the clamp: the composer is hidden and a "Sign in to comment" button renders instead (`apps/web/src/pages/artifact/index.tsx:784-799`).
+
+The data model is NOT a blocker: `comment.author` is notNull, `comment.author_id` is nullable, and the create handler already computes a name-only author with `author_id: null` from a caller-supplied `body.author` (`apps/api/src/routes/comments.ts:191-209`) — currently unreachable dead code.
+
+## Change
+
+Open the two gates narrowly; no new endpoint, no schema change.
+
+### 1. Permissions (`packages/core/src/permissions.ts`)
+
+An anonymous holder of a commenter-or-better link resolves to `commenter`, capped there:
+
+- `link_role = "none"` → anon: no access (unchanged)
+- `link_role = "viewer"` → anon: `viewer` (unchanged)
+- `link_role = "commenter"` → anon: `commenter` (NEW)
+- `link_role = "editor"` → anon: `commenter` (NEW — **anonymous never exceeds commenter**)
+
+Locked (password-protected) artifacts keep the existing unlock requirement before any role applies. Signed-in users are untouched (they continue to get the link's full role). The documented invariant in `permissions.ts` is rewritten to state the new rule: anonymous is never more than `commenter`, and only via an explicit commenter+ link.
+
+Side effect (intended): `my_role` becomes `commenter` for these visitors, so the existing `canCommentWithRole` gate shows the composer with no bespoke UI wiring.
+
+### 2. Anonymous-write allow-list (`apps/api/src/app.ts`)
+
+Add ONLY the comment-create path (`POST /v1/artifacts/{shortId}/comments`) to `ANON_WRITE_ALLOW`. Edit, delete, resolve, and every other write stay principal-only. Authorization still happens in the route via `authorize(c, "comment", artifact)` — the allow-list only lets the request reach it, same pattern as presence/unlock.
+
+### 3. Comment route (`apps/api/src/routes/comments.ts`)
+
+- Anonymous create: require a non-empty trimmed `body.author` (max ~80 chars) → else 400. Store `author = name`, `author_id = null`. Never accept `body.author` from a signed-in caller (session name wins, as today).
+- Comment reads (list/thread routes) must succeed for an anon caller whose effective role is `commenter` — the current `anonLocked`-style 404 applies only below commenter. A commenter must see the thread they're writing into.
+- Rate-limit anonymous comment creation per IP using the existing rate-limit lib (`apps/api/src/lib/rate-limit.ts`) — e.g. a small burst + sustained cap; 429 beyond it. Signed-in callers are not affected.
+- Mentions/notification fan-out: an anonymous comment triggers the same @mention emails and bells as today's flow, with the self-provided name as the author byline.
+
+### 4. Web UI (`apps/web/src/pages/artifact/`)
+
+- Composer: when logged out, show a required "Your name" field above the body field. Persist the name in `localStorage` (one prompt per browser). Sent as `author` on create.
+- Keep a compact "or sign in" link near the composer (the seam the future "track this artifact" flow will grow into).
+- Retire the "Sign in to comment" floating prompt: with the permission change, every case that used to trigger it (`isAnon` + commenter/editor link) now shows the composer instead. `shouldPromptSignInToComment` (`apps/web/src/lib/comment-access.ts:19-23`) and its render site go away.
+- **Guest badge:** any comment whose `author_id` is null renders a subtle "guest" badge next to the name, everywhere comments render (panels, threads). Self-attested names must never be mistakable for verified identities.
+
+### 5. Anti-abuse posture
+
+- Scope: only artifacts whose owner explicitly set the link to commenter+. Private/view-only artifacts see zero behavior change.
+- IP rate limit on create (above).
+- Owners/editors can already delete comments — moderation exists.
+- Anonymous commenters cannot edit or delete anything, including their own comments (no identity to authorize against).
+
+## Out of scope (deliberate, tracked separately)
+
+- "Track this artifact" prompt, email capture, per-artifact subscriptions, notify-on-new-version (task #3 decomposition)
+- Anonymous→account conversion; "shared with you" association; copy-on-edit fork
+- Per-workspace anything; CAPTCHA (revisit if abuse shows up)
+
+## Testing
+
+- **Permissions truth table** (`packages/core/test/permissions.test.ts`): anon × {none, viewer, commenter, editor} link → {none, viewer, commenter, commenter}; anon `can("edit")` false even on editor link; locked artifact → no role until unlocked; signed-in unchanged.
+- **Route** (`apps/api/test/`): anon POST with name → 201, row has `author = name`, `author_id = null`; missing/blank name → 400; viewer-link artifact → 403; private artifact → 403; anon edit/delete → 403; rate limit → 429; anon list/read on commenter link → 200.
+- **Web**: name field renders only when logged out; guest badge renders for `author_id = null` comments; signed-in composer unchanged.

--- a/docs/superpowers/specs/2026-07-23-anonymous-commenting-design.md
+++ b/docs/superpowers/specs/2026-07-23-anonymous-commenting-design.md
@@ -52,7 +52,7 @@ Add ONLY the comment-create path (`POST /v1/artifacts/{shortId}/comments`) to `A
 
 - Scope: only artifacts whose owner explicitly set the link to commenter+. Private/view-only artifacts see zero behavior change.
 - IP rate limit on create (above).
-- Owners/editors can already delete comments — moderation exists.
+- Moderation today: resolve the thread, revoke the link role (cut off further guest comments), or use the instance `DERIVE_TOKEN`. Owner/editor deletion of a guest's comment is a follow-up (DELETE is author-only right now).
 - Anonymous commenters cannot edit or delete anything, including their own comments (no identity to authorize against).
 
 ## Out of scope (deliberate, tracked separately)

--- a/packages/core/src/permissions.test.ts
+++ b/packages/core/src/permissions.test.ts
@@ -125,7 +125,7 @@ describe("effectiveRole — the three grants (max of explicit, seat, world)", ()
     expect(effectiveRole(user({ orgRole: "editor" }), "member", "commenter")).toBe("editor")
   })
 
-  // WORLD LINK — anyone with the URL, incl. non-members; anon clamps to viewer.
+  // WORLD LINK — anyone with the URL, incl. non-members; anon caps at commenter.
   it("the world link grants any signed-in holder its role; a non-member too", () => {
     expect(effectiveRole(user(), "none", "viewer")).toBe("viewer")
     expect(effectiveRole(user(), "none", "commenter")).toBe("commenter")
@@ -133,11 +133,11 @@ describe("effectiveRole — the three grants (max of explicit, seat, world)", ()
     expect(effectiveRole(user({ orgRole: null }), "none", "commenter")).toBe("commenter")
   })
 
-  it("an anonymous holder is clamped to viewer, whatever the world role", () => {
+  it("an anonymous holder is capped at commenter, whatever the world role", () => {
     expect(effectiveRole(anon, "none", "viewer")).toBe("viewer")
-    expect(effectiveRole(anon, "none", "commenter")).toBe("viewer")
-    expect(effectiveRole(anon, "none", "editor")).toBe("viewer")
-    expect(can(anon, "comment", "none", "commenter")).toBe(false)
+    expect(effectiveRole(anon, "none", "commenter")).toBe("commenter")
+    expect(effectiveRole(anon, "none", "editor")).toBe("commenter")
+    expect(can(anon, "comment", "none", "commenter")).toBe(true)
   })
 
   it("link_role=none is an inert link — no world grant", () => {
@@ -190,22 +190,22 @@ describe("effectiveRole — the three grants (max of explicit, seat, world)", ()
 })
 
 describe("effectiveRole — the anonymous invariant", () => {
-  it("never elevates anon above viewer, for ANY workspace access, world role, or lock", () => {
+  it("never elevates anon above commenter, for ANY workspace access, world role, or lock", () => {
     for (const wa of WORKSPACE_ACCESS)
       for (const lr of LINK_ROLES)
         for (const locked of [false, true])
           for (const unlocked of [false, true]) {
             const role = effectiveRole({ kind: "anon", locked, unlocked }, wa, lr)
             expect(
-              role === null || role === "viewer",
+              role === null || role === "viewer" || role === "commenter",
               `anon ${wa}/${lr}/locked=${locked}/unlocked=${unlocked}`,
             ).toBe(true)
           }
   })
 
-  it("anon reaches view ONLY through the world link — never through workspace access", () => {
+  it("anon reaches access ONLY through the world link — never through workspace access", () => {
     expect(effectiveRole(anon, "none", "viewer")).toBe("viewer")
-    expect(effectiveRole(anon, "none", "editor")).toBe("viewer") // clamp, not editor
+    expect(effectiveRole(anon, "none", "editor")).toBe("commenter") // cap, not editor
     expect(effectiveRole(anon, "member", "none")).toBeNull() // never a member
     expect(effectiveRole(anon, "none", "none")).toBeNull()
     expect(effectiveRole({ kind: "anon", locked: true }, "none", "commenter")).toBeNull()
@@ -216,12 +216,24 @@ describe("effectiveRole — the anonymous invariant", () => {
 })
 
 describe("can — the one authorization gate", () => {
-  it("denies every write action to an anonymous caller, on every workspace access and world role", () => {
-    // Not even an editor-grant world link lets an account-less caller write.
+  it("denies actions past commenter to an anonymous caller, on every workspace access and world role", () => {
+    // Not even an editor-grant world link lets an account-less caller publish,
+    // approve, share, or manage — those always need an authenticated identity.
+    const beyondCommenter = WRITE_ACTIONS.filter((a) => a !== "comment" && a !== "propose")
     for (const wa of WORKSPACE_ACCESS)
       for (const lr of LINK_ROLES)
-        for (const action of WRITE_ACTIONS)
+        for (const action of beyondCommenter)
           expect(can(anon, action, wa, lr), `anon ${action} on ${wa}/${lr}`).toBe(false)
+  })
+
+  it("lets an anon caller comment/propose only via a commenter-or-better world link", () => {
+    for (const wa of WORKSPACE_ACCESS) {
+      expect(can(anon, "comment", wa, "none")).toBe(false)
+      expect(can(anon, "comment", wa, "viewer")).toBe(false)
+      expect(can(anon, "comment", wa, "commenter")).toBe(true)
+      expect(can(anon, "comment", wa, "editor")).toBe(true)
+      expect(can(anon, "propose", wa, "commenter")).toBe(true)
+    }
   })
 
   it("lets an anon caller read via a world viewer link, never via workspace access", () => {

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -84,16 +84,17 @@ export interface Actor {
  *   - `linkRole === "none"` → the link is inert.
  *   - a password (the lock) suspends it until unlocked; explicit standing and the
  *     workspace seat are untouched, so members and shares never need the password.
- *   - a signed-in holder gets `linkRole`; an anonymous holder is always clamped to
- *     `viewer` — never elevated to a writing role without an account.
+ *   - a signed-in holder gets `linkRole`; an anonymous holder is capped at
+ *     `commenter`.
  *
  * Note there is NO listing input: discovery (`listed`) carries no access, so it is
  * not part of this gate.
  *
- * Invariant: an anonymous caller is never more than `viewer`, regardless of the
- * grant. Anything past view (comment, propose, publish, share, manage) needs an
- * authenticated identity — a signed-in user or a `DERIVE_TOKEN`. There is
- * deliberately no "trusted anonymous" path.
+ * Invariant: an anonymous caller is never more than `commenter`, and reaches
+ * commenter only through an explicit commenter-or-better world link. Publish,
+ * approve, share, and manage always need an authenticated identity. The old
+ * rule ("anon is never more than viewer") was relaxed 2026-07 so external
+ * reviewers can leave named guest comments on a "can comment" link.
  */
 export function effectiveRole(
   actor: Actor,
@@ -107,8 +108,10 @@ export function effectiveRole(
   // only when the artifact grants workspace access.
   const seat: Role | null =
     workspaceAccess === "member" && actor.kind === "user" ? (actor.orgRole ?? null) : null
-  // The world link: anyone with the URL. A password suspends it until unlocked; an
-  // anonymous holder is clamped to viewer.
+  // The world link: anyone with the URL. A password suspends it until unlocked.
+  // A signed-in holder gets the link's role. An anonymous holder is capped at
+  // commenter: a "can comment" (or better) link admits named guest comments,
+  // but no anonymous caller ever holds a writing role past commenter.
   const world: Role | null =
     linkRole === "none"
       ? null
@@ -116,7 +119,9 @@ export function effectiveRole(
         ? null
         : actor.kind === "user"
           ? linkRole
-          : "viewer"
+          : linkRole === "viewer"
+            ? "viewer"
+            : "commenter"
   return maxRole(explicit, seat, world)
 }
 

--- a/packages/core/test/permissions.test.ts
+++ b/packages/core/test/permissions.test.ts
@@ -49,13 +49,13 @@ describe("effectiveRole resolution", () => {
     expect(effectiveRole(user({}), "member")).toBe(null) // no seat
     expect(effectiveRole(user({ locked: true }), "none", "viewer")).toBe(null)
   })
-  it("a static token is owner; an anonymous caller is always read-only, never above viewer", () => {
+  it("a static token is owner; an anonymous caller never gets a workspace seat or more than commenter", () => {
     expect(effectiveRole({ kind: "token" }, "member")).toBe("owner")
-    // No "open"/trusted-anonymous path exists: anon never gets a writing role, even
-    // on an editor-grant world link, and never gets a workspace seat.
+    // No "open"/trusted-anonymous path exists: anon never gets a workspace seat, and
+    // is capped at commenter even on an editor-grant world link.
     expect(effectiveRole({ kind: "anon" }, "member")).toBe(null)
     expect(effectiveRole({ kind: "anon" }, "none", "viewer")).toBe("viewer")
-    expect(effectiveRole({ kind: "anon" }, "none", "editor")).toBe("viewer")
+    expect(effectiveRole({ kind: "anon" }, "none", "editor")).toBe("commenter")
   })
 })
 
@@ -72,9 +72,10 @@ describe("can", () => {
 })
 
 // The world link (docs/access-model.md), every cell of the matrix. The
-// invariants: an anonymous holder is NEVER more than viewer; the link grants any
-// signed-in holder (member or not) its role; a non-member gets NOTHING by
-// workspace access. Mirrors SECURITY.md.
+// invariants: an anonymous holder is NEVER more than commenter (and only via an
+// explicit commenter-or-better link); the link grants any signed-in holder
+// (member or not) its role; a non-member gets NOTHING by workspace access.
+// Mirrors SECURITY.md.
 describe("the world link (access matrix)", () => {
   const anon: Actor = { kind: "anon" }
   // A signed-in caller with no share/seat — reaching purely via the world link.
@@ -89,9 +90,9 @@ describe("the world link (access matrix)", () => {
     expect(can(outsider, "comment", "none", "viewer")).toBe(false)
   })
 
-  it("world comment link: anon stays viewer (forced auth), a signed-in holder becomes commenter", () => {
-    expect(effectiveRole(anon, "none", "commenter")).toBe("viewer")
-    expect(can(anon, "comment", "none", "commenter")).toBe(false) // anon never elevated
+  it("world comment link: anon becomes commenter (guest comments), a signed-in holder becomes commenter too", () => {
+    expect(effectiveRole(anon, "none", "commenter")).toBe("commenter")
+    expect(can(anon, "comment", "none", "commenter")).toBe(true) // guest commenting
     expect(can(anon, "read", "none", "commenter")).toBe(true)
     expect(effectiveRole(outsider, "none", "commenter")).toBe("commenter")
     expect(can(outsider, "comment", "none", "commenter")).toBe(true)
@@ -118,14 +119,14 @@ describe("the world link (access matrix)", () => {
     )
   })
 
-  it("a lock: the world grant follows unlock, and never elevates anon", () => {
+  it("a lock: the world grant follows unlock, and never elevates anon past commenter", () => {
     expect(effectiveRole({ ...anon, locked: true }, "none", "commenter")).toBe(null)
     expect(effectiveRole({ kind: "anon", locked: true, unlocked: true }, "none", "commenter")).toBe(
-      "viewer",
+      "commenter",
     )
     expect(
       can({ kind: "anon", locked: true, unlocked: true }, "comment", "none", "commenter"),
-    ).toBe(false)
+    ).toBe(true)
     expect(
       effectiveRole(
         { kind: "user", userId: "u", locked: true, unlocked: true },
@@ -144,5 +145,44 @@ describe("the world link (access matrix)", () => {
     expect(effectiveRole(outsider, "none")).toBe(null)
     expect(can(outsider, "comment", "none")).toBe(false)
     expect(effectiveRole(outsider, "none", "none")).toBe(null)
+  })
+})
+
+describe("anonymous commenter links", () => {
+  const anon = { kind: "anon" as const, locked: false, unlocked: false }
+
+  it("anon on a commenter link gets commenter", () => {
+    expect(effectiveRole(anon, "none", "commenter")).toBe("commenter")
+  })
+
+  it("anon on an editor link is capped at commenter", () => {
+    expect(effectiveRole(anon, "none", "editor")).toBe("commenter")
+  })
+
+  it("anon on a viewer link stays viewer", () => {
+    expect(effectiveRole(anon, "none", "viewer")).toBe("viewer")
+  })
+
+  it("anon with no link gets nothing", () => {
+    expect(effectiveRole(anon, "none", "none")).toBeNull()
+  })
+
+  it("anon on a locked commenter link gets nothing until unlocked", () => {
+    const lockedAnon = { kind: "anon" as const, locked: true, unlocked: false }
+    expect(effectiveRole(lockedAnon, "none", "commenter")).toBeNull()
+    const unlockedAnon = { kind: "anon" as const, locked: true, unlocked: true }
+    expect(effectiveRole(unlockedAnon, "none", "commenter")).toBe("commenter")
+  })
+
+  it("anon can comment but never edit/publish on an editor link", () => {
+    expect(can(anon, "comment", "none", "editor")).toBe(true)
+    expect(can(anon, "publish", "none", "editor")).toBe(false)
+    expect(can(anon, "propose", "none", "editor")).toBe(true)
+    expect(can(anon, "share", "none", "editor")).toBe(false)
+  })
+
+  it("signed-in holder still gets the link's full role", () => {
+    const user = { kind: "user" as const, locked: false, unlocked: false }
+    expect(effectiveRole(user, "none", "editor")).toBe("editor")
   })
 })


### PR DESCRIPTION
## Summary

Anyone holding a "Can comment" (or better) link can now leave comments while logged out, under a required self-provided name. This was the top adoption blocker surfaced by Customer.io: external reviewers hit "Sign in to comment" on links that promised commenting.

**The permission change (deliberate invariant relaxation, reviewers please look here first):** `effectiveRole` in `packages/core/src/permissions.ts` previously clamped every anonymous link-holder to `viewer`. Now an anonymous holder of a commenter-or-better world link resolves to `commenter`, capped there even on editor links. Viewer/none links, password locks, and signed-in behavior are unchanged. SECURITY.md and docs/access-model.md are updated to match.

What that enables, layer by layer:

- **API create**: one new `ANON_WRITE_ALLOW` entry for the comment-create path only (edit/delete/resolve/react still refused at the door AND now also 403 route-level via `isPrincipal` defense-in-depth). Guests must send a non-empty trimmed name (max 80 chars, else 400); rows store `author_id = null` and stamp `meta.guest = true` at write time (so legacy null-author rows never render as guests).
- **API read**: guests on commenter+ links can read the threads they write into; viewer/none links still 404 comments for anonymous callers.
- **Rate limiting**: anonymous creates are capped at 5/min per IP in-process (edge builds ride the existing `RL_STRICT` binding at 3/min, namespaced). Signed-in callers keep the existing limiter.
- **Wire**: comments carry `guest: true` when guest-authored; OpenAPI + web types regenerated.
- **Web**: anonymous visitors who can comment now fall through to the full artifact page (comment rail, selection commenting, mobile sheet) instead of the comments-free PublicViewer, which remains for view-only links. The composer and reply line gain a required, localStorage-persisted "Your name" field; the "Sign in to comment" prompt is retired; guest comments render a "guest" badge so self-typed names are never mistaken for accounts. Mutation affordances guests can't use (react, resolve) are hidden for them.
- **Hardening from the whole-branch review**: mention email fan-out is now collaborator-gated (previously a guest comment could email any registered user via caller-supplied mention ids); `ownsComment`'s legacy name-match fallback excludes guest rows (a member renaming themselves to a guest's display name could otherwise edit/delete the guest's comment).

## Test evidence

- Full monorepo suite green: api 1178/1178, web 183/183, core, db, mcp, dispatcher, hosted-agent. Typecheck clean on all 7 projects; `pnpm precommit` (biome + all lint gates) passes.
- New coverage: core permissions truth table (anon x link-role matrix, cap-at-commenter, lock behavior); `apps/api/test/anon-comments.test.ts` (named create 201 / nameless 400 / overlong 400 / viewer+private 403 / edit+delete+resolve 403 / reads 200 vs 404 / 6th-in-a-minute 429 / guest wire flag both directions / mention-email collaborator gating / guest-hijack 403s).
- Live end-to-end against a real Node server: the full guest journey (400 no-name, 201 named with `guest:true`, thread read, viewer-link 403/404, all anon mutations 403) verified with curl.

## Test plan (visual pass on preview)

- [ ] Open a commenter-link artifact in a private window: composer + name field render, posting without a name is blocked client-side, a named post lands with a guest badge
- [ ] Viewer-link artifact in a private window: PublicViewer, no comment surface
- [ ] Signed-in member view: unchanged (rail, reactions, resolve, review card)
- [ ] Mobile: comment sheet opens for a guest on a commenter link

## Follow-ups (deliberately not in this PR)

- Owner/editor moderation delete for guest comments (today: resolve the thread, revoke the link role, or instance token)
- "Track this artifact" (email capture + notify-on-new-version) building on the guest-name seam
- Dedicated `RL_ANON_COMMENT` edge binding for exact 5/min parity; tighter rate-limit test asserting the full 5x201+429 pattern
- Guest badge on the mobile peek teaser; guest initials in the reply avatar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787492327&installation_model_id=428097&pr_number=520&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F520&signature=30d69bba840f7767a5821f26654e7e2c571bc3efd5f479a56215cd097c1a7bf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->