### PR TITLE
Domain-mode serving: host-aware static namespaces + no anchor client on standalone hosts

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -215,6 +215,13 @@ export function createApp(deps: AppDeps): Hono {
         prefix,
         rawPath,
         a.expires_at ? "no-store" : cacheControlFor(a.link_role, !!a.password_hash),
+        undefined, // onMismatch: the raw route owns content-type self-healing
+        undefined, // transformHtml
+        true, // reflow
+        // No anchor client: these hosts are top-level pages, never embedded by the
+        // app viewer, so its hover/selection comment UI would render but reach no
+        // host — a "Comment" chip that can't comment.
+        false,
       )
     }
     app.use("*", async (c, next) => {

--- a/apps/api/src/lib/serve-content.ts
+++ b/apps/api/src/lib/serve-content.ts
@@ -47,6 +47,13 @@ export const serveContent = async (
    *  serve the document exactly as authored. Never applied to markdown-rendered output,
    *  which is already responsive. */
   reflow = true,
+  /** Append the anchor client (selection → comment, hover chips, live cursors).
+   *  It only functions embedded in the app viewer — it talks to the host via
+   *  parent.postMessage — so standalone serving (vanity/draft hosts, which are
+   *  never iframed by the app) passes false: on a top-level page the client's
+   *  hover UI renders but can deliver nothing. Default on for the raw routes,
+   *  whose pages the viewer embeds. */
+  anchors = true,
 ) => {
   const headers = { ...RAW_HEADERS, "Cache-Control": cacheControl }
   const tx = (doc: string) => (transformHtml ? transformHtml(doc) : Promise.resolve(doc))
@@ -59,10 +66,10 @@ export const serveContent = async (
   // other read.
   const wantsMarks = ["1", "true"].includes(c.req.query("marks") ?? "")
   const marks = wantsMarks ? MARKS_SCRIPT : ""
+  const anchorClient = anchors ? SELECTION_SCRIPT : ""
   // Produce the final HTML body for a document: cross-doc rewrite + auto-reflow, then append
   // the anchor client (for comment anchoring + live cursors) and, when asked, the marks overlay.
-  const htmlBody = async (doc: string): Promise<string> =>
-    rf(await tx(doc)) + SELECTION_SCRIPT + marks
+  const htmlBody = async (doc: string): Promise<string> => rf(await tx(doc)) + anchorClient + marks
   let path = rawPath
   if (isBundleContentType(content.content_type)) {
     const manifestBytes = await blobs.get(content.blob_key)
@@ -84,7 +91,7 @@ export const serveContent = async (
       const rewritten = rewriteAbsoluteUrls(new TextDecoder().decode(data), prefix.slice(0, -1))
       // Bundle pages get the anchor client too — comments stick everywhere.
       const out = entry.type.startsWith("text/html")
-        ? rf(rewritten) + SELECTION_SCRIPT + marks
+        ? rf(rewritten) + anchorClient + marks
         : rewritten
       return c.body(out, 200, { ...headers, "Content-Type": entry.type })
     }

--- a/apps/api/src/lib/serve-web.ts
+++ b/apps/api/src/lib/serve-web.ts
@@ -1,5 +1,6 @@
 import { serveStatic } from "@hono/node-server/serve-static"
 import type { Hono } from "hono"
+import { STATIC_NAMESPACE_PREFIXES } from "./static-namespaces"
 
 /**
  * The single source of truth for which request paths the API/server owns. Every
@@ -68,11 +69,18 @@ export const API_PATHS: readonly string[] = [...API_PREFIXES, ...API_EXACT]
 export const isApiPath = (path: string): boolean =>
   API_PREFIXES.some((p) => path.startsWith(p)) || (API_EXACT as readonly string[]).includes(path)
 
+// The static namespaces (see lib/static-namespaces.ts for why they're worker-first
+// on the edge). Deliberately NOT in `isApiPath` (an unmatched one must fall back to
+// the shell, never JSON) and not in the dev proxy (Vite serves them itself in dev);
+// on Node, mountWeb's own routes below serve them and domain mode runs first.
+
 /** The `run_worker_first` globs this contract implies: API prefixes + the
- *  server-rendered page prefixes (both → `/*`), plus the exact paths as-is. */
+ *  server-rendered page prefixes + the static namespaces (all → `/*`), plus the
+ *  exact paths as-is. */
 export const workerFirstGlobs = (): string[] => [
   ...API_PREFIXES.map((p) => `${p}/*`),
   ...SERVER_PAGE_PREFIXES.map((p) => `${p}/*`),
+  ...STATIC_NAMESPACE_PREFIXES.map((p) => `${p}/*`),
   ...API_EXACT,
   ...MARKETING_EXACT,
 ]

--- a/apps/api/src/lib/static-namespaces.ts
+++ b/apps/api/src/lib/static-namespaces.ts
@@ -1,0 +1,14 @@
+// Web-build static namespaces: Vite's hashed /assets plus the marketing /site and
+// /brand files. A pure leaf (no imports) because both sides of the deployment need
+// it — the Node path contract (lib/serve-web) and the Worker's asset passthrough
+// (worker.ts), and the worker bundle must not inherit serve-web's dependency on
+// @hono/node-server.
+//
+// Why these are worker-first at all: Cloudflare Static Assets routing is path-only
+// and HOST-BLIND, so without worker-first these paths on a vanity/draft host
+// (`x.derive.page/assets/logo.png`) never reach domain mode — they miss the web
+// build's files and fall into SPA not-found handling, serving the app shell where
+// a bundle's own asset should be. Worker-first sends them through the Worker,
+// which passes app-host requests straight back to the ASSETS binding and lets
+// vanity hosts hit domain mode.
+export const STATIC_NAMESPACE_PREFIXES = ["/assets", "/site", "/brand"] as const

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -29,6 +29,7 @@ import { buildAuthEmail } from "./lib/email"
 import { slackFromEnv, subdomainBaseFromEnv, superAdminsFromEnv } from "./lib/env"
 import { nativeLimiter } from "./lib/rate-limit"
 import { liveD1, requestD1 } from "./lib/request-d1"
+import { STATIC_NAMESPACE_PREFIXES } from "./lib/static-namespaces"
 import { createDoBackplane, edgeCtx, edgeWaitUntil } from "./realtime-do"
 import { PgvectorSearchIndex } from "./search-pgvector"
 import { enqueueChannelDelivery } from "./webhooks"
@@ -333,8 +334,35 @@ const handle = (req: Request, env: Env, ctx: ExecutionContext): Response | Promi
   })
 }
 
+// Should this request skip the app entirely and go back to Cloudflare Static
+// Assets? True for a static-namespace path on anything that is NOT a vanity host
+// — the app host, its app.* alias, workers.dev, and custom domains all keep the
+// platform's asset serving exactly as it was before these paths were worker-first.
+// A `<label>.<base>` host is the one case that must reach the app: its bundle's
+// own /assets files live in domain mode, not the web build. (Custom domains still
+// have the shadow for these three prefixes — identifying them needs a DB lookup
+// this pre-binding hook can't afford; vanity hosts are the live product surface.)
+const staticNamespacePassthrough = (req: Request, env: Env): boolean => {
+  const path = new URL(req.url).pathname
+  if (!STATIC_NAMESPACE_PREFIXES.some((p) => path.startsWith(`${p}/`))) return false
+  const sub = subdomainBaseFromEnv(env)
+  if (!sub) return true
+  const host = (req.headers.get("host") ?? new URL(req.url).host).toLowerCase().split(":")[0] ?? ""
+  return host !== sub && !host.endsWith(`.${sub}`)
+}
+
 export default {
   fetch(req: Request, env: Env, ctx: ExecutionContext): Response | Promise<Response> {
+    // The static namespaces (/assets, /site, /brand) are worker-first solely so
+    // vanity/draft hosts can reach domain mode (Static Assets routing is host-blind
+    // — see serve-web.ts STATIC_NAMESPACE_PREFIXES). Everything that is NOT a
+    // vanity host gets the platform's asset serving back verbatim, before any DB
+    // binding — the app host, its app.* alias, workers.dev, and every custom
+    // domain behave exactly as they did when these paths never hit the Worker.
+    // URL-string fetch (the siteFetch precedent) sidesteps the workers-types/DOM
+    // Request dualism; assets are GET/HEAD-only so nothing else is intercepted.
+    if ((req.method === "GET" || req.method === "HEAD") && staticNamespacePassthrough(req, env))
+      return env.ASSETS.fetch(req.url) as unknown as Promise<Response>
     // Postgres tier: bind a request-scoped pool (see edge-pg.ts) for livePgPool to
     // resolve. Never end()ed here — `background()` fan-out (context.ts) keeps
     // querying it on waitUntil after the response, so an eager end() would cut

--- a/apps/api/test/drafts.test.ts
+++ b/apps/api/test/drafts.test.ts
@@ -39,8 +39,16 @@ describe("POST /v1/drafts (anonymous mint)", () => {
     // Live on its own host, never CDN-cacheable.
     const served = await drafts.request(`http://${body.short_id}.${BASE}/`)
     expect(served.status).toBe(200)
-    expect(await served.text()).toContain("Hello draft")
+    const html = await served.text()
+    expect(html).toContain("Hello draft")
     expect(served.headers.get("cache-control")).toBe("no-store")
+    // Standalone hosts get no anchor client: its comment UI only works embedded in
+    // the app viewer, and a vanity/draft page is never iframed by the app.
+    expect(html).not.toContain("/raw/derive-client.js")
+    // The same artifact through the raw route (which the viewer embeds) keeps it.
+    const raw = await drafts.request(`/raw/${body.short_id}/v/1/index.html`)
+    expect(raw.status).toBe(200)
+    expect(await raw.text()).toContain("/raw/derive-client.js")
   })
 
   it("forces the draft access shape — client access fields are ignored", async () => {

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -187,7 +187,7 @@ crons = ["* * * * *"]
 [assets]
 directory = "../web/dist/client"
 binding = "ASSETS"
-run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/blob/*", "/oauth/*", "/settings/github/*", "/settings/slack/*", "/artifacts/*", "/users/*", "/healthz", "/mcp", "/openapi.json", "/docs", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource", "/.well-known/openid-configuration", "/skill.md", "/.well-known/agent.json", "/", "/pricing"]
+run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/blob/*", "/oauth/*", "/settings/github/*", "/settings/slack/*", "/artifacts/*", "/users/*", "/assets/*", "/site/*", "/brand/*", "/healthz", "/mcp", "/openapi.json", "/docs", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource", "/.well-known/openid-configuration", "/skill.md", "/.well-known/agent.json", "/", "/pricing"]
 not_found_handling = "single-page-application"
 
 # Public hosts: the derive.to apex is canonical, app.derive.to an alias. Cloudflare


### PR DESCRIPTION
Two bugs on vanity/draft hosts, both predating the drafts work but surfaced by dogfooding it (#536 follow-up). Rob hit the second one live; testing zip drafts on prod hit the first.

## 1. `/assets/*` on a vanity host served the app shell

Cloudflare Static Assets routing is **path-only and host-blind**: any path not in `run_worker_first` goes to the platform's asset layer regardless of Host. So `x.derive.page/assets/logo.png` never reached the Worker at all — it missed the web build's files and fell into SPA not-found handling, returning the app shell where the bundle's own asset belongs. Every bundle with an `/assets` (or `/site`, `/brand`) folder on a vanity or draft host was affected on the edge tier; Node was never affected (domain mode runs before its static routes).

Fix: those namespaces are now worker-first. The Worker passes every **non-vanity** host (app host, `app.*` alias, workers.dev, custom domains) straight back to the `ASSETS` binding before any DB binding — behavior identical to before, one cheap hop added — and vanity hosts fall through to domain mode, which serves the bundle's file. The prefixes live in a new pure-leaf module (`lib/static-namespaces.ts`) so the worker bundle doesn't inherit serve-web's `@hono/node-server` import; the three-way `run_worker_first` lockstep test covers the new globs automatically. Known remainder, documented at the predicate: **custom domains** keep the old shadow for these three prefixes — telling them apart needs a DB lookup the pre-binding hook can't afford.

## 2. The 💬 Comment chip on standalone pages

The anchor client (selection → comment, hover chips, live cursors) was injected into domain-mode pages. It only functions embedded in the app viewer — it talks to the host via `parent.postMessage` — and vanity/draft hosts are top-level, never iframed: the hover chip rendered but could deliver nothing. `serveContent` grew an `anchors` flag, off for domain-mode serving, unchanged for every `/raw` path the viewer embeds.

## Verification

- `drafts.test.ts` asserts the split both ways: the domain-mode-served draft has no `derive-client.js` injection; the same artifact through `/raw` keeps it.
- `serve-web.test.ts` (the wrangler/vite lockstep) passes with the new globs.
- Full API suite 141 files / 1,220 tests; typecheck across both runtime configs; biome clean.
- Post-deploy prod checks planned: `t8mnac05.derive.page` loses the hover chip (serve-time injection, so the existing draft heals itself), and `glsint1n.derive.page/assets/dot.png` returns the bundle's bytes instead of the shell.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787542729&installation_model_id=428097&pr_number=537&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F537&signature=5fda81d1cae7d4870c3d9337ea6d725c84ce9c9245d29875991c7333e54e5da3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->