### PR TITLE
Feat/white label

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -222,6 +222,10 @@
             "type": "boolean",
             "description": "true when the world link is password-locked (the password is never returned)."
           },
+          "badge": {
+            "type": "boolean",
+            "description": "Show the Made-with-Derive mark on this artifact's public surfaces (false = white-label workspace)."
+          },
           "org_id": {
             "type": "string",
             "description": "The artifact's workspace id; drives move-to-workspace."
@@ -863,6 +867,10 @@
             ],
             "description": "Listing a new publish lands with: none (default), workspace, or public."
           },
+          "whiteLabel": {
+            "type": "boolean",
+            "description": "Hide the Made-with-Derive marks on public artifacts and embeds, and honor the bare ?chrome=none embed."
+          },
           "hostedAgentsEnabled": {
             "type": "boolean",
             "description": "Master switch for Derive-hosted agent runs; off silences every hosted run."
@@ -905,6 +913,7 @@
           "defaultWorkspaceAccess",
           "defaultLinkRole",
           "defaultListed",
+          "whiteLabel",
           "hostedAgentsEnabled",
           "agentKillswitch",
           "agentAutoEnabled"

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -1411,6 +1411,10 @@ export const artifactRoutes = (ctx: AppContext) => {
         }),
         sessions: groupSessions(versions, versionWindowMs),
         my_role: myRole,
+        // Show the Made-with-Derive mark on this artifact's public surfaces? False
+        // only for white-label workspaces; the viewer reads this single boolean so
+        // workspace settings never travel to anonymous clients.
+        badge: !(await meta.getOrgSettings(artifact.org_id)).whiteLabel,
         // The artifact's current workspace — the move dialog needs this to exclude
         // it from the destination picker.
         org_id: artifact.org_id,

--- a/apps/api/src/routes/embeds.ts
+++ b/apps/api/src/routes/embeds.ts
@@ -204,8 +204,13 @@ export const embedRoutes = (ctx: AppContext) => {
     if (!artifact) return c.body(embedShell(null), 200, headers)
     const info = await infoFor(artifact)
     const src = `${rawBase}/raw/${artifact.short_id}/v/${artifact.current_version}/`
+    // White-label workspaces lose the plaque and may go fully bare (?chrome=none);
+    // for everyone else the bare frame is ignored — the mark is the free tier's rent.
+    const { whiteLabel } = await meta.getOrgSettings(artifact.org_id)
     const shell =
-      c.req.query("chrome") === "none" ? bareShell({ info, src }) : embedShell({ info, src })
+      whiteLabel && c.req.query("chrome") === "none"
+        ? bareShell({ info, src })
+        : embedShell({ info, src, plaque: !whiteLabel })
     return c.body(shell, 200, headers)
   })
 
@@ -274,7 +279,7 @@ export const embedRoutes = (ctx: AppContext) => {
  * viewer's light/dark scheme with the app's own tokens; the plaque is frosted so it
  * holds over any artifact content. `null` = a private/unavailable placeholder.
  */
-const embedShell = (data: { info: UnfurlInfo; src: string } | null): string => {
+const embedShell = (data: { info: UnfurlInfo; src: string; plaque?: boolean } | null): string => {
   const css =
     ":root{color-scheme:light dark;--canvas:#0a0b0d;--frame:#23252b;--chip:#101216;--tx:#969aa2;--ink:#f3f4f6}" +
     "@media (prefers-color-scheme: light){:root{--canvas:#f7f8fa;--frame:#e5e7eb;--chip:#ffffff;--tx:#5c616b;--ink:#14161a}}" +
@@ -328,8 +333,11 @@ const embedShell = (data: { info: UnfurlInfo; src: string } | null): string => {
     '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9.5"/><path d="M12 11v5"/><path d="M12 7.7h.01"/></svg>'
   const tip =
     "<b>Derive</b> is the home for AI artifacts: publish from any agent, review together, and own the result at a permanent versioned URL."
+  // White-label (plaque:false) keeps the framed shell, just without the mark.
+  const plaqueHtml = (d: { info: UnfurlInfo }) =>
+    `<div class="p"><a class="b" href="${escapeHtml(`${d.info.pageUrl}?ref=embed&src=embed_badge`)}" target="_blank" rel="noopener" title="View on Derive">${mark}Made on Derive</a><button type="button" class="i" aria-label="What is Derive?" aria-describedby="dtip">${infoIcon}</button><span class="tip" id="dtip" role="tooltip">${tip}</span></div>`
   const body = data
-    ? `<div class="c"><iframe src="${escapeHtml(data.src)}" sandbox="allow-scripts allow-forms allow-popups allow-modals" title="${escapeHtml(data.info.title)}"></iframe><div class="p"><a class="b" href="${escapeHtml(`${data.info.pageUrl}?ref=embed&src=embed_badge`)}" target="_blank" rel="noopener" title="View on Derive">${mark}Made on Derive</a><button type="button" class="i" aria-label="What is Derive?" aria-describedby="dtip">${infoIcon}</button><span class="tip" id="dtip" role="tooltip">${tip}</span></div></div>`
+    ? `<div class="c"><iframe src="${escapeHtml(data.src)}" sandbox="allow-scripts allow-forms allow-popups allow-modals" title="${escapeHtml(data.info.title)}"></iframe>${data.plaque !== false ? plaqueHtml(data) : ""}</div>`
     : `<div class="empty">This artifact is private or no longer available.<br>Open it on Derive to request access.</div>`
   return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="robots" content="noindex"><title>${data ? escapeHtml(data.info.title) : "Derive"}</title><style>${css}</style></head><body>${body}</body></html>`
 }

--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -86,6 +86,11 @@ export const workspaceRoutes = (ctx: AppContext) => {
       defaultListed: z
         .enum(["none", "workspace", "public"])
         .describe("Listing a new publish lands with: none (default), workspace, or public."),
+      whiteLabel: z
+        .boolean()
+        .describe(
+          "Hide the Made-with-Derive marks on public artifacts and embeds, and honor the bare ?chrome=none embed.",
+        ),
       hostedAgentsEnabled: z
         .boolean()
         .describe("Master switch for Derive-hosted agent runs; off silences every hosted run."),
@@ -598,6 +603,7 @@ export const workspaceRoutes = (ctx: AppContext) => {
             defaultWorkspaceAccess: z.enum(["none", "member"]),
             defaultLinkRole: z.enum(["none", "viewer", "commenter", "editor"]),
             defaultListed: z.enum(["none", "workspace", "public"]),
+            whiteLabel: z.boolean(),
             hostedAgentsEnabled: z.boolean(),
             agentKillswitch: z.boolean(),
             agentAutoEnabled: z.boolean(),

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -130,6 +130,12 @@ export const Artifact = z
       .boolean()
       .optional()
       .describe("true when the world link is password-locked (the password is never returned)."),
+    badge: z
+      .boolean()
+      .optional()
+      .describe(
+        "Show the Made-with-Derive mark on this artifact's public surfaces (false = white-label workspace).",
+      ),
     org_id: z
       .string()
       .optional()

--- a/apps/api/test/integrations-settings.test.ts
+++ b/apps/api/test/integrations-settings.test.ts
@@ -20,6 +20,8 @@ describe("workspace integration settings", () => {
       defaultWorkspaceAccess: "member",
       defaultLinkRole: "none",
       defaultListed: "none",
+      // Branding stays on until a workspace white-labels (the Team affordance).
+      whiteLabel: false,
       // Hosted-agent controls: hosting available, no autonomy until opted in.
       hostedAgentsEnabled: true,
       agentKillswitch: false,

--- a/apps/api/test/white-label.test.ts
+++ b/apps/api/test/white-label.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+import { app, as, makeAuthedApp, meta, type TestUser, upload } from "./helpers"
+
+const idOf = async (res: Response): Promise<string> => (await res.json()).short_id
+
+// White-label (GTM step 08): one workspace flag hides the Made-with-Derive marks
+// on the shared surfaces and unlocks the bare embed. Free workspaces keep the
+// badge everywhere — including when they ask for ?chrome=none.
+describe("white-label", () => {
+  it("defaults off: detail carries badge true, embed carries the plaque", async () => {
+    const short = await idOf(await upload("w.md", "# Hi", { visibility: "public", title: "W" }))
+    const detail = await (await app.request(`/v1/artifacts/${short}`)).json()
+    expect(detail.badge).toBe(true)
+
+    const shell = await (await app.request(`/v1/embed/${short}`)).text()
+    expect(shell).toContain("Made on Derive")
+  })
+
+  it("ignores ?chrome=none for a workspace without white-label", async () => {
+    const short = await idOf(await upload("wc.md", "# Hi", { visibility: "public", title: "WC" }))
+    const shell = await (await app.request(`/v1/embed/${short}?chrome=none`)).text()
+    // The bare frame is the paid affordance; free embeds keep the plaque.
+    expect(shell).toContain("Made on Derive")
+  })
+
+  it("white-label on: badge false, plaque gone, chrome=none honored", async () => {
+    const short = await idOf(await upload("wl.md", "# Hi", { visibility: "public", title: "WL" }))
+    const cur = await meta.getOrgSettings("default")
+    await meta.setOrgSettings("default", { ...cur, whiteLabel: true })
+    try {
+      const detail = await (await app.request(`/v1/artifacts/${short}`)).json()
+      expect(detail.badge).toBe(false)
+
+      const shell = await (await app.request(`/v1/embed/${short}`)).text()
+      expect(shell).not.toContain("Made on Derive")
+      expect(shell).toContain("<iframe") // still the framed shell, just unbranded
+
+      const bare = await (await app.request(`/v1/embed/${short}?chrome=none`)).text()
+      expect(bare).not.toContain("Made on Derive")
+      expect(bare).not.toContain('class="c"') // bareShell: no frame chrome at all
+    } finally {
+      await meta.setOrgSettings("default", { ...cur, whiteLabel: false })
+    }
+  })
+
+  it("admins flip it over PATCH /v1/workspace/settings; the merge keeps other keys", async () => {
+    const ada: TestUser = { id: "u_wl_ada", email: "wlada@d.test", name: "Ada" }
+    const { app: authed } = makeAuthedApp("white-label", [ada])
+    const res = await authed.request("/v1/workspace/settings", {
+      method: "PATCH",
+      headers: { "content-type": "application/json", ...as(ada.email) },
+      body: JSON.stringify({ whiteLabel: true }),
+    })
+    expect(res.status).toBe(200)
+    const settings = await res.json()
+    expect(settings.whiteLabel).toBe(true)
+    // Untouched keys keep their defaults — the PATCH is a merge, not a replace.
+    expect(settings.emailNotifications).toBe(true)
+  })
+})

--- a/apps/web/public/site/pricing.html
+++ b/apps/web/public/site/pricing.html
@@ -223,6 +223,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
         <li>Everything in Free, plus</li>
         <li><strong>Unlimited editors</strong></li>
         <li>Custom domain</li>
+        <li>White-label shared pages</li>
         <li>Password-protected links</li>
         <li><strong>Brandprint</strong>: your house style, read by every agent</li>
         <li>50 GB pooled storage, then ~$1 per extra 10 GB/month</li>

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -5500,6 +5500,8 @@ export interface components {
             listed?: "none" | "workspace" | "public";
             /** @description true when the world link is password-locked (the password is never returned). */
             password_protected?: boolean;
+            /** @description Show the Made-with-Derive mark on this artifact's public surfaces (false = white-label workspace). */
+            badge?: boolean;
             /** @description The artifact's workspace id; drives move-to-workspace. */
             org_id?: string;
             /** @description Signed, short-lived token for fetching raw content; detail responses only. */
@@ -5737,6 +5739,8 @@ export interface components {
              * @enum {string}
              */
             defaultListed: "none" | "workspace" | "public";
+            /** @description Hide the Made-with-Derive marks on public artifacts and embeds, and honor the bare ?chrome=none embed. */
+            whiteLabel: boolean;
             /** @description Master switch for Derive-hosted agent runs; off silences every hosted run. */
             hostedAgentsEnabled: boolean;
             /** @description When true, every hosted agent write demotes to a proposal, instantly. */

--- a/apps/web/src/pages/artifact/public-viewer.tsx
+++ b/apps/web/src/pages/artifact/public-viewer.tsx
@@ -111,20 +111,23 @@ export function PublicViewer({
       <div className="relative flex min-h-0 flex-1 flex-col">{children}</div>
 
       {/* A quiet, permanent brand mark (the "Made in Framer" idiom — attribution +
-          a soft nudge, never a wall). A real link now: the click lands in product
-          (signup → publish), stamped as the badge surface. */}
-      <footer className="flex shrink-0 items-center justify-center border-t border-border-soft py-1.5 font-mono text-2xs text-muted-foreground">
-        <Link
-          to="/login"
-          search={{ signup: true, return_to: "/new" }}
-          onClick={() => stampSrc("badge", art.short_id)}
-          data-testid="public-made-with"
-          className="flex items-center gap-1.5 rounded-md outline-none hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-        >
-          <Logo size={12} />
-          Made with Derive
-        </Link>
-      </footer>
+          a soft nudge, never a wall). A real link: the click lands in product
+          (signup → publish), stamped as the badge surface. White-label workspaces
+          (art.badge === false) drop the strip entirely — that's what they pay for. */}
+      {art.badge !== false && (
+        <footer className="flex shrink-0 items-center justify-center border-t border-border-soft py-1.5 font-mono text-2xs text-muted-foreground">
+          <Link
+            to="/login"
+            search={{ signup: true, return_to: "/new" }}
+            onClick={() => stampSrc("badge", art.short_id)}
+            data-testid="public-made-with"
+            className="flex items-center gap-1.5 rounded-md outline-none hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+          >
+            <Logo size={12} />
+            Made with Derive
+          </Link>
+        </footer>
+      )}
     </div>
   )
 }

--- a/apps/web/src/pages/settings/general-section.tsx
+++ b/apps/web/src/pages/settings/general-section.tsx
@@ -22,6 +22,7 @@ import {
   SelectMenuItem,
   SelectMenuTrigger,
 } from "@/components/ui/select-menu"
+import { Switch } from "@/components/ui/switch"
 import { reloadAfterWorkspaceChange } from "@/lib/persist"
 import { workspaceQuery, workspaceSettingsQuery, workspacesQuery } from "@/lib/queries"
 import { snapshot, useApiMutation } from "@/lib/use-api-mutation"
@@ -368,6 +369,18 @@ function SharingDefaults() {
             <SelectMenuItem value="public">Public directory</SelectMenuItem>
           </SelectMenuContent>
         </SelectMenu>
+      </SettingRow>
+      <SettingRow
+        htmlFor="toggle-white-label"
+        label="White-label shared pages"
+        description="Hide the Made-with-Derive mark on public artifacts and embeds, and allow the bare embed (?chrome=none). A Team-plan feature once billing arrives; free during the beta."
+      >
+        <Switch
+          id="toggle-white-label"
+          data-testid="toggle-white-label"
+          checked={settings.whiteLabel}
+          onCheckedChange={(next) => set("whiteLabel", next)}
+        />
       </SettingRow>
     </SettingsGroup>
   )

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -2115,6 +2115,10 @@ export interface OrgSettings {
   defaultWorkspaceAccess: WorkspaceAccess
   defaultLinkRole: LinkRole
   defaultListed: Listed
+  /** White-label shared surfaces: hide the Made-with-Derive marks (public-viewer
+   *  footer, embed plaque) and honor the bare `?chrome=none` embed. The Team-tier
+   *  affordance; free workspaces keep the badge and the bare embed is ignored. */
+  whiteLabel: boolean
   /** Master switch for Derive-hosted agent runs in this workspace. Off silences every
    *  hosted run (the managed executor skips the workspace); owner-run agents are
    *  unaffected. */
@@ -2163,6 +2167,7 @@ export const DEFAULT_ORG_SETTINGS: OrgSettings = {
   defaultWorkspaceAccess: "member",
   defaultLinkRole: "none",
   defaultListed: "none",
+  whiteLabel: false,
   // Hosting on by default: it does nothing until an agent is flagged hosted, and
   // the run-time safety lives in the autonomy gate (killswitch defaults off but
   // every write still lands as a proposal until a workspace opts into auto).


### PR DESCRIPTION
## What

The badge surfaces shipped in #523; this is the switch that turns them off — and the first thing money buys. One workspace flag, three enforcement points, one settings row, and the pricing page kept honest in the same PR.

- **The flag:** `OrgSettings.whiteLabel`, a JSON-blob key defaulting to `false` — no schema migration; absent keys fall back like every other setting. Admins flip it in Settings → General beside the sharing defaults, or over `PATCH /v1/workspace/settings` through the same partial-merge path as the other toggles.
- **The public viewer:** the artifact detail response now carries a single derived `badge` boolean; `PublicViewer` drops its footer mark when it's false. Workspace settings never travel to anonymous clients — the viewer learns one bit, nothing else.
- **The embed:** white-label workspaces get plaque-free framed embeds, and `?chrome=none` is honored **only** for them. Until now anyone who read the docs could get a fully unbranded frame for free; this closes that loophole. Free embeds keep the plaque — t rent.
- **Pricing page:** "White-label shared pages" joins the Team tier list (between Custom domain and
Password-protected links), so the paid prrecord before billing exists — consistentwith how we've handled pricing all along.

## Why now, before billing

Two reasons. The gate has to exist day one so step 11 (billing) maps "Team" onto an existing boolean instead of re-plumbing three surfaces under pressiberately free during beta — the settingscopy says so — because the point today is the boundary, not the enforcement.

## Behavior notes                                                                                            
- Defaults change nothing: every existing workspace's pages render identically until an admin opts in.       - A white-labeled workspace removes itselhoice; arrivals still stamp`artifact_visit` server-side, so funnel attribution keeps working either way.                                
## Tests (written first, watched fail)                                                                       
Defaults (badge true, plaque present, `chrome=none` ignored); white-label on (badge false, plaque gone, bare embed honored); the PATCH merge preservinsettings-defaults contract updated toinclude the new key. OpenAPI spec + web API types regenerated. Full workspace suite, CI gate, typecheck, and the coverage lane all green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787693957&installation_model_id=428097&pr_number=546&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F546&signature=fa8a3ddf8bf48afe30d49d4f3853fae97925055a8d6e24a95c3068f1b474d31c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->