### PR TITLE
Feat/brandprint user toggle

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -6534,7 +6534,7 @@
         },
         "responses": {
           "201": {
-            "description": "The rework request was posted and landed in the agent's pull inbox. 409 needsAgent when no agent is registered; 409 needsBrandprint when no Brandprint resolves; 409 alreadyQueued while an earlier request for this artifact still waits.",
+            "description": "The rework request was posted and landed in the agent's pull inbox. 409 needsAgent when no agent is registered; 409 needsBrandprint when no Brandprint resolves; 409 brandprintDisabled when the caller turned the workspace Brandprint off in their settings; 409 alreadyQueued while an earlier request for this artifact still waits.",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3060,6 +3060,10 @@
                           "type": "string",
                           "nullable": true,
                           "maxLength": 64
+                        },
+                        "useWorkspaceBrandprint": {
+                          "type": "boolean",
+                          "description": "False turns the workspace Brandprint off for this user; their personal collection still applies. Absent or true: the workspace layer applies. Personal scope only."
                         }
                       },
                       "description": "Saved personal Brandprint (collection-only; the brand profile is workspace scope); null when cleared."

--- a/apps/api/src/lib/brandprint.ts
+++ b/apps/api/src/lib/brandprint.ts
@@ -11,6 +11,10 @@ import {
  * the two-read + merge sequence the MCP connection, the context runner, and the
  * rework endpoint all need, each keyed on a different user id. The reads are
  * independent, so they run concurrently. `userId` null ⇒ workspace layer only.
+ *
+ * A context's runs key on the context's CREATOR, not whoever triggers a given run:
+ * the creator's personal toggle governs every session that context spawns,
+ * regardless of who reads or fires it.
  */
 export const resolveActorBrandprint = async (
   meta: MetaStore,

--- a/apps/api/src/routes/rework.ts
+++ b/apps/api/src/routes/rework.ts
@@ -157,7 +157,7 @@ export const reworkRoutes = (ctx: AppContext) => {
       summary: "Ask a registered agent to rework this artifact to match the Brandprint.",
       request: { params: z.object({ shortId: z.string() }), body: requestBody },
       responses: requestCreated(
-        "The rework request was posted and landed in the agent's pull inbox. 409 needsAgent when no agent is registered; 409 needsBrandprint when no Brandprint resolves; 409 alreadyQueued while an earlier request for this artifact still waits.",
+        "The rework request was posted and landed in the agent's pull inbox. 409 needsAgent when no agent is registered; 409 needsBrandprint when no Brandprint resolves; 409 brandprintDisabled when the caller turned the workspace Brandprint off in their settings; 409 alreadyQueued while an earlier request for this artifact still waits.",
       ),
     }),
     async (c) => {
@@ -176,12 +176,18 @@ export const reworkRoutes = (ctx: AppContext) => {
       // The resolved Brandprint (workspace ⊕ requester's profile) drives the
       // profile-first line and guards the empty brief: firing the canned instruction
       // with zero derive://brandprint/* resources behind it would hand the agent
-      // nothing to read.
+      // nothing to read. An empty brief has two distinct causes: the caller turned
+      // the workspace layer off (workspaceSuppressed), or nothing was ever set up.
+      // Tell them apart so the client can point at Settings instead of onboarding.
       if (resolved.collectionIds.length === 0 && !resolved.profileId)
         return bail(
-          fail(c, 409, "no Brandprint is set on this workspace or your profile", {
-            code: "needsBrandprint",
-          }),
+          resolved.workspaceSuppressed
+            ? fail(c, 409, "Brandprint is turned off in your settings. Turn it on to rework.", {
+                code: "brandprintDisabled",
+              })
+            : fail(c, 409, "no Brandprint is set on this workspace or your profile", {
+                code: "needsBrandprint",
+              }),
         )
       let profileLive = false
       if (resolved.profileId) {

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -293,9 +293,9 @@ export const BrandprintSchema = z.object({
   profileId: z.string().trim().max(64).nullish(),
 })
 
-/** The personal layer is collection-only — the brand profile is a team property, so the
- *  profile route's request AND response omit `profileId` (a sent one strips, same as any
- *  unknown key, and the generated types can't advertise a field the server never returns). */
+/** The brand profile is a team property, so the profile route's request AND response
+ *  omit `profileId` (a sent one strips, same as any unknown key, and the generated
+ *  types can't advertise a field the server never returns). */
 export const PersonalBrandprintSchema = BrandprintSchema.omit({ profileId: true }).extend({
   useWorkspaceBrandprint: z
     .boolean()

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -296,4 +296,11 @@ export const BrandprintSchema = z.object({
 /** The personal layer is collection-only — the brand profile is a team property, so the
  *  profile route's request AND response omit `profileId` (a sent one strips, same as any
  *  unknown key, and the generated types can't advertise a field the server never returns). */
-export const PersonalBrandprintSchema = BrandprintSchema.omit({ profileId: true })
+export const PersonalBrandprintSchema = BrandprintSchema.omit({ profileId: true }).extend({
+  useWorkspaceBrandprint: z
+    .boolean()
+    .optional()
+    .describe(
+      "False turns the workspace Brandprint off for this user; their personal collection still applies. Absent or true: the workspace layer applies. Personal scope only.",
+    ),
+})

--- a/apps/api/test/integrations-settings.test.ts
+++ b/apps/api/test/integrations-settings.test.ts
@@ -144,8 +144,8 @@ describe("workspace Brandprint (write-side ownership check)", () => {
       await app.request("/v1/collections", jsonAs(as(admin.email), { title: "Brandprint" }))
     ).json()
 
-    // The toggle is personal scope only (Task 2 spec): a workspace PATCH strips it
-    // like any unknown key, same as the legacy `theme` field above.
+    // The toggle is personal scope only: a workspace PATCH strips it like any
+    // unknown key, same as the legacy `theme` field above.
     const r = await patchSettings(app, as(admin.email), {
       brandprint: { collectionId: col.id, useWorkspaceBrandprint: false },
     })

--- a/apps/api/test/integrations-settings.test.ts
+++ b/apps/api/test/integrations-settings.test.ts
@@ -137,6 +137,28 @@ describe("workspace Brandprint (write-side ownership check)", () => {
     expect((await cleared.json()).brandprint).toBeUndefined()
   })
 
+  it("strips the personal-only useWorkspaceBrandprint toggle from a workspace PATCH", async () => {
+    const admin: TestUser = { id: "u-bp-tog", email: "bptog@x.com", name: "Tog", username: "bptog" }
+    const { app } = makeAuthedApp("integ-bp-toggle", [admin])
+    const col = await (
+      await app.request("/v1/collections", jsonAs(as(admin.email), { title: "Brandprint" }))
+    ).json()
+
+    // The toggle is personal scope only (Task 2 spec): a workspace PATCH strips it
+    // like any unknown key, same as the legacy `theme` field above.
+    const r = await patchSettings(app, as(admin.email), {
+      brandprint: { collectionId: col.id, useWorkspaceBrandprint: false },
+    })
+    expect(r.status).toBe(200)
+    expect((await r.json()).brandprint).toEqual({ collectionId: col.id })
+
+    // Persisted without it too, not just stripped from this response.
+    const again = await (
+      await app.request("/v1/workspace/settings", { headers: as(admin.email) })
+    ).json()
+    expect(again.brandprint).toEqual({ collectionId: col.id })
+  })
+
   it("accepts a profileId published in this workspace and round-trips it", async () => {
     const admin: TestUser = { id: "u-bp-pro", email: "bppro@x.com", name: "Pro", username: "bppro" }
     const { app } = makeAuthedApp("integ-bp-profile", [admin])

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -658,8 +658,8 @@ describe("remote MCP endpoint (/mcp)", () => {
     })
 
     // The grant's owner (u_o) keeps their own personal collection but turns the
-    // workspace layer off — same store-level shape /v1/me/profile persists, seeded
-    // directly since this app has no session auth wired up.
+    // workspace layer off: the same store-level shape /v1/me/profile persists,
+    // seeded directly since this app has no session auth wired up.
     const personalDocId = (await (await publish(app, token, "My own conventions")).json()).short_id
     const personalDoc = await meta.getByShortId(personalDocId)
     if (!personalDoc) throw new Error("no artifact")
@@ -682,11 +682,11 @@ describe("remote MCP endpoint (/mcp)", () => {
     const uris = (
       (listed.parsed?.result as { resources?: { uri: string }[] } | undefined)?.resources ?? []
     ).map((r) => r.uri)
-    // No workspace doc, no profile — the toggle suppressed the workspace layer wholesale.
+    // No workspace doc, no profile: the toggle suppressed the workspace layer wholesale.
     expect(uris).not.toContain(`derive://brandprint/${wsDocId}`)
     expect(uris).not.toContain("derive://brandprint/profile")
     expect(uris).not.toContain(`derive://brandprint/${profId}`)
-    // The personal collection's own doc still appears — it's the caller's own opt-in.
+    // The personal collection's own doc still appears; it's the caller's own opt-in.
     expect(uris).toContain(`derive://brandprint/${personalDocId}`)
   })
 

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -38,7 +38,7 @@ function appWithGrant(
   const meta = new SqliteMetaStore(path)
   const db = new Database(path)
   db.exec(`
-    CREATE TABLE IF NOT EXISTS "user" (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT, username TEXT, discoverable INTEGER, profession TEXT, about TEXT);
+    CREATE TABLE IF NOT EXISTS "user" (id TEXT PRIMARY KEY, email TEXT, name TEXT, image TEXT, username TEXT, discoverable INTEGER, profession TEXT, about TEXT, brandprint TEXT);
     CREATE TABLE IF NOT EXISTS "oauthClient" (clientId TEXT PRIMARY KEY, name TEXT);
     CREATE TABLE IF NOT EXISTS "oauthAccessToken" (token TEXT PRIMARY KEY, clientId TEXT, userId TEXT, scopes TEXT, expiresAt TEXT);
   `)
@@ -633,6 +633,61 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(
       toolText(await call(app, token, "read", { short_id: "derive://brandprint/profile" })),
     ).toContain("no live brand profile")
+  })
+
+  it("a caller whose personal toggle is off gets no workspace Brandprint resources, only their own", async () => {
+    const { app, token, meta } = appWithGrant("bp-toggle-off", "openid derive:read derive:publish")
+    // The workspace has a Brandprint: a convention doc plus a brand profile.
+    const wsDocId = (await (await publish(app, token, "Workspace conventions")).json()).short_id
+    const profId = (await (await publish(app, token, "Brand profile")).json()).short_id
+    const wsDoc = await meta.getByShortId(wsDocId)
+    const prof = await meta.getByShortId(profId)
+    if (!wsDoc || !prof) throw new Error("no artifacts")
+    const wsCollectionId = "col_bp_toggle_ws"
+    await meta.createCollection({
+      id: wsCollectionId,
+      org_id: wsDoc.org_id,
+      title: "Brandprint",
+      created_by: "u_o",
+    })
+    await meta.addCollectionItem(wsCollectionId, wsDoc.id)
+    await meta.addCollectionItem(wsCollectionId, prof.id)
+    await meta.setOrgSettings(wsDoc.org_id, {
+      ...(await meta.getOrgSettings(wsDoc.org_id)),
+      brandprint: { collectionId: wsCollectionId, profileId: profId },
+    })
+
+    // The grant's owner (u_o) keeps their own personal collection but turns the
+    // workspace layer off — same store-level shape /v1/me/profile persists, seeded
+    // directly since this app has no session auth wired up.
+    const personalDocId = (await (await publish(app, token, "My own conventions")).json()).short_id
+    const personalDoc = await meta.getByShortId(personalDocId)
+    if (!personalDoc) throw new Error("no artifact")
+    const personalCollectionId = "col_bp_toggle_personal"
+    await meta.createCollection({
+      id: personalCollectionId,
+      org_id: personalDoc.org_id,
+      title: "My Brandprint",
+      created_by: "u_o",
+    })
+    await meta.addCollectionItem(personalCollectionId, personalDoc.id)
+    await meta.setUserProfile("u_o", {
+      brandprint: JSON.stringify({
+        collectionId: personalCollectionId,
+        useWorkspaceBrandprint: false,
+      }),
+    })
+
+    const listed = await rpc(app, token, { jsonrpc: "2.0", id: 3, method: "resources/list" })
+    const uris = (
+      (listed.parsed?.result as { resources?: { uri: string }[] } | undefined)?.resources ?? []
+    ).map((r) => r.uri)
+    // No workspace doc, no profile — the toggle suppressed the workspace layer wholesale.
+    expect(uris).not.toContain(`derive://brandprint/${wsDocId}`)
+    expect(uris).not.toContain("derive://brandprint/profile")
+    expect(uris).not.toContain(`derive://brandprint/${profId}`)
+    // The personal collection's own doc still appears — it's the caller's own opt-in.
+    expect(uris).toContain(`derive://brandprint/${personalDocId}`)
   })
 
   it("publish to derive://brandprint/profile scaffolds the slot, is idempotent, and the loop goes live", async () => {

--- a/apps/api/test/profiles.test.ts
+++ b/apps/api/test/profiles.test.ts
@@ -167,10 +167,9 @@ describe("usernames + public profiles", () => {
       collectionId: col.id,
       useWorkspaceBrandprint: false,
     })
-    expect(JSON.parse(await meta.getUserBrandprint(remy.id))).toEqual({
-      collectionId: col.id,
-      useWorkspaceBrandprint: false,
-    })
+    expect(await meta.getUserBrandprint(remy.id)).toBe(
+      JSON.stringify({ collectionId: col.id, useWorkspaceBrandprint: false }),
+    )
   })
 
   it("strips a profileId from a personal brandprint (workspace-only field)", async () => {

--- a/apps/api/test/profiles.test.ts
+++ b/apps/api/test/profiles.test.ts
@@ -123,6 +123,56 @@ describe("usernames + public profiles", () => {
     expect((await cleared.json()).brandprint).toBeNull()
   })
 
+  it("persists and returns the personal Brandprint toggle", async () => {
+    const kai: TestUser = { id: "u_kai", email: "kai@derive.test", name: "Kai", username: "kai" }
+    const { app, meta } = makeAuthedApp("profiles-brandprint-toggle", [kai])
+
+    const r = await app.request(
+      "/v1/me/profile",
+      jsonAs(as(kai.email), { brandprint: { useWorkspaceBrandprint: false } }),
+    )
+    expect(r.status).toBe(200)
+    expect(await r.json()).toEqual({
+      profession: null,
+      about: null,
+      brandprint: { useWorkspaceBrandprint: false },
+    })
+
+    // Persisted, not just echoed back: the stored JSON blob carries the toggle.
+    expect(await meta.getUserBrandprint(kai.id)).toBe(
+      JSON.stringify({ useWorkspaceBrandprint: false }),
+    )
+  })
+
+  it("saving a collection alongside the toggle keeps both", async () => {
+    const remy: TestUser = {
+      id: "u_remy",
+      email: "remy@derive.test",
+      name: "Remy",
+      username: "remy",
+    }
+    const { app, meta } = makeAuthedApp("profiles-brandprint-toggle-collection", [remy])
+    const col = await (
+      await app.request("/v1/collections", jsonAs(as(remy.email), { title: "Brandprint" }))
+    ).json()
+
+    const r = await app.request(
+      "/v1/me/profile",
+      jsonAs(as(remy.email), {
+        brandprint: { collectionId: col.id, useWorkspaceBrandprint: false },
+      }),
+    )
+    expect(r.status).toBe(200)
+    expect((await r.json()).brandprint).toEqual({
+      collectionId: col.id,
+      useWorkspaceBrandprint: false,
+    })
+    expect(JSON.parse(await meta.getUserBrandprint(remy.id))).toEqual({
+      collectionId: col.id,
+      useWorkspaceBrandprint: false,
+    })
+  })
+
   it("strips a profileId from a personal brandprint (workspace-only field)", async () => {
     const pi: TestUser = { id: "u_pi", email: "pi@derive.test", name: "Pi", username: "pi" }
     const { app, meta } = makeAuthedApp("profiles-brandprint-profileid", [pi])

--- a/apps/api/test/rework.test.ts
+++ b/apps/api/test/rework.test.ts
@@ -85,6 +85,50 @@ describe("rework: gating", () => {
     expect(((await res.json()) as { code: string }).code).toBe("needsBrandprint")
   })
 
+  it("409s brandprintDisabled when the caller turned the workspace Brandprint off", async () => {
+    const { app, meta } = makeAuthedApp("rework-disabled", [owner, editor], "editor")
+    const shortId = await newArtifact(app)
+    await seedBrandprint(meta, shortId)
+    await addAgent(app, "Reviser")
+    // The caller turns the workspace layer off, with no personal collection of
+    // their own to fall back to — the brief goes empty because of the toggle,
+    // not because nothing was ever set up.
+    const saved = await app.request(
+      "/v1/me/profile",
+      jsonAs(as(editor.email), { brandprint: { useWorkspaceBrandprint: false } }),
+    )
+    expect(saved.status).toBe(200)
+    const res = await rework(app, shortId)
+    expect(res.status).toBe(409)
+    const body = (await res.json()) as { code: string; error: string }
+    expect(body.code).toBe("brandprintDisabled")
+    expect(body.error).toBe("Brandprint is turned off in your settings. Turn it on to rework.")
+  })
+
+  it("rework proceeds on the personal collection when the workspace layer is off", async () => {
+    const { app, meta } = makeAuthedApp("rework-disabled-personal", [owner, editor], "editor")
+    const shortId = await newArtifact(app)
+    await seedBrandprint(meta, shortId)
+    const ag = await addAgent(app, "Reviser")
+    // The caller turns the workspace layer off but keeps their own collection —
+    // the resolved brief is non-empty, so rework fires as usual.
+    const col = await (
+      await app.request("/v1/collections", jsonAs(as(editor.email), { title: "My Brandprint" }))
+    ).json()
+    const saved = await app.request(
+      "/v1/me/profile",
+      jsonAs(as(editor.email), {
+        brandprint: { collectionId: col.id, useWorkspaceBrandprint: false },
+      }),
+    )
+    expect(saved.status).toBe(200)
+    const res = await rework(app, shortId)
+    expect(res.status).toBe(201)
+    const mentions = await inboxBodies(app, ag.token)
+    expect(mentions).toHaveLength(1)
+    expect(mentions[0]?.body).toContain("@Reviser")
+  })
+
   it("404 for an unknown artifact; 404 for an agentId from another workspace", async () => {
     const { app, meta } = makeAuthedApp("rework-404", [owner, editor], "editor")
     expect((await rework(app, "nope")).status).toBe(404)

--- a/apps/api/test/rework.test.ts
+++ b/apps/api/test/rework.test.ts
@@ -85,13 +85,13 @@ describe("rework: gating", () => {
     expect(((await res.json()) as { code: string }).code).toBe("needsBrandprint")
   })
 
-  it("409s brandprintDisabled when the caller turned the workspace Brandprint off", async () => {
+  it("409 brandprintDisabled when the caller turned the workspace Brandprint off", async () => {
     const { app, meta } = makeAuthedApp("rework-disabled", [owner, editor], "editor")
     const shortId = await newArtifact(app)
     await seedBrandprint(meta, shortId)
     await addAgent(app, "Reviser")
     // The caller turns the workspace layer off, with no personal collection of
-    // their own to fall back to — the brief goes empty because of the toggle,
+    // their own to fall back to: the brief goes empty because of the toggle,
     // not because nothing was ever set up.
     const saved = await app.request(
       "/v1/me/profile",
@@ -110,7 +110,7 @@ describe("rework: gating", () => {
     const shortId = await newArtifact(app)
     await seedBrandprint(meta, shortId)
     const ag = await addAgent(app, "Reviser")
-    // The caller turns the workspace layer off but keeps their own collection —
+    // The caller turns the workspace layer off but keeps their own collection:
     // the resolved brief is non-empty, so rework fires as usual.
     const col = await (
       await app.request("/v1/collections", jsonAs(as(editor.email), { title: "My Brandprint" }))

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -133,6 +133,8 @@ export interface paths {
                             /** @description Saved personal Brandprint (collection-only; the brand profile is workspace scope); null when cleared. */
                             brandprint: {
                                 collectionId?: string | null;
+                                /** @description False turns the workspace Brandprint off for this user; their personal collection still applies. Absent or true: the workspace layer applies. Personal scope only. */
+                                useWorkspaceBrandprint?: boolean;
                             } | null;
                         };
                     };

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -3880,7 +3880,7 @@ export interface paths {
                 };
             };
             responses: {
-                /** @description The rework request was posted and landed in the agent's pull inbox. 409 needsAgent when no agent is registered; 409 needsBrandprint when no Brandprint resolves; 409 alreadyQueued while an earlier request for this artifact still waits. */
+                /** @description The rework request was posted and landed in the agent's pull inbox. 409 needsAgent when no agent is registered; 409 needsBrandprint when no Brandprint resolves; 409 brandprintDisabled when the caller turned the workspace Brandprint off in their settings; 409 alreadyQueued while an earlier request for this artifact still waits. */
                 201: {
                     headers: {
                         [name: string]: unknown;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -9,11 +9,11 @@ import { guestQuery } from "./lib/guest-id"
 export type { LinkRole, Listed, Role, WorkspaceAccess }
 
 /** A pointer to the conventions collection a workspace or an account likes its
- *  artifacts built from. The personal layer is collection-only — the brand profile
- *  (`profileId`) is workspace scope and rides the generated OrgSettings.brandprint.
- *  Mirrors packages/core/src/ports.ts Brandprint. Not itself a named OpenAPI schema —
- *  the personal copy is a Better Auth additionalField (a JSON string) surfaced through
- *  the hand-mapped `Me`, same as profession/about below. */
+ *  artifacts built from. Mirrors packages/core/src/ports.ts Brandprint, minus
+ *  `profileId`: the brand profile is workspace scope and rides the generated
+ *  OrgSettings.brandprint. Not itself a named OpenAPI schema; the personal copy is
+ *  a Better Auth additionalField (a JSON string) surfaced through the hand-mapped
+ *  `Me`, same as profession/about below. */
 export interface Brandprint {
   collectionId?: string | null
   /** Personal-layer only: false turns the workspace Brandprint off for this user

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -16,6 +16,11 @@ export type { LinkRole, Listed, Role, WorkspaceAccess }
  *  the hand-mapped `Me`, same as profession/about below. */
 export interface Brandprint {
   collectionId?: string | null
+  /** Personal-layer only: false turns the workspace Brandprint off for this user
+   *  (their agents skip the org's conventions and profile; a personal collection
+   *  above still applies). Absent or true: the workspace layer applies. A
+   *  workspace's own settings never carry this field. */
+  useWorkspaceBrandprint?: boolean
 }
 /** Parse a Me.brandprint / SessionUser.brandprint JSON string; null if absent/malformed. */
 export const parseBrandprint = (raw: string | null | undefined): Brandprint | null => {

--- a/apps/web/src/pages/artifact/rework-menu-item.tsx
+++ b/apps/web/src/pages/artifact/rework-menu-item.tsx
@@ -63,9 +63,9 @@ export function ReworkMenuItem({
       const code = err instanceof ApiError ? err.code : undefined
       if (code === "needsAgent") onConnect()
       else if (code === "needsBrandprint") nav({ to: "/brandprint" })
-      else if (code === "alreadyQueued") toast(ALREADY_QUEUED)
       else if (code === "brandprintDisabled")
         toast.error("Brandprint is turned off in your settings. Turn it on to rework.")
+      else if (code === "alreadyQueued") toast(ALREADY_QUEUED)
       else toast.error("Rework request failed — try again.")
     },
   })

--- a/apps/web/src/pages/artifact/rework-menu-item.tsx
+++ b/apps/web/src/pages/artifact/rework-menu-item.tsx
@@ -64,6 +64,8 @@ export function ReworkMenuItem({
       if (code === "needsAgent") onConnect()
       else if (code === "needsBrandprint") nav({ to: "/brandprint" })
       else if (code === "alreadyQueued") toast(ALREADY_QUEUED)
+      else if (code === "brandprintDisabled")
+        toast.error("Brandprint is turned off in your settings. Turn it on to rework.")
       else toast.error("Rework request failed — try again.")
     },
   })

--- a/apps/web/src/pages/brandprint/brandprint-section.tsx
+++ b/apps/web/src/pages/brandprint/brandprint-section.tsx
@@ -535,7 +535,9 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
               id="brandprint-workspace-toggle"
               data-testid="brandprint-workspace-toggle"
               checked={me?.brandprint?.useWorkspaceBrandprint !== false}
-              disabled={toggleWorkspace.isPending || updateAccount.isPending}
+              disabled={
+                toggleWorkspace.isPending || updateAccount.isPending || importDocs.isPending
+              }
               onCheckedChange={(on) => toggleWorkspace.mutate(on)}
             />
           </SettingRow>

--- a/apps/web/src/pages/brandprint/brandprint-section.tsx
+++ b/apps/web/src/pages/brandprint/brandprint-section.tsx
@@ -24,6 +24,7 @@ import {
   SelectMenuTrigger,
 } from "@/components/ui/select-menu"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Switch } from "@/components/ui/switch"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
 import { useAuth } from "@/ctx"
@@ -36,6 +37,7 @@ import {
 } from "@/lib/queries"
 import { snapshot, useApiMutation } from "@/lib/use-api-mutation"
 import { refFor } from "../artifact/parse-ref"
+import { nextPersonalBrandprint } from "./personal-brandprint"
 import {
   ensureProfilePlaceholder,
   type ImportResult,
@@ -166,8 +168,34 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
     success: "Brandprint updated",
   })
   const updateAccount = useApiMutation({
+    // A save must never drop a field it isn't changing. `setProfile` replaces the
+    // whole personal Brandprint object, so this merges into the current one instead
+    // of sending `collectionId` bare (that would silently clear the workspace toggle
+    // below on every collection save, and clearing the collection would clear the
+    // toggle too). nextPersonalBrandprint collapses to null only once nothing is left.
     mutationFn: (collectionId: string) =>
-      api.setProfile({ brandprint: collectionId ? { collectionId } : null }),
+      api.setProfile({
+        brandprint: nextPersonalBrandprint(me?.brandprint, {
+          collectionId: collectionId || undefined,
+        }),
+      }),
+    onSuccess: (r) => {
+      if (me) setMe({ ...me, brandprint: r.brandprint })
+    },
+    success: "Brandprint updated",
+  })
+  // The personal "use workspace Brandprint" switch: off suppresses the workspace
+  // layer for this user while their own personal collection (above) still applies.
+  // Same merge-preserving save and setMe mirroring as updateAccount, just patching
+  // the toggle field instead of the collection pointer.
+  const toggleWorkspace = useApiMutation({
+    mutationFn: (on: boolean) =>
+      api.setProfile({
+        brandprint: nextPersonalBrandprint(me?.brandprint, {
+          // Write undefined (not true) so "on" stores nothing: absent means on.
+          useWorkspaceBrandprint: on ? undefined : false,
+        }),
+      }),
     onSuccess: (r) => {
       if (me) setMe({ ...me, brandprint: r.brandprint })
     },
@@ -494,6 +522,22 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
           </Dialog>
         </SettingRow>
       )}
+      {scope === "account" &&
+        (settings?.brandprint?.collectionId || settings?.brandprint?.profileId) && (
+          <SettingRow
+            htmlFor="brandprint-workspace-toggle"
+            label="Use workspace Brandprint"
+            description="Off: your agents skip this workspace's style and profile. Your personal conventions above still apply."
+          >
+            <Switch
+              id="brandprint-workspace-toggle"
+              data-testid="brandprint-workspace-toggle"
+              checked={me?.brandprint?.useWorkspaceBrandprint !== false}
+              disabled={toggleWorkspace.isPending}
+              onCheckedChange={(on) => toggleWorkspace.mutate(on)}
+            />
+          </SettingRow>
+        )}
     </SettingsGroup>
   )
 }

--- a/apps/web/src/pages/brandprint/brandprint-section.tsx
+++ b/apps/web/src/pages/brandprint/brandprint-section.tsx
@@ -299,7 +299,9 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
   const disabled =
     !ready ||
     importDocs.isPending ||
-    (scope === "workspace" ? !isAdmin || updateWorkspace.isPending : updateAccount.isPending)
+    (scope === "workspace"
+      ? !isAdmin || updateWorkspace.isPending
+      : updateAccount.isPending || toggleWorkspace.isPending)
   const save = (next: string) =>
     scope === "workspace" ? updateWorkspace.mutate(next) : updateAccount.mutate(next)
   const selected = collections?.find((c) => c.id === collectionId)?.title
@@ -533,7 +535,7 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
               id="brandprint-workspace-toggle"
               data-testid="brandprint-workspace-toggle"
               checked={me?.brandprint?.useWorkspaceBrandprint !== false}
-              disabled={toggleWorkspace.isPending}
+              disabled={toggleWorkspace.isPending || updateAccount.isPending}
               onCheckedChange={(on) => toggleWorkspace.mutate(on)}
             />
           </SettingRow>

--- a/apps/web/src/pages/brandprint/brandprint-section.tsx
+++ b/apps/web/src/pages/brandprint/brandprint-section.tsx
@@ -169,10 +169,10 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
   })
   const updateAccount = useApiMutation({
     // A save must never drop a field it isn't changing. `setProfile` replaces the
-    // whole personal Brandprint object, so this merges into the current one instead
-    // of sending `collectionId` bare (that would silently clear the workspace toggle
-    // below on every collection save, and clearing the collection would clear the
-    // toggle too). nextPersonalBrandprint collapses to null only once nothing is left.
+    // whole personal Brandprint object with no server-side merge, so the collection
+    // write merges through nextPersonalBrandprint (a bare { collectionId } would
+    // silently clear the workspace toggle below), which collapses to null only once
+    // nothing is left.
     mutationFn: (collectionId: string) =>
       api.setProfile({
         brandprint: nextPersonalBrandprint(me?.brandprint, {
@@ -535,9 +535,7 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
               id="brandprint-workspace-toggle"
               data-testid="brandprint-workspace-toggle"
               checked={me?.brandprint?.useWorkspaceBrandprint !== false}
-              disabled={
-                toggleWorkspace.isPending || updateAccount.isPending || importDocs.isPending
-              }
+              disabled={disabled}
               onCheckedChange={(on) => toggleWorkspace.mutate(on)}
             />
           </SettingRow>

--- a/apps/web/src/pages/brandprint/brandprint-section.tsx
+++ b/apps/web/src/pages/brandprint/brandprint-section.tsx
@@ -129,8 +129,11 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
     scope === "workspace"
       ? (settings?.brandprint?.collectionId ?? "")
       : (me?.brandprint?.collectionId ?? "")
-  // The workspace's brand-profile pointer. The settings query is disabled on account
-  // scope, so this is always undefined there — no scope branch needed.
+  // The workspace's brand-profile pointer. The settings query never fetches on
+  // account scope, but it still reads the cache the workspace-scope section on this
+  // page fills (one shared key): the "Use workspace Brandprint" row below depends on
+  // that read, and a workspace profileId reaching account scope is benign (the
+  // import hook's account path ignores it; the doc list only hides that artifact).
   const profileId = settings?.brandprint?.profileId ?? undefined
 
   const updateWorkspace = useApiMutation({

--- a/apps/web/src/pages/brandprint/personal-brandprint.test.ts
+++ b/apps/web/src/pages/brandprint/personal-brandprint.test.ts
@@ -47,7 +47,6 @@ describe("nextPersonalBrandprint", () => {
       { useWorkspaceBrandprint: undefined },
     )
     expect(next).toEqual({ collectionId: "col_1" })
-    expect(next && "useWorkspaceBrandprint" in next).toBe(true)
     expect(next?.useWorkspaceBrandprint).toBeUndefined()
   })
 

--- a/apps/web/src/pages/brandprint/personal-brandprint.test.ts
+++ b/apps/web/src/pages/brandprint/personal-brandprint.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+import { nextPersonalBrandprint } from "./personal-brandprint"
+
+// The account-scope save merge: never drop a field the caller isn't changing;
+// collapse to null only when nothing is left worth saving.
+describe("nextPersonalBrandprint", () => {
+  it("sets a collection on a previously empty Brandprint", () => {
+    expect(nextPersonalBrandprint(null, { collectionId: "col_1" })).toEqual({
+      collectionId: "col_1",
+    })
+  })
+
+  it("clears to null when clearing the collection leaves nothing else set", () => {
+    expect(nextPersonalBrandprint({ collectionId: "col_1" }, { collectionId: undefined })).toBe(
+      null,
+    )
+    expect(nextPersonalBrandprint(null, { collectionId: undefined })).toBe(null)
+  })
+
+  it("preserves the workspace toggle when only the collection changes", () => {
+    expect(
+      nextPersonalBrandprint(
+        { collectionId: "col_1", useWorkspaceBrandprint: false },
+        { collectionId: "col_2" },
+      ),
+    ).toEqual({ collectionId: "col_2", useWorkspaceBrandprint: false })
+  })
+
+  it("clearing the collection keeps an explicit toggle instead of collapsing to null", () => {
+    expect(
+      nextPersonalBrandprint(
+        { collectionId: "col_1", useWorkspaceBrandprint: false },
+        { collectionId: undefined },
+      ),
+    ).toEqual({ useWorkspaceBrandprint: false })
+  })
+
+  it("preserves the collection when only the toggle changes", () => {
+    expect(
+      nextPersonalBrandprint({ collectionId: "col_1" }, { useWorkspaceBrandprint: false }),
+    ).toEqual({ collectionId: "col_1", useWorkspaceBrandprint: false })
+  })
+
+  it("turning the toggle back on writes undefined, not true", () => {
+    const next = nextPersonalBrandprint(
+      { collectionId: "col_1", useWorkspaceBrandprint: false },
+      { useWorkspaceBrandprint: undefined },
+    )
+    expect(next).toEqual({ collectionId: "col_1" })
+    expect(next && "useWorkspaceBrandprint" in next).toBe(true)
+    expect(next?.useWorkspaceBrandprint).toBeUndefined()
+  })
+
+  it("turning the toggle off with nothing else set still saves (not null)", () => {
+    expect(nextPersonalBrandprint(null, { useWorkspaceBrandprint: false })).toEqual({
+      useWorkspaceBrandprint: false,
+    })
+  })
+
+  it("turning the toggle on with nothing else set collapses to null", () => {
+    expect(
+      nextPersonalBrandprint(
+        { useWorkspaceBrandprint: false },
+        { useWorkspaceBrandprint: undefined },
+      ),
+    ).toBe(null)
+  })
+})

--- a/apps/web/src/pages/brandprint/personal-brandprint.ts
+++ b/apps/web/src/pages/brandprint/personal-brandprint.ts
@@ -1,0 +1,19 @@
+import type { Brandprint } from "@/api"
+
+/**
+ * Merge a patch into the caller's current personal Brandprint. `api.setProfile`
+ * persists `brandprint` as a whole-object replace (see api.ts / the server route),
+ * with no server-side merge, so every save must start from what's already there, or
+ * a field the caller isn't touching (the collection pointer, the workspace toggle)
+ * silently disappears. Collapses to `null` only when the merged result has nothing
+ * left worth saving: no collection, and the workspace toggle isn't explicitly off.
+ * Pure so the merge is unit-tested; callers supply the live `me.brandprint` and the
+ * one field they're changing.
+ */
+export function nextPersonalBrandprint(
+  current: Brandprint | null | undefined,
+  patch: Partial<Brandprint>,
+): Brandprint | null {
+  const next = { ...current, ...patch }
+  return next.collectionId || next.useWorkspaceBrandprint === false ? next : null
+}

--- a/apps/web/src/pages/brandprint/use-brandprint-import.ts
+++ b/apps/web/src/pages/brandprint/use-brandprint-import.ts
@@ -4,6 +4,7 @@ import { toast } from "@/components/ui/sonner"
 import { useAuth } from "@/ctx"
 import { collectionsQuery, summaryQuery, workspaceSettingsQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { nextPersonalBrandprint } from "./personal-brandprint"
 import { placeholderFile } from "./profile-placeholder"
 
 // What the intake reports back: how many docs made it in, which files didn't, and
@@ -73,7 +74,11 @@ export function useBrandprintImport(
       if (scope === "account") {
         // Personal scope is a preferences layer: docs only, never a profile placeholder.
         if (!created) return { created, ok, failed }
-        const profile = await api.setProfile({ brandprint: { collectionId: target } })
+        // Merge, don't clobber: a caller with the workspace toggle off must keep that
+        // preference when their first personal collection gets created here.
+        const profile = await api.setProfile({
+          brandprint: nextPersonalBrandprint(me?.brandprint, { collectionId: target }),
+        })
         return { created, ok, failed, profile }
       }
       if (created) {

--- a/docs/superpowers/plans/2026-07-24-brandprint-user-toggle.md
+++ b/docs/superpowers/plans/2026-07-24-brandprint-user-toggle.md
@@ -1,0 +1,332 @@
+# Per-user Brandprint Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A personal "use workspace Brandprint" switch (default on); off drops the workspace layer (conventions collection + brand profile) for that user across MCP, rework, and contexts, keeps their personal layer, and rework returns a distinct "disabled" error surfaced as a small message in the UI.
+
+**Architecture:** One new optional field (`useWorkspaceBrandprint`) inside the existing personal-brandprint JSON on the user row; one suppression check in the pure `resolveBrandprint`, which every consumer already flows through; a `workspaceSuppressed` marker on `ResolvedBrandprint` so rework can tell "disabled" from "missing"; a Switch in the Brandprint page's account section riding the existing `/v1/me` save path (fixed to merge, not clobber).
+
+**Tech Stack:** TypeScript monorepo (pnpm), Hono + zod-openapi, Vitest, React. Worktree: `.claude/worktrees/brandprint-user-toggle`, branch `feat/brandprint-user-toggle` (based on origin/main 521afbc).
+
+**Spec:** `docs/superpowers/specs/2026-07-24-brandprint-user-toggle-design.md`
+
+## Global Constraints
+
+- Absent field or `true` = today's behavior exactly; only explicit `false` suppresses. Only the PERSONAL layer carries the field; the workspace-settings write path must not accept it.
+- With the toggle off, a personal collection still applies (rework proceeds on it; MCP still serves personal conventions).
+- No schema migration; no Better-Auth field changes.
+- Test scoping: `corepack pnpm exec vitest run <pattern>` inside the package dir (the `pnpm --filter X test -- pattern` form does NOT scope in this repo).
+- No em dashes in any user-facing copy or comments you write. New interactive controls need `data-testid` (`lint:testids`); no hardcoded colors/text sizes (`lint:tokens`).
+- Commits: conventional, ending `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`. Precommit hook must run (never `--no-verify`).
+
+---
+
+### Task 1: Core — the field, the suppression, and the marker
+
+**Files:**
+- Modify: `packages/core/src/ports.ts` (the `Brandprint` interface, ~line 2087)
+- Modify: `packages/core/src/brandprint.ts` (`ResolvedBrandprint`, `resolveBrandprint`)
+- Test: `packages/core/test/brandprint.test.ts`
+
+**Interfaces:**
+- Produces: `Brandprint.useWorkspaceBrandprint?: boolean`; `ResolvedBrandprint.workspaceSuppressed?: boolean` (true only when a workspace layer existed and the personal toggle dropped it); `resolveBrandprint` drops `ws` entirely when `profile?.useWorkspaceBrandprint === false`.
+
+- [ ] **Step 1: Failing tests** — append to the existing `describe("resolveBrandprint")` in `packages/core/test/brandprint.test.ts` (match its existing style; read the current cases first):
+
+```ts
+  it("toggle off drops the workspace layer but keeps the personal collection", () => {
+    const r = resolveBrandprint(
+      { collectionId: "ws-col", profileId: "prof" },
+      { collectionId: "my-col", useWorkspaceBrandprint: false },
+    )
+    expect(r.collectionIds).toEqual(["my-col"])
+    expect(r.profileId).toBeUndefined()
+    expect(r.workspaceSuppressed).toBe(true)
+  })
+
+  it("toggle off with no personal layer resolves empty, marked suppressed", () => {
+    const r = resolveBrandprint({ collectionId: "ws-col" }, { useWorkspaceBrandprint: false })
+    expect(r.collectionIds).toEqual([])
+    expect(r.profileId).toBeUndefined()
+    expect(r.workspaceSuppressed).toBe(true)
+  })
+
+  it("toggle off with no workspace layer is not marked suppressed", () => {
+    const r = resolveBrandprint(undefined, { collectionId: "my-col", useWorkspaceBrandprint: false })
+    expect(r.collectionIds).toEqual(["my-col"])
+    expect(r.workspaceSuppressed).toBeUndefined()
+  })
+
+  it("absent and true both keep today's merge", () => {
+    for (const p of [{ collectionId: "my-col" }, { collectionId: "my-col", useWorkspaceBrandprint: true }]) {
+      const r = resolveBrandprint({ collectionId: "ws-col", profileId: "prof" }, p)
+      expect(r.collectionIds).toEqual(["ws-col", "my-col"])
+      expect(r.profileId).toBe("prof")
+      expect(r.workspaceSuppressed).toBeUndefined()
+    }
+  })
+
+  it("parseBrandprint round-trips the toggle", () => {
+    expect(parseBrandprint('{"useWorkspaceBrandprint":false}')).toEqual({
+      useWorkspaceBrandprint: false,
+    })
+  })
+```
+
+- [ ] **Step 2: Run to fail** — `cd packages/core && corepack pnpm exec vitest run brandprint` → new cases fail (unknown property / wrong merge).
+
+- [ ] **Step 3: Implement.** `ports.ts`, inside `interface Brandprint` after `profileId`:
+
+```ts
+  /** Personal-layer only: false turns the WORKSPACE Brandprint off for this user
+   *  (their agents skip the org's conventions and profile; a personal collection
+   *  above still applies). Absent or true = the workspace layer applies. A
+   *  workspace's own settings never carry this field. */
+  useWorkspaceBrandprint?: boolean
+```
+
+`brandprint.ts` — extend `ResolvedBrandprint`:
+
+```ts
+  /** True when a workspace layer existed but the personal toggle dropped it.
+   *  Lets rework tell "you turned it off" from "nothing is set up". */
+  workspaceSuppressed?: boolean
+```
+
+and replace `resolveBrandprint`:
+
+```ts
+export const resolveBrandprint = (ws?: Brandprint, profile?: Brandprint): ResolvedBrandprint => {
+  // The personal toggle: false removes the workspace layer wholesale. The personal
+  // collection is the user's own opt-in, so it survives the toggle.
+  if (profile?.useWorkspaceBrandprint === false) {
+    const hadWs = !!(ws?.collectionId || ws?.profileId)
+    return {
+      collectionIds: profile.collectionId ? [profile.collectionId] : [],
+      ...(hadWs ? { workspaceSuppressed: true } : {}),
+    }
+  }
+  const ids = [ws?.collectionId, profile?.collectionId].filter((id): id is string => !!id)
+  return { collectionIds: [...new Set(ids)], profileId: ws?.profileId }
+}
+```
+
+- [ ] **Step 4: Green** — `corepack pnpm exec vitest run brandprint` in packages/core, then the full core suite `corepack pnpm exec vitest run`. All pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/ports.ts packages/core/src/brandprint.ts packages/core/test/brandprint.test.ts
+git commit -m "feat(core): personal toggle suppresses the workspace Brandprint layer
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: API — persist the toggle through /v1/me; workspace route must not accept it
+
+**Files:**
+- Modify: `apps/api/src/schemas.ts` (`PersonalBrandprintSchema`, ~line 299)
+- Test: `apps/api/test/` — extend the suite that covers `POST /v1/me` profile saves (grep for `setProfile`/`/v1/me` in apps/api/test; likely a session/profile test file)
+
+**Interfaces:**
+- Consumes: `Brandprint.useWorkspaceBrandprint` (Task 1).
+- Produces: `PersonalBrandprintSchema` accepts + documents `useWorkspaceBrandprint?: boolean`; `POST /v1/me` persists it inside the JSON blob (handler at `apps/api/src/routes/session.ts:~198-238` already `JSON.stringify`s the parsed body, so accepting it in the schema is the only change needed there — verify by test, not assumption); the workspace-settings PATCH silently strips it (zod default object stripping — prove with a test).
+
+- [ ] **Step 1: Failing tests** (adapt to the harness in the existing profile tests — `makeAuthedApp`/`as`/`jsonAs` per `apps/api/test/helpers.ts`):
+
+```ts
+  it("persists and returns the personal Brandprint toggle", async () => {
+    const r = await (
+      await appX.request("/v1/me", jsonAs(as("u@x.co"), { brandprint: { useWorkspaceBrandprint: false } }))
+    ).json()
+    expect(r.brandprint).toEqual({ useWorkspaceBrandprint: false })
+    const me = await (await appX.request("/v1/me", { headers: as("u@x.co") })).json()
+    expect(me.brandprint?.useWorkspaceBrandprint).toBe(false)
+  })
+
+  it("saving a collection alongside the toggle keeps both", async () => {
+    // collectionId must be a real collection owned by the caller's workspace —
+    // create one first via the harness (see the existing personal-brandprint
+    // ownership tests for the pattern).
+  })
+
+  it("the workspace settings route strips the toggle", async () => {
+    // PATCH workspace settings with brandprint: { collectionId: <real>, useWorkspaceBrandprint: false }
+    // → 200, and a GET shows the stored workspace brandprint WITHOUT the field.
+  })
+```
+
+Fill the two sketches with the harness's real collection-creation pattern (the existing tests that exercise `brandprint collection not found` show it). No empty tests in the final diff.
+
+- [ ] **Step 2: Run to fail** — the first test fails now (zod strips the unknown field, so `r.brandprint` comes back `{}`... verify the actual failure mode and note it in the report).
+
+- [ ] **Step 3: Implement.** `schemas.ts`:
+
+```ts
+export const PersonalBrandprintSchema = BrandprintSchema.omit({ profileId: true }).extend({
+  useWorkspaceBrandprint: z
+    .boolean()
+    .optional()
+    .describe(
+      "False turns the workspace Brandprint off for this user; their personal collection still applies. Absent or true: the workspace layer applies. Personal scope only.",
+    ),
+})
+```
+
+Check `GET /v1/me`'s response path returns the parsed stored JSON (it does not re-validate through a stripping schema at runtime); if a response schema in `session.ts` needs the field added for the OpenAPI spec to document it, add it there too (the GET's `brandprint` response schema).
+
+- [ ] **Step 4: Green + regen** — API tests for the touched files green; then `corepack pnpm gen:openapi` (in apps/api) and `corepack pnpm gen:api-types` (in apps/web); `pnpm lint:api-types` from root ok.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/schemas.ts apps/api/src/routes/session.ts apps/api/openapi.json apps/web/src/api-types.ts apps/api/test/
+git commit -m "feat(api): persist the personal use-workspace-Brandprint toggle on /v1/me
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+(Include `session.ts` only if Step 3 actually touched it.)
+
+---
+
+### Task 3: API — rework distinguishes disabled from missing; MCP suppression proven
+
+**Files:**
+- Modify: `apps/api/src/routes/rework.ts` (empty-brief guard, ~lines 176-186)
+- Test: the existing rework test file (grep apps/api/test for `needsBrandprint`) + the MCP brandprint test file (grep apps/api/test for `derive://brandprint`)
+
+**Interfaces:**
+- Consumes: `ResolvedBrandprint.workspaceSuppressed` (Task 1); the persisted toggle (Task 2).
+- Produces: rework 409 `code: "brandprintDisabled"`, message `"Brandprint is turned off in your settings. Turn it on to rework."` when the brief is empty because of suppression; existing `needsBrandprint` unchanged when nothing was ever set. Task 4's web branch keys on `brandprintDisabled`.
+
+- [ ] **Step 1: Failing tests** (in the rework suite, using its existing setup for workspace brandprint + registered agent):
+
+```ts
+  it("409s brandprintDisabled when the caller turned the workspace Brandprint off", async () => {
+    // workspace HAS a brandprint; caller saves { useWorkspaceBrandprint: false } with no
+    // personal collection via /v1/me; rework → 409 with code "brandprintDisabled"
+  })
+
+  it("rework proceeds on the personal collection when the workspace layer is off", async () => {
+    // caller saves { collectionId: <their own real collection>, useWorkspaceBrandprint: false }
+    // → rework succeeds (request posted)
+  })
+
+  it("no brandprint anywhere still 409s needsBrandprint", async () => { /* unchanged path */ })
+```
+
+Fill from the suite's existing patterns; assert the exact `code` and that the message names settings.
+
+Also extend the MCP brandprint test: a user whose toggle is off connecting over MCP gets NO workspace `derive://brandprint/*` resources (and no profile resource), while a personal-collection doc still appears. Follow the file's existing connect-and-list-resources pattern exactly.
+
+- [ ] **Step 2: Run to fail** — first test currently gets `needsBrandprint` (wrong code).
+
+- [ ] **Step 3: Implement.** In `rework.ts`, replace the empty-brief guard:
+
+```ts
+      if (resolved.collectionIds.length === 0 && !resolved.profileId)
+        return bail(
+          resolved.workspaceSuppressed
+            ? fail(c, 409, "Brandprint is turned off in your settings. Turn it on to rework.", {
+                code: "brandprintDisabled",
+              })
+            : fail(c, 409, "no Brandprint is set on this workspace or your profile", {
+                code: "needsBrandprint",
+              }),
+        )
+```
+
+Update the route's OpenAPI `description` string (~line 160) to name the third 409 code, then regen: `corepack pnpm gen:openapi` (apps/api) + `corepack pnpm gen:api-types` (apps/web); `pnpm lint:api-types` ok.
+
+Also extend the doc comment on `resolveActorBrandprint` (`apps/api/src/lib/brandprint.ts:8-14`) with the caveat the spec names: context runs key on the context CREATOR's id, so a creator's toggle governs that context's sessions regardless of who reads them.
+
+- [ ] **Step 4: Green** — rework + MCP suites green; full apps/api suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/rework.ts apps/api/openapi.json apps/web/src/api-types.ts apps/api/test/
+git commit -m "feat(api): rework tells a disabled Brandprint apart from a missing one
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Web — the switch, merge-preserving saves, and the rework error branch
+
+**Files:**
+- Modify: `apps/web/src/pages/brandprint/brandprint-section.tsx` (account scope: add the switch; fix the clobbering save)
+- Modify: `apps/web/src/pages/artifact/rework-menu-item.tsx` (the `onError` branch, ~line 65)
+- Test: any pure helper you extract gets a unit test; otherwise lints + typecheck are the gate (this repo has no component render harness)
+
+**Interfaces:**
+- Consumes: `me.brandprint.useWorkspaceBrandprint` from the regenerated types; `brandprintDisabled` error code (Task 3).
+- Produces: a `data-testid="brandprint-workspace-toggle"` switch; `api.setProfile` calls that MERGE the existing personal brandprint instead of clobbering it.
+
+- [ ] **Step 1: Fix the clobber first.** `brandprint-section.tsx` `updateAccount` (~line 168) currently writes `{ brandprint: collectionId ? { collectionId } : null }`, which would wipe the toggle on every collection save (and clearing the collection would clear the toggle too). Change account-scope saves to spread the current personal object:
+
+```ts
+    mutationFn: (collectionId: string | null) =>
+      api.setProfile({
+        brandprint: collectionId || me?.brandprint?.useWorkspaceBrandprint === false
+          ? { ...me?.brandprint, collectionId: collectionId || undefined }
+          : null,
+      }),
+```
+
+(Read the surrounding code and keep its exact optimistic/setMe flow; the rule is: a save must never drop a field it wasn't changing, and `null` clears only when nothing else remains.)
+
+- [ ] **Step 2: The switch.** In the account scope of `brandprint-section.tsx`, render (only when the ACTIVE workspace has a brandprint configured — the section already reads `settings?.brandprint`):
+
+```tsx
+  {(settings?.brandprint?.collectionId || settings?.brandprint?.profileId) && (
+    <div className="flex items-center justify-between gap-3">
+      <div>
+        <div className="text-sm font-medium">Use workspace Brandprint</div>
+        <p className="text-xs text-muted-foreground">
+          Off: your agents skip this workspace's style and profile. Your personal
+          conventions above still apply.
+        </p>
+      </div>
+      <Switch
+        data-testid="brandprint-workspace-toggle"
+        checked={me?.brandprint?.useWorkspaceBrandprint !== false}
+        onCheckedChange={(on) => toggleWorkspace.mutate(on)}
+      />
+    </div>
+  )}
+```
+
+with a `toggleWorkspace` `useApiMutation` that calls `api.setProfile({ brandprint: { ...me?.brandprint, useWorkspaceBrandprint: on ? undefined : false } })` (write `undefined`, not `true`, so "on" stores nothing and the absent-means-on rule holds; if the resulting object is empty, send `null`), then mirrors into `setMe` the way `updateAccount` does. Copy layout classes from the section's existing rows, import the repo's `Switch` component (grep `from "@/components/ui/switch"` for usage). Adjust copy/classes to the file's idiom; keep the testid.
+
+- [ ] **Step 3: Rework error branch.** In `rework-menu-item.tsx` `onError`:
+
+```ts
+      else if (code === "brandprintDisabled")
+        toast.error("Brandprint is turned off in your settings. Turn it on to rework.")
+```
+
+placed before the generic fallback; do NOT change the `needsBrandprint` → `/brandprint` navigation.
+
+- [ ] **Step 4: Verify** — `corepack pnpm --filter @derive/web typecheck`; `cd apps/web && npx vitest run`; from root `node scripts/check-testids.mjs && node scripts/check-design-tokens.mjs && node scripts/check-frontend.mjs`. All green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/pages/brandprint/brandprint-section.tsx apps/web/src/pages/artifact/rework-menu-item.tsx
+git commit -m "feat(web): personal use-workspace-Brandprint switch + disabled rework notice
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Full gate + PR handoff
+
+- [ ] `pnpm -r test && pnpm -r typecheck && pnpm precommit` from the worktree root — all green, fix anything that is not.
+- [ ] Push: `git push -u origin feat/brandprint-user-toggle`.
+- [ ] `gh` is NOT installed. Output the PR URL (`https://github.com/derive-to/derive/pull/new/feat/brandprint-user-toggle`) plus title `Personal toggle: turn the workspace Brandprint off for yourself` and a body pasted INLINE in the reply (never saved to a file): summary of the four changes, the merge-preserving save fix, the caveats (global not per-workspace; context runs key on the creator), test evidence, a manual test plan (toggle off → MCP resources gone, rework shows the notice; toggle on → parity with today), and the standard attribution line.

--- a/docs/superpowers/specs/2026-07-24-brandprint-user-toggle-design.md
+++ b/docs/superpowers/specs/2026-07-24-brandprint-user-toggle-design.md
@@ -1,0 +1,51 @@
+# Per-user Brandprint toggle
+
+**Date:** 2026-07-24 · **Status:** approved · **Driver:** Customer.io feedback (users with their own design.md baked into their personal LLM want the org Brandprint out of their agents' context)
+
+## Problem
+
+Brandprint is workspace-level: `OrgSettings.brandprint` (a conventions collection + brand-profile artifact) is injected for every member's agents via the single resolver `resolveActorBrandprint` (`apps/api/src/lib/brandprint.ts:15`), which merges the workspace layer with the user's personal layer and feeds every consumer: MCP connect (`apps/api/src/mcp.ts:133`, keyed on the human behind the agent), rework (`apps/api/src/routes/rework.ts:171`), and context runs (`apps/api/src/routes/contexts.ts:263`, keyed on the context creator). There is no way for an individual to opt out: the workspace layer is always included (`resolveBrandprint`, `packages/core/src/brandprint.ts:22`, appends unconditionally).
+
+## Change
+
+A personal "use workspace Brandprint" switch, default on. When off, the workspace layer (its collection AND its profile) is dropped for that user everywhere the resolver feeds. A personal Brandprint collection, if set, still applies: the toggle governs the org's style only.
+
+### 1. Storage: a field inside the existing personal-brandprint JSON
+
+The personal layer is already a JSON string on the user row, written via `setUserProfile` / read via `getUserBrandprint` (`packages/core/src/ports.ts:930-936`) and parsed by `parseBrandprint` (`packages/core/src/brandprint.ts:34`) into `Brandprint { collectionId?, profileId? }`. Add an optional field to the core type:
+
+- `Brandprint.useWorkspaceBrandprint?: boolean` — absent or `true` = on (today's behavior); `false` = off. Documented on the type as personal-layer-only (a workspace's own settings never carry it).
+
+No schema migration, no Better-Auth field additions. A user with no personal collection can still store `{"useWorkspaceBrandprint": false}`.
+
+### 2. Enforcement: one check in the pure resolver
+
+`resolveBrandprint(ws, profile)` in `packages/core/src/brandprint.ts:22`: when `profile?.useWorkspaceBrandprint === false`, exclude `ws` entirely — `collectionIds` comes from the personal layer only and `profileId` is `undefined`. Every consumer (MCP resources + instructions, `derive://brandprint/profile`, rework, contexts) inherits the suppression with zero per-callsite changes, because they all flow through `resolveActorBrandprint`.
+
+### 3. API surface: rides `/v1/me`
+
+`GET/POST /v1/me` already carries `brandprint: PersonalBrandprintSchema` (`apps/api/src/routes/session.ts:189-232`; schema at `apps/api/src/schemas.ts:299`). Add `useWorkspaceBrandprint: z.boolean().optional()` to `PersonalBrandprintSchema` (and, since that schema is derived from `BrandprintSchema.omit`, ensure only the personal schema exposes it — the workspace-settings write path must NOT accept it). The POST handler persists it inside the same JSON blob; the existing collection-ownership validation is untouched. Regenerate `openapi.json` + web `api-types.ts`.
+
+### 4. Rework guard: a distinct error for "disabled, not missing"
+
+`POST /v1/artifacts/{shortId}/rework` 409s with `code: "needsBrandprint"` when nothing resolves (`rework.ts:182-183`), and the web menu item routes that to `/brandprint` setup (`rework-menu-item.tsx:65`). Split the empty case:
+
+- Workspace has a Brandprint set, but the caller toggled it off and has no personal layer → `409` with `code: "brandprintDisabled"`, message "Brandprint is turned off in your settings. Turn it on to rework."
+- Workspace genuinely has none (today's case) → existing `needsBrandprint` behavior, unchanged.
+
+Web: `rework-menu-item.tsx` handles `brandprintDisabled` by showing that message as a small inline error/toast (matching how the component surfaces other failures) instead of navigating to `/brandprint`. If the caller's toggle is off but they DO have a personal collection, rework proceeds on the personal brief alone: no error.
+
+### 5. Web UI: a switch in the Brandprint page's personal section
+
+`apps/web/src/pages/brandprint/brandprint-section.tsx` (the personal Brandprint surface). Add a labeled switch, "Use workspace Brandprint", with a one-line explanation (e.g. "Off: your agents skip this workspace's style and profile; your personal conventions still apply."). Rendered only when the workspace actually has a Brandprint configured; persists through the existing `/v1/me` save path; reflects server state on load. Default on. `data-testid` required (`lint:testids`). No em dashes in UI copy.
+
+## Documented caveats (not solved here)
+
+- Global per-user, not per-workspace: the personal JSON is one blob per user. A per-workspace toggle needs new storage (`MembershipRecord` has no settings column); deferred until someone asks.
+- Context runs resolve by the context CREATOR (`contexts.ts:263`), so a creator's opt-out applies to that context's sessions regardless of who is reading. State this in the resolver's doc comment.
+
+## Testing
+
+- **Core** (`packages/core/test/brandprint.test.ts`): resolveBrandprint truth table — toggle absent/true keeps today's merge; `false` drops ws collection + profile while keeping personal collection; `false` with no personal layer resolves empty; parseBrandprint round-trips the new field.
+- **API** (`apps/api/test/`): POST /v1/me persists the toggle and GET returns it; workspace-settings route rejects/ignores `useWorkspaceBrandprint`; rework with toggle off + workspace brandprint set + no personal layer → 409 `brandprintDisabled`; toggle off + personal collection → rework proceeds (201/posted); no workspace brandprint at all → 409 `needsBrandprint` unchanged; MCP connect for a user with the toggle off exposes no `derive://brandprint/*` workspace resources (follow the existing MCP brandprint test pattern).
+- **Web**: unit-test any pure state helper added; the switch carries a testid; typecheck + testids/tokens lints green.

--- a/packages/core/src/brandprint.ts
+++ b/packages/core/src/brandprint.ts
@@ -15,11 +15,23 @@ export interface ResolvedBrandprint {
   /** The workspace's brand-profile artifact short_id, when set. The profile is a
    *  team property, so a personal layer never contributes one. */
   profileId?: string
+  /** True when a workspace layer existed but the personal toggle dropped it.
+   *  Lets rework tell "you turned it off" from "nothing is set up". */
+  workspaceSuppressed?: boolean
 }
 
 /** Resolve the workspace + profile Brandprint into the collections to read and the
  *  workspace's brand-profile pointer. */
 export const resolveBrandprint = (ws?: Brandprint, profile?: Brandprint): ResolvedBrandprint => {
+  // The personal toggle: false removes the workspace layer wholesale. The personal
+  // collection is the user's own opt-in, so it survives the toggle.
+  if (profile?.useWorkspaceBrandprint === false) {
+    const hadWs = !!(ws?.collectionId || ws?.profileId)
+    return {
+      collectionIds: profile.collectionId ? [profile.collectionId] : [],
+      ...(hadWs ? { workspaceSuppressed: true } : {}),
+    }
+  }
   const ids = [ws?.collectionId, profile?.collectionId].filter((id): id is string => !!id)
   return { collectionIds: [...new Set(ids)], profileId: ws?.profileId }
 }

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -2092,6 +2092,11 @@ export interface Brandprint {
    *  intake's stub (`profileState` derives live/pending from that). Workspace-only: a
    *  personal Brandprint never sets it. */
   profileId?: string
+  /** Personal-layer only: false turns the WORKSPACE Brandprint off for this user
+   *  (their agents skip the org's conventions and profile; a personal collection
+   *  above still applies). Absent or true = the workspace layer applies. A
+   *  workspace's own settings never carry this field. */
+  useWorkspaceBrandprint?: boolean
 }
 
 export const DEFAULT_ORG_SETTINGS: OrgSettings = {

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -2094,7 +2094,7 @@ export interface Brandprint {
   profileId?: string
   /** Personal-layer only: false turns the WORKSPACE Brandprint off for this user
    *  (their agents skip the org's conventions and profile; a personal collection
-   *  above still applies). Absent or true = the workspace layer applies. A
+   *  above still applies). Absent or true: the workspace layer applies. A
    *  workspace's own settings never carry this field. */
   useWorkspaceBrandprint?: boolean
 }

--- a/packages/core/test/brandprint.test.ts
+++ b/packages/core/test/brandprint.test.ts
@@ -40,6 +40,44 @@ describe("resolveBrandprint", () => {
       resolveBrandprint({ collectionId: "c1" }, { profileId: "nope" }).profileId,
     ).toBeUndefined()
   })
+
+  it("toggle off drops the workspace layer but keeps the personal collection", () => {
+    const r = resolveBrandprint(
+      { collectionId: "ws-col", profileId: "prof" },
+      { collectionId: "my-col", useWorkspaceBrandprint: false },
+    )
+    expect(r.collectionIds).toEqual(["my-col"])
+    expect(r.profileId).toBeUndefined()
+    expect(r.workspaceSuppressed).toBe(true)
+  })
+
+  it("toggle off with no personal layer resolves empty, marked suppressed", () => {
+    const r = resolveBrandprint({ collectionId: "ws-col" }, { useWorkspaceBrandprint: false })
+    expect(r.collectionIds).toEqual([])
+    expect(r.profileId).toBeUndefined()
+    expect(r.workspaceSuppressed).toBe(true)
+  })
+
+  it("toggle off with no workspace layer is not marked suppressed", () => {
+    const r = resolveBrandprint(undefined, {
+      collectionId: "my-col",
+      useWorkspaceBrandprint: false,
+    })
+    expect(r.collectionIds).toEqual(["my-col"])
+    expect(r.workspaceSuppressed).toBeUndefined()
+  })
+
+  it("absent and true both keep today's merge", () => {
+    for (const p of [
+      { collectionId: "my-col" },
+      { collectionId: "my-col", useWorkspaceBrandprint: true },
+    ]) {
+      const r = resolveBrandprint({ collectionId: "ws-col", profileId: "prof" }, p)
+      expect(r.collectionIds).toEqual(["ws-col", "my-col"])
+      expect(r.profileId).toBe("prof")
+      expect(r.workspaceSuppressed).toBeUndefined()
+    }
+  })
 })
 
 describe("parseBrandprint", () => {
@@ -49,6 +87,12 @@ describe("parseBrandprint", () => {
     expect(parseBrandprint("")).toBeUndefined()
     expect(parseBrandprint("not json")).toBeUndefined()
     expect(parseBrandprint("42")).toBeUndefined()
+  })
+
+  it("round-trips the toggle", () => {
+    expect(parseBrandprint('{"useWorkspaceBrandprint":false}')).toEqual({
+      useWorkspaceBrandprint: false,
+    })
   })
 })
 

--- a/packages/core/test/brandprint.test.ts
+++ b/packages/core/test/brandprint.test.ts
@@ -67,7 +67,7 @@ describe("resolveBrandprint", () => {
     expect(r.workspaceSuppressed).toBeUndefined()
   })
 
-  it("absent and true both keep today's merge", () => {
+  it("absent and true both keep the workspace layer in the merge", () => {
     for (const p of [
       { collectionId: "my-col" },
       { collectionId: "my-col", useWorkspaceBrandprint: true },


### PR DESCRIPTION
## Summary

Some users bake their own style guide into their personal LLM setup (a design.md their agent already reads) and do not want the org Brandprint layered on top. This adds a personal "Use workspace Brandprint" switch, default on, requested by Customer.io feedback.

- **Core**: `Brandprint` gains an optional `useWorkspaceBrandprint` (personal layer only; absent or `true` is today's behavior). When `false`, `resolveBrandprint` drops the workspace layer entirely (conventions collection AND brand profile) while keeping the user's personal collection, and marks the result `workspaceSuppressed` so callers can tell "turned off" from "never set up". Strict `=== false` check, so any legacy/odd stored value fails safe to on.
- **Reach**: every injection surface flows through the one resolver, so the suppression covers MCP resources + instructions, `derive://brandprint/profile`, rework, and context sessions with zero per-callsite changes. Deliberately unaffected: writing the workspace profile through the brandprint URI stays possible for a toggled-off admin (reads are personal preference; team maintenance is not).
- **API**: the toggle persists inside the existing personal-brandprint JSON via `POST /v1/me/profile` (no migration). The workspace-settings route provably strips the field, so it can never land on org settings. Rework now returns 409 `brandprintDisabled` ("Brandprint is turned off in your settings. Turn it on to rework.") when suppression left nothing to work from, distinct from the existing `needsBrandprint`; a toggled-off user with a personal collection reworks on that alone, no error.
- **Web**: a Switch in the Brandprint page's account section (shown only when the workspace has a Brandprint; off stores `false`, on stores nothing). All personal-brandprint saves now go through a merge-preserving helper (`nextPersonalBrandprint`, unit-tested), fixing a pre-existing clobber where saving or clearing the collection replaced the whole object. The toggle, collection saves, and imports cross-disable while in flight so concurrent responses cannot revert each other. The rework menu surfaces the disabled message as a toast.

## Known caveats (documented in code/spec)

- Global per user, not per workspace (per-workspace needs new storage; deferred until someone asks).
- Context sessions resolve Brandprint by the context creator, so a creator's toggle governs that context's runs regardless of the reader.

## Test evidence

- Full monorepo suite green in the worktree: api 1189/1189, web 196/196 (8 new for the merge helper), core, cli, db, mcp, dispatcher, hosted-agent, storage. Typecheck clean on all 8 projects; precommit (biome + all lint gates) green.
- New coverage: core suppression truth table (off drops ws + keeps personal, marks suppressed only when a ws layer existed, absent/true byte-identical to today, parse round-trip); API persistence + echo, collection+toggle coexistence, workspace-route stripping; rework `brandprintDisabled` vs `needsBrandprint` vs proceeds-on-personal; an end-to-end MCP test proving a toggled-off user's connection lists no workspace brandprint resources while personal docs still appear.
- Merge-probed against current main (134 commits ahead): zero conflicts; if the auto-merged generated files (openapi.json / api-types.ts) trip CI, a single regen commit fixes it.

## Test plan (visual pass)

- [ ] Brandprint page, account section: switch appears when the workspace has a Brandprint, flips + persists across reload
- [ ] With the toggle off: agent over MCP sees no workspace brandprint resources; rework shows the settings-pointing toast (no personal collection) or proceeds (personal collection set)
- [ ] Toggle on: behavior identical to main

## Follow-ups (deliberately not in this PR)

- Playwright smoke of the toggle surviving a real session reload (Better Auth e2e harness exists)
- `derive://brandprint/profile` read copy when a live profile is suppressed (currently says none exists yet)
- Documenting `brandprint` on the GET /v1/me response schema (pre-existing gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787868456&installation_model_id=428097&pr_number=562&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F562&signature=2341eb4842bd402f110ad8294a073fb7c46aca840ca6fa8be9a4e54bb4c86952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->