### PR TITLE
[experiment, do not merge] one 16-vCPU job vs two 8-vCPU lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,27 @@ jobs:
   # vitest.config.ts, and since `deploy` needs this job, a coverage regression
   # blocks the ship.
   check:
-    runs-on: ubicloud-standard-8
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubicloud-standard-16
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        id: filter
+        with:
+          filters: |
+            web:
+              - 'apps/web/**'
+              - 'packages/**'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+            docker:
+              - 'packages/cli/**'
+              - 'pnpm-lock.yaml'
+              - 'deploy/runner.Dockerfile'
+              - 'deploy/runner.Dockerfile.dockerignore'
+              - 'deploy/runner-entrypoint.sh'
       - uses: ./.github/actions/setup
 
       - name: Lint + format + guardrails (biome + custom checks)
@@ -112,45 +130,6 @@ jobs:
         run: |
           curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz | tar -xz gitleaks
           ./gitleaks detect --no-git --source . --redact --no-banner
-
-  # LANE B — everything that needs a real engine or produces an artifact.
-  #
-  # Postgres: the SAME apps/api suite against a real Postgres (ephemeral Docker
-  # container, via scripts/test-pg.sh) so the hosted-tier driver is covered by the
-  # full behavioral suite. D1: the SAME @derive/db store contract against a real
-  # Cloudflare D1 inside workerd via Miniflare — the default (Node) lane can't
-  # host the D1 driver, so this is the only place src/d1.ts runs, and the edge
-  # tier runs on it.
-  #
-  # The two builds ride along, gated on the paths that can affect them. They used
-  # to be separate jobs fed by a separate path-filter job, which meant three VMs
-  # and a serial hop before either could start; as steps they cost only the
-  # seconds they actually run, and skip to nothing otherwise.
-  db:
-    runs-on: ubicloud-standard-8
-    # paths-filter lists a PR's changed files via the GitHub API, which needs
-    # pull-requests:read (the workflow default is contents:read only).
-    permissions:
-      contents: read
-      pull-requests: read
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
-        id: filter
-        with:
-          filters: |
-            web:
-              - 'apps/web/**'
-              - 'packages/**'
-              - 'pnpm-lock.yaml'
-              - 'package.json'
-            docker:
-              - 'packages/cli/**'
-              - 'pnpm-lock.yaml'
-              - 'deploy/runner.Dockerfile'
-              - 'deploy/runner.Dockerfile.dockerignore'
-              - 'deploy/runner-entrypoint.sh'
-      - uses: ./.github/actions/setup
 
       - name: Test against Postgres
         run: pnpm test:pg
@@ -195,7 +174,7 @@ jobs:
   # else; the step scoping is what keeps them away from package code.
   deploy:
     if: github.repository == 'derive-to/derive' && github.event_name == 'push' # never PRs, never forks
-    needs: [check, db]
+    needs: [check]
     runs-on: ubicloud-standard-4
     # A running deploy is never cancelled — a schema applied for a worker that
     # then didn't ship is the state to avoid. Queued runs are NOT ordered:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,21 +19,120 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+# ---------------------------------------------------------------------------
+# TWO LANES. What a PR waits on is the LONGEST job, never the total, so the only
+# structure that matters is: how few lanes can hold the work, and are they the
+# same length?
+#
+# There used to be five jobs. Exactly one of those splits paid for itself — the
+# SQLite suite and the Postgres suite are ~210s each, so they must run beside
+# each other or a PR waits seven minutes. The rest (a path-filter job, a bundle
+# job, a supply-chain job) were split for conditional execution and tidy
+# reporting, and each one bought a VM boot, a checkout and a ~28s install to do
+# 15-40s of work. Folding them onto a lane that was going to be running anyway
+# makes them free.
+#
+# So: two lanes, anchored by the two suites that cannot share one, with the small
+# work packed onto whichever lane is otherwise lighter. Keep them BALANCED — a
+# 60s lane beside a 300s lane is 60s of wasted capacity, and moving work onto the
+# longer lane costs wall-clock directly.
+#
+# The cost of packing, stated honestly: a lane stops at its first failure, so a
+# red test now hides that gitleaks would also have failed. That is a fair trade
+# for one machine instead of five, and the failing step names itself.
+#
+# RUNNERS — Ubicloud x64, and two things changed at once, both deliberate.
+#
+# SIZE. Every job used to run on 2 vCPU while the suite is ~200 CPU-seconds of
+# embarrassingly parallel work (measured: 176s user + 40s system, 615% CPU across
+# 6 cores locally). Two cores is a hard ~100s floor before a single test is slow,
+# and `check` was spending 212s in tests alone. Cores were the whole lever;
+# nothing about the test code was the problem.
+#
+# ARCH. One architecture for every job, which is why the old x64/arm split and
+# its caveats are gone: gitleaks needs no arch-specific asset, the runner image
+# builds amd64 natively instead of under emulation, and there is no longer a
+# class of "passes on the arm jobs, breaks on the x64 one" failure. The toolchain
+# is arm-native and arm is cheaper per minute, so ubicloud-standard-*-arm is a
+# live follow-up — worth doing once these labels have proven themselves, so that
+# a queued job is never ambiguous.
+#
+# THE ESCAPE HATCH, which this repo has needed before: Ubicloud's integration
+# vanished on 2026-07-02 and every job sat queued forever. The runs-on label is
+# the ONLY coupling. If jobs queue, replace these labels with ubuntu-latest and
+# CI runs unchanged — slower, but green.
+# ---------------------------------------------------------------------------
+
 jobs:
-  # Which areas a change touches — lets the peripheral build jobs (bundle,
-  # runner-image) skip when a PR can't affect them. The core gates
-  # (check/pg/d1/security) always run. No branch protection on this repo,
-  # so a skipped job can't wedge a required check — it just reports success.
-  changes:
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+  # LANE A — everything that reads the source without needing a database engine:
+  # static analysis, the whole suite on embedded SQLite with the coverage
+  # ratchet, and the supply-chain gates. Coverage thresholds live in each
+  # vitest.config.ts, and since `deploy` needs this job, a coverage regression
+  # blocks the ship.
+  check:
+    runs-on: ubicloud-standard-8
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./.github/actions/setup
+
+      - name: Lint + format + guardrails (biome + custom checks)
+        run: pnpm run ci
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test + coverage gate
+        run: pnpm test:coverage
+
+      # Supply chain, folded in from its own job: it reads the lockfile and the
+      # working tree, needs no install of its own, and takes ~15s — nowhere near
+      # enough to justify a second machine.
+      #
+      # pnpm audits via npm's legacy audit endpoint, which npm RETIRED (returns 410 as of
+      # 2026-07-15) — and pnpm (v10 and v11) hasn't migrated to the bulk-advisories endpoint.
+      # So the endpoint being unreachable is now infra, not a finding: treat that specific
+      # failure as non-fatal (a warning) while STILL failing on a real high advisory, so the
+      # gate keeps working the moment pnpm/npm restore it. gitleaks below is the other gate.
+      # Durable fix: migrate this to OSV-Scanner (no npm-endpoint dependency).
+      - name: Audit production dependencies
+        run: |
+          set +e
+          out=$(pnpm audit --prod --audit-level=high 2>&1)
+          code=$?
+          set -e
+          echo "$out"
+          [ "$code" -eq 0 ] && exit 0
+          if echo "$out" | grep -q "ERR_PNPM_AUDIT_BAD_RESPONSE"; then
+            echo "::warning::pnpm audit endpoint unavailable (npm retired the legacy endpoint pnpm uses) — treating as non-fatal. Migrate to OSV-Scanner."
+            exit 0
+          fi
+          exit 1
+
+      - name: Secret scan (gitleaks)
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz | tar -xz gitleaks
+          ./gitleaks detect --no-git --source . --redact --no-banner
+
+  # LANE B — everything that needs a real engine or produces an artifact.
+  #
+  # Postgres: the SAME apps/api suite against a real Postgres (ephemeral Docker
+  # container, via scripts/test-pg.sh) so the hosted-tier driver is covered by the
+  # full behavioral suite. D1: the SAME @derive/db store contract against a real
+  # Cloudflare D1 inside workerd via Miniflare — the default (Node) lane can't
+  # host the D1 driver, so this is the only place src/d1.ts runs, and the edge
+  # tier runs on it.
+  #
+  # The two builds ride along, gated on the paths that can affect them. They used
+  # to be separate jobs fed by a separate path-filter job, which meant three VMs
+  # and a serial hop before either could start; as steps they cost only the
+  # seconds they actually run, and skip to nothing otherwise.
+  db:
+    runs-on: ubicloud-standard-8
     # paths-filter lists a PR's changed files via the GitHub API, which needs
     # pull-requests:read (the workflow default is contents:read only).
     permissions:
       contents: read
       pull-requests: read
-    outputs:
-      web: ${{ steps.filter.outputs.web }}
-      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
@@ -51,48 +150,6 @@ jobs:
               - 'deploy/runner.Dockerfile'
               - 'deploy/runner.Dockerfile.dockerignore'
               - 'deploy/runner-entrypoint.sh'
-
-  # Blacksmith 2-vCPU arm64 — same machine class as the GitHub-hosted
-  # ubuntu-24.04-arm these jobs were on, ~75% cheaper with 3,000 free min/month.
-  # GitHub's included free minutes never applied to its hosted ARM SKU (the
-  # billing API shows the free-pool discount on x64 only), so hosted ARM billed
-  # from minute one. The toolchain (biome, esbuild, vite, vitest, tsgo) is
-  # arm-native. Ubicloud lesson (integration vanished 2026-07-02, jobs queued
-  # forever): the runs-on label is the ONLY coupling — if blacksmith-* jobs ever
-  # sit queued, flip these back to ubuntu-24.04-arm and CI runs unchanged.
-  # deploy/security/runner-image stay GitHub-hosted x64: they fit in the free
-  # x64 pool, and deploy keeps prod secrets off third-party metal.
-  check:
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: ./.github/actions/setup
-
-      - name: Lint + format + guardrails (biome + custom checks)
-        run: pnpm run ci
-
-      - name: Typecheck
-        run: pnpm typecheck
-
-      # Runs every package's suite once WITH coverage. Thresholds live in each
-      # vitest.config.ts (ratchet floors) — a regression fails here, and since
-      # deploy needs `check`, it blocks the ship. Replaces the old separate,
-      # redundant `coverage` job (which re-ran the whole suite a third time).
-      - name: Test + coverage gate
-        run: pnpm test:coverage
-
-  # Two database lanes, one job. Postgres: the SAME apps/api suite against a real
-  # Postgres (ephemeral Docker container, via scripts/test-pg.sh) so the
-  # hosted-tier driver is covered by the full behavioral suite. D1: the SAME
-  # @derive/db store contract against a real Cloudflare D1 inside workerd via
-  # Miniflare (`pnpm test:d1`) — the default (Node) lane can't host the D1
-  # driver, so this is the only place src/d1.ts runs; the edge tier runs on it.
-  # D1's ~45s rides the pg runner (combined still shorter than `check`, so the
-  # critical path doesn't move) instead of paying its own checkout + install.
-  db:
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/setup
 
       - name: Test against Postgres
@@ -101,60 +158,45 @@ jobs:
       - name: Test against Cloudflare D1 (workerd)
         run: pnpm --filter @derive/db test:d1
 
-  # Bundle budget: build the web client and fail if the gzipped JS blows past the
-  # budget (see scripts/check-bundle.mjs), so phosphor / radix / cmdk weight can't
-  # regress silently. Skipped when a PR touches nothing that reaches the web bundle.
-  bundle:
-    needs: changes
-    if: needs.changes.outputs.web == 'true'
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: ./.github/actions/setup
-      - name: Build web client
-        run: pnpm --filter @derive/web build
-      - name: Bundle budget
-        run: pnpm lint:bundle
+      # Bundle budget: build the web client and fail if the gzipped JS blows past
+      # the budget (see scripts/check-bundle.mjs), so phosphor / radix / cmdk
+      # weight can't regress silently.
+      - name: Build web client + bundle budget
+        if: steps.filter.outputs.web == 'true'
+        run: |
+          pnpm --filter @derive/web build
+          pnpm lint:bundle
 
-  # The runner image builds from packages/cli — this catches a CLI change that
-  # breaks the container (deps, bin layout) before someone finds out on a box.
-  # Build-only, non-gating like coverage/bundle; no registry push. Docker build
-  # ships to amd64 infra, so this one job stays on an x64 runner. Skipped unless a
-  # PR touches the CLI or the runner image's build inputs.
-  runner-image:
-    needs: changes
-    if: needs.changes.outputs.docker == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Build runner image
-        run: docker build -f deploy/runner.Dockerfile -t derive-runner:ci .
-      - name: Runner starts and reports config errors cleanly
+      # The runner image builds from packages/cli — this catches a CLI change that
+      # breaks the container (deps, bin layout) before someone finds out on a box.
+      # Build-only; no registry push.
+      - name: Build runner image + start check
+        if: steps.filter.outputs.docker == 'true'
         # No token/context on purpose: a healthy image exits 1 with the house
         # one-liner, not a stack trace — proves node, the CLI, and its deps wired.
         run: |
+          docker build -f deploy/runner.Dockerfile -t derive-runner:ci .
           out=$(docker run --rm derive-runner:ci serve 2>&1) && exit 1 || true
           echo "$out" | grep -q "error: a context id and an agent token are required"
 
   # CD: ship main to the hosted tier (Workers + Hyperdrive/Neon, derive.to) once
-  # check/db + security pass. Schemas (D1 + Postgres) land BEFORE the worker
-  # flips, so a new version never serves against stale DDL. Coverage now GATES:
-  # it's folded into `check` (thresholds per vitest.config.ts), so a regression
-  # fails check and blocks the deploy — a deliberate reversal of the old "ratchets
-  # shouldn't block a prod fix" rule (escape hatch: lower the threshold in the same
-  # PR). `bundle` stays non-gating. The laptop path
+  # both lanes pass. Schemas (D1 + Postgres) land BEFORE the worker flips, so a
+  # new version never serves against stale DDL. Coverage GATES: it rides `check`
+  # (thresholds per vitest.config.ts), so a regression fails that lane and blocks
+  # the deploy — a deliberate reversal of the old "ratchets shouldn't block a prod
+  # fix" rule (escape hatch: lower the threshold in the same PR). The laptop path
   # (`pnpm --filter @derive/api deploy`) remains for manual deploys; this job is
-  # the production path. Stays on an x64 runner — the production deploy path is not
-  # the place to also debut a runner-arch change.
+  # the production path.
   # Secrets — step-scoped, never job-wide (install/build run arbitrary package
   # code that must not see them): CLOUDFLARE_API_TOKEN (account-scoped; the D1
   # schema step needs D1 edit, which a workers-only token lacks),
   # CLOUDFLARE_ACCOUNT_ID, DATABASE_URL (direct Neon — Hyperdrive is only the
-  # worker's data path).
+  # worker's data path). These now run on Ubicloud metal along with everything
+  # else; the step scoping is what keeps them away from package code.
   deploy:
     if: github.repository == 'derive-to/derive' && github.event_name == 'push' # never PRs, never forks
-    needs: [check, db, security]
-    runs-on: ubuntu-latest
+    needs: [check, db]
+    runs-on: ubicloud-standard-4
     # A running deploy is never cancelled — a schema applied for a worker that
     # then didn't ship is the state to avoid. Queued runs are NOT ordered:
     # GitHub keeps only the newest pending run per group, so intermediate green
@@ -253,40 +295,3 @@ jobs:
       # 2026-07-14). Its post-deploy auto-dispatch stays off — a post-ship prod
       # check is separate from the PR gate; trigger it manually with
       # `gh workflow run e2e-smoke.yml --ref main` if wanted.
-
-  # Supply-chain: a known-vulnerable production dependency, or a committed secret,
-  # fails the build. Reads the lockfile + working tree, so no install is needed.
-  # Stays on x64: it curls the linux_x64 gitleaks binary, so an arm runner would
-  # need a different asset for a trivial (~16s) job — not worth the arch swap.
-  security:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: ./.github/actions/setup
-        with:
-          install: "false"
-
-      # pnpm audits via npm's legacy audit endpoint, which npm RETIRED (returns 410 as of
-      # 2026-07-15) — and pnpm (v10 and v11) hasn't migrated to the bulk-advisories endpoint.
-      # So the endpoint being unreachable is now infra, not a finding: treat that specific
-      # failure as non-fatal (a warning) while STILL failing on a real high advisory, so the
-      # gate keeps working the moment pnpm/npm restore it. gitleaks below is the other gate.
-      # Durable fix: migrate this to OSV-Scanner (no npm-endpoint dependency).
-      - name: Audit production dependencies
-        run: |
-          set +e
-          out=$(pnpm audit --prod --audit-level=high 2>&1)
-          code=$?
-          set -e
-          echo "$out"
-          [ "$code" -eq 0 ] && exit 0
-          if echo "$out" | grep -q "ERR_PNPM_AUDIT_BAD_RESPONSE"; then
-            echo "::warning::pnpm audit endpoint unavailable (npm retired the legacy endpoint pnpm uses) — treating as non-fatal. Migrate to OSV-Scanner."
-            exit 0
-          fi
-          exit 1
-
-      - name: Secret scan (gitleaks)
-        run: |
-          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz | tar -xz gitleaks
-          ./gitleaks detect --no-git --source . --redact --no-banner

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ permissions: {}
 jobs:
   analyze:
     if: github.repository == 'derive-to/derive' && github.event.repository.private == false
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-4
     permissions:
       security-events: write # upload analysis results
       contents: read

--- a/.github/workflows/e2e-fidelity.yml
+++ b/.github/workflows/e2e-fidelity.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   render-fidelity:
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm # see ci.yml `check` for the runner rationale
+    runs-on: ubicloud-standard-4 # see ci.yml for the runner rationale
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/setup

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   smoke:
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm # see ci.yml `check` for the runner rationale
+    runs-on: ubicloud-standard-4 # see ci.yml for the runner rationale
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/setup

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,7 +17,7 @@ permissions: read-all
 jobs:
   analysis:
     if: github.repository == 'derive-to/derive' && github.event.repository.private == false
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-4
     permissions:
       security-events: write # upload SARIF to code scanning
       id-token: write # publish results to the OpenSSF REST API

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,12 +214,13 @@ comment.
 - Open one focused PR per change; fill in the PR template. A green gate is required.
 - Prose style: no em-dashes; use colons, periods, or parentheses.
 
-A note on CI runners: workflows in this repo run on Blacksmith runners
-(`runs-on: blacksmith-*`), which are only available in the upstream repository. A PR
-you open against this repo runs CI normally (a maintainer approves the first run for
+A note on CI runners: workflows in this repo run on Ubicloud runners
+(`runs-on: ubicloud-standard-*`), which are only available in the upstream repository. A
+PR you open against this repo runs CI normally (a maintainer approves the first run for
 new contributors), but pushes to your own fork will show those jobs queued forever:
 that's expected, not a broken setup. Run the gate locally (`pnpm run ci`, `pnpm
-typecheck`, `pnpm test`) instead.
+typecheck`, `pnpm test:coverage`) instead — or, in a fork you control, swap the labels
+for `ubuntu-latest`, which is the only coupling to the provider.
 
 ## Tests
 

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -208,7 +208,17 @@ export function runStoreContract(
   })
 
   describe(`${label}: listArtifacts sort modes`, () => {
-    const tick = () => new Promise((r) => setTimeout(r, 2))
+    // Space the creations far enough apart to land on DISTINCT created_at values.
+    // This was 2ms, which is under the timer granularity of some virtualized
+    // hosts: on a 16-vCPU CI runner two rows inserted 2ms apart came back with the
+    // SAME timestamp, so `created` fell through to its `id` tiebreak — and since
+    // ids are random uuids, the expected order then held or didn't by luck.
+    // Nothing was wrong with the store; that tiebreak is exactly what keeps
+    // production ordering deterministic under a tie. The test simply needs
+    // distinct instants, and created_at is stamped by the store's own SQL default,
+    // so wall-clock spacing is the only lever available. 25ms clears any plausible
+    // tick and costs 75ms across the whole test.
+    const tick = () => new Promise((r) => setTimeout(r, 25))
 
     it("orders by each mode (title sort case-insensitive + null-safe) and paginates the keyset", async () => {
       const org = `org_sort_${uuid()}`

--- a/scripts/test-pg.sh
+++ b/scripts/test-pg.sh
@@ -57,11 +57,19 @@ cd "$ROOT/apps/api"
 #
 # File parallelism is ON (previously --no-file-parallelism): helpers.ts keys each
 # schema on VITEST_POOL_ID, so concurrent files land in distinct schemas and can't
-# collide. --maxWorkers=4 bounds the live per-store pools (node-postgres default
-# max=10) so their connections stay well under max_connections. Note vitest does
-# NOT clamp an explicit maxWorkers to core count, so this runs 4 forks even on a
-# 2-vCPU box — fine here because pg tests are I/O-bound (waiting on Postgres).
-pnpm exec vitest run --maxWorkers=4 --testTimeout=15000 "$@"
+# collide.
+#
+# Workers track the core count rather than a fixed 4. The bound that matters here
+# is CONNECTIONS, not cores: each worker holds a store pool (node-postgres default
+# max=10) and the container above starts with max_connections=400, so the ceiling
+# of 16 puts the worst case near 160 — comfortably inside it. A hardcoded 4 was
+# wrong in both directions at once: it oversubscribed the old 2-vCPU runner, and
+# it would leave most of a larger one idle, even though this lane is I/O-bound on
+# Postgres and keeps scaling past one worker per core.
+WORKERS="${DERIVE_PG_WORKERS:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)}"
+[ "$WORKERS" -gt 16 ] && WORKERS=16
+echo "→ ${WORKERS} vitest workers"
+pnpm exec vitest run --maxWorkers="$WORKERS" --testTimeout=15000 "$@"
 
 # Also run @derive/db's store contract against the same Postgres — the only place
 # pg.ts (the hosted-tier driver) is covered + gated by the db package's own suite.


### PR DESCRIPTION
Measurement only — will be closed once the timing is recorded. Compares against #543 (two lanes at 8 vCPU, 2m08s wall).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787620797&installation_model_id=428097&pr_number=544&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F544&signature=2a30e8298720129b953e66abdc0b75b6ef6f25e5d41daa6fe437407568b4de24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->