### PR TITLE
Serve the Agent Skills Discovery well-known endpoints

### DIFF
--- a/apps/api/src/lib/serve-web.ts
+++ b/apps/api/src/lib/serve-web.ts
@@ -16,7 +16,9 @@ import { STATIC_NAMESPACE_PREFIXES } from "./static-namespaces"
  *  · prefixes match the path and any subpath (`/v1`, `/v1/artifacts`, …)
  *  · exact paths match only themselves (`/healthz`)
  */
-const API_PREFIXES = ["/v1", "/api", "/raw", "/blob", "/oauth"] as const
+// /.well-known/skills is a PREFIX (index.json + per-skill files), unlike the other
+// exact well-knowns: the Agent Skills Discovery crawlers fetch several paths under it.
+const API_PREFIXES = ["/v1", "/api", "/raw", "/blob", "/oauth", "/.well-known/skills"] as const
 // Exact server-owned paths. The OAuth 2.0 discovery docs (RFC 8414 / RFC 9728) the
 // Worker must answer with JSON, else SPA not_found_handling shadows them. `/mcp` is
 // EXACT, not a prefix: the MCP Streamable-HTTP endpoint is hit at exactly /mcp with

--- a/apps/api/src/routes/agent-discovery.ts
+++ b/apps/api/src/routes/agent-discovery.ts
@@ -39,6 +39,29 @@ export const agentDiscoveryRoutes = (_ctx: AppContext) => {
     }),
   )
 
+  // The Agent Skills Discovery convention (vercel-labs/skills-handler): an index
+  // naming each skill this domain serves, plus the skill files under
+  // /.well-known/skills/<name>/. Hermes and other skill-source crawlers consume
+  // exactly this shape; here.now serves the same. One skill, one file — the served
+  // copy is self-contained, so `files` is just the SKILL.md.
+  const SKILL_DESCRIPTION = (() => {
+    const m = AGENT_SKILL_MD.match(/^description: ([\s\S]*?)\n(?=\w+:|---)/m)
+    return (m?.[1] ?? "Publish and revise artifacts on Derive.").replace(/\n\s+/g, " ").trim()
+  })()
+  app.get("/.well-known/skills/index.json", (c) =>
+    c.json(
+      { skills: [{ name: "derive", description: SKILL_DESCRIPTION, files: ["SKILL.md"] }] },
+      200,
+      { "Cache-Control": CACHE },
+    ),
+  )
+  app.get("/.well-known/skills/derive/SKILL.md", (c) =>
+    c.body(AGENT_SKILL_MD, 200, {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": CACHE,
+    }),
+  )
+
   app.get("/.well-known/agent.json", (c: Context) => {
     const base = new URL(c.req.url).origin
     return c.json(

--- a/apps/api/test/agent-discovery.test.ts
+++ b/apps/api/test/agent-discovery.test.ts
@@ -23,6 +23,37 @@ describe("GET /skill.md", () => {
   })
 })
 
+describe("GET /.well-known/skills/*", () => {
+  it("serves the Agent Skills Discovery index and the skill file", async () => {
+    const idx = await anonApp.request("/.well-known/skills/index.json")
+    expect(idx.status).toBe(200)
+    const j = (await idx.json()) as {
+      skills: { name: string; description: string; files: string[] }[]
+    }
+    expect(j.skills).toHaveLength(1)
+    const skill = j.skills[0]
+    if (!skill) throw new Error("no skill entry")
+    // Spec name grammar: lowercase alphanumeric + hyphens.
+    expect(skill.name).toMatch(/^[a-z0-9-]{1,64}$/)
+    expect(skill.name).toBe("derive")
+    // The description is parsed from the generated skill's frontmatter — it must
+    // carry the trigger words, not a fallback stub.
+    expect(skill.description).toContain("Derive")
+    expect(skill.description.length).toBeGreaterThan(100)
+    expect(skill.files).toEqual(["SKILL.md"])
+
+    const md = await anonApp.request("/.well-known/skills/derive/SKILL.md")
+    expect(md.status).toBe(200)
+    expect(md.headers.get("content-type")).toContain("text/markdown")
+    expect(await md.text()).toContain("name: derive")
+  })
+
+  it("404s unknown paths under the prefix as JSON, never the SPA shell", async () => {
+    const r = await anonApp.request("/.well-known/skills/nope/SKILL.md")
+    expect(r.status).toBe(404)
+  })
+})
+
 describe("GET /.well-known/agent.json", () => {
   it("serves an instance-relative capability manifest to an anonymous caller", async () => {
     const r = await anonApp.request("https://example.test/.well-known/agent.json")

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -187,7 +187,7 @@ crons = ["* * * * *"]
 [assets]
 directory = "../web/dist/client"
 binding = "ASSETS"
-run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/blob/*", "/oauth/*", "/settings/github/*", "/settings/slack/*", "/artifacts/*", "/users/*", "/assets/*", "/site/*", "/brand/*", "/healthz", "/mcp", "/openapi.json", "/docs", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource", "/.well-known/openid-configuration", "/skill.md", "/.well-known/agent.json", "/", "/pricing"]
+run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/blob/*", "/oauth/*", "/.well-known/skills/*", "/settings/github/*", "/settings/slack/*", "/artifacts/*", "/users/*", "/assets/*", "/site/*", "/brand/*", "/healthz", "/mcp", "/openapi.json", "/docs", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource", "/.well-known/openid-configuration", "/skill.md", "/.well-known/agent.json", "/", "/pricing"]
 not_found_handling = "single-page-application"
 
 # Public hosts: the derive.to apex is canonical, app.derive.to an alias. Cloudflare

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
         "/blob",
         "/healthz",
         "/oauth",
+        "/.well-known/skills",
         "/mcp",
         "/openapi.json",
         "/docs",


### PR DESCRIPTION
Distribution prep from the [skills plan](https://derive.to/artifacts/agent-skills-how-they-work-and-derive-s-distribu-gkwl77jm): the `/.well-known/skills/` convention ([vercel-labs/skills-handler](https://github.com/vercel-labs/skills-handler)) that Hermes and other skill-source crawlers consume. Domain-hosted, so it ships now — it does not wait for the repo going public.

- `GET /.well-known/skills/index.json` → `{ skills: [{ name: "derive", description, files: ["SKILL.md"] }] }` — description parsed from the generated skill's frontmatter, so it can't fork from the canonical text.
- `GET /.well-known/skills/derive/SKILL.md` → the self-contained served skill (same module as `/skill.md`).
- `/.well-known/skills` joins the three-way path contract as a **prefix** (it serves several files), unlike the exact-path OAuth well-knowns; the lockstep test covers it.

Tests: index shape + spec name grammar + frontmatter-derived description, markdown content-type, JSON-404 (never the shell) for unknown paths under the prefix. Full API suite 141/1,222 green, typecheck ×9, biome clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787578274&installation_model_id=428097&pr_number=539&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F539&signature=c1c314b1b2c6214b406ed0355f7969c0ad8e4658accc79237003b7fc2e1e098a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->