### PR TITLE
/security page: abuse + vulnerability reporting contacts

### DIFF
--- a/apps/web/public/security.html
+++ b/apps/web/public/security.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en" class="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="dark">
+<title>Security & abuse — Derive</title>
+<meta name="description" content="How to report abusive content hosted on Derive, and how to report a security vulnerability.">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Security &amp; abuse — Derive">
+<meta property="og:description" content="How to report abusive content hosted on Derive, and how to report a security vulnerability.">
+<meta property="og:url" content="https://derive.to/security">
+<meta property="og:image" content="https://derive.to/site/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="canonical" href="https://derive.to/security">
+<link rel="icon" href="/brand/favicon.svg" type="image/svg+xml">
+<link rel="icon" href="/brand/favicon.png" type="image/png">
+<style>
+@font-face {
+  font-family: "Geist";
+  src: url("/site/geist.woff2") format("woff2");
+  font-weight: 100 900; font-style: normal; font-display: swap;
+}
+@font-face {
+  font-family: "Geist Mono";
+  src: url("/site/geist-mono.woff2") format("woff2");
+  font-weight: 100 900; font-style: normal; font-display: swap;
+}
+:root {
+  --bg:#0a0b0d; --fg:#f3f4f6; --card:#101216; --secondary:#16181d;
+  --muted-fg:#969aa2; --accent:#1b1d23; --border:#23252b; --border-soft:#191b1f;
+  --primary:#f3f4f6; --primary-fg:#0a0b0d;
+  --radius:4px;
+  --font-sans:"Geist",system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+  --font-mono:"Geist Mono",ui-monospace,Menlo,Consolas,monospace;
+  --maxw:720px;
+}
+*,*::before,*::after{box-sizing:border-box}
+html{-webkit-text-size-adjust:100%}
+body{
+  margin:0;background:var(--bg);color:var(--fg);
+  font-family:var(--font-sans);font-size:16px;line-height:1.6;letter-spacing:-0.011em;
+  -webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;
+}
+::selection{background:rgba(243,244,246,.18)}
+a{color:inherit}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
+header{padding:28px 0}
+.wordmark{display:inline-flex;align-items:center;gap:8px;font-weight:500;text-decoration:none}
+.wordmark svg{display:block}
+main{padding:40px 0 120px}
+.eyebrow{font-family:var(--font-mono);font-size:11px;font-weight:500;letter-spacing:.08em;text-transform:uppercase;color:var(--muted-fg)}
+h1{font-weight:500;letter-spacing:-0.022em;font-size:32px;margin:10px 0 14px;text-wrap:balance}
+h2{font-weight:500;letter-spacing:-0.022em;font-size:19px;margin:0 0 8px}
+p{text-wrap:pretty;margin:0 0 12px;color:var(--muted-fg)}
+p strong,section a{color:var(--fg)}
+.lede{font-size:17px;margin-bottom:36px}
+section{
+  border:1px solid var(--border-soft);border-radius:8px;background:var(--card);
+  padding:22px 24px;margin-bottom:16px;
+}
+.addr{
+  display:inline-block;font-family:var(--font-mono);font-size:14px;color:var(--fg);
+  background:var(--secondary);border:1px solid var(--border);border-radius:var(--radius);
+  padding:3px 9px;margin:2px 0 10px;text-decoration:none;
+}
+.addr:hover{background:var(--accent)}
+footer{border-top:1px solid var(--border-soft);padding:22px 0;color:var(--muted-fg);font-size:14px}
+footer a{text-decoration:none}
+footer a:hover{color:var(--fg)}
+</style>
+</head>
+<body>
+<header class="wrap">
+  <a class="wordmark" href="/">
+    <svg width="15" height="15" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+      <path d="M3 15V3h5.2a6 6 0 0 1 0 12H3Z" stroke="currentColor" stroke-width="1.6"/>
+      <path d="M11.5 15 15 3" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+    </svg>
+    Derive
+  </a>
+</header>
+<main class="wrap">
+  <span class="eyebrow">Security &amp; abuse</span>
+  <h1>Report abuse or a vulnerability</h1>
+  <p class="lede">Derive hosts pages and documents published by its users, including on subdomains of
+  <strong>derive.page</strong>, our dedicated user-content domain. If something hosted there — or anywhere
+  on Derive — is being used for phishing, malware, impersonation, or other abuse, we want to know.</p>
+
+  <section>
+    <h2>Report abusive content</h2>
+    <a class="addr" href="mailto:abuse@derive.to">abuse@derive.to</a>
+    <p>Send the full URL of the page and a short description of the problem. Reports are read by a human;
+    confirmed phishing and malware are removed on an expedited basis.</p>
+  </section>
+
+  <section>
+    <h2>Report a security vulnerability</h2>
+    <a class="addr" href="mailto:security@derive.to">security@derive.to</a>
+    <p>For vulnerabilities in Derive itself — the app, the API, or the hosting of user content. Please give
+    us a reasonable window to remediate before public disclosure. The server is
+    <a href="https://github.com/derive-to/derive">open source</a>; issues in the code are also welcome there.</p>
+  </section>
+</main>
+<footer>
+  <div class="wrap">
+    <a href="/">Home</a> · <a href="/pricing">Pricing</a> · <a href="https://github.com/derive-to/derive">GitHub</a>
+  </div>
+</footer>
+</body>
+</html>

--- a/apps/web/public/site/index.html
+++ b/apps/web/public/site/index.html
@@ -1148,6 +1148,7 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
     </span>
     <div class="foot-links">
       <a href="/pricing">Pricing</a>
+      <a href="/security">Security</a>
       <a href="https://github.com/derive-to/derive">GitHub</a>
       <a href="/login">Log in</a>
     </div>

--- a/apps/web/public/site/pricing.html
+++ b/apps/web/public/site/pricing.html
@@ -343,6 +343,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
     <div class="foot-links">
       <a href="/">Home</a>
       <a href="/pricing">Pricing</a>
+      <a href="/security">Security</a>
       <a href="https://github.com/derive-to/derive">GitHub</a>
       <a href="/login">Log in</a>
     </div>


### PR DESCRIPTION
Adds a static `/security` page (abuse@derive.to for hosted-content abuse, security@derive.to for vulnerabilities), linked from the marketing footers.

Required for the derive.page PSL submission: the publicsuffix/list PR template demands an easily-accessible abuse-reporting URL for domains hosting user content, and nothing on derive.to served that. Also just the right thing to have before user pages go live on `*.derive.page`.

No worker changes: `public/security.html` lands in `dist/client` and the static asset layer serves it at `/security` (same html_handling that gives `/site/pricing` its clean URL).

**Note:** the `abuse@derive.to` and `security@derive.to` inboxes need to exist in Google Workspace (aliases or a group) — the PSL listing requires responses within 30 days.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787534904&installation_model_id=428097&pr_number=533&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F533&signature=454cbbfc86058565d121740d15feb66135da7038f889588f9029cb5db3325a6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->