### PR TITLE
feat(artifacts): public version history — an owner opt-in for the ano…

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -230,6 +230,10 @@
             "type": "number",
             "description": "Open-thread count for the sign-in-to-comment pill; present only for anonymous callers on a link that grants commenting."
           },
+          "public_history": {
+            "type": "boolean",
+            "description": "Owner opt-in: the anonymous public page shows version history. When false, anonymous detail responses carry only the current version."
+          },
           "org_id": {
             "type": "string",
             "description": "The artifact's workspace id; drives move-to-workspace."
@@ -4317,13 +4321,18 @@
                     "locked": {
                       "type": "boolean",
                       "description": "true when the world link is now password-locked."
+                    },
+                    "public_history": {
+                      "type": "boolean",
+                      "description": "Whether the anonymous public page shows version history."
                     }
                   },
                   "required": [
                     "workspace_access",
                     "link_role",
                     "listed",
-                    "locked"
+                    "locked",
+                    "public_history"
                   ]
                 }
               }

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -1283,7 +1283,16 @@ export const artifactRoutes = (ctx: AppContext) => {
           removed: true,
           managed: false,
         })
-      const versions = await meta.listVersions(artifact.id)
+      const allVersions = await meta.listVersions(artifact.id)
+      // The public-history gate: unless the owner opted the public page in, an
+      // anonymous caller's history collapses to the current version — the payload
+      // must not leak what the page won't show (version messages and author names
+      // are workbench material). Everything below (versions, sessions, bylines)
+      // derives from this list, so trimming here keeps the response consistent.
+      const versions =
+        actor.kind === "anon" && !artifact.public_history
+          ? allVersions.filter((v) => v.n === artifact.current_version)
+          : allVersions
       const me = actor.kind === "user" ? actor.userId : null
       const tags = (await meta.tagsForArtifacts([artifact.id]))[artifact.id] ?? []
       const favorite = me ? (await meta.listUserFavoriteIds(me)).includes(artifact.id) : false
@@ -1415,6 +1424,10 @@ export const artifactRoutes = (ctx: AppContext) => {
         // only for white-label workspaces; the viewer reads this single boolean so
         // workspace settings never travel to anonymous clients.
         badge: !(await meta.getOrgSettings(artifact.org_id)).whiteLabel,
+        // Owner opt-in: the anonymous public page shows version history. The
+        // client uses it to render the byline dropdown; the server enforces it
+        // above (trimmed versions) and in raw.ts (old-version bytes).
+        public_history: !!artifact.public_history,
         // Open-thread count for the public viewer's sign-in-to-comment pill. Anon
         // never sees comment bodies (collaboration, not content — see comments.ts),
         // so the count is the one bit that crosses; it crosses only where the pill
@@ -1489,6 +1502,9 @@ export const artifactRoutes = (ctx: AppContext) => {
                   .enum(["none", "workspace", "public"])
                   .describe("New discovery listing: nowhere, the workspace, or public."),
                 locked: z.boolean().describe("true when the world link is now password-locked."),
+                public_history: z
+                  .boolean()
+                  .describe("Whether the anonymous public page shows version history."),
               }),
             },
           },
@@ -1506,6 +1522,10 @@ export const artifactRoutes = (ctx: AppContext) => {
           linkRole: z.enum(["none", "viewer", "commenter", "editor"]).optional(),
           listed: z.enum(["none", "workspace", "public"]).optional(),
           password: z.string().optional(),
+          // Owner opt-in: the anonymous public page shows version history.
+          // Omitted preserves; rides this route because it's a disclosure
+          // control like the triple, applied by the same dialog.
+          publicHistory: z.boolean().optional(),
           // Legacy wire (pre-v2 clients): `visibility` maps onto the triple, `generalRole`
           // is the old spelling of the world link role.
           visibility: z.string().optional(),
@@ -1537,11 +1557,15 @@ export const artifactRoutes = (ctx: AppContext) => {
       if (b.visibility === "password" && !passwordHash)
         return bail(fail(c, 400, "a password is required for password visibility"))
       await meta.setAccess(artifact.id, workspaceAccess, listed, linkRole, passwordHash)
+      const publicHistory = b.publicHistory ?? !!artifact.public_history
+      if (b.publicHistory !== undefined)
+        await meta.setPublicHistory(artifact.id, b.publicHistory ? 1 : 0)
       return c.json({
         workspace_access: workspaceAccess,
         link_role: linkRole,
         listed,
         locked: !!passwordHash,
+        public_history: publicHistory,
       })
     },
   )

--- a/apps/api/src/routes/raw.ts
+++ b/apps/api/src/routes/raw.ts
@@ -17,8 +17,18 @@ const RAW_TOKEN_MAX_AGE_MS = 5 * 60 * 1000
 /** The sandbox: raw artifact + proposal bytes under /raw/*. Served with an
  *  opaque-origin CSP; a proposal renders exactly like the live version will. */
 export const rawRoutes = (ctx: AppContext) => {
-  const { meta, blobs, deps, authorize, background } = ctx
+  const { meta, blobs, deps, authorize, actorFor, background } = ctx
   const app = new Hono()
+
+  // The public-history gate: unless the owner opted the public page into history,
+  // an anonymous caller reads only the CURRENT version — an old version's bytes are
+  // as hidden as the workbench that lists them. Applies to the viewer entry points
+  // (cookie + raw_token) only: the preview route's token is a server-minted
+  // capability for exactly one artifact+version, and proposals aren't versions.
+  const anonHistoryBlocked = async (c: Context, artifact: ArtifactRecord, n: number) =>
+    n !== artifact.current_version &&
+    !artifact.public_history &&
+    (await actorFor(c, artifact)).kind === "anon"
 
   // The comment-anchor client, referenced by URL from artifact HTML. Artifact
   // pages are cached immutable; this is cached short so the client can evolve
@@ -84,6 +94,7 @@ export const rawRoutes = (ctx: AppContext) => {
     )
     const ok = claim?.rid === artifact.id || (await authorize(c, "read", artifact))
     if (!ok) return c.text("not found", 404)
+    if (await anonHistoryBlocked(c, artifact, n)) return c.text("not found", 404)
     return serveVersion(
       c,
       artifact,
@@ -132,6 +143,7 @@ export const rawRoutes = (ctx: AppContext) => {
     const artifact = await meta.getByShortId(shortId)
     if (!artifact || !Number.isInteger(n)) return c.text("not found", 404)
     if (!(await authorize(c, "read", artifact))) return c.text("not found", 404)
+    if (await anonHistoryBlocked(c, artifact, n)) return c.text("not found", 404)
     return serveVersion(c, artifact, n, `/raw/${shortId}/v/${c.req.param("n")}/`)
   })
 

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -142,6 +142,12 @@ export const Artifact = z
       .describe(
         "Open-thread count for the sign-in-to-comment pill; present only for anonymous callers on a link that grants commenting.",
       ),
+    public_history: z
+      .boolean()
+      .optional()
+      .describe(
+        "Owner opt-in: the anonymous public page shows version history. When false, anonymous detail responses carry only the current version.",
+      ),
     org_id: z
       .string()
       .optional()

--- a/apps/api/test/public-history.test.ts
+++ b/apps/api/test/public-history.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+import { anonApp, app, bearer, meta, TEST_TOKEN, upload } from "./helpers"
+
+const idOf = async (res: Response): Promise<string> => (await res.json()).short_id
+
+const patchAccess = async (short: string, body: unknown) => {
+  const res = await app.request(`/v1/artifacts/${short}/access`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json", ...bearer(TEST_TOKEN) },
+    body: JSON.stringify(body),
+  })
+  if (res.status !== 200) throw new Error(`access patch failed: ${res.status}`)
+  return res.json()
+}
+
+/** Publish v2 so the artifact has real history to show or hide. */
+const addVersion = async (short: string) => {
+  const res = await upload("v2.md", "# Second", {}, short)
+  if (res.status !== 201 && res.status !== 200) throw new Error(`version failed: ${res.status}`)
+}
+
+// public_history (the launch-essay toggle): the owner opts the ANONYMOUS public
+// page into version history. Off (the default), anon must not see history at all —
+// not in the payload, not via a hand-typed @vN, not via old-version raw. Signed-in
+// readers are untouched either way (auth is the gate, like comments).
+describe("public history", () => {
+  it("defaults off: anon detail carries only the current version and public_history false", async () => {
+    const short = await idOf(await upload("ph.md", "# One", { visibility: "public", title: "PH" }))
+    await addVersion(short)
+
+    const detail = await (await anonApp.request(`/v1/artifacts/${short}`)).json()
+    expect(detail.public_history).toBe(false)
+    expect(detail.current_version).toBe(2)
+    expect(detail.versions.map((v: { n: number }) => v.n)).toEqual([2])
+    expect(detail.sessions.length).toBe(1)
+  })
+
+  it("authenticated callers keep full history regardless of the flag", async () => {
+    const short = await idOf(await upload("pha.md", "# One", { visibility: "public", title: "A" }))
+    await addVersion(short)
+
+    const detail = await (
+      await app.request(`/v1/artifacts/${short}`, { headers: bearer(TEST_TOKEN) })
+    ).json()
+    expect(detail.versions.length).toBe(2)
+  })
+
+  it("the owner flips it over PATCH /access; anon then sees the full history", async () => {
+    const short = await idOf(await upload("phb.md", "# One", { visibility: "public", title: "B" }))
+    await addVersion(short)
+
+    const flipped = await patchAccess(short, { publicHistory: true })
+    expect(flipped.public_history).toBe(true)
+
+    const detail = await (await anonApp.request(`/v1/artifacts/${short}`)).json()
+    expect(detail.public_history).toBe(true)
+    expect(detail.versions.map((v: { n: number }) => v.n)).toEqual([1, 2])
+
+    // Access-triple changes that omit the flag leave it alone.
+    await patchAccess(short, { listed: "public" })
+    const after = await (await anonApp.request(`/v1/artifacts/${short}`)).json()
+    expect(after.public_history).toBe(true)
+  })
+
+  it("anon old-version raw: 404 while off, served once on; the current version always serves", async () => {
+    const short = await idOf(await upload("phc.md", "# One", { visibility: "public", title: "C" }))
+    await addVersion(short)
+    const art = await meta.getByShortId(short)
+    if (!art) throw new Error("artifact missing")
+
+    const current = await anonApp.request(`/raw/${short}/v/2/index.md`)
+    expect(current.status).toBe(200)
+    const old = await anonApp.request(`/raw/${short}/v/1/index.md`)
+    expect(old.status).toBe(404)
+
+    await meta.setPublicHistory(art.id, 1)
+    const oldOn = await anonApp.request(`/raw/${short}/v/1/index.md`)
+    expect(oldOn.status).toBe(200)
+  })
+})

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -1463,6 +1463,8 @@ export interface paths {
                             listed: "none" | "workspace" | "public";
                             /** @description true when the world link is now password-locked. */
                             locked: boolean;
+                            /** @description Whether the anonymous public page shows version history. */
+                            public_history: boolean;
                         };
                     };
                 };
@@ -5504,6 +5506,8 @@ export interface components {
             badge?: boolean;
             /** @description Open-thread count for the sign-in-to-comment pill; present only for anonymous callers on a link that grants commenting. */
             open_comment_count?: number;
+            /** @description Owner opt-in: the anonymous public page shows version history. When false, anonymous detail responses carry only the current version. */
+            public_history?: boolean;
             /** @description The artifact's workspace id; drives move-to-workspace. */
             org_id?: string;
             /** @description Signed, short-lived token for fetching raw content; detail responses only. */

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -608,12 +608,15 @@ export const api = {
       linkRole?: LinkRole
       listed?: Listed
       password?: string
+      /** Owner opt-in: the anonymous public page shows version history. */
+      publicHistory?: boolean
     },
   ): Promise<{
     workspace_access: WorkspaceAccess
     link_role: LinkRole
     listed: Listed
     locked: boolean
+    public_history: boolean
   }> =>
     f(`/v1/artifacts/${id}/access`, {
       ...opts(access),

--- a/apps/web/src/pages/artifact/artifact-document.tsx
+++ b/apps/web/src/pages/artifact/artifact-document.tsx
@@ -36,6 +36,7 @@ export function ArtifactDocument({
   onDeckPrev,
   onDeckNext,
   onFullscreen,
+  anonView = false,
 }: {
   shown: number
   currentVersion: number
@@ -58,6 +59,9 @@ export function ArtifactDocument({
   onDeckPrev: () => void
   onDeckNext: () => void
   onFullscreen: () => void
+  /** Anonymous public viewer: the past-version strip keeps only "Back to current"
+   *  (diff and restore are workbench affordances an anon caller can't use). */
+  anonView?: boolean
 }) {
   const past = shown !== currentVersion
   return (
@@ -66,33 +70,41 @@ export function ArtifactDocument({
           off-current is a "this matters" moment, not a status warning). */}
       {past && (
         <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5 border-b border-primary/30 bg-primary/5 px-4 py-2 text-sm">
-          <span className="font-medium text-primary">Viewing an earlier version</span>
-          <span className="text-muted-foreground">·</span>
-          <Button
-            variant="link"
-            data-testid="artifact-toggle-diff"
-            className="h-auto p-0 underline"
-            onClick={onToggleDiff}
-          >
-            {view === "diff" ? "Hide changes" : "Show changes since this"}
-          </Button>
+          <span className="font-medium text-primary">
+            Viewing an earlier version{anonView ? ` (v${shown})` : ""}
+          </span>
+          {!anonView && (
+            <>
+              <span className="text-muted-foreground">·</span>
+              <Button
+                variant="link"
+                data-testid="artifact-toggle-diff"
+                className="h-auto p-0 underline"
+                onClick={onToggleDiff}
+              >
+                {view === "diff" ? "Hide changes" : "Show changes since this"}
+              </Button>
+            </>
+          )}
           <span className="flex-1" />
-          <Button
-            variant="outline"
-            size="sm"
-            data-testid="artifact-restore"
-            onClick={onRestore}
-            disabled={restoring}
-          >
-            {restoring ? "Restoring…" : "Restore this version"}
-          </Button>
+          {!anonView && (
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="artifact-restore"
+              onClick={onRestore}
+              disabled={restoring}
+            >
+              {restoring ? "Restoring…" : "Restore this version"}
+            </Button>
+          )}
           <Button
             variant="secondary"
             size="sm"
             data-testid="artifact-back-to-current"
             onClick={onBackToCurrent}
           >
-            Back to current
+            {anonView ? `Back to current (v${currentVersion})` : "Back to current"}
           </Button>
         </div>
       )}

--- a/apps/web/src/pages/artifact/artifact-top-bar.tsx
+++ b/apps/web/src/pages/artifact/artifact-top-bar.tsx
@@ -41,6 +41,7 @@ export function ArtifactTopBar(props: {
   linkRole?: LinkRole
   listed?: Listed
   passwordProtected?: boolean
+  publicHistory?: boolean
   favorite: boolean
   tags: string[]
   collections: string[]
@@ -96,6 +97,7 @@ export function ArtifactTopBar(props: {
           linkRole={props.linkRole}
           listed={props.listed}
           passwordProtected={props.passwordProtected}
+          publicHistory={props.publicHistory}
           collectionAccess={props.collectionAccess}
         />
         <StarButton shortId={shortId} favorite={props.favorite} onChange={props.onFavorite} />

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -441,6 +441,14 @@ export function Artifact() {
     )
 
   const shown = version ?? art.current_version
+  // The public-history gate, client half: an anonymous @vN link on an artifact whose
+  // owner kept history private is a 404, not a downgrade — the server already
+  // refuses the old version's bytes (raw.ts), so render the same not-found the
+  // hand-typed-id case gets rather than a broken frame. Only once auth has
+  // SETTLED anonymous: while it loads, `me` is null for signed-in users too,
+  // and they must not flash a not-found for a version they can see.
+  if (!loading && !me && shown !== art.current_version && !art.public_history)
+    return <ArtifactNotFound onBack={() => nav({ to: "/" })} />
   const editable = art.kind === "file" && shown === art.current_version
   // The `t/:raw_token` segment is the sandboxed iframe's own proof of access: it has no
   // `allow-same-origin` (by design — the content must never touch our cookies/storage),
@@ -558,6 +566,7 @@ export function Artifact() {
       onDeckPrev={() => deckCmd("prev")}
       onDeckNext={() => deckCmd("next")}
       onFullscreen={toggleFullscreen}
+      anonView={isAnon}
     />
   )
 
@@ -569,6 +578,7 @@ export function Artifact() {
     return (
       <PublicViewer
         art={art}
+        shown={shown}
         returnTo={`/artifacts/${ref}`}
         viewers={live.viewers}
         selfId={guestPresenceId()}
@@ -680,6 +690,7 @@ export function Artifact() {
               linkRole={art.link_role}
               listed={art.listed}
               passwordProtected={!!art.password_protected}
+              publicHistory={!!art.public_history}
               favorite={!!art.favorite}
               tags={art.tags ?? []}
               collections={art.collections ?? []}

--- a/apps/web/src/pages/artifact/public-viewer.tsx
+++ b/apps/web/src/pages/artifact/public-viewer.tsx
@@ -5,12 +5,19 @@ import type { Artifact, Viewer } from "@/api"
 import { Icon } from "@/components/icons"
 import { Logo } from "@/components/shared/logo"
 import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { artifactTypeLabel } from "@/lib/artifact"
 import { stampSrc } from "@/lib/src-stamp"
 import { ago } from "@/lib/time"
 import { cn } from "@/lib/utils"
 import { FloatingControl } from "./floating-control"
 import { commentNudgeCopy, shouldPromptSignInToComment } from "./lib/comment-access"
+import { refFor } from "./parse-ref"
 import { Presence } from "./rail-deck"
 
 // Backdrop texture for the anon comments panel — the marketing site's "chats
@@ -40,6 +47,7 @@ const GHOST_COMMENTS = [
 // as `children`.
 export function PublicViewer({
   art,
+  shown,
   returnTo,
   viewers,
   selfId,
@@ -47,6 +55,8 @@ export function PublicViewer({
   children,
 }: {
   art: Artifact
+  /** The version being rendered (an @vN link may pin one behind current). */
+  shown: number
   /** The current /artifacts/<ref> path, so Sign in returns here afterward. */
   returnTo: string
   viewers: Viewer[]
@@ -65,6 +75,8 @@ export function PublicViewer({
   const nudge = shouldPromptSignInToComment(art.link_role, !!art.removed)
   const copy = commentNudgeCopy(art.open_comment_count)
   const [nudgeOpen, setNudgeOpen] = useState(false)
+  // Base ref for the version menu's links (current = bare, past = @vN).
+  const baseRef = refFor({ short_id: art.short_id, title: art.title })
 
   return (
     <div data-artifact-view className="flex min-h-0 flex-1 flex-col bg-background">
@@ -105,7 +117,48 @@ export function PublicViewer({
               ) : (
                 <>by {authorName} · </>
               ))}
-            {artifactTypeLabel(art)} · v{art.current_version}
+            {artifactTypeLabel(art)} ·{" "}
+            {/* With public history on, the version reads as a menu: every version,
+                one line each, navigating the @vN refs the router already serves.
+                Off (or a single version), it stays the inert text it always was. */}
+            {art.public_history && (art.versions?.length ?? 0) > 1 ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  data-testid="public-version-menu"
+                  className="rounded-sm text-foreground underline decoration-dotted underline-offset-2 outline-none hover:decoration-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                >
+                  v{shown} ▾
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="max-w-[420px]">
+                  {[...(art.versions ?? [])].reverse().map((v) => (
+                    <DropdownMenuItem key={v.n} asChild data-testid={`public-version-${v.n}`}>
+                      <Link
+                        to="/artifacts/$ref"
+                        params={{
+                          ref: v.n === art.current_version ? baseRef : `${baseRef}@v${v.n}`,
+                        }}
+                        className="flex w-full min-w-0 items-baseline gap-2 font-mono text-xs"
+                      >
+                        <span className={cn("shrink-0", v.n === shown && "font-semibold")}>
+                          v{v.n}
+                        </span>
+                        <span className="shrink-0 text-muted-foreground">
+                          {v.created_at ? ago(v.created_at) : ""}
+                        </span>
+                        {v.author && (
+                          <span className="shrink-0 text-muted-foreground">· {v.author}</span>
+                        )}
+                        {v.message && (
+                          <span className="truncate text-muted-foreground">· {v.message}</span>
+                        )}
+                      </Link>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : (
+              <>v{shown}</>
+            )}
             {art.updated_at ? ` · ${ago(art.updated_at)}` : ""}
           </div>
         </div>

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -97,6 +97,8 @@ type AccessDraft = {
   linkRole: LinkRole
   listed: Listed
   password?: string
+  /** Owner opt-in: the anonymous public page shows version history. */
+  publicHistory?: boolean
 }
 
 /**
@@ -113,6 +115,7 @@ export function ShareButton({
   linkRole,
   listed,
   passwordProtected = false,
+  publicHistory = false,
   collectionAccess,
 }: {
   shortId: string
@@ -123,6 +126,8 @@ export function ShareButton({
   listed?: Listed
   /** The world link carries a password (the lock). */
   passwordProtected?: boolean
+  /** The anonymous public page shows version history (owner opt-in). */
+  publicHistory?: boolean
   /** Collections whose sharing reaches this artifact (detail response) — rendered as
    *  disclosure rows so the dialog never claims "Invited" while a collection grants
    *  the workspace access. */
@@ -149,6 +154,8 @@ export function ShareButton({
   const [pw, setPw] = useState("")
   // The lock as the server knows it, kept locally current as we set/clear it.
   const [hasLock, setHasLock] = useState(passwordProtected)
+  // Public history as the server knows it (see the world-link row below).
+  const [pubHist, setPubHist] = useState(publicHistory)
   // The checkbox is checked before a password exists (the input is showing) —
   // nothing applies until Set password.
   const [lockDraft, setLockDraft] = useState(false)
@@ -232,10 +239,11 @@ export function ShareButton({
   const accessMut = useApiMutation({
     mutationFn: (next: AccessDraft) => api.setAccess(shortId, next),
     optimistic: (next) => {
-      const prev = { wsAccess, lRole, lst, hasLock, lockDraft }
+      const prev = { wsAccess, lRole, lst, hasLock, lockDraft, pubHist }
       setWsAccess(next.workspaceAccess)
       setLRole(next.linkRole)
       setLst(next.listed)
+      if (next.publicHistory !== undefined) setPubHist(next.publicHistory)
       if (next.linkRole === "none") {
         setHasLock(false)
         setLockDraft(false)
@@ -246,6 +254,7 @@ export function ShareButton({
         setLst(prev.lst)
         setHasLock(prev.hasLock)
         setLockDraft(prev.lockDraft)
+        setPubHist(prev.pubHist)
       }
     },
     onSuccess: (r) => {
@@ -253,6 +262,7 @@ export function ShareButton({
       setLRole(r.link_role)
       setLst(r.listed)
       setHasLock(!!r.locked)
+      setPubHist(!!r.public_history)
       setLockDraft(false)
       setPw("")
       setPwOpen(false)
@@ -309,6 +319,9 @@ export function ShareButton({
     listed: lst,
     password,
   })
+  // Public history: applies immediately like every other switch here.
+  const togglePublicHistory = (on: boolean) =>
+    void applyAccess({ workspaceAccess: wsAccess, linkRole: lRole, listed: lst, publicHistory: on })
   // The lock checkbox: checking reveals the password input (applies on Set);
   // unchecking clears the lock immediately (an explicit empty password).
   const toggleLock = (on: boolean) => {
@@ -446,6 +459,7 @@ export function ShareButton({
           // Re-seed the lock from the server's state and drop any half-typed
           // draft — an abandoned checkbox must not survive a close/reopen.
           setHasLock(passwordProtected)
+          setPubHist(publicHistory)
           setLockDraft(false)
           setMore(false)
           load()
@@ -574,6 +588,25 @@ export function ShareButton({
                         aria-label="List in the public directory"
                         data-testid="share-listed"
                         onCheckedChange={toggleListed}
+                      />
+                    </div>
+
+                    {/* Public history — a disclosure like the listing: whether the
+                        anonymous page shows every version (dropdown + old reads).
+                        Signed-in readers always see history; this governs anon only. */}
+                    <div className="mt-3 flex items-center justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="text-sm text-foreground">Show version history</div>
+                        <div className="text-xs text-muted-foreground">
+                          Anyone with the link can browse every version.
+                        </div>
+                      </div>
+                      <Switch
+                        checked={pubHist}
+                        disabled={accessMut.isPending}
+                        aria-label="Show version history on the public page"
+                        data-testid="share-public-history"
+                        onCheckedChange={togglePublicHistory}
                       />
                     </div>
 

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS artifact (
   removed_at TEXT,
   expires_at TEXT,
   first_foreign_view_at TEXT,
+  public_history INTEGER,
   source_path TEXT,
   author_name TEXT,
   author_login TEXT,

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -132,6 +132,10 @@ export interface ArtifactRecord {
    *  stamps it once; owner self-views were already excluded upstream). Null until
    *  someone else has actually seen the work. */
   first_foreign_view_at: string | null
+  /** Owner opt-in: the ANONYMOUS public page shows version history (dropdown + old
+   *  versions). Falsy = anon sees the current version only; signed-in readers always
+   *  keep workbench history (auth is the gate, like comments). */
+  public_history: 0 | 1 | null
   /** For a GitHub-synced artifact: its path within the repo (e.g. "docs/plans/foo.md").
    *  The structural "location" — drives the folder/tree view — kept distinct from the
    *  human `title`. Null for artifacts not mirrored from a repo. */
@@ -320,6 +324,8 @@ export interface ArtifactStore {
   ): Promise<void>
   /** Toggle the change-lock: when locked, direct publishes are rejected. */
   setLocked(artifactId: string, locked: 0 | 1): Promise<void>
+  /** Owner opt-in: the anonymous public page shows version history. */
+  setPublicHistory(artifactId: string, on: 0 | 1): Promise<void>
   getByShortId(shortId: string): Promise<ArtifactRecord | null>
   /** Load an artifact by its internal id (used by domain mode's host lookup). */
   getArtifactById(id: string): Promise<ArtifactRecord | null>

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -61,6 +61,8 @@ export const artifact = pgTable("artifact", {
   expires_at: text("expires_at"),
   // First non-author view (the activation moment; see schema.ts).
   first_foreign_view_at: text("first_foreign_view_at"),
+  // Owner opt-in: anon public page shows version history (see schema.ts).
+  public_history: integer("public_history").$type<0 | 1>(),
   source_path: text("source_path"),
   // The CURRENT (last) author, denormalized from the latest version for the list view +
   // author filtering. For a GitHub-synced artifact these mirror the last commit's author.

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -353,6 +353,10 @@ export class PgMetaStore implements MetaStore {
     await this.db.update(artifact).set({ locked }).where(eq(artifact.id, artifactId))
   }
 
+  async setPublicHistory(artifactId: string, on: 0 | 1): Promise<void> {
+    await this.db.update(artifact).set({ public_history: on }).where(eq(artifact.id, artifactId))
+  }
+
   async getByShortId(shortId: string): Promise<ArtifactRecord | null> {
     const rows = await this.db.select().from(artifact).where(eq(artifact.short_id, shortId))
     return rows[0] ?? null

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -523,6 +523,10 @@ export function makeRepos(db: SqliteDb) {
     await db.update(artifact).set({ locked }).where(eq(artifact.id, artifactId)).run()
   }
 
+  const setPublicHistory = async (artifactId: string, on: 0 | 1): Promise<void> => {
+    await db.update(artifact).set({ public_history: on }).where(eq(artifact.id, artifactId)).run()
+  }
+
   const getVersion = async (artifactId: string, n: number): Promise<VersionRecord | null> =>
     (await db
       .select()
@@ -3521,6 +3525,7 @@ export function makeRepos(db: SqliteDb) {
     createArtifact,
     setAccess,
     setLocked,
+    setPublicHistory,
     getByShortId,
     getArtifactById,
     getArtifactsByIds,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -83,6 +83,11 @@ export const artifact = sqliteTable("artifact", {
   // When the first non-author view landed (recordView stamps it once — the
   // activation moment). Nullable, no default, so it ALTER ADDs cleanly.
   first_foreign_view_at: text("first_foreign_view_at"),
+  // Owner opt-in: the ANONYMOUS public page shows version history (dropdown +
+  // old-version reads). Off, anon callers get the current version only — signed-in
+  // readers always keep workbench history (auth is the gate, like comments).
+  // Nullable (null = off), no default, so it ALTER ADDs cleanly.
+  public_history: integer("public_history").$type<0 | 1>(),
   source_path: text("source_path"),
   // The CURRENT (last) author, denormalized from the latest version row for the list
   // view + author filtering. For a GitHub-synced artifact these mirror the last commit's

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1285,6 +1285,21 @@ export function runStoreContract(
       })
       expect((await store.getByShortId(a.short_id))?.first_foreign_view_at).toBe(stamped)
     })
+
+    it("flips public_history (off by default) without touching access", async () => {
+      const a = await store.createArtifact(newArtifact())
+      expect((await store.getByShortId(a.short_id))?.public_history).toBeFalsy()
+
+      await store.setPublicHistory(a.id, 1)
+      const on = await store.getByShortId(a.short_id)
+      expect(on?.public_history).toBe(1)
+      // The flag rides alone — the access triple is untouched.
+      expect(on?.workspace_access).toBe(a.workspace_access)
+      expect(on?.link_role).toBe(a.link_role)
+
+      await store.setPublicHistory(a.id, 0)
+      expect((await store.getByShortId(a.short_id))?.public_history).toBeFalsy()
+    })
   })
 
   describe(`${label}: webhooks + outbox`, () => {


### PR DESCRIPTION
## What

The public viewer showed "v3" as inert text: no anonymous visitor could reach an artifact's history even when the owner wanted it seen. Meanwhile the anon detail response was quietly serving the complete version list (messages, author names) to anyone holding a link, and hand-typed @vN URLs rendered old drafts. Neither half matched a decision anyone had made. One flag resolves both, default off.

- **The flag:** `artifact.public_history` (nullable int, ALTER-ADD clean, all dialects) with `setPublicHistory` on the store. `PATCH /access` accepts `publicHistory`: disclosure rides the same route and dialog as the access triple.
- **Off (every artifact today):** the anonymous detail response trims versions and sessions to the current version, so the payload no longer leaks what the page won't show. Anon @vN renders not-found and old-version raw 404s. Viewer entry points only: the preview token stays a server-minted capability, and signed-in readers keep workbench history unchanged (auth is the gate, same as comments).
- **On:** the public byline's version becomes a dropdown, every version one line (n, age, author, message truncated), navigating the @vN refs the router already served. An old version shows the workbench's earlier-version strip trimmed to "Back to current": diff and restore are workbench affordances an anon caller can't use.
- **Share dialog:** a "Show version history" switch on the world-link section, applied instantly like the listing toggle.

## Why

This is a current blocker for logged in users to share versioning with anonymous viewers. The primary use case is PMs and agencies who ship design heavy work wanting to show how artifatcts have changed over time without users logging in. And the off-state matters as much as the on-state: creators who never opted in were already exposing version metadata without knowing it.

## Tests (written first)

Store contract (the flag flips without touching access), four API cases (trimmed by default, authed unaffected, PATCH round-trip with the flag surviving unrelated triple changes, raw 404 → 200 across the toggle). Verified live in the browser: dropdown, earlier-version banner, off-state 404. Full gates green; the one full-suite failure is the pre-existing dispatch-sim contention flake (passes isolated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787882980&installation_model_id=428097&pr_number=563&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F563&signature=3254a62039242b818e0e9a95fff5e55b45f72a579fb8c8d84808d863a135fde9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->