### PR TITLE
derive.page usercontent domain: routes, prod vars, apex redirect

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -214,6 +214,11 @@ export function createApp(deps: AppDeps): Hono {
       const host = (c.req.header("host") ?? new URL(c.req.url).host).toLowerCase().split(":")[0]
       if (!host || host === appHostForSub || (sandboxHost && host === sandboxHost.toLowerCase()))
         return next()
+      // The subdomain base's apex (and www) never serve content: once the base is on
+      // the Public Suffix List the apex is cookie-dead, so it can only ever bounce
+      // visitors to the app origin.
+      if (subBase && (host === subBase || host === `www.${subBase}`) && host !== appHostForSub)
+        return c.redirect(deps.baseUrl, 301)
       const isSub = !!subBase && host !== subBase && host.endsWith(`.${subBase}`)
       if (!isSub && !customEnabled) return next()
       // The served HTML references /raw/derive-client.js; let raw + health through.

--- a/apps/api/src/routes/domains.ts
+++ b/apps/api/src/routes/domains.ts
@@ -9,6 +9,7 @@ const RESERVED = new Set([
   "www",
   "app",
   "api",
+  "raw",
   "admin",
   "mail",
   "smtp",

--- a/apps/api/test/domains.test.ts
+++ b/apps/api/test/domains.test.ts
@@ -72,6 +72,19 @@ describe("vanity subdomains", () => {
     expect((await anon.request(`http://nope.${BASE}/`)).status).toBe(404)
   })
 
+  it("301s the base apex and www to the app origin", async () => {
+    for (const host of [BASE, `www.${BASE}`]) {
+      const res = await anon.request(`http://${host}/anything`)
+      expect(res.status).toBe(301)
+      expect(res.headers.get("location")).toBe("http://derive.test")
+    }
+  })
+
+  it("rejects the sandbox host's label as reserved", async () => {
+    const short = await publish("<p>x</p>", { visibility: "public" })
+    expect((await setLabel(short, "raw")).status).toBe(400)
+  })
+
   it("releases a subdomain", async () => {
     const short = await publish("<p>x</p>", { visibility: "public" })
     await setLabel(short, "temp")

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -203,6 +203,19 @@ custom_domain = true
 pattern = "app.derive.to"
 custom_domain = true
 
+# The usercontent domain (derive.page): customer pages only, never the app. The apex
+# is a custom domain (auto DNS + cert) that app.ts 301s to derive.to — once the PSL
+# entry lands the apex is cookie-dead, so it must never serve the SPA. The wildcard
+# can't be a custom domain, so it's a zone route over a manually-managed DNS record
+# (`*.derive.page` AAAA 100::, proxied). PSL tracking: artifact g9o2njps.
+[[routes]]
+pattern = "derive.page"
+custom_domain = true
+
+[[routes]]
+pattern = "*.derive.page/*"
+zone_name = "derive.page"
+
 # baseUrl falls back to the request origin when unset. Secured by Better Auth; set
 # DERIVE_AUTH_SECRET via `wrangler secret put`. Cross-instance realtime fan-out uses
 # the ArtifactRoom Durable Object (one room per channel).
@@ -222,3 +235,10 @@ custom_domain = true
 # extracts the bare address; the display-name form is kept for parity with the Resend (Node)
 # transport, which reads the same EMAIL_FROM. Pairs with the [[send_email]] binding above.
 EMAIL_FROM = "Derive <notifications@send.derive.to>"
+# Origin split (A4): artifact bytes serve from the usercontent domain, never the
+# cookie origin. raw.derive.page rides the wildcard route above; app.ts serves only
+# /raw/* + /healthz on this host and 302s /raw/* on derive.to over to it.
+DERIVE_SANDBOX_URL = "https://raw.derive.page"
+# Domain mode (C1): vanity subdomains `<label>.derive.page` (label claims are gated
+# by routes/domains.ts; `raw` is reserved for the sandbox host above).
+DERIVE_SUBDOMAIN_BASE = "derive.page"


### PR DESCRIPTION
Wires the newly-registered usercontent domain `derive.page` into the worker, executing step 5 of the PSL plan ([artifact g9o2njps](https://derive.to/artifacts/psl-submission-exactly-what-to-do-and-the-5-feat-g9o2njps)).

## What
- **wrangler.toml**: `derive.page` apex as a Workers custom domain + `*.derive.page/*` zone route (the wildcard DNS record `*.derive.page` AAAA `100::` proxied is already live, added out-of-band; apex custom domain + wildcard route were created via API today and this makes CI own them going forward). Prod vars `DERIVE_SANDBOX_URL=https://raw.derive.page` and `DERIVE_SUBDOMAIN_BASE=derive.page` — the origin split (A4) and vanity subdomains (C1), both already shipped, start using the real domain on deploy.
- **app.ts**: the subdomain base's apex and `www` 301 to the app origin. Once the PSL entry lands the apex is cookie-dead by design, so it must never serve the SPA.
- **domains.ts**: `raw` joins the reserved labels — it's the sandbox host.

## Behavior changes on deploy
- `/raw/*` on derive.to 302s to `raw.derive.page` (origin split live)
- `derive.page` + `www.derive.page` → 301 derive.to
- unknown `*.derive.page` hosts → 404 (existing domain-mode behavior, now active)
- vanity subdomain claims mint `<label>.derive.page`

## Not in this PR
The PSL submission itself (separate, publicsuffix/list) and the `_psl` TXT record that follows it.

## Tests
Two new tests: apex/www 301, `raw` label rejected as reserved. Full domain + config suites pass; typecheck, biome, lint:env clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787534514&installation_model_id=428097&pr_number=532&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F532&signature=57b06c4542071b41055a6d74f21a31a4380774b999ca1444f1befac529d18dce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->