### PR TITLE
feat(plans): per-user model-plan credentials (bring your own plan) + Codex logins

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1020,6 +1020,15 @@
             "type": "boolean",
             "description": "Auto-minted for one context at creation — the context's Derive access, not a user-named persona. Hidden from the roster UI."
           },
+          "created_by": {
+            "type": "string",
+            "nullable": true,
+            "description": "The user who registered the agent — who it publishes and bills on behalf of."
+          },
+          "owner_lend": {
+            "type": "boolean",
+            "description": "When true, this agent may bill its OWNER's own model plan as a fallback (initiator -> owner -> pool). Only the owner toggles it; default off."
+          },
           "created_at": {
             "type": "string"
           }
@@ -1030,6 +1039,8 @@
           "role",
           "hosted",
           "managed",
+          "created_by",
+          "owner_lend",
           "created_at"
         ]
       },

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -214,9 +214,17 @@ export const agentRoutes = (ctx: AppContext) => {
     async (c) => {
       const org = await requireWorkspace(c, "manage")
       if (org instanceof Response) return bail(org)
+      const id = c.req.param("id")
       // Scope the delete to the caller's workspace: deleteAgent is keyed by
       // (id, org) so an Admin can't delete another workspace's agent by id.
-      await meta.deleteAgent(c.req.param("id"), org)
+      await meta.deleteAgent(id, org)
+      // Drop it from the owner-lend list so stale ids don't accumulate in org settings.
+      const settings = await meta.getOrgSettings(org)
+      if (settings.ownerLendAgents?.includes(id))
+        await meta.setOrgSettings(org, {
+          ...settings,
+          ownerLendAgents: settings.ownerLendAgents.filter((a) => a !== id),
+        })
       return c.body(null, 204)
     },
   )

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -14,12 +14,14 @@ export const agentRoutes = (ctx: AppContext) => {
   const { meta, agentFor, privateOwnerId, requireUser, requireWorkspace } = ctx
   const app = new OpenAPIHono<BlankEnv>()
 
-  const agentJson = (a: AgentRecord) => ({
+  const agentJson = (a: AgentRecord, ownerLend = false) => ({
     id: a.id,
     name: a.name,
     role: a.role,
     hosted: a.hosted === 1,
     managed: a.managed === 1,
+    created_by: a.created_by,
+    owner_lend: ownerLend,
     created_at: a.created_at,
   })
 
@@ -42,6 +44,15 @@ export const agentRoutes = (ctx: AppContext) => {
         .boolean()
         .describe(
           "Auto-minted for one context at creation — the context's Derive access, not a user-named persona. Hidden from the roster UI.",
+        ),
+      created_by: z
+        .string()
+        .nullable()
+        .describe("The user who registered the agent — who it publishes and bills on behalf of."),
+      owner_lend: z
+        .boolean()
+        .describe(
+          "When true, this agent may bill its OWNER's own model plan as a fallback (initiator -> owner -> pool). Only the owner toggles it; default off.",
         ),
       created_at: z.string(),
     })
@@ -76,7 +87,8 @@ export const agentRoutes = (ctx: AppContext) => {
       const org = await requireWorkspace(c, "manage")
       if (org instanceof Response) return bail(org)
       const agents = await meta.listAgents(org)
-      return c.json({ agents: agents.map(agentJson) })
+      const lent = new Set((await meta.getOrgSettings(org)).ownerLendAgents ?? [])
+      return c.json({ agents: agents.map((a) => agentJson(a, lent.has(a.id))) })
     },
   )
 

--- a/apps/api/src/routes/model-credentials.ts
+++ b/apps/api/src/routes/model-credentials.ts
@@ -5,16 +5,24 @@ import type { AppContext } from "../context"
 import { decryptSecret, encryptSecret } from "../lib/crypto"
 import { bail, fail, readJson } from "../lib/http"
 
-// Per-user model-plan credentials. Every team member connects their OWN Claude/Codex plan
-// token (or an API key) here; it is encrypted at rest (lib/crypto, keyed by DERIVE_AUTH_SECRET)
-// and used ONLY for that user's own agent runs. Two surfaces:
+// Model-plan credentials. Every team member connects their OWN Claude/Codex plan token (or
+// an API key), encrypted at rest (lib/crypto, keyed by DERIVE_AUTH_SECRET). A workspace may
+// also connect a shared POOL plan (one sentinel-user row per org). Surfaces:
 //   - personal (session): a user manages their own credential, one per provider.
-//   - agent (bearer): the executor fetches the credential the run BILLS — the initiator's
-//     (the session's asker) first, then the caller-agent's registrant. Never an unrelated
-//     user's: session lookups are bound to the calling agent's own context.
+//   - workspace pool (session, admin): an admin manages the org's shared plan.
+//   - owner-lend (session, owner): an agent's owner opts THAT agent in to bill the owner's
+//     own plan as a fallback (per-agent, default off).
+//   - agent (bearer): the executor fetches the credential a run BILLS, resolved in priority
+//     initiator -> owner (if this agent is lent) -> workspace pool -> fail-closed. Never an
+//     unrelated user's: session lookups are bound to the calling agent's own context.
 
 const PROVIDERS = ["claude-code", "codex"] as const
 const isoNow = () => new Date().toISOString()
+
+// The workspace-pool credential is a model_credential row keyed on this reserved sentinel
+// user id, so the org's shared plan reuses the whole encrypted-secret store with no new
+// table. It can never collide with a real user id (those are newId-prefixed).
+const POOL_USER = "__workspace_pool__"
 
 export const modelCredentialRoutes = (ctx: AppContext) => {
   const { meta, deps, agentFor, requireUser, requireWorkspace } = ctx
@@ -81,18 +89,106 @@ export const modelCredentialRoutes = (ctx: AppContext) => {
     return c.body(null, 204)
   })
 
-  // The executor fetches the credential a run bills against, decrypted. WHOSE plan is the
-  // run's INITIATOR's: pass `?session=` (the ask loop) or `?run=` (the automation lane)
-  // and the server resolves the initiator first — the session's asker, or the run's
-  // `initiated_by` (the person who clicked Run now) — falling back to the agent's
-  // registrant (the interim chain until the workspace pool lands; then the fallback
-  // becomes the pool). A clock/event run has no initiator (`initiated_by` null) and
-  // resolves straight to the fallback. Without either id (boot preflight) it is the
-  // registrant's. Returns `{ credential: null }` when nobody in the chain has one — the
-  // runner fails the run closed with a "connect your plan" message rather than falling
-  // back to a shared token. Isolation is structural twice over: a session/run id resolves
-  // only when it belongs to THIS agent (404 otherwise, so foreign ids don't leak), and
-  // only the resolved person's row is ever read.
+  // ---- Workspace pool (admin) --------------------------------------------
+  // The org's SHARED plan: billed when a run's initiator has no plan and the agent isn't
+  // owner-lent. One sentinel-user credential row per provider — same encrypted-secret store.
+
+  app.get("/v1/workspace/model-credentials", async (c) => {
+    const org = await requireWorkspace(c, "manage")
+    if (org instanceof Response) return org
+    const creds = await meta.listModelCredentials(org, POOL_USER)
+    return c.json({
+      credentials: creds.map((cr) => ({
+        provider: cr.provider,
+        kind: cr.kind,
+        hint: cr.hint,
+        updated_at: cr.updated_at,
+      })),
+    })
+  })
+
+  app.post("/v1/workspace/model-credentials", async (c) => {
+    const org = await requireWorkspace(c, "manage")
+    if (org instanceof Response) return org
+    if (!deps.encryptionKey) return fail(c, 503, "secret encryption is not configured")
+    const b = await readJson(
+      c,
+      z.object({
+        provider: z.enum(PROVIDERS),
+        kind: z.enum(["oauth", "api_key"]),
+        token: z.string().min(1).max(4000),
+      }),
+    )
+    if (b instanceof Response) return bail(b)
+    const token = b.token.trim()
+    if (token === "") return fail(c, 400, "token is empty")
+    const now = isoNow()
+    const hint = token.slice(-4)
+    await meta.setModelCredential({
+      id: newId("mcr"),
+      org_id: org,
+      user_id: POOL_USER,
+      provider: b.provider,
+      kind: b.kind,
+      secret: encryptSecret(token, deps.encryptionKey),
+      hint,
+      created_at: now,
+      updated_at: now,
+    })
+    return c.json({ ok: true, provider: b.provider, hint }, 201)
+  })
+
+  app.delete("/v1/workspace/model-credentials/:provider", async (c) => {
+    const org = await requireWorkspace(c, "manage")
+    if (org instanceof Response) return org
+    await meta.deleteModelCredential(org, POOL_USER, c.req.param("provider"))
+    return c.body(null, 204)
+  })
+
+  // ---- Owner-lend (per agent, owner only) --------------------------------
+  // An agent's OWNER opts THAT agent in to bill the owner's own plan as a fallback.
+  // Membership lives in org_settings.ownerLendAgents (an attribute on the existing JSON, no
+  // new column). Only the agent's own owner (created_by) may toggle it.
+
+  app.get("/v1/workspace/owner-lend", async (c) => {
+    const org = await requireWorkspace(c, "manage")
+    if (org instanceof Response) return org
+    const settings = await meta.getOrgSettings(org)
+    return c.json({ agentIds: settings.ownerLendAgents ?? [] })
+  })
+
+  app.put("/v1/workspace/owner-lend/:agentId", async (c) => {
+    const org = await requireWorkspace(c, "manage")
+    if (org instanceof Response) return org
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    const agentId = c.req.param("agentId")
+    const agent = (await meta.listAgents(org)).find((a) => a.id === agentId)
+    if (!agent) return fail(c, 404, "unknown agent")
+    if (agent.created_by !== me.id)
+      return fail(c, 403, "only the agent's owner can lend their plan")
+    const b = await readJson(c, z.object({ enabled: z.boolean() }))
+    if (b instanceof Response) return bail(b)
+    const settings = await meta.getOrgSettings(org)
+    const lent = new Set(settings.ownerLendAgents ?? [])
+    if (b.enabled) lent.add(agentId)
+    else lent.delete(agentId)
+    await meta.setOrgSettings(org, { ...settings, ownerLendAgents: [...lent] })
+    return c.json({ ok: true, agentId, enabled: b.enabled })
+  })
+
+  // The executor fetches the credential a run bills against, decrypted. Priority:
+  //   1. INITIATOR — the session's asker (`?session=`) or the run's `initiated_by`
+  //      (`?run=`, the person who clicked Run now). "Bill mine first."
+  //   2. OWNER — the agent's registrant (`created_by`), but ONLY when this agent is on the
+  //      owner's lend-list (org_settings.ownerLendAgents); default off.
+  //   3. WORKSPACE POOL — the org's shared plan (the sentinel-user credential row).
+  //   4. none — `{ credential: null }`; the runner fails the run closed with a "connect
+  //      your plan" message rather than falling back to a shared token.
+  // A clock/event run has no initiator (`initiated_by` null) and resolves straight to the
+  // owner/pool tiers; the boot preflight (no session/run) resolves the same tail. Isolation
+  // is structural: a session/run id resolves only when it belongs to THIS agent (404
+  // otherwise, so foreign ids don't leak), and only the resolved principal's row is read.
   app.get("/v1/agent/model-credential", async (c) => {
     const agent = await agentFor(c)
     if (!agent) return fail(c, 401, "agent token required")
@@ -125,11 +221,19 @@ export const modelCredentialRoutes = (ctx: AppContext) => {
         if (initiator) return present(initiator, "initiator")
       }
     }
+    // Owner tier — only when this agent is on its owner's lend-list (per-agent, default off).
     const owner = agent.created_by
-    if (!owner) return c.json({ credential: null })
-    const cred = await meta.getModelCredential(agent.org_id, owner, provider)
-    if (!cred) return c.json({ credential: null })
-    return present(cred, "registrant")
+    if (owner) {
+      const settings = await meta.getOrgSettings(agent.org_id)
+      if (settings.ownerLendAgents?.includes(agent.id)) {
+        const cred = await meta.getModelCredential(agent.org_id, owner, provider)
+        if (cred) return present(cred, "owner")
+      }
+    }
+    // Workspace pool tier — the org's shared plan, if one is connected.
+    const pool = await meta.getModelCredential(agent.org_id, POOL_USER, provider)
+    if (pool) return present(pool, "pool")
+    return c.json({ credential: null })
   })
 
   return app

--- a/apps/api/src/routes/model-credentials.ts
+++ b/apps/api/src/routes/model-credentials.ts
@@ -183,25 +183,35 @@ export const modelCredentialRoutes = (ctx: AppContext) => {
   //   2. OWNER — the agent's registrant (`created_by`), but ONLY when this agent is on the
   //      owner's lend-list (org_settings.ownerLendAgents); default off.
   //   3. WORKSPACE POOL — the org's shared plan (the sentinel-user credential row).
-  //   4. none — `{ credential: null }`; the runner fails the run closed with a "connect
-  //      your plan" message rather than falling back to a shared token.
+  //   4. none — `{ credential: null, reason }`; the runner fails the run closed rather than
+  //      falling back to a shared token. `reason` is "unreadable" when a row existed but its
+  //      secret couldn't be decrypted (a rotated DERIVE_AUTH_SECRET, a corrupt blob) so the
+  //      runner can say RECONNECT, else "none" (connect one).
   // A clock/event run has no initiator (`initiated_by` null) and resolves straight to the
   // owner/pool tiers; the boot preflight (no session/run) resolves the same tail. Isolation
   // is structural: a session/run id resolves only when it belongs to THIS agent (404
-  // otherwise, so foreign ids don't leak), and only the resolved principal's row is read.
+  // otherwise, so foreign ids don't leak), and only the resolved principal's row is read. A
+  // credential whose secret won't decrypt is treated as absent (fall through), never a 500.
   app.get("/v1/agent/model-credential", async (c) => {
     const agent = await agentFor(c)
     if (!agent) return fail(c, 401, "agent token required")
     const provider = c.req.query("provider") ?? "claude-code"
-    if (!deps.encryptionKey) return c.json({ credential: null })
-    const present = (cred: { kind: string; secret: string }, source: string) =>
-      c.json({
-        credential: {
-          kind: cred.kind,
-          value: decryptSecret(cred.secret, deps.encryptionKey as string),
-        },
-        source,
-      })
+    const key = deps.encryptionKey
+    if (!key) return c.json({ credential: null, reason: "none" })
+    // Decrypt a resolved row into the response, or null when its stored secret can't be read
+    // — then we fall through to the next tier and remember we saw an unreadable one.
+    // decryptSecret FAILS OPEN (returns the blob unchanged) on a wrong key / corrupt secret,
+    // so a `v1.` blob that comes back identical never decrypted: treat it as unreadable rather
+    // than inject ciphertext as a token. (A legacy plaintext secret has no `v1.` prefix.)
+    let sawUnreadable = false
+    const present = (cred: { kind: string; secret: string }, source: string) => {
+      const value = decryptSecret(cred.secret, key)
+      if (cred.secret.startsWith("v1.") && value === cred.secret) {
+        sawUnreadable = true
+        return null
+      }
+      return c.json({ credential: { kind: cred.kind, value }, source })
+    }
     const sessionId = c.req.query("session")
     if (sessionId) {
       const s = await meta.getSession(sessionId)
@@ -209,7 +219,10 @@ export const modelCredentialRoutes = (ctx: AppContext) => {
       if (!s || !sctx || sctx.agent_id !== agent.id || s.org_id !== agent.org_id)
         return fail(c, 404, "unknown session")
       const asker = await meta.getModelCredential(agent.org_id, s.asker_id, provider)
-      if (asker) return present(asker, "asker")
+      if (asker) {
+        const r = present(asker, "asker")
+        if (r) return r
+      }
     }
     const runId = c.req.query("run")
     if (runId) {
@@ -218,7 +231,10 @@ export const modelCredentialRoutes = (ctx: AppContext) => {
         return fail(c, 404, "unknown run")
       if (r.initiated_by) {
         const initiator = await meta.getModelCredential(agent.org_id, r.initiated_by, provider)
-        if (initiator) return present(initiator, "initiator")
+        if (initiator) {
+          const rr = present(initiator, "initiator")
+          if (rr) return rr
+        }
       }
     }
     // Owner tier — only when this agent is on its owner's lend-list (per-agent, default off).
@@ -227,13 +243,19 @@ export const modelCredentialRoutes = (ctx: AppContext) => {
       const settings = await meta.getOrgSettings(agent.org_id)
       if (settings.ownerLendAgents?.includes(agent.id)) {
         const cred = await meta.getModelCredential(agent.org_id, owner, provider)
-        if (cred) return present(cred, "owner")
+        if (cred) {
+          const r = present(cred, "owner")
+          if (r) return r
+        }
       }
     }
     // Workspace pool tier — the org's shared plan, if one is connected.
     const pool = await meta.getModelCredential(agent.org_id, POOL_USER, provider)
-    if (pool) return present(pool, "pool")
-    return c.json({ credential: null })
+    if (pool) {
+      const r = present(pool, "pool")
+      if (r) return r
+    }
+    return c.json({ credential: null, reason: sawUnreadable ? "unreadable" : "none" })
   })
 
   return app

--- a/apps/api/src/routes/model-credentials.ts
+++ b/apps/api/src/routes/model-credentials.ts
@@ -56,8 +56,8 @@ export const modelCredentialRoutes = (ctx: AppContext) => {
       c,
       z.object({
         provider: z.enum(PROVIDERS),
-        kind: z.enum(["oauth", "api_key"]),
-        token: z.string().min(1).max(4000),
+        kind: z.enum(["oauth", "api_key", "login"]),
+        token: z.string().min(1).max(16000),
       }),
     )
     if (b instanceof Response) return bail(b)
@@ -115,8 +115,8 @@ export const modelCredentialRoutes = (ctx: AppContext) => {
       c,
       z.object({
         provider: z.enum(PROVIDERS),
-        kind: z.enum(["oauth", "api_key"]),
-        token: z.string().min(1).max(4000),
+        kind: z.enum(["oauth", "api_key", "login"]),
+        token: z.string().min(1).max(16000),
       }),
     )
     if (b instanceof Response) return bail(b)

--- a/apps/api/src/routes/model-credentials.ts
+++ b/apps/api/src/routes/model-credentials.ts
@@ -1,6 +1,6 @@
 import { newId } from "@derive/core"
 import { z } from "@hono/zod-openapi"
-import { Hono } from "hono"
+import { type Context, Hono } from "hono"
 import type { AppContext } from "../context"
 import { decryptSecret, encryptSecret } from "../lib/crypto"
 import { bail, fail, readJson } from "../lib/http"
@@ -177,85 +177,103 @@ export const modelCredentialRoutes = (ctx: AppContext) => {
     return c.json({ ok: true, agentId, enabled: b.enabled })
   })
 
-  // The executor fetches the credential a run bills against, decrypted. Priority:
-  //   1. INITIATOR — the session's asker (`?session=`) or the run's `initiated_by`
-  //      (`?run=`, the person who clicked Run now). "Bill mine first."
-  //   2. OWNER — the agent's registrant (`created_by`), but ONLY when this agent is on the
-  //      owner's lend-list (org_settings.ownerLendAgents); default off.
-  //   3. WORKSPACE POOL — the org's shared plan (the sentinel-user credential row).
-  //   4. none — `{ credential: null, reason }`; the runner fails the run closed rather than
-  //      falling back to a shared token. `reason` is "unreadable" when a row existed but its
-  //      secret couldn't be decrypted (a rotated DERIVE_AUTH_SECRET, a corrupt blob) so the
-  //      runner can say RECONNECT, else "none" (connect one).
-  // A clock/event run has no initiator (`initiated_by` null) and resolves straight to the
-  // owner/pool tiers; the boot preflight (no session/run) resolves the same tail. Isolation
-  // is structural: a session/run id resolves only when it belongs to THIS agent (404
-  // otherwise, so foreign ids don't leak), and only the resolved principal's row is read. A
-  // credential whose secret won't decrypt is treated as absent (fall through), never a 500.
-  app.get("/v1/agent/model-credential", async (c) => {
-    const agent = await agentFor(c)
-    if (!agent) return fail(c, 401, "agent token required")
-    const provider = c.req.query("provider") ?? "claude-code"
-    const key = deps.encryptionKey
-    if (!key) return c.json({ credential: null, reason: "none" })
-    // Decrypt a resolved row into the response, or null when its stored secret can't be read
-    // — then we fall through to the next tier and remember we saw an unreadable one.
-    // decryptSecret FAILS OPEN (returns the blob unchanged) on a wrong key / corrupt secret,
-    // so a `v1.` blob that comes back identical never decrypted: treat it as unreadable rather
-    // than inject ciphertext as a token. (A legacy plaintext secret has no `v1.` prefix.)
-    let sawUnreadable = false
-    const present = (cred: { kind: string; secret: string }, source: string) => {
-      const value = decryptSecret(cred.secret, key)
-      if (cred.secret.startsWith("v1.") && value === cred.secret) {
-        sawUnreadable = true
-        return null
-      }
-      return c.json({ credential: { kind: cred.kind, value }, source })
-    }
+  // The ordered credential candidates a run bills against — {userId, source} for each tier
+  // that applies, in priority order: INITIATOR (session asker / run `initiated_by`), then the
+  // agent OWNER (only when this agent is on org_settings.ownerLendAgents; default off), then
+  // the WORKSPACE POOL (a sentinel-user row). Returns a Response (404) when a passed
+  // session/run id doesn't belong to THIS agent, so foreign ids never leak or bill. Shared by
+  // the read (GET) and the refreshed-token write (PUT) so both target the same rows.
+  const credentialCandidates = async (
+    c: Context,
+    agent: { id: string; org_id: string; created_by: string | null },
+  ) => {
+    const out: { userId: string; source: string }[] = []
     const sessionId = c.req.query("session")
     if (sessionId) {
       const s = await meta.getSession(sessionId)
       const sctx = s ? await meta.getContext(s.context_id) : null
       if (!s || !sctx || sctx.agent_id !== agent.id || s.org_id !== agent.org_id)
         return fail(c, 404, "unknown session")
-      const asker = await meta.getModelCredential(agent.org_id, s.asker_id, provider)
-      if (asker) {
-        const r = present(asker, "asker")
-        if (r) return r
-      }
+      out.push({ userId: s.asker_id, source: "asker" })
     }
     const runId = c.req.query("run")
     if (runId) {
       const r = await meta.getRun(runId)
       if (!r || r.agent_id !== agent.id || r.org_id !== agent.org_id)
         return fail(c, 404, "unknown run")
-      if (r.initiated_by) {
-        const initiator = await meta.getModelCredential(agent.org_id, r.initiated_by, provider)
-        if (initiator) {
-          const rr = present(initiator, "initiator")
-          if (rr) return rr
-        }
-      }
+      if (r.initiated_by) out.push({ userId: r.initiated_by, source: "initiator" })
     }
-    // Owner tier — only when this agent is on its owner's lend-list (per-agent, default off).
-    const owner = agent.created_by
-    if (owner) {
+    if (agent.created_by) {
       const settings = await meta.getOrgSettings(agent.org_id)
-      if (settings.ownerLendAgents?.includes(agent.id)) {
-        const cred = await meta.getModelCredential(agent.org_id, owner, provider)
-        if (cred) {
-          const r = present(cred, "owner")
-          if (r) return r
-        }
-      }
+      if (settings.ownerLendAgents?.includes(agent.id))
+        out.push({ userId: agent.created_by, source: "owner" })
     }
-    // Workspace pool tier — the org's shared plan, if one is connected.
-    const pool = await meta.getModelCredential(agent.org_id, POOL_USER, provider)
-    if (pool) {
-      const r = present(pool, "pool")
-      if (r) return r
+    out.push({ userId: POOL_USER, source: "pool" })
+    return out
+  }
+
+  // A `v1.` secret that decrypts to itself never decrypted (decryptSecret FAILS OPEN on a
+  // wrong key / corrupt blob): treat it as unreadable rather than inject ciphertext as a token.
+  const unreadable = (cred: { secret: string }, value: string) =>
+    cred.secret.startsWith("v1.") && value === cred.secret
+
+  // The executor fetches the credential a run bills against, decrypted — the FIRST readable
+  // candidate tier. `reason` distinguishes an UNREADABLE stored secret (reconnect) from
+  // nothing connected (connect). A credential whose secret won't decrypt is treated as absent,
+  // never a 500.
+  app.get("/v1/agent/model-credential", async (c) => {
+    const agent = await agentFor(c)
+    if (!agent) return fail(c, 401, "agent token required")
+    const provider = c.req.query("provider") ?? "claude-code"
+    const key = deps.encryptionKey
+    if (!key) return c.json({ credential: null, reason: "none" })
+    const candidates = await credentialCandidates(c, agent)
+    if (candidates instanceof Response) return candidates
+    let sawUnreadable = false
+    for (const { userId, source } of candidates) {
+      const cred = await meta.getModelCredential(agent.org_id, userId, provider)
+      if (!cred) continue
+      const value = decryptSecret(cred.secret, key)
+      if (unreadable(cred, value)) {
+        sawUnreadable = true
+        continue
+      }
+      return c.json({ credential: { kind: cred.kind, value }, source })
     }
     return c.json({ credential: null, reason: sawUnreadable ? "unreadable" : "none" })
+  })
+
+  // The executor PERSISTS a refreshed credential blob back to the SAME row a run resolved to
+  // (the first readable tier). Codex rotates its login's single-use refresh token in place and
+  // writes it to auth.json during a run; the runner reads that back and PUTs it here so the
+  // stored token stays valid for the next run (the sanctioned "run and persist the updated
+  // auth.json" pattern, not a reimplemented refresh). Only the resolved principal's row is
+  // touched — same 404 isolation as the read. The runner calls this in a finally, so a refresh
+  // that landed before a run failed is still saved.
+  app.put("/v1/agent/model-credential", async (c) => {
+    const agent = await agentFor(c)
+    if (!agent) return fail(c, 401, "agent token required")
+    const provider = c.req.query("provider") ?? "claude-code"
+    const key = deps.encryptionKey
+    if (!key) return fail(c, 503, "secret encryption is not configured")
+    const b = await readJson(c, z.object({ token: z.string().min(1).max(16000) }))
+    if (b instanceof Response) return bail(b)
+    const candidates = await credentialCandidates(c, agent)
+    if (candidates instanceof Response) return candidates
+    const token = b.token.trim()
+    for (const { userId } of candidates) {
+      const cred = await meta.getModelCredential(agent.org_id, userId, provider)
+      if (!cred) continue
+      // Update the readable row the run actually used (skip an unreadable one, matching read).
+      if (unreadable(cred, decryptSecret(cred.secret, key))) continue
+      await meta.setModelCredential({
+        ...cred,
+        secret: encryptSecret(token, key),
+        updated_at: isoNow(),
+      })
+      return c.json({ ok: true })
+    }
+    return c.json({ ok: false, reason: "no credential to update" }, 404)
   })
 
   return app

--- a/apps/api/src/routes/model-credentials.ts
+++ b/apps/api/src/routes/model-credentials.ts
@@ -2,7 +2,7 @@ import { newId } from "@derive/core"
 import { z } from "@hono/zod-openapi"
 import { type Context, Hono } from "hono"
 import type { AppContext } from "../context"
-import { decryptSecret, encryptSecret } from "../lib/crypto"
+import { decryptSecret, encryptSecret, sha256 } from "../lib/crypto"
 import { bail, fail, readJson } from "../lib/http"
 
 // Model-plan credentials. Every team member connects their OWN Claude/Codex plan token (or
@@ -243,37 +243,63 @@ export const modelCredentialRoutes = (ctx: AppContext) => {
     return c.json({ credential: null, reason: sawUnreadable ? "unreadable" : "none" })
   })
 
-  // The executor PERSISTS a refreshed credential blob back to the SAME row a run resolved to
-  // (the first readable tier). Codex rotates its login's single-use refresh token in place and
-  // writes it to auth.json during a run; the runner reads that back and PUTs it here so the
-  // stored token stays valid for the next run (the sanctioned "run and persist the updated
-  // auth.json" pattern, not a reimplemented refresh). Only the resolved principal's row is
-  // touched — same 404 isolation as the read. The runner calls this in a finally, so a refresh
-  // that landed before a run failed is still saved.
+  // The executor PERSISTS a refreshed login blob back to the EXACT row a run resolved to.
+  // Codex rotates its login's single-use token in place and writes it to auth.json during a
+  // run; the runner reads that back and PUTs it here so the stored token stays valid for the
+  // next run (the sanctioned "run and persist the updated auth.json" pattern, not a
+  // reimplemented refresh). Hardened four ways, because a runtime bearer must never be able to
+  // rewrite a management-owned secret:
+  //   - BOUND TO A RUN: a `?session=`/`?run=` that belongs to THIS agent is required, so a
+  //     contextless bearer can't reach the owner/pool tiers and overwrite them.
+  //   - EXACT TIER: `source` names the tier the run read; we write only that row, never a
+  //     re-resolved "first readable" (which could drift to another principal mid-run).
+  //   - LOGIN ONLY: only the self-rotating `login` kind is refreshable; an api_key/oauth
+  //     secret is never clobbered.
+  //   - COMPARE-AND-SWAP: we overwrite only if the stored secret still hashes to what the run
+  //     started with (`prev_sha256`), so a concurrent/stale write or a mid-run row replacement
+  //     is rejected. The blob must also parse as a non-empty object (a crashed CLI can leave
+  //     garbage).
   app.put("/v1/agent/model-credential", async (c) => {
     const agent = await agentFor(c)
     if (!agent) return fail(c, 401, "agent token required")
     const provider = c.req.query("provider") ?? "claude-code"
     const key = deps.encryptionKey
     if (!key) return fail(c, 503, "secret encryption is not configured")
-    const b = await readJson(c, z.object({ token: z.string().min(1).max(16000) }))
+    if (!c.req.query("session") && !c.req.query("run"))
+      return fail(c, 400, "a session or run is required to persist a refresh")
+    const b = await readJson(
+      c,
+      z.object({
+        token: z.string().min(1).max(16000),
+        source: z.enum(["asker", "initiator", "owner", "pool"]),
+        prev_sha256: z.string().min(1).max(64),
+      }),
+    )
     if (b instanceof Response) return bail(b)
     const candidates = await credentialCandidates(c, agent)
     if (candidates instanceof Response) return candidates
+    const target = candidates.find((x) => x.source === b.source)
+    if (!target) return fail(c, 404, "unknown credential tier")
+    const cred = await meta.getModelCredential(agent.org_id, target.userId, provider)
+    if (!cred) return c.json({ ok: false, reason: "no credential to update" }, 404)
+    if (cred.kind !== "login") return fail(c, 409, "only login credentials are refreshable")
+    const current = decryptSecret(cred.secret, key)
+    if (unreadable(cred, current) || sha256(current) !== b.prev_sha256)
+      return c.json({ ok: false, reason: "credential changed" }, 409)
     const token = b.token.trim()
-    for (const { userId } of candidates) {
-      const cred = await meta.getModelCredential(agent.org_id, userId, provider)
-      if (!cred) continue
-      // Update the readable row the run actually used (skip an unreadable one, matching read).
-      if (unreadable(cred, decryptSecret(cred.secret, key))) continue
-      await meta.setModelCredential({
-        ...cred,
-        secret: encryptSecret(token, key),
-        updated_at: isoNow(),
-      })
-      return c.json({ ok: true })
+    try {
+      const parsed = JSON.parse(token)
+      if (!parsed || typeof parsed !== "object" || Object.keys(parsed).length === 0)
+        return fail(c, 400, "not a valid login blob")
+    } catch {
+      return fail(c, 400, "not a valid login blob")
     }
-    return c.json({ ok: false, reason: "no credential to update" }, 404)
+    await meta.setModelCredential({
+      ...cred,
+      secret: encryptSecret(token, key),
+      updated_at: isoNow(),
+    })
+    return c.json({ ok: true })
   })
 
   return app

--- a/apps/api/test/model-credentials.test.ts
+++ b/apps/api/test/model-credentials.test.ts
@@ -455,3 +455,58 @@ describe("model credentials: pool isolation + unreadable secrets", () => {
     expect(body.reason).toBe("unreadable")
   })
 })
+
+// Refresh persistence: the executor PUTs a refreshed blob back to the SAME row a run resolved
+// to, so a rotated single-use login (Codex) stays valid across runs. Same 404 isolation as the
+// read: a foreign session/run id never writes a cross-row.
+describe("model credentials: refresh persistence (PUT)", () => {
+  const owner: TestUser = { id: "u_mcr2_own", email: "mcr2own@derive.test", name: "Owner" }
+  const { app } = makeAuthedApp("model-creds-refresh", [owner], "editor", {
+    deps: { encryptionKey: "test-enc-secret" },
+  })
+  const mintAgent = async (name: string) =>
+    (await (await app.request("/v1/agents", jsonAs(as(owner.email), { name }))).json()) as {
+      id: string
+      token: string
+    }
+  const readCred = (agentToken: string) =>
+    app.request("/v1/agent/model-credential?provider=codex", { headers: bearer(agentToken) })
+  const putCred = (token: string, agentToken: string, q = "") =>
+    app.request(`/v1/agent/model-credential?provider=codex${q}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", ...bearer(agentToken) },
+      body: JSON.stringify({ token }),
+    })
+
+  it("persists a refreshed login back to the resolved (pool) row; next read returns it", async () => {
+    await app.request("/v1/me", { headers: as(owner.email) })
+    await app.request(
+      "/v1/workspace/model-credentials",
+      jsonAs(as(owner.email), { provider: "codex", kind: "login", token: '{"tokens":{"v":1}}' }),
+    )
+    const agent = await mintAgent("Refresher")
+    const before = await (await readCred(agent.token)).json()
+    expect(before.credential).toEqual({ kind: "login", value: '{"tokens":{"v":1}}' })
+    // The run rotated the token in place; persist the refreshed blob.
+    expect((await putCred('{"tokens":{"v":2}}', agent.token)).status).toBe(200)
+    const after = await (await readCred(agent.token)).json()
+    expect(after.credential.value).toBe('{"tokens":{"v":2}}')
+  })
+
+  it("a PUT with a foreign session id is a 404, never a cross-row write", async () => {
+    const agent = await mintAgent("Refresher 2")
+    const res = await putCred("x", agent.token, "&session=ses_nope")
+    expect(res.status).toBe(404)
+  })
+
+  it("a PUT that resolves to no row is a 404 no-op (nothing to persist)", async () => {
+    // No claude-code credential exists anywhere, so there is no row to update.
+    const agent = await mintAgent("Refresher 3")
+    const res = await app.request("/v1/agent/model-credential?provider=claude-code", {
+      method: "PUT",
+      headers: { "content-type": "application/json", ...bearer(agent.token) },
+      body: JSON.stringify({ token: "x" }),
+    })
+    expect(res.status).toBe(404)
+  })
+})

--- a/apps/api/test/model-credentials.test.ts
+++ b/apps/api/test/model-credentials.test.ts
@@ -1,4 +1,6 @@
+import { newId } from "@derive/core"
 import { describe, expect, it } from "vitest"
+import { encryptSecret } from "../src/lib/crypto"
 import { as, bearer, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 
 // Model-plan credentials + the chain the executor bills against:
@@ -396,5 +398,60 @@ describe("model credentials: run-keyed initiator resolution", () => {
       headers: bearer(agentToken),
     })
     expect(res.status).toBe(404)
+  })
+})
+
+// Robustness of the resolver's read path: a workspace-pool row keyed on the sentinel user
+// never surfaces in a personal list, and a stored secret that can't be decrypted (a rotated
+// DERIVE_AUTH_SECRET, a corrupt blob) is treated as absent — null with reason "unreadable",
+// never a 500. Both are edges the account-safety story leans on.
+describe("model credentials: pool isolation + unreadable secrets", () => {
+  const owner: TestUser = { id: "u_mcx_own", email: "mcxown@derive.test", name: "Owner" }
+  const { app, meta } = makeAuthedApp("model-creds-x", [owner], "editor", {
+    deps: { encryptionKey: "test-enc-secret" },
+  })
+  const mintAgent = async (name: string) =>
+    (await (await app.request("/v1/agents", jsonAs(as(owner.email), { name }))).json()) as {
+      id: string
+      token: string
+    }
+
+  it("the workspace pool never leaks into a personal list", async () => {
+    await app.request("/v1/me", { headers: as(owner.email) })
+    // Connect ONLY the pool (the sentinel-user row), nothing personal.
+    const res = await app.request(
+      "/v1/workspace/model-credentials",
+      jsonAs(as(owner.email), { provider: "codex", kind: "api_key", token: "sk-pool-only-7777" }),
+    )
+    expect(res.status).toBe(201)
+    const mine = await (
+      await app.request("/v1/me/model-credentials", { headers: as(owner.email) })
+    ).json()
+    // The admin's OWN list is empty: the pool row is keyed on the sentinel user, not them.
+    expect(mine.credentials).toHaveLength(0)
+  })
+
+  it("an unreadable stored secret is null + reason 'unreadable', never a 500", async () => {
+    // Simulate a key rotation: a v1 blob encrypted under a DIFFERENT key can't be read here.
+    const now = new Date().toISOString()
+    await meta.setModelCredential({
+      id: newId("mcr"),
+      org_id: "default",
+      user_id: "__workspace_pool__",
+      provider: "claude-code",
+      kind: "oauth",
+      secret: encryptSecret("stale-token", "a-different-key"),
+      hint: "9999",
+      created_at: now,
+      updated_at: now,
+    })
+    const agent = await mintAgent("Reader")
+    const res = await app.request("/v1/agent/model-credential?provider=claude-code", {
+      headers: bearer(agent.token),
+    })
+    expect(res.status).toBe(200) // NOT a 500
+    const body = await res.json()
+    expect(body.credential).toBeNull()
+    expect(body.reason).toBe("unreadable")
   })
 })

--- a/apps/api/test/model-credentials.test.ts
+++ b/apps/api/test/model-credentials.test.ts
@@ -1,6 +1,6 @@
 import { newId } from "@derive/core"
 import { describe, expect, it } from "vitest"
-import { encryptSecret } from "../src/lib/crypto"
+import { encryptSecret, sha256 } from "../src/lib/crypto"
 import { as, bearer, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 
 // Model-plan credentials + the chain the executor bills against:
@@ -456,57 +456,111 @@ describe("model credentials: pool isolation + unreadable secrets", () => {
   })
 })
 
-// Refresh persistence: the executor PUTs a refreshed blob back to the SAME row a run resolved
-// to, so a rotated single-use login (Codex) stays valid across runs. Same 404 isolation as the
-// read: a foreign session/run id never writes a cross-row.
+// Refresh persistence: the executor PUTs a rotated login back to the EXACT row a run resolved
+// to. The write is hardened: it must be bound to a run belonging to the agent, name the tier
+// via `source`, target only a `login` kind, pass a compare-and-swap of the seed hash, and
+// carry a well-formed blob. A bare bearer must NOT be able to overwrite the shared pool.
 describe("model credentials: refresh persistence (PUT)", () => {
   const owner: TestUser = { id: "u_mcr2_own", email: "mcr2own@derive.test", name: "Owner" }
   const { app } = makeAuthedApp("model-creds-refresh", [owner], "editor", {
     deps: { encryptionKey: "test-enc-secret" },
   })
-  const mintAgent = async (name: string) =>
-    (await (await app.request("/v1/agents", jsonAs(as(owner.email), { name }))).json()) as {
-      id: string
-      token: string
-    }
-  const readCred = (agentToken: string) =>
-    app.request("/v1/agent/model-credential?provider=codex", { headers: bearer(agentToken) })
-  const putCred = (token: string, agentToken: string, q = "") =>
+  const T1 = '{"tokens":{"v":1}}'
+  let agentToken: string
+  let runId: string
+
+  const put = (body: object, q = `&run=${runId}`) =>
     app.request(`/v1/agent/model-credential?provider=codex${q}`, {
       method: "PUT",
       headers: { "content-type": "application/json", ...bearer(agentToken) },
-      body: JSON.stringify({ token }),
+      body: JSON.stringify(body),
+    })
+  const getViaRun = () =>
+    app.request(`/v1/agent/model-credential?provider=codex&run=${runId}`, {
+      headers: bearer(agentToken),
     })
 
-  it("persists a refreshed login back to the resolved (pool) row; next read returns it", async () => {
+  it("setup: an automation run with no initiator plan resolves to the pool login", async () => {
     await app.request("/v1/me", { headers: as(owner.email) })
+    const ag = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Auto" }))
+    ).json()
+    agentToken = ag.token
+    const auto = await (
+      await app.request(
+        "/v1/automations",
+        jsonAs(as(owner.email), { agentId: ag.id, trigger: { kind: "manual" }, instruction: "x" }),
+      )
+    ).json()
+    const run = await (
+      await app.request(`/v1/automations/${auto.id}/run`, {
+        method: "POST",
+        headers: as(owner.email),
+      })
+    ).json()
+    runId = run.id
+    // The initiator (owner) has NO personal codex plan; connect only a POOL login.
     await app.request(
       "/v1/workspace/model-credentials",
-      jsonAs(as(owner.email), { provider: "codex", kind: "login", token: '{"tokens":{"v":1}}' }),
+      jsonAs(as(owner.email), { provider: "codex", kind: "login", token: T1 }),
     )
-    const agent = await mintAgent("Refresher")
-    const before = await (await readCred(agent.token)).json()
-    expect(before.credential).toEqual({ kind: "login", value: '{"tokens":{"v":1}}' })
-    // The run rotated the token in place; persist the refreshed blob.
-    expect((await putCred('{"tokens":{"v":2}}', agent.token)).status).toBe(200)
-    const after = await (await readCred(agent.token)).json()
-    expect(after.credential.value).toBe('{"tokens":{"v":2}}')
+    const got = await (await getViaRun()).json()
+    expect(got).toMatchObject({ credential: { kind: "login", value: T1 }, source: "pool" })
   })
 
-  it("a PUT with a foreign session id is a 404, never a cross-row write", async () => {
-    const agent = await mintAgent("Refresher 2")
-    const res = await putCred("x", agent.token, "&session=ses_nope")
-    expect(res.status).toBe(404)
+  it("persists a refreshed login to the pool row (source + CAS); next read returns it", async () => {
+    const T2 = '{"tokens":{"v":2}}'
+    const res = await put({ token: T2, source: "pool", prev_sha256: sha256(T1) })
+    expect(res.status).toBe(200)
+    expect((await (await getViaRun()).json()).credential.value).toBe(T2)
   })
 
-  it("a PUT that resolves to no row is a 404 no-op (nothing to persist)", async () => {
-    // No claude-code credential exists anywhere, so there is no row to update.
-    const agent = await mintAgent("Refresher 3")
-    const res = await app.request("/v1/agent/model-credential?provider=claude-code", {
+  it("a contextless PUT (no session/run) is rejected — cannot touch the pool", async () => {
+    const res = await app.request("/v1/agent/model-credential?provider=codex", {
       method: "PUT",
-      headers: { "content-type": "application/json", ...bearer(agent.token) },
-      body: JSON.stringify({ token: "x" }),
+      headers: { "content-type": "application/json", ...bearer(agentToken) },
+      body: JSON.stringify({
+        token: '{"tokens":{"v":9}}',
+        source: "pool",
+        prev_sha256: sha256("x"),
+      }),
     })
+    expect(res.status).toBe(400)
+  })
+
+  it("a stale compare-and-swap (wrong prev_sha256) is rejected — 409", async () => {
+    // The stored value is now T2, so quoting T1's hash is a stale write.
+    const res = await put({ token: '{"tokens":{"v":3}}', source: "pool", prev_sha256: sha256(T1) })
+    expect(res.status).toBe(409)
+  })
+
+  it("a garbage (non-JSON) blob is rejected even with a valid CAS — 400", async () => {
+    const res = await put({
+      token: "not json",
+      source: "pool",
+      prev_sha256: sha256('{"tokens":{"v":2}}'),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it("refuses to clobber a non-login (api_key) row — 409", async () => {
+    await app.request(
+      "/v1/workspace/model-credentials",
+      jsonAs(as(owner.email), { provider: "codex", kind: "api_key", token: "sk-pool-key" }),
+    )
+    const res = await put({
+      token: '{"tokens":{"v":4}}',
+      source: "pool",
+      prev_sha256: sha256("sk-pool-key"),
+    })
+    expect(res.status).toBe(409)
+  })
+
+  it("a foreign run id is a 404, never a cross-row write", async () => {
+    const res = await put(
+      { token: '{"tokens":{"v":5}}', source: "pool", prev_sha256: sha256("x") },
+      "&run=run_nope",
+    )
     expect(res.status).toBe(404)
   })
 })

--- a/apps/api/test/model-credentials.test.ts
+++ b/apps/api/test/model-credentials.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest"
 import { as, bearer, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 
-// Per-user model-plan credentials. A member connects their OWN plan token (encrypted at
-// rest); the executor fetches it via an agent bearer — scoped to the agent's registrant, so
-// one user's token never reaches another user's runs. Isolation is the point of these tests.
+// Model-plan credentials + the chain the executor bills against:
+//   initiator (asker/clicker)  ->  owner (only if THIS agent is lent)  ->  workspace pool  ->  null
+// A member connects their OWN plan token (encrypted at rest). The owner fallback is OFF by
+// default — it applies only to agents the owner has explicitly lent — so isolation AND the
+// default-closed gate are what these tests pin down.
 describe("model credentials", () => {
   const owner: TestUser = { id: "u_mc_own", email: "mcown@derive.test", name: "Owner" }
   const other: TestUser = { id: "u_mc_oth", email: "mcoth@derive.test", name: "Other" }
@@ -18,6 +20,14 @@ describe("model credentials", () => {
   }
   const connect = (email: string, body: object) =>
     app.request("/v1/me/model-credentials", jsonAs(as(email), body))
+  const lend = (email: string, agentId: string, enabled: boolean) =>
+    app.request(`/v1/workspace/owner-lend/${agentId}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", ...as(email) },
+      body: JSON.stringify({ enabled }),
+    })
+  const agentCred = (token: string, provider = "codex") =>
+    app.request(`/v1/agent/model-credential?provider=${provider}`, { headers: bearer(token) })
 
   it("connect stores an encrypted secret; list returns hints only, never the token", async () => {
     const token = "sk-ant-oat01-SUPERSECRETVALUE9999"
@@ -34,67 +44,44 @@ describe("model credentials", () => {
     expect(JSON.stringify(list)).not.toContain(token)
   })
 
-  it("the agent surface returns the DECRYPTED credential of the agent's own registrant", async () => {
-    await connect(owner.email, {
-      provider: "codex",
-      kind: "api_key",
-      token: "owner-plan-fixture-value",
-    })
+  it("owner-lend is OFF by default: a no-initiator fetch is null even though the owner has a plan", async () => {
+    await connect(owner.email, { provider: "codex", kind: "api_key", token: "owner-plan-fixture" })
     const agent = await mintAgent(owner.email, "Owner Runner")
-    const got = await (
-      await app.request("/v1/agent/model-credential?provider=codex", {
-        headers: bearer(agent.token),
-      })
-    ).json()
-    // Decrypted round-trip: the runner gets the real value to inject.
-    expect(got.credential).toEqual({ kind: "api_key", value: "owner-plan-fixture-value" })
+    const got = await (await agentCred(agent.token)).json()
+    // The owner has a plan, but this agent isn't lent — fail closed, don't silently bill them.
+    expect(got.credential).toBeNull()
   })
 
-  it("ISOLATION: the endpoint resolves ONLY the calling agent's registrant + provider", async () => {
-    // Owner connects codex, but NOT claude-code. Their own agent gets the codex token and
-    // null for claude-code — the lookup is keyed (org, registrant, provider), so it can only
-    // ever return this agent-owner's own row. Cross-USER keying (one user's row is never
+  it("once the owner lends THIS agent, the fetch returns the owner's decrypted plan (source owner)", async () => {
+    await connect(owner.email, { provider: "codex", kind: "api_key", token: "owner-plan-lent" })
+    const agent = await mintAgent(owner.email, "Lent Runner")
+    const on = await lend(owner.email, agent.id, true)
+    expect(on.status).toBe(200)
+    const got = await (await agentCred(agent.token)).json()
+    expect(got.credential).toEqual({ kind: "api_key", value: "owner-plan-lent" })
+    expect(got.source).toBe("owner")
+    // Un-lending closes it again — the gate is live, not a one-way latch.
+    await lend(owner.email, agent.id, false)
+    expect((await (await agentCred(agent.token)).json()).credential).toBeNull()
+  })
+
+  it("ISOLATION: a lent agent resolves ONLY its owner's row, and only the asked provider", async () => {
+    // Owner connects codex, but NOT claude-code. Cross-USER keying (one user's row is never
     // another's) is proven exhaustively in the db store-contract (u1 vs u2).
     await connect(owner.email, { provider: "codex", kind: "api_key", token: "sk-owner-only" })
     const agent = await mintAgent(owner.email, "Owner Runner 2")
-    const codexGot = await (
-      await app.request("/v1/agent/model-credential?provider=codex", {
-        headers: bearer(agent.token),
-      })
-    ).json()
-    expect(codexGot.credential?.value).toBe("sk-owner-only")
-    const claudeGot = await (
-      await app.request("/v1/agent/model-credential?provider=claude-code", {
-        headers: bearer(agent.token),
-      })
-    ).json()
-    expect(claudeGot.credential).toBeNull()
+    await lend(owner.email, agent.id, true)
+    expect((await (await agentCred(agent.token, "codex")).json()).credential?.value).toBe(
+      "sk-owner-only",
+    )
+    // Even lent, an unconnected provider is null — never another provider's row.
+    expect((await (await agentCred(agent.token, "claude-code")).json()).credential).toBeNull()
   })
 
-  it("a missing provider connection is null (fail-closed at the runner), not a leak", async () => {
-    const agent = await mintAgent(owner.email, "Runner 2")
-    const got = await (
-      await app.request("/v1/agent/model-credential?provider=claude-code", {
-        headers: bearer(agent.token),
-      })
-    ).json()
-    expect(got.credential).toBeNull()
-  })
-
-  it("disconnect removes it; the agent then gets null", async () => {
-    await connect(owner.email, { provider: "codex", kind: "oauth", token: "sk-to-delete" })
-    const del = await app.request("/v1/me/model-credentials/codex", {
-      method: "DELETE",
-      headers: as(owner.email),
-    })
-    expect(del.status).toBe(204)
-    const agent = await mintAgent(owner.email, "Runner 3")
-    const got = await (
-      await app.request("/v1/agent/model-credential?provider=codex", {
-        headers: bearer(agent.token),
-      })
-    ).json()
-    expect(got.credential).toBeNull()
+  it("only the agent's OWNER may lend; a non-admin member is refused", async () => {
+    const agent = await mintAgent(owner.email, "Guarded Runner")
+    const res = await lend(other.email, agent.id, true)
+    expect([401, 403]).toContain(res.status)
   })
 
   it("the agent surface requires an agent bearer", async () => {
@@ -103,10 +90,90 @@ describe("model credentials", () => {
   })
 })
 
+// The workspace POOL (a sentinel-user credential row) is the org's shared plan, billed only
+// when nobody more specific is on the hook. And owner-lend OUTRANKS the pool: a deliberate
+// per-agent grant is honored before the shared wallet.
+describe("model credentials: workspace pool + owner-lend precedence", () => {
+  const owner: TestUser = { id: "u_mcp_own", email: "mcpown@derive.test", name: "Owner" }
+  const editor: TestUser = { id: "u_mcp_ed", email: "mcped@derive.test", name: "Editor" }
+  const { app } = makeAuthedApp("model-creds-pool", [owner, editor], "editor", {
+    deps: { encryptionKey: "test-enc-secret" },
+  })
+  const mintAgent = async (name: string) =>
+    (await (await app.request("/v1/agents", jsonAs(as(owner.email), { name }))).json()) as {
+      id: string
+      token: string
+    }
+  const connectPool = (email: string, body: object) =>
+    app.request("/v1/workspace/model-credentials", jsonAs(as(email), body))
+  const lend = (agentId: string, enabled: boolean) =>
+    app.request(`/v1/workspace/owner-lend/${agentId}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", ...as(owner.email) },
+      body: JSON.stringify({ enabled }),
+    })
+  const agentCred = (token: string) =>
+    app.request("/v1/agent/model-credential?provider=codex", { headers: bearer(token) })
+
+  it("a non-admin cannot connect the workspace pool", async () => {
+    const res = await connectPool(editor.email, {
+      provider: "codex",
+      kind: "api_key",
+      token: "sk-pool-nope",
+    })
+    expect([401, 403]).toContain(res.status)
+  })
+
+  it("the pool bills a run when nobody is lent (source pool)", async () => {
+    const res = await connectPool(owner.email, {
+      provider: "codex",
+      kind: "api_key",
+      token: "sk-workspace-pool",
+    })
+    expect(res.status).toBe(201)
+    const agent = await mintAgent("Pool Runner")
+    const got = await (await agentCred(agent.token)).json()
+    expect(got.credential).toEqual({ kind: "api_key", value: "sk-workspace-pool" })
+    expect(got.source).toBe("pool")
+  })
+
+  it("owner-lend OUTRANKS the pool: a lent agent bills the owner, not the pool", async () => {
+    await app.request(
+      "/v1/me/model-credentials",
+      jsonAs(as(owner.email), {
+        provider: "codex",
+        kind: "api_key",
+        token: "sk-owner-over-pool",
+      }),
+    )
+    const agent = await mintAgent("Precedence Runner")
+    await lend(agent.id, true)
+    const got = await (await agentCred(agent.token)).json()
+    expect(got.credential?.value).toBe("sk-owner-over-pool")
+    expect(got.source).toBe("owner")
+  })
+
+  it("the pool is hints-only on GET and removable; deleting it re-closes the fallback", async () => {
+    const list = await (
+      await app.request("/v1/workspace/model-credentials", { headers: as(owner.email) })
+    ).json()
+    expect(list.credentials.some((c: { provider: string }) => c.provider === "codex")).toBe(true)
+    expect(JSON.stringify(list)).not.toContain("sk-workspace-pool")
+    const del = await app.request("/v1/workspace/model-credentials/codex", {
+      method: "DELETE",
+      headers: as(owner.email),
+    })
+    expect(del.status).toBe(204)
+    // Pool gone and nobody lent → a fresh agent is fail-closed.
+    const agent = await mintAgent("Post-Delete Runner")
+    expect((await (await agentCred(agent.token)).json()).credential).toBeNull()
+  })
+})
+
 // The initiator chain: a session-keyed fetch bills the run's ASKER first — their question,
-// their tokens — and only falls back to the agent's registrant when the asker has no plan
-// (the interim chain until the workspace pool lands). Session ids resolve ONLY within the
-// calling agent's own context: anything else is a 404, so foreign ids neither leak nor bill.
+// their tokens. Only when the asker has no plan does it consider the owner (and only if the
+// agent is lent). Session ids resolve ONLY within the calling agent's own context: anything
+// else is a 404, so foreign ids neither leak nor bill.
 describe("model credentials: session-keyed initiator resolution", () => {
   const owner: TestUser = { id: "u_mcs_own", email: "mcsown@derive.test", name: "Owner" }
   const asker: TestUser = { id: "u_mcs_ask", email: "mcsask@derive.test", name: "Asker" }
@@ -116,6 +183,7 @@ describe("model credentials: session-keyed initiator resolution", () => {
   const connect = (email: string, body: object) =>
     app.request("/v1/me/model-credentials", jsonAs(as(email), body))
 
+  let agentId: string
   let agentToken: string
   let sessionId: string
 
@@ -125,6 +193,7 @@ describe("model credentials: session-keyed initiator resolution", () => {
     const ag = await (
       await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Shared Analyst" }))
     ).json()
+    agentId = ag.id
     agentToken = ag.token
     const manifest = await (await publishAs(app, "# Shared manifest", {}, as(owner.email))).json()
     const ctx = await (
@@ -152,7 +221,7 @@ describe("model credentials: session-keyed initiator resolution", () => {
     await connect(owner.email, {
       provider: "claude-code",
       kind: "api_key",
-      token: "sk-registrant-plan",
+      token: "sk-owner-plan",
     })
     await connect(asker.email, {
       provider: "claude-code",
@@ -161,7 +230,7 @@ describe("model credentials: session-keyed initiator resolution", () => {
     })
   })
 
-  it("a session-keyed fetch returns the ASKER's plan, not the registrant's", async () => {
+  it("a session-keyed fetch returns the ASKER's plan, not the owner's", async () => {
     const got = await (
       await app.request(`/v1/agent/model-credential?provider=claude-code&session=${sessionId}`, {
         headers: bearer(agentToken),
@@ -171,7 +240,7 @@ describe("model credentials: session-keyed initiator resolution", () => {
     expect(got.source).toBe("asker")
   })
 
-  it("an asker with no plan falls back to the registrant (interim, until the pool)", async () => {
+  it("an asker with no plan is null by default (owner not lent, no pool) — fail closed", async () => {
     await app.request("/v1/me/model-credentials/claude-code", {
       method: "DELETE",
       headers: as(asker.email),
@@ -181,8 +250,22 @@ describe("model credentials: session-keyed initiator resolution", () => {
         headers: bearer(agentToken),
       })
     ).json()
-    expect(got.credential).toEqual({ kind: "api_key", value: "sk-registrant-plan" })
-    expect(got.source).toBe("registrant")
+    expect(got.credential).toBeNull()
+  })
+
+  it("an asker with no plan uses the OWNER's plan once the agent is lent (source owner)", async () => {
+    await app.request(`/v1/workspace/owner-lend/${agentId}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", ...as(owner.email) },
+      body: JSON.stringify({ enabled: true }),
+    })
+    const got = await (
+      await app.request(`/v1/agent/model-credential?provider=claude-code&session=${sessionId}`, {
+        headers: bearer(agentToken),
+      })
+    ).json()
+    expect(got.credential).toEqual({ kind: "api_key", value: "sk-owner-plan" })
+    expect(got.source).toBe("owner")
   })
 
   it("ISOLATION: a session outside the calling agent's context is a 404, not a bill", async () => {
@@ -197,7 +280,7 @@ describe("model credentials: session-keyed initiator resolution", () => {
     expect(res.status).toBe(404)
   })
 
-  it("an unknown session id is a 404, never a silent registrant fallback", async () => {
+  it("an unknown session id is a 404, never a silent owner fallback", async () => {
     const res = await app.request(
       "/v1/agent/model-credential?provider=claude-code&session=ses_nope",
       { headers: bearer(agentToken) },
@@ -207,8 +290,8 @@ describe("model credentials: session-keyed initiator resolution", () => {
 })
 
 // The automation lane of the same chain: ?run= resolves the run's initiated_by (the person
-// who clicked Run now) before the registrant; a clock/event run (null initiator) falls
-// straight through. Run ids resolve only for the agent the run belongs to — 404 otherwise.
+// who clicked Run now) before the owner tier; a clock/event run (null initiator) falls
+// straight through to owner/pool. Run ids resolve only for the agent the run belongs to.
 describe("model credentials: run-keyed initiator resolution", () => {
   const owner: TestUser = { id: "u_mcr_own", email: "mcrown@derive.test", name: "Owner" }
   const clicker: TestUser = { id: "u_mcr_clk", email: "mcrclk@derive.test", name: "Clicker" }
@@ -218,6 +301,7 @@ describe("model credentials: run-keyed initiator resolution", () => {
   const connect = (email: string, body: object) =>
     app.request("/v1/me/model-credentials", jsonAs(as(email), body))
 
+  let agentId: string
   let agentToken: string
   let runId: string
 
@@ -227,6 +311,7 @@ describe("model credentials: run-keyed initiator resolution", () => {
     const ag = await (
       await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Automation Runner" }))
     ).json()
+    agentId = ag.id
     agentToken = ag.token
     const auto = await (
       await app.request(
@@ -249,7 +334,7 @@ describe("model credentials: run-keyed initiator resolution", () => {
     await connect(owner.email, {
       provider: "claude-code",
       kind: "api_key",
-      token: "sk-registrant-plan",
+      token: "sk-owner-plan",
     })
     await connect(clicker.email, {
       provider: "claude-code",
@@ -258,7 +343,7 @@ describe("model credentials: run-keyed initiator resolution", () => {
     })
   })
 
-  it("a run-keyed fetch bills the CLICKER (initiated_by), not the registrant", async () => {
+  it("a run-keyed fetch bills the CLICKER (initiated_by), not the owner", async () => {
     const got = await (
       await app.request(`/v1/agent/model-credential?provider=claude-code&run=${runId}`, {
         headers: bearer(agentToken),
@@ -268,7 +353,7 @@ describe("model credentials: run-keyed initiator resolution", () => {
     expect(got.source).toBe("initiator")
   })
 
-  it("an initiator with no plan falls back to the registrant", async () => {
+  it("an initiator with no plan is null by default (agent not lent, no pool)", async () => {
     await app.request("/v1/me/model-credentials/claude-code", {
       method: "DELETE",
       headers: as(clicker.email),
@@ -278,8 +363,22 @@ describe("model credentials: run-keyed initiator resolution", () => {
         headers: bearer(agentToken),
       })
     ).json()
-    expect(got.credential).toEqual({ kind: "api_key", value: "sk-registrant-plan" })
-    expect(got.source).toBe("registrant")
+    expect(got.credential).toBeNull()
+  })
+
+  it("an initiator with no plan uses the OWNER's plan once the agent is lent", async () => {
+    await app.request(`/v1/workspace/owner-lend/${agentId}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", ...as(owner.email) },
+      body: JSON.stringify({ enabled: true }),
+    })
+    const got = await (
+      await app.request(`/v1/agent/model-credential?provider=claude-code&run=${runId}`, {
+        headers: bearer(agentToken),
+      })
+    ).json()
+    expect(got.credential).toEqual({ kind: "api_key", value: "sk-owner-plan" })
+    expect(got.source).toBe("owner")
   })
 
   it("ISOLATION: another agent's run id is a 404, not a bill", async () => {
@@ -292,7 +391,7 @@ describe("model credentials: run-keyed initiator resolution", () => {
     expect(res.status).toBe(404)
   })
 
-  it("an unknown run id is a 404, never a silent registrant fallback", async () => {
+  it("an unknown run id is a 404, never a silent owner fallback", async () => {
     const res = await app.request("/v1/agent/model-credential?provider=claude-code&run=run_nope", {
       headers: bearer(agentToken),
     })

--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -29,23 +29,28 @@ pointers.
 
 **Providers.** The runner is agent-CLI-agnostic (`RUNNER_PROVIDER` / `--provider`,
 default `claude-code`; add one in `packages/cli/src/providers/`). Each provider's
-own CLI owns its auth from the inherited env — no token is ever reimplemented:
+own CLI owns its auth, but the runner supplies the token per run: it fetches the
+run's per-user plan from Derive and injects it into that one spawn as the env var
+the CLI reads. Any inherited model token is stripped first, and there is no
+shared/ambient fallback, so a stray global token on the host is never billed.
 
-| Provider | Binary | Credential (either) |
+| Provider | Binary | Env the CLI reads |
 | --- | --- | --- |
 | `claude-code` | `claude` | `ANTHROPIC_API_KEY`, or `CLAUDE_CODE_OAUTH_TOKEN` (a Pro/Max plan) |
 | `codex` (experimental) | `codex` | `OPENAI_API_KEY`, or a `codex login` (ChatGPT plan) |
 
 A subscription/plan token works because the runner drives the provider's real
-CLI, which consumes the token exactly as licensed — the sanctioned path, not a
-reimplemented client.
+CLI, which consumes the token exactly as licensed. Each member connects their own
+plan in Derive (Settings, Model plans); the runner resolves whose plan pays for
+each run (the initiator's, then a lent owner's, then a workspace pool, else the
+run fails closed) and no token is ever reimplemented.
 
 ## Two lanes
 
 The dispatcher runs both halves of the executor split:
 
 - **Owner-run drain lane** (pg-boss cron → `derive runner once`): serves contexts
-  whose agent runs on the run's initiator's credential (the asker's for a session, the clicker's for Run now), falling back to the owner's. Always on.
+  whose agent runs on the run's initiator's credential (the asker's for a session, the clicker's for Run now), then a lent owner's, then a workspace pool, else the run fails closed. Always on.
 - **Shared hosted lane** (`POST /internal/invoke`, behind `DISPATCHER_HOST_SECRET`):
   runs a Derive-hosted agent (the `@derive/hosted-agent` Mastra harness) live for a
   single task. The API calls it for "Draft with your agent" and @mention replies.
@@ -72,10 +77,11 @@ because every drain empties the whole session queue.
 ## Run it
 
 ```bash
-# Local (needs a Postgres and the CLI on PATH):
+# Local (needs a Postgres and the CLI on PATH). Model auth is NOT set here: each
+# member connects their own plan in Derive, and the runner injects it per run.
 DATABASE_URL=postgres://localhost/dispatcher \
 DISPATCHER_CONTEXTS='[{"id":"ctx_x","token_env":"CTX_X_TOKEN"}]' \
-CTX_X_TOKEN=dk_agt_... ANTHROPIC_API_KEY=sk-... \
+CTX_X_TOKEN=dk_agt_... \
 pnpm --filter @derive/dispatcher start
 
 # Containers: see deploy/dispatcher.compose.example.yml

--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -43,7 +43,23 @@ A subscription/plan token works because the runner drives the provider's real
 CLI, which consumes the token exactly as licensed. Each member connects their own
 plan in Derive (Settings, Model plans); the runner resolves whose plan pays for
 each run (the initiator's, then a lent owner's, then a workspace pool, else the
-run fails closed) and no token is ever reimplemented.
+run fails closed) and no token is ever reimplemented. The resolved credential is
+injected into a private per-run home (Codex: a fresh `CODEX_HOME` holding the
+login `auth.json`, 0600, removed after the run), and the runner strips every
+inherited model-auth var before the spawn, so nothing bills a stray host token.
+
+**Isolation invariant (deploy):** the runner image must carry NO host login
+(`~/.codex/auth.json`, `~/.claude/.credentials.json`) and NO baked model token or
+`*_BASE_URL`. The env strip is defense in depth; the clean image is the primary
+control, since a host login FILE can still be read via `$HOME` if present.
+
+**Codex plan-login concurrency limit:** a Codex `login` refresh token is
+single-use, and the CLI rotates it in place. The runner persists the rotated
+`auth.json` back after each run (bound to the exact tier + a compare-and-swap, so
+a stale write can't clobber a fresher token). SEQUENTIAL runs on one login are
+safe; two runs on the SAME shared login (a pool or owner-lent Codex plan) at once
+can race the rotation and one will need a reconnect. An API key has no such limit.
+Serializing concurrent use of one login is a planned hardening.
 
 ## Two lanes
 

--- a/apps/dispatcher/src/drain.ts
+++ b/apps/dispatcher/src/drain.ts
@@ -45,8 +45,10 @@ export function runDrain(
     const child = spawnImpl(cfg.runnerBin, drainArgs(cfg, ctx), {
       cwd,
       // The runner reads its contract from env; the dispatcher supplies only the
-      // per-context token. Model credentials (ANTHROPIC_API_KEY / OAuth token)
-      // and RUNNER_* knobs pass through from the dispatcher's own env untouched.
+      // per-context token (RUNNER_* knobs pass through). Model credentials are NOT taken
+      // from this env: the runner fetches the run's per-user plan from Derive and strips any
+      // inherited model token before the spawn, so a global ANTHROPIC_API_KEY / OAuth token
+      // set here would simply be ignored.
       env: { ...process.env, DERIVE_TOKEN: token, DERIVE_CONTEXT: ctx.id },
       stdio: ["ignore", "pipe", "pipe"],
     })

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -5789,6 +5789,10 @@ export interface components {
             hosted: boolean;
             /** @description Auto-minted for one context at creation — the context's Derive access, not a user-named persona. Hidden from the roster UI. */
             managed: boolean;
+            /** @description The user who registered the agent — who it publishes and bills on behalf of. */
+            created_by: string | null;
+            /** @description When true, this agent may bill its OWNER's own model plan as a fallback (initiator -> owner -> pool). Only the owner toggles it; default off. */
+            owner_lend: boolean;
             created_at: string;
         };
         ConnectedAgent: {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -788,6 +788,25 @@ export const api = {
       () => undefined,
     ),
 
+  // The workspace's SHARED model-plan pool (admin only) — the fallback billed when a run's
+  // initiator has no plan and the agent isn't owner-lent. Same hints-only discipline.
+  listPoolCredentials: (): Promise<{ credentials: ModelCredentialHint[] }> =>
+    f("/v1/workspace/model-credentials", opts()).then(j),
+  connectPoolCredential: (input: {
+    provider: "claude-code" | "codex"
+    kind: "oauth" | "api_key"
+    token: string
+  }): Promise<{ ok: true; provider: string; hint: string }> =>
+    f("/v1/workspace/model-credentials", opts(input)).then(j),
+  disconnectPoolCredential: (provider: string): Promise<void> =>
+    f(`/v1/workspace/model-credentials/${provider}`, {
+      method: "DELETE",
+      credentials: "include",
+    }).then(() => undefined),
+  // Toggle whether an agent may fall back to its OWNER's plan (only the owner may set it).
+  setAgentOwnerLend: (agentId: string, enabled: boolean): Promise<{ ok: true }> =>
+    f(`/v1/workspace/owner-lend/${agentId}`, { ...opts({ enabled }), method: "PUT" }).then(j),
+
   // Contexts + sessions (the ask loop; see routes/contexts.ts server-side).
   listContexts: (): Promise<{ contexts: ContextInfo[] }> => f("/v1/contexts", opts()).then(j),
   getContext: (id: string): Promise<ContextInfo> => f(`/v1/contexts/${id}`, opts()).then(j),

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -169,7 +169,7 @@ export interface AutomationTrigger {
 /** A connected model-plan credential, as the settings UI sees it — never the secret. */
 export interface ModelCredentialHint {
   provider: "claude-code" | "codex"
-  kind: "oauth" | "api_key"
+  kind: "oauth" | "api_key" | "login"
   hint: string
   updated_at: string
 }
@@ -779,7 +779,7 @@ export const api = {
     f("/v1/me/model-credentials", opts()).then(j),
   connectModelCredential: (input: {
     provider: "claude-code" | "codex"
-    kind: "oauth" | "api_key"
+    kind: "oauth" | "api_key" | "login"
     token: string
   }): Promise<{ ok: true; provider: string; hint: string }> =>
     f("/v1/me/model-credentials", opts(input)).then(j),
@@ -794,7 +794,7 @@ export const api = {
     f("/v1/workspace/model-credentials", opts()).then(j),
   connectPoolCredential: (input: {
     provider: "claude-code" | "codex"
-    kind: "oauth" | "api_key"
+    kind: "oauth" | "api_key" | "login"
     token: string
   }): Promise<{ ok: true; provider: string; hint: string }> =>
     f("/v1/workspace/model-credentials", opts(input)).then(j),

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -370,6 +370,13 @@ export const modelCredentialsQuery = () =>
     queryFn: () => api.listModelCredentials().then((r) => r.credentials),
   })
 
+// The workspace's shared model-plan pool (hints only, admin surface).
+export const poolCredentialsQuery = () =>
+  queryOptions({
+    queryKey: ["pool-model-credentials"] as const,
+    queryFn: () => api.listPoolCredentials().then((r) => r.credentials),
+  })
+
 export const runsQuery = () =>
   queryOptions({
     queryKey: ["runs"] as const,

--- a/apps/web/src/pages/settings/agents-section.tsx
+++ b/apps/web/src/pages/settings/agents-section.tsx
@@ -18,12 +18,14 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { toast } from "@/components/ui/sonner"
+import { Switch } from "@/components/ui/switch"
 import { agentsQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { ModelPlanManager } from "./model-plan-manager"
 import { SettingsListSkeleton } from "./settings-list-skeleton"
 import { SettingsSection } from "./settings-section"
 
-export function AgentsSection() {
+export function AgentsSection({ meId }: { meId: string }) {
   const qc = useQueryClient()
   const { data: agents, isPending, isError, refetch } = useQuery(agentsQuery())
   const reload = () => qc.invalidateQueries({ queryKey: agentsQuery().queryKey })
@@ -67,10 +69,24 @@ export function AgentsSection() {
           {agents
             .filter((a) => !a.managed)
             .map((a) => (
-              <AgentRow key={a.id} agent={a} onDone={reload} />
+              <AgentRow key={a.id} agent={a} meId={meId} onDone={reload} />
             ))}
         </SettingsGroup>
       )}
+
+      {/* How agent runs get billed. A run bills the person who triggered it; if they have
+          no connected plan, it falls to the agent OWNER's plan (only for agents the owner
+          lent, above) and then to this shared pool. Empty pool = everyone brings their own. */}
+      <div className="mt-6 flex flex-col gap-3 border-t pt-6">
+        <div>
+          <div className="text-sm font-medium text-foreground">Workspace model plan pool</div>
+          <p className="mt-0.5 text-2xs text-muted-foreground">
+            A shared plan billed when a run's initiator has no plan of their own and the agent isn't
+            lent its owner's. Optional — leave it empty to require everyone to bring their own.
+          </p>
+        </div>
+        <ModelPlanManager scope="pool" />
+      </div>
     </SettingsSection>
   )
 }
@@ -168,7 +184,7 @@ function NewAgent({ onCreated }: { onCreated: () => void }) {
   )
 }
 
-function AgentRow({ agent, onDone }: { agent: Agent; onDone: () => void }) {
+function AgentRow({ agent, meId, onDone }: { agent: Agent; meId: string; onDone: () => void }) {
   const [confirming, setConfirming] = useState(false)
   const [rotated, setRotated] = useState<string | null>(null)
   const remove = useApiMutation({
@@ -182,6 +198,14 @@ function AgentRow({ agent, onDone }: { agent: Agent; onDone: () => void }) {
     mutationFn: () => api.rotateAgent(agent.id),
     success: `Token rotated for ${agent.name}`,
     onSuccess: (a) => setRotated(a.token),
+  })
+  // Only the agent's OWNER may lend their own plan to it (default off). Others don't see it.
+  const isOwner = agent.created_by === meId
+  const lend = useApiMutation<{ ok: true }, boolean>({
+    mutationFn: (enabled) => api.setAgentOwnerLend(agent.id, enabled),
+    success: (_r, enabled) =>
+      enabled ? `@${agent.name} may run on your plan` : `@${agent.name} won't use your plan`,
+    onSuccess: () => onDone(),
   })
   return (
     <div data-testid={`agent-row-${agent.id}`} className="flex flex-col py-3">
@@ -227,6 +251,21 @@ function AgentRow({ agent, onDone }: { agent: Agent; onDone: () => void }) {
           onConfirm={() => remove.mutate()}
         />
       </div>
+      {isOwner && (
+        <label
+          htmlFor={`agent-lend-${agent.id}`}
+          className="mt-2 flex items-center gap-2 pl-10 text-2xs text-muted-foreground"
+        >
+          <Switch
+            id={`agent-lend-${agent.id}`}
+            data-testid={`agent-lend-${agent.id}`}
+            checked={agent.owner_lend}
+            onCheckedChange={(v) => lend.mutate(v)}
+            disabled={lend.isPending}
+          />
+          Run on my plan when a request has no plan of its own
+        </label>
+      )}
       {rotated && (
         <div data-testid={`agent-rotated-${agent.id}`} className="mt-2">
           <StatusPanel

--- a/apps/web/src/pages/settings/agents-section.tsx
+++ b/apps/web/src/pages/settings/agents-section.tsx
@@ -83,18 +83,33 @@ export function AgentsSection({ meId }: { meId: string }) {
         </SettingsGroup>
       )}
 
-      {/* How agent runs get billed. A run bills the person who triggered it; if they have
-          no connected plan, it falls to the agent OWNER's plan (only for agents the owner
-          lent, above) and then to this shared pool. Empty pool = everyone brings their own. */}
-      <div className="mt-6 flex flex-col gap-3 border-t pt-6">
-        <div>
-          <div className="text-sm font-medium text-foreground">Workspace model plan pool</div>
-          <p className="mt-0.5 text-2xs text-muted-foreground">
-            A shared plan billed when a run's initiator has no plan of their own and the agent isn't
-            lent its owner's. Optional — leave it empty to require everyone to bring their own.
-          </p>
+      {/* How agent runs get billed, in order: the person who triggered the run (their own
+          plan, below), then the agent OWNER's plan (only for agents lent above), then the
+          shared workspace pool. Both plan surfaces live here so it's one place to reason
+          about; your own plan also lives under Account → Model plans. */}
+      <div className="mt-6 flex flex-col gap-5 border-t pt-6">
+        <div className="flex flex-col gap-3">
+          <div>
+            <div className="text-sm font-medium text-foreground">Your plan</div>
+            <p className="mt-0.5 text-2xs text-muted-foreground">
+              Runs you start bill your own connected plan first. Same plan as Account → Model plans;
+              connect it here or there.
+            </p>
+          </div>
+          <ModelPlanManager scope="personal" />
         </div>
-        <ModelPlanManager scope="pool" />
+
+        <div className="flex flex-col gap-3">
+          <div>
+            <div className="text-sm font-medium text-foreground">Workspace model plan pool</div>
+            <p className="mt-0.5 text-2xs text-muted-foreground">
+              A shared plan billed when a run's initiator has no plan of their own and the agent
+              isn't lent its owner's. Optional — leave it empty to require everyone to bring their
+              own.
+            </p>
+          </div>
+          <ModelPlanManager scope="pool" />
+        </div>
       </div>
     </SettingsSection>
   )

--- a/apps/web/src/pages/settings/agents-section.tsx
+++ b/apps/web/src/pages/settings/agents-section.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/components/ui/select"
 import { toast } from "@/components/ui/sonner"
 import { Switch } from "@/components/ui/switch"
-import { agentsQuery } from "@/lib/queries"
+import { agentsQuery, modelCredentialsQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { ModelPlanManager } from "./model-plan-manager"
 import { SettingsListSkeleton } from "./settings-list-skeleton"
@@ -29,6 +29,9 @@ export function AgentsSection({ meId }: { meId: string }) {
   const qc = useQueryClient()
   const { data: agents, isPending, isError, refetch } = useQuery(agentsQuery())
   const reload = () => qc.invalidateQueries({ queryKey: agentsQuery().queryKey })
+  // The per-agent lend toggle is inert until YOU have a plan connected, so gate it on that.
+  const { data: myPlans } = useQuery(modelCredentialsQuery())
+  const hasPersonalPlan = (myPlans?.length ?? 0) > 0
 
   return (
     <SettingsSection
@@ -69,7 +72,13 @@ export function AgentsSection({ meId }: { meId: string }) {
           {agents
             .filter((a) => !a.managed)
             .map((a) => (
-              <AgentRow key={a.id} agent={a} meId={meId} onDone={reload} />
+              <AgentRow
+                key={a.id}
+                agent={a}
+                meId={meId}
+                hasPersonalPlan={hasPersonalPlan}
+                onDone={reload}
+              />
             ))}
         </SettingsGroup>
       )}
@@ -184,7 +193,17 @@ function NewAgent({ onCreated }: { onCreated: () => void }) {
   )
 }
 
-function AgentRow({ agent, meId, onDone }: { agent: Agent; meId: string; onDone: () => void }) {
+function AgentRow({
+  agent,
+  meId,
+  hasPersonalPlan,
+  onDone,
+}: {
+  agent: Agent
+  meId: string
+  hasPersonalPlan: boolean
+  onDone: () => void
+}) {
   const [confirming, setConfirming] = useState(false)
   const [rotated, setRotated] = useState<string | null>(null)
   const remove = useApiMutation({
@@ -261,9 +280,11 @@ function AgentRow({ agent, meId, onDone }: { agent: Agent; meId: string; onDone:
             data-testid={`agent-lend-${agent.id}`}
             checked={agent.owner_lend}
             onCheckedChange={(v) => lend.mutate(v)}
-            disabled={lend.isPending}
+            disabled={lend.isPending || !hasPersonalPlan}
           />
-          Run on my plan when a request has no plan of its own
+          {hasPersonalPlan
+            ? "Fall back to my plan when a run has none of its own"
+            : "Connect your plan under Account → Model plans to lend it here"}
         </label>
       )}
       {rotated && (

--- a/apps/web/src/pages/settings/index.tsx
+++ b/apps/web/src/pages/settings/index.tsx
@@ -145,7 +145,7 @@ export function Settings() {
             {active === "integrations" && <IntegrationsSection />}
             {active === "github" && <GithubSection />}
             {active === "webhooks" && <WebhooksSection />}
-            {active === "agents" && <AgentsSection />}
+            {active === "agents" && <AgentsSection meId={me.id} />}
             {active === "automations" && <AutomationsSection />}
             {active === "domains" && <CustomDomainsSection />}
             {active === "reports" && (

--- a/apps/web/src/pages/settings/model-plan-manager.tsx
+++ b/apps/web/src/pages/settings/model-plan-manager.tsx
@@ -15,26 +15,51 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
 import { modelCredentialsQuery, poolCredentialsQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { SettingsListSkeleton } from "./settings-list-skeleton"
 
 type Provider = "claude-code" | "codex"
+type Kind = "oauth" | "api_key" | "login"
 type Scope = "personal" | "pool"
 
-const PROVIDERS: { id: Provider; label: string; how: string }[] = [
+type KindSpec = { id: Kind; label: string; how: string; multiline?: boolean }
+type ProviderCfg = { id: Provider; label: string; kinds: [KindSpec, ...KindSpec[]] }
+// Each provider offers its own credential kinds. A PLAN (subscription) is the headline for
+// both: Claude via a setup-token (env var), Codex via a login file. API keys are the fallback.
+// Non-empty tuples so the [0] defaults below are always defined.
+const PROVIDERS: [ProviderCfg, ...ProviderCfg[]] = [
   {
     id: "claude-code",
     label: "Claude",
-    how: "Run `claude setup-token` on any machine (it opens a browser) and paste the token it prints.",
+    kinds: [
+      {
+        id: "oauth",
+        label: "Plan (subscription)",
+        how: "Run `claude setup-token` on any machine (it opens a browser) and paste the token it prints.",
+      },
+      { id: "api_key", label: "API key", how: "Paste an Anthropic API key (sk-ant-…)." },
+    ],
   },
   {
     id: "codex",
     label: "Codex",
-    how: "Paste an OpenAI API key. (A ChatGPT-plan login is coming; API keys work today.)",
+    kinds: [
+      {
+        id: "login",
+        label: "Plan (subscription)",
+        multiline: true,
+        how: "Run `codex login` on any machine, then paste the contents of ~/.codex/auth.json here.",
+      },
+      { id: "api_key", label: "API key", how: "Paste an OpenAI API key (sk-…)." },
+    ],
   },
 ]
 const providerLabel = (id: string) => PROVIDERS.find((p) => p.id === id)?.label ?? id
+const kindLabel = (provider: string, kind: string) =>
+  PROVIDERS.find((p) => p.id === provider)?.kinds.find((k) => k.id === kind)?.label ??
+  (kind === "api_key" ? "API key" : "Plan")
 
 // The connect form + connected list for a set of model-plan credentials, shared between the
 // PERSONAL surface (/v1/me — your own plan) and the workspace POOL (/v1/workspace — the
@@ -109,18 +134,23 @@ function ConnectForm({
   prefix,
   onConnected,
 }: {
-  connect: (input: {
-    provider: Provider
-    kind: "oauth" | "api_key"
-    token: string
-  }) => Promise<unknown>
+  connect: (input: { provider: Provider; kind: Kind; token: string }) => Promise<unknown>
   prefix: string
   onConnected: () => void
 }) {
   const [provider, setProvider] = useState<Provider>("claude-code")
-  const [kind, setKind] = useState<"oauth" | "api_key">("oauth")
+  const providerCfg = PROVIDERS.find((p) => p.id === provider) ?? PROVIDERS[0]
+  const [kind, setKind] = useState<Kind>(providerCfg.kinds[0].id)
   const [token, setToken] = useState("")
-  const how = PROVIDERS.find((p) => p.id === provider)?.how ?? ""
+  const kindCfg = providerCfg.kinds.find((k) => k.id === kind) ?? providerCfg.kinds[0]
+
+  // Switching provider resets the kind to that provider's first (its plan) and clears input,
+  // so you never submit a Codex login under the Claude provider.
+  const pickProvider = (v: Provider) => {
+    setProvider(v)
+    setKind((PROVIDERS.find((p) => p.id === v) ?? PROVIDERS[0]).kinds[0].id)
+    setToken("")
+  }
 
   const connect = useApiMutation({
     mutationFn: () => connectFn({ provider, kind, token: token.trim() }),
@@ -135,7 +165,7 @@ function ConnectForm({
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-wrap gap-2">
-        <Select value={provider} onValueChange={(v) => setProvider(v as Provider)}>
+        <Select value={provider} onValueChange={(v) => pickProvider(v as Provider)}>
           <SelectTrigger data-testid={`${prefix}-provider`} aria-label="Provider" className="w-40">
             <SelectValue />
           </SelectTrigger>
@@ -147,7 +177,13 @@ function ConnectForm({
             ))}
           </SelectContent>
         </Select>
-        <Select value={kind} onValueChange={(v) => setKind(v as "oauth" | "api_key")}>
+        <Select
+          value={kind}
+          onValueChange={(v) => {
+            setKind(v as Kind)
+            setToken("")
+          }}
+        >
           <SelectTrigger
             data-testid={`${prefix}-kind`}
             aria-label="Credential type"
@@ -156,21 +192,36 @@ function ConnectForm({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="oauth">Plan token</SelectItem>
-            <SelectItem value="api_key">API key</SelectItem>
+            {providerCfg.kinds.map((k) => (
+              <SelectItem key={k.id} value={k.id}>
+                {k.label}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </div>
-      <Input
-        data-testid={`${prefix}-token`}
-        type="password"
-        aria-label="Plan token or API key"
-        placeholder="Paste your token"
-        value={token}
-        onChange={(e) => setToken(e.target.value)}
-        onKeyDown={(e) => e.key === "Enter" && ready && connect.mutate()}
-      />
-      <p className="text-2xs text-muted-foreground">{how}</p>
+      {kindCfg.multiline ? (
+        <Textarea
+          data-testid={`${prefix}-token`}
+          aria-label="Plan login (auth.json)"
+          placeholder="Paste the contents of ~/.codex/auth.json"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          rows={4}
+          className="font-mono text-2xs"
+        />
+      ) : (
+        <Input
+          data-testid={`${prefix}-token`}
+          type="password"
+          aria-label="Plan token or API key"
+          placeholder="Paste your token"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && ready && connect.mutate()}
+        />
+      )}
+      <p className="text-2xs text-muted-foreground">{kindCfg.how}</p>
       <div className="flex justify-end">
         <Button
           data-testid={`${prefix}-connect`}
@@ -212,7 +263,7 @@ function CredentialRow({
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5 font-medium text-foreground">
           {providerLabel(cred.provider)}
-          <Badge variant="outline">{cred.kind === "oauth" ? "Plan token" : "API key"}</Badge>
+          <Badge variant="outline">{kindLabel(cred.provider, cred.kind)}</Badge>
         </div>
         <div className="font-mono text-2xs text-muted-foreground">connected · ••••{cred.hint}</div>
       </div>

--- a/apps/web/src/pages/settings/model-plan-manager.tsx
+++ b/apps/web/src/pages/settings/model-plan-manager.tsx
@@ -1,0 +1,237 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useState } from "react"
+import { api, type ModelCredentialHint } from "@/api"
+import { ConfirmDialog } from "@/components/shared/confirm-dialog"
+import { EmptyState } from "@/components/shared/empty-state"
+import { SettingsGroup } from "@/components/shared/settings-group"
+import { StatusPanel } from "@/components/shared/status-panel"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { modelCredentialsQuery, poolCredentialsQuery } from "@/lib/queries"
+import { useApiMutation } from "@/lib/use-api-mutation"
+import { SettingsListSkeleton } from "./settings-list-skeleton"
+
+type Provider = "claude-code" | "codex"
+type Scope = "personal" | "pool"
+
+const PROVIDERS: { id: Provider; label: string; how: string }[] = [
+  {
+    id: "claude-code",
+    label: "Claude",
+    how: "Run `claude setup-token` on any machine (it opens a browser) and paste the token it prints.",
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    how: "Paste an OpenAI API key. (A ChatGPT-plan login is coming; API keys work today.)",
+  },
+]
+const providerLabel = (id: string) => PROVIDERS.find((p) => p.id === id)?.label ?? id
+
+// The connect form + connected list for a set of model-plan credentials, shared between the
+// PERSONAL surface (/v1/me — your own plan) and the workspace POOL (/v1/workspace — the
+// shared fallback). `scope` picks the wiring; the markup is identical, so it lives once. The
+// caller supplies its own SettingsSection / heading around this.
+export function ModelPlanManager({ scope }: { scope: Scope }) {
+  const qc = useQueryClient()
+  const query = scope === "pool" ? poolCredentialsQuery() : modelCredentialsQuery()
+  // Both factories return ModelCredentialHint[]; they differ only in their literal queryKey,
+  // which unions poorly across useQuery's overloads. The cast unifies the shape — the runtime
+  // queryKey (and thus the cache entry) is still the scope's own.
+  const {
+    data: creds,
+    isPending,
+    isError,
+    refetch,
+  } = useQuery(query as ReturnType<typeof modelCredentialsQuery>)
+  const reload = () => qc.invalidateQueries({ queryKey: query.queryKey })
+  const connect = scope === "pool" ? api.connectPoolCredential : api.connectModelCredential
+  const disconnect = scope === "pool" ? api.disconnectPoolCredential : api.disconnectModelCredential
+  const prefix = scope === "pool" ? "pool-model-plan" : "model-plan"
+  const empty =
+    scope === "pool"
+      ? "No shared plan connected. Connect one above to give the workspace a fallback."
+      : "No plan connected yet. Connect one above to run on your own plan."
+
+  return (
+    <>
+      <div className="rounded-lg border bg-card p-4">
+        <ConnectForm connect={connect} prefix={prefix} onConnected={reload} />
+      </div>
+
+      {isPending ? (
+        <SettingsListSkeleton />
+      ) : isError ? (
+        <StatusPanel
+          tone="danger"
+          title="Couldn't load plans"
+          description="This is usually temporary."
+          action={
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid={`${prefix}-retry`}
+              onClick={() => refetch()}
+            >
+              Try again
+            </Button>
+          }
+        />
+      ) : !creds || creds.length === 0 ? (
+        <EmptyState>{empty}</EmptyState>
+      ) : (
+        <SettingsGroup>
+          {creds.map((c) => (
+            <CredentialRow
+              key={c.provider}
+              cred={c}
+              disconnect={disconnect}
+              prefix={prefix}
+              onDone={reload}
+            />
+          ))}
+        </SettingsGroup>
+      )}
+    </>
+  )
+}
+
+function ConnectForm({
+  connect: connectFn,
+  prefix,
+  onConnected,
+}: {
+  connect: (input: {
+    provider: Provider
+    kind: "oauth" | "api_key"
+    token: string
+  }) => Promise<unknown>
+  prefix: string
+  onConnected: () => void
+}) {
+  const [provider, setProvider] = useState<Provider>("claude-code")
+  const [kind, setKind] = useState<"oauth" | "api_key">("oauth")
+  const [token, setToken] = useState("")
+  const how = PROVIDERS.find((p) => p.id === provider)?.how ?? ""
+
+  const connect = useApiMutation({
+    mutationFn: () => connectFn({ provider, kind, token: token.trim() }),
+    success: "Plan connected",
+    onSuccess: () => {
+      setToken("")
+      onConnected()
+    },
+  })
+  const ready = token.trim() !== ""
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap gap-2">
+        <Select value={provider} onValueChange={(v) => setProvider(v as Provider)}>
+          <SelectTrigger data-testid={`${prefix}-provider`} aria-label="Provider" className="w-40">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {PROVIDERS.map((p) => (
+              <SelectItem key={p.id} value={p.id}>
+                {p.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={kind} onValueChange={(v) => setKind(v as "oauth" | "api_key")}>
+          <SelectTrigger
+            data-testid={`${prefix}-kind`}
+            aria-label="Credential type"
+            className="w-44"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="oauth">Plan token</SelectItem>
+            <SelectItem value="api_key">API key</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <Input
+        data-testid={`${prefix}-token`}
+        type="password"
+        aria-label="Plan token or API key"
+        placeholder="Paste your token"
+        value={token}
+        onChange={(e) => setToken(e.target.value)}
+        onKeyDown={(e) => e.key === "Enter" && ready && connect.mutate()}
+      />
+      <p className="text-2xs text-muted-foreground">{how}</p>
+      <div className="flex justify-end">
+        <Button
+          data-testid={`${prefix}-connect`}
+          variant="secondary"
+          size="sm"
+          onClick={() => ready && connect.mutate()}
+          loading={connect.isPending}
+          disabled={connect.isPending || !ready}
+        >
+          {connect.isPending ? "Connecting…" : "Connect"}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function CredentialRow({
+  cred,
+  disconnect: disconnectFn,
+  prefix,
+  onDone,
+}: {
+  cred: ModelCredentialHint
+  disconnect: (provider: string) => Promise<void>
+  prefix: string
+  onDone: () => void
+}) {
+  const [confirming, setConfirming] = useState(false)
+  const remove = useApiMutation({
+    mutationFn: () => disconnectFn(cred.provider),
+    success: "Plan disconnected",
+    onSuccess: () => onDone(),
+  })
+  return (
+    <div
+      data-testid={`${prefix}-row-${cred.provider}`}
+      className="flex items-center gap-3 py-3 text-sm"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5 font-medium text-foreground">
+          {providerLabel(cred.provider)}
+          <Badge variant="outline">{cred.kind === "oauth" ? "Plan token" : "API key"}</Badge>
+        </div>
+        <div className="font-mono text-2xs text-muted-foreground">connected · ••••{cred.hint}</div>
+      </div>
+      <Button
+        data-testid={`${prefix}-disconnect-${cred.provider}`}
+        variant="destructive-ghost"
+        size="sm"
+        onClick={() => setConfirming(true)}
+      >
+        Disconnect
+      </Button>
+      <ConfirmDialog
+        open={confirming}
+        onOpenChange={setConfirming}
+        title="Disconnect this plan?"
+        description="Runs that relied on it will stop until it is reconnected."
+        confirmLabel="Disconnect"
+        onConfirm={() => remove.mutate()}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/pages/settings/model-plans-section.tsx
+++ b/apps/web/src/pages/settings/model-plans-section.tsx
@@ -1,200 +1,22 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { useState } from "react"
-import { api, type ModelCredentialHint } from "@/api"
-import { ConfirmDialog } from "@/components/shared/confirm-dialog"
-import { EmptyState } from "@/components/shared/empty-state"
-import { SettingsGroup } from "@/components/shared/settings-group"
-import { StatusPanel } from "@/components/shared/status-panel"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import { modelCredentialsQuery } from "@/lib/queries"
-import { useApiMutation } from "@/lib/use-api-mutation"
-import { SettingsListSkeleton } from "./settings-list-skeleton"
+import { ModelPlanManager } from "./model-plan-manager"
 import { SettingsSection } from "./settings-section"
 
-type Provider = "claude-code" | "codex"
-
-const PROVIDERS: { id: Provider; label: string; how: string }[] = [
-  {
-    id: "claude-code",
-    label: "Claude",
-    how: "Run `claude setup-token` on any machine (it opens a browser) and paste the token it prints.",
-  },
-  {
-    id: "codex",
-    label: "Codex",
-    how: "Paste an OpenAI API key. (A ChatGPT-plan login is coming; API keys work today.)",
-  },
-]
-const providerLabel = (id: string) => PROVIDERS.find((p) => p.id === id)?.label ?? id
-
 // Personal "Model plans": connect your OWN Claude/Codex plan (or API key). It is encrypted
-// and used ONLY for your own agent runs — never shared. This is what lets your work run on
-// hosted Derive without a machine of your own.
+// and used ONLY for runs YOU initiate — never shared. This is what lets your work run on
+// hosted Derive without a machine of your own. (The workspace-shared pool and per-agent
+// owner-lend live in the Agents section.)
 export function ModelPlansSection() {
-  const qc = useQueryClient()
-  const { data: creds, isPending, isError, refetch } = useQuery(modelCredentialsQuery())
-  const reload = () => qc.invalidateQueries({ queryKey: modelCredentialsQuery().queryKey })
-
   return (
     <SettingsSection
       title="Model plans"
       description={
         <>
           Connect your own model plan so your agents run on it. Your token is encrypted and used
-          only for your own runs, never shared with anyone else on the team.
+          only for runs you start, never shared with anyone else on the team.
         </>
       }
     >
-      <div className="rounded-lg border bg-card p-4">
-        <ConnectForm onConnected={reload} />
-      </div>
-
-      {isPending ? (
-        <SettingsListSkeleton />
-      ) : isError ? (
-        <StatusPanel
-          tone="danger"
-          title="Couldn't load your plans"
-          description="This is usually temporary."
-          action={
-            <Button
-              variant="outline"
-              size="sm"
-              data-testid="model-plans-retry"
-              onClick={() => refetch()}
-            >
-              Try again
-            </Button>
-          }
-        />
-      ) : !creds || creds.length === 0 ? (
-        <EmptyState>No plan connected yet. Connect one above to run on your own plan.</EmptyState>
-      ) : (
-        <SettingsGroup>
-          {creds.map((c) => (
-            <CredentialRow key={c.provider} cred={c} onDone={reload} />
-          ))}
-        </SettingsGroup>
-      )}
+      <ModelPlanManager scope="personal" />
     </SettingsSection>
-  )
-}
-
-function ConnectForm({ onConnected }: { onConnected: () => void }) {
-  const [provider, setProvider] = useState<Provider>("claude-code")
-  const [kind, setKind] = useState<"oauth" | "api_key">("oauth")
-  const [token, setToken] = useState("")
-  const how = PROVIDERS.find((p) => p.id === provider)?.how ?? ""
-
-  const connect = useApiMutation({
-    mutationFn: () => api.connectModelCredential({ provider, kind, token: token.trim() }),
-    success: "Plan connected",
-    onSuccess: () => {
-      setToken("")
-      onConnected()
-    },
-  })
-  const ready = token.trim() !== ""
-
-  return (
-    <div className="flex flex-col gap-3">
-      <div className="flex flex-wrap gap-2">
-        <Select value={provider} onValueChange={(v) => setProvider(v as Provider)}>
-          <SelectTrigger data-testid="model-plan-provider" aria-label="Provider" className="w-40">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {PROVIDERS.map((p) => (
-              <SelectItem key={p.id} value={p.id}>
-                {p.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Select value={kind} onValueChange={(v) => setKind(v as "oauth" | "api_key")}>
-          <SelectTrigger
-            data-testid="model-plan-kind"
-            aria-label="Credential type"
-            className="w-44"
-          >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="oauth">Plan token</SelectItem>
-            <SelectItem value="api_key">API key</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      <Input
-        data-testid="model-plan-token"
-        type="password"
-        aria-label="Plan token or API key"
-        placeholder="Paste your token"
-        value={token}
-        onChange={(e) => setToken(e.target.value)}
-        onKeyDown={(e) => e.key === "Enter" && ready && connect.mutate()}
-      />
-      <p className="text-2xs text-muted-foreground">{how}</p>
-      <div className="flex justify-end">
-        <Button
-          data-testid="model-plan-connect"
-          variant="secondary"
-          size="sm"
-          onClick={() => ready && connect.mutate()}
-          loading={connect.isPending}
-          disabled={connect.isPending || !ready}
-        >
-          {connect.isPending ? "Connecting…" : "Connect"}
-        </Button>
-      </div>
-    </div>
-  )
-}
-
-function CredentialRow({ cred, onDone }: { cred: ModelCredentialHint; onDone: () => void }) {
-  const [confirming, setConfirming] = useState(false)
-  const remove = useApiMutation({
-    mutationFn: () => api.disconnectModelCredential(cred.provider),
-    success: "Plan disconnected",
-    onSuccess: () => onDone(),
-  })
-  return (
-    <div
-      data-testid={`model-plan-row-${cred.provider}`}
-      className="flex items-center gap-3 py-3 text-sm"
-    >
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-1.5 font-medium text-foreground">
-          {providerLabel(cred.provider)}
-          <Badge variant="outline">{cred.kind === "oauth" ? "Plan token" : "API key"}</Badge>
-        </div>
-        <div className="font-mono text-2xs text-muted-foreground">connected · ••••{cred.hint}</div>
-      </div>
-      <Button
-        data-testid={`model-plan-disconnect-${cred.provider}`}
-        variant="destructive-ghost"
-        size="sm"
-        onClick={() => setConfirming(true)}
-      >
-        Disconnect
-      </Button>
-      <ConfirmDialog
-        open={confirming}
-        onOpenChange={setConfirming}
-        title="Disconnect this plan?"
-        description="Your agents will stop running on it until you reconnect."
-        confirmLabel="Disconnect"
-        onConfirm={() => remove.mutate()}
-      />
-    </div>
   )
 }

--- a/packages/cli/src/providers/claude-code.js
+++ b/packages/cli/src/providers/claude-code.js
@@ -172,6 +172,12 @@ export const claudeCode = {
     return kind === "oauth" ? { CLAUDE_CODE_OAUTH_TOKEN: value } : { ANTHROPIC_API_KEY: value }
   },
 
+  /** Claude's plan token is env-delivered (see credentialEnv), so there is no file to
+   *  materialize. Present for shape parity with file-delivered providers (Codex login). */
+  credentialFiles() {
+    return null
+  },
+
   /** Version probe for `derive runner doctor`. Resolves the version string, or
    *  null when the binary is missing / not spawnable. */
   version(bin) {

--- a/packages/cli/src/providers/codex.js
+++ b/packages/cli/src/providers/codex.js
@@ -106,11 +106,18 @@ export const codex = {
   },
 
   /** Map an owner's credential to Codex's env. An API key rides OPENAI_API_KEY. A
-   *  ChatGPT-plan login is file-based (~/.codex/auth.json), not an env var, so it can't
-   *  be injected this way yet — returns null (the runner then fails closed with a clear
-   *  message); wiring per-run file auth is a follow-up. */
+   *  ChatGPT-plan login is file-based (see credentialFiles), so it returns null here. */
   credentialEnv(kind, value) {
     return kind === "api_key" ? { OPENAI_API_KEY: value } : null
+  },
+
+  /** A ChatGPT-plan login is delivered as a FILE: Codex reads `auth.json` from `$CODEX_HOME`
+   *  (default ~/.codex). The stored `login` credential IS that file's JSON, so the runner
+   *  writes it into a private per-run CODEX_HOME and points Codex at it. The official CLI then
+   *  authenticates on the subscription exactly as if you had run `codex login` there. Other
+   *  kinds are env-delivered (credentialEnv), so this returns null for them. */
+  credentialFiles(kind, value) {
+    return kind === "login" ? { homeEnv: "CODEX_HOME", files: { "auth.json": value } } : null
   },
 
   version(bin) {

--- a/packages/cli/src/runner.js
+++ b/packages/cli/src/runner.js
@@ -17,7 +17,9 @@ import {
   realpathSync,
   rmSync,
   statSync,
+  writeFileSync,
 } from "node:fs"
+import { tmpdir } from "node:os"
 import { dirname, join, resolve, sep } from "node:path"
 import { claudeCode } from "./providers/claude-code.js"
 import { DEFAULT_PROVIDER, PROVIDERS, selectProvider } from "./providers/index.js"
@@ -704,26 +706,35 @@ export async function serveSession(client, session, manifest, cfg, repoMeta = []
   // fail-closed resolve (nothing connected) fails THIS session like any other run failure;
   // thrown, it would leave the claim dangling and retry-loop.
   let modelEnv = null
+  let cleanupCred = noopCleanup
   if (!cfg.mock) {
     try {
-      modelEnv = await resolveModelEnv(cfg, client, session.id)
+      const resolved = await resolveModelEnv(cfg, client, session.id)
+      modelEnv = resolved.env
+      cleanupCred = resolved.cleanup
     } catch (err) {
       console.error(`[runner] session ${session.id} failed: ${err.message}`)
       await client.fail(session.id)
       return
     }
   }
-  const result = cfg.mock
-    ? { ok: true, answer: MOCK_ANSWER }
-    : await runAgent(selectProvider(cfg.providerName), {
-        bin: cfg.agentBin,
-        cwd: cfg.cwd,
-        model: cfg.model,
-        timeoutMs: cfg.timeoutMs,
-        systemPrompt: manifest,
-        prompt: buildPrompt(session.messages),
-        env: modelEnv ? { ...stripModelTokens(process.env), ...modelEnv } : undefined,
-      })
+  let result
+  try {
+    result = cfg.mock
+      ? { ok: true, answer: MOCK_ANSWER }
+      : await runAgent(selectProvider(cfg.providerName), {
+          bin: cfg.agentBin,
+          cwd: cfg.cwd,
+          model: cfg.model,
+          timeoutMs: cfg.timeoutMs,
+          systemPrompt: manifest,
+          prompt: buildPrompt(session.messages),
+          env: modelEnv ? { ...stripModelTokens(process.env), ...modelEnv } : undefined,
+        })
+  } finally {
+    // Remove any per-run credential files (a Codex login's auth.json) now the spawn is done.
+    await cleanupCred()
+  }
   if (!result.ok || !result.answer) {
     console.error(`[runner] session ${session.id} failed: ${result.error}`)
     await client.fail(session.id)
@@ -801,11 +812,17 @@ export async function serveSession(client, session, manifest, cfg, repoMeta = []
 /** Boot the host state serve/once share: context info, repo corpus, skills,
  *  conventions. Everything here is per-boot truth on purpose (see the comments
  *  inline) — `once` inherits the same freshness contract as a serve restart. */
-// The model-auth env vars the runner OWNS. Only the resolved per-user credential may set
-// one, so any inherited value is STRIPPED before a spawn (see the session loop). This is
-// what makes a stray global token on the host un-billable: there is no ambient fallback,
-// and no leftover env can override the injected plan.
-const MODEL_TOKEN_ENV = ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"]
+// The model-auth env the runner OWNS: the token vars plus CODEX_HOME (which points Codex at
+// a login's auth.json). Only the resolved per-user credential may set these, so any inherited
+// value is STRIPPED before a spawn (see the session loop). This is what makes a stray global
+// token OR login on the host un-billable: there is no ambient fallback, and no leftover env
+// can override the injected plan.
+const MODEL_TOKEN_ENV = [
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "CODEX_HOME",
+]
 
 /** A copy of `env` with every model-auth var removed, so the caller can layer ONLY the
  *  resolved credential on top. */
@@ -815,15 +832,20 @@ export function stripModelTokens(env) {
   return out
 }
 
-/** Resolve the model credential a run bills against, as a per-spawn ENV OVERLAY, never a
- *  process.env mutation, so one asker's plan token can't leak into the next asker's session
- *  on a shared context. Pass a session id to bill the run's INITIATOR; the server walks
+const noopCleanup = async () => {}
+
+/** Resolve the model credential a run bills against, as `{ env, cleanup }`: a per-spawn ENV
+ *  OVERLAY (never a process.env mutation, so one asker's plan can't leak into the next), plus
+ *  a `cleanup` to run AFTER the spawn. Most credentials are env-delivered (an API key, or an
+ *  env-var plan token like Claude's) and cleanup is a no-op. A Codex ChatGPT-plan login is
+ *  FILE-delivered: its `auth.json` is written 0600 into a private per-run CODEX_HOME and
+ *  cleanup removes it. Pass a session id to bill the run's INITIATOR; the server walks
  *  initiator, then owner (per-agent opt-in), then the workspace pool. There is NO
  *  shared/ambient fallback: if nothing resolves the run FAILS CLOSED, and a lookup error
- *  fails closed too (a run can't start without knowing whose plan pays). `reason`
- *  distinguishes an UNREADABLE stored token (reconnect) from nothing connected (connect). */
+ *  fails closed too. `reason` distinguishes an UNREADABLE stored token (reconnect) from
+ *  nothing connected (connect). */
 export async function resolveModelEnv(cfg, client, sessionId = null) {
-  if (cfg.mock) return null
+  if (cfg.mock) return { env: null, cleanup: noopCleanup }
   const provider = selectProvider(cfg.providerName)
   let res
   try {
@@ -839,12 +861,28 @@ export async function resolveModelEnv(cfg, client, sessionId = null) {
         ? `your connected ${cfg.providerName} plan couldn't be read (it may pre-date a key change). Reconnect it at ${cfg.server} (Settings → Model plans)`
         : `no model plan connected for this run's initiator. Connect one at ${cfg.server} (Settings → Model plans)`,
     )
+  // Env-delivered credential: an API key, or an env-var plan token like Claude's.
   const env = provider.credentialEnv?.(res.credential.kind, res.credential.value)
-  if (!env)
-    throw new Error(
-      `the connected ${cfg.providerName} credential (${res.credential.kind}) can't be injected. Connect an API key, or use a provider that supports it`,
-    )
-  return env
+  if (env) return { env, cleanup: noopCleanup }
+  // File-delivered credential: a Codex ChatGPT-plan login lands as auth.json in a private
+  // per-run CODEX_HOME dir, written 0600 and removed once the spawn is done.
+  const spec = provider.credentialFiles?.(res.credential.kind, res.credential.value)
+  if (spec) {
+    const dir = mkdtempSync(join(tmpdir(), "derive-cred-"))
+    for (const [name, content] of Object.entries(spec.files))
+      writeFileSync(join(dir, name), content, { mode: 0o600 })
+    return {
+      env: { [spec.homeEnv]: dir },
+      cleanup: async () => {
+        try {
+          rmSync(dir, { recursive: true, force: true })
+        } catch {}
+      },
+    }
+  }
+  throw new Error(
+    `the connected ${cfg.providerName} credential (${res.credential.kind}) can't be injected. Connect an API key, or use a provider that supports it`,
+  )
 }
 
 async function bootHost(cfg, modeLabel) {
@@ -855,7 +893,8 @@ async function bootHost(cfg, modeLabel) {
   // the gap in the log; don't block startup on it. The overlay is discarded regardless: each
   // session resolves its own initiator's credential.
   try {
-    await resolveModelEnv(cfg, client)
+    const preflight = await resolveModelEnv(cfg, client)
+    await preflight.cleanup()
   } catch (e) {
     console.error(
       `[runner] no default model plan at boot (${e.message}); sessions resolve per-initiator`,

--- a/packages/cli/src/runner.js
+++ b/packages/cli/src/runner.js
@@ -839,10 +839,18 @@ export async function resolveModelEnv(cfg, client, sessionId = null) {
 
 async function bootHost(cfg, modeLabel) {
   const client = new DeriveClient(cfg.server, cfg.token)
-  // Preflight only — verifies SOME credential path exists (registrant plan or ambient)
-  // so misconfiguration fails at boot with a clear message, not at the first answer.
-  // The overlay is discarded: each session resolves its own initiator's credential.
-  await resolveModelEnv(cfg, client)
+  // Preflight only, and non-fatal. With per-initiator billing each session resolves and
+  // fails closed on its own (line ~707), so a host legitimately boots with no DEFAULT plan
+  // — owner-lend off, no workspace pool, no ambient token — and still serves askers who
+  // bring their own. Surface the gap in the log; don't block startup on it. The overlay is
+  // discarded regardless: each session resolves its own initiator's credential.
+  try {
+    await resolveModelEnv(cfg, client)
+  } catch (e) {
+    console.error(
+      `[runner] no default model plan at boot (${e.message}); sessions resolve per-initiator`,
+    )
+  }
   const info = await client.getContext(cfg.contextId)
   if (!info.manifest_md && !cfg.manifestFile) throw new Error("context has no readable manifest")
   const readManifest = () =>

--- a/packages/cli/src/runner.js
+++ b/packages/cli/src/runner.js
@@ -193,6 +193,16 @@ export class DeriveClient {
     return { credential: r.credential ?? null, reason: r.reason ?? "none" }
   }
 
+  /** Persist a refreshed credential blob back to the SAME row this run resolved to (the CLI
+   *  rotated a single-use login in place). The server updates only the run's own row. */
+  async updateModelCredential(provider, sessionId, token) {
+    const q = `provider=${encodeURIComponent(provider)}${sessionId ? `&session=${encodeURIComponent(sessionId)}` : ""}`
+    await this.call(`/v1/agent/model-credential?${q}`, {
+      method: "PUT",
+      body: JSON.stringify({ token }),
+    })
+  }
+
   /** Post an answer. `answers` names the asker message it addresses — if a
    *  follow-up landed mid-run, the server keeps the session open for re-serve
    *  instead of settling it over the unseen follow-up. */
@@ -869,11 +879,32 @@ export async function resolveModelEnv(cfg, client, sessionId = null) {
   const spec = provider.credentialFiles?.(res.credential.kind, res.credential.value)
   if (spec) {
     const dir = mkdtempSync(join(tmpdir(), "derive-cred-"))
-    for (const [name, content] of Object.entries(spec.files))
-      writeFileSync(join(dir, name), content, { mode: 0o600 })
+    // The file whose seed content IS the stored blob is the one the CLI refreshes in place
+    // (Codex rotates its single-use login and writes it back to auth.json). Track it so cleanup
+    // can persist the rotated token; otherwise the next run seeds a token the CLI already burned.
+    let primaryPath = null
+    for (const [name, content] of Object.entries(spec.files)) {
+      const p = join(dir, name)
+      writeFileSync(p, content, { mode: 0o600 })
+      if (content === res.credential.value) primaryPath = p
+    }
+    const seed = res.credential.value
     return {
       env: { [spec.homeEnv]: dir },
       cleanup: async () => {
+        // Persist a refreshed login before discarding the dir (the sanctioned "run and persist
+        // the updated auth.json" pattern). Best-effort: a failed persist never fails the run.
+        try {
+          if (primaryPath) {
+            const after = readFileSync(primaryPath, "utf8")
+            if (after && after !== seed)
+              await client.updateModelCredential(cfg.providerName, sessionId, after)
+          }
+        } catch (e) {
+          console.error(
+            `[runner] couldn't persist refreshed ${cfg.providerName} login: ${e.message}`,
+          )
+        }
         try {
           rmSync(dir, { recursive: true, force: true })
         } catch {}

--- a/packages/cli/src/runner.js
+++ b/packages/cli/src/runner.js
@@ -9,6 +9,7 @@
 // Ported from packages/runner (TS) into the published CLI so `derive runner
 // serve` works from a bare npx on any machine — one package, no build step.
 import { spawn } from "node:child_process"
+import { createHash } from "node:crypto"
 import {
   existsSync,
   mkdirSync,
@@ -190,16 +191,22 @@ export class DeriveClient {
   async modelCredential(provider, sessionId = null) {
     const q = `provider=${encodeURIComponent(provider)}${sessionId ? `&session=${encodeURIComponent(sessionId)}` : ""}`
     const r = await this.call(`/v1/agent/model-credential?${q}`)
-    return { credential: r.credential ?? null, reason: r.reason ?? "none" }
+    return {
+      credential: r.credential ?? null,
+      reason: r.reason ?? "none",
+      source: r.source ?? null,
+    }
   }
 
-  /** Persist a refreshed credential blob back to the SAME row this run resolved to (the CLI
-   *  rotated a single-use login in place). The server updates only the run's own row. */
-  async updateModelCredential(provider, sessionId, token) {
+  /** Persist a refreshed login blob back to the EXACT row this run resolved to (the CLI
+   *  rotated a single-use login in place). Bound to the run's session and the tier it read
+   *  (`source`), with a compare-and-swap (`prevSha256` = sha256 of the blob the run started
+   *  with) so a stale/concurrent write can't clobber a fresher token. */
+  async updateModelCredential(provider, sessionId, token, source, prevSha256) {
     const q = `provider=${encodeURIComponent(provider)}${sessionId ? `&session=${encodeURIComponent(sessionId)}` : ""}`
     await this.call(`/v1/agent/model-credential?${q}`, {
       method: "PUT",
-      body: JSON.stringify({ token }),
+      body: JSON.stringify({ token, source, prev_sha256: prevSha256 }),
     })
   }
 
@@ -822,15 +829,21 @@ export async function serveSession(client, session, manifest, cfg, repoMeta = []
 /** Boot the host state serve/once share: context info, repo corpus, skills,
  *  conventions. Everything here is per-boot truth on purpose (see the comments
  *  inline) — `once` inherits the same freshness contract as a serve restart. */
-// The model-auth env the runner OWNS: the token vars plus CODEX_HOME (which points Codex at
-// a login's auth.json). Only the resolved per-user credential may set these, so any inherited
-// value is STRIPPED before a spawn (see the session loop). This is what makes a stray global
-// token OR login on the host un-billable: there is no ambient fallback, and no leftover env
-// can override the injected plan.
+// The model-auth env the runner OWNS: every token var the provider CLIs read, CODEX_HOME
+// (which points Codex at a login's auth.json), and the base-URL vars (a host value could
+// silently redirect the injected token to a proxy). Only the resolved per-user credential may
+// set these, so any inherited value is STRIPPED before a spawn (see the session loop). This is
+// what makes a stray global token OR login on the host un-billable and un-exfiltratable: there
+// is no ambient fallback, and no leftover env can override or redirect the injected plan.
+// (Defense in depth on top of the deploy invariant that the runner image carries no host
+// `~/.codex` / `~/.claude` login and no baked model token.)
 const MODEL_TOKEN_ENV = [
   "CLAUDE_CODE_OAUTH_TOKEN",
   "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_BASE_URL",
   "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
   "CODEX_HOME",
 ]
 
@@ -843,6 +856,17 @@ export function stripModelTokens(env) {
 }
 
 const noopCleanup = async () => {}
+const sha256Hex = (s) => createHash("sha256").update(s).digest("hex")
+// A well-formed, non-empty JSON object — the shape a refreshed login (auth.json) must have.
+// Guards against persisting a truncated/garbage file a crashed CLI can leave behind.
+const isJsonObject = (s) => {
+  try {
+    const v = JSON.parse(s)
+    return !!v && typeof v === "object" && Object.keys(v).length > 0
+  } catch {
+    return false
+  }
+}
 
 /** Resolve the model credential a run bills against, as `{ env, cleanup }`: a per-spawn ENV
  *  OVERLAY (never a process.env mutation, so one asker's plan can't leak into the next), plus
@@ -878,27 +902,46 @@ export async function resolveModelEnv(cfg, client, sessionId = null) {
   // per-run CODEX_HOME dir, written 0600 and removed once the spawn is done.
   const spec = provider.credentialFiles?.(res.credential.kind, res.credential.value)
   if (spec) {
-    const dir = mkdtempSync(join(tmpdir(), "derive-cred-"))
+    const seed = res.credential.value
+    const source = res.source
     // The file whose seed content IS the stored blob is the one the CLI refreshes in place
     // (Codex rotates its single-use login and writes it back to auth.json). Track it so cleanup
     // can persist the rotated token; otherwise the next run seeds a token the CLI already burned.
+    let dir
     let primaryPath = null
-    for (const [name, content] of Object.entries(spec.files)) {
-      const p = join(dir, name)
-      writeFileSync(p, content, { mode: 0o600 })
-      if (content === res.credential.value) primaryPath = p
+    try {
+      dir = mkdtempSync(join(tmpdir(), "derive-cred-"))
+      for (const [name, content] of Object.entries(spec.files)) {
+        const p = join(dir, name)
+        writeFileSync(p, content, { mode: 0o600 })
+        if (content === seed) primaryPath = p
+      }
+    } catch (e) {
+      // Never leave a half-written 0600 blob behind if materialization fails partway.
+      if (dir)
+        try {
+          rmSync(dir, { recursive: true, force: true })
+        } catch {}
+      throw e
     }
-    const seed = res.credential.value
     return {
       env: { [spec.homeEnv]: dir },
       cleanup: async () => {
         // Persist a refreshed login before discarding the dir (the sanctioned "run and persist
-        // the updated auth.json" pattern). Best-effort: a failed persist never fails the run.
+        // the updated auth.json" pattern), bound to the exact tier the run read (`source`) and
+        // CAS-guarded server-side (`sha256(seed)`). Only a real, well-formed change is sent — a
+        // crashed CLI can leave garbage. Best-effort: a failed persist never fails the run.
         try {
           if (primaryPath) {
             const after = readFileSync(primaryPath, "utf8")
-            if (after && after !== seed)
-              await client.updateModelCredential(cfg.providerName, sessionId, after)
+            if (after && after !== seed && isJsonObject(after))
+              await client.updateModelCredential(
+                cfg.providerName,
+                sessionId,
+                after,
+                source,
+                sha256Hex(seed),
+              )
           }
         } catch (e) {
           console.error(

--- a/packages/cli/src/runner.js
+++ b/packages/cli/src/runner.js
@@ -181,13 +181,14 @@ export class DeriveClient {
     return r.sessions
   }
 
-  /** The owner's connected model credential for a provider (decrypted), or null. The
-   *  server scopes it to THIS agent's registrant, so a runner only ever sees its own
-   *  owner's plan token. */
+  /** The model credential a run bills against (decrypted), plus a `reason` when there is
+   *  none: "unreadable" = a row existed but its secret wouldn't decrypt (reconnect), "none"
+   *  = nothing connected. The server scopes it to THIS agent's own context, so a runner only
+   *  ever sees a credential a run of its own is entitled to. */
   async modelCredential(provider, sessionId = null) {
     const q = `provider=${encodeURIComponent(provider)}${sessionId ? `&session=${encodeURIComponent(sessionId)}` : ""}`
     const r = await this.call(`/v1/agent/model-credential?${q}`)
-    return r.credential ?? null
+    return { credential: r.credential ?? null, reason: r.reason ?? "none" }
   }
 
   /** Post an answer. `answers` names the asker message it addresses — if a
@@ -696,11 +697,12 @@ const MOCK_ANSWER = {
 export async function serveSession(client, session, manifest, cfg, repoMeta = [], skillMeta = []) {
   const asked = session.messages.at(-1)?.body_md?.slice(0, 80) ?? "?"
   console.log(`[runner] session ${session.id}: "${asked}"`)
-  // Whose plan pays for THIS answer: the session's asker (the server resolves it,
-  // falling back to the registrant), composed as a per-spawn overlay so nothing
-  // sticks to process.env between sessions with different askers. A fail-closed
-  // resolve (no plan, no ambient) fails THIS session server-side like any other
-  // run failure — thrown, it would leave the claim dangling and retry-loop.
+  // Whose plan pays for THIS answer: the server resolves it (initiator, then owner-lend,
+  // then the workspace pool), returned as a per-spawn overlay layered over an env whose
+  // inherited model tokens are STRIPPED, so nothing sticks to process.env between sessions
+  // with different askers and no stray host token can override the injected plan. A
+  // fail-closed resolve (nothing connected) fails THIS session like any other run failure;
+  // thrown, it would leave the claim dangling and retry-loop.
   let modelEnv = null
   if (!cfg.mock) {
     try {
@@ -720,7 +722,7 @@ export async function serveSession(client, session, manifest, cfg, repoMeta = []
         timeoutMs: cfg.timeoutMs,
         systemPrompt: manifest,
         prompt: buildPrompt(session.messages),
-        env: modelEnv ? { ...process.env, ...modelEnv } : undefined,
+        env: modelEnv ? { ...stripModelTokens(process.env), ...modelEnv } : undefined,
       })
   if (!result.ok || !result.answer) {
     console.error(`[runner] session ${session.id} failed: ${result.error}`)
@@ -799,51 +801,59 @@ export async function serveSession(client, session, manifest, cfg, repoMeta = []
 /** Boot the host state serve/once share: context info, repo corpus, skills,
  *  conventions. Everything here is per-boot truth on purpose (see the comments
  *  inline) — `once` inherits the same freshness contract as a serve restart. */
-/** Resolve the model credential a run authenticates with, as a per-spawn ENV OVERLAY —
- *  never a process.env mutation, so one asker's plan token can't leak into the next
- *  asker's session on a shared context. Pass a session id to bill the run's INITIATOR:
- *  the server resolves the session's asker first and falls back to the agent's
- *  registrant (interim until the workspace pool lands). Precedence:
- *    1. the initiator's connected plan (fetched, decrypted, provider-mapped) — overlay it;
- *    2. no connection but an ambient token is set (self-host's single global plan) — null
- *       overlay, the spawn inherits process.env;
- *    3. neither — FAIL CLOSED with a connect-your-plan message (never a shared fallback).
- *  A lookup error (older/self-host server without the endpoint) degrades to the ambient path. */
+// The model-auth env vars the runner OWNS. Only the resolved per-user credential may set
+// one, so any inherited value is STRIPPED before a spawn (see the session loop). This is
+// what makes a stray global token on the host un-billable: there is no ambient fallback,
+// and no leftover env can override the injected plan.
+const MODEL_TOKEN_ENV = ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"]
+
+/** A copy of `env` with every model-auth var removed, so the caller can layer ONLY the
+ *  resolved credential on top. */
+export function stripModelTokens(env) {
+  const out = { ...env }
+  for (const k of MODEL_TOKEN_ENV) delete out[k]
+  return out
+}
+
+/** Resolve the model credential a run bills against, as a per-spawn ENV OVERLAY, never a
+ *  process.env mutation, so one asker's plan token can't leak into the next asker's session
+ *  on a shared context. Pass a session id to bill the run's INITIATOR; the server walks
+ *  initiator, then owner (per-agent opt-in), then the workspace pool. There is NO
+ *  shared/ambient fallback: if nothing resolves the run FAILS CLOSED, and a lookup error
+ *  fails closed too (a run can't start without knowing whose plan pays). `reason`
+ *  distinguishes an UNREADABLE stored token (reconnect) from nothing connected (connect). */
 export async function resolveModelEnv(cfg, client, sessionId = null) {
   if (cfg.mock) return null
   const provider = selectProvider(cfg.providerName)
-  let cred = null
+  let res
   try {
-    cred = await client.modelCredential(cfg.providerName, sessionId)
+    res = await client.modelCredential(cfg.providerName, sessionId)
   } catch (e) {
-    console.error(`[runner] model-credential lookup failed (${e.message}); using ambient env`)
-    return null
-  }
-  if (cred) {
-    const env = provider.credentialEnv?.(cred.kind, cred.value)
-    if (!env)
-      throw new Error(
-        `the connected ${cfg.providerName} credential (${cred.kind}) can't be injected — connect an API key, or use a provider that supports it`,
-      )
-    return env
-  }
-  const ambient = ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"].some(
-    (k) => process.env[k],
-  )
-  if (!ambient)
     throw new Error(
-      `no model plan connected for this run's initiator — connect one at ${cfg.server} (Settings → Model plans)`,
+      `couldn't reach the model-plan endpoint (${e.message}); a run can't start without a connected plan. Connect one at ${cfg.server} (Settings → Model plans)`,
     )
-  return null
+  }
+  if (!res.credential)
+    throw new Error(
+      res.reason === "unreadable"
+        ? `your connected ${cfg.providerName} plan couldn't be read (it may pre-date a key change). Reconnect it at ${cfg.server} (Settings → Model plans)`
+        : `no model plan connected for this run's initiator. Connect one at ${cfg.server} (Settings → Model plans)`,
+    )
+  const env = provider.credentialEnv?.(res.credential.kind, res.credential.value)
+  if (!env)
+    throw new Error(
+      `the connected ${cfg.providerName} credential (${res.credential.kind}) can't be injected. Connect an API key, or use a provider that supports it`,
+    )
+  return env
 }
 
 async function bootHost(cfg, modeLabel) {
   const client = new DeriveClient(cfg.server, cfg.token)
   // Preflight only, and non-fatal. With per-initiator billing each session resolves and
   // fails closed on its own (line ~707), so a host legitimately boots with no DEFAULT plan
-  // — owner-lend off, no workspace pool, no ambient token — and still serves askers who
-  // bring their own. Surface the gap in the log; don't block startup on it. The overlay is
-  // discarded regardless: each session resolves its own initiator's credential.
+  // (owner-lend off, no workspace pool) and still serves askers who bring their own. Surface
+  // the gap in the log; don't block startup on it. The overlay is discarded regardless: each
+  // session resolves its own initiator's credential.
   try {
     await resolveModelEnv(cfg, client)
   } catch (e) {

--- a/packages/cli/test/providers.test.js
+++ b/packages/cli/test/providers.test.js
@@ -125,10 +125,14 @@ describe("resolveModelEnv — per-initiator overlay, no shared fallback", () => 
   // The server returns { credential, reason }. Fake it: a credential implies reason "none".
   const client = (credential, { throws = false, reason = "none" } = {}) => ({
     calls: [],
+    persisted: [],
     async modelCredential(provider, sessionId = null) {
       this.calls.push({ provider, sessionId })
       if (throws) throw new Error("404")
       return { credential, reason: credential ? "none" : reason }
+    },
+    async updateModelCredential(provider, sessionId, token) {
+      this.persisted.push({ provider, sessionId, token })
     },
   })
 
@@ -201,20 +205,32 @@ describe("resolveModelEnv — per-initiator overlay, no shared fallback", () => 
     expect(stripped).toEqual({ PATH: "/usr/bin" })
   })
 
-  it("a Codex plan LOGIN is written to a private per-run CODEX_HOME, then cleaned up", async () => {
+  it("a Codex plan LOGIN is written to a private per-run CODEX_HOME; a refresh persists, then cleanup", async () => {
     clean()
-    const authJson = '{"tokens":{"access_token":"a","refresh_token":"r"}}'
-    const { env, cleanup } = await resolveModelEnv(
-      cfg({ providerName: "codex" }),
-      client({ kind: "login", value: authJson }),
-    )
+    const authJson = '{"tokens":{"access_token":"a","refresh_token":"r"},"last_refresh":"t0"}'
+    const c = client({ kind: "login", value: authJson })
+    const { env, cleanup } = await resolveModelEnv(cfg({ providerName: "codex" }), c, "ses_1")
     // The overlay points Codex at the private dir, nothing else.
     expect(Object.keys(env)).toEqual(["CODEX_HOME"])
     const authPath = join(env.CODEX_HOME, "auth.json")
     expect(readFileSync(authPath, "utf8")).toBe(authJson)
-    // Cleanup removes the dir so the login never lingers between runs.
+    // Simulate Codex rotating the single-use token in place during the run.
+    const refreshed = '{"tokens":{"access_token":"a2","refresh_token":"r2"},"last_refresh":"t1"}'
+    writeFileSync(authPath, refreshed)
     await cleanup()
+    // The rotated blob is persisted (so the next run doesn't seed a burned token)...
+    expect(c.persisted).toEqual([{ provider: "codex", sessionId: "ses_1", token: refreshed }])
+    // ...and the dir is gone.
     expect(existsSync(env.CODEX_HOME)).toBe(false)
+    clean()
+  })
+
+  it("an UNCHANGED login is not persisted (no needless write)", async () => {
+    clean()
+    const c = client({ kind: "login", value: '{"tokens":{"x":1}}' })
+    const { cleanup } = await resolveModelEnv(cfg({ providerName: "codex" }), c, "ses_2")
+    await cleanup()
+    expect(c.persisted).toEqual([])
     clean()
   })
 })

--- a/packages/cli/test/providers.test.js
+++ b/packages/cli/test/providers.test.js
@@ -123,16 +123,20 @@ describe("resolveModelEnv — per-initiator overlay, no shared fallback", () => 
   }
   const cfg = (over = {}) => ({ providerName: "claude-code", server: "https://derive.to", ...over })
   // The server returns { credential, reason }. Fake it: a credential implies reason "none".
-  const client = (credential, { throws = false, reason = "none" } = {}) => ({
+  const client = (credential, { throws = false, reason = "none", source = "pool" } = {}) => ({
     calls: [],
     persisted: [],
     async modelCredential(provider, sessionId = null) {
       this.calls.push({ provider, sessionId })
       if (throws) throw new Error("404")
-      return { credential, reason: credential ? "none" : reason }
+      return {
+        credential,
+        reason: credential ? "none" : reason,
+        source: credential ? source : null,
+      }
     },
-    async updateModelCredential(provider, sessionId, token) {
-      this.persisted.push({ provider, sessionId, token })
+    async updateModelCredential(provider, sessionId, token, src, prevSha256) {
+      this.persisted.push({ provider, sessionId, token, source: src, prevSha256 })
     },
   })
 
@@ -218,8 +222,16 @@ describe("resolveModelEnv — per-initiator overlay, no shared fallback", () => 
     const refreshed = '{"tokens":{"access_token":"a2","refresh_token":"r2"},"last_refresh":"t1"}'
     writeFileSync(authPath, refreshed)
     await cleanup()
-    // The rotated blob is persisted (so the next run doesn't seed a burned token)...
-    expect(c.persisted).toEqual([{ provider: "codex", sessionId: "ses_1", token: refreshed }])
+    // The rotated blob is persisted, bound to the tier it read (source) and CAS-guarded by the
+    // seed hash, so the next run doesn't seed a burned token...
+    expect(c.persisted).toHaveLength(1)
+    expect(c.persisted[0]).toMatchObject({
+      provider: "codex",
+      sessionId: "ses_1",
+      token: refreshed,
+      source: "pool",
+    })
+    expect(c.persisted[0].prevSha256).toMatch(/^[0-9a-f]{64}$/)
     // ...and the dir is gone.
     expect(existsSync(env.CODEX_HOME)).toBe(false)
     clean()
@@ -229,6 +241,17 @@ describe("resolveModelEnv — per-initiator overlay, no shared fallback", () => 
     clean()
     const c = client({ kind: "login", value: '{"tokens":{"x":1}}' })
     const { cleanup } = await resolveModelEnv(cfg({ providerName: "codex" }), c, "ses_2")
+    await cleanup()
+    expect(c.persisted).toEqual([])
+    clean()
+  })
+
+  it("a GARBAGE (non-JSON) auth.json after a run is NOT persisted", async () => {
+    clean()
+    const c = client({ kind: "login", value: '{"tokens":{"x":1}}' })
+    const { env, cleanup } = await resolveModelEnv(cfg({ providerName: "codex" }), c, "ses_g")
+    // A crashed CLI leaves a truncated file — must never be persisted over the good token.
+    writeFileSync(join(env.CODEX_HOME, "auth.json"), "not json {truncated")
     await cleanup()
     expect(c.persisted).toEqual([])
     clean()

--- a/packages/cli/test/providers.test.js
+++ b/packages/cli/test/providers.test.js
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { describe, expect, it } from "vitest"
@@ -102,9 +102,17 @@ describe("credentialEnv", () => {
     expect(claudeCode.credentialEnv("oauth", "tok")).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "tok" })
     expect(claudeCode.credentialEnv("api_key", "sk")).toEqual({ ANTHROPIC_API_KEY: "sk" })
   })
-  it("codex maps api_key→OPENAI_API_KEY; a plan (oauth) login is file-based, so null for now", () => {
+  it("codex maps api_key→OPENAI_API_KEY (env); other kinds have no env mapping", () => {
     expect(codex.credentialEnv("api_key", "sk")).toEqual({ OPENAI_API_KEY: "sk" })
+    expect(codex.credentialEnv("login", "blob")).toBeNull()
     expect(codex.credentialEnv("oauth", "tok")).toBeNull()
+  })
+  it("codex maps a plan LOGIN to an auth.json file in CODEX_HOME; other kinds have no file", () => {
+    expect(codex.credentialFiles("login", "BLOB")).toEqual({
+      homeEnv: "CODEX_HOME",
+      files: { "auth.json": "BLOB" },
+    })
+    expect(codex.credentialFiles("api_key", "sk")).toBeNull()
   })
 })
 
@@ -127,7 +135,7 @@ describe("resolveModelEnv — per-initiator overlay, no shared fallback", () => 
   it("returns the initiator's plan as an OVERLAY — process.env is never mutated", async () => {
     clean()
     process.env.CLAUDE_CODE_OAUTH_TOKEN = "host-value-should-survive"
-    const env = await resolveModelEnv(cfg(), client({ kind: "oauth", value: "ASKER-A" }))
+    const { env } = await resolveModelEnv(cfg(), client({ kind: "oauth", value: "ASKER-A" }))
     expect(env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "ASKER-A" })
     // The overlay is separate from process.env, so the NEXT session starts clean.
     expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("host-value-should-survive")
@@ -182,14 +190,32 @@ describe("resolveModelEnv — per-initiator overlay, no shared fallback", () => 
     clean()
   })
 
-  it("stripModelTokens removes every inherited model-auth var, keeps the rest", () => {
+  it("stripModelTokens removes every inherited model-auth var (incl CODEX_HOME), keeps the rest", () => {
     const stripped = stripModelTokens({
       PATH: "/usr/bin",
       CLAUDE_CODE_OAUTH_TOKEN: "a",
       ANTHROPIC_API_KEY: "b",
       OPENAI_API_KEY: "c",
+      CODEX_HOME: "/home/x/.codex",
     })
     expect(stripped).toEqual({ PATH: "/usr/bin" })
+  })
+
+  it("a Codex plan LOGIN is written to a private per-run CODEX_HOME, then cleaned up", async () => {
+    clean()
+    const authJson = '{"tokens":{"access_token":"a","refresh_token":"r"}}'
+    const { env, cleanup } = await resolveModelEnv(
+      cfg({ providerName: "codex" }),
+      client({ kind: "login", value: authJson }),
+    )
+    // The overlay points Codex at the private dir, nothing else.
+    expect(Object.keys(env)).toEqual(["CODEX_HOME"])
+    const authPath = join(env.CODEX_HOME, "auth.json")
+    expect(readFileSync(authPath, "utf8")).toBe(authJson)
+    // Cleanup removes the dir so the login never lingers between runs.
+    await cleanup()
+    expect(existsSync(env.CODEX_HOME)).toBe(false)
+    clean()
   })
 })
 

--- a/packages/cli/test/providers.test.js
+++ b/packages/cli/test/providers.test.js
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest"
 import { claudeCode } from "../src/providers/claude-code.js"
 import { codex } from "../src/providers/codex.js"
 import { DEFAULT_PROVIDER, PROVIDERS, selectProvider } from "../src/providers/index.js"
-import { loadRunnerConfig, resolveModelEnv, runAgent } from "../src/runner.js"
+import { loadRunnerConfig, resolveModelEnv, runAgent, stripModelTokens } from "../src/runner.js"
 
 describe("provider registry", () => {
   it("defaults to claude-code, resolves known names, and throws on an unknown one", () => {
@@ -108,58 +108,69 @@ describe("credentialEnv", () => {
   })
 })
 
-describe("resolveModelEnv — per-initiator overlay + fail-closed", () => {
+describe("resolveModelEnv — per-initiator overlay, no shared fallback", () => {
   const CRED_ENV = ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"]
   const clean = () => {
     for (const k of CRED_ENV) delete process.env[k]
   }
   const cfg = (over = {}) => ({ providerName: "claude-code", server: "https://derive.to", ...over })
-  const client = (credential, throws = false) => ({
+  // The server returns { credential, reason }. Fake it: a credential implies reason "none".
+  const client = (credential, { throws = false, reason = "none" } = {}) => ({
     calls: [],
     async modelCredential(provider, sessionId = null) {
       this.calls.push({ provider, sessionId })
       if (throws) throw new Error("404")
-      return credential
+      return { credential, reason: credential ? "none" : reason }
     },
   })
 
   it("returns the initiator's plan as an OVERLAY — process.env is never mutated", async () => {
     clean()
-    process.env.CLAUDE_CODE_OAUTH_TOKEN = "ambient-should-survive"
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "host-value-should-survive"
     const env = await resolveModelEnv(cfg(), client({ kind: "oauth", value: "ASKER-A" }))
     expect(env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "ASKER-A" })
-    // The isolation property itself: the parent env still holds the ambient value,
-    // so the NEXT session (a different asker) starts from clean ground.
-    expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("ambient-should-survive")
+    // The overlay is separate from process.env, so the NEXT session starts clean.
+    expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("host-value-should-survive")
     clean()
   })
 
   it("passes the session id through, so the server can resolve the ASKER's plan", async () => {
     clean()
-    process.env.ANTHROPIC_API_KEY = "ambient"
-    const c = client(null)
+    const c = client({ kind: "oauth", value: "x" })
     await resolveModelEnv(cfg(), c, "ses_123")
     expect(c.calls).toEqual([{ provider: "claude-code", sessionId: "ses_123" }])
     clean()
   })
 
-  it("FAILS CLOSED when the initiator has no plan and no ambient token is set", async () => {
+  it("FAILS CLOSED when nothing resolves — connect-your-plan message", async () => {
     clean()
     await expect(resolveModelEnv(cfg(), client(null))).rejects.toThrow(/no model plan connected/)
     clean()
   })
 
-  it("falls back to an ambient token (self-host's single plan) — null overlay", async () => {
+  it("a stray HOST token is NOT a fallback: still fails closed when nothing resolves", async () => {
     clean()
-    process.env.ANTHROPIC_API_KEY = "self-host-key"
-    await expect(resolveModelEnv(cfg(), client(null))).resolves.toBeNull()
+    // Even with a global token in the env, an unconnected initiator fails closed —
+    // there is no ambient path anymore.
+    process.env.ANTHROPIC_API_KEY = "stray-host-key"
+    await expect(resolveModelEnv(cfg(), client(null))).rejects.toThrow(/no model plan connected/)
     clean()
   })
 
-  it("a lookup error degrades to the ambient path rather than crashing the run", async () => {
+  it("an UNREADABLE stored token tells the user to reconnect, not to connect", async () => {
     clean()
-    process.env.CLAUDE_CODE_OAUTH_TOKEN = "ambient"
-    await expect(resolveModelEnv(cfg(), client(null, true))).resolves.toBeNull()
+    await expect(resolveModelEnv(cfg(), client(null, { reason: "unreadable" }))).rejects.toThrow(
+      /reconnect/i,
+    )
+    clean()
+  })
+
+  it("a lookup error fails the run closed (a run can't start without a plan)", async () => {
+    clean()
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "stray-host-key"
+    await expect(resolveModelEnv(cfg(), client(null, { throws: true }))).rejects.toThrow(
+      /couldn't reach the model-plan endpoint/,
+    )
     clean()
   })
 
@@ -169,6 +180,16 @@ describe("resolveModelEnv — per-initiator overlay + fail-closed", () => {
       resolveModelEnv(cfg({ providerName: "codex" }), client({ kind: "oauth", value: "x" })),
     ).rejects.toThrow(/can't be injected/)
     clean()
+  })
+
+  it("stripModelTokens removes every inherited model-auth var, keeps the rest", () => {
+    const stripped = stripModelTokens({
+      PATH: "/usr/bin",
+      CLAUDE_CODE_OAUTH_TOKEN: "a",
+      ANTHROPIC_API_KEY: "b",
+      OPENAI_API_KEY: "c",
+    })
+    expect(stripped).toEqual({ PATH: "/usr/bin" })
   })
 })
 

--- a/packages/cli/test/runner.test.js
+++ b/packages/cli/test/runner.test.js
@@ -394,6 +394,9 @@ describe("artifact file channel", () => {
       },
       answer: async (id, body, meta, state) => calls.answered.push({ id, body, meta, state }),
       fail: async (id) => calls.failed.push(id),
+      // The non-mock serve path resolves the run's plan first; the fake `claude` ignores the
+      // token, so any credential lets the artifact channel run end to end.
+      modelCredential: async () => ({ credential: { kind: "oauth", value: "t" }, reason: "none" }),
     }
     const session = () => ({
       id: "ses_1",

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -2163,7 +2163,10 @@ export interface ModelCredentialRecord {
   org_id: string
   user_id: string
   provider: string
-  kind: "oauth" | "api_key"
+  // oauth = an env-var plan token (Claude's setup-token). api_key = a provider API key.
+  // login = a file-delivered plan login blob (Codex's ~/.codex/auth.json), materialized into
+  // a private CODEX_HOME per run.
+  kind: "oauth" | "api_key" | "login"
   secret: string
   hint: string
   created_at: string

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -2114,6 +2114,12 @@ export interface OrgSettings {
    *  the generated brand profile. Absent until set. Mirrored on a profile (user layer);
    *  resolved profile-over-workspace. */
   brandprint?: Brandprint
+  /** Per-agent owner-lend allow-list: agent ids whose OWNER (created_by) has opted that
+   *  agent in to bill the owner's OWN connected model plan when a run's initiator has no
+   *  plan of their own. Default absent = off. Only the agent's owner toggles membership;
+   *  the credential resolver falls to the owner's plan for a listed agent, then the
+   *  workspace pool, then fail-closed. */
+  ownerLendAgents?: string[]
 }
 
 /** How a workspace/profile likes its stuff built: a pointer to a "conventions"

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -522,7 +522,7 @@ export const modelCredential = pgTable(
     org_id: text("org_id").notNull(),
     user_id: text("user_id").notNull(),
     provider: text("provider").notNull(),
-    kind: text("kind").$type<"oauth" | "api_key">().notNull(),
+    kind: text("kind").$type<"oauth" | "api_key" | "login">().notNull(),
     secret: text("secret").notNull(),
     hint: text("hint").notNull().default(""),
     created_at: text("created_at").notNull().$defaultFn(isoNow),

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -990,6 +990,11 @@ export class PgMetaStore implements MetaStore {
     await this.db
       .delete(membership)
       .where(and(eq(membership.org_id, orgId), eq(membership.user_id, userId)))
+    // A removed member's connected plan must stop being billable here — otherwise a lent
+    // agent would keep charging their token after they've lost workspace access.
+    await this.db
+      .delete(modelCredential)
+      .where(and(eq(modelCredential.org_id, orgId), eq(modelCredential.user_id, userId)))
   }
   async getWorkspace(orgId: string): Promise<WorkspaceRecord | null> {
     const rows = await this.db.select().from(workspace).where(eq(workspace.id, orgId))
@@ -1005,6 +1010,10 @@ export class PgMetaStore implements MetaStore {
   }
   async deleteWorkspace(orgId: string): Promise<void> {
     await this.db.delete(membership).where(eq(membership.org_id, orgId))
+    // Every connected plan for this org, INCLUDING the workspace-pool sentinel row, so no
+    // encrypted token is orphaned (the pool row would otherwise have no API path left to
+    // delete once memberships are gone). One predicate covers members and the pool.
+    await this.db.delete(modelCredential).where(eq(modelCredential.org_id, orgId))
     await this.db.delete(workspace).where(eq(workspace.id, orgId))
   }
   listWorkspaces(userId: string): Promise<(WorkspaceRecord & { role: Role })[]> {

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -2913,6 +2913,9 @@ export class PgMetaStore implements MetaStore {
     await this.db.delete(follow).where(eq(follow.user_id, userId))
     await this.db.delete(artifactFavorite).where(eq(artifactFavorite.user_id, userId))
     await this.db.delete(notification).where(eq(notification.user_id, userId))
+    // Encrypted plan tokens must not linger after the account is gone; the workspace pool's
+    // sentinel-user row is keyed differently, so it is never in scope.
+    await this.db.delete(modelCredential).where(eq(modelCredential.user_id, userId))
     await this.db.update(artifact).set({ author_id: null }).where(eq(artifact.author_id, userId))
     await this.db.update(version).set({ author_id: null }).where(eq(version.author_id, userId))
     await this.db.update(comment).set({ author_id: null }).where(eq(comment.author_id, userId))

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -1126,6 +1126,12 @@ export function makeRepos(db: SqliteDb) {
       .delete(membership)
       .where(and(eq(membership.org_id, orgId), eq(membership.user_id, userId)))
       .run()
+    // A removed member's connected plan must stop being billable here — otherwise a lent
+    // agent would keep charging their token after they've lost workspace access.
+    await db
+      .delete(modelCredential)
+      .where(and(eq(modelCredential.org_id, orgId), eq(modelCredential.user_id, userId)))
+      .run()
   }
   const getWorkspace = async (orgId: string): Promise<WorkspaceRecord | null> =>
     (await db.select().from(workspace).where(eq(workspace.id, orgId)).get()) ?? null
@@ -1138,6 +1144,10 @@ export function makeRepos(db: SqliteDb) {
       .get()) as WorkspaceRecord
   const deleteWorkspace = async (orgId: string): Promise<void> => {
     await db.delete(membership).where(eq(membership.org_id, orgId)).run()
+    // Every connected plan for this org, INCLUDING the workspace-pool sentinel row, so no
+    // encrypted token is orphaned (the pool row would otherwise have no API path left to
+    // delete once memberships are gone). One predicate covers members and the pool.
+    await db.delete(modelCredential).where(eq(modelCredential.org_id, orgId)).run()
     await db.delete(workspace).where(eq(workspace.id, orgId)).run()
   }
   const listWorkspaces = async (userId: string): Promise<(WorkspaceRecord & { role: Role })[]> =>

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -2964,6 +2964,10 @@ export function makeRepos(db: SqliteDb) {
     await db.delete(follow).where(eq(follow.user_id, userId)).run()
     await db.delete(artifactFavorite).where(eq(artifactFavorite.user_id, userId)).run()
     await db.delete(notification).where(eq(notification.user_id, userId)).run()
+    // Their connected model-plan credentials — encrypted plan tokens must not linger after
+    // the account is gone. Keyed on a real user id, so the workspace pool's sentinel row is
+    // never in scope.
+    await db.delete(modelCredential).where(eq(modelCredential.user_id, userId)).run()
     // Authorship is anonymized (nullable), so others' artifacts/threads survive intact.
     await db.update(artifact).set({ author_id: null }).where(eq(artifact.author_id, userId)).run()
     await db.update(version).set({ author_id: null }).where(eq(version.author_id, userId)).run()

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -634,7 +634,7 @@ export const modelCredential = sqliteTable(
     org_id: text("org_id").notNull(),
     user_id: text("user_id").notNull(),
     provider: text("provider").notNull(),
-    kind: text("kind").$type<"oauth" | "api_key">().notNull(),
+    kind: text("kind").$type<"oauth" | "api_key" | "login">().notNull(),
     secret: text("secret").notNull(),
     hint: text("hint").notNull().default(""),
     created_at: text("created_at").notNull().default(now),

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -2222,6 +2222,22 @@ export function runStoreContract(
         kind: "user",
         target: other,
       })
+      // The leaver's connected plan token, plus a workspace-pool row and another member's.
+      const credNow = "2026-07-24T00:00:00.000Z"
+      const mkCred = (userId: string, secret: string) => ({
+        id: uuid(),
+        org_id: org,
+        user_id: userId,
+        provider: "codex",
+        kind: "oauth" as const,
+        secret,
+        hint: secret.slice(-4),
+        created_at: credNow,
+        updated_at: credNow,
+      })
+      await store.setModelCredential(mkCred(leaver, "enc-leaver"))
+      await store.setModelCredential(mkCred(other, "enc-other"))
+      await store.setModelCredential(mkCred("__workspace_pool__", "enc-pool"))
 
       await store.deleteUserData(leaver)
 
@@ -2239,6 +2255,13 @@ export function runStoreContract(
       // artifacts still exist (content is never hard-deleted).
       expect((await store.getArtifactById(mine.id))?.author_id ?? null).toBeNull()
       expect((await store.getArtifactById(theirs.id))?.author_id).toBe(other)
+      // Their connected plan token is PURGED; the workspace-pool row (sentinel user) and
+      // other members' plans survive untouched.
+      expect(await store.getModelCredential(org, leaver, "codex")).toBeNull()
+      expect((await store.getModelCredential(org, other, "codex"))?.secret).toBe("enc-other")
+      expect((await store.getModelCredential(org, "__workspace_pool__", "codex"))?.secret).toBe(
+        "enc-pool",
+      )
     })
   })
 

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -2263,6 +2263,38 @@ export function runStoreContract(
         "enc-pool",
       )
     })
+
+    it("removeMembership + deleteWorkspace purge model_credential (incl. the pool sentinel)", async () => {
+      const org = `org_ws_${uuid()}`
+      const member = `member_${uuid()}`
+      const now = "2026-07-24T00:00:00.000Z"
+      const cred = (userId: string, secret: string) => ({
+        id: uuid(),
+        org_id: org,
+        user_id: userId,
+        provider: "codex",
+        kind: "login" as const,
+        secret,
+        hint: secret.slice(-4),
+        created_at: now,
+        updated_at: now,
+      })
+      await store.setWorkspace(org, "WS")
+      await store.setMembership({ id: uuid(), org_id: org, user_id: member, role: "editor" })
+      await store.setModelCredential(cred(member, "enc-member"))
+      await store.setModelCredential(cred("__workspace_pool__", "enc-pool"))
+
+      // Removing a member drops only their credential; the pool row stays.
+      await store.removeMembership(org, member)
+      expect(await store.getModelCredential(org, member, "codex")).toBeNull()
+      expect((await store.getModelCredential(org, "__workspace_pool__", "codex"))?.secret).toBe(
+        "enc-pool",
+      )
+
+      // Deleting the workspace clears the pool sentinel too — nothing orphaned.
+      await store.deleteWorkspace(org)
+      expect(await store.getModelCredential(org, "__workspace_pool__", "codex")).toBeNull()
+    })
   })
 
   describe(`${label}: automations + runs (WP5/WP6)`, () => {


### PR DESCRIPTION
## Bring your own plan: per-user model-plan credentials

Hosted Derive runs agents with your machine off. This lets every member connect their OWN model plan (Claude, Codex) so a run bills the right person's subscription, encrypted and isolated, never a shared token.

### Resolution
Each run resolves which credential it bills against, in order:
1. **Initiator** — the session's asker, or the run's `initiated_by`. Bill mine first.
2. **Owner** — the agent's registrant, ONLY if they lent *this* agent their plan (per-agent, default off).
3. **Workspace pool** — an org-shared plan an admin connects.
4. else **fail closed** ("connect your plan"). There is no shared/ambient fallback.

The resolved credential is injected into a private per-run environment, and the runner strips every inherited model-auth var, so a stray host token can never be billed or redirected.

### Plans, not just API keys
- **Claude** plans ride `CLAUDE_CODE_OAUTH_TOKEN` (a `claude setup-token`) through the official CLI.
- **Codex** ChatGPT-plan **logins** are file-delivered: the stored `auth.json` is written into a private per-run `CODEX_HOME`. Because Codex rotates its single-use token in place, the runner persists the refreshed `auth.json` back after each run (the sanctioned "run and persist" pattern), bound to the exact tier + a compare-and-swap so a stale write can't clobber a fresher token.
- Everything runs the provider's OFFICIAL CLI, never a reimplemented client (the invariant that keeps subscription use working and defensible).

### Security
Reviewed adversarially in three focused passes (security/isolation, correctness/lifecycle, data-model). Posture + fixes:
- Per-run, per-owner injection; one asker's token can't bleed into the next session.
- Endpoint authz: personal creds are self-scoped; pool + owner-lend are admin/owner-gated; the agent read/write is bound to a session/run belonging to the calling agent (404 otherwise).
- The refresh `PUT` is run-bound, tier-exact (`source`), `login`-only, compare-and-swap, and shape-validated, so a runtime bearer cannot rewrite a management-owned secret.
- Encrypted at rest (reuses `DERIVE_AUTH_SECRET`); list responses are hints-only; decrypt fails safe (ciphertext is never injected).
- Credentials are purged on account, membership, and workspace deletion.

### Not in this PR (queued)
- Stage 2: one-tap "Connect ChatGPT" device-code flow (replaces pasting `auth.json`).
- Serializing concurrent runs on one shared Codex login (single-use rotation race; sequential runs are safe).

### Deploy
- No new env vars. The runner image must carry no host login (`~/.codex`, `~/.claude`) or baked model token; the env strip is defense in depth on top of that.

### Tests
cli 158, api 1225, db 103, web 188; full tsgo typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
