### PR TITLE
feat(web): contexts create without picking an agent; managed rows leave the roster

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -736,6 +736,10 @@ export const api = {
   listAgents: (): Promise<{ agents: Agent[] }> => f("/v1/agents", opts()).then(j),
   createAgent: (name: string, role?: Role): Promise<Agent & { token: string }> =>
     f("/v1/agents", opts({ name, role })).then(j),
+  // Rotation is a credential event, never an identity event: the old bearer dies at
+  // once; id, role, hosting, and attribution are untouched. Token shown only here.
+  rotateAgent: (id: string): Promise<Agent & { token: string }> =>
+    f(`/v1/agents/${id}/rotate`, opts({})).then(j),
   deleteAgent: (id: string): Promise<void> =>
     f(`/v1/agents/${id}`, { method: "DELETE", credentials: "include" }).then(() => undefined),
 
@@ -782,11 +786,13 @@ export const api = {
   // Contexts + sessions (the ask loop; see routes/contexts.ts server-side).
   listContexts: (): Promise<{ contexts: ContextInfo[] }> => f("/v1/contexts", opts()).then(j),
   getContext: (id: string): Promise<ContextInfo> => f(`/v1/contexts/${id}`, opts()).then(j),
+  // agent_id omitted → the server auto-mints a MANAGED agent for this context and
+  // returns its bearer as agent_token, exactly once on this response.
   createContext: (input: {
     name: string
-    agent_id: string
+    agent_id?: string
     manifest_short_id: string
-  }): Promise<ContextInfo> => f("/v1/contexts", opts(input)).then(j),
+  }): Promise<ContextInfo & { agent_token?: string }> => f("/v1/contexts", opts(input)).then(j),
   askContext: (
     id: string,
     body_md: string,

--- a/apps/web/src/pages/context/console.tsx
+++ b/apps/web/src/pages/context/console.tsx
@@ -75,6 +75,16 @@ function Console({ id }: { id: string }) {
   const mine = (sessions ?? []).filter((s) => s.asker_id === me?.id)
   const active = picked === "new" ? null : (picked ?? mine[0]?.id ?? null)
   const isOwner = !!context && context.created_by === me?.id
+  // Rotate the context's agent token — the recovery path for a lost runner token
+  // (managed agents are hidden from the Settings roster, so this is their only
+  // credential surface). Admin-gated server-side; a non-admin owner gets a loud
+  // 403 toast, never a silent no-op. Shown exactly once, like every token.
+  const [rotatedToken, setRotatedToken] = useState<string | null>(null)
+  const rotateToken = useApiMutation({
+    mutationFn: () => api.rotateAgent(context?.agent_id ?? ""),
+    success: "Runner token rotated — the old one is dead",
+    onSuccess: (a) => setRotatedToken(a.token),
+  })
 
   // No ask-access reads as 404 (a context's existence never leaks outside its
   // workspace). Say so instead of spinning forever — the loader prefetches (no
@@ -110,6 +120,18 @@ function Console({ id }: { id: string }) {
         <RunnerLiveness seenAt={context.runner_seen_at} />
         <div className="ml-auto flex items-center gap-3">
           {isOwner && <ContextAccess id={id} name={context.name} policy={context.ask_policy} />}
+          {isOwner && (
+            <Button
+              data-testid="console-rotate-token"
+              variant="ghost"
+              size="sm"
+              onClick={() => rotateToken.mutate()}
+              loading={rotateToken.isPending}
+              disabled={rotateToken.isPending}
+            >
+              Rotate token
+            </Button>
+          )}
           {isOwner && context.manifest_short_id && (
             <Link
               to="/artifacts/$ref"
@@ -122,6 +144,50 @@ function Console({ id }: { id: string }) {
           )}
         </div>
       </div>
+
+      {rotatedToken && (
+        <div data-testid="console-rotated-token">
+          <StatusPanel
+            tone="warning"
+            layout="inline"
+            title="New runner token — copy it now, it won't be shown again. The old one is dead."
+            description={
+              <div className="flex flex-col gap-1.5">
+                <code className="block break-all rounded-md bg-secondary px-2.5 py-1.5 font-mono text-2xs text-foreground">
+                  {rotatedToken}
+                </code>
+                <span className="text-2xs text-muted-foreground">
+                  Update it where the runner reads it (e.g.{" "}
+                  <code className="font-mono">.derive/agent-token</code>) and restart the runner.
+                </span>
+              </div>
+            }
+            action={
+              <div className="flex items-center gap-2">
+                <Button
+                  data-testid="console-rotated-copy"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    navigator.clipboard?.writeText(rotatedToken)
+                    toast.success("Token copied")
+                  }}
+                >
+                  Copy
+                </Button>
+                <Button
+                  data-testid="console-rotated-done"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setRotatedToken(null)}
+                >
+                  Done
+                </Button>
+              </div>
+            }
+          />
+        </div>
+      )}
 
       <Tabs value={tab} onValueChange={setTab}>
         <TabsList variant="line">

--- a/apps/web/src/pages/context/index.tsx
+++ b/apps/web/src/pages/context/index.tsx
@@ -15,13 +15,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { toast } from "@/components/ui/sonner"
 import { agentsQuery, contextsQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { useDocumentTitle } from "@/lib/use-document-title"
 import { ContextRowsSkeleton } from "./context-skeleton"
 
-// The contexts directory: the workspace's askable agent setups. Creation wires an
-// existing agent (Settings → Agents) to a manifest artifact by its short id — the
+// The contexts directory: the workspace's askable agent setups. Creation pairs a
+// manifest artifact (by short id) with agent access the server auto-mints — or,
+// optionally, an existing service agent — the
 // two halves already exist as first-class objects; a context is just the joint.
 export function Contexts() {
   useDocumentTitle("Contexts")
@@ -42,12 +44,10 @@ export function Contexts() {
         </p>
       </div>
 
-      {agents && agents.length > 0 && (
-        <NewContext
-          agents={agents.map((a) => ({ id: a.id, name: a.name }))}
-          onCreated={() => qc.invalidateQueries({ queryKey: contextsQuery().queryKey })}
-        />
-      )}
+      <NewContext
+        agents={(agents ?? []).filter((a) => !a.managed).map((a) => ({ id: a.id, name: a.name }))}
+        onCreated={() => qc.invalidateQueries({ queryKey: contextsQuery().queryKey })}
+      />
 
       {isPending ? (
         <ContextRowsSkeleton />
@@ -71,7 +71,7 @@ export function Contexts() {
         <EmptyState
           icon={<Icon name="context" />}
           title="No contexts yet"
-          description="Register an agent in Settings, publish a manifest, then wire them together here."
+          description="Publish a manifest, then create a context from it here — it gets its own agent access automatically."
         />
       ) : (
         <ul className="flex flex-col gap-2">
@@ -103,69 +103,136 @@ function NewContext({
   onCreated: () => void
 }) {
   const [name, setName] = useState("")
-  const [agentId, setAgentId] = useState(agents[0]?.id ?? "")
+  // "" = auto-mint (the default; nobody picks an agent). A non-empty id = run as
+  // an existing service agent — an opt-in the roster's presence (admins) reveals.
+  const [agentId, setAgentId] = useState("")
   const [manifest, setManifest] = useState("")
+  // The minted agent's bearer, shown exactly once; navigation waits for Done so
+  // the only display of the token is never lost to an instant redirect.
+  const [minted, setMinted] = useState<{ contextId: string; name: string; token: string } | null>(
+    null,
+  )
   const nav = useNavigate()
 
   const create = useApiMutation({
     mutationFn: () =>
       api.createContext({
         name: name.trim(),
-        agent_id: agentId,
+        ...(agentId ? { agent_id: agentId } : {}),
         manifest_short_id: manifest.trim(),
       }),
     success: "Context created",
     onSuccess: (ctx) => {
+      const created = name.trim()
       setName("")
       setManifest("")
       onCreated()
+      if (ctx.agent_token) {
+        setMinted({ contextId: ctx.id, name: created, token: ctx.agent_token })
+        return
+      }
       // Carry the user straight into the console they just made — asking the first
       // question is the point, not admiring a new row in the directory.
       nav({ to: "/contexts/$id", params: { id: ctx.id } })
     },
   })
   const submit = () => {
-    if (name.trim() && agentId && manifest.trim()) create.mutate()
+    if (name.trim() && manifest.trim()) create.mutate()
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-2 rounded-xl border bg-card p-3">
-      <Input
-        data-testid="context-create-name"
-        aria-label="Context name"
-        placeholder="Name (e.g. Analytics)"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        className="min-w-40 flex-1"
-      />
-      <Select value={agentId} onValueChange={setAgentId}>
-        <SelectTrigger data-testid="context-create-agent" aria-label="Agent" className="w-40">
-          <SelectValue placeholder="Agent" />
-        </SelectTrigger>
-        <SelectContent>
-          {agents.map((a) => (
-            <SelectItem key={a.id} value={a.id}>
-              {a.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-      <Input
-        data-testid="context-create-manifest"
-        aria-label="Manifest short id"
-        placeholder="Manifest short id"
-        value={manifest}
-        onChange={(e) => setManifest(e.target.value)}
-        className="w-44 font-mono"
-      />
-      <Button
-        data-testid="context-create-submit"
-        onClick={submit}
-        loading={create.isPending}
-        disabled={create.isPending || !name.trim() || !agentId || !manifest.trim()}
-      >
-        Create
-      </Button>
+    <div className="flex flex-col gap-3 rounded-xl border bg-card p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
+          data-testid="context-create-name"
+          aria-label="Context name"
+          placeholder="Name (e.g. Analytics)"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="min-w-40 flex-1"
+        />
+        <Input
+          data-testid="context-create-manifest"
+          aria-label="Manifest short id"
+          placeholder="Manifest short id"
+          value={manifest}
+          onChange={(e) => setManifest(e.target.value)}
+          className="w-44 font-mono"
+        />
+        {/* Only admins can even load the roster; everyone else auto-mints. */}
+        {agents.length > 0 && (
+          <Select value={agentId} onValueChange={(v) => setAgentId(v === "auto" ? "" : v)}>
+            <SelectTrigger data-testid="context-create-agent" aria-label="Agent" className="w-44">
+              <SelectValue placeholder="Its own agent" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="auto">Its own agent (default)</SelectItem>
+              {agents.map((a) => (
+                <SelectItem key={a.id} value={a.id}>
+                  {a.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+        <Button
+          data-testid="context-create-submit"
+          onClick={submit}
+          loading={create.isPending}
+          disabled={create.isPending || !name.trim() || !manifest.trim()}
+        >
+          Create
+        </Button>
+      </div>
+      {/* Shown exactly once, warning tone — same contract as agent registration. */}
+      {minted && (
+        <div data-testid="context-agent-token">
+          <StatusPanel
+            tone="warning"
+            layout="inline"
+            title={`Runner token for ${minted.name} — copy it now, it won't be shown again.`}
+            description={
+              <div className="flex flex-col gap-1.5">
+                <code className="block break-all rounded-md bg-secondary px-2.5 py-1.5 font-mono text-2xs text-foreground">
+                  {minted.token}
+                </code>
+                <span className="text-2xs text-muted-foreground">
+                  Save it where the runner reads it (e.g.{" "}
+                  <code className="font-mono">.derive/agent-token</code>), then{" "}
+                  <code className="font-mono">derive runner serve</code> answers this context.
+                </span>
+              </div>
+            }
+            action={
+              <div className="flex items-center gap-2">
+                <Button
+                  data-testid="context-agent-token-copy"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    navigator.clipboard?.writeText(minted.token)
+                    toast.success("Token copied")
+                  }}
+                >
+                  Copy
+                </Button>
+                <Button
+                  data-testid="context-agent-token-done"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    const id = minted.contextId
+                    setMinted(null)
+                    nav({ to: "/contexts/$id", params: { id } })
+                  }}
+                >
+                  Done
+                </Button>
+              </div>
+            }
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/pages/settings/agents-section.tsx
+++ b/apps/web/src/pages/settings/agents-section.tsx
@@ -60,13 +60,15 @@ export function AgentsSection() {
             </Button>
           }
         />
-      ) : !agents || agents.length === 0 ? (
+      ) : !agents || agents.filter((a) => !a.managed).length === 0 ? (
         <EmptyState>No agents yet. Add one above.</EmptyState>
       ) : (
         <SettingsGroup>
-          {agents.map((a) => (
-            <AgentRow key={a.id} agent={a} onDone={reload} />
-          ))}
+          {agents
+            .filter((a) => !a.managed)
+            .map((a) => (
+              <AgentRow key={a.id} agent={a} onDone={reload} />
+            ))}
         </SettingsGroup>
       )}
     </SettingsSection>
@@ -168,43 +170,100 @@ function NewAgent({ onCreated }: { onCreated: () => void }) {
 
 function AgentRow({ agent, onDone }: { agent: Agent; onDone: () => void }) {
   const [confirming, setConfirming] = useState(false)
+  const [rotated, setRotated] = useState<string | null>(null)
   const remove = useApiMutation({
     mutationFn: () => api.deleteAgent(agent.id),
     success: `Agent ${agent.name} removed`,
     onSuccess: () => onDone(),
   })
+  // A credential event, never an identity event: the old bearer dies the moment
+  // this succeeds, and the new token is shown exactly once, right here.
+  const rotate = useApiMutation({
+    mutationFn: () => api.rotateAgent(agent.id),
+    success: `Token rotated for ${agent.name}`,
+    onSuccess: (a) => setRotated(a.token),
+  })
   return (
-    <div data-testid={`agent-row-${agent.id}`} className="flex items-center gap-3 py-3">
-      <Avatar className="size-7 shrink-0">
-        <AvatarFallback>
-          <Bot className="size-4" aria-hidden />
-        </AvatarFallback>
-      </Avatar>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">
-          @{agent.name}
-          <Badge variant="secondary">{agent.role}</Badge>
+    <div data-testid={`agent-row-${agent.id}`} className="flex flex-col py-3">
+      <div className="flex items-center gap-3">
+        <Avatar className="size-7 shrink-0">
+          <AvatarFallback>
+            <Bot className="size-4" aria-hidden />
+          </AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+            @{agent.name}
+            <Badge variant="secondary">{agent.role}</Badge>
+          </div>
+          <div className="text-sm text-muted-foreground">
+            Mention it in any thread to send it work.
+          </div>
         </div>
-        <div className="text-sm text-muted-foreground">
-          Mention it in any thread to send it work.
-        </div>
+        <Button
+          data-testid={`agent-rotate-${agent.id}`}
+          variant="ghost"
+          size="sm"
+          onClick={() => rotate.mutate()}
+          loading={rotate.isPending}
+          disabled={rotate.isPending}
+        >
+          Rotate token
+        </Button>
+        <Button
+          data-testid={`agent-remove-${agent.id}`}
+          variant="destructive-ghost"
+          size="sm"
+          onClick={() => setConfirming(true)}
+        >
+          Remove
+        </Button>
+        <ConfirmDialog
+          open={confirming}
+          onOpenChange={setConfirming}
+          title={`Remove @${agent.name}?`}
+          description="Its token stops working immediately."
+          confirmLabel="Remove"
+          onConfirm={() => remove.mutate()}
+        />
       </div>
-      <Button
-        data-testid={`agent-remove-${agent.id}`}
-        variant="destructive-ghost"
-        size="sm"
-        onClick={() => setConfirming(true)}
-      >
-        Remove
-      </Button>
-      <ConfirmDialog
-        open={confirming}
-        onOpenChange={setConfirming}
-        title={`Remove @${agent.name}?`}
-        description="Its token stops working immediately."
-        confirmLabel="Remove"
-        onConfirm={() => remove.mutate()}
-      />
+      {rotated && (
+        <div data-testid={`agent-rotated-${agent.id}`} className="mt-2">
+          <StatusPanel
+            tone="warning"
+            layout="inline"
+            title={`New token for ${agent.name} — copy it now, it won't be shown again. The old one is dead.`}
+            description={
+              <code className="block break-all rounded-md bg-secondary px-2.5 py-1.5 font-mono text-2xs text-foreground">
+                {rotated}
+              </code>
+            }
+            action={
+              <div className="flex items-center gap-2">
+                <Button
+                  data-testid={`agent-rotated-copy-${agent.id}`}
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    navigator.clipboard?.writeText(rotated)
+                    toast.success("Token copied")
+                  }}
+                >
+                  Copy
+                </Button>
+                <Button
+                  data-testid={`agent-rotated-done-${agent.id}`}
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setRotated(null)}
+                >
+                  Done
+                </Button>
+              </div>
+            }
+          />
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
The web half of #525 (P3 of the [consolidation plan](https://derive.to/artifacts/wallet-hands-identity-the-credential-consolidati-4845uoln)). **"Pick an agent" is gone from the default path.**

## What changes for a user

- **New context = name + manifest.** The server mints the context's own managed agent; the runner token shows **once**, with the `.derive/agent-token` + `derive runner serve` hint, and navigation waits for Done so the token's only display can't be lost to the redirect.
- **Editors can create contexts now.** The form used to hide for non-admins (it needed the roster to render the picker); with auto-mint it renders for everyone with publish. The picker survives as an admin-only opt-in — "Its own agent (default)" vs a listed service agent.
- **The roster stops showing managed agents** — they're context access, not personas. Each remaining (real) agent row gains **Rotate token**, shown-once contract.
- **The console gains Rotate token** for owners — the recovery path for a lost runner token, and the only credential surface for managed agents now that the roster hides them. Admin-gated server-side; a non-admin owner gets a loud 403 toast, never a silent no-op.

## Not here (next slices)

- Automation form's agent dropdown — that file is #518's; it dies when the automation-side mint lands after the rebase.
- Owner (non-admin) rotate authorization — today rotate is Admin-only server-side; loosening it to context owners is a deliberate follow-up decision, not a UI patch.

## Verification

web 188 · tsgo clean · testids / surfaces / mutations / frontend gates ok · no e2e pins on changed testids · api client matches the regenerated api-types from #525.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787520931&installation_model_id=428097&pr_number=527&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F527&signature=5ab9947dcf580d340d45387e55722ce5a6c0e5681ab581aa308a62f2ff32a160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->