### PR TITLE
feat(automations): auto-mint a managed agent per automation — the last picker dies

### DIFF
--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto"
 import {
   type AutomationRecord,
   type AutomationTrigger,
@@ -8,6 +9,7 @@ import {
 import { z } from "@hono/zod-openapi"
 import { Hono } from "hono"
 import type { AppContext } from "../context"
+import { sha256 } from "../lib/crypto"
 import { bail, fail, readJson } from "../lib/http"
 
 // WP5/WP6 — automations + runs, the generic agent-work primitive. An automation is a
@@ -69,7 +71,7 @@ const TRIGGER = z.object({
 })
 
 export const automationRoutes = (ctx: AppContext) => {
-  const { meta, agentFor, requireUser, requireWorkspace } = ctx
+  const { meta, agentFor, privateOwnerId, requireUser, requireWorkspace } = ctx
   const app = new Hono()
 
   // ---- Owner surface: define / list / delete ---------------------------------
@@ -79,7 +81,10 @@ export const automationRoutes = (ctx: AppContext) => {
     const b = await readJson(
       c,
       z.object({
-        agentId: z.string(),
+        // Omit to auto-mint a MANAGED agent for this automation — its own Derive
+        // access, no roster persona, nothing to pick. Pass an id to run as an
+        // existing (service) agent instead. Mirrors context creation (#525).
+        agentId: z.string().optional(),
         trigger: TRIGGER,
         instruction: z.string().min(1).max(4000),
         refs: REFS.optional(),
@@ -87,21 +92,52 @@ export const automationRoutes = (ctx: AppContext) => {
       }),
     )
     if (b instanceof Response) return bail(b)
-    // The agent must belong to this workspace — never an id from another tenant.
-    const agents = await meta.listAgents(org)
-    if (!agents.some((a) => a.id === b.agentId))
-      return bail(fail(c, 400, "agent must be in this workspace"))
-    const rec = await meta.createAutomation({
-      id: newId("auto"),
-      org_id: org,
-      agent_id: b.agentId,
-      trigger: JSON.stringify(b.trigger satisfies AutomationTrigger),
-      instruction: b.instruction,
-      // Stored CANONICAL (bare strings become artifact selectors) so readers never re-guess.
-      refs: b.refs ? JSON.stringify(normalizeSelectors(b.refs)) : null,
-      enabled: b.enabled ? 1 : 0,
-    })
-    return c.json(present(rec), 201)
+    if (b.agentId) {
+      // The agent must belong to this workspace — never an id from another tenant.
+      const agents = await meta.listAgents(org)
+      if (!agents.some((a) => a.id === b.agentId))
+        return bail(fail(c, 400, "agent must be in this workspace"))
+    }
+    let agentId = b.agentId ?? null
+    let agentToken: string | null = null
+    if (!agentId) {
+      agentToken = `dk_agt_${randomUUID().replace(/-/g, "")}${randomUUID().replace(/-/g, "")}`
+      // Automations have no name; derive one from the instruction so the (hidden)
+      // roster row is still recognizable. Names are unique per workspace — a
+      // collision suffixes instead of failing the create.
+      const base = b.instruction.trim().slice(0, 40).trim() || "Automation"
+      const owner = (await privateOwnerId(c)) ?? null
+      const mint = (name: string) =>
+        meta.createAgent({
+          id: newId("ag"),
+          org_id: org,
+          name,
+          token: sha256(agentToken as string),
+          role: "editor",
+          created_by: owner,
+          managed: 1,
+        })
+      const minted = await mint(base).catch(() => mint(`${base} ${randomUUID().slice(0, 4)}`))
+      agentId = minted.id
+    }
+    try {
+      const rec = await meta.createAutomation({
+        id: newId("auto"),
+        org_id: org,
+        agent_id: agentId,
+        trigger: JSON.stringify(b.trigger satisfies AutomationTrigger),
+        instruction: b.instruction,
+        // Stored CANONICAL (bare strings become artifact selectors) so readers never re-guess.
+        refs: b.refs ? JSON.stringify(normalizeSelectors(b.refs)) : null,
+        enabled: b.enabled ? 1 : 0,
+      })
+      return c.json({ ...present(rec), ...(agentToken ? { agent_token: agentToken } : {}) }, 201)
+    } catch (e) {
+      // A failed create after an auto-mint must not strand an orphaned managed
+      // agent (and its live token) — unwind the mint with the create.
+      if (agentToken && agentId) await meta.deleteAgent(agentId, org).catch(() => {})
+      throw e
+    }
   })
 
   // Edit in place: instruction, trigger, refs (write modes ride IN them), the agent,

--- a/apps/api/test/automations.test.ts
+++ b/apps/api/test/automations.test.ts
@@ -258,3 +258,87 @@ describe("automations + runs", () => {
     expect([401, 403]).toContain(anon.status)
   })
 })
+
+// The end of "pick an agent", automation lane (mirrors contexts #525): creating an
+// automation without an agentId auto-mints a MANAGED agent — its own Derive access,
+// named from the instruction, token returned exactly once — and that agent drives the
+// whole run loop: Run now enqueues, the minted bearer claims, initiated_by rides along.
+describe("automations: auto-minted managed agents", () => {
+  const owner: TestUser = { id: "u_ama_own", email: "amaown@derive.test", name: "Owner" }
+  const { app } = makeAuthedApp("automations-managed", [owner], "editor")
+
+  it("create without agentId mints a managed agent; its token claims the run", async () => {
+    await app.request("/v1/me", { headers: as(owner.email) })
+    const created = await app.request(
+      "/v1/automations",
+      jsonAs(as(owner.email), {
+        trigger: { kind: "manual" },
+        instruction: "keep the weekly ship report current",
+      }),
+    )
+    expect(created.status).toBe(201)
+    const auto = await created.json()
+    expect(auto.agent_id).toBeTruthy()
+    expect(auto.agent_token).toMatch(/^dk_agt_/)
+
+    // The roster row: managed, named from the instruction, attributed to the creator.
+    const roster = (await (await app.request("/v1/agents", { headers: as(owner.email) })).json())
+      .agents
+    const minted = roster.find((a: { id: string }) => a.id === auto.agent_id)
+    expect(minted).toMatchObject({ managed: true, role: "editor" })
+    expect(minted.name).toContain("keep the weekly ship report")
+    // The token never appears anywhere again.
+    expect(JSON.stringify(roster)).not.toContain(auto.agent_token)
+
+    // The loop: Run now → the MINTED agent's bearer claims its own run.
+    const run = await (
+      await app.request(`/v1/automations/${auto.id}/run`, {
+        method: "POST",
+        headers: as(owner.email),
+      })
+    ).json()
+    const claimed = await (
+      await app.request("/v1/agent/runs/claim", { headers: bearer(auto.agent_token) })
+    ).json()
+    const mine = claimed.runs.find((r: { id: string }) => r.id === run.id)
+    expect(mine).toBeTruthy()
+    expect(mine.instruction).toBe("keep the weekly ship report current")
+    expect(mine.initiated_by).toBe("u_ama_own")
+  })
+
+  it("an instruction colliding with an existing agent name mints under a suffix", async () => {
+    await app.request("/v1/agents", jsonAs(as(owner.email), { name: "watch the dashboards" }))
+    const created = await app.request(
+      "/v1/automations",
+      jsonAs(as(owner.email), {
+        trigger: { kind: "manual" },
+        instruction: "watch the dashboards",
+      }),
+    )
+    expect(created.status).toBe(201)
+    const auto = await created.json()
+    const roster = (await (await app.request("/v1/agents", { headers: as(owner.email) })).json())
+      .agents
+    const minted = roster.find((a: { id: string }) => a.id === auto.agent_id)
+    expect(minted.managed).toBe(true)
+    expect(minted.name).toMatch(/^watch the dashboards .{4}$/)
+  })
+
+  it("an explicit agentId still works and returns no token", async () => {
+    const ag = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Service Runner" }))
+    ).json()
+    const created = await (
+      await app.request(
+        "/v1/automations",
+        jsonAs(as(owner.email), {
+          agentId: ag.id,
+          trigger: { kind: "manual" },
+          instruction: "run as the service agent",
+        }),
+      )
+    ).json()
+    expect(created.agent_id).toBe(ag.id)
+    expect(created.agent_token).toBeUndefined()
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -746,13 +746,15 @@ export const api = {
   // Automations + runs (the standing-agent-work surface; see routes/automations.ts).
   listAutomations: (): Promise<{ automations: Automation[] }> =>
     f("/v1/automations", opts()).then(j),
+  // agentId omitted → the server auto-mints a MANAGED agent for this automation and
+  // returns its bearer as agent_token, exactly once on this response.
   createAutomation: (input: {
-    agentId: string
+    agentId?: string
     trigger: AutomationTrigger
     instruction: string
     /** Bare strings are artifact shorthand; the server stores canonical selectors. */
     refs?: (string | AutomationRef)[]
-  }): Promise<Automation> => f("/v1/automations", opts(input)).then(j),
+  }): Promise<Automation & { agent_token?: string }> => f("/v1/automations", opts(input)).then(j),
   updateAutomation: (
     id: string,
     input: {

--- a/apps/web/src/pages/settings/automation-form.tsx
+++ b/apps/web/src/pages/settings/automation-form.tsx
@@ -2,6 +2,7 @@ import { useQueries, useQuery } from "@tanstack/react-query"
 import { FileText, FolderOpen, Hash, Plus, X } from "lucide-react"
 import { type ReactNode, useMemo, useState } from "react"
 import { type Automation, type AutomationRef, type AutomationTrigger, api } from "@/api"
+import { StatusPanel } from "@/components/shared/status-panel"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -20,6 +21,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { toast } from "@/components/ui/sonner"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
 import {
@@ -85,7 +87,12 @@ export function AutomationForm({
   onDone: () => void
 }) {
   const { data: agents, isError: agentsError } = useQuery(agentsQuery())
+  // "" = auto-mint on create (the default; nobody picks an agent). Edit mode keeps
+  // the automation's existing agent. A non-empty id = run as a service agent.
   const [agentId, setAgentId] = useState(automation?.agent_id ?? "")
+  // The minted agent's bearer, shown exactly once; onDone waits for Done so the
+  // token's only display can't be lost to the dialog closing.
+  const [mintedToken, setMintedToken] = useState<string | null>(null)
   const [instruction, setInstruction] = useState(
     automation?.instruction ?? defaultInstruction ?? "",
   )
@@ -161,44 +168,60 @@ export function AutomationForm({
   const save = useApiMutation({
     mutationFn: () => {
       const body = {
-        agentId,
+        ...(agentId ? { agentId } : {}),
         trigger: buildTrigger(),
         instruction: instruction.trim(),
         refs: buildRefs(),
       }
-      return automation ? api.updateAutomation(automation.id, body) : api.createAutomation(body)
+      return automation
+        ? api.updateAutomation(automation.id, { agentId, ...body })
+        : api.createAutomation(body)
     },
     success: automation ? "Automation updated" : "Automation created",
     // Invalidate HERE, not in each caller — both the manager and the artifact dialog write
     // through this form, and a change from either must refresh both views.
     invalidate: [automationsQuery().queryKey, runsQuery().queryKey],
-    onSuccess: () => {
+    onSuccess: (a) => {
       if (!automation) setInstruction(defaultInstruction ?? "")
+      // An auto-minted runner token arrives exactly once — hold the form open on
+      // its panel; onDone fires from its Done button instead.
+      const token = (a as { agent_token?: string }).agent_token
+      if (!automation && token) {
+        setMintedToken(token)
+        return
+      }
       onDone()
     },
   })
-  const ready = agentId !== "" && instruction.trim() !== "" && !agentsError
+  // Edit keeps requiring its agent; create no longer needs one (auto-mint), and a
+  // roster error only blocks someone who actually picked a service agent.
+  const ready =
+    instruction.trim() !== "" && (automation ? agentId !== "" : !(agentId && agentsError))
 
   return (
     <div className="flex flex-col gap-4">
-      {agentsError && (
-        <p className="text-sm text-destructive">Couldn't load agents. Reload and try again.</p>
+      {(automation || (agents ?? []).some((a) => !a.managed)) && (
+        <Field label="Runs as">
+          <Select
+            value={agentId || "auto"}
+            onValueChange={(v) => setAgentId(v === "auto" ? "" : v)}
+          >
+            <SelectTrigger data-testid="automation-agent" aria-label="Runs as" className="w-full">
+              <SelectValue placeholder="Its own agent" />
+            </SelectTrigger>
+            <SelectContent>
+              {!automation && <SelectItem value="auto">Its own agent (default)</SelectItem>}
+              {(agents ?? [])
+                .filter((a) => !a.managed || a.id === automation?.agent_id)
+                .map((a) => (
+                  <SelectItem key={a.id} value={a.id}>
+                    @{a.name}
+                  </SelectItem>
+                ))}
+            </SelectContent>
+          </Select>
+        </Field>
       )}
-
-      <Field label="Agent">
-        <Select value={agentId} onValueChange={setAgentId}>
-          <SelectTrigger data-testid="automation-agent" aria-label="Agent" className="w-full">
-            <SelectValue placeholder="Pick an agent" />
-          </SelectTrigger>
-          <SelectContent>
-            {(agents ?? []).map((a) => (
-              <SelectItem key={a.id} value={a.id}>
-                @{a.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </Field>
 
       <Field label="Instruction">
         <Textarea
@@ -385,6 +408,47 @@ export function AutomationForm({
         )}
       </Field>
 
+      {mintedToken && (
+        <div data-testid="automation-agent-token">
+          <StatusPanel
+            tone="warning"
+            layout="inline"
+            title="Runner token for this automation — copy it now, it won't be shown again."
+            description={
+              <code className="block break-all rounded-md bg-secondary px-2.5 py-1.5 font-mono text-2xs text-foreground">
+                {mintedToken}
+              </code>
+            }
+            action={
+              <div className="flex items-center gap-2">
+                <Button
+                  data-testid="automation-agent-token-copy"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    navigator.clipboard?.writeText(mintedToken)
+                    toast.success("Token copied")
+                  }}
+                >
+                  Copy
+                </Button>
+                <Button
+                  data-testid="automation-agent-token-done"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setMintedToken(null)
+                    onDone()
+                  }}
+                >
+                  Done
+                </Button>
+              </div>
+            }
+          />
+        </div>
+      )}
+
       <div className="flex justify-end">
         <Button
           data-testid="automation-create"
@@ -392,7 +456,7 @@ export function AutomationForm({
           size="sm"
           onClick={() => ready && save.mutate()}
           loading={save.isPending}
-          disabled={save.isPending || !ready}
+          disabled={save.isPending || !ready || !!mintedToken}
         >
           {save.isPending
             ? "Saving…"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     ],
     "overrides": {
       "adm-zip": ">=0.6.0",
-      "brace-expansion@>=3.0.0 <5.0.7": ">=5.0.7",
       "esbuild": ">=0.25.0",
       "fast-uri": ">=3.1.3",
       "drizzle-orm": "0.45.2",
@@ -31,7 +30,8 @@
       "shell-quote": ">=1.9.0",
       "undici": "^7.28.0",
       "ws": "^8.21.0",
-      "postcss": ">=8.5.18"
+      "postcss": ">=8.5.18",
+      "brace-expansion@>=3.0.0 <5.0.8": ">=5.0.8"
     },
     "patchedDependencies": {
       "@better-auth/oauth-provider@1.6.19": "patches/@better-auth__oauth-provider@1.6.19.patch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   adm-zip: '>=0.6.0'
-  brace-expansion@>=3.0.0 <5.0.7: '>=5.0.7'
   esbuild: '>=0.25.0'
   fast-uri: '>=3.1.3'
   drizzle-orm: 0.45.2
@@ -16,6 +15,7 @@ overrides:
   undici: ^7.28.0
   ws: ^8.21.0
   postcss: '>=8.5.18'
+  brace-expansion@>=3.0.0 <5.0.8: '>=5.0.8'
 
 patchedDependencies:
   '@better-auth/oauth-provider@1.6.19':
@@ -4192,9 +4192,9 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5808,11 +5808,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -7310,14 +7305,14 @@ snapshots:
   '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       secure-json-parse: 2.7.0
       zod: 3.25.76
 
   '@ai-sdk/provider-utils@2.2.8(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       secure-json-parse: 2.7.0
       zod: 4.4.3
 
@@ -10888,7 +10883,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -11873,7 +11868,7 @@ snapshots:
 
   ini@4.1.1: {}
 
-  ink-spinner@5.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.5))(react@19.2.5):
+  ink-spinner@5.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.7))(react@19.2.5):
     dependencies:
       cli-spinners: 2.9.2
       ink: 7.1.1(@types/react@19.2.17)(react@19.2.5)
@@ -12542,7 +12537,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@5.1.9:
     dependencies:
@@ -12555,8 +12550,6 @@ snapshots:
   module-details-from-path@1.0.4: {}
 
   ms@2.1.3: {}
-
-  nanoid@3.3.12: {}
 
   nanoid@3.3.16: {}
 
@@ -13181,7 +13174,7 @@ snapshots:
       eslint-plugin-react-hooks: 7.1.1(eslint@10.5.0(jiti@2.7.0))
       figures: 6.1.0
       ink: 7.1.1(@types/react@19.2.17)(react@19.2.5)
-      ink-spinner: 5.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.5))(react@19.2.5)
+      ink-spinner: 5.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.7))(react@19.2.5)
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.74.0


### PR DESCRIPTION
The automation lane of #525/#527, unblocked by Anir's go-ahead on #518 collisions. **With this, nothing in the product ever asks you to pick an agent.**

## What

- **`POST /v1/automations` — `agentId` optional.** Omitted → mints a managed agent (named from the instruction, role editor, creator-attributed) and returns `agent_token` **once**. Explicit `agentId` still wires a service agent, no token. Collision → suffix; failed create after mint → the agent is unwound.
- **The claim loop is closed end-to-end:** a test proves Run now → the *minted* bearer claims its own run, `initiated_by` riding the payload — the exact wiring the inert Fool×Churnkey automation was missing.
- **Web:** the required "Pick an agent" dropdown becomes an optional "Runs as" select (default *its own agent*; service agents listed; managed rows hidden). A roster error no longer blocks creation. Token-once panel, dialog holds open until Done.

## Coordination

`automations.ts` + `automation-form.tsx` are in #518's diff — **Anir explicitly green-lit this** ("if you want to do anything that'll hit 518 do it") and absorbs the conflict at his rebase. The mint block is self-contained at the top of the create handler, so the rebase should be mechanical.

## Verification

api **1210** (3 new: mint + roster + full run-loop, collision suffix, explicit-id) · web **188** · typecheck + biome + testids clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787525438&installation_model_id=428097&pr_number=529&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F529&signature=65a97a54b1fb43130cb977d6a3d4f7b97a7d145d3ae43062f32fb4870a84c7a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->