### PR TITLE
fix(slack): the generated app manifest is rejected by Slack — three defects

### DIFF
--- a/apps/api/src/lib/slack.ts
+++ b/apps/api/src/lib/slack.ts
@@ -315,6 +315,10 @@ export const openSlackDm = async (token: string, userId: string): Promise<string
  *  automatic prompt (a real scope-drift detector is future work). */
 export const SLACK_BOT_SCOPES = [
   "chat:write",
+  // Required by the /derive slash command. Without it Slack rejects the whole manifest
+  // ("Slash Commands requires `commands` bot scope"), so the app could not be created at
+  // all — the command has shipped since #454, but this scope never accompanied it.
+  "commands",
   "channels:read",
   "channels:join",
   "channels:history",
@@ -322,6 +326,9 @@ export const SLACK_BOT_SCOPES = [
   "groups:history",
   "users:read",
   "users:read.email",
+  // Outbound DMs only (mentions, review requests, shares). Reading DMs would need
+  // im:history, which we deliberately do NOT request — see the bot_events note in
+  // slack-app-setup.ts.
   "im:write",
 ]
 

--- a/apps/api/src/slack-app-setup.ts
+++ b/apps/api/src/slack-app-setup.ts
@@ -17,9 +17,14 @@ export const buildSlackManifest = (baseUrl: string) => {
   const u = (path: string): string => new URL(path, baseUrl).toString()
   return {
     display_information: {
+      // Slack hard-caps this at 140 characters and REJECTS the whole manifest past it
+      // (apps.manifest.validate → invalid_manifest / failed_constraint). This read 156 and
+      // so could never be pasted into "Create from manifest" — the setup page handed every
+      // deployer a manifest Slack refused. Kept under the cap with headroom; the test below
+      // pins it, the same way the 35-char name cap is pinned.
       name: "Derive",
       description:
-        "Get Derive comments, publishes and proposal updates in a Slack channel, reply back from the thread, and DM members for mentions, review requests and shares.",
+        "Derive comments, publishes and proposal updates in a Slack channel. Reply from the thread; DMs for mentions, review requests and shares.",
       background_color: "#1a1a2e",
     },
     features: {
@@ -42,7 +47,15 @@ export const buildSlackManifest = (baseUrl: string) => {
     settings: {
       event_subscriptions: {
         request_url: u("/v1/slack/events"),
-        bot_events: ["message.channels", "message.groups", "message.im"],
+        // Public + private channels only. `message.im` was subscribed here but is
+        // unreachable by design: /v1/slack/events gates every reply on a slack_thread_link
+        // lookup (channel + thread_ts), and links are written ONLY by the channel
+        // comment-mirror — slack-dm.ts never writes one. So a DM could never match, while
+        // Slack still refused the manifest over it ("message.im event is missing scope(s):
+        // im:history"). Dropping the event fixes that without asking to READ users' DMs for
+        // a path that ignores them. When the assistant increment lands, add the event and
+        // im:history together.
+        bot_events: ["message.channels", "message.groups"],
       },
       // Buttons on comment cards (resolve / reopen a thread) POST here.
       interactivity: {

--- a/apps/api/test/slack-app-setup.test.ts
+++ b/apps/api/test/slack-app-setup.test.ts
@@ -18,16 +18,31 @@ describe("buildSlackManifest", () => {
   })
 
   it("is born with the events that drive two-way comment sync", () => {
-    // message.channels/groups/im back reply-back across public, private, and DM channels.
+    // message.channels/groups back reply-back across public and private channels.
     expect(m.settings.event_subscriptions.bot_events).toEqual(
-      expect.arrayContaining(["message.channels", "message.groups", "message.im"]),
+      expect.arrayContaining(["message.channels", "message.groups"]),
     )
+  })
+
+  // Regression: message.im was subscribed but is unreachable — /v1/slack/events keys every
+  // reply on a slack_thread_link (channel + thread_ts) and only the channel comment-mirror
+  // writes those, never slack-dm.ts. Slack rejected the manifest over the missing im:history
+  // scope, and granting it would mean asking to READ users' DMs for a path that ignores them.
+  it("does not subscribe to DM messages it cannot act on (and so needs no im:history)", () => {
+    expect(m.settings.event_subscriptions.bot_events).not.toContain("message.im")
+    expect(m.oauth_config.scopes.bot).not.toContain("im:history")
   })
 
   it("declares the scopes posting, reply-back, and mention-DM email resolution need", () => {
     expect(m.oauth_config.scopes.bot).toEqual(
       expect.arrayContaining(["chat:write", "channels:history", "users:read.email", "im:write"]),
     )
+  })
+
+  // Regression: /derive shipped in #454 but `commands` was never added, so Slack refused the
+  // manifest ("Slash Commands requires `commands` bot scope") — the app was uncreatable.
+  it("declares the commands scope its slash command requires", () => {
+    expect(m.oauth_config.scopes.bot).toContain("commands")
   })
 
   it("declares private-channel history scopes to match the message.groups subscription", () => {
@@ -52,6 +67,14 @@ describe("buildSlackManifest", () => {
   it("is named just Derive (Slack caps the app name at 35 chars)", () => {
     expect(m.display_information.name).toBe("Derive")
     expect(m.display_information.name.length).toBeLessThanOrEqual(35)
+  })
+
+  // Regression: this field shipped at 156 chars, and Slack rejects the WHOLE manifest over
+  // 140 (invalid_manifest / failed_constraint on /display_information/description). The app
+  // could not be created from it at all — caught only by posting the real manifest to
+  // apps.manifest.validate. The name cap above was pinned; this neighbouring one was not.
+  it("keeps the description within Slack's 140-char manifest cap", () => {
+    expect(m.display_information.description.length).toBeLessThanOrEqual(140)
   })
 })
 


### PR DESCRIPTION
The Slack app manifest this repo generates is **rejected by Slack**. `/settings/slack/app/new` and `GET /v1/slack/manifest.json` both serve it, so every deployer following DEPLOY.md hits a wall at **Create New App → From a manifest** and cannot create the app at all.

Found by posting the real manifest to Slack's `apps.manifest.validate` with an app-configuration token. All three came back as hard `invalid_manifest` constraint failures — not warnings.

## 1. `description` was 156 chars against a hard cap of 140

```
failed_constraint  max_length  expected 140, got 156
pointer: /display_information/description
```

The neighbouring 35-char **name** cap was already pinned by a test; this field was not. Reworded to 136 chars (headroom, so a future edit doesn't silently re-break it) with every capability retained.

## 2. `/derive` has shipped since #454 without the `commands` scope

```
requires_commands_bot_scope  Slash Commands requires `commands` bot scope
```

**This one is not cosmetic.** `slackAuthorizeUrl()` builds the "Add to Slack" URL from `SLACK_BOT_SCOPES`, so any install performed before this lands omits `commands` and the slash command stays dead until that workspace **reconnects**. Anyone who already installed needs to re-run Add to Slack.

## 3. `message.im` was subscribed without `im:history`

```
message.im_event_missing_scope  message.im event is missing scope(s): im:history
```

Two ways to fix this, and the choice matters — I dropped the event rather than request the scope.

`message.im` is **unreachable by design**. `/v1/slack/events` gates every inbound reply on a `slack_thread_link` lookup (`channel` + `thread_ts`), and those links are written **only** by the channel comment-mirror (`slack-comments.ts:306`). `slack-dm.ts` never writes one, so a DM can never match the gate — the event is received and discarded.

Granting `im:history` would mean asking users for permission to **read their DMs with the bot** in order to feed a code path that ignores them. Dropping the event fixes the manifest at no cost. When the assistant increment lands, `message.im` + `im:history` go back in together.

A test asserted `message.im` was present, with a comment claiming it backed *"reply-back across public, private, and DM channels"*. That was never true for DMs — corrected.

## Verification

Against Slack itself, not just locally:

| | before | after |
|---|---|---|
| `apps.manifest.validate` | `invalid_manifest`, 3 errors | **`{"ok": true, "errors": []}`** |
| `apps.manifest.create` | impossible | **accepted** |

- 3 new tests pin each constraint. The description cap is mutation-checked — restoring the 156-char string fails it with `expected 156 to be less than or equal to 140`.
- `pnpm run ci` — full gate green (knip included), via the pre-commit hook
- 83 Slack tests pass across 7 files (was 80)

## Note for whoever deploys this

Ship this **before** connecting any workspace. An install done against the old scope list will not request `commands`, and the `/derive` slash command will silently do nothing until that workspace reconnects.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787840222&installation_model_id=428097&pr_number=558&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F558&signature=f4384e8f194e24bd33b50ec667349e074898d975182366bafbe2d45eeb8b4dc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->