### PR TITLE
feat(automations): the honesty badge — an inert automation says so

### DIFF
--- a/apps/api/src/lib/oauth-agent.ts
+++ b/apps/api/src/lib/oauth-agent.ts
@@ -128,6 +128,7 @@ export function makeOauthAgent({
           // agent record (a grant has no server-storable credential to run with).
           hosted: 0,
           managed: 0,
+          runs_seen_at: null,
           created_at: new Date().toISOString(),
         },
       }
@@ -190,6 +191,7 @@ export function makeOauthAgent({
         // Never hosted directly, same as the opaque-token branch above.
         hosted: 0,
         managed: 0,
+        runs_seen_at: null,
         created_at: new Date().toISOString(),
       },
     }

--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -184,7 +184,17 @@ export const automationRoutes = (ctx: AppContext) => {
   app.get("/v1/automations", async (c) => {
     const org = await requireWorkspace(c, "read")
     if (org instanceof Response) return org
-    return c.json({ automations: (await meta.listAutomations(org)).map(present) })
+    // Each row carries its agent's runs-lane liveness so the UI can say, honestly,
+    // whether ANYTHING executes this automation — null = no executor has ever polled.
+    // One batched roster read (no-N+1), joined in memory.
+    const [autos, agents] = await Promise.all([meta.listAutomations(org), meta.listAgents(org)])
+    const seen = new Map(agents.map((a) => [a.id, a.runs_seen_at]))
+    return c.json({
+      automations: autos.map((a) => ({
+        ...present(a),
+        executor_seen_at: seen.get(a.agent_id) ?? null,
+      })),
+    })
   })
 
   app.delete("/v1/automations/:id", async (c) => {
@@ -234,6 +244,10 @@ export const automationRoutes = (ctx: AppContext) => {
     const agent = await agentFor(c)
     if (!agent) return fail(c, 401, "agent token required")
     const limit = Math.min(50, Math.max(1, Number(c.req.query("limit")) || 20))
+    // The runs-lane heartbeat (twin of the session queue's runner_seen_at): throttled
+    // to ~minutely, best-effort — liveness display must never fail a claim.
+    if (!agent.runs_seen_at || Date.now() - new Date(agent.runs_seen_at).getTime() > 60_000)
+      await meta.touchAgentRunsSeen(agent.id, isoNow()).catch(() => {})
     const claimed = await meta.claimDueRuns(agent.id, isoNow(), limit)
     // Resolve each claimed run's automation DIRECTLY by id, in ONE batched query — never
     // via a capped org-wide list (which silently loses instructions past its limit), and

--- a/apps/api/test/automations.test.ts
+++ b/apps/api/test/automations.test.ts
@@ -290,6 +290,12 @@ describe("automations: auto-minted managed agents", () => {
     // The token never appears anywhere again.
     expect(JSON.stringify(roster)).not.toContain(auto.agent_token)
 
+    // Before anything ever polls for runs, the list is honest: no executor.
+    const before = (
+      await (await app.request("/v1/automations", { headers: as(owner.email) })).json()
+    ).automations.find((x: { id: string }) => x.id === auto.id)
+    expect(before.executor_seen_at).toBeNull()
+
     // The loop: Run now → the MINTED agent's bearer claims its own run.
     const run = await (
       await app.request(`/v1/automations/${auto.id}/run`, {
@@ -304,6 +310,13 @@ describe("automations: auto-minted managed agents", () => {
     expect(mine).toBeTruthy()
     expect(mine.instruction).toBe("keep the weekly ship report current")
     expect(mine.initiated_by).toBe("u_ama_own")
+
+    // Honesty surface: before any claim the list said "no executor" (null); the
+    // claim above stamped the runs-lane heartbeat, so the row now reads live.
+    const after = (
+      await (await app.request("/v1/automations", { headers: as(owner.email) })).json()
+    ).automations.find((x: { id: string }) => x.id === auto.id)
+    expect(after.executor_seen_at).toBeTruthy()
   })
 
   it("an instruction colliding with an existing agent name mints under a suffix", async () => {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -191,6 +191,9 @@ export interface Automation {
   refs: AutomationRef[]
   enabled: boolean
   created_at: string
+  /** When this automation's agent last polled the run claim endpoint (list responses
+   *  only). Null = no executor has ever polled — the automation is inert. */
+  executor_seen_at?: string | null
 }
 /** One execution — the queue (queued/running) and the ledger (succeeded/failed) in one row. */
 export interface Run {

--- a/apps/web/src/pages/settings/automations-section.tsx
+++ b/apps/web/src/pages/settings/automations-section.tsx
@@ -139,6 +139,7 @@ function AutomationRow({
           <span className="truncate">{automation.instruction}</span>
           <Badge variant="secondary">{triggerLabel(automation.trigger)}</Badge>
           {!automation.enabled && <Badge variant="outline">Paused</Badge>}
+          <ExecutorBadge seenAt={automation.executor_seen_at ?? null} />
         </div>
         <div className="truncate text-sm text-muted-foreground">
           {automation.refs.some((r) => r.mode === "publish")
@@ -290,6 +291,20 @@ function RunStatus({ status }: { status: Run["status"] }) {
   return (
     <Badge variant={variant} shape="pill">
       {runStatusLabel(status)}
+    </Badge>
+  )
+}
+
+/** Honesty over silence (the Buzz rule): an automation whose agent has no executor
+ *  polling for runs is INERT, and the row must say so instead of looking configured.
+ *  Quiet when live — the badge only appears when something's wrong. Thresholds match
+ *  the context console's RunnerLiveness. */
+function ExecutorBadge({ seenAt }: { seenAt: string | null }) {
+  const age = seenAt ? Date.now() - new Date(seenAt).getTime() : Number.POSITIVE_INFINITY
+  if (seenAt && age < 600_000) return null
+  return (
+    <Badge variant="outline" className="border-warning/40 text-warning">
+      {seenAt ? `Executor offline · seen ${ago(seenAt)}` : "No executor"}
     </Badge>
   )
 }

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -163,6 +163,7 @@ CREATE TABLE IF NOT EXISTS agent (
   created_by TEXT,
   hosted INTEGER NOT NULL DEFAULT 0,
   managed INTEGER NOT NULL DEFAULT 0,
+  runs_seen_at TEXT,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   UNIQUE (token),
   UNIQUE (org_id, name)

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -977,6 +977,8 @@ export interface AgentStore {
   /** Replace the agent's token hash (org-scoped). The old bearer dies at once;
    *  identity, role, hosting, and attribution are untouched. Null = not found. */
   rotateAgentToken(id: string, orgId: string, tokenHash: string): Promise<AgentRecord | null>
+  /** Stamp `runs_seen_at` (the claim route's liveness mark). Caller throttles. */
+  touchAgentRunsSeen(id: string, at: string): Promise<void>
   listAgents(orgId: string): Promise<AgentRecord[]>
   /** Flip whether Derive's managed executor serves this agent. Workspace-scoped by
    *  (id, org) like deleteAgent; null when the agent isn't in this workspace. */
@@ -1351,6 +1353,10 @@ export interface AgentRecord {
   /** 1 = auto-minted for one context at creation — the context's Derive access,
    *  not a user-named persona. Hidden from the roster UI. */
   managed: 0 | 1
+  /** Runs-lane liveness (twin of ContextRecord.runner_seen_at): when this agent's
+   *  bearer last polled the run claim endpoint. Null = no executor, ever — the
+   *  honesty signal behind the "No executor" badge. */
+  runs_seen_at: string | null
   created_at: string
 }
 export interface NewAgent {

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -264,6 +264,9 @@ export const agent = pgTable(
     // 1 = auto-minted for one context at creation (never user-named): the context's
     // Derive access, not a persona. The UI hides managed agents from the roster.
     managed: integer("managed").notNull().default(0).$type<0 | 1>(),
+    // The runs-lane liveness mark (twin of context.runner_seen_at): stamped when the
+    // agent's bearer polls the run claim endpoint. Null = no executor has ever polled.
+    runs_seen_at: text("runs_seen_at"),
     created_at: text("created_at").notNull().$defaultFn(isoNow),
   },
   (t) => [

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -2445,6 +2445,9 @@ export class PgMetaStore implements MetaStore {
     const rows = await this.db.insert(agent).values(a).returning()
     return one(rows)
   }
+  async touchAgentRunsSeen(id: string, at: string): Promise<void> {
+    await this.db.update(agent).set({ runs_seen_at: at }).where(eq(agent.id, id))
+  }
   async rotateAgentToken(
     id: string,
     orgId: string,

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -2478,6 +2478,9 @@ export function makeRepos(db: SqliteDb) {
   // ---- Agents + pull inbox -----------------------------------------------
   const createAgent = async (a: NewAgent): Promise<AgentRecord> =>
     (await db.insert(agent).values(a).returning().get()) as AgentRecord
+  const touchAgentRunsSeen = async (id: string, at: string): Promise<void> => {
+    await db.update(agent).set({ runs_seen_at: at }).where(eq(agent.id, id)).run()
+  }
   const rotateAgentToken = async (
     id: string,
     orgId: string,
@@ -3362,6 +3365,7 @@ export function makeRepos(db: SqliteDb) {
     markNotificationsRead,
     createAgent,
     rotateAgentToken,
+    touchAgentRunsSeen,
     listAgents,
     setAgentHosted,
     createAutomation,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -308,6 +308,9 @@ export const agent = sqliteTable(
     // 1 = auto-minted for one context at creation (never user-named): the context's
     // Derive access, not a persona. The UI hides managed agents from the roster.
     managed: integer("managed").notNull().default(0).$type<0 | 1>(),
+    // The runs-lane liveness mark (twin of context.runner_seen_at): stamped when the
+    // agent's bearer polls the run claim endpoint. Null = no executor has ever polled.
+    runs_seen_at: text("runs_seen_at"),
     created_at: text("created_at").notNull().default(now),
   },
   (t) => [

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1502,6 +1502,10 @@ export function runStoreContract(
       expect(await store.getAgentByToken(t2)).toMatchObject({ id: agent.id })
       // Org-scoped: a foreign org rotates nothing.
       expect(await store.rotateAgentToken(agent.id, "org_other", `tok_${uuid()}`)).toBeNull()
+      // Runs-lane liveness: null until an executor polls; the stamp round-trips.
+      expect(rotated?.runs_seen_at).toBeNull()
+      await store.touchAgentRunsSeen(agent.id, "2026-07-24T12:00:00.000Z")
+      expect((await store.getAgentByToken(t2))?.runs_seen_at).toBe("2026-07-24T12:00:00.000Z")
     })
   })
 


### PR DESCRIPTION
P4a of the [consolidation plan](https://derive.to/artifacts/wallet-hands-identity-the-credential-consolidati-4845uoln): **an automation that nothing executes now says so**, instead of sitting configured-looking and silent — the exact failure the Fool×Churnkey automation hit.

## Context

On main today the runs lane has a claim API and a drain function, but no daemon drives it and no schedule tick exists — every automation is inert until #518's execution loop lands. The UI hid that completely.

## What

- **`agent.runs_seen_at`** — runs-lane liveness, twin of `context.runner_seen_at`; stamped (throttled, best-effort) when the agent's bearer polls `/v1/agent/runs/claim`
- **`GET /v1/automations`** joins it per row as `executor_seen_at` (one batched roster read); null = no executor has ever polled
- **`ExecutorBadge`** on automation rows: `No executor` when never polled · `Executor offline · seen X` past 10 min · **nothing when live** — quiet when healthy, loud only when the row is a no-op

When #518's execution loop lands and starts claiming, the badges clear themselves — no coordination needed; the heartbeat is the claim itself.

## Verification

api **1210** (the mint→run→claim loop test now asserts `null` before the first claim, live stamp after) · db **231** (contract round-trip + null default) · web **188** · all gates clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787526275&installation_model_id=428097&pr_number=530&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F530&signature=62411fe93b29ff4dbce90000b95c7c02473a0e89c4072e44250f0633dbe883d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->