### PR TITLE
fix(slack): account linking has never worked — openid.connect.userinfo vs userInfo

### DIFF
--- a/apps/api/src/lib/slack-dm.ts
+++ b/apps/api/src/lib/slack-dm.ts
@@ -1,8 +1,11 @@
 // Per-user Slack DMs: the same "email is for interrupts" policy as notify-email.ts
 // (mentions, review requests, shares — see that file's header), mirrored onto Slack.
-// The Slack user is resolved live from the recipient's Derive account email via
-// users.lookupByEmail (see lib/slack.ts resolveSlackUserIdByEmail) — no per-user OAuth or
-// account-linking step, just the workspace's one bot install. Rides the same durable
+// The Slack user is resolved from the account link when the recipient has one, and only
+// falls back to guessing by their Derive account email via users.lookupByEmail (see
+// lib/slack.ts resolveSlackUserIdByEmail) when they haven't linked. That fallback is
+// best-effort: an unmatched email is reported as delivered-but-skipped rather than a
+// failure, so a Derive address that differs from the Slack one drops the DM silently —
+// linking is what makes delivery reliable. Rides the same durable
 // outbox as the comment mirror (a `slack_dm` delivery kind). Self-host clean: no new env,
 // no scheduler — a DM is enqueued inline with the triggering action and delivered by the
 // outbox.

--- a/apps/api/src/lib/slack.ts
+++ b/apps/api/src/lib/slack.ts
@@ -115,13 +115,20 @@ export const exchangeSlackOidc = async (
   return { accessToken: data.access_token }
 }
 
-/** The linked Slack identity (openid.connect.userinfo). The identifying claims are namespaced
+/** The linked Slack identity (openid.connect.userInfo). The identifying claims are namespaced
  *  URL keys (`https://slack.com/user_id`, `.../team_id`) — read them literally. These are the
- *  same `U…`/`T…` ids the bot sees in events, which is what makes the link resolvable. */
+ *  same `U…`/`T…` ids the bot sees in events, which is what makes the link resolvable.
+ *
+ *  The method name is camelCase — `userInfo`, NOT `userinfo`. Slack's Web API method names are
+ *  case-sensitive, and the all-lowercase spelling this used to send returns `unknown_method`,
+ *  so account linking failed for every user from the day it shipped: the authorize and token
+ *  exchange both succeed, and only this last hop fails, which is why it read as an app-config
+ *  problem rather than a typo. Verified against the live API — `userinfo` → `unknown_method`,
+ *  `userInfo` → `invalid_auth` (i.e. the method exists and only the credential was rejected). */
 export const slackOidcUserinfo = async (
   accessToken: string,
 ): Promise<{ slackUserId: string; teamId: string; email: string | null }> => {
-  const res = await fetch(`${API}/openid.connect.userinfo`, {
+  const res = await fetch(`${API}/openid.connect.userInfo`, {
     headers: { authorization: `Bearer ${accessToken}` },
   })
   const data = (await res.json()) as {

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -251,7 +251,14 @@ describe("slack account linking (OIDC)", () => {
       created_at: new Date().toISOString(),
     })
 
-  // Stub the two OIDC back-channel calls (token exchange + userinfo).
+  // Stub the two OIDC back-channel calls (token exchange + userInfo).
+  //
+  // The method names here must be Slack's EXACT spelling. This mock used to match
+  // "openid.connect.userinfo" — all lowercase, the same typo the client carried — and an
+  // unrecognised URL fell through to `{}`, so the suite stayed green while account linking was
+  // impossible in production: Slack's Web API method names are case-sensitive and the lowercase
+  // spelling returns `unknown_method`. Two changes stop that recurring: the correct camelCase
+  // `userInfo`, and an unstubbed call now THROWS instead of being absorbed as an empty body.
   const stubOidc = (userId: string, teamId: string, email = "o@x.com") =>
     vi.stubGlobal(
       "fetch",
@@ -261,7 +268,7 @@ describe("slack account linking (OIDC)", () => {
           return new Response(JSON.stringify({ ok: true, access_token: "xoxp-oidc" }), {
             status: 200,
           })
-        if (u.includes("openid.connect.userinfo"))
+        if (u.includes("openid.connect.userInfo"))
           return new Response(
             JSON.stringify({
               "https://slack.com/user_id": userId,
@@ -270,7 +277,7 @@ describe("slack account linking (OIDC)", () => {
             }),
             { status: 200 },
           )
-        return new Response("{}", { status: 200 })
+        throw new Error(`unstubbed Slack call: ${u}`)
       }),
     )
 

--- a/apps/api/test/slack.test.ts
+++ b/apps/api/test/slack.test.ts
@@ -6,7 +6,7 @@ import { type ArtifactRecord, newId, type SlackThreadLinkRecord } from "@derive/
 import { SqliteMetaStore } from "@derive/db/sqlite"
 import { describe, expect, it } from "vitest"
 import { parseMeta } from "../src/lib/comments"
-import { slackAuthorizeUrl, verifySlackSignature } from "../src/lib/slack"
+import { slackAuthorizeUrl, slackOidcUserinfo, verifySlackSignature } from "../src/lib/slack"
 import { ingestSlackReply } from "../src/lib/slack-comments"
 
 describe("slack signature verification", () => {
@@ -104,5 +104,37 @@ describe("slack reply ingestion (inbound)", () => {
     const args = { ts: "1700.4", userId: "U1", userName: "X", text: "hi", botUserId: "UBOT" }
     expect(await ingestSlackReply(meta, link, args)).toBeTruthy()
     expect(await ingestSlackReply(meta, link, args)).toBe(null)
+  })
+})
+
+// Regression: this called `openid.connect.userinfo` (all lowercase). Slack's Web API method
+// names are case-sensitive, so it returned `unknown_method` and account linking failed for
+// every user from the day it shipped — silently, because the authorize and token exchange both
+// succeed and only this last hop dies. It went unnoticed because the route test's fetch stub
+// matched the same lowercase typo. Verified against the live API: `userinfo` -> unknown_method,
+// `userInfo` -> invalid_auth (the method exists, only the credential was rejected).
+describe("slack OIDC userinfo", () => {
+  it("calls Slack's camelCase openid.connect.userInfo, not the lowercase spelling", async () => {
+    const seen: string[] = []
+    const original = globalThis.fetch
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      seen.push(String(url))
+      return new Response(
+        JSON.stringify({
+          "https://slack.com/user_id": "U1",
+          "https://slack.com/team_id": "T1",
+          email: "a@b.c",
+        }),
+        { status: 200 },
+      )
+    }) as typeof fetch
+    try {
+      await slackOidcUserinfo("xoxp-test")
+    } finally {
+      globalThis.fetch = original
+    }
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toContain("openid.connect.userInfo")
+    expect(seen[0]).not.toContain("openid.connect.userinfo")
   })
 })


### PR DESCRIPTION
`slackOidcUserinfo` called `openid.connect.userinfo`. Slack's Web API method names are **case-sensitive**, and the method is `openid.connect.userInfo` — so every call returned `unknown_method` and **the OIDC account-link flow has failed for every user since it shipped**.

Confirmed against the live API, not inferred:

```
openid.connect.userinfo  ->  unknown_method   (no such method)
openid.connect.userInfo  ->  invalid_auth     (exists; only the token was rejected)
```

and against production, where the link callback logs:

```
(warn) "slack link failed"  error: "slack oidc userinfo failed: unknown_method"
```

## Why it hid for so long

The authorize redirect and the token exchange both **succeed**. Only the last back-channel hop dies, so the symptom reads as an app-config or missing-scope problem rather than a one-character typo. Every consequence is silent:

- `linked` stays `false` forever, for everyone
- DMs fall back to guessing the recipient by account email; an unmatched email is recorded as **delivered-but-skipped**, never a failure — so **Send test DM returns 200 and nothing arrives**
- `/derive` refuses every user with "link your Slack account", permanently
- Proposal Approve / Request-changes can't resolve the clicker to a Derive account

## Why no test caught it

The route test's fetch stub matched the **same lowercase typo**, and any unmatched URL fell through to a `200 {}`. The mock encoded the bug and then validated it — 83 Slack tests green while the feature was impossible in production.

Both halves are fixed:

- the stub matches Slack's real method name
- an **unstubbed call now throws** instead of being absorbed, so the next wrong method name fails loudly instead of silently passing

## Verification

Reverting the single character fails **three** tests:

| test | failure |
|---|---|
| `stores a link on callback…` | `unstubbed Slack call: …/openid.connect.userinfo` |
| `rejects a linked identity from a different Slack team…` | same |
| `calls Slack's camelCase openid.connect.userInfo…` | `expected '…' to contain 'openid.connect.userInfo'` |

- **61 Slack tests pass** across the four suites
- `pnpm run ci` green (knip included) via the pre-commit hook
- Full pre-push gate green

## Also in here

`slack-dm.ts`'s header claimed there is *"no per-user OAuth or account-linking step, just the workspace's one bot install."* That stopped being true when linking shipped — the sender prefers the link and only falls back to email. It actively misled the diagnosis of this bug, so it's corrected to describe the real behaviour, including that the email fallback drops silently.

## Follow-ups, not in this PR

- `slackQuery` is `staleTime: Infinity` **and** persisted to IndexedDB, and nothing invalidates `["slack"]` on connect (only on disconnect). A successful install renders as "not connected" until `__BUILD_ID__` changes — it caused three unnecessary reinstalls while diagnosing this.
- `dispatch-sim.test.ts` uses `Date.now()` inside a "deterministic simulation" and flakes on the Postgres lane.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787859357&installation_model_id=428097&pr_number=560&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F560&signature=c97365ab1ae31c164d2fbf078f6972e72b6598f4488112b80d7d1b411f075291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->