### PR TITLE
Pin BASE_URL in prod: domain mode needs a fixed app origin

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -216,12 +216,20 @@ custom_domain = true
 pattern = "*.derive.page/*"
 zone_name = "derive.page"
 
-# baseUrl falls back to the request origin when unset. Secured by Better Auth; set
-# DERIVE_AUTH_SECRET via `wrangler secret put`. Cross-instance realtime fan-out uses
-# the ArtifactRoom Durable Object (one room per channel).
+# Secured by Better Auth; set DERIVE_AUTH_SECRET via `wrangler secret put`.
+# Cross-instance realtime fan-out uses the ArtifactRoom Durable Object (one room
+# per channel).
 [vars]
-# DERIVE_SUPERADMIN_EMAILS (operator allow-list) is optional; BASE_URL optional;
+# DERIVE_SUPERADMIN_EMAILS (operator allow-list) is optional;
 # DERIVE_AUTH_SECRET is a secret (`wrangler secret put`). Workspaces are always multi.
+#
+# BASE_URL pins the app origin. It is REQUIRED once DERIVE_SUBDOMAIN_BASE is set:
+# with the per-request-origin fallback, a request on derive.page (or any subdomain)
+# makes appHostForSub equal its own host, so app.ts's domain mode — the apex 301,
+# the unknown-subdomain 404, vanity serving — never engages. Same-origin requests
+# on other hosts (workers.dev smoke tests) stay trusted via auth-config's
+# same-origin rescue; only generated links now always point at derive.to.
+BASE_URL = "https://derive.to"
 #
 # Optional Slack app (all three are secrets; set them to enable Slack, else it stays off):
 #   wrangler secret put SLACK_CLIENT_ID


### PR DESCRIPTION
Follow-up to #532, found verifying it in prod: `/raw/*` correctly 302s to raw.derive.page, but `derive.page` still served the SPA and unknown subdomains returned 200 instead of 404.

Root cause: `worker.ts` falls back to the request origin when `BASE_URL` is unset (`env.BASE_URL ?? new URL(req.url).origin`). Domain mode in `app.ts` starts with `host === appHostForSub → next()` — and with per-request fallback, that's true on **every** host, including derive.page and all its subdomains. The sandbox split worked because it compares against `DERIVE_SANDBOX_URL`, not baseUrl.

Fix: set `BASE_URL = "https://derive.to"` in prod vars — the config already documented this as required once a custom domain is in play (`config.ts:123`).

Auth impact assessed: on derive.to, Better Auth's baseURL already resolved to that exact origin, so nothing changes for real users. Other hosts (workers.dev smoke) keep login working via the same-origin trust rescue in `auth-config.ts`; generated links now always point at derive.to, which is the desired behavior.

After deploy: `derive.page` + www → 301 derive.to; unknown `*.derive.page` → 404; vanity subdomain serving actually works. Config, domains, and auth-origin suites pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787537729&installation_model_id=428097&pr_number=535&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F535&signature=b1b35d2cb95f3909a269714c3e3a591d2da2ce91c7abd1bff9c0f328fbc9f810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->