### PR TITLE
feat(contexts): dogfood polish — owner steer, empty-pull note, REST knobs, page sniffer

### DIFF
--- a/apps/api/src/mcp-tools/use-runner.ts
+++ b/apps/api/src/mcp-tools/use-runner.ts
@@ -22,6 +22,21 @@ import { clipSessionText, ENTRY_MAX, err, json } from "../mcp-util"
 
 type ToolResult = ReturnType<typeof json> | ReturnType<typeof err>
 
+/** OWNER-RUN gate: does this connection's human hold the manage-grade (owner) seat in
+ *  `org`? Grants only — a registered agent runs by agent_id, never by seat. The default
+ *  workspace's role is already membership-capped; a roamed one re-caps from the grant's
+ *  scope against live membership, the same rule as resolveWs / the X-Derive-Workspace
+ *  re-home. Exactly the people who could rewire the context anyway. Shared with `use`'s
+ *  give path, which steers an owner to owner-run when a queue has no live runner. */
+export const ownerRunsOrg = async (tc: ToolContext, org: string): Promise<boolean> => {
+  const { ctx, agent, actingFor, ownerId, scopeForCap, registered, inGrant } = tc
+  if (registered || !actingFor) return false
+  if (org === agent.org_id) return roleAllows(agent.role, "manage")
+  if (!ownerId || !inGrant(org)) return false
+  const m = await ctx.meta.getMembership(org, ownerId)
+  return !!m && roleAllows(capRole(scopeForCap, m.role), "manage")
+}
+
 /** The runner (agent-you-run) half of `use`, dispatched by ownership. Returns a tool
  *  result when the call is a runner op (REPORT/PULL on a context this connection is the
  *  agent for), or null when it isn't — `use` then handles it as a normal asker call. */
@@ -39,22 +54,10 @@ export async function runnerDispatch(
     workspace?: string
   },
 ): Promise<ToolResult | null> {
-  const { ctx, agent, actingFor, ownerId, scopeForCap, registered, inGrant, resolveWs } = tc
+  const { ctx, agent, actingFor, registered, resolveWs } = tc
   const { context, instruction, session_id, answer, progress, state, result_artifact_id, answers } =
     args
 
-  // OWNER-RUN: does this connection's human hold the manage-grade (owner) seat in `org`?
-  // Grants only — a registered agent runs by agent_id, never by seat. The default
-  // workspace's role is already membership-capped; a roamed one re-caps from the grant's
-  // scope against live membership, the same rule as resolveWs / the X-Derive-Workspace
-  // re-home. Exactly the people who could rewire the context anyway.
-  const ownerRunsOrg = async (org: string): Promise<boolean> => {
-    if (registered || !actingFor) return false
-    if (org === agent.org_id) return roleAllows(agent.role, "manage")
-    if (!ownerId || !inGrant(org)) return false
-    const m = await ctx.meta.getMembership(org, ownerId)
-    return !!m && roleAllows(capRole(scopeForCap, m.role), "manage")
-  }
   // The agent turn's author: the registered agent, or the owner-run human — the
   // transcript says who actually did the work.
   const runnerId = registered ? agent.id : (actingFor?.id ?? agent.id)
@@ -117,7 +120,11 @@ export async function runnerDispatch(
         ? {
             note: "At the context's concurrency cap — answer an in-flight session before claiming more.",
           }
-        : {}),
+        : sessions.length === 0
+          ? {
+              note: "Nothing queued. Work arrives when someone gives this context an instruction — use({context, instruction}).",
+            }
+          : {}),
       sessions: sessions.map((s) => ({
         session_id: s.id,
         state: s.state,
@@ -210,7 +217,7 @@ export async function runnerDispatch(
   if (session_id && answer !== undefined) {
     const s = await ctx.meta.getSession(session_id)
     const x = s ? await ctx.meta.getContext(s.context_id) : null
-    if (s && x && (registered ? x.agent_id === agent.id : await ownerRunsOrg(x.org_id)))
+    if (s && x && (registered ? x.agent_id === agent.id : await ownerRunsOrg(tc, x.org_id)))
       return runnerAnswer(s, x, { body: answer, progress, state, result_artifact_id, answers })
   }
   // PULL your queued work: a context you run + NO instruction (a give always has one, so a

--- a/apps/api/src/mcp-tools/use.ts
+++ b/apps/api/src/mcp-tools/use.ts
@@ -2,7 +2,7 @@ import { type ContextRecord, newId, type SessionRecord } from "@derive/core"
 import { z } from "zod"
 import type { ToolContext } from "../mcp-tool-context"
 import { ANSWER_MAX, clipSessionText, ENTRY_MAX, err, json, runnerOnline } from "../mcp-util"
-import { runnerDispatch } from "./use-runner"
+import { ownerRunsOrg, runnerDispatch } from "./use-runner"
 
 // USE A CONTEXT — query a workspace's live data agents ------------------------
 // Contexts are askable agent setups (a registered agent wired to a manifest, answering
@@ -219,11 +219,17 @@ export function registerUseTool(tc: ToolContext): void {
         const resultUrl = s.result_artifact_id
           ? `${base}/artifacts/${s.result_artifact_id}`
           : undefined
+        // A queue with no live runner is a dead end for most askers — but its OWNER can
+        // just serve it (owner-run), so steer them there instead of telling them to wait.
+        // Registered agents keep the wait text: their bare use({context}) pull only
+        // reaches contexts they are the agent for.
         const note =
           s.state === "open"
             ? runnerOnline(x)
               ? "Queued — re-call use with this session_id (+ wait) to collect the answer."
-              : "Queued, but the context's runner looks OFFLINE — it answers when it comes back. Re-call use with this session_id later."
+              : (await ownerRunsOrg(tc, x.org_id))
+                ? `Queued, and no runner is polling this context's queue — but you own this workspace, so you can serve it yourself: use({context: "${x.name}"}) with no instruction pulls the queued work (see derive://skills/contexts).`
+                : "Queued, but the context's runner looks OFFLINE — it answers when it comes back. Re-call use with this session_id later."
             : s.state === "working"
               ? "In progress — the runner is working. Re-call use with this session_id (+ wait) to keep watching; the result link fills in as it goes."
               : s.state === "escalated"

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -334,6 +334,15 @@ export const contextRoutes = (ctx: AppContext) => {
           // an existing (service) agent instead.
           agent_id: z.string().optional(),
           manifest_short_id: z.string(),
+          // Same knobs (and bounds) as the MCP create_context action: per-run
+          // budget and runner parallelism. Omitted → the store defaults.
+          max_run_ms: z
+            .number()
+            .int()
+            .min(30_000)
+            .max(6 * 60 * 60_000)
+            .optional(),
+          max_concurrency: z.number().int().min(1).max(10).optional(),
         }),
       )
       if (b instanceof Response) return bail(b)
@@ -377,6 +386,8 @@ export const contextRoutes = (ctx: AppContext) => {
           agent_id: agentId,
           manifest_artifact_id: manifest.id,
           created_by: owner,
+          max_run_ms: b.max_run_ms ?? null,
+          ...(b.max_concurrency ? { max_concurrency: b.max_concurrency } : {}),
         })
         return c.json(
           {

--- a/apps/api/test/mcp-owner-run.test.ts
+++ b/apps/api/test/mcp-owner-run.test.ts
@@ -183,9 +183,11 @@ describe.skipIf(process.env.DERIVE_TEST_DB === "pg")("MCP owner-run + create_con
   it("owner-run: give, pull, stream progress, settle — one grant end to end", async () => {
     const { app, meta } = ownerApp("own-loop")
     const { created } = await setupContext(app)
-    // Empty queue: a bare use({context}) is the runner pull, not a give error.
+    // Empty queue: a bare use({context}) is the runner pull, not a give error — and
+    // it says the queue is empty rather than returning a bare zero.
     const empty = await call(app, "tok_full", "use", { context: "QA" })
     expect(empty.claimed).toBe(0)
+    expect(empty.note).toContain("Nothing queued")
     // GIVE on the same grant (ask_policy invited admits the creator).
     const opened = await call(app, "tok_full", "use", {
       context: "QA",
@@ -230,6 +232,22 @@ describe.skipIf(process.env.DERIVE_TEST_DB === "pg")("MCP owner-run + create_con
     for (const m of agentTurns) expect(m.author_id).toBe("u_admin")
     // The context's created agent never served: the claim + answers were owner-run.
     expect(agentTurns.some((m) => m.author_id === created.agent_id)).toBe(false)
+  })
+
+  it("a give on an unserved queue steers the owner to owner-run, not to waiting", async () => {
+    const { app } = ownerApp("own-steer")
+    await setupContext(app)
+    // No runner has ever polled: the owner who queued the work is told they can
+    // serve it themselves (a registered agent or non-owner keeps the wait text —
+    // covered in mcp-contexts' offline-note test).
+    const opened = await call(app, "tok_full", "use", {
+      context: "QA",
+      instruction: "Run the smoke suite.",
+      wait: 0,
+    })
+    expect(opened.state).toBe("open")
+    expect(opened.note).toContain("serve it yourself")
+    expect(opened.note).toContain('use({context: "QA"})')
   })
 
   it("non-owner grants fall through to the give path unchanged", async () => {

--- a/apps/api/test/oauth-context-management.test.ts
+++ b/apps/api/test/oauth-context-management.test.ts
@@ -106,6 +106,37 @@ describe.skipIf(process.env.DERIVE_TEST_DB === "pg")("OAuth context management",
     expect(del.status).toBe(204)
   })
 
+  it("create accepts the run knobs (MCP parity) and persists them; out-of-range 400s", async () => {
+    const { app, meta } = managedApp("ctx-mgmt-knobs")
+    const man = await pub(app, "# manifest", { title: "M" }, undefined, {
+      authorization: "Bearer tok_full",
+    })
+    const { short_id } = (await man.json()) as { short_id: string }
+    const res = await app.request("/v1/contexts", {
+      method: "POST",
+      headers: auth("tok_full"),
+      body: JSON.stringify({
+        name: "Knobbed",
+        manifest_short_id: short_id,
+        max_run_ms: 120_000,
+        max_concurrency: 3,
+      }),
+    })
+    expect(res.status).toBe(201)
+    const created = (await res.json()) as { id: string }
+    expect(await meta.getContext(created.id)).toMatchObject({
+      max_run_ms: 120_000,
+      max_concurrency: 3,
+    })
+    // Same bounds as the MCP action: below the 30s lease floor is refused.
+    const bad = await app.request("/v1/contexts", {
+      method: "POST",
+      headers: auth("tok_full"),
+      body: JSON.stringify({ name: "Bad", manifest_short_id: short_id, max_run_ms: 1_000 }),
+    })
+    expect(bad.status).toBe(400)
+  })
+
   it("no manage scope → 403, even for a workspace owner", async () => {
     const { app } = managedApp("ctx-mgmt-noscope")
     expect((await mintAgent(app, "tok_nomanage")).status).toBe(403)

--- a/packages/core/src/publish.test.ts
+++ b/packages/core/src/publish.test.ts
@@ -28,16 +28,31 @@ describe("looksLikeHtmlDocument", () => {
     expect(looksLikeHtmlDocument("")).toBe(false)
   })
 
-  it("is false for an HTML fragment (not a whole document)", () => {
-    // A snippet is not a document; rendering it as markdown is correct.
-    expect(looksLikeHtmlDocument("<div>fragment</div>")).toBe(false)
-    expect(looksLikeHtmlDocument("<p>a paragraph</p>")).toBe(false)
-    expect(looksLikeHtmlDocument("<h1>title</h1>")).toBe(false)
+  it("detects a headless designed page by its head/meta/style openers", () => {
+    // The 2026-07 dogfood miss: a styled report opening with <meta>/<style> (no
+    // doctype) rendered its CSS as visible text through the markdown path.
+    expect(looksLikeHtmlDocument('<meta name="viewport" content="width=device-width" />')).toBe(
+      true,
+    )
+    expect(looksLikeHtmlDocument("<style>body{color:red}</style><p>x</p>")).toBe(true)
+    expect(looksLikeHtmlDocument("<head><title>t</title></head>")).toBe(true)
+    expect(looksLikeHtmlDocument("<body><h1>hi</h1></body>")).toBe(true)
   })
 
-  it("only inspects the very start: a leading comment or XML prolog hides the doc", () => {
-    // Documented limitation — detection keys on the first non-space token.
-    expect(looksLikeHtmlDocument("<!-- note --><!doctype html><html></html>")).toBe(false)
+  it("skips leading HTML comments; the comment alone never decides", () => {
+    expect(looksLikeHtmlDocument("<!-- generated --><!doctype html><html></html>")).toBe(true)
+    expect(looksLikeHtmlDocument('<!-- a -->\n<!-- b -->\n<meta charset="utf-8" />')).toBe(true)
+    // Markdown that merely opens with a comment stays markdown.
+    expect(looksLikeHtmlDocument("<!-- prettier-ignore -->\n# Heading\n\nprose")).toBe(false)
+    expect(looksLikeHtmlDocument("<!-- unterminated comment")).toBe(false)
+  })
+
+  it("is false for ambiguous fragments — how HTML-flavored Markdown opens", () => {
+    // A centered README opens with <div align="center">; a snippet with <p>/<h1>.
+    // Rendering those as markdown is correct.
+    expect(looksLikeHtmlDocument('<div align="center">fragment</div>')).toBe(false)
+    expect(looksLikeHtmlDocument("<p>a paragraph</p>")).toBe(false)
+    expect(looksLikeHtmlDocument("<h1>title</h1>")).toBe(false)
     expect(looksLikeHtmlDocument('<?xml version="1.0"?><svg></svg>')).toBe(false)
   })
 })

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -17,15 +17,25 @@ import {
 import { isSkillBundle, parseFrontmatter } from "./skill"
 
 /**
- * Does this content begin like a full HTML document? Used to classify a payload as
- * text/html even if it carries a .md name (a self-contained HTML report committed
- * as Markdown would otherwise render blank). Conservative on purpose — it must
- * START with the doctype/`<html>` marker, so ordinary Markdown that merely embeds
- * some inline HTML is NOT misclassified.
+ * Does this content read as an HTML page? Used to classify a payload as text/html
+ * even when it carries a .md name or no filename hint (a self-contained HTML report
+ * would otherwise render its CSS as visible text). The boundary that matters:
+ * ordinary Markdown must NEVER classify as HTML (the retype incident), so only
+ * unambiguous page openers count — the doctype/`<html>` markers plus the
+ * head/meta/style/title/body openers a headless designed page starts with, after
+ * skipping leading HTML comments (both designed pages and Markdown open with those,
+ * so a comment alone never decides). A leading `<div>`/`<p>`/custom tag stays
+ * NOT-HTML: that is exactly how HTML-flavored Markdown (a centered README)
+ * legitimately opens.
  */
 export const looksLikeHtmlDocument = (text: string): boolean => {
-  const head = text.replace(/^﻿/, "").trimStart().slice(0, 256).toLowerCase()
-  return head.startsWith("<!doctype html") || head.startsWith("<html")
+  let head = text.replace(/^﻿/, "").trimStart()
+  for (let i = 0; i < 8 && head.startsWith("<!--"); i++) {
+    const end = head.indexOf("-->")
+    if (end === -1) return false
+    head = head.slice(end + 3).trimStart()
+  }
+  return /^<(!doctype\s+html|html|head|body|meta|style|title)[\s/>]/i.test(head.slice(0, 64))
 }
 
 export interface PublishInput {

--- a/packages/mcp/src/filename.ts
+++ b/packages/mcp/src/filename.ts
@@ -6,14 +6,25 @@
 // These mirror the server's own sniff, inlined here because the stdio shim keeps NO
 // @derive/core dependency at runtime (it is a thin HTTP client).
 
-/** A full HTML document starts with `<!doctype html>` or `<html>`. Everything else
- *  (Markdown, plain text, an HTML fragment) is NOT one. */
-export const looksLikeHtmlDocument = (s: string): boolean =>
-  /^\s*<(!doctype\s+html|html)[\s>]/i.test(s.slice(0, 256))
+/** An HTML page opener: the doctype/`<html>` markers, plus the head/meta/style/
+ *  title/body openers a headless designed page starts with — matched after skipping
+ *  leading HTML comments (a comment alone never decides). A leading `<div>`/`<p>`/
+ *  custom tag is NOT one: that is how HTML-flavored Markdown (a centered README)
+ *  legitimately opens. Mirrors @derive/core's looksLikeHtmlDocument exactly. */
+export const looksLikeHtmlDocument = (s: string): boolean => {
+  let head = s.replace(/^﻿/, "").trimStart()
+  for (let i = 0; i < 8 && head.startsWith("<!--"); i++) {
+    const end = head.indexOf("-->")
+    if (end === -1) return false
+    head = head.slice(end + 3).trimStart()
+  }
+  return /^<(!doctype\s+html|html|head|body|meta|style|title)[\s/>]/i.test(head.slice(0, 64))
+}
 
-/** The fallback filename for inline content with none given: a full HTML document →
+/** The fallback filename for inline content with none given: an HTML page →
  *  `index.html`, anything else → `index.md`. So Markdown is never stored as HTML.
- *  Caveat: a fragment-HTML artifact (not starting with a doctype) republished with no
- *  filename lands as `.md` — pass an explicit `filename` (or use `edits`) to keep it. */
+ *  Caveat: fragment HTML that opens with a `<div>` (indistinguishable from
+ *  HTML-flavored Markdown) still lands as `.md` — pass an explicit
+ *  `filename` (or use `edits`) to keep it HTML. */
 export const fallbackFilename = (content: string | undefined): string =>
   looksLikeHtmlDocument(content ?? "") ? "index.html" : "index.md"

--- a/packages/mcp/test/filename.test.ts
+++ b/packages/mcp/test/filename.test.ts
@@ -21,16 +21,27 @@ describe("fallbackFilename — inline publish with no filename never re-types ma
   })
 
   it("an HTML fragment is NOT a document, so it defaults to .md (caveat: pass a filename)", () => {
-    // A styled page whose source starts with <div>/<style> rather than a doctype isn't
-    // detected as a document — the caller must pass filename:"x.html" to keep it HTML.
+    // A <div> opener is exactly how HTML-flavored Markdown (a centered README)
+    // starts, so it stays .md — the caller passes filename:"x.html" to keep it HTML.
     expect(fallbackFilename('<div class="card">hi</div>')).toBe("index.md")
-    expect(fallbackFilename("<style>body{color:red}</style><p>x</p>")).toBe("index.md")
+    expect(fallbackFilename("<!-- prettier-ignore -->\n# Heading\n\nprose")).toBe("index.md")
   })
 
-  it("looksLikeHtmlDocument only matches a leading doctype/html tag", () => {
+  it("a headless designed page (meta/style/head openers) lands as .html", () => {
+    expect(fallbackFilename('<meta name="viewport" content="width=device-width" />')).toBe(
+      "index.html",
+    )
+    expect(fallbackFilename("<style>body{color:red}</style><p>x</p>")).toBe("index.html")
+    expect(fallbackFilename("<!-- generated -->\n<meta charset=utf-8><style>a{}</style>")).toBe(
+      "index.html",
+    )
+  })
+
+  it("looksLikeHtmlDocument matches page openers, never mid-text tags", () => {
     expect(looksLikeHtmlDocument("<!DOCTYPE html>")).toBe(true)
     expect(looksLikeHtmlDocument("<html>")).toBe(true)
     expect(looksLikeHtmlDocument("# md then <html> later")).toBe(false)
     expect(looksLikeHtmlDocument("<htmlish>")).toBe(false) // needs a tag boundary
+    expect(looksLikeHtmlDocument("<!-- unterminated")).toBe(false)
   })
 })


### PR DESCRIPTION
Follow-up to #552 (owner-run + create_context), from the first live dogfood run of a real context served entirely through owner-run. Each fix is something that run actually hit. Model doc addendum: "Owner-run and create_context: closing the contexts loop" (`wfu9j4xy`, v2).

## Fixes

1. **Steer the owner, not the wait.** A give on a queue with no live runner told the owner "the runner looks OFFLINE — check back later" when the right answer was "serve it yourself." The open-state note now steers owner-grade grants to the bare `use({context})` pull. Registered agents and non-owners keep the exact previous text (`ownerRunsOrg` extracted and shared with the runner dispatch).
2. **An empty pull says so.** `claimed: 0` now carries "Nothing queued. Work arrives when someone gives this context an instruction" instead of a bare zero.
3. **REST create parity.** `POST /v1/contexts` accepts `max_run_ms` + `max_concurrency` with the same bounds as the MCP `create_context` action; out-of-range 400s.
4. **Headless pages publish as pages.** The run's report (HTML opening with a comment + `<meta>` + `<style>`, no doctype) sniffed as Markdown and rendered its CSS as visible text. `looksLikeHtmlDocument` (core + the `@derive-to/mcp` shim mirror, kept in lockstep) now skips leading HTML comments and accepts the unambiguous page openers (doctype/html/head/body/meta/style/title). A `<div>` opener still reads as HTML-flavored Markdown (the centered-README case), so the retype-incident guarantee holds; the serve-content self-heal backstop widens with it.

## Tests

- `mcp-owner-run.test.ts`: empty-pull note, owner steer on an unserved queue (registered/non-owner text covered by the existing mcp-contexts offline test).
- `oauth-context-management.test.ts`: knobs persisted via REST, out-of-range 400.
- `packages/core/publish.test.ts` + `packages/mcp/test/filename.test.ts`: comment-skip, meta/style openers, README-div negative, unterminated comment.

Full `pnpm verify` green: 153 files / 1310 tests (api) + 34 (mcp shim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787783060&installation_model_id=428097&pr_number=553&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F553&signature=17b3e9dc1772f45a1d74bef139151e69c2710e07194b6b5de3ffd98ea6e0293b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->