### PR TITLE
README: agent install + no-account publish in the agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,21 @@ The agent acts at the role you grant: publish access publishes directly; a lower
 
 ## Agents: ship a page, get the review comments back
 
-Derive is built for the loop where an agent publishes and a human (or another agent) reviews. `derive init` scaffolds one canonical `derive` skill into the native Codex and Claude locations (`.agents/skills/derive` and `.claude/skills/derive`) plus each client's project MCP config. For an existing repo, run `derive agent setup`; rerun with `--update` to refresh only the packaged Derive skill files while preserving MCP configs. The skill declares its MCP dependency for Codex and routes either client into the matching `derive://skills/*` workflow before it acts.
+Derive is built for the loop where an agent publishes and a human (or another agent) reviews.
+
+**Give your agent the skill** — works with Claude Code, Codex, Cursor, and any agent that reads [skills](https://skills.sh):
+
+```bash
+npx skills add derive-to/derive --skill derive
+```
+
+Or skip installation entirely: the skill is served at [derive.to/skill.md](https://derive.to/skill.md) (paste the URL into a prompt), agents discover the surface via [llms.txt](https://derive.to/llms.txt) and [`/.well-known/agent.json`](https://derive.to/.well-known/agent.json), and publishing needs no account at all:
+
+```bash
+curl -F file=@page.html https://derive.to/v1/drafts
+# → a live URL in about a second, plus a claim link that turns the
+#   draft into a permanent, versioned artifact in your workspace
+``` `derive init` scaffolds one canonical `derive` skill into the native Codex and Claude locations (`.agents/skills/derive` and `.claude/skills/derive`) plus each client's project MCP config. For an existing repo, run `derive agent setup`; rerun with `--update` to refresh only the packaged Derive skill files while preserving MCP configs. The skill declares its MCP dependency for Codex and routes either client into the matching `derive://skills/*` workflow before it acts.
 
 The core MCP tools: `find` (search + browse artifacts and contexts), `read` (content), `catch_up` (what changed, open feedback, version history, and — with no id — your work queue), `comment` (leave, reply, resolve), `publish` (save a revision), `stage` (upload out of band), `use` (ask a workspace context), and `checkpoint` (save resumable working state). For an image/font, `stage` mints a short-lived upload URL; the agent POSTs the local file's raw bytes, then uses the returned permanent URL or bundle ref in `publish`. Staging alone does not publish an artifact. `publish` goes live if your role can publish; otherwise, or with `for_review: true`, it files a proposal a human approves.
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ npx skills add derive-to/derive --skill derive
 Or skip installation entirely: the skill is served at [derive.to/skill.md](https://derive.to/skill.md) (paste the URL into a prompt), agents discover the surface via [llms.txt](https://derive.to/llms.txt) and [`/.well-known/agent.json`](https://derive.to/.well-known/agent.json), and publishing needs no account at all:
 
 ```bash
-curl -F file=@page.html https://derive.to/v1/drafts
+curl -F file=@page.html https://derive.to/v1/drafts   # or a .zip of a whole site
 # → a live URL in about a second, plus a claim link that turns the
 #   draft into a permanent, versioned artifact in your workspace
 ``` `derive init` scaffolds one canonical `derive` skill into the native Codex and Claude locations (`.agents/skills/derive` and `.claude/skills/derive`) plus each client's project MCP config. For an existing repo, run `derive agent setup`; rerun with `--update` to refresh only the packaged Derive skill files while preserving MCP configs. The skill declares its MCP dependency for Codex and routes either client into the matching `derive://skills/*` workflow before it acts.


### PR DESCRIPTION
Prep for the OSS flip ([skills plan](https://derive.to/artifacts/agent-skills-how-they-work-and-derive-s-distribu-gkwl77jm)): the agents section now leads with the three public entry points — `npx skills add derive-to/derive --skill derive` (correct the moment the repo is public), the hosted [skill.md](https://derive.to/skill.md) / [llms.txt](https://derive.to/llms.txt) / [agent.json](https://derive.to/.well-known/agent.json), and the anonymous `POST /v1/drafts` one-liner. Doc-only. The skills.sh badge gets added after the listing exists (it 404s until first install).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787579318&installation_model_id=428097&pr_number=540&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F540&signature=65e01f99ed27b60d7ca5b77ae8a5ba9c7c408a8e12b449dd44d4238447b839e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->