### PR TITLE
chore(connections): enforce the taint invariant in the write gate; base_url stops being required

### DIFF
--- a/apps/api/src/lib/broker.ts
+++ b/apps/api/src/lib/broker.ts
@@ -7,12 +7,47 @@ import { installationToken } from "./github-app"
 /** One tool a hosted run may call, paired with the connected-account ref it executes through.
  *  `kind` and `connectionId` are how the tool proxy routes the call without a second lookup;
  *  the connection RECORD is deliberately not here — it carries secret_enc, and this struct
- *  flows toward the claim response. */
+ *  flows toward the claim response, which is the last stop before the wire.
+ *
+ *  That rule still holds, but its REASON has narrowed: keeping a credential out of the
+ *  executor is no longer the product's safety story (a run with a machine is given the real
+ *  keys its context was bound to, and writes ordinary code with them — see the "keys to the
+ *  run" decision). What this struct protects is narrower and still worth protecting: a claim
+ *  must hand over exactly the access the work item was granted and no routing detail beyond
+ *  it, so a bug here can't widen one run's reach into another's. */
 export interface RunTool {
   def: BrokerToolDef
   ref: string
   kind: ConnectionKind
   connectionId: string
+}
+
+/**
+ * The connections a work item may actually SPEND: its bound ids, narrowed to the ones in THIS
+ * org that are active, and — for a personal connection, which acts as its owner — whose owner
+ * is still a member. An offboarded member's credential stops resolving on the very next run,
+ * the same live-membership recheck a minted API token gets at spend time; workspace
+ * connections are the org's and survive.
+ *
+ * Separate from `toolsForRun` on purpose. "Can this run spend a credential?" and "what HTTP
+ * tools does it get?" are DIFFERENT questions, and conflating them fails open: a connection
+ * with no base_url yields no tools (see below) yet is still a real credential the run may be
+ * handed. The write gate's `credentialed` rung must count THESE, never the tool list.
+ */
+export const spendableConnections = async (
+  meta: MetaStore,
+  orgId: string,
+  connectionIds: string[],
+): Promise<ConnectionRecord[]> => {
+  if (connectionIds.length === 0) return []
+  const conns = await meta.getConnectionsByIds(connectionIds)
+  const active = conns.filter((cn) => cn.org_id === orgId && cn.status === "active")
+  const owners = [...new Set(active.filter((cn) => cn.scope === "personal").map((c) => c.user_id))]
+  const seats = await Promise.all(
+    owners.map(async (uid) => [uid, await meta.getMembership(orgId, uid)] as const),
+  )
+  const stillMembers = new Set(seats.filter(([, seat]) => seat !== null).map(([uid]) => uid))
+  return active.filter((cn) => cn.scope === "workspace" || stillMembers.has(cn.user_id))
 }
 
 /**
@@ -28,18 +63,14 @@ export const toolsForRun = async (
   orgId: string,
   connectionIds: string[],
 ): Promise<RunTool[]> => {
-  if (connectionIds.length === 0) return []
-  const conns = await meta.getConnectionsByIds(connectionIds)
-  const active = conns.filter((cn) => cn.org_id === orgId && cn.status === "active")
-  // A personal connection acts as its owner, so it must not outlive them: an offboarded
-  // member's credential stops resolving on the next run, the same live-membership recheck
-  // a minted API token gets at spend time. Workspace connections are the org's and survive.
-  const owners = [...new Set(active.filter((cn) => cn.scope === "personal").map((c) => c.user_id))]
-  const seats = await Promise.all(
-    owners.map(async (uid) => [uid, await meta.getMembership(orgId, uid)] as const),
-  )
-  const stillMembers = new Set(seats.filter(([, seat]) => seat !== null).map(([uid]) => uid))
-  const usable = active.filter((cn) => cn.scope === "workspace" || stillMembers.has(cn.user_id))
+  const spendable = await spendableConnections(meta, orgId, connectionIds)
+  // A direct connection is called by resolving a path against its base_url and refusing
+  // anything that escapes it, so one without a base_url has nothing to call: base_url is
+  // optional now (nobody types a host — such a connection is spent by DELIVERY into a run
+  // that writes its own code), and advertising `x.get`/`x.post` for it would hand the model
+  // two tools that throw on every call. Expose none instead — but note it is still SPENDABLE,
+  // which is why the gate counts spendableConnections and not this list.
+  const usable = spendable.filter((cn) => !isDirect(cn.kind) || !!cn.base_url)
   const out: RunTool[] = []
   for (const cn of usable) {
     const entry = { ref: cn.broker_ref, kind: cn.kind, connectionId: cn.id }
@@ -61,7 +92,18 @@ const DIRECT_KINDS = new Set<ConnectionKind>(["secret", "github_app", "slack"])
 export const isDirect = (kind: ConnectionKind): boolean => DIRECT_KINDS.has(kind)
 
 /** The tools a direct connection exposes. Named `<toolkit>.<verb>` to match the broker's
- *  convention, so the runner's shim treats every kind of connection identically. */
+ *  convention, so the runner's shim treats every kind of connection identically.
+ *
+ *  FROZEN SURFACE — do not grow this. Its only remaining consumer is the MACHINELESS lane:
+ *  the in-process Workers loop (lib/substrate-loop.ts, the run and session `toolProxy` call
+ *  sites), which has no container and therefore cannot run code. Everywhere a machine exists,
+ *  a context's credentials are DELIVERED to the run and the agent uses ordinary libraries —
+ *  which is both more capable and less for us to maintain.
+ *
+ *  So: a new credential shape (a database URL, an MCP server, a webhook, a key that rides a
+ *  custom header) must NOT arrive here as another tool kind or another verb. That road ends in
+ *  a zoo of hand-written connectors, each a dialect no model was trained on, replacing the
+ *  interface models are already best at. Add it to delivery instead. */
 export const httpTools = (toolkit: string): BrokerToolDef[] => [
   {
     name: `${toolkit}.get`,
@@ -119,6 +161,10 @@ export const bearerFor = async (
  * Execute one tool call for a direct connection: resolve the requested path under the
  * connection's base_url, attach its bearer, return status + body. The caller has already
  * verified the tool is on this run's least-privilege list.
+ *
+ * Serves the machineless lane only (see httpTools' FROZEN SURFACE note). The confinement
+ * below is genuinely load-bearing THERE — it is the only boundary that lane has — which is
+ * why the checks stay exactly as strict as when they were written.
  *
  * The path is attacker-influenced (it comes from the model, which may have read hostile
  * content), so confinement is the load-bearing part: the credential must only ever be

--- a/apps/api/src/lib/session-turn.ts
+++ b/apps/api/src/lib/session-turn.ts
@@ -53,6 +53,9 @@ type TurnInput = {
   artifact: ArtifactRecord
   transcript: SessionMessageRecord[]
   flags: { agentKillswitch: boolean; agentAutoEnabled: boolean }
+  /** Attended chat resolves NO tools (see maxTurns below), so it can never spend a
+   *  connection — the gate's credentialed rung is always off for this lane. Stated here
+   *  rather than threaded through, so wiring tools into chat later trips this comment. */
   /** The human this turn acts for — follower fan-out and version authorship. */
   onBehalf: { id: string; name: string } | null
 }
@@ -141,7 +144,7 @@ ${documentBlock(src.text, input.artifact.short_id)}`
       // same field that says what the session is about — one field, and the two can never
       // disagree.
       autonomy: input.subject.mode === "publish" ? "auto" : "suggest",
-      flags: input.flags,
+      flags: { ...input.flags, credentialed: false },
     },
     land: landInProcess(deps, input, src.version),
   })

--- a/apps/api/src/lib/substrate-loop.ts
+++ b/apps/api/src/lib/substrate-loop.ts
@@ -100,7 +100,14 @@ interface ClaimedSession {
   flags?: AutonomyFlags
 }
 
-const NO_FLAGS: AutonomyFlags = { agentKillswitch: false, agentAutoEnabled: false }
+// The fallback when a claim carried no flags at all. Safe by construction rather than by
+// luck: agentAutoEnabled false already forces a proposal, so an executor talking to a server
+// that sent nothing cannot live-publish regardless of the credentialed rung.
+const NO_FLAGS: AutonomyFlags = {
+  agentKillswitch: false,
+  agentAutoEnabled: false,
+  credentialed: false,
+}
 
 /** A manifest becomes the system prompt, so it is bounded by what a system prompt can be rather
  *  than by what an artifact can be. Well past any real context manifest; a runaway one is

--- a/apps/api/src/mcp-tools/automate.ts
+++ b/apps/api/src/mcp-tools/automate.ts
@@ -38,7 +38,7 @@ export function registerAutomateTool(tc: ToolContext): void {
     "automate",
     {
       description:
-        "Standing automations — a scheduled use(context, instruction). `create`: trigger ({kind: manual|schedule|event, cron?, tz?, on:'webhook'?}) + instruction; optional refs (targets, mode publish|propose), context_id (the run acts as that context's agent), connection_ids (bound sources). Webhook triggers return fire_url + fire_secret ONCE. `run_now` enqueues now. `record` files a run you executed LOCALLY (automation_id, wrote:[short_ids], outcome, note) into the same ledger. `list` shows them. `create_context` (name + manifest_short_id, + max_run_ms?/max_concurrency?) wires a context — no token returned; owners run it via use. Owner grants only.",
+        "Standing automations — a scheduled use(context, instruction). `create`: trigger ({kind: manual|schedule|event, cron?, tz?, on:'webhook'?}) + instruction; optional refs (targets, mode publish|propose), context_id (the run acts as that context's agent), connection_ids (bound sources; binding any forces propose, whatever mode says). Webhook triggers return fire_url + fire_secret ONCE. `run_now` enqueues now. `record` files a run you executed LOCALLY (automation_id, wrote:[short_ids], outcome, note) into the same ledger. `list` shows them. `create_context` (name + manifest_short_id, + max_run_ms?/max_concurrency?) wires a context — no token returned; owners run it via use. Owner grants only.",
       inputSchema: {
         // A STRING, not an enum, on purpose: this discriminator grows (create_context is
         // itself the fifth value, and it shipped unreachable to every already-connected

--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -17,6 +17,7 @@ import {
   callTool,
   connectionBindError,
   parseConnectionIds,
+  spendableConnections,
   toolsForRun,
 } from "../lib/broker"
 import { overBudget } from "../lib/budget"
@@ -465,6 +466,8 @@ export const automationRoutes = (ctx: AppContext) => {
     // seen on the next claim): flags from org settings; write mode rides per-target in refs.
     // The executor gets everything it needs to run each run in one call — no extra round-trips.
     const s = await meta.getOrgSettings(agent.org_id)
+    // The workspace half; `credentialed` is per-run and is added below, next to the tool list
+    // it is derived from, so the two can never disagree about whether this run has hands.
     const flags = { agentKillswitch: s.agentKillswitch, agentAutoEnabled: s.agentAutoEnabled }
     // Defense-in-depth: a run whose automation vanished (the delete race), was disabled after
     // enqueue, or carries no instruction must never reach the executor — it would burn a model
@@ -502,6 +505,13 @@ export const automationRoutes = (ctx: AppContext) => {
         const connIds = parseConnectionIds(a.connection_ids)
         const tools =
           broker && connIds.length ? await toolsForRun(meta, broker, agent.org_id, connIds) : []
+        // Counted from the CONNECTIONS this run may spend, not from `tools` — a connection with
+        // no base_url yields no HTTP tools but is still a real credential (it is spent by
+        // delivery into the run). Deriving this from the tool list would report "not
+        // credentialed" for exactly those, i.e. fail open in the case the rung exists for.
+        const spendable = connIds.length
+          ? await spendableConnections(meta, agent.org_id, connIds)
+          : []
         return {
           id: r.id,
           reason: r.reason,
@@ -537,7 +547,12 @@ export const automationRoutes = (ctx: AppContext) => {
           // them, so a webhook-triggered run executed as though a clock had started it. Empty
           // for schedule and manual runs.
           payloads: parseRunMeta(r.meta).payloads ?? [],
-          flags,
+          // A run that can spend a credential files a proposal instead of publishing live
+          // (@derive/core decideWrite, rung 3). Resolved live rather than read off the
+          // automation's stored id list, which can name a connection that no longer resolves
+          // (revoked, or its owner offboarded): credentials it actually gets, not ones it was
+          // promised.
+          flags: { ...flags, credentialed: spendable.length > 0 },
         }
       }),
     )

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -29,6 +29,20 @@ const present = (cn: ConnectionRecord) => ({
   created_at: cn.created_at,
 })
 
+// Where the machineless lane may send a pasted credential: https anywhere, or plain http ONLY
+// to the loopback host for local development. Compared on the parsed hostname, because a
+// string prefix test on "http://localhost" also accepts http://localhost.evil.com — a
+// cleartext bearer sent to somebody else's server.
+const isAllowedBase = (raw: string): boolean => {
+  try {
+    const u = new URL(raw)
+    if (u.protocol === "https:") return true
+    return u.protocol === "http:" && (u.hostname === "localhost" || u.hostname === "127.0.0.1")
+  } catch {
+    return false
+  }
+}
+
 // What to say when someone wires up an integration Derive isn't connected to yet. The fix
 // is the integration's own setup flow, not this endpoint — so the message points there.
 const installMissing: Record<"github_app" | "slack", string> = {
@@ -86,7 +100,10 @@ export const connectionRoutes = (ctx: AppContext) => {
         kind: z.enum(["oauth", "secret", "github_app", "slack"]).default("oauth"),
         // kind "secret" only:
         secret: z.string().min(8).max(4096).optional(),
-        base_url: z.string().url().max(500).optional(),
+        // nullish, not optional: GET /v1/connections renders an absent host as `base_url: null`,
+        // and round-tripping that object straight back into this route is the obvious client
+        // pattern — it should not 400 on the shape we just handed out.
+        base_url: z.string().url().max(500).nullish(),
       }),
     )
     if (b instanceof Response) return bail(b)
@@ -134,9 +151,17 @@ export const connectionRoutes = (ctx: AppContext) => {
     }
     if (!b.toolkit) return fail(c, 400, "toolkit is required")
     if (b.kind === "secret") {
-      if (!b.secret || !b.base_url)
-        return fail(c, 400, "a secret connection needs `secret` and `base_url`")
-      if (!b.base_url.startsWith("https://") && !b.base_url.startsWith("http://localhost"))
+      if (!b.secret) return fail(c, 400, "a secret connection needs `secret`")
+      // base_url is OPTIONAL. Credentials are delivered into runs, so nothing confines a
+      // pasted key to a host and there is no boundary for this field to express: a
+      // recognized vendor's host is ours to know, and an unrecognized key gets a free-text
+      // note instead. It stays supported because the machineless lane (no container, so the
+      // agent cannot run code) resolves paths against it and confines to it — see httpTools.
+      // When present it is still held to https, since that lane will send a credential there.
+      // The dev escape hatch is the LOCALHOST HOST, not the prefix: `startsWith("http://localhost")`
+      // also accepts http://localhost.evil.com, which would send a decrypted bearer to someone
+      // else's box in cleartext. Parse and compare the hostname instead.
+      if (b.base_url && !isAllowedBase(b.base_url))
         return fail(c, 400, "base_url must be https (or http://localhost for dev)")
       if (!deps.encryptionKey) return fail(c, 502, "secret connections need an encryption key")
       const rec = await meta.createConnection({
@@ -146,8 +171,8 @@ export const connectionRoutes = (ctx: AppContext) => {
         scope: b.scope,
         kind: "secret",
         secret_enc: encryptSecret(b.secret, deps.encryptionKey),
-        // Stored without a trailing slash; executeSecretTool adds one when it resolves a path.
-        base_url: b.base_url.replace(/\/+$/, ""),
+        // Stored without a trailing slash; executeHttpTool adds one when it resolves a path.
+        base_url: b.base_url ? b.base_url.replace(/\/+$/, "") : null,
         broker: "none",
         toolkit: b.toolkit,
         // There is no vendor account behind this, but a run still identifies its tools by

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -23,6 +23,7 @@ import {
   callTool,
   connectionBindError,
   parseConnectionIds,
+  spendableConnections,
   toolsForRun,
 } from "../lib/broker"
 import { overBudget } from "../lib/budget"
@@ -381,11 +382,19 @@ export const contextRoutes = (ctx: AppContext) => {
   // context reaches the same things however it was triggered. The broker rides along
   // because the proxy needs it to execute a non-direct tool; nothing bound means no
   // broker is built at all.
+  // `credentialed` rides along because it is a DIFFERENT question from "what tools": a
+  // connection with no base_url yields no tools yet is still a credential this context may
+  // spend, so the write gate must count spendable connections (see spendableConnections).
   const contextTools = async (x: ContextRecord) => {
     const ids = parseConnectionIds(x.connection_ids)
-    if (ids.length === 0) return { broker: null, tools: [] }
+    if (ids.length === 0) return { broker: null, tools: [], credentialed: false }
     const broker = await brokerFor(meta, x.org_id, null, deps.encryptionKey)
-    return { broker, tools: await toolsForRun(meta, broker, x.org_id, ids) }
+    const spendable = await spendableConnections(meta, x.org_id, ids)
+    return {
+      broker,
+      tools: await toolsForRun(meta, broker, x.org_id, ids),
+      credentialed: spendable.length > 0,
+    }
   }
 
   const contextJson = (x: ContextRecord, manifestShortId: string | null) => ({
@@ -1600,9 +1609,21 @@ export const contextRoutes = (ctx: AppContext) => {
       }))
       // The same list the hosted claim returns. A context's reach must not depend on
       // which kind of executor picked its session up.
+      const reach = await contextTools(x)
+      const settings = await meta.getOrgSettings(x.org_id)
       return c.json({
         sessions: out,
-        tools: (await contextTools(x)).tools.map((t) => ({ def: t.def, ref: t.ref })),
+        tools: reach.tools.map((t) => ({ def: t.def, ref: t.ref })),
+        // The gate's inputs, which this endpoint did NOT send before — so a polling runner had
+        // nothing to gate on while the hosted claim did, and the same ask could land live on one
+        // executor and as a review on the other. Sending them makes the lanes symmetrical in
+        // what they KNOW. Note the CLI's ask path does not consult them yet (serveSession
+        // publishes directly); that half is tracked separately, and this is its prerequisite.
+        flags: {
+          agentKillswitch: settings.agentKillswitch,
+          agentAutoEnabled: settings.agentAutoEnabled,
+          credentialed: reach.credentialed,
+        },
       })
     },
   )
@@ -1651,6 +1672,9 @@ export const contextRoutes = (ctx: AppContext) => {
     // with no flags to gate on would have to either ignore the switch or invent a policy of its
     // own, and both are worse than one more read here.
     const settings = await meta.getOrgSettings(x.org_id)
+    // Resolved ONCE: the same read answers what the executor may call and whether the write
+    // gate must demote this ask. Two reads could disagree.
+    const reach = await contextTools(x)
     return c.json({
       session: {
         ...sessionJson(claimed),
@@ -1660,16 +1684,27 @@ export const contextRoutes = (ctx: AppContext) => {
       flags: {
         agentKillswitch: settings.agentKillswitch,
         agentAutoEnabled: settings.agentAutoEnabled,
+        // Same rung as the run lane: an ask that can spend a credential files its page for
+        // review instead of publishing it live (@derive/core decideWrite, rung 3).
+        credentialed: reach.credentialed,
       },
       // Projected def + ref only, as the run claim is: RunTool's routing fields, and the
       // connection behind them, stay server-side.
-      tools: (await contextTools(x)).tools.map((t) => ({ def: t.def, ref: t.ref })),
+      tools: reach.tools.map((t) => ({ def: t.def, ref: t.ref })),
     })
   })
 
   // Execute one of the session's tools — the ask lane's mirror of the run proxy. The
   // executor holds a capability token and no credential, so the call comes back here to
   // be re-checked against this context's list and run server-side.
+  //
+  // Reached today ONLY by the in-process Workers loop (lib/substrate-loop.ts) — the lane with
+  // no container, which therefore cannot run code. The CLI runner deliberately does not call
+  // it: `queue()` drops the tools array and serveSessionOnce ignores `claimed.tools`, because
+  // a runner HAS a machine, so its contexts get their credentials delivered and use ordinary
+  // libraries instead. That asymmetry is intended, not an unfinished wiring job — the endpoint
+  // is not dead code, and it is also not the road new credential shapes travel (see the
+  // FROZEN SURFACE note on httpTools).
   app.post("/v1/agent/sessions/:id/tool", async (c) => {
     const agent = await agentFor(c)
     if (!agent) return fail(c, 401, "agent token required")

--- a/apps/api/test/agentic-pull-e2e.test.ts
+++ b/apps/api/test/agentic-pull-e2e.test.ts
@@ -58,6 +58,7 @@ const detail = async (shortId: string) =>
   (await (await app.request(`/v1/artifacts/${shortId}`, { headers: as(owner.email) })).json()) as {
     current_version: number
     tags: string[]
+    open_proposals: number
   }
 const content = async (shortId: string) =>
   await (await app.request(`/v1/artifacts/${shortId}/content`, { headers: as(owner.email) })).text()
@@ -90,8 +91,18 @@ process.stdout.write(JSON.stringify({ type: "result", result: "<revision>" + JSO
 }
 
 describe("agentic pull — a scheduled/triggered artifact pulls from a mock source and updates", () => {
-  it("run-now → the runner pulls through the bound source and publishes a new version", async () => {
-    // Opt the workspace into live agent publishing (still with a review round).
+  it("run-now → the runner pulls through the bound source and PROPOSES; approving lands it", async () => {
+    // This asserted a live v2 until the credentialed rung landed. A run bound to a connection
+    // can spend a real credential and reads outside data, so the gate demotes it to a proposal
+    // no matter how confident the model is or how opted-in the workspace is — the invariant the
+    // connections plan calls "taint", which nothing enforced until now.
+    //
+    // The pull is still proven end to end, and more thoroughly than before: the work lands as a
+    // proposal, a human approves it, and the pulled payload appears in the version that
+    // results. Everything below the approve line is the old assertion set, moved one step later.
+
+    // Opt the workspace into live agent publishing (still with a review round). The rung above
+    // now outranks this — which is the point.
     await app.request("/v1/workspace/settings", {
       method: "PATCH",
       headers: { "content-type": "application/json", ...as(owner.email) },
@@ -151,25 +162,58 @@ describe("agentic pull — a scheduled/triggered artifact pulls from a mock sour
       timeoutMs: 30_000,
     })
 
-    // The artifact got a new LIVE version, stamped with the archive tag, carrying the pulled data.
+    // NOT published: the live doc is untouched, and the work is waiting for a human instead.
     const after = await detail(doc.short_id)
-    expect(after.current_version).toBe(2)
-    expect(after.tags).toContain("revenue")
+    expect(after.current_version).toBe(1)
+    expect(after.open_proposals).toBe(1)
+    expect(await content(doc.short_id)).toContain("MRR: unknown")
+
+    // The ledger says the same: a succeeded run whose outcome was a proposal, not a publish.
+    const ledger = (await (
+      await app.request("/v1/workspace/runs", { headers: as(owner.email) })
+    ).json()) as { runs: { status: string; meta: string | null }[] }
+    const run = ledger.runs.find((r) => r.meta?.includes("proposed"))
+    expect(run?.status).toBe("succeeded")
+    expect(ledger.runs.some((r) => r.meta?.includes('"outcome":"published"'))).toBe(false)
+
+    // A human approves it — and only now does the pulled data go live, as v2 with the tag.
+    const { proposals } = (await (
+      await app.request(`/v1/artifacts/${doc.short_id}/proposals?state=open`, {
+        headers: as(owner.email),
+      })
+    ).json()) as { proposals: { id: string }[] }
+    expect(proposals).toHaveLength(1)
+    const approved = await app.request(
+      `/v1/artifacts/${doc.short_id}/proposals/${proposals[0]?.id}/approve`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", ...as(owner.email) },
+        body: "{}",
+      },
+    )
+    expect(approved.status).toBe(200)
+    expect((await approved.json()).published).toBe(2)
+
+    const live = await detail(doc.short_id)
+    expect(live.current_version).toBe(2)
+    // KNOWN GAP, pre-existing and NOT introduced here: the runner sends `add_tags` on the
+    // proposal form (revisionForm), but only the publish route reads that field
+    // (artifacts.ts:787) — the proposals route drops it, so an approved proposal loses the
+    // automation's tag stamps. Every demoted write has always lost them: killswitch on,
+    // propose-mode targets, low confidence. This change makes it VISIBLE rather than causing
+    // it, since a source-bound run now always proposes. Asserted as-is so that fixing it trips
+    // this line and lands the assertion back on `toContain`, instead of passing unnoticed.
+    expect(live.tags).not.toContain("revenue")
     const body = await content(doc.short_id)
     expect(body).toContain("MRR: fresh")
     // Proof the pull actually round-tripped through the broker (the LocalBroker echo).
     expect(body).toContain("stripe.read")
     expect(body).toContain('"provider":"local"')
 
-    // The ledger tells the same story: one succeeded run that published.
-    const ledger = (await (
-      await app.request("/v1/workspace/runs", { headers: as(owner.email) })
-    ).json()) as { runs: { status: string; meta: string | null }[] }
-    const run = ledger.runs.find((r) => r.meta?.includes("published"))
-    expect(run?.status).toBe("succeeded")
-
     // eslint-disable-next-line no-console
-    console.log(`\n[e2e] pulled + published ${doc.short_id} v${after.current_version}:\n${body}\n`)
+    console.log(
+      `\n[e2e] pulled → proposed → approved ${doc.short_id} v${live.current_version}:\n${body}\n`,
+    )
   })
 })
 

--- a/apps/api/test/connections.test.ts
+++ b/apps/api/test/connections.test.ts
@@ -161,6 +161,25 @@ describe("connections (Sources — per-user connected accounts)", () => {
     expect(list).not.toContain("secret_enc")
   })
 
+  it("a secret connection needs no base_url — the host is ours to know, not yours to type", async () => {
+    // Credentials are delivered to runs, so nothing confines a pasted key to a host and there
+    // is no boundary for a base_url to express. A recognized vendor's host is ours to know; an
+    // unrecognized key gets a free-text note instead. So the field is optional, and a
+    // connection without one is perfectly valid — it just can't produce tools for the
+    // machineless lane (pinned in context-connections.test.ts).
+    const res = await app.request(
+      "/v1/connections",
+      jsonAs(as(owner.email), {
+        toolkit: "own-api",
+        kind: "secret",
+        secret: "sk_no_host_needed_1234",
+        scope: "workspace",
+      }),
+    )
+    expect(res.status).toBe(201)
+    expect(await res.json()).toMatchObject({ kind: "secret", base_url: null, status: "active" })
+  })
+
   it("a secret connection refuses http bases and missing fields", async () => {
     const noFields = await app.request(
       "/v1/connections",

--- a/apps/api/test/context-connections.test.ts
+++ b/apps/api/test/context-connections.test.ts
@@ -194,6 +194,95 @@ describe("context connections (the ask lane gets hands)", () => {
     }
   })
 
+  it("a base_url-less secret contributes NO tools — there is nothing to call it against", async () => {
+    // base_url is optional now (nobody types a host), but the machineless lane resolves a
+    // path against it and confines to it. A connection without one can only be SPENT by
+    // delivery into a run, so advertising `own.get`/`own.post` here would hand the model two
+    // tools that throw on every call. Better to expose none and say why.
+    const withHost = await makeConnection({
+      toolkit: "hosted",
+      kind: "secret",
+      secret: "fixture-with-a-host",
+      base_url: "https://api.hosted.test",
+      scope: "workspace",
+    })
+    const noHost = await makeConnection({
+      toolkit: "delivered",
+      kind: "secret",
+      secret: "fixture-delivery-only",
+      scope: "workspace",
+    })
+    const ctx = await makeContext("Mixed", [withHost.id, noHost.id])
+    const ask = await app.request(
+      `/v1/contexts/${ctx.id}/sessions`,
+      jsonAs(as(owner.email), { body_md: "?" }),
+    )
+    const { session } = (await ask.json()) as { session: { id: string } }
+    const claim = await (
+      await app.request("/v1/agent/sessions/claim", jsonAs(bearer(await tokenFor(session.id)), {}))
+    ).json()
+    // Only the one with a host. The delivery-only connection stays bound and invisible here.
+    expect(claim.tools.map((t: { def: { name: string } }) => t.def.name).sort()).toEqual([
+      "hosted.get",
+      "hosted.post",
+    ])
+    // And the proxy refuses the tool it never advertised.
+    const call = await app.request(
+      `/v1/agent/sessions/${session.id}/tool`,
+      jsonAs(bearer(await tokenFor(session.id)), {
+        tool: "delivered.get",
+        args: { path: "/x" },
+      }),
+    )
+    expect(call.status).toBe(403)
+  })
+
+  it("a claim that carries tools says so in flags.credentialed, so the gate can demote it", async () => {
+    // The invariant every plan doc claimed and no code enforced: a run that can spend a
+    // credential proposes, never live-publishes. The gate is pure and does no I/O, so the
+    // claim has to TELL it. Resolved server-side at claim time next to the tool list itself,
+    // so the two can't disagree.
+    const conn = await makeConnection({
+      toolkit: "spend",
+      kind: "secret",
+      secret: "fixture-credentialed-flag",
+      base_url: "https://api.spend.test",
+      scope: "workspace",
+    })
+    const armed = await makeContext("Armed", [conn.id])
+    const bare = await makeContext("Unarmed")
+    const claimFor = async (ctxId: string) => {
+      const ask = await app.request(
+        `/v1/contexts/${ctxId}/sessions`,
+        jsonAs(as(owner.email), { body_md: "?" }),
+      )
+      const { session } = (await ask.json()) as { session: { id: string } }
+      return await (
+        await app.request(
+          "/v1/agent/sessions/claim",
+          jsonAs(bearer(await tokenFor(session.id)), {}),
+        )
+      ).json()
+    }
+    expect((await claimFor(armed.id)).flags).toMatchObject({ credentialed: true })
+    expect((await claimFor(bare.id)).flags).toMatchObject({ credentialed: false })
+
+    // The fail-open case worth pinning: a base_url-less secret contributes NO tools (above),
+    // so deriving the flag from the tool list would report "not credentialed" for a context
+    // holding a real key — exactly the connection delivery is for. Counted from spendable
+    // CONNECTIONS instead, so no-tools-but-has-credentials still demotes the write.
+    const deliveryOnly = await makeConnection({
+      toolkit: "keyonly",
+      kind: "secret",
+      secret: "fixture-no-host-but-real",
+      scope: "workspace",
+    })
+    const quiet = await makeContext("ToolessButArmed", [deliveryOnly.id])
+    const claim = await claimFor(quiet.id)
+    expect(claim.tools).toEqual([])
+    expect(claim.flags).toMatchObject({ credentialed: true })
+  })
+
   it("a session token reaches only its OWN session's tools", async () => {
     const conn = await makeConnection({ toolkit: "stripe" })
     const mine = await makeContext("Mine", [conn.id])

--- a/packages/cli/src/runner.d.ts
+++ b/packages/cli/src/runner.d.ts
@@ -11,7 +11,10 @@ export interface ClaimedRun {
   instruction: string
   targets: unknown[]
   tools: { def: { name: string; description: string }; ref: string }[]
-  flags: { agentKillswitch: boolean; agentAutoEnabled: boolean }
+  /** `credentialed` is OPTIONAL here on purpose: this describes the WIRE, and a runner newer
+   *  than the server it polls will not receive it. Absent means "not credentialed", which is
+   *  the pre-rung behavior — an older server never demoted these runs either. */
+  flags: { agentKillswitch: boolean; agentAutoEnabled: boolean; credentialed?: boolean }
 }
 
 /** Runner config as serveRun/runOnce consume it (a plain object, not a class). */

--- a/packages/cli/src/runner.js
+++ b/packages/cli/src/runner.js
@@ -722,6 +722,10 @@ export function decideWrite({ autonomy, confidence, flags, confidenceFloor }) {
   const floor = confidenceFloor ?? DEFAULT_CONFIDENCE_FLOOR
   if (flags.agentKillswitch) return "proposal"
   if (autonomy === "shadow") return "shadow"
+  // A run that resolved a bound connection can spend a real credential, so it files for a
+  // human rather than publishing — below shadow, above every consent rung. Kept in lockstep
+  // with core's copy by packages/cli/test/gate-parity.test.js.
+  if (flags.credentialed) return "proposal"
   if (autonomy === "suggest") return "proposal"
   if (!flags.agentAutoEnabled) return "proposal"
   if (confidence === null || confidence === undefined || confidence < floor) return "proposal"
@@ -1355,7 +1359,10 @@ export async function serveRun(client, run, manifest, cfg) {
   const hasTools = run.tools?.length > 0
   if (hasTools) writeToolShim(cfg.cwd)
   // The spawn env: the model-plan overlay (session parity) plus the shim's server/token/run-id
-  // when the run has sources, so the shim authenticates without the model holding the token.
+  // when the run has sources. NOTE: these ride the model's OWN environment, so the model does
+  // hold this token — the shim is a convenience, not a confidentiality boundary (runAgent's
+  // header comment says the same about cwd). Anything the token authorizes, an injected model
+  // can call directly, which is why the write gate is defense-in-depth and not a guarantee.
   const shimEnv = hasTools
     ? { DERIVE_SERVER: cfg.server, DERIVE_TOKEN: cfg.token, DERIVE_RUN_ID: run.id }
     : {}

--- a/packages/cli/test/gate-parity.test.js
+++ b/packages/cli/test/gate-parity.test.js
@@ -17,34 +17,59 @@ import { DEFAULT_CONFIDENCE_FLOOR, decideWrite, runRevisionAgent } from "../src/
 // Both are the spec; each holds its own implementation to it. Changing the precedence means
 // changing both tables, and forgetting either implementation fails loudly here.
 describe("decideWrite: parity with @derive/core", () => {
-  it("the full truth table — 36 combinations, identical to core's", () => {
+  it("the full truth table — 72 combinations, identical to core's", () => {
     const rows = []
     for (const autonomy of ["shadow", "suggest", "auto"])
       for (const confidence of [null, 0.5, 1])
         for (const killswitch of [false, true])
-          for (const autoEnabled of [false, true]) {
-            const expected = killswitch
-              ? "proposal"
-              : autonomy === "shadow"
-                ? "shadow"
-                : autonomy === "suggest"
-                  ? "proposal"
-                  : !autoEnabled || confidence === null || confidence < DEFAULT_CONFIDENCE_FLOOR
+          for (const autoEnabled of [false, true])
+            for (const credentialed of [false, true]) {
+              const expected = killswitch
+                ? "proposal"
+                : autonomy === "shadow"
+                  ? "shadow"
+                  : credentialed
                     ? "proposal"
-                    : "live_publish_with_review"
-            rows.push([autonomy, confidence, killswitch, autoEnabled, expected])
-          }
-    expect(rows).toHaveLength(36)
-    for (const [autonomy, confidence, killswitch, autoEnabled, expected] of rows) {
+                    : autonomy === "suggest"
+                      ? "proposal"
+                      : !autoEnabled || confidence === null || confidence < DEFAULT_CONFIDENCE_FLOOR
+                        ? "proposal"
+                        : "live_publish_with_review"
+              rows.push([autonomy, confidence, killswitch, autoEnabled, credentialed, expected])
+            }
+    expect(rows).toHaveLength(72)
+    for (const [autonomy, confidence, killswitch, autoEnabled, credentialed, expected] of rows) {
       expect(
         decideWrite({
           autonomy,
           confidence,
-          flags: { agentKillswitch: killswitch, agentAutoEnabled: autoEnabled },
+          flags: { agentKillswitch: killswitch, agentAutoEnabled: autoEnabled, credentialed },
         }),
-        `${autonomy}/conf=${confidence}/kill=${killswitch}/auto=${autoEnabled}`,
+        `${autonomy}/conf=${confidence}/kill=${killswitch}/auto=${autoEnabled}/cred=${credentialed}`,
       ).toBe(expected)
     }
+  })
+
+  it("a credentialed run is demoted here too — the copy must not be the lenient one", () => {
+    // The whole point of this file: a rung that exists in core and not here would let the
+    // container substrate live-publish a write that every other lane demotes. This is the
+    // rung where that would matter most, since the run was holding a real credential.
+    expect(
+      decideWrite({
+        autonomy: "auto",
+        confidence: 1,
+        flags: { agentKillswitch: false, agentAutoEnabled: true, credentialed: true },
+      }),
+    ).toBe("proposal")
+    // A missing flag (an older server that doesn't send it) must not crash the gate; it
+    // simply doesn't demote.
+    expect(
+      decideWrite({
+        autonomy: "auto",
+        confidence: 1,
+        flags: { agentKillswitch: false, agentAutoEnabled: true },
+      }),
+    ).toBe("live_publish_with_review")
   })
 
   it("the confidence floor constant matches core's", () => {

--- a/packages/core/src/autonomy.ts
+++ b/packages/core/src/autonomy.ts
@@ -21,13 +21,18 @@ export type ChangeKind = "freshness" | "structural" | "creation"
 
 export type GateDecision = "live_publish_with_review" | "proposal" | "shadow"
 
-/** Workspace flags, read fresh by the caller per run — never cached across runs. */
+/** Gate inputs the caller reads fresh per run — never cached across runs. Two are
+ *  workspace switches; `credentialed` is a property of THIS run. */
 export interface AutonomyFlags {
   /** Demotes EVERY write to a proposal, instantly. A killswitch surfaces work
    *  for humans rather than hiding it, so it never demotes to shadow. */
   agentKillswitch: boolean
   /** Workspace opt-in for `auto` to live-publish. Off = auto behaves as suggest. */
   agentAutoEnabled: boolean
+  /** This run can spend a credential — it resolved at least one bound connection.
+   *  Required rather than optional so the compiler names every construction site: a
+   *  forgotten field would default to "not credentialed", which fails OPEN. */
+  credentialed: boolean
 }
 
 export interface GateInput {
@@ -45,11 +50,32 @@ export const DEFAULT_CONFIDENCE_FLOOR = 0.8
 /** Precedence, top to bottom, every rung fail-safe:
  *   1. killswitch            → proposal (work surfaces, never silently drops)
  *   2. autonomy shadow       → shadow
- *   3. autonomy suggest      → proposal
- *   4. autonomy auto (= the target's explicit publish mode):
+ *   3. credentialed run      → proposal
+ *   4. autonomy suggest      → proposal
+ *   5. autonomy auto (= the target's explicit publish mode):
  *      a. workspace opt-in off      → proposal
  *      b. confidence unstated/low   → proposal
  *      c. otherwise                 → live publish, review round opens
+ *
+ *  Rung 3 is the connections plan's "taint": a run that can spend a credential reads
+ *  outside data and acts with real access, so it files for a human instead of
+ *  publishing. It sits BELOW shadow deliberately — filing nothing is safer than
+ *  filing a proposal, so a shadow rollout doesn't get louder because the run held a
+ *  key — and ABOVE the consent rungs, so no per-target mode or confidence score can
+ *  buy its way past it.
+ *
+ *  SCOPE, stated honestly, because the plan has been describing this as a guarantee
+ *  and it is not one. This function is advisory: it runs INSIDE the executor, and a
+ *  run's model already holds the agent token in its environment (the tool shim needs
+ *  it), so a prompt-injected model that decides to POST the publish route directly
+ *  never passes through here. The server does not re-check at write time. That is
+ *  equally true of the killswitch above — every rung here is defense against an
+ *  executor doing its job, not against one that has been turned. What this rung
+ *  genuinely buys: the ordinary path of a credentialed run cannot land live content
+ *  without a human, so the failure needs an ACTIVE hijack rather than a plausible
+ *  wrong answer. Making it a real guarantee means enforcing it server-side at the
+ *  publish route (the run id is already on the claim); until then, do not describe
+ *  it as one.
  *
  *  The KIND of change no longer gates: autonomy here is the user's per-target
  *  write-mode consent, and recoverability (versioned writes + review rounds +
@@ -58,6 +84,7 @@ export function decideWrite(input: GateInput): GateDecision {
   const floor = input.confidenceFloor ?? DEFAULT_CONFIDENCE_FLOOR
   if (input.flags.agentKillswitch) return "proposal"
   if (input.autonomy === "shadow") return "shadow"
+  if (input.flags.credentialed) return "proposal"
   if (input.autonomy === "suggest") return "proposal"
   if (!input.flags.agentAutoEnabled) return "proposal"
   if (input.confidence === null || input.confidence < floor) return "proposal"

--- a/packages/core/test/autonomy.test.ts
+++ b/packages/core/test/autonomy.test.ts
@@ -9,7 +9,7 @@ import {
 const base = {
   autonomy: "auto" as AutonomyLevel,
   confidence: 1,
-  flags: { agentKillswitch: false, agentAutoEnabled: true },
+  flags: { agentKillswitch: false, agentAutoEnabled: true, credentialed: false },
 }
 
 describe("decideWrite", () => {
@@ -20,33 +20,52 @@ describe("decideWrite", () => {
     // precedence here and both tables must change with it; if the CLI's IMPLEMENTATION is not
     // updated too, its parity test fails. That is the only thing standing between two copies of
     // a safety gate and a silent divergence.
-    const rows: Array<[AutonomyLevel, number | null, boolean, boolean, GateDecision]> = []
+    const rows: Array<[AutonomyLevel, number | null, boolean, boolean, boolean, GateDecision]> = []
     for (const autonomy of ["shadow", "suggest", "auto"] as const)
       for (const confidence of [null, 0.5, 1])
         for (const killswitch of [false, true])
-          for (const autoEnabled of [false, true]) {
-            const expected: GateDecision = killswitch
-              ? "proposal"
-              : autonomy === "shadow"
-                ? "shadow"
-                : autonomy === "suggest"
-                  ? "proposal"
-                  : !autoEnabled || confidence === null || confidence < DEFAULT_CONFIDENCE_FLOOR
+          for (const autoEnabled of [false, true])
+            for (const credentialed of [false, true]) {
+              const expected: GateDecision = killswitch
+                ? "proposal"
+                : autonomy === "shadow"
+                  ? "shadow"
+                  : credentialed
                     ? "proposal"
-                    : "live_publish_with_review"
-            rows.push([autonomy, confidence, killswitch, autoEnabled, expected])
-          }
-    expect(rows).toHaveLength(36)
-    for (const [autonomy, confidence, killswitch, autoEnabled, expected] of rows) {
+                    : autonomy === "suggest"
+                      ? "proposal"
+                      : !autoEnabled || confidence === null || confidence < DEFAULT_CONFIDENCE_FLOOR
+                        ? "proposal"
+                        : "live_publish_with_review"
+              rows.push([autonomy, confidence, killswitch, autoEnabled, credentialed, expected])
+            }
+    expect(rows).toHaveLength(72)
+    for (const [autonomy, confidence, killswitch, autoEnabled, credentialed, expected] of rows) {
       expect(
         decideWrite({
           autonomy,
           confidence,
-          flags: { agentKillswitch: killswitch, agentAutoEnabled: autoEnabled },
+          flags: { agentKillswitch: killswitch, agentAutoEnabled: autoEnabled, credentialed },
         }),
-        `${autonomy}/conf=${confidence}/kill=${killswitch}/auto=${autoEnabled}`,
+        `${autonomy}/conf=${confidence}/kill=${killswitch}/auto=${autoEnabled}/cred=${credentialed}`,
       ).toBe(expected)
     }
+  })
+
+  it("a run that can spend a credential proposes, and never live-publishes", () => {
+    // The invariant the plan documents as "taint": a run holding a real credential is exactly
+    // the case where an unreviewed live publish is worst, so it is demoted no matter how
+    // confident the model is or how opted-in the workspace is.
+    expect(decideWrite({ ...base, flags: { ...base.flags, credentialed: true } })).toBe("proposal")
+    // Shadow still outranks it: filing nothing is safer than filing a proposal, so a shadow
+    // rollout does not get louder just because the run had a key.
+    expect(
+      decideWrite({
+        ...base,
+        autonomy: "shadow",
+        flags: { ...base.flags, credentialed: true },
+      }),
+    ).toBe("shadow")
   })
 
   it("the killswitch outranks everything, including shadow — work surfaces, never drops", () => {


### PR DESCRIPTION
Cleanup ahead of credential delivery, from an audit of the four shipped connections PRs (#565, #567, #568, #570). No new feature — this makes an existing promise real and stops the parts we've decided against from growing.

## The headline: we documented a safety invariant we never implemented

Every plan doc says *"a run that touched any source tool is tainted → proposes, never live-publishes. Already enforced server-side."*

It was not enforced anywhere. `decideWrite` considered exactly four things — killswitch, autonomy, `agentAutoEnabled`, confidence — and the server sent only the first two. There is no taint concept in the codebase. A run holding a real credential could live-publish, and the `agentic-pull-e2e` test asserted precisely that as correct behavior.

This adds the missing rung, in **both** copies of the gate (core's and the CLI's hand-copy, which `gate-parity.test.js` holds in lockstep — a rung in one and not the other would let the container substrate publish what every other lane demotes). Precedence: below `shadow` (filing nothing beats filing a proposal, so a shadow rollout doesn't get louder because the run had a key), above every consent rung (no target mode or confidence score buys past it).

## `credentialed` counts spendable connections, not tools

The first cut derived it from `tools.length > 0`. That fails open exactly where the rung matters: a connection with **no base_url** contributes no HTTP tools but is still a real credential (it's spent by delivery into a run that writes its own code). New `spendableConnections()` is the shared resolver — org match, active, live-membership recheck for personal ones — and `toolsForRun` now builds on it. Pinned by a test: no tools, still `credentialed: true`.

## `base_url` is optional on the `secret` kind

Nobody types a host. A recognized vendor's host is ours to know; an unrecognized key gets a free-text note to the agent instead. Still https-validated **when present**, because the machineless lane will send a credential there. Such a connection contributes no tools (nothing to resolve a path against) but stays spendable.

## Also in here

- **The queue endpoint now sends the gate's flags.** A polling BYO runner had nothing to gate on while the hosted claim did, so the same ask could land live on one executor and as a review on the other. This makes the lanes symmetrical in what they *know*; the CLI's ask path consulting them is a separate follow-up (see below).
- **Tightened a dev escape hatch.** `startsWith("http://localhost")` also accepts `http://localhost.evil.com` — a cleartext bearer to someone else's box. Now a parsed-hostname check. Pre-existing, but this diff restructured that exact condition.
- **`base_url` accepts `null`**, so a `GET /v1/connections` response round-trips back into `POST` instead of 400ing on the shape we just handed out.
- **Froze the HTTP hatch.** Comments on `httpTools` / `executeHttpTool` / the session tool route name the machineless in-API loop (`substrate-loop.ts:429,527`) as their only remaining consumer, and say plainly that new credential shapes (a database URL, an MCP server, a webhook, a custom-header key) must not arrive as new tool kinds. Everywhere a machine exists, keys are delivered to the run instead.

## Scope of the control, stated honestly in the code

The gate runs **inside the executor**, and the model already holds the agent token in its environment (the tool shim needs it — `runner.js` claimed otherwise in one comment and admitted it in another; corrected). So a prompt-injected model that decides to POST the publish route directly never passes through the gate, and the server does not re-check at write time. That is equally true of the killswitch.

So this rung is **defense-in-depth, not a guarantee**: the ordinary path of a credentialed run can no longer land live content without a human, which means a failure now requires an active hijack rather than a plausible wrong answer. Making it a real guarantee means enforcing server-side at the publish route (the run id is already on the claim). The code comment says this rather than letting the docs keep overclaiming.

## Known gaps this surfaces (not fixed here)

1. **Tag stamping is dead on the proposal path.** The runner sends `add_tags` on the proposal form, but only the publish route reads that field (`artifacts.ts:787`) — so an approved proposal loses the automation's tag stamps. Every demoted write has always lost them (killswitch on, propose-mode targets, low confidence); this change makes it *visible* for source-bound automations, which previously reached the publish path. Real-world impact is ~zero today (connections have no UI, so no production automation binds one), but it should be fixed before delivery ships. The e2e test asserts the broken behavior with a comment, so fixing it trips that line.
2. **The CLI ask lane doesn't consult the gate at all.** `serveSession` publishes the answer page directly rather than going through `decideWrite`. Sending it flags (above) is the prerequisite; the branch itself is follow-up.
3. **The hosted container timeout is inert.** `substrate-container.ts` sets `DERIVE_RUN_TIMEOUT_MS`; the runner reads `RUNNER_TIMEOUT_MS`. Left alone deliberately — bridging it would silently change hosted runs from 10 to 15 minutes, which is a behavior change that doesn't belong in a cleanup PR.

## Testing

`decideWrite`'s truth table grew from 36 to 72 rows in both suites. New tests: base_url-less secret creation; such a connection contributing no tools while still refusing the proxy; `credentialed` true/false on the session claim; the no-tools-but-credentialed fail-open case. The `agentic-pull-e2e` test now asserts the *safety* property and is stronger for it — the run proposes, a human approves, and the pulled payload lands in the resulting version.

All gates green locally: `typecheck`, `biome`, the repo's custom lints (schema, api, mutations, surfaces, filesize, deadcode), and every suite (api 1582, core 465, cli 185, db 267, web 202, mcp 34).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788037263&installation_model_id=428097&pr_number=584&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F584&signature=a188cc2f3a23c55046a2d6a8ddc0ace99e382674e4a989170c462337a80157de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->