### PR TITLE
feat(connections): GitHub App and Slack installs become connection kinds

### DIFF
--- a/apps/api/src/lib/broker.ts
+++ b/apps/api/src/lib/broker.ts
@@ -52,8 +52,13 @@ export const toolsForRun = async (
 }
 
 /** Kinds Derive authenticates and calls itself, rather than handing to the broker. They
- *  differ only in where the bearer comes from (see bearerFor) — the HTTP call is identical. */
-export const isDirect = (kind: ConnectionKind): boolean => kind !== "oauth"
+ *  differ only in where the bearer comes from (see bearerFor) — the HTTP call is identical.
+ *
+ *  Enumerated rather than `!== "oauth"`: this gates whether we spend a credential ourselves
+ *  and whether a revoke reaches a vendor, so a kind added later must fail into the broker
+ *  path (which refuses an unknown ref) instead of silently into ours. */
+const DIRECT_KINDS = new Set<ConnectionKind>(["secret", "github_app", "slack"])
+export const isDirect = (kind: ConnectionKind): boolean => DIRECT_KINDS.has(kind)
 
 /** The tools a direct connection exposes. Named `<toolkit>.<verb>` to match the broker's
  *  convention, so the runner's shim treats every kind of connection identically. */

--- a/apps/api/src/lib/broker.ts
+++ b/apps/api/src/lib/broker.ts
@@ -2,6 +2,7 @@ import type { BrokerToolDef, ToolBroker } from "@derive/broker"
 import { makeBroker } from "@derive/broker"
 import type { ConnectionKind, ConnectionRecord, MetaStore } from "@derive/core"
 import { decryptSecret } from "./crypto"
+import { installationToken } from "./github-app"
 
 /** One tool a hosted run may call, paired with the connected-account ref it executes through.
  *  `kind` and `connectionId` are how the tool proxy routes the call without a second lookup;
@@ -42,18 +43,21 @@ export const toolsForRun = async (
   const out: RunTool[] = []
   for (const cn of usable) {
     const entry = { ref: cn.broker_ref, kind: cn.kind, connectionId: cn.id }
-    // A secret connection has no vendor account, so its tools are ours to declare and
-    // ours to execute (see executeSecretTool); the broker is never asked about it.
-    const defs =
-      cn.kind === "secret" ? secretTools(cn.toolkit) : await broker.toolsFor([cn.broker_ref])
+    // A direct connection has no vendor account, so its tools are ours to declare and
+    // ours to execute (see executeHttpTool); the broker is never asked about it.
+    const defs = isDirect(cn.kind) ? httpTools(cn.toolkit) : await broker.toolsFor([cn.broker_ref])
     for (const def of defs) out.push({ def, ...entry })
   }
   return out
 }
 
-/** The tools a pasted-secret connection exposes. Named `<toolkit>.<verb>` to match the
- *  broker's convention, so the runner's shim treats both kinds of connection identically. */
-export const secretTools = (toolkit: string): BrokerToolDef[] => [
+/** Kinds Derive authenticates and calls itself, rather than handing to the broker. They
+ *  differ only in where the bearer comes from (see bearerFor) — the HTTP call is identical. */
+export const isDirect = (kind: ConnectionKind): boolean => kind !== "oauth"
+
+/** The tools a direct connection exposes. Named `<toolkit>.<verb>` to match the broker's
+ *  convention, so the runner's shim treats every kind of connection identically. */
+export const httpTools = (toolkit: string): BrokerToolDef[] => [
   {
     name: `${toolkit}.get`,
     description: `GET a path on the ${toolkit} API (authenticated server-side).`,
@@ -67,25 +71,66 @@ export const secretTools = (toolkit: string): BrokerToolDef[] => [
 ]
 
 /**
- * Execute one tool call for a pasted-secret connection: resolve the requested path under
- * the connection's base_url, attach the decrypted credential, return status + body. The
- * caller has already verified the tool is on this run's least-privilege list.
+ * The bearer for a direct connection, resolved at CALL time — never at bind time, and never
+ * stored on the RunTool. Each kind answers the same question from a different place:
+ *
+ *   secret      the pasted credential, decrypted here
+ *   github_app  a short-lived installation token, minted per call (cached ~1h) against the
+ *               App install that repo sync already uses — so nothing long-lived exists to leak
+ *   slack       the workspace's bot token from its existing install
+ *
+ * Throws when the underlying install is gone (uninstalled, revoked): the connection outlives
+ * its integration as a row, and this is where that surfaces as a refusal rather than a call
+ * with no credential.
+ */
+export const bearerFor = async (
+  meta: MetaStore,
+  cn: ConnectionRecord,
+  encryptionKey: string,
+): Promise<string> => {
+  if (cn.kind === "secret") {
+    if (!cn.secret_enc) throw new Error("secret connection is missing its secret")
+    return decryptSecret(cn.secret_enc, encryptionKey)
+  }
+  if (cn.kind === "github_app") {
+    const app = await meta.getGithubApp()
+    if (!app) throw new Error("the GitHub App is not configured on this instance")
+    return installationToken(
+      app.app_id,
+      decryptSecret(app.private_key, encryptionKey),
+      cn.broker_ref,
+    )
+  }
+  if (cn.kind === "slack") {
+    const install = await meta.getSlackInstall(cn.org_id)
+    if (!install) throw new Error("Slack is no longer connected to this workspace")
+    if (install.needs_reauth === 1) throw new Error("the Slack install needs to be reconnected")
+    return decryptSecret(install.bot_token, encryptionKey)
+  }
+  throw new Error(`connection kind ${cn.kind} has no direct credential`)
+}
+
+/**
+ * Execute one tool call for a direct connection: resolve the requested path under the
+ * connection's base_url, attach its bearer, return status + body. The caller has already
+ * verified the tool is on this run's least-privilege list.
  *
  * The path is attacker-influenced (it comes from the model, which may have read hostile
  * content), so confinement is the load-bearing part: the credential must only ever be
- * offered to the base it was pasted for. Two things do that work — resolving as `.<path>`
- * makes `..` climb out of the base instead of escaping the parser, and the containment
- * check compares against base.href WITH its trailing slash, so a base of `/admin` cannot
- * be satisfied by `/administrator` (string-prefix matching without the slash accepts it).
+ * offered to the base it was registered for. Two things do that work — resolving as
+ * `.<path>` makes `..` climb out of the base instead of escaping the parser, and the
+ * containment check compares against base.href WITH its trailing slash, so a base of
+ * `/admin` cannot be satisfied by `/administrator` (a bare prefix test accepts it).
  */
-export const executeSecretTool = async (
+export const executeHttpTool = async (
+  meta: MetaStore,
   cn: ConnectionRecord,
   tool: string,
   args: unknown,
   encryptionKey: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<{ status: number; body: unknown }> => {
-  if (!cn.secret_enc || !cn.base_url) throw new Error("secret connection is missing its secret")
+  if (!cn.base_url) throw new Error("connection is missing its base_url")
   const a = (args ?? {}) as { path?: unknown; body?: unknown }
   const path = typeof a.path === "string" ? a.path : ""
   if (!path.startsWith("/")) throw new Error("path must start with /")
@@ -96,7 +141,7 @@ export const executeSecretTool = async (
   const res = await fetchImpl(url.href, {
     method: verb,
     headers: {
-      authorization: `Bearer ${decryptSecret(cn.secret_enc, encryptionKey)}`,
+      authorization: `Bearer ${await bearerFor(meta, cn, encryptionKey)}`,
       ...(verb === "POST" ? { "content-type": "application/json" } : {}),
     },
     body: verb === "POST" ? JSON.stringify(a.body ?? {}) : undefined,

--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -12,7 +12,13 @@ import { z } from "@hono/zod-openapi"
 import { type Context, Hono } from "hono"
 import type { AppContext } from "../context"
 import { parseConnectionIds, parseRefs, parseTrigger } from "../lib/automation"
-import { brokerFor, connectionBindError, executeSecretTool, toolsForRun } from "../lib/broker"
+import {
+  brokerFor,
+  connectionBindError,
+  executeHttpTool,
+  isDirect,
+  toolsForRun,
+} from "../lib/broker"
 import { overBudget } from "../lib/budget"
 import { mintToken, safeEqual, sha256 } from "../lib/crypto"
 import { bail, fail, readJson } from "../lib/http"
@@ -579,13 +585,14 @@ export const automationRoutes = (ctx: AppContext) => {
     const match = allowed.find((t) => t.def.name === b.tool && (!b.ref || t.ref === b.ref))
     if (!match) return fail(c, 403, "tool not allowed for this run")
     try {
-      // A pasted-secret connection has no vendor, so Derive executes it: the credential is
-      // fetched, decrypted and spent here. Either way the runner only ever sent a tool NAME.
-      if (match.kind === "secret") {
-        if (!deps.encryptionKey) return fail(c, 502, "secret connections need an encryption key")
+      // A direct connection has no vendor, so Derive executes it: the credential is resolved
+      // (decrypted, or minted from an install) and spent here. Either way the runner only
+      // ever sent a tool NAME — no credential has ever been near the executor.
+      if (isDirect(match.kind)) {
+        if (!deps.encryptionKey) return fail(c, 502, "direct connections need an encryption key")
         const cn = await meta.getConnection(match.connectionId)
         if (!cn || cn.org_id !== agent.org_id) return fail(c, 404, "not found")
-        const result = await executeSecretTool(cn, b.tool, b.args ?? {}, deps.encryptionKey)
+        const result = await executeHttpTool(meta, cn, b.tool, b.args ?? {}, deps.encryptionKey)
         return c.json({ result })
       }
       const result = await broker.execute({ ref: match.ref, tool: b.tool, args: b.args ?? {} })

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -2,7 +2,7 @@ import { type ConnectionRecord, newId } from "@derive/core"
 import { z } from "@hono/zod-openapi"
 import { Hono } from "hono"
 import type { AppContext } from "../context"
-import { brokerFor } from "../lib/broker"
+import { brokerFor, isDirect } from "../lib/broker"
 import { encryptSecret } from "../lib/crypto"
 import { bail, fail, readJson } from "../lib/http"
 
@@ -109,6 +109,12 @@ export const connectionRoutes = (ctx: AppContext) => {
               .listGithubInstallations(org)
               .then(([i]) => i && { ref: i.installation_id, label: i.account_login })
       if (!install) return fail(c, 400, installMissing[b.kind])
+      // One install, one connection: re-wiring is idempotent rather than piling up rows
+      // that all point at the same place and can't be told apart in a picker.
+      const existing = (await meta.listConnections(org, undefined, "workspace")).find(
+        (x) => x.kind === b.kind && x.broker_ref === install.ref && x.status === "active",
+      )
+      if (existing) return c.json(present(existing))
       const rec = await meta.createConnection({
         id: newId("conn"),
         org_id: org,
@@ -192,9 +198,12 @@ export const connectionRoutes = (ctx: AppContext) => {
       const gate = await requireWorkspace(c, "manage")
       if (gate instanceof Response) return gate
     }
-    // A secret connection has no vendor side to revoke — flipping the status is the
-    // whole revocation (the tool proxy refuses non-active rows).
-    if (cn.kind !== "secret") {
+    // Only a broker-backed connection has a vendor side to revoke. For every direct kind
+    // the status flip IS the revocation (the tool proxy refuses non-active rows) — and
+    // for the install-backed ones it MUST be: broker_ref is an installation id, not a
+    // broker ref, and removing an agent's access must never uninstall the integration
+    // the workspace uses for everything else.
+    if (!isDirect(cn.kind)) {
       const broker = await brokerFor(meta, org, cn.user_id, deps.encryptionKey)
       try {
         await broker.revoke(cn.broker_ref)

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -29,6 +29,13 @@ const present = (cn: ConnectionRecord) => ({
   created_at: cn.created_at,
 })
 
+// What to say when someone wires up an integration Derive isn't connected to yet. The fix
+// is the integration's own setup flow, not this endpoint — so the message points there.
+const installMissing: Record<"github_app" | "slack", string> = {
+  github_app: "connect the GitHub App first (Settings → Sync), then add it as a connection",
+  slack: "connect Slack to this workspace first (Settings → Slack), then add it as a connection",
+}
+
 export const connectionRoutes = (ctx: AppContext) => {
   const { meta, requireUser, requireWorkspace, deps } = ctx
   const app = new Hono()
@@ -61,29 +68,65 @@ export const connectionRoutes = (ctx: AppContext) => {
       z.object({
         // Slug-shaped because it becomes the prefix of the tool names a model reads
         // (`github.get`): whitespace or a dot would make the surface ambiguous.
+        // Ignored for github_app/slack, which name themselves.
         toolkit: z
           .string()
           .min(1)
           .max(64)
-          .regex(/^[a-z0-9][a-z0-9_-]*$/, "toolkit must be a lowercase slug"),
+          .regex(/^[a-z0-9][a-z0-9_-]*$/, "toolkit must be a lowercase slug")
+          .optional(),
         scopes_label: z.string().max(200).optional(),
         // "personal" (default) = the caller's own account. "workspace" = org
         // infrastructure — requires manage, because whoever can add a workspace
         // credential decides what every context bound to it can reach.
         scope: z.enum(["personal", "workspace"]).default("personal"),
-        // "oauth" (default) = broker round trip. "secret" = paste an API key or
-        // bearer token: stored encrypted, spent only server-side, never returned.
-        kind: z.enum(["oauth", "secret"]).default("oauth"),
+        // How it authenticates. "oauth" (default) = broker round trip. "secret" = paste
+        // a key. "github_app"/"slack" = give an install Derive ALREADY holds a tool
+        // surface; they store no credential of their own.
+        kind: z.enum(["oauth", "secret", "github_app", "slack"]).default("oauth"),
         // kind "secret" only:
         secret: z.string().min(8).max(4096).optional(),
         base_url: z.string().url().max(500).optional(),
       }),
     )
     if (b instanceof Response) return bail(b)
-    if (b.scope === "workspace") {
+    // An install-backed connection is org infrastructure by construction — the install
+    // belongs to the workspace, not to whoever happens to wire it up.
+    const scope = b.kind === "github_app" || b.kind === "slack" ? "workspace" : b.scope
+    if (scope === "workspace") {
       const gate = await requireWorkspace(c, "manage")
       if (gate instanceof Response) return gate
     }
+    if (b.kind === "github_app" || b.kind === "slack") {
+      // Point at what the workspace already connected. Nothing is created here and no
+      // OAuth is started — if the install is missing, the integration's own flow is
+      // where you go. A second App install on the same workspace is a real (if rare)
+      // case; the first is used until someone asks to choose.
+      const install =
+        b.kind === "slack"
+          ? await meta.getSlackInstall(org).then((i) => i && { ref: i.team_id, label: i.team_name })
+          : await meta
+              .listGithubInstallations(org)
+              .then(([i]) => i && { ref: i.installation_id, label: i.account_login })
+      if (!install) return fail(c, 400, installMissing[b.kind])
+      const rec = await meta.createConnection({
+        id: newId("conn"),
+        org_id: org,
+        user_id: me.id,
+        scope: "workspace",
+        kind: b.kind,
+        // Deliberately no secret_enc: the credential is minted or read per call from the
+        // install this ref points at, so there is nothing here to leak or to rotate.
+        broker: "none",
+        toolkit: b.kind === "slack" ? "slack" : "github",
+        broker_ref: install.ref,
+        base_url: b.kind === "slack" ? "https://slack.com/api" : "https://api.github.com",
+        scopes_label: b.scopes_label ?? install.label,
+        status: "active",
+      })
+      return c.json(present(rec), 201)
+    }
+    if (!b.toolkit) return fail(c, 400, "toolkit is required")
     if (b.kind === "secret") {
       if (!b.secret || !b.base_url)
         return fail(c, 400, "a secret connection needs `secret` and `base_url`")

--- a/apps/api/test/hosted-tools.test.ts
+++ b/apps/api/test/hosted-tools.test.ts
@@ -193,6 +193,54 @@ describe("hosted tool injection — least privilege (WO4)", () => {
     ).rejects.toThrow(/reconnect/i)
   })
 
+  it("github_app: points at the sync install, stores nothing, and never revokes it", async () => {
+    const h = makeAuthedApp("conn-gh", [owner], "editor", { deps: { encryptionKey: "k" } })
+    const early = await h.app.request(
+      "/v1/connections",
+      jsonAs(as(owner.email), { kind: "github_app" }),
+    )
+    expect(early.status).toBe(400)
+    expect((await early.json()).error).toMatch(/GitHub App/i)
+
+    await h.meta.upsertGithubInstallation({
+      installation_id: "77123",
+      org_id: "default",
+      account_login: "derive-to",
+      created_by: owner.id,
+      created_at: new Date().toISOString(),
+    })
+    const cn = await (
+      await h.app.request("/v1/connections", jsonAs(as(owner.email), { kind: "github_app" }))
+    ).json()
+    expect(cn).toMatchObject({
+      kind: "github_app",
+      scope: "workspace",
+      toolkit: "github",
+      base_url: "https://api.github.com",
+    })
+    const [rec] = await h.meta.getConnectionsByIds([cn.id])
+    // The installation id is the whole reference — no credential is stored, so there is
+    // nothing here to leak, and nothing to rotate when GitHub rotates the token.
+    expect(rec?.secret_enc).toBeNull()
+    expect(rec?.broker_ref).toBe("77123")
+
+    // Wiring it again returns the same row rather than piling up duplicates.
+    const again = await (
+      await h.app.request("/v1/connections", jsonAs(as(owner.email), { kind: "github_app" }))
+    ).json()
+    expect(again.id).toBe(cn.id)
+
+    // Revoking the connection removes the AGENT's access and must leave the install
+    // alone — the workspace still syncs repos through it.
+    const del = await h.app.request(`/v1/connections/${cn.id}`, {
+      method: "DELETE",
+      headers: as(owner.email),
+    })
+    expect(del.status).toBe(204)
+    expect(await h.meta.listGithubInstallations("default")).toHaveLength(1)
+    expect(await toolsForRun(h.meta, new LocalBroker(), "default", [cn.id])).toHaveLength(0)
+  })
+
   it("a departed member's PERSONAL connection stops resolving; a workspace one survives", async () => {
     // A second member connects a personal toolkit and the owner adds a workspace one.
     const gone: TestUser = { id: "u_ht_gone", email: "htgone@derive.test", name: "G" }

--- a/apps/api/test/hosted-tools.test.ts
+++ b/apps/api/test/hosted-tools.test.ts
@@ -1,6 +1,7 @@
 import { LocalBroker } from "@derive/broker"
 import { describe, expect, it } from "vitest"
-import { executeSecretTool, toolsForRun } from "../src/lib/broker"
+import { executeHttpTool, toolsForRun } from "../src/lib/broker"
+import { encryptSecret } from "../src/lib/crypto"
 import { as, jsonAs, makeAuthedApp, type TestUser } from "./helpers"
 
 // WO4 — least-privilege tool injection. A hosted run sees the tools of its BOUND connections
@@ -73,7 +74,14 @@ describe("hosted tool injection — least privilege (WO4)", () => {
       calls.push({ url: String(url), auth: h.get("authorization"), method: init?.method ?? "GET" })
       return new Response(JSON.stringify({ ok: true }), { status: 200 })
     }) as typeof fetch
-    const out = await executeSecretTool(cn, "game.get", { path: "/report?days=30" }, key, fakeFetch)
+    const out = await executeHttpTool(
+      meta,
+      cn,
+      "game.get",
+      { path: "/report?days=30" },
+      key,
+      fakeFetch,
+    )
     expect(out).toEqual({ status: 200, body: { ok: true } })
     expect(calls[0]).toMatchObject({
       url: "https://api.game.test/admin/report?days=30",
@@ -84,15 +92,15 @@ describe("hosted tool injection — least privilege (WO4)", () => {
     // Confinement. The path comes from the model, so it is attacker-influenced: the
     // credential must only ever be offered to the base it was pasted for.
     await expect(
-      executeSecretTool(cn, "game.get", { path: "https://evil.test/x" }, key, fakeFetch),
+      executeHttpTool(meta, cn, "game.get", { path: "https://evil.test/x" }, key, fakeFetch),
     ).rejects.toThrow(/start with/)
     await expect(
-      executeSecretTool(cn, "game.get", { path: "/../secrets" }, key, fakeFetch),
+      executeHttpTool(meta, cn, "game.get", { path: "/../secrets" }, key, fakeFetch),
     ).rejects.toThrow(/escapes/)
     // A sibling path that merely shares the base's prefix: /admin must not be satisfied by
     // /administrator. Comparing hrefs without the trailing slash accepts this one.
     await expect(
-      executeSecretTool(cn, "game.get", { path: "/../administrator/x" }, key, fakeFetch),
+      executeHttpTool(meta, cn, "game.get", { path: "/../administrator/x" }, key, fakeFetch),
     ).rejects.toThrow(/escapes/)
     expect(calls).toHaveLength(1) // none of the hostile paths reached fetch
   })
@@ -137,6 +145,52 @@ describe("hosted tool injection — least privilege (WO4)", () => {
       "vault.get",
       "vault.post",
     ])
+  })
+
+  it("slack: backed by the workspace's existing install, storing no credential of its own", async () => {
+    const h = makeAuthedApp("conn-slack", [owner], "editor", { deps: { encryptionKey: "k" } })
+    // Refused until the workspace has actually connected Slack — this endpoint starts no
+    // OAuth, it only gives an existing install a tool surface.
+    const early = await h.app.request("/v1/connections", jsonAs(as(owner.email), { kind: "slack" }))
+    expect(early.status).toBe(400)
+    expect((await early.json()).error).toMatch(/connect Slack/i)
+
+    await h.meta.setSlackInstall({
+      org_id: "default",
+      team_id: "T123",
+      team_name: "Derive HQ",
+      bot_token: encryptSecret("xoxb-real-bot-token", "k"),
+      bot_user_id: "U1",
+      default_channel: null,
+      needs_reauth: 0,
+      created_at: new Date().toISOString(),
+    })
+    const res = await h.app.request("/v1/connections", jsonAs(as(owner.email), { kind: "slack" }))
+    expect(res.status).toBe(201)
+    const body = await res.text()
+    expect(body).not.toContain("xoxb-real-bot-token")
+    const cn = JSON.parse(body)
+    // Workspace-scoped by construction — the install belongs to the org, not the wirer.
+    expect(cn).toMatchObject({ kind: "slack", scope: "workspace", toolkit: "slack" })
+
+    const [rec] = await h.meta.getConnectionsByIds([cn.id])
+    if (!rec) throw new Error("connection not found")
+    expect(rec.secret_enc).toBeNull() // nothing stored here to leak or rotate
+    const calls: { auth: string | null }[] = []
+    const fakeFetch = (async (_u: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ auth: new Headers(init?.headers).get("authorization") })
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    }) as typeof fetch
+    await executeHttpTool(h.meta, rec, "slack.get", { path: "/conversations.list" }, "k", fakeFetch)
+    // The bearer came from the install, resolved at call time.
+    expect(calls[0]?.auth).toBe("Bearer xoxb-real-bot-token")
+
+    // An install flagged for re-auth refuses rather than calling with a dead token.
+    const install = await h.meta.getSlackInstall("default")
+    if (install) await h.meta.setSlackInstall({ ...install, needs_reauth: 1 })
+    await expect(
+      executeHttpTool(h.meta, rec, "slack.get", { path: "/x" }, "k", fakeFetch),
+    ).rejects.toThrow(/reconnect/i)
   })
 
   it("a departed member's PERSONAL connection stops resolving; a workspace one survives", async () => {

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1650,11 +1650,16 @@ export type ConnectionStatus = "active" | "pending" | "revoked"
  *  "workspace" = org infrastructure (admin-managed), survives any one member leaving. */
 export type ConnectionScope = "personal" | "workspace"
 
-/** How a connection authenticates. "oauth" = a broker-side connected account (broker_ref
- *  points at the vendor). "secret" = a pasted credential (API key / bearer token) stored
- *  encrypted and spent ONLY server-side by the tool proxy — write-only by construction:
- *  no endpoint ever returns it, runs only ever see tool names. */
-export type ConnectionKind = "oauth" | "secret"
+/** How a connection authenticates. Everything but "oauth" is DIRECT: Derive holds the
+ *  credential and makes the call itself, so a run only ever sees tool names.
+ *
+ *  oauth       a broker-side connected account; broker_ref points at the vendor.
+ *  secret      a pasted API key / bearer token, encrypted at rest and write-only after.
+ *  github_app  no stored credential — broker_ref is the installation id of the App repo
+ *              sync already uses, and a short-lived token is minted per call.
+ *  slack       no stored credential — the workspace's existing bot install provides it.
+ */
+export type ConnectionKind = "oauth" | "secret" | "github_app" | "slack"
 
 /** A per-user connected external account (WO3): the owner authorized Derive's broker to act on
  *  their Gmail/Stripe/GitHub/etc. Always bound to ONE person (identity never falls back), and


### PR DESCRIPTION
Phase 3 of the [connections plan](https://derive.to/artifacts/connections-credentials-you-attach-in-the-ui-5159imi6) — **rewritten** from what the plan originally said.

## Why this replaced "build the Composio OAuth callback"

Derive already owns working OAuth for the two integrations every named use case needs:

- the **GitHub App** behind repo sync (`github_installation`, callback live at `/v1/sync/github/callback`), which mints short-lived installation tokens per call
- the **Slack** bot install (`slack_install`, callback live at `/v1/slack/oauth/callback`), with a `needs_reauth` flag already wired to a settings banner

Routing those through a broker would have given a workspace *two credentials per integration* — one for notifications, one for agents — drifting independently. So instead they become two more values on the `kind` discriminator #567 added. Composio drops to the long tail (Stripe, Notion, Gmail); its callback gets built when someone actually needs one of those.

## What's here

- `kind: "github_app"` — `broker_ref` holds the installation id; the bearer is minted per call via the same `installationToken()` sync uses (cached ~1h). **No credential is stored**, so there's nothing to leak or rotate, and the customer's repo selection is already the scope.
- `kind: "slack"` — reads the bot token from the install it points at, and **refuses when that install is flagged for re-auth** rather than calling with a dead token.
- Both are **workspace-scoped by construction** — the install belongs to the org, not to whoever wires it up, so the scope isn't a choice the caller makes.
- Creating one **starts no OAuth**. If the integration isn't connected, the error points at its own setup flow ("connect the GitHub App first (Settings → Sync)").

## The refactor that fell out

The three non-broker kinds differ only in *where the bearer comes from* — the HTTP call is identical. So rather than three parallel executors: `secretTools`/`executeSecretTool` generalized to `httpTools`/`executeHttpTool` behind an `isDirect()` predicate, with `bearerFor()` resolving the credential **at call time**. Confinement, the wire projection, and the least-privilege path are all unchanged and still apply to every kind.

`bearerFor` also throws when the underlying install is gone (uninstalled, revoked) — a connection outlives its integration as a row, and this is where that surfaces as a refusal instead of a call with no credential. That's the "missing access" state P4 will badge.

## Verification

api 1373 green (2 new: the Slack lifecycle end to end — refused before install, no `secret_enc` stored, bearer resolved from the install at call time, refusal after `needs_reauth`), typecheck, biome clean.

## Next

P3.5 (`context.connection_ids` + tools on the ask/session lane) is the missed prerequisite before P4's UI has anything to write to — see the plan doc.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787936716&installation_model_id=428097&pr_number=568&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F568&signature=315eb7a2c38cc22bf192da31c83cab903e69dac52223bff32b3c87a234dcc9b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->