### PR TITLE
feat(contexts): a context holds connections, and asks get tools

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2289,6 +2289,13 @@
               "invited"
             ],
             "description": "Who in the workspace may ask: any member, or the invited roster. Never outside the workspace."
+          },
+          "connection_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Connections this context may use — its tools, in every lane it runs in."
           }
         },
         "required": [
@@ -2299,7 +2306,8 @@
           "created_by",
           "created_at",
           "runner_seen_at",
-          "ask_policy"
+          "ask_policy",
+          "connection_ids"
         ]
       },
       "BrandprintConfig": {
@@ -7113,6 +7121,69 @@
                   },
                   "required": [
                     "ask_policy"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/contexts/{id}/connections": {
+      "post": {
+        "tags": [
+          "Contexts"
+        ],
+        "summary": "Set the connections this context may use (whole-list replace).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "connection_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "maxLength": 64
+                    },
+                    "maxItems": 20
+                  }
+                },
+                "required": [
+                  "connection_ids"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The context's connections after the change.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "connection_ids": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "connection_ids"
                   ]
                 }
               }

--- a/apps/api/src/lib/automation.ts
+++ b/apps/api/src/lib/automation.ts
@@ -22,14 +22,3 @@ export const parseRefs = (raw: string | null): Selector[] => {
   } catch {}
   return []
 }
-
-/** An automation's bound connection ids (a JSON string array), parsed defensively → []. */
-export const parseConnectionIds = (raw: string | null): string[] => {
-  if (!raw) return []
-  try {
-    const a = JSON.parse(raw)
-    return Array.isArray(a) ? a.filter((x): x is string => typeof x === "string") : []
-  } catch {
-    return []
-  }
-}

--- a/apps/api/src/lib/broker.ts
+++ b/apps/api/src/lib/broker.ts
@@ -162,6 +162,64 @@ export const executeHttpTool = async (
   return { status: res.status, body }
 }
 
+/** A connection-id list as stored (a JSON array in a text column), parsed defensively: a
+ *  hand-edited or truncated row yields no tools rather than 500ing the lane that read it.
+ *  Both the automation column and the context column carry this shape. */
+export const parseConnectionIds = (raw: string | null): string[] => {
+  if (!raw) return []
+  try {
+    const v = JSON.parse(raw)
+    return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : []
+  } catch {
+    return []
+  }
+}
+
+/** What a proxied tool call resolved to: the result, or the status + message the route
+ *  should return. A shared shape so the two lanes can't drift on what a call means. */
+export type ToolCallOutcome =
+  | { ok: true; result: unknown }
+  | { ok: false; status: 403 | 404 | 502; message: string }
+
+/**
+ * Execute one tool call against a lane's already-resolved least-privilege list. Both proxies
+ * are this function plus their own authorization: match the requested NAME to one of this
+ * work item's tools (a supplied ref must be that tool's, never another's), then execute —
+ * ourselves for a direct connection, through the broker otherwise.
+ *
+ * Shared on purpose. The run lane and the ask lane serve the same contexts, so a difference
+ * in what a tool call may do would be a difference in what a context can reach depending on
+ * how it was triggered — the thing bound connections exist to make impossible.
+ */
+export const callTool = async (opts: {
+  meta: MetaStore
+  broker: ToolBroker | null
+  orgId: string
+  encryptionKey: string | undefined
+  allowed: RunTool[]
+  subject: string
+  tool: string
+  args?: unknown
+  ref?: string
+}): Promise<ToolCallOutcome> => {
+  const { meta, broker, orgId, encryptionKey, allowed, tool, args, ref } = opts
+  const match = allowed.find((t) => t.def.name === tool && (!ref || t.ref === ref))
+  if (!match) return { ok: false, status: 403, message: `tool not allowed for ${opts.subject}` }
+  try {
+    if (isDirect(match.kind)) {
+      if (!encryptionKey)
+        return { ok: false, status: 502, message: "direct connections need an encryption key" }
+      const cn = await meta.getConnection(match.connectionId)
+      if (!cn || cn.org_id !== orgId) return { ok: false, status: 404, message: "not found" }
+      return { ok: true, result: await executeHttpTool(meta, cn, tool, args ?? {}, encryptionKey) }
+    }
+    if (!broker) return { ok: false, status: 502, message: "no broker for this workspace" }
+    return { ok: true, result: await broker.execute({ ref: match.ref, tool, args: args ?? {} }) }
+  } catch (e) {
+    return { ok: false, status: 502, message: e instanceof Error ? e.message : "tool failed" }
+  }
+}
+
 /**
  * The bind-time policy for attaching connections to an automation or context. Returns the
  * 400 message, or null when every id is attachable by this actor:

--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -11,12 +11,12 @@ import {
 import { z } from "@hono/zod-openapi"
 import { type Context, Hono } from "hono"
 import type { AppContext } from "../context"
-import { parseConnectionIds, parseRefs, parseTrigger } from "../lib/automation"
+import { parseRefs, parseTrigger } from "../lib/automation"
 import {
   brokerFor,
+  callTool,
   connectionBindError,
-  executeHttpTool,
-  isDirect,
+  parseConnectionIds,
   toolsForRun,
 } from "../lib/broker"
 import { overBudget } from "../lib/budget"
@@ -582,24 +582,18 @@ export const automationRoutes = (ctx: AppContext) => {
     // be one of them; if a ref is supplied it must match that tool's ref (never cross to another).
     const broker = await brokerFor(meta, agent.org_id, null, deps.encryptionKey)
     const allowed = await toolsForRun(meta, broker, agent.org_id, connIds)
-    const match = allowed.find((t) => t.def.name === b.tool && (!b.ref || t.ref === b.ref))
-    if (!match) return fail(c, 403, "tool not allowed for this run")
-    try {
-      // A direct connection has no vendor, so Derive executes it: the credential is resolved
-      // (decrypted, or minted from an install) and spent here. Either way the runner only
-      // ever sent a tool NAME — no credential has ever been near the executor.
-      if (isDirect(match.kind)) {
-        if (!deps.encryptionKey) return fail(c, 502, "direct connections need an encryption key")
-        const cn = await meta.getConnection(match.connectionId)
-        if (!cn || cn.org_id !== agent.org_id) return fail(c, 404, "not found")
-        const result = await executeHttpTool(meta, cn, b.tool, b.args ?? {}, deps.encryptionKey)
-        return c.json({ result })
-      }
-      const result = await broker.execute({ ref: match.ref, tool: b.tool, args: b.args ?? {} })
-      return c.json({ result })
-    } catch (e) {
-      return fail(c, 502, e instanceof Error ? e.message : "tool failed")
-    }
+    const out = await callTool({
+      meta,
+      broker,
+      orgId: agent.org_id,
+      encryptionKey: deps.encryptionKey,
+      allowed,
+      subject: "this run",
+      tool: b.tool,
+      args: b.args,
+      ref: b.ref,
+    })
+    return out.ok ? c.json({ result: out.result }) : fail(c, out.status, out.message)
   })
 
   // Record an already-finished run straight into the ledger — the host's best-effort write

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -1164,7 +1164,13 @@ export const contextRoutes = (ctx: AppContext) => {
         ...sessionJson(s),
         messages: bySession.get(s.id) ?? [],
       }))
-      return c.json({ sessions: out })
+      // The same tools the hosted claim returns. A BYO runner is not a lesser executor —
+      // it serves the same context and must reach the same things, or a context's hands
+      // would depend on where it happens to run.
+      return c.json({
+        sessions: out,
+        tools: (await contextTools(x)).map((t) => ({ def: t.def, ref: t.ref })),
+      })
     },
   )
 
@@ -1226,12 +1232,14 @@ export const contextRoutes = (ctx: AppContext) => {
   app.post("/v1/agent/sessions/:id/tool", async (c) => {
     const agent = await agentFor(c)
     if (!agent) return fail(c, 401, "agent token required")
+    // A session capability bearer may act ONLY on the session it was minted for. A standing
+    // agent bearer (the BYO polling runner) has no session scope, and is allowed here for
+    // sessions of a context it owns — the ownership check below is what bounds it, exactly
+    // as the run lane bounds a standing bearer by run.agent_id.
     const scope = agentSessionScope(c)
-    // Session tokens only, and only for their own session — the mirror of the run lane's
-    // refusal of a session bearer. A standing agent bearer must not reach another
-    // context's tools by naming its session id.
-    if (!scope || scope !== c.req.param("id")) return fail(c, 403, "not this session's token")
-    const s = await meta.getSession(scope)
+    const sessionId = c.req.param("id") ?? ""
+    if (scope && scope !== sessionId) return fail(c, 403, "not this session's token")
+    const s = await meta.getSession(sessionId)
     const x = s ? await meta.getContext(s.context_id) : null
     if (!s || !x || x.agent_id !== agent.id || x.org_id !== agent.org_id)
       return fail(c, 404, "not found")

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -13,7 +13,15 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { Context } from "hono"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
+import { parseConnectionIds } from "../lib/automation"
 import { resolveActorBrandprint } from "../lib/brandprint"
+import {
+  brokerFor,
+  connectionBindError,
+  executeHttpTool,
+  isDirect,
+  toolsForRun,
+} from "../lib/broker"
 import { sha256 } from "../lib/crypto"
 import { bail, fail, readJson } from "../lib/http"
 import { RUN_LEASE_MS } from "../lib/run-lifecycle"
@@ -41,6 +49,7 @@ export const contextRoutes = (ctx: AppContext) => {
     bus,
     canAskContext,
     currentUser,
+    deps,
     managementPrincipal,
     requireUser,
     requireWorkspace,
@@ -71,6 +80,9 @@ export const contextRoutes = (ctx: AppContext) => {
         .describe(
           "Who in the workspace may ask: any member, or the invited roster. Never outside the workspace.",
         ),
+      connection_ids: z
+        .array(z.string())
+        .describe("Connections this context may use — its tools, in every lane it runs in."),
     })
     .openapi("ContextInfo")
 
@@ -169,6 +181,17 @@ export const contextRoutes = (ctx: AppContext) => {
     })
     .openapi("Session")
 
+  // The context's least-privilege tool list. Identical resolution to the run lane's —
+  // same bound-connections-only rule, same live-membership recheck on personal ones —
+  // so a context reaches exactly the same things whether a schedule fired it or someone
+  // asked it a question. Empty (and broker-free) when nothing is bound.
+  const contextTools = async (x: ContextRecord) => {
+    const ids = parseConnectionIds(x.connection_ids)
+    if (ids.length === 0) return []
+    const broker = await brokerFor(meta, x.org_id, null, deps.encryptionKey)
+    return toolsForRun(meta, broker, x.org_id, ids)
+  }
+
   const contextJson = (x: ContextRecord, manifestShortId: string | null) => ({
     id: x.id,
     name: x.name,
@@ -178,6 +201,7 @@ export const contextRoutes = (ctx: AppContext) => {
     created_at: x.created_at,
     runner_seen_at: x.runner_seen_at,
     ask_policy: x.ask_policy,
+    connection_ids: parseConnectionIds(x.connection_ids),
   })
 
   const messageJson = (m: SessionMessageRecord) => {
@@ -343,12 +367,25 @@ export const contextRoutes = (ctx: AppContext) => {
             .max(6 * 60 * 60_000)
             .optional(),
           max_concurrency: z.number().int().min(1).max(10).optional(),
+          // The context's hands: connections it may use, in every lane it runs in.
+          // Same bind policy as an automation's — workspace connections need manage,
+          // personal ones only their owner.
+          connection_ids: z.array(z.string().max(64)).max(20).optional(),
         }),
       )
       if (b instanceof Response) return bail(b)
       if (b.agent_id) {
         const agents = await meta.listAgents(org)
         if (!agents.some((a) => a.id === b.agent_id)) return bail(fail(c, 404, "no such agent"))
+      }
+      if (b.connection_ids?.length) {
+        const bindErr = await connectionBindError(
+          meta,
+          org,
+          { userId: owner, canManage: await workspaceCan(c, "manage") },
+          b.connection_ids,
+        )
+        if (bindErr) return bail(fail(c, 400, bindErr))
       }
       const manifest = await meta.getByShortId(b.manifest_short_id)
       if (!manifest || manifest.org_id !== org || !(await authorize(c, "share", manifest)))
@@ -388,6 +425,7 @@ export const contextRoutes = (ctx: AppContext) => {
           created_by: owner,
           max_run_ms: b.max_run_ms ?? null,
           ...(b.max_concurrency ? { max_concurrency: b.max_concurrency } : {}),
+          connection_ids: b.connection_ids?.length ? JSON.stringify(b.connection_ids) : null,
         })
         return c.json(
           {
@@ -565,6 +603,56 @@ export const contextRoutes = (ctx: AppContext) => {
       if (b instanceof Response) return bail(b)
       await meta.setContextAskPolicy(x.id, b.ask_policy)
       return c.json({ ask_policy: b.ask_policy })
+    },
+  )
+
+  app.openapi(
+    createRoute({
+      method: "post",
+      path: "/v1/contexts/{id}/connections",
+      tags: ["Contexts"],
+      summary: "Set the connections this context may use (whole-list replace).",
+      request: {
+        params: z.object({ id: z.string() }),
+        body: {
+          content: {
+            "application/json": {
+              schema: z.object({ connection_ids: z.array(z.string().max(64)).max(20) }),
+            },
+          },
+        },
+      },
+      responses: {
+        200: {
+          description: "The context's connections after the change.",
+          content: {
+            "application/json": { schema: z.object({ connection_ids: z.array(z.string()) }) },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const x = await manageableContext(c)
+      if (x instanceof Response) return bail(x)
+      const b = await readJson(c, z.object({ connection_ids: z.array(z.string().max(64)).max(20) }))
+      if (b instanceof Response) return bail(b)
+      // Re-checked on every set, not just at create: a personal connection may have
+      // changed hands or a manager may have lost the seat since the last edit.
+      const bindErr = await connectionBindError(
+        meta,
+        x.org_id,
+        {
+          userId: await managementPrincipal(c),
+          canManage: await workspaceCan(c, "manage"),
+        },
+        b.connection_ids,
+      )
+      if (bindErr) return bail(fail(c, 400, bindErr))
+      await meta.setContextConnections(
+        x.id,
+        b.connection_ids.length ? JSON.stringify(b.connection_ids) : null,
+      )
+      return c.json({ connection_ids: b.connection_ids })
     },
   )
 
@@ -1124,7 +1212,58 @@ export const contextRoutes = (ctx: AppContext) => {
         messages: (await meta.listSessionMessagesFor([claimed.id])).map(messageJson),
       },
       context: { id: x.id, name: x.name, manifest_short_id: manifest?.short_id ?? null },
+      // The context's hands, resolved the same way the run lane resolves them, and
+      // projected the same way: def + ref only. RunTool's routing fields (and the
+      // connection behind them) stay server-side.
+      tools: (await contextTools(x)).map((t) => ({ def: t.def, ref: t.ref })),
     })
+  })
+
+  // Execute one of the session's tools. The mirror of the run lane's proxy, and for the
+  // same reason: the executor holds a session capability token and NO credential, so a
+  // tool call comes back here, gets re-checked against this context's least-privilege
+  // list, and is executed server-side.
+  app.post("/v1/agent/sessions/:id/tool", async (c) => {
+    const agent = await agentFor(c)
+    if (!agent) return fail(c, 401, "agent token required")
+    const scope = agentSessionScope(c)
+    // Session tokens only, and only for their own session — the mirror of the run lane's
+    // refusal of a session bearer. A standing agent bearer must not reach another
+    // context's tools by naming its session id.
+    if (!scope || scope !== c.req.param("id")) return fail(c, 403, "not this session's token")
+    const s = await meta.getSession(scope)
+    const x = s ? await meta.getContext(s.context_id) : null
+    if (!s || !x || x.agent_id !== agent.id || x.org_id !== agent.org_id)
+      return fail(c, 404, "not found")
+    const b = await readJson(
+      c,
+      z.object({
+        tool: z.string().max(200),
+        args: z.unknown().optional(),
+        ref: z.string().max(200).optional(),
+      }),
+    )
+    if (b instanceof Response) return bail(b)
+    const allowed = await contextTools(x)
+    if (allowed.length === 0) return fail(c, 403, "this context has no connections")
+    const match = allowed.find((t) => t.def.name === b.tool && (!b.ref || t.ref === b.ref))
+    if (!match) return fail(c, 403, "tool not allowed for this context")
+    try {
+      if (isDirect(match.kind)) {
+        if (!deps.encryptionKey) return fail(c, 502, "direct connections need an encryption key")
+        const cn = await meta.getConnection(match.connectionId)
+        if (!cn || cn.org_id !== x.org_id) return fail(c, 404, "not found")
+        return c.json({
+          result: await executeHttpTool(meta, cn, b.tool, b.args ?? {}, deps.encryptionKey),
+        })
+      }
+      const broker = await brokerFor(meta, x.org_id, null, deps.encryptionKey)
+      return c.json({
+        result: await broker.execute({ ref: match.ref, tool: b.tool, args: b.args ?? {} }),
+      })
+    } catch (e) {
+      return fail(c, 502, e instanceof Error ? e.message : "tool failed")
+    }
   })
 
   return app

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -13,13 +13,12 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { Context } from "hono"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
-import { parseConnectionIds } from "../lib/automation"
 import { resolveActorBrandprint } from "../lib/brandprint"
 import {
   brokerFor,
+  callTool,
   connectionBindError,
-  executeHttpTool,
-  isDirect,
+  parseConnectionIds,
   toolsForRun,
 } from "../lib/broker"
 import { sha256 } from "../lib/crypto"
@@ -181,15 +180,15 @@ export const contextRoutes = (ctx: AppContext) => {
     })
     .openapi("Session")
 
-  // The context's least-privilege tool list. Identical resolution to the run lane's —
-  // same bound-connections-only rule, same live-membership recheck on personal ones —
-  // so a context reaches exactly the same things whether a schedule fired it or someone
-  // asked it a question. Empty (and broker-free) when nothing is bound.
+  // The context's tools, resolved exactly as the run lane resolves an automation's, so a
+  // context reaches the same things however it was triggered. The broker rides along
+  // because the proxy needs it to execute a non-direct tool; nothing bound means no
+  // broker is built at all.
   const contextTools = async (x: ContextRecord) => {
     const ids = parseConnectionIds(x.connection_ids)
-    if (ids.length === 0) return []
+    if (ids.length === 0) return { broker: null, tools: [] }
     const broker = await brokerFor(meta, x.org_id, null, deps.encryptionKey)
-    return toolsForRun(meta, broker, x.org_id, ids)
+    return { broker, tools: await toolsForRun(meta, broker, x.org_id, ids) }
   }
 
   const contextJson = (x: ContextRecord, manifestShortId: string | null) => ({
@@ -367,9 +366,8 @@ export const contextRoutes = (ctx: AppContext) => {
             .max(6 * 60 * 60_000)
             .optional(),
           max_concurrency: z.number().int().min(1).max(10).optional(),
-          // The context's hands: connections it may use, in every lane it runs in.
-          // Same bind policy as an automation's — workspace connections need manage,
-          // personal ones only their owner.
+          // Same bind policy as an automation's: a workspace connection needs manage,
+          // a personal one only its owner.
           connection_ids: z.array(z.string().max(64)).max(20).optional(),
         }),
       )
@@ -1164,12 +1162,11 @@ export const contextRoutes = (ctx: AppContext) => {
         ...sessionJson(s),
         messages: bySession.get(s.id) ?? [],
       }))
-      // The same tools the hosted claim returns. A BYO runner is not a lesser executor —
-      // it serves the same context and must reach the same things, or a context's hands
-      // would depend on where it happens to run.
+      // The same list the hosted claim returns. A context's reach must not depend on
+      // which kind of executor picked its session up.
       return c.json({
         sessions: out,
-        tools: (await contextTools(x)).map((t) => ({ def: t.def, ref: t.ref })),
+        tools: (await contextTools(x)).tools.map((t) => ({ def: t.def, ref: t.ref })),
       })
     },
   )
@@ -1218,17 +1215,15 @@ export const contextRoutes = (ctx: AppContext) => {
         messages: (await meta.listSessionMessagesFor([claimed.id])).map(messageJson),
       },
       context: { id: x.id, name: x.name, manifest_short_id: manifest?.short_id ?? null },
-      // The context's hands, resolved the same way the run lane resolves them, and
-      // projected the same way: def + ref only. RunTool's routing fields (and the
-      // connection behind them) stay server-side.
-      tools: (await contextTools(x)).map((t) => ({ def: t.def, ref: t.ref })),
+      // Projected def + ref only, as the run claim is: RunTool's routing fields, and the
+      // connection behind them, stay server-side.
+      tools: (await contextTools(x)).tools.map((t) => ({ def: t.def, ref: t.ref })),
     })
   })
 
-  // Execute one of the session's tools. The mirror of the run lane's proxy, and for the
-  // same reason: the executor holds a session capability token and NO credential, so a
-  // tool call comes back here, gets re-checked against this context's least-privilege
-  // list, and is executed server-side.
+  // Execute one of the session's tools — the ask lane's mirror of the run proxy. The
+  // executor holds a capability token and no credential, so the call comes back here to
+  // be re-checked against this context's list and run server-side.
   app.post("/v1/agent/sessions/:id/tool", async (c) => {
     const agent = await agentFor(c)
     if (!agent) return fail(c, 401, "agent token required")
@@ -1252,26 +1247,19 @@ export const contextRoutes = (ctx: AppContext) => {
       }),
     )
     if (b instanceof Response) return bail(b)
-    const allowed = await contextTools(x)
-    if (allowed.length === 0) return fail(c, 403, "this context has no connections")
-    const match = allowed.find((t) => t.def.name === b.tool && (!b.ref || t.ref === b.ref))
-    if (!match) return fail(c, 403, "tool not allowed for this context")
-    try {
-      if (isDirect(match.kind)) {
-        if (!deps.encryptionKey) return fail(c, 502, "direct connections need an encryption key")
-        const cn = await meta.getConnection(match.connectionId)
-        if (!cn || cn.org_id !== x.org_id) return fail(c, 404, "not found")
-        return c.json({
-          result: await executeHttpTool(meta, cn, b.tool, b.args ?? {}, deps.encryptionKey),
-        })
-      }
-      const broker = await brokerFor(meta, x.org_id, null, deps.encryptionKey)
-      return c.json({
-        result: await broker.execute({ ref: match.ref, tool: b.tool, args: b.args ?? {} }),
-      })
-    } catch (e) {
-      return fail(c, 502, e instanceof Error ? e.message : "tool failed")
-    }
+    const { broker, tools } = await contextTools(x)
+    const out = await callTool({
+      meta,
+      broker,
+      orgId: x.org_id,
+      encryptionKey: deps.encryptionKey,
+      allowed: tools,
+      subject: "this context",
+      tool: b.tool,
+      args: b.args,
+      ref: b.ref,
+    })
+    return out.ok ? c.json({ result: out.result }) : fail(c, out.status, out.message)
   })
 
   return app

--- a/apps/api/test/context-connections.test.ts
+++ b/apps/api/test/context-connections.test.ts
@@ -144,6 +144,56 @@ describe("context connections (the ask lane gets hands)", () => {
     }
   })
 
+  it("a BYO polling runner gets the same tools, and may spend them with its standing bearer", async () => {
+    const secretValue = "sk-byo-lane-secret-5678"
+    const conn = await makeConnection({
+      toolkit: "ops",
+      kind: "secret",
+      secret: secretValue,
+      base_url: "https://api.ops.test",
+      scope: "workspace",
+    })
+    const ctx = await makeContext("BYO", [conn.id])
+    const ask = await app.request(
+      `/v1/contexts/${ctx.id}/sessions`,
+      jsonAs(as(owner.email), { body_md: "status?" }),
+    )
+    const { session } = (await ask.json()) as { session: { id: string } }
+
+    // The queue is the BYO runner's door, and it carries the same list the hosted claim does.
+    const queue = await app.request(`/v1/contexts/${ctx.id}/queue`, {
+      headers: bearer(ctx.agent_token),
+    })
+    const q = await queue.json()
+    expect(q.tools.map((t: { def: { name: string } }) => t.def.name).sort()).toEqual([
+      "ops.get",
+      "ops.post",
+    ])
+
+    const realFetch = globalThis.fetch
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ ok: 1 }), { status: 200 })) as typeof fetch
+    try {
+      // A standing agent bearer spends them for its OWN context's session — the same
+      // latitude the run lane gives a standing bearer for its own runs.
+      const mine = await app.request(
+        `/v1/agent/sessions/${session.id}/tool`,
+        jsonAs(bearer(ctx.agent_token), { tool: "ops.get", args: { path: "/health" } }),
+      )
+      expect(mine.status).toBe(200)
+
+      // Another context's agent gets nothing, standing bearer or not.
+      const other = await makeContext("Other")
+      const stolen = await app.request(
+        `/v1/agent/sessions/${session.id}/tool`,
+        jsonAs(bearer(other.agent_token), { tool: "ops.get", args: { path: "/health" } }),
+      )
+      expect(stolen.status).toBe(404)
+    } finally {
+      globalThis.fetch = realFetch
+    }
+  })
+
   it("a session token reaches only its OWN session's tools", async () => {
     const conn = await makeConnection({ toolkit: "stripe" })
     const mine = await makeContext("Mine", [conn.id])

--- a/apps/api/test/context-connections.test.ts
+++ b/apps/api/test/context-connections.test.ts
@@ -88,7 +88,7 @@ describe("context connections (the ask lane gets hands)", () => {
   })
 
   it("a session claim carries the context's tools, and nothing behind them", async () => {
-    const secretValue = "sk-context-lane-secret-1234"
+    const secretValue = "fixture-bearer-context-lane"
     const conn = await makeConnection({
       toolkit: "game",
       kind: "secret",
@@ -145,7 +145,7 @@ describe("context connections (the ask lane gets hands)", () => {
   })
 
   it("a BYO polling runner gets the same tools, and may spend them with its standing bearer", async () => {
-    const secretValue = "sk-byo-lane-secret-5678"
+    const secretValue = "fixture-bearer-byo-lane"
     const conn = await makeConnection({
       toolkit: "ops",
       kind: "secret",

--- a/apps/api/test/context-connections.test.ts
+++ b/apps/api/test/context-connections.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest"
+import { dispatchPass, type Substrate } from "../src/lib/dispatch"
+import { as, bearer, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// P3.5 — a context's connections are its hands in EVERY lane. Before this, connection ids
+// lived only on an automation, so credentials attached to a scheduled job and an ask could
+// not use a connection at all. The load-bearing property is that both lanes resolve the
+// SAME least-privilege list from the same place: a context reaches exactly the same things
+// whether a schedule fired it or a person asked it a question.
+const SECRET = "test-secret-at-least-16-chars"
+
+describe("context connections (the ask lane gets hands)", () => {
+  const owner: TestUser = { id: "u_cc_own", email: "ccown@derive.test", name: "Owner" }
+  const member: TestUser = { id: "u_cc_mem", email: "ccmem@derive.test", name: "Member" }
+  const { app, meta } = makeAuthedApp("context-connections", [owner, member], "editor", {
+    deps: { encryptionKey: SECRET },
+  })
+
+  const makeConnection = async (body: Record<string, unknown>) =>
+    (await (await app.request("/v1/connections", jsonAs(as(owner.email), body))).json()) as {
+      id: string
+    }
+
+  // Boot every queued session through a fake substrate and hand back the capability token
+  // dispatch minted for one of them — the executor's real entry into the ask lane.
+  const tokenFor = async (sessionId: string) => {
+    const started: { runId: string; token: string; server: string }[] = []
+    const substrate: Substrate = {
+      name: "fake",
+      async start(input) {
+        started.push(input)
+      },
+    }
+    await dispatchPass({ meta, substrate, server: "https://derive.test", secret: SECRET })
+    return started.find((s) => s.runId === sessionId)?.token ?? ""
+  }
+
+  const makeContext = async (name: string, connectionIds?: string[]) => {
+    const manifest = await publishAs(app, "# How to answer", { title: name }, as(owner.email))
+    const { short_id } = (await manifest.json()) as { short_id: string }
+    return (await (
+      await app.request(
+        "/v1/contexts",
+        jsonAs(as(owner.email), {
+          name,
+          manifest_short_id: short_id,
+          ...(connectionIds ? { connection_ids: connectionIds } : {}),
+        }),
+      )
+    ).json()) as { id: string; agent_token: string; connection_ids: string[] }
+  }
+
+  it("binds at create, reports them back, and replaces the whole list on set", async () => {
+    const stripe = await makeConnection({ toolkit: "stripe" })
+    const gmail = await makeConnection({ toolkit: "gmail" })
+    const ctx = await makeContext("Support", [stripe.id])
+    expect(ctx.connection_ids).toEqual([stripe.id])
+
+    const set = await app.request(
+      `/v1/contexts/${ctx.id}/connections`,
+      jsonAs(as(owner.email), { connection_ids: [gmail.id] }),
+    )
+    expect(set.status).toBe(200)
+    // Whole-list replace: stripe is gone, not merged.
+    expect((await set.json()).connection_ids).toEqual([gmail.id])
+    const read = await (
+      await app.request(`/v1/contexts/${ctx.id}`, { headers: as(owner.email) })
+    ).json()
+    expect(read.connection_ids).toEqual([gmail.id])
+  })
+
+  it("enforces the same bind policy as an automation: someone else's personal connection is refused", async () => {
+    const theirs = (await (
+      await app.request("/v1/connections", jsonAs(as(member.email), { toolkit: "notion" }))
+    ).json()) as { id: string }
+    const manifest = await publishAs(app, "# m", { title: "Bind" }, as(owner.email))
+    const { short_id } = (await manifest.json()) as { short_id: string }
+    const res = await app.request(
+      "/v1/contexts",
+      jsonAs(as(owner.email), {
+        name: "Nosy",
+        manifest_short_id: short_id,
+        connection_ids: [theirs.id],
+      }),
+    )
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toMatch(/owner/i)
+  })
+
+  it("a session claim carries the context's tools, and nothing behind them", async () => {
+    const secretValue = "sk-context-lane-secret-1234"
+    const conn = await makeConnection({
+      toolkit: "game",
+      kind: "secret",
+      secret: secretValue,
+      base_url: "https://api.game.test",
+      scope: "workspace",
+    })
+    const ctx = await makeContext("Steward", [conn.id])
+    const ask = await app.request(
+      `/v1/contexts/${ctx.id}/sessions`,
+      jsonAs(as(owner.email), { body_md: "Anything odd today?" }),
+    )
+    const { session } = (await ask.json()) as { session: { id: string } }
+
+    // Dispatch mints the session capability token the executor claims with.
+    const token = await tokenFor(session.id)
+    expect(token).toBeTruthy()
+
+    const claim = await app.request("/v1/agent/sessions/claim", jsonAs(bearer(token), {}))
+    const text = await claim.text()
+    // The executor learns the tool NAMES and nothing else — no credential, and none of
+    // RunTool's routing fields, exactly as the run lane's claim behaves.
+    expect(text).not.toContain(secretValue)
+    expect(text).not.toContain("secret_enc")
+    expect(text).not.toContain("connectionId")
+    const claimed = JSON.parse(text)
+    expect(claimed.tools.map((t: { def: { name: string } }) => t.def.name).sort()).toEqual([
+      "game.get",
+      "game.post",
+    ])
+
+    // And the proxy executes for that session, server-side, with the credential attached
+    // here rather than anywhere near the executor.
+    const calls: { url: string; auth: string | null }[] = []
+    const realFetch = globalThis.fetch
+    globalThis.fetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(url), auth: new Headers(init?.headers).get("authorization") })
+      return new Response(JSON.stringify({ flagged: 2 }), { status: 200 })
+    }) as typeof fetch
+    try {
+      const call = await app.request(
+        `/v1/agent/sessions/${session.id}/tool`,
+        jsonAs(bearer(token), { tool: "game.get", args: { path: "/report" } }),
+      )
+      expect(call.status).toBe(200)
+      expect((await call.json()).result).toEqual({ status: 200, body: { flagged: 2 } })
+      expect(calls[0]).toMatchObject({
+        url: "https://api.game.test/report",
+        auth: `Bearer ${secretValue}`,
+      })
+    } finally {
+      globalThis.fetch = realFetch
+    }
+  })
+
+  it("a session token reaches only its OWN session's tools", async () => {
+    const conn = await makeConnection({ toolkit: "stripe" })
+    const mine = await makeContext("Mine", [conn.id])
+    const theirs = await makeContext("Theirs", [conn.id])
+    const ask = async (id: string) =>
+      (
+        (await (
+          await app.request(
+            `/v1/contexts/${id}/sessions`,
+            jsonAs(as(owner.email), { body_md: "?" }),
+          )
+        ).json()) as { session: { id: string } }
+      ).session.id
+    const mineSession = await ask(mine.id)
+    const theirsSession = await ask(theirs.id)
+
+    const mineToken = await tokenFor(mineSession)
+    // Aiming this session's token at the other session's tool endpoint is refused before
+    // any tool is resolved — the mirror of the run lane's kind check.
+    const cross = await app.request(
+      `/v1/agent/sessions/${theirsSession}/tool`,
+      jsonAs(bearer(mineToken), { tool: "stripe.read", args: {} }),
+    )
+    expect(cross.status).toBe(403)
+  })
+
+  it("a context with no connections exposes no tools and refuses the proxy", async () => {
+    const ctx = await makeContext("Bare")
+    expect(ctx.connection_ids).toEqual([])
+    const ask = await app.request(
+      `/v1/contexts/${ctx.id}/sessions`,
+      jsonAs(as(owner.email), { body_md: "hello" }),
+    )
+    const { session } = (await ask.json()) as { session: { id: string } }
+    const token = await tokenFor(session.id)
+    const claim = await (
+      await app.request("/v1/agent/sessions/claim", jsonAs(bearer(token), {}))
+    ).json()
+    expect(claim.tools).toEqual([])
+    const call = await app.request(
+      `/v1/agent/sessions/${session.id}/tool`,
+      jsonAs(bearer(token), { tool: "anything.get", args: {} }),
+    )
+    expect(call.status).toBe(403)
+  })
+})

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -4366,6 +4366,52 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/contexts/{id}/connections": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Set the connections this context may use (whole-list replace). */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        connection_ids: string[];
+                    };
+                };
+            };
+            responses: {
+                /** @description The context's connections after the change. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            connection_ids: string[];
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/contexts/{id}/askers": {
         parameters: {
             query?: never;
@@ -6244,6 +6290,8 @@ export interface components {
              * @enum {string}
              */
             ask_policy: "workspace" | "invited";
+            /** @description Connections this context may use — its tools, in every lane it runs in. */
+            connection_ids: string[];
         };
         BrandprintConfig: {
             /** @description The workspace brand-profile artifact (an HTML page carrying theme tokens), when set; null otherwise. Not in `members` — it is the headline read, not a note. */

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -528,6 +528,7 @@ CREATE TABLE IF NOT EXISTS context (
   ask_policy TEXT NOT NULL DEFAULT 'invited',
   max_run_ms INTEGER,
   max_concurrency INTEGER NOT NULL DEFAULT 1,
+  connection_ids TEXT,
   config TEXT,
   UNIQUE (org_id, name),
   FOREIGN KEY (manifest_artifact_id) REFERENCES artifact(id)

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -849,6 +849,9 @@ export interface ContextStore {
   touchContextSeen(id: string, at: string): Promise<void>
   /** Set who may ask (workspace | invited). Does not touch the roster. */
   setContextAskPolicy(id: string, policy: "workspace" | "invited"): Promise<void>
+  /** Replace the context's bound connections (a JSON array of ids, or null for none).
+   *  Whole-list semantics: the caller has already checked every id is attachable. */
+  setContextConnections(id: string, connectionIds: string | null): Promise<void>
   /** The invited-asker roster for a context (only consulted when ask_policy = invited). */
   listContextAskers(contextId: string): Promise<ContextAskerRecord[]>
   /** Is this user on the context's asker roster? (Membership is checked separately.) */
@@ -1952,6 +1955,9 @@ export interface ContextRecord {
   /** Opaque JSON sidecar, parsed only at the route layer (like session_message.meta)
    *  — the store never reads it. Null until the owner sets one. */
   config: string | null
+  /** Connections this context may use, as a JSON array of ids (same shape as
+   *  automation.connection_ids). Null = no tools. */
+  connection_ids: string | null
 }
 export interface NewContext {
   id: string
@@ -1968,6 +1974,8 @@ export interface NewContext {
   max_concurrency?: number
   /** Opaque JSON sidecar; omitted → null. */
   config?: string | null
+  /** JSON array of connection ids the context may use; omitted → null. */
+  connection_ids?: string | null
 }
 export interface ContextAskerRecord {
   id: string

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -705,6 +705,7 @@ export const context = pgTable(
     // route-parsed config sidecar).
     max_run_ms: integer("max_run_ms"),
     max_concurrency: integer("max_concurrency").notNull().default(1),
+    connection_ids: text("connection_ids"),
     config: text("config"),
   },
   (t) => [uniqueIndex("context_org_name").on(t.org_id, t.name)],

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -2077,6 +2077,9 @@ export class PgMetaStore implements MetaStore {
   async setContextAskPolicy(id: string, policy: "workspace" | "invited"): Promise<void> {
     await this.db.update(context).set({ ask_policy: policy }).where(eq(context.id, id))
   }
+  async setContextConnections(id: string, connectionIds: string | null): Promise<void> {
+    await this.db.update(context).set({ connection_ids: connectionIds }).where(eq(context.id, id))
+  }
   async listContextAskers(contextId: string): Promise<ContextAskerRecord[]> {
     return this.db
       .select()

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -2280,6 +2280,9 @@ export function makeRepos(db: SqliteDb) {
   ): Promise<void> => {
     await db.update(context).set({ ask_policy: policy }).where(eq(context.id, id)).run()
   }
+  const setContextConnections = async (id: string, connectionIds: string | null): Promise<void> => {
+    await db.update(context).set({ connection_ids: connectionIds }).where(eq(context.id, id)).run()
+  }
   const listContextAskers = async (contextId: string): Promise<ContextAskerRecord[]> =>
     db
       .select()
@@ -3694,6 +3697,7 @@ export function makeRepos(db: SqliteDb) {
     deleteContext,
     touchContextSeen,
     setContextAskPolicy,
+    setContextConnections,
     listContextAskers,
     getContextAsker,
     addContextAsker,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -879,6 +879,11 @@ export const context = sqliteTable(
     // How many sessions the runner may work in parallel on this context. Constant
     // default 1 (serial), so it migrates onto populated rows without a backfill.
     max_concurrency: integer("max_concurrency").notNull().default(1),
+    // Connections this context may use, as a JSON array of ids — the SAME shape (and
+    // parser) as automation.connection_ids, because an automation bound to a context is
+    // a scheduled use(context, instruction) and the two must not disagree about what a
+    // context can reach. Null/absent = no tools.
+    connection_ids: text("connection_ids"),
     // Opaque JSON sidecar, parsed only at the route layer (like session_message.meta)
     // — never by the store. Nullable (clean ADD COLUMN; unset until the owner sets one).
     config: text("config"),


### PR DESCRIPTION
Phase 3.5 of the [connections plan](https://derive.to/artifacts/connections-credentials-you-attach-in-the-ui-5159imi6) — **the prerequisite the plan missed**, and the one that makes its first sentence true.

## The gap

"A context is instructions + credentials + a trigger" wasn't buildable:

- **A context couldn't bind a connection.** Connection ids lived on `automation.connection_ids` and nowhere else. Credentials attached to a *scheduled job*, never to the context itself — so P4's "checklist on the context form" had nothing to write to.
- **The ask/session lane resolved no tools at all.** `toolsForRun` was called only from the run lane; `routes/contexts.ts` never mentioned tools and there was no session tool proxy. Asking a context couldn't use a connection — and neither could chat, since chat *is* the session lane.

## What's here

- **`context.connection_ids`** — the same JSON shape and the same `parseConnectionIds` the automation column uses. Deliberately identical: an automation bound to a context is already "a scheduled `use(context, instruction)`", so the two must not disagree about what that context can reach.
- **Set at create, replaced whole via `POST /v1/contexts/:id/connections`**, both gated by `connectionBindError`. Re-checked on every set rather than trusted from create — a personal connection may have changed hands, or a manager may have lost the seat, since the last edit.
- **The session claim carries the context's tools**, projected `def` + `ref` only, exactly as the run claim does.
- **`POST /v1/agent/sessions/:id/tool`** mirrors the run proxy: session tokens only, only for their own session, tool re-checked against this context's least-privilege list, executed server-side with the credential attached here.

Both lanes now resolve the same list through the same `toolsForRun`, so **a context reaches exactly the same things whether a schedule fired it or a person asked it a question** — which is the property that keeps one context from behaving like two products depending on the door.

## Design note for #554

This is also the plumbing tools-in-chat needs. Chat is the session lane; with this, "give the chat agent the context's tools" is already done rather than a second mechanism to design.

## Verification

api 1393 green (5 new: bind at create, whole-list replace, the bind policy refusing someone else's personal connection, the claim carrying tools while leaking neither credential nor routing fields, cross-session token refusal, and the no-connections case), db 253, OpenAPI snapshot + web api-types regenerated, both stores (`repos.ts` **and** `pg.ts`) updated together.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787939309&installation_model_id=428097&pr_number=570&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F570&signature=334e550b862c102e9b2e4813f4491b9e2ca1999e64417fb4a05aad217bd72229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->