### PR TITLE
fix(publish): don't say "queued" about a picture already attached

### DIFF
--- a/apps/api/src/mcp-tools/publish.ts
+++ b/apps/api/src/mcp-tools/publish.ts
@@ -791,7 +791,13 @@ export function registerPublishTool(tc: ToolContext): void {
           if (shot && shot.bytes.length <= IMAGE_INLINE_MAX)
             return {
               content: [
-                { type: "text" as const, text: JSON.stringify(payload, null, 2) },
+                {
+                  type: "text" as const,
+                  // The generic `render` field is a POINTER to go look — wrong the moment
+                  // the picture is already attached to this same response. Unset, it told
+                  // an agent to call read again for something already in hand.
+                  text: JSON.stringify({ ...payload, render: "attached below" }, null, 2),
+                },
                 { type: "image" as const, data: toBase64(shot.bytes), mimeType: shot.mimeType },
               ],
             }

--- a/apps/api/test/publish-render.test.ts
+++ b/apps/api/test/publish-render.test.ts
@@ -1,6 +1,8 @@
+import { join } from "node:path"
+import { FsBlobStore } from "@derive/storage/fs"
 import { describe, expect, it } from "vitest"
 import { collectRender } from "../src/lib/collect-render"
-import { as, jsonAs, makeAuthedApp, type TestUser } from "./helpers"
+import { as, dir, jsonAs, makeAuthedApp, type TestUser } from "./helpers"
 
 // PUBLISH → SEE IT, in one call.
 //
@@ -52,6 +54,41 @@ const setup = async (name: string) => {
 }
 
 describe("publish carries its own render", () => {
+  it("when the shot IS delivered, the payload does not also say 'queued — call read'", async () => {
+    // Caught by actually looking at what came back, not by checking "did an image
+    // arrive": the image landed, and the JSON right next to it still said "queued — call
+    // read(...) in a few seconds", the pointer for when nothing was delivered. An agent
+    // reading the text alone would poll for a picture already in its hand.
+    const { app, meta, token } = await setup("pubrender-attached")
+    const blobs = new FsBlobStore(join(dir, "blobs"))
+    const created = await callRaw(app, token, "publish", {
+      title: "Race",
+      content: "# Race\n\nbody",
+    })
+    const { short_id } = JSON.parse(created?.content?.[0]?.text ?? "{}") as { short_id: string }
+    const art = await meta.getByShortId(short_id)
+    if (!art) throw new Error("artifact missing")
+    // The republish below creates version 2; seed ITS variant while the request's real
+    // 1s poll loop is running, so the render lands mid-wait rather than being ready
+    // before the call even starts.
+    const key = await blobs.put(new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0]))
+    setTimeout(() => {
+      void meta.setVersionPreview(art.id, 2, { preview_status: "ready", preview_key: key })
+    }, 300)
+
+    const r = await callRaw(app, token, "publish", {
+      short_id,
+      content: "# Race v2\n\nbody",
+      render: "top",
+      wait: 5,
+    })
+    const body = JSON.parse(r?.content?.[0]?.text ?? "{}")
+    expect(r?.content).toHaveLength(2)
+    expect(r?.content?.[1]?.type).toBe("image")
+    expect(body.render).toBe("attached below")
+    expect(body.render).not.toContain("queued")
+  })
+
   it("without `render`, the response is unchanged — one text block, no image", async () => {
     const { app, token } = await setup("pubrender-off")
     const r = await callRaw(app, token, "publish", { title: "Plain", content: "# Plain\n\nbody" })


### PR DESCRIPTION
Found by testing the live merge of #569, not by reading the code. I republished the ergonomics doc with `render:"top", wait:10` and the image came back inline — but the JSON right next to it still said:

```
"render": "queued — call read(short_id:\"m10e4azk\", render:\"top\") in a few seconds..."
```

with the picture attached in the same response. `payload.render` is a pointer to go look, and it was only ever overwritten on the *not-delivered* path (added in #564). When the shot **was** attached, the base "queued" text survived untouched right alongside it. An agent reading the JSON text alone, without separately noticing a second content block, would poll for a picture already in its hand — the exact "half-reachable, reads as broken" shape this whole line of work exists to remove.

Now set to `"attached below"` on that path.

## Verification

The regression test races a **real** delayed write against the **real** 1s poll loop — the test harness renders nothing on its own, so the shot has to land while `collectRender`'s wait is actually in flight, not be pre-seeded before the call starts. Proven against the unfixed code: it fails with the stale `"queued — call read(...)"` text as the diff.

`pnpm verify` green — 1393 api tests (+1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787949990&installation_model_id=428097&pr_number=572&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F572&signature=d700689f396b0a5ef600097c04e7da40913b8a13a6a207b3ae4cf9255571005f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->