### PR TITLE
fix(mcp): make new parameters reachable from a client that already connected

### DIFF
--- a/apps/api/src/mcp-tools/automate.ts
+++ b/apps/api/src/mcp-tools/automate.ts
@@ -71,13 +71,15 @@ export function registerAutomateTool(tc: ToolContext): void {
         // `create_context` only — wire a new context to a manifest artifact.
         name: z.string().trim().min(1).max(80).optional(),
         manifest_short_id: z.string().max(64).optional(),
-        max_run_ms: z
+        // Coerced for the same reason as publish.wait: added after clients connected, so a
+        // stale schema sends these as strings.
+        max_run_ms: z.coerce
           .number()
           .int()
           .min(30_000)
           .max(6 * 60 * 60_000)
           .optional(),
-        max_concurrency: z.number().int().min(1).max(10).optional(),
+        max_concurrency: z.coerce.number().int().min(1).max(10).optional(),
       },
     },
     async (input) => {

--- a/apps/api/src/mcp-tools/publish.ts
+++ b/apps/api/src/mcp-tools/publish.ts
@@ -235,7 +235,13 @@ export function registerPublishTool(tc: ToolContext): void {
               "Return a screenshot of the published page with this response, instead of a second read.",
             ),
           ),
-        wait: z
+        // COERCED, not bare `z.number()`. A client caches the tool schema at connect, so a
+        // parameter added afterwards has no type for it to coerce against and the value
+        // arrives as a string — the server then rejects it, and the capability is exactly
+        // as unreachable as a new enum value used to be. Found by using it: `render` (a
+        // string) passed through while `wait` did not, so the render could be requested
+        // and never waited for. See scripts/check-mcp-coercion.mjs.
+        wait: z.coerce
           .number()
           .optional()
           .describe(
@@ -789,8 +795,13 @@ export function registerPublishTool(tc: ToolContext): void {
                 { type: "image" as const, data: toBase64(shot.bytes), mimeType: shot.mimeType },
               ],
             }
-          // Not ready inside the wait: fall through to the ordinary response, whose
-          // `render` field already says how to collect it.
+          // Not ready inside the wait. Say WHY rather than falling through to the generic
+          // "queued — call read(...)" pointer, which ignores that a render was asked for
+          // and reads as though nothing was requested.
+          payload.render =
+            wait && wait > 0
+              ? `not ready within ${wait}s — call read(short_id:"${artifact.short_id}", render:"${render}", wait:30) to collect it.`
+              : `requested but not waited for — pass \`wait\` (seconds) to get it inline, or call read(short_id:"${artifact.short_id}", render:"${render}", wait:30).`
         }
         return json(payload)
       } catch (e) {

--- a/apps/api/src/mcp-tools/read.ts
+++ b/apps/api/src/mcp-tools/read.ts
@@ -71,7 +71,7 @@ export function registerReadTool(tc: ToolContext): void {
           .describe(
             'SEE the published page instead of reading its text — what a viewer actually sees, catching visual breakage (a failed font, a broken layout) no text read can. "top": the 1200x630 crop (fastest, what an og:image unfurl shows). "full": the whole page, fullPage screenshot — catches below-the-fold breakage "top" misses. "marked": "full" again with the region map\'s @N refs drawn on it — pairs with a no-heading page\'s region map so what you SEE lines up with what you READ. All three computed a few seconds after each publish; pass alone (optionally with `version`).',
           ),
-        wait: z
+        wait: z.coerce
           .number()
           .int()
           .min(1)
@@ -80,7 +80,7 @@ export function registerReadTool(tc: ToolContext): void {
           .describe(
             "With `render`: when the screenshot isn't computed yet (a publish is seconds old), block up to this many seconds (max 30) for it to land instead of returning the not-ready message. Returns at once when it's already ready or has failed.",
           ),
-        version: z.number().optional().describe("Defaults to the current version."),
+        version: z.coerce.number().optional().describe("Defaults to the current version."),
         workspace: wsArg,
       },
     },

--- a/apps/api/test/publish-render.test.ts
+++ b/apps/api/test/publish-render.test.ts
@@ -86,7 +86,41 @@ describe("publish carries its own render", () => {
     })
     expect(r?.isError).toBeFalsy()
     expect(r?.content).toHaveLength(1)
-    expect(JSON.parse(r?.content?.[0]?.text ?? "{}").published).toBe(true)
+    const body = JSON.parse(r?.content?.[0]?.text ?? "{}")
+    expect(body.published).toBe(true)
+    // And it says WHY there is no picture. The generic "queued — call read(...)" pointer
+    // ignores that a render was asked for, and reads as though nothing was requested.
+    expect(body.render).toContain("not waited for")
+  })
+
+  it("says the wait ELAPSED when one was given and the shot still didn't land", async () => {
+    const { app, token } = await setup("pubrender-elapsed")
+    const r = await callRaw(app, token, "publish", {
+      title: "Elapsed",
+      content: "# Elapsed\n\nbody",
+      render: "top",
+      wait: 1,
+    })
+    const body = JSON.parse(r?.content?.[0]?.text ?? "{}")
+    expect(body.published).toBe(true)
+    expect(body.render).toContain("not ready within 1s")
+  })
+
+  it("accepts a wait sent as a STRING, the way a stale client sends it", async () => {
+    // The bug this change exists for. A client that connected before `wait` existed has no
+    // type to coerce against, so it sends "1". A bare z.number() rejects that — the render
+    // can be requested and never waited for, which is half-reachable and reads as broken.
+    const { app, token } = await setup("pubrender-string-wait")
+    const r = await callRaw(app, token, "publish", {
+      title: "Stringy",
+      content: "# Stringy\n\nbody",
+      render: "top",
+      wait: "1",
+    })
+    expect(r?.isError).toBeFalsy()
+    const body = JSON.parse(r?.content?.[0]?.text ?? "{}")
+    expect(body.published).toBe(true)
+    expect(body.render).toContain("not ready within 1s")
   })
 })
 

--- a/apps/api/test/rename-slug.test.ts
+++ b/apps/api/test/rename-slug.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest"
+import { as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// RENAME RE-DERIVES THE URL NAME.
+//
+// The slug was computed once, at create, from the title — and never again. Renaming a doc
+// updated only `title`, so every link it handed out kept advertising the former name, and
+// there was no lever to fix it: renaming IS the lever. Observed in production on a doc
+// retitled "Agent ergonomics" whose url still read /artifacts/pr-559-what-was-actually-
+// verified-<id>.
+//
+// Changing it is safe because the ref is `<slug>-<short_id>` and parseRef resolves on the
+// TRAILING short id (packages/core/src/publish.ts) — the slug is decorative, so links
+// already shared keep resolving. That property is what this test pins hardest.
+
+const owner: TestUser = { id: "u_slug", email: "slug@derive.test", name: "Owner" }
+
+describe("renaming an artifact re-derives its slug", () => {
+  it("follows the new title, and the OLD url still resolves", async () => {
+    const { app, meta } = makeAuthedApp("rename-slug", [owner], "editor")
+    await app.request("/v1/me", { headers: as(owner.email) })
+
+    const created = await publishAs(
+      app,
+      "# One\n\nbody",
+      { title: "First Working Title" },
+      as(owner.email),
+    )
+    const { short_id } = (await created.json()) as { short_id: string }
+    const before = await meta.getByShortId(short_id)
+    expect(before?.slug).toBe("first-working-title")
+
+    // Rename through the ordinary publish path.
+    await publishAs(
+      app,
+      "# One\n\nbody v2",
+      { title: "A Much Better Name" },
+      as(owner.email),
+      short_id,
+    )
+
+    const after = await meta.getByShortId(short_id)
+    expect(after?.title).toBe("A Much Better Name")
+    expect(after?.slug).toBe("a-much-better-name")
+
+    // THE PROPERTY THAT MAKES THIS SAFE: a link handed out under the old slug still
+    // resolves, because the short id is the last segment and that is what is looked up.
+    const old = await app.request(`/v1/artifacts/${short_id}`, { headers: as(owner.email) })
+    expect(old.status).toBe(200)
+    expect(((await old.json()) as { title: string }).title).toBe("A Much Better Name")
+  })
+
+  it("leaves the slug alone when the republish carries no title", async () => {
+    // A CLI republish without --title must not rename anything, so it must not re-slug
+    // either: the name is the human's, not a side effect of pushing content.
+    const { app, meta } = makeAuthedApp("rename-slug-untouched", [owner], "editor")
+    await app.request("/v1/me", { headers: as(owner.email) })
+    const created = await publishAs(
+      app,
+      "# Two\n\nbody",
+      { title: "Keep This Name" },
+      as(owner.email),
+    )
+    const { short_id } = (await created.json()) as { short_id: string }
+
+    await publishAs(app, "# Two\n\nbody v2", {}, as(owner.email), short_id)
+
+    const after = await meta.getByShortId(short_id)
+    expect(after?.title).toBe("Keep This Name")
+    expect(after?.slug).toBe("keep-this-name")
+  })
+
+  it("falls back to the short id alone when a title has no sluggable characters", async () => {
+    // slugify strips to [a-z0-9-]; a title of only symbols yields "", which must become
+    // null rather than a leading-hyphen ref like "-abc12345".
+    const { app, meta } = makeAuthedApp("rename-slug-empty", [owner], "editor")
+    await app.request("/v1/me", { headers: as(owner.email) })
+    const created = await publishAs(app, "# Three\n\nbody", { title: "Nameable" }, as(owner.email))
+    const { short_id } = (await created.json()) as { short_id: string }
+
+    await publishAs(app, "# Three\n\nbody v2", { title: "＊＊＊" }, as(owner.email), short_id)
+
+    const after = await meta.getByShortId(short_id)
+    expect(after?.slug).toBeNull()
+  })
+})

--- a/apps/api/test/rename-slug.test.ts
+++ b/apps/api/test/rename-slug.test.ts
@@ -50,6 +50,36 @@ describe("renaming an artifact re-derives its slug", () => {
     expect(((await old.json()) as { title: string }).title).toBe("A Much Better Name")
   })
 
+  it("REPAIRS an artifact whose slug already drifted, even with the title unchanged", async () => {
+    // The case that motivated the fix, and the one it originally missed. A doc renamed
+    // before the slug followed along has a title that moved on and a url that did not —
+    // and republishing under its CURRENT title changes nothing, because the title already
+    // matches, so the only lever that could fix it never fires. It self-heals instead.
+    const { app, meta } = makeAuthedApp("rename-slug-drifted", [owner], "editor")
+    await app.request("/v1/me", { headers: as(owner.email) })
+    const created = await publishAs(app, "# Old", { title: "Old Name" }, as(owner.email))
+    const { short_id } = (await created.json()) as { short_id: string }
+    const art = await meta.getByShortId(short_id)
+    if (!art) throw new Error("artifact missing")
+
+    // Exactly the pre-fix state: title advanced, slug left behind.
+    await meta.setArtifactTitle(art.id, "Agent Ergonomics")
+    expect((await meta.getByShortId(short_id))?.slug).toBe("old-name")
+
+    // A republish carrying the CURRENT title — no rename at all.
+    const out = await publishAs(
+      app,
+      "# Old v2",
+      { title: "Agent Ergonomics" },
+      as(owner.email),
+      short_id,
+    )
+    const { url } = (await out.json()) as { url: string }
+    expect((await meta.getByShortId(short_id))?.slug).toBe("agent-ergonomics")
+    expect(url).toContain("agent-ergonomics")
+    expect(url).not.toContain("old-name")
+  })
+
   it("leaves the slug alone when the republish carries no title", async () => {
     // A CLI republish without --title must not rename anything, so it must not re-slug
     // either: the name is the human's, not a side effect of pushing content.

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "format": "biome format --write",
     "check": "biome check",
     "check:fix": "biome check --write",
-    "ci": "biome ci && pnpm lint:tokens && pnpm lint:frontend && pnpm lint:mutations && pnpm lint:reload && pnpm lint:surfaces && pnpm lint:testids && pnpm lint:api && pnpm lint:schema && pnpm lint:hyperdrive && pnpm lint:filesize && pnpm lint:anchor-client && pnpm lint:deadcode && pnpm lint:boundaries && pnpm lint:env && pnpm lint:api-types && pnpm lint:agent-skill && pnpm lint:agent-package-files && pnpm lint:skills",
+    "ci": "biome ci && pnpm lint:tokens && pnpm lint:frontend && pnpm lint:mutations && pnpm lint:reload && pnpm lint:surfaces && pnpm lint:testids && pnpm lint:api && pnpm lint:schema && pnpm lint:hyperdrive && pnpm lint:filesize && pnpm lint:anchor-client && pnpm lint:deadcode && pnpm lint:boundaries && pnpm lint:env && pnpm lint:api-types && pnpm lint:agent-skill && pnpm lint:agent-package-files && pnpm lint:skills && pnpm lint:mcp-coercion",
     "verify": "pnpm run ci && pnpm typecheck && pnpm test:coverage",
     "precommit": "pnpm run ci",
     "prepare": "git config core.hooksPath .githooks || true",
@@ -77,7 +77,8 @@
     "lint:agent-skill": "node scripts/sync-derive-agent-skill.mjs --check",
     "lint:agent-package-files": "node scripts/check-agent-package-files.mjs",
     "lint:skills": "node scripts/gen-skills.mjs --check",
-    "gen:skills": "node scripts/gen-skills.mjs"
+    "gen:skills": "node scripts/gen-skills.mjs",
+    "lint:mcp-coercion": "node scripts/check-mcp-coercion.mjs"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1277,7 +1277,10 @@ export interface ModerationStore {
   takedownArtifact(input: TakedownInput): Promise<void>
   /** Update an artifact's display title (used when a GitHub-synced file is renamed —
    *  the title tracks the repo path; the artifact + its comments are preserved). */
-  setArtifactTitle(id: string, title: string): Promise<void>
+  /** Rename. Pass `slug` to re-derive the URL name with it: the ref is
+   *  `<slug>-<short_id>` and `parseRef` resolves on the trailing short id, so an old
+   *  link keeps working while a renamed doc stops advertising its former title. */
+  setArtifactTitle(id: string, title: string, slug?: string | null): Promise<void>
   /** Set the repo path of a GitHub-synced artifact (its folder/tree "location"). */
   setArtifactSourcePath(id: string, sourcePath: string | null): Promise<void>
   /** Override "updated_at" with an external timestamp (a synced file's last-commit

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -292,8 +292,16 @@ export async function publish(
     // handed out — and nothing could fix it, because renaming is the only lever there is.
     // Safe to change: the ref is `<slug>-<short_id>` and parseRef resolves on the trailing
     // short id, so every link already shared keeps working.
-    if (newTitle && newTitle !== artifact.title)
-      await meta.setArtifactTitle(artifact.id, newTitle, slugify(newTitle) || null)
+    if (newTitle) {
+      const nextSlug = slugify(newTitle) || null
+      // Also when the TITLE is unchanged but the slug no longer matches it. Artifacts
+      // renamed before the slug followed along are stuck otherwise: their title moved on,
+      // their url did not, and republishing under the current title is a no-op because the
+      // title already matches — so the one lever that could fix it never fires. This
+      // self-heals that drift the next time a title is supplied.
+      if (newTitle !== artifact.title || nextSlug !== artifact.slug)
+        await meta.setArtifactTitle(artifact.id, newTitle, nextSlug)
+    }
     return { artifact: (await meta.getByShortId(shortId)) as ArtifactRecord, version }
   }
 

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -287,7 +287,13 @@ export async function publish(
     // Rename on republish only when a title is explicitly supplied (the in-browser
     // editor sends it; a CLI republish without --title leaves the name untouched).
     const newTitle = input.title?.trim()
-    if (newTitle && newTitle !== artifact.title) await meta.setArtifactTitle(artifact.id, newTitle)
+    // Re-derive the URL name with the title. The slug was computed once at create and
+    // never again, so a renamed doc kept advertising its former title in every link it
+    // handed out — and nothing could fix it, because renaming is the only lever there is.
+    // Safe to change: the ref is `<slug>-<short_id>` and parseRef resolves on the trailing
+    // short id, so every link already shared keeps working.
+    if (newTitle && newTitle !== artifact.title)
+      await meta.setArtifactTitle(artifact.id, newTitle, slugify(newTitle) || null)
     return { artifact: (await meta.getByShortId(shortId)) as ArtifactRecord, version }
   }
 

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -3330,8 +3330,11 @@ export class PgMetaStore implements MetaStore {
     if (ids.length === 0) return
     await this.db.update(artifact).set({ removed_at: removedAt }).where(inArray(artifact.id, ids))
   }
-  async setArtifactTitle(id: string, title: string): Promise<void> {
-    await this.db.update(artifact).set({ title }).where(eq(artifact.id, id))
+  async setArtifactTitle(id: string, title: string, slug?: string | null): Promise<void> {
+    await this.db
+      .update(artifact)
+      .set(slug === undefined ? { title } : { title, slug })
+      .where(eq(artifact.id, id))
   }
   async setArtifactSourcePath(id: string, sourcePath: string | null): Promise<void> {
     await this.db.update(artifact).set({ source_path: sourcePath }).where(eq(artifact.id, id))

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -816,8 +816,16 @@ export function makeRepos(db: SqliteDb) {
     if (ids.length === 0) return
     await db.update(artifact).set({ removed_at: removedAt }).where(inArray(artifact.id, ids)).run()
   }
-  const setArtifactTitle = async (id: string, title: string): Promise<void> => {
-    await db.update(artifact).set({ title }).where(eq(artifact.id, id)).run()
+  const setArtifactTitle = async (
+    id: string,
+    title: string,
+    slug?: string | null,
+  ): Promise<void> => {
+    await db
+      .update(artifact)
+      .set(slug === undefined ? { title } : { title, slug })
+      .where(eq(artifact.id, id))
+      .run()
   }
   const setArtifactSourcePath = async (id: string, sourcePath: string | null): Promise<void> => {
     await db.update(artifact).set({ source_path: sourcePath }).where(eq(artifact.id, id)).run()

--- a/scripts/check-mcp-coercion.mjs
+++ b/scripts/check-mcp-coercion.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+// MCP-surface tolerance guardrail: no BARE `z.number()` in a tool's inputSchema.
+//
+// The failure this exists to stop has now shipped three times, in three shapes. A client
+// caches the tool schema when it connects and validates arguments against that copy, so
+// anything added afterwards is a parameter the client has never heard of:
+//
+//   a new ENUM VALUE   -> refused locally, never reaches the server  (fixed: lib/open-choice.ts)
+//   a new STRING param -> passes through untouched                   (fine)
+//   a new NUMBER param -> arrives as a STRING, the server rejects it (this check)
+//
+// The third one is the quiet one. `publish` shipped `render` and `wait` together; `render`
+// worked from an already-connected client and `wait` did not, so a render could be asked
+// for and never waited for — the capability was half-reachable, which reads as broken
+// rather than as missing. `z.coerce.number()` accepts both and validates identically, so
+// there is no reason to prefer the bare form on a surface whose callers hold stale copies
+// of its schema.
+//
+// Enums are deliberately NOT covered: a closed vocabulary (access levels, terminal states)
+// is one a client SHOULD refuse early. Growth-prone discriminators use open-choice instead.
+import { readdirSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+
+const TOOLS_DIR = join(process.cwd(), "apps/api/src/mcp-tools")
+
+// `z.number()` not preceded by `z.coerce`. Matches the bare constructor only, so
+// `z.coerce.number()` and a plain `number` in a comment both pass.
+const BARE_NUMBER = /(?<!coerce\.)\bz\.number\s*\(/g
+
+const offenders = []
+for (const file of readdirSync(TOOLS_DIR).filter((f) => f.endsWith(".ts"))) {
+  const src = readFileSync(join(TOOLS_DIR, file), "utf8")
+  const lines = src.split("\n")
+  lines.forEach((line, i) => {
+    // Skip comment lines: prose about z.number() is not a schema declaration.
+    const t = line.trim()
+    if (t.startsWith("//") || t.startsWith("*") || t.startsWith("/*")) return
+    BARE_NUMBER.lastIndex = 0
+    if (BARE_NUMBER.test(line)) offenders.push(`${file}:${i + 1}  ${t}`)
+  })
+}
+
+if (offenders.length) {
+  console.error(
+    `check-mcp-coercion: ${offenders.length} bare z.number() in the MCP tool surface.\n` +
+      "A client that connected before this parameter existed sends it as a STRING, so the\n" +
+      "server rejects a value the caller passed correctly. Use z.coerce.number() — same\n" +
+      "validation, tolerant of a stale schema.\n",
+  )
+  for (const o of offenders) console.error(`  ${o}`)
+  process.exit(1)
+}
+console.log("check-mcp-coercion: ok — every numeric tool parameter coerces")


### PR DESCRIPTION
Found by using the surface, not by reading it. Five minutes after #564 deployed I ran a full agent loop against production, and `publish(render:"full", wait:28)` **failed**:

```
MCP error -32602: Invalid arguments for tool publish:
  expected "number", received "string"  at ["wait"]
```

My connection predates the deploy, so my cached schema has no `publish.wait` to type the value against and it went out as `"28"`. `read.wait` worked in the same session — it's been in my cached schema as a number all along.

That completes a pattern this repo has now hit three times:

| Added after a client connected | Reachable? |
|---|---|
| New **enum value** (`create_context`) | No — refused locally. Fixed in #559 by `open-choice.ts` |
| New **string param** (`organize.state`) | **Yes** — passed straight through |
| New **number param** (`publish.wait`) | **No** — arrives as a string, server rejects |

The third is the quiet one, because the capability *half*-works: you can ask for the render but not for the wait, so you never get the image. The feature shipped in #564 to end "publish, then guess how long to sleep" was unusable by exactly the clients that were connected when it shipped.

## 1. Numeric tool parameters coerce

`publish.wait`, `automate.max_run_ms`, `automate.max_concurrency`, `read.wait`, `read.version`. Same validation, tolerant of a stale schema — there was never a reason to prefer the bare form on a surface whose callers hold old copies of its own schema.

**`scripts/check-mcp-coercion.mjs` keeps it that way**, in the CI gate. It found one I'd missed (`read.version`) on its first run. Enums are deliberately not covered: a closed vocabulary is one a client *should* refuse early, which is the existing `open-choice` doctrine.

## 2. Renaming re-derives the URL name

The slug was computed once at create and never again, so a renamed doc kept advertising its former title in every link it handed out — with no lever to fix it, since renaming *is* the lever. Live example: a doc retitled **"Agent ergonomics"** whose url still read `/artifacts/pr-559-what-was-actually-verified-…`.

Safe to change: the ref is `<slug>-<short_id>` and `parseRef` resolves on the **trailing short id**, so every link already shared keeps working. The test pins that property hardest, and a republish without a title still doesn't rename or re-slug.

## 3. Publish says why there's no picture

Asking for a render and getting the generic `"queued — call read(...)"` pointer ignored that a render had been asked for. It now distinguishes *"not waited for"* from *"not ready within Ns"*.

## Verification

`pnpm verify` green — **1391 api tests**. Each fix has a test proven to fail without it, including one that sends `wait` as a string the way a stale client does.

## Unrelated: a probable real bug the sim found

The pg lane failed once on `dispatch-sim` — a *different* invariant from the flake fixed in #559 (`run … was requeued under a live holder`), on seed 1035, under full-suite load. It passes 3/3 in isolation, and nothing here touches dispatch.

It looks real rather than cosmetic. `requeueRun` guards on `id + agent_id + status='running'` with **no `started_at` fence**, while `reclaimStaleRuns` has one — with a comment explaining precisely why status alone can't tell "the same stale execution" from "a different execution claimed it since I read it." A late retryable finish from a superseded executor can therefore requeue a run a newer executor just claimed, and a third gets dispatched beside it. Same class as the reclaim race, on the retry path, never fenced.

Out of scope here, but it should not be lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787938214&installation_model_id=428097&pr_number=569&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F569&signature=570e6693c9af7ee94eada60db78f54c33cbd91fd771eeb96f644b2db967ae491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->