### PR TITLE
feat(viewer): ghost drift in the anon comments panel; CTA joins the c…

### DIFF
--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -106,7 +106,9 @@ export function Artifact() {
   const { data: art, isError: failed, error, refetch } = useQuery(artifactQuery(shortId))
   // The tab is named after the document, like the workbench header (title, else id).
   useDocumentTitle(art ? (art.title ?? shortId) : null)
-  const { data: comments = [] } = useQuery(commentsQuery(shortId))
+  // Comments are signed-in-only (the API 404s anon by design) — don't fire the
+  // query just to watch it fail on every public view.
+  const { data: comments = [] } = useQuery({ ...commentsQuery(shortId), enabled: !!me })
   // Agents this viewer can hand a revision to (the "ask an agent" flow). Empty for
   // an anon viewer (the query is authed) or a workspace with no agents — then the
   // affordance simply doesn't appear.

--- a/apps/web/src/pages/artifact/lib/comment-access.test.ts
+++ b/apps/web/src/pages/artifact/lib/comment-access.test.ts
@@ -31,16 +31,16 @@ describe("commentNudgeCopy (pill + panel wording)", () => {
     expect(commentNudgeCopy(9)).toEqual({
       pill: "9 comments",
       heading: "9 comments",
-      cta: "Sign in to join",
+      cta: "Join the conversation",
     })
     expect(commentNudgeCopy(1)).toEqual({
       pill: "1 comment",
       heading: "1 comment",
-      cta: "Sign in to join",
+      cta: "Join the conversation",
     })
   })
-  it("with none (or an absent count): a plain invitation to start", () => {
-    const empty = { pill: "Comments", heading: "No comments yet", cta: "Sign in to comment" }
+  it("with none (or an absent count): no heading — deliberately ambiguous", () => {
+    const empty = { pill: "Comments", heading: null, cta: "Sign in to comment" }
     expect(commentNudgeCopy(0)).toEqual(empty)
     expect(commentNudgeCopy(undefined)).toEqual(empty)
   })

--- a/apps/web/src/pages/artifact/lib/comment-access.ts
+++ b/apps/web/src/pages/artifact/lib/comment-access.ts
@@ -22,14 +22,17 @@ export const shouldPromptSignInToComment = (
   removed: boolean,
 ): boolean => (linkRole === "commenter" || linkRole === "editor") && !removed
 
-/** The nudge's three strings, from the detail response's open-thread count: the
- *  floating pill, the panel heading, and the sign-in CTA. With threads open the
- *  copy sells the conversation ("9 comments · Sign in to join"); empty (or count
- *  withheld) it invites the first one. Pure so the wording is pinned by tests. */
+/** The nudge's strings, from the detail response's open-thread count: the floating
+ *  pill, the panel heading, and the sign-in CTA. With threads open the copy sells
+ *  the conversation ("9 comments · Join the conversation"). Empty (or count
+ *  withheld) drops the heading entirely — "Sign in to comment" over the drifting
+ *  backdrop, deliberately ambiguous about whether anything sits behind the wall,
+ *  rather than announcing there's nothing to see. Pure so the wording is pinned
+ *  by tests. */
 export const commentNudgeCopy = (
   count: number | undefined,
-): { pill: string; heading: string; cta: string } => {
-  if (!count) return { pill: "Comments", heading: "No comments yet", cta: "Sign in to comment" }
+): { pill: string; heading: string | null; cta: string } => {
+  if (!count) return { pill: "Comments", heading: null, cta: "Sign in to comment" }
   const n = `${count} comment${count === 1 ? "" : "s"}`
-  return { pill: n, heading: n, cta: "Sign in to join" }
+  return { pill: n, heading: n, cta: "Join the conversation" }
 }

--- a/apps/web/src/pages/artifact/public-viewer.tsx
+++ b/apps/web/src/pages/artifact/public-viewer.tsx
@@ -8,9 +8,27 @@ import { Button } from "@/components/ui/button"
 import { artifactTypeLabel } from "@/lib/artifact"
 import { stampSrc } from "@/lib/src-stamp"
 import { ago } from "@/lib/time"
+import { cn } from "@/lib/utils"
 import { FloatingControl } from "./floating-control"
 import { commentNudgeCopy, shouldPromptSignInToComment } from "./lib/comment-access"
 import { Presence } from "./rail-deck"
+
+// Backdrop texture for the anon comments panel — the marketing site's "chats
+// scroll away" ocean, miniaturized to one column. Deliberately generic review
+// chatter (no names, no specifics): real comment bodies never reach anonymous
+// viewers, and these must read as decoration, not as a blurred peek at the thread.
+const GHOST_COMMENTS = [
+  "This section sings.",
+  "can we tighten the intro?",
+  "Ship it.",
+  "the chart carries this page",
+  "second look before Friday?",
+  "Approved",
+  "v4 fixed it",
+  "needs a number behind this claim",
+  "much better in this version",
+  "same note as last round, resolved",
+]
 
 // The public / viral viewer — the chrome-light experience an anonymous visitor
 // gets on a shared /artifacts/ link (the growth loop). The render is the whole page; a
@@ -160,18 +178,49 @@ export function PublicViewer({
                 <X className="size-4" aria-hidden />
               </Button>
             </div>
-            <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
-              <Icon name="comments" size={24} className="text-muted-foreground" />
-              <p className="text-sm text-muted-foreground">{copy.heading}</p>
-              <Button asChild variant="default" size="sm" data-testid="public-sign-in-to-comment">
-                <Link
-                  to="/login"
-                  search={{ return_to: returnTo }}
-                  onClick={() => stampSrc("comment_wall", art.short_id)}
-                >
-                  {copy.cta}
-                </Link>
-              </Button>
+            <div className="relative flex flex-1 flex-col items-center justify-center gap-3 overflow-hidden px-6 text-center">
+              {/* The drifting backdrop. The list renders 4x so one loop copy (2x)
+                  outruns any panel height; the mask fades both edges the way the
+                  marketing ocean does. Texture, never content — aria-hidden. */}
+              <div
+                aria-hidden
+                className="pointer-events-none absolute inset-x-5 inset-y-0 [mask-image:linear-gradient(to_bottom,transparent,black_22%,black_78%,transparent)]"
+              >
+                <div className="flex animate-ghost-drift flex-col gap-5">
+                  {Array.from({ length: 4 }, () => GHOST_COMMENTS)
+                    .flat()
+                    .map((g, i) => (
+                      <span
+                        key={`${g}-${i}`}
+                        className={cn(
+                          "whitespace-nowrap font-mono text-2xs text-foreground",
+                          i % 3 === 1 && "self-end",
+                          i % 3 === 2 && "self-center",
+                          i % 2
+                            ? "opacity-10"
+                            : "rounded-lg border border-border-soft bg-card px-3 py-2 opacity-20",
+                        )}
+                      >
+                        {g}
+                      </span>
+                    ))}
+                </div>
+              </div>
+              {/* The crisp card among the ghosts — the marketing ocean's "kept"
+                  idiom: the chatter drifts, the invitation holds still. */}
+              <div className="relative flex flex-col items-center gap-3 rounded-2xl border border-border-soft bg-background/90 px-7 py-6 shadow-[var(--shadow)] backdrop-blur-[2px]">
+                <Icon name="comments" size={24} className="text-muted-foreground" />
+                {copy.heading && <p className="text-sm text-muted-foreground">{copy.heading}</p>}
+                <Button asChild variant="default" size="sm" data-testid="public-sign-in-to-comment">
+                  <Link
+                    to="/login"
+                    search={{ return_to: returnTo }}
+                    onClick={() => stampSrc("comment_wall", art.short_id)}
+                  >
+                    {copy.cta}
+                  </Link>
+                </Button>
+              </div>
             </div>
           </aside>
         )}

--- a/apps/web/src/routes/artifacts.$ref.tsx
+++ b/apps/web/src/routes/artifacts.$ref.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { artifactQuery, commentsQuery, prefetchArtifactRaw } from "../lib/queries"
+import { artifactQuery, commentsQuery, meQuery, prefetchArtifactRaw } from "../lib/queries"
 import { Artifact } from "../pages/artifact"
 import { candidateShortIds, parseRef } from "../pages/artifact/parse-ref"
 import { WorkbenchSkeleton } from "../pages/artifact/workbench-skeleton"
@@ -29,7 +29,10 @@ export const Route = createFileRoute("/artifacts/$ref")({
     for (const id of candidateShortIds(params.ref)) {
       const art = await queryClient.ensureQueryData(artifactQuery(id)).catch(() => null)
       if (art) {
-        queryClient.prefetchQuery(commentsQuery(id))
+        // Comments are signed-in-only (the API 404s anon by design) — warm them
+        // only for a session the page will actually read them with.
+        if (queryClient.getQueryData(meQuery().queryKey))
+          queryClient.prefetchQuery(commentsQuery(id))
         if (!art.removed) prefetchArtifactRaw(id, version ?? art.current_version)
         return
       }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -399,6 +399,23 @@
   animation: derive-skeleton-breath 1.6s ease-in-out infinite;
 }
 
+/* The anon comment panel's ghost drift (public-viewer.tsx) — the marketing site's
+   "chats scroll away" ocean, miniaturized: one column of placeholder chips drifts
+   up behind the sign-in CTA. The column renders its list twice, so -50% loops
+   seamlessly. Reduced motion is handled by the global rule below (the column
+   snaps to rest and reads as a static backdrop). */
+@keyframes derive-ghost-drift {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-50%);
+  }
+}
+@utility animate-ghost-drift {
+  animation: derive-ghost-drift 36s linear infinite;
+}
+
 /* Honor prefers-reduced-motion (unlayered → wins over utilities without !important). */
 @media (prefers-reduced-motion: reduce) {
   *,


### PR DESCRIPTION
## What

Two refinements to the anon comment nudge that shipped in #547, both on the panel:

- **The wording:** with threads open, the CTA leads with the conversation instead of the auth: "9 comments · Join the conversation". On an empty doc the panel drops the heading entirely and says only "Sign in to comment" over the backdrop, deliberately ambiguous about whether anything sits behind the wall rather than announcing there's nothing to see.
- **The backdrop:** the marketing site's "chats scroll away" ocean, miniaturized to one column. Generic review chatter drifts up behind a crisp card holding the CTA: the chatter moves, the invitation holds still. The ghosts are deliberately unspecific (no names, no content) because real comment bodies never reach anonymous viewers; the backdrop must read as decoration, never as a blurred peek at the thread. `prefers-reduced-motion` brings the column to rest via the app's existing global rule.

## Also in here

Every public view was firing the comments fetch just to watch the API 404 it (comments are signed-in-only by design), logging a console error on each anonymous visit. The component query and the route-loader prefetch are now both gated to signed-in sessions.

## Verified

Spun up locally and checked all three states in the browser: nine comments on desktop, the empty doc, and the 390px overlay. Copy matrix pinned by unit tests; web suite (194) and the repo CI gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787704130&installation_model_id=428097&pr_number=548&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F548&signature=78904d2f5588bd3e1e33bf8f24dccb18fd170d3f216edd9010a76e69919340fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->