### PR TITLE
feat(agents): auto-mint a managed agent per context — nobody picks an agent

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1016,6 +1016,10 @@
             "type": "boolean",
             "description": "Served by Derive's managed executor. Hosting changes where the agent runs, never its principal or cap."
           },
+          "managed": {
+            "type": "boolean",
+            "description": "Auto-minted for one context at creation — the context's Derive access, not a user-named persona. Hidden from the roster UI."
+          },
           "created_at": {
             "type": "string"
           }
@@ -1025,6 +1029,7 @@
           "name",
           "role",
           "hosted",
+          "managed",
           "created_at"
         ]
       },
@@ -3961,6 +3966,51 @@
         }
       }
     },
+    "/v1/agents/{id}/rotate": {
+      "post": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Rotate an agent's token (Admin only) — the old bearer dies at once.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The agent, plus its NEW bearer token (shown only here).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Agent"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "token": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "token"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/me/connected-agents": {
       "get": {
         "tags": [
@@ -6866,14 +6916,26 @@
         "tags": [
           "Contexts"
         ],
-        "summary": "Create a context (wire an agent to a manifest artifact).",
+        "summary": "Create a context (wire an agent to a manifest artifact, or auto-mint one).",
         "responses": {
           "201": {
-            "description": "The created context.",
+            "description": "The created context. When no agent_id was given, agent_token carries the auto-minted agent's bearer — shown only here.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ContextInfo"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ContextInfo"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "agent_token": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
                 }
               }
             }

--- a/apps/api/src/lib/oauth-agent.ts
+++ b/apps/api/src/lib/oauth-agent.ts
@@ -127,6 +127,7 @@ export function makeOauthAgent({
           // An OAuth grant is never hosted directly: hosting means a registered
           // agent record (a grant has no server-storable credential to run with).
           hosted: 0,
+          managed: 0,
           created_at: new Date().toISOString(),
         },
       }
@@ -188,6 +189,7 @@ export function makeOauthAgent({
         created_by: userId,
         // Never hosted directly, same as the opaque-token branch above.
         hosted: 0,
+        managed: 0,
         created_at: new Date().toISOString(),
       },
     }

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -19,6 +19,7 @@ export const agentRoutes = (ctx: AppContext) => {
     name: a.name,
     role: a.role,
     hosted: a.hosted === 1,
+    managed: a.managed === 1,
     created_at: a.created_at,
   })
 
@@ -36,6 +37,11 @@ export const agentRoutes = (ctx: AppContext) => {
         .boolean()
         .describe(
           "Served by Derive's managed executor. Hosting changes where the agent runs, never its principal or cap.",
+        ),
+      managed: z
+        .boolean()
+        .describe(
+          "Auto-minted for one context at creation — the context's Derive access, not a user-named persona. Hidden from the roster UI.",
         ),
       created_at: z.string(),
     })
@@ -154,6 +160,33 @@ export const agentRoutes = (ctx: AppContext) => {
       const updated = await meta.setAgentHosted(c.req.param("id"), org, b.hosted ? 1 : 0)
       if (!updated) return bail(fail(c, 404, "agent not found"))
       return c.json(agentJson(updated))
+    },
+  )
+
+  app.openapi(
+    createRoute({
+      method: "post",
+      path: "/v1/agents/{id}/rotate",
+      tags: ["Agents"],
+      summary: "Rotate an agent's token (Admin only) — the old bearer dies at once.",
+      request: { params: z.object({ id: z.string() }) },
+      responses: {
+        200: {
+          description: "The agent, plus its NEW bearer token (shown only here).",
+          content: { "application/json": { schema: Agent.extend({ token: z.string() }) } },
+        },
+      },
+    }),
+    async (c) => {
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
+      // Same mint shape as registration; only the hash is stored. Identity, role,
+      // hosting, and attribution are untouched — rotation is a credential event,
+      // never an identity event.
+      const token = `dk_agt_${randomUUID().replace(/-/g, "")}${randomUUID().replace(/-/g, "")}`
+      const rotated = await meta.rotateAgentToken(c.req.param("id"), org, sha256(token))
+      if (!rotated) return bail(fail(c, 404, "agent not found"))
+      return c.json({ ...agentJson(rotated), token })
     },
   )
 

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto"
 import {
   type ContextAskerRecord,
   type ContextRecord,
@@ -13,6 +14,7 @@ import type { Context } from "hono"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
 import { resolveActorBrandprint } from "../lib/brandprint"
+import { sha256 } from "../lib/crypto"
 import { bail, fail, readJson } from "../lib/http"
 import { log } from "../log"
 
@@ -297,11 +299,16 @@ export const contextRoutes = (ctx: AppContext) => {
       method: "post",
       path: "/v1/contexts",
       tags: ["Contexts"],
-      summary: "Create a context (wire an agent to a manifest artifact).",
+      summary: "Create a context (wire an agent to a manifest artifact, or auto-mint one).",
       responses: {
         201: {
-          description: "The created context.",
-          content: { "application/json": { schema: ContextInfo } },
+          description:
+            "The created context. When no agent_id was given, agent_token carries the auto-minted agent's bearer — shown only here.",
+          content: {
+            "application/json": {
+              schema: ContextInfo.extend({ agent_token: z.string().optional() }),
+            },
+          },
         },
       },
     }),
@@ -320,27 +327,66 @@ export const contextRoutes = (ctx: AppContext) => {
         c,
         z.object({
           name: z.string().trim().min(1).max(80),
-          agent_id: z.string(),
+          // Omit to auto-mint a MANAGED agent for this context — the context's own
+          // Derive access, no roster persona, nothing to pick. Pass an id to run as
+          // an existing (service) agent instead.
+          agent_id: z.string().optional(),
           manifest_short_id: z.string(),
         }),
       )
       if (b instanceof Response) return bail(b)
-      const agents = await meta.listAgents(org)
-      if (!agents.some((a) => a.id === b.agent_id)) return bail(fail(c, 404, "no such agent"))
+      if (b.agent_id) {
+        const agents = await meta.listAgents(org)
+        if (!agents.some((a) => a.id === b.agent_id)) return bail(fail(c, 404, "no such agent"))
+      }
       const manifest = await meta.getByShortId(b.manifest_short_id)
       if (!manifest || manifest.org_id !== org || !(await authorize(c, "share", manifest)))
         return bail(fail(c, 404, "no such artifact"))
+      // Auto-mint under the context-create gate (publish), deliberately below the
+      // roster's manage gate: the minted agent is managed:1, caps at editor, and
+      // acts on behalf of the CREATOR (created_by = owner) — the derived-cap rule
+      // (min of registrant standing and agent role) means it can never exceed what
+      // the creator already holds, so no privilege is conferred that `publish`
+      // didn't already carry. This is what kills the "pick an agent" step.
+      let agentId = b.agent_id ?? null
+      let agentToken: string | null = null
+      if (!agentId) {
+        agentToken = `dk_agt_${randomUUID().replace(/-/g, "")}${randomUUID().replace(/-/g, "")}`
+        const mint = (name: string) =>
+          meta.createAgent({
+            id: newId("ag"),
+            org_id: org,
+            name,
+            token: sha256(agentToken as string),
+            role: "editor",
+            created_by: owner,
+            managed: 1,
+          })
+        // Agent names are unique per workspace; a context named like an existing
+        // agent ("Analytics") must not 409 the whole create — suffix and move on.
+        const minted = await mint(b.name).catch(() => mint(`${b.name} ${randomUUID().slice(0, 4)}`))
+        agentId = minted.id
+      }
       try {
         const created = await meta.createContext({
           id: newId("ctx"),
           org_id: org,
           name: b.name,
-          agent_id: b.agent_id,
+          agent_id: agentId,
           manifest_artifact_id: manifest.id,
           created_by: owner,
         })
-        return c.json(contextJson(created, manifest.short_id), 201)
+        return c.json(
+          {
+            ...contextJson(created, manifest.short_id),
+            ...(agentToken ? { agent_token: agentToken } : {}),
+          },
+          201,
+        )
       } catch {
+        // A name-collision 409 after an auto-mint must not strand an orphaned
+        // managed agent (and its live token) — unwind the mint with the create.
+        if (agentToken && agentId) await meta.deleteAgent(agentId, org).catch(() => {})
         return bail(fail(c, 409, "a context with that name already exists"))
       }
     },

--- a/apps/api/test/contexts-managed-agent.test.ts
+++ b/apps/api/test/contexts-managed-agent.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest"
+import { as, bearer, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// The end of "pick an agent": creating a context WITHOUT an agent_id auto-mints a
+// MANAGED agent — the context's own Derive access, no roster persona. The token is
+// returned exactly once on the create response; the roster marks the row managed so
+// the UI can hide it; rotation is a credential event that never touches identity.
+describe("contexts: auto-minted managed agents", () => {
+  const owner: TestUser = { id: "u_cma_own", email: "cmaown@derive.test", name: "Owner" }
+  const member: TestUser = { id: "u_cma_mem", email: "cmamem@derive.test", name: "Member" }
+  const { app } = makeAuthedApp("contexts-managed", [owner, member], "editor")
+
+  const mkManifest = async () =>
+    (await (await publishAs(app, "# A manifest", {}, as(owner.email))).json()).short_id
+
+  const mkContext = (name: string, body: object = {}) =>
+    app.request("/v1/contexts", jsonAs(as(owner.email), { name, ...body }))
+
+  it("create without agent_id mints a managed agent and returns its token ONCE", async () => {
+    await app.request("/v1/me", { headers: as(owner.email) })
+    const created = await mkContext("Ship Report", { manifest_short_id: await mkManifest() })
+    expect(created.status).toBe(201)
+    const ctx = await created.json()
+    expect(ctx.agent_id).toBeTruthy()
+    expect(ctx.agent_token).toMatch(/^dk_agt_/)
+
+    // The minted token IS a working agent bearer (not a 401)…
+    const probe = await app.request("/v1/agent/model-credential", {
+      headers: bearer(ctx.agent_token),
+    })
+    expect(probe.status).toBe(200)
+
+    // …and the roster row is marked managed, named after the context,
+    // attributed to the creator.
+    const roster = (await (await app.request("/v1/agents", { headers: as(owner.email) })).json())
+      .agents
+    const minted = roster.find((a: { id: string }) => a.id === ctx.agent_id)
+    expect(minted).toMatchObject({ name: "Ship Report", managed: true, role: "editor" })
+
+    // The token never appears anywhere again: the GET surface has no token field.
+    expect(JSON.stringify(roster)).not.toContain(ctx.agent_token)
+  })
+
+  it("a context named like an existing agent mints under a suffixed name, not a 409", async () => {
+    await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Analytics" }))
+    const created = await mkContext("Analytics", { manifest_short_id: await mkManifest() })
+    expect(created.status).toBe(201)
+    const ctx = await created.json()
+    const roster = (await (await app.request("/v1/agents", { headers: as(owner.email) })).json())
+      .agents
+    const minted = roster.find((a: { id: string }) => a.id === ctx.agent_id)
+    expect(minted.managed).toBe(true)
+    expect(minted.name).toMatch(/^Analytics .{4}$/)
+  })
+
+  it("a context-name 409 after the mint unwinds the minted agent — no orphaned tokens", async () => {
+    const manifest = await mkManifest()
+    expect((await mkContext("Dup", { manifest_short_id: manifest })).status).toBe(201)
+    const before = (await (await app.request("/v1/agents", { headers: as(owner.email) })).json())
+      .agents.length
+    const dup = await mkContext("Dup", { manifest_short_id: manifest })
+    expect(dup.status).toBe(409)
+    const after = (await (await app.request("/v1/agents", { headers: as(owner.email) })).json())
+      .agents.length
+    expect(after).toBe(before)
+  })
+
+  it("passing an explicit agent_id still works and returns NO token", async () => {
+    const ag = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Service Agent" }))
+    ).json()
+    const created = await mkContext("Runs As Service", {
+      agent_id: ag.id,
+      manifest_short_id: await mkManifest(),
+    })
+    expect(created.status).toBe(201)
+    const ctx = await created.json()
+    expect(ctx.agent_id).toBe(ag.id)
+    expect(ctx.agent_token).toBeUndefined()
+  })
+})
+
+describe("agents: token rotation", () => {
+  const owner: TestUser = { id: "u_rot_own", email: "rotown@derive.test", name: "Owner" }
+  const member: TestUser = { id: "u_rot_mem", email: "rotmem@derive.test", name: "Member" }
+  const { app } = makeAuthedApp("agents-rotate", [owner, member], "editor")
+
+  it("rotate kills the old bearer at once; the new one works; identity is untouched", async () => {
+    const ag = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Rotor" }))
+    ).json()
+    const rotated = await app.request(`/v1/agents/${ag.id}/rotate`, {
+      method: "POST",
+      headers: as(owner.email),
+    })
+    expect(rotated.status).toBe(200)
+    const r = await rotated.json()
+    expect(r.token).toMatch(/^dk_agt_/)
+    expect(r.token).not.toBe(ag.token)
+    expect(r).toMatchObject({ id: ag.id, name: "Rotor" })
+
+    const oldProbe = await app.request("/v1/agent/model-credential", {
+      headers: bearer(ag.token),
+    })
+    expect(oldProbe.status).toBe(401)
+    const newProbe = await app.request("/v1/agent/model-credential", {
+      headers: bearer(r.token),
+    })
+    expect(newProbe.status).toBe(200)
+  })
+
+  it("rotation is Admin-gated and workspace-scoped", async () => {
+    const ag = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Rotor 2" }))
+    ).json()
+    const denied = await app.request(`/v1/agents/${ag.id}/rotate`, {
+      method: "POST",
+      headers: as(member.email),
+    })
+    expect([401, 403]).toContain(denied.status)
+    const missing = await app.request("/v1/agents/ag_nope/rotate", {
+      method: "POST",
+      headers: as(owner.email),
+    })
+    expect(missing.status).toBe(404)
+  })
+})

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -1145,6 +1145,46 @@ export interface paths {
         };
         trace?: never;
     };
+    "/v1/agents/{id}/rotate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Rotate an agent's token (Admin only) — the old bearer dies at once. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The agent, plus its NEW bearer token (shown only here). */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Agent"] & {
+                            token: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/me/connected-agents": {
         parameters: {
             query?: never;
@@ -4190,7 +4230,7 @@ export interface paths {
             };
         };
         put?: never;
-        /** Create a context (wire an agent to a manifest artifact). */
+        /** Create a context (wire an agent to a manifest artifact, or auto-mint one). */
         post: {
             parameters: {
                 query?: never;
@@ -4200,13 +4240,15 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description The created context. */
+                /** @description The created context. When no agent_id was given, agent_token carries the auto-minted agent's bearer — shown only here. */
                 201: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["ContextInfo"];
+                        "application/json": components["schemas"]["ContextInfo"] & {
+                            agent_token?: string;
+                        };
                     };
                 };
             };
@@ -5745,6 +5787,8 @@ export interface components {
             role: "viewer" | "commenter" | "editor" | "owner";
             /** @description Served by Derive's managed executor. Hosting changes where the agent runs, never its principal or cap. */
             hosted: boolean;
+            /** @description Auto-minted for one context at creation — the context's Derive access, not a user-named persona. Hidden from the roster UI. */
+            managed: boolean;
             created_at: string;
         };
         ConnectedAgent: {

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -162,6 +162,7 @@ CREATE TABLE IF NOT EXISTS agent (
   role TEXT NOT NULL DEFAULT 'commenter',
   created_by TEXT,
   hosted INTEGER NOT NULL DEFAULT 0,
+  managed INTEGER NOT NULL DEFAULT 0,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   UNIQUE (token),
   UNIQUE (org_id, name)

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -974,6 +974,9 @@ export interface DirectoryStore {
 export interface AgentStore {
   // ---- Agents (mentionable principals that act via a scoped token) -------
   createAgent(a: NewAgent): Promise<AgentRecord>
+  /** Replace the agent's token hash (org-scoped). The old bearer dies at once;
+   *  identity, role, hosting, and attribution are untouched. Null = not found. */
+  rotateAgentToken(id: string, orgId: string, tokenHash: string): Promise<AgentRecord | null>
   listAgents(orgId: string): Promise<AgentRecord[]>
   /** Flip whether Derive's managed executor serves this agent. Workspace-scoped by
    *  (id, org) like deleteAgent; null when the agent isn't in this workspace. */
@@ -1345,6 +1348,9 @@ export interface AgentRecord {
   /** 1 = served by Derive's managed executor. Hosting changes where the agent
    *  runs, never its principal, role cap, or attribution. */
   hosted: 0 | 1
+  /** 1 = auto-minted for one context at creation — the context's Derive access,
+   *  not a user-named persona. Hidden from the roster UI. */
+  managed: 0 | 1
   created_at: string
 }
 export interface NewAgent {
@@ -1355,6 +1361,7 @@ export interface NewAgent {
   role: Role
   created_by?: string | null
   hosted?: 0 | 1
+  managed?: 0 | 1
 }
 
 // ---- Automations + runs: the generic agent-work primitive --------------

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -261,6 +261,9 @@ export const agent = pgTable(
     created_by: text("created_by"),
     // Served by Derive's managed executor when 1 (see schema.ts).
     hosted: integer("hosted").notNull().default(0).$type<0 | 1>(),
+    // 1 = auto-minted for one context at creation (never user-named): the context's
+    // Derive access, not a persona. The UI hides managed agents from the roster.
+    managed: integer("managed").notNull().default(0).$type<0 | 1>(),
     created_at: text("created_at").notNull().$defaultFn(isoNow),
   },
   (t) => [

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -2445,6 +2445,18 @@ export class PgMetaStore implements MetaStore {
     const rows = await this.db.insert(agent).values(a).returning()
     return one(rows)
   }
+  async rotateAgentToken(
+    id: string,
+    orgId: string,
+    tokenHash: string,
+  ): Promise<AgentRecord | null> {
+    const rows = await this.db
+      .update(agent)
+      .set({ token: tokenHash })
+      .where(and(eq(agent.id, id), eq(agent.org_id, orgId)))
+      .returning()
+    return (rows[0] as AgentRecord | undefined) ?? null
+  }
   listAgents(orgId: string): Promise<AgentRecord[]> {
     return this.db.select().from(agent).where(eq(agent.org_id, orgId))
   }

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -2478,6 +2478,17 @@ export function makeRepos(db: SqliteDb) {
   // ---- Agents + pull inbox -----------------------------------------------
   const createAgent = async (a: NewAgent): Promise<AgentRecord> =>
     (await db.insert(agent).values(a).returning().get()) as AgentRecord
+  const rotateAgentToken = async (
+    id: string,
+    orgId: string,
+    tokenHash: string,
+  ): Promise<AgentRecord | null> =>
+    ((await db
+      .update(agent)
+      .set({ token: tokenHash })
+      .where(and(eq(agent.id, id), eq(agent.org_id, orgId)))
+      .returning()
+      .get()) as AgentRecord | undefined) ?? null
   const listAgents = async (orgId: string): Promise<AgentRecord[]> =>
     db.select().from(agent).where(eq(agent.org_id, orgId)).all()
   const setAgentHosted = async (
@@ -3350,6 +3361,7 @@ export function makeRepos(db: SqliteDb) {
     unreadNotificationCount,
     markNotificationsRead,
     createAgent,
+    rotateAgentToken,
     listAgents,
     setAgentHosted,
     createAutomation,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -305,6 +305,9 @@ export const agent = sqliteTable(
     // Served by Derive's managed executor when 1. Hosting changes WHERE the
     // agent runs — never its principal, role cap, or attribution.
     hosted: integer("hosted").notNull().default(0).$type<0 | 1>(),
+    // 1 = auto-minted for one context at creation (never user-named): the context's
+    // Derive access, not a persona. The UI hides managed agents from the roster.
+    managed: integer("managed").notNull().default(0).$type<0 | 1>(),
     created_at: text("created_at").notNull().default(now),
   },
   (t) => [

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1473,6 +1473,36 @@ export function runStoreContract(
       await store.deleteAgent(agent.id, ORG)
       expect(await store.getAgentByToken(token)).toBeNull()
     })
+
+    it("rotates a token (org-scoped) and round-trips the managed flag", async () => {
+      const t1 = `tok_${uuid()}`
+      const agent = await store.createAgent({
+        id: uuid(),
+        org_id: ORG,
+        name: "ctx access",
+        token: t1,
+        role: "editor",
+        managed: 1,
+      })
+      // managed round-trips; an unmarked agent defaults to 0.
+      expect(agent.managed).toBe(1)
+      const plain = await store.createAgent({
+        id: uuid(),
+        org_id: ORG,
+        name: "persona",
+        token: `tok_${uuid()}`,
+        role: "editor",
+      })
+      expect(plain.managed).toBe(0)
+      // Rotation: the old hash dies, the new one resolves, identity is untouched.
+      const t2 = `tok_${uuid()}`
+      const rotated = await store.rotateAgentToken(agent.id, ORG, t2)
+      expect(rotated).toMatchObject({ id: agent.id, name: "ctx access", managed: 1 })
+      expect(await store.getAgentByToken(t1)).toBeNull()
+      expect(await store.getAgentByToken(t2)).toMatchObject({ id: agent.id })
+      // Org-scoped: a foreign org rotates nothing.
+      expect(await store.rotateAgentToken(agent.id, "org_other", `tok_${uuid()}`)).toBeNull()
+    })
   })
 
   describe(`${label}: contexts + sessions`, () => {


### PR DESCRIPTION
P3a of the credential-consolidation plan ([working doc](https://derive.to/artifacts/wallet-hands-identity-the-credential-consolidati-4845uoln)): the **"pick an agent" step stops being load-bearing**. Creating a context without an `agent_id` auto-mints a **managed** agent — the context's own Derive access, not a roster persona.

## What

- **`POST /v1/contexts` — `agent_id` optional.** Omitted → mints a managed agent (named after the context, role editor, `created_by` = creator) and returns `agent_token` **once** on the create response. Passed → wires an existing service agent as before, no token.
- **`agent.managed` (0|1, all dialects + d1 snapshot)** — auto-minted context access vs user-named persona; the flag the roster UI hides on (web change is a follow-up slice). OAuth synthetic agents pin `managed: 0`, same as `hosted`.
- **`POST /v1/agents/{id}/rotate`** (Admin) — re-mint the token; old bearer dies instantly; identity, role, hosting, attribution untouched.
- Edge discipline: name collision with an existing agent → suffixed mint, not a 409; context-name 409 after the mint → the minted agent is **unwound**, no orphaned token.

## Why the mint sits below the `manage` gate

Context create requires `publish`; the roster requires `manage` — that asymmetry is what forced the `derive login --manage` dance and the hand-minted "X's Claude" graveyard. The minted agent caps at editor and acts on behalf of the creator, and the derived-cap rule (`min(registrant standing, agent role)`) means it can never exceed what the creator already holds — so minting under `publish` confers nothing `publish` didn't already carry.

## Deliberately not here

- **Automation-side mint** — `automations.ts` is #518's file right now; this lands as its own slice after that merges.
- **Web roster/Access panel** (hide managed rows, rotate button, drop the automation form's agent dropdown) — follow-up slice on this API.
- **Expiring tokens** — roadmap A1, composes later.

## Verification

api **1205** (6 new: mint + bearer probe + roster flag + collision suffix + 409 unwind + explicit-id path; rotate lifecycle + gating) · db **231** (contract: rotate org-scoped, managed round-trip, default 0) · web **188** · OpenAPI + api-types regenerated · typecheck + repo-wide biome clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787519587&installation_model_id=428097&pr_number=525&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F525&signature=b4563a2d4f4dadd3ccaea6556b3d23082923f7792904529c610cc1952a1c6a0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->