### PR TITLE
Fix: enumerate well-known skills paths — dotted globs don't match run_worker_first

### DIFF
--- a/apps/api/src/lib/serve-web.ts
+++ b/apps/api/src/lib/serve-web.ts
@@ -16,9 +16,18 @@ import { STATIC_NAMESPACE_PREFIXES } from "./static-namespaces"
  *  · prefixes match the path and any subpath (`/v1`, `/v1/artifacts`, …)
  *  · exact paths match only themselves (`/healthz`)
  */
-// /.well-known/skills is a PREFIX (index.json + per-skill files), unlike the other
-// exact well-knowns: the Agent Skills Discovery crawlers fetch several paths under it.
+// /.well-known/skills is a PREFIX for path-ownership purposes (Node fallback + the
+// dev proxy), but its worker-first rules are the two EXACT files below: observed in
+// prod, Cloudflare run_worker_first matches exact dotted paths ("/.well-known/x")
+// and dotless globs ("/oauth/*") but NOT a glob under a dot-directory
+// ("/.well-known/skills/*" never routed; assets kept the request and served the
+// shell). The endpoint surface is exactly these two files, so enumerating them
+// loses nothing — adding a skill later means adding its path here.
 const API_PREFIXES = ["/v1", "/api", "/raw", "/blob", "/oauth", "/.well-known/skills"] as const
+const WELL_KNOWN_SKILLS_EXACT = [
+  "/.well-known/skills/index.json",
+  "/.well-known/skills/derive/SKILL.md",
+] as const
 // Exact server-owned paths. The OAuth 2.0 discovery docs (RFC 8414 / RFC 9728) the
 // Worker must answer with JSON, else SPA not_found_handling shadows them. `/mcp` is
 // EXACT, not a prefix: the MCP Streamable-HTTP endpoint is hit at exactly /mcp with
@@ -80,7 +89,10 @@ export const isApiPath = (path: string): boolean =>
  *  server-rendered page prefixes + the static namespaces (all → `/*`), plus the
  *  exact paths as-is. */
 export const workerFirstGlobs = (): string[] => [
-  ...API_PREFIXES.map((p) => `${p}/*`),
+  // The dotted-glob exception (see WELL_KNOWN_SKILLS_EXACT above): every prefix
+  // except /.well-known/skills becomes a glob; that one is enumerated exactly.
+  ...API_PREFIXES.filter((p) => p !== "/.well-known/skills").map((p) => `${p}/*`),
+  ...WELL_KNOWN_SKILLS_EXACT,
   ...SERVER_PAGE_PREFIXES.map((p) => `${p}/*`),
   ...STATIC_NAMESPACE_PREFIXES.map((p) => `${p}/*`),
   ...API_EXACT,

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -187,7 +187,7 @@ crons = ["* * * * *"]
 [assets]
 directory = "../web/dist/client"
 binding = "ASSETS"
-run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/blob/*", "/oauth/*", "/.well-known/skills/*", "/settings/github/*", "/settings/slack/*", "/artifacts/*", "/users/*", "/assets/*", "/site/*", "/brand/*", "/healthz", "/mcp", "/openapi.json", "/docs", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource", "/.well-known/openid-configuration", "/skill.md", "/.well-known/agent.json", "/", "/pricing"]
+run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/blob/*", "/oauth/*", "/.well-known/skills/index.json", "/.well-known/skills/derive/SKILL.md", "/settings/github/*", "/settings/slack/*", "/artifacts/*", "/users/*", "/assets/*", "/site/*", "/brand/*", "/healthz", "/mcp", "/openapi.json", "/docs", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource", "/.well-known/openid-configuration", "/skill.md", "/.well-known/agent.json", "/", "/pricing"]
 not_found_handling = "single-page-application"
 
 # Public hosts: the derive.to apex is canonical, app.derive.to an alias. Cloudflare


### PR DESCRIPTION
#539's `/.well-known/skills/*` glob never routed on prod — Cloudflare's `run_worker_first` matched our exact dotted paths and dotless globs, but not a glob under a dot-directory; Static Assets kept the request and served the SPA shell (proved by controls: OAuth well-knowns 200 JSON, `/v1/*` 404 JSON, this path shell + `cf-cache-status: HIT`).

The endpoint surface is exactly two files, so the worker-first rules now enumerate them (`index.json`, `derive/SKILL.md`); the prefix remains in `API_PATHS` for the Node fallback + dev proxy, where prefix matching works. Behavior documented at the constant. Lockstep + discovery tests green; will verify the live endpoints post-deploy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787579764&installation_model_id=428097&pr_number=541&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F541&signature=e72082fbf16ab280e833338cdbd52e03af07e7afe443f67319563de0b60eb35f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->