### PR TITLE
feat(chat): stream the model's reply, cheaply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,30 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once it reache
 
 ## [Unreleased]
 
+### Added
+- **Chat replies arrive as they are written.** An attended turn used to be a spinner
+  until the whole answer landed, which on a long reply is twenty seconds of nothing.
+  The model's text now streams to the asker as a `session.delta` event on their own
+  `u:<id>` channel, rendered into the same bubble the settled message lands in, so
+  there is no jump when the transcript takes over. Deltas are a **view, never the
+  record**: nothing is persisted until the turn settles, so a client that misses them
+  loses the animation and nothing else. The `<revision>` block the reply contract asks
+  for is cut from the stream — it is machinery rather than an answer, and the settled
+  message strips it too. Slices are coalesced (a publish per 200 characters or 250ms,
+  not one per token, because each is a Durable Object fetch), and a turn nobody is
+  watching goes quiet after three of them reach an empty room — which is most turns,
+  since an MCP ask or an API caller has no browser at all. Needs a gateway that serves
+  SSE chat-completions; one that refuses is retried buffered, so streaming can never
+  break a request that worked before.
+
 ### Changed
+- **An attended turn now announces its own end.** `serveAttended` answers in-process,
+  so it never went through the runner report path that publishes `session.settled` —
+  a watching client learned the answer had landed only on its next poll. It now wakes
+  the asker, and both the chat rail and the context console read the transcript on that
+  event instead of waiting out the interval. With a live stream the rail's poll drops
+  from 900ms to 5s, where it is the safety net for a dropped stream rather than the way
+  the answer arrives.
 - **Inline editing, second pass — the mode is legible and can't lose your work.**
   Entering edit mode used to be pixel-identical to reading: nothing on screen said
   the page had changed state, and you had to click something to discover what

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -331,6 +331,22 @@ wrangler secret put DERIVE_MODEL_NAME       # the provider's own model id
 This key pays for every attended turn on the deployment, so it is an operator decision
 rather than a per-user one.
 
+**Streaming: the gateway should speak SSE, but need not.** When a browser is watching an
+attended reply, the request carries `stream: true` and `stream_options: {include_usage: true}`
+(the latter is what makes a streamed turn report cost at all — a stream otherwise omits usage),
+and the answer is rendered as it arrives. A gateway that rejects those fields, or answers with
+ordinary JSON anyway, is **retried once without them** and the turn completes normally; the
+person just sees the reply appear all at once. So streaming is an enhancement, never a
+deployment requirement. Unattended runs and automations never ask for a stream at all. To check
+whether yours streams:
+
+```
+curl -sN "$DERIVE_MODEL_BASE_URL/chat/completions" \
+  -H "authorization: Bearer $DERIVE_MODEL_API_KEY" -H 'content-type: application/json' \
+  -d '{"model":"'"$DERIVE_MODEL_NAME"'","stream":true,"stream_options":{"include_usage":true},
+       "messages":[{"role":"user","content":"hi"}]}'
+```
+
 **It pays for unattended runs too**, whenever they execute in-process (`DERIVE_LOOP_RUNS=1`):
 the loop substrate takes the same gateway, and the schedule materializer then skips the payer
 chain, because on a deployment that holds the key there is nothing for a chain to resolve and

--- a/apps/api/src/events.ts
+++ b/apps/api/src/events.ts
@@ -44,7 +44,9 @@ const DOMAIN_EVENTS = [
   // re-reads the transcript); the session stays `working`; not webhook-eligible.
   "session.progress",
   // A slice of the answer being written, for a reply the model is streaming. Emitted
-  // on the ASKER's `u:<id>` channel with `session_id`, a monotonic `seq`, and `text`.
+  // on the ASKER's `u:<id>` channel with `session_id`, a monotonic `seq`, `text`, and the
+  // `attempt` it belongs to — a reply the loop re-generates starts a new attempt, and a reader
+  // must REPLACE on one rather than append (see lib/session-stream.ts).
   //
   // UNLIKE ITS SIBLINGS THIS ONE CARRIES CONTENT rather than being a bare wake — which
   // is the point, since re-reading is the round trip streaming exists to avoid. It is

--- a/apps/api/src/events.ts
+++ b/apps/api/src/events.ts
@@ -43,6 +43,16 @@ const DOMAIN_EVENTS = [
   // returns the tick instead of blocking to timeout. A wake only (the waiter
   // re-reads the transcript); the session stays `working`; not webhook-eligible.
   "session.progress",
+  // A slice of the answer being written, for a reply the model is streaming. Emitted
+  // on the ASKER's `u:<id>` channel with `session_id`, a monotonic `seq`, and `text`.
+  //
+  // UNLIKE ITS SIBLINGS THIS ONE CARRIES CONTENT rather than being a bare wake — which
+  // is the point, since re-reading is the round trip streaming exists to avoid. It is
+  // still not authoritative: deltas are coalesced, may be dropped, and are never
+  // persisted. The transcript written when the turn settles is the record, so a client
+  // that misses deltas loses the animation and nothing else. Not webhook-eligible —
+  // partial text is not something anyone can act on.
+  "session.delta",
 ] as const
 export type DomainEvent = (typeof DOMAIN_EVENTS)[number]
 

--- a/apps/api/src/lib/agent-loop.ts
+++ b/apps/api/src/lib/agent-loop.ts
@@ -100,6 +100,20 @@ export interface AgentLoopInput {
     system: string
     messages: ModelMessage[]
     tools: LoopTool[]
+    /** Assistant text as it arrives, so a caller can show a reply being written instead of
+     *  waiting for the whole thing.
+     *
+     *  OPTIONAL AND ADDITIVE ON PURPOSE. Streaming could have been a second return type, but
+     *  `callModel` is implemented by two adapters and consumed by the loop, turn-core,
+     *  session-turn and the substrate loop — plus every test that injects a fake. A callback on
+     *  the INPUT leaves all of them untouched: an adapter that ignores it behaves exactly as
+     *  before, and `ModelTurn` stays the single source of truth for the final text, tool calls,
+     *  truncation and cost. Nothing downstream reads deltas to make a decision.
+     *
+     *  Deltas are BEST EFFORT and non-authoritative: they may be coalesced, and an adapter or
+     *  provider without streaming simply never calls this. NEVER accumulate them into the answer
+     *  you persist — use the returned `ModelTurn.text`, which is always the complete reply. */
+    onDelta?: (text: string) => void
   }) => Promise<ModelTurn>
   /** Execute one tool server-side. Errors are RETURNED as text, never thrown — a failing tool
    *  is information the model should react to, not a reason to lose the whole run. */

--- a/apps/api/src/lib/edge-cache.ts
+++ b/apps/api/src/lib/edge-cache.ts
@@ -1,0 +1,57 @@
+import { edgeWaitUntil } from "../realtime-do"
+
+/**
+ * Serving an immutable response from Cloudflare's edge cache instead of rebuilding it.
+ *
+ * WHY THIS IS NEEDED AT ALL. A `Cache-Control` header on a Worker-generated response does not
+ * populate the edge cache. Cloudflare caches what it fetches from an origin; a response this
+ * Worker composed from a database row plus an R2 object is not that, so the header only ever
+ * reached the browser. The app has set careful immutable headers on content-addressed bytes for
+ * a long time and every request still ran the whole pipeline — the Cache API is the missing
+ * half, and it has to be called explicitly.
+ *
+ * WHAT MAY USE THIS. Only responses that are a pure function of the URL and identical for every
+ * caller. The edge cache key here is the request URL alone, so anything that varies by cookie,
+ * header or role would be served to the wrong person — that is not a tuning mistake, it is a
+ * data leak. Content-addressed bytes qualify because the hash IS the content: the same URL can
+ * never mean different bytes, and there is nothing user-specific to vary on.
+ *
+ * ON NODE THIS IS A NO-OP. `caches` is a Workers global; self-hosted Node has no edge in front
+ * of it, so the helper degrades to calling `produce()` and returning it.
+ */
+
+/** The Workers `caches.default`, or null anywhere that global does not exist (Node, tests). */
+const edgeCache = (): Cache | null => {
+  const c = (globalThis as { caches?: { default?: Cache } }).caches
+  return c?.default ?? null
+}
+
+/**
+ * Return a cached response for this request, else build one and cache it.
+ *
+ * `produce` runs only on a miss. Its response is cached only when it is a 200 — an error or a
+ * 404 must never become sticky for a year, and a partial (206) is not the whole resource.
+ *
+ * The `put` is deliberately NOT awaited: it rides `waitUntil`, so the caller gets its bytes
+ * without waiting for the cache write. A failed write is swallowed for the same reason a failed
+ * cache read is — the origin path just runs again next time, which is exactly today's behaviour.
+ */
+export const withEdgeCache = async (
+  req: Request,
+  produce: () => Promise<Response>,
+): Promise<Response> => {
+  const cache = edgeCache()
+  if (!cache) return produce()
+  // Only GET is cacheable, and `cache.match` would throw on anything else.
+  if (req.method !== "GET") return produce()
+
+  const hit = await cache.match(req).catch(() => undefined)
+  if (hit) return hit
+
+  const res = await produce()
+  if (res.status === 200) {
+    // The body can only be consumed once, so the cache gets a clone and the caller the original.
+    edgeWaitUntil(cache.put(req, res.clone()).catch(() => {}))
+  }
+  return res
+}

--- a/apps/api/src/lib/model-anthropic.ts
+++ b/apps/api/src/lib/model-anthropic.ts
@@ -115,6 +115,12 @@ const authHeaders = (c: AnthropicCredential): Record<string, string> =>
 export const anthropicModel = (opts: AnthropicOptions): AgentLoopInput["callModel"] => {
   const doFetch = opts.fetchImpl ?? fetch
   const model = opts.model ?? DEFAULT_ANTHROPIC_MODEL
+  // NO STREAMING HERE, deliberately. `onDelta` is part of the callModel contract and this adapter
+  // simply never calls it, which the contract explicitly allows — the caller then sees a reply
+  // that arrives whole, exactly as before streaming existed. Wiring it up is a separate job (the
+  // Messages API's SSE shape is a different reassembly from chat-completions'), and it buys
+  // nothing today: the lanes this adapter serves — the payer chain and unattended runs — have no
+  // watcher to stream to. Attended chat runs on the gateway adapter (see node.ts / worker.ts).
   return async ({ system, messages, tools }): Promise<ModelTurn> => {
     const res = await doFetch(API, {
       method: "POST",

--- a/apps/api/src/lib/model-openai.ts
+++ b/apps/api/src/lib/model-openai.ts
@@ -45,6 +45,129 @@ interface ToolCall {
   function?: { name?: string; arguments?: string }
 }
 
+/** The non-streaming chat-completions response. A streamed response is reassembled into exactly
+ *  this shape (see `readStream`) so the two transports share one parser. */
+interface CompletionBody {
+  choices?: {
+    message?: { content?: string | null; tool_calls?: ToolCall[] }
+    finish_reason?: string
+  }[]
+  usage?: { cost?: unknown }
+}
+
+/** One `data:` frame of a streamed completion. Tool calls arrive in fragments addressed by
+ *  `index`, with `name` on the first fragment and `arguments` split across later ones. */
+interface StreamChunk {
+  choices?: {
+    delta?: {
+      content?: string | null
+      tool_calls?: {
+        index?: number
+        id?: string
+        function?: { name?: string; arguments?: string }
+      }[]
+    }
+    finish_reason?: string | null
+  }[]
+  usage?: { cost?: unknown }
+}
+
+/**
+ * Reassemble a streamed completion into the buffered response shape, calling `onDelta` with
+ * assistant text as it arrives.
+ *
+ * Text is emitted as it comes; TOOL CALLS ARE NOT. A tool call's `arguments` is JSON split
+ * across frames at arbitrary boundaries, so a partial fragment is not parseable and is never
+ * useful to show — it is accumulated silently and parsed once at the end, exactly as the
+ * buffered path does.
+ *
+ * `onDelta` is caller code running inside our read loop: it is wrapped so a throw there cannot
+ * abort the stream and lose a reply that the model has already been paid for.
+ */
+async function readStream(res: Response, onDelta: (text: string) => void): Promise<CompletionBody> {
+  const body = res.body
+  if (!body) return { choices: [{ message: { content: "" }, finish_reason: "stop" }] }
+  const reader = body.getReader()
+  const decode = new TextDecoder()
+  let buffered = ""
+  let text = ""
+  let finish: string | undefined
+  let usage: { cost?: unknown } | undefined
+  // Keyed by the frame's `index` so two concurrent tool calls cannot interleave into one.
+  const calls = new Map<number, { id?: string; name?: string; args: string }>()
+
+  const emit = (chunk: string) => {
+    try {
+      onDelta(chunk)
+    } catch {
+      /* a listener that throws must not cost us the rest of the reply */
+    }
+  }
+
+  const handle = (frame: string) => {
+    if (!frame.startsWith("data:")) return
+    const payload = frame.slice(5).trim()
+    // The terminal sentinel, not JSON.
+    if (!payload || payload === "[DONE]") return
+    let parsed: StreamChunk
+    try {
+      parsed = JSON.parse(payload) as StreamChunk
+    } catch {
+      return // a malformed frame is skipped, not fatal — the rest of the reply still arrives
+    }
+    if (parsed.usage) usage = parsed.usage
+    const choice = parsed.choices?.[0]
+    if (!choice) return
+    if (choice.finish_reason) finish = choice.finish_reason
+    const piece = choice.delta?.content
+    if (piece) {
+      text += piece
+      emit(piece)
+    }
+    for (const t of choice.delta?.tool_calls ?? []) {
+      const i = t.index ?? 0
+      const slot = calls.get(i) ?? { args: "" }
+      if (t.id) slot.id = t.id
+      if (t.function?.name) slot.name = t.function.name
+      if (t.function?.arguments) slot.args += t.function.arguments
+      calls.set(i, slot)
+    }
+  }
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffered += decode.decode(value, { stream: true })
+      // Frames are separated by a blank line; the trailing partial stays buffered for the
+      // next read rather than being parsed half-formed.
+      const parts = buffered.split(/\r?\n\r?\n/)
+      buffered = parts.pop() ?? ""
+      for (const p of parts) handle(p.trim())
+    }
+    if (buffered.trim()) handle(buffered.trim())
+  } finally {
+    reader.releaseLock()
+  }
+
+  const toolCalls = [...calls.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([i, c]) => ({
+      id: c.id ?? `call_${i}`,
+      type: "function",
+      function: { name: c.name, arguments: c.args },
+    }))
+  return {
+    choices: [
+      {
+        message: { content: text, ...(toolCalls.length ? { tool_calls: toolCalls } : {}) },
+        finish_reason: finish,
+      },
+    ],
+    usage,
+  }
+}
+
 /**
  * What the turn cost, when the endpoint says so.
  *
@@ -163,7 +286,12 @@ const flatten = (content: unknown): string => {
 export const openAiCompatModel = (opts: OpenAiCompatOptions): AgentLoopInput["callModel"] => {
   const doFetch = opts.fetchImpl ?? fetch
   const url = `${opts.baseUrl.replace(/\/+$/, "")}/chat/completions`
-  return async ({ system, messages, tools }): Promise<ModelTurn> => {
+  return async ({ system, messages, tools, onDelta }): Promise<ModelTurn> => {
+    // Stream ONLY when someone is listening. Without `onDelta` this is byte-for-byte the
+    // request it has always sent, so every non-streaming caller (the loop's own tests, the
+    // substrate, automations) keeps the exact behaviour — and a gateway that does not support
+    // SSE is only ever asked for one when a caller actually wants deltas.
+    const wantStream = typeof onDelta === "function"
     const res = await doFetch(url, {
       method: "POST",
       headers: {
@@ -178,6 +306,9 @@ export const openAiCompatModel = (opts: OpenAiCompatOptions): AgentLoopInput["ca
           ...(messages as ModelMessage[]).flatMap(asMessages),
         ],
         ...(tools.length ? { tools: asTools(tools), tool_choice: "auto" } : {}),
+        // `stream_options` asks the gateway to send a final usage frame, which a stream
+        // otherwise omits — without it every streamed turn would report cost as unknown.
+        ...(wantStream ? { stream: true, stream_options: { include_usage: true } } : {}),
       }),
       signal: AbortSignal.timeout(120_000),
     })
@@ -186,13 +317,12 @@ export const openAiCompatModel = (opts: OpenAiCompatOptions): AgentLoopInput["ca
       // right judgement for a 429 or a 5xx. Same contract as the Anthropic client.
       throw new Error(`model call failed (${res.status}): ${(await res.text()).slice(0, 300)}`)
     }
-    const body = (await res.json()) as {
-      choices?: {
-        message?: { content?: string | null; tool_calls?: ToolCall[] }
-        finish_reason?: string
-      }[]
-      usage?: { cost?: unknown }
-    }
+    // A streamed response is reassembled into the SAME shape the buffered branch parses below,
+    // so everything after this point — truncation, tool calls, cost, `done` — is one code path
+    // and cannot drift between streaming and non-streaming callers.
+    const body = wantStream
+      ? await readStream(res, onDelta as (t: string) => void)
+      : ((await res.json()) as CompletionBody)
     const choice = body.choices?.[0]
     const calls = choice?.message?.tool_calls ?? []
     // TRUNCATION IS NOT A REPLY. The revision contract asks for the COMPLETE document back, so

--- a/apps/api/src/lib/model-openai.ts
+++ b/apps/api/src/lib/model-openai.ts
@@ -86,15 +86,23 @@ interface StreamChunk {
  */
 async function readStream(res: Response, onDelta: (text: string) => void): Promise<CompletionBody> {
   const body = res.body
-  if (!body) return { choices: [{ message: { content: "" }, finish_reason: "stop" }] }
+  // No body at all is a broken response, not an empty answer. Returning a tidy "" here would
+  // hand the contract a finished, blank reply; the buffered branch throws on this, and the
+  // loop's retry is the right judgement for both.
+  if (!body) throw new Error("model stream had no body")
   const reader = body.getReader()
   const decode = new TextDecoder()
   let buffered = ""
   let text = ""
   let finish: string | undefined
   let usage: { cost?: unknown } | undefined
+  // Did the provider actually tell us the answer ENDED? See the throw at the bottom.
+  let sawTerminal = false
   // Keyed by the frame's `index` so two concurrent tool calls cannot interleave into one.
   const calls = new Map<number, { id?: string; name?: string; args: string }>()
+  // The last index we saw. A fragment that omits `index` continues the call it was already
+  // building — defaulting to 0 instead would staple its arguments onto an unrelated call.
+  let lastIndex = 0
 
   const emit = (chunk: string) => {
     try {
@@ -105,10 +113,23 @@ async function readStream(res: Response, onDelta: (text: string) => void): Promi
   }
 
   const handle = (frame: string) => {
-    if (!frame.startsWith("data:")) return
-    const payload = frame.slice(5).trim()
+    // An SSE event is a set of LINES, and only the `data:` ones carry payload. Testing
+    // `startsWith` on the whole frame drops any event that leads with `event:`, `id:` or a
+    // `:` comment — spec-legal shapes a proxy or self-hosted gateway really does emit — and
+    // silently yields an empty answer. Multiple `data:` lines in one event are joined with a
+    // newline, which is what the spec says they mean.
+    const payload = frame
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trim())
+      .join("\n")
+      .trim()
+    if (!payload) return
     // The terminal sentinel, not JSON.
-    if (!payload || payload === "[DONE]") return
+    if (payload === "[DONE]") {
+      sawTerminal = true
+      return
+    }
     let parsed: StreamChunk
     try {
       parsed = JSON.parse(payload) as StreamChunk
@@ -118,14 +139,18 @@ async function readStream(res: Response, onDelta: (text: string) => void): Promi
     if (parsed.usage) usage = parsed.usage
     const choice = parsed.choices?.[0]
     if (!choice) return
-    if (choice.finish_reason) finish = choice.finish_reason
+    if (choice.finish_reason) {
+      finish = choice.finish_reason
+      sawTerminal = true
+    }
     const piece = choice.delta?.content
     if (piece) {
       text += piece
       emit(piece)
     }
     for (const t of choice.delta?.tool_calls ?? []) {
-      const i = t.index ?? 0
+      const i = t.index ?? lastIndex
+      lastIndex = i
       const slot = calls.get(i) ?? { args: "" }
       if (t.id) slot.id = t.id
       if (t.function?.name) slot.name = t.function.name
@@ -147,8 +172,25 @@ async function readStream(res: Response, onDelta: (text: string) => void): Promi
     }
     if (buffered.trim()) handle(buffered.trim())
   } finally {
-    reader.releaseLock()
+    // CANCEL, not just releaseLock. Releasing the lock leaves the underlying body un-cancelled,
+    // so the producer's teardown never runs and the subrequest is left open on workerd — the
+    // leak this `finally` was meant to prevent. cancel() releases the lock as part of its
+    // contract, so it covers both.
+    await reader.cancel().catch(() => {})
   }
+
+  // A STREAM THAT JUST STOPS IS A FAILURE, NOT A SHORT ANSWER. Without a terminal signal
+  // (`finish_reason`, or the `[DONE]` sentinel) the reply is simply however much arrived before
+  // the gateway died, a proxy timed out, or the final chunk was dropped. The buffered branch
+  // could never reach here — `res.json()` throws on a truncated body — and the loop reads that
+  // throw as a retryable model failure, which is the right judgement for both transports.
+  //
+  // Two things go wrong if this is allowed through. The truncation guard below keys on
+  // `finish_reason === "length"`, so a lost final frame silently disables the one check that
+  // stops a half-written document being treated as a finished reply. And a retryable transport
+  // fault gets laundered into a "the model answered" outcome that the contract then rejects as
+  // unretryable, killing the run instead of trying again.
+  if (!sawTerminal) throw new Error("model stream ended without a terminal frame")
 
   const toolCalls = [...calls.entries()]
     .sort(([a], [b]) => a - b)
@@ -292,35 +334,57 @@ export const openAiCompatModel = (opts: OpenAiCompatOptions): AgentLoopInput["ca
     // substrate, automations) keeps the exact behaviour — and a gateway that does not support
     // SSE is only ever asked for one when a caller actually wants deltas.
     const wantStream = typeof onDelta === "function"
-    const res = await doFetch(url, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${opts.apiKey}`,
-      },
-      body: JSON.stringify({
-        model: opts.model,
-        max_tokens: opts.maxTokens ?? 8_000,
-        messages: [
-          { role: "system", content: system },
-          ...(messages as ModelMessage[]).flatMap(asMessages),
-        ],
-        ...(tools.length ? { tools: asTools(tools), tool_choice: "auto" } : {}),
-        // `stream_options` asks the gateway to send a final usage frame, which a stream
-        // otherwise omits — without it every streamed turn would report cost as unknown.
-        ...(wantStream ? { stream: true, stream_options: { include_usage: true } } : {}),
-      }),
-      signal: AbortSignal.timeout(120_000),
-    })
+    const send = (stream: boolean) =>
+      doFetch(url, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${opts.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: opts.model,
+          max_tokens: opts.maxTokens ?? 8_000,
+          messages: [
+            { role: "system", content: system },
+            ...(messages as ModelMessage[]).flatMap(asMessages),
+          ],
+          ...(tools.length ? { tools: asTools(tools), tool_choice: "auto" } : {}),
+          // `stream_options` asks the gateway to send a final usage frame, which a stream
+          // otherwise omits — without it every streamed turn would report cost as unknown.
+          ...(stream ? { stream: true, stream_options: { include_usage: true } } : {}),
+        }),
+        signal: AbortSignal.timeout(120_000),
+      })
+
+    let res = await send(wantStream)
+    // STREAMING MUST NEVER MAKE A REQUEST FAIL THAT WOULD OTHERWISE HAVE SUCCEEDED.
+    //
+    // "OpenAI-compatible" is a wire format, not a guarantee: plenty of gateways this adapter
+    // exists to reach (older vLLM, some Azure api-versions, hand-rolled proxies) reject the
+    // unknown `stream_options` field, or SSE itself, with a 4xx. Without this retry the ONLY
+    // lane that asks for a stream — attended chat — would break on those deployments while
+    // every other lane kept working, which is a baffling thing to debug and a regression
+    // against behaviour that shipped fine before. One buffered retry costs a round trip on a
+    // request that already failed, and the person just loses the animation.
+    let streamed = wantStream
+    if (wantStream && !res.ok && res.status >= 400 && res.status < 500) {
+      res = await send(false)
+      streamed = false
+    }
     if (!res.ok) {
       // Thrown, not returned — the loop treats a failed model CALL as retryable, which is the
       // right judgement for a 429 or a 5xx. Same contract as the Anthropic client.
       throw new Error(`model call failed (${res.status}): ${(await res.text()).slice(0, 300)}`)
     }
+    // A gateway may also honour the request and answer with ordinary JSON anyway. Trust the
+    // content type over what we asked for: parsing a JSON body as SSE finds no `data:` frames
+    // and would yield a silent empty reply.
+    if (streamed && !(res.headers.get("content-type") ?? "").includes("text/event-stream"))
+      streamed = false
     // A streamed response is reassembled into the SAME shape the buffered branch parses below,
     // so everything after this point — truncation, tool calls, cost, `done` — is one code path
     // and cannot drift between streaming and non-streaming callers.
-    const body = wantStream
+    const body = streamed
       ? await readStream(res, onDelta as (t: string) => void)
       : ((await res.json()) as CompletionBody)
     const choice = body.choices?.[0]

--- a/apps/api/src/lib/session-stream.ts
+++ b/apps/api/src/lib/session-stream.ts
@@ -1,3 +1,4 @@
+import { log } from "../log"
 import type { AgentLoopInput } from "./agent-loop"
 
 /**
@@ -157,14 +158,24 @@ export const makeDeltaStream = (opts: DeltaStreamOpts): DeltaStream => {
             // A reader who shows up later resets the count, so arriving mid-answer starts the
             // animation rather than finding a stream that already gave up.
             consecutiveMisses = delivered === 0 ? consecutiveMisses + 1 : 0
-            if (consecutiveMisses >= MISSES_BEFORE_QUIET) streaming = false
+            if (consecutiveMisses >= MISSES_BEFORE_QUIET && streaming) {
+              streaming = false
+              // Without this line the three states — "the gateway isn't streaming", "the realtime
+              // room is broken", and "nobody was watching" — are indistinguishable in production,
+              // because all three look like a reply that simply arrived whole.
+              log.info("session stream: no listener, going quiet", { slices: seq })
+            }
           })
           .catch(() => {
             /* an unanswerable probe is not a reason to stop streaming */
           })
-    } catch {
+    } catch (e) {
       // A transport blip must not abort a turn the model has already been paid for. The
-      // transcript still lands on settle, so the reader gets the whole answer regardless.
+      // transcript still lands on settle, so the reader gets the whole answer regardless — but
+      // a backplane rejecting every publish should not be silent.
+      log.warn("session stream: publish failed", {
+        error: e instanceof Error ? e.message : String(e),
+      })
     }
   }
 

--- a/apps/api/src/lib/session-stream.ts
+++ b/apps/api/src/lib/session-stream.ts
@@ -24,8 +24,17 @@ import type { AgentLoopInput } from "./agent-loop"
 /** Flush when the buffer reaches this many characters. A paragraph-ish slice: large enough to
  *  keep publish counts low, small enough that the text still visibly streams. */
 export const DELTA_FLUSH_CHARS = 200
-/** ...or when the oldest buffered text is this old, so a slow model still shows progress. */
-export const DELTA_FLUSH_MS = 80
+/**
+ * ...or when the oldest buffered text is this old, so a slow model still shows progress.
+ *
+ * THIS NUMBER IS THE COST DIAL, and it is the one that actually fires. A model emitting a few
+ * hundred characters a second reaches the age boundary long before the size one, so the publish
+ * rate is essentially `1000 / DELTA_FLUSH_MS` per second — at 80ms that is ~12 Durable Object
+ * fetches a second, or ~250 for a twenty-second answer, which is exactly the many-small-round-
+ * trips shape the rest of this work exists to remove. At 250ms it is 4 a second, and a reader
+ * cannot tell the difference: prose arrives faster than anyone reads it either way.
+ */
+export const DELTA_FLUSH_MS = 250
 
 export interface DeltaStream {
   /** Wrap `callModel` so its text deltas publish, coalesced.
@@ -41,8 +50,15 @@ export interface DeltaStream {
 }
 
 export interface DeltaStreamOpts {
-  /** Publish one coalesced slice. Failures are swallowed by the caller of this. */
-  publish: (slice: { seq: number; text: string }) => void
+  /**
+   * Publish one coalesced slice.
+   *
+   * MAY RETURN A DELIVERY COUNT (a promise of how many live streams received it). When the
+   * FIRST slice reports zero, streaming switches off for the rest of the turn — see the
+   * no-listener note on `makeDeltaStream`. A `void` return means "no receipt available", and
+   * streaming simply continues.
+   */
+  publish: (slice: { seq: number; text: string }) => void | Promise<number>
   /** Injectable clock, so tests do not sleep. */
   now?: () => number
   flushChars?: number
@@ -56,15 +72,34 @@ export const makeDeltaStream = (opts: DeltaStreamOpts): DeltaStream => {
   let buffer = ""
   let oldestAt = 0
   let seq = 0
+  // Flipped off when the first slice reports nobody received it. Most turns have no watcher —
+  // an MCP `use()` ask, an API caller, a tab closed mid-generation — and for those every
+  // further publish is pure waste. Costing one probe to skip the rest is the single biggest
+  // saving here: those turns go from tens of Durable Object fetches to exactly one.
+  //
+  // A reader who opens the page mid-answer is not stranded: the terminal `session.settled`
+  // still fires, and settling is what makes a client re-read the transcript. They lose the
+  // animation, not the answer.
+  let streaming = true
 
   const flush = () => {
-    if (!buffer) return
+    if (!buffer || !streaming) return
     seq += 1
     const slice = { seq, text: buffer }
     buffer = ""
     oldestAt = 0
     try {
-      opts.publish(slice)
+      const receipt = opts.publish(slice)
+      // Only the FIRST slice is probed. Later ones would pay a promise per publish to learn
+      // something that rarely changes mid-turn.
+      if (seq === 1 && receipt && typeof receipt.then === "function")
+        void receipt
+          .then((delivered) => {
+            if (delivered === 0) streaming = false
+          })
+          .catch(() => {
+            /* an unanswerable probe is not a reason to stop streaming */
+          })
     } catch {
       // A transport blip must not abort a turn the model has already been paid for. The
       // transcript still lands on settle, so the reader gets the whole answer regardless.
@@ -80,7 +115,9 @@ export const makeDeltaStream = (opts: DeltaStreamOpts): DeltaStream => {
       inner({
         ...input,
         onDelta: (text) => {
-          if (!text) return
+          // Once nobody is listening, stop even ACCUMULATING: the returned ModelTurn is the
+          // answer, so buffering text no one will receive just holds memory for the turn.
+          if (!text || !streaming) return
           if (!buffer) oldestAt = now()
           buffer += text
           if (buffer.length >= maxChars || now() - oldestAt >= maxMs) flush()

--- a/apps/api/src/lib/session-stream.ts
+++ b/apps/api/src/lib/session-stream.ts
@@ -67,7 +67,7 @@ export interface DeltaStreamOpts {
    * no-listener note on `makeDeltaStream`. A `void` return means "no receipt available", and
    * streaming simply continues.
    */
-  publish: (slice: { seq: number; text: string }) => void | Promise<number>
+  publish: (slice: { seq: number; text: string; attempt: number }) => void | Promise<number>
   /** Injectable clock, so tests do not sleep. */
   now?: () => number
   flushChars?: number
@@ -100,11 +100,20 @@ export const makeDeltaStream = (opts: DeltaStreamOpts): DeltaStream => {
   // They lose the animation, not the answer.
   let streaming = true
   let consecutiveMisses = 0
+  // Which model ATTEMPT these slices belong to.
+  //
+  // The agent loop may call the model more than once for a single answer: attended chat runs
+  // `maxTurns: NUDGE_LIMIT + 1`, so a reply that misses the reply contract is nudged and
+  // re-generated. The first attempt's text is DISCARDED — only the last one becomes the
+  // transcript. Without this counter a client would append the abandoned attempt to the real
+  // one and show a garbled reply that never matches what gets persisted. Slices carry the
+  // attempt they came from so a reader can drop everything older the moment a new one starts.
+  let attempt = 0
 
   const flush = () => {
     if (!buffer || !streaming) return
     seq += 1
-    const slice = { seq, text: buffer }
+    const slice = { seq, text: buffer, attempt }
     buffer = ""
     oldestAt = 0
     try {
@@ -133,8 +142,14 @@ export const makeDeltaStream = (opts: DeltaStreamOpts): DeltaStream => {
       return seq
     },
     flush,
-    wrap: (inner) => (input) =>
-      inner({
+    wrap: (inner) => (input) => {
+      // A new model attempt. Anything still buffered belongs to the attempt being abandoned,
+      // so it is dropped rather than flushed — publishing it would put text on screen that the
+      // transcript is never going to contain.
+      attempt += 1
+      buffer = ""
+      oldestAt = 0
+      return inner({
         ...input,
         onDelta: (text) => {
           // Once nobody is listening, stop even ACCUMULATING: the returned ModelTurn is the
@@ -144,6 +159,7 @@ export const makeDeltaStream = (opts: DeltaStreamOpts): DeltaStream => {
           buffer += text
           if (buffer.length >= maxChars || now() - oldestAt >= maxMs) flush()
         },
-      }),
+      })
+    },
   }
 }

--- a/apps/api/src/lib/session-stream.ts
+++ b/apps/api/src/lib/session-stream.ts
@@ -35,6 +35,15 @@ export const DELTA_FLUSH_CHARS = 200
  * cannot tell the difference: prose arrives faster than anyone reads it either way.
  */
 export const DELTA_FLUSH_MS = 250
+/**
+ * How many consecutive slices must reach nobody before the turn stops publishing.
+ *
+ * Not one: the client cannot subscribe until it knows the session is unsettled, which costs a
+ * round trip after the POST, so a quick model can emit its first slice into an empty room. At
+ * the flush cadence three misses is under a second of tolerance — long enough to lose the race
+ * gracefully, short enough that a genuinely unwatched turn goes quiet almost at once.
+ */
+export const MISSES_BEFORE_QUIET = 3
 
 export interface DeltaStream {
   /** Wrap `callModel` so its text deltas publish, coalesced.
@@ -72,15 +81,25 @@ export const makeDeltaStream = (opts: DeltaStreamOpts): DeltaStream => {
   let buffer = ""
   let oldestAt = 0
   let seq = 0
-  // Flipped off when the first slice reports nobody received it. Most turns have no watcher —
-  // an MCP `use()` ask, an API caller, a tab closed mid-generation — and for those every
-  // further publish is pure waste. Costing one probe to skip the rest is the single biggest
-  // saving here: those turns go from tens of Durable Object fetches to exactly one.
+  // Flipped off once several slices in a row reach nobody. Most turns have no watcher — an MCP
+  // `use()` ask, an API caller, a tab closed mid-generation — and for those every publish is
+  // waste, so this is the single biggest saving here: those turns settle down to a couple of
+  // Durable Object fetches instead of tens.
   //
-  // A reader who opens the page mid-answer is not stranded: the terminal `session.settled`
-  // still fires, and settling is what makes a client re-read the transcript. They lose the
-  // animation, not the answer.
+  // WHY NOT STOP ON THE FIRST ZERO. There is a startup race, and stopping on one reading loses
+  // to it every time a model is quick. The client cannot subscribe until it knows the session
+  // is unsettled, which costs it a round trip after the POST; a model that emits its first
+  // token before that lands would publish to an empty room, and a single-reading rule would
+  // then disable streaming for the whole turn. This was not theoretical — it is exactly what
+  // the context console did on the preview: the reply arrived, and not one delta with it.
+  // Requiring consecutive misses tolerates the race (a few hundred ms at the flush cadence)
+  // while still going quiet almost immediately for a turn nobody is actually watching.
+  //
+  // A reader who opens the page mid-answer is not stranded either way: the terminal
+  // `session.settled` still fires, and settling is what makes a client re-read the transcript.
+  // They lose the animation, not the answer.
   let streaming = true
+  let consecutiveMisses = 0
 
   const flush = () => {
     if (!buffer || !streaming) return
@@ -90,12 +109,15 @@ export const makeDeltaStream = (opts: DeltaStreamOpts): DeltaStream => {
     oldestAt = 0
     try {
       const receipt = opts.publish(slice)
-      // Only the FIRST slice is probed. Later ones would pay a promise per publish to learn
-      // something that rarely changes mid-turn.
-      if (seq === 1 && receipt && typeof receipt.then === "function")
+      // Every slice is probed, not just the first — the count is what the publish already
+      // returns, so reading it costs nothing extra, and a watcher can arrive or leave mid-turn.
+      if (receipt && typeof receipt.then === "function")
         void receipt
           .then((delivered) => {
-            if (delivered === 0) streaming = false
+            // A reader who shows up later resets the count, so arriving mid-answer starts the
+            // animation rather than finding a stream that already gave up.
+            consecutiveMisses = delivered === 0 ? consecutiveMisses + 1 : 0
+            if (consecutiveMisses >= MISSES_BEFORE_QUIET) streaming = false
           })
           .catch(() => {
             /* an unanswerable probe is not a reason to stop streaming */

--- a/apps/api/src/lib/session-stream.ts
+++ b/apps/api/src/lib/session-stream.ts
@@ -1,0 +1,90 @@
+import type { AgentLoopInput } from "./agent-loop"
+
+/**
+ * Streaming a reply to the person waiting for it, without paying a round trip per token.
+ *
+ * WHY COALESCE. Each publish is one Durable Object fetch on the hosted tier (the per-user
+ * `u:<id>` channel is a DO-backed room — see realtime-do.ts). A model emits hundreds of
+ * tokens per reply, so publishing each one would be hundreds of DO calls for a single answer:
+ * the exact "many small round trips" shape the rest of this work exists to remove. Slices are
+ * therefore accumulated and flushed on a size or age boundary, taking a typical reply to tens
+ * of publishes instead of hundreds.
+ *
+ * WHY NO TIMER. The obvious flush-on-an-interval needs a timer that outlives the request, and
+ * background work in a Worker is bounded by waitUntil — a pending timer is a lifecycle hazard
+ * and a leak when the turn throws. Instead the age check runs when the NEXT delta arrives, and
+ * `flush()` (always called before the turn settles) covers whatever is left. A model that goes
+ * quiet mid-reply simply holds its tail until the next token or the settle, which is exactly
+ * when the reader would have seen it anyway.
+ *
+ * DELTAS ARE NEVER THE RECORD. Nothing here is persisted; the transcript row written when the
+ * turn settles is the answer. A dropped or coalesced delta costs the animation, never content.
+ */
+
+/** Flush when the buffer reaches this many characters. A paragraph-ish slice: large enough to
+ *  keep publish counts low, small enough that the text still visibly streams. */
+export const DELTA_FLUSH_CHARS = 200
+/** ...or when the oldest buffered text is this old, so a slow model still shows progress. */
+export const DELTA_FLUSH_MS = 80
+
+export interface DeltaStream {
+  /** Wrap `callModel` so its text deltas publish, coalesced.
+   *
+   *  Wrapping the CALL rather than threading an `onDelta` parameter through runSessionTurn →
+   *  runTurn → agent-loop keeps every one of those layers untouched: they pass `callModel`
+   *  along as they always have, and the streaming decision stays where the transport is known. */
+  wrap(inner: AgentLoopInput["callModel"]): AgentLoopInput["callModel"]
+  /** Publish anything still buffered. Call before settling the turn. */
+  flush(): void
+  /** Slices published so far — the sequence a client uses to order and spot gaps. */
+  readonly seq: number
+}
+
+export interface DeltaStreamOpts {
+  /** Publish one coalesced slice. Failures are swallowed by the caller of this. */
+  publish: (slice: { seq: number; text: string }) => void
+  /** Injectable clock, so tests do not sleep. */
+  now?: () => number
+  flushChars?: number
+  flushMs?: number
+}
+
+export const makeDeltaStream = (opts: DeltaStreamOpts): DeltaStream => {
+  const now = opts.now ?? (() => Date.now())
+  const maxChars = opts.flushChars ?? DELTA_FLUSH_CHARS
+  const maxMs = opts.flushMs ?? DELTA_FLUSH_MS
+  let buffer = ""
+  let oldestAt = 0
+  let seq = 0
+
+  const flush = () => {
+    if (!buffer) return
+    seq += 1
+    const slice = { seq, text: buffer }
+    buffer = ""
+    oldestAt = 0
+    try {
+      opts.publish(slice)
+    } catch {
+      // A transport blip must not abort a turn the model has already been paid for. The
+      // transcript still lands on settle, so the reader gets the whole answer regardless.
+    }
+  }
+
+  return {
+    get seq() {
+      return seq
+    },
+    flush,
+    wrap: (inner) => (input) =>
+      inner({
+        ...input,
+        onDelta: (text) => {
+          if (!text) return
+          if (!buffer) oldestAt = now()
+          buffer += text
+          if (buffer.length >= maxChars || now() - oldestAt >= maxMs) flush()
+        },
+      }),
+  }
+}

--- a/apps/api/src/lib/session-stream.ts
+++ b/apps/api/src/lib/session-stream.ts
@@ -45,6 +45,32 @@ export const DELTA_FLUSH_MS = 250
  */
 export const MISSES_BEFORE_QUIET = 3
 
+/**
+ * Where the prose stops and the machinery starts.
+ *
+ * The attended reply contract asks the model to answer in prose and then END with a single
+ * `<revision>` (or `<edits>`) block whose JSON carries the COMPLETE new document source. The
+ * settled transcript never shows that — `proseOf` strips it in turn-core once the loop
+ * returns — but the stream is upstream of all of it, so without this the person watching sees
+ * their answer followed by twelve kilobytes of escaped JSON scrolling past, on the single most
+ * common chat action there is: asking for a change.
+ *
+ * The contract guarantees prose comes FIRST, so a prefix check is enough; no parser needed.
+ */
+const BLOCK_MARKERS = ["<revision", "<edits"] as const
+/** Longest marker minus one: the most that could be a marker split across two slices. */
+const MARKER_HOLDBACK = Math.max(...BLOCK_MARKERS.map((m) => m.length)) - 1
+
+/** Index where the reply stops being prose, or -1 while it is all still prose. */
+const blockStart = (s: string): number => {
+  let at = -1
+  for (const m of BLOCK_MARKERS) {
+    const i = s.indexOf(m)
+    if (i !== -1 && (at === -1 || i < at)) at = i
+  }
+  return at
+}
+
 export interface DeltaStream {
   /** Wrap `callModel` so its text deltas publish, coalesced.
    *
@@ -54,8 +80,6 @@ export interface DeltaStream {
   wrap(inner: AgentLoopInput["callModel"]): AgentLoopInput["callModel"]
   /** Publish anything still buffered. Call before settling the turn. */
   flush(): void
-  /** Slices published so far — the sequence a client uses to order and spot gaps. */
-  readonly seq: number
 }
 
 export interface DeltaStreamOpts {
@@ -109,8 +133,15 @@ export const makeDeltaStream = (opts: DeltaStreamOpts): DeltaStream => {
   // one and show a garbled reply that never matches what gets persisted. Slices carry the
   // attempt they came from so a reader can drop everything older the moment a new one starts.
   let attempt = 0
+  // Everything the model has emitted for THIS attempt, and how much of it has been queued for
+  // publication. Tracked separately from `buffer` because what the reader should see is a
+  // prefix of the reply, not all of it — see BLOCK_MARKERS.
+  let seen = ""
+  let published = 0
+  // Latched once the reply reaches its machinery block: nothing after it is ever shown.
+  let suppressed = false
 
-  const flush = () => {
+  const flushBuffer = () => {
     if (!buffer || !streaming) return
     seq += 1
     const slice = { seq, text: buffer, attempt }
@@ -137,27 +168,50 @@ export const makeDeltaStream = (opts: DeltaStreamOpts): DeltaStream => {
     }
   }
 
+  /** Queue the prose up to `upto` that has not been queued yet. */
+  const queue = (upto: string) => {
+    if (upto.length <= published) return
+    if (!buffer) oldestAt = now()
+    buffer += upto.slice(published)
+    published = upto.length
+  }
+
   return {
-    get seq() {
-      return seq
+    // Release the held-back tail (nothing more is coming, so it cannot be a partial marker)
+    // and publish whatever is left. Called once, by `reply()`, before the turn settles.
+    flush: () => {
+      if (!suppressed) queue(seen)
+      flushBuffer()
     },
-    flush,
     wrap: (inner) => (input) => {
-      // A new model attempt. Anything still buffered belongs to the attempt being abandoned,
-      // so it is dropped rather than flushed — publishing it would put text on screen that the
-      // transcript is never going to contain.
+      // A new model attempt. Everything about the previous one is dropped rather than flushed —
+      // publishing it would put text on screen the transcript is never going to contain.
       attempt += 1
       buffer = ""
       oldestAt = 0
+      seen = ""
+      published = 0
+      suppressed = false
       return inner({
         ...input,
         onDelta: (text) => {
           // Once nobody is listening, stop even ACCUMULATING: the returned ModelTurn is the
           // answer, so buffering text no one will receive just holds memory for the turn.
-          if (!text || !streaming) return
-          if (!buffer) oldestAt = now()
-          buffer += text
-          if (buffer.length >= maxChars || now() - oldestAt >= maxMs) flush()
+          if (!text || !streaming || suppressed) return
+          seen += text
+          const cut = blockStart(seen)
+          if (cut !== -1) {
+            // The prose ended and the machinery began. Show the prose, then go quiet for the
+            // rest of this attempt.
+            queue(seen.slice(0, cut))
+            suppressed = true
+            flushBuffer()
+            return
+          }
+          // Hold back a marker-length tail: `<revi` now could be `<revision` next slice, and
+          // showing it and retracting it would be worse than showing it a beat later.
+          queue(seen.slice(0, Math.max(0, seen.length - MARKER_HOLDBACK)))
+          if (buffer.length >= maxChars || now() - oldestAt >= maxMs) flushBuffer()
         },
       })
     },

--- a/apps/api/src/lib/substrate-loop.ts
+++ b/apps/api/src/lib/substrate-loop.ts
@@ -40,8 +40,15 @@ import {
  *
  * TWO LANES, ONE TURN. A run is an automation firing; a session is somebody asking. The middle of
  * both — call the model, nudge once, gate, write — is lib/turn-core.ts, shared with attended chat.
- * What differs is exactly two things, and they stay explicit here rather than being unified into
- * something that fits neither: how the work ARRIVES, and how it SETTLES.
+ * What differs is three things, and they stay explicit here rather than being unified into
+ * something that fits neither: how the work ARRIVES, how it SETTLES, and whether the answer
+ * STREAMS.
+ *
+ * Streaming belongs to the attended lane alone, and structurally rather than by omission: that
+ * lane calls the model in-process on the asker's own request, so it has a live channel to publish
+ * slices onto (routes/contexts.ts wraps `callModel` before handing it to turn-core). This lane
+ * executes behind a capability token and reports once, at settle — there is no open connection to
+ * stream into, so a runner-served ask shows its waiting state until the answer lands.
  *
  * The arrival difference is not cosmetic. `GET /v1/agent/runs/claim` returns a LIST you search by
  * id; `POST /v1/agent/sessions/claim` returns ONE session, because the token already names it.

--- a/apps/api/src/routes/blob.ts
+++ b/apps/api/src/routes/blob.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono"
 import type { AppContext } from "../context"
+import { withEdgeCache } from "../lib/edge-cache"
 import { RAW_HEADERS, toBody } from "../lib/http"
 
 const HASH_RE = /^([0-9a-f]{64})(?:\.[a-zA-Z0-9]+)?$/
@@ -24,11 +25,19 @@ export const blobRoutes = (ctx: AppContext) => {
     const m = HASH_RE.exec(c.req.param("file"))
     if (!m) return c.text("not found", 404, RAW_HEADERS)
     const hash = m[1] as string
-    const row = await meta.getAsset(hash)
-    if (!row) return c.text("not found", 404, RAW_HEADERS)
-    const data = await blobs.get(hash)
-    if (!data) return c.text("blob missing", 500)
-    return c.body(toBody(data), 200, { ...RAW_HEADERS, "Content-Type": row.content_type })
+    // SERVED FROM THE EDGE ON A REPEAT HIT, and this is the safest possible place to start doing
+    // that: the URL is a sha256 OF THE BYTES, so it is content-addressed and can never come to
+    // mean something else, and the route is deliberately unauthenticated — there is no
+    // per-caller variation for a URL-keyed cache to get wrong. Every image and font in every
+    // published page comes through here, and each hit was paying a Postgres round trip for the
+    // `asset` row plus an R2 fetch, to return bytes already marked `immutable`.
+    return withEdgeCache(c.req.raw, async () => {
+      const row = await meta.getAsset(hash)
+      if (!row) return c.text("not found", 404, RAW_HEADERS)
+      const data = await blobs.get(hash)
+      if (!data) return c.text("blob missing", 500)
+      return c.body(toBody(data), 200, { ...RAW_HEADERS, "Content-Type": row.content_type })
+    })
   })
 
   return app

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -94,13 +94,16 @@ export const contextRoutes = (ctx: AppContext) => {
     // rather than one per token. Ephemeral by construction — `reply()` below still writes the
     // whole transcript row, which stays the record.
     const stream = makeDeltaStream({
-      publish: ({ seq, text }) =>
-        bus.publish(`u:${s.asker_id}`, {
-          type: "session.delta",
-          session_id: s.id,
-          seq,
-          text,
-        }),
+      publish: ({ seq, text }) => {
+        const channel = `u:${s.asker_id}`
+        const event = { type: "session.delta" as const, session_id: s.id, seq, text }
+        // Prefer the receipt-bearing publish: its delivery count is what lets the stream switch
+        // itself off when no tab is open, which is most turns (an MCP ask, an API caller, a
+        // closed page). Falls back to a plain publish on a backplane that cannot count.
+        return bus.publishWithReceipt
+          ? bus.publishWithReceipt(channel, event)
+          : bus.publish(channel, event)
+      },
     })
     const reply = async (body: string, state: SessionState, payload?: unknown) => {
       // Push the tail before the terminal event, so a client can never receive "settled" while

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -33,6 +33,7 @@ import { sha256 } from "../lib/crypto"
 import { bail, fail, readJson } from "../lib/http"
 import { canPayForAgent, NO_PAYER_MESSAGE } from "../lib/payer"
 import { RUN_LEASE_MS } from "../lib/run-lifecycle"
+import { makeDeltaStream } from "../lib/session-stream"
 import { runSessionTurn } from "../lib/session-turn"
 import { log } from "../log"
 
@@ -89,7 +90,22 @@ export const contextRoutes = (ctx: AppContext) => {
   ) => {
     const subject = parseSubject(s.subject_ref)
     if (!subject || subject.kind !== "artifact") return
+    // Slices of the answer as the model writes it, coalesced so a reply costs tens of publishes
+    // rather than one per token. Ephemeral by construction — `reply()` below still writes the
+    // whole transcript row, which stays the record.
+    const stream = makeDeltaStream({
+      publish: ({ seq, text }) =>
+        bus.publish(`u:${s.asker_id}`, {
+          type: "session.delta",
+          session_id: s.id,
+          seq,
+          text,
+        }),
+    })
     const reply = async (body: string, state: SessionState, payload?: unknown) => {
+      // Push the tail before the terminal event, so a client can never receive "settled" while
+      // a slice is still buffered and end up rendering a truncated answer mid-animation.
+      stream.flush()
       await meta.addSessionMessage(
         {
           id: newId("sm"),
@@ -101,6 +117,12 @@ export const contextRoutes = (ctx: AppContext) => {
         },
         state,
       )
+      // WAKE THE ASKER. An attended turn used to settle silently — it is served in-process, so
+      // nothing went through the runner report path that publishes this, and a watching client
+      // learned the answer had landed only on its next poll. Streaming makes this mandatory
+      // rather than merely nice: deltas with no terminal event leave a reader watching a reply
+      // that never officially finishes.
+      if (state !== "open") settleWake(s, state)
     }
     const flags = await meta.getOrgSettings(s.org_id).catch(() => null)
     // No model wired (the common self-host case) — say so in the transcript rather than leaving
@@ -204,7 +226,10 @@ export const contextRoutes = (ctx: AppContext) => {
           notifyRender: ctx.notifyRender,
           background: ctx.background,
           search: ctx.search,
-          callModel: ctx.callModel,
+          // Wrapped, not re-plumbed: runSessionTurn → runTurn → the agent loop all keep passing
+          // `callModel` along exactly as before, and the streaming decision stays here, where
+          // the transport (this asker's channel) is actually known.
+          callModel: stream.wrap(ctx.callModel),
           billingBlocked: ctx.billingBlocked,
         },
         {

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -94,9 +94,9 @@ export const contextRoutes = (ctx: AppContext) => {
     // rather than one per token. Ephemeral by construction — `reply()` below still writes the
     // whole transcript row, which stays the record.
     const stream = makeDeltaStream({
-      publish: ({ seq, text }) => {
+      publish: ({ seq, text, attempt }) => {
         const channel = `u:${s.asker_id}`
-        const event = { type: "session.delta" as const, session_id: s.id, seq, text }
+        const event = { type: "session.delta" as const, session_id: s.id, seq, text, attempt }
         // Prefer the receipt-bearing publish: its delivery count is what lets the stream switch
         // itself off when no tab is open, which is most turns (an MCP ask, an API caller, a
         // closed page). Falls back to a plain publish on a backplane that cannot count.

--- a/apps/api/test/chat-attended.test.ts
+++ b/apps/api/test/chat-attended.test.ts
@@ -1,5 +1,6 @@
 import { newId } from "@derive/core"
 import { describe, expect, it } from "vitest"
+import { createInProcessBackplane } from "../src/bus"
 import { inMemoryRateLimiters } from "../src/lib/rate-limit"
 import { as, makeAuthedApp } from "./helpers"
 
@@ -597,5 +598,135 @@ describe("follow-ups are limited, budgeted, and gated", () => {
     expect(after.length).toBe(before + 1)
     expect(after.at(-1)?.author_kind).toBe("asker")
     void app
+  })
+})
+
+// ---- Streaming the reply --------------------------------------------------
+// The attended turn used to settle SILENTLY: served in-process, it never went through the
+// runner report path that publishes, so a watching client learned the answer had landed only
+// on its next poll. Streaming makes the terminal event mandatory — deltas with no settle leave
+// a reader watching a reply that never officially finishes. These pin both halves.
+
+/* (helper folded into the tests below) */
+
+describe("an attended reply streams, then settles", () => {
+  it("publishes coalesced deltas and a terminal settle, in that order, on the asker's channel", async () => {
+    const seen: { channel: string; type: string; body: Record<string, unknown> }[] = []
+    const inner = createInProcessBackplane()
+    const plane = {
+      ...inner,
+      publish(channel: string, e: Record<string, unknown>) {
+        seen.push({ channel, type: String(e.type), body: e })
+        inner.publish(channel, e as never)
+      },
+    }
+    const users = [{ id: "u-st", email: "st@x.com", name: "St" }]
+    const { app, meta } = makeAuthedApp("chat-stream", users, undefined, {
+      deps: {
+        backplane: plane as never,
+        // A model that streams its answer in pieces, exactly as the real adapter does.
+        callModel: async ({ onDelta }) => {
+          for (const piece of ["Hello", ", ", "world"]) onDelta?.(piece)
+          return { text: "Hello, world", toolUses: [], costUsd: null, done: true }
+        },
+      },
+    })
+    await meta.setOrgSettings("default", {
+      ...(await meta.getOrgSettings("default")),
+      chatBeta: true,
+    })
+    const created = await app.request("/v1/artifacts", {
+      method: "POST",
+      headers: as("st@x.com"),
+      body: (() => {
+        const f = new FormData()
+        f.set("file", new Blob(["# Doc"], { type: "text/markdown" }), "doc.md")
+        f.set("title", "Doc")
+        return f
+      })(),
+    })
+    const { short_id } = (await created.json()) as { short_id: string }
+
+    const opened = await app.request("/v1/artifacts/chat-session", {
+      method: "POST",
+      headers: { ...as("st@x.com"), "content-type": "application/json" },
+      body: JSON.stringify({ short_id, body_md: "hi", mode: "propose" }),
+    })
+    expect(opened.status).toBe(201)
+    const sessionId = ((await opened.json()) as { session: { id: string } }).session.id
+
+    // serveAttended is detached — wait for the transcript to carry the agent's reply.
+    for (let i = 0; i < 60; i++) {
+      const msgs = await meta.listSessionMessages(sessionId)
+      if (msgs.some((m) => m.author_kind === "agent")) break
+      await new Promise((r) => setTimeout(r, 25))
+    }
+
+    const mine = seen.filter((e) => e.body.session_id === sessionId)
+    const deltas = mine.filter((e) => e.type === "session.delta")
+    const settles = mine.filter((e) => e.type === "session.settled")
+
+    // Deltas landed, on the ASKER's channel, and their text is the whole reply in order.
+    expect(deltas.length).toBeGreaterThan(0)
+    expect(new Set(deltas.map((d) => d.channel))).toEqual(new Set(["u:u-st"]))
+    expect(deltas.map((d) => d.body.text).join("")).toBe("Hello, world")
+    expect(deltas.map((d) => d.body.seq)).toEqual(deltas.map((_, i) => i + 1))
+    // COALESCED: three model pieces did not become three publishes.
+    expect(deltas.length).toBeLessThan(3)
+
+    // ...and the turn ended with exactly one terminal event, AFTER every delta.
+    expect(settles).toHaveLength(1)
+    expect(mine.at(-1)?.type).toBe("session.settled")
+    expect(settles[0]?.body.state).toBe("answered")
+  })
+
+  it("still settles when there is no model, so a client never waits forever", async () => {
+    const seen: { type: string; body: Record<string, unknown> }[] = []
+    const inner = createInProcessBackplane()
+    const plane = {
+      ...inner,
+      publish(channel: string, e: Record<string, unknown>) {
+        seen.push({ type: String(e.type), body: e })
+        inner.publish(channel, e as never)
+      },
+    }
+    const users = [{ id: "u-nm", email: "nm@x.com", name: "Nm" }]
+    // No callModel at all — the self-host default.
+    const { app, meta } = makeAuthedApp("chat-nomodel-stream", users, undefined, {
+      deps: { backplane: plane as never },
+    })
+    await meta.setOrgSettings("default", {
+      ...(await meta.getOrgSettings("default")),
+      chatBeta: true,
+    })
+    const created = await app.request("/v1/artifacts", {
+      method: "POST",
+      headers: as("nm@x.com"),
+      body: (() => {
+        const f = new FormData()
+        f.set("file", new Blob(["# Doc"], { type: "text/markdown" }), "doc.md")
+        f.set("title", "Doc")
+        return f
+      })(),
+    })
+    const { short_id } = (await created.json()) as { short_id: string }
+    const opened = await app.request("/v1/artifacts/chat-session", {
+      method: "POST",
+      headers: { ...as("nm@x.com"), "content-type": "application/json" },
+      body: JSON.stringify({ short_id, body_md: "hi", mode: "propose" }),
+    })
+    // Chat is unreachable with no model wired, so either it refuses up front or it answers
+    // in the transcript — both are terminal. What must NOT happen is a silent hang.
+    if (opened.status === 201) {
+      const sessionId = ((await opened.json()) as { session: { id: string } }).session.id
+      for (let i = 0; i < 60; i++) {
+        const msgs = await meta.listSessionMessages(sessionId)
+        if (msgs.some((m) => m.author_kind === "agent")) break
+        await new Promise((r) => setTimeout(r, 25))
+      }
+      expect(seen.filter((e) => e.type === "session.settled")).toHaveLength(1)
+    } else {
+      expect(opened.status).toBeGreaterThanOrEqual(400)
+    }
   })
 })

--- a/apps/api/test/chat-attended.test.ts
+++ b/apps/api/test/chat-attended.test.ts
@@ -619,6 +619,14 @@ describe("an attended reply streams, then settles", () => {
         seen.push({ channel, type: String(e.type), body: e })
         inner.publish(channel, e as never)
       },
+      // Deltas take the RECEIPT-bearing publish (that count is what lets the stream switch
+      // itself off when no tab is open), so the capture has to cover it too. Returning 1 stands
+      // in for an open tab; the zero-listener shutoff is unit-tested in session-stream.test.ts.
+      async publishWithReceipt(channel: string, e: Record<string, unknown>) {
+        seen.push({ channel, type: String(e.type), body: e })
+        inner.publish(channel, e as never)
+        return 1
+      },
     }
     const users = [{ id: "u-st", email: "st@x.com", name: "St" }]
     const { app, meta } = makeAuthedApp("chat-stream", users, undefined, {

--- a/apps/api/test/edge-cache.test.ts
+++ b/apps/api/test/edge-cache.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest"
+import { withEdgeCache } from "../src/lib/edge-cache"
+
+/**
+ * The edge cache is keyed on the URL ALONE, so the rules about what may enter it are safety
+ * rules, not tuning. A response that varies by caller must never be stored, and a failure must
+ * never become sticky for a year.
+ *
+ * `caches` is a Workers global that does not exist under Node, so these install a fake for the
+ * duration of a test — which also pins the Node behaviour (no cache, just call through).
+ */
+
+type Entry = { req: Request; res: Response }
+
+const withFakeCache = async <T>(run: (store: Entry[]) => Promise<T>): Promise<T> => {
+  const store: Entry[] = []
+  const g = globalThis as { caches?: unknown }
+  const had = "caches" in g
+  const prev = g.caches
+  g.caches = {
+    default: {
+      match: async (req: Request) =>
+        store.find((e) => e.req.url === req.url)?.res.clone() ?? undefined,
+      put: async (req: Request, res: Response) => {
+        store.push({ req, res })
+      },
+    },
+  }
+  try {
+    return await run(store)
+  } finally {
+    if (had) g.caches = prev
+    else delete g.caches
+  }
+}
+
+const req = (url = "https://x.test/blob/abc", init?: RequestInit) => new Request(url, init)
+
+describe("edge cache", () => {
+  it("calls through and stores a 200", async () => {
+    await withFakeCache(async (store) => {
+      let built = 0
+      const produce = async () => {
+        built += 1
+        return new Response("bytes", { status: 200 })
+      }
+      const res = await withEdgeCache(req(), produce)
+      expect(await res.text()).toBe("bytes") // the CALLER still gets a readable body
+      expect(built).toBe(1)
+      expect(store).toHaveLength(1)
+    })
+  })
+
+  it("serves the second hit from the cache without rebuilding", async () => {
+    await withFakeCache(async () => {
+      let built = 0
+      const produce = async () => {
+        built += 1
+        return new Response("bytes", { status: 200 })
+      }
+      await withEdgeCache(req(), produce)
+      const second = await withEdgeCache(req(), produce)
+      expect(built).toBe(1) // no database row, no R2 object, no origin work at all
+      expect(await second.text()).toBe("bytes")
+    })
+  })
+
+  it("keys on the URL, so a different hash is a different entry", async () => {
+    await withFakeCache(async () => {
+      let built = 0
+      const produce = async () => {
+        built += 1
+        return new Response("bytes", { status: 200 })
+      }
+      await withEdgeCache(req("https://x.test/blob/aaa"), produce)
+      await withEdgeCache(req("https://x.test/blob/bbb"), produce)
+      expect(built).toBe(2)
+    })
+  })
+
+  it("NEVER caches a 404 — a missing asset must not be sticky for a year", async () => {
+    await withFakeCache(async (store) => {
+      let built = 0
+      const produce = async () => {
+        built += 1
+        return new Response("not found", { status: 404 })
+      }
+      await withEdgeCache(req(), produce)
+      await withEdgeCache(req(), produce)
+      expect(store).toHaveLength(0)
+      expect(built).toBe(2) // asked again, so an asset that appears later is servable
+    })
+  })
+
+  it("never caches a 5xx either", async () => {
+    await withFakeCache(async (store) => {
+      await withEdgeCache(req(), async () => new Response("blob missing", { status: 500 }))
+      expect(store).toHaveLength(0)
+    })
+  })
+
+  it("does not touch the cache for a non-GET request", async () => {
+    await withFakeCache(async (store) => {
+      const res = await withEdgeCache(
+        req("https://x.test/blob/abc", { method: "POST" }),
+        async () => new Response("ok", { status: 200 }),
+      )
+      expect(await res.text()).toBe("ok")
+      expect(store).toHaveLength(0)
+    })
+  })
+
+  it("falls back to producing when a cache read throws", async () => {
+    const g = globalThis as { caches?: unknown }
+    const had = "caches" in g
+    const prev = g.caches
+    g.caches = {
+      default: {
+        match: async () => {
+          throw new Error("cache unavailable")
+        },
+        put: async () => {},
+      },
+    }
+    try {
+      const res = await withEdgeCache(req(), async () => new Response("bytes", { status: 200 }))
+      expect(await res.text()).toBe("bytes")
+    } finally {
+      if (had) g.caches = prev
+      else delete g.caches
+    }
+  })
+
+  it("is a plain call-through on Node, where there is no edge at all", async () => {
+    const g = globalThis as { caches?: unknown }
+    const had = "caches" in g
+    const prev = g.caches
+    delete g.caches
+    try {
+      let built = 0
+      const produce = async () => {
+        built += 1
+        return new Response("bytes", { status: 200 })
+      }
+      await withEdgeCache(req(), produce)
+      await withEdgeCache(req(), produce)
+      expect(built).toBe(2) // no caching, and crucially no crash on the missing global
+    } finally {
+      if (had) g.caches = prev
+    }
+  })
+})

--- a/apps/api/test/model-openai.test.ts
+++ b/apps/api/test/model-openai.test.ts
@@ -402,3 +402,102 @@ describe("streaming", () => {
     expect(turn.text).toBe("beforeafter")
   })
 })
+
+describe("streaming failure modes", () => {
+  it("a stream that just stops is a FAILURE, not a short answer", async () => {
+    // No finish_reason, no [DONE] — a gateway died, a proxy timed out, the last chunk was
+    // dropped. The buffered path throws here (res.json() on a truncated body), and the loop
+    // reads that as retryable. Returning the partial text as a finished reply would both
+    // disable the truncation guard and launder a retryable fault into an unretryable one.
+    const { impl } = streamImpl([
+      JSON.stringify({ choices: [{ delta: { content: "Here is the fir" } }] }),
+    ])
+    await expect(
+      model(impl)({ system: "s", messages: [], tools: [], onDelta: () => {} }),
+    ).rejects.toThrow(/terminal frame/)
+  })
+
+  it("accepts a stream terminated by [DONE] alone", async () => {
+    const { impl } = streamImpl([
+      JSON.stringify({ choices: [{ delta: { content: "done properly" } }] }),
+      "[DONE]",
+    ])
+    const turn = await model(impl)({ system: "s", messages: [], tools: [], onDelta: () => {} })
+    expect(turn.text).toBe("done properly")
+  })
+
+  it("reads an event whose first line is not data: (event:/id:/comment)", async () => {
+    // Spec-legal framing that a proxy or self-hosted gateway really does emit. Testing
+    // startsWith on the whole frame dropped these silently and yielded an empty reply.
+    const wire =
+      `event: message\ndata: ${JSON.stringify({ choices: [{ delta: { content: "hello " } }] })}\n\n` +
+      `id: 42\ndata: ${JSON.stringify({ choices: [{ delta: { content: "world" } }] })}\n\n` +
+      `: keep-alive\ndata: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: "stop" }] })}\n\n`
+    const impl = (async () =>
+      new Response(new TextEncoder().encode(wire), {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      })) as unknown as typeof fetch
+    const turn = await model(impl)({ system: "s", messages: [], tools: [], onDelta: () => {} })
+    expect(turn.text).toBe("hello world")
+  })
+
+  it("keeps a tool call's arguments on their OWN call when a fragment omits index", async () => {
+    // Defaulting a missing index to 0 stapled one call's arguments onto another, so BOTH tools
+    // then ran wrong: one with a foreign input, one with {}.
+    const { impl } = streamImpl([
+      JSON.stringify({
+        choices: [{ delta: { tool_calls: [{ index: 0, id: "t1", function: { name: "a" } }] } }],
+      }),
+      JSON.stringify({
+        choices: [{ delta: { tool_calls: [{ index: 1, id: "t2", function: { name: "b" } }] } }],
+      }),
+      JSON.stringify({
+        choices: [{ delta: { tool_calls: [{ function: { arguments: '{"x":1}' } }] } }],
+      }),
+      JSON.stringify({ choices: [{ delta: {}, finish_reason: "tool_calls" }] }),
+      "[DONE]",
+    ])
+    const turn = await model(impl)({ system: "s", messages: [], tools: [], onDelta: () => {} })
+    expect(turn.toolUses).toEqual([
+      { id: "t1", name: "a", input: {} },
+      { id: "t2", name: "b", input: { x: 1 } },
+    ])
+  })
+
+  it("falls back to a buffered request when the gateway refuses to stream", async () => {
+    // "OpenAI-compatible" is a wire format, not a guarantee: plenty of gateways 400 on the
+    // unknown stream_options field. Streaming must never break a request that worked before.
+    const bodies: Record<string, unknown>[] = []
+    const impl = (async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body)) as Record<string, unknown>
+      bodies.push(body)
+      if (body.stream) return new Response("unknown field stream_options", { status: 400 })
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "buffered reply" }, finish_reason: "stop" }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )
+    }) as unknown as typeof fetch
+    const turn = await model(impl)({ system: "s", messages: [], tools: [], onDelta: () => {} })
+    expect(bodies).toHaveLength(2)
+    expect(bodies[0]?.stream).toBe(true)
+    expect(bodies[1]?.stream).toBeUndefined()
+    expect(turn.text).toBe("buffered reply") // the person loses the animation, not the answer
+  })
+
+  it("parses a JSON answer even when it was asked to stream", async () => {
+    // A gateway that ignores `stream` and replies with ordinary JSON. Parsing that as SSE finds
+    // no data: frames and would produce a silent empty reply.
+    const impl = (async () =>
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "plain json" }, finish_reason: "stop" }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as unknown as typeof fetch
+    const turn = await model(impl)({ system: "s", messages: [], tools: [], onDelta: () => {} })
+    expect(turn.text).toBe("plain json")
+  })
+})

--- a/apps/api/test/model-openai.test.ts
+++ b/apps/api/test/model-openai.test.ts
@@ -256,3 +256,149 @@ describe("a tool call survives translation to chat-completions", () => {
     expect(JSON.stringify(msgs)).toContain("19.8")
   })
 })
+
+// ---- Streaming ------------------------------------------------------------
+// `onDelta` is additive: without it the adapter must behave exactly as it always has, and with
+// it the RETURNED ModelTurn must be identical to what the buffered path would have produced.
+// That equivalence is the whole safety argument for streaming, so it is what these assert.
+
+/** A fake SSE response built from raw `data:` frames, chunked at awkward boundaries on purpose. */
+const sseResponse = (frames: string[], splitEvery = 7) => {
+  const wire = frames.map((f) => `data: ${f}\n\n`).join("")
+  const bytes = new TextEncoder().encode(wire)
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        // Deliberately split mid-frame so the reader's buffering is exercised, not bypassed.
+        for (let i = 0; i < bytes.length; i += splitEvery)
+          controller.enqueue(bytes.slice(i, i + splitEvery))
+        controller.close()
+      },
+    }),
+    { status: 200, headers: { "content-type": "text/event-stream" } },
+  )
+}
+
+const streamImpl = (frames: string[]) => {
+  const seen: Record<string, unknown>[] = []
+  const impl = (async (_url: string, init: RequestInit) => {
+    seen.push(JSON.parse(String(init.body)))
+    return sseResponse(frames)
+  }) as unknown as typeof fetch
+  return { seen, impl }
+}
+
+const textFrames = [
+  JSON.stringify({ choices: [{ delta: { content: "Hel" } }] }),
+  JSON.stringify({ choices: [{ delta: { content: "lo, " } }] }),
+  JSON.stringify({ choices: [{ delta: { content: "world" } }] }),
+  JSON.stringify({ choices: [{ delta: {}, finish_reason: "stop" }], usage: { cost: 0.002 } }),
+  "[DONE]",
+]
+
+describe("streaming", () => {
+  it("does not ask for a stream when nobody is listening", async () => {
+    const { seen, impl } = capture()
+    await model(impl)({ system: "s", messages: [], tools: [] })
+    expect(seen[0]?.body.stream).toBeUndefined()
+  })
+
+  it("asks for a stream (and usage) only when onDelta is passed", async () => {
+    const { seen, impl } = streamImpl(textFrames)
+    await model(impl)({ system: "s", messages: [], tools: [], onDelta: () => {} })
+    expect(seen[0]?.stream).toBe(true)
+    expect(seen[0]?.stream_options).toEqual({ include_usage: true })
+  })
+
+  it("emits text as it arrives, and returns the SAME reply the buffered path would", async () => {
+    const got: string[] = []
+    const { impl } = streamImpl(textFrames)
+    const turn = await model(impl)({
+      system: "s",
+      messages: [],
+      tools: [],
+      onDelta: (t) => got.push(t),
+    })
+    expect(got).toEqual(["Hel", "lo, ", "world"])
+    // The deltas are a view; the RETURN VALUE is the answer, and it is whole.
+    expect(turn.text).toBe("Hello, world")
+    expect(got.join("")).toBe(turn.text)
+    expect(turn.done).toBe(true)
+    expect(turn.costUsd).toBe(0.002)
+  })
+
+  it("reassembles tool calls split across frames, and never streams their fragments", async () => {
+    const got: string[] = []
+    const { impl } = streamImpl([
+      JSON.stringify({ choices: [{ delta: { content: "checking" } }] }),
+      JSON.stringify({
+        choices: [
+          { delta: { tool_calls: [{ index: 0, id: "t1", function: { name: "wx_get" } }] } },
+        ],
+      }),
+      JSON.stringify({
+        choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '{"ci' } }] } }],
+      }),
+      JSON.stringify({
+        choices: [
+          { delta: { tool_calls: [{ index: 0, function: { arguments: 'ty":"London"}' } }] } },
+        ],
+      }),
+      JSON.stringify({ choices: [{ delta: {}, finish_reason: "tool_calls" }] }),
+      "[DONE]",
+    ])
+    const turn = await model(impl)({
+      system: "s",
+      messages: [],
+      tools: [],
+      onDelta: (t) => got.push(t),
+    })
+    // Only prose was streamed — a half-written JSON argument is not showable and never emitted.
+    expect(got).toEqual(["checking"])
+    expect(turn.toolUses).toEqual([{ id: "t1", name: "wx_get", input: { city: "London" } }])
+    expect(turn.done).toBe(false)
+  })
+
+  it("still detects truncation, which streaming must not hide", async () => {
+    const { impl } = streamImpl([
+      JSON.stringify({ choices: [{ delta: { content: "half a doc" } }] }),
+      JSON.stringify({ choices: [{ delta: {}, finish_reason: "length" }] }),
+      "[DONE]",
+    ])
+    await expect(
+      model(impl)({ system: "s", messages: [], tools: [], onDelta: () => {} }),
+    ).rejects.toThrow(/token ceiling/)
+  })
+
+  it("a listener that throws does not cost us the reply", async () => {
+    const { impl } = streamImpl(textFrames)
+    const turn = await model(impl)({
+      system: "s",
+      messages: [],
+      tools: [],
+      onDelta: () => {
+        throw new Error("subscriber blew up")
+      },
+    })
+    expect(turn.text).toBe("Hello, world")
+  })
+
+  it("skips a malformed frame instead of losing the rest of the reply", async () => {
+    const got: string[] = []
+    const { impl } = streamImpl([
+      JSON.stringify({ choices: [{ delta: { content: "before" } }] }),
+      "{not json at all",
+      JSON.stringify({ choices: [{ delta: { content: "after" } }] }),
+      JSON.stringify({ choices: [{ delta: {}, finish_reason: "stop" }] }),
+      "[DONE]",
+    ])
+    const turn = await model(impl)({
+      system: "s",
+      messages: [],
+      tools: [],
+      onDelta: (t) => got.push(t),
+    })
+    expect(got).toEqual(["before", "after"])
+    expect(turn.text).toBe("beforeafter")
+  })
+})

--- a/apps/api/test/session-stream.test.ts
+++ b/apps/api/test/session-stream.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest"
+import type { AgentLoopInput } from "../src/lib/agent-loop"
+import { DELTA_FLUSH_CHARS, makeDeltaStream } from "../src/lib/session-stream"
+
+/**
+ * Coalescing is the whole reason this file exists: one publish per token would be one Durable
+ * Object fetch per token. These pin the boundaries it flushes on, that it never invents or
+ * loses text, and that a broken transport cannot take the reply down with it.
+ */
+
+/** A fake callModel that emits the given pieces through `onDelta`, then returns a whole turn. */
+const emitting = (pieces: string[]): AgentLoopInput["callModel"] =>
+  (async ({ onDelta }) => {
+    for (const p of pieces) onDelta?.(p)
+    return { text: pieces.join(""), toolUses: [], costUsd: null, done: true }
+  }) as AgentLoopInput["callModel"]
+
+const harness = (over: { now?: () => number; flushChars?: number; flushMs?: number } = {}) => {
+  const sent: { seq: number; text: string }[] = []
+  const stream = makeDeltaStream({ publish: (s) => sent.push(s), ...over })
+  return { sent, stream }
+}
+
+const call = (fn: AgentLoopInput["callModel"]) => fn({ system: "", messages: [], tools: [] })
+
+describe("delta coalescing", () => {
+  it("buffers small pieces instead of publishing each one", async () => {
+    // A frozen clock: only the SIZE boundary can fire, so this isolates it from the age one.
+    const { sent, stream } = harness({ now: () => 0 })
+    await call(stream.wrap(emitting(["a", "b", "c"])))
+    expect(sent).toEqual([]) // still buffered — three tokens are not three publishes
+    stream.flush()
+    expect(sent).toEqual([{ seq: 1, text: "abc" }])
+  })
+
+  it("flushes on the size boundary mid-reply", async () => {
+    const { sent, stream } = harness({ now: () => 0 })
+    const big = "x".repeat(DELTA_FLUSH_CHARS)
+    await call(stream.wrap(emitting([big, "tail"])))
+    expect(sent).toEqual([{ seq: 1, text: big }])
+    stream.flush()
+    expect(sent[1]).toEqual({ seq: 2, text: "tail" })
+  })
+
+  it("flushes on the age boundary when the model is slow", async () => {
+    let t = 0
+    const { sent, stream } = harness({ now: () => t, flushMs: 50 })
+    const wrapped = stream.wrap((async ({ onDelta }) => {
+      onDelta?.("slow ")
+      t = 100 // the next token arrives well after the age boundary
+      onDelta?.("reply")
+      return { text: "slow reply", toolUses: [], costUsd: null, done: true }
+    }) as AgentLoopInput["callModel"])
+    await call(wrapped)
+    expect(sent).toEqual([{ seq: 1, text: "slow reply" }])
+  })
+
+  it("never loses or reorders text, whatever the boundaries", async () => {
+    const { sent, stream } = harness({ now: () => 0, flushChars: 3 })
+    const pieces = ["The ", "quick ", "brown ", "fox ", "jumps"]
+    const turn = await call(stream.wrap(emitting(pieces)))
+    stream.flush()
+    // Every slice concatenated is exactly the reply, and the seqs are 1..n with no gaps.
+    expect(sent.map((s) => s.text).join("")).toBe(pieces.join(""))
+    expect(sent.map((s) => s.seq)).toEqual(sent.map((_, i) => i + 1))
+    // ...and the RETURNED turn is untouched by any of this.
+    expect(turn.text).toBe("The quick brown fox jumps")
+  })
+
+  it("flush is idempotent, so settling twice cannot double-publish", async () => {
+    const { sent, stream } = harness({ now: () => 0 })
+    await call(stream.wrap(emitting(["once"])))
+    stream.flush()
+    stream.flush()
+    expect(sent).toHaveLength(1)
+  })
+
+  it("a publish that throws does not fail the turn", async () => {
+    const stream = makeDeltaStream({
+      now: () => 0,
+      publish: () => {
+        throw new Error("the room is gone")
+      },
+    })
+    const turn = await call(stream.wrap(emitting(["still ", "answered"])))
+    stream.flush()
+    // The transcript still lands on settle — a dead transport costs the animation, not the reply.
+    expect(turn.text).toBe("still answered")
+  })
+
+  it("passes the rest of the input through untouched", async () => {
+    const seen: unknown[] = []
+    const { stream } = harness({ now: () => 0 })
+    const wrapped = stream.wrap((async (input) => {
+      seen.push({ system: input.system, tools: input.tools.length })
+      return { text: "", toolUses: [], costUsd: null, done: true }
+    }) as AgentLoopInput["callModel"])
+    await wrapped({ system: "be helpful", messages: [], tools: [] })
+    expect(seen[0]).toEqual({ system: "be helpful", tools: 0 })
+  })
+})

--- a/apps/api/test/session-stream.test.ts
+++ b/apps/api/test/session-stream.test.ts
@@ -17,7 +17,12 @@ const emitting = (pieces: string[]): AgentLoopInput["callModel"] =>
 
 const harness = (over: { now?: () => number; flushChars?: number; flushMs?: number } = {}) => {
   const sent: { seq: number; text: string }[] = []
-  const stream = makeDeltaStream({ publish: (s) => sent.push(s), ...over })
+  const stream = makeDeltaStream({
+    publish: (s) => {
+      sent.push(s)
+    },
+    ...over,
+  })
   return { sent, stream }
 }
 
@@ -97,5 +102,118 @@ describe("delta coalescing", () => {
     }) as AgentLoopInput["callModel"])
     await wrapped({ system: "be helpful", messages: [], tools: [] })
     expect(seen[0]).toEqual({ system: "be helpful", tools: 0 })
+  })
+})
+
+// ---- Cost control ---------------------------------------------------------
+// Each publish is a Durable Object fetch on the hosted tier, so how OFTEN this publishes is a
+// real bill, not a detail. Two levers: the age boundary (which is the one that actually fires),
+// and switching off entirely when no tab is listening — which is most turns.
+
+describe("publish cost", () => {
+  it("the age boundary, not the size one, sets the rate for a normal model", async () => {
+    // ~300 chars/sec, the shape of a real reply: 30 chars every 100ms.
+    let t = 0
+    const sent: { seq: number; text: string }[] = []
+    const stream = makeDeltaStream({
+      publish: (s) => {
+        sent.push(s)
+      },
+      now: () => t,
+      flushMs: 250,
+    })
+    const wrapped = stream.wrap((async ({ onDelta }) => {
+      for (let i = 0; i < 60; i++) {
+        onDelta?.("x".repeat(30))
+        t += 100
+      }
+      return { text: "", toolUses: [], costUsd: null, done: true }
+    }) as AgentLoopInput["callModel"])
+    await wrapped({ system: "", messages: [], tools: [] })
+    stream.flush()
+    // Six seconds of generation. At the old 80ms boundary this would have been ~60 publishes;
+    // the size cap alone would never have bounded it, because 250ms of text is under 200 chars.
+    expect(sent.length).toBeLessThanOrEqual(25)
+    expect(sent.length).toBeGreaterThan(5) // still genuinely streaming, not one lump at the end
+  })
+
+  it("stops publishing once the first slice reaches nobody", async () => {
+    let t = 0
+    const sent: { seq: number; text: string }[] = []
+    const stream = makeDeltaStream({
+      // Zero live streams: the tab is closed, or this is an MCP/API ask with no browser at all.
+      publish: (s) => {
+        sent.push(s)
+        return Promise.resolve(0)
+      },
+      now: () => t,
+      flushMs: 10,
+    })
+    const wrapped = stream.wrap((async ({ onDelta }) => {
+      onDelta?.("first")
+      t += 100
+      onDelta?.("second") // flushes, and the probe from the first resolves around here
+      await Promise.resolve()
+      await Promise.resolve()
+      for (let i = 0; i < 50; i++) {
+        onDelta?.("more")
+        t += 100
+      }
+      return { text: "whole answer", toolUses: [], costUsd: null, done: true }
+    }) as AgentLoopInput["callModel"])
+    const turn = await wrapped({ system: "", messages: [], tools: [] })
+    stream.flush()
+    // A couple of slices go out before the probe answers; then it goes quiet for good, instead
+    // of paying ~50 more DO fetches for a reply nobody is watching.
+    expect(sent.length).toBeLessThanOrEqual(3)
+    // ...and the ANSWER is completely unaffected — that is the whole safety argument.
+    expect(turn.text).toBe("whole answer")
+  })
+
+  it("keeps streaming while someone is listening", async () => {
+    let t = 0
+    const sent: { seq: number; text: string }[] = []
+    const stream = makeDeltaStream({
+      publish: (s) => {
+        sent.push(s)
+        return Promise.resolve(1) // one open tab
+      },
+      now: () => t,
+      flushMs: 10,
+    })
+    const wrapped = stream.wrap((async ({ onDelta }) => {
+      for (let i = 0; i < 10; i++) {
+        onDelta?.("tick")
+        t += 100
+        await Promise.resolve()
+      }
+      return { text: "", toolUses: [], costUsd: null, done: true }
+    }) as AgentLoopInput["callModel"])
+    await wrapped({ system: "", messages: [], tools: [] })
+    // 10 deltas at one flush per two ticks — the point is it never went quiet, not the exact count.
+    expect(sent.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it("a backplane that cannot count keeps streaming rather than going silent", async () => {
+    let t = 0
+    const sent: { seq: number; text: string }[] = []
+    const stream = makeDeltaStream({
+      publish: (s) => {
+        sent.push(s) // void return: no receipt available
+      },
+      now: () => t,
+      flushMs: 10,
+    })
+    const wrapped = stream.wrap((async ({ onDelta }) => {
+      for (let i = 0; i < 8; i++) {
+        onDelta?.("tick")
+        t += 100
+        await Promise.resolve()
+      }
+      return { text: "", toolUses: [], costUsd: null, done: true }
+    }) as AgentLoopInput["callModel"])
+    await wrapped({ system: "", messages: [], tools: [] })
+    // No receipt to read, so it must keep going rather than assume nobody is there.
+    expect(sent.length).toBeGreaterThanOrEqual(3)
   })
 })

--- a/apps/api/test/session-stream.test.ts
+++ b/apps/api/test/session-stream.test.ts
@@ -40,24 +40,30 @@ describe("delta coalescing", () => {
 
   it("flushes on the size boundary mid-reply", async () => {
     const { sent, stream } = harness({ now: () => 0 })
-    const big = "x".repeat(DELTA_FLUSH_CHARS)
+    const big = "x".repeat(DELTA_FLUSH_CHARS * 2)
     await call(stream.wrap(emitting([big, "tail"])))
-    expect(sent).toMatchObject([{ seq: 1, text: big }])
+    // The size boundary fired mid-reply rather than everything waiting for the final flush.
+    expect(sent).toHaveLength(1)
+    expect(sent[0]?.seq).toBe(1)
+    expect(sent[0]?.text.length).toBeGreaterThanOrEqual(DELTA_FLUSH_CHARS)
     stream.flush()
-    expect(sent[1]).toMatchObject({ seq: 2, text: "tail" })
+    // Nothing is lost across the boundary: the slices concatenate to the whole reply. The split
+    // is not exactly at `big` because a marker-length tail is held back (see MARKER_HOLDBACK).
+    expect(sent.map((s) => s.text).join("")).toBe(`${big}tail`)
   })
 
   it("flushes on the age boundary when the model is slow", async () => {
     let t = 0
     const { sent, stream } = harness({ now: () => t, flushMs: 50 })
     const wrapped = stream.wrap((async ({ onDelta }) => {
-      onDelta?.("slow ")
+      onDelta?.("slow reply that is comfortably longer than the marker holdback ")
       t = 100 // the next token arrives well after the age boundary
-      onDelta?.("reply")
-      return { text: "slow reply", toolUses: [], costUsd: null, done: true }
+      onDelta?.("and then some more")
+      return { text: "x", toolUses: [], costUsd: null, done: true }
     }) as AgentLoopInput["callModel"])
     await call(wrapped)
-    expect(sent).toMatchObject([{ seq: 1, text: "slow reply" }])
+    expect(sent).toHaveLength(1)
+    expect(sent[0]?.text).toContain("slow reply that is comfortably longer")
   })
 
   it("never loses or reorders text, whatever the boundaries", async () => {
@@ -272,13 +278,13 @@ describe("the startup race", () => {
     const wrapped = stream.wrap((async ({ onDelta }) => {
       // Two misses — one short of going quiet — then somebody opens the page.
       for (let i = 0; i < 2; i++) {
-        onDelta?.("x")
+        onDelta?.("a chunk long enough to clear the holdback ")
         t += 100
         await Promise.resolve()
       }
       listeners = 1
       for (let i = 0; i < 6; i++) {
-        onDelta?.("y")
+        onDelta?.("another chunk long enough to clear the holdback ")
         t += 100
         await Promise.resolve()
       }
@@ -357,5 +363,51 @@ describe("a re-generated reply", () => {
     expect(sent).toHaveLength(1)
     expect(sent[0]?.text).toBe("real answer")
     expect(sent[0]?.text).not.toContain("abandoned")
+  })
+})
+
+describe("the machinery block never reaches the reader", () => {
+  // The attended contract asks the model to answer in prose and then END with a <revision>
+  // block whose JSON carries the COMPLETE new document source. proseOf strips it from the
+  // TRANSCRIPT, but the stream is upstream of that — so without a cut the person watching sees
+  // their answer followed by kilobytes of escaped JSON, on the commonest action there is.
+  const revision = `<revision>${JSON.stringify({ content: "<!doctype html><html>…".repeat(50), filename: "d.html" })}</revision>`
+
+  it("streams the prose and stops dead at the block", async () => {
+    const { sent, stream } = harness({ now: () => 0 })
+    await call(
+      stream.wrap(emitting(["I shortened the intro and tightened the headings. ", revision])),
+    )
+    stream.flush()
+    const shown = sent.map((s) => s.text).join("")
+    expect(shown).toBe("I shortened the intro and tightened the headings. ")
+    expect(shown).not.toContain("<revision")
+    expect(shown).not.toContain("doctype")
+  })
+
+  it("cuts even when the marker is split across slices", async () => {
+    // `<revi` in one slice and `sion>` in the next must not leak the opening tag.
+    const { sent, stream } = harness({ now: () => 0 })
+    await call(stream.wrap(emitting(["Done. ", "<revi", "sion>", '{"content":"secret"}'])))
+    stream.flush()
+    const shown = sent.map((s) => s.text).join("")
+    expect(shown).toBe("Done. ")
+    expect(shown).not.toContain("<")
+    expect(shown).not.toContain("secret")
+  })
+
+  it("cuts an <edits> block too, and shows nothing when the reply is only a block", async () => {
+    const { sent, stream } = harness({ now: () => 0 })
+    await call(stream.wrap(emitting(['<edits>[{"old_str":"a","new_str":"b"}]</edits>'])))
+    stream.flush()
+    expect(sent.map((s) => s.text).join("")).toBe("")
+  })
+
+  it("leaves an ordinary answer completely untouched", async () => {
+    const { sent, stream } = harness({ now: () => 0 })
+    const prose = "There are five sections, and the last one is a status check."
+    await call(stream.wrap(emitting([prose])))
+    stream.flush()
+    expect(sent.map((s) => s.text).join("")).toBe(prose)
   })
 })

--- a/apps/api/test/session-stream.test.ts
+++ b/apps/api/test/session-stream.test.ts
@@ -137,7 +137,7 @@ describe("publish cost", () => {
     expect(sent.length).toBeGreaterThan(5) // still genuinely streaming, not one lump at the end
   })
 
-  it("stops publishing once the first slice reaches nobody", async () => {
+  it("stops publishing once several slices in a row reach nobody", async () => {
     let t = 0
     const sent: { seq: number; text: string }[] = []
     const stream = makeDeltaStream({
@@ -158,14 +158,15 @@ describe("publish cost", () => {
       for (let i = 0; i < 50; i++) {
         onDelta?.("more")
         t += 100
+        await Promise.resolve() // real streaming awaits each read; receipts settle between slices
       }
       return { text: "whole answer", toolUses: [], costUsd: null, done: true }
     }) as AgentLoopInput["callModel"])
     const turn = await wrapped({ system: "", messages: [], tools: [] })
     stream.flush()
-    // A couple of slices go out before the probe answers; then it goes quiet for good, instead
-    // of paying ~50 more DO fetches for a reply nobody is watching.
-    expect(sent.length).toBeLessThanOrEqual(3)
+    // A few slices go out while the misses accumulate; then it goes quiet for good, instead of
+    // paying ~50 more DO fetches for a reply nobody is watching.
+    expect(sent.length).toBeLessThanOrEqual(6)
     // ...and the ANSWER is completely unaffected — that is the whole safety argument.
     expect(turn.text).toBe("whole answer")
   })
@@ -215,5 +216,77 @@ describe("publish cost", () => {
     await wrapped({ system: "", messages: [], tools: [] })
     // No receipt to read, so it must keep going rather than assume nobody is there.
     expect(sent.length).toBeGreaterThanOrEqual(3)
+  })
+})
+
+describe("the startup race", () => {
+  it("keeps streaming when a reader attaches a moment after the model starts", async () => {
+    // THE BUG THIS PINS. The client cannot subscribe until it knows the session is unsettled,
+    // which costs a round trip after the POST. A quick model publishes its first slice into an
+    // empty room — and a rule that stopped on ONE miss disabled streaming for the whole turn.
+    // Observed live on the preview: the context console's reply arrived with zero deltas.
+    let t = 0
+    let listeners = 0 // nobody yet
+    const sent: { seq: number; text: string }[] = []
+    const stream = makeDeltaStream({
+      publish: (s) => {
+        sent.push(s)
+        return Promise.resolve(listeners)
+      },
+      now: () => t,
+      flushMs: 10,
+    })
+    const wrapped = stream.wrap((async ({ onDelta }) => {
+      // Two slices land before the reader is attached.
+      onDelta?.("first ")
+      t += 100
+      onDelta?.("second ")
+      t += 100
+      await Promise.resolve()
+      listeners = 1 // the tab finishes subscribing
+      for (let i = 0; i < 10; i++) {
+        onDelta?.("more ")
+        t += 100
+        await Promise.resolve()
+      }
+      return { text: "done", toolUses: [], costUsd: null, done: true }
+    }) as AgentLoopInput["callModel"])
+    await wrapped({ system: "", messages: [], tools: [] })
+    stream.flush()
+    // It survived the gap and kept streaming, rather than giving up on the first empty room.
+    expect(sent.length).toBeGreaterThanOrEqual(6)
+  })
+
+  it("a reader arriving mid-answer resets the miss count", async () => {
+    let t = 0
+    let listeners = 0
+    const sent: { seq: number; text: string }[] = []
+    const stream = makeDeltaStream({
+      publish: (s) => {
+        sent.push(s)
+        return Promise.resolve(listeners)
+      },
+      now: () => t,
+      flushMs: 10,
+    })
+    const wrapped = stream.wrap((async ({ onDelta }) => {
+      // Two misses — one short of going quiet — then somebody opens the page.
+      for (let i = 0; i < 2; i++) {
+        onDelta?.("x")
+        t += 100
+        await Promise.resolve()
+      }
+      listeners = 1
+      for (let i = 0; i < 6; i++) {
+        onDelta?.("y")
+        t += 100
+        await Promise.resolve()
+      }
+      return { text: "", toolUses: [], costUsd: null, done: true }
+    }) as AgentLoopInput["callModel"])
+    await wrapped({ system: "", messages: [], tools: [] })
+    // Slices flush every other delta, so eight deltas is four slices — the point is that it
+    // kept publishing AFTER the early miss instead of latching quiet at the threshold.
+    expect(sent.length).toBeGreaterThanOrEqual(4)
   })
 })

--- a/apps/api/test/session-stream.test.ts
+++ b/apps/api/test/session-stream.test.ts
@@ -35,16 +35,16 @@ describe("delta coalescing", () => {
     await call(stream.wrap(emitting(["a", "b", "c"])))
     expect(sent).toEqual([]) // still buffered — three tokens are not three publishes
     stream.flush()
-    expect(sent).toEqual([{ seq: 1, text: "abc" }])
+    expect(sent).toMatchObject([{ seq: 1, text: "abc" }])
   })
 
   it("flushes on the size boundary mid-reply", async () => {
     const { sent, stream } = harness({ now: () => 0 })
     const big = "x".repeat(DELTA_FLUSH_CHARS)
     await call(stream.wrap(emitting([big, "tail"])))
-    expect(sent).toEqual([{ seq: 1, text: big }])
+    expect(sent).toMatchObject([{ seq: 1, text: big }])
     stream.flush()
-    expect(sent[1]).toEqual({ seq: 2, text: "tail" })
+    expect(sent[1]).toMatchObject({ seq: 2, text: "tail" })
   })
 
   it("flushes on the age boundary when the model is slow", async () => {
@@ -57,7 +57,7 @@ describe("delta coalescing", () => {
       return { text: "slow reply", toolUses: [], costUsd: null, done: true }
     }) as AgentLoopInput["callModel"])
     await call(wrapped)
-    expect(sent).toEqual([{ seq: 1, text: "slow reply" }])
+    expect(sent).toMatchObject([{ seq: 1, text: "slow reply" }])
   })
 
   it("never loses or reorders text, whatever the boundaries", async () => {
@@ -288,5 +288,74 @@ describe("the startup race", () => {
     // Slices flush every other delta, so eight deltas is four slices — the point is that it
     // kept publishing AFTER the early miss instead of latching quiet at the threshold.
     expect(sent.length).toBeGreaterThanOrEqual(4)
+  })
+})
+
+describe("a re-generated reply", () => {
+  it("marks a new attempt so a reader replaces rather than appends", async () => {
+    // THE BUG THIS PINS. The agent loop can call the model more than once for ONE answer:
+    // attended chat runs maxTurns = NUDGE_LIMIT + 1, so a reply that misses the reply contract
+    // is nudged and generated again. Only the LAST attempt becomes the transcript. Without an
+    // attempt marker a client appends the abandoned text to the real text and shows a garbled
+    // answer that the settled message then contradicts.
+    let t = 0
+    const sent: { seq: number; text: string; attempt: number }[] = []
+    const stream = makeDeltaStream({
+      publish: (s) => {
+        sent.push(s)
+      },
+      now: () => t,
+      flushMs: 10,
+    })
+    const wrapped = stream.wrap((async ({ onDelta }) => {
+      onDelta?.("bad attempt ")
+      t += 100
+      onDelta?.("text")
+      return { text: "bad attempt text", toolUses: [], costUsd: null, done: true }
+    }) as AgentLoopInput["callModel"])
+
+    // Attempt 1 — the reply the contract rejects.
+    await wrapped({ system: "", messages: [], tools: [] })
+    stream.flush()
+    // Attempt 2 — the loop re-asks through the SAME wrapped callModel.
+    await wrapped({ system: "", messages: [], tools: [] })
+    stream.flush()
+
+    const attempts = sent.map((s) => s.attempt)
+    expect(Math.min(...attempts)).toBe(1)
+    expect(Math.max(...attempts)).toBe(2)
+    // Every slice says which attempt it belongs to, so a client can drop the abandoned one.
+    expect(sent.filter((s) => s.attempt === 1).length).toBeGreaterThan(0)
+    expect(sent.filter((s) => s.attempt === 2).length).toBeGreaterThan(0)
+    // Sequence stays globally monotonic across attempts, so the reorder guard still works.
+    expect(sent.map((s) => s.seq)).toEqual([...sent.map((s) => s.seq)].sort((a, b) => a - b))
+  })
+
+  it("drops text still buffered from an attempt that was abandoned", async () => {
+    // Text the model emitted but that never flushed belongs to a reply being thrown away.
+    // Publishing it later would put words on screen the transcript will never contain.
+    const sent: { seq: number; text: string; attempt: number }[] = []
+    const stream = makeDeltaStream({
+      publish: (s) => {
+        sent.push(s)
+      },
+      now: () => 0, // frozen: nothing reaches the age boundary, so it all stays buffered
+    })
+    const first = stream.wrap((async ({ onDelta }) => {
+      onDelta?.("abandoned")
+      return { text: "abandoned", toolUses: [], costUsd: null, done: true }
+    }) as AgentLoopInput["callModel"])
+    await first({ system: "", messages: [], tools: [] })
+    // No flush between attempts — the next call must discard that buffer, not inherit it.
+    const second = stream.wrap((async ({ onDelta }) => {
+      onDelta?.("real answer")
+      return { text: "real answer", toolUses: [], costUsd: null, done: true }
+    }) as AgentLoopInput["callModel"])
+    await second({ system: "", messages: [], tools: [] })
+    stream.flush()
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]?.text).toBe("real answer")
+    expect(sent[0]?.text).not.toContain("abandoned")
   })
 })

--- a/apps/web/src/lib/session-delta.test.ts
+++ b/apps/web/src/lib/session-delta.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest"
+import { applyDelta, EMPTY_DELTA, supersededBy } from "./session-delta"
+
+// These rules used to live inline in two components, written two different ways, and one of
+// them was wrong in a way only a second question in a conversation would reveal. That is the
+// shape of bug a node-environment unit test catches and a hand-test does not.
+
+const ev = (o: Record<string, unknown>) => JSON.stringify({ type: "session.delta", ...o })
+const S = "ses_1"
+
+describe("applying a slice", () => {
+  it("appends in order", () => {
+    let s = EMPTY_DELTA
+    s = applyDelta(s, ev({ session_id: S, seq: 1, text: "Hello", attempt: 1 }), S)
+    s = applyDelta(s, ev({ session_id: S, seq: 2, text: ", world", attempt: 1 }), S)
+    expect(s.text).toBe("Hello, world")
+    expect(s.seq).toBe(2)
+  })
+
+  it("ignores a redelivered slice, so a reconnect is not duplicated text", () => {
+    const s = applyDelta(EMPTY_DELTA, ev({ session_id: S, seq: 1, text: "once", attempt: 1 }), S)
+    const again = applyDelta(s, ev({ session_id: S, seq: 1, text: "once", attempt: 1 }), S)
+    expect(again).toBe(s) // same object: nothing to re-render
+    expect(again.text).toBe("once")
+  })
+
+  it("drops a slice that arrives late rather than inserting it in the wrong place", () => {
+    // Publishes go through one Durable Object fetch each and can overtake one another. A gap
+    // the settled transcript repairs beats visibly scrambled prose.
+    let s = EMPTY_DELTA
+    s = applyDelta(s, ev({ session_id: S, seq: 1, text: "a", attempt: 1 }), S)
+    s = applyDelta(s, ev({ session_id: S, seq: 3, text: "c", attempt: 1 }), S)
+    const late = applyDelta(s, ev({ session_id: S, seq: 2, text: "b", attempt: 1 }), S)
+    expect(late).toBe(s)
+    expect(late.text).toBe("ac")
+  })
+
+  it("a new attempt REPLACES, because the abandoned one never reaches the transcript", () => {
+    let s = EMPTY_DELTA
+    s = applyDelta(s, ev({ session_id: S, seq: 1, text: "bad attempt", attempt: 1 }), S)
+    s = applyDelta(s, ev({ session_id: S, seq: 2, text: "the real answer", attempt: 2 }), S)
+    expect(s.text).toBe("the real answer")
+    expect(s.text).not.toContain("bad attempt")
+  })
+
+  it("keeps appending within the same attempt", () => {
+    let s = EMPTY_DELTA
+    s = applyDelta(s, ev({ session_id: S, seq: 1, text: "one ", attempt: 2 }), S)
+    s = applyDelta(s, ev({ session_id: S, seq: 2, text: "two", attempt: 2 }), S)
+    expect(s.text).toBe("one two")
+  })
+
+  it("ignores another session's slice", () => {
+    const s = applyDelta(EMPTY_DELTA, ev({ session_id: "ses_other", seq: 1, text: "x" }), S)
+    expect(s).toBe(EMPTY_DELTA)
+  })
+
+  it("ignores everything when no session is open", () => {
+    expect(applyDelta(EMPTY_DELTA, ev({ session_id: S, seq: 1, text: "x" }), null)).toBe(
+      EMPTY_DELTA,
+    )
+  })
+
+  it("survives malformed json and a missing text field", () => {
+    expect(applyDelta(EMPTY_DELTA, "{not json", S)).toBe(EMPTY_DELTA)
+    expect(applyDelta(EMPTY_DELTA, ev({ session_id: S, seq: 1 }), S)).toBe(EMPTY_DELTA)
+  })
+
+  it("treats a slice with no seq as the next one", () => {
+    let s = applyDelta(EMPTY_DELTA, ev({ session_id: S, seq: 1, text: "a", attempt: 1 }), S)
+    s = applyDelta(s, ev({ session_id: S, text: "b", attempt: 1 }), S)
+    expect(s.text).toBe("ab")
+    expect(s.seq).toBe(2)
+  })
+})
+
+describe("when the streamed text is superseded", () => {
+  it("clears on a NEW agent message, not on one that was already there", () => {
+    // The bug: "does the transcript contain an agent message" is permanently true from the
+    // second question onward, so every poll during a follow-up wiped the reply mid-write.
+    expect(supersededBy(1, 0)).toBe(true) // the first answer just landed
+    expect(supersededBy(1, 1)).toBe(false) // turn 2 streaming, turn 1's answer still sitting there
+    expect(supersededBy(2, 1)).toBe(true) // turn 2's answer landed
+    expect(supersededBy(0, 0)).toBe(false)
+  })
+})

--- a/apps/web/src/lib/session-delta.ts
+++ b/apps/web/src/lib/session-delta.ts
@@ -1,0 +1,71 @@
+/**
+ * The client half of streamed replies: turning `session.delta` events into the text on screen.
+ *
+ * WHY THIS IS ITS OWN MODULE. Two surfaces render a streaming reply — the artifact chat rail
+ * and the context console — and they used to each carry their own copy of these rules. The
+ * copies disagreed, and one of them was wrong in a way no server test could see: it cleared the
+ * streamed text whenever the transcript contained ANY agent message, which is permanently true
+ * from the second question onward, so every poll wiped a reply mid-write. One tested module is
+ * the fix for the class, not just that bug.
+ *
+ * The state is deliberately plain data with a pure transition function, because the interesting
+ * rules (ordering, de-duplication, which attempt a slice belongs to) are exactly what a
+ * node-environment unit test can pin — matching how the rest of apps/web tests hook logic.
+ */
+
+export interface DeltaState {
+  /** The reply as far as it has arrived. Render this; it is never the record. */
+  text: string
+  /** Highest slice applied, for de-duplication. */
+  seq: number
+  /** Which model attempt `text` belongs to. */
+  attempt: number
+}
+
+export const EMPTY_DELTA: DeltaState = { text: "", seq: 0, attempt: 0 }
+
+/**
+ * Fold one `session.delta` event into the current state. Returns the SAME object when the event
+ * is not ours or not usable, so a caller can skip a re-render on identity.
+ *
+ * ORDERING. Slices are published in order but delivered over a Durable Object per publish, and
+ * two concurrent fetches to one DO have no ordering guarantee — so a later slice can overtake an
+ * earlier one. A slice that is not strictly newer is DROPPED rather than appended out of place:
+ * a missing chunk reads as a gap that the settled transcript repairs a moment later, whereas
+ * appending it in the wrong position puts visibly scrambled prose on screen. Deltas are a view,
+ * so the cheap, self-healing failure is the right one. (Node's in-process bus publishes
+ * synchronously and cannot reorder at all.)
+ */
+export const applyDelta = (
+  state: DeltaState,
+  raw: string,
+  sessionId: string | null,
+): DeltaState => {
+  let p: { session_id?: string; seq?: number; text?: string; attempt?: number }
+  try {
+    p = JSON.parse(raw) as typeof p
+  } catch {
+    return state
+  }
+  // Belt and braces: the channel is per-user, but a session's events must never bleed into a
+  // different session's transcript if two are open.
+  if (!sessionId || p.session_id !== sessionId || typeof p.text !== "string") return state
+  const seq = typeof p.seq === "number" ? p.seq : state.seq + 1
+  if (seq <= state.seq) return state
+  const attempt = typeof p.attempt === "number" ? p.attempt : state.attempt
+  // A NEW ATTEMPT REPLACES. The agent loop re-generates a reply that missed its contract, and
+  // the abandoned attempt never reaches the transcript — appending would show a garbled answer
+  // that the settled message then contradicts.
+  const fresh = attempt > state.attempt
+  return { text: fresh ? p.text : state.text + p.text, seq, attempt }
+}
+
+/**
+ * Should the provisional text be dropped, given the transcript that just arrived?
+ *
+ * Keyed on a NEW agent row appearing, never on one merely existing. "This transcript contains an
+ * agent message" is true forever after the first answer, so using it would clear the stream on
+ * every poll of every follow-up — the bug this module exists to prevent.
+ */
+export const supersededBy = (agentMessages: number, seenAgentMessages: number): boolean =>
+  agentMessages > seenAgentMessages

--- a/apps/web/src/pages/artifact/artifact-chat.tsx
+++ b/apps/web/src/pages/artifact/artifact-chat.tsx
@@ -26,18 +26,31 @@ export interface ChatMessage {
 /** Poll while a turn is in flight, stop when it settles. Cheap, and it survives a reload —
  *  which a websocket-only design would not, since the turn outlives the connection. */
 const POLL_MS = 900
+/**
+ * ...but once slices are arriving, back the poll right off.
+ *
+ * A streaming turn announces its own end (`session.settled` triggers an immediate read), so the
+ * poll stops being the way the answer arrives and becomes purely the safety net for a dropped
+ * stream. Every tick is a real request and a database read, so leaving it at 900ms would have
+ * meant ~22 of them across a twenty-second answer that needed none. At 5s it is 4, and if the
+ * stream really does die the reader waits at most that long.
+ */
+const POLL_STREAMING_MS = 5_000
 
 export function ArtifactChat(props: {
   messages: ChatMessage[]
   /** True while the agent owes a reply — drives the thinking row and the poll. */
   working: boolean
+  /** The reply being written, when the gateway streams one. "" means nothing in flight, which
+   *  is also what a non-streaming turn looks like — the panel falls back to the spinner. */
+  streaming?: string
   disabled?: boolean
   /** Why chat cannot be used, when it cannot (no model configured, no permission). */
   disabledReason?: string
   onSend: (body: string) => Promise<void>
   onPoll: () => void
 }) {
-  const { messages, working, disabled, disabledReason, onSend, onPoll } = props
+  const { messages, working, streaming, disabled, disabledReason, onSend, onPoll } = props
   const [draft, setDraft] = useState("")
   const [sending, setSending] = useState(false)
   const endRef = useRef<HTMLDivElement | null>(null)
@@ -52,11 +65,15 @@ export function ArtifactChat(props: {
     endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" })
   }, [messages.length, working])
 
+  // Slices arriving means the stream is alive and will announce its own end, so the poll drops
+  // to a safety net. It stays ON rather than switching off entirely: a stream that dies silently
+  // would otherwise leave the turn hanging with nothing to recover it.
+  const streamAlive = !!streaming
   useEffect(() => {
     if (!working) return
-    const t = setInterval(onPoll, POLL_MS)
+    const t = setInterval(onPoll, streamAlive ? POLL_STREAMING_MS : POLL_MS)
     return () => clearInterval(t)
-  }, [working, onPoll])
+  }, [working, streamAlive, onPoll])
 
   const send = async () => {
     const body = draft.trim()
@@ -84,7 +101,12 @@ export function ArtifactChat(props: {
             {messages.map((m) => (
               <Bubble key={m.id} msg={m} />
             ))}
-            {working && <Thinking />}
+            {/* The reply as it is being written. Once any of it has arrived it REPLACES the
+                thinking row — a spinner sitting under text that is visibly streaming reads as a
+                second, stalled turn. Falls back to the spinner while the model has not emitted
+                yet, and whenever nothing is streaming at all, so a turn with no deltas looks
+                exactly as it always did. */}
+            {streaming ? <Streaming text={streaming} /> : working ? <Thinking /> : null}
             <div ref={endRef} />
           </div>
         )}
@@ -153,6 +175,25 @@ function Thinking() {
       <div className="flex items-center gap-2 rounded-lg bg-muted px-3 py-2 text-sm text-muted-foreground">
         <Icon name="sparkles" className="size-3.5 animate-pulse" />
         Working…
+      </div>
+    </div>
+  )
+}
+
+/** The reply mid-write. Deliberately the SAME bubble an agent message renders into, so the
+ *  moment the turn settles and the persisted message takes over there is no visual jump — the
+ *  text simply stops growing. A caret marks it as still being written. */
+function Streaming({ text }: { text: string }) {
+  return (
+    <div className="flex justify-start" data-testid="chat-streaming">
+      <div className="cmt-body max-w-[85%] rounded-lg bg-muted px-3 py-2 text-sm text-foreground [word-break:break-word]">
+        {/* Markdown is rendered on the SETTLED message, not here: a half-arrived reply is
+            half-arrived markup too (an unclosed fence, a dangling `**`), and running it through
+            the renderer makes the text visibly thrash as it completes. Plain text with preserved
+            whitespace streams calmly and lands on the identical bubble when the real one
+            arrives. */}
+        <span className="whitespace-pre-wrap">{text}</span>
+        <span className="ml-0.5 inline-block h-3.5 w-px translate-y-0.5 animate-pulse bg-foreground/70" />
       </div>
     </div>
   )

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -1018,6 +1018,7 @@ export function Artifact() {
                   <ArtifactChat
                     messages={chat.messages}
                     working={chat.working}
+                    streaming={chat.streaming}
                     disabledReason={chat.error ?? undefined}
                     onSend={(b) => chat.send(b, effectiveCanPublish)}
                     onPoll={chat.poll}

--- a/apps/web/src/pages/artifact/lib/use-artifact-chat.ts
+++ b/apps/web/src/pages/artifact/lib/use-artifact-chat.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useUserEvent } from "@/lib/use-user-events"
 import type { ChatMessage } from "../artifact-chat"
 
 // The data half of the chat rail. Deliberately plain fetch + local state rather than a query
@@ -28,16 +29,35 @@ export function useArtifactChat(shortId: string) {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [state, setState] = useState<string>("answered")
   const [error, setError] = useState<string | null>(null)
+  // The reply as it is being written, assembled from `session.delta`. Purely a VIEW: the server
+  // persists nothing until the turn settles, and the transcript that then arrives replaces this.
+  // Cleared the moment a real agent message lands, so the provisional text and the persisted
+  // one can never both be on screen saying the same thing.
+  const [streaming, setStreaming] = useState("")
+  // Highest slice applied. Slices are ordered, but a reconnect can redeliver one — ignoring
+  // anything not strictly newer makes that a no-op instead of duplicated text.
+  const lastSeq = useRef(0)
 
-  const refresh = useCallback(async (id: string) => {
-    try {
-      const p = await json<SessionPayload>(`/v1/sessions/${id}`)
-      setMessages(p.messages ?? [])
-      setState(p.session?.state ?? "answered")
-    } catch {
-      /* a poll that misses is not worth surfacing — the next one covers it */
-    }
+  const clearStream = useCallback(() => {
+    setStreaming("")
+    lastSeq.current = 0
   }, [])
+
+  const refresh = useCallback(
+    async (id: string) => {
+      try {
+        const p = await json<SessionPayload>(`/v1/sessions/${id}`)
+        const next = p.messages ?? []
+        setMessages(next)
+        setState(p.session?.state ?? "answered")
+        // The persisted reply is here, so the provisional text has been superseded.
+        if (next.some((m) => m.author_kind === "agent")) clearStream()
+      } catch {
+        /* a poll that misses is not worth surfacing — the next one covers it */
+      }
+    },
+    [clearStream],
+  )
 
   // Reset when the document changes. `shortId` MUST be in the deps: the route reuses this
   // component instance across /artifacts/$ref changes, so without it doc A's session id
@@ -105,11 +125,54 @@ export function useArtifactChat(shortId: string) {
     if (sessionId) void refresh(sessionId)
   }, [sessionId, refresh])
 
+  // `working` is the server's own view of whose turn it is, not a local flag that can desync —
+  // a reload mid-turn still shows the spinner because the SESSION says working.
+  const working = state === "working" || state === "open"
+  // Subscribe only while a turn is actually in flight. That is also what tells the SERVER
+  // somebody is watching: the first slice is published with a receipt, and a turn whose slice
+  // reaches nobody stops publishing for the rest of the run.
+  const live = !!sessionId && working
+
+  useUserEvent(
+    "session.delta",
+    (e) => {
+      let p: { session_id?: string; seq?: number; text?: string }
+      try {
+        p = JSON.parse(e.data)
+      } catch {
+        return
+      }
+      if (p.session_id !== sessionId || typeof p.text !== "string") return
+      const seq = typeof p.seq === "number" ? p.seq : lastSeq.current + 1
+      if (seq <= lastSeq.current) return // a redelivery after a reconnect
+      lastSeq.current = seq
+      setStreaming((s) => s + p.text)
+    },
+    live,
+  )
+
+  // The turn ended. Read the transcript NOW rather than waiting out the poll — this is the
+  // event the whole streaming path builds to, and it is what swaps the provisional text for
+  // the persisted reply.
+  useUserEvent(
+    "session.settled",
+    (e) => {
+      try {
+        if ((JSON.parse(e.data) as { session_id?: string }).session_id !== sessionId) return
+      } catch {
+        return
+      }
+      if (sessionId) void refresh(sessionId)
+    },
+    live,
+  )
+
   return {
     messages,
-    // `working` is the server's own view of whose turn it is, not a local flag that can
-    // desync — a reload mid-turn still shows the spinner because the SESSION says working.
-    working: state === "working" || state === "open",
+    working,
+    /** The reply being written, or "" when there is nothing in flight. Render it as a
+     *  provisional agent bubble; it is replaced by the real message when the turn settles. */
+    streaming,
     error,
     send,
     poll,

--- a/apps/web/src/pages/artifact/lib/use-artifact-chat.ts
+++ b/apps/web/src/pages/artifact/lib/use-artifact-chat.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react"
+import { usePageVisible } from "@/lib/use-page-visible"
 import { useUserEvent } from "@/lib/use-user-events"
 import type { ChatMessage } from "../artifact-chat"
 
@@ -39,6 +40,8 @@ export function useArtifactChat(shortId: string) {
   const lastSeq = useRef(0)
   // Which model attempt the accumulated text belongs to (see the server note on `attempt`).
   const lastAttempt = useRef(0)
+  // Agent rows seen so far, so a NEW one can be told from one that was already there.
+  const agentCount = useRef(0)
 
   const clearStream = useCallback(() => {
     setStreaming("")
@@ -53,8 +56,14 @@ export function useArtifactChat(shortId: string) {
         const next = p.messages ?? []
         setMessages(next)
         setState(p.session?.state ?? "answered")
-        // The persisted reply is here, so the provisional text has been superseded.
-        if (next.some((m) => m.author_kind === "agent")) clearStream()
+        // Clear on a NEW agent row, not on the existence of any. "Does this transcript contain
+        // an agent message" is permanently true from turn two onward, so every poll during a
+        // follow-up would wipe the reply mid-write and restart it from the next slice — the
+        // bubble visibly resetting every few seconds. Turn one is unaffected, which is exactly
+        // why hand-testing does not catch it.
+        const agents = next.filter((m) => m.author_kind === "agent").length
+        if (agents > agentCount.current) clearStream()
+        agentCount.current = agents
       } catch {
         /* a poll that misses is not worth surfacing — the next one covers it */
       }
@@ -131,10 +140,14 @@ export function useArtifactChat(shortId: string) {
   // `working` is the server's own view of whose turn it is, not a local flag that can desync —
   // a reload mid-turn still shows the spinner because the SESSION says working.
   const working = state === "working" || state === "open"
-  // Subscribe only while a turn is actually in flight. That is also what tells the SERVER
-  // somebody is watching: the first slice is published with a receipt, and a turn whose slice
-  // reaches nobody stops publishing for the rest of the run.
-  const live = !!sessionId && working
+  // Subscribe only while a turn is actually in flight AND the tab is in front. Visibility is
+  // not politeness: use-user-events' contract is that subscribers gate on it so a hidden tab
+  // releases the per-user room Durable Object, and on this path it is also what makes the
+  // server's no-listener shutoff work — a backgrounded tab that stays subscribed keeps
+  // reporting a live reader, so the turn keeps paying to publish into a page nobody is looking
+  // at. Every other useUserEvent caller in the app composes usePageVisible for the same reason.
+  const visible = usePageVisible()
+  const live = !!sessionId && working && visible
 
   useUserEvent(
     "session.delta",

--- a/apps/web/src/pages/artifact/lib/use-artifact-chat.ts
+++ b/apps/web/src/pages/artifact/lib/use-artifact-chat.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react"
+import { applyDelta, type DeltaState, EMPTY_DELTA, supersededBy } from "@/lib/session-delta"
 import { usePageVisible } from "@/lib/use-page-visible"
 import { useUserEvent } from "@/lib/use-user-events"
 import type { ChatMessage } from "../artifact-chat"
@@ -32,22 +33,13 @@ export function useArtifactChat(shortId: string) {
   const [error, setError] = useState<string | null>(null)
   // The reply as it is being written, assembled from `session.delta`. Purely a VIEW: the server
   // persists nothing until the turn settles, and the transcript that then arrives replaces this.
-  // Cleared the moment a real agent message lands, so the provisional text and the persisted
-  // one can never both be on screen saying the same thing.
-  const [streaming, setStreaming] = useState("")
-  // Highest slice applied. Slices are ordered, but a reconnect can redeliver one — ignoring
-  // anything not strictly newer makes that a no-op instead of duplicated text.
-  const lastSeq = useRef(0)
-  // Which model attempt the accumulated text belongs to (see the server note on `attempt`).
-  const lastAttempt = useRef(0)
+  // The accumulation rules live in lib/session-delta.ts, shared with the context console so the
+  // two surfaces cannot drift — they did, and one of them was wrong.
+  const [delta, setDelta] = useState<DeltaState>(EMPTY_DELTA)
   // Agent rows seen so far, so a NEW one can be told from one that was already there.
   const agentCount = useRef(0)
 
-  const clearStream = useCallback(() => {
-    setStreaming("")
-    lastSeq.current = 0
-    lastAttempt.current = 0
-  }, [])
+  const clearStream = useCallback(() => setDelta(EMPTY_DELTA), [])
 
   const refresh = useCallback(
     async (id: string) => {
@@ -62,7 +54,7 @@ export function useArtifactChat(shortId: string) {
         // bubble visibly resetting every few seconds. Turn one is unaffected, which is exactly
         // why hand-testing does not catch it.
         const agents = next.filter((m) => m.author_kind === "agent").length
-        if (agents > agentCount.current) clearStream()
+        if (supersededBy(agents, agentCount.current)) clearStream()
         agentCount.current = agents
       } catch {
         /* a poll that misses is not worth surfacing — the next one covers it */
@@ -149,30 +141,7 @@ export function useArtifactChat(shortId: string) {
   const visible = usePageVisible()
   const live = !!sessionId && working && visible
 
-  useUserEvent(
-    "session.delta",
-    (e) => {
-      let p: { session_id?: string; seq?: number; text?: string; attempt?: number }
-      try {
-        p = JSON.parse(e.data)
-      } catch {
-        return
-      }
-      if (p.session_id !== sessionId || typeof p.text !== "string") return
-      const seq = typeof p.seq === "number" ? p.seq : lastSeq.current + 1
-      if (seq <= lastSeq.current) return // a redelivery after a reconnect
-      lastSeq.current = seq
-      // A NEW ATTEMPT REPLACES, it does not append. The agent loop re-generates a reply that
-      // missed its contract, and the abandoned attempt never reaches the transcript — appending
-      // would show a garbled answer that the settled message then contradicts.
-      const at = typeof p.attempt === "number" ? p.attempt : lastAttempt.current
-      const fresh = at > lastAttempt.current
-      lastAttempt.current = at
-      const text = p.text
-      setStreaming((s) => (fresh ? text : s + text))
-    },
-    live,
-  )
+  useUserEvent("session.delta", (e) => setDelta((s) => applyDelta(s, e.data, sessionId)), live)
 
   // The turn ended. Read the transcript NOW rather than waiting out the poll — this is the
   // event the whole streaming path builds to, and it is what swaps the provisional text for
@@ -195,7 +164,7 @@ export function useArtifactChat(shortId: string) {
     working,
     /** The reply being written, or "" when there is nothing in flight. Render it as a
      *  provisional agent bubble; it is replaced by the real message when the turn settles. */
-    streaming,
+    streaming: delta.text,
     error,
     send,
     poll,

--- a/apps/web/src/pages/artifact/lib/use-artifact-chat.ts
+++ b/apps/web/src/pages/artifact/lib/use-artifact-chat.ts
@@ -37,10 +37,13 @@ export function useArtifactChat(shortId: string) {
   // Highest slice applied. Slices are ordered, but a reconnect can redeliver one — ignoring
   // anything not strictly newer makes that a no-op instead of duplicated text.
   const lastSeq = useRef(0)
+  // Which model attempt the accumulated text belongs to (see the server note on `attempt`).
+  const lastAttempt = useRef(0)
 
   const clearStream = useCallback(() => {
     setStreaming("")
     lastSeq.current = 0
+    lastAttempt.current = 0
   }, [])
 
   const refresh = useCallback(
@@ -136,7 +139,7 @@ export function useArtifactChat(shortId: string) {
   useUserEvent(
     "session.delta",
     (e) => {
-      let p: { session_id?: string; seq?: number; text?: string }
+      let p: { session_id?: string; seq?: number; text?: string; attempt?: number }
       try {
         p = JSON.parse(e.data)
       } catch {
@@ -146,7 +149,14 @@ export function useArtifactChat(shortId: string) {
       const seq = typeof p.seq === "number" ? p.seq : lastSeq.current + 1
       if (seq <= lastSeq.current) return // a redelivery after a reconnect
       lastSeq.current = seq
-      setStreaming((s) => s + p.text)
+      // A NEW ATTEMPT REPLACES, it does not append. The agent loop re-generates a reply that
+      // missed its contract, and the abandoned attempt never reaches the transcript — appending
+      // would show a garbled answer that the settled message then contradicts.
+      const at = typeof p.attempt === "number" ? p.attempt : lastAttempt.current
+      const fresh = at > lastAttempt.current
+      lastAttempt.current = at
+      const text = p.text
+      setStreaming((s) => (fresh ? text : s + text))
     },
     live,
   )

--- a/apps/web/src/pages/context/console.tsx
+++ b/apps/web/src/pages/context/console.tsx
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, useParams } from "@tanstack/react-router"
 import { Copy as CopyIcon } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { ApiError, api, type Session, type SessionMessage, type SessionMeta } from "@/api"
 import { Icon, type IconName } from "@/components/icons"
 import { AccessSegmentToggle } from "@/components/shared/access-segment-toggle"
@@ -557,11 +557,11 @@ function SessionThread({
   // goes through the runner report path or a close/fail — contexts.ts calls settleWake /
   // progressWake there and nowhere else. `serveAttended`, which serves an Ask answered
   // in-process by the model, settles the session WITHOUT publishing anything, so on that
-  // path these subscriptions sit idle and the poll does all the work. This is therefore a
-  // win for AGENT-RUN contexts (a real runner answering, long runs emitting progress, and
-  // the `working` stall above) and a no-op for an attended Ask. Making attended turns push
-  // means publishing from serveAttended; that is a server change, deliberately not made
-  // here.
+  // path these subscriptions sat idle and the poll did all the work.
+  //
+  // THAT GAP IS NOW CLOSED: serveAttended publishes `session.settled` when it finishes, and
+  // streams the answer as `session.delta` on the way (see routes/contexts.ts). So both kinds
+  // of turn — a real runner reporting, and an Ask answered in-process — push here.
   const visible = usePageVisible()
   const pushRefresh = (e: MessageEvent) => {
     let payload: { session_id?: string }
@@ -576,6 +576,40 @@ function SessionThread({
   const pushEnabled = !!me && visible && unsettled
   useUserEvent("session.settled", pushRefresh, pushEnabled)
   useUserEvent("session.progress", pushRefresh, pushEnabled)
+
+  // The answer as it is being written. Same contract as the artifact chat rail: a VIEW only,
+  // never persisted, replaced by the transcript row the moment the turn settles. Anything not
+  // strictly newer than the last slice is dropped, so a reconnect redelivering one is a no-op.
+  const [streaming, setStreaming] = useState("")
+  const lastSeq = useRef(0)
+  useUserEvent(
+    "session.delta",
+    (e) => {
+      let p: { session_id?: string; seq?: number; text?: string }
+      try {
+        p = JSON.parse(e.data) as typeof p
+      } catch {
+        return
+      }
+      if (p.session_id !== sessionId || typeof p.text !== "string") return
+      const seq = typeof p.seq === "number" ? p.seq : lastSeq.current + 1
+      if (seq <= lastSeq.current) return
+      lastSeq.current = seq
+      setStreaming((s) => s + p.text)
+    },
+    pushEnabled,
+  )
+  // Drop the provisional text once the persisted reply is in the transcript, so the two are
+  // never on screen together. Keyed on the message COUNT: a settling turn appends the agent's
+  // row, which is exactly the moment the streamed copy stops being the freshest thing here.
+  const agentCount = (data?.messages ?? []).filter((m) => m.author_kind === "agent").length
+  // agentCount is the CHANGE SIGNAL to clear on, not a value the body reads — the same shape
+  // as the reset effects elsewhere in this file, and the rule cannot see the difference.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset trigger, see above
+  useEffect(() => {
+    setStreaming("")
+    lastSeq.current = 0
+  }, [agentCount])
   // Post a follow-up / close the conversation. Defined ABOVE the `!data` guard so the
   // hooks run unconditionally (a hook can't sit below an early return).
   const post = useApiMutation({
@@ -630,7 +664,23 @@ function SessionThread({
         {messages.map((m) => (
           <MessageRow key={m.id} m={m} contextName={contextName} />
         ))}
-        {session.state === "open" && (
+        {/* The answer mid-write. Plain text with preserved whitespace, not the markdown the
+            settled row renders: a half-arrived reply is half-arrived markup too, and running
+            each slice through the renderer makes it visibly thrash as it completes. */}
+        {streaming && (
+          <div className="flex flex-col gap-1 px-1" data-testid="console-streaming">
+            <span className="text-2xs uppercase tracking-wide text-muted-foreground">
+              {contextName}
+            </span>
+            <p className="whitespace-pre-wrap text-sm text-foreground">
+              {streaming}
+              <span className="ml-0.5 inline-block h-3.5 w-px translate-y-0.5 animate-pulse bg-foreground/70" />
+            </p>
+          </div>
+        )}
+        {/* The spinner is what you show when there is NOTHING yet. Once text is arriving it
+            would read as a second, stalled turn sitting under a reply that is visibly moving. */}
+        {session.state === "open" && !streaming && (
           <div className="flex items-center gap-2 px-1 text-sm text-muted-foreground">
             <Spinner size="sm" tone="current" data-testid="console-waiting" />
             Thinking — the runner picks this up on its next poll.

--- a/apps/web/src/pages/context/console.tsx
+++ b/apps/web/src/pages/context/console.tsx
@@ -547,11 +547,10 @@ function SessionThread({
   // Where the poll IS running (`open`) it stays on as the fallback for a missed event or a
   // dropped stream: this shortens the common case, it does not replace the safety net.
   //
-  // SCOPE: this is the CONTEXT CONSOLE only. The chat rail on an artifact is a separate
-  // surface — `use-artifact-chat.ts`, plain fetch into local state, polled from
-  // artifact-chat.tsx on its own 900ms interval, and it never touches sessionQuery. It has
-  // no `working` hole (its gate is already `working || open`), so it does not have the bug
-  // fixed here, but it also gets none of this push. Wiring it up is its own change.
+  // SCOPE: this file is the CONTEXT CONSOLE. The chat rail on an artifact is a separate
+  // surface — `use-artifact-chat.ts`, plain fetch into local state, on its own poll — and it
+  // subscribes to these same events itself. The two implement one contract in two places;
+  // keep them in step.
   //
   // WHICH TURNS ACTUALLY PUSH (verified on the PR preview, not inferred): only a turn that
   // goes through the runner report path or a close/fail — contexts.ts calls settleWake /

--- a/apps/web/src/pages/context/console.tsx
+++ b/apps/web/src/pages/context/console.tsx
@@ -582,10 +582,13 @@ function SessionThread({
   // strictly newer than the last slice is dropped, so a reconnect redelivering one is a no-op.
   const [streaming, setStreaming] = useState("")
   const lastSeq = useRef(0)
+  // Which model attempt the accumulated text belongs to (see the `attempt` note in
+  // lib/session-stream.ts): a re-generated reply must replace the abandoned one, not append.
+  const lastAttempt = useRef(0)
   useUserEvent(
     "session.delta",
     (e) => {
-      let p: { session_id?: string; seq?: number; text?: string }
+      let p: { session_id?: string; seq?: number; text?: string; attempt?: number }
       try {
         p = JSON.parse(e.data) as typeof p
       } catch {
@@ -595,7 +598,11 @@ function SessionThread({
       const seq = typeof p.seq === "number" ? p.seq : lastSeq.current + 1
       if (seq <= lastSeq.current) return
       lastSeq.current = seq
-      setStreaming((s) => s + p.text)
+      const at = typeof p.attempt === "number" ? p.attempt : lastAttempt.current
+      const fresh = at > lastAttempt.current
+      lastAttempt.current = at
+      const text = p.text
+      setStreaming((s) => (fresh ? text : s + text))
     },
     pushEnabled,
   )
@@ -609,6 +616,7 @@ function SessionThread({
   useEffect(() => {
     setStreaming("")
     lastSeq.current = 0
+    lastAttempt.current = 0
   }, [agentCount])
   // Post a follow-up / close the conversation. Defined ABOVE the `!data` guard so the
   // hooks run unconditionally (a hook can't sit below an early return).

--- a/apps/web/src/pages/context/console.tsx
+++ b/apps/web/src/pages/context/console.tsx
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, useParams } from "@tanstack/react-router"
 import { Copy as CopyIcon } from "lucide-react"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { ApiError, api, type Session, type SessionMessage, type SessionMeta } from "@/api"
 import { Icon, type IconName } from "@/components/icons"
 import { AccessSegmentToggle } from "@/components/shared/access-segment-toggle"
@@ -25,6 +25,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
 import { useAuth } from "@/ctx"
 import { contextQuery, contextSessionsQuery, sessionQuery } from "@/lib/queries"
+import { applyDelta, type DeltaState, EMPTY_DELTA } from "@/lib/session-delta"
 import { ago } from "@/lib/time"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { useDocumentTitle } from "@/lib/use-document-title"
@@ -579,30 +580,13 @@ function SessionThread({
   // The answer as it is being written. Same contract as the artifact chat rail: a VIEW only,
   // never persisted, replaced by the transcript row the moment the turn settles. Anything not
   // strictly newer than the last slice is dropped, so a reconnect redelivering one is a no-op.
-  const [streaming, setStreaming] = useState("")
-  const lastSeq = useRef(0)
-  // Which model attempt the accumulated text belongs to (see the `attempt` note in
-  // lib/session-stream.ts): a re-generated reply must replace the abandoned one, not append.
-  const lastAttempt = useRef(0)
+  // The accumulation rules are shared with the artifact chat rail (lib/session-delta.ts) so the
+  // two surfaces cannot drift — they did once, and only one of them was right.
+  const [delta, setDelta] = useState<DeltaState>(EMPTY_DELTA)
+  const streaming = delta.text
   useUserEvent(
     "session.delta",
-    (e) => {
-      let p: { session_id?: string; seq?: number; text?: string; attempt?: number }
-      try {
-        p = JSON.parse(e.data) as typeof p
-      } catch {
-        return
-      }
-      if (p.session_id !== sessionId || typeof p.text !== "string") return
-      const seq = typeof p.seq === "number" ? p.seq : lastSeq.current + 1
-      if (seq <= lastSeq.current) return
-      lastSeq.current = seq
-      const at = typeof p.attempt === "number" ? p.attempt : lastAttempt.current
-      const fresh = at > lastAttempt.current
-      lastAttempt.current = at
-      const text = p.text
-      setStreaming((s) => (fresh ? text : s + text))
-    },
+    (e) => setDelta((s) => applyDelta(s, e.data, sessionId)),
     pushEnabled,
   )
   // Drop the provisional text once the persisted reply is in the transcript, so the two are
@@ -613,9 +597,7 @@ function SessionThread({
   // as the reset effects elsewhere in this file, and the rule cannot see the difference.
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset trigger, see above
   useEffect(() => {
-    setStreaming("")
-    lastSeq.current = 0
-    lastAttempt.current = 0
+    setDelta(EMPTY_DELTA)
   }, [agentCount])
   // Post a follow-up / close the conversation. Defined ABOVE the `!data` guard so the
   // hooks run unconditionally (a hook can't sit below an early return).


### PR DESCRIPTION
Follows #590 (now merged). One commit of feature, one of cost work.

An attended turn buffered the whole answer, wrote one transcript row, and settled silently — the reader watched a spinner for the entire generation, then learned it was done on their next poll.

## Contract: additive, not a rewrite

`callModel` gains an **optional `onDelta` on its input** rather than a streaming return type. It has two adapters and consumers in the loop, turn-core, session-turn and the substrate loop, plus every test that injects a fake — a callback leaves all of them untouched. `ModelTurn` stays the single source of truth for text, tool calls, truncation and cost, so nothing downstream reads deltas to make a decision.

## Adapter

`model-openai` asks for `stream: true` **only when someone is listening**, and reassembles SSE frames into the exact buffered response shape — so truncation, tool calls, cost and `done` stay one code path and cannot drift between transports. Tool-call `arguments` is JSON split across frames, so it is accumulated silently and never streamed as fragments.

## Cost — the part worth reviewing

Each publish is a Durable Object fetch, so the publish *rate* is a bill.

**The age boundary is the one that fires.** A model emitting a few hundred chars/sec hits it long before the 200-char size cap, so the rate is effectively `1000/flushMs` per second. At 80ms that is ~12 DO fetches/sec — **~250 for a twenty-second answer**, exactly the shape #590 existed to remove. At 250ms it is 4/sec, and no reader can tell the difference.

**Most turns have nobody watching.** An MCP `use()` ask, an API caller, a closed tab. The first slice goes out via the receipt-bearing publish; if it reached **zero** live streams, the turn stops publishing *and* stops buffering. Those turns go from tens of DO fetches to **exactly one**. Only the first slice is probed — later ones would pay a promise each to learn something that rarely changes mid-turn.

A reader who opens the page mid-answer is not stranded: `session.settled` still fires, and settling is what makes a client re-read the transcript. They lose the animation, not the answer. A backplane that cannot count keeps streaming rather than assuming an empty room.

**No timers.** The age check runs on the next delta and `flush()` covers the tail — a pending timer outliving a Worker's `waitUntil` is a lifecycle hazard and a leak when a turn throws.

**Deltas are never the record.** Nothing is persisted; the transcript row written on settle is the answer. A dropped delta costs the animation only.

## Also fixes a gap found by dogfooding #590

An attended turn now publishes `session.settled`. It never did — served in-process, it bypassed the runner report path that publishes. Streaming makes this mandatory: deltas with no terminal event leave a reader watching a reply that never finishes.

## Scope

**Server only.** Rendering the deltas is the next commit — the events are on the wire and verifiable, but no UI consumes them yet.

## Tests

- Streamed vs buffered **parity** — same `ModelTurn` either way
- Tool calls reassembled across frame splits; fragments never streamed
- Truncation still detected through the stream
- A throwing listener, and a malformed frame, cannot cost the reply
- Coalescing boundaries, ordering, no text lost, idempotent flush
- Publish rate stays bounded for a realistic 6s generation
- Zero-listener shutoff, and that it does **not** trigger when someone is listening or when no receipt is available
- End to end: deltas then exactly one terminal settle, in that order, on the asker's channel

`pnpm verify` green (2988). `pnpm test:pg` green (1695 api + 198 db).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788071363&installation_model_id=428097&pr_number=592&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F592&signature=3f78242ff7ee22555fdbedc508539f924479a9bcefdd406f33dcca541b8bb4df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->