### PR TITLE
Anonymous drafts: publish before signup — the claim flow

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -235,8 +235,11 @@ export function createApp(deps: AppDeps): Hono {
       // through so an unregistered host pointed at us never serves stale content.
       if (record?.status !== "active") return isSub ? c.text("not found", 404) : next()
       // A claimed draft's old host: unbound from the artifact and left as a signpost
-      // to the artifact's permanent home. Never cache — the target can change again.
-      if (record.redirect_to) return c.redirect(record.redirect_to, 302)
+      // to the artifact's permanent home. no-store because the target can change.
+      if (record.redirect_to) {
+        c.header("Cache-Control", "no-store")
+        return c.redirect(record.redirect_to, 302)
+      }
       if (record.artifact_id) {
         // Artifact-bound host (subdomain today): serve that one artifact at the root.
         const a = await ctx.meta.getArtifactById(record.artifact_id)

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -198,6 +198,13 @@ export function createApp(deps: AppDeps): Hono {
     ) => {
       if (!(await ctx.authorize(c, "read", a))) return c.text("not found", 404)
       if (a.removed_at) return c.text(TOMBSTONE, 410)
+      // Expiring draft (the claim flow): gone the moment its TTL passes — the sweep
+      // is the janitor, this is the fence. Live drafts must never be CDN-cacheable:
+      // their link_role is viewer (cross-origin serving requires it), which would
+      // otherwise earn a year-long immutable cache — an expired-then-swept draft
+      // could outlive itself at the edge.
+      if (a.expires_at && a.expires_at <= new Date().toISOString())
+        return c.text("this draft expired — it was never claimed", 410)
       const version = await ctx.meta.getVersion(a.id, n)
       if (!version) return c.text("not found", 404)
       return serveContent(
@@ -207,7 +214,7 @@ export function createApp(deps: AppDeps): Hono {
         a.title,
         prefix,
         rawPath,
-        cacheControlFor(a.link_role, !!a.password_hash),
+        a.expires_at ? "no-store" : cacheControlFor(a.link_role, !!a.password_hash),
       )
     }
     app.use("*", async (c, next) => {
@@ -227,6 +234,9 @@ export function createApp(deps: AppDeps): Hono {
       // Unknown subdomain → 404 (clearly ours); unknown/pending custom host → fall
       // through so an unregistered host pointed at us never serves stale content.
       if (record?.status !== "active") return isSub ? c.text("not found", 404) : next()
+      // A claimed draft's old host: unbound from the artifact and left as a signpost
+      // to the artifact's permanent home. Never cache — the target can change again.
+      if (record.redirect_to) return c.redirect(record.redirect_to, 302)
       if (record.artifact_id) {
         // Artifact-bound host (subdomain today): serve that one artifact at the root.
         const a = await ctx.meta.getArtifactById(record.artifact_id)
@@ -277,6 +287,10 @@ export function createApp(deps: AppDeps): Hono {
     // Anonymous OAuth client registration (open DCR) gets a tighter per-IP cap on
     // top, so no single source can flood the client table.
     app.use("/api/auth/oauth2/register", ipRateLimit(rateLimiters.oauthRegister))
+    // Anonymous draft mints: the one unauthenticated write that creates durable
+    // state. Registered before the general write limiter so the tighter cap 429s
+    // first (same ordering rationale as authEmail above).
+    app.use("/v1/drafts", ipRateLimit(rateLimiters.draftPublish))
     const writeLimiter = ipRateLimit(rateLimiters.write)
     app.use("/v1/*", (c, next) =>
       c.req.method === "GET" || c.req.method === "HEAD" ? next() : writeLimiter(c, next),
@@ -368,6 +382,7 @@ export function createApp(deps: AppDeps): Hono {
     /^\/v1\/slack\/commands$/, // Slack slash command (/derive) — signing-secret signature is the gate
     /^\/v1\/assets\/t\/[^/]+$/, // MCP-minted upload URL — the signed expiring token is the gate
     /^\/v1\/artifacts\/t\/[^/]+$/, // MCP-minted publish URL (create) — signed token is the gate
+    /^\/v1\/drafts$/, // anonymous draft mint (the claim flow) — anonymous is the point; draftPublish IP cap + publish limiter are the gate
     /^\/v1\/artifacts\/[^/]+\/versions\/t\/[^/]+$/, // MCP-minted publish URL (revise) — signed token is the gate
   ]
   app.use("/v1/*", async (c, next) => {

--- a/apps/api/src/lib/claim-token.ts
+++ b/apps/api/src/lib/claim-token.ts
@@ -1,0 +1,56 @@
+/**
+ * Claim tokens for POST /v1/drafts/claim — the account-less publish → claim flow.
+ *
+ * An anonymous draft is published with no principal at all: nobody owns it, and
+ * the only proof of "this is mine" is possession of the claim URL the publish
+ * response handed back. This token IS that proof — a bearer capability binding
+ * exactly one artifact, spendable by whichever signed-in user presents it first.
+ * That is deliberate (capability, not identity, like publish/upload tokens): the
+ * publisher had no identity to bind, and "whoever holds the link claims it"
+ * matches how the draft itself is shared.
+ *
+ * Scoped tightly all the same:
+ *   - bound to ONE artifact id; a leaked token can't touch anything else.
+ *   - expiry rides the draft's own TTL, so the token dies with the draft.
+ *   - single-use BY STATE, not by signature: the spend path re-checks that the
+ *     artifact still lives in the drafts holding workspace and is unexpired. A
+ *     claimed draft has moved out; a swept draft is gone — either way a replayed
+ *     token finds nothing to spend. (HMAC tokens alone can't be single-use.)
+ *
+ * A thin wrapper over lib/capability-token.ts (which owns the HMAC format, key
+ * caching, and edge-safety notes) with this kind's domain and its one-field
+ * `<artifactId>` payload.
+ */
+import { signCapabilityToken, verifyCapabilityToken } from "./capability-token"
+
+const DOMAIN = "derive-claim-token:"
+
+/**
+ * Sign a claim token.
+ *
+ * @param secret      The DERIVE_AUTH_SECRET / encryptionKey
+ * @param artifactId  The draft artifact this token claims
+ * @param expEpochMs  Expiry as ms since epoch — the draft's own expires_at, so
+ *                    the token can never outlive the draft it claims
+ */
+export const signClaimToken = (
+  secret: string,
+  artifactId: string,
+  expEpochMs: number,
+): Promise<string> => signCapabilityToken(DOMAIN, secret, [artifactId], expEpochMs)
+
+/**
+ * Verify a claim token. Returns the artifact id, or null (bad signature,
+ * malformed, expired). Never throws. The caller MUST still confirm the artifact
+ * is an unexpired draft in the holding workspace — see the single-use note above.
+ */
+export const verifyClaimToken = async (
+  secret: string,
+  token: string,
+  nowMs: number,
+): Promise<{ artifactId: string } | null> => {
+  const claim = await verifyCapabilityToken(DOMAIN, secret, token, nowMs)
+  if (!claim?.rest) return null
+  // Single-field payload: `rest` IS the artifact id.
+  return { artifactId: claim.rest }
+}

--- a/apps/api/src/lib/drafts.ts
+++ b/apps/api/src/lib/drafts.ts
@@ -1,0 +1,53 @@
+import type { MetaStore, SearchIndex } from "@derive/core"
+import { log } from "../log"
+import { deleteArtifactAndUnindex } from "./search"
+
+/**
+ * Anonymous drafts — the account-less publish → claim flow (routes/artifacts.ts
+ * `/v1/drafts`).
+ *
+ * A draft is an ordinary artifact with three twists: it lives in the reserved
+ * holding workspace below, it has no owner at all (author_id null, no member
+ * row — the same state deleteUserData leaves behind), and it carries an
+ * `expires_at`. Claiming moves it into a real workspace and clears the expiry;
+ * the sweep deletes whatever nobody claimed.
+ */
+
+/** The reserved holding workspace every unclaimed draft lives in. A fixed id —
+ *  not a config value — so concurrent mints converge on one row via the
+ *  setWorkspace upsert (the `ws_p_<user>` personal-workspace precedent). No
+ *  human is ever a member; nothing lists it. */
+export const DRAFTS_ORG_ID = "ws_sys_drafts"
+
+/** How long an unclaimed draft lives. 72h: survives a weekend, still a real
+ *  deadline — the expiry is the conversion prompt. */
+export const DRAFT_TTL_MS = 72 * 60 * 60 * 1000
+
+/**
+ * Delete expired drafts: their subdomain rows first (so the host 404s rather
+ * than dangling), then the artifact via the one sanctioned hard-delete helper
+ * (row + FTS + dense vector together). Per-artifact best-effort — one failure
+ * must not strand the rest of the sweep. Returns how many were removed.
+ *
+ * Blob bytes are NOT reclaimed: the store is content-addressed and shared
+ * across artifacts, so real GC needs reference counting (a known, deliberate
+ * gap — see the BlobStore port).
+ */
+export const sweepExpiredDrafts = async (
+  meta: MetaStore,
+  search: Pick<SearchIndex, "unindexArtifact"> | undefined,
+  limit = 500,
+): Promise<number> => {
+  const expired = await meta.listExpiredArtifacts(new Date().toISOString(), limit)
+  let removed = 0
+  for (const a of expired) {
+    try {
+      for (const d of await meta.getArtifactDomains(a.id)) await meta.deleteDomain(d.host, d.org_id)
+      await deleteArtifactAndUnindex(meta, search, a.id, a.org_id)
+      removed++
+    } catch (err) {
+      log.error("draft sweep failed for artifact", { artifact: a.id, err: String(err) })
+    }
+  }
+  return removed
+}

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -62,6 +62,10 @@ export interface RateLimiters {
   /** MCP `ask` — each ask triggers a model run on a context owner's runner, so a
    *  looping agent is the realistic flood. Keyed by the acting human's id. */
   ask: Limiter
+  /** Anonymous draft publishes (POST /v1/drafts) — the one unauthenticated write
+   *  that creates durable state, so it gets its own tight long-window cap on top
+   *  of the general publish limiter. Keyed by IP (there is no principal). */
+  draftPublish: Limiter
 }
 
 /**
@@ -89,6 +93,9 @@ export function inMemoryRateLimiters(
     // 10 asks per minute per acting human: a human-paced agent never sees it; a
     // runaway ask loop does — each ask is a model run on someone's runner.
     ask: inMemoryLimiter(60_000, opts.askRate ?? 10),
+    // 12 anonymous drafts per hour per IP: an agent iterating on a page never sees
+    // it; a bulk-hosting abuser does. The general publish limiter still applies.
+    draftPublish: inMemoryLimiter(3_600_000, 12),
   }
 }
 

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -19,6 +19,7 @@ import { loadLocalEmbedder } from "./embedder-local"
 import { workspacesBlockingDeletion } from "./lib/account"
 import { signupAttributionHook } from "./lib/attribution"
 import { customDomainsFromEnv } from "./lib/cloudflare-saas"
+import { sweepExpiredDrafts } from "./lib/drafts"
 import { buildAuthEmail, emailDeliverySender, logEmailSender, resendEmailSender } from "./lib/email"
 import { makeGithubCommentSender } from "./lib/github-comments"
 import { mountWeb } from "./lib/serve-web"
@@ -424,6 +425,15 @@ void maintain()
 pruneTimer = setInterval(maintain, 24 * 3600_000)
 pruneTimer.unref?.()
 
+// Expired anonymous drafts (the claim flow): swept hourly — the 24h maintenance
+// cadence is too coarse for a 72h TTL. The serve path already 410s an expired
+// draft, so this only reclaims rows; the mint route also sweeps opportunistically.
+const draftSweepTimer = setInterval(
+  () => void sweepExpiredDrafts(meta, search).catch(() => 0),
+  3600_000,
+)
+draftSweepTimer.unref?.()
+
 // Resume any GitHub sync left mid-flight: once on boot (a restart mid-sync) and on a
 // short interval (a self-heal backstop, mirroring the edge cron). The persisted
 // file-map makes resume idempotent, and the runner dedupes already-running loops, so
@@ -495,6 +505,7 @@ const shutdown = makeShutdown({
   clearTimers: () => {
     if (pruneTimer) clearInterval(pruneTimer)
     clearInterval(syncResumeTimer)
+    clearInterval(draftSweepTimer)
   },
   closeStores,
   log,

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -41,7 +41,9 @@ import { afterPublish } from "../lib/after-publish"
 import { authorProfile, resolveHandles, resolveUserBylines } from "../lib/author"
 import { BULK_MAX, BulkSummarySchema, bulkArtifactOp } from "../lib/bulk"
 import { cleanPath, manifestOf } from "../lib/bundle"
+import { signClaimToken, verifyClaimToken } from "../lib/claim-token"
 import { hashPassword, signState, unlockCookie, unlockToken, verifyPassword } from "../lib/crypto"
+import { DRAFT_TTL_MS, DRAFTS_ORG_ID, sweepExpiredDrafts } from "../lib/drafts"
 import {
   EditConflictError,
   type MaterializedEdits,
@@ -476,8 +478,21 @@ export const artifactRoutes = (ctx: AppContext) => {
   const handlePublish = async (
     c: Context,
     shortId?: string,
-    tokenAuth?: { org: string; user: { id: string; name: string | null } },
+    tokenAuth?: {
+      org: string
+      // null = the anonymous draft mint (POST /v1/drafts): no principal exists, so
+      // the artifact is created ownerless — author "anonymous", author_id null, no
+      // member row (the same supported state deleteUserData leaves behind). Only
+      // ever null together with `draft`, and only for a CREATE.
+      user: { id: string; name: string | null } | null
+      // Present on the draft path: forces the draft access shape (link-viewable,
+      // nothing else — the URL is the whole product until it's claimed) and stamps
+      // the expiry. Client-supplied access fields are ignored: an anonymous caller
+      // must not be able to list a draft anywhere or lock it with a password.
+      draft?: { expiresAt: string }
+    },
   ) => {
+    const tokenUser = tokenAuth ? tokenAuth.user : null
     // Republishing a version needs publish rights on that artifact; creating a
     // new one needs publish rights at the workspace level.
     let existing: ArtifactRecord | null = null
@@ -495,8 +510,12 @@ export const artifactRoutes = (ctx: AppContext) => {
       // SAME standing for the bound user, live (revocation-safe). Checking only the
       // seat here would let a workspace editor with a mere viewer share overwrite a
       // private doc — an escalation the authed API forbids.
+      // An anonymous (userless) token can only CREATE — there is no standing to
+      // revise anything, so a userless revise fails closed here.
       const publishOk = tokenAuth
-        ? await authorizeUserStanding(tokenAuth.user.id, "publish", existing)
+        ? tokenUser
+          ? await authorizeUserStanding(tokenUser.id, "publish", existing)
+          : false
         : await authorize(c, "publish", existing)
       if (!publishOk) return fail(c, 403, "forbidden")
       // A GitHub-synced artifact is read-only in Derive: GitHub is the source of
@@ -630,24 +649,35 @@ export const artifactRoutes = (ctx: AppContext) => {
       // drove it and get the artifact URL back in the curl response), so — like a
       // session publish, and unlike the agent `publish` tool — it has no agent
       // principal and fires no "your agent published X" bell to onBehalf.
-      const actor = tokenAuth ? tokenAuth.user : await actingUser(c)
-      const human = tokenAuth ? tokenAuth.user : await actingHuman(c)
-      const onBehalf = tokenAuth ? tokenAuth.user.id : await privateOwnerId(c)
+      const actor = tokenAuth ? tokenUser : await actingUser(c)
+      const human = tokenAuth ? tokenUser : await actingHuman(c)
+      const onBehalf = tokenAuth ? (tokenUser?.id ?? null) : await privateOwnerId(c)
       const agentPrincipal = tokenAuth ? null : await agentFor(c)
       // Access is set-on-create: a republish never re-stamps it (publish() only adds a
       // version). On a NEW artifact each field resolves independently — explicit request
       // field > legacy `visibility` mapping > the workspace default (factory default is
       // the "team draft": workspace_access=member, link_role=none, listed=none). One
       // org-settings read covers all three defaults.
-      const settings = !shortId ? await meta.getOrgSettings(org) : null
+      // A draft's access shape is fixed, never client-resolved: the URL is the only
+      // grant (link-viewer), it surfaces nowhere, and the holding workspace's members
+      // get nothing. Cross-origin serving on the usercontent host REQUIRES the viewer
+      // link (the actor there is anonymous), so this is the product shape, not a default.
+      const draft = tokenAuth?.draft
+      const settings = !shortId && !draft ? await meta.getOrgSettings(org) : null
       const resolvedWorkspaceAccess = !shortId
-        ? (workspaceAccess ?? legacy?.workspace_access ?? settings?.defaultWorkspaceAccess)
+        ? draft
+          ? "none"
+          : (workspaceAccess ?? legacy?.workspace_access ?? settings?.defaultWorkspaceAccess)
         : undefined
       const resolvedLinkRole = !shortId
-        ? (linkRole ?? legacy?.link_role ?? settings?.defaultLinkRole)
+        ? draft
+          ? "viewer"
+          : (linkRole ?? legacy?.link_role ?? settings?.defaultLinkRole)
         : undefined
       const resolvedListed = !shortId
-        ? (listed ?? legacy?.listed ?? settings?.defaultListed)
+        ? draft
+          ? "none"
+          : (listed ?? legacy?.listed ?? settings?.defaultListed)
         : undefined
       // The only cross-field invariants are the two listing preconditions: a doc can't
       // be listed somewhere it grants no access to. Explicit contradictions are rejected,
@@ -659,7 +689,7 @@ export const artifactRoutes = (ctx: AppContext) => {
       // A password locks the world link; a lock with no link is meaningless, so it only
       // takes when link_role != none.
       const passwordHash =
-        resolvedLinkRole && resolvedLinkRole !== "none" && password
+        resolvedLinkRole && resolvedLinkRole !== "none" && password && !draft
           ? hashPassword(password)
           : undefined
       const { artifact, version } = await publish(
@@ -683,19 +713,20 @@ export const artifactRoutes = (ctx: AppContext) => {
           // uses their name and never the client `author` field — otherwise a caller
           // could stamp an arbitrary byline whenever that user's stored name is null.
           author: tokenAuth
-            ? (tokenAuth.user.name ?? undefined)
+            ? (tokenUser?.name ?? undefined)
             : (human?.name ?? actor?.name ?? str(body["author"])),
           authorId: onBehalf,
           // The surface stamp: a stage_publish token IS the MCP flow's upload leg, an
           // agent principal (OAuth bearer / dk_agt_ token, incl. the CLI) is the API,
           // and a plain session publish is the web app.
-          source: tokenAuth ? "mcp" : agentPrincipal ? "api" : "web",
+          source: tokenAuth ? (draft ? "api" : "mcp") : agentPrincipal ? "api" : "web",
           name: str(body["name"]),
           orgId: org,
           workspaceAccess: resolvedWorkspaceAccess,
           passwordHash,
           linkRole: resolvedLinkRole,
           listed: resolvedListed,
+          expiresAt: draft?.expiresAt,
         },
         shortId,
       )
@@ -941,6 +972,153 @@ export const artifactRoutes = (ctx: AppContext) => {
   app.post("/v1/artifacts/:shortId/versions/t/:token", (c) =>
     tokenPublish(c, c.req.param("shortId")),
   )
+
+  // ---- Anonymous drafts: publish before signup (the claim flow) ------------
+  // The account-less front door: any agent POSTs a file with no credentials and
+  // gets back a live expiring page on the usercontent domain plus a claim URL.
+  // The agent finishes the user's request FIRST; signing up happens after, on
+  // the claim page, where the loop (versions, comments, review) lights up.
+  //
+  // A draft is an ordinary artifact with no owner, held in DRAFTS_ORG_ID with an
+  // expires_at (see lib/drafts.ts). It is link-viewable and nothing else — the
+  // secret URL is the whole grant — and it serves ONLY on the usercontent host,
+  // never the app origin.
+
+  // authz-exempt: anonymous draft mint — anonymous is the point; the draftPublish
+  // IP cap + the publish limiter (ip-keyed for an actorless caller) + the
+  // ANON_WRITE_ALLOW entry in app.ts bound it.
+  app.post("/v1/drafts", async (c) => {
+    // Both halves of the product need config: the usercontent host to serve on,
+    // and the signing secret for the claim capability. Absent either, be honest.
+    if (!deps.subdomainBase || !deps.encryptionKey)
+      return fail(c, 501, "anonymous drafts need DERIVE_SUBDOMAIN_BASE and DERIVE_AUTH_SECRET")
+    // Idempotent upsert: the holding workspace exists from the first mint onward.
+    await meta.setWorkspace(DRAFTS_ORG_ID, "Anonymous drafts")
+    const expiresAt = new Date(Date.now() + DRAFT_TTL_MS).toISOString()
+    const res = await handlePublish(c, undefined, {
+      org: DRAFTS_ORG_ID,
+      user: null,
+      draft: { expiresAt },
+    })
+    if (res.status !== 201) return res
+    const created = (await res.json()) as { short_id: string; title: string | null }
+    const artifact = await meta.getByShortId(created.short_id)
+    if (!artifact) return fail(c, 500, "draft vanished after publish")
+    // The draft's home: <short_id>.<base>. The short id is random and fresh, so a
+    // host collision means only that an earlier row leaked — mint-and-move-on is
+    // not needed; fall back to the tokened raw URL shape rather than failing the
+    // publish that already succeeded.
+    const host = `${artifact.short_id}.${deps.subdomainBase}`.toLowerCase()
+    const bound = await meta.setDomain({
+      host,
+      artifact_id: artifact.id,
+      org_id: DRAFTS_ORG_ID,
+      kind: "subdomain",
+      status: "active",
+    })
+    const draftUrl = bound
+      ? `https://${host}/`
+      : `${deps.sandboxOrigin ?? deps.baseUrl}/raw/${artifact.short_id}/v/1/index.html`
+    const claimToken = await signClaimToken(deps.encryptionKey, artifact.id, Date.parse(expiresAt))
+    // Opportunistic sweep, the OAuth-reaper pattern: each mint reaps earlier
+    // expired drafts, best-effort and off the response path. This is the ONLY
+    // sweep the (cron-less-for-pg) edge tier gets; Node also runs an hourly
+    // timer, and the serve path 410s expired drafts regardless.
+    await background(sweepExpiredDrafts(meta, search))
+    return c.json(
+      {
+        short_id: artifact.short_id,
+        title: created.title,
+        draft_url: draftUrl,
+        // The conversion handle: opening this signed URL (sign in, pick a
+        // workspace) moves the draft into that workspace for good.
+        claim_url: `${deps.baseUrl}/claim/${claimToken}`,
+        expires_at: expiresAt,
+      },
+      201,
+    )
+  })
+
+  // The claim page's read: what am I about to claim? Public — the token itself is
+  // the proof of standing, exactly like the mint that produced it.
+  app.get("/v1/drafts/claim/:token", async (c) => {
+    if (!deps.encryptionKey) return fail(c, 501, "drafts are not configured")
+    const v = await verifyClaimToken(deps.encryptionKey, c.req.param("token"), Date.now())
+    if (!v) return fail(c, 404, "invalid or expired claim link")
+    const a = await meta.getArtifactById(v.artifactId)
+    if (!a) return fail(c, 410, "this draft expired and was removed")
+    if (a.org_id !== DRAFTS_ORG_ID || !a.expires_at)
+      return fail(c, 410, "this draft was already claimed")
+    if (a.expires_at <= new Date().toISOString()) return fail(c, 410, "this draft expired")
+    const bound = (await meta.getArtifactDomains(a.id))[0]
+    return c.json({
+      short_id: a.short_id,
+      title: a.title,
+      kind: a.kind,
+      expires_at: a.expires_at,
+      draft_url: bound ? `https://${bound.host}/` : null,
+    })
+  })
+
+  // Spend the claim: move the draft into the signed-in caller's active workspace.
+  // Requires a principal (not in ANON_WRITE_ALLOW — the global anonymous-write
+  // lockdown already refuses this route to anonymous callers before it runs).
+  app.post("/v1/drafts/claim", async (c) => {
+    if (!deps.encryptionKey) return fail(c, 501, "drafts are not configured")
+    const me = await currentUser(c)
+    if (!me) return fail(c, 401, "sign in to claim a draft")
+    const b = await readJson(c, z.object({ token: z.string().max(2048) }))
+    if (b instanceof Response) return b
+    const v = await verifyClaimToken(deps.encryptionKey, b.token, Date.now())
+    if (!v) return fail(c, 404, "invalid or expired claim link")
+    const a = await meta.getArtifactById(v.artifactId)
+    if (!a) return fail(c, 410, "this draft expired and was removed")
+    // Single-use by state: once claimed the draft has left the holding workspace,
+    // so a replayed token finds nothing to spend. Two racing claims on the same
+    // secret link can interleave; the loser's move is overwritten — bounded to
+    // holders of the same claim URL, which is the capability anyway.
+    if (a.org_id !== DRAFTS_ORG_ID || !a.expires_at)
+      return fail(c, 410, "this draft was already claimed")
+    if (a.expires_at <= new Date().toISOString()) return fail(c, 410, "this draft expired")
+    const org = await activeWorkspace(c)
+    if (!(await workspaceCan(c, "publish")))
+      return fail(c, 403, "you need publish rights in this workspace to claim a draft")
+    const url = artifactUrl(deps.baseUrl, a)
+    // Order matters: the host must be unbound before the org move (the move path
+    // refuses to relocate a domain-bound artifact), and the signpost keeps the
+    // shared draft URL alive as a 302 to the artifact's permanent home.
+    for (const d of await meta.getArtifactDomains(a.id))
+      await meta.updateDomain(d.host, { artifact_id: null, redirect_to: url })
+    await meta.moveArtifactOrg(a.id, org)
+    await meta.setArtifactExpiry(a.id, null)
+    // The claimed artifact lands as the workspace's own default (the team draft),
+    // shedding the draft's link-viewable shape — sharing wider stays a human act.
+    const settings = await meta.getOrgSettings(org)
+    await meta.setAccess(
+      a.id,
+      settings.defaultWorkspaceAccess,
+      settings.defaultListed,
+      settings.defaultLinkRole,
+      null,
+    )
+    await meta.setArtifactMember({
+      id: newId("am"),
+      artifact_id: a.id,
+      user_id: me.id,
+      role: "owner",
+    })
+    // moveArtifactOrg re-scopes the FTS row; the dense vector lives outside the DB,
+    // so re-embed under the new org (same recipe as the move route). Best-effort.
+    if (search) {
+      try {
+        const ver = await meta.getVersion(a.id, a.current_version)
+        if (ver) await indexArtifactVersion(meta, blobs, { ...a, org_id: org }, ver, search)
+      } catch (err) {
+        log.error("dense re-index after claim failed", { artifact: a.id, err: String(err) })
+      }
+    }
+    return c.json({ short_id: a.short_id, url, org_id: org })
+  })
 
   // Registered BEFORE GET /v1/artifacts/{shortId} below: Hono's router matches
   // routes in REGISTRATION order, not by static-vs-param specificity, so

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -974,10 +974,9 @@ export const artifactRoutes = (ctx: AppContext) => {
   )
 
   // ---- Anonymous drafts: publish before signup (the claim flow) ------------
-  // The account-less front door: any agent POSTs a file with no credentials and
-  // gets back a live expiring page on the usercontent domain plus a claim URL.
-  // The agent finishes the user's request FIRST; signing up happens after, on
-  // the claim page, where the loop (versions, comments, review) lights up.
+  // POST /v1/drafts takes a file with no credentials and returns a live expiring
+  // page on the usercontent domain plus a claim URL; claiming (below) moves the
+  // draft into a real workspace.
   //
   // A draft is an ordinary artifact with no owner, held in DRAFTS_ORG_ID with an
   // expires_at (see lib/drafts.ts). It is link-viewable and nothing else — the
@@ -988,8 +987,7 @@ export const artifactRoutes = (ctx: AppContext) => {
   // IP cap + the publish limiter (ip-keyed for an actorless caller) + the
   // ANON_WRITE_ALLOW entry in app.ts bound it.
   app.post("/v1/drafts", async (c) => {
-    // Both halves of the product need config: the usercontent host to serve on,
-    // and the signing secret for the claim capability. Absent either, be honest.
+    // Serving needs the usercontent host; the claim URL needs the signing secret.
     if (!deps.subdomainBase || !deps.encryptionKey)
       return fail(c, 501, "anonymous drafts need DERIVE_SUBDOMAIN_BASE and DERIVE_AUTH_SECRET")
     // Idempotent upsert: the holding workspace exists from the first mint onward.
@@ -1001,13 +999,13 @@ export const artifactRoutes = (ctx: AppContext) => {
       draft: { expiresAt },
     })
     if (res.status !== 201) return res
-    const created = (await res.json()) as { short_id: string; title: string | null }
+    const created = (await res.json()) as { short_id: string }
     const artifact = await meta.getByShortId(created.short_id)
     if (!artifact) return fail(c, 500, "draft vanished after publish")
-    // The draft's home: <short_id>.<base>. The short id is random and fresh, so a
-    // host collision means only that an earlier row leaked — mint-and-move-on is
-    // not needed; fall back to the tokened raw URL shape rather than failing the
-    // publish that already succeeded.
+    // The draft's home: <short_id>.<base>. The short id is fresh and globally
+    // unique, so setDomain's insert-only conflict path is effectively unreachable;
+    // if it fires anyway, degrade to the raw URL (documented in llms.txt) rather
+    // than failing a publish that already succeeded.
     const host = `${artifact.short_id}.${deps.subdomainBase}`.toLowerCase()
     const bound = await meta.setDomain({
       host,
@@ -1021,17 +1019,16 @@ export const artifactRoutes = (ctx: AppContext) => {
       : `${deps.sandboxOrigin ?? deps.baseUrl}/raw/${artifact.short_id}/v/1/index.html`
     const claimToken = await signClaimToken(deps.encryptionKey, artifact.id, Date.parse(expiresAt))
     // Opportunistic sweep, the OAuth-reaper pattern: each mint reaps earlier
-    // expired drafts, best-effort and off the response path. This is the ONLY
-    // sweep the (cron-less-for-pg) edge tier gets; Node also runs an hourly
-    // timer, and the serve path 410s expired drafts regardless.
+    // expired drafts. This is the ONLY sweep the edge tier gets (its cron has no
+    // pg binding); on Workers it rides waitUntil, on Node background() awaits
+    // inline — one indexed SELECT when nothing has expired, and the hourly timer
+    // there does the real work. The serve path 410s expired drafts regardless.
     await background(sweepExpiredDrafts(meta, search))
     return c.json(
       {
         short_id: artifact.short_id,
-        title: created.title,
+        title: artifact.title,
         draft_url: draftUrl,
-        // The conversion handle: opening this signed URL (sign in, pick a
-        // workspace) moves the draft into that workspace for good.
         claim_url: `${deps.baseUrl}/claim/${claimToken}`,
         expires_at: expiresAt,
       },

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -282,6 +282,10 @@ const handle = (req: Request, env: Env, ctx: ExecutionContext): Response | Promi
           // Rides the comment binding, namespaced — same order of magnitude of
           // legitimate use, but its count must not share the comment budget.
           ask: nativeLimiter(env.RL_COMMENT, 60, "ask"),
+          // Anonymous draft mints ride RL_STRICT (tight), namespaced from the other
+          // strict surfaces. The 60s native window is tighter-per-minute than the
+          // in-process hourly cap; both bound the same abuse.
+          draftPublish: nativeLimiter(env.RL_STRICT, 60, "draft-publish"),
         },
         // Deliver freshly enqueued events now: poke the outbox DO so its alarm fires,
         // riding waitUntil so the subrequest isn't cancelled when the response is sent.

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -282,9 +282,9 @@ const handle = (req: Request, env: Env, ctx: ExecutionContext): Response | Promi
           // Rides the comment binding, namespaced — same order of magnitude of
           // legitimate use, but its count must not share the comment budget.
           ask: nativeLimiter(env.RL_COMMENT, 60, "ask"),
-          // Anonymous draft mints ride RL_STRICT (tight), namespaced from the other
-          // strict surfaces. The 60s native window is tighter-per-minute than the
-          // in-process hourly cap; both bound the same abuse.
+          // Anonymous draft mints ride RL_STRICT (3/60s), namespaced from the other
+          // strict surfaces. Native periods cap at 60s, so the in-process tier's
+          // hour-long window can't be expressed here; the burst cap is the bound.
           draftPublish: nativeLimiter(env.RL_STRICT, 60, "draft-publish"),
         },
         // Deliver freshly enqueued events now: poke the outbox DO so its alarm fires,

--- a/apps/api/test/drafts.test.ts
+++ b/apps/api/test/drafts.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest"
+import { sweepExpiredDrafts } from "../src/lib/drafts"
+import { as, makeAuthedApp } from "./helpers"
+
+// Anonymous drafts — the account-less publish → claim flow. An agent with no
+// credentials POSTs a file, gets a live expiring page on the usercontent domain
+// plus a claim URL; a signed-in human spends the claim to pull the draft into
+// their workspace. These run against a fake-auth app so both the anonymous mint
+// (no x-test-user header) and the signed-in claim are exercised for real.
+const BASE = "drafts.test"
+const SECRET = "0".repeat(64)
+const { app: drafts, meta } = makeAuthedApp(
+  "drafts",
+  [{ id: "u_alice", email: "alice@x.test", name: "Alice" }],
+  undefined,
+  { deps: { subdomainBase: BASE, encryptionKey: SECRET } },
+)
+
+const mint = async (content: string, extra: Record<string, string> = {}) => {
+  const form = new FormData()
+  form.append("file", new Blob([new TextEncoder().encode(content)]), "page.html")
+  for (const [k, v] of Object.entries(extra)) form.append(k, v)
+  return drafts.request("/v1/drafts", { method: "POST", body: form })
+}
+
+describe("POST /v1/drafts (anonymous mint)", () => {
+  it("publishes an expiring draft with a live subdomain URL and a claim URL", async () => {
+    const res = await mint("<h1>Hello draft</h1>")
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.short_id).toBeTruthy()
+    expect(body.draft_url).toBe(`https://${body.short_id}.${BASE}/`)
+    expect(body.claim_url).toContain("http://derive.test/claim/")
+    // ~72h out, ISO.
+    const ttlMs = Date.parse(body.expires_at) - Date.now()
+    expect(ttlMs).toBeGreaterThan(71 * 3600_000)
+    expect(ttlMs).toBeLessThan(73 * 3600_000)
+
+    // Live on its own host, never CDN-cacheable.
+    const served = await drafts.request(`http://${body.short_id}.${BASE}/`)
+    expect(served.status).toBe(200)
+    expect(await served.text()).toContain("Hello draft")
+    expect(served.headers.get("cache-control")).toBe("no-store")
+  })
+
+  it("forces the draft access shape — client access fields are ignored", async () => {
+    const res = await mint("<p>sneaky</p>", {
+      listed: "public",
+      workspace_access: "member",
+      link_role: "editor",
+      password: "hunter2",
+    })
+    expect(res.status).toBe(201)
+    const { short_id } = await res.json()
+    const a = await meta.getByShortId(short_id)
+    expect(a?.org_id).toBe("ws_sys_drafts")
+    expect(a?.workspace_access).toBe("none")
+    expect(a?.link_role).toBe("viewer")
+    expect(a?.listed).toBe("none")
+    expect(a?.password_hash).toBeNull()
+    expect(a?.expires_at).toBeTruthy()
+    // Ownerless: no author, no member row.
+    expect(a?.author_id ?? null).toBeNull()
+  })
+
+  it("410s an expired draft at its host instead of serving stale bytes", async () => {
+    const res = await mint("<p>old</p>")
+    const { short_id } = await res.json()
+    const a = await meta.getByShortId(short_id)
+    if (!a) throw new Error("draft missing")
+    await meta.setArtifactExpiry(a.id, new Date(Date.now() - 1000).toISOString())
+    const served = await drafts.request(`http://${short_id}.${BASE}/`)
+    expect(served.status).toBe(410)
+  })
+})
+
+describe("the claim flow", () => {
+  const mintAndToken = async () => {
+    const res = await mint("<h1>Claim me</h1>")
+    const body = await res.json()
+    return { ...body, token: (body.claim_url as string).split("/claim/")[1] }
+  }
+
+  it("describes the draft to the claim page (public read)", async () => {
+    const { token, short_id } = await mintAndToken()
+    const info = await drafts.request(`/v1/drafts/claim/${token}`)
+    expect(info.status).toBe(200)
+    const j = await info.json()
+    expect(j.short_id).toBe(short_id)
+    expect(j.draft_url).toBe(`https://${short_id}.${BASE}/`)
+  })
+
+  it("refuses an anonymous claim at the door", async () => {
+    const { token } = await mintAndToken()
+    const res = await drafts.request("/v1/drafts/claim", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token }),
+    })
+    // The global anonymous-write lockdown: /v1/drafts/claim is not allow-listed.
+    expect(res.status).toBe(403)
+  })
+
+  it("moves the draft into the claimer's workspace and signposts the old host", async () => {
+    const { token, short_id } = await mintAndToken()
+    const res = await drafts.request("/v1/drafts/claim", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...as("alice@x.test") },
+      body: JSON.stringify({ token }),
+    })
+    expect(res.status).toBe(200)
+    const j = await res.json()
+    expect(j.org_id).toBe("default")
+    expect(j.url).toContain(short_id)
+
+    const a = await meta.getByShortId(short_id)
+    expect(a?.org_id).toBe("default")
+    expect(a?.expires_at).toBeNull()
+    // Sheds the draft shape for the workspace default (team draft).
+    expect(a?.link_role).toBe("none")
+    expect(a?.workspace_access).toBe("member")
+    // Ownership landed.
+    if (!a) throw new Error("artifact missing")
+    const members = await meta.listArtifactMembers(a.id)
+    expect(members.some((m) => m.user_id === "u_alice" && m.role === "owner")).toBe(true)
+
+    // The shared draft URL survives as a signpost to the permanent home.
+    const redirected = await drafts.request(`http://${short_id}.${BASE}/`, { redirect: "manual" })
+    expect(redirected.status).toBe(302)
+    expect(redirected.headers.get("location")).toBe(j.url)
+
+    // Single-use by state: a replayed token finds nothing to spend.
+    const replay = await drafts.request("/v1/drafts/claim", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...as("alice@x.test") },
+      body: JSON.stringify({ token }),
+    })
+    expect(replay.status).toBe(410)
+  })
+
+  it("410s a claim on an expired draft", async () => {
+    const { token, short_id } = await mintAndToken()
+    const a = await meta.getByShortId(short_id)
+    if (!a) throw new Error("draft missing")
+    await meta.setArtifactExpiry(a.id, new Date(Date.now() - 1000).toISOString())
+    const res = await drafts.request("/v1/drafts/claim", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...as("alice@x.test") },
+      body: JSON.stringify({ token }),
+    })
+    expect(res.status).toBe(410)
+  })
+})
+
+describe("the sweep", () => {
+  it("deletes expired drafts and their subdomain rows; leaves live ones", async () => {
+    const dead = await (await mint("<p>doomed</p>")).json()
+    const alive = await (await mint("<p>fine</p>")).json()
+    const deadArt = await meta.getByShortId(dead.short_id)
+    if (!deadArt) throw new Error("draft missing")
+    await meta.setArtifactExpiry(deadArt.id, new Date(Date.now() - 1000).toISOString())
+
+    const removed = await sweepExpiredDrafts(meta, undefined)
+    expect(removed).toBeGreaterThanOrEqual(1)
+    expect(await meta.getByShortId(dead.short_id)).toBeNull()
+    expect(await meta.getDomain(`${dead.short_id}.${BASE}`)).toBeNull()
+    expect(await meta.getByShortId(alive.short_id)).not.toBeNull()
+    expect(await meta.getDomain(`${alive.short_id}.${BASE}`)).not.toBeNull()
+  })
+})

--- a/apps/api/test/drafts.test.ts
+++ b/apps/api/test/drafts.test.ts
@@ -128,6 +128,7 @@ describe("the claim flow", () => {
     const redirected = await drafts.request(`http://${short_id}.${BASE}/`, { redirect: "manual" })
     expect(redirected.status).toBe(302)
     expect(redirected.headers.get("location")).toBe(j.url)
+    expect(redirected.headers.get("cache-control")).toBe("no-store")
 
     // Single-use by state: a replayed token finds nothing to spend.
     const replay = await drafts.request("/v1/drafts/claim", {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -118,6 +118,16 @@ export type InviteResult = components["schemas"]["InviteResult"]
 export type InvitePreview = components["schemas"]["InvitePreview"]
 export type ArtifactInvite = components["schemas"]["ArtifactInvite"]
 export type ArtifactInvitePreview = components["schemas"]["ArtifactInvitePreview"]
+/** What the claim page shows before an anonymous draft is claimed. Hand-declared:
+ *  the draft-claim routes aren't in the OpenAPI spec. */
+export interface DraftClaimPreview {
+  short_id: string
+  title: string | null
+  kind: string
+  expires_at: string
+  /** The live expiring page on the usercontent domain; null if no host is bound. */
+  draft_url: string | null
+}
 /** PUT members result: shared directly (existing account) or invited by email. */
 export type ShareResult = components["schemas"]["ShareResult"]
 /** Per-workspace integration switches. Generated from the OpenAPI spec. */
@@ -651,6 +661,14 @@ export const api = {
     f(`/v1/artifacts/${id}/members/${userId}`, { method: "DELETE", credentials: "include" }).then(
       () => undefined,
     ),
+
+  // The draft-claim page (/claim/$token): an agent published an anonymous expiring
+  // draft and handed the human a claim link. Preview is public — the token itself
+  // is the proof of standing; claiming moves the draft into the active workspace.
+  previewDraftClaim: (token: string): Promise<DraftClaimPreview> =>
+    f(`/v1/drafts/claim/${encodeURIComponent(token)}`, opts()).then(j),
+  claimDraft: (token: string): Promise<{ short_id: string; url: string; org_id: string }> =>
+    f("/v1/drafts/claim", opts({ token })).then(j),
 
   // Per-artifact vanity subdomains (`base` null when off) + the workspace's custom
   // domains shown read-only as the artifact's URL on each.

--- a/apps/web/src/lib/time.test.ts
+++ b/apps/web/src/lib/time.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { ago } from "./time"
+import { ago, until } from "./time"
 
 // `ago` reads Date.now(), so pin the clock and feed ISO timestamps at known offsets.
 const NOW = new Date("2026-06-14T12:00:00.000Z")
@@ -26,5 +26,26 @@ describe("ago", () => {
     vi.useFakeTimers()
     vi.setSystemTime(NOW)
     expect(ago(new Date(NOW.getTime() + 60_000).toISOString())).toBe("just now")
+  })
+})
+
+describe("until", () => {
+  afterEach(() => vi.useRealTimers())
+
+  const at = (ms: number) => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    return until(new Date(NOW.getTime() + ms).toISOString())
+  }
+
+  it("renders each bucket", () => {
+    expect(at(30_000)).toBe("under a minute")
+    expect(at(5 * 60_000)).toBe("5m")
+    expect(at(3 * 3600_000)).toBe("3h")
+    expect(at(2 * 86400_000)).toBe("2d")
+  })
+
+  it("clamps a past deadline to 'under a minute' (no negative)", () => {
+    expect(at(-60_000)).toBe("under a minute")
   })
 })

--- a/apps/web/src/lib/time.ts
+++ b/apps/web/src/lib/time.ts
@@ -8,6 +8,17 @@ export const ago = (iso: string): string => {
   return `${Math.floor(s / 86400)}d ago`
 }
 
+// Future-facing counterpart for deadlines (the draft-claim page's "Expires in 2d"):
+// "under a minute", "5m", "3h", "2d". Callers supply the surrounding words, so the
+// buckets stay reusable across phrasings.
+export const until = (iso: string): string => {
+  const s = Math.max(0, (new Date(iso).getTime() - Date.now()) / 1000)
+  if (s < 60) return "under a minute"
+  if (s < 3600) return `${Math.floor(s / 60)}m`
+  if (s < 86400) return `${Math.floor(s / 3600)}h`
+  return `${Math.floor(s / 86400)}d`
+}
+
 // Terse variant for dense repeated rows (the comment thread): "now", "5m", "3h",
 // "2d" — "ago" is noise multiplied by every row. Pair with a title attr carrying
 // the full date, so precision is a hover away.

--- a/apps/web/src/pages/claim-draft.tsx
+++ b/apps/web/src/pages/claim-draft.tsx
@@ -1,0 +1,154 @@
+import { useQuery } from "@tanstack/react-query"
+import { getRouteApi, useNavigate } from "@tanstack/react-router"
+import { ApiError, api } from "@/api"
+import { Logo } from "@/components/shared/logo"
+import { Spinner } from "@/components/shared/spinner"
+import { StatusPanel } from "@/components/shared/status-panel"
+import { Button } from "@/components/ui/button"
+import { useAuth } from "@/ctx"
+import { workspaceQuery } from "@/lib/queries"
+import { until } from "@/lib/time"
+import { useApiMutation } from "@/lib/use-api-mutation"
+import { useDocumentTitle } from "@/lib/use-document-title"
+
+const route = getRouteApi("/claim/$token")
+
+// The calm chrome-less shell shared with /login and /invite/$token.
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-dvh flex-col bg-card dark:bg-background">
+      <main className="flex flex-1 items-center justify-center px-6 py-12">
+        <div className="flex w-full max-w-sm flex-col items-center gap-8 text-center">
+          <div className="flex items-center gap-2">
+            <Logo size={26} />
+            <span className="font-serif text-lg font-medium tracking-tight">Derive</span>
+          </div>
+          {children}
+        </div>
+      </main>
+    </div>
+  )
+}
+
+// Redeem an anonymous-draft claim link: an agent published an expiring draft with
+// no account behind it and handed the human this URL. Show what the draft is, then
+// (behind sign-in) move it into the claimant's active workspace and land on it.
+export function ClaimDraft() {
+  useDocumentTitle("Claim draft")
+  const { token } = route.useParams()
+  const { me, loading } = useAuth()
+  const nav = useNavigate()
+
+  const {
+    data: preview,
+    isPending,
+    error,
+  } = useQuery({
+    queryKey: ["draft-claim", token],
+    queryFn: () => api.previewDraftClaim(token),
+    retry: false,
+    // Keyed by the claim token (a capability secret) — never write it to IndexedDB.
+    meta: { persist: false },
+  })
+
+  // Only fetched to name the destination on the button; needs a session.
+  const { data: workspace } = useQuery({ ...workspaceQuery(), enabled: !!me })
+
+  const claimMut = useApiMutation({
+    mutationFn: () => api.claimDraft(token),
+    errorToast: false,
+    // The claimed artifact lands in the library — reconcile the lists + rail counts.
+    invalidate: [["artifacts"], ["summary"]],
+    onSuccess: (r) => nav({ to: "/artifacts/$ref", params: { ref: r.short_id } }),
+    // A session that lapsed between load and click: finish sign-in, then return here.
+    onError: (err) => {
+      if (err instanceof ApiError && err.status === 401)
+        nav({ to: "/login", search: { return_to: `/claim/${token}` } })
+    },
+  })
+  const claim = () => {
+    // Not signed in → send them to sign in, returning here to finish.
+    if (!me) {
+      nav({ to: "/login", search: { return_to: `/claim/${token}` } })
+      return
+    }
+    claimMut.mutate()
+  }
+
+  if (isPending || loading)
+    return (
+      <Shell>
+        <Spinner />
+      </Shell>
+    )
+
+  // 404 (bad/expired token) and 410 (expired / already claimed) carry user-facing
+  // messages from the API — surface them verbatim rather than a generic apology.
+  if (error || !preview)
+    return (
+      <Shell>
+        <StatusPanel
+          tone="danger"
+          title="This draft can't be claimed"
+          description={
+            error instanceof ApiError ? error.message : "The claim link is invalid or has expired."
+          }
+        />
+        <Button variant="outline" data-testid="claim-go-home" onClick={() => nav({ to: "/" })}>
+          Go to Derive
+        </Button>
+      </Shell>
+    )
+
+  const err = claimMut.error?.message ?? ""
+  return (
+    <Shell>
+      <div className="flex flex-col gap-2">
+        <h1 className="font-serif text-2xl font-medium tracking-tight text-balance text-foreground">
+          Claim this draft
+        </h1>
+        <p className="text-sm text-pretty text-muted-foreground">
+          An agent published{" "}
+          <span className="font-medium text-foreground">{preview.title || "Untitled draft"}</span>{" "}
+          as an expiring draft. Claim it to keep it — versions, comments, and sharing included.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          {preview.draft_url && (
+            <>
+              <a
+                href={preview.draft_url}
+                target="_blank"
+                rel="noreferrer"
+                className="font-medium text-foreground underline underline-offset-4 transition-colors hover:text-muted-foreground"
+              >
+                Open the live draft
+              </a>
+              {" · "}
+            </>
+          )}
+          <span title={new Date(preview.expires_at).toLocaleString()}>
+            expires in {until(preview.expires_at)}
+          </span>
+        </p>
+      </div>
+      {err && (
+        <div data-testid="claim-error" className="w-full">
+          <StatusPanel tone="danger" layout="inline" title={err} />
+        </div>
+      )}
+      <Button
+        data-testid="claim-accept"
+        size="lg"
+        className="w-full"
+        loading={claimMut.isPending}
+        onClick={claim}
+      >
+        {me
+          ? claimMut.isPending
+            ? "Claiming…"
+            : `Claim into ${workspace?.name ?? "your workspace"}`
+          : "Sign in to claim"}
+      </Button>
+    </Shell>
+  )
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -31,6 +31,7 @@ import { Route as UsersHandleRouteImport } from './routes/users.$handle'
 import { Route as SettingsSectionRouteImport } from './routes/settings.$section'
 import { Route as InviteTokenRouteImport } from './routes/invite.$token'
 import { Route as ContextsIdRouteImport } from './routes/contexts.$id'
+import { Route as ClaimTokenRouteImport } from './routes/claim.$token'
 import { Route as ArtifactsRefRouteImport } from './routes/artifacts.$ref'
 import { Route as InviteATokenRouteImport } from './routes/invite.a.$token'
 
@@ -144,6 +145,11 @@ const ContextsIdRoute = ContextsIdRouteImport.update({
   path: '/contexts/$id',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ClaimTokenRoute = ClaimTokenRouteImport.update({
+  id: '/claim/$token',
+  path: '/claim/$token',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ArtifactsRefRoute = ArtifactsRefRouteImport.update({
   id: '/artifacts/$ref',
   path: '/artifacts/$ref',
@@ -173,6 +179,7 @@ export interface FileRoutesByFullPath {
   '/unlisted': typeof UnlistedRoute
   '/welcome': typeof WelcomeRoute
   '/artifacts/$ref': typeof ArtifactsRefRoute
+  '/claim/$token': typeof ClaimTokenRoute
   '/contexts/$id': typeof ContextsIdRoute
   '/invite/$token': typeof InviteTokenRoute
   '/settings/$section': typeof SettingsSectionRoute
@@ -198,6 +205,7 @@ export interface FileRoutesByTo {
   '/unlisted': typeof UnlistedRoute
   '/welcome': typeof WelcomeRoute
   '/artifacts/$ref': typeof ArtifactsRefRoute
+  '/claim/$token': typeof ClaimTokenRoute
   '/contexts/$id': typeof ContextsIdRoute
   '/invite/$token': typeof InviteTokenRoute
   '/settings/$section': typeof SettingsSectionRoute
@@ -225,6 +233,7 @@ export interface FileRoutesById {
   '/unlisted': typeof UnlistedRoute
   '/welcome': typeof WelcomeRoute
   '/artifacts/$ref': typeof ArtifactsRefRoute
+  '/claim/$token': typeof ClaimTokenRoute
   '/contexts/$id': typeof ContextsIdRoute
   '/invite/$token': typeof InviteTokenRoute
   '/settings/$section': typeof SettingsSectionRoute
@@ -253,6 +262,7 @@ export interface FileRouteTypes {
     | '/unlisted'
     | '/welcome'
     | '/artifacts/$ref'
+    | '/claim/$token'
     | '/contexts/$id'
     | '/invite/$token'
     | '/settings/$section'
@@ -278,6 +288,7 @@ export interface FileRouteTypes {
     | '/unlisted'
     | '/welcome'
     | '/artifacts/$ref'
+    | '/claim/$token'
     | '/contexts/$id'
     | '/invite/$token'
     | '/settings/$section'
@@ -304,6 +315,7 @@ export interface FileRouteTypes {
     | '/unlisted'
     | '/welcome'
     | '/artifacts/$ref'
+    | '/claim/$token'
     | '/contexts/$id'
     | '/invite/$token'
     | '/settings/$section'
@@ -331,6 +343,7 @@ export interface RootRouteChildren {
   UnlistedRoute: typeof UnlistedRoute
   WelcomeRoute: typeof WelcomeRoute
   ArtifactsRefRoute: typeof ArtifactsRefRoute
+  ClaimTokenRoute: typeof ClaimTokenRoute
   ContextsIdRoute: typeof ContextsIdRoute
   InviteTokenRoute: typeof InviteTokenRoute
   UsersHandleRoute: typeof UsersHandleRoute
@@ -494,6 +507,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ContextsIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/claim/$token': {
+      id: '/claim/$token'
+      path: '/claim/$token'
+      fullPath: '/claim/$token'
+      preLoaderRoute: typeof ClaimTokenRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/artifacts/$ref': {
       id: '/artifacts/$ref'
       path: '/artifacts/$ref'
@@ -543,6 +563,7 @@ const rootRouteChildren: RootRouteChildren = {
   UnlistedRoute: UnlistedRoute,
   WelcomeRoute: WelcomeRoute,
   ArtifactsRefRoute: ArtifactsRefRoute,
+  ClaimTokenRoute: ClaimTokenRoute,
   ContextsIdRoute: ContextsIdRoute,
   InviteTokenRoute: InviteTokenRoute,
   UsersHandleRoute: UsersHandleRoute,

--- a/apps/web/src/routes/claim.$token.tsx
+++ b/apps/web/src/routes/claim.$token.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { ClaimDraft } from "../pages/claim-draft"
+
+// Claim an anonymous expiring draft into a workspace. The token in the path is the
+// secret (possession authorizes), so this route is reachable by anyone with the link;
+// the page itself gates the claim action behind sign-in. Chrome-less, like /invite/$token.
+export const Route = createFileRoute("/claim/$token")({
+  component: ClaimDraft,
+})

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -21,6 +21,7 @@ CREATE TABLE IF NOT EXISTS artifact (
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   updated_at TEXT,
   removed_at TEXT,
+  expires_at TEXT,
   source_path TEXT,
   author_name TEXT,
   author_login TEXT,
@@ -443,6 +444,7 @@ CREATE TABLE IF NOT EXISTS domain (
   status TEXT NOT NULL DEFAULT 'active',
   cf_hostname_id TEXT,
   verification TEXT,
+  redirect_to TEXT,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   FOREIGN KEY (artifact_id) REFERENCES artifact(id)
 );

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -125,6 +125,9 @@ export interface ArtifactRecord {
   updated_at: string | null
   /** A takedown tombstone: when set, the content is gone (410) but the record stays. */
   removed_at: string | null
+  /** Expiring anonymous draft (the claim flow): ISO instant after which the draft is
+   *  served 410 and swept. Null for every ordinary artifact; cleared on claim. */
+  expires_at: string | null
   /** For a GitHub-synced artifact: its path within the repo (e.g. "docs/plans/foo.md").
    *  The structural "location" — drives the folder/tree view — kept distinct from the
    *  human `title`. Null for artifacts not mirrored from a repo. */
@@ -273,6 +276,8 @@ export interface NewArtifact {
   password_hash?: string | null
   kind: ArtifactKind
   spa: 0 | 1
+  /** Expiring anonymous draft: ISO expiry instant. Omit for ordinary artifacts. */
+  expires_at?: string | null
 }
 
 /** Which surface created a version: the web app, the MCP publish tool, the HTTP API
@@ -761,13 +766,24 @@ export interface IntegrationStore {
   getArtifactDomains(artifactId: string): Promise<DomainRecord[]>
   /** A workspace's own custom domains (artifact_id null), for the settings UI. */
   getWorkspaceDomains(orgId: string): Promise<DomainRecord[]>
-  /** Update a custom domain's validation status + the records to display. */
+  /** Update a custom domain's validation status + the records to display — or, on a
+   *  draft claim, unbind the artifact and turn the host into a 302 (`artifact_id:
+   *  null` + `redirect_to`). */
   updateDomain(
     host: string,
-    fields: { status?: DomainStatus; verification?: string | null },
+    fields: {
+      status?: DomainStatus
+      verification?: string | null
+      artifact_id?: string | null
+      redirect_to?: string | null
+    },
   ): Promise<DomainRecord | null>
   /** Release a hostname, scoped to its owning workspace. */
   deleteDomain(host: string, orgId: string): Promise<void>
+  /** Set or clear an artifact's draft expiry (cleared on claim). */
+  setArtifactExpiry(artifactId: string, expiresAt: string | null): Promise<void>
+  /** Expired drafts due for the sweep: artifacts whose expires_at is past `nowIso`. */
+  listExpiredArtifacts(nowIso: string, limit: number): Promise<ArtifactRecord[]>
 }
 
 export interface ReviewStore {
@@ -1977,6 +1993,9 @@ export interface DomainRecord {
   cf_hostname_id: string | null
   /** JSON-encoded DNS records the customer must add to validate (custom, while pending). */
   verification: string | null
+  /** When set, the host answers 302 → this absolute URL instead of serving content
+   *  (a claimed draft's derive.page URL forwarding to its permanent home). */
+  redirect_to: string | null
   created_at: string
 }
 export interface NewDomain {

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -71,6 +71,9 @@ export interface PublishInput {
    *  lets a caller embed the artifact's own id in its first version's content
    *  (the lineage resume block). 409 if already taken. */
   mintShortId?: string
+  /** Expiring anonymous draft (create only): ISO instant after which the draft is
+   *  served 410 and swept. Omit for every ordinary publish. */
+  expiresAt?: string
 }
 
 export interface PublishResult {
@@ -297,6 +300,7 @@ export async function publish(
     password_hash: input.passwordHash ?? null,
     kind,
     spa: input.spa ? 1 : 0,
+    expires_at: input.expiresAt ?? null,
   })
   const version = await meta.addVersion(artifact.id, {
     id: newId("v"),

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -54,6 +54,9 @@ export const artifact = pgTable("artifact", {
   // Set on every new version; null until first versioned (coalesces to created_at).
   updated_at: text("updated_at"),
   removed_at: text("removed_at"),
+  // Expiring anonymous draft (the claim flow): ISO instant after which the draft is
+  // gone — served 410 and swept. Null for every ordinary artifact; cleared on claim.
+  expires_at: text("expires_at"),
   source_path: text("source_path"),
   // The CURRENT (last) author, denormalized from the latest version for the list view +
   // author filtering. For a GitHub-synced artifact these mirror the last commit's author.
@@ -586,6 +589,10 @@ export const domain = pgTable("domain", {
   status: text("status").$type<DomainStatus>().notNull().default("active"),
   cf_hostname_id: text("cf_hostname_id"),
   verification: text("verification"),
+  // When set, the host answers 302 → this absolute URL instead of serving content.
+  // Written when a draft is claimed (the derive.page URL forwards to the artifact's
+  // permanent home); reusable for any future host rename.
+  redirect_to: text("redirect_to"),
   created_at: text("created_at").notNull().$defaultFn(isoNow),
 })
 export const proposal = pgTable("proposal", {

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -111,6 +111,7 @@ import {
   inArray,
   isNotNull,
   isNull,
+  lt,
   lte,
   ne,
   notExists,
@@ -1866,10 +1867,29 @@ export class PgMetaStore implements MetaStore {
   }
   async updateDomain(
     host: string,
-    fields: { status?: DomainStatus; verification?: string | null },
+    fields: {
+      status?: DomainStatus
+      verification?: string | null
+      artifact_id?: string | null
+      redirect_to?: string | null
+    },
   ): Promise<DomainRecord | null> {
     const rows = await this.db.update(domain).set(fields).where(eq(domain.host, host)).returning()
     return rows[0] ?? null
+  }
+
+  async setArtifactExpiry(artifactId: string, expiresAt: string | null): Promise<void> {
+    await this.db.update(artifact).set({ expires_at: expiresAt }).where(eq(artifact.id, artifactId))
+  }
+
+  // lt() on the ISO text column: the file-wide convention keeps instants as ISO-8601
+  // strings, which sort lexically in timestamp order.
+  async listExpiredArtifacts(nowIso: string, limit: number): Promise<ArtifactRecord[]> {
+    return this.db
+      .select()
+      .from(artifact)
+      .where(and(isNotNull(artifact.expires_at), lt(artifact.expires_at, nowIso)))
+      .limit(limit) as Promise<ArtifactRecord[]>
   }
   async deleteDomain(host: string, orgId: string): Promise<void> {
     await this.db.delete(domain).where(and(eq(domain.host, host), eq(domain.org_id, orgId)))

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1882,14 +1882,14 @@ export class PgMetaStore implements MetaStore {
     await this.db.update(artifact).set({ expires_at: expiresAt }).where(eq(artifact.id, artifactId))
   }
 
-  // lt() on the ISO text column: the file-wide convention keeps instants as ISO-8601
-  // strings, which sort lexically in timestamp order.
+  // expires_at is ISO-8601 text (the schema-wide convention), so lexical lt() IS
+  // chronological order.
   async listExpiredArtifacts(nowIso: string, limit: number): Promise<ArtifactRecord[]> {
     return this.db
       .select()
       .from(artifact)
       .where(and(isNotNull(artifact.expires_at), lt(artifact.expires_at, nowIso)))
-      .limit(limit) as Promise<ArtifactRecord[]>
+      .limit(limit)
   }
   async deleteDomain(host: string, orgId: string): Promise<void> {
     await this.db.delete(domain).where(and(eq(domain.host, host), eq(domain.org_id, orgId)))

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -2097,15 +2097,15 @@ export function makeRepos(db: SqliteDb) {
       .where(eq(artifact.id, artifactId))
       .run()
   }
-  // lt() on the ISO text column: the file-wide convention keeps instants as ISO-8601
-  // strings, which sort lexically in timestamp order.
+  // expires_at is ISO-8601 text (the schema-wide convention), so lexical lt() IS
+  // chronological order.
   const listExpiredArtifacts = async (nowIso: string, limit: number): Promise<ArtifactRecord[]> =>
     db
       .select()
       .from(artifact)
       .where(and(isNotNull(artifact.expires_at), lt(artifact.expires_at, nowIso)))
       .limit(limit)
-      .all() as Promise<ArtifactRecord[]>
+      .all()
 
   // ---- Reviews: proposals ------------------------------------------------
   const createProposal = async (p: NewProposal): Promise<ProposalRecord> =>

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -2074,7 +2074,12 @@ export function makeRepos(db: SqliteDb) {
       .all()
   const updateDomain = async (
     host: string,
-    fields: { status?: DomainStatus; verification?: string | null },
+    fields: {
+      status?: DomainStatus
+      verification?: string | null
+      artifact_id?: string | null
+      redirect_to?: string | null
+    },
   ): Promise<DomainRecord | null> =>
     ((await db.update(domain).set(fields).where(eq(domain.host, host)).returning().get()) as
       | DomainRecord
@@ -2085,6 +2090,22 @@ export function makeRepos(db: SqliteDb) {
       .where(and(eq(domain.host, host), eq(domain.org_id, orgId)))
       .run()
   }
+  const setArtifactExpiry = async (artifactId: string, expiresAt: string | null): Promise<void> => {
+    await db
+      .update(artifact)
+      .set({ expires_at: expiresAt })
+      .where(eq(artifact.id, artifactId))
+      .run()
+  }
+  // lt() on the ISO text column: the file-wide convention keeps instants as ISO-8601
+  // strings, which sort lexically in timestamp order.
+  const listExpiredArtifacts = async (nowIso: string, limit: number): Promise<ArtifactRecord[]> =>
+    db
+      .select()
+      .from(artifact)
+      .where(and(isNotNull(artifact.expires_at), lt(artifact.expires_at, nowIso)))
+      .limit(limit)
+      .all() as Promise<ArtifactRecord[]>
 
   // ---- Reviews: proposals ------------------------------------------------
   const createProposal = async (p: NewProposal): Promise<ProposalRecord> =>
@@ -3325,6 +3346,8 @@ export function makeRepos(db: SqliteDb) {
     getArtifactDomains,
     getWorkspaceDomains,
     updateDomain,
+    setArtifactExpiry,
+    listExpiredArtifacts,
     deleteDomain,
     createProposal,
     createReviewRound,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -75,6 +75,9 @@ export const artifact = sqliteTable("artifact", {
   // existing DBs (SQLite forbids a non-constant default there).
   updated_at: text("updated_at"),
   removed_at: text("removed_at"),
+  // Expiring anonymous draft (the claim flow): ISO instant after which the draft is
+  // gone — served 410 and swept. Null for every ordinary artifact; cleared on claim.
+  expires_at: text("expires_at"),
   source_path: text("source_path"),
   // The CURRENT (last) author, denormalized from the latest version row for the list
   // view + author filtering. For a GitHub-synced artifact these mirror the last commit's
@@ -719,6 +722,10 @@ export const domain = sqliteTable("domain", {
   // records to show while pending. Null for subdomains.
   cf_hostname_id: text("cf_hostname_id"),
   verification: text("verification"),
+  // When set, the host answers 302 → this absolute URL instead of serving content.
+  // Written when a draft is claimed (the derive.page URL forwards to the artifact's
+  // permanent home); reusable for any future host rename.
+  redirect_to: text("redirect_to"),
   created_at: text("created_at").notNull().default(now),
 })
 


### PR DESCRIPTION
PR 2 of the here.now adoption plan ([working plan](https://derive.to/artifacts/what-to-take-from-here-now-working-plan-6a4kl2yq), follows #524). The account-less front door: an agent with zero credentials publishes a live page; the human claims it into a workspace afterward. **Value first, conversion after — the claim link is the funnel.**

## The flow

```
curl -F file=@page.html https://derive.to/v1/drafts
→ 201 { draft_url: "https://<id>.derive.page/", claim_url: "https://derive.to/claim/<token>", expires_at: +72h }
```

The draft is live immediately on the usercontent domain. Opening the claim link → sign in → "Claim into workspace" → the draft becomes a normal team-draft artifact at its permanent derive.to URL, and the old derive.page URL 302s there forever.

## Design (what a draft *is*)

An ordinary artifact with no owner (`author_id` null, no member row — the state account deletion already leaves), held in a reserved `ws_sys_drafts` workspace, with a new nullable `artifact.expires_at`. Its access shape is **forced server-side** to link-viewer-only — client-supplied access fields are ignored, so an anonymous caller can never list a draft publicly or password-lock it. Serving reuses the existing domain mode: the mint binds `<short_id>.derive.page` with one `domain` row.

Per the PSL decision: no cookies are involved anywhere on derive.page, drafts are `noindex` (RAW_HEADERS) and **never CDN-cacheable** (`no-store` — the viewer link would otherwise earn a year-long immutable cache and an expired draft could outlive itself at the edge). Expiry is enforced at serve time (410) independently of the sweep.

## The claim

A house capability token (`lib/claim-token.ts`, over `capability-token.ts` like publish/upload tokens) binding one artifact id, expiring with the draft itself. **Single-use by state**: spending re-checks the draft is still in the holding workspace and unexpired — a replayed token finds nothing to spend. Claiming: unbind the host into a 302 signpost (new `domain.redirect_to`, permanently useful for host renames) → `moveArtifactOrg` → clear expiry → owner member row → access reset to the workspace default → dense-vector re-embed (the move-route recipe).

## Sweep & abuse

- Hourly Node timer (registered in `clearTimers`) + opportunistic sweep on each mint (the OAuth-reaper pattern; the edge cron has no pg binding — documented in code). Serve-time 410 covers the gap.
- Dedicated `draftPublish` IP limiter (12/h in-process, `RL_STRICT`-namespaced on the edge) registered ahead of the general write limiter; the ip-keyed publish limiter still applies underneath; one documented `ANON_WRITE_ALLOW` entry.
- **Deliberately out of scope:** blob GC (content-addressed blobs are shared across artifacts; real reclamation needs refcounting — noted at the `BlobStore` port).

## Web

`/claim/$token` mirrors the accept-invite page: preview via a non-persisted query (the capability secret never hits IndexedDB), signed-out → `/login?return_to=…`, claim into the active workspace, navigate to the artifact. New future-facing `until()` relative-time util with tests.

## Implementation notes

- The anonymous mint rides `handlePublish`'s existing `tokenAuth` seam extended to a null user + a `draft` marker — every quota, size cap, sniff, and advisory stays shared with the session/MCP paths.
- Schema: `artifact.expires_at` + `domain.redirect_to`, both nullable boot-DDL adds with SQLite twins; `deploy/d1-schema.sql` regenerated.
- `BASE_URL` (the isolate-pinning hazard on derive.page) was already fixed on main (#535); this builds on it.

## Verification

- New `test/drafts.test.ts` (8): mint shape + TTL, forced access, serve-time 410, claim preview, anonymous claim refused at the door, full claim (move + signpost + replay-410), expired claim, sweep (deletes expired + domain rows, leaves live).
- Full suites: API 141 files / 1,220 tests · web 29 files / 190 tests · db + core packages · schema conformance. `pnpm typecheck` (all 9), `pnpm check`, testids/frontend/api/schema/mutations/boundaries lints — all green.

## Follow-ups (not here)

Skill/llms.txt teach the draft flow once this deploys (workstream 2 v2) · friction benchmark (workstream 3) · blob refcount GC · per-app subdomain graduation for claimed artifacts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787540206&installation_model_id=428097&pr_number=536&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F536&signature=71e0f7f60637370f7a07294a427400b7db0f84e82b7db1991c3db4f5c7da807c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->