### PR TITLE
chore(site): security.txt, sitemap.xml, and structured data

### DIFF
--- a/apps/api/src/lib/serve-web.ts
+++ b/apps/api/src/lib/serve-web.ts
@@ -130,6 +130,13 @@ export const mountWeb = (app: Hono, { webRoot, shellHtml }: ServeWebOpts): void 
   // the Worker's Static Assets serve them natively, so only Node needs the routes.
   app.get("/site/*", serveStatic({ root: webRoot }))
   app.get("/brand/*", serveStatic({ root: webRoot }))
+  // Same reason, for the one static file that lives under a dot-directory:
+  // /.well-known/security.txt (RFC 9116). The root-file route above only matches a
+  // single segment, so without this the shell fallback swallows it and scanners see
+  // HTML where the security contact should be. The server-owned well-knowns (OAuth
+  // discovery, /.well-known/skills, agent.json) are mounted before mountWeb and
+  // still win; an unmatched one falls through to `isApiPath` and stays a JSON 404.
+  app.get("/.well-known/*", serveStatic({ root: webRoot }))
   app.notFound((c) =>
     isApiPath(c.req.path) ? c.json({ error: "not found" }, 404) : c.html(shellHtml),
   )

--- a/apps/api/test/serve-web.test.ts
+++ b/apps/api/test/serve-web.test.ts
@@ -1,7 +1,7 @@
-import { readFileSync } from "node:fs"
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { Hono } from "hono"
-import { describe, expect, it } from "vitest"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
 import { API_PATHS, isApiPath, mountWeb, workerFirstGlobs } from "../src/lib/serve-web"
 
 const apiDir = join(import.meta.dirname, "..")
@@ -45,6 +45,61 @@ describe("serve-web: SPA vs API path contract", () => {
     const miss = await app.request("/v1/nope")
     expect(miss.status).toBe(404) // unknown API path → JSON 404, never the shell
     expect(await miss.json()).toEqual({ error: "not found" })
+  })
+})
+
+// The trust-signal static files (RFC 9116 security.txt, sitemap.xml). Both must
+// serve their real bytes rather than the SPA shell — a scanner that gets HTML from
+// /.well-known/security.txt reads it as a soft-404, which is the thing these were
+// added to fix. sitemap.xml is covered by the root-file route; security.txt needs
+// the dot-directory route, so this pins the one that is easy to regress.
+describe("serve-web: static trust-signal files are not swallowed by the shell", () => {
+  // serveStatic resolves `root` against process.cwd() (apps/api under vitest), so
+  // the fixture has to live on disk under it rather than in a system temp dir.
+  const rootRel = "test/.tmp-serve-web"
+  const rootAbs = join(apiDir, rootRel)
+
+  beforeAll(() => {
+    mkdirSync(join(rootAbs, ".well-known"), { recursive: true })
+    writeFileSync(join(rootAbs, ".well-known", "security.txt"), "Contact: mailto:security@x\n")
+    writeFileSync(join(rootAbs, "sitemap.xml"), '<?xml version="1.0"?><urlset/>')
+  })
+  afterAll(() => rmSync(rootAbs, { recursive: true, force: true }))
+
+  const app = () => {
+    const a = new Hono()
+    // A server-owned well-known, mounted before mountWeb exactly as node.ts does.
+    a.get("/.well-known/openid-configuration", (c) => c.json({ issuer: "https://x" }))
+    mountWeb(a, { webRoot: rootRel, shellHtml: "SHELL_MARKER" })
+    return a
+  }
+
+  it("serves security.txt and sitemap.xml as themselves", async () => {
+    const sec = await app().request("/.well-known/security.txt")
+    expect(sec.status).toBe(200)
+    expect(await sec.text()).toContain("Contact: mailto:security@x")
+
+    const map = await app().request("/sitemap.xml")
+    expect(map.status).toBe(200)
+    expect(await map.text()).toContain("<urlset/>")
+  })
+
+  it("does not shadow server-owned well-knowns", async () => {
+    const oidc = await app().request("/.well-known/openid-configuration")
+    expect(oidc.status).toBe(200)
+    expect(await oidc.json()).toEqual({ issuer: "https://x" })
+
+    // Unknown path under an API-owned well-known prefix stays a JSON 404 — the
+    // static route must fall through, never hand back the shell.
+    const miss = await app().request("/.well-known/skills/nope.json")
+    expect(miss.status).toBe(404)
+    expect(await miss.json()).toEqual({ error: "not found" })
+  })
+
+  it("still falls back to the shell for a missing dot-directory file", async () => {
+    const r = await app().request("/.well-known/nothing-here.txt")
+    expect(r.status).toBe(200)
+    expect(await r.text()).toContain("SHELL_MARKER")
   })
 })
 

--- a/apps/web/public/.well-known/security.txt
+++ b/apps/web/public/.well-known/security.txt
@@ -1,0 +1,20 @@
+# Derive — security contact (RFC 9116)
+#
+# Vulnerabilities in Derive itself (app, API, or the hosting of user content)
+# go to security@. Abusive content hosted on Derive — phishing, malware,
+# impersonation, most often on a derive.page subdomain — goes to abuse@.
+# Both are read by a human. See https://derive.to/security for the detail.
+#
+# NB: Expires below is a hard requirement of RFC 9116 and must stay under a
+# year out. An expired security.txt reads worse to a scanner than none at all,
+# so renew this date (and re-check the contacts) before it lapses.
+
+Contact: mailto:security@derive.to
+Contact: https://derive.to/security
+Expires: 2027-07-29T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://derive.to/.well-known/security.txt
+Policy: https://derive.to/security
+
+# The server is open source; code-level issues are welcome there too.
+Acknowledgments: https://github.com/derive-to/derive

--- a/apps/web/public/security.html
+++ b/apps/web/public/security.html
@@ -13,6 +13,38 @@
 <meta property="og:image" content="https://derive.to/site/og.png">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="canonical" href="https://derive.to/security">
+<!-- See site/index.html for why the structured data is here. The contact points
+     mirror /.well-known/security.txt — change them together. -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Security & abuse — Derive",
+  "url": "https://derive.to/security",
+  "description": "How to report abusive content hosted on Derive, and how to report a security vulnerability.",
+  "isPartOf": { "@id": "https://derive.to/#website" },
+  "publisher": {
+    "@id": "https://derive.to/#organization",
+    "@type": "Organization",
+    "name": "Derive",
+    "url": "https://derive.to/",
+    "contactPoint": [
+      {
+        "@type": "ContactPoint",
+        "contactType": "abuse",
+        "email": "abuse@derive.to",
+        "url": "https://derive.to/security"
+      },
+      {
+        "@type": "ContactPoint",
+        "contactType": "security",
+        "email": "security@derive.to",
+        "url": "https://derive.to/security"
+      }
+    ]
+  }
+}
+</script>
 <link rel="icon" href="/brand/favicon.svg" type="image/svg+xml">
 <link rel="icon" href="/brand/favicon.png" type="image/png">
 <style>

--- a/apps/web/public/site/index.html
+++ b/apps/web/public/site/index.html
@@ -27,6 +27,43 @@
 <link rel="canonical" href="https://derive.to/">
 <link rel="icon" href="/brand/favicon.svg" type="image/svg+xml">
 <link rel="icon" href="/brand/favicon.png" type="image/png">
+<!-- Structured data. Search engines use this, but the reason it's here is URL
+     classifiers: enterprise web filters categorise unknown domains partly from
+     machine-readable identity, and an uncategorised domain gets blocked by
+     default at a lot of companies. Keep it factual — claims here are read by
+     things that penalise overreach. -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://derive.to/#organization",
+      "name": "Derive",
+      "url": "https://derive.to/",
+      "logo": "https://derive.to/brand/favicon.png",
+      "sameAs": ["https://github.com/derive-to/derive"]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://derive.to/#website",
+      "name": "Derive",
+      "url": "https://derive.to/",
+      "publisher": { "@id": "https://derive.to/#organization" }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "name": "Derive",
+      "applicationCategory": "BusinessApplication",
+      "operatingSystem": "Web",
+      "url": "https://derive.to/",
+      "description": "Derive is where your team and its agents publish, review, and revise work. Open source and self-hostable.",
+      "isAccessibleForFree": true,
+      "publisher": { "@id": "https://derive.to/#organization" }
+    }
+  ]
+}
+</script>
 <style>
 /* ── Geist, shipped with the site (zero third-party requests) ── */
 @font-face{

--- a/apps/web/public/site/pricing.html
+++ b/apps/web/public/site/pricing.html
@@ -13,6 +13,18 @@
 <meta property="og:image" content="https://derive.to/site/og.png">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="canonical" href="https://derive.to/pricing">
+<!-- See index.html for why the structured data is here. -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Pricing — Derive",
+  "url": "https://derive.to/pricing",
+  "description": "Free while we're in beta. This is the pricing we intend to charge, published early.",
+  "isPartOf": { "@id": "https://derive.to/#website" },
+  "publisher": { "@id": "https://derive.to/#organization" }
+}
+</script>
 <link rel="icon" href="/brand/favicon.svg" type="image/svg+xml">
 <link rel="icon" href="/brand/favicon.png" type="image/png">
 <style>

--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The public surface only. Artifacts are private by default and are never listed
+  here: a sitemap is a publication signal, and enumerating user content would
+  both leak the library and invite crawlers onto pages their owners chose not to
+  share. These three pages are the whole of derive.to that is meant to be indexed.
+-->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://derive.to/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://derive.to/pricing</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://derive.to/security</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.5</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Three trust signals the public surface was missing. We've had a report of
derive.to being blocked by a corporate web gateway — enterprise filters
default-block domains they can't categorise, and machine-readable identity is
part of what they categorise from.

To be clear about scope: **this PR does not fix that block.** The actual fix is
per-vendor categorisation submission, which is manual. This closes the site-side
gaps that were making derive.to look less maintained than it is.

### What's here

- **`/.well-known/security.txt`** (RFC 9116), pointing at the `security@` and
  `abuse@` contacts `/security` already documents. `Expires` is a hard
  requirement of the RFC and must stay under a year out — it needs renewing
  before it lapses, since an expired file reads worse to a scanner than no file.
- **`/sitemap.xml`** covering the three public pages. Artifacts are deliberately
  absent: a sitemap is a publication signal, and enumerating user content would
  leak the library and send crawlers at pages nobody chose to share.
- **JSON-LD** — `Organization` / `WebSite` / `SoftwareApplication` on the
  landing page, `WebPage` on pricing, and abuse/security `ContactPoint`s on
  `/security`.

All three previously soft-404'd: HTTP 200 with the SPA shell, byte-identical to
what `/nonsense-path-xyz` returns.

### The one non-obvious change

`sitemap.xml` is covered by `mountWeb`'s root-file route, but that route matches
a single path segment (`/:file{[^/]+\.[^/]+}`), so `/.well-known/security.txt`
fell through to the shell fallback on the Node tier. It needed a `/.well-known/*`
static route — the same gap `/site/*` and `/brand/*` were added for. On the edge,
Cloudflare Static Assets serves it directly; I verified Vite does copy the
dot-directory into `dist/client/` rather than assuming it.

The server-owned well-knowns (OAuth discovery, `/.well-known/skills`,
`agent.json`) mount before `mountWeb` and still win. Three tests pin this: the
files serve as themselves, the server-owned well-knowns aren't shadowed, and a
missing dot-directory file still falls back to the shell.

No change to the `run_worker_first` path contract — these are asset-layer paths,
not worker-first — so the three-way lockstep test is untouched.

### Verification

`pnpm run ci`, `pnpm typecheck`, and the full suite pass locally. JSON-LD is
parse-checked and the sitemap is validated as well-formed XML (I had the
namespace wrong on the first pass — `sitemap.org` instead of `sitemaps.org` —
which the validation caught).

### Follow-ups, not in this PR

- Unknown paths still return 200 + shell rather than a real 404. That's the
  change a scanner would actually notice, but it touches worker/SPA path
  ownership and deserves its own PR.
- `robots.txt` is Cloudflare-managed, so it has no `Sitemap:` line. The sitemap
  is still discoverable at the conventional path and can be submitted directly.
- DKIM is still not enabled on the derive.to apex (Workspace admin, no API).
