### PR TITLE
fix(hosted): a claim's work token never expires when its claim does

### DIFF
--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -457,6 +457,13 @@ export const automationRoutes = (ctx: AppContext) => {
         return {
           id: r.id,
           reason: r.reason,
+          // THIS claim's own started_at, so the executor can hand it straight back on
+          // /finish as `claimed_started_at` — its proof that a later call is settling the
+          // claim it just received, not merely a run id its (still valid, unexpired) token
+          // happens to authorize. Without carrying this forward, a run that gets reclaimed
+          // and re-claimed while this executor is mid-flight would let a stale finish call
+          // requeue, or even settle, a run a newer executor now owns.
+          started_at: r.started_at,
           // The wallet key: whose plan this run bills (null = clock/event → registrant
           // today, the workspace pool once it lands). The executor passes it back on
           // the model-credential fetch via ?run=.
@@ -503,34 +510,57 @@ export const automationRoutes = (ctx: AppContext) => {
         status: z.enum(["succeeded", "failed"]),
         cost_micro_usd: z.number().int().nonnegative().nullish(),
         meta: META.nullish(),
+        // The started_at THIS caller's own claim began with — its proof that it is talking
+        // about the claim it actually holds, not merely a run id its (still-valid) token
+        // happens to name. Without it, a run-scoped token authorizes acting on (run, agent,
+        // org) for its whole TTL with no notion of WHICH claim episode minted it: a stale
+        // executor whose claim has already been superseded could otherwise requeue — or
+        // outright settle — a run a newer claim now owns, using a token nobody revoked and
+        // that never expired. Optional so an older, not-yet-upgraded caller keeps working
+        // exactly as before (today's behavior, today's exposure) rather than breaking outright.
+        claimed_started_at: z.string().nullish(),
       }),
     )
     if (b instanceof Response) return bail(b)
     const runId = c.req.param("id")
+    const prior = await meta.getRun(runId)
+    // Caught here, once, for a message that names the problem — the fenced writes below
+    // would ALSO refuse this (same guard, enforced at the row), but as an undifferentiated
+    // 404 that reads like "no such run" rather than "your claim on this run has ended."
+    if (
+      b.claimed_started_at !== undefined &&
+      prior?.status === "running" &&
+      prior.started_at !== b.claimed_started_at
+    )
+      return fail(c, 409, "this run has been claimed again since your token was minted")
     // RETRY, not resurrection. A run that failed for a TRANSIENT reason (the executor says
     // `retryable`: a provider 5xx/429, a timeout, a failed spawn) goes back to the queue with a
     // backoff instead of settling. A deterministic failure — no revision block, a rejected
     // write, an empty instruction — is terminal: retrying it would fail identically while
     // spending the owner's model plan again. The cap is small for the same reason.
     if (b.status === "failed" && b.meta?.retryable === true) {
-      const prior = await meta.getRun(runId)
       const retries = runCounter(parseRunMeta(prior?.meta), "retries")
       if (retries < RUN_MAX_RETRIES) {
         const attempt = retries + 1
-        const requeued = await meta.requeueRun(runId, agent.id, {
-          scheduledFor: new Date(Date.now() + retryDelayMs(attempt)).toISOString(),
-          // MERGE onto the run's existing meta, never replace it — the rule run-meta.ts
-          // states and reclaimStaleRuns already follows. Replacing dropped two things that
-          // live there: the fire-URL `payloads` (so a retried webhook run executed with no
-          // input at all), and the `attempts` counter written by the reclaim sweep (so the
-          // retry cap and the attempt cap stopped composing, allowing far more executions
-          // than either was set to permit).
-          meta: mergeRunMeta(prior?.meta, {
-            ...b.meta,
-            retries: attempt,
-            last_error: b.meta.why ?? null,
-          }),
-        })
+        const requeued = await meta.requeueRun(
+          runId,
+          agent.id,
+          {
+            scheduledFor: new Date(Date.now() + retryDelayMs(attempt)).toISOString(),
+            // MERGE onto the run's existing meta, never replace it — the rule run-meta.ts
+            // states and reclaimStaleRuns already follows. Replacing dropped two things that
+            // live there: the fire-URL `payloads` (so a retried webhook run executed with no
+            // input at all), and the `attempts` counter written by the reclaim sweep (so the
+            // retry cap and the attempt cap stopped composing, allowing far more executions
+            // than either was set to permit).
+            meta: mergeRunMeta(prior?.meta, {
+              ...b.meta,
+              retries: attempt,
+              last_error: b.meta.why ?? null,
+            }),
+          },
+          b.claimed_started_at,
+        )
         if (requeued) return c.json({ id: requeued.id, status: requeued.status, retry: attempt })
       }
     }
@@ -540,13 +570,19 @@ export const automationRoutes = (ctx: AppContext) => {
     // run that failed twice and then succeeded reported zero retries in the timeline built to
     // answer exactly that question — and the `payloads` of a webhook-triggered run, so the
     // ledger no longer showed what it had acted on. Found by the dispatch simulation.
-    const settling = await meta.getRun(runId)
-    const rec = await meta.finishRun(runId, agent.id, {
-      status: b.status,
-      finishedAt: isoNow(),
-      costMicroUsd: b.cost_micro_usd ?? null,
-      meta: b.meta ? mergeRunMeta(settling?.meta, b.meta) : (settling?.meta ?? null),
-    })
+    // `prior`, not a second read: nothing has written to this run since it was read above
+    // unless a requeue attempt already returned above it, and this line is unreached then.
+    const rec = await meta.finishRun(
+      runId,
+      agent.id,
+      {
+        status: b.status,
+        finishedAt: isoNow(),
+        costMicroUsd: b.cost_micro_usd ?? null,
+        meta: b.meta ? mergeRunMeta(prior?.meta, b.meta) : (prior?.meta ?? null),
+      },
+      b.claimed_started_at,
+    )
     return rec ? c.json({ id: rec.id, status: rec.status }) : fail(c, 404, "not found")
   })
 
@@ -566,6 +602,22 @@ export const automationRoutes = (ctx: AppContext) => {
     const run = await meta.getRun(c.req.param("id"))
     if (!run || run.agent_id !== agent.id || run.org_id !== agent.org_id)
       return fail(c, 404, "not found")
+    // A run-scoped token authorizes (run, agent, org) for its whole TTL — it does not expire
+    // when the RUN stops being this token's to act on. Before this, a QUEUED run (never
+    // claimed) or a REQUEUED one (its claim superseded, sitting queued again) would still let
+    // the token invoke tools: real third-party side effects, gated on nothing but the token
+    // not yet expiring. A tool call only ever makes sense while the run is actually running.
+    //
+    // KNOWN GAP, not closed here: this checks status alone, same as /finish did before its
+    // `claimed_started_at` fence (see dispatch-stale-claim.test.ts). A stale claim whose run
+    // has been RE-claimed and is genuinely running again — under someone else's claim — still
+    // passes this check, because the run really is "running", just not running as THIS
+    // caller's claim. Dogfooded live: a superseded token's tool call during another
+    // executor's active claim is refused only by an unrelated guard (no bound sources on the
+    // test automation), not by this one. Extending the started_at fence here needs the same
+    // client-side plumbing /finish got (carrying the claim's started_at on every call, not
+    // just the terminal one) — deferred as its own change rather than folded in unproven.
+    if (run.status !== "running") return fail(c, 409, "this run isn't running")
     const b = await readJson(
       c,
       z.object({

--- a/apps/api/test/dispatch-stale-claim.test.ts
+++ b/apps/api/test/dispatch-stale-claim.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest"
+import { type DispatchDeps, dispatchPass, type Substrate } from "../src/lib/dispatch"
+import { RUN_TOKEN_TTL_MS } from "../src/lib/run-lifecycle"
+import { signWorkToken } from "../src/lib/run-token"
+import { as, bearer, jsonAs, makeAuthedApp, type TestUser } from "./helpers"
+
+// THE BUG dispatch-requeue-race.test.ts's own fix stopped short of.
+//
+// That test proved the RESURRECTION invariant was wrong to assert (a legitimate retry can
+// put a run back in flight). This one is about the invariant right next to it in
+// dispatch-sim -- "no run is ever held by two live executors at once" -- and it proves a
+// genuine way to reach that state, not a false alarm.
+//
+// A per-run work token authorizes exactly one thing: (run.id, agent.id, org.id), signed with
+// an expiry. It carries NOTHING about WHICH claim episode minted it -- no started_at, no
+// attempt counter, no per-claim nonce. So once a run has been re-claimed, the token from the
+// SUPERSEDED claim is still perfectly valid for anything about that run id, for the rest of
+// its TTL. `finish` now accepts `claimed_started_at` -- the started_at the caller's OWN claim
+// began with -- and fences requeueRun/finishRun on it. Optional, so an older client that
+// never sends it gets EXACTLY today's behavior: this file pins both halves of that trade-off,
+// not just the fixed one, so the exposure stays visible rather than looking closed for
+// everyone the moment this merges.
+
+const SECRET = "stale-claim-secret-16-chars-ok"
+const owner: TestUser = { id: "u_stale", email: "stale@derive.test", name: "Stale" }
+
+/** One full retry-then-supersede setup, shared by both tests below: E1 claims, reports a
+ *  transient failure (a legitimate, correctly-fenced requeue), E2 claims the same run with
+ *  its own fresh token. Returns everything needed to then act as either executor. */
+const setupSupersededClaim = async (name: string) => {
+  const { app, meta } = makeAuthedApp(name, [owner], "commenter", {
+    deps: { encryptionKey: SECRET },
+  })
+  const booted: { runId: string; token: string }[] = []
+  const substrate: Substrate = {
+    name: "stale",
+    async start({ runId, token }) {
+      booted.push({ runId, token })
+    },
+  }
+  const now = new Date(Date.now() + 60_000)
+  const deps: DispatchDeps = {
+    meta,
+    substrate,
+    server: "https://stale.test",
+    secret: SECRET,
+    now: () => now,
+  }
+
+  const created = await app.request(
+    "/v1/automations",
+    jsonAs(as(owner.email), { trigger: { kind: "manual" }, instruction: "stale claim" }),
+  )
+  const automationId = ((await created.json()) as { id: string }).id
+  await app.request(`/v1/automations/${automationId}/run`, {
+    method: "POST",
+    headers: as(owner.email),
+  })
+
+  // E1 claims with a real work token, minted the way production mints it.
+  await dispatchPass(deps)
+  const e1 = booted[0] as { runId: string; token: string }
+  const run0 = await meta.getRun(e1.runId)
+  if (!run0) throw new Error("run missing")
+  const startedUnderE1 = now.toISOString()
+  await meta.claimRunById(e1.runId, run0.agent_id, startedUnderE1)
+
+  // E1 hits something transient and reports it, honestly, AS AN UPGRADED CALLER -- this
+  // requeue is legitimate and correctly fenced on its own claim, the retry mechanism
+  // working exactly as designed.
+  await app.request(
+    `/v1/agent/runs/${e1.runId}/finish`,
+    jsonAs(bearer(e1.token), {
+      status: "failed",
+      meta: { retryable: true, why: "transient" },
+      claimed_started_at: startedUnderE1,
+    }),
+  )
+  expect((await meta.getRun(e1.runId))?.status).toBe("queued")
+
+  // E2 is the retry cycle continuing: a later dispatch tick, once the real 60s backoff has
+  // passed, mints its OWN fresh token and claims. `claimRunById` (what a claim ultimately
+  // calls) has no opinion on `scheduled_for` -- that gate is upstream, in
+  // `listDueQueuedRuns` -- so minting directly here is exactly what a real later tick does,
+  // without a test waiting 60 real seconds for retryDelayMs's Date.now()-stamped value.
+  const e2 = {
+    runId: e1.runId,
+    token: await signWorkToken(
+      "run",
+      SECRET,
+      e1.runId,
+      run0.agent_id,
+      run0.org_id,
+      now.getTime() + RUN_TOKEN_TTL_MS,
+    ),
+  }
+  const startedUnderE2 = new Date(now.getTime() + 1000).toISOString()
+  await meta.claimRunById(e2.runId, run0.agent_id, startedUnderE2)
+  expect((await meta.getRun(e1.runId))?.status).toBe("running")
+
+  return { app, meta, e1, e2, startedUnderE1, startedUnderE2 }
+}
+
+describe("a stale-but-unexpired claim acting on a run a NEWER claim holds", () => {
+  it("WITHOUT claimed_started_at: still succeeds -- the documented exposure for an older client", async () => {
+    const { app, meta, e1 } = await setupSupersededClaim("stale-claim-unprotected")
+
+    // E1's token was never revoked and is not expired. Nothing about a request that omits
+    // the new field says "my claim already ended" -- so an older, not-yet-upgraded caller
+    // gets exactly what it got before this fix existed. Documented, not silently patched
+    // over: the shipped CLI is the one caller upgraded to always send the field (below),
+    // but the field being OPTIONAL means this path stays reachable.
+    const stale = await app.request(
+      `/v1/agent/runs/${e1.runId}/finish`,
+      jsonAs(bearer(e1.token), {
+        status: "failed",
+        meta: { retryable: true, why: "old client" },
+      }),
+    )
+    expect(stale.status).toBeLessThan(300)
+    const after = await meta.getRun(e1.runId)
+    expect(after?.status).toBe("queued")
+    expect(after?.started_at).toBeNull()
+  })
+
+  it("WITH claimed_started_at: refused -- E2's claim survives", async () => {
+    const { app, meta, e1, e2, startedUnderE1, startedUnderE2 } =
+      await setupSupersededClaim("stale-claim-protected")
+
+    // Same attack, but E1 is an upgraded caller: it sends the started_at ITS claim began
+    // with. That value is stale the moment E2 claims, so the fence refuses it.
+    const stale = await app.request(
+      `/v1/agent/runs/${e1.runId}/finish`,
+      jsonAs(bearer(e1.token), {
+        status: "failed",
+        meta: { retryable: true, why: "upgraded client" },
+        claimed_started_at: startedUnderE1,
+      }),
+    )
+    expect(stale.status).toBe(409)
+
+    // E2's claim is untouched: still running, still under ITS OWN started_at.
+    const after = await meta.getRun(e1.runId)
+    expect(after?.status).toBe("running")
+    expect(after?.started_at).toBe(startedUnderE2)
+
+    // And E2 itself, the ACTUAL current holder, is unaffected: it can still finish cleanly.
+    const settleByE2 = await app.request(
+      `/v1/agent/runs/${e2.runId}/finish`,
+      jsonAs(bearer(e2.token), { status: "succeeded", claimed_started_at: startedUnderE2 }),
+    )
+    expect(settleByE2.status).toBeLessThan(300)
+    expect((await meta.getRun(e1.runId))?.status).toBe("succeeded")
+  })
+})

--- a/apps/api/test/dispatch-stale-claim.test.ts
+++ b/apps/api/test/dispatch-stale-claim.test.ts
@@ -21,7 +21,7 @@ import { as, bearer, jsonAs, makeAuthedApp, type TestUser } from "./helpers"
 // not just the fixed one, so the exposure stays visible rather than looking closed for
 // everyone the moment this merges.
 
-const SECRET = "stale-claim-secret-16-chars-ok"
+const SECRET = "stale-claim-secret-at-least-16-chars"
 const owner: TestUser = { id: "u_stale", email: "stale@derive.test", name: "Stale" }
 
 /** One full retry-then-supersede setup, shared by both tests below: E1 claims, reports a

--- a/apps/api/test/run-tool-status-gate.test.ts
+++ b/apps/api/test/run-tool-status-gate.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest"
+import { type DispatchDeps, dispatchPass, type Substrate } from "../src/lib/dispatch"
+import { as, bearer, jsonAs, makeAuthedApp, type TestUser } from "./helpers"
+
+// A run-scoped work token authorizes (run, agent, org) for its whole TTL. `/tool` checked
+// only that -- never that the run was actually RUNNING -- so the same still-valid, never-
+// revoked token that a stale claim can misuse against /finish (dispatch-stale-claim.test.ts)
+// could invoke bound-connection tools -- real third-party side effects -- against a run that
+// is queued or REQUEUED (its claim superseded). Unlike /finish, this needed no client
+// change: a genuinely running executor's tool calls always see status='running', so
+// tightening this costs a well-behaved caller nothing.
+//
+// A settled run is already refused, but by a DIFFERENT layer -- context.ts's `agentFor`
+// treats a work token as live only while its run is queued or running, so a token for a
+// finished run fails authentication entirely (global middleware, 403) before this route's
+// own code ever runs. Worth pinning as a fact about the system, not assumed: this file's
+// value is the QUEUED and REQUEUED cases, which that liveness check does NOT cover -- it
+// treats "queued" as live regardless of whether it is a fresh entry or a requeued one.
+
+const SECRET = "tool-gate-secret-16-chars-ok!"
+const owner: TestUser = { id: "u_gate", email: "gate@derive.test", name: "Gate" }
+
+const claimOneRun = async () => {
+  const { app, meta } = makeAuthedApp("run-tool-gate", [owner], "commenter", {
+    deps: { encryptionKey: SECRET },
+  })
+  const booted: { runId: string; token: string }[] = []
+  const substrate: Substrate = {
+    name: "gate",
+    async start({ runId, token }) {
+      booted.push({ runId, token })
+    },
+  }
+  const now = new Date(Date.now() + 60_000)
+  const deps: DispatchDeps = {
+    meta,
+    substrate,
+    server: "https://gate.test",
+    secret: SECRET,
+    now: () => now,
+  }
+  const created = await app.request(
+    "/v1/automations",
+    jsonAs(as(owner.email), { trigger: { kind: "manual" }, instruction: "tool gate" }),
+  )
+  const automationId = ((await created.json()) as { id: string }).id
+  await app.request(`/v1/automations/${automationId}/run`, {
+    method: "POST",
+    headers: as(owner.email),
+  })
+  await dispatchPass(deps)
+  const e = booted[0] as { runId: string; token: string }
+  const run0 = await meta.getRun(e.runId)
+  if (!run0) throw new Error("run missing")
+  return { app, meta, e, run0 }
+}
+
+const callTool = (
+  app: Awaited<ReturnType<typeof claimOneRun>>["app"],
+  token: string,
+  runId: string,
+) =>
+  app.request(`/v1/agent/runs/${runId}/tool`, jsonAs(bearer(token), { tool: "search", args: {} }))
+
+describe("/tool refuses a run-scoped token once the run stops being running", () => {
+  it("refuses before the run is ever claimed (queued)", async () => {
+    const { app, e } = await claimOneRun()
+    // The token exists (dispatch minted it), but nothing has claimed the run yet.
+    const res = await callTool(app, e.token, e.runId)
+    expect(res.status).toBe(409)
+  })
+
+  it("refuses on a REQUEUED run -- the case agentFor's liveness check does not cover", async () => {
+    const { app, meta, e, run0 } = await claimOneRun()
+    const claimedAt = new Date().toISOString()
+    await meta.claimRunById(e.runId, run0.agent_id, claimedAt)
+    // A legitimate retryable failure, correctly fenced (see dispatch-stale-claim.test.ts) --
+    // the run goes back to queued. agentFor's liveness check treats "queued" as live
+    // regardless of how it got there, so the token that just requeued this run is STILL a
+    // valid principal. Only the status gate this test is about stops it from being used to
+    // invoke tools while nobody currently holds the claim.
+    const requeue = await app.request(
+      `/v1/agent/runs/${e.runId}/finish`,
+      jsonAs(bearer(e.token), {
+        status: "failed",
+        meta: { retryable: true, why: "transient" },
+        claimed_started_at: claimedAt,
+      }),
+    )
+    expect(requeue.status).toBeLessThan(300)
+    expect((await meta.getRun(e.runId))?.status).toBe("queued")
+
+    const res = await callTool(app, e.token, e.runId)
+    expect(res.status).toBe(409)
+  })
+
+  it("a SETTLED run's token is already refused, by agentFor's liveness check -- not this route's own code", async () => {
+    const { app, meta, e, run0 } = await claimOneRun()
+    const claimedAt = new Date().toISOString()
+    await meta.claimRunById(e.runId, run0.agent_id, claimedAt)
+    const finish = await app.request(
+      `/v1/agent/runs/${e.runId}/finish`,
+      jsonAs(bearer(e.token), { status: "succeeded", claimed_started_at: claimedAt }),
+    )
+    expect(finish.status).toBeLessThan(300)
+
+    // 403 "forbidden" from the global /v1/* middleware's isPrincipal check, not this
+    // route's 409 -- the token fails to authenticate at all once its run has settled.
+    const res = await callTool(app, e.token, e.runId)
+    expect(res.status).toBe(403)
+    expect(await res.text()).toContain("forbidden")
+  })
+
+  it("still works for the genuine case -- a claimed, running executor", async () => {
+    const { app, meta, e, run0 } = await claimOneRun()
+    await meta.claimRunById(e.runId, run0.agent_id, new Date().toISOString())
+    const res = await callTool(app, e.token, e.runId)
+    // Refused for an UNRELATED reason (no bound connections on this automation) -- proving
+    // this reaches past the status gate rather than being blocked by it.
+    expect(res.status).toBe(403)
+    expect(await res.text()).toContain("no bound sources")
+  })
+})

--- a/packages/cli/src/runner.js
+++ b/packages/cli/src/runner.js
@@ -1271,9 +1271,15 @@ const outcomeFor = (decision) =>
  *  can't stall the drain, exactly like a failed session. */
 export async function serveRun(client, run, manifest, cfg) {
   console.log(`[runner] run ${run.id}: "${run.instruction.slice(0, 80)}"`)
+  // `run.started_at` is what THIS claim actually began with -- proof to the server that
+  // this call is settling the claim it holds, not merely naming a run id its token still
+  // (validly, unexpired) authorizes. Without it, a run that gets reclaimed and re-claimed
+  // while this process is mid-flight would let a stale finish call requeue -- or worse,
+  // SETTLE -- a run a newer executor now owns, using a token nobody revoked. Every call
+  // goes through this one function, so every finish (success, failure, retryable) is fenced.
   const finish = (fields) =>
     client
-      .finishRun(run.id, fields)
+      .finishRun(run.id, { ...fields, claimed_started_at: run.started_at })
       .catch((err) => console.error(`[runner] run ${run.id} finish failed: ${err.message}`))
   // meta rides as an OBJECT: the finish endpoint validates a record and stringifies it
   // server-side, so a pre-stringified blob is a 400 that silently loses the run's outcome.

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1073,11 +1073,20 @@ export interface AgentStore {
   /** Send a RUNNING run back to the queue for a later retry, scoped to the claiming agent.
    *  The transient-failure counterpart to finishRun: instead of a terminal row the run becomes
    *  `queued` again with `scheduled_for` in the future (the backoff) and its attempt count in
-   *  meta. Returns the updated row, or null when the run isn't this agent's or isn't running. */
+   *  meta. Returns the updated row, or null when the run isn't this agent's or isn't running —
+   *  OR when `expectedStartedAt` is given and no longer matches. That fence is what makes this
+   *  safe against a STALE claim: a run-scoped work token authorizes (run, agent, org) for its
+   *  whole TTL with no notion of WHICH claim episode minted it, so once a run is re-claimed,
+   *  the superseded executor's still-valid token could otherwise requeue — or, via finishRun,
+   *  outright SETTLE — a run a newer claim now owns, with no signal to either side. Passing the
+   *  started_at the caller's OWN claim began with closes that: a newer claim changes it, so a
+   *  late request from an old one matches nothing and is refused rather than silently honored.
+   *  Optional for callers with no claim identity to fence on (a human retry, a migration). */
   requeueRun(
     id: string,
     agentId: string,
     fields: { scheduledFor: string; meta?: string | null },
+    expectedStartedAt?: string | null,
   ): Promise<RunRecord | null>
   /** The reclaim sweep: runs stuck `running` since before `cutoffIso` (their substrate died)
    *  go back to `queued` for re-dispatch, with an attempt count kept in meta; a run past
@@ -1093,7 +1102,11 @@ export interface AgentStore {
    *  dispatch scan. Read-only: dispatch does NOT claim; the booted substrate claims. */
   listDueQueuedRuns(now: string, limit?: number): Promise<RunRecord[]>
   /** Terminate a run: set the terminal status, finished_at, and (optional) cost + meta.
-   *  Scoped to (id, agent) so only the claiming agent settles it. */
+   *  Scoped to (id, agent) so only the claiming agent settles it. `expectedStartedAt`, when
+   *  given, fences it to THIS caller's own claim — see requeueRun's doc for why: without it, a
+   *  stale-but-unexpired token from a claim a newer one has already superseded can settle a
+   *  run out from under the executor actually working it, overwriting its eventual real
+   *  outcome (or reporting one before the real work even finished). */
   finishRun(
     id: string,
     agentId: string,
@@ -1103,6 +1116,7 @@ export interface AgentStore {
       costMicroUsd?: number | null
       meta?: string | null
     },
+    expectedStartedAt?: string | null,
   ): Promise<RunRecord | null>
   /** The workspace's recent runs, newest first (the activity view / ledger). Default 50. */
   listRuns(orgId: string, limit?: number): Promise<RunRecord[]>

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -2676,9 +2676,13 @@ export class PgMetaStore implements MetaStore {
     id: string,
     agentId: string,
     fields: { scheduledFor: string; meta?: string | null },
+    expectedStartedAt?: string | null,
   ): Promise<RunRecord | null> {
     // Strict running → queued, only for the claiming agent: the status guard stops a duplicate
-    // or late retry request from resurrecting a run that already settled.
+    // or late retry request from resurrecting a run that already settled. FENCED on
+    // started_at too, when the caller supplies it — see the sqlite twin (repos.ts) for the
+    // full reasoning: status+agent alone can't tell "my own claim" from one that superseded
+    // it, since a run-scoped token carries no notion of which claim episode minted it.
     const rows = await this.db
       .update(run)
       .set({
@@ -2687,7 +2691,18 @@ export class PgMetaStore implements MetaStore {
         scheduled_for: fields.scheduledFor,
         ...(fields.meta === undefined ? {} : { meta: fields.meta }),
       })
-      .where(and(eq(run.id, id), eq(run.agent_id, agentId), eq(run.status, "running")))
+      .where(
+        and(
+          eq(run.id, id),
+          eq(run.agent_id, agentId),
+          eq(run.status, "running"),
+          expectedStartedAt === undefined
+            ? undefined
+            : expectedStartedAt === null
+              ? isNull(run.started_at)
+              : eq(run.started_at, expectedStartedAt),
+        ),
+      )
       .returning()
     return rows[0] ?? null
   }
@@ -2758,10 +2773,14 @@ export class PgMetaStore implements MetaStore {
       costMicroUsd?: number | null
       meta?: string | null
     },
+    expectedStartedAt?: string | null,
   ): Promise<RunRecord | null> {
     // Strict running → terminal transition: only the claiming agent, and only a run that is
     // actually running — a duplicate/retried finish can't clobber a settled run's cost, and a
-    // finish can't terminate a never-claimed queued run.
+    // finish can't terminate a never-claimed queued run. FENCED on started_at too, when
+    // supplied — see requeueRun's twin comment: without it, a stale but unexpired token from
+    // a claim a newer one has superseded can settle a run out from under the executor
+    // actually working it.
     const rows = await this.db
       .update(run)
       .set({
@@ -2770,7 +2789,18 @@ export class PgMetaStore implements MetaStore {
         cost_micro_usd: fields.costMicroUsd ?? null,
         meta: fields.meta ?? null,
       })
-      .where(and(eq(run.id, id), eq(run.agent_id, agentId), eq(run.status, "running")))
+      .where(
+        and(
+          eq(run.id, id),
+          eq(run.agent_id, agentId),
+          eq(run.status, "running"),
+          expectedStartedAt === undefined
+            ? undefined
+            : expectedStartedAt === null
+              ? isNull(run.started_at)
+              : eq(run.started_at, expectedStartedAt),
+        ),
+      )
       .returning()
     return rows[0] ?? null
   }

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -2716,10 +2716,14 @@ export function makeRepos(db: SqliteDb) {
       costMicroUsd?: number | null
       meta?: string | null
     },
+    expectedStartedAt?: string | null,
   ): Promise<RunRecord | null> =>
     // Strict running → terminal transition: only the claiming agent, and only a run that is
     // actually running. Guards a duplicate/retried finish from clobbering a settled run's
-    // status/cost, and stops a finish from terminating a never-claimed queued run.
+    // status/cost, and stops a finish from terminating a never-claimed queued run. FENCED on
+    // started_at too, when supplied — see requeueRun's twin comment: without it, a stale but
+    // unexpired token from a claim a newer one has superseded can settle a run out from under
+    // the executor actually working it.
     (await db
       .update(run)
       .set({
@@ -2728,7 +2732,18 @@ export function makeRepos(db: SqliteDb) {
         cost_micro_usd: fields.costMicroUsd ?? null,
         meta: fields.meta ?? null,
       })
-      .where(and(eq(run.id, id), eq(run.agent_id, agentId), eq(run.status, "running")))
+      .where(
+        and(
+          eq(run.id, id),
+          eq(run.agent_id, agentId),
+          eq(run.status, "running"),
+          expectedStartedAt === undefined
+            ? undefined
+            : expectedStartedAt === null
+              ? isNull(run.started_at)
+              : eq(run.started_at, expectedStartedAt),
+        ),
+      )
       .returning()
       .get()) ?? null
   const listRuns = async (orgId: string, limit = 50): Promise<RunRecord[]> =>
@@ -2771,9 +2786,14 @@ export function makeRepos(db: SqliteDb) {
     id: string,
     agentId: string,
     fields: { scheduledFor: string; meta?: string | null },
+    expectedStartedAt?: string | null,
   ): Promise<RunRecord | null> =>
     // Strict running → queued, only for the claiming agent: the status guard stops a duplicate
-    // or late retry request from resurrecting a run that already settled.
+    // or late retry request from resurrecting a run that already settled. FENCED on
+    // started_at too, when the caller supplies it — the same technique reclaimStaleRuns uses,
+    // here because status+agent alone can't tell "my own claim" from "a claim that superseded
+    // mine": a run-scoped token has no notion of which claim episode minted it, so without
+    // this a stale-but-unexpired token could requeue a run a newer claim already owns.
     (await db
       .update(run)
       .set({
@@ -2782,7 +2802,18 @@ export function makeRepos(db: SqliteDb) {
         scheduled_for: fields.scheduledFor,
         ...(fields.meta === undefined ? {} : { meta: fields.meta }),
       })
-      .where(and(eq(run.id, id), eq(run.agent_id, agentId), eq(run.status, "running")))
+      .where(
+        and(
+          eq(run.id, id),
+          eq(run.agent_id, agentId),
+          eq(run.status, "running"),
+          expectedStartedAt === undefined
+            ? undefined
+            : expectedStartedAt === null
+              ? isNull(run.started_at)
+              : eq(run.started_at, expectedStartedAt),
+        ),
+      )
       .returning()
       .get()) ?? null
   const reclaimStaleRuns = async (


### PR DESCRIPTION
Deterministic proof, then a fix, then a live dogfood that found the fix's own edge — this is the "probable real bug in dispatch, should not be lost" I flagged (and only wrote down) at the end of #569 and #572.

## The bug

A run-scoped work token authorizes exactly `(run.id, agent.id, org.id)` for its whole TTL. Nothing about it says **which claim episode minted it** — no `started_at`, no attempt counter, no per-claim nonce. `/finish`'s only guards are the token's run id and the run's *current* status.

The realistic trigger needs no malice: an executor reports a transient failure (legitimately requeuing the run), a fresh executor claims it again before the first executor's original token expires — entirely plausible, since the TTL exists to outlive one run attempt, not one HTTP round trip — and the first executor can still call `/finish` for that run id. Nothing about the request says "I mean the old claim."

**Proven, not theorized** (`dispatch-stale-claim.test.ts`): real dispatch, real claims, real tokens, against the real routes. A stale claim requeues a run a live executor currently owns, silently, using a token nobody revoked and that never expired.

## The fix

`finish` now accepts `claimed_started_at` — the started_at the caller's own claim began with — and `requeueRun`/`finishRun` fence on it in **both** stores (sqlite + pg), the same technique `reclaimStaleRuns` already uses for its own two-sweep race. A newer claim changes `started_at`, so a stale request's value matches nothing at write time and is refused (409, naming the reason) rather than silently honored.

**Optional**, so an older client that never sends it gets exactly today's behavior. The test file pins **both halves** of that trade-off — the documented exposure for an unupgraded caller, and the protection for an upgraded one — so the gap doesn't quietly look closed for everyone the moment this merges.

The shipped client (`packages/cli/src/runner.js` — what both the node-child and Cloudflare container substrates run as `derive runner run`) is upgraded: every finish call already flows through one local `finish()` helper, so carrying `run.started_at` through it closes the gap for both production substrates in one place.

That required a second, smaller fix caught before it shipped: the claim response's hand-picked field list never included `started_at` at all, so the client would have had nothing to carry forward — a silent no-op, not an error.

## A related gap, closed for free

`/tool` checked only that the token's run id, agent, and org matched — never that the run was actually **running**. A token for a queued (never claimed) or requeued (superseded) run could still invoke bound-connection tools: real third-party side effects, gated on nothing but the token not yet expiring. This needed **no client change** — a genuinely running executor's calls always see `status='running'` — so it's a pure tightening with zero cost to anyone behaving normally.

## Dogfooded live, not just in vitest's harness

Booted a real server, minted real work tokens with `signWorkToken` against its real secret, drove the actual HTTP routes with `curl` through the full sequence: E1 claims → legitimately requeues → E2 claims → E1's stale-but-unexpired token attacks `/finish` (**409**, named) and `/tool` → E2 settles cleanly.

```
### ATTACK 1: E1's stale token tries /finish
{"error":"this run has been claimed again since your token was minted"}
HTTP 409

### E2's claim, still intact?
{ status: 'running', started_at: '2026-07-29T21:34:06.693Z' }

### E2, the ACTUAL current holder, settles cleanly
{"id":"run_dogstale325c54","status":"succeeded"}
HTTP 200
```

That live run found the honest edge of the `/tool` fix: while the run is genuinely running under **E2's** claim, E1's stale token still passes the status check — because the run really is running, just not running as *E1's* claim. My test automation had no bound connections, so *that's* what refused attack 2, not the fix:

```
### ATTACK 2: E1's stale token tries /tool
{"error":"run has no bound sources"}
HTTP 403
```

Documented as a known, deliberate gap in the route's own comment rather than left to look closed. Extending the fence to `/tool` needs the same started_at-carrying plumbing on *every* tool call, not just the terminal one — its own change, not folded in unproven.

## Not audited

The **session lane** (`/v1/agent/sessions/claim`, the ask-a-context path) has its own claim mechanics (`lease_until`, not `started_at`) and was not checked for the same class of issue. Flagging rather than silently skipping.

## Verification

- `pnpm verify` green — **1406 api tests** (+43 across the monorepo, cumulative with the last two PRs).
- `pnpm test:pg` green — 1406, zero pool errors.
- Every claim above has a test or a live curl transcript behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787953125&installation_model_id=428097&pr_number=573&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F573&signature=df9cf24f7a6bb3d2cd3ac8d93d64e094eb4cdeface2a3e1685843b153efa85e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->