### PR TITLE
feat(deploy): turn on Cloudflare hosted runs (containers + dispatch queue)

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -96,50 +96,52 @@ new_sqlite_classes = ["RepoSyncRunner"]
 tag = "v4"
 new_sqlite_classes = ["PreviewRenderer"]
 
-# EXPERIMENTAL — hosted automation runs. Uncomment these three blocks to let the
-# every-minute cron EXECUTE due automation runs in scale-to-zero containers (one run
-# per instance, then it exits): the tick materializes due schedules, reclaims runs
-# whose container died, mints a per-run capability token, and boots one container per
-# run. Leave them commented (the default) and runs stay queued for a polling
-# `derive runner`, exactly as before. Requires Containers on your Cloudflare account.
-#
-# [[durable_objects.bindings]]
-# name = "RUN_CONTAINER"
-# class_name = "RunContainer"
-#
-# [[migrations]]
-# tag = "v5"
-# new_sqlite_classes = ["RunContainer"]
-#
-# [[containers]]
-# class_name = "RunContainer"
-# # The SAME image the owner-operated runner uses: its entrypoint sees the per-run
-# # capability token in the env and takes the one-shot run lane automatically.
-# image = "../../deploy/runner.Dockerfile"
-# # The Dockerfile COPYs packages/cli and deploy/ — repo-root paths — but wrangler builds
-# # relative to THIS file by default, so the image fails to build without this. Caught by
-# # `wrangler deploy --dry-run` rather than by a failed production deploy.
-# image_build_context = "../.."
-# # A run is minutes of coding-agent work — size for the agent, not a web request.
-# instance_type = "standard-1"
-# max_instances = 20
-#
-# # The dispatch queue: a LATENCY nudge, not the source of truth. Postgres is the queue of
-# # record, so a lost or duplicated message costs seconds, never work — the cron sweep above
-# # re-dispatches anything still queued, and starting a run twice is a no-op (the executor's
-# # claim is status-guarded). Without this, "Run now" simply waits for the next minute's tick.
-# [[queues.producers]]
-# binding = "RUN_QUEUE"
-# queue = "derive-runs"
-#
-# [[queues.consumers]]
-# queue = "derive-runs"
-# # Small batches, short wait: this exists to cut latency, so holding messages defeats it.
-# max_batch_size = 10
-# max_batch_timeout = 5
-# # One retry, then drop: the sweep is the real backstop, and a message retried for minutes
-# # would just duplicate what the tick already picked up.
-# max_retries = 1
+# EXPERIMENTAL — hosted automation runs. These blocks let the every-minute cron
+# EXECUTE due automation runs in scale-to-zero containers (one run per instance, then
+# it exits): the tick materializes due schedules, reclaims runs whose container died,
+# mints a per-run capability token, and boots one container per run. Comment them out
+# (the shipped default until now) and runs stay queued for a polling `derive runner`,
+# exactly as before. Requires Containers on your Cloudflare account.
+
+[[durable_objects.bindings]]
+name = "RUN_CONTAINER"
+class_name = "RunContainer"
+
+[[migrations]]
+tag = "v5"
+new_sqlite_classes = ["RunContainer"]
+
+[[containers]]
+class_name = "RunContainer"
+# The SAME image the owner-operated runner uses: its entrypoint sees the per-run
+# capability token in the env and takes the one-shot run lane automatically.
+image = "../../deploy/runner.Dockerfile"
+# The Dockerfile COPYs packages/cli and deploy/ — repo-root paths — but wrangler builds
+# relative to THIS file by default, so the image fails to build without this. Caught by
+# `wrangler deploy --dry-run` rather than by a failed production deploy.
+image_build_context = "../.."
+# A run is minutes of coding-agent work — size for the agent, not a web request.
+instance_type = "standard-1"
+# First-run training wheels: two concurrent runs is enough to prove the lane end to
+# end while capping worst-case spend. Raise toward 20 once a real run has completed.
+max_instances = 2
+
+# The dispatch queue: a LATENCY nudge, not the source of truth. Postgres is the queue of
+# record, so a lost or duplicated message costs seconds, never work — the cron sweep above
+# re-dispatches anything still queued, and starting a run twice is a no-op (the executor's
+# claim is status-guarded). Without this, "Run now" simply waits for the next minute's tick.
+[[queues.producers]]
+binding = "RUN_QUEUE"
+queue = "derive-runs"
+
+[[queues.consumers]]
+queue = "derive-runs"
+# Small batches, short wait: this exists to cut latency, so holding messages defeats it.
+max_batch_size = 10
+max_batch_timeout = 5
+# One retry, then drop: the sweep is the real backstop, and a message retried for minutes
+# would just duplicate what the tick already picked up.
+max_retries = 1
 
 # Cloudflare Browser Rendering binding — required for the PreviewRenderer DO.
 # Leave commented if Browser Rendering is not enabled on your account; the worker


### PR DESCRIPTION
Stacked on #518 — one commit: uncomment the four hosted-run blocks in `apps/api/wrangler.toml` and start `max_instances` at **2** (training wheels for the first live runs; raise toward 20 once the lane is proven).

**Do not merge until the first deploy has been done by hand** — merging to main auto-deploys, and the first containers deploy should be watched (`wrangler tail` + the run timeline).

Pre-flight already done against prod (2026-07-27):

- [x] Pre-deploy SQL (`scripts/pre-deploy-hosted-runs.sql`) — all sections empty, incl. blocking query 2b. Verdict per the script: deploying changes no existing behaviour (0 runs, 1 automation, no dormant schedules).
- [x] `derive-runs` queue created on the prod account.
- [x] All 59 existing workspaces opted out (`hostedAgentsEnabled: false` in `org_settings`, merged into existing blobs; new workspaces still default on).
- [x] `DERIVE_AUTH_SECRET` confirmed set on the prod worker.
- [x] `wrangler deploy --dry-run` green with these blocks live: `RUN_CONTAINER` + `RUN_QUEUE (derive-runs)` bound, runner image builds.

Manual deploy needs the real D1/Hyperdrive ids injected in place of the placeholders (CI does this from repo secrets; pull them from the live worker settings or the dashboard — deliberately not written here).

After #518 merges this retargets to main; merge it only once the hand deploy has been verified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787763738&installation_model_id=428097&pr_number=549&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F549&signature=29baf1537c7f0ebbfbccb4e39686134b49efcbf68821476ad85b29da87fb28f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->