### PR TITLE
Hosted execution: make the unattended lane actually run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -231,12 +231,19 @@ DATA_DIR=./data
 
 # Root of an OPENAI-COMPATIBLE model endpoint (Fireworks, OpenRouter, Together, a
 # self-hosted gateway); `/chat/completions` is appended. Setting it points every in-process
-# run on this deploy at that endpoint instead of the Anthropic Messages API.
+# run AND attended chat on this deploy at that endpoint instead of the Anthropic Messages API.
 #
-# It BYPASSES THE PAYER CHAIN on purpose: one ambient key means the operator pays for
-# everyone on the instance, which is right for a single-tenant box and wrong for a
-# multi-tenant host — so derive.to does not set it. Requires DERIVE_MODEL_API_KEY and
-# DERIVE_MODEL_NAME; all three or none.
+# It BYPASSES THE PAYER CHAIN on purpose: this deployment holds the key and spends it for
+# every workspace on it, so there is no chain to walk and no plan for anyone to connect.
+# That is the HOSTED posture — derive.to sets all three — and the workspace is metered
+# against its tier allowance rather than billed to a credential it never supplied. It is
+# equally right for a single-tenant box, where the operator is the only user.
+#
+# (This entry used to say derive.to does not set it. That was wrong, and it was read as
+# intent: the schedule materializer kept walking a payer chain that cannot resolve on a
+# hosted deploy, so scheduled automations silently never fired.)
+#
+# Requires DERIVE_MODEL_API_KEY and DERIVE_MODEL_NAME; all three or none.
 # DERIVE_MODEL_BASE_URL=https://api.fireworks.ai/inference/v1
 
 # Bearer token for DERIVE_MODEL_BASE_URL. Read by the API process only and never forwarded

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -2,11 +2,26 @@ name: PR preview
 
 # A deployed preview per pull request, on its own workers.dev URL.
 #
-# WHY A SEPARATELY-NAMED WORKER rather than Cloudflare's version preview URLs: those never
-# materialize for this Worker. `wrangler versions upload` returns a version with `preview_url:
-# null` and no aliases, on both the pinned 4.80 and current 4.115, with the account subdomain
-# registered and `previews_enabled` set. A named Worker is the mechanism that demonstrably
-# works here, and it is what derive-staging already uses.
+# WHY A SEPARATELY-NAMED WORKER rather than Cloudflare's version preview URLs — which would be
+# strictly better, because a version runs on the SAME script and therefore inherits its secrets
+# with nothing to copy:
+#
+#   Cloudflare does not issue version preview URLs for a Worker with Durable Objects. Uploading
+#   a version of one whose migrations are NOT yet applied fails outright:
+#
+#     [code: 10211] You attempted to upload a version of a Worker that includes a Durable Object
+#     migration, but migrations must be fully applied via a non-versioned deployment.
+#     → /workers/configuration/versions-and-deployments/gradual-deployments/#gradual-deployments-for-durable-objects
+#
+#   and uploading one whose migrations ARE applied (this Worker) succeeds while silently
+#   returning `preview_url: null` with no aliases. Confirmed on wrangler 4.80 and 4.115, with
+#   the account subdomain registered and previews_enabled set on the script. A throwaway Worker
+#   with no bindings, on the same account and token, DOES get a working preview URL — and gets
+#   none the moment a Durable Object is added. derive declares five DO classes, so this is a
+#   permanent constraint, not a configuration mistake.
+#
+# A separately-named Worker is therefore the mechanism, and it is what derive-staging uses. The
+# cost is that secrets are per-script, so CI has to push them (below) instead of inheriting.
 #
 # THE PREVIEW SHARES PRODUCTION'S DATA. Same D1, same Hyperdrive → Neon, same R2. That is
 # deliberate: a preview you cannot sign into, or that shows an empty library, cannot tell you

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -111,10 +111,19 @@ jobs:
              value the production Worker uses, or every signed-in page of the preview 500s.}"
           put() { printf '%s' "$2" | pnpm --filter @derive/api exec wrangler secret put "$1" --config wrangler.preview.toml; }
           put DERIVE_AUTH_SECRET "$AUTH_SECRET"
-          [ -n "$MODEL_KEY" ] && put DERIVE_MODEL_API_KEY "$MODEL_KEY"
-          [ -n "$MODEL_BASE_URL" ] && put DERIVE_MODEL_BASE_URL "$MODEL_BASE_URL"
-          [ -n "$MODEL_NAME" ] && put DERIVE_MODEL_NAME "$MODEL_NAME"
-          true
+          # `if`, not `[ -n "$X" ] && put ...`. Actions runs `bash -e`, so a false test is a
+          # non-zero exit and kills the step — which is exactly how the first run of this
+          # workflow failed, on an unset optional variable rather than on anything real.
+          if [ -n "$MODEL_KEY" ]; then put DERIVE_MODEL_API_KEY "$MODEL_KEY"; fi
+          if [ -n "$MODEL_BASE_URL" ]; then put DERIVE_MODEL_BASE_URL "$MODEL_BASE_URL"; fi
+          if [ -n "$MODEL_NAME" ]; then put DERIVE_MODEL_NAME "$MODEL_NAME"; fi
+          # A preview with no model answers "no model is configured" in chat, which looks like a
+          # regression rather than missing config. Say so once, here.
+          if [ -z "$MODEL_BASE_URL" ] || [ -z "$MODEL_NAME" ] || [ -z "$MODEL_KEY" ]; then
+            echo "::warning::Preview has no model gateway. Set repo variables DERIVE_MODEL_BASE_URL"\
+                 "and DERIVE_MODEL_NAME plus the DERIVE_MODEL_API_KEY secret, or chat and"\
+                 "automations will report that no model is connected."
+          fi
 
       # A preview that boots but 500s on the first authenticated request is worse than none,
       # because the URL looks fine. Prove both an anonymous and a database-backed route.

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,163 @@
+name: PR preview
+
+# A deployed preview per pull request, on its own workers.dev URL.
+#
+# WHY A SEPARATELY-NAMED WORKER rather than Cloudflare's version preview URLs: those never
+# materialize for this Worker. `wrangler versions upload` returns a version with `preview_url:
+# null` and no aliases, on both the pinned 4.80 and current 4.115, with the account subdomain
+# registered and `previews_enabled` set. A named Worker is the mechanism that demonstrably
+# works here, and it is what derive-staging already uses.
+#
+# THE PREVIEW SHARES PRODUCTION'S DATA. Same D1, same Hyperdrive → Neon, same R2. That is
+# deliberate: a preview you cannot sign into, or that shows an empty library, cannot tell you
+# whether a change is right. It is also why this never runs for a fork — see the `if` below.
+# What it does NOT share is anything that would let it act as production: no routes, no cron,
+# no queue consumer (scripts/preview-config.mjs enforces all three and fails the build if any
+# survives).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    # SAME-REPO PULL REQUESTS ONLY. A preview holds production's bindings and secrets, so a fork
+    # PR could read and write real data by editing this workflow. GitHub does not expose secrets
+    # to fork PRs by default; this makes the intent explicit rather than relying on that.
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build web client
+        run: pnpm --filter @derive/api build:web
+
+      # wrangler.toml ships all-zero placeholder ids so the public tree carries no production
+      # identifiers. Same substitution the deploy job makes, for the same reason.
+      - name: Inject binding ids
+        env:
+          D1_ID: ${{ secrets.CLOUDFLARE_D1_DATABASE_ID }}
+          HD_ID: ${{ secrets.CLOUDFLARE_HYPERDRIVE_ID }}
+        run: |
+          : "${D1_ID:?CLOUDFLARE_D1_DATABASE_ID is unset — refusing to build a preview against the placeholder id}"
+          : "${HD_ID:?CLOUDFLARE_HYPERDRIVE_ID is unset — refusing to build a preview against the placeholder id}"
+          sed -i \
+            -e "s/^database_id = \"00000000-0000-0000-0000-000000000000\"$/database_id = \"$D1_ID\"/" \
+            -e "s/^id = \"00000000000000000000000000000000\"$/id = \"$HD_ID\"/" \
+            apps/api/wrangler.toml
+
+      - name: Generate the preview config
+        id: cfg
+        run: |
+          NAME="derive-pr-${{ github.event.pull_request.number }}"
+          URL="https://$NAME.${{ vars.CLOUDFLARE_WORKERS_SUBDOMAIN || 'derive-to' }}.workers.dev"
+          node apps/api/scripts/preview-config.mjs "$NAME" "$URL" > apps/api/wrangler.preview.toml
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy the preview
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm --filter @derive/api exec wrangler deploy --config wrangler.preview.toml
+
+      # Secrets are per-Worker, so a freshly-created preview has none and every authenticated
+      # route 500s without them.
+      #
+      # DERIVE_AUTH_SECRET MUST MATCH PRODUCTION'S. Better Auth encrypts its JWKS private key
+      # with this secret and stores it in the shared database; a preview with a different one
+      # signs in fine and then throws "Failed to decrypt private key" on the first getSession.
+      # Reproduced locally (two instances, one database, two secrets) before writing this.
+      - name: Push preview secrets
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          AUTH_SECRET: ${{ secrets.DERIVE_AUTH_SECRET }}
+          MODEL_KEY: ${{ secrets.DERIVE_MODEL_API_KEY }}
+          MODEL_BASE_URL: ${{ vars.DERIVE_MODEL_BASE_URL }}
+          MODEL_NAME: ${{ vars.DERIVE_MODEL_NAME }}
+        run: |
+          : "${AUTH_SECRET:?DERIVE_AUTH_SECRET is unset. Add it as a repo secret with the SAME
+             value the production Worker uses, or every signed-in page of the preview 500s.}"
+          put() { printf '%s' "$2" | pnpm --filter @derive/api exec wrangler secret put "$1" --config wrangler.preview.toml; }
+          put DERIVE_AUTH_SECRET "$AUTH_SECRET"
+          [ -n "$MODEL_KEY" ] && put DERIVE_MODEL_API_KEY "$MODEL_KEY"
+          [ -n "$MODEL_BASE_URL" ] && put DERIVE_MODEL_BASE_URL "$MODEL_BASE_URL"
+          [ -n "$MODEL_NAME" ] && put DERIVE_MODEL_NAME "$MODEL_NAME"
+          true
+
+      # A preview that boots but 500s on the first authenticated request is worse than none,
+      # because the URL looks fine. Prove both an anonymous and a database-backed route.
+      - name: Smoke the preview
+        run: |
+          URL="${{ steps.cfg.outputs.url }}"
+          for i in $(seq 1 10); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "$URL/healthz" || true)
+            [ "$code" = "200" ] && break
+            sleep 6
+          done
+          [ "$code" = "200" ] || { echo "preview never served /healthz (last: $code)"; exit 1; }
+          ready=$(curl -s -o /dev/null -w '%{http_code}' "$URL/readyz" || true)
+          [ "$ready" = "200" ] || { echo "preview reached /healthz but /readyz returned $ready — bindings are wrong"; exit 1; }
+          echo "preview healthy: $URL"
+
+      - name: Comment the preview URL
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.cfg.outputs.url }}
+          PREVIEW_NAME: ${{ steps.cfg.outputs.name }}
+        with:
+          script: |
+            const url = process.env.PREVIEW_URL
+            const marker = '<!-- derive-pr-preview -->'
+            const body = `${marker}\n### Preview\n\n${url}\n\n` +
+              `Deployed from \`${context.sha.slice(0, 7)}\` as \`${process.env.PREVIEW_NAME}\`.\n\n` +
+              `It shares **production's database** — sign in with your real account, and treat ` +
+              `anything you change here as changed for real. It has no routes, no cron and no ` +
+              `queue consumer, so it cannot serve derive.to or run scheduled work.`
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo, issue_number: context.issue.number,
+            })
+            const existing = comments.find((c) => c.body?.startsWith(marker))
+            if (existing) {
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body })
+            } else {
+              await github.rest.issues.createComment({ ...context.repo, issue_number: context.issue.number, body })
+            }
+
+  # A preview per PR is only affordable if it goes away again.
+  teardown:
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Delete the preview Worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          NAME="derive-pr-${{ github.event.pull_request.number }}"
+          pnpm --filter @derive/api exec wrangler delete --name "$NAME" --force || \
+            echo "no preview Worker named $NAME (already gone)"

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ apps/api/wrangler.staging.toml
 
 # Generated preview/staging Worker configs: carry REAL binding ids, never committed.
 apps/api/wrangler.preview.toml
+apps/api/wrangler.perf.toml

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ coverage/
 
 # Generated staging Worker config: carries REAL binding ids, never committed.
 apps/api/wrangler.staging.toml
+
+# Generated preview/staging Worker configs: carry REAL binding ids, never committed.
+apps/api/wrangler.preview.toml

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ apps/api/.localdata/
 # Coverage output. Untracked, but a FAILED `pnpm verify` leaves these behind, and the
 # next run's lint step then scans them and fails on generated files.
 coverage/
+
+# Generated staging Worker config: carries REAL binding ids, never committed.
+apps/api/wrangler.staging.toml

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -324,8 +324,19 @@ wrangler secret put DERIVE_MODEL_NAME       # the provider's own model id
 ```
 
 This key pays for every attended turn on the deployment, so it is an operator decision
-rather than a per-user one. Unattended automation runs are unaffected — they still resolve
-their own credential through the payer chain.
+rather than a per-user one.
+
+**It pays for unattended runs too**, whenever they execute in-process (`DERIVE_LOOP_RUNS=1`):
+the loop substrate takes the same gateway, and the schedule materializer then skips the payer
+chain, because on a deployment that holds the key there is nothing for a chain to resolve and
+no plan for anyone to connect. That is the hosted posture; the workspace is metered against
+its tier allowance instead.
+
+Only a deployment WITHOUT these three leaves unattended runs to resolve their own credential
+per run through the payer chain. (An earlier version of this section said unattended runs were
+unaffected. They are not, and believing it cost a release: the materializer kept demanding a
+payer a hosted workspace never has, so scheduled automations silently never fired while
+`Run now` worked.)
 
 > `DERIVE_MODEL_NAME` is your **gateway's** model id and belongs only with the two vars
 > above. Unattended in-process runs (`DERIVE_LOOP_RUNS=1`) talk to the Anthropic Messages

--- a/apps/api/scripts/preview-config.mjs
+++ b/apps/api/scripts/preview-config.mjs
@@ -76,7 +76,12 @@ const must = (cond, msg) => {
 must(!out.includes("[[routes]]"), "routes survived — the preview would serve production hostnames")
 must(!out.includes("[triggers]"), "cron survived — a second scheduler on production's rows")
 must(!out.includes("queues.consumers"), "queue consumer survived — it would steal run messages")
-must(new RegExp(`^name = "${name}"$`, "m").test(out), "worker name was not replaced")
+// A plain line match, NOT `new RegExp(...${name}...)`. The name arrives on argv, so building a
+// pattern out of it is regex injection — a name containing regex metacharacters would change
+// what this guard tests, and the guard is the thing standing between a preview and production's
+// hostnames. CodeQL flags it (js/regex-injection) and is right to: "CI only ever passes
+// derive-pr-<number>" is an argument about today's caller, not about the code.
+must(out.split("\n").includes(`name = "${name}"`), "worker name was not replaced")
 must(!/^name = "derive"$/m.test(out), "the production worker name is still present")
 
 process.stdout.write(out)

--- a/apps/api/scripts/preview-config.mjs
+++ b/apps/api/scripts/preview-config.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// Derive a PREVIEW Worker config from wrangler.toml.
+//
+// A preview is the same Worker under a different name, on its own workers.dev URL, sharing
+// production's data. That last part is the point — a preview you cannot sign into, or that
+// shows an empty database, tells you nothing about a change — and it is also the reason this
+// script is careful about what it strips.
+//
+// WHAT IT REMOVES, and why each one would otherwise reach production:
+//   [[routes]]            derive.to / app.derive.to / derive.page → the preview would SERVE the
+//                         real hostnames, which is a takeover, not a preview.
+//   [triggers]            the every-minute cron → a second scheduler against the same rows,
+//                         materializing and dispatching real automations.
+//   [[queues.consumers]]  → the preview would steal run-dispatch messages from production.
+//   [[containers]]        not needed on the loop substrate, and skips a multi-minute image build.
+//
+// WHAT IT KEEPS: the D1 / Hyperdrive / R2 bindings, so the preview reads and writes the same
+// data production does. Weigh that before opening previews to untrusted PRs — see the fork guard
+// in .github/workflows/pr-preview.yml.
+//
+//   node scripts/preview-config.mjs <name> <base-url> > wrangler.preview.toml
+import { readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const [, , name, baseUrl] = process.argv
+if (!name || !baseUrl) {
+  console.error("usage: preview-config.mjs <worker-name> <base-url>")
+  process.exit(1)
+}
+
+const here = dirname(fileURLToPath(import.meta.url))
+const text = readFileSync(join(here, "../wrangler.toml"), "utf8")
+
+// Split on top-level table headers, keeping each header's leading comment block with it.
+const lines = text.split("\n")
+const blocks = []
+let cur = []
+for (const line of lines) {
+  if (/^\[\[?[a-zA-Z]/.test(line)) {
+    const lead = []
+    while (cur.length && (cur.at(-1).startsWith("#") || cur.at(-1).trim() === ""))
+      lead.unshift(cur.pop())
+    blocks.push(cur)
+    cur = [...lead, line]
+  } else cur.push(line)
+}
+blocks.push(cur)
+
+const DROP = new Set(["[[routes]]", "[triggers]", "[[queues.consumers]]", "[[containers]]"])
+const headerOf = (b) => b.find((l) => /^\[\[?[a-zA-Z]/.test(l))?.trim() ?? null
+
+const kept = []
+for (const b of blocks) {
+  const h = headerOf(b)
+  const body = b.join("\n")
+  if (h && DROP.has(h)) continue
+  // The container's DO binding and its migration go with the container itself.
+  if (h === "[[durable_objects.bindings]]" && body.includes('name = "RUN_CONTAINER"')) continue
+  if (h === "[[migrations]]" && body.includes('new_sqlite_classes = ["RunContainer"]')) continue
+  kept.push(b)
+}
+
+let out = kept.map((b) => b.join("\n")).join("\n")
+out = out.replace(/^name = "derive"$/m, `name = "${name}"`)
+out = out.replace(/^BASE_URL = "https:\/\/derive\.to"$/m, `BASE_URL = "${baseUrl}"`)
+// Serve on workers.dev — a preview with no hostname is not a preview.
+out = out.replace(/^main = "src\/worker\.ts"$/m, 'main = "src/worker.ts"\nworkers_dev = true')
+
+const must = (cond, msg) => {
+  if (!cond) {
+    console.error(`preview-config: ${msg}`)
+    process.exit(1)
+  }
+}
+must(!out.includes("[[routes]]"), "routes survived — the preview would serve production hostnames")
+must(!out.includes("[triggers]"), "cron survived — a second scheduler on production's rows")
+must(!out.includes("queues.consumers"), "queue consumer survived — it would steal run messages")
+must(new RegExp(`^name = "${name}"$`, "m").test(out), "worker name was not replaced")
+must(!/^name = "derive"$/m.test(out), "the production worker name is still present")
+
+process.stdout.write(out)

--- a/apps/api/src/auth-config.ts
+++ b/apps/api/src/auth-config.ts
@@ -262,6 +262,24 @@ export function makeAuth(db: AuthDb, baseUrl: string, secret: string, hooks: Aut
     database: db,
     baseURL: baseUrl,
     secret,
+    // SESSION CACHE. Resolving a cookie session costs a signed-cookie read plus the session and
+    // user rows; on the hosted edge that measured 330-500ms on EVERY authenticated request —
+    // same route, same server, only the credential differing from a bearer token:
+    //
+    //   /v1/artifacts?limit=1   bearer  729ms   cookie 1233ms   (+503)
+    //   /v1/automations         bearer  333ms   cookie  664ms   (+331)
+    //
+    // With this on, Better Auth signs the session into a short-lived cookie and serves
+    // subsequent requests from it without touching the database at all.
+    //
+    // 60s, NOT the 300s default, and the reason is `revokeSessionsOnPasswordReset` below. A
+    // cached session stays usable until its cookie expires, so the cache window is exactly how
+    // long a revoked session outlives its revocation. Five minutes would substantially weaken a
+    // control this app opted into deliberately; a minute keeps nearly all the win (a browsing
+    // SPA makes many requests per minute) for a window short enough to live with. There is a
+    // test that deletes the session row and proves both halves: still authenticated inside the
+    // window, refused once it lapses.
+    session: { cookieCache: { enabled: true, maxAge: 60 } },
     emailAndPassword: {
       enabled: true,
       // Reject too-short passwords server-side (the client enforces 8 too); the fail-open

--- a/apps/api/src/config-manifest.ts
+++ b/apps/api/src/config-manifest.ts
@@ -327,7 +327,7 @@ const CONFIG_VARS: ConfigVar[] = [
   {
     name: "DERIVE_MODEL_BASE_URL",
     group: "advanced",
-    doc: "Root of an OPENAI-COMPATIBLE model endpoint (Fireworks, OpenRouter, Together, a\nself-hosted gateway); `/chat/completions` is appended. Setting it points every in-process\nrun on this deploy at that endpoint instead of the Anthropic Messages API.\n\nIt BYPASSES THE PAYER CHAIN on purpose: one ambient key means the operator pays for\neveryone on the instance, which is right for a single-tenant box and wrong for a\nmulti-tenant host — so derive.to does not set it. Requires DERIVE_MODEL_API_KEY and\nDERIVE_MODEL_NAME; all three or none.",
+    doc: "Root of an OPENAI-COMPATIBLE model endpoint (Fireworks, OpenRouter, Together, a\nself-hosted gateway); `/chat/completions` is appended. Setting it points every in-process\nrun AND attended chat on this deploy at that endpoint instead of the Anthropic Messages API.\n\nIt BYPASSES THE PAYER CHAIN on purpose: this deployment holds the key and spends it for\nevery workspace on it, so there is no chain to walk and no plan for anyone to connect.\nThat is the HOSTED posture — derive.to sets all three — and the workspace is metered\nagainst its tier allowance rather than billed to a credential it never supplied. It is\nequally right for a single-tenant box, where the operator is the only user.\n\n(This entry used to say derive.to does not set it. That was wrong, and it was read as\nintent: the schedule materializer kept walking a payer chain that cannot resolve on a\nhosted deploy, so scheduled automations silently never fired.)\n\nRequires DERIVE_MODEL_API_KEY and DERIVE_MODEL_NAME; all three or none.",
     example: "https://api.fireworks.ai/inference/v1",
   },
   {

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -820,7 +820,36 @@ export function buildContext(deps: AppDeps) {
     return clean ? `anon_${clean}` : anonViewerId(c)
   }
 
-  const actorFor = async (c: Context, a: ArtifactRecord): Promise<Actor> => {
+  // MEMOIZED PER REQUEST + ARTIFACT, exactly like `currentUser` above and for the same reason:
+  // handlers authorize the same artifact more than once, and every miss costs THREE round trips
+  // (membership, artifact member, collection roles).
+  //
+  // Opening a chat session authorizes twice — `read`, then `publish` — and separately reads the
+  // membership a third time, so ONE request made eleven sequential queries against Postgres, of
+  // which the same membership row was fetched three times and the artifact-member and
+  // collection-role rows twice each. On the hosted edge those cost ~100-900ms apiece.
+  //
+  // Safe because an Actor is a pure function of (principal, artifact), and both are fixed for
+  // the life of a request: nothing in a handler can change a role underneath itself, and a role
+  // changed by someone else is picked up by the next request. Keyed by Context, so it dies with
+  // the request rather than outliving a revoked share.
+  const actorCache = new WeakMap<Context, Map<string, Promise<Actor>>>()
+  const actorFor = (c: Context, a: ArtifactRecord): Promise<Actor> => {
+    let perArtifact = actorCache.get(c)
+    if (!perArtifact) {
+      perArtifact = new Map()
+      actorCache.set(c, perArtifact)
+    }
+    // Cache the PROMISE, not the resolved value: two authorize() calls that both start before
+    // the first resolves would otherwise both miss and both issue the three queries.
+    const hit = perArtifact.get(a.id)
+    if (hit) return hit
+    const pending = resolveActor(c, a)
+    perArtifact.set(a.id, pending)
+    return pending
+  }
+
+  const resolveActor = async (c: Context, a: ArtifactRecord): Promise<Actor> => {
     // A password on the artifact is a lock on its public link. Has this visitor
     // entered it? The unlock cookie's value is derived from the server-only
     // hash, so it can't be forged.

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -370,7 +370,25 @@ export function buildContext(deps: AppDeps) {
   const userCache = new WeakMap<Context, SessionUser | null>()
   const currentUser = async (c: Context): Promise<SessionUser | null> => {
     if (userCache.has(c)) return userCache.get(c) ?? null
-    const s = deps.auth ? await deps.auth.api.getSession({ headers: c.req.raw.headers }) : null
+    // A BROKEN CREDENTIAL IS NOT A SERVER FAULT. getSession throws on input it cannot make sense
+    // of, and with the session cookie cache on there is now a second cookie that can be
+    // malformed: a `session_data` of `{}` threw "Error parsing JSON" and every authenticated
+    // request 500'd for as long as the client kept sending it. A 500 is both wrong (the caller's
+    // cookie is bad, not the server) and sticky — the client has no reason to re-authenticate,
+    // so it loops. Unauthenticated is the honest answer and it self-heals: the next sign-in
+    // replaces the cookie.
+    //
+    // Logged at error, not swallowed. This same throw is how a deployment whose secret cannot
+    // decrypt the shared JWKS row announces itself, and that diagnosis has to stay findable —
+    // it just should not be a 500 on every page.
+    const s = deps.auth
+      ? await deps.auth.api.getSession({ headers: c.req.raw.headers }).catch((e: unknown) => {
+          log.error("session could not be read; treating the request as signed out", {
+            error: e instanceof Error ? e.message : String(e),
+          })
+          return null
+        })
+      : null
     // `username`/`discoverable` ride the session via Better Auth additionalFields
     // (see auth-config.ts); read them through a narrow cast (optional extras).
     const su = s?.user as

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -892,6 +892,25 @@ export function buildContext(deps: AppDeps) {
     // shared link never auto-joins you into someone else's workspace; you only carry an org
     // role where you're explicitly a member.
     const me = p.user
+    // ONE ROUND TRIP WHERE THE STORE CAN, four where it cannot. The reads below are the
+    // membership, the per-artifact share and the collection shares — and the last is itself two
+    // queries, so this is four trips to decide one boolean, on every authorize. A store that can
+    // answer it in a single statement implements `artifactGrants`; the fallback is the original
+    // code, unchanged, so a store without it behaves exactly as before.
+    //
+    // Both paths feed the SAME maxRole/can(): the fast path changes how the inputs arrive, never
+    // what they are. artifact-grants-parity.test.ts asserts the two agree.
+    if (meta.artifactGrants) {
+      const g = await meta.artifactGrants(a.id, a.org_id, me.id)
+      return {
+        kind: "user",
+        userId: me.id,
+        artifactRole: maxRole(null, ...g.artifactRoles),
+        orgRole: g.orgRole,
+        locked,
+        unlocked,
+      }
+    }
     const orgRole = (await meta.getMembership(a.org_id, me.id))?.role ?? null
     const am = await meta.getArtifactMember(a.id, me.id)
     // A collection share grants its role on every artifact in the collection,

--- a/apps/api/src/lib/dispatch.ts
+++ b/apps/api/src/lib/dispatch.ts
@@ -53,6 +53,12 @@ export interface DispatchDeps {
   server: string
   /** DERIVE_AUTH_SECRET / encryptionKey — signs the capability tokens. */
   secret: string
+  /** True when this deployment has an operator gateway (DERIVE_MODEL_BASE_URL/_API_KEY/_NAME),
+   *  i.e. it holds the key and pays for every workspace on it. The schedule materializer then
+   *  skips the payer walk: there is no plan for anyone to connect, so the chain returns null and
+   *  would refuse every occurrence forever. Set from the SAME gateway helper each entry point
+   *  already uses to build the substrate, so the two can never disagree about it. */
+  operatorPays?: boolean
   /** Max runs started per pass (the global burst valve). Default 10. */
   limit?: number
   /** Max runs one WORKSPACE may have in flight at once — fairness and cost containment, so a
@@ -112,7 +118,7 @@ export const dispatchPass = async (deps: DispatchDeps): Promise<DispatchResult> 
 
   // 1. Materialize due schedules.
   try {
-    out.materialized = await materializeAllDueRuns(deps.meta, now)
+    out.materialized = await materializeAllDueRuns(deps.meta, now, deps.operatorPays === true)
   } catch (e) {
     log.warn("hosted dispatch: materialize failed", { error: (e as Error).message })
   }

--- a/apps/api/src/lib/schedule.ts
+++ b/apps/api/src/lib/schedule.ts
@@ -147,7 +147,14 @@ const materializeFor = async (
   return created
 }
 
-/** The POLLING tick: due schedule runs for one agent's automations (claim-time). */
+/** The POLLING tick: due schedule runs for one agent's automations (claim-time).
+ *
+ *  Deliberately does NOT take `operatorPays`, and that is not an oversight. A polling runner is
+ *  the user's own machine draining its own queue; the gateway is this deployment's key for work
+ *  this deployment executes. Where hosted dispatch is on, the hosted tick materializes across
+ *  every enabled automation anyway, so this path is redundant there. Where it is off, a gateway
+ *  serves attended chat only and an unattended run really does have to resolve its own
+ *  credential — so demanding a payer here is the correct answer, not the bug fixed above. */
 export const materializeDueRuns = async (
   meta: MetaStore,
   agent: { id: string; org_id: string },

--- a/apps/api/src/lib/schedule.ts
+++ b/apps/api/src/lib/schedule.ts
@@ -31,6 +31,7 @@ const materializeFor = async (
   meta: MetaStore,
   autos: AutomationRecord[],
   now: Date,
+  operatorPays = false,
 ): Promise<number> => {
   let created = 0
   let unpayable = 0
@@ -95,18 +96,28 @@ const materializeFor = async (
     //
     // Checked HERE — after the dedupe, immediately before the insert — so a tick that
     // materializes nothing costs no extra queries, whatever the size of the automation list.
-    const ag = await meta.getAgent(a.agent_id)
-    const payer = await findPayer(meta, {
-      orgId: a.org_id,
-      agentId: a.agent_id,
-      agentCreatedBy: ag?.created_by ?? null,
-      // A clock has no person behind it, so a scheduled run can only reach the owner-lend and
-      // pool tiers. That is also why it is the trigger most likely to have no payer at all.
-      initiator: null,
-    })
-    if (!payer) {
-      unpayable += 1
-      continue
+    //
+    // UNLESS THE OPERATOR PAYS. A configured gateway (DERIVE_MODEL_BASE_URL/_API_KEY/_NAME)
+    // means this deployment holds the key and spends it for every workspace on it, so there is
+    // no chain to walk and no plan for anyone to connect — findPayer would correctly return
+    // null and this guard would then refuse every occurrence, forever, on exactly the hosted
+    // posture the gateway exists to serve. The attended lane (routes/contexts.ts) and the
+    // manual lane (routes/automations.ts `canPay`) already short-circuit on the same
+    // condition; this was the third lane, and the only one with nobody watching it fail.
+    if (!operatorPays) {
+      const ag = await meta.getAgent(a.agent_id)
+      const payer = await findPayer(meta, {
+        orgId: a.org_id,
+        agentId: a.agent_id,
+        agentCreatedBy: ag?.created_by ?? null,
+        // A clock has no person behind it, so a scheduled run can only reach the owner-lend and
+        // pool tiers. That is also why it is the trigger most likely to have no payer at all.
+        initiator: null,
+      })
+      if (!payer) {
+        unpayable += 1
+        continue
+      }
     }
     try {
       await meta.createRun({
@@ -150,6 +161,11 @@ export const materializeDueRuns = async (
     now,
   )
 
-/** The HOSTED tick: due schedule runs across every enabled automation on this deployment. */
-export const materializeAllDueRuns = async (meta: MetaStore, now: Date): Promise<number> =>
-  materializeFor(meta, await meta.listEnabledAutomations(), now)
+/** The HOSTED tick: due schedule runs across every enabled automation on this deployment.
+ *  `operatorPays` is true when the deployment has an operator gateway configured — see the
+ *  payer guard in materializeFor for why the chain must not be walked in that case. */
+export const materializeAllDueRuns = async (
+  meta: MetaStore,
+  now: Date,
+  operatorPays = false,
+): Promise<number> => materializeFor(meta, await meta.listEnabledAutomations(), now, operatorPays)

--- a/apps/api/src/lib/session-turn.ts
+++ b/apps/api/src/lib/session-turn.ts
@@ -28,6 +28,7 @@ import type { AgentLoopInput } from "./agent-loop"
 import {
   documentBlock,
   documentContract,
+  documentName,
   type LandingPort,
   runTurn,
   type TurnOutcome,
@@ -127,7 +128,7 @@ revision block, and do not change the document. Most messages are one or the oth
 
 ${contract.text}
 
-${documentBlock(src.text, input.artifact.short_id)}`
+${documentBlock(src.text, documentName(input.artifact.short_id, input.artifact.current_content_type))}`
 
   const out = await runTurn({
     system,

--- a/apps/api/src/lib/substrate-loop.ts
+++ b/apps/api/src/lib/substrate-loop.ts
@@ -705,10 +705,23 @@ const sourceOf = async (
     if (!res.ok) throw new Error(`artifact ${shortId} → ${res.status}`)
     const body = await res.text()
     if (!body.trim()) throw new Error(`artifact ${shortId} → 200 with an empty body`)
-    // The response header IS the document's recorded type, so keeping it here costs nothing and
-    // saves the write from having to guess one from a filename the model chose. See landOverHttp.
-    const contentType = res.headers.get("content-type")?.split(";")[0]?.trim() || null
-    return { text: body.slice(0, MAX_ARTIFACT_CHARS), contentType }
+    // THE RECORDED TYPE, from the artifact record — NOT from this response's Content-Type
+    // header. That header is the transport's, and `/content` serves every document as
+    // `text/plain; charset=utf-8` so the bytes render as text rather than executing in a
+    // browser. Reading it here looked correct and returned "text/plain" for every artifact,
+    // which matches neither branch downstream, so the format-preserving write silently became
+    // a no-op in production while its test — against a stub that answered `text/markdown` —
+    // stayed green.
+    //
+    // Best-effort: a document whose record cannot be read still gets revised, it just falls
+    // back to naming the file the way the model asked.
+    const meta = await call(`/v1/artifacts/${shortId}`)
+      .then((r) => (r.ok ? (r.json() as Promise<{ current_content_type?: string | null }>) : null))
+      .catch(() => null)
+    return {
+      text: body.slice(0, MAX_ARTIFACT_CHARS),
+      contentType: meta?.current_content_type ?? null,
+    }
   } catch (e) {
     log.warn("loop substrate: could not read the run's target", {
       artifact: shortId,

--- a/apps/api/src/lib/substrate-loop.ts
+++ b/apps/api/src/lib/substrate-loop.ts
@@ -705,22 +705,23 @@ const sourceOf = async (
     if (!res.ok) throw new Error(`artifact ${shortId} → ${res.status}`)
     const body = await res.text()
     if (!body.trim()) throw new Error(`artifact ${shortId} → 200 with an empty body`)
-    // THE RECORDED TYPE, from the artifact record — NOT from this response's Content-Type
-    // header. That header is the transport's, and `/content` serves every document as
-    // `text/plain; charset=utf-8` so the bytes render as text rather than executing in a
-    // browser. Reading it here looked correct and returned "text/plain" for every artifact,
-    // which matches neither branch downstream, so the format-preserving write silently became
-    // a no-op in production while its test — against a stub that answered `text/markdown` —
-    // stayed green.
+    // THE DOCUMENT'S type, from `X-Derive-Content-Type` — NOT from `Content-Type`, which is
+    // the transport's and is always `text/plain; charset=utf-8` here so the bytes render as
+    // text rather than executing in a browser. Reading the wrong one returned "text/plain" for
+    // every artifact, matched neither branch downstream, and made the format-preserving write a
+    // silent no-op in production while its test stayed green against a stub I had invented.
     //
-    // Best-effort: a document whose record cannot be read still gets revised, it just falls
-    // back to naming the file the way the model asked.
-    const meta = await call(`/v1/artifacts/${shortId}`)
-      .then((r) => (r.ok ? (r.json() as Promise<{ current_content_type?: string | null }>) : null))
-      .catch(() => null)
+    // ONE REQUEST. The route already had the version row loaded and used it six lines later,
+    // so this costs nothing: no extra round trip, no second auth, no second query. Asking the
+    // artifact record instead — which is what the first working version of this did — bought
+    // the same answer for a whole additional request per run, and would have reported the
+    // CURRENT type for a `?v=N` read of an older version.
+    //
+    // Best-effort: an older deploy that does not send the header just falls back to naming the
+    // file the way the model asked.
     return {
       text: body.slice(0, MAX_ARTIFACT_CHARS),
-      contentType: meta?.current_content_type ?? null,
+      contentType: res.headers.get("x-derive-content-type")?.split(";")[0]?.trim() || null,
     }
   } catch (e) {
     log.warn("loop substrate: could not read the run's target", {

--- a/apps/api/src/lib/substrate-loop.ts
+++ b/apps/api/src/lib/substrate-loop.ts
@@ -69,14 +69,30 @@ export interface LoopSubstrateOptions {
    *  gateway). When set, every run on this deploy calls it with this key instead of resolving a
    *  per-run credential.
    *
-   *  That BYPASSES THE PAYER CHAIN by design, and it is why this is a self-host/dev affordance
-   *  rather than something derive.to sets: one ambient key means the operator pays for everyone
-   *  on the instance, which is the correct model for a single-tenant box and the wrong one for a
-   *  multi-tenant host. See the Node caveat in the status doc. */
+   *  It BYPASSES THE PAYER CHAIN by design: one operator key means this deployment pays for
+   *  every workspace on it, so there is nothing for a chain to resolve and no plan for anyone to
+   *  connect. That is the HOSTED posture, not a self-host-only affordance — derive.to sets these
+   *  three, and the workspace is metered against its tier allowance instead of billing a
+   *  credential it never supplied. An earlier version of this comment said the opposite; it was
+   *  read as intent and cost a release. */
   gateway?: { baseUrl: string; apiKey: string; model: string }
   /** Cloudflare's `ctx.waitUntil`, so a Worker does not tear the isolate down mid-run. Absent on
    *  Node, where nothing collects the process out from under us. */
   waitUntil?: (p: Promise<unknown>) => void
+  /** How the client REACHES the API. Defaults to global `fetch`, which is right on Node, where
+   *  the loop and the API are the same process reachable over loopback.
+   *
+   *  On Workers it must not be. This substrate calls its own deployment, so a global `fetch` at
+   *  `server` leaves the isolate, crosses the edge, and comes back to the same Worker. One run
+   *  survives that; the cron tick starting three at once does not — each self-subrequest sat
+   *  until it timed out and every scheduled run died on `/v1/agent/runs/claim failed (522)`
+   *  while a single run booted from the queue nudge succeeded. Passing the Worker's own handler
+   *  here keeps the request identical — same route, same bearer, same middleware, same
+   *  authorization — and removes only the trip through the network.
+   *
+   *  It stays an injected function rather than a platform branch so there is still ONE
+   *  implementation, which is the property this substrate exists to have. */
+  fetchImpl?: (req: Request) => Promise<Response>
   /** Bound the model loop. */
   maxTurns?: number
 }
@@ -107,20 +123,26 @@ const NO_FLAGS: AutonomyFlags = { agentKillswitch: false, agentAutoEnabled: fals
  *  truncated rather than sent whole and rejected by the provider. */
 const MAX_MANIFEST_CHARS = 100_000
 
-const api = (server: string, token: string) => {
+const api = (
+  server: string,
+  token: string,
+  fetchImpl: (req: Request) => Promise<Response> = fetch,
+) => {
   const call = async (path: string, init?: RequestInit): Promise<Response> =>
-    fetch(`${server}${path}`, {
-      ...init,
-      headers: {
-        authorization: `Bearer ${token}`,
-        ...(init?.body && typeof init.body === "string"
-          ? { "content-type": "application/json" }
-          : {}),
-        ...(init?.headers ?? {}),
-      },
-      // A blackholed host must not pin the loop open forever.
-      signal: AbortSignal.timeout(60_000),
-    })
+    fetchImpl(
+      new Request(`${server}${path}`, {
+        ...init,
+        headers: {
+          authorization: `Bearer ${token}`,
+          ...(init?.body && typeof init.body === "string"
+            ? { "content-type": "application/json" }
+            : {}),
+          ...(init?.headers ?? {}),
+        },
+        // A blackholed host must not pin the loop open forever.
+        signal: AbortSignal.timeout(60_000),
+      }),
+    )
   return {
     call,
     json: async <T>(path: string, init?: RequestInit): Promise<T> => {
@@ -366,7 +388,7 @@ const serveOneRun = async (
   server: string,
   opts: LoopSubstrateOptions,
 ): Promise<void> => {
-  const client = api(server, token)
+  const client = api(server, token, opts.fetchImpl)
 
   // CLAIM. The token is scoped to this run, so the claim returns it and nothing else — the same
   // status-guarded transition the container executor makes, which is what stops a double-dispatch
@@ -479,7 +501,7 @@ const serveOneSession = async (
   server: string,
   opts: LoopSubstrateOptions,
 ): Promise<void> => {
-  const client = api(server, token)
+  const client = api(server, token, opts.fetchImpl)
 
   // CLAIM — a DIFFERENT shape from the run lane's, deliberately not papered over. The token
   // already names the one session it may touch, so the server claims that session and hands back

--- a/apps/api/src/lib/substrate-loop.ts
+++ b/apps/api/src/lib/substrate-loop.ts
@@ -9,6 +9,7 @@ import {
   askContract,
   documentBlock,
   documentContract,
+  documentName,
   type LandingPort,
   revisionContract,
   runTurn,
@@ -466,7 +467,9 @@ const serveOneRun = async (
     system:
       RUN_SYSTEM_PROMPT +
       contract.text +
-      (source === null ? "" : `\n\n${documentBlock(source, targetId ?? "index.html")}`),
+      (source === null
+        ? ""
+        : `\n\n${documentBlock(source, documentName(targetId ?? "index", targetDoc?.contentType))}`),
     messages: [{ role: "user", content: buildPrompt(run, targetId) }],
     tools: (run.tools ?? []).map((t) => t.def),
     contract,

--- a/apps/api/src/lib/substrate-loop.ts
+++ b/apps/api/src/lib/substrate-loop.ts
@@ -318,16 +318,38 @@ const whyNoCredential = async (
  * ledger can take.
  */
 const landOverHttp =
-  ({ call, json }: Api, targetId: string | undefined): LandingPort =>
+  (
+    { call, json }: Api,
+    targetId: string | undefined,
+    targetContentType?: string | null,
+  ): LandingPort =>
   async (decision, revision) => {
     const form = new FormData()
-    form.set(
-      "file",
-      new Blob([revision.content], {
-        type: revision.filename.endsWith(".md") ? "text/markdown" : "text/html",
-      }),
-      revision.filename,
-    )
+    // KEEP THE DOCUMENT'S OWN FORMAT, as the attended lane does (lib/session-turn.ts).
+    //
+    // The model names the file, and the edits contract falls back to `index.html` when it does
+    // not — right when CREATING an artifact, wrong when REVISING one. On production a markdown
+    // document went v1 text/markdown, v2 text/markdown (a chat edit, which already had this
+    // fix), v3 text/html the moment an automation wrote to it, at which point it rendered as one
+    // unformatted blob with nothing reporting an error.
+    //
+    // THE FILENAME IS WHAT DECIDES THIS, not the part's MIME type. publish.ts's storeContent
+    // reads the extension (after a full-HTML-document body sniff) and ignores what the multipart
+    // part claims — so setting only the Blob type looks correct, passes a test that inspects the
+    // request, and changes nothing about the artifact. Send both, and make the NAME agree with
+    // the document.
+    //
+    // Only markdown and html are rewritten: those are the two the extension actually decides. A
+    // deck is recognised from its body, so leaving its name alone is what keeps it a deck.
+    const contentType =
+      targetContentType ?? (revision.filename.endsWith(".md") ? "text/markdown" : "text/html")
+    const wantExt =
+      contentType === "text/markdown" ? ".md" : contentType === "text/html" ? ".html" : null
+    const filename =
+      wantExt && !new RegExp(`\\${wantExt}$`, "i").test(revision.filename)
+        ? `${revision.filename.replace(/\.[^./]*$/, "")}${wantExt}`
+        : revision.filename
+    form.set("file", new Blob([revision.content], { type: contentType }), filename)
     if (revision.message) form.set("message", revision.message)
     const write = async (path: string) => {
       const res = await call(path, { method: "POST", body: form })
@@ -423,8 +445,8 @@ const serveOneRun = async (
   // the prompt; a run with none is creating something new and has nothing to read. An unreadable
   // target fails the run — retryable, because a 5xx or a lease blip is transient, and because the
   // alternative is asking the model to rewrite a document it cannot see.
-  const source = targetId ? await sourceOf(client, targetId) : null
-  if (targetId && source === null) {
+  const targetDoc = targetId ? await sourceOf(client, targetId) : null
+  if (targetId && targetDoc === null) {
     await finish({
       status: "failed",
       meta: {
@@ -438,6 +460,7 @@ const serveOneRun = async (
 
   // Over EDITS_THRESHOLD_CHARS a whole-document reply cannot fit, so the ask becomes
   // search/replace edits — the same switch attended chat makes, from the same shared helper.
+  const source = targetDoc?.text ?? null
   const contract = source === null ? revisionContract : documentContract(source, false)
   const out = await runTurn({
     system:
@@ -455,7 +478,7 @@ const serveOneRun = async (
       autonomy: target?.mode === "publish" ? "auto" : "suggest",
       flags: run.flags ?? NO_FLAGS,
     },
-    land: landOverHttp(client, targetId),
+    land: landOverHttp(client, targetId, targetDoc?.contentType),
   })
   spentUsd = out.costUsd
 
@@ -670,13 +693,19 @@ const manifestFor = async ({ call }: Api, claimed: ClaimedSession): Promise<stri
  * for a published artifact's content to be empty (`current_version === 0` is filtered upstream),
  * so an empty read is a read that did not work: fail closed, retryable, same as a 500.
  */
-const sourceOf = async ({ call }: Api, shortId: string): Promise<string | null> => {
+const sourceOf = async (
+  { call }: Api,
+  shortId: string,
+): Promise<{ text: string; contentType: string | null } | null> => {
   try {
     const res = await call(`/v1/artifacts/${shortId}/content`)
     if (!res.ok) throw new Error(`artifact ${shortId} → ${res.status}`)
     const body = await res.text()
     if (!body.trim()) throw new Error(`artifact ${shortId} → 200 with an empty body`)
-    return body.slice(0, MAX_ARTIFACT_CHARS)
+    // The response header IS the document's recorded type, so keeping it here costs nothing and
+    // saves the write from having to guess one from a filename the model chose. See landOverHttp.
+    const contentType = res.headers.get("content-type")?.split(";")[0]?.trim() || null
+    return { text: body.slice(0, MAX_ARTIFACT_CHARS), contentType }
   } catch (e) {
     log.warn("loop substrate: could not read the run's target", {
       artifact: shortId,

--- a/apps/api/src/lib/turn-core.ts
+++ b/apps/api/src/lib/turn-core.ts
@@ -184,6 +184,26 @@ export const documentBlock = (source: string, filename: string): string =>
 ${source}
 --- END DOCUMENT ---`
 
+/**
+ * The name to SHOW the model for a document it is about to revise.
+ *
+ * Both lanes passed a bare short_id ("wa68nr6q"), which carries no format signal at all. Asked
+ * to name its output the model then guessed, and the edits contract's fallback turned that guess
+ * into `index.html` — which is how a Markdown document intermittently came back as HTML.
+ *
+ * The landing port no longer trusts the model's filename either (it keeps the document's
+ * recorded type), and the two fixes are not redundant: this one stops the model being misled,
+ * that one stops a misled model doing damage. A model told "this file is called wa68nr6q" can
+ * also write HTML into a Markdown document's BODY, which no amount of correcting the content
+ * type afterwards would undo.
+ */
+export const documentName = (shortId: string, contentType: string | null | undefined): string =>
+  contentType === "text/markdown"
+    ? `${shortId}.md`
+    : contentType === "text/html"
+      ? `${shortId}.html`
+      : shortId
+
 // ---- the landing port -----------------------------------------------------------------------
 
 /** What landed, named so the transcript and the ledger can both point at it. */

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -395,6 +395,10 @@ const hostedDispatch = cfg.hostedRuns
           : nodeSubstrate({ bin: cfg.runnerBin }),
       server: cfg.baseUrl,
       secret: authSecret,
+      // Same gateway the substrate just took: when the operator holds the key, the schedule
+      // materializer must not walk a payer chain that cannot exist. The Worker twin sets this
+      // from workerGateway(env) for the same reason.
+      operatorPays: modelGateway() !== null,
     }
   : null
 

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -1860,6 +1860,15 @@ export const artifactRoutes = (ctx: AppContext) => {
     c.header("X-Content-Type-Options", "nosniff")
     c.header("X-Derive-Version", String(v))
     c.header("X-Derive-Kind", artifact.kind)
+    // The DOCUMENT'S type, which `Content-Type` deliberately cannot carry: that stays
+    // `text/plain` so a browser renders these bytes rather than executing them (see nosniff
+    // above). Without it, a caller that needs to know whether it is holding Markdown or HTML
+    // must fetch the artifact record separately — a second request that re-runs auth and
+    // re-reads the very row this handler already has in hand and uses six lines below.
+    //
+    // Per VERSION, not the artifact's current one: `?v=N` can select a version whose type
+    // differs from the live document's, and this has to describe the bytes actually returned.
+    c.header("X-Derive-Content-Type", version.content_type)
 
     const manifest = await manifestOf(blobs, version)
     if (!manifest) {

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -1159,8 +1159,24 @@ export const contextRoutes = (ctx: AppContext) => {
       // chat-enabled workspace and spend the operator's model key — 201 and a running turn, from
       // outside the workspace entirely. Reading a shared document is not standing to run an
       // agent inside the workspace that owns it.
-      if (!(await meta.getMembership(art.org_id, me.id).catch(() => null)))
-        return bail(fail(c, 404, "not found"))
+      //
+      // Answered from the RESOLVED ACTOR where that is the same question, re-queried where it is
+      // not. For a signed-in human, `actorFor` derives `orgRole` from exactly this row —
+      // getMembership(art.org_id, me.id), same arguments — and it is memoized per request, so the
+      // authorize() above has already paid for it; querying again made this the third read of one
+      // row in a single request.
+      //
+      // The fallback is not defensive padding. `resolvePrincipal` checks the static operator
+      // token BEFORE the session, so a request carrying both resolves to `kind: "token"` and its
+      // actor says nothing about whether the HUMAN is a member. Treating that as "not a member"
+      // would have quietly denied a case that works today. The guard is `userId === me.id`, so
+      // the cache is only trusted when it is describing this request's user.
+      const actor = await ctx.actorFor(c, art)
+      const isMember =
+        actor.kind === "user" && actor.userId === me.id
+          ? !!actor.orgRole
+          : !!(await meta.getMembership(art.org_id, me.id).catch(() => null))
+      if (!isMember) return bail(fail(c, 404, "not found"))
       const wantsPublish = b.mode === "publish"
       if (wantsPublish && !(await authorize(c, "publish", art)))
         return bail(fail(c, 403, "you cannot publish to that artifact"))

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -493,10 +493,11 @@ async function withHostedDispatch(
   const waitUntil = ctx ? (p: Promise<unknown>) => ctx.waitUntil(p) : undefined
   // WHICH SUBSTRATE, mirroring node.ts. `DERIVE_LOOP_RUNS=1` runs the work in this isolate — a
   // model and fetch, which is all "read a document, write a revision" needs, and the only runner
-  // in scope. It is the SAME file Node uses; the entire platform difference is the `waitUntil`
-  // below, without which the isolate is torn down the moment dispatch returns and the run dies
-  // mid-model-call. Anything needing a shell or git still wants the container, so that stays the
-  // default and the flag is the opt-in — off means derive.to behaves exactly as it does today.
+  // in scope. It is the SAME file Node uses; the platform difference is exactly the two options
+  // below — `waitUntil`, without which the isolate is torn down the moment dispatch returns and
+  // the run dies mid-model-call, and `fetchImpl`, without which the loop's calls to this API
+  // leave the isolate and time out. Anything needing a shell or git still wants the container,
+  // so that stays the default and the flag is the opt-in.
   //
   // BOTH LANES, one substrate. The loop used to serve runs only, so a deployment that opted into
   // it had to keep sessions on the container or lose them; it now branches on the work token and
@@ -508,9 +509,11 @@ async function withHostedDispatch(
   // on 100% of hosted runs for any deploy that had configured chat. Unset is the right default:
   // the loop falls back to its own Anthropic model id.
   //
-  // The gateway rides along when the operator configured one, exactly as node.ts does — the two
-  // entries are meant to differ only in `waitUntil`, and this was the one place they silently
-  // did not. derive.to sets none of the three, so nothing changes there.
+  // The gateway rides along when the operator configured one, exactly as node.ts does. An
+  // earlier version of this comment ended "derive.to sets none of the three, so nothing changes
+  // there" — that is FALSE and was worth a release: derive.to sets all three, because holding
+  // the key and spending it for every workspace IS the hosted posture. `operatorPays` below
+  // depends on the same fact.
   const gateway = workerGateway(env)
   const substrate =
     env.DERIVE_LOOP_RUNS === "1"
@@ -528,10 +531,16 @@ async function withHostedDispatch(
           //
           // EACH SUB-REQUEST GETS ITS OWN CONNECTION, exactly as `fetch` above gives every real
           // request one. Calling `handle` bare inherits the DISPATCH's pg context, so every call
-          // from every concurrently-started run shares a single pg Client — the driver serializes
-          // them, statement_timeout (30s) starts firing, and the loop's own 60s abort trips:
-          // "The operation was aborted due to timeout" on runs that had worked moments before.
-          // One run never showed it; three at once did, which is the same trap as the 522.
+          // from every concurrently-started run would share a single pg Client, and
+          // node-postgres queues concurrent queries on one Client — silently serializing work a
+          // network request would have run in parallel.
+          //
+          // Correctness, not a measured win. A run of "operation was aborted due to timeout" was
+          // first blamed on this contention; that was withdrawn when the model host turned out
+          // to have been unreachable at the time, and the failures never reproduced against a
+          // healthy one. The invariant is the reason to keep it: routing through the same entry
+          // point should leave a sub-request differing from a network request in latency and
+          // nothing else.
           ...(ctx
             ? {
                 fetchImpl: (req: Request): Promise<Response> =>

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -459,7 +459,7 @@ export default {
       },
       // Same reason as the cron tick: on the loop substrate the run happens here, so the consumer
       // invocation has to be kept alive past the ack.
-      ctx ? (p) => ctx.waitUntil(p) : undefined,
+      ctx,
     )
   },
 }
@@ -485,8 +485,12 @@ function workerGateway(env: Env): { baseUrl: string; apiKey: string; model: stri
 async function withHostedDispatch(
   env: Env,
   fn: (deps: DispatchDeps) => Promise<void>,
-  waitUntil?: (p: Promise<unknown>) => void,
+  ctx?: ExecutionContext,
 ): Promise<void> {
+  // Two things come from the ExecutionContext, and both are why hosted runs work at all here:
+  // `waitUntil` keeps the isolate alive past dispatch, and `handle` lets the loop reach this
+  // API without leaving the isolate (see `fetchImpl` on the substrate).
+  const waitUntil = ctx ? (p: Promise<unknown>) => ctx.waitUntil(p) : undefined
   // WHICH SUBSTRATE, mirroring node.ts. `DERIVE_LOOP_RUNS=1` runs the work in this isolate — a
   // model and fetch, which is all "read a document, write a revision" needs, and the only runner
   // in scope. It is the SAME file Node uses; the entire platform difference is the `waitUntil`
@@ -510,7 +514,19 @@ async function withHostedDispatch(
   const gateway = workerGateway(env)
   const substrate =
     env.DERIVE_LOOP_RUNS === "1"
-      ? loopSubstrate({ model: env.DERIVE_LOOP_MODEL, gateway, waitUntil })
+      ? loopSubstrate({
+          model: env.DERIVE_LOOP_MODEL,
+          gateway,
+          waitUntil,
+          // Reach this API WITHOUT leaving the isolate. The loop is an HTTP client of its own
+          // deployment; on Workers a global fetch at BASE_URL exits to the edge and comes back
+          // to this same Worker, and the cron tick starting several runs at once made every one
+          // of those self-subrequests time out (522 on the claim). `handle` is the exact entry a
+          // real request takes, so the route, the bearer, the middleware and the authorization
+          // are unchanged — only the network hop is gone. Needs the ExecutionContext, which is
+          // why withHostedDispatch takes `ctx` rather than a bare waitUntil.
+          ...(ctx ? { fetchImpl: (req: Request) => Promise.resolve(handle(req, env, ctx)) } : {}),
+        })
       : containerSubstrateFromEnv(env as unknown as Record<string, unknown>)
   const secret = env.DERIVE_AUTH_SECRET
   if (!substrate || !secret) return
@@ -541,5 +557,5 @@ const hostedRunTick = (env: Env, ctx?: ExecutionContext): Promise<void> =>
     // work has begun. Without handing it waitUntil, the cron invocation finishes and Cloudflare
     // tears the isolate down mid-run: the run stays `running` until the reclaim sweep requeues it,
     // which looks like a hang rather than the truncation it is.
-    ctx ? (p) => ctx.waitUntil(p) : undefined,
+    ctx,
   )

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -525,7 +525,23 @@ async function withHostedDispatch(
           // real request takes, so the route, the bearer, the middleware and the authorization
           // are unchanged — only the network hop is gone. Needs the ExecutionContext, which is
           // why withHostedDispatch takes `ctx` rather than a bare waitUntil.
-          ...(ctx ? { fetchImpl: (req: Request) => Promise.resolve(handle(req, env, ctx)) } : {}),
+          //
+          // EACH SUB-REQUEST GETS ITS OWN CONNECTION, exactly as `fetch` above gives every real
+          // request one. Calling `handle` bare inherits the DISPATCH's pg context, so every call
+          // from every concurrently-started run shares a single pg Client — the driver serializes
+          // them, statement_timeout (30s) starts firing, and the loop's own 60s abort trips:
+          // "The operation was aborted due to timeout" on runs that had worked moments before.
+          // One run never showed it; three at once did, which is the same trap as the 522.
+          ...(ctx
+            ? {
+                fetchImpl: (req: Request): Promise<Response> =>
+                  env.HYPERDRIVE
+                    ? requestPg.run(hyperdriveConn(env.HYPERDRIVE), async () =>
+                        handle(req, env, ctx),
+                      )
+                    : Promise.resolve(handle(req, env, ctx)),
+              }
+            : {}),
         })
       : containerSubstrateFromEnv(env as unknown as Record<string, unknown>)
   const secret = env.DERIVE_AUTH_SECRET

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -507,9 +507,10 @@ async function withHostedDispatch(
   // The gateway rides along when the operator configured one, exactly as node.ts does — the two
   // entries are meant to differ only in `waitUntil`, and this was the one place they silently
   // did not. derive.to sets none of the three, so nothing changes there.
+  const gateway = workerGateway(env)
   const substrate =
     env.DERIVE_LOOP_RUNS === "1"
-      ? loopSubstrate({ model: env.DERIVE_LOOP_MODEL, gateway: workerGateway(env), waitUntil })
+      ? loopSubstrate({ model: env.DERIVE_LOOP_MODEL, gateway, waitUntil })
       : containerSubstrateFromEnv(env as unknown as Record<string, unknown>)
   const secret = env.DERIVE_AUTH_SECRET
   if (!substrate || !secret) return
@@ -519,6 +520,9 @@ async function withHostedDispatch(
       substrate,
       server: env.BASE_URL ?? "",
       secret,
+      // Same gateway the substrate just took: when the operator holds the key, the schedule
+      // materializer must not walk a payer chain that cannot exist.
+      operatorPays: !!gateway,
     })
   await (env.HYPERDRIVE
     ? requestPg.run(hyperdriveConn(env.HYPERDRIVE), scoped)

--- a/apps/api/test/auth-session-cache-tamper.test.ts
+++ b/apps/api/test/auth-session-cache-tamper.test.ts
@@ -1,0 +1,152 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { SqliteMetaStore } from "@derive/db/sqlite"
+import { FsBlobStore } from "@derive/storage/fs"
+import Database from "better-sqlite3"
+import { afterAll, describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { makeAuth, migrateAuth } from "../src/auth-config"
+
+/**
+ * THE COOKIE CACHE IS AN IDENTITY SOURCE. Attack it.
+ *
+ * Serving the session from a signed cookie lets a request authenticate without the database
+ * being read. That is the point, and it is also new attack surface: if the payload can be
+ * edited, forged, or replayed from another deployment, the fast path is an authentication
+ * bypass rather than a cache.
+ *
+ * What this pins, all found by trying them:
+ *   - the cached payload is NOT a credential on its own — without a session token it is 401;
+ *   - editing it does not change who you are;
+ *   - a payload minted under another secret is refused;
+ *   - a malformed one is a 401, never a 500. `{}` used to throw "Error parsing JSON" out of
+ *     getSession, and since every authenticated request goes through it, one bad cookie meant a
+ *     sticky 500 on every page — the client has no reason to re-authenticate, so it loops.
+ *
+ * KNOWN AND ACCEPTED: presenting account A's session token with account B's cached payload
+ * resolves as B. It is not an escalation — both cookies are HttpOnly with identical exposure, so
+ * anyone who can read B's session_data can read B's session_token, which already impersonates B
+ * outright. It is recorded here so the property is a decision rather than a surprise.
+ */
+const dir = mkdtempSync(join(tmpdir(), "derive-cache-tamper-"))
+const dbPath = join(dir, "auth.db")
+const db = new Database(dbPath)
+const BASE = "http://localhost:8080"
+const SECRET = "tamper-secret-0123456789abcd"
+
+const appWith = (secret: string) =>
+  createApp({
+    meta: new SqliteMetaStore(dbPath),
+    blobs: new FsBlobStore(join(dir, "blobs")),
+    baseUrl: BASE,
+    auth: makeAuth(db, BASE, secret),
+  })
+const app = appWith(SECRET)
+
+const signIn = (a: ReturnType<typeof createApp>, email: string) =>
+  a.request(`${BASE}/api/auth/sign-in/email`, {
+    method: "POST",
+    headers: { "content-type": "application/json", origin: BASE, cookie: "p=1" },
+    body: JSON.stringify({ email, password: "initialPassw0rd" }),
+  })
+const meAs = (cookie: string) => app.request(`${BASE}/v1/me`, { headers: { origin: BASE, cookie } })
+
+/** The `name=value` pair for a Set-Cookie whose name contains `part`. */
+const pair = (res: Response, part: string): string =>
+  res.headers
+    .getSetCookie()
+    .map((c) => c.split(";")[0] ?? "")
+    .find((p) => p.includes(part)) ?? ""
+const emailOf = async (res: Response): Promise<string | undefined> =>
+  res.status === 200 ? ((await res.json()) as { user?: { email?: string } }).user?.email : undefined
+
+const VICTIM = "victim@derive.test"
+const ATTACKER = "attacker@derive.test"
+let victimToken = ""
+let victimData = ""
+let attackerToken = ""
+
+afterAll(() => {
+  db.close()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe("the session cookie cache resists tampering", () => {
+  it("issues an HttpOnly session-data cookie alongside the token", async () => {
+    await migrateAuth(makeAuth(db, BASE, SECRET))
+    for (const email of [VICTIM, ATTACKER]) {
+      const up = await app.request(`${BASE}/api/auth/sign-up/email`, {
+        method: "POST",
+        headers: { "content-type": "application/json", origin: BASE, cookie: "p=1" },
+        body: JSON.stringify({ email, password: "initialPassw0rd", name: email }),
+      })
+      expect(up.status).toBe(200)
+    }
+    const v = await signIn(app, VICTIM)
+    const a = await signIn(app, ATTACKER)
+    victimToken = pair(v, "session_token")
+    victimData = pair(v, "session_data")
+    attackerToken = pair(a, "session_token")
+    expect(victimData).not.toBe("")
+    // HttpOnly is what makes the cross-account note below an accepted property rather than a
+    // hole: script on the page cannot read this cookie any more than it can read the token.
+    const raw = v.headers.getSetCookie().find((c) => c.includes("session_data")) ?? ""
+    expect(raw).toContain("HttpOnly")
+    expect(await emailOf(await meAs(`${victimToken}; ${victimData}`))).toBe(VICTIM)
+  })
+
+  it("is not a credential on its own — no session token, no identity", async () => {
+    expect((await meAs(victimData)).status).toBe(401)
+  })
+
+  it("EDITING the payload never yields a different identity", async () => {
+    const [name = "", value = ""] = victimData.split(/=(.*)/s)
+    const decoded = decodeURIComponent(value)
+    const edited = decoded.includes(VICTIM) ? decoded.replaceAll(VICTIM, ATTACKER) : `${decoded}x`
+    const res = await meAs(`${victimToken}; ${name}=${encodeURIComponent(edited)}`)
+    // Falling back to the database on a bad signature is fine; becoming someone else is not.
+    if (res.status === 200) expect(await emailOf(res)).toBe(VICTIM)
+    else expect([401, 403]).toContain(res.status)
+  })
+
+  it("a MALFORMED payload is a clean 401 or a fallback — never a 500", async () => {
+    const [name = ""] = victimData.split("=")
+    const value = victimData.slice(name.length + 1)
+    const broken = [
+      value.slice(0, Math.floor(value.length / 2)), // truncated
+      `${value}AAAA`, // appended garbage
+      "", // empty
+      "null",
+      "%7B%7D", // `{}` — the one that used to throw out of getSession and 500 the request
+      "%5B%5D", // `[]`
+      "not-base64-at-all",
+    ]
+    for (const bad of broken) {
+      const res = await meAs(`${victimToken}; ${name}=${bad}`)
+      expect(
+        res.status,
+        `payload ${JSON.stringify(bad.slice(0, 16))} returned ${res.status}`,
+      ).not.toBe(500)
+      if (res.status === 200) expect(await emailOf(res)).toBe(VICTIM)
+    }
+  })
+
+  it("a payload minted under a DIFFERENT secret is refused", async () => {
+    // Same database, another deployment's secret: a preview, a rotated key, a self-host sharing
+    // storage. Its cached payload must not authenticate here.
+    const foreign = appWith("another-secret-0123456789ab")
+    const foreignData = pair(await signIn(foreign, VICTIM), "session_data")
+    if (!foreignData) return // that deployment issued no cache cookie; nothing to replay
+    expect((await meAs(foreignData)).status).toBe(401)
+  })
+
+  it("cross-account mixing resolves to the CACHED account, and both cookies are HttpOnly", async () => {
+    // Recorded, not celebrated. Reaching this requires already holding the victim's HttpOnly
+    // session_data, and anyone who can read that can read the victim's HttpOnly session_token —
+    // which impersonates them without touching the cache at all. If session_data ever stops
+    // being HttpOnly, this test is where that becomes a real finding.
+    const who = await emailOf(await meAs(`${attackerToken}; ${victimData}`))
+    expect(who === VICTIM || who === ATTACKER).toBe(true)
+  })
+})

--- a/apps/api/test/auth-session-cache-tamper.test.ts
+++ b/apps/api/test/auth-session-cache-tamper.test.ts
@@ -33,7 +33,7 @@ const dir = mkdtempSync(join(tmpdir(), "derive-cache-tamper-"))
 const dbPath = join(dir, "auth.db")
 const db = new Database(dbPath)
 const BASE = "http://localhost:8080"
-const SECRET = "tamper-secret-0123456789abcd"
+const SECRET = "tamper-secret-at-least-16-chars"
 
 const appWith = (secret: string) =>
   createApp({
@@ -135,7 +135,7 @@ describe("the session cookie cache resists tampering", () => {
   it("a payload minted under a DIFFERENT secret is refused", async () => {
     // Same database, another deployment's secret: a preview, a rotated key, a self-host sharing
     // storage. Its cached payload must not authenticate here.
-    const foreign = appWith("another-secret-0123456789ab")
+    const foreign = appWith("another-secret-at-least-16-chars")
     const foreignData = pair(await signIn(foreign, VICTIM), "session_data")
     if (!foreignData) return // that deployment issued no cache cookie; nothing to replay
     expect((await meAs(foreignData)).status).toBe(401)

--- a/apps/api/test/auth-session-cache.test.ts
+++ b/apps/api/test/auth-session-cache.test.ts
@@ -1,0 +1,116 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { SqliteMetaStore } from "@derive/db/sqlite"
+import { FsBlobStore } from "@derive/storage/fs"
+import Database from "better-sqlite3"
+import { afterAll, describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { makeAuth, migrateAuth } from "../src/auth-config"
+
+/**
+ * THE SESSION COOKIE CACHE, against a REAL Better Auth instance — the fake-session harness
+ * (`x-test-user`) cannot see any of this, which is exactly why it needs its own test.
+ *
+ * Resolving a cookie session was measured at 330-500ms on EVERY authenticated request on the
+ * hosted edge, isolated by holding the route fixed and changing only the credential:
+ *
+ *   /v1/artifacts?limit=1   bearer 729ms   cookie 1233ms   (+503)
+ *   /v1/automations         bearer 333ms   cookie  664ms   (+331)
+ *
+ * With the cache on, Better Auth signs the session into a short-lived cookie and answers from
+ * it without touching the database.
+ *
+ * PROVING THAT WITHOUT A STOPWATCH: delete the session ROW, then make a request. If the caller
+ * is still authenticated, nothing read the session table — there is nothing left to read. The
+ * same assertion is also the honest statement of the trade: for the length of the window, a
+ * revoked session still works. The second case pins that the window actually closes, which is
+ * the property that makes it acceptable.
+ */
+const dir = mkdtempSync(join(tmpdir(), "derive-session-cache-"))
+const dbPath = join(dir, "auth.db")
+const db = new Database(dbPath)
+
+const BASE = "http://localhost:8080"
+const auth = makeAuth(db, BASE, "test-secret-0123456789abcd")
+const app = createApp({
+  meta: new SqliteMetaStore(dbPath),
+  blobs: new FsBlobStore(join(dir, "blobs")),
+  baseUrl: BASE,
+  auth,
+})
+
+const post = (path: string, body: unknown, cookie = "derive_probe=1") =>
+  app.request(`${BASE}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", origin: BASE, cookie },
+    body: JSON.stringify(body),
+  })
+const get = (path: string, cookie: string) =>
+  app.request(`${BASE}${path}`, { headers: { origin: BASE, cookie } })
+
+/** Every Set-Cookie folded into one request-ready Cookie header. */
+const cookiesOf = (res: Response): string =>
+  res.headers
+    .getSetCookie()
+    .map((c) => c.split(";")[0])
+    .join("; ")
+
+afterAll(() => {
+  db.close()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe("the session cookie cache", () => {
+  const email = "cache@derive.test"
+  let cookie = ""
+
+  it("migrates and signs up", async () => {
+    await migrateAuth(auth)
+    const res = await post("/api/auth/sign-up/email", {
+      email,
+      password: "initialPassw0rd",
+      name: "Cache",
+    })
+    expect(res.status).toBe(200)
+  })
+
+  it("issues a session-data cookie alongside the session token", async () => {
+    const res = await post("/api/auth/sign-in/email", { email, password: "initialPassw0rd" })
+    expect(res.status).toBe(200)
+    cookie = cookiesOf(res)
+    // The cache is what makes the DB-free path possible; without this cookie the rest of the
+    // feature is inert, which is precisely how an earlier attempt at this failed silently.
+    expect(cookie).toContain("session_data")
+    expect(cookie).toContain("session_token")
+  })
+
+  it("still authenticates after the session ROW is deleted — nothing read the table", async () => {
+    const before = await get("/v1/me", cookie)
+    expect(before.status).toBe(200)
+
+    // Remove every session row. A request that still resolves a user cannot have consulted them.
+    const removed = db.prepare("delete from session").run()
+    expect(removed.changes).toBeGreaterThan(0)
+    expect(db.prepare("select count(*) as n from session").get()).toEqual({ n: 0 })
+
+    const after = await get("/v1/me", cookie)
+    expect(after.status).toBe(200)
+    expect(await after.json()).toMatchObject({ user: { email } })
+  })
+
+  it("refuses once the cached cookie is gone — the window is bounded, not a bypass", async () => {
+    // The cache is a cookie with a maxAge; dropping it is what its expiry does. With the rows
+    // already deleted, the request must now fail closed rather than fall through to a stale
+    // identity — this is the half that makes the trade acceptable.
+    const tokenOnly = cookie
+      .split("; ")
+      .filter((c) => !c.startsWith("__Secure-better-auth.session_data"))
+      .filter((c) => !c.startsWith("better-auth.session_data"))
+      .join("; ")
+    expect(tokenOnly).not.toContain("session_data")
+
+    const res = await get("/v1/me", tokenOnly)
+    expect(res.status).toBe(401)
+  })
+})

--- a/apps/api/test/auth-shared-database.test.ts
+++ b/apps/api/test/auth-shared-database.test.ts
@@ -86,13 +86,17 @@ describe("a second deployment on the same database", () => {
     expect(await res.json()).toMatchObject({ user: { email } })
   })
 
-  it("DIFFERENT secret: signs in fine, then every authenticated request fails", async () => {
+  it("DIFFERENT secret: signs in fine, then never actually authenticates", async () => {
     const preview = appWith(OTHER_SECRET)
     // The trap: this succeeds, so a smoke test that stops at the login page reports healthy.
     const signIn = await post(preview, "/api/auth/sign-in/email", { email, password })
     expect(signIn.status).toBe(200)
-    // And this does not.
+    // And this does not. 401, not 500: getSession throwing means this request has no readable
+    // credential, which is the caller's problem to fix by signing in again — and a 500 here was
+    // sticky, since a client with a bad cookie has no reason to re-authenticate and just loops.
+    // The JWKS decrypt error itself is not lost; context.ts logs it at error level, which is
+    // where this misconfiguration has to stay findable.
     const res = await me(preview, cookiesOf(signIn))
-    expect(res.status).toBe(500)
+    expect(res.status).toBe(401)
   })
 })

--- a/apps/api/test/auth-shared-database.test.ts
+++ b/apps/api/test/auth-shared-database.test.ts
@@ -1,0 +1,98 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { SqliteMetaStore } from "@derive/db/sqlite"
+import { FsBlobStore } from "@derive/storage/fs"
+import Database from "better-sqlite3"
+import { afterAll, describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { makeAuth, migrateAuth } from "../src/auth-config"
+
+/**
+ * TWO DEPLOYMENTS, ONE DATABASE — the preview/staging contract.
+ *
+ * A preview Worker shares production's database on purpose (a preview you cannot sign into, or
+ * that shows an empty library, proves nothing). Whether that works turns on one thing that is
+ * easy to get wrong and fails in a thoroughly misleading way: sign-in SUCCEEDS with the wrong
+ * secret, and the failure only appears on the next request.
+ *
+ * Better Auth encrypts the JWKS private key with DERIVE_AUTH_SECRET and stores it in the shared
+ * database. A second deployment with a different secret cannot decrypt that row, and getSession
+ * throws — so every signed-in page 500s while the login page looks perfectly healthy.
+ *
+ * Observed exactly this on a real preview Worker: /healthz 200, /readyz 200, sign-in 200,
+ * /v1/artifacts 500. This test is why .github/workflows/pr-preview.yml refuses to deploy
+ * without DERIVE_AUTH_SECRET, and why its comment says the value must MATCH production's.
+ */
+const dir = mkdtempSync(join(tmpdir(), "derive-shared-db-"))
+const dbPath = join(dir, "auth.db")
+const db = new Database(dbPath)
+const BASE = "http://localhost:8080"
+
+const PROD_SECRET = "prod-secret-0123456789abcdef"
+const OTHER_SECRET = "other-secret-0123456789abcd"
+
+const appWith = (secret: string) =>
+  createApp({
+    meta: new SqliteMetaStore(dbPath),
+    blobs: new FsBlobStore(join(dir, "blobs")),
+    baseUrl: BASE,
+    auth: makeAuth(db, BASE, secret),
+  })
+
+const post = (app: ReturnType<typeof createApp>, path: string, body: unknown) =>
+  app.request(`${BASE}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", origin: BASE, cookie: "p=1" },
+    body: JSON.stringify(body),
+  })
+const cookiesOf = (res: Response) =>
+  res.headers
+    .getSetCookie()
+    .map((c) => c.split(";")[0])
+    .join("; ")
+const me = (app: ReturnType<typeof createApp>, cookie: string) =>
+  app.request(`${BASE}/v1/me`, { headers: { origin: BASE, cookie } })
+
+afterAll(() => {
+  db.close()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe("a second deployment on the same database", () => {
+  const email = "shared@derive.test"
+  const password = "initialPassw0rd"
+
+  it("production creates the user and the encrypted jwks row", async () => {
+    const prod = makeAuth(db, BASE, PROD_SECRET)
+    await migrateAuth(prod)
+    expect(
+      (await post(appWith(PROD_SECRET), "/api/auth/sign-up/email", { email, password, name: "S" }))
+        .status,
+    ).toBe(200)
+    // Force the row to exist — this is what a second deployment inherits.
+    await prod.api.getJwks()
+    expect((db.prepare("select count(*) as n from jwks").get() as { n: number }).n).toBeGreaterThan(
+      0,
+    )
+  })
+
+  it("SAME secret: signs in and reads the session — a preview works", async () => {
+    const preview = appWith(PROD_SECRET)
+    const signIn = await post(preview, "/api/auth/sign-in/email", { email, password })
+    expect(signIn.status).toBe(200)
+    const res = await me(preview, cookiesOf(signIn))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ user: { email } })
+  })
+
+  it("DIFFERENT secret: signs in fine, then every authenticated request fails", async () => {
+    const preview = appWith(OTHER_SECRET)
+    // The trap: this succeeds, so a smoke test that stops at the login page reports healthy.
+    const signIn = await post(preview, "/api/auth/sign-in/email", { email, password })
+    expect(signIn.status).toBe(200)
+    // And this does not.
+    const res = await me(preview, cookiesOf(signIn))
+    expect(res.status).toBe(500)
+  })
+})

--- a/apps/api/test/auth-shared-database.test.ts
+++ b/apps/api/test/auth-shared-database.test.ts
@@ -29,8 +29,11 @@ const dbPath = join(dir, "auth.db")
 const db = new Database(dbPath)
 const BASE = "http://localhost:8080"
 
-const PROD_SECRET = "prod-secret-0123456789abcdef"
-const OTHER_SECRET = "other-secret-0123456789abcd"
+// Two throwaway values standing in for two deployments' DERIVE_AUTH_SECRETs. Marked for the
+// secret scanner: the names are what trip its generic-api-key rule, and renaming them to satisfy
+// a scanner would cost the thing that makes this test readable.
+const PROD_SECRET = "prod-secret-at-least-16-chars" // gitleaks:allow
+const OTHER_SECRET = "other-secret-at-least-16-chars" // gitleaks:allow
 
 const appWith = (secret: string) =>
   createApp({

--- a/apps/api/test/authz-memoization.test.ts
+++ b/apps/api/test/authz-memoization.test.ts
@@ -1,56 +1,77 @@
+import type { MetaStore } from "@derive/core"
 import { describe, expect, it } from "vitest"
 import { as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 
 /**
  * ONE ACTOR RESOLUTION PER REQUEST, PER ARTIFACT.
  *
- * `authorize()` narrows the request's principal to an Actor for a specific artifact, and that
- * costs three round trips: the workspace membership, the per-artifact share, and the collection
- * shares. Handlers routinely authorize the same artifact more than once — opening a chat session
- * checks `read` and then `publish` — and `actorFor` was not memoized, so each check paid for all
- * three again.
+ * `authorize()` narrows the request's principal to an Actor for a specific artifact. On a store
+ * without the `artifactGrants` fast path that costs three reads (workspace membership, the
+ * per-artifact share, the collection shares — and the last is itself two queries); with it, one.
+ * Either way handlers authorize the same artifact repeatedly: opening a chat session checks
+ * `read`, then membership, then `publish`. `actorFor` was not memoized, so each check paid again.
  *
- * Counted on the real handler before the fix: eleven sequential queries for one chat POST, with
- * the same membership row fetched THREE times (twice inside authorize, once explicitly) and the
- * artifact-member and collection-role rows twice each. On the hosted edge each of those is
- * ~100-900ms, because the isolate and Postgres are in different regions.
+ * Counted on the real handler before the fix: thirteen sequential queries for one chat POST,
+ * with the same membership row fetched three times. On the hosted edge each is ~100-900ms,
+ * because the isolate and Postgres sit in different regions.
  *
- * This pins the dedup at the store boundary — where the cost actually is — rather than asserting
- * on a cache's internals.
+ * Asserted at the STORE BOUNDARY, where the cost is, and counted through a `get`-level Proxy
+ * rather than by patching methods — the pg test store is itself a Proxy deferring to an
+ * async-created store, so assigning over its methods silently counts nothing. That is how the
+ * first version of this test passed on SQLite while measuring nothing at all on Postgres.
  */
 const owner: TestUser = { id: "u_memo_own", email: "memo@derive.test", name: "Owner" }
-const { app, meta } = makeAuthedApp("authz-memo", [owner])
 
-/** Count calls to the three reads an Actor resolution makes, in place: `createApp` captured this
- *  exact object, so patching its methods is what the handler will call. */
-const countCalls = () => {
-  const counts = { membership: 0, artifactMember: 0, collectionRoles: 0 }
-  const m = meta as unknown as Record<string, (...a: unknown[]) => unknown>
-  for (const [key, name] of [
-    ["getMembership", "membership"],
-    ["getArtifactMember", "artifactMember"],
-    ["collectionRolesForArtifact", "collectionRoles"],
-  ] as const) {
-    const original = m[key]?.bind(meta)
-    if (!original) throw new Error(`store has no ${key}`)
-    m[key] = (...args: unknown[]) => {
-      counts[name] += 1
-      return original(...args)
-    }
+const COUNTED = [
+  "getMembership",
+  "getArtifactMember",
+  "collectionRolesForArtifact",
+  "artifactGrants",
+] as const
+type Counted = (typeof COUNTED)[number]
+
+const counting = (inner: MetaStore) => {
+  const counts: Record<Counted, number> = {
+    getMembership: 0,
+    getArtifactMember: 0,
+    collectionRolesForArtifact: 0,
+    artifactGrants: 0,
   }
-  return counts
+  const proxy = new Proxy(inner, {
+    get(target, prop, recv) {
+      const value = Reflect.get(target, prop, recv)
+      if (!COUNTED.includes(prop as Counted) || typeof value !== "function") return value
+      return (...args: unknown[]) => {
+        counts[prop as Counted] += 1
+        return (value as (...a: unknown[]) => unknown).apply(target, args)
+      }
+    },
+  })
+  return { proxy, counts }
 }
 
-describe("actor resolution is memoized per request", () => {
-  it("authorizing the same artifact twice reads each permission row once", async () => {
-    // chat-session is the handler that motivated this: it authorizes `read`, then `publish`.
-    const settings = await meta.getOrgSettings("default")
-    await meta.setOrgSettings("default", { ...settings, chatBeta: true })
+// The first app owns the store; the second drives the request through a counting wrapper around
+// that same store, so both see identical data.
+//
+// The probe app takes its OWN name deliberately. Two apps sharing a name share a Postgres schema,
+// and each `makeAuthedApp` races to CREATE it — "duplicate key value violates unique constraint
+// pg_namespace_nspname_index". Its own store is then built and never used, because `deps.meta`
+// overrides it with the wrapper below; only the schema name has to differ.
+const base = makeAuthedApp("authz-memo", [owner])
+const { proxy, counts } = counting(base.meta as MetaStore)
+const { app } = makeAuthedApp("authz-memo-probe", [owner], undefined, { deps: { meta: proxy } })
 
-    const published = await publishAs(app, "# Memo\n\n## One\n\nBody.\n", {}, as(owner.email))
+describe("actor resolution is memoized per request", () => {
+  it("authorizing an artifact repeatedly resolves its Actor once", async () => {
+    // chat-session is the handler that motivated this: it authorizes `read`, checks membership,
+    // then authorizes `publish` — three questions about the same artifact.
+    const settings = await base.meta.getOrgSettings("default")
+    await base.meta.setOrgSettings("default", { ...settings, chatBeta: true })
+
+    const published = await publishAs(base.app, "# Memo\n\n## One\n\nBody.\n", {}, as(owner.email))
     const { short_id } = (await published.json()) as { short_id: string }
 
-    const counts = countCalls()
+    for (const k of COUNTED) counts[k] = 0
     const res = await app.request(
       "/v1/artifacts/chat-session",
       jsonAs(as(owner.email), { short_id, body_md: "How many sections?", mode: "publish" }),
@@ -59,11 +80,22 @@ describe("actor resolution is memoized per request", () => {
     // editing — the authorization work under test happens before either way.
     expect(res.status).toBe(201)
 
-    // Each permission row: fetched once, however many times the handler authorizes.
-    expect(counts.artifactMember).toBe(1)
-    expect(counts.collectionRoles).toBe(1)
-    // Membership too: the route's own member check now reads the resolved actor instead of
-    // querying again, so ONE read covers the authorize and the check.
-    expect(counts.membership).toBe(1)
+    // The store WAS consulted. A zero here means the wrapper missed, not that the cache worked —
+    // which is exactly how this test previously lied on Postgres.
+    const total = COUNTED.reduce((n, k) => n + counts[k], 0)
+    expect(total, "counting proxy saw no permission reads at all").toBeGreaterThan(0)
+
+    if (counts.artifactGrants > 0) {
+      // Fast path: one call answers everything, and the reads it replaces stay untouched.
+      expect(counts.artifactGrants).toBe(1)
+      expect(counts.getMembership).toBe(0)
+      expect(counts.getArtifactMember).toBe(0)
+      expect(counts.collectionRolesForArtifact).toBe(0)
+    } else {
+      // Fallback path: each permission row read exactly once for the whole request.
+      expect(counts.getMembership).toBe(1)
+      expect(counts.getArtifactMember).toBe(1)
+      expect(counts.collectionRolesForArtifact).toBe(1)
+    }
   })
 })

--- a/apps/api/test/authz-memoization.test.ts
+++ b/apps/api/test/authz-memoization.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import { as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+/**
+ * ONE ACTOR RESOLUTION PER REQUEST, PER ARTIFACT.
+ *
+ * `authorize()` narrows the request's principal to an Actor for a specific artifact, and that
+ * costs three round trips: the workspace membership, the per-artifact share, and the collection
+ * shares. Handlers routinely authorize the same artifact more than once — opening a chat session
+ * checks `read` and then `publish` — and `actorFor` was not memoized, so each check paid for all
+ * three again.
+ *
+ * Counted on the real handler before the fix: eleven sequential queries for one chat POST, with
+ * the same membership row fetched THREE times (twice inside authorize, once explicitly) and the
+ * artifact-member and collection-role rows twice each. On the hosted edge each of those is
+ * ~100-900ms, because the isolate and Postgres are in different regions.
+ *
+ * This pins the dedup at the store boundary — where the cost actually is — rather than asserting
+ * on a cache's internals.
+ */
+const owner: TestUser = { id: "u_memo_own", email: "memo@derive.test", name: "Owner" }
+const { app, meta } = makeAuthedApp("authz-memo", [owner])
+
+/** Count calls to the three reads an Actor resolution makes, in place: `createApp` captured this
+ *  exact object, so patching its methods is what the handler will call. */
+const countCalls = () => {
+  const counts = { membership: 0, artifactMember: 0, collectionRoles: 0 }
+  const m = meta as unknown as Record<string, (...a: unknown[]) => unknown>
+  for (const [key, name] of [
+    ["getMembership", "membership"],
+    ["getArtifactMember", "artifactMember"],
+    ["collectionRolesForArtifact", "collectionRoles"],
+  ] as const) {
+    const original = m[key]?.bind(meta)
+    if (!original) throw new Error(`store has no ${key}`)
+    m[key] = (...args: unknown[]) => {
+      counts[name] += 1
+      return original(...args)
+    }
+  }
+  return counts
+}
+
+describe("actor resolution is memoized per request", () => {
+  it("authorizing the same artifact twice reads each permission row once", async () => {
+    // chat-session is the handler that motivated this: it authorizes `read`, then `publish`.
+    const settings = await meta.getOrgSettings("default")
+    await meta.setOrgSettings("default", { ...settings, chatBeta: true })
+
+    const published = await publishAs(app, "# Memo\n\n## One\n\nBody.\n", {}, as(owner.email))
+    const { short_id } = (await published.json()) as { short_id: string }
+
+    const counts = countCalls()
+    const res = await app.request(
+      "/v1/artifacts/chat-session",
+      jsonAs(as(owner.email), { short_id, body_md: "How many sections?", mode: "publish" }),
+    )
+    // No model is configured in tests, so the turn answers in the transcript rather than
+    // editing — the authorization work under test happens before either way.
+    expect(res.status).toBe(201)
+
+    // Each permission row: fetched once, however many times the handler authorizes.
+    expect(counts.artifactMember).toBe(1)
+    expect(counts.collectionRoles).toBe(1)
+    // Membership is also read directly by the route (a membership check that is not an
+    // authorize), so one resolution plus that explicit read.
+    expect(counts.membership).toBeLessThanOrEqual(2)
+  })
+})

--- a/apps/api/test/authz-memoization.test.ts
+++ b/apps/api/test/authz-memoization.test.ts
@@ -62,8 +62,8 @@ describe("actor resolution is memoized per request", () => {
     // Each permission row: fetched once, however many times the handler authorizes.
     expect(counts.artifactMember).toBe(1)
     expect(counts.collectionRoles).toBe(1)
-    // Membership is also read directly by the route (a membership check that is not an
-    // authorize), so one resolution plus that explicit read.
-    expect(counts.membership).toBeLessThanOrEqual(2)
+    // Membership too: the route's own member check now reads the resolved actor instead of
+    // querying again, so ONE read covers the authorize and the check.
+    expect(counts.membership).toBe(1)
   })
 })

--- a/apps/api/test/hosted-dispatch.test.ts
+++ b/apps/api/test/hosted-dispatch.test.ts
@@ -581,3 +581,69 @@ describe("the ask lane gives up rather than paying forever", () => {
     expect((await meta.getSession(session.id))?.state).toBe("failed")
   })
 })
+
+describe("the unattended lane on a deployment that holds the model key", () => {
+  // THE REGRESSION. A gateway (DERIVE_MODEL_BASE_URL/_API_KEY/_NAME) means the operator pays for
+  // every workspace on the deployment, so no workspace connects a plan and findPayer correctly
+  // finds nobody. The attended lane and the manual lane both short-circuit on that; the schedule
+  // materializer did not, so on derive.to every cron occurrence was silently dropped — `Run now`
+  // worked, the clock never did, and nothing surfaced it because the only signal was a log line.
+  it("materializes a due schedule when the operator pays, and skips it when nobody can", async () => {
+    const auto = await mkAutomation({
+      // Always due: the previous occurrence of an every-minute cron is never more than a minute
+      // old, so one pass is enough and the test needs no clock travel.
+      trigger: { kind: "schedule", cron: "* * * * *" },
+      instruction: "Keep the roadmap current.",
+    })
+    const mine = async () =>
+      (await meta.listRuns("default", 200)).filter((r) => r.automation_id === auto.id)
+
+    // A workspace on a hosted deployment connects NOTHING: `GET /v1/plans` returns `[]`, which
+    // is the observed state on derive.to. Simulate that at the store boundary so every payer
+    // tier — initiator, owner-lend, pool — genuinely comes up empty.
+    const noPlans = Object.create(meta) as typeof meta
+    noPlans.listModelCredentials = async () => []
+
+    // Without a gateway, refusing is correct: this is the guard doing its job.
+    const { substrate } = fakeSubstrate()
+    const refused = await dispatchPass({ ...deps(substrate), meta: noPlans, operatorPays: false })
+    expect(refused.materialized).toBe(0)
+    expect(await mine()).toHaveLength(0)
+
+    // Same workspace, same empty plan list, but the operator holds the key. The occurrence must
+    // materialize: there is no chain to walk and nothing for anyone to connect.
+    const res = await dispatchPass({ ...deps(substrate), meta: noPlans, operatorPays: true })
+    expect(res.materialized).toBeGreaterThanOrEqual(1)
+    const runs = await mine()
+    expect(runs).toHaveLength(1)
+    expect(runs[0]?.reason).toBe("schedule")
+
+    // Still idempotent inside the window — paying for everyone must not mean firing every tick.
+    await dispatchPass({ ...deps(substrate), meta: noPlans, operatorPays: true })
+    expect(await mine()).toHaveLength(1)
+  })
+
+  it("still obeys automateBeta when the operator pays — the gate is not a payer question", async () => {
+    const auto = await mkAutomation({
+      trigger: { kind: "schedule", cron: "* * * * *" },
+      instruction: "Should never fire with the beta off.",
+    })
+    const patched = await app.request("/v1/workspace/settings", {
+      method: "PATCH",
+      headers: { "content-type": "application/json", ...as(owner.email) },
+      body: JSON.stringify({ automateBeta: false }),
+    })
+    expect(patched.status).toBeLessThan(300)
+
+    const { substrate } = fakeSubstrate()
+    await dispatchPass({ ...deps(substrate), operatorPays: true })
+    const runs = (await meta.listRuns("default", 200)).filter((r) => r.automation_id === auto.id)
+    expect(runs).toHaveLength(0)
+
+    await app.request("/v1/workspace/settings", {
+      method: "PATCH",
+      headers: { "content-type": "application/json", ...as(owner.email) },
+      body: JSON.stringify({ automateBeta: true }),
+    })
+  })
+})

--- a/apps/api/test/session-turn.test.ts
+++ b/apps/api/test/session-turn.test.ts
@@ -435,3 +435,32 @@ describe("a document too large for a whole-document reply uses EDITS", () => {
     expect((await meta.getArtifactById("a1"))?.current_version).toBe(1)
   })
 })
+
+describe("what filename attended chat SHOWS the model", () => {
+  // The same upstream bug the run lane had: the prompt named the document by bare short_id
+  // ("doc1"), which carries no format signal, so a model asked to name its output guessed and
+  // the edits contract's fallback made that guess index.html. Correcting the content type on
+  // the way out does not cover this — a model that believes it is editing an extensionless file
+  // will also write HTML into a Markdown document's BODY.
+  it("names a markdown document doc1.md in the prompt", async () => {
+    const { meta, blobs, artifact } = await setup()
+    let system = ""
+    const d = deps(meta, blobs, revision())
+    const spy: typeof d = {
+      ...d,
+      callModel: async (input) => {
+        system = input.system ?? ""
+        return { text: revision(), toolUses: [], costUsd: null, done: true }
+      },
+    }
+    await runSessionTurn(spy, {
+      session: session(),
+      subject: { kind: "artifact", id: "doc1" },
+      artifact,
+      transcript: transcript("tighten the intro"),
+      flags: FLAGS,
+      onBehalf: ED,
+    })
+    expect(system).toContain("its filename is doc1.md")
+  })
+})

--- a/apps/api/test/substrate-loop.test.ts
+++ b/apps/api/test/substrate-loop.test.ts
@@ -42,6 +42,8 @@ const stubApi = (opts: {
   content?: string
   /** Status for that read — 404/500 exercises the unreadable-target path. */
   contentStatus?: number
+  /** What the artifact RECORD reports as its stored type (the thing a revision must preserve). */
+  artifactContentType?: string
   /** Per-provider credentials. Default: a claude-code api key, which is what every pre-existing
    *  test in this file implicitly assumed while injecting `callModel` over the top of it. */
   credentials?: Record<string, StubCredential>
@@ -95,8 +97,20 @@ const stubApi = (opts: {
           rec.reads.push(url)
           const status = opts.contentStatus ?? 200
           if (status >= 400) return send(status, { error: "nope" })
-          res.writeHead(200, { "content-type": "text/markdown" })
+          // AS PRODUCTION SERVES IT. /content returns text/plain for EVERY artifact so the bytes
+          // render as text instead of executing in a browser — the header is the transport's,
+          // not the document's. This stub used to answer text/markdown, which made a fix that
+          // read the header look correct here while doing nothing at all in production.
+          res.writeHead(200, { "content-type": "text/plain; charset=utf-8" })
           return res.end(opts.content ?? "# Roadmap\n\n## Now\nShip the thing.\n")
+        }
+        // The artifact RECORD, which carries the type the document is actually stored as.
+        if (/\/v1\/artifacts\/[^/]+$/.test(url) && req.method === "GET") {
+          return send(200, {
+            short_id: "art_1",
+            current_content_type: opts.artifactContentType ?? "text/markdown",
+            current_version: 1,
+          })
         }
         if (url.endsWith("/finish")) {
           rec.finishes.push(JSON.parse(body || "{}"))

--- a/apps/api/test/substrate-loop.test.ts
+++ b/apps/api/test/substrate-loop.test.ts
@@ -22,6 +22,9 @@ interface Recorded {
   finishes: Record<string, unknown>[]
   /** Artifact content GETs — the run lane must read its target before revising it. */
   reads: string[]
+  /** GETs of the artifact RECORD. Should stay EMPTY: the document's type rides a header on
+   *  the content read, so wanting it must not cost a second request. */
+  recordReads: string[]
   /** Every `/v1/agent/model-credential` query the substrate made, in order. WHICH PROVIDER it
    *  asks about, and whether it asks a second time, is behaviour under test. */
   credentialQueries: string[]
@@ -56,6 +59,7 @@ const stubApi = (opts: {
     writes: [],
     finishes: [],
     reads: [],
+    recordReads: [],
     credentialQueries: [],
   }
   let server: Server
@@ -97,15 +101,22 @@ const stubApi = (opts: {
           rec.reads.push(url)
           const status = opts.contentStatus ?? 200
           if (status >= 400) return send(status, { error: "nope" })
-          // AS PRODUCTION SERVES IT. /content returns text/plain for EVERY artifact so the bytes
-          // render as text instead of executing in a browser — the header is the transport's,
-          // not the document's. This stub used to answer text/markdown, which made a fix that
-          // read the header look correct here while doing nothing at all in production.
-          res.writeHead(200, { "content-type": "text/plain; charset=utf-8" })
+          // AS PRODUCTION SERVES IT. `Content-Type` is text/plain for EVERY artifact so the
+          // bytes render as text instead of executing in a browser — it is the transport's, not
+          // the document's. The DOCUMENT's type rides X-Derive-Content-Type alongside the other
+          // X-Derive-* headers the route already emits. This stub used to answer text/markdown
+          // on Content-Type, which made a fix that read the wrong header look correct here while
+          // doing nothing at all in production.
+          res.writeHead(200, {
+            "content-type": "text/plain; charset=utf-8",
+            "x-derive-content-type": opts.artifactContentType ?? "text/markdown",
+          })
           return res.end(opts.content ?? "# Roadmap\n\n## Now\nShip the thing.\n")
         }
-        // The artifact RECORD, which carries the type the document is actually stored as.
+        // A read of the artifact RECORD. Recorded so a test can assert the loop does NOT need
+        // one: the type comes back on the content read, which the run already makes.
         if (/\/v1\/artifacts\/[^/]+$/.test(url) && req.method === "GET") {
+          rec.recordReads.push(url)
           return send(200, {
             short_id: "art_1",
             current_content_type: opts.artifactContentType ?? "text/markdown",
@@ -1129,6 +1140,43 @@ describe("what filename the model is SHOWN", () => {
       })
       expect(systemSeen).toContain("its filename is art_1.md")
       expect(systemSeen).not.toContain("its filename is art_1\n")
+    } finally {
+      await api.close()
+    }
+  })
+})
+
+describe("what the run READS to learn the document's format", () => {
+  // The type is needed to preserve it on the write. The first working version of that fix
+  // fetched the artifact RECORD for it — a whole extra request per run, re-running auth and
+  // re-reading a row the content route already had in hand and used six lines later. It also
+  // answered with the artifact's CURRENT type, which is the wrong answer for a `?v=N` read.
+  //
+  // It rides X-Derive-Content-Type on the content read instead, next to the X-Derive-* headers
+  // that route already emits. This pins that it stays free.
+  it("learns it from the content read, without a second request", async () => {
+    const api = stubApi({ run: baseRun, artifactContentType: "text/markdown" })
+    const url = await api.url
+    try {
+      const settled = await runToSettle(
+        url,
+        api.rec,
+        answerTurn(
+          `<revision>${JSON.stringify({
+            content: "# Roadmap\n\n## Now\nShip it.\n\n## Status\nDone.\n",
+            filename: "index.html",
+            confidence: 0.95,
+            message: "m",
+          })}</revision>`,
+        ),
+      )
+      expect(settled).toBeTruthy()
+      // It read the content exactly once...
+      expect(api.rec.reads.length).toBe(1)
+      // ...never asked for the record...
+      expect(api.rec.recordReads).toEqual([])
+      // ...and still preserved the format.
+      for (const w of api.rec.writes) expect(w.name).toMatch(/\.md$/i)
     } finally {
       await api.close()
     }

--- a/apps/api/test/substrate-loop.test.ts
+++ b/apps/api/test/substrate-loop.test.ts
@@ -1094,3 +1094,29 @@ describe("the revised document KEEPS its own format", () => {
     }
   })
 })
+
+describe("what filename the model is SHOWN", () => {
+  // The upstream half of the content-type bug. Both lanes passed a bare short_id, so the prompt
+  // said "its filename is art_1" — no extension, no format signal. Asked to name its output the
+  // model guessed, and the edits contract's fallback made that guess index.html. That is why the
+  // flip was intermittent rather than constant: it depended on what the model felt like naming.
+  //
+  // Correcting the type on the way out (landOverHttp) is not a substitute. A model that believes
+  // it is editing an extensionless file will also write HTML into a Markdown document's BODY,
+  // and no amount of re-stamping the content type afterwards undoes that.
+  it("tells the model a markdown target's name ends in .md", async () => {
+    const api = stubApi({ run: baseRun, content: "# Roadmap\n\n## Now\nShip it.\n" })
+    const url = await api.url
+    let systemSeen = ""
+    try {
+      await runToSettle(url, api.rec, async (input) => {
+        systemSeen = input.system ?? ""
+        return { text: revision(), toolUses: [], costUsd: 0.001, done: true }
+      })
+      expect(systemSeen).toContain("its filename is art_1.md")
+      expect(systemSeen).not.toContain("its filename is art_1\n")
+    } finally {
+      await api.close()
+    }
+  })
+})

--- a/apps/api/test/substrate-loop.test.ts
+++ b/apps/api/test/substrate-loop.test.ts
@@ -957,3 +957,58 @@ describe("loop substrate: resolving the model credential", () => {
     await api.close()
   })
 })
+
+describe("how the loop REACHES the API", () => {
+  // THE REGRESSION. This substrate is an HTTP client of its own deployment. On Node that is a
+  // loopback call and global fetch is right; on Workers it exits the isolate, crosses the edge
+  // and comes back to the SAME Worker. One run survived that. The cron tick starting three at
+  // once did not: every self-subrequest sat until it timed out, so each scheduled run died on
+  // `/v1/agent/runs/claim failed (522)` while a run booted from the queue nudge succeeded —
+  // which is exactly the shape that makes it look like the schedule lane is broken.
+  //
+  // Guarded by making global fetch a landmine: if anything in the loop stops honouring
+  // `fetchImpl`, the run cannot complete.
+  it("uses the injected transport for EVERY call, never global fetch", async () => {
+    const api = stubApi({ run: baseRun })
+    const url = await api.url
+    const realFetch = globalThis.fetch
+    const seen: string[] = []
+    globalThis.fetch = (async () => {
+      throw new Error("global fetch used: on Workers this is a self-subrequest and times out")
+    }) as typeof fetch
+    try {
+      await loopSubstrate({
+        callModel: answerTurn(revision()),
+        fetchImpl: (req) => {
+          seen.push(new URL(req.url).pathname)
+          return realFetch(req)
+        },
+      }).start({ runId: "run_1", token: "tok", server: url })
+
+      const deadline = Date.now() + 10_000
+      while (api.rec.finishes.length === 0 && Date.now() < deadline)
+        await new Promise((r) => setTimeout(r, 20))
+
+      // It ran to completion without global fetch ever being reachable...
+      expect(api.rec.finishes).toHaveLength(1)
+      // ...and the claim in particular — the call that 522'd in production — went through the
+      // injected transport.
+      expect(seen).toContain("/v1/agent/runs/claim")
+      expect(seen.length).toBeGreaterThan(1)
+    } finally {
+      globalThis.fetch = realFetch
+      await api.close()
+    }
+  })
+
+  it("falls back to global fetch when no transport is injected — Node keeps working", async () => {
+    const api = stubApi({ run: baseRun })
+    const url = await api.url
+    try {
+      const settled = await runToSettle(url, api.rec, answerTurn(revision()))
+      expect(settled).toBeTruthy()
+    } finally {
+      await api.close()
+    }
+  })
+})

--- a/apps/api/test/substrate-loop.test.ts
+++ b/apps/api/test/substrate-loop.test.ts
@@ -14,7 +14,11 @@ import { loopSubstrate } from "../src/lib/substrate-loop"
 interface Recorded {
   claims: number
   tools: { tool: string; args: unknown }[]
-  writes: { path: string }[]
+  /** What the substrate actually uploaded. `name` is the one that MATTERS: publish.ts derives
+   *  the stored content type from the filename EXTENSION and ignores the part's MIME type, so a
+   *  test that only checks `type` passes while the artifact still flips to HTML. Both are
+   *  recorded so the assertion is on the field the server reads. */
+  writes: { path: string; type: string | null; name: string | null }[]
   finishes: Record<string, unknown>[]
   /** Artifact content GETs — the run lane must read its target before revising it. */
   reads: string[]
@@ -99,7 +103,13 @@ const stubApi = (opts: {
           return send(200, { ok: true })
         }
         // Artifact writes: proposals, versions, create.
-        rec.writes.push({ path: url })
+        // Pull the file part's Content-Type straight out of the multipart body.
+        const part = /name="file"; filename="([^"]*)"[\s\S]*?Content-Type:\s*([^\r\n]+)/i.exec(body)
+        rec.writes.push({
+          path: url,
+          name: part?.[1] ?? null,
+          type: part?.[2]?.trim() ?? null,
+        })
         const status = opts.writeStatus ?? 201
         return send(status, status < 400 ? { short_id: "art_new" } : { error: "forbidden" })
       })
@@ -1007,6 +1017,78 @@ describe("how the loop REACHES the API", () => {
     try {
       const settled = await runToSettle(url, api.rec, answerTurn(revision()))
       expect(settled).toBeTruthy()
+    } finally {
+      await api.close()
+    }
+  })
+})
+
+describe("the revised document KEEPS its own format", () => {
+  // THE REGRESSION, and the third lane to need the same fix. Attended chat already learned this
+  // (lib/session-turn.ts): deriving the content type from the model's filename converts a
+  // Markdown document to HTML the moment the model omits or mangles the name, because the edits
+  // contract falls back to `index.html` — correct when CREATING an artifact, wrong when REVISING
+  // one. Observed on production, same document, same approval flow:
+  //
+  //     v1  text/markdown   upload
+  //     v2  text/markdown   chat edit          (already fixed)
+  //     v3  text/html       automation run     (this)
+  //
+  // At v3 the document stops rendering as markdown and reads as one unformatted blob, and
+  // nothing reports an error.
+  it("writes text/markdown for a markdown target even when the model says index.html", async () => {
+    const api = stubApi({ run: baseRun, content: "# Roadmap\n\n## Now\nShip it.\n" })
+    const url = await api.url
+    try {
+      // `filename: "index.html"` is exactly what the edits contract falls back to.
+      const settled = await runToSettle(
+        url,
+        api.rec,
+        answerTurn(
+          `<revision>${JSON.stringify({
+            content: "# Roadmap\n\n## Now\nShip it.\n\n## Status\nReviewed.\n",
+            filename: "index.html",
+            confidence: 0.95,
+            message: "m",
+          })}</revision>`,
+        ),
+      )
+      expect(settled).toBeTruthy()
+      expect(api.rec.writes.length).toBeGreaterThan(0)
+      // The target was served as text/markdown, so the revision must be written as markdown.
+      // The FILENAME is the assertion that matters — publish.ts reads the extension and ignores
+      // the part's MIME type, so checking only `type` would pass with the bug still present.
+      for (const w of api.rec.writes) {
+        expect(w.name).toMatch(/\.md$/i)
+        expect(w.type).toBe("text/markdown")
+      }
+    } finally {
+      await api.close()
+    }
+  })
+
+  it("still honours the filename when CREATING, where there is no document to keep", async () => {
+    // No artifact target: nothing to preserve, so the model's filename is the only signal.
+    const api = stubApi({ run: { ...baseRun, targets: [] } })
+    const url = await api.url
+    try {
+      const settled = await runToSettle(
+        url,
+        api.rec,
+        answerTurn(
+          `<revision>${JSON.stringify({
+            content: "<h1>New</h1>",
+            filename: "index.html",
+            confidence: 0.95,
+            message: "m",
+          })}</revision>`,
+        ),
+      )
+      expect(settled).toBeTruthy()
+      for (const w of api.rec.writes) {
+        expect(w.name).toBe("index.html")
+        expect(w.type).toBe("text/html")
+      }
     } finally {
       await api.close()
     }

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -661,6 +661,31 @@ export interface CollectionStore {
    *  artifact — folded into their effective artifact role (collection sharing). */
   collectionRolesForArtifact(artifactId: string, userId: string): Promise<Role[]>
 
+  /**
+   * OPTIONAL FAST PATH: every grant one user holds over one artifact, in ONE round trip.
+   *
+   * Narrowing a principal to an Actor needs the workspace membership, the per-artifact share and
+   * the collection shares — `getMembership` + `getArtifactMember` +
+   * `collectionRolesForArtifact` — and that last one is itself two queries. Four round trips to
+   * decide one boolean, on every authorize.
+   *
+   * Affordable when the database is local, ruinous when it is a region away: on the hosted edge
+   * each trip measured ~100-900ms, and one chat request spent most of a second on permission
+   * rows alone. A store that can answer this in a single statement implements it; one that
+   * cannot omits it and context.ts falls back to the four calls, so implementing it is always
+   * optional.
+   *
+   * It never changes the ANSWER. `can()` remains the only place a decision is made; this only
+   * changes how its inputs arrive. Returns exactly what the four calls would: the org role (null
+   * when not a member) and every artifact-level role — explicit and collection-derived —
+   * unreduced, so the caller folds them with maxRole as before.
+   */
+  artifactGrants?(
+    artifactId: string,
+    orgId: string,
+    userId: string,
+  ): Promise<{ orgRole: Role | null; artifactRoles: Role[] }>
+
   // ---- Folders (organize a collection's artifacts; inherit its access, grant nothing) --
   createFolder(f: NewFolder): Promise<FolderRecord>
   /** The folders belonging to a collection. Name order is a view concern. */

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1083,6 +1083,54 @@ export class PgMetaStore implements MetaStore {
   listArtifactMembers(artifactId: string): Promise<ArtifactMemberRecord[]> {
     return this.db.select().from(artifactMember).where(eq(artifactMember.artifact_id, artifactId))
   }
+  /**
+   * Every grant one user holds over one artifact, in ONE round trip — see MetaStore.
+   *
+   * A union of the four reads it replaces, tagged by source so the caller can tell an org role
+   * from an artifact role. Deliberately a union rather than joins: an artifact can sit in many
+   * collections, and joining would multiply the membership row across them, making the result
+   * depend on collection layout. Each arm returns its own rows; the caller reduces.
+   *
+   * The arms mirror, in order, getMembership, getArtifactMember, and the two halves of
+   * collectionRolesForArtifact — the explicit collection share, then the workspace-open
+   * collection that propagates the viewer's SEAT role. Change either of those and change this.
+   */
+  async artifactGrants(
+    artifactId: string,
+    orgId: string,
+    userId: string,
+  ): Promise<{ orgRole: Role | null; artifactRoles: Role[] }> {
+    const res = await this.db.execute(sql`
+      select 'org' as kind, m.role as role
+        from membership m
+       where m.org_id = ${orgId} and m.user_id = ${userId}
+      union all
+      select 'artifact' as kind, am.role as role
+        from artifact_member am
+       where am.artifact_id = ${artifactId} and am.user_id = ${userId}
+      union all
+      select 'artifact' as kind, cm.role as role
+        from collection_member cm
+        join collection_item ci on ci.collection_id = cm.collection_id
+       where ci.artifact_id = ${artifactId} and cm.user_id = ${userId}
+      union all
+      select 'artifact' as kind, m2.role as role
+        from collection_item ci2
+        join collection c on c.id = ci2.collection_id
+        join membership m2 on m2.org_id = c.org_id
+       where ci2.artifact_id = ${artifactId}
+         and c.workspace_access = 'member'
+         and m2.user_id = ${userId}
+    `)
+    const rows = (res as unknown as { rows?: { kind: string; role: Role }[] }).rows ?? []
+    let orgRole: Role | null = null
+    const artifactRoles: Role[] = []
+    for (const r of rows) {
+      if (r.kind === "org") orgRole = r.role
+      else artifactRoles.push(r.role)
+    }
+    return { orgRole, artifactRoles }
+  }
   async artifactRolesFor(userId: string, artifactIds: string[]): Promise<Record<string, Role>> {
     if (artifactIds.length === 0) return {}
     const rows = await this.db

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1,6 +1,6 @@
 import { randomUUID as uuid } from "node:crypto"
 import type { MetaStore, NewArtifact, NewRun, NewVersion, SortMode } from "@derive/core"
-import { DEFAULT_ORG_SETTINGS } from "@derive/core"
+import { DEFAULT_ORG_SETTINGS, maxRole } from "@derive/core"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
 
 /**
@@ -3113,6 +3113,92 @@ export function runStoreContract(
       // …and the rightful workspace can still remove it.
       await store.deletePlan(theirs.id, other)
       expect(await store.getPlan(theirs.id)).toBeNull()
+    })
+  })
+  // OPTIONAL FAST PATH. `artifactGrants` collapses four reads — membership, artifact share, and
+  // both halves of collectionRolesForArtifact — into one statement, and it is an authorization
+  // INPUT: a disagreement is not a slow page, it is someone seeing a document they should not,
+  // or losing one they own.
+  //
+  // So rather than assert hand-written expectations, run BOTH paths over the same fixtures and
+  // require them to agree. The four-read path is the specification. A store that does not
+  // implement the fast path skips this, which is what makes implementing it optional.
+  describe(`${label}: artifactGrants agrees with the four reads it replaces`, () => {
+    it("matches for a stranger, a member, a sharee, and both kinds of collection share", async () => {
+      if (!store.artifactGrants) return // dialect has no fast path — the fallback is the only path
+
+      const org = `org_grants_${uuid()}`
+      const other = `org_other_${uuid()}`
+      await store.setWorkspace(org, "Grants")
+      await store.setWorkspace(other, "Other")
+      const art = newArtifact({ org_id: org, workspace_access: "member", link_role: "none" })
+      await store.createArtifact(art)
+
+      const [owner, member, sharee, collab, stranger] = [
+        `u_own_${uuid()}`,
+        `u_mem_${uuid()}`,
+        `u_shr_${uuid()}`,
+        `u_col_${uuid()}`,
+        `u_str_${uuid()}`,
+      ]
+      for (const [u, role] of [
+        [owner, "owner"],
+        [member, "editor"],
+        [collab, "viewer"],
+      ] as const)
+        await store.setMembership({ id: uuid(), org_id: org, user_id: u, role })
+      // An explicit share held by a NON-member: artifact role present, org role must stay null.
+      await store.setArtifactMember({
+        id: uuid(),
+        artifact_id: art.id,
+        user_id: sharee,
+        role: "commenter",
+      })
+      // TWO collections holding the same artifact — one shared explicitly, one open to the
+      // workspace so members inherit their SEAT role. Several collections is precisely where a
+      // join would multiply the membership row.
+      const explicitCol = uuid()
+      const openCol = uuid()
+      await store.createCollection({
+        id: explicitCol,
+        org_id: org,
+        title: "Explicit",
+        created_by: owner,
+        workspace_access: "none",
+      })
+      await store.createCollection({
+        id: openCol,
+        org_id: org,
+        title: "Open",
+        created_by: owner,
+        workspace_access: "member",
+      })
+      await store.addCollectionItem(explicitCol, art.id)
+      await store.addCollectionItem(openCol, art.id)
+      await store.setCollectionMember({
+        id: uuid(),
+        collection_id: explicitCol,
+        user_id: collab,
+        role: "editor",
+      })
+
+      const slow = async (orgId: string, userId: string) => {
+        const orgRole = (await store.getMembership(orgId, userId))?.role ?? null
+        const am = await store.getArtifactMember(art.id, userId)
+        const cRoles = await store.collectionRolesForArtifact(art.id, userId)
+        return { orgRole, artifactRole: maxRole(am?.role ?? null, ...cRoles) }
+      }
+      const fast = async (orgId: string, userId: string) => {
+        const g = await store.artifactGrants?.(art.id, orgId, userId)
+        if (!g) throw new Error("artifactGrants vanished mid-test")
+        return { orgRole: g.orgRole, artifactRole: maxRole(null, ...g.artifactRoles) }
+      }
+
+      for (const u of [owner, member, sharee, collab, stranger])
+        expect(await fast(org, u), `grants disagree for ${u}`).toEqual(await slow(org, u))
+
+      // The org arm must key on the org PASSED IN, not on the artifact's own workspace.
+      for (const u of [owner, stranger]) expect(await fast(other, u)).toEqual(await slow(other, u))
     })
   })
 }

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -3201,4 +3201,90 @@ export function runStoreContract(
       for (const u of [owner, stranger]) expect(await fast(other, u)).toEqual(await slow(other, u))
     })
   })
+  // CHAOS: the same question, asked both ways, over randomly-shaped access graphs.
+  //
+  // The curated case above covers the shapes I thought of. This covers the ones I did not: a
+  // seeded random walk over memberships, per-artifact shares, open and closed collections, and
+  // artifacts that sit in several collections at once — the arrangement where a join would
+  // multiply rows and the two paths would quietly disagree.
+  //
+  // Seeded so a failure reproduces: the seed is printed with the mismatch.
+  describe(`${label}: artifactGrants survives randomised access graphs`, () => {
+    it("agrees with the four reads across 40 random configurations", async () => {
+      if (!store.artifactGrants) return
+
+      // xorshift32 — small, deterministic, and dependency-free.
+      let seed = 0x9e3779b9
+      const rnd = () => {
+        seed ^= seed << 13
+        seed ^= seed >>> 17
+        seed ^= seed << 5
+        return Math.abs(seed) / 2 ** 31
+      }
+      const pick = <T>(xs: readonly T[]): T => xs[Math.floor(rnd() * xs.length)] as T
+      const ROLES = ["owner", "admin", "editor", "commenter", "viewer"] as const
+
+      for (let round = 0; round < 40; round++) {
+        const startSeed = seed
+        const org = `org_fz_${uuid()}`
+        await store.setWorkspace(org, "Fuzz")
+        const art = newArtifact({
+          org_id: org,
+          workspace_access: pick(["member", "none"]),
+          link_role: pick(["none", "viewer"]),
+        })
+        await store.createArtifact(art)
+
+        const users = Array.from({ length: 4 }, () => `u_fz_${uuid()}`)
+        for (const u of users) {
+          // Each user independently may hold: a seat, a direct share, and membership of
+          // collections that may or may not contain the artifact.
+          if (rnd() < 0.6)
+            await store.setMembership({ id: uuid(), org_id: org, user_id: u, role: pick(ROLES) })
+          if (rnd() < 0.4)
+            await store.setArtifactMember({
+              id: uuid(),
+              artifact_id: art.id,
+              user_id: u,
+              role: pick(ROLES),
+            })
+        }
+        // Between zero and three collections, each independently workspace-open or not, each
+        // independently holding the artifact, each with a random subset of members.
+        const collections = Math.floor(rnd() * 4)
+        for (let ci = 0; ci < collections; ci++) {
+          const col = uuid()
+          await store.createCollection({
+            id: col,
+            org_id: org,
+            title: `C${ci}`,
+            created_by: users[0] as string,
+            workspace_access: rnd() < 0.5 ? "member" : "none",
+          })
+          if (rnd() < 0.75) await store.addCollectionItem(col, art.id)
+          for (const u of users)
+            if (rnd() < 0.35)
+              await store.setCollectionMember({
+                id: uuid(),
+                collection_id: col,
+                user_id: u,
+                role: pick(ROLES),
+              })
+        }
+
+        for (const u of users) {
+          const orgRole = (await store.getMembership(org, u))?.role ?? null
+          const am = await store.getArtifactMember(art.id, u)
+          const cRoles = await store.collectionRolesForArtifact(art.id, u)
+          const slow = { orgRole, artifactRole: maxRole(am?.role ?? null, ...cRoles) }
+          const g = await store.artifactGrants?.(art.id, org, u)
+          const fast = {
+            orgRole: g?.orgRole ?? null,
+            artifactRole: maxRole(null, ...(g?.artifactRoles ?? [])),
+          }
+          expect(fast, `round ${round} (seed ${startSeed}) disagreed for ${u}`).toEqual(slow)
+        }
+      }
+    })
+  })
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,302 @@
+# Cloudflare Workers entry for Derive (experimental edge tier: Workers + D1 + R2).
+name = "derive"
+main = "src/worker.ts"
+compatibility_date = "2024-11-01"
+# populate_process_env mirrors vars + secrets into process.env (automatic only at
+# compat dates ≥ 2025-04-01) — auth-config reads its optional providers
+# (GOOGLE_*, GITHUB_LOGIN_*, OIDC_*) there, same as on Node.
+compatibility_flags = ["nodejs_compat", "nodejs_compat_populate_process_env"]
+
+# Workers Logs: persist + index every invocation's structured logs (queryable in the
+# dashboard; retention per plan). Without this block console output is live-tail-only
+# and "what happened yesterday" is unanswerable. log.ts emits JSON on workerd, so
+# request_id / duration_ms / actor index as fields. Sample everything — volume is
+# modest, and a sampled-away incident costs more than the log spend. Longer retention
+# → add a Logpush job to a dedicated R2 bucket (NOT derive-blobs).
+[observability]
+enabled = true
+head_sampling_rate = 1
+
+[[d1_databases]]
+binding = "DB"
+database_name = "derive"
+# Placeholder — run `wrangler d1 create derive` and put your own id here (see
+# DEPLOY.md). The hosted deploy injects its id from a repo secret in CI
+# (.github/workflows/ci.yml, "Inject production binding ids") before this file is
+# read. NOTE: with the HYPERDRIVE binding below, metadata + auth live in Postgres
+# and this database sits idle — the binding stays only because the runtime
+# requires every declared binding to resolve.
+database_id = "00000000-0000-0000-0000-000000000000"
+
+# Hyperdrive → Postgres (the hosted tier's metadata + auth store). Bound ⇒
+# the worker takes the Postgres path; remove the binding to fall back to D1.
+# Placeholder id — run `wrangler hyperdrive create` and put your own here (the
+# DATABASE_URL lives inside the Hyperdrive config, never in this file); the
+# hosted deploy injects its id from a repo secret in CI. Schema is applied at
+# deploy time by `pnpm deploy:pg-schema`.
+# ⚠ Query caching MUST stay disabled on this config (--caching-disabled).
+# Hyperdrive caches SELECT results ~60s by default; this app reads its own
+# writes (workspace resolution, artifact read-back), and cached-stale reads made
+# first-login provision a workspace per request until the TTL expired.
+[[hyperdrive]]
+binding = "HYPERDRIVE"
+id = "00000000000000000000000000000000"
+
+[[r2_buckets]]
+binding = "BUCKET"
+bucket_name = "derive-blobs"
+
+# Semantic search (the dense/hybrid arm of workspace search) embeds with Workers AI (bge-m3) and
+# stores the vectors in pgvector in the SAME Hyperdrive Postgres as the metadata — no separate
+# vector store. Bind AI (with HYPERDRIVE) to enable it; omit AI to stay lexical-only (self-host
+# parity — the worker gates on `env.AI && env.HYPERDRIVE`). The pgvector table is created out of
+# band by `deploy:pg-schema`; then backfill per workspace corpus: POST /v1/system/search-reindex
+# with the operator token. See DEPLOY.md.
+[ai]
+binding = "AI"
+
+[[durable_objects.bindings]]
+name = "ROOMS"
+class_name = "ArtifactRoom"
+
+# The webhook outbox drainer (a single named instance). Its alarm delivers queued
+# webhooks with retries + backoff — the edge counterpart to the Node interval worker.
+[[durable_objects.bindings]]
+name = "WEBHOOK_OUTBOX"
+class_name = "WebhookOutbox"
+
+# The GitHub-sync runner (one instance per source, addressed by name). Its alarm
+# mirrors a repo batch-by-batch to completion server-side, so a sync survives the
+# user closing the tab — the edge counterpart to the Node detached batch-loop.
+[[durable_objects.bindings]]
+name = "SYNC_RUNNER"
+class_name = "RepoSyncRunner"
+
+# The preview renderer (a single named instance). Its alarm drains the render_job
+# queue sequentially via Cloudflare Browser Rendering — one browser at a time so
+# concurrent-browser billing stays at the floor. Omit this block (and the browser
+# binding below) to disable preview rendering (e.g. D1-only or self-host deploys).
+[[durable_objects.bindings]]
+name = "PREVIEW_RENDERER"
+class_name = "PreviewRenderer"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["ArtifactRoom"]
+
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = ["WebhookOutbox"]
+
+[[migrations]]
+tag = "v3"
+new_sqlite_classes = ["RepoSyncRunner"]
+
+[[migrations]]
+tag = "v4"
+new_sqlite_classes = ["PreviewRenderer"]
+
+# EXPERIMENTAL — hosted automation runs. These blocks let the every-minute cron
+# EXECUTE due automation runs in scale-to-zero containers (one run per instance, then
+# it exits): the tick materializes due schedules, reclaims runs whose container died,
+# mints a per-run capability token, and boots one container per run. Comment them out
+# (the shipped default until now) and runs stay queued for a polling `derive runner`,
+# exactly as before. Requires Containers on your Cloudflare account.
+
+[[durable_objects.bindings]]
+name = "RUN_CONTAINER"
+class_name = "RunContainer"
+
+[[migrations]]
+tag = "v5"
+new_sqlite_classes = ["RunContainer"]
+
+[[containers]]
+class_name = "RunContainer"
+# The SAME image the owner-operated runner uses: its entrypoint sees the per-run
+# capability token in the env and takes the one-shot run lane automatically.
+image = "../../deploy/runner.Dockerfile"
+# The Dockerfile COPYs packages/cli and deploy/ — repo-root paths — but wrangler builds
+# relative to THIS file by default, so the image fails to build without this. Caught by
+# `wrangler deploy --dry-run` rather than by a failed production deploy.
+image_build_context = "../.."
+# A run is minutes of coding-agent work — size for the agent, not a web request.
+instance_type = "standard-1"
+# First-run training wheels: two concurrent runs is enough to prove the lane end to
+# end while capping worst-case spend. Raise toward 20 once a real run has completed.
+max_instances = 2
+
+# The dispatch queue: a LATENCY nudge, not the source of truth. Postgres is the queue of
+# record, so a lost or duplicated message costs seconds, never work — the cron sweep above
+# re-dispatches anything still queued, and starting a run twice is a no-op (the executor's
+# claim is status-guarded). Without this, "Run now" simply waits for the next minute's tick.
+[[queues.producers]]
+binding = "RUN_QUEUE"
+queue = "derive-runs"
+
+[[queues.consumers]]
+queue = "derive-runs"
+# Small batches, short wait: this exists to cut latency, so holding messages defeats it.
+max_batch_size = 10
+max_batch_timeout = 5
+# One retry, then drop: the sweep is the real backstop, and a message retried for minutes
+# would just duplicate what the tick already picked up.
+max_retries = 1
+
+# Cloudflare Browser Rendering binding — required for the PreviewRenderer DO.
+# Leave commented if Browser Rendering is not enabled on your account; the worker
+# gates renderPreviews on !!env.BROWSER so this can be omitted safely.
+[browser]
+binding = "BROWSER"
+
+# Transactional + notification email (Cloudflare Email Service — the arbitrary-recipient
+# product, NOT the older verified-destinations-only Email Routing binding). Enabled on the
+# DEDICATED sending subdomain send.derive.to, deliberately isolated from the apex derive.to
+# Google Workspace mail: send.derive.to has its own SPF/DKIM/DMARC (p=reject on
+# _dmarc.send.derive.to), so a strict policy there never touches corporate email. The domain
+# is onboarded and DNS-verified. `remote = true` routes the binding to the Email Service
+# (structured send API, see src/email-cf.ts). Arbitrary recipients require Workers Paid
+# (3,000/mo included, then $0.35/1k). Delivery goes live on the next `wrangler deploy`; until
+# then the app no-ops email (self-host/Node uses Resend via EMAIL_FROM instead).
+[[send_email]]
+name = "SEND_EMAIL"
+remote = true
+
+# Native rate limiting (per-colo). One binding per surface; the worker counts each
+# rate-limited request against the matching binding (apps/api/src/worker.ts). The window
+# (period) can only be 10 or 60s, so the long in-process windows (unlock 5 min, oauth
+# registration 1 hr) become tighter per-minute caps here — the abuse-backstop intent
+# holds, just per-colo. namespace_id is an arbitrary unique id per limiter.
+[[ratelimits]]
+name = "RL_AUTH"
+namespace_id = "1001"
+  [ratelimits.simple]
+  limit = 20
+  period = 60
+
+[[ratelimits]]
+name = "RL_WRITE"
+namespace_id = "1002"
+  [ratelimits.simple]
+  limit = 120
+  period = 60
+
+[[ratelimits]]
+name = "RL_PUBLISH"
+namespace_id = "1003"
+  [ratelimits.simple]
+  limit = 30
+  period = 60
+
+[[ratelimits]]
+name = "RL_COMMENT"
+namespace_id = "1004"
+  [ratelimits.simple]
+  limit = 60
+  period = 60
+
+# Shared by the two tight 3/60 surfaces (unlock + oauth registration); the worker
+# namespaces the key per surface so their counts stay separate.
+[[ratelimits]]
+name = "RL_STRICT"
+namespace_id = "1005"
+  [ratelimits.simple]
+  limit = 3
+  period = 60
+
+# Invite creation (workspace + artifact): each request emails an arbitrary address
+# with caller-influenced content, so it gets its own cap below the write rate.
+[[ratelimits]]
+name = "RL_INVITE"
+namespace_id = "1007"
+  [ratelimits.simple]
+  limit = 10
+  period = 60
+
+# Retry/crash backstop for webhook delivery: the outbox DO self-reschedules while busy
+# and is poked on each new event, then goes idle. This wakes it every minute so a retry
+# scheduled during an idle gap (or a missed poke) still drains. The leased claim makes
+# this safe with the per-event pokes — no delivery fires twice.
+[triggers]
+crons = ["* * * * *"]
+
+# The web SPA (apps/web) ships from this same Worker via Static Assets, so the whole
+# app — login, library, settings, the /artifacts/:ref artifact viewer — lives same-origin with
+# the API (no CORS, first-party cookies). Prepare the build first:
+# `pnpm --filter @derive/api build:web` (builds apps/web and preps dist/client for Workers:
+# _shell.html -> index.html, drops the Pages _redirects).
+# The API/data paths run the Worker first; so do /artifacts/* and /users/* — the share + profile
+# URLs, where the Worker serves the SPA shell with per-artifact / per-profile OG/unfurl
+# meta injected for crawlers (it reads the shell via the ASSETS binding). Every other
+# path serves a static asset,
+# and non-asset routes fall back to the SPA shell (index.html) so the client router
+# owns the page. The SPA is the one and only frontend (no server-rendered viewer).
+[assets]
+directory = "../web/dist/client"
+binding = "ASSETS"
+run_worker_first = ["/v1/*", "/api/*", "/raw/*", "/blob/*", "/oauth/*", "/.well-known/skills/index.json", "/.well-known/skills/derive/SKILL.md", "/settings/github/*", "/settings/slack/*", "/artifacts/*", "/users/*", "/assets/*", "/site/*", "/brand/*", "/healthz", "/mcp", "/openapi.json", "/docs", "/.well-known/oauth-authorization-server", "/.well-known/oauth-protected-resource", "/.well-known/openid-configuration", "/skill.md", "/.well-known/agent.json", "/", "/pricing"]
+not_found_handling = "single-page-application"
+
+# Public hosts: the derive.to apex is canonical, app.derive.to an alias. Cloudflare
+# auto-creates the DNS records + edge certs. baseUrl falls back to the request
+# origin, so the workers.dev origin keeps serving for smoke tests.
+# NB: must be [[routes]] — a bare `routes = [...]` below a table header belongs to
+# that table and is silently ignored.
+[[routes]]
+pattern = "derive.to"
+custom_domain = true
+
+[[routes]]
+pattern = "app.derive.to"
+custom_domain = true
+
+# The usercontent domain (derive.page): customer pages only, never the app. The apex
+# is a custom domain (auto DNS + cert) that app.ts 301s to derive.to — once the PSL
+# entry lands the apex is cookie-dead, so it must never serve the SPA. The wildcard
+# can't be a custom domain, so it's a zone route over a manually-managed DNS record
+# (`*.derive.page` AAAA 100::, proxied). A Public Suffix List entry for the base domain is planned.
+[[routes]]
+pattern = "derive.page"
+custom_domain = true
+
+[[routes]]
+pattern = "*.derive.page/*"
+zone_name = "derive.page"
+
+# Secured by Better Auth; set DERIVE_AUTH_SECRET via `wrangler secret put`.
+# Cross-instance realtime fan-out uses the ArtifactRoom Durable Object (one room
+# per channel).
+[vars]
+# Automations execute in the isolate (model + fetch), no container. Which workspaces may use
+# them is the per-workspace `automateBeta` setting, not this.
+DERIVE_LOOP_RUNS = "1"
+# DERIVE_SUPERADMIN_EMAILS (operator allow-list) is optional;
+# DERIVE_AUTH_SECRET is a secret (`wrangler secret put`). Workspaces are always multi.
+#
+# BASE_URL pins the app origin. It is REQUIRED once DERIVE_SUBDOMAIN_BASE is set:
+# with the per-request-origin fallback, a request on derive.page (or any subdomain)
+# makes appHostForSub equal its own host, so app.ts's domain mode — the apex 301,
+# the unknown-subdomain 404, vanity serving — never engages. Same-origin requests
+# on other hosts (workers.dev smoke tests) stay trusted via auth-config's
+# same-origin rescue; only generated links now always point at derive.to.
+BASE_URL = "https://derive.to"
+#
+# Optional Slack app (all three are secrets; set them to enable Slack, else it stays off):
+#   wrangler secret put SLACK_CLIENT_ID
+#   wrangler secret put SLACK_CLIENT_SECRET
+#   wrangler secret put SLACK_SIGNING_SECRET
+# Create the app from Settings → Integrations → Set up Slack app (the manifest,
+# pre-filled, is served at /v1/slack/manifest.json); see DEPLOY.md → Slack app.
+#
+# Sender for all transactional + notification mail (reset / verify / invites / comments).
+# Must be an address on the onboarded Email Sending domain (send.derive.to). The CF adapter
+# extracts the bare address; the display-name form is kept for parity with the Resend (Node)
+# transport, which reads the same EMAIL_FROM. Pairs with the [[send_email]] binding above.
+EMAIL_FROM = "Derive <notifications@send.derive.to>"
+# Origin split (A4): artifact bytes serve from the usercontent domain, never the
+# cookie origin. raw.derive.page rides the wildcard route above; app.ts serves only
+# /raw/* + /healthz on this host and 302s /raw/* on derive.to over to it.
+DERIVE_SANDBOX_URL = "https://raw.derive.page"
+# Domain mode (C1): vanity subdomains `<label>.derive.page` (label claims are gated
+# by routes/domains.ts; `raw` is reserved for the sandbox host above).
+DERIVE_SUBDOMAIN_BASE = "derive.page"


### PR DESCRIPTION
Six fixes plus documentation corrections. Together they take a scheduled automation on a hosted deployment from **doing nothing at all** to running end to end with nobody watching, and stop it corrupting the document when it does.

Four of them are the same shape: **right in two lanes, missing in the third — and the third is the one nobody watches.**

Every one was found by running the lane on production, and the behavioural ones are proven on a second Cloudflare Worker (`derive-staging`) pointed at **the same Hyperdrive and the same Neon database**, with production left unpatched as the control.

---

## 1. The cron materializer ignored the operator gateway

On a deployment that sets `DERIVE_MODEL_BASE_URL` / `_API_KEY` / `_NAME`, **scheduled automations never fired.** Manual `Run now` worked. The clock did nothing, silently, forever.

That is the whole hosted posture: Derive holds the key and spends it for every workspace, so no workspace connects a plan and `findPayer` correctly resolves nobody. Attended chat (`routes/contexts.ts`) and create + manual run (`routes/automations.ts`, `if (ctx.callModel) return true`) already knew this. `lib/schedule.ts` did not, and counted every occurrence `unpayable`.

`operatorPays` on `DispatchDeps`, set from the **same** gateway helper each entry point already uses to build its substrate, so the substrate and the payer guard cannot disagree. `automateBeta` is untouched: a permission question, not a payer question, still enforced on the clock.

## 2. The loop substrate self-subrequested, and timed out

With occurrences finally materializing, every one died:

```
hosted dispatch  materialized=0 started=3 deferred=7 substrate=worker-loop
loop substrate: work failed outside the settle path
  error: /v1/agent/runs/claim failed (522)
```

The substrate is an HTTP client of its own deployment. On Node that is a loopback call. On Workers it leaves the isolate, crosses the edge and comes back to the **same** Worker. One run survived that; the cron tick starting three at once did not — which is why it read as "the schedule lane is broken" rather than "the transport is."

`fetchImpl` on `LoopSubstrateOptions`, defaulting to global fetch so **Node is unchanged**. The Worker passes its own `handle`, the exact entry a real request takes, so route, bearer, middleware and authorization are identical and only the network hop is gone. An injected function rather than a platform branch, because one implementation across Node and Workers is the property this substrate exists to have.

## 3. Each in-process sub-request gets its own pg connection

`fetch` gives every real request a fresh `hyperdriveConn`. Calling `handle` bare inherited the **dispatch's** Postgres context, so one pg Client served the outer tick plus every call from every run it started. node-postgres queues concurrent queries on a single Client, so that silently serializes work a network request would have run in parallel.

Correctness, not a measured win — see *On the evidence* below, where I withdraw the symptom I first attributed to it.

## 4. An automation write flipped a markdown document to HTML

Same document, same approval flow, different lane:

```
v1  text/markdown   upload
v2  text/markdown   chat edit, approved
v3  text/html       automation run, approved   <- wrong
```

At v3 the document stopped rendering as markdown and collapsed into one unformatted blob, with nothing reporting an error. Attended chat already carried this fix (`lib/session-turn.ts`, reading `current_content_type`); the run lane never got it.

This one took three attempts, and the two failures are worth recording because both looked finished.

**Attempt one set the upload's MIME type.** `publish.ts`'s `storeContent` reads the filename *extension* and ignores what the multipart part claims, so this changed nothing. A test that inspected the outgoing request passed. Running it against the real server did not: v2 came back `text/html`.

**Attempt two corrected the filename, from the Content-Type of `GET /v1/artifacts/:id/content`.** That header is the transport's, not the document's — the route serves every artifact as `text/plain; charset=utf-8` so bytes render as text rather than executing in a browser. So the value was `text/plain` for everything, matched neither branch, and no filename was corrected. **It was a complete no-op in production**, and its test stayed green because my stub answered `text/markdown` there — a behaviour I had invented.

Measured live with that version deployed: **1 of 4** unattended runs kept the document markdown.

**What actually works** is reading `current_content_type` from the artifact record, which is what attended chat has always done. The stub now serves `text/plain; charset=utf-8` from `/content` like production and answers the record separately, so the tests fail against attempt two — which they could not do before.

## 5. The model was shown a filename with no format in it

The upstream half of #4, and the reason it was intermittent rather than constant. Both lanes passed a bare short_id, so the prompt read *"its filename is wa68nr6q"* — no extension, no signal. Asked to name its output the model guessed, and the edits contract's fallback turned that guess into `index.html`.

`documentName(shortId, contentType)` appends `.md` or `.html`, used by the run lane and attended chat.

Not redundant with #4: this stops the model being misled, #4 stops a misled model doing damage. A model that believes it is editing an extensionless file will also write HTML into a Markdown document's **body**, which re-stamping the content type afterwards would not undo.

---

## Proven live

| | materialized | executed | document kept markdown |
| --- | --- | --- | --- |
| production, unpatched | **0 in 15+ min** | — | — |
| fix 1 only | one per minute, deduped per window | **0** — all `522` on claim | — |
| fixes 1-2, content fix v2 | one per minute | `succeeded` | **1 of 4** |
| **all six** | one per minute | `succeeded` | **5 of 5** |

An unattended run, nobody pressing anything:

```
status succeeded | reason schedule | initiated_by None
queued_ms 54 | ran_ms 708 | retries 0
```

Across the whole exercise: **18 successful scheduled runs, median `ran_ms` 871, max 1941, and zero failures not caused by my own harness** deleting an automation while its run was in flight. No 522s, no timeouts.

The strongest single sequence is the 5-round content-type run above. Later confirmation rounds are weaker evidence — not because runs misbehaved, but because the staging cron becomes unreliable after repeated toggling; see the retraction below.

Control in the other direction: deleting the staging cron stopped materialization dead at 06:37:51, and production alone went back to producing nothing.

`ran_ms` also fell from **4247 to 708** on the same work — removing the self-subrequests took roughly 6x off a run, because every claim, tool call and write had been round-tripping out to the edge.

## On the evidence, and what I got wrong

Three claims in earlier revisions of this PR did not survive being measured. They are listed because the pattern is the useful part.

**Smart Placement.** An earlier revision carried a change to run the isolate next to the database, justified by a confident story about Worker-to-Postgres distance. Deployed to the second Worker and measured, it was worth **11ms**. Reverted. The database was never the bottleneck: a DB-backed request with no session is **80ms** on Cloudflare against **254ms** on a box sitting next to the database. The real cost is ~489ms that appears only once a valid session resolves — 73ms anonymous, 75ms with a garbage cookie, 587ms with a real one. Localized, not fixed, out of scope here.

**A timeout blamed on connection contention.** Runs began failing with `{"outcome":"failed","why":"The operation was aborted due to timeout"}` right after fix 3 went in, and fix 3 was a plausible culprit. It was not: the model host (`inference.makora.com`) went fully unreachable at about the same time — root, `/v1/models` and `/v1/chat/completions` all hanging — and the failures did not reproduce once it recovered. Fix 3 stays, on its invariant rather than on that evidence.

**Two "finished" versions of fix 4** that changed nothing in production, described above. The second is the instructive one: it passed a test that asserted against a stub whose behaviour I had invented, so the test could not have failed.

**A "3/3" I reported and then retracted.** A final confirmation run on the exact branch head printed 3/3, but two processes had written to the same log file and the surviving content showed the harness crashing on round 3. The number was not reproducible, so it is not claimed here. A clean re-run scored one pass and three rounds where **no run materialized at all** — the staging Worker's cron stops dispatching after being toggled repeatedly through the API while still reporting itself armed. That is the test rig, not the code: every run that did fire behaved correctly, and production's cron has run continuously throughout.

The common thread is that a fix inspecting its own request will confirm whatever you already believe. Every claim here is now backed either by a test that fails against the specific wrong version, or by a run against the real server, and the stub was corrected to match production where it did not.

## Tests

`hosted-dispatch.test.ts`, against a store with no credentials in any tier:
- refuses without a gateway, materializes with one, idempotent inside the cron window
- still refuses when `automateBeta` is off, even though the operator pays

`substrate-loop.test.ts`:
- global fetch made a landmine that throws; the run must still complete through the injected transport, and the claim in particular must go through it
- the no-transport fallback still works, so Node keeps its behaviour
- a markdown target stays markdown even when the model says `index.html`, asserted on the **filename**, the field the server actually reads
- creating an artifact still honours the model's filename
- the prompt names a markdown target `art_1.md`

`session-turn.test.ts`:
- attended chat names a markdown document `doc1.md` too

Every one verified to fail without its fix, and the content-type test verified to fail against the MIME-only near-miss as well.

`pnpm verify` green: 1512 tests, typecheck (tsgo) clean.

## Also: the documentation that caused this

The claim "derive.to does not set it" outlived the code in three operator-facing places, which is how it kept doing damage — it reads as intent:

- `config-manifest.ts` (and `.env.example`, regenerated from it): the gateway is "right for a single-tenant box and wrong for a multi-tenant host — so derive.to does not set it."
- `DEPLOY.md`: "Unattended automation runs are unaffected — they still resolve their own credential through the payer chain." They are affected; with `DERIVE_LOOP_RUNS=1` the loop takes the same gateway.
- `worker.ts`: "derive.to sets none of the three, so nothing changes there" — directly above the code that reads the gateway and sets `operatorPays` from it.

All three now state what is true and name the wrong version. A confident stale comment is worse than no comment: this one cost a release and then several hours of diagnosis pointed the wrong way.

Also documents why the *polling* materializer deliberately does not take `operatorPays`, which is the obvious next question after fix 1.

---

## Known, not fixed here

**`cost_micro_usd` is `null` on every run.** Metered billing per workspace is the stated hosted posture, so the ledger it depends on is empty. Needs a price table for the configured model; separate change.

**The authenticated request path costs ~489ms on Workers**, localized above but not fixed. Needs timing spans inside the request.

**`inference.makora.com` is currently unreachable**, so chat and automations on derive.to are failing in production right now. Unrelated to this PR — production runs unpatched main — but it blocks further live verification until the host is back or a different gateway is configured.
